### PR TITLE
docs: rebalance CLAUDE.md and AGENTS.md, refresh stale facts

### DIFF
--- a/.claude/skills/code-review/references/review-checklist.md
+++ b/.claude/skills/code-review/references/review-checklist.md
@@ -1,6 +1,6 @@
 # TeXRA Review Checklist
 
-Targeted greps + concrete fixes. Pair with the design rules in `CLAUDE.md` (Zod, Flattening Abstraction Layers, Discouraged Factory Patterns, Render-Time Workarounds, Separation of Concerns) — don't restate those; consult them when the diff lands in their territory.
+Targeted greps + concrete fixes. Pair with the design rules in `CLAUDE.md` (Schemas, Abstraction discipline, UI anti-patterns, Separation of Concerns) and their full patterns in `AGENTS.md` (Zod v4 Schema Patterns, Flattening abstraction layers, Discouraged factory patterns, UI anti-patterns) — don't restate those; consult them when the diff lands in their territory.
 
 ## 1. Platform decoupling (highest-signal)
 
@@ -17,7 +17,7 @@ The full zone list lives in `CLAUDE.md` → "Separation of Concerns: VS Code Cou
 
 ## 2. Zod v4 schema correctness
 
-Design rules in `CLAUDE.md` → "Schema and Type Guidelines" / "Backward Compatibility with Zod" and `AGENTS.md` → "Zod v4 Schema Patterns". Greps for the diff:
+Design rules in `AGENTS.md` → "Zod v4 Schema Patterns" (including "Schemas as the single source of truth" and "Backward compatibility with legacy formats"; summary in `CLAUDE.md` → "Schemas (Zod v4)"). Greps for the diff:
 
 - **Tool input schemas using `.optional()`** instead of `.nullish()` (breaks DeepSeek/Kimi/etc. structured output). At use sites, check for `=== undefined` (should be `== null`).
 - **Verbose old-style types**: `.string().int()`, `.string().uuid()`, `.string().datetime()`, `.nativeEnum`, `.passthrough()` → `.int()`, `.uuid()`, `.iso.datetime()`, `.enum()`, `.looseObject()`.
@@ -45,7 +45,7 @@ Design rules in `CLAUDE.md` → "Schema and Type Guidelines" / "Backward Compati
 
 ## 5. Webview / render-time
 
-`CLAUDE.md` → "Render-Time Workarounds" already lists the anti-patterns. Greps for the diff:
+`AGENTS.md` → "UI anti-patterns" already lists the anti-patterns. Greps for the diff:
 
 - **`Date.now()` or synthetic IDs inside render functions** → move ID/timestamp creation to the producer.
 - **Lit components mutating shared state** → dispatch events; let the manager handle (`StreamTabs`, `LogList`, `OutputFilesManager`, `WebviewUpdater`, `UsageStatsManager`).
@@ -53,7 +53,7 @@ Design rules in `CLAUDE.md` → "Schema and Type Guidelines" / "Backward Compati
 - **Webview providers/handlers not extending `BaseViewContentProvider` / `BaseViewMessageHandler`** (`src/common/webview/`).
 - **String literals for webview commands** → constants in `src/common/webview/commands.ts`.
 - **New shared module path referenced without updating `localResourceRoots`** → 401 at runtime.
-- **The same action exposed from two UI surfaces** → one home per action. Flag an `*Events.<name>(` creator dispatched from 2+ components, the same config/state/message key edited in 2+ tabs or views, or multiple UI controls wired to the same command/effect. Secondary surfaces show **read-only status**, not a second control. Legit: global default vs per-item override; a command plus a single UI button for one stable action. See `CLAUDE.md` → "Duplicate UI Controls".
+- **The same action exposed from two UI surfaces** → one home per action. Flag an `*Events.<name>(` creator dispatched from 2+ components, the same config/state/message key edited in 2+ tabs or views, or multiple UI controls wired to the same command/effect. Secondary surfaces show **read-only status**, not a second control. Legit: global default vs per-item override; a command plus a single UI button for one stable action. See `AGENTS.md` → "UI anti-patterns" (Duplicate UI controls).
 
 ## 6. Error handling and logging
 
@@ -72,8 +72,8 @@ Design rules in `CLAUDE.md` → "Schema and Type Guidelines" / "Backward Compati
 - **`npm test` invocations** added anywhere (scripts, CI, docs) → must not exist; downloads VS Code test env.
 - **Type-sensitive changes without mention of `npm run typecheck` / `compile:safe`** → `compile:fast`/`package:fast`/`build:fast` skip type checks.
 - **Long relative imports** (`../../../../`) where a path alias exists.
-- **Re-export shims** for renamed/removed code, "// removed" comments, `_unused` placeholder vars — delete cleanly per `CLAUDE.md` Flattening rules.
-- **Dead exports** (declared, no consumer). `grep -r "exportedSymbol" src/`.
+- **Re-export shims** for renamed/removed code, "// removed" comments, `_unused` placeholder vars — delete cleanly per `AGENTS.md` "Flattening abstraction layers".
+- **Dead exports** (declared, no consumer): `npm run check:dead-code-ratchet` fails on any new one; for a single symbol, `rg "exportedSymbol" src packages`.
 
 ## 9. Comments
 
