### PR TITLE
docs(cli): announce legacy result field removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,9 @@ All notable changes to this project will be documented in this file.
 
 - **Structured run results are moving to one outcome field** — scripts reading
   final result objects from `--output-format json` or `ndjson` should use
-  `outcome`. The legacy `status`, `terminalStatus`, and `endGroupStatus` fields
-  remain available through v0.40 and will be removed in v0.41. Status fields on
-  streamed progress records are unaffected.
+  `outcome`. Current v0.39 releases and all v0.40 releases continue to emit the
+  legacy `status`, `terminalStatus`, and `endGroupStatus` fields; v0.41 removes
+  them. Status fields on streamed progress records are unaffected.
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ All notable changes to this project will be documented in this file.
 
 ### CLI
 
+#### Breaking Changes
+
+- **Structured run results are moving to one outcome field** — scripts reading
+  final result objects from `--output-format json` or `ndjson` should use
+  `outcome`. The legacy `status`, `terminalStatus`, and `endGroupStatus` fields
+  remain available through v0.40 and will be removed in v0.41. Status fields on
+  streamed progress records are unaffected.
+
 #### Bug Fixes
 
 - **The chat transcript breathes and shows run activity** — a blank line now

--- a/docs/guide/texra-cli.md
+++ b/docs/guide/texra-cli.md
@@ -82,7 +82,13 @@ With `--output`, TeXRA also copies the final artifact to the requested
 filesystem destination. JSON and NDJSON output keep `outputs[]` as the
 run-storage source of truth (`relativePath`, `absolutePath`, and `location`),
 include `runDirectory`, include `copiedOutput` or `copiedOutputs` when a
-filesystem copy was written, and report `terminalStatus` for the completed run.
+filesystem copy was written, and report the completed run's canonical
+`outcome`.
+
+For final run result objects, `status`, `terminalStatus`, and `endGroupStatus`
+are deprecated compatibility fields. They remain available through v0.40 and
+will be removed in v0.41; use `outcome` instead. This removal does not apply to
+status fields on streamed NDJSON progress records.
 
 ## Authentication
 

--- a/docs/guide/texra-cli.md
+++ b/docs/guide/texra-cli.md
@@ -86,9 +86,9 @@ filesystem copy was written, and report the completed run's canonical
 `outcome`.
 
 For final run result objects, `status`, `terminalStatus`, and `endGroupStatus`
-are deprecated compatibility fields. They remain available through v0.40 and
-will be removed in v0.41; use `outcome` instead. This removal does not apply to
-status fields on streamed NDJSON progress records.
+are deprecated compatibility fields. Current v0.39 releases and all v0.40
+releases continue to emit them; v0.41 removes them. Use `outcome` instead. This
+removal does not apply to status fields on streamed NDJSON progress records.
 
 ## Authentication
 

