### PR TITLE
docs(changelog): note CLI workflow round display and waiting-request aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,18 @@ All notable changes to this project will be documented in this file.
   legacy `status`, `terminalStatus`, and `endGroupStatus` fields; v0.41 removes
   them. Status fields on streamed progress records are unaffected.
 
+#### New Features
+
+- **Workflow round progress shows per agent** — session rows and the status
+  bar display each running agent's round (for example `r2/3`), so a
+  multi-agent workflow's delegated agents show where they are without
+  focusing each one.
+- **Waiting agents say what they are waiting on** — a session row that needs
+  your input shows the kind of request (command approval, edit, question,
+  and so on) and how many more are queued behind it. Selecting that session
+  brings its request forward immediately instead of leaving it behind other
+  sessions' prompts.
+
 #### Bug Fixes
 
 - **Workflow-script progress is visible in the CLI** — delegated workflow


### PR DESCRIPTION
Adds the missing [Unreleased] CLI entries for #8660 and #8661 (workflow round progress on session rows/status bar; per-session waiting-on labels with jump-to-waiting). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changelog text only; no runtime, API, or build changes.
> 
> **Overview**
> Docs-only update to **`CHANGELOG.md` [Unreleased] → CLI → New Features**, recording two CLI UX improvements that shipped in earlier work (#8660, #8661).
> 
> **Workflow round progress on session rows and the status bar** — delegated agents in multi-agent workflows now show per-agent round position (e.g. `r2/3`) without focusing each session.
> 
> **Waiting-session labels and jump-to-prompt** — rows that need input show the approval/request type and any queued count; selecting that session surfaces its prompt ahead of other sessions’ dialogs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89b514eb3b327c9cb15521c893fd1d16d40fe364. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->