### PR TITLE
fix(agent): charge only executed workflow children

### DIFF
--- a/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
@@ -260,8 +260,34 @@ describe('createWorkflowScriptAgentRunner', () => {
     );
   });
 
-  it('threads onCost through to the child execution', async () => {
+  it('reports live child cost with its workflow invocation identity', async () => {
     const onCost = vi.fn();
+    mocks.executeStableSubagentInBand.mockImplementationOnce(
+      async (options) => {
+        const prepared = await options.prepare();
+        await prepared.onCost?.(0.25);
+        return { executionId: 'bbbbbb222222', result };
+      },
+    );
+    const runner = createWorkflowScriptAgentRunner(
+      parentContext(),
+      'correct',
+      'tool-call-7',
+      { onCost },
+    );
+    const call = invocation();
+
+    await runner(call);
+
+    expect(onCost).toHaveBeenCalledWith(call, 0.25);
+  });
+
+  it('does not report recovered stable child cost as live execution', async () => {
+    const onCost = vi.fn();
+    mocks.executeStableSubagentInBand.mockResolvedValueOnce({
+      executionId: 'bbbbbb222222',
+      result: { ...result, cost: 0.25 },
+    });
     const runner = createWorkflowScriptAgentRunner(
       parentContext(),
       'correct',
@@ -269,11 +295,9 @@ describe('createWorkflowScriptAgentRunner', () => {
       { onCost },
     );
 
-    await runner(invocation());
+    await runner({ ...invocation(), index: 3 });
 
-    expect(mocks.preparedOptions[0]).toEqual(
-      expect.objectContaining({ onCost }),
-    );
+    expect(onCost).not.toHaveBeenCalled();
   });
 
   it('uses one stable child id per workflow call identity', async () => {

--- a/src/test-kernel/agent/WorkflowScriptCost.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptCost.vitest.ts
@@ -72,18 +72,27 @@ describe('workflow-script completed journal cost', () => {
     expect(sumCompletedWorkflowJournalCost([entry(0, result)])).toBe(0);
   });
 
-  it('counts live replacements when prior keys move to different indices', () => {
-    const prior = [
-      entry(2, workflowResult(1), 'aaaaaaaaaaaaaaaa'),
-      entry(3, workflowResult(0.8), 'bbbbbbbbbbbbbbbb'),
+  it('charges a live replacement but not stable recoveries moved to new indices', () => {
+    const priorA = entry(2, workflowResult(1), 'aaaaaaaaaaaaaaaa');
+    const priorB = entry(3, workflowResult(0.8), 'bbbbbbbbbbbbbbbb');
+    const priorReplaced = entry(4, workflowResult(0.6), 'dddddddddddddddd');
+    const recoveredAfterReorder = [
+      entry(priorA.index, priorB.result, priorB.key),
+      entry(priorB.index, priorA.result, priorA.key),
     ];
-    const settledEntries = new Set(prior.map(workflowJournalEntryCostIdentity));
-    const retry = [
-      entry(2, workflowResult(0.85), 'bbbbbbbbbbbbbbbb'),
-      entry(3, workflowResult(1.05), 'aaaaaaaaaaaaaaaa'),
-    ];
+    const liveReplacement = entry(
+      priorReplaced.index,
+      workflowResult(0.45),
+      'cccccccccccccccc',
+    );
+    const retry = [...recoveredAfterReorder, liveReplacement];
 
-    expect(sumCompletedWorkflowJournalCost(retry, settledEntries)).toBe(1.9);
+    expect(
+      sumCompletedWorkflowJournalCost(
+        retry,
+        new Set([workflowJournalEntryCostIdentity(liveReplacement)]),
+      ),
+    ).toBe(0.45);
   });
 
   it.each([

--- a/src/test-kernel/agent/WorkflowScriptCost.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptCost.vitest.ts
@@ -10,6 +10,7 @@ import {
 import { RUN_OUTCOME, type ExecutionId } from '@shared/schemas';
 import {
   sumCompletedWorkflowJournalCost,
+  workflowJournalEntryCostIdentity,
   WorkflowJournalCostError,
 } from '@tools/delegation/workflowScriptRun';
 
@@ -22,8 +23,12 @@ const meta = `export const meta = {
 
 setupPlatform({ storagePath: '/storage', workspacePath: '/workspace' });
 
-function entry(index: number, result: unknown): WorkflowJournalEntry {
-  return { index, key, result };
+function entry(
+  index: number,
+  result: unknown,
+  entryKey = key,
+): WorkflowJournalEntry {
+  return { index, key: entryKey, result };
 }
 
 function workflowResult(cost: number): unknown {
@@ -65,6 +70,20 @@ describe('workflow-script completed journal cost', () => {
     delete result.cost;
 
     expect(sumCompletedWorkflowJournalCost([entry(0, result)])).toBe(0);
+  });
+
+  it('counts live replacements when prior keys move to different indices', () => {
+    const prior = [
+      entry(2, workflowResult(1), 'aaaaaaaaaaaaaaaa'),
+      entry(3, workflowResult(0.8), 'bbbbbbbbbbbbbbbb'),
+    ];
+    const settledEntries = new Set(prior.map(workflowJournalEntryCostIdentity));
+    const retry = [
+      entry(2, workflowResult(0.85), 'bbbbbbbbbbbbbbbb'),
+      entry(3, workflowResult(1.05), 'aaaaaaaaaaaaaaaa'),
+    ];
+
+    expect(sumCompletedWorkflowJournalCost(retry, settledEntries)).toBe(1.9);
   });
 
   it.each([

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -27,6 +27,7 @@ import { createWorkflowScriptAgentRunner } from './workflowScriptAgentRunner';
 import {
   runPersistedWorkflowScriptWithProgress,
   sumCompletedWorkflowJournalCost,
+  workflowJournalEntryCostIdentity,
 } from './workflowScriptRun';
 
 const WorkflowScriptToolInputSchema = z.strictObject({
@@ -96,7 +97,7 @@ Durable resume is content-keyed: re-running the identical script and args in thi
     // still validated so malformed entries fail closed.
     const settledEntries = new Set(
       (await readWorkflowScriptCheckpoint(store, checkpointId))?.journal.map(
-        (entry) => entry.index,
+        workflowJournalEntryCostIdentity,
       ),
     );
     let costSettled = false;

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -90,20 +90,15 @@ Durable resume is content-keyed: re-running the identical script and args in thi
     }
 
     const store = getExecutionStore(parent.runScope.executionId);
-    // Delta accounting across attempts: a checkpoint now outlives one tool
-    // call, and every attempt (including the failure path) settles cost, so
-    // re-settling replayed entries would double-bill the parent. Each attempt
-    // settles only the entries it journaled itself; the whole journal is
-    // still validated so malformed entries fail closed.
-    const settledEntries = new Set(
-      (await readWorkflowScriptCheckpoint(store, checkpointId))?.journal.map(
-        workflowJournalEntryCostIdentity,
-      ),
-    );
+    // The stable child runner's native cost callback fires only for work that
+    // executes in this attempt. Exact journal replays and stable-child
+    // recoveries do not fire it, even when completion-order changes move a
+    // recovered invocation key to another journal index.
+    const executedEntries = new Set<string>();
     let costSettled = false;
     const settleCost = (journal: readonly WorkflowJournalEntry[]): void => {
       if (costSettled) return;
-      const cost = sumCompletedWorkflowJournalCost(journal, settledEntries);
+      const cost = sumCompletedWorkflowJournalCost(journal, executedEntries);
       costSettled = true;
       callContext.hooks?.recordSubagentCost?.(cost);
     };
@@ -125,7 +120,8 @@ Durable resume is content-keyed: re-running the identical script and args in thi
           input.agent,
           checkpointId,
           {
-            onCost: (totalCostUsd) => {
+            onCost: (invocation, totalCostUsd) => {
+              executedEntries.add(workflowJournalEntryCostIdentity(invocation));
               liveCostUsd += totalCostUsd ?? 0;
             },
           },

--- a/src/tools/delegation/workflowScriptAgentRunner.ts
+++ b/src/tools/delegation/workflowScriptAgentRunner.ts
@@ -2,6 +2,7 @@
 import { resolveChildRunOutput } from '@agent/storage';
 import {
   WorkflowRunAbortError,
+  type WorkflowAgentInvocation,
   type WorkflowAgentRunner,
 } from '@agent/workflowScript';
 import type { LaunchRunContext } from '@agent/runtime/RunContext';
@@ -62,7 +63,10 @@ export function createWorkflowScriptAgentRunner(
   checkpointId: string,
   hooks?: {
     /** Fires per live child on success and failure with its total cost. */
-    readonly onCost?: (totalCostUsd: number | undefined) => void;
+    readonly onCost?: (
+      invocation: WorkflowAgentInvocation,
+      totalCostUsd: number | undefined,
+    ) => void;
   },
 ): WorkflowAgentRunner {
   const { runScope } = parent;
@@ -130,7 +134,7 @@ export function createWorkflowScriptAgentRunner(
                 runScope.session,
               );
             },
-            onCost: hooks?.onCost,
+            onCost: (totalCostUsd) => hooks?.onCost?.(invocation, totalCostUsd),
           };
         },
       });

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -45,13 +45,12 @@ export function workflowJournalEntryCostIdentity(
 
 /**
  * Sum completed logical-call cost; failed and cancelled attempts are not
- * journaled. Every entry is validated, but entries in `excludeEntries`
- * (journaled by a prior attempt, whose cost that attempt already settled)
- * do not count toward the total.
+ * journaled. Every entry is validated; when `executedEntries` is supplied,
+ * only entries whose native child cost callback fired count toward the total.
  */
 export function sumCompletedWorkflowJournalCost(
   journal: readonly WorkflowJournalEntry[],
-  excludeEntries: ReadonlySet<string> = new Set(),
+  executedEntries?: ReadonlySet<string>,
 ): number {
   let total = 0;
   for (const entry of journal) {
@@ -61,7 +60,10 @@ export function sumCompletedWorkflowJournalCost(
         cause: result.error,
       });
     }
-    if (!excludeEntries.has(workflowJournalEntryCostIdentity(entry))) {
+    if (
+      executedEntries === undefined ||
+      executedEntries.has(workflowJournalEntryCostIdentity(entry))
+    ) {
       total += result.data.cost;
     }
   }

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -35,14 +35,23 @@ export class WorkflowJournalCostError extends Error {
 }
 
 /**
+ * Stable identity for excluding a previously settled journal entry.
+ */
+export function workflowJournalEntryCostIdentity(
+  entry: Pick<WorkflowJournalEntry, 'index' | 'key'>,
+): string {
+  return `${entry.index}:${entry.key}`;
+}
+
+/**
  * Sum completed logical-call cost; failed and cancelled attempts are not
- * journaled. Every entry is validated, but entries in `excludeIndices`
+ * journaled. Every entry is validated, but entries in `excludeEntries`
  * (journaled by a prior attempt, whose cost that attempt already settled)
  * do not count toward the total.
  */
 export function sumCompletedWorkflowJournalCost(
   journal: readonly WorkflowJournalEntry[],
-  excludeIndices: ReadonlySet<number> = new Set(),
+  excludeEntries: ReadonlySet<string> = new Set(),
 ): number {
   let total = 0;
   for (const entry of journal) {
@@ -52,7 +61,9 @@ export function sumCompletedWorkflowJournalCost(
         cause: result.error,
       });
     }
-    if (!excludeIndices.has(entry.index)) total += result.data.cost;
+    if (!excludeEntries.has(workflowJournalEntryCostIdentity(entry))) {
+      total += result.data.cost;
+    }
   }
   return total;
 }


### PR DESCRIPTION
## Summary

- Record chargeable workflow journal identities from the stable child runner native cost callback, which fires only for a real child execution.
- Exclude exact journal replays and recovered stable children even when pipeline completion order moves their invocation keys to new indices.
- Continue charging genuinely executed replacement and new calls while retaining fail-closed journal validation.

## Issue acceptance gates

Closes #8654

- Uses an explicit production execution signal instead of inferring work from journal indices.
- Excludes a recovered stable invocation when its key is journaled at a different index.
- Charges a live replacement at a reused index.
- Adds focused cost-settlement and stable-runner callback tests.

## Single source of truth

`executeStableSubagentInBand` already owns the execution-versus-recovery decision through whether it launches `prepare()` and fires the native `onCost` callback. `workflowScriptAgentRunner.ts` attaches the workflow invocation to that callback, and `WorkflowScriptTool.ts` records those executed identities for journal settlement.

## Duplication and abstraction budget

The existing cost callback carries one additional native invocation value. The existing journal identity helper remains the single encoding used by callback recording and cost summation; no persistence schema, recovery protocol, or pass-through layer was added.

## Net elements (R6)

5 modified files, 91 insertions, 25 deletions; one exported function added; no files, classes, interfaces, or enums added.

## Consumer counts (R8)

n/a: no event path, subscriber, or existing export was deleted or rerouted.

## Host impact

Extension: Correct workflow-script child-cost rollup on reordered retries and stable recovery.

Desktop: Same correction through the shared runtime.

CLI: Same correction through the shared runtime.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/agent/WorkflowScriptCost.vitest.ts src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts src/test-kernel/tools/WorkflowScriptTool.vitest.ts` (25 tests passed)
- `npm run typecheck`
- `npm run lint` (0 errors; one pre-existing warning in `AgentCreatorToolCatalogParity.vitest.mts`)
- `npm run compile:fast`
- `npm run check:dead-code-ratchet`
- `git diff --check origin/main...HEAD`