### PR TITLE
refactor(ui): simplify state ownership

### DIFF
--- a/docs/proposals/cli-child-stream-state-consolidation.md
+++ b/docs/proposals/cli-child-stream-state-consolidation.md
@@ -227,40 +227,39 @@ Use one signal-backed map in the existing CLI state area. The exact private help
 owned shape is:
 
 ```typescript
-export interface ChildStreamEntry {
-  /** Latest roster metadata, excluding identity and status. */
-  readonly summary?: Omit<SubagentChildInfo, 'childStreamId' | 'status'>;
-
-  /** Parent whose latest roster includes this child. */
-  readonly activeParentStreamId?: StreamTabId;
-
-  /** Parent under which the child first acquired a retained row. */
-  readonly retainedParentStreamId?: StreamTabId;
-  /** One-based, first-seen order within retainedParentStreamId. */
-  readonly retainedOrder?: number;
-
-  /**
-   * undefined: no explicit edge fact observed; use retained parent provisionally
-   * string: explicit current parent
-   * null: explicitly promoted to top-level
-   */
-  readonly edgeParentStreamId?: StreamTabId | null;
-
-  /** Explicit removeStream tombstone for this session-scoped stream identity. */
-  readonly removed: boolean;
+interface RetainedParent {
+  readonly streamId: StreamTabId;
+  readonly order: number;
 }
+
+type ParentProvenance =
+  | { readonly kind: 'roster'; readonly retained: RetainedParent }
+  | {
+      readonly kind: 'explicit';
+      readonly streamId: StreamTabId | null;
+      readonly retained?: RetainedParent;
+    };
+
+type ChildStreamEntry =
+  | {
+      readonly kind: 'live';
+      readonly summary?: Omit<SubagentChildInfo, 'childStreamId' | 'status'>;
+      readonly active: boolean;
+      readonly parent?: ParentProvenance;
+    }
+  | { readonly kind: 'removed' };
 
 const CHILD_STREAMS = signal<ReadonlyMap<StreamTabId, ChildStreamEntry>>(
   new Map(),
 );
 ```
 
-The map key is normally the child identity; `ChildStreamEntry` does not repeat `childStreamId`. The map may also
-hold a minimal tombstone for a removed parent-only stream. This keeps child-removal and parent-removal authority in
-the same collection instead of adding a second mutable `removedStreams` set. No field stores lifecycle status. No
-non-tombstone entry is created merely because a root or child stream is attached.
+The map key is normally the child identity; `ChildStreamEntry` does not repeat `childStreamId`. The `kind`
+discriminant prevents a removal tombstone from carrying stale live fields, while `ParentProvenance.kind` makes
+roster-vs-explicit authority structural instead of inferred from overlapping optional fields. The map may also
+hold a minimal tombstone for a removed parent-only stream. No field stores lifecycle status.
 
-`retainedOrder` is one-based and monotonic within each retained parent. For one roster batch, compute the
+`RetainedParent.order` is one-based and monotonic within each retained parent. For one roster batch, compute the
 pre-existing maximum (zero when there are no retained children), then assign `max + 1`, `max + 2`, and so on to
 previously unretained accepted children in payload order. Existing children keep their original values. The
 maximum is computed from the map during the uncommon insertion transition, so no second mutable order counter is
@@ -277,30 +276,26 @@ All former views are computed from `CHILD_STREAMS` and, where status or existenc
 
 ### Effective parent
 
-For a non-removed entry, first choose a candidate parent:
-
-1. a string `edgeParentStreamId` is the current parent;
-2. `null` means no parent; and
-3. `undefined` falls back to `retainedParentStreamId`, which is the provisional parent learned from a roster.
+For a live entry, `parent.kind` selects authority directly: an explicit parent id is current, explicit `null`
+means no parent, and a roster parent uses `parent.retained.streamId` provisionally.
 
 If the candidate parent has a removal tombstone, return no parent. This precedence preserves roster-before-edge,
 prevents a late roster from reversing promotion, and prevents late child facts from reviving a removed parent.
 
 ### Active subagents for a parent
 
-Return an empty result when the requested parent is tombstoned. Otherwise, select entries whose
-`activeParentStreamId` equals the requested parent and whose effective parent is that same parent. Require
-`summary`. Reconstruct `SubagentChildInfo` by adding the map key as `childStreamId` and reading `status` from
-`streams.get(childStreamId)?.status`.
+Return an empty result when the requested parent is tombstoned. Otherwise, select live entries whose `active`
+flag is true and whose effective parent is the requested parent. Require `summary`. Reconstruct
+`SubagentChildInfo` by adding the map key as `childStreamId` and reading status from the child stream.
 
 The active selector, not status, determines whether a control is killable. A terminal status that arrives after
 roster removal cannot make a retained child active again.
 
 ### Retained child streams for a parent
 
-Return an empty result when the requested parent is tombstoned. Otherwise, select non-removed entries whose
-`retainedParentStreamId` equals the requested parent, require `summary`, and sort by `retainedOrder`. Reconstruct
-each row with status from the child `StreamSlice`.
+Return an empty result when the requested parent is tombstoned. Otherwise, select live entries whose nested
+retained parent names the requested parent, require `summary`, and sort by its `order`. Reconstruct each row with
+status from the child `StreamSlice`.
 
 Promotion does not erase this historical row. Explicit removal of the child or parent does.
 
@@ -344,17 +339,15 @@ is never stored in `ChildStreamEntry`.
 For `child.activity(kind: 'subagents', parentStreamId, children)`:
 
 1. If the payload parent is tombstoned, ignore the snapshot. Late facts cannot recreate a removed parent.
-2. Accept an included child only when neither child nor parent is tombstoned and the child's explicit edge is
-   either absent or equal to the payload parent. Explicit `null` and an explicit different parent make the row
-   incompatible.
+2. Accept an included child only when neither child nor parent is tombstoned and its effective parent is absent or
+   equals the payload parent. Promotion and a different roster- or edge-derived parent make the row incompatible.
 3. Treat the accepted children as the complete active-membership snapshot for that parent at this hub position.
-   Clear `activeParentStreamId` for entries previously active under that parent but absent or incompatible.
+   Clear `active` for entries currently parented there but absent or incompatible.
 4. For each accepted child, update `summary` after removing `childStreamId` and `status`.
-5. Set `activeParentStreamId` to the payload parent.
-6. On the first accepted roster observation, set `retainedParentStreamId` and append `retainedOrder` in payload
-   order.
-7. Do not write `edgeParentStreamId`. A roster supplies provisional topology only through the effective-parent
-   fallback.
+5. Set `active` true.
+6. On the first accepted roster observation, attach a `RetainedParent` in payload order. When no explicit edge
+   exists, store it in the roster-provenance arm; otherwise preserve explicit provenance and add retained history.
+7. Never replace explicit provenance from a roster.
 8. Discard the roster's copied `status` for TUI state. The independently delivered lifecycle transition updates
    the child `StreamSlice`; until it arrives, a derived row may have an undefined status.
 
@@ -366,8 +359,8 @@ from overwriting a newer lifecycle event and leaves exactly one TUI status owner
 For `setParentStream(child, parent)`:
 
 - upsert an entry even if metadata is not yet known;
-- set `edgeParentStreamId` to the parent id or `null`;
-- clear `activeParentStreamId` when it names a different parent;
+- replace parent provenance with `{ kind: 'explicit', streamId: parent }`;
+- clear `active` when the previous effective parent differs;
 - never delete retained metadata or retained order; and
 - ignore the fact while the child is tombstoned by `removeStream`, or while a non-null parent is tombstoned.
 
@@ -412,7 +405,7 @@ explicitly removed.
 
 For the sequence `edge(parent) -> roster(parent, child) -> edge(null) -> late roster(parent, child)`:
 
-- `edgeParentStreamId` remains `null`;
+- explicit parent provenance remains `null`;
 - the effective parent remains absent;
 - the incompatible late roster cannot change active membership or summary metadata;
 - the historical row remains under the former parent; and
@@ -423,14 +416,14 @@ non-killable historical task row.
 
 For `edge(newParent) -> roster(newParent, child) -> late roster(oldParent, child)`, the explicit new edge makes the
 old-parent row incompatible. The child remains active under the new parent, and the late old-parent roster cannot
-overwrite its summary or `activeParentStreamId`.
+overwrite its summary or active membership.
 
 ### Explicit removal and parent removal
 
 For `removeStream(stream)`:
 
 - delete the stream's `StreamSlice` and clear active focus as today;
-- replace any map entry, or create a parent-only entry, with a minimal `removed: true` tombstone;
+- replace any map entry, or create a parent-only entry, with `{ kind: 'removed' }`;
 - exclude the tombstone from every selector; and
 - ignore every later roster, edge, attachment, and status fact for that stream id.
 

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -100,8 +100,9 @@ export function sessionHeaderIdentityLine(
       streamId: context.streamId,
       streams: context.streams,
     });
-    const toolName = context.childStreamEntries?.get(context.streamId)?.summary
-      ?.toolName;
+    const childEntry = context.childStreamEntries?.get(context.streamId);
+    const toolName =
+      childEntry?.kind === 'live' ? childEntry.summary?.toolName : undefined;
     const streamKind =
       toolName === DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME
         ? 'workflow script'

