### PR TITLE
chore(lint): enforce import/order and no-nested-ternary as errors

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -471,8 +471,9 @@ export default tseslint.config(
       eqeqeq: ['warn', 'always', { null: 'ignore' }],
       'no-throw-literal': 'warn',
       'local/prefer-alias-for-deep-relative-imports': 'error',
+      'no-nested-ternary': 'error',
       'import/order': [
-        'warn',
+        'error',
         {
           groups: [
             'builtin',

--- a/packages/cli/src/chat/tui/appLayout.ts
+++ b/packages/cli/src/chat/tui/appLayout.ts
@@ -175,11 +175,17 @@ export function allocateConversationBottomPanelRows({
   const sessionPanelContentRows = sessionCount + processCount;
   const minimumSessionRows = sessionCount > 1 ? 1 : 0;
   const availableTranscriptRows = Math.max(0, transcriptRows);
-  const panelTranscriptLimit = sessionListFocused
-    ? availableTranscriptRows
-    : availableTranscriptRows === 0
-      ? 0
-      : Math.max(minimumSessionRows, Math.floor(availableTranscriptRows / 2));
+  let panelTranscriptLimit: number;
+  if (sessionListFocused) {
+    panelTranscriptLimit = availableTranscriptRows;
+  } else if (availableTranscriptRows === 0) {
+    panelTranscriptLimit = 0;
+  } else {
+    panelTranscriptLimit = Math.max(
+      minimumSessionRows,
+      Math.floor(availableTranscriptRows / 2),
+    );
+  }
   const bottomPanelRows = Math.min(
     maxRows,
     sessionPanelContentRows + todosPlanContentRows,

--- a/packages/cli/src/chat/tui/input/BaseTextInput.tsx
+++ b/packages/cli/src/chat/tui/input/BaseTextInput.tsx
@@ -303,12 +303,15 @@ export function textInputDisplayWindow({
     cursorRow === undefined
       ? 0
       : clampCursor(sourceCursor - cursorRow.start, cursorRowTextLength);
-  const ellipsisCursorColumn =
-    clipped && startRow > 0 && displayCursorRow === 0
-      ? firstRowEllipsisRemovedPrefixCodeUnits > 0
+  let ellipsisCursorColumn: number;
+  if (clipped && startRow > 0 && displayCursorRow === 0) {
+    ellipsisCursorColumn =
+      firstRowEllipsisRemovedPrefixCodeUnits > 0
         ? Math.max(1, cursorColumn - firstRowEllipsisRemovedPrefixCodeUnits + 1)
-        : cursorColumn + 1
-      : cursorColumn;
+        : cursorColumn + 1;
+  } else {
+    ellipsisCursorColumn = cursorColumn;
+  }
   const cursorPrefixLength = rowTexts
     .slice(0, displayCursorRow)
     .reduce((sum, row) => sum + row.length + 1, 0);

--- a/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
+++ b/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
@@ -10,6 +10,7 @@ import {
   confirmCardFeedbackHints,
   confirmCardKeyAction,
   confirmCardKeyHintsForWidth,
+  type ConfirmCardHintAction,
   type ConfirmCardRejectionMode,
 } from './ConfirmCardState';
 import { CONFIRM_CARD_HORIZONTAL_DECORATION } from '../ui/theme';
@@ -149,17 +150,20 @@ export function ConfirmCard({
         extraActions: mappedExtraActions,
         columns,
       });
-  const hints = feedbackMode
-    ? confirmCardFeedbackHints()
-    : compact
-      ? (compactHintLayout?.inlineHints ?? [])
-      : confirmCardKeyHintsForWidth({
-          approveLabel,
-          rejectLabel,
-          alwaysAllowLabel: alwaysAllow?.label,
-          extraActions: mappedExtraActions,
-          maxColumns: Math.max(0, columns - CONFIRM_CARD_HORIZONTAL_DECORATION),
-        });
+  let hints: readonly ConfirmCardHintAction[];
+  if (feedbackMode) {
+    hints = confirmCardFeedbackHints();
+  } else if (compact) {
+    hints = compactHintLayout?.inlineHints ?? [];
+  } else {
+    hints = confirmCardKeyHintsForWidth({
+      approveLabel,
+      rejectLabel,
+      alwaysAllowLabel: alwaysAllow?.label,
+      extraActions: mappedExtraActions,
+      maxColumns: Math.max(0, columns - CONFIRM_CARD_HORIZONTAL_DECORATION),
+    });
+  }
   const stackedCompactHints = compactHintLayout?.stackedHints ?? hints;
   const stackCompactHints = compact && (compactHintLayout?.stack ?? false);
 

--- a/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
@@ -227,12 +227,14 @@ export function transcriptEntryLayout(
   const isInquiryContinuation =
     entry.role === 'user' && isInquiryContinuationText(entry.text);
   const marginTopRows = isInquiryContinuation ? 0 : base.marginTopRows;
-  const marginBottomRows =
-    entry.role === 'tool'
-      ? toolUseMarginBottomRows(entry.toolUse)
-      : isInquiryContinuation
-        ? 0
-        : base.marginBottomRows;
+  let marginBottomRows: number;
+  if (entry.role === 'tool') {
+    marginBottomRows = toolUseMarginBottomRows(entry.toolUse);
+  } else if (isInquiryContinuation) {
+    marginBottomRows = 0;
+  } else {
+    marginBottomRows = base.marginBottomRows;
+  }
   // The ctrl+t viewer is a full-width text projection with no Ink padding;
   // its lines still share role prefixes and wrapping rules with the layout.
   const columns = transcriptColumns(width, mode === 'viewer' ? 0 : inset);

--- a/packages/cli/src/chat/tui/state/taskDetailScroll.ts
+++ b/packages/cli/src/chat/tui/state/taskDetailScroll.ts
@@ -258,11 +258,14 @@ function taskDetailScrollStateAtOffset(
     maxOffset,
     followOffset,
   );
-  const anchor = followsTail
-    ? undefined
-    : context
-      ? taskDetailScrollAnchorFromOffset(context, clampedOffset)
-      : state.anchor;
+  let anchor: TaskDetailScrollAnchor | undefined;
+  if (followsTail) {
+    anchor = undefined;
+  } else if (context) {
+    anchor = taskDetailScrollAnchorFromOffset(context, clampedOffset);
+  } else {
+    anchor = state.anchor;
+  }
   return {
     executionId: state.executionId,
     followsTail,

--- a/packages/cli/src/commands/_helpers/dispatch.ts
+++ b/packages/cli/src/commands/_helpers/dispatch.ts
@@ -4,25 +4,25 @@
  * rendering. Formerly one file per concern under `dispatch/`.
  */
 import {
-  GLOBAL_ARGS,
-  GLOBAL_BOOL_FLAGS,
-  GLOBAL_VALUE_FLAGS,
-  HEADLESS_ONLY_GLOBAL_ARG_NAMES,
-} from './globalArgs';
-import {
   type ArgDef,
   type ArgsDef,
   type CommandDef,
   type CommandMeta,
   renderUsage,
 } from 'citty';
+import stripAnsi from 'strip-ansi';
+import { writeRawStderr, writeRawStdout } from '@cli/runtime/logSinks';
+import { readCliAmbientState } from '@cli/runtime/cliContext';
 import {
   editDistance,
   typoSuggestionThreshold,
 } from '@utils/text/editDistance';
-import stripAnsi from 'strip-ansi';
-import { writeRawStderr, writeRawStdout } from '@cli/runtime/logSinks';
-import { readCliAmbientState } from '@cli/runtime/cliContext';
+import {
+  GLOBAL_ARGS,
+  GLOBAL_BOOL_FLAGS,
+  GLOBAL_VALUE_FLAGS,
+  HEADLESS_ONLY_GLOBAL_ARG_NAMES,
+} from './globalArgs';
 
 // ---------------------------------------------------------------------------
 // cliError

--- a/packages/cli/src/onboarding/runOnboarding.tsx
+++ b/packages/cli/src/onboarding/runOnboarding.tsx
@@ -571,16 +571,21 @@ function RelayProviderStep(props: {
     if (input.toLowerCase() === 'd') props.onDeviceCode();
   });
 
+  let subtitle: string;
+  if (props.noBrowser) {
+    subtitle =
+      'No-browser mode: we print the sign-in URL instead of opening it.';
+  } else if (isLikelyRemoteSession()) {
+    subtitle =
+      'Remote session detected — press d for device-code sign-in (no callback port needed).';
+  } else {
+    subtitle = 'Choose a provider to sign in with:';
+  }
+
   return (
     <OnboardingFrame
       title="Sign in · Researcher Access"
-      subtitle={
-        props.noBrowser
-          ? 'No-browser mode: we print the sign-in URL instead of opening it.'
-          : isLikelyRemoteSession()
-            ? 'Remote session detected — press d for device-code sign-in (no callback port needed).'
-            : 'Choose a provider to sign in with:'
-      }
+      subtitle={subtitle}
       error={props.error}
       hints={[
         { key: '↑/↓', action: 'navigate' },

--- a/packages/cli/src/orchestration/runOrchestrationTui.tsx
+++ b/packages/cli/src/orchestration/runOrchestrationTui.tsx
@@ -277,45 +277,62 @@ export function OrchestrationApp(
   const modelStepSubtitle = isPendingTeam
     ? 'Runs the orchestrator agent and is the model it can choose for delegation.'
     : 'Model for the first message.';
-  const headerLines = modelAccessOpen
-    ? ['Model access', 'Choose how TeXRA should authenticate model calls.']
-    : resumeOpen
-      ? ['Resume', 'Choose a previous session to continue.']
-      : agentOpen
-        ? ['Agent', 'Choose one agent for this session.']
-        : teamOpen
-          ? ['Team', 'Choose a team for this session.']
-          : accountOpen
-            ? ['Account', 'Sign in, change account, or sign out.']
-            : pending
-              ? [
-                  `${modelStepTitle} · ${formatCliModelAccessRoute(props.apiMode)}`,
-                  modelStepSubtitle,
-                ]
-              : [`TeXRA v${props.version}`, ORCHESTRATION_LAUNCHER_SUBTITLE];
+  let headerLines: readonly string[];
+  if (modelAccessOpen) {
+    headerLines = [
+      'Model access',
+      'Choose how TeXRA should authenticate model calls.',
+    ];
+  } else if (resumeOpen) {
+    headerLines = ['Resume', 'Choose a previous session to continue.'];
+  } else if (agentOpen) {
+    headerLines = ['Agent', 'Choose one agent for this session.'];
+  } else if (teamOpen) {
+    headerLines = ['Team', 'Choose a team for this session.'];
+  } else if (accountOpen) {
+    headerLines = ['Account', 'Sign in, change account, or sign out.'];
+  } else if (pending) {
+    headerLines = [
+      `${modelStepTitle} · ${formatCliModelAccessRoute(props.apiMode)}`,
+      modelStepSubtitle,
+    ];
+  } else {
+    headerLines = [`TeXRA v${props.version}`, ORCHESTRATION_LAUNCHER_SUBTITLE];
+  }
+
+  let itemCount: number;
+  if (modelAccessOpen) {
+    itemCount = modelAccessItems.length;
+  } else if (resumeOpen) {
+    itemCount = props.resumeItems?.length ?? 0;
+  } else if (agentOpen) {
+    itemCount = agentItems.length;
+  } else if (teamOpen) {
+    itemCount = teamItems.length;
+  } else if (accountOpen) {
+    itemCount = props.accountItems?.length ?? 0;
+  } else if (pending) {
+    itemCount = modelItems.length;
+  } else {
+    itemCount = items.length;
+  }
+
+  let footerHints: readonly string[];
+  if (teamOpen) {
+    footerHints = orchestrationFooterHints(teamItems);
+  } else if (step.kind === 'launcher') {
+    footerHints = listFooterHints;
+  } else {
+    footerHints = [];
+  }
+
   const layout = orchestrationLauncherLayout({
     rows,
     columns,
-    itemCount: modelAccessOpen
-      ? modelAccessItems.length
-      : resumeOpen
-        ? (props.resumeItems?.length ?? 0)
-        : agentOpen
-          ? agentItems.length
-          : teamOpen
-            ? teamItems.length
-            : accountOpen
-              ? (props.accountItems?.length ?? 0)
-              : pending
-                ? modelItems.length
-                : items.length,
+    itemCount,
     headerLines,
     statusLines: step.kind === 'launcher' ? statusLines : [],
-    footerHints: teamOpen
-      ? orchestrationFooterHints(teamItems)
-      : step.kind === 'launcher'
-        ? listFooterHints
-        : [],
+    footerHints,
   });
 
   const finish = (action: CliOrchestrationAction): void => {
@@ -422,23 +439,30 @@ export function OrchestrationApp(
   }
 
   if (agentOpen || teamOpen || accountOpen) {
-    const picker = agentOpen
-      ? {
-          title: 'Agent',
-          subtitle: 'Choose one agent for this session.',
-          items: agentItems,
-        }
-      : teamOpen
-        ? {
-            title: 'Team',
-            subtitle: 'Choose a team for this session.',
-            items: teamItems,
-          }
-        : {
-            title: 'Account',
-            subtitle: 'Sign in, change account, or sign out.',
-            items: props.accountItems ?? [],
-          };
+    let picker: {
+      readonly title: string;
+      readonly subtitle: string;
+      readonly items: readonly CliOrchestrationItem[];
+    };
+    if (agentOpen) {
+      picker = {
+        title: 'Agent',
+        subtitle: 'Choose one agent for this session.',
+        items: agentItems,
+      };
+    } else if (teamOpen) {
+      picker = {
+        title: 'Team',
+        subtitle: 'Choose a team for this session.',
+        items: teamItems,
+      };
+    } else {
+      picker = {
+        title: 'Account',
+        subtitle: 'Sign in, change account, or sign out.',
+        items: props.accountItems ?? [],
+      };
+    }
     return (
       <Box flexDirection="column" paddingX={1}>
         <Text bold color="cyan">

--- a/packages/cli/src/runtime/gitOps.ts
+++ b/packages/cli/src/runtime/gitOps.ts
@@ -1,8 +1,7 @@
 // Thin wrappers over `git` and `gh` for the `install-github-action` command.
 // Every call captures output and never throws — callers branch on `success`.
-import { executeCommandSync } from '@utils/system/execUtils';
-
 import type { ExecResult } from '@shared/schemas/opResults';
+import { executeCommandSync } from '@utils/system/execUtils';
 
 export function git(cwd: string, ...args: readonly string[]): ExecResult {
   return executeCommandSync(['git', ...args], { cwd, quiet: true });

--- a/packages/cli/src/runtime/history/generatedFiles.ts
+++ b/packages/cli/src/runtime/history/generatedFiles.ts
@@ -65,11 +65,14 @@ export async function listWorkspaceToolFiles(
   persistedPaths: readonly string[],
   conversation: readonly unknown[] | null,
 ): Promise<CliHistoryFile[]> {
-  const filePaths = persistedPaths.length
-    ? persistedPaths
-    : conversation?.length
-      ? extractWorkspaceFileToolPaths(conversation)
-      : [];
+  let filePaths: readonly string[];
+  if (persistedPaths.length) {
+    filePaths = persistedPaths;
+  } else if (conversation?.length) {
+    filePaths = extractWorkspaceFileToolPaths(conversation);
+  } else {
+    filePaths = [];
+  }
   const workspaceFiles = await listExecutionWorkspaceFiles(config, filePaths);
   return workspaceFiles.map((file) => ({
     path: file.displayPath,

--- a/packages/cli/src/runtime/multiAgentPresets.ts
+++ b/packages/cli/src/runtime/multiAgentPresets.ts
@@ -9,12 +9,12 @@ import { teamHostedNamesForPreflight } from '@common/teams/TeamRoster';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { hasDelegationTool } from '@shared/constants/delegationTools';
 import { agentKeyOf } from '@shared/schemas/agent';
-import { formatResultCount, pluralize } from '@utils/text/stringUtils';
 import {
   AGENT_MODE_PRESETS,
   parseAgentModePresets,
   type AgentModePreset,
 } from '@shared/schemas/agentPresets';
+import { formatResultCount, pluralize } from '@utils/text/stringUtils';
 import { implicitDefaultToolUseAgents } from './defaultAgents';
 
 type CliMultiAgentPresetSource = 'built-in' | 'custom';

--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -318,16 +318,20 @@ function modelAccessItem(status: CliModelAccessStatus): CliOrchestrationItem {
 export function buildModelAccessItems(
   status: CliModelAccessStatus,
 ): CliModelAccessItem[] {
+  let chatGptDescription: string;
+  if (status.active === 'chatgpt') {
+    chatGptDescription = `On · ${status.chatGptAccountLabel ?? 'your account'}`;
+  } else if (status.chatGptSignedIn) {
+    chatGptDescription = `Off · ${status.chatGptAccountLabel ?? 'your account'}`;
+  } else {
+    chatGptDescription = 'Sign in with ChatGPT Plus/Pro/Team';
+  }
+
   return [
     {
       value: 'chatgpt',
       label: 'Prefer ChatGPT subscription',
-      description:
-        status.active === 'chatgpt'
-          ? `On · ${status.chatGptAccountLabel ?? 'your account'}`
-          : status.chatGptSignedIn
-            ? `Off · ${status.chatGptAccountLabel ?? 'your account'}`
-            : 'Sign in with ChatGPT Plus/Pro/Team',
+      description: chatGptDescription,
     },
     {
       value: 'included',

--- a/packages/extension/src/commands/housekeeping/cleanCommands.ts
+++ b/packages/extension/src/commands/housekeeping/cleanCommands.ts
@@ -2,7 +2,6 @@
 import * as vscode from 'vscode';
 
 // Local imports
-import type { FileOpResult } from '@shared/schemas/opResults';
 import { registerCommands } from '@commands/_shared/registerCommands';
 import {
   parseWithErrorDisplay,
@@ -14,6 +13,7 @@ import {
   runCleanRunDir,
 } from '@housekeeping';
 import * as logger from '@logger/logUtils';
+import type { FileOpResult } from '@shared/schemas/opResults';
 import {
   FileOpParamsSchema,
   fileOpConfigFields,

--- a/packages/extension/src/commands/housekeeping/packCommands.ts
+++ b/packages/extension/src/commands/housekeeping/packCommands.ts
@@ -3,7 +3,6 @@ import * as vscode from 'vscode';
 import { z } from 'zod';
 
 // Local imports
-import type { FileOpResult } from '@shared/schemas/opResults';
 import { registerCommands } from '@commands/_shared/registerCommands';
 import {
   parseWithErrorDisplay,
@@ -16,6 +15,7 @@ import {
   runPackRunDir,
 } from '@housekeeping';
 import * as logger from '@logger/logUtils';
+import type { FileOpResult } from '@shared/schemas/opResults';
 import { WorkspaceFS } from '@utils/files';
 import {
   FileOpParamsSchema,

--- a/packages/extension/src/common/webview/BaseViewMessageHandler.ts
+++ b/packages/extension/src/common/webview/BaseViewMessageHandler.ts
@@ -4,6 +4,7 @@ import { ZodError } from 'zod';
 
 // Local imports - common
 import * as logger from '@logger/logUtils';
+import { COMMON_COMMANDS } from '@shared/ipc';
 import {
   UnsupportedCommandError,
   type DispatcherFn,
@@ -11,7 +12,6 @@ import {
 } from '@shared/utils/dispatcher';
 
 // Local file imports
-import { COMMON_COMMANDS } from '@shared/ipc';
 
 type CommandMessage = { command: string };
 

--- a/packages/extension/src/progressView/frontend/eventHandlers.ts
+++ b/packages/extension/src/progressView/frontend/eventHandlers.ts
@@ -409,27 +409,29 @@ export function handlePermissionAction(
           initiatingProposalId: data.proposalId,
         });
       }
-      const message: ProgressViewInboundMessage =
-        decision.action === 'approve' || approveAllDelegatedWork
-          ? {
-              command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
-              proposalId: data.proposalId,
-              action: 'approve',
-              ...(decision.model ? { model: decision.model } : {}),
-              ...(decision.agent ? { agent: decision.agent } : {}),
-            }
-          : decision.action === 'reject'
-            ? {
-                command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
-                proposalId: data.proposalId,
-                action: 'reject',
-                ...(decision.feedback ? { feedback: decision.feedback } : {}),
-              }
-            : {
-                command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
-                proposalId: data.proposalId,
-                action: 'setup',
-              };
+      let message: ProgressViewInboundMessage;
+      if (decision.action === 'approve' || approveAllDelegatedWork) {
+        message = {
+          command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
+          proposalId: data.proposalId,
+          action: 'approve',
+          ...(decision.model ? { model: decision.model } : {}),
+          ...(decision.agent ? { agent: decision.agent } : {}),
+        };
+      } else if (decision.action === 'reject') {
+        message = {
+          command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
+          proposalId: data.proposalId,
+          action: 'reject',
+          ...(decision.feedback ? { feedback: decision.feedback } : {}),
+        };
+      } else {
+        message = {
+          command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
+          proposalId: data.proposalId,
+          action: 'setup',
+        };
+      }
       postPermissionMessage(message);
       // Optimistic removal — track resolved ID so late SHOW is a no-op
       const removed = removePrompt(

--- a/packages/extension/src/progressView/frontend/formatters/index.ts
+++ b/packages/extension/src/progressView/frontend/formatters/index.ts
@@ -89,12 +89,14 @@ function getToolUseRenderLabel(message: LogMessageData): string {
   // Reads the raw (unparsed) payload, so fall back to the legacy `tool` field
   // — older persisted streams stored the name there — to keep error labels
   // actionable. The main render path normalizes this via ToolUseLogSchema.
-  const toolName =
-    typeof data.toolName === 'string'
-      ? data.toolName
-      : typeof data.tool === 'string'
-        ? data.tool
-        : '';
+  let toolName: string;
+  if (typeof data.toolName === 'string') {
+    toolName = data.toolName;
+  } else if (typeof data.tool === 'string') {
+    toolName = data.tool;
+  } else {
+    toolName = '';
+  }
   return toolName.trim() ? `tool use (${toolName.trim()})` : 'tool use';
 }
 

--- a/packages/extension/src/progressView/frontend/formatters/progressBadgeFormatter.ts
+++ b/packages/extension/src/progressView/frontend/formatters/progressBadgeFormatter.ts
@@ -9,12 +9,14 @@ export function renderProgressBadgeContent(
   progress: ConversationProgress | undefined,
   roundStage: RoundStage | undefined,
 ): TemplateResult | typeof nothing {
-  const round =
-    roundStage !== undefined
-      ? roundStage.total !== undefined
-        ? `r${roundStage.index + 1}/${roundStage.total}`
-        : `r${roundStage.index + 1}`
-      : undefined;
+  let round: string | undefined;
+  if (roundStage === undefined) {
+    round = undefined;
+  } else if (roundStage.total !== undefined) {
+    round = `r${roundStage.index + 1}/${roundStage.total}`;
+  } else {
+    round = `r${roundStage.index + 1}`;
+  }
   const tools = progress?.toolCallCount ?? 0;
   if (!round && tools <= 0) return nothing;
   if (round && tools > 0) return html`${round}, ${tools} tool calls`;

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -299,6 +299,37 @@ export class LaTeXTab extends LitElement {
     const detectedPaths = installed ? this.getDetectedPaths(dep) : [];
     const installCmd = !installed ? this.getInstallCommand(dep) : null;
 
+    let actionSlot: TemplateResult | typeof nothing;
+    if (installed) {
+      actionSlot = nothing;
+    } else if (dep.actionEvent) {
+      actionSlot = html`
+        <wa-button
+          appearance="outlined"
+          variant="neutral"
+          size="small"
+          title="${dep.actionLabel ?? 'Install'}"
+          @click=${() =>
+            this.dispatchEvent(
+              new CustomEvent(dep.actionEvent!, {
+                bubbles: true,
+                composed: true,
+              }),
+            )}
+        >
+          ${waIcon('cloud-download', { slot: 'start' })}
+          ${dep.actionLabel ?? 'Install'}
+        </wa-button>
+      `;
+    } else {
+      actionSlot = html`<wa-tag
+        class="setting-badge"
+        variant="neutral"
+        size="small"
+        >Not found</wa-tag
+      >`;
+    }
+
     return html`
       <div class="dependency-card">
         <div class="dependency-row">
@@ -314,35 +345,7 @@ export class LaTeXTab extends LitElement {
               (p) => html`<div class="dependency-path">${p}</div>`,
             )}
           </div>
-          ${
-            installed
-              ? nothing
-              : dep.actionEvent
-                ? html`
-                    <wa-button
-                      appearance="outlined"
-                      variant="neutral"
-                      size="small"
-                      title="${dep.actionLabel ?? 'Install'}"
-                      @click=${() =>
-                        this.dispatchEvent(
-                          new CustomEvent(dep.actionEvent!, {
-                            bubbles: true,
-                            composed: true,
-                          }),
-                        )}
-                    >
-                      ${waIcon('cloud-download', { slot: 'start' })}
-                      ${dep.actionLabel ?? 'Install'}
-                    </wa-button>
-                  `
-                : html`<wa-tag
-                    class="setting-badge"
-                    variant="neutral"
-                    size="small"
-                    >Not found</wa-tag
-                  >`
-          }
+          ${actionSlot}
         </div>
         ${
           !installed && installCmd

--- a/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
@@ -344,11 +344,14 @@ export class ModelsTab extends LitElement {
     const unavailableCount = models.filter(
       (model) => model.availability === 'copilot-unavailable',
     ).length;
-    const status = consentModel
-      ? 'VS Code is ready to ask for your consent.'
-      : readyCount > 0
-        ? `${readyCount} ${pluralize(readyCount, 'Copilot model is', 'Copilot models are')} ready.`
-        : `${unavailableCount} ${pluralize(unavailableCount, 'Copilot model is', 'Copilot models are')} unavailable.`;
+    let status: string;
+    if (consentModel) {
+      status = 'VS Code is ready to ask for your consent.';
+    } else if (readyCount > 0) {
+      status = `${readyCount} ${pluralize(readyCount, 'Copilot model is', 'Copilot models are')} ready.`;
+    } else {
+      status = `${unavailableCount} ${pluralize(unavailableCount, 'Copilot model is', 'Copilot models are')} unavailable.`;
+    }
 
     return html`
       <section id="copilot-access" class="keyless-source">

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -136,11 +136,14 @@ export async function runReflectionFlow<C = unknown>(
 
   const latexMediaManager = new LatexMediaManager(logger, fileService);
 
-  const requestCount = Array.isArray(prompt.userRequest)
-    ? prompt.userRequest.length
-    : prompt.userRequest
-      ? 1
-      : 0;
+  let requestCount: number;
+  if (Array.isArray(prompt.userRequest)) {
+    requestCount = prompt.userRequest.length;
+  } else if (prompt.userRequest) {
+    requestCount = 1;
+  } else {
+    requestCount = 0;
+  }
   const totalRounds = Math.max(setting.rounds ?? 2, requestCount);
 
   const getOutputFileLocation =

--- a/src/agent/roster/AgentRosterController.ts
+++ b/src/agent/roster/AgentRosterController.ts
@@ -298,12 +298,14 @@ export class AgentRosterController<
   }
 
   private missingTeamId(selection: AgentRosterSelection): string | undefined {
-    const teamId =
-      selection.kind === 'inherit'
-        ? (this.getDefaultTeamId() ?? this.deps.fallbackTeamId)
-        : selection.kind === 'team'
-          ? selection.teamId
-          : undefined;
+    let teamId: string | null | undefined;
+    if (selection.kind === 'inherit') {
+      teamId = this.getDefaultTeamId() ?? this.deps.fallbackTeamId;
+    } else if (selection.kind === 'team') {
+      teamId = selection.teamId;
+    } else {
+      teamId = undefined;
+    }
     if (!teamId) return undefined;
     return allPresets(this.deps.getPresets?.() ?? []).some(
       (preset) => preset.id === teamId,

--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -113,11 +113,14 @@ export class StreamStatusMachine {
     const previousState = this.phases.get(stream);
     const from = previousState?.phase;
     const fromReservation = this.reservations.has(stream);
-    const tableFrom = fromReservation
-      ? to === STREAM_PHASE.RUNNING
-        ? undefined
-        : STREAM_PHASE.RUNNING
-      : from;
+    let tableFrom: StreamPhase | undefined;
+    if (!fromReservation) {
+      tableFrom = from;
+    } else if (to === STREAM_PHASE.RUNNING) {
+      tableFrom = undefined;
+    } else {
+      tableFrom = STREAM_PHASE.RUNNING;
+    }
     if (!canTransitionStreamPhase(tableFrom, to, cause)) return false;
 
     this.reservations.delete(stream);

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -295,12 +295,17 @@ export class ExecutionRegistry {
   ): boolean {
     if (this.handles.get(handle.executionId) !== handle) return false;
     const previous = this.streamStatus.get(handle.childStreamId);
-    const cause =
-      status === STREAM_PHASE.WAITING
-        ? 'wait'
-        : status === STREAM_PHASE.RUNNING && previous === STREAM_PHASE.WAITING
-          ? 'resume'
-          : 'lifecycle';
+    let cause: 'wait' | 'resume' | 'lifecycle';
+    if (status === STREAM_PHASE.WAITING) {
+      cause = 'wait';
+    } else if (
+      status === STREAM_PHASE.RUNNING &&
+      previous === STREAM_PHASE.WAITING
+    ) {
+      cause = 'resume';
+    } else {
+      cause = 'lifecycle';
+    }
     return this.streamStatus.transition(
       handle.childStreamId,
       status,

--- a/src/agent/storage/conversationFormat.ts
+++ b/src/agent/storage/conversationFormat.ts
@@ -118,14 +118,17 @@ function formatToolResultMarker(
   options: ConversationFormatOptions,
 ): string {
   const marker = options.truncationMarker ?? DEFAULT_TRUNCATION_MARKER;
-  const inner = Array.isArray(content)
-    ? content
-        .map((block) => formatConversationBlock(block, options))
-        .join('\n')
-        .trim()
-    : typeof content === 'string'
-      ? content
-      : stringifyConversationValue(content);
+  let inner: string;
+  if (Array.isArray(content)) {
+    inner = content
+      .map((block) => formatConversationBlock(block, options))
+      .join('\n')
+      .trim();
+  } else if (typeof content === 'string') {
+    inner = content;
+  } else {
+    inner = stringifyConversationValue(content);
+  }
   return `[tool_result: ${truncate(inner, options.toolBlockLimit, marker)}]`;
 }
 

--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -416,11 +416,16 @@ export class ProgressFactApplier {
   }
 
   public handleClearMissingOutputs(payload: ClearMissingOutputsPayload): void {
-    const targets: StreamTabId[] = payload.streamId
-      ? [payload.streamId]
-      : payload.streamConfig
-        ? this.state.snapshots.findWorkflowStreamsMatching(payload.streamConfig)
-        : [];
+    let targets: StreamTabId[];
+    if (payload.streamId) {
+      targets = [payload.streamId];
+    } else if (payload.streamConfig) {
+      targets = this.state.snapshots.findWorkflowStreamsMatching(
+        payload.streamConfig,
+      );
+    } else {
+      targets = [];
+    }
     for (const streamId of targets) {
       this.state.snapshots.clearMissingOutputs(streamId);
       this.sendIfActive(streamId, () =>

--- a/src/controllers/settingsView/LatexConfigPersistenceController.ts
+++ b/src/controllers/settingsView/LatexConfigPersistenceController.ts
@@ -1,4 +1,5 @@
 // Local imports - state keys
+import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 
 // Local imports - shared constants
@@ -8,7 +9,6 @@ import {
 } from '@shared/constants/latex';
 
 // Local imports - shared schemas
-import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import {
   LatexConfigValuesSchema,
   type LatexConfigValues,

--- a/src/controllers/settingsView/SettingsGoalController.ts
+++ b/src/controllers/settingsView/SettingsGoalController.ts
@@ -1,8 +1,8 @@
+import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import type {
   Goal,
   UpdateGoalListMessage,
 } from '@shared/schemas/settingsViewMessages';
-import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 
 export interface SettingsGoalControllerDeps {
   listGoals(): readonly Goal[];

--- a/src/controllers/settingsView/SettingsModelSelectionControllerFactory.ts
+++ b/src/controllers/settingsView/SettingsModelSelectionControllerFactory.ts
@@ -9,8 +9,8 @@ import {
   type SettingsModelSelectionControllerDeps,
 } from '@controllers/settingsView/SettingsModelSelectionController';
 import { DEFAULT_MODELS } from '@model/modelOptionsBasic';
-import { GlobalStateKey } from '@shared/state/stateKeys';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
+import { GlobalStateKey } from '@shared/state/stateKeys';
 import type { UpdateModelSelectionMessage } from '@shared/schemas/settingsViewMessages';
 
 import type { SettingsStatePorts } from '@shared/settingsView/types';

--- a/src/housekeeping/utils.ts
+++ b/src/housekeeping/utils.ts
@@ -5,13 +5,13 @@ import * as path from 'node:path';
 import { sync as globSync } from 'glob';
 
 // Local imports
+import { buildBetweenRoundDiffSuffix } from '@latex/latexdiff/diffFileNameManager';
+import * as logger from '@logger/logUtils';
 import {
   legacyWorkflowOutputStem,
   midEraWorkflowOutputStem,
   normalizeLegacyModel,
 } from '@shared/constants/legacyWorkflowOutput';
-import { buildBetweenRoundDiffSuffix } from '@latex/latexdiff/diffFileNameManager';
-import * as logger from '@logger/logUtils';
 import { getConfig } from '@utils/config';
 import { WorkspaceFS } from '@utils/files';
 

--- a/src/latex/latexdiff/diffOperations.ts
+++ b/src/latex/latexdiff/diffOperations.ts
@@ -8,11 +8,6 @@ import * as path from 'node:path';
 
 // Local imports
 import { platform } from '@platform/platform';
-import {
-  legacyWorkflowOutputRoundRegex,
-  midEraWorkflowOutputStem,
-} from '@shared/constants/legacyWorkflowOutput';
-import { parseWorkflowOutputRoundDir } from '@shared/constants/workflowOutput';
 import type { MathMarkupOption } from '@latex/latexdiff/mathMarkup';
 import * as logger from '@logger/logUtils';
 import {
@@ -21,6 +16,11 @@ import {
   RoundKeySchema,
 } from '@shared/schemas';
 import type { OutputFileInfo, RoundIndexed } from '@shared/schemas';
+import { parseWorkflowOutputRoundDir } from '@shared/constants/workflowOutput';
+import {
+  legacyWorkflowOutputRoundRegex,
+  midEraWorkflowOutputStem,
+} from '@shared/constants/legacyWorkflowOutput';
 import {
   WorkspaceFS,
   FlexibleFS,

--- a/src/shared/schemas/errors.ts
+++ b/src/shared/schemas/errors.ts
@@ -93,14 +93,16 @@ function normalizeLegacyExhaustionFlags(value: unknown): unknown {
     isChatGptSubscriptionLimited,
     ...rest
   } = data;
-  const exhaustionReason: ExhaustionReason | undefined =
-    isChatGptSubscriptionLimited === true
-      ? 'chatgpt-subscription'
-      : isUpstreamCreditDepleted === true
-        ? 'upstream-credit'
-        : isCredentialExhausted === true
-          ? 'relay-limit'
-          : undefined;
+  let exhaustionReason: ExhaustionReason | undefined;
+  if (isChatGptSubscriptionLimited === true) {
+    exhaustionReason = 'chatgpt-subscription';
+  } else if (isUpstreamCreditDepleted === true) {
+    exhaustionReason = 'upstream-credit';
+  } else if (isCredentialExhausted === true) {
+    exhaustionReason = 'relay-limit';
+  } else {
+    exhaustionReason = undefined;
+  }
   return exhaustionReason === undefined ? rest : { ...rest, exhaustionReason };
 }
 

--- a/src/shared/schemas/streamData.ts
+++ b/src/shared/schemas/streamData.ts
@@ -204,9 +204,17 @@ export function parseUsageData(raw: unknown): ParsedUsageData {
   const unparsedRuns = new Map<string, unknown>();
   if (raw === undefined) return { usage, unparsedRuns };
   if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    let rawKind: string;
+    if (raw === null) {
+      rawKind = 'null';
+    } else if (Array.isArray(raw)) {
+      rawKind = 'array';
+    } else {
+      rawKind = typeof raw;
+    }
     console.warn(
       `[streamData] usageStats.json is not a per-run object (got ` +
-        `${raw === null ? 'null' : Array.isArray(raw) ? 'array' : typeof raw}); ` +
+        `${rawKind}); ` +
         'ignoring for this read instead of silently zeroing usage.',
     );
     return { usage, unparsedRuns };

--- a/src/test-kernel/agent/AgentRegistryAlias.vitest.mts
+++ b/src/test-kernel/agent/AgentRegistryAlias.vitest.mts
@@ -12,7 +12,6 @@ import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { platform } from '@platform/platform';
 import { createFakePlatform } from '@test/support/FakePlatform';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import * as logger from '@logger/logUtils';
 import {
   computeAgentOptionsData,
   getAgent,
@@ -25,6 +24,7 @@ import {
   refresh,
   resolveAgentKey,
 } from '@agent/index/agentRegistry';
+import * as logger from '@logger/logUtils';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import type { AgentDirectoriesPort } from '@platform/interfaces';
 

--- a/src/test-kernel/agent/followUp/ChildStreamYoloInheritance.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamYoloInheritance.vitest.ts
@@ -5,6 +5,7 @@ import '@test/support/defaultSessionTestSetup';
 import { afterEach, describe, expect, it } from 'vitest';
 
 // Local imports
+import { currentSession } from '@agent/runtime/SessionHandle';
 import type { StreamTabId } from '@shared/schemas';
 import {
   cleanupAllApprovals,
@@ -17,7 +18,6 @@ import {
   setToolEditApprovalSessionBypass,
   toggleBashApprovalSessionBypass,
 } from '@tools/approval';
-import { currentSession } from '@agent/runtime/SessionHandle';
 
 import { createRecordingHost } from '../progressTestUtils';
 

--- a/src/test-kernel/cli/SubscribeStreamLogDispose.vitest.mts
+++ b/src/test-kernel/cli/SubscribeStreamLogDispose.vitest.mts
@@ -7,7 +7,6 @@ import '@test/support/defaultSessionTestSetup';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { StreamLogStore } from '@transcript';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { subscribeStreamLog } from '@cli/chat/tui/state/subscribeStreamLog';
 import { streams, resetCliState } from '@cli/chat/tui/state/cliState';
@@ -17,6 +16,7 @@ import {
   STREAM_LOG_ENTRY_TYPES,
   type StreamTabId,
 } from '@shared/schemas';
+import type { StreamLogStore } from '@transcript';
 
 const streamA = 'stream-a' as StreamTabId;
 const streamB = 'stream-b' as StreamTabId;

--- a/src/test-kernel/controllers/SettingsGoalController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsGoalController.vitest.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import { SettingsGoalController } from '@controllers/settingsView/SettingsGoalController';
-import type { Goal } from '@shared/schemas/settingsViewMessages';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
+import type { Goal } from '@shared/schemas/settingsViewMessages';
 
 const GOAL: Goal = {
   goalId: 'goal-1',

--- a/src/test-kernel/desktop/DesktopProtocolCallbacks.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProtocolCallbacks.vitest.mts
@@ -1,6 +1,7 @@
 // Suites for packages/desktop protocol callbacks (registration lifecycle +
 // callback behavior).
 
+import { strict as assert } from 'node:assert';
 import { describe, expect, it, vi } from 'vitest';
 import {
   createDesktopProtocolCallbackRouter,
@@ -9,7 +10,6 @@ import {
   installDesktopProtocolCallbackLifecycle,
   parseDesktopProtocolCallback,
 } from '@desktop/main/desktopProtocolCallbacks';
-import { strict as assert } from 'node:assert';
 
 // ---------------------------------------------------------------------------
 // DesktopProtocolCallbacks

--- a/src/test-kernel/schemas/SharedSchemas.vitest.ts
+++ b/src/test-kernel/schemas/SharedSchemas.vitest.ts
@@ -3,18 +3,18 @@
 // settings-view tab invariants).
 
 import { describe, expect, it } from 'vitest';
-import { planSummaryLine } from '@shared/schemas/workPlan';
-import {
-  parseClaudeAgentModel,
-  parseCodexApprovalPolicy,
-} from '@shared/schemas/agentCliSettings';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
-import { MainViewInboundMessageSchema } from '@shared/schemas/mainView';
 import {
   SETTINGS_TAB_PANEL_NAMES,
   WebFetchPayloadSchema,
   WebSearchPayloadSchema,
 } from '@shared/schemas';
+import { planSummaryLine } from '@shared/schemas/workPlan';
+import {
+  parseClaudeAgentModel,
+  parseCodexApprovalPolicy,
+} from '@shared/schemas/agentCliSettings';
+import { MainViewInboundMessageSchema } from '@shared/schemas/mainView';
 
 // ---------------------------------------------------------------------------
 // WorkPlan

--- a/src/test-kernel/shared/LegacyWorkflowOutput.vitest.ts
+++ b/src/test-kernel/shared/LegacyWorkflowOutput.vitest.ts
@@ -7,6 +7,7 @@ import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 // Local imports
+import { installPlatform } from '@test/support/setupPlatform';
 import {
   findFilesFromPatterns,
   resolveHousekeepingTargets,
@@ -18,7 +19,6 @@ import {
   midEraWorkflowOutputStem,
   normalizeLegacyModel,
 } from '@shared/constants/legacyWorkflowOutput';
-import { installPlatform } from '@test/support/setupPlatform';
 
 describe('filename-era workflow output grammar', () => {
   let workspacePath: string;

--- a/src/test-kernel/shared/SharedStreams.vitest.ts
+++ b/src/test-kernel/shared/SharedStreams.vitest.ts
@@ -2,7 +2,6 @@
 // status display, stream-meta reducer).
 
 import { describe, expect, it } from 'vitest';
-import { diffActiveChildren } from '@shared/streams/childActivityReducer';
 import {
   type ActiveChildInfo,
   AgentCategory,
@@ -10,6 +9,7 @@ import {
   STREAM_STATUS,
   STREAM_SUBSTATE,
 } from '@shared/schemas';
+import { diffActiveChildren } from '@shared/streams/childActivityReducer';
 import { buildStreamMetadata } from '@shared/streams/streamMetadata';
 import {
   formatStreamStatusLabel,

--- a/src/test-kernel/supabase/RelayRequestLimits.vitest.ts
+++ b/src/test-kernel/supabase/RelayRequestLimits.vitest.ts
@@ -584,22 +584,22 @@ describe('relay free-tier request limits', () => {
     const client = {
       async rpc(name: string, args: Record<string, unknown>) {
         calls.push({ name, args });
-        return {
-          data:
-            name === 'relay_request_gate'
-              ? {
-                  allowed: true,
-                  slotId: args.p_slot_id,
-                  activeRequests: 1,
-                  concurrencyLimit: 2,
-                  requestsThisMinute: 1,
-                  rateLimitPerMinute: 20,
-                }
-              : name === 'relay_request_refresh'
-                ? { refreshed: true }
-                : {},
-          error: null,
-        };
+        let data: Record<string, unknown>;
+        if (name === 'relay_request_gate') {
+          data = {
+            allowed: true,
+            slotId: args.p_slot_id,
+            activeRequests: 1,
+            concurrencyLimit: 2,
+            requestsThisMinute: 1,
+            rateLimitPerMinute: 20,
+          };
+        } else if (name === 'relay_request_refresh') {
+          data = { refreshed: true };
+        } else {
+          data = {};
+        }
+        return { data, error: null };
       },
     };
 
@@ -626,22 +626,22 @@ describe('relay free-tier request limits', () => {
   it('rejects refreshes when the request slot is already gone', async () => {
     const client = {
       async rpc(name: string, args: Record<string, unknown>) {
-        return {
-          data:
-            name === 'relay_request_gate'
-              ? {
-                  allowed: true,
-                  slotId: args.p_slot_id,
-                  activeRequests: 1,
-                  concurrencyLimit: 2,
-                  requestsThisMinute: 1,
-                  rateLimitPerMinute: 20,
-                }
-              : name === 'relay_request_refresh'
-                ? { refreshed: false }
-                : {},
-          error: null,
-        };
+        let data: Record<string, unknown>;
+        if (name === 'relay_request_gate') {
+          data = {
+            allowed: true,
+            slotId: args.p_slot_id,
+            activeRequests: 1,
+            concurrencyLimit: 2,
+            requestsThisMinute: 1,
+            rateLimitPerMinute: 20,
+          };
+        } else if (name === 'relay_request_refresh') {
+          data = { refreshed: false };
+        } else {
+          data = {};
+        }
+        return { data, error: null };
       },
     };
 
@@ -739,22 +739,22 @@ describe('relay free-tier request limits', () => {
       const client = {
         async rpc(name: string, args: Record<string, unknown>) {
           calls.push(name);
-          return {
-            data:
-              name === 'relay_request_gate'
-                ? {
-                    allowed: true,
-                    slotId: args.p_slot_id,
-                    activeRequests: 1,
-                    concurrencyLimit: 2,
-                    requestsThisMinute: 1,
-                    rateLimitPerMinute: 20,
-                  }
-                : name === 'relay_request_refresh'
-                  ? { refreshed: false }
-                  : {},
-            error: null,
-          };
+          let data: Record<string, unknown>;
+          if (name === 'relay_request_gate') {
+            data = {
+              allowed: true,
+              slotId: args.p_slot_id,
+              activeRequests: 1,
+              concurrencyLimit: 2,
+              requestsThisMinute: 1,
+              rateLimitPerMinute: 20,
+            };
+          } else if (name === 'relay_request_refresh') {
+            data = { refreshed: false };
+          } else {
+            data = {};
+          }
+          return { data, error: null };
         },
       };
       const slot = await acquireRelayRequestSlot(client, crypto.randomUUID(), {

--- a/src/test-kernel/support/tempDirPlatform.ts
+++ b/src/test-kernel/support/tempDirPlatform.ts
@@ -8,9 +8,8 @@ import { MemoryStateStore } from '@platform/defaults/memoryState';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
 import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
-import type { Platform } from '@platform/platform';
-
 import { createFakePlatform } from './FakePlatform';
+import type { Platform } from '@platform/platform';
 
 /**
  * Creates a node-backed `FakePlatform` rooted in a fresh temp directory

--- a/src/test-kernel/tools/PRPollingSourceAnnotationPages.vitest.ts
+++ b/src/test-kernel/tools/PRPollingSourceAnnotationPages.vitest.ts
@@ -3,8 +3,8 @@
 
 import { afterEach, describe, expect, it, type Mock, vi } from 'vitest';
 import type { GhCheckAnnotation, GhCheckRun } from '@tools/github/prTypes';
-import { mockGitHubClient } from '../support/githubClientMock';
 import { AnnotationFetchBudget } from '@tools/github/annotationFetchBudget';
+import { mockGitHubClient } from '../support/githubClientMock';
 
 // ---------------------------------------------------------------------------
 // PRPollingSourceAnnotationPages

--- a/src/test-kernel/tools/Wolfram.vitest.ts
+++ b/src/test-kernel/tools/Wolfram.vitest.ts
@@ -4,6 +4,7 @@ import '@test/support/defaultSessionTestSetup';
 // Suites for src/tools/wolfram (WolframTool approval gating +
 // wolframScriptUtils argument handling).
 
+import { strict as assert } from 'node:assert';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import type { StreamTabId } from '@shared/schemas';
@@ -17,11 +18,10 @@ import {
   executeWolframCode,
   executeWolframScriptFile,
 } from '@tools/wolfram/wolframScriptUtils';
-import { createRecordingHost } from '../agent/progressTestUtils';
-import { waitForRecordedEvent } from '../support/asyncTestUtils';
-import { strict as assert } from 'node:assert';
 import * as toolUtils from '@utils/system/toolUtils';
 import * as execUtils from '@utils/system/execUtils';
+import { createRecordingHost } from '../agent/progressTestUtils';
+import { waitForRecordedEvent } from '../support/asyncTestUtils';
 
 // ---------------------------------------------------------------------------
 // Wolfram

--- a/src/test-kernel/tools/lean/LeanTools.vitest.ts
+++ b/src/test-kernel/tools/lean/LeanTools.vitest.ts
@@ -2,20 +2,20 @@
 // resolution, external-tool status, lake command mutex). The LSP adapter,
 // server registry, and JSON-RPC connection keep their own suites.
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { extractHoverText } from '@tools/lean/leanTypes';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
-import { defaultResolveWorkspaceRoot } from '@tools/lean/direct/directLspAdapter';
+import { performance } from 'node:perf_hooks';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { findExternalToolDef } from '@tools/externalToolDefs';
+import { defaultResolveWorkspaceRoot } from '@tools/lean/direct/directLspAdapter';
 import {
   clearLeanServerRegistry,
   registerLeanServer,
   updateLeanServer,
 } from '@tools/lean/leanServerRegistry';
-import { performance } from 'node:perf_hooks';
+import { extractHoverText } from '@tools/lean/leanTypes';
 import { runLakeCommand } from '@tools/lean/direct/lakeCommands';
 
 // ---------------------------------------------------------------------------

--- a/src/test-kernel/utils/config/ConfigUtils.vitest.ts
+++ b/src/test-kernel/utils/config/ConfigUtils.vitest.ts
@@ -4,13 +4,13 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import { installPlatform } from '@test/support/setupPlatform';
 import * as logger from '@logger/logUtils';
+import { LATEX_CONFIG_DEFAULTS } from '@shared/constants/latex';
+import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
 import { getValidatedConfig } from '@utils/config/configUtils';
 import {
   getProviderEndpoint,
   getUseOpenRouter,
 } from '@utils/config/providerConfig';
-import { LATEX_CONFIG_DEFAULTS } from '@shared/constants/latex';
-import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
 import { readPlatformSetting } from '@utils/config/platformSettings';
 
 // ---------------------------------------------------------------------------

--- a/src/test-kernel/utils/files/FilesUtils.vitest.ts
+++ b/src/test-kernel/utils/files/FilesUtils.vitest.ts
@@ -2,6 +2,9 @@
 // relativeFS JSON, pasted images).
 
 import * as assert from 'node:assert';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { promises as fs } from 'node:fs';
 import {
   afterAll,
   beforeAll,
@@ -11,18 +14,15 @@ import {
   it,
   vi,
 } from 'vitest';
-import { WorkspaceFS } from '@utils/files/workspaceFS';
-import { getMimeType } from '@utils/files';
-import * as path from 'node:path';
-import { isTexFile } from '@common/files/fileTypeUtils';
-import { FlexibleFS } from '@utils/files/flexibleFS';
-import { pathToLocation } from '@utils/files/taskRunStorage';
-import { AbsoluteFS } from '@utils/files/absoluteFS';
-import * as os from 'node:os';
-import { promises as fs } from 'node:fs';
 import { z } from 'zod';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { setupPlatform } from '@test/support/setupPlatform';
+import { isTexFile } from '@common/files/fileTypeUtils';
+import { getMimeType } from '@utils/files';
+import { AbsoluteFS } from '@utils/files/absoluteFS';
+import { pathToLocation } from '@utils/files/taskRunStorage';
+import { FlexibleFS } from '@utils/files/flexibleFS';
+import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { RelativeFS } from '@utils/files/relativeFS';
 import { pastedImageFileName } from '@utils/files/pastedImageUtils';
 

--- a/src/test-kernel/utils/system/SystemUtils.vitest.ts
+++ b/src/test-kernel/utils/system/SystemUtils.vitest.ts
@@ -7,13 +7,13 @@ import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { join } from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
-import { afterEach, describe, expect, it } from 'vitest';
-import { setupPlatform } from '@test/support/setupPlatform';
-import { executeCommand, executeCommandSync } from '@utils/system/execUtils';
 import * as fs from 'node:fs/promises';
 import { mkdtemp, rm } from 'node:fs/promises';
+import { setupPlatform } from '@test/support/setupPlatform';
+import { afterEach, describe, expect, it } from 'vitest';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { createFakePlatform } from '@test/support/FakePlatform';
+import { executeCommand, executeCommandSync } from '@utils/system/execUtils';
 import { buildWorkspaceInfoBlock } from '@utils/system/workspaceInfo';
 import { BinaryResolverService } from '@utils/system/binaryResolver';
 

--- a/src/tools/github/githubSubscriptionTool.ts
+++ b/src/tools/github/githubSubscriptionTool.ts
@@ -224,13 +224,17 @@ async function execSubscribe(
     const wasIssuePath = !knownPR;
     const annotationLevelDescription =
       ANNOTATION_LEVEL_DESCRIPTIONS[minAnnotationLevel];
+    let summary: string;
+    if (!created) {
+      summary = `Already subscribed to ${prSlug}`;
+    } else if (wasIssuePath) {
+      summary = `Subscribed to ${prSlug} (was /issues/${target.issueNumber}; resolved to PR)`;
+    } else {
+      summary = `Subscribed to ${prSlug}`;
+    }
     return {
       status: 'executed',
-      summary: created
-        ? wasIssuePath
-          ? `Subscribed to ${prSlug} (was /issues/${target.issueNumber}; resolved to PR)`
-          : `Subscribed to ${prSlug}`
-        : `Already subscribed to ${prSlug}`,
+      summary,
       output: created
         ? `${prSlug} is a PR. ${prSubscriptionActivitySentence(annotationLevelDescription)} Auto-unsubscribes on close/merge.`
         : `Already subscribed to ${prSlug}. Inline check annotation filter is now ${annotationLevelDescription}.`,


### PR DESCRIPTION
## What

A recent 23-PR simplification campaign left nearly every touched area with
residue of import/order warnings and nested ternaries fixed by hand. This PR
promotes both rules to error level so the linter catches this going forward
instead of relying on manual cleanup passes, then cleans up the repo to match.

- `eslint.config.mjs`: `import/order` goes from `warn` to `error`; `no-nested-ternary`
  is added at `error` (it was not previously configured at all, so it was
  effectively off).
- Ran `eslint --fix` to mechanically reorder every import/order violation.
- Hand-rewrote every remaining nested ternary as an equivalent if/else chain
  (or a small precomputed local for JSX/mock-RPC call sites), preserving
  behavior exactly. No inline eslint-disable comments were needed.

Both rules apply uniformly across the single shared TS config block (source,
tests, and webview frontends all lint together today), so no new scoped
overrides were needed.

## Baseline counts (measured before promotion)

Measured by temporarily running eslint with both rules forced to error
(`--rule '{"import/order":"error","no-nested-ternary":"error"}'`) against the
same file set `npm run lint` covers:

- `import/order`: 44 violations across 26 files
- `no-nested-ternary`: 38 violations across 24 files (all in one shared config
  block, well under the ~30-file mega-diff guardrail, so hand rewrites were
  in scope for this PR)

After `eslint --fix`, all 44 `import/order` violations were auto-fixed (pure
import reordering, no logic changes). The 38 `no-nested-ternary` violations
were not auto-fixable and were hand-rewritten in the third commit.

## Commits

1. `chore(lint): promote import/order and no-nested-ternary to error` — config only.
2. `chore(lint): auto-fix import/order violations` — mechanical `eslint --fix`
   output, imports only, no logic changes.
3. `chore(lint): hand-rewrite nested ternaries as if/else chains` — behavior-identical
   rewrites across CLI TUI layout/orchestration, extension progress/settings
   frontends, agent runtime and storage, shared schemas, a GitHub tool, and one
   test mock.

## Verification

- `npm run lint` exits 0 with the new error levels.
- `npx tsc --noEmit` (root) exits 0.
- `npx tsc --noEmit -p tsconfig.test-kernel.json` exits 0.
- Scoped package typechecks all exit 0: `packages/cli/tsconfig.json`,
  `packages/extension/tsconfig.json`, `packages/desktop/tsconfig.main.json`,
  `packages/desktop/tsconfig.preload.json`, `packages/desktop/tsconfig.renderer.json`,
  `packages/trace-viewer/tsconfig.json`.
- `npx vitest run --config vitest.config.mjs` against every test-kernel suite
  that exercises a rewritten function (34 files, 735 tests, all passing),
  including `RelayRequestLimits.vitest.ts` (edited directly),
  `AgentRosterController.vitest.ts`, `StreamStatusService.vitest.ts`,
  `ExecutionRegistry.vitest.ts`, `ExecutionsConversationFormat.vitest.ts`,
  `SdkErrorUtils.vitest.mts`, `StreamDataUsage.vitest.ts`,
  `StreamDataRoundMaps.vitest.ts`, `GitHubSubscriptionTool.vitest.ts`,
  `FollowUpEventHandlers.vitest.ts`, `PermissionActionEventHandlers.vitest.ts`,
  `ConfirmCardRowsBudget.vitest.mts`, `ConfirmCardState.vitest.mts`,
  `AgentCreatorOrchestration.vitest.ts`, `Orchestration.vitest.mts`,
  `ConversationPane.vitest.mts`, `TuiStateAndFocus.vitest.mts`,
  `ChildControls.vitest.mts`, `ExternalInquiry.vitest.mts`, `InputBar.vitest.mts`,
  `StatusBar.vitest.mts`, `OnboardingState.vitest.mts`,
  `RunChatSignalOwnership.vitest.mts`, `SetupCommand.vitest.mts`,
  `OnboardingGate.vitest.mts`, `RepairRoundBadge.vitest.ts`,
  `SettingsReliabilityPlacement.vitest.ts`, `CopilotModelAccess.vitest.ts`,
  `stateSettings.vitest.ts`, `AgentWorkspaceWorkPlanState.vitest.ts`,
  `ReflectionFlowStateRecovery.vitest.ts`, `ResumeToolUseCancellation.vitest.ts`,
  `XmlOutputManager.vitest.ts`, `StreamContentSync.vitest.ts`.
- No test-kernel coverage exists for two of the rewritten functions
  (`listWorkspaceToolFiles` in `packages/cli/src/runtime/history/generatedFiles.ts`
  and `getToolUseRenderLabel` in
  `packages/extension/src/progressView/frontend/formatters/index.ts`); both
  are simple, behavior-preserving rewrites that pass strict typecheck.

## Notes

One incidental `unicorn/prefer-string-replace-all` autofix picked up by the
broad `eslint --fix` run (in `AgentCreatorToolCatalogParity.vitest.mts`, an
unrelated pre-existing warning) was reverted to keep this diff scoped to the
two promoted rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Style and lint enforcement with no intended behavior changes; risk is limited to accidental logic drift in hand-rewritten conditionals, which the PR description says was heavily tested.
> 
> **Overview**
> Tightens shared ESLint policy so **`import/order`** is an **error** (was warn) and **`no-nested-ternary`** is newly enforced at **error**, then brings the tree in line with those rules.
> 
> Most import changes are mechanical reordering (`eslint --fix`). Logic edits are **behavior-preserving** refactors: nested ternaries become `if`/`else` (or small locals) in CLI TUI/orchestration/onboarding, extension progress/settings UI, agent runtime, shared schemas, GitHub subscription tooling, and a few test RPC mocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e645d0434fbb52e31fe1aff7585e90fb2e7a9afe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->