### PR TITLE
fix(cli): pin the compact goal notice and reset modal scroll on new content

### DIFF
--- a/packages/cli/src/chat/tui/modals/PlanApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/PlanApproval.tsx
@@ -109,7 +109,9 @@ export function isPlanApprovalGoalActionVisible({
   readonly goalEnabled: boolean;
   readonly visibleBodyRows: number;
 }): boolean {
-  return goalEnabled && (!compact || visibleBodyRows > 0);
+  // Compact cards pin the notice above the body, so the action needs room
+  // for the notice row plus at least one plan row.
+  return goalEnabled && (!compact || visibleBodyRows > 1);
 }
 
 export function PlanApproval(props: PlanApprovalProps): React.JSX.Element {
@@ -134,14 +136,11 @@ export function PlanApproval(props: PlanApprovalProps): React.JSX.Element {
     visibleBodyRows: compactBodyRows ?? 0,
   });
   const goalNoticeVisible = goalActionVisible && !feedbackMode;
-  // The compact card has no room for a separate notice row; fold it into the
-  // scrollable body so it stays readable on its way past.
-  const bodyText =
-    compact && goalNoticeVisible
-      ? `${PLAN_APPROVAL_GOAL_NOTICE}\n\n${props.payload.plan.objective}`
-      : props.payload.plan.objective;
+  // The notice is pinned outside the scroll region in both layouts so the
+  // `r approve & run` action can never outlive its scope warning; in the
+  // compact card it costs one body row.
   const maxBodyRows = compact
