### PR TITLE
feat(cli): aggregate waiting-for-you approvals per subagent with jump-to-waiting

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -39,9 +39,10 @@ import { ConversationRegion } from './panes/ConversationRegion';
 import { StatusBar } from './panes/StatusBar';
 import {
   currentApproval,
-  pendingApprovalsByStream,
+  pendingApprovalSummaries,
   promoteApprovalsForStream,
   ROOT_APPROVAL_STREAM_KEY,
+  type PendingApprovalKind,
 } from './state/approvalQueue';
 import {
   isEscapeInput,
@@ -130,7 +131,7 @@ export function App(props: AppProps): React.JSX.Element {
   const transcriptViewerStreamId = useSignal(transcriptViewerStreamIdSignal);
   const taskDetailExecutionId = useSignal(taskDetailExecutionIdSignal);
   const rootRunStartAvailable = useSignal(rootRunStartAvailableSignal);
-  const pendingByStream = useSignal(pendingApprovalsByStream);
+  const pendingSummaries = useSignal(pendingApprovalSummaries);
   const [childListSelection, dispatchChildListSelection] = useReducer(
     reduceChildListSelection,
     INITIAL_CHILD_LIST_SELECTION,
@@ -243,19 +244,24 @@ export function App(props: AppProps): React.JSX.Element {
       streams,
     ],
   );
-  // Fold stream-less (session-wide) approvals onto the root/main row so no
-  // child row inherits them.
+  // Group the flat FIFO summaries per row, folding stream-less (session-wide)
+  // approvals onto the root/main row. Grouping from the flat list keeps each
+  // row's first shown kind the first-to-present even when the root's own and
+  // session-wide items interleave in the global queue.
   const pendingApprovalsForRows = useMemo(() => {
-    const rootKinds = pendingByStream.get(ROOT_APPROVAL_STREAM_KEY);
-    if (!rootKinds || rootStreamId === undefined) return pendingByStream;
-    const folded = new Map(pendingByStream);
-    folded.delete(ROOT_APPROVAL_STREAM_KEY);
-    folded.set(rootStreamId, [
-      ...(folded.get(rootStreamId) ?? []),
-      ...rootKinds,
-    ]);
-    return folded;
-  }, [pendingByStream, rootStreamId]);
+    const grouped = new Map<string, PendingApprovalKind[]>();
+    for (const summary of pendingSummaries) {
+      const key =
+        summary.streamKey === ROOT_APPROVAL_STREAM_KEY
+          ? rootStreamId
+          : summary.streamKey;
+      if (key === undefined) continue;
+      const kinds = grouped.get(key);
+      if (kinds) kinds.push(summary.kind);
+      else grouped.set(key, [summary.kind]);
+    }
+    return grouped;
+  }, [pendingSummaries, rootStreamId]);
   const activeSubagentExecutionIds = useMemo(() => {
     const executionIds = new Map<StreamTabId, string>();
     const parentIds = new Set(
@@ -338,8 +344,11 @@ export function App(props: AppProps): React.JSX.Element {
     dispatchChildListSelection({ kind: 'focusStream', streamId });
     activeStreamIdSignal.set(streamId);
     // Jump-to-waiting: surface the focused stream's pending approval right
-    // away instead of leaving it queued behind other streams' items.
-    promoteApprovalsForStream(streamId);
+    // away instead of leaving it queued behind other streams' items. The root
+    // row also owns session-wide (stream-less) approvals.
+    promoteApprovalsForStream(streamId, {
+      includeSessionWide: streamId === rootStreamIdSignal.get(),
+    });
   }, []);
   const foregroundKind = foregroundSurfaceKind({
     activeFormOpen: activeForm !== undefined,
@@ -443,7 +452,9 @@ export function App(props: AppProps): React.JSX.Element {
       });
       if (!target) return false;
       activeStreamIdSignal.set(target);
-      promoteApprovalsForStream(target);
+      promoteApprovalsForStream(target, {
+        includeSessionWide: target === rootStreamIdSignal.get(),
+      });
       return true;
     }
     return false;

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -37,7 +37,12 @@ import { TranscriptViewer } from './modals/TranscriptViewer';
 import { InputBar, type InputBarHandle } from './panes/InputBar';
 import { ConversationRegion } from './panes/ConversationRegion';
 import { StatusBar } from './panes/StatusBar';
-import { currentApproval } from './state/approvalQueue';
+import {
+  currentApproval,
+  pendingApprovalsByStream,
+  promoteApprovalsForStream,
+  ROOT_APPROVAL_STREAM_KEY,
+} from './state/approvalQueue';
 import {
   isEscapeInput,
   metaChordInput,
@@ -125,6 +130,7 @@ export function App(props: AppProps): React.JSX.Element {
   const transcriptViewerStreamId = useSignal(transcriptViewerStreamIdSignal);
   const taskDetailExecutionId = useSignal(taskDetailExecutionIdSignal);
   const rootRunStartAvailable = useSignal(rootRunStartAvailableSignal);
+  const pendingByStream = useSignal(pendingApprovalsByStream);
   const [childListSelection, dispatchChildListSelection] = useReducer(
     reduceChildListSelection,
     INITIAL_CHILD_LIST_SELECTION,
@@ -237,6 +243,19 @@ export function App(props: AppProps): React.JSX.Element {
       streams,
     ],
   );
+  // Fold stream-less (session-wide) approvals onto the root/main row so no
+  // child row inherits them.
+  const pendingApprovalsForRows = useMemo(() => {
+    const rootKinds = pendingByStream.get(ROOT_APPROVAL_STREAM_KEY);
+    if (!rootKinds || rootStreamId === undefined) return pendingByStream;
+    const folded = new Map(pendingByStream);
+    folded.delete(ROOT_APPROVAL_STREAM_KEY);
+    folded.set(rootStreamId, [
+      ...(folded.get(rootStreamId) ?? []),
+      ...rootKinds,
+    ]);
+    return folded;
+  }, [pendingByStream, rootStreamId]);
   const activeSubagentExecutionIds = useMemo(() => {
     const executionIds = new Map<StreamTabId, string>();
     const parentIds = new Set(
@@ -318,6 +337,9 @@ export function App(props: AppProps): React.JSX.Element {
   const focusSession = useCallback((streamId: StreamTabId) => {
     dispatchChildListSelection({ kind: 'focusStream', streamId });
     activeStreamIdSignal.set(streamId);
+    // Jump-to-waiting: surface the focused stream's pending approval right
+    // away instead of leaving it queued behind other streams' items.
+    promoteApprovalsForStream(streamId);
   }, []);
   const foregroundKind = foregroundSurfaceKind({
     activeFormOpen: activeForm !== undefined,
@@ -421,6 +443,7 @@ export function App(props: AppProps): React.JSX.Element {
       });
       if (!target) return false;
       activeStreamIdSignal.set(target);
+      promoteApprovalsForStream(target);
       return true;
     }
     return false;
@@ -594,6 +617,7 @@ export function App(props: AppProps): React.JSX.Element {
           streams,
           activeSubagentExecutionIds,
           childListTarget,
+          pendingApprovals: pendingApprovalsForRows,
           transcriptViewerStreamId,
         }}
         onCancelChildList={cancelChildList}

--- a/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
@@ -35,6 +35,7 @@ import { StaticConversationTranscript } from './StaticConversationTranscript';
 import { SubagentList } from './SubagentList';
 import { TodosPlanPanel, todosPlanPanelRowCount } from './TodosPlanPanel';
 import type { ForegroundSurfaceKind } from '../appInteractionPolicy';
+import type { PendingApprovalKind } from '../state/approvalQueue';
 import type { ChildListTarget } from '../state/childControls';
 import type { ChildListValue } from '../state/childListSelection';
 import type { StreamSlice } from '../state/cliState';
@@ -57,6 +58,10 @@ interface ConversationRegionSnapshot {
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
   readonly activeSubagentExecutionIds: ReadonlyMap<StreamTabId, string>;
   readonly childListTarget: ChildListTarget;
+  readonly pendingApprovals: ReadonlyMap<
+    string,
+    readonly PendingApprovalKind[]
+  >;
   readonly transcriptViewerStreamId: StreamTabId | undefined;
 }
 
@@ -257,6 +262,7 @@ export function ConversationRegion({
               onOpenProcessDetail={onOpenProcessDetail}
               onSelectionChange={onChildSelectionChange}
               onViewStream={onViewStream}
+              pendingApprovals={snapshot.pendingApprovals}
               selectedValue={snapshot.selectedChildValue}
               sessions={snapshot.sessionViews}
               activeProcesses={activeProcesses}

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -30,7 +30,12 @@ import { useLiveNowMs } from '../state/useLiveNowMs';
 import { COLOR_HINT } from '../ui/colors';
 import { POINTER, TICK } from '../ui/glyphs';
 import { Select, visibleSelectRange } from '../ui/Select';
-import { CHILD_STATUS_MARKER, childStatusColor } from './SubagentListDisplay';
+import {
+  CHILD_STATUS_MARKER,
+  childStatusColor,
+  pendingApprovalRowSuffix,
+} from './SubagentListDisplay';
+import type { PendingApprovalKind } from '../state/approvalQueue';
 import type { ProcessOutputTail } from '../state/cliState';
 import type { StreamView } from '../state/streamViews';
 
@@ -82,12 +87,14 @@ function SessionRow({
   focused,
   hiddenRowSummary,
   nowMs,
+  pendingKinds,
   session,
 }: {
   readonly active: boolean;
   readonly focused: boolean;
   readonly hiddenRowSummary: string | undefined;
   readonly nowMs: number;
+  readonly pendingKinds: readonly PendingApprovalKind[] | undefined;
   readonly session: StreamView;
 }): React.JSX.Element {
   const status = session.slice?.status;
@@ -103,7 +110,9 @@ function SessionRow({
     },
     nowMs,
   );
-  // Significance order — truncate-end sheds elapsed first, then the round.
+  // Significance order — truncate-end sheds elapsed first, then the round,
+  // then the pending-approval kind.
+  const approvalSuffix = pendingApprovalRowSuffix(pendingKinds);
   const roundLabel = formatRoundStageLabel(session.slice?.roundStage);
   return (
     <Box flexDirection="row" height={1} minWidth={0} overflowY="hidden">
@@ -118,6 +127,7 @@ function SessionRow({
         <Text bold={active} wrap="truncate-end">
           {session.label}
           {statusLabel ? ` ${statusLabel}` : ''}
+          {approvalSuffix ? ` · ${approvalSuffix}` : ''}
           {roundLabel ? ` · ${roundLabel}` : ''}
           {elapsed ? ` · ${elapsed}` : ''}
         </Text>
@@ -166,6 +176,12 @@ export interface SubagentListProps {
   readonly onOpenProcessDetail?: (executionId: string) => void;
   readonly onSelectionChange?: (value: ChildListValue) => void;
   readonly onViewStream?: (streamId: StreamTabId) => void;
+  /** Pending approval kinds per stream id (see `pendingApprovalsByStream`,
+   *  root bucket already folded onto the root stream id by the caller). */
+  readonly pendingApprovals?: ReadonlyMap<
+    string,
+    readonly PendingApprovalKind[]
+  >;
   readonly selectedValue?: ChildListValue;
   readonly sessions?: readonly StreamView[];
   readonly activeProcesses?: readonly ActiveChildInfo[];
@@ -321,6 +337,7 @@ export function SubagentList(
                 focused={state.focused}
                 hiddenRowSummary={hiddenRowSummary || undefined}
                 nowMs={nowMs}
+                pendingKinds={props.pendingApprovals?.get(session.id)}
                 session={session}
               />
             );

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -176,7 +176,7 @@ export interface SubagentListProps {
   readonly onOpenProcessDetail?: (executionId: string) => void;
   readonly onSelectionChange?: (value: ChildListValue) => void;
   readonly onViewStream?: (streamId: StreamTabId) => void;
-  /** Pending approval kinds per stream id (see `pendingApprovalsByStream`,
+  /** Pending approval kinds per stream id (see `pendingApprovalSummaries`,
    *  root bucket already folded onto the root stream id by the caller). */
   readonly pendingApprovals?: ReadonlyMap<
     string,

--- a/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
@@ -7,6 +7,7 @@ import {
   COLOR_WARNING,
 } from '../ui/colors';
 import { STATUS_DOT } from '../ui/glyphs';
+import type { PendingApprovalKind } from '../state/approvalQueue';
 
 export function childStatusColor(status: string | undefined): string {
   if (!status) return COLOR_SUCCESS;
@@ -26,3 +27,24 @@ export function childStatusColor(status: string | undefined): string {
 // is conveyed by `childStatusColor`, and liveness by the `running · Ns` text, so
 // the animation bought churn without information.
 export const CHILD_STATUS_MARKER = `${STATUS_DOT} `;
+
+const PENDING_APPROVAL_ROW_LABELS: Record<PendingApprovalKind, string> = {
+  bash: 'bash',
+  toolEdit: 'edit',
+  plan: 'plan',
+  proposal: 'proposal',
+  retry: 'retry',
+  externalInquiry: 'inquiry',
+  userQuestion: 'question',
+};
+
+/** One-word "waiting on what" suffix for a session row: the row's first
+ *  pending approval kind, plus a `+N` overflow when more are queued. */
+export function pendingApprovalRowSuffix(
+  kinds: readonly PendingApprovalKind[] | undefined,
+): string | undefined {
+  const first = kinds?.[0];
+  if (kinds === undefined || first === undefined) return undefined;
+  const label = PENDING_APPROVAL_ROW_LABELS[first];
+  return kinds.length > 1 ? `${label} +${kinds.length - 1}` : label;
+}

--- a/packages/cli/src/chat/tui/state/approvalQueue.ts
+++ b/packages/cli/src/chat/tui/state/approvalQueue.ts
@@ -69,13 +69,28 @@ export interface EnqueueApprovalOptions {
   readonly onPresent?: () => void;
 }
 
+export type PendingApprovalKind = ApprovalPayload['kind'];
+
+/** Grouping key for payloads that carry no stream id — they are session-wide
+ *  and belong to the root/main row, never a child row. */
+export const ROOT_APPROVAL_STREAM_KEY = '';
+
 const CURRENT = signal<PendingApproval | undefined>(undefined);
 const STATUS = signal<ApprovalQueueStatus>({ depth: 0, kind: 'approval' });
+const PENDING_BY_STREAM = signal<
+  ReadonlyMap<string, readonly PendingApprovalKind[]>
+>(new Map());
 
 export const currentApproval = CURRENT as Signal.State<
   PendingApproval | undefined
 >;
 export const approvalQueueStatus = STATUS as Signal.State<ApprovalQueueStatus>;
+/** Pending approval kinds grouped by their stream (FIFO order per stream);
+ *  stream-less payloads group under {@link ROOT_APPROVAL_STREAM_KEY}. Powers
+ *  the session list's per-row "waiting on what" suffix. */
+export const pendingApprovalsByStream = PENDING_BY_STREAM as Signal.State<
+  ReadonlyMap<string, readonly PendingApprovalKind[]>
+>;
 
 const clearListeners = new Set<() => void>();
 
@@ -83,6 +98,9 @@ interface ApprovalQueueItem {
   readonly payload: ApprovalPayload;
   readonly resolve: (decision: ApprovalDecision) => void;
   readonly onPresent?: () => void;
+  /** Set once the item has been foregrounded, so re-presentations after a
+   *  queue reorder cannot re-fire focus/notification side effects. */
+  presented?: boolean;
 }
 
 const pendingItems: ApprovalQueueItem[] = [];
@@ -96,11 +114,14 @@ function presentForeground(): void {
   const item = pendingItems[0];
   if (!item || CURRENT.get()) return;
 
-  try {
-    item.onPresent?.();
-  } catch {
-    // Presentation hooks update surrounding TUI state only; approval
-    // resolution must remain available even if focus activation fails.
+  if (!item.presented) {
+    item.presented = true;
+    try {
+      item.onPresent?.();
+    } catch {
+      // Presentation hooks update surrounding TUI state only; approval
+      // resolution must remain available even if focus activation fails.
+    }
   }
   if (pendingItems[0] !== item) return;
 
@@ -207,6 +228,39 @@ function syncApprovalStatus(): void {
         ? 'approval'
         : approvalQueueStatusKind(pendingApprovalPayloads()),
   });
+  const byStream = new Map<string, PendingApprovalKind[]>();
+  for (const item of pendingItems) {
+    const key =
+      approvalPayloadStreamId(item.payload) ?? ROOT_APPROVAL_STREAM_KEY;
+    const kinds = byStream.get(key);
+    if (kinds) kinds.push(item.payload.kind);
+    else byStream.set(key, [item.payload.kind]);
+  }
+  PENDING_BY_STREAM.set(byStream);
+}
+
+/**
+ * Stable-partition the queue so `streamId`'s pending items lead, then
+ * re-project the head. Settling matches by item identity, so a decision made
+ * against the previous projection still resolves the right item; nothing is
+ * settled, resolved, or (re-)notified by a promotion. Used by jump-to-waiting:
+ * focusing a session surfaces that session's approval immediately.
+ */
+export function promoteApprovalsForStream(streamId: StreamTabId): void {
+  if (pendingItems.length < 2) return;
+  const head = pendingItems[0];
+  if (head && approvalPayloadStreamId(head.payload) === streamId) return;
+  const promoted: ApprovalQueueItem[] = [];
+  const rest: ApprovalQueueItem[] = [];
+  for (const item of pendingItems) {
+    (approvalPayloadStreamId(item.payload) === streamId ? promoted : rest).push(
+      item,
+    );
+  }
+  if (promoted.length === 0) return;
+  pendingItems.splice(0, pendingItems.length, ...promoted, ...rest);
+  CURRENT.set(undefined);
+  presentForeground();
 }
 
 export function enqueueApproval(

--- a/packages/cli/src/chat/tui/state/approvalQueue.ts
+++ b/packages/cli/src/chat/tui/state/approvalQueue.ts
@@ -265,17 +265,24 @@ export function promoteApprovalsForStream(
       (options.includeSessionWide === true && itemStreamId === undefined)
     );
   };
-  const head = pendingItems[0];
-  if (head && matches(head)) return;
   const promoted: ApprovalQueueItem[] = [];
   const rest: ApprovalQueueItem[] = [];
   for (const item of pendingItems) {
     (matches(item) ? promoted : rest).push(item);
   }
   if (promoted.length === 0) return;
-  pendingItems.splice(0, pendingItems.length, ...promoted, ...rest);
-  CURRENT.set(undefined);
-  presentForeground();
+  const next = [...promoted, ...rest];
+  // Already a contiguous prefix (a head-only check would miss matching items
+  // still parked behind other streams) — nothing to reorder.
+  if (next.every((item, index) => item === pendingItems[index])) return;
+  const headChanged = pendingItems[0] !== next[0];
+  pendingItems.splice(0, pendingItems.length, ...next);
+  // Only re-project when the head actually moved; the current projection's
+  // decide closure settles by item identity, so it stays valid either way.
+  if (headChanged) {
+    CURRENT.set(undefined);
+    presentForeground();
+  }
   syncApprovalStatus();
 }
 

--- a/packages/cli/src/chat/tui/state/approvalQueue.ts
+++ b/packages/cli/src/chat/tui/state/approvalQueue.ts
@@ -71,25 +71,32 @@ export interface EnqueueApprovalOptions {
 
 export type PendingApprovalKind = ApprovalPayload['kind'];
 
-/** Grouping key for payloads that carry no stream id — they are session-wide
+/** Stream key for payloads that carry no stream id — they are session-wide
  *  and belong to the root/main row, never a child row. */
 export const ROOT_APPROVAL_STREAM_KEY = '';
 
+/** One queued approval as seen by list surfaces: its owning stream key and
+ *  payload kind, in global FIFO position. */
+export interface PendingApprovalSummary {
+  readonly streamKey: string;
+  readonly kind: PendingApprovalKind;
+}
+
 const CURRENT = signal<PendingApproval | undefined>(undefined);
 const STATUS = signal<ApprovalQueueStatus>({ depth: 0, kind: 'approval' });
-const PENDING_BY_STREAM = signal<
-  ReadonlyMap<string, readonly PendingApprovalKind[]>
->(new Map());
+const PENDING_SUMMARIES = signal<readonly PendingApprovalSummary[]>([]);
 
 export const currentApproval = CURRENT as Signal.State<
   PendingApproval | undefined
 >;
 export const approvalQueueStatus = STATUS as Signal.State<ApprovalQueueStatus>;
-/** Pending approval kinds grouped by their stream (FIFO order per stream);
- *  stream-less payloads group under {@link ROOT_APPROVAL_STREAM_KEY}. Powers
- *  the session list's per-row "waiting on what" suffix. */
-export const pendingApprovalsByStream = PENDING_BY_STREAM as Signal.State<
-  ReadonlyMap<string, readonly PendingApprovalKind[]>
+/** Every pending approval's stream key and kind, in global FIFO order;
+ *  stream-less payloads carry {@link ROOT_APPROVAL_STREAM_KEY}. Kept flat so
+ *  callers that fold buckets together (e.g. root row + session-wide) can
+ *  still order by first-to-present. Powers the session list's per-row
+ *  "waiting on what" suffix. */
+export const pendingApprovalSummaries = PENDING_SUMMARIES as Signal.State<
+  readonly PendingApprovalSummary[]
 >;
 
 const clearListeners = new Set<() => void>();
@@ -228,15 +235,13 @@ function syncApprovalStatus(): void {
         ? 'approval'
         : approvalQueueStatusKind(pendingApprovalPayloads()),
   });
-  const byStream = new Map<string, PendingApprovalKind[]>();
-  for (const item of pendingItems) {
-    const key =
-      approvalPayloadStreamId(item.payload) ?? ROOT_APPROVAL_STREAM_KEY;
-    const kinds = byStream.get(key);
-    if (kinds) kinds.push(item.payload.kind);
-    else byStream.set(key, [item.payload.kind]);
-  }
-  PENDING_BY_STREAM.set(byStream);
+  PENDING_SUMMARIES.set(
+    pendingItems.map((item) => ({
+      streamKey:
+        approvalPayloadStreamId(item.payload) ?? ROOT_APPROVAL_STREAM_KEY,
+      kind: item.payload.kind,
+    })),
+  );
 }
 
 /**
@@ -245,22 +250,33 @@ function syncApprovalStatus(): void {
  * against the previous projection still resolves the right item; nothing is
  * settled, resolved, or (re-)notified by a promotion. Used by jump-to-waiting:
  * focusing a session surfaces that session's approval immediately.
+ * `includeSessionWide` also promotes stream-less (session-wide) items — pass
+ * it when promoting the root stream, whose row those items fold onto.
  */
-export function promoteApprovalsForStream(streamId: StreamTabId): void {
+export function promoteApprovalsForStream(
+  streamId: StreamTabId,
+  options: { readonly includeSessionWide?: boolean } = {},
+): void {
   if (pendingItems.length < 2) return;
+  const matches = (item: ApprovalQueueItem): boolean => {
+    const itemStreamId = approvalPayloadStreamId(item.payload);
+    return (
+      itemStreamId === streamId ||
+      (options.includeSessionWide === true && itemStreamId === undefined)
+    );
+  };
   const head = pendingItems[0];
-  if (head && approvalPayloadStreamId(head.payload) === streamId) return;
+  if (head && matches(head)) return;
   const promoted: ApprovalQueueItem[] = [];
   const rest: ApprovalQueueItem[] = [];
   for (const item of pendingItems) {
-    (approvalPayloadStreamId(item.payload) === streamId ? promoted : rest).push(
-      item,
-    );
+    (matches(item) ? promoted : rest).push(item);
   }
   if (promoted.length === 0) return;
   pendingItems.splice(0, pendingItems.length, ...promoted, ...rest);
   CURRENT.set(undefined);
   presentForeground();
+  syncApprovalStatus();
 }
 
 export function enqueueApproval(

--- a/src/test-kernel/cli/ApprovalQueue.vitest.mts
+++ b/src/test-kernel/cli/ApprovalQueue.vitest.mts
@@ -17,7 +17,7 @@ import {
   clearApprovalsWhere,
   currentApproval,
   enqueueApproval,
-  pendingApprovalsByStream,
+  pendingApprovalSummaries,
   promoteApprovalsForStream,
   ROOT_APPROVAL_STREAM_KEY,
   type ApprovalPayload,
@@ -297,24 +297,24 @@ describe('CLI approval queue', () => {
     await expect(untouchedResult).resolves.toEqual({ accepted: true });
   });
 
-  it('groups pending kinds by stream, folding stream-less payloads under the root key', async () => {
+  it('summarizes pending items in global FIFO order, keying stream-less payloads to the root', async () => {
     enqueueApproval(bashPayload('child-1'));
+    // Empty streamId is normalized to undefined by approvalPayloadStreamId,
+    // so session-wide payloads carry the root stream key — interleaved here
+    // to pin that consumers folding buckets still see first-to-present order.
+    enqueueApproval(bashPayload(''));
     enqueueApproval(externalInquiryPayload('child-1'));
     enqueueApproval(bashPayload('child-2'));
-    // Empty streamId is normalized to undefined by approvalPayloadStreamId,
-    // so session-wide payloads land in the root bucket.
-    enqueueApproval(bashPayload(''));
 
-    expect(pendingApprovalsByStream.get()).toEqual(
-      new Map([
-        ['child-1', ['bash', 'externalInquiry']],
-        ['child-2', ['bash']],
-        [ROOT_APPROVAL_STREAM_KEY, ['bash']],
-      ]),
-    );
+    expect(pendingApprovalSummaries.get()).toEqual([
+      { streamKey: 'child-1', kind: 'bash' },
+      { streamKey: ROOT_APPROVAL_STREAM_KEY, kind: 'bash' },
+      { streamKey: 'child-1', kind: 'externalInquiry' },
+      { streamKey: 'child-2', kind: 'bash' },
+    ]);
 
     clearApprovals();
-    expect(pendingApprovalsByStream.get()).toEqual(new Map());
+    expect(pendingApprovalSummaries.get()).toEqual([]);
   });
 
   it('promotes a stream to the head without settling, resolving, or re-presenting', async () => {
@@ -338,6 +338,13 @@ describe('CLI approval queue', () => {
     expect(approvalQueueStatus.get().depth).toBe(2);
     expect(presented).toEqual(['child-1', 'child-2']);
 
+    // The summaries reflect the promoted order, so per-row suffixes agree
+    // with what will present next.
+    expect(pendingApprovalSummaries.get()).toEqual([
+      { streamKey: 'child-2', kind: 'bash' },
+      { streamKey: 'child-1', kind: 'bash' },
+    ]);
+
     // Promoting an absent stream is a no-op.
     promoteApprovalsForStream('missing' as StreamTabId);
     expect(currentApproval.get()?.payload).toBe(second);
@@ -353,5 +360,42 @@ describe('CLI approval queue', () => {
 
     currentApproval.get()?.decide({ accepted: false });
     await expect(firstResult).resolves.toEqual({ accepted: false });
+  });
+
+  it('promotes session-wide items together with the root stream when asked', async () => {
+    const childItem = bashPayload('child-1');
+    const sessionWide = bashPayload('');
+    const rootItem = bashPayload('root');
+    const childResult = enqueueApproval(childItem);
+    const sessionWideResult = enqueueApproval(sessionWide);
+    const rootResult = enqueueApproval(rootItem);
+    await vi.waitFor(() => {
+      expect(currentApproval.get()?.payload).toBe(childItem);
+    });
+
+    promoteApprovalsForStream('root' as StreamTabId, {
+      includeSessionWide: true,
+    });
+
+    // Session-wide and root items lead, preserving their relative order.
+    expect(pendingApprovalSummaries.get()).toEqual([
+      { streamKey: ROOT_APPROVAL_STREAM_KEY, kind: 'bash' },
+      { streamKey: 'root', kind: 'bash' },
+      { streamKey: 'child-1', kind: 'bash' },
+    ]);
+    expect(currentApproval.get()?.payload).toBe(sessionWide);
+
+    currentApproval.get()?.decide({ accepted: true });
+    await expect(sessionWideResult).resolves.toEqual({ accepted: true });
+    await vi.waitFor(() => {
+      expect(currentApproval.get()?.payload).toBe(rootItem);
+    });
+    currentApproval.get()?.decide({ accepted: true });
+    await expect(rootResult).resolves.toEqual({ accepted: true });
+    await vi.waitFor(() => {
+      expect(currentApproval.get()?.payload).toBe(childItem);
+    });
+    currentApproval.get()?.decide({ accepted: false });
+    await expect(childResult).resolves.toEqual({ accepted: false });
   });
 });

--- a/src/test-kernel/cli/ApprovalQueue.vitest.mts
+++ b/src/test-kernel/cli/ApprovalQueue.vitest.mts
@@ -17,9 +17,13 @@ import {
   clearApprovalsWhere,
   currentApproval,
   enqueueApproval,
+  pendingApprovalsByStream,
+  promoteApprovalsForStream,
+  ROOT_APPROVAL_STREAM_KEY,
   type ApprovalPayload,
 } from '@cli/chat/tui/state/approvalQueue';
 import { enqueueTuiApproval } from '@cli/chat/tui/state/subscribeApprovals';
+import type { StreamTabId } from '@shared/schemas';
 
 function bashPayload(streamId: string): ApprovalPayload {
   return {
@@ -291,5 +295,63 @@ describe('CLI approval queue', () => {
     expect(presented).toEqual(['plan', 'untouched']);
     currentApproval.get()?.decide({ accepted: true });
     await expect(untouchedResult).resolves.toEqual({ accepted: true });
+  });
+
+  it('groups pending kinds by stream, folding stream-less payloads under the root key', async () => {
+    enqueueApproval(bashPayload('child-1'));
+    enqueueApproval(externalInquiryPayload('child-1'));
+    enqueueApproval(bashPayload('child-2'));
+    // Empty streamId is normalized to undefined by approvalPayloadStreamId,
+    // so session-wide payloads land in the root bucket.
+    enqueueApproval(bashPayload(''));
+
+    expect(pendingApprovalsByStream.get()).toEqual(
+      new Map([
+        ['child-1', ['bash', 'externalInquiry']],
+        ['child-2', ['bash']],
+        [ROOT_APPROVAL_STREAM_KEY, ['bash']],
+      ]),
+    );
+
+    clearApprovals();
+    expect(pendingApprovalsByStream.get()).toEqual(new Map());
+  });
+
+  it('promotes a stream to the head without settling, resolving, or re-presenting', async () => {
+    const presented: string[] = [];
+    const first = bashPayload('child-1');
+    const second = bashPayload('child-2');
+    const firstResult = enqueueApproval(first, {
+      onPresent: () => presented.push('child-1'),
+    });
+    const secondResult = enqueueApproval(second, {
+      onPresent: () => presented.push('child-2'),
+    });
+    await vi.waitFor(() => {
+      expect(currentApproval.get()?.payload).toBe(first);
+    });
+
+    promoteApprovalsForStream('child-2' as StreamTabId);
+
+    // The promoted item is foregrounded; nothing was settled or resolved.
+    expect(currentApproval.get()?.payload).toBe(second);
+    expect(approvalQueueStatus.get().depth).toBe(2);
+    expect(presented).toEqual(['child-1', 'child-2']);
+
+    // Promoting an absent stream is a no-op.
+    promoteApprovalsForStream('missing' as StreamTabId);
+    expect(currentApproval.get()?.payload).toBe(second);
+
+    // Settling the promoted head re-presents the demoted item — but its
+    // presentation side effects do not fire a second time.
+    currentApproval.get()?.decide({ accepted: true });
+    await expect(secondResult).resolves.toEqual({ accepted: true });
+    await vi.waitFor(() => {
+      expect(currentApproval.get()?.payload).toBe(first);
+    });
+    expect(presented).toEqual(['child-1', 'child-2']);
+
+    currentApproval.get()?.decide({ accepted: false });
+    await expect(firstResult).resolves.toEqual({ accepted: false });
   });
 });

--- a/src/test-kernel/cli/ApprovalQueue.vitest.mts
+++ b/src/test-kernel/cli/ApprovalQueue.vitest.mts
@@ -349,10 +349,28 @@ describe('CLI approval queue', () => {
     promoteApprovalsForStream('missing' as StreamTabId);
     expect(currentApproval.get()?.payload).toBe(second);
 
-    // Settling the promoted head re-presents the demoted item — but its
-    // presentation side effects do not fire a second time.
+    // A matching head does not short-circuit gathering the stream's later
+    // items: with [child-2, child-1, child-2'] promoting child-2 pulls the
+    // trailing item up behind the head without re-projecting the foreground.
+    const third = bashPayload('child-2');
+    const thirdResult = enqueueApproval(third);
+    promoteApprovalsForStream('child-2' as StreamTabId);
+    expect(currentApproval.get()?.payload).toBe(second);
+    expect(pendingApprovalSummaries.get()).toEqual([
+      { streamKey: 'child-2', kind: 'bash' },
+      { streamKey: 'child-2', kind: 'bash' },
+      { streamKey: 'child-1', kind: 'bash' },
+    ]);
+    // Settling the promoted head presents the pulled-up item next; the
+    // demoted item re-presents last, but its presentation side effects do
+    // not fire a second time.
     currentApproval.get()?.decide({ accepted: true });
     await expect(secondResult).resolves.toEqual({ accepted: true });
+    await vi.waitFor(() => {
+      expect(currentApproval.get()?.payload).toBe(third);
+    });
+    currentApproval.get()?.decide({ accepted: true });
+    await expect(thirdResult).resolves.toEqual({ accepted: true });
     await vi.waitFor(() => {
       expect(currentApproval.get()?.payload).toBe(first);
     });

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   CHILD_STATUS_MARKER,
   childStatusColor,
+  pendingApprovalRowSuffix,
 } from '@cli/chat/tui/panes/SubagentListDisplay';
 import { compactChildRowText } from '@cli/chat/tui/panes/SubagentList';
 import {
@@ -35,6 +36,16 @@ describe('CLI child list display model', () => {
     expect(childStatusColor('stopped')).toBe('gray');
     expect(childStatusColor(STREAM_PHASE.CANCELLED)).toBe('gray');
     expect(childStatusColor(STREAM_PHASE.COMPLETED)).toBe('green');
+  });
+
+  it('summarizes what a row is waiting on from its pending approval kinds', () => {
+    expect(pendingApprovalRowSuffix(undefined)).toBeUndefined();
+    expect(pendingApprovalRowSuffix([])).toBeUndefined();
+    expect(pendingApprovalRowSuffix(['bash'])).toBe('bash');
+    expect(pendingApprovalRowSuffix(['externalInquiry'])).toBe('inquiry');
+    expect(pendingApprovalRowSuffix(['toolEdit', 'bash', 'userQuestion'])).toBe(
+      'edit +2',
+    );
   });
 
   it('moves selection through every session and wraps at the ends', () => {


### PR DESCRIPTION
## Summary

- `approvalQueue.ts` publishes `pendingApprovalsByStream`: pending approval kinds grouped per stream in FIFO order, produced at the queue's single `syncApprovalStatus` choke point; stream-less (session-wide) payloads fold onto the root row via `ROOT_APPROVAL_STREAM_KEY`.
- Session rows show what each stream is waiting on: `waiting for you · bash` (`+N` when more are queued), via `pendingApprovalRowSuffix` in the existing display-model module.
- Jump-to-waiting: focusing a session (Enter on its row, or Alt-1..9) calls `promoteApprovalsForStream`, a stable partition that moves that stream's items to the queue head — its approval modal surfaces immediately through the existing `approvalVisibleForActiveStream` mechanics. Promotion settles and resolves nothing (settling matches by item identity), and items now fire presentation side effects (focus emit, notification) only the first time they are foregrounded, so reorders cannot re-notify.

The approval FIFO remains the single owner; the new signal is a pure projection. No new panel or modal.

**Stacked on** the workflow-facts PR (base `feat/tui-workflow-facts`), which stacks on #8655.

Closes #8659.

## Verification

- `corepack pnpm --filter @texra-ai/cli typecheck` and test-kernel tsc: clean
- `npx vitest run src/test-kernel/cli`: 1764 passed (139 files); new `ApprovalQueue.vitest.mts` cases pin grouping (incl. root fold + clear), promote-without-settle/resolve/re-present, and no-op promotion; `SubagentListDisplay.vitest.mts` covers the row suffix
- `npm run check:dead-code-ratchet`: OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reorders the approval FIFO and changes when presentation hooks run, but promotion does not resolve items and behavior is covered by new queue tests.
> 
> **Overview**
> The CLI TUI now surfaces **which approvals each stream is waiting on** in the subagent/session list, and **jump-to-waiting** reorders the shared approval FIFO when you focus a stream so its modal can show immediately.
> 
> `approvalQueue` adds a flat `pendingApprovalSummaries` projection (stream key + kind in global FIFO order, with stream-less items keyed for the root row) and **`promoteApprovalsForStream`**, which stable-partitions pending items without settling or re-firing `onPresent` after the first foreground (via a `presented` flag). **App** folds session-wide summaries onto the root row and calls promotion when focusing a session (list Enter) or **Alt-1..9**, including session-wide items when focusing root.
> 
> Session rows gain a compact suffix (e.g. `bash`, `inquiry`, `edit +2`) through `pendingApprovalRowSuffix` in the list display layer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93699e222b2a8576a0fa59c64b8d59e7b116e82e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->