### PR TITLE
fix(workflow): retain counts when agents open phases early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,12 @@ All notable changes to this project will be documented in this file.
 
 ### Extension (VS Code)
 
+#### New Features
+
+- **Workflow phase headers show their plan position** — focused workflow runs
+  label each declared phase with its current and total position, matching the
+  CLI progress view.
+
 #### Bug Fixes
 
 - **Extension history stays available if automatic updates cannot start** —

--- a/src/agent/workflowScript/runWorkflowScript.ts
+++ b/src/agent/workflowScript/runWorkflowScript.ts
@@ -36,6 +36,12 @@ const MAX_FANOUT = 512;
 const DRAIN_GRACE_MS = 5_000;
 const LABEL_EXCERPT_LENGTH = 48;
 
+type WorkflowScriptPhaseContext = {
+  readonly phase: string | undefined;
+  readonly phaseIndex?: number;
+  readonly phaseTotal?: number;
+};
+
 /**
  * Fan-out primitives, defined INSIDE the sandbox realm (trusted prelude,
  * compiled by the host, run before the script body). They must not live
@@ -219,6 +225,21 @@ export async function runWorkflowScript(
 
   const emit = (event: WorkflowScriptEvent) => onEvent?.(event);
 
+  const phaseContextFor = (
+    phase: string | undefined,
+  ): WorkflowScriptPhaseContext => {
+    const phaseIndex = plannedPhases.findIndex(
+      (plannedPhase) => plannedPhase.title === phase,
+    );
+    return {
+      phase,
+      ...(phaseIndex >= 0 && {
+        phaseIndex,
+        phaseTotal: plannedPhases.length,
+      }),
+    };
+  };
+
   const rememberFatalRunError = (error: unknown): WorkflowRunAbortError => {
     fatalRunError ??=
       error instanceof WorkflowRunAbortError
@@ -231,7 +252,7 @@ export async function runWorkflowScript(
   const recordJournalEntry = async (
     entry: WorkflowJournalEntry,
     label: string,
-    phase: string | undefined,
+    phaseContext: WorkflowScriptPhaseContext,
   ): Promise<void> => {
     journal.set(entry.index, entry);
     try {
@@ -243,7 +264,7 @@ export async function runWorkflowScript(
         type: 'agent:end',
         index: entry.index,
         label,
-        phase,
+        ...phaseContext,
         cached: false,
         error: message,
       });
@@ -268,16 +289,7 @@ export async function runWorkflowScript(
       );
     }
     const callOptions = normalizeAgentOptions(rawOptions, currentPhase);
-    const phaseIndex = plannedPhases.findIndex(
-      (phase) => phase.title === callOptions.phase,
-    );
-    const phaseContext = {
-      phase: callOptions.phase,
-      ...(phaseIndex >= 0 && {
-        phaseIndex,
-        phaseTotal: plannedPhases.length,
-      }),
-    };
+    const phaseContext = phaseContextFor(callOptions.phase);
     const index = callCounter;
     callCounter += 1;
 
@@ -406,7 +418,7 @@ export async function runWorkflowScript(
     await recordJournalEntry(
       { index, key, result: normalizedResult },
       label,
-      callOptions.phase,
+      phaseContext,
     );
     emit({
       type: 'agent:end',
@@ -449,13 +461,14 @@ export async function runWorkflowScript(
           },
           phase: (args) => {
             currentPhase = String(args[0]);
-            const index = plannedPhases.findIndex(
-              (phase) => phase.title === currentPhase,
-            );
+            const { phaseIndex, phaseTotal } = phaseContextFor(currentPhase);
             emit({
               type: 'phase',
               title: currentPhase,
-              ...(index >= 0 && { index, total: plannedPhases.length }),
+              ...(phaseIndex !== undefined && {
+                index: phaseIndex,
+                total: phaseTotal,
+              }),
             });
             return undefined;
           },

--- a/src/agent/workflowScript/runWorkflowScript.ts
+++ b/src/agent/workflowScript/runWorkflowScript.ts
@@ -10,6 +10,7 @@ import type {
   WorkflowAgentCallOptions,
   WorkflowJournalEntry,
   WorkflowScriptEvent,
+  WorkflowScriptPhaseContext,
   WorkflowScriptRunOptions,
   WorkflowScriptRunResult,
 } from './types';
@@ -35,12 +36,6 @@ const DEFAULT_MAX_AGENT_CALLS = 200;
 const MAX_FANOUT = 512;
 const DRAIN_GRACE_MS = 5_000;
 const LABEL_EXCERPT_LENGTH = 48;
-
-type WorkflowScriptPhaseContext = {
-  readonly phase: string | undefined;
-  readonly phaseIndex?: number;
-  readonly phaseTotal?: number;
-};
 
 /**
  * Fan-out primitives, defined INSIDE the sandbox realm (trusted prelude,

--- a/src/agent/workflowScript/runWorkflowScript.ts
+++ b/src/agent/workflowScript/runWorkflowScript.ts
@@ -268,6 +268,16 @@ export async function runWorkflowScript(
       );
     }
     const callOptions = normalizeAgentOptions(rawOptions, currentPhase);
+    const phaseIndex = plannedPhases.findIndex(
+      (phase) => phase.title === callOptions.phase,
+    );
+    const phaseContext = {
+      phase: callOptions.phase,
+      ...(phaseIndex >= 0 && {
+        phaseIndex,
+        phaseTotal: plannedPhases.length,
+      }),
+    };
     const index = callCounter;
     callCounter += 1;
 
@@ -301,7 +311,7 @@ export async function runWorkflowScript(
           type: 'agent:end',
           index,
           label,
-          phase: callOptions.phase,
+          ...phaseContext,
           cached,
           error: toErrorMessage(error),
         });
@@ -321,7 +331,7 @@ export async function runWorkflowScript(
         type: 'agent:end',
         index,
         label,
-        phase: callOptions.phase,
+        ...phaseContext,
         cached: true,
       });
       return payload;
@@ -338,7 +348,7 @@ export async function runWorkflowScript(
       );
     }
 
-    emit({ type: 'agent:start', index, label, phase: callOptions.phase });
+    emit({ type: 'agent:start', index, label, ...phaseContext });
     // Host-side wall clock (the sandbox's Date.now ban is guest-only): timing
     // and the reported model are progress-only, never journaled, so they can't
     // affect resume identity or determinism.
@@ -377,7 +387,7 @@ export async function runWorkflowScript(
         type: 'agent:end',
         index,
         label,
-        phase: callOptions.phase,
+        ...phaseContext,
         cached: false,
         error: toErrorMessage(error),
         ...(resolvedModel !== undefined ? { model: resolvedModel } : {}),
@@ -402,7 +412,7 @@ export async function runWorkflowScript(
       type: 'agent:end',
       index,
       label,
-      phase: callOptions.phase,
+      ...phaseContext,
       cached: false,
       ...(resolvedModel !== undefined ? { model: resolvedModel } : {}),
       durationMs: Date.now() - startedAt,

--- a/src/agent/workflowScript/types.ts
+++ b/src/agent/workflowScript/types.ts
@@ -78,7 +78,7 @@ export interface WorkflowJournalEntry {
   result: unknown;
 }
 
-interface WorkflowScriptPhaseContext {
+export interface WorkflowScriptPhaseContext {
   phase?: string;
   /** Zero-based position in meta.phases, when phase is declared. */
   phaseIndex?: number;

