### PR TITLE
test(cli): pin the todos borrow-row allocation branch

### DIFF
--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -566,6 +566,24 @@ describe('CLI TUI row allocation', () => {
     ).toMatchObject({ bottomPanelRows: 3, todosPlanRows: 3 });
   });
 
+  it('borrows a child-list row so an active todo stays visible', () => {
+    // Codex review case: many children + one todo under the 10-row cap. The
+    // proportional split grants todos one row — too small for separator +
+    // content — so one row shifts from the ample child list instead.
+    const allocation = allocateConversationBottomPanelRows({
+      maxRows: 10,
+      sessionCount: 11,
+      childListFocused: false,
+      todosPlanContentRows: 1,
+      transcriptRows: 30,
+    });
+    expect(allocation.todosPlanRows).toBe(2);
+    expect(allocation.sessionPanelRows).toBeGreaterThanOrEqual(2);
+    expect(allocation.bottomPanelRows).toBe(
+      allocation.sessionPanelRows + allocation.todosPlanRows,
+    );
+  });
+
   it('hands a lone todos row back instead of rendering a dead separator', () => {
     // The grant would be exactly one row — too small for separator + content.
     const allocation = allocateConversationBottomPanelRows({


### PR DESCRIPTION
Follow-up to #8695: the review-driven borrow-then-fold fix landed without a test pinning the borrow branch (many children + one todo under the row cap → one row shifts from the ample child list instead of hiding the active todo). This adds that pin.

Test-only; no product code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds a regression test for existing CLI row-allocation behavior; no runtime or product logic is modified.
> 
> **Overview**
> Adds a **Vitest** case in `TuiStateAndFocus.vitest.mts` that locks in the **borrow-row** path of `allocateConversationBottomPanelRows`: under a tight bottom-panel cap, many child sessions, and a single todo line, the proportional split would give todos only one row (not enough for separator + content), so the allocator should grant **2** todo rows and fund them by shrinking the child-list budget while keeping `bottomPanelRows` equal to session + todos rows.
> 
> **Test-only** follow-up to the #8695 layout fix; no production code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d2e064e35899a55e4826ffccfceb09c29066400. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->