### PR TITLE
fix(progress): propagate bulk stop failures

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -872,11 +872,13 @@ export class DesktopProgressBridge {
         this.routeToProgress();
         return;
       case 'requestShowError':
-      case 'requestShowInstruction':
-        void this.options.host.showErrorMessage(
-          (payload as AgentRuntimeEventPayloads['requestShowError']).message,
-        );
+      case 'requestShowInstruction': {
+        const { message } = payload as
+          | AgentRuntimeEventPayloads['requestShowError']
+          | AgentRuntimeEventPayloads['requestShowInstruction'];
+        void this.options.host.showErrorMessage(message);
         return;
+      }
       case 'requestOpenFile': {
         // The extension previews via its LaTeX-Workshop build+view flow
         // (openBuildDisplayIfTex); desktop has no such editor integration,

--- a/src/controllers/progressView/backend/ProgressBackend.ts
+++ b/src/controllers/progressView/backend/ProgressBackend.ts
@@ -253,7 +253,7 @@ export class ProgressBackend {
         ownerSessions.get(stream)?.executions.getAgentHandleByStream(stream) !==
         undefined,
     );
-    await Promise.allSettled(
+    await Promise.all(
       locallyOwnedStreams.map(async (stream) => {
         const ownerSession = ownerSessions.get(stream) ?? this.session;
         if (isInFlightPhase(ownerSession.status.get(stream))) {

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -703,6 +703,45 @@ describe('ProgressBackend', () => {
     }
   });
 
+  it('aborts bulk cleanup when stopping an owned stream fails', async () => {
+    const stopError = new Error('stop failed');
+    const lifecycle = createLifecycleOptions({
+      stopStream: vi.fn().mockRejectedValue(stopError),
+    });
+    const { backend, session } = createIsolatedRecordingBackend(
+      createTestSession(),
+      lifecycle,
+    );
+    const stream = 'owned-stop-failure' as StreamTabId;
+    backend.state.streamLogs.ensureStream(stream);
+    session.status.transition(
+      stream,
+      STREAM_PHASE.RUNNING,
+      STREAM_TRANSITION_CAUSE.LIFECYCLE,
+    );
+    vi.spyOn(session.executions, 'getAgentHandleByStream').mockReturnValue(
+      {} as never,
+    );
+    const waitForRelease = vi.spyOn(
+      backend.state,
+      'waitForOwnedExecutionRelease',
+    );
+    const clearAll = vi.spyOn(backend.state, 'clearAll');
+
+    try {
+      await expect(backend.deleteAllStreams()).rejects.toBe(stopError);
+
+      expect(lifecycle.stopStream).toHaveBeenCalledWith(stream, session);
+      expect(waitForRelease).not.toHaveBeenCalled();
+      expect(clearAll).not.toHaveBeenCalled();
+      expect(lifecycle.cleanupDeletedStream).not.toHaveBeenCalled();
+      expect(lifecycle.cleanupDeletedStreams).not.toHaveBeenCalled();
+    } finally {
+      backend.dispose();
+      session.dispose();
+    }
+  });
+
   it('retains protected streams during bulk cleanup', async () => {
     const { backend, lifecycle, messages, session } =
       createIsolatedRecordingBackend();


### PR DESCRIPTION
## Summary

- propagate bulk-deletion stop failures to the caller before execution-release waits or cleanup begin
- add focused coverage proving a rejected stop leaves release and cleanup untouched
- type desktop error and instruction message payloads as an explicit union

## Design

Bulk deletion now uses a rejecting concurrent stop barrier. This preserves parallel stopping while maintaining the invariant that cleanup begins only after every required stop succeeds. No new abstraction or compatibility shim is introduced.

## Verification

- `npm run format`
- `npm run typecheck`
- `npm run lint` (0 errors; one pre-existing unrelated warning)
- `npm run check:dead-code-ratchet` (233 current = 233 baseline)
- `npm run compile:fast`
- `npx vitest run src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts` (131 tests)

## Net LoC

- Production: +7 / -5, net +2
- Tests: +39 / -0, net +39
- Total: +46 / -5, net +41
- Files: 3 modified
- Exported symbols: 0 added, 0 removed
- Relocations: none
- Compatibility shims: none

Closes #8762