@@ -114,7 +114,7 @@ Standing rules from the 2026-07 tech-debt re-calibration, which found that a run
 - **Build implies delete in the same PR.** A new port/facade/projector/strategy/template-method merges only if it deletes the path it replaces in that same PR. Deferral is allowed only with a ledger row **and** a concrete removal-trigger issue that is a merge-blocker for the next stage.
 - **No leapfrogging a migration.** A staged migration may not merge stage N+1 scaffolding while stage N's deletion issue is still open.
 - **Net-positive-LOC "reductions" need a reason.** Reject a PR titled `refactor:`/`simplify:`/`consolidate`/`dedupe`/`extract` that grows LoC unless it (a) deletes an old path, (b) collapses to a genuine ≥2-caller helper, or (c) trades LoC for a `CLAUDE.md`-mandated type-safety win (e.g. a discriminated union with `assertNever`). The PR body must state the actual `git diff --stat origin/main` net LoC and justify any positive number.
-- **No trivial-identity or single-caller extractions.** Grep the caller count before approving any new shared helper — one caller is not DRY. Extends `CLAUDE.md` → "Discouraged Factory Patterns".
+- **No trivial-identity or single-caller extractions.** Grep the caller count before approving any new shared helper — one caller is not DRY. Extends `AGENTS.md` → "Discouraged factory patterns".
 - **Don't reward activity.** A program/migration that opens more follow-up issues than it retires pauses further building until its tail closes.
 
 ## 14. Fewer-elements rulings (2026-07-07)

