### PR TITLE
feat(workflow): improve script recovery diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ All notable changes to this project will be documented in this file.
 - **Delegated agents follow live auto-approval changes** — enabling or
   disabling file and command auto-approval on a parent now updates its running
   delegated agents and their visible status.
+- **Resumable workflows are easier for agents to use and repair** — workflow
+  scripts now explain their file-passing contract, report useful source
+  locations and recent activity after failures, reject missing file inputs,
+  and retain completed steps when a retry revises the script.
 
 ### CLI
 

--- a/src/agent/workflowScript/checkpointKey.ts
+++ b/src/agent/workflowScript/checkpointKey.ts
@@ -7,30 +7,26 @@ import stableStringify from 'fast-json-stable-stringify';
 const WORKFLOW_SCRIPT_CHECKPOINT_KEY_PREFIX = 'workflow-script-';
 
 /**
- * Content-derived checkpoint identity: the same script, args, and default
- * agent under the same parent execution resume the same durable journal, so
- * an LLM retry after a timeout or interruption (which mints a new tool-call
- * id) replays completed work instead of orphaning it. Same-content
- * semantics: a script that must re-execute from scratch needs different
- * content (e.g. a nonce field in args).
- *
- * Omitted args and explicit null args hash differently (stableStringify
- * drops undefined properties), matching the persistence layer, which
- * stores them as distinct values and fails loudly on a mismatch.
+ * Named checkpoint identity: `meta.name` plus the default agent under one
+ * parent execution owns one durable journal. A retry after a timeout or
+ * interruption resumes that journal even when the model rewrites the script
+ * (models rarely reproduce source byte-for-byte); safety lives in the journal
+ * itself, whose entries replay only on a matching call index and prompt/
+ * options hash — a changed call re-executes, an unchanged one is free.
+ * A script that must re-execute everything from scratch needs a new
+ * meta.name.
  */
 export function deriveWorkflowScriptCheckpointId(identity: {
-  readonly script: string;
-  readonly args: unknown;
+  readonly name: string;
   readonly defaultAgent: string;
   readonly parentExecutionId: string;
 }): string {
   return createHash('sha256')
     .update(
       stableStringify({
-        args: identity.args,
         defaultAgent: identity.defaultAgent,
+        name: identity.name,
         parentExecutionId: identity.parentExecutionId,
-        script: identity.script,
       }),
     )
     .digest('hex')

--- a/src/agent/workflowScript/persistence.ts
+++ b/src/agent/workflowScript/persistence.ts
@@ -1,6 +1,5 @@
 // Third-party imports
 import { z } from 'zod';
-import stableStringify from 'fast-json-stable-stringify';
 
 // Local imports - storage
 import type { ExecutionKVStore } from '@agent/storage/ExecutionKVStore';
@@ -108,13 +107,6 @@ function decodeJsonValue(value: PersistedJsonValue): unknown {
   return value.kind === 'undefined' ? undefined : value.value;
 }
 
-function persistedValuesEqual(
-  left: PersistedJsonValue,
-  right: PersistedJsonValue,
-): boolean {
-  return stableStringify(left) === stableStringify(right);
-}
-
 function encodeJournalEntry(
   entry: WorkflowJournalEntry,
 ): PersistedWorkflowJournalEntry {
@@ -215,16 +207,13 @@ async function runPersistedWorkflowScriptLocked(
     ...runOptions
   } = options;
   const prior = await readWorkflowScriptCheckpoint(store, checkpointId);
-  if (
-    prior !== null &&
-    requestedScript !== undefined &&
-    requestedScript !== prior.script
-  ) {
-    throw new WorkflowScriptPersistenceError(
-      `Workflow checkpoint ${checkpointId} belongs to different script text.`,
-    );
-  }
-  const script = prior?.script ?? requestedScript;
+  // A named checkpoint outlives one tool call, and callers legitimately
+  // evolve the script between attempts (a model retrying after a timeout
+  // rarely reproduces its source byte-for-byte). Adopt the requested script
+  // and args, keep the journal: an entry replays only on a matching call
+  // index and prompt/options hash, so drifted calls re-execute while
+  // unchanged ones stay free.
+  const script = requestedScript ?? prior?.script;
   if (script === undefined) {
     throw new WorkflowScriptPersistenceError(
       `Workflow checkpoint ${checkpointId} does not exist; a script is required for the first run.`,
@@ -241,17 +230,10 @@ async function runPersistedWorkflowScriptLocked(
       { cause: error },
     );
   }
-  if (
-    prior !== null &&
-    Object.hasOwn(options, 'args') &&
-    !persistedValuesEqual(encodedRequestedArgs, encodeJsonValue(prior.args))
-  ) {
-    throw new WorkflowScriptPersistenceError(
-      `Workflow checkpoint ${checkpointId} belongs to different arguments.`,
-    );
-  }
   const args =
-    prior !== null ? prior.args : decodeJsonValue(encodedRequestedArgs);
+    Object.hasOwn(options, 'args') || prior === null
+      ? decodeJsonValue(encodedRequestedArgs)
+      : prior.args;
 
   const journalByIndex = new Map(
     (prior?.journal ?? []).map((entry) => [entry.index, entry]),

--- a/src/agent/workflowScript/sandbox.ts
+++ b/src/agent/workflowScript/sandbox.ts
@@ -211,7 +211,14 @@ const BRIDGE_PRELUDE = `
     delivered = true;
     if (isError) {
       const err = toRealmError(value);
-      hostDeliver(undefined, stringifyJson({ name: err.name, message: err.message }));
+      const stack =
+        value && typeof value === 'object' && 'stack' in value && value.stack
+          ? String(value.stack)
+          : undefined;
+      hostDeliver(
+        undefined,
+        stringifyJson({ name: err.name, message: err.message, stack }),
+      );
       return;
     }
     let payload;
@@ -655,8 +662,22 @@ function parseOutcome(payload?: string, errorJson?: string): GuestOutcome {
         ),
       };
     }
-    const record = parsed as { name: string; message: string };
-    const error = new Error(record.message);
+    const record = parsed as { name: string; message: string; stack?: string };
+    // Guest stack frames locate the failure inside the script (the only
+    // context a caller has for a sandboxed error), so fold them into the
+    // message the tool result carries.
+    const frames =
+      typeof record.stack === 'string'
+        ? record.stack
+            .split('\n')
+            .filter((line) => line.trim().startsWith('at '))
+            .slice(0, 3)
+        : [];
+    const error = new Error(
+      frames.length > 0
+        ? `${record.message}\n${frames.join('\n')}`
+        : record.message,
+    );
     error.name = record.name;
     return { error };
   }

--- a/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
@@ -103,8 +103,11 @@ function defaultRunner(): ReturnType<typeof createWorkflowScriptAgentRunner> {
   );
 }
 
+// Default options carry inputFiles: workflow agents without input files (and
+// without declared default outputs) fail fast by design; the dedicated test
+// below covers that path.
 function invocation(
-  options: WorkflowAgentInvocation['options'] = {},
+  options: WorkflowAgentInvocation['options'] = { inputFiles: ['draft.tex'] },
 ): WorkflowAgentInvocation {
   return {
     index: 0,
@@ -225,7 +228,7 @@ describe('createWorkflowScriptAgentRunner', () => {
     );
   });
 
-  it('omits declared symlink placeholders from the next child input', async () => {
+  it('rejects a run-storage input that no longer resolves', async () => {
     const placeholder = '/storage/executions/bbbbbb222222/r1/unchanged.tex';
     mocks.runStorageLocationFromAnyAbsolutePath.mockReturnValue({
       kind: 'runStorage',
@@ -233,13 +236,10 @@ describe('createWorkflowScriptAgentRunner', () => {
     mocks.resolveChildRunOutput.mockResolvedValue(undefined);
     const runner = defaultRunner();
 
-    await runner(invocation({ inputFiles: [placeholder] }));
-
-    expect(mocks.preparedOptions[0]).toEqual(
-      expect.objectContaining({
-        configPayload: expect.objectContaining({ inputFiles: [] }),
-      }),
-    );
+    await expect(
+      runner(invocation({ inputFiles: [placeholder] })),
+    ).rejects.toThrow(/pass options\.inputFiles with files that still exist/);
+    expect(mocks.preparedOptions).toHaveLength(0);
   });
 
   it('links child approval ancestry to the parent stream on resolve', async () => {
@@ -298,6 +298,27 @@ describe('createWorkflowScriptAgentRunner', () => {
     await runner({ ...invocation(), index: 3 });
 
     expect(onCost).not.toHaveBeenCalled();
+  });
+
+  it('fails fast when a file-editing agent gets no input files', async () => {
+    const runner = defaultRunner();
+
+    await expect(runner(invocation({}))).rejects.toThrow(
+      /pass options\.inputFiles with files that still exist/,
+    );
+  });
+
+  it('allows empty input files when the agent declares default outputs', async () => {
+    mocks.requireVisibleAgent.mockImplementation((_category, name) => ({
+      name,
+      source: 'builtInWorkflow',
+      category: 'workflow',
+      path: `/agents/${name}.yml`,
+      defaultOutputFiles: ['generated.tex'],
+    }));
+    const runner = defaultRunner();
+
+    await expect(runner(invocation({}))).resolves.toBe(result);
   });
 
   it('uses one stable child id per workflow call identity', async () => {

--- a/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
@@ -648,6 +648,21 @@ return results[0]`,
     ).rejects.toThrow(/not JSON-serializable/i);
   });
 
+  it('carries guest stack frames on script errors', async () => {
+    // The classic un-awaited fan-out mistake: destructuring the Promise that
+    // parallel() returns. The bare QuickJS message ("value is not iterable")
+    // is useless without the frame locating it inside the script.
+    await expect(
+      runWorkflowScript({
+        script: `${META}
+const [a, b] = parallel([() => agent('x'), () => agent('y')])
+return a`,
+        runAgent: echoRunner,
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow(/is not iterable[\s\S]*at .*test-flow\.workflow\.js:\d+/);
+  });
+
   it('cannot forge a result by overriding Promise.prototype.then', async () => {
     // then/catch/finally are locked non-writable before the body runs, so a
     // script that tries to reassign then (to invoke the kickoff's delivery

--- a/src/test-kernel/agent/WorkflowScriptPersistence.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptPersistence.vitest.ts
@@ -99,23 +99,39 @@ describe('workflow-script persistence', () => {
     ).rejects.toBeInstanceOf(WorkflowScriptPersistenceError);
   });
 
-  it('rejects script drift for an existing tool call id', async () => {
+  it('accepts script drift: unchanged calls replay, changed calls re-run', async () => {
     const store = getExecutionStore(executionId);
     await runPersistedWorkflowScript({
       store,
       checkpointId: 'stable-call',
       script,
-      runAgent: async () => 'done',
+      runAgent: async ({ prompt }) => `v1:${prompt}`,
     });
 
+    clearStoreCache();
+    const retryRunner = vi.fn(
+      async ({ prompt }: { prompt: string }) => `v2:${prompt}`,
+    );
+    const evolved = await runPersistedWorkflowScript({
+      store: getExecutionStore(executionId),
+      checkpointId: 'stable-call',
+      script: script.replace(`agent('second')`, `agent('changed')`),
+      runAgent: retryRunner,
+    });
+
+    // 'first' is unchanged (same index + prompt hash) so it replays free;
+    // only the drifted second call executes live, and the evolved script
+    // becomes the stored one.
+    expect(retryRunner).toHaveBeenCalledTimes(1);
+    expect(evolved.result).toEqual(['v1:first', 'v2:changed']);
     await expect(
-      runPersistedWorkflowScript({
-        store,
-        checkpointId: 'stable-call',
-        script: script.replace('second', 'changed'),
-        runAgent: async () => 'changed',
-      }),
-    ).rejects.toThrow(/different script text/i);
+      readWorkflowScriptCheckpoint(
+        getExecutionStore(executionId),
+        'stable-call',
+      ),
+    ).resolves.toMatchObject({
+      script: expect.stringContaining(`agent('changed')`),
+    });
   });
 
   it('round-trips an undefined agent result explicitly', async () => {
@@ -212,24 +228,35 @@ return await agent(args.topic)`;
     ).resolves.toMatchObject({ args: { topic: 'geometry' } });
   });
 
-  it('rejects argument drift for an existing tool call id', async () => {
+  it('adopts new arguments on resume and keeps the journal', async () => {
     const store = getExecutionStore(executionId);
+    const argsScript = `export const meta = {
+  name: 'args-evolve',
+  description: 'adopts evolved arguments',
+}
+const first = await agent('first')
+return [first, args.topic]`;
     await runPersistedWorkflowScript({
       store,
       checkpointId: 'stable-args',
-      script,
+      script: argsScript,
       args: { topic: 'geometry' },
-      runAgent: async () => 'done',
+      runAgent: async ({ prompt }) => `v1:${prompt}`,
     });
 
-    await expect(
-      runPersistedWorkflowScript({
-        store,
-        checkpointId: 'stable-args',
-        args: { topic: 'analysis' },
-        runAgent: async () => 'changed',
-      }),
-    ).rejects.toThrow(/different arguments/i);
+    clearStoreCache();
+    const retryRunner = vi.fn(() => Promise.reject(new Error('live run')));
+    const evolved = await runPersistedWorkflowScript({
+      store: getExecutionStore(executionId),
+      checkpointId: 'stable-args',
+      script: argsScript,
+      args: { topic: 'analysis' },
+      runAgent: retryRunner,
+    });
+
+    // The unchanged agent() call replays; the script sees the new args.
+    expect(retryRunner).not.toHaveBeenCalled();
+    expect(evolved.result).toEqual(['v1:first', 'analysis']);
   });
 
   it('validates arguments before creating a checkpoint or launching an agent', async () => {

--- a/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
@@ -52,11 +52,10 @@ function parentContext(): LaunchRunContext {
   };
 }
 
-/** The tool's durable identity for a script+args pair under the test parent. */
-function checkpointIdFor(scriptSource: string, args?: unknown): string {
+/** The tool's durable identity for one meta.name under the test parent. */
+function checkpointIdFor(name: string): string {
   return deriveWorkflowScriptCheckpointId({
-    script: scriptSource,
-    args,
+    name,
     defaultAgent: 'correct',
     parentExecutionId: executionId,
   });
@@ -83,7 +82,7 @@ async function callTool(options?: {
         new WorkflowScriptTool().call({
           agent: 'correct',
           script: options?.script ?? script,
-          args: options?.args,
+          ...(options?.args !== undefined && { args: options.args }),
         }),
     ),
   );
@@ -134,10 +133,10 @@ describe('WorkflowScriptTool', () => {
     });
   });
 
-  it('replays a content-keyed checkpoint across distinct tool-call ids', async () => {
+  it('resumes a named checkpoint even when the retry rewrites the script', async () => {
     await runPersistedWorkflowScript({
       store: getExecutionStore(executionId),
-      checkpointId: checkpointIdFor(script),
+      checkpointId: checkpointIdFor('tool-test'),
       script,
       runAgent: async () => finalResult,
     });
@@ -151,29 +150,34 @@ describe('WorkflowScriptTool', () => {
       summary: "Completed workflow script 'tool-test' (1 agent call)",
     });
     expect(result.output).toContain('"category": "workflow"');
+    // The run log rides along so the invoking model sees what executed.
+    expect(result.output).toContain('=== Run log ===');
+    expect(result.output).toContain('Using saved result');
     // Delta accounting: replayed entries were settled by the attempt that
     // executed them, so a pure replay settles zero instead of double-billing.
     expect(recordCost).toHaveBeenCalledTimes(1);
     expect(recordCost).toHaveBeenCalledWith(0);
 
-    // A retry mints a new tool-call id; identical content resumes the journal.
+    // A retrying model rewrites its source; same meta.name still resumes,
+    // and the unchanged agent() call replays instead of re-executing.
     clearStoreCache();
     const retryCost = vi.fn();
     const retry = await callTool({
       toolCallId: 'attempt-2',
       recordCost: retryCost,
+      script: `${script}\n// retry rewrote me`,
     });
     expect(retry).toMatchObject({ status: 'executed' });
+    expect(retry.output).toContain('Using saved result');
     expect(retryCost).toHaveBeenCalledWith(0);
   });
 
-  it('derives distinct checkpoints when args presence or default agent differ', () => {
-    const base = checkpointIdFor(script);
-    expect(checkpointIdFor(script, null)).not.toBe(base);
+  it('derives distinct checkpoints when name or default agent differ', () => {
+    const base = checkpointIdFor('tool-test');
+    expect(checkpointIdFor('other-name')).not.toBe(base);
     expect(
       deriveWorkflowScriptCheckpointId({
-        script,
-        args: undefined,
+        name: 'tool-test',
         defaultAgent: 'merge',
         parentExecutionId: executionId,
       }),
@@ -201,9 +205,56 @@ return args`,
     expect(recordCost).toHaveBeenCalledWith(0);
   });
 
+  it('retains checkpoint arguments when a retry omits them', async () => {
+    const argsScript = `export const meta = {
+  name: 'retained-arguments',
+  description: 'retains omitted retry arguments',
+}
+return args`;
+    await runPersistedWorkflowScript({
+      store: getExecutionStore(executionId),
+      checkpointId: checkpointIdFor('retained-arguments'),
+      script: argsScript,
+      args: { topic: 'geometry' },
+      runAgent: async () => finalResult,
+    });
+    clearStoreCache();
+
+    const result = await callTool({
+      script: `${argsScript}\n// revised retry`,
+    });
+
+    expect(result).toMatchObject({
+      status: 'executed',
+      output: expect.stringContaining('"topic": "geometry"'),
+    });
+  });
+
+  it('bounds and normalizes the model-visible run log', async () => {
+    const result = await callTool({
+      script: `export const meta = {
+  name: 'bounded-log',
+  description: 'bounds model-visible activity',
+}
+for (let index = 0; index < 100; index += 1) log('line-' + index)
+log('oversized\\n' + 'x'.repeat(2_000))
+return 'done'`,
+    });
+
+    expect(result).toMatchObject({ status: 'executed' });
+    expect(result.output).toContain(
+      '=== Run log (last 80 lines; 21 earlier lines omitted) ===',
+    );
+    expect(result.output).not.toContain('line-20\n');
+    expect(result.output).toContain('line-21\n');
+    expect(result.output).toContain('oversized x');
+    expect(result.output).not.toContain('oversized\n');
+    expect(result.output?.length).toBeLessThan(42_000);
+  });
+
   it('settles a retained journal when later script code fails', async () => {
     const failingScript = `export const meta = {
-  name: 'tool-test',
+  name: 'retained-settlement',
   description: 'tests retained journal settlement',
 }
 await agent('saved call')
@@ -211,7 +262,7 @@ throw new Error('script failed after replay')`;
     await expect(
       runPersistedWorkflowScript({
         store: getExecutionStore(executionId),
-        checkpointId: checkpointIdFor(failingScript),
+        checkpointId: checkpointIdFor('retained-settlement'),
         script: failingScript,
         runAgent: async () => finalResult,
       }),
@@ -228,21 +279,25 @@ throw new Error('script failed after replay')`;
       status: 'error',
       error: expect.stringContaining('script failed after replay'),
     });
+    // Failures carry the run log and the resume hint back to the model.
+    expect(result.error).toContain(
+      "journaled under meta.name 'retained-settlement'",
+    );
     // The seeding attempt journaled the entry; this attempt only replays it.
     expect(recordCost).toHaveBeenCalledTimes(1);
     expect(recordCost).toHaveBeenCalledWith(0);
   });
 
   it('fails closed on malformed journal costs without recording a scalar', async () => {
-    // Distinct script so this journal cannot alias the replay test's content key.
+    // Distinct meta.name so this journal cannot alias the replay test's key.
     const malformedScript = `export const meta = {
-  name: 'tool-test',
+  name: 'malformed-cost',
   description: 'tests malformed journal cost settlement',
 }
 return await agent('saved call')`;
     await runPersistedWorkflowScript({
       store: getExecutionStore(executionId),
-      checkpointId: checkpointIdFor(malformedScript),
+      checkpointId: checkpointIdFor('malformed-cost'),
       script: malformedScript,
       runAgent: async () => ({ not: 'an agent result' }),
     });

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { getExecutionStore } from '@agent/storage';
 import {
   deriveWorkflowScriptCheckpointId,
+  parseWorkflowScript,
   readWorkflowScriptCheckpoint,
   type WorkflowJournalEntry,
   type WorkflowScriptRunResult,
@@ -20,7 +21,7 @@ import { defineTool } from '@tools/core/define';
 
 // Local imports - utilities
 import { toErrorMessage } from '@utils/errors/errorMessage';
-import { formatResultCount } from '@utils/text/stringUtils';
+import { formatResultCount, truncateSummary } from '@utils/text/stringUtils';
 
 // Local imports - delegation
 import { createWorkflowScriptAgentRunner } from './workflowScriptAgentRunner';
@@ -54,16 +55,59 @@ function formatWorkflowResult(result: unknown): string {
   return JSON.stringify(result, null, 2) ?? 'undefined';
 }
 
+const RUN_LOG_MAX_LINES = 80;
+const RUN_LOG_MAX_LINE_LENGTH = 500;
+
+interface RunLogCollector {
+  readonly add: (line: string) => void;
+  readonly format: () => string;
+}
+
+/** Retain a small, single-line tail for the invoking model. */
+function createRunLogCollector(): RunLogCollector {
+  const lines: string[] = [];
+  let omitted = 0;
+  return {
+    add: (line) => {
+      lines.push(truncateSummary(line, RUN_LOG_MAX_LINE_LENGTH));
+      if (lines.length > RUN_LOG_MAX_LINES) {
+        lines.shift();
+        omitted += 1;
+      }
+    },
+    format: () => {
+      if (lines.length === 0) return '';
+      const header =
+        omitted > 0
+          ? `=== Run log (last ${lines.length} lines; ${omitted} earlier lines omitted) ===`
+          : '=== Run log ===';
+      return `\n\n${header}\n${lines.join('\n')}`;
+    },
+  };
+}
+
 /** Execute a durable, deterministic workflow script from an opted-in agent. */
 export class WorkflowScriptTool extends defineTool({
   name: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
-  description: `Run a deterministic JavaScript workflow that coordinates one or more workflow agents. Use this when the complete fan-out, pipeline, and join structure is known in advance and should resume safely after interruption. The script must start with export const meta = { name, description } and may call agent(prompt, options), phase(title), log(message), parallel(thunks), pipeline(items, ...stages), and concat(parts, options). Its final return value is delivered as this tool's result.
+  description: `Run a deterministic JavaScript workflow that coordinates workflow agents. Workflow agents edit or produce FILES: each agent() call resolves to a result envelope { category: 'workflow', outcome, outputs, diffs, compileFailures, cost } listing the files it produced, never prose. Use this when the complete fan-out, pipeline, and join structure is known in advance and should resume safely after interruption.
 
-Available agents: loaded from the active roster at runtime.
+Script rules: start with export const meta = { name, description }; no imports or require (only the injected primitives exist: agent, phase, log, parallel, pipeline, concat, and the args global). agent(), parallel(), and pipeline() return Promises: ALWAYS await them. agent(prompt, options) options: inputFiles (REQUIRED for file-editing agents; workspace paths, or a previous call's output paths to chain stages), agentName (another visible workflow agent; defaults to this tool's agent field), id (distinguish otherwise-identical calls), label, phase. A failed call inside parallel()/pipeline() resolves to null; filter with .filter(Boolean). The script's return value is this tool's result, followed by the run log (phases, log() lines, per-call outcomes with cost).
 
-The agent field is the default for agent() calls; a call may select another visible workflow agent with options.agentName. Model selection follows the active model access mode automatically. Tool inclusion is the opt-in boundary: do not add this tool to a default agent configuration.
+Example:
+export const meta = { name: 'fix-drafts', description: 'Fix typos in two drafts', timeoutMs: 1800000 }
+phase('Fix')
+const results = await parallel([
+  () => agent('Fix spelling errors only.', { inputFiles: ['draft1.tex'] }),
+  () => agent('Fix spelling errors only.', { inputFiles: ['draft2.tex'] }),
+])
+const correctedFiles = results
+  .filter(Boolean)
+  .flatMap((result) => result.outputs.map((output) => output.absolutePath))
+return await agent('Merge the corrected drafts.', { inputFiles: correctedFiles })
 
-Durable resume is content-keyed: re-running the identical script and args in this session replays already-completed agent() calls from the saved journal instead of re-executing them, so retry a timed-out or interrupted call with the SAME script and args to keep its completed work. To force a fresh run instead, change the content (e.g. add a nonce field to args). meta.timeoutMs (1s to 60min) overrides the default 10-minute whole-run wall clock.`,
+Durability: the journal is keyed by meta.name within this session. If the run times out or is interrupted, call this tool again with the SAME meta.name: completed agent() calls replay for free (the script may be revised; only changed or unfinished calls execute). Use a new meta.name to start over. The default whole-run wall clock is 10 minutes; set meta.timeoutMs (1s to 60min) for longer runs.
+
+Tool inclusion is the opt-in boundary: do not add this tool to a default agent configuration.`,
   schema: WorkflowScriptToolInputSchema,
 }) {
   protected async execute(input: WorkflowScriptToolInput): Promise<ToolResult> {
@@ -74,12 +118,14 @@ Durable resume is content-keyed: re-running the identical script and args in thi
       );
     }
     const { runContext: parent, callContext } = contexts;
-    // Content-keyed, not toolCallId-keyed: an LLM retry after a timeout or
-    // interruption mints a new tool-call id, and keying on it would orphan
-    // the journal and every derived child identity (#8647).
+    // Named checkpoint, not content- or toolCallId-keyed: a retrying model
+    // rewrites its script, so any key derived from call identity or source
+    // text orphans the journal exactly when resume matters (#8666). meta.name
+    // is the durable identity; per-entry prompt/options hashes in the journal
+    // keep replays honest when the script evolves.
+    const { meta } = parseWorkflowScript(input.script);
     const checkpointId = deriveWorkflowScriptCheckpointId({
-      script: input.script,
-      args: input.args,
+      name: meta.name,
       defaultAgent: input.agent,
       parentExecutionId: parent.runScope.executionId,
     });
@@ -107,13 +153,14 @@ Durable resume is content-keyed: re-running the identical script and args in thi
     // live children (cached replays spend nothing). Boundary settlement below
     // stays journal-based so resumed runs still roll up replayed spend.
     let liveCostUsd = 0;
+    const runLog = createRunLogCollector();
     let run: WorkflowScriptRunResult;
     try {
       run = await runPersistedWorkflowScriptWithProgress(callContext.trace, {
         store,
         checkpointId,
         script: input.script,
-        args: input.args,
+        ...(input.args !== undefined && { args: input.args }),
         signal: callContext.signal,
         runAgent: createWorkflowScriptAgentRunner(
           parent,
@@ -127,6 +174,7 @@ Durable resume is content-keyed: re-running the identical script and args in thi
           },
         ),
         getLiveCostUsd: () => liveCostUsd,
+        onActivity: runLog.add,
       });
     } catch (runError) {
       try {
@@ -141,14 +189,20 @@ Durable resume is content-keyed: re-running the identical script and args in thi
           `Workflow script failed: ${toErrorMessage(runError)} Cost settlement also failed: ${toErrorMessage(settlementError)}`,
         );
       }
-      throw runError;
+      // The run log is the model's only view into what executed before the
+      // failure; without it a timeout reads as total loss instead of
+      // resumable progress.
+      throw new Error(
+        `${toErrorMessage(runError)}${runLog.format()}\n\nCompleted agent() calls are journaled under meta.name '${meta.name}': call this tool again with the same meta.name to resume without repeating them.`,
+        { cause: runError },
+      );
     }
 
     settleCost(run.journal);
     return {
       status: 'executed',
       summary: `Completed workflow script '${run.meta.name}' (${formatResultCount(run.agentCalls, 'agent call')})`,
-      output: formatWorkflowResult(run.result),
+      output: `${formatWorkflowResult(run.result)}${runLog.format()}`,
     };
   }
 }

--- a/src/tools/delegation/workflowScriptAgentRunner.ts
+++ b/src/tools/delegation/workflowScriptAgentRunner.ts
@@ -99,6 +99,19 @@ export function createWorkflowScriptAgentRunner(
               invocation.options.inputFiles ?? [],
             ),
           ]);
+          // Run-storage references can disappear during recovery. Validate
+          // the resolved inputs, not merely the paths supplied by the script,
+          // so a stale reference cannot launch a useless empty-envelope run.
+          if (
+            inputFiles.length === 0 &&
+            (agent.defaultOutputFiles ?? []).length === 0
+          ) {
+            throw new Error(
+              `Workflow agent '${agent.name}' edits files: pass options.inputFiles ` +
+                `with files that still exist (its result carries output files and ` +
+                `diffs, not response text).`,
+            );
+          }
           const configPayload: AgentConfigPayload = {
             agent: agent.name,
             agentSource: agent.source,

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -17,6 +17,12 @@ type WorkflowScriptRunWithProgressOptions = Omit<
 > & {
   /** Cumulative live spend across this run's children, for progress lines. */
   readonly getLiveCostUsd?: () => number;
+  /**
+   * Receives every progress line also written to the trace (phases, script
+   * log() output, per-call outcomes) so the caller can hand the run log back
+   * to the invoking model, which otherwise cannot see any of it.
+   */
+  readonly onActivity?: (line: string) => void;
 };
 
 interface PhaseStage {
@@ -75,7 +81,7 @@ export async function runPersistedWorkflowScriptWithProgress(
   trace: AgentTrace,
   options: WorkflowScriptRunWithProgressOptions,
 ): Promise<WorkflowScriptRunResult> {
-  const { getLiveCostUsd, ...runOptions } = options;
+  const { getLiveCostUsd, onActivity, ...runOptions } = options;
   const parentStageId = trace.activeStageId();
   const phases = new Map<string, PhaseStage>();
   const callPhases = new Map<number, string | undefined>();
@@ -100,15 +106,25 @@ export async function runPersistedWorkflowScriptWithProgress(
   const stageIdFor = (phase: string | undefined): string | undefined =>
     phase ? phaseFor(phase).handle.id : parentStageId;
 
+  const info = (message: string, stageId: string | undefined): void => {
+    trace.info(message, { stageId });
+    onActivity?.(message);
+  };
+  const error = (message: string, stageId: string | undefined): void => {
+    trace.error(message, { stageId });
+    onActivity?.(message);
+  };
+
   const project = (event: WorkflowScriptEvent): void => {
     if (closed) return;
     switch (event.type) {
       case 'phase':
         currentPhase = event.title;
         phaseFor(event.title);
+        onActivity?.(`Phase: ${event.title}`);
         break;
       case 'log':
-        trace.info(event.message, { stageId: stageIdFor(currentPhase) });
+        info(event.message, stageIdFor(currentPhase));
         break;
       case 'agent:start': {
         const phaseTitle = event.phase ?? currentPhase;
@@ -133,13 +149,11 @@ export async function runPersistedWorkflowScriptWithProgress(
           spent === undefined ? '' : ` (${formatCostUsd(spent)} total)`;
         if (event.error) {
           if (phaseTitle) phaseFor(phaseTitle).failed = true;
-          trace.error(`Failed: ${event.label} - ${event.error}${total}`, {
-            stageId,
-          });
+          error(`Failed: ${event.label} - ${event.error}${total}`, stageId);
         } else if (event.cached) {
-          trace.info(`Using saved result: ${event.label}`, { stageId });
+          info(`Using saved result: ${event.label}`, stageId);
         } else {
-          trace.info(`Finished: ${event.label}${total}`, { stageId });
+          info(`Finished: ${event.label}${total}`, stageId);
         }
         break;
       }


### PR DESCRIPTION
## Summary

- teach workflow agents the actual asynchronous, file-based scripting contract with a chaining example
- preserve completed work and omitted arguments under a stable workflow name when a retry revises the script
- return bounded recent activity and source-located sandbox errors to the invoking model
- reject workflow children whose supplied inputs are empty or no longer resolve
- preserve invocation-aware cost settlement for revised workflows

## Design

The checkpoint now identifies a logical workflow by its declared name, default agent, and parent execution. Safety remains local to each journal entry: only the same call position with the same prompt-and-options hash replays. Changed calls execute again, while unchanged completed calls remain available without another model charge. Omitted retry arguments retain the checkpointed value; an explicit `null` remains an intentional replacement.

The model-visible activity collector normalizes each event to one line, bounds each line, and retains only the latest 80 entries. This prevents diagnostics from becoming an unbounded memory or prompt surface.

## Verification

- 113 focused workflow tests
- root TypeScript check
- test-kernel TypeScript check
- touched-file ESLint
- CLI trace-viewer build, bundle, resource copy, and documentation copy

Closes #8666

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Checkpoint identity and resume rules changed (named journal vs content-keyed), which affects how retries reuse work; journal entry hashing limits incorrect replays, but callers must use distinct meta.name for fresh runs.
> 
> **Overview**
> Workflow script durability now keys the execution journal by **`meta.name`** (plus default agent and parent execution), not full script text and args, so a retry after timeout can **revise the script** and still resume—unchanged `agent()` steps replay from the journal via call index and prompt/options hash; only drifted calls run again.
> 
> **Persistence** stops rejecting script or argument mismatches on resume; it adopts the latest script and args (omitted retry args keep the checkpointed value) while retaining the journal. The **delegate_workflow_script** tool documents the async, file-based contract with examples, appends a **bounded run log** (phases, `log()` lines, per-call outcomes) to success and failure results, and failures remind the model to retry with the same `meta.name`.
> 
> **Sandbox errors** now surface a few guest stack frames in the tool message. **Child workflow agents** fail fast when resolved `inputFiles` are empty and the agent has no declared default outputs, instead of launching a useless run or silently dropping stale run-storage paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cecb6d3c424cb4a6ba59dbe017248df28aff8b61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->