### PR TITLE
fix(runtime): preserve partial cleanup outcomes

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -987,6 +987,7 @@ export class DesktopProgressBridge {
     }
     const deletion = await this.state.clearStream(streamId);
     if (deletion !== 'deleted') {
+      this.syncStreamContent(this.updateStreamMetadata());
       await this.options.host.showInfoMessage(
         deletion === 'active'
           ? formatActiveStreamRetention(1)

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -1062,7 +1062,8 @@ export class DesktopProgressBridge {
         });
       }
     }
-    this.updateStreamMetadata();
+    const activeStream = this.updateStreamMetadata();
+    if (retainedStreams.size > 0) this.syncStreamContent(activeStream);
     if (retainedStreams.size > 0) {
       await this.options.host.showInfoMessage(
         formatStreamDeletionRetention(

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -985,9 +985,13 @@ export class DesktopProgressBridge {
     if (ownedLocally) {
       await this.state.waitForOwnedExecutionRelease(streamId);
     }
-    const deleted = await this.state.clearStream(streamId);
-    if (!deleted) {
-      await this.options.host.showInfoMessage(formatActiveStreamRetention(1));
+    const deletion = await this.state.clearStream(streamId);
+    if (deletion !== 'deleted') {
+      await this.options.host.showInfoMessage(
+        deletion === 'active'
+          ? formatActiveStreamRetention(1)
+          : formatStreamDeletionRetention(0, 1),
+      );
       return;
     }
     this.deletedStreams.add(streamId);

--- a/src/agent/storage/executionListing.ts
+++ b/src/agent/storage/executionListing.ts
@@ -206,7 +206,6 @@ export type DeleteExecutionResult =
   | {
       readonly status: 'deleted' | 'not-found';
       readonly executionId: ExecutionId;
-      readonly adjacentCleanupFailure?: string;
     }
   | {
       readonly status: 'active';
@@ -225,8 +224,8 @@ export interface DeleteAllExecutionsResult {
 }
 
 export interface DeleteExecutionOptions {
-  /** Adjacent cleanup run under the lock only after execution storage is gone. */
-  readonly afterDelete?: () => Promise<void>;
+  /** Cleanup that must succeed under the inactive lease before storage removal. */
+  readonly beforeDelete?: () => Promise<void>;
 }
 
 export async function deleteExecution(
@@ -239,6 +238,7 @@ export async function deleteExecution(
       const existed = await StorageFS.exists(
         `${RUNS_STORAGE_DIR}/${executionId}`,
       );
+      await options.beforeDelete?.();
       let status: 'deleted' | 'not-found' = 'not-found';
       if (existed) {
         try {
@@ -248,16 +248,7 @@ export async function deleteExecution(
           if (!isFileNotFoundError(error)) throw error;
         }
       }
-      try {
-        await options.afterDelete?.();
-        return { status, executionId };
-      } catch (error) {
-        return {
-          status,
-          executionId,
-          adjacentCleanupFailure: toErrorMessage(error),
-        };
-      }
+      return { status, executionId };
     },
   );
   if (guarded.status === 'active') {

--- a/src/controllers/progressView/ProgressStreamLifecycleController.ts
+++ b/src/controllers/progressView/ProgressStreamLifecycleController.ts
@@ -3,7 +3,10 @@ import { canUseStreamDataDir } from '@transcript/streamDataPaths';
 
 // Local imports - shared
 import type { StreamTabId } from '@shared/schemas';
-import type { DeleteAllStreamsResult } from './backend/state/SessionStores';
+import type {
+  DeleteAllStreamsResult,
+  DeleteStreamResult,
+} from './backend/state/SessionStores';
 
 export interface ProgressStreamLifecycleState {
   getActiveStream(): StreamTabId | '';
@@ -13,7 +16,7 @@ export interface ProgressStreamLifecycleState {
   getStreamIds(): StreamTabId[];
   pickValidActiveStream(availableStreams: StreamTabId[]): StreamTabId | '';
   waitForOwnedExecutionRelease(stream: StreamTabId): Promise<void>;
-  clearStream(stream: StreamTabId): Promise<boolean>;
+  clearStream(stream: StreamTabId): Promise<DeleteStreamResult>;
   clearAll(): Promise<DeleteAllStreamsResult>;
 }
 
@@ -57,8 +60,13 @@ export class ProgressStreamLifecycleController {
     const hasStream =
       this.deps.state.hasStream(stream) || this.deps.state.hasTaskState(stream);
     if (!hasStream) {
-      const deleted = await this.deps.state.clearStream(stream);
-      if (!deleted) await this.deps.host.notifyDeletionRetained(1);
+      const deletion = await this.deps.state.clearStream(stream);
+      if (deletion !== 'deleted') {
+        await this.deps.host.notifyDeletionRetained(
+          deletion === 'active' ? 1 : 0,
+          deletion === 'failed' ? 1 : 0,
+        );
+      }
       return;
     }
 
@@ -74,10 +82,13 @@ export class ProgressStreamLifecycleController {
     if (ownedLocally)
       await this.deps.state.waitForOwnedExecutionRelease(stream);
 
-    const deleted = await this.deps.state.clearStream(stream);
-    if (!deleted) {
+    const deletion = await this.deps.state.clearStream(stream);
+    if (deletion !== 'deleted') {
       this.deps.host.rebuildRenderedStreams({ forceRebuild: true });
-      await this.deps.host.notifyDeletionRetained(1);
+      await this.deps.host.notifyDeletionRetained(
+        deletion === 'active' ? 1 : 0,
+        deletion === 'failed' ? 1 : 0,
+      );
       return;
     }
     this.deps.host.cleanupDeletedStream(stream);

--- a/src/controllers/progressView/backend/state/ProgressViewState.ts
+++ b/src/controllers/progressView/backend/state/ProgressViewState.ts
@@ -34,7 +34,11 @@ import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { GoalStore } from '@tools/goal';
 import { clamp } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
-import { SessionStores, type DeleteAllStreamsResult } from './SessionStores';
+import {
+  SessionStores,
+  type DeleteAllStreamsResult,
+  type DeleteStreamResult,
+} from './SessionStores';
 import type { MementoStorage } from '@controllers/progressView/backend/persistence/PersistentMapManager';
 
 /** Bounded fan-out for the one-time legacy-instruction backfill at load(),
@@ -403,9 +407,9 @@ export class ProgressViewState {
     return this.stores.waitForOwnedExecutionRelease(stream);
   }
 
-  async clearStream(stream: StreamTabId): Promise<boolean> {
+  async clearStream(stream: StreamTabId): Promise<DeleteStreamResult> {
     const deletion = await this.stores.deleteStream(stream);
-    if (deletion === 'active') return false;
+    if (deletion !== 'deleted') return deletion;
 
     this.streamStatus.clearStream(stream);
     this._sessionState.delete(stream);
@@ -415,7 +419,7 @@ export class ProgressViewState {
     if (this._prefs.get('activeStream') === stream) {
       this._prefs.update({ activeStream: this.topmostStreamTab() });
     }
-    return true;
+    return 'deleted';
   }
 
   async clearAll(): Promise<DeleteAllStreamsResult> {

--- a/src/controllers/progressView/backend/state/ProgressViewState.ts
+++ b/src/controllers/progressView/backend/state/ProgressViewState.ts
@@ -459,6 +459,22 @@ export class ProgressViewState {
     const streamIds = this.streamLogs.keys();
     this.logger.info(`[Persistence] Discovered ${streamIds.length} stream(s)`);
 
+    const reconciledDeletions = await this.snapshots.reconcileStagedDeletions(
+      new Set(streamIds),
+    );
+    if (
+      reconciledDeletions.restored.length > 0 ||
+      reconciledDeletions.pendingCleanup.length > 0 ||
+      reconciledDeletions.discarded.length > 0
+    ) {
+      this.logger.info(
+        '[Persistence] Reconciled interrupted stream deletions',
+        {
+          data: reconciledDeletions,
+        },
+      );
+    }
+
     const sweep = await this.stores.sweepOrphanedStreams(new Set(streamIds));
     if (sweep.streams.length > 0) {
       this.logger.info(

--- a/src/controllers/progressView/backend/state/SessionStores.ts
+++ b/src/controllers/progressView/backend/state/SessionStores.ts
@@ -56,6 +56,8 @@ export interface DeleteAllStreamsResult {
   readonly failed: ReadonlySet<StreamTabId>;
 }
 
+export type DeleteStreamResult = 'deleted' | 'active' | 'failed';
+
 /**
  * Owns the durable footprint for a progress stream.
  *
@@ -89,7 +91,7 @@ export class SessionStores {
     if (executionId) await waitForOwnedExecutionLeaseRelease(executionId);
   }
 
-  async deleteStream(stream: StreamTabId): Promise<'deleted' | 'active'> {
+  async deleteStream(stream: StreamTabId): Promise<DeleteStreamResult> {
     if (!canUseStreamDataDir(stream)) return 'deleted';
 
     const executionId = await this.executionIdForStream(stream);
@@ -100,9 +102,10 @@ export class SessionStores {
       } catch (error) {
         logger.warn(
           CHANNEL,
-          `Stream ${stream} was removed, but adjacent cleanup was incomplete: ${toErrorMessage(error)}`,
+          `Stream ${stream} was retained because cleanup was incomplete: ${toErrorMessage(error)}`,
           { data: error },
         );
+        return 'failed';
       }
       return 'deleted';
     }
@@ -114,6 +117,7 @@ export class SessionStores {
         CHANNEL,
         `Execution ${executionId} was deleted, but adjacent stream cleanup was incomplete: ${result.adjacentCleanupFailure}`,
       );
+      return 'failed';
     }
     return result.status === 'active' ? 'active' : 'deleted';
   }
@@ -170,6 +174,7 @@ export class SessionStores {
             `Failed to delete stream ${stream}: ${toErrorMessage(error)}`,
             { data: error },
           );
+          failed.add(stream);
         }
       }),
     );
@@ -186,6 +191,7 @@ export class SessionStores {
               CHANNEL,
               `Execution ${executionId} was deleted, but adjacent stream cleanup was incomplete: ${result.adjacentCleanupFailure}`,
             );
+            for (const stream of streams) failed.add(stream);
           }
         } catch (error) {
           logger.warn(

--- a/src/controllers/progressView/backend/state/SessionStores.ts
+++ b/src/controllers/progressView/backend/state/SessionStores.ts
@@ -264,20 +264,24 @@ export class SessionStores {
   }
 
   private async deleteAdjacentStreamState(stream: StreamTabId): Promise<void> {
+    // The transcript registry owns tab visibility. Delete it only after every
+    // other sidecar succeeds so a partial cleanup remains retryable in the UI.
     await waitForAdjacentCleanup([
-      this.streamLogs.delete(stream),
       this.snapshots.deleteStream(stream),
       this.goalEntries?.forget(stream),
     ]);
+    await this.streamLogs.delete(stream);
   }
 
   private async deleteAdjacentStreamStates(
     streams: readonly StreamTabId[],
   ): Promise<void> {
     await waitForAdjacentCleanup([
-      ...streams.map((stream) => this.streamLogs.delete(stream)),
       ...streams.map((stream) => this.snapshots.deleteStream(stream)),
       this.goalEntries?.forgetMany(streams),
     ]);
+    await waitForAdjacentCleanup(
+      streams.map((stream) => this.streamLogs.delete(stream)),
+    );
   }
 }

--- a/src/controllers/progressView/backend/state/SessionStores.ts
+++ b/src/controllers/progressView/backend/state/SessionStores.ts
@@ -142,10 +142,14 @@ export class SessionStores {
   }
 
   async deleteAll(): Promise<DeleteAllStreamsResult> {
-    const persistedStreams = await this.snapshots.listPersistedStreams();
-    const streamIds = unique([...persistedStreams, ...this.streamLogs.keys()]);
+    const [persistedStreams, stagedDeletions] = await Promise.all([
+      this.snapshots.listPersistedStreams(),
+      this.snapshots.listStagedDeletions(),
+    ]);
+    const snapshotStreams = unique([...persistedStreams, ...stagedDeletions]);
+    const streamIds = unique([...snapshotStreams, ...this.streamLogs.keys()]);
     const executionIdsByStream = new Map(this.snapshots.getExecutionIdMap());
-    for (const stream of persistedStreams) {
+    for (const stream of snapshotStreams) {
       const executionId = await this.snapshots.readPersistedExecutionId(stream);
       if (executionId) executionIdsByStream.set(stream, executionId);
       else {

--- a/src/controllers/progressView/backend/state/SessionStores.ts
+++ b/src/controllers/progressView/backend/state/SessionStores.ts
@@ -45,6 +45,10 @@ async function waitForAdjacentCleanup(
   const failures = results.flatMap((result) =>
     result.status === 'rejected' ? [result.reason] : [],
   );
+  throwAdjacentCleanupFailures(failures);
+}
+
+function throwAdjacentCleanupFailures(failures: readonly unknown[]): void {
   if (failures.length === 1) throw failures[0];
   if (failures.length > 1) {
     throw new AggregateError(failures, 'Multiple adjacent cleanups failed');
@@ -181,8 +185,13 @@ export class SessionStores {
     await Promise.all(
       [...streamsByExecution].map(async ([executionId, streams]) => {
         try {
+          let failedAdjacentStreams = new Set<StreamTabId>();
           const result = await this.deleteExecution(executionId, {
-            afterDelete: () => this.deleteAdjacentStreamStates(streams),
+            afterDelete: async () => {
+              const cleanup = await this.deleteAdjacentStreamStates(streams);
+              failedAdjacentStreams = cleanup.failed;
+              throwAdjacentCleanupFailures(cleanup.failures);
+            },
           });
           if (result.status === 'active') {
             for (const stream of streams) active.add(stream);
@@ -191,7 +200,11 @@ export class SessionStores {
               CHANNEL,
               `Execution ${executionId} was deleted, but adjacent stream cleanup was incomplete: ${result.adjacentCleanupFailure}`,
             );
-            for (const stream of streams) failed.add(stream);
+            const retainedStreams =
+              failedAdjacentStreams.size > 0
+                ? failedAdjacentStreams
+                : streams.filter((stream) => this.streamLogs.has(stream));
+            for (const stream of retainedStreams) failed.add(stream);
           }
         } catch (error) {
           logger.warn(
@@ -275,13 +288,54 @@ export class SessionStores {
 
   private async deleteAdjacentStreamStates(
     streams: readonly StreamTabId[],
-  ): Promise<void> {
-    await waitForAdjacentCleanup([
-      ...streams.map((stream) => this.snapshots.deleteStream(stream)),
-      this.goalEntries?.forgetMany(streams),
-    ]);
-    await waitForAdjacentCleanup(
-      streams.map((stream) => this.streamLogs.delete(stream)),
+  ): Promise<{
+    failed: Set<StreamTabId>;
+    failures: unknown[];
+  }> {
+    const failed = new Set<StreamTabId>();
+    const failures: unknown[] = [];
+    const goalResult = this.goalEntries?.forgetMany(streams).then(
+      () => ({ status: 'fulfilled' as const }),
+      (error: unknown) => ({ status: 'rejected' as const, error }),
     );
+    const snapshotResults = await Promise.all(
+      streams.map(async (stream) => {
+        try {
+          await this.snapshots.deleteStream(stream);
+          return { stream, status: 'fulfilled' as const };
+        } catch (error) {
+          return { stream, status: 'rejected' as const, error };
+        }
+      }),
+    );
+    for (const result of snapshotResults) {
+      if (result.status === 'fulfilled') continue;
+      failed.add(result.stream);
+      failures.push(result.error);
+    }
+    const settledGoal = await goalResult;
+    if (settledGoal?.status === 'rejected') {
+      for (const stream of streams) failed.add(stream);
+      failures.push(settledGoal.error);
+    }
+
+    const transcriptResults = await Promise.all(
+      streams
+        .filter((stream) => !failed.has(stream))
+        .map(async (stream) => {
+          try {
+            await this.streamLogs.delete(stream);
+            return { stream, status: 'fulfilled' as const };
+          } catch (error) {
+            return { stream, status: 'rejected' as const, error };
+          }
+        }),
+    );
+    for (const result of transcriptResults) {
+      if (result.status === 'fulfilled') continue;
+      failed.add(result.stream);
+      failures.push(result.error);
+    }
+    return { failed, failures };
   }
 }

--- a/src/controllers/progressView/backend/state/SessionStores.ts
+++ b/src/controllers/progressView/backend/state/SessionStores.ts
@@ -38,16 +38,6 @@ export interface SessionStoresOptions {
   };
 }
 
-async function waitForAdjacentCleanup(
-  operations: readonly unknown[],
-): Promise<void> {
-  const results = await Promise.allSettled(operations);
-  const failures = results.flatMap((result) =>
-    result.status === 'rejected' ? [result.reason] : [],
-  );
-  throwAdjacentCleanupFailures(failures);
-}
-
 function throwAdjacentCleanupFailures(failures: readonly unknown[]): void {
   if (failures.length === 1) throw failures[0];
   if (failures.length > 1) {
@@ -302,13 +292,36 @@ export class SessionStores {
   }
 
   private async deleteAdjacentStreamState(stream: StreamTabId): Promise<void> {
-    // The transcript registry owns tab visibility. Delete it only after every
-    // other sidecar succeeds so a partial cleanup remains retryable in the UI.
-    await waitForAdjacentCleanup([
-      this.snapshots.deleteStream(stream),
+    const snapshotDeletion = await this.snapshots.stageDeleteStream(stream);
+    try {
+      // The transcript registry is the commit point for tab visibility.
+      // Snapshot sidecars are only renamed before this, so a failure can roll
+      // them back without reconstructing state from partial files.
+      await this.streamLogs.delete(stream);
+    } catch (error) {
+      try {
+        await snapshotDeletion.rollback();
+      } catch (rollbackError) {
+        throw new AggregateError(
+          [error, rollbackError],
+          `Transcript and snapshot rollback failed for stream ${stream}`,
+        );
+      }
+      throw error;
+    }
+
+    const cleanup = await Promise.allSettled([
+      snapshotDeletion.commit(),
       this.goalEntries?.forget(stream),
     ]);
-    await this.streamLogs.delete(stream);
+    for (const result of cleanup) {
+      if (result.status === 'fulfilled') continue;
+      logger.warn(
+        CHANNEL,
+        `Stream ${stream} was deleted, but auxiliary cleanup was incomplete: ${toErrorMessage(result.reason)}`,
+        { data: result.reason },
+      );
+    }
   }
 
   private async deleteAdjacentStreamStates(
@@ -319,30 +332,20 @@ export class SessionStores {
   }> {
     const failed = new Set<StreamTabId>();
     const failures: unknown[] = [];
-    const goalResult = this.goalEntries?.forgetMany(streams).then(
-      () => ({ status: 'fulfilled' as const }),
-      (error: unknown) => ({ status: 'rejected' as const, error }),
-    );
-    const snapshotResults = await Promise.all(
+    const staged = new Map<
+      StreamTabId,
+      Awaited<ReturnType<StreamSnapshotStore['stageDeleteStream']>>
+    >();
+    await Promise.all(
       streams.map(async (stream) => {
         try {
-          await this.snapshots.deleteStream(stream);
-          return { stream, status: 'fulfilled' as const };
+          staged.set(stream, await this.snapshots.stageDeleteStream(stream));
         } catch (error) {
-          return { stream, status: 'rejected' as const, error };
+          failed.add(stream);
+          failures.push(error);
         }
       }),
     );
-    for (const result of snapshotResults) {
-      if (result.status === 'fulfilled') continue;
-      failed.add(result.stream);
-      failures.push(result.error);
-    }
-    const settledGoal = await goalResult;
-    if (settledGoal?.status === 'rejected') {
-      for (const stream of streams) failed.add(stream);
-      failures.push(settledGoal.error);
-    }
 
     const transcriptResults = await Promise.all(
       streams
@@ -360,6 +363,27 @@ export class SessionStores {
       if (result.status === 'fulfilled') continue;
       failed.add(result.stream);
       failures.push(result.error);
+      try {
+        await staged.get(result.stream)?.rollback();
+      } catch (rollbackError) {
+        failures.push(rollbackError);
+      }
+    }
+
+    const committedStreams = streams.filter((stream) => !failed.has(stream));
+    const cleanup = await Promise.allSettled([
+      ...committedStreams.map((stream) => staged.get(stream)?.commit()),
+      committedStreams.length > 0
+        ? this.goalEntries?.forgetMany(committedStreams)
+        : undefined,
+    ]);
+    for (const result of cleanup) {
+      if (result.status === 'fulfilled') continue;
+      logger.warn(
+        CHANNEL,
+        `Streams were deleted, but auxiliary cleanup was incomplete: ${toErrorMessage(result.reason)}`,
+        { data: result.reason },
+      );
     }
     return { failed, failures };
   }

--- a/src/controllers/progressView/backend/state/SessionStores.ts
+++ b/src/controllers/progressView/backend/state/SessionStores.ts
@@ -113,13 +113,28 @@ export class SessionStores {
       }
       return 'deleted';
     }
-    const result = await this.deleteExecution(executionId, {
-      afterDelete: () => this.deleteAdjacentStreamState(stream),
-    });
-    if (result.status !== 'active' && result.adjacentCleanupFailure) {
+    let adjacentCleanupCompleted = false;
+    let result: DeleteExecutionResult;
+    try {
+      result = await this.deleteExecution(executionId, {
+        beforeDelete: async () => {
+          await this.deleteAdjacentStreamState(stream);
+          adjacentCleanupCompleted = true;
+        },
+      });
+    } catch (error) {
+      if (adjacentCleanupCompleted) {
+        logger.warn(
+          CHANNEL,
+          `Stream ${stream} was deleted, but execution ${executionId} cleanup was incomplete: ${toErrorMessage(error)}`,
+          { data: error },
+        );
+        return 'deleted';
+      }
       logger.warn(
         CHANNEL,
-        `Execution ${executionId} was deleted, but adjacent stream cleanup was incomplete: ${result.adjacentCleanupFailure}`,
+        `Stream ${stream} was retained because cleanup was incomplete: ${toErrorMessage(error)}`,
+        { data: error },
       );
       return 'failed';
     }
@@ -184,35 +199,39 @@ export class SessionStores {
     );
     await Promise.all(
       [...streamsByExecution].map(async ([executionId, streams]) => {
+        let failedAdjacentStreams = new Set<StreamTabId>();
+        let adjacentCleanupCompleted = false;
         try {
-          let failedAdjacentStreams = new Set<StreamTabId>();
           const result = await this.deleteExecution(executionId, {
-            afterDelete: async () => {
+            beforeDelete: async () => {
               const cleanup = await this.deleteAdjacentStreamStates(streams);
               failedAdjacentStreams = cleanup.failed;
               throwAdjacentCleanupFailures(cleanup.failures);
+              adjacentCleanupCompleted = true;
             },
           });
           if (result.status === 'active') {
             for (const stream of streams) active.add(stream);
-          } else if (result.adjacentCleanupFailure) {
-            logger.warn(
-              CHANNEL,
-              `Execution ${executionId} was deleted, but adjacent stream cleanup was incomplete: ${result.adjacentCleanupFailure}`,
-            );
-            const retainedStreams =
-              failedAdjacentStreams.size > 0
-                ? failedAdjacentStreams
-                : streams.filter((stream) => this.streamLogs.has(stream));
-            for (const stream of retainedStreams) failed.add(stream);
           }
         } catch (error) {
+          if (adjacentCleanupCompleted) {
+            logger.warn(
+              CHANNEL,
+              `Streams for execution ${executionId} were deleted, but execution cleanup was incomplete: ${toErrorMessage(error)}`,
+              { data: error },
+            );
+            return;
+          }
           logger.warn(
             CHANNEL,
-            `Failed to delete execution ${executionId}: ${toErrorMessage(error)}`,
+            `Failed to delete streams for execution ${executionId}: ${toErrorMessage(error)}`,
             { data: error },
           );
-          for (const stream of streams) failed.add(stream);
+          const retainedStreams =
+            failedAdjacentStreams.size > 0
+              ? failedAdjacentStreams
+              : streams.filter((stream) => this.streamLogs.has(stream));
+          for (const stream of retainedStreams) failed.add(stream);
         }
       }),
     );
@@ -237,11 +256,24 @@ export class SessionStores {
             executionIdFromStream(stream);
           if (executionId) {
             let result: DeleteExecutionResult;
+            let adjacentCleanupCompleted = false;
             try {
               result = await this.deleteExecution(executionId, {
-                afterDelete: () => this.deleteAdjacentStreamState(stream),
+                beforeDelete: async () => {
+                  await this.deleteAdjacentStreamState(stream);
+                  adjacentCleanupCompleted = true;
+                },
               });
             } catch (error) {
+              if (adjacentCleanupCompleted) {
+                sweptStreams.push(stream);
+                logger.warn(
+                  CHANNEL,
+                  `Orphaned stream ${stream} was removed, but execution ${executionId} cleanup was incomplete.`,
+                  { data: error },
+                );
+                return;
+              }
               logger.warn(
                 CHANNEL,
                 `Skipping orphaned execution cleanup for ${executionId}; startup will continue.`,
@@ -250,13 +282,6 @@ export class SessionStores {
               return;
             }
             if (result.status === 'active') return;
-            if (result.adjacentCleanupFailure) {
-              logger.warn(
-                CHANNEL,
-                `Execution ${executionId} was deleted, but orphaned stream cleanup was incomplete: ${result.adjacentCleanupFailure}`,
-              );
-              return;
-            }
             if (result.status === 'deleted') {
               sweptExecutionIds.push(executionId);
             }

--- a/src/controllers/progressView/backend/state/SessionStores.ts
+++ b/src/controllers/progressView/backend/state/SessionStores.ts
@@ -231,10 +231,14 @@ export class SessionStores {
   async sweepOrphanedStreams(
     liveStreams: ReadonlySet<StreamTabId>,
   ): Promise<{ streams: StreamTabId[]; executionIds: ExecutionId[] }> {
-    const persistedStreams = await this.snapshots.listPersistedStreams();
-    const orphanedStreams = persistedStreams.filter(
-      (stream) => !liveStreams.has(stream),
-    );
+    const [persistedStreams, stagedDeletions] = await Promise.all([
+      this.snapshots.listPersistedStreams(),
+      this.snapshots.listStagedDeletions(),
+    ]);
+    const orphanedStreams = unique([
+      ...persistedStreams,
+      ...stagedDeletions,
+    ]).filter((stream) => !liveStreams.has(stream));
     const sweptStreams: StreamTabId[] = [];
     const sweptExecutionIds: ExecutionId[] = [];
 

--- a/src/test-kernel/agent/DeleteExecution.vitest.mts
+++ b/src/test-kernel/agent/DeleteExecution.vitest.mts
@@ -70,47 +70,34 @@ describe('deleteExecution', () => {
     expect(mocks.clear).toHaveBeenCalledTimes(1);
   });
 
-  it('removes execution storage before adjacent state', async () => {
+  it('runs required cleanup before removing execution storage', async () => {
     mocks.exists.mockResolvedValue(true);
     mocks.clear.mockResolvedValue(undefined);
-    const afterDelete = vi.fn(async () => {
-      expect(mocks.clear).toHaveBeenCalledOnce();
+    const beforeDelete = vi.fn(async () => {
+      expect(mocks.clear).not.toHaveBeenCalled();
     });
 
     await expect(
-      deleteExecution('a73039a36eca' as ExecutionId, { afterDelete }),
+      deleteExecution('a73039a36ec8' as ExecutionId, { beforeDelete }),
     ).resolves.toEqual({
       status: 'deleted',
-      executionId: 'a73039a36eca',
+      executionId: 'a73039a36ec8',
     });
-    expect(afterDelete).toHaveBeenCalledOnce();
+    expect(beforeDelete).toHaveBeenCalledOnce();
+    expect(mocks.clear).toHaveBeenCalledOnce();
   });
 
-  it('leaves adjacent state untouched when execution deletion fails', async () => {
-    mocks.exists.mockResolvedValue(true);
-    mocks.clear.mockRejectedValue(new Error('permission denied'));
-    const afterDelete = vi.fn();
-
-    await expect(
-      deleteExecution('a73039a36ecb' as ExecutionId, { afterDelete }),
-    ).rejects.toThrow('permission denied');
-    expect(afterDelete).not.toHaveBeenCalled();
-  });
-
-  it('reports adjacent cleanup failure after execution deletion succeeds', async () => {
+  it('preserves execution storage when required cleanup fails', async () => {
     mocks.exists.mockResolvedValue(true);
     mocks.clear.mockResolvedValue(undefined);
 
     await expect(
-      deleteExecution('a73039a36ecc' as ExecutionId, {
-        afterDelete: async () => {
+      deleteExecution('a73039a36ec7' as ExecutionId, {
+        beforeDelete: async () => {
           throw new Error('sidecar cleanup failed');
         },
       }),
-    ).resolves.toEqual({
-      status: 'deleted',
-      executionId: 'a73039a36ecc',
-      adjacentCleanupFailure: 'sidecar cleanup failed',
-    });
+    ).rejects.toThrow('sidecar cleanup failed');
+    expect(mocks.clear).not.toHaveBeenCalled();
   });
 });

--- a/src/test-kernel/controllers/ProgressStreamLifecycleController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressStreamLifecycleController.vitest.ts
@@ -92,6 +92,23 @@ describe('ProgressStreamLifecycleController', () => {
     assert.deepEqual(syncCalls, [{ forceRebuild: true }]);
   });
 
+  it('keeps a stream rendered when durable cleanup fails', async () => {
+    const { controller, recorder, streams, activeStream, syncCalls } =
+      createProgressStreamLifecycleHarness({
+        activeStream: 'stream-a',
+        failedStreams: ['stream-a'],
+      });
+
+    await controller.deleteStream('stream-a');
+
+    assert.deepEqual(streams(), ['stream-a', 'stream-b']);
+    assert.equal(activeStream(), 'stream-a');
+    assert.deepEqual(recorder.calls.get('cleanupApprovals'), undefined);
+    assert.deepEqual(recorder.calls.get('deleteWebview'), undefined);
+    assert.deepEqual(recorder.calls.get('retained'), ['0/1']);
+    assert.deepEqual(syncCalls, [{ forceRebuild: true }]);
+  });
+
   it('deletes active finished streams and activates the next visible stream', async () => {
     const { controller, recorder, streams, activeStream } =
       createProgressStreamLifecycleHarness({

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -1521,7 +1521,7 @@ describe('DesktopProgressBridge', () => {
     const bridge = await createBridge(messages, {
       canonicalStreamIds: [stream],
       configureProgressSnapshotStore: (store) => {
-        vi.spyOn(store, 'deleteStream').mockRejectedValueOnce(
+        vi.spyOn(store, 'stageDeleteStream').mockRejectedValueOnce(
           new Error('snapshot directory is locked'),
         );
       },
@@ -1777,13 +1777,15 @@ describe('DesktopProgressBridge', () => {
     const bridge = await createBridge(messages, {
       canonicalStreamIds: [deletedStream, retainedStream],
       configureProgressSnapshotStore: (store) => {
-        const deleteSnapshot = store.deleteStream.bind(store);
-        vi.spyOn(store, 'deleteStream').mockImplementation(async (stream) => {
-          if (stream === retainedStream) {
-            throw new Error('snapshot directory is locked');
-          }
-          await deleteSnapshot(stream);
-        });
+        const stageSnapshotDelete = store.stageDeleteStream.bind(store);
+        vi.spyOn(store, 'stageDeleteStream').mockImplementation(
+          async (stream) => {
+            if (stream === retainedStream) {
+              throw new Error('snapshot directory is locked');
+            }
+            return stageSnapshotDelete(stream);
+          },
+        );
       },
     });
     bridge.setActiveStream(deletedStream);

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -1770,6 +1770,36 @@ describe('DesktopProgressBridge', () => {
     expect(cancel).toHaveBeenCalledWith({ cause: 'All streams deleted.' });
   });
 
+  it('syncs an inactive stream retained by bulk deletion', async () => {
+    const deletedStream = 'deleted-stream' as StreamTabId;
+    const retainedStream = 'retained-stream' as StreamTabId;
+    const messages: unknown[] = [];
+    const bridge = await createBridge(messages, {
+      canonicalStreamIds: [deletedStream, retainedStream],
+      configureProgressSnapshotStore: (store) => {
+        const deleteSnapshot = store.deleteStream.bind(store);
+        vi.spyOn(store, 'deleteStream').mockImplementation(async (stream) => {
+          if (stream === retainedStream) {
+            throw new Error('snapshot directory is locked');
+          }
+          await deleteSnapshot(stream);
+        });
+      },
+    });
+    bridge.setActiveStream(deletedStream);
+    messages.length = 0;
+
+    await bridge.deleteAllStreams();
+    await settleProgressEvents();
+
+    expect(
+      progressMessages(messages, PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS).at(-1),
+    ).toMatchObject({ activeStream: retainedStream });
+    expect(
+      progressMessages(messages, PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT),
+    ).toContainEqual(expect.objectContaining({ stream: retainedStream }));
+  });
+
   it('cancels a pending bash approval instead of hanging when all streams are deleted', async () => {
     const messages: unknown[] = [];
     const bridge = await createBridge(messages);

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -1515,6 +1515,38 @@ describe('DesktopProgressBridge', () => {
     });
   });
 
+  it('resyncs a stream retained after durable cleanup fails', async () => {
+    const stream = 'retained-stream' as StreamTabId;
+    const messages: unknown[] = [];
+    const bridge = await createBridge(messages, {
+      canonicalStreamIds: [stream],
+      configureProgressSnapshotStore: (store) => {
+        vi.spyOn(store, 'deleteStream').mockRejectedValueOnce(
+          new Error('snapshot directory is locked'),
+        );
+      },
+    });
+    emitSessionFact(bridge, 'setActiveStream', {
+      streamId: stream,
+      agentCategory: AgentCategory.Workflow,
+    });
+    await settleProgressEvents();
+    messages.length = 0;
+
+    await bridge.deleteStream(stream);
+    await settleProgressEvents();
+
+    expect(
+      progressMessages(messages, PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS).at(-1),
+    ).toMatchObject({ activeStream: stream });
+    expect(
+      progressMessages(messages, PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT),
+    ).toContainEqual(expect.objectContaining({ stream }));
+    expect(
+      progressMessages(messages, PROGRESS_VIEW_COMMANDS.DELETE_STREAM),
+    ).toEqual([]);
+  });
+
   it('cancels a pending plan approval instead of hanging when its stream is deleted', async () => {
     const messages: unknown[] = [];
     const bridge = await createBridge(messages);

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -2054,6 +2054,53 @@ describe('ProgressBackend', () => {
     }
   });
 
+  it('tracks transcript cleanup failures per stream within one execution', async () => {
+    const failedStream = 'tool@deepseek#f00baa6966' as StreamTabId;
+    const deletedStream = 'workflow@deepseek#f00baa6966' as StreamTabId;
+    const executionId = 'f00baa6966' as ExecutionId;
+    const { backend, session } = createIsolatedRecordingBackend();
+    backend.state.streamLogs.ensureStream(failedStream);
+    backend.state.streamLogs.ensureStream(deletedStream);
+    backend.state.snapshots.setTaskState(
+      failedStream,
+      toolUseTaskState('search', 'deepseekproT'),
+      executionId,
+    );
+    backend.state.snapshots.setTaskState(
+      deletedStream,
+      toolUseTaskState('search', 'deepseekproT'),
+      executionId,
+    );
+    await writeExecutionConfig(executionId);
+    const deleteTranscript = backend.state.streamLogs.delete.bind(
+      backend.state.streamLogs,
+    );
+    const deleteTranscriptSpy = vi
+      .spyOn(backend.state.streamLogs, 'delete')
+      .mockImplementation(async (stream) => {
+        if (stream === failedStream) {
+          throw new Error('transcript directory is locked');
+        }
+        await deleteTranscript(stream);
+      });
+
+    try {
+      const result = await backend.state.clearAll();
+
+      expect(result).toEqual({
+        active: new Set(),
+        failed: new Set([failedStream]),
+      });
+      expect(backend.state.streamLogs.has(failedStream)).toBe(true);
+      expect(backend.state.streamLogs.has(deletedStream)).toBe(false);
+    } finally {
+      deleteTranscriptSpy.mockRestore();
+      await backend.state.clearAll();
+      backend.dispose();
+      session.dispose();
+    }
+  });
+
   it('forgets goal entries when clearing never-registered streams', async () => {
     const stream = 'tool@deepseek#missing' as StreamTabId;
     const { backend, session } = createIsolatedRecordingBackend();

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -1862,19 +1862,9 @@ describe('ProgressBackend', () => {
     const { backend, session } = createIsolatedRecordingBackend();
     const stream = 'tool@deepseek#a6966f' as StreamTabId;
     const executionId = 'a6966f' as ExecutionId;
-    const stores = backend.state.stores as unknown as {
-      deleteExecution(
-        executionId: ExecutionId,
-        options?: DeleteExecutionOptions,
-      ): Promise<DeleteExecutionResult>;
-    };
-    const deleteExecutionSpy = vi
-      .spyOn(stores, 'deleteExecution')
-      .mockResolvedValue({
-        status: 'deleted',
-        executionId,
-        adjacentCleanupFailure: 'snapshot directory is locked',
-      });
+    const snapshotDeleteSpy = vi
+      .spyOn(backend.state.snapshots, 'deleteStream')
+      .mockRejectedValueOnce(new Error('snapshot directory is locked'));
 
     try {
       backend.state.streamLogs.ensureStream(stream);
@@ -1883,13 +1873,16 @@ describe('ProgressBackend', () => {
         toolUseTaskState('search', 'deepseekproT'),
         executionId,
       );
+      await writeExecutionConfig(executionId);
+      await backend.state.flush();
 
       await expect(backend.state.clearStream(stream)).resolves.toBe('failed');
 
       expect(backend.state.streamLogs.has(stream)).toBe(true);
       expect(backend.state.snapshots.getExecutionId(stream)).toBe(executionId);
+      expect(await StorageFS.exists(`executions/${executionId}`)).toBe(false);
     } finally {
-      deleteExecutionSpy.mockRestore();
+      snapshotDeleteSpy.mockRestore();
       await backend.state.clearAll();
       backend.dispose();
       session.dispose();

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -2062,7 +2062,7 @@ describe('ProgressBackend', () => {
     }
   });
 
-  it('retains a stream already participating in staged deletion during bulk cleanup', async () => {
+  it('serializes bulk cleanup behind an existing staged deletion', async () => {
     const { backend, session } = createIsolatedRecordingBackend();
     const stream = 'tool@deepseek#a6966e' as StreamTabId;
     const executionId = 'a6966e' as ExecutionId;
@@ -2082,14 +2082,17 @@ describe('ProgressBackend', () => {
       await backend.state.flush();
       stagedDeletion = await backend.state.snapshots.stageDeleteStream(stream);
 
-      const retained = await backend.state.clearAll();
+      const cleanup = backend.state.clearAll();
+      await stagedDeletion.rollback();
+      stagedDeletion = undefined;
+      const retained = await cleanup;
 
       expect(retained).toEqual({
         active: new Set(),
-        failed: new Set([stream]),
+        failed: new Set(),
       });
-      expect(backend.state.streamLogs.has(stream)).toBe(true);
-      expect(await StorageFS.exists(`executions/${executionId}`)).toBe(true);
+      expect(backend.state.streamLogs.has(stream)).toBe(false);
+      expect(await StorageFS.exists(`executions/${executionId}`)).toBe(false);
     } finally {
       await stagedDeletion?.rollback();
       await getExecutionStore(executionId).clear();

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -2317,6 +2317,41 @@ describe('ProgressBackend', () => {
     }
   });
 
+  it('finishes a staged deletion whose transcript committed before a crash', async () => {
+    const stream = 'tool@deepseek#c69660' as StreamTabId;
+    const executionId = 'c69660' as ExecutionId;
+    const seed = new StreamSnapshotStore();
+    await seed.load([]);
+    seed.setTaskState(
+      stream,
+      toolUseTaskState('search', 'deepseekproT'),
+      executionId,
+    );
+    await writeExecutionConfig(executionId);
+    await seed.flush();
+    await GoalStore.start(stream, 'finish this interrupted deletion');
+    await seed.stageDeleteStream(stream);
+
+    const { backend, session } = await createPersistentRecordingBackend();
+    try {
+      expect(await StorageFS.exists(streamDataDir(stream))).toBe(false);
+      expect(await seed.listStagedDeletions()).toContain(stream);
+
+      await backend.state.load();
+
+      expect(await backend.state.snapshots.listStagedDeletions()).not.toContain(
+        stream,
+      );
+      expect(await StorageFS.exists(`executions/${executionId}`)).toBe(false);
+      expect(GoalStore.getForStream(stream)).toBeNull();
+    } finally {
+      await GoalStore.forget(stream);
+      await backend.state.clearAll();
+      backend.dispose();
+      session.dispose();
+    }
+  });
+
   it('continues sweeping streamData orphans when one orphan cleanup fails', async () => {
     const failingStream = 'tool@deepseek#d6966d' as StreamTabId;
     const sweptStream = 'tool@deepseek#e6966e' as StreamTabId;

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -1858,7 +1858,7 @@ describe('ProgressBackend', () => {
     }
   });
 
-  it('retains stream state when adjacent cleanup fails after execution deletion', async () => {
+  it('retains stream state and execution config when adjacent cleanup fails', async () => {
     const { backend, session } = createIsolatedRecordingBackend();
     const stream = 'tool@deepseek#a6966f' as StreamTabId;
     const executionId = 'a6966f' as ExecutionId;
@@ -1880,9 +1880,53 @@ describe('ProgressBackend', () => {
 
       expect(backend.state.streamLogs.has(stream)).toBe(true);
       expect(backend.state.snapshots.getExecutionId(stream)).toBe(executionId);
-      expect(await StorageFS.exists(`executions/${executionId}`)).toBe(false);
+      expect(backend.state.snapshots.getTaskState(stream)).toEqual(
+        toolUseTaskState('search', 'deepseekproT'),
+      );
+      expect(await StorageFS.exists(`executions/${executionId}`)).toBe(true);
     } finally {
       snapshotDeleteSpy.mockRestore();
+      await backend.state.clearAll();
+      backend.dispose();
+      session.dispose();
+    }
+  });
+
+  it('commits stream deletion when only final execution cleanup fails', async () => {
+    const { backend, session } = createIsolatedRecordingBackend();
+    const stream = 'tool@deepseek#a6966e' as StreamTabId;
+    const executionId = 'a6966e' as ExecutionId;
+    const stores = backend.state.stores as unknown as {
+      deleteExecution(
+        id: ExecutionId,
+        options?: DeleteExecutionOptions,
+      ): Promise<DeleteExecutionResult>;
+    };
+    const deleteExecutionSpy = vi
+      .spyOn(stores, 'deleteExecution')
+      .mockImplementation(async (_id, options) => {
+        await options?.beforeDelete?.();
+        throw new Error('execution directory is locked');
+      });
+
+    try {
+      backend.state.streamLogs.ensureStream(stream);
+      backend.state.setStreamTaskState(
+        stream,
+        toolUseTaskState('search', 'deepseekproT'),
+        executionId,
+      );
+      await writeExecutionConfig(executionId);
+      await backend.state.flush();
+
+      await expect(backend.state.clearStream(stream)).resolves.toBe('deleted');
+
+      expect(backend.state.streamLogs.has(stream)).toBe(false);
+      expect(backend.state.snapshots.getTaskState(stream)).toBeUndefined();
+      expect(await StorageFS.exists(`executions/${executionId}`)).toBe(true);
+    } finally {
+      deleteExecutionSpy.mockRestore();
+      await getExecutionStore(executionId).clear();
       await backend.state.clearAll();
       backend.dispose();
       session.dispose();
@@ -1987,16 +2031,16 @@ describe('ProgressBackend', () => {
     }
   });
 
-  it('reconciles successful and failed execution deletions independently', async () => {
+  it('reconciles required cleanup and final execution cleanup independently', async () => {
     const failedStream = 'tool@deepseek#fa11ed6966' as StreamTabId;
-    const partialStream = 'tool@deepseek#faded6966' as StreamTabId;
+    const incompleteStream = 'tool@deepseek#faded6966' as StreamTabId;
     const deletedStream = 'tool@deepseek#de1e7ed6966' as StreamTabId;
     const failedExecution = 'fa11ed6966' as ExecutionId;
-    const partialExecution = 'faded6966' as ExecutionId;
+    const incompleteExecution = 'faded6966' as ExecutionId;
     const deletedExecution = 'de1e7ed6966' as ExecutionId;
     const { backend, session } = createIsolatedRecordingBackend();
     backend.state.streamLogs.ensureStream(failedStream);
-    backend.state.streamLogs.ensureStream(partialStream);
+    backend.state.streamLogs.ensureStream(incompleteStream);
     backend.state.streamLogs.ensureStream(deletedStream);
     backend.state.snapshots.setTaskState(
       failedStream,
@@ -2004,9 +2048,9 @@ describe('ProgressBackend', () => {
       failedExecution,
     );
     backend.state.snapshots.setTaskState(
-      partialStream,
+      incompleteStream,
       toolUseTaskState('search', 'deepseekproT'),
-      partialExecution,
+      incompleteExecution,
     );
     backend.state.snapshots.setTaskState(
       deletedStream,
@@ -2025,14 +2069,10 @@ describe('ProgressBackend', () => {
         if (executionId === failedExecution) {
           throw new Error('execution directory is locked');
         }
-        if (executionId === partialExecution) {
-          return {
-            status: 'deleted',
-            executionId,
-            adjacentCleanupFailure: 'snapshot directory is locked',
-          };
+        await options?.beforeDelete?.();
+        if (executionId === incompleteExecution) {
+          throw new Error('execution directory is locked');
         }
-        await options?.afterDelete?.();
         return { status: 'deleted', executionId };
       });
 
@@ -2041,10 +2081,10 @@ describe('ProgressBackend', () => {
 
       expect(result).toEqual({
         active: new Set(),
-        failed: new Set([failedStream, partialStream]),
+        failed: new Set([failedStream]),
       });
       expect(backend.state.streamLogs.has(failedStream)).toBe(true);
-      expect(backend.state.streamLogs.has(partialStream)).toBe(true);
+      expect(backend.state.streamLogs.has(incompleteStream)).toBe(false);
       expect(backend.state.streamLogs.has(deletedStream)).toBe(false);
     } finally {
       deleteExecutionSpy.mockRestore();
@@ -2243,11 +2283,12 @@ describe('ProgressBackend', () => {
 
       expect(warnSpy).toHaveBeenCalledWith(
         'SessionStores',
-        `Execution ${failingExecution} was deleted, but orphaned stream cleanup was incomplete: locked stream sidecar`,
+        `Skipping orphaned execution cleanup for ${failingExecution}; startup will continue.`,
+        { data: expect.any(Error) },
       );
       expect(await StorageFS.exists(streamDataDir(failingStream))).toBe(true);
       expect(await StorageFS.exists(`executions/${failingExecution}`)).toBe(
-        false,
+        true,
       );
       expect(await StorageFS.exists(streamDataDir(sweptStream))).toBe(false);
       expect(await StorageFS.exists(`executions/${sweptExecution}`)).toBe(

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -1858,6 +1858,44 @@ describe('ProgressBackend', () => {
     }
   });
 
+  it('retains stream state when adjacent cleanup fails after execution deletion', async () => {
+    const { backend, session } = createIsolatedRecordingBackend();
+    const stream = 'tool@deepseek#a6966f' as StreamTabId;
+    const executionId = 'a6966f' as ExecutionId;
+    const stores = backend.state.stores as unknown as {
+      deleteExecution(
+        executionId: ExecutionId,
+        options?: DeleteExecutionOptions,
+      ): Promise<DeleteExecutionResult>;
+    };
+    const deleteExecutionSpy = vi
+      .spyOn(stores, 'deleteExecution')
+      .mockResolvedValue({
+        status: 'deleted',
+        executionId,
+        adjacentCleanupFailure: 'snapshot directory is locked',
+      });
+
+    try {
+      backend.state.streamLogs.ensureStream(stream);
+      backend.state.setStreamTaskState(
+        stream,
+        toolUseTaskState('search', 'deepseekproT'),
+        executionId,
+      );
+
+      await expect(backend.state.clearStream(stream)).resolves.toBe('failed');
+
+      expect(backend.state.streamLogs.has(stream)).toBe(true);
+      expect(backend.state.snapshots.getExecutionId(stream)).toBe(executionId);
+    } finally {
+      deleteExecutionSpy.mockRestore();
+      await backend.state.clearAll();
+      backend.dispose();
+      session.dispose();
+    }
+  });
+
   it('retains execution sidecars and goals for an externally active run', async () => {
     const { backend, session } = createIsolatedRecordingBackend();
     const stream = 'tool@deepseek#a6966b' as StreamTabId;
@@ -1958,16 +1996,24 @@ describe('ProgressBackend', () => {
 
   it('reconciles successful and failed execution deletions independently', async () => {
     const failedStream = 'tool@deepseek#fa11ed6966' as StreamTabId;
+    const partialStream = 'tool@deepseek#faded6966' as StreamTabId;
     const deletedStream = 'tool@deepseek#de1e7ed6966' as StreamTabId;
     const failedExecution = 'fa11ed6966' as ExecutionId;
+    const partialExecution = 'faded6966' as ExecutionId;
     const deletedExecution = 'de1e7ed6966' as ExecutionId;
     const { backend, session } = createIsolatedRecordingBackend();
     backend.state.streamLogs.ensureStream(failedStream);
+    backend.state.streamLogs.ensureStream(partialStream);
     backend.state.streamLogs.ensureStream(deletedStream);
     backend.state.snapshots.setTaskState(
       failedStream,
       toolUseTaskState('search', 'deepseekproT'),
       failedExecution,
+    );
+    backend.state.snapshots.setTaskState(
+      partialStream,
+      toolUseTaskState('search', 'deepseekproT'),
+      partialExecution,
     );
     backend.state.snapshots.setTaskState(
       deletedStream,
@@ -1986,6 +2032,13 @@ describe('ProgressBackend', () => {
         if (executionId === failedExecution) {
           throw new Error('execution directory is locked');
         }
+        if (executionId === partialExecution) {
+          return {
+            status: 'deleted',
+            executionId,
+            adjacentCleanupFailure: 'snapshot directory is locked',
+          };
+        }
         await options?.afterDelete?.();
         return { status: 'deleted', executionId };
       });
@@ -1995,9 +2048,10 @@ describe('ProgressBackend', () => {
 
       expect(result).toEqual({
         active: new Set(),
-        failed: new Set([failedStream]),
+        failed: new Set([failedStream, partialStream]),
       });
       expect(backend.state.streamLogs.has(failedStream)).toBe(true);
+      expect(backend.state.streamLogs.has(partialStream)).toBe(true);
       expect(backend.state.streamLogs.has(deletedStream)).toBe(false);
     } finally {
       deleteExecutionSpy.mockRestore();

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -2062,6 +2062,43 @@ describe('ProgressBackend', () => {
     }
   });
 
+  it('retains a stream already participating in staged deletion during bulk cleanup', async () => {
+    const { backend, session } = createIsolatedRecordingBackend();
+    const stream = 'tool@deepseek#a6966e' as StreamTabId;
+    const executionId = 'a6966e' as ExecutionId;
+    let stagedDeletion:
+      | Awaited<ReturnType<typeof backend.state.snapshots.stageDeleteStream>>
+      | undefined;
+
+    try {
+      await backend.state.snapshots.load([stream]);
+      backend.state.streamLogs.ensureStream(stream);
+      backend.state.setStreamTaskState(
+        stream,
+        toolUseTaskState('search', 'deepseekproT'),
+        executionId,
+      );
+      await writeExecutionConfig(executionId);
+      await backend.state.flush();
+      stagedDeletion = await backend.state.snapshots.stageDeleteStream(stream);
+
+      const retained = await backend.state.clearAll();
+
+      expect(retained).toEqual({
+        active: new Set(),
+        failed: new Set([stream]),
+      });
+      expect(backend.state.streamLogs.has(stream)).toBe(true);
+      expect(await StorageFS.exists(`executions/${executionId}`)).toBe(true);
+    } finally {
+      await stagedDeletion?.rollback();
+      await getExecutionStore(executionId).clear();
+      await backend.state.clearAll();
+      backend.dispose();
+      session.dispose();
+    }
+  });
+
   it('reconciles required cleanup and final execution cleanup independently', async () => {
     const failedStream = 'tool@deepseek#fa11ed6966' as StreamTabId;
     const incompleteStream = 'tool@deepseek#faded6966' as StreamTabId;

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -1863,7 +1863,7 @@ describe('ProgressBackend', () => {
     const stream = 'tool@deepseek#a6966f' as StreamTabId;
     const executionId = 'a6966f' as ExecutionId;
     const snapshotDeleteSpy = vi
-      .spyOn(backend.state.snapshots, 'deleteStream')
+      .spyOn(backend.state.snapshots, 'stageDeleteStream')
       .mockRejectedValueOnce(new Error('snapshot directory is locked'));
 
     try {
@@ -1927,6 +1927,37 @@ describe('ProgressBackend', () => {
     } finally {
       deleteExecutionSpy.mockRestore();
       await getExecutionStore(executionId).clear();
+      await backend.state.clearAll();
+      backend.dispose();
+      session.dispose();
+    }
+  });
+
+  it('does not retain a stream after the transcript commit point', async () => {
+    const { backend, session } = createIsolatedRecordingBackend();
+    const stream = 'tool@deepseek#a69660' as StreamTabId;
+    const executionId = 'a69660' as ExecutionId;
+    const forgetSpy = vi
+      .spyOn(GoalStore, 'forget')
+      .mockRejectedValueOnce(new Error('goal state is locked'));
+
+    try {
+      backend.state.streamLogs.ensureStream(stream);
+      backend.state.setStreamTaskState(
+        stream,
+        toolUseTaskState('search', 'deepseekproT'),
+        executionId,
+      );
+      await writeExecutionConfig(executionId);
+      await backend.state.flush();
+
+      await expect(backend.state.clearStream(stream)).resolves.toBe('deleted');
+
+      expect(backend.state.streamLogs.has(stream)).toBe(false);
+      expect(await StorageFS.exists(streamDataDir(stream))).toBe(false);
+      expect(await StorageFS.exists(`executions/${executionId}`)).toBe(false);
+    } finally {
+      forgetSpy.mockRestore();
       await backend.state.clearAll();
       backend.dispose();
       session.dispose();
@@ -2094,8 +2125,40 @@ describe('ProgressBackend', () => {
     }
   });
 
+  it('does not retain bulk-deleted streams after the transcript commit point', async () => {
+    const stream = 'tool@deepseek#b69660' as StreamTabId;
+    const executionId = 'b69660' as ExecutionId;
+    const { backend, session } = createIsolatedRecordingBackend();
+    backend.state.streamLogs.ensureStream(stream);
+    backend.state.snapshots.setTaskState(
+      stream,
+      toolUseTaskState('search', 'deepseekproT'),
+      executionId,
+    );
+    await writeExecutionConfig(executionId);
+    const forgetManySpy = vi
+      .spyOn(GoalStore, 'forgetMany')
+      .mockRejectedValueOnce(new Error('goal index is locked'));
+
+    try {
+      await expect(backend.state.clearAll()).resolves.toEqual({
+        active: new Set(),
+        failed: new Set(),
+      });
+
+      expect(backend.state.streamLogs.has(stream)).toBe(false);
+      expect(await StorageFS.exists(streamDataDir(stream))).toBe(false);
+      expect(await StorageFS.exists(`executions/${executionId}`)).toBe(false);
+    } finally {
+      forgetManySpy.mockRestore();
+      await backend.state.clearAll();
+      backend.dispose();
+      session.dispose();
+    }
+  });
+
   it('tracks transcript cleanup failures per stream within one execution', async () => {
-    const failedStream = 'tool@deepseek#f00baa6966' as StreamTabId;
+    const failedStream = 'restored-override-stream' as StreamTabId;
     const deletedStream = 'workflow@deepseek#f00baa6966' as StreamTabId;
     const executionId = 'f00baa6966' as ExecutionId;
     const { backend, session } = createIsolatedRecordingBackend();
@@ -2133,6 +2196,17 @@ describe('ProgressBackend', () => {
       });
       expect(backend.state.streamLogs.has(failedStream)).toBe(true);
       expect(backend.state.streamLogs.has(deletedStream)).toBe(false);
+      expect(backend.state.snapshots.getExecutionId(failedStream)).toBe(
+        executionId,
+      );
+      expect(await StorageFS.exists(streamDataDir(failedStream))).toBe(true);
+      expect(await StorageFS.exists(`executions/${executionId}`)).toBe(true);
+
+      deleteTranscriptSpy.mockRestore();
+      await expect(backend.state.clearStream(failedStream)).resolves.toBe(
+        'deleted',
+      );
+      expect(await StorageFS.exists(`executions/${executionId}`)).toBe(false);
     } finally {
       deleteTranscriptSpy.mockRestore();
       await backend.state.clearAll();
@@ -2265,17 +2339,16 @@ describe('ProgressBackend', () => {
     await seed.flush();
 
     const { backend, session } = await createPersistentRecordingBackend();
-    const originalDeleteStream = backend.state.snapshots.deleteStream.bind(
-      backend.state.snapshots,
-    );
+    const originalStageDeleteStream =
+      backend.state.snapshots.stageDeleteStream.bind(backend.state.snapshots);
     const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
     const deleteSpy = vi
-      .spyOn(backend.state.snapshots, 'deleteStream')
+      .spyOn(backend.state.snapshots, 'stageDeleteStream')
       .mockImplementation(async (stream) => {
         if (stream === failingStream) {
           throw new Error('locked stream sidecar');
         }
-        await originalDeleteStream(stream);
+        return originalStageDeleteStream(stream);
       });
 
     try {

--- a/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
+++ b/src/test-kernel/progressView/ProgressViewOnboardingRefresh.vitest.mts
@@ -88,7 +88,7 @@ function createProgressViewProvider(): ProgressViewProviderFake {
       snapshots,
       pickValidActiveStream: vi.fn(() => ''),
       waitForOwnedExecutionRelease: vi.fn(async () => undefined),
-      clearStream: vi.fn(async () => true),
+      clearStream: vi.fn(async () => 'deleted' as const),
       clearAll: vi.fn(async () => ({
         active: new Set<StreamTabId>(),
         failed: new Set<StreamTabId>(),

--- a/src/test-kernel/support/ProgressControllerHarnesses.ts
+++ b/src/test-kernel/support/ProgressControllerHarnesses.ts
@@ -42,6 +42,7 @@ export interface ProgressStreamLifecycleHarnessOptions {
   locallyOwnedStreams?: StreamTabId[];
   visibleStreams?: StreamTabId[];
   protectedStreams?: StreamTabId[];
+  failedStreams?: StreamTabId[];
   releaseProtectedOnWaitStreams?: StreamTabId[];
 }
 
@@ -63,6 +64,7 @@ export function createProgressStreamLifecycleHarness(
   const inFlightStreams = new Set(options.inFlightStreams ?? []);
   const locallyOwnedStreams = new Set(options.locallyOwnedStreams ?? []);
   const protectedStreams = new Set(options.protectedStreams ?? []);
+  const failedStreams = new Set(options.failedStreams ?? []);
   const releaseProtectedOnWaitStreams = new Set(
     options.releaseProtectedOnWaitStreams ?? [],
   );
@@ -85,17 +87,23 @@ export function createProgressStreamLifecycleHarness(
     },
     clearStream: async (stream) => {
       recorder.record('clearStream', stream);
-      if (protectedStreams.has(stream)) return false;
+      if (protectedStreams.has(stream)) return 'active';
+      if (failedStreams.has(stream)) return 'failed';
       streams = streams.filter((candidate) => candidate !== stream);
       if (activeStream === stream) {
         activeStream = streams[0] ?? '';
       }
-      return true;
+      return 'deleted';
     },
     clearAll: async () => {
-      streams = streams.filter((stream) => protectedStreams.has(stream));
+      streams = streams.filter(
+        (stream) => protectedStreams.has(stream) || failedStreams.has(stream),
+      );
       activeStream = streams[0] ?? '';
-      return { active: new Set(protectedStreams), failed: new Set() };
+      return {
+        active: new Set(protectedStreams),
+        failed: new Set(failedStreams),
+      };
     },
   };
   const host: ProgressStreamLifecycleHost = {

--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -634,6 +634,26 @@ describe('headless delegation', () => {
     expect(mocks.writeReport).not.toHaveBeenCalled();
   });
 
+  it('preserves the child failure when final lease cleanup also fails', async () => {
+    const childFailure = new Error('review model failed');
+    mocks.executeAgent.mockRejectedValueOnce(childFailure);
+    mocks.releaseOwnedExecutionLease.mockRejectedValueOnce(
+      new Error('artifact flush failed'),
+    );
+
+    await expect(runInBand(delegationOptions())).rejects.toBe(childFailure);
+  });
+
+  it('surfaces final lease cleanup failure after a successful child', async () => {
+    mocks.releaseOwnedExecutionLease.mockRejectedValueOnce(
+      new Error('artifact flush failed'),
+    );
+
+    await expect(runInBand(delegationOptions())).rejects.toThrow(
+      'artifact flush failed',
+    );
+  });
+
   it('preserves the child failure when its failure manifest cannot be written', async () => {
     mocks.executeAgent.mockRejectedValueOnce(new Error('review model failed'));
     mocks.writeResultMeta.mockRejectedValueOnce(new Error('storage offline'));

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -36,6 +36,7 @@ interface MockStorageOptions {
   summaryWriteError?: Error;
   summaryDeleteError?: Error;
   logWriteError?: Error;
+  logDeleteError?: Error;
   logMtimes?: Record<string, number>;
   summaryMtimes?: Record<string, number>;
   onLogRead?: (key: string) => Promise<void> | void;
@@ -124,6 +125,7 @@ function mockStorage({
   summaryWriteError,
   summaryDeleteError,
   logWriteError,
+  logDeleteError,
   logMtimes = {},
   summaryMtimes = {},
   onLogRead,
@@ -241,6 +243,9 @@ function mockStorage({
   vi.spyOn(StorageFS, 'write').mockImplementation(recordWrite);
   vi.spyOn(StorageFS, 'writeAtomic').mockImplementation(recordWrite);
   vi.spyOn(StorageFS, 'delete').mockImplementation(async (target) => {
+    if (logDeleteError && target.startsWith(`${STREAM_LOGS_DIR}${path.sep}`)) {
+      throw logDeleteError;
+    }
     if (
       summaryDeleteError &&
       (target === STREAM_LOG_SUMMARIES_DIR ||
@@ -434,6 +439,22 @@ describe('StreamLogStore load', () => {
         'Failed to delete transcript summary cache for alpha',
       ),
     );
+  });
+
+  it('retains the stream registry when authoritative log deletion fails', async () => {
+    mockStorage({
+      logs: { alpha: [logEntry('alpha', 1, 200)] },
+      summaries: {
+        alpha: { firstTimestamp: 200, lastTimestamp: 200 },
+      },
+      logDeleteError: new Error('log delete denied'),
+    });
+    const store = await StreamLogStore.open();
+
+    await expect(store.delete('alpha')).rejects.toThrow('log delete denied');
+
+    expect(store.keys()).toEqual(['alpha']);
+    expect(store.has('alpha')).toBe(true);
   });
 
   it('clears authoritative logs when summary cache clearing fails', async () => {

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -1026,6 +1026,24 @@ describe('StreamSnapshotStore', () => {
     await recovered.deleteStream(STREAM);
   });
 
+  it('allows retry after staged rollback fails', async () => {
+    const store = new StreamSnapshotStore();
+    await store.load([]);
+    store.setPlan(STREAM, PLAN);
+    await store.flush();
+    const deletion = await store.stageDeleteStream(STREAM);
+    const rollbackError = new Error('snapshot directory is still locked');
+    const renameSpy = vi
+      .spyOn(StorageFS, 'rename')
+      .mockRejectedValueOnce(rollbackError);
+
+    await expect(deletion.rollback()).rejects.toBe(rollbackError);
+
+    renameSpy.mockRestore();
+    await expect(store.deleteStream(STREAM)).resolves.toBeUndefined();
+    expect(await StorageFS.exists(streamDataDir(STREAM))).toBe(false);
+  });
+
   it('waits for active hydration before staging deletion', async () => {
     await installPlatform();
     const executionId = 'feedface' as ExecutionId;

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -1026,6 +1026,30 @@ describe('StreamSnapshotStore', () => {
     await recovered.deleteStream(STREAM);
   });
 
+  it('buffers sidecar writes until a staged deletion rolls back', async () => {
+    const store = new StreamSnapshotStore();
+    await store.load([]);
+    store.setPlan(STREAM, PLAN);
+    await store.flush();
+
+    const deletion = await store.stageDeleteStream(STREAM);
+    store.setPlan(STREAM, null);
+    await store.flush();
+
+    expect(await StorageFS.exists(streamDataDir(STREAM))).toBe(false);
+
+    await deletion.rollback();
+    await store.flush();
+
+    const reloaded = new StreamSnapshotStore();
+    await reloaded.load([STREAM]);
+    expect(reloaded.getWorkPlan(STREAM)).toMatchObject({
+      todos: [],
+      plan: null,
+      planSummary: null,
+    });
+  });
+
   it('allows retry after staged rollback fails', async () => {
     const store = new StreamSnapshotStore();
     await store.load([]);

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -968,6 +968,30 @@ describe('StreamSnapshotStore', () => {
     expect(await StorageFS.exists(dir)).toBe(false);
   });
 
+  it('keeps the in-memory snapshot when durable deletion fails', async () => {
+    const store = new StreamSnapshotStore();
+    await store.load([]);
+    store.setTodos(STREAM, [TODO]);
+    store.setPlan(STREAM, PLAN);
+    await store.flush();
+    const deleteSpy = vi
+      .spyOn(StorageFS, 'delete')
+      .mockRejectedValueOnce(new Error('stream data directory is locked'));
+
+    await expect(store.deleteStream(STREAM)).rejects.toThrow(
+      'stream data directory is locked',
+    );
+
+    expect(store.getWorkPlan(STREAM)).toEqual({
+      todos: [TODO],
+      plan: PLAN,
+      planSummary: PLAN_SUMMARY,
+    });
+
+    deleteSpy.mockRestore();
+    await store.deleteStream(STREAM);
+  });
+
   it('does not resurrect a deleted sidecar dir when deleteStream lands during hydration', async () => {
     // Regression for #8226: applyStreamData awaits execution-config hydration
     // mid-seed. If the stream is deleted during that await, the continuation

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -9,7 +9,10 @@ import {
   createTempDirPlatform,
 } from '@test/support/tempDirPlatform';
 import { StreamSnapshotStore, streamDataDir } from '@transcript';
-import { STREAM_DATA_DIR } from '@transcript/streamDataPaths';
+import {
+  stagedStreamDataDir,
+  STREAM_DATA_DIR,
+} from '@transcript/streamDataPaths';
 import { getExecutionStore } from '@agent/storage';
 import { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import { TaskStateSchema, type TaskState } from '@agent/core/state/TaskState';
@@ -1015,6 +1018,13 @@ describe('StreamSnapshotStore', () => {
     expect(await StorageFS.exists(streamDataDir(STREAM))).toBe(false);
 
     const recovered = new StreamSnapshotStore();
+    await expect(
+      recovered.reconcileStagedDeletions(new Set([STREAM])),
+    ).resolves.toEqual({
+      restored: [STREAM],
+      pendingCleanup: [],
+      discarded: [],
+    });
     await recovered.load([STREAM]);
 
     expect(recovered.getWorkPlan(STREAM)).toMatchObject({
@@ -1079,6 +1089,8 @@ describe('StreamSnapshotStore', () => {
     store.setPlan(STREAM, PLAN);
     await store.flush();
     const deletion = await store.stageDeleteStream(STREAM);
+    store.setPlan(STREAM, null);
+    await store.flush();
     const rollbackError = new Error('snapshot directory is still locked');
     const renameSpy = vi
       .spyOn(StorageFS, 'rename')
@@ -1087,8 +1099,58 @@ describe('StreamSnapshotStore', () => {
     await expect(deletion.rollback()).rejects.toBe(rollbackError);
 
     renameSpy.mockRestore();
-    await expect(store.deleteStream(STREAM)).resolves.toBeUndefined();
-    expect(await StorageFS.exists(streamDataDir(STREAM))).toBe(false);
+    const retry = await store.stageDeleteStream(STREAM);
+    await retry.rollback();
+    await store.flush();
+
+    const reloaded = new StreamSnapshotStore();
+    await reloaded.load([STREAM]);
+    expect(reloaded.getWorkPlan(STREAM).plan).toBeNull();
+    await store.deleteStream(STREAM);
+  });
+
+  it('restores committed residue for complete orphan cleanup', async () => {
+    const store = new StreamSnapshotStore();
+    await store.load([]);
+    store.setPlan(STREAM, PLAN);
+    await store.flush();
+    await store.stageDeleteStream(STREAM);
+
+    const recovered = new StreamSnapshotStore();
+    await expect(
+      recovered.reconcileStagedDeletions(new Set()),
+    ).resolves.toEqual({
+      restored: [],
+      pendingCleanup: [STREAM],
+      discarded: [],
+    });
+
+    expect(await StorageFS.exists(streamDataDir(STREAM))).toBe(true);
+    expect(await StorageFS.exists(stagedStreamDataDir(STREAM))).toBe(false);
+  });
+
+  it('does not treat storage errors as an absent snapshot directory', async () => {
+    const store = new StreamSnapshotStore();
+    await store.load([]);
+    store.setPlan(STREAM, PLAN);
+    await store.flush();
+    const liveDir = streamDataDir(STREAM);
+    const stat = StorageFS.stat.bind(StorageFS);
+    const statError = Object.assign(new Error('snapshot directory is locked'), {
+      code: 'EACCES',
+    });
+    const statSpy = vi
+      .spyOn(StorageFS, 'stat')
+      .mockImplementation(async (target) => {
+        if (target === liveDir) throw statError;
+        return stat(target);
+      });
+
+    await expect(store.stageDeleteStream(STREAM)).rejects.toBe(statError);
+
+    expect(await StorageFS.exists(liveDir)).toBe(true);
+    statSpy.mockRestore();
+    await store.deleteStream(STREAM);
   });
 
   it('waits for active hydration before staging deletion', async () => {

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -974,15 +974,27 @@ describe('StreamSnapshotStore', () => {
     store.setTodos(STREAM, [TODO]);
     store.setPlan(STREAM, PLAN);
     await store.flush();
+    const deleteStorage = StorageFS.delete.bind(StorageFS);
     const deleteSpy = vi
       .spyOn(StorageFS, 'delete')
-      .mockRejectedValueOnce(new Error('stream data directory is locked'));
+      .mockImplementationOnce(async () => {
+        await deleteStorage(path.join(streamDataDir(STREAM), 'workPlan.json'));
+        throw new Error('stream data directory is locked');
+      });
 
     await expect(store.deleteStream(STREAM)).rejects.toThrow(
       'stream data directory is locked',
     );
 
     expect(store.getWorkPlan(STREAM)).toEqual({
+      todos: [TODO],
+      plan: PLAN,
+      planSummary: PLAN_SUMMARY,
+    });
+
+    const reloaded = new StreamSnapshotStore();
+    await reloaded.load([STREAM]);
+    expect(reloaded.getWorkPlan(STREAM)).toMatchObject({
       todos: [TODO],
       plan: PLAN,
       planSummary: PLAN_SUMMARY,

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -1050,6 +1050,29 @@ describe('StreamSnapshotStore', () => {
     });
   });
 
+  it('serializes overlapping staged deletions for one stream', async () => {
+    const store = new StreamSnapshotStore();
+    await store.load([]);
+    store.setPlan(STREAM, PLAN);
+    await store.flush();
+
+    const firstDeletion = await store.stageDeleteStream(STREAM);
+    let secondStarted = false;
+    const secondDeletion = store.stageDeleteStream(STREAM).then((deletion) => {
+      secondStarted = true;
+      return deletion;
+    });
+    await Promise.resolve();
+
+    expect(secondStarted).toBe(false);
+
+    await firstDeletion.rollback();
+    const deletion = await secondDeletion;
+    expect(secondStarted).toBe(true);
+    await deletion.commit();
+    expect(await StorageFS.exists(streamDataDir(STREAM))).toBe(false);
+  });
+
   it('allows retry after staged rollback fails', async () => {
     const store = new StreamSnapshotStore();
     await store.load([]);

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -992,6 +992,46 @@ describe('StreamSnapshotStore', () => {
     await store.deleteStream(STREAM);
   });
 
+  it('restarts hydration when deletion fails during an active seed', async () => {
+    await installPlatform();
+    const executionId = 'feedface' as ExecutionId;
+    const writer = new StreamSnapshotStore();
+    await writer.load([]);
+    writer.setTaskState(STREAM, toolUseTaskState(), executionId);
+    writer.setPlan(STREAM, PLAN);
+    await writer.flush();
+    await getExecutionStore(executionId).writeConfig(
+      toolUseTaskState().agentConfig,
+    );
+
+    const store = new StreamSnapshotStore();
+    const deletionError = new Error('stream data directory is locked');
+    vi.spyOn(StorageFS, 'delete').mockRejectedValueOnce(deletionError);
+    let deletion: Promise<void> | undefined;
+    const wasDeleteInjected = injectDuringExecutionConfigHydration(
+      executionId,
+      () => {
+        deletion = store.deleteStream(STREAM);
+        void deletion.catch(() => undefined);
+      },
+    );
+
+    await store.load([STREAM]);
+    if (!deletion) throw new Error('Deletion was not injected');
+    await expect(deletion).rejects.toBe(deletionError);
+    await store.flush();
+
+    expect(wasDeleteInjected).toHaveBeenCalledOnce();
+    expect(store.getWorkPlan(STREAM).plan).toEqual(PLAN);
+    store.setTodos(STREAM, [TODO]);
+    expect(store.getWorkPlan(STREAM).todos).toEqual([TODO]);
+    await store.flush();
+
+    const reloaded = new StreamSnapshotStore();
+    await reloaded.load([STREAM]);
+    expect(reloaded.getWorkPlan(STREAM).todos).toEqual([TODO]);
+  });
+
   it('does not resurrect a deleted sidecar dir when deleteStream lands during hydration', async () => {
     // Regression for #8226: applyStreamData awaits execution-config hydration
     // mid-seed. If the stream is deleted during that await, the continuation

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -901,12 +901,17 @@ describe('StreamSnapshotStore', () => {
     ]);
 
     const store = new StreamSnapshotStore();
+    let deletion: Promise<void> | undefined;
     const wasDeletedDuringHydration = injectDuringExecutionConfigHydration(
       executionId,
-      () => store.deleteStream(STREAM),
+      () => {
+        deletion = store.deleteStream(STREAM);
+      },
     );
 
     await store.load([STREAM]);
+    if (!deletion) throw new Error('Deletion was not injected');
+    await deletion;
     await store.flush();
 
     expect(wasDeletedDuringHydration).toHaveBeenCalledOnce();
@@ -968,23 +973,18 @@ describe('StreamSnapshotStore', () => {
     expect(await StorageFS.exists(dir)).toBe(false);
   });
 
-  it('keeps the in-memory snapshot when durable deletion fails', async () => {
+  it('keeps the complete snapshot when atomic staging fails', async () => {
     const store = new StreamSnapshotStore();
     await store.load([]);
     store.setTodos(STREAM, [TODO]);
     store.setPlan(STREAM, PLAN);
     await store.flush();
-    const deleteStorage = StorageFS.delete.bind(StorageFS);
-    const deleteSpy = vi
-      .spyOn(StorageFS, 'delete')
-      .mockImplementationOnce(async () => {
-        await deleteStorage(path.join(streamDataDir(STREAM), 'workPlan.json'));
-        throw new Error('stream data directory is locked');
-      });
+    const deletionError = new Error('stream data directory is locked');
+    const renameSpy = vi
+      .spyOn(StorageFS, 'rename')
+      .mockRejectedValueOnce(deletionError);
 
-    await expect(store.deleteStream(STREAM)).rejects.toThrow(
-      'stream data directory is locked',
-    );
+    await expect(store.deleteStream(STREAM)).rejects.toBe(deletionError);
 
     expect(store.getWorkPlan(STREAM)).toEqual({
       todos: [TODO],
@@ -1000,11 +1000,33 @@ describe('StreamSnapshotStore', () => {
       planSummary: PLAN_SUMMARY,
     });
 
-    deleteSpy.mockRestore();
+    renameSpy.mockRestore();
     await store.deleteStream(STREAM);
   });
 
-  it('restarts hydration when deletion fails during an active seed', async () => {
+  it('recovers a crash-interrupted staged deletion before hydration', async () => {
+    const store = new StreamSnapshotStore();
+    await store.load([]);
+    store.setTodos(STREAM, [TODO]);
+    store.setPlan(STREAM, PLAN);
+    await store.flush();
+
+    await store.stageDeleteStream(STREAM);
+    expect(await StorageFS.exists(streamDataDir(STREAM))).toBe(false);
+
+    const recovered = new StreamSnapshotStore();
+    await recovered.load([STREAM]);
+
+    expect(recovered.getWorkPlan(STREAM)).toMatchObject({
+      todos: [TODO],
+      plan: PLAN,
+      planSummary: PLAN_SUMMARY,
+    });
+    expect(await StorageFS.exists(streamDataDir(STREAM))).toBe(true);
+    await recovered.deleteStream(STREAM);
+  });
+
+  it('waits for active hydration before staging deletion', async () => {
     await installPlatform();
     const executionId = 'feedface' as ExecutionId;
     const writer = new StreamSnapshotStore();
@@ -1018,7 +1040,7 @@ describe('StreamSnapshotStore', () => {
 
     const store = new StreamSnapshotStore();
     const deletionError = new Error('stream data directory is locked');
-    vi.spyOn(StorageFS, 'delete').mockRejectedValueOnce(deletionError);
+    vi.spyOn(StorageFS, 'rename').mockRejectedValueOnce(deletionError);
     let deletion: Promise<void> | undefined;
     const wasDeleteInjected = injectDuringExecutionConfigHydration(
       executionId,
@@ -1074,14 +1096,17 @@ describe('StreamSnapshotStore', () => {
     ]);
 
     const store = new StreamSnapshotStore();
-    // Await the delete so evict + deleteDir fully complete before hydration
-    // resumes — only the post-await continuation can recreate the dir.
+    let deletion: Promise<void> | undefined;
     const wasDeleteInjected = injectDuringExecutionConfigHydration(
       executionId,
-      () => store.deleteStream(STREAM),
+      () => {
+        deletion = store.deleteStream(STREAM);
+      },
     );
 
     await store.load([STREAM]);
+    if (!deletion) throw new Error('Deletion was not injected');
+    await deletion;
     expect(wasDeleteInjected).toHaveBeenCalledOnce();
     await store.flush();
 

--- a/src/tools/delegation/inBandSubagentExecution.ts
+++ b/src/tools/delegation/inBandSubagentExecution.ts
@@ -142,6 +142,34 @@ const MAX_STABLE_ATTEMPTS = 1_024;
 // within that owner while durable manifests handle later restart recovery.
 const stableExecutionMutex = new KeyedMutex<ExecutionId>();
 
+interface InBandExecutionFailure {
+  readonly error: unknown;
+}
+
+/** Release final ownership without letting cleanup replace the run failure. */
+async function releaseInBandExecutionLease(
+  session: SessionHandle,
+  executionId: ExecutionId,
+  executionFailure?: InBandExecutionFailure,
+): Promise<void> {
+  if (!ownsExecutionLease(executionId)) return;
+  try {
+    await releaseExecutionLeaseAfterArtifacts(session, executionId);
+  } catch (releaseError) {
+    if (!executionFailure) throw releaseError;
+    logger.warn(
+      LOG_CHANNEL,
+      `Failed to persist final artifacts for failed subagent ${executionId}: ${toErrorMessage(releaseError)}`,
+      {
+        data: {
+          executionError: executionFailure.error,
+          releaseError,
+        },
+      },
+    );
+  }
+}
+
 function stableAttemptExecutionId(
   logicalExecutionId: ExecutionId,
   attempt: number,
@@ -706,6 +734,7 @@ export async function executeStableSubagentInBand(
         `Prepared subagent ${executionId} changed its parent execution.`,
       );
     }
+    let executionFailure: InBandExecutionFailure | undefined;
     try {
       const completed = await executeInBand(
         prepared,
@@ -719,14 +748,14 @@ export async function executeStableSubagentInBand(
       };
     } catch (error) {
       markOwnedExecutionLeaseUndurable(executionId);
+      executionFailure = { error };
       throw error;
     } finally {
-      if (ownsExecutionLease(executionId)) {
-        await releaseExecutionLeaseAfterArtifacts(
-          prepared.session,
-          executionId,
-        );
-      }
+      await releaseInBandExecutionLease(
+        prepared.session,
+        executionId,
+        executionFailure,
+      );
     }
   });
 }
@@ -736,6 +765,7 @@ export async function executeSubagentForDeliveryInBand(
   options: InBandSubagentDeliveryOptions,
 ): Promise<InBandSubagentDeliveryResult> {
   const executionId = generateExecutionId() as ExecutionId;
+  let executionFailure: InBandExecutionFailure | undefined;
   try {
     const completed = await executeInBand(
       options,
@@ -752,10 +782,13 @@ export async function executeSubagentForDeliveryInBand(
     };
   } catch (error) {
     markOwnedExecutionLeaseUndurable(executionId);
+    executionFailure = { error };
     throw error;
   } finally {
-    if (ownsExecutionLease(executionId)) {
-      await releaseExecutionLeaseAfterArtifacts(options.session, executionId);
-    }
+    await releaseInBandExecutionLease(
+      options.session,
+      executionId,
+      executionFailure,
+    );
   }
 }

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -473,18 +473,25 @@ export class StreamLogStore {
     this.assertWritableStore('delete a transcript stream');
     this.writeTombstones.add(streamId);
     this.debouncedSave.cancel();
-    this.forgetStreamState(streamId);
-    this.stateRevision += 1;
 
     try {
       await this.inFlightWrite;
-      this.forgetStreamState(streamId);
       await this.executeWrite();
-      if (this.mode.kind === 'ephemeral') return;
-
-      log.info(LOG_TAG, `Deleting stream: ${streamId}`);
-      await this.kv.delete(streamId);
-      await this.deleteSummaryCache(streamId);
+      if (this.mode.kind !== 'ephemeral') {
+        log.info(LOG_TAG, `Deleting stream: ${streamId}`);
+        await this.kv.delete(streamId);
+        await this.deleteSummaryCache(streamId);
+      }
+      // The summaries map is the progress tab registry. Commit its removal
+      // only after durable deletion succeeds so callers can retain and retry a
+      // stream whose transcript cleanup failed.
+      this.forgetStreamState(streamId);
+      this.stateRevision += 1;
+    } catch (error) {
+      // executeWrite() drains dirty ids while the tombstone suppresses writes.
+      // Restore the retry marker if deletion fails and a resident log remains.
+      if (this.logs.has(streamId)) this.dirtyStreamIds.add(streamId);
+      throw error;
     } finally {
       this.writeTombstones.delete(streamId);
     }

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -886,9 +886,23 @@ export class StreamSnapshotStore {
       return;
     }
 
-    await new KVStore(streamDataDir(stream), {
-      throwOnErrors: true,
-    }).deleteDir();
+    try {
+      await new KVStore(streamDataDir(stream), {
+        throwOnErrors: true,
+      }).deleteDir();
+    } catch (error) {
+      // A version bump can interrupt hydration as well as writes. Chain a
+      // fresh seed behind that interrupted work so the retained record returns
+      // to a current, mutable state once the still-durable sidecars are read.
+      void this.refreshSeed(stream).catch((seedError: unknown) =>
+        logger.warn(
+          CHANNEL,
+          `Failed to restore snapshot state after retaining stream ${stream}`,
+          { data: seedError },
+        ),
+      );
+      throw error;
+    }
     this.records.delete(stream);
   }
 

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -331,9 +331,13 @@ export class StreamSnapshotStore {
     return record.kv;
   }
 
-  private async readPersistedStreamDirs(): Promise<[string, number][]> {
+  private async listStreamsUnder(root: string): Promise<StreamTabId[]> {
     try {
-      return await StorageFS.readDir(STREAM_DATA_DIR);
+      const entries = await StorageFS.readDir(root);
+      return entries
+        .filter(([, type]) => isDirectory(type))
+        .map(([encoded]) => decodeStreamId(encoded))
+        .filter((stream): stream is StreamTabId => stream !== undefined);
     } catch (error) {
       if (isFileNotFoundError(error)) return [];
       throw error;
@@ -969,11 +973,14 @@ export class StreamSnapshotStore {
         },
         rollback: async () => {
           if (settled) return;
-          if (staged && stagedDir && liveDir) {
-            await StorageFS.rename(stagedDir, liveDir);
-          }
-          this.stagedDeletions.delete(stream);
           settled = true;
+          try {
+            if (staged && stagedDir && liveDir) {
+              await StorageFS.rename(stagedDir, liveDir);
+            }
+          } finally {
+            this.stagedDeletions.delete(stream);
+          }
         },
       };
     } catch (error) {
@@ -1134,11 +1141,12 @@ export class StreamSnapshotStore {
 
   /** Streams with persisted sidecars under `streamData/`. */
   async listPersistedStreams(): Promise<StreamTabId[]> {
-    const entries = await this.readPersistedStreamDirs();
-    return entries
-      .filter(([, type]) => isDirectory(type))
-      .map(([encoded]) => decodeStreamId(encoded))
-      .filter((stream): stream is StreamTabId => stream !== undefined);
+    return this.listStreamsUnder(STREAM_DATA_DIR);
+  }
+
+  /** Streams left in reversible staging by an interrupted deletion. */
+  async listStagedDeletions(): Promise<StreamTabId[]> {
+    return this.listStreamsUnder(STREAM_DATA_DELETION_DIR);
   }
 
   /**

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -824,8 +824,8 @@ export class StreamSnapshotStore {
    * whether the stream has a record: every record defaults `missingOutputs`
    * to `{}` on creation, and a record gets created for read-only reasons
    * too (`kv()` — used by `read()`, `readPersistedExecutionId()`, and the
-   * post-`evict()` `kv()` call in `deleteStream()` — as well as any other
-   * accumulator's own lazy creation, e.g. `setTodos`). Gating on record
+   * read-only `kv()` calls — as well as any other accumulator's own lazy
+   * creation, e.g. `setTodos`). Gating on record
    * presence alone would treat those as "missing outputs existed" and write
    * a spurious `missingOutputs.json`, resurrecting a `streamData/{id}/`
    * directory `listPersistedStreams()` would then report for a stream that
@@ -874,13 +874,22 @@ export class StreamSnapshotStore {
   /** Delete a stream's on-disk sidecar directory + in-memory state. */
   async deleteStream(stream: StreamTabId): Promise<void> {
     const pending = this.cancelPendingWritesForStream(stream);
-    this.evict(stream);
+    // Invalidate in-flight hydration/writes immediately, but keep the record
+    // readable until durable deletion commits. If deleteDir() fails, callers
+    // retain the stream and can retry with its complete in-memory snapshot.
+    this.bumpStreamVersion(stream);
     await Promise.all(pending);
     // Keep this after pending-write cancellation so reserved ids cannot leave
     // older write chains free to recreate a non-stream-owned sidecar path.
-    if (!canUseStreamDataDir(stream)) return;
+    if (!canUseStreamDataDir(stream)) {
+      this.records.delete(stream);
+      return;
+    }
 
-    await this.kv(stream).deleteDir();
+    await new KVStore(streamDataDir(stream), {
+      throwOnErrors: true,
+    }).deleteDir();
+    this.records.delete(stream);
   }
 
   /** Delete the entire `streamData/` tree + all in-memory state. */
@@ -1509,10 +1518,9 @@ export class StreamSnapshotStore {
   ): void {
     // `record` rode across `applyStreamData`'s hydration await. Identity —
     // not mere presence — against the live map entry: eviction during the
-    // await orphans `record`, and `deleteStream()`'s own post-evict `kv()`
-    // call (or a concurrent eager mutation) can already have re-created a
-    // fresh entry, so a presence check would still let orphaned seed state
-    // resurrect the deleted `streamData/{id}/` dir on disk (#8226).
+    // await orphans `record`, and a concurrent eager mutation can already have
+    // re-created a fresh entry, so a presence check would still let orphaned
+    // seed state resurrect the deleted `streamData/{id}/` dir on disk (#8226).
     if (this.records.get(stream) !== record) return;
     for (const key of keys) {
       switch (key) {

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -288,7 +288,16 @@ interface StreamRecord {
 
 export class StreamSnapshotStore {
   private readonly records = new Map<StreamTabId, StreamRecord>();
-  private readonly stagedDeletions = new Set<StreamTabId>();
+  /**
+   * Writes arriving while a stream's live directory is reversibly staged.
+   * Keeping the latest value per sidecar makes the staging rename a real
+   * transaction boundary: commit discards them, rollback replays them only
+   * after the live namespace has been restored.
+   */
+  private readonly stagedDeletions = new Map<
+    StreamTabId,
+    Map<string, unknown>
+  >();
 
   // -- Per (stream, category) serialized write locks -------------------------
   private readonly writeMutexes = new Map<string, Mutex>();
@@ -905,6 +914,17 @@ export class StreamSnapshotStore {
     if (record) record.kv = undefined;
   }
 
+  /** Restore writes buffered behind a staging attempt after live data returns. */
+  private replayStagedWrites(
+    stream: StreamTabId,
+    stagedWrites: ReadonlyMap<string, unknown>,
+  ): void {
+    this.stagedDeletions.delete(stream);
+    for (const [key, value] of stagedWrites) {
+      this.write(stream, key, value);
+    }
+  }
+
   /**
    * Atomically move a stream's sidecars out of the live namespace while
    * keeping its in-memory record available until the transcript registry
@@ -924,7 +944,8 @@ export class StreamSnapshotStore {
         `Snapshot deletion is already staged for stream ${stream}`,
       );
     }
-    this.stagedDeletions.add(stream);
+    const stagedWrites = new Map<string, unknown>();
+    this.stagedDeletions.set(stream, stagedWrites);
 
     try {
       // Let hydration finish before staging. A record with `seeded === false`
@@ -978,13 +999,14 @@ export class StreamSnapshotStore {
             if (staged && stagedDir && liveDir) {
               await StorageFS.rename(stagedDir, liveDir);
             }
+            this.replayStagedWrites(stream, stagedWrites);
           } finally {
             this.stagedDeletions.delete(stream);
           }
         },
       };
     } catch (error) {
-      this.stagedDeletions.delete(stream);
+      this.replayStagedWrites(stream, stagedWrites);
       throw error;
     }
   }
@@ -1266,6 +1288,11 @@ export class StreamSnapshotStore {
   }
 
   private write(stream: StreamTabId, key: string, value: unknown): void {
+    const stagedWrites = this.stagedDeletions.get(stream);
+    if (stagedWrites) {
+      stagedWrites.set(key, value);
+      return;
+    }
     const chainKey = `${stream}::${key}`;
     const version = this.streamVersion(stream);
     const mutex = this.writeMutexes.get(chainKey) ?? new Mutex();

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -286,6 +286,12 @@ interface StreamRecord {
   kv: KVStore | undefined;
 }
 
+interface StagedDeletionState {
+  writes: Map<string, unknown>;
+  settled: Promise<void>;
+  resolveSettled: () => void;
+}
+
 export class StreamSnapshotStore {
   private readonly records = new Map<StreamTabId, StreamRecord>();
   /**
@@ -296,7 +302,7 @@ export class StreamSnapshotStore {
    */
   private readonly stagedDeletions = new Map<
     StreamTabId,
-    Map<string, unknown>
+    StagedDeletionState
   >();
 
   // -- Per (stream, category) serialized write locks -------------------------
@@ -892,13 +898,22 @@ export class StreamSnapshotStore {
     for (const stream of this.records.keys()) this.bumpStreamVersion(stream);
     this.records.clear();
     this.writeMutexes.clear();
+    for (const state of this.stagedDeletions.values()) state.resolveSettled();
     this.stagedDeletions.clear();
   }
 
   /** Restore a crash-interrupted pre-commit rename before reading the stream. */
-  private async recoverStagedDeletion(stream: StreamTabId): Promise<void> {
-    if (this.stagedDeletions.has(stream) || !canUseStreamDataDir(stream))
+  private async recoverStagedDeletion(
+    stream: StreamTabId,
+    owner?: StagedDeletionState,
+  ): Promise<void> {
+    const activeDeletion = this.stagedDeletions.get(stream);
+    if (
+      (activeDeletion && activeDeletion !== owner) ||
+      !canUseStreamDataDir(stream)
+    ) {
       return;
+    }
     const stagedDir = stagedStreamDataDir(stream);
     if (!(await StorageFS.exists(stagedDir))) return;
 
@@ -917,12 +932,15 @@ export class StreamSnapshotStore {
   /** Restore writes buffered behind a staging attempt after live data returns. */
   private replayStagedWrites(
     stream: StreamTabId,
-    stagedWrites: ReadonlyMap<string, unknown>,
+    state: StagedDeletionState,
   ): void {
-    this.stagedDeletions.delete(stream);
-    for (const [key, value] of stagedWrites) {
+    if (this.stagedDeletions.get(stream) === state) {
+      this.stagedDeletions.delete(stream);
+    }
+    for (const [key, value] of state.writes) {
       this.write(stream, key, value);
     }
+    state.resolveSettled();
   }
 
   /**
@@ -933,21 +951,24 @@ export class StreamSnapshotStore {
   async stageDeleteStream(
     stream: StreamTabId,
   ): Promise<StagedStreamSnapshotDeletion> {
-    if (this.stagedDeletions.has(stream)) {
-      throw new Error(
-        `Snapshot deletion is already staged for stream ${stream}`,
-      );
+    const activeDeletion = this.stagedDeletions.get(stream);
+    if (activeDeletion) {
+      await activeDeletion.settled;
+      return this.stageDeleteStream(stream);
     }
-    await this.recoverStagedDeletion(stream);
-    if (this.stagedDeletions.has(stream)) {
-      throw new Error(
-        `Snapshot deletion is already staged for stream ${stream}`,
-      );
-    }
-    const stagedWrites = new Map<string, unknown>();
-    this.stagedDeletions.set(stream, stagedWrites);
+    let resolveSettled = () => {};
+    const settlement = new Promise<void>((resolve) => {
+      resolveSettled = resolve;
+    });
+    const state: StagedDeletionState = {
+      writes: new Map(),
+      settled: settlement,
+      resolveSettled,
+    };
+    this.stagedDeletions.set(stream, state);
 
     try {
+      await this.recoverStagedDeletion(stream, state);
       // Let hydration finish before staging. A record with `seeded === false`
       // may already contain sidecars while execution-config hydration is still
       // in flight, so invalidating that seed would make neither disk nor memory
@@ -979,17 +1000,24 @@ export class StreamSnapshotStore {
         commit: async () => {
           if (settled) return;
           settled = true;
-          this.stagedDeletions.delete(stream);
           this.evict(stream);
-          if (!staged || !stagedDir) return;
           try {
-            await StorageFS.delete(stagedDir, { recursive: true });
-          } catch (error) {
-            logger.warn(
-              CHANNEL,
-              `Stream ${stream} was deleted, but staged snapshot cleanup was incomplete.`,
-              { data: error },
-            );
+            if (staged && stagedDir) {
+              try {
+                await StorageFS.delete(stagedDir, { recursive: true });
+              } catch (error) {
+                logger.warn(
+                  CHANNEL,
+                  `Stream ${stream} was deleted, but staged snapshot cleanup was incomplete.`,
+                  { data: error },
+                );
+              }
+            }
+          } finally {
+            if (this.stagedDeletions.get(stream) === state) {
+              this.stagedDeletions.delete(stream);
+            }
+            state.resolveSettled();
           }
         },
         rollback: async () => {
@@ -999,14 +1027,17 @@ export class StreamSnapshotStore {
             if (staged && stagedDir && liveDir) {
               await StorageFS.rename(stagedDir, liveDir);
             }
-            this.replayStagedWrites(stream, stagedWrites);
+            this.replayStagedWrites(stream, state);
           } finally {
-            this.stagedDeletions.delete(stream);
+            if (this.stagedDeletions.get(stream) === state) {
+              this.stagedDeletions.delete(stream);
+            }
+            state.resolveSettled();
           }
         },
       };
     } catch (error) {
-      this.replayStagedWrites(stream, stagedWrites);
+      this.replayStagedWrites(stream, state);
       throw error;
     }
   }
@@ -1288,9 +1319,9 @@ export class StreamSnapshotStore {
   }
 
   private write(stream: StreamTabId, key: string, value: unknown): void {
-    const stagedWrites = this.stagedDeletions.get(stream);
-    if (stagedWrites) {
-      stagedWrites.set(key, value);
+    const stagedDeletion = this.stagedDeletions.get(stream);
+    if (stagedDeletion) {
+      stagedDeletion.writes.set(key, value);
       return;
     }
     const chainKey = `${stream}::${key}`;

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -873,6 +873,8 @@ export class StreamSnapshotStore {
 
   /** Delete a stream's on-disk sidecar directory + in-memory state. */
   async deleteStream(stream: StreamTabId): Promise<void> {
+    const record = this.records.get(stream);
+    const wasSeeded = record?.seeded ?? false;
     const pending = this.cancelPendingWritesForStream(stream);
     // Invalidate in-flight hydration/writes immediately, but keep the record
     // readable until durable deletion commits. If deleteDir() fails, callers
@@ -891,16 +893,33 @@ export class StreamSnapshotStore {
         throwOnErrors: true,
       }).deleteDir();
     } catch (error) {
-      // A version bump can interrupt hydration as well as writes. Chain a
-      // fresh seed behind that interrupted work so the retained record returns
-      // to a current, mutable state once the still-durable sidecars are read.
-      void this.refreshSeed(stream).catch((seedError: unknown) =>
-        logger.warn(
-          CHANNEL,
-          `Failed to restore snapshot state after retaining stream ${stream}`,
-          { data: seedError },
-        ),
-      );
+      if (wasSeeded && record) {
+        // Recursive removal may have deleted only some sidecars before failing.
+        // Restore every durable field from the authoritative resident record;
+        // reseeding here would replace complete memory with disk fragments.
+        if (record.meta) this.writeMeta(stream, record.meta);
+        this.writeOutputFiles(stream);
+        this.write(stream, STREAM_DATA_KEYS.MISSING_OUTPUTS, {
+          ...record.missingOutputs,
+        });
+        this.write(stream, STREAM_DATA_KEYS.COMPILE_FAILURES, {
+          ...record.compileFailures,
+        });
+        this.writeUsage(stream);
+        this.writeWorkPlan(stream, record.workPlan);
+        await this.flushWritesForStream(stream);
+      } else {
+        // A version bump can interrupt hydration as well as writes. Chain a
+        // fresh seed behind that interrupted work so the retained record
+        // becomes current and mutable once its durable sidecars are read.
+        void this.refreshSeed(stream).catch((seedError: unknown) =>
+          logger.warn(
+            CHANNEL,
+            `Failed to restore snapshot state after retaining stream ${stream}`,
+            { data: seedError },
+          ),
+        );
+      }
       throw error;
     }
     this.records.delete(stream);

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -87,6 +87,16 @@ const CHANNEL = 'StreamSnapshotStore';
  *  managers' `pMap` hydration so startup doesn't open a file handle per tab). */
 const SEED_IO_CONCURRENCY = 8;
 
+async function storagePathExists(target: string): Promise<boolean> {
+  try {
+    await StorageFS.stat(target);
+    return true;
+  } catch (error) {
+    if (isFileNotFoundError(error)) return false;
+    throw error;
+  }
+}
+
 interface StagedStreamSnapshotDeletion {
   commit(): Promise<void>;
   rollback(): Promise<void>;
@@ -301,6 +311,10 @@ export class StreamSnapshotStore {
    * after the live namespace has been restored.
    */
   private readonly stagedDeletions = new Map<
+    StreamTabId,
+    StagedDeletionState
+  >();
+  private readonly failedRollbacks = new Map<
     StreamTabId,
     StagedDeletionState
   >();
@@ -530,8 +544,6 @@ export class StreamSnapshotStore {
   private async readSeed(stream: StreamTabId, version: number): Promise<void> {
     if (this.streamVersion(stream) !== version) return;
     if (this.records.get(stream)?.seeded) return;
-    await this.recoverStagedDeletion(stream);
-    if (this.streamVersion(stream) !== version) return;
     const data = await readStreamData(this.kv(stream));
     if (this.streamVersion(stream) !== version) return;
     await this.applyStreamData(stream, data);
@@ -900,33 +912,81 @@ export class StreamSnapshotStore {
     this.writeMutexes.clear();
     for (const state of this.stagedDeletions.values()) state.resolveSettled();
     this.stagedDeletions.clear();
+    this.failedRollbacks.clear();
   }
 
-  /** Restore a crash-interrupted pre-commit rename before reading the stream. */
-  private async recoverStagedDeletion(
-    stream: StreamTabId,
-    owner?: StagedDeletionState,
-  ): Promise<void> {
-    const activeDeletion = this.stagedDeletions.get(stream);
-    if (
-      (activeDeletion && activeDeletion !== owner) ||
-      !canUseStreamDataDir(stream)
-    ) {
-      return;
+  /**
+   * Reconcile crash-interrupted deletions against the transcript registry.
+   * A live transcript rolls its snapshot directory back. An absent transcript
+   * restores the directory only into the orphan-cleanup namespace so the
+   * execution directory and goal can be removed with the snapshot.
+   */
+  async reconcileStagedDeletions(
+    liveStreams: ReadonlySet<StreamTabId>,
+  ): Promise<{
+    restored: StreamTabId[];
+    pendingCleanup: StreamTabId[];
+    discarded: StreamTabId[];
+  }> {
+    let entries: [string, number][];
+    try {
+      entries = await StorageFS.readDir(STREAM_DATA_DELETION_DIR);
+    } catch (error) {
+      if (isFileNotFoundError(error)) {
+        return { restored: [], pendingCleanup: [], discarded: [] };
+      }
+      throw error;
     }
-    const stagedDir = stagedStreamDataDir(stream);
-    if (!(await StorageFS.exists(stagedDir))) return;
 
-    const liveDir = streamDataDir(stream);
-    if (await StorageFS.exists(liveDir)) {
-      // A newer generation already owns the live path; this is committed
-      // deletion residue whose best retry is ordinary garbage collection.
-      await StorageFS.delete(stagedDir, { recursive: true });
-    } else {
-      await StorageFS.rename(stagedDir, liveDir);
-    }
-    const record = this.records.get(stream);
-    if (record) record.kv = undefined;
+    const restored: StreamTabId[] = [];
+    const pendingCleanup: StreamTabId[] = [];
+    const discarded: StreamTabId[] = [];
+    await pMap(
+      entries.filter(([, type]) => isDirectory(type)),
+      async ([encoded]) => {
+        const parsedStream = StreamTabIdSchema.safeParse(
+          decodeStreamId(encoded),
+        );
+        if (!parsedStream.success) {
+          logger.warn(
+            CHANNEL,
+            `Ignoring invalid staged snapshot directory ${encoded}`,
+            { data: parsedStream.error },
+          );
+          return;
+        }
+        const stream = parsedStream.data;
+        if (this.stagedDeletions.has(stream)) return;
+
+        const stagedDir = stagedStreamDataDir(stream);
+        const liveDir = streamDataDir(stream);
+        const failedWrites = this.failedRollbacks.get(stream);
+        if (!(await storagePathExists(liveDir))) {
+          await StorageFS.ensureDir(STREAM_DATA_DIR);
+          await StorageFS.rename(stagedDir, liveDir);
+          const record = this.records.get(stream);
+          if (record) record.kv = undefined;
+          if (liveStreams.has(stream) && failedWrites) {
+            this.replayStagedWrites(stream, failedWrites);
+            await this.flushWritesForStream(stream);
+          }
+          this.failedRollbacks.delete(stream);
+          if (liveStreams.has(stream)) restored.push(stream);
+          else pendingCleanup.push(stream);
+          return;
+        }
+
+        await StorageFS.delete(stagedDir, { recursive: true });
+        if (liveStreams.has(stream) && failedWrites) {
+          this.replayStagedWrites(stream, failedWrites);
+          await this.flushWritesForStream(stream);
+        }
+        this.failedRollbacks.delete(stream);
+        discarded.push(stream);
+      },
+      { concurrency: SEED_IO_CONCURRENCY },
+    );
+    return { restored, pendingCleanup, discarded };
   }
 
   /** Restore writes buffered behind a staging attempt after live data returns. */
@@ -941,6 +1001,19 @@ export class StreamSnapshotStore {
       this.write(stream, key, value);
     }
     state.resolveSettled();
+  }
+
+  /** Persist a failed rollback's buffered values before staging its retry. */
+  private replayFailedRollbackWrites(
+    stream: StreamTabId,
+    failedState: StagedDeletionState,
+    retryState: StagedDeletionState,
+  ): void {
+    for (const [key, value] of failedState.writes) {
+      retryState.writes.set(key, value);
+      this.writeUnbuffered(stream, key, value);
+    }
+    failedState.resolveSettled();
   }
 
   /**
@@ -968,7 +1041,30 @@ export class StreamSnapshotStore {
     this.stagedDeletions.set(stream, state);
 
     try {
-      await this.recoverStagedDeletion(stream, state);
+      const failedState = this.failedRollbacks.get(stream);
+      if (failedState) {
+        const stagedDir = stagedStreamDataDir(stream);
+        const liveDir = streamDataDir(stream);
+        if (await storagePathExists(stagedDir)) {
+          if (await storagePathExists(liveDir)) {
+            throw new Error(
+              `Cannot retry snapshot deletion for ${stream}; both live and staged directories exist`,
+            );
+          }
+          await StorageFS.rename(stagedDir, liveDir);
+        }
+        this.failedRollbacks.delete(stream);
+        this.replayFailedRollbackWrites(stream, failedState, state);
+        await this.flushWritesForStream(stream);
+      }
+      if (
+        canUseStreamDataDir(stream) &&
+        (await storagePathExists(stagedStreamDataDir(stream)))
+      ) {
+        throw new Error(
+          `Stream ${stream} has an unreconciled snapshot deletion`,
+        );
+      }
       // Let hydration finish before staging. A record with `seeded === false`
       // may already contain sidecars while execution-config hydration is still
       // in flight, so invalidating that seed would make neither disk nor memory
@@ -989,7 +1085,7 @@ export class StreamSnapshotStore {
       const liveDir = canStage ? streamDataDir(stream) : undefined;
       const stagedDir = canStage ? stagedStreamDataDir(stream) : undefined;
       let staged = false;
-      if (liveDir && stagedDir && (await StorageFS.exists(liveDir))) {
+      if (liveDir && stagedDir && (await storagePathExists(liveDir))) {
         await StorageFS.ensureDir(STREAM_DATA_DELETION_DIR);
         await StorageFS.rename(liveDir, stagedDir);
         staged = true;
@@ -1000,6 +1096,7 @@ export class StreamSnapshotStore {
         commit: async () => {
           if (settled) return;
           settled = true;
+          this.failedRollbacks.delete(stream);
           this.evict(stream);
           try {
             if (staged && stagedDir) {
@@ -1028,6 +1125,9 @@ export class StreamSnapshotStore {
               await StorageFS.rename(stagedDir, liveDir);
             }
             this.replayStagedWrites(stream, state);
+          } catch (error) {
+            this.failedRollbacks.set(stream, state);
+            throw error;
           } finally {
             if (this.stagedDeletions.get(stream) === state) {
               this.stagedDeletions.delete(stream);
@@ -1212,7 +1312,6 @@ export class StreamSnapshotStore {
   async readPersistedExecutionId(
     stream: StreamTabId,
   ): Promise<ExecutionId | undefined> {
-    await this.recoverStagedDeletion(stream);
     return executionIdFromMeta(await readMeta(this.kv(stream)));
   }
 
@@ -1225,7 +1324,6 @@ export class StreamSnapshotStore {
    * bare `meta.json`-only match.
    */
   async hasPersistedWorkPlan(stream: StreamTabId): Promise<boolean> {
-    await this.recoverStagedDeletion(stream);
     return this.kv(stream).exists(STREAM_DATA_KEYS.WORK_PLAN);
   }
 
@@ -1240,7 +1338,6 @@ export class StreamSnapshotStore {
   async readLegacyInstruction(
     stream: StreamTabId,
   ): Promise<LegacyInstructionEntry | null> {
-    await this.recoverStagedDeletion(stream);
     const record = this.records.get(stream);
     const meta = record?.seeded
       ? record.meta
@@ -1324,6 +1421,14 @@ export class StreamSnapshotStore {
       stagedDeletion.writes.set(key, value);
       return;
     }
+    this.writeUnbuffered(stream, key, value);
+  }
+
+  private writeUnbuffered(
+    stream: StreamTabId,
+    key: string,
+    value: unknown,
+  ): void {
     const chainKey = `${stream}::${key}`;
     const version = this.streamVersion(stream);
     const mutex = this.writeMutexes.get(chainKey) ?? new Mutex();
@@ -1400,7 +1505,6 @@ export class StreamSnapshotStore {
     if (this.records.get(streamId)?.seeded) {
       return this.snapshotFromMemory(streamId);
     }
-    await this.recoverStagedDeletion(streamId);
     return assembleSnapshot(streamId, await readStreamData(this.kv(streamId)));
   }
 
@@ -1443,7 +1547,6 @@ export class StreamSnapshotStore {
     if (this.records.get(streamId)?.seeded) {
       return this.getOutputFiles(streamId);
     }
-    await this.recoverStagedDeletion(streamId);
     return (await readStreamData(this.kv(streamId))).outputFiles;
   }
 
@@ -1494,8 +1597,6 @@ export class StreamSnapshotStore {
     const next = prev.then(async () => {
       if (this.streamVersion(stream) !== version) return;
       await this.flushWritesForStream(stream);
-      if (this.streamVersion(stream) !== version) return;
-      await this.recoverStagedDeletion(stream);
       if (this.streamVersion(stream) !== version) return;
       const record = this.records.get(stream);
       if (record) record.kv = undefined;

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -66,8 +66,10 @@ import { isDirectory } from '@utils/files/fsEntryType';
 import {
   canUseStreamDataDir,
   decodeStreamId,
+  STREAM_DATA_DELETION_DIR,
   STREAM_DATA_DIR,
   STREAM_DATA_KEYS,
+  stagedStreamDataDir,
   streamDataDir,
 } from './streamDataPaths';
 import {
@@ -84,6 +86,11 @@ const CHANNEL = 'StreamSnapshotStore';
 /** Bounded fan-out for seeding many streams' sidecars (mirrors the retired
  *  managers' `pMap` hydration so startup doesn't open a file handle per tab). */
 const SEED_IO_CONCURRENCY = 8;
+
+interface StagedStreamSnapshotDeletion {
+  commit(): Promise<void>;
+  rollback(): Promise<void>;
+}
 
 const UsageRunEventDataSchema = z.looseObject({
   streamId: StreamTabIdSchema,
@@ -281,6 +288,7 @@ interface StreamRecord {
 
 export class StreamSnapshotStore {
   private readonly records = new Map<StreamTabId, StreamRecord>();
+  private readonly stagedDeletions = new Set<StreamTabId>();
 
   // -- Per (stream, category) serialized write locks -------------------------
   private readonly writeMutexes = new Map<string, Mutex>();
@@ -503,6 +511,8 @@ export class StreamSnapshotStore {
   private async readSeed(stream: StreamTabId, version: number): Promise<void> {
     if (this.streamVersion(stream) !== version) return;
     if (this.records.get(stream)?.seeded) return;
+    await this.recoverStagedDeletion(stream);
+    if (this.streamVersion(stream) !== version) return;
     const data = await readStreamData(this.kv(stream));
     if (this.streamVersion(stream) !== version) return;
     await this.applyStreamData(stream, data);
@@ -869,60 +879,113 @@ export class StreamSnapshotStore {
     for (const stream of this.records.keys()) this.bumpStreamVersion(stream);
     this.records.clear();
     this.writeMutexes.clear();
+    this.stagedDeletions.clear();
   }
 
-  /** Delete a stream's on-disk sidecar directory + in-memory state. */
-  async deleteStream(stream: StreamTabId): Promise<void> {
-    const record = this.records.get(stream);
-    const wasSeeded = record?.seeded ?? false;
-    const pending = this.cancelPendingWritesForStream(stream);
-    // Invalidate in-flight hydration/writes immediately, but keep the record
-    // readable until durable deletion commits. If deleteDir() fails, callers
-    // retain the stream and can retry with its complete in-memory snapshot.
-    this.bumpStreamVersion(stream);
-    await Promise.all(pending);
-    // Keep this after pending-write cancellation so reserved ids cannot leave
-    // older write chains free to recreate a non-stream-owned sidecar path.
-    if (!canUseStreamDataDir(stream)) {
-      this.records.delete(stream);
+  /** Restore a crash-interrupted pre-commit rename before reading the stream. */
+  private async recoverStagedDeletion(stream: StreamTabId): Promise<void> {
+    if (this.stagedDeletions.has(stream) || !canUseStreamDataDir(stream))
       return;
+    const stagedDir = stagedStreamDataDir(stream);
+    if (!(await StorageFS.exists(stagedDir))) return;
+
+    const liveDir = streamDataDir(stream);
+    if (await StorageFS.exists(liveDir)) {
+      // A newer generation already owns the live path; this is committed
+      // deletion residue whose best retry is ordinary garbage collection.
+      await StorageFS.delete(stagedDir, { recursive: true });
+    } else {
+      await StorageFS.rename(stagedDir, liveDir);
     }
+    const record = this.records.get(stream);
+    if (record) record.kv = undefined;
+  }
+
+  /**
+   * Atomically move a stream's sidecars out of the live namespace while
+   * keeping its in-memory record available until the transcript registry
+   * decides whether deletion commits.
+   */
+  async stageDeleteStream(
+    stream: StreamTabId,
+  ): Promise<StagedStreamSnapshotDeletion> {
+    if (this.stagedDeletions.has(stream)) {
+      throw new Error(
+        `Snapshot deletion is already staged for stream ${stream}`,
+      );
+    }
+    await this.recoverStagedDeletion(stream);
+    if (this.stagedDeletions.has(stream)) {
+      throw new Error(
+        `Snapshot deletion is already staged for stream ${stream}`,
+      );
+    }
+    this.stagedDeletions.add(stream);
 
     try {
-      await new KVStore(streamDataDir(stream), {
-        throwOnErrors: true,
-      }).deleteDir();
-    } catch (error) {
-      if (wasSeeded && record) {
-        // Recursive removal may have deleted only some sidecars before failing.
-        // Restore every durable field from the authoritative resident record;
-        // reseeding here would replace complete memory with disk fragments.
-        if (record.meta) this.writeMeta(stream, record.meta);
-        this.writeOutputFiles(stream);
-        this.write(stream, STREAM_DATA_KEYS.MISSING_OUTPUTS, {
-          ...record.missingOutputs,
-        });
-        this.write(stream, STREAM_DATA_KEYS.COMPILE_FAILURES, {
-          ...record.compileFailures,
-        });
-        this.writeUsage(stream);
-        this.writeWorkPlan(stream, record.workPlan);
-        await this.flushWritesForStream(stream);
-      } else {
-        // A version bump can interrupt hydration as well as writes. Chain a
-        // fresh seed behind that interrupted work so the retained record
-        // becomes current and mutable once its durable sidecars are read.
-        void this.refreshSeed(stream).catch((seedError: unknown) =>
-          logger.warn(
-            CHANNEL,
-            `Failed to restore snapshot state after retaining stream ${stream}`,
-            { data: seedError },
-          ),
-        );
+      // Let hydration finish before staging. A record with `seeded === false`
+      // may already contain sidecars while execution-config hydration is still
+      // in flight, so invalidating that seed would make neither disk nor memory
+      // authoritative for rollback.
+      let seedChain = this.records.get(stream)?.seedChain;
+      while (seedChain) {
+        await seedChain;
+        const current = this.records.get(stream)?.seedChain;
+        if (!current || current === seedChain) break;
+        seedChain = current;
       }
+
+      const pending = this.cancelPendingWritesForStream(stream);
+      this.bumpStreamVersion(stream);
+      await Promise.all(pending);
+
+      const canStage = canUseStreamDataDir(stream);
+      const liveDir = canStage ? streamDataDir(stream) : undefined;
+      const stagedDir = canStage ? stagedStreamDataDir(stream) : undefined;
+      let staged = false;
+      if (liveDir && stagedDir && (await StorageFS.exists(liveDir))) {
+        await StorageFS.ensureDir(STREAM_DATA_DELETION_DIR);
+        await StorageFS.rename(liveDir, stagedDir);
+        staged = true;
+      }
+
+      let settled = false;
+      return {
+        commit: async () => {
+          if (settled) return;
+          settled = true;
+          this.stagedDeletions.delete(stream);
+          this.evict(stream);
+          if (!staged || !stagedDir) return;
+          try {
+            await StorageFS.delete(stagedDir, { recursive: true });
+          } catch (error) {
+            logger.warn(
+              CHANNEL,
+              `Stream ${stream} was deleted, but staged snapshot cleanup was incomplete.`,
+              { data: error },
+            );
+          }
+        },
+        rollback: async () => {
+          if (settled) return;
+          if (staged && stagedDir && liveDir) {
+            await StorageFS.rename(stagedDir, liveDir);
+          }
+          this.stagedDeletions.delete(stream);
+          settled = true;
+        },
+      };
+    } catch (error) {
+      this.stagedDeletions.delete(stream);
       throw error;
     }
-    this.records.delete(stream);
+  }
+
+  /** Delete a stream's sidecars and in-memory state as one committed action. */
+  async deleteStream(stream: StreamTabId): Promise<void> {
+    const deletion = await this.stageDeleteStream(stream);
+    await deletion.commit();
   }
 
   /** Delete the entire `streamData/` tree + all in-memory state. */
@@ -932,7 +995,14 @@ export class StreamSnapshotStore {
     );
     this.evictAll();
     await Promise.all(pending);
-    await new KVStore(STREAM_DATA_DIR).deleteDir();
+    await Promise.all([
+      new KVStore(STREAM_DATA_DIR).deleteDir(),
+      StorageFS.delete(STREAM_DATA_DELETION_DIR, { recursive: true }).catch(
+        (error: unknown) => {
+          if (!isFileNotFoundError(error)) throw error;
+        },
+      ),
+    ]);
   }
 
   setTodos(stream: StreamTabId, todos: TodoItem[]): void {
@@ -1081,6 +1151,7 @@ export class StreamSnapshotStore {
   async readPersistedExecutionId(
     stream: StreamTabId,
   ): Promise<ExecutionId | undefined> {
+    await this.recoverStagedDeletion(stream);
     return executionIdFromMeta(await readMeta(this.kv(stream)));
   }
 
@@ -1093,6 +1164,7 @@ export class StreamSnapshotStore {
    * bare `meta.json`-only match.
    */
   async hasPersistedWorkPlan(stream: StreamTabId): Promise<boolean> {
+    await this.recoverStagedDeletion(stream);
     return this.kv(stream).exists(STREAM_DATA_KEYS.WORK_PLAN);
   }
 
@@ -1107,6 +1179,7 @@ export class StreamSnapshotStore {
   async readLegacyInstruction(
     stream: StreamTabId,
   ): Promise<LegacyInstructionEntry | null> {
+    await this.recoverStagedDeletion(stream);
     const record = this.records.get(stream);
     const meta = record?.seeded
       ? record.meta
@@ -1261,6 +1334,7 @@ export class StreamSnapshotStore {
     if (this.records.get(streamId)?.seeded) {
       return this.snapshotFromMemory(streamId);
     }
+    await this.recoverStagedDeletion(streamId);
     return assembleSnapshot(streamId, await readStreamData(this.kv(streamId)));
   }
 
@@ -1303,6 +1377,7 @@ export class StreamSnapshotStore {
     if (this.records.get(streamId)?.seeded) {
       return this.getOutputFiles(streamId);
     }
+    await this.recoverStagedDeletion(streamId);
     return (await readStreamData(this.kv(streamId))).outputFiles;
   }
 
@@ -1353,6 +1428,8 @@ export class StreamSnapshotStore {
     const next = prev.then(async () => {
       if (this.streamVersion(stream) !== version) return;
       await this.flushWritesForStream(stream);
+      if (this.streamVersion(stream) !== version) return;
+      await this.recoverStagedDeletion(stream);
       if (this.streamVersion(stream) !== version) return;
       const record = this.records.get(stream);
       if (record) record.kv = undefined;

--- a/src/transcript/streamDataPaths.ts
+++ b/src/transcript/streamDataPaths.ts
@@ -25,6 +25,11 @@ import { WORKSPACE_STORAGE_LAYOUT } from '@common/storage/storageLayout';
 
 /** Root directory (relative to the platform storage root) for per-stream sidecar data. */
 export const STREAM_DATA_DIR = WORKSPACE_STORAGE_LAYOUT.streamData;
+/**
+ * Reversible staging area for snapshot directories while transcript deletion
+ * decides whether a stream removal commits.
+ */
+export const STREAM_DATA_DELETION_DIR = `${STREAM_DATA_DIR}.deleting`;
 
 /**
  * Per-category file keys within a stream's `streamData/{id}/` directory.
@@ -78,4 +83,9 @@ export function decodeStreamId(encoded: string): string | undefined {
 /** Build the relative directory path for a stream's sidecar data: `streamData/{encoded}`. */
 export function streamDataDir(streamId: string): string {
   return path.join(STREAM_DATA_DIR, encodeStreamId(streamId));
+}
+
+/** Build the reversible staging path for one stream's snapshot directory. */
+export function stagedStreamDataDir(streamId: string): string {
+  return path.join(STREAM_DATA_DELETION_DIR, encodeStreamId(streamId));
 }


### PR DESCRIPTION
Follow-up to #8656, which merged just before its exact-head Codex review completed.

## Summary

- Keep progress streams in memory/UI when execution deletion succeeds but adjacent snapshot, transcript, or goal cleanup fails.
- Propagate `deleted` / `active` / `failed` outcomes through single-stream deletion and account for partial failures during bulk deletion.
- Preserve the primary in-band subagent error when final artifact/lease cleanup also fails; still surface cleanup failure when the run itself succeeded.

## Validation

- 208 affected Vitest tests
- `npm run typecheck`
- `npm run format`
- `npm run lint` (0 errors; one pre-existing unrelated warning)
- `npm run check:dead-code-ratchet`
- `npm run check:cli-architecture`
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multi-store persistence, crash recovery, and deletion ordering across transcripts, snapshots, and executions; behavior is heavily tested but regressions could strand or duplicate on-disk state.
> 
> **Overview**
> Makes progress **stream deletion transactional** so partial cleanup failures no longer drop tabs from memory while durable data survives (or vice versa).
> 
> **Deletion semantics** now return `deleted`, `active`, or **`failed`** instead of a boolean. When snapshot/transcript/goal cleanup fails, the stream stays in the UI; desktop and the lifecycle controller **resync** content and show retention copy that distinguishes **active leases** from **failed cleanup**. Execution removal runs **`beforeDelete`** adjacent cleanup under the lease, so required sidecar/transcript work must succeed before the execution KV is cleared; if cleanup fails first, execution storage is left intact.
> 
> **Snapshot sidecars** use **staged deletion** (`streamData.deleting/` rename with commit/rollback). The **transcript registry** is the commit point: staged snapshots roll back if log deletion fails. Startup **`reconcileStagedDeletions`** finishes or restores crash-interrupted deletions. **`StreamLogStore.delete`** only removes the in-memory tab after durable deletes succeed.
> 
> **In-band subagent** runs keep the **primary child error** when final lease/artifact cleanup fails after a failed run; successful runs still surface cleanup failures from release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e04a7a866df7cda36c80a25c025899cbdb44b7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->