--- a/.claude/workflows/passthrough-detect.mjs
+++ b/.claude/workflows/passthrough-detect.mjs
@@ -169,7 +169,7 @@ function buildPrompt(batch) {
     `Hunt for collapsible PASS-THROUGH / DELEGATION code in these ${files.length} files (batch "${name}"), focusing on code changed since the v0.38.5 tag (inspect with \`git diff v0.38.5..HEAD -- <file>\`, but you may flag a pass-through even if it predates the tag as long as it sits in one of these files):`,
     files.map((f) => `  - ${f}`).join('\n'),
     ``,
-    `## What counts as a pass-through (the repo's "Flattening Abstraction Layers" smell)`,
+    `## What counts as a pass-through (the repo's "Flattening abstraction layers" smell)`,
     `- method-passthrough: a class/object method whose body is essentially \`return this.inner.foo(...sameArgs)\` (or \`this.inner.foo(...)\` with no return value), adding no logic, validation, transform, or error handling.`,
     `- function-wrapper: a free function that only forwards to another function/helper with the same (or trivially reordered) args and returns its result. Includes a wrapper that only "creates state + runs a flow + returns its result".`,
     `- one-call-factory: a factory called from exactly ONE site that just constructs and returns an object/closure (the repo's discouraged-factory rule).`,

--- a/.github/prompts/claude-code-review-prompt.md
+++ b/.github/prompts/claude-code-review-prompt.md
@@ -20,7 +20,7 @@ configuration and storage correctness, and CI/toolchain hygiene. Do not run
 Conversely, flag pass-through layers this pull request newly introduces — wrapper
 functions that only forward to a single callee, single-use two-layer factories,
 trivial identity factories that just spread an object, and re-export shims — per
-CLAUDE.md's "Flattening Abstraction Layers" and "Discouraged Factory Patterns",
+AGENTS.md's "Flattening abstraction layers" and "Discouraged factory patterns",
 and recommend inlining them. Limit this to indirection the PR adds; respect
 load-bearing thin layers (dependency-injection seams, multi-caller DRY helpers,
 the prescribed PocketFlow `Node.exec() -> createFlow() -> flow.run()` shape),

--- a/.github/prompts/texra-code-review-prompt.md
+++ b/.github/prompts/texra-code-review-prompt.md
@@ -59,8 +59,8 @@ not pre-existing code, and respect the documented exceptions (variable-stride
 token consumers, queues appended mid-iteration, `charCodeAt` hash loops).
 
 A second convention worth enforcing on changed lines is the repository's
-anti-indirection rules in `CLAUDE.md` ("Flattening Abstraction Layers",
-"Discouraged Factory Patterns"). Flag pass-through layers this pull request
+anti-indirection rules in `AGENTS.md` ("Flattening abstraction layers",
+"Discouraged factory patterns"). Flag pass-through layers this pull request
 newly introduces — wrapper functions that only forward to a single callee,
 two-layer factories called from one place, trivial identity factories that just
 spread an object, and re-export shims — and recommend inlining them at the call

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ The extension host is bundled with esbuild and the webviews with Vite (`compile:
 ## Coding style
 
 - TypeScript code in repo-root `src/` and `packages/*/src/` targets ES2022.
-- Use the provided ESLint configuration (`eslint.config.mjs`) and Prettier settings (`.prettierrc`). Run `npm run format` before committing.
+- Use the provided ESLint configuration (`eslint.config.mjs`) and Prettier settings (`.prettierrc`). Run `npm run format` before committing. `import/order` and `no-nested-ternary` are enforced at error level.
 - Prefer `const` and `let` over `var`.
 - Group imports by source and prefix each block with a descriptive comment (e.g., `// Third-party imports`, `// Local imports - component`).
 - Use the path aliases defined in `tsconfig.json` (for example `@frontend/*`, `@common/*`, `@utils/*`) instead of long relative import chains.
@@ -78,7 +78,8 @@ The extension host is bundled with esbuild and the webviews with Vite (`compile:
 ### Directory organization
 
 This repository is a pnpm workspace. Repo-root `src/` contains shared core logic and host-neutral tests,
-`packages/extension/` contains the VS Code extension, and `packages/desktop/` contains the Electron shell.
+`packages/extension/` contains the VS Code extension, `packages/desktop/` the Electron shell, `packages/cli/`
+the `texra` terminal client, and `packages/trace-viewer/` the standalone trace-viewer web app.
 There is currently no `@texra/core` workspace package. Hosts import shared core through the repo-root path
 aliases until a future SDK surface is enforced with a build and import-boundary lint gate.
 
@@ -106,7 +107,7 @@ aliases until a future SDK surface is enforced with a build and import-boundary 
   - `utils/text/` - Text, string, and XML processing utilities — the single home for generic string helpers (validation, truncation, duration/token/percent formatting)
   - `utils/prompt/` - Prompt builder utilities
 - `packages/extension/src/commands/` - VS Code commands grouped by domain
-- `packages/extension/src/settingsView/` - Unified settings webview combining History, Memory, Models, Agents, Multi-Agent, LaTeX, and Tools tabs
+- `packages/extension/src/settingsView/` - Unified settings webview combining Memory, History, Models, Agents, Multi-Agent, Tools, AI Agents, Git, LaTeX, and Goal tabs
 - `packages/extension/src/progressView/` - Task tracking board webview
 - `packages/extension/src/webview/` - Main agent interaction webview
 - `packages/extension/resources/` - Packaged agents, tool-use agents, docs, templates, examples, and extension assets
@@ -125,6 +126,14 @@ aliases until a future SDK surface is enforced with a build and import-boundary 
 ### Zod v4 Schema Patterns
 
 This project uses Zod v4. Follow these idiomatic patterns:
+
+**Schemas as the single source of truth**
+
+- Define schemas first, then derive TypeScript types using `z.infer<typeof Schema>`
+- Use schema composition (`.extend()`, `.pick()`) instead of duplicating field definitions
+- Avoid `z.custom<T>()` when a proper schema exists; prefer `z.discriminatedUnion()` for union types
+- Co-locate types with schemas in the same file for maintainability
+- Add compile-time assertions (using `satisfies`) when schemas must stay synchronized with external types
 
 **Type definitions**
 
@@ -228,6 +237,31 @@ See: https://platform.openai.com/docs/guides/structured-outputs
 **Design for the model's first call**
 
 Any parameter with an obvious default should be optional with that default applied at dispatch time (`.nullish()` plus a default when the tool runs), not required. A required parameter that models routinely omit is a tool bug, not a model error. When a description string enumerates dispatch behavior (for example, "every command except X"), verify it against the actual dispatch table whenever either changes; the two can drift independently. Evidence: the memory tool once required `path` for `view`, so every fresh session rendered an error card until the model retried; the fix's own description string then misdescribed `rename` until review caught it.
+
+**Backward compatibility with legacy formats**
+
+When evolving persisted or wire data formats:
+
+- Use `z.union()` with `.transform()` to handle multiple formats in one schema
+- Put the new format first in the union (Zod tries members in order)
+- The legacy member transforms into the canonical structure
+- Handle legacy at the entry point using `safeParse`, not scattered fallbacks in consumers
+- One canonical format for all downstream code; never branch on format version
+
+```typescript
+// Canonical format (new)
+const NewFormatSchema = z.object({ revised: OutputFileInfoSchema, ... });
+
+// Legacy format transforms to canonical
+const LegacyFormatSchema = z.object({ baseLabel: z.string(), ... })
+  .transform((e): NewFormat => ({ /* map to canonical */ }));
+
+// Single entry point handles both
+const EntrySchema = z.union([NewFormatSchema, LegacyFormatSchema]);
+
+// Usage: always returns canonical format
+const result = EntrySchema.safeParse(raw);
+```
 
 ### ES2023+ Patterns
 
@@ -397,12 +431,11 @@ See `docs/pocketflow/` for full framework documentation.
 - **Dropdown Menus**: Should close when clicking outside, not just on toggle
 - **CSS Organization**: Keep per-component styles as TypeScript in each view's `frontend/` directory, shared tokens in `packages/extension/src/common/styles/common.css`
 
-### Source Organization
+### UI anti-patterns
 
-VS Code commands live under `packages/extension/src/commands/` and are grouped by domain. Key folders include
-`agent/` for agent lifecycle and merge commands, `housekeeping/` for cleanup and packaging, `latex/` for
-LaTeX document tasks, `settings/` for settings view commands, and `system/` for editor helpers along with
-XML/YAML utilities. This structure keeps each area focused and aligns with the design philosophy of deep modules.
+**Render-time workarounds.** Never compensate for data model problems at render time; renderers only transform and display. Signs of a broken data model: `Date.now()` or synthetic IDs generated during rendering, DOM queries to check whether data exists before rendering, deduplication logic comparing rendered content. Fix: store data once at the source with all metadata (timestamps, IDs). If a renderer needs to generate or deduplicate, the upstream code path is missing data.
+
+**Duplicate UI controls.** One home per user action. Do not surface the same action (a dispatched event, a config/state write, or a command) from two controls; competing controls confuse users and drift out of sync. Secondary surfaces show read-only status, never a second control. Legitimate exceptions: a global default versus a per-item override, or one action as a command plus a single UI button. Grep procedure and details: code-review checklist § 5.
 
 ## Design and refactoring
 
@@ -422,15 +455,87 @@ adding new code or refactoring existing modules:
 - When your refactoring include a large number of renames, use search tools to make sure you are not missing any files or paths where changes need to be made.
 - **Share instances via constructors**: When managers share state, pass the shared dependency through the constructor. This keeps state consistent and dependencies explicit.
 
+### Flattening abstraction layers
+
+When refactoring, eliminate unnecessary wrapper functions and indirection layers:
+
+**Anti-pattern (too many layers):**
+
+```
+Node.exec()
+  → wrapperFunction()
+    → coreFunction()
+      → createFlow()
+      → flow.run()
+```
+
+**Preferred (direct execution):**
+
+```
+Node.exec()
+  → createFlow()
+  → flow.run()
+```
+
+**Guidelines:**
+
+- Nodes should create and run flows directly in `exec()`, not delegate to wrapper functions
+- If a wrapper only creates state + runs flow + interprets results, inline it
+- Delete wrapper files entirely when they become unused (don't leave empty re-exports)
+- Update tests to use the underlying flow directly rather than through wrappers
+- Update imports to point to the source of truth (e.g., `CycleServices` not re-exporting files)
+
+### Discouraged factory patterns
+
+Avoid these patterns that add indirection without value:
+
+**Two-layer factories (called once):**
+
+```typescript
+// ❌ Anti-pattern: buildX only called from createX
+export function createContext(init) {
+  const services = buildServices(init);  // ← Extra layer
+  return { services, ... };
+}
+function buildServices(init) { ... }
+
+// ✅ Preferred: Inline if only called once
+export function createContext(init) {
+  const services = { ... };  // ← Direct
+  return { services, ... };
+}
+```
+
+**Trivial identity factories:**
+
+```typescript
+// ❌ Anti-pattern: Just spreads into new object
+function createOptions(options: Options): Options {
+  return { ...options };
+}
+
+// ✅ Preferred: Use object literal directly
+const options: Options = { ... };
+```
+
+**When factories ARE justified:**
+
+- Called from multiple locations (DRY)
+- Contain meaningful logic (validation, defaults, transforms)
+- Create class instances or complex objects
+- Need to capture closures with initialization context
+
+At review time this extends into the abstraction-cost guardrails (code-review checklist § 13): grep the caller count before approving any new shared helper (single-caller extractions are banned), and hold new ports/facades/template-methods to build-implies-delete-in-the-same-PR with net-LOC accounting.
+
 ## Code quality rules
 
-These rules were earned from a 2026-07 whole-repo simplification campaign, not derived top-down. Each one carries the evidence that motivated it, so a future reader can tell it was learned rather than theorized. They complement, and don't restate, the guardrails already documented in CLAUDE.md: "Discouraged Factory Patterns", "Render-Time Workarounds", "Flattening Abstraction Layers", the abstraction-cost guardrails, and the Zod-as-SSOT guidance above.
+These rules were earned from a 2026-07 whole-repo simplification campaign, not derived top-down. Each one carries the evidence that motivated it, so a future reader can tell it was learned rather than theorized. They complement, and don't restate, the guardrails documented in this file: "Flattening abstraction layers" and "Discouraged factory patterns" above, "UI anti-patterns", the abstraction-cost guardrails (code-review checklist § 13), and the Zod-as-SSOT guidance above.
 
-- **Exports are contracts; default to file-local.** A new export needs a consumer in the same PR. Across the 2026-07 campaign, five separate areas' main cleanup yield was deleting exports with zero outside consumers (20 in `src/tools` alone). Mechanical enforcement lives in the dead-export ratchet (being tightened in a separate PR); this is the principle behind it.
+- **Exports are contracts; default to file-local.** A new export needs a consumer in the same PR. Across the 2026-07 campaign, five separate areas' main cleanup yield was deleting exports with zero outside consumers (20 in `src/tools` alone). Mechanical enforcement lives in the dead-export ratchet (`npm run check:dead-code-ratchet`, per-symbol baseline in `config/ratchets/knip-baseline.json`; any unused export not in the baseline fails the check); this is the principle behind it.
 
 - **No convenience barrels.** A barrel/index re-export file exists only for a documented public surface (for example, the trace events SDK contract, which declares its surface in its own docstring). Everything else imports the file that defines the symbol directly — this includes model handlers (`src/agent/modelHandlers/`; see that directory's `README.md`), which have no barrel and no re-export shims. The campaign deleted dead barrels in `workflowScript/`, `storage/`, and `index/` that no caller actually used.
 
-- **Never hand out a shared mutable literal.** A module-level object that a function returns, or that crosses a module boundary, must be frozen (`as const` plus `Object.freeze`) or produced fresh by a factory that returns a new object each call; see CLAUDE.md's "Discouraged Factory Patterns" for when a factory is and isn't warranted. `Object.freeze` is shallow — for a literal with nested objects/arrays, or for a `Map`/`Set`, either deep-freeze it or use a factory, since a shallow freeze doesn't stop mutation of nested values or calls like `.set()`/`.add()`. A campaign consolidation once replaced fresh no-retry result literals with a single shared constant; the resulting aliasing behavior change was caught only by a follow-up factory rewrite and a `notStrictEqual` regression test.
+- **Never hand out a shared mutable literal.** A module-level object that a function returns, or that crosses a module boundary, must be frozen (`as const` plus `Object.freeze`) or produced fresh by a factory that returns a new object each call; see "Discouraged factory patterns" above for when a factory is and isn't warranted. `Object.freeze` is shallow — for a literal with nested objects/arrays, or for a `Map`/`Set`, either deep-freeze it or use a factory, since a shallow freeze doesn't stop mutation of nested values or calls like `.set()`/`.add()`. A campaign consolidation once replaced fresh no-retry result literals with a single shared constant; the resulting aliasing behavior change was caught only by a follow-up factory rewrite and a `notStrictEqual` regression test.
 
 - **Global registration requires a global consumer.** Register something globally (components, commands, providers) only when an external surface actually references it; consumers that are internal-only import locally instead. The docs theme once globally registered two components that no markdown page used.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,25 +40,19 @@ npm run format
 
 # Run the test suite (Vitest)
 npm test
+
+# Type check (builds don't; esbuild only strips types)
+npm run typecheck
+
+# Dead-export gate (fails on any unused export not in config/ratchets/knip-baseline.json)
+npm run check:dead-code-ratchet
 ```
 
 ### Builds and Type Checking
 
