### PR TITLE
fix(workflow): preserve checkpoint args on null retry

### DIFF
--- a/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
@@ -82,7 +82,8 @@ async function callTool(options?: {
         new WorkflowScriptTool().call({
           agent: 'correct',
           script: options?.script ?? script,
-          ...(options?.args !== undefined && { args: options.args }),
+          ...(options &&
+            Object.hasOwn(options, 'args') && { args: options.args }),
         }),
     ),
   );
@@ -205,7 +206,7 @@ return args`,
     expect(recordCost).toHaveBeenCalledWith(0);
   });
 
-  it('retains checkpoint arguments when a retry omits them', async () => {
+  it('retains checkpoint arguments for null retries and replaces explicit values', async () => {
     const argsScript = `export const meta = {
   name: 'retained-arguments',
   description: 'retains omitted retry arguments',
@@ -222,11 +223,23 @@ return args`;
 
     const result = await callTool({
       script: `${argsScript}\n// revised retry`,
+      args: null,
     });
 
     expect(result).toMatchObject({
       status: 'executed',
       output: expect.stringContaining('"topic": "geometry"'),
+    });
+
+    clearStoreCache();
+    const replacement = await callTool({
+      script: `${argsScript}\n// retry with replacement arguments`,
+      args: { topic: 'analysis' },
+    });
+
+    expect(replacement).toMatchObject({
+      status: 'executed',
+      output: expect.stringContaining('"topic": "analysis"'),
     });
   });
 

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -160,7 +160,7 @@ Tool inclusion is the opt-in boundary: do not add this tool to a default agent c
         store,
         checkpointId,
         script: input.script,
-        ...(input.args !== undefined && { args: input.args }),
+        ...(input.args != null && { args: input.args }),
         signal: callContext.signal,
         runAgent: createWorkflowScriptAgentRunner(
           parent,


### PR DESCRIPTION
## Summary

- treat a structured-output `null` workflow `args` field as omitted during retry
- preserve the checkpointed arguments when no replacement was supplied
- retain explicit non-null argument replacement behavior

## Design

The workflow tool schema deliberately accepts optional fields as nullish for provider compatibility. The dispatch boundary now normalizes that representation by including `args` only when it is non-null, so persistence receives one unambiguous contract: absence means retain the checkpoint value; a present object means replace it.

## Verification

- focused `WorkflowScriptTool` suite (10 tests)
- repository type checking
- ESLint
- formatting and diff checks

Closes #8679

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small dispatch-boundary normalization for optional workflow args on retry; behavior is covered by focused WorkflowScriptTool tests.
> 
> **Overview**
> Workflow script retries from structured tool output can send **`args: null`** for an omitted optional field. The delegate tool previously forwarded any value that was not `undefined`, so **`null` overwrote checkpointed arguments** on resume instead of keeping them.
> 
> **`WorkflowScriptTool`** now passes **`args` into persisted runs only when the value is non-null** (`input.args != null`). Omitted/`null` retries no longer include `args`, matching persistence’s rule: **no `args` property → retain checkpoint; present object → replace**.
> 
> Tests use **`Object.hasOwn(options, 'args')`** so **`args: null`** can be sent explicitly, and cover both **null retry (retain)** and **explicit replacement**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fad90a9639f096c0dfa87c946bd6df27d5647e06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->