### PR TITLE
refactor(storage): tighten Node JSON store contracts

### DIFF
--- a/packages/cli/src/runtime/cliConfig.ts
+++ b/packages/cli/src/runtime/cliConfig.ts
@@ -294,9 +294,7 @@ export async function setWorkspaceCliChatAgent(
   if (agent !== undefined && !trimmed) {
     throw new Error('The default chat agent must not be empty.');
   }
-  const store = await JsonStore.open(workspaceTexraConfigPath(cwd), {
-    corruptionPolicy: 'fail',
-  });
+  const store = await JsonStore.open(workspaceTexraConfigPath(cwd));
   const snapshot = store.snapshot();
   const sectionKey = Object.hasOwn(snapshot, 'texra.chat')
     ? 'texra.chat'

--- a/packages/cli/src/runtime/cliSecrets.ts
+++ b/packages/cli/src/runtime/cliSecrets.ts
@@ -75,7 +75,6 @@ export class CliSecrets implements PlatformSecrets {
   private openStore(): Promise<JsonStore> {
     return JsonStore.open(this.filePath, {
       mode: SECRETS_FILE_MODE,
-      corruptionPolicy: 'fail',
     });
   }
 }

--- a/packages/cli/src/runtime/cliStateStores.ts
+++ b/packages/cli/src/runtime/cliStateStores.ts
@@ -24,12 +24,8 @@ export async function createCliStateStores(
     workspacePath: init.workspacePath,
   });
   const [globalStore, workspaceStore] = await Promise.all([
-    JsonStore.open(path.join(storage.getGlobalStoragePath(), 'state.json'), {
-      corruptionPolicy: 'fail',
-    }),
-    JsonStore.open(path.join(storage.getStoragePath(), 'state.json'), {
-      corruptionPolicy: 'fail',
-    }),
+    JsonStore.open(path.join(storage.getGlobalStoragePath(), 'state.json')),
+    JsonStore.open(path.join(storage.getStoragePath(), 'state.json')),
   ]);
 
   return {

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -264,7 +264,6 @@ export async function initCliPlatform(
   if (!tryPlatform()) {
     const configStore = await JsonStore.open(
       workspaceTexraConfigPath(cliWorkspaceCwd),
-      { corruptionPolicy: 'fail' },
     );
     const stateStores = await createCliStateStores({
       storageRoot: context.storageRoot,
@@ -279,7 +278,6 @@ export async function initCliPlatform(
         stateStores.storage.getGlobalStoragePath(),
         TEXRA_CONFIG_FILE_NAME,
       ),
-      { corruptionPolicy: 'fail' },
     );
     // Same severity and wording as the extension/desktop hosts: a shutdown
     // handler failure is an error everywhere, not a warning in one host.

--- a/packages/cli/src/runtime/updateChecker.ts
+++ b/packages/cli/src/runtime/updateChecker.ts
@@ -408,7 +408,6 @@ export async function notifyCliUpdate(context: CliContext): Promise<void> {
         createNodeStorageProvider().getGlobalStoragePath(),
         'state.json',
       ),
-      { corruptionPolicy: 'fail' },
     );
     latest = await checkCliUpdateAvailable({
       currentVersion: context.version,

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -111,7 +111,6 @@ export async function initializeElectronPlatform(
   const userDataPath = app.getPath('userData');
   const globalStateStore = await JsonStore.open(
     join(userDataPath, 'state', 'global.json'),
-    { corruptionPolicy: 'fail' },
   );
   const storedWorkspacePath = globalStateStore.get<string>(
     DESKTOP_WORKSPACE_PATH_STATE_KEY,
@@ -134,11 +133,9 @@ export async function initializeElectronPlatform(
   const storage = new WorkspaceStorageProvider(dataRoot, workspacePath);
   const workspaceStateStore = await JsonStore.open(
     join(storage.getStoragePath(), 'state.json'),
-    { corruptionPolicy: 'fail' },
   );
   const globalConfigStore = await JsonStore.open(
     join(userDataPath, 'config', 'global.json'),
-    { corruptionPolicy: 'fail' },
   );
   // Workspace config lives in the project's `.texra/config.json` — the same
   // file the CLI reads and writes — so a checked-in config behaves
@@ -158,9 +155,7 @@ export async function initializeElectronPlatform(
   if (workspacePath) {
     const projectConfigPath = workspaceTexraConfigPath(workspacePath);
     try {
-      projectConfigStore = await JsonStore.open(projectConfigPath, {
-        corruptionPolicy: 'fail',
-      });
+      projectConfigStore = await JsonStore.open(projectConfigPath);
       projectConfigWritable = await canCreateOrWrite(projectConfigPath);
     } catch (error) {
       console.warn(
@@ -175,9 +170,7 @@ export async function initializeElectronPlatform(
   // degradation.
   let internalConfigStore: JsonStore | undefined;
   try {
-    internalConfigStore = await JsonStore.open(legacyWorkspaceConfigPath, {
-      corruptionPolicy: 'fail',
-    });
+    internalConfigStore = await JsonStore.open(legacyWorkspaceConfigPath);
   } catch (error) {
     if (projectConfigStore === undefined) throw error;
     console.warn(
@@ -263,10 +256,7 @@ export async function initializeElectronPlatform(
       );
     }
   }
-  const secretsStore = await JsonStore.open(
-    join(userDataPath, 'secrets.json'),
-    { corruptionPolicy: 'fail' },
-  );
+  const secretsStore = await JsonStore.open(join(userDataPath, 'secrets.json'));
 
   repairLaunchPath();
   const agentDirectories = createPlatformAgentDirectories({

--- a/src/platform/defaults/jsonConfigProvider.ts
+++ b/src/platform/defaults/jsonConfigProvider.ts
@@ -15,21 +15,20 @@ import type {
 
 export interface JsonConfigProviderOptions {
   workspace: JsonStore;
-  global?: JsonStore;
+  global: JsonStore;
 }
 
 /**
  * File-backed {@link ConfigProvider}. Keys are stored flat with the canonical
  * `texra.*` prefix; bare keys are accepted on read for legacy compatibility.
  * Writes use the canonical prefixed form unless a legacy unprefixed entry
- * already exists. When a `global` store is supplied, workspace values shadow
- * global values on read and `update()` routes writes by {@link ConfigTarget}.
- * Writing to `'global'` without a `global` store throws.
+ * already exists. Workspace values shadow global values on read and
+ * `update()` routes writes by {@link ConfigTarget}.
  */
 export class JsonConfigProvider implements ConfigProvider {
   private readonly watchers = createWatcherRegistry();
   private readonly workspaceStore: JsonStore;
-  private readonly globalStore: JsonStore | undefined;
+  private readonly globalStore: JsonStore;
 
   constructor({ workspace, global }: JsonConfigProviderOptions) {
     this.workspaceStore = workspace;
@@ -40,10 +39,8 @@ export class JsonConfigProvider implements ConfigProvider {
     const keys = configKeyVariants(key);
     const workspaceValue = firstStoredValue<T>(this.workspaceStore, keys);
     if (workspaceValue !== undefined) return workspaceValue;
-    if (this.globalStore) {
-      const globalValue = firstStoredValue<T>(this.globalStore, keys);
-      if (globalValue !== undefined) return globalValue;
-    }
+    const globalValue = firstStoredValue<T>(this.globalStore, keys);
+    if (globalValue !== undefined) return globalValue;
     return defaultValue as T;
   }
 
@@ -52,7 +49,7 @@ export class JsonConfigProvider implements ConfigProvider {
     value: T,
     target: ConfigTarget = 'workspace',
   ): Promise<void> {
-    const store = this.storeForWrite(target);
+    const store = target === 'global' ? this.globalStore : this.workspaceStore;
     const keys = configKeyVariants(key);
     if (value === undefined) {
       await Promise.all(
@@ -72,9 +69,7 @@ export class JsonConfigProvider implements ConfigProvider {
   inspect<T = unknown>(key: string): ConfigInspection<T> | undefined {
     const keys = configKeyVariants(key);
     return {
-      globalValue: this.globalStore
-        ? firstStoredValue<T>(this.globalStore, keys)
-        : undefined,
+      globalValue: firstStoredValue<T>(this.globalStore, keys),
       workspaceValue: firstStoredValue<T>(this.workspaceStore, keys),
       effectiveValue: this.get<T>(key),
     };
@@ -83,8 +78,7 @@ export class JsonConfigProvider implements ConfigProvider {
   isExplicitlySet(key: string): boolean {
     return configKeyVariants(key).some(
       (candidate) =>
-        this.workspaceStore.has(candidate) ||
-        (this.globalStore?.has(candidate) ?? false),
+        this.workspaceStore.has(candidate) || this.globalStore.has(candidate),
     );
   }
 
@@ -93,17 +87,5 @@ export class JsonConfigProvider implements ConfigProvider {
     listener: () => void,
   ): Disposable {
     return this.watchers.add({ key, listener });
-  }
-
-  private storeForWrite(target: ConfigTarget): JsonStore {
-    if (target === 'global') {
-      if (!this.globalStore) {
-        throw new Error(
-          "JsonConfigProvider was constructed without a global store; cannot update with target='global'.",
-        );
-      }
-      return this.globalStore;
-    }
-    return this.workspaceStore;
   }
 }

--- a/src/platform/defaults/jsonStore.ts
+++ b/src/platform/defaults/jsonStore.ts
@@ -19,13 +19,6 @@ type JsonRecord = Record<string, unknown>;
 
 export interface JsonStoreOptions {
   /**
-   * Determines how a present file containing malformed or non-object JSON is
-   * handled. The current contract permits only `fail`; a recovery policy must
-   * define how the original bytes are preserved and how recovery is reported
-   * before this type is widened.
-   */
-  corruptionPolicy: 'fail';
-  /**
    * POSIX mode for the store file (e.g. `0o600` to restrict a secrets file
    * to its owner). The containing directory is created/chmod'd with the
    * same owner permissions plus execute — `0o600` -> `0o700` — so it stays
@@ -102,7 +95,7 @@ export class JsonStore implements StateStore {
    */
   static async open(
     filePath: string,
-    options: JsonStoreOptions,
+    options: JsonStoreOptions = {},
   ): Promise<JsonStore> {
     const storePath = resolve(filePath);
     return new JsonStore(storePath, await readJsonRecord(storePath), options);

--- a/src/test-kernel/desktop/ElectronAgentDirectories.vitest.mts
+++ b/src/test-kernel/desktop/ElectronAgentDirectories.vitest.mts
@@ -30,10 +30,7 @@ interface JsonStore {
 
 interface JsonStoreModule {
   JsonStore: {
-    open(
-      filePath: string,
-      options: { corruptionPolicy: 'fail' },
-    ): Promise<JsonStore>;
+    open(filePath: string): Promise<JsonStore>;
   };
 }
 
@@ -118,11 +115,9 @@ describe('desktop agent directory bootstrap', () => {
     const storage = new WorkspaceStorageProvider(userDataPath, workspacePath);
     const globalStateStore = await JsonStore.open(
       join(userDataPath, 'state', 'global.json'),
-      { corruptionPolicy: 'fail' },
     );
     const workspaceStateStore = await JsonStore.open(
       join(storage.getStoragePath(), 'state.json'),
-      { corruptionPolicy: 'fail' },
     );
 
     initPlatform({

--- a/src/test-kernel/desktop/ElectronConfig.vitest.mts
+++ b/src/test-kernel/desktop/ElectronConfig.vitest.mts
@@ -36,17 +36,14 @@ interface JsonConfigProvider {
 
 interface JsonStoreModule {
   JsonStore: {
-    open(
-      filePath: string,
-      options: { corruptionPolicy: 'fail' },
-    ): Promise<JsonStore>;
+    open(filePath: string): Promise<JsonStore>;
   };
 }
 
 interface JsonConfigProviderModule {
   JsonConfigProvider: new (options: {
     workspace: JsonStore;
-    global?: JsonStore;
+    global: JsonStore;
   }) => JsonConfigProvider;
 }
 
@@ -80,12 +77,9 @@ describe('desktop JsonConfigProvider (dual-store)', () => {
     const { JsonStore, JsonConfigProvider } =
       await loadDesktopConfigConstructors();
     tempDir = await mkdtemp(join(tmpdir(), 'texra-electron-config-'));
-    const globalStore = await JsonStore.open(join(tempDir, 'global.json'), {
-      corruptionPolicy: 'fail',
-    });
+    const globalStore = await JsonStore.open(join(tempDir, 'global.json'));
     const workspaceStore = await JsonStore.open(
       join(tempDir, 'workspace.json'),
-      { corruptionPolicy: 'fail' },
     );
     return {
       provider: new JsonConfigProvider({

--- a/src/test-kernel/desktop/ElectronPlatformAdapters.vitest.mts
+++ b/src/test-kernel/desktop/ElectronPlatformAdapters.vitest.mts
@@ -40,10 +40,7 @@ interface JsonStore {
 
 interface JsonStoreModule {
   JsonStore: {
-    open(
-      filePath: string,
-      options: { corruptionPolicy: 'fail' },
-    ): Promise<JsonStore>;
+    open(filePath: string): Promise<JsonStore>;
   };
 }
 
@@ -136,9 +133,7 @@ describe('desktop platform adapters', () => {
       loadJsonStore(),
     ]);
     const root = await makeTempDir('texra-electron-secrets-');
-    const store = await JsonStore.open(join(root, 'secrets.json'), {
-      corruptionPolicy: 'fail',
-    });
+    const store = await JsonStore.open(join(root, 'secrets.json'));
     const secrets = new secretsModule.ElectronSecrets(store, options);
     return { module: secretsModule, store, secrets };
   }
@@ -171,9 +166,7 @@ describe('desktop platform adapters', () => {
   it('persists state values and deletes undefined updates through JsonStore', async () => {
     const JsonStore = await loadJsonStore();
     const root = await makeTempDir('texra-electron-state-');
-    const store = await JsonStore.open(join(root, 'state.json'), {
-      corruptionPolicy: 'fail',
-    });
+    const store = await JsonStore.open(join(root, 'state.json'));
 
     await store.update('session', { active: true });
     await store.update('cleared', 'value');

--- a/src/test-kernel/desktop/JsonStore.vitest.mts
+++ b/src/test-kernel/desktop/JsonStore.vitest.mts
@@ -30,14 +30,9 @@ interface JsonStore {
   snapshot(): Record<string, unknown>;
 }
 
-interface JsonStoreOptions {
-  corruptionPolicy: 'fail';
-  mode?: number;
-}
-
 interface JsonStoreModule {
   JsonStore: {
-    open(filePath: string, options: JsonStoreOptions): Promise<JsonStore>;
+    open(filePath: string, options?: { mode?: number }): Promise<JsonStore>;
   };
 }
 
@@ -71,9 +66,7 @@ describe('shared JsonStore', () => {
     const original = '{"truncated"';
     const filePath = await createTempFile('state.json', original);
 
-    await expect(
-      JsonStore.open(filePath, { corruptionPolicy: 'fail' }),
-    ).rejects.toBeInstanceOf(SyntaxError);
+    await expect(JsonStore.open(filePath)).rejects.toBeInstanceOf(SyntaxError);
     expect(await readFile(filePath, 'utf8')).toBe(original);
   });
 
@@ -85,9 +78,9 @@ describe('shared JsonStore', () => {
     const JsonStore = await loadJsonStore();
     const filePath = await createTempFile('state.json', content);
 
-    await expect(
-      JsonStore.open(filePath, { corruptionPolicy: 'fail' }),
-    ).rejects.toThrow('to contain a JSON object');
+    await expect(JsonStore.open(filePath)).rejects.toThrow(
+      'to contain a JSON object',
+    );
   });
 
   it('merges with a concurrent writer instead of flushing a stale open-time snapshot', async () => {
@@ -97,9 +90,7 @@ describe('shared JsonStore', () => {
       '{"keep": 1, "drop": 1}\n',
     );
 
-    const store = await JsonStore.open(filePath, {
-      corruptionPolicy: 'fail',
-    });
+    const store = await JsonStore.open(filePath);
     // Simulate another process persisting a key while this store sits open
     // (e.g. across an awaited network fetch).
     await writeFile(filePath, '{"keep": 1, "drop": 1, "foreign": 2}\n');
@@ -115,9 +106,7 @@ describe('shared JsonStore', () => {
   it('rejects a mutation when the file becomes corrupt and preserves its bytes', async () => {
     const JsonStore = await loadJsonStore();
     const filePath = await createTempFile('state.json', '{"keep": 1}\n');
-    const store = await JsonStore.open(filePath, {
-      corruptionPolicy: 'fail',
-    });
+    const store = await JsonStore.open(filePath);
 
     const corrupt = '{"truncated"';
     await writeFile(filePath, corrupt);
@@ -129,9 +118,7 @@ describe('shared JsonStore', () => {
   it('preserves loaded keys when the backing file disappears before a mutation', async () => {
     const JsonStore = await loadJsonStore();
     const filePath = await createTempFile('state.json', '{"keep": 1}\n');
-    const store = await JsonStore.open(filePath, {
-      corruptionPolicy: 'fail',
-    });
+    const store = await JsonStore.open(filePath);
 
     await rm(filePath);
     await store.set('added', 2);
@@ -147,8 +134,8 @@ describe('shared JsonStore', () => {
     const filePath = await createTempFile('state.json', '{}\n');
 
     const [a, b] = await Promise.all([
-      JsonStore.open(filePath, { corruptionPolicy: 'fail' }),
-      JsonStore.open(filePath, { corruptionPolicy: 'fail' }),
+      JsonStore.open(filePath),
+      JsonStore.open(filePath),
     ]);
     // Both instances opened off the same on-disk snapshot; without per-path
     // read-modify-write serialization the later flush drops the other's key.
@@ -204,7 +191,7 @@ describe('shared JsonStore', () => {
     const script = `
       (async () => {
         const { JsonStore } = require(${JSON.stringify(bundlePath)});
-        const store = await JsonStore.open(${JSON.stringify(filePath)}, { corruptionPolicy: 'fail' });
+        const store = await JsonStore.open(${JSON.stringify(filePath)});
         console.log('ready');
         await store.set('child', 2);
       })().catch((error) => {
@@ -258,7 +245,6 @@ describe('shared JsonStore', () => {
 
     try {
       const store = await JsonStore.open(filePath, {
-        corruptionPolicy: 'fail',
         mode: 0o600,
       });
 
@@ -282,7 +268,6 @@ describe('shared JsonStore', () => {
     const filePath = join(tempDir, 'nested', 'secrets.json');
 
     const store = await JsonStore.open(filePath, {
-      corruptionPolicy: 'fail',
       mode: 0o600,
     });
     await store.set('key', 'value');


### PR DESCRIPTION
## Summary

- Remove the unread `corruptionPolicy: 'fail'` option from `JsonStore` and every live caller while retaining the existing fail-on-malformed-data path.
- Require the global JSON configuration store that both Node composition roots already install.
- Delete the impossible missing-global-store branch while preserving workspace precedence, canonical and legacy key selection, and targeted writes.

No user-visible behavior, persisted format, or public wire-format change is intended. File-mode handling remains on the existing `mode` option. No changelog entry is included.

## Issue acceptance gates

Closes #8793.

- Malformed present JSON and non-object JSON still throw without changing the original bytes.
- Secret file and directory permissions are unchanged.
- Workspace values still shadow global values.
- Legacy unprefixed configuration keys retain their read/write precedence.
- `texra run` and `--print` output retain their tested behavior.

## Single source of truth

`JsonStore` remains the file-backed JSON contract, and `JsonConfigProvider` remains the sole owner of workspace-over-global configuration precedence.

## Duplication and abstraction budget

The unread corruption-policy ritual and the impossible optional-global-store branch are deleted. No facade, compatibility shim, or replacement abstraction is introduced.

## Net elements (R6)

- Production: `+16/-61`, net `-45`.
- Tests: `+18/-51`, net `-33`.
- Total: `+34/-112`, net `-78`.
- Relocated lines: 0.
- Exported types: `JsonStoreOptions` and `JsonConfigProviderOptions` are tightened in place; no exported symbol is added or deleted.
- Files, classes, interfaces, and enums: no net change.

## Consumer counts (R8)

Repository-wide searches, including `.mts` and `.cts`, found:

- Every live `corruptionPolicy` argument was the literal `'fail'`; the option had no read site.
- `JsonConfigProvider` has two production composition roots, CLI and desktop, and both already install a global store.
- No supported production construction omits the global store.

## Host impact

Extension: none.

Desktop: construction contracts are tightened; storage behavior is unchanged.

CLI: construction contracts are tightened; output and storage behavior are unchanged.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (passes with one pre-existing warning in an unrelated test)
- `npm run check:dead-code-ratchet`
- Targeted Vitest: 14 files, 237 tests passed
- Post-simplifier `JsonStore` rerun: 11 tests passed
- Targeted Prettier check for all 12 changed files
- Manual simplifier review; the remaining single-consumer test options interface was inlined
