### PR TITLE
refactor(tools): shrink setup platform surface

### DIFF
--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -1127,31 +1127,6 @@
       "name": "LspRange"
     },
     {
-      "file": "src/tools/setup/platform.ts",
-      "category": "types",
-      "name": "SetupAuthAdapter"
-    },
-    {
-      "file": "src/tools/setup/platform.ts",
-      "category": "types",
-      "name": "SetupCommandAdapter"
-    },
-    {
-      "file": "src/tools/setup/platform.ts",
-      "category": "types",
-      "name": "SetupConfigAdapter"
-    },
-    {
-      "file": "src/tools/setup/platform.ts",
-      "category": "types",
-      "name": "SetupExtensionAdapter"
-    },
-    {
-      "file": "src/tools/setup/platform.ts",
-      "category": "types",
-      "name": "SetupTerminalAdapter"
-    },
-    {
       "file": "src/transcript/index.ts",
       "category": "exports",
       "name": "unregisterFlushers"

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -40,10 +40,7 @@ import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 
 // Local imports - setup tools
-import {
-  createDefaultSetupPlatform,
-  setSetupPlatform,
-} from '@tools/setup/platform';
+import { setSetupPlatform } from '@tools/setup/platform';
 
 // Local imports - utilities
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -352,15 +349,11 @@ export async function initCliPlatform(
     serverSideKeysInitialized = true;
   }
 
-  const defaultSetupPlatform = createDefaultSetupPlatform('cli');
   setSetupPlatform({
-    ...defaultSetupPlatform,
-    auth: {
-      ...defaultSetupPlatform.auth,
-      signIn: async () => {
-        await signInCliSupabase({ openBrowser: true });
-        return getCliAuthProvider().canAccessRemoteAgentCatalog();
-      },
+    host: 'cli',
+    signIn: async () => {
+      await signInCliSupabase({ openBrowser: true });
+      return getCliAuthProvider().canAccessRemoteAgentCatalog();
     },
   });
 

--- a/packages/desktop/src/main/desktopSetupAuth.ts
+++ b/packages/desktop/src/main/desktopSetupAuth.ts
@@ -1,19 +1,12 @@
-import {
-  createDefaultSetupPlatform,
-  setSetupPlatform,
-} from '@tools/setup/platform';
+import { setSetupPlatform } from '@tools/setup/platform';
 
 let activeSignIn: (() => Promise<boolean>) | undefined;
 
 /** Install a process-owned setup adapter that resolves the active window lazily. */
 export function initializeDesktopSetupAuth(): void {
-  const defaults = createDefaultSetupPlatform('desktop');
   setSetupPlatform({
-    ...defaults,
-    auth: {
-      ...defaults.auth,
-      signIn: () => activeSignIn?.() ?? Promise.resolve(false),
-    },
+    host: 'desktop',
+    signIn: () => activeSignIn?.() ?? Promise.resolve(false),
   });
 }
 

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -100,7 +100,7 @@ import { migrateLegacyGlobalBashApprovalOverride } from '@shared/settingsView/ha
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { setOpenPdfOpener } from '@tools/OpenPdfTool';
 import { refreshToolAvailability } from '@tools/toolAvailability';
-import { createDefaultSetupPlatform, setSetupPlatform } from '@tools/setup';
+import { setSetupPlatform } from '@tools/setup';
 import {
   SharedPRPollingSource,
   SharedRepoPollingSource,
@@ -544,16 +544,11 @@ export async function activate(context: vscode.ExtensionContext) {
       } satisfies vscode.TextDocumentShowOptions,
     );
   });
