### PR TITLE
feat(cli): show workflow round progress and per-stream tokens in the TUI

### DIFF
--- a/packages/cli/src/chat/tui/modals/TranscriptViewer.tsx
+++ b/packages/cli/src/chat/tui/modals/TranscriptViewer.tsx
@@ -9,6 +9,10 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { Box, Text, useInput } from 'ink';
 
+import { isEmptyUsage } from '@shared/schemas';
+import { formatRoundStageLabel } from '@shared/streams/streamStatusDisplay';
+import { formatCompactTokenCount } from '@utils/core';
+
 import {
   isEscapeInput,
   isJumpToBottomInput,
@@ -50,9 +54,19 @@ export function TranscriptViewer({
     // O(N) re-flatten on status-only ticks during streaming.
     [slice?.entries, width],
   );
+  const usage = slice?.cumulativeUsage;
+  const headerText = [
+    title,
+    formatRoundStageLabel(slice?.roundStage),
+    usage && !isEmptyUsage(usage)
+      ? `${formatCompactTokenCount(usage.inputTokens)} in / ${formatCompactTokenCount(usage.outputTokens)} out`
+      : undefined,
+  ]
+    .filter(Boolean)
+    .join(' · ');
   // Reserve one row for the footer hint strip, plus one for the title header
   // when present, so the scrollable region never overflows availableRows.
-  const titleRows = title ? 1 : 0;
+  const titleRows = headerText ? 1 : 0;
   const viewRows = Math.max(1, availableRows - 1 - titleRows);
   // Open pinned to the bottom — the latest output is what the user just asked
   // to inspect.
@@ -98,9 +112,9 @@ export function TranscriptViewer({
 
   return (
     <Box flexDirection="column" width={width}>
-      {title ? (
+      {headerText ? (
         <Text bold color={COLOR_HINT} wrap="truncate-end">
-          {title}
+          {headerText}
         </Text>
       ) : null}
       <Box flexDirection="column" overflowY="hidden">

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -6,7 +6,10 @@ import { useMemo } from 'react';
 
 // Local imports - shared stream state
 import type { ActiveChildInfo, StreamTabId } from '@shared/schemas';
-import { formatStreamStatusLabel } from '@shared/streams/streamStatusDisplay';
+import {
+  formatRoundStageLabel,
+  formatStreamStatusLabel,
+} from '@shared/streams/streamStatusDisplay';
 import { formatResultCount } from '@utils/text/stringUtils';
 
 // Local imports - TUI state and controls
@@ -100,6 +103,8 @@ function SessionRow({
     },
     nowMs,
   );
+  // Significance order — truncate-end sheds elapsed first, then the round.
+  const roundLabel = formatRoundStageLabel(session.slice?.roundStage);
   return (
     <Box flexDirection="row" height={1} minWidth={0} overflowY="hidden">
       <Text color={focused ? COLOR_HINT : undefined}>
@@ -113,6 +118,7 @@ function SessionRow({
         <Text bold={active} wrap="truncate-end">
           {session.label}
           {statusLabel ? ` ${statusLabel}` : ''}
+          {roundLabel ? ` · ${roundLabel}` : ''}
           {elapsed ? ` · ${elapsed}` : ''}
         </Text>
       </Box>

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -210,7 +210,7 @@ function roundSegment(
         text: formatRoundStageLabel(roundStage),
         // Keep round visibility on narrow terminals: degrade to the bare
         // current-round label instead of dropping the planned total's context.
-        compactText: `r${roundStage.index + 1}`,
+        compactText: formatRoundStageLabel({ index: roundStage.index }),
         color: 'dim',
         compactPriority: STATUS_BAR_COMPACT_PRIORITY.round,
       }

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -20,6 +20,7 @@ import {
   type TokenUsageStats,
 } from '@shared/schemas';
 import { isActivePhase } from '@shared/streams/streamStatus';
+import { formatRoundStageLabel } from '@shared/streams/streamStatusDisplay';
 import {
   filterNotNullish,
   formatCompactDuration,
@@ -206,7 +207,10 @@ function roundSegment(
 ): StatusBarSegment | undefined {
   return roundStage !== undefined
     ? {
-        text: `r${roundStage.index + 1}`,
+        text: formatRoundStageLabel(roundStage),
+        // Keep round visibility on narrow terminals: degrade to the bare
+        // current-round label instead of dropping the planned total's context.
+        compactText: `r${roundStage.index + 1}`,
         color: 'dim',
         compactPriority: STATUS_BAR_COMPACT_PRIORITY.round,
       }

--- a/packages/extension/src/progressView/frontend/formatters/progressBadgeFormatter.ts
+++ b/packages/extension/src/progressView/frontend/formatters/progressBadgeFormatter.ts
@@ -1,5 +1,6 @@
 import { html, nothing, type TemplateResult } from 'lit';
 import type { ConversationProgress, RoundStage } from '@shared/schemas';
+import { formatRoundStageLabel } from '@shared/streams/streamStatusDisplay';
 
 /**
  * Render progress badge with conversation turns and tool call count.
@@ -9,14 +10,7 @@ export function renderProgressBadgeContent(
   progress: ConversationProgress | undefined,
   roundStage: RoundStage | undefined,
 ): TemplateResult | typeof nothing {
-  let round: string | undefined;
-  if (roundStage === undefined) {
-    round = undefined;
-  } else if (roundStage.total !== undefined) {
-    round = `r${roundStage.index + 1}/${roundStage.total}`;
-  } else {
-    round = `r${roundStage.index + 1}`;
-  }
+  const round = formatRoundStageLabel(roundStage);
   const tools = progress?.toolCallCount ?? 0;
   if (!round && tools <= 0) return nothing;
   if (round && tools > 0) return html`${round}, ${tools} tool calls`;

--- a/src/shared/streams/streamStatusDisplay.ts
+++ b/src/shared/streams/streamStatusDisplay.ts
@@ -151,3 +151,24 @@ export function formatStreamStatusLabel(
   }
   return STREAM_STATUS_LABELS[style][key] ?? status;
 }
+
+/** Compact round/turn progress label: `r2/3` when the planned total is known
+ *  (workflow runs), else `r2`. Zero-based `index` renders one-based. */
+export function formatRoundStageLabel(stage: {
+  readonly index: number;
+  readonly total?: number | undefined;
+}): string;
+
+export function formatRoundStageLabel(
+  stage:
+    { readonly index: number; readonly total?: number | undefined } | undefined,
+): string | undefined;
+
+export function formatRoundStageLabel(
+  stage:
+    { readonly index: number; readonly total?: number | undefined } | undefined,
+): string | undefined {
+  if (stage === undefined) return undefined;
+  const current = `r${stage.index + 1}`;
+  return stage.total !== undefined ? `${current}/${stage.total}` : current;
+}

--- a/src/shared/streams/streamStatusDisplay.ts
+++ b/src/shared/streams/streamStatusDisplay.ts
@@ -6,6 +6,7 @@ import {
   StreamStatusSchema,
   streamStatusToPhase,
   streamStatusToSubstate,
+  type RoundStage,
   type StreamPhase,
   type StreamSubstate,
 } from '@shared/schemas';
@@ -154,19 +155,14 @@ export function formatStreamStatusLabel(
 
 /** Compact round/turn progress label: `r2/3` when the planned total is known
  *  (workflow runs), else `r2`. Zero-based `index` renders one-based. */
-export function formatRoundStageLabel(stage: {
-  readonly index: number;
-  readonly total?: number | undefined;
-}): string;
+export function formatRoundStageLabel(stage: Readonly<RoundStage>): string;
 
 export function formatRoundStageLabel(
-  stage:
-    { readonly index: number; readonly total?: number | undefined } | undefined,
+  stage: Readonly<RoundStage> | undefined,
 ): string | undefined;
 
 export function formatRoundStageLabel(
-  stage:
-    { readonly index: number; readonly total?: number | undefined } | undefined,
+  stage: Readonly<RoundStage> | undefined,
 ): string | undefined {
   if (stage === undefined) return undefined;
   const current = `r${stage.index + 1}`;

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -453,6 +453,20 @@ describe('CLI StatusBar display model', () => {
     expect(display.bindings).toContain('Alt-1..9 focus');
   });
 
+  it('shows the planned round total when the workflow declares one', () => {
+    const display = buildStatusBarDisplay(
+      statusInput({
+        status: STREAM_PHASE.RUNNING,
+        roundStage: { index: 1, total: 3 },
+      }),
+    );
+
+    const segment = display.left.find((item) => item.text === 'r2/3');
+    expect(segment).toBeDefined();
+    // Narrow terminals degrade to the bare current round, not to nothing.
+    expect(segment?.compactText).toBe('r2');
+  });
+
   it('prefixes the running label with the current spin frame', () => {
     const display = buildStatusBarDisplay(
       statusInput({ status: STREAM_PHASE.RUNNING, runningFrame: '/' }),

--- a/src/test-kernel/shared/SharedStreams.vitest.ts
+++ b/src/test-kernel/shared/SharedStreams.vitest.ts
@@ -12,6 +12,7 @@ import {
 import { diffActiveChildren } from '@shared/streams/childActivityReducer';
 import { buildStreamMetadata } from '@shared/streams/streamMetadata';
 import {
+  formatRoundStageLabel,
   formatStreamStatusLabel,
   streamStatusDisplayKey,
   streamStatusIndicatorClass,
@@ -137,6 +138,20 @@ describe('buildStreamMetadata', () => {
 // ---------------------------------------------------------------------------
 // StreamStatusDisplay
 // ---------------------------------------------------------------------------
+
+describe('formatRoundStageLabel', () => {
+  it('renders the one-based round over the planned total when known', () => {
+    expect(formatRoundStageLabel({ index: 1, total: 3 })).toBe('r2/3');
+  });
+
+  it('renders the bare round when no total is planned', () => {
+    expect(formatRoundStageLabel({ index: 0 })).toBe('r1');
+  });
+
+  it('passes undefined through for streams without a round', () => {
+    expect(formatRoundStageLabel(undefined)).toBeUndefined();
+  });
+});
 
 describe('stream status display labels', () => {
   const wordingCases: Array<[StreamStatusLabelStyle, string, string]> = [


### PR DESCRIPTION
## Summary

- Session rows render the stream's round progress (`r2/3`) between status and elapsed, so delegated workflow children show where they are in place; tool-use children without a round stay unchanged.
- The status-bar round segment gains the planned total (`r2/3`), degrading to the bare current round (`r2`) on narrow terminals via `compactText`.
- The transcript viewer header names the viewed stream's round and cumulative tokens (in/out).
- New shared `formatRoundStageLabel` lives next to `formatStreamStatusLabel` in `src/shared/streams/streamStatusDisplay.ts` (two CLI callers; no new `@agent/*` specifiers, ratchet unchanged).

Everything renders from facts already stored per `StreamSlice` by `subscribeRuntimeHost.ts` — no new events, no `runProgressRenderer.ts` changes (headless output byte-identical).

**Stacked on #8655** (base is `fix/8629-cli-child-list-convergence`); retarget to `main` after it merges.

Part of #8659.

## Verification

- `corepack pnpm --filter @texra-ai/cli typecheck` and test-kernel tsc: clean
- `npx vitest run src/test-kernel/cli`: 1764 passed (139 files); new cases in `SharedStreams.vitest.ts` (label helper) and `StatusBar.vitest.mts` (`r2/3` + compact degradation)
- `npm run check:dead-code-ratchet`: OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only changes using existing per-stream metadata; no new runtime events or persistence paths.
> 
> **Overview**
> Introduces **`formatRoundStageLabel`** in `streamStatusDisplay.ts` so round text is consistent (`r2/3` when `total` is known, else `r2`).
> 
> The **CLI TUI** starts showing that data from existing `StreamSlice` fields: child **session rows** include round between status and elapsed; the **status bar** round segment uses the full label with **`compactText`** falling back to the current round only on narrow widths; the **transcript viewer** header combines title, round, and **cumulative** in/out token counts when usage is non-empty.
> 
> The **VS Code extension** progress badge drops its inline round formatting in favor of the same helper. Tests cover the helper and status-bar `r2/3` / compact behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb397779a47e51b1e571608b3027c2289fae3430. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->