--- a/src/agent/workflowScript/types.ts
+++ b/src/agent/workflowScript/types.ts
@@ -78,6 +78,14 @@ export interface WorkflowJournalEntry {
   result: unknown;
 }
 
+interface WorkflowScriptPhaseContext {
+  phase?: string;
+  /** Zero-based position in meta.phases, when phase is declared. */
+  phaseIndex?: number;
+  /** Number of phases declared in meta.phases. */
+  phaseTotal?: number;
+}
+
 export type WorkflowScriptEvent =
   | {
       type: 'phase';
@@ -88,19 +96,22 @@ export type WorkflowScriptEvent =
       total?: number;
     }
   | { type: 'log'; message: string }
-  | { type: 'agent:start'; index: number; label: string; phase?: string }
-  | {
+  | (WorkflowScriptPhaseContext & {
+      type: 'agent:start';
+      index: number;
+      label: string;
+    })
+  | (WorkflowScriptPhaseContext & {
       type: 'agent:end';
       index: number;
       label: string;
-      phase?: string;
       cached: boolean;
       error?: string;
       /** Child model resolved by the runner (live calls only). */
       model?: string;
       /** Host-measured wall time of the agent() call (live calls only). */
       durationMs?: number;
-    };
+    });
 
 export interface WorkflowScriptRunOptions {
   /** Full script source, starting with `export const meta = {...}`. */

--- a/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
@@ -493,6 +493,8 @@ return null`,
       index: 0,
       label: 'labelled',
       phase: 'Work',
+      phaseIndex: 0,
+      phaseTotal: 1,
     });
   });
 

--- a/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
@@ -252,9 +252,10 @@ return await parallel([
   });
 
   it('surfaces a late checkpoint failure from an abandoned agent call', async () => {
+    const events: WorkflowScriptEvent[] = [];
     await expect(
       runWorkflowScript({
-        script: `${META}agent('abandoned'); return 'guest success'`,
+        script: `${META}agent('abandoned', { phase: 'Work' }); return 'guest success'`,
         runAgent: async () => {
           await delay(5);
           return 'completed child';
@@ -263,8 +264,16 @@ return await parallel([
           await delay(5);
           throw new Error('checkpoint offline');
         },
+        onEvent: (event) => events.push(event),
       }),
     ).rejects.toMatchObject({ name: 'WorkflowRunAbortError' });
+    expect(events.at(-1)).toMatchObject({
+      type: 'agent:end',
+      phase: 'Work',
+      phaseIndex: 0,
+      phaseTotal: 1,
+      error: expect.stringContaining('checkpoint offline'),
+    });
   });
 
   it('does not let a guest error mask a late checkpoint failure', async () => {

--- a/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
@@ -131,6 +131,35 @@ return await agent('Read', { phase: 'Review' })`;
     );
   });
 