-All builds use esbuild (for the extension host) and Vite (for webviews); the legacy webpack pipeline has been removed, and `npm run compile` / `watch` / `package` are aliases for the `:fast` variants:
+All builds use esbuild (for the extension host) and Vite (for webviews); the legacy webpack pipeline has been removed, and `npm run compile` / `watch` / `package` are aliases for the `:fast` variants listed above.
 
-- `npm run compile:fast` - Development build
-- `npm run watch:fast` - Watch mode for development
-- `npm run package:fast` - Production build
-- `npm run build:fast` - Build VSIX extension file
-- `npm run build:initial` - Build desktop plus VSIX artifacts and verify both
-
-**Important:** These builds do NOT perform TypeScript type checking (esbuild only strips types). To verify there are no type errors, run:
-
-```bash
-npm run typecheck
-```
-
-Alternatively, use `npm run compile:safe` which runs type checking before building.
+**Important:** These builds do NOT perform TypeScript type checking (esbuild only strips types). Run `npm run typecheck`, or use the `:safe` variants (`compile:safe`, `package:safe`, `build:safe`) that type check before building. Build-system rationale and the full safe-script table: AGENTS.md "Build system: esbuild + Vite".
 
 ### Local CLI (`texra-local`)
 
@@ -82,7 +76,7 @@ The core of TeXRA is its agent architecture in repo-root `src/agent/`:
 
 - **`core/`** holds the host-agnostic domain model, organized by bounded concern: `definition/` (what an agent is), `state/` (run-state snapshots), `usage/` (usage value objects), `tools/` (tool contracts), and `flows/` (reusable cycle primitives). See `src/agent/core/README.md` for the module map and dependency rules.
 - **`implementations/flows/`** provides the PocketFlow-based flow implementations (`reflection`, `tooluse`, `agentCreator`)
