### PR TITLE
refactor(storage): require TaskRunFileService execution identity

### DIFF
--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -60,13 +60,12 @@ export class OutputNode<C = unknown> extends Node<
 > {
   private outputDependencies(): OutputDependencies {
     const { runScope } = useLaunchRunContext();
-    const { executionId, runtimeHost, streamId } = runScope;
+    const { runtimeHost, streamId } = runScope;
     const { baseFiles, config, fileService, logger, setting } = this.services;
 
     return {
       baseFiles,
       config,
-      executionId,
       fileService,
       logger,
       runtimeHost,
@@ -99,7 +98,7 @@ export class OutputNode<C = unknown> extends Node<
     // stats all see the same base locations (see snapshotResolution).
     const diffBaseFiles = await resolveBaseFilesForDiff(
       baseFiles,
-      outputDependencies.executionId,
+      outputDependencies.fileService.executionId,
     );
 
     let mapping: RoundFileMapping | undefined;

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -149,15 +149,6 @@ export async function runReflectionFlow<C = unknown>(
   const getOutputFileLocation =
     input.getOutputFileLocation ??
     (async (round: number): Promise<AgentFileLocation> => {
-      // The default `r{round}/output.xml` filename is only collision-safe
-      // when resolved through a run-storage-bound fileService. Enforce the
-      // invariant so a misconfigured TaskRunFileService can't silently
-      // route outputs to a shared `<workspace>/r{round}/output.xml` path.
-      if (!fileService.hasRunDirectory()) {
-        throw new Error(
-          'runReflectionFlow requires a TaskRunFileService bound to an executionId for default output-path resolution.',
-        );
-      }
       const canonical = fileService.createLocation(
         getOutputFileName(WORKFLOW_RAW_OUTPUT_EXT, round),
       ) as AgentFileLocation;
@@ -184,7 +175,6 @@ export async function runReflectionFlow<C = unknown>(
       baseFiles,
       logger,
       fileService,
-      executionId,
       streamId,
       runtimeHost,
     },

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -17,9 +17,7 @@ import {
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { LATEX_CONFIG_RANGES } from '@shared/constants/latex';
 import {
-  createExternalLocation,
   createRunStorageLocation,
-  createWorkspaceLocation,
   FlexibleFS,
   TaskRunFileService,
 } from '@utils/files';
@@ -151,7 +149,12 @@ export class LatexDiffManager {
     // relative \input{} resolution works when its cwd is runDir/r{round}.
     await this.fileService.ensureMirroredInRoundDir(currRound);
     await this.fileService.ensureMirroredInDiffRoundDir(currRound);
-    const diffDirectory = this.getDiffOutputDirectory(currRound);
+    const relativePath = path.join('diff', `r${currRound}`);
+    const diffDirectory: DiffOutputDirectory = {
+      absolutePath: path.join(this.fileService.runDirectory, relativePath),
+      relativePath,
+      executionId: this.fileService.executionId,
+    };
 
     const outputByPath = new Map(
       outputFiles.map((f) => [getComparablePath(f.location), f]),
@@ -200,7 +203,7 @@ export class LatexDiffManager {
                 revised,
                 currRound,
                 undefined,
-                { cwd, outputDirectory: diffDirectory?.absolutePath },
+                { cwd, outputDirectory: diffDirectory.absolutePath },
               ),
             label: 'round-diff',
             pdfStemSuffix: '-diff',
@@ -237,7 +240,7 @@ export class LatexDiffManager {
                 undefined,
                 {
                   cwd,
-                  outputDirectory: diffDirectory?.absolutePath,
+                  outputDirectory: diffDirectory.absolutePath,
                 },
               ),
             label: 'between-rounds-diff',
@@ -290,7 +293,7 @@ export class LatexDiffManager {
     ) => Promise<LaTeXdiffResult>;
     label: string;
     pdfStemSuffix: string;
-    diffDirectory: DiffOutputDirectory | null;
+    diffDirectory: DiffOutputDirectory;
   }): Promise<SingleDiffOutcome | null> {
     const {
       outputPath,
@@ -354,7 +357,7 @@ export class LatexDiffManager {
   private async compileDiffIfSuccessful(
     result: LaTeXdiffResult,
     referenceLocation: FileLocation,
-    diffDirectory: DiffOutputDirectory | null,
+    diffDirectory: DiffOutputDirectory,
     round: number,
     sourceLocation: FileLocation,
     pdfStemSuffix: string,
@@ -366,10 +369,10 @@ export class LatexDiffManager {
       return null;
     }
 
-    const diffLocation = this.buildDiffLocation(
-      referenceLocation,
-      result.diffFileName,
-      diffDirectory,
+    const diffLocation = createRunStorageLocation(
+      path.join(diffDirectory.absolutePath, result.diffFileName),
+      path.join(diffDirectory.relativePath, result.diffFileName),
+      diffDirectory.executionId,
     );
 
     const buildDir = path.join(
@@ -421,93 +424,35 @@ export class LatexDiffManager {
       return { diffLocation, artifact: null };
     }
 
-    const { executionId, runDirectory } = this.fileService.metadata;
+    const { executionId, runDirectory } = this.fileService;
     const compiledPdfPath = path.join(
       buildDir,
       `${path.basename(diffLocation.absolutePath).replace(/\.tex$/i, '')}.pdf`,
     );
     let artifact: CompiledPdfArtifact | null = null;
-    if (executionId && runDirectory) {
-      try {
-        artifact = await publishCompiledPdfArtifact({
-          runDirectory,
-          executionId,
-          round,
-          displayName: path.basename(diffLocation.absolutePath),
-          source: sourceLocation,
-          compiledPdfPath,
-          pdfStemSuffix,
-        });
-      } catch (error) {
-        this.logger.warn(
-          `Failed to publish latexdiff PDF: ${toErrorMessage(error)}`,
-          {
-            data: {
-              diffFile: diffLocation.absolutePath,
-              compiledPdfPath,
-              error,
-            },
+    try {
+      artifact = await publishCompiledPdfArtifact({
+        runDirectory,
+        executionId,
+        round,
+        displayName: path.basename(diffLocation.absolutePath),
+        source: sourceLocation,
+        compiledPdfPath,
+        pdfStemSuffix,
+      });
+    } catch (error) {
+      this.logger.warn(
+        `Failed to publish latexdiff PDF: ${toErrorMessage(error)}`,
+        {
+          data: {
+            diffFile: diffLocation.absolutePath,
+            compiledPdfPath,
+            error,
           },
-        );
-      }
+        },
+      );
     }
 
     return { diffLocation, artifact };
-  }
-
-  /**
-   * Describe the diff file that LaTeXdiffService wrote. Workflow runs pass a
-   * run-storage output directory so the generated `.tex` and build artifacts
-   * stay out of the user's workspace. Older callers that do not have run
-   * storage keep the historical sibling placement.
-   */
-  private buildDiffLocation(
-    reference: FileLocation,
-    diffFileName: string,
-    diffDirectory: DiffOutputDirectory | null,
-  ): FileLocation {
-    if (diffDirectory) {
-      const absolutePath = path.join(diffDirectory.absolutePath, diffFileName);
-      return createRunStorageLocation(
-        absolutePath,
-        path.join(diffDirectory.relativePath, diffFileName),
-        diffDirectory.executionId,
-      );
-    }
-
-    const siblingAbsolute = path.join(
-      path.dirname(reference.absolutePath),
-      diffFileName,
-    );
-    if (reference.kind === 'workspace') {
-      const relativeDir = path.dirname(reference.relativePath);
-      return createWorkspaceLocation(
-        siblingAbsolute,
-        path.join(relativeDir, diffFileName),
-      );
-    }
-    if (reference.kind === 'runStorage') {
-      const relativeDir = path.dirname(reference.relativePath);
-      return createRunStorageLocation(
-        siblingAbsolute,
-        path.join(relativeDir, diffFileName),
-        reference.executionId,
-      );
-    }
-    return createExternalLocation(siblingAbsolute);
-  }
-
-  private getDiffOutputDirectory(round: number): DiffOutputDirectory | null {
-    const { executionId, runDirectory } = this.fileService.metadata;
-    if (!executionId || !runDirectory) {
-      return null;
-    }
-
-    const relativePath = path.join('diff', `r${round}`);
-    return {
-      absolutePath: path.join(runDirectory, relativePath),
-      relativePath,
-      executionId,
-    };
   }
 }

--- a/src/agent/output/compileCheck.ts
+++ b/src/agent/output/compileCheck.ts
@@ -95,8 +95,8 @@ export function resolveWorkspaceSourceDir(
 /**
  * Compile each .tex output of a round to verify the workflow produced a
  * buildable document. Success is silent; failures write the log tail to
- * `<runDir>/compile/r<round>_<safe>.log`. Missing toolchains, runs without a run
- * directory, and non-root fragments are skipped gracefully.
+ * `<runDir>/compile/r<round>_<safe>.log`. Missing toolchains and non-root
+ * fragments are skipped gracefully.
  */
 export async function runCompileCheck(
   ctx: CompileCheckContext,
@@ -106,11 +106,7 @@ export async function runCompileCheck(
     return { failures: [], artifacts: [] };
   }
 
-  const runDirectory = ctx.fileService.metadata.runDirectory;
-  if (!runDirectory) {
-    ctx.logger.debug('Compile check skipped: no run directory');
-    return { failures: [], artifacts: [] };
-  }
+  const { runDirectory } = ctx.fileService;
 
   const texOutputs = (
     getOutputFilesByRound(ctx.outputState)[currentRound] ?? []
@@ -283,7 +279,7 @@ async function compileOne(
   const legacyLogDest = pathToLocation(
     path.join(opts.compileRoot, `r${currentRound}_${legacySafeName}.log`),
   );
-  const executionId = ctx.fileService.metadata.executionId;
+  const { executionId } = ctx.fileService;
 
   const clearStaleLogs = (): Promise<void[]> =>
     Promise.all([
@@ -391,7 +387,7 @@ interface WriteCompileFailureArgs {
   outputFile: OutputFileInfo;
   logDest: FileLocation;
   logRelativePath: string;
-  executionId: ExecutionId | undefined;
+  executionId: ExecutionId;
   failureLogExcerpt: string;
 }
 
@@ -428,13 +424,11 @@ async function writeCompileFailure(args: WriteCompileFailureArgs): Promise<{
     );
   }
 
-  const logLocation = executionId
-    ? createRunStorageLocation(
-        logDest.absolutePath,
-        logRelativePath,
-        executionId,
-      )
-    : logDest;
+  const logLocation = createRunStorageLocation(
+    logDest.absolutePath,
+    logRelativePath,
+    executionId,
+  );
   return {
     failure: {
       round: currentRound,
@@ -456,7 +450,7 @@ interface TryPublishArtifactArgs {
   outputFile: OutputFileInfo;
   compiledBasename: string;
   buildDir: string;
-  executionId: ExecutionId | undefined;
+  executionId: ExecutionId;
 }
 
 /**
@@ -477,7 +471,6 @@ async function tryPublishArtifact(
     buildDir,
     executionId,
   } = args;
-  if (!executionId) return null;
 
   const compiledPdfPath = path.join(
     buildDir,

--- a/src/agent/output/outputState.ts
+++ b/src/agent/output/outputState.ts
@@ -42,7 +42,6 @@ export interface OutputDependencies {
   baseFiles: FileLocation[];
   logger: AgentTrace;
   fileService: TaskRunFileService;
-  executionId: string;
   streamId: string;
   runtimeHost: AgentRuntimeHost;
 }
@@ -137,8 +136,6 @@ export function setActiveRun(
   deps: OutputDependencies,
   storageKey: StorageKey,
 ): void {
-  deps.fileService.updateRunContext(deps.executionId);
-
   if (storageKey === state.storageKey) return;
 
   // Clear reference to old preparation - allows GC even if it's still running

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -68,7 +68,7 @@ export class LatexMediaManager {
     baseDir?: string,
   ): Promise<void> {
     const fileService = this.fileService;
-    if (!fileService?.hasRunDirectory() || figures.length === 0) {
+    if (!fileService || figures.length === 0) {
       return;
     }
 
@@ -201,7 +201,7 @@ export class LatexMediaManager {
     files: FileLocation[],
   ): Promise<void> {
     const fileService = this.fileService;
-    if (!fileService?.hasRunDirectory() || files.length === 0) {
+    if (!fileService || files.length === 0) {
       return;
     }
 
@@ -378,7 +378,7 @@ export class LatexMediaManager {
    * but not re-sent to the model on every round.
    */
   private async mirrorFiguresForFiles(files: FileLocation[]): Promise<void> {
-    if (!this.fileService?.hasRunDirectory() || files.length === 0) {
+    if (!this.fileService || files.length === 0) {
       return;
     }
 

--- a/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
+++ b/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
@@ -46,7 +46,7 @@ function createXmlManager(
         info: vi.fn(),
         domain: vi.fn(),
       } as unknown as AgentTrace),
-    new TaskRunFileService(),
+    new TaskRunFileService('xml-output-manager-test'),
   );
 }
 
@@ -1256,7 +1256,7 @@ Appendix.
         warn: vi.fn(),
         domain: vi.fn(),
       } as unknown as AgentTrace,
-      new TaskRunFileService(),
+      new TaskRunFileService('xml-single-artifact-test'),
     );
   }
 

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -13,7 +13,6 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 import {
   createExternalLocation,
   createRunStorageLocation,
-  createWorkspaceLocation,
   pathToLocation,
 } from './fileLocation';
 import {
@@ -56,49 +55,16 @@ export {
 } from './runStorageFs';
 
 export class TaskRunFileService {
-  public metadata: {
-    executionId: ExecutionId | undefined;
-    runDirectory: string | undefined;
-  };
+  public readonly runDirectory: string;
   private hasPreparedSnapshot = false;
   private readonly mirroredDependencies = new Set<string>();
 
-  constructor(executionId?: ExecutionId) {
-    this.metadata = {
-      executionId: undefined,
-      runDirectory: undefined,
-    };
-    this.updateRunContext(executionId);
-  }
-
-  public updateRunContext(executionId?: ExecutionId | null): void {
-    const nextRunDirectory = executionId ? getRunDir(executionId) : undefined;
-
-    const contextChanged =
-      this.metadata.executionId !== executionId ||
-      this.metadata.runDirectory !== nextRunDirectory;
-
-    this.metadata.executionId = executionId ?? undefined;
-    this.metadata.runDirectory = nextRunDirectory;
-
-    if (contextChanged) {
-      this.hasPreparedSnapshot = false;
-      this.mirroredDependencies.clear();
-    }
-  }
-
-  public getExecutionId(): ExecutionId | undefined {
-    return this.metadata.executionId;
-  }
-
-  public hasRunDirectory(): boolean {
-    return Boolean(this.metadata.runDirectory);
+  constructor(public readonly executionId: ExecutionId) {
+    this.runDirectory = getRunDir(executionId);
   }
 
   private async ensureRunDirectory(): Promise<void> {
-    const executionId = this.metadata.executionId;
-    if (!executionId) return;
-    await ensureRunDir(executionId);
+    await ensureRunDir(this.executionId);
   }
 
   /**
@@ -119,10 +85,7 @@ export class TaskRunFileService {
       mirrorBaseFiles?: boolean;
     } = {},
   ): Promise<void> {
-    const executionId = this.metadata.executionId;
-    if (!executionId || this.hasPreparedSnapshot) {
-      return;
-    }
+    if (this.hasPreparedSnapshot) return;
 
     await this.ensureRunDirectory();
 
@@ -165,15 +128,12 @@ export class TaskRunFileService {
     if (target.kind !== 'workspace') return;
     if (shouldSkipRelocation(target.relativePath)) return;
 
-    const executionId = this.metadata.executionId;
-    if (!executionId) return;
-
     try {
       const stats = await fs.stat(target.absolutePath);
       if (!stats.isFile()) return;
 
       const snapshotAbsolute = getOriginalSnapshotPath(
-        executionId,
+        this.executionId,
         target.relativePath,
       );
 
@@ -201,22 +161,14 @@ export class TaskRunFileService {
       return createExternalLocation(resolved.absolutePath);
     }
 
-    const executionId = this.metadata.executionId;
-    if (executionId) {
-      const runAbsolute = getRunStorageAbsolutePath(
-        executionId,
-        resolved.relativePath,
-      );
-      return createRunStorageLocation(
-        runAbsolute,
-        resolved.relativePath,
-        executionId,
-      );
-    }
-
-    return createWorkspaceLocation(
-      resolved.absolutePath,
+    const runAbsolute = getRunStorageAbsolutePath(
+      this.executionId,
       resolved.relativePath,
+    );
+    return createRunStorageLocation(
+      runAbsolute,
+      resolved.relativePath,
+      this.executionId,
     );
   }
 
@@ -248,14 +200,9 @@ export class TaskRunFileService {
       return location;
     }
 
-    const executionId = this.metadata.executionId;
-    if (!executionId) {
-      return location;
-    }
-
     await this.ensureRunDirectory();
     const runAbsolute = getRunStorageAbsolutePath(
-      executionId,
+      this.executionId,
       location.relativePath,
     );
 
@@ -271,7 +218,7 @@ export class TaskRunFileService {
     return createRunStorageLocation(
       runAbsolute,
       location.relativePath,
-      executionId,
+      this.executionId,
     );
   }
 
@@ -313,10 +260,7 @@ export class TaskRunFileService {
     relativeDirectory: string,
     options: { protectPrimaryOutput: boolean },
   ): Promise<void> {
-    const executionId = this.metadata.executionId;
-    if (!executionId || this.mirroredDependencies.size === 0) {
-      return;
-    }
+    if (this.mirroredDependencies.size === 0) return;
 
     await Promise.all(
       [...this.mirroredDependencies].map(async (relativePath) => {
@@ -346,11 +290,11 @@ export class TaskRunFileService {
         // workspace mirror at `runDir/<rel>`, which is correct — those
         // are never written to.
         const snapshotAbsolute = getOriginalSnapshotPath(
-          executionId,
+          this.executionId,
           relativePath,
         );
         const workspaceMirrorAbsolute = getRunStorageAbsolutePath(
-          executionId,
+          this.executionId,
           relativePath,
         );
         let sourceAbsolute = workspaceMirrorAbsolute;
@@ -366,7 +310,7 @@ export class TaskRunFileService {
           }
         }
         const destinationAbsolute = getRunStorageAbsolutePath(
-          executionId,
+          this.executionId,
           path.join(relativeDirectory, relativePath),
         );
 


### PR DESCRIPTION
## Summary

Require every `TaskRunFileService` to receive its execution identifier at construction. The service now exposes immutable execution identity and run-directory fields, while the mutable metadata object, rebinding path, accessors, and branches for an unbound service are removed.

LaTeX managers still accept no file service when they run outside an agent execution. A supplied service is now necessarily bound to one execution. No user-visible behavior or public or persisted wire-format change is intended, and no `CHANGELOG.md` entry is included.

## Issue acceptance gates

Closes #8794.

- Fetched the current `origin/main`, inspected all open pull requests, and searched TypeScript, JavaScript, `.mts`, and `.cts` consumers before implementation and again before publication.
- Required the execution identifier at `TaskRunFileService` construction and derived its run directory once.
- Deleted run-context rebinding, mutable execution metadata, the execution/run-directory accessors, and downstream branches that were possible only for an unbound service.
- Preserved optional `TaskRunFileService` injection in `LatexMediaManager` and `TikzPictureManager`.
- Preserved run-storage paths, LaTeX output placement, compile artifacts, and CLI `texra run` and `--print` output.
- Deleted the named symbols without a re-export shim, compatibility alias, or replacement facade.
- Rebased onto the current `origin/main` before publication.

## Single source of truth

`TaskRunFileService` now owns one immutable `executionId` and the corresponding immutable `runDirectory`. Consumers read those fields directly; there is no second mutable execution-context representation.

## Duplication and abstraction budget

The mutable metadata envelope, rebinding method, two accessors, repeated absence checks, and two single-consumer LaTeXdiff path builders are removed. The code-simplifier pass inlined the final directory construction at its only use. No new module, factory, wrapper, facade, or pass-through layer is introduced.

## Net elements (R6)

- Production TypeScript: 70 additions, 202 deletions, net -132 lines.
- Tests: 2 additions, 2 deletions, net 0 lines.
- Total: 72 additions, 204 deletions, net -132 lines across 8 modified files.
- Relocations: 0 verbatim lines. Two existing single-consumer path-construction responsibilities were rewritten directly at their consumers.
- Deletions excluding relocations: 204 lines; the added lines express the required immutable contract and direct consumers.
- Exported class members: removed `metadata`, `updateRunContext`, `getExecutionId`, and `hasRunDirectory`; added immutable `executionId` and `runDirectory` fields on the existing class.
- Classes, interfaces, and enums: no class or enum added or deleted; one duplicate `executionId` field was deleted from `OutputDependencies`.
- Files: none added or deleted.
- `CHANGELOG.md`: unchanged.

## Consumer counts (R8)

Repository-wide searches over TypeScript, JavaScript, `.mts`, and `.cts` found:

- `TaskRunFileService` construction: 25 call sites before and after (2 production, 23 tests). Before, 2 test fixtures omitted the execution identifier; after, all 25 pass one.
- `updateRunContext`: 1 production consumer before, 0 after.
- `hasRunDirectory`: 4 production consumers before, 0 after. The 3 optional `LatexMediaManager` paths now test only whether a service was supplied; the reflection-flow guard was impossible once construction requires identity.
- `getExecutionId`: 0 consumers before and after; the unread method is deleted.
- `fileService.metadata`: 4 production consumers before, 0 after. They now read immutable fields directly.
- No remaining zero-argument construction, rebinding, metadata-envelope access, or removed accessor reference exists.

## Host impact

Extension: Agent runs already supplied their execution identifier. Output, compile, and LaTeXdiff paths remain under the same execution directory.

Desktop: Uses the same shared agent flows and receives the same immutable execution-bound service; no host-specific behavior changes.

CLI: Uses the same shared flows. `validate:run` and the run/output parity suites confirm unchanged `texra run` and `--print` output.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm install`
- `npm run format`
- `npm run typecheck` (repeated after rebase)
- `npm run compile:fast`
- `npm run lint` (0 errors; one pre-existing warning in `AgentCreatorToolCatalogParity.vitest.mts`)
- `npm run check:dead-code-ratchet`
- `npm test -- src/test-kernel/agent/output/CompileCheck.vitest.ts src/test-kernel/agent/output/LatexCompileInputDirs.vitest.ts src/test-kernel/agent/output/XmlOutputManager.vitest.ts src/test-kernel/latex/LatexProcessingHelpers.vitest.ts src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts src/test-kernel/utils/RoundDirOwnership.vitest.ts src/test-kernel/utils/files/RunStorageEntryInspection.vitest.ts src/test-kernel/tools/BashTool.vitest.ts` (8 files, 121 tests; repeated after rebase)
- `npm test -- src/test-kernel/cli/RunExecution.vitest.mts src/test-kernel/cli/WorkflowRunCommand.vitest.mts src/test-kernel/cli/OutputGuards.vitest.mts src/test-kernel/cli/WorkflowOutputResolution.vitest.mts` (4 files, 66 tests)
- `npm --prefix packages/cli run validate:run` (`CLI run validation passed`)
- `git diff --check`
- Manual code-simplifier pass over the complete diff; it inlined the remaining single-consumer diff-directory builder and found no further warranted changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core agent output, compile, and latexdiff storage paths; behavior is intended unchanged for normal runs but mis-instantiated services are now a construction-time error rather than a silent workspace fallback.
> 
> **Overview**
> **`TaskRunFileService` is always bound to one execution.** Construction takes a required `executionId` and exposes immutable `executionId` and `runDirectory`; the mutable `metadata` object, `updateRunContext`, `getExecutionId`, and `hasRunDirectory` are gone.
> 
> **Consumers read identity from the service directly** instead of parallel `executionId` on `OutputDependencies` or `fileService.metadata`. `createLocation` always maps workspace paths into that run’s storage (no workspace fallback when unbound). `setActiveRun` no longer calls rebinding.
> 
> **Reflection flow** drops the guard that required a run-directory-bound service for default `r{round}/output` paths—construction already enforces that.
> 
> **Compile check and latexdiff** assume a run directory always exists: no early skip when `runDirectory` was missing; failure logs and PDF publish always use run-storage locations. **Latexdiff** inlines run-scoped `diff/r{round}` paths and removes legacy sibling/workspace diff placement (`buildDiffLocation`, `getDiffOutputDirectory`).
> 
> **`LatexMediaManager`** still accepts an optional service; mirroring gates on “service provided” only, not `hasRunDirectory()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0057fe4b87e105c9e0e1ebe3a7786e233b2991ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->