### PR TITLE
refactor(runtime): pass canonical AgentConfig into executeAgent

### DIFF
--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -550,6 +550,9 @@ export async function buildAgentLaunchContext(
   const launchSession = input.session ?? currentSession();
   const streamStatus = launchSession.status;
   const executionId = input.executionId ?? generateExecutionId();
+  if (!input.streamTabIdOverride && (!config.agent || !config.model)) {
+    throw new AgentError('Missing required fields: model and/or agent');
+  }
   const reservedStreamId = input.streamTabIdOverride
     ? undefined
     : getStreamTabId(config.agent, config.model, { executionId });

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -18,11 +18,7 @@ import {
 import { getExecutionStore } from '@agent/storage';
 import { createChannelTrace } from '@agent/trace';
 import type { AgentCore } from '@agent/core/flows/BaseFlowServices';
-import {
-  AgentConfigSchema,
-  type AgentConfig,
-  type AgentConfigPayload,
-} from '@agent/core/definition/AgentConfig';
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { UserVariableChannels } from '@agent/core/definition/AgentCycleOptions';
 import {
@@ -89,14 +85,14 @@ export interface AgentLaunchContext extends AgentCore {
 }
 
 export interface AgentLaunchInput {
-  configPayload: AgentConfigPayload;
+  config: AgentConfig;
   executionId?: ExecutionId;
   runtimeHost: AgentRuntimeHost;
   streamTabIdOverride?: StreamTabId;
   taskType?: string;
   /** Fires after streamId is assigned but before setActiveStream is emitted. */
   onBeforeActivation?: (streamId: StreamTabId) => void;
-  /** When true, reject if configPayload.agentCategory doesn't match the YAML-defined category. */
+  /** When true, reject if an explicit category doesn't match the YAML-defined category. */
   enforceCategory?: boolean;
   /** Skip the `requestShowError` toast -- for callers that show their own UI. */
   suppressErrorNotification?: boolean;
@@ -236,8 +232,7 @@ async function assembleAgentLaunchContext(
   reservedStreamId: StreamTabId | undefined,
   resources: AgentLaunchResources,
 ): Promise<AgentLaunchContext> {
-  const { configPayload } = input;
-  const fullConfig = AgentConfigSchema.parse(configPayload);
+  const fullConfig = input.config;
   // Resolve by the source the delegation captured at validation time, so launch
   // lands on the exact entry validation/display resolved. When no source is
   // pinned (direct launches, restored records), resolution falls to the
@@ -260,20 +255,18 @@ async function assembleAgentLaunchContext(
   // registry's pre-merge category can't see: a child agent that `inherits` a
   // parent of the other category resolves with the scanner's pre-merge category
   // (used by getVisibleAgent) but loads a post-merge `setting.agentCategory`
-  // that differs. Only enforced when the caller opts in via enforceCategory,
-  // because many code paths pass pre-parsed configs where agentCategory was
-  // prefaulted to Workflow by the schema (not explicitly chosen by the caller).
+  // that differs. Only enforced when the caller opts in and the category was
+  // explicitly supplied before schema defaults were applied.
   if (
     input.enforceCategory &&
-    configPayload.agentCategory &&
-    configPayload.agentCategory !== setting.agentCategory
+    fullConfig.agentCategory !== setting.agentCategory
   ) {
     const suggestion =
       setting.agentCategory === AgentCategory.ToolUse
         ? 'delegate_agent'
         : 'delegate_workflow';
     throw new AgentError(
-      `Agent '${fullConfig.agent}' is a ${setting.agentCategory} agent but was launched as ${configPayload.agentCategory}. Use ${suggestion} instead.`,
+      `Agent '${fullConfig.agent}' is a ${setting.agentCategory} agent but was launched as ${fullConfig.agentCategory}. Use ${suggestion} instead.`,
     );
   }
 
@@ -379,7 +372,7 @@ async function assembleAgentLaunchContext(
   }
 
   const agentPath = path.dirname(resolution.definitionPath);
-  const workingDirectory = configPayload.workingDirectory?.trim() || undefined;
+  const workingDirectory = config.workingDirectory?.trim() || undefined;
   const runScope = createRunScope({
     runtimeHost,
     streamId,
@@ -482,7 +475,7 @@ function acquireStreamOrThrow(
  *    tab doesn't hang in STARTING.
  */
 function compensateFailedActivation(args: {
-  configPayload: AgentConfigPayload;
+  config: AgentConfig;
   reservedStreamId?: StreamTabId;
   activatedStreamId?: StreamTabId;
   streamStatus: StreamStatusMachine;
@@ -494,7 +487,7 @@ function compensateFailedActivation(args: {
   runTrace?: RunTrace;
 }): void {
   const {
-    configPayload,
+    config,
     reservedStreamId,
     activatedStreamId,
     streamStatus,
@@ -510,9 +503,9 @@ function compensateFailedActivation(args: {
     if (runTrace) {
       logSdkError(
         runTrace.trace,
-        `Failed to start agent ${configPayload.agent}: ${getSdkErrorMessage(err)}`,
+        `Failed to start agent ${config.agent}: ${getSdkErrorMessage(err)}`,
         err,
-        { operation: `start ${configPayload.agent}` },
+        { operation: `start ${config.agent}` },
       );
     }
     if (
@@ -527,7 +520,7 @@ function compensateFailedActivation(args: {
     ) {
       runTrace?.trace.warn('Failed to mark activation failure terminal', {
         data: {
-          agentIdentifier: configPayload.agent,
+          agentIdentifier: config.agent,
           streamId: activatedStreamId,
         },
       });
@@ -553,20 +546,13 @@ function compensateFailedActivation(args: {
 export async function buildAgentLaunchContext(
   input: AgentLaunchInput,
 ): Promise<AgentLaunchContext> {
-  const { configPayload, runtimeHost } = input;
+  const { config, runtimeHost } = input;
   const launchSession = input.session ?? currentSession();
   const streamStatus = launchSession.status;
   const executionId = input.executionId ?? generateExecutionId();
-  if (
-    !input.streamTabIdOverride &&
-    (!configPayload.agent || !configPayload.model)
-  ) {
-    throw new AgentError('Missing required fields: model and/or agent');
-  }
-
   const reservedStreamId = input.streamTabIdOverride
     ? undefined
-    : getStreamTabId(configPayload.agent, configPayload.model, { executionId });
+    : getStreamTabId(config.agent, config.model, { executionId });
   if (reservedStreamId) {
     acquireStreamOrThrow(
       reservedStreamId,
@@ -590,7 +576,7 @@ export async function buildAgentLaunchContext(
   } catch (err) {
     resources.fail((activatedStreamId, runTrace) => {
       compensateFailedActivation({
-        configPayload,
+        config,
         reservedStreamId,
         activatedStreamId,
         streamStatus,

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -14,10 +14,7 @@ import {
   type RunReflectionFlowResult,
 } from '@agent/implementations/flows/reflection/runReflectionFlow';
 import { inferPersistedModelHandlerCompatibilityKey } from '@agent/runtime/modelHandlerCompatibilityInference';
-import {
-  type AgentConfig,
-  type AgentConfigPayload,
-} from '@agent/core/definition/AgentConfig';
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { RoundFinalizedCallback } from '@agent/core/flows/BaseFlowServices';
 import {
   AgentCategory,
@@ -326,10 +323,8 @@ export interface ExecuteAgentOptions extends SubagentRunOptions {
   /** When true, proposal tools are filtered out to prevent nesting. */
   isSubagent?: boolean;
   /**
-   * When true, enforce that configPayload.agentCategory matches the agent's
-   * YAML-defined category. Callers that explicitly set a category (e.g.
-   * DelegationTools) should opt in; callers that pass pre-parsed configs with
-   * prefaulted defaults (e.g. runExecuteCommand) should leave this off.
+   * When true, enforce that an explicitly supplied category matches the
+   * agent's YAML-defined category.
    */
   enforceCategory?: boolean;
   /** Fires with the real streamId before the stream is activated (before UI sync). */
@@ -352,12 +347,12 @@ export interface ExecuteAgentOptions extends SubagentRunOptions {
 }
 
 export function executeAgent(
-  configPayload: AgentConfigPayload,
+  config: AgentConfig,
   executionId: ExecutionId | undefined,
   options: ExecuteAgentOptions & { allowWaitingResult: true },
 ): Promise<AgentFlowResult | WaitingToolUseFlowResult>;
 export function executeAgent(
-  configPayload: AgentConfigPayload,
+  config: AgentConfig,
   executionId: ExecutionId | undefined,
   options: ExecuteAgentOptions & { allowWaitingResult?: false | undefined },
 ): Promise<AgentFlowResult>;
@@ -369,7 +364,7 @@ export function executeAgent(
  * its descriptor. Resume paths reuse the existing execution record.
  */
 export async function executeAgent(
-  configPayload: AgentConfigPayload,
+  config: AgentConfig,
   executionId: ExecutionId | undefined,
   options: ExecuteAgentOptions,
 ): Promise<AgentRuntimeFlowResult> {
@@ -379,7 +374,7 @@ export async function executeAgent(
 
   const { runtimeHost } = options;
   const ctx = await buildAgentLaunchContext({
-    configPayload,
+    config,
     executionId,
     runtimeHost,
     onBeforeActivation: options.onStreamResolved,
@@ -506,7 +501,7 @@ export async function resumeToolUseFromSnapshot(
   try {
     isSubagent = await hasPersistedParent(snapshot.executionId);
     ctx = await buildAgentLaunchContext({
-      configPayload: snapshot.agentConfig,
+      config: snapshot.agentConfig,
       executionId: snapshot.executionId,
       runtimeHost,
       streamTabIdOverride: snapshot.streamId,

--- a/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
@@ -38,6 +38,7 @@ import {
   type AgentLaunchContext,
 } from '@agent/runtime/AgentLaunchContext';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
+import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { useRunContext } from '@agent/runtime/RunContext';
 import { createRunScope } from '@agent/runtime/RunScope';
@@ -152,12 +153,12 @@ describe('AgentLaunchContext', () => {
     try {
       await expect(
         buildAgentLaunchContext({
-          configPayload: {
+          config: AgentConfigSchema.parse({
             agent: 'chat',
             model: 'gpt55',
             agentCategory: AgentCategory.ToolUse,
             delegationAgentScope,
-          },
+          }),
           runtimeHost: createRecordingHost().host,
           session,
           streamTabIdOverride: 'late-assembly-stream',

--- a/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
@@ -47,6 +47,23 @@ import { RUN_OUTCOME, STREAM_PHASE } from '@shared/schemas';
 import { createRecordingHost } from '../progressTestUtils';
 
 describe('AgentLaunchContext', () => {
+  it('retains the missing-field diagnostic for empty canonical values', async () => {
+    const session = createTestSession();
+    try {
+      await expect(
+        buildAgentLaunchContext({
+          config: AgentConfigSchema.parse({ agent: '', model: '' }),
+          runtimeHost: createRecordingHost().host,
+          session,
+        }),
+      ).rejects.toMatchObject({
+        message: 'Missing required fields: model and/or agent',
+      });
+    } finally {
+      session.dispose();
+    }
+  });
+
   it('publishes missing-agent banners through the explicit runtime host', async () => {
     const explicit = createRecordingHost();
 

--- a/src/test-kernel/tools/NativeToolUseStrategy.vitest.ts
+++ b/src/test-kernel/tools/NativeToolUseStrategy.vitest.ts
@@ -14,6 +14,7 @@ import {
   isChildRunLoopActive,
   startChildRunLoop,
 } from '@agent/runtime/childRunLoop';
+import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { AgentExecutionHandle } from '@agent/runtime/ExecutionHandle';
 import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
 import {
@@ -72,11 +73,12 @@ function fakePorts() {
 function baseParams(parentSession = createTestSession()) {
   if (parentSession !== defaultSession()) ownedSessions.add(parentSession);
   return {
-    configPayload: {
+    config: AgentConfigSchema.parse({
       agent: 'review',
       model: 'gpt5',
       agentCategory: 'toolUse',
-    } as never,
+    }),
+    agentCategoryExplicit: true,
     executionId: 'exec-1' as ExecutionId,
     agentName: 'review',
     orchestratorStreamId: 'orchestrator-stream' as StreamTabId,
@@ -135,6 +137,11 @@ describe('NativeToolUseStrategy', () => {
     });
 
     await strategy.launch(fakePorts(), new AbortController());
+    expect(mocks.executeAgent).toHaveBeenLastCalledWith(
+      params.config,
+      params.executionId,
+      expect.objectContaining({ enforceCategory: true }),
+    );
     expect(strategy.resolveDeliveryTarget?.()).toBe(
       params.orchestratorStreamId,
     );

--- a/src/tools/delegation/nativeToolUseStrategy.ts
+++ b/src/tools/delegation/nativeToolUseStrategy.ts
@@ -32,7 +32,7 @@ import type {
   ChildRunPorts,
   ChildRunStrategy,
 } from '@agent/runtime/childRunLoop';
-import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import {
   RUN_OUTCOME,
   STREAM_PHASE,
@@ -49,7 +49,8 @@ import {
 import { subagentDeliveryMessage } from './subagentDeliveryFormat';
 
 export interface NativeToolUseStrategyParams {
-  readonly configPayload: AgentConfigPayload;
+  readonly config: AgentConfig;
+  readonly agentCategoryExplicit: boolean;
   readonly executionId: ExecutionId;
   readonly agentName: string;
   readonly orchestratorStreamId: StreamTabId;
@@ -139,11 +140,11 @@ export function createNativeToolUseStrategy(
 
     launch: (ports) =>
       runNative(ports, () =>
-        executeAgent(params.configPayload, params.executionId, {
+        executeAgent(params.config, params.executionId, {
           runtimeHost: params.runtimeHost,
           session: params.parentSession,
           isSubagent: true,
-          enforceCategory: true,
+          enforceCategory: params.agentCategoryExplicit,
           parentStreamId: params.orchestratorStreamId,
           approvalPromptsUnavailable: params.approvalPromptsUnavailable,
           runtimeUnavailableTools: params.runtimeUnavailableTools,

--- a/src/tools/delegation/nativeWorkflowStrategy.ts
+++ b/src/tools/delegation/nativeWorkflowStrategy.ts
@@ -12,7 +12,7 @@ import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { AgentRunHandle } from '@agent/runtime/ExecutionHandle';
 import type { ChildRunStrategy } from '@agent/runtime/childRunLoop';
-import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 
 import {
@@ -22,7 +22,8 @@ import {
 import { subagentDeliveryMessage } from './subagentDeliveryFormat';
 
 export interface NativeWorkflowStrategyParams {
-  readonly configPayload: AgentConfigPayload;
+  readonly config: AgentConfig;
+  readonly agentCategoryExplicit: boolean;
   readonly executionId: ExecutionId;
   readonly agentName: string;
   readonly orchestratorStreamId: StreamTabId;
@@ -64,27 +65,23 @@ export function createNativeWorkflowStrategy(
     stageLabel: 'Native workflow subagent',
 
     launch: async (ports) => {
-      const result = await executeAgent(
-        params.configPayload,
-        params.executionId,
-        {
-          runtimeHost: params.runtimeHost,
-          session: params.parentSession,
-          isSubagent: true,
-          enforceCategory: true,
-          parentStreamId: params.orchestratorStreamId,
-          approvalPromptsUnavailable: params.approvalPromptsUnavailable,
-          runtimeUnavailableTools: params.runtimeUnavailableTools,
-          onStreamResolved: params.onStreamResolved,
-          onProgress: (update) => ports.notify(update),
-          onRunError: (err) => {
-            lastErr = err;
-          },
-          onRun: (handle) => {
-            runHandle = handle;
-          },
+      const result = await executeAgent(params.config, params.executionId, {
+        runtimeHost: params.runtimeHost,
+        session: params.parentSession,
+        isSubagent: true,
+        enforceCategory: params.agentCategoryExplicit,
+        parentStreamId: params.orchestratorStreamId,
+        approvalPromptsUnavailable: params.approvalPromptsUnavailable,
+        runtimeUnavailableTools: params.runtimeUnavailableTools,
+        onStreamResolved: params.onStreamResolved,
+        onProgress: (update) => ports.notify(update),
+        onRunError: (err) => {
+          lastErr = err;
         },
-      );
+        onRun: (handle) => {
+          runHandle = handle;
+        },
+      });
       // The run's total cost to date (including nested subagents), not a
       // per-turn delta — the loop commits the latest value to the parent
       // exactly once, when the child's run ends.

--- a/src/tools/delegation/subagentExecution.ts
+++ b/src/tools/delegation/subagentExecution.ts
@@ -160,31 +160,23 @@ export async function executeSubagent(
 
   const executionId = generateExecutionId();
   const startedAt = Date.now();
-  const syntheticConfig = AgentConfigSchema.parse(childConfigPayload);
-  await registerExecution(
-    executionId,
-    syntheticConfig,
-    agentName,
-    parentExecutionId,
-  );
+  const config = AgentConfigSchema.parse(childConfigPayload);
+  await registerExecution(executionId, config, agentName, parentExecutionId);
 
-  const isToolUse = childConfigPayload.agentCategory === AgentCategory.ToolUse;
+  const isToolUse = config.agentCategory === AgentCategory.ToolUse;
   // Must match the id `buildAgentLaunchContext` actually reserves for this
   // executionId (see AgentLaunchContext.ts's `reservedStreamId`), or the
   // loop acquires the wrong follow-up queue/interrupt slot. That reservation
-  // uses the RAW, unparsed `configPayload.agent`/`configPayload.model` — not
-  // `AgentConfigSchema.parse(configPayload).agent` (the later `config.agent`
-  // recomputation never wins; the upfront reservation always does) — and
-  // NOT the `agentName` parameter, which callers may resolve differently
+  // uses the canonical config's agent/model — not the `agentName` parameter,
+  // which callers may resolve differently
   // (e.g. an approved agent override's display name vs. its registry name).
   // Derive from the exact same fields, not a parallel formula.
-  const childStreamId = getStreamTabId(
-    childConfigPayload.agent,
-    childConfigPayload.model,
-    { executionId },
-  );
+  const childStreamId = getStreamTabId(config.agent, config.model, {
+    executionId,
+  });
   const strategyParams = {
-    configPayload: childConfigPayload,
+    config,
+    agentCategoryExplicit: childConfigPayload.agentCategory !== undefined,
     executionId,
     agentName,
     orchestratorStreamId,


### PR DESCRIPTION
## Summary

Native agent launches now pass the canonical `AgentConfig` produced at the registration boundary through both native strategies and into `executeAgent`. The launch context no longer reparses that value. A separate `agentCategoryExplicit` marker preserves whether delegation supplied a category before schema defaults were applied.

No user-visible behavior, public or persisted wire format, or CLI output changes are intended. No changelog entry is needed.

## Issue acceptance gates

- Closes #8799.
- Passes canonical `AgentConfig` values through both native child-run strategies.
- Deletes the second schema parse while preserving the empty-agent/model guard and its exact diagnostic against canonical values.
- Retains `agentCategoryExplicit` independently from the canonical configuration, so a prefaulted category is not mistaken for caller intent.
- Preserves category mismatch messages, stream identity, registration order, and launch ordering.
- Leaves persisted execution configurations and resume snapshots unchanged.
- Treats the issue's verifier corrections as hard requirements.

## Single source of truth

`subagentExecution` parses the delegation payload once, registers that canonical configuration, derives the stream identity from it, and gives the same value to the selected native strategy. `executeAgent` and `AgentLaunchContext` now consume that canonical value directly.

## Duplication and abstraction budget

The launch-boundary parse was deleted, while the existing missing-field branch now reads the canonical configuration directly. No facade, compatibility shim, re-export, wrapper, or replacement abstraction was added. The existing strategy parameter contracts were narrowed from `AgentConfigPayload` to `AgentConfig`.

## Net elements (R6)

- Files: 7 modified; 0 added; 0 deleted.
- Exported symbols: 0 added; 0 deleted.
- Classes/interfaces/enums: 0 added; 0 deleted.
- Production LoC: +62 / -88, net -26.
- Test LoC: +29 / -4, net +25.
- Total LoC: +91 / -92, net -1.
- Relocated lines: 0 between modules. Some diff churn is Prettier's compaction of shorter calls, not relocated logic.
- Deleted lines: 92 by Git accounting, including the obsolete parse and replaced payload plumbing.

## Consumer counts (R8)

- `executeAgent`: 4 production call sites (`runAgent`, in-band delegation, native tool-use strategy, native workflow strategy).
- `buildAgentLaunchContext`: 2 production call sites, both in `executeAgent.ts` (fresh launch and persisted tool-use resume), plus 1 focused test call.
- `createNativeToolUseStrategy`: 1 production construction path in `subagentExecution`, plus its dedicated test suite.
- `createNativeWorkflowStrategy`: 1 production construction path in `subagentExecution`.
- `AgentConfigSchema.parse` at native delegation launch: 1 remaining production parse in `subagentExecution`; the second parse in `AgentLaunchContext` is deleted.
- Open pull requests overlapping these launch contracts at implementation start: 0.

## Host impact

Extension: Continues to launch canonical configurations through `runAgent`; behavior is unchanged.

Desktop: Continues to launch validated configurations through `runAgent`; behavior is unchanged.

CLI: `texra run`, `texra agents run`, multi-agent execution, and `--print` routing are unchanged. CLI command, output-guard, root-argument, and progress-renderer tests pass.

## Scheduled refactoring

The campaign's tool-use resume cleanup remains separate under #8791; this pull request does not change persisted or transient resume formats.

## Validation

- `corepack pnpm install`
- `npm run format`
- `npm run typecheck` (rerun after rebasing onto current `origin/main`)
- `npm run compile:fast`
- `npm run lint`
- `npm run check:dead-code-ratchet` (225 current findings, equal to the 225 baseline)
- Targeted runtime, delegation, and CLI launch suites: 10 files, 163 tests
- Focused post-review runtime suites: 3 files, 19 tests
- CLI output and argument parity suites: 3 files, 139 tests
- `git diff --check`
- Code-simplifier pass: confined the explicit-category marker to native strategy transport, removed broader request/CLI propagation, and found no further in-scope abstraction or duplicate parse to delete.
