### PR TITLE
refactor(tools): delete dead executeSubagentInBand, dedupe SubagentResultMeta type

### DIFF
--- a/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
@@ -11,7 +11,7 @@ import {
 } from '@tools/delegation/inBandSubagentExecution';
 
 const mocks = vi.hoisted(() => ({
-  executeSubagentInBand: vi.fn(),
+  executeStableSubagentInBand: vi.fn(),
   preparedOptions: [] as unknown[],
   requireVisibleAgent: vi.fn(),
   selectAvailableDelegationModel: vi.fn(),
@@ -34,7 +34,7 @@ vi.mock('@tools/delegation/inBandSubagentExecution', () => {
     }
   }
   return {
-    executeStableSubagentInBand: mocks.executeSubagentInBand,
+    executeStableSubagentInBand: mocks.executeStableSubagentInBand,
     SubagentDurabilityError,
     SubagentReconciliationError,
   };
@@ -123,7 +123,7 @@ describe('createWorkflowScriptAgentRunner', () => {
     mocks.selectAvailableDelegationModel.mockResolvedValue('child-model');
     mocks.assertWorkflowFilesExist.mockResolvedValue(undefined);
     mocks.runStorageLocationFromAnyAbsolutePath.mockReturnValue(undefined);
-    mocks.executeSubagentInBand.mockImplementation(async (options) => {
+    mocks.executeStableSubagentInBand.mockImplementation(async (options) => {
       mocks.preparedOptions.push(await options.prepare());
       return { executionId: 'bbbbbb222222', result };
     });
@@ -149,7 +149,7 @@ describe('createWorkflowScriptAgentRunner', () => {
       parentModel: 'parent-model',
       agentCategory: 'workflow',
     });
-    expect(mocks.executeSubagentInBand).toHaveBeenCalledWith(
+    expect(mocks.executeStableSubagentInBand).toHaveBeenCalledWith(
       expect.objectContaining({
         executionId: expect.stringMatching(/^[a-f0-9]{24}$/),
         parentExecutionId,
@@ -245,7 +245,7 @@ describe('createWorkflowScriptAgentRunner', () => {
     await runner({ ...invocation(), index: 1 });
     await runner({ ...invocation(), key: 'fedcba9876543210' });
 
-    const executionIds = mocks.executeSubagentInBand.mock.calls.map(
+    const executionIds = mocks.executeStableSubagentInBand.mock.calls.map(
       ([options]) => options.executionId,
     );
     expect(executionIds[0]).toBe(executionIds[1]);
@@ -254,7 +254,7 @@ describe('createWorkflowScriptAgentRunner', () => {
   });
 
   it('rejects a cancelled child so the workflow journal can retry it', async () => {
-    mocks.executeSubagentInBand.mockResolvedValueOnce({
+    mocks.executeStableSubagentInBand.mockResolvedValueOnce({
       executionId: 'bbbbbb222222',
       result: {
         category: 'toolUse',
@@ -272,7 +272,7 @@ describe('createWorkflowScriptAgentRunner', () => {
   });
 
   it('turns durable reconciliation failures into fatal workflow aborts', async () => {
-    mocks.executeSubagentInBand.mockRejectedValueOnce(
+    mocks.executeStableSubagentInBand.mockRejectedValueOnce(
       new SubagentReconciliationError('incomplete child state'),
     );
     const runner = defaultRunner();
@@ -288,7 +288,7 @@ describe('createWorkflowScriptAgentRunner', () => {
       'result manifest unavailable',
       { cause: new Error('storage offline') },
     );
-    mocks.executeSubagentInBand.mockRejectedValueOnce(durabilityError);
+    mocks.executeStableSubagentInBand.mockRejectedValueOnce(durabilityError);
     const runner = defaultRunner();
 
     await expect(runner(invocation())).rejects.toMatchObject({

--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -25,7 +25,6 @@ import {
 } from '@shared/schemas';
 import { DelegateAgentTool } from '@tools/DelegationTools';
 import {
-  executeSubagentInBand,
   executeStableSubagentInBand,
   SubagentDurabilityError,
   SubagentReconciliationError,
@@ -118,6 +117,9 @@ function callDelegateReview(agent = 'review') {
   });
 }
 
+const STABLE_PARENT_EXECUTION_ID = 'abcdef123456' as ExecutionId;
+const IN_BAND_LOGICAL_EXECUTION_ID = 'aaaaaa111111' as ExecutionId;
+
 /** The in-band delegation options shared by nearly every case (fields vary). */
 function delegationOptions(
   overrides: Partial<InBandSubagentExecutionOptions> = {},
@@ -129,12 +131,25 @@ function delegationOptions(
       model: 'deepseekT',
     },
     agentName: 'review',
-    parentExecutionId: 'parent-exec' as ExecutionId,
+    parentExecutionId: STABLE_PARENT_EXECUTION_ID,
     parentStreamId: 'parent-stream' as StreamTabId,
     runtimeHost: runtimeHost(),
     session: defaultSession(),
     ...overrides,
   };
+}
+
+/** Run the typed required-result path the way production callers reach it. */
+function runInBand(
+  options: InBandSubagentExecutionOptions,
+  executionId: ExecutionId = IN_BAND_LOGICAL_EXECUTION_ID,
+) {
+  return executeStableSubagentInBand({
+    executionId,
+    parentExecutionId: options.parentExecutionId,
+    signal: options.signal,
+    prepare: async () => options,
+  });
 }
 
 /**
@@ -155,8 +170,6 @@ function mockExecuteAgentErrorOnce(totalCostUsd: number): void {
   });
 }
 
-const STABLE_PARENT_EXECUTION_ID = 'abcdef123456' as ExecutionId;
-
 function stableAttempt(
   logicalExecutionId: ExecutionId,
   phase: 'reserved' | 'launched' | 'retryable' = 'launched',
@@ -167,6 +180,21 @@ function stableAttempt(
     parentExecutionId: STABLE_PARENT_EXECUTION_ID,
     phase,
   } as const;
+}
+
+/** In-memory execution KV store: enough surface for the stable attempt path. */
+function memoryExecutionStore() {
+  const kv = new Map<string, unknown>();
+  return {
+    listKeys: vi.fn(async () => [...kv.keys()]),
+    read: vi.fn(async (key: string) => kv.get(key)),
+    write: vi.fn(async (key: string, value: unknown) => {
+      kv.set(key, value);
+    }),
+    readResultMeta: vi.fn(async () => null),
+    writeReport: mocks.writeReport,
+    writeResultMeta: mocks.writeResultMeta,
+  };
 }
 
 function stableSequenceStore(logicalExecutionId: ExecutionId, nextAttempt = 0) {
@@ -216,9 +244,17 @@ describe('headless delegation', () => {
     mocks.registerExecution.mockResolvedValue(undefined);
     mocks.writeReport.mockResolvedValue(undefined);
     mocks.writeResultMeta.mockResolvedValue(undefined);
-    mocks.getExecutionStore.mockReturnValue({
-      writeReport: mocks.writeReport,
-      writeResultMeta: mocks.writeResultMeta,
+    const memoryStores = new Map<
+      ExecutionId,
+      ReturnType<typeof memoryExecutionStore>
+    >();
+    mocks.getExecutionStore.mockImplementation((executionId: ExecutionId) => {
+      let store = memoryStores.get(executionId);
+      if (!store) {
+        store = memoryExecutionStore();
+        memoryStores.set(executionId, store);
+      }
+      return store;
     });
     mocks.executeAgent.mockResolvedValue({
       category: 'toolUse',
@@ -267,7 +303,7 @@ describe('headless delegation', () => {
   });
 
   it('returns and persists the typed final result for in-band consumers', async () => {
-    const result = await executeSubagentInBand(delegationOptions());
+    const result = await runInBand(delegationOptions());
 
     expect(result.result).toEqual({
       category: 'toolUse',
@@ -281,12 +317,12 @@ describe('headless delegation', () => {
       result.executionId,
       expect.objectContaining({ agent: 'review' }),
       'review',
-      'parent-exec',
+      STABLE_PARENT_EXECUTION_ID,
     );
     expect(mocks.writeResultMeta).toHaveBeenCalledWith({
       producer: 'subagent',
       agentName: 'review',
-      parentExecutionId: 'parent-exec',
+      parentExecutionId: STABLE_PARENT_EXECUTION_ID,
       wallTimeMs: expect.any(Number),
       result: result.result,
     });
@@ -434,12 +470,7 @@ describe('headless delegation', () => {
     );
 
     await expect(
-      executeSubagentInBand(
-        delegationOptions({
-          executionId: logicalExecutionId,
-          parentExecutionId: STABLE_PARENT_EXECUTION_ID,
-        }),
-      ),
+      runInBand(delegationOptions(), logicalExecutionId),
     ).rejects.toBeInstanceOf(SubagentReconciliationError);
     expect(mocks.registerExecution).not.toHaveBeenCalled();
     expect(mocks.executeAgent).not.toHaveBeenCalled();
@@ -477,11 +508,9 @@ describe('headless delegation', () => {
         return store;
       });
 
-      const completed = await executeSubagentInBand(
-        delegationOptions({
-          executionId: logicalExecutionId,
-          parentExecutionId: STABLE_PARENT_EXECUTION_ID,
-        }),
+      const completed = await runInBand(
+        delegationOptions(),
+        logicalExecutionId,
       );
 
       expect(completed.executionId).not.toBe(logicalExecutionId);
@@ -507,12 +536,9 @@ describe('headless delegation', () => {
     mocks.getExecutionStore.mockImplementation((executionId: ExecutionId) =>
       executionId === STABLE_PARENT_EXECUTION_ID ? sequenceStore : childStore,
     );
-    const options = delegationOptions({
-      executionId: logicalExecutionId,
-      parentExecutionId: STABLE_PARENT_EXECUTION_ID,
-    });
+    const options = delegationOptions();
 
-    await expect(executeSubagentInBand(options)).rejects.toBeInstanceOf(
+    await expect(runInBand(options, logicalExecutionId)).rejects.toBeInstanceOf(
       SubagentDurabilityError,
     );
 
@@ -520,7 +546,7 @@ describe('headless delegation', () => {
       'stable-subagent-attempt',
       expect.objectContaining({ phase: 'launched' }),
     );
-    await expect(executeSubagentInBand(options)).rejects.toBeInstanceOf(
+    await expect(runInBand(options, logicalExecutionId)).rejects.toBeInstanceOf(
       SubagentReconciliationError,
     );
     expect(mocks.executeAgent).toHaveBeenCalledOnce();
@@ -567,12 +593,7 @@ describe('headless delegation', () => {
       return store;
     });
 
-    const completed = await executeSubagentInBand(
-      delegationOptions({
-        executionId: logicalExecutionId,
-        parentExecutionId: STABLE_PARENT_EXECUTION_ID,
-      }),
-    );
+    const completed = await runInBand(delegationOptions(), logicalExecutionId);
 
     expect(completed.executionId).not.toBe(logicalExecutionId);
     expect(stores.size).toBe(3);
@@ -588,9 +609,9 @@ describe('headless delegation', () => {
   it('does not return a typed result when its durable manifest cannot be written', async () => {
     mocks.writeResultMeta.mockRejectedValueOnce(new Error('storage offline'));
 
-    await expect(
-      executeSubagentInBand(delegationOptions()),
-    ).rejects.toBeInstanceOf(SubagentDurabilityError);
+    await expect(runInBand(delegationOptions())).rejects.toBeInstanceOf(
+      SubagentDurabilityError,
+    );
     expect(mocks.writeReport).not.toHaveBeenCalled();
   });
 
@@ -598,7 +619,7 @@ describe('headless delegation', () => {
     mocks.executeAgent.mockRejectedValueOnce(new Error('review model failed'));
     mocks.writeResultMeta.mockRejectedValueOnce(new Error('storage offline'));
 
-    const run = executeSubagentInBand(delegationOptions());
+    const run = runInBand(delegationOptions());
 
     await expect(run).rejects.toMatchObject({
       name: 'SubagentDurabilityError',
@@ -618,7 +639,7 @@ describe('headless delegation', () => {
       } as never),
     );
 
-    const run = executeSubagentInBand(delegationOptions());
+    const run = runInBand(delegationOptions());
 
     await expect(run).rejects.toMatchObject({
       name: 'SubagentDurabilityError',
@@ -637,7 +658,7 @@ describe('headless delegation', () => {
       touchedFiles: [42],
     });
 
-    await expect(executeSubagentInBand(delegationOptions())).rejects.toThrow();
+    await expect(runInBand(delegationOptions())).rejects.toThrow();
     expect(mocks.writeResultMeta).not.toHaveBeenCalled();
     expect(mocks.writeReport).not.toHaveBeenCalled();
   });
@@ -669,7 +690,7 @@ describe('headless delegation', () => {
       };
     });
 
-    const run = executeSubagentInBand(
+    const run = runInBand(
       delegationOptions({ signal: controller.signal, onCost }),
     );
     await ready;
@@ -695,9 +716,7 @@ describe('headless delegation', () => {
     });
     mocks.writeResultMeta.mockReturnValueOnce(persistencePending);
 
-    const run = executeSubagentInBand(
-      delegationOptions({ signal: controller.signal }),
-    );
+    const run = runInBand(delegationOptions({ signal: controller.signal }));
     await vi.waitFor(() => {
       expect(mocks.writeResultMeta).toHaveBeenCalledOnce();
     });
@@ -721,7 +740,7 @@ describe('headless delegation', () => {
     controller.abort(new Error('Workflow already stopped.'));
 
     await expect(
-      executeSubagentInBand(delegationOptions({ signal: controller.signal })),
+      runInBand(delegationOptions({ signal: controller.signal })),
     ).rejects.toThrow('Workflow already stopped.');
     expect(mocks.registerExecution).not.toHaveBeenCalled();
     expect(mocks.executeAgent).not.toHaveBeenCalled();

--- a/src/tools/delegation/inBandSubagentExecution.ts
+++ b/src/tools/delegation/inBandSubagentExecution.ts
@@ -74,8 +74,6 @@ interface InBandSubagentExecutionBaseOptions {
 /** Options for the typed child API. Direct persisted parentage is required. */
 export interface InBandSubagentExecutionOptions extends InBandSubagentExecutionBaseOptions {
   readonly parentExecutionId: ExecutionId;
-  /** Stable logical-call identity for restart recovery; random when omitted. */
-  readonly executionId?: ExecutionId;
 }
 
 export interface StableInBandSubagentExecutionOptions {
@@ -84,9 +82,7 @@ export interface StableInBandSubagentExecutionOptions {
   readonly parentExecutionId: ExecutionId;
   readonly signal?: AbortSignal;
   /** Resolve mutable launch prerequisites only when no result can be recovered. */
-  readonly prepare: () => Promise<
-    Omit<InBandSubagentExecutionOptions, 'executionId'>
-  >;
+  readonly prepare: () => Promise<InBandSubagentExecutionOptions>;
 }
 
 /** Legacy delivery callers may still provide a bare one-shot run context. */
@@ -578,30 +574,6 @@ async function executeInBand(
   // Cancellation observed here rejects the caller without changing that record.
   options.signal?.throwIfAborted();
   return { executionId, flowResult, built, delivery };
-}
-
-/** Run a direct child and return the durable, XML-free result envelope. */
-export async function executeSubagentInBand(
-  options: InBandSubagentExecutionOptions,
-): Promise<InBandSubagentExecutionResult> {
-  if (options.executionId) {
-    const { executionId, ...launchOptions } = options;
-    return executeStableSubagentInBand({
-      executionId,
-      parentExecutionId: options.parentExecutionId,
-      signal: options.signal,
-      prepare: async () => launchOptions,
-    });
-  }
-  const completed = await executeInBand(
-    options,
-    'required-result',
-    generateExecutionId() as ExecutionId,
-  );
-  return {
-    executionId: completed.executionId,
-    result: completed.built.result,
-  };
 }
 
 /** Recover a logical child first; resolve launch-only state only when needed. */

--- a/src/tools/delegation/subagentDeliveryFormat.ts
+++ b/src/tools/delegation/subagentDeliveryFormat.ts
@@ -4,7 +4,6 @@
  * XML formatting is a separate boundary operation over that same result.
  */
 
-import type { ResultMeta } from '@agent/storage';
 import {
   buildAgentFinalResult,
   type AgentFinalResult,
@@ -20,11 +19,11 @@ import {
 import {
   buildSubagentResultMeta,
   formatSubagentDelivery,
+  type SubagentResultMeta,
 } from '@tools/subagentResults';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 const LOG_CHANNEL = 'subagentDelivery';
-type SubagentResultMeta = Extract<ResultMeta, { producer: 'subagent' }>;
 
 export interface BuiltSubagentResult {
   readonly result: AgentFinalResult;

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -41,7 +41,7 @@ import {
   formatChildRunError,
 } from './deliveryEnvelope';
 
-type SubagentResultMeta = Extract<ResultMeta, { producer: 'subagent' }>;
+export type SubagentResultMeta = Extract<ResultMeta, { producer: 'subagent' }>;
 
 // ============================================================================
 // Formatting helpers


### PR DESCRIPTION
## Summary

Deletes the dead `executeSubagentInBand` dispatcher from `src/tools/delegation/inBandSubagentExecution.ts` and dedupes the `SubagentResultMeta` type.

- **Dead-export evidence**: `executeSubagentInBand` had zero production callers — the only references outside its own module were in `src/test-kernel/tools/DelegationHeadless.vitest.mts` (calls) and a mock variable *name* in `src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts`. The sole production consumer of this module's typed path is `workflowScriptAgentRunner.ts`, which calls `executeStableSubagentInBand` directly. The private `executeInBand` core, `executeStableSubagentInBand`, and `executeSubagentForDeliveryInBand` remain.
- With the dispatcher gone, the `executionId?` field on `InBandSubagentExecutionOptions` (its only consumer) is also removed, and `StableInBandSubagentExecutionOptions.prepare` loses its now-pointless `Omit<..., 'executionId'>`.
- `SubagentResultMeta` (`Extract<ResultMeta, { producer: 'subagent' }>`) was defined identically in both `subagentResults.ts` and `subagentDeliveryFormat.ts`; it is now exported from `subagentResults.ts` and imported by `subagentDeliveryFormat.ts`.

## Test migration

`DelegationHeadless.vitest.mts` exercised the deleted dispatcher at ~14 sites. Those tests now drive the same required-result semantics through `executeStableSubagentInBand` via a local `runInBand(options, executionId?)` helper that wraps options in a `prepare` callback with a fixed logical execution id — the same shape production callers use. Supporting changes:

- The default `getExecutionStore` mock is now a small per-execution in-memory KV fake (`listKeys`/`read`/`write`/`readResultMeta` plus the shared `writeReport`/`writeResultMeta` spies), since the stable path does attempt/sequence bookkeeping the old bare mock didn't support.
- `delegationOptions()` now defaults `parentExecutionId` to a hex id (`abcdef123456`) because the stable path zod-validates execution ids (`ExecutionIdSchema` requires hex); the two assertions on that value were updated to match.
- Every test's asserted semantics are unchanged (typed result envelope, `registerExecution` args, `writeResultMeta` payloads, cancellation and durability-error behavior). **No tests were deleted** — the dispatcher-only random-id behavior had no dedicated test, so nothing verified mechanics that no longer exist.
- `WorkflowScriptAgentRunner.vitest.ts`: renamed the mock variable `mocks.executeSubagentInBand` → `mocks.executeStableSubagentInBand` to match the function it actually mocks; behavior unchanged.

## Verification

- `npx vitest run src/test-kernel/tools/DelegationHeadless.vitest.mts src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts` — 39 tests passed
- `npm run typecheck` — clean
- `npm run check:dead-code-ratchet` — OK (234 findings vs 234 baselined, no new)

Closes #8645

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal and test-only harness changes; production already used `executeStableSubagentInBand` for the typed path.
> 
> **Overview**
> Removes the unused **`executeSubagentInBand`** wrapper so typed in-band subagent runs go only through **`executeStableSubagentInBand`**. **`InBandSubagentExecutionOptions`** no longer carries optional **`executionId`**, and **`StableInBandSubagentExecutionOptions.prepare`** now returns full launch options instead of an **`Omit<..., 'executionId'>`** shape.
> 
> **`SubagentResultMeta`** is exported once from **`subagentResults.ts`** and imported in **`subagentDeliveryFormat.ts`** instead of duplicating the type.
> 
> Headless and workflow-script tests call the stable API via **`runInBand`** / renamed mocks, with an in-memory execution store mock so stable attempt bookkeeping matches production.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3262b21b854c0f1bf0aa46c2d7ff658a227cd85a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Net elements (R6)

- Functions: -1 (`executeSubagentInBand` deleted; no replacement added)
- Type fields: -1 (`InBandSubagentExecutionOptions.executionId?` removed)
- Type aliases: -1 (duplicate `SubagentResultMeta` definition removed from `subagentDeliveryFormat.ts`; single definition now exported from `subagentResults.ts`)
- New abstractions: 0 production; 2 test-local helpers (`runInBand`, in-memory store fake) each with multiple call sites inside the suite
- Net LoC: -10 (+74/-84)

## Consumer counts (R8)

- `executeSubagentInBand`: 0 production consumers (grep across src/ and packages/); only test-file references, both migrated
- `executeStableSubagentInBand`: 2 consumers after change (`workflowScriptAgentRunner.ts`, `DelegationHeadless.vitest.mts` via `runInBand`)
- `SubagentResultMeta` export: 2 consumers (`subagentDeliveryFormat.ts`, `SubagentResultMeta.vitest.ts`)
- `InBandSubagentExecutionOptions`: consumers unchanged (`StableInBandSubagentExecutionOptions.prepare`, `subagentExecution.ts`)
