### PR TITLE
ci: fail the dead-export ratchet on any new unused export

### DIFF
--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -1,6 +1,1175 @@
 {
-  "unusedFiles": 2,
-  "unusedExports": 385,
-  "unusedTypes": 299,
-  "duplicateExports": 3
+  "semantics": "Per-symbol baseline of knip dead-code findings (files/exports/types/duplicate-export groups), each identified by (file, category, name) -- never by line number, so unrelated edits that shift lines never spuriously mark a baseline entry as fixed. The ratchet (scripts/check-dead-code-ratchet.mjs) fails only when the current knip run contains a finding not in this list. Removing entries here is always welcome (it means the dead code was cleaned up); a genuinely new unused file/export/type must either be deleted or, if intentionally kept, added here in the same PR. Regenerate by piping `knip --reporter json` through extractFindings() and sorting with compareFindings(); do not hand-edit into disorder.",
+  "findings": [
+    {
+      "file": "packages/cli/src/chat/tui/panes/transcriptEntries.ts",
+      "category": "exports",
+      "name": "nextRenderableTranscriptEntry"
+    },
+    {
+      "file": "packages/cli/src/commands/_helpers/globalArgs.ts",
+      "category": "duplicates",
+      "name": "AGENT_RUN_GLOBAL_ARGS,ROOT_ROUTING_ARGS"
+    },
+    {
+      "file": "packages/desktop/src/desktopCommandSurface.ts",
+      "category": "exports",
+      "name": "DESKTOP_COMMAND_IDS"
+    },
+    {
+      "file": "packages/desktop/src/desktopDiffMessages.ts",
+      "category": "exports",
+      "name": "DESKTOP_DIFF_COMMANDS"
+    },
+    {
+      "file": "packages/desktop/src/desktopLogMessages.ts",
+      "category": "exports",
+      "name": "DesktopLogSnapshotSchema"
+    },
+    {
+      "file": "packages/desktop/src/desktopPdfMessages.ts",
+      "category": "exports",
+      "name": "DESKTOP_PDF_COMMANDS"
+    },
+    {
+      "file": "packages/desktop/src/desktopPromptMessages.ts",
+      "category": "exports",
+      "name": "DESKTOP_PROMPT_COMMANDS"
+    },
+    {
+      "file": "packages/desktop/src/desktopShellMessages.ts",
+      "category": "exports",
+      "name": "DesktopRouteSchema"
+    },
+    {
+      "file": "packages/desktop/src/main/desktopAppLog.ts",
+      "category": "exports",
+      "name": "getDesktopLogFilePath"
+    },
+    {
+      "file": "packages/desktop/src/main/desktopCrashReporting.ts",
+      "category": "exports",
+      "name": "createDesktopCrashEventScrubber"
+    },
+    {
+      "file": "packages/desktop/src/main/desktopCrashReporting.ts",
+      "category": "exports",
+      "name": "scrubDesktopCrashEvent"
+    },
+    {
+      "file": "packages/desktop/src/main/desktopNavigationPolicy.ts",
+      "category": "exports",
+      "name": "isAllowedExternalUrl"
+    },
+    {
+      "file": "packages/desktop/src/main/desktopSetupTerminal.ts",
+      "category": "exports",
+      "name": "buildMacTerminalCommand"
+    },
+    {
+      "file": "packages/desktop/src/main/desktopUpdateChecker.ts",
+      "category": "exports",
+      "name": "fetchLatestDesktopRelease"
+    },
+    {
+      "file": "packages/desktop/src/main/platform/electronSecrets.ts",
+      "category": "exports",
+      "name": "__resetKeychainStateForTests"
+    },
+    {
+      "file": "packages/desktop/src/main/platform/electronSecrets.ts",
+      "category": "exports",
+      "name": "getSecretStorageMode"
+    },
+    {
+      "file": "packages/desktop/src/main/platform/electronSecrets.ts",
+      "category": "exports",
+      "name": "KEYCHAIN_DENIED_WARNING_MESSAGE"
+    },
+    {
+      "file": "packages/desktop/src/main/platform/electronSecrets.ts",
+      "category": "exports",
+      "name": "LINUX_BASIC_TEXT_SECRET_STORAGE_MESSAGE"
+    },
+    {
+      "file": "packages/desktop/src/main/platform/secretStorageWarningDialog.ts",
+      "category": "exports",
+      "name": "getSecretStorageWarningParentWindow"
+    },
+    {
+      "file": "packages/desktop/src/preload/hostBridge.ts",
+      "category": "exports",
+      "name": "createElectronHostBridge"
+    },
+    {
+      "file": "packages/desktop/src/preload/hostBridge.ts",
+      "category": "exports",
+      "name": "ELECTRON_WEBVIEW_MESSAGE_CHANNEL"
+    },
+    {
+      "file": "packages/desktop/src/preload/hostBridge.ts",
+      "category": "exports",
+      "name": "ELECTRON_WEBVIEW_PUSH_CHANNEL"
+    },
+    {
+      "file": "packages/extension/src/frontend/lean/VscodeIntegration.ts",
+      "category": "exports",
+      "name": "executeFileCommand"
+    },
+    {
+      "file": "packages/extension/src/frontend/lean/VscodeIntegration.ts",
+      "category": "exports",
+      "name": "executeProjectCommand"
+    },
+    {
+      "file": "packages/extension/src/frontend/lean/VscodeIntegration.ts",
+      "category": "exports",
+      "name": "fetchDiagnosticsForFile"
+    },
+    {
+      "file": "packages/extension/src/frontend/lean/VscodeIntegration.ts",
+      "category": "exports",
+      "name": "getGoalState"
+    },
+    {
+      "file": "packages/extension/src/frontend/lean/VscodeIntegration.ts",
+      "category": "exports",
+      "name": "getHoverInfo"
+    },
+    {
+      "file": "packages/extension/src/frontend/lean/VscodeIntegration.ts",
+      "category": "exports",
+      "name": "getTermGoal"
+    },
+    {
+      "file": "packages/extension/src/frontend/lean/VscodeIntegration.ts",
+      "category": "exports",
+      "name": "navigateToFirstError"
+    },
+    {
+      "file": "packages/extension/src/frontend/ui/errorHandlingUtils.ts",
+      "category": "exports",
+      "name": "isFileNotFoundError"
+    },
+    {
+      "file": "packages/trace-viewer/vite.standalone.config.ts",
+      "category": "files",
+      "name": "packages/trace-viewer/vite.standalone.config.ts"
+    },
+    {
+      "file": "src/agent/core/definition/AgentConfig.ts",
+      "category": "types",
+      "name": "ToolUseAgentConfig"
+    },
+    {
+      "file": "src/agent/core/definition/AgentConfig.ts",
+      "category": "types",
+      "name": "WorkflowAgentConfig"
+    },
+    {
+      "file": "src/agent/runtime/modelHandlerCompatibilityKey.ts",
+      "category": "exports",
+      "name": "MODEL_HANDLER_COMPATIBILITY_KEYS"
+    },
+    {
+      "file": "src/agent/runtime/streamApprovalQueue.ts",
+      "category": "types",
+      "name": "BypassAncestryKind"
+    },
+    {
+      "file": "src/agent/trace/events.ts",
+      "category": "types",
+      "name": "ChildActivityEvent"
+    },
+    {
+      "file": "src/agent/trace/events.ts",
+      "category": "types",
+      "name": "ContextStateEvent"
+    },
+    {
+      "file": "src/agent/trace/events.ts",
+      "category": "types",
+      "name": "ConversationProgressEvent"
+    },
+    {
+      "file": "src/agent/trace/events.ts",
+      "category": "types",
+      "name": "DomainEvent"
+    },
+    {
+      "file": "src/agent/trace/events.ts",
+      "category": "types",
+      "name": "ProcessOutputEvent"
+    },
+    {
+      "file": "src/agent/trace/events.ts",
+      "category": "types",
+      "name": "RunConfigEvent"
+    },
+    {
+      "file": "src/agent/trace/events.ts",
+      "category": "types",
+      "name": "RunFactEvent"
+    },
+    {
+      "file": "src/agent/trace/events.ts",
+      "category": "types",
+      "name": "RunStartEvent"
+    },
+    {
+      "file": "src/agent/trace/events.ts",
+      "category": "types",
+      "name": "StageEndEvent"
+    },
+    {
+      "file": "src/agent/trace/events.ts",
+      "category": "types",
+      "name": "StageStamp"
+    },
+    {
+      "file": "src/agent/trace/events.ts",
+      "category": "types",
+      "name": "StreamChunkEvent"
+    },
+    {
+      "file": "src/agent/trace/events.ts",
+      "category": "types",
+      "name": "StreamEndEvent"
+    },
+    {
+      "file": "src/agent/trace/events.ts",
+      "category": "types",
+      "name": "StreamStartEvent"
+    },
+    {
+      "file": "src/agent/trace/events.ts",
+      "category": "types",
+      "name": "ToolEndEvent"
+    },
+    {
+      "file": "src/agent/trace/events.ts",
+      "category": "types",
+      "name": "ToolStartEvent"
+    },
+    {
+      "file": "src/agent/trace/events.ts",
+      "category": "types",
+      "name": "UsageEvent"
+    },
+    {
+      "file": "src/agent/trace/index.ts",
+      "category": "types",
+      "name": "ChannelSubscriberOptions"
+    },
+    {
+      "file": "src/agent/trace/index.ts",
+      "category": "types",
+      "name": "LogEvent"
+    },
+    {
+      "file": "src/controllers/progressView/backend/restartRepair.ts",
+      "category": "exports",
+      "name": "RESTART_REPAIR_PHASES"
+    },
+    {
+      "file": "src/controllers/progressView/ProgressViewHost.ts",
+      "category": "types",
+      "name": "ProgressViewHostCommandOptions"
+    },
+    {
+      "file": "src/controllers/settingsView/LatexToolingController.ts",
+      "category": "exports",
+      "name": "isAllowedLatexInstallCommand"
+    },
+    {
+      "file": "src/controllers/settingsView/SettingsAgentCatalogController.ts",
+      "category": "exports",
+      "name": "enabledKeysIncludeAgent"
+    },
+    {
+      "file": "src/platform/languageModel.ts",
+      "category": "types",
+      "name": "LanguageModelSelector"
+    },
+    {
+      "file": "src/shared/constants/agents.ts",
+      "category": "exports",
+      "name": "REMOTE_ORCHESTRATOR_AGENT_NAMES"
+    },
+    {
+      "file": "src/shared/schemas/agent.ts",
+      "category": "duplicates",
+      "name": "AgentSource,AgentSourceSchema"
+    },
+    {
+      "file": "src/shared/schemas/agentRoster.ts",
+      "category": "exports",
+      "name": "AgentRosterCategorySelectionSchema"
+    },
+    {
+      "file": "src/shared/schemas/commonViewMessages.ts",
+      "category": "exports",
+      "name": "ErrorMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/commonViewMessages.ts",
+      "category": "exports",
+      "name": "SetDebugModeMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/commonViewMessages.ts",
+      "category": "exports",
+      "name": "StateRestoreMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/commonViewMessages.ts",
+      "category": "exports",
+      "name": "SwitchViewTargetSchema"
+    },
+    {
+      "file": "src/shared/schemas/contextManagement.ts",
+      "category": "exports",
+      "name": "ContextManagementAction"
+    },
+    {
+      "file": "src/shared/schemas/coreSettings.ts",
+      "category": "exports",
+      "name": "CoreSettingsSchema"
+    },
+    {
+      "file": "src/shared/schemas/coreSettings.ts",
+      "category": "exports",
+      "name": "NON_REGEX_REPLACEMENT_CATEGORIES"
+    },
+    {
+      "file": "src/shared/schemas/coreSettings.ts",
+      "category": "exports",
+      "name": "REGEX_REPLACEMENT_CATEGORIES"
+    },
+    {
+      "file": "src/shared/schemas/coreSettings.ts",
+      "category": "types",
+      "name": "CoreSettingPath"
+    },
+    {
+      "file": "src/shared/schemas/diffResult.ts",
+      "category": "exports",
+      "name": "DiffResultSchema"
+    },
+    {
+      "file": "src/shared/schemas/diffResult.ts",
+      "category": "exports",
+      "name": "DiffStatusSchema"
+    },
+    {
+      "file": "src/shared/schemas/errors.ts",
+      "category": "exports",
+      "name": "ErrorContextSchema"
+    },
+    {
+      "file": "src/shared/schemas/errors.ts",
+      "category": "exports",
+      "name": "StreamDiagnosticsSchema"
+    },
+    {
+      "file": "src/shared/schemas/goal.ts",
+      "category": "duplicates",
+      "name": "goalDurationMs,goalElapsedMs"
+    },
+    {
+      "file": "src/shared/schemas/historyViewMessages.ts",
+      "category": "exports",
+      "name": "HistoryIdMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/historyViewMessages.ts",
+      "category": "exports",
+      "name": "HistoryItemSchema"
+    },
+    {
+      "file": "src/shared/schemas/log.ts",
+      "category": "exports",
+      "name": "LogLevelSchema"
+    },
+    {
+      "file": "src/shared/schemas/log.ts",
+      "category": "exports",
+      "name": "MessageTypeSchema"
+    },
+    {
+      "file": "src/shared/schemas/log.ts",
+      "category": "exports",
+      "name": "StreamLogEntryTypeSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/executeMessage.ts",
+      "category": "exports",
+      "name": "MainViewExecuteSessionSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/executeMessage.ts",
+      "category": "types",
+      "name": "MainViewExecuteSession"
+    },
+    {
+      "file": "src/shared/schemas/mainView/inbound.ts",
+      "category": "exports",
+      "name": "AcceptEditedMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/inbound.ts",
+      "category": "exports",
+      "name": "CompareMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/inbound.ts",
+      "category": "exports",
+      "name": "LatexdiffMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/inbound.ts",
+      "category": "exports",
+      "name": "LatexdiffvcMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/inbound.ts",
+      "category": "exports",
+      "name": "MergeMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/inbound.ts",
+      "category": "exports",
+      "name": "OpenAgentDirectoryMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/inbound.ts",
+      "category": "exports",
+      "name": "OpenAgentSettingsMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/inbound.ts",
+      "category": "exports",
+      "name": "PackLatexdiffvcMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/inbound.ts",
+      "category": "exports",
+      "name": "PackMultipleMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/inbound.ts",
+      "category": "exports",
+      "name": "RequestRecentCommitsMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/inbound.ts",
+      "category": "types",
+      "name": "AcceptEditedMessage"
+    },
+    {
+      "file": "src/shared/schemas/mainView/outbound.ts",
+      "category": "exports",
+      "name": "AddMediaFileMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/outbound.ts",
+      "category": "exports",
+      "name": "EditedFileSelectedMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/outbound.ts",
+      "category": "exports",
+      "name": "InstructionTextPolishedMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/outbound.ts",
+      "category": "exports",
+      "name": "InstructionTextPolishErrorMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/outbound.ts",
+      "category": "exports",
+      "name": "InstructionTextTranscribedMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/outbound.ts",
+      "category": "exports",
+      "name": "SetAgentOptionsMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/outbound.ts",
+      "category": "exports",
+      "name": "SetBaseFileMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/outbound.ts",
+      "category": "exports",
+      "name": "SetContextFilesMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/outbound.ts",
+      "category": "exports",
+      "name": "SetCurrentFileMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/outbound.ts",
+      "category": "exports",
+      "name": "SetEditedFileMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/outbound.ts",
+      "category": "exports",
+      "name": "SetInputFilesMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/outbound.ts",
+      "category": "exports",
+      "name": "SetMediaFilesMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/outbound.ts",
+      "category": "exports",
+      "name": "SetModelOptionsMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/outbound.ts",
+      "category": "exports",
+      "name": "SetOnboardingFunnelMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/outbound.ts",
+      "category": "exports",
+      "name": "SetOpenedFilesMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/outbound.ts",
+      "category": "exports",
+      "name": "SetOutputFilesMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/outbound.ts",
+      "category": "exports",
+      "name": "SetRecentCommitsMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/outbound.ts",
+      "category": "exports",
+      "name": "SetSelectedAgentMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/outbound.ts",
+      "category": "exports",
+      "name": "SetSelectedCommitMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/outbound.ts",
+      "category": "exports",
+      "name": "ShowAgentConfigBannerMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/outbound.ts",
+      "category": "exports",
+      "name": "ShowApiKeyBannerMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/outbound.ts",
+      "category": "exports",
+      "name": "ShowDependencyBannerMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/outbound.ts",
+      "category": "exports",
+      "name": "ShowGettingStartedBannerMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/outbound.ts",
+      "category": "exports",
+      "name": "ShowLoginBannerMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/outbound.ts",
+      "category": "exports",
+      "name": "ShowOrchestratorBannerMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/mainView/state.ts",
+      "category": "types",
+      "name": "StringValueDetail"
+    },
+    {
+      "file": "src/shared/schemas/memoryViewMessages.ts",
+      "category": "exports",
+      "name": "MemoryDeleteMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/memoryViewMessages.ts",
+      "category": "exports",
+      "name": "MemoryEnabledMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/memoryViewMessages.ts",
+      "category": "exports",
+      "name": "MemoryPathMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/output.ts",
+      "category": "exports",
+      "name": "ExternalFileLocationSchema"
+    },
+    {
+      "file": "src/shared/schemas/output.ts",
+      "category": "exports",
+      "name": "FileLineageSchema"
+    },
+    {
+      "file": "src/shared/schemas/output.ts",
+      "category": "exports",
+      "name": "OutputFileSchema"
+    },
+    {
+      "file": "src/shared/schemas/output.ts",
+      "category": "exports",
+      "name": "RunStorageFileLocationSchema"
+    },
+    {
+      "file": "src/shared/schemas/output.ts",
+      "category": "exports",
+      "name": "WorkspaceFileLocationSchema"
+    },
+    {
+      "file": "src/shared/schemas/plan.ts",
+      "category": "exports",
+      "name": "UpdatePlanPayloadSchema"
+    },
+    {
+      "file": "src/shared/schemas/progressView/outbound.ts",
+      "category": "exports",
+      "name": "LogDeltaMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/progressView/outbound.ts",
+      "category": "exports",
+      "name": "ProgressDeleteAllMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/progressView/outbound.ts",
+      "category": "exports",
+      "name": "ProgressDeleteStreamMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/progressView/outbound.ts",
+      "category": "exports",
+      "name": "ProgressSetThemeMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/progressView/outbound.ts",
+      "category": "exports",
+      "name": "SetActiveStreamMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/progressView/outbound.ts",
+      "category": "exports",
+      "name": "SetFollowupOptionsMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/progressView/outbound.ts",
+      "category": "exports",
+      "name": "SetPlacementMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/progressView/outbound.ts",
+      "category": "exports",
+      "name": "SyncInquiryThreadsMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/progressView/outbound.ts",
+      "category": "exports",
+      "name": "UpdateBypassMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/progressView/outbound.ts",
+      "category": "exports",
+      "name": "UpdateCompileFailuresMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/progressView/outbound.ts",
+      "category": "exports",
+      "name": "UpdateConversationProgressMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/progressView/outbound.ts",
+      "category": "exports",
+      "name": "UpdateFilesMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/progressView/outbound.ts",
+      "category": "exports",
+      "name": "UpdateFollowUpTextMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/progressView/outbound.ts",
+      "category": "exports",
+      "name": "UpdateInquiryThreadMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/progressView/outbound.ts",
+      "category": "exports",
+      "name": "UpdateMissingOutputsMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/progressView/outbound.ts",
+      "category": "exports",
+      "name": "UpdateParentStreamMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/progressView/outbound.ts",
+      "category": "exports",
+      "name": "UpdatePermissionMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/progressView/outbound.ts",
+      "category": "exports",
+      "name": "UpdatePlanMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/progressView/outbound.ts",
+      "category": "exports",
+      "name": "UpdateProcessOutputMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/progressView/outbound.ts",
+      "category": "exports",
+      "name": "UpdateQueuedFollowUpsMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/progressView/outbound.ts",
+      "category": "exports",
+      "name": "UpdateRecordingMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/progressView/outbound.ts",
+      "category": "exports",
+      "name": "UpdateRoundStageMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/progressView/outbound.ts",
+      "category": "exports",
+      "name": "UpdateRunUsageMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/progressView/outbound.ts",
+      "category": "exports",
+      "name": "UpdateStreamBadgesMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/progressView/outbound.ts",
+      "category": "exports",
+      "name": "UpdateStreamDescriptionMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/progressView/outbound.ts",
+      "category": "exports",
+      "name": "UpdateStreamMetadataMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/progressView/outbound.ts",
+      "category": "exports",
+      "name": "UpdateStreamsMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/progressView/outbound.ts",
+      "category": "exports",
+      "name": "UpdateStreamStatusMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/progressView/outbound.ts",
+      "category": "exports",
+      "name": "UpdateTodosMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/runDescriptor.ts",
+      "category": "exports",
+      "name": "RunConfigReferenceSchema"
+    },
+    {
+      "file": "src/shared/schemas/settingsView/data.ts",
+      "category": "exports",
+      "name": "AgentSelectionItemSchema"
+    },
+    {
+      "file": "src/shared/schemas/settingsView/data.ts",
+      "category": "exports",
+      "name": "ChatGptAuthStatusSchema"
+    },
+    {
+      "file": "src/shared/schemas/settingsView/data.ts",
+      "category": "exports",
+      "name": "LatexdiffMathMarkupSchema"
+    },
+    {
+      "file": "src/shared/schemas/settingsView/data.ts",
+      "category": "exports",
+      "name": "LatexFormatterSchema"
+    },
+    {
+      "file": "src/shared/schemas/settingsView/data.ts",
+      "category": "exports",
+      "name": "LatexSettingsStatusSchema"
+    },
+    {
+      "file": "src/shared/schemas/settingsView/data.ts",
+      "category": "exports",
+      "name": "ModelSelectionItemSchema"
+    },
+    {
+      "file": "src/shared/schemas/settingsView/data.ts",
+      "category": "exports",
+      "name": "PRSubscriptionEntrySchema"
+    },
+    {
+      "file": "src/shared/schemas/settingsView/data.ts",
+      "category": "exports",
+      "name": "PRSubscriptionOwnerSchema"
+    },
+    {
+      "file": "src/shared/schemas/settingsView/data.ts",
+      "category": "exports",
+      "name": "SetTabMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/settingsView/data.ts",
+      "category": "exports",
+      "name": "SettingsViewOutboundMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/settingsView/data.ts",
+      "category": "exports",
+      "name": "SetUnsupportedCommandsMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/settingsView/data.ts",
+      "category": "exports",
+      "name": "ToolCategorySchema"
+    },
+    {
+      "file": "src/shared/schemas/settingsView/data.ts",
+      "category": "exports",
+      "name": "ToolDashboardItemSchema"
+    },
+    {
+      "file": "src/shared/schemas/settingsView/data.ts",
+      "category": "exports",
+      "name": "ToolInfoSchema"
+    },
+    {
+      "file": "src/shared/schemas/settingsView/data.ts",
+      "category": "exports",
+      "name": "ToolStatusSchema"
+    },
+    {
+      "file": "src/shared/schemas/settingsView/data.ts",
+      "category": "exports",
+      "name": "UpdateAgentModePresetsMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/settingsView/data.ts",
+      "category": "exports",
+      "name": "UpdateAgentSelectionMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/settingsView/data.ts",
+      "category": "exports",
+      "name": "UpdateApprovalSettingsMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/settingsView/data.ts",
+      "category": "exports",
+      "name": "UpdateChatGptAuthStatusMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/settingsView/data.ts",
+      "category": "exports",
+      "name": "UpdateCustomAgentDirMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/settingsView/data.ts",
+      "category": "exports",
+      "name": "UpdateDesktopCrashReportingMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/settingsView/data.ts",
+      "category": "exports",
+      "name": "UpdateGitAuthorSettingsMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/settingsView/data.ts",
+      "category": "exports",
+      "name": "UpdateGitHubTokenStatusMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/settingsView/data.ts",
+      "category": "exports",
+      "name": "UpdateGoalListMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/settingsView/data.ts",
+      "category": "exports",
+      "name": "UpdateInlineCriticismEnabledMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/settingsView/data.ts",
+      "category": "exports",
+      "name": "UpdateLatexConfigValuesMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/settingsView/data.ts",
+      "category": "exports",
+      "name": "UpdateLatexSettingsStatusMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/settingsView/data.ts",
+      "category": "exports",
+      "name": "UpdateModelSelectionMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/settingsView/data.ts",
+      "category": "exports",
+      "name": "UpdatePRSubscriptionsMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/settingsView/data.ts",
+      "category": "exports",
+      "name": "UpdateSuperYoloEnabledMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/settingsView/data.ts",
+      "category": "exports",
+      "name": "UpdateToolDashboardMessageSchema"
+    },
+    {
+      "file": "src/shared/schemas/settingsView/data.ts",
+      "category": "types",
+      "name": "SettingsViewOutboundMessage"
+    },
+    {
+      "file": "src/shared/schemas/settingsView/data.ts",
+      "category": "types",
+      "name": "SetUnsupportedCommandsMessage"
+    },
+    {
+      "file": "src/shared/schemas/stream.ts",
+      "category": "exports",
+      "name": "StreamTabInfoBaseSchema"
+    },
+    {
+      "file": "src/shared/schemas/stream.ts",
+      "category": "exports",
+      "name": "WorktreeCIStateSchema"
+    },
+    {
+      "file": "src/shared/schemas/stream.ts",
+      "category": "exports",
+      "name": "WorktreeInfoSchema"
+    },
+    {
+      "file": "src/shared/schemas/stream.ts",
+      "category": "exports",
+      "name": "WorktreePRInfoSchema"
+    },
+    {
+      "file": "src/shared/schemas/stream.ts",
+      "category": "exports",
+      "name": "WorktreePRStateSchema"
+    },
+    {
+      "file": "src/shared/schemas/subagentProgress.ts",
+      "category": "types",
+      "name": "OverviewProgressUpdate"
+    },
+    {
+      "file": "src/shared/schemas/subagentProgress.ts",
+      "category": "types",
+      "name": "PlanProgressUpdate"
+    },
+    {
+      "file": "src/shared/schemas/subagentProgress.ts",
+      "category": "types",
+      "name": "StartedProgressUpdate"
+    },
+    {
+      "file": "src/shared/schemas/subagentProgress.ts",
+      "category": "types",
+      "name": "TodoProgressUpdate"
+    },
+    {
+      "file": "src/shared/schemas/taskGroup.ts",
+      "category": "exports",
+      "name": "StageKindSchema"
+    },
+    {
+      "file": "src/shared/schemas/taskGroup.ts",
+      "category": "types",
+      "name": "GroupLogPayload"
+    },
+    {
+      "file": "src/shared/schemas/taskGroup.ts",
+      "category": "types",
+      "name": "StageKind"
+    },
+    {
+      "file": "src/shared/schemas/todo.ts",
+      "category": "exports",
+      "name": "TodoStatusSchema"
+    },
+    {
+      "file": "src/shared/schemas/todo.ts",
+      "category": "exports",
+      "name": "UpdateTodosPayloadSchema"
+    },
+    {
+      "file": "src/shared/schemas/toolResult.ts",
+      "category": "exports",
+      "name": "EditedFileRecordSchema"
+    },
+    {
+      "file": "src/shared/schemas/toolResult.ts",
+      "category": "exports",
+      "name": "EditRecordSchema"
+    },
+    {
+      "file": "src/shared/schemas/toolResult.ts",
+      "category": "exports",
+      "name": "ErrorToolResultSchema"
+    },
+    {
+      "file": "src/shared/schemas/toolResult.ts",
+      "category": "exports",
+      "name": "ExecutedToolResultSchema"
+    },
+    {
+      "file": "src/shared/schemas/toolResult.ts",
+      "category": "exports",
+      "name": "FileReferenceSchema"
+    },
+    {
+      "file": "src/shared/tools/toolKind.ts",
+      "category": "exports",
+      "name": "TOOL_DISPLAY_KIND"
+    },
+    {
+      "file": "src/telemetry/UsageLogService.ts",
+      "category": "types",
+      "name": "UsageLogFlushOutcome"
+    },
+    {
+      "file": "src/test-kernel/support/setupFakePlatform.ts",
+      "category": "files",
+      "name": "src/test-kernel/support/setupFakePlatform.ts"
+    },
+    {
+      "file": "src/tools/approval/index.ts",
+      "category": "types",
+      "name": "BashApprovalRequest"
+    },
+    {
+      "file": "src/tools/approval/index.ts",
+      "category": "types",
+      "name": "BashApprovalResult"
+    },
+    {
+      "file": "src/tools/approval/index.ts",
+      "category": "types",
+      "name": "WriteApprovedContentResult"
+    },
+    {
+      "file": "src/tools/approval/toolEditApproval.ts",
+      "category": "types",
+      "name": "ApprovedEditContent"
+    },
+    {
+      "file": "src/tools/github/checkRunsClient.ts",
+      "category": "types",
+      "name": "CheckRunsCachePage"
+    },
+    {
+      "file": "src/tools/goal/goalStore.ts",
+      "category": "types",
+      "name": "GoalStateChange"
+    },
+    {
+      "file": "src/tools/goal/index.ts",
+      "category": "types",
+      "name": "GoalStateChange"
+    },
+    {
+      "file": "src/tools/goal/index.ts",
+      "category": "types",
+      "name": "GoalStateChangeListener"
+    },
+    {
+      "file": "src/tools/lean/lspTypes.ts",
+      "category": "types",
+      "name": "LspMarkedString"
+    },
+    {
+      "file": "src/tools/lean/lspTypes.ts",
+      "category": "types",
+      "name": "LspMarkupContent"
+    },
+    {
+      "file": "src/tools/lean/lspTypes.ts",
+      "category": "types",
+      "name": "LspPosition"
+    },
+    {
+      "file": "src/tools/lean/lspTypes.ts",
+      "category": "types",
+      "name": "LspRange"
+    },
+    {
+      "file": "src/tools/setup/platform.ts",
+      "category": "types",
+      "name": "SetupAuthAdapter"
+    },
+    {
+      "file": "src/tools/setup/platform.ts",
+      "category": "types",
+      "name": "SetupCommandAdapter"
+    },
+    {
+      "file": "src/tools/setup/platform.ts",
+      "category": "types",
+      "name": "SetupConfigAdapter"
+    },
+    {
+      "file": "src/tools/setup/platform.ts",
+      "category": "types",
+      "name": "SetupExtensionAdapter"
+    },
+    {
+      "file": "src/tools/setup/platform.ts",
+      "category": "types",
+      "name": "SetupSecretsAdapter"
+    },
+    {
+      "file": "src/tools/setup/platform.ts",
+      "category": "types",
+      "name": "SetupTerminalAdapter"
+    },
+    {
+      "file": "src/transcript/index.ts",
+      "category": "exports",
+      "name": "unregisterFlushers"
+    },
+    {
+      "file": "src/transcript/index.ts",
+      "category": "types",
+      "name": "StreamLogStoreMode"
+    },
+    {
+      "file": "src/utils/files/taskRunStorage.ts",
+      "category": "types",
+      "name": "RunStorageEntryInspection"
+    }
+  ]
 }