--- a/packages/cli/src/runtime/terminalStatus.ts
+++ b/packages/cli/src/runtime/terminalStatus.ts
@@ -26,6 +26,7 @@ interface CliRunResultMetadata {
 
 type CliRunResultFor<T extends ExecuteAgentResult> = T & CliRunResultMetadata;
 
+// Compatibility window announced in v0.40; remove these projections in v0.41.
 type PublishedCliRunResultFor<T extends ExecuteAgentResult> = T & {
   /** @deprecated Use `outcome`; this is a frozen projection for JSON-output compatibility. */
   status: ExecutionStatus;
@@ -55,7 +56,7 @@ export function toolUseResultText(result: CliToolUseRunResult): string {
   );
 }
 
-/** Add the frozen v0.40 status fields at the CLI serialization boundary. */
+/** Add legacy status fields during the v0.40 compatibility window. */
 export function serializeCliRunResult<T extends ExecuteAgentResult>(
   result: CliRunResultFor<T>,
 ): T extends ExecuteAgentResult ? PublishedCliRunResultFor<T> : never {

--- a/packages/cli/src/runtime/terminalStatus.ts
+++ b/packages/cli/src/runtime/terminalStatus.ts
@@ -26,7 +26,7 @@ interface CliRunResultMetadata {
 
 type CliRunResultFor<T extends ExecuteAgentResult> = T & CliRunResultMetadata;
 
-// Compatibility window announced in v0.40; remove these projections in v0.41.
+// Announced during v0.39; keep through v0.40 and remove in v0.41.
 type PublishedCliRunResultFor<T extends ExecuteAgentResult> = T & {
   /** @deprecated Use `outcome`; this is a frozen projection for JSON-output compatibility. */
   status: ExecutionStatus;
@@ -56,7 +56,7 @@ export function toolUseResultText(result: CliToolUseRunResult): string {
   );
 }
 
-/** Add legacy status fields during the v0.40 compatibility window. */
+/** Add legacy status fields through the v0.40 compatibility window. */
 export function serializeCliRunResult<T extends ExecuteAgentResult>(
   result: CliRunResultFor<T>,
 ): T extends ExecuteAgentResult ? PublishedCliRunResultFor<T> : never {


### PR DESCRIPTION
## Summary

The CLI now gives script authors a release-bounded migration path from the three legacy status projections on final JSON and NDJSON result objects to the canonical `outcome` field.

The unreleased changelog and CLI guide state that current v0.39 releases and all v0.40 releases continue to emit `status`, `terminalStatus`, and `endGroupStatus`, with removal in v0.41. They also distinguish these final-result compatibility fields from status fields on streamed NDJSON progress records, which are unaffected.

The removal horizon is recorded beside the serialization type so the v0.41 cleanup does not depend on issue-history archaeology.

Closes #8613.

## Issue acceptance gates

- The unreleased changelog names all three deprecated final-result fields, their replacement, and the v0.41 removal release.
- The CLI guide carries the same migration notice next to the JSON/NDJSON result documentation.
- The notice explicitly excludes streamed progress-record status fields.
- Serialization is unchanged; the existing contract suite still pins the exact fields, values, and key order.

## Single source of truth

`ExecuteAgentResult.outcome` remains the canonical terminal result. `serializeCliRunResult` remains the sole boundary that adds the three temporary compatibility projections.

## Duplication and abstraction budget

No abstraction or data path was added. The user-facing migration notice appears in the release changelog and the CLI reference because they serve different readers; both state the same field names and release horizon.

## Net elements (R6)

3 files changed, 17 insertions, 2 deletions, net +15 lines. No files, exports, types, classes, interfaces, enums, factories, schemas, or runtime branches were added.

## Consumer counts (R8)

n/a. No export, event path, schema, or runtime consumer changed.

## Host impact

Extension: none.

Desktop: none.

CLI: structured-output consumers now receive an advance migration notice; emitted bytes are unchanged.

## Scheduled refactoring

Remove `status`, `terminalStatus`, and `endGroupStatus` from final CLI result objects in v0.41, tracked by #6984 and #6981.

## Validation

- Changed-file Prettier check
- Strict ESLint for `packages/cli/src/runtime/terminalStatus.ts`
- Repository `npm run lint`: 0 errors
- Full workspace `npm run typecheck`
- `src/test-kernel/cli/CliRootArgs.vitest.mts`: 108 tests passed
- Documentation dependencies installed with the CI-equivalent `npm ci --legacy-peer-deps`
- `docs/npm run docs:build`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and inline comments only; no serialization or runtime behavior changes, so structured CLI output bytes are unchanged.
> 
> **Overview**
> Documents a **release-bounded migration** for scripts that read final CLI run results from `--output-format json` or `ndjson`: use canonical **`outcome`** instead of **`status`**, **`terminalStatus`**, and **`endGroupStatus`**.
> 
> The unreleased changelog adds a CLI **Breaking Changes** entry with the v0.41 removal horizon. The CLI guide states the same next to JSON/NDJSON result docs and clarifies that **streamed NDJSON progress records** keep their status fields. A comment on `serializeCliRunResult` records the v0.39–v0.40 compatibility window so v0.41 cleanup is explicit.
> 
> **Emitted JSON is unchanged** in this PR; `serializeCliRunResult` still adds the three legacy projections through v0.40.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f86bd2336b64a9dfa3e488dd99a18d48c84d4437. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
