### PR TITLE
refactor(desktop): delete impossible pre-platform fallbacks

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -6,8 +6,7 @@ import { prepareMainViewExecutionRequest } from '@controllers/mainView/MainViewE
 import { buildMainViewState } from '@controllers/mainView/MainViewStateRestoreController';
 import { ProgressViewHost } from '@controllers/progressView/ProgressViewHost';
 import { getProgressStreamControls } from '@controllers/progressView/progressStreamControls';
-import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
-import { platform, tryPlatform } from '@platform/platform';
+import { platform } from '@platform/platform';
 import { StreamLogStore, type StreamSnapshotStore } from '@transcript';
 import {
   isProgressBackendInteractionEvent,
@@ -110,7 +109,6 @@ import {
 } from './desktopLegacyStreamImporter.js';
 import type { DesktopProgressInboundHandlerRegistry } from './desktopProgressIpc.js';
 import type { DesktopAgentExecutionHost } from './desktopAgentExecutionHost.js';
-import type { MementoStorage } from '@controllers/progressView/backend/persistence/PersistentMapManager';
 
 const DESKTOP_UNAVAILABLE_TOOLS: readonly RegisteredToolName[] = [
   ...SETUP_PLATFORM_VSCODE_ONLY_TOOL_NAMES,
@@ -149,24 +147,6 @@ export interface DesktopProgressBridgeOptions {
   progressSnapshotStore: StreamSnapshotStore;
   /** Runs after canonical state is loaded and before restart repair begins. */
   afterCanonicalLoad?: () => Promise<void>;
-}
-
-class MemoryProgressStorage implements MementoStorage {
-  private readonly values = new Map<string, unknown>();
-
-  get<T>(key: string): T | undefined;
-  get<T>(key: string, defaultValue: T): T;
-  get<T>(key: string, defaultValue?: T): T | undefined {
-    return this.values.has(key) ? (this.values.get(key) as T) : defaultValue;
-  }
-
-  async update<T>(key: string, value: T | undefined): Promise<void> {
-    if (value === undefined) {
-      this.values.delete(key);
-      return;
-    }
-    this.values.set(key, value);
-  }
 }
 
 export class DesktopProgressBridge {
@@ -244,7 +224,7 @@ export class DesktopProgressBridge {
 
     this.backend = new ProgressBackend({
       session: this.session,
-      storage: tryPlatform()?.workspaceState ?? new MemoryProgressStorage(),
+      storage: platform().workspaceState,
       snapshots: options.progressSnapshotStore,
       sendMessage: (message) => {
         return this.postToRenderer(message) !== false;
@@ -1333,8 +1313,7 @@ export class DesktopProgressBridge {
     return listWorkspaceFiles({
       root: workspacePath,
       config,
-      readDirectory: (directory) =>
-        (tryPlatform()?.fs ?? nodeFilesystem).readDirectory(directory),
+      readDirectory: (directory) => platform().fs.readDirectory(directory),
     });
   }
 }

--- a/packages/desktop/src/main/desktopFileSelection.ts
+++ b/packages/desktop/src/main/desktopFileSelection.ts
@@ -1,7 +1,6 @@
 import { isAbsolute, relative, resolve } from 'node:path';
 
-import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
-import { platform, tryPlatform } from '@platform/platform';
+import { platform } from '@platform/platform';
 import {
   getEditedFileListConfig,
   getFileListConfig,
@@ -54,10 +53,6 @@ const MULTI_SET_COMMAND_BY_FILE_TYPE = {
 
 type DesktopMultiFileType = keyof typeof MULTI_SET_COMMAND_BY_FILE_TYPE;
 
-function readDirectory(directory: string) {
-  return (tryPlatform()?.fs ?? nodeFilesystem).readDirectory(directory);
-}
-
 async function listFiles(
   root: string,
   rawConfig: FileListConfig,
@@ -65,7 +60,7 @@ async function listFiles(
   return listWorkspaceFiles({
     root,
     config: rawConfig,
-    readDirectory,
+    readDirectory: (directory) => platform().fs.readDirectory(directory),
   });
 }
 

--- a/src/test-kernel/desktop/ElectronFileSelection.vitest.mts
+++ b/src/test-kernel/desktop/ElectronFileSelection.vitest.mts
@@ -28,6 +28,11 @@ interface DesktopFileSelectionModule {
 
 async function loadDesktopFileSelection(): Promise<DesktopFileSelectionModule> {
   vi.resetModules();
+  const [{ installPlatform }, { nodeFilesystem }] = await Promise.all([
+    import('@test/support/setupPlatform'),
+    import('@platform/defaults/nodeFilesystem'),
+  ]);
+  await installPlatform({}, { fs: nodeFilesystem });
   return import(
     moduleFileUrl(desktopSourcePath('main', 'desktopFileSelection.ts'))
   ) as Promise<DesktopFileSelectionModule>;


### PR DESCRIPTION
## Summary

Electron installs the desktop platform before creating any window or loading the desktop execution and file-selection services. This change removes the unreachable in-memory progress-state and direct Node-filesystem fallbacks from those services. Desktop tests now install the same fresh platform singleton used by the dynamically imported production module.

No user-visible behavior or persisted format changes are intended, and no changelog entry is needed.

## Issue acceptance gates

- Closes #8801.
- Deletes the desktop memory progress store without a replacement facade or re-export.
- Deletes both pre-platform filesystem fallback paths.
- Preserves the Electron initialization order in which `initializeElectronPlatform` completes before `createWindow` constructs these services.
- Initializes the exact post-`vi.resetModules()` platform module before dynamically importing the file-selection production module.
- Leaves public and persisted wire formats unchanged.

## Single source of truth

The platform singleton installed by `initializeElectronPlatform` is the sole owner of desktop `workspaceState` and filesystem access. Desktop execution and file selection now read those ports directly through `platform()`.

## Duplication and abstraction budget

The local `MemoryProgressStorage` class, two fallback expressions, and the fallback-only `readDirectory` helper were deleted. No abstraction, compatibility shim, facade, or pass-through layer was added. The test uses the existing `installPlatform` helper.

## Net elements (R6)

- Files: 3 modified; 0 added; 0 deleted.
- Exported symbols: 0 added; 0 deleted.
- Classes/interfaces/enums: 0 added; 1 file-local class deleted (`MemoryProgressStorage`).
- Production LoC: +5 / -31, net -26.
- Test LoC: +5 / -0, net +5.
- Total LoC: +10 / -31, net -21.
- Relocated lines: 0.
- Deleted lines: 31. The 10 added lines are direct platform calls and test setup, not relocations.

## Consumer counts (R8)

- `MemoryProgressStorage`: 1 runtime construction path, in `DesktopProgressBridge`.
- Workspace-state fallback: 1 runtime call site.
- Filesystem fallbacks: 2 runtime call sites, one in desktop execution file listing and one shared by the two desktop file-selection listing paths.
- `DesktopProgressBridge`: 1 production construction path through `createDesktopAgentExecution`; tests construct additional isolated windows.
- `createDesktopFileSelection`: 1 production consumer in the Electron main composition and 1 dedicated test suite.
- Open pull requests overlapping these symbols at implementation start: 0.

## Host impact

Extension: None.

Desktop: Uses the already-installed platform state and filesystem directly. Startup, progress restoration, file-list ordering, validation, and renderer messages are unchanged.

CLI: None. CLI sources and `texra run` / `--print` output paths are untouched.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm install`
- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; one unrelated pre-existing warning in `AgentCreatorToolCatalogParity.vitest.mts`)
- `npm run check:dead-code-ratchet`
- `npm test -- src/test-kernel/desktop` (48 files, 474 tests)
- `npm test -- src/test-kernel/desktop/ElectronFileSelection.vitest.mts` after the simplifier pass (1 file, 7 tests)
- `git diff --check`
- Code-simplifier pass: replaced hand-wired platform construction with the established `installPlatform` test helper; no further simplification was found within scope.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving cleanup that relies on existing Electron startup ordering; no wire format or public API changes.
> 
> **Overview**
> Desktop agent execution and file selection now always use **`platform().workspaceState`** and **`platform().fs`** instead of **`tryPlatform()`** fallbacks to in-memory progress storage or **`nodeFilesystem`**.
> 
> The file-local **`MemoryProgressStorage`** class and the shared **`readDirectory`** helper in file selection are removed as dead paths, on the assumption Electron has already run **`initializeElectronPlatform`** before these services load.
> 
> **`ElectronFileSelection.vitest.mts`** installs the platform via **`installPlatform`** (with **`nodeFilesystem`**) after **`vi.resetModules()`** so dynamic imports of the production module see the same singleton contract as the app.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c06b765321225f6433fe4749b48fff032f2f74d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->