### PR TITLE
refactor(trace): centralize run fact event types

### DIFF
--- a/packages/cli/src/runtime/sessionProgressSubscription.ts
+++ b/packages/cli/src/runtime/sessionProgressSubscription.ts
@@ -1,4 +1,4 @@
-import type { AgentEvent } from '@agent/trace';
+import { RUN_FACT_EVENT_TYPES, type AgentEvent } from '@agent/trace';
 import { toUpdateStreamUsagePayload } from '@agent/runtime/runFactUsage';
 import type {
   SessionEventHub,
@@ -22,22 +22,6 @@ type CliProjectedNdjsonProgressEvent = {
 }[CliNdjsonProgressEvent];
 
 export type CliNdjsonProgressRecordWriter = (record: CliNdjsonRecord) => void;
-
-const CLI_RUN_PROGRESS_EVENT_TYPES: readonly AgentEvent['type'][] = [
-  'conversation.progress',
-  'updateTodos',
-  'updatePlan',
-  'addOutputFiles',
-  'updateMissingOutputs',
-  'updateCompileFailures',
-  'goalPaused',
-  'run.config',
-  'usage',
-  'status',
-  'stage.start',
-  'child.activity',
-  'process.output',
-];
 
 /**
  * Project session facts onto the frozen NDJSON progress-event vocabulary.
@@ -71,7 +55,7 @@ function projectCliSessionFact(
   assertNever(fact, 'Unhandled CLI NDJSON session fact');
 }
 
-function projectCliRunFact(
+export function projectCliRunFact(
   streamId: StreamTabId,
   event: AgentEvent,
 ): CliProjectedNdjsonProgressEvent | undefined {
@@ -272,7 +256,7 @@ export function attachCliSessionProgressProjection(
       );
       if (projected) emitProjected(projected);
     },
-    { scope: 'run', types: CLI_RUN_PROGRESS_EVENT_TYPES },
+    { scope: 'run', types: RUN_FACT_EVENT_TYPES },
   );
 
   return () => {

--- a/packages/cli/src/runtime/sessionProgressSubscription.ts
+++ b/packages/cli/src/runtime/sessionProgressSubscription.ts
@@ -55,7 +55,7 @@ function projectCliSessionFact(
   assertNever(fact, 'Unhandled CLI NDJSON session fact');
 }
 
-export function projectCliRunFact(
+function projectCliRunFact(
   streamId: StreamTabId,
   event: AgentEvent,
 ): CliProjectedNdjsonProgressEvent | undefined {

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -379,8 +379,12 @@ export type AgentEvent =
   | DomainEvent
   | ResultEvent;
 
-/** Run facts consumed by both progress-view and headless CLI projections. */
-export const RUN_FACT_EVENT_TYPES = [
+/**
+ * Event types consumed by both progress-view and headless CLI projections.
+ * This host subscription vocabulary is intentionally broader than
+ * `RunFactEvent`: it also includes transient runtime events that hosts project.
+ */
+export const RUN_FACT_EVENT_TYPES = Object.freeze([
   'conversation.progress',
   'updateTodos',
   'updatePlan',
@@ -394,4 +398,4 @@ export const RUN_FACT_EVENT_TYPES = [
   'stage.start',
   'child.activity',
   'process.output',
-] as const satisfies readonly AgentEvent['type'][];
+] as const satisfies readonly AgentEvent['type'][]);

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -378,3 +378,20 @@ export type AgentEvent =
   | ResponseFinalizedEvent
   | DomainEvent
   | ResultEvent;
+
+/** Run facts consumed by both progress-view and headless CLI projections. */
+export const RUN_FACT_EVENT_TYPES = [
+  'conversation.progress',
+  'updateTodos',
+  'updatePlan',
+  'addOutputFiles',
+  'updateMissingOutputs',
+  'updateCompileFailures',
+  'goalPaused',
+  'run.config',
+  'usage',
+  'status',
+  'stage.start',
+  'child.activity',
+  'process.output',
+] as const satisfies readonly AgentEvent['type'][];

--- a/src/agent/trace/index.ts
+++ b/src/agent/trace/index.ts
@@ -17,6 +17,7 @@ export type {
   StageStartEvent,
   StatusEvent,
 } from './events';
+export { RUN_FACT_EVENT_TYPES } from './events';
 
 export type {
   AgentTrace,

--- a/src/controllers/progressView/backend/ProgressBackend.ts
+++ b/src/controllers/progressView/backend/ProgressBackend.ts
@@ -5,7 +5,6 @@ import {
 import { WebviewUpdater } from '@controllers/progressView/backend/WebviewUpdater';
 import {
   ProgressFactApplier,
-  PROGRESS_BACKEND_RUN_PROGRESS_EVENT_TYPES,
   type GetProgressStreamControls,
   type ProgressEventSubscription,
 } from '@controllers/progressView/backend/events/ProgressFactApplier';
@@ -23,6 +22,7 @@ import {
   type BuildApprovalRequestHandlerSetParams,
 } from '@controllers/progressView/backend/progressBackendUiConfig';
 import { canUseStreamDataDir } from '@transcript/streamDataPaths';
+import { RUN_FACT_EVENT_TYPES } from '@agent/trace';
 import {
   defaultSession,
   type SessionHandle,
@@ -327,7 +327,7 @@ export class ProgressBackend {
           sessionEvent.event,
         );
       },
-      { scope: 'run', types: PROGRESS_BACKEND_RUN_PROGRESS_EVENT_TYPES },
+      { scope: 'run', types: RUN_FACT_EVENT_TYPES },
     );
     return {
       dispose: () => {

--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -7,8 +7,12 @@ import {
   type StreamExecutionState,
 } from '@controllers/progressView/backend/state/ProgressViewState';
 import { WebviewBridge } from '@controllers/progressView/backend/WebviewBridge';
-import type { AgentEvent, AgentTrace } from '@agent/trace';
-import { createChannelTrace } from '@agent/trace';
+import {
+  createChannelTrace,
+  RUN_FACT_EVENT_TYPES,
+  type AgentEvent,
+  type AgentTrace,
+} from '@agent/trace';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { TaskState } from '@agent/core/state/TaskState';
 import { toUpdateStreamUsagePayload } from '@agent/runtime/runFactUsage';
@@ -75,33 +79,6 @@ export type ProgressStreamControls = ProgressStreamBypassControls &
 export type GetProgressStreamControls = (
   stream: StreamTabId,
 ) => ProgressStreamControls;
-
-/**
- * Run-scoped event types this backend handles, and the single source of truth
- * for the `runFactHandlers` table: the `RunFactHandlers` mapped type requires
- * exactly one handler per entry, so a listed type without a handler (or vice
- * versa) is a compile error. `ProgressBackend` reuses this as its run-scope
- * subscription filter, keeping delivered and handled events in sync by
- * construction.
- */
-const RUN_FACT_EVENT_TYPES = [
-  'conversation.progress',
-  'updateTodos',
-  'updatePlan',
-  'addOutputFiles',
-  'updateMissingOutputs',
-  'updateCompileFailures',
-  'goalPaused',
-  'run.config',
-  'usage',
-  'status',
-  'stage.start',
-  'child.activity',
-  'process.output',
-] as const satisfies readonly AgentEvent['type'][];
-
-export const PROGRESS_BACKEND_RUN_PROGRESS_EVENT_TYPES: readonly AgentEvent['type'][] =
-  RUN_FACT_EVENT_TYPES;
 
 type RunFactType = (typeof RUN_FACT_EVENT_TYPES)[number];
 

--- a/src/test-kernel/agent/trace/AgentTrace.vitest.ts
+++ b/src/test-kernel/agent/trace/AgentTrace.vitest.ts
@@ -9,6 +9,7 @@ import {
   type AgentTrace,
   emitToolUseCard,
   logFileCategory,
+  RUN_FACT_EVENT_TYPES,
   type StageStartEvent,
   TraceEmitter,
 } from '@agent/trace';
@@ -17,6 +18,12 @@ import { MESSAGE_TYPES } from '@shared/schemas';
 // ---------------------------------------------------------------------------
 // StageMetadata
 // ---------------------------------------------------------------------------
+
+describe('run-fact event vocabulary', () => {
+  it('does not expose a mutable shared subscription list', () => {
+    expect(Object.isFrozen(RUN_FACT_EVENT_TYPES)).toBe(true);
+  });
+});
 
 describe('TraceEmitter stage metadata', () => {
   it('emits typed stage metadata for round stages', () => {

--- a/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
+++ b/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
@@ -18,7 +18,6 @@ import type {
 } from '@cli/runtime/cliNdjsonProgressEvents';
 import {
   attachCliSessionProgressProjection,
-  projectCliRunFact,
   type CliNdjsonProgressRecordWriter,
 } from '@cli/runtime/sessionProgressSubscription';
 import {
@@ -610,13 +609,25 @@ describe('attachCliSessionProgressProjection', () => {
   });
 
   it('does not project run events outside the shared fact vocabulary', () => {
-    expect(
-      projectCliRunFact(streamId, {
-        type: 'log',
-        level: 'info',
-        message: 'not a progress fact',
-      }),
-    ).toBeUndefined();
+    const events = new SessionEventHub();
+    const writeRecord = recordWriter();
+    const detach = attachCliSessionProgressProjection(events, writeRecord);
+
+    try {
+      events.emit({
+        scope: 'run',
+        streamId,
+        event: {
+          type: 'log',
+          level: 'info',
+          message: 'not a progress fact',
+        },
+      });
+
+      expect(writeRecord).not.toHaveBeenCalled();
+    } finally {
+      detach();
+    }
   });
 
   it('derives updateConversationProgress from a typed conversation progress event', () => {

--- a/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
+++ b/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
@@ -18,6 +18,7 @@ import type {
 } from '@cli/runtime/cliNdjsonProgressEvents';
 import {
   attachCliSessionProgressProjection,
+  projectCliRunFact,
   type CliNdjsonProgressRecordWriter,
 } from '@cli/runtime/sessionProgressSubscription';
 import {
@@ -606,6 +607,16 @@ describe('attachCliSessionProgressProjection', () => {
     } finally {
       detach();
     }
+  });
+
+  it('does not project run events outside the shared fact vocabulary', () => {
+    expect(
+      projectCliRunFact(streamId, {
+        type: 'log',
+        level: 'info',
+        message: 'not a progress fact',
+      }),
+    ).toBeUndefined();
   });
 
   it('derives updateConversationProgress from a typed conversation progress event', () => {


### PR DESCRIPTION
Closes #8750

## Summary

- Define the shared run-fact subscription vocabulary beside `AgentEvent`.
- Have both progress-view and headless CLI subscriptions consume that value.
- Delete the two host-owned copies and the progress-backend forwarding alias.
- Keep the CLI projector file-local and cover out-of-vocabulary events through the public subscription boundary.

## Issue acceptance gates

- `CLI_RUN_PROGRESS_EVENT_TYPES` no longer exists.
- `PROGRESS_BACKEND_RUN_PROGRESS_EVENT_TYPES` no longer exists.
- `RUN_FACT_EVENT_TYPES` is owned by `src/agent/trace/events.ts` and exported through `@agent/trace`.
- Progress-view and headless CLI subscriptions consume the shared tuple without changing its 13 entries or order.
- The CLI projection test verifies that a run event outside the shared vocabulary emits no NDJSON progress record.
- The intentionally different TUI and headless subsets remain local and unchanged.

## Single source of truth

`src/agent/trace/events.ts` owns `RUN_FACT_EVENT_TYPES` beside the `AgentEvent` union. Host projections retain their distinct projection behavior while sharing one subscription vocabulary.

## Duplication and abstraction budget

Deleted two byte-identical host lists and one forwarding export. The replacement is a frozen tuple in the existing event-vocabulary module; no wrapper, facade, or pass-through layer was added.

## Net elements (R6)

- Files: 7 changed.
- LoC: +61 / -49, net +12, including the required boundary tests and tuple-freezing assertion.
- Exported symbols: +1 shared `RUN_FACT_EVENT_TYPES`, -1 forwarding `PROGRESS_BACKEND_RUN_PROGRESS_EVENT_TYPES`, net 0 symbols; the existing `@agent/trace` barrel re-exports the shared value.
- Constants: two host-owned lists and one forwarding alias cease to exist; one shared tuple is added, net -2 constant elements.
- Classes/interfaces/enums: no change.

## Consumer counts (R8)

- Deleted `PROGRESS_BACKEND_RUN_PROGRESS_EVENT_TYPES`: 1 production consumer, replaced directly in `ProgressBackend`.
- Deleted `CLI_RUN_PROGRESS_EVENT_TYPES`: 1 production consumer, replaced directly in `attachCliSessionProgressProjection`.
- Shared `RUN_FACT_EVENT_TYPES`: 2 runtime subscription consumers plus 1 mapped-type exhaustiveness consumer.
- Emit paths: n/a; no emit path was deleted or rerouted.

## Host impact

Extension: progress-view subscription now imports the shared tuple; delivered events and handlers are unchanged.

Desktop: no host-specific change.

CLI: headless session-progress subscription now imports the shared tuple; NDJSON projection behavior is unchanged.

## Scheduled refactoring

None. The intentionally different TUI and headless subsets remain out of scope.

## Validation

- `npm run format`
- `npm run compile:safe`
- `npm run lint` (zero errors; one pre-existing warning)
- `npm run typecheck` after rebasing onto current `main`
- `npm run check:dead-code-ratchet` (233 current = 233 baseline)
- Focused Vitest after the review fix: `CliSessionProgressSubscription.vitest.mts` — 11/11 passed
- Earlier focused Vitest: 88 tests across CLI projection, progress backend, trace, and the CLI architecture boundary
- Full Vitest before the review fix: 6771 passed; broad local resource timeouts were rerun serially, where 15 of 16 affected files passed. `RunChatSignalOwnership` also timed out unchanged on an untouched `origin/main` worktree, classifying it as a pre-existing base failure.
