### PR TITLE
refactor(progress): remove desktop proposal self-reference

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -72,7 +72,6 @@ import {
   type StreamTabId,
 } from '@shared/schemas';
 import { PROGRESS_VIEW_COMMANDS, COMMON_COMMANDS } from '@shared/ipc';
-import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import {
   formatActiveStreamRetention,
   formatStreamDeletionRetention,
@@ -268,18 +267,6 @@ export class DesktopProgressBridge {
           retry: {
             show: () => undefined,
             dismiss: () => undefined,
-          },
-          agentProposal: {
-            show: (p) =>
-              this.backend.webviewUpdater.showPermission({
-                kind: PERMISSION_KIND.PROPOSAL,
-                data: p,
-              }),
-            dismiss: (id) =>
-              this.backend.webviewUpdater.resolvePermission(
-                PERMISSION_KIND.PROPOSAL,
-                id,
-              ),
           },
         },
       },

--- a/src/controllers/progressView/backend/progressBackendUiConfig.ts
+++ b/src/controllers/progressView/backend/progressBackendUiConfig.ts
@@ -144,10 +144,9 @@ const APPROVAL_REQUEST_HANDLER_KEYS = Object.keys(
 ) as Array<keyof ApprovalRequestHandlerSet>;
 
 /**
- * Host-specific show/dismiss transport for one approval kind. retry and
- * agentProposal differ across hosts (the extension shows a retry panel and
- * upgrades proposals with model/agent dropdowns; the desktop cancels retries
- * and shows a plain proposal), so each host supplies these two directly.
+ * Host-specific show/dismiss transport for one approval kind. Every host
+ * supplies retry behavior. A host may override agent proposals when it needs
+ * richer presentation data than the built-in permission handler provides.
  */
 interface ApprovalHandlerTransport<T> {
   show: (item: T) => void;
@@ -156,7 +155,7 @@ interface ApprovalHandlerTransport<T> {
 
 interface ApprovalRequestHandlerOverrides {
   retry: ApprovalHandlerTransport<RetryPermission>;
-  agentProposal: ApprovalHandlerTransport<AgentProposalPermission>;
+  agentProposal?: ApprovalHandlerTransport<AgentProposalPermission>;
 }
 
 export interface BuildApprovalRequestHandlerSetParams {
@@ -238,16 +237,22 @@ export function buildApprovalRequestHandlerSet(
       overrides.retry.dismiss,
       canSend,
     ),
-    agentProposal: new ApprovalRequestHandler<
-      AgentProposalPermission,
-      'proposalId',
-      ProposalResult
-    >(
-      'proposalId',
-      overrides.agentProposal.show,
-      overrides.agentProposal.dismiss,
-      canSend,
-    ),
+    agentProposal: overrides.agentProposal
+      ? new ApprovalRequestHandler<
+          AgentProposalPermission,
+          'proposalId',
+          ProposalResult
+        >(
+          'proposalId',
+          overrides.agentProposal.show,
+          overrides.agentProposal.dismiss,
+          canSend,
+        )
+      : webviewPermissionHandler<
+          typeof PERMISSION_KIND.PROPOSAL,
+          'proposalId',
+          ProposalResult
+        >(webviewUpdater, canSend, PERMISSION_KIND.PROPOSAL, 'proposalId'),
   };
 }
 

--- a/src/test-kernel/progressView/ApprovalRequestHandlerSet.vitest.ts
+++ b/src/test-kernel/progressView/ApprovalRequestHandlerSet.vitest.ts
@@ -1,14 +1,86 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  buildApprovalRequestHandlerSet,
   cancelApprovalRequestHandlers,
   createProgressBackendUiConfig,
   replayApprovalRequestHandlers,
   type ApprovalRequestHandlerSet,
 } from '@controllers/progressView/backend/progressBackendUiConfig';
