### PR TITLE
fix(cli): keep history recall on arrows when slash palette has one match

### DIFF
--- a/packages/cli/src/chat/tui/commands/SlashPalette.tsx
+++ b/packages/cli/src/chat/tui/commands/SlashPalette.tsx
@@ -96,6 +96,15 @@ export function slashPaletteWindow({
   };
 }
 
+/**
+ * The palette owns ↑/↓ only while it presents a real choice. With a single
+ * match (e.g. a fully typed command name) the arrows must keep doing input
+ * history recall in the text input, which shares the same keystrokes.
+ */
+export function slashPaletteOwnsArrows(matchCount: number): boolean {
+  return matchCount > 1;
+}
+
 export function slashPaletteEnterHintAction(
   command: SlashCommand | undefined,
 ): string {
@@ -139,20 +148,11 @@ export function SlashPalette(
         props.onCancel();
         return;
       }
-      if (key.upArrow) {
+      if (key.upArrow || key.downArrow) {
+        if (!slashPaletteOwnsArrows(matchCount)) return;
         setHighlight((h) =>
           nextWrappingHighlightIndex({
-            direction: -1,
-            highlight: h,
-            itemCount: matchCount,
-          }),
-        );
-        return;
-      }
-      if (key.downArrow) {
-        setHighlight((h) =>
-          nextWrappingHighlightIndex({
-            direction: 1,
+            direction: key.upArrow ? -1 : 1,
             highlight: h,
             itemCount: matchCount,
           }),
@@ -214,7 +214,9 @@ export function SlashPalette(
       <Box marginTop={1}>
         <KeyHints
           hints={[
-            { key: '↑/↓', action: 'navigate' },
+            ...(slashPaletteOwnsArrows(matchCount)
+              ? [{ key: '↑/↓', action: 'navigate' }]
+              : []),
             {
               key: 'Enter',
               action: slashPaletteEnterHintAction(highlightedCommand),

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -22,7 +22,7 @@ import {
 import { ReverseSearch } from '../input/ReverseSearch';
 import { isCtrlInput } from '../input/inputKeys';
 import { openRegisteredCliSlashForm } from '../commands/slashForms';
-import { SlashPalette } from '../commands/SlashPalette';
+import { SlashPalette, slashPaletteOwnsArrows } from '../commands/SlashPalette';
 import { COLOR_BORDER, COLOR_HINT } from '../ui/colors';
 import { POINTER } from '../ui/glyphs';
 import {
@@ -331,15 +331,20 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
   const parsed = parseSlashInput(value);
   const isTypingSlashCommandName =
     parsed !== undefined && !/\s/.test(value.slice(1));
-  const hasPaletteMatches =
-    parsed !== undefined && matchSlashCommands(parsed.name).length > 0;
+  const paletteMatchCount =
+    parsed !== undefined ? matchSlashCommands(parsed.name).length : 0;
   const showPalette =
     parsed !== undefined &&
     isTypingSlashCommandName &&
-    hasPaletteMatches &&
+    paletteMatchCount > 0 &&
     !reverseSearchOpen &&
     !disabled &&
     keyboardActive;
+  // The palette owns ↑/↓ only while it presents a real choice (2+ matches);
+  // with a single match — e.g. a fully typed command name — the arrows keep
+  // recalling input history.
+  const paletteOwnsArrows =
+    showPalette && slashPaletteOwnsArrows(paletteMatchCount);
 
   useEffect(() => {
     // Auto-close the reverse-search overlay when the input is disabled —
@@ -404,10 +409,14 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
             value={value}
             focus={keyboardActive && !disabled && !reverseSearchOpen}
             onChange={setValue}
-            // While the slash palette is open it owns ↑/↓ for row selection;
-            // history recall would clobber the draft mid-navigation.
-            onHistoryUp={showPalette ? undefined : () => browseHistory(-1)}
-            onHistoryDown={showPalette ? undefined : () => browseHistory(1)}
+            // While the palette shows multiple rows it owns ↑/↓ for row
+            // selection; history recall would clobber the draft mid-navigation.
+            onHistoryUp={
+              paletteOwnsArrows ? undefined : () => browseHistory(-1)
+            }
+            onHistoryDown={
+              paletteOwnsArrows ? undefined : () => browseHistory(1)
+            }
             imagePasteQueue={imagePasteQueue}
             readLatestValue={() => draftValueRef.current}
             prepareInputChunk={

--- a/src/test-kernel/cli/SlashPalette.vitest.mts
+++ b/src/test-kernel/cli/SlashPalette.vitest.mts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 
 import {
   slashPaletteCommandLabelWidth,
-  slashPaletteOwnsArrows,
   slashPaletteEnterHintAction,
+  slashPaletteOwnsArrows,
   slashPaletteWindow,
 } from '@cli/chat/tui/commands/SlashPalette';
 import { nextWrappingHighlightIndex } from '@cli/chat/tui/ui/Select';

--- a/src/test-kernel/cli/SlashPalette.vitest.mts
+++ b/src/test-kernel/cli/SlashPalette.vitest.mts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   slashPaletteCommandLabelWidth,
+  slashPaletteOwnsArrows,
   slashPaletteEnterHintAction,
   slashPaletteWindow,
 } from '@cli/chat/tui/commands/SlashPalette';
@@ -59,6 +60,14 @@ describe('SlashPalette navigation', () => {
         itemCount: 15,
       }),
     ).toBe(14);
+  });
+
+  it('owns ↑/↓ only when there is a real choice to make', () => {
+    // With 0 or 1 matches the arrows stay with the text input for history
+    // recall — a fully typed command name must not block recalling drafts.
+    expect(slashPaletteOwnsArrows(0)).toBe(false);
+    expect(slashPaletteOwnsArrows(1)).toBe(false);
+    expect(slashPaletteOwnsArrows(2)).toBe(true);
   });
 
   it('describes what Enter does for the highlighted slash command', () => {


### PR DESCRIPTION
## Summary

Typing a slash command whose palette had any matches at all — including a single match like a fully typed `/yolo` — blocked ↑/↓ input-history recall entirely: `InputBar` dropped its `onHistoryUp/Down` handlers whenever the palette was visible, and the palette swallowed the arrows as (no-op) row navigation.

The palette now owns ↑/↓ only while it presents a real choice (2+ matches). With 0–1 matches the arrows fall back to history recall. The rule lives in one exported helper, `slashPaletteOwnsArrows`, shared by the palette's key handler, its hint row ("↑/↓ navigate" no longer shows for a single match), and `InputBar`'s history fallback, so the two sides can't drift.

This matches the reference behavior in Claude Code's PromptInput, which only suppresses history navigation when `suggestions.length > 1`.

## Verification

- `SlashPalette.vitest.mts`: 5 passed (new ownership-rule case included); `@texra-ai/cli` typecheck clean.
- Live TUI (tmux, worktree build): ↑ on empty input recalled `/yolo` from history (1-match palette opened, hint row without navigate); second ↑ recalled the next older entry instead of being swallowed — the exact reported flow. `/m` (2 matches) still navigates the palette rows with the draft untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized TUI input routing in the CLI slash palette and InputBar with a small exported helper and tests; no auth, data, or API impact.
> 
> **Overview**
> **Fixes ↑/↓ being swallowed whenever the slash palette was visible**, including when only one command matched (e.g. a fully typed `/yolo`).
> 
> The CLI now treats arrow ownership as **2+ palette matches** via exported `slashPaletteOwnsArrows`. With 0–1 matches, `InputBar` keeps `onHistoryUp`/`onHistoryDown` wired and the palette’s `useInput` no-ops on arrows; with multiple matches, behavior is unchanged (palette navigates rows). The **↑/↓ navigate** hint is shown only when the palette owns arrows.
> 
> A unit test documents the `matchCount` thresholds (0/1 → false, 2+ → true).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2b2fd3604198a0e8a86c44bc94a40b82a5fab83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->