### PR TITLE
feat(cli): summarize each subagent's latest response on its list row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ All notable changes to this project will be documented in this file.
 
 #### New Features
 
+- **Child rows show what each subagent last said** — the session list
+  summarizes every subagent's latest response (or its current instruction
+  while a turn is running) inline on its row, so you can triage children
+  without focusing them.
 - **Workflow round progress shows per agent** — session rows and the status
   bar display each running agent's round (for example `r2/3`), so a
   multi-agent workflow's delegated agents show where they are without

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -2014,6 +2014,8 @@ const SCENARIOS = [
       'strategy',
       'leanSolver',
       'reviewer',
+      // Child rows summarize the subagent's latest instruction/response.
+      '· Please handle the harness-child-review',
       'main.tex: Proof sketch',
       '3 sub',
       'Tab children',

--- a/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
@@ -261,6 +261,7 @@ export function ConversationRegion({
               onSelectionChange={onChildSelectionChange}
               onPrintStream={onPrintStream}
               pendingApprovals={snapshot.pendingApprovals}
+              listRootStreamId={snapshot.childListTarget.streamId}
               selectedValue={snapshot.selectedChildValue}
               sessions={snapshot.sessionViews}
               activeProcesses={activeProcesses}

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -15,6 +15,7 @@ import { formatResultCount } from '@utils/text/stringUtils';
 // Local imports - TUI state and controls
 import {
   childElapsed,
+  latestChildResponseSummary,
   liveChildExecutionElapsedKey,
   processTailLines,
 } from '../state/childControls';
@@ -26,6 +27,7 @@ import {
   childStreamListValue,
   type ChildListValue,
 } from '../state/childListSelection';
+import { truncateSummaryToWidth } from '../render/terminalText';
 import { useLiveNowMs } from '../state/useLiveNowMs';
 import { COLOR_HINT } from '../ui/colors';
 import { POINTER, TICK } from '../ui/glyphs';
@@ -82,6 +84,8 @@ function HiddenRowSummary({
   ) : null;
 }
 
+const SUBAGENT_SUMMARY_MAX_COLUMNS = 100;
+
 function SessionRow({
   active,
   focused,
@@ -114,6 +118,12 @@ function SessionRow({
   // then the pending-approval kind.
   const approvalSuffix = pendingApprovalRowSuffix(pendingKinds);
   const roundLabel = formatRoundStageLabel(session.slice?.roundStage);
+  // Child rows summarize what the subagent last said; the root row is the
+  // conversation itself — echoing your own last message there is noise.
+  const summary =
+    session.parentId !== undefined
+      ? latestChildResponseSummary(session.slice?.entries)
+      : undefined;
   return (
     <Box flexDirection="row" height={1} minWidth={0} overflowY="hidden">
       <Text color={focused ? COLOR_HINT : undefined}>
@@ -132,6 +142,13 @@ function SessionRow({
           {elapsed ? ` · ${elapsed}` : ''}
         </Text>
       </Box>
+      {summary ? (
+        <Box minWidth={0} flexShrink={2}>
+          <Text dimColor wrap="truncate-end">
+            {` · ${truncateSummaryToWidth(summary, SUBAGENT_SUMMARY_MAX_COLUMNS)}`}
+          </Text>
+        </Box>
+      ) : null}
       {focused ? <HiddenRowSummary text={hiddenRowSummary} /> : null}
     </Box>
   );

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -12,6 +12,9 @@ import {
 } from '@shared/streams/streamStatusDisplay';
 import { formatResultCount } from '@utils/text/stringUtils';
 
+// Local imports - TUI rendering
+import { truncateSummaryToWidth } from '../render/terminalText';
+
 // Local imports - TUI state and controls
 import {
   childElapsed,
@@ -27,7 +30,6 @@ import {
   childStreamListValue,
   type ChildListValue,
 } from '../state/childListSelection';
-import { truncateSummaryToWidth } from '../render/terminalText';
 import { useLiveNowMs } from '../state/useLiveNowMs';
 import { COLOR_HINT } from '../ui/colors';
 import { POINTER, TICK } from '../ui/glyphs';
@@ -90,6 +92,7 @@ function SessionRow({
   active,
   focused,
   hiddenRowSummary,
+  isListRoot,
   nowMs,
   pendingKinds,
   session,
@@ -97,6 +100,7 @@ function SessionRow({
   readonly active: boolean;
   readonly focused: boolean;
   readonly hiddenRowSummary: string | undefined;
+  readonly isListRoot: boolean;
   readonly nowMs: number;
   readonly pendingKinds: readonly PendingApprovalKind[] | undefined;
   readonly session: StreamView;
@@ -118,12 +122,12 @@ function SessionRow({
   // then the pending-approval kind.
   const approvalSuffix = pendingApprovalRowSuffix(pendingKinds);
   const roundLabel = formatRoundStageLabel(session.slice?.roundStage);
-  // Child rows summarize what the subagent last said; the root row is the
-  // conversation itself — echoing your own last message there is noise.
-  const summary =
-    session.parentId !== undefined
-      ? latestChildResponseSummary(session.slice?.entries)
-      : undefined;
+  // Child rows summarize what the subagent last said; the list-root row is
+  // the conversation itself — echoing its own last exchange there is noise
+  // (and the root can itself be a nested subagent when focus is scoped).
+  const summary = isListRoot
+    ? undefined
+    : latestChildResponseSummary(session.slice?.entries);
   return (
     <Box flexDirection="row" height={1} minWidth={0} overflowY="hidden">
       <Text color={focused ? COLOR_HINT : undefined}>
@@ -201,6 +205,8 @@ export interface SubagentListProps {
   >;
   readonly selectedValue?: ChildListValue;
   readonly sessions?: readonly StreamView[];
+  /** Stream the list is rooted on — its row never shows a summary. */
+  readonly listRootStreamId?: StreamTabId;
   readonly activeProcesses?: readonly ActiveChildInfo[];
   readonly activeSubagentExecutionIds?: ReadonlyMap<StreamTabId, string>;
   readonly processOutput?: ReadonlyMap<string, ProcessOutputTail>;
@@ -350,6 +356,7 @@ export function SubagentList(
           if (session) {
             return (
               <SessionRow
+                isListRoot={session.id === props.listRootStreamId}
                 active={state.active}
                 focused={state.focused}
                 hiddenRowSummary={hiddenRowSummary || undefined}

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -2,6 +2,7 @@
 
 // Local imports - shared schemas
 import {
+  MESSAGE_TYPES,
   STREAM_PHASE,
   type ActiveChildInfo,
   type StreamTabId,
@@ -14,7 +15,11 @@ import {
   visibleSubagentRows,
   type ChildStreamEntries,
 } from './childExecutions';
-import type { ProcessOutputTail, StreamSlice } from './cliState';
+import type {
+  ConversationEntry,
+  ProcessOutputTail,
+  StreamSlice,
+} from './cliState';
 
 export interface ChildListTarget {
   readonly slice: StreamSlice | undefined;
@@ -153,4 +158,42 @@ export function numericFocusTargetForActiveStream(init: {
     rootStreamId: target.streamId,
     streams: init.streams,
   }).find((entry) => entry.shortcutIndex === shortcutIndex)?.id;
+}
+
+// The panel re-renders on every stream-sync tick; entries arrays are replaced
+// wholesale on change, so one scan per entries version is enough. `has` (not
+// the value) discriminates a cached undefined from a miss.
+const childResponseSummaryCache = new WeakMap<
+  readonly ConversationEntry[],
+  string | undefined
+>();
+
+/**
+ * Latest thing the child "said": its final model response after the newest
+ * user instruction, falling back to that instruction while a turn is still
+ * running. Rendered on the child list's session rows.
+ */
+export function latestChildResponseSummary(
+  entries: readonly ConversationEntry[] | undefined,
+): string | undefined {
+  if (!entries) return undefined;
+  if (childResponseSummaryCache.has(entries)) {
+    return childResponseSummaryCache.get(entries);
+  }
+  const latestUserIndex = entries.findLastIndex(
+    (entry) => entry.role === 'user' && entry.text.trim(),
+  );
+  const latestInstruction =
+    latestUserIndex >= 0 ? entries[latestUserIndex]?.text : undefined;
+  const summary =
+    entries.findLast(
+      (entry, index) =>
+        index > latestUserIndex &&
+        entry.role === 'assistant' &&
+        entry.messageType === MESSAGE_TYPES.MODEL_RESPONSE &&
+        entry.finalized &&
+        entry.text.trim(),
+    )?.text ?? latestInstruction;
+  childResponseSummaryCache.set(entries, summary);
+  return summary;
 }

--- a/src/test-kernel/cli/LatestChildResponseSummary.vitest.mts
+++ b/src/test-kernel/cli/LatestChildResponseSummary.vitest.mts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { latestChildResponseSummary } from '@cli/chat/tui/state/childControls';
+import { MESSAGE_TYPES } from '@shared/schemas';
+import type { ConversationEntry } from '@cli/chat/tui/state/cliState';
+
+function user(text: string): ConversationEntry {
+  return { id: `u-${text}`, role: 'user', text, finalized: true };
+}
+
+function reply(text: string, finalized = true): ConversationEntry {
+  return {
+    id: `a-${text}`,
+    role: 'assistant',
+    text,
+    finalized,
+    messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+  };
+}
+
+describe('latest child response summary', () => {
+  it('prefers the final response after the newest instruction', () => {
+    expect(
+      latestChildResponseSummary([
+        user('check the proof'),
+        reply('first draft'),
+        user('now verify lemma 2'),
+        reply('lemma 2 holds'),
+      ]),
+    ).toBe('lemma 2 holds');
+  });
+
+  it('falls back to the instruction while the turn still streams', () => {
+    expect(
+      latestChildResponseSummary([
+        user('now verify lemma 2'),
+        reply('working…', false),
+      ]),
+    ).toBe('now verify lemma 2');
+  });
+
+  it('caches per entries version, including empty results', () => {
+    const entries: readonly ConversationEntry[] = [];
+    expect(latestChildResponseSummary(entries)).toBeUndefined();
+    expect(latestChildResponseSummary(entries)).toBeUndefined();
+    expect(latestChildResponseSummary(undefined)).toBeUndefined();
+  });
+});

--- a/src/test-kernel/cli/LatestChildResponseSummary.vitest.mts
+++ b/src/test-kernel/cli/LatestChildResponseSummary.vitest.mts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import { latestChildResponseSummary } from '@cli/chat/tui/state/childControls';
-import { MESSAGE_TYPES } from '@shared/schemas';
 import type { ConversationEntry } from '@cli/chat/tui/state/cliState';
+import { MESSAGE_TYPES } from '@shared/schemas';
 
 function user(text: string): ConversationEntry {
   return { id: `u-${text}`, role: 'user', text, finalized: true };


### PR DESCRIPTION
Closes #8629 — the final piece of the audit's navigation item.

#8655 landed the convergence itself in parallel (picker deletion, unified child list with kill, separator row) and even the auto-return-focus design point (the lifecycle-cause guard in `subscribeStreamStatus` — a cleaner edge discriminator than the previous-status approach my superseded #8686 used, and it returns to the immediate owner, which handles nested children better). The one #8629 piece not covered upstream: **the child rows lost the picker's latest-response summary**.

This PR restores it on the converged list: each child session row shows a dim inline summary of the subagent's final model response after its newest instruction (falling back to the instruction while a turn streams) — triage children without focusing them. Derived once per entries version via a WeakMap cache (the picker recomputed this uncached per tick); the root row deliberately stays clean.

Verification: full CLI kernel suite 1769/1769, CLI + test-kernel tsc clean, dead-code ratchet at baseline, all touched list scenarios pass with the `subagents` frame now pinning a child summary, plus unit tests for the derivation (final-response preference, streaming fallback, cache including empty results).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI TUI display-only change with a small pure helper and tests; no auth, persistence, or execution-path changes.
> 
> **Overview**
> Restores **latest-response triage** on the converged child list (#8629): each subagent row gets a dim ` · …` suffix with text derived from that stream's conversation entries.
> 
> **`latestChildResponseSummary`** in `childControls` picks the newest finalized `MODEL_RESPONSE` after the latest user instruction, or falls back to that instruction while the turn is still streaming; results are cached per entries array via `WeakMap` so stream-sync ticks do not rescan every row.
> 
> **`SubagentList`** passes **`listRootStreamId`** from `childListTarget` so the rooted conversation row never shows a summary (avoids echoing the focused thread). Summaries use **`truncateSummaryToWidth`** (100 columns). Changelog and the TUI harness expect the inline summary on child rows; unit tests cover preference, streaming fallback, and cache behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f63222b8c70589c1e80ed6daaaec5ffcb9a97143. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->