### PR TITLE
fix(cli): preserve styling in bounded tool rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Clipped tool output keeps its visual status cues** — tool rows that exceed
+  the available transcript space now retain their status, preview, and error
+  styling.
 - **A calmer footer with one home per hint** — the rotating tip line is gone
   (its shortcuts live in the status bar and `/help`), and queued follow-ups
   preview only in their dedicated panel instead of also scrolling through the

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -151,7 +151,8 @@ const SCENARIOS = [
       '● grep (Found 12 matches for "theorem" in .)',
     ],
     maxBlankLinesBetween: [
-      { from: 'what is this repo about', to: '● grep', max: 0 },
+      // The user band always keeps one breathing row below the prompt.
+      { from: 'what is this repo about', to: '● grep', max: 1 },
     ],
   },
   {
@@ -173,7 +174,8 @@ const SCENARIOS = [
       {
         from: 'what is this repo about',
         to: '● grep (Found 12 matches for "theorem" in .)',
-        max: 0,
+        // The user band always keeps one breathing row below the prompt.
+        max: 1,
       },
       {
         from: '● grep (Found 12 matches for "theorem" in .)',

--- a/packages/cli/src/chat/tui/panes/ToolUseRow.tsx
+++ b/packages/cli/src/chat/tui/panes/ToolUseRow.tsx
@@ -1,54 +1,157 @@
-// CLI-native tool-call row.
-//
-// The renderer registry provides richer presentations for tools whose
-// structure is worth preserving in a terminal. Everything else falls back to
-// the compact universal row.
+// CLI-native tool-call row: paints the styled-line model from toolRenderers.
+// The spans carry all styling; the only rich block is the patch preview,
+// which renders through DiffView instead of its plain-text projection.
 
 import { memo } from 'react';
 import { Box, Text } from 'ink';
 
 import { type NormalizedToolUse } from '@shared/schemas';
 
-import { fillRows } from '../render/terminalText';
+import { DiffView } from '../render/DiffView';
+import { TOOL_OUTPUT_CORNER } from '../ui/glyphs';
 import {
-  pickToolRenderer,
-  toolUseDisplayLines,
-  UniversalToolRow,
+  toolUseMarginBottomRows,
+  toolUseStyledLines,
+  type ToolDisplayLine,
 } from './toolRenderers';
-import { transcriptColumns } from './transcriptEntryLayout';
 
-export function filledToolUseDisplayText(
-  toolUse: NormalizedToolUse,
-  width?: number,
-): string {
-  const cols = transcriptColumns(width);
-  return fillRows(toolUseDisplayLines(toolUse).join('\n'), cols);
+/** Combined left padding of the two nested boxes wrapping the patch diff. */
+const PATCH_PREVIEW_INDENT = 4;
+const PATCH_PREVIEW_FALLBACK_WIDTH = 80;
+
+function PatchPreview({
+  groups,
+  maxRows,
+  width,
+}: {
+  readonly groups: Extract<ToolDisplayLine, { kind: 'patch' }>['groups'];
+  readonly maxRows?: number;
+  readonly width?: number;
+}): React.JSX.Element {
+  // The diff sits under two nested `paddingLeft={2}` boxes; derive its width
+  // from the real terminal so the full-row bands fill exactly the available
+  // columns instead of padding to a fixed default and wrapping on narrow
+  // terminals. `DiffView` floors this at its own minimum.
+  const diffWidth =
+    (width ?? PATCH_PREVIEW_FALLBACK_WIDTH) - PATCH_PREVIEW_INDENT;
+  return (
+    <Box
+      flexDirection="column"
+      height={maxRows}
+      overflowY={maxRows === undefined ? undefined : 'hidden'}
+      paddingLeft={2}
+    >
+      {groups.map((group, index) => (
+        <Box key={`${group.fileLabel}-${index}`} flexDirection="column">
+          <Text dimColor>{`${TOOL_OUTPUT_CORNER} ${group.fileLabel}`}</Text>
+          <Box flexDirection="column" paddingLeft={2}>
+            <DiffView
+              hunks={group.hunks}
+              maxDisplayLines={
+                maxRows === undefined ? undefined : Math.max(1, maxRows - 1)
+              }
+              width={diffWidth}
+            />
+          </Box>
+        </Box>
+      ))}
+    </Box>
+  );
+}
+
+type ToolDisplaySpan = Extract<
+  ToolDisplayLine,
+  { kind: 'row' }
+>['spans'][number];
+
+/** Translate semantic span styles to Ink's Text properties. */
+export function toolDisplaySpanTextProps(span: ToolDisplaySpan): {
+  readonly bold: boolean | undefined;
+  readonly color: string | undefined;
+  readonly dimColor: boolean;
+} {
+  return {
+    bold: span.bold,
+    color: span.color,
+    dimColor: span.dim === true && span.color === undefined,
+  };
+}
+
+interface ToolDisplayViewportLine {
+  readonly index: number;
+  readonly line: ToolDisplayLine;
+  readonly maxRows?: number;
+}
+
+function toolDisplayLineRows(line: ToolDisplayLine): number {
+  return line.kind === 'patch' ? line.textLines.length : 1;
+}
+
+function toolDisplayViewport(
+  lines: readonly ToolDisplayLine[],
+  maxRows: number | undefined,
+): readonly ToolDisplayViewportLine[] {
+  const indexed = lines.map((line, index) => ({ index, line }));
+  if (maxRows === undefined) return indexed;
+
+  let remainingRows = Math.max(1, Math.floor(maxRows));
+  const visible: ToolDisplayViewportLine[] = [];
+  for (const item of indexed.toReversed()) {
+    const lineRows = toolDisplayLineRows(item.line);
+    visible.unshift({
+      ...item,
+      ...(lineRows > remainingRows ? { maxRows: remainingRows } : {}),
+    });
+    remainingRows -= Math.min(lineRows, remainingRows);
+    if (remainingRows === 0) break;
+  }
+  return visible;
 }
 
 // Memoized: tool-use objects stay reference-identical across stream-sync
 // ticks unless their status/result changed, so streaming text deltas skip
 // re-rendering every settled tool row in the live region.
 export const ToolUseRow = memo(function ToolUseRow({
-  fillWidth,
+  maxRows,
   toolUse,
   width,
 }: {
-  readonly fillWidth?: boolean;
+  readonly maxRows?: number;
   readonly toolUse: NormalizedToolUse;
   readonly width?: number;
 }): React.JSX.Element {
-  if (fillWidth === true) {
-    return (
-      <Box flexDirection="column">
-        <Text>{filledToolUseDisplayText(toolUse, width)}</Text>
-      </Box>
-    );
-  }
-
-  const renderer = pickToolRenderer(toolUse);
-  return renderer ? (
-    renderer.render(toolUse, width)
-  ) : (
-    <UniversalToolRow toolUse={toolUse} width={width} />
+  const lines = toolUseStyledLines(toolUse, { width });
+  const viewport = toolDisplayViewport(lines, maxRows);
+  return (
+    <Box
+      flexDirection="column"
+      marginBottom={
+        maxRows === undefined ? toolUseMarginBottomRows(toolUse) : 0
+      }
+    >
+      {viewport.map(({ index, line, maxRows: lineMaxRows }) =>
+        line.kind === 'patch' ? (
+          <PatchPreview
+            key={index}
+            groups={line.groups}
+            maxRows={lineMaxRows}
+            width={width}
+          />
+        ) : (
+          <Box
+            key={index}
+            flexDirection="row"
+            flexWrap="nowrap"
+            paddingLeft={index === 0 ? 0 : 2}
+          >
+            {line.spans.map((span, spanIndex) => (
+              <Text key={spanIndex} {...toolDisplaySpanTextProps(span)}>
+                {span.text}
+              </Text>
+            ))}
+          </Box>
+        ),
+      )}
+    </Box>
   );
 });

--- a/packages/cli/src/chat/tui/panes/ToolUseRow.tsx
+++ b/packages/cli/src/chat/tui/panes/ToolUseRow.tsx
@@ -8,6 +8,7 @@ import { Box, Text } from 'ink';
 import { type NormalizedToolUse } from '@shared/schemas';
 
 import { DiffView } from '../render/DiffView';
+import { clipToWidth } from '../render/terminalText';
 import { TOOL_OUTPUT_CORNER } from '../ui/glyphs';
 import {
   toolUseMarginBottomRows,
@@ -34,6 +35,7 @@ function PatchPreview({
   // terminals. `DiffView` floors this at its own minimum.
   const diffWidth =
     (width ?? PATCH_PREVIEW_FALLBACK_WIDTH) - PATCH_PREVIEW_INDENT;
+  const labelWidth = (width ?? PATCH_PREVIEW_FALLBACK_WIDTH) - 2;
   return (
     <Box
       flexDirection="column"
@@ -43,7 +45,12 @@ function PatchPreview({
     >
       {groups.map((group, index) => (
         <Box key={`${group.fileLabel}-${index}`} flexDirection="column">
-          <Text dimColor>{`${TOOL_OUTPUT_CORNER} ${group.fileLabel}`}</Text>
+          <Text dimColor>
+            {clipToWidth(
+              `${TOOL_OUTPUT_CORNER} ${group.fileLabel}`,
+              labelWidth,
+            )}
+          </Text>
           <Box flexDirection="column" paddingLeft={2}>
             <DiffView
               hunks={group.hunks}

--- a/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
@@ -164,9 +164,7 @@ export const TranscriptEntry = memo(function TranscriptEntry({
   readonly fillWidth?: boolean;
 }): React.JSX.Element {
   if (entry.role === 'tool') {
-    return (
-      <ToolUseRow fillWidth={fillWidth} toolUse={entry.toolUse} width={width} />
-    );
+    return <ToolUseRow toolUse={entry.toolUse} width={width} />;
   }
 
   const layout = transcriptEntryLayout(entry, {
@@ -221,6 +219,12 @@ export const BoundedTranscriptEntry = memo(function BoundedTranscriptEntry({
   readonly maxRows: number;
   readonly width?: number;
 }): React.JSX.Element {
+  if (entry.role === 'tool') {
+    return (
+      <ToolUseRow maxRows={maxRows} toolUse={entry.toolUse} width={width} />
+    );
+  }
+
   const layout = boundedTranscriptEntryLayout(
     transcriptEntryLayout(entry, {
       colorEnabled,

--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -1,7 +1,12 @@
-// Third-party imports
-import { useMemo } from 'react';
-
-import { Box, Text } from 'ink';
+// Tool-row rendering: one styled-line model is the single source of truth.
+//
+// `toolUseStyledLines` builds every visually distinct row of a tool card as
+// spans (text + color/dim/bold); the Ink painter in ToolUseRow renders those
+// spans, and `toolUseDisplayLines` projects the same lines to plain text for
+// the row-budget estimator, static row counting, and the ctrl+t transcript
+// viewer. The two presentations can no longer drift because there is nothing
+// to keep in sync by hand — the patch preview (DiffView) is the one rich
+// block that renders beyond its plain-text projection.
 
 // Local imports - shared schemas and utilities
 import { TOOL_USE_STATUS, type NormalizedToolUse } from '@shared/schemas';
@@ -14,7 +19,6 @@ import {
 
 // Local imports - CLI TUI rendering
 import {
-  DiffView,
   diffDisplayLines,
   editPatchGroups,
   type InlinePatchGroup,
@@ -25,6 +29,7 @@ import {
 } from '../render/terminalText';
 import { COLOR_ERROR, COLOR_HINT, COLOR_SUCCESS } from '../ui/colors';
 import { STATUS_DOT, TOOL_OUTPUT_CORNER } from '../ui/glyphs';
+
 const MAX_HEADER_PREVIEW = 80;
 const MAX_ERROR_PREVIEW = 240;
 // Header chrome around the preview: `● ` plus ` (` and `)`.
@@ -80,8 +85,8 @@ function elideOutputLines(lines: readonly string[]): ElidedOutput {
     return { head: lines.map(capLine), tail: [], hiddenCount: 0 };
   }
   // Cap only the head/tail lines actually rendered, not every discarded line
-  // in between — this runs on every OutputBlock redraw while a tool streams,
-  // so truncating lines nobody sees would be wasted grapheme-segmentation work.
+  // in between — this runs while a tool streams, so truncating lines nobody
+  // sees would be wasted grapheme-segmentation work.
   return {
     head: lines.slice(0, OUTPUT_HEAD_LINES).map(capLine),
     tail: lines.slice(lines.length - OUTPUT_TAIL_LINES).map(capLine),
@@ -110,16 +115,32 @@ export interface DisplayLineOptions {
   readonly elide?: boolean;
 }
 
-export interface ToolRenderer {
-  readonly key: string;
-  matches(toolUse: NormalizedToolUse): boolean;
-  render(toolUse: NormalizedToolUse, width?: number): React.JSX.Element;
-  /** Text geometry for budgeting and plain projections. Keep one line for
-   *  every visually distinct row emitted by `render`. */
-  displayLines(
-    toolUse: NormalizedToolUse,
-    options?: DisplayLineOptions,
-  ): readonly string[];
+export interface StyledLineOptions extends DisplayLineOptions {
+  /** Terminal columns for the width-adaptive header preview. Omitted (plain
+   *  projections) keeps the historical fixed 80-column budget. */
+  readonly width?: number;
+}
+
+/** One styled fragment of a tool row. */
+interface ToolDisplaySpan {
+  readonly text: string;
+  readonly bold?: boolean;
+  readonly color?: string;
+  readonly dim?: boolean;
+}
+
+/** A tool card row: ordinary span rows, plus one rich patch block whose
+ *  plain-text projection is carried alongside its DiffView groups. */
+export type ToolDisplayLine =
+  | { readonly kind: 'row'; readonly spans: readonly ToolDisplaySpan[] }
+  | {
+      readonly kind: 'patch';
+      readonly groups: readonly InlinePatchGroup[];
+      readonly textLines: readonly string[];
+    };
+
+function row(spans: readonly ToolDisplaySpan[]): ToolDisplayLine {
+  return { kind: 'row', spans };
 }
 
 function lastSegmentToolName(toolName: string): string {
@@ -187,14 +208,9 @@ function toolUsePatchGroups(
   return editPatchGroups(toolUse.input);
 }
 
-export function toolUsePatchDisplayLines(
-  toolUse: NormalizedToolUse,
-): readonly string[] {
-  const groups = toolUsePatchGroups(toolUse);
-  if (!groups) return [];
+function patchTextLines(groups: readonly InlinePatchGroup[]): string[] {
   // Plain text only: the colored full-width bands come from the `DiffView`
-  // component (live cards + scrollback render through it); these lines feed the
-  // transcript viewer and stay uncolored.
+  // component; these lines feed row budgeting and the transcript viewer.
   return groups.flatMap((group) => [
     `${TOOL_OUTPUT_CORNER} ${group.fileLabel}`,
     ...diffDisplayLines(group.hunks).map((line) => `  ${line.text}`),
@@ -207,8 +223,8 @@ export function toolUsePatchDisplayLines(
  *  all other tools prefer the curated per-tool summary first. */
 function toolHeaderPreview(
   toolUse: NormalizedToolUse,
-  maxPreview = MAX_HEADER_PREVIEW,
-  preferInputPreview = false,
+  maxPreview: number,
+  preferInputPreview: boolean,
 ): string {
   if (maxPreview <= 0) return '';
   const sourceText = preferInputPreview
@@ -217,29 +233,8 @@ function toolHeaderPreview(
   return sourceText ? truncateSummaryToWidth(sourceText, maxPreview) : '';
 }
 
-function formatHeader(
-  toolUse: NormalizedToolUse,
-  displayName = displayToolName(toolUse.toolName) || 'tool',
-): string {
-  const preview = toolHeaderPreview(toolUse);
-  return `${STATUS_DOT} ${displayName}${preview ? ` (${preview})` : ''}`;
-}
-
 function errorTextForDisplay(toolUse: NormalizedToolUse): string {
   return toolUse.isError ? toolUse.errorText || '(error)' : '';
-}
-
-/** Single corner line with the collapsed, truncated error text, or none when
- *  the tool did not error. */
-function errorCornerLines(toolUse: NormalizedToolUse): readonly string[] {
-  const errorText = errorTextForDisplay(toolUse);
-  if (!errorText) return [];
-  return [
-    `${TOOL_OUTPUT_CORNER} ${truncateWithEllipsis(
-      collapseWhitespace(errorText),
-      MAX_ERROR_PREVIEW,
-    )}`,
-  ];
 }
 
 function errorPreviewWouldTruncate(toolUse: NormalizedToolUse): boolean {
@@ -268,12 +263,11 @@ function outputDuplicatesError(
 
 function visibleOutputLines(
   toolUse: NormalizedToolUse,
-  options: { readonly keepDuplicateWhenErrorPreviewTruncates?: boolean } = {},
+  elide: boolean,
 ): readonly string[] {
   if (
     outputDuplicatesError(toolUse, {
-      keepWhenErrorPreviewTruncates:
-        options.keepDuplicateWhenErrorPreviewTruncates,
+      keepWhenErrorPreviewTruncates: !elide,
     })
   ) {
     return [];
@@ -299,359 +293,204 @@ function extractExitCode(toolUse: NormalizedToolUse): number | undefined {
   return match ? Number(match[1]) : undefined;
 }
 
-function outputDisplayLines(
+const CORNER_PREFIX_SPAN: ToolDisplaySpan = {
+  text: `${TOOL_OUTPUT_CORNER} `,
+  dim: true,
+};
+const CONTINUATION_PREFIX_SPAN: ToolDisplaySpan = { text: '  ', dim: true };
+
+function outputRows(
   toolUse: NormalizedToolUse,
-  elide = true,
-): string[] {
-  const lines = visibleOutputLines(toolUse, {
-    keepDuplicateWhenErrorPreviewTruncates: !elide,
-  });
+  elide: boolean,
+): ToolDisplayLine[] {
+  const lines = visibleOutputLines(toolUse, elide);
   const sliced = elide
     ? elideOutputLines(lines)
     : { head: lines, tail: [] as readonly string[], hiddenCount: 0 };
-  const out = sliced.head.map((line, index) =>
-    index === 0 ? `${TOOL_OUTPUT_CORNER} ${line}` : `  ${line}`,
+  const rows = sliced.head.map((line, index) =>
+    row([
+      index === 0 ? CORNER_PREFIX_SPAN : CONTINUATION_PREFIX_SPAN,
+      { text: line },
+    ]),
   );
   if (sliced.hiddenCount > 0) {
-    out.push(`  ${elisionMarker(sliced.hiddenCount)}`);
+    rows.push(
+      row([
+        CONTINUATION_PREFIX_SPAN,
+        { text: elisionMarker(sliced.hiddenCount), dim: true },
+      ]),
+    );
   }
-  for (const line of sliced.tail) out.push(`  ${line}`);
-  return out;
+  for (const line of sliced.tail) {
+    rows.push(row([CONTINUATION_PREFIX_SPAN, { text: line }]));
+  }
+  return rows;
 }
 
-function universalToolUseDisplayLines(
+/** Per-kind presentation switches — the whole replacement for the old
+ *  matches/render/displayLines renderer registry, in the registry's
+ *  precedence order: edit-style (a parseable patch) wins over MCP and bash. */
+function toolRowOptions(
   toolUse: NormalizedToolUse,
-  options: {
-    readonly displayName?: string;
-    readonly showOutput?: boolean;
-    readonly elide?: boolean;
-  } = {},
-): readonly string[] {
-  const patchLines = toolUsePatchDisplayLines(toolUse);
-  const outputLines =
-    options.showOutput === true
-      ? outputDisplayLines(toolUse, options.elide ?? true)
-      : [];
-  const showNoOutput =
-    options.showOutput === true &&
-    toolUse.status === TOOL_USE_STATUS.COMPLETED &&
-    outputLines.length === 0 &&
-    patchLines.length === 0 &&
-    !toolUse.isError;
-
-  return [
-    formatHeader(toolUse, options.displayName),
-    ...outputLines,
-    ...patchLines,
-    ...errorCornerLines(toolUse),
-    ...(showNoOutput ? [`${TOOL_OUTPUT_CORNER} (no output)`] : []),
-  ];
+  hasPatch: boolean,
+): {
+  readonly displayName: string;
+  readonly preferInputPreview: boolean;
+  readonly previewColor: string | undefined;
+  readonly showExitCode: boolean;
+  readonly showOutput: boolean;
+} {
+  const plain = {
+    displayName: displayToolName(toolUse.toolName) || 'tool',
+    preferInputPreview: false,
+    previewColor: undefined,
+    showExitCode: false,
+    showOutput: false,
+  };
+  // Edit-like tools show their patch preview instead of raw output.
+  if (hasPatch) return plain;
+  if (displayMcpToolName(toolUse.toolName) !== undefined) {
+    return { ...plain, showOutput: true };
+  }
+  const isBash =
+    toolDisplayKind(lastSegmentToolName(toolUse.toolName).toLowerCase()) ===
+    'bash';
+  if (isBash) {
+    return {
+      displayName: displayToolName(toolUse.toolName) || 'bash',
+      preferInputPreview: true,
+      previewColor: COLOR_HINT,
+      showExitCode: true,
+      showOutput: true,
+    };
+  }
+  // Every other tool keeps the compact header-only row (plus error and
+  // no-output corners) so e.g. a read_file result never dumps file contents.
+  return plain;
 }
 
-function bashToolUseDisplayLines(
+function buildStyledLines(
   toolUse: NormalizedToolUse,
-  options: { readonly elide?: boolean } = {},
-): readonly string[] {
-  const exitCode = extractExitCode(toolUse);
-  const outputLines = outputDisplayLines(toolUse, options.elide ?? true);
-  return [
-    formatHeader(toolUse),
-    ...outputLines,
-    ...(toolUse.isError && exitCode !== undefined
-      ? [`${TOOL_OUTPUT_CORNER} exit ${exitCode}`]
-      : []),
-    ...errorCornerLines(toolUse),
-    ...(toolUse.status === TOOL_USE_STATUS.COMPLETED &&
-    !toolUse.isError &&
-    outputLines.length === 0
-      ? [`${TOOL_OUTPUT_CORNER} (no output)`]
-      : []),
-  ];
-}
-
-/** Combined left padding of the two nested boxes wrapping the patch diff. */
-const PATCH_PREVIEW_INDENT = 4;
-
-function PatchPreview({
-  groups,
-  width,
-}: {
-  readonly groups: readonly InlinePatchGroup[];
-  readonly width?: number;
-}): React.JSX.Element {
-  // The diff sits under two nested `paddingLeft={2}` boxes; derive its width
-  // from the real terminal so the full-row bands fill exactly the available
-  // columns instead of padding to a fixed default and wrapping on narrow
-  // terminals. `DiffView` floors this at its own minimum.
-  const diffWidth = (width ?? MAX_HEADER_PREVIEW) - PATCH_PREVIEW_INDENT;
-  return (
-    <Box flexDirection="column" paddingLeft={2}>
-      {groups.map((group, index) => (
-        <Box key={`${group.fileLabel}-${index}`} flexDirection="column">
-          <Text dimColor>{`${TOOL_OUTPUT_CORNER} ${group.fileLabel}`}</Text>
-          <Box flexDirection="column" paddingLeft={2}>
-            <DiffView hunks={group.hunks} width={diffWidth} />
-          </Box>
-        </Box>
-      ))}
-    </Box>
-  );
-}
-
-function OutputBlock({
-  lines,
-}: {
-  readonly lines: readonly string[];
-}): React.JSX.Element | null {
-  if (lines.length === 0) return null;
-  const { head, tail, hiddenCount } = elideOutputLines(lines);
-  return (
-    <Box flexDirection="column" paddingLeft={2}>
-      {head.map((line, index) => (
-        <Box key={`h${index}`} flexDirection="row" flexWrap="nowrap">
-          <Text dimColor>{index === 0 ? `${TOOL_OUTPUT_CORNER} ` : '  '}</Text>
-          <Text>{line}</Text>
-        </Box>
-      ))}
-      {hiddenCount > 0 && (
-        <Box flexDirection="row" flexWrap="nowrap">
-          <Text dimColor>{'  '}</Text>
-          <Text dimColor>{elisionMarker(hiddenCount)}</Text>
-        </Box>
-      )}
-      {tail.map((line, index) => (
-        <Box key={`t${index}`} flexDirection="row" flexWrap="nowrap">
-          <Text dimColor>{'  '}</Text>
-          <Text>{line}</Text>
-        </Box>
-      ))}
-    </Box>
-  );
-}
-
-function CornerLine({
-  color,
-  children,
-}: {
-  readonly color?: typeof COLOR_ERROR;
-  readonly children: React.ReactNode;
-}): React.JSX.Element {
-  return (
-    <Box flexDirection="row" flexWrap="nowrap" paddingLeft={2}>
-      <Text dimColor>{`${TOOL_OUTPUT_CORNER} `}</Text>
-      <Text color={color} dimColor={!color}>
-        {children}
-      </Text>
-    </Box>
-  );
-}
-
-interface ToolRowProps {
-  readonly toolUse: NormalizedToolUse;
-  readonly width?: number;
-  readonly displayName?: string;
-  readonly fallbackName?: string;
-  readonly previewColor?: typeof COLOR_HINT;
-  readonly showPatch?: boolean;
-  readonly showOutput?: boolean;
-  readonly showExitCode?: boolean;
-  readonly preferInputPreview?: boolean;
-}
-
-function ToolRow(props: ToolRowProps): React.JSX.Element {
-  const {
-    toolUse,
-    previewColor,
-    showPatch = false,
-    showOutput = false,
-    showExitCode = false,
-    preferInputPreview = false,
-  } = props;
-  const columns = props.width;
+  options: StyledLineOptions,
+): readonly ToolDisplayLine[] {
+  const elide = options.elide !== false;
+  const patchGroups = toolUsePatchGroups(toolUse);
+  const opts = toolRowOptions(toolUse, patchGroups !== undefined);
   const color = statusColor(toolUse);
-  const name =
-    (props.displayName ?? displayToolName(toolUse.toolName)) ||
-    props.fallbackName ||
-    'tool';
-
-  const { patchGroups, preview, visibleOutput } = useMemo(
-    () => ({
-      patchGroups: showPatch ? toolUsePatchGroups(toolUse) : undefined,
-      preview: toolHeaderPreview(
-        toolUse,
-        toolHeaderPreviewBudget(columns, name),
-        preferInputPreview,
-      ),
-      visibleOutput: showOutput ? visibleOutputLines(toolUse) : [],
-    }),
-    [toolUse, showPatch, showOutput, preferInputPreview, columns, name],
+  const preview = toolHeaderPreview(
+    toolUse,
+    options.width === undefined
+      ? MAX_HEADER_PREVIEW
+      : toolHeaderPreviewBudget(options.width, opts.displayName),
+    opts.preferInputPreview,
   );
 
+  const output = opts.showOutput ? outputRows(toolUse, elide) : [];
+  const exitCode =
+    opts.showExitCode && toolUse.isError ? extractExitCode(toolUse) : undefined;
   const errorText = errorTextForDisplay(toolUse);
-  const exitCode = showExitCode ? extractExitCode(toolUse) : undefined;
   const showNoOutput =
-    showOutput &&
+    opts.showOutput &&
     toolUse.status === TOOL_USE_STATUS.COMPLETED &&
-    visibleOutput.length === 0 &&
+    output.length === 0 &&
     !patchGroups &&
     !toolUse.isError;
 
-  return (
-    <Box flexDirection="column" marginBottom={toolUseMarginBottomRows(toolUse)}>
-      <Box flexDirection="row" flexWrap="nowrap">
-        <Text color={color} dimColor={!color}>
-          {STATUS_DOT}{' '}
-        </Text>
-        <Text bold>{name}</Text>
-        {preview ? (
-          <Text color={previewColor} dimColor={!previewColor}>
-            {` (${preview})`}
-          </Text>
-        ) : null}
-      </Box>
-      <OutputBlock lines={visibleOutput} />
-      {patchGroups ? (
-        <PatchPreview groups={patchGroups} width={columns} />
-      ) : null}
-      {toolUse.isError && exitCode !== undefined ? (
-        <CornerLine color={COLOR_ERROR}>{`exit ${exitCode}`}</CornerLine>
-      ) : null}
-      {toolUse.isError ? (
-        <CornerLine color={COLOR_ERROR}>
-          {truncateWithEllipsis(
-            collapseWhitespace(errorText),
-            MAX_ERROR_PREVIEW,
-          )}
-        </CornerLine>
-      ) : null}
-      {showNoOutput ? <CornerLine>(no output)</CornerLine> : null}
-    </Box>
-  );
-}
-
-export function UniversalToolRow({
-  toolUse,
-  displayName,
-  showOutput,
-  width,
-}: {
-  readonly toolUse: NormalizedToolUse;
-  readonly displayName?: string;
-  readonly showOutput?: boolean;
-  readonly width?: number;
-}): React.JSX.Element {
-  return (
-    <ToolRow
-      toolUse={toolUse}
-      displayName={displayName}
-      showPatch={true}
-      showOutput={showOutput}
-      width={width}
-    />
-  );
-}
-
-function isBashTool(toolUse: NormalizedToolUse): boolean {
-  return (
-    toolDisplayKind(lastSegmentToolName(toolUse.toolName).toLowerCase()) ===
-    'bash'
-  );
-}
-
-function isMcpTool(toolUse: NormalizedToolUse): boolean {
-  return displayMcpToolName(toolUse.toolName) !== undefined;
-}
-
-const editRenderer: ToolRenderer = {
-  key: 'edit',
-  matches: (toolUse) => toolUsePatchGroups(toolUse) !== undefined,
-  render: (toolUse, width) => (
-    <UniversalToolRow toolUse={toolUse} width={width} />
-  ),
-  displayLines: (toolUse, options) =>
-    universalToolUseDisplayLines(toolUse, { elide: options?.elide }),
-};
-
-const bashRenderer: ToolRenderer = {
-  key: 'bash',
-  matches: isBashTool,
-  render: (toolUse, width) => (
-    <ToolRow
-      toolUse={toolUse}
-      fallbackName="bash"
-      previewColor={COLOR_HINT}
-      showOutput={true}
-      showExitCode={true}
-      preferInputPreview={true}
-      width={width}
-    />
-  ),
-  displayLines: (toolUse, options) =>
-    bashToolUseDisplayLines(toolUse, { elide: options?.elide }),
-};
-
-const mcpRenderer: ToolRenderer = {
-  key: 'mcp',
-  matches: isMcpTool,
-  render: (toolUse, width) => (
-    <UniversalToolRow
-      toolUse={toolUse}
-      displayName={displayMcpToolName(toolUse.toolName)}
-      showOutput={true}
-      width={width}
-    />
-  ),
-  displayLines: (toolUse, options) =>
-    universalToolUseDisplayLines(toolUse, {
-      displayName: displayMcpToolName(toolUse.toolName),
-      showOutput: true,
-      elide: options?.elide,
-    }),
-};
-
-const REGISTRY: readonly ToolRenderer[] = [
-  editRenderer,
-  bashRenderer,
-  mcpRenderer,
-];
-
-export function pickToolRenderer(
-  toolUse: NormalizedToolUse,
-): ToolRenderer | undefined {
-  return REGISTRY.find((renderer) => renderer.matches(toolUse));
+  return [
+    row([
+      { text: `${STATUS_DOT} `, color, dim: !color },
+      { text: opts.displayName, bold: true },
+      ...(preview
+        ? [
+            {
+              text: ` (${preview})`,
+              color: opts.previewColor,
+              dim: !opts.previewColor,
+            },
+          ]
+        : []),
+    ]),
+    ...output,
+    ...(patchGroups
+      ? [
+          {
+            kind: 'patch' as const,
+            groups: patchGroups,
+            textLines: patchTextLines(patchGroups),
+          },
+        ]
+      : []),
+    ...(exitCode !== undefined
+      ? [
+          row([
+            CORNER_PREFIX_SPAN,
+            { text: `exit ${exitCode}`, color: COLOR_ERROR },
+          ]),
+        ]
+      : []),
+    ...(errorText
+      ? [
+          row([
+            CORNER_PREFIX_SPAN,
+            {
+              text: truncateWithEllipsis(
+                collapseWhitespace(errorText),
+                MAX_ERROR_PREVIEW,
+              ),
+              color: COLOR_ERROR,
+            },
+          ]),
+        ]
+      : []),
+    ...(showNoOutput
+      ? [row([CORNER_PREFIX_SPAN, { text: '(no output)', dim: true }])]
+      : []),
+  ];
 }
 
 // Memoized per NormalizedToolUse object. `subscribeStreamLog` keeps the
 // toolUse reference stable across sync ticks unless its content changed, so
 // the derived lines (including diff hunks for edit tools) can be shared by
-// the live row estimator, the bounded renderer, and static row counting
-// instead of being recomputed for every visible tool row on every frame.
-interface ToolUseDisplayLinesCacheEntry {
-  elided?: readonly string[];
-  full?: readonly string[];
-}
-const displayLinesCache = new WeakMap<
+// the live painter, the row estimator, the bounded renderer, and static row
+// counting instead of being recomputed for every visible row on each frame.
+// The map key carries elision and the width-adaptive header budget.
+const styledLinesCache = new WeakMap<
   NormalizedToolUse,
-  ToolUseDisplayLinesCacheEntry
+  Map<string, readonly ToolDisplayLine[]>
 >();
 
+export function toolUseStyledLines(
+  toolUse: NormalizedToolUse,
+  options: StyledLineOptions = {},
+): readonly ToolDisplayLine[] {
+  const key = `${options.elide === false ? 'f' : 'e'}|${options.width ?? 'd'}`;
+  let cached = styledLinesCache.get(toolUse);
+  const hit = cached?.get(key);
+  if (hit) return hit;
+  const lines = buildStyledLines(toolUse, options);
+  if (!cached) {
+    cached = new Map();
+    styledLinesCache.set(toolUse, cached);
+  }
+  cached.set(key, lines);
+  return lines;
+}
+
+function lineText(line: ToolDisplayLine): readonly string[] {
+  return line.kind === 'patch'
+    ? line.textLines
+    : [line.spans.map((span) => span.text).join('')];
+}
+
+/** Plain-text projection of the same styled lines, for row budgeting, static
+ *  row counting, and the ctrl+t transcript viewer. */
 export function toolUseDisplayLines(
   toolUse: NormalizedToolUse,
   options?: DisplayLineOptions,
 ): readonly string[] {
-  const slot = options?.elide === false ? 'full' : 'elided';
-  let cached = displayLinesCache.get(toolUse);
-  const hit = cached?.[slot];
-  if (hit) return hit;
-  const lines =
-    pickToolRenderer(toolUse)?.displayLines(toolUse, options) ??
-    universalToolUseDisplayLines(toolUse, { elide: options?.elide });
-  if (!cached) {
-    cached = {};
-    displayLinesCache.set(toolUse, cached);
-  }
-  cached[slot] = lines;
-  return lines;
+  return toolUseStyledLines(toolUse, { elide: options?.elide }).flatMap(
+    lineText,
+  );
 }
 
 /** Tool detail rows are separated from the next conversation entry. Derive

--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -139,7 +139,10 @@ export type ToolDisplayLine =
     };
 
 function row(spans: readonly ToolDisplaySpan[]): ToolDisplayLine {
-  return { kind: 'row', spans };
+  return Object.freeze({
+    kind: 'row',
+    spans: Object.freeze(spans.map((span) => Object.freeze(span))),
+  });
 }
 
 function lastSegmentToolName(toolName: string): string {
@@ -299,11 +302,14 @@ function extractExitCode(toolUse: NormalizedToolUse): number | undefined {
   return match ? Number(match[1]) : undefined;
 }
 
-const CORNER_PREFIX_SPAN: ToolDisplaySpan = {
+const CORNER_PREFIX_SPAN: ToolDisplaySpan = Object.freeze({
   text: `${TOOL_OUTPUT_CORNER} `,
   dim: true,
-};
-const CONTINUATION_PREFIX_SPAN: ToolDisplaySpan = { text: '  ', dim: true };
+});
+const CONTINUATION_PREFIX_SPAN: ToolDisplaySpan = Object.freeze({
+  text: '  ',
+  dim: true,
+});
 
 function outputRows(
   toolUse: NormalizedToolUse,
@@ -355,9 +361,6 @@ function toolRowOptions(
   };
   // Edit-like tools show their patch preview instead of raw output.
   if (hasPatch) return plain;
-  if (displayMcpToolName(toolUse.toolName) !== undefined) {
-    return { ...plain, showOutput: true };
-  }
   const isBash =
     toolDisplayKind(lastSegmentToolName(toolUse.toolName).toLowerCase()) ===
     'bash';
@@ -369,6 +372,9 @@ function toolRowOptions(
       showExitCode: true,
       showOutput: true,
     };
+  }
+  if (displayMcpToolName(toolUse.toolName) !== undefined) {
+    return { ...plain, showOutput: true };
   }
   // Every other tool keeps the compact header-only row (plus error and
   // no-output corners) so e.g. a read_file result never dumps file contents.

--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -22,6 +22,7 @@ import {
   diffDisplayLines,
   editPatchGroups,
   type InlinePatchGroup,
+  wrappedDiffDisplayLines,
 } from '../render/DiffView';
 import {
   textDisplayWidth,
@@ -113,13 +114,11 @@ export interface DisplayLineOptions {
   /** When false, emit the full output instead of the head+tail slice.
    *  The transcript viewer (ctrl+t) sets this to show everything. */
   readonly elide?: boolean;
-}
-
-export interface StyledLineOptions extends DisplayLineOptions {
-  /** Terminal columns for the width-adaptive header preview. Omitted (plain
-   *  projections) keeps the historical fixed 80-column budget. */
+  /** Terminal columns when the projection must match rich rendered rows. */
   readonly width?: number;
 }
+
+export type StyledLineOptions = DisplayLineOptions;
 
 /** One styled fragment of a tool row. */
 interface ToolDisplaySpan {
@@ -208,12 +207,19 @@ function toolUsePatchGroups(
   return editPatchGroups(toolUse.input);
 }
 
-function patchTextLines(groups: readonly InlinePatchGroup[]): string[] {
+function patchTextLines(
+  groups: readonly InlinePatchGroup[],
+  width?: number,
+): string[] {
   // Plain text only: the colored full-width bands come from the `DiffView`
   // component; these lines feed row budgeting and the transcript viewer.
+  const diffWidth = width === undefined ? undefined : width - 4;
   return groups.flatMap((group) => [
     `${TOOL_OUTPUT_CORNER} ${group.fileLabel}`,
-    ...diffDisplayLines(group.hunks).map((line) => `  ${line.text}`),
+    ...(diffWidth === undefined
+      ? diffDisplayLines(group.hunks)
+      : wrappedDiffDisplayLines(group.hunks, diffWidth)
+    ).map((line) => `  ${line.text}`),
   ]);
 }
 
@@ -416,7 +422,7 @@ function buildStyledLines(
           {
             kind: 'patch' as const,
             groups: patchGroups,
-            textLines: patchTextLines(patchGroups),
+            textLines: patchTextLines(patchGroups, options.width),
           },
         ]
       : []),
@@ -488,9 +494,7 @@ export function toolUseDisplayLines(
   toolUse: NormalizedToolUse,
   options?: DisplayLineOptions,
 ): readonly string[] {
-  return toolUseStyledLines(toolUse, { elide: options?.elide }).flatMap(
-    lineText,
-  );
+  return toolUseStyledLines(toolUse, options).flatMap(lineText);
 }
 
 /** Tool detail rows are separated from the next conversation entry. Derive

--- a/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
@@ -179,14 +179,15 @@ function entryLines(
           }).split('\n')
         : wrapWithPrefix(entry.text, columns, '', '');
     case 'tool': {
+      const richProjection =
+        mode === 'live' || mode === 'bounded' || mode === 'scrollback-budget';
       const lines = toolUseDisplayLines(entry.toolUse, {
         elide: mode !== 'viewer' && mode !== 'scrollback-budget',
+        ...(richProjection ? { width: columns } : {}),
       });
       // Rich rows and their bounded fallback keep each display line on one
       // terminal row. Other modes paint the wrapped text projection directly.
-      return mode === 'live' || mode === 'bounded'
-        ? lines
-        : wrapDisplayLines(lines, columns);
+      return richProjection ? lines : wrapDisplayLines(lines, columns);
     }
     case 'process': {
       const lines = completedProcessDisplayLines(entry.process);
@@ -221,9 +222,7 @@ export function transcriptEntryLayout(
   } = {},
 ): TranscriptEntryLayout {
   const base = ROLE_GEOMETRY[entry.role];
-  // The bounded tool fallback historically uses a one-column Ink gutter; the
-  // rich unbounded tool renderer owns its own per-line indentation.
-  const inset = entry.role === 'tool' && mode === 'bounded' ? 2 : base.inset;
+  const inset = base.inset;
   const isInquiryContinuation =
     entry.role === 'user' && isInquiryContinuationText(entry.text);
   const marginTopRows = isInquiryContinuation ? 0 : base.marginTopRows;

--- a/src/test-kernel/cli/ToolRenderers.vitest.mts
+++ b/src/test-kernel/cli/ToolRenderers.vitest.mts
@@ -53,6 +53,11 @@ describe('CLI tool display lines', () => {
         spans: [{ dim: true, text: '⎿ ' }, { text: 'passed' }],
       },
     ]);
+    expect(Object.isFrozen(toolUseStyledLines(entry)[0])).toBe(true);
+    const firstLine = toolUseStyledLines(entry)[0];
+    if (firstLine?.kind !== 'row') throw new Error('expected a row');
+    expect(Object.isFrozen(firstLine.spans)).toBe(true);
+    expect(firstLine.spans.every(Object.isFrozen)).toBe(true);
   });
 
   it('counts wrapped patch rows at the rich terminal width', () => {
@@ -83,6 +88,27 @@ describe('CLI tool display lines', () => {
         "  +We use a transformer.",
       ]
     `);
+  });
+
+  it('keeps bash semantics ahead of generic MCP presentation', () => {
+    const entry = toolUse(
+      'mcp:terminal:bash',
+      { command: 'false' },
+      {
+        errorText: 'Command failed (exit 7)',
+        isError: true,
+        parsed: { exitCode: 7 },
+      },
+    );
+
+    expect(toolUseDisplayLines(entry)).toEqual([
+      '● terminal/bash (false)',
+      '⎿ exit 7',
+      '⎿ Command failed (exit 7)',
+    ]);
+    const header = toolUseStyledLines(entry)[0];
+    if (header?.kind !== 'row') throw new Error('expected a header row');
+    expect(header.spans.at(-1)).toMatchObject({ color: 'cyan' });
   });
 
   it('renders TeXRA edit_file calls through the native diff row', () => {

--- a/src/test-kernel/cli/ToolRenderers.vitest.mts
+++ b/src/test-kernel/cli/ToolRenderers.vitest.mts
@@ -3,9 +3,9 @@ import { describe, expect, it } from 'vitest';
 
 // Local imports - shared schemas
 import {
-  pickToolRenderer,
   toolHeaderPreviewBudget,
   toolUseDisplayLines,
+  toolUseStyledLines,
 } from '@cli/chat/tui/panes/toolRenderers';
 import { TOOL_USE_STATUS, type NormalizedToolUse } from '@shared/schemas';
 
@@ -31,7 +31,30 @@ function toolUse(
   };
 }
 
-describe('CLI tool renderer registry', () => {
+describe('CLI tool display lines', () => {
+  it('carries semantic styles in the display model', () => {
+    const entry = toolUse(
+      'bash',
+      { command: 'npm test' },
+      { outputText: 'passed' },
+    );
+
+    expect(toolUseStyledLines(entry)).toEqual([
+      {
+        kind: 'row',
+        spans: [
+          { color: 'green', dim: false, text: '● ' },
+          { bold: true, text: 'bash' },
+          { color: 'cyan', dim: false, text: ' (npm test)' },
+        ],
+      },
+      {
+        kind: 'row',
+        spans: [{ dim: true, text: '⎿ ' }, { text: 'passed' }],
+      },
+    ]);
+  });
+
   it('registers edit patch rendering before the universal fallback', () => {
     const entry = toolUse('Edit', {
       path: 'paper.tex',
@@ -39,7 +62,6 @@ describe('CLI tool renderer registry', () => {
       new_string: 'We use a transformer.\n',
     });
 
-    expect(pickToolRenderer(entry)?.key).toBe('edit');
     expect(toolUseDisplayLines(entry)).toMatchInlineSnapshot(`
       [
         "● Edit (paper.tex)",
@@ -58,7 +80,6 @@ describe('CLI tool renderer registry', () => {
       new_str: 'We use a transformer.\n',
     });
 
-    expect(pickToolRenderer(entry)?.key).toBe('edit');
     expect(toolUseDisplayLines(entry)).toMatchInlineSnapshot(`
       [
         "● edit_file (paper.tex)",
@@ -83,7 +104,6 @@ describe('CLI tool renderer registry', () => {
       },
     );
 
-    expect(pickToolRenderer(entry)?.key).toBe('bash');
     expect(toolUseDisplayLines(entry)).toMatchInlineSnapshot(`
       [
         "● bash (npm run lint)",
@@ -225,7 +245,6 @@ describe('CLI tool renderer registry', () => {
       { outputText: 'sent' },
     );
 
-    expect(pickToolRenderer(entry)?.key).toBe('mcp');
     expect(toolUseDisplayLines(entry)).toMatchInlineSnapshot(`
       [
         "● slack/send ({"channel":"#drafts","text":"done"})",
@@ -237,7 +256,6 @@ describe('CLI tool renderer registry', () => {
   it('keeps unregistered tools on the universal renderer', () => {
     const entry = toolUse('CustomTool', { path: 'paper.tex' });
 
-    expect(pickToolRenderer(entry)).toBeUndefined();
     expect(toolUseDisplayLines(entry)).toMatchInlineSnapshot(`
       [
         "● CustomTool (paper.tex)",

--- a/src/test-kernel/cli/ToolRenderers.vitest.mts
+++ b/src/test-kernel/cli/ToolRenderers.vitest.mts
@@ -55,6 +55,18 @@ describe('CLI tool display lines', () => {
     ]);
   });
 
+  it('counts wrapped patch rows at the rich terminal width', () => {
+    const entry = toolUse('Edit', {
+      path: 'paper.tex',
+      old_string: 'short\n',
+      new_string: `${'a long replacement '.repeat(8)}\n`,
+    });
+
+    expect(toolUseDisplayLines(entry, { width: 24 }).length).toBeGreaterThan(
+      toolUseDisplayLines(entry).length,
+    );
+  });
+
   it('registers edit patch rendering before the universal fallback', () => {
     const entry = toolUse('Edit', {
       path: 'paper.tex',

--- a/src/test-kernel/cli/ToolUseRowPatch.vitest.mts
+++ b/src/test-kernel/cli/ToolUseRowPatch.vitest.mts
@@ -1,8 +1,18 @@
+import { createRequire } from 'node:module';
+
 import { describe, expect, it } from 'vitest';
 
-import { filledToolUseDisplayText } from '@cli/chat/tui/panes/ToolUseRow';
-import { toolUsePatchDisplayLines } from '@cli/chat/tui/panes/toolRenderers';
+import { toolDisplaySpanTextProps } from '@cli/chat/tui/panes/ToolUseRow';
+import {
+  toolUseDisplayLines,
+  toolUseStyledLines,
+} from '@cli/chat/tui/panes/toolRenderers';
+import type { ConversationEntry } from '@cli/chat/tui/state/cliState';
 import { TOOL_USE_STATUS, type NormalizedToolUse } from '@shared/schemas';
+
+const cliRequire = createRequire(
+  new URL('../../../packages/cli/package.json', import.meta.url),
+);
 
 function toolUse(
   toolName: string,
@@ -24,9 +34,39 @@ function toolUse(
   };
 }
 
+function patchRows(entry: NormalizedToolUse): readonly string[] {
+  // The patch block follows the single header row in the display lines.
+  return toolUseDisplayLines(entry).slice(1);
+}
+
+async function renderBoundedTool(
+  entry: NormalizedToolUse,
+  maxRows: number,
+): Promise<string> {
+  const ink = (await import(cliRequire.resolve('ink'))) as any;
+  const React = ((await import(cliRequire.resolve('react'))) as any).default;
+  const { BoundedTranscriptEntry } =
+    await import('@cli/chat/tui/panes/TranscriptEntry');
+  const transcriptEntry: ConversationEntry = {
+    finalized: false,
+    id: 'bounded-tool',
+    role: 'tool',
+    text: '',
+    toolUse: entry,
+  };
+  return ink.renderToString(
+    React.createElement(BoundedTranscriptEntry, {
+      entry: transcriptEntry,
+      maxRows,
+      width: 80,
+    }),
+    { columns: 80 },
+  );
+}
+
 describe('ToolUseRow edit patch rendering', () => {
   it('renders an Edit input as an inline patch preview', () => {
-    const rows = toolUsePatchDisplayLines(
+    const rows = patchRows(
       toolUse('Edit', {
         path: 'paper.tex',
         old_string: 'We use a CNN.\n',
@@ -45,7 +85,7 @@ describe('ToolUseRow edit patch rendering', () => {
   });
 
   it('renders MultiEdit edits as patch previews for the target file', () => {
-    const rows = toolUsePatchDisplayLines(
+    const rows = patchRows(
       toolUse('MultiEdit', {
         file_path: 'paper.tex',
         edits: [
@@ -76,15 +116,17 @@ describe('ToolUseRow edit patch rendering', () => {
   });
 
   it('falls back for non-edit tools and failed edits', () => {
+    // Bash keeps its output pipeline (no patch rows beyond the header).
     expect(
-      toolUsePatchDisplayLines(
+      toolUseDisplayLines(
         toolUse('Bash', {
           command: 'echo hi',
         }),
       ),
-    ).toEqual([]);
+    ).toEqual(['● Bash (echo hi)', '⎿ (no output)']);
+    // A failed edit shows the error corner instead of a patch preview.
     expect(
-      toolUsePatchDisplayLines(
+      toolUseDisplayLines(
         toolUse(
           'Edit',
           {
@@ -92,22 +134,59 @@ describe('ToolUseRow edit patch rendering', () => {
             old_string: 'old',
             new_string: 'new',
           },
-          { isError: true },
+          { errorText: 'edit failed', isError: true },
         ),
       ),
-    ).toEqual([]);
+    ).toEqual(['● Edit (paper.tex)', '⎿ edit failed']);
   });
 
-  it('pads compact tool display lines to the viewport width', () => {
-    expect(
-      filledToolUseDisplayText(
-        toolUse(
-          'Bash',
-          { command: 'ls' },
-          { status: TOOL_USE_STATUS.IN_PROGRESS },
-        ),
-        14,
+  it('maps semantic spans to Ink text styles', () => {
+    const lines = toolUseStyledLines(
+      toolUse(
+        'bash',
+        { command: 'false' },
+        { errorText: 'command failed', isError: true },
       ),
-    ).toBe('● Bash (ls)   ');
+    );
+    const errorLine = lines.at(-1);
+    expect(errorLine?.kind).toBe('row');
+    if (errorLine?.kind !== 'row') throw new Error('expected an error row');
+
+    expect(toolDisplaySpanTextProps(errorLine.spans[0])).toEqual({
+      bold: undefined,
+      color: undefined,
+      dimColor: true,
+    });
+    expect(toolDisplaySpanTextProps(errorLine.spans[1])).toEqual({
+      bold: undefined,
+      color: 'red',
+      dimColor: false,
+    });
+  });
+
+  it('renders a styled tail when a tool exceeds its bounded viewport', async () => {
+    const rendered = await renderBoundedTool(
+      toolUse(
+        'bash',
+        { command: 'npm test' },
+        {
+          errorText: 'Command failed (exit 2)',
+          isError: true,
+          outputText: Array.from(
+            { length: 20 },
+            (_, index) => `line ${index + 1}`,
+          ).join('\n'),
+          parsed: { exitCode: 2 },
+        },
+      ),
+      2,
+    );
+
+    expect(rendered.split('\n').map((line) => line.trimStart())).toEqual([
+      '⎿ exit 2',
+      '⎿ Command failed (exit 2)',
+    ]);
+    expect(rendered).not.toContain('line 20');
+    expect(rendered).not.toContain('● bash');
   });
 });


### PR DESCRIPTION
## Summary

Closes #8628.

CLI tool rows previously had two independent presentations: an Ink component tree for normal display and a parallel plain-string formatter for row budgeting, bounded overflow, and transcript projection. Error rows, exit codes, no-output state, patch labels, and elision therefore had to remain synchronized by convention.

This change replaces both with one span-capable styled-line model. The normal painter, bounded painter, row estimator, margin calculation, and plain transcript projection all consume that model. Tool rows clipped by the transcript viewport now retain their status, preview, and error styling.

## Design

- `toolUseStyledLines()` owns text, semantic spans, and patch blocks.
- `ToolUseRow` is a small painter from spans to Ink `Text` properties.
- `toolUseDisplayLines()` is a text-only projection of the same model.
- The edit/bash/MCP renderer registry and duplicate JSX/string logic are removed; one options function selects the few tool-kind differences.
- Width-adaptive headers use a width-keyed cache; plain projection preserves the established default budget.
- Patch previews remain a rich `DiffView` block while carrying width-aware wrapped geometry from the same diff helper in the line model.
- Bounded rows select a viewport from the same semantic lines rather than flattening to one unstyled `Text`.

## Acceptance gates

- Normal, bounded, and plain tool presentations derive from one model.
- Error, exit, output-elision, patch, and no-output rows have one production definition.
- Bounded overflow preserves semantic Ink styles.
- Row budgeting and transcript projection retain existing text geometry.
- No exported renderer registry or dead fill-width formatter remains.

## Net elements

7 files changed, 479 insertions, 431 deletions, net +48 lines. Although the line count grows modestly because the new model and bounded painter now have direct style-level tests, the parallel renderer interface, three renderer objects, duplicated formatter branches, and dead fill-width path are removed.

## Validation

- Focused Vitest: 77 tests passed across the tool renderer and CLI transcript suites
- CLI and test-kernel TypeScript checks
- ESLint on changed TypeScript files
- Prettier and commit-hook formatting
- Dead-code ratchet
- Six relevant PTY TUI scenarios, including static and live tool rows

The two PTY spacing expectations now document the user message band's intentional single trailing row; reverting them fails the corresponding scenarios on current main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core TUI transcript rendering and row budgeting for all tool types; behavior is well-covered by focused Vitest and PTY harness updates, but regressions could affect layout or overflow in edge cases.
> 
> **Overview**
> CLI tool rows no longer maintain **two parallel presentations** (Ink components plus a separate plain-string formatter). Everything flows through **`toolUseStyledLines()`** — span-based rows and optional patch blocks — with **`ToolUseRow`** painting those spans and **`toolUseDisplayLines()`** as the text-only projection for row budgeting and Ctrl+T.
> 
> **Bounded transcript overflow** for tools now uses the same styled model with a **`maxRows` viewport** (tail-preserved clipping) instead of flattening to unstyled filled text, so status dots, previews, errors, and patch **`DiffView`** blocks keep their cues when space is tight. The old renderer registry, duplicate JSX formatters, and **`fillWidth`** tool path are removed.
> 
> Row budgeting passes **terminal width** into the projection where live/bounded modes need it; TUI harness spacing expectations allow **one blank line** below the user band by design.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc14142b12d1c5f31f5fb00a47a19a0a1b04f8b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->