### PR TITLE
fix(workflow): teachable script contract, stack-bearing errors, model-visible run log, rewrite-surviving resume

### DIFF
--- a/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
@@ -300,12 +300,17 @@ describe('createWorkflowScriptAgentRunner', () => {
     expect(onCost).not.toHaveBeenCalled();
   });
 
-  it('fails fast when a file-editing agent gets no input files', async () => {
+  it('aborts the run when a file-editing agent gets no input files', async () => {
     const runner = defaultRunner();
 
-    await expect(runner(invocation({}))).rejects.toThrow(
-      /pass options\.inputFiles with files that still exist/,
-    );
+    // Run-fatal (WorkflowRunAbortError), not a per-call failure: a plain
+    // error would resolve to null inside parallel() and be silently filtered.
+    await expect(runner(invocation({}))).rejects.toMatchObject({
+      name: 'WorkflowRunAbortError',
+      message: expect.stringMatching(
+        /pass options\.inputFiles with files that still exist/,
+      ),
+    });
   });
 
   it('allows empty input files when the agent declares default outputs', async () => {

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -79,7 +79,7 @@ function createRunLogCollector(): RunLogCollector {
       if (lines.length === 0) return '';
       const header =
         omitted > 0
-          ? `=== Run log (last ${lines.length} lines; ${omitted} earlier lines omitted) ===`
+          ? `=== Run log (last ${lines.length} lines; ${omitted} earlier ${omitted === 1 ? 'line' : 'lines'} omitted) ===`
           : '=== Run log ===';
       return `\n\n${header}\n${lines.join('\n')}`;
     },

--- a/src/tools/delegation/workflowScriptAgentRunner.ts
+++ b/src/tools/delegation/workflowScriptAgentRunner.ts
@@ -102,11 +102,14 @@ export function createWorkflowScriptAgentRunner(
           // Run-storage references can disappear during recovery. Validate
           // the resolved inputs, not merely the paths supplied by the script,
           // so a stale reference cannot launch a useless empty-envelope run.
+          // Run-fatal, not a per-call failure: a plain error would resolve
+          // this agent() to null inside parallel()/pipeline(), silently
+          // filtering away the very misuse this guard exists to surface.
           if (
             inputFiles.length === 0 &&
             (agent.defaultOutputFiles ?? []).length === 0
           ) {
-            throw new Error(
+            throw new WorkflowRunAbortError(
               `Workflow agent '${agent.name}' edits files: pass options.inputFiles ` +
                 `with files that still exist (its result carries output files and ` +
                 `diffs, not response text).`,


### PR DESCRIPTION
## Problem (live dogfood, #8666)

Driving `delegate_workflow_script` in a real session (texra-local, deepseekproT, custom opted-in agent), the model needed 6 tool attempts over ~12 minutes and never got a useful result:

1. It used `require('fs')` — nothing said scripts cannot import.
2. It destructured `parallel([...])` without `await` and got back the bare QuickJS message `value is not iterable` — no frame, no hint.
3. It never passed `options.inputFiles` (the description didn't document the options), so `correct` children completed with empty `outputs: []` envelopes — workflow agents produce files, not prose, and the model was inlining document text into prompts.
4. Its `log()` diagnostics went only to the trace; the tool result carried none of the run activity, so it debugged blind.
5. Attempt 3 hit the 10-minute wall clock; the retry **rewrote** the script, so the content-keyed checkpoint from #8651 never matched and all completed child work re-ran and was re-paid. Content keying only survives byte-identical retries; real models rewrite.

## Change (root causes, one per failure)

- **Teachable contract**: tool description rewritten around the result envelope, the await rule, the documented `agent()` options, a worked example with file chaining, and resume semantics.
- **Fail fast on the empty-envelope trap**: a workflow `agent()` call with no `inputFiles` and no declared `defaultOutputFiles` errors immediately with the fix in the message, instead of completing uselessly (`workflowScriptAgentRunner.ts`).
- **Errors carry guest stack frames**: the sandbox error record now includes the QuickJS stack; the host folds up to 3 `at` frames into the message, so the un-awaited-parallel mistake reads `value is not iterable\n    at <script>:N`.
- **Model-visible run log**: the progress bridge tees every projected line (phases, `log()`, per-call outcomes with cost) into a bounded run log appended to the tool result — on success and on failure. Failures also state the resume hint explicitly.
- **Resume survives rewrites**: checkpoint identity is now `(meta.name, default agent, parent execution)`. The persistence layer adopts an evolved script/args and keeps the journal; safety lives in the journal itself, whose entries replay only on a matching call index + prompt/options hash, so drifted calls re-execute and unchanged ones stay free. Cost settlement is positively keyed to entries whose native cost callback fired this attempt (`workflowJournalEntryCostIdentity`), immune to replay double-billing and index drift.

## Verified

- 121 tests across the six workflow-script suites (new coverage: script/args drift resume, guest stack frames, fail-fast inputFiles, defaultOutputFiles exemption, run log in success and failure results, named-checkpoint replay across rewritten source); root + test-kernel tsc clean; dead-code ratchet clean.
- Live re-test on the fixed build (same task, same model): the first script attempt was valid — correct `await` usage and `inputFiles` — and children executed with real work, versus three consecutive failed attempts on the old build. (Session was interrupted before final completion; the contract fixes are what the live test exercised.)

Closes #8666

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes durable checkpoint identity and resume semantics (named journals vs content-keyed), which affects cost replay and retry behavior; journal-level hashing limits unsafe replay when scripts drift.
> 
> **Overview**
> Makes **`delegate_workflow_script`** easier for models to use and recover from failures, and fixes resume when a retry **rewrites** the script instead of repeating it byte-for-byte.
> 
> **Checkpoint identity** moves from script+args hashing to **`meta.name`** (plus default agent and parent execution). Persistence **adopts** evolved script/args on resume and keeps the journal; replay safety stays on per-call index + prompt/options hash, so unchanged `agent()` calls stay free while changed ones re-run.
> 
> **Operator-facing feedback**: expanded tool description (file envelopes, `await`, `inputFiles`, example, durability); a **bounded run log** (phases, `log()`, outcomes) appended to success and failure tool results, with an explicit resume hint on failure; sandbox errors now include **guest stack frames** in the message.
> 
> **Fail-fast**: workflow `agent()` calls with no resolvable `inputFiles` and no `defaultOutputFiles` abort the run with guidance instead of completing with empty outputs; missing run-storage inputs are rejected similarly (replacing silent omission of stale paths).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f68ad59b97bff1b7e8d8d5ca7236710d9ec4a5fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->