### PR TITLE
fix(latex): sync stale _diff cleanup between manual Accept and accept_run_files

### DIFF
--- a/packages/desktop/src/main/desktopProgressFileActions.ts
+++ b/packages/desktop/src/main/desktopProgressFileActions.ts
@@ -123,6 +123,13 @@ export class DesktopProgressFileActions {
             absolutePaths: [absolutePath],
           }),
         showInfo: (message) => this.ui.showInfoMessage(message),
+        deleteFile: async (location) => {
+          try {
+            await AbsoluteFS.delete(location.absolutePath);
+          } catch {
+            // Non-fatal: diff file may not exist or may be locked.
+          }
+        },
       },
     );
   }

--- a/packages/extension/src/commands/latex/compareCommands.ts
+++ b/packages/extension/src/commands/latex/compareCommands.ts
@@ -16,6 +16,7 @@ import { registerDiffRefresh } from '@frontend/ui/diffView';
 import {
   acceptEditedFileReplace,
   buildAcceptSuccessMessage,
+  cleanupStaleDiffFile,
   getAcceptedFileTarget,
   siblingLocation,
 } from '@latex/acceptedFileTarget';
@@ -43,6 +44,16 @@ function validateFileLocations(
     return null;
   }
   return fileToUseLocation;
+}
+
+/** Delete a workspace file, swallowing errors (already gone, locked) since
+ *  diff-file cleanup is a best-effort side effect of accepting a file. */
+async function deleteDiffFileNonFatal(location: FileLocation): Promise<void> {
+  try {
+    await FlexibleFS.delete(location);
+  } catch {
+    // Non-fatal: diff file may not exist or may be locked.
+  }
 }
 
 async function validateFilesExist(
@@ -163,6 +174,16 @@ function buildCopyTarget(
   };
 }
 
+type ReplaceOrCopyTarget = {
+  targetLocation: FileLocation;
+  targetFileName: string;
+  /** 'replace' overwrites baseLocation itself — the same target
+   *  acceptEditedFileReplace would resolve to — so it's eligible for the
+   *  same stale-diff cleanup. 'copy' leaves baseLocation untouched, so its
+   *  diff against the edited content is still meaningful and is kept. */
+  kind: 'replace' | 'copy';
+};
+
 /** Offer a quick-pick between replacing the original and saving a postfixed
  *  copy, used when run metadata is available. Returns undefined when the user
  *  cancels. */
@@ -170,24 +191,22 @@ async function pickReplaceOrCopyTarget(
   baseLocation: FileLocation,
   editedPath: string,
   copyMeta: AcceptCopyMeta,
-): Promise<
-  { targetLocation: FileLocation; targetFileName: string } | undefined
-> {
+): Promise<ReplaceOrCopyTarget | undefined> {
   const replaceTarget = getAcceptedFileTarget(baseLocation, editedPath);
   const copyTarget = buildCopyTarget(baseLocation, copyMeta);
   type AcceptItem = vscode.QuickPickItem & {
-    target: { targetLocation: FileLocation; targetFileName: string };
+    target: ReplaceOrCopyTarget;
   };
   const acceptItems: AcceptItem[] = [
     {
       label: '$(replace) Replace original',
       description: replaceTarget.targetFileName,
-      target: replaceTarget,
+      target: { ...replaceTarget, kind: 'replace' },
     },
     {
       label: '$(files) Save as copy',
       description: copyTarget.targetFileName,
-      target: copyTarget,
+      target: { ...copyTarget, kind: 'copy' },
     },
   ];
 
@@ -242,13 +261,7 @@ async function handleAcceptEdited(
           vscode.window.showInformationMessage(message);
           logger.info(CHANNEL, message);
         },
-        deleteFile: async (location) => {
-          try {
-            await FlexibleFS.delete(location);
-          } catch {
-            // Non-fatal: diff file may not exist or may be locked.
-          }
-        },
+        deleteFile: deleteDiffFileNonFatal,
       });
     }
 
@@ -261,7 +274,7 @@ async function handleAcceptEdited(
     );
     if (!resolved) return false;
 
-    const { targetLocation, targetFileName } = resolved;
+    const { targetLocation, targetFileName, kind } = resolved;
     const targetExisted = await FlexibleFS.exists(targetLocation);
 
     const editedContent = await FlexibleFS.read(editedLocation);
