### PR TITLE
feat(cli): show workflow script progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Workflow-script progress is visible in the CLI** — delegated workflow
+  phases, script log messages, and per-step cost summaries now remain in
+  terminal scrollback beneath the workflow call that produced them.
 - **Full tool output stays in terminal scrollback** — press Ctrl-T to print the
   focused session's complete output once without leaving the chat, or press v
   on a selected child session. Long output remains searchable and available to

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -39,7 +39,7 @@ import { EntryErrorBoundary } from './EntryErrorBoundary';
 import { isStaticTranscriptEntryAt } from './transcriptEntries';
 import { TranscriptEntry } from './TranscriptEntry';
 import { ToolUseRow } from './ToolUseRow';
-import { toolUseDisplayLines } from './toolRenderers';
+import { toolUseDisplayLines, toolUseMarginBottomRows } from './toolRenderers';
 import {
   transcriptColumns,
   transcriptEntryLayout,
@@ -236,8 +236,9 @@ function staticTranscriptItemRowCount(
       1 +
       toolUseDisplayLines(item.entry.toolUse, {
         showOutput: true,
-        width,
-      }).slice(1).length
+        width: transcriptColumns(width, 2),
+      }).slice(1).length +
+      toolUseMarginBottomRows(item.entry.toolUse)
     );
   }
   return transcriptEntryLayoutRows(
@@ -301,21 +302,23 @@ function StaticTranscriptItemContent({
     case 'workflowScriptCompletion':
       return (
         <EntryErrorBoundary label="workflow script result">
-          <Box flexDirection="column" paddingLeft={2}>
-            <Text
-              color={
-                item.entry.workflowScriptOutcome === 'failed'
-                  ? COLOR_ERROR
-                  : COLOR_SUCCESS
-              }
-            >
-              {`${TOOL_OUTPUT_CORNER} ${item.entry.workflowScriptOutcome === 'failed' ? 'Workflow script failed' : 'Workflow script completed'}`}
-            </Text>
+          <Box flexDirection="column">
+            <Box paddingLeft={2}>
+              <Text
+                color={
+                  item.entry.workflowScriptOutcome === 'failed'
+                    ? COLOR_ERROR
+                    : COLOR_SUCCESS
+                }
+              >
+                {`${TOOL_OUTPUT_CORNER} ${item.entry.workflowScriptOutcome === 'failed' ? 'Workflow script failed' : 'Workflow script completed'}`}
+              </Text>
+            </Box>
             <ToolUseRow
               omitHeader
               showOutput
               toolUse={item.entry.toolUse}
-              width={width}
+              width={transcriptColumns(width, 2)}
             />
           </Box>
         </EntryErrorBoundary>

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -10,7 +10,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { Box, Static, Text } from 'ink';
 
 import { shortCliApiMode } from '@cli/runtime/apiAccessMode';
-import { TOOL_USE_STATUS, type StreamTabId } from '@shared/schemas';
+import type { StreamTabId } from '@shared/schemas';
 import { safeHomedir } from '@utils/system/platformPaths';
 
 import { wrapAnsiToWidth } from '../render/ansiWrap';
@@ -33,7 +33,7 @@ import {
   type TranscriptPrintRequest,
 } from '../state/transcriptLines';
 import { useSignal } from '../state/useSignal';
-import { COLOR_HINT } from '../ui/colors';
+import { COLOR_ERROR, COLOR_HINT, COLOR_SUCCESS } from '../ui/colors';
 import { TOOL_OUTPUT_CORNER } from '../ui/glyphs';
 import { EntryErrorBoundary } from './EntryErrorBoundary';
 import { isStaticTranscriptEntryAt } from './transcriptEntries';
@@ -232,9 +232,12 @@ function staticTranscriptItemRowCount(
       .length;
   }
   if (item.kind === 'workflowScriptCompletion') {
-    return Math.max(
-      1,
-      toolUseDisplayLines(item.entry.toolUse, { width }).slice(1).length,
+    return (
+      1 +
+      toolUseDisplayLines(item.entry.toolUse, {
+        showOutput: true,
+        width,
+      }).slice(1).length
     );
   }
   return transcriptEntryLayoutRows(
@@ -298,7 +301,23 @@ function StaticTranscriptItemContent({
     case 'workflowScriptCompletion':
       return (
         <EntryErrorBoundary label="workflow script result">
-          <ToolUseRow omitHeader toolUse={item.entry.toolUse} width={width} />
+          <Box flexDirection="column" paddingLeft={2}>
+            <Text
+              color={
+                item.entry.workflowScriptOutcome === 'failed'
+                  ? COLOR_ERROR
+                  : COLOR_SUCCESS
+              }
+            >
+              {`${TOOL_OUTPUT_CORNER} ${item.entry.workflowScriptOutcome === 'failed' ? 'Workflow script failed' : 'Workflow script completed'}`}
+            </Text>
+            <ToolUseRow
+              omitHeader
+              showOutput
+              toolUse={item.entry.toolUse}
+              width={width}
+            />
+          </Box>
         </EntryErrorBoundary>
       );
   }
@@ -416,10 +435,7 @@ export function appendStaticTranscriptItems({
       }
     }
     const completionId = `${entry.id}:completion`;
-    if (
-      entry.toolUse.status === TOOL_USE_STATUS.COMPLETED &&
-      !seen.has(completionId)
-    ) {
+    if (entry.workflowScriptOutcome !== undefined && !seen.has(completionId)) {
       appendItem({
         id: completionId,
         kind: 'workflowScriptCompletion',

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -10,15 +10,17 @@ import { useEffect, useMemo, useState } from 'react';
 import { Box, Static, Text } from 'ink';
 
 import { shortCliApiMode } from '@cli/runtime/apiAccessMode';
-import type { StreamTabId } from '@shared/schemas';
+import { TOOL_USE_STATUS, type StreamTabId } from '@shared/schemas';
 import { safeHomedir } from '@utils/system/platformPaths';
 
+import { wrapAnsiToWidth } from '../render/ansiWrap';
 import {
   sessionMeta as sessionMetaSignal,
   streams as streamsSignal,
   type ConversationEntry,
   type SessionMeta,
   type StreamSlice,
+  type WorkflowScriptProgressFact,
 } from '../state/cliState';
 import {
   childStreamEntries as childStreamEntriesSignal,
@@ -32,14 +34,26 @@ import {
 } from '../state/transcriptLines';
 import { useSignal } from '../state/useSignal';
 import { COLOR_HINT } from '../ui/colors';
+import { TOOL_OUTPUT_CORNER } from '../ui/glyphs';
 import { EntryErrorBoundary } from './EntryErrorBoundary';
 import { isStaticTranscriptEntryAt } from './transcriptEntries';
 import { TranscriptEntry } from './TranscriptEntry';
+import { ToolUseRow } from './ToolUseRow';
+import { toolUseDisplayLines } from './toolRenderers';
 import {
   transcriptColumns,
   transcriptEntryLayout,
   transcriptEntryLayoutRows,
 } from './transcriptEntryLayout';
+
+type WorkflowScriptToolEntry = Extract<ConversationEntry, { role: 'tool' }>;
+
+function workflowScriptFactDisplayLine(
+  fact: WorkflowScriptProgressFact,
+): string {
+  if (fact.type === 'phase') return `${TOOL_OUTPUT_CORNER} ${fact.label}`;
+  return `${fact.phaseId ? '  ' : `${TOOL_OUTPUT_CORNER} `}${fact.message}`;
+}
 
 export type StaticTranscriptItem =
   | {
@@ -58,6 +72,16 @@ export type StaticTranscriptItem =
       readonly id: string;
       readonly kind: 'printedTranscript';
       readonly request: TranscriptPrintRequest;
+    }
+  | {
+      readonly id: string;
+      readonly kind: 'workflowScriptFact';
+      readonly fact: WorkflowScriptProgressFact;
+    }
+  | {
+      readonly id: string;
+      readonly kind: 'workflowScriptCompletion';
+      readonly entry: WorkflowScriptToolEntry;
     };
 
 interface StaticTranscriptState {
@@ -202,6 +226,17 @@ function staticTranscriptItemRowCount(
       request: item.request,
     }).split('\n').length;
   }
+  if (item.kind === 'workflowScriptFact') {
+    const line = workflowScriptFactDisplayLine(item.fact);
+    return wrapAnsiToWidth(line, transcriptColumns(width, 2)).split('\n')
+      .length;
+  }
+  if (item.kind === 'workflowScriptCompletion') {
+    return Math.max(
+      1,
+      toolUseDisplayLines(item.entry.toolUse, { width }).slice(1).length,
+    );
+  }
   return transcriptEntryLayoutRows(
     transcriptEntryLayout(item.entry, {
       mode: 'scrollback-budget',
@@ -250,6 +285,20 @@ function StaticTranscriptItemContent({
               request: item.request,
             })}
           </Text>
+        </EntryErrorBoundary>
+      );
+    case 'workflowScriptFact':
+      return (
+        <EntryErrorBoundary label="workflow script progress">
+          <Box paddingLeft={2}>
+            <Text dimColor>{workflowScriptFactDisplayLine(item.fact)}</Text>
+          </Box>
+        </EntryErrorBoundary>
+      );
+    case 'workflowScriptCompletion':
+      return (
+        <EntryErrorBoundary label="workflow script result">
+          <ToolUseRow omitHeader toolUse={item.entry.toolUse} width={width} />
         </EntryErrorBoundary>
       );
   }
@@ -328,10 +377,8 @@ export function appendStaticTranscriptItems({
     ? streams.get(scrollbackStreamId)
     : undefined;
   const entries = slice?.entries ?? [];
-  const finalizedEntries = entries.filter(
-    (entry, index) =>
-      isStaticTranscriptEntryAt(entries, index, slice?.status) &&
-      !seen.has(entry.id),
+  const staticEntries = entries.filter((entry, index) =>
+    isStaticTranscriptEntryAt(entries, index, slice?.status),
   );
   const unseenRequests = printRequests.filter(
     (request) => !seen.has(request.id),
@@ -355,10 +402,29 @@ export function appendStaticTranscriptItems({
     if (anchored) anchored.push(request);
     else requestsByUnseenAnchor.set(request.afterEntryId, [request]);
   }
-  for (const entry of finalizedEntries) {
-    appendItem({ id: entry.id, kind: 'entry', entry });
+  for (const entry of staticEntries) {
+    if (!seen.has(entry.id)) {
+      appendItem({ id: entry.id, kind: 'entry', entry });
+    }
     for (const request of requestsByUnseenAnchor.get(entry.id) ?? []) {
       appendItem({ id: request.id, kind: 'printedTranscript', request });
+    }
+    if (entry.role !== 'tool' || !entry.workflowScriptFacts) continue;
+    for (const fact of entry.workflowScriptFacts) {
+      if (!seen.has(fact.id)) {
+        appendItem({ id: fact.id, kind: 'workflowScriptFact', fact });
+      }
+    }
+    const completionId = `${entry.id}:completion`;
+    if (
+      entry.toolUse.status === TOOL_USE_STATUS.COMPLETED &&
+      !seen.has(completionId)
+    ) {
+      appendItem({
+        id: completionId,
+        kind: 'workflowScriptCompletion',
+        entry,
+      });
     }
   }
   // A legacy or externally restored request may name an entry no longer in

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -271,6 +271,20 @@ function StaticTranscriptItemContent({
         </EntryErrorBoundary>
       );
     case 'entry':
+      if (
+        item.entry.role === 'tool' &&
+        item.entry.workflowScriptFacts !== undefined
+      ) {
+        return (
+          <EntryErrorBoundary label="workflow script">
+            <ToolUseRow
+              neutralStatus
+              toolUse={item.entry.toolUse}
+              width={width}
+            />
+          </EntryErrorBoundary>
+        );
+      }
       return (
         <EntryErrorBoundary label={item.entry.role}>
           <TranscriptEntry

--- a/packages/cli/src/chat/tui/panes/ToolUseRow.tsx
+++ b/packages/cli/src/chat/tui/panes/ToolUseRow.tsx
@@ -120,14 +120,17 @@ function toolDisplayViewport(
 // re-rendering every settled tool row in the live region.
 export const ToolUseRow = memo(function ToolUseRow({
   maxRows,
+  omitHeader,
   toolUse,
   width,
 }: {
   readonly maxRows?: number;
+  readonly omitHeader?: boolean;
   readonly toolUse: NormalizedToolUse;
   readonly width?: number;
 }): React.JSX.Element {
-  const lines = toolUseStyledLines(toolUse, { width });
+  const allLines = toolUseStyledLines(toolUse, { width });
+  const lines = omitHeader === true ? allLines.slice(1) : allLines;
   const viewport = toolDisplayViewport(lines, maxRows);
   return (
     <Box
@@ -149,7 +152,7 @@ export const ToolUseRow = memo(function ToolUseRow({
             key={index}
             flexDirection="row"
             flexWrap="nowrap"
-            paddingLeft={index === 0 ? 0 : 2}
+            paddingLeft={omitHeader === true || index !== 0 ? 2 : 0}
           >
             {line.spans.map((span, spanIndex) => (
               <Text key={spanIndex} {...toolDisplaySpanTextProps(span)}>

--- a/packages/cli/src/chat/tui/panes/ToolUseRow.tsx
+++ b/packages/cli/src/chat/tui/panes/ToolUseRow.tsx
@@ -121,15 +121,17 @@ function toolDisplayViewport(
 export const ToolUseRow = memo(function ToolUseRow({
   maxRows,
   omitHeader,
+  showOutput,
   toolUse,
   width,
 }: {
   readonly maxRows?: number;
   readonly omitHeader?: boolean;
+  readonly showOutput?: boolean;
   readonly toolUse: NormalizedToolUse;
   readonly width?: number;
 }): React.JSX.Element {
-  const allLines = toolUseStyledLines(toolUse, { width });
+  const allLines = toolUseStyledLines(toolUse, { showOutput, width });
   const lines = omitHeader === true ? allLines.slice(1) : allLines;
   const viewport = toolDisplayViewport(lines, maxRows);
   return (

--- a/packages/cli/src/chat/tui/panes/ToolUseRow.tsx
+++ b/packages/cli/src/chat/tui/panes/ToolUseRow.tsx
@@ -120,18 +120,24 @@ function toolDisplayViewport(
 // re-rendering every settled tool row in the live region.
 export const ToolUseRow = memo(function ToolUseRow({
   maxRows,
+  neutralStatus,
   omitHeader,
   showOutput,
   toolUse,
   width,
 }: {
   readonly maxRows?: number;
+  readonly neutralStatus?: boolean;
   readonly omitHeader?: boolean;
   readonly showOutput?: boolean;
   readonly toolUse: NormalizedToolUse;
   readonly width?: number;
 }): React.JSX.Element {
-  const allLines = toolUseStyledLines(toolUse, { showOutput, width });
+  const allLines = toolUseStyledLines(toolUse, {
+    neutralStatus,
+    showOutput,
+    width,
+  });
   const lines = omitHeader === true ? allLines.slice(1) : allLines;
   const viewport = toolDisplayViewport(lines, maxRows);
   return (

--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -114,6 +114,8 @@ export interface DisplayLineOptions {
   /** When false, emit the full output instead of the head+tail slice.
    *  The ctrl+t print path sets this to include everything. */
   readonly elide?: boolean;
+  /** Include raw output for a caller with an explicit result surface. */
+  readonly showOutput?: boolean;
   /** Terminal columns when the projection must match rich rendered rows. */
   readonly width?: number;
 }
@@ -397,12 +399,13 @@ function buildStyledLines(
     opts.preferInputPreview,
   );
 
-  const output = opts.showOutput ? outputRows(toolUse, elide) : [];
+  const showOutput = options.showOutput === true || opts.showOutput;
+  const output = showOutput ? outputRows(toolUse, elide) : [];
   const exitCode =
     opts.showExitCode && toolUse.isError ? extractExitCode(toolUse) : undefined;
   const errorText = errorTextForDisplay(toolUse);
   const showNoOutput =
-    opts.showOutput &&
+    showOutput &&
     toolUse.status === TOOL_USE_STATUS.COMPLETED &&
     output.length === 0 &&
     !patchGroups &&
@@ -475,7 +478,7 @@ export function toolUseStyledLines(
   toolUse: NormalizedToolUse,
   options: StyledLineOptions = {},
 ): readonly ToolDisplayLine[] {
-  const key = `${options.elide === false ? 'f' : 'e'}|${options.width ?? 'd'}`;
+  const key = `${options.elide === false ? 'f' : 'e'}|${options.showOutput === true ? 'o' : 'h'}|${options.width ?? 'd'}`;
   let cached = styledLinesCache.get(toolUse);
   const hit = cached?.get(key);
   if (hit) return hit;

--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -116,6 +116,8 @@ export interface DisplayLineOptions {
   readonly elide?: boolean;
   /** Include raw output for a caller with an explicit result surface. */
   readonly showOutput?: boolean;
+  /** Render the status marker without active or terminal state color. */
+  readonly neutralStatus?: boolean;
   /** Terminal columns when the projection must match rich rendered rows. */
   readonly width?: number;
 }
@@ -390,7 +392,8 @@ function buildStyledLines(
   const elide = options.elide !== false;
   const patchGroups = toolUsePatchGroups(toolUse);
   const opts = toolRowOptions(toolUse, patchGroups !== undefined);
-  const color = statusColor(toolUse);
+  const color =
+    options.neutralStatus === true ? undefined : statusColor(toolUse);
   const preview = toolHeaderPreview(
     toolUse,
     options.width === undefined
@@ -478,7 +481,7 @@ export function toolUseStyledLines(
   toolUse: NormalizedToolUse,
   options: StyledLineOptions = {},
 ): readonly ToolDisplayLine[] {
-  const key = `${options.elide === false ? 'f' : 'e'}|${options.showOutput === true ? 'o' : 'h'}|${options.width ?? 'd'}`;
+  const key = `${options.elide === false ? 'f' : 'e'}|${options.showOutput === true ? 'o' : 'h'}|${options.neutralStatus === true ? 'n' : 's'}|${options.width ?? 'd'}`;
   let cached = styledLinesCache.get(toolUse);
   const hit = cached?.get(key);
   if (hit) return hit;

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -73,8 +73,10 @@ export type ConversationEntry =
   | (ConversationEntryBase & {
       readonly role: 'tool';
       readonly toolUse: NormalizedToolUse;
-      /** Finalized progress emitted by one delegate_workflow_script call. */
+      /** Progress emitted by one delegate_workflow_script call. */
       readonly workflowScriptFacts?: readonly WorkflowScriptProgressFact[];
+      /** Terminal trace outcome, kept outside the narrower normalized schema. */
+      readonly workflowScriptOutcome?: WorkflowScriptOutcome;
     })
   | (ConversationEntryBase & {
       readonly role: 'process';
@@ -105,6 +107,16 @@ export type WorkflowScriptProgressFact =
       readonly message: string;
       readonly phaseId?: string;
     };
+
+type WorkflowScriptOutcome = 'completed' | 'failed';
+
+/** Transient ownership of workflow events by one open tool invocation. */
+export interface ActiveWorkflowScriptInvocation {
+  readonly logId: string;
+  readonly parentStageId: string | undefined;
+  readonly phaseIds: ReadonlySet<string>;
+  readonly nextFactIndex: number;
+}
 
 export interface SessionMeta {
   readonly agent: string;
@@ -157,6 +169,7 @@ export interface StreamSlice {
   readonly conversation: ConversationProgress | undefined;
   readonly roundStage?: RoundStage | undefined;
   readonly entries: readonly ConversationEntry[];
+  readonly activeWorkflowScript?: ActiveWorkflowScriptInvocation;
   readonly queuedFollowUps: number;
   readonly queuedFollowUpMessages: readonly string[];
   readonly activeProcesses: readonly ActiveChildInfo[];

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -262,6 +262,7 @@ function emptySlice(streamId: StreamTabId): StreamSlice {
 // re-render on an actual change.
 
 const STREAMS = signal<ReadonlyMap<StreamTabId, StreamSlice>>(new Map());
+const RETIRED_STREAMS = new Set<StreamTabId>();
 
 /** Per-stream state map, keyed by `StreamTabId`. */
 export const streams = STREAMS;
@@ -270,6 +271,7 @@ export function patchStream(
   streamId: StreamTabId,
   update: (slice: StreamSlice) => StreamSlice,
 ): void {
+  RETIRED_STREAMS.delete(streamId);
   const current = STREAMS.get();
   const slice = current.get(streamId) ?? emptySlice(streamId);
   const next = update(slice);
@@ -319,8 +321,10 @@ export function setStreamStatusInCliState({
   readonly status: StreamPhase;
   readonly substate?: StreamSubstate;
   readonly streamId: StreamTabId;
-}): void {
-  if (isChildStreamRemoved(streamId)) return;
+}): boolean {
+  if (isChildStreamRemoved(streamId) || RETIRED_STREAMS.has(streamId)) {
+    return false;
+  }
   const current = STREAMS.get();
   const existingSlice = current.get(streamId);
   const targetSlice = streamSliceWithStatus(
@@ -329,10 +333,11 @@ export function setStreamStatusInCliState({
     substate,
     nowMs,
   );
-  if (targetSlice === existingSlice) return;
+  if (targetSlice === existingSlice) return true;
   const out = new Map(current);
   out.set(streamId, targetSlice);
   STREAMS.set(out);
+  return true;
 }
 
 // ---------------------------------------------------------------------------
@@ -513,6 +518,12 @@ export function removeStream(streamId: StreamTabId): void {
 // registry other state modules use to reset their own signals in step.
 
 const RESET_HOOKS = new Set<() => void>();
+let CLI_STATE_GENERATION = 0;
+
+/** Identity of the current signal-state lifetime for asynchronous subscribers. */
+export function getCliStateGeneration(): number {
+  return CLI_STATE_GENERATION;
+}
 
 export function registerCliStateResetHook(resetHook: () => void): void {
   RESET_HOOKS.add(resetHook);
@@ -521,6 +532,8 @@ export function registerCliStateResetHook(resetHook: () => void): void {
 export function resetCliState(
   nextSessionMeta: SessionMeta = defaultSessionMeta(),
 ): void {
+  CLI_STATE_GENERATION += 1;
+  for (const streamId of streams.get().keys()) RETIRED_STREAMS.add(streamId);
   sessionMeta.set(nextSessionMeta);
   activeStreamId.set(undefined);
   rootStreamId.set(undefined);

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -267,6 +267,11 @@ const RETIRED_STREAMS = new Set<StreamTabId>();
 /** Per-stream state map, keyed by `StreamTabId`. */
 export const streams = STREAMS;
 
+/** Whether reset retired this stream identity from the current state lifetime. */
+export function isCliStreamRetired(streamId: StreamTabId): boolean {
+  return RETIRED_STREAMS.has(streamId);
+}
+
 export function patchStream(
   streamId: StreamTabId,
   update: (slice: StreamSlice) => StreamSlice,
@@ -533,6 +538,7 @@ export function resetCliState(
   nextSessionMeta: SessionMeta = defaultSessionMeta(),
 ): void {
   CLI_STATE_GENERATION += 1;
+  RETIRED_STREAMS.clear();
   for (const streamId of streams.get().keys()) RETIRED_STREAMS.add(streamId);
   sessionMeta.set(nextSessionMeta);
   activeStreamId.set(undefined);

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -73,6 +73,8 @@ export type ConversationEntry =
   | (ConversationEntryBase & {
       readonly role: 'tool';
       readonly toolUse: NormalizedToolUse;
+      /** Finalized progress emitted by one delegate_workflow_script call. */
+      readonly workflowScriptFacts?: readonly WorkflowScriptProgressFact[];
     })
   | (ConversationEntryBase & {
       readonly role: 'process';
@@ -87,6 +89,22 @@ export interface CompletedProcessTranscript {
   readonly isError: boolean;
   readonly tailLines: readonly string[];
 }
+
+/** Immutable workflow-script fact appended once to terminal scrollback. */
+export type WorkflowScriptProgressFact =
+  | {
+      readonly type: 'phase';
+      readonly id: string;
+      readonly stageId: string;
+      readonly label: string;
+    }
+  | {
+      readonly type: 'log';
+      readonly id: string;
+      readonly level: 'debug' | 'info' | 'warn' | 'error';
+      readonly message: string;
+      readonly phaseId?: string;
+    };
 
 export interface SessionMeta {
   readonly agent: string;

--- a/packages/cli/src/chat/tui/state/streamStatus.ts
+++ b/packages/cli/src/chat/tui/state/streamStatus.ts
@@ -2,8 +2,8 @@ import type { StreamStatusChange } from '@agent/runtime/StreamStatusService';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { setStreamStatusInCliState } from './cliState';
 
-export function applyStreamStatusChange(change: StreamStatusChange): void {
-  setStreamStatusInCliState({
+export function applyStreamStatusChange(change: StreamStatusChange): boolean {
+  return setStreamStatusInCliState({
     streamId: change.streamId,
     status: change.status,
     ...(change.substate ? { substate: change.substate } : {}),

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -6,7 +6,6 @@ import { toUpdateStreamUsagePayload } from '@agent/runtime/runFactUsage';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import {
-  TOOL_USE_STATUS,
   type ActiveChildInfo,
   type GoalPausedPayload,
   type SetActiveStreamPayload,
@@ -17,24 +16,18 @@ import {
   type UpdateRoundStagePayload,
   type UpdateStreamUsagePayload,
 } from '@shared/schemas';
-import { normalizeToolUseData } from '@shared/toolUse';
-import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
 import { diffActiveChildren } from '@shared/streams/childActivityReducer';
 import {
   reduceStreamMeta,
   type StreamMetaCommand,
 } from '@shared/streams/streamMetaReducer';
-import { assertNever, isObject } from '@utils/core';
+import { assertNever } from '@utils/core';
 
 import {
   activeStreamId,
   removeStream,
   patchStream,
-  streams,
-  type ActiveWorkflowScriptInvocation,
-  type ConversationEntry,
   type StreamSlice,
-  type WorkflowScriptProgressFact,
 } from './cliState';
 import {
   applySubagentRoster,
@@ -43,8 +36,8 @@ import {
 } from './childExecutions';
 import { appendCompletedProcessEntries } from './completedProcessTranscript';
 import { sumResumeUsageStats } from './resumeHint';
-import { syncStreamLog } from './subscribeStreamLog';
 import { appendLocalAssistantTranscript } from './transcript';
+import { applyWorkflowScriptProgressEvent } from './workflowScriptProgress';
 
 const GOAL_PAUSED_TRANSCRIPT_NOTICE =
   'Goal paused after a failed cycle. Review the error before starting a new goal.';
@@ -184,133 +177,11 @@ function applyParentStream(payload: {
   setParentStream(payload.childStreamId, payload.parentStreamId);
 }
 
-type ToolConversationEntry = Extract<ConversationEntry, { role: 'tool' }>;
-
-function patchWorkflowScriptOwner(
-  streamId: StreamTabId,
-  logId: string,
-  update: (entry: ToolConversationEntry) => ToolConversationEntry,
-): void {
-  patchStream(streamId, (slice) => {
-    const index = slice.entries.findIndex(
-      (entry) => entry.role === 'tool' && entry.id === logId,
-    );
-    const entry = slice.entries[index];
-    if (index < 0 || entry?.role !== 'tool') return slice;
-
-    const entries = [...slice.entries];
-    entries[index] = update(entry);
-    return { ...slice, entries };
-  });
-}
-
-function appendWorkflowScriptFact(
-  streamId: StreamTabId,
-  logId: string,
-  fact: WorkflowScriptProgressFact,
-): void {
-  patchWorkflowScriptOwner(streamId, logId, (entry) => ({
-    ...entry,
-    workflowScriptFacts: [...(entry.workflowScriptFacts ?? []), fact],
-  }));
-}
-
-function startWorkflowScriptOwnership(
-  streamId: StreamTabId,
-  logId: string,
-  parentStageId: string | undefined,
-): void {
-  patchStream(streamId, (slice) => {
-    const index = slice.entries.findIndex(
-      (entry) => entry.role === 'tool' && entry.id === logId,
-    );
-    const entry = slice.entries[index];
-    if (index < 0 || entry?.role !== 'tool') return slice;
-    const entries = [...slice.entries];
-    entries[index] = {
-      ...entry,
-      workflowScriptFacts: entry.workflowScriptFacts ?? [],
-    };
-    return {
-      ...slice,
-      entries,
-      activeWorkflowScript: {
-        logId,
-        parentStageId,
-        phaseIds: new Set(),
-        nextFactIndex: 0,
-      },
-    };
-  });
-}
-
-function activeWorkflowScript(
-  streamId: StreamTabId,
-): ActiveWorkflowScriptInvocation | undefined {
-  return streams.get().get(streamId)?.activeWorkflowScript;
-}
-
-function terminalWorkflowScriptToolUse(
-  entry: ToolConversationEntry,
-  outcome: 'completed' | 'failed',
-  result: unknown,
-): ToolConversationEntry['toolUse'] {
-  let resultData: Record<string, unknown>;
-  if (isObject(result)) resultData = result;
-  else if (result === undefined) resultData = {};
-  else resultData = { output: result };
-  const normalized = normalizeToolUseData({
-    ...entry.toolUse.parsed,
-    ...resultData,
-    status: TOOL_USE_STATUS.COMPLETED,
-  });
-  const terminal = normalized ?? {
-    ...entry.toolUse,
-    status: TOOL_USE_STATUS.COMPLETED,
-  };
-  if (outcome === 'completed') return terminal;
-
-  const failureText =
-    (typeof resultData.error === 'string' && resultData.error.trim()) ||
-    (typeof resultData.output === 'string' && resultData.output.trim()) ||
-    'Workflow script failed.';
-  return {
-    ...terminal,
-    errorText: terminal.errorText || failureText,
-    headerSummary: terminal.headerSummary || failureText,
-    isError: true,
-  };
-}
-
-function finishWorkflowScriptOwnership(
-  streamId: StreamTabId,
-  invocation: ActiveWorkflowScriptInvocation,
-  outcome: 'completed' | 'failed',
-  result: unknown,
-): void {
-  patchStream(streamId, (slice) => {
-    if (slice.activeWorkflowScript !== invocation) return slice;
-    const index = slice.entries.findIndex(
-      (entry) => entry.role === 'tool' && entry.id === invocation.logId,
-    );
-    const entry = slice.entries[index];
-    if (index < 0 || entry?.role !== 'tool') return slice;
-
-    const entries = [...slice.entries];
-    entries[index] = {
-      ...entry,
-      toolUse: terminalWorkflowScriptToolUse(entry, outcome, result),
-      workflowScriptOutcome: outcome,
-    };
-    const { activeWorkflowScript: _finished, ...rest } = slice;
-    return { ...rest, entries };
-  });
-}
-
 function applyDirectTuiRunEvent(
   event: AgentEvent,
   fallbackStreamId: StreamTabId,
 ): boolean {
+  if (applyWorkflowScriptProgressEvent(event, fallbackStreamId)) return true;
   switch (event.type) {
     case 'run.config':
       applyRunConfig(event.streamId, event.config);
@@ -346,31 +217,7 @@ function applyDirectTuiRunEvent(
     case 'updateMissingOutputs':
     case 'updateCompileFailures':
       return false;
-    case 'stage.start': {
-      if (event.kind === 'phase') {
-        const invocation = activeWorkflowScript(fallbackStreamId);
-        if (!invocation || event.parentId !== invocation.parentStageId) {
-          return false;
-        }
-        appendWorkflowScriptFact(fallbackStreamId, invocation.logId, {
-          type: 'phase',
-          id: `${invocation.logId}:phase:${event.id}`,
-          stageId: event.id,
-          label: event.label,
-        });
-        patchStream(fallbackStreamId, (slice) =>
-          slice.activeWorkflowScript === invocation
-            ? {
-                ...slice,
-                activeWorkflowScript: {
-                  ...invocation,
-                  phaseIds: new Set([...invocation.phaseIds, event.id]),
-                },
-              }
-            : slice,
-        );
-        return true;
-      }
+    case 'stage.start':
       if (event.kind !== 'round') return false;
       applyRoundStage({
         streamId: fallbackStreamId,
@@ -382,64 +229,6 @@ function applyDirectTuiRunEvent(
         },
       });
       return true;
-    }
-    case 'log': {
-      const invocation = activeWorkflowScript(fallbackStreamId);
-      if (!invocation || event.stageId === undefined) return false;
-      const inPhase = invocation.phaseIds.has(event.stageId);
-      if (!inPhase && event.stageId !== invocation.parentStageId) return false;
-      appendWorkflowScriptFact(fallbackStreamId, invocation.logId, {
-        type: 'log',
-        id: `${invocation.logId}:log:${invocation.nextFactIndex}`,
-        level: event.level,
-        message: event.message,
-        ...(inPhase ? { phaseId: event.stageId } : {}),
-      });
-      patchStream(fallbackStreamId, (slice) =>
-        slice.activeWorkflowScript === invocation
-          ? {
-              ...slice,
-              activeWorkflowScript: {
-                ...invocation,
-                nextFactIndex: invocation.nextFactIndex + 1,
-              },
-            }
-          : slice,
-      );
-      return true;
-    }
-    case 'tool.start':
-      if (event.toolName !== DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME) return false;
-      // The transcript recorder runs before the SessionEventHub bridge, so a
-      // direct sync materializes the canonical tool row before synchronous
-      // script phase/log events can follow in the same turn.
-      syncStreamLog(fallbackStreamId);
-      startWorkflowScriptOwnership(
-        fallbackStreamId,
-        event.logId,
-        event.stageId,
-      );
-      // Re-run ordered finalization after attaching workflow ownership. This
-      // promotes the header only when every preceding transcript row is also
-      // settled; progress facts remain attached until that condition holds.
-      syncStreamLog(fallbackStreamId);
-      return true;
-    case 'tool.end': {
-      const invocation = activeWorkflowScript(fallbackStreamId);
-      if (!invocation || invocation.logId !== event.logId) return false;
-      if (event.status === 'in_progress') {
-        syncStreamLog(fallbackStreamId);
-        return true;
-      }
-      finishWorkflowScriptOwnership(
-        fallbackStreamId,
-        invocation,
-        event.status,
-        event.result,
-      );
-      syncStreamLog(fallbackStreamId);
-      return true;
-    }
     case 'child.activity':
       if (event.kind === 'subagents') {
         applyActiveSubagents({

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -6,6 +6,7 @@ import { toUpdateStreamUsagePayload } from '@agent/runtime/runFactUsage';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import {
+  TOOL_USE_STATUS,
   type ActiveChildInfo,
   type GoalPausedPayload,
   type SetActiveStreamPayload,
@@ -16,18 +17,21 @@ import {
   type UpdateRoundStagePayload,
   type UpdateStreamUsagePayload,
 } from '@shared/schemas';
+import { normalizeToolUseData } from '@shared/toolUse';
 import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
 import { diffActiveChildren } from '@shared/streams/childActivityReducer';
 import {
   reduceStreamMeta,
   type StreamMetaCommand,
 } from '@shared/streams/streamMetaReducer';
-import { assertNever } from '@utils/core';
+import { assertNever, isObject } from '@utils/core';
 
 import {
   activeStreamId,
   removeStream,
   patchStream,
+  streams,
+  type ActiveWorkflowScriptInvocation,
   type ConversationEntry,
   type StreamSlice,
   type WorkflowScriptProgressFact,
@@ -180,13 +184,6 @@ function applyParentStream(payload: {
   setParentStream(payload.childStreamId, payload.parentStreamId);
 }
 
-interface ActiveWorkflowScriptInvocation {
-  readonly logId: string;
-  readonly parentStageId: string | undefined;
-  readonly phaseIds: Set<string>;
-  nextFactIndex: number;
-}
-
 type ToolConversationEntry = Extract<ConversationEntry, { role: 'tool' }>;
 
 function patchWorkflowScriptOwner(
@@ -218,22 +215,101 @@ function appendWorkflowScriptFact(
   }));
 }
 
-/** Move the immutable invocation header to Static before progress arrives. */
-function finalizeWorkflowScriptOwner(
+function startWorkflowScriptOwnership(
   streamId: StreamTabId,
   logId: string,
+  parentStageId: string | undefined,
 ): void {
-  patchWorkflowScriptOwner(streamId, logId, (entry) => ({
-    ...entry,
-    finalized: true,
-    workflowScriptFacts: entry.workflowScriptFacts ?? [],
-  }));
+  patchStream(streamId, (slice) => {
+    const index = slice.entries.findIndex(
+      (entry) => entry.role === 'tool' && entry.id === logId,
+    );
+    const entry = slice.entries[index];
+    if (index < 0 || entry?.role !== 'tool') return slice;
+    const entries = [...slice.entries];
+    entries[index] = {
+      ...entry,
+      workflowScriptFacts: entry.workflowScriptFacts ?? [],
+    };
+    return {
+      ...slice,
+      entries,
+      activeWorkflowScript: {
+        logId,
+        parentStageId,
+        phaseIds: new Set(),
+        nextFactIndex: 0,
+      },
+    };
+  });
+}
+
+function activeWorkflowScript(
+  streamId: StreamTabId,
+): ActiveWorkflowScriptInvocation | undefined {
+  return streams.get().get(streamId)?.activeWorkflowScript;
+}
+
+function terminalWorkflowScriptToolUse(
+  entry: ToolConversationEntry,
+  outcome: 'completed' | 'failed',
+  result: unknown,
+): ToolConversationEntry['toolUse'] {
+  let resultData: Record<string, unknown>;
+  if (isObject(result)) resultData = result;
+  else if (result === undefined) resultData = {};
+  else resultData = { output: result };
+  const normalized = normalizeToolUseData({
+    ...entry.toolUse.parsed,
+    ...resultData,
+    status: TOOL_USE_STATUS.COMPLETED,
+  });
+  const terminal = normalized ?? {
+    ...entry.toolUse,
+    status: TOOL_USE_STATUS.COMPLETED,
+  };
+  if (outcome === 'completed') return terminal;
+
+  const failureText =
+    (typeof resultData.error === 'string' && resultData.error.trim()) ||
+    (typeof resultData.output === 'string' && resultData.output.trim()) ||
+    'Workflow script failed.';
+  return {
+    ...terminal,
+    errorText: terminal.errorText || failureText,
+    headerSummary: terminal.headerSummary || failureText,
+    isError: true,
+  };
+}
+
+function finishWorkflowScriptOwnership(
+  streamId: StreamTabId,
+  invocation: ActiveWorkflowScriptInvocation,
+  outcome: 'completed' | 'failed',
+  result: unknown,
+): void {
+  patchStream(streamId, (slice) => {
+    if (slice.activeWorkflowScript !== invocation) return slice;
+    const index = slice.entries.findIndex(
+      (entry) => entry.role === 'tool' && entry.id === invocation.logId,
+    );
+    const entry = slice.entries[index];
+    if (index < 0 || entry?.role !== 'tool') return slice;
+
+    const entries = [...slice.entries];
+    entries[index] = {
+      ...entry,
+      toolUse: terminalWorkflowScriptToolUse(entry, outcome, result),
+      workflowScriptOutcome: outcome,
+    };
+    const { activeWorkflowScript: _finished, ...rest } = slice;
+    return { ...rest, entries };
+  });
 }
 
 function applyDirectTuiRunEvent(
   event: AgentEvent,
   fallbackStreamId: StreamTabId,
-  activeWorkflowScripts: Map<StreamTabId, ActiveWorkflowScriptInvocation>,
 ): boolean {
   switch (event.type) {
     case 'run.config':
@@ -272,17 +348,27 @@ function applyDirectTuiRunEvent(
       return false;
     case 'stage.start': {
       if (event.kind === 'phase') {
-        const invocation = activeWorkflowScripts.get(fallbackStreamId);
+        const invocation = activeWorkflowScript(fallbackStreamId);
         if (!invocation || event.parentId !== invocation.parentStageId) {
           return false;
         }
-        invocation.phaseIds.add(event.id);
         appendWorkflowScriptFact(fallbackStreamId, invocation.logId, {
           type: 'phase',
           id: `${invocation.logId}:phase:${event.id}`,
           stageId: event.id,
           label: event.label,
         });
+        patchStream(fallbackStreamId, (slice) =>
+          slice.activeWorkflowScript === invocation
+            ? {
+                ...slice,
+                activeWorkflowScript: {
+                  ...invocation,
+                  phaseIds: new Set([...invocation.phaseIds, event.id]),
+                },
+              }
+            : slice,
+        );
         return true;
       }
       if (event.kind !== 'round') return false;
@@ -298,17 +384,28 @@ function applyDirectTuiRunEvent(
       return true;
     }
     case 'log': {
-      const invocation = activeWorkflowScripts.get(fallbackStreamId);
+      const invocation = activeWorkflowScript(fallbackStreamId);
       if (!invocation || event.stageId === undefined) return false;
       const inPhase = invocation.phaseIds.has(event.stageId);
       if (!inPhase && event.stageId !== invocation.parentStageId) return false;
       appendWorkflowScriptFact(fallbackStreamId, invocation.logId, {
         type: 'log',
-        id: `${invocation.logId}:log:${invocation.nextFactIndex++}`,
+        id: `${invocation.logId}:log:${invocation.nextFactIndex}`,
         level: event.level,
         message: event.message,
         ...(inPhase ? { phaseId: event.stageId } : {}),
       });
+      patchStream(fallbackStreamId, (slice) =>
+        slice.activeWorkflowScript === invocation
+          ? {
+              ...slice,
+              activeWorkflowScript: {
+                ...invocation,
+                nextFactIndex: invocation.nextFactIndex + 1,
+              },
+            }
+          : slice,
+      );
       return true;
     }
     case 'tool.start':
@@ -317,18 +414,29 @@ function applyDirectTuiRunEvent(
       // direct sync materializes the canonical tool row before synchronous
       // script phase/log events can follow in the same turn.
       syncStreamLog(fallbackStreamId);
-      finalizeWorkflowScriptOwner(fallbackStreamId, event.logId);
-      activeWorkflowScripts.set(fallbackStreamId, {
-        logId: event.logId,
-        parentStageId: event.stageId,
-        phaseIds: new Set(),
-        nextFactIndex: 0,
-      });
+      startWorkflowScriptOwnership(
+        fallbackStreamId,
+        event.logId,
+        event.stageId,
+      );
+      // Re-run ordered finalization after attaching workflow ownership. This
+      // promotes the header only when every preceding transcript row is also
+      // settled; progress facts remain attached until that condition holds.
+      syncStreamLog(fallbackStreamId);
       return true;
     case 'tool.end': {
-      const invocation = activeWorkflowScripts.get(fallbackStreamId);
+      const invocation = activeWorkflowScript(fallbackStreamId);
       if (!invocation || invocation.logId !== event.logId) return false;
-      activeWorkflowScripts.delete(fallbackStreamId);
+      if (event.status === 'in_progress') {
+        syncStreamLog(fallbackStreamId);
+        return true;
+      }
+      finishWorkflowScriptOwnership(
+        fallbackStreamId,
+        invocation,
+        event.status,
+        event.result,
+      );
       syncStreamLog(fallbackStreamId);
       return true;
     }
@@ -405,10 +513,6 @@ function applyStreamMeta(
 export function attachTuiRunFactSubscription(
   events: SessionEventHub,
 ): () => void {
-  const activeWorkflowScripts = new Map<
-    StreamTabId,
-    ActiveWorkflowScriptInvocation
-  >();
   const detachSessionFacts = events.subscribe(
     (sessionEvent) => {
       if (sessionEvent.scope !== 'session') return;
@@ -454,13 +558,7 @@ export function attachTuiRunFactSubscription(
     (sessionEvent) => {
       if (sessionEvent.scope !== 'run') return;
       const { event } = sessionEvent;
-      if (
-        applyDirectTuiRunEvent(
-          event,
-          sessionEvent.streamId,
-          activeWorkflowScripts,
-        )
-      ) {
+      if (applyDirectTuiRunEvent(event, sessionEvent.streamId)) {
         return;
       }
     },

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -25,6 +25,7 @@ import { assertNever } from '@utils/core';
 
 import {
   activeStreamId,
+  getCliStateGeneration,
   removeStream,
   patchStream,
   type StreamSlice,
@@ -302,8 +303,10 @@ function applyStreamMeta(
 export function attachTuiRunFactSubscription(
   events: SessionEventHub,
 ): () => void {
+  const generation = getCliStateGeneration();
   const detachSessionFacts = events.subscribe(
     (sessionEvent) => {
+      if (generation !== getCliStateGeneration()) return;
       if (sessionEvent.scope !== 'session') return;
       const fact = sessionEvent.event;
       switch (fact.type) {
@@ -345,7 +348,9 @@ export function attachTuiRunFactSubscription(
   );
   const detachRunFacts = events.subscribe(
     (sessionEvent) => {
+      if (generation !== getCliStateGeneration()) return;
       if (sessionEvent.scope !== 'run') return;
+      if (isChildStreamRemoved(sessionEvent.streamId)) return;
       const { event } = sessionEvent;
       if (applyDirectTuiRunEvent(event, sessionEvent.streamId)) {
         return;

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -16,6 +16,7 @@ import {
   type UpdateRoundStagePayload,
   type UpdateStreamUsagePayload,
 } from '@shared/schemas';
+import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
 import { diffActiveChildren } from '@shared/streams/childActivityReducer';
 import {
   reduceStreamMeta,
@@ -27,7 +28,9 @@ import {
   activeStreamId,
   removeStream,
   patchStream,
+  type ConversationEntry,
   type StreamSlice,
+  type WorkflowScriptProgressFact,
 } from './cliState';
 import {
   applySubagentRoster,
@@ -36,6 +39,7 @@ import {
 } from './childExecutions';
 import { appendCompletedProcessEntries } from './completedProcessTranscript';
 import { sumResumeUsageStats } from './resumeHint';
+import { syncStreamLog } from './subscribeStreamLog';
 import { appendLocalAssistantTranscript } from './transcript';
 
 const GOAL_PAUSED_TRANSCRIPT_NOTICE =
@@ -176,9 +180,60 @@ function applyParentStream(payload: {
   setParentStream(payload.childStreamId, payload.parentStreamId);
 }
 
+interface ActiveWorkflowScriptInvocation {
+  readonly logId: string;
+  readonly parentStageId: string | undefined;
+  readonly phaseIds: Set<string>;
+  nextFactIndex: number;
+}
+
+type ToolConversationEntry = Extract<ConversationEntry, { role: 'tool' }>;
+
+function patchWorkflowScriptOwner(
+  streamId: StreamTabId,
+  logId: string,
+  update: (entry: ToolConversationEntry) => ToolConversationEntry,
+): void {
+  patchStream(streamId, (slice) => {
+    const index = slice.entries.findIndex(
+      (entry) => entry.role === 'tool' && entry.id === logId,
+    );
+    const entry = slice.entries[index];
+    if (index < 0 || entry?.role !== 'tool') return slice;
+
+    const entries = [...slice.entries];
+    entries[index] = update(entry);
+    return { ...slice, entries };
+  });
+}
+
+function appendWorkflowScriptFact(
+  streamId: StreamTabId,
+  logId: string,
+  fact: WorkflowScriptProgressFact,
+): void {
+  patchWorkflowScriptOwner(streamId, logId, (entry) => ({
+    ...entry,
+    workflowScriptFacts: [...(entry.workflowScriptFacts ?? []), fact],
+  }));
+}
+
+/** Move the immutable invocation header to Static before progress arrives. */
+function finalizeWorkflowScriptOwner(
+  streamId: StreamTabId,
+  logId: string,
+): void {
+  patchWorkflowScriptOwner(streamId, logId, (entry) => ({
+    ...entry,
+    finalized: true,
+    workflowScriptFacts: entry.workflowScriptFacts ?? [],
+  }));
+}
+
 function applyDirectTuiRunEvent(
   event: AgentEvent,
   fallbackStreamId: StreamTabId,
+  activeWorkflowScripts: Map<StreamTabId, ActiveWorkflowScriptInvocation>,
 ): boolean {
   switch (event.type) {
     case 'run.config':
@@ -215,7 +270,21 @@ function applyDirectTuiRunEvent(
     case 'updateMissingOutputs':
     case 'updateCompileFailures':
       return false;
-    case 'stage.start':
+    case 'stage.start': {
+      if (event.kind === 'phase') {
+        const invocation = activeWorkflowScripts.get(fallbackStreamId);
+        if (!invocation || event.parentId !== invocation.parentStageId) {
+          return false;
+        }
+        invocation.phaseIds.add(event.id);
+        appendWorkflowScriptFact(fallbackStreamId, invocation.logId, {
+          type: 'phase',
+          id: `${invocation.logId}:phase:${event.id}`,
+          stageId: event.id,
+          label: event.label,
+        });
+        return true;
+      }
       if (event.kind !== 'round') return false;
       applyRoundStage({
         streamId: fallbackStreamId,
@@ -227,6 +296,42 @@ function applyDirectTuiRunEvent(
         },
       });
       return true;
+    }
+    case 'log': {
+      const invocation = activeWorkflowScripts.get(fallbackStreamId);
+      if (!invocation || event.stageId === undefined) return false;
+      const inPhase = invocation.phaseIds.has(event.stageId);
+      if (!inPhase && event.stageId !== invocation.parentStageId) return false;
+      appendWorkflowScriptFact(fallbackStreamId, invocation.logId, {
+        type: 'log',
+        id: `${invocation.logId}:log:${invocation.nextFactIndex++}`,
+        level: event.level,
+        message: event.message,
+        ...(inPhase ? { phaseId: event.stageId } : {}),
+      });
+      return true;
+    }
+    case 'tool.start':
+      if (event.toolName !== DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME) return false;
+      // The transcript recorder runs before the SessionEventHub bridge, so a
+      // direct sync materializes the canonical tool row before synchronous
+      // script phase/log events can follow in the same turn.
+      syncStreamLog(fallbackStreamId);
+      finalizeWorkflowScriptOwner(fallbackStreamId, event.logId);
+      activeWorkflowScripts.set(fallbackStreamId, {
+        logId: event.logId,
+        parentStageId: event.stageId,
+        phaseIds: new Set(),
+        nextFactIndex: 0,
+      });
+      return true;
+    case 'tool.end': {
+      const invocation = activeWorkflowScripts.get(fallbackStreamId);
+      if (!invocation || invocation.logId !== event.logId) return false;
+      activeWorkflowScripts.delete(fallbackStreamId);
+      syncStreamLog(fallbackStreamId);
+      return true;
+    }
     case 'child.activity':
       if (event.kind === 'subagents') {
         applyActiveSubagents({
@@ -300,6 +405,10 @@ function applyStreamMeta(
 export function attachTuiRunFactSubscription(
   events: SessionEventHub,
 ): () => void {
+  const activeWorkflowScripts = new Map<
+    StreamTabId,
+    ActiveWorkflowScriptInvocation
+  >();
   const detachSessionFacts = events.subscribe(
     (sessionEvent) => {
       if (sessionEvent.scope !== 'session') return;
@@ -345,7 +454,13 @@ export function attachTuiRunFactSubscription(
     (sessionEvent) => {
       if (sessionEvent.scope !== 'run') return;
       const { event } = sessionEvent;
-      if (applyDirectTuiRunEvent(event, sessionEvent.streamId)) {
+      if (
+        applyDirectTuiRunEvent(
+          event,
+          sessionEvent.streamId,
+          activeWorkflowScripts,
+        )
+      ) {
         return;
       }
     },
@@ -361,7 +476,10 @@ export function attachTuiRunFactSubscription(
         'goalPaused',
         'run.config',
         'usage',
+        'log',
         'stage.start',
+        'tool.start',
+        'tool.end',
         'child.activity',
         'process.output',
       ],

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -196,13 +196,7 @@ function renderLogEntry(
     const toolUse = normalizeToolUseData(entry.data);
     // Drop malformed tool entries rather than crash. The progress view
     // does the same — a bad payload shouldn't take down the transcript.
-    // A failed tool.end status is outside ToolUseLogSchema's historical
-    // in_progress/completed vocabulary. The direct runtime subscription has
-    // already projected that terminal workflow result into `prev`; retain it
-    // when the canonical log update therefore cannot be normalized.
-    if (!toolUse) {
-      return prev?.role === 'tool' && prev.workflowScriptOutcome ? prev : null;
-    }
+    if (!toolUse) return null;
     // Never finalize here. `finalizeSettledPrefix` promotes a tool row only
     // once it completes AND every entry before it has promoted, so a
     // fast tool can't jump ahead of still-streaming assistant text in
@@ -279,6 +273,7 @@ function isSettledEntry(
     case 'tool':
       return (
         entry.toolUse.status === TOOL_USE_STATUS.COMPLETED ||
+        entry.toolUse.status === TOOL_USE_STATUS.FAILED ||
         // An empty array deliberately anchors a neutral immutable owner row
         // before the first append-only workflow fact arrives.
         entry.workflowScriptFacts !== undefined

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -147,6 +147,7 @@ function entriesEqual(
   if (prev.role === 'tool' && next.role === 'tool') {
     return (
       prev.workflowScriptFacts === next.workflowScriptFacts &&
+      prev.workflowScriptOutcome === next.workflowScriptOutcome &&
       toolUseEqual(prev.toolUse, next.toolUse)
     );
   }
@@ -195,7 +196,13 @@ function renderLogEntry(
     const toolUse = normalizeToolUseData(entry.data);
     // Drop malformed tool entries rather than crash. The progress view
     // does the same — a bad payload shouldn't take down the transcript.
-    if (!toolUse) return null;
+    // A failed tool.end status is outside ToolUseLogSchema's historical
+    // in_progress/completed vocabulary. The direct runtime subscription has
+    // already projected that terminal workflow result into `prev`; retain it
+    // when the canonical log update therefore cannot be normalized.
+    if (!toolUse) {
+      return prev?.role === 'tool' && prev.workflowScriptOutcome ? prev : null;
+    }
     // Never finalize here. `finalizeSettledPrefix` promotes a tool row only
     // once it completes AND every entry before it has promoted, so a
     // fast tool can't jump ahead of still-streaming assistant text in
@@ -210,6 +217,9 @@ function renderLogEntry(
       toolUse,
       ...(prev?.role === 'tool' && prev.workflowScriptFacts
         ? { workflowScriptFacts: prev.workflowScriptFacts }
+        : {}),
+      ...(prev?.role === 'tool' && prev.workflowScriptOutcome
+        ? { workflowScriptOutcome: prev.workflowScriptOutcome }
         : {}),
     };
     if (prev && entriesEqual(prev, next)) {
@@ -267,7 +277,10 @@ function isSettledEntry(
     case 'process':
       return true;
     case 'tool':
-      return entry.toolUse.status === TOOL_USE_STATUS.COMPLETED;
+      return (
+        entry.toolUse.status === TOOL_USE_STATUS.COMPLETED ||
+        entry.workflowScriptFacts !== undefined
+      );
     case 'assistant':
       return (
         !entry.pendingEmbeddedSubagentFollowup && index < entries.length - 1

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -145,7 +145,10 @@ function entriesEqual(
     return false;
   }
   if (prev.role === 'tool' && next.role === 'tool') {
-    return toolUseEqual(prev.toolUse, next.toolUse);
+    return (
+      prev.workflowScriptFacts === next.workflowScriptFacts &&
+      toolUseEqual(prev.toolUse, next.toolUse)
+    );
   }
   if (prev.role === 'process' && next.role === 'process') {
     return prev.process === next.process;
@@ -205,6 +208,9 @@ function renderLogEntry(
       ...(entry.messageType ? { messageType: entry.messageType } : {}),
       finalized: prev?.finalized ?? false,
       toolUse,
+      ...(prev?.role === 'tool' && prev.workflowScriptFacts
+        ? { workflowScriptFacts: prev.workflowScriptFacts }
+        : {}),
     };
     if (prev && entriesEqual(prev, next)) {
       // Same content under a fresh `data` reference: refresh the cache

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -279,6 +279,8 @@ function isSettledEntry(
     case 'tool':
       return (
         entry.toolUse.status === TOOL_USE_STATUS.COMPLETED ||
+        // An empty array deliberately anchors a neutral immutable owner row
+        // before the first append-only workflow fact arrives.
         entry.workflowScriptFacts !== undefined
       );
     case 'assistant':

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -29,9 +29,12 @@ import {
 } from '../panes/transcriptEntries';
 import {
   activeStreamId,
+  getCliStateGeneration,
   patchStream,
+  streams,
   type ConversationEntry,
 } from './cliState';
+import { isChildStreamRemoved } from './childExecutions';
 import { isFinalTranscriptStatus } from './transcript';
 
 const TRANSCRIPT_MESSAGE_TYPES = new Set<string>([
@@ -359,7 +362,7 @@ function sortTranscriptCandidatesIfNeeded(
 
 export function subscribeStreamLog(): () => void {
   const store = defaultSession().transcripts;
-  const pendingStreams = new Set<StreamTabId>();
+  const pendingStreams = new Map<StreamTabId, number>();
 
   // One trailing timer shared by every stream: during a multi-subagent burst
   // the root and each child emit within the same window, and per-stream
@@ -369,11 +372,14 @@ export function subscribeStreamLog(): () => void {
   const syncDebounce = createFlushableDebounce(() => {
     const streamIds = [...pendingStreams];
     pendingStreams.clear();
-    for (const id of streamIds) syncStreamLog(id);
+    for (const [id, generation] of streamIds) {
+      if (generation === getCliStateGeneration()) syncStreamLog(id);
+    }
   }, STREAM_SYNC_THROTTLE_MS);
 
   const dispose = store.onChange((streamId) => {
-    pendingStreams.add(streamId);
+    if (!streams.get().has(streamId)) return;
+    pendingStreams.set(streamId, getCliStateGeneration());
     // Only start the window on its first tick — later ticks in the same
     // window join the batch without resetting the countdown (`pending`
     // guard), unlike a classic debounce that would restart on every call.
@@ -391,6 +397,7 @@ export function subscribeStreamLog(): () => void {
 }
 
 export function syncStreamLog(streamId: StreamTabId): void {
+  if (isChildStreamRemoved(streamId)) return;
   // AgentTrace throttles MODEL_RESPONSE chunks into the store via a 50ms
   // timer. If we read before that timer fires (e.g. the stream finalized
   // between two TUI sync ticks), the assistant text is still sitting in

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -30,8 +30,8 @@ import {
 import {
   activeStreamId,
   getCliStateGeneration,
+  isCliStreamRetired,
   patchStream,
-  streams,
   type ConversationEntry,
 } from './cliState';
 import { isChildStreamRemoved } from './childExecutions';
@@ -378,7 +378,7 @@ export function subscribeStreamLog(): () => void {
   }, STREAM_SYNC_THROTTLE_MS);
 
   const dispose = store.onChange((streamId) => {
-    if (!streams.get().has(streamId)) return;
+    if (isCliStreamRetired(streamId)) return;
     pendingStreams.set(streamId, getCliStateGeneration());
     // Only start the window on its first tick — later ticks in the same
     // window join the batch without resetting the countdown (`pending`

--- a/packages/cli/src/chat/tui/state/subscribeStreamStatus.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamStatus.ts
@@ -18,8 +18,10 @@ export function subscribeStreamStatus(): () => void {
     // carrying `WAITING` from the previous turn would otherwise finalize
     // the next run's first chunks early, shoving partial text into
     // `<Static>` before it finished streaming.
-    applyStreamStatusChange(change);
-    projectStreamTranscriptForStatus(change.streamId, change.status);
+    const recognized = applyStreamStatusChange(change);
+    if (recognized) {
+      projectStreamTranscriptForStatus(change.streamId, change.status);
+    }
 
     // A lifecycle-owned child completion returns manual focus to that child's
     // immediate owner. WAITING, repair events, unrelated streams, and detached

--- a/packages/cli/src/chat/tui/state/transcriptProjection.ts
+++ b/packages/cli/src/chat/tui/state/transcriptProjection.ts
@@ -1,5 +1,6 @@
 import type { StreamPhase, StreamTabId } from '@shared/schemas';
 
+import { isChildStreamRemoved } from './childExecutions';
 import { syncStreamLog } from './subscribeStreamLog';
 import {
   finalizeAssistantTranscriptEntries,
@@ -22,6 +23,7 @@ export function projectStreamTranscript(
   streamId: StreamTabId,
   options: ProjectStreamTranscriptOptions = {},
 ): void {
+  if (isChildStreamRemoved(streamId)) return;
   syncStreamLog(streamId);
   if (options.finalize) {
     finalizeAssistantTranscriptEntries(streamId);

--- a/packages/cli/src/chat/tui/state/workflowScriptProgress.ts
+++ b/packages/cli/src/chat/tui/state/workflowScriptProgress.ts
@@ -194,6 +194,7 @@ export function applyWorkflowScriptProgressEvent(
     }
     case 'tool.start':
       if (event.toolName !== DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME) return false;
+      if (!streams.get().has(streamId)) return false;
       // The recorder runs before this bridge, so the canonical tool row is
       // available before synchronous workflow phase and log events arrive.
       syncStreamLog(streamId);

--- a/packages/cli/src/chat/tui/state/workflowScriptProgress.ts
+++ b/packages/cli/src/chat/tui/state/workflowScriptProgress.ts
@@ -1,0 +1,223 @@
+import type { AgentEvent } from '@agent/trace';
+import { TOOL_USE_STATUS, type StreamTabId } from '@shared/schemas';
+import { normalizeToolUseData } from '@shared/toolUse';
+import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
+import { isObject } from '@utils/core';
+
+import {
+  patchStream,
+  streams,
+  type ActiveWorkflowScriptInvocation,
+  type ConversationEntry,
+  type WorkflowScriptProgressFact,
+} from './cliState';
+import { syncStreamLog } from './subscribeStreamLog';
+
+type ToolConversationEntry = Extract<ConversationEntry, { role: 'tool' }>;
+
+function patchWorkflowScriptOwner(
+  streamId: StreamTabId,
+  logId: string,
+  update: (entry: ToolConversationEntry) => ToolConversationEntry,
+): void {
+  patchStream(streamId, (slice) => {
+    const index = slice.entries.findIndex(
+      (entry) => entry.role === 'tool' && entry.id === logId,
+    );
+    const entry = slice.entries[index];
+    if (index < 0 || entry?.role !== 'tool') return slice;
+
+    const entries = [...slice.entries];
+    entries[index] = update(entry);
+    return { ...slice, entries };
+  });
+}
+
+function appendWorkflowScriptFact(
+  streamId: StreamTabId,
+  logId: string,
+  fact: WorkflowScriptProgressFact,
+): void {
+  patchWorkflowScriptOwner(streamId, logId, (entry) => ({
+    ...entry,
+    workflowScriptFacts: [...(entry.workflowScriptFacts ?? []), fact],
+  }));
+}
+
+function startWorkflowScriptOwnership(
+  streamId: StreamTabId,
+  logId: string,
+  parentStageId: string | undefined,
+): void {
+  patchStream(streamId, (slice) => {
+    const index = slice.entries.findIndex(
+      (entry) => entry.role === 'tool' && entry.id === logId,
+    );
+    const entry = slice.entries[index];
+    if (index < 0 || entry?.role !== 'tool') return slice;
+    const entries = [...slice.entries];
+    entries[index] = {
+      ...entry,
+      workflowScriptFacts: entry.workflowScriptFacts ?? [],
+    };
+    return {
+      ...slice,
+      entries,
+      activeWorkflowScript: {
+        logId,
+        parentStageId,
+        phaseIds: new Set(),
+        nextFactIndex: 0,
+      },
+    };
+  });
+}
+
+function activeWorkflowScript(
+  streamId: StreamTabId,
+): ActiveWorkflowScriptInvocation | undefined {
+  return streams.get().get(streamId)?.activeWorkflowScript;
+}
+
+function terminalWorkflowScriptToolUse(
+  entry: ToolConversationEntry,
+  outcome: 'completed' | 'failed',
+  result: unknown,
+): ToolConversationEntry['toolUse'] {
+  let resultData: Record<string, unknown>;
+  if (isObject(result)) resultData = result;
+  else if (result === undefined) resultData = {};
+  else resultData = { output: result };
+  const normalized = normalizeToolUseData({
+    ...entry.toolUse.parsed,
+    ...resultData,
+    status: TOOL_USE_STATUS.COMPLETED,
+  });
+  const terminal = normalized ?? {
+    ...entry.toolUse,
+    status: TOOL_USE_STATUS.COMPLETED,
+  };
+  if (outcome === 'completed') return terminal;
+
+  const failureText =
+    (typeof resultData.error === 'string' && resultData.error.trim()) ||
+    (typeof resultData.output === 'string' && resultData.output.trim()) ||
+    'Workflow script failed.';
+  return {
+    ...terminal,
+    errorText: terminal.errorText || failureText,
+    headerSummary: terminal.headerSummary || failureText,
+    isError: true,
+  };
+}
+
+function finishWorkflowScriptOwnership(
+  streamId: StreamTabId,
+  invocation: ActiveWorkflowScriptInvocation,
+  outcome: 'completed' | 'failed',
+  result: unknown,
+): void {
+  patchStream(streamId, (slice) => {
+    if (slice.activeWorkflowScript !== invocation) return slice;
+    const index = slice.entries.findIndex(
+      (entry) => entry.role === 'tool' && entry.id === invocation.logId,
+    );
+    const entry = slice.entries[index];
+    if (index < 0 || entry?.role !== 'tool') return slice;
+
+    const entries = [...slice.entries];
+    entries[index] = {
+      ...entry,
+      toolUse: terminalWorkflowScriptToolUse(entry, outcome, result),
+      workflowScriptOutcome: outcome,
+    };
+    const { activeWorkflowScript: _finished, ...rest } = slice;
+    return { ...rest, entries };
+  });
+}
+
+/** Project workflow-script lifecycle facts into their owning CLI tool row. */
+export function applyWorkflowScriptProgressEvent(
+  event: AgentEvent,
+  streamId: StreamTabId,
+): boolean {
+  switch (event.type) {
+    case 'stage.start': {
+      if (event.kind !== 'phase') return false;
+      const invocation = activeWorkflowScript(streamId);
+      if (!invocation || event.parentId !== invocation.parentStageId) {
+        return false;
+      }
+      appendWorkflowScriptFact(streamId, invocation.logId, {
+        type: 'phase',
+        id: `${invocation.logId}:phase:${event.id}`,
+        stageId: event.id,
+        label: event.label,
+      });
+      patchStream(streamId, (slice) =>
+        slice.activeWorkflowScript === invocation
+          ? {
+              ...slice,
+              activeWorkflowScript: {
+                ...invocation,
+                phaseIds: new Set([...invocation.phaseIds, event.id]),
+              },
+            }
+          : slice,
+      );
+      return true;
+    }
+    case 'log': {
+      const invocation = activeWorkflowScript(streamId);
+      if (!invocation || event.stageId === undefined) return false;
+      const inPhase = invocation.phaseIds.has(event.stageId);
+      if (!inPhase && event.stageId !== invocation.parentStageId) return false;
+      appendWorkflowScriptFact(streamId, invocation.logId, {
+        type: 'log',
+        id: `${invocation.logId}:log:${invocation.nextFactIndex}`,
+        level: event.level,
+        message: event.message,
+        ...(inPhase ? { phaseId: event.stageId } : {}),
+      });
+      patchStream(streamId, (slice) =>
+        slice.activeWorkflowScript === invocation
+          ? {
+              ...slice,
+              activeWorkflowScript: {
+                ...invocation,
+                nextFactIndex: invocation.nextFactIndex + 1,
+              },
+            }
+          : slice,
+      );
+      return true;
+    }
+    case 'tool.start':
+      if (event.toolName !== DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME) return false;
+      // The recorder runs before this bridge, so the canonical tool row is
+      // available before synchronous workflow phase and log events arrive.
+      syncStreamLog(streamId);
+      startWorkflowScriptOwnership(streamId, event.logId, event.stageId);
+      // Ordered prefix finalization keeps this row behind any earlier live tool.
+      syncStreamLog(streamId);
+      return true;
+    case 'tool.end': {
+      const invocation = activeWorkflowScript(streamId);
+      if (!invocation || invocation.logId !== event.logId) return false;
+      if (event.status === 'in_progress') {
+        syncStreamLog(streamId);
+        return true;
+      }
+      finishWorkflowScriptOwnership(
+        streamId,
+        invocation,
+        event.status,
+        event.result,
+      );
+      syncStreamLog(streamId);
+      return true;
+    }
+    default:
+      return false;
+  }
+}

--- a/packages/cli/src/chat/tui/state/workflowScriptProgress.ts
+++ b/packages/cli/src/chat/tui/state/workflowScriptProgress.ts
@@ -79,11 +79,11 @@ function activeWorkflowScript(
   return streams.get().get(streamId)?.activeWorkflowScript;
 }
 
-function terminalWorkflowScriptToolUse(
+function terminalWorkflowScriptState(
   entry: ToolConversationEntry,
-  outcome: 'completed' | 'failed',
+  status: 'completed' | 'failed',
   result: unknown,
-): ToolConversationEntry['toolUse'] {
+): Pick<ToolConversationEntry, 'toolUse' | 'workflowScriptOutcome'> {
   let resultData: Record<string, unknown>;
   if (isObject(result)) resultData = result;
   else if (result === undefined) resultData = {};
@@ -91,30 +91,37 @@ function terminalWorkflowScriptToolUse(
   const normalized = normalizeToolUseData({
     ...entry.toolUse.parsed,
     ...resultData,
-    status: TOOL_USE_STATUS.COMPLETED,
+    status,
   });
   const terminal = normalized ?? {
     ...entry.toolUse,
-    status: TOOL_USE_STATUS.COMPLETED,
+    status,
   };
-  if (outcome === 'completed') return terminal;
+  const failed = status === 'failed' || terminal.isError;
+  if (!failed) {
+    return { toolUse: terminal, workflowScriptOutcome: 'completed' };
+  }
 
   const failureText =
     (typeof resultData.error === 'string' && resultData.error.trim()) ||
     (typeof resultData.output === 'string' && resultData.output.trim()) ||
     'Workflow script failed.';
   return {
-    ...terminal,
-    errorText: terminal.errorText || failureText,
-    headerSummary: terminal.headerSummary || failureText,
-    isError: true,
+    toolUse: {
+      ...terminal,
+      status: TOOL_USE_STATUS.FAILED,
+      errorText: terminal.errorText || failureText,
+      headerSummary: terminal.headerSummary || failureText,
+      isError: true,
+    },
+    workflowScriptOutcome: 'failed',
   };
 }
 
 function finishWorkflowScriptOwnership(
   streamId: StreamTabId,
   invocation: ActiveWorkflowScriptInvocation,
-  outcome: 'completed' | 'failed',
+  status: 'completed' | 'failed',
   result: unknown,
 ): void {
   patchStream(streamId, (slice) => {
@@ -126,10 +133,10 @@ function finishWorkflowScriptOwnership(
     if (index < 0 || entry?.role !== 'tool') return slice;
 
     const entries = [...slice.entries];
+    const terminal = terminalWorkflowScriptState(entry, status, result);
     entries[index] = {
       ...entry,
-      toolUse: terminalWorkflowScriptToolUse(entry, outcome, result),
-      workflowScriptOutcome: outcome,
+      ...terminal,
     };
     const { activeWorkflowScript: _finished, ...rest } = slice;
     return { ...rest, entries };

--- a/src/shared/schemas/progressView/data.ts
+++ b/src/shared/schemas/progressView/data.ts
@@ -72,6 +72,7 @@ export const UserMessagePayloadSchema = z.object({
 export const TOOL_USE_STATUS = {
   IN_PROGRESS: 'in_progress',
   COMPLETED: 'completed',
+  FAILED: 'failed',
 } as const;
 
 const ToolUseStatusSchema = z.enum(TOOL_USE_STATUS);

--- a/src/shared/toolUse.ts
+++ b/src/shared/toolUse.ts
@@ -73,7 +73,12 @@ export function normalizeToolUseData(data: unknown): NormalizedToolUse | null {
 
   const toolName = trimmedOrNull(validated.toolName) ?? '';
   const isUserFeedback = userInstructionText.length > 0;
-  const isError = Boolean(validated.isError || nested.isError || errorText);
+  const isError = Boolean(
+    validated.status === TOOL_USE_STATUS.FAILED ||
+    validated.isError ||
+    nested.isError ||
+    errorText,
+  );
 
   // Preserve unknown fields stripped by the schema for fallback rendering.
   const parsed: Record<string, unknown> = isObject(data)

--- a/src/shared/toolUse.ts
+++ b/src/shared/toolUse.ts
@@ -3,12 +3,16 @@
 // Both the VS Code progress view and the CLI TUI read the same
 // `ToolUseLog` payload off `StreamLogStore.data` and need a flat,
 // renderer-friendly view: tool name, derived output text, error/summary
-// strings, and the in-progress vs completed status. This module is the
+// strings, and the runtime tool status. This module is the
 // single entry point for that derivation so hosts don't drift.
 
 import yaml from 'yaml';
 
-import { ToolUseLogSchema, type NormalizedToolUse } from '@shared/schemas';
+import {
+  TOOL_USE_STATUS,
+  ToolUseLogSchema,
+  type NormalizedToolUse,
+} from '@shared/schemas';
 import { isObject } from '@utils/core';
 
 function trimmedOrNull(value: unknown): string | null {
@@ -69,6 +73,7 @@ export function normalizeToolUseData(data: unknown): NormalizedToolUse | null {
 
   const toolName = trimmedOrNull(validated.toolName) ?? '';
   const isUserFeedback = userInstructionText.length > 0;
+  const isError = Boolean(validated.isError || nested.isError || errorText);
 
   // Preserve unknown fields stripped by the schema for fallback rendering.
   const parsed: Record<string, unknown> = isObject(data)
@@ -82,9 +87,12 @@ export function normalizeToolUseData(data: unknown): NormalizedToolUse | null {
     outputText,
     userInstructionText,
     input: validated.input,
-    isError: Boolean(validated.isError || nested.isError || errorText),
+    isError,
     isUserFeedback,
     headerSummary: summaryText || (isUserFeedback ? '' : errorText),
-    status: validated.status,
+    status:
+      isError && validated.status === TOOL_USE_STATUS.COMPLETED
+        ? TOOL_USE_STATUS.FAILED
+        : validated.status,
   };
 }

--- a/src/test-kernel/cli/WorkflowScriptProgress.vitest.mts
+++ b/src/test-kernel/cli/WorkflowScriptProgress.vitest.mts
@@ -1,0 +1,240 @@
+import { createRequire } from 'node:module';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import '@test/support/defaultSessionTestSetup';
+
+import { createRunTrace } from '@transcript';
+import { SessionEventHub } from '@agent/runtime/SessionEventHub';
+import { defaultSession } from '@agent/runtime/SessionHandle';
+import {
+  appendStaticTranscriptItems,
+  StaticConversationTranscript,
+} from '@cli/chat/tui/panes/StaticConversationTranscript';
+import { splitTranscriptEntries } from '@cli/chat/tui/panes/transcriptEntries';
+import {
+  patchStream,
+  resetCliState,
+  streams,
+  type WorkflowScriptProgressFact,
+} from '@cli/chat/tui/state/cliState';
+import { attachTuiRunFactSubscription } from '@cli/chat/tui/state/subscribeRuntimeHost';
+import { TOOL_USE_STATUS, type StreamTabId } from '@shared/schemas';
+import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
+
+const STREAM_ID = 'workflow-script-progress' as StreamTabId;
+const cliRequire = createRequire(
+  new URL('../../../packages/cli/package.json', import.meta.url),
+);
+const SESSION_META = {
+  agent: 'research',
+  category: 'toolUse',
+  model: 'deepseekT',
+  modelSource: 'builtin-default',
+  cwd: '/tmp/project',
+  apiMode: 'personal',
+  approvalPolicy: 'ask',
+  canDelegate: true,
+  transcriptMode: 'persistent',
+  version: '0.39.6',
+} as const;
+
+const FACTS: readonly WorkflowScriptProgressFact[] = [
+  {
+    type: 'phase',
+    id: 'workflow-tool:phase:draft-phase',
+    stageId: 'draft-phase',
+    label: 'Draft sections',
+  },
+  {
+    type: 'log',
+    id: 'workflow-tool:log:0',
+    level: 'info',
+    message: 'Running: introduction',
+    phaseId: 'draft-phase',
+  },
+  {
+    type: 'log',
+    id: 'workflow-tool:log:1',
+    level: 'info',
+    message: 'Finished: introduction ($0.002 total)',
+    phaseId: 'draft-phase',
+  },
+];
+
+beforeEach(async () => {
+  resetCliState();
+  await defaultSession().transcripts.clear();
+});
+
+afterEach(() => {
+  resetCliState();
+});
+
+describe('CLI workflow-script progress', () => {
+  it('appends only facts owned by the active invocation to Static scrollback', () => {
+    const events = new SessionEventHub();
+    const detachTui = attachTuiRunFactSubscription(events);
+    const runTrace = createRunTrace(STREAM_ID, defaultSession().transcripts);
+    const detachHub = runTrace.trace.subscribe((event) =>
+      events.emit({ scope: 'run', streamId: STREAM_ID, event }),
+    );
+
+    try {
+      runTrace.trace.toolStart(
+        {
+          logId: 'workflow-tool',
+          toolName: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+          input: { agent: 'writer', script: '...' },
+        },
+        { stageId: 'round-1' },
+      );
+      let staticItems = appendStaticTranscriptItems({
+        currentItems: [],
+        streams: streams.get(),
+        meta: SESSION_META,
+        scrollbackStreamId: STREAM_ID,
+      });
+      expect(staticItems.map((item) => item.id)).toEqual([
+        'session-header',
+        'workflow-tool',
+      ]);
+      const startedEntries = streams.get().get(STREAM_ID)?.entries ?? [];
+      expect(splitTranscriptEntries(startedEntries, undefined).pending).toEqual(
+        [],
+      );
+
+      runTrace.trace.info('Preparing shared inputs', { stageId: 'round-1' });
+      const phase = runTrace.trace.openStage('Draft sections', {
+        id: 'draft-phase',
+        kind: 'phase',
+        parentId: 'round-1',
+      });
+      runTrace.trace.info('Running: introduction', { stageId: phase.id });
+      runTrace.trace.info('Finished: introduction ($0.002 total)', {
+        stageId: phase.id,
+      });
+      runTrace.trace.info('unrelated parent log', { stageId: 'other-stage' });
+
+      staticItems = appendStaticTranscriptItems({
+        currentItems: staticItems,
+        streams: streams.get(),
+        meta: SESSION_META,
+        scrollbackStreamId: STREAM_ID,
+      });
+      expect(staticItems.map((item) => item.id)).toEqual([
+        'session-header',
+        'workflow-tool',
+        'workflow-tool:log:0',
+        'workflow-tool:phase:draft-phase',
+        'workflow-tool:log:1',
+        'workflow-tool:log:2',
+      ]);
+
+      phase.end('completed');
+      runTrace.trace.toolEnd(
+        {
+          logId: 'workflow-tool',
+          status: 'completed',
+          result: {
+            toolName: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+            input: { agent: 'writer' },
+            output: 'assembled draft',
+          },
+        },
+        { stageId: 'round-1' },
+      );
+      runTrace.trace.info('after completion', { stageId: 'round-1' });
+
+      const entry = streams
+        .get()
+        .get(STREAM_ID)
+        ?.entries.find((candidate) => candidate.id === 'workflow-tool');
+      expect(entry?.role).toBe('tool');
+      if (entry?.role !== 'tool') throw new Error('missing workflow tool row');
+      expect(entry.workflowScriptFacts).toEqual([
+        {
+          type: 'log',
+          id: 'workflow-tool:log:0',
+          level: 'info',
+          message: 'Preparing shared inputs',
+        },
+        {
+          type: 'phase',
+          id: 'workflow-tool:phase:draft-phase',
+          stageId: 'draft-phase',
+          label: 'Draft sections',
+        },
+        {
+          type: 'log',
+          id: 'workflow-tool:log:1',
+          level: 'info',
+          message: 'Running: introduction',
+          phaseId: 'draft-phase',
+        },
+        {
+          type: 'log',
+          id: 'workflow-tool:log:2',
+          level: 'info',
+          message: 'Finished: introduction ($0.002 total)',
+          phaseId: 'draft-phase',
+        },
+      ]);
+      staticItems = appendStaticTranscriptItems({
+        currentItems: staticItems,
+        streams: streams.get(),
+        meta: SESSION_META,
+        scrollbackStreamId: STREAM_ID,
+      });
+      expect(staticItems.at(-1)).toMatchObject({
+        id: 'workflow-tool:completion',
+        kind: 'workflowScriptCompletion',
+      });
+    } finally {
+      detachHub();
+      runTrace.dispose();
+      detachTui();
+    }
+  });
+
+  it('renders dim Static facts verbatim without interpreting child costs', async () => {
+    patchStream(STREAM_ID, (slice) => ({
+      ...slice,
+      entries: [
+        {
+          finalized: true,
+          id: 'workflow-tool',
+          role: 'tool',
+          text: '',
+          toolUse: {
+            parsed: {},
+            toolName: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+            errorText: '',
+            outputText: '',
+            userInstructionText: '',
+            input: { agent: 'writer' },
+            isError: false,
+            isUserFeedback: false,
+            headerSummary: '',
+            status: TOOL_USE_STATUS.IN_PROGRESS,
+          },
+          workflowScriptFacts: FACTS,
+        },
+      ],
+    }));
+    const ink = (await import(cliRequire.resolve('ink'))) as any;
+    const React = ((await import(cliRequire.resolve('react'))) as any).default;
+    const output = ink.renderToString(
+      React.createElement(StaticConversationTranscript, {
+        ownerKey: 'root',
+        scrollbackStreamId: STREAM_ID,
+        width: 80,
+      }),
+      { columns: 80 },
+    );
+
+    expect(output).toContain('⎿ Draft sections');
+    expect(output).toContain('Running: introduction');
+    expect(output).toContain('Finished: introduction ($0.002 total)');
+  });
+});

--- a/src/test-kernel/cli/WorkflowScriptProgress.vitest.mts
+++ b/src/test-kernel/cli/WorkflowScriptProgress.vitest.mts
@@ -1,8 +1,10 @@
 import { createRequire } from 'node:module';
+import { setTimeout as sleep } from 'node:timers/promises';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import '@test/support/defaultSessionTestSetup';
+import { clearAllStreamStatusesForTest } from '@test/helpers/streamStatusTestUtils';
 
 import { createRunTrace } from '@transcript';
 import { SessionEventHub } from '@agent/runtime/SessionEventHub';
@@ -20,8 +22,16 @@ import {
   type WorkflowScriptProgressFact,
 } from '@cli/chat/tui/state/cliState';
 import { attachTuiRunFactSubscription } from '@cli/chat/tui/state/subscribeRuntimeHost';
-import { syncStreamLog } from '@cli/chat/tui/state/subscribeStreamLog';
-import { TOOL_USE_STATUS, type StreamTabId } from '@shared/schemas';
+import {
+  subscribeStreamLog,
+  syncStreamLog,
+} from '@cli/chat/tui/state/subscribeStreamLog';
+import { subscribeStreamStatus } from '@cli/chat/tui/state/subscribeStreamStatus';
+import {
+  STREAM_PHASE,
+  TOOL_USE_STATUS,
+  type StreamTabId,
+} from '@shared/schemas';
 import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
 
 const STREAM_ID = 'workflow-script-progress' as StreamTabId;
@@ -79,6 +89,7 @@ async function renderStaticTranscript(): Promise<string> {
 
 beforeEach(async () => {
   resetCliState();
+  clearAllStreamStatusesForTest(defaultSession().status);
   await defaultSession().transcripts.clear();
   patchStream(STREAM_ID, (slice) => ({ ...slice }));
 });
@@ -377,6 +388,7 @@ describe('CLI workflow-script progress', () => {
     (retirement) => {
       const events = new SessionEventHub();
       const detachTui = attachTuiRunFactSubscription(events);
+      const detachStatus = subscribeStreamStatus();
       const runTrace = createRunTrace(STREAM_ID, defaultSession().transcripts);
       const detachHub = runTrace.trace.subscribe((event) =>
         events.emit({ scope: 'run', streamId: STREAM_ID, event }),
@@ -397,6 +409,22 @@ describe('CLI workflow-script progress', () => {
 
         if (retirement === 'remove') removeStream(STREAM_ID);
         else resetCliState();
+
+        if (retirement === 'remove') syncStreamLog(STREAM_ID);
+        defaultSession().status.transition(
+          STREAM_ID,
+          STREAM_PHASE.RUNNING,
+          'restart-repair',
+        );
+        events.emit({
+          scope: 'run',
+          streamId: STREAM_ID,
+          event: {
+            type: 'updateTodos',
+            streamId: STREAM_ID,
+            todos: [],
+          },
+        });
 
         events.emit({
           scope: 'run',
@@ -446,10 +474,27 @@ describe('CLI workflow-script progress', () => {
       } finally {
         detachHub();
         runTrace.dispose();
+        detachStatus();
         detachTui();
       }
     },
   );
+
+  it('drops transcript synchronization queued before a reset', async () => {
+    const detachLog = subscribeStreamLog();
+    const runTrace = createRunTrace(STREAM_ID, defaultSession().transcripts);
+
+    try {
+      runTrace.trace.info('queued before reset');
+      resetCliState();
+      await sleep(100);
+
+      expect(streams.get().has(STREAM_ID)).toBe(false);
+    } finally {
+      runTrace.dispose();
+      detachLog();
+    }
+  });
 
   it('renders dim Static facts verbatim without interpreting child costs', async () => {
     patchStream(STREAM_ID, (slice) => ({

--- a/src/test-kernel/cli/WorkflowScriptProgress.vitest.mts
+++ b/src/test-kernel/cli/WorkflowScriptProgress.vitest.mts
@@ -296,15 +296,27 @@ describe('CLI workflow-script progress', () => {
   });
 
   it.each([
-    ['failed', { error: 'Writer agent failed' }, 'Writer agent failed'],
+    [
+      'failed',
+      'failed',
+      { error: 'Writer agent failed' },
+      'Writer agent failed',
+    ],
     [
       'cancelled',
+      'failed',
       { output: 'Tool execution cancelled by user.' },
       'Tool execution cancelled by user.',
     ],
-  ])(
+    [
+      'completed error result',
+      'completed',
+      { error: 'Workflow validation failed', isError: true },
+      'Workflow validation failed',
+    ],
+  ] as const)(
     'renders a terminal failure for a %s workflow',
-    async (_caseName, result, expectedMessage) => {
+    async (_caseName, status, result, expectedMessage) => {
       const events = new SessionEventHub();
       const detachTui = attachTuiRunFactSubscription(events);
       const runTrace = createRunTrace(STREAM_ID, defaultSession().transcripts);
@@ -324,7 +336,7 @@ describe('CLI workflow-script progress', () => {
         runTrace.trace.toolEnd(
           {
             logId: 'workflow-tool',
-            status: 'failed',
+            status,
             result: {
               toolName: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
               input: { agent: 'writer' },
@@ -346,7 +358,7 @@ describe('CLI workflow-script progress', () => {
         });
         if (entry?.role !== 'tool')
           throw new Error('missing workflow tool row');
-        expect(entry.toolUse.status).toBe(TOOL_USE_STATUS.COMPLETED);
+        expect(entry.toolUse.status).toBe(TOOL_USE_STATUS.FAILED);
         expect(entry.toolUse.isError).toBe(true);
 
         const output = await renderStaticTranscript();

--- a/src/test-kernel/cli/WorkflowScriptProgress.vitest.mts
+++ b/src/test-kernel/cli/WorkflowScriptProgress.vitest.mts
@@ -14,11 +14,13 @@ import {
 import { splitTranscriptEntries } from '@cli/chat/tui/panes/transcriptEntries';
 import {
   patchStream,
+  removeStream,
   resetCliState,
   streams,
   type WorkflowScriptProgressFact,
 } from '@cli/chat/tui/state/cliState';
 import { attachTuiRunFactSubscription } from '@cli/chat/tui/state/subscribeRuntimeHost';
+import { syncStreamLog } from '@cli/chat/tui/state/subscribeStreamLog';
 import { TOOL_USE_STATUS, type StreamTabId } from '@shared/schemas';
 import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
 
@@ -62,6 +64,19 @@ const FACTS: readonly WorkflowScriptProgressFact[] = [
   },
 ];
 
+async function renderStaticTranscript(): Promise<string> {
+  const ink = (await import(cliRequire.resolve('ink'))) as any;
+  const React = ((await import(cliRequire.resolve('react'))) as any).default;
+  return ink.renderToString(
+    React.createElement(StaticConversationTranscript, {
+      ownerKey: 'root',
+      scrollbackStreamId: STREAM_ID,
+      width: 80,
+    }),
+    { columns: 80 },
+  );
+}
+
 beforeEach(async () => {
   resetCliState();
   await defaultSession().transcripts.clear();
@@ -72,7 +87,7 @@ afterEach(() => {
 });
 
 describe('CLI workflow-script progress', () => {
-  it('appends only facts owned by the active invocation to Static scrollback', () => {
+  it('renders the successful terminal state and workflow result', async () => {
     const events = new SessionEventHub();
     const detachTui = attachTuiRunFactSubscription(events);
     const runTrace = createRunTrace(STREAM_ID, defaultSession().transcripts);
@@ -139,6 +154,7 @@ describe('CLI workflow-script progress', () => {
           result: {
             toolName: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
             input: { agent: 'writer' },
+            summary: "Completed workflow script 'draft' (1 agent call)",
             output: 'assembled draft',
           },
         },
@@ -190,12 +206,226 @@ describe('CLI workflow-script progress', () => {
         id: 'workflow-tool:completion',
         kind: 'workflowScriptCompletion',
       });
+      const output = await renderStaticTranscript();
+      expect(output).toContain('Workflow script completed');
+      expect(output).toContain('assembled draft');
     } finally {
       detachHub();
       runTrace.dispose();
       detachTui();
     }
   });
+
+  it('keeps workflow facts behind a preceding in-progress tool', () => {
+    const events = new SessionEventHub();
+    const detachTui = attachTuiRunFactSubscription(events);
+    const runTrace = createRunTrace(STREAM_ID, defaultSession().transcripts);
+    const detachHub = runTrace.trace.subscribe((event) =>
+      events.emit({ scope: 'run', streamId: STREAM_ID, event }),
+    );
+
+    try {
+      runTrace.trace.toolStart(
+        {
+          logId: 'preceding-tool',
+          toolName: 'bash',
+          input: { command: 'pwd' },
+        },
+        { stageId: 'round-1' },
+      );
+      runTrace.trace.toolStart(
+        {
+          logId: 'workflow-tool',
+          toolName: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+          input: { agent: 'writer', script: '...' },
+        },
+        { stageId: 'round-1' },
+      );
+      runTrace.trace.info('Preparing shared inputs', { stageId: 'round-1' });
+
+      let entries = streams.get().get(STREAM_ID)?.entries ?? [];
+      expect(entries.map((entry) => [entry.id, entry.finalized])).toEqual([
+        ['preceding-tool', false],
+        ['workflow-tool', false],
+      ]);
+      let staticItems = appendStaticTranscriptItems({
+        currentItems: [],
+        streams: streams.get(),
+        meta: SESSION_META,
+        scrollbackStreamId: STREAM_ID,
+      });
+      expect(staticItems.map((item) => item.id)).toEqual(['session-header']);
+
+      runTrace.trace.toolEnd(
+        {
+          logId: 'preceding-tool',
+          status: 'completed',
+          result: {
+            toolName: 'bash',
+            input: { command: 'pwd' },
+            output: '/tmp/project',
+          },
+        },
+        { stageId: 'round-1' },
+      );
+      syncStreamLog(STREAM_ID);
+
+      entries = streams.get().get(STREAM_ID)?.entries ?? [];
+      expect(entries.map((entry) => [entry.id, entry.finalized])).toEqual([
+        ['preceding-tool', true],
+        ['workflow-tool', true],
+      ]);
+      staticItems = appendStaticTranscriptItems({
+        currentItems: staticItems,
+        streams: streams.get(),
+        meta: SESSION_META,
+        scrollbackStreamId: STREAM_ID,
+      });
+      expect(staticItems.map((item) => item.id)).toEqual([
+        'session-header',
+        'preceding-tool',
+        'workflow-tool',
+        'workflow-tool:log:0',
+      ]);
+    } finally {
+      detachHub();
+      runTrace.dispose();
+      detachTui();
+    }
+  });
+
+  it.each([
+    ['failed', { error: 'Writer agent failed' }, 'Writer agent failed'],
+    [
+      'cancelled',
+      { output: 'Tool execution cancelled by user.' },
+      'Tool execution cancelled by user.',
+    ],
+  ])(
+    'renders a terminal failure for a %s workflow',
+    async (_caseName, result, expectedMessage) => {
+      const events = new SessionEventHub();
+      const detachTui = attachTuiRunFactSubscription(events);
+      const runTrace = createRunTrace(STREAM_ID, defaultSession().transcripts);
+      const detachHub = runTrace.trace.subscribe((event) =>
+        events.emit({ scope: 'run', streamId: STREAM_ID, event }),
+      );
+
+      try {
+        runTrace.trace.toolStart(
+          {
+            logId: 'workflow-tool',
+            toolName: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+            input: { agent: 'writer', script: '...' },
+          },
+          { stageId: 'round-1' },
+        );
+        runTrace.trace.toolEnd(
+          {
+            logId: 'workflow-tool',
+            status: 'failed',
+            result: {
+              toolName: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+              input: { agent: 'writer' },
+              isError: true,
+              ...result,
+            },
+          },
+          { stageId: 'round-1' },
+        );
+
+        const entry = streams
+          .get()
+          .get(STREAM_ID)
+          ?.entries.find((candidate) => candidate.id === 'workflow-tool');
+        expect(entry).toMatchObject({
+          finalized: true,
+          role: 'tool',
+          workflowScriptOutcome: 'failed',
+        });
+        if (entry?.role !== 'tool')
+          throw new Error('missing workflow tool row');
+        expect(entry.toolUse.status).toBe(TOOL_USE_STATUS.COMPLETED);
+        expect(entry.toolUse.isError).toBe(true);
+
+        const output = await renderStaticTranscript();
+        expect(output).toContain('Workflow script failed');
+        expect(output).toContain(expectedMessage);
+      } finally {
+        detachHub();
+        runTrace.dispose();
+        detachTui();
+      }
+    },
+  );
+
+  it.each(['remove', 'reset'] as const)(
+    '%s retires workflow ownership before late events arrive',
+    (retirement) => {
+      const events = new SessionEventHub();
+      const detachTui = attachTuiRunFactSubscription(events);
+      const runTrace = createRunTrace(STREAM_ID, defaultSession().transcripts);
+      const detachHub = runTrace.trace.subscribe((event) =>
+        events.emit({ scope: 'run', streamId: STREAM_ID, event }),
+      );
+
+      try {
+        runTrace.trace.toolStart(
+          {
+            logId: 'workflow-tool',
+            toolName: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+            input: { agent: 'writer', script: '...' },
+          },
+          { stageId: 'round-1' },
+        );
+        expect(streams.get().get(STREAM_ID)?.activeWorkflowScript?.logId).toBe(
+          'workflow-tool',
+        );
+
+        if (retirement === 'remove') removeStream(STREAM_ID);
+        else resetCliState();
+
+        events.emit({
+          scope: 'run',
+          streamId: STREAM_ID,
+          event: {
+            type: 'stage.start',
+            id: 'late-phase',
+            kind: 'phase',
+            label: 'Late phase',
+            parentId: 'round-1',
+          },
+        });
+        events.emit({
+          scope: 'run',
+          streamId: STREAM_ID,
+          event: {
+            type: 'log',
+            level: 'info',
+            message: 'late workflow log',
+            stageId: 'round-1',
+          },
+        });
+        events.emit({
+          scope: 'run',
+          streamId: STREAM_ID,
+          event: {
+            type: 'tool.end',
+            logId: 'workflow-tool',
+            status: 'failed',
+            result: { error: 'late failure' },
+            stageId: 'round-1',
+          },
+        });
+
+        expect(streams.get().has(STREAM_ID)).toBe(false);
+      } finally {
+        detachHub();
+        runTrace.dispose();
+        detachTui();
+      }
+    },
+  );
 
   it('renders dim Static facts verbatim without interpreting child costs', async () => {
     patchStream(STREAM_ID, (slice) => ({
@@ -222,16 +452,7 @@ describe('CLI workflow-script progress', () => {
         },
       ],
     }));
-    const ink = (await import(cliRequire.resolve('ink'))) as any;
-    const React = ((await import(cliRequire.resolve('react'))) as any).default;
-    const output = ink.renderToString(
-      React.createElement(StaticConversationTranscript, {
-        ownerKey: 'root',
-        scrollbackStreamId: STREAM_ID,
-        width: 80,
-      }),
-      { columns: 80 },
-    );
+    const output = await renderStaticTranscript();
 
     expect(output).toContain('⎿ Draft sections');
     expect(output).toContain('Running: introduction');

--- a/src/test-kernel/cli/WorkflowScriptProgress.vitest.mts
+++ b/src/test-kernel/cli/WorkflowScriptProgress.vitest.mts
@@ -80,6 +80,7 @@ async function renderStaticTranscript(): Promise<string> {
 beforeEach(async () => {
   resetCliState();
   await defaultSession().transcripts.clear();
+  patchStream(STREAM_ID, (slice) => ({ ...slice }));
 });
 
 afterEach(() => {
@@ -385,6 +386,17 @@ describe('CLI workflow-script progress', () => {
         if (retirement === 'remove') removeStream(STREAM_ID);
         else resetCliState();
 
+        events.emit({
+          scope: 'run',
+          streamId: STREAM_ID,
+          event: {
+            type: 'tool.start',
+            logId: 'late-workflow-tool',
+            toolName: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+            input: { agent: 'writer', script: '...' },
+            stageId: 'round-1',
+          },
+        });
         events.emit({
           scope: 'run',
           streamId: STREAM_ID,

--- a/src/test-kernel/shared/NormalizeToolUse.vitest.ts
+++ b/src/test-kernel/shared/NormalizeToolUse.vitest.ts
@@ -89,6 +89,18 @@ describe('normalizeToolUseData', () => {
     });
   });
 
+  it('treats a status-only runtime failure as an error', () => {
+    const normalized = normalizeToolUseData({
+      toolName: 'Bash',
+      status: 'failed',
+    });
+
+    expect(normalized).toMatchObject({
+      isError: true,
+      status: 'failed',
+    });
+  });
+
   // Backward compat: streams persisted by older versions stored the tool name
   // under the legacy `tool` key. `ToolUseLogSchema` folds it into `toolName` so
   // resumed/replayed cards keep tool-specific headers, icons, and file links.

--- a/src/test-kernel/shared/NormalizeToolUse.vitest.ts
+++ b/src/test-kernel/shared/NormalizeToolUse.vitest.ts
@@ -69,9 +69,24 @@ describe('normalizeToolUseData', () => {
       status: 'completed',
     });
     expect(normalized?.isError).toBe(true);
+    expect(normalized?.status).toBe('failed');
     expect(normalized?.errorText).toBe('no such file');
     // headerSummary falls back to errorText when there's no summary
     expect(normalized?.headerSummary).toBe('no such file');
+  });
+
+  it('accepts failed runtime tool status directly', () => {
+    const normalized = normalizeToolUseData({
+      toolName: 'Bash',
+      error: 'cancelled by user',
+      status: 'failed',
+    });
+
+    expect(normalized).toMatchObject({
+      errorText: 'cancelled by user',
+      isError: true,
+      status: 'failed',
+    });
   });
 
   // Backward compat: streams persisted by older versions stored the tool name


### PR DESCRIPTION
## Summary

- keep workflow phases, script log messages, and per-child cost summaries in terminal scrollback under their owning tool call
- render explicit completed and failed workflow outcomes without reordering concurrent tool rows
- bind transient workflow ownership to the stream lifecycle so removed sessions cannot be reconstructed by late events
- isolate the workflow projection behind one focused event-routing module

## Validation

- 7 focused workflow-progress tests
- root, CLI, and test-kernel TypeScript checks
- touched-file ESLint and Prettier checks
- CLI architecture check
- CLI TUI validator: 138 scenarios passed

Closes #8667

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transcript ordering, async subscribers after reset, and shared tool-use normalization; behavior is covered by focused tests but spans several TUI state edges.
> 
> **Overview**
> **Delegated workflow script runs** now leave phases, script log lines, and per-step cost text in terminal scrollback under the owning `delegate_workflow_script` tool row, with a separate completion block for success or failure plus full tool output.
> 
> A new **`workflowScriptProgress`** path maps `tool.start` / `tool.end`, `stage.start` (phases), and `log` events into immutable facts on the tool conversation entry; **`StaticConversationTranscript`** expands those into scrollback items (neutral tool header while in progress, dim fact lines, then colored completion + output). **`ToolUseRow`** / **`toolRenderers`** gain `neutralStatus`, `omitHeader`, and `showOutput` so that layout stays consistent.
> 
> **Ordering and lifecycle:** tool rows with workflow facts can enter static scrollback before the call finishes; facts append only after earlier in-progress tools settle. **`resetCliState`** / stream removal retire stream IDs and bump a **CLI state generation** so late transcript sync and run events cannot repopulate cleared sessions. Shared **`TOOL_USE_STATUS.FAILED`** and **`normalizeToolUseData`** updates align failed workflow and error payloads with the new rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e8e44e88a71a1ed6e71fae56e28eae4e82cde81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->