### PR TITLE
feat: interactive per-agent skip/retry for workflow-script runs

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -2022,6 +2022,8 @@ function renderHarnessApp(): React.JSX.Element {
     <App
       onSubmit={handleHarnessSubmit}
       onKillExecution={markHarnessExecutionStopped}
+      onSkipExecution={() => undefined}
+      onRetryExecution={() => undefined}
       canInterruptActiveRun={() => canInterrupt}
       canStopActiveRun={() => canInterrupt}
       colorEnabled={HARNESS_COLOR_ENABLED}

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -14,7 +14,11 @@ import {
 
 // Local imports - shared runtime
 import { defaultShortcutModifierLabel } from '@cli/runtime/shortcutLabels';
-import type { ActiveChildInfo, StreamTabId } from '@shared/schemas';
+import {
+  AgentCategory,
+  type ActiveChildInfo,
+  type StreamTabId,
+} from '@shared/schemas';
 
 // Local imports - TUI surfaces and state
 import {
@@ -123,6 +127,10 @@ function focusStreamAndPromoteApprovals(streamId: StreamTabId): void {
 export interface AppProps {
   readonly onSubmit: (line: string, mediaFiles?: readonly string[]) => void;
   readonly onKillExecution: (executionId: string) => void;
+  /** Skip a focused, in-flight workflow-script grandchild `agent()` call. */
+  readonly onSkipExecution: (executionId: string) => void;
+  /** Retry a focused, in-flight workflow-script grandchild `agent()` call. */
+  readonly onRetryExecution: (executionId: string) => void;
   readonly canInterruptActiveRun: () => boolean;
   readonly canStopActiveRun?: () => boolean;
   readonly colorEnabled?: boolean;
@@ -336,6 +344,21 @@ export function App(props: AppProps): React.JSX.Element {
       )
     : selectedChildStreamId !== undefined &&
       activeSubagentExecutionIds.has(selectedChildStreamId);
+  // A workflow-script grandchild `agent()` call is the only interactively
+  // skip/retry-able row: it is a Workflow-category subagent whose parent
+  // stream is itself the Workflow run (the run stream's parent is the
+  // orchestrator, a non-Workflow category), which excludes the run stream
+  // itself so its row never shows a control that would silently no-op.
+  const parentOfSelectedChild =
+    selectedChildStreamId !== undefined
+      ? parentStream.get(selectedChildStreamId)
+      : undefined;
+  const selectedChildWorkflowControllable =
+    selectedChildKillable &&
+    selectedChildStreamId !== undefined &&
+    streams.get(selectedChildStreamId)?.category === AgentCategory.Workflow &&
+    parentOfSelectedChild !== undefined &&
+    streams.get(parentOfSelectedChild)?.category === AgentCategory.Workflow;
   const taskDetailProcess = taskDetailExecutionId
     ? activeProcesses.find(
         (process) => process.executionId === taskDetailExecutionId,
@@ -627,6 +650,9 @@ export function App(props: AppProps): React.JSX.Element {
               childListFocused={childListFocused}
               childListSelectionKind={selectedChildKind}
               childListSelectionKillable={selectedChildKillable}
+              childListSelectionWorkflowControllable={
+                selectedChildWorkflowControllable
+              }
               childNavigationAvailable={childListAvailable}
               shortcutsActive={focusShortcutsActive}
               streamFocusAvailable={sessionViews.length > 0}
@@ -657,6 +683,8 @@ export function App(props: AppProps): React.JSX.Element {
         onCancelChildList={cancelChildList}
         onFocusSession={focusSession}
         onKillExecution={props.onKillExecution}
+        onSkipExecution={props.onSkipExecution}
+        onRetryExecution={props.onRetryExecution}
         onOpenProcessDetail={(executionId) =>
           taskDetailExecutionIdSignal.set(executionId)
         }

--- a/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
@@ -78,6 +78,8 @@ interface ConversationRegionProps {
   readonly onChildSelectionChange: (value: ChildListValue) => void;
   readonly onFocusSession: (streamId: StreamTabId) => void;
   readonly onKillExecution: (executionId: string) => void;
+  readonly onSkipExecution: (executionId: string) => void;
+  readonly onRetryExecution: (executionId: string) => void;
   readonly onOpenProcessDetail: (executionId: string) => void;
   readonly onPrintStream: (streamId: StreamTabId) => void;
 }
@@ -89,6 +91,8 @@ export function ConversationRegion({
   onChildSelectionChange,
   onFocusSession,
   onKillExecution,
+  onSkipExecution,
+  onRetryExecution,
   onOpenProcessDetail,
   onPrintStream,
   onStaticTranscriptChange,
@@ -253,6 +257,8 @@ export function ConversationRegion({
               onCancel={onCancelChildList}
               onFocusStream={onFocusSession}
               onKillExecution={onKillExecution}
+              onSkipExecution={onSkipExecution}
+              onRetryExecution={onRetryExecution}
               onOpenProcessDetail={onOpenProcessDetail}
               onSelectionChange={onChildSelectionChange}
               onPrintStream={onPrintStream}

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -42,6 +42,7 @@ interface StatusBarProps {
   readonly childListFocused?: boolean;
   readonly childListSelectionKind?: 'stream' | 'process';
   readonly childListSelectionKillable?: boolean;
+  readonly childListSelectionWorkflowControllable?: boolean;
   readonly childNavigationAvailable: boolean;
   readonly commandName?: string;
   readonly foregroundEscapeAction?: string;
@@ -177,6 +178,8 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     childListFocused: props.childListFocused,
     childListSelectionKind: props.childListSelectionKind,
     childListSelectionKillable: props.childListSelectionKillable,
+    childListSelectionWorkflowControllable:
+      props.childListSelectionWorkflowControllable,
     childNavigationAvailable: props.childNavigationAvailable,
     streamFocusAvailable: props.streamFocusAvailable,
     model: accessTarget.model,

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -377,22 +377,22 @@ export function SubagentList(
     (input, key) => {
       if (key.ctrl || key.meta) return;
       const streamId = childListStreamId(props.selectedValue);
-      if (input.toLowerCase() === 'v' && streamId) {
+      const pressed = input.toLowerCase();
+      if (pressed === 'v' && streamId) {
         props.onPrintStream?.(streamId);
         return;
       }
-      const key_ = input.toLowerCase();
       // Skip/retry target only a focused subagent stream (a workflow-script
       // grandchild); the session control registry no-ops for any execution id
       // that is not an in-flight grandchild, so non-workflow rows are inert.
-      if ((key_ === 's' || key_ === 'r') && streamId) {
+      if ((pressed === 's' || pressed === 'r') && streamId) {
         const executionId = props.activeSubagentExecutionIds?.get(streamId);
         if (!executionId) return;
-        if (key_ === 's') props.onSkipExecution?.(executionId);
+        if (pressed === 's') props.onSkipExecution?.(executionId);
         else props.onRetryExecution?.(executionId);
         return;
       }
-      if (key_ !== 'k') return;
+      if (pressed !== 'k') return;
       const processId = childListProcessId(props.selectedValue);
       let executionId: string | undefined;
       if (processId && props.selectedValue) {

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -264,6 +264,10 @@ export interface SubagentListProps {
   readonly onCancel?: () => void;
   readonly onFocusStream?: (streamId: StreamTabId) => void;
   readonly onKillExecution?: (executionId: string) => void;
+  /** Skip the focused, in-flight workflow-script grandchild `agent()` call. */
+  readonly onSkipExecution?: (executionId: string) => void;
+  /** Retry the focused, in-flight workflow-script grandchild `agent()` call. */
+  readonly onRetryExecution?: (executionId: string) => void;
   readonly onOpenProcessDetail?: (executionId: string) => void;
   readonly onSelectionChange?: (value: ChildListValue) => void;
   readonly onPrintStream?: (streamId: StreamTabId) => void;
@@ -377,7 +381,18 @@ export function SubagentList(
         props.onPrintStream?.(streamId);
         return;
       }
-      if (input.toLowerCase() !== 'k') return;
+      const key_ = input.toLowerCase();
+      // Skip/retry target only a focused subagent stream (a workflow-script
+      // grandchild); the session control registry no-ops for any execution id
+      // that is not an in-flight grandchild, so non-workflow rows are inert.
+      if ((key_ === 's' || key_ === 'r') && streamId) {
+        const executionId = props.activeSubagentExecutionIds?.get(streamId);
+        if (!executionId) return;
+        if (key_ === 's') props.onSkipExecution?.(executionId);
+        else props.onRetryExecution?.(executionId);
+        return;
+      }
+      if (key_ !== 'k') return;
       const processId = childListProcessId(props.selectedValue);
       let executionId: string | undefined;
       if (processId && props.selectedValue) {

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -127,6 +127,9 @@ export interface StatusBarDisplayInput {
   readonly childListFocused?: boolean;
   readonly childListSelectionKind?: 'stream' | 'process';
   readonly childListSelectionKillable?: boolean;
+  /** True while the focused row is an in-flight workflow-script grandchild
+   *  that can be skipped or retried. */
+  readonly childListSelectionWorkflowControllable?: boolean;
 }
 
 interface StatusBarDisplay {
@@ -498,6 +501,7 @@ function childListBindingsText(
   ctrlCAction: CtrlCAction,
   selectionKind: 'stream' | 'process' | undefined,
   selectionKillable: boolean,
+  selectionWorkflowControllable: boolean,
   maxColumns?: number,
 ): string {
   const ctrlCBinding = keyHintText({ key: 'Ctrl-C', action: ctrlCAction });
@@ -512,7 +516,24 @@ function childListBindingsText(
   const killBinding = selectionKillable
     ? keyHintText({ key: 'k', action: 'kill' })
     : undefined;
+  const skipBinding = selectionWorkflowControllable
+    ? keyHintText({ key: 's', action: 'skip' })
+    : undefined;
+  const retryBinding = selectionWorkflowControllable
+    ? keyHintText({ key: 'r', action: 'retry' })
+    : undefined;
   const candidates = [
+    statusBarBindingRow([
+      keyHintText({ key: 'Up/Down', action: 'select' }),
+      enterBinding,
+      fullOutputBinding,
+      killBinding,
+      skipBinding,
+      retryBinding,
+      keyHintText({ key: 'Tab', action: 'input' }),
+      keyHintText({ key: 'Esc', action: 'input' }),
+      ctrlCBinding,
+    ]),
     statusBarBindingRow([
       keyHintText({ key: 'Up/Down', action: 'select' }),
       enterBinding,
@@ -697,6 +718,7 @@ function resolveStatusBarBindings(input: StatusBarDisplayInput): string {
       ctrlCAction,
       input.childListSelectionKind,
       input.childListSelectionKillable ?? false,
+      input.childListSelectionWorkflowControllable ?? false,
       maxColumns,
     );
   }

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -832,6 +832,12 @@ export async function runChat(
           detachActiveChildren: detachSubagentsOnStop(),
         });
       }}
+      onSkipExecution={(executionId) => {
+        defaultSession().workflowControls.skip(executionId as ExecutionId);
+      }}
+      onRetryExecution={(executionId) => {
+        defaultSession().workflowControls.retry(executionId as ExecutionId);
+      }}
       history={inputHistory}
     />,
     {

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -52,6 +52,7 @@ import {
   createSessionApprovals,
   type SessionApprovals,
 } from './streamApprovalQueue';
+import { WorkflowControlRegistry } from './workflowControlRegistry';
 import { releaseExecutionLeaseAfterArtifacts } from './executionOwnership';
 import type { StreamLogStore } from '@transcript/StreamLogStore';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
@@ -70,6 +71,7 @@ export type SessionHandleInit = Pick<SessionHandle, 'transcripts'> &
       | 'followUps'
       | 'flushers'
       | 'interactions'
+      | 'workflowControls'
       | 'hostChannel'
     >
   >;
@@ -102,6 +104,13 @@ export class SessionHandle {
   readonly interactions: SessionHostInteractions;
   /** Session-owned approval queues, pending registries, and bypass state. */
   readonly approvals: SessionApprovals;
+  /**
+   * Session-owned bridge from a workflow-script grandchild's execution id to
+   * its run's engine skip/retry control. Populated by the workflow-script
+   * strategy while a run is in flight; a host (the CLI child list) consumes it
+   * to skip/retry a focused grandchild `agent()` call.
+   */
+  readonly workflowControls: WorkflowControlRegistry;
   /**
    * Optional session-scoped emit surface for the non-run-scoped host-path
    * emissions (SDK Step 7d follow-on F-1). Unset ⇒ those stay on the bus.
@@ -147,6 +156,8 @@ export class SessionHandle {
     this.followUps = followUps;
     this.interactions = init.interactions ?? new SessionHostInteractions();
     this.approvals = approvals;
+    this.workflowControls =
+      init.workflowControls ?? new WorkflowControlRegistry();
     // A fresh session owns its own flusher set; the default session aliases
     // the process-module set (`getActiveFlushers()`) so the process-wide
     // shutdown drain (`flushPendingRunTraces()`) still reaches it.

--- a/src/agent/runtime/workflowControlRegistry.ts
+++ b/src/agent/runtime/workflowControlRegistry.ts
@@ -1,0 +1,64 @@
+/**
+ * `WorkflowControlRegistry` — a session-scoped bridge from a workflow-script
+ * grandchild's execution id to that run's engine control handle (skip/retry by
+ * call index).
+ *
+ * The workflow engine's control (see {@link WorkflowScriptControl}) is keyed by
+ * an engine-internal call *index*; the host UI targets a run's `agent()`
+ * grandchild by its *execution id* (the same identity the child list, focus,
+ * and kill use). Each in-flight workflow run registers a {@link WorkflowRunControl}
+ * that translates its own live grandchild execution ids into engine indices;
+ * the registry fans a skip/retry request out to every registered run, so the
+ * one run that currently owns that grandchild acts and the rest no-op — the
+ * same no-op-if-not-in-flight semantics the engine already guarantees.
+ *
+ * Host-agnostic and session-owned: registration happens in the workflow-script
+ * strategy (`src/tools/delegation`), consumption in a host (the CLI child list).
+ */
+
+// Local imports - shared schemas
+import type { ExecutionId } from '@shared/schemas';
+
+/**
+ * One in-flight workflow run's control surface, keyed by the execution id of
+ * its live `agent()` grandchildren. Both actions no-op when `grandchildId` is
+ * not a currently in-flight grandchild of this run.
+ */
+export interface WorkflowRunControl {
+  /** Cancel the in-flight grandchild `agent()` call as a deliberate skip. */
+  skip(grandchildId: ExecutionId): void;
+  /** Cancel and re-run the in-flight grandchild `agent()` call as a fresh attempt. */
+  retry(grandchildId: ExecutionId): void;
+}
+
+/** Session-owned map of live workflow runs to their control handles. */
+export class WorkflowControlRegistry {
+  private readonly runs = new Map<ExecutionId, WorkflowRunControl>();
+
+  /**
+   * Register a run's control handle under its run execution id. Returns a
+   * disposer that removes exactly this registration (identity-checked so a
+   * relaunch under the same id cannot tear out the fresh entry).
+   */
+  register(
+    runExecutionId: ExecutionId,
+    control: WorkflowRunControl,
+  ): () => void {
+    this.runs.set(runExecutionId, control);
+    return () => {
+      if (this.runs.get(runExecutionId) === control) {
+        this.runs.delete(runExecutionId);
+      }
+    };
+  }
+
+  /** Skip the in-flight grandchild `agent()` call with this execution id. No-op if none owns it. */
+  skip(grandchildId: ExecutionId): void {
+    for (const control of this.runs.values()) control.skip(grandchildId);
+  }
+
+  /** Retry the in-flight grandchild `agent()` call with this execution id. No-op if none owns it. */
+  retry(grandchildId: ExecutionId): void {
+    for (const control of this.runs.values()) control.retry(grandchildId);
+  }
+}

--- a/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
@@ -454,4 +454,57 @@ describe('createWorkflowScriptAgentRunner', () => {
       cause: durabilityError,
     });
   });
+
+  it('reports the active-attempt execution id to onChildActive, not the logical id', async () => {
+    // After a durable retry advances the attempt sequence, the live run uses an
+    // attempt-specific execution id — the id its child stream / roster expose.
+    // The runner must bridge THAT id (bracketed active→settle), not the logical
+    // id it hands stable execution, so a host's skip/retry finds the row.
+    const attemptExecutionId = 'cccccc333333' as ExecutionId;
+    let logicalExecutionId: string | undefined;
+    mocks.executeStableSubagentInBand.mockImplementation(async (options) => {
+      logicalExecutionId = options.executionId;
+      options.onActiveExecutionId?.(attemptExecutionId);
+      mocks.preparedOptions.push(await options.prepare());
+      return { executionId: attemptExecutionId, result };
+    });
+    const onChildActive = vi.fn();
+    const runner = defaultRunner({ onChildActive });
+
+    await expect(runner(invocation())).resolves.toBe(result);
+
+    expect(logicalExecutionId).toMatch(/^[a-f0-9]{24}$/);
+    expect(logicalExecutionId).not.toBe(attemptExecutionId);
+    expect(onChildActive).toHaveBeenNthCalledWith(
+      1,
+      attemptExecutionId,
+      expect.objectContaining({ index: 0 }),
+      true,
+    );
+    expect(onChildActive).toHaveBeenNthCalledWith(
+      2,
+      attemptExecutionId,
+      expect.objectContaining({ index: 0 }),
+      false,
+    );
+    expect(onChildActive).not.toHaveBeenCalledWith(
+      logicalExecutionId,
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it('leaves onChildActive untouched when a recovered attempt runs no live work', async () => {
+    // A recovered attempt never fires onActiveExecutionId, so the settle guard
+    // must not emit a phantom active/inactive pair for a call that never ran.
+    mocks.executeStableSubagentInBand.mockImplementation(async () => ({
+      executionId: 'bbbbbb222222',
+      result,
+    }));
+    const onChildActive = vi.fn();
+    const runner = defaultRunner({ onChildActive });
+
+    await expect(runner(invocation())).resolves.toBe(result);
+    expect(onChildActive).not.toHaveBeenCalled();
+  });
 });

--- a/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
@@ -129,6 +129,9 @@ describe('SessionHandle', () => {
       expect(fresh.transcripts).not.toBe(defaultSession().transcripts);
       expect(fresh.followUps).not.toBe(defaultSession().followUps);
       expect(fresh.approvals).not.toBe(defaultSession().approvals);
+      expect(fresh.workflowControls).not.toBe(
+        defaultSession().workflowControls,
+      );
       expect(fresh.flushers).not.toBe(getActiveFlushers());
       expect(fresh.hostChannel).toBeUndefined();
     } finally {

--- a/src/test-kernel/cli/ChildListInteraction.vitest.mts
+++ b/src/test-kernel/cli/ChildListInteraction.vitest.mts
@@ -154,6 +154,50 @@ describe('CLI child list interaction', () => {
     }
   });
 
+  it('skips and retries the focused subagent grandchild by execution id', async () => {
+    const ink = (await import(cliRequire.resolve('ink'))) as any;
+    const React = ((await import(cliRequire.resolve('react'))) as any).default;
+    const root = 'root' as StreamTabId;
+    const child = 'child' as StreamTabId;
+    const onSkipExecution = vi.fn();
+    const onRetryExecution = vi.fn();
+
+    const stdin = new FakeStdin();
+    const instance = ink.render(
+      React.createElement(SubagentList, {
+        activeSubagentExecutionIds: new Map([[child, 'child-exec']]),
+        keyboardActive: true,
+        maxRows: 5,
+        onCancel: vi.fn(),
+        onSkipExecution,
+        onRetryExecution,
+        onSelectionChange: vi.fn(),
+        selectedValue: childStreamListValue(child),
+        sessions: [session(root, true), session(child)],
+      }),
+      {
+        stdin,
+        stdout: new FakeStdout(),
+        interactive: true,
+        exitOnCtrlC: false,
+        patchConsole: false,
+      },
+    );
+
+    try {
+      await waitFor(() => stdin.listenerCount('readable') > 0);
+      stdin.write('s');
+      await waitFor(() => onSkipExecution.mock.calls.length === 1);
+      stdin.write('r');
+      await waitFor(() => onRetryExecution.mock.calls.length === 1);
+
+      expect(onSkipExecution).toHaveBeenCalledWith('child-exec');
+      expect(onRetryExecution).toHaveBeenCalledWith('child-exec');
+    } finally {
+      instance.unmount();
+    }
+  });
+
   it('opens and kills a selected process without printing stream output', async () => {
     const ink = (await import(cliRequire.resolve('ink'))) as any;
     const React = ((await import(cliRequire.resolve('react'))) as any).default;

--- a/src/test-kernel/tools/WorkflowScriptStrategy.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptStrategy.vitest.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { setupPlatform } from '@test/support/setupPlatform';
-import { createTestSession } from '@test/support/sessionTestUtils';
 import { clearStoreCache, getExecutionStore } from '@agent/storage';
 import { TraceEmitter } from '@agent/trace';
 import {
@@ -12,7 +11,7 @@ import {
   type WorkflowAgentRunner,
 } from '@agent/workflowScript';
 import type { AgentFinalResult } from '@agent/runtime/AgentFinalResult';
-import type { SessionHandle } from '@agent/runtime/SessionHandle';
+import { WorkflowControlRegistry } from '@agent/runtime/workflowControlRegistry';
 import type { ExecutionId } from '@shared/schemas';
 import {
   createWorkflowScriptStrategy,
@@ -58,7 +57,7 @@ function fakePorts() {
   return { notify: vi.fn(), recordCost: vi.fn() };
 }
 
-let session: SessionHandle;
+let workflowControls: WorkflowControlRegistry;
 
 function strategyParams(
   overrides: Partial<WorkflowScriptStrategyParams> & {
@@ -73,14 +72,14 @@ function strategyParams(
     checkpointId: checkpointIdFor(overrides.name),
     script,
     args: undefined,
-    session,
+    workflowControls,
     ...overrides,
   };
 }
 
 beforeEach(() => {
   clearStoreCache();
-  session = createTestSession();
+  workflowControls = new WorkflowControlRegistry();
 });
 
 describe('createWorkflowScriptStrategy', () => {
@@ -298,19 +297,41 @@ function deferred(): { promise: Promise<void>; resolve: () => void } {
   return { promise, resolve };
 }
 
+/** Let queued abort/skip handling settle without resolving a hung run. */
+async function drainMacrotasks(): Promise<void> {
+  for (let tick = 0; tick < 5; tick += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
 /**
- * A fake `runAgent` that stands in for the production runner: it announces its
- * grandchild execution id through the `onChildActive` bridge and hangs the
- * first attempt until the per-call signal aborts, so a test can drive an
- * interactive skip/retry against a call that is genuinely in flight.
+ * A fake `runAgent` that stands in for the production runner. Each attempt
+ * announces the execution id it actually runs under through the `onChildActive`
+ * bridge — modeling how the real runner reports the logical id on attempt 0 and
+ * an attempt-specific id after a durable retry — and hangs until the per-call
+ * signal aborts (unless it is the designated `succeedAtAttempt`), so a test can
+ * drive an interactive skip/retry against a call that is genuinely in flight.
  */
-function controllableRunAgent(grandchildExecutionId: ExecutionId): {
+function controllableRunAgent(config: {
+  readonly attemptExecutionIds: readonly ExecutionId[];
+  /** 1-based attempt that settles with finalResult; earlier attempts hang.
+   *  Omit so every attempt hangs until a control action resolves it. */
+  readonly succeedAtAttempt?: number;
+}): {
   readonly createRunAgent: WorkflowScriptStrategyParams['createRunAgent'];
-  readonly firstAttemptStarted: Promise<void>;
+  readonly attemptStarted: (attempt: number) => Promise<void>;
   readonly attempts: () => number;
   readonly onCost: (cost: number) => void;
 } {
-  const started = deferred();
+  const attemptGates: ReturnType<typeof deferred>[] = [];
+  const gateFor = (attempt: number): ReturnType<typeof deferred> => {
+    while (attemptGates.length < attempt) attemptGates.push(deferred());
+    return attemptGates[attempt - 1]!;
+  };
+  const execIdForAttempt = (attempt: number): ExecutionId =>
+    config.attemptExecutionIds[
+      Math.min(attempt - 1, config.attemptExecutionIds.length - 1)
+    ]!;
   let attemptCount = 0;
   let reportCost: ((cost: number) => void) | undefined;
   const createRunAgent: WorkflowScriptStrategyParams['createRunAgent'] = (
@@ -319,11 +340,12 @@ function controllableRunAgent(grandchildExecutionId: ExecutionId): {
     return async (invocation) => {
       attemptCount += 1;
       const thisAttempt = attemptCount;
+      const execId = execIdForAttempt(thisAttempt);
       reportCost = (cost) => hooks.onCost(invocation, cost);
-      hooks.onChildActive(grandchildExecutionId, invocation, true);
-      started.resolve();
+      hooks.onChildActive(execId, invocation, true);
+      gateFor(thisAttempt).resolve();
       try {
-        if (thisAttempt === 1) {
+        if (config.succeedAtAttempt !== thisAttempt) {
           // Hang until a control action aborts this attempt (skip/retry).
           await new Promise<never>((_, reject) => {
             invocation.signal.addEventListener(
@@ -335,13 +357,13 @@ function controllableRunAgent(grandchildExecutionId: ExecutionId): {
         }
         return finalResult;
       } finally {
-        hooks.onChildActive(grandchildExecutionId, invocation, false);
+        hooks.onChildActive(execId, invocation, false);
       }
     };
   };
   return {
     createRunAgent,
-    firstAttemptStarted: started.promise,
+    attemptStarted: (attempt) => gateFor(attempt).promise,
     attempts: () => attemptCount,
     onCost: (cost) => reportCost?.(cost),
   };
@@ -351,7 +373,9 @@ describe('createWorkflowScriptStrategy interactive controls', () => {
   const grandchildExecutionId = 'grandchild-exec-0' as ExecutionId;
 
   it('skips an in-flight grandchild by execution id via the session registry', async () => {
-    const fake = controllableRunAgent(grandchildExecutionId);
+    const fake = controllableRunAgent({
+      attemptExecutionIds: [grandchildExecutionId],
+    });
     const strategy = createWorkflowScriptStrategy(
       strategyParams({
         name: 'strategy-test',
@@ -360,21 +384,24 @@ describe('createWorkflowScriptStrategy interactive controls', () => {
     );
 
     const launch = strategy.launch(fakePorts(), new AbortController());
-    await fake.firstAttemptStarted;
+    await fake.attemptStarted(1);
     // An unknown execution id no-ops (the call stays in flight)...
-    session.workflowControls.skip('not-a-grandchild' as ExecutionId);
+    workflowControls.skip('not-a-grandchild' as ExecutionId);
     // ...while the right one translates execId → index → engine skip.
-    session.workflowControls.skip(grandchildExecutionId);
+    workflowControls.skip(grandchildExecutionId);
 
     const turn = await launch;
     expect(turn.result).toBe(WORKFLOW_SKIPPED_RESULT);
     expect(fake.attempts()).toBe(1);
     // The registration is dropped when the run settles.
-    session.workflowControls.skip(grandchildExecutionId);
+    workflowControls.skip(grandchildExecutionId);
   });
 
   it('retries an in-flight grandchild by execution id, re-running the call', async () => {
-    const fake = controllableRunAgent(grandchildExecutionId);
+    const fake = controllableRunAgent({
+      attemptExecutionIds: [grandchildExecutionId],
+      succeedAtAttempt: 2,
+    });
     const strategy = createWorkflowScriptStrategy(
       strategyParams({
         name: 'strategy-test',
@@ -383,8 +410,8 @@ describe('createWorkflowScriptStrategy interactive controls', () => {
     );
 
     const launch = strategy.launch(fakePorts(), new AbortController());
-    await fake.firstAttemptStarted;
-    session.workflowControls.retry(grandchildExecutionId);
+    await fake.attemptStarted(1);
+    workflowControls.retry(grandchildExecutionId);
 
     const turn = await launch;
     // The second attempt settles with the real result, and the call ran twice.
@@ -392,8 +419,52 @@ describe('createWorkflowScriptStrategy interactive controls', () => {
     expect(fake.attempts()).toBe(2);
   });
 
+  it('targets the attempt-specific execution id after a durable retry advances it', async () => {
+    // After a retry, the re-run registers its child stream under an
+    // attempt-specific id (not the logical id) — the id the roster exposes.
+    // The control bridge must follow that id, not the stale logical one.
+    const logicalExecutionId = grandchildExecutionId;
+    const attemptExecutionId = 'grandchild-exec-0#1' as ExecutionId;
+    const fake = controllableRunAgent({
+      attemptExecutionIds: [logicalExecutionId, attemptExecutionId],
+    });
+    const ports = fakePorts();
+    let settled = false;
+    const strategy = createWorkflowScriptStrategy(
+      strategyParams({
+        name: 'strategy-test',
+        createRunAgent: fake.createRunAgent,
+      }),
+    );
+
+    const launch = strategy
+      .launch(ports, new AbortController())
+      .then((turn) => {
+        settled = true;
+        return turn;
+      });
+    // Attempt 0 runs under the logical id; retry advances to attempt 1.
+    await fake.attemptStarted(1);
+    workflowControls.retry(logicalExecutionId);
+    await fake.attemptStarted(2);
+
+    // The stale logical id no longer maps to the in-flight attempt: a skip on
+    // it must no-op, leaving the run pending.
+    workflowControls.skip(logicalExecutionId);
+    await drainMacrotasks();
+    expect(settled).toBe(false);
+
+    // The attempt-specific id the roster exposes reaches the engine index.
+    workflowControls.skip(attemptExecutionId);
+    const turn = await launch;
+    expect(turn.result).toBe(WORKFLOW_SKIPPED_RESULT);
+    expect(fake.attempts()).toBe(2);
+  });
+
   it('bills a skipped attempt that consumed cost to the parent exactly once', async () => {
-    const fake = controllableRunAgent(grandchildExecutionId);
+    const fake = controllableRunAgent({
+      attemptExecutionIds: [grandchildExecutionId],
+    });
     const ports = fakePorts();
     const strategy = createWorkflowScriptStrategy(
       strategyParams({
@@ -403,10 +474,10 @@ describe('createWorkflowScriptStrategy interactive controls', () => {
     );
 
     const launch = strategy.launch(ports, new AbortController());
-    await fake.firstAttemptStarted;
+    await fake.attemptStarted(1);
     // Model tokens were spent before the user skipped the attempt.
     fake.onCost(0.42);
-    session.workflowControls.skip(grandchildExecutionId);
+    workflowControls.skip(grandchildExecutionId);
 
     const turn = await launch;
     expect(turn.result).toBe(WORKFLOW_SKIPPED_RESULT);

--- a/src/test-kernel/tools/WorkflowScriptStrategy.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptStrategy.vitest.ts
@@ -1,15 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { setupPlatform } from '@test/support/setupPlatform';
+import { createTestSession } from '@test/support/sessionTestUtils';
 import { clearStoreCache, getExecutionStore } from '@agent/storage';
 import { TraceEmitter } from '@agent/trace';
 import {
   deriveWorkflowScriptCheckpointId,
   runPersistedWorkflowScript,
+  WORKFLOW_SKIPPED_RESULT,
   type WorkflowAgentInvocation,
   type WorkflowAgentRunner,
 } from '@agent/workflowScript';
 import type { AgentFinalResult } from '@agent/runtime/AgentFinalResult';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { ExecutionId } from '@shared/schemas';
 import {
   createWorkflowScriptStrategy,
@@ -55,6 +58,8 @@ function fakePorts() {
   return { notify: vi.fn(), recordCost: vi.fn() };
 }
 
+let session: SessionHandle;
+
 function strategyParams(
   overrides: Partial<WorkflowScriptStrategyParams> & {
     readonly name: string;
@@ -68,11 +73,15 @@ function strategyParams(
     checkpointId: checkpointIdFor(overrides.name),
     script,
     args: undefined,
+    session,
     ...overrides,
   };
 }
 
-beforeEach(() => clearStoreCache());
+beforeEach(() => {
+  clearStoreCache();
+  session = createTestSession();
+});
 
 describe('createWorkflowScriptStrategy', () => {
   it('is a terminal-only strategy with no runTurn', () => {
@@ -278,5 +287,131 @@ return await agent('saved call')`;
       'Workflow journal entry 0 is not an agent final result',
     );
     expect(ports.recordCost).not.toHaveBeenCalled();
+  });
+});
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve = (): void => undefined;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+/**
+ * A fake `runAgent` that stands in for the production runner: it announces its
+ * grandchild execution id through the `onChildActive` bridge and hangs the
+ * first attempt until the per-call signal aborts, so a test can drive an
+ * interactive skip/retry against a call that is genuinely in flight.
+ */
+function controllableRunAgent(grandchildExecutionId: ExecutionId): {
+  readonly createRunAgent: WorkflowScriptStrategyParams['createRunAgent'];
+  readonly firstAttemptStarted: Promise<void>;
+  readonly attempts: () => number;
+  readonly onCost: (cost: number) => void;
+} {
+  const started = deferred();
+  let attemptCount = 0;
+  let reportCost: ((cost: number) => void) | undefined;
+  const createRunAgent: WorkflowScriptStrategyParams['createRunAgent'] = (
+    hooks,
+  ) => {
+    return async (invocation) => {
+      attemptCount += 1;
+      const thisAttempt = attemptCount;
+      reportCost = (cost) => hooks.onCost(invocation, cost);
+      hooks.onChildActive(grandchildExecutionId, invocation, true);
+      started.resolve();
+      try {
+        if (thisAttempt === 1) {
+          // Hang until a control action aborts this attempt (skip/retry).
+          await new Promise<never>((_, reject) => {
+            invocation.signal.addEventListener(
+              'abort',
+              () => reject(invocation.signal.reason),
+              { once: true },
+            );
+          });
+        }
+        return finalResult;
+      } finally {
+        hooks.onChildActive(grandchildExecutionId, invocation, false);
+      }
+    };
+  };
+  return {
+    createRunAgent,
+    firstAttemptStarted: started.promise,
+    attempts: () => attemptCount,
+    onCost: (cost) => reportCost?.(cost),
+  };
+}
+
+describe('createWorkflowScriptStrategy interactive controls', () => {
+  const grandchildExecutionId = 'grandchild-exec-0' as ExecutionId;
+
+  it('skips an in-flight grandchild by execution id via the session registry', async () => {
+    const fake = controllableRunAgent(grandchildExecutionId);
+    const strategy = createWorkflowScriptStrategy(
+      strategyParams({
+        name: 'strategy-test',
+        createRunAgent: fake.createRunAgent,
+      }),
+    );
+
+    const launch = strategy.launch(fakePorts(), new AbortController());
+    await fake.firstAttemptStarted;
+    // An unknown execution id no-ops (the call stays in flight)...
+    session.workflowControls.skip('not-a-grandchild' as ExecutionId);
+    // ...while the right one translates execId → index → engine skip.
+    session.workflowControls.skip(grandchildExecutionId);
+
+    const turn = await launch;
+    expect(turn.result).toBe(WORKFLOW_SKIPPED_RESULT);
+    expect(fake.attempts()).toBe(1);
+    // The registration is dropped when the run settles.
+    session.workflowControls.skip(grandchildExecutionId);
+  });
+
+  it('retries an in-flight grandchild by execution id, re-running the call', async () => {
+    const fake = controllableRunAgent(grandchildExecutionId);
+    const strategy = createWorkflowScriptStrategy(
+      strategyParams({
+        name: 'strategy-test',
+        createRunAgent: fake.createRunAgent,
+      }),
+    );
+
+    const launch = strategy.launch(fakePorts(), new AbortController());
+    await fake.firstAttemptStarted;
+    session.workflowControls.retry(grandchildExecutionId);
+
+    const turn = await launch;
+    // The second attempt settles with the real result, and the call ran twice.
+    expect(turn.result).toMatchObject({ category: 'workflow', cost: 0.42 });
+    expect(fake.attempts()).toBe(2);
+  });
+
+  it('bills a skipped attempt that consumed cost to the parent exactly once', async () => {
+    const fake = controllableRunAgent(grandchildExecutionId);
+    const ports = fakePorts();
+    const strategy = createWorkflowScriptStrategy(
+      strategyParams({
+        name: 'strategy-test',
+        createRunAgent: fake.createRunAgent,
+      }),
+    );
+
+    const launch = strategy.launch(ports, new AbortController());
+    await fake.firstAttemptStarted;
+    // Model tokens were spent before the user skipped the attempt.
+    fake.onCost(0.42);
+    session.workflowControls.skip(grandchildExecutionId);
+
+    const turn = await launch;
+    expect(turn.result).toBe(WORKFLOW_SKIPPED_RESULT);
+    // The discarded attempt is billed once even though it was never journaled.
+    expect(ports.recordCost).toHaveBeenCalledTimes(1);
+    expect(ports.recordCost).toHaveBeenCalledWith(0.42);
   });
 });

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -203,6 +203,7 @@ Tool inclusion is the opt-in boundary: do not add this tool to a default agent c
           script: input.script,
           args: input.args,
           name: meta.name,
+          session: runScope.session,
           createRunAgent: (hooks) =>
             createWorkflowScriptAgentRunner(
               parent,

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -203,7 +203,7 @@ Tool inclusion is the opt-in boundary: do not add this tool to a default agent c
           script: input.script,
           args: input.args,
           name: meta.name,
-          session: runScope.session,
+          workflowControls: runScope.session.workflowControls,
           createRunAgent: (hooks) =>
             createWorkflowScriptAgentRunner(
               parent,

--- a/src/tools/delegation/inBandSubagentExecution.ts
+++ b/src/tools/delegation/inBandSubagentExecution.ts
@@ -89,6 +89,15 @@ export interface StableInBandSubagentExecutionOptions {
   readonly signal?: AbortSignal;
   /** Resolve mutable launch prerequisites only when no result can be recovered. */
   readonly prepare: () => Promise<InBandSubagentExecutionOptions>;
+  /**
+   * Fires once, just before a live attempt runs, with the execution id that
+   * attempt actually uses — the logical id on attempt 0, an attempt-specific
+   * id after a durable retry advanced the sequence. This is the id the child
+   * stream registers under and the roster exposes, so a host targeting the
+   * in-flight child (skip/retry) must key on it, not the pre-derived logical
+   * id. Recovered attempts never run live, so this does not fire for them.
+   */
+  readonly onActiveExecutionId?: (executionId: ExecutionId) => void;
 }
 
 /** Legacy delivery callers may still provide a bare one-shot run context. */
@@ -727,6 +736,9 @@ export async function executeStableSubagentInBand(
         { cause },
       );
     }
+    // The resolved attempt id is now final and about to run live; surface it
+    // so a host can target this in-flight attempt by the id the roster shows.
+    options.onActiveExecutionId?.(executionId);
     const prepared = await options.prepare();
     if (prepared.parentExecutionId !== options.parentExecutionId) {
       throw new SubagentReconciliationError(

--- a/src/tools/delegation/workflowScriptAgentRunner.ts
+++ b/src/tools/delegation/workflowScriptAgentRunner.ts
@@ -109,17 +109,25 @@ export function createWorkflowScriptAgentRunner(
   const { runScope } = parent;
 
   return async (invocation) => {
-    const grandchildExecutionId = deriveExecutionId({
+    const logicalExecutionId = deriveExecutionId({
       checkpointId,
       key: invocation.key,
       parentExecutionId: run.executionId,
     });
-    hooks?.onChildActive?.(grandchildExecutionId, invocation, true);
+    // The id this attempt actually runs (and registers its child stream)
+    // under: the logical id on attempt 0, an attempt-specific id after a
+    // durable retry. A host targets the in-flight attempt by THIS id, so
+    // report it — not the logical id — through the control bridge.
+    let activeExecutionId: ExecutionId | undefined;
     try {
       const { result } = await executeStableSubagentInBand({
-        executionId: grandchildExecutionId,
+        executionId: logicalExecutionId,
         parentExecutionId: run.executionId,
         signal: invocation.signal,
+        onActiveExecutionId: (executionId) => {
+          activeExecutionId = executionId;
+          hooks?.onChildActive?.(executionId, invocation, true);
+        },
         prepare: async () => {
           const requestedAgent =
             invocation.options.agentName ?? defaultAgentName;
@@ -209,7 +217,11 @@ export function createWorkflowScriptAgentRunner(
       }
       throw error;
     } finally {
-      hooks?.onChildActive?.(grandchildExecutionId, invocation, false);
+      // Only a live attempt registered (recovered attempts never fire the
+      // active callback), so settle exactly what was registered.
+      if (activeExecutionId !== undefined) {
+        hooks?.onChildActive?.(activeExecutionId, invocation, false);
+      }
     }
   };
 }

--- a/src/tools/delegation/workflowScriptAgentRunner.ts
+++ b/src/tools/delegation/workflowScriptAgentRunner.ts
@@ -92,18 +92,32 @@ export function createWorkflowScriptAgentRunner(
       invocation: WorkflowAgentInvocation,
       totalCostUsd: number | undefined,
     ) => void;
+    /**
+     * Fires when a live attempt for this grandchild begins (`active: true`)
+     * and settles (`active: false`), carrying its derived execution id — the
+     * identity a host uses to target interactive skip/retry. Retries re-enter
+     * the runner with the same id, so each attempt is bracketed by a
+     * start/settle pair.
+     */
+    readonly onChildActive?: (
+      grandchildExecutionId: ExecutionId,
+      invocation: WorkflowAgentInvocation,
+      active: boolean,
+    ) => void;
   },
 ): WorkflowAgentRunner {
   const { runScope } = parent;
 
   return async (invocation) => {
+    const grandchildExecutionId = deriveExecutionId({
+      checkpointId,
+      key: invocation.key,
+      parentExecutionId: run.executionId,
+    });
+    hooks?.onChildActive?.(grandchildExecutionId, invocation, true);
     try {
       const { result } = await executeStableSubagentInBand({
-        executionId: deriveExecutionId({
-          checkpointId,
-          key: invocation.key,
-          parentExecutionId: run.executionId,
-        }),
+        executionId: grandchildExecutionId,
         parentExecutionId: run.executionId,
         signal: invocation.signal,
         prepare: async () => {
@@ -194,6 +208,8 @@ export function createWorkflowScriptAgentRunner(
         throw new WorkflowRunAbortError(error.message, { cause: error });
       }
       throw error;
+    } finally {
+      hooks?.onChildActive?.(grandchildExecutionId, invocation, false);
     }
   };
 }

--- a/src/tools/delegation/workflowScriptStrategy.ts
+++ b/src/tools/delegation/workflowScriptStrategy.ts
@@ -20,8 +20,10 @@ import type {
 import type { AgentTrace } from '@agent/trace';
 import type { ExecutionKVStore } from '@agent/storage';
 import type { ChildRunStrategy } from '@agent/runtime/childRunLoop';
-import type { SessionHandle } from '@agent/runtime/SessionHandle';
-import type { WorkflowRunControl } from '@agent/runtime/workflowControlRegistry';
+import type {
+  WorkflowControlRegistry,
+  WorkflowRunControl,
+} from '@agent/runtime/workflowControlRegistry';
 
 // Local imports - shared
 import { DELIVERY_TAG } from '@shared/deliveryTags';
@@ -95,11 +97,10 @@ export interface WorkflowScriptStrategyParams {
   /** Durable identity (`meta.name`) — used in the resume hint on failure. */
   readonly name: string;
   /**
-   * Session that owns the interactive control registry. The strategy
-   * registers this run's skip/retry bridge on `session.workflowControls`
-   * while the run is in flight so a host can target a focused grandchild.
+   * Session-owned registry the strategy registers this run's skip/retry bridge
+   * on while the run is in flight, so a host can target a focused grandchild.
    */
-  readonly session: SessionHandle;
+  readonly workflowControls: WorkflowControlRegistry;
   /**
    * Build the `agent()` adapter bound to the run's ancestry, wired to the
    * supplied per-live-child cost hook so delta accounting stays local to this
@@ -190,7 +191,7 @@ export function createWorkflowScriptStrategy(
                 if (index !== undefined) control.retry(index);
               },
             };
-            unregisterControls = params.session.workflowControls.register(
+            unregisterControls = params.workflowControls.register(
               params.executionId,
               runControl,
             );

--- a/src/tools/delegation/workflowScriptStrategy.ts
+++ b/src/tools/delegation/workflowScriptStrategy.ts
@@ -20,6 +20,8 @@ import type {
 import type { AgentTrace } from '@agent/trace';
 import type { ExecutionKVStore } from '@agent/storage';
 import type { ChildRunStrategy } from '@agent/runtime/childRunLoop';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
+import type { WorkflowRunControl } from '@agent/runtime/workflowControlRegistry';
 
 // Local imports - shared
 import { DELIVERY_TAG } from '@shared/deliveryTags';
@@ -93,14 +95,26 @@ export interface WorkflowScriptStrategyParams {
   /** Durable identity (`meta.name`) — used in the resume hint on failure. */
   readonly name: string;
   /**
+   * Session that owns the interactive control registry. The strategy
+   * registers this run's skip/retry bridge on `session.workflowControls`
+   * while the run is in flight so a host can target a focused grandchild.
+   */
+  readonly session: SessionHandle;
+  /**
    * Build the `agent()` adapter bound to the run's ancestry, wired to the
    * supplied per-live-child cost hook so delta accounting stays local to this
-   * run.
+   * run, plus the child-active hook that maps a live grandchild's execution id
+   * to its engine call index.
    */
   readonly createRunAgent: (hooks: {
     readonly onCost: (
       invocation: WorkflowAgentInvocation,
       totalCostUsd: number | undefined,
+    ) => void;
+    readonly onChildActive: (
+      grandchildExecutionId: ExecutionId,
+      invocation: WorkflowAgentInvocation,
+      active: boolean,
     ) => void;
   }) => WorkflowAgentRunner;
 }
@@ -127,6 +141,10 @@ export function createWorkflowScriptStrategy(
       // pure journal replay settles zero.
       const observedCosts = new Map<string, number>();
       let liveCostUsd = 0;
+      // Live grandchild execution id → engine call index, maintained by the
+      // runner's child-active hook. The identity bridge that lets an
+      // execution-id-keyed host action reach the engine's index-keyed control.
+      const liveCallIndexByChild = new Map<ExecutionId, number>();
       const runAgent = params.createRunAgent({
         onCost: (invocation, totalCostUsd) => {
           const cost = totalCostUsd ?? 0;
@@ -137,8 +155,16 @@ export function createWorkflowScriptStrategy(
           );
           liveCostUsd += cost;
         },
+        onChildActive: (grandchildExecutionId, invocation, active) => {
+          if (active) {
+            liveCallIndexByChild.set(grandchildExecutionId, invocation.index);
+          } else {
+            liveCallIndexByChild.delete(grandchildExecutionId);
+          }
+        },
       });
 
+      let unregisterControls: (() => void) | undefined;
       let run: WorkflowScriptRunResult;
       try {
         run = await runPersistedWorkflowScriptWithProgress(params.logger, {
@@ -150,6 +176,25 @@ export function createWorkflowScriptStrategy(
           runAgent,
           getLiveCostUsd: () => liveCostUsd,
           onActivity: runLog.add,
+          onControl: (control) => {
+            // Translate an execution-id-keyed host request into an
+            // index-keyed engine action; unknown/settled children no-op,
+            // matching the engine's own not-in-flight semantics.
+            const runControl: WorkflowRunControl = {
+              skip: (grandchildId) => {
+                const index = liveCallIndexByChild.get(grandchildId);
+                if (index !== undefined) control.skip(index);
+              },
+              retry: (grandchildId) => {
+                const index = liveCallIndexByChild.get(grandchildId);
+                if (index !== undefined) control.retry(index);
+              },
+            };
+            unregisterControls = params.session.workflowControls.register(
+              params.executionId,
+              runControl,
+            );
+          },
         });
       } catch (runError) {
         // Settle whatever the journal recorded before the failure so a resumed
@@ -168,6 +213,11 @@ export function createWorkflowScriptStrategy(
           // Cost settlement is best-effort on the failure path.
         }
         throw runError;
+      } finally {
+        // The control handle outlives no in-flight call; drop the registration
+        // the moment the run settles so a later host request cannot reach a
+        // dead engine control.
+        unregisterControls?.();
       }
 
       // Combine observed attempts with journal-authoritative completed costs;


### PR DESCRIPTION
Final #8722 increment — wires the engine's per-call skip/retry control (shipped unconsumed in #8741) through to the CLI, so a user can skip or retry a single in-flight workflow `agent()` grandchild from the focused subagent row (Claude Code's WorkflowDetailDialog per-agent controls). Both skip and retry landed — they share the identity bridge.

## The identity bridge (execId ↔ engine call-index)
The engine's control is keyed by call **index**; the UI targets grandchildren by **executionId** (same identity kill/focus use). Bridged cleanly:
- **New `WorkflowControlRegistry`** (`src/agent/runtime/`): session-owned `Map<runExecutionId, WorkflowRunControl>`; `session.workflowControls`. `skip/retry(grandchildId)` fan out to registered runs — the one owning that live grandchild acts, the rest no-op (matching the engine's not-in-flight semantics). `register` returns an identity-checked disposer (relaunch-safe).
- **Runner** (`workflowScriptAgentRunner.ts`): an `onChildActive(execId, invocation, active)` hook fired at attempt start/settle — the single place that pairs the engine `index` with the host `executionId`.
- **Strategy** (`workflowScriptStrategy.ts`): maintains `liveCallIndexByChild` from `onChildActive`; in the engine `onControl` callback registers a `WorkflowRunControl` translating execId → index → `control.skip/retry(index)`; unregisters in `finally` on settle. Host-agnostic (no CLI import).

## CLI
`onSkipExecution`/`onRetryExecution(execId)` → `session.workflowControls`, mirroring `onKillExecution` → `executions.kill`. `s` = skip, `r` = retry on the focused subagent row (same executionId resolution as `k`/kill). Status-bar hints gated so only a controllable grandchild row shows them (Workflow-category stream whose parent is also Workflow — the run stream itself never shows a no-op control).

## Discarded-attempt cost (the #8741 deferred P2)
`observedCosts` + `sumCurrentWorkflowRunCost` bills every observed attempt by stable call identity (per-call max vs journal to avoid double-count, plus leftover unjournaled observed cost), so a skipped/retried attempt that spent tokens is billed exactly once. Test proves it.

## Verified (mocks only, no live model)
- `WorkflowScriptStrategy.vitest.ts` (+3): skip translates execId→index→engine skip + no-ops unknown execId; retry re-runs (2 attempts + real result); discarded-cost billed once.
- `ChildListInteraction.vitest.mts` (+1): `s`/`r` on a synthetic focused roster fire `onSkip/onRetryExecution`.
- `SessionHandle.vitest.ts` (+1): fresh-session `workflowControls` isolation.
- Both tsc configs, eslint, dead-code ratchet, host-agent deep-import ratchet: clean. (Pre-existing parallel-shard flakes `ModelAccessForm`/`RunChatSignalOwnership` verified unrelated.)

Completes the Claude-Code-parity workflow UI (display in #8739/#8740/#8759/#8754, engine backend + queue in #8741).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches workflow execution control, in-band subagent identity after retries, and cost settlement for skipped attempts; changes are guarded by no-op semantics for non-matching ids and scoped UI gating.
> 
> **Overview**
> **Interactive skip/retry** for individual in-flight workflow-script `agent()` grandchildren is wired from the CLI child list through a new session-owned control bridge.
> 
> A **`WorkflowControlRegistry`** on `SessionHandle` maps run execution ids to skip/retry handlers; the workflow-script strategy registers while a run is live, translating grandchild **execution id → engine call index**. The runner reports the **attempt-specific execution id** (not the logical id after durable retries) via `onActiveExecutionId` / `onChildActive` so UI targeting matches the roster.
> 
> In the TUI, focused subagent rows accept **`s` (skip)** and **`r` (retry)** (same execution id resolution as kill); status-bar hints appear only for workflow grandchild rows (Workflow stream whose parent is also Workflow). `runChatTui` delegates to `session.workflowControls`; the TUI harness stubs the callbacks.
> 
> Tests cover registry/strategy skip-retry, attempt-id bridging, discarded-attempt billing, and child-list key handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67be5bb41754b9e4ecbc1f78530c5cddc484f998. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->