### PR TITLE
feat(workflowScript): render() Nunjucks primitive (Phase 4)

### DIFF
--- a/src/agent/workflowScript/renderPrimitive.ts
+++ b/src/agent/workflowScript/renderPrimitive.ts
@@ -1,0 +1,27 @@
+// Third-party imports
+import * as nunjucks from 'nunjucks';
+
+// Isolated Nunjucks environment so `autoescape: false` does not leak into the
+// shared singleton that `nunjucks.configure` / `nunjucks.renderString` would
+// otherwise set for every other caller. Nunjucks is a host-side Node library,
+// so `render` runs in the host and only the resulting string crosses into the
+// sandbox realm. Rendering is deterministic and pure, so it is safe to expose
+// as a synchronous primitive.
+const env = new nunjucks.Environment(null, { autoescape: false });
+
+/**
+ * Render a Nunjucks template string with already-resolved JSON `data`, for the
+ * workflow-script `render()` primitive. Lets a script template a prior stage's
+ * structured result into the next prompt or a text artifact.
+ */
+export function renderWorkflowTemplate(
+  templateString: string,
+  data: Record<string, unknown>,
+): string {
+  if (typeof templateString !== 'string') {
+    throw new Error(
+      'render(templateString, data) requires templateString to be a string.',
+    );
+  }
+  return env.renderString(templateString, data ?? {});
+}

--- a/src/agent/workflowScript/runWorkflowScript.ts
+++ b/src/agent/workflowScript/runWorkflowScript.ts
@@ -6,6 +6,7 @@ import { isNonEmptyString } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { parseWorkflowScript } from './parseScript';
+import { renderWorkflowTemplate } from './renderPrimitive';
 import { runScriptInSandbox } from './sandbox';
 import {
   WORKFLOW_SKIPPED_RESULT,
@@ -544,6 +545,11 @@ export async function runWorkflowScript(
             });
             return undefined;
           },
+          render: (args) =>
+            renderWorkflowTemplate(
+              args[0] as string,
+              (args[1] as Record<string, unknown> | undefined) ?? {},
+            ),
         },
         argsJson,
         realmPreludes: [ORCHESTRATION_PRELUDE],

--- a/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
@@ -1394,4 +1394,29 @@ return 'incorrect success'`,
       }),
     ).rejects.toThrow();
   });
+
+  it('templates structured data into a string via render()', async () => {
+    const run = await runWorkflowScript({
+      script: `${META}return render('{{ n }} items: {% for f in items %}{{ f.title }} {% endfor %}', { n: 2, items: [{ title: 'a' }, { title: 'b' }] })`,
+      runAgent: echoRunner,
+    });
+    expect(run.result).toBe('2 items: a b ');
+  });
+
+  it('renders with autoescape off so values are not HTML-escaped', async () => {
+    const run = await runWorkflowScript({
+      script: `${META}return render('{{ v }}', { v: 'a & b < c' })`,
+      runAgent: echoRunner,
+    });
+    expect(run.result).toBe('a & b < c');
+  });
+
+  it('throws when render() is given a non-string template', async () => {
+    await expect(
+      runWorkflowScript({
+        script: `${META}return render(42, {})`,
+        runAgent: echoRunner,
+      }),
+    ).rejects.toThrow(/templateString to be a string/);
+  });
 });


### PR DESCRIPTION
Phase 4 of the structured-output feature (tracking #8829). Depends on Phase 1 (#8830).

## What this adds

A `render(templateString, data) -> string` primitive for the workflow-script sandbox, so a script can template a prior stage's structured result into the next agent's prompt or a text artifact.

- **`src/agent/workflowScript/renderPrimitive.ts`** (new) — `renderWorkflowTemplate` uses an isolated `new nunjucks.Environment(null, { autoescape: false })` (mirroring `agentTemplateRenderer.ts`) so the shared Nunjucks singleton is never mutated. Validates the template is a string; `data` arrives as already-resolved JSON.
- **`src/agent/workflowScript/runWorkflowScript.ts`** — registers `render` in the `syncFns` map right after `log`/`phase`; no special-casing, so the existing `syncNames` bridge surfaces it to the realm automatically.

## Notes

With the terminal-tool structured-output channel (Phase 1/3), structured values reach a script as tool-call args, so no YAML/JSON text-parsing of outputs is needed for extraction. `render()` covers the remaining need: composing structured data into text.

Determinism: `render` is a pure syncFn; it is not affected by and does not touch the Date.now/Math.random determinism guards.

## Testing

- `npm run typecheck` clean across all projects.
- Workflow-script engine suite: 75 passed (72 prior + 3 new): a for-loop template, autoescape-off (an `&`/`<` value is not HTML-escaped), and a non-string template rejecting.

Mocks/synthetic only, no live models.

Part of #8829. Closes #8833.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive sandbox API with isolated Nunjucks usage; no changes to auth, journaling, or agent execution paths beyond registering one sync function.
> 
> **Overview**
> Workflow scripts can now turn structured JSON from earlier stages into text via a synchronous **`render(templateString, data)`** primitive—useful for building the next agent prompt or a text artifact without hand-rolling string assembly.
> 
> Implementation adds **`renderWorkflowTemplate`** on the host with a dedicated Nunjucks environment (`autoescape: false`), matching **`agentTemplateRenderer`** so the global Nunjucks config is untouched. **`runWorkflowScript`** wires **`render`** into the existing **`syncFns`** bridge next to **`log`** / **`phase`**, so sandbox scripts call it like other sync primitives.
> 
> Tests cover loop/for templating, unescaped `&`/`<` output, and rejecting a non-string template.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8581b2ebdc2e948a43462288fcd6b5b477e38ec2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->