### PR TITLE
refactor(setup): require sign-in capability

### DIFF
--- a/src/test-kernel/cli/CliInitPlatform.vitest.mts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.mts
@@ -460,7 +460,7 @@ describe('CLI platform init', () => {
     await initCliPlatform(cliContext());
 
     expect(getSetupPlatform().host).toBe('cli');
-    await expect(getSetupPlatform().signIn?.()).resolves.toBe(true);
+    await expect(getSetupPlatform().signIn()).resolves.toBe(true);
     expect(mocks.signInCliSupabase).toHaveBeenCalledOnce();
     expect(mocks.signInCliSupabase).toHaveBeenCalledWith({ openBrowser: true });
   });

--- a/src/test-kernel/desktop/DesktopSetupAuth.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSetupAuth.vitest.mts
@@ -13,7 +13,7 @@ describe('desktop setup auth adapter', () => {
     registerDesktopSetupSignIn(signIn);
 
     expect(getSetupPlatform().host).toBe('desktop');
-    await expect(getSetupPlatform().signIn?.()).resolves.toBe(true);
+    await expect(getSetupPlatform().signIn()).resolves.toBe(true);
     expect(signIn).toHaveBeenCalledOnce();
   });
 
@@ -24,7 +24,7 @@ describe('desktop setup auth adapter', () => {
 
     windowRegistration.dispose();
 
-    await expect(getSetupPlatform().signIn?.()).resolves.toBe(false);
+    await expect(getSetupPlatform().signIn()).resolves.toBe(false);
     expect(signIn).not.toHaveBeenCalled();
   });
 });

