### PR TITLE
fix(agent): content-keyed workflow-script checkpoints and meta timeout

### DIFF
--- a/src/agent/workflowScript/checkpointKey.ts
+++ b/src/agent/workflowScript/checkpointKey.ts
@@ -1,26 +1,34 @@
+// Node imports
 import { createHash } from 'node:crypto';
 
+// Third-party imports
 import stableStringify from 'fast-json-stable-stringify';
 
 const WORKFLOW_SCRIPT_CHECKPOINT_KEY_PREFIX = 'workflow-script-';
 
 /**
- * Content-derived checkpoint identity: the same script and args under the
- * same parent execution resume the same durable journal, so an LLM retry
- * after a timeout or interruption (which mints a new tool-call id) replays
- * completed work instead of orphaning it. Same-content semantics: a script
- * that must re-execute from scratch needs different content (e.g. a nonce
- * field in args).
+ * Content-derived checkpoint identity: the same script, args, and default
+ * agent under the same parent execution resume the same durable journal, so
+ * an LLM retry after a timeout or interruption (which mints a new tool-call
+ * id) replays completed work instead of orphaning it. Same-content
+ * semantics: a script that must re-execute from scratch needs different
+ * content (e.g. a nonce field in args).
+ *
+ * Omitted args and explicit null args hash differently (stableStringify
+ * drops undefined properties), matching the persistence layer, which
+ * stores them as distinct values and fails loudly on a mismatch.
  */
 export function deriveWorkflowScriptCheckpointId(identity: {
   readonly script: string;
   readonly args: unknown;
+  readonly defaultAgent: string;
   readonly parentExecutionId: string;
 }): string {
   return createHash('sha256')
     .update(
       stableStringify({
-        args: identity.args ?? null,
+        args: identity.args,
+        defaultAgent: identity.defaultAgent,
         parentExecutionId: identity.parentExecutionId,
         script: identity.script,
       }),

--- a/src/agent/workflowScript/checkpointKey.ts
+++ b/src/agent/workflowScript/checkpointKey.ts
@@ -1,6 +1,33 @@
 import { createHash } from 'node:crypto';
 
+import stableStringify from 'fast-json-stable-stringify';
+
 const WORKFLOW_SCRIPT_CHECKPOINT_KEY_PREFIX = 'workflow-script-';
+
+/**
+ * Content-derived checkpoint identity: the same script and args under the
+ * same parent execution resume the same durable journal, so an LLM retry
+ * after a timeout or interruption (which mints a new tool-call id) replays
+ * completed work instead of orphaning it. Same-content semantics: a script
+ * that must re-execute from scratch needs different content (e.g. a nonce
+ * field in args).
+ */
+export function deriveWorkflowScriptCheckpointId(identity: {
+  readonly script: string;
+  readonly args: unknown;
+  readonly parentExecutionId: string;
+}): string {
+  return createHash('sha256')
+    .update(
+      stableStringify({
+        args: identity.args ?? null,
+        parentExecutionId: identity.parentExecutionId,
+        script: identity.script,
+      }),
+    )
+    .digest('hex')
+    .slice(0, 32);
+}
 
 /** Build the execution-KV key owned by one workflow invocation. */
 export function workflowScriptCheckpointKvKey(checkpointId: string): string {

--- a/src/agent/workflowScript/index.ts
+++ b/src/agent/workflowScript/index.ts
@@ -1,3 +1,4 @@
+export { deriveWorkflowScriptCheckpointId } from './checkpointKey';
 export { parseWorkflowScript, WorkflowScriptParseError } from './parseScript';
 export { runWorkflowScript, WorkflowRunAbortError } from './runWorkflowScript';
 export {

--- a/src/agent/workflowScript/runWorkflowScript.ts
+++ b/src/agent/workflowScript/runWorkflowScript.ts
@@ -193,10 +193,10 @@ export async function runWorkflowScript(
 ): Promise<WorkflowScriptRunResult> {
   const { runAgent, onEvent, onJournalEntry } = options;
   const concurrency = options.concurrency ?? DEFAULT_CONCURRENCY;
-  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const maxAgentCalls = options.maxAgentCalls ?? DEFAULT_MAX_AGENT_CALLS;
 
   const { meta, body } = parseWorkflowScript(options.script);
+  const timeoutMs = options.timeoutMs ?? meta.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const priorEntries = new Map<number, WorkflowJournalEntry>(
     (options.journal ?? []).map((entry) => [entry.index, entry]),
   );

--- a/src/agent/workflowScript/types.ts
+++ b/src/agent/workflowScript/types.ts
@@ -15,6 +15,12 @@ export const WorkflowScriptMetaSchema = z.object({
   description: z.string().min(1),
   whenToUse: z.string().optional(),
   phases: z.array(WorkflowScriptPhaseSchema).optional(),
+  /** Whole-run wall clock, bounded; an explicit run option still wins. */
+  timeoutMs: z
+    .int()
+    .min(1_000)
+    .max(60 * 60 * 1000)
+    .optional(),
 });
 
 export type WorkflowScriptMeta = z.infer<typeof WorkflowScriptMetaSchema>;

--- a/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
@@ -855,6 +855,43 @@ return await agent('two')`,
     expect(sawAbort).toBe(true);
   });
 
+  it('honors meta.timeoutMs when no run option is given', async () => {
+    await expect(
+      runWorkflowScript({
+        script: `export const meta = {
+  name: 'engine-test',
+  description: 'meta-declared wall clock',
+  timeoutMs: 1000,
+}
+return await agent('one')`,
+        runAgent: async () => {
+          await delay(2_500);
+          return 'late';
+        },
+      }),
+    ).rejects.toThrow(/timed out/);
+  });
+
+  it('lets an explicit run option override meta.timeoutMs', async () => {
+    const startedAt = Date.now();
+    await expect(
+      runWorkflowScript({
+        script: `export const meta = {
+  name: 'engine-test',
+  description: 'run option beats meta',
+  timeoutMs: 3600000,
+}
+return await agent('one')`,
+        runAgent: async () => {
+          await delay(300);
+          return 'late';
+        },
+        timeoutMs: 40,
+      }),
+    ).rejects.toThrow(/timed out/);
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
+  });
+
   it('preempts a CPU loop reached after an agent await', async () => {
     const startedAt = Date.now();
     await expect(

--- a/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
@@ -57,6 +57,7 @@ function checkpointIdFor(scriptSource: string, args?: unknown): string {
   return deriveWorkflowScriptCheckpointId({
     script: scriptSource,
     args,
+    defaultAgent: 'correct',
     parentExecutionId: executionId,
   });
 }
@@ -150,8 +151,10 @@ describe('WorkflowScriptTool', () => {
       summary: "Completed workflow script 'tool-test' (1 agent call)",
     });
     expect(result.output).toContain('"category": "workflow"');
+    // Delta accounting: replayed entries were settled by the attempt that
+    // executed them, so a pure replay settles zero instead of double-billing.
     expect(recordCost).toHaveBeenCalledTimes(1);
-    expect(recordCost).toHaveBeenCalledWith(0.42);
+    expect(recordCost).toHaveBeenCalledWith(0);
 
     // A retry mints a new tool-call id; identical content resumes the journal.
     clearStoreCache();
@@ -161,7 +164,20 @@ describe('WorkflowScriptTool', () => {
       recordCost: retryCost,
     });
     expect(retry).toMatchObject({ status: 'executed' });
-    expect(retryCost).toHaveBeenCalledWith(0.42);
+    expect(retryCost).toHaveBeenCalledWith(0);
+  });
+
+  it('derives distinct checkpoints when args presence or default agent differ', () => {
+    const base = checkpointIdFor(script);
+    expect(checkpointIdFor(script, null)).not.toBe(base);
+    expect(
+      deriveWorkflowScriptCheckpointId({
+        script,
+        args: undefined,
+        defaultAgent: 'merge',
+        parentExecutionId: executionId,
+      }),
+    ).not.toBe(base);
   });
 
   it('passes JSON arguments through and formats a zero-call result', async () => {
@@ -212,8 +228,9 @@ throw new Error('script failed after replay')`;
       status: 'error',
       error: expect.stringContaining('script failed after replay'),
     });
+    // The seeding attempt journaled the entry; this attempt only replays it.
     expect(recordCost).toHaveBeenCalledTimes(1);
-    expect(recordCost).toHaveBeenCalledWith(0.42);
+    expect(recordCost).toHaveBeenCalledWith(0);
   });
 
   it('fails closed on malformed journal costs without recording a scalar', async () => {

--- a/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
@@ -3,7 +3,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { clearStoreCache, getExecutionStore } from '@agent/storage';
 import { TraceEmitter } from '@agent/trace';
-import { runPersistedWorkflowScript } from '@agent/workflowScript';
+import {
+  deriveWorkflowScriptCheckpointId,
+  runPersistedWorkflowScript,
+} from '@agent/workflowScript';
 import { withToolFileInteractionContext } from '@agent/followUp/ToolFileInteractionContext';
 import type { AgentFinalResult } from '@agent/runtime/AgentFinalResult';
 import type { LaunchRunContext } from '@agent/runtime/RunContext';
@@ -49,8 +52,17 @@ function parentContext(): LaunchRunContext {
   };
 }
 
+/** The tool's durable identity for a script+args pair under the test parent. */
+function checkpointIdFor(scriptSource: string, args?: unknown): string {
+  return deriveWorkflowScriptCheckpointId({
+    script: scriptSource,
+    args,
+    parentExecutionId: executionId,
+  });
+}
+
 async function callTool(options?: {
-  readonly checkpointId?: string;
+  readonly toolCallId?: string;
   readonly script?: string;
   readonly recordCost?: (cost: number) => void;
   readonly signal?: AbortSignal;
@@ -61,7 +73,7 @@ async function callTool(options?: {
     withToolFileInteractionContext(
       {
         tracker: {} as never,
-        toolCallId: options?.checkpointId ?? 'tool-call',
+        toolCallId: options?.toolCallId ?? 'tool-call',
         trace: options?.trace ?? new TraceEmitter(),
         signal: options?.signal,
         hooks: { recordSubagentCost: options?.recordCost ?? vi.fn() },
@@ -119,31 +131,19 @@ describe('WorkflowScriptTool', () => {
       status: 'error',
       error: expect.stringContaining('parent progress trace'),
     });
-
-    const missingCallId = await withRunContext(parentContext(), () =>
-      withToolFileInteractionContext(
-        { tracker: {} as never, trace: new TraceEmitter() },
-        () => new WorkflowScriptTool().call({ agent: 'correct', script }),
-      ),
-    );
-    expect(missingCallId).toMatchObject({
-      status: 'error',
-      error: expect.stringContaining('tool call id'),
-    });
   });
 
-  it('replays a checkpoint and settles completed child cost exactly once', async () => {
-    const checkpointId = 'replay-cost';
+  it('replays a content-keyed checkpoint across distinct tool-call ids', async () => {
     await runPersistedWorkflowScript({
       store: getExecutionStore(executionId),
-      checkpointId,
+      checkpointId: checkpointIdFor(script),
       script,
       runAgent: async () => finalResult,
     });
     clearStoreCache();
     const recordCost = vi.fn();
 
-    const result = await callTool({ checkpointId, recordCost });
+    const result = await callTool({ toolCallId: 'attempt-1', recordCost });
 
     expect(result).toMatchObject({
       status: 'executed',
@@ -152,12 +152,21 @@ describe('WorkflowScriptTool', () => {
     expect(result.output).toContain('"category": "workflow"');
     expect(recordCost).toHaveBeenCalledTimes(1);
     expect(recordCost).toHaveBeenCalledWith(0.42);
+
+    // A retry mints a new tool-call id; identical content resumes the journal.
+    clearStoreCache();
+    const retryCost = vi.fn();
+    const retry = await callTool({
+      toolCallId: 'attempt-2',
+      recordCost: retryCost,
+    });
+    expect(retry).toMatchObject({ status: 'executed' });
+    expect(retryCost).toHaveBeenCalledWith(0.42);
   });
 
   it('passes JSON arguments through and formats a zero-call result', async () => {
     const recordCost = vi.fn();
     const result = await callTool({
-      checkpointId: 'args-result',
       script: `export const meta = {
   name: 'arguments',
   description: 'returns its arguments',
@@ -177,7 +186,6 @@ return args`,
   });
 
   it('settles a retained journal when later script code fails', async () => {
-    const checkpointId = 'partial-failure';
     const failingScript = `export const meta = {
   name: 'tool-test',
   description: 'tests retained journal settlement',
@@ -187,7 +195,7 @@ throw new Error('script failed after replay')`;
     await expect(
       runPersistedWorkflowScript({
         store: getExecutionStore(executionId),
-        checkpointId,
+        checkpointId: checkpointIdFor(failingScript),
         script: failingScript,
         runAgent: async () => finalResult,
       }),
@@ -196,7 +204,6 @@ throw new Error('script failed after replay')`;
     const recordCost = vi.fn();
 
     const result = await callTool({
-      checkpointId,
       recordCost,
       script: failingScript,
     });
@@ -210,17 +217,22 @@ throw new Error('script failed after replay')`;
   });
 
   it('fails closed on malformed journal costs without recording a scalar', async () => {
-    const checkpointId = 'malformed-cost';
+    // Distinct script so this journal cannot alias the replay test's content key.
+    const malformedScript = `export const meta = {
+  name: 'tool-test',
+  description: 'tests malformed journal cost settlement',
+}
+return await agent('saved call')`;
     await runPersistedWorkflowScript({
       store: getExecutionStore(executionId),
-      checkpointId,
-      script,
+      checkpointId: checkpointIdFor(malformedScript),
+      script: malformedScript,
       runAgent: async () => ({ not: 'an agent result' }),
     });
     clearStoreCache();
     const recordCost = vi.fn();
 
-    const result = await callTool({ checkpointId, recordCost });
+    const result = await callTool({ recordCost, script: malformedScript });
 
     expect(result).toMatchObject({
       status: 'error',

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -79,6 +79,7 @@ Durable resume is content-keyed: re-running the identical script and args in thi
     const checkpointId = deriveWorkflowScriptCheckpointId({
       script: input.script,
       args: input.args,
+      defaultAgent: input.agent,
       parentExecutionId: parent.runScope.executionId,
     });
     if (!callContext.trace) {
@@ -88,10 +89,20 @@ Durable resume is content-keyed: re-running the identical script and args in thi
     }
 
     const store = getExecutionStore(parent.runScope.executionId);
+    // Delta accounting across attempts: a checkpoint now outlives one tool
+    // call, and every attempt (including the failure path) settles cost, so
+    // re-settling replayed entries would double-bill the parent. Each attempt
+    // settles only the entries it journaled itself; the whole journal is
+    // still validated so malformed entries fail closed.
+    const settledEntries = new Set(
+      (await readWorkflowScriptCheckpoint(store, checkpointId))?.journal.map(
+        (entry) => entry.index,
+      ),
+    );
     let costSettled = false;
     const settleCost = (journal: readonly WorkflowJournalEntry[]): void => {
       if (costSettled) return;
-      const cost = sumCompletedWorkflowJournalCost(journal);
+      const cost = sumCompletedWorkflowJournalCost(journal, settledEntries);
       costSettled = true;
       callContext.hooks?.recordSubagentCost?.(cost);
     };

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 // Local imports - agent runtime
 import { getExecutionStore } from '@agent/storage';
 import {
+  deriveWorkflowScriptCheckpointId,
   readWorkflowScriptCheckpoint,
   type WorkflowJournalEntry,
   type WorkflowScriptRunResult,
@@ -59,7 +60,9 @@ export class WorkflowScriptTool extends defineTool({
 
 Available agents: loaded from the active roster at runtime.
 
-The agent field is the default for agent() calls; a call may select another visible workflow agent with options.agentName. Model selection follows the active model access mode automatically. Tool inclusion is the opt-in boundary: do not add this tool to a default agent configuration.`,
+The agent field is the default for agent() calls; a call may select another visible workflow agent with options.agentName. Model selection follows the active model access mode automatically. Tool inclusion is the opt-in boundary: do not add this tool to a default agent configuration.
+
+Durable resume is content-keyed: re-running the identical script and args in this session replays already-completed agent() calls from the saved journal instead of re-executing them, so retry a timed-out or interrupted call with the SAME script and args to keep its completed work. To force a fresh run instead, change the content (e.g. add a nonce field to args). meta.timeoutMs (1s to 60min) overrides the default 10-minute whole-run wall clock.`,
   schema: WorkflowScriptToolInputSchema,
 }) {
   protected async execute(input: WorkflowScriptToolInput): Promise<ToolResult> {
@@ -70,12 +73,14 @@ The agent field is the default for agent() calls; a call may select another visi
       );
     }
     const { runContext: parent, callContext } = contexts;
-    const checkpointId = callContext.toolCallId;
-    if (!checkpointId) {
-      throw new Error(
-        'delegate_workflow_script requires a tool call id for durable resume.',
-      );
-    }
+    // Content-keyed, not toolCallId-keyed: an LLM retry after a timeout or
+    // interruption mints a new tool-call id, and keying on it would orphan
+    // the journal and every derived child identity (#8647).
+    const checkpointId = deriveWorkflowScriptCheckpointId({
+      script: input.script,
+      args: input.args,
+      parentExecutionId: parent.runScope.executionId,
+    });
     if (!callContext.trace) {
       throw new Error(
         'delegate_workflow_script requires the parent progress trace.',

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -30,9 +30,15 @@ export class WorkflowJournalCostError extends Error {
   }
 }
 
-/** Sum completed logical-call cost; failed and cancelled attempts are not journaled. */
+/**
+ * Sum completed logical-call cost; failed and cancelled attempts are not
+ * journaled. Every entry is validated, but entries in `excludeIndices`
+ * (journaled by a prior attempt, whose cost that attempt already settled)
+ * do not count toward the total.
+ */
 export function sumCompletedWorkflowJournalCost(
   journal: readonly WorkflowJournalEntry[],
+  excludeIndices: ReadonlySet<number> = new Set(),
 ): number {
   let total = 0;
   for (const entry of journal) {
@@ -42,7 +48,7 @@ export function sumCompletedWorkflowJournalCost(
         cause: result.error,
       });
     }
-    total += result.data.cost;
+    if (!excludeIndices.has(entry.index)) total += result.data.cost;
   }
   return total;
 }


### PR DESCRIPTION
## Problem

Verified in the 2026-07-16 delegation audit (#8647):

1. `delegate_workflow_script` keyed its durable checkpoint on `callContext.toolCallId`, and every child execution id derives from that checkpoint id. An LLM retry after a timeout or interruption mints a new tool-call id, so the journal and all completed child work were orphaned: the run could not resume despite the durable journal existing, and all paid-for work was lost.
2. The whole-run wall clock was a hard, non-configurable 10 minutes (the engine accepted `timeoutMs`, but the tool never passed it and scripts could not declare it), so any script whose total wall time exceeds 10 minutes could neither finish nor resume.

## Change

- New `deriveWorkflowScriptCheckpointId({script, args, parentExecutionId})` (sha256 over stable-stringified content) in `src/agent/workflowScript/checkpointKey.ts`; the tool uses it instead of `toolCallId` and no longer requires a tool-call id. Semantics move from same-call to same-content: identical retried content resumes the journal, which matches the engine's deterministic replay contract. Forcing a fresh run means changing the content (e.g. a nonce field in `args`) — documented in the tool description.
- `WorkflowScriptMetaSchema` gains optional `timeoutMs` (1s to 60min); the engine resolves `options.timeoutMs ?? meta.timeoutMs ?? DEFAULT_TIMEOUT_MS` (an explicit run option still wins).
- The persistence layer's script/args mismatch fail-loud check stays; with content keying it becomes a defensive invariant rather than a reachable path.

## Verified

- `WorkflowScriptTool.vitest.ts`: replay test now proves cross-tool-call-id resume (attempt-1 and attempt-2 both replay one seeded journal); seeding switched to derived content keys; per-test scripts made distinct so content keys cannot alias.
- `WorkflowScriptEngine.vitest.ts`: +2 tests (meta.timeoutMs honored; explicit run option overrides meta).
- 97 tests green across the four affected suites; root + test-kernel tsc clean.

Closes #8647

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes durable checkpoint identity and billing for delegation workflows—behavior shifts on retry/resume—but is covered by targeted tests and preserves fail-closed journal validation.
> 
> **Overview**
> **Durable workflow-script resume** no longer keys checkpoints on `toolCallId`. `deriveWorkflowScriptCheckpointId` hashes script, args, default agent, and parent execution id so LLM retries with the same content reuse the journal; the tool drops the tool-call-id requirement and documents same-content vs fresh-run (e.g. nonce in args).
> 
> **Cost settlement** avoids double-billing across attempts: prior journal indices are excluded when summing subagent cost for a new tool call.
> 
> **Wall clock**: optional `meta.timeoutMs` (1s–60min) in script meta; the engine uses `options.timeoutMs ?? meta.timeoutMs ??` the 10-minute default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fea61c0b3062c53ecc0f6ea7a49e27e8b326c22e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->