### PR TITLE
fix(cli): keep TTY onboarding interactive in CI

### DIFF
--- a/packages/cli/src/onboarding/runOnboarding.tsx
+++ b/packages/cli/src/onboarding/runOnboarding.tsx
@@ -219,6 +219,10 @@ async function runOnboardingFlow(options: {
         onResolve={record}
       />,
       {
+        // Both callers reject non-TTY output before reaching this flow. Keep
+        // that product boundary authoritative when a real PTY also has CI set;
+        // Ink otherwise disables interactive rendering from its CI heuristic.
+        interactive: true,
         stdout: tuiOutputStreamForColor(
           process.stdout,
           options.colorEnabled ?? true,

--- a/src/test-kernel/cli/OnboardingFlow.vitest.mts
+++ b/src/test-kernel/cli/OnboardingFlow.vitest.mts
@@ -185,5 +185,5 @@ describe('provider-key onboarding flow', () => {
       expect.stringContaining(providerKey),
     );
     expect(stdout.output).not.toContain(providerKey);
-  });
+  }, 30_000);
 });

--- a/src/test-kernel/cli/OnboardingFlow.vitest.mts
+++ b/src/test-kernel/cli/OnboardingFlow.vitest.mts
@@ -91,9 +91,10 @@ class FakeInput extends EventEmitter {
 }
 
 async function waitFor(predicate: () => boolean): Promise<void> {
-  for (let attempt = 0; attempt < 200; attempt += 1) {
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
     if (predicate()) return;
-    await new Promise((resolve) => setTimeout(resolve, 5));
+    await new Promise((resolve) => setTimeout(resolve, 10));
   }
   throw new Error('Timed out waiting for onboarding interaction');
 }

--- a/src/test-kernel/cli/OnboardingFlow.vitest.mts
+++ b/src/test-kernel/cli/OnboardingFlow.vitest.mts
@@ -159,7 +159,14 @@ describe('provider-key onboarding flow', () => {
     const { runCliOnboarding } = await import('@cli/onboarding/runOnboarding');
     const resultPromise = runCliOnboarding(false);
 
-    await waitFor(() => stdin.listenerCount('readable') > 0);
+    // Ink attaches its input stream before the active Select handler has
+    // necessarily committed. Wait for both input attachment and the rendered
+    // picker so the shortcut cannot be discarded during a loaded CI run.
+    await waitFor(
+      () =>
+        stdin.listenerCount('readable') > 0 &&
+        stdout.output.includes('Choose how to power model calls'),
+    );
     stdin.write('3');
     await waitFor(() => stdout.output.includes('Choose your provider:'));
     stdin.write('\r');


### PR DESCRIPTION
## Summary

The provider-key onboarding integration test exposed two independent timing assumptions:

1. Ink treats every process with `CI` set as non-interactive unless the caller explicitly overrides it, even when the supplied streams are TTYs. The onboarding entry points already reject non-TTY use, so the render call now makes that established product decision explicit.
2. Ink can attach its input stream before the picker’s active `Select` handler has committed. The test now waits for both the listener and the rendered picker before sending the shortcut.

The wait helper also uses a wall-clock deadline, and the test timeout is long enough to report its own interaction failure under a loaded runner.

Follow-up to #8718.

## Issue acceptance gates

- Provider-key onboarding renders and accepts input when `CI` is set and the supplied streams are TTYs.
- The integration test waits for committed UI state before sending each input.
- The secret key remains masked and absent from output.
- The access-route warning returned after the key is saved remains visible.

## Single source of truth

The existing onboarding TTY guards decide whether this flow is interactive. The Ink render call now carries that decision explicitly instead of allowing Ink’s separate CI heuristic to override it.

## Duplication and abstraction budget

No helper or product state was added. The production change is one render option; the test uses its existing output buffer as the readiness signal.

## Net elements (R6)

- Files: 0 added, 0 deleted, 2 modified.
- Exported declarations, classes, interfaces, and enums: 0 added, 0 deleted.
- Lines: 16 inserted, 4 deleted; net +12.

## Consumer counts (R8)

n/a. No export, event, or subscription path is deleted or rerouted.

## Host impact

Extension: None.

Desktop: None.

CLI: Onboarding remains interactive in a real TTY even when the process also has `CI` set.

## Scheduled refactoring

None.

## Validation

- `npm run format` (commit hook)
- `npm run typecheck`
- Scoped ESLint and Prettier checks
- Onboarding integration test under `CI=true`: passed once normally and four times concurrently
- `git diff --check`
- Full GitHub CI pending on the updated commit
