### PR TITLE
refactor(flows): remove duplicate run dependencies

### DIFF
--- a/src/agent/core/README.md
+++ b/src/agent/core/README.md
@@ -26,19 +26,16 @@ flows ──▶ state ──▶ definition
 depend on neither. Don't introduce imports that point back outward (e.g.
 `definition` importing from `state`).
 
-This diagram covers dependencies _within_ `core`. Two `flows/` files also take
-narrow, accepted dependencies on host-agnostic collaborators outside `core`
-that aren't otherwise abstracted: `BaseFlowServices.ts` and `RetryState.ts`
-take `type`-only imports of `AgentRuntimeHost`/`StreamStatusMachine` from
-`@agent/runtime` (the shared service-injection contract every flow node
-receives; `CycleServices.ts` only inherits these transitively through
-`BaseFlowContextInit`, not via its own import), and `RetryState.ts`
-additionally calls `@auth/SupabaseClient` directly for relay-401 token
-refresh — the same pattern `@agent/modelHandlers` already uses, not a
-`core`-specific exception. None of this pulls in `vscode` or `packages/*`;
-it's still host-agnostic, just not self-contained within `core`'s own module
-boundaries. Don't read the diagram above as "flow files never import outside
-`core`."
+This diagram covers dependencies _within_ `core`. Flow files may still call a
+canonical host-agnostic collaborator outside `core` directly instead of
+injecting a second reference to the same run-owned service. For example,
+`RetryState.ts` reads the current session through `@agent/runtime/RunContext`,
+`ResponseCycleFlow.ts` calls `@agent/runtime/textConnection`, and
+`RetryState.ts` calls `@auth/SupabaseClient` for relay-401 token refresh. This
+is the same pattern `@agent/modelHandlers` already uses, not a `core`-specific
+exception. None of this pulls in `vscode` or `packages/*`; it's still
+host-agnostic, just not self-contained within `core`'s own module boundaries.
+Don't read the diagram above as "flow files never import outside `core`."
 
 Files kept at the `core/` root are limited infrastructure helpers or shared
 constants, not domain types:

--- a/src/agent/core/flows/BaseFlowServices.ts
+++ b/src/agent/core/flows/BaseFlowServices.ts
@@ -9,7 +9,6 @@ import type {
 } from '@agent/core/definition/AgentDataclass';
 import type { UserVariableChannels } from '@agent/core/definition/AgentCycleOptions';
 import type { AgentRunStateSnapshot } from '@agent/core/state/AgentState';
