### PR TITLE
test(cli): accept advancing liveness elapsed time

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1096,12 +1096,13 @@ const SCENARIOS = [
   },
   {
     // The liveness row shows for the whole active run (not just hidden
-    // reasoning) with a ticking elapsed time; the harness pins the run's
-    // start 42s in the past so the elapsed suffix is deterministic.
+    // reasoning) with a ticking elapsed time. The run starts 42s in the past,
+    // but frame settlement may advance the displayed second.
     name: 'run-liveness-row',
     env: { HARNESS_ENTRIES: '4', HARNESS_TODOS: '1' },
     frame: 'viewport',
-    expect: ['✻ Working', '42s', '◆ running'],
+    expect: ['✻ Working', '◆ running'],
+    expectPatterns: [/✻ Working\.{1,3}\s+(?:4[2-9]|[5-9]\d|\d{3,})s/],
   },
   {
     name: 'tools-form',
@@ -3720,6 +3721,7 @@ function expectedFrameTextVisible(scenario, frame) {
   const collapsedFrame = collapseFrameText(frame);
   return (
     (scenario.expect ?? []).every((text) => frame.includes(text)) &&
+    (scenario.expectPatterns ?? []).every((pattern) => pattern.test(frame)) &&
     (scenario.expectCollapsed ?? []).every((text) =>
       collapsedFrame.includes(text),
     )
@@ -4273,6 +4275,9 @@ async function runScenarioWithResources(scenario, fakeClipboard, index) {
   const missingCollapsed = (scenario.expectCollapsed ?? []).filter(
     (t) => !collapsedFrame.includes(t),
   );
+  const missingPatterns = (scenario.expectPatterns ?? []).filter(
+    (pattern) => !pattern.test(frame),
+  );
   const present = (scenario.unexpect ?? []).filter((t) => frame.includes(t));
   const failures = [...checkpointFailures];
   if (!booted) failures.push('input prompt never rendered (boot timeout)');
@@ -4280,6 +4285,8 @@ async function runScenarioWithResources(scenario, fakeClipboard, index) {
     failures.push(`expected text missing: ${JSON.stringify(t)}`);
   for (const t of missingCollapsed)
     failures.push(`expected collapsed text missing: ${JSON.stringify(t)}`);
+  for (const pattern of missingPatterns)
+    failures.push(`expected pattern missing: ${pattern.toString()}`);
   for (const t of present)
     failures.push(`unexpected text present: ${JSON.stringify(t)}`);
   for (const check of scenario.maxOccurrences ?? []) {

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1102,7 +1102,9 @@ const SCENARIOS = [
     env: { HARNESS_ENTRIES: '4', HARNESS_TODOS: '1' },
     frame: 'viewport',
     expect: ['✻ Working', '◆ running'],
-    expectPatterns: [/✻ Working\.{1,3}\s+(?:4[2-9]|[5-9]\d|\d{3,})s/],
+    expectPatterns: [
+      /✻ Working\.{1,3}[ \t]+(?:4[2-9]s|5\ds|[1-9]\d*(?:m|h|d)(?: [1-9]\d*(?:s|m|h))?)/,
+    ],
   },
   {
     name: 'tools-form',


### PR DESCRIPTION
## Summary

The `run-liveness-row` PTY scenario now accepts elapsed time advancing while the validator waits for a settled terminal frame. It still requires the liveness row itself to show `Working` with a duration of at least 42 seconds.

The assertion accepts the compact formatter's second, minute, hour, and day forms and restricts spacing to the same line, so it cannot accidentally match the status bar's elapsed value.

This follows the post-merge review of #8604, where the exact `42s` assertion was correctly identified as nondeterministic on slower workers.

## Issue acceptance gates

No linked issue.

- The scenario no longer depends on capture occurring within one exact second.
- The elapsed assertion remains on the `Working` liveness row.
- Durations below the harness's 42-second starting offset do not pass.
- Compact minute and larger-unit durations pass.
- The real PTY scenario passes repeatedly.

## Single source of truth

The rendered frame remains the test oracle. The validator's scenario declaration owns both literal text assertions and regular-expression assertions; no harness clock or production timing behavior is changed.

## Duplication and abstraction budget

One optional `expectPatterns` field extends the existing scenario assertion mechanism at its two existing evaluation points: frame settlement and final failure reporting. No new module, class, dependency, or timing wrapper is added.

## Net elements (R6)

1 file changed, 12 insertions and 3 deletions, net +9 lines. No exported symbols or production elements are added.

## Consumer counts (R8)

- `expectPatterns`: one PTY scenario.
- No production consumer, event path, or host contract changes.

## Host impact

- CLI: validation only; prevents a false CI failure.
- Extension: no impact.
- Desktop: no impact.

## Scheduled refactoring

None.

## Validation

- Prettier
- `git diff --check`
- Direct pattern cases: 42–59 seconds, compact minutes/hours, below-threshold rejection, and cross-line rejection
- `run-liveness-row` PTY validator passed repeatedly