--- a/src/test-kernel/model/ApiProviders.vitest.ts
+++ b/src/test-kernel/model/ApiProviders.vitest.ts
@@ -79,6 +79,7 @@ function setupApiKeyToolPlatform(
   );
   setSetupPlatform({
     host: 'cli',
+    signIn: async () => false,
     commands: {
       async invoke() {},
     },

--- a/src/test-kernel/tools/setup/DefaultSetupPlatform.vitest.ts
+++ b/src/test-kernel/tools/setup/DefaultSetupPlatform.vitest.ts
@@ -39,7 +39,7 @@ afterEach(() => {
 
 beforeEach(() => {
   __resetSetupPlatformForTests();
-  setSetupPlatform({ host: 'extension' });
+  setSetupPlatform({ host: 'extension', signIn: async () => false });
 });
 
 describe('shared setup capabilities', () => {

--- a/src/test-kernel/tools/setup/fixtures.ts
+++ b/src/test-kernel/tools/setup/fixtures.ts
@@ -11,7 +11,7 @@ export function createFakeSetupPlatform(
 ): SetupPlatform {
   return {
     host: overrides.host ?? 'cli',
-    signIn: overrides.signIn,
+    signIn: overrides.signIn ?? (async () => false),
     commands: {
       async invoke() {},
       ...overrides.commands,

--- a/src/tools/setup/ApplyTeamTool.ts
+++ b/src/tools/setup/ApplyTeamTool.ts
@@ -19,7 +19,6 @@ import {
   getAgentsByCategory,
   refresh,
 } from '@agent/index/agentRegistry';
-import { AUTH_COMMANDS } from '@auth/constants';
 import { preflightTeamAvailability } from '@common/teams/TeamAvailabilityPreflight';
 import {
   resolveTeamRoster,
@@ -99,7 +98,7 @@ ${describeTeams()}`,
       preset,
       initial.resolution.unresolvedNames,
     );
-    const setupPlatform = getSetupPlatform();
+    const { signIn } = getSetupPlatform();
     const authenticated = await getSetupAuthStatus();
 
     const preflight = await preflightTeamAvailability({
@@ -110,16 +109,7 @@ ${describeTeams()}`,
         authenticated.remoteAgentCatalogAvailable,
       providedChoice: input.unavailableAction ?? undefined,
       choose: async () => undefined,
-      signIn: async () => {
-        if (setupPlatform.signIn) return setupPlatform.signIn();
-        if (setupPlatform.commands) {
-          return (
-            (await setupPlatform.commands.invoke(AUTH_COMMANDS.SIGN_IN)) ===
-            true
-          );
-        }
-        return false;
-      },
+      signIn,
       refresh: async () => {
         await refresh({ includeRemote: true });
         return { preset, resolution: resolveTeamRoster(state, preset) };
@@ -136,16 +126,10 @@ ${describeTeams()}`,
     }
 
     if (preflight.status === 'cancelled') {
-      const signInAdvice =
-        input.unavailableAction === 'sign-in' &&
-        !setupPlatform.signIn &&
-        !setupPlatform.commands
-          ? ' Sign-in is unavailable in this host; sign in through the host account UI, then call apply_team again.'
-          : '';
       return {
         status: 'executed',
         summary: `Cancelled ${preset.name} team application.`,
-        output: `Cancelled. No roster or default-team state was written.${signInAdvice}`,
+        output: 'Cancelled. No roster or default-team state was written.',
       };
     }
     if (preflight.status === 'unavailable') {

--- a/src/tools/setup/platform.ts
+++ b/src/tools/setup/platform.ts
@@ -93,8 +93,8 @@ export type SetupHost = 'cli' | 'desktop' | 'extension';
 export interface SetupPlatform {
   /** Product surface currently running the shared setup agent. */
   host: SetupHost;
-  /** Start the host's existing TeXRA account sign-in flow, when available. */
-  signIn?: () => Promise<boolean>;
+  /** Start the host's existing TeXRA account sign-in flow. */
+  signIn: () => Promise<boolean>;
   /** VS Code-only command invocation. */
   commands?: SetupCommandAdapter;
   /** VS Code extension inspection and installation. */


### PR DESCRIPTION
## Summary

Make the setup-platform sign-in capability a required construction-time invariant. `apply_team` now calls the installed host capability directly, and all test platform constructions provide an explicit sign-in function.

This removes the unreachable extension-command fallback and the corresponding unavailable-host advice while preserving the optional VS Code-only command, extension, and terminal capabilities. `SetupSecretsAdapter` remains value-free and unchanged.

Closes #8777.

## Scope and behavior

- `SetupPlatform.signIn` changes from optional to required.
- Extension, desktop, and CLI already install sign-in and require no production host-wiring changes.
- `apply_team` uses the required capability directly; its successful, cancelled, and failed sign-in behavior is unchanged for every installed host.
- Test fixtures and direct constructions install explicit false-returning sign-in functions when the test does not exercise authentication.
- Optional calls in the CLI and desktop host tests are removed.
- No common adapter, factory, facade, or secret-value read is added.

## Net elements (R6)

- Files: 7 modified; none added or deleted.
- LoC: +11/-26 overall, net -15; production +5/-21, net -16; tests +6/-5, net +1.
- Exported symbols: none added or deleted.
- Interfaces/type aliases: no type is added or deleted; one existing interface property becomes required.
- Branches: the optional sign-in check, command fallback, false fallback, and unavailable-host advice branch cease to exist.
- Dead-code baseline: unchanged at 228 findings.

## Consumer counts (R8)

- Production host installers: 3 (`extension`, `desktop`, `cli`), all already provide `signIn`.
- Production setup consumer: 1 (`ApplyTeamTool`), now a direct required-capability call.
- Direct test constructions: 2, both explicit.
- Shared test fixture: 1, with an explicit false-returning default.
- Remaining optional `SetupPlatform.signIn` declarations or calls across `.ts`, `.tsx`, `.mts`, and `.cts`: 0.

## Code-simplifier pass

The pass narrowed `ApplyTeamTool` from retaining the full setup-platform object to retaining only its `signIn` capability. No further extraction or indirection was warranted.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint` (0 errors; 1 unrelated existing `replaceAll` warning)
- `npm run check:dead-code-ratchet` (228 current = 228 baseline)
- `npm run compile:fast`
- Focused setup/host Vitest run: 8 files, 62 tests passed
- Post-simplifier `ApplyTeamTool` Vitest run: 1 file, 9 tests passed
- Consumer greps over `.ts`, `.tsx`, `.mts`, and `.cts`
- `git diff --check`

## Scheduled refactoring

None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small setup-platform contract tightening with no production host wiring changes; behavior change is limited to removing dead fallback paths and cancel copy.
> 
> **Overview**
> **`SetupPlatform.signIn` is now required** at the type level, so every host and test stub must supply a sign-in function instead of leaving it optional.
> 
> **`apply_team`** passes that capability straight into team availability preflight: the `AUTH_COMMANDS` invoke fallback, inline optional checks, and the extra “sign-in unavailable in this host” message on cancel are removed. Successful sign-in, continue, and cancel behavior for CLI, desktop, and extension stays the same because those hosts already wired `signIn`.
> 
> **Tests and fixtures** call `signIn()` without optional chaining and default stub platforms to `async () => false` where auth is not under test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33d19f18f4dca5c01cf173f6de8bbaa40302d6a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->