### PR TITLE
feat(extension): show (i/n) count in workflow-script phase headers

### DIFF
--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -488,6 +488,14 @@ export class TaskGroupList extends LitElement {
       : '';
 
     const statusIcon = getStatusIcon(group.status);
+    // Surface a stage's position in its plan as `(i/n)` when both counts are
+    // present (round stages always carry them; phase stages when the engine
+    // knows the count). `index` is zero-based, so display it one-based — at
+    // parity with the CLI's `(index+1/total)` phase/round headers.
+    const positionText =
+      group.index !== undefined && group.total !== undefined
+        ? ` (${group.index + 1}/${group.total})`
+        : '';
     return html`
       <span class="group-status-icon">
         ${
@@ -500,7 +508,7 @@ export class TaskGroupList extends LitElement {
             : html`<wa-spinner></wa-spinner>`
         }
       </span>
-      <span class="group-title">${group.name}</span>
+      <span class="group-title">${group.name}${positionText}</span>
       <span class="group-time">
         <span class="group-start-time" data-start=${String(group.startTime)}>
           <wa-icon

--- a/src/agent/workflowScript/runWorkflowScript.ts
+++ b/src/agent/workflowScript/runWorkflowScript.ts
@@ -213,6 +213,7 @@ export async function runWorkflowScript(
   const pendingAgentCalls = new Set<Promise<unknown>>();
   let callCounter = 0;
   const issuedCallKeys = new Set<string>();
+  const plannedPhases = meta.phases ?? [];
   let currentPhase: string | undefined;
   let fatalRunError: WorkflowRunAbortError | undefined;
 
@@ -426,7 +427,14 @@ export async function runWorkflowScript(
           },
           phase: (args) => {
             currentPhase = String(args[0]);
-            emit({ type: 'phase', title: currentPhase });
+            const index = plannedPhases.findIndex(
+              (phase) => phase.title === currentPhase,
+            );
+            emit({
+              type: 'phase',
+              title: currentPhase,
+              ...(index >= 0 && { index, total: plannedPhases.length }),
+            });
             return undefined;
           },
         },

--- a/src/agent/workflowScript/types.ts
+++ b/src/agent/workflowScript/types.ts
@@ -73,7 +73,14 @@ export interface WorkflowJournalEntry {
 }
 
 export type WorkflowScriptEvent =
-  | { type: 'phase'; title: string }
+  | {
+      type: 'phase';
+      title: string;
+      /** Zero-based position in meta.phases, when the phase is declared. */
+      index?: number;
+      /** Number of phases declared in meta.phases. */
+      total?: number;
+    }
   | { type: 'log'; message: string }
   | { type: 'agent:start'; index: number; label: string; phase?: string }
   | {

--- a/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
@@ -482,7 +482,12 @@ return null`,
       onEvent: (event) => events.push(event),
     });
     expect(invocations[0].options.phase).toBe('Work');
