### PR TITLE
docs: codify code quality rules from the simplification campaign

### DIFF
--- a/.claude/skills/code-review/references/review-checklist.md
+++ b/.claude/skills/code-review/references/review-checklist.md
@@ -148,9 +148,9 @@ Standing rules from the 2026-07 error-handling audit: 880 catch sites read acros
 
 Concrete rules earned from the 2026-07 whole-repo simplification campaign. Full rationale and evidence lives in `AGENTS.md` → "Code quality rules"; don't restate it in review comments, just check for it.
 
-- **New exports need a consumer in the same PR.** `grep -r "exportedSymbol" src/` for any newly exported symbol; zero outside hits is a finding. Sharpens §8's "dead exports" grep from a cleanup pass into a pre-merge gate.
+- **New exports need a consumer in the same PR.** `rg "exportedSymbol" src/ packages/extension packages/desktop packages/cli` for any newly exported symbol; zero outside hits is a finding. Search the whole workspace, not just `src/` — a root export consumed only via a `packages/*` import (e.g. `@shared`, `@utils`, `@agent`) is still live. Sharpens §8's "dead exports" grep from a cleanup pass into a pre-merge gate.
 - **No new convenience barrels.** A new index/barrel re-export file is a finding unless it documents a real external public surface (precedent: the trace events SDK contract).
