### PR TITLE
fix(agent): admit WAITING results on every tool-use resume path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to this project will be documented in this file.
   them, while the local CLI terminal keeps its operator-readable output.
 - **Unavailable-tool notices are scoped to each agent session** — one active
   session no longer suppresses dependency guidance for another session.
+- **Follow-ups to waiting subagents resume once without a false failure** — a
+  completed follow-up is no longer reported as failed or repeated later.
 
 ### CLI
 

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -15,7 +15,6 @@ import {
   type AgentConfigPayload,
 } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import type { AgentRuntimeFlowResult } from '@agent/runtime/AgentFlowResult';
 import { detachSubagentsOnStop } from '@agent/runtime/detachSubagentsOnStop';
 import {
   executeAgent,
@@ -600,7 +599,7 @@ export function createChatSessionController(
    * a finished agent, so it never fires `agentFinished`.
    */
   const settleResumedTurn = (
-    outcome: AgentRuntimeFlowResult['outcome'],
+    outcome: Parameters<typeof runOutcomeExitCode>[0],
     sessionContext: CliContext,
   ): void => {
     if (session.streamId) {
@@ -668,7 +667,7 @@ export function createChatSessionController(
         session.runExitCode = CliExitCode.Success;
         publishChatTuiRunState(session);
 
-        let resumedOutcome: AgentRuntimeFlowResult['outcome'] =
+        let resumedOutcome: Parameters<typeof runOutcomeExitCode>[0] =
           RUN_OUTCOME.COMPLETED;
         const resumed = await setCliHelperModel(currentModel).then(() =>
           resolveAndResumeStream(streamId, {

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -15,6 +15,7 @@ import {
   type AgentConfigPayload,
 } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import type { AgentRuntimeFlowResult } from '@agent/runtime/AgentFlowResult';
 import { detachSubagentsOnStop } from '@agent/runtime/detachSubagentsOnStop';
 import {
   executeAgent,
@@ -599,7 +600,7 @@ export function createChatSessionController(
    * a finished agent, so it never fires `agentFinished`.
    */
   const settleResumedTurn = (
-    outcome: Parameters<typeof runOutcomeExitCode>[0],
+    outcome: AgentRuntimeFlowResult['outcome'],
     sessionContext: CliContext,
   ): void => {
     if (session.streamId) {
@@ -667,7 +668,7 @@ export function createChatSessionController(
         session.runExitCode = CliExitCode.Success;
         publishChatTuiRunState(session);
 
-        let resumedOutcome: Parameters<typeof runOutcomeExitCode>[0] =
+        let resumedOutcome: AgentRuntimeFlowResult['outcome'] =
           RUN_OUTCOME.COMPLETED;
         const resumed = await setCliHelperModel(currentModel).then(() =>
           resolveAndResumeStream(streamId, {

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -672,7 +672,6 @@ export function createChatSessionController(
                 session: defaultSession(),
                 approvalPromptsUnavailable: approvalsUnavailable,
                 runtimeUnavailableTools: CLI_UNAVAILABLE_TOOLS,
-                allowWaitingResult: true,
                 extraFollowUps: options.extraFollowUps,
                 onFollowUpQueueReady: () => {
                   if (options.onFollowUpQueueReady) {

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -46,6 +46,7 @@ import { runOutcomeExitCode } from '@cli/runtime/terminalStatus';
 import { CLI_UNAVAILABLE_TOOLS } from '@cli/runtime/unavailableTools';
 import {
   EXECUTION_STATUS,
+  RUN_OUTCOME,
   STREAM_PHASE,
   type ExecutionId,
   type StreamTabId,
@@ -572,16 +573,7 @@ export function createChatSessionController(
             isCancellationRequested: () => session.stopRequested,
           }),
         )
-        .then((result) => {
-          if (session.streamId) {
-            projectStreamTranscript(session.streamId, { finalize: true });
-          }
-          session.runExitCode = runOutcomeExitCode(
-            result.outcome,
-            sessionContext,
-          );
-          notify({ kind: 'agentFinished' });
-        })
+        .then((result) => settleResumedTurn(result.outcome, sessionContext))
         .catch(reportRunFailure)
         .finally(finalize);
       // `session.runPromise` was already claimed synchronously above with
@@ -597,6 +589,25 @@ export function createChatSessionController(
       reportRunFailure(error);
       markChatTuiRunCompleted(session);
       resolveRunPromise();
+    }
+  };
+
+  /**
+   * One settlement site for a successfully resumed turn: finalize the
+   * transcript projection, map the outcome to the exit code, and announce
+   * completion. A subagent parking back to WAITING is a completed turn, not
+   * a finished agent, so it never fires `agentFinished`.
+   */
+  const settleResumedTurn = (
+    outcome: Parameters<typeof runOutcomeExitCode>[0],
+    sessionContext: CliContext,
+  ): void => {
+    if (session.streamId) {
+      projectStreamTranscript(session.streamId, { finalize: true });
+    }
+    session.runExitCode = runOutcomeExitCode(outcome, sessionContext);
+    if (outcome !== STREAM_PHASE.WAITING) {
+      notify({ kind: 'agentFinished' });
     }
   };
 
@@ -656,7 +667,8 @@ export function createChatSessionController(
         session.runExitCode = CliExitCode.Success;
         publishChatTuiRunState(session);
 
-        let resumedToWaiting = false;
+        let resumedOutcome: Parameters<typeof runOutcomeExitCode>[0] =
+          RUN_OUTCOME.COMPLETED;
         const resumed = await setCliHelperModel(currentModel).then(() =>
           resolveAndResumeStream(streamId, {
             runtimeHost,
@@ -683,7 +695,7 @@ export function createChatSessionController(
                 },
                 isCancellationRequested: () => session.stopRequested,
                 onResult: (result) => {
-                  resumedToWaiting = result.outcome === STREAM_PHASE.WAITING;
+                  resumedOutcome = result.outcome;
                 },
                 onError: reportRunFailure,
               }),
@@ -703,13 +715,7 @@ export function createChatSessionController(
         );
 
         if (resumed) {
-          if (session.streamId) {
-            projectStreamTranscript(session.streamId, { finalize: true });
-          }
-          session.runExitCode = CliExitCode.Success;
-          if (!resumedToWaiting) {
-            notify({ kind: 'agentFinished' });
-          }
+          settleResumedTurn(resumedOutcome, sessionContext);
         } else if (session.stopRequested) {
           session.runExitCode = CliExitCode.Interrupted;
         }

--- a/packages/cli/src/runtime/terminalStatus.ts
+++ b/packages/cli/src/runtime/terminalStatus.ts
@@ -1,10 +1,10 @@
 import { getExecutionStore } from '@agent/storage';
 import { runAgent } from '@agent/runtime/runAgent';
+import type { AgentRuntimeFlowResult } from '@agent/runtime/AgentFlowResult';
 import {
   type ExecutionStatus,
   RUN_OUTCOME,
   type RunOutcome,
-  STREAM_PHASE,
 } from '@shared/schemas';
 import {
   legacyEndGroupStatusForOutcome,
@@ -85,7 +85,7 @@ export function serializeCliRunResult<T extends ExecuteAgentResult>(
  *  approval-denied error distinctly from a generic agent error. A resumed
  *  subagent that parks back to WAITING is a successfully completed turn. */
 export function runOutcomeExitCode(
-  outcome: RunOutcome | typeof STREAM_PHASE.WAITING,
+  outcome: AgentRuntimeFlowResult['outcome'],
   context: CliContext,
 ): CliExitCode {
   if (outcome === RUN_OUTCOME.FAILED) {

--- a/packages/cli/src/runtime/terminalStatus.ts
+++ b/packages/cli/src/runtime/terminalStatus.ts
@@ -4,6 +4,7 @@ import {
   type ExecutionStatus,
   RUN_OUTCOME,
   type RunOutcome,
+  STREAM_PHASE,
 } from '@shared/schemas';
 import {
   legacyEndGroupStatusForOutcome,
@@ -81,9 +82,10 @@ export function serializeCliRunResult<T extends ExecuteAgentResult>(
 }
 
 /** Map a run outcome to the CLI process exit code, treating an
- *  approval-denied error distinctly from a generic agent error. */
+ *  approval-denied error distinctly from a generic agent error. A resumed
+ *  subagent that parks back to WAITING is a successfully completed turn. */
 export function runOutcomeExitCode(
-  outcome: RunOutcome,
+  outcome: RunOutcome | typeof STREAM_PHASE.WAITING,
   context: CliContext,
 ): CliExitCode {
   if (outcome === RUN_OUTCOME.FAILED) {

--- a/packages/cli/src/runtime/terminalStatus.ts
+++ b/packages/cli/src/runtime/terminalStatus.ts
@@ -1,10 +1,10 @@
 import { getExecutionStore } from '@agent/storage';
 import { runAgent } from '@agent/runtime/runAgent';
-import type { AgentRuntimeFlowResult } from '@agent/runtime/AgentFlowResult';
 import {
   type ExecutionStatus,
   RUN_OUTCOME,
   type RunOutcome,
+  STREAM_PHASE,
 } from '@shared/schemas';
 import {
   legacyEndGroupStatusForOutcome,
@@ -85,7 +85,7 @@ export function serializeCliRunResult<T extends ExecuteAgentResult>(
  *  approval-denied error distinctly from a generic agent error. A resumed
  *  subagent that parks back to WAITING is a successfully completed turn. */
 export function runOutcomeExitCode(
-  outcome: AgentRuntimeFlowResult['outcome'],
+  outcome: RunOutcome | typeof STREAM_PHASE.WAITING,
   context: CliContext,
 ): CliExitCode {
   if (outcome === RUN_OUTCOME.FAILED) {

--- a/src/agent/implementations/flows/tooluse/ToolUseSessionLifecycle.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseSessionLifecycle.ts
@@ -47,14 +47,13 @@ export class ToolUseSessionLifecycle implements IToolUseSession {
   /**
    * Same wake-up as `interrupt()` (unblock any in-progress `waitForFollowUp`)
    * but, unlike it, does not drop already-queued items. For the narrow window
-   * during resume startup where a caller (`resumeQueuedToolUseSnapshot`'s
-   * `setupSession`) has just re-appended its drained follow-up batch into
-   * this queue before the flow is interruptible: an async cancellation
-   * landing in that window must not erase that batch, since the flow's own
-   * early-cancel branch preserves the resume record for a later replay (see
-   * `runToolUseFlow`'s `preserveResumeRecord` finally guard, which also
-   * skips releasing this queue in that case). Every other cancellation path
-   * keeps using `interrupt()`'s destructive clear.
+   * during resume startup after the live flow context is attached but before
+   * the flow is interruptible: an async cancellation must not erase a new
+   * follow-up appended through that context, since the flow's own early-cancel
+   * branch preserves the resume record for a later replay (see
+   * `runToolUseFlow`'s `preserveResumeRecord` finally guard, which also skips
+   * releasing this queue in that case). Every other cancellation path keeps
+   * using `interrupt()`'s destructive clear.
    */
   interruptPreservingQueue(): void {
     this.syntheticFollowUpPending = false;

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -71,6 +71,11 @@ export interface RunToolUseFlowInput<
   resumeSnapshot?: ToolUseSessionSnapshot | null;
   /** One batch already drained by an external child-turn owner. */
   drainedFollowUps?: readonly FollowUpQueueBatchItem[];
+  /**
+   * Take messages queued between the initial drain and live flow attachment.
+   * Called exactly once after attachment and before the persisted cursor runs.
+   */
+  takePendingFollowUps?: () => readonly FollowUpQueueBatchItem[];
   onFollowUpConsumed?: () => void;
   /** When true, delegation tools are filtered out to prevent nesting, and
    *  every completed model cycle suspends at WAITING (see `ToolUseWaitNode`)
@@ -312,13 +317,12 @@ export async function runToolUseFlow<C = unknown>(
     input.onModelChanged?.(nextHandler, model);
   };
 
-  // A resume's setupSession (see `resumeQueuedToolUseSnapshot`) re-appends
-  // its drained follow-up batch into `sessionLifecycle` from inside
-  // `onSetup` below, before the flow is interruptible. An async
-  // cancellation racing in during that window (through the recovery read,
-  // see the `checkInterruption()` guards below) must not erase that batch
-  // -- `flowContext.interrupt()` uses the queue-preserving variant for
-  // exactly this window, matching `preserveResumeRecord`'s finally guard.
+  // A resume completes its one-shot handoff immediately after `onSetup`
+  // attaches the live context, before the flow is interruptible. An async
+  // cancellation racing in during the recovery read must not erase follow-ups
+  // appended to the now-live session after attachment --
+  // `flowContext.interrupt()` uses the queue-preserving variant for exactly
+  // this window, matching `preserveResumeRecord`'s finally guard.
   // Cleared once the flow has passed both guards and moved into real work,
   // so a later mid-run cancellation keeps the normal destructive clear.
   let inResumeStartupWindow = input.resumeSnapshot !== undefined;
@@ -359,6 +363,7 @@ export async function runToolUseFlow<C = unknown>(
   let touchedFiles: string[] | undefined;
   let totalCostUsd: number | undefined;
   let teardownSetup: (() => void) | undefined;
+  let attachmentFollowUps: readonly FollowUpQueueBatchItem[] = [];
   let preserveResumeRecord = false;
   let persistenceRecoveryPending = false;
   let flowRunStarted = false;
@@ -375,6 +380,7 @@ export async function runToolUseFlow<C = unknown>(
 
   try {
     teardownSetup = onSetup?.(flowContext) ?? undefined;
+    attachmentFollowUps = input.takePendingFollowUps?.() ?? [];
     // A host can hand off a cancellation synchronously during setup. Observe
     // it before touching the persisted resume record.
     if (input.checkInterruption()) {
@@ -482,7 +488,11 @@ export async function runToolUseFlow<C = unknown>(
 
     const prepareNode = new ToolUsePrepareNode<C>();
     const cycleNode = new ToolUseCycleNode<C>();
-    const waitNode = new ToolUseWaitNode<C>(input.drainedFollowUps);
+    const resumedFollowUps = [
+      ...(input.drainedFollowUps ?? []),
+      ...attachmentFollowUps,
+    ];
+    const waitNode = new ToolUseWaitNode<C>(resumedFollowUps);
     prepareNode.next(cycleNode);
     cycleNode.next(waitNode);
     waitNode.on(FlowTransition.CONTINUE, cycleNode);

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -8,7 +8,6 @@ import {
   runToolUseFlow,
   type RunToolUseFlowResult,
 } from '@agent/implementations/flows/tooluse/runToolUseFlow';
-import type { IToolUseSession } from '@agent/core/flows/IToolUseSession';
 import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
 import {
   runReflectionFlow,
@@ -462,8 +461,11 @@ export async function executeAgent(
 }
 
 export interface ResumeToolUseFromSnapshotOptions extends SubagentRunOptions {
-  /** Initialize the rebuilt session immediately after its flow is attached. */
-  readonly setupSession?: (session: IToolUseSession) => void;
+  /**
+   * Take messages queued after the initial drain. The flow invokes this once
+   * after attaching its live context and before resuming the persisted cursor.
+   */
+  readonly takePendingFollowUps?: () => readonly FollowUpQueueBatchItem[];
   /** Query caller-owned cancellation once the resumed flow is interruptible. */
   readonly isCancellationRequested?: () => boolean;
   /**
@@ -535,6 +537,7 @@ export async function resumeToolUseFromSnapshot(
             setting,
             resumeSnapshot: snapshot,
             drainedFollowUps: options.drainedFollowUps,
+            takePendingFollowUps: options.takePendingFollowUps,
             // A persisted parent marks this execution as a subagent. Without
             // this, the rebuilt system prompt would drop subagent-specific
             // instructions (e.g. the shared /memories protocol) that the fresh
@@ -551,7 +554,6 @@ export async function resumeToolUseFromSnapshot(
           undefined,
           (flowContext) => {
             handle.attachToolUseFlow(flowContext);
-            options.setupSession?.(flowContext.session);
             if (options.isCancellationRequested?.()) {
               flowContext.interrupt();
             }

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -129,18 +129,6 @@ function wrapOnFollowUpConsumed(
   };
 }
 
-function assertAllowedWaitingResult(
-  result: AgentRuntimeFlowResult,
-  allowWaitingResult: boolean | undefined,
-  callerName: string,
-): void {
-  if (isWaitingFlowResult(result) && allowWaitingResult !== true) {
-    throw new Error(
-      `${callerName} received a non-terminal WAITING result without allowWaitingResult.`,
-    );
-  }
-}
-
 /**
  * Run the tool-use flow for a single agent execution.
  *
@@ -311,12 +299,6 @@ export interface SubagentRunOptions {
   onFollowUpConsumed?: () => void;
   /** Fires on meaningful progress: todo changes and tool call milestones. */
   onProgress?: (update: SubagentProgressUpdate) => void;
-  /**
-   * Allow the promise to resolve with the non-terminal WAITING result. This is
-   * reserved for native subagent drivers that keep the execution handle and
-   * delivery state alive across conversational turns.
-   */
-  allowWaitingResult?: boolean;
   /** Hide tools whose approval prompts cannot be answered in this host mode. */
   approvalPromptsUnavailable?: boolean;
   /** Hide tools unavailable because the current host/runtime cannot support them. */
@@ -356,6 +338,15 @@ export interface ExecuteAgentOptions extends SubagentRunOptions {
   onIdle?: (lastResponse: string | undefined) => void;
   /** Stop a tool-use execution after one model/tool cycle instead of waiting for follow-up input. */
   stopAfterCycle?: boolean;
+  /**
+   * Allow the promise to resolve with the non-terminal WAITING result. Only
+   * a fresh launch of a persistent native subagent (`isSubagent` without
+   * `stopAfterCycle`) can produce one, so only such drivers opt in. Resume
+   * paths have no equivalent flag: whether a resumed run is a subagent comes
+   * from persisted lineage, so `resumeToolUseFromSnapshot` always admits
+   * WAITING and callers narrow with `isWaitingFlowResult`.
+   */
+  allowWaitingResult?: boolean;
   /** Resume using this persisted provider-message format instead of today's default route. */
   modelHandlerCompatibilityKey?: ModelHandlerCompatibilityKey | null;
 }
@@ -461,11 +452,11 @@ export async function executeAgent(
         onRun: options.onRun,
       },
     );
-    assertAllowedWaitingResult(
-      result,
-      options.allowWaitingResult,
-      'executeAgent',
-    );
+    if (isWaitingFlowResult(result) && options.allowWaitingResult !== true) {
+      throw new Error(
+        'executeAgent received a non-terminal WAITING result without allowWaitingResult.',
+      );
+    }
     return result;
   });
 }
@@ -483,24 +474,11 @@ export interface ResumeToolUseFromSnapshotOptions extends SubagentRunOptions {
   readonly drainedFollowUps?: readonly FollowUpQueueBatchItem[];
 }
 
-export function resumeToolUseFromSnapshot(
-  snapshot: ToolUseSessionSnapshot,
-  runtimeHost: AgentRuntimeHost,
-  options: ResumeToolUseFromSnapshotOptions & { allowWaitingResult: true },
-): Promise<AgentFlowResult | WaitingToolUseFlowResult>;
-export function resumeToolUseFromSnapshot(
-  snapshot: ToolUseSessionSnapshot,
-  runtimeHost: AgentRuntimeHost,
-  options?: ResumeToolUseFromSnapshotOptions & {
-    allowWaitingResult?: false | undefined;
-  },
-): Promise<AgentFlowResult>;
-export function resumeToolUseFromSnapshot(
-  snapshot: ToolUseSessionSnapshot,
-  runtimeHost: AgentRuntimeHost,
-  options: ResumeToolUseFromSnapshotOptions,
-): Promise<AgentRuntimeFlowResult>;
-
+/**
+ * Resume a persisted tool-use session at its WAITING cursor. Whether the run
+ * is a subagent — and can therefore legitimately resolve WAITING again — comes
+ * from persisted lineage (`hasPersistedParent`), never from the caller.
+ */
 export async function resumeToolUseFromSnapshot(
   snapshot: ToolUseSessionSnapshot,
   runtimeHost: AgentRuntimeHost,
@@ -593,11 +571,6 @@ export async function resumeToolUseFromSnapshot(
         onError: options.onRunError,
         onRun: options.onRun,
       },
-    );
-    assertAllowedWaitingResult(
-      result,
-      options.allowWaitingResult,
-      'resumeToolUseFromSnapshot',
     );
     return result;
   });

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -468,6 +468,8 @@ export interface ResumeToolUseFromSnapshotOptions extends SubagentRunOptions {
   readonly takePendingFollowUps?: () => readonly FollowUpQueueBatchItem[];
   /** Query caller-owned cancellation once the resumed flow is interruptible. */
   readonly isCancellationRequested?: () => boolean;
+  /** Observe cancellation accepted at the live-flow attachment boundary. */
+  readonly onCancellationAtFlowAttachment?: () => void;
   /**
    * Follow-ups already drained by an external turn owner. The resumed flow
    * consumes this batch once at its persisted WAITING cursor; it must never
@@ -555,6 +557,7 @@ export async function resumeToolUseFromSnapshot(
           (flowContext) => {
             handle.attachToolUseFlow(flowContext);
             if (options.isCancellationRequested?.()) {
+              options.onCancellationAtFlowAttachment?.();
               flowContext.interrupt();
             }
             return () => handle.detachToolUseFlow(flowContext);

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -112,7 +112,6 @@ export async function resumeQueuedToolUseSnapshot(
       runtimeUnavailableTools: options.runtimeUnavailableTools,
       parentStreamId:
         options.parentStreamId ?? snapshot.parentStreamId ?? undefined,
-      allowWaitingResult: options.allowWaitingResult,
       onFollowUpConsumed: options.onFollowUpConsumed,
       onProgress: options.onProgress,
       onRunError: options.onRunError,

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -132,6 +132,9 @@ export async function resumeQueuedToolUseSnapshot(
       onRunError: options.onRunError,
       onRun: options.onRun,
       isCancellationRequested: options.isCancellationRequested,
+      onCancellationAtFlowAttachment: () => {
+        cancelledAtFlowAttachment = true;
+      },
       drainedFollowUps: followUps.map(toFollowUpBatchItem),
       // The live context is attached before this second drain. Items arriving
       // later therefore target that context directly; this callback owns the
@@ -139,9 +142,6 @@ export async function resumeQueuedToolUseSnapshot(
       takePendingFollowUps: () => {
         const raced = followUpsQueue.drainItems(streamId);
         followUps = [...followUps, ...raced];
-        if (options.isCancellationRequested?.()) {
-          cancelledAtFlowAttachment = true;
-        }
         return raced.map(toFollowUpBatchItem);
       },
     });

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -1,5 +1,8 @@
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
-import type { FollowUpQueueInput } from '@agent/followUp/FollowUpQueue';
+import type {
+  FollowUpQueueBatchItem,
+  FollowUpQueueInput,
+} from '@agent/followUp/FollowUpQueue';
 import type { AgentRuntimeFlowResult } from '@agent/runtime/AgentFlowResult';
 import {
   STREAM_PHASE,
@@ -58,7 +61,7 @@ export interface ResumeQueuedToolUseOptions extends SubagentRunOptions {
  * Hosts stay thin adapters: they supply only what differs (`session`,
  * `runtimeUnavailableTools`, an optional seed follow-up, and the `onError`
  * toast). Returns `true` when the resume completed and `false` when it failed
- * or was cancelled before the rebuilt session accepted its follow-ups.
+ * or returned before the resumed cursor consumed its follow-ups.
  */
 export async function resumeQueuedToolUseSnapshot(
   streamId: StreamTabId,
@@ -78,10 +81,13 @@ export async function resumeQueuedToolUseSnapshot(
 
   const seed = options.extraFollowUps ?? [];
   let followUps: readonly FollowUpQueueInput[] = seed;
-  let cancelledBeforeSessionSetup = false;
-  let resumeReturned = false;
+  let cancelledAtFlowAttachment = false;
+  let followUpsConsumed = false;
+  let followUpsRestored = false;
   let resumeError: { error: unknown } | undefined;
   const restoreFollowUps = (): void => {
+    if (followUpsRestored) return;
+    followUpsRestored = true;
     for (const item of followUps) {
       followUpsQueue.enqueue(streamId, item, { force: true });
     }
@@ -118,51 +124,42 @@ export async function resumeQueuedToolUseSnapshot(
       runtimeUnavailableTools: options.runtimeUnavailableTools,
       parentStreamId:
         options.parentStreamId ?? snapshot.parentStreamId ?? undefined,
-      onFollowUpConsumed: options.onFollowUpConsumed,
+      onFollowUpConsumed: () => {
+        followUpsConsumed = true;
+        options.onFollowUpConsumed?.();
+      },
       onProgress: options.onProgress,
       onRunError: options.onRunError,
       onRun: options.onRun,
       isCancellationRequested: options.isCancellationRequested,
-      drainedFollowUps: followUps.length
-        ? followUps.map((item) => ({
-            text: item.text,
-            displayText: item.displayText,
-            mediaFiles: item.mediaFiles,
-            origin: item.origin ?? ('user' as const),
-          }))
-        : undefined,
-      setupSession: (session) => {
-        // Items that raced into the queue after the initial drain go through
-        // the rebuilt session's queue: a root cursor drains them at its next
-        // suspension, a subagent leaves them for its next wake. They are
-        // tracked in `followUps` so a failed resume restores them too.
+      drainedFollowUps: followUps.map(toFollowUpBatchItem),
+      // The live context is attached before this second drain. Items arriving
+      // later therefore target that context directly; this callback owns the
+      // only queue gap between the initial drain and attachment.
+      takePendingFollowUps: () => {
         const raced = followUpsQueue.drainItems(streamId);
         followUps = [...followUps, ...raced];
         if (options.isCancellationRequested?.()) {
-          cancelledBeforeSessionSetup = true;
-          return;
+          cancelledAtFlowAttachment = true;
         }
-        for (const item of raced) {
-          session.appendFollowUp(item);
-        }
+        return raced.map(toFollowUpBatchItem);
       },
     });
-    resumeReturned = true;
-    if (cancelledBeforeSessionSetup) restoreFollowUps();
+    if (followUps.length > 0 && !followUpsConsumed) restoreFollowUps();
     options.onResult?.(result);
   } catch (error) {
     resumeError = { error };
-    // A rejected resume has not committed the drained batch's disposition,
-    // so a later resume must replay it. Once the resume returns, the flow has
-    // either consumed, disposed, or deliberately left the batch live; an
-    // observer failure must not enqueue it again.
-    if (!resumeReturned) restoreFollowUps();
+    // A rejection before the wait node acknowledges consumption must replay
+    // the drained batch. A callback failure after that acknowledgement must
+    // not enqueue the same user input again.
+    if (!followUpsConsumed) restoreFollowUps();
   } finally {
     // Early failures leave the stream RESUMING. Startup cancellation can
     // instead reach lifecycle terminalization before the queue owner regains
     // control. In both cases, restored input makes WAITING the durable state.
     if (
-      cancelledBeforeSessionSetup ||
+      cancelledAtFlowAttachment ||
+      followUpsRestored ||
       streamStatus.getSubstate(streamId) === STREAM_SUBSTATE.RESUMING
     ) {
       streamStatus.transitionToWaiting(streamId, 'wait', {
@@ -172,7 +169,7 @@ export async function resumeQueuedToolUseSnapshot(
   }
 
   if (!resumeError) {
-    return !cancelledBeforeSessionSetup;
+    return !cancelledAtFlowAttachment && !followUpsRestored;
   }
   try {
     await options.onError(resumeError.error);
@@ -181,4 +178,13 @@ export async function resumeQueuedToolUseSnapshot(
     // an unhandled rejection.
   }
   return false;
+}
+
+function toFollowUpBatchItem(item: FollowUpQueueInput): FollowUpQueueBatchItem {
+  return {
+    text: item.text,
+    displayText: item.displayText,
+    mediaFiles: item.mediaFiles,
+    origin: item.origin ?? 'user',
+  };
 }

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -50,10 +50,10 @@ export interface ResumeQueuedToolUseOptions extends SubagentRunOptions {
  * extension and the desktop bridge wrap around `resumeToolUseFromSnapshot`:
  *
  *   acquire the follow-up queue → flip the stream to RESUMING → drain the
- *   queued follow-ups and notify the UI → resume, re-appending the drained
- *   items into the rebuilt session → on failure, re-enqueue the follow-ups
- *   (force) and re-notify → always return the stream to WAITING if the resume
- *   never reached the run lifecycle.
+ *   queued follow-ups and notify the UI → resume, handing the drained batch
+ *   to the flow's WAITING cursor via `drainedFollowUps` → on failure,
+ *   re-enqueue the follow-ups (force) and re-notify → always return the
+ *   stream to WAITING if the resume never reached the run lifecycle.
  *
  * Hosts stay thin adapters: they supply only what differs (`session`,
  * `runtimeUnavailableTools`, an optional seed follow-up, and the `onError`
@@ -106,6 +106,12 @@ export async function resumeQueuedToolUseSnapshot(
       },
     });
 
+    // The drained batch must reach the resumed flow through the direct
+    // `drainedFollowUps` handoff, not `appendFollowUp`: a subagent's WAITING
+    // cursor suspends again before ever reading the stream queue (see
+    // `ToolUseWaitNode` — only its child-run loop's queue wait consumes it),
+    // so re-queued items would sit unconsumed until the next wake. A root
+    // cursor accepts either route; the handoff works for both.
     const result = await resumeToolUseFromSnapshot(snapshot, runtimeHost, {
       session: options.session,
       approvalPromptsUnavailable: options.approvalPromptsUnavailable,
@@ -117,13 +123,26 @@ export async function resumeQueuedToolUseSnapshot(
       onRunError: options.onRunError,
       onRun: options.onRun,
       isCancellationRequested: options.isCancellationRequested,
+      drainedFollowUps: followUps.length
+        ? followUps.map((item) => ({
+            text: item.text,
+            displayText: item.displayText,
+            mediaFiles: item.mediaFiles,
+            origin: item.origin ?? ('user' as const),
+          }))
+        : undefined,
       setupSession: (session) => {
-        followUps = [...followUps, ...followUpsQueue.drainItems(streamId)];
+        // Items that raced into the queue after the initial drain go through
+        // the rebuilt session's queue: a root cursor drains them at its next
+        // suspension, a subagent leaves them for its next wake. They are
+        // tracked in `followUps` so a failed resume restores them too.
+        const raced = followUpsQueue.drainItems(streamId);
+        followUps = [...followUps, ...raced];
         if (options.isCancellationRequested?.()) {
           cancelledBeforeSessionSetup = true;
           return;
         }
-        for (const item of followUps) {
+        for (const item of raced) {
           session.appendFollowUp(item);
         }
       },

--- a/src/agent/runtime/resumeToolUseSnapshot.ts
+++ b/src/agent/runtime/resumeToolUseSnapshot.ts
@@ -2,8 +2,8 @@
  * Host-neutral tool-use snapshot resume.
  *
  * Drives the shared queue dance (`resumeQueuedToolUseSnapshot`): acquire the
- * follow-up queue, flip the stream to RESUMING, replay drained follow-ups into
- * the rebuilt session, and on failure re-enqueue the follow-ups and settle the
+ * follow-up queue, flip the stream to RESUMING, hand drained follow-ups to the
+ * resumed wait cursor, and on failure re-enqueue the follow-ups and settle the
  * stream back to WAITING.
  *
  * Hosts stay thin adapters: they inject only what differs (`runtimeHost`, an

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -844,12 +844,12 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
   });
 
   it('preserves a follow-up appended during setup when cancellation arrives during the recovery read (issue #8049 P2)', async () => {
-    // Regression: resumeQueuedToolUseSnapshot's setupSession re-appends its
-    // drained follow-up batch into the live session queue *before* the flow
-    // is interruptible. If an external cancellation then lands while the
-    // recovery read is pending -- this same "cancellation during read"
-    // window as the sibling test above -- the early return here reports
-    // CANCELLED with the resume record preserved, but previously
+    // Regression: once setup attaches the live flow context, a new follow-up
+    // can enter its session queue before the flow is interruptible. If an
+    // external cancellation then lands while the recovery read is pending --
+    // this same "cancellation during read" window as the sibling test above --
+    // the early return here reports CANCELLED with the resume record preserved,
+    // but previously
     // `ToolUseSessionLifecycle.interrupt()` unconditionally disposed the
     // queue (dropping the just-appended follow-up) and the finally below
     // unconditionally released it again, so neither the caller
@@ -868,7 +868,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     let flowContext: ToolUseSetupContext | undefined;
     const readSpy = vi.spyOn(store, 'read').mockImplementationOnce(async () => {
       // Cancellation arrives while the recovery read is pending -- after
-      // setupSession already appended the drained follow-up below.
+      // setup already appended the live follow-up below.
       flowContext?.interrupt();
       return undefined;
     });

--- a/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
+++ b/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
@@ -50,6 +50,7 @@ import {
 interface InterruptibleFlowInput {
   checkInterruption(): boolean;
   onInterrupt?: () => void;
+  takePendingFollowUps?: () => readonly unknown[];
 }
 
 interface TestFlowContext {
@@ -130,6 +131,7 @@ describe('resumeToolUseFromSnapshot cancellation handoff', () => {
           },
         };
         const teardown = onSetup(flowContext);
+        input.takePendingFollowUps?.();
         if (!input.checkInterruption()) mocks.invokeModelOrTool();
         teardown?.();
         return {
@@ -148,7 +150,10 @@ describe('resumeToolUseFromSnapshot cancellation handoff', () => {
     } as unknown as ToolUseSessionSnapshot;
 
     const result = await resumeToolUseFromSnapshot(snapshot, runtimeHost, {
-      setupSession: () => order.push('setup'),
+      takePendingFollowUps: () => {
+        order.push('take');
+        return [];
+      },
       isCancellationRequested: () => {
         order.push('query');
         expect(attachedContext).toBeDefined();
@@ -158,6 +163,6 @@ describe('resumeToolUseFromSnapshot cancellation handoff', () => {
 
     expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
     expect(mocks.invokeModelOrTool).not.toHaveBeenCalled();
-    expect(order).toEqual(['attach', 'setup', 'query', 'interrupt', 'detach']);
+    expect(order).toEqual(['attach', 'query', 'interrupt', 'take', 'detach']);
   });
 });

--- a/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
+++ b/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
@@ -159,10 +159,18 @@ describe('resumeToolUseFromSnapshot cancellation handoff', () => {
         expect(attachedContext).toBeDefined();
         return true;
       },
+      onCancellationAtFlowAttachment: () => order.push('cancel'),
     });
 
     expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
     expect(mocks.invokeModelOrTool).not.toHaveBeenCalled();
-    expect(order).toEqual(['attach', 'query', 'interrupt', 'take', 'detach']);
+    expect(order).toEqual([
+      'attach',
+      'query',
+      'cancel',
+      'interrupt',
+      'take',
+      'detach',
+    ]);
   });
 });

--- a/src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts
+++ b/src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts
@@ -45,6 +45,7 @@ interface CapturedResumeOptions {
   drainedFollowUps?: readonly FollowUpQueueInput[];
   takePendingFollowUps: () => readonly FollowUpQueueInput[];
   onFollowUpConsumed?: () => void;
+  onCancellationAtFlowAttachment?: () => void;
 }
 
 function capturedResumeOptions(): CapturedResumeOptions {
@@ -206,6 +207,9 @@ describe('resumeToolUseSnapshot', () => {
           { text: 'queued during resume' },
           { force: true },
         );
+        if (options.isCancellationRequested?.()) {
+          options.onCancellationAtFlowAttachment?.();
+        }
         options.takePendingFollowUps();
         seedStreamStatusForTest(
           defaultSession().status,

--- a/src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts
+++ b/src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts
@@ -299,6 +299,48 @@ describe('resumeToolUseSnapshot', () => {
     ).toHaveLength(1);
   });
 
+  it('treats a subagent parking back to WAITING as success without replaying follow-ups', async () => {
+    // Host-path resume of a WAITING subagent (e.g. a follow-up sent to a
+    // child stream from the progress view): the turn completes and the wait
+    // node parks the stream WAITING again. That is success — no failure
+    // surface, and the consumed follow-up must not be re-enqueued.
+    const reportFailure = vi.fn();
+    defaultSession().followUps.enqueue(
+      STREAM,
+      { text: 'queued one' },
+      { force: true },
+    );
+    resumeToolUseFromSnapshotMock.mockImplementationOnce(
+      async (...args: unknown[]) => {
+        const options = args[2] as ReturnType<typeof capturedResumeOptions>;
+        options.setupSession({ appendFollowUp: vi.fn() });
+        seedStreamStatusForTest(
+          defaultSession().status,
+          STREAM,
+          STREAM_PHASE.WAITING,
+        );
+        return {
+          category: 'toolUse',
+          outcome: STREAM_PHASE.WAITING,
+          executionId: 'exec-waiting',
+          streamId: STREAM,
+        };
+      },
+    );
+
+    await expect(
+      resumeToolUseSnapshot(snapshot('stream:parent' as StreamTabId), {
+        runtimeHost,
+        explicitFollowUp: 'talk to the subagent',
+        reportFailure,
+      }),
+    ).resolves.toBe(true);
+
+    expect(reportFailure).not.toHaveBeenCalled();
+    expect(defaultSession().followUps.getAll(STREAM)).toEqual([]);
+    expect(defaultSession().status.get(STREAM)).toBe(STREAM_STATUS.WAITING);
+  });
+
   it('re-enqueues follow-ups, settles to WAITING, and reports on failure', async () => {
     const failure = new Error('resume blew up');
     resumeToolUseFromSnapshotMock.mockRejectedValue(failure);

--- a/src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts
+++ b/src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts
@@ -23,7 +23,12 @@ import { resumeQueuedToolUseSnapshot } from '@agent/runtime/resumeQueuedToolUse'
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import type { FollowUpQueueInput } from '@agent/followUp/FollowUpQueue';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
-import { STREAM_PHASE, STREAM_STATUS, type StreamTabId } from '@shared/schemas';
+import {
+  RUN_OUTCOME,
+  STREAM_PHASE,
+  STREAM_STATUS,
+  type StreamTabId,
+} from '@shared/schemas';
 import { recordSessionEvents, sessionFactPayloads } from '../progressTestUtils';
 
 const STREAM = 'stream:tooluse-resume' as StreamTabId;
@@ -38,9 +43,8 @@ interface CapturedResumeOptions {
   parentStreamId?: StreamTabId;
   isCancellationRequested?: () => boolean;
   drainedFollowUps?: readonly FollowUpQueueInput[];
-  setupSession: (session: {
-    appendFollowUp(item: FollowUpQueueInput): void;
-  }) => void;
+  takePendingFollowUps: () => readonly FollowUpQueueInput[];
+  onFollowUpConsumed?: () => void;
 }
 
 function capturedResumeOptions(): CapturedResumeOptions {
@@ -49,18 +53,22 @@ function capturedResumeOptions(): CapturedResumeOptions {
   return calls.at(-1)?.[2] as CapturedResumeOptions;
 }
 
-/** Capture the `setupSession` replay callback handed to the leaf resume. */
-function capturedSetupSession(): (session: {
-  appendFollowUp(item: FollowUpQueueInput): void;
-}) => void {
+/** Capture the callback that closes the queue gap at flow attachment. */
+function capturedTakePendingFollowUps(): () => readonly FollowUpQueueInput[] {
   const options = capturedResumeOptions();
-  return options.setupSession;
+  return options.takePendingFollowUps;
 }
 
 describe('resumeToolUseSnapshot', () => {
   beforeEach(() => {
     resumeToolUseFromSnapshotMock.mockReset();
-    resumeToolUseFromSnapshotMock.mockResolvedValue(undefined);
+    resumeToolUseFromSnapshotMock.mockImplementation(
+      async (...args: unknown[]) => {
+        const options = args[2] as CapturedResumeOptions;
+        options.onFollowUpConsumed?.();
+        return undefined;
+      },
+    );
     runtimeHost.emit.mockReset();
     recordedSession = recordSessionEvents(defaultSession().events, {
       scope: 'session',
@@ -86,8 +94,8 @@ describe('resumeToolUseSnapshot', () => {
     ).resolves.toBe(true);
 
     // The initial batch travels via the direct drainedFollowUps handoff (a
-    // subagent's WAITING cursor never reads the stream queue); setupSession
-    // replays only items that raced in after the drain.
+    // subagent's WAITING cursor never reads the stream queue). The attachment
+    // drain supplies any item that arrived before the live context existed.
     expect(capturedResumeOptions().drainedFollowUps).toEqual([
       {
         text: 'queued one',
@@ -96,9 +104,7 @@ describe('resumeToolUseSnapshot', () => {
         origin: 'user',
       },
     ]);
-    const appendFollowUp = vi.fn();
-    capturedSetupSession()({ appendFollowUp });
-    expect(appendFollowUp).not.toHaveBeenCalled();
+    expect(capturedTakePendingFollowUps()()).toEqual([]);
     expect(
       sessionFactPayloads(
         recordedSession?.events ?? [],
@@ -130,6 +136,17 @@ describe('resumeToolUseSnapshot', () => {
         text: 'queued at the ready boundary',
       });
     });
+    let attachmentFollowUps: readonly FollowUpQueueInput[] = [];
+    resumeToolUseFromSnapshotMock.mockImplementationOnce(
+      async (...args: unknown[]) => {
+        const options = args[2] as ReturnType<typeof capturedResumeOptions>;
+        defaultSession().followUps.enqueue(STREAM, {
+          text: 'queued after the initial drain',
+        });
+        attachmentFollowUps = options.takePendingFollowUps();
+        options.onFollowUpConsumed?.();
+      },
+    );
 
     await resumeQueuedToolUseSnapshot(STREAM, snapshot(), runtimeHost, {
       onFollowUpQueueReady,
@@ -138,17 +155,14 @@ describe('resumeToolUseSnapshot', () => {
 
     expect(onFollowUpQueueReady).toHaveBeenCalledOnce();
     expect(
-      capturedResumeOptions().drainedFollowUps?.map((item) => item.text),
-    ).toEqual(['queued at the ready boundary']);
-    defaultSession().followUps.enqueue(STREAM, {
-      text: 'queued after the initial drain',
-    });
-    const appendFollowUp = vi.fn();
-    capturedSetupSession()({ appendFollowUp });
-    expect(appendFollowUp).toHaveBeenCalledExactlyOnceWith({
-      text: 'queued after the initial drain',
-      origin: 'user',
-    });
+      [
+        ...(capturedResumeOptions().drainedFollowUps ?? []),
+        ...attachmentFollowUps,
+      ].map((item) => item.text),
+    ).toEqual([
+      'queued at the ready boundary',
+      'queued after the initial drain',
+    ]);
   });
 
   it('passes snapshot parent stream identity to the leaf resume', async () => {
@@ -183,7 +197,6 @@ describe('resumeToolUseSnapshot', () => {
       { force: true },
     );
     const isCancellationRequested = vi.fn(() => true);
-    const appendFollowUp = vi.fn();
     resumeToolUseFromSnapshotMock.mockImplementationOnce(
       async (...args: unknown[]) => {
         const options = args[2] as ReturnType<typeof capturedResumeOptions>;
@@ -193,7 +206,7 @@ describe('resumeToolUseSnapshot', () => {
           { text: 'queued during resume' },
           { force: true },
         );
-        options.setupSession({ appendFollowUp });
+        options.takePendingFollowUps();
         seedStreamStatusForTest(
           defaultSession().status,
           STREAM,
@@ -209,11 +222,45 @@ describe('resumeToolUseSnapshot', () => {
       }),
     ).resolves.toBe(false);
 
-    expect(appendFollowUp).not.toHaveBeenCalled();
     expect(defaultSession().followUps.getAll(STREAM)).toEqual([
       'queued one',
       'queued during resume',
     ]);
+    expect(defaultSession().status.get(STREAM)).toBe(STREAM_STATUS.WAITING);
+  });
+
+  it('restores an unconsumed batch when cancellation lands after attachment', async () => {
+    defaultSession().followUps.enqueue(
+      STREAM,
+      { text: 'queued one' },
+      { force: true },
+    );
+    resumeToolUseFromSnapshotMock.mockImplementationOnce(
+      async (...args: unknown[]) => {
+        const options = args[2] as ReturnType<typeof capturedResumeOptions>;
+        options.takePendingFollowUps();
+        seedStreamStatusForTest(
+          defaultSession().status,
+          STREAM,
+          STREAM_PHASE.CANCELLED,
+        );
+        return {
+          category: 'toolUse',
+          outcome: RUN_OUTCOME.CANCELLED,
+          executionId: 'exec-cancelled',
+          streamId: STREAM,
+        };
+      },
+    );
+
+    await expect(
+      resumeQueuedToolUseSnapshot(STREAM, snapshot(), runtimeHost, {
+        isCancellationRequested: () => false,
+        onError: vi.fn(),
+      }),
+    ).resolves.toBe(false);
+
+    expect(defaultSession().followUps.getAll(STREAM)).toEqual(['queued one']);
     expect(defaultSession().status.get(STREAM)).toBe(STREAM_STATUS.WAITING);
   });
 
@@ -228,7 +275,7 @@ describe('resumeToolUseSnapshot', () => {
     resumeToolUseFromSnapshotMock.mockImplementationOnce(
       async (...args: unknown[]) => {
         const options = args[2] as ReturnType<typeof capturedResumeOptions>;
-        options.setupSession({ appendFollowUp: vi.fn() });
+        options.takePendingFollowUps();
       },
     );
 
@@ -252,7 +299,7 @@ describe('resumeToolUseSnapshot', () => {
     ).toHaveLength(2);
   });
 
-  it('does not duplicate a live batch when post-setup cancellation result handling throws', async () => {
+  it('does not restore a consumed batch when cancellation result handling throws', async () => {
     const failure = new Error('result callback failed');
     const reportFailure = vi.fn();
     let cancellationRequested = false;
@@ -265,14 +312,8 @@ describe('resumeToolUseSnapshot', () => {
     resumeToolUseFromSnapshotMock.mockImplementationOnce(
       async (...args: unknown[]) => {
         const options = args[2] as ReturnType<typeof capturedResumeOptions>;
-        const liveQueue = defaultSession().followUps.acquire(STREAM);
-        options.setupSession({
-          appendFollowUp: (item) => liveQueue.enqueue(item),
-        });
-        // Emulate the flow deliberately leaving the handed-off batch live.
-        for (const item of options.drainedFollowUps ?? []) {
-          liveQueue.enqueue(item);
-        }
+        options.takePendingFollowUps();
+        options.onFollowUpConsumed?.();
         cancellationRequested = true;
         seedStreamStatusForTest(
           defaultSession().status,
@@ -292,7 +333,7 @@ describe('resumeToolUseSnapshot', () => {
       }),
     ).resolves.toBe(false);
 
-    expect(defaultSession().followUps.getAll(STREAM)).toEqual(['queued one']);
+    expect(defaultSession().followUps.getAll(STREAM)).toEqual([]);
     expect(reportFailure).toHaveBeenCalledWith(failure);
     expect(
       sessionFactPayloads(
@@ -316,7 +357,8 @@ describe('resumeToolUseSnapshot', () => {
     resumeToolUseFromSnapshotMock.mockImplementationOnce(
       async (...args: unknown[]) => {
         const options = args[2] as ReturnType<typeof capturedResumeOptions>;
-        options.setupSession({ appendFollowUp: vi.fn() });
+        options.takePendingFollowUps();
+        options.onFollowUpConsumed?.();
         seedStreamStatusForTest(
           defaultSession().status,
           STREAM,

--- a/src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts
+++ b/src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts
@@ -6,7 +6,9 @@ import { createTestSession } from '@test/support/sessionTestUtils';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const resumeToolUseFromSnapshotMock = vi.hoisted(() => vi.fn(async () => {}));
+const resumeToolUseFromSnapshotMock = vi.hoisted(() =>
+  vi.fn(async (..._args: unknown[]): Promise<unknown> => undefined),
+);
 
 vi.mock('@agent/runtime/executeAgent', () => ({
   resumeToolUseFromSnapshot: resumeToolUseFromSnapshotMock,
@@ -32,22 +34,19 @@ function snapshot(parentStreamId?: StreamTabId): ToolUseSessionSnapshot {
   return { streamId: STREAM, parentStreamId } as ToolUseSessionSnapshot;
 }
 
-function capturedResumeOptions(): {
+interface CapturedResumeOptions {
   parentStreamId?: StreamTabId;
   isCancellationRequested?: () => boolean;
+  drainedFollowUps?: readonly FollowUpQueueInput[];
   setupSession: (session: {
     appendFollowUp(item: FollowUpQueueInput): void;
   }) => void;
-} {
+}
+
+function capturedResumeOptions(): CapturedResumeOptions {
   const calls = resumeToolUseFromSnapshotMock.mock
     .calls as unknown as unknown[][];
-  return calls.at(-1)?.[2] as {
-    parentStreamId?: StreamTabId;
-    isCancellationRequested?: () => boolean;
-    setupSession: (session: {
-      appendFollowUp(item: FollowUpQueueInput): void;
-    }) => void;
-  };
+  return calls.at(-1)?.[2] as CapturedResumeOptions;
 }
 
 /** Capture the `setupSession` replay callback handed to the leaf resume. */
@@ -75,7 +74,7 @@ describe('resumeToolUseSnapshot', () => {
     clearStreamStatusForTest(defaultSession().status, STREAM);
   });
 
-  it('drains queued follow-ups, replays them, and notifies the UI', async () => {
+  it('drains queued follow-ups, hands them to the flow, and notifies the UI', async () => {
     defaultSession().followUps.enqueue(
       STREAM,
       { text: 'queued one' },
@@ -86,12 +85,20 @@ describe('resumeToolUseSnapshot', () => {
       resumeToolUseSnapshot(snapshot(), { runtimeHost }),
     ).resolves.toBe(true);
 
+    // The initial batch travels via the direct drainedFollowUps handoff (a
+    // subagent's WAITING cursor never reads the stream queue); setupSession
+    // replays only items that raced in after the drain.
+    expect(capturedResumeOptions().drainedFollowUps).toEqual([
+      {
+        text: 'queued one',
+        displayText: undefined,
+        mediaFiles: undefined,
+        origin: 'user',
+      },
+    ]);
     const appendFollowUp = vi.fn();
     capturedSetupSession()({ appendFollowUp });
-    expect(appendFollowUp).toHaveBeenCalledWith({
-      text: 'queued one',
-      origin: 'user',
-    });
+    expect(appendFollowUp).not.toHaveBeenCalled();
     expect(
       sessionFactPayloads(
         recordedSession?.events ?? [],
@@ -112,16 +119,9 @@ describe('resumeToolUseSnapshot', () => {
       explicitFollowUp: 'typed alongside resume',
     });
 
-    const appendFollowUp = vi.fn();
-    capturedSetupSession()({ appendFollowUp });
-    expect(appendFollowUp).toHaveBeenNthCalledWith(1, {
-      text: 'typed alongside resume',
-      origin: 'user',
-    });
-    expect(appendFollowUp).toHaveBeenNthCalledWith(2, {
-      text: 'queued one',
-      origin: 'user',
-    });
+    expect(
+      capturedResumeOptions().drainedFollowUps?.map((item) => item.text),
+    ).toEqual(['typed alongside resume', 'queued one']);
   });
 
   it('keeps ready-boundary and setup-race follow-ups in order', async () => {
@@ -137,16 +137,15 @@ describe('resumeToolUseSnapshot', () => {
     });
 
     expect(onFollowUpQueueReady).toHaveBeenCalledOnce();
+    expect(
+      capturedResumeOptions().drainedFollowUps?.map((item) => item.text),
+    ).toEqual(['queued at the ready boundary']);
     defaultSession().followUps.enqueue(STREAM, {
       text: 'queued after the initial drain',
     });
     const appendFollowUp = vi.fn();
     capturedSetupSession()({ appendFollowUp });
-    expect(appendFollowUp).toHaveBeenNthCalledWith(1, {
-      text: 'queued at the ready boundary',
-      origin: 'user',
-    });
-    expect(appendFollowUp).toHaveBeenNthCalledWith(2, {
+    expect(appendFollowUp).toHaveBeenCalledExactlyOnceWith({
       text: 'queued after the initial drain',
       origin: 'user',
     });
@@ -270,6 +269,10 @@ describe('resumeToolUseSnapshot', () => {
         options.setupSession({
           appendFollowUp: (item) => liveQueue.enqueue(item),
         });
+        // Emulate the flow deliberately leaving the handed-off batch live.
+        for (const item of options.drainedFollowUps ?? []) {
+          liveQueue.enqueue(item);
+        }
         cancellationRequested = true;
         seedStreamStatusForTest(
           defaultSession().status,
@@ -336,6 +339,9 @@ describe('resumeToolUseSnapshot', () => {
       }),
     ).resolves.toBe(true);
 
+    expect(
+      capturedResumeOptions().drainedFollowUps?.map((item) => item.text),
+    ).toEqual(['talk to the subagent', 'queued one']);
     expect(reportFailure).not.toHaveBeenCalled();
     expect(defaultSession().followUps.getAll(STREAM)).toEqual([]);
     expect(defaultSession().status.get(STREAM)).toBe(STREAM_STATUS.WAITING);

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -671,6 +671,27 @@ describe('createChatSessionController', () => {
     });
   });
 
+  it('treats a manually resumed subagent returning to WAITING as a successful turn', async () => {
+    const session = makeSession({ runCompleted: true });
+    mocks.resumeToolUseFromSnapshot.mockResolvedValueOnce({
+      category: 'toolUse',
+      outcome: STREAM_PHASE.WAITING,
+      executionId: 'exec-resume',
+      streamId: 'stream-resume',
+    });
+    const ctrl = createChatSessionController(makeInit({ session }));
+
+    await ctrl.resume('exec-resume' as ExecutionId, makeResolvedResume());
+    await session.runPromise;
+
+    expect(session.runExitCode).toBe(CliExitCode.Success);
+    expect(mocks.projectStreamTranscript).toHaveBeenCalledWith(
+      'stream-resume',
+      { finalize: true },
+    );
+    expect(mocks.notify).not.toHaveBeenCalledWith({ kind: 'agentFinished' });
+  });
+
   it('manual resume supersedes stale interrupted recovery state', async () => {
     const session = makeSession({
       interruptedStreamId: 'stream-interrupted' as StreamTabId,

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -979,7 +979,6 @@ describe('createChatSessionController', () => {
       { version: 2 },
       expect.any(Object),
       expect.objectContaining({
-        allowWaitingResult: true,
         isCancellationRequested: expect.any(Function),
       }),
     );

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -1955,6 +1955,7 @@ describe('DesktopProgressBridge', () => {
         unknown,
         unknown,
         {
+          drainedFollowUps?: readonly { text: string; origin?: string }[];
           setupSession(session: {
             appendFollowUp(followUp: {
               text: string;
@@ -1965,12 +1966,15 @@ describe('DesktopProgressBridge', () => {
           }): void;
         },
       ];
+      // The drained batch travels via the direct drainedFollowUps handoff (a
+      // subagent's WAITING cursor never reads the stream queue); setupSession
+      // replays only items that race in after the drain.
+      expect(resumeOptions.drainedFollowUps?.map((item) => item.text)).toEqual([
+        'queued follow-up',
+      ]);
       const appendFollowUp = vi.fn();
       resumeOptions.setupSession({ appendFollowUp });
-      expect(appendFollowUp).toHaveBeenCalledWith({
-        text: 'queued follow-up',
-        origin: 'user',
-      });
+      expect(appendFollowUp).not.toHaveBeenCalled();
     } finally {
       bridgeFollowUps(bridge).release('stream-1');
       bridgeStatus(bridge).clearStream('stream-1');

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -1910,7 +1910,10 @@ describe('DesktopProgressBridge', () => {
         },
       }),
     );
-    const resumeToolUseFromSnapshot = vi.fn(async () => {});
+    const resumeToolUseFromSnapshot = vi.fn(async (...args: unknown[]) => {
+      const options = args[2] as { onFollowUpConsumed?: () => void };
+      options.onFollowUpConsumed?.();
+    });
     const messages: unknown[] = [];
     const bridge = await createBridge(messages, {
       retrieveSessionResumeData,
@@ -1948,7 +1951,9 @@ describe('DesktopProgressBridge', () => {
           parentStreamId,
         }),
         expect.objectContaining({ emit: expect.any(Function) }),
-        expect.objectContaining({ setupSession: expect.any(Function) }),
+        expect.objectContaining({
+          takePendingFollowUps: expect.any(Function),
+        }),
       );
       const [, , resumeOptions] = resumeToolUseFromSnapshot.mock
         .calls[0] as unknown as [
@@ -1956,25 +1961,16 @@ describe('DesktopProgressBridge', () => {
         unknown,
         {
           drainedFollowUps?: readonly { text: string; origin?: string }[];
-          setupSession(session: {
-            appendFollowUp(followUp: {
-              text: string;
-              mediaFiles?: readonly string[];
-              displayText?: string;
-              origin?: 'user' | 'subagent_result';
-            }): void;
-          }): void;
+          takePendingFollowUps(): readonly { text: string; origin?: string }[];
         },
       ];
       // The drained batch travels via the direct drainedFollowUps handoff (a
-      // subagent's WAITING cursor never reads the stream queue); setupSession
-      // replays only items that race in after the drain.
+      // subagent's WAITING cursor never reads the stream queue). The attachment
+      // drain closes the only race before later input can target the live flow.
       expect(resumeOptions.drainedFollowUps?.map((item) => item.text)).toEqual([
         'queued follow-up',
       ]);
-      const appendFollowUp = vi.fn();
-      resumeOptions.setupSession({ appendFollowUp });
-      expect(appendFollowUp).not.toHaveBeenCalled();
+      expect(resumeOptions.takePendingFollowUps()).toEqual([]);
     } finally {
       bridgeFollowUps(bridge).release('stream-1');
       bridgeStatus(bridge).clearStream('stream-1');

--- a/src/test-kernel/tools/NativeToolUseStrategy.vitest.ts
+++ b/src/test-kernel/tools/NativeToolUseStrategy.vitest.ts
@@ -277,7 +277,6 @@ describe('NativeToolUseStrategy', () => {
       snapshot,
       params.runtimeHost,
       expect.objectContaining({
-        allowWaitingResult: true,
         approvalPromptsUnavailable: true,
         parentStreamId: params.orchestratorStreamId,
         drainedFollowUps: [

--- a/src/test-kernel/tools/NativeToolUseStrategy.vitest.ts
+++ b/src/test-kernel/tools/NativeToolUseStrategy.vitest.ts
@@ -10,7 +10,6 @@ import { createTestSession } from '@test/support/sessionTestUtils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - agent
-import { ToolUseSessionLifecycle } from '@agent/implementations/flows/tooluse/ToolUseSessionLifecycle';
 import {
   isChildRunLoopActive,
   startChildRunLoop,
@@ -387,16 +386,6 @@ describe('NativeToolUseStrategy', () => {
       async (_snapshot, _host, options) => {
         if (mocks.resumeToolUseFromSnapshot.mock.calls.length > 1) {
           throw new Error('the same follow-up batch resumed more than once');
-        }
-        // This branch models the former queue-owning wrapper. Before the fix,
-        // NativeToolUseStrategy called that wrapper, which supplied
-        // setupSession and thereby put the child-loop batch back into this
-        // exact queue. Keeping the branch in the integration fixture makes a
-        // regression fail after two turns instead of spinning indefinitely.
-        if (options.setupSession) {
-          options.setupSession(
-            new ToolUseSessionLifecycle(childStreamId, session.followUps),
-          );
         }
         options.onRun?.(handle);
         session.status.transitionToWaiting(childStreamId, 'wait');

--- a/src/tools/delegation/nativeToolUseStrategy.ts
+++ b/src/tools/delegation/nativeToolUseStrategy.ts
@@ -208,7 +208,6 @@ export function createNativeToolUseStrategy(
             approvalPromptsUnavailable: params.approvalPromptsUnavailable,
             runtimeUnavailableTools: params.runtimeUnavailableTools,
             parentStreamId: params.orchestratorStreamId,
-            allowWaitingResult: true,
             // The loop's queue never admits synthetic goal continuations for
             // a subagent, but its batch type is shared with root flows. Keep
             // the existing defensive downgrade rather than silently dropping


### PR DESCRIPTION
## Summary

A resumed native subagent may legitimately process a follow-up and return to `WAITING`. The resume wrapper previously required each host to opt into that outcome even though only persisted lineage can determine whether the run is a subagent. Extension and desktop callers therefore reported a completed turn as failed and restored its consumed follow-up for duplicate replay.

This change makes `WAITING` a normal snapshot-resume outcome, hands drained messages directly to the resumed wait cursor, closes the queue race at live-flow attachment, and centralizes CLI resume settlement so a parked subagent is successful without being announced as finished. A lifecycle acknowledgement now distinguishes consumed input from input that must be restored after early cancellation.

## Issue acceptance gates

Closes #8619.

- Extension and desktop resume-to-WAITING resolves successfully without a failure surface.
- The initial drain and messages arriving before flow attachment reach the resumed cursor exactly once and in order.
- A cancellation before consumption restores the batch and returns the stream to durable `WAITING`; a consumed batch is never replayed.
- Explicit and queued CLI resume map `WAITING` to success and do not emit `agentFinished`.
- Fresh launches retain their stricter terminal-result contract.
- Shared, CLI, desktop, cancellation, and wait-node regression tests cover the handoff and settlement behavior.

## Single source of truth

Persisted parent lineage in `resumeToolUseFromSnapshot` determines whether a resumed run is a subagent. `ToolUseWaitNode` remains the sole flow-level owner of whether that subagent parks in `WAITING`; hosts no longer restate that decision with `allowWaitingResult`.

`runToolUseFlow` owns the exact attachment boundary: after the live context is installed, it takes the one pending queue batch and combines it with the initial drain before entering the persisted cursor. The existing `onFollowUpConsumed` lifecycle fact determines whether recovery restores that batch.

`settleResumedTurn` is the single CLI settlement site for explicit and queued resume outcomes.

## Duplication and abstraction budget

The change removes the resume-path opt-in, three return-type overload declarations, the session-replay callback, and duplicated CLI settlement logic. It adds no wrapper module or pass-through layer. The explicit `takePendingFollowUps` boundary replaces mutation through the rebuilt session queue and is consumed once by the flow that owns attachment ordering.

## Net elements (R6)

15 files changed, 351 insertions, 217 deletions, net +134 lines. No files or exported symbol identities were added. Three exported overload declarations and the `setupSession` option were removed; `takePendingFollowUps` replaces the latter on the two existing exported option interfaces. One test-local interface and one local CLI settlement helper were added. Most added lines are regression tests.

## Consumer counts (R8)

`resumeToolUseFromSnapshot` has three production consumers: the shared queued-resume leaf, native subagent strategy, and CLI explicit resume. All three were audited. `runToolUseFlow` has two production callers; only snapshot resume supplies the new attachment-drain callback. No event subscription or emit path was added or rerouted; the existing `agentFinished` notification is now consistently suppressed for `WAITING` in both CLI resume paths.

## Host impact

Extension: Waiting subagent follow-ups no longer show a false resume failure, repeat later, or remain stranded when they arrive during attachment.

Desktop: Uses the same corrected shared resume leaf; bridge coverage pins both queue-drain boundaries.

CLI: Explicit and queued resume now settle `WAITING` consistently as a successful turn without announcing completion.

## Scheduled refactoring

None.

## Validation

- Repository commit-hook formatting and Prettier checks
- ESLint on every changed TypeScript file with `--max-warnings=0`
- Root, test-kernel, CLI, extension, and all desktop TypeScript programs (rerun after the attachment-cancel correction)
- Focused Vitest: 7 files, 170 tests passed (`resumeToolUseSnapshot`, `ResumeToolUseCancellation`, `SessionResumeRetrieval`, `DesktopAgentExecution`, `chatSessionController`, `ToolUseWaitNode`, `NativeToolUseStrategy`)
- The standalone trace-viewer check was not locally repeatable because the shared worktree dependency tree lacks `vite-plugin-singlefile`; this PR does not change trace-viewer code and exact-head CI installs its declared dependencies.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared tool-use resume, follow-up queue recovery, and CLI exit/notification behavior across extension, desktop, and CLI hosts; regression coverage is broad but the cancellation race window is subtle.
> 
> **Overview**
> Fixes **follow-ups to parked native subagents** being treated as failed resumes and having their consumed messages **re-queued for a second turn**.
> 
> **Resume handoff** no longer replays drained follow-ups through `setupSession` / `appendFollowUp`. The shared queue dance passes them via **`drainedFollowUps`** plus a one-shot **`takePendingFollowUps`** at live flow attachment, merged into **`ToolUseWaitNode`** so subagent WAITING cursors get input without relying on the stream queue.
> 
> **`resumeToolUseFromSnapshot`** always allows a **WAITING** outcome (subagent vs root comes from persisted lineage); **`allowWaitingResult`** is only for fresh **`executeAgent`** launches. Recovery uses **`onFollowUpConsumed`** so batches are restored only when the wait cursor never acknowledged them.
> 
> **CLI** centralizes resume settlement in **`settleResumedTurn`**: **WAITING** maps to success and **does not** fire **`agentFinished`**; **`runOutcomeExitCode`** treats **WAITING** like a completed turn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0ddb42f6fe3b2a2fb26ed7048a41fbe0582af2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->