-- **`modelHandlers/`** abstracts AI provider APIs (Anthropic, OpenAI, Google, OpenRouter)
+- **`modelHandlers/`** abstracts AI provider APIs (Anthropic, OpenAI and OpenAI-compatible families, Google, OpenRouter, VS Code LM). No barrel: import via the `@agent/modelHandlers/<provider>/<File>` alias, per that directory's `README.md`
 - Agents are configured via YAML files in `packages/extension/resources/agents/`
 
 Agent prompts handle single and multi-document output through one unified YAML per agent. Workflow edit prompts use the input filenames as the output filenames, and agents that generate new artifacts may declare `defaultOutputFiles` and refer to `OUTPUT_FILES`.
@@ -95,6 +89,7 @@ This repository is a pnpm workspace:
 - `packages/extension/` holds the VS Code extension entrypoint, commands, webviews, and packaged resources.
 - `packages/desktop/` holds the Electron desktop shell and adapters around the shared core.
 - `packages/cli/` holds the `texra` terminal client (Ink TUI plus headless `texra run` / `--print` modes).
+- `packages/trace-viewer/` holds the standalone trace-viewer web app (`@texra/trace-viewer`), built with Vite and bundled into host resources.
 - `src/hosts/` defines host capability ports used by both VS Code and Electron integrations.
 - `src/test-kernel/` contains Vitest suites for host-neutral and Electron-facing behavior.
 
