### PR TITLE
refactor(desktop): inline IPC identity builders

### DIFF
--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -17,24 +17,9 @@
       "name": "DESKTOP_COMMAND_IDS"
     },
     {
-      "file": "packages/desktop/src/desktopDiffMessages.ts",
-      "category": "exports",
-      "name": "DESKTOP_DIFF_COMMANDS"
-    },
-    {
       "file": "packages/desktop/src/desktopLogMessages.ts",
       "category": "exports",
       "name": "DesktopLogSnapshotSchema"
-    },
-    {
-      "file": "packages/desktop/src/desktopPdfMessages.ts",
-      "category": "exports",
-      "name": "DESKTOP_PDF_COMMANDS"
-    },
-    {
-      "file": "packages/desktop/src/desktopPromptMessages.ts",
-      "category": "exports",
-      "name": "DESKTOP_PROMPT_COMMANDS"
     },
     {
       "file": "packages/desktop/src/desktopShellMessages.ts",

--- a/packages/desktop/src/desktopDiffMessages.ts
+++ b/packages/desktop/src/desktopDiffMessages.ts
@@ -41,15 +41,6 @@ export const DesktopCloseDiffMessageSchema = z.object({
   command: z.literal(DESKTOP_DIFF_COMMANDS.CLOSE_DIFF),
 });
 
-export function buildDesktopShowDiffMessage(
-  payload: Omit<DesktopShowDiffMessage, 'command'>,
-): DesktopShowDiffMessage {
-  return {
-    command: DESKTOP_DIFF_COMMANDS.SHOW_DIFF,
-    ...payload,
-  };
-}
-
 // `desktop:closeDiff` is consumed by the renderer's window-message
 // handler; producers (today: the Playwright trajectory test) construct
 // the literal `{ command: 'desktop:closeDiff' }` inline via

--- a/packages/desktop/src/desktopPdfMessages.ts
+++ b/packages/desktop/src/desktopPdfMessages.ts
@@ -42,15 +42,6 @@ export const DesktopClosePdfMessageSchema = z.object({
   command: z.literal(DESKTOP_PDF_COMMANDS.CLOSE_PDF),
 });
 
-export function buildDesktopShowPdfMessage(
-  payload: Omit<DesktopShowPdfMessage, 'command'>,
-): DesktopShowPdfMessage {
-  return {
-    command: DESKTOP_PDF_COMMANDS.SHOW_PDF,
-    ...payload,
-  };
-}
-
 // Sanitize the PDF path before rendering it in an iframe. The renderer
 // must only accept absolute filesystem paths — anything that smells
 // like a different URL scheme (`http:`, `javascript:`, `data:`, ...)

--- a/packages/desktop/src/desktopPromptMessages.ts
+++ b/packages/desktop/src/desktopPromptMessages.ts
@@ -26,16 +26,3 @@ export const DesktopSettlePromptMessageSchema = z.strictObject({
 export type DesktopSettlePromptMessage = z.infer<
   typeof DesktopSettlePromptMessageSchema
 >;
-
-export function buildDesktopShowPromptMessage(
-  payload: Omit<DesktopShowPromptMessage, 'command'>,
-): DesktopShowPromptMessage {
-  return { command: DESKTOP_PROMPT_COMMANDS.SHOW, ...payload };
-}
-
-export function buildDesktopSettlePromptMessage(
-  requestId: string,
-  value: string | null,
-): DesktopSettlePromptMessage {
-  return { command: DESKTOP_PROMPT_COMMANDS.SETTLE, requestId, value };
-}

--- a/packages/desktop/src/main/desktopDiffHost.ts
+++ b/packages/desktop/src/main/desktopDiffHost.ts
@@ -11,7 +11,8 @@ import {
 import { computeUserPatch } from '@tools/approval/toolEditApproval';
 
 import {
-  buildDesktopShowDiffMessage,
+  DESKTOP_DIFF_COMMANDS,
+  type DesktopShowDiffMessage,
   monacoLanguageForFilePath,
 } from '../desktopDiffMessages.js';
 import { createTexraTempDir } from './desktopTempDir.js';
@@ -51,7 +52,7 @@ export function createDesktopDiffHost(
   // Try to render the diff in the wa-dialog overlay. Returns `false` (so the
   // caller falls back to the external editor) when the renderer rejects or
   // throws; mirrors the preview host's contract.
-  function tryShowDiffInRenderer(message: unknown): boolean {
+  function tryShowDiffInRenderer(message: DesktopShowDiffMessage): boolean {
     if (!options.postToRenderer || options.forceExternal) return false;
     try {
       return options.postToRenderer(message) !== false;
@@ -77,16 +78,15 @@ export function createDesktopDiffHost(
     // Prefer the in-app overlay when wired. A `false` return value or
     // a thrown error opts into the external-editor fallback (covers the
     // startup IPC race, destroyed BrowserWindow, and `forceExternal`).
-    const shownInRenderer = tryShowDiffInRenderer(
-      buildDesktopShowDiffMessage({
-        title,
-        originalText: originalContent,
-        proposedText: proposedContent,
-        language: monacoLanguageForFilePath(proposed.filePath),
-        originalPath: original.filePath,
-        proposedPath: proposed.filePath,
-      }),
-    );
+    const shownInRenderer = tryShowDiffInRenderer({
+      command: DESKTOP_DIFF_COMMANDS.SHOW_DIFF,
+      title,
+      originalText: originalContent,
+      proposedText: proposedContent,
+      language: monacoLanguageForFilePath(proposed.filePath),
+      originalPath: original.filePath,
+      proposedPath: proposed.filePath,
+    });
     if (shownInRenderer) return { original, proposed, title };
 
     // External-editor fallback: write a unified patch file and open it.

--- a/packages/desktop/src/main/desktopPreviewHost.ts
+++ b/packages/desktop/src/main/desktopPreviewHost.ts
@@ -10,7 +10,10 @@ import { getFileStem } from '@utils/core';
 import { createExternalLocation } from '@utils/files';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
-import { buildDesktopShowPdfMessage } from '../desktopPdfMessages.js';
+import {
+  DESKTOP_PDF_COMMANDS,
+  type DesktopShowPdfMessage,
+} from '../desktopPdfMessages.js';
 
 interface DesktopShellAdapter {
   openExternal(url: string): Promise<void>;
@@ -95,9 +98,11 @@ export function createDesktopPreviewHost(
   function tryShowPdfInRenderer(pdfPath: string, title: string): boolean {
     if (!options.postToRenderer || options.forceExternal) return false;
     try {
-      const result = options.postToRenderer(
-        buildDesktopShowPdfMessage({ title, pdfPath }),
-      );
+      const result = options.postToRenderer({
+        command: DESKTOP_PDF_COMMANDS.SHOW_PDF,
+        title,
+        pdfPath,
+      } satisfies DesktopShowPdfMessage);
       return result !== false;
     } catch (error) {
       console.error(

--- a/packages/desktop/src/main/desktopPromptController.ts
+++ b/packages/desktop/src/main/desktopPromptController.ts
@@ -1,8 +1,9 @@
 import { randomUUID } from 'node:crypto';
 
 import {
-  buildDesktopShowPromptMessage,
+  DESKTOP_PROMPT_COMMANDS,
   DesktopSettlePromptMessageSchema,
+  type DesktopShowPromptMessage,
 } from '../desktopPromptMessages.js';
 import type {
   DesktopCommandMessage,
@@ -38,14 +39,13 @@ export class DesktopPromptController implements DesktopPromptIpc {
     const requestId = randomUUID();
     return new Promise((resolve) => {
       this.pending.set(requestId, { resolve });
-      const delivered = this.renderer.postToRenderer(
-        buildDesktopShowPromptMessage({
-          requestId,
-          title: input.title,
-          prompt: input.prompt,
-          password: input.password ?? false,
-        }),
-      );
+      const delivered = this.renderer.postToRenderer({
+        command: DESKTOP_PROMPT_COMMANDS.SHOW,
+        requestId,
+        title: input.title,
+        prompt: input.prompt,
+        password: input.password ?? false,
+      } satisfies DesktopShowPromptMessage);
       if (!delivered) this.settle(requestId, undefined);
     });
   }

--- a/packages/desktop/src/renderer/promptOverlay.ts
+++ b/packages/desktop/src/renderer/promptOverlay.ts
@@ -4,7 +4,7 @@ import '@awesome.me/webawesome/dist/components/input/input.js';
 
 // Local imports - prompt protocol
 import {
-  buildDesktopSettlePromptMessage,
+  DESKTOP_PROMPT_COMMANDS,
   type DesktopSettlePromptMessage,
   type DesktopShowPromptMessage,
 } from '../desktopPromptMessages';
@@ -66,7 +66,11 @@ export function createDesktopPromptOverlay(
     request: DesktopShowPromptMessage,
     value: string | null,
   ): void {
-    send(buildDesktopSettlePromptMessage(request.requestId, value));
+    send({
+      command: DESKTOP_PROMPT_COMMANDS.SETTLE,
+      requestId: request.requestId,
+      value,
+    });
   }
 
   function settle(value: string | null): void {

--- a/src/test-kernel/desktop/DesktopDiffMessages.vitest.mts
+++ b/src/test-kernel/desktop/DesktopDiffMessages.vitest.mts
@@ -34,9 +34,9 @@ describe('monacoLanguageForFilePath', () => {
 
 describe('DesktopShowDiffMessageSchema', () => {
   it('round-trips a complete payload', async () => {
-    const { DesktopShowDiffMessageSchema, buildDesktopShowDiffMessage } =
-      await loadDiffMessages();
-    const message = buildDesktopShowDiffMessage({
+    const { DesktopShowDiffMessageSchema } = await loadDiffMessages();
+    const parsed = DesktopShowDiffMessageSchema.parse({
+      command: 'desktop:showDiff',
       title: 'Compare',
       originalText: 'a',
       proposedText: 'b',
@@ -44,7 +44,6 @@ describe('DesktopShowDiffMessageSchema', () => {
       originalPath: '/a',
       proposedPath: '/b',
     });
-    const parsed = DesktopShowDiffMessageSchema.parse(message);
     expect(parsed.command).toBe('desktop:showDiff');
     expect(parsed.language).toBe('latex');
   });

--- a/src/test-kernel/desktop/DesktopPdfMessages.vitest.mts
+++ b/src/test-kernel/desktop/DesktopPdfMessages.vitest.mts
@@ -12,13 +12,12 @@ async function loadPdfMessages(): Promise<
 
 describe('DesktopShowPdfMessageSchema', () => {
   it('round-trips a complete payload', async () => {
-    const { DesktopShowPdfMessageSchema, buildDesktopShowPdfMessage } =
-      await loadPdfMessages();
-    const message = buildDesktopShowPdfMessage({
+    const { DesktopShowPdfMessageSchema } = await loadPdfMessages();
+    const parsed = DesktopShowPdfMessageSchema.parse({
+      command: 'desktop:showPdf',
       title: 'paper.pdf',
       pdfPath: '/abs/path/to/paper.pdf',
     });
-    const parsed = DesktopShowPdfMessageSchema.parse(message);
     expect(parsed.command).toBe('desktop:showPdf');
     expect(parsed.pdfPath).toBe('/abs/path/to/paper.pdf');
   });


### PR DESCRIPTION
## Summary

- Inline the diff, PDF, prompt-open, and prompt-settlement IPC objects at their sole producers.
- Delete the four identity builders without replacement facades or re-exports.
- Retain the protocol schemas, command constants, Monaco language mapping, PDF path safety, and the shared onboarding builder.
- Remove three dead-code baseline exceptions made obsolete by direct command-constant consumers.

No user-visible behavior or public or persisted wire-format change is intended. No changelog entry is needed.

## Issue acceptance gates

Closes #8802.

- Diff, PDF, prompt-open, and prompt-settlement messages are constructed as typed literals at their sole producers.
- The four identity builders are deleted.
- Schemas, command constants, language mapping, PDF safety, and the three-consumer onboarding builder are unchanged.

## Single source of truth

The existing Zod schemas and `DESKTOP_*_COMMANDS` constants remain the single sources of truth for each IPC message contract.

## Duplication and abstraction budget

Four trivial one-consumer identity builders are removed. No abstraction, facade, compatibility export, or duplicated protocol definition is added.

## Net elements (R6)

- Production TypeScript: `+36/-58`, net `-22`.
- Tests: `+6/-8`, net `-2`.
- Dead-code ratchet configuration: `+0/-15`, net `-15`.
- Total: `+42/-81`, net `-39`.
- Exported functions: four deleted, none added.
- Files, classes, interfaces, and enums: no net change.

The four IPC object constructions are relocations from identity builders to their sole producers; their command and payload values are unchanged. The four builder definitions account for 31 deleted production lines. The remaining reduction comes from simpler call sites, schema-test setup, and obsolete ratchet entries.

## Consumer counts (R8)

Repository-wide searches, including `.mts` and `.cts`, found one production consumer for each deleted builder:

- `buildDesktopShowDiffMessage`: 1.
- `buildDesktopShowPdfMessage`: 1.
- `buildDesktopShowPromptMessage`: 1.
- `buildDesktopSettlePromptMessage`: 1.

The onboarding builder remains because it has three consumers.

## Host impact

Extension: none.

Desktop: internal message construction is inlined; commands and payloads are byte-for-byte unchanged.

CLI: none.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (passes with one pre-existing warning in `AgentCreatorToolCatalogParity.vitest.mts`)
- `npm run check:dead-code-ratchet`
- `npm test -- src/test-kernel/desktop/DesktopDiffMessages.vitest.mts src/test-kernel/desktop/DesktopDiffHost.vitest.mts src/test-kernel/desktop/DesktopPdfMessages.vitest.mts src/test-kernel/desktop/DesktopPreviewHost.vitest.mts src/test-kernel/desktop/DesktopPromptController.vitest.mts src/test-kernel/desktop/DesktopPromptOverlay.vitest.mts` (46 tests)
- Manual simplification review of the complete diff
