### PR TITLE
test(transcript): await mirrored snapshot write

### DIFF
--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 
+import pDefer from 'p-defer';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { resolveRunStoragePath } from '@platform/defaults/workspaceStorage';
@@ -1345,11 +1346,17 @@ describe('StreamSnapshotStore', () => {
 
     renameSpy.mockRestore();
     const writeAtomic = StorageFS.writeAtomic.bind(StorageFS);
+    const writeFinished = pDefer<void>();
     const writeSpy = vi
       .spyOn(StorageFS, 'writeAtomic')
-      .mockImplementation(writeAtomic);
+      .mockImplementation((...args) => {
+        const write = writeAtomic(...args);
+        writeFinished.resolve(write);
+        return write;
+      });
     store.setTodos(STREAM, [TODO]);
-    await vi.waitFor(() => expect(writeSpy).toHaveBeenCalledTimes(1));
+    await writeFinished.promise;
+    expect(writeSpy).toHaveBeenCalledTimes(1);
     writeSpy.mockRestore();
 
     const reloaded = new StreamSnapshotStore();


### PR DESCRIPTION
## Summary

- make the rollback-mirroring regression test await the exact `StorageFS.writeAtomic` promise observed by its spy
- retain the assertion that automatic mirroring performs exactly one write
- remove the race between spy invocation and the fresh store reload

## Design and scope

The test now uses the repository's existing `p-defer` synchronization primitive. The spy passes the real write promise to the deferred promise, whose resolution adopts the write's settlement. Reload therefore cannot begin merely because the spy recorded a call.

This is test-only. It adds no production seam, timeout, sleep, explicit production `flush()`, or behavior change. No changelog entry is warranted.

## Net elements (R6)

- production elements: unchanged
- test synchronization: one file-local deferred promise
- files: 1 changed
- LoC: +9 / -2, net **+7**

## Consumer counts (R8)

Not applicable: no production symbol, export, or consumer changes.

## Verification

- `npm run format`
- `npm run typecheck`
- `npm run lint` (0 errors; one unchanged warning in `AgentCreatorToolCatalogParity.vitest.mts`)
- `npm run check:dead-code-ratchet` (233/233)
- `npm run compile:fast`
- exact failing test: passed once normally
- exact failing test: passed in 8/8 concurrent isolated Vitest processes
- complete `StreamSnapshotStore.vitest.ts`: 62/62 passed
- `git diff --check`

Follow-up to #8743 and PR #8770.

Closes #8771

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only test synchronization in one Vitest file; production behavior is untouched.
> 
> **Overview**
> **Test-only** fix for the `mirrors writes when rollback moved data before reporting failure` regression in `StreamSnapshotStore.vitest.ts`.
> 
> The `StorageFS.writeAtomic` spy now wires the real write promise through **`p-defer`**, and the test **`await`s that deferred promise** before constructing a fresh `StreamSnapshotStore` and reloading from disk. That removes a race where `vi.waitFor` could pass as soon as the spy was invoked, while the atomic write was still in flight—so reload could flake under concurrency.
> 
> The assertion that automatic mirroring performs **exactly one** `writeAtomic` call is unchanged. **No production code** changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50e3bf3da1b4c105f95aaa01ce98602ff6e95b89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->