-  const defaultSetupPlatform = createDefaultSetupPlatform('extension');
   setSetupPlatform({
-    ...defaultSetupPlatform,
-    auth: {
-      ...defaultSetupPlatform.auth,
-      signIn: async () =>
-        (await vscode.commands.executeCommand<boolean>(
-          AUTH_COMMANDS.SIGN_IN,
-        )) === true,
-    },
+    host: 'extension',
+    signIn: async () =>
+      (await vscode.commands.executeCommand<boolean>(AUTH_COMMANDS.SIGN_IN)) ===
+      true,
     commands: {
       invoke: (cmd, ...args) =>
         Promise.resolve(vscode.commands.executeCommand(cmd, ...args)),

--- a/src/test-kernel/cli/CliInitPlatform.vitest.mts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.mts
@@ -460,7 +460,7 @@ describe('CLI platform init', () => {
     await initCliPlatform(cliContext());
 
     expect(getSetupPlatform().host).toBe('cli');
-    await expect(getSetupPlatform().auth.signIn?.()).resolves.toBe(true);
+    await expect(getSetupPlatform().signIn?.()).resolves.toBe(true);
     expect(mocks.signInCliSupabase).toHaveBeenCalledOnce();
     expect(mocks.signInCliSupabase).toHaveBeenCalledWith({ openBrowser: true });
   });

--- a/src/test-kernel/desktop/DesktopSetupAuth.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSetupAuth.vitest.mts
@@ -13,7 +13,7 @@ describe('desktop setup auth adapter', () => {
     registerDesktopSetupSignIn(signIn);
 
     expect(getSetupPlatform().host).toBe('desktop');
-    await expect(getSetupPlatform().auth.signIn?.()).resolves.toBe(true);
+    await expect(getSetupPlatform().signIn?.()).resolves.toBe(true);
     expect(signIn).toHaveBeenCalledOnce();
   });
 
@@ -24,7 +24,7 @@ describe('desktop setup auth adapter', () => {
 
     windowRegistration.dispose();
 
-    await expect(getSetupPlatform().auth.signIn?.()).resolves.toBe(false);
+    await expect(getSetupPlatform().signIn?.()).resolves.toBe(false);
     expect(signIn).not.toHaveBeenCalled();
   });
 });

--- a/src/test-kernel/model/ApiProviders.vitest.ts
+++ b/src/test-kernel/model/ApiProviders.vitest.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import {
@@ -13,7 +13,7 @@ import {
   type ApiProvider,
 } from '@model/apiProviders';
 import { UnsetApiKeyTool } from '@tools/setup/UnsetApiKeyTool';
-import { setSetupPlatform, type SetupPlatform } from '@tools/setup/platform';
+import { setSetupPlatform, setupSecrets } from '@tools/setup/platform';
 import type { PlatformSecrets } from '@platform/secrets';
 
 function createSecrets(
@@ -64,71 +64,25 @@ function setupApiKeyToolPlatform(
   store: Map<string, string>,
   envProviders: ReadonlySet<ApiProvider> = new Set(),
 ): void {
-  const platform: SetupPlatform = {
-    host: 'cli',
-    secrets: {
-      providers: ['openai', 'kimiCode'],
-      async deleteApiKey(provider) {
-        store.delete(apiKeySecretName(provider));
-      },
-      async hasUsableApiKey(provider) {
-        return (
-          (store.get(apiKeySecretName(provider))?.trim().length ?? 0) > 0 ||
-          envProviders.has(provider)
-        );
-      },
-      async apiKeyOrigin(provider) {
-        if (store.has(apiKeySecretName(provider))) return 'secret';
-        return envProviders.has(provider) ? 'env' : 'none';
-      },
-      async storedApiKeyExists(provider) {
-        return store.has(apiKeySecretName(provider));
-      },
-      async anyUsableCredentialExists() {
-        return store.size > 0;
-      },
-      async gitHubTokenExists() {
-        return 'none';
-      },
-      async listStoredKeys() {
-        return [...store.keys()] as readonly string[];
-      },
+  vi.spyOn(setupSecrets, 'deleteApiKey').mockImplementation(
+    async (provider) => {
+      store.delete(apiKeySecretName(provider));
     },
+  );
+  vi.spyOn(setupSecrets, 'hasUsableApiKey').mockImplementation(
+    async (provider) =>
+      (store.get(apiKeySecretName(provider))?.trim().length ?? 0) > 0 ||
+      envProviders.has(provider),
+  );
+  vi.spyOn(setupSecrets, 'storedApiKeyExists').mockImplementation(
+    async (provider) => store.has(apiKeySecretName(provider)),
+  );
+  setSetupPlatform({
+    host: 'cli',
     commands: {
       async invoke() {},
     },
-    extensions: {
-      isInstalled() {
-        return false;
-      },
-      async install() {},
-    },
-    auth: {
-      async getStatus() {
-        return {
-          authenticated: false,
-          remoteAgentCatalogAvailable: false,
-        };
-      },
-    },
-    modelAccess: {
-      async getChatGptSubscriptionStatus() {
-        return { signedIn: false, enabled: false };
-      },
-    },
-    config: {
-      get() {
-        return undefined;
-      },
-      async update() {},
-    },
-    terminal: {
-      async runCommand() {
-        return { exitCode: 0, output: '', timedOut: false };
-      },
-    },
-  };
-  setSetupPlatform(platform);
+  });
 }
 
 describe('API provider key caches', () => {
@@ -138,6 +92,7 @@ describe('API provider key caches', () => {
 
   afterEach(() => {
     invalidateApiKeyCache();
+    vi.restoreAllMocks();
   });
 
   it('uses the documented Kimi Code environment variable', () => {

--- a/src/test-kernel/tools/setup/ApplyTeamTool.vitest.mts
+++ b/src/test-kernel/tools/setup/ApplyTeamTool.vitest.mts
@@ -3,13 +3,22 @@ import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 // Third-party imports
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 
 // Local imports
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { platform } from '@platform/platform';
 import { createFakePlatform } from '@test/support/FakePlatform';
 import { refresh } from '@agent/index/agentRegistry';
+import { SupabaseClient } from '@auth/SupabaseClient';
 import { getDefaultTeamId } from '@shared/state/onboardingState';
 import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
 import { ApplyTeamTool } from '@tools/setup/ApplyTeamTool';
@@ -84,6 +93,10 @@ beforeAll(async () => {
     ),
   );
   await refresh({ includeRemote: false });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 describe('apply_team', () => {
@@ -192,16 +205,12 @@ describe('apply_team', () => {
   });
 
   it('honors an explicit continuation when catalog access is available', async () => {
-    setSetupPlatform(
-      createFakeSetupPlatform({
-        auth: {
-          getStatus: async () => ({
-            authenticated: true,
-            remoteAgentCatalogAvailable: true,
-          }),
-        },
-      }),
+    vi.spyOn(SupabaseClient, 'isAuthenticated').mockResolvedValue(true);
+    vi.spyOn(SupabaseClient, 'canAccessRemoteAgentCatalog').mockResolvedValue(
+      true,
     );
+    vi.spyOn(SupabaseClient, 'getUser').mockResolvedValue(null);
+    vi.spyOn(SupabaseClient, 'getUserTier').mockResolvedValue('free');
 
     const result = await new ApplyTeamTool().call({
       teamId: 'starter',
@@ -216,17 +225,13 @@ describe('apply_team', () => {
 
   it('uses the host setup sign-in capability before its forced retry', async () => {
     const signIn = vi.fn(async () => true);
-    setSetupPlatform(
-      createFakeSetupPlatform({
-        auth: {
-          getStatus: async () => ({
-            authenticated: true,
-            remoteAgentCatalogAvailable: false,
-          }),
-          signIn,
-        },
-      }),
+    vi.spyOn(SupabaseClient, 'isAuthenticated').mockResolvedValue(true);
+    vi.spyOn(SupabaseClient, 'canAccessRemoteAgentCatalog').mockResolvedValue(
+      false,
     );
+    vi.spyOn(SupabaseClient, 'getUser').mockResolvedValue(null);
+    vi.spyOn(SupabaseClient, 'getUserTier').mockResolvedValue('free');
+    setSetupPlatform(createFakeSetupPlatform({ signIn }));
 
     const result = await new ApplyTeamTool().call({
       teamId: 'starter',

--- a/src/test-kernel/tools/setup/ConfigTools.vitest.ts
+++ b/src/test-kernel/tools/setup/ConfigTools.vitest.ts
@@ -1,11 +1,9 @@
 // Third-party imports
 import { strict as assert } from 'node:assert';
-import { describe, it } from 'vitest';
+import { afterEach, describe, it, vi } from 'vitest';
 
 import { ReadConfigTool, UpdateConfigTool } from '@tools/setup/ConfigTools';
-import { setSetupPlatform, type SetupPlatform } from '@tools/setup/platform';
-
-import { createFakeSetupPlatform } from './fixtures';
+import { texraScopedConfig } from '@tools/setup/platform';
 
 interface UpdateRecord {
   key: string;
@@ -14,30 +12,28 @@ interface UpdateRecord {
 }
 
 function createPlatform(initial: Record<string, unknown> = {}): {
-  platform: SetupPlatform;
   store: Record<string, unknown>;
   updates: UpdateRecord[];
 } {
   const store: Record<string, unknown> = { ...initial };
   const updates: UpdateRecord[] = [];
-  const platform = createFakeSetupPlatform({
-    config: {
-      get(key) {
-        return store[key];
-      },
-      async update(key, value, target) {
-        updates.push({ key, value, target });
-        store[key] = value;
-      },
+  vi.spyOn(texraScopedConfig, 'get').mockImplementation((key) => store[key]);
+  vi.spyOn(texraScopedConfig, 'update').mockImplementation(
+    async (key, value, target) => {
+      updates.push({ key, value, target });
+      store[key] = value;
     },
-  });
-  return { platform, store, updates };
+  );
+  return { store, updates };
 }
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('ConfigTools — read_config', () => {
   it('reads an existing texra.* key', async () => {
-    const { platform } = createPlatform({ 'texra.bib.zoteroPort': 23119 });
-    setSetupPlatform(platform);
+    createPlatform({ 'texra.bib.zoteroPort': 23119 });
     const tool = new ReadConfigTool();
 
     const result = await tool.call({ key: 'texra.bib.zoteroPort' });
@@ -47,8 +43,7 @@ describe('ConfigTools — read_config', () => {
   });
 
   it('rejects keys not starting with texra.', async () => {
-    const { platform } = createPlatform();
-    setSetupPlatform(platform);
+    createPlatform();
     const tool = new ReadConfigTool();
 
     const result = await tool.call({ key: 'editor.fontSize' });
@@ -59,10 +54,9 @@ describe('ConfigTools — read_config', () => {
 
 describe('ConfigTools — update_config allowlist', () => {
   it('writes an allowlisted key when the value matches its schema', async () => {
-    const { platform, store, updates } = createPlatform({
+    const { store, updates } = createPlatform({
       'texra.bib.zoteroPort': 23119,
     });
-    setSetupPlatform(platform);
     const tool = new UpdateConfigTool();
 
     const result = await tool.call({
@@ -83,8 +77,7 @@ describe('ConfigTools — update_config allowlist', () => {
   });
 
   it('rejects non-allowlisted keys at schema parse time (no write)', async () => {
-    const { platform, updates } = createPlatform();
-    setSetupPlatform(platform);
+    const { updates } = createPlatform();
     const tool = new UpdateConfigTool();
 
     const result = await tool.call({
@@ -98,8 +91,7 @@ describe('ConfigTools — update_config allowlist', () => {
   });
 
   it('rejects type-mismatched values for an allowlisted key', async () => {
-    const { platform, updates } = createPlatform();
-    setSetupPlatform(platform);
+    const { updates } = createPlatform();
     const tool = new UpdateConfigTool();
 
     const result = await tool.call({
@@ -113,8 +105,7 @@ describe('ConfigTools — update_config allowlist', () => {
   });
 
   it('rejects out-of-range numeric values', async () => {
-    const { platform, updates } = createPlatform();
-    setSetupPlatform(platform);
+    const { updates } = createPlatform();
     const tool = new UpdateConfigTool();
 
     // Port range is 1..65535
@@ -131,8 +122,7 @@ describe('ConfigTools — update_config allowlist', () => {
   });
 
   it('honors target=workspace scope', async () => {
-    const { platform, updates } = createPlatform();
-    setSetupPlatform(platform);
+    const { updates } = createPlatform();
     const tool = new UpdateConfigTool();
 
     await tool.call({

--- a/src/test-kernel/tools/setup/CredentialReporting.vitest.ts
+++ b/src/test-kernel/tools/setup/CredentialReporting.vitest.ts
@@ -1,78 +1,84 @@
 // Third-party imports
 import { strict as assert } from 'node:assert';
-import { describe, it } from 'vitest';
+import { afterEach, describe, it, vi } from 'vitest';
 
 // Local imports
 import { ProbeEnvironmentTool } from '@tools/setup/ProbeEnvironmentTool';
 import { VerifySetupTool } from '@tools/setup/VerifySetupTool';
-import {
-  setSetupPlatform,
-  type SetupSecretsAdapter,
-} from '@tools/setup/platform';
+import * as setupPlatformModule from '@tools/setup/platform';
+import { setSetupPlatform, setupSecrets } from '@tools/setup/platform';
 
 // Local file imports
 import { createFakeSetupPlatform } from './fixtures';
 
-function installSetupPlatformWithSecrets(
-  secretsOverrides: Partial<SetupSecretsAdapter>,
-): void {
-  const platform = createFakeSetupPlatform();
-  setSetupPlatform({
-    ...platform,
-    secrets: { ...platform.secrets, ...secretsOverrides },
-  });
+const ORIGINAL_PROVIDERS = setupSecrets.providers;
+
+function installSetupPlatformWithSecrets(options: {
+  providers?: typeof setupSecrets.providers;
+  apiKeyOrigin?: typeof setupSecrets.apiKeyOrigin;
+  anyUsableCredentialExists?: typeof setupSecrets.anyUsableCredentialExists;
+}): void {
+  setSetupPlatform(createFakeSetupPlatform());
+  if (options.providers) {
+    Object.defineProperty(setupSecrets, 'providers', {
+      configurable: true,
+      value: options.providers,
+    });
+  }
+  if (options.apiKeyOrigin) {
+    vi.spyOn(setupSecrets, 'apiKeyOrigin').mockImplementation(
+      options.apiKeyOrigin,
+    );
+  }
+  if (options.anyUsableCredentialExists) {
+    vi.spyOn(setupSecrets, 'anyUsableCredentialExists').mockImplementation(
+      options.anyUsableCredentialExists,
+    );
+  }
 }
 
 function installChatGptOnlySetupPlatform(): void {
-  const platform = createFakeSetupPlatform();
-  setSetupPlatform({
-    ...platform,
-    secrets: {
-      ...platform.secrets,
-      async anyUsableCredentialExists() {
-        return true;
-      },
-    },
-    modelAccess: {
-      async getChatGptSubscriptionStatus() {
-        return {
-          signedIn: true,
-          enabled: true,
-        };
-      },
-    },
-  });
+  setSetupPlatform(createFakeSetupPlatform());
+  vi.spyOn(setupSecrets, 'anyUsableCredentialExists').mockResolvedValue(true);
+  vi.spyOn(
+    setupPlatformModule,
+    'getChatGptSubscriptionStatus',
+  ).mockResolvedValue({ signedIn: true, enabled: true });
 }
 
 async function assertAuthPrecedesCredentialProbe(
   run: () => Promise<unknown>,
 ): Promise<void> {
   const calls: string[] = [];
-  const platform = createFakeSetupPlatform();
-  setSetupPlatform({
-    ...platform,
-    auth: {
-      async getStatus() {
-        calls.push('auth');
-        return {
-          authenticated: false,
-          remoteAgentCatalogAvailable: false,
-        };
-      },
+  setSetupPlatform(createFakeSetupPlatform());
+  vi.spyOn(setupPlatformModule, 'getSetupAuthStatus').mockImplementation(
+    async () => {
+      calls.push('auth');
+      return {
+        authenticated: false,
+        remoteAgentCatalogAvailable: false,
+      };
     },
-    secrets: {
-      ...platform.secrets,
-      async anyUsableCredentialExists() {
-        calls.push('credential');
-        return false;
-      },
+  );
+  vi.spyOn(setupSecrets, 'anyUsableCredentialExists').mockImplementation(
+    async () => {
+      calls.push('credential');
+      return false;
     },
-  });
+  );
 
   await run();
 
   assert.deepEqual(calls, ['auth', 'credential']);
 }
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  Object.defineProperty(setupSecrets, 'providers', {
+    configurable: true,
+    value: ORIGINAL_PROVIDERS,
+  });
+});
 
 describe('setup credential reporting', () => {
   it('reports the active host and provider-key origin without secret values', async () => {

--- a/src/test-kernel/tools/setup/DefaultSetupPlatform.vitest.ts
+++ b/src/test-kernel/tools/setup/DefaultSetupPlatform.vitest.ts
@@ -14,9 +14,12 @@ import * as codexAuth from '@auth/codex';
 import * as codexSubscription from '@model/codexSubscriptionActive';
 import {
   __resetSetupPlatformForTests,
-  createDefaultSetupPlatform,
+  getChatGptSubscriptionStatus,
+  getSetupAuthStatus,
   getSetupPlatform,
   setSetupPlatform,
+  setupSecrets,
+  texraScopedConfig,
 } from '@tools/setup/platform';
 
 setupPlatform({
@@ -36,10 +39,10 @@ afterEach(() => {
 
 beforeEach(() => {
   __resetSetupPlatformForTests();
-  setSetupPlatform(createDefaultSetupPlatform('extension'));
+  setSetupPlatform({ host: 'extension' });
 });
 
-describe('default setup platform', () => {
+describe('shared setup capabilities', () => {
   it('derives credential and configuration operations from platform ports', async () => {
     const setup = getSetupPlatform();
 
@@ -47,24 +50,24 @@ describe('default setup platform', () => {
     expect(setup.commands).toBeUndefined();
     expect(setup.extensions).toBeUndefined();
     expect(setup.terminal).toBeUndefined();
-    await expect(setup.secrets.storedApiKeyExists('openai')).resolves.toBe(
-      true,
-    );
-    await expect(setup.secrets.hasUsableApiKey('openai')).resolves.toBe(true);
-    await expect(setup.secrets.gitHubTokenExists()).resolves.toBe('env');
-    await expect(setup.secrets.listStoredKeys()).resolves.toContain(
+    await expect(setupSecrets.storedApiKeyExists('openai')).resolves.toBe(true);
+    await expect(setupSecrets.hasUsableApiKey('openai')).resolves.toBe(true);
+    await expect(setupSecrets.gitHubTokenExists()).resolves.toBe('env');
+    await expect(setupSecrets.listStoredKeys()).resolves.toContain(
       'apiKey.openai',
     );
 
-    expect(setup.config.get('texra.bib.defaultPath')).toBe('references.bib');
-    await setup.config.update('texra.bib.defaultPath', 'main.bib', 'user');
+    expect(texraScopedConfig.get('texra.bib.defaultPath')).toBe(
+      'references.bib',
+    );
+    await texraScopedConfig.update('texra.bib.defaultPath', 'main.bib', 'user');
     expect(
       platform().config.inspect('texra.bib.defaultPath')?.globalValue,
     ).toBe('main.bib');
   });
 
   it('keeps the configuration boundary at texra.* keys', () => {
-    expect(() => getSetupPlatform().config.get('editor.fontSize')).toThrow(
+    expect(() => texraScopedConfig.get('editor.fontSize')).toThrow(
       'Setup config adapter is scoped to texra.* keys',
     );
   });
@@ -75,9 +78,7 @@ describe('default setup platform', () => {
       'apiKey.openai',
     ]);
 
-    await expect(
-      getSetupPlatform().secrets.storedApiKeyExists('openai'),
-    ).resolves.toBe(true);
+    await expect(setupSecrets.storedApiKeyExists('openai')).resolves.toBe(true);
   });
 
   it('does not report a rejected relay token as authenticated', async () => {
@@ -87,7 +88,7 @@ describe('default setup platform', () => {
       vi.fn().mockResolvedValue(new Response(null, { status: 401 })),
     );
 
-    await expect(getSetupPlatform().auth.getStatus()).resolves.toEqual({
+    await expect(getSetupAuthStatus()).resolves.toEqual({
       authenticated: false,
       remoteAgentCatalogAvailable: false,
     });
@@ -112,7 +113,7 @@ describe('default setup platform', () => {
     } as Awaited<ReturnType<typeof SupabaseClient.getUser>>);
     vi.spyOn(SupabaseClient, 'getUserTier').mockResolvedValue('Max');
 
-    await expect(getSetupPlatform().auth.getStatus()).resolves.toEqual({
+    await expect(getSetupAuthStatus()).resolves.toEqual({
       authenticated: true,
       remoteAgentCatalogAvailable: true,
       email: 'researcher@example.com',
@@ -128,7 +129,7 @@ describe('default setup platform', () => {
     vi.spyOn(SupabaseClient, 'getUser').mockResolvedValue(null);
     vi.spyOn(SupabaseClient, 'getUserTier').mockResolvedValue('Max');
 
-    await expect(getSetupPlatform().auth.getStatus()).resolves.toEqual({
+    await expect(getSetupAuthStatus()).resolves.toEqual({
       authenticated: true,
       remoteAgentCatalogAvailable: false,
       email: undefined,
@@ -137,10 +138,8 @@ describe('default setup platform', () => {
   });
 
   it('keeps API-key-only setup usable without reporting sign-in', async () => {
-    const setup = getSetupPlatform();
-
-    await expect(setup.secrets.anyUsableCredentialExists()).resolves.toBe(true);
-    await expect(setup.auth.getStatus()).resolves.toEqual({
+    await expect(setupSecrets.anyUsableCredentialExists()).resolves.toBe(true);
+    await expect(getSetupAuthStatus()).resolves.toEqual({
       authenticated: false,
       remoteAgentCatalogAvailable: false,
     });
@@ -153,8 +152,7 @@ describe('default setup platform', () => {
       accountId: 'account-private-id',
     });
 
-    const status =
-      await getSetupPlatform().modelAccess.getChatGptSubscriptionStatus();
+    const status = await getChatGptSubscriptionStatus();
 
     expect(status.signedIn).toBe(true);
     expect(status).not.toHaveProperty('account');
@@ -171,8 +169,9 @@ describe('default setup platform', () => {
       false,
     );
 
-    await expect(
-      getSetupPlatform().modelAccess.getChatGptSubscriptionStatus(),
-    ).resolves.toEqual({ signedIn: true, enabled: false });
+    await expect(getChatGptSubscriptionStatus()).resolves.toEqual({
+      signedIn: true,
+      enabled: false,
+    });
   });
 });

--- a/src/test-kernel/tools/setup/ListApiKeysTool.vitest.ts
+++ b/src/test-kernel/tools/setup/ListApiKeysTool.vitest.ts
@@ -2,31 +2,25 @@
 import { strict as assert } from 'node:assert';
 
 // Third-party imports
-import { describe, it } from 'vitest';
+import { afterEach, describe, it, vi } from 'vitest';
 
 // Local imports
 import { apiKeySecretName } from '@model/apiProviders';
 import { GITHUB_TOKEN_STORAGE_KEY } from '@tools/github/githubAuth';
 import { ListApiKeysTool } from '@tools/setup/ListApiKeysTool';
-import { setSetupPlatform } from '@tools/setup/platform';
-
-// Local file imports
-import { createFakeSetupPlatform } from './fixtures';
+import { setupSecrets } from '@tools/setup/platform';
 
 const FAKE_PROVIDERS = ['anthropic', 'openai'] as const;
+const ORIGINAL_PROVIDERS = setupSecrets.providers;
 
 function installPlatform(
   listStoredKeys: () => Promise<readonly string[]>,
 ): void {
-  const base = createFakeSetupPlatform();
-  setSetupPlatform({
-    ...base,
-    secrets: {
-      ...base.secrets,
-      providers: FAKE_PROVIDERS,
-      listStoredKeys,
-    },
+  Object.defineProperty(setupSecrets, 'providers', {
+    configurable: true,
+    value: FAKE_PROVIDERS,
   });
+  vi.spyOn(setupSecrets, 'listStoredKeys').mockImplementation(listStoredKeys);
 }
 
 function installPlatformWithKeys(keys: readonly string[]): void {
@@ -34,6 +28,14 @@ function installPlatformWithKeys(keys: readonly string[]): void {
 }
 
 const tool = new ListApiKeysTool();
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  Object.defineProperty(setupSecrets, 'providers', {
+    configurable: true,
+    value: ORIGINAL_PROVIDERS,
+  });
+});
 
 describe('list_api_keys tool', () => {
   it('reports an empty credential store', async () => {

--- a/src/test-kernel/tools/setup/fixtures.ts
+++ b/src/test-kernel/tools/setup/fixtures.ts
@@ -2,40 +2,16 @@
 import type { SetupPlatform, TerminalRunResult } from '@tools/setup/platform';
 
 /**
- * Build a fully stubbed `SetupPlatform` for tool unit tests, with each
- * adapter overridable. The defaults are the "deny / not present"
- * answers — no API keys configured, no extensions installed, not
- * authenticated, no terminal capture — so a test only needs to override
- * the specific surface it exercises.
+ * Build a fully stubbed host-varying `SetupPlatform` for tool unit tests.
+ * Process-global credential, auth, model-access, and config behavior comes
+ * from the shared platform and is tested through those canonical surfaces.
  */
 export function createFakeSetupPlatform(
   overrides: Partial<SetupPlatform> = {},
 ): SetupPlatform {
   return {
     host: overrides.host ?? 'cli',
-    secrets: {
-      async deleteApiKey() {},
-      async hasUsableApiKey() {
-        return false;
-      },
-      async apiKeyOrigin() {
-        return 'none';
-      },
-      async storedApiKeyExists() {
-        return false;
-      },
-      async anyUsableCredentialExists() {
-        return false;
-      },
-      async gitHubTokenExists() {
-        return 'none';
-      },
-      async listStoredKeys() {
-        return [] as readonly string[];
-      },
-      providers: [],
-      ...overrides.secrets,
-    },
+    signIn: overrides.signIn,
     commands: {
       async invoke() {},
       ...overrides.commands,
@@ -46,28 +22,6 @@ export function createFakeSetupPlatform(
       },
       async install() {},
       ...overrides.extensions,
-    },
-    auth: {
-      async getStatus() {
-        return {
-          authenticated: false,
-          remoteAgentCatalogAvailable: false,
-        };
-      },
-      ...overrides.auth,
-    },
-    modelAccess: {
-      async getChatGptSubscriptionStatus() {
-        return { signedIn: false, enabled: false };
-      },
-      ...overrides.modelAccess,
-    },
-    config: {
-      get() {
-        return undefined;
-      },
-      async update() {},
-      ...overrides.config,
     },
     terminal: {
       async runCommand(): Promise<TerminalRunResult> {

--- a/src/tools/setup/ApplyTeamTool.ts
+++ b/src/tools/setup/ApplyTeamTool.ts
@@ -34,7 +34,7 @@ import {
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 
 import { defineTool } from '../core/define';
-import { getSetupPlatform } from './platform';
+import { getSetupAuthStatus, getSetupPlatform } from './platform';
 
 /**
  * Built from the actual preset list (plus the hidden starter team) so the
@@ -100,7 +100,7 @@ ${describeTeams()}`,
       initial.resolution.unresolvedNames,
     );
     const setupPlatform = getSetupPlatform();
-    const authenticated = await setupPlatform.auth.getStatus();
+    const authenticated = await getSetupAuthStatus();
 
     const preflight = await preflightTeamAvailability({
       initial,
@@ -111,7 +111,7 @@ ${describeTeams()}`,
       providedChoice: input.unavailableAction ?? undefined,
       choose: async () => undefined,
       signIn: async () => {
-        if (setupPlatform.auth.signIn) return setupPlatform.auth.signIn();
+        if (setupPlatform.signIn) return setupPlatform.signIn();
         if (setupPlatform.commands) {
           return (
             (await setupPlatform.commands.invoke(AUTH_COMMANDS.SIGN_IN)) ===
@@ -138,7 +138,7 @@ ${describeTeams()}`,
     if (preflight.status === 'cancelled') {
       const signInAdvice =
         input.unavailableAction === 'sign-in' &&
-        !setupPlatform.auth.signIn &&
+        !setupPlatform.signIn &&
         !setupPlatform.commands
           ? ' Sign-in is unavailable in this host; sign in through the host account UI, then call apply_team again.'
           : '';

--- a/src/tools/setup/ConfigTools.ts
+++ b/src/tools/setup/ConfigTools.ts
@@ -14,7 +14,7 @@ import { z } from 'zod';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 
 import { defineTool } from '../core/define';
-import { getSetupPlatform } from './platform';
+import { texraScopedConfig } from './platform';
 
 /**
  * Per-key value validators for `update_config`. Read access (`read_config`)
@@ -106,7 +106,7 @@ Accepts any key starting with \`texra.\`. Returns the current resolved value (wo
   schema: ReadConfigInputSchema,
 }) {
   protected async execute(input: ReadConfigInput): Promise<ToolResult> {
-    const value = getSetupPlatform().config.get(input.key);
+    const value = texraScopedConfig.get(input.key);
     const json = JSON.stringify(value, null, 2) ?? 'undefined';
     return {
       status: 'executed',
@@ -159,9 +159,8 @@ Anything outside this list must be changed through the host's regular configurat
       );
     }
 
-    const config = getSetupPlatform().config;
-    const previous = config.get(input.key);
-    await config.update(input.key, parsed.data, input.target);
+    const previous = texraScopedConfig.get(input.key);
+    await texraScopedConfig.update(input.key, parsed.data, input.target);
 
     const before = JSON.stringify(previous);
     const after = JSON.stringify(parsed.data);

--- a/src/tools/setup/ListApiKeysTool.ts
+++ b/src/tools/setup/ListApiKeysTool.ts
@@ -9,7 +9,7 @@ import { formatResultCount } from '@utils/text/stringUtils';
 
 // Local file imports
 import { defineTool } from '../core/define';
-import { getSetupPlatform } from './platform';
+import { setupSecrets } from './platform';
 
 const ListApiKeysInputSchema = z
   .strictObject({})
@@ -31,8 +31,7 @@ export class ListApiKeysTool extends defineTool({
   schema: ListApiKeysInputSchema,
 }) {
   protected async execute(_input: ListApiKeysInput): Promise<ToolResult> {
-    const platform = getSetupPlatform();
-    const storedKeys = await platform.secrets.listStoredKeys();
+    const storedKeys = await setupSecrets.listStoredKeys();
 
     if (storedKeys.length === 0) {
       return {
@@ -43,7 +42,7 @@ export class ListApiKeysTool extends defineTool({
       };
     }
 
-    const { providers } = platform.secrets;
+    const { providers } = setupSecrets;
     const knownProviderKeyMap = new Map(
       providers.map((p) => [apiKeySecretName(p), p] as const),
     );

--- a/src/tools/setup/ProbeEnvironmentTool.ts
+++ b/src/tools/setup/ProbeEnvironmentTool.ts
@@ -13,7 +13,12 @@ import { extendEnvPath, safeHomedir } from '@utils/system/platformPaths';
 
 // Local file imports
 import { defineTool } from '../core/define';
-import { getSetupPlatform } from './platform';
+import {
+  getChatGptSubscriptionStatus,
+  getSetupAuthStatus,
+  getSetupPlatform,
+  setupSecrets,
+} from './platform';
 import { CORE_LATEX_TOOLS, IMAGE_TOOLS, locateTool } from './toolProbing';
 
 const ProbeEnvironmentInputSchema = z
@@ -66,7 +71,7 @@ export class ProbeEnvironmentTool extends defineTool({
     const pm = detectPackageManager();
     // Authentication verifies a configured relay token and primes the shared
     // status cache. Credential readiness must read that settled state.
-    const auth = await platform.auth.getStatus().catch(() => ({
+    const auth = await getSetupAuthStatus().catch(() => ({
       authenticated: false as const,
     }));
 
@@ -81,19 +86,19 @@ export class ProbeEnvironmentTool extends defineTool({
       Promise.all(PROBED_CORE_TOOLS.map(checkTool)),
       Promise.all(OPTIONAL_TOOLS.map(checkTool)),
       Promise.all(
-        platform.secrets.providers.map(async (provider) => {
-          const origin = await platform.secrets
+        setupSecrets.providers.map(async (provider) => {
+          const origin = await setupSecrets
             .apiKeyOrigin(provider)
             .catch(() => 'unknown' as const);
           return { provider, origin };
         }),
       ),
-      platform.secrets
+      setupSecrets
         .anyUsableCredentialExists()
         .then((available) => ({ available, status: 'known' as const }))
         .catch(() => ({ available: false, status: 'unknown' as const })),
-      platform.secrets.gitHubTokenExists().catch(() => 'none' as const),
-      platform.modelAccess.getChatGptSubscriptionStatus().catch(() => ({
+      setupSecrets.gitHubTokenExists().catch(() => 'none' as const),
+      getChatGptSubscriptionStatus().catch(() => ({
         signedIn: false,
         enabled: false,
       })),

--- a/src/tools/setup/UnsetApiKeyTool.ts
+++ b/src/tools/setup/UnsetApiKeyTool.ts
@@ -7,7 +7,7 @@ import { type ToolResult } from '@shared/schemas/toolResult';
 
 // Local file imports
 import { defineTool } from '../core/define';
-import { getSetupPlatform } from './platform';
+import { getSetupPlatform, setupSecrets } from './platform';
 import { refreshApiKeyCaches, requireApiProvider } from './apiKeyHelpers';
 
 const UnsetApiKeyInputSchema = z.strictObject({
@@ -30,7 +30,7 @@ export class UnsetApiKeyTool extends defineTool({
     const provider = requireApiProvider(input.provider);
     const envVar = apiKeyEnvName(provider);
 
-    const storedExists = await platform.secrets.storedApiKeyExists(provider);
+    const storedExists = await setupSecrets.storedApiKeyExists(provider);
     if (!storedExists) {
       // If no persisted entry exists but a *usable* (non-blank) key
       // is still reported, it's coming from the `<PROVIDER>_API_KEY`
@@ -38,7 +38,7 @@ export class UnsetApiKeyTool extends defineTool({
       // Use `hasUsableApiKey` (not `apiKeyExists`) so a stale
       // `PROVIDER_API_KEY=""` doesn't falsely claim an env var is
       // supplying credentials.
-      const envExists = await platform.secrets.hasUsableApiKey(provider);
+      const envExists = await setupSecrets.hasUsableApiKey(provider);
       if (envExists) {
         return {
           status: 'executed',
@@ -53,7 +53,7 @@ export class UnsetApiKeyTool extends defineTool({
       };
     }
 
-    await platform.secrets.deleteApiKey(provider);
+    await setupSecrets.deleteApiKey(provider);
     // Mirror the manual removal flow: drop cached model availability and
     // key-origin lookups so models that just lost their credential stop
     // appearing selectable.
@@ -63,7 +63,7 @@ export class UnsetApiKeyTool extends defineTool({
     // tell the user why the key still appears to exist after removal.
     // `hasUsableApiKey` here too, so a blank env var doesn't trip the
     // "env var still active" branch.
-    const stillPresent = await platform.secrets.hasUsableApiKey(provider);
+    const stillPresent = await setupSecrets.hasUsableApiKey(provider);
     if (stillPresent) {
       return {
         status: 'executed',

--- a/src/tools/setup/VerifySetupTool.ts
+++ b/src/tools/setup/VerifySetupTool.ts
@@ -7,7 +7,7 @@ import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 
 // Local file imports
 import { defineTool } from '../core/define';
-import { getSetupPlatform } from './platform';
+import { getSetupAuthStatus, getSetupPlatform, setupSecrets } from './platform';
 import { CORE_LATEX_TOOLS, isToolPresent } from './toolProbing';
 
 const VerifySetupInputSchema = z.strictObject({
@@ -73,7 +73,7 @@ export class VerifySetupTool extends defineTool({
 
     // Authentication verifies a configured relay token and primes the shared
     // status cache. Credential readiness must read that settled state.
-    const auth = await platform.auth.getStatus().catch(() => ({
+    const auth = await getSetupAuthStatus().catch(() => ({
       authenticated: false as const,
     }));
     const [coreResults, hasMagick, hasGm, hasUsableCredential] =
@@ -81,7 +81,7 @@ export class VerifySetupTool extends defineTool({
         Promise.all(CORE_LATEX_TOOLS.map(isToolPresent)),
         isToolPresent('magick'),
         isToolPresent('gm'),
-        platform.secrets.anyUsableCredentialExists(),
+        setupSecrets.anyUsableCredentialExists(),
       ]);
 
     const missingCore: string[] = CORE_LATEX_TOOLS.filter(

--- a/src/tools/setup/index.ts
+++ b/src/tools/setup/index.ts
@@ -29,4 +29,4 @@ export { InstallVscodeExtensionTool } from './InstallVscodeExtensionTool';
 export { ReadConfigTool, UpdateConfigTool } from './ConfigTools';
 export { SendToTerminalTool } from './SendToTerminalTool';
 export { ApplyTeamTool } from './ApplyTeamTool';
-export { createDefaultSetupPlatform, setSetupPlatform } from './platform';
+export { setSetupPlatform } from './platform';

--- a/src/tools/setup/platform.ts
+++ b/src/tools/setup/platform.ts
@@ -2,8 +2,8 @@
  * VS Code-free platform adapter for setup tools.
  *
  * Setup tools live in the `@tools/*` VS Code-free zone. Their common
- * credential and configuration capabilities derive from the shared platform;
- * only VS Code-specific interactions are supplied by the extension host.
+ * credential and configuration capabilities derive directly from the shared
+ * platform; hosts install only the capabilities that actually vary.
  *
  * Keep this interface narrow — add methods only when a setup tool needs them.
  */
@@ -62,46 +62,14 @@ export interface SetupSecretsAdapter {
 }
 
 /** Per-command surface. */
-export interface SetupCommandAdapter {
+interface SetupCommandAdapter {
   invoke(commandId: string, ...args: unknown[]): Promise<unknown>;
 }
 
 /** Extension host surface. */
-export interface SetupExtensionAdapter {
+interface SetupExtensionAdapter {
   isInstalled(extensionId: string): boolean;
   install(extensionId: string): Promise<void>;
-}
-
-/** Auth / Researcher Access surface. */
-export interface SetupAuthAdapter {
-  getStatus(): Promise<{
-    authenticated: boolean;
-    remoteAgentCatalogAvailable: boolean;
-    email?: string;
-    tier?: string;
-  }>;
-  /** Start the host's existing TeXRA account sign-in flow, when available. */
-  signIn?: () => Promise<boolean>;
-}
-
-/** Subscription access reported separately from provider API keys. */
-interface SetupModelAccessAdapter {
-  getChatGptSubscriptionStatus(): Promise<{
-    signedIn: boolean;
-    enabled: boolean;
-  }>;
-}
-
-/** Configuration-value surface. Reads/writes scoped to `texra.*` keys. */
-export interface SetupConfigAdapter {
-  /** Read the effective value of a `texra.*` setting. */
-  get(key: string): unknown;
-  /** Write a `texra.*` setting. `target` selects user vs. workspace scope. */
-  update(
-    key: string,
-    value: unknown,
-    target: 'user' | 'workspace',
-  ): Promise<void>;
 }
 
 /**
@@ -117,25 +85,22 @@ export interface SetupConfigAdapter {
  * same as "user interrupted", since neither path tells us anything
  * actionable.
  */
-export type SetupTerminalAdapter = TerminalRunner;
 export type { TerminalRunResult };
 
 export type SetupHost = 'cli' | 'desktop' | 'extension';
 
-/** Aggregated setup platform. */
+/** Host-varying setup capabilities. */
 export interface SetupPlatform {
   /** Product surface currently running the shared setup agent. */
   host: SetupHost;
-  secrets: SetupSecretsAdapter;
-  auth: SetupAuthAdapter;
-  modelAccess: SetupModelAccessAdapter;
-  config: SetupConfigAdapter;
+  /** Start the host's existing TeXRA account sign-in flow, when available. */
+  signIn?: () => Promise<boolean>;
   /** VS Code-only command invocation. */
   commands?: SetupCommandAdapter;
   /** VS Code extension inspection and installation. */
   extensions?: SetupExtensionAdapter;
   /** VS Code integrated-terminal execution. */
-  terminal?: SetupTerminalAdapter;
+  terminal?: TerminalRunner;
 }
 
 /** Setup tools that require a VS Code-specific adapter. */
@@ -153,7 +118,8 @@ function assertTexraScopedKey(key: string): void {
   }
 }
 
-async function defaultAuthStatus(): Promise<{
+/** Researcher Access status shared by every host. */
+export async function getSetupAuthStatus(): Promise<{
   authenticated: boolean;
   remoteAgentCatalogAvailable: boolean;
   email?: string;
@@ -184,59 +150,61 @@ async function defaultAuthStatus(): Promise<{
   };
 }
 
-/**
- * Derive setup capabilities shared by every host from their existing platform
- * ports. This is the sole owner of the common setup wiring; hosts add only
- * capabilities that cannot exist outside VS Code.
- */
-export function createDefaultSetupPlatform(host: SetupHost): SetupPlatform {
-  const services = currentPlatform();
-  const { secrets, config } = services;
+/** Value-free credential capability exposed to setup tools. */
+export const setupSecrets: SetupSecretsAdapter = {
+  providers: API_PROVIDERS,
+  deleteApiKey: (provider) =>
+    currentPlatform().secrets.delete(apiKeySecretName(provider)),
+  hasUsableApiKey: (provider) =>
+    hasUsableApiKey(currentPlatform().secrets, provider),
+  apiKeyOrigin: (provider) =>
+    lookupApiKeyOrigin(currentPlatform().secrets, provider),
+  storedApiKeyExists: async (provider) =>
+    (await currentPlatform().secrets.listStoredKeys()).includes(
+      apiKeySecretName(provider),
+    ),
+  anyUsableCredentialExists: () =>
+    hasUsableSetupCredential(currentPlatform().secrets),
+  gitHubTokenExists: () => resolveGitHubTokenSource(currentPlatform().secrets),
+  listStoredKeys: () => currentPlatform().secrets.listStoredKeys(),
+};
 
+/** Subscription access reported separately from provider API keys. */
+export async function getChatGptSubscriptionStatus(): Promise<{
+  signedIn: boolean;
+  enabled: boolean;
+}> {
+  const status = await getCodexStatus();
   return {
-    host,
-    secrets: {
-      providers: API_PROVIDERS,
-      deleteApiKey: (provider) => secrets.delete(apiKeySecretName(provider)),
-      hasUsableApiKey: (provider) => hasUsableApiKey(secrets, provider),
-      apiKeyOrigin: (provider) => lookupApiKeyOrigin(secrets, provider),
-      storedApiKeyExists: async (provider) =>
-        (await secrets.listStoredKeys()).includes(apiKeySecretName(provider)),
-      anyUsableCredentialExists: () => hasUsableSetupCredential(secrets),
-      gitHubTokenExists: () => resolveGitHubTokenSource(secrets),
-      listStoredKeys: () => secrets.listStoredKeys(),
-    },
-    auth: { getStatus: defaultAuthStatus },
-    modelAccess: {
-      getChatGptSubscriptionStatus: async () => {
-        const status = await getCodexStatus();
-        return {
-          signedIn: status.signedIn,
-          enabled:
-            status.signedIn &&
-            (await isCodexSubscriptionActive(
-              CHATGPT_SETUP_MODEL,
-              AgentCategory.ToolUse,
-            )),
-        };
-      },
-    },
-    config: {
-      get: (key) => {
-        assertTexraScopedKey(key);
-        return config.get(key);
-      },
-      update: async (key, value, target) => {
-        assertTexraScopedKey(key);
-        await config.update(
-          key,
-          value,
-          target === 'workspace' ? 'workspace' : 'global',
-        );
-      },
-    },
+    signedIn: status.signedIn,
+    enabled:
+      status.signedIn &&
+      (await isCodexSubscriptionActive(
+        CHATGPT_SETUP_MODEL,
+        AgentCategory.ToolUse,
+      )),
   };
 }
+
+/** Configuration operations scoped to `texra.*` keys. */
+export const texraScopedConfig = {
+  get(key: string): unknown {
+    assertTexraScopedKey(key);
+    return currentPlatform().config.get(key);
+  },
+  async update(
+    key: string,
+    value: unknown,
+    target: 'user' | 'workspace',
+  ): Promise<void> {
+    assertTexraScopedKey(key);
+    await currentPlatform().config.update(
+      key,
+      value,
+      target === 'workspace' ? 'workspace' : 'global',
+    );
+  },
+};
 
 let override: SetupPlatform | undefined;
 


### PR DESCRIPTION
## Summary

Shrink the setup-specific service locator to the five capabilities that actually vary by host: `host`, `signIn`, `commands`, `extensions`, and `terminal`.

Common credential, authentication, ChatGPT-access, and scoped-config behavior now has one implementation derived directly from the shared platform. The credential surface remains deliberately value-free: setup tools can delete keys and inspect existence, origin, and stored names, but cannot read secret values.

Closes #8747.

## Issue acceptance gates

- `SetupPlatform` contains only the host-varying quintet.
- Extension, desktop, and CLI install their differing capabilities directly; no host reconstructs common defaults.
- `SetupAuthAdapter`, `SetupModelAccessAdapter`, `SetupConfigAdapter`, and `createDefaultSetupPlatform` cease to exist.
- `SetupSecretsAdapter` remains the capability-attenuation boundary and exposes no secret-value read.
- The five newly fixed dead-type baseline entries are removed from the knip ratchet.

## Single source of truth

`src/tools/setup/platform.ts` now derives shared setup behavior directly from `platform()`: `setupSecrets` owns the value-free credential boundary, `getSetupAuthStatus` owns Researcher Access status, `getChatGptSubscriptionStatus` owns ChatGPT readiness, and `texraScopedConfig` owns the `texra.*` configuration boundary. `SetupPlatform` owns only host variation.

## Duplication and abstraction budget

Deleted the second full service-locator construction and the three identical host default compositions. No module, class, facade, or pass-through layer was added. The four shared exports replace fields that previously wrapped those same implementations inside every installed `SetupPlatform` object.

## Net elements (R6)

- Files: 21 modified, none added or deleted.
- LoC: +272/-434 overall, net -162; production +106/-154, net -48.
- Exported symbols: 4 added and 6 removed, net -2.
- Interfaces/type aliases: 3 interfaces and 1 type alias deleted; 2 adapter interfaces made file-local; none added.
- Factory functions: `createDefaultSetupPlatform` deleted; no factory added.
- Dead-code baseline: 233 -> 228 findings.

## Consumer counts (R8)

- `createDefaultSetupPlatform`: 3 host callers rerouted, 0 remaining.
- Shared auth status: 3 tool consumers.
- Shared ChatGPT status: 1 tool consumer.
- Scoped config: 1 tool module containing both config tools.
- Value-free secrets adapter: 4 setup-tool consumers.
- `SetupCommandAdapter`, `SetupExtensionAdapter`, and `SetupTerminalAdapter`: 0 external type consumers; the first two are now file-local and the trivial terminal alias is deleted.

## Host impact

Extension: installs `host`, sign-in, command, extension, and integrated-terminal capabilities directly; behavior unchanged.

Desktop: installs `host` and its active-window sign-in callback directly; behavior unchanged.

CLI: installs `host` and browser sign-in directly; shared credentials/config/auth continue to use the already initialized CLI platform.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; 1 pre-existing unrelated `replaceAll` warning)
- `npm run check:dead-code-ratchet` (228 current = 228 baseline)
- Targeted setup/host suite: 10 files, 81 tests passed
- `CI=true npm test`: 737 files passed, 1 skipped; 6,797 tests passed, 4 skipped
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches setup credential/auth/config paths used by onboarding and API-key tools, but behavior is intended to be unchanged with broad test coverage; risk is mainly regression in multi-host sign-in and secret handling.
> 
> **Overview**
> **Shrinks `SetupPlatform` to host-specific wiring** (`host`, optional `signIn`, and VS Code-only `commands` / `extensions` / `terminal`). **`createDefaultSetupPlatform` and the nested auth/model/config adapters are removed**; CLI, desktop, and extension call `setSetupPlatform` with small objects instead of spreading defaults.
> 
> **Shared setup behavior is centralized** in `platform.ts` as `setupSecrets`, `getSetupAuthStatus`, `getChatGptSubscriptionStatus`, and `texraScopedConfig`, all wired from `platform()`. Setup tools and probes now import those surfaces instead of `getSetupPlatform().secrets` / `.auth` / `.config`.
> 
> **Tests** mock the shared exports (or `SupabaseClient`) rather than building full fake platforms; the knip baseline drops five unused setup adapter types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8d90442c1d0684098b91126fd602f7ea9f227a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->