### PR TITLE
refactor: consolidate ad-hoc string truncation onto truncateWithEllipsis

### DIFF
--- a/src/common/errors/errorFormatUtils.ts
+++ b/src/common/errors/errorFormatUtils.ts
@@ -1,12 +1,10 @@
 import { toErrorMessage } from '@utils/errors/errorMessage';
+import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
 const MAX_ERROR_LENGTH = 500;
 
 /** Format an error with a prefix for logging or user messages. */
 export function formatError(prefix: string, err: unknown): string {
-  const detail = toErrorMessage(err);
-  if (detail.length > MAX_ERROR_LENGTH) {
-    return `${prefix}: ${detail.slice(0, MAX_ERROR_LENGTH)}...`;
-  }
+  const detail = truncateWithEllipsis(toErrorMessage(err), MAX_ERROR_LENGTH);
   return `${prefix}: ${detail}`;
 }

--- a/src/tools/delegation/proposalFlow.ts
+++ b/src/tools/delegation/proposalFlow.ts
@@ -37,6 +37,7 @@ import {
   getDelegationAgentsForScope,
 } from '@tools/delegationAgentAvailability';
 import { toErrorMessage } from '@utils/errors/errorMessage';
+import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
 // Local imports - delegation
 import { executeSubagent } from './subagentExecution';
@@ -98,11 +99,9 @@ function summarizeProposal(
   if (proposal.memories.length > 0) {
     parts.push(`Memories: ${proposal.memories.join(', ')}`);
   }
-  const instrPreview =
-    proposal.instruction.length > 120
-      ? `${proposal.instruction.slice(0, 117)}...`
-      : proposal.instruction;
-  parts.push(`Instruction: "${instrPreview}"`);
+  parts.push(
+    `Instruction: "${truncateWithEllipsis(proposal.instruction, 120)}"`,
+  );
   return parts.join(', ');
 }
 

--- a/src/tools/lean/LoogleTool.ts
+++ b/src/tools/lean/LoogleTool.ts
@@ -20,7 +20,10 @@ import {
 import { defineTool } from '@tools/core/define';
 import { ensureArray } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
-import { formatResultCount } from '@utils/text/stringUtils';
+import {
+  formatResultCount,
+  truncateWithEllipsis,
+} from '@utils/text/stringUtils';
 
 const LOOGLE_TIMEOUT_MS = 10_000; // 10 s
 const LOOGLE_CHANNEL = 'lean_loogle';
@@ -100,11 +103,7 @@ function formatHit(hit: LoogleHit, index: number): string {
   ];
 
   if (hit.doc) {
-    const truncatedDoc =
-      hit.doc.length > MAX_DOC_LENGTH
-        ? hit.doc.slice(0, MAX_DOC_LENGTH) + '...'
-        : hit.doc;
-    lines.push(`   Doc: ${truncatedDoc}`);
+    lines.push(`   Doc: ${truncateWithEllipsis(hit.doc, MAX_DOC_LENGTH)}`);
   }
 
   return lines.join('\n');

--- a/src/utils/text/stringUtils.ts
+++ b/src/utils/text/stringUtils.ts
@@ -195,10 +195,20 @@ export function countLines(text: string): number {
  * truncateWithEllipsis('a very long text', 10) // 'a very lo…'
  */
 export function truncateWithEllipsis(text: string, maxLen: number): string {
-  const graphemes = toGraphemes(text);
-  if (graphemes.length <= maxLen) return text;
-  if (maxLen <= 1) return '…';
-  return `${graphemes.slice(0, maxLen - 1).join('')}…`;
+  const prefix: string[] = [];
+
+  // Intl.Segmenter is lazy: stop after the first grapheme beyond the budget so
+  // truncating a large error or tool payload stays bounded by maxLen.
+  for (const { segment } of graphemeSegmenter.segment(text)) {
+    if (prefix.length >= maxLen) {
+      if (maxLen <= 0) return '…';
+      prefix[maxLen - 1] = '…';
+      return prefix.join('');
+    }
+    prefix.push(segment);
+  }
+
+  return text;
 }
 
 /**


### PR DESCRIPTION
## Summary

- replace three ad-hoc truncation implementations with the shared grapheme-aware `truncateWithEllipsis`
- make the shared helper stop after the first grapheme beyond its budget, so truncating large provider errors remains bounded
- retain one consistent rule: the ellipsis counts within the requested display width

## Design

Before this change, error messages, delegation previews, and Loogle documentation each implemented their own code-unit slicing and ASCII marker. Those copies could split emoji or combining sequences and disagreed about whether the marker counted toward the limit.

After this change, all three call sites use the existing text helper. The helper itself now consumes at most `maxLen + 1` graphemes instead of materializing the entire input, which is important on the central error-reporting path where an SDK may attach a very large response body.

## Net elements (R6)

| What | Added | Removed |
| --- | --- | --- |
| Exports | None | None |
| Files | None | None |
| Local truncation implementations | None | Three |
| Lines | 25 | 19 (+6 net, including the bounded shared implementation) |

## Verification

- rebased onto current `main`
- four focused text, delegation, agent-runner, and tool-rendering suites (69 tests)
- root and test-kernel TypeScript checks
- ESLint, Prettier, and `git diff --check`
- previous full CI/build/webview-smoke matrix passed; fresh exact-head CI is running

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized display-string refactor with bounded performance improvement on error paths; no auth, persistence, or API contract changes.
> 
> **Overview**
> Replaces three hand-rolled truncation paths with the shared grapheme-aware **`truncateWithEllipsis`** helper: **`formatError`**, delegation proposal instruction previews, and Loogle hit documentation.
> 
> **`truncateWithEllipsis`** is reworked to iterate graphemes lazily and stop after one segment past the budget, so formatting huge provider error bodies no longer materializes the full string. Display limits still treat the Unicode ellipsis as part of the width (replacing the last kept grapheme when over budget).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65786fae208d7eaffddca86fece7453d9406f576. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->