-    expect(events).toContainEqual({ type: 'phase', title: 'Work' });
+    expect(events).toContainEqual({
+      type: 'phase',
+      title: 'Work',
+      index: 0,
+      total: 1,
+    });
     expect(events).toContainEqual({
       type: 'agent:start',
       index: 0,

--- a/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
@@ -43,12 +43,17 @@ describe('workflow-script progress bridge', () => {
   it('projects phases and logs under the captured parent stage', async () => {
     const { trace, events } = recordingTrace();
     const parent = trace.openStage('Parent');
+    const plannedMeta = `export const meta = {
+  name: 'planned-progress-test',
+  description: 'tests planned workflow progress projection',
+  phases: [{ title: 'Research' }, { title: 'Write' }],
+}`;
 
     await parent.within(() =>
       runPersistedWorkflowScriptWithProgress(trace, {
         store: getExecutionStore(executionId),
         checkpointId: 'phase-log',
-        script: `${meta}
+        script: `${plannedMeta}
 log('Preparing the workflow')
 phase('Research')
 log('Checking the source')
@@ -71,6 +76,8 @@ return await agent('Inspect')`,
         id: phaseId,
         parentId: parent.id,
         kind: 'phase',
+        index: 0,
+        total: 2,
       }),
     );
     expect(events.some((event) => event.type === 'child.activity')).toBe(false);

--- a/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
+++ b/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
@@ -392,3 +392,92 @@ describe('task-group-list status icon (#7993 step 3)', () => {
     expect(iconFor('failed-phase')).toBe('error');
   });
 });
+
+// #8722 Phase 2b: a focused delegate_workflow_script run projects its phases
+// as `kind: 'phase'` groups with per-agent Running/Finished/Failed lines
+// beneath. This locks the extension progress view at parity with the CLI's
+// phase/per-agent rendering (#8739): the phase renders as a group header with
+// its label plus the one-based `(i/n)` position, the enriched per-agent lines
+// render under it, and a `Failed:` line keeps error-level styling.
+describe('task-group-list workflow-script phase rendering (#8722)', () => {
+  it('renders a phase group with its (i/n) header and per-agent lines beneath', async () => {
+    const run: TaskGroup = {
+      id: 'run',
+      name: 'Run: workflow',
+      startTime: 1,
+      status: STREAM_PHASE.RUNNING,
+    };
+    const phase: TaskGroup = {
+      id: 'phase-review',
+      name: 'Review',
+      startTime: 2,
+      status: STREAM_PHASE.RUNNING,
+      parentGroupId: 'run',
+      kind: 'phase',
+      index: 1,
+      total: 3,
+    };
+    const messages: LogMessageData[] = [
+      {
+        id: 'agent-a',
+        text: 'Finished: reviewer · claude-opus-4 · 12.3s ($0.04)',
+        timestamp: 3,
+        level: LOG_LEVELS.INFO,
+        groupId: 'phase-review',
+      },
+      {
+        id: 'agent-b',
+        text: 'Failed: critic - timed out ($0.01 total)',
+        timestamp: 4,
+        level: LOG_LEVELS.ERROR,
+        groupId: 'phase-review',
+      },
+    ];
+
+    const list = await renderList([run, phase], messages);
+
+    // Header shows the phase label plus the one-based position, matching the
+    // CLI's `(index+1/total)` diamond header.
+    const title = list.shadowRoot
+      ?.querySelector(
+        `#${GROUP_DOM_IDS.HEADER_PREFIX}phase-review .group-title`,
+      )
+      ?.textContent?.trim();
+    expect(title).toBe('Review (2/3)');
+
+    // The enriched per-agent lines render under the phase group, and the
+    // Failed line keeps error-level styling.
+    const content = list.shadowRoot?.querySelector(
+      `#${GROUP_DOM_IDS.CONTENT_PREFIX}phase-review`,
+    );
+    expect(content?.textContent).toContain(
+      'Finished: reviewer · claude-opus-4 · 12.3s ($0.04)',
+    );
+    expect(content?.textContent).toContain('Failed: critic - timed out');
+    expect(content?.querySelector('.message-error')).not.toBeNull();
+  });
+
+  it('omits the (i/n) suffix when a phase group carries no counts', async () => {
+    const run: TaskGroup = {
+      id: 'run',
+      name: 'Run: workflow',
+      startTime: 1,
+      status: STREAM_PHASE.RUNNING,
+    };
+    const phase: TaskGroup = {
+      id: 'phase-solo',
+      name: 'Solo phase',
+      startTime: 2,
+      status: STREAM_PHASE.RUNNING,
+      parentGroupId: 'run',
+      kind: 'phase',
+    };
+
+    const list = await renderList([run, phase], []);
+
+    const title = list.shadowRoot
+      ?.querySelector(`#${GROUP_DOM_IDS.HEADER_PREFIX}phase-solo .group-title`)
+      ?.textContent?.trim();
+    expect(title).toBe('Solo phase');
+  });
+});

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -89,13 +89,19 @@ export async function runPersistedWorkflowScriptWithProgress(
   let closed = false;
   let runOutcome: RunOutcome = RUN_OUTCOME.FAILED;
 
-  const phaseFor = (title: string): PhaseStage => {
+  const phaseFor = (
+    title: string,
+    index?: number,
+    total?: number,
+  ): PhaseStage => {
     const existing = phases.get(title);
     if (existing) return existing;
     const phase = {
       handle: trace.openStage(title, {
         kind: 'phase',
         parentId: parentStageId,
+        index,
+        total,
       }),
       failed: false,
     };
@@ -120,7 +126,7 @@ export async function runPersistedWorkflowScriptWithProgress(
     switch (event.type) {
       case 'phase':
         currentPhase = event.title;
-        phaseFor(event.title);
+        phaseFor(event.title, event.index, event.total);
         onActivity?.(`Phase: ${event.title}`);
         break;
       case 'log':


### PR DESCRIPTION
Part of #8722. The extension progress view already renders a focused delegate_workflow_script run's phase-grouped per-agent view via the transcript plane (phase GROUP_START → collapsible group, enriched `Finished: … · model · duration ($cost)` lines beneath, `Failed:` with error styling). The only gap vs the CLI (#8739) was the phase header not surfacing the `(index/total)` that logSlice already captured. Adds ` (i/n)` (one-based, matching the CLI) to the group header when both are present — 9 production LoC, no new projection. Mocks-only test in TaskGroupListIndex.vitest.ts. tsc/eslint/ratchet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, backward-compatible optional fields on phase events and a display-only header change; no auth, persistence, or execution semantics.
> 
> **Overview**
> Workflow-script **phase** progress now carries **position in the declared plan** from `meta.phases` through to the extension progress view, matching CLI `(i/n)` headers (#8739).
> 
> When `phase()` runs, the engine looks up the title in `meta.phases` and emits optional zero-based `index` and `total` on `WorkflowScriptEvent` `phase` events. The progress bridge passes those into `trace.openStage` for `kind: 'phase'` stages, and **`TaskGroupList`** appends **` (index+1/total)`** to the group title when both fields are present; phases without counts keep the title unchanged.
> 
> Tests lock engine events, trace projection, and DOM rendering (including omitting the suffix when counts are missing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f48157dd9583aa0746ddc2154e6556c6fb4b4425. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->