### PR TITLE
feat(cli): give the todos panel a separator row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ All notable changes to this project will be documented in this file.
 
 #### New Features
 
+- **The todo checklist gets breathing room** — a blank separator row now sits
+  above the todos/plan panel, so the checklist no longer merges visually with
+  the session list or the footer.
 - **Child rows show what each subagent last said** — the session list
   summarizes every subagent's latest response (or its current instruction
   while a turn is running) inline on its row, so you can triage children

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -2914,6 +2914,7 @@ const SCENARIOS = [
       'Split theorem into algebraic and analytic checks',
       'Coordinate a small math proof through nested CLI work.',
     ],
+    expectPatterns: [/\n\n ☑ Split theorem into algebraic and analytic checks/],
   },
   {
     name: 'completed-todos-hidden-while-running',

--- a/packages/cli/src/chat/tui/appLayout.ts
+++ b/packages/cli/src/chat/tui/appLayout.ts
@@ -166,6 +166,9 @@ export function allocateConversationBottomPanelRows({
   // The persistent child list owns one blank separator row above its Select.
   const sessionPanelContentRows =
     childListRowCount > 0 ? childListRowCount + 1 : 0;
+  // The todos/plan panel likewise owns a separator row above its checklist.
+  const todosPanelContentRows =
+    todosPlanContentRows > 0 ? todosPlanContentRows + 1 : 0;
   const minimumSessionRows = childListRowCount > 0 ? 2 : 0;
   const availableTranscriptRows = Math.max(0, transcriptRows);
   let panelTranscriptLimit: number;
@@ -182,7 +185,7 @@ export function allocateConversationBottomPanelRows({
   }
   if (
     sessionPanelContentRows > 0 &&
-    todosPlanContentRows === 0 &&
+    todosPanelContentRows === 0 &&
     panelTranscriptLimit < minimumSessionRows
   ) {
     return {
@@ -193,12 +196,12 @@ export function allocateConversationBottomPanelRows({
   }
   const bottomPanelRows = Math.min(
     maxRows,
-    sessionPanelContentRows + todosPlanContentRows,
+    sessionPanelContentRows + todosPanelContentRows,
     panelTranscriptLimit,
   );
   const allocated = allocateSidePanelRows({
     subagentContentRows: sessionPanelContentRows,
-    todosPlanContentRows,
+    todosPlanContentRows: todosPanelContentRows,
     rows: bottomPanelRows,
   });
   const sessionPanelRows =
@@ -208,10 +211,20 @@ export function allocateConversationBottomPanelRows({
     sessionPanelContentRows > 0
       ? Math.max(minimumSessionRows, allocated.subagentRows)
       : 0;
+  const todosPlanRows = bottomPanelRows - sessionPanelRows;
+  // A lone row cannot hold the separator plus content; hand it back instead
+  // of rendering a dead blank line under the child list.
+  if (todosPanelContentRows > 0 && todosPlanRows === 1) {
+    return {
+      bottomPanelRows: bottomPanelRows - 1,
+      sessionPanelRows,
+      todosPlanRows: 0,
+    };
+  }
   return {
     bottomPanelRows,
     sessionPanelRows,
-    todosPlanRows: bottomPanelRows - sessionPanelRows,
+    todosPlanRows,
   };
 }
 

--- a/packages/cli/src/chat/tui/appLayout.ts
+++ b/packages/cli/src/chat/tui/appLayout.ts
@@ -213,8 +213,17 @@ export function allocateConversationBottomPanelRows({
       : 0;
   const todosPlanRows = bottomPanelRows - sessionPanelRows;
   // A lone row cannot hold the separator plus content; hand it back instead
-  // of rendering a dead blank line under the child list.
+  // of rendering a dead blank line under the child list. When the child list
+  // has rows above its own minimum, transfer one first so both panels remain
+  // useful under a proportional split.
   if (todosPanelContentRows > 0 && todosPlanRows === 1) {
+    if (sessionPanelRows > minimumSessionRows) {
+      return {
+        bottomPanelRows,
+        sessionPanelRows: sessionPanelRows - 1,
+        todosPlanRows: 2,
+      };
+    }
     return {
       bottomPanelRows: bottomPanelRows - 1,
       sessionPanelRows,

--- a/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
+++ b/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
@@ -183,10 +183,13 @@ export function TodosPlanPanel(
   if (!slice) return null;
   const { todos, plan } = slice;
   if (todos.length === 0 && !plan) return null;
+  // Like the child list above it, the panel owns one blank separator row so
+  // the todo checklist never sits flush against its neighbor. If the gap and
+  // one content row do not both fit, render nothing.
   const rowBudget =
     props.maxRows === undefined
       ? undefined
-      : Math.max(0, Math.floor(props.maxRows));
+      : Math.max(0, Math.floor(props.maxRows)) - 1;
   if (rowBudget !== undefined && rowBudget <= 0) return null;
 
   if (rowBudget !== undefined) {
@@ -199,6 +202,7 @@ export function TodosPlanPanel(
       <Box
         flexDirection="column"
         height={rowBudget}
+        marginTop={1}
         overflowY="hidden"
         paddingX={1}
       >

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -575,7 +575,27 @@ describe('CLI TUI row allocation', () => {
       todosPlanContentRows: 4,
       transcriptRows: 2,
     });
-    expect(allocation.todosPlanRows).not.toBe(1);
+    expect(allocation).toEqual({
+      bottomPanelRows: 0,
+      sessionPanelRows: 0,
+      todosPlanRows: 0,
+    });
+  });
+
+  it('preserves todo content when the child list can yield one row', () => {
+    expect(
+      allocateConversationBottomPanelRows({
+        maxRows: 10,
+        sessionCount: 11,
+        childListFocused: false,
+        todosPlanContentRows: 1,
+        transcriptRows: 20,
+      }),
+    ).toEqual({
+      bottomPanelRows: 10,
+      sessionPanelRows: 8,
+      todosPlanRows: 2,
+    });
   });
 
   it('does not allocate session rows without transcript space', () => {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -553,6 +553,31 @@ describe('CLI TUI row allocation', () => {
     });
   });
 
+  it('reserves a separator row above the todos panel', () => {
+    // 2 todos + separator = 3 rows when the transcript allows it.
+    expect(
+      allocateConversationBottomPanelRows({
+        maxRows: 10,
+        sessionCount: 0,
+        childListFocused: false,
+        todosPlanContentRows: 2,
+        transcriptRows: 8,
+      }),
+    ).toMatchObject({ bottomPanelRows: 3, todosPlanRows: 3 });
+  });
+
+  it('hands a lone todos row back instead of rendering a dead separator', () => {
+    // The grant would be exactly one row — too small for separator + content.
+    const allocation = allocateConversationBottomPanelRows({
+      maxRows: 10,
+      sessionCount: 0,
+      childListFocused: false,
+      todosPlanContentRows: 4,
+      transcriptRows: 2,
+    });
+    expect(allocation.todosPlanRows).not.toBe(1);
+  });
+
   it('does not allocate session rows without transcript space', () => {
     expect(
       allocateConversationBottomPanelRows({


### PR DESCRIPTION
Maintainer request: a visual separator for the todos.

The todo checklist rendered flush against the child list (or the footer when no children are live), so the checkbox rows visually merged with the session rows. The panel now owns one blank separator row above its checklist — the exact pattern the child list itself uses (`marginTop={1}` + a `+1` in the panel budget inside `allocateConversationBottomPanelRows`), so the input bar can never be pushed. A degenerate one-row grant (too small for separator + content) folds back into the budget instead of rendering a dead blank line under the child list.

Verification: full CLI kernel suite 1776/1776, dead-code ratchet at baseline, eslint/tsc clean, and all todo/list scenarios pass (`todos`, `completed-todos-hidden-while-running`, `idle-todos-hidden`, `subagents-with-todos-compact`, `subagents-with-todos-narrow-status`, `tiny-status-separators`) with the separator visible in the captured frames. Two new allocation unit tests pin the budget rule and the fold-back.

Also confirmed in this session (no code needed): the #8685 subagent-identity labeling already reaches all three surfaces — CLI, extension, and desktop — via the shared `executionsDisplay.ts` layer and the progress-board webview the desktop reuses; the main webview renders no tool rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI TUI layout and row budgeting only; no auth, persistence, or API behavior changes.
> 
> **Overview**
> The CLI chat **todos/plan** panel now matches the child session list: it reserves one blank row above the checklist (`marginTop={1}`) so todo rows no longer sit flush against the session list or footer.
> 
> **`allocateConversationBottomPanelRows`** counts that separator in `todosPanelContentRows` (+1 when todos exist). If the split only grants a single row to todos—too small for gap plus content—it folds that row back into the budget instead of drawing a useless blank line; when the child list has spare height, it can yield one row so both panels stay usable.
> 
> Changelog, TUI harness expectation for the separator, and allocation unit tests cover the new budgeting rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98d18ec806af5c86dede67f51d073c4dd068a9af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Closes #8697