--- a/packages/cli/src/chat/tui/state/childExecutions.ts
+++ b/packages/cli/src/chat/tui/state/childExecutions.ts
@@ -20,30 +20,42 @@ import type {
 
 import type { StreamSlice } from './cliState';
 
-/**
- * One child stream's relationship state. Also doubles as a minimal removal
- * tombstone (`removed: true`, every other field absent) for a stream
- * identity — child or parent — that must never be resurrected by a later
- * fact.
- */
-export interface ChildStreamEntry {
+interface RetainedParent {
+  readonly streamId: StreamTabId;
+  /** One-based, first-seen order within `streamId`. */
+  readonly order: number;
+}
+
+type ParentProvenance =
+  | {
+      /** No explicit edge fact yet; the first roster owns current topology. */
+      readonly kind: 'roster';
+      readonly retained: RetainedParent;
+    }
+  | {
+      /** Explicit edge wins; null means promotion to top level. */
+      readonly kind: 'explicit';
+      readonly streamId: StreamTabId | null;
+      /** Historical first-roster placement, independent of current topology. */
+      readonly retained?: RetainedParent;
+    };
+
+interface LiveChildStreamEntry {
+  readonly kind: 'live';
   /** Latest roster metadata, excluding identity and status. */
   readonly summary?: Omit<SubagentChildInfo, 'childStreamId' | 'status'>;
-  /** Parent whose latest roster includes this child. */
-  readonly activeParentStreamId?: StreamTabId;
-  /** Parent under which the child first acquired a retained row. */
-  readonly retainedParentStreamId?: StreamTabId;
-  /** One-based, first-seen order within `retainedParentStreamId`. */
-  readonly retainedOrder?: number;
-  /**
-   * `undefined`: no explicit edge fact observed; use the retained parent
-   * provisionally. A string is the explicit current parent. `null` means
-   * explicitly promoted to top-level.
-   */
-  readonly edgeParentStreamId?: StreamTabId | null;
-  /** Explicit `removeStream` tombstone for this session-scoped identity. */
-  readonly removed: boolean;
+  /** Whether the current parent roster still includes this child. */
+  readonly active: boolean;
+  /** Current topology and its authority, plus optional retained history. */
+  readonly parent?: ParentProvenance;
 }
+
+interface RemovedChildStreamEntry {
+  readonly kind: 'removed';
+}
+
+/** One live child relationship or an explicit removal tombstone. */
+export type ChildStreamEntry = LiveChildStreamEntry | RemovedChildStreamEntry;
 
 export type ChildStreamEntries = ReadonlyMap<StreamTabId, ChildStreamEntry>;
 
@@ -64,7 +76,7 @@ export const subagentExecutionLabels: Signal.Computed<
 > = computed(() => {
   const labels = new Map<string, string>();
   for (const entry of CHILD_STREAMS.get().values()) {
-    if (entry.removed || !entry.summary) continue;
+    if (entry.kind === 'removed' || !entry.summary) continue;
     const label = childExecutionLabel(entry.summary);
     if (label !== entry.summary.executionId) {
       labels.set(entry.summary.executionId, label);
@@ -73,12 +85,20 @@ export const subagentExecutionLabels: Signal.Computed<
   return labels;
 });
 
-function candidateParent(
-  entry: ChildStreamEntry,
+function retainedParent(
+  entry: LiveChildStreamEntry | undefined,
+): RetainedParent | undefined {
+  if (!entry?.parent) return undefined;
+  return entry.parent.retained;
+}
+
+function currentParent(
+  entry: LiveChildStreamEntry | undefined,
 ): StreamTabId | null | undefined {
-  return entry.edgeParentStreamId !== undefined
-    ? entry.edgeParentStreamId
-    : entry.retainedParentStreamId;
+  if (!entry?.parent) return undefined;
+  return entry.parent.kind === 'explicit'
+    ? entry.parent.streamId
+    : entry.parent.retained.streamId;
 }
 
 /**
@@ -92,10 +112,10 @@ function effectiveParentFromEntries(
   entries: ChildStreamEntries,
 ): StreamTabId | undefined {
   const entry = entries.get(childStreamId);
-  if (!entry || entry.removed) return undefined;
-  const candidate = candidateParent(entry);
+  if (!entry || entry.kind === 'removed') return undefined;
+  const candidate = currentParent(entry);
   if (!candidate) return undefined;
-  if (entries.get(candidate)?.removed) return undefined;
+  if (entries.get(candidate)?.kind === 'removed') return undefined;
   return candidate;
 }
 
@@ -119,7 +139,7 @@ export const parentStream: Signal.Computed<
 
 /** Whether a stream identity (child or parent) carries a removal tombstone. */
 export function isChildStreamRemoved(streamId: StreamTabId): boolean {
-  return CHILD_STREAMS.get().get(streamId)?.removed === true;
+  return CHILD_STREAMS.get().get(streamId)?.kind === 'removed';
 }
 
 export function resetChildStreamEntries(): void {
@@ -143,18 +163,30 @@ export function setParentStream(
   if (parentStreamId === undefined) return;
   const current = CHILD_STREAMS.get();
   const entry = current.get(childStreamId);
-  if (entry?.removed) return;
-  if (parentStreamId !== null && current.get(parentStreamId)?.removed) return;
-  if (entry?.edgeParentStreamId === parentStreamId) return;
+  if (entry?.kind === 'removed') return;
+  if (
+    parentStreamId !== null &&
+    current.get(parentStreamId)?.kind === 'removed'
+  ) {
+    return;
+  }
+  if (
+    entry?.parent?.kind === 'explicit' &&
+    entry.parent.streamId === parentStreamId
+  ) {
+    return;
+  }
 
-  const nextActiveParentStreamId =
-    entry?.activeParentStreamId === parentStreamId
-      ? entry.activeParentStreamId
-      : undefined;
-  const next: ChildStreamEntry = {
-    ...(entry ?? { removed: false }),
-    edgeParentStreamId: parentStreamId,
-    activeParentStreamId: nextActiveParentStreamId,
+  const live = entry ?? { kind: 'live', active: false };
+  const retained = retainedParent(live);
+  const next: LiveChildStreamEntry = {
+    ...live,
+    parent: {
+      kind: 'explicit',
+      streamId: parentStreamId,
+      ...(retained && { retained }),
+    },
+    active: live.active && currentParent(live) === parentStreamId,
   };
   const out = new Map(current);
   out.set(childStreamId, next);
@@ -165,8 +197,8 @@ export function setParentStream(
  *  spurious `changed` on a same-content roster snapshot the runtime resends
  *  as a fresh array/object on every poll. */
 function summaryUnchanged(
-  a: ChildStreamEntry['summary'],
-  b: ChildStreamEntry['summary'],
+  a: LiveChildStreamEntry['summary'],
+  b: LiveChildStreamEntry['summary'],
 ): boolean {
   if (a === b) return true;
   if (!a || !b) return false;
@@ -179,18 +211,15 @@ function summaryUnchanged(
   );
 }
 
-/** Whether applying `nextEntry` over `entry` would be a no-op — compares only
- *  the fields `applySubagentRoster` itself writes (summary, active/retained
- *  parent, retained order), never `edgeParentStreamId`/`removed`. */
+/** Whether applying `nextEntry` over `entry` would be a no-op. */
 function subagentEntryUnchanged(
-  entry: ChildStreamEntry | undefined,
-  nextEntry: ChildStreamEntry,
+  entry: LiveChildStreamEntry | undefined,
+  nextEntry: LiveChildStreamEntry,
 ): boolean {
   return (
     entry !== undefined &&
-    entry.activeParentStreamId === nextEntry.activeParentStreamId &&
-    entry.retainedParentStreamId === nextEntry.retainedParentStreamId &&
-    entry.retainedOrder === nextEntry.retainedOrder &&
+    entry.active === nextEntry.active &&
+    entry.parent === nextEntry.parent &&
     summaryUnchanged(entry.summary, nextEntry.summary)
   );
 }
@@ -207,7 +236,7 @@ export function applySubagentRoster(
   children: readonly ActiveChildInfo[],
 ): void {
   const current = CHILD_STREAMS.get();
-  if (current.get(parentStreamId)?.removed) return;
+  if (current.get(parentStreamId)?.kind === 'removed') return;
 
   const subagents = children.filter(
     (child): child is SubagentChildInfo => child.kind === 'subagent',
@@ -216,20 +245,18 @@ export function applySubagentRoster(
   const accepted = new Map<StreamTabId, SubagentChildInfo>();
   for (const child of subagents) {
     const entry = current.get(child.childStreamId);
-    if (entry?.removed) continue;
-    const edge = entry?.edgeParentStreamId;
-    if (edge !== undefined && edge !== parentStreamId) continue;
+    if (entry?.kind === 'removed') continue;
+    const parent = currentParent(entry);
+    if (parent !== undefined && parent !== parentStreamId) continue;
     accepted.set(child.childStreamId, child);
   }
 
   let maxRetainedOrder = 0;
   for (const entry of current.values()) {
-    if (
-      entry.retainedParentStreamId === parentStreamId &&
-      entry.retainedOrder !== undefined &&
-      entry.retainedOrder > maxRetainedOrder
-    ) {
-      maxRetainedOrder = entry.retainedOrder;
+    if (entry.kind === 'removed') continue;
+    const retained = retainedParent(entry);
+    if (retained?.streamId === parentStreamId) {
+      maxRetainedOrder = Math.max(maxRetainedOrder, retained.order);
     }
   }
 
@@ -239,28 +266,44 @@ export function applySubagentRoster(
   // Clear active membership for entries previously active under this parent
   // but absent or incompatible with this snapshot.
   for (const [childStreamId, entry] of current) {
-    if (entry.activeParentStreamId !== parentStreamId) continue;
+    if (
+      entry.kind === 'removed' ||
+      !entry.active ||
+      currentParent(entry) !== parentStreamId
+    ) {
+      continue;
+    }
     if (accepted.has(childStreamId)) continue;
-    out.set(childStreamId, { ...entry, activeParentStreamId: undefined });
+    out.set(childStreamId, { ...entry, active: false });
     changed = true;
   }
 
   for (const [childStreamId, child] of accepted) {
-    const entry = out.get(childStreamId);
+    const currentEntry = out.get(childStreamId);
+    const entry = currentEntry?.kind === 'live' ? currentEntry : undefined;
     const {
       childStreamId: _childStreamId,
       status: _status,
       ...summary
     } = child;
-    const isFirstRetained = entry?.retainedParentStreamId === undefined;
-    const nextEntry: ChildStreamEntry = {
-      ...(entry ?? { removed: false }),
+    const existingRetained = retainedParent(entry);
+    const retained =
+      existingRetained ??
+      ({
+        streamId: parentStreamId,
+        order: ++maxRetainedOrder,
+      } satisfies RetainedParent);
+    let parent = entry?.parent;
+    if (!parent) {
+      parent = { kind: 'roster', retained };
+    } else if (parent.kind === 'explicit' && !parent.retained) {
+      parent = { ...parent, retained };
+    }
+    const nextEntry: LiveChildStreamEntry = {
+      ...(entry ?? { kind: 'live' as const }),
       summary,
-      activeParentStreamId: parentStreamId,
-      retainedParentStreamId: entry?.retainedParentStreamId ?? parentStreamId,
-      retainedOrder: isFirstRetained
-        ? ++maxRetainedOrder
-        : entry?.retainedOrder,
+      active: true,
+      parent,
     };
     if (subagentEntryUnchanged(entry, nextEntry)) continue;
     out.set(childStreamId, nextEntry);
@@ -280,25 +323,39 @@ export function applySubagentRoster(
 export function applyChildStreamRemoval(streamId: StreamTabId): void {
   const current = CHILD_STREAMS.get();
   const out = new Map(current);
-  out.set(streamId, { removed: true });
+  out.set(streamId, { kind: 'removed' });
 
   for (const [childStreamId, entry] of current) {
-    if (childStreamId === streamId || entry.removed) continue;
-    let next = entry;
-    if (next.activeParentStreamId === streamId) {
-      next = { ...next, activeParentStreamId: undefined };
+    if (childStreamId === streamId || entry.kind === 'removed') continue;
+    const beforeParent = currentParent(entry);
+    const retained = retainedParent(entry);
+    const nextRetained = retained?.streamId === streamId ? undefined : retained;
+    let parent = entry.parent;
+    if (parent?.kind === 'roster' && !nextRetained) {
+      parent = { kind: 'explicit', streamId: null };
+    } else if (parent?.kind === 'explicit') {
+      const streamIdValue =
+        parent.streamId === streamId ? null : parent.streamId;
+      if (
+        streamIdValue !== parent.streamId ||
+        nextRetained !== parent.retained
+      ) {
+        parent = {
+          kind: 'explicit',
+          streamId: streamIdValue,
+          ...(nextRetained && { retained: nextRetained }),
+        };
+      }
     }
-    if (next.retainedParentStreamId === streamId) {
-      next = {
-        ...next,
-        retainedParentStreamId: undefined,
-        retainedOrder: undefined,
-      };
+    const active = beforeParent === streamId ? false : entry.active;
+    const next: LiveChildStreamEntry = {
+      ...entry,
+      active,
+      parent,
+    };
+    if (active !== entry.active || parent !== entry.parent) {
+      out.set(childStreamId, next);
     }
-    if (next.edgeParentStreamId === streamId) {
-      next = { ...next, edgeParentStreamId: null };
-    }
-    if (next !== entry) out.set(childStreamId, next);
   }
 
   CHILD_STREAMS.set(out);
@@ -310,7 +367,7 @@ export function applyChildStreamRemoval(streamId: StreamTabId): void {
 
 function reconstruct(
   childStreamId: StreamTabId,
-  entry: ChildStreamEntry,
+  entry: LiveChildStreamEntry,
   streams: ReadonlyMap<StreamTabId, Pick<StreamSlice, 'status'>>,
 ): SubagentChildInfo | undefined {
   if (!entry.summary) return undefined;
@@ -334,10 +391,10 @@ export function activeSubagentsFor(
   entries: ChildStreamEntries,
   streams: ReadonlyMap<StreamTabId, Pick<StreamSlice, 'status'>>,
 ): readonly SubagentChildInfo[] {
-  if (entries.get(parentStreamId)?.removed) return [];
+  if (entries.get(parentStreamId)?.kind === 'removed') return [];
   const out: SubagentChildInfo[] = [];
   for (const [childStreamId, entry] of entries) {
-    if (entry.removed || entry.activeParentStreamId !== parentStreamId) {
+    if (entry.kind === 'removed' || !entry.active) {
       continue;
     }
     if (effectiveParentFromEntries(childStreamId, entries) !== parentStreamId) {
@@ -359,14 +416,16 @@ export function retainedChildStreamsFor(
   entries: ChildStreamEntries,
   streams: ReadonlyMap<StreamTabId, Pick<StreamSlice, 'status'>>,
 ): readonly SubagentChildInfo[] {
-  if (entries.get(parentStreamId)?.removed) return [];
+  if (entries.get(parentStreamId)?.kind === 'removed') return [];
   const rows: Array<{ order: number; info: SubagentChildInfo }> = [];
   for (const [childStreamId, entry] of entries) {
-    if (entry.removed || entry.retainedParentStreamId !== parentStreamId) {
+    if (entry.kind === 'removed') {
       continue;
     }
+    const retained = retainedParent(entry);
+    if (retained?.streamId !== parentStreamId) continue;
     const info = reconstruct(childStreamId, entry, streams);
-    if (info) rows.push({ order: entry.retainedOrder ?? 0, info });
+    if (info) rows.push({ order: retained.order, info });
   }
   rows.sort((left, right) => left.order - right.order);
   return rows.map((row) => row.info);
@@ -420,7 +479,7 @@ export function focusOrderDescendants(
     out.push(child.childStreamId);
   }
   for (const [childStreamId, entry] of entries) {
-    if (entry.removed || seen.has(childStreamId)) continue;
+    if (entry.kind === 'removed' || seen.has(childStreamId)) continue;
     if (effectiveParentFromEntries(childStreamId, entries) !== parentStreamId) {
       continue;
     }

--- a/packages/extension/src/progressView/frontend/components/messageIndex.ts
+++ b/packages/extension/src/progressView/frontend/components/messageIndex.ts
@@ -12,6 +12,13 @@ export type TimelineEntry =
   | { key: string; time: number; msg: LogMessageData }
   | { key: string; time: number; tree: GroupTree };
 
+type MessageTimelineEntry = Extract<TimelineEntry, { msg: LogMessageData }>;
+
+interface MessageLocation {
+  ungroupedIndex?: number;
+  timelineEntry?: MessageTimelineEntry;
+}
+
 /**
  * Owns the derived data structures for the non-terminal render path:
  * the hierarchical group tree, the ungrouped message list, the interleaved
@@ -23,14 +30,11 @@ export class MessageIndex {
   ungrouped: LogMessageData[] = [];
   timeline: TimelineEntry[] = [];
 
-  private ungroupedById = new Map<string, LogMessageData>();
-  private ungroupedIndex = new Map<string, number>();
+  /** Both derived locations for an ungrouped message, keyed once by ID. */
+  private messageLocations = new Map<string, MessageLocation>();
 
   /** O(1) lookup from groupId → tree node. */
   private groupNodeIndex = new Map<string, GroupTree>();
-
-  /** O(1) lookup from ungrouped message ID → timeline index. */
-  private timelineMessageIndex = new Map<string, number>();
 
   /**
    * Patch status/name/end-time changes into the existing group tree.
@@ -94,8 +98,7 @@ export class MessageIndex {
     );
     const messagesByGroup = new Map<string, LogMessageData[]>();
     const ungrouped: LogMessageData[] = [];
-    this.ungroupedById.clear();
-    this.ungroupedIndex.clear();
+    this.messageLocations.clear();
 
     for (const msg of sortedMessages) {
       if (msg.groupId && groupMap.has(msg.groupId)) {
@@ -103,8 +106,9 @@ export class MessageIndex {
         bucket.push(msg);
         messagesByGroup.set(msg.groupId, bucket);
       } else {
-        this.ungroupedIndex.set(msg.id, ungrouped.length);
-        this.ungroupedById.set(msg.id, msg);
+        this.messageLocations.set(msg.id, {
+          ungroupedIndex: ungrouped.length,
+        });
         ungrouped.push(msg);
       }
     }
@@ -156,9 +160,14 @@ export class MessageIndex {
       })),
     ].sort((a, b) => a.time - b.time);
     this.timeline = timeline;
-    this.timelineMessageIndex.clear();
-    for (const [i, item] of timeline.entries()) {
-      if ('msg' in item) this.timelineMessageIndex.set(item.key, i);
+    this.messageLocations.clear();
+    this.reindexUngroupedFrom(0);
+    for (const item of timeline) {
+      if ('msg' in item) {
+        const location = this.messageLocations.get(item.key) ?? {};
+        location.timelineEntry = item;
+        this.messageLocations.set(item.key, location);
+      }
     }
   }
 
@@ -202,7 +211,7 @@ export class MessageIndex {
         ? this.groupNodeIndex.has(m.groupId)
         : false;
       if (inGroupNode) continue;
-      const entry: TimelineEntry = {
+      const entry: MessageTimelineEntry = {
         key: m.id,
         time: m.timestamp ?? 0,
         msg: m,
@@ -210,18 +219,18 @@ export class MessageIndex {
       const lastTime =
         this.timeline.length > 0 ? this.timeline.at(-1)!.time : -Infinity;
       if (entry.time >= lastTime) {
-        this.timelineMessageIndex.set(entry.key, this.timeline.length);
         this.timeline.push(entry);
       } else {
         const idx = this.timeline.findIndex((e) => e.time > entry.time);
         if (idx >= 0) {
           this.timeline.splice(idx, 0, entry);
-          this.reindexTimelineFrom(idx);
         } else {
-          this.timelineMessageIndex.set(entry.key, this.timeline.length);
           this.timeline.push(entry);
         }
       }
+      const location = this.messageLocations.get(entry.key) ?? {};
+      location.timelineEntry = entry;
+      this.messageLocations.set(entry.key, location);
     }
   }
 
@@ -268,11 +277,9 @@ export class MessageIndex {
       for (const index of deltaIndices) {
         const msg = messages[index];
         if (!msg) continue;
-        const timelineIndex = this.timelineMessageIndex.get(msg.id);
-        if (timelineIndex === undefined) continue;
-        const item = this.timeline[timelineIndex];
-        if (item && 'msg' in item && item.key === msg.id) {
-          item.msg = msg;
+        const timelineEntry = this.messageLocations.get(msg.id)?.timelineEntry;
+        if (timelineEntry) {
+          timelineEntry.msg = msg;
         }
       }
       return;
@@ -282,7 +289,13 @@ export class MessageIndex {
       const item = this.timeline[i];
       if (!item) continue;
       if (!('msg' in item)) continue;
-      const fresh = this.ungroupedById.get(item.key);
+      const ungroupedIndex = this.messageLocations.get(
+        item.key,
+      )?.ungroupedIndex;
+      const fresh =
+        ungroupedIndex === undefined
+          ? undefined
+          : this.ungrouped[ungroupedIndex];
       if (fresh && fresh !== item.msg) {
         item.msg = fresh;
       }
@@ -311,18 +324,18 @@ export class MessageIndex {
       }
     }
 
-    const indexed = this.ungroupedIndex.get(msg.id);
+    const indexed = this.messageLocations.get(msg.id)?.ungroupedIndex;
     if (indexed !== undefined && this.ungrouped[indexed]?.id === msg.id) {
       this.ungrouped[indexed] = msg;
-      this.ungroupedById.set(msg.id, msg);
       return;
     }
 
     const idx = this.ungrouped.findIndex((m) => m.id === msg.id);
     if (idx >= 0) {
       this.ungrouped[idx] = msg;
-      this.ungroupedIndex.set(msg.id, idx);
-      this.ungroupedById.set(msg.id, msg);
+      const location = this.messageLocations.get(msg.id) ?? {};
+      location.ungroupedIndex = idx;
+      this.messageLocations.set(msg.id, location);
     }
   }
 
@@ -351,23 +364,22 @@ export class MessageIndex {
     return target.length - 1;
   }
 
-  private reindexTimelineFrom(startIndex: number): void {
-    for (let i = startIndex; i < this.timeline.length; i++) {
-      const item = this.timeline[i];
-      if ('msg' in item) this.timelineMessageIndex.set(item.key, i);
-    }
-  }
-
   private reindexUngroupedFrom(startIndex: number): void {
     for (let i = startIndex; i < this.ungrouped.length; i++) {
       const message = this.ungrouped[i];
-      this.ungroupedIndex.set(message.id, i);
-      this.ungroupedById.set(message.id, message);
+      const location = this.messageLocations.get(message.id) ?? {};
+      location.ungroupedIndex = i;
+      this.messageLocations.set(message.id, location);
     }
   }
 
   private removeUngroupedEntry(id: string): void {
-    this.ungroupedIndex.delete(id);
-    this.ungroupedById.delete(id);
+    const location = this.messageLocations.get(id);
+    if (!location) return;
+    if (location.timelineEntry) {
+      delete location.ungroupedIndex;
+    } else {
+      this.messageLocations.delete(id);
+    }
   }
 }

--- a/packages/extension/src/progressView/frontend/components/messageIndex.ts
+++ b/packages/extension/src/progressView/frontend/components/messageIndex.ts
@@ -160,8 +160,6 @@ export class MessageIndex {
       })),
     ].sort((a, b) => a.time - b.time);
     this.timeline = timeline;
-    this.messageLocations.clear();
-    this.reindexUngroupedFrom(0);
     for (const item of timeline) {
       if ('msg' in item) {
         const location = this.messageLocations.get(item.key) ?? {};

--- a/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
@@ -14,12 +14,9 @@ import {
   designTokens,
   searchHighlightStyles,
 } from '@shared/styles';
-import { AgentCategory } from '@shared/schemas/agent';
 import { getLightweightMd } from '@shared/highlighting/lightweightMd';
 import { markdownStyles } from '@shared/styles/markdownStyles';
 import { isKnownUnsupported } from '@shared/utils/dispatcher';
-import { getAgentCategoryDecorator } from '@shared/utils/icons';
-import { formatShortDateTime } from '@shared/utils/string';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
 import { metaStripStyles, renderDotMeta } from '@shared/wa/metaStrip';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
@@ -33,9 +30,13 @@ import { historyStyles } from '@shared/styles/historyStyles';
 
 // Local imports - history view events
 import { HistoryViewEvents } from './events';
-import { hasSearchValue } from './historySearch';
+import {
+  getHistoryItemPresentation,
+  hasHistoryConfigValue,
+  type HistoryConfigValue,
+} from './historyItemPresentation';
 
-type ConfigValue = string | number | boolean | string[] | null | undefined;
+type ConfigValue = HistoryConfigValue;
 
 const LONG_INSTRUCTION_CHARS = 400;
 
@@ -253,7 +254,9 @@ export class HistoryItemElement extends LitElement {
     label: string | TemplateResult,
     entries: Array<[string, ConfigValue]>,
   ): TemplateResult | null {
-    const filtered = entries.filter(([, value]) => hasSearchValue(value));
+    const filtered = entries.filter(([, value]) =>
+      hasHistoryConfigValue(value),
+    );
     if (!filtered.length) return null;
 
     return html`
@@ -276,17 +279,10 @@ export class HistoryItemElement extends LitElement {
       return nothing;
     }
 
-    const config = this.item.agentConfig;
-    const timestamp = formatShortDateTime(this.item.timestamp) ?? 'Unknown';
-    const isToolUse = config.agentCategory === AgentCategory.ToolUse;
-    const categoryVariant: 'warning' | 'brand' = isToolUse
+    const presentation = getHistoryItemPresentation(this.item);
+    const categoryVariant: 'warning' | 'brand' = presentation.isToolUse
       ? 'warning'
       : 'brand';
-    const decorator = getAgentCategoryDecorator(config.agentCategory);
-    const instructionText = config.instruction?.trim()
-      ? config.instruction
-      : null;
-    const descriptionText = this.item.description?.trim() || null;
 
     const extraDetails: TemplateResult[] = [];
     const pushSection = (
@@ -298,40 +294,33 @@ export class HistoryItemElement extends LitElement {
       if (section) extraDetails.push(section);
     };
 
-    if (config.agentCategory === AgentCategory.Workflow) {
-      pushSection('Context', [['ContextFiles', config.contextFiles]]);
-      pushSection('Output Files', [['Files', config.outputFiles]]);
-      if (config.toolConfig) {
-        pushSection(
-          html`${waIcon('tools')} Config`,
-          Object.entries(config.toolConfig) as Array<[string, ConfigValue]>,
-        );
-      }
-    } else if (config.agentCategory === AgentCategory.ToolUse) {
-      pushSection('Edited Files', [['Files', config.editedFiles]]);
+    for (const section of presentation.sections) {
+      pushSection(
+        section.icon
+          ? html`${waIcon(section.icon)} ${section.label}`
+          : section.label,
+        section.entries,
+      );
     }
 
-    const titleText = instructionText ?? descriptionText ?? '(no instruction)';
-    const summaryText =
-      instructionText && descriptionText && descriptionText !== instructionText
-        ? descriptionText
-        : null;
-
     const metaParts: Array<string | TemplateResult> = [
-      timestamp,
+      presentation.timestamp,
       html`<wa-tag variant=${categoryVariant} size="small">
-        ${decorator.icon ? waIcon(decorator.icon) : nothing} ${decorator.label}
+        ${
+          presentation.decorator.icon
+            ? waIcon(presentation.decorator.icon)
+            : nothing
+        }
+        ${presentation.decorator.label}
       </wa-tag>`,
-      `Agent: ${config.agent ?? 'Unknown'}`,
-      `Model: ${config.model ?? 'Unknown'}`,
+      `Agent: ${presentation.agent}`,
+      `Model: ${presentation.model}`,
     ];
-    if (config.agentCategory === AgentCategory.Workflow) {
-      if (config.inputFiles?.length) {
-        metaParts.push(`Inputs: ${config.inputFiles.join(', ')}`);
-      }
-      if (config.mediaFiles?.length) {
-        metaParts.push(`Media: ${config.mediaFiles.join(', ')}`);
-      }
+    if (presentation.inputFiles.length > 0) {
+      metaParts.push(`Inputs: ${presentation.inputFiles.join(', ')}`);
+    }
+    if (presentation.mediaFiles.length > 0) {
+      metaParts.push(`Media: ${presentation.mediaFiles.join(', ')}`);
     }
 
     return html`
@@ -380,7 +369,7 @@ export class HistoryItemElement extends LitElement {
                   })
             }
             ${
-              isToolUse
+              presentation.isToolUse
                 ? html`
                     ${
                       isKnownUnsupported(
@@ -429,10 +418,15 @@ export class HistoryItemElement extends LitElement {
             }
           </div>
         </div>
-        ${this.renderInstructionBlock(instructionText, titleText)}
+        ${this.renderInstructionBlock(
+          presentation.instruction,
+          presentation.title,
+        )}
         ${
-          summaryText
-            ? html`<div class="history-description">${summaryText}</div>`
+          presentation.summary
+            ? html`<div class="history-description">
+                ${presentation.summary}
+              </div>`
             : nothing
         }
         ${

--- a/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
@@ -36,8 +36,6 @@ import {
   type HistoryConfigValue,
 } from './historyItemPresentation';
 
-type ConfigValue = HistoryConfigValue;
-
 const LONG_INSTRUCTION_CHARS = 400;
 
 @customElement('history-item')
@@ -206,7 +204,7 @@ export class HistoryItemElement extends LitElement {
     return this.markElements ?? [];
   }
 
-  private renderValue(value: ConfigValue): TemplateResult {
+  private renderValue(value: HistoryConfigValue): TemplateResult {
     if (Array.isArray(value)) {
       return this.renderMarkdownValue(value.join(', '));
     }
@@ -252,7 +250,7 @@ export class HistoryItemElement extends LitElement {
 
   private renderConfigSection(
     label: string | TemplateResult,
-    entries: Array<[string, ConfigValue]>,
+    entries: Array<[string, HistoryConfigValue]>,
   ): TemplateResult | null {
     const filtered = entries.filter(([, value]) =>
       hasHistoryConfigValue(value),
@@ -287,7 +285,7 @@ export class HistoryItemElement extends LitElement {
     const extraDetails: TemplateResult[] = [];
     const pushSection = (
       label: string | TemplateResult,
-      entries: Array<[string, ConfigValue]>,
+      entries: Array<[string, HistoryConfigValue]>,
     ): void => {
       // renderConfigSection filters empty entries and returns null when none remain.
       const section = this.renderConfigSection(label, entries);

--- a/packages/extension/src/settingsView/frontend/components/history/historyItemPresentation.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/historyItemPresentation.ts
@@ -1,0 +1,72 @@
+import type { HistoryItem } from '@shared/schemas';
+import { AgentCategory } from '@shared/schemas/agent';
+import { getAgentCategoryDecorator } from '@shared/utils/icons';
+import { formatShortDateTime } from '@shared/utils/string';
+
+export type HistoryConfigValue =
+  string | number | boolean | string[] | null | undefined;
+
+interface HistoryConfigSection {
+  readonly label: string;
+  readonly icon?: 'tools';
+  readonly entries: Array<[string, HistoryConfigValue]>;
+}
+
+/** The one presentation model shared by history rendering and search. */
+export function getHistoryItemPresentation(item: HistoryItem) {
+  const config = item.agentConfig;
+  const isToolUse = config.agentCategory === AgentCategory.ToolUse;
+  const instruction = config.instruction?.trim() ? config.instruction : null;
+  const description = item.description?.trim() || null;
+  const sections: HistoryConfigSection[] = [];
+
+  if (config.agentCategory === AgentCategory.Workflow) {
+    sections.push(
+      { label: 'Context', entries: [['ContextFiles', config.contextFiles]] },
+      { label: 'Output Files', entries: [['Files', config.outputFiles]] },
+    );
+    if (config.toolConfig) {
+      sections.push({
+        label: 'Config',
+        icon: 'tools',
+        entries: Object.entries(config.toolConfig),
+      });
+    }
+  } else {
+    sections.push({
+      label: 'Edited Files',
+      entries: [['Files', config.editedFiles]],
+    });
+  }
+
+  return {
+    id: item.id,
+    rawTimestamp: item.timestamp,
+    timestamp: formatShortDateTime(item.timestamp) ?? 'Unknown',
+    decorator: getAgentCategoryDecorator(config.agentCategory),
+    isToolUse,
+    agent: config.agent ?? 'Unknown',
+    model: config.model ?? 'Unknown',
+    instruction,
+    description,
+    title: instruction ?? description ?? '(no instruction)',
+    summary:
+      instruction && description && description !== instruction
+        ? description
+        : null,
+    inputFiles:
+      config.agentCategory === AgentCategory.Workflow
+        ? (config.inputFiles ?? [])
+        : [],
+    mediaFiles:
+      config.agentCategory === AgentCategory.Workflow
+        ? (config.mediaFiles ?? [])
+        : [],
+    sections,
+  };
+}
+
+export function hasHistoryConfigValue(value: unknown): boolean {
+  if (value == null) return false;
+  return !Array.isArray(value) || value.length > 0;
+}

--- a/packages/extension/src/settingsView/frontend/components/history/historySearch.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/historySearch.ts
@@ -1,6 +1,9 @@
 import type { HistoryItem } from '@shared/schemas';
-import { getAgentCategoryDecorator } from '@shared/utils/icons';
-import { formatShortDateTime } from '@shared/utils/string';
+
+import {
+  getHistoryItemPresentation,
+  hasHistoryConfigValue,
+} from './historyItemPresentation';
 
 type ToolConfigEntry = [string, unknown];
 
@@ -9,11 +12,6 @@ function normalizeSearchText(text: string): string {
     .normalize('NFD')
     .replaceAll(/[\u0300-\u036f]/g, '')
     .toLocaleLowerCase();
-}
-
-export function hasSearchValue(value: unknown): boolean {
-  if (value == null) return false;
-  return !Array.isArray(value) || value.length > 0;
 }
 
 function addSearchValue(parts: string[], value: unknown): void {
@@ -49,7 +47,7 @@ function addLabelledValue(
   label: string,
   value: unknown,
 ): boolean {
-  if (!hasSearchValue(value)) return false;
+  if (!hasHistoryConfigValue(value)) return false;
 
   parts.push(label);
   addSearchValue(parts, value);
@@ -61,7 +59,9 @@ function addConfigSection(
   sectionLabel: string,
   entries: ToolConfigEntry[],
 ): boolean {
-  const visibleEntries = entries.filter(([, value]) => hasSearchValue(value));
+  const visibleEntries = entries.filter(([, value]) =>
+    hasHistoryConfigValue(value),
+  );
   if (visibleEntries.length === 0) return false;
 
   parts.push(sectionLabel);
@@ -76,50 +76,29 @@ function addConfigSection(
  * Build a lowercase search body matching the fields HistoryItemElement renders.
  */
 export function getHistorySearchText(item: HistoryItem): string {
+  const presentation = getHistoryItemPresentation(item);
   const parts: string[] = [
-    item.id,
-    item.timestamp,
-    formatShortDateTime(item.timestamp) ?? '',
+    presentation.id,
+    presentation.rawTimestamp,
+    presentation.timestamp,
   ];
-  addSearchValue(parts, item.description);
+  addSearchValue(parts, presentation.description);
 
-  const config = item.agentConfig;
-  parts.push('Category', getAgentCategoryDecorator(config.agentCategory).label);
+  parts.push('Category', presentation.decorator.label);
   parts.push('Agent');
-  addSearchValue(parts, config.agent ?? 'Unknown');
+  addSearchValue(parts, presentation.agent);
   parts.push('Model');
-  addSearchValue(parts, config.model ?? 'Unknown');
+  addSearchValue(parts, presentation.model);
   parts.push('Instruction');
-  addSearchValue(
-    parts,
-    config.instruction?.trim() ? config.instruction : 'Not set',
-  );
+  addSearchValue(parts, presentation.instruction ?? 'Not set');
 
-  if (config.agentCategory === 'workflow') {
-    addLabelledValue(parts, 'InputFiles', config.inputFiles);
-    addLabelledValue(parts, 'MediaFiles', config.mediaFiles);
-
-    const hasMoreDetails = [
-      addConfigSection(parts, 'Context', [
-        ['ContextFiles', config.contextFiles],
-      ]),
-      addConfigSection(parts, 'Output Files', [['Files', config.outputFiles]]),
-      config.toolConfig
-        ? addConfigSection(parts, 'Config', Object.entries(config.toolConfig))
-        : false,
-    ].some(Boolean);
-
-    if (hasMoreDetails) {
-      parts.push('More details');
-    }
-  } else if (config.agentCategory === 'toolUse') {
-    const hasMoreDetails = addConfigSection(parts, 'Edited Files', [
-      ['Files', config.editedFiles],
-    ]);
-
-    if (hasMoreDetails) {
-      parts.push('More details');
-    }
+  addLabelledValue(parts, 'InputFiles', presentation.inputFiles);
+  addLabelledValue(parts, 'MediaFiles', presentation.mediaFiles);
+  const hasMoreDetails = presentation.sections
+    .map((section) => addConfigSection(parts, section.label, section.entries))
+    .some(Boolean);
+  if (hasMoreDetails) {
+    parts.push('More details');
   }
 
   return normalizeSearchText(parts.join('\n'));

--- a/packages/extension/src/webview/frontend/mainViewActions.ts
+++ b/packages/extension/src/webview/frontend/mainViewActions.ts
@@ -47,7 +47,6 @@ import {
   isSelectedAgentOrchestrator$,
   model$,
   multiFiles$,
-  outputFilesActive$,
   primaryInputFile,
   sessionType$,
   singleFiles$,
@@ -172,7 +171,6 @@ export function enterToolUseSession(): void {
     swapModeInstruction(sessionType$.get(), SESSION_TYPES.TOOL_USE);
     sessionType$.set(SESSION_TYPES.TOOL_USE);
     fileSelectionOpen$.set(false);
-    outputFilesActive$.set(false);
     updateMultiFiles('outputFiles', []);
     refreshModelSelectionForActiveSession();
   }
@@ -212,11 +210,6 @@ export function removeFile(listId: keyof MultiFiles, file: string): void {
   const files = (multiFiles$.get()[listId] ?? []).filter(
     (f: string) => f !== file,
   );
-  if (files.length === 0) {
-    if (listId === 'outputFiles') {
-      outputFilesActive$.set(false);
-    }
-  }
   updateMultiFiles(listId, files);
 }
 
@@ -264,9 +257,6 @@ export function emptyFile(type: DocumentFileType | 'base' | 'edited'): void {
 
 export function emptyFiles(type: MultipleDocumentFileType): void {
   const listId = `${type}Files`;
-  if (type === 'output') {
-    outputFilesActive$.set(false);
-  }
   updateMultiFiles(listId as keyof MultiFiles, []);
 }
 
@@ -317,7 +307,6 @@ export function changeSessionType(value: string): void {
   fileSelectionOpen$.set(parsed === SESSION_TYPES.WORKFLOW);
   refreshInstructionPlaceholder();
   if (parsed === SESSION_TYPES.TOOL_USE) {
-    outputFilesActive$.set(false);
     updateMultiFiles('outputFiles', []);
   }
   saveState();
@@ -383,8 +372,6 @@ function polishInstruction(): void {
     contextFilesActive: files.contextFilesActive,
     mediaFiles: files.mediaFiles,
     mediaFilesActive: files.mediaFilesActive,
-    outputFiles: files.outputFiles,
-    outputFilesActive: files.outputFilesActive,
   });
 }
 

--- a/packages/extension/src/webview/frontend/mainViewState.ts
+++ b/packages/extension/src/webview/frontend/mainViewState.ts
@@ -76,7 +76,6 @@ export const instructionPlaceholder$ = signal(
 export const singleFiles$ = signal<SingleFiles>({ ...DEFAULT_SINGLE_FILES });
 export const fileOptions$ = signal<FileOptions>({ ...DEFAULT_FILE_OPTIONS });
 export const multiFiles$ = signal<MultiFiles>({ ...DEFAULT_MULTI_FILES });
-export const outputFilesActive$ = signal(DEFAULT_STATE.outputFilesActive);
 export const checkboxValues$ = signal<CheckboxValues>({
   ...DEFAULT_CHECKBOX_VALUES,
 });
@@ -190,7 +189,6 @@ export const fileStateContext$ = new Signal.Computed(
     singleFiles: singleFiles$.get(),
     fileOptions: fileOptions$.get(),
     multiFiles: multiFiles$.get(),
-    outputFilesActive: outputFilesActive$.get(),
   }),
 );
 
@@ -232,7 +230,6 @@ export function resetMainViewState(): void {
   singleFiles$.set({ ...DEFAULT_SINGLE_FILES });
   fileOptions$.set({ ...DEFAULT_FILE_OPTIONS });
   multiFiles$.set({ ...DEFAULT_MULTI_FILES });
-  outputFilesActive$.set(DEFAULT_STATE.outputFilesActive);
   checkboxValues$.set({ ...DEFAULT_CHECKBOX_VALUES });
   isGitRepo$.set(true);
   latexdiffsVisible$.set(DEFAULT_STATE.latexdiffsVisible);

--- a/packages/extension/src/webview/frontend/persistence.ts
+++ b/packages/extension/src/webview/frontend/persistence.ts
@@ -7,9 +7,9 @@
  *   1. mount-time webview-storage restore (`restorePersistedState`), and
  *   2. backend-pushed history-rerun/reset restore (`handleRestoreState`).
  *
- * Both paths force `outputFiles`/`outputFilesActive` back to empty/false and
- * share `restorePerModeInstructions`'s legacy-migration precedence. Behavior
- * is pinned by `src/test-kernel/webview/MainAppPersistenceRestore.vitest.mts`.
+ * Both paths apply state through `applyState`, which owns output-file reset
+ * and legacy-instruction precedence. Behavior is pinned by
+ * `src/test-kernel/webview/MainAppPersistenceRestore.vitest.mts`.
  */
 
 // Third-party imports
@@ -38,7 +38,6 @@ import {
   latexdiffsVisible$,
   model$,
   multiFiles$,
-  outputFilesActive$,
   sessionType$,
   singleFiles$,
   toolUseAgent$,
@@ -106,7 +105,6 @@ export function saveState(): void {
     contextFiles: mf.contextFiles,
     mediaFiles: mf.mediaFiles,
     outputFiles: [],
-    outputFilesActive: false,
     latexdiffsVisible: latexdiffsVisible$.get(),
     autoExtractFigure: cv.autoExtractFigure,
     autoExtractTikzFigure: cv.autoExtractTikzFigure,
@@ -121,33 +119,7 @@ export function restorePersistedState(): void {
   // State is parsed through MainViewPersistedStateSchema which provides all defaults.
   // No manual fallbacks needed - schema handles missing/invalid values.
   const state = stateManager.getState();
-
-  sessionType$.set(state.sessionType);
-  fileSelectionOpen$.set(state.sessionType === SESSION_TYPES.WORKFLOW);
-  workflowAgent$.set(state.workflowAgent);
-  toolUseAgent$.set(state.toolUseAgent);
-  model$.set(state.model);
-  commit$.set(state.commit);
-
-  restorePerModeInstructions(state);
-  singleFiles$.set({
-    editedFile: state.editedFile,
-    baseFile: state.baseFile,
-  });
-  multiFiles$.set({
-    inputFiles: state.inputFiles,
-    contextFiles: state.contextFiles,
-    mediaFiles: state.mediaFiles,
-    outputFiles: [],
-  });
-  outputFilesActive$.set(false);
-  latexdiffsVisible$.set(state.latexdiffsVisible);
-  checkboxValues$.set({
-    autoExtractFigure: state.autoExtractFigure,
-    autoExtractTikzFigure: state.autoExtractTikzFigure,
-    autoCompileInputPdf: state.autoCompileInputPdf,
-    attachTeXCount: state.attachTeXCount,
-  });
+  applyState(state);
 }
 
 /**
@@ -193,32 +165,35 @@ export function handleRestoreState(
   const state = parsed.data;
   blockSave();
   try {
-    sessionType$.set(state.sessionType);
-    workflowAgent$.set(state.workflowAgent);
-    toolUseAgent$.set(state.toolUseAgent);
-    model$.set(state.model);
-    commit$.set(state.commit);
-    restorePerModeInstructions(state);
-    singleFiles$.set({
-      editedFile: state.editedFile,
-      baseFile: state.baseFile,
-    });
-
-    checkboxValues$.set({
-      autoExtractFigure: state.autoExtractFigure,
-      autoExtractTikzFigure: state.autoExtractTikzFigure,
-      autoCompileInputPdf: state.autoCompileInputPdf,
-      attachTeXCount: state.attachTeXCount,
-    });
-    outputFilesActive$.set(false);
-    latexdiffsVisible$.set(state.latexdiffsVisible);
-
-    restoreFileArrays(state);
+    applyState(state);
   } finally {
     unblockSave();
   }
   saveState();
   return true;
+}
+
+/** Apply one parsed snapshot regardless of whether storage or the host sent it. */
+function applyState(state: MainViewPersistedState): void {
+  sessionType$.set(state.sessionType);
+  fileSelectionOpen$.set(state.sessionType === SESSION_TYPES.WORKFLOW);
+  workflowAgent$.set(state.workflowAgent);
+  toolUseAgent$.set(state.toolUseAgent);
+  model$.set(state.model);
+  commit$.set(state.commit);
+  restorePerModeInstructions(state);
+  singleFiles$.set({
+    editedFile: state.editedFile,
+    baseFile: state.baseFile,
+  });
+  restoreFileArrays(state);
+  latexdiffsVisible$.set(state.latexdiffsVisible);
+  checkboxValues$.set({
+    autoExtractFigure: state.autoExtractFigure,
+    autoExtractTikzFigure: state.autoExtractTikzFigure,
+    autoCompileInputPdf: state.autoCompileInputPdf,
+    attachTeXCount: state.attachTeXCount,
+  });
 }
 
 function restoreFileArrays(state: MainViewPersistedState): void {
@@ -256,9 +231,6 @@ function clearForNewSession(): void {
         ...checkboxValues$.get(),
         ...defaults.checkboxOverrides,
       });
-    }
-    if (defaults.outputFilesActive !== undefined) {
-      outputFilesActive$.set(false);
     }
   }
   saveState();

--- a/packages/extension/src/webview/frontend/sessionDefaults.ts
+++ b/packages/extension/src/webview/frontend/sessionDefaults.ts
@@ -6,7 +6,6 @@ export interface SessionDefaults {
   fileInputEnabled: boolean;
   resetFiles: boolean;
   checkboxOverrides?: Partial<CheckboxValues>;
-  outputFilesActive?: boolean;
 }
 
 export const SESSION_DEFAULTS = {
@@ -18,7 +17,6 @@ export const SESSION_DEFAULTS = {
       autoExtractTikzFigure: false,
       autoCompileInputPdf: false,
     },
-    outputFilesActive: false,
   },
   toolUse: {
     fileInputEnabled: false,

--- a/packages/extension/src/webview/frontend/slices/documentSlice.ts
+++ b/packages/extension/src/webview/frontend/slices/documentSlice.ts
@@ -20,7 +20,6 @@ import {
   fileOptions$,
   isGitRepo$,
   multiFiles$,
-  outputFilesActive$,
   singleFiles$,
 } from '../mainViewState';
 import { showInformation, updateMultiFiles } from '../mainViewActions';
@@ -45,9 +44,6 @@ function handleSetMultipleFiles(message: SetMultipleFilesMessage): void {
   if (!listId) return;
 
   multiFiles$.set({ ...multiFiles$.get(), [listId]: files });
-  if (listId === 'outputFiles') {
-    outputFilesActive$.set(false);
-  }
   saveState();
 }
 

--- a/packages/extension/src/webview/managers/InstructionManager.ts
+++ b/packages/extension/src/webview/managers/InstructionManager.ts
@@ -86,7 +86,6 @@ export class InstructionManager extends BaseWebviewManager {
       ['inputFiles', 'inputFilesActive'],
       ['contextFiles', 'contextFilesActive'],
       ['mediaFiles', 'mediaFilesActive'],
-      ['outputFiles', 'outputFilesActive'],
     ] as const;
     for (const [field, activeField] of multiFields) {
       const files: (string | null)[] | undefined = message[field];

--- a/src/controllers/mainView/MainViewStateRestoreController.ts
+++ b/src/controllers/mainView/MainViewStateRestoreController.ts
@@ -18,7 +18,6 @@ export function buildMainViewState(
 ): MainViewPersistedState {
   const agentConfig = 'agentConfig' in state ? state.agentConfig : state;
   const isToolUse = agentConfig.agentCategory === AgentCategory.ToolUse;
-  const isWorkflow = agentConfig.agentCategory === AgentCategory.Workflow;
   const toolConfig = agentConfig.toolConfig ?? {};
 
   const agentCategory = isToolUse
@@ -43,9 +42,6 @@ export function buildMainViewState(
     contextFiles: agentConfig.contextFiles,
     mediaFiles: agentConfig.mediaFiles,
     outputFiles: agentConfig.outputFiles,
-    outputFilesActive: isWorkflow
-      ? agentConfig.outputFiles.length > 0
-      : undefined,
     autoExtractFigure: toolConfig.autoExtractFigure,
     autoExtractTikzFigure: toolConfig.autoExtractTikzFigure,
     autoCompileInputPdf: toolConfig.autoCompileInputPdf,

--- a/src/shared/mainView/executeMessage.ts
+++ b/src/shared/mainView/executeMessage.ts
@@ -30,8 +30,6 @@ type MainViewMultipleFileSelections = Pick<
   | 'contextFilesActive'
   | 'mediaFiles'
   | 'mediaFilesActive'
-  | 'outputFiles'
-  | 'outputFilesActive'
 >;
 
 export function buildMainViewExecuteMessage(
@@ -63,7 +61,5 @@ function buildMainViewMultipleFileSelections(
     contextFilesActive: multiFiles.contextFiles.length > 0,
     mediaFiles: multiFiles.mediaFiles,
     mediaFilesActive: multiFiles.mediaFiles.length > 0,
-    outputFiles: [],
-    outputFilesActive: false,
   };
 }

--- a/src/shared/schemas/mainView/executeMessage.ts
+++ b/src/shared/schemas/mainView/executeMessage.ts
@@ -17,7 +17,6 @@ export const MainViewExecuteFilesSchema = z.object({
   inputFilesActive: z.boolean().optional(),
   contextFilesActive: z.boolean().optional(),
   mediaFilesActive: z.boolean().optional(),
-  outputFilesActive: z.boolean().optional(),
 });
 export type MainViewExecuteFiles = z.infer<typeof MainViewExecuteFilesSchema>;
 

--- a/src/shared/schemas/mainView/inbound.ts
+++ b/src/shared/schemas/mainView/inbound.ts
@@ -194,7 +194,6 @@ const InstructionMessages = [
       inputFilesActive: true,
       contextFilesActive: true,
       mediaFilesActive: true,
-      outputFilesActive: true,
     }).shape,
   }),
   z.object({

--- a/src/shared/schemas/mainView/state.ts
+++ b/src/shared/schemas/mainView/state.ts
@@ -111,7 +111,6 @@ const MainViewPersistedStateBaseSchema = UIFileFieldsSchema.merge(
   workflowInstruction: z.string().prefault(''),
   toolUseInstruction: z.string().prefault(''),
   baseFile: z.string().prefault(''),
-  outputFilesActive: z.boolean().prefault(false),
   latexdiffsVisible: z.boolean().prefault(false),
   openedFiles: z.array(z.string()).nullish(),
 });
@@ -199,7 +198,6 @@ const FileStateContextSchema = z.object({
   singleFiles: SingleFilesSchema,
   fileOptions: FileOptionsSchema,
   multiFiles: MultiFilesSchema,
-  outputFilesActive: z.boolean(),
 });
 export type FileStateContextValue = z.infer<typeof FileStateContextSchema>;
 

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -3119,4 +3119,17 @@ describe('child-stream ordered transition matrix', () => {
 
     expect(childStreamEntries.get()).toBe(entriesAfterFirst);
   });
+
+  it('13. first roster parent rejects a conflicting roster until an explicit edge arrives', () => {
+    patchStream(kid, (s) => ({ ...s, status: STREAM_PHASE.RUNNING }));
+    applySubagentRoster(parentP, [rosterRow(STREAM_PHASE.RUNNING)]);
+
+    applySubagentRoster(parentQ, [
+      { ...rosterRow(STREAM_PHASE.RUNNING), agentName: 'stale-parent' },
+    ]);
+
+    expect(parentStream.get().get(kid)).toBe(parentP);
+    expect(activeRows(parentP)).toMatchObject([{ agentName: 'kid-agent' }]);
+    expect(activeRows(parentQ)).toEqual([]);
+  });
 });

--- a/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.mts
+++ b/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.mts
@@ -122,10 +122,12 @@ describe('CLI workflow-script child-stream transcript', () => {
           [
             STREAM_ID,
             {
-              activeParentStreamId: PARENT_STREAM_ID,
-              removed: false,
-              retainedOrder: 1,
-              retainedParentStreamId: PARENT_STREAM_ID,
+              kind: 'live' as const,
+              active: true,
+              parent: {
+                kind: 'roster' as const,
+                retained: { streamId: PARENT_STREAM_ID, order: 1 },
+              },
               summary: {
                 agentName: 'draft-sections',
                 executionId: 'exec-1',

--- a/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
+++ b/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
@@ -168,6 +168,40 @@ describe('task-group-list ungrouped message indexes', () => {
     expect(timelineEntry?.msg).toBe(updated);
   });
 
+  it('keeps one location record coherent across out-of-order insertion and update', () => {
+    const original = [
+      createMessage('m1', 'one', 1),
+      createMessage('m3', 'three', 3),
+    ];
+    const list = createList(original);
+    const inserted = createMessage('m2', 'two', 2);
+    const withInsertion = [...original, inserted];
+
+    list.index.appendNewMessages(withInsertion, original.length);
+    list.index.appendToTimeline(withInsertion, original.length);
+
+    expect(list.index.ungrouped.map((message) => message.id)).toEqual([
+      'm1',
+      'm2',
+      'm3',
+    ]);
+    expect(list.index.timeline.map((entry) => entry.key)).toEqual([
+      'm1',
+      'm2',
+      'm3',
+    ]);
+
+    const updated = { ...inserted, text: 'two updated' };
+    const next = [...original, updated];
+    list.index.updateCachedMessageRefs(next, withInsertion, [2]);
+    list.index.updateTimelineMessageRefs(next, [2]);
+
+    expect(list.index.ungrouped[1]).toBe(updated);
+    expect(
+      list.index.timeline.find((entry) => entry.key === 'm2' && 'msg' in entry),
+    ).toMatchObject({ msg: updated });
+  });
+
   it('patches stable group metadata without rebuilding the message tree', () => {
     const group = createGroup('g1', STREAM_PHASE.RUNNING);
     const message = createMessage('m1', 'grouped', 2, group.id);

--- a/src/test-kernel/shared/MainViewExecuteMessage.vitest.ts
+++ b/src/test-kernel/shared/MainViewExecuteMessage.vitest.ts
@@ -44,8 +44,6 @@ describe('MainView execute message builder', () => {
         contextFilesActive: true,
         mediaFiles: ['figure.png'],
         mediaFilesActive: true,
-        outputFiles: [],
-        outputFilesActive: false,
       },
       toolConfig: {
         autoExtractFigure: true,

--- a/src/test-kernel/support/childStreamEntries.ts
+++ b/src/test-kernel/support/childStreamEntries.ts
@@ -22,13 +22,32 @@ export interface ChildStreamEntryRow extends SubagentChildInfo {
   readonly active?: boolean;
 }
 
+type TestParentProvenance =
+  | {
+      readonly kind: 'explicit';
+      readonly streamId: StreamTabId | null;
+      readonly retained?: {
+        readonly streamId: StreamTabId;
+        readonly order: number;
+      };
+    }
+  | {
+      readonly kind: 'roster';
+      readonly retained: {
+        readonly streamId: StreamTabId;
+        readonly order: number;
+      };
+    };
+
 function toEntry(
   row: ChildStreamEntryRow,
   parentDefaults: {
-    readonly activeParentStreamId?: StreamTabId;
-    readonly edgeParentStreamId?: StreamTabId | null;
-    readonly retainedParentStreamId?: StreamTabId;
-    readonly retainedOrder?: number;
+    readonly active: boolean;
+    readonly explicitParentStreamId?: StreamTabId | null;
+    readonly retained?: {
+      readonly streamId: StreamTabId;
+      readonly order: number;
+    };
   },
 ): ChildStreamEntry {
   const {
@@ -39,14 +58,27 @@ function toEntry(
     active,
     ...summary
   } = row;
+  if (removed === true) return { kind: 'removed' };
+  const retained = parentDefaults.retained;
+  const explicitParent =
+    edgeParentStreamId !== undefined
+      ? edgeParentStreamId
+      : parentDefaults.explicitParentStreamId;
+  let parent: TestParentProvenance | undefined;
+  if (explicitParent !== undefined) {
+    parent = {
+      kind: 'explicit',
+      streamId: explicitParent,
+      ...(retained && { retained }),
+    };
+  } else if (retained) {
+    parent = { kind: 'roster', retained };
+  }
   return {
+    kind: 'live',
     summary,
-    activeParentStreamId:
-      active === false ? undefined : parentDefaults.activeParentStreamId,
-    retainedParentStreamId: parentDefaults.retainedParentStreamId,
-    retainedOrder: parentDefaults.retainedOrder,
-    edgeParentStreamId: edgeParentStreamId ?? parentDefaults.edgeParentStreamId,
-    removed: removed ?? false,
+    active: active ?? parentDefaults.active,
+    ...(parent && { parent }),
   };
 }
 
@@ -79,9 +111,8 @@ export function buildChildStreamEntries(init: {
     map.set(
       row.childStreamId,
       toEntry(row, {
-        activeParentStreamId: parentStreamId,
-        retainedParentStreamId: parentStreamId,
-        retainedOrder: index + 1,
+        active: true,
+        retained: { streamId: parentStreamId, order: index + 1 },
       }),
     );
   });
@@ -89,15 +120,16 @@ export function buildChildStreamEntries(init: {
     map.set(
       row.childStreamId,
       toEntry(row, {
-        activeParentStreamId: parentStreamId,
-        edgeParentStreamId: parentStreamId,
+        active: true,
+        explicitParentStreamId: parentStreamId,
       }),
     );
   }
   for (const childStreamId of edgeOnly) {
     map.set(childStreamId, {
-      edgeParentStreamId: parentStreamId,
-      removed: false,
+      kind: 'live',
+      active: false,
+      parent: { kind: 'explicit', streamId: parentStreamId },
     });
   }
   return map;

--- a/src/test-kernel/webview/MainAppPersistenceRestore.vitest.mts
+++ b/src/test-kernel/webview/MainAppPersistenceRestore.vitest.mts
@@ -19,13 +19,12 @@ import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
 /**
  * Characterization tests for MainApp's persistence/restore machinery.
  *
- * These pin down the CURRENT behavior of the two independently-triggered
- * restore paths:
+ * These pin down the shared behavior of the two restore entry points:
  *   1. mount-time webview-storage restore (`restorePersistedState`), and
  *   2. backend-pushed history-rerun/reset restore (`handleRestoreState`),
- * including the legacy single-`instruction` migration precedence, the forced
- * `outputFiles`/`outputFilesActive` reset, and the save-reentrancy guard
- * (exactly one storage write per backend restore).
+ * including legacy single-`instruction` migration, transient output-file
+ * reset, Files-panel state, and the save-reentrancy guard (exactly one
+ * storage write per backend restore).
  *
  * They observe only refactor-stable surfaces — the `@provide`/`@state` context
  * values, host-bridge storage writes, and posted messages — so they must pass
@@ -41,7 +40,7 @@ let webviewState: Record<string, unknown>;
 /**
  * Legacy persisted blob: predates the per-mode instruction fields (only the
  * single `instruction` field is present) and carries stale output-file state
- * that both restore paths must force back to inactive/empty.
+ * that both restore entry points must discard.
  */
 const LEGACY_SEED = {
   sessionType: 'workflow',
@@ -160,10 +159,13 @@ describe('MainApp persistence and restore characterization', () => {
   // singleton before the HOST_BRIDGE_API_KEY mock above is wired up.
   let persistence: typeof import('@webview/frontend/persistence');
   let setInstruction: typeof import('@webview/frontend/mainViewActions').setInstruction;
+  let fileSelectionOpen: typeof import('@webview/frontend/mainViewState').fileSelectionOpen$;
 
   beforeAll(async () => {
     persistence = await import('@webview/frontend/persistence');
     ({ setInstruction } = await import('@webview/frontend/mainViewActions'));
+    ({ fileSelectionOpen$: fileSelectionOpen } =
+      await import('@webview/frontend/mainViewState'));
   });
 
   beforeEach(() => {
@@ -172,7 +174,7 @@ describe('MainApp persistence and restore characterization', () => {
     storageWrites.length = 0;
   });
 
-  it('restores persisted state on mount, migrating the legacy instruction and forcing output files inactive', async () => {
+  it('restores persisted state on mount through the canonical state applicator', async () => {
     const element = await mountMainApp();
     const { fileState, session } = contextsOf(element);
 
@@ -181,12 +183,13 @@ describe('MainApp persistence and restore characterization', () => {
     expect(session.workflowAgent).toBe('correct');
     expect(session.toolUseAgent).toBe('orchestrator');
     expect(session.model).toBe('seed-model');
+    expect(fileSelectionOpen.get()).toBe(true);
 
     // Legacy migration: active mode was workflow, so the single legacy
     // `instruction` becomes the workflow instruction and stays active.
     expect(session.instruction).toBe('legacy single-field instruction');
 
-    // File state restored — EXCEPT output files, which are forced inactive.
+    // File state restored — except output files, which are transient.
     expect(fileState.singleFiles).toEqual({
       editedFile: 'main_polish.tex',
       baseFile: 'main.tex',
@@ -197,7 +200,7 @@ describe('MainApp persistence and restore characterization', () => {
       mediaFiles: [],
       outputFiles: [],
     });
-    expect(fileState.outputFilesActive).toBe(false);
+    expect(fileState).not.toHaveProperty('outputFilesActive');
     expect(fileState.checkboxValues).toEqual({
       autoExtractFigure: true,
       autoExtractTikzFigure: false,
@@ -219,7 +222,7 @@ describe('MainApp persistence and restore characterization', () => {
     expect(blob.workflowInstruction).toBe('legacy single-field instruction');
     expect(blob.toolUseInstruction).toBe('');
     expect(blob.outputFiles).toEqual([]);
-    expect(blob.outputFilesActive).toBe(false);
+    expect(blob).not.toHaveProperty('outputFilesActive');
     expect(blob.latexdiffsVisible).toBe(true);
     expect(blob.editedFile).toBe('other_polish.tex');
   });
@@ -253,7 +256,7 @@ describe('MainApp persistence and restore characterization', () => {
     expect(blob.mediaFiles).toEqual(['figure.png']);
     // Restored output files are dropped, not re-persisted.
     expect(blob.outputFiles).toEqual([]);
-    expect(blob.outputFilesActive).toBe(false);
+    expect(blob).not.toHaveProperty('outputFilesActive');
     expect(blob.instruction).toBe('restored tool-use instruction');
     expect(blob.workflowInstruction).toBe('restored workflow instruction');
     expect(blob.toolUseInstruction).toBe('restored tool-use instruction');
@@ -261,8 +264,9 @@ describe('MainApp persistence and restore characterization', () => {
     const { fileState, session } = contextsOf(element);
     expect(session.sessionType).toBe('toolUse');
     expect(session.instruction).toBe('restored tool-use instruction');
+    expect(fileSelectionOpen.get()).toBe(false);
     expect(fileState.multiFiles.outputFiles).toEqual([]);
-    expect(fileState.outputFilesActive).toBe(false);
+    expect(fileState).not.toHaveProperty('outputFilesActive');
     expect(fileState.checkboxValues.autoExtractTikzFigure).toBe(true);
 
     // No execute unless explicitly requested.
@@ -390,7 +394,7 @@ describe('MainApp persistence and restore characterization', () => {
     expect(blob.contextFiles).toEqual([]);
     expect(blob.mediaFiles).toEqual([]);
     expect(blob.outputFiles).toEqual([]);
-    expect(blob.outputFilesActive).toBe(false);
+    expect(blob).not.toHaveProperty('outputFilesActive');
     // Workflow reset overrides the auto-extract/compile toggles but leaves
     // attachTeXCount as the user set it.
     expect(blob.autoExtractFigure).toBe(false);


### PR DESCRIPTION
## Summary

- route both main-webview restore entry points through one canonical state applicator
- replace the progress view's separate ungrouped/timeline lookup maps with one message-location index
- encode CLI child removal and parent provenance as discriminated state instead of independently optional fields
- remove the unread main-view `outputFilesActive` signal and its serialization/execute plumbing
- give history rendering and search one shared presentation model

## Issue acceptance gates

Closes #8738.

- [x] Consolidate divergent persistence restore paths to one canonical path
- [x] Simplify the four-map `MessageIndex` and preserve out-of-order append/update behavior
- [x] Make `ChildStreamEntry` parent authority explicit and reject conflicting late rosters
- [x] Remove dead main-view `outputFilesActive` plumbing
- [x] Deduplicate `HistoryItem` field enumeration
- [x] Verify the progress and settings webviews live at desktop and compact sizes

## Single source of truth

- `persistence.ts::applyState` owns applying every parsed main-view snapshot.
- `MessageIndex.messageLocations` owns both derived locations for an ungrouped message.
- `ChildStreamEntry`'s discriminated live/removed and roster/explicit unions own child-parent authority.
- `historyItemPresentation.ts` owns the fields and sections shared by history rendering and search.

## Duplication and abstraction budget

The two restore assignment lists become one, four persistent `MessageIndex` lookup maps become two, and the history field list moves from two consumers to one presentation function. The new history module has two direct consumers and owns the invariant that searchable fields match visible fields; it is not a pass-through layer. The child-state unions add type structure so invalid combinations such as a removal tombstone with live metadata or half of a retained-parent pair are no longer representable.

## Net elements (R6)

- Files: +1 / -0
- Exported symbols: +4 / -3 (net +1; `ChildStreamEntry` remains the same public name as a union type)
- Classes: +0 / -0
- Interfaces: +5 / -1
- Enums: +0 / -0
- LoC: +538 / -412 (net +126 total); production +374 / -324 (net +50), tests net +83, docs net -7

The production increase is concentrated in the child-state discriminants and transition handling; it removes invalid state combinations and pins the precedence matrix with a new conflicting-roster regression.

## Consumer counts (R8)

- `outputFilesActive$`: zero UI/behavioral consumers on the base revision; its only read projected the signal into state while the remaining references set, serialized, or reset it. Main-view references are now zero.
- `applyState`: two restore entry points.
- `getHistoryItemPresentation`: two consumers (`HistoryItemElement` and `historySearch`).

## Host impact

Extension: Main-view restore/state, progress indexing, and settings history presentation are simplified. Legacy persisted `outputFilesActive` input is accepted and stripped by the object schema.

Desktop: No desktop-specific behavior changes.

CLI: Child-stream parent authority and removal state are structurally explicit; visible/focus behavior remains covered by the ordered transition matrix.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; one pre-existing unrelated `prefer-string-replace-all` warning)
- `CI=true npm test` (735 files passed, 1 skipped; 6784 tests passed, 4 skipped)
- focused changed-path suite (174/174)
- `npm run check:dead-code-ratchet` (228 current = 228 baseline)
- `npm run check:test-loc-growth` (warn-only repository baseline drift; this PR does not update the baseline)
- `git diff --check`
- live Electron/Playwright verification of Settings history rendering/search and Progress out-of-order append/full-entry update at 1440x830 and 900x650

`npm run smoke:webviews:run` was attempted twice but the harness stopped before the changed pages at its unrelated main-webview startup assertion (`main rendered no visible text content`). The generated Settings and Progress pages were therefore exercised directly in the installed Electron runtime for the required live verification.