@@ -123,6 +118,7 @@ Key directories in `src/`:
 - `skills/` - Skill schemas, loading, and runtime skill sources
 - `telemetry/` - Usage logging
 - `transcript/` - Stream logs, snapshots, and run transcript recording
+- `types/` - Ambient type declarations (`ambient.d.ts`)
 - `test-kernel/` - Vitest suites (run via `npm test`); shared fakes live in `test-kernel/support/`
 
 Key directories in `packages/extension/`:
@@ -161,136 +157,17 @@ Key documentation in `docs/`:
 - `system/` - Help, tests, XML/YAML utilities, editor commands
 - `tests/` - Test commands
 
-### Schema and Type Guidelines
+### Schemas (Zod v4)
 
-Use Zod schemas as the single source of truth for data structures:
+Zod schemas are the single source of truth for data structures: define the schema first, derive types with `z.infer`, compose with `.extend()`/`.pick()`, and prefer `z.discriminatedUnion()` over `z.custom<T>()`. Legacy data formats are normalized once at the entry point with a `z.union()` whose legacy member `.transform()`s into the one canonical format; downstream code never branches on format version. Full patterns (SSOT rules, the backward-compatibility union, `.prefault()`/`.catch()`/`.nullish()`, and tool-schema design): AGENTS.md "Zod v4 Schema Patterns".
 
-- **Define schemas first**, then derive TypeScript types using `z.infer<typeof Schema>`
-- **Use schema composition** (`.extend()`, `.pick()`) instead of duplicating field definitions
-- **Avoid `z.custom<T>()`** when a proper schema exists—prefer `z.discriminatedUnion()` for union types
-- **Co-locate types with schemas** in the same file for maintainability
-- **Add compile-time assertions** (using `satisfies`) when schemas must stay synchronized with external types
+### Abstraction discipline
 
-This project uses **Zod v4**. See AGENTS.md for idiomatic Zod v4 patterns including `.prefault()`, `.catch()`, and `.nullish()` for tool schemas.
+Collapse pass-through layers: nodes create and run flows directly in `exec()`; a wrapper that only creates state, runs a flow, and interprets results gets inlined; deleted wrappers leave no re-export shims behind. Factories are justified only by multiple callers, meaningful logic (validation, defaults, transforms), class construction, or captured initialization context; two-layer factories called once and identity factories that just spread into a new object are banned. At review time this extends into the **Abstraction-cost guardrails** (code-review checklist § 13): grep the caller count before approving any new shared helper (single-caller extractions are banned), and hold new ports/facades/template-methods to build-implies-delete-in-the-same-PR with net-LOC accounting. Full patterns with examples: AGENTS.md "Design and refactoring".
 
-### Backward Compatibility with Zod
+### UI anti-patterns
 
-When evolving data formats while maintaining backward compatibility:
-
-- **Use `z.union()` with `.transform()`** to handle multiple formats in one schema
-- **New format first** in the union (Zod tries in order)
-- **Legacy format transforms** into the canonical structure
-- **Handle legacy at entry point** using `safeParse`, not scattered fallbacks in consumers
-- **One canonical format** for all downstream code—no conditional handling based on format version
-
-Example pattern:
-
-```typescript
-// Canonical format (new)
-const NewFormatSchema = z.object({ revised: OutputFileInfoSchema, ... });
-
-// Legacy format transforms to canonical
-const LegacyFormatSchema = z.object({ baseLabel: z.string(), ... })
-  .transform((e): NewFormat => ({ /* map to canonical */ }));
-
-// Single entry point handles both
-const EntrySchema = z.union([NewFormatSchema, LegacyFormatSchema]);
-
-// Usage: always returns canonical format
-const result = EntrySchema.safeParse(raw);
-```
-
-### Flattening Abstraction Layers
-
-When refactoring, eliminate unnecessary wrapper functions and indirection layers:
-
-**Anti-pattern (too many layers):**
-
-```
-Node.exec()
-  → wrapperFunction()
-    → coreFunction()
-      → createFlow()
-      → flow.run()
-```
-
-**Preferred (direct execution):**
-
-```
-Node.exec()
-  → createFlow()
-  → flow.run()
-```
-
-**Guidelines:**
-
-- Nodes should create and run flows directly in `exec()`, not delegate to wrapper functions
-- If a wrapper only creates state + runs flow + interprets results, inline it
-- Delete wrapper files entirely when they become unused (don't leave empty re-exports)
-- Update tests to use the underlying flow directly rather than through wrappers
-- Update imports to point to the source of truth (e.g., `CycleServices` not re-exporting files)
-
-### Discouraged Factory Patterns
-
-Avoid these patterns that add indirection without value:
-
-**Two-layer factories (called once):**
-
-```typescript
-// ❌ Anti-pattern: buildX only called from createX
-export function createContext(init) {
-  const services = buildServices(init);  // ← Extra layer
-  return { services, ... };
-}
-function buildServices(init) { ... }
-
-// ✅ Preferred: Inline if only called once
-export function createContext(init) {
-  const services = { ... };  // ← Direct
-  return { services, ... };
-}
-```
-
-**Trivial identity factories:**
-
-```typescript
-// ❌ Anti-pattern: Just spreads into new object
-function createOptions(options: Options): Options {
-  return { ...options };
-}
-
-// ✅ Preferred: Use object literal directly
-const options: Options = { ... };
-```
-
-**When factories ARE justified:**
-
-- Called from multiple locations (DRY)
-- Contain meaningful logic (validation, defaults, transforms)
-- Create class instances or complex objects
-- Need to capture closures with initialization context
-
-At review time this extends into the **Abstraction-cost guardrails** (code-review checklist § 13): grep the caller count before approving any new shared helper (single-caller extractions are banned), and hold new ports/facades/template-methods to build-implies-delete-in-the-same-PR with net-LOC accounting.
-
-### Render-Time Workarounds (Anti-pattern)
-
-Never compensate for data model problems at render time. Renderers should only transform and display.
-
-**Signs of broken data model:**
-
-- `Date.now()` or synthetic IDs generated during rendering
-- DOM queries to check if data exists before rendering
-- Deduplication logic comparing rendered content
-
-**Fix:** Store data once at the source with all metadata (timestamps, IDs). If renderers need to generate or deduplicate, the upstream code path is missing data.
-
-### Duplicate UI Controls (Anti-pattern)
-
-One home per user action. Don't surface the same action (a dispatched event, a
-config/state write, or a command) from two controls; competing controls confuse
-users and drift out of sync. Secondary surfaces show read-only status, never a
-second control. Legit: a global default vs a per-item override, or one action as
-a command plus a single UI button. Grep and details: code-review checklist § 5.
+Two standing bans, detailed in AGENTS.md "UI anti-patterns": never compensate for data-model problems at render time (no `Date.now()`, synthetic IDs, or dedup logic in renderers; fix the upstream data), and one home per user action (never surface the same action from two controls; secondary surfaces show read-only status). Duplicate-control grep procedure: code-review checklist § 5.
 
 ### Terminal UI (CLI / Ink) discipline
 
