### PR TITLE
refactor(logger): delete eager initialization ritual

### DIFF
--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -105,7 +105,6 @@ function logAt(
 }
 
 const cliPlatformLog: LogBackend = {
-  initialize() {},
   debug: (channel, message) => logAt('debug', channel, message),
   info: (channel, message) => logAt('info', channel, message),
   warn: (channel, message) => logAt('warn', channel, message),

--- a/packages/cli/src/runtime/supabaseAuth.ts
+++ b/packages/cli/src/runtime/supabaseAuth.ts
@@ -47,7 +47,6 @@ import type { PlatformSecrets } from '@platform/secrets';
  * platform layer.
  */
 export interface LogBackend {
-  initialize(channel: string, isAgent?: boolean): void;
   debug(channel: string, message: string): void;
   info(channel: string, message: string): void;
   warn(channel: string, message: string): void;
@@ -90,7 +89,6 @@ let coordinator: SupabaseSessionCoordinator | undefined;
 let coordinatorSecrets: PlatformSecrets | undefined;
 let activeAuthLog: LogBackend | undefined;
 const deferredAuthLog: LogBackend = {
-  initialize: (channel, isAgent) => activeAuthLog?.initialize(channel, isAgent),
   debug: (channel, message) => activeAuthLog?.debug(channel, message),
   info: (channel, message) => activeAuthLog?.info(channel, message),
   warn: (channel, message) => activeAuthLog?.warn(channel, message),

--- a/packages/extension/src/commands/agent/agentCreatorCommands.ts
+++ b/packages/extension/src/commands/agent/agentCreatorCommands.ts
@@ -15,11 +15,9 @@ import { renderAgentTemplateString } from '@agent/templates/agentTemplateRendere
 import { settleQuickInput } from '@commands/_shared/quickInputUtils';
 import { agentDirectories, promptToAddAgentToConfig } from '@frontend/agents';
 import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
-import * as logger from '@logger/logUtils';
 import { AbsoluteFS } from '@utils/files';
 
 const CHANNEL = 'AgentCreator';
-logger.initialize(CHANNEL);
 
 // Validation only — no .trim() transform, so multiline block-scalar prompts
 // (including their trailing newline) pass through verbatim.

--- a/packages/extension/src/commands/api/apiKeyCommands.ts
+++ b/packages/extension/src/commands/api/apiKeyCommands.ts
@@ -9,7 +9,6 @@ import { VscodeExternalOpener } from '@frontend/hosts/VscodeExternalOpener';
 import { VscodePromptHost } from '@frontend/hosts/VscodePromptHost';
 import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import { getMainWebview } from '@frontend/system/commandUtils';
-import * as logger from '@logger/logUtils';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
 import { PROVIDER_DISPLAY_NAMES } from '@shared/constants/providers';
 import { refreshApiKeyCaches } from '@tools/setup/apiKeyHelpers';
@@ -20,7 +19,6 @@ import {
 } from '@utils/config/providerConfig';
 
 const CHANNEL = 'ApiKeyCommands';
-logger.initialize(CHANNEL);
 
 export const apiKeyCommands = {
   setApiKey: 'texra.setApiKey',

--- a/packages/extension/src/commands/auth/authCommands.ts
+++ b/packages/extension/src/commands/auth/authCommands.ts
@@ -9,11 +9,9 @@ import {
   showLoggedErrorMessage,
   showLoggedMessage,
 } from '@frontend/ui/errorHandlingUtils';
-import * as logger from '@logger/logUtils';
 import { getConfig } from '@utils/config';
 
 const CHANNEL = 'authCommands';
-logger.initialize(CHANNEL);
 
 type AuthMethod = OAuthProvider | 'github-browser' | 'email';
 

--- a/packages/extension/src/commands/files/fileSelectionCommands.ts
+++ b/packages/extension/src/commands/files/fileSelectionCommands.ts
@@ -11,7 +11,6 @@ import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
 
 const CHANNEL = 'fileSelectionCommands';
-logger.initialize(CHANNEL);
 
 interface PickerOptions<Many extends boolean> {
   allowMany: Many;

--- a/packages/extension/src/commands/files/openFileCommands.ts
+++ b/packages/extension/src/commands/files/openFileCommands.ts
@@ -18,7 +18,6 @@ import { WorkspaceFS } from '@utils/files';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 const CHANNEL = 'openFileCommands';
-logger.initialize(CHANNEL);
 
 const openFileCommands = {
   openFileCompile: 'texra.openFileCompile',

--- a/packages/extension/src/commands/git/gitCommands.ts
+++ b/packages/extension/src/commands/git/gitCommands.ts
@@ -26,7 +26,6 @@ import { extendEnvPath } from '@utils/system/platformPaths';
 import { isGitRepository } from '@utils/system/isGitRepository';
 
 const CHANNEL = 'gitCommands';
-logger.initialize(CHANNEL);
 
 const COMMIT_HASH_PATTERN = /^[0-9a-fA-F]{4,40}$/;
 const OVERLEAF_GIT_TOKEN_URL = 'https://www.overleaf.com/user/settings';

--- a/packages/extension/src/commands/housekeeping/cleanCommands.ts
+++ b/packages/extension/src/commands/housekeeping/cleanCommands.ts
@@ -22,7 +22,6 @@ import {
 import { emitClearMissingOutputs } from './streamEventUtils';
 
 const CHANNEL = 'cleanCommands';
-logger.initialize(CHANNEL);
 
 const CleanConfigSchema = FileOpParamsSchema.extend(fileOpConfigFields);
 

--- a/packages/extension/src/commands/housekeeping/packCommands.ts
+++ b/packages/extension/src/commands/housekeeping/packCommands.ts
@@ -14,7 +14,6 @@ import {
   runPackMultiple,
   runPackRunDir,
 } from '@housekeeping';
-import * as logger from '@logger/logUtils';
 import type { FileOpResult } from '@shared/schemas/opResults';
 import { WorkspaceFS } from '@utils/files';
 import {
@@ -29,7 +28,6 @@ import {
 } from './streamEventUtils';
 
 const CHANNEL = 'packCommands';
-logger.initialize(CHANNEL);
 
 const PackConfigSchema = FileOpParamsSchema.extend({
   // Pack permits an empty model in config; clean keeps it required.

--- a/packages/extension/src/commands/latex/arXivCommands.ts
+++ b/packages/extension/src/commands/latex/arXivCommands.ts
@@ -11,7 +11,6 @@ import {
 import * as logger from '@logger/logUtils';
 
 const CHANNEL = 'arXivCommands';
-logger.initialize(CHANNEL);
 
 // Command IDs
 export const arXivCommands = {

--- a/packages/extension/src/commands/latex/compareCommands.ts
+++ b/packages/extension/src/commands/latex/compareCommands.ts
@@ -30,7 +30,6 @@ import { FlexibleFS } from '@utils/files';
 type AcceptCopyMeta = { agent: string; model: string; round: number };
 
 const CHANNEL = 'CompareCommands';
-logger.initialize(CHANNEL);
 
 function validateFileLocations(
   inputLocation: FileLocation,

--- a/packages/extension/src/commands/latex/figCommands.ts
+++ b/packages/extension/src/commands/latex/figCommands.ts
@@ -17,7 +17,6 @@ import { pathToLocation } from '@utils/files';
 import { pluralize } from '@utils/text/stringUtils';
 
 const CHANNEL = 'TestCommands';
-logger.initialize(CHANNEL);
 
 async function runLaTeXCommand(
   action: string,

--- a/packages/extension/src/commands/latex/imageCommands.ts
+++ b/packages/extension/src/commands/latex/imageCommands.ts
@@ -15,7 +15,6 @@ import {
 } from '@utils/media/img';
 
 const CHANNEL = 'TestCommands';
-logger.initialize(CHANNEL);
 
 const PDF_FILTERS = { 'PDF files': ['pdf'] };
 

--- a/packages/extension/src/commands/latex/latexCommands.ts
+++ b/packages/extension/src/commands/latex/latexCommands.ts
@@ -28,7 +28,6 @@ import { delay } from '@utils/core';
 import { getIndentTeXNotification } from './latexHousekeepingNotifications';
 
 const CHANNEL = 'LaTeXCommands';
-logger.initialize(CHANNEL);
 
 /**
  * Run a LaTeX entry-point command under the active-file guard, surfacing any

--- a/packages/extension/src/commands/latex/linterCommands.ts
+++ b/packages/extension/src/commands/latex/linterCommands.ts
@@ -12,7 +12,6 @@ import {
 } from '@utils/diagnostics/diagnosticFormatting';
 
 const CHANNEL = 'LinterCommands';
-logger.initialize(CHANNEL);
 
 function showNoIssuesMessage(): void {
   vscode.window.showInformationMessage(

--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -29,7 +29,6 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 import { getUseOpenRouter } from '@utils/config/providerConfig';
 
 const CHANNEL = 'SetupAssistant';
-logger.initialize(CHANNEL);
 
 interface LaunchModelResolution {
   model: string;

--- a/packages/extension/src/commands/system/sampleProjectCommands.ts
+++ b/packages/extension/src/commands/system/sampleProjectCommands.ts
@@ -11,11 +11,9 @@ import {
   showLoggedMessage,
 } from '@frontend/ui/errorHandlingUtils';
 import { selectFolder } from '@frontend/ui/dialogs';
-import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
 
 const CHANNEL = 'SampleProjectCommands';
-logger.initialize(CHANNEL);
 
 export const sampleProjectCommands = {
   createSampleProject: 'texra.createSampleProject',

--- a/packages/extension/src/commands/system/textEditorCommands.ts
+++ b/packages/extension/src/commands/system/textEditorCommands.ts
@@ -15,7 +15,6 @@ import {
 import { WorkspaceFS } from '@utils/files';
 
 const CHANNEL = 'TextEditorCommands';
-logger.initialize(CHANNEL);
 
 // Prompt for a line number, rejecting non-numeric input and (when `min` is
 // given) values below the floor. Shared by the start/end/insert prompts.

--- a/packages/extension/src/commands/system/xmlCommands.ts
+++ b/packages/extension/src/commands/system/xmlCommands.ts
@@ -10,7 +10,6 @@ import {
 import * as logger from '@logger/logUtils';
 
 const CHANNEL = 'XmlCommands';
-logger.initialize(CHANNEL);
 
 export async function handleParseXml(): Promise<void> {
   try {

--- a/packages/extension/src/commands/system/yamlCommands.ts
+++ b/packages/extension/src/commands/system/yamlCommands.ts
@@ -18,7 +18,6 @@ import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import * as logger from '@logger/logUtils';
 
 const CHANNEL = 'TestCommands';
-logger.initialize(CHANNEL);
 
 export async function handleTestAgentLoading(): Promise<void> {
   try {

--- a/packages/extension/src/commands/taskFormState/stateRestoreCommand.ts
+++ b/packages/extension/src/commands/taskFormState/stateRestoreCommand.ts
@@ -15,7 +15,6 @@ import * as logger from '@logger/logUtils';
 import { COMMON_COMMANDS } from '@shared/ipc';
 
 const CHANNEL = 'stateRestoreCommand';
-logger.initialize(CHANNEL);
 
 const RESTORE_MALFORMED_MESSAGE =
   'Cannot restore state: persisted task data is malformed or from an incompatible version';

--- a/packages/extension/src/commands/tests/connectionTests.ts
+++ b/packages/extension/src/commands/tests/connectionTests.ts
@@ -10,7 +10,6 @@ import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 
 const CHANNEL = 'TestCommands';
-logger.initialize(CHANNEL);
 
 type TestCase = { str1: string; str2: string };
 type ConnectionMethod = (

--- a/packages/extension/src/common/webview/BaseViewContentProvider.ts
+++ b/packages/extension/src/common/webview/BaseViewContentProvider.ts
@@ -26,7 +26,6 @@ abstract class BaseViewContentProvider {
     // Default: convert 'HistoryView' to 'historyView'
     this.viewPath =
       viewPath ?? viewName.charAt(0).toLowerCase() + viewName.slice(1);
-    logger.initialize(this.channel);
   }
 
   protected getViewPath(): string {

--- a/packages/extension/src/common/webview/BaseViewMessageHandler.ts
+++ b/packages/extension/src/common/webview/BaseViewMessageHandler.ts
@@ -69,7 +69,6 @@ export abstract class BaseViewMessageHandler<
     this.logger = logger;
     this.channel = `${viewName}MessageHandler`;
     this._options = options ?? {};
-    logger.initialize(this.channel);
   }
 
   /**

--- a/packages/extension/src/frontend/agents/AgentDirectoryManager.ts
+++ b/packages/extension/src/frontend/agents/AgentDirectoryManager.ts
@@ -22,7 +22,6 @@ import { AbsoluteFS } from '@utils/files';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 const CHANNEL = 'AgentLoad';
-logger.initialize(CHANNEL);
 
 type AgentDirectoryEventType = 'create' | 'change' | 'delete';
 

--- a/packages/extension/src/frontend/agents/finalOutputOpener.ts
+++ b/packages/extension/src/frontend/agents/finalOutputOpener.ts
@@ -5,7 +5,6 @@ import { selectAutoOpenFinalOutput } from '@agent/runtime/selectAutoOpenFinalOut
 import * as logger from '@logger/logUtils';
 
 const CHANNEL = 'FinalOutputOpener';
-logger.initialize(CHANNEL);
 
 /**
  * On successful workflow completion, preview the final revised output so

--- a/packages/extension/src/frontend/agents/register.ts
+++ b/packages/extension/src/frontend/agents/register.ts
@@ -9,7 +9,6 @@ import * as logger from '@logger/logUtils';
 import type { AgentSource } from '@shared/schemas/agent';
 
 const CHANNEL = 'AgentRegister';
-logger.initialize(CHANNEL);
 
 export type AgentRegistrationSkipReason = 'alreadyRegistered';
 

--- a/packages/extension/src/frontend/files/fileLister.ts
+++ b/packages/extension/src/frontend/files/fileLister.ts
@@ -15,7 +15,6 @@ import { WorkspaceFS } from '@utils/files';
 import { getFilesRecursively } from './listing';
 
 const CHANNEL = 'FileLister';
-logger.initialize(CHANNEL);
 
 export class FileLister {
   private static instance: FileLister | null = null;

--- a/packages/extension/src/frontend/git/recentCommits.ts
+++ b/packages/extension/src/frontend/git/recentCommits.ts
@@ -5,7 +5,6 @@ import * as vscode from 'vscode';
 import * as logger from '@logger/logUtils';
 
 const CHANNEL = 'recentCommits';
-logger.initialize(CHANNEL);
 
 export interface RecentCommitsResult {
   commits: string[];

--- a/packages/extension/src/frontend/media/RecordingManager.ts
+++ b/packages/extension/src/frontend/media/RecordingManager.ts
@@ -11,7 +11,6 @@ import * as logger from '@logger/logUtils';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 const CHANNEL = 'RecordingManager';
-logger.initialize(CHANNEL);
 
 type RecordingMessageInput =
   { status: 'started' | 'stopped' } | { status: 'error'; error: string };

--- a/packages/extension/src/frontend/media/audio.ts
+++ b/packages/extension/src/frontend/media/audio.ts
@@ -18,7 +18,6 @@ import { checkToolInstalled } from '@utils/system/toolUtils';
 import { extendEnvPath } from '@utils/system/platformPaths';
 
 const CHANNEL = 'AudioUtils';
-logger.initialize(CHANNEL);
 
 const RECORDINGS_DIR = 'recordings';
 

--- a/packages/extension/src/frontend/ui/diffView.ts
+++ b/packages/extension/src/frontend/ui/diffView.ts
@@ -4,7 +4,6 @@ import * as logger from '@logger/logUtils';
 import { REFRESH_THRESHOLD_MS } from '@utils/config';
 
 const CHANNEL = 'DiffRefresh';
-logger.initialize(CHANNEL);
 
 interface DiffInfo {
   left: vscode.Uri;

--- a/packages/extension/src/webview/managers/FileManager.ts
+++ b/packages/extension/src/webview/managers/FileManager.ts
@@ -88,7 +88,6 @@ type UpdateFilesMessage = MessageFor<
 >;
 
 const CHANNEL = 'FileManager';
-logger.initialize(CHANNEL);
 
 type FileUpdateOptions = {
   notifyWhenEmpty?: boolean;

--- a/packages/extension/src/webview/managers/InstructionManager.ts
+++ b/packages/extension/src/webview/managers/InstructionManager.ts
@@ -16,7 +16,6 @@ import {
 import { BaseWebviewManager } from './BaseWebviewManager';
 
 const CHANNEL = 'InstructionManager';
-logger.initialize(CHANNEL);
 
 type PolishInstructionMessage = Extract<
   MainViewInboundMessage,

--- a/packages/extension/src/webview/managers/executionHandlers.ts
+++ b/packages/extension/src/webview/managers/executionHandlers.ts
@@ -8,7 +8,6 @@ import type { MainViewExecuteMessage } from '@shared/mainView';
 import type { FileOperationMessage } from '@shared/schemas/mainView/inbound';
 
 const CHANNEL = 'ExecutionHandlers';
-logger.initialize(CHANNEL);
 
 /** Housekeeping commands take no payload beyond the command itself. */
 export interface HousekeepingMessage {

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -37,7 +37,6 @@ import {
 import type { AgentEntry, ResolvedAgent } from './agentEntry';
 
 const CHANNEL = 'agentRegistry';
-logger.initialize(CHANNEL);
 
 // Re-exports kept stable for external consumers.
 export type { AgentEntry, ResolvedAgent } from './agentEntry';

--- a/src/agent/modelHandlers/openai/modelHandlerCodex.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerCodex.ts
@@ -54,7 +54,6 @@ import { ModelHandlerOpenAIResponse } from './modelHandlerOpenAIResponse';
 import type { ResponseCreateParamsBase } from 'openai/resources/responses/responses';
 
 const CHANNEL = 'ModelHandlerCodex';
-logger.initialize(CHANNEL);
 
 /** Flatten Responses message content (string or typed parts) to plain text. */
 function partsToText(content: unknown): string {

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -24,7 +24,6 @@ import type {
 // ============================================================================
 
 const CHANNEL = 'toolConversion';
-logger.initialize(CHANNEL);
 
 type JSONSchemaObject = Record<string, unknown>;
 

--- a/src/agent/node/index.ts
+++ b/src/agent/node/index.ts
@@ -13,7 +13,6 @@ const CHANNEL = 'PocketFlow';
 // every reflection-flow failure even though ending is the intended behavior.
 // (`waiting` is not terminal — ToolUseWaitNode wires it as a self-loop successor.)
 const TERMINAL_ACTIONS = new Set<Action>(['complete', 'finalize']);
-logger.initialize(CHANNEL);
 
 /**
  * Base node class for PocketFlow.

--- a/src/agent/node/persistedFlow.ts
+++ b/src/agent/node/persistedFlow.ts
@@ -24,7 +24,6 @@ export function flowKey(runId: string): string {
 }
 
 const CHANNEL = 'PersistedFlow';
-logger.initialize(CHANNEL);
 
 export const FLOW_RECORD_SCHEMA_VERSION = 2;
 const START_NODE_ID = 'start';

--- a/src/agent/output/diffComputation.ts
+++ b/src/agent/output/diffComputation.ts
@@ -24,7 +24,6 @@ import { ensureRoundData, type OutputState } from './outputState';
 import type { RoundFileMapping } from './types';
 
 const CHANNEL = 'OutputDiffStats';
-logger.initialize(CHANNEL);
 
 // ============================================================================
 // Helpers

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -26,7 +26,6 @@ import {
 import { fetchRemoteAgentConfigYaml } from './remoteAgentConfigClient';
 
 const CHANNEL = 'RemoteAgentLoader';
-logger.initialize(CHANNEL);
 
 const FETCH_TIMEOUT_MS = 30_000;
 

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -43,7 +43,6 @@ import {
 import type { ModelHandlerCompatibilityKey } from './modelHandlerCompatibilityKey';
 
 const CHANNEL = 'ModelFactory';
-logger.initialize(CHANNEL);
 
 type ModelHandlerConstructor = new (
   config: ModelConfig,

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -24,7 +24,6 @@ import { resolveToolDefinitions, type RawToolConfig } from '@tools/registry';
 import { AbsoluteFS } from '@utils/files';
 
 const CHANNEL = 'agentLoad';
-logger.initialize(CHANNEL);
 
 interface ValidAgentDefinition {
   name: string;

--- a/src/agent/runtime/textConnection.ts
+++ b/src/agent/runtime/textConnection.ts
@@ -6,7 +6,6 @@ import { classifyAgentError, getSdkErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 
 const CHANNEL = 'LaTeXCommands';
-logger.initialize(CHANNEL);
 
 export interface ConnectionResult {
   connector: string;

--- a/src/housekeeping/clean.ts
+++ b/src/housekeeping/clean.ts
@@ -15,7 +15,6 @@ import { TEMP_EXTENSIONS, PACK_EXTENSIONS, HISTORY_DIR } from './constants';
 import { findFilesFromPatterns, resolveHousekeepingTargets } from './utils';
 
 const CHANNEL = 'Housekeeping';
-logger.initialize(CHANNEL);
 
 function toIgnoreGlobs(dirs: Iterable<string>): string[] {
   return [...dirs].map((dir) => `**/${dir}/**`);

--- a/src/housekeeping/latexdiff.ts
+++ b/src/housekeeping/latexdiff.ts
@@ -8,7 +8,6 @@ import { findFilesFromPatterns, generateTimestamp } from './utils';
 import { TEMP_EXTENSIONS } from './constants';
 
 const CHANNEL = 'Housekeeping';
-logger.initialize(CHANNEL);
 
 export type LatexdiffPackResult =
   | {

--- a/src/housekeeping/pack.ts
+++ b/src/housekeeping/pack.ts
@@ -30,7 +30,6 @@ import {
 } from './utils';
 
 const CHANNEL = 'Housekeeping';
-logger.initialize(CHANNEL);
 
 export async function runPackSingle(
   model: string,

--- a/src/housekeeping/runDirOps.ts
+++ b/src/housekeeping/runDirOps.ts
@@ -15,7 +15,6 @@ import { HISTORY_DIR } from './constants';
 import { generateTimestamp } from './utils';
 
 const CHANNEL = 'Housekeeping';
-logger.initialize(CHANNEL);
 
 /**
  * Snapshot a completed run's runDir into `workspace/History/`. Symlinks

--- a/src/housekeeping/utils.ts
+++ b/src/housekeeping/utils.ts
@@ -18,7 +18,6 @@ import { WorkspaceFS } from '@utils/files';
 import { DEFAULT_MAX_ROUNDS } from './constants';
 
 const CHANNEL = 'Housekeeping';
-logger.initialize(CHANNEL);
 
 /**
  * Produce an ISO-8601 timestamp stripped of separators, suitable for use in

--- a/src/latex/TikzPictureManager.ts
+++ b/src/latex/TikzPictureManager.ts
@@ -12,7 +12,6 @@ import { getConfig } from '@utils/config/configUtils';
 import { compileLatex2Pdf } from './texTools';
 
 const CHANNEL = 'LaTeXCommands';
-logger.initialize(CHANNEL);
 
 /**
  * Pick the run-storage-relative path for a location, falling back to its

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -71,14 +71,12 @@ export function resolveArxivPaperDirectoryRelative(
 }
 
 class ArxivSourceProcessor {
-  // NOTE: The default channel string stays 'arxivProcessor' (lowercase) even
+  // NOTE: The channel string stays 'arxivProcessor' (lowercase) even
   // though the exported singleton was renamed to PascalCase in #7347. It is used
   // directly as the logger channel and prefixes every log line as
   // `[arxivProcessor] ...`, so keep it stable for anything filtering on the
   // channel name — a class-identifier rename must not change this value.
-  constructor(private readonly channel: string = 'arxivProcessor') {
-    logger.initialize(this.channel);
-  }
+  private readonly channel = 'arxivProcessor';
 
   /** Best-effort delete that logs failures at debug level instead of throwing. */
   private async cleanUpBestEffort(

--- a/src/latex/formatter/indentDirectory.ts
+++ b/src/latex/formatter/indentDirectory.ts
@@ -13,7 +13,6 @@ import { hasExtension } from '@utils/core/pathCore';
 import { runLatexFormatter } from '../texFormatter';
 
 const CHANNEL = 'LaTeXCommands';
-logger.initialize(CHANNEL);
 
 export type IndentLatexResult =
   | {

--- a/src/latex/formatter/latexindentpt.ts
+++ b/src/latex/formatter/latexindentpt.ts
@@ -11,7 +11,6 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 import { getConfig } from '@utils/config/configUtils';
 
 const CHANNEL = 'LaTeXCommands';
-logger.initialize(CHANNEL);
 
 async function cleanupIndentLog(logPath: string): Promise<void> {
   try {

--- a/src/latex/formatter/texfmt.ts
+++ b/src/latex/formatter/texfmt.ts
@@ -5,7 +5,6 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 import { getConfig } from '@utils/config/configUtils';
 
 const CHANNEL = 'LaTeXCommands';
-logger.initialize(CHANNEL);
 
 export async function runTexFmt(filePath: string): Promise<boolean> {
   try {

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -31,7 +31,6 @@ const LaTeXdiffResultSchema = z.object({
 export type LaTeXdiffResult = z.infer<typeof LaTeXdiffResultSchema>;
 
 const CHANNEL = 'LaTeXCommands';
-logger.initialize(CHANNEL);
 
 function hasDocumentEnvironment(content: string): boolean {
   return (

--- a/src/latex/latexdiff/service.ts
+++ b/src/latex/latexdiff/service.ts
@@ -7,10 +7,7 @@
  */
 
 import { LaTeXdiffService as LaTeXdiffServiceImpl } from '@latex/latexdiff';
-import * as logger from '@logger/logUtils';
 
 export const CHANNEL = 'LaTeXCommands';
-
-logger.initialize(CHANNEL);
 
 export const LaTeXdiffService = new LaTeXdiffServiceImpl(CHANNEL);

--- a/src/latex/texTools.ts
+++ b/src/latex/texTools.ts
@@ -17,7 +17,6 @@ import { getConfig } from '@utils/config/configUtils';
 import { splitContentLines } from '@utils/text/stringUtils';
 
 const CHANNEL = 'LaTeXCommands';
-logger.initialize(CHANNEL);
 
 // Raw tail, no TeX-log parsing -- a deliberate choice (see compileCheck.ts):
 // tex compile logs are noisy and heuristic parsing is a losing game, so every

--- a/src/latex/texcount.ts
+++ b/src/latex/texcount.ts
@@ -10,7 +10,6 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 import { hasExtension } from '@utils/core/pathCore';
 
 const CHANNEL = 'LaTeXCommands';
-logger.initialize(CHANNEL);
 
 /**
  * Check if a LaTeX file contains Chinese-related packages

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -143,7 +143,7 @@ export type ChannelWriter = (
 
 /**
  * Create a protocol-neutral writer for one shared or agent channel.
- * Channel creation is eager, matching `initialize`.
+ * Channel creation is eager so the returned writer owns a ready sink.
  */
 export function createChannelWriter(
   channel: string,
@@ -177,10 +177,6 @@ function logAt(
 ): void {
   // Functional callers write to the shared output channel.
   writeLine(level, channel, /* isAgent */ false, message, options.data);
-}
-
-export function initialize(channel: string, isAgent = false): void {
-  ensureChannel(channel, isAgent);
 }
 
 /**

--- a/src/platform/platform.ts
+++ b/src/platform/platform.ts
@@ -82,9 +82,8 @@ export function platform(): Readonly<Platform> {
 /**
  * Get the active platform context, or null if not yet initialized.
  *
- * Use this in facade modules that need to handle module-level
- * initialization (e.g. `logger.initialize(CHANNEL)` at import time)
- * before `initPlatform()` has been called.
+ * Use this in facade modules that need to tolerate access before
+ * `initPlatform()` has been called.
  */
 export function tryPlatform(): Readonly<Platform> | null {
   return _platform;

--- a/src/replacement/advanced.ts
+++ b/src/replacement/advanced.ts
@@ -6,7 +6,6 @@
 import * as logger from '@logger/logUtils';
 
 const CHANNEL = 'ReplacementEngine';
-logger.initialize(CHANNEL);
 
 /**
  * Applies LaTeX quotes formatting to a LaTeX document.

--- a/src/replacement/engine.ts
+++ b/src/replacement/engine.ts
@@ -48,7 +48,6 @@ import {
 } from './rulesRegex';
 
 const CHANNEL = 'ReplacementEngine';
-logger.initialize(CHANNEL);
 
 /**
  * High-level APIs for applying text replacement rules.

--- a/src/telemetry/UsageLogService.ts
+++ b/src/telemetry/UsageLogService.ts
@@ -16,7 +16,6 @@ import type {
 } from './UsageLogTypes';
 
 const CHANNEL = 'UsageLogService';
-logger.initialize(CHANNEL);
 
 const USAGE_LOG_ENDPOINT = `https://${SUPABASE_CUSTOM_DOMAIN}/functions/v1/log-usage`;
 const MAX_QUEUE_SIZE = 1000;

--- a/src/test-kernel/cli/CliSupabaseAuth.vitest.mts
+++ b/src/test-kernel/cli/CliSupabaseAuth.vitest.mts
@@ -206,7 +206,6 @@ describe('CLI Supabase auth', () => {
     const { initializeCliSupabaseAuth, signOutCliSupabase } =
       await loadSupabaseAuth();
     initializeCliSupabaseAuth({
-      initialize: vi.fn(),
       debug: vi.fn(),
       info: vi.fn(),
       warn,

--- a/src/test-kernel/logger/LogUtils.vitest.ts
+++ b/src/test-kernel/logger/LogUtils.vitest.ts
@@ -130,8 +130,8 @@ describe('logUtils', () => {
     const sink = { appendLine: vi.fn(), dispose };
     logger.setOutputChannelFactory(() => sink);
 
-    logger.initialize('shared');
-    logger.initialize('agent', true);
+    logger.createChannelWriter('shared', false);
+    logger.createChannelWriter('agent', true);
     logger.setOutputChannelFactory(null);
 
     expect(dispose).toHaveBeenCalledOnce();

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -72,7 +72,6 @@ export { rejectOversizedBibAttachments } from './delegation/inputFields';
 export type { WorkflowAgentInput };
 
 const LOG_CHANNEL = 'delegation';
-logger.initialize(LOG_CHANNEL);
 
 /**
  * Deliver a terminal error to the orchestrator when a resumed subagent's wake

--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -22,7 +22,6 @@ import {
 import { defineTool } from './core/define';
 
 const CHANNEL = 'DiagnosticsTool';
-logger.initialize(CHANNEL);
 
 const DiagnosticsPathSchema = z
   .string()

--- a/src/tools/ReportReviewIssueTool.ts
+++ b/src/tools/ReportReviewIssueTool.ts
@@ -14,7 +14,6 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 import { defineTool } from './core/define';
 
 const CHANNEL = 'ReportReviewIssueTool';
-logger.initialize(CHANNEL);
 
 /**
  * Sink injected by the extension host. Returns `accepted: false` with a

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -37,7 +37,6 @@ import { requireField } from './utils';
 
 // Constants
 const CHANNEL = 'TextEditorTool';
-logger.initialize(CHANNEL);
 const SNIPPET_LINES = 4;
 
 /** Rethrow ToolError as-is; wrap other errors with context message */

--- a/src/tools/comment/InlineCommentTool.ts
+++ b/src/tools/comment/InlineCommentTool.ts
@@ -16,7 +16,6 @@ import { formatResultCount } from '@utils/text/stringUtils';
 import { defineTool } from '../core/define';
 
 const CHANNEL = 'InlineCommentTool';
-logger.initialize(CHANNEL);
 
 /** A single comment within a thread, as seen by the agent. */
 interface InlineCommentView {

--- a/src/tools/delegation/inBandSubagentExecution.ts
+++ b/src/tools/delegation/inBandSubagentExecution.ts
@@ -62,7 +62,6 @@ import {
 } from './stableSubagentAttempt';
 
 const LOG_CHANNEL = 'inBandSubagentExecution';
-logger.initialize(LOG_CHANNEL);
 
 interface InBandSubagentExecutionBaseOptions {
   readonly configPayload: AgentConfigPayload;

--- a/src/tools/delegation/subagentExecution.ts
+++ b/src/tools/delegation/subagentExecution.ts
@@ -26,9 +26,6 @@ import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionCo
 import { getStreamTabId } from '@agent/runtime/streamTab';
 import { startChildRunLoop } from '@agent/runtime/childRunLoop';
 
-// Local imports - logger
-import * as logger from '@logger/logUtils';
-
 // Local imports - tools
 import {
   AgentCategory,
@@ -53,9 +50,6 @@ import { executeSubagentForDeliveryInBand } from './inBandSubagentExecution';
 // ============================================================================
 // Shared utilities
 // ============================================================================
-
-const LOG_CHANNEL = 'delegation';
-logger.initialize(LOG_CHANNEL);
 
 /** Metadata about how the delegation was approved, included in the tool result. */
 interface ApprovalMeta {

--- a/src/utils/files/rulesUtils.ts
+++ b/src/utils/files/rulesUtils.ts
@@ -8,7 +8,6 @@ import { AbsoluteFS } from './absoluteFS';
 import { WorkspaceFS } from './workspaceFS';
 
 const CHANNEL = 'rulesUtils';
-logger.initialize(CHANNEL);
 
 const RULES_FILE = '.texrarules';
 

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -55,8 +55,6 @@ export {
   type RunStorageEntryInspection,
 } from './runStorageFs';
 
-logger.initialize(CHANNEL);
-
 export class TaskRunFileService {
   public metadata: {
     executionId: ExecutionId | undefined;

--- a/src/utils/media/img.ts
+++ b/src/utils/media/img.ts
@@ -16,7 +16,6 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 import { executeCommand } from '@utils/system/execUtils';
 
 const CHANNEL = 'ImgUtils';
-logger.initialize(CHANNEL);
 
 // Define the temporary directory path
 const TEMP_DIR = path.join(os.tmpdir(), 'texra-pdf-conversion');

--- a/src/utils/prompt/promptUtils.ts
+++ b/src/utils/prompt/promptUtils.ts
@@ -7,7 +7,6 @@ import { filterNotNull } from '@utils/core';
 import { WorkspaceFS } from '@utils/files';
 
 const CHANNEL = 'promptUtils';
-logger.initialize(CHANNEL);
 
 export interface XmlFormatFromFilesResult {
   readonly xml: string | null;

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -22,7 +22,6 @@ import { getGitAuthorEnv } from '@utils/system/gitAuthorEnv';
 import { IS_WINDOWS, extendEnvPath } from '@utils/system/platformPaths';
 
 const CHANNEL = 'execUtils';
-logger.initialize(CHANNEL);
 
 type ExecaTextEncoding = Extract<
   NonNullable<Options['encoding']>,

--- a/src/utils/system/platformPaths.ts
+++ b/src/utils/system/platformPaths.ts
@@ -21,7 +21,6 @@ export const IS_WINDOWS = process.platform === 'win32';
 const TEX_TOOLS = ['latexdiff', 'latexindent', 'latexmk'] as const;
 
 const CHANNEL = 'platformPaths';
-logger.initialize(CHANNEL);
 
 // Cache for extra directories to avoid repeated glob operations
 let cachedExtraDirs: string[] | null = null;

--- a/src/utils/system/toolUtils.ts
+++ b/src/utils/system/toolUtils.ts
@@ -32,7 +32,6 @@ import { BinaryResolver } from './binaryResolver';
 import { executeCommand, executeCommandSync } from './execUtils';
 
 const CHANNEL = 'toolUtils';
-logger.initialize(CHANNEL);
 
 // Interface for tool configuration (internal to this module)
 interface ToolConfig {

--- a/src/utils/text/xmlConversion.ts
+++ b/src/utils/text/xmlConversion.ts
@@ -40,7 +40,6 @@ function detectInputFormat(text: string): OutputFormat {
 }
 
 const CHANNEL = 'xmlConversion';
-logger.initialize(CHANNEL);
 
 /**
  * Cached pandoc availability check.

--- a/src/utils/text/xmlExtraction.ts
+++ b/src/utils/text/xmlExtraction.ts
@@ -17,7 +17,6 @@ import { removeCDATA } from './xmlCdata';
 import { formatContent } from './xmlConversion';
 
 const CHANNEL = 'xmlExtraction';
-logger.initialize(CHANNEL);
 
 /**
  * Regex pattern for matching document opening tags with name attributes.


### PR DESCRIPTION
## Summary

- Delete the eager `logger.initialize` API and all 80 executable call sites.
- Keep ordinary sink creation lazy; retain eager creation only when `createChannelWriter` explicitly returns a writer.
- Remove the dead CLI log-backend shape member, now-unused imports, and the one orphaned delegation channel constant.

The 80 executable calls comprise 77 ordinary runtime sites, the test-oriented `connectionTests.ts` command, and two logger unit-test calls. No deletion is represented as a relocation, and no compatibility re-export remains.

Closes #8746

## Issue acceptance gates

- `logUtils.initialize` no longer exists and has no consumers.
- All 77 issue-cited runtime rituals and the three additional test-oriented calls are removed or replaced.
- The orphaned `subagentExecution.ts` channel constant and logger import are deleted.
- Comments in `logUtils.ts` and `platform.ts` no longer teach eager channel registration.
- Logging remains behavior-preserving because `writeLine` still creates sinks lazily through `ensureChannel`.

## Single source of truth

`src/logger/logUtils.ts` remains the sole owner of sink creation: ordinary log calls create their sink on first write, while `createChannelWriter` eagerly binds the explicit writer.

## Duplication and abstraction budget

This removes a registration ritual and its dead compatibility-shaped CLI member. No abstraction, adapter, shim, relocation, or re-export is added.

## Net elements

- Files: 83 modified, 0 added, 0 deleted.
- Exported symbols (`^[+-]export`): 0 added, 1 deleted; net -1.
- Named elements: 0 added; the logger initializer and orphaned `LOG_CHANNEL` are deleted, together with the unused CLI interface/object members.
- Full GitHub diff: +7 / -107 lines; net -100.

## Consumer counts

- `logger.initialize` / `logUtils.initialize`: 0 post-change hits across `.ts`, `.tsx`, `.mts`, and `.cts`.
- Removed executable calls: 80 total = 77 ordinary runtime + 1 connection-test command + 2 logger unit tests.
- `createChannelWriter`: 1 production consumer module (`src/agent/trace/channelTrace.ts`), where eager writer creation remains intentional; test mocks and coverage remain.

## Host impact

Extension:

- Shared TeXRA output sinks are created on first write instead of during module or class construction.

Desktop:

- No host-specific behavior change; shared logging keeps the same lazy first-write path.

CLI:

- Removes the unused `LogBackend.initialize` no-op and forwarder; debug, info, warn, and error behavior is unchanged.

## Rebase and simplification

- Rebased onto `origin/main` after PRs #8774 and #8776 merged.
- Inspected their overlapping changes in `packages/cli/src/runtime/initPlatform.ts`, `src/tools/DelegationTools.ts`, and `src/tools/delegation/inBandSubagentExecution.ts`; each retained only this PR's residual initializer deletion.
- A dedicated code-simplifier pass found no further simplification, unused logger import, orphaned retained channel constant, or unrelated change.

## Validation

- `corepack pnpm install` in the fresh worktree
- `npm run format` (no changes)
- `npm run typecheck`
- `npm run lint` (0 errors; 1 pre-existing warning in `AgentCreatorToolCatalogParity.vitest.mts`)
- `npm run check:dead-code-ratchet` (228 current = 228 baseline)
- `npm run compile:fast`
- Focused logger and CLI suites: 3 files, 27/27 tests passed
- Full `npm test`: 736 files passed, 1 skipped; 6,789 tests passed, 4 skipped
- Four-extension deletion greps and `git diff --check` passed on the rebased head
