### PR TITLE
feat(storage): cross-host execution liveness heartbeat guards deletes

### DIFF
--- a/packages/cli/src/commands/history.ts
+++ b/packages/cli/src/commands/history.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 import { defineCommand } from 'citty';
 
 import { assembleTrace, injectStandaloneTrace } from '@transcript';
+import { describeHeartbeatOwner } from '@agent/storage';
 import { formatChatAsMarkdown } from '@agent/export/chatExportFormatter';
 import { type ExecutionId } from '@shared/schemas';
 import { formatResultCount } from '@utils/text/stringUtils';
@@ -234,10 +235,27 @@ async function runHistoryDelete(
     writeTextStderr(formatCliHistoryNotFoundText(result.id, context.cwd));
     return CliExitCode.Usage;
   }
+  // Same split for a refused live deletion: structured consumers branch on
+  // `live: true`, text consumers get a stderr error and a failure exit.
+  if (
+    result.deleted === 'one' &&
+    result.live &&
+    context.outputFormat === 'text'
+  ) {
+    writeTextStderr(
+      `Cannot delete execution ${result.id}: it is running in ${describeHeartbeatOwner(result.liveHost)}.`,
+    );
+    return CliExitCode.AgentError;
+  }
 
   let text: string;
   if (result.deleted === 'all') {
     text = `Deleted ${formatResultCount(result.count, 'stored execution')}.`;
+    if (result.skippedLive > 0) {
+      text += ` Skipped ${formatResultCount(result.skippedLive, 'running execution')}.`;
+    }
+  } else if (result.live) {
+    text = '';
   } else if (result.found) {
     text = `Deleted execution ${result.id}.`;
   } else {

--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -6,9 +6,11 @@ import {
   deleteAllExecutions,
   deleteExecution,
   deriveResumability,
+  getExecutionLiveness,
   getExecutionStore,
   isUserVisibleExecution,
   listExecutions,
+  listLiveExecutionIds,
   unwrapResultMeta,
   type ExecutionListingEntry,
   type ExecutionMeta,
@@ -106,11 +108,20 @@ export function userStartedCliHistoryEntries<
 }
 
 export type CliHistoryDeleteResult =
-  | { readonly deleted: 'all'; readonly count: number }
+  | {
+      readonly deleted: 'all';
+      readonly count: number;
+      /** Executions skipped because they are live in some process (#8625). */
+      readonly skippedLive: number;
+    }
   | {
       readonly deleted: 'one';
       readonly id: ExecutionId;
       readonly found: boolean;
+      /** True when deletion was refused because the run is live (#8625). */
+      readonly live?: boolean;
+      /** Host that owns the live run, when its heartbeat records one. */
+      readonly liveHost?: string;
     };
 
 export function parseCliHistoryId(raw: string): ExecutionId | undefined {
@@ -304,13 +315,30 @@ export async function deleteCliHistory(options: {
   preCountForAll?: number;
 }): Promise<CliHistoryDeleteResult> {
   if (options.all) {
-    const deletedExecutionIds = await deleteAllExecutions();
+    // Executions live in any host sharing ~/.texra survive a clear (#8625).
+    const liveIds = await listLiveExecutionIds();
+    const deletedExecutionIds = await deleteAllExecutions(new Set(liveIds));
     await GoalStore.forgetByExecutionIds(deletedExecutionIds);
-    const count = options.preCountForAll ?? deletedExecutionIds.length;
-    return { deleted: 'all', count };
+    // The preflight count was taken before live runs were excluded, so it
+    // overstates the deletion when any were skipped — report actuals then.
+    const count =
+      liveIds.length > 0
+        ? deletedExecutionIds.length
+        : (options.preCountForAll ?? deletedExecutionIds.length);
+    return { deleted: 'all', count, skippedLive: liveIds.length };
   }
   if (!options.id) {
     throw new Error('Expected an execution id, or --all.');
+  }
+  const liveness = await getExecutionLiveness(options.id);
+  if (liveness.live) {
+    return {
+      deleted: 'one',
+      id: options.id,
+      found: true,
+      live: true,
+      liveHost: liveness.ownerHost,
+    };
   }
   const found = await deleteExecution(options.id);
   if (found) {

--- a/packages/cli/src/runtime/history.ts
+++ b/packages/cli/src/runtime/history.ts
@@ -10,7 +10,6 @@ import {
   getExecutionStore,
   isUserVisibleExecution,
   listExecutions,
-  listLiveExecutionIds,
   unwrapResultMeta,
   type ExecutionListingEntry,
   type ExecutionMeta,
@@ -315,17 +314,17 @@ export async function deleteCliHistory(options: {
   preCountForAll?: number;
 }): Promise<CliHistoryDeleteResult> {
   if (options.all) {
-    // Executions live in any host sharing ~/.texra survive a clear (#8625).
-    const liveIds = await listLiveExecutionIds();
-    const deletedExecutionIds = await deleteAllExecutions(new Set(liveIds));
-    await GoalStore.forgetByExecutionIds(deletedExecutionIds);
+    // deleteAllExecutions skips runs live in any host sharing ~/.texra,
+    // checking liveness per id at delete time (#8625).
+    const { deleted, skippedLive } = await deleteAllExecutions();
+    await GoalStore.forgetByExecutionIds(deleted);
     // The preflight count was taken before live runs were excluded, so it
     // overstates the deletion when any were skipped — report actuals then.
     const count =
-      liveIds.length > 0
-        ? deletedExecutionIds.length
-        : (options.preCountForAll ?? deletedExecutionIds.length);
-    return { deleted: 'all', count, skippedLive: liveIds.length };
+      skippedLive.length > 0
+        ? deleted.length
+        : (options.preCountForAll ?? deleted.length);
+    return { deleted: 'all', count, skippedLive: skippedLive.length };
   }
   if (!options.id) {
     throw new Error('Expected an execution id, or --all.');

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -17,12 +17,12 @@ import {
 } from '@platform/defaults/nodeStorage';
 import { SHUTDOWN_PHASE } from '@platform/interfaces';
 import { initPlatform, platform, tryPlatform } from '@platform/platform';
-import { UsageLogService } from '@telemetry/UsageLogService';
-import { setHeartbeatOwnerHost } from '@agent/storage';
 
 // Local imports - telemetry
+import { UsageLogService } from '@telemetry/UsageLogService';
 
-// Local imports - agent index
+// Local imports - agent
+import { setHeartbeatOwnerHost } from '@agent/storage';
 import { createPlatformAgentDirectories } from '@agent/index/platformAgentDirectories';
 
 // Local imports - auth

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -17,9 +17,10 @@ import {
 } from '@platform/defaults/nodeStorage';
 import { SHUTDOWN_PHASE } from '@platform/interfaces';
 import { initPlatform, platform, tryPlatform } from '@platform/platform';
+import { UsageLogService } from '@telemetry/UsageLogService';
+import { setHeartbeatOwnerHost } from '@agent/storage';
 
 // Local imports - telemetry
-import { UsageLogService } from '@telemetry/UsageLogService';
 
 // Local imports - agent index
 import { createPlatformAgentDirectories } from '@agent/index/platformAgentDirectories';
@@ -300,6 +301,7 @@ export async function initCliPlatform(
       channel: 'cli',
       customDirectoryStore: { get: () => undefined },
     });
+    setHeartbeatOwnerHost('cli');
     initPlatform(
       createNodePlatform({
         configStores: { workspace: configStore, global: globalConfigStore },

--- a/packages/desktop/src/main/desktopHistoryHandlers.ts
+++ b/packages/desktop/src/main/desktopHistoryHandlers.ts
@@ -10,7 +10,6 @@ import {
   describeHeartbeatOwner,
   getExecutionLiveness,
   getExecutionStore,
-  listLiveExecutionIds,
 } from '@agent/storage';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import {
@@ -111,11 +110,10 @@ export class DesktopHistoryHandlers implements DesktopHistorySettingsController 
   }
 
   private async clear(): Promise<void> {
+    // deleteAllExecutions itself skips runs live in any host (#8625);
+    // this process's active ids are excluded up front as a cheap fast path.
     await deleteAllExecutions(
-      new Set([
-        ...this.dependencies.getActiveExecutionIds(),
-        ...(await listLiveExecutionIds()),
-      ]),
+      new Set(this.dependencies.getActiveExecutionIds()),
     );
     this.dependencies.postToRenderer({
       command: SETTINGS_VIEW_COMMANDS.HISTORY_CLEARED,

--- a/packages/desktop/src/main/desktopHistoryHandlers.ts
+++ b/packages/desktop/src/main/desktopHistoryHandlers.ts
@@ -7,7 +7,10 @@ import { buildHistoryMessage } from '@controllers/settingsView/HistoryMessageBui
 import {
   deleteAllExecutions,
   deleteExecution,
+  describeHeartbeatOwner,
+  getExecutionLiveness,
   getExecutionStore,
+  listLiveExecutionIds,
 } from '@agent/storage';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import {
@@ -87,6 +90,15 @@ export class DesktopHistoryHandlers implements DesktopHistorySettingsController 
       );
       return;
     }
+    // The shared ~/.texra root means the run may be live in another host
+    // (CLI or extension) this process's registry cannot see (#8625).
+    const liveness = await getExecutionLiveness(historyId as ExecutionId);
+    if (liveness.live) {
+      await this.dependencies.showInfoMessage(
+        `Cannot delete: this execution is running in ${describeHeartbeatOwner(liveness.ownerHost)}`,
+      );
+      return;
+    }
 
     const deleted = await deleteExecution(historyId as ExecutionId);
     if (!deleted) {
@@ -100,7 +112,10 @@ export class DesktopHistoryHandlers implements DesktopHistorySettingsController 
 
   private async clear(): Promise<void> {
     await deleteAllExecutions(
-      new Set(this.dependencies.getActiveExecutionIds()),
+      new Set([
+        ...this.dependencies.getActiveExecutionIds(),
+        ...(await listLiveExecutionIds()),
+      ]),
     );
     this.dependencies.postToRenderer({
       command: SETTINGS_VIEW_COMMANDS.HISTORY_CLEARED,

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -17,6 +17,7 @@ import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 import { initPlatform } from '@platform/platform';
 import { SHUTDOWN_PHASE } from '@platform/interfaces';
 import { StreamSnapshotStore } from '@transcript';
+import { setHeartbeatOwnerHost } from '@agent/storage';
 import { createPlatformAgentDirectories } from '@agent/index/platformAgentDirectories';
 import { isFileNotFoundError } from '@common/errors';
 import { DESKTOP_WORKSPACE_PATH_STATE_KEY } from '@desktop/workspacePath.js';
@@ -275,6 +276,7 @@ export async function initializeElectronPlatform(
       get: () => globalStateStore.get<string>(GlobalStateKey.CUSTOM_AGENT_DIR),
     },
   });
+  setHeartbeatOwnerHost('desktop');
   initPlatform(
     createNodePlatform({
       configStores: {

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -16,7 +16,11 @@ import { defaultSkillSources, setRuntimeSkillSources } from '@skills/index';
 import { StreamLogStore } from '@transcript';
 import { createNodeStorageProvider } from '@platform/defaults/nodeStorage';
 import { loadAgents } from '@agent/index';
-import { clearStoreCache, listExecutions } from '@agent/storage';
+import {
+  clearStoreCache,
+  listExecutions,
+  setHeartbeatOwnerHost,
+} from '@agent/storage';
 import { registerAgentFeatures } from '@agent/features';
 import { initializeGoalPrompts } from '@agent/goal/promptLoader';
 import {
@@ -221,6 +225,7 @@ export async function activate(context: vscode.ExtensionContext) {
     workspacePath: () => workspace.getWorkspacePath(),
   });
   await migrateLegacyVscodeStorage(context, storage);
+  setHeartbeatOwnerHost('extension');
   initPlatform({
     config: new VscodeConfigProvider(),
     globalState: context.globalState,

--- a/packages/extension/src/settingsView/handlers/historyHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/historyHandlers.ts
@@ -24,7 +24,6 @@ import {
   deleteAllExecutions,
   describeHeartbeatOwner,
   getExecutionLiveness,
-  listLiveExecutionIds,
 } from '@agent/storage';
 import {
   AgentConfigSchema,
@@ -139,11 +138,10 @@ export class HistoryHandlers {
 
   async handleClearHistory(): Promise<void> {
     try {
+      // deleteAllExecutions itself skips runs live in any host (#8625);
+      // this process's active ids are excluded up front as a cheap fast path.
       await deleteAllExecutions(
-        new Set([
-          ...defaultSession().executions.getActiveIds(),
-          ...(await listLiveExecutionIds()),
-        ]),
+        new Set(defaultSession().executions.getActiveIds()),
       );
       await vscode.window.showInformationMessage('Agent history cleared');
       await this.ctx.withActiveWebview(async (w) => {

--- a/packages/extension/src/settingsView/handlers/historyHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/historyHandlers.ts
@@ -22,6 +22,9 @@ import {
   getExecutionStore,
   deleteExecution,
   deleteAllExecutions,
+  describeHeartbeatOwner,
+  getExecutionLiveness,
+  listLiveExecutionIds,
 } from '@agent/storage';
 import {
   AgentConfigSchema,
@@ -106,6 +109,17 @@ export class HistoryHandlers {
         );
         return;
       }
+      // The shared ~/.texra root means the run may be live in another host
+      // (CLI or desktop) this process's registry cannot see (#8625).
+      const liveness = await getExecutionLiveness(
+        data.historyId as ExecutionId,
+      );
+      if (liveness.live) {
+        await vscode.window.showWarningMessage(
+          `Cannot delete: this execution is running in ${describeHeartbeatOwner(liveness.ownerHost)}`,
+        );
+        return;
+      }
       const deleted = await deleteExecution(data.historyId as ExecutionId);
       if (deleted) {
         await this.ctx.withActiveWebview((w) => this.sendHistoryData(w));
@@ -126,7 +140,10 @@ export class HistoryHandlers {
   async handleClearHistory(): Promise<void> {
     try {
       await deleteAllExecutions(
-        new Set(defaultSession().executions.getActiveIds()),
+        new Set([
+          ...defaultSession().executions.getActiveIds(),
+          ...(await listLiveExecutionIds()),
+        ]),
       );
       await vscode.window.showInformationMessage('Agent history cleared');
       await this.ctx.withActiveWebview(async (w) => {

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -262,6 +262,10 @@ export class ExecutionRegistry {
   track(handle: ExecutionHandle): void {
     this.handles.set(handle.executionId, handle);
     this.ensureHeartbeatTimer();
+    // Best-effort: a failed touch only shortens this run's cross-host delete
+    // protection (guards fail open to pre-#8625 behavior). The run itself
+    // writes the same executions/ tree constantly, so a persistent disk
+    // failure surfaces loudly through the run, not through this touch.
     void touchExecutionHeartbeat(handle.executionId as ExecutionId).catch(
       () => {},
     );
@@ -358,6 +362,7 @@ export class ExecutionRegistry {
     if (this.heartbeatTimer) return;
     const timer = setInterval(() => {
       for (const executionId of this.handles.keys()) {
+        // Best-effort, same rationale as the touch in track().
         void touchExecutionHeartbeat(executionId as ExecutionId).catch(
           () => {},
         );

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -6,8 +6,10 @@
  */
 
 import {
+  HEARTBEAT_INTERVAL_MS,
   finalizeExecution,
   synchronizeAgentResultOutcome,
+  touchExecutionHeartbeat,
 } from '@agent/storage';
 import { createChannelTrace, type ResultEvent } from '@agent/trace';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
@@ -17,6 +19,7 @@ import {
   StreamStatusMachine,
   type StreamStatusEmitOptions,
 } from '@agent/runtime/StreamStatusService';
+import type { ExecutionId } from '@shared/schemas';
 import {
   RUN_OUTCOME,
   STREAM_PHASE,
@@ -135,6 +138,7 @@ export type ManualCompactionRequestResult =
  */
 export class ExecutionRegistry {
   private readonly handles = new Map<string, ExecutionHandle>();
+  private heartbeatTimer: ReturnType<typeof setInterval> | undefined;
   private readonly activeChildRunLoops = new Set<StreamTabId>();
   private readonly changeCallbacks = new Map<string, Array<() => void>>();
   private readonly disposeStatusListener: () => void;
@@ -229,6 +233,7 @@ export class ExecutionRegistry {
     this.disposeStatusListener();
     const executionIds = [...this.handles.keys()];
     this.handles.clear();
+    this.stopHeartbeatTimerIfIdle();
     this.activeChildRunLoops.clear();
     this.processOutput.dispose();
     for (const executionId of executionIds) {
@@ -256,6 +261,10 @@ export class ExecutionRegistry {
   /** Register an execution handle. */
   track(handle: ExecutionHandle): void {
     this.handles.set(handle.executionId, handle);
+    this.ensureHeartbeatTimer();
+    void touchExecutionHeartbeat(handle.executionId as ExecutionId).catch(
+      () => {},
+    );
     if (handle instanceof AgentExecutionHandle) {
       if (handle.isChildExecution) {
         this.emitChildActivity(handle.parentStreamId, 'subagents');
@@ -339,8 +348,34 @@ export class ExecutionRegistry {
     return true;
   }
 
+  /**
+   * One shared timer refreshes every active execution's on-disk heartbeat so
+   * other processes sharing the `~/.texra` root can tell these runs are live
+   * (#8625). Started on first track, stopped when the last handle untracks;
+   * unref'd so it never keeps a headless CLI process alive.
+   */
+  private ensureHeartbeatTimer(): void {
+    if (this.heartbeatTimer) return;
+    const timer = setInterval(() => {
+      for (const executionId of this.handles.keys()) {
+        void touchExecutionHeartbeat(executionId as ExecutionId).catch(
+          () => {},
+        );
+      }
+    }, HEARTBEAT_INTERVAL_MS);
+    timer.unref?.();
+    this.heartbeatTimer = timer;
+  }
+
+  private stopHeartbeatTimerIfIdle(): void {
+    if (this.handles.size > 0 || !this.heartbeatTimer) return;
+    clearInterval(this.heartbeatTimer);
+    this.heartbeatTimer = undefined;
+  }
+
   private untrackHandle(handle: ExecutionHandle): void {
     this.handles.delete(handle.executionId);
+    this.stopHeartbeatTimerIfIdle();
     this.notifyRegistrationListeners(handle.executionId, undefined);
     this.notifyWaiters(handle.executionId);
     if (handle instanceof AgentExecutionHandle && handle.isChildExecution) {

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -67,7 +67,7 @@ const RESERVED_KEY_NAMES = new Set<string>(Object.values(SINGLE_VALUE_KEYS));
 /**
  * True when `key` is one of ExecutionKVStore's reserved keys — a single-value
  * key (meta, config, report, todos, conversation, workspace-files,
- * result-meta) or a per-child record key (`child-{id}`). Exported so callers
+ * result-meta, heartbeat) or a per-child record key (`child-{id}`). Exported so callers
  * that walk an execution's storage directory (e.g.
  * `src/tools/executions/executionKvFiles.ts`) can recognize internal KV
  * entries without re-deriving this vocabulary themselves.

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -52,6 +52,8 @@ const SINGLE_VALUE_KEYS = {
   CONVERSATION: 'conversation',
   WORKSPACE_FILES: 'workspace-files',
   RESULT_META: 'result-meta',
+  /** Cross-process liveness heartbeat; owned by executionLiveness.ts. */
+  HEARTBEAT: 'heartbeat',
 } as const;
 
 const KEYS = {

--- a/src/agent/storage/executionLifecycle.ts
+++ b/src/agent/storage/executionLifecycle.ts
@@ -27,6 +27,7 @@ import {
   type ExecutionMetaInput,
   getExecutionStore,
 } from './ExecutionKVStore';
+import { touchExecutionHeartbeat } from './executionLiveness';
 import { ResultMetaSchema } from './resultMeta';
 
 /**
@@ -145,6 +146,10 @@ export async function registerExecution(
     );
   }
 
+  // The first heartbeat lands with the launch writes so there is no window
+  // where the run exists on disk as non-terminal but unprotected (#8625);
+  // the registry's interval takes over refreshing it.
+  writes.push(touchExecutionHeartbeat(executionId));
   await Promise.all(writes);
 }
 

--- a/src/agent/storage/executionLifecycle.ts
+++ b/src/agent/storage/executionLifecycle.ts
@@ -122,6 +122,11 @@ export async function registerExecution(
   parentExecutionId?: ExecutionId,
   category?: string,
 ): Promise<void> {
+  // The heartbeat lands before every other launch write so a concurrent
+  // clear-all never observes a partially-written execution as dead (#8625):
+  // liveness reads a fresh heartbeat without meta as a launching run, and
+  // the registry's interval takes over refreshing it.
+  await touchExecutionHeartbeat(executionId);
   const timestamp = new Date().toISOString();
   const store = getExecutionStore(executionId);
 
@@ -146,10 +151,6 @@ export async function registerExecution(
     );
   }
 
-  // The first heartbeat lands with the launch writes so there is no window
-  // where the run exists on disk as non-terminal but unprotected (#8625);
-  // the registry's interval takes over refreshing it.
-  writes.push(touchExecutionHeartbeat(executionId));
   await Promise.all(writes);
 }
 

--- a/src/agent/storage/executionListing.ts
+++ b/src/agent/storage/executionListing.ts
@@ -26,6 +26,7 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 import { isDirectory } from '@utils/files/fsEntryType';
 
 import { getExecutionStore } from './ExecutionKVStore';
+import { getExecutionLiveness } from './executionLiveness';
 
 const CHANNEL = 'ExecutionListing';
 const INDEX_PATH = `${RUNS_STORAGE_DIR}/index.json`;
@@ -222,22 +223,52 @@ export async function deleteExecution(
   }
 }
 
+export interface DeleteAllExecutionsResult {
+  /** Ids whose storage was cleared, for adjacent per-execution cleanup. */
+  readonly deleted: ExecutionId[];
+  /** Ids skipped because they are live in some process (#8625). */
+  readonly skippedLive: ExecutionId[];
+}
+
 /**
- * Delete all executions, optionally excluding a set of IDs (e.g. active runs).
- * Returns the execution ids selected for deletion so callers can clean up
- * adjacent per-execution state without re-scanning storage.
+ * Delete all executions, optionally excluding a set of IDs (e.g. this
+ * process's active runs). Executions live in ANY process sharing the storage
+ * root are skipped: liveness is checked per id at delete time, because a
+ * batch-level scan goes stale against runs launched while the wipe is in
+ * progress.
  */
 export async function deleteAllExecutions(
   exclude?: ReadonlySet<string>,
-): Promise<ExecutionId[]> {
+): Promise<DeleteAllExecutionsResult> {
   const entries = await readDirOrEmpty(RUNS_STORAGE_DIR);
   const executionDirs = listExecutionDirs(entries, exclude);
 
-  await pMap(executionDirs, (id) => getExecutionStore(id).clear(), {
-    concurrency: EXECUTION_STORAGE_CONCURRENCY,
-    stopOnError: false,
-  });
-  return executionDirs;
+  const deleted: ExecutionId[] = [];
+  const skippedLive: ExecutionId[] = [];
+  await pMap(
+    executionDirs,
+    async (id) => {
+      let live: boolean;
+      try {
+        live = (await getExecutionLiveness(id)).live;
+      } catch {
+        // Fail safe for an irreversible operation: an unreadable heartbeat
+        // (EACCES, EIO) cannot prove the run is dead, so keep the execution.
+        live = true;
+      }
+      if (live) {
+        skippedLive.push(id);
+        return;
+      }
+      await getExecutionStore(id).clear();
+      deleted.push(id);
+    },
+    {
+      concurrency: EXECUTION_STORAGE_CONCURRENCY,
+      stopOnError: false,
+    },
+  );
+  return { deleted, skippedLive };
 }
 
 // ============================================================================

--- a/src/agent/storage/executionLiveness.ts
+++ b/src/agent/storage/executionLiveness.ts
@@ -25,7 +25,6 @@ import { StorageFS } from '@utils/files/storageFS';
 
 // Local imports - storage
 import { getExecutionStore } from './ExecutionKVStore';
-import { listExecutions } from './executionListing';
 
 // Type imports
 
@@ -112,7 +111,10 @@ export async function getExecutionLiveness(
   executionId: ExecutionId,
 ): Promise<ExecutionLiveness> {
   const meta = await getExecutionStore(executionId).readMeta();
-  if (!meta || meta.terminalStatus) return { live: false };
+  if (meta?.terminalStatus) return { live: false };
+  // No meta + fresh heartbeat = a launching run: registerExecution lands the
+  // heartbeat before its other writes, so mid-launch state reads as live
+  // instead of as deletable debris.
   const mtime = await heartbeatMtime(executionId);
   if (mtime == null || Date.now() - mtime >= HEARTBEAT_FRESH_MS) {
     return { live: false };
@@ -143,29 +145,4 @@ export function describeHeartbeatOwner(ownerHost: string | undefined): string {
     default:
       return 'another TeXRA host';
   }
-}
-
-/**
- * Ids of every execution currently live in any process. Only non-terminal
- * listing entries pay the heartbeat stat.
- */
-export async function listLiveExecutionIds(): Promise<ExecutionId[]> {
-  const entries = await listExecutions();
-  const candidates = entries.filter((entry) => !entry.terminalStatus);
-  const results = await Promise.all(
-    candidates.map(async (entry) => {
-      try {
-        const mtime = await heartbeatMtime(entry.id);
-        return mtime != null && Date.now() - mtime < HEARTBEAT_FRESH_MS
-          ? entry.id
-          : null;
-      } catch {
-        // Fail safe for an irreversible operation: an unreadable heartbeat
-        // (EACCES, EIO) cannot prove the run is dead, so keep the execution
-        // out of bulk deletion as if it were live.
-        return entry.id;
-      }
-    }),
-  );
-  return results.filter((id): id is ExecutionId => id != null);
 }

--- a/src/agent/storage/executionLiveness.ts
+++ b/src/agent/storage/executionLiveness.ts
@@ -1,0 +1,165 @@
+/**
+ * Cross-process execution liveness via a per-execution heartbeat file.
+ *
+ * The shared `~/.texra` root is read and written by independent CLI, desktop,
+ * and extension processes (#8622), so "is this run active right now?" cannot
+ * be answered from any in-process registry: `ExecutionMeta.terminalStatus` is
+ * write-once at the end, and a crashed run never writes it. The owning
+ * process touches `executions/{id}/heartbeat.json` on an interval while the
+ * run is active; any process classifies an execution as live when its meta
+ * has no terminal status AND the heartbeat mtime is fresher than
+ * {@link HEARTBEAT_FRESH_MS}. A crashed run stops heartbeating and becomes
+ * deletable once the freshness window lapses (#8625).
+ */
+
+// Third-party imports
+import { z } from 'zod';
+
+// Platform imports
+import { resolveRunStoragePath } from '@platform/defaults/workspaceStorage';
+
+// Local imports - utils
+import { isFileNotFoundError } from '@common/errors';
+import type { ExecutionId } from '@shared/schemas';
+import { StorageFS } from '@utils/files/storageFS';
+
+// Local imports - storage
+import { getExecutionStore } from './ExecutionKVStore';
+import { listExecutions } from './executionListing';
+
+// Type imports
+
+/** Cadence at which the owning process refreshes active heartbeats. */
+export const HEARTBEAT_INTERVAL_MS = 10_000;
+
+/**
+ * Staleness window for classifying a heartbeat as live. Three intervals, so
+ * one missed touch (event-loop stall, slow disk) never flags a live run as
+ * dead, while a crashed run becomes deletable within half a minute.
+ */
+export const HEARTBEAT_FRESH_MS = 3 * HEARTBEAT_INTERVAL_MS;
+
+const HEARTBEAT_KEY_FILE = 'heartbeat.json';
+
+function heartbeatPath(executionId: ExecutionId): string {
+  return resolveRunStoragePath(executionId, HEARTBEAT_KEY_FILE);
+}
+
+export type HeartbeatOwnerHost = 'extension' | 'desktop' | 'cli' | 'unknown';
+
+const HeartbeatSchema = z.object({
+  at: z.string(),
+  host: z.string().optional(),
+  pid: z.number().optional(),
+});
+
+let ownerHost: HeartbeatOwnerHost = 'unknown';
+
+/**
+ * Identify which host this process is, stamped into every heartbeat it
+ * writes so other hosts can tell the user where a live run is actually
+ * running. Called once at host startup (extension/desktop/CLI init).
+ */
+export function setHeartbeatOwnerHost(host: HeartbeatOwnerHost): void {
+  ownerHost = host;
+}
+
+/**
+ * Refresh `executionId`'s heartbeat. Called only by the process that owns the
+ * run (single-writer-per-execution); freshness is carried by the file's
+ * mtime, the body records the owner for guard messages and diagnosis.
+ */
+export async function touchExecutionHeartbeat(
+  executionId: ExecutionId,
+): Promise<void> {
+  await StorageFS.writeJson(heartbeatPath(executionId), {
+    at: new Date().toISOString(),
+    host: ownerHost,
+    pid: process.pid,
+  });
+}
+
+async function heartbeatMtime(
+  executionId: ExecutionId,
+): Promise<number | null> {
+  try {
+    const stat = await StorageFS.stat(heartbeatPath(executionId));
+    return stat.mtime;
+  } catch (error) {
+    if (isFileNotFoundError(error)) return null;
+    throw error;
+  }
+}
+
+export interface ExecutionLiveness {
+  readonly live: boolean;
+  /** Which host owns the live run, when its heartbeat records one. */
+  readonly ownerHost?: string;
+  readonly ownerPid?: number;
+}
+
+/**
+ * Classify whether `executionId` is running in SOME process — this one or
+ * another host sharing the storage root — and, when live, who owns it.
+ * Executions that predate the heartbeat and runs that crashed without
+ * finalizing read as not live (stale or missing heartbeat), so they stay
+ * deletable.
+ */
+export async function getExecutionLiveness(
+  executionId: ExecutionId,
+): Promise<ExecutionLiveness> {
+  const meta = await getExecutionStore(executionId).readMeta();
+  if (!meta || meta.terminalStatus) return { live: false };
+  const mtime = await heartbeatMtime(executionId);
+  if (mtime == null || Date.now() - mtime >= HEARTBEAT_FRESH_MS) {
+    return { live: false };
+  }
+  const heartbeat = await StorageFS.readJson(
+    heartbeatPath(executionId),
+    HeartbeatSchema,
+  ).catch(() => null);
+  return {
+    live: true,
+    ownerHost: heartbeat?.host,
+    ownerPid: heartbeat?.pid,
+  };
+}
+
+/** True when `executionId` is live in any process sharing the storage root. */
+export async function isExecutionLiveOnDisk(
+  executionId: ExecutionId,
+): Promise<boolean> {
+  return (await getExecutionLiveness(executionId)).live;
+}
+
+/** Human label for where a live run is running, for guard messages. */
+export function describeHeartbeatOwner(ownerHost: string | undefined): string {
+  switch (ownerHost) {
+    case 'cli':
+      return 'the TeXRA CLI';
+    case 'desktop':
+      return 'the TeXRA desktop app';
+    case 'extension':
+      return 'the TeXRA VS Code extension';
+    default:
+      return 'another TeXRA host';
+  }
+}
+
+/**
+ * Ids of every execution currently live in any process. Only non-terminal
+ * listing entries pay the heartbeat stat.
+ */
+export async function listLiveExecutionIds(): Promise<ExecutionId[]> {
+  const entries = await listExecutions();
+  const candidates = entries.filter((entry) => !entry.terminalStatus);
+  const results = await Promise.all(
+    candidates.map(async (entry) => {
+      const mtime = await heartbeatMtime(entry.id).catch(() => null);
+      return mtime != null && Date.now() - mtime < HEARTBEAT_FRESH_MS
+        ? entry.id
+        : null;
+    }),
+  );
+  return results.filter((id): id is ExecutionId => id != null);
+}

--- a/src/agent/storage/executionLiveness.ts
+++ b/src/agent/storage/executionLiveness.ts
@@ -72,6 +72,9 @@ export function setHeartbeatOwnerHost(host: HeartbeatOwnerHost): void {
 export async function touchExecutionHeartbeat(
   executionId: ExecutionId,
 ): Promise<void> {
+  // The first touch runs concurrently with registerExecution's other launch
+  // writes and may beat the one that creates the execution directory.
+  await StorageFS.ensureDir(resolveRunStoragePath(executionId));
   await StorageFS.writeJson(heartbeatPath(executionId), {
     at: new Date().toISOString(),
     host: ownerHost,

--- a/src/agent/storage/executionLiveness.ts
+++ b/src/agent/storage/executionLiveness.ts
@@ -37,7 +37,7 @@ export const HEARTBEAT_INTERVAL_MS = 10_000;
  * one missed touch (event-loop stall, slow disk) never flags a live run as
  * dead, while a crashed run becomes deletable within half a minute.
  */
-export const HEARTBEAT_FRESH_MS = 3 * HEARTBEAT_INTERVAL_MS;
+const HEARTBEAT_FRESH_MS = 3 * HEARTBEAT_INTERVAL_MS;
 
 const HEARTBEAT_KEY_FILE = 'heartbeat.json';
 
@@ -114,6 +114,9 @@ export async function getExecutionLiveness(
   if (mtime == null || Date.now() - mtime >= HEARTBEAT_FRESH_MS) {
     return { live: false };
   }
+  // Best-effort owner read: liveness is already settled by the mtime check
+  // above, so a torn read racing the owner's next write or a schema mismatch
+  // only degrades the guard message to "another TeXRA host".
   const heartbeat = await StorageFS.readJson(
     heartbeatPath(executionId),
     HeartbeatSchema,
@@ -123,13 +126,6 @@ export async function getExecutionLiveness(
     ownerHost: heartbeat?.host,
     ownerPid: heartbeat?.pid,
   };
-}
-
-/** True when `executionId` is live in any process sharing the storage root. */
-export async function isExecutionLiveOnDisk(
-  executionId: ExecutionId,
-): Promise<boolean> {
-  return (await getExecutionLiveness(executionId)).live;
 }
 
 /** Human label for where a live run is running, for guard messages. */
@@ -155,10 +151,17 @@ export async function listLiveExecutionIds(): Promise<ExecutionId[]> {
   const candidates = entries.filter((entry) => !entry.terminalStatus);
   const results = await Promise.all(
     candidates.map(async (entry) => {
-      const mtime = await heartbeatMtime(entry.id).catch(() => null);
-      return mtime != null && Date.now() - mtime < HEARTBEAT_FRESH_MS
-        ? entry.id
-        : null;
+      try {
+        const mtime = await heartbeatMtime(entry.id);
+        return mtime != null && Date.now() - mtime < HEARTBEAT_FRESH_MS
+          ? entry.id
+          : null;
+      } catch {
+        // Fail safe for an irreversible operation: an unreadable heartbeat
+        // (EACCES, EIO) cannot prove the run is dead, so keep the execution
+        // out of bulk deletion as if it were live.
+        return entry.id;
+      }
     }),
   );
   return results.filter((id): id is ExecutionId => id != null);

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -46,7 +46,6 @@ export {
   listLiveExecutionIds,
   setHeartbeatOwnerHost,
   touchExecutionHeartbeat,
-  type HeartbeatOwnerHost,
 } from './executionLiveness';
 export {
   RESUMABILITY_CAUSE,

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -43,7 +43,6 @@ export {
   HEARTBEAT_INTERVAL_MS,
   describeHeartbeatOwner,
   getExecutionLiveness,
-  listLiveExecutionIds,
   setHeartbeatOwnerHost,
   touchExecutionHeartbeat,
 } from './executionLiveness';

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -40,6 +40,16 @@ export {
   isUserVisibleExecution,
 } from './executionListing';
 export {
+  HEARTBEAT_INTERVAL_MS,
+  describeHeartbeatOwner,
+  getExecutionLiveness,
+  isExecutionLiveOnDisk,
+  listLiveExecutionIds,
+  setHeartbeatOwnerHost,
+  touchExecutionHeartbeat,
+  type HeartbeatOwnerHost,
+} from './executionLiveness';
+export {
   RESUMABILITY_CAUSE,
   deriveResumability,
   type ResumabilityDecision,

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -43,7 +43,6 @@ export {
   HEARTBEAT_INTERVAL_MS,
   describeHeartbeatOwner,
   getExecutionLiveness,
-  isExecutionLiveOnDisk,
   listLiveExecutionIds,
   setHeartbeatOwnerHost,
   touchExecutionHeartbeat,

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -70,6 +70,8 @@ const channelTraceMocks = vi.hoisted(() => ({
 vi.mock('@agent/storage', () => ({
   finalizeExecution: storageMocks.finalizeExecution,
   synchronizeAgentResultOutcome: storageMocks.synchronizeAgentResultOutcome,
+  HEARTBEAT_INTERVAL_MS: 10_000,
+  touchExecutionHeartbeat: () => Promise.resolve(),
 }));
 
 vi.mock('@agent/trace', async (importOriginal) => {

--- a/src/test-kernel/agent/runtime/ExecutionRegistryHeartbeat.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistryHeartbeat.vitest.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const storageMocks = vi.hoisted(() => ({
+  touchExecutionHeartbeat: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock('@agent/storage', () => ({
+  HEARTBEAT_INTERVAL_MS: 10_000,
+  touchExecutionHeartbeat: storageMocks.touchExecutionHeartbeat,
+  finalizeExecution: vi.fn(),
+  synchronizeAgentResultOutcome: vi.fn(),
+}));
+
+import { ExecutionRegistry } from '@agent/runtime/executionRegistry';
+import type { ExecutionHandle } from '@agent/runtime/executionRegistry';
+
+function fakeHandle(executionId: string): ExecutionHandle {
+  return { executionId } as ExecutionHandle;
+}
+
+describe('ExecutionRegistry heartbeat timer (#8625)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    storageMocks.touchExecutionHeartbeat.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('touches immediately on track and on every interval while active', () => {
+    const registry = new ExecutionRegistry();
+    registry.track(fakeHandle('aaa111'));
+    expect(storageMocks.touchExecutionHeartbeat).toHaveBeenCalledWith('aaa111');
+
+    registry.track(fakeHandle('bbb222'));
+    storageMocks.touchExecutionHeartbeat.mockClear();
+
+    vi.advanceTimersByTime(10_000);
+    const touched = storageMocks.touchExecutionHeartbeat.mock.calls.flat();
+    expect(touched).toEqual(['aaa111', 'bbb222']);
+
+    registry.dispose();
+  });
+
+  it('stops touching once the last handle untracks', () => {
+    const registry = new ExecutionRegistry();
+    registry.track(fakeHandle('ccc333'));
+    registry.untrack('ccc333');
+    storageMocks.touchExecutionHeartbeat.mockClear();
+
+    vi.advanceTimersByTime(60_000);
+    expect(storageMocks.touchExecutionHeartbeat).not.toHaveBeenCalled();
+
+    registry.dispose();
+  });
+});

--- a/src/test-kernel/agent/runtime/SessionIsolation.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionIsolation.vitest.ts
@@ -49,6 +49,8 @@ const storageMocks = vi.hoisted(() => ({
 
 vi.mock('@agent/storage', () => ({
   finalizeExecution: storageMocks.finalizeExecution,
+  HEARTBEAT_INTERVAL_MS: 10_000,
+  touchExecutionHeartbeat: () => Promise.resolve(),
 }));
 
 function initTestPlatform(): Promise<void> {

--- a/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
@@ -47,6 +47,8 @@ const storageMocks = vi.hoisted(() => ({
 
 vi.mock('@agent/storage', () => ({
   finalizeExecution: storageMocks.finalizeExecution,
+  HEARTBEAT_INTERVAL_MS: 10_000,
+  touchExecutionHeartbeat: () => Promise.resolve(),
 }));
 
 let counter = 0;

--- a/src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts
@@ -39,6 +39,7 @@ describe('isReservedKvKeyName', () => {
     'conversation',
     'workspace-files',
     'result-meta',
+    'heartbeat',
   ])('recognizes the reserved single-value key %s', (key) => {
     expect(isReservedKvKeyName(key)).toBe(true);
   });

--- a/src/test-kernel/agent/storage/ExecutionLiveness.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionLiveness.vitest.ts
@@ -6,7 +6,6 @@ import {
   clearStoreCache,
   getExecutionLiveness,
   getExecutionStore,
-  isExecutionLiveOnDisk,
   listLiveExecutionIds,
   setHeartbeatOwnerHost,
   touchExecutionHeartbeat,
@@ -53,14 +52,18 @@ describe('execution liveness heartbeat (#8625)', () => {
       Date.now() + 6 * HEARTBEAT_INTERVAL_MS,
     );
 
-    await expect(isExecutionLiveOnDisk(id)).resolves.toBe(false);
+    await expect(getExecutionLiveness(id).then((l) => l.live)).resolves.toBe(
+      false,
+    );
   });
 
   it('is not live without a heartbeat file (pre-heartbeat executions)', async () => {
     const id = 'ab1003' as ExecutionId;
     await writeRunningExecution(id);
 
-    await expect(isExecutionLiveOnDisk(id)).resolves.toBe(false);
+    await expect(getExecutionLiveness(id).then((l) => l.live)).resolves.toBe(
+      false,
+    );
   });
 
   it('is not live once a terminal status is persisted, even with a fresh heartbeat', async () => {
@@ -71,13 +74,15 @@ describe('execution liveness heartbeat (#8625)', () => {
     });
     await touchExecutionHeartbeat(id);
 
-    await expect(isExecutionLiveOnDisk(id)).resolves.toBe(false);
+    await expect(getExecutionLiveness(id).then((l) => l.live)).resolves.toBe(
+      false,
+    );
   });
 
   it('is not live for an unknown execution id', async () => {
-    await expect(isExecutionLiveOnDisk('ab1005' as ExecutionId)).resolves.toBe(
-      false,
-    );
+    await expect(
+      getExecutionLiveness('ab1005' as ExecutionId).then((l) => l.live),
+    ).resolves.toBe(false);
   });
 
   it('lists only the live executions', async () => {

--- a/src/test-kernel/agent/storage/ExecutionLiveness.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionLiveness.vitest.ts
@@ -4,9 +4,9 @@ import { setupPlatform } from '@test/support/setupPlatform';
 import {
   HEARTBEAT_INTERVAL_MS,
   clearStoreCache,
+  deleteAllExecutions,
   getExecutionLiveness,
   getExecutionStore,
-  listLiveExecutionIds,
   setHeartbeatOwnerHost,
   touchExecutionHeartbeat,
 } from '@agent/storage';
@@ -85,7 +85,16 @@ describe('execution liveness heartbeat (#8625)', () => {
     ).resolves.toBe(false);
   });
 
-  it('lists only the live executions', async () => {
+  it('treats a fresh heartbeat without meta as a launching (live) run', async () => {
+    const id = 'ab3001' as ExecutionId;
+    await touchExecutionHeartbeat(id);
+
+    await expect(getExecutionLiveness(id).then((l) => l.live)).resolves.toBe(
+      true,
+    );
+  });
+
+  it('clear-all deletes finished and crashed runs but skips live ones', async () => {
     const live = 'ab2001' as ExecutionId;
     const finished = 'ab2002' as ExecutionId;
     const crashed = 'ab2003' as ExecutionId;
@@ -97,6 +106,12 @@ describe('execution liveness heartbeat (#8625)', () => {
     });
     await writeRunningExecution(crashed);
 
-    await expect(listLiveExecutionIds()).resolves.toEqual([live]);
+    const result = await deleteAllExecutions();
+
+    expect(result.skippedLive).toEqual([live]);
+    expect([...result.deleted].sort()).toEqual([finished, crashed]);
+    await expect(getExecutionLiveness(live).then((l) => l.live)).resolves.toBe(
+      true,
+    );
   });
 });

--- a/src/test-kernel/agent/storage/ExecutionLiveness.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionLiveness.vitest.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { setupPlatform } from '@test/support/setupPlatform';
+import {
+  HEARTBEAT_INTERVAL_MS,
+  clearStoreCache,
+  getExecutionLiveness,
+  getExecutionStore,
+  isExecutionLiveOnDisk,
+  listLiveExecutionIds,
+  setHeartbeatOwnerHost,
+  touchExecutionHeartbeat,
+} from '@agent/storage';
+import type { ExecutionId } from '@shared/schemas';
+
+describe('execution liveness heartbeat (#8625)', () => {
+  setupPlatform({ workspacePath: '/workspace' });
+
+  beforeEach(() => {
+    clearStoreCache();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    setHeartbeatOwnerHost('unknown');
+  });
+
+  async function writeRunningExecution(id: ExecutionId): Promise<void> {
+    await getExecutionStore(id).writeMeta({
+      timestamp: '2026-07-16T12:00:00.000Z',
+    });
+  }
+
+  it('classifies a freshly heartbeaten, non-terminal execution as live, marked with its owner', async () => {
+    const id = 'ab1001' as ExecutionId;
+    setHeartbeatOwnerHost('cli');
+    await writeRunningExecution(id);
+    await touchExecutionHeartbeat(id);
+
+    await expect(getExecutionLiveness(id)).resolves.toEqual({
+      live: true,
+      ownerHost: 'cli',
+      ownerPid: process.pid,
+    });
+  });
+
+  it('treats a stale heartbeat as not live (crashed run stays deletable)', async () => {
+    const id = 'ab1002' as ExecutionId;
+    await writeRunningExecution(id);
+    await touchExecutionHeartbeat(id);
+
+    vi.spyOn(Date, 'now').mockReturnValue(
+      Date.now() + 6 * HEARTBEAT_INTERVAL_MS,
+    );
+
+    await expect(isExecutionLiveOnDisk(id)).resolves.toBe(false);
+  });
+
+  it('is not live without a heartbeat file (pre-heartbeat executions)', async () => {
+    const id = 'ab1003' as ExecutionId;
+    await writeRunningExecution(id);
+
+    await expect(isExecutionLiveOnDisk(id)).resolves.toBe(false);
+  });
+
+  it('is not live once a terminal status is persisted, even with a fresh heartbeat', async () => {
+    const id = 'ab1004' as ExecutionId;
+    await getExecutionStore(id).writeMeta({
+      timestamp: '2026-07-16T12:00:00.000Z',
+      terminalStatus: 'completed',
+    });
+    await touchExecutionHeartbeat(id);
+
+    await expect(isExecutionLiveOnDisk(id)).resolves.toBe(false);
+  });
+
+  it('is not live for an unknown execution id', async () => {
+    await expect(isExecutionLiveOnDisk('ab1005' as ExecutionId)).resolves.toBe(
+      false,
+    );
+  });
+
+  it('lists only the live executions', async () => {
+    const live = 'ab2001' as ExecutionId;
+    const finished = 'ab2002' as ExecutionId;
+    const crashed = 'ab2003' as ExecutionId;
+    await writeRunningExecution(live);
+    await touchExecutionHeartbeat(live);
+    await getExecutionStore(finished).writeMeta({
+      timestamp: '2026-07-16T12:01:00.000Z',
+      terminalStatus: 'completed',
+    });
+    await writeRunningExecution(crashed);
+
+    await expect(listLiveExecutionIds()).resolves.toEqual([live]);
+  });
+});

--- a/src/test-kernel/cli/History.vitest.mts
+++ b/src/test-kernel/cli/History.vitest.mts
@@ -1072,7 +1072,10 @@ describe('CLI history runtime', () => {
   });
 
   it('surfaces the bulk-delete count in the structured result', async () => {
-    mocks.deleteAllExecutions.mockResolvedValue(['a1', 'b2', 'c3', 'd4']);
+    mocks.deleteAllExecutions.mockResolvedValue({
+      deleted: ['a1', 'b2', 'c3', 'd4'],
+      skippedLive: [],
+    });
 
     await expect(deleteCliHistory({ all: true })).resolves.toEqual({
       deleted: 'all',
@@ -1082,7 +1085,10 @@ describe('CLI history runtime', () => {
   });
 
   it('reuses the preflight count instead of re-listing', async () => {
-    mocks.deleteAllExecutions.mockResolvedValue(['a1']);
+    mocks.deleteAllExecutions.mockResolvedValue({
+      deleted: ['a1'],
+      skippedLive: [],
+    });
 
     await expect(
       deleteCliHistory({ all: true, preCountForAll: 7 }),
@@ -1099,7 +1105,10 @@ describe('CLI history runtime', () => {
     await GoalStore.start(deletedA, 'delete a');
     await GoalStore.start(deletedB, 'delete b');
     await GoalStore.start(live, 'keep me');
-    mocks.deleteAllExecutions.mockResolvedValue(['a1', 'b2']);
+    mocks.deleteAllExecutions.mockResolvedValue({
+      deleted: ['a1', 'b2'],
+      skippedLive: [],
+    });
 
     await deleteCliHistory({ all: true });
 

--- a/src/test-kernel/cli/History.vitest.mts
+++ b/src/test-kernel/cli/History.vitest.mts
@@ -49,6 +49,8 @@ vi.mock('@agent/storage', async () => {
     listExecutions: mocks.listExecutions,
     deleteExecution: mocks.deleteExecution,
     deleteAllExecutions: mocks.deleteAllExecutions,
+    getExecutionLiveness: vi.fn(async () => ({ live: false })),
+    listLiveExecutionIds: vi.fn(async () => []),
   };
 });
 
@@ -1075,6 +1077,7 @@ describe('CLI history runtime', () => {
     await expect(deleteCliHistory({ all: true })).resolves.toEqual({
       deleted: 'all',
       count: 4,
+      skippedLive: 0,
     });
   });
 
@@ -1083,7 +1086,7 @@ describe('CLI history runtime', () => {
 
     await expect(
       deleteCliHistory({ all: true, preCountForAll: 7 }),
-    ).resolves.toEqual({ deleted: 'all', count: 7 });
+    ).resolves.toEqual({ deleted: 'all', count: 7, skippedLive: 0 });
 
     // listExecutions must not be called when the count was passed in.
     expect(mocks.listExecutions).not.toHaveBeenCalled();

--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -58,6 +58,8 @@ vi.mock('@agent/runtime/executeAgent', () => ({
 vi.mock('@agent/storage', () => ({
   getExecutionStore: mocks.getExecutionStore,
   registerExecution: mocks.registerExecution,
+  HEARTBEAT_INTERVAL_MS: 10_000,
+  touchExecutionHeartbeat: () => Promise.resolve(),
 }));
 
 vi.mock('@model/computeModelOptions', () => ({

--- a/src/test-kernel/tools/NativeToolUseStrategy.vitest.ts
+++ b/src/test-kernel/tools/NativeToolUseStrategy.vitest.ts
@@ -42,6 +42,8 @@ vi.mock('@agent/runtime/executeAgent', () => ({
 
 vi.mock('@agent/storage', () => ({
   finalizeExecution: mocks.finalizeExecution,
+  HEARTBEAT_INTERVAL_MS: 10_000,
+  touchExecutionHeartbeat: () => Promise.resolve(),
   getExecutionStore: vi.fn(() => ({ readConfig: mocks.readConfig })),
   synchronizeAgentResultOutcome: mocks.synchronizeAgentResultOutcome,
 }));


### PR DESCRIPTION
First half of #8625 (follow-up to #8624's shared `~/.texra` storage root).

## Problem

With all three hosts sharing one storage root, a delete in one host could remove an execution another host was actively writing. Nothing on disk distinguishes *running* from *crashed mid-run*: `ExecutionMeta.terminalStatus` is write-once at the end, and every host's delete guard consulted only its own in-process registry — the CLI's `history delete` had no guard at all.

## Changes

- **Heartbeat**: `ExecutionRegistry` touches `executions/{id}/heartbeat.json` for every active handle from one shared interval (10s, `unref`'d so it never keeps a headless CLI process alive), immediately on track, stopped when the last handle untracks. The body stamps the owning host (`extension`/`desktop`/`cli`, set once at each host's init) and pid for guard messages and diagnosis; freshness is carried by mtime.
- **Classification** (`executionLiveness.ts` in `@agent/storage`): live ⇔ meta exists ∧ no `terminalStatus` ∧ heartbeat fresher than 3 intervals. Crashed runs go stale within ~30s and stay deletable; pre-heartbeat executions read as not live.
- **Guards**: extension and desktop single-delete refuse live runs with the owning host named ("running in the TeXRA CLI"); clear-all excludes live ids alongside locally-active ones; CLI `history delete` now refuses live runs (text: stderr + exit 1; JSON/NDJSON gain `live`/`liveHost`, `--all` gains `skippedLive` and reports actual deletions when any were skipped).
- `heartbeat` registered as a reserved KV key so storage-dir walkers recognize it.

Internal post-kill cleanup paths are intentionally unguarded — a killed run's `terminalStatus` is written at finalize, so it classifies as not live immediately.

The storage-watcher live-refresh half of #8625 follows as a separate PR.

## Verification

- New `ExecutionLiveness` suite (6 tests: fresh/stale/missing heartbeat, terminal status, owner stamping, live-id listing) and `ExecutionRegistryHeartbeat` suite (2 tests: immediate + interval touches, stop-on-last-untrack) 
- Full affected set green: 41 files / 373 tests across agent/storage, agent/runtime, settings + desktop history handlers
- `tsc --noEmit` clean at root, test-kernel, extension, desktop, CLI; eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes irreversible history deletion behavior across CLI, desktop, and extension using shared storage; misclassified liveness could block deletes or allow unsafe wipes, though bulk delete errs on the side of keeping executions when heartbeats are unreadable.
> 
> **Overview**
> Adds **cross-process execution liveness** so history deletes cannot wipe runs that are still active in another TeXRA host sharing `~/.texra` (#8625).
> 
> **Heartbeat & classification:** Active runs refresh `executions/{id}/heartbeat.json` on a 10s interval (via `ExecutionRegistry`, including an immediate touch on track). Each host calls `setHeartbeatOwnerHost` at startup so heartbeats record `cli` / `desktop` / `extension`. `getExecutionLiveness` treats a run as live when meta has no terminal status and the heartbeat mtime is fresh (~30s); `registerExecution` writes the heartbeat before other launch data so mid-launch runs are protected.
> 
> **Delete guards:** Single-delete paths (CLI `history delete`, extension/desktop history handlers) refuse live runs and name the owning host via `describeHeartbeatOwner`. `deleteAllExecutions` checks liveness per id at delete time, returns `{ deleted, skippedLive }`, and fails safe on unreadable heartbeats. CLI structured output gains `live` / `liveHost` / `skippedLive`; text mode surfaces errors and skip counts.
> 
> `heartbeat` is registered as a reserved KV key. New tests cover liveness classification, bulk delete skipping, and registry heartbeat timing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8eac9470dc3862a4d263f80ef5cc698c059256c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->