@@ -320,7 +197,7 @@ mouse-scroll for finalized history, so don't reinvent them.
   belongs to that child's Static scrollback owner and Ctrl-T transcript viewer.
   Cap root panels (`BOTTOM_PANEL_MAX_ROWS`) so chrome never pushes the input
   off-screen. Don't park finalized content in the live region "for now."
-- **Stateless renderers.** Tool / diff / markdown components are props-in → JSX-out (the "Render-Time Workarounds" rule, applied to the TUI). No `Date.now()`, synthetic ids, or dedup at render time. Any view-level toggle (collapse/expand, focus) belongs in shared signal state (`state/cliState.ts`), not per-component local state.
+- **Stateless renderers.** Tool / diff / markdown components are props-in → JSX-out (the render-time workarounds ban from "UI anti-patterns", applied to the TUI). No `Date.now()`, synthetic ids, or dedup at render time. Any view-level toggle (collapse/expand, focus) belongs in shared signal state (`state/cliState.ts`), not per-component local state.
 - **Defer non-terminal content to the host.** The TUI does not render PDFs, LaTeX figures, or inline images (iTerm2 / Kitty / Sixel). Hand previews to the webview/desktop or the OS opener. The terminal is for chat, text, and diffs; rebuilding a document viewer in cells is out of scope.
 - **Capability-gate terminal features.** Negotiate support via the DA1-sentinel discovery (`state/terminalCapabilities.ts`) before emitting Kitty-keyboard, OSC color, bracketed-paste, or notification sequences. No "assume a modern terminal" feature use.
 - **Headless parity is sacred.** The TUI runs only on an interactive TTY. `texra run`, `--print/-p`, and `--output-format json|ndjson` must stay byte-identical — never let Ink rendering, ANSI chrome, or spinners leak into the piped / non-TTY path.
@@ -429,10 +306,8 @@ For good separation of concerns, testability, and platform independence, core bu
 **Patterns for keeping code platform-agnostic:**
 
 - Reach host services through `platform()` from `@platform/platform` (config, state, log, fs, workspace, storage, secrets) — never import `vscode` in agnostic zones.
-- Use `isFile()` / `isDirectory()` from `@utils/files/fsEntryType` instead of `vscode.FileType`
-- Use `isFileNotFoundError()` from `@common/errors` instead of `instanceof vscode.FileSystemError`
-- Return error results instead of calling `vscode.window.show*Message()` from business logic — let the caller (command layer) handle UI
 - Add typed `Platform` ports (like `toolAvailability.isVscodeExtensionInstalled`) for platform-specific capabilities needed in agnostic code
+- Helper substitutions for `vscode` types (`isFile`/`isDirectory`, `isFileNotFoundError`, numeric file types) and the push-UI-to-the-caller rule: AGENTS.md "Platform decoupling rules"
 - New run-scoped facts extend `AgentEvent` (trace), and session-scoped facts extend `SessionFact` — never a new `bus.emit` from a VS Code-free zone, and never a new subscribe surface. (Ruled in `docs/proposals/error-pipeline-and-ownership.md`. The direct `bus.emit` sites in `src/tools` that this rule once grandfathered have since been migrated to session-owned event-hub emission — see `SessionHandle.events` / `SessionEventHub` in `src/agent/runtime/` — so the exception no longer applies; a new direct `bus.emit` from a VS Code-free zone is a rule violation, not a grandfathered pattern.)
 
 ### Path Aliases