+  it('keeps phase counts when an agent opens the stage before phase()', async () => {
+    const { trace, events } = recordingTrace();
+    const script = `export const meta = {
+  name: 'early-phase-agent',
+  description: 'opens a declared phase from an agent event',
+  phases: [{ title: 'Research' }, { title: 'Write' }],
+}
+const early = agent('Draft', { phase: 'Write' })
+phase('Write')
+return await early`;
+
+    await runPersistedWorkflowScriptWithProgress(trace, {
+      store: getExecutionStore(executionId),
+      checkpointId: 'early-phase-agent',
+      script,
+      runAgent: async () => 'done',
+    });
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: 'stage.start',
+        id: stageId(events, 'Write'),
+        kind: 'phase',
+        index: 1,
+        total: 2,
+      }),
+    );
+  });
+
   it('renders the running total on live finish lines only', async () => {
     const store = getExecutionStore(executionId);
     const script = `${meta}

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -109,8 +109,12 @@ export async function runPersistedWorkflowScriptWithProgress(
     return phase;
   };
 
-  const stageIdFor = (phase: string | undefined): string | undefined =>
-    phase ? phaseFor(phase).handle.id : parentStageId;
+  const stageIdFor = (
+    phase: string | undefined,
+    index?: number,
+    total?: number,
+  ): string | undefined =>
+    phase ? phaseFor(phase, index, total).handle.id : parentStageId;
 
   const info = (message: string, stageId: string | undefined): void => {
     trace.info(message, { stageId });
@@ -136,7 +140,7 @@ export async function runPersistedWorkflowScriptWithProgress(
         const phaseTitle = event.phase ?? currentPhase;
         callPhases.set(event.index, phaseTitle);
         trace.info(`Running: ${event.label}`, {
-          stageId: stageIdFor(phaseTitle),
+          stageId: stageIdFor(phaseTitle, event.phaseIndex, event.phaseTotal),
         });
         break;
       }
@@ -147,7 +151,11 @@ export async function runPersistedWorkflowScriptWithProgress(
           ? callPhases.get(event.index)
           : (event.phase ?? currentPhase);
         callPhases.delete(event.index);
-        const stageId = stageIdFor(phaseTitle);
+        const stageId = stageIdFor(
+          phaseTitle,
+          event.phaseIndex,
+          event.phaseTotal,
+        );
         // Cached replays spend nothing, so their lines stay cost-free; live
         // onCost settles before agent:end, so the total here is current.
         const spent = event.cached ? undefined : getLiveCostUsd?.();
@@ -163,7 +171,10 @@ export async function runPersistedWorkflowScriptWithProgress(
         const metaSuffix =
           event.model === undefined ? '' : ` · ${event.model}${duration}`;
         if (event.error) {
-          if (phaseTitle) phaseFor(phaseTitle).failed = true;
+          if (phaseTitle) {
+            phaseFor(phaseTitle, event.phaseIndex, event.phaseTotal).failed =
+              true;
+          }
           error(
             `Failed: ${event.label}${metaSuffix} - ${event.error}${total}`,
             stageId,


### PR DESCRIPTION
## Summary

Follow-up to #8740 and part of #8722.

Workflow phase stages now retain their declared `(index/total)` when an `agent()` event opens the stage before the script calls `phase(title)`. The changelog records the resulting extension behavior.

## Root cause

#8740 initially carried counts only on `phase` events. An agent may name a planned phase directly, so its earlier `agent:start` event could create and cache an uncounted trace stage. The later `phase` event could not update an already-open stage, leaving the extension header without its plan position.

## Design

The workflow metadata remains the single source of truth. The engine derives the declared phase position once per call and stamps it on agent events as well as phase events. The existing progress bridge passes those values into the existing trace stage; the renderer remains display-only and does not infer state.

## Validation

- 89 focused workflow engine, progress bridge, and extension renderer tests
- `npm run typecheck`
- `npm run lint` (no errors; one unrelated pre-existing warning)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to workflow event metadata and progress/trace staging; behavior is covered by new engine and progress-bridge tests with no security or persistence contract changes beyond richer events.
> 
> **Overview**
> Workflow runs can open a declared phase from an **`agent({ phase })`** call before the script invokes **`phase()`**, which left extension trace stages without their plan **(index/total)** because counts lived only on **`phase`** events and an already-open stage could not be updated.
> 
> The engine now derives **`phaseIndex`** / **`phaseTotal`** from **`meta.phases`** once per phase title and attaches that **`WorkflowScriptPhaseContext`** to **`agent:start`** and **`agent:end`** (including journal-persist failures). The workflow progress bridge passes those fields into **`phaseFor`** when resolving stage IDs, so early agent-driven stages get the same position labels as the CLI.
> 
> CHANGELOG notes that focused workflow phase headers in the VS Code extension match the CLI progress view.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d5381c2c0be7aeaa808440652b97f74b2b1aaf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->