-import type { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 
 /** Callback invoked when a round/cycle completes for usage tracking. */
 export type RoundFinalizedCallback = (
@@ -28,9 +27,8 @@ export interface AgentCore<C = unknown> {
 }
 
 export interface BaseFlowContextInit<C = unknown> extends AgentCore<C> {
-  streamStatus: StreamStatusMachine;
   checkInterruption: () => boolean;
   setAbortController: (ctrl: AbortController | null) => void;
   onInterrupt?: () => void;
-  onRoundFinalized?: RoundFinalizedCallback;
+  onRoundFinalized: RoundFinalizedCallback;
 }

--- a/src/agent/core/flows/CycleServices.ts
+++ b/src/agent/core/flows/CycleServices.ts
@@ -75,14 +75,6 @@ export interface ResponseCycleServices<
   C = unknown,
 > extends CycleRunServices<C> {
   round: ConversationRoundStateSnapshot;
-  /**
-   * Determines the best textual connector between two strings in a LaTeX
-   * document context (empty string, space, or newline).
-   */
-  readonly bestConnectionMethod: (
-    str1: string,
-    str2: string,
-  ) => Promise<{ connector: string; choice: string }>;
 }
 
 /**

--- a/src/agent/core/flows/ModelInvocationNode.ts
+++ b/src/agent/core/flows/ModelInvocationNode.ts
@@ -46,8 +46,8 @@ export interface ModelInvocationConfig<TShared, TServices> {
 /**
  * Only the services this node and its `RetryableInvocationNode` base class
  * actually read: the model handler, logger, setting (temperature/tools),
- * config (for `saveCycleDebug`'s log context), and the retry machinery's
- * `streamStatus`/`setAbortController`, plus the live model client. Picking
+ * config (for `saveCycleDebug`'s log context), the retry machinery's abort
+ * controller setter, plus the live model client. Picking
  * from `AgentCore`/`BaseFlowContextInit` instead of requiring the literal
  * type keeps every existing caller, which passes the full services bag,
  * satisfying this narrower shape structurally.
@@ -56,7 +56,7 @@ type InvocationServices = Pick<
   AgentCore,
   'modelHandler' | 'logger' | 'setting' | 'config'
 > &
-  Pick<BaseFlowContextInit, 'setAbortController' | 'streamStatus'> & {
+  Pick<BaseFlowContextInit, 'setAbortController'> & {
     readonly client: unknown;
     readonly refreshClient?: () => Promise<void>;
   };

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -21,6 +21,7 @@ import {
 import type { ProviderUsage } from '@agent/core/usage/ResponseUsage';
 import { K_SLICE } from '@agent/core/constants';
 import { useLaunchRunContext } from '@agent/runtime/RunContext';
+import { bestConnectionMethod } from '@agent/runtime/textConnection';
 import type { ToolDefinition } from '@model';
 import { MESSAGE_TYPES, AgentFileLocationSchema } from '@shared/schemas';
 import { OUTPUT_END_TAG } from '@shared/constants/outputProtocol';
@@ -315,7 +316,7 @@ class ResponseProcessNode<C> extends BaseNode<
       // Re-applying would run non-idempotent custom replacements twice.
       const processedResponse = newResponse;
 
-      const connector = await this.services.bestConnectionMethod(
+      const connector = await bestConnectionMethod(
         prepRes.lastResponse.slice(-K_SLICE),
         processedResponse.slice(0, K_SLICE),
       );
@@ -450,7 +451,7 @@ class ResponseCycleFinalizeNode<C> extends BaseNode<
     // throwing *after* recordRound has already mutated run state — otherwise
     // that catch would re-record the round and double-count usage/response time.
     try {
-      await onRoundFinalized?.(run);
+      await onRoundFinalized(run);
     } catch (error) {
       logger.warn(
         `Round finalization callback failed: ${toErrorMessage(error)}`,

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -7,7 +7,6 @@ import { Node } from '@agent/node';
 import { logErrorData, logProgressStatus, type AgentTrace } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { useLaunchRunContext } from '@agent/runtime/RunContext';
-import type { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { normalizeProviderError } from '@common/errors';
 import {
@@ -57,7 +56,6 @@ export type InvocationResult<TSuccess> =
 
 interface RetryableNodeServices {
   config: Pick<AgentConfig, 'model'>;
-  streamStatus: StreamStatusMachine;
   logger: AgentTrace;
   setAbortController: (ac: AbortController | null) => void;
   refreshClient?: () => Promise<void>;
@@ -271,9 +269,10 @@ export abstract class RetryableInvocationNode<
   protected async handleManualRetryPrompt(
     error: Error,
   ): Promise<ManualRetryPromptResult> {
-    const { logger, streamStatus } = this.services;
+    const { logger } = this.services;
     const { runScope } = useLaunchRunContext();
     const { session, streamId } = runScope;
+    const streamStatus = session.status;
     const operationName = this.getOperationName();
     const formatted = normalizeProviderError(error);
 

--- a/src/agent/core/flows/toolUseRound/ToolUseProcessNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseProcessNode.ts
@@ -195,7 +195,7 @@ export class ToolUseProcessNode<C> extends BaseNode<
       shared.roundResponseTimeMs,
       shared.roundNormalizedUsage ?? null,
     );
-    await onRoundFinalized?.(run);
+    await onRoundFinalized(run);
     run.totalRounds += 1;
 
     shared.stopReason = execRes.stopReason;

--- a/src/agent/implementations/flows/reflection/ReflectionServices.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionServices.ts
@@ -1,9 +1,6 @@
 import type { PromptBuilder } from '@agent/prompt';
 import type { AgentWorkflowSetting } from '@agent/core/definition/AgentDataclass';
-import type {
-  BaseFlowContextInit,
-  RoundFinalizedCallback,
-} from '@agent/core/flows/BaseFlowServices';
+import type { BaseFlowContextInit } from '@agent/core/flows/BaseFlowServices';
 import type { OutputState } from '@agent/output/outputState';
 import type { LatexDiffManager } from '@agent/output/LatexDiffManager';
 import type { XmlOutputManager } from '@agent/output/XmlOutputManager';
@@ -31,5 +28,4 @@ export interface ReflectionServices<
   ) => AgentFileLocation | Promise<AgentFileLocation>;
   readonly workflowOutputPolicy: WorkflowOutputPolicy;
   readonly baseFiles: FileLocation[];
-  readonly onRoundFinalized: RoundFinalizedCallback;
 }

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
@@ -11,7 +11,6 @@ import type {
   AgentRunStateSnapshot,
   ConversationRoundStateSnapshot,
 } from '@agent/core/state/AgentState';
-import { bestConnectionMethod } from '@agent/runtime/textConnection';
 import { buildFailedRetryInfo } from '@common/errors';
 import type { AgentFileLocation, RetryErrorInfo } from '@shared/schemas';
 import { getDefaultToolRegistry } from '@tools/registry';
@@ -107,7 +106,6 @@ export class ResponseCycleNode<C = unknown> extends Node<
         await withModelClient(
           {
             ...this.services,
-            bestConnectionMethod,
             toolRegistry: getDefaultToolRegistry(),
             round: prepRes.round,
             run: prepRes.run,

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -99,7 +99,7 @@ export async function runReflectionFlow<C = unknown>(
     parentStage,
     userVarChannels,
     checkInterruption,
-    onRoundFinalized = async () => {},
+    onRoundFinalized,
   } = input;
   const { runScope } = useLaunchRunContext();
   const { runtimeHost, streamId, executionId, session: runSession } = runScope;

--- a/src/agent/implementations/flows/tooluse/ToolUseServices.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseServices.ts
@@ -1,12 +1,8 @@
 import type { AgentToolUseSetting } from '@agent/core/definition/AgentDataclass';
-import type {
-  BaseFlowContextInit,
-  RoundFinalizedCallback,
-} from '@agent/core/flows/BaseFlowServices';
+import type { BaseFlowContextInit } from '@agent/core/flows/BaseFlowServices';
 import type { IToolRegistry } from '@agent/core/tools/ToolTypes';
 import type { AttachedMemoryMiss } from '@agent/types/AttachedMemory';
 import type { IToolUseSession } from '@agent/core/flows/IToolUseSession';
-import type { ToolDefinition } from '@model';
 import type { SubagentProgressUpdate, TodoItem } from '@shared/schemas';
 import type { TaskRunFileService } from '@utils/files';
 import type { ToolUseSessionSnapshot } from './ToolUseSessionTypes';
@@ -16,10 +12,8 @@ export interface ToolUseServices<C = unknown> extends BaseFlowContextInit<C> {
   readonly session: IToolUseSession;
   /** Run-storage-aware file locator; used to attach follow-up media files. */
   readonly fileService: TaskRunFileService;
-  readonly resolvedTools: ToolDefinition[];
   readonly toolRegistry: IToolRegistry;
   readonly snapshot: ToolUseSessionSnapshot | null;
-  readonly onRoundFinalized: RoundFinalizedCallback;
   readonly onFollowUpConsumed?: () => void;
   readonly attachedMemoryMisses?: readonly AttachedMemoryMiss[];
   readonly onProgress?: (update: SubagentProgressUpdate) => void;

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -60,7 +60,7 @@ export class ToolUseCycleNode<C> extends Node<
   }
 
   async exec(prepRes: CyclePrepResult): Promise<ToolUseCycleOutcome> {
-    const { setting, resolvedTools, modelHandler } = this.services;
+    const { modelHandler } = this.services;
     const { runScope } = useLaunchRunContext();
     const { streamId } = runScope;
 
@@ -93,7 +93,6 @@ export class ToolUseCycleNode<C> extends Node<
       await withModelClient(
         {
           ...this.services,
-          setting: { ...setting, tools: resolvedTools },
           run: prepRes.runState,
           workspace: prepRes.workspaceState,
         },

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
@@ -29,9 +29,9 @@ export class ToolUsePrepareNode<C> extends Node<
   async exec(
     _prepRes: void,
   ): Promise<{ kind: 'success'; result: CyclePrepResult }> {
-    const { userVarChannels, logger, snapshot, config, fileService } =
+    const { userVarChannels, logger, snapshot, config, fileService, setting } =
       this.services;
-    const resolvedToolNames = this.services.resolvedTools.map((t) => t.name);
+    const resolvedToolNames = setting.tools.map((tool) => tool.name);
     const hasDelegationTools = hasDelegationTool(resolvedToolNames);
     const promptOptions = {
       resolvedToolNames,

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -57,10 +57,9 @@ export class ToolUseWaitNode<C> extends Node<
   }
 
   async exec(prepRes: WaitPrepResult): Promise<WaitExecResult> {
-    const { checkInterruption, session, streamStatus, isSubagent } =
-      this.services;
+    const { checkInterruption, session, isSubagent } = this.services;
     const { runScope, stopAfterCycle } = useLaunchRunContext();
-    const { streamId, runtimeHost } = runScope;
+    const { streamId, runtimeHost, session: ownerSession } = runScope;
 
     if (checkInterruption()) {
       return { kind: 'stop' };
@@ -120,7 +119,7 @@ export class ToolUseWaitNode<C> extends Node<
     // delivers after suspension, then owns the next queue wait. This keeps
     // every ordinary suspension symmetric and leaves one delivery site.
     if (isSubagent === true) {
-      streamStatus.transitionToWaiting(streamId, 'wait', {
+      ownerSession.status.transitionToWaiting(streamId, 'wait', {
         trace: this.services.logger,
       });
       return { kind: 'waiting' };
@@ -143,7 +142,7 @@ export class ToolUseWaitNode<C> extends Node<
     }
 
     if (!session.hasQueuedFollowUp()) {
-      streamStatus.transitionToWaiting(streamId, 'wait', {
+      ownerSession.status.transitionToWaiting(streamId, 'wait', {
         trace: this.services.logger,
       });
     }
@@ -173,9 +172,9 @@ export class ToolUseWaitNode<C> extends Node<
     prepRes: WaitPrepResult,
     execRes: WaitExecResult,
   ): Promise<string | undefined> {
-    const { onFollowUpConsumed, logger, streamStatus } = this.services;
+    const { onFollowUpConsumed, logger } = this.services;
     const { runScope } = useLaunchRunContext();
-    const { streamId } = runScope;
+    const { streamId, session } = runScope;
 
     if (execRes.kind === 'waiting') {
       return FlowTransition.WAITING;
@@ -192,7 +191,7 @@ export class ToolUseWaitNode<C> extends Node<
     shared.lastError = undefined;
     shared.userCancelledRetry = undefined;
 
-    streamStatus.transition(streamId, STREAM_PHASE.RUNNING, 'resume', {
+    session.status.transition(streamId, STREAM_PHASE.RUNNING, 'resume', {
       trace: logger,
     });
 

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -222,11 +222,10 @@ export async function runToolUseFlow<C = unknown>(
 
   const services: ToolUseServices<C> = {
     ...input,
+    setting: { ...setting, tools: resolvedTools },
     session: sessionLifecycle,
-    resolvedTools,
     toolRegistry: registry,
     snapshot: input.resumeSnapshot ?? null,
-    onRoundFinalized: input.onRoundFinalized ?? (async () => {}),
     persistTodos: (todos) => kv.writeTodos(todos),
     fileService: new TaskRunFileService(executionId),
   };

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -153,17 +153,12 @@ async function runToolUseAgent(
     'isSubagent' | 'onFollowUpConsumed' | 'onProgress' | 'onIdle'
   >,
 ): Promise<AgentRuntimeFlowResult> {
-  const {
-    streamId: runStreamId,
-    executionId: runExecutionId,
-    session: runSession,
-  } = ctx.runScope;
+  const { streamId: runStreamId, executionId: runExecutionId } = ctx.runScope;
   const onRoundFinalized = createUsageRecordingCallback(ctx);
   try {
     const result = await runToolUseFlow(
       {
         ...ctx,
-        streamStatus: runSession.status,
         ...createInterruptCallbacks(),
         onRoundFinalized,
         setting,
@@ -250,7 +245,6 @@ async function runReflectionAgent(
   try {
     result = await runReflectionFlow({
       ...ctx,
-      streamStatus: runSession.status,
       ...interruptCallbacks,
       onRoundFinalized,
       setting,
@@ -556,7 +550,6 @@ export async function resumeToolUseFromSnapshot(
             const result = await runToolUseFlow(
               {
                 ...ctx,
-                streamStatus: runSession.status,
                 ...createInterruptCallbacks(),
                 onRoundFinalized: createUsageRecordingCallback(ctx),
                 setting,

--- a/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
+++ b/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
@@ -102,9 +102,9 @@ async function runPersistedReflectionFlow(
           transient: {},
         },
         modelHandler: createModelHandler(),
-        streamStatus: session.status,
         checkInterruption: () => true,
         setAbortController: () => {},
+        onRoundFinalized: () => {},
       }),
     );
   } finally {

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -171,12 +171,12 @@ async function runPersistedFlow(
           logger: noopTrace,
           userVarChannels,
           modelHandler: createTaggedModelHandler(ACTIVE_COMPATIBILITY_KEY),
-          streamStatus: session.status,
           checkInterruption: () => interrupted,
           onInterrupt: () => {
             interrupted = true;
           },
           setAbortController: () => {},
+          onRoundFinalized: () => {},
           ...(snapshot !== undefined && { resumeSnapshot: snapshot }),
           isSubagent: options.isSubagent ?? true,
           onIdle: options.onIdle,

--- a/src/test-kernel/agent/ToolUseDispatchParallel.vitest.ts
+++ b/src/test-kernel/agent/ToolUseDispatchParallel.vitest.ts
@@ -84,6 +84,7 @@ function dispatchHarness(opts: HarnessOptions) {
     logger: runTrace.trace,
     toolRegistry: new MapToolRegistry(opts.tools),
     checkInterruption: opts.checkInterruption ?? (() => false),
+    onRoundFinalized: () => {},
     setAbortController: opts.setAbortController ?? (() => {}),
     run: AgentRunStateSnapshotSchema.parse({}),
     workspace: AgentWorkspaceState.create(),

--- a/src/test-kernel/agent/followUp/ToolUseDispatchInterruption.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseDispatchInterruption.vitest.ts
@@ -13,7 +13,6 @@ import {
 import { MapToolRegistry } from '@agent/core/tools/ToolTypes';
 import type { ProviderMessage } from '@agent/types/ProviderMessage';
 import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import { withTestRunContext } from '../progressTestUtils';
 
 /**
@@ -135,6 +134,7 @@ describe('ToolUseDispatchNode interruption', () => {
       },
       prompt: { systemPrompt: '', userPrefix: '', userRequest: '' },
       run: AgentRunStateSnapshotSchema.parse({}),
+      onRoundFinalized: () => {},
       session: {
         hasQueuedFollowUp: () => false,
       },
@@ -143,7 +143,6 @@ describe('ToolUseDispatchNode interruption', () => {
         temperature: 0,
         tools: [{ name: 'toolA' }, { name: 'toolB' }],
       },
-      streamStatus: new StreamStatusMachine(),
       toolRegistry: new MapToolRegistry({
         toolA: { call: toolACall, definition: { name: 'toolA' } } as never,
         toolB: { call: toolBCall, definition: { name: 'toolB' } } as never,
@@ -308,6 +307,7 @@ describe('ToolUseDispatchNode interruption', () => {
       },
       prompt: { systemPrompt: '', userPrefix: '', userRequest: '' },
       run: AgentRunStateSnapshotSchema.parse({}),
+      onRoundFinalized: () => {},
       session: {
         hasQueuedFollowUp: () => false,
       },
@@ -316,7 +316,6 @@ describe('ToolUseDispatchNode interruption', () => {
         temperature: 0,
         tools: [{ name: 'toolA' }, { name: 'toolB' }],
       },
-      streamStatus: new StreamStatusMachine(),
       toolRegistry: new MapToolRegistry({
         toolA: { call: toolACall, definition: { name: 'toolA' } } as never,
         toolB: { call: toolBCall, definition: { name: 'toolB' } } as never,

--- a/src/test-kernel/agent/followUp/ToolUsePrepareNodeTranscriptLog.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUsePrepareNodeTranscriptLog.vitest.ts
@@ -29,11 +29,9 @@ function buildServices(
       systemPrompt: 'You are careful.',
       userRequest: 'Do the thing.',
     }),
-    resolvedTools: [],
     session: {} as never,
-    setting: { agentCategory: 'toolUse' } as never,
+    setting: { agentCategory: 'toolUse', tools: [] } as never,
     snapshot: null,
-    streamStatus: {} as never,
     toolRegistry: {} as never,
     userVarChannels: { input: {}, transient: {} },
     checkInterruption: () => false,
@@ -121,7 +119,7 @@ describe('ToolUsePrepareNode resume (prompt-cache preservation)', () => {
     const snapshot = buildSnapshot();
     const services = buildServices({ snapshot });
     const node = new ToolUsePrepareNode().setServices(services);
-    const resolvedToolNames = services.resolvedTools.map((tool) => tool.name);
+    const resolvedToolNames = services.setting.tools.map((tool) => tool.name);
     const rebuiltPrompts = await buildInitialToolUsePrompts(
       services.prompt,
       services.userVarChannels.transient,

--- a/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
@@ -100,9 +100,9 @@ describe('tool-use progress events', () => {
       runtimeHost: host,
       logger,
       modelHandler: { getClient: vi.fn() },
+      onRoundFinalized: vi.fn(),
       config: { model: 'test-model', agent: 'test-agent' },
       setting: { tools: [] },
-      resolvedTools: [],
     } as unknown as ToolUseServices);
 
     try {
@@ -200,9 +200,9 @@ describe('tool-use round outcome persistence (#8023)', () => {
         runtimeHost: host,
         logger,
         modelHandler: { getClient: vi.fn() },
+        onRoundFinalized: vi.fn(),
         config: { model: 'test-model', agent: 'test-agent' },
         setting: { tools: [] },
-        resolvedTools: [],
       } as unknown as ToolUseServices);
 
       try {

--- a/src/test-kernel/agent/followUp/ToolUseRoundFollowUpMedia.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseRoundFollowUpMedia.vitest.ts
@@ -13,7 +13,6 @@ import {
 import { MapToolRegistry } from '@agent/core/tools/ToolTypes';
 import type { ProviderMessage } from '@agent/types/ProviderMessage';
 import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import { withTestRunContext } from '../progressTestUtils';
 
 /**
@@ -30,10 +29,10 @@ function baseRoundServices(traceLabel: string) {
       createLocation: (filePath: string) => ({ absolutePath: filePath }),
     },
     logger: createRunTrace(traceLabel, StreamLogStore.ephemeral('test')).trace,
+    onRoundFinalized: () => {},
     prompt: { systemPrompt: '', userPrefix: '', userRequest: '' },
     run: AgentRunStateSnapshotSchema.parse({}),
     setAbortController: () => {},
-    streamStatus: new StreamStatusMachine(),
     userVarChannels: { input: {}, transient: {} },
     workspace: AgentWorkspaceState.create(),
   };

--- a/src/test-kernel/agent/followUp/ToolUseRoundPrepNodeFollowUpTranscriptLog.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseRoundPrepNodeFollowUpTranscriptLog.vitest.ts
@@ -14,6 +14,7 @@ function buildServices(
     checkInterruption: () => false,
     config: { model: 'deepseekT', agent: 'chat' } as never,
     logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    onRoundFinalized: () => {},
     modelHandler: {
       createUserFollowUpMessages: vi.fn(async (messages) => messages),
       addMediaToUserMessage: vi.fn(async () => []),

--- a/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
@@ -22,7 +22,6 @@ import {
 } from '@agent/implementations/flows/tooluse/nodes/types';
 import type { ToolUseServices } from '@agent/implementations/flows/tooluse/ToolUseServices';
 import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
-import { defaultSession } from '@agent/runtime/SessionHandle';
 import { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import type { ProviderMessage } from '@agent/types/ProviderMessage';
 import {
@@ -36,6 +35,7 @@ import { GoalStore } from '@tools/goal';
 import {
   recordSessionEvents,
   runEventsOfType,
+  sessionWithInteractions,
   toolUseRunShared,
   withTestRunContext,
 } from '../progressTestUtils';
@@ -50,11 +50,7 @@ type WaitNodeModelHandlerOverrides = Omit<
 type WaitNodeServiceOverrides = Partial<
   Pick<
     ToolUseServices,
-    | 'checkInterruption'
-    | 'isSubagent'
-    | 'onFollowUpConsumed'
-    | 'onIdle'
-    | 'streamStatus'
+    'checkInterruption' | 'isSubagent' | 'onFollowUpConsumed' | 'onIdle'
   >
 > & {
   fileService?: Partial<ToolUseServices['fileService']>;
@@ -89,7 +85,6 @@ function createWaitNodeServices(
       waitForFollowUp: vi.fn(async () => null),
       ...session,
     },
-    streamStatus: new StreamStatusMachine(),
     ...topLevel,
   } as unknown as ToolUseServices;
 }
@@ -491,6 +486,7 @@ describe('ToolUseWaitNode', () => {
     const onFollowUpConsumed = vi.fn();
     const waitForFollowUp = vi.fn();
     const streamStatus = new StreamStatusMachine();
+    const ownerSession = sessionWithInteractions(undefined, streamStatus);
     const runtimeHost = { emit: vi.fn() };
     const services = createWaitNodeServices({
       isSubagent: false,
@@ -501,15 +497,17 @@ describe('ToolUseWaitNode', () => {
       session: {
         waitForFollowUp,
       },
-      streamStatus,
     });
     const node = new ToolUseWaitNode().setServices(services);
 
     try {
       seedStreamStatusForTest(streamStatus, streamId, STREAM_PHASE.RUNNING);
       const prep = await node.prep(shared);
-      const exec = await withTestRunContext(runtimeHost, streamId, () =>
-        node.exec(prep),
+      const exec = await withTestRunContext(
+        runtimeHost,
+        streamId,
+        () => node.exec(prep),
+        { session: ownerSession },
       );
 
       expect(exec.kind).toBe('continue');
@@ -524,8 +522,11 @@ describe('ToolUseWaitNode', () => {
       expect(waitForFollowUp).not.toHaveBeenCalled();
       expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.RUNNING);
 
-      const transition = await withTestRunContext(runtimeHost, streamId, () =>
-        node.post(shared, prep, exec),
+      const transition = await withTestRunContext(
+        runtimeHost,
+        streamId,
+        () => node.post(shared, prep, exec),
+        { session: ownerSession },
       );
 
       expect(transition).toBe(FlowTransition.CONTINUE);
@@ -701,9 +702,10 @@ describe('ToolUseWaitNode', () => {
     }
   });
 
-  it('updates the injected stream status owner while waiting and resuming', async () => {
+  it('updates the run session status while waiting and resuming', async () => {
     const streamId = 'wait-node-owner' as StreamTabId;
     const streamStatus = new StreamStatusMachine();
+    const ownerSession = sessionWithInteractions(undefined, streamStatus);
     const shared: ToolUseRunShared = toolUseRunShared();
     const createUserFollowUpMessages = vi.fn(async () => []);
     const runtimeHost = { emit: vi.fn() };
@@ -717,44 +719,38 @@ describe('ToolUseWaitNode', () => {
           synthetic: true,
         }),
       },
-      streamStatus,
     });
     const node = new ToolUseWaitNode().setServices(services);
 
     try {
       seedStreamStatusForTest(streamStatus, streamId, STREAM_STATUS.RUNNING);
-      seedStreamStatusForTest(
-        defaultSession().status,
-        streamId,
-        STREAM_PHASE.CANCELLED,
-      );
 
       const prep = await node.prep(shared);
-      const exec = await withTestRunContext(runtimeHost, streamId, () =>
-        node.exec(prep),
+      const exec = await withTestRunContext(
+        runtimeHost,
+        streamId,
+        () => node.exec(prep),
+        { session: ownerSession },
       );
       expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.WAITING);
-      expect(defaultSession().status.get(streamId)).toBe(
-        STREAM_PHASE.CANCELLED,
-      );
 
-      await withTestRunContext(runtimeHost, streamId, () =>
-        node.post(shared, prep, exec),
+      await withTestRunContext(
+        runtimeHost,
+        streamId,
+        () => node.post(shared, prep, exec),
+        { session: ownerSession },
       );
       expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.RUNNING);
-      expect(defaultSession().status.get(streamId)).toBe(
-        STREAM_PHASE.CANCELLED,
-      );
       expect(createUserFollowUpMessages).toHaveBeenCalledOnce();
     } finally {
       clearStreamStatusForTest(streamStatus, streamId);
-      clearStreamStatusForTest(defaultSession().status, streamId);
     }
   });
 
   it('repairs retry-cancelled parent cycles to waiting before blocking', async () => {
     const streamId = 'wait-node-retry-cancelled-wait' as StreamTabId;
     const streamStatus = new StreamStatusMachine();
+    const ownerSession = sessionWithInteractions(undefined, streamStatus);
     const runtimeHost = { emit: vi.fn() };
     const logger = Object.assign(new TraceEmitter(), {
       error: vi.fn(),
@@ -772,19 +768,22 @@ describe('ToolUseWaitNode', () => {
       session: {
         waitForFollowUp,
       },
-      streamStatus,
     });
     const node = new ToolUseWaitNode().setServices(services);
 
     try {
       seedStreamStatusForTest(streamStatus, streamId, STREAM_PHASE.CANCELLED);
 
-      const exec = await withTestRunContext(runtimeHost, streamId, () =>
-        node.exec({
-          afterError: true,
-          lastResponse: undefined,
-          touchedFiles: [],
-        }),
+      const exec = await withTestRunContext(
+        runtimeHost,
+        streamId,
+        () =>
+          node.exec({
+            afterError: true,
+            lastResponse: undefined,
+            touchedFiles: [],
+          }),
+        { session: ownerSession },
       );
 
       expect(exec.kind).toBe('stop');
@@ -844,6 +843,7 @@ describe('ToolUseWaitNode', () => {
       events.emit({ scope: 'run', streamId, event });
     });
     const streamStatus = new StreamStatusMachine();
+    const ownerSession = sessionWithInteractions(undefined, streamStatus);
     const services = createWaitNodeServices({
       logger,
       modelHandler: {
@@ -866,7 +866,6 @@ describe('ToolUseWaitNode', () => {
           synthetic: false,
         }),
       },
-      streamStatus,
     });
     const node = new ToolUseWaitNode().setServices(services);
     seedStreamStatusForTest(streamStatus, streamId, STREAM_PHASE.WAITING);
@@ -880,6 +879,7 @@ describe('ToolUseWaitNode', () => {
           const exec = await node.exec(prep);
           return node.post(shared, prep, exec);
         },
+        { session: ownerSession },
       );
 
       expect(transition).toBe(FlowTransition.CONTINUE);

--- a/src/test-kernel/agent/followUp/ToolUseWaitNodeFollowUpTranscriptLog.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNodeFollowUpTranscriptLog.vitest.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
+import { TraceEmitter } from '@agent/trace';
 import { ToolUseWaitNode } from '@agent/implementations/flows/tooluse/nodes/ToolUseWaitNode';
 import type {
   ToolUseRunShared,
@@ -14,14 +15,19 @@ function buildServices(
   overrides: Partial<ToolUseServices<unknown>> = {},
 ): ToolUseServices<unknown> {
   return {
-    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    logger: Object.assign(new TraceEmitter(), {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
     modelHandler: {
       createUserFollowUpMessages: vi.fn(async (messages) => messages),
       addMediaToUserMessage: vi.fn(async () => []),
       capabilities: {},
     } as never,
     fileService: { createLocation: vi.fn() } as never,
-    streamStatus: { transition: vi.fn() } as never,
+    onRoundFinalized: () => {},
     ...overrides,
   } as ToolUseServices<unknown>;
 }

--- a/src/test-kernel/agent/progressTestUtils.ts
+++ b/src/test-kernel/agent/progressTestUtils.ts
@@ -26,6 +26,7 @@ import type {
   SessionFact,
 } from '@agent/runtime/SessionEventHub';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
+import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import { createSessionApprovals } from '@agent/runtime/streamApprovalQueue';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 
@@ -359,12 +360,14 @@ export function createRecordingHost(): {
  */
 export function sessionWithInteractions(
   interactions: HostInteractions | undefined,
+  status = new StreamStatusMachine(),
 ): SessionHandle {
   const owner = new SessionHostInteractions();
   if (interactions) owner.use(interactions);
   return {
     interactions: owner,
     approvals: createSessionApprovals(),
+    status,
   } as unknown as SessionHandle;
 }
 
@@ -383,9 +386,14 @@ export function withTestRunContext<T>(
   options: {
     approvalPromptsUnavailable?: boolean;
     runtimeUnavailableTools?: readonly string[];
+    session?: SessionHandle;
     stopAfterCycle?: boolean;
   } = {},
 ): Promise<T> {
+  const {
+    session = sessionWithInteractions(interactionsByHost.get(runtimeHost)),
+    ...contextOptions
+  } = options;
   return withRunContext(
     createRunContext({
       runScope: createRunScope({
@@ -393,11 +401,11 @@ export function withTestRunContext<T>(
         streamId: streamId as StreamTabId,
         executionId: 'deadbeef' as ExecutionId,
         agentName: 'test-agent',
-        session: sessionWithInteractions(interactionsByHost.get(runtimeHost)),
+        session,
       }),
       modelSource: 'live',
       getModel: () => undefined,
-      ...options,
+      ...contextOptions,
     }),
     fn,
   ) as Promise<T>;

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -24,7 +24,7 @@ import type {
 } from '@agent/runtime/HostInteractions';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { createRunScope } from '@agent/runtime/RunScope';
-import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import {
   noopAgentRuntimeHost,
@@ -50,7 +50,6 @@ interface TestRetryServices {
   config: { model: string };
   streamId: StreamTabId;
   runtimeHost: AgentRuntimeHost;
-  streamStatus: StreamStatusMachine;
   logger: AgentTrace;
   setAbortController: (ac: AbortController | null) => void;
 }
@@ -74,6 +73,7 @@ class ExposedRetryNode extends RetryableInvocationNode<
 
 interface RetryNodeKit {
   node: ExposedRetryNode;
+  session: SessionHandle;
   streamStatus: StreamStatusMachine;
   requestRetry: Mock<(request: HostRetryRequest) => Promise<RetryResult>>;
 }
@@ -81,20 +81,23 @@ interface RetryNodeKit {
 function createRetryNode(streamId: StreamTabId): RetryNodeKit {
   const streamStatus = new StreamStatusMachine();
   const requestRetry = vi.fn<RetryNodeKit['requestRetry']>();
+  const session = sessionWithInteractions(
+    { requestRetry, cancel: () => {} },
+    streamStatus,
+  );
   const node = new ExposedRetryNode().setServices({
     config: { model: 'copilot:sonnet46' },
     streamId,
     runtimeHost: noopAgentRuntimeHost,
-    streamStatus,
     logger: noopTrace,
     setAbortController: vi.fn(),
   });
-  return { node, streamStatus, requestRetry };
+  return { node, session, streamStatus, requestRetry };
 }
 
 async function withRetryRunContext<T>(
   streamId: StreamTabId,
-  requestRetry: RetryNodeKit['requestRetry'],
+  session: SessionHandle,
   fn: () => T | Promise<T>,
 ): Promise<T> {
   const context = createRunContext({
@@ -105,10 +108,7 @@ async function withRetryRunContext<T>(
       streamId,
       executionId: `${streamId}-execution` as ExecutionId,
       agentName: 'retry-test',
-      session: sessionWithInteractions({
-        requestRetry,
-        cancel: () => {},
-      }),
+      session,
     }),
   });
   return await withRunContext(context, fn);
@@ -234,28 +234,21 @@ describe('RetryState', () => {
     expect(node.shouldAutoRetry(overflow)).toBe(false);
   });
 
-  it('updates the injected stream status owner during manual retry', async () => {
+  it('updates the run session status during manual retry', async () => {
     const streamId = 'retry-state-owner' as StreamTabId;
-    const { node, streamStatus, requestRetry } = createRetryNode(streamId);
+    const { node, session, streamStatus, requestRetry } =
+      createRetryNode(streamId);
 
     requestRetry.mockResolvedValueOnce({ action: 'retry' });
 
     try {
       seedStreamStatusForTest(streamStatus, streamId, STREAM_STATUS.RUNNING);
-      seedStreamStatusForTest(
-        defaultSession().status,
-        streamId,
-        STREAM_PHASE.CANCELLED,
-      );
 
-      await withRetryRunContext(streamId, requestRetry, () =>
+      await withRetryRunContext(streamId, session, () =>
         node.promptFor(new Error('temporary provider failure')),
       );
 
       expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.RUNNING);
-      expect(defaultSession().status.get(streamId)).toBe(
-        STREAM_PHASE.CANCELLED,
-      );
       expect(requestRetry).toHaveBeenCalledWith(
         expect.objectContaining({
           streamId,
@@ -266,7 +259,6 @@ describe('RetryState', () => {
       );
     } finally {
       clearStreamStatusForTest(streamStatus, streamId);
-      clearStreamStatusForTest(defaultSession().status, streamId);
     }
   });
 
@@ -275,7 +267,8 @@ describe('RetryState', () => {
     const session = createTestSession();
     const recording = createRecordingHost();
     session.useHostInteractions(recording.interactions);
-    const { node, streamStatus } = createRetryNode(streamId);
+    const { node } = createRetryNode(streamId);
+    const streamStatus = session.status;
 
     try {
       seedStreamStatusForTest(streamStatus, streamId, STREAM_STATUS.RUNNING);
@@ -309,14 +302,15 @@ describe('RetryState', () => {
     'stops the stream after manual retry %s',
     async (action) => {
       const streamId = `retry-state-${action}` as StreamTabId;
-      const { node, streamStatus, requestRetry } = createRetryNode(streamId);
+      const { node, session, streamStatus, requestRetry } =
+        createRetryNode(streamId);
 
       requestRetry.mockResolvedValueOnce({ action });
 
       try {
         seedStreamStatusForTest(streamStatus, streamId, STREAM_STATUS.RUNNING);
 
-        await withRetryRunContext(streamId, requestRetry, () =>
+        await withRetryRunContext(streamId, session, () =>
           node.promptFor(new Error('temporary provider failure')),
         );
 
@@ -329,7 +323,8 @@ describe('RetryState', () => {
 
   it('classifies a policy/headless retry denial as failed, not cancelled (#7331)', async () => {
     const streamId = 'retry-state-deny' as StreamTabId;
-    const { node, streamStatus, requestRetry } = createRetryNode(streamId);
+    const { node, session, streamStatus, requestRetry } =
+      createRetryNode(streamId);
 
     requestRetry.mockResolvedValueOnce({
       action: 'deny',
@@ -340,10 +335,8 @@ describe('RetryState', () => {
     try {
       seedStreamStatusForTest(streamStatus, streamId, STREAM_STATUS.RUNNING);
 
-      const shouldRetry = await withRetryRunContext(
-        streamId,
-        requestRetry,
-        () => node.retryPrompt(undefined, error),
+      const shouldRetry = await withRetryRunContext(streamId, session, () =>
+        node.retryPrompt(undefined, error),
       );
 
       // A denial does not retry and — crucially — is NOT a user cancel, so the

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -45,7 +45,6 @@ import * as toolUseFollowUp from '@agent/followUp/ToolUseFollowUp';
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/openai/modelHandlerOpenAIResponse';
 import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { defaultSession } from '@agent/runtime/SessionHandle';
-import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 // Type imports
 import type { ProviderMessage } from '@agent/types/ProviderMessage';
 import type { SdkToolCall } from '@agent/types/ModelHandlerContracts';
@@ -187,12 +186,12 @@ function roundServices(opts: {
     } satisfies AgentPrompt,
     userVarChannels: { input: {}, transient: {} },
     logger: opts.logger,
-    streamStatus: new StreamStatusMachine(),
     client: {} as OpenAI,
     fileService: new TaskRunFileService('deadbeef'),
     toolRegistry: opts.toolRegistry,
     checkInterruption: opts.checkInterruption ?? (() => false),
     setAbortController: opts.setAbortController ?? (() => {}),
+    onRoundFinalized: () => {},
     run: AgentRunStateSnapshotSchema.parse({}),
     workspace: AgentWorkspaceState.create(),
   };


### PR DESCRIPTION
## Summary

- make the owning `RunContext.runScope.session` the only source of stream status inside flows, removing the duplicate service-bag reference and three production copy sites
- call the single text-connection helper directly from its sole flow consumer
- make round finalization a required base-flow contract and normalize resolved tools once into `setting.tools`
- update flow tests so their run context owns the status machine, eliminating the production-impossible bag/session divergence

Closes #8749

## Issue acceptance gates

- `BaseFlowContextInit.streamStatus`, `RetryableNodeServices.streamStatus`, the invocation-service pick, and all three `executeAgent` copies are removed.
- `RetryState` and `ToolUseWaitNode` read status from the owning run session.
- The response-cycle text connector is no longer carried through a services field.
- `onRoundFinalized` is required once in `BaseFlowContextInit`; duplicate redeclarations, no-op defaults, and optional guards are removed.
- `ToolUseServices.resolvedTools` is removed; resolved definitions replace `setting.tools` once at flow setup.
- Status surfaces outside the ALS-owned flow path are untouched.

## Single source of truth

- Run-owned status: `RunContext.runScope.session.status`
- Resolved tool definitions: `ToolUseServices.setting.tools`
- Round finalization contract: `BaseFlowContextInit.onRoundFinalized`

## Duplication and abstraction budget

Removed duplicate service fields, copy sites, fallbacks, and a one-injector/one-consumer pass-through. Added no abstraction, facade, port, factory, or helper layer. The test context helper accepts the owning session explicitly so direct-node tests exercise the same ownership model as production.

## Net elements (R6)

- Files: 0 added, 0 deleted, 29 modified
- Exported symbols: 0 added, 0 deleted
- Classes/interfaces/enums: 0 added, 0 deleted
- Named service members removed: `streamStatus` from two contracts, `bestConnectionMethod`, `resolvedTools`, and two duplicate `onRoundFinalized` redeclarations
- Net LoC: -31 overall (125 added / 156 deleted); -32 in production TypeScript
- New wrapper/indirection layers: 0

## Consumer counts (R8)

n/a — no emit key or exported symbol is deleted or rerouted. The direct dependency changes cover one text-connector consumer, two status-consuming flow modules, and three removed status injection sites.

## Host impact

Extension: behavior-preserving shared flow cleanup; no extension-only surface changed.

Desktop: behavior-preserving shared flow cleanup; no desktop-only surface changed.

CLI: behavior-preserving shared flow and resume cleanup; no command, TUI, JSON, or NDJSON contract changed.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run compile:safe`
- `npm run lint` — 0 errors; one pre-existing `replaceAll` warning in `AgentCreatorToolCatalogParity.vitest.mts`
- `npm run check:dead-code-ratchet` — 228 current / 228 baseline
- Full Vitest result on the implementation branch — 736 files passed, 1 skipped; 6,789 tests passed, 4 skipped
- After rebasing onto current `origin/main`: `npm run typecheck`
- After rebasing: 14 focused files, 117 tests passed
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches wait/retry stream phase transitions and tool-use service wiring across core flows and runtime entry points; behavior should be equivalent but tests were updated to match the new ownership model.
> 
> **Overview**
> **Consolidates run-owned dependencies** so flow code no longer carries parallel copies of the same services through the flow services bag.
> 
> **Stream status** is no longer injected via `BaseFlowContextInit.streamStatus` or passed from `executeAgent`. `RetryState` and `ToolUseWaitNode` read `useLaunchRunContext().runScope.session.status` instead, matching production’s single session owner.
> 
> **Text connection** for response cycles is no longer threaded through `ResponseCycleServices.bestConnectionMethod`; `ResponseCycleFlow` imports `bestConnectionMethod` from `@agent/runtime/textConnection` directly.
> 
> **Round finalization** is required on `BaseFlowContextInit.onRoundFinalized` (no optional chaining or no-op defaults). Duplicate redeclarations on reflection/tool-use service types are removed.
> 
> **Resolved tools** are normalized once in `runToolUseFlow` as `setting: { ...setting, tools: resolvedTools }`; `ToolUseServices.resolvedTools` and per-node merging are dropped.
> 
> Tests that call flow nodes directly now put the status machine on the run `session` via `sessionWithInteractions` / `withTestRunContext`, so bag vs session divergence cannot be exercised accidentally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d039e69e3f267ce13ff595409aca9811d1f85d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
