### PR TITLE
test(cli): replace fixed ModelAccessForm render delay

### DIFF
--- a/src/test-kernel/cli/ModelAccessForm.vitest.mts
+++ b/src/test-kernel/cli/ModelAccessForm.vitest.mts
@@ -85,7 +85,7 @@ describe('ModelAccessForm status', () => {
 
     try {
       await waitFor(() => loadCliModelAccessOverview.mock.calls.length > 0);
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await waitFor(() => stdout.output.includes('model access unavailable'));
       expect(stdout.output).toContain('model access unavailable');
       expect(stdout.output).toContain('Sign in through Account');
       expect(stdout.output).not.toContain('Use your TeXRA account');


### PR DESCRIPTION
## Summary

- wait for the rejected model-access state to appear in captured Ink output
- remove the fixed 50 ms render assumption that failed repeatedly under the full Linux kernel shard
- preserve every existing semantic assertion and leave product code unchanged

## Context

This follow-up was found while shipping parent issue #8760 and its blocked PR #8767. The same timing race recurred on #8755, #8763, and twice on #8767. Each #8767 occurrence was the sole failing test in its shard: 3,395 tests passed.

## Design

The test already has a bounded condition-based `waitFor` helper. Reusing it for the observable rejected-state text makes the test synchronize on the state it asserts, with the existing two-second timeout retained. No helper, timeout, product behavior, or assertion is weakened.

## Verification

- `npm run format`
- `npm run typecheck`
- `npm run lint` (0 errors; one pre-existing unrelated warning in `AgentCreatorToolCatalogParity.vitest.mts`)
- `npm run check:dead-code-ratchet` (233 current = 233 baseline)
- `npm run compile:fast`
- `npx vitest run src/test-kernel/cli/ModelAccessForm.vitest.mts` (six pre-rebase passes and one post-rebase pass)
- consumer grep includes `.ts`, `.tsx`, `.mts`, and `.cts`; the fixed 50 ms wait is absent from the touched test

## Accounting

- test code: +1 / -1, net 0 lines
- production code: unchanged
- total: +1 / -1, net 0 lines
- no relocations, re-export shims, or baseline changes
- no CHANGELOG entry because this is a test-only reliability correction

Closes #8768

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timing fix with no production or assertion changes.
> 
> **Overview**
> **Replaces a fixed 50 ms sleep** in `ModelAccessForm.vitest.mts` with the existing `waitFor` helper so the test waits until Ink stdout includes `model access unavailable` before asserting.
> 
> The test already waited for the mocked `loadCliModelAccessOverview` call; the extra delay assumed render timing and flaked on slow Linux CI shards. **Assertions and product code are unchanged**—only synchronization is tied to the observable error state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22ac9733def9e5441496fe330d89b3460a3cd3c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->