### PR TITLE
fix(agent): deliver late resumed subagent follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ All notable changes to this project will be documented in this file.
   them, while the local CLI terminal keeps its operator-readable output.
 - **Unavailable-tool notices are scoped to each agent session** — one active
   session no longer suppresses dependency guidance for another session.
-- **Follow-ups to waiting subagents resume once without a false failure** — a
+- **Follow-ups to waiting or resumed subagents are delivered exactly once** —
+  messages sent during an active resumed turn no longer remain dormant, and a
   completed follow-up is no longer reported as failed or repeated later.
 - **Delegated agents follow live auto-approval changes** — enabling or
   disabling file and command auto-approval on a parent now updates its running

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -539,7 +539,17 @@ export async function runToolUseFlow<C = unknown>(
       if (finalAction !== FlowTransition.WAITING || input.checkInterruption()) {
         break;
       }
+
+      // Close the live-flow admission boundary before the post-park drain.
+      // From this synchronous detach onward, sendFollowUp queues instead of
+      // reporting `sent`; the immediately following drain therefore cannot
+      // miss input in a gap between its empty check and final teardown.
+      teardownSetup?.();
+      teardownSetup = undefined;
       resumedFollowUps = [...(input.takePendingFollowUps?.() ?? [])];
+      if (resumedFollowUps.length > 0) {
+        teardownSetup = onSetup?.(flowContext) ?? undefined;
+      }
     } while (resumedFollowUps.length > 0);
 
     lastResponse =

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -341,7 +341,10 @@ export async function runToolUseFlow<C = unknown>(
     interrupt(): void {
       onInterrupt?.();
       runSession.interactions.cancel({ streamId, cause: 'Run interrupted.' });
-      if (inResumeStartupWindow) {
+      if (
+        inResumeStartupWindow ||
+        (input.isSubagent === true && input.takePendingFollowUps !== undefined)
+      ) {
         sessionLifecycle.interruptPreservingQueue();
       } else {
         sessionLifecycle.interrupt();

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -72,8 +72,9 @@ export interface RunToolUseFlowInput<
   /** One batch already drained by an external child-turn owner. */
   drainedFollowUps?: readonly FollowUpQueueBatchItem[];
   /**
-   * Take messages queued between the initial drain and live flow attachment.
-   * Called exactly once after attachment and before the persisted cursor runs.
+   * Take messages queued at a resume ownership boundary. Called first after
+   * live-flow attachment and then after each WAITING suspension; a later call
+   * may decline ownership by returning an empty batch.
    */
   takePendingFollowUps?: () => readonly FollowUpQueueBatchItem[];
   onFollowUpConsumed?: () => void;
@@ -486,51 +487,57 @@ export async function runToolUseFlow<C = unknown>(
     // confirmed or a present record passed its migration boundary.
     persistenceRecoveryPending = false;
 
-    const prepareNode = new ToolUsePrepareNode<C>();
-    const cycleNode = new ToolUseCycleNode<C>();
-    const resumedFollowUps = [
+    let resumedFollowUps = [
       ...(input.drainedFollowUps ?? []),
       ...attachmentFollowUps,
     ];
-    const waitNode = new ToolUseWaitNode<C>(resumedFollowUps);
-    prepareNode.next(cycleNode);
-    cycleNode.next(waitNode);
-    waitNode.on(FlowTransition.CONTINUE, cycleNode);
-    waitNode.on(FlowTransition.WAITING, waitNode);
-    const pf = new ToolUsePersistedFlow<C>(
-      prepareNode,
-      kv,
-      executionId,
-      ToolUseRunSharedCanonicalSchema,
-    );
-    activePersistedFlow = pf;
-    pf.setServices(services);
-    // Note: the flow record is the resume SSOT and the transcript sidecar
-    // owns completed-run display/export (#7246 Decision 1) — the old
-    // per-step `conversation.json`/`todos.json` projections are gone.
-    // Live-run todos still persist event-driven via `persistTodos` above.
-    pf.setProjection(async (s, store) => {
-      const currentTouchedFiles = extractTouchedFiles(s.stateSlices);
-      if (currentTouchedFiles.length) {
-        await store.writeWorkspaceFiles(currentTouchedFiles);
+    let finalAction: Awaited<ReturnType<ToolUsePersistedFlow<C>['run']>>;
+    do {
+      const prepareNode = new ToolUsePrepareNode<C>();
+      const cycleNode = new ToolUseCycleNode<C>();
+      const waitNode = new ToolUseWaitNode<C>(resumedFollowUps);
+      prepareNode.next(cycleNode);
+      cycleNode.next(waitNode);
+      waitNode.on(FlowTransition.CONTINUE, cycleNode);
+      waitNode.on(FlowTransition.WAITING, waitNode);
+      const pf = new ToolUsePersistedFlow<C>(
+        prepareNode,
+        kv,
+        executionId,
+        ToolUseRunSharedCanonicalSchema,
+      );
+      activePersistedFlow = pf;
+      pf.setServices(services);
+      // Note: the flow record is the resume SSOT and the transcript sidecar
+      // owns completed-run display/export (#7246 Decision 1) — the old
+      // per-step `conversation.json`/`todos.json` projections are gone.
+      // Live-run todos still persist event-driven via `persistTodos` above.
+      pf.setProjection(async (s, store) => {
+        const currentTouchedFiles = extractTouchedFiles(s.stateSlices);
+        if (currentTouchedFiles.length) {
+          await store.writeWorkspaceFiles(currentTouchedFiles);
+        }
+      });
+      flowRunStarted = true;
+      try {
+        finalAction = await pf.run(shared);
+      } catch (error: unknown) {
+        if (input.checkInterruption()) {
+          shared = (await pf.getShared()) ?? shared;
+          await pf.prepareForFollowUp(shared);
+        }
+        throw error;
       }
-    });
-    flowRunStarted = true;
-    let finalAction: Awaited<ReturnType<typeof pf.run>>;
-    try {
-      finalAction = await pf.run(shared);
-    } catch (error: unknown) {
-      if (input.checkInterruption()) {
-        shared = (await pf.getShared()) ?? shared;
-        await pf.prepareForFollowUp(shared);
+      // Re-read shared from the flow record — PersistedFlow deep-clones the
+      // initial shared via structuredClone, so nodes mutate the clone, not the
+      // original object. Without this, reads of lastError, messages, etc. below
+      // would always see the stale initial values.
+      shared = (await pf.getShared()) ?? shared;
+      if (finalAction !== FlowTransition.WAITING || input.checkInterruption()) {
+        break;
       }
-      throw error;
-    }
-    // Re-read shared from the flow record — PersistedFlow deep-clones the
-    // initial shared via structuredClone, so nodes mutate the clone, not the
-    // original object.  Without this, reads of lastError, messages, etc. below
-    // would always see the stale initial values.
-    shared = (await pf.getShared()) ?? shared;
+      resumedFollowUps = [...(input.takePendingFollowUps?.() ?? [])];
+    } while (resumedFollowUps.length > 0);
 
     lastResponse =
       findLastAssistantText(shared.messages, (m) =>
@@ -558,7 +565,7 @@ export async function runToolUseFlow<C = unknown>(
       });
     }
     if (outcome === RUN_OUTCOME.CANCELLED && input.checkInterruption()) {
-      await pf.prepareForFollowUp(shared);
+      await activePersistedFlow?.prepareForFollowUp(shared);
     }
     if (shared.lastError) {
       // Re-throw so runFlowWithLifecycle logs the error and shows

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -81,8 +81,8 @@ export async function resumeQueuedToolUseSnapshot(
 
   const seed = options.extraFollowUps ?? [];
   let followUps: readonly FollowUpQueueInput[] = seed;
+  let followUpBoundaryReached = false;
   let cancelledAtFlowAttachment = false;
-  let followUpsConsumed = false;
   let followUpsRestored = false;
   let resumeError: { error: unknown } | undefined;
   const restoreFollowUps = (): void => {
@@ -125,7 +125,7 @@ export async function resumeQueuedToolUseSnapshot(
       parentStreamId:
         options.parentStreamId ?? snapshot.parentStreamId ?? undefined,
       onFollowUpConsumed: () => {
-        followUpsConsumed = true;
+        followUps = [];
         options.onFollowUpConsumed?.();
       },
       onProgress: options.onProgress,
@@ -136,23 +136,33 @@ export async function resumeQueuedToolUseSnapshot(
         cancelledAtFlowAttachment = true;
       },
       drainedFollowUps: followUps.map(toFollowUpBatchItem),
-      // The live context is attached before this second drain. Items arriving
-      // later therefore target that context directly; this callback owns the
-      // only queue gap between the initial drain and attachment.
+      // The first call closes the gap between the initial drain and live-flow
+      // attachment. Later calls occur after a subagent parks at WAITING. A
+      // native child loop owns that queue boundary when registered; otherwise
+      // this host resume must claim the late batch so input accepted by the
+      // live context cannot remain dormant.
       takePendingFollowUps: () => {
+        const isPostParkClaim = followUpBoundaryReached;
+        followUpBoundaryReached = true;
+        if (
+          isPostParkClaim &&
+          session.executions.isChildRunLoopActive(streamId)
+        ) {
+          return [];
+        }
         const raced = followUpsQueue.drainItems(streamId);
         followUps = [...followUps, ...raced];
         return raced.map(toFollowUpBatchItem);
       },
     });
-    if (followUps.length > 0 && !followUpsConsumed) restoreFollowUps();
+    if (followUps.length > 0) restoreFollowUps();
     options.onResult?.(result);
   } catch (error) {
     resumeError = { error };
     // A rejection before the wait node acknowledges consumption must replay
     // the drained batch. A callback failure after that acknowledgement must
     // not enqueue the same user input again.
-    if (!followUpsConsumed) restoreFollowUps();
+    if (followUps.length > 0) restoreFollowUps();
   } finally {
     // Early failures leave the stream RESUMING. Startup cancellation can
     // instead reach lifecycle terminalization before the queue owner regains

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -916,6 +916,56 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     }
   });
 
+  it('preserves late input when an orphaned host-resumed subagent is cancelled mid-turn', async () => {
+    const executionId = 'abc-cancel-active-followup' as ExecutionId;
+    const streamId = 'chat@gpt54#abc-cancel-active-followup' as StreamTabId;
+    const snapshot = buildToolUseSnapshot(executionId, streamId);
+    const session = createTestSession();
+    await getExecutionStore(executionId).write(flowKey(executionId), {
+      flowName: 'texra',
+      params: {},
+      shared: {
+        ...VALID_TOOL_USE_SHARED,
+        modelHandlerCompatibilityKey: ACTIVE_COMPATIBILITY_KEY,
+      },
+      createdAt: new Date().toISOString(),
+      nodes: [],
+    });
+    let flowContext: ToolUseSetupContext | undefined;
+    const abortError = new DOMException(
+      'This operation was aborted',
+      'AbortError',
+    );
+    const runSpy = vi
+      .spyOn(PersistedFlow.prototype, 'run')
+      .mockImplementationOnce(async () => {
+        flowContext?.session.appendFollowUp({ text: 'late active-turn input' });
+        flowContext?.interrupt();
+        throw abortError;
+      });
+
+    try {
+      await expect(
+        runPersistedFlow(
+          executionId,
+          streamId,
+          snapshot,
+          (context) => {
+            flowContext = context;
+          },
+          session,
+          { takePendingFollowUps: () => [] },
+        ),
+      ).rejects.toBe(abortError);
+      expect(session.followUps.getAll(streamId)).toEqual([
+        'late active-turn input',
+      ]);
+    } finally {
+      runSpy.mockRestore();
+      session.followUps.release(streamId);
+    }
+  });
+
   it('hydrates a legacy-shaped flow record through the single boundary, then self-heals via its canonical fields', async () => {
     const executionId = 'abc140' as ExecutionId;
     const streamId = 'chat@gpt54#abc140' as StreamTabId;

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -131,7 +131,7 @@ async function runPersistedFlow(
   executionId: ExecutionId,
   streamId: StreamTabId,
   snapshot: ToolUseSessionSnapshot | undefined,
-  onSetup?: (context: ToolUseSetupContext) => void,
+  onSetup?: ToolUseFlowSetupCallback,
   session: SessionHandle = createTestSession(),
   options: {
     readonly isSubagent?: boolean;
@@ -539,19 +539,27 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     const executionId = 'abc-flow-post-park-owner' as ExecutionId;
     const streamId = 'chat@gpt54#abc-flow-post-park-owner' as StreamTabId;
     const snapshot = buildToolUseSnapshot(executionId, streamId);
-    const takePendingFollowUps = vi.fn(() => []);
+    const boundaryEvents: string[] = [];
+    const takePendingFollowUps = vi.fn(() => {
+      boundaryEvents.push('take');
+      return [];
+    });
 
     const result = await runPersistedFlow(
       executionId,
       streamId,
       snapshot,
-      undefined,
+      () => {
+        boundaryEvents.push('attach');
+        return () => boundaryEvents.push('detach');
+      },
       undefined,
       { takePendingFollowUps },
     );
 
     expect(result.outcome).toBe(STREAM_PHASE.WAITING);
     expect(takePendingFollowUps).toHaveBeenCalledTimes(2);
+    expect(boundaryEvents).toEqual(['attach', 'take', 'detach', 'take']);
   });
 
   it('releases follow-ups while preserving the record after a persistence read failure', async () => {

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -136,6 +136,7 @@ async function runPersistedFlow(
   options: {
     readonly isSubagent?: boolean;
     readonly onIdle?: () => void;
+    readonly takePendingFollowUps?: RunToolUseFlowInput['takePendingFollowUps'];
     readonly onFlowRecordDisposition?: (
       disposition: 'preserve' | 'delete',
     ) => void;
@@ -178,6 +179,7 @@ async function runPersistedFlow(
           ...(snapshot !== undefined && { resumeSnapshot: snapshot }),
           isSubagent: options.isSubagent ?? true,
           onIdle: options.onIdle,
+          takePendingFollowUps: options.takePendingFollowUps,
           onFlowRecordDisposition: options.onFlowRecordDisposition,
           toolInjections: new ToolInjectionRegistry(),
         },
@@ -531,6 +533,25 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
         },
       },
     );
+  });
+
+  it('offers queue ownership again after a resumed subagent parks', async () => {
+    const executionId = 'abc-flow-post-park-owner' as ExecutionId;
+    const streamId = 'chat@gpt54#abc-flow-post-park-owner' as StreamTabId;
+    const snapshot = buildToolUseSnapshot(executionId, streamId);
+    const takePendingFollowUps = vi.fn(() => []);
+
+    const result = await runPersistedFlow(
+      executionId,
+      streamId,
+      snapshot,
+      undefined,
+      undefined,
+      { takePendingFollowUps },
+    );
+
+    expect(result.outcome).toBe(STREAM_PHASE.WAITING);
+    expect(takePendingFollowUps).toHaveBeenCalledTimes(2);
   });
 
   it('releases follow-ups while preserving the record after a persistence read failure', async () => {

--- a/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
+++ b/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
@@ -241,12 +241,13 @@ describe('childRunLoop E2E fixtures', () => {
   it('delegate → complete → follow-up delivery: an interim turn delivers, then the loop picks up a queued follow-up for the next turn', async () => {
     const childStreamId = uniqueStreamId('complete-followup');
     const parentStreamId = 'parent' as StreamTabId;
-    const { strategy, resolveTurn } = createFakeStrategy();
+    const { strategy, callCount, resolveTurn } = createFakeStrategy();
     const onTurnSuccess = vi.fn();
     const parentWake = vi.fn();
+    const deliveryCompleted = pDefer<{ kind: 'delivered' }>();
     mocks.wakeChildRunFollowUp.mockImplementation(async () => {
       parentWake();
-      return { kind: 'delivered' };
+      return deliveryCompleted.promise;
     });
 
     startChildRunLoop({
@@ -270,9 +271,9 @@ describe('childRunLoop E2E fixtures', () => {
         }),
       );
     });
-    // An interim (non-terminal) turn wakes inline — no finalize is pending
-    // for it — so the wake for this delivery is expected right away, unlike
-    // the terminal delivery below (see the deferred-wake regression test).
+    // The loop starts delivery for turn N before reading the queue for turn
+    // N+1. Even input already queued during delivery must not begin another
+    // model turn until the parent has received this result.
     await vi.waitFor(() =>
       expect(mocks.wakeChildRunFollowUp).toHaveBeenCalled(),
     );
@@ -285,6 +286,10 @@ describe('childRunLoop E2E fixtures', () => {
     session.followUps
       .acquire(childStreamId)
       .enqueue({ text: 'keep going', origin: 'user' });
+    expect(callCount()).toBe(1);
+
+    deliveryCompleted.resolve({ kind: 'delivered' });
+    await vi.waitFor(() => expect(callCount()).toBe(2));
 
     // Waits for the loop to have actually invoked runTurn a second time —
     // NOT for the queue to read empty, which can happen synchronously on

--- a/src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts
+++ b/src/test-kernel/agent/runtime/resumeToolUseSnapshot.vitest.ts
@@ -166,6 +166,112 @@ describe('resumeToolUseSnapshot', () => {
     ]);
   });
 
+  it('claims a follow-up queued during an orphaned host-resumed subagent turn after it parks', async () => {
+    let postParkFollowUps: readonly FollowUpQueueInput[] = [];
+    resumeToolUseFromSnapshotMock.mockImplementationOnce(
+      async (...args: unknown[]) => {
+        const options = args[2] as ReturnType<typeof capturedResumeOptions>;
+        expect(options.takePendingFollowUps()).toEqual([]);
+
+        defaultSession().followUps.enqueue(STREAM, {
+          text: 'queued during the active turn',
+        });
+        postParkFollowUps = options.takePendingFollowUps();
+        options.onFollowUpConsumed?.();
+        return {
+          category: 'toolUse',
+          outcome: STREAM_PHASE.WAITING,
+          executionId: 'exec-orphan-waiting',
+          streamId: STREAM,
+        };
+      },
+    );
+
+    await expect(
+      resumeQueuedToolUseSnapshot(STREAM, snapshot(), runtimeHost, {
+        onError: vi.fn(),
+      }),
+    ).resolves.toBe(true);
+
+    expect(postParkFollowUps.map((item) => item.text)).toEqual([
+      'queued during the active turn',
+    ]);
+    expect(defaultSession().followUps.getAll(STREAM)).toEqual([]);
+  });
+
+  it('restores a post-park batch exactly once when cancellation wins before consumption', async () => {
+    resumeToolUseFromSnapshotMock.mockImplementationOnce(
+      async (...args: unknown[]) => {
+        const options = args[2] as ReturnType<typeof capturedResumeOptions>;
+        expect(options.takePendingFollowUps()).toEqual([]);
+
+        defaultSession().followUps.enqueue(STREAM, {
+          text: 'late input before cancellation',
+        });
+        expect(options.takePendingFollowUps().map((item) => item.text)).toEqual(
+          ['late input before cancellation'],
+        );
+        seedStreamStatusForTest(
+          defaultSession().status,
+          STREAM,
+          STREAM_PHASE.CANCELLED,
+        );
+        return {
+          category: 'toolUse',
+          outcome: RUN_OUTCOME.CANCELLED,
+          executionId: 'exec-orphan-cancelled',
+          streamId: STREAM,
+        };
+      },
+    );
+
+    await expect(
+      resumeQueuedToolUseSnapshot(STREAM, snapshot(), runtimeHost, {
+        onError: vi.fn(),
+      }),
+    ).resolves.toBe(false);
+
+    expect(defaultSession().followUps.getAll(STREAM)).toEqual([
+      'late input before cancellation',
+    ]);
+  });
+
+  it('leaves post-park input to a registered child loop', async () => {
+    const unregisterChildRunLoop =
+      defaultSession().executions.registerChildRunLoop(STREAM);
+    try {
+      resumeToolUseFromSnapshotMock.mockImplementationOnce(
+        async (...args: unknown[]) => {
+          const options = args[2] as ReturnType<typeof capturedResumeOptions>;
+          expect(options.takePendingFollowUps()).toEqual([]);
+
+          defaultSession().followUps.enqueue(STREAM, {
+            text: 'next loop-backed turn',
+          });
+          expect(options.takePendingFollowUps()).toEqual([]);
+          return {
+            category: 'toolUse',
+            outcome: STREAM_PHASE.WAITING,
+            executionId: 'exec-loop-waiting',
+            streamId: STREAM,
+          };
+        },
+      );
+
+      await expect(
+        resumeQueuedToolUseSnapshot(STREAM, snapshot(), runtimeHost, {
+          onError: vi.fn(),
+        }),
+      ).resolves.toBe(true);
+
+      expect(defaultSession().followUps.getAll(STREAM)).toEqual([
+        'next loop-backed turn',
+      ]);
+    } finally {
+      unregisterChildRunLoop();
+    }
+  });
+
   it('passes snapshot parent stream identity to the leaf resume', async () => {
     const parentStreamId = 'stream:parent' as StreamTabId;
 


### PR DESCRIPTION
## Summary

Closes #8636.

A follow-up sent while an orphaned persisted subagent was executing could be accepted by its live flow, then remain dormant when the subagent parked at WAITING. Native child loops deliberately own a different boundary: they must deliver each completed turn to the parent before starting another queued turn.

This change gives the host resume wrapper an explicit post-park queue boundary. It claims late input only when no registered child loop owns the stream, runs claimed batches before returning WAITING, and acknowledges each batch only after it has reached the persisted conversation.

## Design

- `runToolUseFlow` asks for pending input after each resumed subagent suspension.
- The live-flow context detaches before the post-park drain. Follow-ups arriving from that point are reported as queued, so an empty drain cannot be followed by a falsely accepted `sent` message during teardown.
- If the drain returns input, the context reattaches for the next cycle.
- `resumeQueuedToolUseSnapshot` declines post-park ownership when a native child loop is registered.
- Cancellation preserves unconsumed late input and restores a claimed batch exactly once.
- The ordinary child loop remains the sole owner of loop-backed ordering and still delivers turn N before beginning turn N+1.

No wait-node special case or host-specific queue implementation was added.

## Acceptance gates

- Active-turn input for an orphaned host-resumed subagent runs before it returns dormant WAITING.
- Native child loops retain one-cycle/one-parent-delivery ordering.
- `sendFollowUp` sees either a live consumer or a queue owner throughout post-park teardown.
- Cancellation does not lose or duplicate late input.
- Consumed batches are acknowledged exactly once.

## Net elements

6 files changed, 279 insertions, 58 deletions. Production changes are confined to the shared resume wrapper and tool-use flow; the remaining lines are focused race and ordering regressions.

## Validation

- Focused Vitest: 3 files, 59 tests passed
- Root and test-kernel TypeScript checks
- ESLint on all changed TypeScript files
- Dead-code ratchet
- Repository formatting through commit hooks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core tool-use resume and follow-up queue boundaries between host resume and child-run loops; behavior is race-sensitive but heavily covered by new tests.
> 
> **Overview**
> Fixes **dormant follow-ups** when a host-resumed subagent parks at `WAITING`: messages accepted during an active turn are now drained and run instead of sitting unused.
> 
> **`runToolUseFlow`** loops after each subagent `WAITING`: it detaches the live-flow context, calls `takePendingFollowUps` again, and starts another persisted-flow cycle when the drain returns input. **`takePendingFollowUps`** is documented and used at both initial attachment and each post-park boundary. Subagent interrupts with that callback use **queue-preserving** interrupt semantics so mid-turn cancellation does not drop late input.
> 
> **`resumeQueuedToolUseSnapshot`** implements the host-side post-park claim: a second `takePendingFollowUps` drains the queue after park, but **returns empty** when a **native child-run loop** is registered so loop-backed streams keep one parent delivery per turn. Restore/replay logic keys off remaining `followUps` instead of a consumed flag so batches are restored exactly once on failure or cancellation.
> 
> Changelog wording is updated; Vitest covers post-park ownership, orphan cancel, child-loop deferral, and child-loop ordering (no second turn until parent delivery completes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ec421f5df59294c405a56200913bd98a09e26c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->