### PR TITLE
refactor(modelHandlers): dedupe DeepSeek/GLM reasoning-effort clamp

### DIFF
--- a/src/agent/modelHandlers/openai/modelHandlerDeepSeek.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerDeepSeek.ts
@@ -3,6 +3,7 @@ import { ReasoningEffort } from 'llm-zoo';
 
 // Local file imports
 import type { DeepSeekToolCall } from '@agent/types/ModelHandlerContracts';
+import { clampReasoningEffortToHighOrMax } from '@agent/modelHandlers/support/reasoningEffort';
 import { ReasoningModelHandlerOpenAI } from './reasoningModelHandlerOpenAI';
 
 // Type imports
@@ -79,14 +80,11 @@ export class ModelHandlerDeepSeek extends ReasoningModelHandlerOpenAI<DeepSeekTo
   }
 
   /**
-   * DeepSeek's OpenAI-format API accepts only high/max. Its compatibility layer
-   * maps low/medium to high and the above-high tiers (xhigh, max) to max, so do
-   * that explicitly.
+   * DeepSeek's OpenAI-format API accepts only high/max; delegate to the shared
+   * high-or-max clamp (see `clampReasoningEffortToHighOrMax`).
    */
   protected override validateReasoningEffort(effort: string): string {
-    return effort === ReasoningEffort.XHIGH || effort === ReasoningEffort.MAX
-      ? 'max'
-      : 'high';
+    return clampReasoningEffortToHighOrMax(effort);
   }
 
   /** DeepSeek requires merging consecutive roles and stringified content. */

--- a/src/agent/modelHandlers/openai/modelHandlerGLM.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerGLM.ts
@@ -1,4 +1,5 @@
 // Local file imports
+import { clampReasoningEffortToHighOrMax } from '@agent/modelHandlers/support/reasoningEffort';
 import { ReasoningModelHandlerOpenAI } from './reasoningModelHandlerOpenAI';
 
 /**
@@ -30,10 +31,11 @@ export class ModelHandlerGLM extends ReasoningModelHandlerOpenAI {
 
   /**
    * GLM effort-capable models accept only high/max on the OpenAI-compatible
-   * surface. Keep lower user selections valid by mapping them to high.
+   * surface; delegate to the shared high-or-max clamp (see
+   * `clampReasoningEffortToHighOrMax`).
    */
   protected override validateReasoningEffort(effort: string): string {
-    return effort === 'xhigh' || effort === 'max' ? 'max' : 'high';
+    return clampReasoningEffortToHighOrMax(effort);
   }
 
   /**

--- a/src/agent/modelHandlers/support/reasoningEffort.ts
+++ b/src/agent/modelHandlers/support/reasoningEffort.ts
@@ -62,3 +62,18 @@ export function toOpenAIReasoningEffort(
       return maxReasoningEffort === ReasoningEffort.MAX ? 'max' : 'xhigh';
   }
 }
+
+/**
+ * Clamp an internal reasoning-effort value for providers whose OpenAI-compatible
+ * surface accepts only 'high' and 'max' (DeepSeek, GLM). Their compatibility
+ * layer maps the below-high tiers (none/low/medium) up to the 'high' floor and
+ * the above-high tiers (xhigh, max) to 'max'; reproduce that explicitly so an
+ * out-of-vocabulary value never leaks to the API.
+ */
+export function clampReasoningEffortToHighOrMax(
+  effort: string,
+): 'high' | 'max' {
+  return effort === ReasoningEffort.XHIGH || effort === ReasoningEffort.MAX
+    ? 'max'
+    : 'high';
+}

--- a/src/test-kernel/agent/modelHandlers/ReasoningEffortMapping.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ReasoningEffortMapping.vitest.ts
@@ -4,7 +4,10 @@ import { ReasoningEffort } from 'llm-zoo';
 
 // Local imports - mappings under test
 import { toOpenRouterReasoningEffort } from '@agent/modelHandlers/openrouter/openRouterStreaming';
-import { toOpenAIReasoningEffort } from '@agent/modelHandlers/support/reasoningEffort';
+import {
+  clampReasoningEffortToHighOrMax,
+  toOpenAIReasoningEffort,
+} from '@agent/modelHandlers/support/reasoningEffort';
 
 // Regression coverage for the SDK-vocabulary mismatch that produced
 // `400 reasoning_effort: Invalid option: expected one of
