### PR TITLE
refactor(cli): remove duplicate color context state

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -25,11 +25,7 @@ import {
   wakeQueuedFollowUpStream,
 } from '@agent/followUp/ToolUseFollowUp';
 import { setCliAgentResumeHandler } from '@cli/runtime/agentResume';
-import {
-  type CliContext,
-  readCliVersion,
-  resolveCliStdoutColorEnabled,
-} from '@cli/runtime/cliContext';
+import { type CliContext, readCliVersion } from '@cli/runtime/cliContext';
 import { type CliToolUseResumeResolution } from '@cli/runtime/sessionResume';
 import { effectiveCliApiMode } from '@cli/runtime/apiAccessMode';
 import { firstRunSetupAgentOverride } from '@cli/onboarding/setupContinuation';
@@ -812,7 +808,7 @@ export async function runChat(
     });
   };
 
-  const stdoutColorEnabled = resolveCliStdoutColorEnabled(context) ?? true;
+  const stdoutColorEnabled = context.stdoutColorEnabled;
   const inkRef: { current?: InkInstance } = {};
   const viewportController = createTuiViewportController(inkRef);
   const ink = render(

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -44,11 +44,7 @@ import { GLOBAL_ARGS, optString } from './_helpers/globalArgs';
 import { emitCliResult } from './_helpers/output';
 import { chatgptAuthCommand } from './chatgptAuth';
 import { authTokenCommand } from './relayTokens';
-import {
-  CliUsageError,
-  resolveCliStdoutColorEnabled,
-  type CliContext,
-} from '../runtime/cliContext';
+import { CliUsageError, type CliContext } from '../runtime/cliContext';
 
 interface LoginCommandArgs {
   readonly provider?: string;
@@ -253,9 +249,7 @@ export async function runLoginCommand(
   }
 
   const { promptForLoginProvider } = await import('./loginProviderPicker');
-  const choice = await promptForLoginProvider(
-    resolveCliStdoutColorEnabled(context),
-  );
+  const choice = await promptForLoginProvider(context.stdoutColorEnabled);
   if (!choice) {
     writeTextStderr('Cancelled. No sign-in started.');
     return CliExitCode.Success;

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -8,7 +8,6 @@ import { CLI_STATE_SETTINGS } from '@shared/schemas/stateSettings';
 import {
   CliUsageError,
   readCliAmbientState,
-  resolveCliStdoutColorEnabled,
   type CliContext,
 } from '../runtime/cliContext';
 import {
@@ -250,7 +249,7 @@ const configEditCommand = defineCliCommand({
     await initLocalCliPlatform(context);
     const { runConfigTui } = await import('../config/runConfigTui');
     await runConfigTui({
-      colorEnabled: resolveCliStdoutColorEnabled(context),
+      colorEnabled: context.stdoutColorEnabled,
       onError: writeErrorStderr,
     });
     return CliExitCode.Success;

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -29,10 +29,7 @@ import {
 import { defineCliCommand } from './_helpers/defineCliCommand';
 import { emitCliResult } from './_helpers/output';
 import { GLOBAL_ARGS } from './_helpers/globalArgs';
-import {
-  resolveCliStdoutColorEnabled,
-  type CliContext,
-} from '../runtime/cliContext';
+import { type CliContext } from '../runtime/cliContext';
 
 interface InitAgentOption {
   readonly name: string;
@@ -206,7 +203,7 @@ async function runInit(
     const result = await runInitWizard({
       agents,
       models,
-      colorEnabled: resolveCliStdoutColorEnabled(context),
+      colorEnabled: context.stdoutColorEnabled,
     });
     if (!result) {
       writeTextStderr('Cancelled. No config written.');

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -71,10 +71,7 @@ import {
   rejectHeadlessOnlyFlags,
 } from './_helpers/globalArgs';
 import { runResumeExecution } from '../runtime/resumeExecution';
-import {
-  resolveCliStdoutColorEnabled,
-  type CliContext,
-} from '../runtime/cliContext';
+import { type CliContext } from '../runtime/cliContext';
 
 async function canLaunchWithDefaultModel(
   context: CliContext,
@@ -235,7 +232,7 @@ async function runOrchestration(context: CliContext): Promise<number> {
       version: context.version,
       statusLines,
       allowDefaultModelLaunch,
-      colorEnabled: resolveCliStdoutColorEnabled(context),
+      colorEnabled: context.stdoutColorEnabled,
     });
 
     switch (action.kind) {
@@ -334,7 +331,7 @@ async function runOrchestration(context: CliContext): Promise<number> {
       case 'configure-settings': {
         const { runConfigTui } = await import('../config/runConfigTui');
         await runConfigTui({
-          colorEnabled: resolveCliStdoutColorEnabled(context),
+          colorEnabled: context.stdoutColorEnabled,
           onError: writeErrorStderr,
         });
         continue launcher;

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -18,10 +18,7 @@ import {
   INTERACTIVE_GLOBAL_ARGS,
   rejectHeadlessOnlyFlags,
 } from './_helpers/globalArgs';
-import {
-  resolveCliStdoutColorEnabled,
-  type CliContext,
-} from '../runtime/cliContext';
+import { type CliContext } from '../runtime/cliContext';
 
 /** Exported for the test kernel — the command's `run` is the only other caller. */
 export async function runSetup(context: CliContext): Promise<number> {
@@ -48,9 +45,7 @@ export async function runSetup(context: CliContext): Promise<number> {
   // `texra login`'s job under the new vocabulary.
   if (!(await hasCliCredentialForApiMode(undefined).catch(() => false))) {
     const { runCliOnboarding } = await import('../onboarding/runOnboarding');
-    const result = await runCliOnboarding(
-      resolveCliStdoutColorEnabled(context),
-    );
+    const result = await runCliOnboarding(context.stdoutColorEnabled);
     // Skipped or abandoned the picker: exit cleanly (the skip summary already
     // printed) — there is no credential for the setup agent to run on.
     if (!result.configured) return CliExitCode.Success;

--- a/packages/cli/src/onboarding/runOnboarding.tsx
+++ b/packages/cli/src/onboarding/runOnboarding.tsx
@@ -50,7 +50,6 @@ import { KeyHints, type KeyHint } from '../chat/tui/ui/KeyHints';
 import { Select, type SelectItem } from '../chat/tui/ui/Select';
 import { type CliApiMode } from '../runtime/apiAccessMode';
 import { chatGptAccountLabel, signInCliChatGpt } from '../runtime/chatgptLogin';
-import { resolveCliStdoutColorEnabled } from '../runtime/cliContext';
 import { hasCliCredentialForApiMode } from '../runtime/credentialStatus';
 import { selectCliApiModelAccessRoute } from '../runtime/modelAccessSelection';
 import { saveProviderApiKey } from '../runtime/providerApiKey';
@@ -91,7 +90,6 @@ export interface OnboardingGateContext {
   readonly stdoutIsTty?: boolean;
   readonly termIsDumb?: boolean;
   readonly stdoutColorEnabled?: boolean;
-  readonly colorEnabled?: boolean;
   readonly apiMode?: CliApiMode;
 }
 
@@ -182,7 +180,7 @@ export async function maybeRunCliOnboarding(
   return runOnboardingFlow({
     firstRun: true,
     apiMode: context.apiMode,
-    colorEnabled: resolveCliStdoutColorEnabled(context),
+    colorEnabled: context.stdoutColorEnabled,
   });
 }
 

--- a/packages/cli/src/runtime/cliContext.ts
+++ b/packages/cli/src/runtime/cliContext.ts
@@ -52,8 +52,6 @@ export interface CliContext {
   readonly stdoutColorEnabled: boolean;
   /** Color allowed when writing to stderr. */
   readonly stderrColorEnabled: boolean;
-  /** Back-compat alias for `stderrColorEnabled`. */
-  readonly colorEnabled: boolean;
   readonly commandName: string;
   readonly version: string;
   readonly resourcesPath: string;
@@ -73,23 +71,6 @@ export class CliUsageError extends Error {
   }
 }
 
-/**
- * Resolves the color-enabled decision for stdout-bound output.
- *
- * `colorEnabled` is documented on `CliContext` as a back-compat alias for
- * `stderrColorEnabled`, but every CLI entry point already reused it as the
- * pre-stdout/stderr-split generic fallback for stdout too — this centralizes
- * that existing behavior rather than introducing it. Takes a structural pick
- * (not the full `CliContext`) so narrower "minimal slice" contexts, like
- * `OnboardingGateContext`, can share the helper.
- */
-export function resolveCliStdoutColorEnabled(context: {
-  readonly stdoutColorEnabled?: boolean;
-  readonly colorEnabled?: boolean;
-}): boolean | undefined {
-  return context.stdoutColorEnabled ?? context.colorEnabled;
-}
-
 export interface CliAmbientState {
   readonly isCi: boolean;
   readonly stdinIsTty: boolean;
@@ -100,8 +81,6 @@ export interface CliAmbientState {
   readonly stdoutColorEnabled: boolean;
   /** Color is allowed on stderr. */
   readonly stderrColorEnabled: boolean;
-  /** Back-compat alias for `stderrColorEnabled`. */
-  readonly colorEnabled: boolean;
 }
 
 /**
@@ -163,7 +142,6 @@ export function readCliAmbientState(): CliAmbientState {
     termIsDumb: dumbTerm,
     stdoutColorEnabled,
     stderrColorEnabled,
-    colorEnabled: stderrColorEnabled,
   };
   return cachedAmbient;
 }
@@ -473,7 +451,6 @@ export async function buildCliContext(
     stderrIsTty: ambient.stderrIsTty,
     stdoutColorEnabled,
     stderrColorEnabled,
-    colorEnabled: stderrColorEnabled,
     commandName: resolveCliCommandName(readCliEntrypointPath()),
     version: await readCliVersion(),
     resourcesPath: resolveCliResourcesPath(),

--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -75,7 +75,9 @@ export function shouldRenderRunProgress(
 
 export function createRunProgressRenderer(
   context: CliContext,
-  init: RunProgressRendererInit = { colorEnabled: context.colorEnabled },
+  init: RunProgressRendererInit = {
+    colorEnabled: context.stderrColorEnabled,
+  },
 ): RunProgressRenderer | undefined {
   if (context.renderRunProgress !== true) return undefined;
   return new DefaultRunProgressRenderer(init);

--- a/packages/cli/src/runtime/style.ts
+++ b/packages/cli/src/runtime/style.ts
@@ -6,7 +6,7 @@ import pico from 'picocolors';
  *
  * The gate is a per-stream color boolean from `CliContext`:
  * `stdoutColorEnabled` for stdout-bound output (e.g. `doctor`'s success
- * report), `stderrColorEnabled` (= `colorEnabled`) for stderr-bound output
+ * report), `stderrColorEnabled` for stderr-bound output
  * (progress, update checker). Both are computed in `readCliAmbientState`
  * honoring TTY, `NO_COLOR`,
  * `FORCE_COLOR`, `TERM=dumb`, and `--no-color`. When the gate is false,

--- a/packages/cli/src/runtime/updateChecker.ts
+++ b/packages/cli/src/runtime/updateChecker.ts
@@ -393,7 +393,7 @@ export async function notifyCliUpdate(context: CliContext): Promise<void> {
 
   const method = detectInstallMethod();
   const updateCmd = formatUpdateCommand(method);
-  const style = createCliStyle(context.colorEnabled);
+  const style = createCliStyle(context.stderrColorEnabled);
   // Runs before `initInteractiveCliPlatform`, so `platform()` isn't up yet —
   // open the same global `state.json` that `createCliStateStores` opens later
   // directly (see `cliStateStores.ts`). Failures here (e.g. an unreadable or

--- a/src/test-kernel/cli/CliContext.vitest.mts
+++ b/src/test-kernel/cli/CliContext.vitest.mts
@@ -29,7 +29,6 @@ const ambient = {
   stderrIsTty: false,
   stdoutColorEnabled: false,
   stderrColorEnabled: false,
-  colorEnabled: false,
 };
 
 function ttyAmbient(overrides: Partial<CliAmbientState> = {}): CliAmbientState {
@@ -40,7 +39,6 @@ function ttyAmbient(overrides: Partial<CliAmbientState> = {}): CliAmbientState {
     stderrIsTty: true,
     stdoutColorEnabled: true,
     stderrColorEnabled: true,
-    colorEnabled: true,
     ...overrides,
   };
 }
@@ -437,8 +435,6 @@ describe('CLI color/no-input flag wiring', () => {
     });
     expect(context.stdoutColorEnabled).toBe(true);
     expect(context.stderrColorEnabled).toBe(false);
-    // Back-compat alias still mirrors the stderr gate.
-    expect(context.colorEnabled).toBe(false);
   });
 
   it('--no-color force-disables both stream gates', async () => {
@@ -449,7 +445,6 @@ describe('CLI color/no-input flag wiring', () => {
     });
     expect(context.stdoutColorEnabled).toBe(false);
     expect(context.stderrColorEnabled).toBe(false);
-    expect(context.colorEnabled).toBe(false);
   });
 
   it('--no-input forces headless mode and defaults approval policy to never', async () => {

--- a/src/test-kernel/cli/Doctor.vitest.mts
+++ b/src/test-kernel/cli/Doctor.vitest.mts
@@ -316,7 +316,6 @@ describe('CLI doctor', () => {
     const stdout = captureDoctorStdout(
       {
         ...context,
-        colorEnabled: true,
         stdoutIsTty: false,
         stderrIsTty: true,
         stdoutColorEnabled: false,
@@ -333,7 +332,6 @@ describe('CLI doctor', () => {
     const stdout = captureDoctorStdout(
       {
         ...context,
-        colorEnabled: false,
         stdoutIsTty: true,
         stderrIsTty: false,
         stdoutColorEnabled: true,

--- a/src/test-kernel/cli/ResumeCommand.vitest.mts
+++ b/src/test-kernel/cli/ResumeCommand.vitest.mts
@@ -43,7 +43,6 @@ function cliContext(overrides: Partial<CliContext> = {}): CliContext {
     stderrIsTty: true,
     stdoutColorEnabled: true,
     stderrColorEnabled: true,
-    colorEnabled: true,
     ...overrides,
   });
 }

--- a/src/test-kernel/cli/RunChatSignalOwnership.vitest.mts
+++ b/src/test-kernel/cli/RunChatSignalOwnership.vitest.mts
@@ -188,7 +188,6 @@ const INTERACTIVE_CONTEXT: CliContext = createTestCliContext({
   stderrIsTty: true,
   stdoutColorEnabled: false,
   stderrColorEnabled: false,
-  colorEnabled: false,
   commandName: 'texra',
   version: '0.0.0',
   resourcesPath: '/tmp/resources',

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -42,7 +42,6 @@ function context(overrides: Partial<CliContext> = {}): CliContext {
     stderrIsTty: true,
     stdoutColorEnabled: true,
     stderrColorEnabled: true,
-    colorEnabled: true,
     ...overrides,
   });
 }
@@ -445,7 +444,7 @@ describe('CLI run progress renderer', () => {
   it('summarizes multi-input workflow progress without hiding extra files', () => {
     const output = outputBuffer();
     const renderer = createRunProgressRenderer(
-      context({ colorEnabled: false }),
+      context({ stderrColorEnabled: false }),
       {
         colorEnabled: false,
         write: output.write,
@@ -469,7 +468,7 @@ describe('CLI run progress renderer', () => {
     });
     const output = outputBuffer();
     const renderer = createRunProgressRenderer(
-      context({ colorEnabled: false }),
+      context({ stderrColorEnabled: false }),
       {
         colorEnabled: false,
         write: output.write,
@@ -496,7 +495,7 @@ describe('CLI run progress renderer', () => {
     });
     const output = outputBuffer();
     const renderer = createRunProgressRenderer(
-      context({ colorEnabled: false }),
+      context({ stderrColorEnabled: false }),
       {
         colorEnabled: false,
         write: output.write,
@@ -518,7 +517,7 @@ describe('CLI run progress renderer', () => {
   it('prints phase changes on separate lines when ANSI is disabled', () => {
     const output = outputBuffer();
     const renderer = createRunProgressRenderer(
-      context({ colorEnabled: false }),
+      context({ stderrColorEnabled: false }),
       {
         colorEnabled: false,
         write: output.write,
@@ -548,7 +547,7 @@ describe('CLI run progress renderer', () => {
   it('renders the live line from direct session and run facts', () => {
     const output = outputBuffer();
     const renderer = createRunProgressRenderer(
-      context({ colorEnabled: false }),
+      context({ stderrColorEnabled: false }),
       {
         colorEnabled: false,
         write: output.write,
@@ -639,7 +638,7 @@ describe('CLI run progress renderer', () => {
   it('keeps the root run visible when child streams update progress', () => {
     const output = outputBuffer();
     const renderer = createRunProgressRenderer(
-      context({ colorEnabled: false }),
+      context({ stderrColorEnabled: false }),
       {
         colorEnabled: false,
         write: output.write,
@@ -790,7 +789,7 @@ describe('CLI run progress renderer', () => {
   it('can add typed round progress after tool-call progress claims the root stream', () => {
     const output = outputBuffer();
     const renderer = createRunProgressRenderer(
-      context({ colorEnabled: false }),
+      context({ stderrColorEnabled: false }),
       {
         colorEnabled: false,
         write: output.write,
@@ -818,7 +817,7 @@ describe('CLI run progress renderer', () => {
   it('keeps named active children visible when earlier entries are unnamed', () => {
     const output = outputBuffer();
     const renderer = createRunProgressRenderer(
-      context({ colorEnabled: false }),
+      context({ stderrColorEnabled: false }),
       {
         colorEnabled: false,
         write: output.write,
@@ -852,7 +851,7 @@ describe('CLI run progress renderer', () => {
     let now = 0;
     const output = outputBuffer();
     const renderer = createRunProgressRenderer(
-      context({ colorEnabled: false }),
+      context({ stderrColorEnabled: false }),
       {
         colorEnabled: false,
         write: output.write,
@@ -907,7 +906,7 @@ describe('CLI run progress renderer', () => {
   it('keeps interrupted terminal stream stops distinct from completion', () => {
     const output = outputBuffer();
     const renderer = createRunProgressRenderer(
-      context({ colorEnabled: false }),
+      context({ stderrColorEnabled: false }),
       {
         colorEnabled: false,
         write: output.write,
@@ -934,7 +933,7 @@ describe('CLI run progress renderer', () => {
   it('freezes on a failed terminal stream stop, same as completed/cancelled', () => {
     const output = outputBuffer();
     const renderer = createRunProgressRenderer(
-      context({ colorEnabled: false }),
+      context({ stderrColorEnabled: false }),
       {
         colorEnabled: false,
         write: output.write,
@@ -992,11 +991,16 @@ describe('CLI run progress renderer', () => {
     expect(shouldRenderRunProgress(context({ stderrIsTty: false }))).toBe(true);
   });
 
-  it('routes progress events even when ordinary CLI logs are quiet', async () => {
+  it('uses the stderr color gate when stdout alone allows color', async () => {
     const output = await captureStreamWrites(process.stderr, async () => {
       const events = new SessionEventHub();
       const host = createCliRuntimeHost(
-        context({ quietLogs: true, renderRunProgress: true }),
+        context({
+          quietLogs: true,
+          renderRunProgress: true,
+          stdoutColorEnabled: true,
+          stderrColorEnabled: false,
+        }),
       );
       const detach = host.attachRunProgressRenderer(events);
       emitWorkflowRunConfig(events);
@@ -1005,6 +1009,7 @@ describe('CLI run progress renderer', () => {
     });
 
     expect(output).toContain('polish paper.tex · 0s');
+    expect(output).not.toContain('\r\x1b[2K');
   });
 
   it('deduplicates matching run and session stream-status facts', async () => {
@@ -1012,7 +1017,7 @@ describe('CLI run progress renderer', () => {
       const events = new SessionEventHub();
       const host = createCliRuntimeHost(
         context({
-          colorEnabled: false,
+          stderrColorEnabled: false,
           quietLogs: true,
           renderRunProgress: true,
         }),
@@ -1080,7 +1085,7 @@ describe('CLI run progress renderer', () => {
         const host = createCliRuntimeHost(
           context({
             outputFormat: 'json',
-            colorEnabled: false,
+            stderrColorEnabled: false,
             renderRunProgress: true,
           }),
         );

--- a/src/test-kernel/cli/fixtures/cliContext.ts
+++ b/src/test-kernel/cli/fixtures/cliContext.ts
@@ -12,7 +12,6 @@ const BASE_CLI_CONTEXT = {
   stderrIsTty: false,
   stdoutColorEnabled: false,
   stderrColorEnabled: false,
-  colorEnabled: false,
   commandName: 'texra',
   version: '0.0.0',
   resourcesPath: '/tmp/resources',


### PR DESCRIPTION
## Summary

`CliContext` and `CliAmbientState` now store only the two independent color decisions: one for stdout and one for stderr. The ambiguous `colorEnabled` field, which exactly duplicated `stderrColorEnabled`, is removed from both context layers and from all fixtures.

Every consumer now names its destination. Interactive stdout surfaces read `stdoutColorEnabled`; the progress renderer and update notice, which write to stderr, read `stderrColorEnabled`. The compatibility helper that could silently fall back from stdout to the stderr alias is deleted.

Closes #8724.

## Issue acceptance gates

- No `colorEnabled` field remains on `CliContext` or `CliAmbientState`.
- No production read of `context.colorEnabled` or `ambient.colorEnabled` remains.
- Every context-bound color choice names stdout or stderr explicitly.
- Context fixtures carry only the two independent booleans.
- Asymmetric tests retain both directions: doctor output follows stdout when stderr differs, and default run progress follows stderr when stdout differs.
- The change removes two stored fields, one compatibility helper, and 50 net lines.

## Single source of truth

`resolveStreamColor` still owns per-stream ambient color detection. `buildCliContext` applies `--no-color` once and exposes the normalized `stdoutColorEnabled` and `stderrColorEnabled` facts. Consumers select the fact matching their output stream.

## Duplication and abstraction budget

Two synchronized alias fields and the fallback helper are deleted. No replacement abstraction, wrapper, state field, or compatibility branch is added. Narrow renderer and Ink option objects retain their local `colorEnabled` property only after the destination stream has already been selected.

## Net elements (R6)

- Files: 17 modified; none added or deleted.
- Stored fields: 2 removed (`CliContext.colorEnabled` and `CliAmbientState.colorEnabled`), none added.
- Exported symbols: 1 removed (`resolveCliStdoutColorEnabled`), none added.
- Classes/interfaces/enums: no construct added or removed; two existing interfaces each lose one field.
- LoC: +39/-89, net -50.

## Consumer counts (R8)

- `resolveCliStdoutColorEnabled`: 8 production call sites removed. Seven full `CliContext` consumers now read `stdoutColorEnabled`; the narrow onboarding gate reads its optional stdout field directly.
- `context.colorEnabled`: 2 production reads removed; both stderr writers now read `stderrColorEnabled`.
- `ambient.colorEnabled`: no downstream read existed; its stored assignment and the forwarding assignment into `CliContext` are deleted.
- No event or persistence path changes.

## Host impact

Extension: None.

Desktop: None.

CLI: No intended visual change. Color decisions are now explicitly tied to their destination stream.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck`
- `npm run lint` (passes with one unrelated pre-existing `replaceAll` warning)
- `npm run compile:fast`
- 109 focused CLI tests passed
- `npm test`: 6,773 passed, 4 skipped

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with no intended behavior change; color is now explicitly tied to stdout vs stderr, with focused tests for asymmetric stream gates.
> 
> **Overview**
> **CLI color context is split into two explicit stream gates** — `stdoutColorEnabled` and `stderrColorEnabled` — with no shared alias.
> 
> `CliContext` and `CliAmbientState` no longer store `colorEnabled` (it duplicated `stderrColorEnabled`). **`resolveCliStdoutColorEnabled` is deleted**; Ink/TUI paths (`chat`, `orchestrate`, `config edit`, `init`, login picker, onboarding) read **`context.stdoutColorEnabled`**, while stderr writers (run progress default, update checker) read **`context.stderrColorEnabled`**.
> 
> Docs and tests drop back-compat expectations; asymmetric cases stay covered (e.g. doctor follows stdout when stderr differs; run progress follows stderr when stdout alone allows color).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d55fbab75686c80531c67847e27345f4ce5ee185. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->