### PR TITLE
refactor(runtime): delete unread service fields

### DIFF
--- a/src/agent/implementations/flows/tooluse/ToolUseServices.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseServices.ts
@@ -1,7 +1,6 @@
 import type { AgentToolUseSetting } from '@agent/core/definition/AgentDataclass';
 import type { BaseFlowContextInit } from '@agent/core/flows/BaseFlowServices';
 import type { IToolRegistry } from '@agent/core/tools/ToolTypes';
-import type { AttachedMemoryMiss } from '@agent/types/AttachedMemory';
 import type { IToolUseSession } from '@agent/core/flows/IToolUseSession';
 import type { SubagentProgressUpdate, TodoItem } from '@shared/schemas';
 import type { TaskRunFileService } from '@utils/files';
@@ -15,7 +14,6 @@ export interface ToolUseServices<C = unknown> extends BaseFlowContextInit<C> {
   readonly toolRegistry: IToolRegistry;
   readonly snapshot: ToolUseSessionSnapshot | null;
   readonly onFollowUpConsumed?: () => void;
-  readonly attachedMemoryMisses?: readonly AttachedMemoryMiss[];
   readonly onProgress?: (update: SubagentProgressUpdate) => void;
   /** Persist todos to the execution KV store. Injected by runToolUseFlow. */
   readonly persistTodos?: (todos: TodoItem[]) => Promise<void>;

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -412,7 +412,7 @@ async function assembleAgentLaunchContext(
 
   const usageMonitor = new UsageMonitor(
     { capabilities: modelHandler.capabilities, config: modelHandler.config },
-    { logger: agentLogger, runtimeHost, storageKey, streamId },
+    { logger: agentLogger, storageKey, streamId },
     {
       agentName: config.agent,
       agentCategory: setting.agentCategory,

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -6,7 +6,6 @@ import type { AgentTrace } from '@agent/trace';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentRunStateSnapshot } from '@agent/core/state/AgentState';
 import type { RunUsageTotals } from '@agent/core/usage/RunUsageAccumulator';
-import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { usesServerSideKeysRoute } from '@agent/modelHandlers/support/ProxyConfigResolver';
 import type {
   ExtendedTokenUsageStats,
@@ -86,7 +85,6 @@ export interface UsageMonitorModelInfo {
  */
 export interface UsageMonitorContext {
   logger: AgentTrace;
-  runtimeHost: AgentRuntimeHost;
   storageKey: StorageKey;
   streamId: StreamTabId;
 }

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -163,7 +163,6 @@ function createLifecycleContext({
       modelInfo,
       {
         logger: noopTrace,
-        runtimeHost: explicit.host,
         storageKey,
         streamId,
       },

--- a/src/test-kernel/agent/runtime/SessionIsolation.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionIsolation.vitest.ts
@@ -112,7 +112,6 @@ function createLifecycleContext(
       modelInfo,
       {
         logger: noopTrace,
-        runtimeHost,
         storageKey,
         streamId,
       },

--- a/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
@@ -108,7 +108,7 @@ function createCtx(overrides?: { logger?: TraceEmitter }): {
     attachedMemoryMisses: [],
     usageMonitor: new UsageMonitor(
       modelInfo,
-      { logger, runtimeHost: explicit.host, storageKey, streamId },
+      { logger, storageKey, streamId },
       { agentName: config.agent, agentCategory: setting.agentCategory },
     ),
     modelHandler: {

--- a/src/test-kernel/agent/runtime/UsageMonitorLastTotals.vitest.ts
+++ b/src/test-kernel/agent/runtime/UsageMonitorLastTotals.vitest.ts
@@ -21,11 +21,7 @@ import {
   type StreamTabId,
 } from '@shared/schemas';
 
-import {
-  createRecordingHost,
-  recordSessionEvents,
-  runEventsOfType,
-} from '../progressTestUtils';
+import { recordSessionEvents, runEventsOfType } from '../progressTestUtils';
 
 const modelInfo = {
   capabilities: {
@@ -45,7 +41,6 @@ const modelInfo = {
 };
 
 function createMonitorWithEvents() {
-  const { host } = createRecordingHost();
   const logger = new TraceEmitter();
   const hub = new SessionEventHub();
   const storageKey = 'usage-last-totals' as StorageKey;
@@ -56,7 +51,7 @@ function createMonitorWithEvents() {
   );
   const monitor = new UsageMonitor(
     modelInfo,
-    { logger, runtimeHost: host, storageKey, streamId },
+    { logger, storageKey, streamId },
     { agentName: 'assistant', agentCategory: AgentCategory.ToolUse },
   );
   return {


### PR DESCRIPTION
Closes #8803

## Summary

- remove the unread `runtimeHost` dependency from `UsageMonitorContext`
- remove the unread `attachedMemoryMisses` value from `ToolUseServices`
- delete the corresponding fixture ceremony while retaining the real `AgentLaunchContext.attachedMemoryMisses` result path

## Design

This shrinks both service-context contracts to the dependencies their consumers actually read. It adds no compatibility shim, facade, or replacement abstraction, and does not change runtime behavior or wire formats.

Line accounting: 15 lines deleted, 4 inserted, 0 relocated; net -11 lines.

The adjacent #8842 change to `AgentLaunchContext` merged before this branch was published; this branch is rebased on that result.

No changelog entry is needed because this is an internal contract cleanup with no user-visible change.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (passes with one unrelated existing warning in `AgentCreatorToolCatalogParity.vitest.mts`)
- `npm run check:dead-code-ratchet`
- `corepack pnpm exec vitest run src/test-kernel/agent/runtime/UsageMonitorLastTotals.vitest.ts src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts src/test-kernel/agent/runtime/SessionIsolation.vitest.ts src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts` (43 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No runtime or wire-format behavior change—only unused interface fields and test fixtures are removed.
> 
> **Overview**
> Internal contract cleanup that removes dependencies nothing in these paths was reading.
> 
> **`UsageMonitor`** no longer takes `runtimeHost` on `UsageMonitorContext`; construction at launch and in tests now passes only `logger`, `storageKey`, and `streamId`.
> 
> **`ToolUseServices`** drops the unused `attachedMemoryMisses` field (and its type import). **`AgentLaunchContext.attachedMemoryMisses`** is unchanged and still feeds lifecycle/terminal results.
> 
> Tests shed `createRecordingHost` / `runtimeHost` wiring where it only existed for `UsageMonitor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d9a12adf1aad29c6a0b89123ad6cdf189067146. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->