### PR TITLE
fix(runtime): restart retained child stream status

### DIFF
--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -33,6 +33,7 @@ import {
 import {
   isActivePhase,
   isInFlightPhase,
+  isTerminalOutcomePhase,
   projectRunOutcome,
 } from '@shared/streams/streamStatus';
 import { formatDuration } from '@utils/core';
@@ -295,10 +296,16 @@ export class ExecutionRegistry {
     options: TrackAgentExecutionOptions = {},
   ): void {
     if (options.status) {
+      const previousStatus = this.streamStatus.get(handle.childStreamId);
+      const cause =
+        options.status === STREAM_PHASE.RUNNING &&
+        isTerminalOutcomePhase(previousStatus)
+          ? 'resume'
+          : 'lifecycle';
       this.streamStatus.transition(
         handle.childStreamId,
         options.status,
-        'lifecycle',
+        cause,
         this.streamStatusEmitOptions(handle),
       );
     }

--- a/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
@@ -19,6 +19,7 @@ import {
   type ExecutionId,
   type StreamTabId,
 } from '@shared/schemas';
+import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
 import { createChildStream } from '@tools/childStream';
 import {
   createRecordingHost,
@@ -44,6 +45,8 @@ const normalizedErrorExecutionId = 'c11117' as ExecutionId;
 const normalizedErrorChildStreamId = 'codex#c11117' as StreamTabId;
 const noProjectionAutoCloseExecutionId = 'c11118' as ExecutionId;
 const noProjectionAutoCloseChildStreamId = 'bash#c11118' as StreamTabId;
+const workflowRelaunchExecutionId = 'c11119' as ExecutionId;
+const workflowRelaunchChildStreamId = 'workflow-script#c11119' as StreamTabId;
 const config = {
   agentCategory: AgentCategory.ToolUse,
   model: 'test-model',
@@ -92,6 +95,7 @@ describe('child stream progress events', () => {
       failedChildStreamId,
       normalizedErrorChildStreamId,
       noProjectionAutoCloseChildStreamId,
+      workflowRelaunchChildStreamId,
     ]) {
       clearStreamStatusForTest(defaultSession().status, streamId);
     }
@@ -238,6 +242,66 @@ describe('child stream progress events', () => {
         streamId: childStreamId,
       });
     } finally {
+      recorded.detach();
+    }
+  });
+
+  it('marks a deterministic child-stream relaunch as running', async () => {
+    const active = createRecordingHost();
+    const firstRun = withSessionEventRecording(() =>
+      createChildStream(workflowRelaunchExecutionId, parentStreamId, {
+        runtimeHost: active.host,
+        streamPrefix: 'workflow-script',
+        streamCategory: AgentCategory.Workflow,
+        agentName: 'draft-sections',
+        description: 'Run a named child task',
+        config,
+        toolName: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+      }),
+    );
+    await withSessionEventRecording(() => firstRun.finalize());
+    expect(defaultSession().status.get(workflowRelaunchChildStreamId)).toBe(
+      STREAM_PHASE.COMPLETED,
+    );
+
+    const recorded = recordSessionEvents(defaultSession().events);
+    const relaunched = createChildStream(
+      workflowRelaunchExecutionId,
+      parentStreamId,
+      {
+        runtimeHost: active.host,
+        streamPrefix: 'workflow-script',
+        streamCategory: AgentCategory.Workflow,
+        agentName: 'draft-sections',
+        description: 'Resume the named child task',
+        config,
+        toolName: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+      },
+    );
+
+    try {
+      expect(defaultSession().status.get(workflowRelaunchChildStreamId)).toBe(
+        STREAM_PHASE.RUNNING,
+      );
+      expect(
+        defaultSession().executions.getActiveChildren(parentStreamId).subagents,
+      ).toContainEqual(
+        expect.objectContaining({
+          childStreamId: workflowRelaunchChildStreamId,
+          executionId: workflowRelaunchExecutionId,
+          status: STREAM_PHASE.RUNNING,
+        }),
+      );
+      expect(runEventsOfType(recorded.events, 'status')).toContainEqual(
+        expect.objectContaining({
+          cause: 'resume',
+          phase: STREAM_PHASE.RUNNING,
+          previousPhase: STREAM_PHASE.COMPLETED,
+          streamId: workflowRelaunchChildStreamId,
+        }),
+      );
+    } finally {
+      await relaunched.finalize();
       recorded.detach();
     }
   });


### PR DESCRIPTION
## Summary

Named workflow-script relaunches deliberately reuse their execution and child-stream identifiers. The preceding run leaves a terminal phase in the session status table, so the new handle's former lifecycle transition to `running` was rejected and callers could observe the preceding result while the relaunched workflow was active.

`ExecutionRegistry` now classifies an initial `running` status as a resume when the retained stream phase is terminal. This keeps the transition rule in the registry that already owns initial handle status, and it applies to any deterministic child relaunch.

Closes #8719.

## Issue acceptance gates

- A workflow-script child can be finalized and relaunched with the same execution identifier.
- The retained stream changes from `completed` to `running` for the second handle.
- The published status event records cause `resume` and the preceding terminal phase.
- The active-child roster reports the new run as active rather than returning the preceding terminal result.

## Single source of truth

`ExecutionRegistry.trackAgentExecution` remains the owner of the initial stream-status transition for a newly tracked agent handle. It derives the transition cause from the existing `StreamStatusMachine` phase and the requested initial phase.

## Duplication and abstraction budget

No workflow-specific status write, option, or wrapper was added. The fix adds one cause derivation at the existing registry boundary and one regression test through `createChildStream`.

## Net elements (R6)

- Files: 0 added, 0 deleted, 2 modified.
- Exported declarations, classes, interfaces, and enums: 0 added, 0 deleted.
- Lines: 72 inserted, 1 deleted; net +71, of which 64 lines are the end-to-end regression test.

## Consumer counts (R8)

n/a. No export or event subscription is deleted or rerouted. The existing status transition call remains in place and now chooses its cause from retained state.

## Host impact

Extension: Relaunched deterministic child executions report their current running phase.

Desktop: Relaunched deterministic child executions report their current running phase.

CLI: `executions view` and `executions wait` no longer see the preceding terminal phase while a named workflow-script relaunch is active.

## Scheduled refactoring

None.

## Validation

- `npm run format` (commit hook)
- `npm run typecheck`
- `npm run lint` (passes with one pre-existing warning in `AgentCreatorToolCatalogParity.vitest.mts`)
- `npm run compile:fast`
- Focused runtime suites: 42 tests passed
- Isolated `SystemUtils.vitest.ts`: 18 tests passed
- `git diff --check`
- `npm test` did not complete cleanly in the local environment. The first run passed 6773 tests and failed only the unrelated process-group PID assertion, which passed immediately when rerun in isolation. A second run was stopped after the known onboarding failure from #8720 and several unrelated tests exceeded the shared 10-second timeout. CI is required for the full-suite result.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to initial status transition cause derivation in the execution registry, with a focused regression test and no new public APIs.
> 
> **Overview**
> Deterministic child-stream relaunches (e.g. named **workflow-script** runs that reuse the same execution and stream IDs) could leave the session status stuck on the **previous terminal phase** because `trackAgentExecution` always published initial `running` with cause `lifecycle`, which the status machine rejects from `completed`/`failed`/`cancelled`.
> 
> **`ExecutionRegistry.trackAgentExecution`** now reads the retained phase for that stream and, when the requested initial phase is `running` and the prior phase is terminal, uses transition cause **`resume`** instead of **`lifecycle`**. Status events then record `resume` with the prior terminal phase, and active-child rosters reflect the new run as in flight.
> 
> An end-to-end regression test covers finalize-then-relaunch via `createChildStream` for workflow-script delegation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16a66d068d3f731081da297f8259e6b7561fa388. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->