### PR TITLE
refactor(files): delete unused filesystem helper APIs

### DIFF
--- a/src/utils/files/baseFS.ts
+++ b/src/utils/files/baseFS.ts
@@ -6,7 +6,7 @@ import * as path from 'node:path';
 import { FileType, type FileStat } from '@platform/interfaces';
 import { platform } from '@platform/platform';
 import { normalizeLineEndings } from '@utils/text/stringUtils';
-import { isFile, isDirectory } from './fsEntryType';
+import { isFile } from './fsEntryType';
 
 /** Convert content to Buffer for writing. */
 function toBuffer(content: string | Uint8Array): Uint8Array {
@@ -177,18 +177,6 @@ export abstract class BaseFS {
     );
   }
 
-  public static async isDir(
-    this: typeof BaseFS,
-    target: string,
-  ): Promise<boolean> {
-    try {
-      const stats = await this.stat(target);
-      return isDirectory(stats.type);
-    } catch {
-      return false;
-    }
-  }
-
   public static async isFile(
     this: typeof BaseFS,
     target: string,
@@ -229,19 +217,6 @@ export abstract class BaseFS {
     return fs.readFileSync(this.preparePath(target));
   }
 
-  public static writeSync(
-    this: typeof BaseFS,
-    target: string,
-    content: string | Buffer,
-  ): void {
-    const resolved = this.preparePath(target);
-    if (typeof content === 'string') {
-      fs.writeFileSync(resolved, content, 'utf-8');
-    } else {
-      fs.writeFileSync(resolved, content);
-    }
-  }
-
   public static deleteSync(this: typeof BaseFS, target: string): void {
     fs.unlinkSync(this.preparePath(target));
   }
@@ -252,12 +227,6 @@ export abstract class BaseFS {
     options?: { recursive?: boolean },
   ): void {
     fs.mkdirSync(this.preparePath(target), options);
-  }
-
-  public static ensureDirSync(this: typeof BaseFS, target: string): void {
-    if (!this.existsSync(target)) {
-      this.mkdirSync(target, { recursive: true });
-    }
   }
 
   public static readDirSync(this: typeof BaseFS, target: string): string[] {
@@ -304,14 +273,6 @@ export abstract class BaseFS {
         }),
   ): fs.WriteStream {
     return fs.createWriteStream(this.preparePath(target), options);
-  }
-
-  public static unlink(
-    this: typeof BaseFS,
-    target: string,
-    callback: (err: NodeJS.ErrnoException | null) => void,
-  ): void {
-    fs.unlink(this.preparePath(target), callback);
   }
 
   // ===== Utility helpers =====

--- a/src/utils/files/flexibleFS.ts
+++ b/src/utils/files/flexibleFS.ts
@@ -35,10 +35,6 @@ class FlexibleFSImpl {
     return AbsoluteFS.read(target.absolutePath);
   }
 
-  readBytes(target: FileLocation): Promise<Buffer> {
-    return AbsoluteFS.readBytes(target.absolutePath);
-  }
-
   appendFile(
     target: FileLocation,
     content: string | Uint8Array,

--- a/src/utils/files/storageFS.ts
+++ b/src/utils/files/storageFS.ts
@@ -19,13 +19,6 @@ export class StorageFS extends RelativeFS {
     return platform().storage.getStoragePath();
   }
 
-  /**
-   * Get the global storage base path (shared across workspaces)
-   */
-  public static getGlobalPath(): string {
-    return platform().storage.getGlobalStoragePath();
-  }
-
   // Inherit file operations from RelativeFS
 }
 
@@ -35,6 +28,6 @@ export class StorageFS extends RelativeFS {
  */
 export class GlobalStorageFS extends RelativeFS {
   protected static override getBasePath(): string {
-    return StorageFS.getGlobalPath();
+    return platform().storage.getGlobalStoragePath();
   }
 }


### PR DESCRIPTION
## Summary

This pull request removes six unused filesystem helper methods while preserving every live provider capability. `GlobalStorageFS` now obtains its global storage root directly from the platform provider instead of passing through `StorageFS.getGlobalPath`.

No user-visible behavior or public or persisted wire format changes are intended. This pull request intentionally has no changelog entry.

## Issue acceptance gates

- Closes #8795.
- Rechecked TypeScript and JavaScript consumers, including `.mts`, `.cts`, bracket access, property-name references, and dynamic-looking access, immediately before deletion.
- Inspected every open pull request for file overlap before implementation and again before publication; none overlaps these files.
- Used a fresh worktree from current `origin/main` and installed dependencies locally.
- Deleted the methods without replacement facades or re-export shims.
- Preserved every filesystem provider capability with a real consumer.
- Ran every required check and the focused filesystem/storage test suites.

## Single source of truth

`BaseFS`, `RelativeFS`, and `FlexibleFS` remain the owners of their respective live filesystem operations. `GlobalStorageFS.getBasePath` now owns the direct mapping to `platform().storage.getGlobalStoragePath()`; there is no intermediate public shim.

## Duplication and abstraction budget

The change deletes six unused methods and introduces no files, exports, classes, interfaces, factories, facades, or other abstractions. The single pass-through global-path method is replaced by its underlying provider call at the only internal call site.

## Net elements (R6)

- files: 0 added, 0 deleted, 3 modified
- exported symbols: 0 added, 0 deleted
- classes/interfaces/enums: 0 added, 0 deleted
- production: 2 additions, 52 deletions, net **-50 LoC**
- tests: 0 additions, 0 deletions, net **0 LoC**
- total: net **-50 LoC**
- deleted API implementation: 50 lines across six unused methods
- relocated operations: one existing global-storage provider lookup moved from `StorageFS.getGlobalPath` into `GlobalStorageFS.getBasePath`; no provider capability was deleted
- other replacements: one import line narrowed after removing `isDir`

## Consumer counts (R8)

No emit path is deleted or rerouted. The pre-deletion repository consumer counts were:

- `BaseFS.isDir`: 0
- `BaseFS.writeSync`: 0
- `BaseFS.ensureDirSync`: 0
- callback-style `BaseFS.unlink`: 0
- `FlexibleFS.readBytes`: 0
- `StorageFS.getGlobalPath`: 0 external consumers and one internal pass-through call from `GlobalStorageFS.getBasePath`, now routed directly to the same platform provider

## Host impact

Extension: No behavior change; live filesystem calls are unchanged.

Desktop: No behavior change; live filesystem calls are unchanged.

CLI: No behavior change; global storage resolution uses the same platform provider.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (passes with one pre-existing warning in `AgentCreatorToolCatalogParity.vitest.mts`)
- `npm run check:dead-code-ratchet`
- `npx vitest run src/test-kernel/utils/files/FilesUtils.vitest.ts src/test-kernel/platform/WorkspaceStorage.vitest.ts src/test-kernel/frontend/SharedStorageRoot.vitest.ts src/test-kernel/cli/ChatDefaults.vitest.mts src/test-kernel/cli/ChatDefaultsFastPath.vitest.mts` (42 tests)
- code-simplifier review of the final diff; no further behavior-preserving simplification was warranted
