### PR TITLE
feat(workflow): detach delegate_workflow_script into an async child execution

### DIFF
--- a/docs/proposals/workflow-script-async-execution.md
+++ b/docs/proposals/workflow-script-async-execution.md
@@ -1,0 +1,219 @@
+# Workflow script async execution: detach the run from the orchestrator turn
+
+Status: audit + proposal → scoped to issues #8712 (core), #8713 (CLI cleanup)
+Date: 2026-07-17
+Prereqs shipped: durable named checkpoints (#8666/#8651), CLI progress projection (#8672), teachable contract + run log (#8681)
+
+## Framing: this is a convergence, not a new mode
+
+The constraint is to make the system _simpler_. Detaching the run does that
+by **removing a dual system**: `delegate_workflow_script` is today the one
+delegation tool that bypasses `startChildRunLoop` and delivers synchronously.
+Folding it into the existing async path means one delivery mechanism (the
+follow-up queue) for all three delegation tools, and lets us **delete** the
+synchronous special-casing (inline cost settlement, run-log-in-tool-result,
+parent-stage trace projection) and, in a follow-up, the bespoke #8672 CLI
+tool-row projection. It is a **full replacement, no sync/async flag** —
+keeping both modes would be the exact dual-system trap the constraint forbids;
+safe because the tool ships in no default agent YAML. Net elements must trend
+down.
+
+## Problem
+
+`delegate_workflow_script` runs **synchronously inside the orchestrator's
+tool-call turn**. The parent turn blocks for the whole run — up to the
+10-minute wall clock (`meta.timeoutMs`, capped at 60 min) — and the model
+gets exactly one thing back: the final tool result. While the run is in
+flight the orchestrator cannot do anything else, and the human cannot steer
+it beyond a whole-run interrupt.
+
+Claude Code's `Workflow` tool uses the opposite model: the tool returns a
+task ID immediately, the run executes as a background task, results arrive as
+a `<task-notification>`, and a `/workflows` detail view offers **per-agent
+kill / skip / retry** while the run continues. The one capability TeXRA
+structurally cannot match today is that mid-run human control, and it is
+absent precisely _because_ the run is synchronous.
+
+Note this was a deliberate choice, not an oversight: the sync model was kept
+to keep the follow-up-queue / wake machinery (and its self-stall race
+history, #7289 / #8093) out of the deterministic engine. This document
+audits what reversing that choice actually costs, now that the async
+delegation path and the CLI progress projection both exist.
+
+## What "same execution mode" means (and does not)
+
+Even in Claude Code the _script_ still runs to completion in one continuous
+engine loop; `agent()` calls resolve synchronously **within the run**. What
+is asynchronous is the **run relative to the parent turn**. So this proposal
+does **not** touch the QuickJS engine's control flow, the journal, or the
+in-band child execution. It changes one thing: the workflow run stops
+blocking the orchestrator turn and becomes a **detached execution** — the
+same shape `delegate_agent` already is.
+
+## Key finding: the machinery already fits
+
+`startChildRunLoop` (`src/agent/runtime/childRunLoop.ts:491`) is
+turn-_capable_ but not turn-_required_. A strategy that omits `runTurn` and
+returns `isTerminal() => true` runs exactly once to completion and delivers
+through the same follow-up-queue path `delegate_agent` uses.
+`createNativeWorkflowStrategy` (`src/tools/delegation/nativeWorkflowStrategy.ts:95`),
+which backs the fixed-round `delegate_workflow`, is exactly this shape and is
+**run-to-completion, not turn-based**. A workflow-script run is the same kind
+of job.
+
+So the async conversion is a **new strategy**, not new runtime:
+
+- **New** `createWorkflowScriptStrategy(params)` — a `ChildRunStrategy` shaped
+  like `createNativeWorkflowStrategy`, whose `launch(ports)` calls
+  `runPersistedWorkflowScriptWithProgress` (moved out of
+  `WorkflowScriptTool.execute`), uses `ports.recordCost` for the final total
+  and `ports.notify` for interim phase/log progress, `isTerminal: () => true`,
+  no `runTurn`. `formatDelivery` → result + run log; `formatError` → error +
+  run log + "resume with same meta.name" hint; `buildResultMeta` → the
+  structured result envelope so `/executions/{id}/result` chaining works.
+- **Split** `WorkflowScriptTool.execute` into a launch half (mint/derive the
+  run executionId, capture `recordSubagentCost` +
+  `approvalPromptsUnavailable`/`runtimeUnavailableTools` up front, call
+  `registerExecution` + `startChildRunLoop`, return "Launched (async)") and
+  the run body (now inside the strategy's `launch`).
+
+Reused unchanged: `startChildRunLoop`, `childRunDelivery.ts` (persist report /
+enqueue / wake), the `executions` tool (kill / wait / subscribe / report /
+result), and `runPersistedWorkflowScriptWithProgress` itself (with its
+`trace`/`onActivity` re-pointed at the run's own stream instead of the parent
+tool-call stage).
+
+## The load-bearing hazard: durability across async relaunch
+
+Resume (#8666) works today _because_ the checkpoint is anchored to the stable
+orchestrator executionId plus `meta.name`:
+`deriveWorkflowScriptCheckpointId({ name, defaultAgent, parentExecutionId })`
+where `parentExecutionId` is the orchestrator's execution
+(`WorkflowScriptTool.ts:127`), and the journal KV lives on
+`getExecutionStore(orchestratorExecutionId)`.
+
+If a detached run minted a fresh random executionId
+(`generateExecutionId()`), then **every async relaunch would produce a new
+checkpointId, orphan the journal, and destroy resume** — a direct regression
+of #8666. This is the central design constraint.
+
+**Resolution:** mint the workflow-run executionId **deterministically** from
+the checkpoint identity — `deriveExecutionId({ checkpointId })` — the same
+technique the run's `agent()` grandchildren already use. Then a relaunch with
+the same `meta.name` from the same orchestrator regenerates the _same_ run
+executionId, and registration, checkpoint store, and children all re-root at
+that stable ID while resume still replays completed calls for free. This
+requires teaching `registerExecution` (or a guard around it) to tolerate
+re-registration of an already-known ID on relaunch — the async subagent path
+today assumes a fresh random ID.
+
+The journal store and checkpoint key must continue to bind to the
+**orchestrator's** executionId + `meta.name`. If they migrate to the
+workflow-run executionId, that is fine _only_ because the run executionId is
+now itself deterministic from the same inputs; the two identities collapse to
+one stable anchor.
+
+## Mid-run steering: mostly free, one real engine gap
+
+Each `agent()` call is **already** a registered execution with a stable
+`executionId` (`workflowScriptAgentRunner.ts:27` →
+`inBandSubagentExecution.ts:458`) and its own child stream. Therefore:
+
+**Already works (inherited from `delegate_agent` children):**
+
+- **Per-child kill.** CLI `k` in the subagent list resolves the row to an
+  `executionId` and calls `executions.kill(executionId)`
+  (`SubagentList.tsx:365`); the extension per-stream stop button does the same
+  via `stopAgentStream`. A workflow `agent()` child is a normal registered
+  execution, so both already target it.
+- **Skip + retry-on-resume for free.** Killing one child makes `runAgent`
+  reject; `agentPrimitive` resolves that call to `null` and deliberately does
+  **not** journal it (`runWorkflowScript.ts:350`), so `.filter(Boolean)`
+  fan-outs drop it and the next resume re-runs it. That is skip semantics with
+  zero engine change.
+
+**The one genuine engine gap — live single-call skip/retry:** the engine has
+exactly one run-level `AbortController` (`runWorkflowScript.ts:205`), shared
+by every `runAgent` call (`:342`). There is no per-call controller (contrast
+Claude Code's `agentControllers` map keyed by call index), and
+`pendingAgentCalls` is a `Set<Promise>` keyed by promise identity, not by
+index, so a specific in-flight call cannot be addressed from inside the
+engine. A first-class _live_ retry (re-run now, not on next resume) and a
+"skip" distinct from "failure" would need:
+
+- a `Map<number, AbortController>` keyed by call index, each linked to
+  `runAbort`, passed to `runAgent` instead of the shared signal;
+- an external `skip(index)` / `retry(index)` API on the run;
+- a decision on the resolved value for a _deliberate_ skip (today only
+  fail→null→un-journaled exists).
+
+This is the only substantial new engine plumbing. It is optional — the
+detached model delivers non-blocking runs and per-child kill without it, and
+live retry can be a fast-follow.
+
+## UI: what has to be rebuilt
+
+The #8672 CLI projection (`workflowScriptProgress.ts`) is built entirely
+around finding and patching the **owning tool row** (gated on
+`DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME`, keyed to `logId`). A detached run is its
+own stream, so its phase/log lines must instead route into a `StreamSlice`
+and render through the existing focused-child viewport — a different
+mechanism, not a config flip. The workflow's `agent()` children _already_
+become real child streams, so only the workflow-run **container** stream and
+its phase/log rendering are new work. The extension gets the run as a normal
+child stream with its own header/stop for free; a Claude-Code-style flattened
+multi-level detail view with per-agent skip/retry buttons does not exist in
+either host and would be net-new.
+
+The CLI child list also shows **one level at a time**
+(`streamViews.ts:165`) — orchestrator → workflow-run → `agent()` child is a
+two-drill-down path, not a single flattened tree. A `WorkflowDetailDialog`
+equivalent is a separate, larger UI effort.
+
+## Scope tiers
+
+- **Tier 1 — detach the run (core).** New `createWorkflowScriptStrategy`,
+  split `execute` into launch + run body, deterministic run executionId,
+  re-point the trace projection to the run's own stream, route progress
+  through the child-stream viewport. Delivers: non-blocking orchestrator,
+  result-via-follow-up, whole-run kill, per-child kill (inherited), skip +
+  retry-on-resume (inherited). This is the "same execution mode" ask.
+- **Tier 2 — live per-call steering.** Per-call `AbortController` map,
+  `skip(index)`/`retry(index)` engine API, index-addressable
+  `pendingAgentCalls`. Delivers: live skip/retry of a single in-flight
+  `agent()` call.
+- **Tier 3 — detail UI.** A flattened multi-level workflow detail view with
+  per-agent controls in CLI and extension.
+
+## Open questions
+
+1. **Re-rooting the grandchildren.** Today the script's `agent()` children
+   register with `parentExecutionId`/`parentStreamId` = the _orchestrator_
+   (`workflowScriptAgentRunner.ts:99,153`), so the orchestrator can kill a
+   grandchild directly. Re-rooting them under the workflow-run execution gives
+   a clean 3-level tree but **removes** the orchestrator's direct
+   grandchild-kill authority (`executions.kill` gates on _direct_
+   `parentStreamId` equality, no transitive kill). Killing the run cascades to
+   its in-flight child via the run signal — arguably more correct, but a
+   capability change to decide deliberately.
+2. **Resume ergonomics.** With the run detached, who relaunches after a crash
+   or lease loss — the orchestrator re-issuing `delegate_workflow_script`, or
+   a resume-by-executionId path like `delegate_agent execution_id=`? The
+   lease-lost watchdog (`childRunLoop.ts:510`) would now interrupt a detached
+   run on ownership loss, a behavior the inline version never had.
+3. **Is Tier 1 alone worth it?** Non-blocking + per-child kill + retry-on-
+   resume may already close most of the gap with Claude Code for TeXRA's
+   document-processing domain, deferring Tiers 2–3 until a real workflow needs
+   live steering.
+
+## Recommendation
+
+Tier 1 is a real, contained change (~one new strategy file plus an
+`execute` split and the deterministic-id guard) that reuses the entire async
+delegation runtime and reverses the sync limitation the earlier audit flagged
+as the one it "consciously would not fix." The durability hazard has a clean
+resolution (deterministic run executionId). Tiers 2 and 3 are genuine
+net-new engine and UI work and should be gated on demand, not shipped
+speculatively. Recommend building Tier 1, keeping the run executionId
+deterministic from day one, and treating live per-call steering as a
+fast-follow only if dogfooding shows whole-run kill is too coarse.

--- a/docs/proposals/workflow-script-async-execution.md
+++ b/docs/proposals/workflow-script-async-execution.md
@@ -69,8 +69,13 @@ So the async conversion is a **new strategy**, not new runtime:
   `WorkflowScriptTool.execute`), uses `ports.recordCost` for the final total
   and `ports.notify` for interim phase/log progress, `isTerminal: () => true`,
   no `runTurn`. `formatDelivery` → result + run log; `formatError` → error +
-  run log + "resume with same meta.name" hint; `buildResultMeta` → the
-  structured result envelope so `/executions/{id}/result` chaining works.
+  run log + "resume with same meta.name" hint, both wrapped in the shared
+  child-run delivery envelope so the async follow-up carries the run's
+  executionId. `buildResultMeta` is intentionally omitted (matching the
+  agent-CLI strategies): the script's return value is free-form and does not
+  map onto the `AgentFinalResult`-shaped `ResultMeta`; the prose result is
+  delivered and persisted as the report, and each `agent()` grandchild still
+  persists its own chainable manifest.
 - **Split** `WorkflowScriptTool.execute` into a launch half (mint/derive the
   run executionId, capture `recordSubagentCost` +
   `approvalPromptsUnavailable`/`runtimeUnavailableTools` up front, call

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -53,4 +53,5 @@ export {
   completeOwnedExecutionLease,
   markOwnedExecutionLeaseUndurable,
   releaseOwnedExecutionLeaseAfterFailure,
+  ExecutionLeaseActiveError,
 } from './executionLease';

--- a/src/shared/deliveryTags.ts
+++ b/src/shared/deliveryTags.ts
@@ -22,6 +22,8 @@ export const DELIVERY_TAG = {
   codexError: 'codex-error',
   claudeAgentResult: 'claude-agent-result',
   claudeAgentError: 'claude-agent-error',
+  workflowScriptResult: 'workflow-script-result',
+  workflowScriptError: 'workflow-script-error',
   githubWebhookActivity: 'github-webhook-activity',
   executionActivity: 'execution-activity',
 } as const;
@@ -54,6 +56,8 @@ export const DELIVERY_TAGS: readonly DeliveryTagEntry[] = [
   { tag: DELIVERY_TAG.codexError, escaped: true },
   { tag: DELIVERY_TAG.claudeAgentResult, escaped: true },
   { tag: DELIVERY_TAG.claudeAgentError, escaped: true },
+  { tag: DELIVERY_TAG.workflowScriptResult, escaped: true },
+  { tag: DELIVERY_TAG.workflowScriptError, escaped: true },
   { tag: DELIVERY_TAG.githubWebhookActivity, escaped: false },
   { tag: DELIVERY_TAG.executionActivity, escaped: false },
 ];

--- a/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
@@ -65,6 +65,11 @@ vi.mock('@tools/delegation/workflowFileValidation', () => ({
 
 const parentExecutionId = 'aaaaaa111111' as ExecutionId;
 const parentStreamId = 'stream:workflow-script' as StreamTabId;
+// The detached workflow-run's own identity — grandchild agent() calls re-root
+// here, not on the orchestrator (#8712).
+const runExecutionId = 'run0run0run0' as ExecutionId;
+const runStreamId = 'workflow-script#run0run0run0' as StreamTabId;
+const run = { executionId: runExecutionId, streamId: runStreamId };
 const result: AgentFinalResult = {
   category: 'workflow',
   outcome: 'completed',
@@ -100,6 +105,7 @@ function defaultRunner(): ReturnType<typeof createWorkflowScriptAgentRunner> {
     parentContext(),
     'correct',
     'tool-call-7',
+    run,
   );
 }
 
@@ -160,7 +166,7 @@ describe('createWorkflowScriptAgentRunner', () => {
     expect(mocks.executeStableSubagentInBand).toHaveBeenCalledWith(
       expect.objectContaining({
         executionId: expect.stringMatching(/^[a-f0-9]{24}$/),
-        parentExecutionId,
+        parentExecutionId: runExecutionId,
         signal: call.signal,
         prepare: expect.any(Function),
       }),
@@ -168,8 +174,8 @@ describe('createWorkflowScriptAgentRunner', () => {
     expect(mocks.preparedOptions[0]).toEqual(
       expect.objectContaining({
         agentName: 'correct',
-        parentExecutionId,
-        parentStreamId,
+        parentExecutionId: runExecutionId,
+        parentStreamId: runStreamId,
         signal: call.signal,
         approvalPromptsUnavailable: true,
         runtimeUnavailableTools: ['user_question'],
@@ -225,12 +231,12 @@ describe('createWorkflowScriptAgentRunner', () => {
 
     expect(mocks.resolveChildRunOutput).toHaveBeenNthCalledWith(
       1,
-      parentExecutionId,
+      runExecutionId,
       firstRequested,
     );
     expect(mocks.resolveChildRunOutput).toHaveBeenNthCalledWith(
       2,
-      parentExecutionId,
+      runExecutionId,
       secondRequested,
     );
     expect(mocks.assertWorkflowFilesExist).toHaveBeenCalledWith([
@@ -323,7 +329,7 @@ describe('createWorkflowScriptAgentRunner', () => {
     prepared.onStreamResolved?.('stream:child' as StreamTabId);
     expect(mocks.configureDelegatedChildApprovals).toHaveBeenCalledWith(
       'stream:child',
-      parentStreamId,
+      runStreamId,
       'inherit',
       expect.objectContaining({ id: 'session' }),
     );
@@ -342,6 +348,7 @@ describe('createWorkflowScriptAgentRunner', () => {
       parentContext(),
       'correct',
       'tool-call-7',
+      run,
       { onCost },
     );
     const call = invocation();
@@ -361,6 +368,7 @@ describe('createWorkflowScriptAgentRunner', () => {
       parentContext(),
       'correct',
       'tool-call-7',
+      run,
       { onCost },
     );
 

--- a/src/test-kernel/tools/WorkflowScriptStrategy.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptStrategy.vitest.ts
@@ -65,6 +65,7 @@ function strategyParams(
   },
 ): WorkflowScriptStrategyParams {
   return {
+    executionId,
     logger: new TraceEmitter(),
     store: getExecutionStore(executionId),
     checkpointId: checkpointIdFor(overrides.name),

--- a/src/test-kernel/tools/WorkflowScriptStrategy.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptStrategy.vitest.ts
@@ -1,0 +1,284 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { setupPlatform } from '@test/support/setupPlatform';
+import { clearStoreCache, getExecutionStore } from '@agent/storage';
+import { TraceEmitter } from '@agent/trace';
+import {
+  deriveWorkflowScriptCheckpointId,
+  runPersistedWorkflowScript,
+  type WorkflowAgentInvocation,
+  type WorkflowAgentRunner,
+} from '@agent/workflowScript';
+import type { AgentFinalResult } from '@agent/runtime/AgentFinalResult';
+import type { ExecutionId } from '@shared/schemas';
+import {
+  createWorkflowScriptStrategy,
+  type WorkflowScriptStrategyParams,
+} from '@tools/delegation/workflowScriptStrategy';
+
+setupPlatform({ storagePath: '/storage', workspacePath: '/workspace' });
+
+const executionId = '7154strategy' as ExecutionId;
+const script = `export const meta = {
+  name: 'strategy-test',
+  description: 'tests the workflow script strategy',
+}
+return await agent('saved call')`;
+const finalResult: AgentFinalResult = {
+  category: 'workflow',
+  outcome: 'completed',
+  outputs: [],
+  compileFailures: [],
+  diffs: [],
+  cost: 0.42,
+};
+
+function checkpointIdFor(name: string): string {
+  return deriveWorkflowScriptCheckpointId({
+    name,
+    defaultAgent: 'correct',
+    parentExecutionId: executionId,
+  });
+}
+
+/** A runAgent that reports its cost through the strategy's onCost hook. */
+function billingRunAgent(
+  hooks: {
+    onCost: (i: WorkflowAgentInvocation, c: number | undefined) => void;
+  },
+  result: unknown = finalResult,
+): WorkflowAgentRunner {
+  return async (invocation) => {
+    hooks.onCost(invocation, finalResult.cost);
+    return result as AgentFinalResult;
+  };
+}
+
+function fakePorts() {
+  return { notify: vi.fn(), recordCost: vi.fn() };
+}
+
+function strategyParams(
+  overrides: Partial<WorkflowScriptStrategyParams> & {
+    readonly name: string;
+    readonly createRunAgent: WorkflowScriptStrategyParams['createRunAgent'];
+  },
+): WorkflowScriptStrategyParams {
+  return {
+    logger: new TraceEmitter(),
+    store: getExecutionStore(executionId),
+    checkpointId: checkpointIdFor(overrides.name),
+    script,
+    args: undefined,
+    ...overrides,
+  };
+}
+
+beforeEach(() => clearStoreCache());
+
+describe('createWorkflowScriptStrategy', () => {
+  it('is a terminal-only strategy with no runTurn', () => {
+    const strategy = createWorkflowScriptStrategy(
+      strategyParams({
+        name: 'strategy-test',
+        createRunAgent: (hooks) => billingRunAgent(hooks),
+      }),
+    );
+    expect(strategy.isTerminal({} as never)).toBe(true);
+    expect(strategy.runTurn).toBeUndefined();
+    expect(strategy.stageLabel).toBe("Workflow script 'strategy-test'");
+  });
+
+  it('runs a live call, settles its journal cost, and delivers the result', async () => {
+    const ports = fakePorts();
+    const strategy = createWorkflowScriptStrategy(
+      strategyParams({
+        name: 'strategy-test',
+        createRunAgent: (hooks) => billingRunAgent(hooks),
+      }),
+    );
+
+    const turn = await strategy.launch(ports, new AbortController());
+
+    // Journal-based settlement of the one live call.
+    expect(ports.recordCost).toHaveBeenCalledTimes(1);
+    expect(ports.recordCost).toHaveBeenCalledWith(0.42);
+
+    const delivery = await strategy.formatDelivery(turn, 0);
+    expect(delivery).toContain('"category": "workflow"');
+    // The run log rides along so the invoking model sees what executed.
+    expect(delivery).toContain('=== Run log ===');
+    expect(delivery).toContain('Finished');
+  });
+
+  it('replays a named checkpoint and settles zero for a pure resume', async () => {
+    await runPersistedWorkflowScript({
+      store: getExecutionStore(executionId),
+      checkpointId: checkpointIdFor('strategy-test'),
+      script,
+      runAgent: async () => finalResult,
+    });
+    clearStoreCache();
+    const ports = fakePorts();
+    const strategy = createWorkflowScriptStrategy(
+      strategyParams({
+        name: 'strategy-test',
+        // A retrying model rewrites its source; same meta.name still resumes.
+        script: `${script}\n// retry rewrote me`,
+        createRunAgent: () => async () => {
+          throw new Error('replayed call must not re-execute');
+        },
+      }),
+    );
+
+    const turn = await strategy.launch(ports, new AbortController());
+
+    // Delta accounting: replayed entries were billed by the executing attempt.
+    expect(ports.recordCost).toHaveBeenCalledWith(0);
+    const delivery = await strategy.formatDelivery(turn, 0);
+    expect(delivery).toContain('Using saved result');
+  });
+
+  it('passes JSON arguments through and formats a zero-call result', async () => {
+    const ports = fakePorts();
+    const strategy = createWorkflowScriptStrategy(
+      strategyParams({
+        name: 'arguments',
+        script: `export const meta = {
+  name: 'arguments',
+  description: 'returns its arguments',
+}
+return args`,
+        args: { question: 'What is conserved?' },
+        createRunAgent: (hooks) => billingRunAgent(hooks),
+      }),
+    );
+
+    const turn = await strategy.launch(ports, new AbortController());
+    const delivery = await strategy.formatDelivery(turn, 0);
+    expect(delivery).toContain('"question": "What is conserved?"');
+    expect(ports.recordCost).toHaveBeenCalledWith(0);
+  });
+
+  it('retains checkpoint arguments when a null retry omits them', async () => {
+    const argsScript = `export const meta = {
+  name: 'retained-arguments',
+  description: 'retains omitted retry arguments',
+}
+return args`;
+    await runPersistedWorkflowScript({
+      store: getExecutionStore(executionId),
+      checkpointId: checkpointIdFor('retained-arguments'),
+      script: argsScript,
+      args: { topic: 'geometry' },
+      runAgent: async () => finalResult,
+    });
+    clearStoreCache();
+    const strategy = createWorkflowScriptStrategy(
+      strategyParams({
+        name: 'retained-arguments',
+        script: `${argsScript}\n// revised retry`,
+        args: null,
+        createRunAgent: (hooks) => billingRunAgent(hooks),
+      }),
+    );
+
+    const turn = await strategy.launch(fakePorts(), new AbortController());
+    const delivery = await strategy.formatDelivery(turn, 0);
+    expect(delivery).toContain('"topic": "geometry"');
+  });
+
+  it('bounds and normalizes the model-visible run log', async () => {
+    const strategy = createWorkflowScriptStrategy(
+      strategyParams({
+        name: 'bounded-log',
+        script: `export const meta = {
+  name: 'bounded-log',
+  description: 'bounds model-visible activity',
+}
+for (let index = 0; index < 100; index += 1) log('line-' + index)
+log('oversized\\n' + 'x'.repeat(2_000))
+return 'done'`,
+        createRunAgent: (hooks) => billingRunAgent(hooks),
+      }),
+    );
+
+    const turn = await strategy.launch(fakePorts(), new AbortController());
+    const delivery = await strategy.formatDelivery(turn, 0);
+    expect(delivery).toContain(
+      '=== Run log (last 80 lines; 21 earlier lines omitted) ===',
+    );
+    expect(delivery).not.toContain('line-20\n');
+    expect(delivery).toContain('line-21\n');
+    expect(delivery).toContain('oversized x');
+    expect(delivery.length).toBeLessThan(42_000);
+  });
+
+  it('settles a retained journal and surfaces the resume hint when script code fails', async () => {
+    const failingScript = `export const meta = {
+  name: 'retained-settlement',
+  description: 'tests retained journal settlement',
+}
+await agent('saved call')
+throw new Error('script failed after replay')`;
+    await expect(
+      runPersistedWorkflowScript({
+        store: getExecutionStore(executionId),
+        checkpointId: checkpointIdFor('retained-settlement'),
+        script: failingScript,
+        runAgent: async () => finalResult,
+      }),
+    ).rejects.toThrow('script failed after replay');
+    clearStoreCache();
+    const ports = fakePorts();
+    const strategy = createWorkflowScriptStrategy(
+      strategyParams({
+        name: 'retained-settlement',
+        script: failingScript,
+        createRunAgent: () => async () => {
+          throw new Error('replayed call must not re-execute');
+        },
+      }),
+    );
+
+    await expect(strategy.launch(ports, new AbortController())).rejects.toThrow(
+      'script failed after replay',
+    );
+    // The seeding attempt billed the entry; this attempt only replays it.
+    expect(ports.recordCost).toHaveBeenCalledWith(0);
+
+    const errText = await strategy.formatError(null, new Error('boom'));
+    expect(errText).toContain(
+      "journaled under meta.name 'retained-settlement'",
+    );
+    expect(errText).toContain('boom');
+  });
+
+  it('fails closed on a malformed journal cost without recording a scalar', async () => {
+    const malformedScript = `export const meta = {
+  name: 'malformed-cost',
+  description: 'tests malformed journal cost settlement',
+}
+return await agent('saved call')`;
+    await runPersistedWorkflowScript({
+      store: getExecutionStore(executionId),
+      checkpointId: checkpointIdFor('malformed-cost'),
+      script: malformedScript,
+      runAgent: async () => ({ not: 'an agent result' }),
+    });
+    clearStoreCache();
+    const ports = fakePorts();
+    const strategy = createWorkflowScriptStrategy(
+      strategyParams({
+        name: 'malformed-cost',
+        script: malformedScript,
+        createRunAgent: () => async () => finalResult,
+      }),
+    );
+
+    await expect(strategy.launch(ports, new AbortController())).rejects.toThrow(
+      'Workflow journal entry 0 is not an agent final result',
+    );
+    expect(ports.recordCost).not.toHaveBeenCalled();
+  });
+});

--- a/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
@@ -1,14 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { setupPlatform } from '@test/support/setupPlatform';
-import { clearStoreCache, getExecutionStore } from '@agent/storage';
 import { TraceEmitter } from '@agent/trace';
-import {
-  deriveWorkflowScriptCheckpointId,
-  runPersistedWorkflowScript,
-} from '@agent/workflowScript';
+import { deriveWorkflowScriptCheckpointId } from '@agent/workflowScript';
 import { withToolFileInteractionContext } from '@agent/followUp/ToolFileInteractionContext';
-import type { AgentFinalResult } from '@agent/runtime/AgentFinalResult';
 import type { LaunchRunContext } from '@agent/runtime/RunContext';
 import { withRunContext } from '@agent/runtime/RunContext';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
@@ -17,10 +12,40 @@ import {
   DELEGATION_TOOL_CATEGORY,
   DELEGATION_TOOLS,
 } from '@shared/constants/delegationTools';
-import { getDefaultToolRegistry } from '@tools/registry';
-import { WorkflowScriptTool } from '@tools/delegation/WorkflowScriptTool';
+import { deriveExecutionId } from '@utils/core/idHash';
 
 setupPlatform({ storagePath: '/storage', workspacePath: '/workspace' });
+
+const mocks = vi.hoisted(() => ({
+  registerExecution: vi.fn(),
+  startChildRunLoop: vi.fn(),
+  createChildStream: vi.fn(),
+  configureDelegatedChildApprovals: vi.fn(),
+}));
+
+// Spread the real storage module so `ExecutionLeaseActiveError`,
+// `getExecutionStore`, and lease helpers stay authentic; only registration is
+// spied so the launch can be observed without touching the async run loop.
+vi.mock('@agent/storage', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@agent/storage')>();
+  return { ...actual, registerExecution: mocks.registerExecution };
+});
+
+vi.mock('@agent/runtime/childRunLoop', () => ({
+  startChildRunLoop: mocks.startChildRunLoop,
+}));
+
+vi.mock('@tools/childStream', () => ({
+  createChildStream: mocks.createChildStream,
+}));
+
+vi.mock('@tools/approval', () => ({
+  configureDelegatedChildApprovals: mocks.configureDelegatedChildApprovals,
+}));
+
+import { ExecutionLeaseActiveError } from '@agent/storage';
+import { WorkflowScriptTool } from '@tools/delegation/WorkflowScriptTool';
+import { getDefaultToolRegistry } from '@tools/registry';
 
 const executionId = '7154scripttool' as ExecutionId;
 const streamId = 'stream:workflow-script-tool' as StreamTabId;
@@ -29,14 +54,6 @@ const script = `export const meta = {
   description: 'tests the workflow script tool',
 }
 return await agent('saved call')`;
-const finalResult: AgentFinalResult = {
-  category: 'workflow',
-  outcome: 'completed',
-  outputs: [],
-  compileFailures: [],
-  diffs: [],
-  cost: 0.42,
-};
 
 function parentContext(): LaunchRunContext {
   return {
@@ -61,35 +78,44 @@ function checkpointIdFor(name: string): string {
   });
 }
 
+/** The deterministic run executionId derived from that checkpoint identity. */
+function runExecutionIdFor(name: string): ExecutionId {
+  return deriveExecutionId({ checkpointId: checkpointIdFor(name) });
+}
+
 async function callTool(options?: {
-  readonly toolCallId?: string;
   readonly script?: string;
   readonly recordCost?: (cost: number) => void;
-  readonly signal?: AbortSignal;
-  readonly trace?: TraceEmitter;
-  readonly args?: unknown;
 }) {
   return withRunContext(parentContext(), () =>
     withToolFileInteractionContext(
       {
         tracker: {} as never,
-        toolCallId: options?.toolCallId ?? 'tool-call',
-        trace: options?.trace ?? new TraceEmitter(),
-        signal: options?.signal,
+        toolCallId: 'tool-call',
+        trace: new TraceEmitter(),
         hooks: { recordSubagentCost: options?.recordCost ?? vi.fn() },
       },
       () =>
         new WorkflowScriptTool().call({
           agent: 'correct',
           script: options?.script ?? script,
-          ...(options &&
-            Object.hasOwn(options, 'args') && { args: options.args }),
         }),
     ),
   );
 }
 
-beforeEach(() => clearStoreCache());
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.registerExecution.mockResolvedValue(undefined);
+  mocks.createChildStream.mockImplementation((runId: ExecutionId): unknown => ({
+    childStreamId: `workflow-script#${runId}` as StreamTabId,
+    logger: new TraceEmitter(),
+    waitForInput: vi.fn(),
+    beginTurn: vi.fn(),
+    failTurn: vi.fn(),
+    finalize: vi.fn(),
+  }));
+});
 
 describe('WorkflowScriptTool', () => {
   it('is registered and classified without becoming a proposal tool', () => {
@@ -110,9 +136,10 @@ describe('WorkflowScriptTool', () => {
 
     expect(result.status).toBe('error');
     expect(result.diagnostics).toMatchObject({ type: 'validation_error' });
+    expect(mocks.startChildRunLoop).not.toHaveBeenCalled();
   });
 
-  it('requires a launched tool context and parent trace', async () => {
+  it('requires a launched tool context', async () => {
     const outside = await new WorkflowScriptTool().call({
       agent: 'correct',
       script,
@@ -121,56 +148,92 @@ describe('WorkflowScriptTool', () => {
       status: 'error',
       error: expect.stringContaining('active launched agent session'),
     });
-
-    const missingTrace = await withRunContext(parentContext(), () =>
-      withToolFileInteractionContext(
-        { tracker: {} as never, toolCallId: 'missing-trace' },
-        () => new WorkflowScriptTool().call({ agent: 'correct', script }),
-      ),
-    );
-    expect(missingTrace).toMatchObject({
-      status: 'error',
-      error: expect.stringContaining('parent progress trace'),
-    });
+    expect(mocks.startChildRunLoop).not.toHaveBeenCalled();
   });
 
-  it('resumes a named checkpoint even when the retry rewrites the script', async () => {
-    await runPersistedWorkflowScript({
-      store: getExecutionStore(executionId),
-      checkpointId: checkpointIdFor('tool-test'),
-      script,
-      runAgent: async () => finalResult,
-    });
-    clearStoreCache();
-    const recordCost = vi.fn();
+  it('launches the run as a detached child with a deterministic run id', async () => {
+    const result = await callTool();
 
-    const result = await callTool({ toolCallId: 'attempt-1', recordCost });
+    const runExecutionId = runExecutionIdFor('tool-test');
+    // The run id is derived from the checkpoint identity (NOT random), so a
+    // relaunch with the same meta.name re-roots at the same anchor and resume
+    // still works (#8712).
+    expect(mocks.registerExecution).toHaveBeenCalledWith(
+      runExecutionId,
+      expect.objectContaining({ agentCategory: 'workflow', agent: 'correct' }),
+      'tool-test',
+      executionId,
+    );
+    expect(mocks.createChildStream).toHaveBeenCalledWith(
+      runExecutionId,
+      streamId,
+      expect.objectContaining({
+        streamPrefix: 'workflow-script',
+        streamCategory: 'workflow',
+        agentName: 'tool-test',
+      }),
+    );
+    // The run's own stream inherits the orchestrator's approval ancestry.
+    expect(mocks.configureDelegatedChildApprovals).toHaveBeenCalledWith(
+      `workflow-script#${runExecutionId}`,
+      streamId,
+      'inherit',
+      expect.objectContaining({ id: 'workflow-script-test' }),
+    );
+    expect(mocks.startChildRunLoop).toHaveBeenCalledTimes(1);
+    const loopParams = mocks.startChildRunLoop.mock.calls[0]?.[0];
+    expect(loopParams).toMatchObject({
+      childStreamId: `workflow-script#${runExecutionId}`,
+      parentStreamId: streamId,
+      executionId: runExecutionId,
+      agentName: 'tool-test',
+    });
+    expect(loopParams.strategy).toMatchObject({
+      stageLabel: "Workflow script 'tool-test'",
+      launch: expect.any(Function),
+      isTerminal: expect.any(Function),
+    });
+    // Terminal-only: no runTurn (matches the native workflow strategy shape).
+    expect(loopParams.strategy.runTurn).toBeUndefined();
+    expect(loopParams.recordCost).toEqual(expect.any(Function));
 
     expect(result).toMatchObject({
       status: 'executed',
-      summary: "Completed workflow script 'tool-test' (1 agent call)",
+      summary: "Launched workflow script 'tool-test' (async)",
     });
-    expect(result.output).toContain('"category": "workflow"');
-    // The run log rides along so the invoking model sees what executed.
-    expect(result.output).toContain('=== Run log ===');
-    expect(result.output).toContain('Using saved result');
-    // Delta accounting: replayed entries were settled by the attempt that
-    // executed them, so a pure replay settles zero instead of double-billing.
-    expect(recordCost).toHaveBeenCalledTimes(1);
-    expect(recordCost).toHaveBeenCalledWith(0);
+    expect(result.output).toContain(`Execution ID: ${runExecutionId}`);
+    expect(result.output).toContain('same meta.name');
+  });
 
-    // A retrying model rewrites its source; same meta.name still resumes,
-    // and the unchanged agent() call replays instead of re-executing.
-    clearStoreCache();
-    const retryCost = vi.fn();
-    const retry = await callTool({
-      toolCallId: 'attempt-2',
-      recordCost: retryCost,
-      script: `${script}\n// retry rewrote me`,
+  it('regenerates the same run id across relaunches of one meta.name', async () => {
+    await callTool();
+    const first = mocks.startChildRunLoop.mock.calls[0]?.[0].executionId;
+    mocks.startChildRunLoop.mockClear();
+    // A retrying model rewrites its source; the deterministic run id and the
+    // meta.name-anchored checkpoint keep resume intact.
+    await callTool({ script: `${script}\n// retry rewrote me` });
+    const second = mocks.startChildRunLoop.mock.calls[0]?.[0].executionId;
+
+    expect(first).toBe(runExecutionIdFor('tool-test'));
+    expect(second).toBe(first);
+  });
+
+  it('reports already-running when the deterministic id is still leased', async () => {
+    const runExecutionId = runExecutionIdFor('tool-test');
+    mocks.registerExecution.mockRejectedValueOnce(
+      new ExecutionLeaseActiveError(runExecutionId, Date.now()),
+    );
+
+    const result = await callTool();
+
+    expect(result).toMatchObject({
+      status: 'executed',
+      summary: "Workflow script 'tool-test' is already running",
     });
-    expect(retry).toMatchObject({ status: 'executed' });
-    expect(retry.output).toContain('Using saved result');
-    expect(retryCost).toHaveBeenCalledWith(0);
+    expect(result.output).toContain(`Execution ID: ${runExecutionId}`);
+    // A relaunch over a live run never starts a second competing loop.
+    expect(mocks.createChildStream).not.toHaveBeenCalled();
+    expect(mocks.startChildRunLoop).not.toHaveBeenCalled();
   });
 
   it('derives distinct checkpoints when name or default agent differ', () => {
@@ -183,148 +246,5 @@ describe('WorkflowScriptTool', () => {
         parentExecutionId: executionId,
       }),
     ).not.toBe(base);
-  });
-
-  it('passes JSON arguments through and formats a zero-call result', async () => {
-    const recordCost = vi.fn();
-    const result = await callTool({
-      script: `export const meta = {
-  name: 'arguments',
-  description: 'returns its arguments',
-}
-return args`,
-      args: { question: 'What is conserved?' },
-      recordCost,
-    });
-
-    expect(result).toMatchObject({
-      status: 'executed',
-      summary: "Completed workflow script 'arguments' (0 agent calls)",
-      output: expect.stringContaining('"question": "What is conserved?"'),
-    });
-    expect(recordCost).toHaveBeenCalledTimes(1);
-    expect(recordCost).toHaveBeenCalledWith(0);
-  });
-
-  it('retains checkpoint arguments for null retries and replaces explicit values', async () => {
-    const argsScript = `export const meta = {
-  name: 'retained-arguments',
-  description: 'retains omitted retry arguments',
-}
-return args`;
-    await runPersistedWorkflowScript({
-      store: getExecutionStore(executionId),
-      checkpointId: checkpointIdFor('retained-arguments'),
-      script: argsScript,
-      args: { topic: 'geometry' },
-      runAgent: async () => finalResult,
-    });
-    clearStoreCache();
-
-    const result = await callTool({
-      script: `${argsScript}\n// revised retry`,
-      args: null,
-    });
-
-    expect(result).toMatchObject({
-      status: 'executed',
-      output: expect.stringContaining('"topic": "geometry"'),
-    });
-
-    clearStoreCache();
-    const replacement = await callTool({
-      script: `${argsScript}\n// retry with replacement arguments`,
-      args: { topic: 'analysis' },
-    });
-
-    expect(replacement).toMatchObject({
-      status: 'executed',
-      output: expect.stringContaining('"topic": "analysis"'),
-    });
-  });
-
-  it('bounds and normalizes the model-visible run log', async () => {
-    const result = await callTool({
-      script: `export const meta = {
-  name: 'bounded-log',
-  description: 'bounds model-visible activity',
-}
-for (let index = 0; index < 100; index += 1) log('line-' + index)
-log('oversized\\n' + 'x'.repeat(2_000))
-return 'done'`,
-    });
-
-    expect(result).toMatchObject({ status: 'executed' });
-    expect(result.output).toContain(
-      '=== Run log (last 80 lines; 21 earlier lines omitted) ===',
-    );
-    expect(result.output).not.toContain('line-20\n');
-    expect(result.output).toContain('line-21\n');
-    expect(result.output).toContain('oversized x');
-    expect(result.output).not.toContain('oversized\n');
-    expect(result.output?.length).toBeLessThan(42_000);
-  });
-
-  it('settles a retained journal when later script code fails', async () => {
-    const failingScript = `export const meta = {
-  name: 'retained-settlement',
-  description: 'tests retained journal settlement',
-}
-await agent('saved call')
-throw new Error('script failed after replay')`;
-    await expect(
-      runPersistedWorkflowScript({
-        store: getExecutionStore(executionId),
-        checkpointId: checkpointIdFor('retained-settlement'),
-        script: failingScript,
-        runAgent: async () => finalResult,
-      }),
-    ).rejects.toThrow('script failed after replay');
-    clearStoreCache();
-    const recordCost = vi.fn();
-
-    const result = await callTool({
-      recordCost,
-      script: failingScript,
-    });
-
-    expect(result).toMatchObject({
-      status: 'error',
-      error: expect.stringContaining('script failed after replay'),
-    });
-    // Failures carry the run log and the resume hint back to the model.
-    expect(result.error).toContain(
-      "journaled under meta.name 'retained-settlement'",
-    );
-    // The seeding attempt journaled the entry; this attempt only replays it.
-    expect(recordCost).toHaveBeenCalledTimes(1);
-    expect(recordCost).toHaveBeenCalledWith(0);
-  });
-
-  it('fails closed on malformed journal costs without recording a scalar', async () => {
-    // Distinct meta.name so this journal cannot alias the replay test's key.
-    const malformedScript = `export const meta = {
-  name: 'malformed-cost',
-  description: 'tests malformed journal cost settlement',
-}
-return await agent('saved call')`;
-    await runPersistedWorkflowScript({
-      store: getExecutionStore(executionId),
-      checkpointId: checkpointIdFor('malformed-cost'),
-      script: malformedScript,
-      runAgent: async () => ({ not: 'an agent result' }),
-    });
-    clearStoreCache();
-    const recordCost = vi.fn();
-
-    const result = await callTool({ recordCost, script: malformedScript });
-
-    expect(result).toMatchObject({
-      status: 'error',
-      error: expect.stringContaining(
-        'Workflow journal entry 0 is not an agent final result',
-      ),
-    });
-    expect(recordCost).not.toHaveBeenCalled();
   });
 });

--- a/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
@@ -1,8 +1,10 @@
+/* eslint-disable import/order -- Vitest mocks must be declared before importing the module under test. */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { setupPlatform } from '@test/support/setupPlatform';
 import { TraceEmitter } from '@agent/trace';
 import { deriveWorkflowScriptCheckpointId } from '@agent/workflowScript';
+import { ExecutionLeaseActiveError } from '@agent/storage';
 import { withToolFileInteractionContext } from '@agent/followUp/ToolFileInteractionContext';
 import type { LaunchRunContext } from '@agent/runtime/RunContext';
 import { withRunContext } from '@agent/runtime/RunContext';
@@ -43,7 +45,6 @@ vi.mock('@tools/approval', () => ({
   configureDelegatedChildApprovals: mocks.configureDelegatedChildApprovals,
 }));
 
-import { ExecutionLeaseActiveError } from '@agent/storage';
 import { WorkflowScriptTool } from '@tools/delegation/WorkflowScriptTool';
 import { getDefaultToolRegistry } from '@tools/registry';
 

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -20,7 +20,7 @@ import { startChildRunLoop } from '@agent/runtime/childRunLoop';
 import { getCurrentToolContexts } from '@agent/followUp/ToolFileInteractionContext';
 
 // Local imports - shared schemas
-import { AgentCategory } from '@shared/schemas';
+import { AgentCategory, type StreamTabId } from '@shared/schemas';
 import { DEFAULT_AGENT_MODEL } from '@shared/constants/providers';
 import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
@@ -162,17 +162,23 @@ Tool inclusion is the opt-in boundary: do not add this tool to a default agent c
       );
     }
 
-    const childStream = createChildStream(runExecutionId, runScope.streamId, {
-      streamPrefix: STREAM_PREFIX,
-      streamCategory: AgentCategory.Workflow,
-      agentName: meta.name,
-      description: meta.description,
-      config: runConfig,
-      toolName: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
-      runtimeHost: runScope.runtimeHost,
-    });
-    const runChildStreamId = childStream.childStreamId;
+    // createChildStream is inside the lease-protected try: it runs after the
+    // deterministic run lease is held, so a throw here (missing subscribers,
+    // duplicate stream tab) must release the lease — otherwise the lease
+    // survives to its heartbeat timeout and a prompt relaunch is refused.
+    let runChildStreamId: StreamTabId;
     try {
+      const childStream = createChildStream(runExecutionId, runScope.streamId, {
+        streamPrefix: STREAM_PREFIX,
+        streamCategory: AgentCategory.Workflow,
+        agentName: meta.name,
+        description: meta.description,
+        config: runConfig,
+        toolName: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+        runtimeHost: runScope.runtimeHost,
+      });
+      runChildStreamId = childStream.childStreamId;
+
       // The run's own stream inherits the orchestrator's bypass so grandchild
       // agent() calls, which link to this stream, still resolve it transitively.
       configureDelegatedChildApprovals(
@@ -189,6 +195,7 @@ Tool inclusion is the opt-in boundary: do not add this tool to a default agent c
         executionId: runExecutionId,
         agentName: meta.name,
         strategy: createWorkflowScriptStrategy({
+          executionId: runExecutionId,
           logger: childStream.logger,
           store,
           checkpointId,

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -2,34 +2,40 @@
 import { z } from 'zod';
 
 // Local imports - agent runtime
-import { getExecutionStore } from '@agent/storage';
+import {
+  ExecutionLeaseActiveError,
+  getExecutionStore,
+  registerExecution,
+  releaseOwnedExecutionLeaseAfterFailure,
+} from '@agent/storage';
+import {
+  AgentConfigSchema,
+  type AgentConfigPayload,
+} from '@agent/core/definition/AgentConfig';
+import { startChildRunLoop } from '@agent/runtime/childRunLoop';
 import {
   deriveWorkflowScriptCheckpointId,
   parseWorkflowScript,
-  readWorkflowScriptCheckpoint,
-  type WorkflowJournalEntry,
-  type WorkflowScriptRunResult,
 } from '@agent/workflowScript';
 import { getCurrentToolContexts } from '@agent/followUp/ToolFileInteractionContext';
 
 // Local imports - shared schemas
+import { AgentCategory } from '@shared/schemas';
+import { DEFAULT_AGENT_MODEL } from '@shared/constants/providers';
 import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
-import type { ToolResult } from '@shared/schemas/toolResult';
+import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 
 // Local imports - tools
+import { configureDelegatedChildApprovals } from '@tools/approval';
+import { createChildStream } from '@tools/childStream';
 import { defineTool } from '@tools/core/define';
 
 // Local imports - utilities
-import { toErrorMessage } from '@utils/errors/errorMessage';
-import { formatResultCount, truncateSummary } from '@utils/text/stringUtils';
+import { deriveExecutionId } from '@utils/core/idHash';
 
 // Local imports - delegation
 import { createWorkflowScriptAgentRunner } from './workflowScriptAgentRunner';
-import {
-  runPersistedWorkflowScriptWithProgress,
-  sumCompletedWorkflowJournalCost,
-  workflowJournalEntryCostIdentity,
-} from './workflowScriptRun';
+import { createWorkflowScriptStrategy } from './workflowScriptStrategy';
 
 const WorkflowScriptToolInputSchema = z.strictObject({
   agent: z
@@ -50,48 +56,16 @@ const WorkflowScriptToolInputSchema = z.strictObject({
 
 type WorkflowScriptToolInput = z.infer<typeof WorkflowScriptToolInputSchema>;
 
-function formatWorkflowResult(result: unknown): string {
-  if (typeof result === 'string') return result;
-  return JSON.stringify(result, null, 2) ?? 'undefined';
-}
-
-const RUN_LOG_MAX_LINES = 80;
-const RUN_LOG_MAX_LINE_LENGTH = 500;
-
-interface RunLogCollector {
-  readonly add: (line: string) => void;
-  readonly format: () => string;
-}
-
-/** Retain a small, single-line tail for the invoking model. */
-function createRunLogCollector(): RunLogCollector {
-  const lines: string[] = [];
-  let omitted = 0;
-  return {
-    add: (line) => {
-      lines.push(truncateSummary(line, RUN_LOG_MAX_LINE_LENGTH));
-      if (lines.length > RUN_LOG_MAX_LINES) {
-        lines.shift();
-        omitted += 1;
-      }
-    },
-    format: () => {
-      if (lines.length === 0) return '';
-      const header =
-        omitted > 0
-          ? `=== Run log (last ${lines.length} lines; ${omitted} earlier ${omitted === 1 ? 'line' : 'lines'} omitted) ===`
-          : '=== Run log ===';
-      return `\n\n${header}\n${lines.join('\n')}`;
-    },
-  };
-}
+const STREAM_PREFIX = 'workflow-script';
 
 /** Execute a durable, deterministic workflow script from an opted-in agent. */
 export class WorkflowScriptTool extends defineTool({
   name: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
   description: `Run a deterministic JavaScript workflow that coordinates workflow agents. Workflow agents edit or produce FILES: each agent() call resolves to a result envelope { category: 'workflow', outcome, outputs, diffs, compileFailures, cost } listing the files it produced, never prose. Use this when the complete fan-out, pipeline, and join structure is known in advance and should resume safely after interruption.
 
-Script rules: start with export const meta = { name, description }; no imports or require (only the injected primitives exist: agent, phase, log, parallel, pipeline, concat, and the args global). agent(), parallel(), and pipeline() return Promises: ALWAYS await them. agent(prompt, options) options: inputFiles (REQUIRED for file-editing agents; workspace paths, or a previous call's output paths to chain stages), agentName (another visible workflow agent; defaults to this tool's agent field), id (distinguish otherwise-identical calls), label, phase. A failed call inside parallel()/pipeline() resolves to null; filter with .filter(Boolean). The script's return value is this tool's result, followed by the run log (phases, log() lines, per-call outcomes with cost).
+Script rules: start with export const meta = { name, description }; no imports or require (only the injected primitives exist: agent, phase, log, parallel, pipeline, concat, and the args global). agent(), parallel(), and pipeline() return Promises: ALWAYS await them. agent(prompt, options) options: inputFiles (REQUIRED for file-editing agents; workspace paths, or a previous call's output paths to chain stages), agentName (another visible workflow agent; defaults to this tool's agent field), id (distinguish otherwise-identical calls), label, phase. A failed call inside parallel()/pipeline() resolves to null; filter with .filter(Boolean).
+
+Async: this tool returns immediately with an execution ID and runs the workflow as its own detached execution. The script's return value plus the run log (phases, log() lines, per-call outcomes with cost) are delivered back as a follow-up message when the run completes. Check intermediate progress with the executions tool (path=/executions/<id>, action=wait).
 
 Example:
 export const meta = { name: 'fix-drafts', description: 'Fix typos in two drafts', timeoutMs: 1800000 }
@@ -118,6 +92,8 @@ Tool inclusion is the opt-in boundary: do not add this tool to a default agent c
       );
     }
     const { runContext: parent, callContext } = contexts;
+    const { runScope } = parent;
+
     // Named checkpoint, not content- or toolCallId-keyed: a retrying model
     // rewrites its script, so any key derived from call identity or source
     // text orphans the journal exactly when resume matters (#8666). meta.name
@@ -127,82 +103,123 @@ Tool inclusion is the opt-in boundary: do not add this tool to a default agent c
     const checkpointId = deriveWorkflowScriptCheckpointId({
       name: meta.name,
       defaultAgent: input.agent,
-      parentExecutionId: parent.runScope.executionId,
+      parentExecutionId: runScope.executionId,
     });
-    if (!callContext.trace) {
-      throw new Error(
-        'delegate_workflow_script requires the parent progress trace.',
-      );
-    }
 
-    const store = getExecutionStore(parent.runScope.executionId);
-    // The stable child runner's native cost callback fires only for work that
-    // executes in this attempt. Exact journal replays and stable-child
-    // recoveries do not fire it, even when completion-order changes move a
-    // recovered invocation key to another journal index.
-    const executedEntries = new Set<string>();
-    let costSettled = false;
-    const settleCost = (journal: readonly WorkflowJournalEntry[]): void => {
-      if (costSettled) return;
-      const cost = sumCompletedWorkflowJournalCost(journal, executedEntries);
-      costSettled = true;
-      callContext.hooks?.recordSubagentCost?.(cost);
+    // The run executionId is deterministic from the checkpoint identity, NOT a
+    // fresh random id: a relaunch with the same meta.name regenerates the same
+    // run id, so registration, stream, and grandchildren re-root at one stable
+    // anchor and resume still replays completed calls (#8712). The journal
+    // itself stays on the orchestrator store, where the checkpoint lives.
+    const runExecutionId = deriveExecutionId({ checkpointId });
+    const store = getExecutionStore(runScope.executionId);
+
+    // Captured now, while the launching tool call's ALS frame is live, so the
+    // detached run can still roll its cost into the parent after this call
+    // returns. Undefined totals are skipped (a malformed-journal failure never
+    // records a spurious cost).
+    const recordSubagentCost = callContext?.hooks?.recordSubagentCost;
+    const recordCost = (totalCostUsd: number | undefined): void => {
+      if (totalCostUsd !== undefined) recordSubagentCost?.(totalCostUsd);
     };
 
-    // Live display accumulator only: covers success and failure of this run's
-    // live children (cached replays spend nothing). Boundary settlement below
-    // stays journal-based so resumed runs still roll up replayed spend.
-    let liveCostUsd = 0;
-    const runLog = createRunLogCollector();
-    let run: WorkflowScriptRunResult;
+    const runConfigPayload: AgentConfigPayload = {
+      agent: input.agent,
+      agentCategory: AgentCategory.Workflow,
+      model: parent.model ?? DEFAULT_AGENT_MODEL,
+      instruction: `Workflow script '${meta.name}'`,
+      ...(runScope.workingDirectory !== undefined && {
+        workingDirectory: runScope.workingDirectory,
+      }),
+    };
+    const runConfig = AgentConfigSchema.parse(runConfigPayload);
+
     try {
-      run = await runPersistedWorkflowScriptWithProgress(callContext.trace, {
-        store,
-        checkpointId,
-        script: input.script,
-        ...(input.args != null && { args: input.args }),
-        signal: callContext.signal,
-        runAgent: createWorkflowScriptAgentRunner(
-          parent,
-          input.agent,
-          checkpointId,
-          {
-            onCost: (invocation, totalCostUsd) => {
-              executedEntries.add(workflowJournalEntryCostIdentity(invocation));
-              liveCostUsd += totalCostUsd ?? 0;
-            },
-          },
-        ),
-        getLiveCostUsd: () => liveCostUsd,
-        onActivity: runLog.add,
-      });
-    } catch (runError) {
-      try {
-        const checkpoint = await readWorkflowScriptCheckpoint(
-          store,
-          checkpointId,
-        );
-        settleCost(checkpoint?.journal ?? []);
-      } catch (settlementError) {
-        throw new AggregateError(
-          [runError, settlementError],
-          `Workflow script failed: ${toErrorMessage(runError)} Cost settlement also failed: ${toErrorMessage(settlementError)}`,
-        );
+      await registerExecution(
+        runExecutionId,
+        runConfig,
+        meta.name,
+        runScope.executionId,
+      );
+    } catch (error) {
+      // A relaunch whose prior run is still in flight shares this deterministic
+      // id: the fresh-lease acquisition fails closed rather than starting a
+      // second competing run over the same journal. Point the model at the
+      // live run instead of erroring.
+      if (error instanceof ExecutionLeaseActiveError) {
+        return {
+          status: 'executed',
+          summary: `Workflow script '${meta.name}' is already running`,
+          output: [
+            `A workflow script run for meta.name '${meta.name}' is already in progress; its result will arrive as a follow-up.`,
+            `Execution ID: ${runExecutionId}`,
+            `To check progress: executions tool with path=/executions/${runExecutionId} and action=wait.`,
+          ].join('\n'),
+        };
       }
-      // The run log is the model's only view into what executed before the
-      // failure; without it a timeout reads as total loss instead of
-      // resumable progress.
-      throw new Error(
-        `${toErrorMessage(runError)}${runLog.format()}\n\nCompleted agent() calls are journaled under meta.name '${meta.name}': call this tool again with the same meta.name to resume without repeating them.`,
-        { cause: runError },
+      throw new ToolError(
+        `Failed to launch workflow script '${meta.name}': ${error instanceof Error ? error.message : String(error)}`,
       );
     }
 
-    settleCost(run.journal);
+    const childStream = createChildStream(runExecutionId, runScope.streamId, {
+      streamPrefix: STREAM_PREFIX,
+      streamCategory: AgentCategory.Workflow,
+      agentName: meta.name,
+      description: meta.description,
+      config: runConfig,
+      toolName: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+      runtimeHost: runScope.runtimeHost,
+    });
+    const runChildStreamId = childStream.childStreamId;
+    try {
+      // The run's own stream inherits the orchestrator's bypass so grandchild
+      // agent() calls, which link to this stream, still resolve it transitively.
+      configureDelegatedChildApprovals(
+        runChildStreamId,
+        runScope.streamId,
+        'inherit',
+        runScope.session,
+      );
+
+      startChildRunLoop({
+        childStream,
+        childStreamId: runChildStreamId,
+        parentStreamId: runScope.streamId,
+        executionId: runExecutionId,
+        agentName: meta.name,
+        strategy: createWorkflowScriptStrategy({
+          logger: childStream.logger,
+          store,
+          checkpointId,
+          script: input.script,
+          args: input.args,
+          name: meta.name,
+          createRunAgent: (hooks) =>
+            createWorkflowScriptAgentRunner(
+              parent,
+              input.agent,
+              checkpointId,
+              { executionId: runExecutionId, streamId: runChildStreamId },
+              hooks,
+            ),
+        }),
+        recordCost,
+      });
+    } catch (error) {
+      throw await releaseOwnedExecutionLeaseAfterFailure(runExecutionId, error);
+    }
+
     return {
       status: 'executed',
-      summary: `Completed workflow script '${run.meta.name}' (${formatResultCount(run.agentCalls, 'agent call')})`,
-      output: `${formatWorkflowResult(run.result)}${runLog.format()}`,
+      summary: `Launched workflow script '${meta.name}' (async)`,
+      output: [
+        `Workflow script '${meta.name}' launched. Its result and run log will be delivered automatically as a follow-up message when the run completes.`,
+        `Execution ID: ${runExecutionId}`,
+        `Stream tab: ${runChildStreamId}`,
+        `To check intermediate progress: executions tool with path=/executions/${runExecutionId} and action=wait (waits for next status change).`,
+        `To resume after a timeout or interruption: call this tool again with the same meta.name.`,
+      ].join('\n'),
     };
   }
 }

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -9,14 +9,14 @@ import {
   releaseOwnedExecutionLeaseAfterFailure,
 } from '@agent/storage';
 import {
+  deriveWorkflowScriptCheckpointId,
+  parseWorkflowScript,
+} from '@agent/workflowScript';
+import {
   AgentConfigSchema,
   type AgentConfigPayload,
 } from '@agent/core/definition/AgentConfig';
 import { startChildRunLoop } from '@agent/runtime/childRunLoop';
-import {
-  deriveWorkflowScriptCheckpointId,
-  parseWorkflowScript,
-} from '@agent/workflowScript';
 import { getCurrentToolContexts } from '@agent/followUp/ToolFileInteractionContext';
 
 // Local imports - shared schemas

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -151,9 +151,9 @@ Tool inclusion is the opt-in boundary: do not add this tool to a default agent c
           status: 'executed',
           summary: `Workflow script '${meta.name}' is already running`,
           output: [
-            `A workflow script run for meta.name '${meta.name}' is already in progress; its result will arrive as a follow-up.`,
+            `A workflow script run for meta.name '${meta.name}' is already in progress (or finishing); its result arrives as a follow-up. Do not launch a competing run — wait for it, then resume with the same meta.name if it did not complete.`,
             `Execution ID: ${runExecutionId}`,
-            `To check progress: executions tool with path=/executions/${runExecutionId} and action=wait.`,
+            `To check progress or collect the result: executions tool with path=/executions/${runExecutionId} and action=wait (returns immediately if it already finished).`,
           ].join('\n'),
         };
       }

--- a/src/tools/delegation/workflowScriptAgentRunner.ts
+++ b/src/tools/delegation/workflowScriptAgentRunner.ts
@@ -6,6 +6,7 @@ import {
   type WorkflowAgentRunner,
 } from '@agent/workflowScript';
 import type { LaunchRunContext } from '@agent/runtime/RunContext';
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
 import { formatError } from '@common/errors';
 import { AgentCategory } from '@shared/schemas';
@@ -73,11 +74,26 @@ async function resolveInvocationInputFiles(
   return resolved;
 }
 
+/**
+ * Identity of the detached workflow-run that owns this script's `agent()`
+ * grandchildren. Re-rooting them here (instead of the orchestrator) gives a
+ * clean 3-level tree — orchestrator → run → agent — so killing the run
+ * cascades to its in-flight child. Both fields are stable across relaunch:
+ * `executionId` is derived deterministically from the checkpoint identity, so
+ * the grandchild execution ids and run-storage lineage stay consistent when a
+ * timed-out run is resumed under the same `meta.name`.
+ */
+export interface WorkflowRunIdentity {
+  readonly executionId: ExecutionId;
+  readonly streamId: StreamTabId;
+}
+
 /** Build the production `agent()` adapter for one workflow-script run. */
 export function createWorkflowScriptAgentRunner(
   parent: LaunchRunContext,
   defaultAgentName: string,
   checkpointId: string,
+  run: WorkflowRunIdentity,
   hooks?: {
     /** Fires per live child on success and failure with its total cost. */
     readonly onCost?: (
@@ -92,11 +108,11 @@ export function createWorkflowScriptAgentRunner(
     try {
       const { result } = await executeStableSubagentInBand({
         executionId: workflowChildExecutionId(
-          runScope.executionId,
+          run.executionId,
           checkpointId,
           invocation.key,
         ),
-        parentExecutionId: runScope.executionId,
+        parentExecutionId: run.executionId,
         signal: invocation.signal,
         prepare: async () => {
           const requestedAgent =
@@ -112,7 +128,7 @@ export function createWorkflowScriptAgentRunner(
               agentCategory: AgentCategory.Workflow,
             }),
             resolveInvocationInputFiles(
-              runScope.executionId,
+              run.executionId,
               invocation.options.inputFiles ?? [],
             ),
           ]);
@@ -149,8 +165,8 @@ export function createWorkflowScriptAgentRunner(
           return {
             configPayload,
             agentName: agent.name,
-            parentExecutionId: runScope.executionId,
-            parentStreamId: runScope.streamId,
+            parentExecutionId: run.executionId,
+            parentStreamId: run.streamId,
             runtimeHost: runScope.runtimeHost,
             session: runScope.session,
             signal: invocation.signal,
@@ -158,11 +174,12 @@ export function createWorkflowScriptAgentRunner(
             runtimeUnavailableTools: parent.runtimeUnavailableTools,
             // Live per-kind ancestry, matching LLM delegation: bash and
             // tool-edit each follow the parent's own bypass; proposal stays
-            // unlinked so a child's own delegations still prompt.
+            // unlinked so a child's own delegations still prompt. The run's own
+            // stream inherits from the orchestrator, so this stays transitive.
             onStreamResolved: (resolvedStreamId) => {
               configureDelegatedChildApprovals(
                 resolvedStreamId,
-                runScope.streamId,
+                run.streamId,
                 'inherit',
                 runScope.session,
               );

--- a/src/tools/delegation/workflowScriptAgentRunner.ts
+++ b/src/tools/delegation/workflowScriptAgentRunner.ts
@@ -6,9 +6,9 @@ import {
   type WorkflowAgentRunner,
 } from '@agent/workflowScript';
 import type { LaunchRunContext } from '@agent/runtime/RunContext';
-import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
 import { formatError } from '@common/errors';
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { AgentCategory } from '@shared/schemas';
 import { configureDelegatedChildApprovals } from '@tools/approval';
 import { deriveExecutionId } from '@utils/core/idHash';

--- a/src/tools/delegation/workflowScriptStrategy.ts
+++ b/src/tools/delegation/workflowScriptStrategy.ts
@@ -17,9 +17,9 @@ import type {
   WorkflowAgentRunner,
   WorkflowScriptRunResult,
 } from '@agent/workflowScript';
-import type { ChildRunStrategy } from '@agent/runtime/childRunLoop';
 import type { AgentTrace } from '@agent/trace';
 import type { ExecutionKVStore } from '@agent/storage';
+import type { ChildRunStrategy } from '@agent/runtime/childRunLoop';
 
 // Local imports - utilities
 import { toErrorMessage } from '@utils/errors/errorMessage';

--- a/src/tools/delegation/workflowScriptStrategy.ts
+++ b/src/tools/delegation/workflowScriptStrategy.ts
@@ -24,6 +24,7 @@ import type { ChildRunStrategy } from '@agent/runtime/childRunLoop';
 // Local imports - shared
 import { DELIVERY_TAG } from '@shared/deliveryTags';
 import type { ExecutionId } from '@shared/schemas';
+import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
 
 // Local imports - tools
 import {
@@ -196,7 +197,7 @@ export function createWorkflowScriptStrategy(
           executionId: params.executionId,
         },
         {
-          message: `${toErrorMessage(err)}${runLog.format()}\n\nCompleted agent() calls are journaled under meta.name '${params.name}': call delegate_workflow_script again with the same meta.name to resume without repeating them.`,
+          message: `${toErrorMessage(err)}${runLog.format()}\n\nCompleted agent() calls are journaled under meta.name '${params.name}': call ${DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME} again with the same meta.name to resume without repeating them.`,
         },
       ),
   };

--- a/src/tools/delegation/workflowScriptStrategy.ts
+++ b/src/tools/delegation/workflowScriptStrategy.ts
@@ -1,0 +1,174 @@
+/**
+ * Workflow-script child-run strategy over the shared `childRunLoop`.
+ *
+ * Terminal-only: a workflow-script run executes once to completion inside
+ * `launch` and delivers its result through the same follow-up-queue path every
+ * detached child uses. No `runTurn` — the loop never calls it for a strategy
+ * whose first (and only) turn is always terminal (the same shape
+ * `createNativeWorkflowStrategy` uses).
+ *
+ * Host-agnostic, VS Code-free.
+ */
+
+// Local imports - agent runtime
+import { readWorkflowScriptCheckpoint } from '@agent/workflowScript';
+import type {
+  WorkflowAgentInvocation,
+  WorkflowAgentRunner,
+  WorkflowScriptRunResult,
+} from '@agent/workflowScript';
+import type { ChildRunStrategy } from '@agent/runtime/childRunLoop';
+import type { AgentTrace } from '@agent/trace';
+import type { ExecutionKVStore } from '@agent/storage';
+
+// Local imports - utilities
+import { toErrorMessage } from '@utils/errors/errorMessage';
+import { truncateSummary } from '@utils/text/stringUtils';
+
+// Local imports - delegation
+import {
+  runPersistedWorkflowScriptWithProgress,
+  sumCompletedWorkflowJournalCost,
+  workflowJournalEntryCostIdentity,
+} from './workflowScriptRun';
+
+const RUN_LOG_MAX_LINES = 80;
+const RUN_LOG_MAX_LINE_LENGTH = 500;
+
+interface RunLogCollector {
+  readonly add: (line: string) => void;
+  readonly format: () => string;
+}
+
+/** Retain a small, single-line tail for the invoking model. */
+function createRunLogCollector(): RunLogCollector {
+  const lines: string[] = [];
+  let omitted = 0;
+  return {
+    add: (line) => {
+      lines.push(truncateSummary(line, RUN_LOG_MAX_LINE_LENGTH));
+      if (lines.length > RUN_LOG_MAX_LINES) {
+        lines.shift();
+        omitted += 1;
+      }
+    },
+    format: () => {
+      if (lines.length === 0) return '';
+      const header =
+        omitted > 0
+          ? `=== Run log (last ${lines.length} lines; ${omitted} earlier ${omitted === 1 ? 'line' : 'lines'} omitted) ===`
+          : '=== Run log ===';
+      return `\n\n${header}\n${lines.join('\n')}`;
+    },
+  };
+}
+
+function formatWorkflowResult(result: unknown): string {
+  if (typeof result === 'string') return result;
+  return JSON.stringify(result, null, 2) ?? 'undefined';
+}
+
+export interface WorkflowScriptStrategyParams {
+  /** The run's child-stream trace — where phase/log progress projects. */
+  readonly logger: AgentTrace;
+  /** Orchestrator store that owns the durable journal (checkpoint anchor). */
+  readonly store: ExecutionKVStore;
+  readonly checkpointId: string;
+  readonly script: string;
+  /** JSON arguments; `null`/`undefined` retains the checkpoint's arguments. */
+  readonly args: unknown;
+  /** Durable identity (`meta.name`) — used in the resume hint on failure. */
+  readonly name: string;
+  /**
+   * Build the `agent()` adapter bound to the run's ancestry, wired to the
+   * supplied per-live-child cost hook so delta accounting stays local to this
+   * run.
+   */
+  readonly createRunAgent: (hooks: {
+    readonly onCost: (
+      invocation: WorkflowAgentInvocation,
+      totalCostUsd: number | undefined,
+    ) => void;
+  }) => WorkflowAgentRunner;
+}
+
+/**
+ * Create the terminal-only strategy that runs one durable workflow script as a
+ * detached child. The run body — cost delta-accounting, run-log capture, and
+ * progress projection onto the run's own stream — lives here; the tool only
+ * launches it.
+ */
+export function createWorkflowScriptStrategy(
+  params: WorkflowScriptStrategyParams,
+): ChildRunStrategy<WorkflowScriptRunResult> {
+  const runLog = createRunLogCollector();
+
+  return {
+    stageLabel: `Workflow script '${params.name}'`,
+
+    launch: async (ports, abortController) => {
+      // The stable child runner's native cost callback fires only for work
+      // that executes in this attempt; exact journal replays and stable-child
+      // recoveries do not fire it. Delta accounting excludes replayed entries
+      // so a pure resume settles zero instead of double-billing.
+      const executedEntries = new Set<string>();
+      let liveCostUsd = 0;
+      const runAgent = params.createRunAgent({
+        onCost: (invocation, totalCostUsd) => {
+          executedEntries.add(workflowJournalEntryCostIdentity(invocation));
+          liveCostUsd += totalCostUsd ?? 0;
+        },
+      });
+
+      let run: WorkflowScriptRunResult;
+      try {
+        run = await runPersistedWorkflowScriptWithProgress(params.logger, {
+          store: params.store,
+          checkpointId: params.checkpointId,
+          script: params.script,
+          ...(params.args != null && { args: params.args }),
+          signal: abortController.signal,
+          runAgent,
+          getLiveCostUsd: () => liveCostUsd,
+          onActivity: runLog.add,
+        });
+      } catch (runError) {
+        // Settle whatever the journal recorded before the failure so a resumed
+        // run still rolls up already-spent cost. Settlement failure never
+        // masks the run error — the run log and resume hint are the model's
+        // only view into what executed.
+        try {
+          const checkpoint = await readWorkflowScriptCheckpoint(
+            params.store,
+            params.checkpointId,
+          );
+          ports.recordCost(
+            sumCompletedWorkflowJournalCost(
+              checkpoint?.journal ?? [],
+              executedEntries,
+            ),
+          );
+        } catch {
+          // Cost settlement is best-effort on the failure path.
+        }
+        throw runError;
+      }
+
+      // Journal-based settlement (not the live accumulator) so replayed spend
+      // rolls up on resume; a malformed journal fails closed here, before any
+      // cost is recorded.
+      ports.recordCost(
+        sumCompletedWorkflowJournalCost(run.journal, executedEntries),
+      );
+      return run;
+    },
+
+    isTerminal: () => true,
+
+    formatDelivery: (turn) =>
+      `${formatWorkflowResult(turn.result)}${runLog.format()}`,
+
+    formatError: (_turn, err) =>
+      `${toErrorMessage(err)}${runLog.format()}\n\nCompleted agent() calls are journaled under meta.name '${params.name}': call delegate_workflow_script again with the same meta.name to resume without repeating them.`,
+  };
+}

--- a/src/tools/delegation/workflowScriptStrategy.ts
+++ b/src/tools/delegation/workflowScriptStrategy.ts
@@ -21,6 +21,16 @@ import type { AgentTrace } from '@agent/trace';
 import type { ExecutionKVStore } from '@agent/storage';
 import type { ChildRunStrategy } from '@agent/runtime/childRunLoop';
 
+// Local imports - shared
+import { DELIVERY_TAG } from '@shared/deliveryTags';
+import type { ExecutionId } from '@shared/schemas';
+
+// Local imports - tools
+import {
+  formatChildRunDelivery,
+  formatChildRunError,
+} from '@tools/deliveryEnvelope';
+
 // Local imports - utilities
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { truncateSummary } from '@utils/text/stringUtils';
@@ -69,6 +79,8 @@ function formatWorkflowResult(result: unknown): string {
 }
 
 export interface WorkflowScriptStrategyParams {
+  /** The detached run's execution id — echoed on the delivery envelope. */
+  readonly executionId: ExecutionId;
   /** The run's child-stream trace — where phase/log progress projects. */
   readonly logger: AgentTrace;
   /** Orchestrator store that owns the durable journal (checkpoint anchor). */
@@ -165,10 +177,27 @@ export function createWorkflowScriptStrategy(
 
     isTerminal: () => true,
 
+    // Wrap the free-form result in the shared child-run envelope so the async
+    // follow-up carries the run's executionId, like every other detached
+    // delivery — the invoking model correlates and can resume by that id.
     formatDelivery: (turn) =>
-      `${formatWorkflowResult(turn.result)}${runLog.format()}`,
+      formatChildRunDelivery(
+        {
+          tag: DELIVERY_TAG.workflowScriptResult,
+          executionId: params.executionId,
+        },
+        { response: `${formatWorkflowResult(turn.result)}${runLog.format()}` },
+      ),
 
     formatError: (_turn, err) =>
-      `${toErrorMessage(err)}${runLog.format()}\n\nCompleted agent() calls are journaled under meta.name '${params.name}': call delegate_workflow_script again with the same meta.name to resume without repeating them.`,
+      formatChildRunError(
+        {
+          tag: DELIVERY_TAG.workflowScriptError,
+          executionId: params.executionId,
+        },
+        {
+          message: `${toErrorMessage(err)}${runLog.format()}\n\nCompleted agent() calls are journaled under meta.name '${params.name}': call delegate_workflow_script again with the same meta.name to resume without repeating them.`,
+        },
+      ),
   };
 }


### PR DESCRIPTION
## What & why

Folds `delegate_workflow_script` into the **existing** async delegation runtime (`startChildRunLoop` + follow-up queue) instead of running the script synchronously inside the orchestrator's tool-call turn. Design audit: `docs/proposals/workflow-script-async-execution.md`. Closes #8712.

This is a **convergence, not a new mode**: workflow-script was the one delegation tool that bypassed `startChildRunLoop` and delivered synchronously. Now all three delegation tools share one delivery mechanism. **Full replacement, no sync/async flag** (a flag would be the dual-system trap); safe because the tool ships in no default agent YAML.

The tool now returns "Launched (async)" immediately; the run executes as its own detached child stream and delivers its result + run log back as a follow-up when it completes.

## Change

- **New `createWorkflowScriptStrategy`** — a terminal-only `ChildRunStrategy` (like `createNativeWorkflowStrategy`): `launch` runs the script via `runPersistedWorkflowScriptWithProgress` against the run's own stream trace, settles cost through `ports.recordCost` with the preserved journal delta-accounting, and `formatDelivery`/`formatError` carry the result + run log + resume hint.
- **`WorkflowScriptTool.execute` rewritten to the launch pattern** (mirrors `launchAgentCliChild`): derive checkpointId (unchanged, orchestrator-anchored), mint the run executionId, `registerExecution`, `createChildStream`, `startChildRunLoop`, return "Launched (async)".
- **Grandchildren re-rooted** onto the run (`parentExecutionId`/`parentStreamId`/run-storage lineage/child-id derivation/approval ancestry) → clean orchestrator → run → agent tree; killing the run cascades to its in-flight child.

## Deleted (the sync special-casing)

From `WorkflowScriptTool.execute`: inline cost settlement + the `AggregateError` double-failure branch, run-log-in-tool-result assembly, and the direct `callContext.trace` projection onto the parent's active stage. (The bespoke CLI tool-row projection deletion is the companion #8713 — the full net-negative lands across both.)

## Durability preserved (#8666)

The checkpoint stays anchored to the orchestrator executionId + `meta.name`, and the journal store stays on the orchestrator. The run executionId is minted **deterministically** via `deriveExecutionId({ checkpointId })`, so a relaunch with the same `meta.name` regenerates the same run id — registration, stream, and grandchildren re-root at one stable anchor and completed calls still replay. A relaunch whose prior run is still leased catches `ExecutionLeaseActiveError` and points the model at the live run instead of starting a competing loop.

## Verified

- 162 tests green across the workflow suites + `WorkflowScriptStrategy` (new, drives launch/formatDelivery/formatError directly) + `DelegationHeadless`/`SubagentResults`; root tsc clean; dead-code ratchet clean.
- **Live dogfood** (texra-local, deepseekproT): launched async and non-blocking; the run rendered as its own stream with `correct` children re-rooted under it (`subagent: correct · parent: fix-typos`); the terminal result delivered back as a follow-up with run log + resume hint; the model resumed with the same `meta.name` and got the same deterministic execution id; the completed child's corrected file + diff persisted and were inspectable via the `executions` tool. The run hit the 10-min wall clock only because one child was pathologically slow on the test model — which validated the resumable-timeout-delivery path.

## Notes for review

- `buildResultMeta` omitted (matching agent-CLI strategies): the script's return value is free-form `unknown` and doesn't map onto the `AgentFinalResult`-shaped `ResultMeta`; the prose result is delivered/persisted and each `agent()` grandchild still persists its own chainable manifest.
- Net LoC is positive for this PR alone (run body relocated into the strategy + new async plumbing); the deletion payoff completes in #8713.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches delegation lifecycle (leases, child streams, cost rollup, and execution tree ancestry); durability depends on deterministic run IDs and lease semantics, but behavior is heavily covered by new strategy/tool tests and mirrors existing async delegation patterns.
> 
> **Overview**
> **`delegate_workflow_script` no longer blocks the orchestrator turn.** The tool now launches a detached child via `registerExecution`, `createChildStream`, and `startChildRunLoop`, returns immediately with an execution ID, and delivers the script result plus run log through the shared follow-up queue (same path as other delegation tools).
> 
> A new terminal-only **`createWorkflowScriptStrategy`** owns the run body: `runPersistedWorkflowScriptWithProgress` on the run’s stream, journal-based cost settlement via `ports.recordCost`, and **`workflow-script-result` / `workflow-script-error`** delivery envelopes. Sync-only behavior is removed from **`WorkflowScriptTool.execute`** (inline run, parent trace projection, final result in the tool return).
> 
> **Resume (#8666) is preserved** by deriving the run **`executionId` from `checkpointId`** (`deriveExecutionId`), keeping the journal on the orchestrator store; relaunches with the same `meta.name` reuse the same run id. **`ExecutionLeaseActiveError`** is handled so a second launch while a run is leased points at the live execution instead of starting a competing loop.
> 
> **`agent()` grandchildren are re-rooted** under the workflow run (`WorkflowRunIdentity`) for an orchestrator → run → agent tree; tests and docs capture the design (#8712).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c88ce3f27d03af2e4035fc7c461e4c39d790568e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->