### PR TITLE
feat(cli): phase-grouped per-agent rendering for focused workflow-script runs

### DIFF
--- a/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
@@ -191,6 +191,19 @@ export const TranscriptEntry = memo(function TranscriptEntry({
           process={entry.process}
         />
       );
+    case 'phase':
+      // A bold, colored divider that separates a workflow-script run's phases
+      // from the per-agent rows beneath. Stateless props-in → JSX-out.
+      return (
+        <Box
+          marginBottom={layout.marginBottomRows}
+          marginTop={layout.marginTopRows}
+        >
+          <Text bold color={colorEnabled !== false ? COLOR_HINT : undefined}>
+            {layout.lines.join('\n')}
+          </Text>
+        </Box>
+      );
     case 'assistant':
       return (
         <Box

--- a/packages/cli/src/chat/tui/panes/transcriptEntries.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntries.ts
@@ -67,6 +67,7 @@ export function isRenderableTranscriptEntry(entry: ConversationEntry): boolean {
     case 'assistant':
     case 'error':
     case 'user':
+    case 'phase':
       return terminalVisibleTranscriptText(entry.text).trim().length > 0;
     case 'process':
     case 'tool':

--- a/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
@@ -7,6 +7,7 @@ import { wrapAnsiToWidth } from '../render/ansiWrap';
 import { completedProcessDisplayLines } from '../state/completedProcessTranscript';
 import {
   ERROR_ENTRY_PREFIX,
+  STATUS_DIAMOND,
   TOOL_OUTPUT_CORNER,
   USER_ENTRY_PREFIX,
 } from '../ui/glyphs';
@@ -47,6 +48,13 @@ const ROLE_GEOMETRY = {
     inset: 2,
     marginBottomRows: 0,
     marginTopRows: 0,
+  },
+  phase: {
+    firstPrefix: '',
+    continuationPrefix: '  ',
+    inset: 0,
+    marginBottomRows: 0,
+    marginTopRows: 1,
   },
   process: {
     firstPrefix: '',
@@ -195,6 +203,19 @@ function entryLines(
       return mode === 'live' || mode === 'bounded'
         ? lines
         : wrapDisplayLines(lines, columns);
+    }
+    case 'phase': {
+      const suffix =
+        entry.phaseIndex !== undefined && entry.phaseTotal !== undefined
+          ? ` (${entry.phaseIndex + 1}/${entry.phaseTotal})`
+          : '';
+      const geometry = ROLE_GEOMETRY.phase;
+      return wrapWithPrefix(
+        `${STATUS_DIAMOND} ${entry.phaseLabel}${suffix}`,
+        columns,
+        geometry.firstPrefix,
+        geometry.continuationPrefix,
+      );
     }
     default: {
       const geometry = ROLE_GEOMETRY[entry.role];

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -71,6 +71,15 @@ interface ConversationEntryBase {
 export type ConversationEntry =
   | (ConversationEntryBase & { readonly role: 'assistant' | 'error' | 'user' })
   | (ConversationEntryBase & {
+      readonly role: 'phase';
+      /** Phase title displayed in the group-header divider row. */
+      readonly phaseLabel: string;
+      /** 0-based phase order within the run, when the emitter provides it. */
+      readonly phaseIndex?: number;
+      /** Total phase count for the run, when the emitter provides it. */
+      readonly phaseTotal?: number;
+    })
+  | (ConversationEntryBase & {
       readonly role: 'tool';
       readonly toolUse: NormalizedToolUse;
     })

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -275,6 +275,11 @@ function renderLogEntry(
   if (phaseData) {
     const phaseLabel = entry.text ?? '';
     if (phaseLabel.trim().length === 0) return null;
+    // GROUP_END (phase close) carries no index/total; keep the counts the
+    // GROUP_START row established so `(i/n)` doesn't vanish when a phase ends.
+    const prevPhase = prev?.role === 'phase' ? prev : undefined;
+    const phaseIndex = phaseData.index ?? prevPhase?.phaseIndex;
+    const phaseTotal = phaseData.total ?? prevPhase?.phaseTotal;
     const next: ConversationEntry = {
       id: entry.id,
       role: 'phase',
@@ -282,8 +287,8 @@ function renderLogEntry(
       ...(entry.messageType ? { messageType: entry.messageType } : {}),
       finalized: true,
       phaseLabel,
-      ...(phaseData.index !== undefined ? { phaseIndex: phaseData.index } : {}),
-      ...(phaseData.total !== undefined ? { phaseTotal: phaseData.total } : {}),
+      ...(phaseIndex !== undefined ? { phaseIndex } : {}),
+      ...(phaseTotal !== undefined ? { phaseTotal } : {}),
     };
     return prev && entriesEqual(prev, next) ? prev : next;
   }

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -10,6 +10,7 @@ import { defaultSession } from '@agent/runtime/SessionHandle';
 import { appendCliApiSwitchHint } from '@cli/runtime/approvalAdapter';
 import {
   MESSAGE_TYPES,
+  STREAM_LOG_ENTRY_TYPES,
   TOOL_USE_STATUS,
   type NormalizedToolUse,
   type StreamLogEntry,
@@ -160,7 +161,44 @@ function entriesEqual(
   if (prev.role === 'process' && next.role === 'process') {
     return prev.process === next.process;
   }
+  if (prev.role === 'phase' && next.role === 'phase') {
+    return (
+      prev.phaseIndex === next.phaseIndex && prev.phaseTotal === next.phaseTotal
+    );
+  }
   return true;
+}
+
+/**
+ * A phase group header — the `stage.start`/`stage.end` rows a workflow-script
+ * run emits per `phase()` (recorded as GROUP_START then upserted in place to
+ * GROUP_END with `data.kind === 'phase'`). Detected by `kind`, not entry
+ * `type`, so the header keeps its distinct role after the phase closes. Round,
+ * run, and session groups (other `kind` values) fall through to plain rows.
+ */
+function phaseGroupData(
+  entry: StreamLogEntry,
+): { index?: number; total?: number } | null {
+  if (
+    entry.type !== STREAM_LOG_ENTRY_TYPES.GROUP_START &&
+    entry.type !== STREAM_LOG_ENTRY_TYPES.GROUP_END
+  ) {
+    return null;
+  }
+  const data = entry.data;
+  if (typeof data !== 'object' || data === null || !('kind' in data)) {
+    return null;
+  }
+  const { kind, index, total } = data as {
+    kind?: unknown;
+    index?: unknown;
+    total?: unknown;
+  };
+  if (kind !== 'phase') return null;
+  return {
+    ...(typeof index === 'number' ? { index } : {}),
+    ...(typeof total === 'number' ? { total } : {}),
+  };
 }
 
 function logEntryRole(
@@ -229,6 +267,27 @@ function renderLogEntry(
     return next;
   }
 
+  // Phase group headers finalize the moment they appear (like user/error
+  // rows): the label never changes, and a later stage.end only upserts the
+  // group's `data`, keeping the same id. Detect before the generic text path
+  // so the row renders as a distinct divider instead of plain assistant prose.
+  const phaseData = phaseGroupData(entry);
+  if (phaseData) {
+    const phaseLabel = entry.text ?? '';
+    if (phaseLabel.trim().length === 0) return null;
+    const next: ConversationEntry = {
+      id: entry.id,
+      role: 'phase',
+      text: phaseLabel,
+      ...(entry.messageType ? { messageType: entry.messageType } : {}),
+      finalized: true,
+      phaseLabel,
+      ...(phaseData.index !== undefined ? { phaseIndex: phaseData.index } : {}),
+      ...(phaseData.total !== undefined ? { phaseTotal: phaseData.total } : {}),
+    };
+    return prev && entriesEqual(prev, next) ? prev : next;
+  }
+
   const text = entry.text ?? '';
   const role = logEntryRole(entry.messageType);
   const assistantTranscript =
@@ -269,6 +328,7 @@ function isSettledEntry(
     case 'user':
     case 'error':
     case 'process':
+    case 'phase':
       return true;
     case 'tool':
       return (

--- a/src/agent/workflowScript/runWorkflowScript.ts
+++ b/src/agent/workflowScript/runWorkflowScript.ts
@@ -338,6 +338,11 @@ export async function runWorkflowScript(
     }
 
     emit({ type: 'agent:start', index, label, phase: callOptions.phase });
+    // Host-side wall clock (the sandbox's Date.now ban is guest-only): timing
+    // and the reported model are progress-only, never journaled, so they can't
+    // affect resume identity or determinism.
+    const startedAt = Date.now();
+    let resolvedModel: string | undefined;
     let result: unknown;
     try {
       result = await semaphore.run(() => {
@@ -356,6 +361,9 @@ export async function runWorkflowScript(
           prompt,
           options: callOptions,
           signal: runAbort.signal,
+          reportModel: (model) => {
+            resolvedModel = model;
+          },
         });
       });
     } catch (error) {
@@ -371,6 +379,8 @@ export async function runWorkflowScript(
         phase: callOptions.phase,
         cached: false,
         error: toErrorMessage(error),
+        ...(resolvedModel !== undefined ? { model: resolvedModel } : {}),
+        durationMs: Date.now() - startedAt,
       });
       return 'null';
     }
@@ -393,6 +403,8 @@ export async function runWorkflowScript(
       label,
       phase: callOptions.phase,
       cached: false,
+      ...(resolvedModel !== undefined ? { model: resolvedModel } : {}),
+      durationMs: Date.now() - startedAt,
     });
     return payload;
   }

--- a/src/agent/workflowScript/types.ts
+++ b/src/agent/workflowScript/types.ts
@@ -52,6 +52,12 @@ export interface WorkflowAgentInvocation {
    * consuming model quota instead of finishing in the background.
    */
   signal: AbortSignal;
+  /**
+   * Optional host-side side channel: the runner reports the child model it
+   * resolved so the engine can attach it to the matching `agent:end` event
+   * for progress UIs. Never journaled — it does not affect resume identity.
+   */
+  reportModel?: (model: string) => void;
 }
 
 /**
@@ -83,6 +89,10 @@ export type WorkflowScriptEvent =
       phase?: string;
       cached: boolean;
       error?: string;
+      /** Child model resolved by the runner (live calls only). */
+      model?: string;
+      /** Host-measured wall time of the agent() call (live calls only). */
+      durationMs?: number;
     };
 
 export interface WorkflowScriptRunOptions {

--- a/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
@@ -179,6 +179,31 @@ return await agent('Second')`;
     );
   });
 
+  it('enriches live finish lines with the reported model and duration', async () => {
+    const { trace, events } = recordingTrace();
+    let liveCostUsd = 0;
+    await runPersistedWorkflowScriptWithProgress(trace, {
+      store: getExecutionStore(executionId),
+      checkpointId: 'model-duration',
+      script: `${meta}
+return await agent('Draft')`,
+      runAgent: async (invocation: WorkflowAgentInvocation) => {
+        invocation.reportModel?.('deepseekT');
+        liveCostUsd += 0.02;
+        return 'done';
+      },
+      getLiveCostUsd: () => liveCostUsd,
+    });
+
+    const finish = events.find(
+      (event) =>
+        event.type === 'log' && event.message.startsWith('Finished: Draft'),
+    );
+    expect(finish?.type === 'log' ? finish.message : '').toMatch(
+      /^Finished: Draft · deepseekT · \d+s \(\$0\.020 total\)$/,
+    );
+  });
+
   it('marks a phase failed when an agent call fails', async () => {
     const { trace, events } = recordingTrace();
     await runPersistedWorkflowScriptWithProgress(trace, {

--- a/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.mts
+++ b/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.mts
@@ -86,14 +86,24 @@ describe('CLI workflow-script child-stream transcript', () => {
 
       syncStreamLog(STREAM_ID);
 
-      const texts = (streams.get().get(STREAM_ID)?.entries ?? []).map(
-        (entry) => entry.text,
-      );
+      const entries = streams.get().get(STREAM_ID)?.entries ?? [];
+      const texts = entries.map((entry) => entry.text);
       // The phase group row surfaces its label; the agent lines surface as
       // their own generic assistant rows — the parity bar for a focused run.
       expect(texts).toContain('Draft sections');
       expect(texts).toContain('Running: introduction');
       expect(texts).toContain('Finished: introduction ($0.002 total)');
+
+      // The phase group is a distinct `role: 'phase'` header, not a plain
+      // assistant row, so the CLI can render it as a divider between phases.
+      const phaseEntry = entries.find(
+        (entry) => entry.text === 'Draft sections',
+      );
+      expect(phaseEntry).toMatchObject({
+        role: 'phase',
+        phaseLabel: 'Draft sections',
+        finalized: true,
+      });
 
       // Finalize the stream so the settled prefix promotes into scrollback.
       patchStream(STREAM_ID, (slice) => ({
@@ -138,7 +148,8 @@ describe('CLI workflow-script child-stream transcript', () => {
       });
 
       const output = await renderStaticTranscript();
-      expect(output).toContain('Draft sections');
+      // The phase header renders with its distinct diamond divider glyph.
+      expect(output).toContain('◆ Draft sections');
       expect(output).toContain('Running: introduction');
       expect(output).toContain('Finished: introduction ($0.002 total)');
     } finally {

--- a/src/tools/delegation/workflowScriptAgentRunner.ts
+++ b/src/tools/delegation/workflowScriptAgentRunner.ts
@@ -124,6 +124,9 @@ export function createWorkflowScriptAgentRunner(
               invocation.options.inputFiles ?? [],
             ),
           ]);
+          // Surface the resolved child model so the engine can attach it to
+          // this call's `agent:end` progress event.
+          invocation.reportModel?.(model);
           // Run-storage references can disappear during recovery. Validate
           // the resolved inputs, not merely the paths supplied by the script,
           // so a stale reference cannot launch a useless empty-envelope run.

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -9,7 +9,7 @@ import {
 } from '@agent/workflowScript';
 import { AgentFinalResultSchema } from '@agent/runtime/AgentFinalResult';
 import { RUN_OUTCOME, type RunOutcome } from '@shared/schemas';
-import { formatCostUsd } from '@utils/text/stringUtils';
+import { formatCompactDuration, formatCostUsd } from '@utils/text/stringUtils';
 
 type WorkflowScriptRunWithProgressOptions = Omit<
   PersistedWorkflowScriptRunOptions,
@@ -147,13 +147,25 @@ export async function runPersistedWorkflowScriptWithProgress(
         const spent = event.cached ? undefined : getLiveCostUsd?.();
         const total =
           spent === undefined ? '' : ` (${formatCostUsd(spent)} total)`;
+        // Live calls carry the resolved child model plus host-measured wall
+        // time; the duration rides alongside the model so it never appears as
+        // a bare orphan. Cached replays report neither, so the suffix is empty.
+        const duration =
+          event.durationMs === undefined
+            ? ''
+            : ` · ${formatCompactDuration(event.durationMs)}`;
+        const metaSuffix =
+          event.model === undefined ? '' : ` · ${event.model}${duration}`;
         if (event.error) {
           if (phaseTitle) phaseFor(phaseTitle).failed = true;
-          error(`Failed: ${event.label} - ${event.error}${total}`, stageId);
+          error(
+            `Failed: ${event.label}${metaSuffix} - ${event.error}${total}`,
+            stageId,
+          );
         } else if (event.cached) {
           info(`Using saved result: ${event.label}`, stageId);
         } else {
-          info(`Finished: ${event.label}${total}`, stageId);
+          info(`Finished: ${event.label}${metaSuffix}${total}`, stageId);
         }
         break;
       }


### PR DESCRIPTION
First increment of the rich workflow-run UI (#8722) — the Claude Code `/workflows` display target. After #8712 (async detach) + #8713 (delete the old projection), a `delegate_workflow_script` run is its own focusable child stream, but its phases and per-agent lines rendered as undifferentiated plain rows. This makes the focused stream read as a **phase-grouped per-agent view**.

## Part A — distinct phase headers
- `cliState.ts`: new `role: 'phase'` `ConversationEntry` variant (`phaseLabel`, optional `phaseIndex`/`phaseTotal`).
- `subscribeStreamLog.ts`: detects a phase group by `data.kind === 'phase'` on `GROUP_START` (and the upserted `GROUP_END`, so the header keeps its role after the phase closes); round/run/session groups fall through unchanged, so non-phase streams are unaffected; `GROUP_END` shares the group id → no spurious second row.
- `TranscriptEntry.tsx` + layout: a stateless bold/colored `◆ <label>` divider, consistent across live pane and Static scrollback, inside the existing per-entry error boundary.

## Part B — enriched per-agent lines
- `types.ts`: `agent:end` gains optional `model?`/`durationMs?`; `WorkflowAgentInvocation` gains a `reportModel?` side channel.
- `runWorkflowScript.ts`: measures wall time with a **host-side** `Date.now()` (the sandbox ban is guest-only) and captures the runner-reported model, attaching both to live `agent:end` emits (success + failure). Neither is journaled → resume identity/determinism untouched.
- `workflowScriptAgentRunner.ts`: reports the resolved child model. `workflowScriptRun.ts`: live `Finished:`/`Failed:` lines now read `... · <model> · <duration> ($cost total)`; cached replays omit the suffix.

## Verified (mocks only — no live model)
- `WorkflowScriptStreamTranscript.vitest.mts` (extended): drives a real trace through `TexraTranscriptRecorder` into a `workflow-script#` stream; asserts the phase entry is `{ role:'phase', phaseLabel:'Draft sections', finalized:true }` and the Ink `renderToString` Static render contains `◆ Draft sections` alongside the per-agent rows.
- `WorkflowScriptProgressBridge.vitest.ts` (added): a fake `runAgent` calls `reportModel('deepseekT')`; asserts the line matches `/^Finished: Draft · deepseekT · \d+s \(\$0\.020 total\)$/`.
- `src/test-kernel/cli/` + `WorkflowScript*` suites: 1924 pass. tsc (main + test-kernel), eslint, dead-code ratchet (233/233) clean. (One unrelated cross-file session-init flake `RunChatSignalOwnership` passes in isolation; touches nothing here.)

## Next increments (#8722)
Selectable per-agent detail pane (agentType, tokens · tool-calls · duration, expandable prompt, activity tail, structured outcome), a Phases panel with per-phase done/total, extension parity, and interactive per-agent kill/skip/retry (needs the per-call engine plumbing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly CLI transcript mapping and progress-only metadata that does not affect workflow journal or resume identity; risk is limited to display regressions on focused workflow-script streams.
> 
> **Overview**
> Focused **workflow-script** child streams now surface workflow **phases** as first-class transcript rows instead of plain assistant text. Stream log entries whose group `data.kind === 'phase'` map to a new `role: 'phase'` `ConversationEntry` (label plus optional `(i/n)`), render as a bold **`◆`** divider in live and static scrollback, and finalize immediately like user/error rows.
> 
> **Live `agent()` progress** is richer: the runner can call `reportModel`, the engine attaches optional **`model`** and host-measured **`durationMs`** on `agent:end` (not journaled), and trace lines read **`Finished:` / `Failed: … · <model> · <duration> ($total)`**; cached replays omit model and duration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81d3fa291ea4f9290134bc90e13ed27ac0a0a7e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->