### PR TITLE
fix(desktop): report history watcher refresh errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,6 +237,8 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Live history refresh failures stay contained** — a filesystem refresh error
+  no longer becomes an unhandled desktop process failure.
 - **Running sessions stay connected after reopening the desktop window** —
   active runs, later turns, subagents, status updates, and pending interactions
   are rebound to the replacement window instead of continuing without visible

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,8 +82,8 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
-- **Live history refresh failures stay contained** — a filesystem refresh error
-  no longer becomes an unhandled desktop process failure.
+- **Desktop history remains usable when live refresh fails** — manual refresh
+  continues to work without the app closing unexpectedly.
 
 ## [0.39.5] - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,13 @@ All notable changes to this project will be documented in this file.
   with text in a foreground dialog now clears that text; pressing it again
   keeps the existing response-stop or exit behavior.
 
+### Desktop
+
+#### Bug Fixes
+
+- **Live history refresh failures stay contained** — a filesystem refresh error
+  no longer becomes an unhandled desktop process failure.
+
 ## [0.39.5] - 2026-07-15
 
 ### Shared (all surfaces)
@@ -237,8 +244,6 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
-- **Live history refresh failures stay contained** — a filesystem refresh error
-  no longer becomes an unhandled desktop process failure.
 - **Running sessions stay connected after reopening the desktop window** —
   active runs, later turns, subagents, status updates, and pending interactions
   are rebound to the replacement window instead of continuing without visible

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -922,7 +922,7 @@ function createWindow(options: {
   try {
     mkdirSync(executionsDir, { recursive: true });
     executionsWatcher = watch(executionsDir, { recursive: true }, () => {
-      void debouncedHistoryRepost();
+      void debouncedHistoryRepost().catch(reportAsyncError);
     });
   } catch (error) {
     reportAsyncError(error);

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -915,14 +915,18 @@ function createWindow(options: {
     RUNS_STORAGE_DIR,
   );
   const debouncedHistoryRepost = debounce(async () => {
-    if (windowClosed) return;
-    await historySettingsController.postHistoryData();
+    try {
+      if (windowClosed) return;
+      await historySettingsController.postHistoryData();
+    } catch (error) {
+      reportAsyncError(error);
+    }
   }, DEBOUNCE_OPTIONS_MS);
   let executionsWatcher: FSWatcher | undefined;
   try {
     mkdirSync(executionsDir, { recursive: true });
     executionsWatcher = watch(executionsDir, { recursive: true }, () => {
-      void debouncedHistoryRepost().catch(reportAsyncError);
+      void debouncedHistoryRepost();
     });
   } catch (error) {
     reportAsyncError(error);


### PR DESCRIPTION
## Summary

- route rejected live-history refresh promises through the desktop error reporter
- keep filesystem watching best-effort without allowing an unhandled rejection to reach Electron
- document the user-visible reliability fix

## Validation

- desktop TypeScript checks
- touched-file ESLint
- Prettier and `git diff --check`

Closes #8663

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change in a debounced background refresh path; no auth, data migration, or API contract changes.
> 
> **Overview**
> **Desktop history live refresh** no longer risks an unhandled rejection when reposting history to the renderer fails. The debounced filesystem watcher callback that calls `historySettingsController.postHistoryData()` is wrapped in **try/catch**, with failures routed through the desktop async error reporter instead of bubbling to Electron.
> 
> Manual history refresh is unchanged; watcher setup failures were already reported. The changelog notes that **history stays usable** when automatic refresh errors occur, without the app closing unexpectedly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f94f217ccb9948c6ae653307a93131bbff260f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->