@@ -271,6 +284,18 @@ async function handleAcceptEdited(
       appSignals.emit('workspaceFilesWritten', {
         absolutePaths: [targetLocation.absolutePath],
       });
+    }
+
+    // Only 'replace' overwrites the base file in place, matching the
+    // no-copyMeta path's semantics — 'copy' leaves the base (and its diff)
+    // untouched, so cleanup would delete a still-meaningful diff.
+    if (kind === 'replace') {
+      await cleanupStaleDiffFile(
+        fileToUseLocation,
+        editedLocation.absolutePath,
+        targetLocation,
+        deleteDiffFileNonFatal,
+      );
     }
 
     const successMessage = buildAcceptSuccessMessage(

--- a/packages/extension/src/commands/latex/compareCommands.ts
+++ b/packages/extension/src/commands/latex/compareCommands.ts
@@ -242,6 +242,13 @@ async function handleAcceptEdited(
           vscode.window.showInformationMessage(message);
           logger.info(CHANNEL, message);
         },
+        deleteFile: async (location) => {
+          try {
+            await FlexibleFS.delete(location);
+          } catch {
+            // Non-fatal: diff file may not exist or may be locked.
+          }
+        },
       });
     }
 

--- a/packages/extension/src/commands/latex/compareCommands.ts
+++ b/packages/extension/src/commands/latex/compareCommands.ts
@@ -177,11 +177,6 @@ function buildCopyTarget(
 type ReplaceOrCopyTarget = {
   targetLocation: FileLocation;
   targetFileName: string;
-  /** 'replace' overwrites baseLocation itself — the same target
-   *  acceptEditedFileReplace would resolve to — so it's eligible for the
-   *  same stale-diff cleanup. 'copy' leaves baseLocation untouched, so its
-   *  diff against the edited content is still meaningful and is kept. */
-  kind: 'replace' | 'copy';
 };
 
 /** Offer a quick-pick between replacing the original and saving a postfixed
@@ -201,12 +196,12 @@ async function pickReplaceOrCopyTarget(
     {
       label: '$(replace) Replace original',
       description: replaceTarget.targetFileName,
-      target: { ...replaceTarget, kind: 'replace' },
+      target: replaceTarget,
     },
     {
       label: '$(files) Save as copy',
       description: copyTarget.targetFileName,
-      target: { ...copyTarget, kind: 'copy' },
+      target: copyTarget,
     },
   ];
 
@@ -274,7 +269,7 @@ async function handleAcceptEdited(
     );
     if (!resolved) return false;
 
-    const { targetLocation, targetFileName, kind } = resolved;
+    const { targetLocation, targetFileName } = resolved;
     const targetExisted = await FlexibleFS.exists(targetLocation);
 
     const editedContent = await FlexibleFS.read(editedLocation);
@@ -286,17 +281,15 @@ async function handleAcceptEdited(
       });
     }
 
-    // Only 'replace' overwrites the base file in place, matching the
-    // no-copyMeta path's semantics — 'copy' leaves the base (and its diff)
-    // untouched, so cleanup would delete a still-meaningful diff.
-    if (kind === 'replace') {
-      await cleanupStaleDiffFile(
-        fileToUseLocation,
-        editedLocation.absolutePath,
-        targetLocation,
-        deleteDiffFileNonFatal,
-      );
-    }
+    // No-ops unless targetLocation is fileToUseLocation itself: "save as
+    // copy" and an extension-mismatched "replace" both leave the base (and
+    // its diff) untouched, so cleanup would delete a still-meaningful diff.
+    await cleanupStaleDiffFile(
+      fileToUseLocation,
+      editedLocation.absolutePath,
+      targetLocation,
+      deleteDiffFileNonFatal,
+    );
 
     const successMessage = buildAcceptSuccessMessage(
       targetFileName,

--- a/src/latex/acceptedFileTarget.ts
+++ b/src/latex/acceptedFileTarget.ts
@@ -4,6 +4,9 @@ import path from 'node:path';
 // Local imports - agent
 import { extractAgentSuffix } from '@agent/utils/mergeFileUtils';
 
+// Local imports - latex
+import { generateDiffFileName } from '@latex/latexdiff/diffFileNameManager';
+
 // Local imports - utilities
 import type { FileLocation } from '@shared/schemas';
 import {
@@ -106,6 +109,12 @@ export interface AcceptEditedFileReplacePorts {
   /** Notify the host that a workspace file was written at this absolute path. */
   emitWritten: (absolutePath: string) => void;
   showInfo: (message: string) => void | Promise<void>;
+  /**
+   * Remove the stale `_diff` companion file left over from the run that
+   * produced `editedLocation`, if any. Errors (e.g. the file was already
+   * gone) are non-fatal and should be swallowed by the port implementation.
+   */
+  deleteFile: (location: FileLocation) => Promise<void>;
 }
 
 /**
@@ -142,6 +151,8 @@ export async function acceptEditedFileReplace(
     ports.emitWritten(targetLocation.absolutePath);
   }
 
+  await ports.deleteFile(diffFileLocation(baseLocation, editedPath));
+
   await ports.showInfo(
     buildAcceptSuccessMessage(
       targetFileName,
@@ -150,6 +161,24 @@ export async function acceptEditedFileReplace(
     ),
   );
   return true;
+}
+
+/**
+ * Location of the stale `_diff` companion file that a prior latexdiff run
+ * would have generated for the `baseLocation` / `editedPath` pair, sitting
+ * beside `baseLocation`. Shared by every "accept edited content" path so the
+ * diff-naming convention (see {@link generateDiffFileName}) is computed once.
+ */
+export function diffFileLocation(
+  baseLocation: FileLocation,
+  editedPath: string,
+): FileLocation {
+  const diffFileName = generateDiffFileName(
+    baseLocation.absolutePath,
+    editedPath,
+    '_diff',
+  );
+  return siblingLocation(baseLocation, diffFileName);
 }
 
 export function getAcceptedFileTarget(

--- a/src/latex/acceptedFileTarget.ts
+++ b/src/latex/acceptedFileTarget.ts
@@ -151,7 +151,12 @@ export async function acceptEditedFileReplace(
     ports.emitWritten(targetLocation.absolutePath);
   }
 
-  await ports.deleteFile(diffFileLocation(baseLocation, editedPath));
+  await cleanupStaleDiffFile(
+    baseLocation,
+    editedPath,
+    targetLocation,
+    ports.deleteFile,
+  );
 
   await ports.showInfo(
     buildAcceptSuccessMessage(
@@ -179,6 +184,27 @@ export function diffFileLocation(
     '_diff',
   );
   return siblingLocation(baseLocation, diffFileName);
+}
+
+/**
+ * Delete the stale `_diff` companion file for (baseLocation, editedPath) via
+ * `deleteFile`, unless doing so would delete `targetLocation` itself — the
+ * file just accepted. This coincidence is possible whenever `baseLocation`'s
+ * own name already matches the generated diff-name pattern for `editedPath`
+ * (e.g. accepting into a base literally named `<edited-stem>_diff.tex`, or
+ * accepting directly into a latexdiff artifact). `deleteFile` is expected to
+ * swallow its own errors (missing/locked file); this only guards against
+ * deleting content that was never stale.
+ */
+export async function cleanupStaleDiffFile(
+  baseLocation: FileLocation,
+  editedPath: string,
+  targetLocation: FileLocation,
+  deleteFile: (location: FileLocation) => Promise<void>,
+): Promise<void> {
+  const diffLocation = diffFileLocation(baseLocation, editedPath);
+  if (diffLocation.absolutePath === targetLocation.absolutePath) return;
+  await deleteFile(diffLocation);
 }
 
 export function getAcceptedFileTarget(

--- a/src/latex/acceptedFileTarget.ts
+++ b/src/latex/acceptedFileTarget.ts
@@ -188,13 +188,20 @@ export function diffFileLocation(
 
 /**
  * Delete the stale `_diff` companion file for (baseLocation, editedPath) via
- * `deleteFile`, unless doing so would delete `targetLocation` itself — the
- * file just accepted. This coincidence is possible whenever `baseLocation`'s
- * own name already matches the generated diff-name pattern for `editedPath`
- * (e.g. accepting into a base literally named `<edited-stem>_diff.tex`, or
- * accepting directly into a latexdiff artifact). `deleteFile` is expected to
- * swallow its own errors (missing/locked file); this only guards against
- * deleting content that was never stale.
+ * `deleteFile`. No-ops in two cases:
+ *
+ * - `targetLocation` isn't `baseLocation` itself: a copy/sibling write (an
+ *   extension mismatch resolving to a new file via {@link getAcceptedFileTarget},
+ *   or an explicit "save as copy" choice) leaves the base untouched, so the
+ *   diff comparing it against `editedPath` is still accurate.
+ * - The derived diff location equals `targetLocation`: possible whenever
+ *   `baseLocation`'s own name already matches the generated diff-name
+ *   pattern for `editedPath` (e.g. accepting into a base literally named
+ *   `<edited-stem>_diff.tex`, or accepting directly into a latexdiff
+ *   artifact) — deleting it would delete the file just accepted.
+ *
+ * `deleteFile` is expected to swallow its own errors (missing/locked file);
+ * this only guards against deleting content that was never stale.
  */
 export async function cleanupStaleDiffFile(
   baseLocation: FileLocation,
@@ -202,6 +209,7 @@ export async function cleanupStaleDiffFile(
   targetLocation: FileLocation,
   deleteFile: (location: FileLocation) => Promise<void>,
 ): Promise<void> {
+  if (targetLocation.absolutePath !== baseLocation.absolutePath) return;
   const diffLocation = diffFileLocation(baseLocation, editedPath);
   if (diffLocation.absolutePath === targetLocation.absolutePath) return;
   await deleteFile(diffLocation);

--- a/src/test-kernel/latex/AcceptedFileTarget.vitest.ts
+++ b/src/test-kernel/latex/AcceptedFileTarget.vitest.ts
@@ -4,6 +4,7 @@ import { describe, it } from 'vitest';
 
 import {
   acceptEditedFileReplace,
+  cleanupStaleDiffFile,
   diffFileLocation,
   type AcceptEditedFileReplacePorts,
 } from '@latex/acceptedFileTarget';
@@ -24,6 +25,44 @@ describe('diffFileLocation', () => {
     if (loc.kind === 'workspace') {
       assert.strictEqual(loc.relativePath, 'chapters/paper_correct_diff.tex');
     }
+  });
+});
+
+describe('cleanupStaleDiffFile', () => {
+  it('deletes the derived diff location when it differs from the target', async () => {
+    const base = createWorkspaceLocation('/ws/paper.tex', 'paper.tex');
+    const deleted: FileLocation[] = [];
+
+    await cleanupStaleDiffFile(
+      base,
+      '/ws/paper_correct.tex',
+      base,
+      async (location) => {
+        deleted.push(location);
+      },
+    );
+
+    assert.strictEqual(deleted.length, 1);
+    assert.strictEqual(deleted[0].absolutePath, '/ws/paper_correct_diff.tex');
+  });
+
+  it('skips deletion when the derived diff location is the accept target', async () => {
+    const base = createWorkspaceLocation(
+      '/ws/paper_diff.tex',
+      'paper_diff.tex',
+    );
+    const deleted: FileLocation[] = [];
+
+    await cleanupStaleDiffFile(
+      base,
+      '/ws/paper.tex',
+      base,
+      async (location) => {
+        deleted.push(location);
+      },
+    );
+
+    assert.strictEqual(deleted.length, 0);
   });
 });
 
@@ -76,6 +115,23 @@ describe('acceptEditedFileReplace', () => {
     const accepted = await acceptEditedFileReplace(base, edited, ports);
 
     assert.strictEqual(accepted, false);
+    assert.strictEqual(ports.deleted.length, 0);
+  });
+
+  it('does not delete the just-accepted file when it collides with the derived diff name', async () => {
+    // base is literally named "<edited-stem>_diff.tex" — the same name
+    // diffFileLocation would derive for this edited/base pair — so the
+    // write target and the "stale diff" coincide.
+    const base = createWorkspaceLocation(
+      '/ws/paper_diff.tex',
+      'paper_diff.tex',
+    );
+    const edited = createWorkspaceLocation('/ws/paper.tex', 'paper.tex');
+    const ports = buildPorts();
+
+    const accepted = await acceptEditedFileReplace(base, edited, ports);
+
+    assert.strictEqual(accepted, true);
     assert.strictEqual(ports.deleted.length, 0);
   });
 });

--- a/src/test-kernel/latex/AcceptedFileTarget.vitest.ts
+++ b/src/test-kernel/latex/AcceptedFileTarget.vitest.ts
@@ -1,0 +1,81 @@
+import * as assert from 'node:assert';
+
+import { describe, it } from 'vitest';
+
+import {
+  acceptEditedFileReplace,
+  diffFileLocation,
+  type AcceptEditedFileReplacePorts,
+} from '@latex/acceptedFileTarget';
+import type { FileLocation } from '@shared/schemas';
+import { createWorkspaceLocation } from '@utils/files';
+
+describe('diffFileLocation', () => {
+  it('computes the stale _diff sibling for a base/edited pair', () => {
+    const base = createWorkspaceLocation(
+      '/ws/chapters/paper.tex',
+      'chapters/paper.tex',
+    );
+
+    const loc = diffFileLocation(base, '/ws/chapters/paper_correct.tex');
+
+    assert.strictEqual(loc.kind, 'workspace');
+    assert.strictEqual(loc.absolutePath, '/ws/chapters/paper_correct_diff.tex');
+    if (loc.kind === 'workspace') {
+      assert.strictEqual(loc.relativePath, 'chapters/paper_correct_diff.tex');
+    }
+  });
+});
+
+describe('acceptEditedFileReplace', () => {
+  function buildPorts(
+    overrides: Partial<AcceptEditedFileReplacePorts> = {},
+  ): AcceptEditedFileReplacePorts & { deleted: FileLocation[] } {
+    const deleted: FileLocation[] = [];
+    return {
+      exists: async () => false,
+      readFile: async () => 'edited content',
+      writeFile: async () => undefined,
+      confirm: async () => true,
+      emitWritten: () => undefined,
+      showInfo: async () => undefined,
+      deleteFile: async (location) => {
+        deleted.push(location);
+      },
+      deleted,
+      ...overrides,
+    };
+  }
+
+  it('cleans up the stale diff file after a successful accept', async () => {
+    const base = createWorkspaceLocation('/ws/paper.tex', 'paper.tex');
+    const edited = createWorkspaceLocation(
+      '/ws/paper_correct.tex',
+      'paper_correct.tex',
+    );
+    const ports = buildPorts();
+
+    const accepted = await acceptEditedFileReplace(base, edited, ports);
+
+    assert.strictEqual(accepted, true);
+    assert.strictEqual(ports.deleted.length, 1);
+    assert.strictEqual(
+      ports.deleted[0].absolutePath,
+      '/ws/paper_correct_diff.tex',
+    );
+  });
+
+  it('does not clean up when the user declines the confirmation', async () => {
+    const base = createWorkspaceLocation('/ws/paper.tex', 'paper.tex');
+    const edited = createWorkspaceLocation(
+      '/ws/paper_correct.tex',
+      'paper_correct.tex',
+    );
+    const ports = buildPorts({ confirm: async () => false });
+
+    const accepted = await acceptEditedFileReplace(base, edited, ports);
+
+    assert.strictEqual(accepted, false);
+    assert.strictEqual(ports.deleted.length, 0);
+  });
+});

--- a/src/test-kernel/latex/AcceptedFileTarget.vitest.ts
+++ b/src/test-kernel/latex/AcceptedFileTarget.vitest.ts
@@ -64,6 +64,26 @@ describe('cleanupStaleDiffFile', () => {
 
     assert.strictEqual(deleted.length, 0);
   });
+
+  it('skips deletion when the target is not the base itself (copy/sibling write)', async () => {
+    const base = createWorkspaceLocation('/ws/paper.tex', 'paper.tex');
+    const sibling = createWorkspaceLocation(
+      '/ws/paper_copy.tex',
+      'paper_copy.tex',
+    );
+    const deleted: FileLocation[] = [];
+
+    await cleanupStaleDiffFile(
+      base,
+      '/ws/paper_correct.tex',
+      sibling,
+      async (location) => {
+        deleted.push(location);
+      },
+    );
+
+    assert.strictEqual(deleted.length, 0);
+  });
 });
 
 describe('acceptEditedFileReplace', () => {
@@ -127,6 +147,19 @@ describe('acceptEditedFileReplace', () => {
       'paper_diff.tex',
     );
     const edited = createWorkspaceLocation('/ws/paper.tex', 'paper.tex');
+    const ports = buildPorts();
+
+    const accepted = await acceptEditedFileReplace(base, edited, ports);
+
+    assert.strictEqual(accepted, true);
+    assert.strictEqual(ports.deleted.length, 0);
+  });
+
+  it('does not clean up the base diff when accepting into a new sibling (extension mismatch)', async () => {
+    // Different extensions -> getAcceptedFileTarget resolves to a new
+    // sibling file, leaving base untouched, so its diff is still accurate.
+    const base = createWorkspaceLocation('/ws/paper.tex', 'paper.tex');
+    const edited = createWorkspaceLocation('/ws/notes.md', 'notes.md');
     const ports = buildPorts();
 
     const accepted = await acceptEditedFileReplace(base, edited, ports);

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -399,6 +399,11 @@ Optional:
         const loc = diffFileLocation(originalLocation, outputPath);
         if (loc.kind === 'external') return null;
 
+        // Never delete the file we just accepted into — possible when
+        // originalPath's own name already matches the generated diff-name
+        // pattern for outputPath (see cleanupStaleDiffFile's docstring).
+        if (loc.absolutePath === originalLocation.absolutePath) return null;
+
         try {
           await WorkspaceFS.delete(loc.relativePath);
           return loc.relativePath;

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -9,9 +9,6 @@
  * panel as write_file), so the user can review, edit, or reject each file.
  */
 
-// Standard library imports
-import * as path from 'node:path';
-
 // Third-party imports
 import { z } from 'zod';
 
@@ -22,7 +19,7 @@ import { getExecutionStore } from '@agent/storage';
 import { appSignals } from '@eventBus/AppSignals';
 
 // Local imports - shared
-import { generateDiffFileName } from '@latex/latexdiff/diffFileNameManager';
+import { diffFileLocation } from '@latex/acceptedFileTarget';
 import { stripCriticizeAnnotations } from '@replacement/advanced';
 import { ExecutionIdSchema } from '@shared/schemas';
 import type { ExecutionId, FileLocation } from '@shared/schemas';
@@ -383,24 +380,19 @@ Optional:
   }
 
   /**
-   * Remove diff files from the workspace that correspond to accepted output files.
-   * Uses generateDiffFileName (the same logic that creates diff files) to derive names.
+   * Remove diff files from the workspace that correspond to accepted output
+   * files, using the same diff-naming convention as the manual "Accept" flow
+   * (see {@link diffFileLocation}) so both paths stay in sync.
    */
   private async cleanupDiffFiles(
     entries: { outputPath: string; originalPath: string }[],
   ): Promise<string[]> {
     const results = await Promise.all(
       entries.map(async ({ outputPath, originalPath }) => {
-        const diffFileName = generateDiffFileName(
-          originalPath,
-          outputPath,
-          '_diff',
-        );
-        const dir = path.dirname(originalPath);
-        const fullDiffPath =
-          dir === '.' ? diffFileName : `${dir}/${diffFileName}`;
+        const originalLocation = WorkspaceFS.locatePath(originalPath);
+        if (originalLocation.kind === 'external') return null;
 
-        const loc = WorkspaceFS.locatePath(fullDiffPath);
+        const loc = diffFileLocation(originalLocation, outputPath);
         if (loc.kind === 'external') return null;
 
         try {

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -392,6 +392,10 @@ Optional:
         const originalLocation = WorkspaceFS.locatePath(originalPath);
         if (originalLocation.kind === 'external') return null;
 
+        // diffFileLocation's return type is the full FileLocation union
+        // (siblingLocation isn't generic over the input's kind), so this
+        // narrows for relativePath access below even though, given a
+        // 'workspace' input, it can only ever resolve to 'workspace'.
         const loc = diffFileLocation(originalLocation, outputPath);
         if (loc.kind === 'external') return null;
 


### PR DESCRIPTION
## Summary

TeXRA has two entry points for accepting generated edits into the workspace:

- the `accept_run_files` agent tool; and
- the manual **Accept edits** action used by the extension progress view, the compare command, and the desktop bridge.

Both are intended to perform the same acceptance operation, but only `accept_run_files` removed the corresponding latexdiff `_diff` artifact. Manual acceptance therefore left an obsolete diff behind after replacing its base file.

This PR gives both entry points one derivation for the corresponding diff path and one cleanup policy. A diff is removed only after a successful write that actually replaces its base. It is retained when acceptance creates a sibling or postfixed copy, because the unchanged base still has a valid comparison to the edited content. Cleanup also refuses to delete the accepted target itself when a legitimate filename happens to coincide with the generated diff name.

## User-visible behavior

- Extension acceptance without run metadata removes the matching `_diff` sibling after replacing the base.
- Extension acceptance with run metadata does the same after **Replace original** when that choice overwrites the base.
- **Save as copy**, and a replacement that resolves to a sibling because the extensions differ, retain the diff because the base is unchanged.
- Desktop acceptance inherits the same behavior through the shared host-neutral operation.
- `accept_run_files` retains its existing cleanup behavior while using the shared filename derivation and the same collision protection.
- Missing or locked diff files remain non-fatal.

## Single source of truth

`diffFileLocation()` in `src/latex/acceptedFileTarget.ts` is the sole derivation of the `_diff` companion path, using the existing `generateDiffFileName()` and `siblingLocation()` primitives. `cleanupStaleDiffFile()` owns the deletion policy: it deletes only when the accepted target is the base and differs from the derived diff path.

The extension and desktop hosts provide only their filesystem deletion capability through `AcceptEditedFileReplacePorts`; they do not duplicate the path or policy logic. `AcceptRunFilesTool.cleanupDiffFiles()` calls `diffFileLocation()` directly because it must return the deleted relative paths in its tool result.

## Duplication and abstraction budget

Removed: `AcceptRunFilesTool`'s private path construction (`path.dirname`, string joining, and a second workspace-location resolution). The two extension acceptance branches share one non-fatal deletion function.

Added: two exported functions (`diffFileLocation`, `cleanupStaleDiffFile`) and one field (`deleteFile`) on the existing host port. These have multiple production consumers and replace duplicated policy; no new manager, service, or wrapper layer was introduced.

## Net elements (R6)

- Files changed: 4 source files and 1 test file.
- Exported symbols: +2 (`diffFileLocation`, `cleanupStaleDiffFile`), 0 removed.
- Classes/interfaces/enums: 0 added; `AcceptEditedFileReplacePorts` gains one field. One file-local structural type names the replace-or-copy picker result.
- Net LoC: +286 / -20 across 5 files, including the new 170-line regression suite.

## Consumer counts (R8)

- `AcceptEditedFileReplacePorts` has exactly 2 production implementers: the extension compare command and the desktop progress-file actions.
- `cleanupStaleDiffFile` has exactly 2 production callers: `acceptEditedFileReplace` and the extension run-metadata acceptance branch.
- `diffFileLocation` has exactly 2 production callers: `cleanupStaleDiffFile` and `AcceptRunFilesTool.cleanupDiffFiles`.

## Host impact

- Extension: both manual acceptance branches use the shared cleanup policy.
- Desktop: the existing shared acceptance operation gains cleanup through its filesystem port.
- CLI: no manual-accept UI changes; `accept_run_files` preserves its behavior through the shared derivation.

## Validation

- `npm run typecheck` — passed for the root, test kernel, extension, CLI, trace viewer, and desktop projects.
- `npm run compile:fast` — passed.
- ESLint on all changed TypeScript files — passed without findings.
- Prettier check on all changed files — passed.
- `npm run check:dead-code-ratchet` — passed at the unchanged baseline of 234 findings.
- `npx vitest run src/test-kernel/latex/AcceptedFileTarget.vitest.ts` — 8/8 passed, covering successful cleanup, declined acceptance, accepted-target collisions, sibling/copy retention, and extension-mismatch retention.
- Current GitHub CI head `9c246a5a5` — static checks, both kernel shards, build artifacts, webview smoke, and final validation all passed.

## Scheduled refactoring

None. The identified drift and all review findings are addressed within this PR.
