### PR TITLE
fix(tools): wire approval inheritance and live cost into workflow-script children

### DIFF
--- a/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
@@ -18,6 +18,11 @@ const mocks = vi.hoisted(() => ({
   resolveChildRunOutput: vi.fn(),
   runStorageLocationFromAnyAbsolutePath: vi.fn(),
   assertWorkflowFilesExist: vi.fn(),
+  configureDelegatedChildApprovals: vi.fn(),
+}));
+
+vi.mock('@tools/approval', () => ({
+  configureDelegatedChildApprovals: mocks.configureDelegatedChildApprovals,
 }));
 
 vi.mock('@tools/delegation/inBandSubagentExecution', () => {
@@ -234,6 +239,40 @@ describe('createWorkflowScriptAgentRunner', () => {
       expect.objectContaining({
         configPayload: expect.objectContaining({ inputFiles: [] }),
       }),
+    );
+  });
+
+  it('links child approval ancestry to the parent stream on resolve', async () => {
+    const runner = defaultRunner();
+
+    await runner(invocation());
+
+    const prepared = mocks.preparedOptions[0] as {
+      onStreamResolved?: (streamId: StreamTabId) => void;
+    };
+    expect(prepared.onStreamResolved).toEqual(expect.any(Function));
+    prepared.onStreamResolved?.('stream:child' as StreamTabId);
+    expect(mocks.configureDelegatedChildApprovals).toHaveBeenCalledWith(
+      'stream:child',
+      parentStreamId,
+      'inherit',
+      expect.objectContaining({ id: 'session' }),
+    );
+  });
+
+  it('threads onCost through to the child execution', async () => {
+    const onCost = vi.fn();
+    const runner = createWorkflowScriptAgentRunner(
+      parentContext(),
+      'correct',
+      'tool-call-7',
+      { onCost },
+    );
+
+    await runner(invocation());
+
+    expect(mocks.preparedOptions[0]).toEqual(
+      expect.objectContaining({ onCost }),
     );
   });
 

--- a/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
@@ -124,6 +124,61 @@ return await agent('Read', { phase: 'Review' })`;
     );
   });
 
+  it('renders the running total on live finish lines only', async () => {
+    const store = getExecutionStore(executionId);
+    const script = `${meta}
+await agent('First')
+return await agent('Second')`;
+    const { trace, events } = recordingTrace();
+    let liveCostUsd = 0;
+    await runPersistedWorkflowScriptWithProgress(trace, {
+      store,
+      checkpointId: 'live-cost',
+      script,
+      runAgent: async () => {
+        liveCostUsd += 0.05;
+        return 'done';
+      },
+      getLiveCostUsd: () => liveCostUsd,
+    });
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: 'log',
+        message: 'Finished: First ($0.050 total)',
+      }),
+    );
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: 'log',
+        message: 'Finished: Second ($0.100 total)',
+      }),
+    );
+
+    clearStoreCache();
+    const replay = recordingTrace();
+    await runPersistedWorkflowScriptWithProgress(replay.trace, {
+      store: getExecutionStore(executionId),
+      checkpointId: 'live-cost',
+      script,
+      runAgent: vi.fn(() => Promise.reject(new Error('must not run'))),
+      getLiveCostUsd: () => 0,
+    });
+
+    expect(replay.events).toContainEqual(
+      expect.objectContaining({
+        type: 'log',
+        message: 'Using saved result: First',
+      }),
+    );
+    expect(replay.events).not.toContainEqual(
+      expect.objectContaining({
+        type: 'log',
+        message: expect.stringContaining('total)'),
+      }),
+    );
+  });
+
   it('marks a phase failed when an agent call fails', async () => {
     const { trace, events } = recordingTrace();
     await runPersistedWorkflowScriptWithProgress(trace, {

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -91,6 +91,10 @@ The agent field is the default for agent() calls; a call may select another visi
       callContext.hooks?.recordSubagentCost?.(cost);
     };
 
+    // Live display accumulator only: covers success and failure of this run's
+    // live children (cached replays spend nothing). Boundary settlement below
+    // stays journal-based so resumed runs still roll up replayed spend.
+    let liveCostUsd = 0;
     let run: WorkflowScriptRunResult;
     try {
       run = await runPersistedWorkflowScriptWithProgress(callContext.trace, {
@@ -103,7 +107,13 @@ The agent field is the default for agent() calls; a call may select another visi
           parent,
           input.agent,
           checkpointId,
+          {
+            onCost: (totalCostUsd) => {
+              liveCostUsd += totalCostUsd ?? 0;
+            },
+          },
         ),
+        getLiveCostUsd: () => liveCostUsd,
       });
     } catch (runError) {
       try {

--- a/src/tools/delegation/workflowScriptAgentRunner.ts
+++ b/src/tools/delegation/workflowScriptAgentRunner.ts
@@ -7,6 +7,7 @@ import {
 import type { LaunchRunContext } from '@agent/runtime/RunContext';
 import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@shared/schemas';
+import { configureDelegatedChildApprovals } from '@tools/approval';
 import { filterNotNullish } from '@utils/core';
 import { deriveExecutionId } from '@utils/core/idHash';
 import { runStorageLocationFromAnyAbsolutePath } from '@utils/files/taskRunStorage';
@@ -59,6 +60,10 @@ export function createWorkflowScriptAgentRunner(
   parent: LaunchRunContext,
   defaultAgentName: string,
   checkpointId: string,
+  hooks?: {
+    /** Fires per live child on success and failure with its total cost. */
+    readonly onCost?: (totalCostUsd: number | undefined) => void;
+  },
 ): WorkflowAgentRunner {
   const { runScope } = parent;
 
@@ -114,6 +119,18 @@ export function createWorkflowScriptAgentRunner(
             signal: invocation.signal,
             approvalPromptsUnavailable: parent.approvalPromptsUnavailable,
             runtimeUnavailableTools: parent.runtimeUnavailableTools,
+            // Live per-kind ancestry, matching LLM delegation: bash and
+            // tool-edit each follow the parent's own bypass; proposal stays
+            // unlinked so a child's own delegations still prompt.
+            onStreamResolved: (resolvedStreamId) => {
+              configureDelegatedChildApprovals(
+                resolvedStreamId,
+                runScope.streamId,
+                'inherit',
+                runScope.session,
+              );
+            },
+            onCost: hooks?.onCost,
           };
         },
       });

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -9,11 +9,15 @@ import {
 } from '@agent/workflowScript';
 import { AgentFinalResultSchema } from '@agent/runtime/AgentFinalResult';
 import { RUN_OUTCOME, type RunOutcome } from '@shared/schemas';
+import { formatCostUsd } from '@utils/text/stringUtils';
 
 type WorkflowScriptRunWithProgressOptions = Omit<
   PersistedWorkflowScriptRunOptions,
   'onEvent'
->;
+> & {
+  /** Cumulative live spend across this run's children, for progress lines. */
+  readonly getLiveCostUsd?: () => number;
+};
 
 interface PhaseStage {
   readonly handle: StageHandle;
@@ -52,6 +56,7 @@ export async function runPersistedWorkflowScriptWithProgress(
   trace: AgentTrace,
   options: WorkflowScriptRunWithProgressOptions,
 ): Promise<WorkflowScriptRunResult> {
+  const { getLiveCostUsd, ...runOptions } = options;
   const parentStageId = trace.activeStageId();
   const phases = new Map<string, PhaseStage>();
   const callPhases = new Map<number, string | undefined>();
@@ -102,13 +107,20 @@ export async function runPersistedWorkflowScriptWithProgress(
           : (event.phase ?? currentPhase);
         callPhases.delete(event.index);
         const stageId = stageIdFor(phaseTitle);
+        // Cached replays spend nothing, so their lines stay cost-free; live
+        // onCost settles before agent:end, so the total here is current.
+        const spent = event.cached ? undefined : getLiveCostUsd?.();
+        const total =
+          spent === undefined ? '' : ` (${formatCostUsd(spent)} total)`;
         if (event.error) {
           if (phaseTitle) phaseFor(phaseTitle).failed = true;
-          trace.error(`Failed: ${event.label} - ${event.error}`, { stageId });
+          trace.error(`Failed: ${event.label} - ${event.error}${total}`, {
+            stageId,
+          });
         } else if (event.cached) {
           trace.info(`Using saved result: ${event.label}`, { stageId });
         } else {
-          trace.info(`Finished: ${event.label}`, { stageId });
+          trace.info(`Finished: ${event.label}${total}`, { stageId });
         }
         break;
       }
@@ -117,7 +129,7 @@ export async function runPersistedWorkflowScriptWithProgress(
 
   try {
     const result = await runPersistedWorkflowScript({
-      ...options,
+      ...runOptions,
       onEvent: project,
     });
     runOutcome = RUN_OUTCOME.COMPLETED;


### PR DESCRIPTION
## Problem

Two gaps in the workflow-script `agent()` runner (verified in the 2026-07-16 delegation audit):

1. **Approval inheritance**: `createWorkflowScriptAgentRunner`'s `prepare()` never returned `onStreamResolved`, so script children skipped `configureDelegatedChildApprovals` and defaulted to gated. In interactive hosts, script children could raise per-child approval prompts inside the script's wall clock with no bash/toolEdit bypass ancestry from the parent, while LLM-delegated children (via `executeSubagent`) inherit correctly.
2. **Cost visibility**: the runner never wired `onCost`, so a running script (up to 200 children) surfaced zero spend until the tool-result boundary, and failed children's spend was invisible there too (failed attempts are never journaled).

## Change

- `prepare()` now returns `onStreamResolved` wired to `configureDelegatedChildApprovals(child, parentStream, 'inherit', session)` — same per-kind ancestry semantics as LLM delegation (bash/toolEdit linked, proposal deliberately unlinked).
- `prepare()` threads an optional `onCost` hook; `WorkflowScriptTool` feeds it into a live accumulator covering success and failure of live children (`createCostSettler` fires on both; cached replays and stable recoveries never reach it, so they correctly add $0).
- `runPersistedWorkflowScriptWithProgress` folds the running total into the existing trace lines: `Finished: label ($0.100 total)` / `Failed: ...`; cached `Using saved result:` lines stay cost-free.
- Boundary settlement (`recordSubagentCost`) stays journal-based, unchanged, so resumed runs still roll up replayed spend; the accumulator is display-only.

## Verified

- `WorkflowScriptAgentRunner.vitest.ts` (+2 tests: ancestry linking on resolve, onCost threading)
- `WorkflowScriptProgressBridge.vitest.ts` (+1 test: totals on live finish lines, none on cached replay)
- `WorkflowScriptTool.vitest.ts` unchanged and green; root + test-kernel tsc clean

Closes #8646

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches approval inheritance and cost display in the workflow-script delegation path; behavior is aligned with existing LLM delegation but affects interactive prompts and trace output for script runs.
> 
> **Overview**
> Workflow-script `agent()` children now match LLM delegation for **approval bypass ancestry** and **live spend visibility**.
> 
> `createWorkflowScriptAgentRunner` adds `onStreamResolved` → `configureDelegatedChildApprovals(..., 'inherit', session)` so bash/toolEdit bypass follows the parent stream; proposal stays unlinked. An optional `onCost` hook is passed through to in-band child execution.
> 
> `WorkflowScriptTool` accumulates live child spend via `onCost` and passes `getLiveCostUsd` into progress projection. **Finished** / **Failed** trace lines append a running total (e.g. `($0.100 total)`); cached **Using saved result:** lines stay unchanged. Journal-based `recordSubagentCost` at the tool boundary is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36509a001728f9c8f2f01a14abc2b59c2e7a37d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->