### PR TITLE
feat(cli): show elapsed time and generated tokens on child rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@ All notable changes to this project will be documented in this file.
 
 #### New Features
 
+- **Subagent rows show elapsed time and generated tokens** — each row in the
+  child list gains a right-aligned metadata column with the subagent's
+  elapsed time and how many tokens it has generated so far, so a glance shows
+  which children are working and how much they have produced. Narrow
+  terminals keep the compact inline form.
 - **The todo checklist gets breathing room** — a blank separator row now sits
   above the todos/plan panel, so the checklist no longer merges visually with
   the session list or the footer.

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -1468,6 +1468,12 @@ if (SHOW_CHILDREN) {
       entries: makeChildEntries(child.agentName, child.executionId),
       runStartedAt:
         child.status === STREAM_STATUS.RUNNING ? child.startedAt : undefined,
+      // One child carries usage so scenarios pin the row metadata column's
+      // generated-token figure (`↓40k`).
+      cumulativeUsage:
+        child.agentName === 'reviewer'
+          ? { inputTokens: 52_000, outputTokens: 39_900, cost: 0.12 }
+          : slice.cumulativeUsage,
     }));
   }
   if (SHOW_NESTED_CHILDREN) {

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -2080,6 +2080,8 @@ const SCENARIOS = [
       // Child rows summarize the subagent's latest instruction/response.
       '· Please handle the harness-child-review',
       'main.tex: Proof sketch',
+      // Right-aligned metadata column: generated tokens for a child with usage.
+      '↓40k',
       '3 sub',
       'Tab children',
     ],

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -1,7 +1,7 @@
 // Persistent heterogeneous child-session and process list.
 
 // Third-party imports
-import { Box, Text, useInput } from 'ink';
+import { Box, Text, useInput, useWindowSize } from 'ink';
 import { useMemo } from 'react';
 
 // Local imports - shared stream state
@@ -35,7 +35,9 @@ import { COLOR_HINT } from '../ui/colors';
 import { POINTER, TICK } from '../ui/glyphs';
 import { Select, visibleSelectRange } from '../ui/Select';
 import {
+  CHILD_ROW_METADATA_MIN_COLUMNS,
   CHILD_STATUS_MARKER,
+  childRowMetadataText,
   childStatusColor,
   pendingApprovalRowSuffix,
 } from './SubagentListDisplay';
@@ -56,13 +58,16 @@ export function compactChildRowText({
   child,
   nowMs,
   tail,
+  omitElapsed = false,
 }: {
   readonly child: ActiveChildInfo;
   readonly nowMs: number;
   readonly tail?: ProcessOutputTail;
+  /** When the row shows elapsed in a trailing metadata column instead. */
+  readonly omitElapsed?: boolean;
 }): string {
   const tailSummary = processTailLines(tail).at(-1);
-  const elapsed = childElapsed(child, nowMs);
+  const elapsed = omitElapsed ? undefined : childElapsed(child, nowMs);
   const label = childExecutionLabel(child);
   const statusLabel = childStatusLabel(child.status);
   return [
@@ -86,6 +91,25 @@ function HiddenRowSummary({
   ) : null;
 }
 
+/** Right-aligned `elapsed · ↓tokens` column, pushed to the terminal edge so
+ *  the figures line up across rows. Non-shrinking: the summary segment yields
+ *  first; rows drop the column entirely on narrow terminals (see
+ *  `CHILD_ROW_METADATA_MIN_COLUMNS`). */
+function RowMetadata({
+  text,
+}: {
+  readonly text: string | undefined;
+}): React.JSX.Element | null {
+  return text ? (
+    <>
+      <Box flexGrow={1} />
+      <Box flexShrink={0}>
+        <Text dimColor>{`  ${text}`}</Text>
+      </Box>
+    </>
+  ) : null;
+}
+
 const SUBAGENT_SUMMARY_MAX_COLUMNS = 100;
 
 function SessionRow({
@@ -93,6 +117,7 @@ function SessionRow({
   focused,
   hiddenRowSummary,
   isListRoot,
+  metadataColumn,
   nowMs,
   pendingKinds,
   session,
@@ -101,6 +126,7 @@ function SessionRow({
   readonly focused: boolean;
   readonly hiddenRowSummary: string | undefined;
   readonly isListRoot: boolean;
+  readonly metadataColumn: boolean;
   readonly nowMs: number;
   readonly pendingKinds: readonly PendingApprovalKind[] | undefined;
   readonly session: StreamView;
@@ -118,10 +144,18 @@ function SessionRow({
     },
     nowMs,
   );
-  // Significance order — truncate-end sheds elapsed first, then the round,
-  // then the pending-approval kind.
+  // Significance order — the summary segment sheds first (flexShrink 2), then
+  // this truncate-end text sheds inline elapsed (narrow mode only), the round,
+  // and last the pending-approval kind. The metadata column never shrinks.
   const approvalSuffix = pendingApprovalRowSuffix(pendingKinds);
   const roundLabel = formatRoundStageLabel(session.slice?.roundStage);
+  const metadata = metadataColumn
+    ? childRowMetadataText({
+        elapsed,
+        outputTokens: (session.slice?.cumulativeUsage ?? session.slice?.usage)
+          ?.outputTokens,
+      })
+    : undefined;
   // Child rows summarize what the subagent last said; the list-root row is
   // the conversation itself — echoing its own last exchange there is noise
   // (and the root can itself be a nested subagent when focus is scoped).
@@ -129,7 +163,13 @@ function SessionRow({
     ? undefined
     : latestChildResponseSummary(session.slice?.entries);
   return (
-    <Box flexDirection="row" height={1} minWidth={0} overflowY="hidden">
+    <Box
+      flexDirection="row"
+      flexGrow={1}
+      height={1}
+      minWidth={0}
+      overflowY="hidden"
+    >
       <Text color={focused ? COLOR_HINT : undefined}>
         {focused ? POINTER : ' '}
       </Text>
@@ -143,7 +183,7 @@ function SessionRow({
           {statusLabel ? ` ${statusLabel}` : ''}
           {approvalSuffix ? ` · ${approvalSuffix}` : ''}
           {roundLabel ? ` · ${roundLabel}` : ''}
-          {elapsed ? ` · ${elapsed}` : ''}
+          {!metadataColumn && elapsed ? ` · ${elapsed}` : ''}
         </Text>
       </Box>
       {summary ? (
@@ -154,6 +194,7 @@ function SessionRow({
         </Box>
       ) : null}
       {focused ? <HiddenRowSummary text={hiddenRowSummary} /> : null}
+      <RowMetadata text={metadata} />
     </Box>
   );
 }
@@ -162,17 +203,34 @@ function ProcessRow({
   child,
   focused,
   hiddenRowSummary,
+  metadataColumn,
   nowMs,
   tail,
 }: {
   readonly child: ProcessChildInfo;
   readonly focused: boolean;
   readonly hiddenRowSummary: string | undefined;
+  readonly metadataColumn: boolean;
   readonly nowMs: number;
   readonly tail?: ProcessOutputTail;
 }): React.JSX.Element {
+  // Raw processes report no token usage, so their metadata column is elapsed
+  // only. Adding usage would need the runtime to stamp it onto the roster
+  // entry (`ActiveChildInfo`).
+  const metadata = metadataColumn
+    ? childRowMetadataText({
+        elapsed: childElapsed(child, nowMs),
+        outputTokens: undefined,
+      })
+    : undefined;
   return (
-    <Box flexDirection="row" height={1} minWidth={0} overflowY="hidden">
+    <Box
+      flexDirection="row"
+      flexGrow={1}
+      height={1}
+      minWidth={0}
+      overflowY="hidden"
+    >
       <Text color={focused ? COLOR_HINT : undefined}>
         {focused ? POINTER : ' '}
       </Text>
@@ -180,10 +238,16 @@ function ProcessRow({
       <Text color={childStatusColor(child.status)}>{CHILD_STATUS_MARKER}</Text>
       <Box minWidth={0} flexShrink={1}>
         <Text wrap="truncate-end">
-          {compactChildRowText({ child, nowMs, tail })}
+          {compactChildRowText({
+            child,
+            nowMs,
+            tail,
+            omitElapsed: metadataColumn,
+          })}
         </Text>
       </Box>
       {focused ? <HiddenRowSummary text={hiddenRowSummary} /> : null}
+      <RowMetadata text={metadata} />
     </Box>
   );
 }
@@ -265,6 +329,8 @@ export function SubagentList(
     [activeProcesses],
   );
   const nowMs = useLiveNowMs(liveElapsedKey !== undefined, liveElapsedKey);
+  const { columns } = useWindowSize();
+  const metadataColumn = columns >= CHILD_ROW_METADATA_MIN_COLUMNS;
   const contentRows =
     props.maxRows === undefined ? undefined : Math.max(0, props.maxRows - 1);
   const selectedIndex = Math.max(
@@ -330,6 +396,9 @@ export function SubagentList(
       marginTop={1}
       overflowY={contentRows === undefined ? undefined : 'hidden'}
       paddingX={1}
+      // Pin the panel to the terminal width so rows stretch and the trailing
+      // metadata column right-aligns; without it the panel is content-sized.
+      width={metadataColumn ? columns : undefined}
     >
       <Select
         activeValue={
@@ -360,6 +429,7 @@ export function SubagentList(
                 active={state.active}
                 focused={state.focused}
                 hiddenRowSummary={hiddenRowSummary || undefined}
+                metadataColumn={metadataColumn}
                 nowMs={nowMs}
                 pendingKinds={props.pendingApprovals?.get(session.id)}
                 session={session}
@@ -372,6 +442,7 @@ export function SubagentList(
               child={process}
               focused={state.focused}
               hiddenRowSummary={hiddenRowSummary || undefined}
+              metadataColumn={metadataColumn}
               nowMs={nowMs}
               tail={processOutput?.get(process.executionId)}
             />

--- a/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
@@ -1,5 +1,5 @@
 // Local imports - shared formatting
-import { formatCompactTokenCount } from '@utils/text/stringUtils';
+import { formatCompactTokenCount } from '@utils/core';
 
 // Local imports - TUI state and presentation
 import { isChildExecutionErrorStatus } from '../state/childExecutionStatus';
@@ -46,7 +46,7 @@ const PENDING_APPROVAL_ROW_LABELS: Record<PendingApprovalKind, string> = {
 export const CHILD_ROW_METADATA_MIN_COLUMNS = 60;
 
 /** Right-aligned metadata column for a child row: elapsed time plus the
- *  child's generated tokens so far (e.g. `2m 30s · ↓9.4k`). Output tokens are
+ *  child's generated tokens so far (e.g. `2m 30s · ↓40k`). Output tokens are
  *  the "work produced" figure — deliberately not the context-fill number the
  *  status bar reports for the focused stream. */
 export function childRowMetadataText({

--- a/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
@@ -1,3 +1,6 @@
+// Local imports - shared formatting
+import { formatCompactTokenCount } from '@utils/text/stringUtils';
+
 // Local imports - TUI state and presentation
 import { isChildExecutionErrorStatus } from '../state/childExecutionStatus';
 import {
@@ -6,7 +9,7 @@ import {
   COLOR_SUCCESS,
   COLOR_WARNING,
 } from '../ui/colors';
-import { STATUS_DOT } from '../ui/glyphs';
+import { STATUS_DOT, TOKENS_GENERATED } from '../ui/glyphs';
 import type { PendingApprovalKind } from '../state/approvalQueue';
 
 export function childStatusColor(status: string | undefined): string {
@@ -37,6 +40,29 @@ const PENDING_APPROVAL_ROW_LABELS: Record<PendingApprovalKind, string> = {
   externalInquiry: 'inquiry',
   userQuestion: 'question',
 };
+
+/** Terminal width below which the right-aligned metadata column is dropped
+ *  and rows keep their inline elapsed, so identity is not crowded out. */
+export const CHILD_ROW_METADATA_MIN_COLUMNS = 60;
+
+/** Right-aligned metadata column for a child row: elapsed time plus the
+ *  child's generated tokens so far (e.g. `2m 30s · ↓9.4k`). Output tokens are
+ *  the "work produced" figure — deliberately not the context-fill number the
+ *  status bar reports for the focused stream. */
+export function childRowMetadataText({
+  elapsed,
+  outputTokens,
+}: {
+  readonly elapsed: string | null | undefined;
+  readonly outputTokens: number | undefined;
+}): string | undefined {
+  const tokens =
+    outputTokens !== undefined && outputTokens > 0
+      ? `${TOKENS_GENERATED}${formatCompactTokenCount(outputTokens)}`
+      : undefined;
+  const parts = [elapsed, tokens].filter(Boolean);
+  return parts.length > 0 ? parts.join(' · ') : undefined;
+}
 
 /** One-word "waiting on what" suffix for a session row: the row's first
  *  pending approval kind, plus a `+N` overflow when more are queued. */

--- a/packages/cli/src/chat/tui/ui/glyphs.ts
+++ b/packages/cli/src/chat/tui/ui/glyphs.ts
@@ -38,7 +38,7 @@ export const ERROR_ENTRY_PREFIX = '! ';
 /** Corner glyph that opens each tool-output block. */
 export const TOOL_OUTPUT_CORNER = '⎿';
 
-/** Generated-tokens marker in child-row metadata (`↓9.4k`). */
+/** Generated-tokens marker in child-row metadata (`↓40k`). */
 export const TOKENS_GENERATED = '↓';
 
 /** Marker for the liveness row shown while a run is active. */

--- a/packages/cli/src/chat/tui/ui/glyphs.ts
+++ b/packages/cli/src/chat/tui/ui/glyphs.ts
@@ -38,6 +38,9 @@ export const ERROR_ENTRY_PREFIX = '! ';
 /** Corner glyph that opens each tool-output block. */
 export const TOOL_OUTPUT_CORNER = '⎿';
 
+/** Generated-tokens marker in child-row metadata (`↓9.4k`). */
+export const TOKENS_GENERATED = '↓';
+
 /** Marker for the liveness row shown while a run is active. */
 export const THINKING_MARKER = '✻';
 

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   CHILD_STATUS_MARKER,
+  childRowMetadataText,
   childStatusColor,
   pendingApprovalRowSuffix,
 } from '@cli/chat/tui/panes/SubagentListDisplay';
@@ -137,5 +138,37 @@ describe('CLI child list display model', () => {
     ).toBe(
       'latex build running · 19sec · main.tex: Proof sketch needs one missing reference',
     );
+  });
+
+  it('drops elapsed from the compact row text when the metadata column owns it', () => {
+    expect(
+      compactChildRowText({
+        child: {
+          kind: 'process',
+          executionId: 'latexmk',
+          agentName: 'latex build',
+          status: 'running',
+          elapsed: '19sec',
+        },
+        nowMs: Date.now(),
+        omitElapsed: true,
+      }),
+    ).toBe('latex build running');
+  });
+
+  it('formats the row metadata column from elapsed and generated tokens', () => {
+    expect(
+      childRowMetadataText({ elapsed: '2m 30s', outputTokens: 39_900 }),
+    ).toBe('2m 30s · ↓40k');
+    expect(
+      childRowMetadataText({ elapsed: '45s', outputTokens: undefined }),
+    ).toBe('45s');
+    expect(
+      childRowMetadataText({ elapsed: undefined, outputTokens: 512 }),
+    ).toBe('↓512');
+    // Zero tokens is "nothing generated yet", not a datum worth a column.
+    expect(
+      childRowMetadataText({ elapsed: null, outputTokens: 0 }),
+    ).toBeUndefined();
   });
 });


### PR DESCRIPTION
Each subagent/process row in the child list gains a right-aligned metadata column: elapsed time plus the child's cumulative generated tokens (e.g. `1m 2s · ↓40k`), read from the per-stream usage already in CLI state — no wire change. The summary segment still sheds first; below 60 columns rows keep the previous inline-elapsed form so identity is never crowded out. Raw processes show elapsed only (no usage exists for them in the roster contract).

## Summary

<!-- Explain the change for a reader who has not seen the issue discussion. -->

## Issue acceptance gates

<!-- List the issue(s) this PR addresses and the exact acceptance gates satisfied. If a gate remains incomplete, say so. -->

## Single source of truth

<!-- Name the module, schema, context object, or coordinator that now owns the relevant fact or decision. -->

## Duplication and abstraction budget

<!-- State what duplication was removed or avoided. If a new abstraction was added, state the invariant or host-boundary decision it owns. Do not add pass-through layers. -->

## Net elements (R6)

<!-- Constructs added vs deleted: files (diffstat), exported symbols (`^[+-]export` over the diff), classes/interfaces/enums, net LoC. Required for refactor/simplify/consolidate/dedupe/extract PRs. -->

## Consumer counts (R8)

<!-- Deleting or re-routing an emit path or export? State the grepped subscriber count per affected key. Otherwise: "n/a" + reason. -->

## Host impact

Extension:

Desktop:

CLI:

## Scheduled refactoring

<!-- Link any follow-up issue, or state "None" if no follow-up is needed. -->

## Validation

<!-- List the checks run. If a check was intentionally not run, say why. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only TUI changes in the child list with a width threshold; token data is already on stream slices and is not used for billing or auth.
> 
> **Overview**
> The CLI **child list** (Tab children) gains a **right-aligned metadata column** on each subagent and process row: **elapsed time** plus **cumulative generated output tokens** (e.g. `2m 30s · ↓40k`), read from existing per-stream `cumulativeUsage` / `usage` in CLI state—no protocol or wire changes.
> 
> On terminals **≥ 60 columns**, elapsed moves out of the inline label into that column so summaries truncate first; **narrow** terminals drop the column and keep the previous **inline elapsed** compact row layout. **Raw process** rows show elapsed only (no token figure until usage exists on the roster contract).
> 
> Adds `childRowMetadataText`, a `↓` glyph for generated tokens, TUI harness/validator expectations, and unit tests for metadata formatting and `omitElapsed` on compact rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56fa254d748c433c19afbeb0b98107941799bb67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->