@@ -54,5 +57,25 @@ describe('toOpenRouterReasoningEffort', () => {
 
   it('falls back to "low" for unrecognized values', () => {
     expect(toOpenRouterReasoningEffort('bogus', false)).toBe('low');
+  });
+});
+
+// Shared clamp for providers (DeepSeek, GLM) whose OpenAI-compatible surface
+// accepts only 'high' and 'max'. Previously copy-pasted in both handlers.
+describe('clampReasoningEffortToHighOrMax', () => {
+  it('maps the above-high tiers to "max"', () => {
+    expect(clampReasoningEffortToHighOrMax(ReasoningEffort.XHIGH)).toBe('max');
+    expect(clampReasoningEffortToHighOrMax(ReasoningEffort.MAX)).toBe('max');
+  });
+
+  it('maps high and every below-high tier to the "high" floor', () => {
+    for (const effort of [
+      ReasoningEffort.HIGH,
+      ReasoningEffort.MEDIUM,
+      ReasoningEffort.LOW,
+      ReasoningEffort.NONE,
+    ]) {
+      expect(clampReasoningEffortToHighOrMax(effort)).toBe('high');
+    }
   });
 });


### PR DESCRIPTION
## Summary

`ModelHandlerDeepSeek` and `ModelHandlerGLM` each carried a byte-identical `validateReasoningEffort` override: the above-high tiers (`xhigh`, `max`) map to `'max'` and everything else to the `'high'` floor, because both providers' OpenAI-compatible surfaces accept only `high`/`max`. This extracts that policy into a single shared helper and points both handlers at it.

This is the first, deliberately low-risk increment from a broader tech-debt audit of the model-handler layer (larger items — the per-provider `createResponseImpl` pipeline, the two parallel Google handlers, streaming aggregators — are called out as follow-ups below, not attempted here).

## Issue acceptance gates

No linked issue — follow-up to a codebase tech-debt scan. Gate: remove the duplicated clamp without changing observed behavior for any provider.

## Single source of truth

`clampReasoningEffortToHighOrMax` in `src/agent/modelHandlers/support/reasoningEffort.ts` now owns the "OpenAI-compat surface accepts only high/max" clamp, alongside the sibling `toOpenAIReasoningEffort`. DeepSeek and GLM delegate to it.

## Duplication and abstraction budget

- **Removed:** two identical inline clamp expressions (DeepSeek used the `ReasoningEffort` enum, GLM used string literals — same values, same result).
- **Added:** one exported pure function with its own doc comment. Two consumers, so not a single-caller extraction. It is a leaf helper, not a pass-through layer.
- **Deliberately excluded:** `ModelHandlerXAI.validateReasoningEffort` is left untouched — its vocabulary (`low`/`medium`/`high`) and fallback-to-`high` behavior differ, so folding it in would either change behavior or degrade the helper into a single-caller config.

## Net elements (R6)

- Files: 0 added / 0 deleted (4 modified). Diffstat: +47 / −9.
- Exported symbols: **+1** (`clampReasoningEffortToHighOrMax`); 0 removed.
- Classes/interfaces/enums: 0.
- Net LoC: **+38** (a ~4-line net reduction in handler logic, offset by the shared helper's doc comment and new regression tests).

## Consumer counts (R8)

n/a — no emit path or existing export was deleted or re-routed. The new export has 2 consumers (`modelHandlerDeepSeek.ts`, `modelHandlerGLM.ts`), grep-confirmed.

## Host impact

Extension: none — shared core logic; no behavior change.

Desktop: none — same.

CLI: none — same.

## Scheduled refactoring

Follow-ups identified by the same audit, not in this PR: shared `createResponseImpl` request pipeline across the 7 provider handlers; consolidation of the two parallel Google handlers (`modelHandlerGoogleGenAI` / `modelHandlerGoogleInteractions`); generic streaming-aggregator base. None are prerequisites for this change.

## Validation

- `npm run typecheck` — clean.
- `npx eslint` on all changed files — clean.
- `npx vitest run` on `ReasoningEffortMapping.vitest.ts` + `ModelHandlerDeepSeek.vitest.ts` — 32 passed (added coverage for the new helper: above-high → `max`, high/below-high → `high`).
- `npm run check:dead-code-ratchet` — OK, no new unused exports (new export is consumed).
- `npx prettier --check` on changed files — clean.
