### PR TITLE
refactor(storage): delete legacy heartbeat reader

### DIFF
--- a/src/agent/storage/executionLease.ts
+++ b/src/agent/storage/executionLease.ts
@@ -4,7 +4,6 @@ import * as path from 'node:path';
 
 import { z } from 'zod';
 
-import { RUNS_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 import { platform } from '@platform/platform';
 import { isFileNotFoundError } from '@common/errors';
 import { WORKSPACE_STORAGE_LAYOUT } from '@common/storage/storageLayout';
@@ -17,9 +16,6 @@ const CHANNEL = 'ExecutionLease';
 /** A host that misses eight heartbeats is no longer considered live. */
 export const EXECUTION_LEASE_STALE_MS = 120_000;
 const EXECUTION_LEASE_HEARTBEAT_MS = 15_000;
-/** Compatibility horizon used by the heartbeat protocol shipped before leases. */
-const LEGACY_HEARTBEAT_STALE_MS = 30_000;
-const LEGACY_HEARTBEAT_FILE = 'heartbeat.json';
 
 const LeaseExecutionIdSchema = z
   .string()
@@ -96,16 +92,6 @@ function leasePath(root: string, executionId: ExecutionId): string {
   );
 }
 
-function legacyHeartbeatPath(root: string, executionId: ExecutionId): string {
-  const safeExecutionId = LeaseExecutionIdSchema.parse(executionId);
-  return path.join(
-    root,
-    RUNS_STORAGE_DIR,
-    safeExecutionId,
-    LEGACY_HEARTBEAT_FILE,
-  );
-}
-
 function coordinationPath(root: string, executionId: ExecutionId): string {
   const safeExecutionId = LeaseExecutionIdSchema.parse(executionId);
   return path.join(
@@ -165,33 +151,11 @@ function isFresh(record: ExecutionLeaseRecord, now: number): boolean {
   return now - record.heartbeatAt <= EXECUTION_LEASE_STALE_MS;
 }
 
-async function readLegacyHeartbeatAt(
-  executionId: ExecutionId,
-  root: string,
-): Promise<number | undefined> {
-  try {
-    return (await StorageFS.stat(legacyHeartbeatPath(root, executionId))).mtime;
-  } catch (error) {
-    if (isFileNotFoundError(error)) return undefined;
-    throw error;
-  }
-}
-
-function isLegacyHeartbeatFresh(
-  heartbeatAt: number | undefined,
-  now: number,
-): heartbeatAt is number {
-  return (
-    heartbeatAt !== undefined && now - heartbeatAt < LEGACY_HEARTBEAT_STALE_MS
-  );
-}
-
 type PersistedExecutionLiveness =
   | {
       readonly status: 'active';
-      readonly source: 'lease' | 'legacy-heartbeat';
       readonly heartbeatAt: number;
-      readonly currentLease: ExecutionLeaseRecord | undefined;
+      readonly currentLease: ExecutionLeaseRecord;
     }
   | {
       readonly status: 'inactive';
@@ -199,7 +163,6 @@ type PersistedExecutionLiveness =
       readonly currentLease: ExecutionLeaseRecord | undefined;
     };
 
-/** Read both the current lease protocol and its one-release compatibility seam. */
 async function readPersistedExecutionLiveness(
   executionId: ExecutionId,
   root: string,
@@ -209,23 +172,13 @@ async function readPersistedExecutionLiveness(
   if (currentLease && isFresh(currentLease, now)) {
     return {
       status: 'active',
-      source: 'lease',
       heartbeatAt: currentLease.heartbeatAt,
-      currentLease,
-    };
-  }
-  const legacyHeartbeatAt = await readLegacyHeartbeatAt(executionId, root);
-  if (isLegacyHeartbeatFresh(legacyHeartbeatAt, now)) {
-    return {
-      status: 'active',
-      source: 'legacy-heartbeat',
-      heartbeatAt: legacyHeartbeatAt,
       currentLease,
     };
   }
   return {
     status: 'inactive',
-    staleHeartbeatAt: currentLease?.heartbeatAt ?? legacyHeartbeatAt,
+    staleHeartbeatAt: currentLease?.heartbeatAt,
     currentLease,
   };
 }
@@ -549,18 +502,15 @@ export async function inspectExecutionLease(
 ): Promise<ExecutionLeasePresence> {
   const root = storageRoot();
   const liveness = await readPersistedExecutionLiveness(executionId, root, now);
-  if (liveness.status === 'active' && liveness.source === 'lease') {
+  if (liveness.status === 'active') {
     const local = ownedLeases.get(ownershipKey(root, executionId));
     return {
       status:
-        local?.ownerToken === liveness.currentLease?.ownerToken
+        local?.ownerToken === liveness.currentLease.ownerToken
           ? 'owned'
           : 'foreign',
       heartbeatAt: liveness.heartbeatAt,
     };
-  }
-  if (liveness.status === 'active') {
-    return { status: 'foreign', heartbeatAt: liveness.heartbeatAt };
   }
   return liveness.staleHeartbeatAt === undefined
     ? { status: 'missing' }

--- a/src/test-kernel/agent/storage/ExecutionLease.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionLease.vitest.ts
@@ -92,40 +92,6 @@ describe('cross-process execution leases', () => {
     expect(await StorageFS.exists(`executions/${executionId}`)).toBe(true);
   });
 
-  it('protects executions owned by a host using the legacy heartbeat protocol', async () => {
-    const executionId = 'a8644b' as ExecutionId;
-    await writeExecution(executionId);
-    await StorageFS.writeAtomic(
-      `executions/${executionId}/heartbeat.json`,
-      '{}',
-    );
-
-    await expect(deleteExecution(executionId)).resolves.toMatchObject({
-      status: 'active',
-      executionId,
-    });
-    await expect(
-      acquireResumedExecutionLease(executionId),
-    ).rejects.toBeInstanceOf(ExecutionLeaseActiveError);
-    expect(await StorageFS.exists(`executions/${executionId}`)).toBe(true);
-  });
-
-  it('allows deletion after a legacy heartbeat becomes stale', async () => {
-    const executionId = 'a8644c' as ExecutionId;
-    await writeExecution(executionId);
-    await StorageFS.writeAtomic(
-      `executions/${executionId}/heartbeat.json`,
-      '{}',
-    );
-    const now = Date.now();
-    vi.spyOn(Date, 'now').mockReturnValue(now + 30_001);
-
-    await expect(deleteExecution(executionId)).resolves.toEqual({
-      status: 'deleted',
-      executionId,
-    });
-  });
-
   it('takes over a stale lease after the explicit horizon', async () => {
     const executionId = 'b8644b' as ExecutionId;
     const now = Date.now();


### PR DESCRIPTION
## Summary

- remove the compatibility reader for heartbeat.json, which no released TeXRA build ever wrote
- make active persisted liveness always carry a current lease record
- delete the two fixtures for the impossible legacy state

Closes #8752

## Release-history check

Both the heartbeat writer and its lease replacement first shipped in v0.39.6. The v0.39.6 production tree contains no heartbeat.json writer.

## Validation

- npm run format
- npm run compile:safe
- npm run lint (passes with one pre-existing warning)
- npm test (740 files passed, 6792 tests passed; 1 file and 4 tests skipped)
- focused lease/deletion/restart/progress/lifecycle suite (6 files, 121 tests passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cross-process execution liveness and deletion/resume gating; behavior shifts only for hypothetical legacy heartbeat state that shipped builds never wrote.
> 
> **Overview**
> Removes the **one-release compatibility path** that treated `executions/<id>/heartbeat.json` mtime as proof an execution was still live. Liveness is now determined **only** from persisted lease JSON under `executionLeases/`.
> 
> **`PersistedExecutionLiveness`** no longer carries a `source` of `lease` vs `legacy-heartbeat`; when status is `active`, `currentLease` is always a full lease record. **`inspectExecutionLease`** is simplified to a single active branch (owned vs foreign by token match). Stale/missing paths no longer consider legacy heartbeat timestamps.
> 
> The two vitest cases that simulated legacy heartbeat protection and stale deletion are removed as dead scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14c83fb318d9a8d3f424104b40358f1510c35a29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->