### PR TITLE
test(cli): exercise unknown run event projection

### DIFF
--- a/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
+++ b/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
@@ -10,6 +10,7 @@ import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
   SessionEventHub,
   type SessionEvent,
+  type SessionEventSubscriber,
   type SessionFact,
 } from '@agent/runtime/SessionEventHub';
 import type {
@@ -608,13 +609,21 @@ describe('attachCliSessionProgressProjection', () => {
     }
   });
 
-  it('does not project run events outside the shared fact vocabulary', () => {
+  it('returns no record for an unknown event that reaches the run projection callback', () => {
     const events = new SessionEventHub();
     const writeRecord = recordWriter();
+    let runSubscriber: SessionEventSubscriber | undefined;
+    vi.spyOn(events, 'subscribe').mockImplementation(
+      (subscriber, filter = {}) => {
+        if (filter.scope === 'run') runSubscriber = subscriber;
+        return () => {};
+      },
+    );
     const detach = attachCliSessionProgressProjection(events, writeRecord);
 
     try {
-      events.emit({
+      if (!runSubscriber) throw new Error('Run subscriber was not attached');
+      runSubscriber({
         scope: 'run',
         streamId,
         event: {


### PR DESCRIPTION
## Summary

Replace the ineffective unknown-event test with callback-level coverage that actually reaches `projectCliRunFact`'s fall-through and proves it produces no NDJSON record.

The test captures the run-scope subscriber installed by `attachCliSessionProgressProjection` and invokes that real callback directly with a `log` event. Production code and the event vocabulary are unchanged.

Closes #8775.

## Issue acceptance gates

- Directly exercises the projection callback with an out-of-vocabulary `AgentEvent`.
- Proves the callback writes no record.
- Keeps `projectCliRunFact` file-local; no test-only production export is added.
- Preserves the intentionally local TUI and headless event subsets.
- Replaces the old test that stopped at `SessionEventHub`'s type filter before reaching the projection.

## Single source of truth

`projectCliRunFact` remains the file-local owner of the headless CLI run-event projection. The test reaches it through the public attachment boundary and its existing `SessionEventHub.subscribe` dependency.

## Duplication and abstraction budget

No production abstraction, helper, export, or event type was added. The existing ineffective test is replaced rather than retained alongside the corrected coverage.

## Net elements (R6)

- Files: 1 test file modified.
- LoC: +11/-2, net +9 test lines.
- Production constructs and exports: unchanged.
- Test-only named elements: one imported callback type; no helper or fixture added.

## Consumer counts (R8)

n/a — no production export, emit path, or subscriber set is added, deleted, or rerouted.

## Host impact

Extension:

- None.

Desktop:

- None.

CLI:

- Test coverage now pins the existing unknown-event fall-through at the real projection callback. Runtime behavior is unchanged.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run compile:safe`
- `npm run lint` (0 errors; 1 pre-existing unrelated `replaceAll` warning)
- `npm run check:dead-code-ratchet` (228 current = 228 baseline)
- `CI=true npx vitest run src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts`: 11/11 passed
- `CI=true npm test`: 736 files passed, 1 skipped; 6,789 tests passed, 4 skipped
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes in one vitest file; no production code paths modified.
> 
> **Overview**
> Replaces a CLI session progress test that never reached run projection because **`SessionEventHub`** filtered out-of-vocabulary events before subscribers ran.
> 
> The new case **mocks `subscribe`** to capture the run-scope callback installed by **`attachCliSessionProgressProjection`**, then invokes it with a **`log`** **`AgentEvent`** and asserts **`writeRecord`** is not called. That pins the existing fall-through for unknown run events without exporting **`projectCliRunFact`** or changing runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fd4c49dd3978a90ca35ee8dd6c6f8ca66d18e31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->