### PR TITLE
refactor: consolidate duplicate helpers into shared @utils/core

### DIFF
--- a/packages/desktop/src/main/desktopPreviewHost.ts
+++ b/packages/desktop/src/main/desktopPreviewHost.ts
@@ -1,6 +1,7 @@
 import { access } from 'node:fs/promises';
 import path from 'node:path';
 
+import { isFileNotFoundError } from '@common/errors';
 import { isLatexFile } from '@common/files/fileTypeUtils';
 import type { ExternalOpener } from '@hosts/uiHosts';
 import type { FileLocation } from '@shared/schemas';
@@ -46,12 +47,6 @@ export interface DesktopPreviewHostOptions {
   forceExternal?: boolean;
 }
 
-function getErrorCode(error: unknown): string | undefined {
-  return typeof error === 'object' && error !== null && 'code' in error
-    ? String(error.code)
-    : undefined;
-}
-
 export function createDesktopPreviewHost(
   options: DesktopPreviewHostOptions,
 ): DesktopPreviewHost {
@@ -64,7 +59,7 @@ export function createDesktopPreviewHost(
     try {
       await access(filePath);
     } catch (error) {
-      if (getErrorCode(error) === 'ENOENT') {
+      if (isFileNotFoundError(error)) {
         await fail(`File not found: ${filePath}`);
       }
       await fail(`Cannot access file ${filePath}: ${toErrorMessage(error)}`);

--- a/src/agent/roster/AgentRosterController.ts
+++ b/src/agent/roster/AgentRosterController.ts
@@ -21,6 +21,7 @@ import {
   setDefaultTeamId,
 } from '@shared/state/onboardingState';
 import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
+import { KeyedMutex, unique } from '@utils/core';
 import type { StateStore } from '@platform/interfaces';
 
 export interface AgentRosterEntry {
@@ -48,24 +49,13 @@ export interface AgentRosterControllerDeps<
   readonly fallbackTeamId?: string | null;
 }
 
-const workspaceWriteQueues = new WeakMap<StateStore, Promise<void>>();
+const workspaceWriteMutex = new KeyedMutex<StateStore>();
 
 function serializeWorkspaceWrite(
   store: StateStore,
   write: () => Promise<void>,
 ): Promise<void> {
-  const previous = workspaceWriteQueues.get(store) ?? Promise.resolve();
-  const run = previous.then(write);
-  // Release the queue after either outcome; callers still receive `run` and
-  // therefore observe their own write error.
-  workspaceWriteQueues.set(
-    store,
-    run.then(
-      () => undefined,
-      () => undefined,
-    ),
-  );
-  return run;
+  return workspaceWriteMutex.runExclusive(store, write);
 }
 
 export interface AgentRosterSnapshot<
@@ -88,10 +78,6 @@ function allPresets(
   extra: readonly AgentModePreset[] = [],
 ): readonly AgentModePreset[] {
   return [STARTER_AGENT_MODE_PRESET, ...AGENT_MODE_PRESETS, ...extra];
-}
-
-function unique(values: readonly string[]): string[] {
-  return [...new Set(values)];
 }
 
 function identifiersEqual(

--- a/src/controllers/progressView/backend/events/errorHandling.ts
+++ b/src/controllers/progressView/backend/events/errorHandling.ts
@@ -1,6 +1,6 @@
 // Local imports - logger
 import { createChannelTrace } from '@agent/trace';
-import { serializeError } from '@utils/core';
+import { isThenable, serializeError } from '@utils/core';
 
 // Shared logger for all event handlers
 const eventLogger = createChannelTrace('ProgressEvents');
@@ -10,11 +10,6 @@ function toErrorData(error: unknown): Record<string, unknown> {
   return error instanceof Error
     ? { ...serializeError(error), error }
     : { error };
-}
-
-/** Check if a value is a thenable (has .catch method). */
-function isThenable(value: unknown): value is PromiseLike<unknown> {
-  return typeof (value as PromiseLike<unknown>)?.then === 'function';
 }
 
 /** Log an error with module context. */

--- a/src/platform/defaults/nodeWorkspace.ts
+++ b/src/platform/defaults/nodeWorkspace.ts
@@ -7,6 +7,7 @@ import * as path from 'node:path';
 
 import { normalizeFilePath } from '@utils/core';
 import { isPathWithin } from '@utils/core/pathCore';
+import { capitalize } from '@utils/text/stringUtils';
 
 import type { WorkspaceProvider } from '../interfaces';
 
@@ -36,9 +37,7 @@ export function canonicalizeWorkspacePath(workspacePath: string): string {
       existingAncestor = parent;
     }
   }
-  return /^[a-z]:[\\/]/.test(canonical)
-    ? `${canonical.charAt(0).toUpperCase()}${canonical.slice(1)}`
-    : canonical;
+  return /^[a-z]:[\\/]/.test(canonical) ? capitalize(canonical) : canonical;
 }
 
 export function createNodeWorkspace(

--- a/src/shared/wa/commandPalette.ts
+++ b/src/shared/wa/commandPalette.ts
@@ -12,6 +12,7 @@ import '@awesome.me/webawesome/dist/components/dialog/dialog.js';
 import '@awesome.me/webawesome/dist/components/input/input.js';
 import { html, nothing, render } from 'lit';
 import { repeat } from 'lit/directives/repeat.js';
+import { isThenable } from '@utils/core';
 import type WaDialog from '@awesome.me/webawesome/dist/components/dialog/dialog.js';
 import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
 
@@ -119,7 +120,7 @@ export function executeCommandPaletteEntry(
   // logs but doesn't propagate — sync handler errors still throw
   // synchronously and bubble to the caller.
   const result = onExecute(entry.id);
-  if (typeof (result as { then?: unknown })?.then === 'function') {
+  if (isThenable(result)) {
     (result as Promise<boolean>).catch((error) => {
       console.error('[command-palette] async dispatch rejected', error);
     });

--- a/src/utils/core/index.ts
+++ b/src/utils/core/index.ts
@@ -49,6 +49,11 @@ export function isFiniteNumber(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value);
 }
 
+/** Check if a value is a thenable (has a callable `.then`). */
+export function isThenable(value: unknown): value is PromiseLike<unknown> {
+  return typeof (value as PromiseLike<unknown> | null)?.then === 'function';
+}
+
 /** Predicate for filtering null values from arrays while narrowing the element type. */
 export function filterNotNull<T>(item: T | null): item is T {
   return item !== null;


### PR DESCRIPTION
## Summary

A scheduled consolidation scan flagged several small, independently-maintained duplicates of logic that already exists as a shared utility elsewhere in the codebase. This PR removes each duplicate in favor of the existing shared helper:

- **`AgentRosterController.ts`**: local `unique()` array-dedup and a hand-rolled per-`StateStore` write queue (`workspaceWriteQueues`/`serializeWorkspaceWrite`) replaced with the shared `unique()` and `KeyedMutex` (already used for the identical per-key async-write-serialization pattern in `workflowScript/persistence.ts`, `externalInquiryStorage.ts`, and `inBandSubagentExecution.ts`).
- **`packages/desktop/src/main/desktopPreviewHost.ts`**: local `getErrorCode()` (used only to test `=== 'ENOENT'`) replaced with the shared `isFileNotFoundError()` predicate from `@common/errors`.
- **`src/platform/defaults/nodeWorkspace.ts`**: inline drive-letter capitalization (`charAt(0).toUpperCase() + slice(1)`) replaced with the shared `capitalize()` string helper.
- **`src/utils/core/index.ts`**: added a new `isThenable()` type guard, replacing two independently-written inline "has a callable `.then`" checks in `controllers/progressView/backend/events/errorHandling.ts` and `shared/wa/commandPalette.ts`.

No behavior change — this is a pure consolidation pass.

## Issue acceptance gates

No linked issue; this is a proactive maintenance PR from a scheduled "identify consolidation opportunities" scan. Acceptance gate: each duplicate is removed and its call site(s) now route through the single existing shared implementation, with no behavior change.

## Single source of truth

- Array dedup: `unique()` in `src/utils/core/index.ts`.
- Per-key async write serialization: `KeyedMutex` in `src/utils/core/keyedMutex.ts`.
- File-not-found detection: `isFileNotFoundError()` in `src/common/errors/errorPredicates.ts`.
- String capitalization: `capitalize()` in `src/utils/text/stringUtils.ts`.
- Thenable detection: new `isThenable()` in `src/utils/core/index.ts`.

## Duplication and abstraction budget

Removed four independent duplicate implementations (one `unique`, one write-queue, one `getErrorCode`, one inline capitalize) and one duplicated inline type-guard pattern. Added one new tiny function (`isThenable`) to `@utils/core`, justified by two existing call sites that already needed it independently (not a single-caller extraction). No new ports, facades, or pass-through layers.

## Net elements (R6)

- Files: 6 changed, 0 added/removed (diffstat: `+15 -34`, net **-19 LoC**).
- Exported symbols: `+1` (`isThenable` in `@utils/core`), `0` removed (the removed `unique`/`getErrorCode`/inline capitalize were all unexported, file-local functions).
- Classes/interfaces/enums: none added or removed.

## Consumer counts (R8)

No emit path or public export was deleted or re-routed — only file-local, unexported helpers were removed in favor of existing shared exports. n/a.

## Host impact

Extension: `AgentRosterController.ts` and `progressView/backend/events/errorHandling.ts` are host-neutral core code used by the VS Code extension; no behavior change.

Desktop: `desktopPreviewHost.ts` (Electron main process) — no behavior change, same ENOENT detection.

CLI: `nodeWorkspace.ts` is shared by CLI/Electron/tests — no behavior change, same drive-letter capitalization output. `commandPalette.ts` is host-neutral shared UI code (Electron renderer today) — no behavior change.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — clean across all workspace packages (extension, CLI, trace-viewer, desktop).
- `npm run lint` — clean (0 errors) on all changed files.
- `npm run check:dead-code-ratchet` — no new unused exports/files introduced.
- Targeted tests: `AgentRosterController.vitest.ts`, `DesktopPreviewHost.vitest.mts`, `DesktopCommandPalette.vitest.mts` — all 40 tests pass.
- Full suite (`npm test`): 6767 passed, 1 pre-existing unrelated failure (`SystemUtils.vitest.ts` process-group abort test — reproduced identically on `main` before this change via `git stash`; a sandbox/environment flake, not caused by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXQZY95STDjtDf6gJWTsFA

---
_Generated by [Claude Code](https://claude.ai/code/session_01SXQZY95STDjtDf6gJWTsFA)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical deduplication with no API or feature changes; the only subtlety is `isFileNotFoundError` covering slightly more codes than the old ENOENT-only check.
> 
> **Overview**
> **Maintenance consolidation** that removes file-local duplicates in favor of existing shared utilities, with a small new export where two call sites already needed the same guard.
> 
> `AgentRosterController` drops its local `unique()` and hand-rolled per-`StateStore` write queue in favor of `@utils/core` **`unique`** and **`KeyedMutex.runExclusive`**. Desktop preview path checks use **`isFileNotFoundError`** instead of a local `getErrorCode` + `ENOENT` test. **`canonicalizeWorkspacePath`** uses shared **`capitalize`** for Windows drive letters. Progress event wrapping and the shared command palette now share a new **`isThenable`** type guard exported from `@utils/core`, replacing inline `.then` checks.
> 
> Net effect is fewer lines and one canonical implementation per concern; intended behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e3036f78f5395a0f2f5fd88d22094274a7b774a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->