-    ? Math.max(1, compactBodyRows ?? 1)
+    ? Math.max(1, (compactBodyRows ?? 1) - (goalNoticeVisible ? 1 : 0))
     : scrollableModalTextRowsBudget({
         availableRows: props.availableRows,
         columns,
@@ -179,13 +178,17 @@ export function PlanApproval(props: PlanApprovalProps): React.JSX.Element {
       onFeedbackValueChange={setFeedbackValue}
       onDecide={props.onDecide}
     >
+      {compact && goalNoticeVisible ? (
+        <Text>{planApprovalGoalNoticeLine(contentWidth)}</Text>
+      ) : null}
       <ScrollableModalText
         hiddenNoun={PLAN_APPROVAL_HIDDEN_NOUN}
         marginWhenSpacious={!compact}
         maxRows={maxBodyRows}
         scrollActive={!feedbackMode}
         scrollHint="scroll plan"
-        text={bodyText}
+        showScrollHints={!compact}
+        text={props.payload.plan.objective}
         trimWrappedLeadingWhitespace
         width={contentWidth}
       />

--- a/packages/cli/src/chat/tui/modals/ScrollableModalText.tsx
+++ b/packages/cli/src/chat/tui/modals/ScrollableModalText.tsx
@@ -142,6 +142,8 @@ interface ScrollableModalTextProps {
   readonly marginWhenSpacious?: boolean;
   /** Release ↑/↓ while another surface owns them (feedback input). */
   readonly scrollActive?: boolean;
+  /** Suppress the hint row where no row is budgeted for it (compact cards). */
+  readonly showScrollHints?: boolean;
   /** ↑/↓ hint verb, e.g. `scroll command`. */
   readonly scrollHint: string;
   readonly text: string;
@@ -178,6 +180,7 @@ export function ScrollableModalText(
   const { scrollOffset, scrollable } = useScrollableOffset({
     active: props.scrollActive !== false,
     maxScrollOffset,
+    resetKey: text,
     pageRows: scrollPageRows({
       compactRows: COMPACT_MODAL_TEXT_ROWS,
       maxDisplayLines: maxRows,
@@ -209,7 +212,10 @@ export function ScrollableModalText(
           </Text>
         ))}
       </Box>
-      {scrollable && maxRows > 1 ? (
+      {scrollable &&
+      maxRows > 1 &&
+      props.scrollActive !== false &&
+      props.showScrollHints !== false ? (
         <KeyHints
           confirmCancel={false}
           hints={[

--- a/packages/cli/src/chat/tui/state/useScrollableOffset.ts
+++ b/packages/cli/src/chat/tui/state/useScrollableOffset.ts
@@ -13,12 +13,15 @@ export function useScrollableOffset({
   active = true,
   maxScrollOffset,
   pageRows,
+  resetKey,
 }: {
   /** Release the key bindings while another surface owns ↑/↓ (e.g. a
    *  feedback text input); the offset itself is retained. */
   readonly active?: boolean;
   readonly maxScrollOffset: number;
   readonly pageRows: number;
+  /** Snap back to the top whenever this changes (e.g. new content). */
+  readonly resetKey?: unknown;
 }): { scrollOffset: number; scrollable: boolean } {
   const [scrollOffset, setScrollOffset] = useState(0);
   const scrollable = maxScrollOffset > 0;
@@ -30,6 +33,10 @@ export function useScrollableOffset({
   useEffect(() => {
     setScrollOffset((current) => clamp(current, 0, maxScrollOffset));
   }, [maxScrollOffset]);
+
+  useEffect(() => {
+    setScrollOffset(0);
+  }, [resetKey]);
 
   useInput(
     (_input, key) => {

--- a/src/test-kernel/cli/PlanApproval.vitest.mts
+++ b/src/test-kernel/cli/PlanApproval.vitest.mts
@@ -65,6 +65,13 @@ describe('CLI plan approval layout', () => {
         goalEnabled: true,
         visibleBodyRows: 1,
       }),
+    ).toBe(false);
+    expect(
+      isPlanApprovalGoalActionVisible({
+        compact: true,
+        goalEnabled: true,
+        visibleBodyRows: 2,
+      }),
     ).toBe(true);
   });
 


### PR DESCRIPTION
Follow-up to #8635, addressing the five second-wave review findings that arrived after merge:

- **Reset scroll on content change** (codex + Bugbot Medium): `useScrollableOffset` gains a `resetKey`; `ScrollableModalText` keys it by its text, so back-to-back queued approvals promoted without remounting start at the top, and PlanApproval's feedback-mode text swap can no longer desync the visible slice (the notice also no longer lives inside the body text at all).
- **Pinned compact goal notice** (codex): the compact plan card renders the approve-and-run notice above the scroll region, costing one body row — the `r` action can never outlive its scope warning. `isPlanApprovalGoalActionVisible` now requires room for the notice plus at least one plan row.
- **Hint-row budgeting** (codex): scroll hints are suppressed in compact cards (`showScrollHints={!compact}`) whose row budget reserves no hint row, so the foreground clip can't eat a row.
- **Hints during feedback** (Bugbot Low): the hint row hides while `scrollActive` is false.

21/21 modal tests (one goal-action expectation updated for the pinned-notice rule), 12/12 approval smoke scenarios including all plan/goal/compact variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only modal layout and scroll UX; no auth, data, or API changes.
> 
> **Overview**
> Follow-up polish for plan approval modals in the CLI TUI.
> 
> **Compact “approve & run” notice** is no longer folded into the scrollable plan text. It renders as a pinned row above the body (compact) or below it (spacious), with row budgeting adjusted so the **`r` approve & run** action only appears when there is room for the warning plus at least one plan row (`visibleBodyRows > 1` in compact mode).
> 
> **Scroll behavior**: `useScrollableOffset` accepts a **`resetKey`**; `ScrollableModalText` passes plan text so offset snaps to the top when content changes (e.g. queued approvals without remount, or feedback-mode swaps). **`showScrollHints`** hides ↑/↓ hints on compact cards where no hint row is budgeted, and hints are also suppressed when **`scrollActive`** is false (feedback input owns the keys).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ddab9b0ce4bd313100b209704aa8730dc80b261. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->