### PR TITLE
feat(history): live history refresh when another host writes executions

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -928,7 +928,14 @@ function createWindow(options: {
       executionsDir,
       { recursive: true },
       (_event, filename) => {
-        if (filename?.endsWith('heartbeat.json')) return;
+        // filename may be a Buffer (or null) per fs.watch's contract; the
+        // separator anchor avoids matching an unrelated *heartbeat.json name.
+        if (
+          filename != null &&
+          /(?:^|[\\/])heartbeat\.json$/.test(String(filename))
+        ) {
+          return;
+        }
         void debouncedHistoryRepost();
       },
     );

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs';
+import { existsSync, mkdirSync, watch, type FSWatcher } from 'node:fs';
 import { writeFile } from 'node:fs/promises';
 import { spawn } from 'node:child_process';
 import { dirname, join, resolve as resolvePath } from 'node:path';
@@ -13,6 +13,7 @@ import {
 } from 'electron';
 
 import { platform } from '@platform/platform';
+import { RUNS_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 import { SHUTDOWN_PHASE, type LifecycleHost } from '@platform/interfaces';
 import { LatexConfigPersistenceController } from '@controllers/settingsView/LatexConfigPersistenceController';
 import { LatexToolingController } from '@controllers/settingsView/LatexToolingController';
@@ -40,6 +41,8 @@ import {
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { backfillFirstRunDone } from '@shared/state/onboardingState';
 import { setOpenBuildDisplay } from '@tools/approval/latexPreview';
+import { DEBOUNCE_OPTIONS_MS } from '@utils/config';
+import { debounce } from '@utils/core';
 import { BinaryResolver } from '@utils/system/binaryResolver';
 import {
   checkToolInstalled,
@@ -905,6 +908,33 @@ function createWindow(options: {
     showErrorMessage: settingsUi.showErrorMessage,
     onError: settingsUi.onError,
   });
+  // Cross-host history refresh (#8625): the shared ~/.texra executions dir
+  // is written by the CLI and extension too, so the settings history list
+  // re-posts when any host adds, finishes, or deletes a run. heartbeat.json
+  // churn (touched every 10s per live run) is filtered; best-effort — a
+  // watch failure only means no live refresh, manual refresh still works.
+  const executionsDir = join(
+    platform().storage.getStoragePath(),
+    RUNS_STORAGE_DIR,
+  );
+  const debouncedHistoryRepost = debounce(async () => {
+    if (windowClosed) return;
+    await historySettingsController.postHistoryData();
+  }, DEBOUNCE_OPTIONS_MS);
+  let executionsWatcher: FSWatcher | undefined;
+  try {
+    mkdirSync(executionsDir, { recursive: true });
+    executionsWatcher = watch(
+      executionsDir,
+      { recursive: true },
+      (_event, filename) => {
+        if (filename?.endsWith('heartbeat.json')) return;
+        void debouncedHistoryRepost();
+      },
+    );
+  } catch (error) {
+    reportAsyncError(error);
+  }
   const settingsIpc = createDesktopSettingsIpc({
     postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
     agentSettingsController,
@@ -1111,6 +1141,7 @@ function createWindow(options: {
   installDesktopMenu(shellActions);
   window.once('closed', () => {
     windowClosed = true;
+    executionsWatcher?.close();
     if (mainWindow === window) {
       mainWindow = null;
     }

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -160,6 +160,7 @@ export function planToolTerminalAction(input: {
 export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   vscode.WebviewView | vscode.WebviewPanel
 > {
+  private executionsWatcher: vscode.FileSystemWatcher | undefined;
   private readonly handlerRegistry: SettingsViewInboundHandlerRegistry;
 
   // Domain-specific handler delegates
@@ -288,30 +289,49 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
 
     // Cross-host history refresh (#8625): the shared ~/.texra executions dir
     // is written by the CLI and desktop too, so an open history tab re-lists
-    // when any host adds, finishes, or deletes a run. The dir lives outside
-    // the workspace, hence the RelativePattern base. heartbeat.json churn
-    // (touched every 10s per live run) is filtered out; the debounce
-    // coalesces the remaining launch/terminal write bursts.
+    // when any host adds, finishes, or deletes a run. Re-registered on
+    // workspace-folder changes because the storage path follows the current
+    // workspace.
+    void this.registerExecutionsWatcher();
+    context.subscriptions.push(
+      vscode.workspace.onDidChangeWorkspaceFolders(() => {
+        void this.registerExecutionsWatcher();
+      }),
+      { dispose: () => this.executionsWatcher?.dispose() },
+    );
+  }
+
+  /**
+   * Watch the shared executions directory (outside the workspace, hence the
+   * RelativePattern base) and re-send the history list to the active settings
+   * webview. heartbeat.json churn (touched every 10s per live run, #8652) is
+   * filtered out; the debounce coalesces launch/terminal write bursts.
+   */
+  private async registerExecutionsWatcher(): Promise<void> {
+    this.executionsWatcher?.dispose();
     const executionsDir = path.join(
       platform().storage.getStoragePath(),
       RUNS_STORAGE_DIR,
     );
+    // A watcher rooted at a not-yet-existing directory can silently never
+    // fire; the dir is cheap to create and always wanted.
+    await StorageFS.ensureDir(RUNS_STORAGE_DIR);
     const refreshHistory = debounce(
       () =>
         this.withActiveWebview((w) => this.historyHandlers.sendHistoryData(w)),
       DEBOUNCE_OPTIONS_MS,
     );
     const onExecutionsEvent = (uri: vscode.Uri) => {
-      if (uri.path.endsWith('heartbeat.json')) return;
+      if (uri.path.endsWith('/heartbeat.json')) return;
       void refreshHistory();
     };
-    const executionsWatcher = vscode.workspace.createFileSystemWatcher(
+    const watcher = vscode.workspace.createFileSystemWatcher(
       new vscode.RelativePattern(vscode.Uri.file(executionsDir), '**'),
     );
-    executionsWatcher.onDidCreate(onExecutionsEvent);
-    executionsWatcher.onDidChange(onExecutionsEvent);
-    executionsWatcher.onDidDelete(onExecutionsEvent);
-    context.subscriptions.push(executionsWatcher);
+    watcher.onDidCreate(onExecutionsEvent);
+    watcher.onDidChange(onExecutionsEvent);
+    watcher.onDidDelete(onExecutionsEvent);
+    this.executionsWatcher = watcher;
   }
 
   private createHandlerRegistry(): SettingsViewInboundHandlerRegistry {

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -8,6 +8,8 @@
  * - AgentHandlers: agent selection, directories, and teams
  * - LatexSettingsHandlers: LaTeX tool detection and recommended settings
  */
+import * as path from 'node:path';
+
 import * as vscode from 'vscode';
 
 // Shared schemas and dispatchers
@@ -23,7 +25,10 @@ import {
   LANGUAGE_MODEL_PORT_ERROR_CODE,
   LanguageModelPortError,
 } from '@platform/languageModel';
-import { resolveMemoryStoragePath } from '@platform/defaults/workspaceStorage';
+import {
+  resolveMemoryStoragePath,
+  RUNS_STORAGE_DIR,
+} from '@platform/defaults/workspaceStorage';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { AUTH_COMMANDS } from '@auth/constants';
 import { getServerSideKeyService } from '@auth/serverKeys';
@@ -85,6 +90,8 @@ import {
   refreshDisabledToolCache,
 } from '@tools/toolAvailability';
 import { StorageFS } from '@utils/files';
+import { debounce } from '@utils/core';
+import { DEBOUNCE_OPTIONS_MS } from '@utils/config';
 import { hasExtension } from '@utils/core/pathCore';
 import {
   buildGitAuthorSettingsMessage,
@@ -278,6 +285,33 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       void this.withActiveWebview((w) => this.sendGoalList(w));
     });
     context.subscriptions.push({ dispose: unsubscribeGoals });
+
+    // Cross-host history refresh (#8625): the shared ~/.texra executions dir
+    // is written by the CLI and desktop too, so an open history tab re-lists
+    // when any host adds, finishes, or deletes a run. The dir lives outside
+    // the workspace, hence the RelativePattern base. heartbeat.json churn
+    // (touched every 10s per live run) is filtered out; the debounce
+    // coalesces the remaining launch/terminal write bursts.
+    const executionsDir = path.join(
+      platform().storage.getStoragePath(),
+      RUNS_STORAGE_DIR,
+    );
+    const refreshHistory = debounce(
+      () =>
+        this.withActiveWebview((w) => this.historyHandlers.sendHistoryData(w)),
+      DEBOUNCE_OPTIONS_MS,
+    );
+    const onExecutionsEvent = (uri: vscode.Uri) => {
+      if (uri.path.endsWith('heartbeat.json')) return;
+      void refreshHistory();
+    };
+    const executionsWatcher = vscode.workspace.createFileSystemWatcher(
+      new vscode.RelativePattern(vscode.Uri.file(executionsDir), '**'),
+    );
+    executionsWatcher.onDidCreate(onExecutionsEvent);
+    executionsWatcher.onDidChange(onExecutionsEvent);
+    executionsWatcher.onDidDelete(onExecutionsEvent);
+    context.subscriptions.push(executionsWatcher);
   }
 
   private createHandlerRegistry(): SettingsViewInboundHandlerRegistry {


### PR DESCRIPTION
Second half of #8625 (follows the heartbeat delete guard, #8652). Closes #8625.

## Problem

With all three hosts sharing the `~/.texra` executions root (#8624), a run started or finished in one host only appeared in another host's history tab after closing and reopening it — nothing observed the storage directory.

## Changes

- **Extension**: `SettingsViewMessageHandler` registers a `FileSystemWatcher` over the shared executions directory. The directory lives outside the workspace, so the watcher uses a `RelativePattern` rooted at the storage path (a bare glob would never fire). Events re-send the history list to the active settings webview via the existing `withActiveWebview` + `sendHistoryData` path; watcher lifetime is the extension's (`context.subscriptions`), matching the `MainViewProvider` watcher pattern.
- **Desktop**: the main process watches the same directory with `fs.watch({recursive: true})` (created best-effort next to `DesktopHistoryHandlers`, closed in the window teardown block) and re-posts through the existing `postHistoryData`.
- Both hosts **ignore `heartbeat.json` events** — the #8652 heartbeat touches it every 10s per live run, which would otherwise re-post history continuously — and debounce the remaining launch/terminal write bursts (`DEBOUNCE_OPTIONS_MS`) into a single refresh.
- The CLI needs nothing: each invocation re-scans disk already.
- Progress board intentionally out of scope: it renders this process's in-memory stream snapshots, not the on-disk history (cross-host entries don't belong there).

## Verification

- Typechecks clean (root, test-kernel, extension, desktop, CLI); eslint clean; dead-code ratchet at baseline
- settings + desktop suites: 68 files / 537 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only filesystem observation with existing history refresh paths; no auth or execution logic changes.
> 
> **Overview**
> **Live cross-host history updates** so the settings history list refreshes when the shared `~/.texra` executions directory changes from the CLI, extension, or desktop—without reopening the tab.
> 
> **Desktop** adds a recursive `fs.watch` on that directory (created if missing), debounces refreshes, ignores `heartbeat.json` events, and closes the watcher on window teardown. Refreshes reuse `historySettingsController.postHistoryData()`.
> 
> **Extension** registers a `FileSystemWatcher` with a `RelativePattern` rooted at the storage path (outside the workspace), re-registers on workspace-folder changes, applies the same heartbeat filter and debounce, and pushes updates via `historyHandlers.sendHistoryData` to the active settings webview.
> 
> Watch setup is best-effort; failures only disable automatic refresh—manual refresh still works.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5daacb3ed302bf26bce0b4ddb9b9f9f3dfc76300. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->