### PR TITLE
refactor(flows): make runtime injection partition exact

### DIFF
--- a/src/agent/core/flows/BaseFlowServices.ts
+++ b/src/agent/core/flows/BaseFlowServices.ts
@@ -9,7 +9,6 @@ import type {
 } from '@agent/core/definition/AgentDataclass';
 import type { UserVariableChannels } from '@agent/core/definition/AgentCycleOptions';
 import type { AgentRunStateSnapshot } from '@agent/core/state/AgentState';
-import type { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 
 /** Callback invoked when a round/cycle completes for usage tracking. */
 export type RoundFinalizedCallback = (
@@ -28,9 +27,8 @@ export interface AgentCore<C = unknown> {
 }
 
 export interface BaseFlowContextInit<C = unknown> extends AgentCore<C> {
-  streamStatus: StreamStatusMachine;
   checkInterruption: () => boolean;
   setAbortController: (ctrl: AbortController | null) => void;
   onInterrupt?: () => void;
-  onRoundFinalized?: RoundFinalizedCallback;
+  onRoundFinalized: RoundFinalizedCallback;
 }

--- a/src/agent/core/flows/CycleServices.ts
+++ b/src/agent/core/flows/CycleServices.ts
@@ -75,14 +75,6 @@ export interface ResponseCycleServices<
   C = unknown,
 > extends CycleRunServices<C> {
   round: ConversationRoundStateSnapshot;
-  /**
-   * Determines the best textual connector between two strings in a LaTeX
-   * document context (empty string, space, or newline).
-   */
-  readonly bestConnectionMethod: (
-    str1: string,
-    str2: string,
-  ) => Promise<{ connector: string; choice: string }>;
 }
 
 /**

--- a/src/agent/core/flows/ModelInvocationNode.ts
+++ b/src/agent/core/flows/ModelInvocationNode.ts
@@ -46,8 +46,8 @@ export interface ModelInvocationConfig<TShared, TServices> {
 /**
  * Only the services this node and its `RetryableInvocationNode` base class
  * actually read: the model handler, logger, setting (temperature/tools),
- * config (for `saveCycleDebug`'s log context), and the retry machinery's
- * `streamStatus`/`setAbortController`, plus the live model client. Picking
+ * config (for `saveCycleDebug`'s log context), the retry machinery's
+ * `setAbortController`, and the live model client. Picking
  * from `AgentCore`/`BaseFlowContextInit` instead of requiring the literal
  * type keeps every existing caller, which passes the full services bag,
  * satisfying this narrower shape structurally.
@@ -56,7 +56,7 @@ type InvocationServices = Pick<
   AgentCore,
   'modelHandler' | 'logger' | 'setting' | 'config'
 > &
-  Pick<BaseFlowContextInit, 'setAbortController' | 'streamStatus'> & {
+  Pick<BaseFlowContextInit, 'setAbortController'> & {
     readonly client: unknown;
     readonly refreshClient?: () => Promise<void>;
   };

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -21,6 +21,7 @@ import {
 import type { ProviderUsage } from '@agent/core/usage/ResponseUsage';
 import { K_SLICE } from '@agent/core/constants';
 import { useLaunchRunContext } from '@agent/runtime/RunContext';
+import { bestConnectionMethod } from '@agent/runtime/textConnection';
 import type { ToolDefinition } from '@model';
 import { MESSAGE_TYPES, AgentFileLocationSchema } from '@shared/schemas';
 import { OUTPUT_END_TAG } from '@shared/constants/outputProtocol';
@@ -315,7 +316,7 @@ class ResponseProcessNode<C> extends BaseNode<
       // Re-applying would run non-idempotent custom replacements twice.
       const processedResponse = newResponse;
 
-      const connector = await this.services.bestConnectionMethod(
+      const connector = await bestConnectionMethod(
         prepRes.lastResponse.slice(-K_SLICE),
         processedResponse.slice(0, K_SLICE),
       );
@@ -450,7 +451,7 @@ class ResponseCycleFinalizeNode<C> extends BaseNode<
     // throwing *after* recordRound has already mutated run state — otherwise
     // that catch would re-record the round and double-count usage/response time.
     try {
-      await onRoundFinalized?.(run);
+      await onRoundFinalized(run);
     } catch (error) {
       logger.warn(
         `Round finalization callback failed: ${toErrorMessage(error)}`,

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -7,7 +7,6 @@ import { Node } from '@agent/node';
 import { logErrorData, logProgressStatus, type AgentTrace } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { useLaunchRunContext } from '@agent/runtime/RunContext';
-import type { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { normalizeProviderError } from '@common/errors';
 import {
@@ -57,7 +56,6 @@ export type InvocationResult<TSuccess> =
 
 interface RetryableNodeServices {
   config: Pick<AgentConfig, 'model'>;
-  streamStatus: StreamStatusMachine;
   logger: AgentTrace;
   setAbortController: (ac: AbortController | null) => void;
   refreshClient?: () => Promise<void>;
@@ -271,9 +269,10 @@ export abstract class RetryableInvocationNode<
   protected async handleManualRetryPrompt(
     error: Error,
   ): Promise<ManualRetryPromptResult> {
-    const { logger, streamStatus } = this.services;
+    const { logger } = this.services;
     const { runScope } = useLaunchRunContext();
     const { session, streamId } = runScope;
+    const streamStatus = session.status;
     const operationName = this.getOperationName();
     const formatted = normalizeProviderError(error);
 

--- a/src/agent/core/flows/toolUseRound/ToolUseProcessNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseProcessNode.ts
@@ -195,7 +195,7 @@ export class ToolUseProcessNode<C> extends BaseNode<
       shared.roundResponseTimeMs,
       shared.roundNormalizedUsage ?? null,
     );
-    await onRoundFinalized?.(run);
+    await onRoundFinalized(run);
     run.totalRounds += 1;
 
     shared.stopReason = execRes.stopReason;

--- a/src/agent/implementations/flows/reflection/ReflectionServices.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionServices.ts
@@ -1,9 +1,6 @@
 import type { PromptBuilder } from '@agent/prompt';
 import type { AgentWorkflowSetting } from '@agent/core/definition/AgentDataclass';
-import type {
-  BaseFlowContextInit,
-  RoundFinalizedCallback,
-} from '@agent/core/flows/BaseFlowServices';
+import type { BaseFlowContextInit } from '@agent/core/flows/BaseFlowServices';
 import type { OutputState } from '@agent/output/outputState';
 import type { LatexDiffManager } from '@agent/output/LatexDiffManager';
 import type { XmlOutputManager } from '@agent/output/XmlOutputManager';
@@ -31,5 +28,4 @@ export interface ReflectionServices<
   ) => AgentFileLocation | Promise<AgentFileLocation>;
   readonly workflowOutputPolicy: WorkflowOutputPolicy;
   readonly baseFiles: FileLocation[];
-  readonly onRoundFinalized: RoundFinalizedCallback;
 }

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
@@ -11,7 +11,6 @@ import type {
   AgentRunStateSnapshot,
   ConversationRoundStateSnapshot,
 } from '@agent/core/state/AgentState';
-import { bestConnectionMethod } from '@agent/runtime/textConnection';
 import { buildFailedRetryInfo } from '@common/errors';
 import type { AgentFileLocation, RetryErrorInfo } from '@shared/schemas';
 import { getDefaultToolRegistry } from '@tools/registry';
@@ -107,7 +106,6 @@ export class ResponseCycleNode<C = unknown> extends Node<
         await withModelClient(
           {
             ...this.services,
-            bestConnectionMethod,
             toolRegistry: getDefaultToolRegistry(),
             round: prepRes.round,
             run: prepRes.run,

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -99,7 +99,7 @@ export async function runReflectionFlow<C = unknown>(
     parentStage,
     userVarChannels,
     checkInterruption,
-    onRoundFinalized = async () => {},
+    onRoundFinalized,
   } = input;
   const { runScope } = useLaunchRunContext();
   const { runtimeHost, streamId, executionId, session: runSession } = runScope;

--- a/src/agent/implementations/flows/tooluse/ToolUseServices.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseServices.ts
@@ -1,12 +1,8 @@
 import type { AgentToolUseSetting } from '@agent/core/definition/AgentDataclass';
-import type {
-  BaseFlowContextInit,
-  RoundFinalizedCallback,
-} from '@agent/core/flows/BaseFlowServices';
+import type { BaseFlowContextInit } from '@agent/core/flows/BaseFlowServices';
 import type { IToolRegistry } from '@agent/core/tools/ToolTypes';
 import type { AttachedMemoryMiss } from '@agent/types/AttachedMemory';
 import type { IToolUseSession } from '@agent/core/flows/IToolUseSession';
-import type { ToolDefinition } from '@model';
 import type { SubagentProgressUpdate, TodoItem } from '@shared/schemas';
 import type { TaskRunFileService } from '@utils/files';
 import type { ToolUseSessionSnapshot } from './ToolUseSessionTypes';
@@ -16,10 +12,8 @@ export interface ToolUseServices<C = unknown> extends BaseFlowContextInit<C> {
   readonly session: IToolUseSession;
   /** Run-storage-aware file locator; used to attach follow-up media files. */
   readonly fileService: TaskRunFileService;
-  readonly resolvedTools: ToolDefinition[];
   readonly toolRegistry: IToolRegistry;
   readonly snapshot: ToolUseSessionSnapshot | null;
-  readonly onRoundFinalized: RoundFinalizedCallback;
   readonly onFollowUpConsumed?: () => void;
   readonly attachedMemoryMisses?: readonly AttachedMemoryMiss[];
   readonly onProgress?: (update: SubagentProgressUpdate) => void;

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -60,7 +60,7 @@ export class ToolUseCycleNode<C> extends Node<
   }
 
   async exec(prepRes: CyclePrepResult): Promise<ToolUseCycleOutcome> {
-    const { setting, resolvedTools, modelHandler } = this.services;
+    const { modelHandler } = this.services;
     const { runScope } = useLaunchRunContext();
     const { streamId } = runScope;
 
@@ -93,7 +93,6 @@ export class ToolUseCycleNode<C> extends Node<
       await withModelClient(
         {
           ...this.services,
-          setting: { ...setting, tools: resolvedTools },
           run: prepRes.runState,
           workspace: prepRes.workspaceState,
         },

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
@@ -31,7 +31,7 @@ export class ToolUsePrepareNode<C> extends Node<
   ): Promise<{ kind: 'success'; result: CyclePrepResult }> {
     const { userVarChannels, logger, snapshot, config, fileService } =
       this.services;
-    const resolvedToolNames = this.services.resolvedTools.map((t) => t.name);
+    const resolvedToolNames = this.services.setting.tools.map((t) => t.name);
     const hasDelegationTools = hasDelegationTool(resolvedToolNames);
     const promptOptions = {
       resolvedToolNames,

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -57,10 +57,10 @@ export class ToolUseWaitNode<C> extends Node<
   }
 
   async exec(prepRes: WaitPrepResult): Promise<WaitExecResult> {
-    const { checkInterruption, session, streamStatus, isSubagent } =
-      this.services;
+    const { checkInterruption, session, isSubagent } = this.services;
     const { runScope, stopAfterCycle } = useLaunchRunContext();
-    const { streamId, runtimeHost } = runScope;
+    const { streamId, runtimeHost, session: runSession } = runScope;
+    const streamStatus = runSession.status;
 
     if (checkInterruption()) {
       return { kind: 'stop' };
@@ -173,9 +173,9 @@ export class ToolUseWaitNode<C> extends Node<
     prepRes: WaitPrepResult,
     execRes: WaitExecResult,
   ): Promise<string | undefined> {
-    const { onFollowUpConsumed, logger, streamStatus } = this.services;
+    const { onFollowUpConsumed, logger } = this.services;
     const { runScope } = useLaunchRunContext();
-    const { streamId } = runScope;
+    const { streamId, session: runSession } = runScope;
 
     if (execRes.kind === 'waiting') {
       return FlowTransition.WAITING;
@@ -192,7 +192,7 @@ export class ToolUseWaitNode<C> extends Node<
     shared.lastError = undefined;
     shared.userCancelledRetry = undefined;
 
-    streamStatus.transition(streamId, STREAM_PHASE.RUNNING, 'resume', {
+    runSession.status.transition(streamId, STREAM_PHASE.RUNNING, 'resume', {
       trace: logger,
     });
 

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -223,10 +223,9 @@ export async function runToolUseFlow<C = unknown>(
   const services: ToolUseServices<C> = {
     ...input,
     session: sessionLifecycle,
-    resolvedTools,
+    setting: { ...setting, tools: resolvedTools },
     toolRegistry: registry,
     snapshot: input.resumeSnapshot ?? null,
-    onRoundFinalized: input.onRoundFinalized ?? (async () => {}),
     persistTodos: (todos) => kv.writeTodos(todos),
     fileService: new TaskRunFileService(executionId),
   };

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -153,17 +153,12 @@ async function runToolUseAgent(
     'isSubagent' | 'onFollowUpConsumed' | 'onProgress' | 'onIdle'
   >,
 ): Promise<AgentRuntimeFlowResult> {
-  const {
-    streamId: runStreamId,
-    executionId: runExecutionId,
-    session: runSession,
-  } = ctx.runScope;
+  const { streamId: runStreamId, executionId: runExecutionId } = ctx.runScope;
   const onRoundFinalized = createUsageRecordingCallback(ctx);
   try {
     const result = await runToolUseFlow(
       {
         ...ctx,
-        streamStatus: runSession.status,
         ...createInterruptCallbacks(),
         onRoundFinalized,
         setting,
@@ -250,7 +245,6 @@ async function runReflectionAgent(
   try {
     result = await runReflectionFlow({
       ...ctx,
-      streamStatus: runSession.status,
       ...interruptCallbacks,
       onRoundFinalized,
       setting,
@@ -556,7 +550,6 @@ export async function resumeToolUseFromSnapshot(
             const result = await runToolUseFlow(
               {
                 ...ctx,
-                streamStatus: runSession.status,
                 ...createInterruptCallbacks(),
                 onRoundFinalized: createUsageRecordingCallback(ctx),
                 setting,

--- a/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
+++ b/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
@@ -102,9 +102,9 @@ async function runPersistedReflectionFlow(
           transient: {},
         },
         modelHandler: createModelHandler(),
-        streamStatus: session.status,
         checkInterruption: () => true,
         setAbortController: () => {},
+        onRoundFinalized: () => {},
       }),
     );
   } finally {

--- a/src/test-kernel/agent/ResponseCycleContinuation.vitest.ts
+++ b/src/test-kernel/agent/ResponseCycleContinuation.vitest.ts
@@ -57,6 +57,7 @@ function createServices(interrupted = false) {
     config: {},
     workspace: {},
     logger: { info: vi.fn() },
+    onRoundFinalized: () => {},
     modelHandler: {
       checkStopConditions,
       shouldContinue,

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -171,12 +171,12 @@ async function runPersistedFlow(
           logger: noopTrace,
           userVarChannels,
           modelHandler: createTaggedModelHandler(ACTIVE_COMPATIBILITY_KEY),
-          streamStatus: session.status,
           checkInterruption: () => interrupted,
           onInterrupt: () => {
             interrupted = true;
           },
           setAbortController: () => {},
+          onRoundFinalized: () => {},
           ...(snapshot !== undefined && { resumeSnapshot: snapshot }),
           isSubagent: options.isSubagent ?? true,
           onIdle: options.onIdle,

--- a/src/test-kernel/agent/ToolUseDispatchParallel.vitest.ts
+++ b/src/test-kernel/agent/ToolUseDispatchParallel.vitest.ts
@@ -85,6 +85,7 @@ function dispatchHarness(opts: HarnessOptions) {
     toolRegistry: new MapToolRegistry(opts.tools),
     checkInterruption: opts.checkInterruption ?? (() => false),
     setAbortController: opts.setAbortController ?? (() => {}),
+    onRoundFinalized: () => {},
     run: AgentRunStateSnapshotSchema.parse({}),
     workspace: AgentWorkspaceState.create(),
   } as unknown as ToolUseRoundServices<unknown>;

--- a/src/test-kernel/agent/followUp/ToolUseDispatchInterruption.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseDispatchInterruption.vitest.ts
@@ -13,7 +13,6 @@ import {
 import { MapToolRegistry } from '@agent/core/tools/ToolTypes';
 import type { ProviderMessage } from '@agent/types/ProviderMessage';
 import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import { withTestRunContext } from '../progressTestUtils';
 
 /**
@@ -135,6 +134,7 @@ describe('ToolUseDispatchNode interruption', () => {
       },
       prompt: { systemPrompt: '', userPrefix: '', userRequest: '' },
       run: AgentRunStateSnapshotSchema.parse({}),
+      onRoundFinalized: () => {},
       session: {
         hasQueuedFollowUp: () => false,
       },
@@ -143,7 +143,6 @@ describe('ToolUseDispatchNode interruption', () => {
         temperature: 0,
         tools: [{ name: 'toolA' }, { name: 'toolB' }],
       },
-      streamStatus: new StreamStatusMachine(),
       toolRegistry: new MapToolRegistry({
         toolA: { call: toolACall, definition: { name: 'toolA' } } as never,
         toolB: { call: toolBCall, definition: { name: 'toolB' } } as never,
@@ -308,6 +307,7 @@ describe('ToolUseDispatchNode interruption', () => {
       },
       prompt: { systemPrompt: '', userPrefix: '', userRequest: '' },
       run: AgentRunStateSnapshotSchema.parse({}),
+      onRoundFinalized: () => {},
       session: {
         hasQueuedFollowUp: () => false,
       },
@@ -316,7 +316,6 @@ describe('ToolUseDispatchNode interruption', () => {
         temperature: 0,
         tools: [{ name: 'toolA' }, { name: 'toolB' }],
       },
-      streamStatus: new StreamStatusMachine(),
       toolRegistry: new MapToolRegistry({
         toolA: { call: toolACall, definition: { name: 'toolA' } } as never,
         toolB: { call: toolBCall, definition: { name: 'toolB' } } as never,

--- a/src/test-kernel/agent/followUp/ToolUsePrepareNodeTranscriptLog.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUsePrepareNodeTranscriptLog.vitest.ts
@@ -29,11 +29,9 @@ function buildServices(
       systemPrompt: 'You are careful.',
       userRequest: 'Do the thing.',
     }),
-    resolvedTools: [],
     session: {} as never,
-    setting: { agentCategory: 'toolUse' } as never,
+    setting: { agentCategory: 'toolUse', tools: [] } as never,
     snapshot: null,
-    streamStatus: {} as never,
     toolRegistry: {} as never,
     userVarChannels: { input: {}, transient: {} },
     checkInterruption: () => false,
@@ -121,7 +119,7 @@ describe('ToolUsePrepareNode resume (prompt-cache preservation)', () => {
     const snapshot = buildSnapshot();
     const services = buildServices({ snapshot });
     const node = new ToolUsePrepareNode().setServices(services);
-    const resolvedToolNames = services.resolvedTools.map((tool) => tool.name);
+    const resolvedToolNames = services.setting.tools.map((tool) => tool.name);
     const rebuiltPrompts = await buildInitialToolUsePrompts(
       services.prompt,
       services.userVarChannels.transient,

--- a/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
@@ -100,9 +100,9 @@ describe('tool-use progress events', () => {
       runtimeHost: host,
       logger,
       modelHandler: { getClient: vi.fn() },
+      onRoundFinalized: () => {},
       config: { model: 'test-model', agent: 'test-agent' },
       setting: { tools: [] },
-      resolvedTools: [],
     } as unknown as ToolUseServices);
 
     try {
@@ -200,9 +200,9 @@ describe('tool-use round outcome persistence (#8023)', () => {
         runtimeHost: host,
         logger,
         modelHandler: { getClient: vi.fn() },
+        onRoundFinalized: () => {},
         config: { model: 'test-model', agent: 'test-agent' },
         setting: { tools: [] },
-        resolvedTools: [],
       } as unknown as ToolUseServices);
 
       try {

--- a/src/test-kernel/agent/followUp/ToolUseRoundFollowUpMedia.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseRoundFollowUpMedia.vitest.ts
@@ -13,7 +13,6 @@ import {
 import { MapToolRegistry } from '@agent/core/tools/ToolTypes';
 import type { ProviderMessage } from '@agent/types/ProviderMessage';
 import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import { withTestRunContext } from '../progressTestUtils';
 
 /**
@@ -30,10 +29,10 @@ function baseRoundServices(traceLabel: string) {
       createLocation: (filePath: string) => ({ absolutePath: filePath }),
     },
     logger: createRunTrace(traceLabel, StreamLogStore.ephemeral('test')).trace,
+    onRoundFinalized: () => {},
     prompt: { systemPrompt: '', userPrefix: '', userRequest: '' },
     run: AgentRunStateSnapshotSchema.parse({}),
     setAbortController: () => {},
-    streamStatus: new StreamStatusMachine(),
     userVarChannels: { input: {}, transient: {} },
     workspace: AgentWorkspaceState.create(),
   };

--- a/src/test-kernel/agent/followUp/ToolUseRoundPrepNodeFollowUpTranscriptLog.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseRoundPrepNodeFollowUpTranscriptLog.vitest.ts
@@ -20,6 +20,7 @@ function buildServices(
       capabilities: {},
     } as never,
     fileService: { createLocation: vi.fn() } as never,
+    onRoundFinalized: () => {},
     toolRegistry: {} as never,
     ...overrides,
   } as ToolUseRoundServices<unknown>;

--- a/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
@@ -22,7 +22,6 @@ import {
 } from '@agent/implementations/flows/tooluse/nodes/types';
 import type { ToolUseServices } from '@agent/implementations/flows/tooluse/ToolUseServices';
 import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
-import { defaultSession } from '@agent/runtime/SessionHandle';
 import { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import type { ProviderMessage } from '@agent/types/ProviderMessage';
 import {
@@ -50,11 +49,7 @@ type WaitNodeModelHandlerOverrides = Omit<
 type WaitNodeServiceOverrides = Partial<
   Pick<
     ToolUseServices,
-    | 'checkInterruption'
-    | 'isSubagent'
-    | 'onFollowUpConsumed'
-    | 'onIdle'
-    | 'streamStatus'
+    'checkInterruption' | 'isSubagent' | 'onFollowUpConsumed' | 'onIdle'
   >
 > & {
   fileService?: Partial<ToolUseServices['fileService']>;
@@ -84,12 +79,12 @@ function createWaitNodeServices(
       extractAssistantText: () => undefined,
       ...modelHandlerOverrides,
     },
+    onRoundFinalized: () => {},
     session: {
       hasQueuedFollowUp: () => false,
       waitForFollowUp: vi.fn(async () => null),
       ...session,
     },
-    streamStatus: new StreamStatusMachine(),
     ...topLevel,
   } as unknown as ToolUseServices;
 }
@@ -501,15 +496,17 @@ describe('ToolUseWaitNode', () => {
       session: {
         waitForFollowUp,
       },
-      streamStatus,
     });
     const node = new ToolUseWaitNode().setServices(services);
 
     try {
       seedStreamStatusForTest(streamStatus, streamId, STREAM_PHASE.RUNNING);
       const prep = await node.prep(shared);
-      const exec = await withTestRunContext(runtimeHost, streamId, () =>
-        node.exec(prep),
+      const exec = await withTestRunContext(
+        runtimeHost,
+        streamId,
+        () => node.exec(prep),
+        { sessionStatus: streamStatus },
       );
 
       expect(exec.kind).toBe('continue');
@@ -524,8 +521,11 @@ describe('ToolUseWaitNode', () => {
       expect(waitForFollowUp).not.toHaveBeenCalled();
       expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.RUNNING);
 
-      const transition = await withTestRunContext(runtimeHost, streamId, () =>
-        node.post(shared, prep, exec),
+      const transition = await withTestRunContext(
+        runtimeHost,
+        streamId,
+        () => node.post(shared, prep, exec),
+        { sessionStatus: streamStatus },
       );
 
       expect(transition).toBe(FlowTransition.CONTINUE);
@@ -701,7 +701,7 @@ describe('ToolUseWaitNode', () => {
     }
   });
 
-  it('updates the injected stream status owner while waiting and resuming', async () => {
+  it('updates the run session status owner while waiting and resuming', async () => {
     const streamId = 'wait-node-owner' as StreamTabId;
     const streamStatus = new StreamStatusMachine();
     const shared: ToolUseRunShared = toolUseRunShared();
@@ -717,38 +717,30 @@ describe('ToolUseWaitNode', () => {
           synthetic: true,
         }),
       },
-      streamStatus,
     });
     const node = new ToolUseWaitNode().setServices(services);
 
     try {
       seedStreamStatusForTest(streamStatus, streamId, STREAM_STATUS.RUNNING);
-      seedStreamStatusForTest(
-        defaultSession().status,
-        streamId,
-        STREAM_PHASE.CANCELLED,
-      );
-
       const prep = await node.prep(shared);
-      const exec = await withTestRunContext(runtimeHost, streamId, () =>
-        node.exec(prep),
+      const exec = await withTestRunContext(
+        runtimeHost,
+        streamId,
+        () => node.exec(prep),
+        { sessionStatus: streamStatus },
       );
       expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.WAITING);
-      expect(defaultSession().status.get(streamId)).toBe(
-        STREAM_PHASE.CANCELLED,
-      );
 
-      await withTestRunContext(runtimeHost, streamId, () =>
-        node.post(shared, prep, exec),
+      await withTestRunContext(
+        runtimeHost,
+        streamId,
+        () => node.post(shared, prep, exec),
+        { sessionStatus: streamStatus },
       );
       expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.RUNNING);
-      expect(defaultSession().status.get(streamId)).toBe(
-        STREAM_PHASE.CANCELLED,
-      );
       expect(createUserFollowUpMessages).toHaveBeenCalledOnce();
     } finally {
       clearStreamStatusForTest(streamStatus, streamId);
-      clearStreamStatusForTest(defaultSession().status, streamId);
     }
   });
 
@@ -772,19 +764,22 @@ describe('ToolUseWaitNode', () => {
       session: {
         waitForFollowUp,
       },
-      streamStatus,
     });
     const node = new ToolUseWaitNode().setServices(services);
 
     try {
       seedStreamStatusForTest(streamStatus, streamId, STREAM_PHASE.CANCELLED);
 
-      const exec = await withTestRunContext(runtimeHost, streamId, () =>
-        node.exec({
-          afterError: true,
-          lastResponse: undefined,
-          touchedFiles: [],
-        }),
+      const exec = await withTestRunContext(
+        runtimeHost,
+        streamId,
+        () =>
+          node.exec({
+            afterError: true,
+            lastResponse: undefined,
+            touchedFiles: [],
+          }),
+        { sessionStatus: streamStatus },
       );
 
       expect(exec.kind).toBe('stop');
@@ -866,7 +861,6 @@ describe('ToolUseWaitNode', () => {
           synthetic: false,
         }),
       },
-      streamStatus,
     });
     const node = new ToolUseWaitNode().setServices(services);
     seedStreamStatusForTest(streamStatus, streamId, STREAM_PHASE.WAITING);
@@ -880,6 +874,7 @@ describe('ToolUseWaitNode', () => {
           const exec = await node.exec(prep);
           return node.post(shared, prep, exec);
         },
+        { sessionStatus: streamStatus },
       );
 
       expect(transition).toBe(FlowTransition.CONTINUE);

--- a/src/test-kernel/agent/followUp/ToolUseWaitNodeFollowUpTranscriptLog.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNodeFollowUpTranscriptLog.vitest.ts
@@ -14,14 +14,20 @@ function buildServices(
   overrides: Partial<ToolUseServices<unknown>> = {},
 ): ToolUseServices<unknown> {
   return {
-    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    logger: {
+      debug: vi.fn(),
+      emit: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
     modelHandler: {
       createUserFollowUpMessages: vi.fn(async (messages) => messages),
       addMediaToUserMessage: vi.fn(async () => []),
       capabilities: {},
     } as never,
     fileService: { createLocation: vi.fn() } as never,
-    streamStatus: { transition: vi.fn() } as never,
+    onRoundFinalized: () => {},
     ...overrides,
   } as ToolUseServices<unknown>;
 }

--- a/src/test-kernel/agent/progressTestUtils.ts
+++ b/src/test-kernel/agent/progressTestUtils.ts
@@ -26,6 +26,7 @@ import type {
   SessionFact,
 } from '@agent/runtime/SessionEventHub';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
+import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import { createSessionApprovals } from '@agent/runtime/streamApprovalQueue';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 
@@ -359,12 +360,14 @@ export function createRecordingHost(): {
  */
 export function sessionWithInteractions(
   interactions: HostInteractions | undefined,
+  status = new StreamStatusMachine(),
 ): SessionHandle {
   const owner = new SessionHostInteractions();
   if (interactions) owner.use(interactions);
   return {
     interactions: owner,
     approvals: createSessionApprovals(),
+    status,
   } as unknown as SessionHandle;
 }
 
@@ -383,6 +386,7 @@ export function withTestRunContext<T>(
   options: {
     approvalPromptsUnavailable?: boolean;
     runtimeUnavailableTools?: readonly string[];
+    sessionStatus?: StreamStatusMachine;
     stopAfterCycle?: boolean;
   } = {},
 ): Promise<T> {
@@ -393,11 +397,16 @@ export function withTestRunContext<T>(
         streamId: streamId as StreamTabId,
         executionId: 'deadbeef' as ExecutionId,
         agentName: 'test-agent',
-        session: sessionWithInteractions(interactionsByHost.get(runtimeHost)),
+        session: sessionWithInteractions(
+          interactionsByHost.get(runtimeHost),
+          options.sessionStatus,
+        ),
       }),
       modelSource: 'live',
       getModel: () => undefined,
-      ...options,
+      approvalPromptsUnavailable: options.approvalPromptsUnavailable,
+      runtimeUnavailableTools: options.runtimeUnavailableTools,
+      stopAfterCycle: options.stopAfterCycle,
     }),
     fn,
   ) as Promise<T>;

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -24,7 +24,7 @@ import type {
 } from '@agent/runtime/HostInteractions';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { createRunScope } from '@agent/runtime/RunScope';
-import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
+import { SessionHandle } from '@agent/runtime/SessionHandle';
 import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import {
   noopAgentRuntimeHost,
@@ -50,7 +50,6 @@ interface TestRetryServices {
   config: { model: string };
   streamId: StreamTabId;
   runtimeHost: AgentRuntimeHost;
-  streamStatus: StreamStatusMachine;
   logger: AgentTrace;
   setAbortController: (ac: AbortController | null) => void;
 }
@@ -85,7 +84,6 @@ function createRetryNode(streamId: StreamTabId): RetryNodeKit {
     config: { model: 'copilot:sonnet46' },
     streamId,
     runtimeHost: noopAgentRuntimeHost,
-    streamStatus,
     logger: noopTrace,
     setAbortController: vi.fn(),
   });
@@ -94,6 +92,7 @@ function createRetryNode(streamId: StreamTabId): RetryNodeKit {
 
 async function withRetryRunContext<T>(
   streamId: StreamTabId,
+  streamStatus: StreamStatusMachine,
   requestRetry: RetryNodeKit['requestRetry'],
   fn: () => T | Promise<T>,
 ): Promise<T> {
@@ -105,10 +104,13 @@ async function withRetryRunContext<T>(
       streamId,
       executionId: `${streamId}-execution` as ExecutionId,
       agentName: 'retry-test',
-      session: sessionWithInteractions({
-        requestRetry,
-        cancel: () => {},
-      }),
+      session: sessionWithInteractions(
+        {
+          requestRetry,
+          cancel: () => {},
+        },
+        streamStatus,
+      ),
     }),
   });
   return await withRunContext(context, fn);
@@ -234,7 +236,7 @@ describe('RetryState', () => {
     expect(node.shouldAutoRetry(overflow)).toBe(false);
   });
 
-  it('updates the injected stream status owner during manual retry', async () => {
+  it('updates the run session status owner during manual retry', async () => {
     const streamId = 'retry-state-owner' as StreamTabId;
     const { node, streamStatus, requestRetry } = createRetryNode(streamId);
 
@@ -242,20 +244,11 @@ describe('RetryState', () => {
 
     try {
       seedStreamStatusForTest(streamStatus, streamId, STREAM_STATUS.RUNNING);
-      seedStreamStatusForTest(
-        defaultSession().status,
-        streamId,
-        STREAM_PHASE.CANCELLED,
-      );
-
-      await withRetryRunContext(streamId, requestRetry, () =>
+      await withRetryRunContext(streamId, streamStatus, requestRetry, () =>
         node.promptFor(new Error('temporary provider failure')),
       );
 
       expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.RUNNING);
-      expect(defaultSession().status.get(streamId)).toBe(
-        STREAM_PHASE.CANCELLED,
-      );
       expect(requestRetry).toHaveBeenCalledWith(
         expect.objectContaining({
           streamId,
@@ -266,7 +259,6 @@ describe('RetryState', () => {
       );
     } finally {
       clearStreamStatusForTest(streamStatus, streamId);
-      clearStreamStatusForTest(defaultSession().status, streamId);
     }
   });
 
@@ -275,10 +267,10 @@ describe('RetryState', () => {
     const session = createTestSession();
     const recording = createRecordingHost();
     session.useHostInteractions(recording.interactions);
-    const { node, streamStatus } = createRetryNode(streamId);
+    const { node } = createRetryNode(streamId);
 
     try {
-      seedStreamStatusForTest(streamStatus, streamId, STREAM_STATUS.RUNNING);
+      seedStreamStatusForTest(session.status, streamId, STREAM_STATUS.RUNNING);
 
       const prompt = withSessionRetryRunContext(
         streamId,
@@ -298,10 +290,9 @@ describe('RetryState', () => {
         shouldRetry: true,
         userCancelled: false,
       });
-      expect(streamStatus.get(streamId)).toBe(STREAM_STATUS.RUNNING);
+      expect(session.status.get(streamId)).toBe(STREAM_STATUS.RUNNING);
     } finally {
       session.dispose();
-      clearStreamStatusForTest(streamStatus, streamId);
     }
   });
 
@@ -316,7 +307,7 @@ describe('RetryState', () => {
       try {
         seedStreamStatusForTest(streamStatus, streamId, STREAM_STATUS.RUNNING);
 
-        await withRetryRunContext(streamId, requestRetry, () =>
+        await withRetryRunContext(streamId, streamStatus, requestRetry, () =>
           node.promptFor(new Error('temporary provider failure')),
         );
 
@@ -342,6 +333,7 @@ describe('RetryState', () => {
 
       const shouldRetry = await withRetryRunContext(
         streamId,
+        streamStatus,
         requestRetry,
         () => node.retryPrompt(undefined, error),
       );

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -45,7 +45,6 @@ import * as toolUseFollowUp from '@agent/followUp/ToolUseFollowUp';
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/openai/modelHandlerOpenAIResponse';
 import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { defaultSession } from '@agent/runtime/SessionHandle';
-import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 // Type imports
 import type { ProviderMessage } from '@agent/types/ProviderMessage';
 import type { SdkToolCall } from '@agent/types/ModelHandlerContracts';
@@ -187,12 +186,12 @@ function roundServices(opts: {
     } satisfies AgentPrompt,
     userVarChannels: { input: {}, transient: {} },
     logger: opts.logger,
-    streamStatus: new StreamStatusMachine(),
     client: {} as OpenAI,
     fileService: new TaskRunFileService('deadbeef'),
     toolRegistry: opts.toolRegistry,
     checkInterruption: opts.checkInterruption ?? (() => false),
     setAbortController: opts.setAbortController ?? (() => {}),
+    onRoundFinalized: () => {},
     run: AgentRunStateSnapshotSchema.parse({}),
     workspace: AgentWorkspaceState.create(),
   };


### PR DESCRIPTION
## Summary

- Remove the duplicate flow-bag `streamStatus` channel; retry and wait nodes now read the authoritative launch-session status through the existing run context.
- Remove the response-cycle `bestConnectionMethod` service field and injector; the response flow calls the canonical runtime function directly.
- Require `onRoundFinalized` in the shared flow contract and remove both no-op defaults, both redundant redeclarations, and both optional-call guards.
- Store resolved tool definitions once in `setting.tools`, deleting `ToolUseServices.resolvedTools` and the per-cycle respread.

The documented outside-ALS host surfaces remain unchanged. The change is internal and behavior-preserving; no changelog entry is warranted.

## Design

The flow service bags now carry only state that is not already authoritative in the ambient launch context. Tests that invoke nodes directly install their status machine on the fake run session, matching production and eliminating the test-only possibility of divergent session and service-bag status owners.

## Net LoC

- Total: **+105 / -136 = -31**
- Production: **+23 / -54 = -31**
- Tests: **+82 / -82 = 0**
- Relocations counted as deletions: **0**

## Verification

- `npm run format`
- `npm run typecheck`
- `npm run lint` — 0 errors; 1 pre-existing warning
- `npm run check:dead-code-ratchet` — 228 current / 228 baseline
- `npm run compile:fast`
- Targeted Vitest: 15 suites, 121 tests passed
- Full Vitest: 736 files passed, 1 skipped; 6,789 tests passed, 4 skipped
- Read-only code-simplifier pass: no further changes warranted
- Consumer greps covered `.ts`, `.tsx`, `.mts`, and `.cts`

Closes #8749

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches retry UI, WAITING/resume stream phases, and mandatory round-finalization across tool-use and reflection flows; behavior is intended to be equivalent but regressions would show up as wrong stream status or missed usage accounting.
> 
> **Overview**
> **Tightens flow service bags** so they no longer duplicate state that already lives on the launch run context.
> 
> **Stream status** is removed from `BaseFlowContextInit`, retry nodes, and `executeAgent` wiring. Manual retry and tool-use wait/resume paths now drive transitions through `runScope.session.status` instead of a separately injected `streamStatus`.
> 
> **Response cycle** drops the `bestConnectionMethod` service hook; `ResponseCycleFlow` imports and calls the runtime helper directly.
> 
> **Round finalization** is required on `BaseFlowContextInit`: optional `onRoundFinalized`, no-op defaults, and `?.` guards are removed so usage recording always runs through the shared callback supplied at launch.
> 
> **Tool-use** stores resolved tools only on `setting.tools` (merged in `runToolUseFlow`); `resolvedTools` and per-cycle `{ ...setting, tools: resolvedTools }` respreads in cycle/prepare nodes go away.
> 
> Tests that invoke nodes without full launch wiring pass `onRoundFinalized` and attach `sessionStatus` on the fake run session via `withTestRunContext` / `sessionWithInteractions`, matching production’s single status owner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2825b701350d71621432dc7e96f9d4e1513ef02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->