### PR TITLE
fix(progress): reconcile staged cleanup before deletion

### DIFF
--- a/src/controllers/progressView/backend/state/ProgressViewState.ts
+++ b/src/controllers/progressView/backend/state/ProgressViewState.ts
@@ -459,22 +459,6 @@ export class ProgressViewState {
     const streamIds = this.streamLogs.keys();
     this.logger.info(`[Persistence] Discovered ${streamIds.length} stream(s)`);
 
-    const reconciledDeletions = await this.snapshots.reconcileStagedDeletions(
-      new Set(streamIds),
-    );
-    if (
-      reconciledDeletions.restored.length > 0 ||
-      reconciledDeletions.pendingCleanup.length > 0 ||
-      reconciledDeletions.discarded.length > 0
-    ) {
-      this.logger.info(
-        '[Persistence] Reconciled interrupted stream deletions',
-        {
-          data: reconciledDeletions,
-        },
-      );
-    }
-
     const sweep = await this.stores.sweepOrphanedStreams(new Set(streamIds));
     if (sweep.streams.length > 0) {
       this.logger.info(

--- a/src/controllers/progressView/backend/state/SessionStores.ts
+++ b/src/controllers/progressView/backend/state/SessionStores.ts
@@ -141,7 +141,24 @@ export class SessionStores {
     );
   }
 
+  private async reconcileStagedDeletions(
+    liveStreams: ReadonlySet<StreamTabId>,
+  ): Promise<void> {
+    const reconciliation =
+      await this.snapshots.reconcileStagedDeletions(liveStreams);
+    if (
+      reconciliation.restored.length > 0 ||
+      reconciliation.pendingCleanup.length > 0 ||
+      reconciliation.discarded.length > 0
+    ) {
+      logger.info(CHANNEL, 'Reconciled interrupted stream deletions', {
+        data: reconciliation,
+      });
+    }
+  }
+
   async deleteAll(): Promise<DeleteAllStreamsResult> {
+    await this.reconcileStagedDeletions(new Set(this.streamLogs.keys()));
     const [persistedStreams, stagedDeletions] = await Promise.all([
       this.snapshots.listPersistedStreams(),
       this.snapshots.listStagedDeletions(),
@@ -235,6 +252,7 @@ export class SessionStores {
   async sweepOrphanedStreams(
     liveStreams: ReadonlySet<StreamTabId>,
   ): Promise<{ streams: StreamTabId[]; executionIds: ExecutionId[] }> {
+    await this.reconcileStagedDeletions(liveStreams);
     const [persistedStreams, stagedDeletions] = await Promise.all([
       this.snapshots.listPersistedStreams(),
       this.snapshots.listStagedDeletions(),

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -16,7 +16,10 @@ import {
   StreamLogStore,
   StreamSnapshotStore,
 } from '@transcript';
-import { STREAM_DATA_DIR } from '@transcript/streamDataPaths';
+import {
+  stagedStreamDataDir,
+  STREAM_DATA_DIR,
+} from '@transcript/streamDataPaths';
 
 // Local imports - agent
 import {
@@ -2385,6 +2388,52 @@ describe('ProgressBackend', () => {
       expect(await StorageFS.exists(`executions/${executionId}`)).toBe(false);
       expect(GoalStore.getForStream(stream)).toBeNull();
     } finally {
+      await GoalStore.forget(stream);
+      await backend.state.clearAll();
+      backend.dispose();
+      session.dispose();
+    }
+  });
+
+  it('finishes committed staged residue without requiring a reload', async () => {
+    const stream = 'tool@deepseek#c69661' as StreamTabId;
+    const executionId = 'c69661' as ExecutionId;
+    const { backend, session } = createIsolatedRecordingBackend();
+    backend.state.snapshots.setTaskState(
+      stream,
+      toolUseTaskState('search', 'deepseekproT'),
+      executionId,
+    );
+    await writeExecutionConfig(executionId);
+    await backend.state.flush();
+    await GoalStore.start(stream, 'finish same-session cleanup');
+    const deletion = await backend.state.snapshots.stageDeleteStream(stream);
+    const deleteStorage = StorageFS.delete.bind(StorageFS);
+    const deleteSpy = vi
+      .spyOn(StorageFS, 'delete')
+      .mockImplementationOnce(async (target, options) => {
+        if (target === stagedStreamDataDir(stream)) {
+          throw new Error('staged snapshot directory is locked');
+        }
+        await deleteStorage(target, options);
+      });
+
+    try {
+      await deletion.commit();
+      deleteSpy.mockRestore();
+      expect(await backend.state.snapshots.listStagedDeletions()).toContain(
+        stream,
+      );
+
+      await backend.state.clearAll();
+
+      expect(await backend.state.snapshots.listStagedDeletions()).not.toContain(
+        stream,
+      );
+      expect(await StorageFS.exists(`executions/${executionId}`)).toBe(false);
+      expect(GoalStore.getForStream(stream)).toBeNull();
+    } finally {
+      deleteSpy.mockRestore();
       await GoalStore.forget(stream);
       await backend.state.clearAll();
       backend.dispose();


### PR DESCRIPTION
## Summary

- moves staged-deletion reconciliation into `SessionStores`, the lifecycle owner for delete-all and orphan sweeping
- restores committed staging residue before enumeration so same-session cleanup can remove snapshots, execution state, and goals
- adds a regression for cleanup after staged-directory removal fails, without requiring an application reload

## Context

Follow-up to #8668 and the late review finding that unreconciled staged directories blocked subsequent cleanup until restart.

## Verification

- 161 focused persistence and desktop tests passed
- all workspace type checks passed
- lint passed with only the unrelated pre-existing `replaceAll` warning
- dead-code ratchet passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes progress-view persistence lifecycle around stream deletion and orphan cleanup; incorrect reconciliation could leave stale disk state or delete too aggressively, though scope is limited to SessionStores call sites and existing snapshot APIs.
> 
> **Overview**
> **Staged-deletion reconciliation** moves out of `ProgressViewState.load()` into `SessionStores`, which already owns delete-all and orphan sweeping.
> 
> `SessionStores` now runs `reconcileStagedDeletions` at the start of **`deleteAll`** and **`sweepOrphanedStreams`** (still invoked from load via orphan sweep). That reconciles interrupted or partially committed staged snapshot dirs **before** persisted/staged stream lists are built, so same-session bulk cleanup can finish snapshots, executions, and goals without an app reload.
> 
> A regression test covers **`clearAll`** after a staged-directory delete fails during commit, leaving committed staging residue that previously blocked cleanup until restart.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76bdbf49061783af06d18b4c4c7404adfe2ed0bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->