### PR TITLE
feat(cli): show model + tool-call count on subagent rows (workflow-script per-agent detail)

### DIFF
--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -149,11 +149,16 @@ function SessionRow({
   // and last the pending-approval kind. The metadata column never shrinks.
   const approvalSuffix = pendingApprovalRowSuffix(pendingKinds);
   const roundLabel = formatRoundStageLabel(session.slice?.roundStage);
+  // The resolved model is per-agent identity (a workflow run's grandchildren
+  // can each resolve a different model); the list-root row is the conversation
+  // itself, whose model already rides the status bar.
+  const modelLabel = isListRoot ? undefined : session.slice?.model;
   const metadata = metadataColumn
     ? childRowMetadataText({
         elapsed,
         outputTokens: (session.slice?.cumulativeUsage ?? session.slice?.usage)
           ?.outputTokens,
+        toolCallCount: session.slice?.conversation?.toolCallCount,
       })
     : undefined;
   // Child rows summarize what the subagent last said; the list-root row is
@@ -183,6 +188,7 @@ function SessionRow({
           {statusLabel ? ` ${statusLabel}` : ''}
           {approvalSuffix ? ` · ${approvalSuffix}` : ''}
           {roundLabel ? ` · ${roundLabel}` : ''}
+          {modelLabel ? ` · ${modelLabel}` : ''}
           {!metadataColumn && elapsed ? ` · ${elapsed}` : ''}
         </Text>
       </Box>

--- a/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
@@ -1,5 +1,6 @@
 // Local imports - shared formatting
 import { formatCompactTokenCount } from '@utils/core';
+import { formatResultCount } from '@utils/text/stringUtils';
 
 // Local imports - TUI state and presentation
 import { isChildExecutionErrorStatus } from '../state/childExecutionStatus';
@@ -45,22 +46,31 @@ const PENDING_APPROVAL_ROW_LABELS: Record<PendingApprovalKind, string> = {
  *  and rows keep their inline elapsed, so identity is not crowded out. */
 export const CHILD_ROW_METADATA_MIN_COLUMNS = 60;
 
-/** Right-aligned metadata column for a child row: elapsed time plus the
- *  child's generated tokens so far (e.g. `2m 30s · ↓40k`). Output tokens are
- *  the "work produced" figure — deliberately not the context-fill number the
- *  status bar reports for the focused stream. */
+/** Right-aligned metadata column for a child row: elapsed time, the number of
+ *  tool calls the child has made, and its generated tokens so far (e.g.
+ *  `2m 30s · 5 tool calls · ↓40k`). This is the per-agent stats summary a
+ *  workflow-script run's `agent()` grandchildren surface when the run is
+ *  focused; a plain subagent with no tool calls yet just shows elapsed/tokens.
+ *  Output tokens are the "work produced" figure — deliberately not the
+ *  context-fill number the status bar reports for the focused stream. */
 export function childRowMetadataText({
   elapsed,
   outputTokens,
+  toolCallCount,
 }: {
   readonly elapsed: string | null | undefined;
   readonly outputTokens: number | undefined;
+  readonly toolCallCount?: number | undefined;
 }): string | undefined {
+  const toolCalls =
+    toolCallCount !== undefined && toolCallCount > 0
+      ? formatResultCount(toolCallCount, 'tool call')
+      : undefined;
   const tokens =
     outputTokens !== undefined && outputTokens > 0
       ? `${TOKENS_GENERATED}${formatCompactTokenCount(outputTokens)}`
       : undefined;
-  const parts = [elapsed, tokens].filter(Boolean);
+  const parts = [elapsed, toolCalls, tokens].filter(Boolean);
   return parts.length > 0 ? parts.join(' · ') : undefined;
 }
 

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -1,3 +1,5 @@
+import { createRequire } from 'node:module';
+
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -6,7 +8,11 @@ import {
   childStatusColor,
   pendingApprovalRowSuffix,
 } from '@cli/chat/tui/panes/SubagentListDisplay';
-import { compactChildRowText } from '@cli/chat/tui/panes/SubagentList';
+import {
+  SubagentList,
+  compactChildRowText,
+} from '@cli/chat/tui/panes/SubagentList';
+import type { StreamSlice } from '@cli/chat/tui/state/cliState';
 import {
   nextSelectHighlightIndex,
   selectControlledHighlightIndex,
@@ -14,7 +20,11 @@ import {
   type SelectItem,
 } from '@cli/chat/tui/ui/Select';
 import type { StreamView } from '@cli/chat/tui/state/streamViews';
-import { STREAM_PHASE, type StreamTabId } from '@shared/schemas';
+import { AgentCategory, STREAM_PHASE, type StreamTabId } from '@shared/schemas';
+
+const cliRequire = createRequire(
+  new URL('../../../packages/cli/package.json', import.meta.url),
+);
 
 function session(id: string, active = false): StreamView {
   return {
@@ -22,6 +32,35 @@ function session(id: string, active = false): StreamView {
     label: id,
     slice: undefined,
     active,
+  };
+}
+
+function workflowAgentSlice(
+  id: string,
+  overrides: Partial<StreamSlice>,
+): StreamSlice {
+  return {
+    streamId: id as StreamTabId,
+    model: undefined,
+    category: AgentCategory.Workflow,
+    status: STREAM_PHASE.COMPLETED,
+    substate: undefined,
+    runStartedAt: undefined,
+    description: undefined,
+    thinkingActive: false,
+    usage: undefined,
+    cumulativeUsage: undefined,
+    conversation: undefined,
+    roundStage: undefined,
+    entries: [],
+    queuedFollowUps: 0,
+    queuedFollowUpMessages: [],
+    activeProcesses: [],
+    todos: [],
+    plan: null,
+    processOutput: new Map(),
+    bypass: { bash: false, toolEdit: false, superYolo: false },
+    ...overrides,
   };
 }
 
@@ -170,5 +209,72 @@ describe('CLI child list display model', () => {
     expect(
       childRowMetadataText({ elapsed: null, outputTokens: 0 }),
     ).toBeUndefined();
+  });
+
+  it('adds the tool-call count between elapsed and generated tokens', () => {
+    expect(
+      childRowMetadataText({
+        elapsed: '2m 30s',
+        outputTokens: 39_900,
+        toolCallCount: 5,
+      }),
+    ).toBe('2m 30s · 5 tool calls · ↓40k');
+    expect(
+      childRowMetadataText({
+        elapsed: '45s',
+        outputTokens: undefined,
+        toolCallCount: 1,
+      }),
+    ).toBe('45s · 1 tool call');
+    // No tool calls yet is not a datum worth a column segment.
+    expect(
+      childRowMetadataText({
+        elapsed: '45s',
+        outputTokens: undefined,
+        toolCallCount: 0,
+      }),
+    ).toBe('45s');
+  });
+
+  it('surfaces per-agent model, tool calls, and tokens for a focused run', async () => {
+    const ink = (await import(cliRequire.resolve('ink'))) as any;
+    const React = ((await import(cliRequire.resolve('react'))) as any).default;
+    const run = 'run' as StreamTabId;
+    const agent = 'agent-1' as StreamTabId;
+    const output: string = ink.renderToString(
+      React.createElement(SubagentList, {
+        listRootStreamId: run,
+        maxRows: 6,
+        keyboardActive: false,
+        sessions: [
+          {
+            id: run,
+            label: 'workflow-run',
+            slice: workflowAgentSlice('run', { status: STREAM_PHASE.RUNNING }),
+            active: true,
+          },
+          {
+            id: agent,
+            label: 'coder',
+            slice: workflowAgentSlice('agent-1', {
+              model: 'claude-sonnet-4',
+              conversation: { toolCallCount: 5 },
+              cumulativeUsage: {
+                inputTokens: 1000,
+                outputTokens: 39_900,
+                cost: 0,
+              },
+            }),
+            active: false,
+          },
+        ],
+      }),
+      { columns: 100 },
+    );
+
+    expect(output).toContain('coder');
+    expect(output).toContain('claude-sonnet-4');
+    expect(output).toContain('5 tool calls');
+    expect(output).toContain('↓40k');
   });
 });


### PR DESCRIPTION
Part of #8722 — the per-agent detail (display half) for a focused delegate_workflow_script run.

## Key finding: the generic child focus already covers most of it
A workflow `agent()` grandchild is a real registered child stream (parentExecutionId/parentStreamId = the run, onStreamResolved registers its stream). So when a workflow run is focused, its grandchildren already appear as focusable SubagentList rows, and focusing one already switches the transcript viewport to that agent's full transcript (responses, tool calls, result), with model/agentType/usage on its StreamSlice. This was a **small enhancement, not a new pane** — no bespoke workflow projection (consistent with #8713 deleting one).

## Change (+26 product LoC, reuse only)
- `SubagentListDisplay.ts`: `childRowMetadataText` gains optional `toolCallCount`, so the right column reads `elapsed · N tool calls · ↓tokens` (via `formatResultCount`, omitted at 0).
- `SubagentList.tsx`: threads `slice.conversation.toolCallCount` into that column and surfaces `slice.model` after the round label (suppressed on the list-root row, whose model rides the status bar).

Both are plain reads off the existing `StreamSlice` — stateless renderer, no Date.now/synthetic ids, no per-component toggle state. Generic to all subagent rows (desirable given multi-provider model mixing), not workflow-specific.

## Verified (mocks only)
`SubagentListDisplay.vitest.mts`: pure `childRowMetadataText` cases + an `ink.renderToString` test rendering `SubagentList` with a synthetic focused-run roster (a grandchild slice with model/toolCallCount/outputTokens), asserting label + model + `5 tool calls` + `↓40k`. 10/10 pass. tsc (main + test-kernel), eslint, dead-code ratchet clean. (Pre-existing unrelated failures `RunChatSignalOwnership` + flaky `ModelAccessForm` verified present without this change.)

## Deferred (follow-ups)
Interactive per-agent kill/skip/retry (consumes the engine onControl from #8741); a fuller expanded detail card (prompt excerpt / activity tail / full outcome) beyond the compact row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only TUI changes with no auth, data, or runtime behavior changes; narrow formatting and test coverage.
> 
> **Overview**
> **Subagent list rows** now expose more per-child identity from existing `StreamSlice` fields, without new state or workflow-only UI.
> 
> Child session rows append the resolved **`model`** after the round label (skipped on the **list-root** row so it does not duplicate the status bar). The right-aligned metadata column can include **`N tool call(s)`** between elapsed time and generated tokens via an optional `toolCallCount` on `childRowMetadataText` (omitted when zero).
> 
> Tests cover the metadata formatter and an Ink `renderToString` case for a focused workflow run with a grandchild showing model, tool calls, and token output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4b233c6ea6f288ebe9c44fd15e9806a22d76780. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->