### PR TITLE
fix(workflow): reject partially missing child inputs

### DIFF
--- a/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
@@ -191,29 +191,47 @@ describe('createWorkflowScriptAgentRunner', () => {
   });
 
   it('honors an explicit agent and binds verified run outputs', async () => {
-    const requested = '/storage/executions/bbbbbb222222/r1/draft.tex';
-    const canonical = '/canonical/executions/bbbbbb222222/r1/draft.tex';
+    const firstRequested =
+      '/storage/executions/bbbbbb222222/r1/introduction.tex';
+    const firstCanonical =
+      '/canonical/executions/bbbbbb222222/r1/introduction.tex';
+    const secondRequested =
+      '/storage/executions/cccccc333333/r1/conclusion.tex';
+    const secondCanonical =
+      '/canonical/executions/cccccc333333/r1/conclusion.tex';
     mocks.runStorageLocationFromAnyAbsolutePath.mockImplementation((file) =>
-      file === requested ? { kind: 'runStorage' } : undefined,
+      file === firstRequested || file === secondRequested
+        ? { kind: 'runStorage' }
+        : undefined,
     );
-    mocks.resolveChildRunOutput.mockResolvedValue({
-      kind: 'runStorage',
-      absolutePath: canonical,
-      relativePath: 'r1/draft.tex',
-      executionId: 'bbbbbb222222',
-    });
+    mocks.resolveChildRunOutput.mockImplementation(
+      async (_parentExecutionId, file) => ({
+        kind: 'runStorage',
+        absolutePath:
+          file === firstRequested ? firstCanonical : secondCanonical,
+        relativePath:
+          file === firstRequested ? 'r1/introduction.tex' : 'r1/conclusion.tex',
+        executionId: file === firstRequested ? 'bbbbbb222222' : 'cccccc333333',
+      }),
+    );
     const runner = defaultRunner();
 
     await runner(
       invocation({
         agentName: 'merge',
-        inputFiles: ['notes.tex', requested],
+        inputFiles: [firstRequested, 'notes.tex', secondRequested],
       }),
     );
 
-    expect(mocks.resolveChildRunOutput).toHaveBeenCalledWith(
+    expect(mocks.resolveChildRunOutput).toHaveBeenNthCalledWith(
+      1,
       parentExecutionId,
-      requested,
+      firstRequested,
+    );
+    expect(mocks.resolveChildRunOutput).toHaveBeenNthCalledWith(
+      2,
+      parentExecutionId,
+      secondRequested,
     );
     expect(mocks.assertWorkflowFilesExist).toHaveBeenCalledWith([
       { label: 'Input file', files: ['notes.tex'] },
@@ -222,7 +240,7 @@ describe('createWorkflowScriptAgentRunner', () => {
       expect.objectContaining({
         agentName: 'merge',
         configPayload: expect.objectContaining({
-          inputFiles: ['notes.tex', canonical],
+          inputFiles: [firstCanonical, 'notes.tex', secondCanonical],
         }),
       }),
     );
@@ -238,7 +256,58 @@ describe('createWorkflowScriptAgentRunner', () => {
 
     await expect(
       runner(invocation({ inputFiles: [placeholder] })),
-    ).rejects.toThrow(/pass options\.inputFiles with files that still exist/);
+    ).rejects.toMatchObject({
+      name: 'WorkflowRunAbortError',
+      message: expect.stringContaining(placeholder),
+    });
+    expect(mocks.preparedOptions).toHaveLength(0);
+  });
+
+  it('makes storage resolver failures run-fatal', async () => {
+    const placeholder = '/storage/executions/bbbbbb222222/r1/deleted.tex';
+    const storageError = new Error(
+      'Declared output r1/deleted.tex is missing from execution bbbbbb222222.',
+    );
+    mocks.runStorageLocationFromAnyAbsolutePath.mockReturnValue({
+      kind: 'runStorage',
+    });
+    mocks.resolveChildRunOutput.mockRejectedValue(storageError);
+    const runner = defaultRunner();
+
+    await expect(
+      runner(invocation({ inputFiles: [placeholder] })),
+    ).rejects.toMatchObject({
+      name: 'WorkflowRunAbortError',
+      message: expect.stringContaining(storageError.message),
+      cause: storageError,
+    });
+    expect(mocks.preparedOptions).toHaveLength(0);
+  });
+
+  it('rejects mixed inputs when any run-storage input no longer resolves', async () => {
+    const resolved = '/storage/executions/bbbbbb222222/r1/draft.tex';
+    const stale = '/storage/executions/cccccc333333/r1/review.tex';
+    mocks.runStorageLocationFromAnyAbsolutePath.mockImplementation((file) =>
+      file === resolved || file === stale ? { kind: 'runStorage' } : undefined,
+    );
+    mocks.resolveChildRunOutput.mockImplementation(async (_parent, file) =>
+      file === resolved
+        ? {
+            kind: 'runStorage',
+            absolutePath: '/canonical/executions/bbbbbb222222/r1/draft.tex',
+            relativePath: 'r1/draft.tex',
+            executionId: 'bbbbbb222222',
+          }
+        : undefined,
+    );
+    const runner = defaultRunner();
+
+    await expect(
+      runner(invocation({ inputFiles: ['notes.tex', resolved, stale] })),
+    ).rejects.toMatchObject({
+      name: 'WorkflowRunAbortError',
+      message: expect.stringContaining(stale),
+    });
     expect(mocks.preparedOptions).toHaveLength(0);
   });
 

--- a/src/tools/delegation/workflowScriptAgentRunner.ts
+++ b/src/tools/delegation/workflowScriptAgentRunner.ts
@@ -7,9 +7,9 @@ import {
 } from '@agent/workflowScript';
 import type { LaunchRunContext } from '@agent/runtime/RunContext';
 import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
+import { formatError } from '@common/errors';
 import { AgentCategory } from '@shared/schemas';
 import { configureDelegatedChildApprovals } from '@tools/approval';
-import { filterNotNullish } from '@utils/core';
 import { deriveExecutionId } from '@utils/core/idHash';
 import { runStorageLocationFromAnyAbsolutePath } from '@utils/files/taskRunStorage';
 
@@ -49,11 +49,28 @@ async function resolveInvocationInputFiles(
   const resolved = await Promise.all(
     references.map(async ({ file, runStorage }) => {
       if (!runStorage) return file;
-      return (await resolveChildRunOutput(parentExecutionId, file))
-        ?.absolutePath;
+      let output: Awaited<ReturnType<typeof resolveChildRunOutput>>;
+      try {
+        output = await resolveChildRunOutput(parentExecutionId, file);
+      } catch (error) {
+        throw new WorkflowRunAbortError(
+          formatError(
+            `Workflow run-storage input could not be resolved: ${file}`,
+            error,
+          ),
+          { cause: error },
+        );
+      }
+      if (!output) {
+        throw new WorkflowRunAbortError(
+          `Workflow run-storage input could not be resolved: ${file}; ` +
+            'pass options.inputFiles with files that still exist.',
+        );
+      }
+      return output.absolutePath;
     }),
   );
-  return resolved.filter(filterNotNullish);
+  return resolved;
 }
 
 /** Build the production `agent()` adapter for one workflow-script run. */


### PR DESCRIPTION
## Summary

- reject a workflow child invocation when any requested run-storage input can no longer be resolved
- preserve the original order of complete mixed workspace and run-storage input sets
- report the missing input as a run-fatal workflow error before child preparation or launch

## Design

Before this change, run-storage inputs were resolved and then passed through a null-removing filter. A mixed invocation could therefore lose one stale dependency while retaining another input, allowing a merge or comparison child to run on incomplete data.

After this change, resolution is total: each requested run-storage reference either contributes its canonical path in the original position or aborts the workflow with the unresolved path named in the error. Workspace-file validation remains unchanged.

## Verification

- focused `WorkflowScriptAgentRunner` suite (13 tests)
- repository type checking
- ESLint
- formatting and `git diff --check`

Closes #8680

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workflow input resolution on the path to delegated child runs; incorrect behavior could block valid workflows or still pass bad inputs, but scope is limited to run-storage reference handling with explicit abort semantics.
> 
> **Overview**
> Workflow child invocations now **fail the whole run** when any run-storage input cannot be resolved, instead of dropping unresolved paths and continuing with a partial file list.
> 
> `resolveInvocationInputFiles` wraps `resolveChildRunOutput` errors in `WorkflowRunAbortError` (with `cause` preserved), treats a missing resolution as fatal with the unresolved path in the message, and returns the full ordered list of paths—workspace files unchanged, run-storage slots replaced by canonical paths—without filtering nulls. Mixed workspace + run-storage sets keep their original order when all references resolve.
> 
> Tests cover multiple run-storage bindings, resolver throws, and mixed inputs where one stale reference aborts before child preparation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53132b3839dd0a1219a1c14767b1266451b89a48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->