### PR TITLE
fix(cli): surface onboarding access route

### DIFF
--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -26,7 +26,6 @@ import { SlashPalette, slashPaletteOwnsArrows } from '../commands/SlashPalette';
 import { COLOR_BORDER, COLOR_HINT } from '../ui/colors';
 import { POINTER } from '../ui/glyphs';
 import {
-  findSlashCommand,
   matchSlashCommands,
   parseSlashInput,
   prefixSlashCommands,

--- a/packages/cli/src/onboarding/onboardingState.ts
+++ b/packages/cli/src/onboarding/onboardingState.ts
@@ -8,6 +8,8 @@ import {
   apiKeySecretName,
   type ApiProvider,
 } from '@model/apiProviders';
+import { PROVIDER_DISPLAY_NAMES } from '@shared/constants/providers';
+import type { CliModelAccessSelectionResult } from '../runtime/modelAccessSelection';
 
 /**
  * Human-facing "we stored your key here" line. Naming the exact secret entry
@@ -16,4 +18,13 @@ import {
  */
 export function describeSavedKeyLocation(provider: ApiProvider): string {
   return `Stored in TeXRA secrets as \`${apiKeySecretName(provider)}\` (or set ${apiKeyEnvName(provider)} in your environment).`;
+}
+
+export function formatSavedKeySummary(
+  provider: ApiProvider,
+  selection: CliModelAccessSelectionResult,
+): string {
+  return `Saved your ${
+    PROVIDER_DISPLAY_NAMES[provider] ?? provider
+  } API key. ${describeSavedKeyLocation(provider)} ${selection.message}`;
 }

--- a/packages/cli/src/onboarding/runOnboarding.tsx
+++ b/packages/cli/src/onboarding/runOnboarding.tsx
@@ -69,7 +69,7 @@ import {
 } from '../runtime/supabaseAuthDeviceCode';
 import { interactiveTerminalFailure } from '../runtime/terminalRequirements';
 
-import { describeSavedKeyLocation } from './onboardingState';
+import { formatSavedKeySummary } from './onboardingState';
 
 export interface CliOnboardingResult {
   /**
@@ -406,14 +406,11 @@ function OnboardingApp(props: OnboardingAppProps): React.JSX.Element {
           void (async () => {
             try {
               await saveProviderApiKey(keyProvider, key);
-              await selectCliApiModelAccessRoute('personal');
-              const where = describeSavedKeyLocation(keyProvider);
+              const selection = await selectCliApiModelAccessRoute('personal');
               finish({
                 configured: true,
                 declined: false,
-                summary: `Saved your ${
-                  PROVIDER_DISPLAY_NAMES[keyProvider] ?? keyProvider
-                } API key. ${where}`,
+                summary: formatSavedKeySummary(keyProvider, selection),
               });
             } catch (saveError: unknown) {
               setSaving(false);

--- a/src/test-kernel/cli/OnboardingFlow.vitest.mts
+++ b/src/test-kernel/cli/OnboardingFlow.vitest.mts
@@ -1,0 +1,188 @@
+import { Console } from 'node:console';
+import { EventEmitter } from 'node:events';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  selectCliApiModelAccessRoute: vi.fn(),
+  saveProviderApiKey: vi.fn(),
+  writeTextStderr: vi.fn(),
+  writeTextStdout: vi.fn(),
+  state: new Map<string, unknown>(),
+}));
+
+vi.mock('@cli/runtime/modelAccessSelection', () => ({
+  selectCliApiModelAccessRoute: mocks.selectCliApiModelAccessRoute,
+}));
+
+vi.mock('@cli/runtime/providerApiKey', () => ({
+  saveProviderApiKey: mocks.saveProviderApiKey,
+}));
+
+vi.mock('@cli/runtime/logSinks', () => ({
+  writeTextStderr: mocks.writeTextStderr,
+  writeTextStdout: mocks.writeTextStdout,
+}));
+
+vi.mock('@platform/platform', () => ({
+  platform: () => ({
+    globalState: {
+      get: (key: string, defaultValue?: unknown) =>
+        mocks.state.has(key) ? mocks.state.get(key) : defaultValue,
+      update: async (key: string, value: unknown) => {
+        mocks.state.set(key, value);
+      },
+    },
+  }),
+}));
+
+class FakeOutput extends EventEmitter {
+  readonly isTTY = true;
+  readonly columns = 100;
+  readonly rows = 30;
+  readonly fd = 1;
+  readonly destroyed = false;
+  output = '';
+
+  write(chunk: string | Uint8Array, ...args: unknown[]): boolean {
+    this.output += Buffer.isBuffer(chunk)
+      ? chunk.toString('utf8')
+      : String(chunk);
+    const callback = args.findLast(
+      (arg): arg is () => void => typeof arg === 'function',
+    );
+    callback?.();
+    return true;
+  }
+
+  getColorDepth(): number {
+    return 24;
+  }
+}
+
+class FakeInput extends EventEmitter {
+  readonly isTTY = true;
+  readonly fd = 0;
+  private readonly chunks: string[] = [];
+
+  write(chunk: string): void {
+    this.chunks.push(chunk);
+    this.emit('readable');
+  }
+
+  read(): string | null {
+    return this.chunks.shift() ?? null;
+  }
+
+  ref(): void {}
+  unref(): void {}
+  pause(): this {
+    return this;
+  }
+  resume(): this {
+    return this;
+  }
+  setEncoding(): this {
+    return this;
+  }
+  setRawMode(): this {
+    return this;
+  }
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error('Timed out waiting for onboarding interaction');
+}
+
+const originalStdin = Object.getOwnPropertyDescriptor(process, 'stdin');
+const originalStdout = Object.getOwnPropertyDescriptor(process, 'stdout');
+const originalStderr = Object.getOwnPropertyDescriptor(process, 'stderr');
+const originalConsoleConstructor = Object.getOwnPropertyDescriptor(
+  console,
+  'Console',
+);
+
+function restoreProcessStream(
+  name: 'stdin' | 'stdout' | 'stderr',
+  descriptor: PropertyDescriptor | undefined,
+): void {
+  if (descriptor) Object.defineProperty(process, name, descriptor);
+}
+
+beforeEach(() => {
+  mocks.state.clear();
+  mocks.saveProviderApiKey.mockReset().mockResolvedValue(undefined);
+  mocks.selectCliApiModelAccessRoute.mockReset();
+  mocks.writeTextStderr.mockReset();
+  mocks.writeTextStdout.mockReset();
+});
+
+afterEach(() => {
+  restoreProcessStream('stdin', originalStdin);
+  restoreProcessStream('stdout', originalStdout);
+  restoreProcessStream('stderr', originalStderr);
+  if (originalConsoleConstructor) {
+    Object.defineProperty(console, 'Console', originalConsoleConstructor);
+  } else {
+    Reflect.deleteProperty(console, 'Console');
+  }
+});
+
+describe('provider-key onboarding flow', () => {
+  it('emits the access-route warning returned after the submitted key without exposing the key', async () => {
+    const warning =
+      'DISTINCTIVE OVERRIDE: workspace policy keeps ChatGPT subscription active.';
+    const providerKey = 'sk-ant-integration-secret';
+    mocks.selectCliApiModelAccessRoute.mockResolvedValue({
+      apiMode: 'personal',
+      message: warning,
+    });
+
+    Object.defineProperty(console, 'Console', {
+      value: Console,
+      configurable: true,
+    });
+    const stdin = new FakeInput();
+    const stdout = new FakeOutput();
+    const stderr = new FakeOutput();
+    Object.defineProperties(process, {
+      stdin: { value: stdin, configurable: true },
+      stdout: { value: stdout, configurable: true },
+      stderr: { value: stderr, configurable: true },
+    });
+
+    const { runCliOnboarding } = await import('@cli/onboarding/runOnboarding');
+    const resultPromise = runCliOnboarding(false);
+
+    await waitFor(() => stdin.listenerCount('readable') > 0);
+    stdin.write('3');
+    await waitFor(() => stdout.output.includes('Choose your provider:'));
+    stdin.write('\r');
+    await waitFor(() => stdout.output.includes('enter your API key (hidden)'));
+    stdin.write(providerKey);
+    await waitFor(() => stdout.output.includes('•'));
+    stdin.write('\r');
+
+    await expect(resultPromise).resolves.toEqual({
+      configured: true,
+      declined: false,
+    });
+    expect(mocks.saveProviderApiKey).toHaveBeenCalledWith(
+      'anthropic',
+      providerKey,
+    );
+    expect(mocks.selectCliApiModelAccessRoute).toHaveBeenCalledWith('personal');
+    expect(mocks.writeTextStdout).toHaveBeenCalledWith(
+      'Saved your Anthropic API key. Stored in TeXRA secrets as `apiKey.anthropic` (or set ANTHROPIC_API_KEY in your environment). ' +
+        warning,
+    );
+    expect(mocks.writeTextStdout).not.toHaveBeenCalledWith(
+      expect.stringContaining(providerKey),
+    );
+    expect(stdout.output).not.toContain(providerKey);
+  });
+});

--- a/src/test-kernel/cli/OnboardingState.vitest.mts
+++ b/src/test-kernel/cli/OnboardingState.vitest.mts
@@ -3,7 +3,10 @@ import { describe, expect, it, vi } from 'vitest';
 import { maskDisplayValue } from '@cli/chat/tui/input/textInputEditing';
 import { formatApiKeyShadowWarning } from '@cli/runtime/apiStatus';
 import { maybeRunCliOnboarding } from '@cli/onboarding/runOnboarding';
-import { describeSavedKeyLocation } from '@cli/onboarding/onboardingState';
+import {
+  describeSavedKeyLocation,
+  formatSavedKeySummary,
+} from '@cli/onboarding/onboardingState';
 import {
   getOnboardingDeclined,
   setOnboardingDeclined,
@@ -48,11 +51,37 @@ describe('onboarding decline flag', () => {
   });
 });
 
-describe('describeSavedKeyLocation', () => {
+describe('saved key summary', () => {
   it('names the exact secret entry and env-var fallback', () => {
     const message = describeSavedKeyLocation('anthropic');
     expect(message).toContain('apiKey.anthropic');
     expect(message).toContain('ANTHROPIC_API_KEY');
+  });
+
+  it('surfaces the access-route warning when ChatGPT remains active', () => {
+    const warning =
+      'Model access remains on ChatGPT subscription because a more specific setting overrides workspace config.';
+
+    expect(
+      formatSavedKeySummary('anthropic', {
+        apiMode: 'personal',
+        message: warning,
+      }),
+    ).toBe(
+      'Saved your Anthropic API key. Stored in TeXRA secrets as `apiKey.anthropic` (or set ANTHROPIC_API_KEY in your environment). ' +
+        warning,
+    );
+  });
+
+  it('confirms the normal personal-key access route', () => {
+    expect(
+      formatSavedKeySummary('anthropic', {
+        apiMode: 'personal',
+        message: 'Model access: Personal API keys.',
+      }),
+    ).toBe(
+      'Saved your Anthropic API key. Stored in TeXRA secrets as `apiKey.anthropic` (or set ANTHROPIC_API_KEY in your environment). Model access: Personal API keys.',
+    );
   });
 });
 


### PR DESCRIPTION
Follow-up to #8710 after the original PR was merged while final review feedback was still being addressed.

- surfaces the canonical model-access selection message after saving a provider key during onboarding
- preserves warnings when a more-specific ChatGPT preference remains active
- removes the stale `findSlashCommand` import
- adds an end-to-end Ink onboarding test proving the warning propagates and the submitted key is absent from output

Verification:
- 27 focused tests passed
- CLI and test-kernel type checks passed
- CLI architecture check passed
- scoped lint/format checks passed
- independent re-review found no remaining issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding messaging and test-only changes; no auth or credential storage logic changes beyond surfacing an existing selection result.
> 
> **Overview**
> After a user saves a provider API key during CLI onboarding, the success line now includes the **canonical model-access message** from `selectCliApiModelAccessRoute('personal')`—including warnings when ChatGPT subscription stays active due to a more specific override.
> 
> That text is centralized in **`formatSavedKeySummary`** in `onboardingState.ts` (provider label, secret/env hint, plus `selection.message`). **`InputBar`** drops an unused **`findSlashCommand`** import.
> 
> New coverage: unit tests for the summary formatter and an Ink **end-to-end** onboarding test that asserts the warning appears on stdout and the submitted key never does.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21f9734dcef9fe382cc889b9345ae5b2f7bff314. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->