-import type { WebviewUpdater } from '@controllers/progressView/backend/WebviewUpdater';
+import { WebviewUpdater } from '@controllers/progressView/backend/WebviewUpdater';
+import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+import {
+  AgentCategory,
+  type AgentProposalPermission,
+  type ProgressViewOutboundMessage,
+} from '@shared/schemas';
+import { PERMISSION_KIND } from '@shared/utils/uiConstants';
+
+const proposal = {
+  proposalId: 'proposal-1',
+  streamId: 'stream-1',
+  agentCategory: AgentCategory.ToolUse,
+  agent: 'search',
+  model: 'deepseekproT',
+  instruction: 'Search for a reference.',
+  memories: [],
+} satisfies AgentProposalPermission;
 
 describe('ApprovalRequestHandlerSet helpers', () => {
+  it('uses the built-in permission transport for agent proposals by default', () => {
+    const messages: ProgressViewOutboundMessage[] = [];
+    const handlers = buildApprovalRequestHandlerSet({
+      webviewUpdater: new WebviewUpdater(
+        (message) => messages.push(message),
+        () => true,
+      ),
+      canSend: () => true,
+      overrides: {
+        retry: { show: vi.fn(), dismiss: vi.fn() },
+      },
+    });
+
+    handlers.agentProposal.show(proposal);
+    expect(messages).toContainEqual({
+      command: PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION,
+      action: 'show',
+      permission: { kind: PERMISSION_KIND.PROPOSAL, data: proposal },
+    });
+
+    expect(handlers.agentProposal.dismiss(proposal.proposalId)).toBe(true);
+    expect(messages).toContainEqual({
+      command: PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION,
+      action: 'resolve',
+      kind: PERMISSION_KIND.PROPOSAL,
+      id: proposal.proposalId,
+    });
+  });
+
+  it('uses an explicit agent proposal transport override when supplied', () => {
+    const messages: ProgressViewOutboundMessage[] = [];
+    const show = vi.fn();
+    const dismiss = vi.fn();
+    const handlers = buildApprovalRequestHandlerSet({
+      webviewUpdater: new WebviewUpdater(
+        (message) => messages.push(message),
+        () => true,
+      ),
+      canSend: () => true,
+      overrides: {
+        retry: { show: vi.fn(), dismiss: vi.fn() },
+        agentProposal: { show, dismiss },
+      },
+    });
+
+    handlers.agentProposal.show(proposal);
+    expect(show).toHaveBeenCalledWith(proposal);
+    expect(messages).toEqual([]);
+
+    expect(handlers.agentProposal.dismiss(proposal.proposalId)).toBe(true);
+    expect(dismiss).toHaveBeenCalledWith(proposal.proposalId);
+    expect(messages).toEqual([]);
+  });
+
   it('routes cancellation through the exact listed interaction handlers', () => {
     const cancellationScope = {};
     const request = { streamId: 'stream-1' };


### PR DESCRIPTION
## Summary

- make the agent-proposal approval transport optional in the shared handler composition
- use the existing built-in proposal permission handler when no host override is supplied
- delete the desktop proposal override that lazily referenced `this.backend`, while preserving its retry no-op and the extension's richer proposal override
- add focused coverage for both default and overridden proposal transports

## Design

The shared approval builder now owns the ordinary proposal presentation path. Hosts override it only when they add behavior: the extension still supplies model-option data, while desktop uses the built-in handler. This removes a construction-order dependency without adding a wrapper, adapter, or compatibility surface.

## Verification

- `npm run format`
- `npm run typecheck`
- `npm run lint` (0 errors; one pre-existing unrelated warning)
- `npm run check:dead-code-ratchet` (233 current = 233 baseline)
- `npm run compile:fast`
- `npx vitest run src/test-kernel/progressView/ApprovalRequestHandlerSet.vitest.ts src/test-kernel/progressView/ProgressBackend.vitest.ts src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts` (152 tests on the rebased head)
- consumer greps covered `.ts`, `.tsx`, `.mts`, and `.cts`; desktop has no proposal `showPermission` or `resolvePermission` call through `this.backend`, and the extension proposal override remains

## Net LoC

- Production: +20 / -28, net -8
- Tests: +73 / -1, net +72
- Total: +93 / -29, net +64
- Files: 3 modified
- Exported symbols: 0 added, 0 removed
- Relocations: none
- Compatibility shims: none

No changelog entry is included because the change is not user-visible.

Closes #8760

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal approval wiring refactor with equivalent desktop proposal IPC; extension override unchanged and new unit tests cover both paths.
> 
> **Overview**
> **Agent proposal approvals** now use the shared `webviewPermissionHandler` path when a host does not supply a custom transport, instead of requiring every host to wire `show`/`dismiss` for proposals.
> 
> `buildApprovalRequestHandlerSet` treats **`agentProposal` as an optional override** (retry remains required). Omitted overrides get the same built-in `PERMISSION_KIND.PROPOSAL` show/resolve messages as other permission kinds. The VS Code extension **still overrides** proposals to attach model options and extra UI data.
> 
> The **desktop host drops** its proposal override that forwarded through `this.backend.webviewUpdater` during `ProgressBackend` construction, removing that lazy self-reference while keeping desktop retry as a no-op. **Tests** cover default webview transport vs explicit override behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d72ee6c06bce086ba70e2371a34169ab28b27cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->