### PR TITLE
feat: Moonshot China/international region toggle

### DIFF
--- a/src/agent/modelHandlers/support/ProxyConfigResolver.ts
+++ b/src/agent/modelHandlers/support/ProxyConfigResolver.ts
@@ -11,6 +11,7 @@ import {
   getProviderEndpoint,
   getDashScopeUseChina,
   getMiniMaxUseChina,
+  getMoonshotUseChina,
   getGLMUseChina,
   getGLMCodingPlan,
   getUseOpenRouter,
@@ -45,7 +46,7 @@ const BASE_URLS: Record<ModelProvider, string | null> = {
   [ModelProvider.ANTHROPIC]: null,
   [ModelProvider.DEEPSEEK]: 'https://api.deepseek.com',
   [ModelProvider.XAI]: 'https://api.x.ai/v1',
-  [ModelProvider.MOONSHOT]: 'https://api.moonshot.cn/v1',
+  [ModelProvider.MOONSHOT]: null, // Resolved dynamically (China/international toggle)
   [ModelProvider.DASHSCOPE]: null, // Resolved dynamically (China/international toggle)
   [ModelProvider.MINIMAX]: null, // Resolved dynamically (China/international toggle)
   [ModelProvider.GLM]: null, // Resolved dynamically (China/international toggle)
@@ -197,6 +198,15 @@ export function resolveBaseUrl(config: ProxyConfig): string | null {
       const domain = getMiniMaxUseChina()
         ? 'api.minimaxi.com'
         : 'api.minimax.io';
+      return `https://${domain}/v1`;
+    }
+    case ModelProvider.MOONSHOT: {
+      // China: api.moonshot.cn, International: api.moonshot.ai. Keys are
+      // platform-specific. Kimi Code models never reach this switch — their
+      // directAccess baseUrl wins as customBaseUrl at the top of this resolver.
+      const domain = getMoonshotUseChina()
+        ? 'api.moonshot.cn'
+        : 'api.moonshot.ai';
       return `https://${domain}/v1`;
     }
     case ModelProvider.GLM: {

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -99,6 +99,14 @@ const PROVIDER_REGISTRY = [
     keyUrl: 'https://platform.moonshot.cn/console',
     streamingKey: GlobalStateKey.STREAMING_MOONSHOT,
     endpointKey: GlobalStateKey.ENDPOINT_MOONSHOT,
+    // China=true is the default since moonshot.cn is the primary platform;
+    // when toggled off (international), keys come from platform.moonshot.ai.
+    // Keys are platform-specific — a .cn key does not work on .ai.
+    region: {
+      key: GlobalStateKey.MOONSHOT_USE_CHINA,
+      default: true,
+      keyUrlWhenUnset: 'https://platform.moonshot.ai/console',
+    },
   },
   {
     id: ModelProvider.DASHSCOPE,
@@ -203,7 +211,7 @@ export const PROVIDER_URLS: Record<string, string> = {
     PROVIDER_REGISTRY.flatMap((p) => (p.keyUrl ? [[p.id, p.keyUrl]] : [])),
   ),
   openRouter: 'https://openrouter.ai/keys',
-  kimiCode: 'https://code.kimi.com/',
+  kimiCode: 'https://www.kimi.com/code/console',
 };
 
 export const PROVIDER_STATE_ENTRIES: readonly ProviderStateEntry[] = [
@@ -373,6 +381,20 @@ export const PROVIDER_VSCODE_SETTINGS: Record<
       warningUrl: 'https://platform.minimax.io/',
       warningUrlLabel: 'Get API key',
       globalStateKey: GlobalStateKey.MINIMAX_USE_CHINA,
+    },
+  ],
+  moonshot: [
+    {
+      key: GlobalStateKey.MOONSHOT_USE_CHINA,
+      label: 'China Region',
+      description:
+        'Use the China endpoint (api.moonshot.cn) instead of international (api.moonshot.ai). Enabled by default. Keys are platform-specific — get international keys at platform.moonshot.ai.',
+      defaultValue: true,
+      warning:
+        'A platform.moonshot.cn key does not work with the international endpoint, and vice versa.',
+      warningUrl: 'https://platform.moonshot.ai/console',
+      warningUrlLabel: 'International console',
+      globalStateKey: GlobalStateKey.MOONSHOT_USE_CHINA,
     },
   ],
   glm: [

--- a/src/shared/state/stateKeys.ts
+++ b/src/shared/state/stateKeys.ts
@@ -129,6 +129,7 @@ export enum GlobalStateKey {
   DASHSCOPE_USE_CHINA = 'texra.dashscope.useChina',
   MINIMAX_USE_CHINA = 'texra.minimax.useChina',
   GLM_USE_CHINA = 'texra.glm.useChina',
+  MOONSHOT_USE_CHINA = 'texra.moonshot.useChina',
 
   // Coding plan settings
   GLM_CODING_PLAN = 'texra.glm.codingPlan',

--- a/src/test-kernel/agent/modelHandlers/MoonshotBaseUrl.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/MoonshotBaseUrl.vitest.ts
@@ -1,0 +1,47 @@
+// Third-party imports
+import { beforeEach, describe, expect, it } from 'vitest';
+import { ModelProvider } from 'llm-zoo';
+
+// Local imports
+import { installPlatform } from '@test/support/setupPlatform';
+import { resolveBaseUrl } from '@agent/modelHandlers/support/ProxyConfigResolver';
+import { GlobalStateKey } from '@shared/state/stateKeys';
+
+function moonshotConfig(
+  overrides: { customBaseUrl?: string } = {},
+): Parameters<typeof resolveBaseUrl>[0] {
+  return {
+    provider: ModelProvider.MOONSHOT,
+    openRouterOnly: false,
+    useServerSideKeys: false,
+    ...overrides,
+  };
+}
+
+describe('Moonshot base URL region resolution', () => {
+  beforeEach(async () => {
+    await installPlatform();
+  });
+
+  it('defaults to the China endpoint', () => {
+    expect(resolveBaseUrl(moonshotConfig())).toBe('https://api.moonshot.cn/v1');
+  });
+
+  it('uses the international endpoint when the China toggle is off', async () => {
+    await installPlatform({
+      globalState: { [GlobalStateKey.MOONSHOT_USE_CHINA]: false },
+    });
+    expect(resolveBaseUrl(moonshotConfig())).toBe('https://api.moonshot.ai/v1');
+  });
+
+  it('lets a pinned custom base URL beat the region switch (Kimi Code)', async () => {
+    await installPlatform({
+      globalState: { [GlobalStateKey.MOONSHOT_USE_CHINA]: false },
+    });
+    expect(
+      resolveBaseUrl(
+        moonshotConfig({ customBaseUrl: 'https://api.kimi.com/coding/v1' }),
+      ),
+    ).toBe('https://api.kimi.com/coding/v1');
+  });
+});

--- a/src/test-kernel/shared/settingsConfiguration.vitest.ts
+++ b/src/test-kernel/shared/settingsConfiguration.vitest.ts
@@ -13,7 +13,10 @@ import {
 } from '@extensionSchemas/texraSettings';
 import { PROVIDER_VSCODE_SETTINGS } from '@shared/constants/providers';
 import { GlobalStateKey } from '@shared/state/stateKeys';
-import { getGLMUseChina } from '@utils/config/providerConfig';
+import {
+  getGLMUseChina,
+  getMoonshotUseChina,
+} from '@utils/config/providerConfig';
 
 interface PackageConfigurationProperty {
   default?: unknown;
@@ -94,6 +97,7 @@ describe('TexraSettingsSchema', () => {
     const settingsDefaults = flattenTexraSettings();
     const globalStateDefaults: Record<string, boolean> = {
       [GlobalStateKey.GLM_USE_CHINA]: getGLMUseChina(),
+      [GlobalStateKey.MOONSHOT_USE_CHINA]: getMoonshotUseChina(),
     };
 
     for (const setting of Object.values(PROVIDER_VSCODE_SETTINGS).flat()) {

--- a/src/utils/config/providerConfig.ts
+++ b/src/utils/config/providerConfig.ts
@@ -125,6 +125,10 @@ export function getMiniMaxUseChina(): boolean {
   return regionSet('minimax') ?? false;
 }
 
+export function getMoonshotUseChina(): boolean {
+  return regionSet('moonshot') ?? true;
+}
+
 export function getGLMUseChina(): boolean {
   return regionSet('glm') ?? true;
 }


### PR DESCRIPTION
## Summary

Adds a China/international **region toggle for the Moonshot provider**, mirroring the existing DashScope / MiniMax / GLM toggles:

- New `texra.moonshot.useChina` provider setting (surfaced in the Models tab under Moonshot), **defaulting to China** so current behavior is unchanged.
- `resolveBaseUrl` now selects `api.moonshot.cn/v1` (China) vs `api.moonshot.ai/v1` (international) for the Moonshot open-platform provider, matching the pattern already used for the other three region-toggled providers. Keys are platform-specific (a `.cn` key is rejected by `.ai` and vice versa), noted in the setting's warning.
- Kimi Code models are unaffected — their pinned `directAccess` base URL wins as `customBaseUrl` at the top of the resolver, before the region switch (asserted by a new test).

Also corrects the **Kimi Code API-key row URL** from the generic `code.kimi.com/` to the actual console `www.kimi.com/code/console` where members mint keys.

## Verification

- `npm run typecheck` — 0 errors.
- New `MoonshotBaseUrl.vitest.ts`: China default, international-when-off, and custom-base-URL-beats-region (Kimi Code) — 3 cases.
- `settingsConfiguration.vitest.ts` extended to assert the new toggle's dashboard default matches its behavioral default.

## Notes

Independent of any Kimi Code subscription/auth work — this only affects which endpoint the open-platform Moonshot **API key** talks to.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped provider endpoint configuration with China as the default; wrong region/key pairing can cause auth failures but does not touch core auth or data paths.
> 
> **Overview**
> Adds a **China Region** toggle for open-platform **Moonshot** API keys (`texra.moonshot.useChina`, default **on**), matching DashScope / MiniMax / GLM. `resolveBaseUrl` now picks `api.moonshot.cn/v1` vs `api.moonshot.ai/v1` from that setting instead of always using China; registry metadata drives the Models tab copy, platform-specific key warnings, and international console links when the toggle is off.
> 
> **Kimi Code** paths are unchanged: a per-model `customBaseUrl` still wins over the region switch. The Kimi Code key URL is updated to `www.kimi.com/code/console`.
> 
> Tests cover default China routing, international when toggled off, custom URL precedence, and alignment between dashboard and behavioral defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9820c5306679f68bd7af78a0346a9b46229b241. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->