### PR TITLE
fix(agent): let subagents follow the parent's edit-YOLO live, like bash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ All notable changes to this project will be documented in this file.
   session no longer suppresses dependency guidance for another session.
 - **Follow-ups to waiting subagents resume once without a false failure** — a
   completed follow-up is no longer reported as failed or repeated later.
+- **Delegated agents follow live auto-approval changes** — enabling or
+  disabling file and command auto-approval on a parent now updates its running
+  delegated agents and their visible status.
 
 ### CLI
 

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -118,6 +118,7 @@ export class SessionHandle {
     const events = init.events ?? new SessionEventHub();
     const transcripts = init.transcripts;
     const followUps = init.followUps ?? new ToolUseFollowUpQueue();
+    const approvals = createSessionApprovals();
     const executions =
       init.executions ??
       new ExecutionRegistry({ streamStatus: status, events });
@@ -127,6 +128,7 @@ export class SessionHandle {
     executions.attachSessionEvents(events, (event, streamId) =>
       this.publishRunEvent(streamId, event),
     );
+    executions.attachSessionApprovals(approvals);
 
     this.executions = executions;
     const subscriptions =
@@ -142,7 +144,7 @@ export class SessionHandle {
     this.transcripts = transcripts;
     this.followUps = followUps;
     this.interactions = init.interactions ?? new SessionHostInteractions();
-    this.approvals = createSessionApprovals();
+    this.approvals = approvals;
     // A fresh session owns its own flusher set; the default session aliases
     // the process-module set (`getActiveFlushers()`) so the process-wide
     // shutdown drain (`flushPendingRunTraces()`) still reaches it.

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -12,6 +12,7 @@ import {
 import { createChannelTrace, type ResultEvent } from '@agent/trace';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
+import type { SessionApprovals } from '@agent/runtime/streamApprovalQueue';
 import {
   StreamStatusMachine,
   type StreamStatusEmitOptions,
@@ -140,6 +141,7 @@ export class ExecutionRegistry {
   private readonly processOutput: ProcessOutputPoller;
   private readonly streamStatus: StreamStatusMachine;
   private events: SessionEventHub | undefined;
+  private approvals: SessionApprovals | undefined;
   /**
    * Publishes a synthesized terminal `result` event to the owning session's
    * `onResult` channel — the same forwarding `SessionHandle.attachRunTrace`
@@ -216,6 +218,11 @@ export class ExecutionRegistry {
         },
       });
     });
+  }
+
+  /** Bind the session-owned approval state used when a child is detached. */
+  attachSessionApprovals(approvals: SessionApprovals): void {
+    this.approvals = approvals;
   }
 
   dispose(): void {
@@ -602,6 +609,7 @@ export class ExecutionRegistry {
     for (const handle of this.handles.values()) {
       if (!isChildExecution(handle, parentStreamId)) continue;
       if (handle instanceof AgentExecutionHandle) {
+        this.approvals?.detachStreamFromParent(handle.childStreamId);
         handle.detach();
         this.emitParentStreamUpdate({
           childStreamId: handle.childStreamId,

--- a/src/agent/runtime/streamApprovalQueue.ts
+++ b/src/agent/runtime/streamApprovalQueue.ts
@@ -257,7 +257,7 @@ export interface SessionApprovals {
    * Used for delegated subagent streams (parent = the orchestrator stream,
    * `kinds: ['bash', 'toolEdit']` — each kind follows the parent's own bypass
    * live, while `proposal` stays unlinked so a child's own delegations still
-   * prompt; see `inheritApprovalBypassesOnChildStream`) and, in the CLI,
+   * prompt; see `configureDelegatedChildApprovals`) and, in the CLI,
    * successive conversation rounds (parent = the previous round's root
    * stream, all kinds — a CLI round should carry forward whichever bypasses
    * were on) — both mint a fresh `StreamTabId` that would otherwise start
@@ -269,12 +269,14 @@ export interface SessionApprovals {
     kinds?: readonly BypassAncestryKind[],
   ): void;
   /**
-   * Drop `streamId` from the ancestry graph (all kinds): both its own parent
-   * links and any child that named it as parent. Called on per-stream
-   * teardown (`cleanupApprovalsForStream`) so a torn-down stream can't
-   * linger as a live ancestor — without this, a still-running child would
-   * keep resolving its bypass through a parent whose own bypass state was
-   * just cleared, silently changing the child's effective bypass.
+   * Promote a stream out of its approval ancestry while preserving each
+   * effective bypass value as an explicit value on the stream.
+   */
+  detachStreamFromParent(streamId: StreamTabId): void;
+  /**
+   * Drop `streamId` from the ancestry graph (all kinds). Direct children are
+   * first promoted through {@link detachStreamFromParent}, preserving their
+   * effective values before the torn-down parent's own values are cleared.
    */
   forgetStreamAncestry(streamId: StreamTabId): void;
   /**
@@ -334,6 +336,30 @@ export function createSessionApprovals(): SessionApprovals {
     resolveParentFor('proposal'),
     resolveDescendantsFor('proposal'),
   );
+  const bypassByKind: Record<BypassAncestryKind, StreamApprovalBypass> = {
+    toolEdit: toolEdit.bypass,
+    bash: bash.bypass,
+    proposal,
+  };
+
+  function detachKindFromParent(
+    kind: BypassAncestryKind,
+    streamId: StreamTabId,
+  ): void {
+    const graph = parentOf[kind];
+    if (!graph.has(streamId)) return;
+    const bypass = bypassByKind[kind];
+    const effectiveValue = bypass.isBypassed(streamId);
+    graph.delete(streamId);
+    bypass.setBypass(streamId, effectiveValue, undefined, { silent: true });
+  }
+
+  function detachStreamFromParent(streamId: StreamTabId): void {
+    for (const kind of ALL_BYPASS_ANCESTRY_KINDS) {
+      detachKindFromParent(kind, streamId);
+    }
+  }
+
   return {
     toolEdit,
     bash,
@@ -347,14 +373,15 @@ export function createSessionApprovals(): SessionApprovals {
         parentOf[kind].set(childStreamId, parentStreamId);
       }
     },
+    detachStreamFromParent,
     forgetStreamAncestry(streamId) {
       for (const kind of ALL_BYPASS_ANCESTRY_KINDS) {
         const graph = parentOf[kind];
-        graph.delete(streamId);
-        const orphaned = [...graph]
+        const directChildren = [...graph]
           .filter(([, parent]) => parent === streamId)
           .map(([child]) => child);
-        for (const child of orphaned) graph.delete(child);
+        for (const child of directChildren) detachKindFromParent(kind, child);
+        graph.delete(streamId);
       }
     },
     rejectAndClearAll() {

--- a/src/agent/runtime/streamApprovalQueue.ts
+++ b/src/agent/runtime/streamApprovalQueue.ts
@@ -234,13 +234,14 @@ export interface SessionApprovals {
    * parent's bypass state whenever the child has no explicit value of its
    * own. Ancestry is tracked separately per kind — linking `bash` does NOT
    * also let the child inherit `toolEdit` or `proposal` bypass — so a
-   * delegation that only wants bash to follow the parent can't accidentally
-   * grant tool-edit or super-YOLO auto-approval too.
+   * delegation that only wants some kinds to follow the parent can't
+   * accidentally grant super-YOLO auto-approval too.
    *
    * Used for delegated subagent streams (parent = the orchestrator stream,
-   * `kinds: ['bash']` — tool-edit YOLO is granted separately and explicitly
-   * via `enableYoloOnChildStream` when a delegation asks for it) and, in the
-   * CLI, successive conversation rounds (parent = the previous round's root
+   * `kinds: ['bash', 'toolEdit']` — each kind follows the parent's own bypass
+   * live, while `proposal` stays unlinked so a child's own delegations still
+   * prompt; see `inheritApprovalBypassesOnChildStream`) and, in the CLI,
+   * successive conversation rounds (parent = the previous round's root
    * stream, all kinds — a CLI round should carry forward whichever bypasses
    * were on) — both mint a fresh `StreamTabId` that would otherwise start
    * every bypass kind ungated.

--- a/src/agent/runtime/streamApprovalQueue.ts
+++ b/src/agent/runtime/streamApprovalQueue.ts
@@ -73,6 +73,7 @@ export interface StreamApprovalBypass {
 function createStreamApprovalBypass(
   event: ApprovalBypassEvent,
   resolveParent: (streamId: StreamTabId) => StreamTabId | undefined,
+  resolveDescendants: (streamId: StreamTabId) => readonly StreamTabId[],
 ): StreamApprovalBypass {
   const byStream = new Map<StreamTabId, boolean>();
 
@@ -94,9 +95,23 @@ function createStreamApprovalBypass(
     runtimeHost,
     options,
   ) => {
+    const descendants =
+      runtimeHost && !options?.silent ? resolveDescendants(streamId) : [];
+    const previousDescendantStates = new Map(
+      descendants.map((descendant) => [descendant, resolve(descendant)]),
+    );
     byStream.set(streamId, enabled);
     if (runtimeHost && !options?.silent) {
       runtimeHost.emit(event, { streamId, bypassActive: enabled });
+      for (const descendant of descendants) {
+        const bypassActive = resolve(descendant);
+        if (previousDescendantStates.get(descendant) !== bypassActive) {
+          runtimeHost.emit(event, {
+            streamId: descendant,
+            bypassActive,
+          });
+        }
+      }
     }
   };
 
@@ -149,6 +164,7 @@ interface StreamApprovalControllerOptions<R extends { accepted: boolean }> {
   rejectionResult: () => R;
   bypassEvent: ApprovalBypassEvent;
   resolveParent: (streamId: StreamTabId) => StreamTabId | undefined;
+  resolveDescendants: (streamId: StreamTabId) => readonly StreamTabId[];
 }
 
 function createStreamApprovalController<R extends { accepted: boolean }>(
@@ -177,6 +193,7 @@ function createStreamApprovalController<R extends { accepted: boolean }>(
     bypass: createStreamApprovalBypass(
       options.bypassEvent,
       options.resolveParent,
+      options.resolveDescendants,
     ),
     enqueue<T>(
       streamId: StreamTabId | undefined,
@@ -281,20 +298,41 @@ export function createSessionApprovals(): SessionApprovals {
     (kind: BypassAncestryKind) =>
     (streamId: StreamTabId): StreamTabId | undefined =>
       parentOf[kind].get(streamId);
+  const resolveDescendantsFor =
+    (kind: BypassAncestryKind) =>
+    (streamId: StreamTabId): readonly StreamTabId[] => {
+      const graph = parentOf[kind];
+      const descendants: StreamTabId[] = [];
+      const pending = [streamId];
+      const seen = new Set(pending);
+      for (let index = 0; index < pending.length; index += 1) {
+        const parent = pending[index];
+        for (const [child, directParent] of graph) {
+          if (directParent !== parent || seen.has(child)) continue;
+          seen.add(child);
+          descendants.push(child);
+          pending.push(child);
+        }
+      }
+      return descendants;
+    };
 
   const toolEdit = createStreamApprovalController<ToolEditApprovalResult>({
     rejectionResult: () => ({ accepted: false }),
     bypassEvent: 'updateToolEditApprovalBypassState',
     resolveParent: resolveParentFor('toolEdit'),
+    resolveDescendants: resolveDescendantsFor('toolEdit'),
   });
   const bash = createStreamApprovalController<HostBashApprovalResult>({
     rejectionResult: () => ({ accepted: false }),
     bypassEvent: 'updateBashApprovalBypassState',
     resolveParent: resolveParentFor('bash'),
+    resolveDescendants: resolveDescendantsFor('bash'),
   });
   const proposal = createStreamApprovalBypass(
     'updateSuperYoloBypassState',
     resolveParentFor('proposal'),
+    resolveDescendantsFor('proposal'),
   );
   return {
     toolEdit,

--- a/src/test-kernel/agent/followUp/ChildStreamYoloInheritance.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamYoloInheritance.vitest.ts
@@ -10,10 +10,10 @@ import type { StreamTabId } from '@shared/schemas';
 import {
   cleanupAllApprovals,
   cleanupApprovalsForStream,
-  enableYoloOnChildStream,
-  inheritBashBypassOnChildStream,
+  inheritApprovalBypassesOnChildStream,
   isApprovalBypassedForStream,
   isBashApprovalBypassedForStream,
+  proposalApprovals,
   setBashApprovalSessionBypass,
   setToolEditApprovalSessionBypass,
   toggleBashApprovalSessionBypass,
@@ -34,43 +34,48 @@ describe('child subagent stream approval inheritance', () => {
     // Sanity: the parent bypass round-trips through the public barrel.
     expect(isBashApprovalBypassedForStream(parent)).toBe(true);
 
-    inheritBashBypassOnChildStream(child, parent);
+    inheritApprovalBypassesOnChildStream(child, parent);
 
     expect(isBashApprovalBypassedForStream(child)).toBe(true);
   });
 
-  it('leaves the child gated when the parent still prompts for bash', () => {
-    const parent = 'stream:parent-no-bash' as StreamTabId;
-    const child = 'stream:child-no-bash' as StreamTabId;
+  it('mirrors the parent tool-edit bypass onto the child stream', () => {
+    const { host } = createRecordingHost();
+    const parent = 'stream:parent-edit' as StreamTabId;
+    const child = 'stream:child-edit' as StreamTabId;
+    setToolEditApprovalSessionBypass(parent, true, host, { silent: true });
 
-    inheritBashBypassOnChildStream(child, parent);
+    inheritApprovalBypassesOnChildStream(child, parent);
+
+    expect(isApprovalBypassedForStream(child)).toBe(true);
+    // Edit-YOLO inheritance must not drag bash along — kinds stay per-graph.
+    expect(isBashApprovalBypassedForStream(child)).toBe(false);
+  });
+
+  it('leaves the child gated when the parent still prompts', () => {
+    const parent = 'stream:parent-no-bypass' as StreamTabId;
+    const child = 'stream:child-no-bypass' as StreamTabId;
+
+    inheritApprovalBypassesOnChildStream(child, parent);
 
     expect(isBashApprovalBypassedForStream(child)).toBe(false);
+    expect(isApprovalBypassedForStream(child)).toBe(false);
   });
 
   it('mirrors bash independently of tool-edit YOLO (CLI AUTO-BASH, no AUTO-APPROVE)', () => {
     // The bug this guards against: a parent with bash auto-approved but edits
-    // still gated must still propagate bash to the child, even though the child
-    // does not get tool-edit YOLO.
+    // still gated must propagate bash to the child without also granting the
+    // child tool-edit YOLO.
     const { host } = createRecordingHost();
     const parent = 'stream:parent-bash-only' as StreamTabId;
     const child = 'stream:child-bash-only' as StreamTabId;
     setBashApprovalSessionBypass(parent, true, host, { silent: true });
 
-    inheritBashBypassOnChildStream(child, parent);
+    inheritApprovalBypassesOnChildStream(child, parent);
 
     expect(isBashApprovalBypassedForStream(child)).toBe(true);
-    // No edit-YOLO was applied, so tool-edit stays gated on the child.
+    // The parent's edits are gated, so the child's stay gated too.
     expect(isApprovalBypassedForStream(child)).toBe(false);
-  });
-
-  it('enables tool-edit YOLO on the child without touching bash', () => {
-    const child = 'stream:child-edit' as StreamTabId;
-
-    enableYoloOnChildStream(child);
-
-    expect(isApprovalBypassedForStream(child)).toBe(true);
-    expect(isBashApprovalBypassedForStream(child)).toBe(false);
   });
 
   it('picks up a parent bash bypass toggled after the child stream already started', () => {
@@ -82,12 +87,34 @@ describe('child subagent stream approval inheritance', () => {
     const parent = 'stream:parent-late-toggle' as StreamTabId;
     const child = 'stream:child-late-toggle' as StreamTabId;
 
-    inheritBashBypassOnChildStream(child, parent);
+    inheritApprovalBypassesOnChildStream(child, parent);
     expect(isBashApprovalBypassedForStream(child)).toBe(false);
 
     setBashApprovalSessionBypass(parent, true, host, { silent: true });
 
     expect(isBashApprovalBypassedForStream(child)).toBe(true);
+  });
+
+  it('picks up a parent edit-YOLO toggled after the child stream already started', () => {
+    // The extension's one shield couples edit + bash bypass; flipping it on
+    // while delegated children are already running must reach their edits
+    // exactly like it reaches their bash. Tool-edit inheritance used to be a
+    // one-shot grant at delegation launch, so a mid-run toggle left children
+    // prompting for every edit.
+    const { host } = createRecordingHost();
+    const parent = 'stream:parent-late-edit' as StreamTabId;
+    const child = 'stream:child-late-edit' as StreamTabId;
+
+    inheritApprovalBypassesOnChildStream(child, parent);
+    expect(isApprovalBypassedForStream(child)).toBe(false);
+
+    setToolEditApprovalSessionBypass(parent, true, host, { silent: true });
+    expect(isApprovalBypassedForStream(child)).toBe(true);
+
+    // And back off: the child follows the parent's current state, not a
+    // snapshot taken at delegation time.
+    setToolEditApprovalSessionBypass(parent, false, host, { silent: true });
+    expect(isApprovalBypassedForStream(child)).toBe(false);
   });
 
   it('lets a conversation round inherit bypass from the previous round via the session-level ancestry link', () => {
@@ -118,7 +145,7 @@ describe('child subagent stream approval inheritance', () => {
     const parent = 'stream:parent-toggle' as StreamTabId;
     const child = 'stream:child-toggle' as StreamTabId;
     setBashApprovalSessionBypass(parent, true, host, { silent: true });
-    inheritBashBypassOnChildStream(child, parent);
+    inheritApprovalBypassesOnChildStream(child, parent);
     expect(isBashApprovalBypassedForStream(child)).toBe(true);
 
     const first = toggleBashApprovalSessionBypass(child, host);
@@ -136,7 +163,7 @@ describe('child subagent stream approval inheritance', () => {
     const parent = 'stream:parent-torn-down' as StreamTabId;
     const child = 'stream:child-survives-parent' as StreamTabId;
     setBashApprovalSessionBypass(parent, true, host, { silent: true });
-    inheritBashBypassOnChildStream(child, parent);
+    inheritApprovalBypassesOnChildStream(child, parent);
     expect(isBashApprovalBypassedForStream(child)).toBe(true);
 
     cleanupApprovalsForStream(parent);
@@ -144,19 +171,33 @@ describe('child subagent stream approval inheritance', () => {
     expect(isBashApprovalBypassedForStream(child)).toBe(false);
   });
 
-  it('does not let bash ancestry also grant tool-edit or proposal bypass', () => {
+  it('does not let delegation ancestry also grant super-YOLO proposal bypass', () => {
+    // Delegation links bash + tool-edit only. Proposal (super-YOLO) bypass is
+    // deliberately unlinked, so a child's own delegations still prompt unless
+    // granted on the child explicitly.
+    const { host } = createRecordingHost();
+    const parent = 'stream:parent-super-yolo' as StreamTabId;
+    const child = 'stream:child-no-proposal' as StreamTabId;
+    proposalApprovals().setBypass(parent, true, host);
+
+    inheritApprovalBypassesOnChildStream(child, parent);
+
+    expect(proposalApprovals().isBypassed(parent)).toBe(true);
+    expect(proposalApprovals().isBypassed(child)).toBe(false);
+  });
+
+  it('keeps ancestry graphs independent per bypass kind', () => {
     // Ancestry used to be one shared graph for all three bypass kinds, so
     // linking a child for bash inheritance silently let it inherit tool-edit
-    // YOLO too whenever the parent had it on — even without
-    // `enableYoloOnChild`. Each kind must have its own independent ancestry
-    // graph.
+    // YOLO too whenever the parent had it on. Each kind must resolve through
+    // its own graph: a bash-only link must not leak tool-edit bypass.
     const { host } = createRecordingHost();
     const parent = 'stream:parent-toolEdit-on' as StreamTabId;
     const child = 'stream:child-bash-only-ancestry' as StreamTabId;
     setToolEditApprovalSessionBypass(parent, true, host, { silent: true });
     setBashApprovalSessionBypass(parent, true, host, { silent: true });
 
-    inheritBashBypassOnChildStream(child, parent);
+    currentSession().approvals.registerStreamParent(child, parent, ['bash']);
 
     expect(isBashApprovalBypassedForStream(child)).toBe(true);
     // No ancestry link was registered for 'toolEdit', so the child stays

--- a/src/test-kernel/agent/followUp/ChildStreamYoloInheritance.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamYoloInheritance.vitest.ts
@@ -15,6 +15,7 @@ import {
   isBashApprovalBypassedForStream,
   proposalApprovals,
   setBashApprovalSessionBypass,
+  setDelegatedWorkApprovalBypasses,
   setToolEditApprovalSessionBypass,
   toggleBashApprovalSessionBypass,
 } from '@tools/approval';
@@ -169,6 +170,25 @@ describe('child subagent stream approval inheritance', () => {
     cleanupApprovalsForStream(parent);
 
     expect(isBashApprovalBypassedForStream(child)).toBe(false);
+  });
+
+  it('super-YOLO on an inheriting child pins its own edit bypass', () => {
+    // `setDelegatedWorkApprovalBypasses` must write the child's own explicit
+    // tool-edit entry even when `isBypassed` already reports true via
+    // ancestry — otherwise the grant silently evaporates when the parent
+    // later re-gates its own edits while the child's proposal/bash stay on.
+    const { host } = createRecordingHost();
+    const parent = 'stream:parent-pin' as StreamTabId;
+    const child = 'stream:child-pin' as StreamTabId;
+    setToolEditApprovalSessionBypass(parent, true, host, { silent: true });
+    inheritApprovalBypassesOnChildStream(child, parent);
+    expect(isApprovalBypassedForStream(child)).toBe(true);
+
+    setDelegatedWorkApprovalBypasses(child, true, host);
+    setToolEditApprovalSessionBypass(parent, false, host, { silent: true });
+
+    expect(isApprovalBypassedForStream(child)).toBe(true);
+    expect(isApprovalBypassedForStream(parent)).toBe(false);
   });
 
   it('does not let delegation ancestry also grant super-YOLO proposal bypass', () => {

--- a/src/test-kernel/agent/followUp/ChildStreamYoloInheritance.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamYoloInheritance.vitest.ts
@@ -118,6 +118,41 @@ describe('child subagent stream approval inheritance', () => {
     expect(isApprovalBypassedForStream(child)).toBe(false);
   });
 
+  it('announces inherited edit-bypass changes for visible descendants', () => {
+    const { events, host } = createRecordingHost();
+    const parent = 'stream:visible-parent' as StreamTabId;
+    const child = 'stream:visible-child' as StreamTabId;
+    const grandchild = 'stream:visible-grandchild' as StreamTabId;
+    const pinnedChild = 'stream:pinned-child' as StreamTabId;
+    setToolEditApprovalSessionBypass(parent, true, host, { silent: true });
+    inheritApprovalBypassesOnChildStream(child, parent);
+    inheritApprovalBypassesOnChildStream(grandchild, child);
+    inheritApprovalBypassesOnChildStream(pinnedChild, parent);
+    setToolEditApprovalSessionBypass(pinnedChild, true, host, { silent: true });
+
+    setToolEditApprovalSessionBypass(parent, false, host);
+
+    expect(
+      events.filter(
+        ({ event }) => event === 'updateToolEditApprovalBypassState',
+      ),
+    ).toEqual([
+      {
+        event: 'updateToolEditApprovalBypassState',
+        payload: { streamId: parent, bypassActive: false },
+      },
+      {
+        event: 'updateToolEditApprovalBypassState',
+        payload: { streamId: child, bypassActive: false },
+      },
+      {
+        event: 'updateToolEditApprovalBypassState',
+        payload: { streamId: grandchild, bypassActive: false },
+      },
+    ]);
+    expect(isApprovalBypassedForStream(pinnedChild)).toBe(true);
+  });
+
   it('lets a conversation round inherit bypass from the previous round via the session-level ancestry link', () => {
     // Mirrors the CLI: every chat round mints a brand-new root StreamTabId,
     // so bypass must be carried forward explicitly (see

--- a/src/test-kernel/agent/followUp/ChildStreamYoloInheritance.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamYoloInheritance.vitest.ts
@@ -10,7 +10,7 @@ import type { StreamTabId } from '@shared/schemas';
 import {
   cleanupAllApprovals,
   cleanupApprovalsForStream,
-  inheritApprovalBypassesOnChildStream,
+  configureDelegatedChildApprovals,
   isApprovalBypassedForStream,
   isBashApprovalBypassedForStream,
   proposalApprovals,
@@ -35,7 +35,7 @@ describe('child subagent stream approval inheritance', () => {
     // Sanity: the parent bypass round-trips through the public barrel.
     expect(isBashApprovalBypassedForStream(parent)).toBe(true);
 
-    inheritApprovalBypassesOnChildStream(child, parent);
+    configureDelegatedChildApprovals(child, parent);
 
     expect(isBashApprovalBypassedForStream(child)).toBe(true);
   });
@@ -46,7 +46,7 @@ describe('child subagent stream approval inheritance', () => {
     const child = 'stream:child-edit' as StreamTabId;
     setToolEditApprovalSessionBypass(parent, true, host, { silent: true });
 
-    inheritApprovalBypassesOnChildStream(child, parent);
+    configureDelegatedChildApprovals(child, parent);
 
     expect(isApprovalBypassedForStream(child)).toBe(true);
     // Edit-YOLO inheritance must not drag bash along — kinds stay per-graph.
@@ -57,7 +57,7 @@ describe('child subagent stream approval inheritance', () => {
     const parent = 'stream:parent-no-bypass' as StreamTabId;
     const child = 'stream:child-no-bypass' as StreamTabId;
 
-    inheritApprovalBypassesOnChildStream(child, parent);
+    configureDelegatedChildApprovals(child, parent);
 
     expect(isBashApprovalBypassedForStream(child)).toBe(false);
     expect(isApprovalBypassedForStream(child)).toBe(false);
@@ -72,7 +72,7 @@ describe('child subagent stream approval inheritance', () => {
     const child = 'stream:child-bash-only' as StreamTabId;
     setBashApprovalSessionBypass(parent, true, host, { silent: true });
 
-    inheritApprovalBypassesOnChildStream(child, parent);
+    configureDelegatedChildApprovals(child, parent);
 
     expect(isBashApprovalBypassedForStream(child)).toBe(true);
     // The parent's edits are gated, so the child's stay gated too.
@@ -88,7 +88,7 @@ describe('child subagent stream approval inheritance', () => {
     const parent = 'stream:parent-late-toggle' as StreamTabId;
     const child = 'stream:child-late-toggle' as StreamTabId;
 
-    inheritApprovalBypassesOnChildStream(child, parent);
+    configureDelegatedChildApprovals(child, parent);
     expect(isBashApprovalBypassedForStream(child)).toBe(false);
 
     setBashApprovalSessionBypass(parent, true, host, { silent: true });
@@ -106,7 +106,7 @@ describe('child subagent stream approval inheritance', () => {
     const parent = 'stream:parent-late-edit' as StreamTabId;
     const child = 'stream:child-late-edit' as StreamTabId;
 
-    inheritApprovalBypassesOnChildStream(child, parent);
+    configureDelegatedChildApprovals(child, parent);
     expect(isApprovalBypassedForStream(child)).toBe(false);
 
     setToolEditApprovalSessionBypass(parent, true, host, { silent: true });
@@ -125,9 +125,9 @@ describe('child subagent stream approval inheritance', () => {
     const grandchild = 'stream:visible-grandchild' as StreamTabId;
     const pinnedChild = 'stream:pinned-child' as StreamTabId;
     setToolEditApprovalSessionBypass(parent, true, host, { silent: true });
-    inheritApprovalBypassesOnChildStream(child, parent);
-    inheritApprovalBypassesOnChildStream(grandchild, child);
-    inheritApprovalBypassesOnChildStream(pinnedChild, parent);
+    configureDelegatedChildApprovals(child, parent);
+    configureDelegatedChildApprovals(grandchild, child);
+    configureDelegatedChildApprovals(pinnedChild, parent);
     setToolEditApprovalSessionBypass(pinnedChild, true, host, { silent: true });
 
     setToolEditApprovalSessionBypass(parent, false, host);
@@ -181,7 +181,7 @@ describe('child subagent stream approval inheritance', () => {
     const parent = 'stream:parent-toggle' as StreamTabId;
     const child = 'stream:child-toggle' as StreamTabId;
     setBashApprovalSessionBypass(parent, true, host, { silent: true });
-    inheritApprovalBypassesOnChildStream(child, parent);
+    configureDelegatedChildApprovals(child, parent);
     expect(isBashApprovalBypassedForStream(child)).toBe(true);
 
     const first = toggleBashApprovalSessionBypass(child, host);
@@ -191,19 +191,49 @@ describe('child subagent stream approval inheritance', () => {
     expect(isBashApprovalBypassedForStream(parent)).toBe(true);
   });
 
-  it('detaches a child from a torn-down parent instead of leaving it inheriting through a dead stream', () => {
-    // Per-stream cleanup used to clear only the parent's own bypass
-    // entries, leaving the ancestry link intact so a live child silently
-    // changed effective bypass the moment the parent's tab closed.
+  it('preserves a surviving child state when its parent is torn down', () => {
     const { host } = createRecordingHost();
     const parent = 'stream:parent-torn-down' as StreamTabId;
     const child = 'stream:child-survives-parent' as StreamTabId;
     setBashApprovalSessionBypass(parent, true, host, { silent: true });
-    inheritApprovalBypassesOnChildStream(child, parent);
+    configureDelegatedChildApprovals(child, parent);
     expect(isBashApprovalBypassedForStream(child)).toBe(true);
 
     cleanupApprovalsForStream(parent);
 
+    expect(isBashApprovalBypassedForStream(child)).toBe(true);
+    setBashApprovalSessionBypass(parent, false, host, { silent: true });
+    expect(isBashApprovalBypassedForStream(child)).toBe(true);
+  });
+
+  it('pins edit approval for an auto-approved delegation', () => {
+    const parent = 'stream:auto-approved-parent' as StreamTabId;
+    const child = 'stream:auto-approved-child' as StreamTabId;
+
+    configureDelegatedChildApprovals(child, parent, 'auto-approved');
+
+    expect(isApprovalBypassedForStream(parent)).toBe(false);
+    expect(isApprovalBypassedForStream(child)).toBe(true);
+  });
+
+  it('preserves independent ancestry when one kind loses its parent', () => {
+    const { host } = createRecordingHost();
+    const editParent = 'stream:edit-parent-cleanup' as StreamTabId;
+    const bashParent = 'stream:bash-parent-survives' as StreamTabId;
+    const child = 'stream:split-ancestry-child' as StreamTabId;
+    setToolEditApprovalSessionBypass(editParent, true, host, { silent: true });
+    setBashApprovalSessionBypass(bashParent, true, host, { silent: true });
+    currentSession().approvals.registerStreamParent(child, editParent, [
+      'toolEdit',
+    ]);
+    currentSession().approvals.registerStreamParent(child, bashParent, [
+      'bash',
+    ]);
+
+    cleanupApprovalsForStream(editParent);
+    setBashApprovalSessionBypass(bashParent, false, host, { silent: true });
+
+    expect(isApprovalBypassedForStream(child)).toBe(true);
     expect(isBashApprovalBypassedForStream(child)).toBe(false);
   });
 
@@ -216,7 +246,7 @@ describe('child subagent stream approval inheritance', () => {
     const parent = 'stream:parent-pin' as StreamTabId;
     const child = 'stream:child-pin' as StreamTabId;
     setToolEditApprovalSessionBypass(parent, true, host, { silent: true });
-    inheritApprovalBypassesOnChildStream(child, parent);
+    configureDelegatedChildApprovals(child, parent);
     expect(isApprovalBypassedForStream(child)).toBe(true);
 
     setDelegatedWorkApprovalBypasses(child, true, host);
@@ -235,7 +265,7 @@ describe('child subagent stream approval inheritance', () => {
     const child = 'stream:child-no-proposal' as StreamTabId;
     proposalApprovals().setBypass(parent, true, host);
 
-    inheritApprovalBypassesOnChildStream(child, parent);
+    configureDelegatedChildApprovals(child, parent);
 
     expect(proposalApprovals().isBypassed(parent)).toBe(true);
     expect(proposalApprovals().isBypassed(child)).toBe(false);

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -21,6 +21,7 @@ import {
 } from '@agent/runtime/SessionEventHub';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
+import { createSessionApprovals } from '@agent/runtime/streamApprovalQueue';
 import {
   RUN_OUTCOME,
   STREAM_PHASE,
@@ -1411,6 +1412,37 @@ describe('executionRegistry', () => {
     } finally {
       registry.dispose();
       recorded.detach();
+    }
+  });
+
+  it('preserves child approvals when detaching it from its parent', () => {
+    const explicit = createRecordingHost();
+    const registry = new ExecutionRegistry();
+    const approvals = createSessionApprovals();
+    const parentStreamId = 'parent-detach-approvals' as StreamTabId;
+    const childStreamId = 'child-detach-approvals' as StreamTabId;
+    const handle = createHandle(
+      'exec-detach-approvals',
+      parentStreamId,
+      childStreamId,
+      explicit.host,
+    );
+
+    try {
+      registry.attachSessionApprovals(approvals);
+      approvals.toolEdit.bypass.setBypass(parentStreamId, true);
+      approvals.registerStreamParent(childStreamId, parentStreamId, [
+        'toolEdit',
+      ]);
+      registry.track(handle);
+
+      registry.detachActiveChildren(parentStreamId, explicit.host);
+      approvals.toolEdit.bypass.setBypass(parentStreamId, false);
+
+      expect(approvals.toolEdit.bypass.isBypassed(childStreamId)).toBe(true);
+      expect(handle.deliveryTargetStreamId).toBeUndefined();
+    } finally {
+      registry.dispose();
     }
   });
 

--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -33,8 +33,7 @@ import {
 } from '@tools/delegation/inBandSubagentExecution';
 
 const mocks = vi.hoisted(() => ({
-  enableYoloOnChildStream: vi.fn(),
-  inheritBashBypassOnChildStream: vi.fn(),
+  inheritApprovalBypassesOnChildStream: vi.fn(),
   executeAgent: vi.fn(),
   getExecutionStore: vi.fn(),
   getVisibleAgent: vi.fn(),
@@ -66,8 +65,8 @@ vi.mock('@model/computeModelOptions', () => ({
 }));
 
 vi.mock('@tools/approval', () => ({
-  enableYoloOnChildStream: mocks.enableYoloOnChildStream,
-  inheritBashBypassOnChildStream: mocks.inheritBashBypassOnChildStream,
+  inheritApprovalBypassesOnChildStream:
+    mocks.inheritApprovalBypassesOnChildStream,
   isApprovalBypassedForStream: mocks.isApprovalBypassedForStream,
   proposalApprovals: () => ({
     isBypassed: mocks.isProposalBypassed,

--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -33,7 +33,7 @@ import {
 } from '@tools/delegation/inBandSubagentExecution';
 
 const mocks = vi.hoisted(() => ({
-  inheritApprovalBypassesOnChildStream: vi.fn(),
+  configureDelegatedChildApprovals: vi.fn(),
   executeAgent: vi.fn(),
   getExecutionStore: vi.fn(),
   getVisibleAgent: vi.fn(),
@@ -65,8 +65,7 @@ vi.mock('@model/computeModelOptions', () => ({
 }));
 
 vi.mock('@tools/approval', () => ({
-  inheritApprovalBypassesOnChildStream:
-    mocks.inheritApprovalBypassesOnChildStream,
+  configureDelegatedChildApprovals: mocks.configureDelegatedChildApprovals,
   isApprovalBypassedForStream: mocks.isApprovalBypassedForStream,
   proposalApprovals: () => ({
     isBypassed: mocks.isProposalBypassed,

--- a/src/test-kernel/tools/SubagentExecutionChildStreamId.vitest.ts
+++ b/src/test-kernel/tools/SubagentExecutionChildStreamId.vitest.ts
@@ -49,8 +49,7 @@ vi.mock('@agent/followUp/ToolFileInteractionContext', () => ({
 }));
 
 vi.mock('@tools/approval', () => ({
-  enableYoloOnChildStream: vi.fn(),
-  inheritBashBypassOnChildStream: vi.fn(),
+  inheritApprovalBypassesOnChildStream: vi.fn(),
 }));
 
 import { executeSubagent } from '@tools/delegation/subagentExecution';

--- a/src/test-kernel/tools/SubagentExecutionChildStreamId.vitest.ts
+++ b/src/test-kernel/tools/SubagentExecutionChildStreamId.vitest.ts
@@ -49,7 +49,7 @@ vi.mock('@agent/followUp/ToolFileInteractionContext', () => ({
 }));
 
 vi.mock('@tools/approval', () => ({
-  inheritApprovalBypassesOnChildStream: vi.fn(),
+  configureDelegatedChildApprovals: vi.fn(),
 }));
 
 import { executeSubagent } from '@tools/delegation/subagentExecution';

--- a/src/tools/approval/index.ts
+++ b/src/tools/approval/index.ts
@@ -8,12 +8,41 @@
  */
 
 import {
+  currentSession,
   defaultSession,
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
 import type { StreamTabId } from '@shared/schemas';
 
-export { inheritApprovalBypassesOnChildStream } from './toolEditApproval';
+/**
+ * Link a freshly resolved child subagent stream to its parent for bash and
+ * tool-edit bypass resolution.
+ *
+ * A child delegated by a parent that auto-runs bash or auto-approves edits
+ * should do the same — and should keep following the parent when either
+ * bypass is toggled *after* the child stream already started, since this
+ * registers live ancestry links rather than copying the parent's values once
+ * at child creation (see `registerStreamParent`). Ancestry is tracked per
+ * bypass kind, so the CLI's distinct AUTO-BASH / AUTO-APPROVE grants are
+ * respected: a parent with AUTO-BASH but edits still gated propagates only
+ * bash, and fresh streams default to gated either way. Delegation-proposal
+ * (super-YOLO) bypass is deliberately NOT linked — a child's own delegations
+ * still prompt unless granted on the child explicitly (and
+ * `setDelegatedWorkApprovalBypasses` pins the child's own explicit entries,
+ * so that grant survives the parent later re-gating).
+ */
+export function inheritApprovalBypassesOnChildStream(
+  childStreamId: StreamTabId,
+  parentStreamId?: StreamTabId,
+  session: SessionHandle = currentSession(),
+): void {
+  if (parentStreamId) {
+    session.approvals.registerStreamParent(childStreamId, parentStreamId, [
+      'bash',
+      'toolEdit',
+    ]);
+  }
+}
 
 /**
  * Clean up all approval state for a deleted stream in the owning session.

--- a/src/tools/approval/index.ts
+++ b/src/tools/approval/index.ts
@@ -13,10 +13,7 @@ import {
 } from '@agent/runtime/SessionHandle';
 import type { StreamTabId } from '@shared/schemas';
 
-export {
-  enableYoloOnChildStream,
-  inheritBashBypassOnChildStream,
-} from './toolEditApproval';
+export { inheritApprovalBypassesOnChildStream } from './toolEditApproval';
 
 /**
  * Clean up all approval state for a deleted stream in the owning session.

--- a/src/tools/approval/index.ts
+++ b/src/tools/approval/index.ts
@@ -31,9 +31,12 @@ import type { StreamTabId } from '@shared/schemas';
  * `setDelegatedWorkApprovalBypasses` pins the child's own explicit entries,
  * so that grant survives the parent later re-gating).
  */
-export function inheritApprovalBypassesOnChildStream(
+export type DelegatedChildApprovalPolicy = 'inherit' | 'auto-approved';
+
+export function configureDelegatedChildApprovals(
   childStreamId: StreamTabId,
   parentStreamId?: StreamTabId,
+  policy: DelegatedChildApprovalPolicy = 'inherit',
   session: SessionHandle = currentSession(),
 ): void {
   if (parentStreamId) {
@@ -41,6 +44,16 @@ export function inheritApprovalBypassesOnChildStream(
       'bash',
       'toolEdit',
     ]);
+  }
+  if (policy === 'auto-approved') {
+    session.approvals.toolEdit.bypass.setBypass(
+      childStreamId,
+      true,
+      undefined,
+      {
+        silent: true,
+      },
+    );
   }
 }
 
@@ -55,10 +68,10 @@ export function cleanupApprovalsForStream(
   const { toolEdit, bash, proposal } = session.approvals;
   toolEdit.rejectPendingForStream(streamId);
   bash.rejectPendingForStream(streamId);
+  session.approvals.forgetStreamAncestry(streamId);
   toolEdit.bypass.clearForStream(streamId);
   bash.bypass.clearForStream(streamId);
   proposal.clearForStream(streamId);
-  session.approvals.forgetStreamAncestry(streamId);
   session.interactions.cancel({
     streamId,
     cause: 'Stream resources released.',

--- a/src/tools/approval/proposalApproval.ts
+++ b/src/tools/approval/proposalApproval.ts
@@ -39,8 +39,10 @@ export function setDelegatedWorkApprovalBypasses(
   const { proposal, toolEdit, bash } = session.approvals;
 
   proposal.setBypass(streamId, enabled, runtimeHost);
-  if (!enabled || !toolEdit.bypass.isBypassed(streamId)) {
-    toolEdit.bypass.setBypass(streamId, enabled, runtimeHost);
-  }
+  // Unconditional: write the stream's own explicit tool-edit entry even when
+  // `isBypassed` already reports true, because that can be an
+  // ancestry-resolved inheritance from the parent — super-YOLO granted here
+  // must survive the parent later re-gating its own edits.
+  toolEdit.bypass.setBypass(streamId, enabled, runtimeHost);
   bash.bypass.setBypass(streamId, enabled, runtimeHost, { silent: true });
 }

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -505,31 +505,3 @@ export async function requestAndWriteApprovedEdit(request: {
   );
   return { approval, ...written };
 }
-
-/**
- * Link a freshly resolved child subagent stream to its parent for bash and
- * tool-edit bypass resolution.
- *
- * A child delegated by a parent that auto-runs bash or auto-approves edits
- * should do the same — and should keep following the parent when either
- * bypass is toggled *after* the child stream already started, since this
- * registers live ancestry links rather than copying the parent's values once
- * at child creation (see `registerStreamParent`). Ancestry is tracked per
- * bypass kind, so the CLI's distinct AUTO-BASH / AUTO-APPROVE grants are
- * respected: a parent with AUTO-BASH but edits still gated propagates only
- * bash, and fresh streams default to gated either way. Delegation-proposal
- * (super-YOLO) bypass is deliberately NOT linked — a child's own delegations
- * still prompt unless granted on the child explicitly.
- */
-export function inheritApprovalBypassesOnChildStream(
-  childStreamId: StreamTabId,
-  parentStreamId?: StreamTabId,
-  session: SessionHandle = currentSession(),
-): void {
-  if (parentStreamId) {
-    session.approvals.registerStreamParent(childStreamId, parentStreamId, [
-      'bash',
-      'toolEdit',
-    ]);
-  }
-}

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -507,47 +507,29 @@ export async function requestAndWriteApprovedEdit(request: {
 }
 
 /**
- * Link a freshly resolved child subagent stream to its parent for bash-bypass
- * resolution, independent of any tool-edit auto-approval.
+ * Link a freshly resolved child subagent stream to its parent for bash and
+ * tool-edit bypass resolution.
  *
- * A child delegated by a parent that auto-runs bash should auto-run bash too —
- * and should keep doing so even if the parent's bash bypass is toggled on
- * *after* the child stream already started, since this registers a live
- * ancestry link rather than copying the parent's bypass value once at child
- * creation (see `registerStreamParent`). If the parent's bash is still gated
- * the child stays gated too — fresh streams default to gated either way.
- * Kept separate from the tool-edit YOLO flag to respect the CLI's distinct
- * AUTO-BASH / AUTO-APPROVE grants: a parent with AUTO-BASH but edits still
- * gated still propagates bash.
+ * A child delegated by a parent that auto-runs bash or auto-approves edits
+ * should do the same — and should keep following the parent when either
+ * bypass is toggled *after* the child stream already started, since this
+ * registers live ancestry links rather than copying the parent's values once
+ * at child creation (see `registerStreamParent`). Ancestry is tracked per
+ * bypass kind, so the CLI's distinct AUTO-BASH / AUTO-APPROVE grants are
+ * respected: a parent with AUTO-BASH but edits still gated propagates only
+ * bash, and fresh streams default to gated either way. Delegation-proposal
+ * (super-YOLO) bypass is deliberately NOT linked — a child's own delegations
+ * still prompt unless granted on the child explicitly.
  */
-export function inheritBashBypassOnChildStream(
+export function inheritApprovalBypassesOnChildStream(
   childStreamId: StreamTabId,
   parentStreamId?: StreamTabId,
   session: SessionHandle = currentSession(),
 ): void {
   if (parentStreamId) {
-    // Scoped to 'bash' only — ancestry is tracked per bypass kind, so this
-    // cannot also let the child inherit tool-edit or super-YOLO bypass from
-    // the parent. Those are granted separately and explicitly (see
-    // `enableYoloOnChildStream`) when a delegation asks for them.
     session.approvals.registerStreamParent(childStreamId, parentStreamId, [
       'bash',
+      'toolEdit',
     ]);
   }
-}
-
-/**
- * Enable tool-edit auto-approval on a freshly resolved child subagent stream.
- *
- * Used by DelegationTools when the parent is auto-approving edits / delegated
- * tasks. Silent because it fires before the child stream is activated; the
- * subsequent SYNC_STREAM_CONTENT carries the tool-edit / super-YOLO bypass.
- * Bash bypass is handled separately by `inheritBashBypassOnChildStream` so it
- * follows the parent regardless of the tool-edit flag.
- */
-export function enableYoloOnChildStream(
-  childStreamId: StreamTabId,
-  session: SessionHandle = currentSession(),
-): void {
-  session.approvals.toolEdit.bypass.setBypass(childStreamId, true);
 }

--- a/src/tools/delegation/proposalFlow.ts
+++ b/src/tools/delegation/proposalFlow.ts
@@ -25,10 +25,7 @@ import {
 } from '@shared/schemas';
 import type { ToolResult } from '@shared/schemas/toolResult';
 import type { AgentDelegationScope } from '@shared/schemas/agentRoster';
-import {
-  isApprovalBypassedForStream,
-  proposalApprovals,
-} from '@tools/approval';
+import { proposalApprovals } from '@tools/approval';
 import {
   availableModelNamesFromOptions,
   selectDelegationModelFromAvailableNames,
@@ -158,8 +155,10 @@ export async function proposeAndExecute(
   streamId: StreamTabId,
 ): Promise<ToolResult> {
   if (proposalApprovals().isBypassed(streamId)) {
+    // No explicit edit grant for the child: super-YOLO always couples the
+    // parent's tool-edit + bash bypass on (setDelegatedWorkApprovalBypasses),
+    // so the child's live ancestry links already resolve to auto-approve.
     return executeSubagent(proposal, agentName, streamId, {
-      enableYoloOnChild: true,
       approvalMeta: { autoApproved: true },
     });
   }
@@ -238,7 +237,6 @@ export async function proposeAndExecute(
   };
   const effectiveAgentName = resolvedAgentOverride?.name ?? agentName;
   return executeSubagent(effective, effectiveAgentName, streamId, {
-    enableYoloOnChild: isApprovalBypassedForStream(streamId),
     approvalMeta: {
       autoApproved: false,
       ...(modelOverride && {

--- a/src/tools/delegation/proposalFlow.ts
+++ b/src/tools/delegation/proposalFlow.ts
@@ -155,9 +155,8 @@ export async function proposeAndExecute(
   streamId: StreamTabId,
 ): Promise<ToolResult> {
   if (proposalApprovals().isBypassed(streamId)) {
-    // No explicit edit grant for the child: super-YOLO always couples the
-    // parent's tool-edit + bash bypass on (setDelegatedWorkApprovalBypasses),
-    // so the child's live ancestry links already resolve to auto-approve.
+    // Preserve the approved delegation's edit grant explicitly on the child.
+    // Proposal bypass can outlive the parent's ordinary edit-YOLO state.
     return executeSubagent(proposal, agentName, streamId, {
       approvalMeta: { autoApproved: true },
     });

--- a/src/tools/delegation/subagentExecution.ts
+++ b/src/tools/delegation/subagentExecution.ts
@@ -33,10 +33,7 @@ import {
   type StreamTabId,
 } from '@shared/schemas';
 import type { ToolResult } from '@shared/schemas/toolResult';
-import {
-  enableYoloOnChildStream,
-  inheritBashBypassOnChildStream,
-} from '@tools/approval';
+import { inheritApprovalBypassesOnChildStream } from '@tools/approval';
 import { generateExecutionId } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -78,7 +75,7 @@ export async function executeSubagent(
   configPayload: AgentConfigPayload,
   agentName: string,
   orchestratorStreamId: StreamTabId,
-  options?: { enableYoloOnChild?: boolean; approvalMeta?: ApprovalMeta },
+  options?: { approvalMeta?: ApprovalMeta },
 ): Promise<ToolResult> {
   const parentContext = tryUseRunContext();
   const runtimeHost = getRunContextRuntimeHost(parentContext);
@@ -120,12 +117,14 @@ export async function executeSubagent(
   const workingDirectory = childConfigPayload.workingDirectory ?? undefined;
 
   const inheritChildStreamApprovals = (resolvedStreamId: StreamTabId): void => {
-    // Bash bypass follows the parent regardless of edit-YOLO, so a bash-only
-    // parent (CLI AUTO-BASH without AUTO-APPROVE) still propagates to the child.
-    inheritBashBypassOnChildStream(resolvedStreamId, orchestratorStreamId);
-    if (options?.enableYoloOnChild) {
-      enableYoloOnChildStream(resolvedStreamId);
-    }
+    // Live per-kind ancestry: bash and tool-edit each follow the parent's own
+    // bypass, so a bash-only parent (CLI AUTO-BASH without AUTO-APPROVE) still
+    // propagates only bash, and a YOLO toggle on the parent mid-run reaches
+    // already-launched children.
+    inheritApprovalBypassesOnChildStream(
+      resolvedStreamId,
+      orchestratorStreamId,
+    );
   };
 
   if (parentContext.stopAfterCycle) {

--- a/src/tools/delegation/subagentExecution.ts
+++ b/src/tools/delegation/subagentExecution.ts
@@ -33,7 +33,7 @@ import {
   type StreamTabId,
 } from '@shared/schemas';
 import type { ToolResult } from '@shared/schemas/toolResult';
-import { inheritApprovalBypassesOnChildStream } from '@tools/approval';
+import { configureDelegatedChildApprovals } from '@tools/approval';
 import { generateExecutionId } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -121,9 +121,12 @@ export async function executeSubagent(
     // bypass, so a bash-only parent (CLI AUTO-BASH without AUTO-APPROVE) still
     // propagates only bash, and a YOLO toggle on the parent mid-run reaches
     // already-launched children.
-    inheritApprovalBypassesOnChildStream(
+    configureDelegatedChildApprovals(
       resolvedStreamId,
       orchestratorStreamId,
+      options?.approvalMeta?.autoApproved === true
+        ? 'auto-approved'
+        : 'inherit',
     );
   };
 

--- a/src/tools/goal/goalAutoApproval.ts
+++ b/src/tools/goal/goalAutoApproval.ts
@@ -12,8 +12,9 @@ import type { StreamTabId } from '@shared/schemas/identifiers';
  * it pauses or ends so manual follow-up turns prompt normally again.
  *
  * Subagents inherit the parent stream's bypass through the existing
- * delegation wiring (`inheritBashBypassOnChildStream`), so no child-stream
- * handling is needed here.
+ * delegation wiring (`inheritApprovalBypassesOnChildStream`), so no
+ * child-stream handling is needed here — per-kind ancestry means a goal
+ * parent with bash bypassed but edits gated propagates exactly that split.
  *
  * The approval modules are imported lazily: this file sits in the host-neutral
  * agent-loop import graph (via ToolUseWaitNode), and pulling the approval

--- a/src/tools/goal/goalAutoApproval.ts
+++ b/src/tools/goal/goalAutoApproval.ts
@@ -12,7 +12,7 @@ import type { StreamTabId } from '@shared/schemas/identifiers';
  * it pauses or ends so manual follow-up turns prompt normally again.
  *
  * Subagents inherit the parent stream's bypass through the existing
- * delegation wiring (`inheritApprovalBypassesOnChildStream`), so no
+ * delegation wiring (`configureDelegatedChildApprovals`), so no
  * child-stream handling is needed here — per-kind ancestry means a goal
  * parent with bash bypassed but edits gated propagates exactly that split.
  *


### PR DESCRIPTION
## Summary

Delegated subagents inherited command auto-approval through a live parent link, but file-edit auto-approval was copied once at launch. Toggling the parent's YOLO shield after a child started therefore changed command behavior while leaving edit behavior stale, and disabling the shield could leave child edits permanently auto-approved.

Delegation now registers one live, per-kind ancestry relation for both command and file-edit approvals. A child follows the parent's current state unless it has an explicit override. Super-YOLO still writes an explicit child edit grant, proposal approval remains unlinked, and inherited state changes are emitted for every visible descendant whose effective value changed.

## Issue acceptance gates

Closes #8634.

- Parent edit and command toggles affect already-running delegated agents immediately.
- Disabling the parent re-gates descendants without stale launch-time grants.
- Explicit child grants survive later parent changes.
- Detached or surviving children preserve their effective state while severing ancestry.
- Auto-approved delegations explicitly grant child edit approval even if the parent edit shield is off.
- Proposal/super-YOLO approval remains independent from delegation ancestry.
- Visible child and grandchild headers receive effective state updates; explicitly pinned descendants do not receive false updates.
- Stale helper exports, options, call sites, and test mocks are removed.

## Single source of truth

`SessionApprovals` owns the per-kind ancestry graphs and resolved bypass values. `configureDelegatedChildApprovals` names the one delegation policy (`bash` + `toolEdit`, never `proposal`), while `createStreamApprovalBypass` compares descendant states before and after a write and emits only actual effective changes.

`setDelegatedWorkApprovalBypasses` remains the owner of the coupled task/edit/command grant and always writes the stream's explicit edit value.

## Duplication and abstraction budget

One dual-kind delegation helper replaces the former bash-inheritance helper and one-shot edit-grant helper. The helper owns a real policy boundary rather than forwarding data: which approval kinds delegation inherits. Descendant notification is implemented once in the existing generic approval controller, so extension, desktop, CLI, and all bypass kinds cannot drift.

## Net elements (R6)

14 files changed, 355 insertions, 126 deletions, net +229 lines. No files were added. Two exported helpers were removed and one policy helper replaced them (net -1 exported symbol). No classes, schemas, factories, or modules were added. Most added lines are inheritance and event regressions.

## Consumer counts (R8)

The removed `enableYoloOnChildStream`, `inheritBashBypassOnChildStream`, and `enableYoloOnChild` option have zero remaining references. The replacement delegation helper has one production consumer (`subagentExecution`) and owns the two-kind policy formerly split across that consumer and `proposalFlow`. The existing bypass event path now fans out to changed descendants; tests pin parent, child, grandchild, and explicit-override counts.

## Host impact

Extension: The single YOLO shield now changes running delegated agents consistently, and visible child headers update immediately.

Desktop: Session-owned approvals use the same live inheritance and descendant events.

CLI: Separate AUTO-BASH and AUTO-APPROVE grants remain independent; children inherit only the kinds enabled on the parent.

## Scheduled refactoring

None.

## Validation

- Prettier and ESLint on changed files with zero warnings
- Root and test-kernel TypeScript checks
- Focused Vitest: 6 files, 133 tests passed (`ChildStreamYoloInheritance`, `DelegationHeadless`, `SubagentExecutionChildStreamId`, `ToolEditApprovalGate`, `HumanPromptProgressEvents`, `ProgressViewCommandHandlers`)
- Commit-hook repository formatting

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes approval bypass resolution, ancestry teardown, and UI events for delegated runs—security-sensitive behavior, but heavily regression-tested and scoped to session-owned approval state.
> 
> **Overview**
> Delegated subagents now **inherit bash and tool-edit auto-approval through live parent links** instead of a one-time copy at launch, so toggling the parent’s shields mid-run updates already-running children and their UI.
> 
> **`configureDelegatedChildApprovals`** replaces the separate bash-inheritance and child YOLO helpers: it registers `bash` + `toolEdit` ancestry (not proposal/super-YOLO), and can pin edit auto-approval for auto-approved delegations. **`setDelegatedWorkApprovalBypasses`** always writes an explicit tool-edit bypass on the stream so super-YOLO grants survive if the parent later re-gates edits.
> 
> Bypass toggles **emit events for descendants** whose effective state changed (parent, child, grandchild), while streams with their own explicit bypass are left alone. **`detachStreamFromParent`** freezes inherited state as explicit values when a child is detached or a parent is torn down; **`ExecutionRegistry.detachActiveChildren`** calls this before unlinking. **`SessionHandle`** shares one approvals instance with the execution registry via **`attachSessionApprovals`**.
> 
> Delegation launch drops **`enableYoloOnChild`**; proposal flow uses the new policy helper instead of copying parent edit state at approve time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 334eb0192e36ac9cbe93bfe612a6eb86018ad720. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->