@@ -462,7 +337,7 @@ Common aliases (full list in `tsconfig.json`):
 
 ### New Model Provider
 
-1. Create handler in `src/agent/modelHandlers/`
+1. Create handler under `src/agent/modelHandlers/<provider>/` (no barrel; consumers import via the `@agent/modelHandlers/<provider>/<File>` alias)
 2. Register capabilities and pricing in `src/model/computeModelOptions.ts`
 
 ## Release Process
@@ -479,4 +354,4 @@ TeXRA ships three release tracks off the same commit, with identical user-facing
 4. **Desktop**: `.github/workflows/desktop-package.yml` is `workflow_dispatch`-only (not release-triggered) — build signed macOS/Linux/Windows installers and publish them to the public `texra-ai/texra-desktop-releases` repo by dispatching it with `run_desktop_installers`, `run_windows_desktop`, `require_desktop_signing`, and `publish_desktop_release_artifacts` all `true`.
 5. If this release changes `llm-zoo`, also update the exact pin in `supabase/functions/relay/deno.json` and refresh `supabase/functions/relay/deno.lock` (called out in the `version-bump.yml` PR body, but easy to miss since it isn't part of the automated bump).
 
-**Changelog guidelines**: Focus on user-visible changes. Never document intermediate bugs fixed within the same PR.
+**Changelog guidelines**: Focus on user-visible changes. Never document intermediate bugs fixed within the same PR. Full rules: AGENTS.md "Changelog Guidelines".

--- a/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
@@ -268,7 +268,7 @@ export class AIAgentsTab extends LitElement {
    * Read-only status summary derived from the same `toolDashboardItems`
    * signal the Tools tab uses to drive its actionable "Re-check" button.
    * This tab only reflects that shared state — the Tools tab owns the one
-   * control that re-runs the probe (see CLAUDE.md "Duplicate UI Controls").
+   * control that re-runs the probe (see AGENTS.md "UI anti-patterns" (Duplicate UI controls)).
    */
   private renderStatusSummary(
     items: readonly ToolDashboardItem[],


### PR DESCRIPTION
## Summary

Rebalances the two instruction files so each has one clear job, and refreshes stale facts in both.

- CLAUDE.md (482 -> 357 lines) keeps the operational map: commands, architecture, VS Code coupling zones, TUI and CLI discipline, release process. Deep coding-convention content moved out; each moved section leaves a short summary plus a pointer.
- AGENTS.md (453 -> 558 lines) is now the single home for coding conventions: it gains the Zod SSOT bullets, the backward-compatibility union pattern, Flattening abstraction layers, Discouraged factory patterns, and a new UI anti-patterns section (render-time workarounds plus duplicate UI controls), all moved verbatim from CLAUDE.md.
- Stale facts fixed: workspace layout now lists packages/cli and packages/trace-viewer everywhere; the model-handler provider list and no-barrel import rule are current; the settingsView tab list in AGENTS.md now matches all 10 actual tabs; src/types added to the source map; the dead-export ratchet bullet now describes the merged per-symbol gate instead of "being tightened in a separate PR"; dev commands now include npm run typecheck and npm run check:dead-code-ratchet; the eslint error-level promotions are documented.
- Cross-references repointed in the live surfaces that cite the moved sections: the code-review checklist (sections 2, 5, 8, 13 and the header) and both .github review prompts. Historical docs under docs/ intentionally keep their point-in-time references.
- AGENTS.md's redundant Source Organization section (a subset of CLAUDE.md's Commands section) was removed.

## Verification

- An independent review pass audited the full diff for lost content, dangling section references, and factual errors. It confirmed every moved block survives intact and every factual claim matches the tree (scripts in package.json, config/ratchets/knip-baseline.json, tab files, commands directories, modelHandlers README, trace-viewer package name), and caught two missed cross-references (checklist lines 56 and 75), which are fixed in this PR.
- Heading uniqueness and code-fence pairing checked in both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown and comment-only changes; no runtime, auth, or data-path behavior.
> 
> **Overview**
> **Rebalances** `CLAUDE.md` (operational map, shorter) and `AGENTS.md` (single home for coding conventions, longer). Long Zod SSOT/back-compat, flattening layers, discouraged factories, and UI anti-patterns move **verbatim** into `AGENTS.md`; `CLAUDE.md` keeps short summaries with pointers.
> 
> **Updates stale documentation**: workspace packages (`cli`, `trace-viewer`), model-handler import rules, full settings tabs list, `src/types`, ESLint error rules, and dev commands (`typecheck`, `check:dead-code-ratchet` + knip baseline). Drops redundant **Source Organization** from `AGENTS.md`.
> 
> **Repoints live references** to the new section names/locations: code-review checklist, GitHub review prompts, passthrough-detect workflow, and `AIAgentsTab` comment (`AGENTS.md` UI anti-patterns).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52c1f87875b912fa9899752e500cb7a57f68b979. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->