### PR TITLE
feat: label subagent execution tool rows

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -1989,9 +1989,7 @@ function renderHarnessApp(): React.JSX.Element {
       canStopActiveRun={() => canInterrupt}
       colorEnabled={HARNESS_COLOR_ENABLED}
       onInterruptActive={markHarnessInterrupted}
-      onTranscriptViewportChange={
-        viewportController.handleTranscriptViewportChange
-      }
+      onStaticTranscriptChange={viewportController.repaintTranscript}
       onCtrlC={handleHarnessCtrlC}
     />
   );

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -73,6 +73,7 @@ import {
   activeSubagentsFor,
   childStreamEntries as childStreamEntriesSignal,
   parentStream as parentStreamSignal,
+  subagentExecutionLabels as subagentExecutionLabelsSignal,
 } from './state/childExecutions';
 import { focusedChildInputDisabledMessage } from './state/focusedChildFollowUp';
 import {
@@ -140,6 +141,7 @@ export function App(props: AppProps): React.JSX.Element {
   const streams = useSignal(streamsSignal);
   const parentStream = useSignal(parentStreamSignal);
   const childStreamEntries = useSignal(childStreamEntriesSignal);
+  const subagentExecutionLabels = useSignal(subagentExecutionLabelsSignal);
   const activeForm = useSignal(activeFormSignal);
   const slashPaletteOpen = useSignal(slashPaletteOpenSignal);
   const reverseSearchOpen = useSignal(reverseSearchOpenSignal);
@@ -650,6 +652,7 @@ export function App(props: AppProps): React.JSX.Element {
           sessionViews,
           selectedChildValue,
           streams,
+          subagentExecutionLabels,
           activeSubagentExecutionIds,
           childListTarget,
           pendingApprovals: pendingApprovalsForRows,

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -91,10 +91,7 @@ import {
 } from './state/childListSelection';
 import { streamDisplayLabel, streamTreeViews } from './state/streamViews';
 import { useSignal } from './state/useSignal';
-import {
-  transcriptViewportKey,
-  type TranscriptViewportChange,
-} from './state/transcriptViewportMode';
+import { transcriptViewportKey } from './state/transcriptViewportMode';
 import type { InputHistory } from './history/inputHistory';
 
 // Narrow subset of Ink's internal stdin emitter used to synthesize Enter.
@@ -121,9 +118,7 @@ export interface AppProps {
   readonly colorEnabled?: boolean;
   readonly commandName?: string;
   readonly onInterruptActive: () => void;
-  readonly onTranscriptViewportChange?: (
-    change: TranscriptViewportChange,
-  ) => void;
+  readonly onStaticTranscriptChange?: () => void;
   readonly onCtrlC?: () => void;
   /** Suspend the process (Ctrl-Z). Raw mode swallows the tty driver's own
    *  ^Z→SIGTSTP translation, so the parsed key must be routed explicitly. */
@@ -605,7 +600,7 @@ export function App(props: AppProps): React.JSX.Element {
       <ConversationRegion
         colorEnabled={props.colorEnabled}
         columns={columns}
-        onTranscriptViewportChange={props.onTranscriptViewportChange}
+        onStaticTranscriptChange={props.onStaticTranscriptChange}
         renderFooterChrome={() => (
           <>
             <InputBar

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -4,6 +4,7 @@
 import { Box, Text } from 'ink';
 
 import { isActivePhase } from '@shared/streams/streamStatus';
+import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 import { formatCompactDuration } from '@utils/core';
 
 import {
@@ -73,17 +74,20 @@ export interface ConversationPaneProps {
   readonly width?: number;
   readonly maxRows?: number;
   readonly colorEnabled?: boolean;
+  readonly subagentExecutionLabels?: ExecutionLabels;
 }
 
 function renderConversationPaneEntry({
   colorEnabled,
   entry,
   rowLimit,
+  subagentExecutionLabels,
   width,
 }: {
   readonly colorEnabled?: boolean;
   readonly entry: ConversationEntry;
   readonly rowLimit?: number;
+  readonly subagentExecutionLabels?: ExecutionLabels;
   readonly width?: number;
 }): React.JSX.Element | null {
   // When the newest entry alone overflows the pane, the bounded renderer is the
@@ -96,12 +100,19 @@ function renderConversationPaneEntry({
           colorEnabled={colorEnabled}
           entry={entry}
           maxRows={rowLimit}
+          subagentExecutionLabels={subagentExecutionLabels}
           width={width}
         />
       );
     }
     if (entry.role === 'tool') {
-      return <ToolUseRow toolUse={entry.toolUse} width={width} />;
+      return (
+        <ToolUseRow
+          subagentExecutionLabels={subagentExecutionLabels}
+          toolUse={entry.toolUse}
+          width={width}
+        />
+      );
     }
     if (entry.role === 'assistant') {
       return <LiveTranscriptEntry entry={entry} width={width} />;
@@ -121,7 +132,11 @@ function renderConversationPaneEntry({
         <BoundedTranscriptEntry
           colorEnabled={colorEnabled}
           entry={entry}
-          maxRows={estimateTranscriptEntryRows(entry, width)}
+          maxRows={estimateTranscriptEntryRows(
+            entry,
+            width,
+            subagentExecutionLabels,
+          )}
           width={width}
         />
       );
@@ -163,6 +178,7 @@ export function ConversationPane(
     displayEntries,
     maxRows - livenessRows,
     props.width,
+    props.subagentExecutionLabels,
   );
   const visibleRows =
     (visibleEntries.entries.length > 0
@@ -179,6 +195,7 @@ export function ConversationPane(
           colorEnabled: props.colorEnabled,
           entry,
           rowLimit: visibleEntries.rowLimits.get(entry.id),
+          subagentExecutionLabels: props.subagentExecutionLabels,
           width: props.width,
         }),
       )}

--- a/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
@@ -4,7 +4,7 @@
 
 // Third-party imports
 import { Box } from 'ink';
-import { useLayoutEffect, useMemo, useRef, type ReactNode } from 'react';
+import { useLayoutEffect, useMemo, type ReactNode } from 'react';
 
 // Local imports - shared constants and schemas
 import { type StreamTabId } from '@shared/schemas';
@@ -22,9 +22,7 @@ import {
 } from '../appLayout';
 import {
   isScopedTranscriptViewport,
-  transcriptViewportChange,
   transcriptViewportKey,
-  type TranscriptViewportChange,
 } from '../state/transcriptViewportMode';
 import { clampModalWidth } from '../ui/theme';
 import { ConversationPane } from './ConversationPane';
@@ -71,9 +69,7 @@ interface ConversationRegionSnapshot {
 interface ConversationRegionProps {
   readonly colorEnabled?: boolean;
   readonly columns: number;
-  readonly onTranscriptViewportChange?: (
-    change: TranscriptViewportChange,
-  ) => void;
+  readonly onStaticTranscriptChange?: () => void;
   readonly renderForegroundSurface: (availableRows: number) => ReactNode;
   readonly renderFooterChrome: () => ReactNode;
   readonly rows: number;
@@ -95,7 +91,7 @@ export function ConversationRegion({
   onKillExecution,
   onOpenProcessDetail,
   onPrintStream,
-  onTranscriptViewportChange,
+  onStaticTranscriptChange,
   renderFooterChrome,
   renderForegroundSurface,
   rows,
@@ -120,17 +116,11 @@ export function ConversationRegion({
     rootStreamId: snapshot.rootStreamId,
     scopedTranscript,
   });
-  const previousViewportKey = useRef<string | undefined>(undefined);
-
-  useLayoutEffect(() => {
-    const previous = previousViewportKey.current;
-    previousViewportKey.current = viewportKey;
-    const change = transcriptViewportChange({
-      previousViewportKey: previous,
-      nextViewportKey: viewportKey,
-    });
-    if (change) onTranscriptViewportChange?.(change);
-  }, [onTranscriptViewportChange, viewportKey]);
+  const executionLabelsKey = useMemo(
+    () => JSON.stringify([...snapshot.subagentExecutionLabels]),
+    [snapshot.subagentExecutionLabels],
+  );
+  const staticTranscriptKey = `${scrollbackTarget.ownerKey}:${executionLabelsKey}`;
 
   const activeSlice = snapshot.activeStreamId
     ? snapshot.streams.get(snapshot.activeStreamId)
@@ -216,6 +206,8 @@ export function ConversationRegion({
         colorEnabled={colorEnabled}
         maxRows={staticTranscriptRows}
         ownerKey={scrollbackTarget.ownerKey}
+        onRenderKeyChange={onStaticTranscriptChange}
+        renderKey={staticTranscriptKey}
         printRequests={ownerPrintRequests}
         scrollbackStreamId={scrollbackTarget.streamId}
         subagentExecutionLabels={snapshot.subagentExecutionLabels}

--- a/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
@@ -8,6 +8,7 @@ import { useLayoutEffect, useMemo, useRef, type ReactNode } from 'react';
 
 // Local imports - shared constants and schemas
 import { type StreamTabId } from '@shared/schemas';
+import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 import { clamp } from '@utils/core';
 
 // Local imports - conversation panes and layout
@@ -57,6 +58,7 @@ interface ConversationRegionSnapshot {
   readonly childListFocused: boolean;
   readonly sessionViews: readonly StreamView[];
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
+  readonly subagentExecutionLabels: ExecutionLabels;
   readonly activeSubagentExecutionIds: ReadonlyMap<StreamTabId, string>;
   readonly childListTarget: ChildListTarget;
   readonly pendingApprovals: ReadonlyMap<
@@ -216,6 +218,7 @@ export function ConversationRegion({
         ownerKey={scrollbackTarget.ownerKey}
         printRequests={ownerPrintRequests}
         scrollbackStreamId={scrollbackTarget.streamId}
+        subagentExecutionLabels={snapshot.subagentExecutionLabels}
         width={transcriptWidth}
       />
       <Box flexDirection="column">
@@ -225,6 +228,7 @@ export function ConversationRegion({
               colorEnabled={colorEnabled}
               width={transcriptWidth}
               maxRows={conversationRows}
+              subagentExecutionLabels={snapshot.subagentExecutionLabels}
             />
           ) : null}
           {foregroundSurface ? (

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -6,7 +6,7 @@
 
 import path from 'node:path';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Box, Static, Text } from 'ink';
 
 import { shortCliApiMode } from '@cli/runtime/apiAccessMode';
@@ -489,7 +489,9 @@ export function appendStaticTranscriptItems({
 export function StaticConversationTranscript({
   colorEnabled,
   maxRows,
+  onRenderKeyChange,
   ownerKey,
+  renderKey = ownerKey,
   printRequests = [],
   scrollbackStreamId,
   subagentExecutionLabels,
@@ -497,13 +499,23 @@ export function StaticConversationTranscript({
 }: {
   readonly colorEnabled?: boolean;
   readonly maxRows?: number;
+  readonly onRenderKeyChange?: () => void;
   readonly ownerKey: string;
+  readonly renderKey?: string;
   readonly printRequests?: readonly TranscriptPrintRequest[];
   readonly scrollbackStreamId: StreamTabId | undefined;
   readonly subagentExecutionLabels?: ExecutionLabels;
   readonly width?: number;
 }): React.JSX.Element {
   const normalizedWidth = transcriptColumns(width);
+  const previousRenderKey = useRef<string | undefined>(undefined);
+  useLayoutEffect(() => {
+    const previous = previousRenderKey.current;
+    previousRenderKey.current = renderKey;
+    if (previous !== undefined && previous !== renderKey) {
+      onRenderKeyChange?.();
+    }
+  }, [onRenderKeyChange, renderKey]);
   const streams = useSignal(streamsSignal);
   const sessionMeta = useSignal(sessionMetaSignal);
   const parentStream = useSignal(parentStreamSignal);
@@ -587,7 +599,7 @@ export function StaticConversationTranscript({
 
   return (
     <Static
-      key={`transcript:${ownerKey}:${normalizedWidth}`}
+      key={`transcript:${renderKey}:${normalizedWidth}`}
       items={staticItems}
     >
       {(item: StaticTranscriptItem) => (

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -11,6 +11,7 @@ import { Box, Static, Text } from 'ink';
 
 import { shortCliApiMode } from '@cli/runtime/apiAccessMode';
 import type { StreamTabId } from '@shared/schemas';
+import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 import { safeHomedir } from '@utils/system/platformPaths';
 
 import { wrapAnsiToWidth } from '../render/ansiWrap';
@@ -214,6 +215,7 @@ function childHeaderIdentityPending({
 function staticTranscriptItemRowCount(
   item: StaticTranscriptItem,
   width?: number,
+  executionLabels?: ExecutionLabels,
 ): number {
   if (item.kind === 'header') {
     return item.compact
@@ -223,6 +225,7 @@ function staticTranscriptItemRowCount(
   if (item.kind === 'printedTranscript') {
     return formatTranscriptForScrollback({
       cols: transcriptColumns(width),
+      executionLabels,
       request: item.request,
     }).split('\n').length;
   }
@@ -235,6 +238,7 @@ function staticTranscriptItemRowCount(
     return (
       1 +
       toolUseDisplayLines(item.entry.toolUse, {
+        executionLabels,
         showOutput: true,
         width: transcriptColumns(width, 2),
       }).slice(1).length +
@@ -243,6 +247,7 @@ function staticTranscriptItemRowCount(
   }
   return transcriptEntryLayoutRows(
     transcriptEntryLayout(item.entry, {
+      executionLabels,
       mode: 'scrollback-budget',
       width,
     }),
@@ -251,10 +256,12 @@ function staticTranscriptItemRowCount(
 
 function StaticTranscriptItemContent({
   colorEnabled,
+  executionLabels,
   item,
   width,
 }: {
   readonly colorEnabled?: boolean;
+  readonly executionLabels?: ExecutionLabels;
   readonly item: StaticTranscriptItem;
   readonly width: number;
 }): React.JSX.Element {
@@ -279,6 +286,7 @@ function StaticTranscriptItemContent({
           <EntryErrorBoundary label="workflow script">
             <ToolUseRow
               neutralStatus
+              subagentExecutionLabels={executionLabels}
               toolUse={item.entry.toolUse}
               width={width}
             />
@@ -289,6 +297,7 @@ function StaticTranscriptItemContent({
         <EntryErrorBoundary label={item.entry.role}>
           <TranscriptEntry
             entry={item.entry}
+            subagentExecutionLabels={executionLabels}
             width={width}
             colorEnabled={colorEnabled}
           />
@@ -300,6 +309,7 @@ function StaticTranscriptItemContent({
           <Text>
             {formatTranscriptForScrollback({
               cols: width,
+              executionLabels,
               request: item.request,
             })}
           </Text>
@@ -331,6 +341,7 @@ function StaticTranscriptItemContent({
             <ToolUseRow
               omitHeader
               showOutput
+              subagentExecutionLabels={executionLabels}
               toolUse={item.entry.toolUse}
               width={transcriptColumns(width, 2)}
             />
@@ -344,6 +355,7 @@ export function appendStaticTranscriptItems({
   currentItems,
   streams,
   childStreamEntries = new Map(),
+  executionLabels,
   meta,
   maxRows,
   parentStream = new Map(),
@@ -354,6 +366,7 @@ export function appendStaticTranscriptItems({
   readonly currentItems: readonly StaticTranscriptItem[];
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
   readonly childStreamEntries?: ChildStreamEntries;
+  readonly executionLabels?: ExecutionLabels;
   readonly meta: SessionMeta;
   readonly maxRows?: number;
   readonly parentStream?: ReadonlyMap<StreamTabId, StreamTabId>;
@@ -389,8 +402,9 @@ export function appendStaticTranscriptItems({
     const fitsBudget =
       maxRows === undefined ||
       currentItems.reduce(
-        (total, item) => total + staticTranscriptItemRowCount(item, width),
-        staticTranscriptItemRowCount(header, width),
+        (total, item) =>
+          total + staticTranscriptItemRowCount(item, width, executionLabels),
+        staticTranscriptItemRowCount(header, width, executionLabels),
       ) <= maxRows;
     if (fitsBudget) {
       nextItems = [...currentItems];
@@ -478,6 +492,7 @@ export function StaticConversationTranscript({
   ownerKey,
   printRequests = [],
   scrollbackStreamId,
+  subagentExecutionLabels,
   width,
 }: {
   readonly colorEnabled?: boolean;
@@ -485,6 +500,7 @@ export function StaticConversationTranscript({
   readonly ownerKey: string;
   readonly printRequests?: readonly TranscriptPrintRequest[];
   readonly scrollbackStreamId: StreamTabId | undefined;
+  readonly subagentExecutionLabels?: ExecutionLabels;
   readonly width?: number;
 }): React.JSX.Element {
   const normalizedWidth = transcriptColumns(width);
@@ -498,6 +514,7 @@ export function StaticConversationTranscript({
       currentItems: [],
       streams,
       childStreamEntries,
+      executionLabels: subagentExecutionLabels,
       meta: sessionMeta,
       maxRows,
       parentStream,
@@ -514,6 +531,7 @@ export function StaticConversationTranscript({
           currentItems: [],
           streams,
           childStreamEntries,
+          executionLabels: subagentExecutionLabels,
           meta: sessionMeta,
           maxRows,
           parentStream,
@@ -535,6 +553,7 @@ export function StaticConversationTranscript({
         currentItems: isHardReset || ownerChanged ? [] : current.items,
         streams,
         childStreamEntries,
+        executionLabels: subagentExecutionLabels,
         meta: sessionMeta,
         maxRows,
         parentStream,
@@ -556,6 +575,7 @@ export function StaticConversationTranscript({
     scrollbackStreamId,
     sessionMeta,
     streams,
+    subagentExecutionLabels,
     normalizedWidth,
   ]);
 
@@ -574,6 +594,7 @@ export function StaticConversationTranscript({
         <Box key={item.id} flexDirection="column">
           <StaticTranscriptItemContent
             colorEnabled={colorEnabled}
+            executionLabels={subagentExecutionLabels}
             item={item}
             width={normalizedWidth}
           />

--- a/packages/cli/src/chat/tui/panes/ToolUseRow.tsx
+++ b/packages/cli/src/chat/tui/panes/ToolUseRow.tsx
@@ -6,6 +6,7 @@ import { memo } from 'react';
 import { Box, Text } from 'ink';
 
 import { type NormalizedToolUse } from '@shared/schemas';
+import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 
 import { DiffView } from '../render/DiffView';
 import { clipToWidth } from '../render/terminalText';
@@ -123,6 +124,7 @@ export const ToolUseRow = memo(function ToolUseRow({
   neutralStatus,
   omitHeader,
   showOutput,
+  subagentExecutionLabels,
   toolUse,
   width,
 }: {
@@ -130,10 +132,12 @@ export const ToolUseRow = memo(function ToolUseRow({
   readonly neutralStatus?: boolean;
   readonly omitHeader?: boolean;
   readonly showOutput?: boolean;
+  readonly subagentExecutionLabels?: ExecutionLabels;
   readonly toolUse: NormalizedToolUse;
   readonly width?: number;
 }): React.JSX.Element {
   const allLines = toolUseStyledLines(toolUse, {
+    executionLabels: subagentExecutionLabels,
     neutralStatus,
     showOutput,
     width,

--- a/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
@@ -5,6 +5,7 @@
 // Third-party imports
 import { memo } from 'react';
 import { Box, Text } from 'ink';
+import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 
 // Local imports - CLI TUI rendering
 import { Markdown } from '../render/Markdown';
@@ -157,14 +158,22 @@ export const TranscriptEntry = memo(function TranscriptEntry({
   width,
   colorEnabled,
   fillWidth,
+  subagentExecutionLabels,
 }: {
   readonly entry: ConversationEntry;
   readonly width?: number;
   readonly colorEnabled?: boolean;
   readonly fillWidth?: boolean;
+  readonly subagentExecutionLabels?: ExecutionLabels;
 }): React.JSX.Element {
   if (entry.role === 'tool') {
-    return <ToolUseRow toolUse={entry.toolUse} width={width} />;
+    return (
+      <ToolUseRow
+        subagentExecutionLabels={subagentExecutionLabels}
+        toolUse={entry.toolUse}
+        width={width}
+      />
+    );
   }
 
   const layout = transcriptEntryLayout(entry, {
@@ -212,16 +221,23 @@ export const BoundedTranscriptEntry = memo(function BoundedTranscriptEntry({
   colorEnabled,
   entry,
   maxRows,
+  subagentExecutionLabels,
   width,
 }: {
   readonly colorEnabled?: boolean;
   readonly entry: ConversationEntry;
   readonly maxRows: number;
+  readonly subagentExecutionLabels?: ExecutionLabels;
   readonly width?: number;
 }): React.JSX.Element {
   if (entry.role === 'tool') {
     return (
-      <ToolUseRow maxRows={maxRows} toolUse={entry.toolUse} width={width} />
+      <ToolUseRow
+        maxRows={maxRows}
+        subagentExecutionLabels={subagentExecutionLabels}
+        toolUse={entry.toolUse}
+        width={width}
+      />
     );
   }
 

--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -10,6 +10,10 @@
 
 // Local imports - shared schemas and utilities
 import { TOOL_USE_STATUS, type NormalizedToolUse } from '@shared/schemas';
+import {
+  executionsSubagentSummary,
+  type ExecutionLabels,
+} from '@shared/tools/executionsDisplay';
 import { toolDisplayKind } from '@shared/tools/toolKind';
 import { isObject } from '@utils/core';
 import {
@@ -120,6 +124,8 @@ export interface DisplayLineOptions {
   readonly neutralStatus?: boolean;
   /** Terminal columns when the projection must match rich rendered rows. */
   readonly width?: number;
+  /** Retained subagent identities used by executions wait/view headers. */
+  readonly executionLabels?: ExecutionLabels;
 }
 
 export type StyledLineOptions = DisplayLineOptions;
@@ -238,11 +244,13 @@ function toolHeaderPreview(
   toolUse: NormalizedToolUse,
   maxPreview: number,
   preferInputPreview: boolean,
+  summaryOverride?: string,
 ): string {
   if (maxPreview <= 0) return '';
+  const headerSummary = summaryOverride ?? toolUse.headerSummary;
   const sourceText = preferInputPreview
-    ? previewInput(toolUse.input) || toolUse.headerSummary || ''
-    : toolUse.headerSummary || previewInput(toolUse.input) || '';
+    ? previewInput(toolUse.input) || headerSummary || ''
+    : headerSummary || previewInput(toolUse.input) || '';
   return sourceText ? truncateSummaryToWidth(sourceText, maxPreview) : '';
 }
 
@@ -388,6 +396,7 @@ function toolRowOptions(
 function buildStyledLines(
   toolUse: NormalizedToolUse,
   options: StyledLineOptions,
+  executionSummary: string | undefined,
 ): readonly ToolDisplayLine[] {
   const elide = options.elide !== false;
   const patchGroups = toolUsePatchGroups(toolUse);
@@ -400,6 +409,7 @@ function buildStyledLines(
       ? MAX_HEADER_PREVIEW
       : toolHeaderPreviewBudget(options.width, opts.displayName),
     opts.preferInputPreview,
+    executionSummary,
   );
 
   const showOutput = options.showOutput === true || opts.showOutput;
@@ -481,11 +491,15 @@ export function toolUseStyledLines(
   toolUse: NormalizedToolUse,
   options: StyledLineOptions = {},
 ): readonly ToolDisplayLine[] {
-  const key = `${options.elide === false ? 'f' : 'e'}|${options.showOutput === true ? 'o' : 'h'}|${options.neutralStatus === true ? 'n' : 's'}|${options.width ?? 'd'}`;
+  const executionSummary =
+    toolUse.toolName === 'executions' && options.executionLabels
+      ? executionsSubagentSummary(toolUse.input, options.executionLabels)
+      : undefined;
+  const key = `${options.elide === false ? 'f' : 'e'}|${options.showOutput === true ? 'o' : 'h'}|${options.neutralStatus === true ? 'n' : 's'}|${options.width ?? 'd'}|${executionSummary ?? ''}`;
   let cached = styledLinesCache.get(toolUse);
   const hit = cached?.get(key);
   if (hit) return hit;
-  const lines = buildStyledLines(toolUse, options);
+  const lines = buildStyledLines(toolUse, options, executionSummary);
   if (!cached) {
     cached = new Map();
     styledLinesCache.set(toolUse, cached);

--- a/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
@@ -1,6 +1,7 @@
 // Declarative conversation-entry geometry shared by Ink renderers, viewport
 // budgeting, static scrollback, and print-once full output.
 
+import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 import { renderAnsiMarkdown } from '../render/ansiMarkdown';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
 import { completedProcessDisplayLines } from '../state/completedProcessTranscript';
@@ -157,6 +158,7 @@ function entryLines(
   columns: number,
   colorEnabled: boolean | undefined,
   maxRows: number | undefined,
+  executionLabels: ExecutionLabels | undefined,
 ): readonly string[] {
   switch (entry.role) {
     case 'assistant':
@@ -183,6 +185,7 @@ function entryLines(
         mode === 'live' || mode === 'bounded' || mode === 'scrollback-budget';
       const lines = toolUseDisplayLines(entry.toolUse, {
         elide: mode !== 'scrollback-budget',
+        executionLabels,
         ...(richProjection ? { width: columns } : {}),
       });
       // Rich rows and their bounded fallback keep each display line on one
@@ -213,11 +216,13 @@ export function transcriptEntryLayout(
     colorEnabled,
     maxRows,
     mode = 'scrollback',
+    executionLabels,
     width,
   }: {
     readonly colorEnabled?: boolean;
     readonly maxRows?: number;
     readonly mode?: TranscriptEntryLayoutMode;
+    readonly executionLabels?: ExecutionLabels;
     readonly width?: number;
   } = {},
 ): TranscriptEntryLayout {
@@ -238,7 +243,14 @@ export function transcriptEntryLayout(
   return {
     ...base,
     columns,
-    lines: entryLines(entry, mode, columns, colorEnabled, maxRows),
+    lines: entryLines(
+      entry,
+      mode,
+      columns,
+      colorEnabled,
+      maxRows,
+      executionLabels,
+    ),
     inset,
     marginBottomRows,
     marginTopRows,
@@ -250,19 +262,24 @@ export function transcriptEntryLayout(
 export function fullTranscriptEntryLayout(
   entry: ConversationEntry,
   width: number,
+  executionLabels?: ExecutionLabels,
 ): TranscriptEntryLayout {
   // Ordinary Ink rows spend this inset as paddingX. Printed text has no Box
   // padding, so add it back before the shared layout subtracts it.
   const printWidth = width + ROLE_GEOMETRY[entry.role].inset;
   const layout = transcriptEntryLayout(entry, {
     mode: 'scrollback-budget',
+    executionLabels,
     width: printWidth,
   });
   if (entry.role !== 'tool') return layout;
   return {
     ...layout,
     lines: wrapDisplayLines(
-      toolUseDisplayLines(entry.toolUse, { elide: false }),
+      toolUseDisplayLines(entry.toolUse, {
+        elide: false,
+        executionLabels,
+      }),
       layout.columns,
     ),
   };

--- a/packages/cli/src/chat/tui/panes/transcriptViewport.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptViewport.ts
@@ -1,5 +1,6 @@
 // Pure viewport math for bounded pending transcript panes.
 
+import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 import {
   transcriptEntryLayout,
   transcriptEntryLayoutRows,
@@ -20,22 +21,30 @@ function estimateEntryRows(computeRows: () => number): number {
 export function estimateTranscriptEntryRows(
   entry: ConversationEntry,
   width?: number,
+  executionLabels?: ExecutionLabels,
 ): number {
   return estimateEntryRows(() =>
-    transcriptEntryLayoutRows(transcriptEntryLayout(entry, { width })),
+    transcriptEntryLayoutRows(
+      transcriptEntryLayout(entry, { executionLabels, width }),
+    ),
   );
 }
 
 function estimateLiveTranscriptEntryRows(
   entry: ConversationEntry,
   width?: number,
+  executionLabels?: ExecutionLabels,
 ): number {
   // Live mode captures the pending-pane paint contract: assistant text uses
   // its capped raw tail, while rich tool/process rows keep one descriptor
   // line per terminal row instead of being reflowed like plain projections.
   return estimateEntryRows(() =>
     transcriptEntryLayoutRows(
-      transcriptEntryLayout(entry, { mode: 'live', width }),
+      transcriptEntryLayout(entry, {
+        executionLabels,
+        mode: 'live',
+        width,
+      }),
     ),
   );
 }
@@ -52,6 +61,7 @@ export function selectTranscriptEntriesForViewport(
   entries: readonly ConversationEntry[],
   maxRows: number,
   width?: number,
+  executionLabels?: ExecutionLabels,
 ): TranscriptEntrySelection {
   if (!Number.isFinite(maxRows) || maxRows <= 0) {
     return { entries: [], rowLimits: new Map(), usedRows: 0 };
@@ -63,7 +73,11 @@ export function selectTranscriptEntriesForViewport(
   for (let index = entries.length - 1; index >= 0; index -= 1) {
     const entry = entries[index];
     if (!isRenderableTranscriptEntry(entry)) continue;
-    const entryRows = estimateLiveTranscriptEntryRows(entry, width);
+    const entryRows = estimateLiveTranscriptEntryRows(
+      entry,
+      width,
+      executionLabels,
+    );
     if (usedRows + entryRows > maxRows) {
       if (selected.length === 0) {
         selected.unshift(entry);

--- a/packages/cli/src/chat/tui/render/tuiViewportController.ts
+++ b/packages/cli/src/chat/tui/render/tuiViewportController.ts
@@ -1,5 +1,3 @@
-import type { TranscriptViewportChange } from '../state/transcriptViewportMode';
-
 export interface TuiRepaintOptions {
   readonly clearScrollback?: boolean;
   readonly preserveStatic?: boolean;
@@ -19,9 +17,7 @@ const TERMINAL_RESUME_REPAINT_OPTIONS = {
 } satisfies TuiRepaintOptions;
 
 export interface TuiViewportController {
-  readonly handleTranscriptViewportChange: (
-    change: TranscriptViewportChange,
-  ) => void;
+  readonly repaintTranscript: () => void;
   readonly repaintAfterTerminalResume: () => void;
 }
 
@@ -29,7 +25,7 @@ export function createTuiViewportController(inkRef: {
   readonly current?: TuiRepaintTarget;
 }): TuiViewportController {
   return {
-    handleTranscriptViewportChange(): void {
+    repaintTranscript(): void {
       inkRef.current?.repaint(TRANSCRIPT_VIEWPORT_REPAINT_OPTIONS);
     },
     repaintAfterTerminalResume(): void {

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -818,9 +818,7 @@ export async function runChat(
       colorEnabled={stdoutColorEnabled}
       commandName={context.commandName}
       onInterruptActive={interruptActive}
-      onTranscriptViewportChange={
-        viewportController.handleTranscriptViewportChange
-      }
+      onStaticTranscriptChange={viewportController.repaintTranscript}
       onCtrlC={() => handleSigint()}
       onSuspend={() => handleSigtstp()}
       onKillExecution={(executionId) => {

--- a/packages/cli/src/chat/tui/state/childExecutions.ts
+++ b/packages/cli/src/chat/tui/state/childExecutions.ts
@@ -58,6 +58,21 @@ export const childStreamEntries: Signal.Computed<ChildStreamEntries> = computed(
   () => CHILD_STREAMS.get(),
 );
 
+/** Retained execution-id → human label projection for executions tool rows. */
+export const subagentExecutionLabels: Signal.Computed<
+  ReadonlyMap<string, string>
+> = computed(() => {
+  const labels = new Map<string, string>();
+  for (const entry of CHILD_STREAMS.get().values()) {
+    if (entry.removed || !entry.summary) continue;
+    const label = childExecutionLabel(entry.summary);
+    if (label !== entry.summary.executionId) {
+      labels.set(entry.summary.executionId, label);
+    }
+  }
+  return labels;
+});
+
 function candidateParent(
   entry: ChildStreamEntry,
 ): StreamTabId | null | undefined {
@@ -424,7 +439,9 @@ export function childExecutionKey(child: ActiveChildInfo): string {
   return child.kind === 'subagent' ? child.childStreamId : child.executionId;
 }
 
-export function childExecutionLabel(child: ActiveChildInfo): string {
+export function childExecutionLabel(
+  child: Pick<ActiveChildInfo, 'agentName' | 'executionId' | 'toolName'>,
+): string {
   // The agent name is always set by the runtime (for both kinds), so it's the
   // label; toolName/executionId are just defensive fallbacks for a malformed
   // entry. `kind` isn't needed here — it's `childExecutionKey` that actually

--- a/packages/cli/src/chat/tui/state/transcriptLines.ts
+++ b/packages/cli/src/chat/tui/state/transcriptLines.ts
@@ -3,6 +3,7 @@
 // region, this renders every tool-output line.
 
 import stripAnsi from 'strip-ansi';
+import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 
 import { isRenderableTranscriptEntry } from '../panes/transcriptEntries';
 import { fullTranscriptEntryLayout } from '../panes/transcriptEntryLayout';
@@ -39,23 +40,31 @@ export function createTranscriptPrintRequest({
 // frame (terminal transcript, static row budget, task-detail panel), so keep
 // the width dimension inside the entry cache instead of letting callers thrash
 // a single slot.
+const EMPTY_EXECUTION_LABELS: ExecutionLabels = new Map();
 const entryLinesCache = new WeakMap<
   ConversationEntry,
-  Map<number, readonly string[]>
+  WeakMap<ExecutionLabels, Map<number, readonly string[]>>
 >();
 
 function transcriptEntryLines(
   entry: ConversationEntry,
   cols: number,
+  executionLabels: ExecutionLabels,
 ): readonly string[] {
-  const cachedByCols = entryLinesCache.get(entry);
+  const cachedByLabels = entryLinesCache.get(entry);
+  const cachedByCols = cachedByLabels?.get(executionLabels);
   const cached = cachedByCols?.get(cols);
   if (cached) return cached;
-  const lines = computeTranscriptEntryLines(entry, cols);
+  const lines = computeTranscriptEntryLines(entry, cols, executionLabels);
   if (cachedByCols) {
     cachedByCols.set(cols, lines);
+  } else if (cachedByLabels) {
+    cachedByLabels.set(executionLabels, new Map([[cols, lines]]));
   } else {
-    entryLinesCache.set(entry, new Map([[cols, lines]]));
+    entryLinesCache.set(
+      entry,
+      new WeakMap([[executionLabels, new Map([[cols, lines]])]]),
+    );
   }
   return lines;
 }
@@ -63,8 +72,9 @@ function transcriptEntryLines(
 function computeTranscriptEntryLines(
   entry: ConversationEntry,
   cols: number,
+  executionLabels: ExecutionLabels,
 ): readonly string[] {
-  return fullTranscriptEntryLayout(entry, cols).lines;
+  return fullTranscriptEntryLayout(entry, cols, executionLabels).lines;
 }
 
 function isCompactToolEntry(
@@ -106,6 +116,7 @@ function shouldSeparateEntries({
 export function transcriptToLines(
   slice: StreamSlice | undefined,
   cols: number,
+  executionLabels: ExecutionLabels = EMPTY_EXECUTION_LABELS,
 ): readonly string[] {
   if (!slice) return [];
   const out: string[] = [];
@@ -113,7 +124,7 @@ export function transcriptToLines(
   let previousLines: readonly string[] = [];
   for (const entry of slice.entries) {
     if (!isRenderableTranscriptEntry(entry)) continue;
-    const lines = transcriptEntryLines(entry, cols);
+    const lines = transcriptEntryLines(entry, cols, executionLabels);
     if (lines.length === 0) continue;
     if (
       out.length > 0 &&
@@ -148,16 +159,18 @@ function safeTerminalText(text: string): string {
 /** Format one immutable request for the terminal's static scrollback. */
 export function formatTranscriptForScrollback({
   cols,
+  executionLabels = EMPTY_EXECUTION_LABELS,
   request,
 }: {
   readonly cols: number;
+  readonly executionLabels?: ExecutionLabels;
   readonly request: TranscriptPrintRequest;
 }): string {
   const heading = safeTerminalText(request.title ?? '')
     .replaceAll('\n', ' ')
     .trim();
   const body = safeTerminalText(
-    transcriptToLines(request.slice, cols).join('\n'),
+    transcriptToLines(request.slice, cols, executionLabels).join('\n'),
   );
   const label = heading ? `Full output: ${heading}` : 'Full output';
   return `\n[${label}]\n${body.trimEnd() || '(no output yet)'}\n`;

--- a/packages/cli/src/chat/tui/state/transcriptViewportMode.ts
+++ b/packages/cli/src/chat/tui/state/transcriptViewportMode.ts
@@ -28,24 +28,3 @@ export function transcriptViewportKey({
 export function isScopedTranscriptViewport(viewportKey: string): boolean {
   return viewportKey !== ROOT_SCROLLBACK_VIEWPORT_KEY;
 }
-
-export interface TranscriptViewportChange {
-  readonly previousViewportKey: string;
-  readonly nextViewportKey: string;
-}
-
-export function transcriptViewportChange({
-  nextViewportKey,
-  previousViewportKey,
-}: {
-  readonly nextViewportKey: string;
-  readonly previousViewportKey: string | undefined;
-}): TranscriptViewportChange | undefined {
-  if (
-    previousViewportKey === undefined ||
-    previousViewportKey === nextViewportKey
-  ) {
-    return undefined;
-  }
-  return { previousViewportKey, nextViewportKey };
-}

--- a/packages/extension/src/progressView/frontend/components/LogList.ts
+++ b/packages/extension/src/progressView/frontend/components/LogList.ts
@@ -33,6 +33,7 @@ import type { LogMessageData, TaskGroup } from '@shared/schemas';
 import { PersistedState } from '@shared/state';
 import { designTokens } from '@shared/styles';
 import { postMessage } from '@shared/hostBridge';
+import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 import { ToggleStateStore } from '@shared/state/ToggleStateStore';
 import { copyWithFeedback } from '@shared/utils/clipboard';
 import { webviewStorage } from '../webviewStorage';
@@ -75,6 +76,7 @@ interface CachedStream {
   isToolUse: boolean;
   /** Whether to render this stream's logs in terminal style. */
   terminalMode: boolean;
+  subagentExecutionLabels: ExecutionLabels;
 }
 
 @customElement('log-list')
@@ -138,6 +140,8 @@ export class LogList extends LitElement {
       entry.status = this.streamContext.streamStatus;
       entry.isToolUse = this.streamContext.isToolUse;
       entry.terminalMode = this.streamContext.terminalMode;
+      entry.subagentExecutionLabels =
+        this.streamContext.subagentExecutionLabels ?? new Map();
     }
   }
 
@@ -166,6 +170,7 @@ export class LogList extends LitElement {
           .streamStatus=${data.status}
           .isToolUse=${data.isToolUse}
           .toggleStates=${data.toggleStates}
+          .subagentExecutionLabels=${data.subagentExecutionLabels}
           ?terminal=${data.terminalMode}
         ></task-group-list>
       `,
@@ -235,6 +240,7 @@ export class LogList extends LitElement {
       status: null,
       isToolUse: false,
       terminalMode: false,
+      subagentExecutionLabels: new Map(),
     };
     this.streamCache.set(streamId, createdEntry);
     return createdEntry;

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -17,6 +17,8 @@ import {
   type LogMessageData,
   type TaskGroup,
 } from '@shared/schemas';
+import { designTokens } from '@shared/styles';
+import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 
 // Side-effect imports - register WA icon and spinner components
 import '@awesome.me/webawesome/dist/components/button/button.js';
@@ -24,7 +26,6 @@ import '@awesome.me/webawesome/dist/components/details/details.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
 
-import { designTokens } from '@shared/styles';
 import { isInFlightPhase } from '@shared/streams/streamStatus';
 import { parseWorkflowOutputRoundDir } from '@shared/constants/workflowOutput';
 import { ToggleStateStore } from '@shared/state/ToggleStateStore';
@@ -119,6 +120,10 @@ export class TaskGroupList extends LitElement {
    * Reflected to the host attribute so scoped CSS can target it.
    */
   @property({ type: Boolean, reflect: true }) terminal = false;
+
+  /** Retained subagent identities used by executions tool cards. */
+  @property({ attribute: false })
+  subagentExecutionLabels: ExecutionLabels = new Map();
 
   /** Track previous group statuses to detect completion (not rendered — no @state needed) */
   private previousStatuses = new Map<string, string>();
@@ -385,7 +390,12 @@ export class TaskGroupList extends LitElement {
     }${repeat(
       visibleMessages,
       (m) => m.id,
-      (m) => guard([m], () => formatLogEntry(m)),
+      (m) =>
+        guard([m, this.subagentExecutionLabels], () =>
+          formatLogEntry(m, {
+            executionLabels: this.subagentExecutionLabels,
+          }),
+        ),
     )}`;
   }
 
@@ -706,7 +716,11 @@ export class TaskGroupList extends LitElement {
           (item) => item.key,
           (item) =>
             'msg' in item
-              ? guard([item.msg], () => formatLogEntry(item.msg))
+              ? guard([item.msg, this.subagentExecutionLabels], () =>
+                  formatLogEntry(item.msg, {
+                    executionLabels: this.subagentExecutionLabels,
+                  }),
+                )
               : this.renderGroupNode(item.tree, true),
         )}
       </div>

--- a/packages/extension/src/progressView/frontend/contexts/streamContexts.ts
+++ b/packages/extension/src/progressView/frontend/contexts/streamContexts.ts
@@ -16,6 +16,7 @@ import type {
   StreamTabInfo,
   TaskGroup,
 } from '@shared/schemas';
+import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 import type {
   FollowupOptionsState,
   ProcessOutputMap,
@@ -81,6 +82,8 @@ export interface StreamLogContextValue {
   streamStatus: StreamLifecycleStatus | null;
   /** Render log output in terminal style (monospace, no timestamps, etc). */
   terminalMode: boolean;
+  /** Retained subagent identities for executions tool summaries. */
+  subagentExecutionLabels?: ExecutionLabels;
 }
 
 export const EMPTY_LOG_CONTEXT: StreamLogContextValue = {

--- a/packages/extension/src/progressView/frontend/formatters/baseLogFormatter.ts
+++ b/packages/extension/src/progressView/frontend/formatters/baseLogFormatter.ts
@@ -5,11 +5,13 @@ import {
   STREAMING_TEXT_MESSAGE_TYPES,
   type LogMessageData,
 } from '@shared/schemas';
+import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 export type FormatOptions = {
   preservedOpen?: boolean;
   defaultOpen?: boolean;
+  executionLabels?: ExecutionLabels;
 };
 
 function isRunningData(data: unknown): boolean {

--- a/packages/extension/src/progressView/frontend/formatters/index.ts
+++ b/packages/extension/src/progressView/frontend/formatters/index.ts
@@ -41,7 +41,7 @@ export { isStreamingTextLogMessage } from './baseLogFormatter';
 
 type TemplateFormatterFn = (
   message: LogMessageData,
-  options?: { defaultOpen?: boolean; isRunning?: boolean },
+  options?: FormatOptions & { isRunning?: boolean },
 ) => FormatResult;
 
 /** Message types that auto-expand when defaultOpen is set. */
@@ -69,7 +69,7 @@ function formatRenderError(label: string, errorMsg: string): TemplateResult {
 function wrapWithErrorHandling(
   fn: (
     m: LogMessageData,
-    opts?: { defaultOpen?: boolean; isRunning?: boolean },
+    opts?: FormatOptions & { isRunning?: boolean },
   ) => FormatResult,
   label: string,
 ): TemplateFormatterFn {
@@ -169,6 +169,7 @@ export function formatLogEntry(
   // logs until the stream finalizes (#7276).
   const templateOptions = {
     defaultOpen: isOpen,
+    executionLabels: options.executionLabels,
     isRunning: isStreamingTextLogMessage(logMessage),
   };
 

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -23,6 +23,11 @@ import {
 } from '@shared/constants/delegationTools';
 import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
 import { toolDisplayKind } from '@shared/tools/toolKind';
+import {
+  EXECUTIONS_DEFAULT_ACTION,
+  executionsSubagentSummary,
+  type ExecutionLabels,
+} from '@shared/tools/executionsDisplay';
 import { isObject } from '@utils/core';
 import { truncateSummary } from '@utils/text/stringUtils';
 
@@ -56,7 +61,6 @@ import {
   getToolTimeoutMs,
   joinWithSeparator,
   truncateHeaderSummary,
-  EXECUTIONS_DEFAULT_ACTION,
 } from './toolFormatters/helpers';
 import { dispatchToolSections } from './toolFormatters/toolSections';
 
@@ -68,7 +72,10 @@ export {
 /** Format tool use log entry as TemplateResult. */
 export function formatToolUseTemplate(
   message: LogMessageData,
-  options?: { defaultOpen?: boolean },
+  options?: {
+    defaultOpen?: boolean;
+    executionLabels?: ExecutionLabels;
+  },
 ): FormatResult {
   const { timestamp, data } = message;
   const normalizedToolLog = normalizeToolUseData(data);
@@ -103,6 +110,13 @@ export function formatToolUseTemplate(
 
   // Surface action + path for executions tool so it's visible without expanding
   let headerSummary = normalizedToolLog.headerSummary || '';
+  const labeledExecutionSummary =
+    toolName === 'executions' && options?.executionLabels
+      ? executionsSubagentSummary(input, options.executionLabels)
+      : undefined;
+  if (labeledExecutionSummary) {
+    headerSummary = labeledExecutionSummary;
+  }
   if (!headerSummary) {
     if (toolName === 'executions' && isObject(input)) {
       headerSummary =

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/helpers.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/helpers.ts
@@ -53,9 +53,6 @@ const TIMEOUT_GATED_BY_ACTION: Record<string, string> = {
   executions: 'wait',
 };
 
-/** Default action for the executions tool when the model omits it. */
-export const EXECUTIONS_DEFAULT_ACTION = 'view';
-
 export function getExecutionsWaitTimeoutSeconds(timeout: unknown): number {
   return typeof timeout === 'number' && Number.isFinite(timeout)
     ? Math.min(

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
@@ -42,6 +42,7 @@ import {
   DELEGATION_TOOLS,
 } from '@shared/constants/delegationTools';
 import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+import { EXECUTIONS_DEFAULT_ACTION } from '@shared/tools/executionsDisplay';
 import { toolDisplayKind } from '@shared/tools/toolKind';
 import type { ExecutionsToolInput } from '@tools/ExecutionsTool';
 import type { EditInput } from '@tools/EditTool';
@@ -62,7 +63,6 @@ import {
   getOutputEdits,
   getExecutionsWaitTimeoutSeconds,
   isMcpTextBlock,
-  EXECUTIONS_DEFAULT_ACTION,
 } from './helpers';
 
 type SpecializedToolRenderer = (

--- a/packages/extension/src/progressView/frontend/progressState.ts
+++ b/packages/extension/src/progressView/frontend/progressState.ts
@@ -271,7 +271,7 @@ const subagentExecutionLabels$ = new Signal.Computed((): ExecutionLabels => {
     if (child.kind !== 'agent' || !child.parentStreamId || !child.executionId) {
       continue;
     }
-    const label = (child.agent ?? child.label).trim();
+    const label = child.label.trim();
     if (label && label !== child.executionId) {
       labels.set(child.executionId, label);
     }

--- a/packages/extension/src/progressView/frontend/progressState.ts
+++ b/packages/extension/src/progressView/frontend/progressState.ts
@@ -24,6 +24,7 @@ import {
   type StreamTabInfo,
   type TaskGroup,
 } from '@shared/schemas';
+import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 import { toNewestFirstByTimestamp } from '@utils/core';
 
 import { setsEqual } from './utils';
@@ -263,6 +264,21 @@ const activeIsToolUse$ = new Signal.Computed(() => {
   return state ? isToolUseState(state) : false;
 });
 
+/** Session-wide identity projection; ordinary log ticks do not rebuild it. */
+const subagentExecutionLabels$ = new Signal.Computed((): ExecutionLabels => {
+  const labels = new Map<string, string>();
+  for (const child of streamById$.get().values()) {
+    if (child.kind !== 'agent' || !child.parentStreamId || !child.executionId) {
+      continue;
+    }
+    const label = (child.agent ?? child.label).trim();
+    if (label && label !== child.executionId) {
+      labels.set(child.executionId, label);
+    }
+  }
+  return labels;
+});
+
 /** Stream context derived from active stream + state. */
 export const streamContext$ = new Signal.Computed((): StreamContextValue => {
   const activeStreamInfo = activeStreamInfo$.get();
@@ -307,6 +323,7 @@ export const logContext$ = new Signal.Computed((): StreamLogContextValue => {
     hasStreams,
     streamName: activeStreamInfo.name,
     streamStatus: activeStreamState$.get()?.status ?? null,
+    subagentExecutionLabels: subagentExecutionLabels$.get(),
     // Process agents emit raw stdout/stderr; render them terminal-style
     // (monospace, no timestamps, tight spacing) rather than logger entries.
     terminalMode: activeStreamInfo.kind === 'process',

--- a/src/shared/tools/executionsDisplay.ts
+++ b/src/shared/tools/executionsDisplay.ts
@@ -4,11 +4,23 @@ export const EXECUTIONS_DEFAULT_ACTION = 'view';
 
 export type ExecutionLabels = ReadonlyMap<string, string>;
 
-function executionIdFromPath(path: unknown): string | undefined {
+interface ExecutionPathTarget {
+  id: string;
+  resourceSuffix: string;
+}
+
+function executionTargetFromPath(
+  path: unknown,
+): ExecutionPathTarget | undefined {
   if (typeof path !== 'string') return undefined;
   const segments = path.split('/').filter(Boolean);
   if (segments[0] !== 'executions' || segments.length < 2) return undefined;
-  return segments[1] === 'current' ? undefined : segments[1];
+  if (segments[1] === 'current') return undefined;
+  return {
+    id: segments[1],
+    resourceSuffix:
+      segments.length > 2 ? `/${segments.slice(2).join('/')}` : '',
+  };
 }
 
 /**
@@ -28,19 +40,20 @@ export function executionsSubagentSummary(
   const listedIds = Array.isArray(input.ids)
     ? input.ids.filter((id): id is string => typeof id === 'string' && !!id)
     : [];
-  const pathId = executionIdFromPath(input.path);
-  let targetIds = listedIds;
-  if (targetIds.length === 0) {
-    targetIds = pathId ? [pathId] : [];
-  }
-  if (targetIds.length === 0) return undefined;
+  const pathTarget = executionTargetFromPath(input.path);
+  const targets: ExecutionPathTarget[] = listedIds.map((id) => ({
+    id,
+    resourceSuffix: '',
+  }));
+  if (targets.length === 0 && pathTarget) targets.push(pathTarget);
+  if (targets.length === 0) return undefined;
 
   let matchedSubagent = false;
-  const targets = targetIds.map((id) => {
+  const displayTargets = targets.map(({ id, resourceSuffix }) => {
     const label = labels.get(id)?.trim();
-    if (!label) return id;
+    if (!label) return `${id}${resourceSuffix}`;
     matchedSubagent = true;
-    return label;
+    return `${label}${resourceSuffix}`;
   });
   if (!matchedSubagent) return undefined;
 
@@ -48,5 +61,5 @@ export function executionsSubagentSummary(
     typeof input.action === 'string' && input.action.trim()
       ? input.action.trim()
       : EXECUTIONS_DEFAULT_ACTION;
-  return `${action}: ${targets.join(', ')}`;
+  return `${action}: ${displayTargets.join(', ')}`;
 }

--- a/src/shared/tools/executionsDisplay.ts
+++ b/src/shared/tools/executionsDisplay.ts
@@ -1,0 +1,52 @@
+import { isObject } from '@utils/core';
+
+export const EXECUTIONS_DEFAULT_ACTION = 'view';
+
+export type ExecutionLabels = ReadonlyMap<string, string>;
+
+function executionIdFromPath(path: unknown): string | undefined {
+  if (typeof path !== 'string') return undefined;
+  const segments = path.split('/').filter(Boolean);
+  if (segments[0] !== 'executions' || segments.length < 2) return undefined;
+  return segments[1] === 'current' ? undefined : segments[1];
+}
+
+/**
+ * Build the identity-aware summary for an executions tool call.
+ *
+ * Returning `undefined` when none of the targets are known subagents is
+ * deliberate: each host then keeps its existing background-process title.
+ * Mixed waits substitute the known subagents while retaining opaque IDs for
+ * process targets, so the summary still describes the complete wait set.
+ */
+export function executionsSubagentSummary(
+  input: unknown,
+  labels: ExecutionLabels,
+): string | undefined {
+  if (!isObject(input)) return undefined;
+
+  const listedIds = Array.isArray(input.ids)
+    ? input.ids.filter((id): id is string => typeof id === 'string' && !!id)
+    : [];
+  const pathId = executionIdFromPath(input.path);
+  let targetIds = listedIds;
+  if (targetIds.length === 0) {
+    targetIds = pathId ? [pathId] : [];
+  }
+  if (targetIds.length === 0) return undefined;
+
+  let matchedSubagent = false;
+  const targets = targetIds.map((id) => {
+    const label = labels.get(id)?.trim();
+    if (!label) return id;
+    matchedSubagent = true;
+    return label;
+  });
+  if (!matchedSubagent) return undefined;
+
+  const action =
+    typeof input.action === 'string' && input.action.trim()
+      ? input.action.trim()
+      : EXECUTIONS_DEFAULT_ACTION;
+  return `${action}: ${targets.join(', ')}`;
+}

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -27,10 +27,7 @@ import {
   sessionHeaderIdentityLine,
 } from '@cli/chat/tui/panes/StaticConversationTranscript';
 import { staticScrollbackTarget } from '@cli/chat/tui/appLayout';
-import {
-  transcriptViewportChange,
-  transcriptViewportKey,
-} from '@cli/chat/tui/state/transcriptViewportMode';
+import { transcriptViewportKey } from '@cli/chat/tui/state/transcriptViewportMode';
 import {
   createTuiViewportController,
   type TuiRepaintOptions,
@@ -1412,43 +1409,9 @@ describe('CLI conversation transcript splitting', () => {
 
     expect(rootViewportKey).toBe('root-scrollback');
     expect(childViewportKey).toBe(`scoped:${CHILD}`);
-    expect(
-      transcriptViewportChange({
-        previousViewportKey: rootViewportKey,
-        nextViewportKey: childViewportKey,
-      }),
-    ).toMatchObject({
-      previousViewportKey: rootViewportKey,
-      nextViewportKey: childViewportKey,
-    });
-    expect(
-      transcriptViewportChange({
-        previousViewportKey: childViewportKey,
-        nextViewportKey: rootViewportKey,
-      }),
-    ).toMatchObject({
-      previousViewportKey: childViewportKey,
-      nextViewportKey: rootViewportKey,
-    });
   });
 
-  it('repaints viewport switches from a clean scrollback owner', () => {
-    const rootToChild = transcriptViewportChange({
-      previousViewportKey: 'root-scrollback',
-      nextViewportKey: 'scoped:child',
-    });
-    const childToRoot = transcriptViewportChange({
-      previousViewportKey: 'scoped:child',
-      nextViewportKey: 'root-scrollback',
-    });
-    const childToChild = transcriptViewportChange({
-      previousViewportKey: 'scoped:child',
-      nextViewportKey: 'scoped:other-child',
-    });
-
-    expect(rootToChild).toBeDefined();
-    expect(childToRoot).toBeDefined();
-    expect(childToChild).toBeDefined();
+  it('repaints static transcript invalidations from a clean origin', () => {
     const calls: TuiRepaintOptions[] = [];
     const controller = createTuiViewportController({
       current: {
@@ -1458,14 +1421,10 @@ describe('CLI conversation transcript splitting', () => {
       },
     });
 
-    controller.handleTranscriptViewportChange(rootToChild!);
-    controller.handleTranscriptViewportChange(childToRoot!);
-    controller.handleTranscriptViewportChange(childToChild!);
+    controller.repaintTranscript();
     controller.repaintAfterTerminalResume();
 
     expect(calls).toEqual([
-      { clearScrollback: true, preserveStatic: false },
-      { clearScrollback: true, preserveStatic: false },
       { clearScrollback: true, preserveStatic: false },
       { clearScrollback: true },
     ]);

--- a/src/test-kernel/cli/StaticBandResize.vitest.mts
+++ b/src/test-kernel/cli/StaticBandResize.vitest.mts
@@ -245,6 +245,106 @@ describe('Static band resize', () => {
     }
   });
 
+  it('replaces finalized execution rows when subagent labels arrive', async () => {
+    const ink = (await import(cliRequire.resolve('ink'))) as any;
+    const React = ((await import(cliRequire.resolve('react'))) as any).default;
+    const { createElement } = React;
+    const { StaticConversationTranscript } =
+      await import('@cli/chat/tui/panes/StaticConversationTranscript');
+    const { patchStream, resetCliState } =
+      await import('@cli/chat/tui/state/cliState');
+    const inkRequire = createRequire(cliRequire.resolve('ink'));
+    const { clearTerminal } = inkRequire('ansi-escapes') as {
+      readonly clearTerminal: string;
+    };
+    const streamId = 'execution-label-stream' as StreamTabId;
+    const executionId = 'late-subagent-id';
+    const executionPath = `/executions/${executionId}/report`;
+    const executionEntry: ConversationEntry = {
+      id: 'execution-view',
+      role: 'tool',
+      text: '',
+      finalized: true,
+      toolUse: {
+        parsed: {},
+        toolName: 'executions',
+        errorText: '',
+        outputText: 'report',
+        userInstructionText: '',
+        input: { path: executionPath },
+        isError: false,
+        isUserFeedback: false,
+        headerSummary: '',
+        status: 'completed',
+      },
+    };
+
+    resetCliState({
+      agent: 'research',
+      category: AgentCategory.ToolUse,
+      model: 'test-model',
+      modelSource: 'builtin-default',
+      cwd: '/tmp/execution-label-proof',
+      apiMode: 'personal',
+      approvalPolicy: 'ask',
+      canDelegate: false,
+      transcriptMode: 'persistent',
+      version: '0.0.0-test',
+    });
+    patchStream(streamId, (slice) => ({
+      ...slice,
+      entries: [executionEntry],
+    }));
+
+    let inst: any;
+    function App({ labels }: { labels: ReadonlyMap<string, string> }): unknown {
+      const renderKey = JSON.stringify([...labels]);
+      return createElement(StaticConversationTranscript, {
+        onRenderKeyChange: () => {
+          inst.repaint({ clearScrollback: true, preserveStatic: false });
+        },
+        ownerKey: 'execution-label-owner',
+        renderKey,
+        scrollbackStreamId: streamId,
+        subagentExecutionLabels: labels,
+        width: 80,
+      });
+    }
+
+    const out = new FakeStdout(80);
+    inst = ink.render(createElement(App, { labels: new Map() }), {
+      stdout: out,
+      stdin: new FakeStdin(),
+      interactive: true,
+      exitOnCtrlC: false,
+      patchConsole: false,
+    });
+
+    try {
+      expect(await waitFor(() => out.buf.includes(executionPath), 5000)).toBe(
+        true,
+      );
+
+      out.buf = '';
+      inst.rerender(
+        createElement(App, {
+          labels: new Map([[executionId, 'reviewer']]),
+        }),
+      );
+
+      expect(await waitFor(() => out.buf.includes(clearTerminal), 5000)).toBe(
+        true,
+      );
+      const frame = stripAnsi(latestRepaintFrame(out.buf, clearTerminal));
+      expect(frame).toContain('executions (view: reviewer/report)');
+      expect(frame).not.toContain(executionPath);
+      expect(occurrences(frame, 'executions (view: reviewer/report)')).toBe(1);
+    } finally {
+      inst.unmount();
+      resetCliState();
+    }
+  });
+
   it('keeps resize subscriptions constant as tool history grows', async () => {
     const ink = (await import(cliRequire.resolve('ink'))) as any;
     const React = ((await import(cliRequire.resolve('react'))) as any).default;

--- a/src/test-kernel/cli/StaticBandResize.vitest.mts
+++ b/src/test-kernel/cli/StaticBandResize.vitest.mts
@@ -23,6 +23,7 @@ import stripAnsi from 'strip-ansi';
 import { afterAll, describe, expect, it } from 'vitest';
 
 // Local imports
+import type { TuiRepaintOptions } from '@cli/chat/tui/render/tuiViewportController';
 import type { ConversationEntry } from '@cli/chat/tui/state/cliState';
 import { AgentCategory, type StreamTabId } from '@shared/schemas';
 import { delay } from '@utils/core';
@@ -296,12 +297,17 @@ describe('Static band resize', () => {
       entries: [executionEntry],
     }));
 
-    let inst: any;
+    const inkRef: {
+      current?: { repaint(options: TuiRepaintOptions): void };
+    } = {};
     function App({ labels }: { labels: ReadonlyMap<string, string> }): unknown {
       const renderKey = JSON.stringify([...labels]);
       return createElement(StaticConversationTranscript, {
         onRenderKeyChange: () => {
-          inst.repaint({ clearScrollback: true, preserveStatic: false });
+          inkRef.current?.repaint({
+            clearScrollback: true,
+            preserveStatic: false,
+          });
         },
         ownerKey: 'execution-label-owner',
         renderKey,
@@ -312,13 +318,14 @@ describe('Static band resize', () => {
     }
 
     const out = new FakeStdout(80);
-    inst = ink.render(createElement(App, { labels: new Map() }), {
+    const inst = ink.render(createElement(App, { labels: new Map() }), {
       stdout: out,
       stdin: new FakeStdin(),
       interactive: true,
       exitOnCtrlC: false,
       patchConsole: false,
     });
+    inkRef.current = inst;
 
     try {
       expect(await waitFor(() => out.buf.includes(executionPath), 5000)).toBe(

--- a/src/test-kernel/cli/ToolRenderers.vitest.mts
+++ b/src/test-kernel/cli/ToolRenderers.vitest.mts
@@ -141,6 +141,18 @@ describe('CLI tool display lines', () => {
     ).toEqual(['● executions (/executions/process-1)']);
   });
 
+  it('keeps the resource path when labeling an executions target', () => {
+    const entry = toolUse('executions', {
+      path: '/executions/sub-1/workspace-files/review.md',
+    });
+
+    expect(
+      toolUseDisplayLines(entry, {
+        executionLabels: new Map([['sub-1', 'reviewer']]),
+      }),
+    ).toEqual(['● executions (view: reviewer/workspace-files/review.md)']);
+  });
+
   it('renders TeXRA edit_file calls through the native diff row', () => {
     const entry = toolUse('edit_file', {
       path: 'paper.tex',

--- a/src/test-kernel/cli/ToolRenderers.vitest.mts
+++ b/src/test-kernel/cli/ToolRenderers.vitest.mts
@@ -111,6 +111,36 @@ describe('CLI tool display lines', () => {
     expect(header.spans.at(-1)).toMatchObject({ color: 'cyan' });
   });
 
+  it('renders executions targets with retained subagent labels', () => {
+    const entry = toolUse('executions', {
+      action: 'wait',
+      path: '/executions',
+      ids: ['sub-1', 'sub-2'],
+    });
+
+    expect(
+      toolUseDisplayLines(entry, {
+        executionLabels: new Map([
+          ['sub-1', 'reviewer'],
+          ['sub-2', 'leanSolver'],
+        ]),
+      }),
+    ).toEqual(['● executions (wait: reviewer, leanSolver)']);
+  });
+
+  it('keeps the existing executions path for a background process', () => {
+    const entry = toolUse('executions', {
+      action: 'view',
+      path: '/executions/process-1',
+    });
+
+    expect(
+      toolUseDisplayLines(entry, {
+        executionLabels: new Map([['sub-1', 'reviewer']]),
+      }),
+    ).toEqual(['● executions (/executions/process-1)']);
+  });
+
   it('renders TeXRA edit_file calls through the native diff row', () => {
     const entry = toolUse('edit_file', {
       path: 'paper.tex',

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -38,6 +38,7 @@ import {
   parentStream,
   retainedChildStreamsFor,
   setParentStream,
+  subagentExecutionLabels,
   visibleSubagentRows,
 } from '@cli/chat/tui/state/childExecutions';
 import {
@@ -220,6 +221,8 @@ describe('cliState Phase 4 fields', () => {
       // A later, empty roster clears active membership; the retained row
       // survives and its status is read live from the child's own slice.
       applySubagentRoster(root, []);
+
+      expect(subagentExecutionLabels.get().get('agent-1')).toBe('codex');
 
       defaultSession().status.transition(
         child1,

--- a/src/test-kernel/progressView/ProgressExecutionLabels.vitest.ts
+++ b/src/test-kernel/progressView/ProgressExecutionLabels.vitest.ts
@@ -25,7 +25,7 @@ const completedChild: StreamTabInfo = {
   kind: 'agent',
   name: 'reviewer#sub-1',
   label: 'reviewer',
-  agent: 'reviewer',
+  agent: 'builtInToolUse:reviewer',
   agentCategory: AgentCategory.ToolUse,
   creationTimestamp: 2,
   executionId: 'sub-1',

--- a/src/test-kernel/progressView/ProgressExecutionLabels.vitest.ts
+++ b/src/test-kernel/progressView/ProgressExecutionLabels.vitest.ts
@@ -1,0 +1,97 @@
+// Third-party imports
+import { afterEach, describe, expect, it } from 'vitest';
+
+// Local imports - progress view state
+import {
+  appState,
+  logContext$,
+  resetProgressState,
+} from '@progressView/frontend/progressState';
+import { createInitialState } from '@progressView/frontend/store';
+
+// Local imports - shared schemas
+import { AgentCategory, type StreamTabInfo } from '@shared/schemas';
+
+const parent: StreamTabInfo = {
+  kind: 'agent',
+  name: 'parent',
+  label: 'parent',
+  agent: 'root',
+  agentCategory: AgentCategory.ToolUse,
+  creationTimestamp: 1,
+};
+
+const completedChild: StreamTabInfo = {
+  kind: 'agent',
+  name: 'reviewer#sub-1',
+  label: 'reviewer',
+  agent: 'reviewer',
+  agentCategory: AgentCategory.ToolUse,
+  creationTimestamp: 2,
+  executionId: 'sub-1',
+  parentStreamId: 'parent',
+};
+
+const completedSibling: StreamTabInfo = {
+  ...completedChild,
+  name: 'leanSolver#sub-2',
+  label: 'leanSolver',
+  agent: 'leanSolver',
+  executionId: 'sub-2',
+};
+
+afterEach(resetProgressState);
+
+describe('progress executions labels', () => {
+  it('retains child-stream identities after the active roster is empty', () => {
+    appState.set({
+      ...createInitialState(),
+      activeStreamId: 'parent',
+      streamById: new Map<string, StreamTabInfo>([
+        ['parent', parent],
+        ['reviewer#sub-1', completedChild],
+      ]),
+    });
+
+    expect(logContext$.get().subagentExecutionLabels?.get('sub-1')).toBe(
+      'reviewer',
+    );
+  });
+
+  it('exposes sibling identities while a subagent tab is active', () => {
+    appState.set({
+      ...createInitialState(),
+      activeStreamId: completedChild.name,
+      streamById: new Map<string, StreamTabInfo>([
+        ['parent', parent],
+        [completedChild.name, completedChild],
+        [completedSibling.name, completedSibling],
+      ]),
+    });
+
+    expect(logContext$.get().subagentExecutionLabels?.get('sub-2')).toBe(
+      'leanSolver',
+    );
+  });
+
+  it('does not label child process streams as subagents', () => {
+    const process: StreamTabInfo = {
+      ...completedChild,
+      kind: 'process',
+      name: 'bash#process-1',
+      label: 'bash',
+      agent: 'bash',
+      executionId: 'process-1',
+    };
+    appState.set({
+      ...createInitialState(),
+      activeStreamId: 'parent',
+      streamById: new Map<string, StreamTabInfo>([
+        ['parent', parent],
+        ['bash#process-1', process],
+      ]),
+    });
+
+    expect(logContext$.get().subagentExecutionLabels?.size).toBe(0);
+  });
+});

--- a/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
+++ b/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
@@ -222,6 +222,68 @@ return { papers, question: args.question };`;
     expect(container.textContent).toContain('wait (timeout: 1800s)');
     expect(container.textContent).not.toContain('3600s');
   });
+
+  it('labels executions targets when the display model knows the subagents', () => {
+    const message: LogMessageData = {
+      id: 'executions-subagents',
+      text: '',
+      level: LOG_LEVELS.INFO,
+      timestamp: 1,
+      messageType: 'toolUse',
+      data: {
+        toolName: 'executions',
+        input: {
+          action: 'wait',
+          path: '/executions',
+          ids: ['sub-1', 'sub-2'],
+        },
+      },
+    };
+
+    const container = document.createElement('div');
+    render(
+      formatToolUseTemplate(message, {
+        executionLabels: new Map([
+          ['sub-1', 'reviewer'],
+          ['sub-2', 'leanSolver'],
+        ]),
+      }),
+      container,
+    );
+
+    expect(container.querySelector('.tool-use-title')?.textContent).toBe(
+      'executions — wait: reviewer, leanSolver',
+    );
+  });
+
+  it('keeps the existing executions title for a background process', () => {
+    const message: LogMessageData = {
+      id: 'executions-process',
+      text: '',
+      level: LOG_LEVELS.INFO,
+      timestamp: 1,
+      messageType: 'toolUse',
+      data: {
+        toolName: 'executions',
+        input: {
+          action: 'view',
+          path: '/executions/process-1',
+        },
+      },
+    };
+
+    const container = document.createElement('div');
+    render(
+      formatToolUseTemplate(message, {
+        executionLabels: new Map([['sub-1', 'reviewer']]),
+      }),
+      container,
+    );
+
+    expect(container.querySelector('.tool-use-title')?.textContent).toBe(
+      'executions — view /executions/process-1',
+    );
+  });
 });
 
 /**

--- a/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
+++ b/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
@@ -256,6 +256,34 @@ return { papers, question: args.question };`;
     );
   });
 
+  it('keeps the resource path when labeling an executions target', () => {
+    const message: LogMessageData = {
+      id: 'executions-subagent-resource',
+      text: '',
+      level: LOG_LEVELS.INFO,
+      timestamp: 1,
+      messageType: 'toolUse',
+      data: {
+        toolName: 'executions',
+        input: {
+          path: '/executions/sub-1/workspace-files/review.md',
+        },
+      },
+    };
+
+    const container = document.createElement('div');
+    render(
+      formatToolUseTemplate(message, {
+        executionLabels: new Map([['sub-1', 'reviewer']]),
+      }),
+      container,
+    );
+
+    expect(container.querySelector('.tool-use-title')?.textContent).toBe(
+      'executions — view: reviewer/workspace-files/review.md',
+    );
+  });
+
   it('keeps the existing executions title for a background process', () => {
     const message: LogMessageData = {
       id: 'executions-process',

--- a/src/test-kernel/shared/ExecutionsDisplay.vitest.ts
+++ b/src/test-kernel/shared/ExecutionsDisplay.vitest.ts
@@ -26,7 +26,13 @@ describe('executions tool display', () => {
   it('labels a subagent selected through a specific execution path', () => {
     expect(
       executionsSubagentSummary({ path: '/executions/sub-1/report' }, labels),
-    ).toBe('view: reviewer');
+    ).toBe('view: reviewer/report');
+    expect(
+      executionsSubagentSummary(
+        { path: '/executions/sub-1/workspace-files/review.md' },
+        labels,
+      ),
+    ).toBe('view: reviewer/workspace-files/review.md');
   });
 
   it('keeps mixed wait targets complete', () => {

--- a/src/test-kernel/shared/ExecutionsDisplay.vitest.ts
+++ b/src/test-kernel/shared/ExecutionsDisplay.vitest.ts
@@ -1,0 +1,55 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - shared tool display
+import { executionsSubagentSummary } from '@shared/tools/executionsDisplay';
+
+const labels = new Map([
+  ['sub-1', 'reviewer'],
+  ['sub-2', 'leanSolver'],
+]);
+
+describe('executions tool display', () => {
+  it('labels every subagent in a wait target list', () => {
+    expect(
+      executionsSubagentSummary(
+        {
+          action: 'wait',
+          path: '/executions',
+          ids: ['sub-1', 'sub-2'],
+        },
+        labels,
+      ),
+    ).toBe('wait: reviewer, leanSolver');
+  });
+
+  it('labels a subagent selected through a specific execution path', () => {
+    expect(
+      executionsSubagentSummary({ path: '/executions/sub-1/report' }, labels),
+    ).toBe('view: reviewer');
+  });
+
+  it('keeps mixed wait targets complete', () => {
+    expect(
+      executionsSubagentSummary(
+        { action: 'wait', path: '/executions', ids: ['sub-1', 'process-1'] },
+        labels,
+      ),
+    ).toBe('wait: reviewer, process-1');
+  });
+
+  it('preserves the host title when every target is a process', () => {
+    expect(
+      executionsSubagentSummary(
+        { action: 'wait', path: '/executions/process-1' },
+        labels,
+      ),
+    ).toBeUndefined();
+  });
+
+  it('does not treat the current execution alias as a subagent id', () => {
+    expect(
+      executionsSubagentSummary({ path: '/executions/current' }, labels),
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #8639

## Summary
- add one browser-safe executions summary model shared by the CLI and extension
- derive retained execution-id to agent-label maps from each host existing child-stream state
- render subagent names in wait/view rows while preserving current background-process titles

## Design
Identity resolution happens before JSX/Lit rendering. The CLI keeps one derived projection of its consolidated child-stream store, while the extension derives labels from retained child stream metadata. Both feed the same pure executions summary function into their existing tool display models, so live rows, static transcript geometry, printed output, grouped cards, and timeline cards stay consistent.

## Validation
- npm run format (targeted files)
- npm run compile:fast
- npm run lint (0 errors; one unrelated existing warning)
- npm run typecheck
- npm test (728 files passed, 1 skipped; 6655 tests passed, 4 skipped)
- focused post-rebase suite (6 files, 205 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-layer and transcript repaint wiring only; no auth or execution control changes. Main risk is incorrect scrollback repaint or label leakage in edge cases, covered by new tests.
> 
> **Overview**
> **Executions** wait/view tool rows can show **retained subagent names** (e.g. `wait: reviewer, leanSolver`) instead of raw execution IDs, while **background-process** targets keep their existing titles when no subagent label applies.
> 
> A shared **`executionsSubagentSummary`** helper in `@shared/tools/executionsDisplay` drives the header text from tool input plus an `executionId → label` map. The **CLI** derives that map from child-stream state (`subagentExecutionLabels`) and threads **`ExecutionLabels`** through live pane, static scrollback, row budgeting, and printed transcript paths so geometry and text stay aligned. The **extension progress view** builds the same map from retained child stream metadata and passes it into tool formatters and log cards.
> 
> Static transcript **repaint** is keyed off scrollback owner **and** label changes: viewport-switch callbacks are replaced with **`onStaticTranscriptChange`** / **`repaintTranscript`** when the static render identity changes (including late-arriving labels), so finalized rows can refresh without relying only on stream tab switches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b88141e91b4d18ee81f9f146a484891f51ebe3d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->