### PR TITLE
feat(cli): animate the running status and approval-prompt titles

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -55,6 +55,7 @@ const UP = ESC + '[A';
 const DOWN = ESC + '[B';
 const PAGE_DOWN = ESC + '[6~';
 const ANSI_SGR_PATTERN = new RegExp(`${ESC}\\[[0-?]*[ -/]*m`, 'g');
+const RUNNING_STATUS_PATTERN = /◆ [-|\/\\] running/;
 const shortcutModifierLabel = process.platform === 'darwin' ? 'Esc' : 'Alt';
 const metaChordLabel = (key) =>
   `${shortcutModifierLabel}${shortcutModifierLabel === 'Esc' ? ' ' : '-'}${key}`;
@@ -1095,7 +1096,8 @@ const SCENARIOS = [
     name: 'uninterruptible-running-status-bar',
     env: { HARNESS_ENTRIES: '4', HARNESS_TODOS: '1' },
     frame: 'viewport',
-    expect: ['◆ running', 'Ctrl-C exit'],
+    expect: ['Ctrl-C exit'],
+    expectPatterns: [RUNNING_STATUS_PATTERN],
     unexpect: ['Ctrl-C stop'],
   },
   {
@@ -1105,8 +1107,9 @@ const SCENARIOS = [
     name: 'run-liveness-row',
     env: { HARNESS_ENTRIES: '4', HARNESS_TODOS: '1' },
     frame: 'viewport',
-    expect: ['✻ Working', '◆ running'],
+    expect: ['✻ Working'],
     expectPatterns: [
+      RUNNING_STATUS_PATTERN,
       /✻ Working\.{1,3}[ \t]+(?:4[2-9]s|5\ds|[1-9]\d*(?:m|h|d)(?: [1-9]\d*(?:s|m|h))?)/,
     ],
   },
@@ -2594,10 +2597,8 @@ const SCENARIOS = [
     bootExpect: 'Tab sessions',
     keys: ['\t', DOWN, '\r', '/status', '\r'],
     frame: 'viewport',
-    expect: [
-      'strategy is checking the harness-child-strategy details',
-      '◆ running',
-    ],
+    expect: ['strategy is checking the harness-child-strategy details'],
+    expectPatterns: [RUNNING_STATUS_PATTERN],
     unexpect: [
       'agent: harness-agent',
       'api: relay',
@@ -3039,7 +3040,8 @@ const SCENARIOS = [
     bootExpect: 'TeXRA',
     keys: [ESC + 's'], // Esc/Alt-s
     frame: 'viewport',
-    expect: ['◆ running 1m', 'personal'],
+    expect: ['personal'],
+    expectPatterns: [/◆ [-|\/\\] running 1m/],
     unexpect: ['◆running', 'personal3', '3 sub 1 proc'],
   },
   {
@@ -3218,7 +3220,8 @@ const SCENARIOS = [
       'Ctrl-C stop root',
     ],
     expectCollapsed: [STOPPED_SUBAGENT_INPUT_MESSAGE],
-    unexpect: ['◆ running', '2 sub 1 proc'],
+    unexpect: ['2 sub 1 proc'],
+    unexpectPatterns: [RUNNING_STATUS_PATTERN],
   },
   {
     name: 'focused-stopped-subagent-esc-s-picker',
@@ -3232,7 +3235,8 @@ const SCENARIOS = [
     keys: [ESC + 'p', 'k', ESC + 's', 'f', { input: ESC, delayMs: 40 }, 's'],
     frame: 'viewport',
     expect: ['Subagents', 'strategy', '1. strategy — stopped', 'root active'],
-    unexpect: ['Tasks and sub-workflows', '◆ running', '2 sub 1 proc'],
+    unexpect: ['Tasks and sub-workflows', '2 sub 1 proc'],
+    unexpectPatterns: [RUNNING_STATUS_PATTERN],
   },
   {
     name: 'focused-stopped-subagent-esc-tab-focus',
@@ -3286,9 +3290,9 @@ const SCENARIOS = [
     unexpect: [
       'The selected subagent is no longer accepting follow-ups.',
       'Harness received: can you still receive this?',
-      '◆ running',
       '2 sub 1 proc',
     ],
+    unexpectPatterns: [RUNNING_STATUS_PATTERN],
   },
   {
     name: 'empty-task-shortcut-hidden',
@@ -3343,7 +3347,7 @@ const SCENARIOS = [
       HARNESS_TODOS_COMPLETED: '1',
     },
     frame: 'viewport',
-    expect: ['◆ running'],
+    expectPatterns: [RUNNING_STATUS_PATTERN],
     unexpect: [
       'Split theorem into algebraic and analytic checks',
       'Coordinate a small math proof through nested CLI work.',
@@ -4289,6 +4293,9 @@ async function runScenarioWithResources(scenario, fakeClipboard, index) {
     (pattern) => !pattern.test(frame),
   );
   const present = (scenario.unexpect ?? []).filter((t) => frame.includes(t));
+  const presentPatterns = (scenario.unexpectPatterns ?? []).filter((pattern) =>
+    pattern.test(frame),
+  );
   const failures = [...checkpointFailures];
   if (!booted) failures.push('input prompt never rendered (boot timeout)');
   for (const t of missing)
@@ -4299,6 +4306,8 @@ async function runScenarioWithResources(scenario, fakeClipboard, index) {
     failures.push(`expected pattern missing: ${pattern.toString()}`);
   for (const t of present)
     failures.push(`unexpected text present: ${JSON.stringify(t)}`);
+  for (const pattern of presentPatterns)
+    failures.push(`unexpected pattern present: ${pattern.toString()}`);
   for (const check of scenario.maxOccurrences ?? []) {
     const actual = countOccurrences(frame, check.text);
     if (actual > check.max) {

--- a/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
+++ b/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
@@ -11,6 +11,7 @@ import {
   confirmCardKeyAction,
   confirmCardKeyHintsForWidth,
   type ConfirmCardHintAction,
+  confirmCardPulsedTitle,
   type ConfirmCardRejectionMode,
 } from './ConfirmCardState';
 import { CONFIRM_CARD_HORIZONTAL_DECORATION } from '../ui/theme';
@@ -18,6 +19,7 @@ import { BaseTextInput } from '../input/BaseTextInput';
 import { isEscapeInput } from '../input/inputKeys';
 import { KEY_HINT_SEPARATOR, KeyHints } from '../ui/KeyHints';
 import { BorderedPanel } from '../ui/BorderedPanel';
+import { useLiveNowMs } from '../state/useLiveNowMs';
 import type {
   ApprovalBypassKind,
   ApprovalDecision,
@@ -66,6 +68,11 @@ export function ConfirmCard({
   const [feedbackMode, setFeedbackMode] = useState(false);
   const [feedback, setFeedback] = useState('');
   const { columns } = useWindowSize();
+  // A pending approval always needs the user's eyes on it — pulse the title
+  // at 1 Hz off the shared clock (same pattern as LoadingIndicator/
+  // LivenessRow) instead of a static line, so it's harder to miss.
+  const now = useLiveNowMs(true);
+  const pulsedTitle = confirmCardPulsedTitle(now, title);
 
   function setFeedbackActive(active: boolean): void {
     setFeedbackMode(active);
@@ -143,7 +150,7 @@ export function ConfirmCard({
   const compactHintLayout = feedbackMode
     ? undefined
     : confirmCardCompactHintLayout({
-        title,
+        title: pulsedTitle,
         approveLabel,
         rejectLabel,
         alwaysAllowLabel: alwaysAllow?.label,
@@ -173,13 +180,13 @@ export function ConfirmCard({
         {stackCompactHints ? (
           <>
             <Text bold color={color} wrap="truncate-end">
-              {title}
+              {pulsedTitle}
             </Text>
             <KeyHints hints={stackedCompactHints} confirmCancel={false} />
           </>
         ) : (
           <Text bold color={color} wrap="truncate-end">
-            {title}
+            {pulsedTitle}
             <Text dimColor>{KEY_HINT_SEPARATOR}</Text>
             <Text dimColor>
               {hints.map((hint, index) => (
@@ -200,7 +207,7 @@ export function ConfirmCard({
     <BorderedPanel
       borderStyle={borderStyle}
       color={color}
-      title={title}
+      title={pulsedTitle}
       footer={<KeyHints hints={hints} confirmCancel={false} />}
     >
       {children}

--- a/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
+++ b/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
@@ -150,7 +150,7 @@ export function ConfirmCard({
   const compactHintLayout = feedbackMode
     ? undefined
     : confirmCardCompactHintLayout({
-        title: pulsedTitle,
+        title,
         approveLabel,
         rejectLabel,
         alwaysAllowLabel: alwaysAllow?.label,

--- a/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
+++ b/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
@@ -3,6 +3,8 @@ import { DELEGATION_APPROVAL_COPY } from '@shared/copy/delegationApproval';
 import { KEY_HINT_SEPARATOR, keyHintText } from '../ui/KeyHints';
 import { isEscapeInput } from '../input/inputKeys';
 import { textDisplayWidth } from '../render/terminalText';
+import { loadingFrameAt } from '../ui/LoadingIndicator';
+import { APPROVAL_PULSE_FRAMES } from '../ui/glyphs';
 
 export type ConfirmCardKeyAction =
   'approve' | 'reject' | 'approveAlways' | 'feedback' | 'ignore';
@@ -45,6 +47,16 @@ export interface ConfirmCardCompactHintLayout {
   readonly inlineHints: readonly ConfirmCardHintAction[];
   readonly stackedHints: readonly ConfirmCardHintAction[];
   readonly stack: boolean;
+}
+
+/**
+ * A pending approval always needs the user's eyes on it — prefix the title
+ * with a 1 Hz solid/hollow blink (see `ui/glyphs.APPROVAL_PULSE_FRAMES`) off
+ * the shared clock, same pattern as `LoadingIndicator`/`LivenessRow`, so the
+ * card is harder to miss than a static line.
+ */
+export function confirmCardPulsedTitle(nowMs: number, title: string): string {
+  return `${loadingFrameAt(nowMs, APPROVAL_PULSE_FRAMES)} ${title}`;
 }
 
 export function confirmCardKeyAction(

--- a/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
+++ b/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
@@ -167,12 +167,16 @@ export function confirmCardCompactHintLayout({
   alwaysAllowLabel,
   extraActions,
 }: ConfirmCardCompactHintLayoutOptions): ConfirmCardCompactHintLayout {
+  const pulsedTitleColumns = textDisplayWidth(confirmCardPulsedTitle(0, title));
   const inlineHints = confirmCardKeyHintsForWidth({
     approveLabel,
     rejectLabel,
     alwaysAllowLabel,
     extraActions,
-    maxColumns: Math.max(0, columns - title.length - KEY_HINT_SEPARATOR.length),
+    maxColumns: Math.max(
+      0,
+      columns - pulsedTitleColumns - KEY_HINT_SEPARATOR.length,
+    ),
   });
   const stackedHints = confirmCardKeyHintsForWidth({
     approveLabel,

--- a/packages/cli/src/chat/tui/modals/confirmCardRowsBudget.ts
+++ b/packages/cli/src/chat/tui/modals/confirmCardRowsBudget.ts
@@ -5,6 +5,7 @@ import {
   CONFIRM_CARD_HORIZONTAL_DECORATION,
 } from '../ui/theme';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
+import { confirmCardPulsedTitle } from './ConfirmCardState';
 
 /**
  * Rows budget for the scrollable content region of a ConfirmCard modal
@@ -51,7 +52,10 @@ export function confirmCardContentRowsBudget({
     columns - CONFIRM_CARD_HORIZONTAL_DECORATION,
     minContentWidth,
   );
-  const titleRows = wrapAnsiToWidth(title, titleWidth).split('\n').length;
+  const titleRows = wrapAnsiToWidth(
+    confirmCardPulsedTitle(0, title),
+    titleWidth,
+  ).split('\n').length;
   const fixedRows = titleRows + extraFixedRows;
 
   const spaciousRows = availableRows - spaciousFixedRows - fixedRows;

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -14,6 +14,7 @@ import {
 } from '../state/cliState';
 import { useLiveNowMs } from '../state/useLiveNowMs';
 import { useSignal } from '../state/useSignal';
+import { loadingFrameAt } from '../ui/LoadingIndicator';
 import { THINKING_MARKER } from '../ui/glyphs';
 import { EntryErrorBoundary } from './EntryErrorBoundary';
 import {
@@ -52,7 +53,7 @@ function LivenessRow({
   readonly thinking: boolean;
 }): React.JSX.Element {
   const now = useLiveNowMs(true, startedAtMs);
-  const dots = LIVENESS_DOTS[Math.floor(now / 1000) % LIVENESS_DOTS.length];
+  const dots = loadingFrameAt(now, LIVENESS_DOTS);
   const elapsed =
     startedAtMs === undefined
       ? ''

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -28,6 +28,7 @@ import {
 } from '../state/childExecutions';
 import { useLiveNowMs } from '../state/useLiveNowMs';
 import { COLOR_ERROR } from '../ui/colors';
+import { loadingFrameAt } from '../ui/LoadingIndicator';
 import { useSignal } from '../state/useSignal';
 import {
   buildStatusBarDisplay,
@@ -162,6 +163,7 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     status: statusSlice?.status,
     substate: statusSlice?.substate,
     elapsedMs: runStartedAt !== undefined ? now - runStartedAt : undefined,
+    runningFrame: runStartedAt !== undefined ? loadingFrameAt(now) : undefined,
     pendingExitHint,
     pendingExitResumeId,
     commandName: props.commandName,

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -74,6 +74,11 @@ export interface StatusBarDisplayInput {
    *  `running`, the bar shows a live `Ns` segment so a long token-less
    *  "thinking" turn still reads as alive. Omitted in tests/headless. */
   readonly elapsedMs?: number;
+  /** Current 1 Hz spin-cycle character (see `ui/LoadingIndicator`'s
+   *  `loadingFrameAt`) shown ahead of the status label while a turn is
+   *  active, so "running" reads as alive rather than a static word. Omitted
+   *  in tests/headless, same as `elapsedMs`. */
+  readonly runningFrame?: string;
   readonly pendingExitHint: boolean;
   readonly pendingExitResumeId: string | undefined;
   readonly commandName?: string;
@@ -741,12 +746,17 @@ export function buildStatusBarDisplay(
       });
     }
   } else {
+    const statusLabel = formatCliStatusLabel(
+      input.status,
+      input.substate,
+      input.isChildStream,
+    );
+    const spinPrefix =
+      isActivePhase(input.status) && input.runningFrame
+        ? `${input.runningFrame} `
+        : '';
     left.push({
-      text: formatCliStatusLabel(
-        input.status,
-        input.substate,
-        input.isChildStream,
-      ),
+      text: `${spinPrefix}${statusLabel}`,
       color: 'dim',
     });
     if (isActivePhase(input.status) && input.elapsedMs !== undefined) {

--- a/packages/cli/src/chat/tui/ui/LoadingIndicator.tsx
+++ b/packages/cli/src/chat/tui/ui/LoadingIndicator.tsx
@@ -13,7 +13,19 @@ import { useLiveNowMs } from '../state/useLiveNowMs';
 // Plain ASCII spin cycle (not a braille cli-spinners frame set) — ticking at
 // 1 Hz off the shared clock reads as a slow rotation, not a smooth spin, so a
 // simple, always-safe frame set fits better than porting the 80ms glyph set.
-const LOADING_FRAMES = ['|', '/', '-', '\\'] as const;
+// Exported so other 1 Hz "this is live" indicators (e.g. the status bar's
+// running segment) share the same frame set instead of each declaring its own.
+export const LOADING_FRAMES = ['|', '/', '-', '\\'] as const;
+
+/** Current frame for a 1 Hz shared-clock rotation through `frames`, keyed off
+ *  epoch ms from `useLiveNowMs` — the same computation `LoadingIndicator` and
+ *  `ConversationPane`'s `LivenessRow` each do inline. */
+export function loadingFrameAt(
+  nowMs: number,
+  frames: readonly string[] = LOADING_FRAMES,
+): string {
+  return frames[Math.floor(nowMs / 1000) % frames.length];
+}
 
 export interface LoadingIndicatorProps {
   readonly label: string;
@@ -23,7 +35,7 @@ export function LoadingIndicator(
   props: LoadingIndicatorProps,
 ): React.JSX.Element {
   const now = useLiveNowMs(true);
-  const frame = LOADING_FRAMES[Math.floor(now / 1000) % LOADING_FRAMES.length];
+  const frame = loadingFrameAt(now);
   return (
     <Box gap={1}>
       <Text dimColor>{frame}</Text>

--- a/packages/cli/src/chat/tui/ui/LoadingIndicator.tsx
+++ b/packages/cli/src/chat/tui/ui/LoadingIndicator.tsx
@@ -13,9 +13,9 @@ import { useLiveNowMs } from '../state/useLiveNowMs';
 // Plain ASCII spin cycle (not a braille cli-spinners frame set) — ticking at
 // 1 Hz off the shared clock reads as a slow rotation, not a smooth spin, so a
 // simple, always-safe frame set fits better than porting the 80ms glyph set.
-// Exported so other 1 Hz "this is live" indicators (e.g. the status bar's
-// running segment) share the same frame set instead of each declaring its own.
-export const LOADING_FRAMES = ['|', '/', '-', '\\'] as const;
+// Other 1 Hz "this is live" indicators share this frame set through
+// `loadingFrameAt` instead of each declaring its own.
+const LOADING_FRAMES = ['|', '/', '-', '\\'] as const;
 
 /** Current frame for a 1 Hz shared-clock rotation through `frames`, keyed off
  *  epoch ms from `useLiveNowMs` — the same computation `LoadingIndicator` and

--- a/packages/cli/src/chat/tui/ui/glyphs.ts
+++ b/packages/cli/src/chat/tui/ui/glyphs.ts
@@ -40,3 +40,9 @@ export const TOOL_OUTPUT_CORNER = '⎿';
 
 /** Marker for the liveness row shown while a run is active. */
 export const THINKING_MARKER = '✻';
+
+/** 1 Hz solid/hollow blink pair for "your input is needed" prompts (approval
+ *  modals) — deliberately distinct from STATUS_DOT (never animated) so the
+ *  two never read as the same signal. Pair with `ui/LoadingIndicator`'s
+ *  `loadingFrameAt` for the actual per-tick frame selection. */
+export const APPROVAL_PULSE_FRAMES = ['●', '○'] as const;

--- a/src/test-kernel/cli/AgentProposal.vitest.mts
+++ b/src/test-kernel/cli/AgentProposal.vitest.mts
@@ -66,4 +66,18 @@ describe('CLI agent proposal approval layout', () => {
     expect(visible).toHaveLength(budget);
     expect(visible.at(-1)?.kind).toBe('overflow');
   });
+
+  it('includes the pulse prefix when a dynamic proposal title reaches the width boundary', () => {
+    const title = `Spawn ${'a'.repeat(57)}?`;
+    expect(title).toHaveLength(64);
+
+    expect(
+      scrollableModalTextRowsBudget({
+        availableRows: 16,
+        columns: 68,
+        extraFixedRows: 3,
+        title,
+      }),
+    ).toBe(4);
+  });
 });

--- a/src/test-kernel/cli/ConfirmCardState.vitest.mts
+++ b/src/test-kernel/cli/ConfirmCardState.vitest.mts
@@ -13,16 +13,14 @@ import { DELEGATION_APPROVAL_COPY } from '@shared/copy/delegationApproval';
 describe('confirmCardPulsedTitle', () => {
   it('alternates a solid/hollow dot ahead of the title every second', () => {
     expect(confirmCardPulsedTitle(0, 'Run command?')).toBe('● Run command?');
-    expect(confirmCardPulsedTitle(1000, 'Run command?')).toBe(
-      '○ Run command?',
-    );
-    expect(confirmCardPulsedTitle(2000, 'Run command?')).toBe(
-      '● Run command?',
-    );
+    expect(confirmCardPulsedTitle(1000, 'Run command?')).toBe('○ Run command?');
+    expect(confirmCardPulsedTitle(2000, 'Run command?')).toBe('● Run command?');
   });
 
   it('only advances once per whole second', () => {
-    expect(confirmCardPulsedTitle(999, 'x')).toBe(confirmCardPulsedTitle(0, 'x'));
+    expect(confirmCardPulsedTitle(999, 'x')).toBe(
+      confirmCardPulsedTitle(0, 'x'),
+    );
   });
 });
 

--- a/src/test-kernel/cli/ConfirmCardState.vitest.mts
+++ b/src/test-kernel/cli/ConfirmCardState.vitest.mts
@@ -6,8 +6,25 @@ import {
   confirmCardKeyAction,
   confirmCardKeyHints,
   confirmCardKeyHintsForWidth,
+  confirmCardPulsedTitle,
 } from '@cli/chat/tui/modals/ConfirmCardState';
 import { DELEGATION_APPROVAL_COPY } from '@shared/copy/delegationApproval';
+
+describe('confirmCardPulsedTitle', () => {
+  it('alternates a solid/hollow dot ahead of the title every second', () => {
+    expect(confirmCardPulsedTitle(0, 'Run command?')).toBe('● Run command?');
+    expect(confirmCardPulsedTitle(1000, 'Run command?')).toBe(
+      '○ Run command?',
+    );
+    expect(confirmCardPulsedTitle(2000, 'Run command?')).toBe(
+      '● Run command?',
+    );
+  });
+
+  it('only advances once per whole second', () => {
+    expect(confirmCardPulsedTitle(999, 'x')).toBe(confirmCardPulsedTitle(0, 'x'));
+  });
+});
 
 describe('CLI confirm-card key handling', () => {
   const feedbackRejection = {

--- a/src/test-kernel/cli/EditApproval.vitest.mts
+++ b/src/test-kernel/cli/EditApproval.vitest.mts
@@ -21,6 +21,19 @@ describe('CLI edit approval layout', () => {
     ).toBe(6);
   });
 
+  it('includes the pulse prefix when a dynamic edit title reaches the width boundary', () => {
+    const title = `Apply edit to ${'x'.repeat(31)}?`;
+    expect(title).toHaveLength(46);
+
+    expect(
+      editApprovalDiffRowsBudget({
+        availableRows: 16,
+        columns: 50,
+        title,
+      }),
+    ).toBe(6);
+  });
+
   it('reserves feedback input rows while collecting a rejection note', () => {
     expect(
       editApprovalDiffRowsBudget({

--- a/src/test-kernel/cli/PlanApproval.vitest.mts
+++ b/src/test-kernel/cli/PlanApproval.vitest.mts
@@ -51,6 +51,42 @@ describe('CLI plan approval layout', () => {
     ).toBe(1);
   });
 
+  it('includes the pulse prefix at compact chrome boundaries', () => {
+    for (const columns of [49, 50]) {
+      expect(
+        planApprovalCompactBodyRowsBudget({
+          availableRows: 9,
+          columns,
+          goalEnabled: false,
+        }),
+      ).toBe(7);
+    }
+    expect(
+      planApprovalCompactBodyRowsBudget({
+        availableRows: 9,
+        columns: 51,
+        goalEnabled: false,
+      }),
+    ).toBe(8);
+
+    for (const columns of [67, 68]) {
+      expect(
+        planApprovalCompactBodyRowsBudget({
+          availableRows: 9,
+          columns,
+          goalEnabled: true,
+        }),
+      ).toBe(7);
+    }
+    expect(
+      planApprovalCompactBodyRowsBudget({
+        availableRows: 9,
+        columns: 69,
+        goalEnabled: true,
+      }),
+    ).toBe(8);
+  });
+
   it('hides approve-and-run when compact mode cannot show its scope notice', () => {
     expect(
       isPlanApprovalGoalActionVisible({

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -421,6 +421,24 @@ describe('CLI StatusBar display model', () => {
     expect(display.bindings).toContain('Alt-1..9 focus');
   });
 
+  it('prefixes the running label with the current spin frame', () => {
+    const display = buildStatusBarDisplay(
+      statusInput({ status: STREAM_PHASE.RUNNING, runningFrame: '/' }),
+    );
+
+    expect(display.left.map(statusBarSegmentText)).toContain('/ running');
+  });
+
+  it('omits the spin prefix outside active phases', () => {
+    const display = buildStatusBarDisplay(
+      statusInput({ status: STREAM_PHASE.WAITING, runningFrame: '/' }),
+    );
+
+    expect(
+      display.left.map(statusBarSegmentText).some((text) => text.includes('/')),
+    ).toBe(false);
+  });
+
   it.each(['relay', 'api-key'] as const)(
     'shows the raw registry context window for %s usage',
     (usageRoute) => {
@@ -436,7 +454,6 @@ describe('CLI StatusBar display model', () => {
           },
         }),
       );
-
       expect(display.left.map(statusBarSegmentText)).toContain(
         '187k/1.1M (18%)',
       );


### PR DESCRIPTION
## Summary
- Prefix active CLI status labels with the existing `|/-\` loading cycle at 1 Hz, using the shared `useLiveNowMs` clock and `loadingFrameAt`.
- Pulse shared y/n approval titles between solid and hollow dots at 1 Hz. This applies through `ConfirmCard` to bash, edit, plan, agent-proposal, and retry approvals; inquiry and free-form question modals are unchanged.
- Measure the pulse-prefixed title in shared compact-chrome and content-row geometry, including plan boundaries at 49-50 and 67-68 columns and dynamic edit/proposal titles.
- Make PTY running-status assertions frame-aware.
- Preserve current `main` model-access, subscription, and status-bar layout behavior without additional changes.

## Test plan
- [x] Focused modal/status Vitest suites: 9 files, 144 tests passed.
- [x] `corepack pnpm --filter @texra-ai/cli typecheck`
- [x] `npx tsc --noEmit -p tsconfig.test-kernel.json`
- [x] `npm run lint` (0 errors; one pre-existing warning in `AgentCreatorToolCatalogParity.vitest.mts`)
- [x] `npm run format` and `npm run format:check`
- [x] `npm run check:dead-code` and `npm run check:dead-code-ratchet` (no findings above the 234-item baseline)
- [x] Five affected PTY scenarios passed, including active-status frames and a stopped-subagent negative check.
- [ ] Three affected PTY scenarios reach and satisfy the new frame assertions but still fail unrelated current-main expectations: one selects `reviewer` where the scenario expects `strategy`; two render separated focus/status markers where the scenario expects contiguous `› ✓`. These assertions are not changed in this feature PR.