### PR TITLE
refactor(tests): dedupe local StateStore/Secrets fakes onto shared FakePlatform

### DIFF
--- a/src/test-kernel/cli/UpdateChecker.vitest.mts
+++ b/src/test-kernel/cli/UpdateChecker.vitest.mts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
+import { FakeStateStore } from '@test/support/FakePlatform';
 import {
   buildUpdateCommand,
   checkCliUpdateAvailable,
@@ -10,22 +11,6 @@ import {
   isPackageManagerInstall,
 } from '@cli/runtime/updateChecker';
 import { GlobalStateKey } from '@shared/state/stateKeys';
-
-class MemoryStateStore {
-  readonly values = new Map<string, unknown>();
-
-  get<T>(key: string, defaultValue?: T): T {
-    return (this.values.has(key) ? this.values.get(key) : defaultValue) as T;
-  }
-
-  async update(key: string, value: unknown): Promise<void> {
-    if (value === undefined) {
-      this.values.delete(key);
-    } else {
-      this.values.set(key, value);
-    }
-  }
-}
 
 describe('detectInstallMethod', () => {
   it('recognizes pnpm, yarn, and bun global layouts', () => {
@@ -282,7 +267,7 @@ describe('checkCliUpdateAvailable', () => {
   const noopNotify = async () => {};
 
   it('checks on a first launch (no prior lastCheckedAt) and reports a newer version', async () => {
-    const globalState = new MemoryStateStore();
+    const globalState = new FakeStateStore();
     let fetchCalls = 0;
     const notified: string[] = [];
 
@@ -304,7 +289,7 @@ describe('checkCliUpdateAvailable', () => {
   });
 
   it('returns undefined and does not notify when the fetched version is not newer', async () => {
-    const globalState = new MemoryStateStore();
+    const globalState = new FakeStateStore();
     const notified: string[] = [];
 
     const latest = await checkCliUpdateAvailable({
@@ -320,12 +305,12 @@ describe('checkCliUpdateAvailable', () => {
     expect(notified).toEqual([]);
     // The check itself completed, so the day's stamp is still persisted.
     expect(
-      globalState.values.get(GlobalStateKey.CLI_UPDATE_CHECK_LAST_CHECKED_AT),
+      globalState.get(GlobalStateKey.CLI_UPDATE_CHECK_LAST_CHECKED_AT),
     ).toBeDefined();
   });
 
   it('throttles repeated checks within the same day', async () => {
-    const globalState = new MemoryStateStore();
+    const globalState = new FakeStateStore();
     let fetchCalls = 0;
     // A realistic epoch timestamp: on the very first check ever,
     // `lastCheckedAt` defaults to 0, and this must be far enough past that
@@ -359,7 +344,7 @@ describe('checkCliUpdateAvailable', () => {
   });
 
   it('does not persist the throttle stamp on a failed fetch, so the next launch retries', async () => {
-    const globalState = new MemoryStateStore();
+    const globalState = new FakeStateStore();
     let fetchCalls = 0;
     const nowMs = Date.UTC(2026, 0, 1);
 
@@ -377,7 +362,7 @@ describe('checkCliUpdateAvailable', () => {
 
     expect(fetchCalls).toBe(1);
     expect(
-      globalState.values.get(GlobalStateKey.CLI_UPDATE_CHECK_LAST_CHECKED_AT),
+      globalState.get(GlobalStateKey.CLI_UPDATE_CHECK_LAST_CHECKED_AT),
     ).toBeUndefined();
 
     // Immediately "relaunching" (same day) must retry rather than being
@@ -395,7 +380,7 @@ describe('checkCliUpdateAvailable', () => {
 
     expect(fetchCalls).toBe(2);
     expect(
-      globalState.values.get(GlobalStateKey.CLI_UPDATE_CHECK_LAST_CHECKED_AT),
+      globalState.get(GlobalStateKey.CLI_UPDATE_CHECK_LAST_CHECKED_AT),
     ).toBe(nowMs + 1000);
   });
 
@@ -403,7 +388,7 @@ describe('checkCliUpdateAvailable', () => {
     // #8223: a failed `brew update` that still yields the locally cached
     // formula version must not count as a completed check — the next launch
     // retries the tap refresh instead of going silent for 24h.
-    const globalState = new MemoryStateStore();
+    const globalState = new FakeStateStore();
     const nowMs = Date.UTC(2026, 0, 1);
     const notified: string[] = [];
 
@@ -420,7 +405,7 @@ describe('checkCliUpdateAvailable', () => {
     expect(latest).toBe(latestVersion);
     expect(notified).toEqual([latestVersion]);
     expect(
-      globalState.values.get(GlobalStateKey.CLI_UPDATE_CHECK_LAST_CHECKED_AT),
+      globalState.get(GlobalStateKey.CLI_UPDATE_CHECK_LAST_CHECKED_AT),
     ).toBeUndefined();
   });
 
@@ -428,7 +413,7 @@ describe('checkCliUpdateAvailable', () => {
     // #8224: the stamp must be written only after the user actually saw the
     // notice — a prompt killed mid-way (closed stdin) leaves the attempt
     // un-stamped so the next launch re-checks.
-    const globalState = new MemoryStateStore();
+    const globalState = new FakeStateStore();
     const nowMs = Date.UTC(2026, 0, 1);
 
     await expect(
@@ -444,7 +429,7 @@ describe('checkCliUpdateAvailable', () => {
     ).rejects.toThrow('stdin closed');
 
     expect(
-      globalState.values.get(GlobalStateKey.CLI_UPDATE_CHECK_LAST_CHECKED_AT),
+      globalState.get(GlobalStateKey.CLI_UPDATE_CHECK_LAST_CHECKED_AT),
     ).toBeUndefined();
   });
 
@@ -454,10 +439,10 @@ describe('checkCliUpdateAvailable', () => {
     // must not reject the completed attempt (which would cancel an update the
     // user already accepted via the notify prompt) — the next launch just
     // re-checks a day early.
-    const globalState = new MemoryStateStore();
-    globalState.update = async () => {
-      throw new Error('EACCES: permission denied');
-    };
+    const globalState = new FakeStateStore();
+    vi.spyOn(globalState, 'update').mockRejectedValue(
+      new Error('EACCES: permission denied'),
+    );
     const notified: string[] = [];
 
     const latest = await checkCliUpdateAvailable({
@@ -474,7 +459,7 @@ describe('checkCliUpdateAvailable', () => {
   });
 
   it('persists the throttle stamp only after notify completes', async () => {
-    const globalState = new MemoryStateStore();
+    const globalState = new FakeStateStore();
     const nowMs = Date.UTC(2026, 0, 1);
     let stampAtNotifyTime: unknown = 'unread';
 
@@ -484,7 +469,7 @@ describe('checkCliUpdateAvailable', () => {
       now: () => nowMs,
       fetchLatest: async () => ({ version: latestVersion, refreshed: true }),
       notify: async () => {
-        stampAtNotifyTime = globalState.values.get(
+        stampAtNotifyTime = globalState.get(
           GlobalStateKey.CLI_UPDATE_CHECK_LAST_CHECKED_AT,
         );
       },
@@ -492,7 +477,7 @@ describe('checkCliUpdateAvailable', () => {
 
     expect(stampAtNotifyTime).toBeUndefined();
     expect(
-      globalState.values.get(GlobalStateKey.CLI_UPDATE_CHECK_LAST_CHECKED_AT),
+      globalState.get(GlobalStateKey.CLI_UPDATE_CHECK_LAST_CHECKED_AT),
     ).toBe(nowMs);
   });
 });

--- a/src/test-kernel/desktop/DesktopAgentSettingsController.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentSettingsController.vitest.mts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { FakeStateStore } from '@test/support/FakePlatform';
+import { isStored } from '@test/support/settingsStoresFake';
 import type { AgentEntry } from '@agent/index/agentRegistry';
 import { DefaultDesktopAgentSettingsController } from '@desktop/main/desktopAgentSettingsController';
 import { MAIN_VIEW_COMMANDS, SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
@@ -7,29 +9,12 @@ import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { isUnsupported } from '@shared/utils/dispatcher';
 
 import type { AgentCategory, AgentSource } from '@shared/schemas/agent';
-import type { StateStore } from '@platform/interfaces';
-
-class MemoryStateStore implements StateStore {
-  readonly values = new Map<string, unknown>();
-
-  get<T>(key: string, defaultValue?: T): T {
-    return (this.values.has(key) ? this.values.get(key) : defaultValue) as T;
-  }
-
-  async update(key: string, value: unknown): Promise<void> {
-    if (value === undefined) {
-      this.values.delete(key);
-    } else {
-      this.values.set(key, value);
-    }
-  }
-}
 
 type AgentCatalog = Record<AgentCategory, AgentEntry[]>;
 
 interface ControllerFixtureOptions {
-  readonly workspaceState?: MemoryStateStore;
-  readonly globalState?: MemoryStateStore;
+  readonly workspaceState?: FakeStateStore;
+  readonly globalState?: FakeStateStore;
   readonly catalog?: AgentCatalog;
   readonly visibleCatalog?: AgentCatalog;
   readonly loadAgents?: (options?: {
@@ -48,8 +33,8 @@ interface ControllerFixtureOptions {
 }
 
 function createControllerFixture(options: ControllerFixtureOptions = {}) {
-  const workspaceState = options.workspaceState ?? new MemoryStateStore();
-  const globalState = options.globalState ?? new MemoryStateStore();
+  const workspaceState = options.workspaceState ?? new FakeStateStore();
+  const globalState = options.globalState ?? new FakeStateStore();
   const posted: unknown[] = [];
   const opened: string[] = [];
   const revealed: string[] = [];
@@ -206,7 +191,7 @@ describe('DefaultDesktopAgentSettingsController', () => {
       enabled: false,
     });
 
-    expect(workspaceState.values.get(WorkspaceStateKey.ENABLED_AGENTS)).toEqual(
+    expect(workspaceState.get(WorkspaceStateKey.ENABLED_AGENTS)).toEqual(
       expect.not.arrayContaining(['builtInWorkflow:polish', 'polish']),
     );
     expect(posted.map(messageCommand)).toEqual(
@@ -229,14 +214,14 @@ describe('DefaultDesktopAgentSettingsController', () => {
 
     await applyPreset('physicist');
 
-    expect(workspaceState.values.get(WorkspaceStateKey.ENABLED_AGENTS)).toEqual(
+    expect(workspaceState.get(WorkspaceStateKey.ENABLED_AGENTS)).toEqual(
       expect.arrayContaining([
         'builtInWorkflow:correct',
         'builtInWorkflow:polish',
       ]),
     );
     expect(
-      workspaceState.values.get(WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS),
+      workspaceState.get(WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS),
     ).toEqual(
       expect.arrayContaining([
         'builtInToolUse:orchestrator',
@@ -263,18 +248,19 @@ describe('DefaultDesktopAgentSettingsController', () => {
   });
 
   it('signs in before one forced remote refresh and commits the team once', async () => {
-    const workspaceState = new MemoryStateStore();
-    workspaceState.values.set(WorkspaceStateKey.CUSTOM_AGENT_PRESETS, [
-      {
-        id: 'remote-team',
-        name: 'Remote team',
-        description: 'Uses a hosted root',
-        icon: 'tools',
-        workflowAgents: [],
-        toolUseAgents: ['orchestrator'],
-        texraHostedAgents: ['orchestrator'],
-      },
-    ]);
+    const workspaceState = new FakeStateStore({
+      [WorkspaceStateKey.CUSTOM_AGENT_PRESETS]: [
+        {
+          id: 'remote-team',
+          name: 'Remote team',
+          description: 'Uses a hosted root',
+          icon: 'tools',
+          workflowAgents: [],
+          toolUseAgents: ['orchestrator'],
+          texraHostedAgents: ['orchestrator'],
+        },
+      ],
+    });
     const catalog: AgentCatalog = { workflow: [], toolUse: [] };
     const order: string[] = [];
     const refreshAgents = vi.fn(async () => {
@@ -322,23 +308,24 @@ describe('DefaultDesktopAgentSettingsController', () => {
       ),
     ).toHaveLength(1);
     expect(
-      workspaceState.values.get(WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS),
+      workspaceState.get(WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS),
     ).toEqual(['remote:orchestrator']);
   });
 
   it('does not write roster state when team preflight is cancelled', async () => {
-    const workspaceState = new MemoryStateStore();
-    workspaceState.values.set(WorkspaceStateKey.CUSTOM_AGENT_PRESETS, [
-      {
-        id: 'remote-team',
-        name: 'Remote team',
-        description: 'Uses a hosted root',
-        icon: 'tools',
-        workflowAgents: [],
-        toolUseAgents: ['orchestrator'],
-        texraHostedAgents: ['orchestrator'],
-      },
-    ]);
+    const workspaceState = new FakeStateStore({
+      [WorkspaceStateKey.CUSTOM_AGENT_PRESETS]: [
+        {
+          id: 'remote-team',
+          name: 'Remote team',
+          description: 'Uses a hosted root',
+          icon: 'tools',
+          workflowAgents: [],
+          toolUseAgents: ['orchestrator'],
+          texraHostedAgents: ['orchestrator'],
+        },
+      ],
+    });
     const update = vi.spyOn(workspaceState, 'update');
     const refreshAgents = vi.fn(async () => undefined);
     const { controller } = createControllerFixture({
@@ -381,9 +368,7 @@ describe('DefaultDesktopAgentSettingsController', () => {
 
     await savePreset();
 
-    expect(
-      workspaceState.values.get(WorkspaceStateKey.CUSTOM_AGENT_PRESETS),
-    ).toEqual([
+    expect(workspaceState.get(WorkspaceStateKey.CUSTOM_AGENT_PRESETS)).toEqual([
       expect.objectContaining({
         name: 'Paper Team',
         workflowAgents: ['correct'],
@@ -398,17 +383,18 @@ describe('DefaultDesktopAgentSettingsController', () => {
   });
 
   it('deletes custom teams and reports unknown team ids', async () => {
-    const workspaceState = new MemoryStateStore();
-    workspaceState.values.set(WorkspaceStateKey.CUSTOM_AGENT_PRESETS, [
-      {
-        id: 'custom-team',
-        name: 'Custom Team',
-        description: 'test',
-        icon: 'codicon-bookmark',
-        workflowAgents: ['correct'],
-        toolUseAgents: ['review'],
-      },
-    ]);
+    const workspaceState = new FakeStateStore({
+      [WorkspaceStateKey.CUSTOM_AGENT_PRESETS]: [
+        {
+          id: 'custom-team',
+          name: 'Custom Team',
+          description: 'test',
+          icon: 'codicon-bookmark',
+          workflowAgents: ['correct'],
+          toolUseAgents: ['review'],
+        },
+      ],
+    });
     const { controller, errorMessages, posted } = createControllerFixture({
       workspaceState,
     });
@@ -418,9 +404,9 @@ describe('DefaultDesktopAgentSettingsController', () => {
 
     await deletePreset('custom-team');
 
-    expect(
-      workspaceState.values.get(WorkspaceStateKey.CUSTOM_AGENT_PRESETS),
-    ).toEqual([]);
+    expect(workspaceState.get(WorkspaceStateKey.CUSTOM_AGENT_PRESETS)).toEqual(
+      [],
+    );
     expect(posted.at(-1)).toMatchObject({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_MODE_PRESETS,
       customPresets: [],
@@ -454,11 +440,11 @@ describe('DefaultDesktopAgentSettingsController', () => {
     await applyPreset('missing-team');
 
     expect(errorMessages).toEqual(['Unknown team: missing-team']);
-    expect(workspaceState.values.has(WorkspaceStateKey.ENABLED_AGENTS)).toBe(
+    expect(isStored(workspaceState, WorkspaceStateKey.ENABLED_AGENTS)).toBe(
       false,
     );
     expect(
-      workspaceState.values.has(WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS),
+      isStored(workspaceState, WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS),
     ).toBe(false);
   });
 });

--- a/src/test-kernel/desktop/DesktopCrashReporting.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCrashReporting.vitest.mts
@@ -1,53 +1,22 @@
 import { describe, expect, it } from 'vitest';
 
+import { FakeSecrets, FakeStateStore } from '@test/support/FakePlatform';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
 
-class MemoryStateStore {
-  readonly values = new Map<string, unknown>();
-
-  get<T>(key: string, defaultValue?: T): T {
-    return (this.values.has(key) ? this.values.get(key) : defaultValue) as T;
-  }
-
-  async update(key: string, value: unknown): Promise<void> {
-    if (value === undefined) {
-      this.values.delete(key);
-    } else {
-      this.values.set(key, value);
-    }
-  }
-}
-
-class MemorySecrets {
-  readonly values = new Map<string, string>();
-
-  async get(key: string): Promise<string | undefined> {
-    return this.values.get(key);
-  }
-
-  async set(key: string, value: string): Promise<void> {
-    this.values.set(key, value);
-  }
-
-  async delete(key: string): Promise<void> {
-    this.values.delete(key);
-  }
-}
-
 interface DesktopCrashReportingModule {
   DESKTOP_CRASH_REPORTING_DSN_SECRET: string;
   getDesktopCrashReportingStatus(
-    globalState: MemoryStateStore,
-    secrets: MemorySecrets,
+    globalState: FakeStateStore,
+    secrets: FakeSecrets,
   ): Promise<{ enabled: boolean; configured: boolean }>;
   setDesktopCrashReportingDsn(
-    secrets: MemorySecrets,
+    secrets: FakeSecrets,
     dsn: string | undefined,
   ): Promise<void>;
   setDesktopCrashReportingEnabled(
-    globalState: MemoryStateStore,
+    globalState: FakeStateStore,
     enabled: boolean,
   ): Promise<void>;
   scrubDesktopCrashEvent(
@@ -68,10 +37,7 @@ describe('desktop crash reporting', () => {
       await loadDesktopCrashReporting();
 
     await expect(
-      getDesktopCrashReportingStatus(
-        new MemoryStateStore(),
-        new MemorySecrets(),
-      ),
+      getDesktopCrashReportingStatus(new FakeStateStore(), new FakeSecrets()),
     ).resolves.toEqual({ enabled: false, configured: false });
   });
 
@@ -82,16 +48,16 @@ describe('desktop crash reporting', () => {
       setDesktopCrashReportingDsn,
       setDesktopCrashReportingEnabled,
     } = await loadDesktopCrashReporting();
-    const globalState = new MemoryStateStore();
-    const secrets = new MemorySecrets();
+    const globalState = new FakeStateStore();
+    const secrets = new FakeSecrets();
 
     await setDesktopCrashReportingEnabled(globalState, true);
     await setDesktopCrashReportingDsn(secrets, ' https://example.invalid/1 ');
 
     expect(
-      globalState.values.get(GlobalStateKey.DESKTOP_CRASH_REPORTING_ENABLED),
+      globalState.get(GlobalStateKey.DESKTOP_CRASH_REPORTING_ENABLED),
     ).toBe(true);
-    expect(secrets.values.get(DESKTOP_CRASH_REPORTING_DSN_SECRET)).toBe(
+    expect(await secrets.get(DESKTOP_CRASH_REPORTING_DSN_SECRET)).toBe(
       'https://example.invalid/1',
     );
     await expect(

--- a/src/test-kernel/desktop/DesktopCrashReportingSettingsController.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCrashReportingSettingsController.vitest.mts
@@ -2,6 +2,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports - desktop crash reporting
+import { FakeSecrets, FakeStateStore } from '@test/support/FakePlatform';
 import { DefaultDesktopCrashReportingSettingsController } from '@desktop/main/desktopCrashReportingSettingsController';
 import { DESKTOP_CRASH_REPORTING_DSN_SECRET } from '@desktop/main/desktopCrashReporting';
 
@@ -10,62 +11,14 @@ import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { assertSupported } from '@shared/utils/dispatcher';
 
-// Local imports - supporting types
-import type { StateStore } from '@platform/interfaces';
-import type { PlatformSecrets } from '@platform/secrets';
-
-class MemoryStateStore implements StateStore {
-  readonly values = new Map<string, unknown>();
-
-  get<T>(key: string, defaultValue?: T): T {
-    return (this.values.has(key) ? this.values.get(key) : defaultValue) as T;
-  }
-
-  async update(key: string, value: unknown): Promise<void> {
-    if (value === undefined) {
-      this.values.delete(key);
-    } else {
-      this.values.set(key, value);
-    }
-  }
-}
-
-class MemorySecrets implements PlatformSecrets {
-  readonly values = new Map<string, string>();
-
-  async get(key: string): Promise<string | undefined> {
-    return this.values.get(key);
-  }
-
-  async getStored(key: string): Promise<string | undefined> {
-    return this.values.get(key);
-  }
-
-  async set(key: string, value: string): Promise<void> {
-    this.values.set(key, value);
-  }
-
-  async delete(key: string): Promise<void> {
-    this.values.delete(key);
-  }
-
-  async listStoredKeys(): Promise<readonly string[]> {
-    return [...this.values.keys()];
-  }
-
-  getEnv(): string | undefined {
-    return undefined;
-  }
-}
-
 type ControllerOptions = ConstructorParameters<
   typeof DefaultDesktopCrashReportingSettingsController
 >[0];
 
 function createFixture(overrides: Partial<ControllerOptions> = {}) {
   const posted: unknown[] = [];
-  const state = overrides.state ?? new MemoryStateStore();
-  const memorySecrets = new MemorySecrets();
+  const state = overrides.state ?? new FakeStateStore();
+  const memorySecrets = new FakeSecrets();
   const secrets = overrides.secrets ?? memorySecrets;
   const promptInput = vi.fn<ControllerOptions['prompt']['input']>(
     async () => undefined,
@@ -85,13 +38,12 @@ function createFixture(overrides: Partial<ControllerOptions> = {}) {
 
 describe('DefaultDesktopCrashReportingSettingsController', () => {
   it('posts the current status during startup', async () => {
-    const state = new MemoryStateStore();
-    const secrets = new MemorySecrets();
-    state.values.set(GlobalStateKey.DESKTOP_CRASH_REPORTING_ENABLED, true);
-    secrets.values.set(
-      DESKTOP_CRASH_REPORTING_DSN_SECRET,
-      'https://example.invalid/1',
-    );
+    const state = new FakeStateStore({
+      [GlobalStateKey.DESKTOP_CRASH_REPORTING_ENABLED]: true,
+    });
+    const secrets = new FakeSecrets({
+      [DESKTOP_CRASH_REPORTING_DSN_SECRET]: 'https://example.invalid/1',
+    });
     const { controller, posted } = createFixture({ state, secrets });
 
     await controller.postStartupData();
@@ -117,19 +69,18 @@ describe('DefaultDesktopCrashReportingSettingsController', () => {
       title: 'Set Sentry DSN',
       prompt: 'Enter the Sentry DSN for opt-in desktop crash reports',
     });
-    expect(memorySecrets.values).toEqual(new Map());
+    expect(await memorySecrets.listStoredKeys()).toEqual([]);
     expect(initialize).not.toHaveBeenCalled();
     expect(posted).toEqual([]);
   });
 
   it('deletes a stored DSN when the prompt returns a blank value', async () => {
-    const state = new MemoryStateStore();
-    const secrets = new MemorySecrets();
-    state.values.set(GlobalStateKey.DESKTOP_CRASH_REPORTING_ENABLED, true);
-    secrets.values.set(
-      DESKTOP_CRASH_REPORTING_DSN_SECRET,
-      'https://example.invalid/old',
-    );
+    const state = new FakeStateStore({
+      [GlobalStateKey.DESKTOP_CRASH_REPORTING_ENABLED]: true,
+    });
+    const secrets = new FakeSecrets({
+      [DESKTOP_CRASH_REPORTING_DSN_SECRET]: 'https://example.invalid/old',
+    });
     const { controller, initialize, posted } = createFixture({
       state,
       secrets,
@@ -138,7 +89,9 @@ describe('DefaultDesktopCrashReportingSettingsController', () => {
 
     await assertSupported(controller.actions.setDsn)();
 
-    expect(secrets.values.has(DESKTOP_CRASH_REPORTING_DSN_SECRET)).toBe(false);
+    expect(
+      await secrets.get(DESKTOP_CRASH_REPORTING_DSN_SECRET),
+    ).toBeUndefined();
     expect(initialize).not.toHaveBeenCalled();
     expect(posted).toEqual([
       {
@@ -150,8 +103,9 @@ describe('DefaultDesktopCrashReportingSettingsController', () => {
   });
 
   it('stores a trimmed nonblank DSN and initializes when enabled', async () => {
-    const state = new MemoryStateStore();
-    state.values.set(GlobalStateKey.DESKTOP_CRASH_REPORTING_ENABLED, true);
+    const state = new FakeStateStore({
+      [GlobalStateKey.DESKTOP_CRASH_REPORTING_ENABLED]: true,
+    });
     const { controller, initialize, memorySecrets, posted } = createFixture({
       state,
       prompt: { input: async () => ' https://example.invalid/new ' },
@@ -159,7 +113,7 @@ describe('DefaultDesktopCrashReportingSettingsController', () => {
 
     await assertSupported(controller.actions.setDsn)();
 
-    expect(memorySecrets.values.get(DESKTOP_CRASH_REPORTING_DSN_SECRET)).toBe(
+    expect(await memorySecrets.get(DESKTOP_CRASH_REPORTING_DSN_SECRET)).toBe(
       'https://example.invalid/new',
     );
     expect(initialize).toHaveBeenCalledOnce();
@@ -173,8 +127,8 @@ describe('DefaultDesktopCrashReportingSettingsController', () => {
   });
 
   it('initializes only when an enablement change leaves reporting ready', async () => {
-    const state = new MemoryStateStore();
-    const secrets = new MemorySecrets();
+    const state = new FakeStateStore();
+    const secrets = new FakeSecrets();
     const { controller, initialize, posted } = createFixture({
       state,
       secrets,
@@ -182,12 +136,12 @@ describe('DefaultDesktopCrashReportingSettingsController', () => {
 
     await assertSupported(controller.actions.setEnabled)(true);
 
-    expect(
-      state.values.get(GlobalStateKey.DESKTOP_CRASH_REPORTING_ENABLED),
-    ).toBe(true);
+    expect(state.get(GlobalStateKey.DESKTOP_CRASH_REPORTING_ENABLED)).toBe(
+      true,
+    );
     expect(initialize).not.toHaveBeenCalled();
 
-    secrets.values.set(
+    await secrets.set(
       DESKTOP_CRASH_REPORTING_DSN_SECRET,
       'https://example.invalid/ready',
     );

--- a/src/test-kernel/desktop/DesktopCredentialSettingsController.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCredentialSettingsController.vitest.mts
@@ -3,7 +3,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MODEL_CONFIGS } from 'llm-zoo';
 
 // Local imports - tests
-import { FakeConfigProvider } from '@test/support/FakePlatform';
+import {
+  FakeConfigProvider,
+  FakeSecrets,
+  FakeStateStore,
+} from '@test/support/FakePlatform';
 import { installPlatform } from '@test/support/setupPlatform';
 
 // Local imports - authentication and models
@@ -16,10 +20,6 @@ import { DEFAULT_MODELS, MODEL_LIST_VERSION } from '@model/modelOptionsBasic';
 // Local imports - shared
 import { MAIN_VIEW_COMMANDS, SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import { GlobalStateKey } from '@shared/state/stateKeys';
-
-// Local imports - platform
-import type { StateStore } from '@platform/interfaces';
-import type { PlatformSecrets } from '@platform/secrets';
 
 const codexMocks = vi.hoisted(() => ({
   getStatus: vi.fn(async () => ({
@@ -59,52 +59,6 @@ vi.mock('@model/computeModelOptions', async (importOriginal) => ({
   invalidateModelOptionsCache: modelMocks.invalidate,
 }));
 
-class MemoryStateStore implements StateStore {
-  readonly values = new Map<string, unknown>();
-
-  get<T>(key: string, defaultValue?: T): T {
-    return (this.values.has(key) ? this.values.get(key) : defaultValue) as T;
-  }
-
-  async update(key: string, value: unknown): Promise<void> {
-    if (value === undefined) {
-      this.values.delete(key);
-    } else {
-      this.values.set(key, value);
-    }
-  }
-}
-
-class MemorySecrets implements PlatformSecrets {
-  readonly values = new Map<string, string>();
-  readonly deleted: string[] = [];
-
-  async get(key: string): Promise<string | undefined> {
-    return this.values.get(key);
-  }
-
-  async getStored(key: string): Promise<string | undefined> {
-    return this.values.get(key);
-  }
-
-  async set(key: string, value: string): Promise<void> {
-    this.values.set(key, value);
-  }
-
-  async delete(key: string): Promise<void> {
-    this.deleted.push(key);
-    this.values.delete(key);
-  }
-
-  async listStoredKeys(): Promise<readonly string[]> {
-    return [...this.values.keys()];
-  }
-
-  getEnv(): string | undefined {
-    return undefined;
-  }
-}
-
 type ControllerOptions = ConstructorParameters<
   typeof DefaultDesktopCredentialSettingsController
 >[0];
@@ -113,8 +67,8 @@ async function createFixture(
   overrides: Partial<ControllerOptions> = {},
 ): Promise<{
   controller: DefaultDesktopCredentialSettingsController;
-  globalState: MemoryStateStore;
-  secrets: MemorySecrets;
+  globalState: FakeStateStore;
+  secrets: FakeSecrets;
   posted: unknown[];
   events: string[];
   confirms: string[];
@@ -126,13 +80,13 @@ async function createFixture(
   setUseIncludedModelAccess: ReturnType<typeof vi.fn>;
 }> {
   const globalState =
-    (overrides.globalState as MemoryStateStore | undefined) ??
-    new MemoryStateStore();
+    (overrides.globalState as FakeStateStore | undefined) ??
+    new FakeStateStore();
   const workspaceState =
-    (overrides.workspaceState as MemoryStateStore | undefined) ??
-    new MemoryStateStore();
+    (overrides.workspaceState as FakeStateStore | undefined) ??
+    new FakeStateStore();
   const secrets =
-    (overrides.secrets as MemorySecrets | undefined) ?? new MemorySecrets();
+    (overrides.secrets as FakeSecrets | undefined) ?? new FakeSecrets();
   const posted: unknown[] = [];
   const events: string[] = [];
   const confirms: string[] = [];
@@ -253,10 +207,10 @@ describe('DefaultDesktopCredentialSettingsController', () => {
   });
 
   it('preserves a provider key when removal is cancelled', async () => {
-    const secrets = new MemorySecrets();
-    const confirms: string[] = [];
     const secretName = apiKeySecretName('openai');
-    secrets.values.set(secretName, 'sk-test');
+    const secrets = new FakeSecrets({ [secretName]: 'sk-test' });
+    const deleteSpy = vi.spyOn(secrets, 'delete');
+    const confirms: string[] = [];
     const fixture = await createFixture({
       secrets,
       prompt: {
@@ -275,7 +229,7 @@ describe('DefaultDesktopCredentialSettingsController', () => {
     expect(confirms).toEqual([
       'Remove the OpenAI API key? This cannot be undone.',
     ]);
-    expect(secrets.deleted).toEqual([]);
+    expect(deleteSpy).not.toHaveBeenCalled();
     expect(await secrets.get(secretName)).toBe('sk-test');
     expect(fixture.onCredentialChanged).not.toHaveBeenCalled();
   });
@@ -288,7 +242,7 @@ describe('DefaultDesktopCredentialSettingsController', () => {
       '  sk-test  ',
     );
 
-    expect(fixture.secrets.values.get('apiKey.google')).toBe('sk-test');
+    expect(await fixture.secrets.get('apiKey.google')).toBe('sk-test');
     expect(fixture.infos).toEqual(['Google API key has been set']);
     expect(
       fixture.posted.findLast(
@@ -309,10 +263,10 @@ describe('DefaultDesktopCredentialSettingsController', () => {
   });
 
   it('uses the shared key prompt and removes a confirmed key', async () => {
-    const secrets = new MemorySecrets();
-    const confirms: string[] = [];
     const secretName = apiKeySecretName('openai');
-    secrets.values.set(secretName, 'old-key');
+    const secrets = new FakeSecrets({ [secretName]: 'old-key' });
+    const deleteSpy = vi.spyOn(secrets, 'delete');
+    const confirms: string[] = [];
     const fixture = await createFixture({
       secrets,
       prompt: {
@@ -333,7 +287,7 @@ describe('DefaultDesktopCredentialSettingsController', () => {
     await requireAction(fixture.controller.profileActions.removeProviderKey)(
       'openai',
     );
-    expect(secrets.deleted).toEqual([secretName]);
+    expect(deleteSpy).toHaveBeenCalledExactlyOnceWith(secretName);
     expect(await secrets.get(secretName)).toBeUndefined();
     expect(confirms).toEqual([
       'Remove the OpenAI API key? This cannot be undone.',
@@ -341,8 +295,9 @@ describe('DefaultDesktopCredentialSettingsController', () => {
   });
 
   it('persists included access and clears OpenRouter before refreshing', async () => {
-    const globalState = new MemoryStateStore();
-    globalState.values.set(GlobalStateKey.USE_OPENROUTER, true);
+    const globalState = new FakeStateStore({
+      [GlobalStateKey.USE_OPENROUTER]: true,
+    });
     const fixture = await createFixture({ globalState });
 
     await requireAction(fixture.controller.profileActions.setApiAccessMode)(
@@ -350,7 +305,7 @@ describe('DefaultDesktopCredentialSettingsController', () => {
     );
 
     expect(fixture.setUseIncludedModelAccess).toHaveBeenCalledWith(true);
-    expect(globalState.values.get(GlobalStateKey.USE_OPENROUTER)).toBe(false);
+    expect(globalState.get(GlobalStateKey.USE_OPENROUTER)).toBe(false);
     expect(fixture.events).toEqual([
       'access:true',
       `render:${SETTINGS_VIEW_COMMANDS.UPDATE_PROFILE}`,
@@ -490,9 +445,10 @@ describe('DefaultDesktopCredentialSettingsController', () => {
   });
 
   it('awaits the production model-list migration before model data', async () => {
-    const globalState = new MemoryStateStore();
-    globalState.values.set(GlobalStateKey.MODEL_LIST_VERSION, 12);
-    globalState.values.set(GlobalStateKey.ENABLED_MODELS, ['custom-model']);
+    const globalState = new FakeStateStore({
+      [GlobalStateKey.MODEL_LIST_VERSION]: 12,
+      [GlobalStateKey.ENABLED_MODELS]: ['custom-model'],
+    });
     const fixture = await createFixture({
       globalState,
       modelListRefresh: refreshDesktopModelListStateIfNeeded({ globalState }),
@@ -500,25 +456,23 @@ describe('DefaultDesktopCredentialSettingsController', () => {
 
     await fixture.controller.prepareModelSelectionData();
 
-    expect(globalState.values.get(GlobalStateKey.MODEL_LIST_VERSION)).toBe(
+    expect(globalState.get(GlobalStateKey.MODEL_LIST_VERSION)).toBe(
       MODEL_LIST_VERSION,
     );
     const activeDefaults = DEFAULT_MODELS.filter(
       (model) => !(MODEL_CONFIGS[model]?.deprecated ?? false),
     );
-    expect(globalState.values.get(GlobalStateKey.ENABLED_MODELS)).toEqual([
+    expect(globalState.get(GlobalStateKey.ENABLED_MODELS)).toEqual([
       'custom-model',
       ...activeDefaults,
     ]);
   });
 
   it('removes retired models from a recent persisted model list', async () => {
-    const globalState = new MemoryStateStore();
-    globalState.values.set(GlobalStateKey.MODEL_LIST_VERSION, 20);
-    globalState.values.set(GlobalStateKey.ENABLED_MODELS, [
-      'custom-model',
-      'haiku3',
-    ]);
+    const globalState = new FakeStateStore({
+      [GlobalStateKey.MODEL_LIST_VERSION]: 20,
+      [GlobalStateKey.ENABLED_MODELS]: ['custom-model', 'haiku3'],
+    });
     const fixture = await createFixture({
       globalState,
       modelListRefresh: refreshDesktopModelListStateIfNeeded({ globalState }),
@@ -531,7 +485,7 @@ describe('DefaultDesktopCredentialSettingsController', () => {
         !(MODEL_CONFIGS[model]?.deprecated ?? false) &&
         !(MODEL_CONFIGS[model]?.retired ?? false),
     );
-    expect(globalState.values.get(GlobalStateKey.ENABLED_MODELS)).toEqual([
+    expect(globalState.get(GlobalStateKey.ENABLED_MODELS)).toEqual([
       'custom-model',
       ...activeDefaults,
     ]);

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -1,4 +1,5 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { FakeStateStore } from '@test/support/FakePlatform';
 import { MODEL_LIST_VERSION } from '@model/modelOptionsBasic';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
@@ -71,22 +72,6 @@ type CapturedSettingsFixtureOverrides = Omit<
   'postToRenderer'
 >;
 
-class MemoryStateStore implements StateStore {
-  readonly values = new Map<string, unknown>();
-
-  get<T>(key: string, defaultValue?: T): T {
-    return (this.values.has(key) ? this.values.get(key) : defaultValue) as T;
-  }
-
-  async update(key: string, value: unknown): Promise<void> {
-    if (value === undefined) {
-      this.values.delete(key);
-    } else {
-      this.values.set(key, value);
-    }
-  }
-}
-
 class MemoryConfigStore {
   readonly values = new Map<string, unknown>();
   // Only recorded when a call site passes an explicit target -- do not
@@ -139,8 +124,8 @@ let createDesktopSettingsIpc!: DesktopSettingsIpcModule['createDesktopSettingsIp
 
 function createSettingsFixture(overrides: SettingsFixtureOverrides = {}) {
   const {
-    globalState = new MemoryStateStore(),
-    workspaceState = new MemoryStateStore(),
+    globalState = new FakeStateStore(),
+    workspaceState = new FakeStateStore(),
     config = new MemoryConfigStore(),
     ui,
     ...settingsOverrides
@@ -224,12 +209,10 @@ describe('desktop settings IPC', () => {
   });
 
   it('applies Git author settings on creation and posts only for settings readiness', async () => {
-    const workspaceState = new MemoryStateStore();
-    workspaceState.values.set(WorkspaceStateKey.GIT_AUTHOR_NAME, 'TeXRA Bot');
-    workspaceState.values.set(
-      WorkspaceStateKey.GIT_AUTHOR_EMAIL,
-      'bot@example.com',
-    );
+    const workspaceState = new FakeStateStore({
+      [WorkspaceStateKey.GIT_AUTHOR_NAME]: 'TeXRA Bot',
+      [WorkspaceStateKey.GIT_AUTHOR_EMAIL]: 'bot@example.com',
+    });
 
     const { settings, posted } = createCapturedSettingsFixture({
       workspaceState,
@@ -334,7 +317,7 @@ describe('desktop settings IPC', () => {
   });
 
   it('round-trips Git author writes through workspace state and refreshes the renderer', async () => {
-    const workspaceState = new MemoryStateStore();
+    const workspaceState = new FakeStateStore();
 
     const { settings, posted } = createCapturedSettingsFixture({
       workspaceState,
@@ -348,7 +331,7 @@ describe('desktop settings IPC', () => {
     ).toBe(true);
     await Promise.resolve();
 
-    expect(workspaceState.values.get(WorkspaceStateKey.GIT_AUTHOR_NAME)).toBe(
+    expect(workspaceState.get(WorkspaceStateKey.GIT_AUTHOR_NAME)).toBe(
       'Desktop TeXRA',
     );
     expect(posted.at(-1)).toMatchObject({
@@ -363,9 +346,7 @@ describe('desktop settings IPC', () => {
       }),
     ).toBe(true);
     await Promise.resolve();
-    expect(workspaceState.values.get(WorkspaceStateKey.GIT_MARK_COMMITS)).toBe(
-      false,
-    );
+    expect(workspaceState.get(WorkspaceStateKey.GIT_MARK_COMMITS)).toBe(false);
     expect(getGitAuthorEnv()).toEqual({});
 
     expect(
@@ -375,9 +356,9 @@ describe('desktop settings IPC', () => {
       }),
     ).toBe(true);
     await Promise.resolve();
-    expect(
-      workspaceState.values.get(WorkspaceStateKey.GIT_WORKTREE_SUPPORT),
-    ).toBe(true);
+    expect(workspaceState.get(WorkspaceStateKey.GIT_WORKTREE_SUPPORT)).toBe(
+      true,
+    );
     expect(isWorktreeSupportEnabled()).toBe(true);
   });
 
@@ -555,8 +536,8 @@ describe('desktop settings IPC', () => {
 
   it('delegates profile and ChatGPT commands to the credential controller', async () => {
     const state = {
-      globalState: new MemoryStateStore(),
-      workspaceState: new MemoryStateStore(),
+      globalState: new FakeStateStore(),
+      workspaceState: new FakeStateStore(),
     };
     const setProviderKey = vi.fn(async () => undefined);
     const signIn = vi.fn(async () => undefined);
@@ -609,17 +590,12 @@ describe('desktop settings IPC', () => {
   });
 
   it('persists model settings through global state', async () => {
-    const workspaceState = new MemoryStateStore();
-    const globalState = new MemoryStateStore();
-    globalState.values.set(GlobalStateKey.ENABLED_MODELS, [
-      'gpt55',
-      'sonnet46T',
-    ]);
-    globalState.values.set(
-      GlobalStateKey.MODEL_LIST_VERSION,
-      MODEL_LIST_VERSION,
-    );
-    globalState.values.set(GlobalStateKey.HELPER_MODEL, 'gpt55');
+    const workspaceState = new FakeStateStore();
+    const globalState = new FakeStateStore({
+      [GlobalStateKey.ENABLED_MODELS]: ['gpt55', 'sonnet46T'],
+      [GlobalStateKey.MODEL_LIST_VERSION]: MODEL_LIST_VERSION,
+      [GlobalStateKey.HELPER_MODEL]: 'gpt55',
+    });
 
     const errors: unknown[] = [];
     const postMainModelOptionsData = vi.fn(async () => undefined);
@@ -645,12 +621,10 @@ describe('desktop settings IPC', () => {
     ).toBe(true);
     await flushAsyncWork();
 
-    expect(globalState.values.get(GlobalStateKey.ENABLED_MODELS)).toEqual([
+    expect(globalState.get(GlobalStateKey.ENABLED_MODELS)).toEqual([
       'sonnet46T',
     ]);
-    expect(globalState.values.get(GlobalStateKey.HELPER_MODEL)).toBe(
-      'sonnet46T',
-    );
+    expect(globalState.get(GlobalStateKey.HELPER_MODEL)).toBe('sonnet46T');
     expect(errors).toEqual([]);
     expect(
       posted.findLast(
@@ -671,9 +645,7 @@ describe('desktop settings IPC', () => {
     ).toBe(true);
     await flushAsyncWork();
 
-    expect(
-      globalState.values.get(GlobalStateKey.PREFER_SHORT_MODEL_NAMES),
-    ).toBe(true);
+    expect(globalState.get(GlobalStateKey.PREFER_SHORT_MODEL_NAMES)).toBe(true);
     expect(posted.at(-1)).toMatchObject({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_MODEL_SELECTION,
       preferShortModelNames: true,
@@ -681,11 +653,9 @@ describe('desktop settings IPC', () => {
   });
 
   it('delegates domain startup and posts approval settings on readiness', async () => {
-    const workspaceState = new MemoryStateStore();
-    workspaceState.values.set(
-      WorkspaceStateKey.CODEX_SANDBOX_MODE,
-      'danger-full-access',
-    );
+    const workspaceState = new FakeStateStore({
+      [WorkspaceStateKey.CODEX_SANDBOX_MODE]: 'danger-full-access',
+    });
     const config = new MemoryConfigStore();
     config.values.set('texra.toolUse.requireBashApproval', false);
     const agentSettingsController = createStubDesktopAgentSettingsController();
@@ -781,8 +751,8 @@ describe('desktop settings IPC', () => {
   it('does not delay unrelated startup settings behind model-list refresh', async () => {
     const modelListRefresh = createDeferred();
     const state = {
-      globalState: new MemoryStateStore(),
-      workspaceState: new MemoryStateStore(),
+      globalState: new FakeStateStore(),
+      workspaceState: new FakeStateStore(),
     };
     const credentialSettingsController =
       createStubDesktopCredentialSettingsController(state, {
@@ -835,8 +805,8 @@ describe('desktop settings IPC', () => {
 
   it('refreshes credentials before conditionally refreshing the agent catalog', async () => {
     const state = {
-      globalState: new MemoryStateStore(),
-      workspaceState: new MemoryStateStore(),
+      globalState: new FakeStateStore(),
+      workspaceState: new FakeStateStore(),
     };
     const events: string[] = [];
     const refreshAuthDependentData = vi.fn(async () => {
@@ -872,7 +842,7 @@ describe('desktop settings IPC', () => {
   });
 
   it('handles desktop memory toggle messages', async () => {
-    const globalState = new MemoryStateStore();
+    const globalState = new FakeStateStore();
 
     const { settings, posted } = createCapturedSettingsFixture({
       globalState,
@@ -886,7 +856,7 @@ describe('desktop settings IPC', () => {
     ).toBe(true);
     await flushAsyncWork();
 
-    expect(globalState.values.get(GlobalStateKey.MEMORY_ENABLED)).toBe(false);
+    expect(globalState.get(GlobalStateKey.MEMORY_ENABLED)).toBe(false);
     expect(posted.at(-1)).toEqual({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_MEMORY_ENABLED,
       enabled: false,

--- a/src/test-kernel/desktop/DesktopToolingSettingsController.vitest.mts
+++ b/src/test-kernel/desktop/DesktopToolingSettingsController.vitest.mts
@@ -4,6 +4,8 @@ import { describe, expect, it, vi } from 'vitest';
 // Local imports - settings controllers
 import { LatexConfigPersistenceController } from '@controllers/settingsView/LatexConfigPersistenceController';
 import { LatexToolingController } from '@controllers/settingsView/LatexToolingController';
+import { FakeStateStore } from '@test/support/FakePlatform';
+import { isStored } from '@test/support/settingsStoresFake';
 import { DefaultDesktopToolingSettingsController } from '@desktop/main/desktopToolingSettingsController';
 
 // Local imports - shared settings
@@ -18,25 +20,22 @@ import { assertSupported } from '@shared/utils/dispatcher';
 // Local imports - supporting types
 import type { ToolDashboardItem } from '@shared/schemas/settingsViewMessages';
 import type { ExternalToolCheckResult } from '@tools/toolAvailability';
-import type { StateStore } from '@platform/interfaces';
 
-class MemoryStateStore implements StateStore {
-  readonly values = new Map<string, unknown>();
-
-  constructor(private readonly onUpdate?: (key: string) => void) {}
-
-  get<T>(key: string, defaultValue?: T): T {
-    return (this.values.has(key) ? this.values.get(key) : defaultValue) as T;
-  }
-
-  async update(key: string, value: unknown): Promise<void> {
-    this.onUpdate?.(key);
-    if (value === undefined) {
-      this.values.delete(key);
-    } else {
-      this.values.set(key, value);
-    }
-  }
+/**
+ * Wraps `store.update` with a synchronous hook fired before the write, so a
+ * test can interleave state persistence with other async event sources in a
+ * single ordered `events` log without reaching into the fake's internals.
+ */
+function spyOnUpdate(
+  store: FakeStateStore,
+  onUpdate: (key: string) => void,
+): FakeStateStore {
+  const originalUpdate = store.update.bind(store);
+  vi.spyOn(store, 'update').mockImplementation((key, value) => {
+    onUpdate(key);
+    return originalUpdate(key, value);
+  });
+  return store;
 }
 
 const DASHBOARD_ITEM: ToolDashboardItem = {
@@ -60,8 +59,8 @@ function createFixture(overrides: Partial<ControllerOptions> = {}) {
   const commands: string[] = [];
   const openedUrls: string[] = [];
   const presentedExtensions: string[] = [];
-  const globalState = overrides.globalState ?? new MemoryStateStore();
-  const workspaceState = overrides.workspaceState ?? new MemoryStateStore();
+  const globalState = overrides.globalState ?? new FakeStateStore();
+  const workspaceState = overrides.workspaceState ?? new FakeStateStore();
   const dashboard: ControllerOptions['dashboard'] = {
     buildItems: async () => [DASHBOARD_ITEM],
     getCachedCheckResults: async () => [],
@@ -137,7 +136,9 @@ describe('DefaultDesktopToolingSettingsController', () => {
   it('persists a toggle before refreshing caches and posting cached data', async () => {
     const events: string[] = [];
     const cachedResults: ExternalToolCheckResult[] = [];
-    const globalState = new MemoryStateStore(() => events.push('state:update'));
+    const globalState = spyOnUpdate(new FakeStateStore(), () =>
+      events.push('state:update'),
+    );
     const { controller } = createFixture({
       globalState,
       renderer: {
@@ -163,9 +164,7 @@ describe('DefaultDesktopToolingSettingsController', () => {
 
     await assertSupported(controller.toolsActions.toggle)('zotero', false);
 
-    expect(globalState.values.get(GlobalStateKey.DISABLED_TOOLS)).toEqual([
-      'zotero',
-    ]);
+    expect(globalState.get(GlobalStateKey.DISABLED_TOOLS)).toEqual(['zotero']);
     expect(events).toEqual([
       'state:update',
       'dashboard:disabled',
@@ -239,7 +238,7 @@ describe('DefaultDesktopToolingSettingsController', () => {
 
   it('validates LaTeX writes before persistence and reposts after the write', async () => {
     const events: string[] = [];
-    const workspaceState = new MemoryStateStore(() =>
+    const workspaceState = spyOnUpdate(new FakeStateStore(), () =>
       events.push('state:update'),
     );
     const { controller, posted } = createFixture({
@@ -257,9 +256,7 @@ describe('DefaultDesktopToolingSettingsController', () => {
       value: 'none',
     });
 
-    expect(workspaceState.values.get(WorkspaceStateKey.LATEX_FORMATTER)).toBe(
-      'none',
-    );
+    expect(workspaceState.get(WorkspaceStateKey.LATEX_FORMATTER)).toBe('none');
     expect(events).toEqual(['state:update', 'renderer:post']);
     expect(posted.at(-1)).toEqual({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_CONFIG_VALUES,
@@ -273,7 +270,7 @@ describe('DefaultDesktopToolingSettingsController', () => {
       }),
     ).rejects.toThrow('Invalid LaTeX config value for latexdiffTimeoutMs');
     expect(
-      workspaceState.values.has(WorkspaceStateKey.LATEXDIFF_TIMEOUT_MS),
+      isStored(workspaceState, WorkspaceStateKey.LATEXDIFF_TIMEOUT_MS),
     ).toBe(false);
     expect(events).toEqual(['state:update', 'renderer:post']);
   });

--- a/src/test-kernel/desktop/DesktopUpdateChecker.vitest.mts
+++ b/src/test-kernel/desktop/DesktopUpdateChecker.vitest.mts
@@ -1,24 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
+import { FakeStateStore } from '@test/support/FakePlatform';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
-
-class MemoryStateStore {
-  readonly values = new Map<string, unknown>();
-
-  get<T>(key: string, defaultValue?: T): T {
-    return (this.values.has(key) ? this.values.get(key) : defaultValue) as T;
-  }
-
-  async update(key: string, value: unknown): Promise<void> {
-    if (value === undefined) {
-      this.values.delete(key);
-    } else {
-      this.values.set(key, value);
-    }
-  }
-}
 
 interface DesktopLatestRelease {
   version: string;
@@ -28,7 +13,7 @@ interface DesktopUpdateCheckerModule {
   DESKTOP_RELEASES_PAGE_URL: string;
   checkForDesktopUpdate(options: {
     currentVersion: string;
-    globalState: MemoryStateStore;
+    globalState: FakeStateStore;
     isPackaged: boolean;
     notify: (release: DesktopLatestRelease) => Promise<void> | void;
     now?: () => number;
@@ -59,7 +44,7 @@ describe('desktop update checker', () => {
 
     it('skips entirely for unpackaged (dev) runs', async () => {
       const { checkForDesktopUpdate } = await loadDesktopUpdateChecker();
-      const globalState = new MemoryStateStore();
+      const globalState = new FakeStateStore();
       let fetchCalls = 0;
       let notifyCalls = 0;
 
@@ -82,7 +67,7 @@ describe('desktop update checker', () => {
 
     it('skips entirely when TEXRA_NO_UPDATE_CHECK is set', async () => {
       const { checkForDesktopUpdate } = await loadDesktopUpdateChecker();
-      const globalState = new MemoryStateStore();
+      const globalState = new FakeStateStore();
       let fetchCalls = 0;
 
       await checkForDesktopUpdate({
@@ -102,7 +87,7 @@ describe('desktop update checker', () => {
 
     it('notifies once when a newer release is found, and persists the notified version', async () => {
       const { checkForDesktopUpdate } = await loadDesktopUpdateChecker();
-      const globalState = new MemoryStateStore();
+      const globalState = new FakeStateStore();
       const notified: DesktopLatestRelease[] = [];
 
       await checkForDesktopUpdate({
@@ -118,7 +103,7 @@ describe('desktop update checker', () => {
 
       expect(notified).toEqual([release]);
       expect(
-        globalState.values.get(
+        globalState.get(
           GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_NOTIFIED_VERSION,
         ),
       ).toBe('0.40.0');
@@ -126,7 +111,7 @@ describe('desktop update checker', () => {
 
     it('does not notify when the latest release is not newer', async () => {
       const { checkForDesktopUpdate } = await loadDesktopUpdateChecker();
-      const globalState = new MemoryStateStore();
+      const globalState = new FakeStateStore();
       let notifyCalls = 0;
 
       await checkForDesktopUpdate({
@@ -145,7 +130,7 @@ describe('desktop update checker', () => {
 
     it('throttles repeated checks within the same day', async () => {
       const { checkForDesktopUpdate } = await loadDesktopUpdateChecker();
-      const globalState = new MemoryStateStore();
+      const globalState = new FakeStateStore();
       let fetchCalls = 0;
       // A realistic epoch timestamp: on the very first check ever,
       // `lastCheckedAt` defaults to 0, and this must be far enough past that
@@ -182,7 +167,7 @@ describe('desktop update checker', () => {
 
     it('does not re-notify for a release version already notified', async () => {
       const { checkForDesktopUpdate } = await loadDesktopUpdateChecker();
-      const globalState = new MemoryStateStore();
+      const globalState = new FakeStateStore();
       let notifyCalls = 0;
       let nowMs = Date.UTC(2026, 0, 1);
 
@@ -211,7 +196,7 @@ describe('desktop update checker', () => {
 
     it('does not persist the throttle stamp on a failed fetch, so the next launch retries', async () => {
       const { checkForDesktopUpdate } = await loadDesktopUpdateChecker();
-      const globalState = new MemoryStateStore();
+      const globalState = new FakeStateStore();
       let fetchCalls = 0;
       const nowMs = Date.UTC(2026, 0, 1);
 
@@ -230,9 +215,7 @@ describe('desktop update checker', () => {
 
       expect(fetchCalls).toBe(1);
       expect(
-        globalState.values.get(
-          GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT,
-        ),
+        globalState.get(GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT),
       ).toBeUndefined();
 
       // Immediately "relaunching" (same day) must retry rather than being
@@ -252,15 +235,13 @@ describe('desktop update checker', () => {
 
       expect(fetchCalls).toBe(2);
       expect(
-        globalState.values.get(
-          GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT,
-        ),
+        globalState.get(GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT),
       ).toBe(nowMs + 1000);
     });
 
     it('does not persist the throttle stamp when notification fails', async () => {
       const { checkForDesktopUpdate } = await loadDesktopUpdateChecker();
-      const globalState = new MemoryStateStore();
+      const globalState = new FakeStateStore();
       const nowMs = Date.UTC(2026, 0, 1);
       let notifyCalls = 0;
 
@@ -282,9 +263,7 @@ describe('desktop update checker', () => {
         }),
       ).rejects.toThrow('dialog failed');
       expect(
-        globalState.values.get(
-          GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT,
-        ),
+        globalState.get(GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT),
       ).toBeUndefined();
 
       await run(() => {
@@ -292,15 +271,13 @@ describe('desktop update checker', () => {
       });
       expect(notifyCalls).toBe(2);
       expect(
-        globalState.values.get(
-          GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT,
-        ),
+        globalState.get(GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT),
       ).toBe(nowMs);
     });
 
     it('coalesces concurrent checks into one fetch and notification', async () => {
       const { checkForDesktopUpdate } = await loadDesktopUpdateChecker();
-      const globalState = new MemoryStateStore();
+      const globalState = new FakeStateStore();
       let fetchCalls = 0;
       let firstNotifyCalls = 0;
       let secondNotifyCalls = 0;


### PR DESCRIPTION
## Summary

Eight CLI and desktop test suites now use the repository's shared `FakeStateStore` and `FakeSecrets` implementations instead of maintaining local copies. The tests continue to assert values, ordering, deletion calls, and configuration scope through the shared fakes' public interfaces.

The specialized `MemoryConfigStore` in `DesktopSettingsIpc.vitest.mts` remains local because it records global-versus-workspace write targets, behavior that the general fake deliberately does not model.

## Issue acceptance gates

No linked issue. This is a test-only simplification. All scenarios and assertions remain present, and the affected CLI and desktop suites pass after replacing the local fakes.

## Single source of truth

`src/test-kernel/support/FakePlatform.ts` remains the owner of general in-memory platform state and secrets. Tests use constructor seeding, `.get()`, `isStored()`, and method spies instead of reading private storage.

## Duplication and abstraction budget

Eight duplicated local fake classes are removed. One file-local `spyOnUpdate` test helper preserves an ordering assertion at two call sites without enlarging the shared fake API. No production abstraction or compatibility layer is added.

## Net elements (R6)

8 files changed, 224 insertions and 435 deletions, net -211 lines. Eight duplicated local fake definitions are removed. One file-local helper is added; no exported production or test API changes.

## Consumer counts (R8)

- `FakeStateStore` and `FakeSecrets` already serve about 45 test files; eight more suites now use them.
- `isStored` gains two test-file consumers.
- No production emit path, export, or host contract changes.

## Host impact

- CLI: test code only.
- Extension: no impact.
- Desktop: test code only.

## Scheduled refactoring

None. The scope-specific configuration fake remains intentionally local until a second consumer requires that behavior.

## Validation

- TypeScript test-kernel typecheck
- Changed-file Prettier and ESLint
- Affected Vitest suites: 8 files, 93 tests passed
- Broader CLI and desktop test run completed; the independently reproducible `RunChatSignalOwnership.vitest.mts` timeout is unrelated to these test-only substitutions