### PR TITLE
refactor: route GitHub env-token fallback through platform secrets seam

### DIFF
--- a/packages/extension/src/progressView/frontend/eventHandlers.ts
+++ b/packages/extension/src/progressView/frontend/eventHandlers.ts
@@ -273,6 +273,24 @@ export function sendFollowupCommand(
   });
 }
 
+/**
+ * Post an optional session-bypass-enable message before the terminal
+ * protocol message it gates. Webview messages are delivered FIFO to the
+ * extension host, and the bypass-enable message sets the per-stream bypass
+ * synchronously when handled — so sending it first guarantees it lands
+ * before the terminal message unblocks the agent, and the agent can't race
+ * ahead and re-prompt the next gated action before bypass is live.
+ */
+function postWithOptionalBypass(
+  bypassMessage: ProgressViewInboundMessage | undefined,
+  message: ProgressViewInboundMessage,
+): void {
+  if (bypassMessage) {
+    postPermissionMessage(bypassMessage);
+  }
+  postPermissionMessage(message);
+}
+
 export function handlePermissionAction(
   event: CustomEvent<PermissionActionDetail>,
   ctx: MessageHandlerContext,
@@ -287,24 +305,19 @@ export function handlePermissionAction(
       // stream — mirroring the toolbar shield and the CLI's `a` = approve
       // session. It never reaches the backend approval protocol.
       const isYolo = decision.action === APPROVE_SESSION_ACTION;
-      if (isYolo) {
-        // Enable session bypass BEFORE settling the approval. Webview messages
-        // are delivered FIFO and ENABLE_APPROVAL_BYPASS sets the per-stream
-        // bypass synchronously when handled, so it lands before the approve
-        // message unblocks the agent — the agent can't race ahead and
-        // re-prompt the next gated action. Set-on (not toggle) is also
-        // inversion-proof: edit and bash bypass can be decoupled on a delegated
-        // child stream. The button only renders with a real stream (see
-        // canBypass), but guard anyway.
-        const stream = data.streamId;
-        if (stream) {
-          postMessage(PROGRESS_VIEW_COMMANDS.ENABLE_APPROVAL_BYPASS, {
-            stream,
-          });
-        }
-      }
+      // Set-on (not toggle) is inversion-proof: edit and bash bypass can be
+      // decoupled on a delegated child stream. The button only renders with
+      // a real stream (see canBypass), but guard anyway.
+      const bypassMessage =
+        isYolo && data.streamId
+          ? ({
+              command: PROGRESS_VIEW_COMMANDS.ENABLE_APPROVAL_BYPASS,
+              stream: data.streamId,
+            } satisfies ProgressViewInboundMessage)
+          : undefined;
       const action = isYolo ? 'approve' : decision.action;
-      postPermissionMessage(
+      postWithOptionalBypass(
+        bypassMessage,
         decision.action === 'reject'
           ? {
               command: PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION,
@@ -329,12 +342,15 @@ export function handlePermissionAction(
     case PERMISSION_KIND.BASH: {
       const { data, decision } = detail;
       const isYolo = decision.action === APPROVE_SESSION_ACTION;
-      if (isYolo && data.streamId) {
-        postMessage(PROGRESS_VIEW_COMMANDS.ENABLE_APPROVAL_BYPASS, {
-          stream: data.streamId,
-        });
-      }
-      postPermissionMessage(
+      const bypassMessage =
+        isYolo && data.streamId
+          ? ({
+              command: PROGRESS_VIEW_COMMANDS.ENABLE_APPROVAL_BYPASS,
+              stream: data.streamId,
+            } satisfies ProgressViewInboundMessage)
+          : undefined;
+      postWithOptionalBypass(
+        bypassMessage,
         decision.action === 'reject'
           ? {
               command: PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION,
@@ -392,23 +408,22 @@ export function handlePermissionAction(
       const { data, decision } = detail;
       // Approve-all accepts this proposal and enables delegated-task approval
       // for the rest of the stream. It never reaches the backend proposal
-      // protocol (action stays approve|reject|setup). Enable the bypass BEFORE
-      // settling the approval:
-      // webview messages are FIFO and ENABLE_SUPER_YOLO_BYPASS sets the
-      // per-stream bypass synchronously, so it lands before approve unblocks the
-      // agent and the next proposal can't race ahead and re-prompt. Use the
-      // idempotent ENABLE (force-on), not the TOGGLE: approval can be turned on
-      // from the stream header while this prompt is still visible (which does not
-      // auto-resolve the open proposal), and a toggle would then flip bypass back
-      // OFF here — the opposite of "enable". Mirrors edit/bash ENABLE_APPROVAL_BYPASS.
+      // protocol (action stays approve|reject|setup). Use the idempotent
+      // ENABLE (force-on), not the TOGGLE: approval can be turned on from the
+      // stream header while this prompt is still visible (which does not
+      // auto-resolve the open proposal), and a toggle would then flip bypass
+      // back OFF here — the opposite of "enable". Mirrors edit/bash
+      // ENABLE_APPROVAL_BYPASS (see postWithOptionalBypass for the FIFO
+      // ordering rationale shared by all three bypass-gated permission kinds).
       const approveAllDelegatedWork =
         decision.action === APPROVE_ALL_DELEGATED_WORK_ACTION;
-      if (approveAllDelegatedWork) {
-        postMessage(PROGRESS_VIEW_COMMANDS.ENABLE_SUPER_YOLO_BYPASS, {
-          stream: data.streamId,
-          initiatingProposalId: data.proposalId,
-        });
-      }
+      const bypassMessage = approveAllDelegatedWork
+        ? ({
+            command: PROGRESS_VIEW_COMMANDS.ENABLE_SUPER_YOLO_BYPASS,
+            stream: data.streamId,
+            initiatingProposalId: data.proposalId,
+          } satisfies ProgressViewInboundMessage)
+        : undefined;
       let message: ProgressViewInboundMessage;
       if (decision.action === 'approve' || approveAllDelegatedWork) {
         message = {
@@ -432,7 +447,7 @@ export function handlePermissionAction(
           action: 'setup',
         };
       }
-      postPermissionMessage(message);
+      postWithOptionalBypass(bypassMessage, message);
       // Optimistic removal — track resolved ID so late SHOW is a no-op
       const removed = removePrompt(
         ctx,

--- a/src/test-kernel/tools/GitHubAuth.vitest.ts
+++ b/src/test-kernel/tools/GitHubAuth.vitest.ts
@@ -77,14 +77,13 @@ describe('getGitHubToken', () => {
   });
 
   it('ignores blank platform secrets before using environment fallbacks', async () => {
-    process.env.GH_TOKEN = 'gh-env-token';
-
     const githubAuth = await import('@tools/github/githubAuth');
 
     await installPlatform({
       secrets: {
         [githubAuth.GITHUB_TOKEN_STORAGE_KEY]: '   ',
       },
+      secretsEnv: { GH_TOKEN: 'gh-env-token' },
     });
 
     await expect(githubAuth.getGitHubToken()).resolves.toBe('gh-env-token');

--- a/src/tools/github/githubAuth.ts
+++ b/src/tools/github/githubAuth.ts
@@ -22,17 +22,27 @@ function normalizeGitHubToken(token: string | undefined): string | undefined {
   return trimmed ? trimmed : undefined;
 }
 
-function getGitHubEnvToken(): string | undefined {
+function getGitHubEnvToken(
+  readEnv: (name: string) => string | undefined,
+): string | undefined {
   for (const envVar of GITHUB_TOKEN_ENV_VARS) {
-    const token = normalizeGitHubToken(process.env[envVar]);
+    const token = normalizeGitHubToken(readEnv(envVar));
     if (token) return token;
   }
   return undefined;
 }
 
 export async function getGitHubToken(): Promise<string | undefined> {
-  const stored = await tryPlatform()?.secrets.get(GITHUB_TOKEN_STORAGE_KEY);
-  return normalizeGitHubToken(stored) ?? getGitHubEnvToken();
+  const secrets = tryPlatform()?.secrets;
+  // No platform yet (e.g. module-level init before `initPlatform()` runs):
+  // there's no secrets seam to call, so read process.env directly — same
+  // documented pre-init exception as `tryPlatform()` itself.
+  if (!secrets) return getGitHubEnvToken((name) => process.env[name]);
+  const stored = await secrets.get(GITHUB_TOKEN_STORAGE_KEY);
+  return (
+    normalizeGitHubToken(stored) ??
+    getGitHubEnvToken((name) => secrets.getEnv(name))
+  );
 }
 
 /**

--- a/src/tools/github/githubAuth.ts
+++ b/src/tools/github/githubAuth.ts
@@ -60,9 +60,5 @@ export async function resolveGitHubTokenSource(
   if (normalizeGitHubToken(await secrets.getStored(GITHUB_TOKEN_STORAGE_KEY))) {
     return 'secret';
   }
-  return GITHUB_TOKEN_ENV_VARS.some((name) =>
-    normalizeGitHubToken(secrets.getEnv(name)),
-  )
-    ? 'env'
-    : 'none';
+  return getGitHubEnvToken((name) => secrets.getEnv(name)) ? 'env' : 'none';
 }


### PR DESCRIPTION
## Summary

Follow-up to a scheduled abstraction-layer audit. Two of the three findings from that audit are addressed here (the third — a small filename-extension heuristic duplicated in a Lit component — was deliberately left alone; see "Scheduled refactoring" below):

- `getGitHubToken()` (`src/tools/github/githubAuth.ts`) read `process.env[envVar]` directly for the `GH_TOKEN`/`GITHUB_TOKEN` fallback, while the sibling `resolveGitHubTokenSource()` in the same file already routed the identical check through `PlatformSecrets.getEnv()`. The raw read was the one non-test-injectable, non-host-agnostic path in GitHub token resolution.
- `handlePermissionAction()` (`packages/extension/src/progressView/frontend/eventHandlers.ts`) duplicated the same "enable session bypass, then send the terminal approval message, because webview messages are FIFO" sequencing three times (TOOL_EDIT, BASH, PROPOSAL), each with a slightly different comment restating the same invariant.

## Issue acceptance gates

- GitHub token env fallback now goes through `platform().secrets.getEnv()` whenever a platform is initialized — ✅. The pre-`initPlatform()` case (module-level init before any host wires a platform) still reads `process.env` directly, since there's no seam to call yet; this mirrors `tryPlatform()`'s own documented pre-init exception — ✅.
- Bypass-then-approve message ordering for TOOL_EDIT/BASH/PROPOSAL is defined once and reused, not restated per case — ✅.

## Single source of truth

- `PlatformSecrets.getEnv()` is now the sole owner of "read a conventional GitHub-token env var" for any platform-initialized caller — `getGitHubToken()` and `resolveGitHubTokenSource()` both call it the same way.
- `postWithOptionalBypass()` is the sole owner of the FIFO bypass-then-terminal-message ordering invariant for permission actions; the three call sites (TOOL_EDIT, BASH, PROPOSAL) each just build their own `bypassMessage`/`message` and hand them to it.

## Duplication and abstraction budget

Removed: the repeated "if isYolo, postMessage(ENABLE_*_BYPASS, ...) before postPermissionMessage(...)" pattern (3 call sites, each with its own 5–9 line comment re-deriving the same FIFO rationale). Replaced with one named, documented function plus three short `bypassMessage = cond ? {...} : undefined` expressions.

No new pass-through layer: `postWithOptionalBypass` has 3 real call sites (not 1), and it encodes a genuine invariant (ordering + conditionality), not just a forwarding call — it clears the project's "meaningful logic, not identity forwarding" bar for a shared helper.

The third audit finding (a `getSourceDisplayPath` extension-vs-version-qualifier regex heuristic in `FileList.ts`) was intentionally **not** extracted to a shared module — it has exactly one caller and does no meaningful transformation beyond that single site, so extracting it would itself be a single-caller extraction, which this repo's own abstraction-discipline rule bans. Left in place.

## Net elements (R6)

3 files changed, +70/−50 (net +20 LoC). No exported symbols added or removed (`git diff | grep '^[+-]export'` is empty) — `postWithOptionalBypass` and the `getGitHubEnvToken` signature change are both module-local.

## Consumer counts (R8)

n/a — no emit path, export, or public API was deleted or re-routed; both changes are internal to their existing functions/call sites.

## Host impact

Extension: `githubAuth.ts` is used by the extension's GitHub tools; `eventHandlers.ts` is the extension webview's progress-view permission handling.

Desktop: `eventHandlers.ts`'s `createHostEventHandlerContext()` is explicitly shared with desktop's progress view, so the bypass-ordering fix applies there too. `githubAuth.ts` is host-neutral via `platform().secrets`.

CLI: `githubAuth.ts` is host-neutral via `platform().secrets`, so the CLI's GitHub tools pick up the same env-fallback path.

## Scheduled refactoring

None — the remaining low-impact finding (FileList.ts heuristic) was evaluated and intentionally left as-is per the abstraction-discipline rule (see above), not deferred.

## Validation

- `npm run typecheck` — passed (full monorepo, all packages).
- `npx vitest run src/test-kernel/tools/GitHubAuth.vitest.ts src/test-kernel/progressView/PermissionActionEventHandlers.vitest.ts` — 34/34 passed. One existing test (`ignores blank platform secrets before using environment fallbacks`) was updated to set its env fallback via the `secretsEnv` fixture instead of raw `process.env`, since that's the exact behavior this PR changes (env fallback now goes through the mockable `PlatformSecrets.getEnv()` seam once a platform is installed).
- `npx vitest run src/test-kernel/progressView src/test-kernel/tools/github` — 373/373 passed (full progress-view and GitHub-tools suites).
- `npx eslint` on all three changed files — clean.
- `npx prettier --check` — clean (auto-fixed one formatting issue before commit).
- `npm run check:dead-code-ratchet` — no new unused exports/files (234 findings, matches baseline).


---
_Generated by [Claude Code](https://claude.ai/code/session_01CoPNqzrM3KsWnxsJVQ15rS)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactors with existing test coverage; GitHub precedence is unchanged, only the env read path is host-agnostic when the platform is wired.
> 
> **Overview**
> Internal cleanup in two areas: **GitHub token env fallback** and **progress-view permission “yolo” messaging**.
> 
> **`getGitHubToken()`** no longer reads `process.env` for `GH_TOKEN` / `GITHUB_TOKEN` when a platform is initialized. Env fallbacks now go through **`PlatformSecrets.getEnv()`**, aligned with **`resolveGitHubTokenSource()`** via a shared **`getGitHubEnvToken(readEnv)`** helper. The only direct `process.env` read left is the documented pre-`initPlatform()` case.
> 
> **`handlePermissionAction()`** consolidates the repeated “post **ENABLE_*_BYPASS** first, then the approval/proposal action” pattern into **`postWithOptionalBypass()`** for tool-edit, bash, and proposal (approve-all delegated) flows, preserving FIFO ordering so bypass is live before the agent is unblocked.
> 
> The GitHub auth test for blank stored secrets now supplies env via the **`secretsEnv`** fixture instead of mutating **`process.env`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a7a40943da989a18affbbc8222fd2499f9b86c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->