### PR TITLE
refactor(webview): collapse the MainApp event-adapter plane

### DIFF
--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -148,97 +148,17 @@ export class MainApp extends MainAppBase {
     this.sessionContextValue = sessionContext$.get();
   }
 
-  private readonly onLatexdiffGetCurrentFile =
-    this.detailHandler<FileActionDetail>(({ type }) => getCurrentFile(type));
+  // Named handlers only where an inline arrow won't do: multi-statement
+  // bodies, plus the two handlers bound at two template sites each. Everything
+  // else binds inline at its template site.
 
-  private readonly onLatexdiffEmptyFile = this.detailHandler<FileActionDetail>(
-    ({ type }) => emptyFile(type),
-  );
-
-  private readonly onAddOpenedFiles =
-    this.detailHandler<MultipleFilesTypeActionDetail>(({ type }) => {
-      if (type !== 'output') {
-        addOpenedFiles(type as DocumentFileType);
-      }
-    });
-
-  private readonly onEmptyFiles =
-    this.detailHandler<MultipleFilesTypeActionDetail>(({ type }) =>
-      emptyFiles(type),
-    );
-
-  private readonly onSelectMultipleFiles =
-    this.detailHandler<MultipleFilesActionDetail>(({ listId }) =>
-      selectMultipleFiles(listId),
-    );
-
-  private readonly onRemoveFile = this.detailHandler<RemoveFileDetail>(
-    ({ listId, file }) => removeFile(listId, file),
-  );
-
-  private readonly onFilesReordered = this.detailHandler<ReorderFilesDetail>(
-    ({ listId, files }) => updateMultiFiles(listId, files),
-  );
-
-  private readonly onCheckboxChange = this.detailHandler<CheckboxChangeDetail>(
-    ({ id, checked }) => updateCheckboxValue(id, checked),
-  );
-
-  private readonly onFocusInstruction =
-    this.detailCommandHandler<FocusInstructionDetail>(
-      MAIN_VIEW_COMMANDS.SHOW_INSTRUCTION,
-      ({ key, text }) => ({ key, text }),
-    );
-
-  private readonly onApiKeyAction = this.detailHandler<BannerActionDetail>(
-    ({ action }) => runApiKeyBannerAction(action as 'set' | 'guide'),
-  );
-
-  private readonly onAgentConfigAction = this.detailHandler<BannerActionDetail>(
-    ({ action }) => runAgentConfigAction(action as 'edit' | 'dir' | 'docs'),
-  );
-
-  private readonly onDependencyDismiss = (): void => {
-    dependencyBanner$.set({ visible: false });
+  private readonly onSignInFromBanner = (): void => {
+    postMessage(MAIN_VIEW_COMMANDS.SIGN_IN_FROM_BANNER);
   };
 
-  private readonly onRecheckDependencies = this.commandHandler(
-    MAIN_VIEW_COMMANDS.RECHECK_DEPENDENCIES,
-  );
-
-  private readonly onOpenInstallGuide =
-    this.detailCommandHandler<InstallGuideDetail>(
-      MAIN_VIEW_COMMANDS.OPEN_INSTALL_GUIDE,
-      ({ tool }) => ({ tool }),
-    );
-
-  private readonly onSignInFromBanner = this.commandHandler(
-    MAIN_VIEW_COMMANDS.SIGN_IN_FROM_BANNER,
-  );
-
-  private readonly onWelcomeChatGpt = this.commandHandler(
-    MAIN_VIEW_COMMANDS.ONBOARDING_SIGN_IN_CHATGPT,
-  );
-
-  private readonly onWelcomeApiKey = this.commandHandler(
-    MAIN_VIEW_COMMANDS.OPEN_SET_API_KEY,
-  );
-
-  private readonly onWelcomeSkip = this.commandHandler(
-    MAIN_VIEW_COMMANDS.ONBOARDING_SKIP,
-  );
-
-  private readonly onOnboardingRunSetup = this.commandHandler(
-    MAIN_VIEW_COMMANDS.ONBOARDING_RUN_SETUP,
-  );
-
-  private readonly onOnboardingOpenGettingStarted = this.commandHandler(
-    MAIN_VIEW_COMMANDS.ONBOARDING_OPEN_GETTING_STARTED,
-  );
-
-  private readonly onOnboardingSkipSetup = this.commandHandler(
-    MAIN_VIEW_COMMANDS.ONBOARDING_SKIP_SETUP,
-  );
+  private readonly onOnboardingOpenGettingStarted = (): void => {
+    postMessage(MAIN_VIEW_COMMANDS.ONBOARDING_OPEN_GETTING_STARTED);
+  };
 
   private readonly onDismissLogin = (): void => {
     postMessage(MAIN_VIEW_COMMANDS.DISMISS_LOGIN_BANNER);
@@ -251,91 +171,24 @@ export class MainApp extends MainAppBase {
     gettingStartedDismissed$.set(true);
   };
 
-  private readonly onGettingStartedAction =
-    this.detailCommandHandler<GettingStartedActionDetail>(
-      MAIN_VIEW_COMMANDS.GETTING_STARTED_ACTION,
-      ({ action }) => ({ action }),
-    );
-
   private readonly onDismissSessionHint = (): void => {
     postMessage(MAIN_VIEW_COMMANDS.DISMISS_ORCHESTRATOR_BANNER);
     sessionHintDismissed$.set(true);
   };
 
-  private readonly onLatexDiffsToggle =
-    this.detailHandler<LatexDiffsToggleDetail>(({ visible }) => {
-      latexdiffsVisible$.set(visible);
-      saveState();
-    });
-
-  private readonly onLatexDiffsAction =
-    this.detailHandler<LatexDiffsActionDetail>(({ action }) =>
-      runLatexDiffsAction(action),
-    );
-
-  private readonly onBaseFileChange = this.detailHandler<BaseFileChangeDetail>(
-    ({ value }) => setBaseFile(value),
-  );
-
-  private readonly onEditedFileChange =
-    this.detailHandler<EditedFileChangeDetail>(({ value }) =>
-      setEditedFile(value),
-    );
-
-  private readonly onCommitChange = this.detailHandler<CommitChangeDetail>(
-    ({ value }) => setCommit(value),
-  );
-
-  private readonly onRefreshEditedFiles = (): void => {
-    refreshEditedFiles();
-  };
-
-  private readonly onRefreshCommits = this.commandHandler(
-    MAIN_VIEW_COMMANDS.REFRESH_COMMITS,
-  );
-
-  private readonly onSessionTypeChange =
-    this.detailHandler<SessionTypeChangeDetail>(({ value }) =>
-      changeSessionType(value),
-    );
-
-  private readonly onAgentChange = this.detailHandler<AgentChangeDetail>(
-    ({ sessionType, value }) => changeAgent(sessionType, value),
-  );
-
-  private readonly onModelChange = this.detailHandler<ModelChangeDetail>(
-    ({ value }) => changeModel(value),
-  );
-
-  private readonly onInstructionInput =
-    this.detailHandler<InstructionChangeDetail>(({ value }) => {
-      setInstruction(value);
-      scheduleInstructionSave();
-    });
-
-  private readonly onInstructionPaste = (): void => {
+  private readonly onLatexDiffsToggle = ({
+    detail,
+  }: CustomEvent<LatexDiffsToggleDetail>): void => {
+    latexdiffsVisible$.set(detail.visible);
     saveState();
   };
 
-  private readonly onPanelAction = this.detailHandler<ActionDetail>(
-    ({ action }) => runPanelAction(action),
-  );
-
-  private readonly onExecute = (): void => {
-    executeAgent();
+  private readonly onInstructionInput = ({
+    detail,
+  }: CustomEvent<InstructionChangeDetail>): void => {
+    setInstruction(detail.value);
+    scheduleInstructionSave();
   };
-
-  private readonly onAgentSettings = (): void => {
-    runAgentConfigAction('edit');
-  };
-
-  private readonly onBrowseAllAgents = (): void => {
-    runAgentConfigAction('edit');
-  };
-
-  private readonly onModelSettings = this.commandHandler(
-    MAIN_VIEW_COMMANDS.OPEN_MODEL_SETTINGS,
-  );
 
   override connectedCallback(): void {
     super.connectedCallback();
@@ -385,26 +238,6 @@ export class MainApp extends MainAppBase {
       MAIN_VIEW_COMMANDS.REQUEST_BASE_FILE,
     ];
     commands.forEach((command) => postMessage(command));
-  }
-
-  private commandHandler(
-    command: string,
-    payload?: Record<string, unknown>,
-  ): () => void {
-    return () => postMessage(command, payload);
-  }
-
-  private detailHandler<TDetail>(
-    handler: (detail: TDetail) => void,
-  ): (event: CustomEvent<TDetail>) => void {
-    return (event) => handler(event.detail);
-  }
-
-  private detailCommandHandler<TDetail>(
-    command: string,
-    getPayload: (detail: TDetail) => Record<string, unknown> | undefined,
-  ): (event: CustomEvent<TDetail>) => void {
-    return (event) => postMessage(command, getPayload(event.detail));
   }
 
   protected override onStateRestore(message: StateRestoreMessage): void {
@@ -474,9 +307,12 @@ export class MainApp extends MainAppBase {
           <div class="main-content">
             <onboarding-welcome-card
               @welcome-sign-in=${this.onSignInFromBanner}
-              @welcome-chatgpt=${this.onWelcomeChatGpt}
-              @welcome-api-key=${this.onWelcomeApiKey}
-              @welcome-skip=${this.onWelcomeSkip}
+              @welcome-chatgpt=${() =>
+                postMessage(MAIN_VIEW_COMMANDS.ONBOARDING_SIGN_IN_CHATGPT)}
+              @welcome-api-key=${() =>
+                postMessage(MAIN_VIEW_COMMANDS.OPEN_SET_API_KEY)}
+              @welcome-skip=${() =>
+                postMessage(MAIN_VIEW_COMMANDS.ONBOARDING_SKIP)}
               @onboarding-open-getting-started=${
                 this.onOnboardingOpenGettingStarted
               }
@@ -510,28 +346,43 @@ export class MainApp extends MainAppBase {
           ${
             onboardingState === 'setup'
               ? html`<onboarding-setup-card
-                  @onboarding-run-setup=${this.onOnboardingRunSetup}
+                  @onboarding-run-setup=${() =>
+                    postMessage(MAIN_VIEW_COMMANDS.ONBOARDING_RUN_SETUP)}
                   @onboarding-open-getting-started=${
                     this.onOnboardingOpenGettingStarted
                   }
-                  @onboarding-skip-setup=${this.onOnboardingSkipSetup}
+                  @onboarding-skip-setup=${() =>
+                    postMessage(MAIN_VIEW_COMMANDS.ONBOARDING_SKIP_SETUP)}
                 ></onboarding-setup-card>`
               : nothing
           }
 
           <instruction-panel
             .showSessionHint=${!sessionHintDismissed$.get()}
-            @session-type-change=${this.onSessionTypeChange}
-            @agent-change=${this.onAgentChange}
-            @model-change=${this.onModelChange}
+            @session-type-change=${({
+              detail,
+            }: CustomEvent<SessionTypeChangeDetail>) =>
+              changeSessionType(detail.value)}
+            @agent-change=${({ detail }: CustomEvent<AgentChangeDetail>) =>
+              changeAgent(detail.sessionType, detail.value)}
+            @model-change=${({ detail }: CustomEvent<ModelChangeDetail>) =>
+              changeModel(detail.value)}
             @instruction-input=${this.onInstructionInput}
-            @instruction-paste=${this.onInstructionPaste}
-            @panel-action=${this.onPanelAction}
-            @execute=${this.onExecute}
-            @agent-settings=${this.onAgentSettings}
-            @browse-all-agents=${this.onBrowseAllAgents}
-            @model-settings=${this.onModelSettings}
-            @focus-instruction=${this.onFocusInstruction}
+            @instruction-paste=${() => saveState()}
+            @panel-action=${({ detail }: CustomEvent<ActionDetail>) =>
+              runPanelAction(detail.action)}
+            @execute=${() => executeAgent()}
+            @agent-settings=${() => runAgentConfigAction('edit')}
+            @browse-all-agents=${() => runAgentConfigAction('edit')}
+            @model-settings=${() =>
+              postMessage(MAIN_VIEW_COMMANDS.OPEN_MODEL_SETTINGS)}
+            @focus-instruction=${({
+              detail,
+            }: CustomEvent<FocusInstructionDetail>) =>
+              postMessage(MAIN_VIEW_COMMANDS.SHOW_INSTRUCTION, {
+                key: detail.key,
+                text: detail.text,
+              })}
             @dismiss-session-hint=${this.onDismissSessionHint}
           ></instruction-panel>
 
@@ -543,15 +394,31 @@ export class MainApp extends MainAppBase {
               gettingStartedVisible$.get() && !gettingStartedDismissed$.get()
             }
             .loginBannerVisible=${loginBannerVisible$.get()}
-            @api-key-action=${this.onApiKeyAction}
-            @agent-config-action=${this.onAgentConfigAction}
-            @dependency-dismiss=${this.onDependencyDismiss}
-            @recheck-dependencies=${this.onRecheckDependencies}
-            @open-install-guide=${this.onOpenInstallGuide}
+            @api-key-action=${({ detail }: CustomEvent<BannerActionDetail>) =>
+              runApiKeyBannerAction(detail.action as 'set' | 'guide')}
+            @agent-config-action=${({
+              detail,
+            }: CustomEvent<BannerActionDetail>) =>
+              runAgentConfigAction(detail.action as 'edit' | 'dir' | 'docs')}
+            @dependency-dismiss=${() =>
+              dependencyBanner$.set({ visible: false })}
+            @recheck-dependencies=${() =>
+              postMessage(MAIN_VIEW_COMMANDS.RECHECK_DEPENDENCIES)}
+            @open-install-guide=${({
+              detail,
+            }: CustomEvent<InstallGuideDetail>) =>
+              postMessage(MAIN_VIEW_COMMANDS.OPEN_INSTALL_GUIDE, {
+                tool: detail.tool,
+              })}
             @sign-in=${this.onSignInFromBanner}
             @dismiss-login=${this.onDismissLogin}
             @dismiss-getting-started=${this.onDismissGettingStarted}
-            @getting-started-action=${this.onGettingStartedAction}
+            @getting-started-action=${({
+              detail,
+            }: CustomEvent<GettingStartedActionDetail>) =>
+              postMessage(MAIN_VIEW_COMMANDS.GETTING_STARTED_ACTION, {
+                action: detail.action,
+              })}
           ></banner-group>
 
           <wa-divider></wa-divider>
@@ -584,12 +451,33 @@ export class MainApp extends MainAppBase {
                 (config) => html`
                   <file-select-group
                     .config=${config}
-                    @add-opened-files=${this.onAddOpenedFiles}
-                    @empty-files=${this.onEmptyFiles}
-                    @select-multiple-files=${this.onSelectMultipleFiles}
-                    @remove-file=${this.onRemoveFile}
-                    @files-reordered=${this.onFilesReordered}
-                    @checkbox-change=${this.onCheckboxChange}
+                    @add-opened-files=${({
+                      detail,
+                    }: CustomEvent<MultipleFilesTypeActionDetail>) => {
+                      if (detail.type !== 'output') {
+                        addOpenedFiles(detail.type as DocumentFileType);
+                      }
+                    }}
+                    @empty-files=${({
+                      detail,
+                    }: CustomEvent<MultipleFilesTypeActionDetail>) =>
+                      emptyFiles(detail.type)}
+                    @select-multiple-files=${({
+                      detail,
+                    }: CustomEvent<MultipleFilesActionDetail>) =>
+                      selectMultipleFiles(detail.listId)}
+                    @remove-file=${({
+                      detail,
+                    }: CustomEvent<RemoveFileDetail>) =>
+                      removeFile(detail.listId, detail.file)}
+                    @files-reordered=${({
+                      detail,
+                    }: CustomEvent<ReorderFilesDetail>) =>
+                      updateMultiFiles(detail.listId, detail.files)}
+                    @checkbox-change=${({
+                      detail,
+                    }: CustomEvent<CheckboxChangeDetail>) =>
+                      updateCheckboxValue(detail.id, detail.checked)}
                   ></file-select-group>
                 `,
               )}
@@ -611,14 +499,31 @@ export class MainApp extends MainAppBase {
                   .commitOptions=${fo.commit ?? []}
                   .isGitRepo=${isGitRepo$.get()}
                   @latexdiffs-toggle=${this.onLatexDiffsToggle}
-                  @latexdiffs-action=${this.onLatexDiffsAction}
-                  @base-file-change=${this.onBaseFileChange}
-                  @edited-file-change=${this.onEditedFileChange}
-                  @get-current-file=${this.onLatexdiffGetCurrentFile}
-                  @empty-file=${this.onLatexdiffEmptyFile}
-                  @refresh-edited-files=${this.onRefreshEditedFiles}
-                  @commit-change=${this.onCommitChange}
-                  @refresh-commits=${this.onRefreshCommits}
+                  @latexdiffs-action=${({
+                    detail,
+                  }: CustomEvent<LatexDiffsActionDetail>) =>
+                    runLatexDiffsAction(detail.action)}
+                  @base-file-change=${({
+                    detail,
+                  }: CustomEvent<BaseFileChangeDetail>) =>
+                    setBaseFile(detail.value)}
+                  @edited-file-change=${({
+                    detail,
+                  }: CustomEvent<EditedFileChangeDetail>) =>
+                    setEditedFile(detail.value)}
+                  @get-current-file=${({
+                    detail,
+                  }: CustomEvent<FileActionDetail>) =>
+                    getCurrentFile(detail.type)}
+                  @empty-file=${({ detail }: CustomEvent<FileActionDetail>) =>
+                    emptyFile(detail.type)}
+                  @refresh-edited-files=${() => refreshEditedFiles()}
+                  @commit-change=${({
+                    detail,
+                  }: CustomEvent<CommitChangeDetail>) =>
+                    setCommit(detail.value)}
+                  @refresh-commits=${() =>
+                    postMessage(MAIN_VIEW_COMMANDS.REFRESH_COMMITS)}
                 ></latexdiffs-section>
               `
         }


### PR DESCRIPTION
## Summary

Collapses the MainApp event-adapter plane in `packages/extension/src/webview/frontend/MainApp.ts`. The main webview had 42 one-line `private readonly onX` adapter fields manufactured by a `commandHandler`/`detailHandler`/`detailCommandHandler` factory trio, existing solely to unwrap `event.detail` into a `mainViewActions` call. All three factories and all 42 adapter fields cease to exist. The 35 trivial adapters become inline arrows over the same action functions at their existing template sites (the same pattern the template already used for `wa-show`/`wa-hide`); the remaining 7 stay as named private handlers per the issue's hard-scope corrections: the five multi-statement bodies (`onDismissLogin`, `onDismissGettingStarted`, `onDismissSessionHint`, `onLatexDiffsToggle`, `onInstructionInput`) and the two handlers bound at two template sites each (`onSignInFromBanner`, `onOnboardingOpenGettingStarted`).

Closes #8819

## Issue acceptance gates

- `MainApp.commandHandler`, `MainApp.detailHandler`, `MainApp.detailCommandHandler` cease to exist: done (grep for the three names in MainApp.ts returns nothing; the remaining repo hits are the unrelated `ProgressViewHost.commandHandlers`).
- The 42 `onX` adapter fields cease to exist: done; 35 collapsed to inline arrows, 7 retained as named handlers exactly as the corrections mandate.
- Correction (1): the 5 multi-statement bodies kept as named private handlers (budget 4-5): done, 5 kept.
- Correction (2): `onSignInFromBanner` and `onOnboardingOpenGettingStarted` kept as named handlers because each binds at two template sites: done.
- Correction (3): MainApp-only, independent of the SettingsApp switchboard lane: done, single-file diff.

## Single source of truth

`packages/extension/src/webview/frontend/mainViewActions.ts` remains the owner of all main-view behavior; the template site in `MainApp.render()` is now the single place where each DOM event maps to its action, with no intermediate adapter layer.

## Duplication and abstraction budget

Removed a pass-through abstraction plane: three handler factories plus 42 fields that each restated an event-to-action mapping already visible at the template binding. No new abstractions added; the 7 retained named handlers are justified by multi-statement bodies or double binding sites (a named handler avoids duplicating the inline expression).

## Net elements (R6)

- Files: 0 added, 0 deleted (1 modified).
- Exported symbols: 0 added, 0 deleted (`grep -cE "^[+-]export"` over the diff = 0; everything deleted was `private`).
- Classes/interfaces/enums: 0 added, 0 deleted.
- Class members: -38 (3 factory methods + 42 adapter fields deleted; 7 named handlers retained/rewritten in place).
- Net LoC: -95 (124 insertions, 219 deletions per diffstat).

## Consumer counts (R8)

n/a — all deleted symbols were `private` class members of `MainApp` with zero consumers outside the class. Verified by repo-wide grep (including `*.mts`/`*.cts`): `commandHandler|detailHandler|detailCommandHandler` outside MainApp.ts only matches the unrelated `ProgressViewHost.commandHandlers` map; none of the 42 `onX` field names appear outside MainApp.ts.

## Host impact

Extension: Main webview only; event wiring is behavior-identical (same actions, same payloads, same template sites).

Desktop: None beyond sharing the same webview bundle; desktop attaches no listeners to these components and the `isDesktopHost` branches are untouched.

CLI: None.

## Scheduled refactoring

None. The sibling SettingsApp switchboard lane is tracked separately per the issue's correction (3).

## Validation

- `npm run typecheck` — all six stages pass.
- `npm run lint` — 0 errors, 1 pre-existing known warning (`AgentCreatorToolCatalogParity.vitest.mts` unicorn/prefer-string-replace-all).
- `npm run check:dead-code-ratchet` — OK, 225 vs 225 baselined.
- `npx vitest run --config vitest.config.mjs src/test-kernel/webview/MainAppPersistenceRestore.vitest.mts` — 11/11 pass (the only test file referencing MainApp).
- Full suite not run: single-file webview refactor, not repo-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file UI wiring refactor with no API or host contract changes; risk is limited to accidental binding mistakes, mitigated by existing MainApp persistence tests.
> 
> **Overview**
> Removes the **MainApp** pass-through event layer: the `commandHandler`, `detailHandler`, and `detailCommandHandler` helpers and **42** one-line `onX` adapter fields are gone. **35** bindings are now **inline arrows** in `render()` that call the same `mainViewActions` / `postMessage` paths; **7** stay as named private handlers (multi-step dismiss/toggle/input logic, plus sign-in and getting-started handlers reused at two template sites).
> 
> Behavior should be unchanged—each DOM event still maps to the same action at the same template site, without an intermediate adapter class member.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a79da056d79e7d1f222296ab231d6284ba97ac0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->