### PR TITLE
fix(settings): serialize history watcher registration

### DIFF
--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -162,6 +162,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   vscode.WebviewView | vscode.WebviewPanel
 > {
   private executionsWatcher: vscode.FileSystemWatcher | undefined;
+  private executionsWatcherGeneration = 0;
   private readonly handlerRegistry: SettingsViewInboundHandlerRegistry;
 
   // Domain-specific handler delegates
@@ -298,8 +299,16 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       vscode.workspace.onDidChangeWorkspaceFolders(() => {
         void this.registerExecutionsWatcher();
       }),
-      { dispose: () => this.executionsWatcher?.dispose() },
+      { dispose: () => this.invalidateExecutionsWatcher() },
     );
+  }
+
+  private invalidateExecutionsWatcher(): number {
+    const generation = ++this.executionsWatcherGeneration;
+    const watcher = this.executionsWatcher;
+    this.executionsWatcher = undefined;
+    watcher?.dispose();
+    return generation;
   }
 
   /**
@@ -308,9 +317,9 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
    * webview. The debounce coalesces launch and terminal write bursts.
    */
   private async registerExecutionsWatcher(): Promise<void> {
+    const generation = this.invalidateExecutionsWatcher();
+    let candidate: vscode.FileSystemWatcher | undefined;
     try {
-      this.executionsWatcher?.dispose();
-      this.executionsWatcher = undefined;
       const executionsDir = path.join(
         platform().storage.getStoragePath(),
         RUNS_STORAGE_DIR,
@@ -318,6 +327,9 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       // A watcher rooted at a not-yet-existing directory can silently never
       // fire; the dir is cheap to create and always wanted.
       await StorageFS.ensureDir(RUNS_STORAGE_DIR);
+      // A workspace change or teardown may supersede this registration while
+      // directory setup is pending.
+      if (generation !== this.executionsWatcherGeneration) return;
       const refreshHistory = debounce(
         () =>
           this.withActiveWebview((w) =>
@@ -328,14 +340,21 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       const onExecutionsEvent = () => {
         void refreshHistory();
       };
-      const watcher = vscode.workspace.createFileSystemWatcher(
+      candidate = vscode.workspace.createFileSystemWatcher(
         new vscode.RelativePattern(vscode.Uri.file(executionsDir), '**'),
       );
-      watcher.onDidCreate(onExecutionsEvent);
-      watcher.onDidChange(onExecutionsEvent);
-      watcher.onDidDelete(onExecutionsEvent);
-      this.executionsWatcher = watcher;
+      candidate.onDidCreate(onExecutionsEvent);
+      candidate.onDidChange(onExecutionsEvent);
+      candidate.onDidDelete(onExecutionsEvent);
+      // Publish only a candidate that still owns the current generation.
+      if (generation !== this.executionsWatcherGeneration) {
+        candidate.dispose();
+        return;
+      }
+      this.executionsWatcher = candidate;
     } catch (error) {
+      candidate?.dispose();
+      if (generation !== this.executionsWatcherGeneration) return;
       logErrorMessage(
         this.channel,
         'Failed to register execution history watcher',

--- a/src/test-kernel/settings/ExecutionHistoryWatcher.vitest.ts
+++ b/src/test-kernel/settings/ExecutionHistoryWatcher.vitest.ts
@@ -1,32 +1,123 @@
 // Test composition imports
 import '@test/support/defaultSessionTestSetup';
 
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as vscode from 'vscode';
 
 import * as logger from '@logger/logUtils';
 import { SettingsViewMessageHandler } from '@settingsView/SettingsViewMessageHandler';
 import { StorageFS } from '@utils/files';
 
+type WatcherHarness = {
+  executionsWatcher?: vscode.FileSystemWatcher;
+  executionsWatcherGeneration: number;
+  invalidateExecutionsWatcher: () => number;
+  registerExecutionsWatcher: () => Promise<void>;
+};
+
+function createHandlerHarness(): WatcherHarness {
+  // The full constructor requires a live ExtensionContext; these methods reach
+  // only the explicitly initialized watcher, generation, and logging fields.
+  const handler = Object.create(SettingsViewMessageHandler.prototype);
+  Reflect.set(handler, 'channel', 'SettingsViewMessageHandler');
+  Reflect.set(handler, 'executionsWatcherGeneration', 0);
+  return handler as WatcherHarness;
+}
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve = () => {};
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function watcher(): vscode.FileSystemWatcher {
+  return {
+    onDidCreate: vi.fn(() => ({ dispose: vi.fn() })),
+    onDidChange: vi.fn(() => ({ dispose: vi.fn() })),
+    onDidDelete: vi.fn(() => ({ dispose: vi.fn() })),
+    dispose: vi.fn(),
+    ignoreChangeEvents: false,
+    ignoreCreateEvents: false,
+    ignoreDeleteEvents: false,
+  };
+}
+
 describe('settings execution history watcher', () => {
+  afterEach(() => vi.restoreAllMocks());
+
   it('logs and absorbs directory setup failures', async () => {
     const failure = new Error('permission denied');
     vi.spyOn(StorageFS, 'ensureDir').mockRejectedValue(failure);
     const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
-    // The full constructor requires a live ExtensionContext; this method reaches
-    // only the explicitly initialized watcher and logging fields in this path.
-    const handler = Object.create(SettingsViewMessageHandler.prototype);
-    Reflect.set(handler, 'channel', 'SettingsViewMessageHandler');
-    const registerWatcher = Reflect.get(
-      handler,
-      'registerExecutionsWatcher',
-    ) as () => Promise<void>;
+    const handler = createHandlerHarness();
 
-    await expect(Reflect.apply(registerWatcher, handler, [])).resolves.toBe(
-      undefined,
-    );
+    await expect(handler.registerExecutionsWatcher()).resolves.toBeUndefined();
     expect(errorSpy).toHaveBeenCalledWith(
       'SettingsViewMessageHandler',
       'Failed to register execution history watcher: permission denied',
     );
+  });
+
+  it('keeps the newest watcher when setup completes out of order', async () => {
+    const firstSetup = deferred();
+    const secondSetup = deferred();
+    vi.spyOn(StorageFS, 'ensureDir')
+      .mockImplementationOnce(() => firstSetup.promise)
+      .mockImplementationOnce(() => secondSetup.promise);
+    const currentWatcher = watcher();
+    const createWatcher = vi
+      .spyOn(vscode.workspace, 'createFileSystemWatcher')
+      .mockReturnValue(currentWatcher);
+    const handler = createHandlerHarness();
+
+    const first = handler.registerExecutionsWatcher();
+    const second = handler.registerExecutionsWatcher();
+    secondSetup.resolve();
+    await second;
+    firstSetup.resolve();
+    await first;
+
+    expect(createWatcher).toHaveBeenCalledTimes(1);
+    expect(handler.executionsWatcher).toBe(currentWatcher);
+    expect(currentWatcher.dispose).not.toHaveBeenCalled();
+  });
+
+  it('disposes a candidate made stale by synchronous reentrancy', async () => {
+    vi.spyOn(StorageFS, 'ensureDir').mockResolvedValue(undefined);
+    const staleWatcher = watcher();
+    const currentWatcher = watcher();
+    const handler = createHandlerHarness();
+    let second: Promise<void> | undefined;
+    vi.spyOn(vscode.workspace, 'createFileSystemWatcher')
+      .mockImplementationOnce(() => {
+        second = handler.registerExecutionsWatcher();
+        return staleWatcher;
+      })
+      .mockReturnValueOnce(currentWatcher);
+
+    await handler.registerExecutionsWatcher();
+    if (!second) throw new Error('reentrant registration did not start');
+    await second;
+
+    expect(staleWatcher.dispose).toHaveBeenCalledOnce();
+    expect(currentWatcher.dispose).not.toHaveBeenCalled();
+    expect(handler.executionsWatcher).toBe(currentWatcher);
+  });
+
+  it('invalidates setup still pending during teardown', async () => {
+    const setup = deferred();
+    vi.spyOn(StorageFS, 'ensureDir').mockReturnValue(setup.promise);
+    const createWatcher = vi.spyOn(vscode.workspace, 'createFileSystemWatcher');
+    const handler = createHandlerHarness();
+
+    const registration = handler.registerExecutionsWatcher();
+    handler.invalidateExecutionsWatcher();
+    setup.resolve();
+    await registration;
+
+    expect(createWatcher).not.toHaveBeenCalled();
+    expect(handler.executionsWatcher).toBeUndefined();
   });
 });

--- a/src/test-kernel/support/vscode-mock.ts
+++ b/src/test-kernel/support/vscode-mock.ts
@@ -21,6 +21,12 @@ export const workspace = {
     get: <T>(_key: string, defaultValue?: T): T | undefined => defaultValue,
   }),
   onDidChangeConfiguration: () => ({ dispose: () => {} }),
+  createFileSystemWatcher: () => ({
+    onDidCreate: () => ({ dispose: () => {} }),
+    onDidChange: () => ({ dispose: () => {} }),
+    onDidDelete: () => ({ dispose: () => {} }),
+    dispose: () => {},
+  }),
 };
 
 export const commands = {
@@ -31,6 +37,13 @@ export const Uri = {
   file: (p: string) => ({ fsPath: p, toString: () => p, path: p }),
   parse: (s: string) => ({ fsPath: s, toString: () => s, path: s }),
 };
+
+export class RelativePattern {
+  constructor(
+    public readonly base: unknown,
+    public readonly pattern: string,
+  ) {}
+}
 
 export const FileType = {
   Unknown: 0,


### PR DESCRIPTION
## Summary

- make the newest execution-history watcher registration the sole owner
- dispose stale candidate watchers and invalidate pending setup during teardown
- cover out-of-order completion, synchronous reentrancy, and teardown during setup

## Validation

- 4 focused execution-history watcher tests
- production and test-kernel TypeScript checks
- touched-file ESLint
- Prettier and `git diff --check`

Stacked on #8674; retarget to `main` after that PR merges.

Closes #8665

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized settings-view lifecycle fix for the shared executions directory watcher, with focused unit tests and no auth or data-model changes.
> 
> **Overview**
> Fixes a race where overlapping `registerExecutionsWatcher` calls (workspace folder changes or rapid re-registration) could leave multiple file watchers active or publish a stale watcher after async directory setup.
> 
> **Generation-based ownership:** Each registration bumps `executionsWatcherGeneration` via `invalidateExecutionsWatcher()`, which disposes the current watcher. In-flight setups compare their captured generation before creating or publishing a watcher; superseded work exits early and disposes any candidate. Extension teardown uses the same invalidation path instead of only disposing the last stored watcher.
> 
> **Tests:** Vitest coverage for out-of-order `ensureDir` completion, synchronous re-entrancy during watcher creation, and invalidation while setup is still pending. The vscode test stub gains `createFileSystemWatcher` and `RelativePattern`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52a950944d24498be242553b699ba8fbca3e87e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->