--- a/scripts/check-dead-code-ratchet.d.mts
+++ b/scripts/check-dead-code-ratchet.d.mts
@@ -1,14 +1,14 @@
-export interface KnipCounts {
-  unusedFiles: number;
-  unusedExports: number;
-  unusedTypes: number;
-  duplicateExports: number;
+export type FindingCategory = 'files' | 'exports' | 'types' | 'duplicates';
+
+export interface KnipFinding {
+  file: string;
+  category: FindingCategory;
+  name: string;
 }
 
-export interface RatchetViolation {
-  metric: keyof KnipCounts;
-  currentCount: number;
-  baselineCount: number;
+export interface FindingsDiff {
+  newFindings: KnipFinding[];
+  resolvedFindings: KnipFinding[];
 }
 
 export interface KnipIssue {
@@ -19,11 +19,21 @@ export interface KnipIssue {
   duplicates?: readonly unknown[];
 }
 
-export function summarizeKnipIssues(issues: readonly KnipIssue[]): KnipCounts;
+export function extractFindings(issues: readonly KnipIssue[]): KnipFinding[];
 
-export function findRatchetViolations(
-  current: KnipCounts,
-  baseline: KnipCounts,
-): RatchetViolation[];
+export function findingKey(finding: KnipFinding): string;
+
+export function compareFindings(a: KnipFinding, b: KnipFinding): number;
+
+export function diffFindings(
+  current: readonly KnipFinding[],
+  baseline: readonly KnipFinding[],
+): FindingsDiff;
+
+export function countByCategory(
+  findings: readonly KnipFinding[],
+): Record<FindingCategory, number>;
 
 export function parseKnipIssues(stdout: string, stderr: string): KnipIssue[];
+
+export function readBaseline(rawJson: string): KnipFinding[];

--- a/scripts/check-dead-code-ratchet.mjs
+++ b/scripts/check-dead-code-ratchet.mjs
@@ -1,8 +1,18 @@
 #!/usr/bin/env node
-// Ratchets knip's dead-code counts: fails CI only when a PR *increases* the
-// number of unused files/exports/types or duplicate exports past the
-// checked-in baseline (config/ratchets/knip-baseline.json), rather than blocking on the
-// existing debt. Burning the baseline down is a separate, scheduled sweep.
+// Ratchets knip's dead-code findings: fails CI when a PR introduces a newly
+// unused file/export/type/duplicate-export group that isn't already recorded
+// in the checked-in baseline (config/ratchets/knip-baseline.json), rather
+// than blocking on the existing debt. Burning the baseline down is a
+// separate, scheduled sweep.
+//
+// Each finding is identified by (file, category, name) -- deliberately never
+// by line number, so an unrelated edit that shifts lines above a dead export
+// does not spuriously "resolve" it in the baseline. This mirrors the
+// by-identity ratchet pattern used elsewhere (see
+// src/test-kernel/architecture/subsystemEdgeRatchet.vitest.ts) rather than
+// this script's previous count-based threshold, which let any new unused
+// export land silently as long as some other unused export was deleted in
+// the same PR.
 
 import { spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
@@ -21,38 +31,75 @@ const baselinePath = path.join(
   'knip-baseline.json',
 );
 
-const METRICS = /** @type {const} */ ([
-  ['unusedFiles', 'files'],
-  ['unusedExports', 'exports'],
-  ['unusedTypes', 'types'],
-  ['duplicateExports', 'duplicates'],
-]);
+const EMPTY_COUNTS = { files: 0, exports: 0, types: 0, duplicates: 0 };
 
-export function summarizeKnipIssues(issues) {
-  const counts = {
-    unusedFiles: 0,
-    unusedExports: 0,
-    unusedTypes: 0,
-    duplicateExports: 0,
-  };
+// Flattens knip's per-issue-file shape (`{ file, files, exports, types,
+// duplicates }`) into one finding per unused symbol, keyed by (file,
+// category, name). A `duplicates` entry is a group of co-exported names that
+// alias the same declaration; the group's own identity is the sorted,
+// comma-joined member names, since knip doesn't give the group itself a name.
+export function extractFindings(issues) {
+  const findings = [];
   for (const issue of issues) {
-    for (const [countKey, issueKey] of METRICS) {
-      counts[countKey] += (issue[issueKey] ?? []).length;
+    for (const entry of issue.files ?? []) {
+      findings.push({ file: issue.file, category: 'files', name: entry.name });
+    }
+    for (const entry of issue.exports ?? []) {
+      findings.push({
+        file: issue.file,
+        category: 'exports',
+        name: entry.name,
+      });
+    }
+    for (const entry of issue.types ?? []) {
+      findings.push({ file: issue.file, category: 'types', name: entry.name });
+    }
+    for (const group of issue.duplicates ?? []) {
+      const name = group
+        .map((entry) => entry.name)
+        .sort()
+        .join(',');
+      findings.push({ file: issue.file, category: 'duplicates', name });
     }
   }
-  return counts;
+  return findings;
 }
 
-export function findRatchetViolations(current, baseline) {
-  const violations = [];
-  for (const [countKey] of METRICS) {
-    const currentCount = current[countKey];
-    const baselineCount = baseline[countKey];
-    if (currentCount > baselineCount) {
-      violations.push({ metric: countKey, currentCount, baselineCount });
-    }
+export function findingKey(finding) {
+  return `${finding.file} ${finding.category} ${finding.name}`;
+}
+
+export function compareFindings(a, b) {
+  return (
+    a.file.localeCompare(b.file) ||
+    a.category.localeCompare(b.category) ||
+    a.name.localeCompare(b.name)
+  );
+}
+
+// Diffs by identity, not by count: a finding is "new" only if no baseline
+// entry shares its (file, category, name), and a baseline entry is
+// "resolved" only if nothing in the current run matches it. Both lists come
+// back sorted for stable, readable CLI output.
+export function diffFindings(current, baseline) {
+  const baselineKeys = new Set(baseline.map(findingKey));
+  const currentKeys = new Set(current.map(findingKey));
+  return {
+    newFindings: current
+      .filter((finding) => !baselineKeys.has(findingKey(finding)))
+      .toSorted(compareFindings),
+    resolvedFindings: baseline
+      .filter((finding) => !currentKeys.has(findingKey(finding)))
+      .toSorted(compareFindings),
+  };
+}
+
+export function countByCategory(findings) {
+  const counts = { ...EMPTY_COUNTS };
+  for (const { category } of findings) {
+    counts[category] += 1;
   }
-  return violations;
+  return counts;
 }
 
 // Parses and validates the `--reporter json` stdout produced by `knip`.
@@ -94,40 +141,62 @@ function runKnip() {
     throw result.error;
   }
   // knip exits 1 whenever it finds any issue at all, which is expected here
-  // (the whole point is to count existing issues), so a non-zero status is
-  // only a real failure if it didn't produce parseable JSON.
+  // (the whole point is to enumerate existing issues), so a non-zero status
+  // is only a real failure if it didn't produce parseable JSON.
   return parseKnipIssues(result.stdout, result.stderr);
 }
 
+export function readBaseline(rawJson) {
+  const data = JSON.parse(rawJson);
+  if (!Array.isArray(data.findings)) {
+    throw new Error(
+      `${baselinePath} is missing a "findings" array; regenerate it (see scripts/check-dead-code-ratchet.mjs)`,
+    );
+  }
+  return data.findings;
+}
+
+function formatFinding(finding) {
+  return `[${finding.category}] ${finding.file}: ${finding.name}`;
+}
+
 function main() {
-  const baseline = JSON.parse(readFileSync(baselinePath, 'utf8'));
-  const current = summarizeKnipIssues(runKnip());
-  const violations = findRatchetViolations(current, baseline);
+  const baseline = readBaseline(readFileSync(baselinePath, 'utf8'));
+  const current = extractFindings(runKnip());
+  const { newFindings, resolvedFindings } = diffFindings(current, baseline);
+  const counts = countByCategory(current);
 
   console.log(
-    `knip dead-code counts: unusedFiles=${current.unusedFiles} (baseline ${baseline.unusedFiles}), ` +
-      `unusedExports=${current.unusedExports} (baseline ${baseline.unusedExports}), ` +
-      `unusedTypes=${current.unusedTypes} (baseline ${baseline.unusedTypes}), ` +
-      `duplicateExports=${current.duplicateExports} (baseline ${baseline.duplicateExports})`,
+    `knip dead-code findings: ${current.length} current (unusedFiles=${counts.files}, ` +
+      `unusedExports=${counts.exports}, unusedTypes=${counts.types}, ` +
+      `duplicateExports=${counts.duplicates}) vs ${baseline.length} baselined`,
   );
 
-  if (violations.length > 0) {
+  if (newFindings.length > 0) {
     console.error(
-      '\nDead-code ratchet failed: this PR increases knip counts above the baseline.',
+      `\nDead-code ratchet failed: this PR introduces ${newFindings.length} unused file(s)/export(s)/type(s) not in the baseline.`,
     );
-    for (const { metric, currentCount, baselineCount } of violations) {
-      console.error(
-        `  - ${metric}: ${currentCount} > baseline ${baselineCount}`,
-      );
+    for (const finding of newFindings) {
+      console.error(`  - ${formatFinding(finding)}`);
     }
     console.error(
       '\nRun `npm run check:dead-code` to see the newly introduced dead code, then either ' +
-        'remove it or, if the increase is intentional, update config/ratchets/knip-baseline.json in this PR.',
+        'remove it or, if the addition is intentional, add it to config/ratchets/knip-baseline.json in this PR ' +
+        '(keep the "findings" array sorted by file, then category, then name).',
     );
     process.exit(1);
   }
 
-  console.log('Dead-code ratchet OK: counts are at or below the baseline.');
+  console.log('Dead-code ratchet OK: no new unused files/exports/types found.');
+  if (resolvedFindings.length > 0) {
+    console.log(
+      `\n${resolvedFindings.length} baseline entries are no longer found (fixed!). Remove them from ` +
+        'config/ratchets/knip-baseline.json to shrink the baseline:',
+    );
+    for (const finding of resolvedFindings) {
+      console.log(`  - ${formatFinding(finding)}`);
+    }
+  }
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/src/test-kernel/scripts/CheckDeadCodeRatchet.vitest.mts
+++ b/src/test-kernel/scripts/CheckDeadCodeRatchet.vitest.mts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  findRatchetViolations,
+  compareFindings,
+  countByCategory,
+  diffFindings,
+  extractFindings,
+  findingKey,
   parseKnipIssues,
-  summarizeKnipIssues,
+  readBaseline,
 } from '../../../scripts/check-dead-code-ratchet.mjs';
+import type { KnipFinding } from '../../../scripts/check-dead-code-ratchet.d.mts';
 
 // Captured verbatim from a real `knip --reporter json` run against this repo
 // (knip 6.24.0, `--include files,exports,types,duplicates`) and trimmed to a
@@ -65,8 +70,8 @@ const REAL_KNIP_STDOUT = JSON.stringify({
   ],
 });
 
-describe('check-dead-code-ratchet summarizeKnipIssues', () => {
-  it('sums files/exports/types/duplicates across all knip issue entries', () => {
+describe('check-dead-code-ratchet extractFindings', () => {
+  it('flattens files/exports/types/duplicates into one finding per symbol, keyed by (file, category, name)', () => {
     const issues = [
       {
         file: 'a.ts',
@@ -91,42 +96,54 @@ describe('check-dead-code-ratchet summarizeKnipIssues', () => {
       },
     ];
 
-    expect(summarizeKnipIssues(issues)).toEqual({
-      unusedFiles: 1,
-      unusedExports: 2,
-      unusedTypes: 1,
-      duplicateExports: 1,
-    });
+    expect(extractFindings(issues)).toEqual([
+      { file: 'a.ts', category: 'files', name: 'a.ts' },
+      { file: 'b.ts', category: 'exports', name: 'foo' },
+      { file: 'b.ts', category: 'exports', name: 'bar' },
+      { file: 'b.ts', category: 'types', name: 'Baz' },
+      { file: 'c.ts', category: 'duplicates', name: 'x,y' },
+    ]);
   });
 
-  it('treats missing per-metric arrays as zero, matching knip omitting empty keys', () => {
-    const issues = [{ file: 'a.ts' }];
+  it('never keys a finding by line number, only by (file, category, name)', () => {
+    const issue = {
+      file: 'a.ts',
+      files: [],
+      exports: [{ name: 'foo', line: 10, col: 1, pos: 99 }],
+      types: [],
+      duplicates: [],
+    };
 
-    expect(summarizeKnipIssues(issues)).toEqual({
-      unusedFiles: 0,
-      unusedExports: 0,
-      unusedTypes: 0,
-      duplicateExports: 0,
-    });
+    expect(extractFindings([issue])).toEqual([
+      { file: 'a.ts', category: 'exports', name: 'foo' },
+    ]);
   });
 
-  it('returns all-zero counts for an empty issue list', () => {
-    expect(summarizeKnipIssues([])).toEqual({
-      unusedFiles: 0,
-      unusedExports: 0,
-      unusedTypes: 0,
-      duplicateExports: 0,
-    });
+  it('sorts a duplicate group by member name so key order does not depend on knip emission order', () => {
+    const groupA = { duplicates: [[{ name: 'b' }, { name: 'a' }]] };
+    const groupB = { duplicates: [[{ name: 'a' }, { name: 'b' }]] };
+
+    expect(findingKey(extractFindings([{ file: 'x.ts', ...groupA }])[0])).toBe(
+      findingKey(extractFindings([{ file: 'x.ts', ...groupB }])[0]),
+    );
   });
 
-  it('sums counts correctly against real captured knip --reporter json output', () => {
+  it('treats missing per-category arrays as no findings, matching knip omitting empty keys', () => {
+    expect(extractFindings([{ file: 'a.ts' }])).toEqual([]);
+  });
+
+  it('returns no findings for an empty issue list', () => {
+    expect(extractFindings([])).toEqual([]);
+  });
+
+  it('extracts one finding per symbol from real captured knip --reporter json output', () => {
     const { issues } = JSON.parse(REAL_KNIP_STDOUT);
 
-    expect(summarizeKnipIssues(issues)).toEqual({
-      unusedFiles: 2,
-      unusedExports: 3,
-      unusedTypes: 2,
-      duplicateExports: 1,
+    expect(countByCategory(extractFindings(issues))).toEqual({
+      files: 2,
+      exports: 3,
+      types: 2,
+      duplicates: 1,
     });
   });
 });
@@ -166,41 +183,68 @@ describe('check-dead-code-ratchet parseKnipIssues', () => {
   });
 });
 
-describe('check-dead-code-ratchet findRatchetViolations', () => {
-  const baseline = {
-    unusedFiles: 2,
-    unusedExports: 385,
-    unusedTypes: 299,
-    duplicateExports: 3,
-  };
+describe('check-dead-code-ratchet readBaseline', () => {
+  it('returns the findings array from a well-formed baseline document', () => {
+    const findings = [{ file: 'a.ts', category: 'exports', name: 'foo' }];
 
-  it('reports no violations when counts stay at or below the baseline', () => {
-    expect(findRatchetViolations(baseline, baseline)).toEqual([]);
-    expect(
-      findRatchetViolations(
-        {
-          unusedFiles: 0,
-          unusedExports: 0,
-          unusedTypes: 0,
-          duplicateExports: 0,
-        },
-        baseline,
-      ),
-    ).toEqual([]);
+    expect(readBaseline(JSON.stringify({ semantics: 'x', findings }))).toEqual(
+      findings,
+    );
   });
 
-  it('flags only the metrics that increase past the baseline', () => {
-    const current = { ...baseline, unusedExports: 386, unusedTypes: 300 };
+  it('throws when the baseline document has no findings array', () => {
+    expect(() => readBaseline(JSON.stringify({ semantics: 'x' }))).toThrow(
+      /missing a "findings" array/,
+    );
+  });
+});
 
-    expect(findRatchetViolations(current, baseline)).toEqual([
-      { metric: 'unusedExports', currentCount: 386, baselineCount: 385 },
-      { metric: 'unusedTypes', currentCount: 300, baselineCount: 299 },
-    ]);
+describe('check-dead-code-ratchet diffFindings', () => {
+  const baseline: KnipFinding[] = [
+    { file: 'a.ts', category: 'exports', name: 'foo' },
+    { file: 'b.ts', category: 'types', name: 'Bar' },
+  ];
+
+  it('reports no new or resolved findings when current matches baseline exactly', () => {
+    expect(diffFindings(baseline, baseline)).toEqual({
+      newFindings: [],
+      resolvedFindings: [],
+    });
   });
 
-  it('does not flag a decrease below the baseline', () => {
-    const current = { ...baseline, unusedFiles: 1 };
+  it('flags a finding present in current but absent from the baseline as new, by identity not count', () => {
+    // Same total count as baseline (2), but a different export replaced
+    // `foo` -- a pure count comparison would miss this entirely.
+    const current: KnipFinding[] = [
+      { file: 'a.ts', category: 'exports', name: 'newlyUnused' },
+      { file: 'b.ts', category: 'types', name: 'Bar' },
+    ];
 
-    expect(findRatchetViolations(current, baseline)).toEqual([]);
+    expect(diffFindings(current, baseline)).toEqual({
+      newFindings: [{ file: 'a.ts', category: 'exports', name: 'newlyUnused' }],
+      resolvedFindings: [{ file: 'a.ts', category: 'exports', name: 'foo' }],
+    });
+  });
+
+  it('reports a baseline entry as resolved (but does not fail) when it disappears from current', () => {
+    const current: KnipFinding[] = [
+      { file: 'b.ts', category: 'types', name: 'Bar' },
+    ];
+
+    expect(diffFindings(current, baseline)).toEqual({
+      newFindings: [],
+      resolvedFindings: [{ file: 'a.ts', category: 'exports', name: 'foo' }],
+    });
+  });
+
+  it('sorts both new and resolved findings by file, then category, then name', () => {
+    const current: KnipFinding[] = [
+      { file: 'z.ts', category: 'exports', name: 'z' },
+      { file: 'a.ts', category: 'exports', name: 'a' },
+    ];
+
+    expect(diffFindings(current, []).newFindings).toEqual(
+      [...current].sort(compareFindings),
+    );
   });
 });


### PR DESCRIPTION
## What

Converts `scripts/check-dead-code-ratchet.mjs` from a count-based ratchet to a per-symbol one, so no new unused export, file, type, or duplicate-export group can land silently.

Previously the ratchet summed knip's issue counts into four numbers (`unusedFiles`, `unusedExports`, `unusedTypes`, `duplicateExports`) and compared each against a numeric baseline in `config/ratchets/knip-baseline.json`. That let a PR introduce a brand-new unused export as long as the total count for that category did not exceed the baseline, for example by deleting one dead export elsewhere in the same PR while adding a different one.

The baseline is now an explicit, sorted list of findings, each identified by `(file, category, name)`:

```json
{
  "semantics": "...",
  "findings": [
    { "file": "src/foo.ts", "category": "exports", "name": "unusedThing" }
  ]
}
```

The check fails when the current knip run contains any finding not in that list, regardless of totals. Baseline entries that disappear (dead code that got cleaned up) are reported but do not fail the check, with a hint to shrink the baseline file. Identity is keyed by name, not line number, so an unrelated edit that shifts lines above a dead export can't spuriously mark it "resolved" and mask a real new one at the same line.

Regenerated `config/ratchets/knip-baseline.json` from a clean-tree `knip` run: 234 current findings (`unusedFiles=2, unusedExports=173, unusedTypes=56, duplicateExports=3`). The previous count baseline (689 total across the same four categories) was stale left over from before several recent dead-code cleanup PRs, so it had drifted well above the real number of findings and had lost most of its ratchet effect.

The script's CLI contract is unchanged: same file path, same `npm run check:dead-code-ratchet` invocation (no flags), same exit codes (0 = pass, 1 = fail), same CI workflow step in `.github/workflows/ci.yml`. `npm run check:dead-code` (plain knip, used for local investigation) is untouched. `knip.json` is untouched.

## Why

A recent dead-export sweep found the count-based ratchet's biggest gap: it only ratchets a category's total, so a single PR can trade a deleted dead export for a newly introduced one at zero net cost, and CI stays green. Per-symbol identity closes that gap, matching the by-identity ratchet pattern already used elsewhere in this repo (`src/test-kernel/architecture/subsystemEdgeRatchet.vitest.ts`).

## Verification

- `node scripts/check-dead-code-ratchet.mjs` on the clean tree: passes (`234 current ... vs 234 baselined`).
- `./node_modules/.bin/vitest run src/test-kernel/scripts/CheckDeadCodeRatchet.vitest.mts --config vitest.config.mjs`: 17/17 tests pass, covering `extractFindings`, `diffFindings`, `parseKnipIssues`, and `readBaseline`.
- A/B test: appended an unused export (`__scratchUnusedRatchetProbe123`) to `src/shared/schemas/goal.ts`, ran the script:
  ```
  knip dead-code findings: 235 current (unusedFiles=2, unusedExports=174, unusedTypes=56, duplicateExports=3) vs 234 baselined

  Dead-code ratchet failed: this PR introduces 1 unused file(s)/export(s)/type(s) not in the baseline.
    - [exports] src/shared/schemas/goal.ts: __scratchUnusedRatchetProbe123

  Run `npm run check:dead-code` to see the newly introduced dead code, then either remove it or, if the addition is intentional, add it to config/ratchets/knip-baseline.json in this PR (keep the "findings" array sorted by file, then category, then name).
  ```
  exit code 1, naming the exact symbol. Reverted with `git checkout -- src/shared/schemas/goal.ts`, re-ran: back to the clean-tree pass above.
- Also verified the "resolved" path directly on the baseline file: temporarily added an extra baseline entry with no matching current finding, ran the script, confirmed it exits 0 and prints "1 baseline entries are no longer found (fixed!)" naming that entry, then restored the regenerated baseline.
- `./node_modules/.bin/tsc -p tsconfig.test-kernel.json --noEmit`: no errors in the touched files.
- Confirmed `package.json` and `.github/workflows/ci.yml` have no diff (CLI contract unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI guardrail and baseline data only; no runtime product behavior. Stricter checks may require baseline updates when PRs add intentional unused exports.
> 
> **Overview**
> Replaces the **count-based** knip dead-code ratchet with a **per-symbol** baseline so CI fails when any new unused file, export, type, or duplicate-export group appears—not only when category totals rise.
> 
> `scripts/check-dead-code-ratchet.mjs` now flattens knip JSON into findings keyed by `(file, category, name)` (not line numbers), diffs current vs baseline with `diffFindings`, and exits **1** only on **new** findings. Cleaned-up debt is reported as **resolved** without failing. `config/ratchets/knip-baseline.json` switches from four numeric caps to a sorted `findings` list plus a `semantics` note; types and tests move from `summarizeKnipIssues` / `findRatchetViolations` to `extractFindings`, `readBaseline`, and related helpers.
> 
> **npm script and CI entrypoint are unchanged** (`check:dead-code-ratchet` still runs the same script path).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97e5f62512664cfee3a9986ce9068b67cb56dd2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->