### PR TITLE
fix(settings): handle history watcher setup failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,8 +82,8 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
-- **Extension history remains usable when live refresh cannot start** — manual
-  refresh continues to work without disrupting the extension.
+- **Extension history stays available if automatic updates cannot start** —
+  reopening Settings refreshes the list without disrupting the extension.
 
 ### Desktop
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,14 @@ All notable changes to this project will be documented in this file.
   with text in a foreground dialog now clears that text; pressing it again
   keeps the existing response-stop or exit behavior.
 
+### Extension (VS Code)
+
+#### Bug Fixes
+
+- **Live history refresh setup failures stay contained** — an inaccessible
+  executions directory now disables automatic refresh without producing an
+  unhandled extension-host failure.
+
 ### Desktop
 
 #### Bug Fixes
@@ -225,9 +233,6 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
-- **Live history refresh setup failures stay contained** — an inaccessible
-  executions directory now disables automatic refresh without producing an
-  unhandled extension-host failure.
 - **Lean project commands wait for the Lean extension to become ready** — cache
   fetching and other project actions no longer fail with a missing-command
   error while the Lean client is still activating.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,6 +225,9 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Live history refresh setup failures stay contained** — an inaccessible
+  executions directory now disables automatic refresh without producing an
+  unhandled extension-host failure.
 - **Lean project commands wait for the Lean extension to become ready** — cache
   fetching and other project actions no longer fail with a missing-command
   error while the Lean client is still activating.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,9 +82,8 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
-- **Live history refresh setup failures stay contained** — an inaccessible
-  executions directory now disables automatic refresh without producing an
-  unhandled extension-host failure.
+- **Extension history remains usable when live refresh cannot start** — manual
+  refresh continues to work without disrupting the extension.
 
 ### Desktop
 

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -37,6 +37,7 @@ import { WorkspaceStateKey, globalSM, workspaceSM } from '@common/state';
 import { appSignals } from '@eventBus/AppSignals';
 import { SecretManager, type ApiProvider } from '@frontend/secretManager';
 import {
+  logErrorMessage,
   showLoggedErrorMessage,
   showLoggedInfoMessage,
 } from '@frontend/ui/errorHandlingUtils';
