### PR TITLE
fix(progress): finish staged deletion recovery

### DIFF
--- a/src/controllers/progressView/backend/state/ProgressViewState.ts
+++ b/src/controllers/progressView/backend/state/ProgressViewState.ts
@@ -459,22 +459,6 @@ export class ProgressViewState {
     const streamIds = this.streamLogs.keys();
     this.logger.info(`[Persistence] Discovered ${streamIds.length} stream(s)`);
 
-    const reconciledDeletions = await this.snapshots.reconcileStagedDeletions(
-      new Set(streamIds),
-    );
-    if (
-      reconciledDeletions.restored.length > 0 ||
-      reconciledDeletions.pendingCleanup.length > 0 ||
-      reconciledDeletions.discarded.length > 0
-    ) {
-      this.logger.info(
-        '[Persistence] Reconciled interrupted stream deletions',
-        {
-          data: reconciledDeletions,
-        },
-      );
-    }
-
     const sweep = await this.stores.sweepOrphanedStreams(new Set(streamIds));
     if (sweep.streams.length > 0) {
       this.logger.info(

--- a/src/controllers/progressView/backend/state/SessionStores.ts
+++ b/src/controllers/progressView/backend/state/SessionStores.ts
@@ -141,7 +141,24 @@ export class SessionStores {
     );
   }
 
+  private async reconcileStagedDeletions(
+    liveStreams: ReadonlySet<StreamTabId>,
+  ): Promise<void> {
+    const reconciliation =
+      await this.snapshots.reconcileStagedDeletions(liveStreams);
+    if (
+      reconciliation.restored.length > 0 ||
+      reconciliation.pendingCleanup.length > 0 ||
+      reconciliation.discarded.length > 0
+    ) {
+      logger.info(CHANNEL, 'Reconciled interrupted stream deletions', {
+        data: reconciliation,
+      });
+    }
+  }
+
   async deleteAll(): Promise<DeleteAllStreamsResult> {
+    await this.reconcileStagedDeletions(new Set(this.streamLogs.keys()));
     const [persistedStreams, stagedDeletions] = await Promise.all([
       this.snapshots.listPersistedStreams(),
       this.snapshots.listStagedDeletions(),
@@ -235,6 +252,7 @@ export class SessionStores {
   async sweepOrphanedStreams(
     liveStreams: ReadonlySet<StreamTabId>,
   ): Promise<{ streams: StreamTabId[]; executionIds: ExecutionId[] }> {
+    await this.reconcileStagedDeletions(liveStreams);
     const [persistedStreams, stagedDeletions] = await Promise.all([
       this.snapshots.listPersistedStreams(),
       this.snapshots.listStagedDeletions(),

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -16,7 +16,10 @@ import {
   StreamLogStore,
   StreamSnapshotStore,
 } from '@transcript';
-import { STREAM_DATA_DIR } from '@transcript/streamDataPaths';
+import {
+  stagedStreamDataDir,
+  STREAM_DATA_DIR,
+} from '@transcript/streamDataPaths';
 
 // Local imports - agent
 import {
@@ -2385,6 +2388,52 @@ describe('ProgressBackend', () => {
       expect(await StorageFS.exists(`executions/${executionId}`)).toBe(false);
       expect(GoalStore.getForStream(stream)).toBeNull();
     } finally {
+      await GoalStore.forget(stream);
+      await backend.state.clearAll();
+      backend.dispose();
+      session.dispose();
+    }
+  });
+
+  it('finishes committed staged residue without requiring a reload', async () => {
+    const stream = 'tool@deepseek#c69661' as StreamTabId;
+    const executionId = 'c69661' as ExecutionId;
+    const { backend, session } = createIsolatedRecordingBackend();
+    backend.state.snapshots.setTaskState(
+      stream,
+      toolUseTaskState('search', 'deepseekproT'),
+      executionId,
+    );
+    await writeExecutionConfig(executionId);
+    await backend.state.flush();
+    await GoalStore.start(stream, 'finish same-session cleanup');
+    const deletion = await backend.state.snapshots.stageDeleteStream(stream);
+    const deleteStorage = StorageFS.delete.bind(StorageFS);
+    const deleteSpy = vi
+      .spyOn(StorageFS, 'delete')
+      .mockImplementationOnce(async (target, options) => {
+        if (target === stagedStreamDataDir(stream)) {
+          throw new Error('staged snapshot directory is locked');
+        }
+        await deleteStorage(target, options);
+      });
+
+    try {
+      await deletion.commit();
+      deleteSpy.mockRestore();
+      expect(await backend.state.snapshots.listStagedDeletions()).toContain(
+        stream,
+      );
+
+      await backend.state.clearAll();
+
+      expect(await backend.state.snapshots.listStagedDeletions()).not.toContain(
+        stream,
+      );
+      expect(await StorageFS.exists(`executions/${executionId}`)).toBe(false);
+      expect(GoalStore.getForStream(stream)).toBeNull();
+    } finally {
+      deleteSpy.mockRestore();
       await GoalStore.forget(stream);
       await backend.state.clearAll();
       backend.dispose();

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -1246,6 +1246,43 @@ describe('StreamSnapshotStore', () => {
     await store.deleteStream(STREAM);
   });
 
+  it('retries buffered writes after staged-directory reconciliation', async () => {
+    const store = new StreamSnapshotStore();
+    await store.load([]);
+    store.setPlan(STREAM, PLAN);
+    await store.flush();
+    const deletion = await store.stageDeleteStream(STREAM);
+    store.setPlan(STREAM, null);
+    const rollbackError = new Error('snapshot directory is still locked');
+    const renameSpy = vi
+      .spyOn(StorageFS, 'rename')
+      .mockRejectedValueOnce(rollbackError);
+
+    await expect(deletion.rollback()).rejects.toBe(rollbackError);
+
+    renameSpy.mockRestore();
+    const writeError = new Error('snapshot disk is full');
+    const writeSpy = vi
+      .spyOn(StorageFS, 'writeAtomic')
+      .mockRejectedValueOnce(writeError);
+    await expect(
+      store.reconcileStagedDeletions(new Set([STREAM])),
+    ).rejects.toBe(writeError);
+
+    writeSpy.mockRestore();
+    await expect(
+      store.reconcileStagedDeletions(new Set([STREAM])),
+    ).resolves.toEqual({
+      restored: [],
+      pendingCleanup: [],
+      discarded: [],
+    });
+    const reloaded = new StreamSnapshotStore();
+    await reloaded.load([STREAM]);
+    expect(reloaded.getWorkPlan(STREAM).plan).toBeNull();
+    await store.deleteStream(STREAM);
+  });
+
   it('restores committed residue for complete orphan cleanup', async () => {
     const store = new StreamSnapshotStore();
     await store.load([]);

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -1739,6 +1739,67 @@ describe('StreamSnapshotStore', () => {
     await store.deleteStream(STREAM);
   });
 
+  it('serializes setup-failure replay as the failed recovery owner', async () => {
+    const store = new StreamSnapshotStore();
+    await store.load([]);
+    store.setPlan(STREAM, PLAN);
+    await store.flush();
+    const setupError = new Error('staging directory is locked');
+    const ensureDir = StorageFS.ensureDir.bind(StorageFS);
+    const ensureDirSpy = vi
+      .spyOn(StorageFS, 'ensureDir')
+      .mockImplementationOnce(async () => {
+        store.setPlan(STREAM, null);
+        throw setupError;
+      })
+      .mockImplementation(ensureDir);
+    type RecoveryHarness = {
+      replayStagedWrites: (
+        stream: StreamTabId,
+        state: unknown,
+      ) => Promise<void>;
+      failedRollbacks: Map<StreamTabId, { recovery?: Promise<void> }>;
+    };
+    const recoveryHarness = store as unknown as RecoveryHarness;
+    const replay = recoveryHarness.replayStagedWrites.bind(recoveryHarness);
+    let replayStarted = () => {};
+    const replayStart = new Promise<void>((resolve) => {
+      replayStarted = resolve;
+    });
+    let releaseReplay = () => {};
+    const replayGate = new Promise<void>((resolve) => {
+      releaseReplay = resolve;
+    });
+    const replaySpy = vi
+      .spyOn(recoveryHarness, 'replayStagedWrites')
+      .mockImplementationOnce(async (stream, state) => {
+        await replay(stream, state);
+        replayStarted();
+        await replayGate;
+      })
+      .mockImplementation(replay);
+
+    const staging = store.stageDeleteStream(STREAM);
+    await replayStart;
+
+    const failedState = recoveryHarness.failedRollbacks.get(STREAM);
+    expect(failedState?.recovery).toBeInstanceOf(Promise);
+    const flushing = store.flush();
+    expect(replaySpy).toHaveBeenCalledTimes(1);
+
+    releaseReplay();
+    await expect(staging).rejects.toBe(setupError);
+    await expect(flushing).resolves.toBeUndefined();
+    expect(recoveryHarness.failedRollbacks.has(STREAM)).toBe(false);
+
+    ensureDirSpy.mockRestore();
+    replaySpy.mockRestore();
+    const reloaded = new StreamSnapshotStore();
+    await reloaded.load([STREAM]);
+    expect(reloaded.getWorkPlan(STREAM).plan).toBeNull();
+    await store.deleteStream(STREAM);
+  });
+
   it('waits for active hydration before staging deletion', async () => {
     await installPlatform();
     const executionId = 'feedface' as ExecutionId;

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -1574,7 +1574,13 @@ describe('StreamSnapshotStore', () => {
       }),
     );
 
-    await store.flush();
+    await expect(
+      store.reconcileStagedDeletions(new Set([STREAM])),
+    ).resolves.toEqual({
+      restored: [],
+      pendingCleanup: [],
+      discarded: [STREAM],
+    });
     const reloaded = new StreamSnapshotStore();
     await reloaded.load([STREAM]);
     expect(reloaded.getWorkPlan(STREAM).plan).toBeNull();

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -1738,61 +1738,55 @@ describe('StreamSnapshotStore', () => {
     await store.deleteStream(STREAM);
   });
 
-  it('serializes setup-failure replay as the failed recovery owner', async () => {
+  it('serializes setup recovery before another staging attempt can cancel its writes', async () => {
     const store = new StreamSnapshotStore();
     await store.load([]);
+    const streamPlanPath = path.join(streamDataDir(STREAM), 'workPlan.json');
+    let releaseInitialWrite = () => {};
+    const initialWriteGate = new Promise<void>((resolve) => {
+      releaseInitialWrite = resolve;
+    });
+    let initialWriteStarted = () => {};
+    const initialWriteStart = new Promise<void>((resolve) => {
+      initialWriteStarted = resolve;
+    });
+    const writeAtomic = StorageFS.writeAtomic.bind(StorageFS);
+    vi.spyOn(StorageFS, 'writeAtomic').mockImplementation(
+      async (target, contents) => {
+        if (target === streamPlanPath) {
+          initialWriteStarted();
+          await initialWriteGate;
+        }
+        return writeAtomic(target, contents);
+      },
+    );
+
     store.setPlan(STREAM, PLAN);
-    await store.flush();
-    const setupError = new Error('staging directory is locked');
-    const ensureDir = StorageFS.ensureDir.bind(StorageFS);
-    const ensureDirSpy = vi
-      .spyOn(StorageFS, 'ensureDir')
+    await initialWriteStart;
+    const setupError = new Error('cannot inspect staged snapshot');
+    const stat = StorageFS.stat.bind(StorageFS);
+    const statSpy = vi
+      .spyOn(StorageFS, 'stat')
       .mockImplementationOnce(async () => {
         store.setPlan(STREAM, null);
         throw setupError;
       })
-      .mockImplementation(ensureDir);
-    type RecoveryHarness = {
-      replayStagedWrites: (
-        stream: StreamTabId,
-        state: unknown,
-      ) => Promise<void>;
-      failedRollbacks: Map<StreamTabId, { recovery?: Promise<void> }>;
-    };
-    const recoveryHarness = store as unknown as RecoveryHarness;
-    const replay = recoveryHarness.replayStagedWrites.bind(recoveryHarness);
-    let replayStarted = () => {};
-    const replayStart = new Promise<void>((resolve) => {
-      replayStarted = resolve;
-    });
-    let releaseReplay = () => {};
-    const replayGate = new Promise<void>((resolve) => {
-      releaseReplay = resolve;
-    });
-    const replaySpy = vi
-      .spyOn(recoveryHarness, 'replayStagedWrites')
-      .mockImplementationOnce(async (stream, state) => {
-        await replay(stream, state);
-        replayStarted();
-        await replayGate;
-      })
-      .mockImplementation(replay);
+      .mockImplementation(stat);
 
     const staging = store.stageDeleteStream(STREAM);
-    await replayStart;
-
-    const failedState = recoveryHarness.failedRollbacks.get(STREAM);
-    expect(failedState?.recovery).toBeInstanceOf(Promise);
+    await new Promise<void>((resolve) => setImmediate(resolve));
     const flushing = store.flush();
-    expect(replaySpy).toHaveBeenCalledTimes(1);
+    const retrying = store.stageDeleteStream(STREAM);
+    await new Promise<void>((resolve) => setImmediate(resolve));
 
-    releaseReplay();
+    expect(statSpy).toHaveBeenCalledTimes(1);
+
+    releaseInitialWrite();
     await expect(staging).rejects.toBe(setupError);
-    await expect(flushing).resolves.toBeUndefined();
-    expect(recoveryHarness.failedRollbacks.has(STREAM)).toBe(false);
+    await flushing;
+    const retry = await retrying;
+    await retry.rollback();
 
-    ensureDirSpy.mockRestore();
-    replaySpy.mockRestore();
     const reloaded = new StreamSnapshotStore();
     await reloaded.load([STREAM]);
     expect(reloaded.getWorkPlan(STREAM).plan).toBeNull();

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -1246,6 +1246,41 @@ describe('StreamSnapshotStore', () => {
     await store.deleteStream(STREAM);
   });
 
+  it('revalidates live storage after recovery before retaining writes', async () => {
+    const store = new StreamSnapshotStore();
+    await store.load([]);
+    store.setPlan(STREAM, PLAN);
+    await store.flush();
+    const deletion = await store.stageDeleteStream(STREAM);
+    store.setPlan(STREAM, null);
+    const writeError = new Error('snapshot disk is full');
+    const writeSpy = vi
+      .spyOn(StorageFS, 'writeAtomic')
+      .mockRejectedValueOnce(writeError);
+
+    await expect(deletion.rollback()).rejects.toBe(writeError);
+
+    writeSpy.mockRestore();
+    const renameError = new Error('snapshot directory is still locked');
+    const renameSpy = vi
+      .spyOn(StorageFS, 'rename')
+      .mockImplementationOnce(async () => {
+        store.setTodos(STREAM, [TODO]);
+        throw renameError;
+      });
+    await expect(store.stageDeleteStream(STREAM)).rejects.toBe(renameError);
+
+    renameSpy.mockRestore();
+    await store.flush();
+    const reloaded = new StreamSnapshotStore();
+    await reloaded.load([STREAM]);
+    expect(reloaded.getWorkPlan(STREAM)).toMatchObject({
+      plan: null,
+      todos: [TODO],
+    });
+    await store.deleteStream(STREAM);
+  });
+
   it('retries buffered writes after staged-directory reconciliation', async () => {
     const store = new StreamSnapshotStore();
     await store.load([]);

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -1116,6 +1116,33 @@ describe('StreamSnapshotStore', () => {
     await store.deleteStream(STREAM);
   });
 
+  it('retains buffered writes when rollback persistence fails', async () => {
+    const store = new StreamSnapshotStore();
+    await store.load([]);
+    store.setPlan(STREAM, PLAN);
+    await store.flush();
+    const deletion = await store.stageDeleteStream(STREAM);
+    store.setPlan(STREAM, null);
+    const writeError = new Error('snapshot disk is full');
+    const writeAtomic = StorageFS.writeAtomic.bind(StorageFS);
+    const writeSpy = vi
+      .spyOn(StorageFS, 'writeAtomic')
+      .mockImplementationOnce(async () => {
+        throw writeError;
+      })
+      .mockImplementation(writeAtomic);
+
+    await expect(deletion.rollback()).rejects.toBe(writeError);
+
+    writeSpy.mockRestore();
+    const retry = await store.stageDeleteStream(STREAM);
+    await retry.rollback();
+    const reloaded = new StreamSnapshotStore();
+    await reloaded.load([STREAM]);
+    expect(reloaded.getWorkPlan(STREAM).plan).toBeNull();
+    await store.deleteStream(STREAM);
+  });
+
   it('restores committed residue for complete orphan cleanup', async () => {
     const store = new StreamSnapshotStore();
     await store.load([]);

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -1184,6 +1184,34 @@ describe('StreamSnapshotStore', () => {
     await store.deleteStream(STREAM);
   });
 
+  it('keeps writes buffered when a staging rename fails after moving data', async () => {
+    const store = new StreamSnapshotStore();
+    await store.load([]);
+    store.setPlan(STREAM, PLAN);
+    await store.flush();
+    const renameError = new Error('snapshot rename acknowledgement failed');
+    const rename = StorageFS.rename.bind(StorageFS);
+    const renameSpy = vi
+      .spyOn(StorageFS, 'rename')
+      .mockImplementationOnce(async (source, destination) => {
+        store.setPlan(STREAM, null);
+        await rename(source, destination);
+        throw renameError;
+      })
+      .mockImplementation(rename);
+
+    await expect(store.stageDeleteStream(STREAM)).rejects.toBe(renameError);
+
+    store.setPlan(STREAM, PLAN);
+    renameSpy.mockRestore();
+    const retry = await store.stageDeleteStream(STREAM);
+    await retry.rollback();
+    const reloaded = new StreamSnapshotStore();
+    await reloaded.load([STREAM]);
+    expect(reloaded.getWorkPlan(STREAM).plan).toEqual(PLAN);
+    await store.deleteStream(STREAM);
+  });
+
   it('retains prior rollback writes when retry setup also fails', async () => {
     const store = new StreamSnapshotStore();
     await store.load([]);
@@ -1267,31 +1295,26 @@ describe('StreamSnapshotStore', () => {
     await store.load([]);
     store.setPlan(STREAM, PLAN);
     await store.flush();
-    const liveDir = streamDataDir(STREAM);
-    const stat = StorageFS.stat.bind(StorageFS);
-    const statError = Object.assign(new Error('snapshot directory is locked'), {
-      code: 'EACCES',
-    });
+    const setupError = new Error('staging directory is locked');
     const writeError = new Error('snapshot disk is full');
     const writeSpy = vi
       .spyOn(StorageFS, 'writeAtomic')
       .mockRejectedValueOnce(writeError);
-    const statSpy = vi
-      .spyOn(StorageFS, 'stat')
-      .mockImplementation(async (target) => {
-        if (target === liveDir) {
-          store.setPlan(STREAM, null);
-          throw statError;
-        }
-        return stat(target);
-      });
+    const ensureDir = StorageFS.ensureDir.bind(StorageFS);
+    const ensureDirSpy = vi
+      .spyOn(StorageFS, 'ensureDir')
+      .mockImplementationOnce(async () => {
+        store.setPlan(STREAM, null);
+        throw setupError;
+      })
+      .mockImplementation(ensureDir);
 
     const error = await store.stageDeleteStream(STREAM).catch((cause) => cause);
 
     expect(error).toBeInstanceOf(AggregateError);
-    expect((error as AggregateError).errors).toEqual([statError, writeError]);
+    expect((error as AggregateError).errors).toEqual([setupError, writeError]);
 
-    statSpy.mockRestore();
+    ensureDirSpy.mockRestore();
     writeSpy.mockRestore();
     const retry = await store.stageDeleteStream(STREAM);
     await retry.rollback();

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -1136,8 +1136,13 @@ describe('StreamSnapshotStore', () => {
     await expect(deletion.rollback()).rejects.toBe(writeError);
 
     const revisedPlan: Plan = { objective: 'Use the recovered draft' };
-    store.setPlan(STREAM, revisedPlan);
     writeSpy.mockRestore();
+    store.setPlan(STREAM, revisedPlan);
+    await store.flush();
+    const beforeRetry = new StreamSnapshotStore();
+    await beforeRetry.load([STREAM]);
+    expect(beforeRetry.getWorkPlan(STREAM).plan).toEqual(revisedPlan);
+
     const retry = await store.stageDeleteStream(STREAM);
     await retry.rollback();
     const reloaded = new StreamSnapshotStore();

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -1318,6 +1318,40 @@ describe('StreamSnapshotStore', () => {
     await store.deleteStream(STREAM);
   });
 
+  it('keeps the staged base when failed rollback data also has live residue', async () => {
+    const store = new StreamSnapshotStore();
+    await store.load([]);
+    store.setPlan(STREAM, PLAN);
+    void store.addUsage(STREAM, RUN, usage(100, 20, 0.5));
+    await store.flush();
+    const deletion = await store.stageDeleteStream(STREAM);
+    store.setPlan(STREAM, null);
+    const rollbackError = new Error('snapshot directory is still locked');
+    const renameSpy = vi
+      .spyOn(StorageFS, 'rename')
+      .mockRejectedValueOnce(rollbackError);
+
+    await expect(deletion.rollback()).rejects.toBe(rollbackError);
+
+    renameSpy.mockRestore();
+    await StorageFS.ensureDir(streamDataDir(STREAM));
+    await expect(
+      store.reconcileStagedDeletions(new Set([STREAM])),
+    ).resolves.toEqual({
+      restored: [STREAM],
+      pendingCleanup: [],
+      discarded: [],
+    });
+    const reloaded = await new StreamSnapshotStore().read(STREAM);
+    expect(reloaded.plan).toBeNull();
+    expect(reloaded.runUsage[RUN]).toMatchObject({
+      inputTokens: 100,
+      outputTokens: 20,
+      cost: 0.5,
+    });
+    await store.deleteStream(STREAM);
+  });
+
   it('restores committed residue for complete orphan cleanup', async () => {
     const store = new StreamSnapshotStore();
     await store.load([]);

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -1160,6 +1160,37 @@ describe('StreamSnapshotStore', () => {
     await store.deleteStream(STREAM);
   });
 
+  it('settles staging after setup fails with buffered writes', async () => {
+    const store = new StreamSnapshotStore();
+    await store.load([]);
+    store.setPlan(STREAM, PLAN);
+    await store.flush();
+    const liveDir = streamDataDir(STREAM);
+    const stat = StorageFS.stat.bind(StorageFS);
+    const statError = Object.assign(new Error('snapshot directory is locked'), {
+      code: 'EACCES',
+    });
+    const statSpy = vi
+      .spyOn(StorageFS, 'stat')
+      .mockImplementation(async (target) => {
+        if (target === liveDir) {
+          store.setPlan(STREAM, null);
+          throw statError;
+        }
+        return stat(target);
+      });
+
+    await expect(store.stageDeleteStream(STREAM)).rejects.toBe(statError);
+
+    statSpy.mockRestore();
+    const retry = await store.stageDeleteStream(STREAM);
+    await retry.rollback();
+    const reloaded = new StreamSnapshotStore();
+    await reloaded.load([STREAM]);
+    expect(reloaded.getWorkPlan(STREAM).plan).toBeNull();
+    await store.deleteStream(STREAM);
+  });
+
   it('waits for active hydration before staging deletion', async () => {
     await installPlatform();
     const executionId = 'feedface' as ExecutionId;

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -1234,6 +1234,43 @@ describe('StreamSnapshotStore', () => {
     await store.deleteStream(STREAM);
   });
 
+  it('mirrors writes when rollback moved data before reporting failure', async () => {
+    const store = new StreamSnapshotStore();
+    await store.load([]);
+    store.setPlan(STREAM, PLAN);
+    await store.flush();
+    const deletion = await store.stageDeleteStream(STREAM);
+    store.setPlan(STREAM, null);
+    const renameError = new Error('snapshot rename acknowledgement failed');
+    const rename = StorageFS.rename.bind(StorageFS);
+    const renameSpy = vi
+      .spyOn(StorageFS, 'rename')
+      .mockImplementationOnce(async (source, destination) => {
+        await rename(source, destination);
+        throw renameError;
+      });
+
+    await expect(deletion.rollback()).rejects.toBe(renameError);
+
+    renameSpy.mockRestore();
+    const writeAtomic = StorageFS.writeAtomic.bind(StorageFS);
+    const writeSpy = vi
+      .spyOn(StorageFS, 'writeAtomic')
+      .mockImplementation(writeAtomic);
+    store.setTodos(STREAM, [TODO]);
+    await vi.waitFor(() => expect(writeSpy).toHaveBeenCalledTimes(1));
+    writeSpy.mockRestore();
+
+    const reloaded = new StreamSnapshotStore();
+    await reloaded.load([STREAM]);
+    expect(reloaded.getWorkPlan(STREAM)).toMatchObject({
+      plan: null,
+      todos: [TODO],
+    });
+    await store.flush();
+    await store.deleteStream(STREAM);
+  });
+
   it('retains prior rollback writes when retry setup also fails', async () => {
     const store = new StreamSnapshotStore();
     await store.load([]);
@@ -1374,7 +1411,7 @@ describe('StreamSnapshotStore', () => {
     await store.deleteStream(STREAM);
   });
 
-  it('keeps the live base when only failed write replay left staged residue', async () => {
+  it('discards staged residue when failed rollback data has a live base', async () => {
     const store = new StreamSnapshotStore();
     await store.load([]);
     store.setPlan(STREAM, PLAN);
@@ -1390,7 +1427,16 @@ describe('StreamSnapshotStore', () => {
     await expect(deletion.rollback()).rejects.toBe(writeError);
 
     writeSpy.mockRestore();
-    await StorageFS.ensureDir(stagedStreamDataDir(STREAM));
+    const stagedDir = stagedStreamDataDir(STREAM);
+    await StorageFS.ensureDir(stagedDir);
+    await StorageFS.writeAtomic(
+      path.join(stagedDir, 'workPlan.json'),
+      JSON.stringify({
+        todos: [],
+        plan: PLAN,
+        planSummary: PLAN_SUMMARY,
+      }),
+    );
     await expect(
       store.reconcileStagedDeletions(new Set([STREAM])),
     ).resolves.toEqual({
@@ -1398,6 +1444,7 @@ describe('StreamSnapshotStore', () => {
       pendingCleanup: [],
       discarded: [STREAM],
     });
+
     const reloaded = await new StreamSnapshotStore().read(STREAM);
     expect(reloaded.plan).toBeNull();
     expect(reloaded.runUsage[RUN]).toMatchObject({
@@ -1405,6 +1452,61 @@ describe('StreamSnapshotStore', () => {
       outputTokens: 20,
       cost: 0.5,
     });
+    expect(await StorageFS.exists(stagedDir)).toBe(false);
+    await store.deleteStream(STREAM);
+  });
+
+  it('serializes a staging retry behind failed rollback reconciliation', async () => {
+    const store = new StreamSnapshotStore();
+    await store.load([]);
+    store.setPlan(STREAM, PLAN);
+    await store.flush();
+    const deletion = await store.stageDeleteStream(STREAM);
+    store.setPlan(STREAM, null);
+    const rollbackError = new Error('snapshot directory is still locked');
+    const rollbackSpy = vi
+      .spyOn(StorageFS, 'rename')
+      .mockRejectedValueOnce(rollbackError);
+
+    await expect(deletion.rollback()).rejects.toBe(rollbackError);
+
+    rollbackSpy.mockRestore();
+    let releaseRename = () => {};
+    const renameGate = new Promise<void>((resolve) => {
+      releaseRename = resolve;
+    });
+    const rename = StorageFS.rename.bind(StorageFS);
+    const recoverySpy = vi
+      .spyOn(StorageFS, 'rename')
+      .mockImplementationOnce(async (source, destination) => {
+        await renameGate;
+        return rename(source, destination);
+      })
+      .mockImplementation(rename);
+    const reconciliation = store.reconcileStagedDeletions(new Set([STREAM]));
+    await vi.waitFor(() => expect(recoverySpy).toHaveBeenCalledTimes(1));
+
+    let retrySettled = false;
+    const retryPromise = store.stageDeleteStream(STREAM).then((retry) => {
+      retrySettled = true;
+      return retry;
+    });
+    await Promise.resolve();
+    expect(retrySettled).toBe(false);
+
+    releaseRename();
+    await expect(reconciliation).resolves.toEqual({
+      restored: [STREAM],
+      pendingCleanup: [],
+      discarded: [],
+    });
+    const retry = await retryPromise;
+    await retry.rollback();
+    recoverySpy.mockRestore();
+
+    const reloaded = new StreamSnapshotStore();
+    await reloaded.load([STREAM]);
+    expect(reloaded.getWorkPlan(STREAM).plan).toBeNull();
     await store.deleteStream(STREAM);
   });
 

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -1067,6 +1067,7 @@ describe('StreamSnapshotStore', () => {
     await store.flush();
 
     const firstDeletion = await store.stageDeleteStream(STREAM);
+    store.setPlan(STREAM, null);
     let secondStarted = false;
     const secondDeletion = store.stageDeleteStream(STREAM).then((deletion) => {
       secondStarted = true;
@@ -1079,8 +1080,14 @@ describe('StreamSnapshotStore', () => {
     await firstDeletion.rollback();
     const deletion = await secondDeletion;
     expect(secondStarted).toBe(true);
-    await deletion.commit();
-    expect(await StorageFS.exists(streamDataDir(STREAM))).toBe(false);
+    await deletion.rollback();
+
+    const reloaded = new StreamSnapshotStore();
+    await reloaded.load([STREAM]);
+    expect(reloaded.getWorkPlan(STREAM)).toMatchObject({
+      plan: null,
+      planSummary: null,
+    });
   });
 
   it('allows retry after staged rollback fails', async () => {

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -1547,6 +1547,66 @@ describe('StreamSnapshotStore', () => {
     await store.deleteStream(STREAM);
   });
 
+  it('does not restore staged residue after a live base disappears', async () => {
+    const store = new StreamSnapshotStore();
+    await store.load([]);
+    store.setPlan(STREAM, PLAN);
+    await store.flush();
+    const deletion = await store.stageDeleteStream(STREAM);
+    store.setPlan(STREAM, null);
+    const writeError = new Error('snapshot disk is full');
+    const writeSpy = vi
+      .spyOn(StorageFS, 'writeAtomic')
+      .mockRejectedValueOnce(writeError);
+
+    await expect(deletion.rollback()).rejects.toBe(writeError);
+
+    writeSpy.mockRestore();
+    const liveDir = streamDataDir(STREAM);
+    const stagedDir = stagedStreamDataDir(STREAM);
+    await StorageFS.delete(liveDir, { recursive: true });
+    await StorageFS.ensureDir(stagedDir);
+    await StorageFS.writeAtomic(
+      path.join(stagedDir, 'workPlan.json'),
+      JSON.stringify({
+        todos: [],
+        plan: PLAN,
+        planSummary: PLAN_SUMMARY,
+      }),
+    );
+
+    await store.flush();
+    const reloaded = new StreamSnapshotStore();
+    await reloaded.load([STREAM]);
+    expect(reloaded.getWorkPlan(STREAM).plan).toBeNull();
+    expect(await StorageFS.exists(stagedDir)).toBe(false);
+    await store.deleteStream(STREAM);
+  });
+
+  it('recreates live storage from buffered writes when both bases vanish', async () => {
+    const store = new StreamSnapshotStore();
+    await store.load([]);
+    store.setPlan(STREAM, PLAN);
+    await store.flush();
+    const deletion = await store.stageDeleteStream(STREAM);
+    store.setPlan(STREAM, null);
+    const rollbackError = new Error('snapshot directory is still locked');
+    const renameSpy = vi
+      .spyOn(StorageFS, 'rename')
+      .mockRejectedValueOnce(rollbackError);
+
+    await expect(deletion.rollback()).rejects.toBe(rollbackError);
+
+    renameSpy.mockRestore();
+    await StorageFS.delete(stagedStreamDataDir(STREAM), { recursive: true });
+    await store.flush();
+    const reloaded = new StreamSnapshotStore();
+    await reloaded.load([STREAM]);
+    expect(reloaded.getWorkPlan(STREAM).plan).toBeNull();
+    expect(await StorageFS.exists(streamDataDir(STREAM))).toBe(true);
+    await store.deleteStream(STREAM);
+  });
+
   it('serializes a staging retry behind failed rollback reconciliation', async () => {
     const store = new StreamSnapshotStore();
     await store.load([]);

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -1173,6 +1173,62 @@ describe('StreamSnapshotStore', () => {
     await store.deleteStream(STREAM);
   });
 
+  it('waits unrelated writes before flush reports a recovery failure', async () => {
+    const store = new StreamSnapshotStore();
+    await store.load([]);
+    store.setPlan(STREAM, PLAN);
+    await store.flush();
+    const deletion = await store.stageDeleteStream(STREAM);
+    store.setPlan(STREAM, null);
+    const initialWriteError = new Error('snapshot disk is full');
+    const initialWriteSpy = vi
+      .spyOn(StorageFS, 'writeAtomic')
+      .mockRejectedValueOnce(initialWriteError);
+    await expect(deletion.rollback()).rejects.toBe(initialWriteError);
+    initialWriteSpy.mockRestore();
+
+    let releaseUnrelatedWrite = () => {};
+    const unrelatedWriteGate = new Promise<void>((resolve) => {
+      releaseUnrelatedWrite = resolve;
+    });
+    const recoveryError = new Error('snapshot disk remains full');
+    const writeAtomic = StorageFS.writeAtomic.bind(StorageFS);
+    const streamPlanPath = path.join(streamDataDir(STREAM), 'workPlan.json');
+    const otherPlanPath = path.join(
+      streamDataDir(OTHER_STREAM),
+      'workPlan.json',
+    );
+    const writeSpy = vi
+      .spyOn(StorageFS, 'writeAtomic')
+      .mockImplementation(async (target, data) => {
+        if (target === streamPlanPath) throw recoveryError;
+        if (target === otherPlanPath) await unrelatedWriteGate;
+        return writeAtomic(target, data);
+      });
+    store.setPlan(OTHER_STREAM, PLAN);
+    let flushSettled = false;
+    const flushing = store.flush().finally(() => {
+      flushSettled = true;
+    });
+    void flushing.catch(() => undefined);
+
+    await vi.waitFor(() =>
+      expect(writeSpy).toHaveBeenCalledWith(streamPlanPath, expect.any(String)),
+    );
+    expect(flushSettled).toBe(false);
+
+    releaseUnrelatedWrite();
+    await expect(flushing).rejects.toBe(recoveryError);
+    writeSpy.mockRestore();
+    const reloaded = new StreamSnapshotStore();
+    await reloaded.load([OTHER_STREAM]);
+    expect(reloaded.getWorkPlan(OTHER_STREAM).plan).toEqual(PLAN);
+
+    await store.flush();
+    await store.deleteStream(STREAM);
+    await store.deleteStream(OTHER_STREAM);
+  });
+
   it('does not recreate live storage while setup residue is staged', async () => {
     const store = new StreamSnapshotStore();
     await store.load([]);

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -1187,7 +1187,7 @@ describe('StreamSnapshotStore', () => {
     await store.deleteStream(STREAM);
   });
 
-  it('settles staging after setup fails with buffered writes', async () => {
+  it('settles staging and retains writes when setup recovery fails', async () => {
     const store = new StreamSnapshotStore();
     await store.load([]);
     store.setPlan(STREAM, PLAN);
@@ -1197,6 +1197,10 @@ describe('StreamSnapshotStore', () => {
     const statError = Object.assign(new Error('snapshot directory is locked'), {
       code: 'EACCES',
     });
+    const writeError = new Error('snapshot disk is full');
+    const writeSpy = vi
+      .spyOn(StorageFS, 'writeAtomic')
+      .mockRejectedValueOnce(writeError);
     const statSpy = vi
       .spyOn(StorageFS, 'stat')
       .mockImplementation(async (target) => {
@@ -1207,9 +1211,13 @@ describe('StreamSnapshotStore', () => {
         return stat(target);
       });
 
-    await expect(store.stageDeleteStream(STREAM)).rejects.toBe(statError);
+    const error = await store.stageDeleteStream(STREAM).catch((cause) => cause);
+
+    expect(error).toBeInstanceOf(AggregateError);
+    expect((error as AggregateError).errors).toEqual([statError, writeError]);
 
     statSpy.mockRestore();
+    writeSpy.mockRestore();
     const retry = await store.stageDeleteStream(STREAM);
     await retry.rollback();
     const reloaded = new StreamSnapshotStore();

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -12,6 +12,7 @@ import { StreamSnapshotStore, streamDataDir } from '@transcript';
 import {
   stagedStreamDataDir,
   STREAM_DATA_DIR,
+  STREAM_DATA_DELETION_DIR,
 } from '@transcript/streamDataPaths';
 import { getExecutionStore } from '@agent/storage';
 import { SessionEventHub } from '@agent/runtime/SessionEventHub';
@@ -1134,12 +1135,81 @@ describe('StreamSnapshotStore', () => {
 
     await expect(deletion.rollback()).rejects.toBe(writeError);
 
+    const revisedPlan: Plan = { objective: 'Use the recovered draft' };
+    store.setPlan(STREAM, revisedPlan);
     writeSpy.mockRestore();
     const retry = await store.stageDeleteStream(STREAM);
     await retry.rollback();
     const reloaded = new StreamSnapshotStore();
     await reloaded.load([STREAM]);
+    expect(reloaded.getWorkPlan(STREAM).plan).toEqual(revisedPlan);
+    await store.deleteStream(STREAM);
+  });
+
+  it('does not recreate live storage while setup residue is staged', async () => {
+    const store = new StreamSnapshotStore();
+    await store.load([]);
+    store.setPlan(STREAM, PLAN);
+    await store.flush();
+    const liveDir = streamDataDir(STREAM);
+    const stagedDir = stagedStreamDataDir(STREAM);
+    await StorageFS.ensureDir(STREAM_DATA_DELETION_DIR);
+    await StorageFS.rename(liveDir, stagedDir);
+    const stat = StorageFS.stat.bind(StorageFS);
+    const statSpy = vi
+      .spyOn(StorageFS, 'stat')
+      .mockImplementationOnce(async (target) => {
+        expect(target).toBe(stagedDir);
+        store.setPlan(STREAM, null);
+        return stat(target);
+      });
+
+    await expect(store.stageDeleteStream(STREAM)).rejects.toThrow(
+      'unreconciled snapshot deletion',
+    );
+
+    statSpy.mockRestore();
+    expect(await StorageFS.exists(liveDir)).toBe(false);
+    expect(await StorageFS.exists(stagedDir)).toBe(true);
+    const retry = await store.stageDeleteStream(STREAM);
+    await retry.rollback();
+    const reloaded = new StreamSnapshotStore();
+    await reloaded.load([STREAM]);
     expect(reloaded.getWorkPlan(STREAM).plan).toBeNull();
+    await store.deleteStream(STREAM);
+  });
+
+  it('retains prior rollback writes when retry setup also fails', async () => {
+    const store = new StreamSnapshotStore();
+    await store.load([]);
+    store.setPlan(STREAM, PLAN);
+    await store.flush();
+    const deletion = await store.stageDeleteStream(STREAM);
+    store.setPlan(STREAM, null);
+    const rollbackError = new Error('snapshot directory is still locked');
+    const renameSpy = vi
+      .spyOn(StorageFS, 'rename')
+      .mockRejectedValueOnce(rollbackError);
+
+    await expect(deletion.rollback()).rejects.toBe(rollbackError);
+
+    renameSpy.mockRestore();
+    const setupError = new Error('cannot inspect staged snapshot');
+    const statSpy = vi
+      .spyOn(StorageFS, 'stat')
+      .mockRejectedValueOnce(setupError);
+    await expect(store.stageDeleteStream(STREAM)).rejects.toBe(setupError);
+
+    statSpy.mockRestore();
+    store.setTodos(STREAM, [TODO]);
+    const retry = await store.stageDeleteStream(STREAM);
+    await retry.rollback();
+    const reloaded = new StreamSnapshotStore();
+    await reloaded.load([STREAM]);
+    expect(reloaded.getWorkPlan(STREAM)).toMatchObject({
+      plan: null,
+      todos: [TODO],
+    });
     await store.deleteStream(STREAM);
   });
 

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -1061,6 +1061,41 @@ describe('StreamSnapshotStore', () => {
     });
   });
 
+  it('drains writes that arrive as rollback replay returns', async () => {
+    const store = new StreamSnapshotStore();
+    await store.load([]);
+    store.setPlan(STREAM, PLAN);
+    await store.flush();
+    const deletion = await store.stageDeleteStream(STREAM);
+    store.setPlan(STREAM, null);
+    type ReplayHarness = {
+      replayStagedWrites: (
+        stream: StreamTabId,
+        state: unknown,
+      ) => Promise<void>;
+    };
+    const replayHarness = store as unknown as ReplayHarness;
+    const replay = replayHarness.replayStagedWrites.bind(replayHarness);
+    const replaySpy = vi
+      .spyOn(replayHarness, 'replayStagedWrites')
+      .mockImplementationOnce(async (stream, state) => {
+        await replay(stream, state);
+        store.setTodos(STREAM, [TODO]);
+      })
+      .mockImplementation(replay);
+
+    await deletion.rollback();
+
+    replaySpy.mockRestore();
+    const reloaded = new StreamSnapshotStore();
+    await reloaded.load([STREAM]);
+    expect(reloaded.getWorkPlan(STREAM)).toMatchObject({
+      plan: null,
+      todos: [TODO],
+    });
+    await store.deleteStream(STREAM);
+  });
+
   it('serializes overlapping staged deletions for one stream', async () => {
     const store = new StreamSnapshotStore();
     await store.load([]);

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -1396,7 +1396,7 @@ describe('StreamSnapshotStore', () => {
     await store.deleteStream(STREAM);
   });
 
-  it('revalidates live storage after recovery before retaining writes', async () => {
+  it('revalidates storage during setup recovery before returning', async () => {
     const store = new StreamSnapshotStore();
     await store.load([]);
     store.setPlan(STREAM, PLAN);
@@ -1421,7 +1421,6 @@ describe('StreamSnapshotStore', () => {
     await expect(store.stageDeleteStream(STREAM)).rejects.toBe(renameError);
 
     renameSpy.mockRestore();
-    await store.flush();
     const reloaded = new StreamSnapshotStore();
     await reloaded.load([STREAM]);
     expect(reloaded.getWorkPlan(STREAM)).toMatchObject({

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -1151,6 +1151,28 @@ describe('StreamSnapshotStore', () => {
     await store.deleteStream(STREAM);
   });
 
+  it('retries retained live rollback writes during flush', async () => {
+    const store = new StreamSnapshotStore();
+    await store.load([]);
+    store.setPlan(STREAM, PLAN);
+    await store.flush();
+    const deletion = await store.stageDeleteStream(STREAM);
+    store.setPlan(STREAM, null);
+    const writeError = new Error('snapshot disk is full');
+    const writeSpy = vi
+      .spyOn(StorageFS, 'writeAtomic')
+      .mockRejectedValueOnce(writeError);
+
+    await expect(deletion.rollback()).rejects.toBe(writeError);
+
+    writeSpy.mockRestore();
+    await store.flush();
+    const reloaded = new StreamSnapshotStore();
+    await reloaded.load([STREAM]);
+    expect(reloaded.getWorkPlan(STREAM).plan).toBeNull();
+    await store.deleteStream(STREAM);
+  });
+
   it('does not recreate live storage while setup residue is staged', async () => {
     const store = new StreamSnapshotStore();
     await store.load([]);
@@ -1341,6 +1363,40 @@ describe('StreamSnapshotStore', () => {
       restored: [STREAM],
       pendingCleanup: [],
       discarded: [],
+    });
+    const reloaded = await new StreamSnapshotStore().read(STREAM);
+    expect(reloaded.plan).toBeNull();
+    expect(reloaded.runUsage[RUN]).toMatchObject({
+      inputTokens: 100,
+      outputTokens: 20,
+      cost: 0.5,
+    });
+    await store.deleteStream(STREAM);
+  });
+
+  it('keeps the live base when only failed write replay left staged residue', async () => {
+    const store = new StreamSnapshotStore();
+    await store.load([]);
+    store.setPlan(STREAM, PLAN);
+    void store.addUsage(STREAM, RUN, usage(100, 20, 0.5));
+    await store.flush();
+    const deletion = await store.stageDeleteStream(STREAM);
+    store.setPlan(STREAM, null);
+    const writeError = new Error('snapshot disk is full');
+    const writeSpy = vi
+      .spyOn(StorageFS, 'writeAtomic')
+      .mockRejectedValueOnce(writeError);
+
+    await expect(deletion.rollback()).rejects.toBe(writeError);
+
+    writeSpy.mockRestore();
+    await StorageFS.ensureDir(stagedStreamDataDir(STREAM));
+    await expect(
+      store.reconcileStagedDeletions(new Set([STREAM])),
+    ).resolves.toEqual({
+      restored: [],
+      pendingCleanup: [],
+      discarded: [STREAM],
     });
     const reloaded = await new StreamSnapshotStore().read(STREAM);
     expect(reloaded.plan).toBeNull();

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -1646,14 +1646,17 @@ export class StreamSnapshotStore {
         .map((record) => record.seedChain)
         .filter((chain): chain is Promise<void> => chain !== undefined),
     );
-    await pMap(
-      [...this.failedRollbacks],
-      ([stream, state]) => this.recoverFailedRollback(stream, state),
-      { concurrency: SEED_IO_CONCURRENCY },
-    );
-    await Promise.all(
-      [...this.writeMutexes.values()].map((mutex) => mutex.waitForUnlock()),
-    );
+    try {
+      await pMap(
+        [...this.failedRollbacks],
+        ([stream, state]) => this.recoverFailedRollback(stream, state),
+        { concurrency: SEED_IO_CONCURRENCY },
+      );
+    } finally {
+      await Promise.all(
+        [...this.writeMutexes.values()].map((mutex) => mutex.waitForUnlock()),
+      );
+    }
   }
 
   // ==========================================================================

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -1050,7 +1050,7 @@ export class StreamSnapshotStore {
     while (true) {
       await this.replayStagedWrites(stream, state);
       if (state.writes.size > 0) continue;
-      this.releaseStagedOwnership(stream, state);
+      this.releaseStagedOwnership(stream, state, state.recovery);
       return;
     }
   }
@@ -1058,8 +1058,11 @@ export class StreamSnapshotStore {
   private releaseStagedOwnership(
     stream: StreamTabId,
     state: StagedDeletionState,
+    expectedRecovery: Promise<void> | undefined = undefined,
   ): void {
-    if (state.writes.size > 0 || state.recovery) return;
+    if (state.writes.size > 0 || state.recovery !== expectedRecovery) {
+      return;
+    }
     if (this.failedRollbacks.get(stream) === state) {
       this.failedRollbacks.delete(stream);
     }
@@ -1080,7 +1083,6 @@ export class StreamSnapshotStore {
     if (this.failedRollbacks.get(stream) !== state) return Promise.resolve();
     if (state.recovery) return state.recovery;
 
-    let recovered = false;
     const recovery = (async () => {
       if (canUseStreamDataDir(stream)) {
         const stagedDir = stagedStreamDataDir(stream);
@@ -1091,7 +1093,7 @@ export class StreamSnapshotStore {
           storagePathExists(stagedDir),
         ]);
 
-        if (liveWasAuthoritative && hasLiveData) {
+        if (liveWasAuthoritative) {
           if (hasStagedData) {
             await StorageFS.delete(stagedDir, { recursive: true });
           }
@@ -1108,22 +1110,20 @@ export class StreamSnapshotStore {
             record.kv = undefined;
             record.writeKv = undefined;
           }
-        } else if (!hasLiveData && !liveWasAuthoritative) {
-          state.phase = 'unavailable';
-          throw new Error(
-            `Stream ${stream} has no snapshot namespace to recover`,
-          );
+        }
+        if (!hasLiveData && (liveWasAuthoritative || !hasStagedData)) {
+          await StorageFS.ensureDir(liveDir);
         }
       }
 
+      // If neither namespace remains, buffered values are the only recoverable
+      // state; replay recreates the live directory instead of wedging ownership.
       state.phase = 'live';
       await this.drainStagedWrites(stream, state);
-      recovered = true;
     })();
     const trackedRecovery = recovery.finally(() => {
       if (state.recovery === trackedRecovery) {
         state.recovery = undefined;
-        if (recovered) this.releaseStagedOwnership(stream, state);
       }
     });
     state.recovery = trackedRecovery;

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -1000,6 +1000,13 @@ export class StreamSnapshotStore {
       }
       await this.flushWritesForStream(stream);
     }
+  }
+
+  /** Release deletion waiters after every terminal transaction path. */
+  private settleStagedDeletion(
+    stream: StreamTabId,
+    state: StagedDeletionState,
+  ): void {
     if (this.stagedDeletions.get(stream) === state) {
       this.stagedDeletions.delete(stream);
     }
@@ -1114,10 +1121,7 @@ export class StreamSnapshotStore {
               }
             }
           } finally {
-            if (this.stagedDeletions.get(stream) === state) {
-              this.stagedDeletions.delete(stream);
-            }
-            state.resolveSettled();
+            this.settleStagedDeletion(stream, state);
           }
         },
         rollback: async () => {
@@ -1132,15 +1136,16 @@ export class StreamSnapshotStore {
             this.failedRollbacks.set(stream, state);
             throw error;
           } finally {
-            if (this.stagedDeletions.get(stream) === state) {
-              this.stagedDeletions.delete(stream);
-            }
-            state.resolveSettled();
+            this.settleStagedDeletion(stream, state);
           }
         },
       };
     } catch (error) {
-      await this.replayStagedWrites(stream, state);
+      try {
+        await this.replayStagedWrites(stream, state);
+      } finally {
+        this.settleStagedDeletion(stream, state);
+      }
       throw error;
     }
   }

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -299,6 +299,7 @@ interface StreamRecord {
 
 interface StagedDeletionState {
   writes: Map<string, unknown>;
+  liveStorageAvailable: boolean;
   settled: Promise<void>;
   resolveSettled: () => void;
 }
@@ -983,6 +984,7 @@ export class StreamSnapshotStore {
             record.writeKv = undefined;
           }
           if (liveStreams.has(stream) && failedWrites) {
+            failedWrites.liveStorageAvailable = true;
             await this.replayStagedWrites(stream, failedWrites);
           }
           this.failedRollbacks.delete(stream);
@@ -993,6 +995,7 @@ export class StreamSnapshotStore {
 
         await StorageFS.delete(stagedDir, { recursive: true });
         if (liveStreams.has(stream) && failedWrites) {
+          failedWrites.liveStorageAvailable = true;
           await this.replayStagedWrites(stream, failedWrites);
         }
         this.failedRollbacks.delete(stream);
@@ -1068,6 +1071,7 @@ export class StreamSnapshotStore {
     });
     const state: StagedDeletionState = {
       writes: new Map(),
+      liveStorageAvailable: true,
       settled: settlement,
       resolveSettled,
     };
@@ -1079,12 +1083,16 @@ export class StreamSnapshotStore {
         const stagedDir = stagedStreamDataDir(stream);
         const liveDir = streamDataDir(stream);
         if (await storagePathExists(stagedDir)) {
+          state.liveStorageAvailable = false;
           if (await storagePathExists(liveDir)) {
             throw new Error(
               `Cannot retry snapshot deletion for ${stream}; both live and staged directories exist`,
             );
           }
           await StorageFS.rename(stagedDir, liveDir);
+          state.liveStorageAvailable = true;
+        } else {
+          state.liveStorageAvailable = true;
         }
         for (const [key, value] of failedState.writes) {
           if (!state.writes.has(key)) state.writes.set(key, value);
@@ -1092,13 +1100,14 @@ export class StreamSnapshotStore {
         await this.replayStagedWrites(stream, state);
         this.failedRollbacks.delete(stream);
       }
-      if (
-        canUseStreamDataDir(stream) &&
-        (await storagePathExists(stagedStreamDataDir(stream)))
-      ) {
-        throw new Error(
-          `Stream ${stream} has an unreconciled snapshot deletion`,
-        );
+      if (canUseStreamDataDir(stream)) {
+        if (await storagePathExists(stagedStreamDataDir(stream))) {
+          state.liveStorageAvailable = false;
+          throw new Error(
+            `Stream ${stream} has an unreconciled snapshot deletion`,
+          );
+        }
+        state.liveStorageAvailable = true;
       }
       // Let hydration finish before staging. A record with `seeded === false`
       // may already contain sidecars while execution-config hydration is still
@@ -1122,6 +1131,7 @@ export class StreamSnapshotStore {
       let staged = false;
       if (liveDir && stagedDir && (await storagePathExists(liveDir))) {
         await StorageFS.ensureDir(STREAM_DATA_DELETION_DIR);
+        state.liveStorageAvailable = false;
         await StorageFS.rename(liveDir, stagedDir);
         staged = true;
       }
@@ -1155,6 +1165,7 @@ export class StreamSnapshotStore {
           try {
             if (staged && stagedDir && liveDir) {
               await StorageFS.rename(stagedDir, liveDir);
+              state.liveStorageAvailable = true;
             }
             await this.replayStagedWrites(stream, state);
           } catch (error) {
@@ -1168,9 +1179,12 @@ export class StreamSnapshotStore {
     } catch (error) {
       const failures: unknown[] = [error];
       try {
+        const canInspectStaging = canUseStreamDataDir(stream);
+        state.liveStorageAvailable = !canInspectStaging;
         const snapshotRemainsStaged =
-          canUseStreamDataDir(stream) &&
+          canInspectStaging &&
           (await storagePathExists(stagedStreamDataDir(stream)));
+        state.liveStorageAvailable = !snapshotRemainsStaged;
         if (snapshotRemainsStaged) {
           this.retainFailedRollback(stream, state);
         } else {
@@ -1466,10 +1480,32 @@ export class StreamSnapshotStore {
   }
 
   private write(stream: StreamTabId, key: string, value: unknown): void {
-    const stagedDeletion =
-      this.stagedDeletions.get(stream) ?? this.failedRollbacks.get(stream);
+    const stagedDeletion = this.stagedDeletions.get(stream);
     if (stagedDeletion) {
       stagedDeletion.writes.set(key, value);
+      return;
+    }
+    const failedRollback = this.failedRollbacks.get(stream);
+    if (failedRollback) {
+      failedRollback.writes.set(key, value);
+      if (failedRollback.liveStorageAvailable) {
+        void this.queueWrite(stream, key, value)
+          .then(() => {
+            if (
+              this.failedRollbacks.get(stream) === failedRollback &&
+              failedRollback.writes.get(key) === value
+            ) {
+              failedRollback.writes.delete(key);
+            }
+          })
+          .catch((err: unknown) =>
+            logger.warn(
+              CHANNEL,
+              `Failed to persist ${key}.json for stream ${stream}; sidecar remains buffered.`,
+              { data: err },
+            ),
+          );
+      }
       return;
     }
     this.writeUnbuffered(stream, key, value);

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -1571,9 +1571,8 @@ export class StreamSnapshotStore {
               failedRollback.writes.get(key) === value
             ) {
               failedRollback.writes.delete(key);
-              if (failedRollback.writes.size === 0) {
-                this.failedRollbacks.delete(stream);
-              }
+              // Recovery owns release even when this mirrored write drained
+              // the last value, so namespace repair cannot lose its owner.
             }
           })
           .catch((err: unknown) =>

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -1021,30 +1021,6 @@ export class StreamSnapshotStore {
     state.resolveSettled();
   }
 
-  /** Restore buffered writes and release ownership after setup fails. */
-  private async failStagedDeletionSetup(
-    stream: StreamTabId,
-    state: StagedDeletionState,
-    setupError: unknown,
-  ): Promise<never> {
-    const failures: unknown[] = [setupError];
-    try {
-      await this.replayStagedWrites(stream, state);
-    } catch (error) {
-      this.failedRollbacks.set(stream, state);
-      failures.push(error);
-    } finally {
-      this.settleStagedDeletion(stream, state);
-    }
-    if (failures.length > 1) {
-      throw new AggregateError(
-        failures,
-        `Snapshot staging and rollback both failed for ${stream}`,
-      );
-    }
-    throw setupError;
-  }
-
   /**
    * Atomically move a stream's sidecars out of the live namespace while
    * keeping its in-memory record available until the transcript registry
@@ -1162,7 +1138,18 @@ export class StreamSnapshotStore {
         },
       };
     } catch (error) {
-      return this.failStagedDeletionSetup(stream, state, error);
+      try {
+        await this.replayStagedWrites(stream, state);
+      } catch (replayError) {
+        this.failedRollbacks.set(stream, state);
+        throw new AggregateError(
+          [error, replayError],
+          `Failed to stage snapshot deletion for ${stream} and restore buffered writes`,
+        );
+      } finally {
+        this.settleStagedDeletion(stream, state);
+      }
+      throw error;
     }
   }
 

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -948,9 +948,10 @@ export class StreamSnapshotStore {
       entries = await StorageFS.readDir(STREAM_DATA_DELETION_DIR);
     } catch (error) {
       if (isFileNotFoundError(error)) {
-        return { restored: [], pendingCleanup: [], discarded: [] };
+        entries = [];
+      } else {
+        throw error;
       }
-      throw error;
     }
 
     const restored: StreamTabId[] = [];
@@ -1001,6 +1002,17 @@ export class StreamSnapshotStore {
         }
         this.failedRollbacks.delete(stream);
         discarded.push(stream);
+      },
+      { concurrency: SEED_IO_CONCURRENCY },
+    );
+    await pMap(
+      [...this.failedRollbacks],
+      async ([stream, state]) => {
+        if (!liveStreams.has(stream) || !state.liveStorageAvailable) return;
+        await this.replayStagedWrites(stream, state);
+        if (this.failedRollbacks.get(stream) === state) {
+          this.failedRollbacks.delete(stream);
+        }
       },
       { concurrency: SEED_IO_CONCURRENCY },
     );

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -297,13 +297,14 @@ interface StreamRecord {
   writeKv: KVStore | undefined;
 }
 
-type StagedDeletionPhase =
-  'live' | 'transitioning' | 'staged' | 'unavailable' | 'replaying-recovery';
+type StagedDeletionPhase = 'live' | 'transitioning' | 'staged' | 'unavailable';
 
 interface StagedDeletionState {
   writes: Map<string, unknown>;
   /** Namespace authority and whether failed ownership may mirror writes. */
   phase: StagedDeletionPhase;
+  /** One recovery owns namespace repair and buffered-write replay at a time. */
+  recovery?: Promise<void>;
   settled: Promise<void>;
   resolveSettled: () => void;
 }
@@ -979,33 +980,25 @@ export class StreamSnapshotStore {
 
         const stagedDir = stagedStreamDataDir(stream);
         const liveDir = streamDataDir(stream);
-        const hasLiveData = await storagePathExists(liveDir);
         const failedWrites = this.failedRollbacks.get(stream);
-        const stagedIsAuthoritative =
-          failedWrites !== undefined && failedWrites.phase !== 'live';
-        if (!hasLiveData || stagedIsAuthoritative) {
-          if (failedWrites) failedWrites.phase = 'staged';
-          if (hasLiveData) {
-            // A failed rollback owner makes the staged tree the complete base;
-            // its buffered writes are the newer delta applied below.
-            await StorageFS.delete(liveDir, { recursive: true });
-          }
+        if (failedWrites) {
+          const hasLiveData = await storagePathExists(liveDir);
+          const liveWasAuthoritative =
+            failedWrites.phase === 'live' && hasLiveData;
+          await this.recoverFailedRollback(stream, failedWrites);
+          if (liveWasAuthoritative) discarded.push(stream);
+          else if (liveStreams.has(stream)) restored.push(stream);
+          else pendingCleanup.push(stream);
+          return;
+        }
+        const hasLiveData = await storagePathExists(liveDir);
+        if (!hasLiveData) {
           await StorageFS.ensureDir(STREAM_DATA_DIR);
-          if (failedWrites) failedWrites.phase = 'transitioning';
           await StorageFS.rename(stagedDir, liveDir);
           const record = this.records.get(stream);
           if (record) {
             record.kv = undefined;
             record.writeKv = undefined;
-          }
-          if (failedWrites) {
-            failedWrites.phase = 'live';
-            if (liveStreams.has(stream)) {
-              await this.replayFailedRollbackWrites(stream, failedWrites);
-            } else {
-              failedWrites.writes.clear();
-              this.releaseFailedRollbackOwnership(stream, failedWrites);
-            }
           }
           if (liveStreams.has(stream)) restored.push(stream);
           else pendingCleanup.push(stream);
@@ -1013,15 +1006,6 @@ export class StreamSnapshotStore {
         }
 
         await StorageFS.delete(stagedDir, { recursive: true });
-        if (failedWrites) {
-          failedWrites.phase = 'live';
-          if (liveStreams.has(stream)) {
-            await this.replayFailedRollbackWrites(stream, failedWrites);
-          } else {
-            failedWrites.writes.clear();
-            this.releaseFailedRollbackOwnership(stream, failedWrites);
-          }
-        }
         discarded.push(stream);
       },
       { concurrency: SEED_IO_CONCURRENCY },
@@ -1030,7 +1014,7 @@ export class StreamSnapshotStore {
       [...this.failedRollbacks],
       async ([stream, state]) => {
         if (!liveStreams.has(stream)) return;
-        await this.replayFailedRollbackWrites(stream, state);
+        await this.recoverFailedRollback(stream, state);
       },
       { concurrency: SEED_IO_CONCURRENCY },
     );
@@ -1058,26 +1042,75 @@ export class StreamSnapshotStore {
     }
   }
 
-  private async replayFailedRollbackWrites(
+  /** Drain a failed owner's buffer and release it without an await-sized gap. */
+  private async drainFailedRollbackWrites(
     stream: StreamTabId,
     state: StagedDeletionState,
   ): Promise<void> {
-    if (state.phase !== 'live') return;
-    await this.replayStagedWrites(stream, state);
-    this.releaseFailedRollbackOwnership(stream, state);
+    while (true) {
+      await this.replayStagedWrites(stream, state);
+      if (state.writes.size > 0) continue;
+      if (this.failedRollbacks.get(stream) === state) {
+        this.failedRollbacks.delete(stream);
+      }
+      return;
+    }
   }
 
-  private releaseFailedRollbackOwnership(
+  /**
+   * Repair a failed rollback exactly once, then release its write buffer only
+   * after the namespace is live and no buffered values remain.
+   */
+  private recoverFailedRollback(
     stream: StreamTabId,
-    state: StagedDeletionState | undefined,
-  ): void {
-    if (
-      state &&
-      state.writes.size === 0 &&
-      this.failedRollbacks.get(stream) === state
-    ) {
-      this.failedRollbacks.delete(stream);
-    }
+    state: StagedDeletionState,
+  ): Promise<void> {
+    if (this.failedRollbacks.get(stream) !== state) return Promise.resolve();
+    if (state.recovery) return state.recovery;
+
+    const recovery = (async () => {
+      if (canUseStreamDataDir(stream)) {
+        const stagedDir = stagedStreamDataDir(stream);
+        const liveDir = streamDataDir(stream);
+        const liveWasAuthoritative = state.phase === 'live';
+        const [hasLiveData, hasStagedData] = await Promise.all([
+          storagePathExists(liveDir),
+          storagePathExists(stagedDir),
+        ]);
+
+        if (liveWasAuthoritative && hasLiveData) {
+          if (hasStagedData) {
+            await StorageFS.delete(stagedDir, { recursive: true });
+          }
+        } else if (hasStagedData) {
+          state.phase = 'staged';
+          if (hasLiveData) {
+            await StorageFS.delete(liveDir, { recursive: true });
+          }
+          await StorageFS.ensureDir(STREAM_DATA_DIR);
+          state.phase = 'transitioning';
+          await StorageFS.rename(stagedDir, liveDir);
+          const record = this.records.get(stream);
+          if (record) {
+            record.kv = undefined;
+            record.writeKv = undefined;
+          }
+        } else if (!hasLiveData && !liveWasAuthoritative) {
+          state.phase = 'unavailable';
+          throw new Error(
+            `Stream ${stream} has no snapshot namespace to recover`,
+          );
+        }
+      }
+
+      state.phase = 'live';
+      await this.drainFailedRollbackWrites(stream, state);
+    })();
+    const trackedRecovery = recovery.finally(() => {
+      if (state.recovery === trackedRecovery) state.recovery = undefined;
+    });
+    state.recovery = trackedRecovery;
+    return trackedRecovery;
   }
 
   /** Release ownership of a stream after its staged transaction finishes. */
@@ -1104,6 +1137,11 @@ export class StreamSnapshotStore {
       await activeDeletion.settled;
       return this.stageDeleteStream(stream);
     }
+    const failedRollback = this.failedRollbacks.get(stream);
+    if (failedRollback) {
+      await this.recoverFailedRollback(stream, failedRollback);
+      return this.stageDeleteStream(stream);
+    }
     let resolveSettled = () => {};
     const settlement = new Promise<void>((resolve) => {
       resolveSettled = resolve;
@@ -1117,34 +1155,6 @@ export class StreamSnapshotStore {
     this.stagedDeletions.set(stream, state);
 
     try {
-      const failedState = this.failedRollbacks.get(stream);
-      if (failedState) {
-        // Transfer ownership before the first await so new writes cannot slip
-        // between the failed transaction and its retry.
-        for (const [key, value] of failedState.writes) {
-          if (!state.writes.has(key)) state.writes.set(key, value);
-        }
-        this.failedRollbacks.delete(stream);
-        state.phase = failedState.phase;
-        const stagedDir = stagedStreamDataDir(stream);
-        const liveDir = streamDataDir(stream);
-        if (await storagePathExists(stagedDir)) {
-          state.phase = 'staged';
-          if (await storagePathExists(liveDir)) {
-            // Writes after the failure stayed buffered, so the staged tree is
-            // the last complete on-disk snapshot and remains authoritative.
-            await StorageFS.delete(liveDir, { recursive: true });
-          }
-          state.phase = 'transitioning';
-          await StorageFS.rename(stagedDir, liveDir);
-          state.phase = 'live';
-        } else {
-          state.phase = 'live';
-        }
-        state.phase = 'replaying-recovery';
-        await this.replayStagedWrites(stream, state);
-        state.phase = 'live';
-      }
       if (canUseStreamDataDir(stream)) {
         const hasStagedData = await storagePathExists(
           stagedStreamDataDir(stream),
@@ -1190,7 +1200,6 @@ export class StreamSnapshotStore {
         commit: async () => {
           if (settled) return;
           settled = true;
-          this.releaseFailedRollbackOwnership(stream, state);
           this.evict(stream);
           try {
             if (state.phase === 'staged' && stagedDir) {
@@ -1219,7 +1228,27 @@ export class StreamSnapshotStore {
             }
             await this.replayStagedWrites(stream, state);
           } catch (error) {
+            const failures: unknown[] = [error];
+            if (state.phase !== 'live' && canUseStreamDataDir(stream)) {
+              try {
+                const [hasLiveData, hasStagedData] = await Promise.all([
+                  storagePathExists(streamDataDir(stream)),
+                  storagePathExists(stagedStreamDataDir(stream)),
+                ]);
+                if (hasStagedData) state.phase = 'staged';
+                else if (hasLiveData) state.phase = 'live';
+                else state.phase = 'unavailable';
+              } catch (recoveryError) {
+                failures.push(recoveryError);
+              }
+            }
             this.failedRollbacks.set(stream, state);
+            if (failures.length > 1) {
+              throw new AggregateError(
+                failures,
+                `Failed to roll back snapshot deletion for ${stream} and inspect its namespace`,
+              );
+            }
             throw error;
           } finally {
             this.settleStagedDeletion(stream, state);
@@ -1228,29 +1257,12 @@ export class StreamSnapshotStore {
       };
     } catch (error) {
       const failures: unknown[] = [error];
+      this.failedRollbacks.set(stream, state);
       try {
-        if (state.phase === 'replaying-recovery') {
-          state.phase = 'live';
-          this.failedRollbacks.set(stream, state);
-        } else {
-          if (state.phase !== 'live' && canUseStreamDataDir(stream)) {
-            state.phase = 'transitioning';
-            const [hasLiveData, hasStagedData] = await Promise.all([
-              storagePathExists(streamDataDir(stream)),
-              storagePathExists(stagedStreamDataDir(stream)),
-            ]);
-            if (hasStagedData) state.phase = 'staged';
-            else if (hasLiveData) state.phase = 'live';
-            else state.phase = 'unavailable';
-          }
-          if (state.phase === 'live') {
-            await this.replayStagedWrites(stream, state);
-          } else {
-            this.failedRollbacks.set(stream, state);
-          }
+        if (state.phase === 'live') {
+          await this.drainFailedRollbackWrites(stream, state);
         }
       } catch (recoveryError) {
-        this.failedRollbacks.set(stream, state);
         failures.push(recoveryError);
       } finally {
         this.settleStagedDeletion(stream, state);
@@ -1547,7 +1559,7 @@ export class StreamSnapshotStore {
     const failedRollback = this.failedRollbacks.get(stream);
     if (failedRollback) {
       failedRollback.writes.set(key, value);
-      if (failedRollback.phase === 'live') {
+      if (failedRollback.phase === 'live' && !failedRollback.recovery) {
         void this.queueWrite(stream, key, value)
           .then(() => {
             if (
@@ -1555,7 +1567,9 @@ export class StreamSnapshotStore {
               failedRollback.writes.get(key) === value
             ) {
               failedRollback.writes.delete(key);
-              this.releaseFailedRollbackOwnership(stream, failedRollback);
+              if (failedRollback.writes.size === 0) {
+                this.failedRollbacks.delete(stream);
+              }
             }
           })
           .catch((err: unknown) =>
@@ -1634,7 +1648,7 @@ export class StreamSnapshotStore {
     );
     await pMap(
       [...this.failedRollbacks],
-      ([stream, state]) => this.replayFailedRollbackWrites(stream, state),
+      ([stream, state]) => this.recoverFailedRollback(stream, state),
       { concurrency: SEED_IO_CONCURRENCY },
     );
     await Promise.all(

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -305,6 +305,9 @@ interface StagedDeletionState {
   resolveSettled: () => void;
 }
 
+type StagedDeletionSetupPhase =
+  'preparing' | 'changing-namespace' | 'replaying-recovery';
+
 export class StreamSnapshotStore {
   private readonly records = new Map<StreamTabId, StreamRecord>();
   /**
@@ -976,8 +979,14 @@ export class StreamSnapshotStore {
 
         const stagedDir = stagedStreamDataDir(stream);
         const liveDir = streamDataDir(stream);
+        const hasLiveData = await storagePathExists(liveDir);
         const failedWrites = this.failedRollbacks.get(stream);
-        if (!(await storagePathExists(liveDir))) {
+        if (!hasLiveData || failedWrites) {
+          if (hasLiveData) {
+            // A failed rollback owner makes the staged tree the complete base;
+            // its buffered writes are the newer delta applied below.
+            await StorageFS.delete(liveDir, { recursive: true });
+          }
           await StorageFS.ensureDir(STREAM_DATA_DIR);
           await StorageFS.rename(stagedDir, liveDir);
           const record = this.records.get(stream);
@@ -989,18 +998,13 @@ export class StreamSnapshotStore {
             failedWrites.liveStorageAvailable = true;
             await this.replayStagedWrites(stream, failedWrites);
           }
-          this.failedRollbacks.delete(stream);
+          this.releaseFailedRollbackOwnership(stream, failedWrites);
           if (liveStreams.has(stream)) restored.push(stream);
           else pendingCleanup.push(stream);
           return;
         }
 
         await StorageFS.delete(stagedDir, { recursive: true });
-        if (liveStreams.has(stream) && failedWrites) {
-          failedWrites.liveStorageAvailable = true;
-          await this.replayStagedWrites(stream, failedWrites);
-        }
-        this.failedRollbacks.delete(stream);
         discarded.push(stream);
       },
       { concurrency: SEED_IO_CONCURRENCY },
@@ -1010,9 +1014,7 @@ export class StreamSnapshotStore {
       async ([stream, state]) => {
         if (!liveStreams.has(stream) || !state.liveStorageAvailable) return;
         await this.replayStagedWrites(stream, state);
-        if (this.failedRollbacks.get(stream) === state) {
-          this.failedRollbacks.delete(stream);
-        }
+        this.releaseFailedRollbackOwnership(stream, state);
       },
       { concurrency: SEED_IO_CONCURRENCY },
     );
@@ -1037,6 +1039,15 @@ export class StreamSnapshotStore {
         }
         throw error;
       }
+    }
+  }
+
+  private releaseFailedRollbackOwnership(
+    stream: StreamTabId,
+    state: StagedDeletionState | undefined,
+  ): void {
+    if (state && this.failedRollbacks.get(stream) === state) {
+      this.failedRollbacks.delete(stream);
     }
   }
 
@@ -1075,8 +1086,7 @@ export class StreamSnapshotStore {
       resolveSettled,
     };
     this.stagedDeletions.set(stream, state);
-    let namespaceTransitionStarted = false;
-    let recoveryReplayInProgress = false;
+    let setupPhase: StagedDeletionSetupPhase = 'preparing';
 
     try {
       const failedState = this.failedRollbacks.get(stream);
@@ -1087,7 +1097,7 @@ export class StreamSnapshotStore {
           if (!state.writes.has(key)) state.writes.set(key, value);
         }
         this.failedRollbacks.delete(stream);
-        namespaceTransitionStarted = true;
+        setupPhase = 'changing-namespace';
         const stagedDir = stagedStreamDataDir(stream);
         const liveDir = streamDataDir(stream);
         if (await storagePathExists(stagedDir)) {
@@ -1102,16 +1112,16 @@ export class StreamSnapshotStore {
         } else {
           state.liveStorageAvailable = true;
         }
-        recoveryReplayInProgress = true;
+        setupPhase = 'replaying-recovery';
         await this.replayStagedWrites(stream, state);
-        recoveryReplayInProgress = false;
+        setupPhase = 'preparing';
       }
       if (canUseStreamDataDir(stream)) {
         const hasStagedData = await storagePathExists(
           stagedStreamDataDir(stream),
         );
         if (hasStagedData) {
-          namespaceTransitionStarted = true;
+          setupPhase = 'changing-namespace';
           state.liveStorageAvailable = false;
           throw new Error(
             `Stream ${stream} has an unreconciled snapshot deletion`,
@@ -1144,7 +1154,7 @@ export class StreamSnapshotStore {
       if (liveDir && stagedDir && hasLiveData) {
         await StorageFS.ensureDir(STREAM_DATA_DELETION_DIR);
         state.liveStorageAvailable = false;
-        namespaceTransitionStarted = true;
+        setupPhase = 'changing-namespace';
         await StorageFS.rename(liveDir, stagedDir);
         staged = true;
       }
@@ -1192,10 +1202,10 @@ export class StreamSnapshotStore {
     } catch (error) {
       const failures: unknown[] = [error];
       try {
-        let canReplay = !recoveryReplayInProgress;
+        let canReplay = setupPhase !== 'replaying-recovery';
         if (
           canReplay &&
-          namespaceTransitionStarted &&
+          setupPhase === 'changing-namespace' &&
           canUseStreamDataDir(stream)
         ) {
           state.liveStorageAvailable = false;

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -1000,12 +1000,7 @@ export class StreamSnapshotStore {
             failedWrites.phase = 'live';
             await this.replayStagedWrites(stream, failedWrites);
           }
-          if (
-            failedWrites &&
-            this.failedRollbacks.get(stream) === failedWrites
-          ) {
-            this.failedRollbacks.delete(stream);
-          }
+          this.releaseFailedRollbackOwnership(stream, failedWrites);
           if (liveStreams.has(stream)) restored.push(stream);
           else pendingCleanup.push(stream);
           return;
@@ -1021,9 +1016,7 @@ export class StreamSnapshotStore {
       async ([stream, state]) => {
         if (!liveStreams.has(stream) || state.phase !== 'live') return;
         await this.replayStagedWrites(stream, state);
-        if (this.failedRollbacks.get(stream) === state) {
-          this.failedRollbacks.delete(stream);
-        }
+        this.releaseFailedRollbackOwnership(stream, state);
       },
       { concurrency: SEED_IO_CONCURRENCY },
     );
@@ -1048,6 +1041,15 @@ export class StreamSnapshotStore {
         }
         throw error;
       }
+    }
+  }
+
+  private releaseFailedRollbackOwnership(
+    stream: StreamTabId,
+    state: StagedDeletionState | undefined,
+  ): void {
+    if (state && this.failedRollbacks.get(stream) === state) {
+      this.failedRollbacks.delete(stream);
     }
   }
 
@@ -1161,9 +1163,7 @@ export class StreamSnapshotStore {
         commit: async () => {
           if (settled) return;
           settled = true;
-          if (this.failedRollbacks.get(stream) === state) {
-            this.failedRollbacks.delete(stream);
-          }
+          this.releaseFailedRollbackOwnership(stream, state);
           this.evict(stream);
           try {
             if (state.phase === 'staged' && stagedDir) {

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -1079,12 +1079,13 @@ export class StreamSnapshotStore {
   private recoverFailedRollback(
     stream: StreamTabId,
     state: StagedDeletionState,
+    namespace: 'inspect' | 'known-live' = 'inspect',
   ): Promise<void> {
     if (this.failedRollbacks.get(stream) !== state) return Promise.resolve();
     if (state.recovery) return state.recovery;
 
     const recovery = (async () => {
-      if (canUseStreamDataDir(stream)) {
+      if (namespace === 'inspect' && canUseStreamDataDir(stream)) {
         const stagedDir = stagedStreamDataDir(stream);
         const liveDir = streamDataDir(stream);
         const liveWasAuthoritative = state.phase === 'live';
@@ -1277,7 +1278,7 @@ export class StreamSnapshotStore {
       this.failedRollbacks.set(stream, state);
       try {
         if (state.phase === 'live') {
-          await this.drainStagedWrites(stream, state);
+          await this.recoverFailedRollback(stream, state, 'known-live');
         }
       } catch (recoveryError) {
         failures.push(recoveryError);

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -1021,6 +1021,30 @@ export class StreamSnapshotStore {
     state.resolveSettled();
   }
 
+  /** Restore buffered writes and release ownership after setup fails. */
+  private async failStagedDeletionSetup(
+    stream: StreamTabId,
+    state: StagedDeletionState,
+    setupError: unknown,
+  ): Promise<never> {
+    const failures: unknown[] = [setupError];
+    try {
+      await this.replayStagedWrites(stream, state);
+    } catch (error) {
+      this.failedRollbacks.set(stream, state);
+      failures.push(error);
+    } finally {
+      this.settleStagedDeletion(stream, state);
+    }
+    if (failures.length > 1) {
+      throw new AggregateError(
+        failures,
+        `Snapshot staging and rollback both failed for ${stream}`,
+      );
+    }
+    throw setupError;
+  }
+
   /**
    * Atomically move a stream's sidecars out of the live namespace while
    * keeping its in-memory record available until the transcript registry
@@ -1138,18 +1162,7 @@ export class StreamSnapshotStore {
         },
       };
     } catch (error) {
-      try {
-        await this.replayStagedWrites(stream, state);
-      } catch (replayError) {
-        this.failedRollbacks.set(stream, state);
-        throw new AggregateError(
-          [error, replayError],
-          `Failed to stage snapshot deletion for ${stream} and restore buffered writes`,
-        );
-      } finally {
-        this.settleStagedDeletion(stream, state);
-      }
-      throw error;
+      return this.failStagedDeletionSetup(stream, state, error);
     }
   }
 

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -355,7 +355,9 @@ export class StreamSnapshotStore {
   private kv(streamId: StreamTabId): KVStore {
     const record = this.getOrCreateRecord(streamId);
     if (!record.kv) {
-      record.kv = new KVStore(streamDataDir(streamId));
+      record.kv = new KVStore(streamDataDir(streamId), {
+        throwOnErrors: true,
+      });
     }
     return record.kv;
   }
@@ -996,10 +998,9 @@ export class StreamSnapshotStore {
       const writes = [...state.writes];
       state.writes.clear();
       try {
-        for (const [key, value] of writes) {
-          this.writeUnbuffered(stream, key, value);
-        }
-        await this.flushWritesForStream(stream);
+        await Promise.all(
+          writes.map(([key, value]) => this.queueWrite(stream, key, value)),
+        );
       } catch (error) {
         for (const [key, value] of writes) {
           if (!state.writes.has(key)) state.writes.set(key, value);
@@ -1018,19 +1019,6 @@ export class StreamSnapshotStore {
       this.stagedDeletions.delete(stream);
     }
     state.resolveSettled();
-  }
-
-  /** Persist a failed rollback's buffered values before staging its retry. */
-  private replayFailedRollbackWrites(
-    stream: StreamTabId,
-    failedState: StagedDeletionState,
-    retryState: StagedDeletionState,
-  ): void {
-    for (const [key, value] of failedState.writes) {
-      retryState.writes.set(key, value);
-      this.writeUnbuffered(stream, key, value);
-    }
-    failedState.resolveSettled();
   }
 
   /**
@@ -1071,8 +1059,10 @@ export class StreamSnapshotStore {
           await StorageFS.rename(stagedDir, liveDir);
         }
         this.failedRollbacks.delete(stream);
-        this.replayFailedRollbackWrites(stream, failedState, state);
-        await this.flushWritesForStream(stream);
+        for (const [key, value] of failedState.writes) {
+          if (!state.writes.has(key)) state.writes.set(key, value);
+        }
+        await this.replayStagedWrites(stream, state);
       }
       if (
         canUseStreamDataDir(stream) &&
@@ -1447,28 +1437,33 @@ export class StreamSnapshotStore {
     key: string,
     value: unknown,
   ): void {
+    void this.queueWrite(stream, key, value).catch((err: unknown) =>
+      logger.warn(
+        CHANNEL,
+        `Failed to persist ${key}.json for stream ${stream}; sidecar may be stale.`,
+        { data: err },
+      ),
+    );
+  }
+
+  /** Queue a sidecar write and expose its completion to transactional callers. */
+  private queueWrite(
+    stream: StreamTabId,
+    key: string,
+    value: unknown,
+  ): Promise<void> {
     const chainKey = `${stream}::${key}`;
     const version = this.streamVersion(stream);
     const mutex = this.writeMutexes.get(chainKey) ?? new Mutex();
     this.writeMutexes.set(chainKey, mutex);
-    // Best-effort: a failed sidecar write must not break the lock, but it is
-    // logged so silent data loss (disk full, permission denied) is diagnosable.
-    void mutex
-      .runExclusive(() => {
-        // Eviction guard: `evict()`/`deleteStream()` drop this chain key. A
-        // write queued before that must NOT fire afterward, or a late `kv()`
-        // would re-create the `streamData/{id}/` dir `deleteDir()` just removed.
-        if (!this.writeMutexes.has(chainKey)) return;
-        if (this.streamVersion(stream) !== version) return;
-        return this.kv(stream).write(key, value);
-      })
-      .catch((err: unknown) =>
-        logger.warn(
-          CHANNEL,
-          `Failed to persist ${key}.json for stream ${stream}; sidecar may be stale.`,
-          { data: err },
-        ),
-      );
+    return mutex.runExclusive(() => {
+      // Eviction guard: `evict()`/`deleteStream()` drop this chain key. A
+      // write queued before that must NOT fire afterward, or a late `kv()`
+      // would re-create the `streamData/{id}/` dir `deleteDir()` just removed.
+      if (!this.writeMutexes.has(chainKey)) return;
+      if (this.streamVersion(stream) !== version) return;
+      return this.kv(stream).write(key, value);
+    });
   }
 
   private async flushWritesForStream(stream: StreamTabId): Promise<void> {

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -981,7 +981,9 @@ export class StreamSnapshotStore {
         const liveDir = streamDataDir(stream);
         const hasLiveData = await storagePathExists(liveDir);
         const failedWrites = this.failedRollbacks.get(stream);
-        if (!hasLiveData || failedWrites) {
+        const stagedIsAuthoritative =
+          failedWrites !== undefined && failedWrites.phase !== 'live';
+        if (!hasLiveData || stagedIsAuthoritative) {
           if (failedWrites) failedWrites.phase = 'staged';
           if (hasLiveData) {
             // A failed rollback owner makes the staged tree the complete base;
@@ -996,17 +998,30 @@ export class StreamSnapshotStore {
             record.kv = undefined;
             record.writeKv = undefined;
           }
-          if (liveStreams.has(stream) && failedWrites) {
+          if (failedWrites) {
             failedWrites.phase = 'live';
-            await this.replayStagedWrites(stream, failedWrites);
+            if (liveStreams.has(stream)) {
+              await this.replayFailedRollbackWrites(stream, failedWrites);
+            } else {
+              failedWrites.writes.clear();
+              this.releaseFailedRollbackOwnership(stream, failedWrites);
+            }
           }
-          this.releaseFailedRollbackOwnership(stream, failedWrites);
           if (liveStreams.has(stream)) restored.push(stream);
           else pendingCleanup.push(stream);
           return;
         }
 
         await StorageFS.delete(stagedDir, { recursive: true });
+        if (failedWrites) {
+          failedWrites.phase = 'live';
+          if (liveStreams.has(stream)) {
+            await this.replayFailedRollbackWrites(stream, failedWrites);
+          } else {
+            failedWrites.writes.clear();
+            this.releaseFailedRollbackOwnership(stream, failedWrites);
+          }
+        }
         discarded.push(stream);
       },
       { concurrency: SEED_IO_CONCURRENCY },
@@ -1014,9 +1029,8 @@ export class StreamSnapshotStore {
     await pMap(
       [...this.failedRollbacks],
       async ([stream, state]) => {
-        if (!liveStreams.has(stream) || state.phase !== 'live') return;
-        await this.replayStagedWrites(stream, state);
-        this.releaseFailedRollbackOwnership(stream, state);
+        if (!liveStreams.has(stream)) return;
+        await this.replayFailedRollbackWrites(stream, state);
       },
       { concurrency: SEED_IO_CONCURRENCY },
     );
@@ -1044,11 +1058,24 @@ export class StreamSnapshotStore {
     }
   }
 
+  private async replayFailedRollbackWrites(
+    stream: StreamTabId,
+    state: StagedDeletionState,
+  ): Promise<void> {
+    if (state.phase !== 'live') return;
+    await this.replayStagedWrites(stream, state);
+    this.releaseFailedRollbackOwnership(stream, state);
+  }
+
   private releaseFailedRollbackOwnership(
     stream: StreamTabId,
     state: StagedDeletionState | undefined,
   ): void {
-    if (state && this.failedRollbacks.get(stream) === state) {
+    if (
+      state &&
+      state.writes.size === 0 &&
+      this.failedRollbacks.get(stream) === state
+    ) {
       this.failedRollbacks.delete(stream);
     }
   }
@@ -1528,6 +1555,7 @@ export class StreamSnapshotStore {
               failedRollback.writes.get(key) === value
             ) {
               failedRollback.writes.delete(key);
+              this.releaseFailedRollbackOwnership(stream, failedRollback);
             }
           })
           .catch((err: unknown) =>
@@ -1603,6 +1631,11 @@ export class StreamSnapshotStore {
       [...this.records.values()]
         .map((record) => record.seedChain)
         .filter((chain): chain is Promise<void> => chain !== undefined),
+    );
+    await pMap(
+      [...this.failedRollbacks],
+      ([stream, state]) => this.replayFailedRollbackWrites(stream, state),
+      { concurrency: SEED_IO_CONCURRENCY },
     );
     await Promise.all(
       [...this.writeMutexes.values()].map((mutex) => mutex.waitForUnlock()),

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -1050,14 +1050,22 @@ export class StreamSnapshotStore {
     while (true) {
       await this.replayStagedWrites(stream, state);
       if (state.writes.size > 0) continue;
-      if (this.failedRollbacks.get(stream) === state) {
-        this.failedRollbacks.delete(stream);
-      }
-      if (this.stagedDeletions.get(stream) === state) {
-        this.stagedDeletions.delete(stream);
-        state.resolveSettled();
-      }
+      this.releaseStagedOwnership(stream, state);
       return;
+    }
+  }
+
+  private releaseStagedOwnership(
+    stream: StreamTabId,
+    state: StagedDeletionState,
+  ): void {
+    if (state.writes.size > 0 || state.recovery) return;
+    if (this.failedRollbacks.get(stream) === state) {
+      this.failedRollbacks.delete(stream);
+    }
+    if (this.stagedDeletions.get(stream) === state) {
+      this.stagedDeletions.delete(stream);
+      state.resolveSettled();
     }
   }
 
@@ -1072,6 +1080,7 @@ export class StreamSnapshotStore {
     if (this.failedRollbacks.get(stream) !== state) return Promise.resolve();
     if (state.recovery) return state.recovery;
 
+    let recovered = false;
     const recovery = (async () => {
       if (canUseStreamDataDir(stream)) {
         const stagedDir = stagedStreamDataDir(stream);
@@ -1109,9 +1118,13 @@ export class StreamSnapshotStore {
 
       state.phase = 'live';
       await this.drainStagedWrites(stream, state);
+      recovered = true;
     })();
     const trackedRecovery = recovery.finally(() => {
-      if (state.recovery === trackedRecovery) state.recovery = undefined;
+      if (state.recovery === trackedRecovery) {
+        state.recovery = undefined;
+        if (recovered) this.releaseStagedOwnership(stream, state);
+      }
     });
     state.recovery = trackedRecovery;
     return trackedRecovery;
@@ -1571,8 +1584,7 @@ export class StreamSnapshotStore {
               failedRollback.writes.get(key) === value
             ) {
               failedRollback.writes.delete(key);
-              // Recovery owns release even when this mirrored write drained
-              // the last value, so namespace repair cannot lose its owner.
+              this.releaseStagedOwnership(stream, failedRollback);
             }
           })
           .catch((err: unknown) =>

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -298,13 +298,14 @@ interface StreamRecord {
 }
 
 type StagedDeletionPhase = 'live' | 'transitioning' | 'staged' | 'unavailable';
+type StagedRecoveryOutcome = 'discarded' | 'restored' | 'unchanged';
 
 interface StagedDeletionState {
   writes: Map<string, unknown>;
   /** Namespace authority and whether failed ownership may mirror writes. */
   phase: StagedDeletionPhase;
   /** One recovery owns namespace repair and buffered-write replay at a time. */
-  recovery?: Promise<void>;
+  recovery?: Promise<StagedRecoveryOutcome>;
   settled: Promise<void>;
   resolveSettled: () => void;
 }
@@ -982,13 +983,16 @@ export class StreamSnapshotStore {
         const liveDir = streamDataDir(stream);
         const failedWrites = this.failedRollbacks.get(stream);
         if (failedWrites) {
-          const hasLiveData = await storagePathExists(liveDir);
-          const liveWasAuthoritative =
-            failedWrites.phase === 'live' && hasLiveData;
-          await this.recoverFailedRollback(stream, failedWrites);
-          if (liveWasAuthoritative) discarded.push(stream);
-          else if (liveStreams.has(stream)) restored.push(stream);
-          else pendingCleanup.push(stream);
+          const outcome = await this.recoverFailedRollback(
+            stream,
+            failedWrites,
+          );
+          if (outcome === 'discarded') discarded.push(stream);
+          else if (outcome === 'restored' && liveStreams.has(stream)) {
+            restored.push(stream);
+          } else if (outcome === 'restored') {
+            pendingCleanup.push(stream);
+          }
           return;
         }
         const hasLiveData = await storagePathExists(liveDir);
@@ -1058,7 +1062,7 @@ export class StreamSnapshotStore {
   private releaseStagedOwnership(
     stream: StreamTabId,
     state: StagedDeletionState,
-    expectedRecovery: Promise<void> | undefined = undefined,
+    expectedRecovery: Promise<StagedRecoveryOutcome> | undefined = undefined,
   ): void {
     if (state.writes.size > 0 || state.recovery !== expectedRecovery) {
       return;
@@ -1074,8 +1078,8 @@ export class StreamSnapshotStore {
 
   private runStagedRecovery(
     state: StagedDeletionState,
-    recover: () => Promise<void>,
-  ): Promise<void> {
+    recover: () => Promise<StagedRecoveryOutcome>,
+  ): Promise<StagedRecoveryOutcome> {
     if (state.recovery) return state.recovery;
     const recovery = recover();
     const trackedRecovery = recovery.finally(() => {
@@ -1094,9 +1098,12 @@ export class StreamSnapshotStore {
   private recoverFailedRollback(
     stream: StreamTabId,
     state: StagedDeletionState,
-  ): Promise<void> {
-    if (this.failedRollbacks.get(stream) !== state) return Promise.resolve();
+  ): Promise<StagedRecoveryOutcome> {
+    if (this.failedRollbacks.get(stream) !== state) {
+      return Promise.resolve('unchanged');
+    }
     return this.runStagedRecovery(state, async () => {
+      let outcome: StagedRecoveryOutcome = 'unchanged';
       if (canUseStreamDataDir(stream)) {
         const stagedDir = stagedStreamDataDir(stream);
         const liveDir = streamDataDir(stream);
@@ -1109,6 +1116,7 @@ export class StreamSnapshotStore {
         if (liveWasAuthoritative) {
           if (hasStagedData) {
             await StorageFS.delete(stagedDir, { recursive: true });
+            outcome = 'discarded';
           }
         } else if (hasStagedData) {
           state.phase = 'staged';
@@ -1118,6 +1126,7 @@ export class StreamSnapshotStore {
           await StorageFS.ensureDir(STREAM_DATA_DIR);
           state.phase = 'transitioning';
           await StorageFS.rename(stagedDir, liveDir);
+          outcome = 'restored';
           const record = this.records.get(stream);
           if (record) {
             record.kv = undefined;
@@ -1133,6 +1142,7 @@ export class StreamSnapshotStore {
       // state; replay recreates the live directory instead of wedging ownership.
       state.phase = 'live';
       await this.drainStagedWrites(stream, state);
+      return outcome;
     });
   }
 
@@ -1283,9 +1293,10 @@ export class StreamSnapshotStore {
       this.failedRollbacks.set(stream, state);
       try {
         if (state.phase === 'live') {
-          await this.runStagedRecovery(state, () =>
-            this.drainStagedWrites(stream, state),
-          );
+          await this.runStagedRecovery(state, async () => {
+            await this.drainStagedWrites(stream, state);
+            return 'unchanged';
+          });
         } else if (state.phase === 'transitioning') {
           await this.recoverFailedRollback(stream, state);
         }

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -995,14 +995,21 @@ export class StreamSnapshotStore {
     while (state.writes.size > 0) {
       const writes = [...state.writes];
       state.writes.clear();
-      for (const [key, value] of writes) {
-        this.writeUnbuffered(stream, key, value);
+      try {
+        for (const [key, value] of writes) {
+          this.writeUnbuffered(stream, key, value);
+        }
+        await this.flushWritesForStream(stream);
+      } catch (error) {
+        for (const [key, value] of writes) {
+          if (!state.writes.has(key)) state.writes.set(key, value);
+        }
+        throw error;
       }
-      await this.flushWritesForStream(stream);
     }
   }
 
-  /** Release deletion waiters after every terminal transaction path. */
+  /** Release ownership of a stream after its staged transaction finishes. */
   private settleStagedDeletion(
     stream: StreamTabId,
     state: StagedDeletionState,
@@ -1143,6 +1150,9 @@ export class StreamSnapshotStore {
     } catch (error) {
       try {
         await this.replayStagedWrites(stream, state);
+      } catch (replayError) {
+        this.failedRollbacks.set(stream, state);
+        throw replayError;
       } finally {
         this.settleStagedDeletion(stream, state);
       }

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -1279,6 +1279,8 @@ export class StreamSnapshotStore {
       try {
         if (state.phase === 'live') {
           await this.recoverFailedRollback(stream, state, 'known-live');
+        } else if (state.phase === 'transitioning') {
+          await this.recoverFailedRollback(stream, state);
         }
       } catch (recoveryError) {
         failures.push(recoveryError);

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -1142,7 +1142,10 @@ export class StreamSnapshotStore {
         await this.replayStagedWrites(stream, state);
       } catch (replayError) {
         this.failedRollbacks.set(stream, state);
-        throw replayError;
+        throw new AggregateError(
+          [error, replayError],
+          `Failed to stage snapshot deletion for ${stream} and restore buffered writes`,
+        );
       } finally {
         this.settleStagedDeletion(stream, state);
       }

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -967,8 +967,7 @@ export class StreamSnapshotStore {
           const record = this.records.get(stream);
           if (record) record.kv = undefined;
           if (liveStreams.has(stream) && failedWrites) {
-            this.replayStagedWrites(stream, failedWrites);
-            await this.flushWritesForStream(stream);
+            await this.replayStagedWrites(stream, failedWrites);
           }
           this.failedRollbacks.delete(stream);
           if (liveStreams.has(stream)) restored.push(stream);
@@ -978,8 +977,7 @@ export class StreamSnapshotStore {
 
         await StorageFS.delete(stagedDir, { recursive: true });
         if (liveStreams.has(stream) && failedWrites) {
-          this.replayStagedWrites(stream, failedWrites);
-          await this.flushWritesForStream(stream);
+          await this.replayStagedWrites(stream, failedWrites);
         }
         this.failedRollbacks.delete(stream);
         discarded.push(stream);
@@ -990,15 +988,20 @@ export class StreamSnapshotStore {
   }
 
   /** Restore writes buffered behind a staging attempt after live data returns. */
-  private replayStagedWrites(
+  private async replayStagedWrites(
     stream: StreamTabId,
     state: StagedDeletionState,
-  ): void {
+  ): Promise<void> {
+    while (state.writes.size > 0) {
+      const writes = [...state.writes];
+      state.writes.clear();
+      for (const [key, value] of writes) {
+        this.writeUnbuffered(stream, key, value);
+      }
+      await this.flushWritesForStream(stream);
+    }
     if (this.stagedDeletions.get(stream) === state) {
       this.stagedDeletions.delete(stream);
-    }
-    for (const [key, value] of state.writes) {
-      this.write(stream, key, value);
     }
     state.resolveSettled();
   }
@@ -1124,7 +1127,7 @@ export class StreamSnapshotStore {
             if (staged && stagedDir && liveDir) {
               await StorageFS.rename(stagedDir, liveDir);
             }
-            this.replayStagedWrites(stream, state);
+            await this.replayStagedWrites(stream, state);
           } catch (error) {
             this.failedRollbacks.set(stream, state);
             throw error;
@@ -1137,7 +1140,7 @@ export class StreamSnapshotStore {
         },
       };
     } catch (error) {
-      this.replayStagedWrites(stream, state);
+      await this.replayStagedWrites(stream, state);
       throw error;
     }
   }

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -1072,6 +1072,21 @@ export class StreamSnapshotStore {
     }
   }
 
+  private runStagedRecovery(
+    state: StagedDeletionState,
+    recover: () => Promise<void>,
+  ): Promise<void> {
+    if (state.recovery) return state.recovery;
+    const recovery = recover();
+    const trackedRecovery = recovery.finally(() => {
+      if (state.recovery === trackedRecovery) {
+        state.recovery = undefined;
+      }
+    });
+    state.recovery = trackedRecovery;
+    return trackedRecovery;
+  }
+
   /**
    * Repair a failed rollback exactly once, then release its write buffer only
    * after the namespace is live and no buffered values remain.
@@ -1079,13 +1094,10 @@ export class StreamSnapshotStore {
   private recoverFailedRollback(
     stream: StreamTabId,
     state: StagedDeletionState,
-    namespace: 'inspect' | 'known-live' = 'inspect',
   ): Promise<void> {
     if (this.failedRollbacks.get(stream) !== state) return Promise.resolve();
-    if (state.recovery) return state.recovery;
-
-    const recovery = (async () => {
-      if (namespace === 'inspect' && canUseStreamDataDir(stream)) {
+    return this.runStagedRecovery(state, async () => {
+      if (canUseStreamDataDir(stream)) {
         const stagedDir = stagedStreamDataDir(stream);
         const liveDir = streamDataDir(stream);
         const liveWasAuthoritative = state.phase === 'live';
@@ -1121,14 +1133,7 @@ export class StreamSnapshotStore {
       // state; replay recreates the live directory instead of wedging ownership.
       state.phase = 'live';
       await this.drainStagedWrites(stream, state);
-    })();
-    const trackedRecovery = recovery.finally(() => {
-      if (state.recovery === trackedRecovery) {
-        state.recovery = undefined;
-      }
     });
-    state.recovery = trackedRecovery;
-    return trackedRecovery;
   }
 
   /** Release ownership of a stream after its staged transaction finishes. */
@@ -1278,7 +1283,9 @@ export class StreamSnapshotStore {
       this.failedRollbacks.set(stream, state);
       try {
         if (state.phase === 'live') {
-          await this.recoverFailedRollback(stream, state, 'known-live');
+          await this.runStagedRecovery(state, () =>
+            this.drainStagedWrites(stream, state),
+          );
         } else if (state.phase === 'transitioning') {
           await this.recoverFailedRollback(stream, state);
         }

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -1076,7 +1076,7 @@ export class StreamSnapshotStore {
     };
     this.stagedDeletions.set(stream, state);
     let namespaceTransitionStarted = false;
-    let replayAttempted = false;
+    let recoveryReplayInProgress = false;
 
     try {
       const failedState = this.failedRollbacks.get(stream);
@@ -1102,8 +1102,9 @@ export class StreamSnapshotStore {
         } else {
           state.liveStorageAvailable = true;
         }
-        replayAttempted = true;
+        recoveryReplayInProgress = true;
         await this.replayStagedWrites(stream, state);
+        recoveryReplayInProgress = false;
       }
       if (canUseStreamDataDir(stream)) {
         const hasStagedData = await storagePathExists(
@@ -1191,7 +1192,7 @@ export class StreamSnapshotStore {
     } catch (error) {
       const failures: unknown[] = [error];
       try {
-        let canReplay = !replayAttempted;
+        let canReplay = !recoveryReplayInProgress;
         if (
           canReplay &&
           namespaceTransitionStarted &&

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -297,16 +297,16 @@ interface StreamRecord {
   writeKv: KVStore | undefined;
 }
 
+type StagedDeletionPhase =
+  'live' | 'transitioning' | 'staged' | 'unavailable' | 'replaying-recovery';
+
 interface StagedDeletionState {
   writes: Map<string, unknown>;
-  /** Whether failed ownership may safely mirror new writes to the live tree. */
-  liveStorageAvailable: boolean;
+  /** Namespace authority and whether failed ownership may mirror writes. */
+  phase: StagedDeletionPhase;
   settled: Promise<void>;
   resolveSettled: () => void;
 }
-
-type StagedDeletionSetupPhase =
-  'preparing' | 'changing-namespace' | 'replaying-recovery';
 
 export class StreamSnapshotStore {
   private readonly records = new Map<StreamTabId, StreamRecord>();
@@ -982,12 +982,14 @@ export class StreamSnapshotStore {
         const hasLiveData = await storagePathExists(liveDir);
         const failedWrites = this.failedRollbacks.get(stream);
         if (!hasLiveData || failedWrites) {
+          if (failedWrites) failedWrites.phase = 'staged';
           if (hasLiveData) {
             // A failed rollback owner makes the staged tree the complete base;
             // its buffered writes are the newer delta applied below.
             await StorageFS.delete(liveDir, { recursive: true });
           }
           await StorageFS.ensureDir(STREAM_DATA_DIR);
+          if (failedWrites) failedWrites.phase = 'transitioning';
           await StorageFS.rename(stagedDir, liveDir);
           const record = this.records.get(stream);
           if (record) {
@@ -995,10 +997,15 @@ export class StreamSnapshotStore {
             record.writeKv = undefined;
           }
           if (liveStreams.has(stream) && failedWrites) {
-            failedWrites.liveStorageAvailable = true;
+            failedWrites.phase = 'live';
             await this.replayStagedWrites(stream, failedWrites);
           }
-          this.releaseFailedRollbackOwnership(stream, failedWrites);
+          if (
+            failedWrites &&
+            this.failedRollbacks.get(stream) === failedWrites
+          ) {
+            this.failedRollbacks.delete(stream);
+          }
           if (liveStreams.has(stream)) restored.push(stream);
           else pendingCleanup.push(stream);
           return;
@@ -1012,9 +1019,11 @@ export class StreamSnapshotStore {
     await pMap(
       [...this.failedRollbacks],
       async ([stream, state]) => {
-        if (!liveStreams.has(stream) || !state.liveStorageAvailable) return;
+        if (!liveStreams.has(stream) || state.phase !== 'live') return;
         await this.replayStagedWrites(stream, state);
-        this.releaseFailedRollbackOwnership(stream, state);
+        if (this.failedRollbacks.get(stream) === state) {
+          this.failedRollbacks.delete(stream);
+        }
       },
       { concurrency: SEED_IO_CONCURRENCY },
     );
@@ -1039,15 +1048,6 @@ export class StreamSnapshotStore {
         }
         throw error;
       }
-    }
-  }
-
-  private releaseFailedRollbackOwnership(
-    stream: StreamTabId,
-    state: StagedDeletionState | undefined,
-  ): void {
-    if (state && this.failedRollbacks.get(stream) === state) {
-      this.failedRollbacks.delete(stream);
     }
   }
 
@@ -1081,12 +1081,11 @@ export class StreamSnapshotStore {
     });
     const state: StagedDeletionState = {
       writes: new Map(),
-      liveStorageAvailable: true,
+      phase: 'live',
       settled: settlement,
       resolveSettled,
     };
     this.stagedDeletions.set(stream, state);
-    let setupPhase: StagedDeletionSetupPhase = 'preparing';
 
     try {
       const failedState = this.failedRollbacks.get(stream);
@@ -1097,37 +1096,37 @@ export class StreamSnapshotStore {
           if (!state.writes.has(key)) state.writes.set(key, value);
         }
         this.failedRollbacks.delete(stream);
-        setupPhase = 'changing-namespace';
+        state.phase = failedState.phase;
         const stagedDir = stagedStreamDataDir(stream);
         const liveDir = streamDataDir(stream);
         if (await storagePathExists(stagedDir)) {
-          state.liveStorageAvailable = false;
+          state.phase = 'staged';
           if (await storagePathExists(liveDir)) {
             // Writes after the failure stayed buffered, so the staged tree is
             // the last complete on-disk snapshot and remains authoritative.
             await StorageFS.delete(liveDir, { recursive: true });
           }
+          state.phase = 'transitioning';
           await StorageFS.rename(stagedDir, liveDir);
-          state.liveStorageAvailable = true;
+          state.phase = 'live';
         } else {
-          state.liveStorageAvailable = true;
+          state.phase = 'live';
         }
-        setupPhase = 'replaying-recovery';
+        state.phase = 'replaying-recovery';
         await this.replayStagedWrites(stream, state);
-        setupPhase = 'preparing';
+        state.phase = 'live';
       }
       if (canUseStreamDataDir(stream)) {
         const hasStagedData = await storagePathExists(
           stagedStreamDataDir(stream),
         );
         if (hasStagedData) {
-          setupPhase = 'changing-namespace';
-          state.liveStorageAvailable = false;
+          state.phase = 'staged';
           throw new Error(
             `Stream ${stream} has an unreconciled snapshot deletion`,
           );
         }
-        state.liveStorageAvailable = true;
+        state.phase = 'live';
       }
       // Let hydration finish before staging. A record with `seeded === false`
       // may already contain sidecars while execution-config hydration is still
@@ -1148,15 +1147,13 @@ export class StreamSnapshotStore {
       const canStage = canUseStreamDataDir(stream);
       const liveDir = canStage ? streamDataDir(stream) : undefined;
       const stagedDir = canStage ? stagedStreamDataDir(stream) : undefined;
-      let staged = false;
       const hasLiveData =
         !liveDir || !stagedDir || (await storagePathExists(liveDir));
       if (liveDir && stagedDir && hasLiveData) {
         await StorageFS.ensureDir(STREAM_DATA_DELETION_DIR);
-        state.liveStorageAvailable = false;
-        setupPhase = 'changing-namespace';
+        state.phase = 'transitioning';
         await StorageFS.rename(liveDir, stagedDir);
-        staged = true;
+        state.phase = 'staged';
       }
 
       let settled = false;
@@ -1164,10 +1161,12 @@ export class StreamSnapshotStore {
         commit: async () => {
           if (settled) return;
           settled = true;
-          this.failedRollbacks.delete(stream);
+          if (this.failedRollbacks.get(stream) === state) {
+            this.failedRollbacks.delete(stream);
+          }
           this.evict(stream);
           try {
-            if (staged && stagedDir) {
+            if (state.phase === 'staged' && stagedDir) {
               try {
                 await StorageFS.delete(stagedDir, { recursive: true });
               } catch (error) {
@@ -1186,9 +1185,10 @@ export class StreamSnapshotStore {
           if (settled) return;
           settled = true;
           try {
-            if (staged && stagedDir && liveDir) {
+            if (state.phase === 'staged' && stagedDir && liveDir) {
+              state.phase = 'transitioning';
               await StorageFS.rename(stagedDir, liveDir);
-              state.liveStorageAvailable = true;
+              state.phase = 'live';
             }
             await this.replayStagedWrites(stream, state);
           } catch (error) {
@@ -1202,26 +1202,25 @@ export class StreamSnapshotStore {
     } catch (error) {
       const failures: unknown[] = [error];
       try {
-        let canReplay = setupPhase !== 'replaying-recovery';
-        if (
-          canReplay &&
-          setupPhase === 'changing-namespace' &&
-          canUseStreamDataDir(stream)
-        ) {
-          state.liveStorageAvailable = false;
-          const [hasLiveData, hasStagedData] = await Promise.all([
-            storagePathExists(streamDataDir(stream)),
-            storagePathExists(stagedStreamDataDir(stream)),
-          ]);
-          canReplay = hasLiveData && !hasStagedData;
-          state.liveStorageAvailable = canReplay;
-        } else if (canReplay) {
-          state.liveStorageAvailable = true;
-        }
-        if (canReplay) {
-          await this.replayStagedWrites(stream, state);
-        } else {
+        if (state.phase === 'replaying-recovery') {
+          state.phase = 'live';
           this.failedRollbacks.set(stream, state);
+        } else {
+          if (state.phase !== 'live' && canUseStreamDataDir(stream)) {
+            state.phase = 'transitioning';
+            const [hasLiveData, hasStagedData] = await Promise.all([
+              storagePathExists(streamDataDir(stream)),
+              storagePathExists(stagedStreamDataDir(stream)),
+            ]);
+            if (hasStagedData) state.phase = 'staged';
+            else if (hasLiveData) state.phase = 'live';
+            else state.phase = 'unavailable';
+          }
+          if (state.phase === 'live') {
+            await this.replayStagedWrites(stream, state);
+          } else {
+            this.failedRollbacks.set(stream, state);
+          }
         }
       } catch (recoveryError) {
         this.failedRollbacks.set(stream, state);
@@ -1521,7 +1520,7 @@ export class StreamSnapshotStore {
     const failedRollback = this.failedRollbacks.get(stream);
     if (failedRollback) {
       failedRollback.writes.set(key, value);
-      if (failedRollback.liveStorageAvailable) {
+      if (failedRollback.phase === 'live') {
         void this.queueWrite(stream, key, value)
           .then(() => {
             if (

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -299,6 +299,7 @@ interface StreamRecord {
 
 interface StagedDeletionState {
   writes: Map<string, unknown>;
+  /** Whether failed ownership may safely mirror new writes to the live tree. */
   liveStorageAvailable: boolean;
   settled: Promise<void>;
   resolveSettled: () => void;
@@ -1038,20 +1039,6 @@ export class StreamSnapshotStore {
     state.resolveSettled();
   }
 
-  /** Retain the latest buffered values until a later deletion retry. */
-  private retainFailedRollback(
-    stream: StreamTabId,
-    state: StagedDeletionState,
-  ): void {
-    const prior = this.failedRollbacks.get(stream);
-    if (prior && prior !== state) {
-      for (const [key, value] of prior.writes) {
-        if (!state.writes.has(key)) state.writes.set(key, value);
-      }
-    }
-    this.failedRollbacks.set(stream, state);
-  }
-
   /**
    * Atomically move a stream's sidecars out of the live namespace while
    * keeping its in-memory record available until the transcript registry
@@ -1076,32 +1063,42 @@ export class StreamSnapshotStore {
       resolveSettled,
     };
     this.stagedDeletions.set(stream, state);
+    let namespaceTransitionStarted = false;
+    let replayAttempted = false;
 
     try {
       const failedState = this.failedRollbacks.get(stream);
       if (failedState) {
+        // Transfer ownership before the first await so new writes cannot slip
+        // between the failed transaction and its retry.
+        for (const [key, value] of failedState.writes) {
+          if (!state.writes.has(key)) state.writes.set(key, value);
+        }
+        this.failedRollbacks.delete(stream);
+        namespaceTransitionStarted = true;
         const stagedDir = stagedStreamDataDir(stream);
         const liveDir = streamDataDir(stream);
         if (await storagePathExists(stagedDir)) {
           state.liveStorageAvailable = false;
           if (await storagePathExists(liveDir)) {
-            throw new Error(
-              `Cannot retry snapshot deletion for ${stream}; both live and staged directories exist`,
-            );
+            // Writes after the failure stayed buffered, so the staged tree is
+            // the last complete on-disk snapshot and remains authoritative.
+            await StorageFS.delete(liveDir, { recursive: true });
           }
           await StorageFS.rename(stagedDir, liveDir);
           state.liveStorageAvailable = true;
         } else {
           state.liveStorageAvailable = true;
         }
-        for (const [key, value] of failedState.writes) {
-          if (!state.writes.has(key)) state.writes.set(key, value);
-        }
+        replayAttempted = true;
         await this.replayStagedWrites(stream, state);
-        this.failedRollbacks.delete(stream);
       }
       if (canUseStreamDataDir(stream)) {
-        if (await storagePathExists(stagedStreamDataDir(stream))) {
+        const hasStagedData = await storagePathExists(
+          stagedStreamDataDir(stream),
+        );
+        if (hasStagedData) {
+          namespaceTransitionStarted = true;
           state.liveStorageAvailable = false;
           throw new Error(
             `Stream ${stream} has an unreconciled snapshot deletion`,
@@ -1129,9 +1126,12 @@ export class StreamSnapshotStore {
       const liveDir = canStage ? streamDataDir(stream) : undefined;
       const stagedDir = canStage ? stagedStreamDataDir(stream) : undefined;
       let staged = false;
-      if (liveDir && stagedDir && (await storagePathExists(liveDir))) {
+      const hasLiveData =
+        !liveDir || !stagedDir || (await storagePathExists(liveDir));
+      if (liveDir && stagedDir && hasLiveData) {
         await StorageFS.ensureDir(STREAM_DATA_DELETION_DIR);
         state.liveStorageAvailable = false;
+        namespaceTransitionStarted = true;
         await StorageFS.rename(liveDir, stagedDir);
         staged = true;
       }
@@ -1169,7 +1169,7 @@ export class StreamSnapshotStore {
             }
             await this.replayStagedWrites(stream, state);
           } catch (error) {
-            this.retainFailedRollback(stream, state);
+            this.failedRollbacks.set(stream, state);
             throw error;
           } finally {
             this.settleStagedDeletion(stream, state);
@@ -1179,19 +1179,29 @@ export class StreamSnapshotStore {
     } catch (error) {
       const failures: unknown[] = [error];
       try {
-        const canInspectStaging = canUseStreamDataDir(stream);
-        state.liveStorageAvailable = !canInspectStaging;
-        const snapshotRemainsStaged =
-          canInspectStaging &&
-          (await storagePathExists(stagedStreamDataDir(stream)));
-        state.liveStorageAvailable = !snapshotRemainsStaged;
-        if (snapshotRemainsStaged) {
-          this.retainFailedRollback(stream, state);
-        } else {
+        let canReplay = !replayAttempted;
+        if (
+          canReplay &&
+          namespaceTransitionStarted &&
+          canUseStreamDataDir(stream)
+        ) {
+          state.liveStorageAvailable = false;
+          const [hasLiveData, hasStagedData] = await Promise.all([
+            storagePathExists(streamDataDir(stream)),
+            storagePathExists(stagedStreamDataDir(stream)),
+          ]);
+          canReplay = hasLiveData && !hasStagedData;
+          state.liveStorageAvailable = canReplay;
+        } else if (canReplay) {
+          state.liveStorageAvailable = true;
+        }
+        if (canReplay) {
           await this.replayStagedWrites(stream, state);
+        } else {
+          this.failedRollbacks.set(stream, state);
         }
       } catch (recoveryError) {
-        this.retainFailedRollback(stream, state);
+        this.failedRollbacks.set(stream, state);
         failures.push(recoveryError);
       } finally {
         this.settleStagedDeletion(stream, state);

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -1042,8 +1042,8 @@ export class StreamSnapshotStore {
     }
   }
 
-  /** Drain a failed owner's buffer and release it without an await-sized gap. */
-  private async drainFailedRollbackWrites(
+  /** Drain buffered writes and release every owner without an await-sized gap. */
+  private async drainStagedWrites(
     stream: StreamTabId,
     state: StagedDeletionState,
   ): Promise<void> {
@@ -1052,6 +1052,10 @@ export class StreamSnapshotStore {
       if (state.writes.size > 0) continue;
       if (this.failedRollbacks.get(stream) === state) {
         this.failedRollbacks.delete(stream);
+      }
+      if (this.stagedDeletions.get(stream) === state) {
+        this.stagedDeletions.delete(stream);
+        state.resolveSettled();
       }
       return;
     }
@@ -1104,7 +1108,7 @@ export class StreamSnapshotStore {
       }
 
       state.phase = 'live';
-      await this.drainFailedRollbackWrites(stream, state);
+      await this.drainStagedWrites(stream, state);
     })();
     const trackedRecovery = recovery.finally(() => {
       if (state.recovery === trackedRecovery) state.recovery = undefined;
@@ -1226,7 +1230,7 @@ export class StreamSnapshotStore {
               await StorageFS.rename(stagedDir, liveDir);
               state.phase = 'live';
             }
-            await this.replayStagedWrites(stream, state);
+            await this.drainStagedWrites(stream, state);
           } catch (error) {
             const failures: unknown[] = [error];
             if (state.phase !== 'live' && canUseStreamDataDir(stream)) {
@@ -1260,7 +1264,7 @@ export class StreamSnapshotStore {
       this.failedRollbacks.set(stream, state);
       try {
         if (state.phase === 'live') {
-          await this.drainFailedRollbackWrites(stream, state);
+          await this.drainStagedWrites(stream, state);
         }
       } catch (recoveryError) {
         failures.push(recoveryError);

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -294,6 +294,7 @@ interface StreamRecord {
 
   // -- Cached KVStore handle for this stream's sidecar directory. ----------
   kv: KVStore | undefined;
+  writeKv: KVStore | undefined;
 }
 
 interface StagedDeletionState {
@@ -346,6 +347,7 @@ export class StreamSnapshotStore {
         compileFailuresOverlay: undefined,
         usageOverlay: undefined,
         kv: undefined,
+        writeKv: undefined,
       };
       this.records.set(stream, record);
     }
@@ -355,11 +357,20 @@ export class StreamSnapshotStore {
   private kv(streamId: StreamTabId): KVStore {
     const record = this.getOrCreateRecord(streamId);
     if (!record.kv) {
-      record.kv = new KVStore(streamDataDir(streamId), {
+      record.kv = new KVStore(streamDataDir(streamId));
+    }
+    return record.kv;
+  }
+
+  /** Strict write handle; read callers retain the KV store's fallback policy. */
+  private writeKv(streamId: StreamTabId): KVStore {
+    const record = this.getOrCreateRecord(streamId);
+    if (!record.writeKv) {
+      record.writeKv = new KVStore(streamDataDir(streamId), {
         throwOnErrors: true,
       });
     }
-    return record.kv;
+    return record.writeKv;
   }
 
   private async listStreamsUnder(root: string): Promise<StreamTabId[]> {
@@ -967,7 +978,10 @@ export class StreamSnapshotStore {
           await StorageFS.ensureDir(STREAM_DATA_DIR);
           await StorageFS.rename(stagedDir, liveDir);
           const record = this.records.get(stream);
-          if (record) record.kv = undefined;
+          if (record) {
+            record.kv = undefined;
+            record.writeKv = undefined;
+          }
           if (liveStreams.has(stream) && failedWrites) {
             await this.replayStagedWrites(stream, failedWrites);
           }
@@ -1465,7 +1479,7 @@ export class StreamSnapshotStore {
       // would re-create the `streamData/{id}/` dir `deleteDir()` just removed.
       if (!this.writeMutexes.has(chainKey)) return;
       if (this.streamVersion(stream) !== version) return;
-      return this.kv(stream).write(key, value);
+      return this.writeKv(stream).write(key, value);
     });
   }
 

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -1035,6 +1035,20 @@ export class StreamSnapshotStore {
     state.resolveSettled();
   }
 
+  /** Retain the latest buffered values until a later deletion retry. */
+  private retainFailedRollback(
+    stream: StreamTabId,
+    state: StagedDeletionState,
+  ): void {
+    const prior = this.failedRollbacks.get(stream);
+    if (prior && prior !== state) {
+      for (const [key, value] of prior.writes) {
+        if (!state.writes.has(key)) state.writes.set(key, value);
+      }
+    }
+    this.failedRollbacks.set(stream, state);
+  }
+
   /**
    * Atomically move a stream's sidecars out of the live namespace while
    * keeping its in-memory record available until the transcript registry
@@ -1072,11 +1086,11 @@ export class StreamSnapshotStore {
           }
           await StorageFS.rename(stagedDir, liveDir);
         }
-        this.failedRollbacks.delete(stream);
         for (const [key, value] of failedState.writes) {
           if (!state.writes.has(key)) state.writes.set(key, value);
         }
         await this.replayStagedWrites(stream, state);
+        this.failedRollbacks.delete(stream);
       }
       if (
         canUseStreamDataDir(stream) &&
@@ -1144,7 +1158,7 @@ export class StreamSnapshotStore {
             }
             await this.replayStagedWrites(stream, state);
           } catch (error) {
-            this.failedRollbacks.set(stream, state);
+            this.retainFailedRollback(stream, state);
             throw error;
           } finally {
             this.settleStagedDeletion(stream, state);
@@ -1152,16 +1166,27 @@ export class StreamSnapshotStore {
         },
       };
     } catch (error) {
+      const failures: unknown[] = [error];
       try {
-        await this.replayStagedWrites(stream, state);
-      } catch (replayError) {
-        this.failedRollbacks.set(stream, state);
-        throw new AggregateError(
-          [error, replayError],
-          `Failed to stage snapshot deletion for ${stream} and restore buffered writes`,
-        );
+        const snapshotRemainsStaged =
+          canUseStreamDataDir(stream) &&
+          (await storagePathExists(stagedStreamDataDir(stream)));
+        if (snapshotRemainsStaged) {
+          this.retainFailedRollback(stream, state);
+        } else {
+          await this.replayStagedWrites(stream, state);
+        }
+      } catch (recoveryError) {
+        this.retainFailedRollback(stream, state);
+        failures.push(recoveryError);
       } finally {
         this.settleStagedDeletion(stream, state);
+      }
+      if (failures.length > 1) {
+        throw new AggregateError(
+          failures,
+          `Failed to stage snapshot deletion for ${stream} and restore buffered writes`,
+        );
       }
       throw error;
     }
@@ -1441,7 +1466,8 @@ export class StreamSnapshotStore {
   }
 
   private write(stream: StreamTabId, key: string, value: unknown): void {
-    const stagedDeletion = this.stagedDeletions.get(stream);
+    const stagedDeletion =
+      this.stagedDeletions.get(stream) ?? this.failedRollbacks.get(stream);
     if (stagedDeletion) {
       stagedDeletion.writes.set(key, value);
       return;
@@ -1629,7 +1655,10 @@ export class StreamSnapshotStore {
       await this.flushWritesForStream(stream);
       if (this.streamVersion(stream) !== version) return;
       const record = this.records.get(stream);
-      if (record) record.kv = undefined;
+      if (record) {
+        record.kv = undefined;
+        record.writeKv = undefined;
+      }
       const data = await readStreamData(this.kv(stream));
       if (this.streamVersion(stream) !== version) return;
       await this.applyStreamData(stream, data);


### PR DESCRIPTION
## Summary

- reconcile interrupted snapshot staging before bulk and orphan cleanup
- preserve buffered sidecar writes across rollback failure and retry
- keep overlapping deletion waiters blocked until rollback writes are durable

Follow-up to #8668. That PR was merged while these final transaction-lifecycle fixes were still being validated.

## Root cause

A staged snapshot directory was treated as an implementation detail rather than a complete per-stream transaction state. Recovery, retry, bulk cleanup, and concurrent writes could therefore observe different partial states. This follow-up centralizes reconciliation in `SessionStores` and keeps the staging owner responsible until rollback data is durably restored.

## Validation

- 8 focused Vitest files: 266 tests passed
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; one unrelated pre-existing warning)
- `npm run check:dead-code-ratchet`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches durable stream/execution cleanup and on-disk transaction boundaries; behavior is heavily tested but mistakes could leak orphaned sidecars or lose buffered snapshot writes.
> 
> **Overview**
> Hardens **staged stream snapshot deletion** so interrupted commits, rollbacks, and overlapping cleanup see one consistent transaction state instead of partial live/staged directories.
> 
> **`SessionStores`** now runs **`reconcileStagedDeletions`** before orphan sweep and bulk delete (startup load no longer reconciles on its own). That lets same-session **`clearAll`** finish residue left when staged-dir delete fails after commit, without a reload.
> 
> **`StreamSnapshotStore`** tracks deletion **phase** and serialized **recovery**, centralizes **`recoverFailedRollback`**, and **drains/replays buffered sidecar writes** only after the live namespace is repaired. Persistence uses a strict **`writeKv`** and **`queueWrite`** promises so rollback replay and **`flush`** can await durability; failed-rollbacks can mirror writes when ownership is live. Staging retries wait on in-flight recovery, and setup/rollback failures surface **`AggregateError`** where both the primary op and recovery fail.
> 
> Vitest adds broad coverage for disk/rename failures, concurrent staging, and reconciliation outcomes (restore vs discard).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aeeed14f590e5e9622bfb9ba0d61794594dd9df4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->