### PR TITLE
fix(agent): retry status-less OpenAI server errors

### DIFF
--- a/src/common/errors/sdkError/relayDetection.ts
+++ b/src/common/errors/sdkError/relayDetection.ts
@@ -4,11 +4,11 @@ import { isObject, isString } from '@utils/core';
 import { pickStringField } from './errorInspection';
 
 /**
- * Maps Anthropic error type strings to their corresponding HTTP status codes.
- * Used to recover the status code when SDK error objects lose it
- * (e.g., streaming SSE errors that produce generic APIError instances).
+ * Maps provider error type/code strings to their corresponding HTTP status
+ * codes. Used to recover the status code when SDK error objects lose it
+ * (e.g., streaming errors that produce generic APIError instances).
  */
-const ANTHROPIC_ERROR_TYPE_TO_STATUS: Record<string, number> = {
+const ERROR_TYPE_OR_CODE_TO_STATUS: Record<string, number> = {
   invalid_request_error: StatusCodes.BAD_REQUEST, // 400
   authentication_error: StatusCodes.UNAUTHORIZED, // 401
   permission_error: StatusCodes.FORBIDDEN, // 403
@@ -16,14 +16,16 @@ const ANTHROPIC_ERROR_TYPE_TO_STATUS: Record<string, number> = {
   request_too_large: StatusCodes.REQUEST_TOO_LONG, // 413
   rate_limit_error: StatusCodes.TOO_MANY_REQUESTS, // 429
   api_error: StatusCodes.INTERNAL_SERVER_ERROR, // 500
+  server_error: StatusCodes.INTERNAL_SERVER_ERROR, // 500
   timeout_error: StatusCodes.REQUEST_TIMEOUT, // 408
   overloaded_error: 529,
 };
 
 /**
- * Infers an HTTP status code from the Anthropic error type in the raw error body.
- * Handles both the envelope format `{ type: "error", error: { type: "api_error" } }`
- * and the direct format `{ type: "api_error" }`.
+ * Infers an HTTP status code from a provider error type/code in the raw body.
+ * Handles both enveloped errors such as
+ * `{ type: "error", error: { type: "api_error" } }` and direct errors such as
+ * `{ type: "server_error", code: "server_error" }`.
  *
  * The nested path is checked first because Anthropic's canonical envelope uses
  * `type: "error"` at the top level (not a real error type), with the actual
@@ -35,16 +37,18 @@ export function inferStatusCodeFromBody(
   if (!isObject(rawErrorBody)) {
     return undefined;
   }
-  const body = rawErrorBody as { type?: unknown; error?: { type?: unknown } };
-  // Nested first: { type: "error", error: { type: "api_error" } }
-  const nestedType =
-    isObject(body.error) && isString(body.error.type)
-      ? body.error.type
-      : undefined;
-  // Direct fallback: { type: "api_error" }
-  const directType = isString(body.type) ? body.type : undefined;
-  const errorType = nestedType ?? directType;
-  return errorType ? ANTHROPIC_ERROR_TYPE_TO_STATUS[errorType] : undefined;
+  const body = rawErrorBody as { error?: unknown };
+  const candidates = [body.error, rawErrorBody];
+  for (const candidate of candidates) {
+    if (!isObject(candidate)) continue;
+    for (const field of ['type', 'code'] as const) {
+      const value = candidate[field];
+      if (!isString(value)) continue;
+      const statusCode = ERROR_TYPE_OR_CODE_TO_STATUS[value];
+      if (statusCode !== undefined) return statusCode;
+    }
+  }
+  return undefined;
 }
 
 export function isRelayError(rawErrorBody: unknown): boolean {

--- a/src/test-kernel/agent/modelHandlers/OpenAIResponseErrors.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIResponseErrors.vitest.ts
@@ -136,7 +136,7 @@ describe('OpenAI Responses error normalization', () => {
     expect(providerError.userRetryable).toBe(true);
   });
 
-  it('keeps terminal background statuses retryable without HTTP metadata', () => {
+  it('infers retryable server status for terminal background responses', () => {
     const wrapped = createOpenAIBackgroundTerminalError(
       {
         id: 'resp_failed',
@@ -153,7 +153,7 @@ describe('OpenAI Responses error normalization', () => {
     const providerError = formatProviderHttpError(wrapped);
 
     expect(providerError.provider).toBe('openai');
-    expect(providerError.statusCode).toBeUndefined();
+    expect(providerError.statusCode).toBe(500);
     expect(providerError.userRetryable).toBe(true);
     expect(providerError.message).toContain('resp_failed');
     expect(requiresFlowAutoRetry(wrapped)).toBe(true);

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -5,6 +5,7 @@ import '@test/support/defaultSessionTestSetup';
 import { createTestSession } from '@test/support/sessionTestUtils';
 
 // Third-party imports
+import { APIError as OpenAIAPIError } from 'openai';
 import { describe, expect, it, vi, type Mock } from 'vitest';
 
 // Local imports - agent runtime
@@ -16,6 +17,7 @@ import { noopTrace, type AgentTrace } from '@agent/trace';
 import type { BaseCycleFields } from '@agent/core/flows/CommonCycleTypes';
 import { ModelInvocationNode } from '@agent/core/flows/ModelInvocationNode';
 import { RetryableInvocationNode } from '@agent/core/flows/RetryState';
+import { tagOpenAISdkError } from '@agent/modelHandlers/openai/openAISdkError';
 import type {
   HostRetryRequest,
   RetryResult,
@@ -165,6 +167,21 @@ describe('RetryState', () => {
 
     expect(node.shouldAutoRetry(abort)).toBe(false);
     expect(node.fallbackFor(abort)).toEqual({ kind: 'cancelled' });
+  });
+
+  it('auto-retries a status-less OpenAI server_error response', () => {
+    const node = new ExposedRetryNode();
+    const body = {
+      type: 'server_error',
+      code: 'server_error',
+      message:
+        'An error occurred while processing your request. You can retry your request, or contact us through our help center at help.openai.com if the error persists. Please include the request ID 988f71d8-3453-46f1-a466-529d2a967244 in your message.',
+      param: null,
+    };
+    const error = new OpenAIAPIError(undefined, body, body.message, undefined);
+    tagOpenAISdkError(error, 'openai');
+
+    expect(node.shouldAutoRetry(error)).toBe(true);
   });
 
   it('skips flow-level auto-retry when the model handler delegates retries to the provider', () => {

--- a/src/test-kernel/common/SdkErrorUtils.vitest.mts
+++ b/src/test-kernel/common/SdkErrorUtils.vitest.mts
@@ -9,6 +9,7 @@ import { ApiError as GoogleApiError } from '@google/genai';
 import {
   APIConnectionError as OpenAIAPIConnectionError,
   APIConnectionTimeoutError as OpenAIAPIConnectionTimeoutError,
+  APIError as OpenAIAPIError,
   APIUserAbortError as OpenAIAPIUserAbortError,
   AuthenticationError as OpenAIAuthenticationError,
   BadRequestError as OpenAIBadRequestError,
@@ -333,6 +334,40 @@ describe('formatProviderHttpError', () => {
     expect(formatted.userRetryable).toBe(true);
   });
 
+  it('infers a retryable 500 from a status-less OpenAI server_error body', () => {
+    const body = {
+      type: 'server_error',
+      code: 'server_error',
+      message:
+        'An error occurred while processing your request. You can retry your request, or contact us through our help center at help.openai.com if the error persists. Please include the request ID 988f71d8-3453-46f1-a466-529d2a967244 in your message.',
+      param: null,
+    };
+    const error = new OpenAIAPIError(undefined, body, body.message, undefined);
+    tagOpenAISdkError(error, 'openai');
+
+    const formatted = formatProviderHttpError(error);
+
+    expect(formatted.provider).toBe('openai');
+    expect(formatted.statusCode).toBe(500);
+    expect(formatted.userRetryable).toBe(true);
+    expect(formatted.rawErrorBody).toEqual(body);
+  });
+
+  it('keeps unknown status-less OpenAI API errors non-retryable', () => {
+    const body = {
+      type: 'unexpected_error',
+      code: 'unexpected_error',
+      message: 'Unexpected provider failure.',
+    };
+    const error = new OpenAIAPIError(undefined, body, body.message, undefined);
+    tagOpenAISdkError(error, 'openai');
+
+    const formatted = formatProviderHttpError(error);
+
+    expect(formatted.statusCode).toBeUndefined();
+    expect(formatted.userRetryable).toBe(false);
+  });
+
   it('formats tagged OpenAI HTTP errors with status metadata', () => {
     const error = new OpenAIBadRequestError(
       400,
@@ -412,7 +447,7 @@ describe('formatProviderHttpError', () => {
     expect(formatted.userRetryable).toBe(true);
   });
 
-  it('keeps provider-attributed background failures retryable without a status code', () => {
+  it('infers a retryable status for provider-attributed background server errors', () => {
     const error = new Error('background response failed') as Error & {
       error: unknown;
       provider: string;
@@ -426,7 +461,7 @@ describe('formatProviderHttpError', () => {
     const formatted = formatProviderHttpError(error);
 
     expect(formatted.provider).toBe('openai');
-    expect(formatted.statusCode).toBeUndefined();
+    expect(formatted.statusCode).toBe(500);
     expect(formatted.exhaustionReason).toBeUndefined();
     expect(formatted.userRetryable).toBe(true);
   });


### PR DESCRIPTION
## Summary

- infer HTTP 500 from status-less provider errors whose raw body reports `server_error`
- route those transient OpenAI failures through the normal retry path instead of terminating the tool-use turn
- keep unknown status-less API errors non-retryable
- add normalization and retry-gate regression coverage using the observed OpenAI error shape

## Root cause

OpenAI can return a generic SDK `APIError` without an HTTP status while retaining this raw body shape:

```json
{
  "type": "server_error",
  "code": "server_error",
  "message": "An error occurred while processing your request...",
  "param": null
}
```

TeXRA tagged the value as a known OpenAI `api_error`, but raw-body status inference only recognized the existing Anthropic type values. The known-SDK-error branch therefore classified the error as `userRetryable: false`, logged `Tool-use call failed (no retry available)`, and ended the turn.

## Verification

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/common/SdkErrorUtils.vitest.mts src/test-kernel/agent/runtime/RetryState.vitest.ts` — 71 tests passed
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json`
- `corepack pnpm --filter texra typecheck`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared error classification used for auto-retry and user-facing retry affordances across providers; scope is narrow but affects agent failure handling on the hot path.
> 
> **Overview**
> **Provider raw-body status inference** now maps `server_error` (via `type` or `code`) to HTTP **500**, and walks both nested `error` objects and the top-level body instead of only Anthropic `type` strings. That recovers a status when the SDK drops HTTP metadata on generic `APIError` instances.
> 
> **Retry and formatting behavior** for those failures now follows the normal **retryable 5xx** path (`userRetryable`, flow auto-retry, terminal background responses) instead of treating them as non-retryable status-less API errors. Unmapped status-less shapes (e.g. `unexpected_error`) stay **non-retryable**.
> 
> Regression tests cover the observed OpenAI body shape, background terminal failures, and `RetryState.shouldAutoRetry`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca089498bda0548633a42c8989355542d1717669. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->