### PR TITLE
fix(agent): acknowledge follow-up consumption only after append succeeds

### DIFF
--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -200,7 +200,6 @@ export class ToolUseWaitNode<C> extends Node<
     // must not emit updateQueuedFollowUps via the consume callback. They
     // also don't need to be replayed in the chat log.
     if (!execRes.synthetic) {
-      onFollowUpConsumed?.();
       const instruction = userFollowUpInstruction(execRes.followUps);
       if (instruction && shared.stateSlices) {
         shared.stateSlices.userChannels.transient.INSTRUCTION = instruction;
@@ -233,6 +232,14 @@ export class ToolUseWaitNode<C> extends Node<
           );
         }
       }
+    }
+
+    // Acknowledge consumption only after every item actually landed in
+    // `shared.messages`: an append failure (e.g. corrupt media) must leave
+    // the batch unacknowledged so the resume wrapper restores it for replay
+    // instead of treating the lost input as consumed.
+    if (!execRes.synthetic) {
+      onFollowUpConsumed?.();
     }
 
     return FlowTransition.CONTINUE;

--- a/src/test-kernel/agent/followUp/ToolUseWaitNodeFollowUpTranscriptLog.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNodeFollowUpTranscriptLog.vitest.ts
@@ -65,6 +65,52 @@ describe('ToolUseWaitNode follow-up transcript logging (regression: #7508 patter
     );
   });
 
+  it('does not acknowledge consumption when the append throws', async () => {
+    // The resume wrapper restores an unacknowledged drained batch; firing
+    // onFollowUpConsumed before a failing append would mark the lost input
+    // as consumed and drop it instead of replaying it on the next resume.
+    const onFollowUpConsumed = vi.fn();
+    const services = buildServices({ onFollowUpConsumed });
+    (
+      services.modelHandler.createUserFollowUpMessages as ReturnType<
+        typeof vi.fn
+      >
+    ).mockRejectedValue(new Error('follow-up append failed'));
+    const node = new ToolUseWaitNode().setServices(services);
+    const shared: ToolUseRunShared = toolUseRunShared();
+    const runtimeHost = { emit: vi.fn() };
+    const execRes: WaitExecResult = {
+      kind: 'continue',
+      followUps: [{ text: 'Do the thing.', origin: 'user' }],
+    };
+
+    await expect(
+      withTestRunContext(runtimeHost, 'test-stream', () =>
+        node.post(shared, PREP_RES, execRes),
+      ),
+    ).rejects.toThrow('follow-up append failed');
+
+    expect(onFollowUpConsumed).not.toHaveBeenCalled();
+  });
+
+  it('acknowledges consumption after a successful append', async () => {
+    const onFollowUpConsumed = vi.fn();
+    const services = buildServices({ onFollowUpConsumed });
+    const node = new ToolUseWaitNode().setServices(services);
+    const shared: ToolUseRunShared = toolUseRunShared();
+    const runtimeHost = { emit: vi.fn() };
+    const execRes: WaitExecResult = {
+      kind: 'continue',
+      followUps: [{ text: 'Do the thing.', origin: 'user' }],
+    };
+
+    await withTestRunContext(runtimeHost, 'test-stream', () =>
+      node.post(shared, PREP_RES, execRes),
+    );
+
+    expect(onFollowUpConsumed).toHaveBeenCalledOnce();
+  });
+
   it('still logs exactly once per follow-up on the success path', async () => {
     const services = buildServices();
     const node = new ToolUseWaitNode().setServices(services);


### PR DESCRIPTION
Follow-up to #8616, closing the last gap in the consumption-keyed restore it introduced.

## Problem

`ToolUseWaitNode.post` fired `onFollowUpConsumed` **before** the `appendFollowUpAsUserMessage` loop. That loop can throw (corrupt/oversized media, provider validation error). Since #8616, the resume wrapper (`resumeQueuedToolUseSnapshot`) keys its drained-batch restore on that acknowledgement — so an append failure marked the batch consumed and the user's queued input was dropped instead of being re-enqueued for the next resume. Before #8616 the wrapper restored on any rejection, so this ordering was harmless; the consumption-keyed restore made it load-bearing.

## Fix

Fire the acknowledgement only after every item has actually landed in `shared.messages`. The transcript-row logging on the throw path (#7508 regression guard) is unchanged.

## Verification

- New tests: append-throw → `onFollowUpConsumed` not called; success path → called once.
- Full follow-up suites + resume wrapper suite green (149 tests), root + test-kernel typechecks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent resume/follow-up queue semantics where a wrong ordering loses user input; change is narrow and well-tested.
> 
> **Overview**
> **`ToolUseWaitNode.post`** now calls **`onFollowUpConsumed`** only after every follow-up has been appended to **`shared.messages`**, not at the start of resume handling.
> 
> Previously, acknowledging consumption before **`appendFollowUpAsUserMessage`** could throw (bad media, validation, etc.) while the resume path treated the batch as consumed, so queued user input was dropped instead of restored for replay. Instruction wiring still happens before the append loop; transcript logging on failure is unchanged.
> 
> Vitest coverage asserts no acknowledgement when append throws and exactly one call on success.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 208d291ae4fd9f4ba00bcb39504eb77471060b27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->