### PR TITLE
feat: structured output via terminal tool (contract + tool-use consumer)

### DIFF
--- a/packages/extension/resources/docs/agent-creation/tool_catalog.md
+++ b/packages/extension/resources/docs/agent-creation/tool_catalog.md
@@ -63,8 +63,11 @@ recommended groups at the bottom are a good starting point.
   workflow-agent calls with predetermined branching and fan-out. Pass a default
   `agent`, the complete `script`, and optional JSON `args`. The script begins
   with `export const meta = { name, description }` and can use `agent`, `phase`,
-  `log`, `parallel`, `pipeline`, and `concat`. It is intentionally absent from
-  the recommended orchestrator set.
+  `log`, `parallel`, `pipeline`, and `concat`. `agent(prompt, { schema })`, where
+  `schema` is a JSON Schema object, runs a tool-use agent (name one via
+  `agentName`) that finishes by calling `submit_output`; the call resolves to an
+  envelope whose `.structured` is the validated object. It is intentionally
+  absent from the recommended orchestrator set.
 - `delegate_agent` — delegate to another tool-use agent. Pass `agent`,
   `model`, and `instruction` for a fresh run, or `execution_id` +
   `instruction` to resume a WAITING subagent.

--- a/packages/trace-viewer/src/traceDataSchema.ts
+++ b/packages/trace-viewer/src/traceDataSchema.ts
@@ -65,6 +65,7 @@ const TraceAgentConfigSchema = z
     }),
     TraceAgentConfigSharedFieldsSchema.extend({
       agentCategory: z.literal(AgentCategory.ToolUse),
+      outputSchema: z.record(z.string(), z.unknown()).nullish(),
     }),
   ])
   .superRefine((config, ctx) => {

--- a/src/agent/core/definition/AgentConfig.ts
+++ b/src/agent/core/definition/AgentConfig.ts
@@ -55,6 +55,13 @@ const WorkflowAgentConfigFieldsSchema = AgentConfigSharedFieldsSchema.extend({
 
 const ToolUseAgentConfigFieldsSchema = AgentConfigSharedFieldsSchema.extend({
   agentCategory: z.literal(AgentCategory.ToolUse),
+  /**
+   * JSON Schema (a plain object) describing a structured output the agent must
+   * submit through the synthetic `submit_output` terminal tool. Serializable by
+   * design: a live Zod schema or ITool must never travel through config. Absent
+   * for ordinary tool-use runs.
+   */
+  outputSchema: z.record(z.string(), z.unknown()).nullish(),
 });
 
 const AgentConfigFieldsSchema = z.discriminatedUnion('agentCategory', [

--- a/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
@@ -69,6 +69,10 @@ interface ToolExecutionResult {
   logRef: { logId: string | undefined; groupId: string | undefined };
 }
 
+function endsToolUseTurn(result: ToolExecutionResult | null): boolean {
+  return result?.result.status === 'executed' && result.result.endTurn === true;
+}
+
 /**
  * Dispatches tool calls with ordering barriers.
  *
@@ -191,6 +195,7 @@ export class ToolUseDispatchNode<C> extends Node<
             batchController.signal,
           );
           i += 1;
+          if (endsToolUseTurn(results[index])) break;
           continue;
         }
         // Contiguous run of parallel-safe calls executes concurrently.
@@ -212,6 +217,7 @@ export class ToolUseDispatchNode<C> extends Node<
             }),
           ),
         );
+        if (run.some((index) => endsToolUseTurn(results[index]))) break;
       }
       this.fanOutDuplicateResults(calls, results);
       this.rejectUnsafeDuplicates(calls, results);
@@ -631,6 +637,11 @@ export class ToolUseDispatchNode<C> extends Node<
     if (interrupted) {
       shared.shouldStop = true;
     }
+    const endTurn = allResults.some((result) => endsToolUseTurn(result));
+    if (endTurn) {
+      shared.shouldStop = true;
+      shared.endTurn = true;
+    }
 
     const assistantText = shared.text ?? '';
 
@@ -691,6 +702,6 @@ export class ToolUseDispatchNode<C> extends Node<
 
     shared.toolCalls = [];
 
-    return FlowTransition.CONTINUE;
+    return endTurn ? FlowTransition.COMPLETE : FlowTransition.CONTINUE;
   }
 }

--- a/src/agent/implementations/flows/tooluse/ToolUseServices.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseServices.ts
@@ -4,7 +4,7 @@ import type { IToolRegistry } from '@agent/core/tools/ToolTypes';
 import type { IToolUseSession } from '@agent/core/flows/IToolUseSession';
 import type { SubagentProgressUpdate, TodoItem } from '@shared/schemas';
 import type { TaskRunFileService } from '@utils/files';
-import type { PreparedShared } from './nodes/types';
+import type { PreparedShared, ToolUseRunShared } from './nodes/types';
 
 export interface ToolUseServices<C = unknown> extends BaseFlowContextInit<C> {
   readonly setting: AgentToolUseSetting;
@@ -17,6 +17,8 @@ export interface ToolUseServices<C = unknown> extends BaseFlowContextInit<C> {
   readonly onProgress?: (update: SubagentProgressUpdate) => void;
   /** Persist todos to the execution KV store. Injected by runToolUseFlow. */
   readonly persistTodos?: (todos: TodoItem[]) => Promise<void>;
+  /** Read the run-local terminal result so the cycle can persist it atomically. */
+  readonly getPendingStructuredOutput?: () => ToolUseRunShared['structured'];
   /** True when this agent was launched as a subagent by an orchestrator. */
   readonly isSubagent?: boolean;
   /**

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -215,9 +215,12 @@ export class ToolUseCycleNode<C> extends Node<
     // Tool-use agents are conversational — the user can send a
     // follow-up to retry after a failure, unlike workflows.
     switch (execRes.outcome) {
-      case 'completed':
+      case 'completed': {
         shared.messages = execRes.messages;
+        const structured = this.services.getPendingStructuredOutput?.();
+        if (structured !== undefined) shared.structured = structured;
         break;
+      }
       case 'skipped':
         break;
       case 'failed':

--- a/src/agent/implementations/flows/tooluse/nodes/types.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/types.ts
@@ -50,6 +50,8 @@ const ToolUseRunSharedSchema = z.looseObject({
   lastError: RetryErrorInfoSchema.optional(),
   /** Last assistant response without the full assembly buffers. */
   lastResponse: z.string().optional(),
+  /** Validated terminal-tool result retained across interrupt and resume. */
+  structured: z.json().optional(),
 });
 
 /** Per-step schema after the one-time legacy workspace migration. */

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -50,7 +50,6 @@ import { getDefaultToolRegistry } from '@tools/registry';
 import {
   buildTerminalTool,
   buildTerminalToolRegistry,
-  resolveStructuredOutput,
 } from '@tools/structuredOutput';
 import { TaskRunFileService } from '@utils/files';
 import { ToolUsePrepareNode } from './nodes/ToolUsePrepareNode';
@@ -215,8 +214,7 @@ export async function runToolUseFlow<C = unknown>(
   let capturedStructured: unknown;
   let registry = baseRegistry;
   if (outputSchema) {
-    const spec = resolveStructuredOutput(outputSchema);
-    const terminalTool = buildTerminalTool(spec, (value) => {
+    const terminalTool = buildTerminalTool(outputSchema, (value) => {
       capturedStructured = value;
     });
     resolvedTools.push(terminalTool.definition);
@@ -634,6 +632,16 @@ export async function runToolUseFlow<C = unknown>(
     for (const handler of switchedHandlers) {
       handler.dispose();
     }
+  }
+
+  if (
+    outputSchema !== undefined &&
+    outcome === RUN_OUTCOME.COMPLETED &&
+    capturedStructured === undefined
+  ) {
+    throw new Error(
+      'Structured-output run completed without calling submit_output.',
+    );
   }
 
   return {

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -211,11 +211,11 @@ export async function runToolUseFlow<C = unknown>(
     input.config.agentCategory === AgentCategory.ToolUse
       ? input.config.outputSchema
       : undefined;
-  let capturedStructured: unknown;
+  let pendingStructuredOutput: ToolUseRunShared['structured'];
   let registry = baseRegistry;
   if (outputSchema) {
     const terminalTool = buildTerminalTool(outputSchema, (value) => {
-      capturedStructured = value;
+      pendingStructuredOutput = value;
     });
     resolvedTools.push(terminalTool.definition);
     registry = buildTerminalToolRegistry(baseRegistry, terminalTool);
@@ -230,6 +230,7 @@ export async function runToolUseFlow<C = unknown>(
     toolRegistry: registry,
     resumeShared: input.resume?.shared ?? null,
     persistTodos: (todos) => kv.writeTodos(todos),
+    getPendingStructuredOutput: () => pendingStructuredOutput,
     fileService: new TaskRunFileService(executionId),
   };
   const switchedHandlers = new Set<ToolUseServices<C>['modelHandler']>();
@@ -637,7 +638,7 @@ export async function runToolUseFlow<C = unknown>(
   if (
     outputSchema !== undefined &&
     outcome === RUN_OUTCOME.COMPLETED &&
-    capturedStructured === undefined
+    shared.structured === undefined
   ) {
     throw new Error(
       'Structured-output run completed without calling submit_output.',
@@ -649,6 +650,6 @@ export async function runToolUseFlow<C = unknown>(
     lastResponse,
     touchedFiles,
     totalCostUsd,
-    structured: capturedStructured,
+    structured: shared.structured,
   };
 }

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -21,7 +21,10 @@ import {
   readPersistedFlowRecord,
   stampFlowRecordSchemaVersion,
 } from '@agent/node/persistedFlow';
-import type { AgentToolUseSetting } from '@agent/core/definition/AgentDataclass';
+import {
+  AgentCategory,
+  type AgentToolUseSetting,
+} from '@agent/core/definition/AgentDataclass';
 import type { IToolRegistry } from '@agent/core/tools/ToolTypes';
 import type { BaseFlowContextInit } from '@agent/core/flows/BaseFlowServices';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
@@ -44,6 +47,11 @@ import { deriveRunOutcome } from '@shared/streams/streamStatus';
 
 // Local imports - tools and flow
 import { getDefaultToolRegistry } from '@tools/registry';
+import {
+  buildTerminalTool,
+  buildTerminalToolRegistry,
+  resolveStructuredOutput,
+} from '@tools/structuredOutput';
 import { TaskRunFileService } from '@utils/files';
 import { ToolUsePrepareNode } from './nodes/ToolUsePrepareNode';
 import { ToolUseCycleNode } from './nodes/ToolUseCycleNode';
@@ -110,6 +118,12 @@ export interface RunToolUseFlowResult {
    * runs.
    */
   totalCostUsd?: number;
+  /**
+   * Value the model submitted through the synthetic `submit_output` terminal
+   * tool, already validated by that tool's Zod schema. Present only when the
+   * run's config carried an `outputSchema` and the model called the tool.
+   */
+  structured?: unknown;
 }
 
 class ToolUseFlowError extends Error {
@@ -178,15 +192,36 @@ export async function runToolUseFlow<C = unknown>(
     streamId,
     runSession.followUps,
   );
-  const registry = toolRegistry ?? getDefaultToolRegistry();
+  const baseRegistry = toolRegistry ?? getDefaultToolRegistry();
   const { tools: resolvedTools } = await resolveAgentTools({
     tools: setting.tools,
-    registry,
+    registry: baseRegistry,
     logger,
     approvalPromptsUnavailable: runContext.approvalPromptsUnavailable,
     runtimeUnavailableTools: runContext.runtimeUnavailableTools,
     toolInjections: input.toolInjections,
   });
+
+  // Unforced structured-output floor: when the config declares an output
+  // schema, append a synthetic `submit_output` terminal tool to the
+  // model-facing list and route lookups for it through a per-run registry
+  // overlay. The model finishes by calling the tool; its own Zod schema
+  // validates the call (with the existing ZodError -> retry repair), and
+  // `capture` records the validated value into this flow-local slot.
+  const outputSchema =
+    input.config.agentCategory === AgentCategory.ToolUse
+      ? input.config.outputSchema
+      : undefined;
+  let capturedStructured: unknown;
+  let registry = baseRegistry;
+  if (outputSchema) {
+    const spec = resolveStructuredOutput(outputSchema);
+    const terminalTool = buildTerminalTool(spec, (value) => {
+      capturedStructured = value;
+    });
+    resolvedTools.push(terminalTool.definition);
+    registry = buildTerminalToolRegistry(baseRegistry, terminalTool);
+  }
 
   const kv = getExecutionStore(executionId);
 
@@ -606,5 +641,6 @@ export async function runToolUseFlow<C = unknown>(
     lastResponse,
     touchedFiles,
     totalCostUsd,
+    structured: capturedStructured,
   };
 }

--- a/src/agent/runtime/AgentFinalResult.ts
+++ b/src/agent/runtime/AgentFinalResult.ts
@@ -37,6 +37,7 @@ export const WorkflowAgentFinalResultSchema = WorkflowFlowResultSchema.pick({
     diffs: z.array(ResultDiffSummarySchema).prefault(() => []),
     cost: CostSchema,
     diffsUnavailable: z.string().optional(),
+    structured: z.unknown().optional(),
   })
   .strict();
 
@@ -50,6 +51,7 @@ const ToolUseAgentFinalResultSchema = ToolUseFlowResultSchema.pick({
       .unwrap()
       .prefault(() => []),
     cost: CostSchema,
+    structured: z.unknown().optional(),
   })
   .strict();
 
@@ -67,10 +69,12 @@ type AgentFinalResultSource =
       readonly outcome?: RunOutcome;
       readonly diffs?: readonly ResultDiffSummary[];
       readonly diffsUnavailable?: string;
+      readonly structured?: unknown;
     }
   | {
       readonly category: AgentFlowCategory;
       readonly outcome: RunOutcome;
+      readonly structured?: unknown;
     };
 
 /**
@@ -83,6 +87,7 @@ export function buildAgentFinalResult(source: {
   readonly outcome?: RunOutcome;
   readonly diffs?: readonly ResultDiffSummary[];
   readonly diffsUnavailable?: string;
+  readonly structured?: unknown;
 }): Extract<AgentFinalResult, { category: 'workflow' }>;
 export function buildAgentFinalResult(
   source: AgentFinalResultSource,
@@ -102,6 +107,7 @@ export function buildAgentFinalResult(
         diffs: source.diffs,
         cost: result.totalCostUsd,
         diffsUnavailable: source.diffsUnavailable,
+        structured: source.structured,
       });
     }
     return AgentFinalResultSchema.parse({
@@ -110,6 +116,7 @@ export function buildAgentFinalResult(
       response: result.lastResponse,
       files: result.touchedFiles,
       cost: result.totalCostUsd,
+      structured: source.structured,
     });
   }
 

--- a/src/agent/runtime/AgentFinalResult.ts
+++ b/src/agent/runtime/AgentFinalResult.ts
@@ -37,7 +37,7 @@ export const WorkflowAgentFinalResultSchema = WorkflowFlowResultSchema.pick({
     diffs: z.array(ResultDiffSummarySchema).prefault(() => []),
     cost: CostSchema,
     diffsUnavailable: z.string().optional(),
-    structured: z.unknown().optional(),
+    structured: z.json().optional(),
   })
   .strict();
 
@@ -51,7 +51,7 @@ const ToolUseAgentFinalResultSchema = ToolUseFlowResultSchema.pick({
       .unwrap()
       .prefault(() => []),
     cost: CostSchema,
-    structured: z.unknown().optional(),
+    structured: z.json().optional(),
   })
   .strict();
 

--- a/src/agent/runtime/AgentFinalResult.ts
+++ b/src/agent/runtime/AgentFinalResult.ts
@@ -98,6 +98,11 @@ export function buildAgentFinalResult(
   if ('flowResult' in source) {
     const result = source.flowResult;
     const outcome = source.outcome ?? result.outcome;
+    // Surface the flow result's own captured structured value when the caller
+    // did not pass one, so a populated flow result carries `structured` without
+    // every caller re-threading it.
+    const structured =
+      source.structured ?? (result as { structured?: unknown }).structured;
     if (result.category === 'workflow') {
       return AgentFinalResultSchema.parse({
         category: result.category,
@@ -107,7 +112,7 @@ export function buildAgentFinalResult(
         diffs: source.diffs,
         cost: result.totalCostUsd,
         diffsUnavailable: source.diffsUnavailable,
-        structured: source.structured,
+        structured,
       });
     }
     return AgentFinalResultSchema.parse({
@@ -116,7 +121,7 @@ export function buildAgentFinalResult(
       response: result.lastResponse,
       files: result.touchedFiles,
       cost: result.totalCostUsd,
-      structured: source.structured,
+      structured,
     });
   }
 

--- a/src/agent/runtime/AgentFlowResult.ts
+++ b/src/agent/runtime/AgentFlowResult.ts
@@ -42,6 +42,8 @@ export const ToolUseFlowResultSchema = AgentFlowMetaSchema.extend({
   lastResponse: z.string().optional(),
   /** Workspace-relative paths of files edited by tool calls during this session. */
   touchedFiles: z.array(z.string()).optional(),
+  /** Value captured by the `submit_output` terminal tool, if the run used one. */
+  structured: z.unknown().optional(),
 });
 
 const AgentFlowResultSchema = z.discriminatedUnion('category', [

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -101,6 +101,9 @@ function buildToolUseFlowResult(
     touchedFiles: result.touchedFiles,
     executionId,
     streamId,
+    ...(result.structured !== undefined
+      ? { structured: result.structured }
+      : {}),
     ...buildOptionalFlowResultFields(memoryMisses, result.totalCostUsd),
   };
 }

--- a/src/agent/workflowScript/README.md
+++ b/src/agent/workflowScript/README.md
@@ -26,6 +26,10 @@ return concat(sections, { separator: '\n\n' });
 
 - `agent(prompt, opts?)` — one subagent run; resolves to the host runner's
   typed result, or `null` on failure (filter with `.filter(Boolean)`).
+  `agent(prompt, { schema })`, where `schema` is a JSON Schema object, runs a
+  tool-use agent (name one via `agentName`) that finishes by calling
+  `submit_output`; the call resolves to an envelope whose `.structured` is the
+  validated object rather than edited files.
 - `parallel(thunks)` — concurrent barrier; failed thunks resolve to `null`.
 - `pipeline(items, ...stages)` — per-item stage chains with **no barrier**
   between stages; a throwing stage drops that item to `null`. Each stage is

--- a/src/agent/workflowScript/runWorkflowScript.ts
+++ b/src/agent/workflowScript/runWorkflowScript.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 
 import stableStringify from 'fast-json-stable-stringify';
 import PQueue from 'p-queue';
+import { normalizeStructuredOutputSchema } from '@tools/structuredOutput';
 import { isNonEmptyString } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -659,7 +660,15 @@ function normalizeAgentOptions(
         'agent() option "schema" must be a plain JSON Schema object.',
       );
     }
-    options.schema = schema as Record<string, unknown>;
+    try {
+      options.schema = normalizeStructuredOutputSchema(
+        schema as Record<string, unknown>,
+      ).jsonSchema;
+    } catch (error) {
+      throw new Error(
+        `agent() option "schema" is not a supported object-root JSON Schema: ${toErrorMessage(error)}`,
+      );
+    }
   }
   if (source.inputFiles !== undefined) {
     if (

--- a/src/agent/workflowScript/runWorkflowScript.ts
+++ b/src/agent/workflowScript/runWorkflowScript.ts
@@ -648,11 +648,18 @@ function normalizeAgentOptions(
     }
     options[field] = field === 'id' ? value.trim() : value;
   }
-  for (const field of ['schema', 'outputSchema'] as const) {
-    if (!Object.hasOwn(source, field)) continue;
-    throw new Error(
-      `agent() option "${field}" is unsupported. Pass structured data between stages through a JSON output file.`,
-    );
+  if (Object.hasOwn(source, 'schema')) {
+    const schema = source.schema;
+    if (
+      schema === null ||
+      typeof schema !== 'object' ||
+      Array.isArray(schema)
+    ) {
+      throw new Error(
+        'agent() option "schema" must be a plain JSON Schema object.',
+      );
+    }
+    options.schema = schema as Record<string, unknown>;
   }
   if (source.inputFiles !== undefined) {
     if (

--- a/src/agent/workflowScript/types.ts
+++ b/src/agent/workflowScript/types.ts
@@ -37,6 +37,13 @@ export interface WorkflowAgentCallOptions {
   agentName?: string;
   /** Workspace or run-storage files bound as the child's input files. */
   inputFiles?: string[];
+  /**
+   * Plain JSON Schema object describing the structured result the call must
+   * produce. Its presence routes the call to a tool-use agent that finishes by
+   * submitting a validated value, surfaced on the result's `.structured`.
+   * Participates in the journal key, so resume stays correct.
+   */
+  schema?: Record<string, unknown>;
 }
 
 export interface WorkflowAgentInvocation {

--- a/src/shared/schemas/toolResult.ts
+++ b/src/shared/schemas/toolResult.ts
@@ -145,6 +145,8 @@ const ExecutedToolResultSchema = z
     output: z.string().optional(),
     /** Brief summary of the tool execution result */
     summary: z.string().optional(),
+    /** End the current model turn after this successful tool result is paired. */
+    endTurn: z.boolean().optional(),
     error: z.undefined().optional(),
     /** Statistics about line changes made */
     lineChanges: LineChangesSchema.optional(),

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -223,6 +223,23 @@ describe('retrieveSessionResumeData', () => {
     });
   });
 
+  it('preserves structured output at the persisted shared-state boundary', () => {
+    const result = migrateSharedState({
+      messages: [],
+      shouldSkipCycle: false,
+      stateSlices: null,
+      structured: { title: 'Durable result' },
+    });
+
+    expect(result).toEqual({
+      success: true,
+      data: expect.objectContaining({
+        structured: { title: 'Durable result' },
+      }),
+      migrated: false,
+    });
+  });
+
   it('uses the persisted current model while preserving the original stream id', async () => {
     const executionId = 'abc123' as ExecutionId;
     const streamId = 'chat@gpt54#abc123' as StreamTabId;

--- a/src/test-kernel/agent/ToolUseDispatchParallel.vitest.ts
+++ b/src/test-kernel/agent/ToolUseDispatchParallel.vitest.ts
@@ -8,6 +8,7 @@ import { describe, it, beforeAll } from 'vitest';
 import { createFakePlatform } from '@test/support/FakePlatform';
 import { createRunTrace, StreamLogStore } from '@transcript';
 import { ToolUseDispatchNode } from '@agent/core/flows/toolUseRound/ToolUseDispatchNode';
+import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import type { ToolUseRoundServices } from '@agent/core/flows/CycleServices';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
@@ -33,7 +34,7 @@ function probeTool(
   probe: DispatchProbe,
   name: string,
   delayMs: number,
-  options: { parallelSafe?: boolean } = {},
+  options: { endTurn?: boolean; parallelSafe?: boolean } = {},
 ): ITool {
   return {
     definition: { name, description: name, parameters: {} },
@@ -46,7 +47,11 @@ function probeTool(
       await delay(delayMs);
       probe.inFlight -= 1;
       probe.events.push(`end ${tag}`);
-      return { status: 'executed', output: `${tag} ok` };
+      return {
+        status: 'executed',
+        output: `${tag} ok`,
+        endTurn: options.endTurn,
+      };
     },
   } as ITool;
 }
@@ -86,6 +91,10 @@ function dispatchHarness(opts: HarnessOptions) {
     checkInterruption: opts.checkInterruption ?? (() => false),
     onRoundFinalized: () => {},
     setAbortController: opts.setAbortController ?? (() => {}),
+    modelHandler: {
+      requiresBatchedParallelToolResults: false,
+      createToolUseFollowUpMessages: async () => [],
+    },
     run: AgentRunStateSnapshotSchema.parse({}),
     workspace: AgentWorkspaceState.create(),
   } as unknown as ToolUseRoundServices<unknown>;
@@ -211,6 +220,61 @@ describe('ToolUseDispatchNode parallel dispatch', () => {
         'start read_file:{"n":3}',
         'end read_file:{"n":3}',
       ]);
+    } finally {
+      dispose();
+    }
+  });
+
+  it('stops dispatch and ends the turn after a terminal result', async () => {
+    const probe: DispatchProbe = { events: [], inFlight: 0, maxInFlight: 0 };
+    const { node, dispose } = dispatchHarness({
+      tools: {
+        submit_output: probeTool(probe, 'submit_output', 0, { endTurn: true }),
+        write_file: probeTool(probe, 'write_file', 0),
+      },
+    });
+    const calls = [
+      makeCall('c1', 'submit_output', { title: 'done' }),
+      makeCall('c2', 'write_file', { path: 'late.txt' }),
+    ];
+    const shared = {
+      toolCalls: calls,
+      shouldStop: false,
+      endTurn: false,
+      messages: [],
+    };
+
+    try {
+      const prepped = await (
+        node as unknown as { prep(s: unknown): Promise<SdkToolCall[]> }
+      ).prep(shared);
+      const results = await withTestRunContext(
+        noopAgentRuntimeHost,
+        'dispatch-test',
+        () =>
+          (
+            node as unknown as {
+              _exec(items: unknown[]): Promise<unknown[]>;
+            }
+          )._exec(prepped),
+      );
+      const transition = await (
+        node as unknown as {
+          post(
+            state: typeof shared,
+            dispatched: SdkToolCall[],
+            result: unknown[],
+          ): Promise<string | undefined>;
+        }
+      ).post(shared, prepped, results);
+
+      assert.deepEqual(probe.events, [
+        'start submit_output:{"title":"done"}',
+        'end submit_output:{"title":"done"}',
+      ]);
+      assert.equal(shared.shouldStop, true);
+      assert.equal(shared.endTurn, true);
+      assert.equal(transition, FlowTransition.COMPLETE);
     } finally {
       dispose();
     }

--- a/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
@@ -78,6 +78,16 @@ const result: AgentFinalResult = {
   diffs: [],
   cost: 0,
 };
+// A completed tool-use result carrying a structured value, as a schema call
+// resolves once the agent submits output.
+const structuredResult: AgentFinalResult = {
+  category: 'toolUse',
+  outcome: 'completed',
+  response: '',
+  files: [],
+  cost: 0,
+  structured: { title: 'Lemma 1' },
+};
 
 function parentContext(): LaunchRunContext {
   return {
@@ -501,6 +511,12 @@ describe('createWorkflowScriptAgentRunner', () => {
       category: 'toolUse',
       path: `/agents/${name}.yml`,
     }));
+    mocks.executeStableSubagentInBand.mockImplementationOnce(
+      async (options) => {
+        mocks.preparedOptions.push(await options.prepare());
+        return { executionId: 'bbbbbb222222', result: structuredResult };
+      },
+    );
     const schema = {
       type: 'object',
       properties: { title: { type: 'string' } },
@@ -511,7 +527,7 @@ describe('createWorkflowScriptAgentRunner', () => {
 
     await expect(
       runner(invocation({ agentName: 'assistant', schema })),
-    ).resolves.toBe(result);
+    ).resolves.toBe(structuredResult);
 
     expect(mocks.requireVisibleAgent).toHaveBeenCalledWith(
       'toolUse',
@@ -540,17 +556,81 @@ describe('createWorkflowScriptAgentRunner', () => {
       category: 'toolUse',
       path: `/agents/${name}.yml`,
     }));
+    mocks.executeStableSubagentInBand.mockImplementationOnce(
+      async (options) => {
+        mocks.preparedOptions.push(await options.prepare());
+        return { executionId: 'bbbbbb222222', result: structuredResult };
+      },
+    );
     const schema = { type: 'object', additionalProperties: false };
     const runner = defaultRunner();
 
     // No input files and no default outputs: the workflow path aborts, but a
     // schema call runs a tool-use agent whose result is the submitted value.
-    await expect(runner(invocation({ schema }))).resolves.toBe(result);
+    await expect(
+      runner(invocation({ agentName: 'assistant', schema })),
+    ).resolves.toBe(structuredResult);
     expect(mocks.preparedOptions[0]).toEqual(
       expect.objectContaining({
         configPayload: expect.objectContaining({ agentCategory: 'toolUse' }),
       }),
     );
+  });
+
+  it('aborts a schema call that omits agentName', async () => {
+    const schema = { type: 'object', additionalProperties: false };
+    const runner = defaultRunner();
+
+    // The workflow default 'correct' is a document editor with no tool-use
+    // counterpart, so a schema call must name a tool-use agent explicitly
+    // rather than silently reuse the workflow default under the tool-use
+    // category.
+    await expect(runner(invocation({ schema }))).rejects.toMatchObject({
+      name: 'WorkflowRunAbortError',
+      message: expect.stringMatching(
+        /must name a tool-use agent via agentName/,
+      ),
+    });
+    expect(mocks.preparedOptions).toHaveLength(0);
+    expect(mocks.requireVisibleAgent).not.toHaveBeenCalled();
+  });
+
+  it('aborts a schema run whose agent never submitted structured output', async () => {
+    mocks.requireVisibleAgent.mockImplementation((_category, name) => ({
+      name,
+      source: 'builtInToolUse',
+      category: 'toolUse',
+      path: `/agents/${name}.yml`,
+    }));
+    // The tool-use agent answered in prose and never called submit_output, so
+    // the completed result carries no structured value: the floor must fail
+    // clearly instead of resolving to an envelope with structured undefined.
+    mocks.executeStableSubagentInBand.mockImplementationOnce(
+      async (options) => {
+        mocks.preparedOptions.push(await options.prepare());
+        return {
+          executionId: 'bbbbbb222222',
+          result: {
+            category: 'toolUse',
+            outcome: 'completed',
+            response: 'Here is my answer in prose.',
+            files: [],
+            cost: 0,
+          },
+        };
+      },
+    );
+    const schema = { type: 'object', additionalProperties: false };
+    const runner = defaultRunner();
+
+    await expect(
+      runner(invocation({ agentName: 'assistant', schema })),
+    ).rejects.toMatchObject({
+      name: 'WorkflowRunAbortError',
+      message: expect.stringMatching(
+        /did not call submit_output; no structured result was produced/,
+      ),
+    });
   });
 
   it('leaves onChildActive untouched when a recovered attempt runs no live work', async () => {

--- a/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
@@ -494,6 +494,65 @@ describe('createWorkflowScriptAgentRunner', () => {
     );
   });
 
+  it('routes an agent({ schema }) call to a tool-use agent with an output schema', async () => {
+    mocks.requireVisibleAgent.mockImplementation((_category, name) => ({
+      name,
+      source: 'builtInToolUse',
+      category: 'toolUse',
+      path: `/agents/${name}.yml`,
+    }));
+    const schema = {
+      type: 'object',
+      properties: { title: { type: 'string' } },
+      required: ['title'],
+      additionalProperties: false,
+    };
+    const runner = defaultRunner();
+
+    await expect(
+      runner(invocation({ agentName: 'assistant', schema })),
+    ).resolves.toBe(result);
+
+    expect(mocks.requireVisibleAgent).toHaveBeenCalledWith(
+      'toolUse',
+      'assistant',
+      expect.anything(),
+    );
+    expect(mocks.selectAvailableDelegationModel).toHaveBeenCalledWith({
+      parentModel: 'parent-model',
+      agentCategory: 'toolUse',
+    });
+    expect(mocks.preparedOptions[0]).toEqual(
+      expect.objectContaining({
+        agentName: 'assistant',
+        configPayload: expect.objectContaining({
+          agentCategory: 'toolUse',
+          outputSchema: schema,
+        }),
+      }),
+    );
+  });
+
+  it('exempts a schema call from the workflow empty-files guard', async () => {
+    mocks.requireVisibleAgent.mockImplementation((_category, name) => ({
+      name,
+      source: 'builtInToolUse',
+      category: 'toolUse',
+      path: `/agents/${name}.yml`,
+    }));
+    const schema = { type: 'object', additionalProperties: false };
+    const runner = defaultRunner();
+
+    // No input files and no default outputs: the workflow path aborts, but a
+    // schema call runs a tool-use agent whose result is the submitted value.
+    await expect(runner(invocation({ schema }))).resolves.toBe(result);
+    expect(mocks.preparedOptions[0]).toEqual(
+      expect.objectContaining({
+        configPayload: expect.objectContaining({ agentCategory: 'toolUse' }),
+      }),
+    );
+  });
+
   it('leaves onChildActive untouched when a recovered attempt runs no live work', async () => {
     // A recovered attempt never fires onActiveExecutionId, so the settle guard
     // must not emit a phantom active/inactive pair for a call that never ran.

--- a/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
@@ -595,44 +595,6 @@ describe('createWorkflowScriptAgentRunner', () => {
     expect(mocks.requireVisibleAgent).not.toHaveBeenCalled();
   });
 
-  it('aborts a schema run whose agent never submitted structured output', async () => {
-    mocks.requireVisibleAgent.mockImplementation((_category, name) => ({
-      name,
-      source: 'builtInToolUse',
-      category: 'toolUse',
-      path: `/agents/${name}.yml`,
-    }));
-    // The tool-use agent answered in prose and never called submit_output, so
-    // the completed result carries no structured value: the floor must fail
-    // clearly instead of resolving to an envelope with structured undefined.
-    mocks.executeStableSubagentInBand.mockImplementationOnce(
-      async (options) => {
-        mocks.preparedOptions.push(await options.prepare());
-        return {
-          executionId: 'bbbbbb222222',
-          result: {
-            category: 'toolUse',
-            outcome: 'completed',
-            response: 'Here is my answer in prose.',
-            files: [],
-            cost: 0,
-          },
-        };
-      },
-    );
-    const schema = { type: 'object', additionalProperties: false };
-    const runner = defaultRunner();
-
-    await expect(
-      runner(invocation({ agentName: 'assistant', schema })),
-    ).rejects.toMatchObject({
-      name: 'WorkflowRunAbortError',
-      message: expect.stringMatching(
-        /did not call submit_output; no structured result was produced/,
-      ),
-    });
-  });
-
   it('leaves onChildActive untouched when a recovered attempt runs no live work', async () => {
     // A recovered attempt never fires onActiveExecutionId, so the settle guard
     // must not emit a phantom active/inactive pair for a call that never ran.

--- a/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
@@ -167,6 +167,21 @@ return { structured: withSchema.structured, plain }`,
     ).rejects.toThrow(/schema.*must be a plain JSON Schema object/i);
   });
 
+  it('rejects an empty or regex-bearing structured-output schema', async () => {
+    await expect(
+      runWorkflowScript({
+        script: `${META}return await agent('draft', { schema: {} })`,
+        runAgent: echoRunner,
+      }),
+    ).rejects.toThrow(/schema.*object-root JSON Schema/i);
+    await expect(
+      runWorkflowScript({
+        script: `${META}return await agent('draft', { schema: { type: 'object', properties: { value: { type: 'string', pattern: '(a+)+$' } } } })`,
+        runAgent: echoRunner,
+      }),
+    ).rejects.toThrow(/cannot use pattern/i);
+  });
+
   it('requires explicit identities for otherwise-repeated calls', async () => {
     const invocations: WorkflowAgentInvocation[] = [];
     await runWorkflowScript({
@@ -634,7 +649,10 @@ return await agent('b', { outputSchema: { type: 'object' } })`,
 
     // schema is a first-class option now; outputSchema is no longer recognized
     // and is silently dropped like any other unknown option.
-    expect(seen[0]?.options.schema).toEqual({ type: 'object' });
+    expect(seen[0]?.options.schema).toMatchObject({
+      type: 'object',
+      properties: {},
+    });
     expect(seen[1]?.options.schema).toBeUndefined();
     expect(seen[1]?.options).not.toHaveProperty('outputSchema');
   });

--- a/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
@@ -116,6 +116,57 @@ return [a, b]`,
     expect(run.meta.name).toBe('test-flow');
   });
 
+  it('passes a structured result from agent({ schema }) to the script and keys the journal by schema', async () => {
+    const schema = {
+      type: 'object',
+      properties: { title: { type: 'string' } },
+      required: ['title'],
+      additionalProperties: false,
+    };
+    const keys: string[] = [];
+    const run = await runWorkflowScript({
+      script: `${META}
+const withSchema = await agent('draft', { schema: args.schema })
+const plain = await agent('draft')
+return { structured: withSchema.structured, plain }`,
+      args: { schema },
+      runAgent: (invocation) => {
+        keys.push(invocation.key);
+        return Promise.resolve(
+          invocation.options.schema
+            ? {
+                category: 'toolUse',
+                outcome: 'completed',
+                response: '',
+                files: [],
+                cost: 0,
+                structured: { title: 'Lemma' },
+              }
+            : `result:${invocation.prompt}`,
+        );
+      },
+    });
+
+    // The `.structured` envelope reaches the script unchanged.
+    expect(run.result).toMatchObject({
+      structured: { title: 'Lemma' },
+      plain: 'result:draft',
+    });
+    // Same prompt, differing only by the schema option, must yield distinct
+    // journal keys so resume identity tracks the schema.
+    expect(keys).toHaveLength(2);
+    expect(keys[0]).not.toBe(keys[1]);
+  });
+
+  it('rejects a non-object schema option', async () => {
+    await expect(
+      runWorkflowScript({
+        script: `${META}return await agent('draft', { schema: 'nope' })`,
+        runAgent: echoRunner,
+      }),
+    ).rejects.toThrow(/schema.*must be a plain JSON Schema object/i);
+  });
+
   it('requires explicit identities for otherwise-repeated calls', async () => {
     const invocations: WorkflowAgentInvocation[] = [];
     await runWorkflowScript({
@@ -568,19 +619,25 @@ return null`,
     ).rejects.toThrow(/inputFiles.*array of non-empty strings/);
   });
 
-  it.each(['schema', 'outputSchema'] as const)(
-    'rejects the obsolete %s option instead of silently ignoring it',
-    async (field) => {
-      const runner = vi.fn(echoRunner);
-      await expect(
-        runWorkflowScript({
-          script: `${META}return await agent('x', { ${field}: { type: 'object' } })`,
-          runAgent: runner,
-        }),
-      ).rejects.toThrow(/structured data.*JSON output file/);
-      expect(runner).not.toHaveBeenCalled();
-    },
-  );
+  it('accepts a schema option and drops the obsolete outputSchema option', async () => {
+    const seen: WorkflowAgentInvocation[] = [];
+    const runner = vi.fn((invocation: WorkflowAgentInvocation) => {
+      seen.push(invocation);
+      return echoRunner(invocation);
+    });
+    await runWorkflowScript({
+      script: `${META}
+await agent('a', { schema: { type: 'object' } })
+return await agent('b', { outputSchema: { type: 'object' } })`,
+      runAgent: runner,
+    });
+
+    // schema is a first-class option now; outputSchema is no longer recognized
+    // and is silently dropped like any other unknown option.
+    expect(seen[0]?.options.schema).toEqual({ type: 'object' });
+    expect(seen[1]?.options.schema).toBeUndefined();
+    expect(seen[1]?.options).not.toHaveProperty('outputSchema');
+  });
 
   it('blocks Function-constructor escapes through injected primitives', async () => {
     // agent is a realm-local wrapper, so its .constructor is the sandbox's

--- a/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
@@ -32,6 +32,7 @@ import { StreamLogStore } from '@transcript/StreamLogStore';
 import { attachTranscriptRecorder } from '@transcript/TexraTranscriptRecorder';
 import { TraceEmitter } from '@agent/trace';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
+import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import { ToolUseCycleNode } from '@agent/implementations/flows/tooluse/nodes/ToolUseCycleNode';
 import { SessionEventHub } from '@agent/runtime/SessionEventHub';
@@ -75,7 +76,7 @@ function createPrepResult(
   return {
     shouldSkipCycle,
     messages: [],
-    runState: { totalRounds: 0 } as CyclePrepResult['runState'],
+    runState: AgentRunStateSnapshotSchema.parse({}),
     workspaceState,
     userChannels: { input: {}, transient: {} },
   };
@@ -146,6 +147,22 @@ describe('tool-use progress events', () => {
     expect(error).toHaveBeenCalledWith('Model claude-opus-4-7 not found', {
       messageType: MESSAGE_TYPES.ERROR,
     });
+  });
+
+  it('persists a completed cycle structured result in shared state', async () => {
+    const prepRes = createPrepResult(AgentWorkspaceState.create());
+    const shared: Partial<ToolUseRunShared> = {};
+    const structured = { title: 'Durable result' };
+    const node = new ToolUseCycleNode().setServices({
+      getPendingStructuredOutput: () => structured,
+    } as unknown as ToolUseServices);
+
+    await node.post(shared as ToolUseRunShared, prepRes, {
+      outcome: 'completed',
+      messages: [],
+    });
+
+    expect(shared.structured).toEqual(structured);
   });
 });
 

--- a/src/test-kernel/agent/runtime/AgentFinalResult.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentFinalResult.vitest.ts
@@ -109,6 +109,40 @@ describe('AgentFinalResult', () => {
     });
   });
 
+  it('surfaces structured output on the workflow envelope', () => {
+    const flowResult: AgentFlowResult = {
+      category: 'workflow',
+      outcome: 'completed',
+      executionId: 'abcdefabcdef' as ExecutionId,
+      streamId: 'stream:workflow' as StreamTabId,
+      outputs: [],
+      compileFailures: [],
+    };
+
+    expect(
+      buildAgentFinalResult({ flowResult, structured: { title: 'Lemma 1' } }),
+    ).toMatchObject({
+      category: 'workflow',
+      structured: { title: 'Lemma 1' },
+    });
+  });
+
+  it('surfaces structured output on the tool-use envelope', () => {
+    const flowResult: AgentFlowResult = {
+      category: 'toolUse',
+      outcome: 'completed',
+      executionId: 'abcdefabcdef' as ExecutionId,
+      streamId: 'stream:tool-use' as StreamTabId,
+    };
+
+    expect(
+      buildAgentFinalResult({ flowResult, structured: [1, 2, 3] }),
+    ).toMatchObject({
+      category: 'toolUse',
+      structured: [1, 2, 3],
+    });
+  });
+
   it.each(['failed', 'cancelled'] as RunOutcome[])(
     'allows an error path to preserve the %s outcome',
     (outcome) => {

--- a/src/test-kernel/agent/runtime/AgentFinalResult.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentFinalResult.vitest.ts
@@ -143,6 +143,23 @@ describe('AgentFinalResult', () => {
     });
   });
 
+  it('surfaces the flow result own structured value when the source omits it', () => {
+    const flowResult: AgentFlowResult = {
+      category: 'toolUse',
+      outcome: 'completed',
+      executionId: 'abcdefabcdef' as ExecutionId,
+      streamId: 'stream:tool-use' as StreamTabId,
+      structured: { title: 'Captured' },
+    };
+
+    // The caller passed no `structured`, so the flow result's own captured
+    // value must surface without the caller re-threading it.
+    expect(buildAgentFinalResult({ flowResult })).toMatchObject({
+      category: 'toolUse',
+      structured: { title: 'Captured' },
+    });
+  });
+
   it.each(['failed', 'cancelled'] as RunOutcome[])(
     'allows an error path to preserve the %s outcome',
     (outcome) => {

--- a/src/test-kernel/agent/runtime/AgentFinalResult.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentFinalResult.vitest.ts
@@ -179,6 +179,16 @@ describe('AgentFinalResult', () => {
     ).toBe(false);
   });
 
+  it('rejects structured values that cannot be persisted as JSON', () => {
+    expect(
+      AgentFinalResultSchema.safeParse({
+        category: 'toolUse',
+        outcome: 'completed',
+        structured: { count: 1n },
+      }).success,
+    ).toBe(false);
+  });
+
   it('rejects WAITING and negative cumulative cost', () => {
     expect(
       AgentFinalResultSchema.safeParse({

--- a/src/test-kernel/tools/SubagentDeliveryStructured.vitest.ts
+++ b/src/test-kernel/tools/SubagentDeliveryStructured.vitest.ts
@@ -1,0 +1,48 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports
+import type { AgentFlowResult } from '@agent/runtime/AgentFlowResult';
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
+import { buildSubagentResult } from '@tools/delegation/subagentDeliveryFormat';
+
+// A tool-use flow result carrying a value captured by the submit_output
+// terminal tool must surface as `.structured` on the built AgentFinalResult,
+// so a workflow-script agent({ schema }) call receives it unchanged.
+function toolUseFlowResult(
+  structured: unknown,
+): Extract<AgentFlowResult, { category: 'toolUse' }> {
+  return {
+    category: 'toolUse',
+    outcome: 'completed',
+    executionId: 'exec-structured' as ExecutionId,
+    streamId: 'stream-structured' as StreamTabId,
+    lastResponse: 'done',
+    structured,
+  };
+}
+
+describe('buildSubagentResult structured pass-through', () => {
+  it('carries a captured structured value onto the final result', async () => {
+    const built = await buildSubagentResult(
+      'exec-structured' as ExecutionId,
+      'assistant',
+      toolUseFlowResult({ title: 'Lemma', count: 2 }),
+      { startedAt: Date.now() },
+    );
+
+    expect(built.result.category).toBe('toolUse');
+    expect(built.result.structured).toEqual({ title: 'Lemma', count: 2 });
+  });
+
+  it('omits structured when the run captured nothing', async () => {
+    const built = await buildSubagentResult(
+      'exec-structured' as ExecutionId,
+      'assistant',
+      toolUseFlowResult(undefined),
+      { startedAt: Date.now() },
+    );
+
+    expect(built.result.structured).toBeUndefined();
+  });
+});

--- a/src/test-kernel/tools/structuredOutput.vitest.ts
+++ b/src/test-kernel/tools/structuredOutput.vitest.ts
@@ -2,9 +2,13 @@
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 
+// Local imports - core
+import { MapToolRegistry, type ITool } from '@agent/core/tools/ToolTypes';
+
 // Local imports - tools
 import {
   buildTerminalTool,
+  buildTerminalToolRegistry,
   isStrictNativeCompatible,
   resolveStructuredOutput,
   SUBMIT_OUTPUT_TOOL_NAME,
@@ -161,5 +165,34 @@ describe('buildTerminalTool', () => {
 
     expect(captureA).toHaveBeenCalledTimes(1);
     expect(captureB).not.toHaveBeenCalled();
+  });
+});
+
+describe('buildTerminalToolRegistry', () => {
+  const spec = resolveStructuredOutput(z.strictObject({ title: z.string() }));
+  const realTool = {
+    definition: { name: 'read_file', description: 'read', parameters: {} },
+  } as ITool;
+  const base = new MapToolRegistry({ read_file: realTool });
+
+  it('overrides submit_output while delegating every other lookup', () => {
+    const terminalTool = buildTerminalTool(spec, vi.fn());
+    const overlay = buildTerminalToolRegistry(base, terminalTool);
+
+    expect(overlay.get(SUBMIT_OUTPUT_TOOL_NAME)).toBe(terminalTool);
+    expect(overlay.has(SUBMIT_OUTPUT_TOOL_NAME)).toBe(true);
+    expect(overlay.get('read_file')).toBe(realTool);
+    expect(overlay.has('read_file')).toBe(true);
+    expect(overlay.get('missing')).toBeUndefined();
+    expect(overlay.has('missing')).toBe(false);
+  });
+
+  it('never mutates the base registry', () => {
+    const terminalTool = buildTerminalTool(spec, vi.fn());
+    buildTerminalToolRegistry(base, terminalTool);
+
+    // The shared default registry must never gain the synthetic tool.
+    expect(base.get(SUBMIT_OUTPUT_TOOL_NAME)).toBeUndefined();
+    expect(base.has(SUBMIT_OUTPUT_TOOL_NAME)).toBe(false);
   });
 });

--- a/src/test-kernel/tools/structuredOutput.vitest.ts
+++ b/src/test-kernel/tools/structuredOutput.vitest.ts
@@ -102,6 +102,18 @@ describe('isStrictNativeCompatible', () => {
 
     expect(isStrictNativeCompatible(spec)).toBe(false);
   });
+
+  it('rejects a bare object node with no additionalProperties: false', () => {
+    const spec = resolveStructuredOutput({ type: 'object' });
+
+    expect(isStrictNativeCompatible(spec)).toBe(false);
+  });
+
+  it('rejects an unconstrained (empty) schema', () => {
+    const spec = resolveStructuredOutput({});
+
+    expect(isStrictNativeCompatible(spec)).toBe(false);
+  });
 });
 
 describe('buildTerminalTool', () => {

--- a/src/test-kernel/tools/structuredOutput.vitest.ts
+++ b/src/test-kernel/tools/structuredOutput.vitest.ts
@@ -143,6 +143,14 @@ describe('buildTerminalTool', () => {
     expect(capture).not.toHaveBeenCalled();
   });
 
+  it('rejects a non-object root schema so provider tool inputs stay valid', () => {
+    const arraySpec = resolveStructuredOutput(z.array(z.string()));
+
+    expect(() => buildTerminalTool(arraySpec, vi.fn())).toThrow(
+      /object at the root/,
+    );
+  });
+
   it('binds capture per instance so concurrent runs never share a sink', async () => {
     const captureA = vi.fn<(value: unknown) => void>();
     const captureB = vi.fn<(value: unknown) => void>();

--- a/src/test-kernel/tools/structuredOutput.vitest.ts
+++ b/src/test-kernel/tools/structuredOutput.vitest.ts
@@ -1,0 +1,145 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+// Local imports - tools
+import {
+  buildTerminalTool,
+  isStrictNativeCompatible,
+  resolveStructuredOutput,
+  SUBMIT_OUTPUT_TOOL_NAME,
+} from '@tools/structuredOutput';
+
+describe('resolveStructuredOutput', () => {
+  it('round-trips a JSON Schema object through z.fromJSONSchema', () => {
+    const jsonSchema = {
+      type: 'object',
+      properties: {
+        title: { type: 'string' },
+        count: { type: 'integer' },
+      },
+      required: ['title', 'count'],
+      additionalProperties: false,
+    };
+
+    const spec = resolveStructuredOutput(jsonSchema, 'result');
+
+    expect(spec.name).toBe('result');
+    expect(spec.jsonSchema).toBe(jsonSchema);
+    expect(spec.validate({ title: 'Lemma', count: 2 }).success).toBe(true);
+    expect(spec.validate({ title: 'Lemma' }).success).toBe(false);
+  });
+
+  it('derives an equivalent JSON Schema from a Zod schema', () => {
+    const zodSchema = z.strictObject({
+      title: z.string(),
+      count: z.number(),
+    });
+
+    const spec = resolveStructuredOutput(zodSchema, 'result');
+
+    expect(spec.zodSchema).toBe(zodSchema);
+    expect(spec.jsonSchema).toMatchObject({
+      type: 'object',
+      properties: {
+        title: { type: 'string' },
+        count: { type: 'number' },
+      },
+    });
+    expect(spec.validate({ title: 'Lemma', count: 2 }).success).toBe(true);
+    expect(spec.validate({ title: 'Lemma', count: 'two' }).success).toBe(false);
+  });
+});
+
+describe('isStrictNativeCompatible', () => {
+  it('accepts a plain all-required additionalProperties:false object', () => {
+    const spec = resolveStructuredOutput({
+      type: 'object',
+      properties: {
+        title: { type: 'string' },
+        done: { type: 'boolean' },
+      },
+      required: ['title', 'done'],
+      additionalProperties: false,
+    });
+
+    expect(isStrictNativeCompatible(spec)).toBe(true);
+  });
+
+  it('rejects numeric constraint keywords from .int().min()', () => {
+    const spec = resolveStructuredOutput(
+      z.strictObject({ count: z.int().min(1) }),
+    );
+
+    expect(isStrictNativeCompatible(spec)).toBe(false);
+  });
+
+  it('rejects an optional (not required) property', () => {
+    const spec = resolveStructuredOutput(
+      z.strictObject({ title: z.string(), note: z.string().nullish() }),
+    );
+
+    expect(isStrictNativeCompatible(spec)).toBe(false);
+  });
+
+  it('rejects a string pattern constraint', () => {
+    const spec = resolveStructuredOutput({
+      type: 'object',
+      properties: { id: { type: 'string', pattern: '^[a-z]+$' } },
+      required: ['id'],
+      additionalProperties: false,
+    });
+
+    expect(isStrictNativeCompatible(spec)).toBe(false);
+  });
+
+  it('rejects an object that allows extra properties', () => {
+    const spec = resolveStructuredOutput({
+      type: 'object',
+      properties: { title: { type: 'string' } },
+      required: ['title'],
+    });
+
+    expect(isStrictNativeCompatible(spec)).toBe(false);
+  });
+});
+
+describe('buildTerminalTool', () => {
+  const spec = resolveStructuredOutput(
+    z.strictObject({ title: z.string(), count: z.number() }),
+  );
+
+  it('captures already-validated input and returns a success result', async () => {
+    const capture = vi.fn<(value: unknown) => void>();
+    const tool = buildTerminalTool(spec, capture);
+
+    expect(tool.definition.name).toBe(SUBMIT_OUTPUT_TOOL_NAME);
+
+    const result = await tool.call({ title: 'Lemma', count: 2 });
+
+    expect(result.status).toBe('executed');
+    expect(capture).toHaveBeenCalledWith({ title: 'Lemma', count: 2 });
+  });
+
+  it('rejects invalid input via its own schema before execute (repair path)', async () => {
+    const capture = vi.fn<(value: unknown) => void>();
+    const tool = buildTerminalTool(spec, capture);
+
+    const result = await tool.call({ title: 'Lemma', count: 'two' });
+
+    expect(result.status).toBe('error');
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('binds capture per instance so concurrent runs never share a sink', async () => {
+    const captureA = vi.fn<(value: unknown) => void>();
+    const captureB = vi.fn<(value: unknown) => void>();
+    const toolA = buildTerminalTool(spec, captureA);
+    const toolB = buildTerminalTool(spec, captureB);
+
+    await toolA.call({ title: 'A', count: 1 });
+
+    expect(captureA).toHaveBeenCalledTimes(1);
+    expect(captureB).not.toHaveBeenCalled();
+  });
+});

--- a/src/test-kernel/tools/structuredOutput.vitest.ts
+++ b/src/test-kernel/tools/structuredOutput.vitest.ts
@@ -73,6 +73,17 @@ describe('normalizeStructuredOutputSchema', () => {
         properties: { value: { type: 'string', pattern: '(a+)+$' } },
       }),
     ).toThrow(/cannot use pattern/);
+    expect(() =>
+      normalizeStructuredOutputSchema({
+        type: 'object',
+        properties: {
+          tuple: {
+            type: 'array',
+            items: [{ type: 'string', pattern: '(a+)+$' }],
+          },
+        },
+      }),
+    ).toThrow(/cannot use pattern/);
   });
 
   it('allows output fields whose names match JSON Schema keywords', () => {

--- a/src/test-kernel/tools/structuredOutput.vitest.ts
+++ b/src/test-kernel/tools/structuredOutput.vitest.ts
@@ -11,8 +11,11 @@ import {
   buildTerminalToolRegistry,
   isStrictNativeCompatible,
   resolveStructuredOutput,
-  SUBMIT_OUTPUT_TOOL_NAME,
 } from '@tools/structuredOutput';
+
+// The synthetic terminal tool's name is a file-local const in
+// structuredOutput.ts; assert against the literal here.
+const SUBMIT_OUTPUT_TOOL_NAME = 'submit_output';
 
 describe('resolveStructuredOutput', () => {
   it('round-trips a JSON Schema object through z.fromJSONSchema', () => {

--- a/src/test-kernel/tools/structuredOutput.vitest.ts
+++ b/src/test-kernel/tools/structuredOutput.vitest.ts
@@ -9,16 +9,15 @@ import { MapToolRegistry, type ITool } from '@agent/core/tools/ToolTypes';
 import {
   buildTerminalTool,
   buildTerminalToolRegistry,
-  isStrictNativeCompatible,
-  resolveStructuredOutput,
+  normalizeStructuredOutputSchema,
 } from '@tools/structuredOutput';
 
 // The synthetic terminal tool's name is a file-local const in
 // structuredOutput.ts; assert against the literal here.
 const SUBMIT_OUTPUT_TOOL_NAME = 'submit_output';
 
-describe('resolveStructuredOutput', () => {
-  it('round-trips a JSON Schema object through z.fromJSONSchema', () => {
+describe('normalizeStructuredOutputSchema', () => {
+  it('normalizes a JSON Schema object through the pinned Zod API', async () => {
     const jsonSchema = {
       type: 'object',
       properties: {
@@ -29,120 +28,84 @@ describe('resolveStructuredOutput', () => {
       additionalProperties: false,
     };
 
-    const spec = resolveStructuredOutput(jsonSchema, 'result');
+    const normalized = normalizeStructuredOutputSchema(jsonSchema);
+    const capture = vi.fn<(value: unknown) => void>();
+    const tool = buildTerminalTool(jsonSchema, capture);
 
-    expect(spec.name).toBe('result');
-    expect(spec.jsonSchema).toBe(jsonSchema);
-    expect(spec.validate({ title: 'Lemma', count: 2 }).success).toBe(true);
-    expect(spec.validate({ title: 'Lemma' }).success).toBe(false);
+    expect(normalized.jsonSchema).toMatchObject(jsonSchema);
+    await expect(
+      tool.call({ title: 'Lemma', count: 2 }),
+    ).resolves.toMatchObject({ status: 'executed' });
+    await expect(tool.call({ title: 'Lemma' })).resolves.toMatchObject({
+      status: 'error',
+    });
   });
 
-  it('derives an equivalent JSON Schema from a Zod schema', () => {
+  it('derives an equivalent object schema from a Zod schema', () => {
     const zodSchema = z.strictObject({
       title: z.string(),
       count: z.number(),
     });
 
-    const spec = resolveStructuredOutput(zodSchema, 'result');
+    const normalized = normalizeStructuredOutputSchema(zodSchema);
 
-    expect(spec.zodSchema).toBe(zodSchema);
-    expect(spec.jsonSchema).toMatchObject({
+    expect(normalized.zodSchema).toBe(zodSchema);
+    expect(normalized.jsonSchema).toMatchObject({
       type: 'object',
       properties: {
         title: { type: 'string' },
         count: { type: 'number' },
       },
     });
-    expect(spec.validate({ title: 'Lemma', count: 2 }).success).toBe(true);
-    expect(spec.validate({ title: 'Lemma', count: 'two' }).success).toBe(false);
-  });
-});
-
-describe('isStrictNativeCompatible', () => {
-  it('accepts a plain all-required additionalProperties:false object', () => {
-    const spec = resolveStructuredOutput({
-      type: 'object',
-      properties: {
-        title: { type: 'string' },
-        done: { type: 'boolean' },
-      },
-      required: ['title', 'done'],
-      additionalProperties: false,
-    });
-
-    expect(isStrictNativeCompatible(spec)).toBe(true);
   });
 
-  it('rejects numeric constraint keywords from .int().min()', () => {
-    const spec = resolveStructuredOutput(
-      z.strictObject({ count: z.int().min(1) }),
+  it('rejects non-object and unconstrained roots at normalization time', () => {
+    expect(() => normalizeStructuredOutputSchema({})).toThrow(/object.*root/);
+    expect(() => normalizeStructuredOutputSchema(z.array(z.string()))).toThrow(
+      /object.*root/,
     );
-
-    expect(isStrictNativeCompatible(spec)).toBe(false);
   });
 
-  it('rejects an optional (not required) property', () => {
-    const spec = resolveStructuredOutput(
-      z.strictObject({ title: z.string(), note: z.string().nullish() }),
-    );
-
-    expect(isStrictNativeCompatible(spec)).toBe(false);
+  it('rejects regex-bearing sandbox schemas before host compilation', () => {
+    expect(() =>
+      normalizeStructuredOutputSchema({
+        type: 'object',
+        properties: { value: { type: 'string', pattern: '(a+)+$' } },
+      }),
+    ).toThrow(/cannot use pattern/);
   });
 
-  it('rejects a string pattern constraint', () => {
-    const spec = resolveStructuredOutput({
-      type: 'object',
-      properties: { id: { type: 'string', pattern: '^[a-z]+$' } },
-      required: ['id'],
-      additionalProperties: false,
-    });
-
-    expect(isStrictNativeCompatible(spec)).toBe(false);
-  });
-
-  it('rejects an object that allows extra properties', () => {
-    const spec = resolveStructuredOutput({
-      type: 'object',
-      properties: { title: { type: 'string' } },
-      required: ['title'],
-    });
-
-    expect(isStrictNativeCompatible(spec)).toBe(false);
-  });
-
-  it('rejects a bare object node with no additionalProperties: false', () => {
-    const spec = resolveStructuredOutput({ type: 'object' });
-
-    expect(isStrictNativeCompatible(spec)).toBe(false);
-  });
-
-  it('rejects an unconstrained (empty) schema', () => {
-    const spec = resolveStructuredOutput({});
-
-    expect(isStrictNativeCompatible(spec)).toBe(false);
+  it('allows output fields whose names match JSON Schema keywords', () => {
+    expect(() =>
+      normalizeStructuredOutputSchema({
+        type: 'object',
+        properties: {
+          pattern: { type: 'string' },
+          patternProperties: { type: 'string' },
+        },
+      }),
+    ).not.toThrow();
   });
 });
 
 describe('buildTerminalTool', () => {
-  const spec = resolveStructuredOutput(
-    z.strictObject({ title: z.string(), count: z.number() }),
-  );
+  const schema = z.strictObject({ title: z.string(), count: z.number() });
 
   it('captures already-validated input and returns a success result', async () => {
     const capture = vi.fn<(value: unknown) => void>();
-    const tool = buildTerminalTool(spec, capture);
+    const tool = buildTerminalTool(schema, capture);
 
     expect(tool.definition.name).toBe(SUBMIT_OUTPUT_TOOL_NAME);
 
     const result = await tool.call({ title: 'Lemma', count: 2 });
 
-    expect(result.status).toBe('executed');
+    expect(result).toMatchObject({ status: 'executed', endTurn: true });
     expect(capture).toHaveBeenCalledWith({ title: 'Lemma', count: 2 });
   });
 
   it('rejects invalid input via its own schema before execute (repair path)', async () => {
     const capture = vi.fn<(value: unknown) => void>();
-    const tool = buildTerminalTool(spec, capture);
+    const tool = buildTerminalTool(schema, capture);
 
     const result = await tool.call({ title: 'Lemma', count: 'two' });
 
@@ -151,18 +114,59 @@ describe('buildTerminalTool', () => {
   });
 
   it('rejects a non-object root schema so provider tool inputs stay valid', () => {
-    const arraySpec = resolveStructuredOutput(z.array(z.string()));
-
-    expect(() => buildTerminalTool(arraySpec, vi.fn())).toThrow(
+    expect(() => buildTerminalTool(z.array(z.string()), vi.fn())).toThrow(
       /object at the root/,
     );
+  });
+
+  it('supports async Zod validation through the canonical tool boundary', async () => {
+    const capture = vi.fn<(value: unknown) => void>();
+    const tool = buildTerminalTool(
+      z.strictObject({
+        title: z.string().refine(async (value) => value === 'accepted'),
+      }),
+      capture,
+    );
+
+    await expect(tool.call({ title: 'rejected' })).resolves.toMatchObject({
+      status: 'error',
+    });
+    await expect(tool.call({ title: 'accepted' })).resolves.toMatchObject({
+      status: 'executed',
+    });
+  });
+
+  it('rejects transformed values that cannot cross the JSON boundary', async () => {
+    const capture = vi.fn<(value: unknown) => void>();
+    const tool = buildTerminalTool(
+      z.strictObject({ value: z.string().transform(() => 1n) }),
+      capture,
+    );
+
+    await expect(tool.call({ value: 'one' })).resolves.toMatchObject({
+      status: 'error',
+    });
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('accepts only one structured result per run', async () => {
+    const capture = vi.fn<(value: unknown) => void>();
+    const tool = buildTerminalTool(schema, capture);
+
+    await expect(
+      tool.call({ title: 'First', count: 1 }),
+    ).resolves.toMatchObject({ status: 'executed' });
+    await expect(
+      tool.call({ title: 'Second', count: 2 }),
+    ).resolves.toMatchObject({ status: 'error' });
+    expect(capture).toHaveBeenCalledTimes(1);
   });
 
   it('binds capture per instance so concurrent runs never share a sink', async () => {
     const captureA = vi.fn<(value: unknown) => void>();
     const captureB = vi.fn<(value: unknown) => void>();
-    const toolA = buildTerminalTool(spec, captureA);
-    const toolB = buildTerminalTool(spec, captureB);
+    const toolA = buildTerminalTool(schema, captureA);
+    const toolB = buildTerminalTool(schema, captureB);
 
     await toolA.call({ title: 'A', count: 1 });
 
@@ -172,14 +176,14 @@ describe('buildTerminalTool', () => {
 });
 
 describe('buildTerminalToolRegistry', () => {
-  const spec = resolveStructuredOutput(z.strictObject({ title: z.string() }));
+  const schema = z.strictObject({ title: z.string() });
   const realTool = {
     definition: { name: 'read_file', description: 'read', parameters: {} },
   } as ITool;
   const base = new MapToolRegistry({ read_file: realTool });
 
   it('overrides submit_output while delegating every other lookup', () => {
-    const terminalTool = buildTerminalTool(spec, vi.fn());
+    const terminalTool = buildTerminalTool(schema, vi.fn());
     const overlay = buildTerminalToolRegistry(base, terminalTool);
 
     expect(overlay.get(SUBMIT_OUTPUT_TOOL_NAME)).toBe(terminalTool);
@@ -191,7 +195,7 @@ describe('buildTerminalToolRegistry', () => {
   });
 
   it('never mutates the base registry', () => {
-    const terminalTool = buildTerminalTool(spec, vi.fn());
+    const terminalTool = buildTerminalTool(schema, vi.fn());
     buildTerminalToolRegistry(base, terminalTool);
 
     // The shared default registry must never gain the synthetic tool.

--- a/src/tools/core/base.ts
+++ b/src/tools/core/base.ts
@@ -30,8 +30,15 @@ export abstract class BaseTool<T> implements ITool {
     this.schema = schema;
   }
 
-  validate(input: unknown): T {
-    return this.schema.parse(input);
+  validate(input: unknown): T | Promise<T> {
+    try {
+      return this.schema.parse(input);
+    } catch (error) {
+      if (error instanceof z.core.$ZodAsyncError) {
+        return this.schema.parseAsync(input);
+      }
+      throw error;
+    }
   }
 
   /**
@@ -51,7 +58,8 @@ export abstract class BaseTool<T> implements ITool {
    */
   async call(rawInput: unknown): Promise<ToolResult> {
     try {
-      const input = this.validate(rawInput);
+      const validated = this.validate(rawInput);
+      const input = validated instanceof Promise ? await validated : validated;
       // await is required here - without it, rejections bypass the catch block
       return await this.execute(input);
     } catch (err) {

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -67,6 +67,8 @@ export class WorkflowScriptTool extends defineTool({
 
 Script rules: start with export const meta = { name, description }; no imports or require (only the injected primitives exist: agent, phase, log, parallel, pipeline, concat, and the args global). agent(), parallel(), and pipeline() return Promises: ALWAYS await them. agent(prompt, options) options: inputFiles (REQUIRED for file-editing agents; workspace paths, or a previous call's output paths to chain stages), agentName (another visible workflow agent; defaults to this tool's agent field), id (distinguish otherwise-identical calls), label, phase. A failed call inside parallel()/pipeline() resolves to null; filter with .filter(Boolean).
 
+Structured output: agent(prompt, { schema }) where schema is a JSON Schema object runs a tool-use agent (name one via agentName; the default agent field is a file editor with no tool-use counterpart) that finishes by calling submit_output with a value matching schema. The call resolves to an envelope whose .structured is the validated object rather than edited files.
+
 Async: this tool returns immediately with an execution ID and runs the workflow as its own detached execution. The script's return value plus the run log (phases, log() lines, per-call outcomes with cost) are delivered back as a follow-up message when the run completes. Check intermediate progress with the executions tool (path=/executions/<id>, action=wait).
 
 Example:

--- a/src/tools/delegation/subagentDeliveryFormat.ts
+++ b/src/tools/delegation/subagentDeliveryFormat.ts
@@ -78,6 +78,7 @@ export async function buildSubagentResult(
     flowResult: result,
     diffs,
     diffsUnavailable,
+    structured: result.category === 'toolUse' ? result.structured : undefined,
   });
   return {
     result: finalResult,

--- a/src/tools/delegation/workflowScriptAgentRunner.ts
+++ b/src/tools/delegation/workflowScriptAgentRunner.ts
@@ -242,19 +242,6 @@ export function createWorkflowScriptAgentRunner(
           `Workflow subagent ended with ${result.outcome} outcome.`,
         );
       }
-      // Floor guarantee: a schema call that completes without the agent ever
-      // calling submit_output yields no structured value. Fail the run clearly
-      // rather than resolving the call to an envelope with `structured`
-      // undefined (reliable forcing/repair is the deferred accelerator, #8831).
-      if (
-        invocation.options.schema !== undefined &&
-        result.structured === undefined
-      ) {
-        throw new WorkflowRunAbortError(
-          `agent '${invocation.options.agentName}' did not call submit_output; ` +
-            `no structured result was produced.`,
-        );
-      }
       return result;
     } catch (error) {
       if (error instanceof SubagentDurabilityError) {

--- a/src/tools/delegation/workflowScriptAgentRunner.ts
+++ b/src/tools/delegation/workflowScriptAgentRunner.ts
@@ -138,6 +138,22 @@ export function createWorkflowScriptAgentRunner(
             schema !== undefined
               ? AgentCategory.ToolUse
               : AgentCategory.Workflow;
+          // A schema call runs a tool-use agent, so it must name one: the
+          // workflow default (this tool's `agent` field) is a document editor
+          // with no same-named tool-use counterpart, and resolving it under the
+          // tool-use category would fail with a confusing "Unknown toolUse
+          // agent". Fail loudly here instead of silently substituting an
+          // unrelated general agent.
+          if (
+            schema !== undefined &&
+            invocation.options.agentName === undefined
+          ) {
+            throw new WorkflowRunAbortError(
+              `Structured-output agent() calls must name a tool-use agent via ` +
+                `agentName: the workflow default '${defaultAgentName}' is a ` +
+                `document editor with no tool-use counterpart.`,
+            );
+          }
           const requestedAgent =
             invocation.options.agentName ?? defaultAgentName;
           const agent = requireVisibleAgent(
@@ -224,6 +240,19 @@ export function createWorkflowScriptAgentRunner(
       if (result.outcome !== 'completed') {
         throw new Error(
           `Workflow subagent ended with ${result.outcome} outcome.`,
+        );
+      }
+      // Floor guarantee: a schema call that completes without the agent ever
+      // calling submit_output yields no structured value. Fail the run clearly
+      // rather than resolving the call to an envelope with `structured`
+      // undefined (reliable forcing/repair is the deferred accelerator, #8831).
+      if (
+        invocation.options.schema !== undefined &&
+        result.structured === undefined
+      ) {
+        throw new WorkflowRunAbortError(
+          `agent '${invocation.options.agentName}' did not call submit_output; ` +
+            `no structured result was produced.`,
         );
       }
       return result;

--- a/src/tools/delegation/workflowScriptAgentRunner.ts
+++ b/src/tools/delegation/workflowScriptAgentRunner.ts
@@ -129,17 +129,26 @@ export function createWorkflowScriptAgentRunner(
           hooks?.onChildActive?.(executionId, invocation, true);
         },
         prepare: async () => {
+          // A `schema` option routes the call to a tool-use agent that
+          // finishes by submitting a validated structured value; otherwise it
+          // is an ordinary workflow-edit agent. The category parameterizes
+          // agent resolution, model selection, and the launched config.
+          const schema = invocation.options.schema;
+          const category =
+            schema !== undefined
+              ? AgentCategory.ToolUse
+              : AgentCategory.Workflow;
           const requestedAgent =
             invocation.options.agentName ?? defaultAgentName;
           const agent = requireVisibleAgent(
-            AgentCategory.Workflow,
+            category,
             requestedAgent,
             runScope.delegationAgentScope ?? undefined,
           );
           const [model, inputFiles] = await Promise.all([
             selectAvailableDelegationModel({
               parentModel: parent.model,
-              agentCategory: AgentCategory.Workflow,
+              agentCategory: category,
             }),
             resolveInvocationInputFiles(
               run.executionId,
@@ -155,7 +164,10 @@ export function createWorkflowScriptAgentRunner(
           // Run-fatal, not a per-call failure: a plain error would resolve
           // this agent() to null inside parallel()/pipeline(), silently
           // filtering away the very misuse this guard exists to surface.
+          // A schema call runs a tool-use agent whose result is the submitted
+          // value, not edited files, so this workflow-edit guard is exempt.
           if (
+            schema === undefined &&
             inputFiles.length === 0 &&
             (agent.defaultOutputFiles ?? []).length === 0
           ) {
@@ -165,13 +177,17 @@ export function createWorkflowScriptAgentRunner(
                 `diffs, not response text).`,
             );
           }
+          const categoryFields =
+            schema !== undefined
+              ? { agentCategory: AgentCategory.ToolUse, outputSchema: schema }
+              : { agentCategory: AgentCategory.Workflow };
           const configPayload: AgentConfigPayload = {
             agent: agent.name,
             agentSource: agent.source,
-            agentCategory: AgentCategory.Workflow,
             model,
             instruction: invocation.prompt,
             inputFiles,
+            ...categoryFields,
             ...(runScope.workingDirectory !== undefined && {
               workingDirectory: runScope.workingDirectory,
             }),

--- a/src/tools/structuredOutput.ts
+++ b/src/tools/structuredOutput.ts
@@ -9,95 +9,122 @@ import type { ToolResult } from '@shared/schemas/toolResult';
 // Local file imports
 import { defineTool } from './core/define';
 
-/**
- * Dual-shape description of a structured-output target, mirroring
- * {@link import('@model/ToolDefinition').ToolDefinition}: a JSON Schema for
- * provider payloads and the original Zod schema for the single validation site.
- *
- * `validate` is a closure over `zodSchema.safeParse`, so structured-output
- * validation routes through the exact same Zod parse the tool layer uses; no
- * second parallel validator is introduced.
- */
-export type StructuredOutputSpec = {
-  /** Logical name of the output (used for the terminal tool and diagnostics). */
-  name: string;
-  /** JSON Schema form, for provider-native structured output later. */
-  jsonSchema: Record<string, unknown>;
-  /** Original Zod schema, the single source of truth for validation. */
-  zodSchema: z.ZodType;
-  /** Validate a raw value against `zodSchema` without throwing. */
-  validate(raw: unknown): z.ZodSafeParseResult<unknown>;
+type StructuredOutputSchema = {
+  readonly jsonSchema: Record<string, unknown>;
+  readonly zodSchema: z.ZodType;
 };
 
-/**
- * Resolve a structured-output spec from either a Zod schema (host callers) or a
- * plain JSON Schema object (sandbox callers).
- *
- * - A Zod schema keeps `zodSchema = input` and derives `jsonSchema` through
- *   `convertToolSchema`, reusing the same `toJSONSchema` options and top-level
- *   union / `$schema` normalization the tool converters use.
- * - A JSON Schema object keeps `jsonSchema = input` and derives `zodSchema` via
- *   `z.fromJSONSchema`, so both callers land on one Zod validation site.
- */
-export function resolveStructuredOutput(
-  input: z.ZodType | Record<string, unknown>,
-  name = 'output',
-): StructuredOutputSpec {
-  const fromZod = input instanceof z.ZodType;
-  const zodSchema = fromZod ? input : (z.fromJSONSchema(input) as z.ZodType);
-  const jsonSchema = fromZod
-    ? (convertToolSchema({ name, zodSchema }) ?? {})
-    : input;
-  return {
-    name,
-    jsonSchema,
-    zodSchema,
-    validate: (raw) => zodSchema.safeParse(raw),
-  };
-}
+const JsonValueSchema = z.json();
 
 /** Name of the synthetic tool the model calls to submit its final result. */
 const SUBMIT_OUTPUT_TOOL_NAME = 'submit_output';
 
 /**
- * Build a synthetic terminal tool whose schema is the spec's Zod schema.
+ * JSON Schema authored inside a workflow sandbox is untrusted. Zod compiles
+ * these keywords to host RegExp instances, where catastrophic backtracking
+ * would escape the sandbox's execution limits.
+ */
+function assertNoHostRegex(schema: unknown): void {
+  if (schema === null || typeof schema !== 'object') return;
+  if (Array.isArray(schema)) return;
+  const record = schema as Record<string, unknown>;
+  if ('pattern' in record || 'patternProperties' in record) {
+    throw new Error(
+      'Structured output JSON Schema cannot use pattern or patternProperties.',
+    );
+  }
+
+  for (const key of [
+    'additionalItems',
+    'additionalProperties',
+    'contains',
+    'else',
+    'if',
+    'items',
+    'not',
+    'propertyNames',
+    'then',
+    'unevaluatedItems',
+    'unevaluatedProperties',
+  ]) {
+    assertNoHostRegex(record[key]);
+  }
+  for (const key of ['allOf', 'anyOf', 'oneOf', 'prefixItems']) {
+    const branches = record[key];
+    if (Array.isArray(branches)) {
+      for (const branch of branches) assertNoHostRegex(branch);
+    }
+  }
+  for (const key of [
+    '$defs',
+    'definitions',
+    'dependentSchemas',
+    'dependencies',
+    'properties',
+  ]) {
+    const schemas = record[key];
+    if (schemas !== null && typeof schemas === 'object') {
+      for (const child of Object.values(schemas)) assertNoHostRegex(child);
+    }
+  }
+}
+
+/**
+ * Normalize a structured-output schema at its boundary. Both live Zod schemas
+ * and sandbox JSON Schema land on the same Zod validation path and the same
+ * provider-facing object schema conversion.
+ */
+export function normalizeStructuredOutputSchema(
+  input: z.ZodType | Record<string, unknown>,
+): StructuredOutputSchema {
+  const fromZod = input instanceof z.ZodType;
+  if (!fromZod) assertNoHostRegex(input);
+  const zodSchema = fromZod ? input : (z.fromJSONSchema(input) as z.ZodType);
+  const jsonSchema = convertToolSchema({
+    name: SUBMIT_OUTPUT_TOOL_NAME,
+    zodSchema,
+  });
+  if (jsonSchema?.type !== 'object') {
+    const got =
+      typeof jsonSchema?.type === 'string'
+        ? `type "${jsonSchema.type}"`
+        : 'no object root';
+    throw new Error(
+      `Structured output schema must be an object at the root (got ${got}). Wrap a scalar or array result in an object property.`,
+    );
+  }
+  return { jsonSchema, zodSchema };
+}
+
+/**
+ * Build a terminal tool from a normalized structured-output schema.
  *
  * The guarantee is the tool layer's own spine: `defineTool`/`BaseTool` validate
- * the model's call against `spec.zodSchema` before `execute` runs, and an
- * invalid call surfaces a `ZodError` the model self-corrects. So `execute`
- * receives already-validated input and simply hands it to `capture`.
+ * the model's call before `execute` runs, and an invalid call surfaces a
+ * `ZodError` the model self-corrects. `execute` then enforces the persisted
+ * JSON-value contract and hands the result to `capture`.
  *
  * `capture` is bound to instance state, not a module-level global, so
  * concurrent runs never share a sink.
  */
 export function buildTerminalTool(
-  spec: StructuredOutputSpec,
+  input: z.ZodType | Record<string, unknown>,
   capture: (value: unknown) => void,
 ): ITool {
-  // Provider tool inputs (and native structured output) require an object at the
-  // root; a scalar or array root would be rejected at request time. Fail here
-  // with a clear message instead, so a caller wraps the value in a property.
-  if (spec.jsonSchema.type !== 'object') {
-    const got =
-      typeof spec.jsonSchema.type === 'string'
-        ? `type "${spec.jsonSchema.type}"`
-        : 'no root type';
-    throw new Error(
-      `Structured output schema must be an object at the root (got ${got}). Wrap a scalar or array result in an object property.`,
-    );
-  }
+  const { zodSchema } = normalizeStructuredOutputSchema(input);
 
   const GeneratedTool = defineTool({
     name: SUBMIT_OUTPUT_TOOL_NAME,
     description:
       'Submit the final result. Call this exactly once, with the complete result, when the task is done.',
-    schema: spec.zodSchema,
+    schema: zodSchema,
   });
 
   class TerminalTool extends GeneratedTool {
     // Run-scoped capture slot bound to instance state, so concurrent workflow
     // runs never race on a shared sink.
     private readonly capture: (value: unknown) => void;
+    private captured = false;
 
     constructor(capture: (value: unknown) => void) {
       super();
@@ -105,9 +132,15 @@ export function buildTerminalTool(
     }
 
     protected async execute(input: unknown): Promise<ToolResult> {
-      this.capture(input);
+      if (this.captured) {
+        throw new Error('submit_output can only be accepted once per run.');
+      }
+      const jsonValue = JsonValueSchema.parse(input);
+      this.captured = true;
+      this.capture(jsonValue);
       return {
         status: 'executed',
+        endTurn: true,
         summary: 'Structured output captured.',
         output: 'Structured output captured.',
       };
@@ -133,100 +166,4 @@ export function buildTerminalToolRegistry(
       name === SUBMIT_OUTPUT_TOOL_NAME ? terminalTool : base.get(name),
     has: (name) => name === SUBMIT_OUTPUT_TOOL_NAME || base.has(name),
   };
-}
-
-/**
- * JSON Schema keywords provider strict-mode structured output rejects. Presence
- * of any of these means native forcing must not be attempted for the schema.
- */
-const STRICT_INCOMPATIBLE_KEYWORDS = [
-  'minimum',
-  'maximum',
-  'exclusiveMinimum',
-  'exclusiveMaximum',
-  'multipleOf',
-  'minLength',
-  'maxLength',
-  'pattern',
-] as const;
-
-/**
- * Keywords whose presence means a schema node constrains its value. A node with
- * none of these (a bare `{}`, or the `{}` fallback when `convertToolSchema`
- * returns null) accepts any value, which strict native output cannot represent.
- */
-const CONSTRAINT_KEYWORDS = [
-  'type',
-  'anyOf',
-  'oneOf',
-  'allOf',
-  'not',
-  '$ref',
-  'enum',
-  'const',
-] as const;
-
-/**
- * Whether the spec's JSON Schema is compatible with provider strict-mode native
- * structured output. Consumed later (Phase 2) to decide whether to attempt
- * native forcing.
- *
- * Returns false when the schema uses numeric/string constraint keywords, or an
- * object node that allows extra properties or has an optional (not required)
- * property, since strict mode requires every property required and
- * `additionalProperties: false`.
- */
-export function isStrictNativeCompatible(spec: StructuredOutputSpec): boolean {
-  return isNodeStrictNativeCompatible(spec.jsonSchema);
-}
-
-function isNodeStrictNativeCompatible(node: unknown): boolean {
-  if (node === null || typeof node !== 'object') return true;
-  const schema = node as Record<string, unknown>;
-
-  for (const keyword of STRICT_INCOMPATIBLE_KEYWORDS) {
-    if (keyword in schema) return false;
-  }
-
-  const isObjectNode = schema.type === 'object' || 'properties' in schema;
-  if (isObjectNode) {
-    // Strict mode requires objects to forbid extra properties and mark every
-    // property required. A bare { type: 'object' } (no properties, no
-    // additionalProperties: false) still accepts arbitrary fields.
-    if (schema.additionalProperties !== false) return false;
-    const properties = schema.properties as Record<string, unknown> | undefined;
-    if (properties && typeof properties === 'object') {
-      const required = new Set(
-        Array.isArray(schema.required) ? (schema.required as string[]) : [],
-      );
-      for (const key of Object.keys(properties)) {
-        if (!required.has(key)) return false;
-        if (!isNodeStrictNativeCompatible(properties[key])) return false;
-      }
-    }
-  } else if (!CONSTRAINT_KEYWORDS.some((keyword) => keyword in schema)) {
-    return false;
-  }
-
-  for (const key of ['items', 'additionalItems', 'not'] as const) {
-    if (!isNodeStrictNativeCompatible(schema[key])) return false;
-  }
-  for (const key of ['prefixItems', 'anyOf', 'oneOf', 'allOf'] as const) {
-    const branches = schema[key];
-    if (
-      Array.isArray(branches) &&
-      !branches.every((branch) => isNodeStrictNativeCompatible(branch))
-    ) {
-      return false;
-    }
-  }
-  for (const key of ['$defs', 'definitions'] as const) {
-    const defs = schema[key];
-    if (defs && typeof defs === 'object') {
-      for (const value of Object.values(defs as Record<string, unknown>)) {
-        if (!isNodeStrictNativeCompatible(value)) return false;
-      }
-    }
-  }
-  return true;
 }

--- a/src/tools/structuredOutput.ts
+++ b/src/tools/structuredOutput.ts
@@ -1,0 +1,185 @@
+// Third-party imports
+import { z } from 'zod';
+
+// Internal imports
+import type { ITool } from '@agent/core/tools/ToolTypes';
+import { convertToolSchema } from '@agent/modelHandlers/toolConversion';
+import type { ToolResult } from '@shared/schemas/toolResult';
+
+// Local file imports
+import { defineTool } from './core/define';
+
+/**
+ * Dual-shape description of a structured-output target, mirroring
+ * {@link import('@model/ToolDefinition').ToolDefinition}: a JSON Schema for
+ * provider payloads and the original Zod schema for the single validation site.
+ *
+ * `validate` is a closure over `zodSchema.safeParse`, so structured-output
+ * validation routes through the exact same Zod parse the tool layer uses; no
+ * second parallel validator is introduced.
+ */
+export type StructuredOutputSpec = {
+  /** Logical name of the output (used for the terminal tool and diagnostics). */
+  name: string;
+  /** JSON Schema form, for provider-native structured output later. */
+  jsonSchema: Record<string, unknown>;
+  /** Original Zod schema, the single source of truth for validation. */
+  zodSchema: z.ZodType;
+  /** Validate a raw value against `zodSchema` without throwing. */
+  validate(raw: unknown): z.ZodSafeParseResult<unknown>;
+};
+
+/**
+ * Resolve a structured-output spec from either a Zod schema (host callers) or a
+ * plain JSON Schema object (sandbox callers).
+ *
+ * - A Zod schema keeps `zodSchema = input` and derives `jsonSchema` through
+ *   `convertToolSchema`, reusing the same `toJSONSchema` options and top-level
+ *   union / `$schema` normalization the tool converters use.
+ * - A JSON Schema object keeps `jsonSchema = input` and derives `zodSchema` via
+ *   `z.fromJSONSchema`, so both callers land on one Zod validation site.
+ */
+export function resolveStructuredOutput(
+  input: z.ZodType | Record<string, unknown>,
+  name = 'output',
+): StructuredOutputSpec {
+  if (input instanceof z.ZodType) {
+    const zodSchema = input;
+    const jsonSchema = convertToolSchema({ name, zodSchema }) ?? {};
+    return {
+      name,
+      jsonSchema,
+      zodSchema,
+      validate: (raw) => zodSchema.safeParse(raw),
+    };
+  }
+
+  const jsonSchema = input;
+  const zodSchema = z.fromJSONSchema(jsonSchema) as z.ZodType;
+  return {
+    name,
+    jsonSchema,
+    zodSchema,
+    validate: (raw) => zodSchema.safeParse(raw),
+  };
+}
+
+/** Name of the synthetic tool the model calls to submit its final result. */
+export const SUBMIT_OUTPUT_TOOL_NAME = 'submit_output';
+
+/**
+ * Build a synthetic terminal tool whose schema is the spec's Zod schema.
+ *
+ * The guarantee is the tool layer's own spine: `defineTool`/`BaseTool` validate
+ * the model's call against `spec.zodSchema` before `execute` runs, and an
+ * invalid call surfaces a `ZodError` the model self-corrects. So `execute`
+ * receives already-validated input and simply hands it to `capture`.
+ *
+ * `capture` is bound to instance state, not a module-level global, so
+ * concurrent runs never share a sink.
+ */
+export function buildTerminalTool(
+  spec: StructuredOutputSpec,
+  capture: (value: unknown) => void,
+): ITool {
+  const GeneratedTool = defineTool({
+    name: SUBMIT_OUTPUT_TOOL_NAME,
+    description:
+      'Submit the final result. Call this exactly once, with the complete result, when the task is done.',
+    schema: spec.zodSchema,
+  });
+
+  class TerminalTool extends GeneratedTool {
+    // Run-scoped capture slot bound to instance state, so concurrent workflow
+    // runs never race on a shared sink.
+    private readonly capture: (value: unknown) => void;
+
+    constructor(capture: (value: unknown) => void) {
+      super();
+      this.capture = capture;
+    }
+
+    protected async execute(input: unknown): Promise<ToolResult> {
+      this.capture(input);
+      return {
+        status: 'executed',
+        summary: 'Structured output captured.',
+        output: 'Structured output captured.',
+      };
+    }
+  }
+
+  return new TerminalTool(capture);
+}
+
+/**
+ * JSON Schema keywords provider strict-mode structured output rejects. Presence
+ * of any of these means native forcing must not be attempted for the schema.
+ */
+const STRICT_INCOMPATIBLE_KEYWORDS = [
+  'minimum',
+  'maximum',
+  'exclusiveMinimum',
+  'exclusiveMaximum',
+  'multipleOf',
+  'minLength',
+  'maxLength',
+  'pattern',
+] as const;
+
+/**
+ * Whether the spec's JSON Schema is compatible with provider strict-mode native
+ * structured output. Consumed later (Phase 2) to decide whether to attempt
+ * native forcing.
+ *
+ * Returns false when the schema uses numeric/string constraint keywords, or an
+ * object node that allows extra properties or has an optional (not required)
+ * property, since strict mode requires every property required and
+ * `additionalProperties: false`.
+ */
+export function isStrictNativeCompatible(spec: StructuredOutputSpec): boolean {
+  return isNodeStrictNativeCompatible(spec.jsonSchema);
+}
+
+function isNodeStrictNativeCompatible(node: unknown): boolean {
+  if (node === null || typeof node !== 'object') return true;
+  const schema = node as Record<string, unknown>;
+
+  for (const keyword of STRICT_INCOMPATIBLE_KEYWORDS) {
+    if (keyword in schema) return false;
+  }
+
+  const properties = schema.properties as Record<string, unknown> | undefined;
+  if (properties && typeof properties === 'object') {
+    if (schema.additionalProperties !== false) return false;
+    const required = new Set(
+      Array.isArray(schema.required) ? (schema.required as string[]) : [],
+    );
+    for (const key of Object.keys(properties)) {
+      if (!required.has(key)) return false;
+      if (!isNodeStrictNativeCompatible(properties[key])) return false;
+    }
+  }
+
+  for (const key of ['items', 'additionalItems', 'not'] as const) {
+    if (!isNodeStrictNativeCompatible(schema[key])) return false;
+  }
+  for (const key of ['prefixItems', 'anyOf', 'oneOf', 'allOf'] as const) {
+    const branches = schema[key];
+    if (
+      Array.isArray(branches) &&
+      !branches.every((branch) => isNodeStrictNativeCompatible(branch))
+    ) {
+      return false;
+    }
+  }
+  for (const key of ['$defs', 'definitions'] as const) {
+    const defs = schema[key];
+    if (defs && typeof defs === 'object') {
+      for (const value of Object.values(defs as Record<string, unknown>)) {
+        if (!isNodeStrictNativeCompatible(value)) return false;
+      }
+    }
+  }
+  return true;
+}

--- a/src/tools/structuredOutput.ts
+++ b/src/tools/structuredOutput.ts
@@ -2,7 +2,7 @@
 import { z } from 'zod';
 
 // Internal imports
-import type { ITool } from '@agent/core/tools/ToolTypes';
+import type { ITool, IToolRegistry } from '@agent/core/tools/ToolTypes';
 import { convertToolSchema } from '@agent/modelHandlers/toolConversion';
 import type { ToolResult } from '@shared/schemas/toolResult';
 
@@ -115,6 +115,24 @@ export function buildTerminalTool(
   }
 
   return new TerminalTool(capture);
+}
+
+/**
+ * Wrap a base registry so `submit_output` resolves to the run-scoped terminal
+ * tool while every other lookup delegates to `base`. The shared default
+ * registry is never mutated, so concurrent runs never see one another's
+ * terminal tool. Used by the tool-use flow to make the synthetic tool findable
+ * by name (`toolRegistry.get('submit_output')`) alongside the real tools.
+ */
+export function buildTerminalToolRegistry(
+  base: IToolRegistry,
+  terminalTool: ITool,
+): IToolRegistry {
+  return {
+    get: (name) =>
+      name === SUBMIT_OUTPUT_TOOL_NAME ? terminalTool : base.get(name),
+    has: (name) => name === SUBMIT_OUTPUT_TOOL_NAME || base.has(name),
+  };
 }
 
 /**

--- a/src/tools/structuredOutput.ts
+++ b/src/tools/structuredOutput.ts
@@ -15,6 +15,7 @@ type StructuredOutputSchema = {
 };
 
 const JsonValueSchema = z.json();
+type JsonValue = z.infer<typeof JsonValueSchema>;
 
 /** Name of the synthetic tool the model calls to submit its final result. */
 const SUBMIT_OUTPUT_TOOL_NAME = 'submit_output';
@@ -26,7 +27,10 @@ const SUBMIT_OUTPUT_TOOL_NAME = 'submit_output';
  */
 function assertNoHostRegex(schema: unknown): void {
   if (schema === null || typeof schema !== 'object') return;
-  if (Array.isArray(schema)) return;
+  if (Array.isArray(schema)) {
+    for (const child of schema) assertNoHostRegex(child);
+    return;
+  }
   const record = schema as Record<string, unknown>;
   if ('pattern' in record || 'patternProperties' in record) {
     throw new Error(
@@ -109,7 +113,7 @@ export function normalizeStructuredOutputSchema(
  */
 export function buildTerminalTool(
   input: z.ZodType | Record<string, unknown>,
-  capture: (value: unknown) => void,
+  capture: (value: JsonValue) => void,
 ): ITool {
   const { zodSchema } = normalizeStructuredOutputSchema(input);
 
@@ -123,10 +127,10 @@ export function buildTerminalTool(
   class TerminalTool extends GeneratedTool {
     // Run-scoped capture slot bound to instance state, so concurrent workflow
     // runs never race on a shared sink.
-    private readonly capture: (value: unknown) => void;
+    private readonly capture: (value: JsonValue) => void;
     private captured = false;
 
-    constructor(capture: (value: unknown) => void) {
+    constructor(capture: (value: JsonValue) => void) {
       super();
       this.capture = capture;
     }

--- a/src/tools/structuredOutput.ts
+++ b/src/tools/structuredOutput.ts
@@ -57,7 +57,7 @@ export function resolveStructuredOutput(
 }
 
 /** Name of the synthetic tool the model calls to submit its final result. */
-export const SUBMIT_OUTPUT_TOOL_NAME = 'submit_output';
+const SUBMIT_OUTPUT_TOOL_NAME = 'submit_output';
 
 /**
  * Build a synthetic terminal tool whose schema is the spec's Zod schema.

--- a/src/tools/structuredOutput.ts
+++ b/src/tools/structuredOutput.ts
@@ -120,6 +120,22 @@ const STRICT_INCOMPATIBLE_KEYWORDS = [
 ] as const;
 
 /**
+ * Keywords whose presence means a schema node constrains its value. A node with
+ * none of these (a bare `{}`, or the `{}` fallback when `convertToolSchema`
+ * returns null) accepts any value, which strict native output cannot represent.
+ */
+const CONSTRAINT_KEYWORDS = [
+  'type',
+  'anyOf',
+  'oneOf',
+  'allOf',
+  'not',
+  '$ref',
+  'enum',
+  'const',
+] as const;
+
+/**
  * Whether the spec's JSON Schema is compatible with provider strict-mode native
  * structured output. Consumed later (Phase 2) to decide whether to attempt
  * native forcing.
@@ -141,16 +157,24 @@ function isNodeStrictNativeCompatible(node: unknown): boolean {
     if (keyword in schema) return false;
   }
 
-  const properties = schema.properties as Record<string, unknown> | undefined;
-  if (properties && typeof properties === 'object') {
+  const isObjectNode = schema.type === 'object' || 'properties' in schema;
+  if (isObjectNode) {
+    // Strict mode requires objects to forbid extra properties and mark every
+    // property required. A bare { type: 'object' } (no properties, no
+    // additionalProperties: false) still accepts arbitrary fields.
     if (schema.additionalProperties !== false) return false;
-    const required = new Set(
-      Array.isArray(schema.required) ? (schema.required as string[]) : [],
-    );
-    for (const key of Object.keys(properties)) {
-      if (!required.has(key)) return false;
-      if (!isNodeStrictNativeCompatible(properties[key])) return false;
+    const properties = schema.properties as Record<string, unknown> | undefined;
+    if (properties && typeof properties === 'object') {
+      const required = new Set(
+        Array.isArray(schema.required) ? (schema.required as string[]) : [],
+      );
+      for (const key of Object.keys(properties)) {
+        if (!required.has(key)) return false;
+        if (!isNodeStrictNativeCompatible(properties[key])) return false;
+      }
     }
+  } else if (!CONSTRAINT_KEYWORDS.some((keyword) => keyword in schema)) {
+    return false;
   }
 
   for (const key of ['items', 'additionalItems', 'not'] as const) {

--- a/src/tools/structuredOutput.ts
+++ b/src/tools/structuredOutput.ts
@@ -74,6 +74,19 @@ export function buildTerminalTool(
   spec: StructuredOutputSpec,
   capture: (value: unknown) => void,
 ): ITool {
+  // Provider tool inputs (and native structured output) require an object at the
+  // root; a scalar or array root would be rejected at request time. Fail here
+  // with a clear message instead, so a caller wraps the value in a property.
+  if (spec.jsonSchema.type !== 'object') {
+    const got =
+      typeof spec.jsonSchema.type === 'string'
+        ? `type "${spec.jsonSchema.type}"`
+        : 'no root type';
+    throw new Error(
+      `Structured output schema must be an object at the root (got ${got}). Wrap a scalar or array result in an object property.`,
+    );
+  }
+
   const GeneratedTool = defineTool({
     name: SUBMIT_OUTPUT_TOOL_NAME,
     description:

--- a/src/tools/structuredOutput.ts
+++ b/src/tools/structuredOutput.ts
@@ -43,19 +43,11 @@ export function resolveStructuredOutput(
   input: z.ZodType | Record<string, unknown>,
   name = 'output',
 ): StructuredOutputSpec {
-  if (input instanceof z.ZodType) {
-    const zodSchema = input;
-    const jsonSchema = convertToolSchema({ name, zodSchema }) ?? {};
-    return {
-      name,
-      jsonSchema,
-      zodSchema,
-      validate: (raw) => zodSchema.safeParse(raw),
-    };
-  }
-
-  const jsonSchema = input;
-  const zodSchema = z.fromJSONSchema(jsonSchema) as z.ZodType;
+  const fromZod = input instanceof z.ZodType;
+  const zodSchema = fromZod ? input : (z.fromJSONSchema(input) as z.ZodType);
+  const jsonSchema = fromZod
+    ? (convertToolSchema({ name, zodSchema }) ?? {})
+    : input;
   return {
     name,
     jsonSchema,


### PR DESCRIPTION
Adds provider-independent structured output through a synthetic terminal tool, including its first runtime and workflow-script consumers. Tracking #8829.

## Design

- `normalizeStructuredOutputSchema(...)` is the single boundary for live Zod schemas and sandbox JSON Schema. It converts both to the canonical object-root tool schema, rejects unsupported roots early, and blocks regex-bearing sandbox schemas before they can compile into host `RegExp` instances.
- `buildTerminalTool(...)` creates a run-local `submit_output` tool through the existing `defineTool` / `BaseTool` validation spine. Successful submission is single-shot, JSON-safe, and explicitly ends the tool-use turn.
- The tool-use flow installs the terminal tool through a non-mutating registry overlay, moves a completed result into persisted shared state for interrupt/resume durability, and refuses to complete a configured structured-output run without a submission.
- Tool dispatch owns terminal-result semantics: it pairs the terminal result, stops later calls, and completes the turn. The workflow runner no longer rechecks the contract after child-run persistence.
- `BaseTool` preserves synchronous validation timing for ordinary schemas and falls back to async parsing only for schemas that require it.
- Final-result schemas enforce that `.structured` is persistable JSON on both workflow and tool-use envelopes.
- Workflow scripts accept `agent(prompt, { agentName, schema })`, normalize the schema at the sandbox boundary, include it in journal identity, route the call through a tool-use agent, and return the captured value as `.structured`.

The unused speculative native-forcing predicate and contract wrapper were removed. Native forcing remains an optional follow-up accelerator in #8831; this PR's ordinary tool-call path owns correctness.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint` (zero errors; one unrelated existing warning)
- `npm run compile:fast`
- `npm run check:dead-code-ratchet`
- `npm test` — 740 files passed, 1 skipped; 6,860 tests passed, 4 skipped

Part of #8829. Closes #8830, #8832.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core tool-use flow, dispatch ordering, and subagent delegation paths with new completion invariants, but behavior is gated on outputSchema/schema options and covered by extensive new tests.
> 
> **Overview**
> Introduces **provider-independent structured output** for tool-use agents: when config carries `outputSchema`, the run exposes a run-scoped **`submit_output`** terminal tool (via a non-mutating registry overlay), validates submissions through the normal tool/Zod path, and surfaces the captured value as **`structured`** on flow results, final envelopes, and persisted shared state (resume-safe).
> 
> **Tool dispatch** now honors an optional **`endTurn`** flag on executed tool results so a successful terminal submission stops further calls in the batch and completes the model turn instead of continuing the tool loop.
> 
> **Workflow scripts** replace the old rejection of `schema`/`outputSchema` with first-class **`agent(prompt, { schema, agentName })`**: normalized object-root JSON Schema (regex patterns blocked for sandbox safety) routes to a tool-use subagent with `outputSchema`, exempts the empty-input-files guard, and includes schema in journal identity; callers read **`.structured`** on the returned envelope.
> 
> Supporting changes: optional **`outputSchema`** on tool-use agent config and trace schema; **`BaseTool`** falls back to async Zod parse when needed; docs/tool descriptions updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 375f9e883314ed1fe006e0eba4f5d5b46c2bf03f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->