-- **Shared mutable literals must be frozen or factory-made.** A module-level object that a function returns or that crosses a boundary needs `as const` plus `Object.freeze`, or a factory returning a fresh object per call, not a bare shared literal.
+- **Shared mutable literals must be frozen or factory-made.** A module-level object that a function returns or that crosses a boundary needs `as const` plus `Object.freeze` (deep-freeze, or a factory, for literals with nested objects/arrays or `Map`/`Set` — a shallow freeze doesn't stop those from mutating), or a factory returning a fresh object per call, not a bare shared literal.
 - **Fixture rule of three.** Same literal test setup block 3+ times in one file → file-local helper; setup shared across suites → `src/test-kernel/support/`.
 - **Local fakes need justification.** A local fake for a platform port that already has a shared fake in `src/test-kernel/support/` needs a one-line comment naming the capability gap.
 - **Registrations need a consumer.** Global registration (component, command, provider) needs an external surface that actually references it; internal-only usage imports locally.

--- a/.claude/skills/code-review/references/review-checklist.md
+++ b/.claude/skills/code-review/references/review-checklist.md
@@ -24,6 +24,7 @@ Design rules in `CLAUDE.md` → "Schema and Type Guidelines" / "Backward Compati
 - **Manual `safeParse` + ternary for defaults** → `Schema.catch(default).parse(data)` — display/derived defaults only; on persisted data see §15.
 - **`z.custom<T>()` without a comment** justifying why a real schema isn't possible.
 - **`.prefault` vs `.default` vs `.catch`** misuse: `.prefault` normalizes input _before_ validation (deserialization); `.default` fills in _after_ a missing field; `.catch` recovers from validation throws. Wrong choice silently corrupts state.
+- **Tool parameter required despite having an obvious default** → make it `.nullish()` plus a dispatch-time default; a required param that models routinely omit is a tool bug, not a model error. Also check description strings that enumerate dispatch behavior ("every command except X") against the actual dispatch table whenever either changes. Precedent: the memory tool's required `path` on `view`, and its own fix's `rename` description drifting from the dispatch table.
 
 ## 3. PocketFlow / agent runtime
 
@@ -142,6 +143,18 @@ Standing rules from the 2026-07 error-handling audit: 880 catch sites read acros
 - **No downgrade below `warn` on a resume/persisted-state read failure.** `logger.debug` in a catch that changes run behavior (fresh start, dropped history, zeroed usage) is a blocker.
 - **Fire-and-forget writes get exactly one logging rejection owner.** A chain-keep-alive `.catch(() => {})` on a write queue is legal only paired with one shared observer that logs the rejection.
 - **Cleaner-solutions menu** (the fix names which it uses): parse-at-entry (Zod at the boundary, canonical thereafter); decide-once-carry-as-data; result types (`{ok}|{error}`) in core with one throw boundary; define-errors-out-of-existence (make the invalid state unrepresentable); loud read (warn + surface + `schemaVersion`); single classifier boundary; delete-the-guard (let it crash to an existing L1/L4 boundary).
+
+## 16. Code quality rules (2026-07 simplification campaign)
+
+Concrete rules earned from the 2026-07 whole-repo simplification campaign. Full rationale and evidence lives in `AGENTS.md` → "Code quality rules"; don't restate it in review comments, just check for it.
+
+- **New exports need a consumer in the same PR.** `grep -r "exportedSymbol" src/` for any newly exported symbol; zero outside hits is a finding. Sharpens §8's "dead exports" grep from a cleanup pass into a pre-merge gate.
+- **No new convenience barrels.** A new index/barrel re-export file is a finding unless it documents a real external public surface (precedent: the trace events SDK contract).
+- **Shared mutable literals must be frozen or factory-made.** A module-level object that a function returns or that crosses a boundary needs `as const` plus `Object.freeze`, or a factory returning a fresh object per call, not a bare shared literal.
+- **Fixture rule of three.** Same literal test setup block 3+ times in one file → file-local helper; setup shared across suites → `src/test-kernel/support/`.
+- **Local fakes need justification.** A local fake for a platform port that already has a shared fake in `src/test-kernel/support/` needs a one-line comment naming the capability gap.
+- **Registrations need a consumer.** Global registration (component, command, provider) needs an external surface that actually references it; internal-only usage imports locally.
+- **No new bare module-level mutable singletons in tested code.** Flag module-level `let`/mutable object state that tests would need to reset between runs; it needs an injectable, resettable handle instead.
 
 ## Final pass
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -337,7 +337,7 @@ For good separation of concerns and platform independence, core business logic s
 - Define agents using `AgentDataclass` and `AgentConfig` (`src/agent/core/`) and compose them via the factories in `src/agent/runtime`.
 - Launch executions from host code (commands, frontend services, desktop IPC) via `runAgent` (`src/agent/runtime/runAgent.ts`) — it assigns an `executionId`, registers the run in storage, and opens workflow output. Only use the lower-level `executeAgent` when you already own the `executionId` (e.g. subagent dispatch in `DelegationTools.ts` or a resume path). Both functions require an explicit `runtimeHost`.
 - Resume a persisted tool-use session via `resumeToolUseFromSnapshot` (`src/agent/runtime/executeAgent.ts`), not `runAgent`.
-- Add new model handlers under `src/agent/modelHandlers/`, export them through the index, and register capabilities/pricing in `src/model/computeModelOptions.ts`.
+- Add new model handlers under `src/agent/modelHandlers/<provider>/` (no barrel — import via the `@agent/modelHandlers/<provider>/<File>` alias, per that directory's `README.md`), and register capabilities/pricing in `src/model/computeModelOptions.ts`.
 
 **PocketFlow architecture**
 
@@ -428,9 +428,9 @@ These rules were earned from a 2026-07 whole-repo simplification campaign, not d
 
 - **Exports are contracts; default to file-local.** A new export needs a consumer in the same PR. Across the 2026-07 campaign, five separate areas' main cleanup yield was deleting exports with zero outside consumers (20 in `src/tools` alone). Mechanical enforcement lives in the dead-export ratchet (being tightened in a separate PR); this is the principle behind it.
 
-- **No convenience barrels.** A barrel/index re-export file exists only for a documented public surface (for example, the trace events SDK contract, which declares its surface in its own docstring). Everything else imports the file that defines the symbol directly. The campaign deleted dead barrels in `workflowScript/`, `storage/`, and `index/` that no caller actually used.
+- **No convenience barrels.** A barrel/index re-export file exists only for a documented public surface (for example, the trace events SDK contract, which declares its surface in its own docstring). Everything else imports the file that defines the symbol directly — this includes model handlers (`src/agent/modelHandlers/`; see that directory's `README.md`), which have no barrel and no re-export shims. The campaign deleted dead barrels in `workflowScript/`, `storage/`, and `index/` that no caller actually used.
 
-- **Never hand out a shared mutable literal.** A module-level object that a function returns, or that crosses a module boundary, must be frozen (`as const` plus `Object.freeze`) or produced fresh by a factory that returns a new object each call; see CLAUDE.md's "Discouraged Factory Patterns" for when a factory is and isn't warranted. A campaign consolidation once replaced fresh no-retry result literals with a single shared constant; the resulting aliasing behavior change was caught only by a follow-up factory rewrite and a `notStrictEqual` regression test.
+- **Never hand out a shared mutable literal.** A module-level object that a function returns, or that crosses a module boundary, must be frozen (`as const` plus `Object.freeze`) or produced fresh by a factory that returns a new object each call; see CLAUDE.md's "Discouraged Factory Patterns" for when a factory is and isn't warranted. `Object.freeze` is shallow — for a literal with nested objects/arrays, or for a `Map`/`Set`, either deep-freeze it or use a factory, since a shallow freeze doesn't stop mutation of nested values or calls like `.set()`/`.add()`. A campaign consolidation once replaced fresh no-retry result literals with a single shared constant; the resulting aliasing behavior change was caught only by a follow-up factory rewrite and a `notStrictEqual` regression test.
 
 - **Global registration requires a global consumer.** Register something globally (components, commands, providers) only when an external surface actually references it; consumers that are internal-only import locally instead. The docs theme once globally registered two components that no markdown page used.
 
@@ -440,7 +440,7 @@ These rules were earned from a 2026-07 whole-repo simplification campaign, not d
 
 - **Fixture rule of three.** When the same literal setup block appears three or more times in one test file, extract it to a file-local helper. Setup shared across multiple suites gets promoted to `src/test-kernel/support/`. Five test lanes in the campaign removed about 860 lines that were almost entirely repeated literal setup; one file constructed the same handle inline 33 times.
 
-- **One fake per port.** Tests use the shared fakes in `src/test-kernel/support/` for platform ports. A local fake for a port that already has a shared fake requires a one-line comment naming the capability the shared fake deliberately lacks (precedent: `MemoryConfigStore` tracking global-vs-workspace write targets).
+- **One fake per port.** Tests use the shared fakes in `src/test-kernel/support/` for platform ports. A local fake for a port that already has a shared fake requires a one-line comment naming the capability the shared fake deliberately lacks.
 
 ## Documentation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,6 +225,10 @@ const result = processPath(input.path ?? undefined);
 
 See: https://platform.openai.com/docs/guides/structured-outputs
 
+**Design for the model's first call**
+
+Any parameter with an obvious default should be optional with that default applied at dispatch time (`.nullish()` plus a default when the tool runs), not required. A required parameter that models routinely omit is a tool bug, not a model error. When a description string enumerates dispatch behavior (for example, "every command except X"), verify it against the actual dispatch table whenever either changes; the two can drift independently. Evidence: the memory tool once required `path` for `view`, so every fresh session rendered an error card until the model retried; the fix's own description string then misdescribed `rename` until review caught it.
+
 ### ES2023+ Patterns
 
 Use modern JavaScript features available with ES2022+ target:
@@ -417,6 +421,26 @@ adding new code or refactoring existing modules:
 - Most importantly, ideally, when you have finished with each change, the system will have the structure it would have had if you had designed it from the start with that change in mind.
 - When your refactoring include a large number of renames, use search tools to make sure you are not missing any files or paths where changes need to be made.
 - **Share instances via constructors**: When managers share state, pass the shared dependency through the constructor. This keeps state consistent and dependencies explicit.
+
+## Code quality rules
+
+These rules were earned from a 2026-07 whole-repo simplification campaign, not derived top-down. Each one carries the evidence that motivated it, so a future reader can tell it was learned rather than theorized. They complement, and don't restate, the guardrails already documented in CLAUDE.md: "Discouraged Factory Patterns", "Render-Time Workarounds", "Flattening Abstraction Layers", the abstraction-cost guardrails, and the Zod-as-SSOT guidance above.
+
+- **Exports are contracts; default to file-local.** A new export needs a consumer in the same PR. Across the 2026-07 campaign, five separate areas' main cleanup yield was deleting exports with zero outside consumers (20 in `src/tools` alone). Mechanical enforcement lives in the dead-export ratchet (being tightened in a separate PR); this is the principle behind it.
+
+- **No convenience barrels.** A barrel/index re-export file exists only for a documented public surface (for example, the trace events SDK contract, which declares its surface in its own docstring). Everything else imports the file that defines the symbol directly. The campaign deleted dead barrels in `workflowScript/`, `storage/`, and `index/` that no caller actually used.
+
+- **Never hand out a shared mutable literal.** A module-level object that a function returns, or that crosses a module boundary, must be frozen (`as const` plus `Object.freeze`) or produced fresh by a factory that returns a new object each call; see CLAUDE.md's "Discouraged Factory Patterns" for when a factory is and isn't warranted. A campaign consolidation once replaced fresh no-retry result literals with a single shared constant; the resulting aliasing behavior change was caught only by a follow-up factory rewrite and a `notStrictEqual` regression test.
+
+- **Global registration requires a global consumer.** Register something globally (components, commands, providers) only when an external surface actually references it; consumers that are internal-only import locally instead. The docs theme once globally registered two components that no markdown page used.
+
+- **No bare module-level mutable singletons in tested code.** State that tests need to isolate belongs behind an injectable, resettable handle, not a bare module-level variable. The only test flake hit during the 2026-07 campaign was a module-level session singleton colliding across suites.
+
+### Test fixtures and fakes
+
+- **Fixture rule of three.** When the same literal setup block appears three or more times in one test file, extract it to a file-local helper. Setup shared across multiple suites gets promoted to `src/test-kernel/support/`. Five test lanes in the campaign removed about 860 lines that were almost entirely repeated literal setup; one file constructed the same handle inline 33 times.
+
+- **One fake per port.** Tests use the shared fakes in `src/test-kernel/support/` for platform ports. A local fake for a port that already has a shared fake requires a one-line comment naming the capability the shared fake deliberately lacks (precedent: `MemoryConfigStore` tracking global-vs-workspace write targets).
 
 ## Documentation
 


### PR DESCRIPTION
## What

Adds eight code-quality rules earned from the 2026-07 whole-repo simplification campaign to `AGENTS.md`, and matching one-line checks to the code-review checklist (`.claude/skills/code-review/references/review-checklist.md`). Rules integrate with the existing structure: the tool-schema rule extends the existing "Tool input schemas" subsection under Zod v4 patterns, and the corresponding checklist bullet extends checklist section 2 (Zod v4 schema correctness). The remaining seven rules form a new "Code quality rules" section in AGENTS.md (with a "Test fixtures and fakes" subsection for the two test-specific rules), and a new checklist section 16, appended after section 15 without renumbering anything existing.

Rules covered: export hygiene (new exports need a same-PR consumer), no convenience barrels, no shared mutable literals, tool schema defaults matching a model's first call, global registration needs a global consumer, no bare module-level mutable singletons in tested code, the fixture rule of three, and one fake per platform port.

## Why

These rules were previously undocumented tribal knowledge from the campaign's cleanup findings. Each one keeps its one-line evidence rationale (real counts, real precedents) so future readers can tell it was earned, not theorized, and so the same classes of dead exports, barrels, and fixture duplication do not silently reaccumulate.

Guidance already covered elsewhere (abstraction-cost guardrails, factory anti-patterns, render-time workarounds, Zod SSOT) is referenced rather than duplicated.

## Verification

Docs-only change. Verified by reading both files back in full after editing to confirm they render sensibly and integrate cleanly with the existing structure. The pre-commit `npm run format` hook (Prettier) ran clean on first commit. No build or tests needed for a docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and review-checklist updates only; no runtime, auth, or data-path changes.
> 
> **Overview**
> Documents **eight campaign-earned code quality rules** in `AGENTS.md` (new **Code quality rules** section plus **Test fixtures and fakes**) and adds matching one-line review checks as **checklist §16**, with pointers to `AGENTS.md` so reviewers don't restate rationale in comments.
> 
> Also extends existing guidance: **§2 Zod** / tool-schema docs gain **"Design for the model's first call"** (optional params with dispatch-time defaults, keep tool descriptions aligned with dispatch tables), and **model handler** registration text now says **per-provider paths, no barrel** (`@agent/modelHandlers/<provider>/<File>`), consistent with `src/agent/modelHandlers/README.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2c10920dde16a87baca4a155a3ee641fffe0b28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->