### PR TITLE
fix(extension): honor Moonshot region for key links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,9 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Moonshot key links follow the selected region** — API-key actions now open
+  the international or China console that matches the configured Moonshot
+  endpoint.
 - **Extension history stays available if automatic updates cannot start** —
   reopening Settings refreshes the list without disrupting the extension.
 

--- a/packages/extension/src/commands/api/apiKeyCommands.ts
+++ b/packages/extension/src/commands/api/apiKeyCommands.ts
@@ -11,10 +11,7 @@ import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import { getMainWebview } from '@frontend/system/commandUtils';
 import * as logger from '@logger/logUtils';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
-import {
-  PROVIDER_DISPLAY_NAMES,
-  PROVIDER_URLS,
-} from '@shared/constants/providers';
+import { PROVIDER_DISPLAY_NAMES } from '@shared/constants/providers';
 import { refreshApiKeyCaches } from '@tools/setup/apiKeyHelpers';
 import { getSetupPlatform } from '@tools/setup/platform';
 import {
@@ -44,10 +41,7 @@ function createProfileKeyController(): SettingsProfileKeyController {
         provider,
         PROVIDER_DISPLAY_NAMES[provider] ?? provider,
       ),
-    getProviderKeyUrl: (provider) => {
-      const defaultUrl = PROVIDER_URLS[provider];
-      return defaultUrl ? getProviderKeyUrl(provider, defaultUrl) : undefined;
-    },
+    getProviderKeyUrl,
     getApiKeySecretName: (provider) =>
       SecretManager.getApiKeySecretName(provider as ApiProvider),
     setSecret: (key, value) => SecretManager.set(key, value),
@@ -104,7 +98,8 @@ async function promptForApiKey(
   ib.buttons = [getKeyButton];
   ib.onDidTriggerButton((button) => {
     if (button === getKeyButton) {
-      void vscode.env.openExternal(vscode.Uri.parse(PROVIDER_URLS[provider]));
+      const keyUrl = getProviderKeyUrl(provider);
+      if (keyUrl) void vscode.env.openExternal(vscode.Uri.parse(keyUrl));
     }
   });
   return settleQuickInput(ib, (accept) => {

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -225,12 +225,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
             provider,
             PROVIDER_DISPLAY_NAMES[provider] ?? provider,
           ),
-        getProviderKeyUrl: (provider) => {
-          const defaultUrl = PROVIDER_URLS[provider];
-          return defaultUrl
-            ? getProviderKeyUrl(provider, defaultUrl)
-            : undefined;
-        },
+        getProviderKeyUrl,
         getApiKeySecretName: (provider) =>
           SecretManager.getApiKeySecretName(provider as ApiProvider),
         setSecret: (key, value) => SecretManager.set(key, value),

--- a/packages/extension/src/webview/MainViewMessageHandler.ts
+++ b/packages/extension/src/webview/MainViewMessageHandler.ts
@@ -25,9 +25,9 @@ import {
   setFirstRunDone,
   setOnboardingDeclined,
 } from '@shared/state/onboardingState';
-import { PROVIDER_URLS } from '@shared/constants/providers';
 import { getConfig, updateConfig, SETTINGS_QUERY } from '@utils/config';
 import { checkCoreDependencies, getToolDocsCommand } from '@utils/system';
+import { getProviderKeyUrl } from '@utils/config/providerConfig';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { DiffManager } from './managers/DiffManager';
@@ -79,8 +79,7 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
     this.diffManager = new DiffManager();
     this.instructionManager = new InstructionManager();
     this.interactionController = new MainViewInteractionController({
-      getProviderUrl: (provider) =>
-        PROVIDER_URLS[provider as keyof typeof PROVIDER_URLS],
+      getProviderUrl: getProviderKeyUrl,
       getToolDocsCommand,
     });
     this.startupController = new MainViewStartupController({

--- a/src/test-kernel/utils/config/ConfigUtils.vitest.ts
+++ b/src/test-kernel/utils/config/ConfigUtils.vitest.ts
@@ -9,6 +9,7 @@ import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
 import { getValidatedConfig } from '@utils/config/configUtils';
 import {
   getProviderEndpoint,
+  getProviderKeyUrl,
   getUseOpenRouter,
 } from '@utils/config/providerConfig';
 import { readPlatformSetting } from '@utils/config/platformSettings';
@@ -174,5 +175,29 @@ describe('getProviderEndpoint', () => {
 
   it('returns empty string for a provider with no endpoint key', () => {
     expect(getProviderEndpoint('not-a-real-provider')).toBe('');
+  });
+});
+
+describe('getProviderKeyUrl', () => {
+  it('owns the provider default and applies the configured region', async () => {
+    await installPlatform({
+      globalState: { [GlobalStateKey.MOONSHOT_USE_CHINA]: false },
+    });
+
+    expect(getProviderKeyUrl('moonshot')).toBe(
+      'https://platform.moonshot.ai/console',
+    );
+  });
+
+  it('returns the registry default when the default region is active', async () => {
+    await installPlatform({});
+
+    expect(getProviderKeyUrl('moonshot')).toBe(
+      'https://platform.moonshot.cn/console',
+    );
+    expect(getProviderKeyUrl('openai')).toBe(
+      'https://platform.openai.com/api-keys',
+    );
+    expect(getProviderKeyUrl('not-a-provider')).toBeUndefined();
   });
 });

--- a/src/utils/config/providerConfig.ts
+++ b/src/utils/config/providerConfig.ts
@@ -17,6 +17,7 @@
 import { tryGlobalState } from '@platform/platform';
 import {
   PROVIDER_STATE_ENTRIES,
+  PROVIDER_URLS,
   type ProviderStateEntry,
 } from '@shared/constants/providers';
 import { GlobalStateKey } from '@shared/state/stateKeys';
@@ -104,10 +105,13 @@ export function getProviderDisplayName(
   return regionSet(provider) ? region.displayName : defaultName;
 }
 
+export function getProviderKeyUrl(provider: string): string | undefined;
+export function getProviderKeyUrl(provider: string, defaultUrl: string): string;
 export function getProviderKeyUrl(
   provider: string,
-  defaultUrl: string,
-): string {
+  defaultUrl = PROVIDER_URLS[provider],
+): string | undefined {
+  if (!defaultUrl) return undefined;
   const region = entry(provider)?.region;
   if (!region) return defaultUrl;
   const isSet = regionSet(provider);


### PR DESCRIPTION
## Summary

- make the shared provider-key URL resolver own registry defaults and region selection
- route extension quick-input, main-view, and settings key actions through that resolver
- cover China, international, ordinary-provider, and unknown-provider behavior

Closes #8711

## Validation

- npm run format
- npm run compile:safe
- npm run lint (passes with one pre-existing warning)
- npm test (740 files passed, 6794 tests passed; 1 file and 4 tests skipped)
- focused settings/config suite (4 files, 41 tests passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only which external URL opens for key setup; secrets and endpoint configuration are unchanged.
> 
> **Overview**
> **Moonshot “get API key” links now follow the configured region** instead of always opening the static registry URL (`.cn` by default).
> 
> `getProviderKeyUrl` is the single resolver: it pulls defaults from `PROVIDER_URLS`, applies per-provider region overrides (e.g. Moonshot international → `platform.moonshot.ai`), and returns `undefined` for unknown providers. The VS Code extension wires API-key quick input, Settings profile key actions, and main-view provider URLs through that helper instead of duplicating `PROVIDER_URLS` lookups.
> 
> Vitest coverage documents China vs international Moonshot, ordinary providers, and missing providers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3987f7d45ace77c3d6645f68bcbee34c45c8169d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->