### PR TITLE
test(cli): pin the compact /memory picker with a deterministic harness seed

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -2,7 +2,13 @@
 // to the real terminal. Used to verify the ConversationPane viewport without
 // needing API access. Exits on Ctrl-C.
 
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -22,6 +28,7 @@ import { SupabaseClient } from '@auth/SupabaseClient';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { STREAM_TRANSITION_CAUSE } from '@shared/streams/streamStatus';
 import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
+import { MEMORY_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 import { platform, tryPlatform } from '@platform/platform';
 import {
   AgentCategory,
@@ -329,6 +336,7 @@ const HARNESS_VISIBLE_WORKFLOW_AGENTS = parseList(
   process.env.HARNESS_VISIBLE_WORKFLOW_AGENTS,
 );
 const HARNESS_VISIBLE_MODELS = parseList(process.env.HARNESS_VISIBLE_MODELS);
+const HARNESS_MEMORY_FILES = parseList(process.env.HARNESS_MEMORY_FILES);
 
 if (SHOW_PROJECT_SKILL) {
   seedHarnessProjectSkill();
@@ -342,6 +350,23 @@ await initLocalCliPlatform({
   storageRoot: path.join(HARNESS_CWD, '.texra-storage'),
   helperModel: 'harness-model',
 });
+// Seed workspace-storage memory files so `/memory` has rows to list. Files
+// get descending mtimes in list order, so the first name is the newest row
+// and the listing order is deterministic.
+if (HARNESS_MEMORY_FILES.length > 0) {
+  const memoryRoot = path.join(
+    platform().storage.getStoragePath(),
+    MEMORY_STORAGE_DIR,
+  );
+  const newestEpochSeconds = Date.now() / 1000;
+  HARNESS_MEMORY_FILES.forEach((name, index) => {
+    const filePath = path.join(memoryRoot, name);
+    mkdirSync(path.dirname(filePath), { recursive: true });
+    writeFileSync(filePath, `Harness memory ${name}.\n`);
+    const mtime = newestEpochSeconds - index * 60;
+    utimesSync(filePath, mtime, mtime);
+  });
+}
 initializeDefaultSession({ transcripts: await StreamLogStore.open() });
 const harnessFollowUpQueue = defaultSession().followUps.acquire(STREAM_ID);
 for (const followUp of QUEUED_FOLLOW_UPS) {

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1265,6 +1265,58 @@ const SCENARIOS = [
     maxLineColumns: 60,
   },
   {
+    name: 'memory-form',
+    cols: 100,
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_MEMORY_FILES: 'project.md||ideas.md||notes/plan.md',
+    },
+    keys: ['/memory', '\r'],
+    frame: 'viewport',
+    settleMs: ASYNC_FORM_SETTLE_MS,
+    expect: [
+      '/memory',
+      'Choose a memory to preview in the transcript.',
+      '/memories/project.md',
+      '/memories/ideas.md',
+      '/memories/notes/plan.md',
+      '↑/↓ navigate',
+      '1-3/Enter preview',
+      'Esc close',
+    ],
+    unexpect: ['No memory files found.', '/memory - error'],
+  },
+  {
+    // Short terminals collapse /memory to the shared compact single-row
+    // variant instead of overflowing the viewport.
+    name: 'compact-memory-form',
+    rows: 12,
+    cols: 80,
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_MEMORY_FILES: 'a.md||b.md||c.md||d.md||e.md||f.md',
+    },
+    keys: ['/memory', '\r'],
+    frame: 'viewport',
+    settleMs: ASYNC_FORM_SETTLE_MS,
+    expect: [
+      '/memory',
+      '/memories/a.md',
+      '+5 more',
+      '↑/↓ navigate',
+      '1-6/Enter preview',
+      'Esc close',
+    ],
+    unexpect: [
+      'Choose a memory to preview in the transcript.',
+      'No memory files found.',
+      '/memory - error',
+    ],
+    maxBlankLinesBetween: [
+      { from: 'entry-4 chat history line', to: '/memory', max: 2 },
+    ],
+  },
+  {
     name: 'compact-tools-form',
     rows: 12,
     cols: 80,


### PR DESCRIPTION
Final residue of #8630, which #8687 ("unify list form behavior") implemented in parallel — the ListForm engine, all nine form conversions, the memory/resume compact fix, generalized load-time hotkey replay, and hint canonicalization all landed there. Verified against all three audit drifts.

What #8687 did not carry: the compact `/memory` behavior had no scenario pin (there was no memory-form scenario at all). This PR adds a `HARNESS_MEMORY_FILES` seed knob (workspace-storage memory files with descending mtimes for deterministic ordering) and two scenarios — `memory-form` and `compact-memory-form` — pinning the full frame and the short-terminal single-row `+5 more` degradation.

Verification: 26 scenarios pass (the full form set + the two new ones), CLI + test-kernel tsc clean, dead-code ratchet at baseline, full CLI kernel suite 1767/1767 with no flakes.

Deliberately not included (would re-litigate #8687's fresh choices): an alternative budget-driven compact rule, footer-hint rewrites, and an /api async conversion — all preserved on a local marker branch if ever wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the CLI TUI harness and validate-tui scenarios; no production runtime behavior is modified.
> 
> **Overview**
> Adds **test-only** coverage for the `/memory` slash picker that was missing after the ListForm work landed elsewhere.
> 
> The TUI harness now accepts **`HARNESS_MEMORY_FILES`** (`||`-separated paths). After platform init it writes those files under workspace **`MEMORY_STORAGE_DIR`** and sets **descending mtimes** so list order is stable in PTY snapshots.
> 
> **`validate-tui.mjs`** gains two scenarios: **`memory-form`** (full list + preview hints) and **`compact-memory-form`** (12×80 terminal, **`+5 more`** compact row, no full subtitle).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5367c16dce1aa2bff7b231d3f0d084fafc75ea11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->