@@ -307,29 +308,40 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
    * webview. The debounce coalesces launch and terminal write bursts.
    */
   private async registerExecutionsWatcher(): Promise<void> {
-    this.executionsWatcher?.dispose();
-    const executionsDir = path.join(
-      platform().storage.getStoragePath(),
-      RUNS_STORAGE_DIR,
-    );
-    // A watcher rooted at a not-yet-existing directory can silently never
-    // fire; the dir is cheap to create and always wanted.
-    await StorageFS.ensureDir(RUNS_STORAGE_DIR);
-    const refreshHistory = debounce(
-      () =>
-        this.withActiveWebview((w) => this.historyHandlers.sendHistoryData(w)),
-      DEBOUNCE_OPTIONS_MS,
-    );
-    const onExecutionsEvent = () => {
-      void refreshHistory();
-    };
-    const watcher = vscode.workspace.createFileSystemWatcher(
-      new vscode.RelativePattern(vscode.Uri.file(executionsDir), '**'),
-    );
-    watcher.onDidCreate(onExecutionsEvent);
-    watcher.onDidChange(onExecutionsEvent);
-    watcher.onDidDelete(onExecutionsEvent);
-    this.executionsWatcher = watcher;
+    try {
+      this.executionsWatcher?.dispose();
+      this.executionsWatcher = undefined;
+      const executionsDir = path.join(
+        platform().storage.getStoragePath(),
+        RUNS_STORAGE_DIR,
+      );
+      // A watcher rooted at a not-yet-existing directory can silently never
+      // fire; the dir is cheap to create and always wanted.
+      await StorageFS.ensureDir(RUNS_STORAGE_DIR);
+      const refreshHistory = debounce(
+        () =>
+          this.withActiveWebview((w) =>
+            this.historyHandlers.sendHistoryData(w),
+          ),
+        DEBOUNCE_OPTIONS_MS,
+      );
+      const onExecutionsEvent = () => {
+        void refreshHistory();
+      };
+      const watcher = vscode.workspace.createFileSystemWatcher(
+        new vscode.RelativePattern(vscode.Uri.file(executionsDir), '**'),
+      );
+      watcher.onDidCreate(onExecutionsEvent);
+      watcher.onDidChange(onExecutionsEvent);
+      watcher.onDidDelete(onExecutionsEvent);
+      this.executionsWatcher = watcher;
+    } catch (error) {
+      logErrorMessage(
+        this.channel,
+        'Failed to register execution history watcher',
+        error,
+      );
+    }
   }
 
   private createHandlerRegistry(): SettingsViewInboundHandlerRegistry {

--- a/src/test-kernel/settings/ExecutionHistoryWatcher.vitest.ts
+++ b/src/test-kernel/settings/ExecutionHistoryWatcher.vitest.ts
@@ -12,6 +12,8 @@ describe('settings execution history watcher', () => {
     const failure = new Error('permission denied');
     vi.spyOn(StorageFS, 'ensureDir').mockRejectedValue(failure);
     const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    // The full constructor requires a live ExtensionContext; this method reaches
+    // only the explicitly initialized watcher and logging fields in this path.
     const handler = Object.create(SettingsViewMessageHandler.prototype);
     Reflect.set(handler, 'channel', 'SettingsViewMessageHandler');
     const registerWatcher = Reflect.get(

--- a/src/test-kernel/settings/ExecutionHistoryWatcher.vitest.ts
+++ b/src/test-kernel/settings/ExecutionHistoryWatcher.vitest.ts
@@ -1,0 +1,30 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import * as logger from '@logger/logUtils';
+import { SettingsViewMessageHandler } from '@settingsView/SettingsViewMessageHandler';
+import { StorageFS } from '@utils/files';
+
+describe('settings execution history watcher', () => {
+  it('logs and absorbs directory setup failures', async () => {
+    const failure = new Error('permission denied');
+    vi.spyOn(StorageFS, 'ensureDir').mockRejectedValue(failure);
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    const handler = Object.create(SettingsViewMessageHandler.prototype);
+    Reflect.set(handler, 'channel', 'SettingsViewMessageHandler');
+    const registerWatcher = Reflect.get(
+      handler,
+      'registerExecutionsWatcher',
+    ) as () => Promise<void>;
+
+    await expect(Reflect.apply(registerWatcher, handler, [])).resolves.toBe(
+      undefined,
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      'SettingsViewMessageHandler',
+      'Failed to register execution history watcher: permission denied',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- contain execution-history watcher setup failures inside the extension host
- log the failure through the existing extension error channel and leave automatic refresh disabled
- clear disposed watcher state and cover an inaccessible executions directory

## Validation

- focused execution-history watcher test
- production and test-kernel TypeScript checks
- touched-file ESLint
- Prettier and `git diff --check`

Closes #8664

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized defensive handling around file watcher registration; no auth, data migration, or API contract changes.
> 
> **Overview**
> **VS Code extension:** execution-history auto-refresh no longer takes down the extension host when watcher setup fails (for example an inaccessible shared executions directory).
> 
> `registerExecutionsWatcher` in `SettingsViewMessageHandler` now runs inside **try/catch**, disposes any prior watcher and clears `executionsWatcher` before retrying, and on failure logs through **`logErrorMessage`** instead of throwing. Automatic live updates are skipped in that case; reopening Settings can still refresh history manually.
> 
> **CHANGELOG** documents the fix under Extension (VS Code). A focused **Vitest** test asserts `StorageFS.ensureDir` rejections are logged and absorbed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f730ec2e236b060e0c4b7998747966ff591c4b0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->