### PR TITLE
feat(cli): add transient status notices

### DIFF
--- a/docs/proposals/cli-slash-output-ephemerality.md
+++ b/docs/proposals/cli-slash-output-ephemerality.md
@@ -1,0 +1,227 @@
+# Slash-command output redesign: busy-forms + transientNotice + archival outcome lines
+
+Winner of a 4-proposal / 3-judge design tournament (2026-07-18) on making texra CLI
+slash-command output ephemeral. Base: the "archival-first" proposal (unanimous winner,
+aggregate 22/23/21), with judge grafts folded in and robustness failure modes resolved.
+Scope: `packages/cli/src/chat/tui/` only. Headless (`texra run`, `--print`) untouched
+by construction.
+
+## Contract
+
+Three surfaces, one job each:
+
+- **Scrollback** (root `<Static>`) persists only rows with archaeology value: one
+  outcome line per real state change, and full dumps only when the user explicitly
+  asked to record a snapshot (`/status`, `/auth`).
+- **Foreground surface** (`App.tsx` `renderForegroundSurface`) hosts progress and
+  reference text: forms gain a submit-side busy phase; help-style dumps get a
+  hard-capped InfoPane.
+- **Status bar** carries regenerable hints via a `transientNotice` TTL slot
+  generalized from the exit-hint pipe.
+
+## 1. Primitives (each with the existing code it extends, verified)
+
+### 1.1 `transientNotice` status-bar slot
+
+`{text: string, resumeId?: string, expiresAt: number} | undefined`, single-slot,
+last-writer-wins, producer-armed `setTimeout` TTL.
+
+- **Extends:** `state/cliState.ts:447-453` (`PENDING_EXIT_HINT`/`PENDING_EXIT_RESUME_ID`
+  fold into it). Caveat (verified): `pendingExitHint` is a **boolean** with the hint text
+  living in `panes/statusBarDisplay.ts:699/759/849`, so this is a small rewrite of that
+  path, not a field rename.
+- **Consumer pipe unchanged:** `panes/StatusBar.tsx:61-62` reads the signal;
+  `statusBarDisplay.ts` keeps its special resume-id layout by reading the structured
+  `resumeId?` field (do not fold resume-id into free text).
+- **Producer precedent:** `runChatTui.tsx:957-963` `armExit()` TTL pattern; the
+  exit-clear at `runChatTui.tsx:879-883` retargets to the new slot.
+- **Reset:** cleared in `resetCliState` exactly where `pendingExitHint.set(false)` sits
+  today (`cliState.ts:533-534`).
+- **Truncation:** notice text truncates against available StatusBar width via the
+  existing fitted-segment logic (`statusBarDisplay.ts:849` already implements
+  hint-preempts-fitted-left).
+- **Policy:** nothing load-bearing routes here. Only regenerable chatter: usage strings
+  on parse-fail, unknown-command suggestion, guard refusals ("agent is fixed for this
+  session", `handleSlashCommand.ts:118`), the `/key` no-arg safety notice (`:141`),
+  picker cancels.
+
+### 1.2 Submit-side busy phase (`completion: 'busy'`) in `formSelectionHandler`
+
+Form stays mounted while the selected action runs; FormFrame renders spinner + a
+progress-line slot; input is hard-disabled (no re-submit, no navigation) except Esc.
+
+- **Extends:** `commands/registerBuiltins.tsx:58-86` (`formSelectionHandler`, today
+  `'afterAction' | 'beforeAction'`). `'beforeAction'` on Login/Logout/ModelAccess
+  adapters exists only because progress had nowhere to render but scrollback; those
+  three flip to `'busy'`. `'beforeAction'` stays for Memory/Resume/Skills/Approval
+  (instant actions).
+- **Chrome:** mirrors `forms/_shared/FormFrame.tsx:67` `renderAsyncListFormTransient`
+  (the load-side spinner, wired in `ListForm.tsx:253`), reused for the submit side.
+- **Progress feed:** new `formProgress` signal in `cliState.ts` (registered via
+  `registerCliStateResetHook`). The three `writeProgress` injection sites retarget to
+  it: `handlers/loginCommands.ts:61` (`signInCliChatGpt`), the device-code/auth-url
+  callbacks at `loginCommands.ts:83-99`, and `handlers/apiModeCommands.ts:121`
+  (`selectCliModelAccessRoute`). `runtime/chatgptLogin.ts` / `supabaseAuth.ts` keep
+  their injected-callback contracts, so headless `texra login` stdout is untouched.
+- **Copyability:** while a device code or manual URL is displayed, the spinner freezes
+  (no repaint churn under mouse selection — selection over a repainting live region
+  tears).
+- **Hold-open:** if a device code or manual URL was shown, the success/error frame
+  stays open until an explicit keypress; otherwise it closes on settle.
+- **Generation gating** (mechanism verified at `cliState.ts:507`): the handler captures
+  `getCliStateGeneration()` at submit; every progress write, outcome append, and notice
+  set is dropped if the generation changed (a `/clear` mid-login can never stamp a
+  stale row into the fresh session).
+- **Cancellation:** Esc during busy calls an optional `abort()` the action may provide
+  (AbortSignal threading into `signInCliSupabase`/`signInCliChatGpt` is a follow-up;
+  v1 fallback: detach — close the form, set
+  `transientNotice('Sign-in abandoned; the browser flow may still complete')`, and gate
+  the orphaned settle on generation + a per-submit token so it writes nothing).
+
+### 1.3 InfoPane foreground kind
+
+Fourth `renderForegroundSurface` case (alongside `form`/`approval`/`taskDetail`,
+verified at `App.tsx:416-448` and `appInteractionPolicy.ts:143-156`). Stateless
+`{title, lines, availableRows}` renderer; active pane in a `cliState.ts` signal
+registered in the reset-hook set.
+
+- **Hard caps (the anti-pager rule):** Esc-only dismiss, viewport-budgeted; if content
+  exceeds `availableRows`, fall back to the scrollback dump. No scroll keys, no
+  search — the terminal owns those.
+- **Hosts:** `/help` (`handleSlashCommand.ts:100`), `/goal` help (`:228`),
+  `/memory list`/`preview` (`handlers/memoryCommands.ts`). Content builders
+  (`formatSlashCommandHelp`, `GOAL_MODE_HELP`) are reused as-is.
+- **3 callers** on day one; clears the abstraction-cost guardrail.
+
+### 1.4 Registry-declared dispatch `{argHandler?, formName?, echo}`
+
+Registry entries (`commands/slashRegistry.ts` shape, registered in
+`registerBuiltins.tsx:320-463`) gain `argHandler` and `echo: 'ifPersists' | 'never'`.
+`handleSlashCommand.ts` collapses its 7 hand-rolled
+`if (!rest) openCanonicalSlashForm else handler(rest)` arms (agent :116-126,
+model :127, api :130-138, login :150-156, logout :157-163, approval :164-170,
+resume :230-241, memory :243-253) into one generic loop, and the hardcoded echo
+skip-list (:91-97) dies.
+
+- **Error sink:** `runGuardedSlashCommand` (`handleSlashCommand.ts:52-60`) becomes the
+  sole error sink and lazily emits the typed-line echo immediately before persisting
+  any error row, so failures are never context-free even for `echo:'never'` commands.
+  Only the guard and the outcome writer emit echoes, both centralized.
+- Hand-rolled catch tails in `agentModelCommands.ts` and `loginCommands.ts:139-141`
+  route through it and are deleted.
+
+## 2. Per-command behavior
+
+| Command                      | Ephemeral behavior                                                                                                                                                                                                             | Persists in scrollback                                                                                                                                                         |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `/login`                     | LoginForm stays mounted (busy); "Opening browser...", select-account warning, device code, manual URL render in the form's progress slot; spinner frozen while code/URL shown; frame held open on settle if code/URL was shown | Echo + one line: `Signed in with ChatGPT as X (Codex models enabled)` or the TeXRA equivalent. **Failure row includes the manual sign-in URL** so it stays copyable/searchable |
+| `/logout`                    | Busy form via logout picker                                                                                                                                                                                                    | Echo + one line: `Signed out of ChatGPT (X)`; relay-token caveat folded into the line when applicable                                                                          |
+| `/auth`                      | None (explicit snapshot request)                                                                                                                                                                                               | Echo + full dump via the one shared status assembly (see DRY 3)                                                                                                                |
+| `/api` (bare or `status`)    | None                                                                                                                                                                                                                           | Echo + the same shared dump as `/auth` (the `apiModeCommands.ts:101-113` assembly folds into `/auth`'s)                                                                        |
+| `/api <route>`               | Route picker/arg path runs busy with `writeProgress` retargeted from `:121`                                                                                                                                                    | Echo + one outcome line (`Model access via API keys`), incl. model-reconcile notice                                                                                            |
+| `/key`                       | Masked form unchanged; no-arg safety notice (`:141`) becomes transientNotice                                                                                                                                                   | One line `Saved the X API key` (keeps the `registerBuiltins.tsx:200-209` precedent); typed input never echoed                                                                  |
+| `/model`                     | Picker unchanged; bad-arg usage → transientNotice; cancel → nothing                                                                                                                                                            | Echo + `Root model set to X`                                                                                                                                                   |
+| `/agent`                     | Picker unchanged; fixed-session guard (`:118`) → transientNotice                                                                                                                                                               | Echo + `Root agent set to X`                                                                                                                                                   |
+| `/approval`                  | Picker unchanged; usage → transientNotice                                                                                                                                                                                      | Echo + one-line mode confirmation                                                                                                                                              |
+| `/yolo`                      | Direct toggle                                                                                                                                                                                                                  | Echo + one-line confirmation                                                                                                                                                   |
+| `/help`                      | InfoPane; overflow falls back to scrollback dump                                                                                                                                                                               | Nothing (echo:'never')                                                                                                                                                         |
+| `/status`                    | None (point-in-time snapshot is the archaeology)                                                                                                                                                                               | Echo + full dump, unchanged                                                                                                                                                    |
+| `/goal`                      | Help text in InfoPane                                                                                                                                                                                                          | Goal set/clear: echo + one line                                                                                                                                                |
+| `/memory`                    | list/preview in InfoPane; mutations direct                                                                                                                                                                                     | Mutations: echo + one outcome line. list/preview: nothing                                                                                                                      |
+| `/resume`                    | Picker unchanged; invalid-id (`:237`) persists as error via guard                                                                                                                                                              | Echo + resume outcome (session switch is archaeology)                                                                                                                          |
+| `/config` `/tools` `/skills` | Pure overlays, unchanged                                                                                                                                                                                                       | Nothing at all (echo:'never'; kills orphan `> /config` rows)                                                                                                                   |
+| `/compact`                   | `appendTranscript` injection (`:260`) stays scrollback — compaction is a run-affecting fact                                                                                                                                    | Echo + compaction notice, unchanged                                                                                                                                            |
+| unknown / unavailable        | Suggestion → transientNotice; hard failures persist via guard (with lazy echo)                                                                                                                                                 | Error row only on real failure                                                                                                                                                 |
+
+## 3. DRY deletions
+
+1. **7 picker-vs-arg switch arms** in `handleSlashCommand.ts` → one registry dispatch loop (~70 LOC).
+2. **Echo skip-list** (`:91-97`) → registry `echo` field + guard's lazy error-echo (~10).
+3. **Three hand-built `lines.push + join('\n') + append` status assemblies**
+   (`loginCommands.ts:151-194` logout tail, `apiModeCommands.ts:101-113` and `:132-137`)
+   → one shared status-lines helper over `loadCliApiStatusLines`/`loadCliModelAccessOverview`,
+   serving `/auth`, `/api`, `/status`, and the logout outcome (~40).
+4. **Hand-rolled catch tails** (`agentModelCommands.ts`, `loginCommands.ts:139-141`)
+   → `runGuardedSlashCommand` sole sink (~25).
+5. **Login progress chatter** (`loginStartMessage` at `loginCommands.ts:46-55` +
+   `:79/84/97/131` appends) → formProgress retarget; `loginStartMessage` becomes the
+   busy frame's title (~30).
+6. **`'beforeAction'` on Login/Logout/ModelAccess adapters** — its only reason to exist
+   (progress had nowhere to go) disappears; mode retained for the instant-action forms.
+7. **`pendingExitHint`/`pendingExitResumeId`** fold into `transientNotice{resumeId?}`
+   incl. the `runChatTui.tsx:870-883` timer bookkeeping (~20, partially offset by the
+   statusBarDisplay rewrite).
+8. **Usage-constant append-on-parse-fail triplet** (`CHAT_LOGIN_USAGE`,
+   `CHAT_LOGOUT_USAGE`, `MODEL_ACCESS_USAGE`) → transientNotice via one guard-level
+   path (~10).
+
+## 4. Honest net-LOC estimate
+
+Added: busy phase + formProgress signal + FormFrame submit slot + generation/token
+gating ~90; InfoPane ~70; transientNotice slice + StatusBar/statusBarDisplay rewrite
+~45; registry fields + dispatch loop ~30. **~235 added.**
+Deleted: items above ~205. **Net ≈ +30 LOC**, worse (up to +60) if AbortSignal
+threading lands in the same change. The payoff is behavioral (login chatter gone,
+orphan echoes gone, clean command→outcome pairs) plus real 3-caller dedup; every new
+primitive has 3+ callers on day one.
+
+## 5. Edge cases
+
+- **Headless parity.** All primitives are tui-scoped signals + Ink components.
+  `chatgptLogin.ts`/`supabaseAuth.ts` keep injected callbacks; headless `texra login`
+  still passes its own stdout writer. No change to `texra run`/`--print` byte output.
+- **/clear mid-flight.** `resetCliState` bumps `CLI_STATE_GENERATION`
+  (`cliState.ts:518`) and clears `activeForm`; `formProgress` + InfoPane +
+  `transientNotice` register reset hooks. Every busy-phase settle/progress/outcome
+  write checks captured generation and no-ops when stale. Nothing ghosts into the new
+  session.
+- **Resize.** Busy forms, InfoPane, and the notice are ordinary live-region JSX
+  recomputed from `availableRows`/columns; the vendored-ink full repaint handles them
+  free. Nothing finalized is parked in the live region: busy progress is in-flight by
+  definition, InfoPane is a view, the notice is TTL'd.
+- **Approval vs busy form.** Verified: `appInteractionPolicy.ts:152-154` currently
+  ranks `form` above `approval`, so a long-lived busy login would starve an approval.
+  Rule: `foregroundSurfaceKind` gains a `formBusy` input; when
+  `pendingApproval && formBusy`, approval wins and the busy form restores after the
+  decision (its state lives in signals, remount is free). Short-lived pickers keep
+  today's ordering.
+- **Ctrl-C mid-login.** First Ctrl-C behaves like Esc-during-busy: abort if available,
+  else detach + notice; the busy form never swallows the existing armExit
+  double-Ctrl-C exit path (`runChatTui.tsx:957`), which now writes the exit hint
+  through `transientNotice{resumeId}`. Sync teardown on exit is unaffected (no new
+  terminal modes).
+- **Notice overwrite.** Last-writer-wins is accepted and documented (exit-hint
+  precedent); nothing load-bearing routes there, so a lost hint is regenerable.
+
+## 6. Ordered PR plan
+
+1. **PR1 — transientNotice.** Add the slot; rewrite exit-hint path (`cliState.ts`,
+   `runChatTui.tsx:870-963`, `StatusBar.tsx`, `statusBarDisplay.ts`) onto it with
+   structured `resumeId`; move guard refusals/usage/unknown-suggestion to notices.
+   Self-contained, deletes the bespoke fields.
+2. **PR2 — registry dispatch + guard echo.** `{argHandler, echo}` fields, collapse the
+   7 switch arms, guard becomes sole error sink with lazy error-echo, delete catch
+   tails and the echo skip-list. Behavior-preserving except orphan-echo removal for
+   overlays.
+3. **PR3 — shared status assembly.** One helper over
+   `loadCliApiStatusLines`/`loadCliModelAccessOverview`; `/auth`, `/api` status,
+   logout tail converge; `/status` unchanged.
+4. **PR4 — busy phase.** `'busy'` completion mode + `formProgress` + FormFrame submit
+   slot + generation/token gating + spinner-freeze + hold-open + failure-row URL;
+   retarget the two login/api `writeProgress` sites; flip Login/Logout/ModelAccess off
+   `'beforeAction'`. Includes the `foregroundSurfaceKind` `formBusy` preemption rule.
+5. **PR5 — InfoPane.** New foreground kind; move `/help`, `/goal` help,
+   `/memory list|preview` into it with overflow fallback.
+6. **PR6 (optional follow-up) — AbortSignal threading** into
+   `signInCliSupabase`/`signInCliChatGpt` to upgrade Esc from detach to true cancel
+   (touches `runtime/`, so isolated deliberately).
+
+Each PR is independently shippable; PR4 depends on PR1 (notices for detach fallback)
+and PR2 (guard sink); PR5 depends on PR2 (echo policy). Changelog note in the PR4/PR5
+release: `/help` and login progress no longer persist to scrollback.
+
+Key verified files: `packages/cli/src/chat/tui/commands/handleSlashCommand.ts`,
+`commands/registerBuiltins.tsx`, `commands/handlers/loginCommands.ts`,
+`commands/handlers/apiModeCommands.ts`, `state/cliState.ts`, `App.tsx`,
+`appInteractionPolicy.ts`, `panes/StatusBar.tsx`, `panes/statusBarDisplay.ts`,
+`forms/_shared/FormFrame.tsx`, `forms/_shared/ListForm.tsx`, `runChatTui.tsx`.

--- a/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
+++ b/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
@@ -13,6 +13,7 @@ import { requestCliCompaction } from '../state/compactionRequest';
 import {
   activeStreamId as activeStreamIdSignal,
   sessionMeta,
+  setTransientNotice,
   streamAccessTarget,
   streams,
 } from '../state/cliState';
@@ -67,11 +68,11 @@ export async function handleTuiSlashCommand(
   const parsed = parseSlashInput(line);
   if (!parsed) {
     if (!redactedIntent) return false;
-    appendLocalAssistantTranscript(
+    setTransientNotice(
       `For safety, /${redactedIntent.name} accepts credentials only through its masked form.`,
     );
     if (!openRegisteredCliSlashForm(redactedIntent, '')) {
-      appendLocalAssistantTranscript(
+      setTransientNotice(
         `/${redactedIntent.name} is not available in this CLI view yet.`,
       );
     }
@@ -115,7 +116,7 @@ export async function handleTuiSlashCommand(
       return true;
     case 'agent':
       if (!chatTuiCanStartRootRun(context.session) && rest) {
-        appendLocalAssistantTranscript(
+        setTransientNotice(
           'The agent is fixed for this chat session. Start a new chat to use a different agent.',
         );
       } else if (rest) {
@@ -138,7 +139,7 @@ export async function handleTuiSlashCommand(
       return true;
     case 'key':
       if (rest) {
-        appendLocalAssistantTranscript(
+        setTransientNotice(
           'For safety, `/key` does not accept a key as an argument. Enter it in the masked form.',
         );
       }
@@ -265,7 +266,7 @@ export async function handleTuiSlashCommand(
         if (openRegisteredCliSlashForm(registered, parsed.remainder)) {
           return true;
         }
-        appendLocalAssistantTranscript(
+        setTransientNotice(
           `/${parsed.name} is registered but is not available in this CLI view yet.`,
         );
       } else {
@@ -273,7 +274,7 @@ export async function handleTuiSlashCommand(
         const didYouMean = suggestion
           ? ` Did you mean /${suggestion.name}?`
           : '';
-        appendLocalAssistantTranscript(
+        setTransientNotice(
           shouldRedactSlashInput(line)
             ? 'Unknown command with protected input. Type /help to list commands.'
             : `Unknown command: /${parsed.name}.${didYouMean} Type /help to list commands.`,

--- a/packages/cli/src/chat/tui/commands/handlers/apiModeCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/apiModeCommands.ts
@@ -19,7 +19,11 @@ import {
   selectCliModelAccessRoute,
 } from '@cli/runtime/modelAccessSelection';
 
-import { patchSessionMeta, sessionMeta } from '@cli/chat/tui/state/cliState';
+import {
+  patchSessionMeta,
+  sessionMeta,
+  setTransientNotice,
+} from '@cli/chat/tui/state/cliState';
 import { chatTuiCanStartRootRun } from '@cli/chat/tui/state/sessionRunState';
 import { appendLocalAssistantTranscript } from '@cli/chat/tui/state/transcript';
 import type { ApiProvider } from '@model/apiProviders';
@@ -126,7 +130,7 @@ export async function applyCliModelAccessSelection(
     return;
   }
 
-  appendLocalAssistantTranscript(MODEL_ACCESS_USAGE);
+  setTransientNotice(MODEL_ACCESS_USAGE);
 }
 
 export async function showCliAuthStatus(): Promise<void> {

--- a/packages/cli/src/chat/tui/commands/handlers/loginCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/loginCommands.ts
@@ -2,7 +2,7 @@ import {
   refreshCodexPreferenceViews,
   setCliCodexSubscription,
 } from '@cli/chat/tui/state/codexSubscription';
-import { sessionMeta } from '@cli/chat/tui/state/cliState';
+import { sessionMeta, setTransientNotice } from '@cli/chat/tui/state/cliState';
 import { appendLocalAssistantTranscript } from '@cli/chat/tui/state/transcript';
 import {
   loadCliApiStatusLines,
@@ -113,14 +113,14 @@ export async function loginFromChat(
 ): Promise<void> {
   const args = parseChatLoginSlashArgs(input);
   if (!args) {
-    appendLocalAssistantTranscript(CHAT_LOGIN_USAGE);
+    setTransientNotice(CHAT_LOGIN_USAGE);
     return;
   }
 
   // Match the CLI `login` guard: reject `--device` + `--no-browser` from the
   // user's parsed flags before the ChatGPT path can auto-resolve `device`.
   if (hasLoginTransportConflict(args)) {
-    appendLocalAssistantTranscript(LOGIN_TRANSPORT_CONFLICT_MESSAGE);
+    setTransientNotice(LOGIN_TRANSPORT_CONFLICT_MESSAGE);
     return;
   }
 
@@ -144,7 +144,7 @@ export async function loginFromChat(
 export async function logoutFromChat(input: string): Promise<void> {
   const target = parseCliLogoutTarget(input);
   if (!target) {
-    appendLocalAssistantTranscript(CHAT_LOGOUT_USAGE);
+    setTransientNotice(CHAT_LOGOUT_USAGE);
     return;
   }
 

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -10,8 +10,7 @@ import { approvalQueueStatus } from '../state/approvalQueue';
 import { terminalCapabilities } from '../state/terminalCapabilities';
 import {
   codexPreferenceVersion as codexPreferenceVersionSignal,
-  pendingExitHint as pendingExitHintSignal,
-  pendingExitResumeId as pendingExitResumeIdSignal,
+  transientNotice as transientNoticeSignal,
   activeStreamId as activeStreamIdSignal,
   rootRunPending as rootRunPendingSignal,
   rootRunStreamId as rootRunStreamIdSignal,
@@ -58,8 +57,7 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
   const parentStream = useSignal(parentStreamSignal);
   const childStreamEntries = useSignal(childStreamEntriesSignal);
   const sessionMeta = useSignal(sessionMetaSignal);
-  const pendingExitHint = useSignal(pendingExitHintSignal);
-  const pendingExitResumeId = useSignal(pendingExitResumeIdSignal);
+  const transientNotice = useSignal(transientNoticeSignal);
   const approvals = useSignal(approvalQueueStatus);
   const caps = useSignal(terminalCapabilities);
   const { columns } = useWindowSize();
@@ -155,8 +153,7 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     substate: statusSlice?.substate,
     elapsedMs: runStartedAt !== undefined ? now - runStartedAt : undefined,
     runningFrame: runStartedAt !== undefined ? loadingFrameAt(now) : undefined,
-    pendingExitHint,
-    pendingExitResumeId,
+    transientNotice,
     commandName: props.commandName,
     bypass: statusSlice?.bypass ?? NO_BYPASS,
     thinkingActive: statusSlice?.thinkingActive ?? false,

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -42,6 +42,7 @@ import {
   thinkingIndicatorVisible,
   type BypassState,
   type StreamSlice,
+  type TransientNotice,
 } from '../state/cliState';
 import {
   activeStreamScope,
@@ -80,8 +81,7 @@ export interface StatusBarDisplayInput {
    *  active, so "running" reads as alive rather than a static word. Omitted
    *  in tests/headless, same as `elapsedMs`. */
   readonly runningFrame?: string;
-  readonly pendingExitHint: boolean;
-  readonly pendingExitResumeId: string | undefined;
+  readonly transientNotice: TransientNotice | undefined;
   readonly commandName?: string;
   readonly bypass: BypassState;
   readonly thinkingActive?: boolean;
@@ -220,7 +220,6 @@ function roundSegment(
     : undefined;
 }
 
-const PENDING_EXIT_HINT_TEXT = 'Press Ctrl-C again to exit';
 // Lower values are removed first when the left status group exceeds the row.
 const STATUS_BAR_COMPACT_PRIORITY = {
   activeProcess: 10,
@@ -287,7 +286,7 @@ function statusBarInnerWidth(width: number | undefined): number | undefined {
     : Math.max(0, width - STATUS_BAR_HORIZONTAL_PADDING);
 }
 
-function fitPendingExitStatusBarLeftSegments(
+function fitTransientNoticeStatusBarLeftSegments(
   segments: readonly StatusBarSegment[],
   width: number | undefined,
 ): readonly StatusBarSegment[] {
@@ -696,10 +695,10 @@ const BYPASS_BADGES: ReadonlyArray<{
 // condition: an active pending-exit prompt always wins, then an actual
 // foreground surface, then the child list, and only then normal chat shortcuts.
 function resolveStatusBarBindings(input: StatusBarDisplayInput): string {
-  if (input.pendingExitHint && input.pendingExitResumeId) {
+  if (input.transientNotice?.resumeId) {
     return `Resume this session with: ${formatResumeCommand(
       input.commandName,
-      input.pendingExitResumeId,
+      input.transientNotice.resumeId,
       { approvalPolicy: input.approvalPolicy },
     )}`;
   }
@@ -756,8 +755,8 @@ export function buildStatusBarDisplay(
     });
   }
 
-  if (input.pendingExitHint) {
-    left.push({ text: PENDING_EXIT_HINT_TEXT, color: COLOR_WARNING });
+  if (input.transientNotice) {
+    left.push({ text: input.transientNotice.text, color: COLOR_WARNING });
     const queuedCount = input.queuedFollowUpMessages.length;
     if (queuedCount > 0) {
       // Exiting drops queued follow-ups silently — warn before the user
@@ -846,8 +845,8 @@ export function buildStatusBarDisplay(
       });
     }
   }
-  const fittedLeft = input.pendingExitHint
-    ? fitPendingExitStatusBarLeftSegments(left, input.width)
+  const fittedLeft = input.transientNotice
+    ? fitTransientNoticeStatusBarLeftSegments(left, input.width)
     : fitStatusBarLeftSegments(left, input.width);
 
   return {

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -288,14 +288,22 @@ function statusBarInnerWidth(width: number | undefined): number | undefined {
 
 function fitTransientNoticeStatusBarLeftSegments(
   segments: readonly StatusBarSegment[],
+  noticeIndex: number,
   width: number | undefined,
 ): readonly StatusBarSegment[] {
   const innerWidth = statusBarInnerWidth(width);
   if (innerWidth === undefined) return segments;
 
   const fitted = [...segments];
-  while (fitted.length > 2 && statusBarSegmentsWidth(fitted) > innerWidth) {
+  while (
+    fitted.length > noticeIndex + 1 &&
+    statusBarSegmentsWidth(fitted) > innerWidth
+  ) {
     fitted.pop();
+  }
+
+  if (noticeIndex > 1 && statusBarSegmentsWidth(fitted) > innerWidth) {
+    fitted.splice(1, noticeIndex - 1);
   }
 
   const icon = fitted[0];
@@ -692,10 +700,13 @@ const BYPASS_BADGES: ReadonlyArray<{
 ];
 
 // Which text occupies the bindings row is a priority order, not a single
-// condition: an active pending-exit prompt always wins, then an actual
+// condition: a resumable exit confirmation always wins, then an actual
 // foreground surface, then the child list, and only then normal chat shortcuts.
 function resolveStatusBarBindings(input: StatusBarDisplayInput): string {
-  if (input.transientNotice?.resumeId) {
+  if (
+    input.transientNotice?.kind === 'exit' &&
+    input.transientNotice.resumeId
+  ) {
     return `Resume this session with: ${formatResumeCommand(
       input.commandName,
       input.transientNotice.resumeId,
@@ -755,10 +766,12 @@ export function buildStatusBarDisplay(
     });
   }
 
+  let transientNoticeIndex: number | undefined;
   if (input.transientNotice) {
+    transientNoticeIndex = left.length;
     left.push({ text: input.transientNotice.text, color: COLOR_WARNING });
     const queuedCount = input.queuedFollowUpMessages.length;
-    if (queuedCount > 0) {
+    if (input.transientNotice.kind === 'exit' && queuedCount > 0) {
       // Exiting drops queued follow-ups silently — warn before the user
       // confirms with the second Ctrl-C.
       left.push({
@@ -845,9 +858,14 @@ export function buildStatusBarDisplay(
       });
     }
   }
-  const fittedLeft = input.transientNotice
-    ? fitTransientNoticeStatusBarLeftSegments(left, input.width)
-    : fitStatusBarLeftSegments(left, input.width);
+  const fittedLeft =
+    transientNoticeIndex !== undefined
+      ? fitTransientNoticeStatusBarLeftSegments(
+          left,
+          transientNoticeIndex,
+          input.width,
+        )
+      : fitStatusBarLeftSegments(left, input.width);
 
   return {
     left: fittedLeft,

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -104,8 +104,8 @@ import {
   patchSessionMeta,
   sessionMeta as sessionMetaSignal,
   streams as streamsSignal,
-  pendingExitHint,
-  pendingExitResumeId,
+  clearTransientNotice,
+  setTransientNotice,
 } from './state/cliState';
 import {
   childStreamEntries as childStreamEntriesSignal,
@@ -879,8 +879,7 @@ export async function runChat(
     if (pendingExitTimer) clearTimeout(pendingExitTimer);
     pendingExitTimer = undefined;
     exitArmed = false;
-    pendingExitHint.set(false);
-    pendingExitResumeId.set(undefined);
+    clearTransientNotice();
   };
   const removeProcessHandlers = (): void => {
     process.off('SIGINT', handleSigint);
@@ -956,10 +955,10 @@ export async function runChat(
   };
   const armExit = (): void => {
     exitArmed = true;
-    pendingExitHint.set(true);
-    pendingExitResumeId.set(
-      transcriptLifecycle.canResume ? session.executionId : undefined,
-    );
+    setTransientNotice('Press Ctrl-C again to exit', {
+      resumeId: transcriptLifecycle.canResume ? session.executionId : undefined,
+      ttlMs: 800,
+    });
     if (pendingExitTimer) clearTimeout(pendingExitTimer);
     pendingExitTimer = setTimeout(clearPendingExit, 800);
   };

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -106,6 +106,7 @@ import {
   streams as streamsSignal,
   clearTransientNotice,
   setTransientNotice,
+  transientNotice as transientNoticeSignal,
 } from './state/cliState';
 import {
   childStreamEntries as childStreamEntriesSignal,
@@ -151,6 +152,8 @@ import {
   type TuiSession,
 } from './state/sessionRunState';
 import type { SkillActivation } from './forms/SkillsListForm';
+
+const EXIT_CONFIRMATION_TTL_MS = 800;
 
 export interface ChatResult {
   exitCode: number;
@@ -867,20 +870,12 @@ export async function runChat(
   );
   inkRef.current = ink;
 
-  let pendingExitTimer: ReturnType<typeof setTimeout> | undefined;
-  let exitArmed = false;
   const terminalJobControlSupported = supportsTerminalJobControl();
   // Set once a signal exit (exitNow) starts: its ink.unmount() resolves
   // waitUntilExit and re-enters the post-waitUntilExit finally, so the finally
   // guards on this to avoid draining persistence / printing the resume hint a
   // second time.
   let exiting = false;
-  const clearPendingExit = (): void => {
-    if (pendingExitTimer) clearTimeout(pendingExitTimer);
-    pendingExitTimer = undefined;
-    exitArmed = false;
-    clearTransientNotice();
-  };
   const removeProcessHandlers = (): void => {
     process.off('SIGINT', handleSigint);
     process.off('SIGTERM', handleSigterm);
@@ -936,7 +931,7 @@ export async function runChat(
   const exitNow = (exitCode: number): void => {
     exiting = true;
     removeProcessHandlers();
-    clearPendingExit();
+    clearTransientNotice();
     ink.unmount();
     cleanupTerminalModes({ clearItermProgress });
     // Print the resume hint last, after Ink has torn down and the terminal modes
@@ -954,17 +949,15 @@ export async function runChat(
     ]).finally(() => process.exit(exitCode));
   };
   const armExit = (): void => {
-    exitArmed = true;
     setTransientNotice('Press Ctrl-C again to exit', {
+      kind: 'exit',
       resumeId: transcriptLifecycle.canResume ? session.executionId : undefined,
-      ttlMs: 800,
+      ttlMs: EXIT_CONFIRMATION_TTL_MS,
     });
-    if (pendingExitTimer) clearTimeout(pendingExitTimer);
-    pendingExitTimer = setTimeout(clearPendingExit, 800);
   };
   const handleSigint = (): void => {
     const sigintAction = chatTuiSigintAction({
-      exitArmed,
+      exitArmed: transientNoticeSignal.get()?.kind === 'exit',
       canStopActiveRun: canStopActiveRun(),
       resumableIdle: isResumableIdle(),
     });
@@ -1031,7 +1024,7 @@ export async function runChat(
   };
   function requestInputExit(): void {
     removeProcessHandlers();
-    clearPendingExit();
+    clearTransientNotice();
     ink.unmount();
   }
   // Ownership transfers right here, not any earlier: everything above this
@@ -1083,7 +1076,7 @@ export async function runChat(
     // async exit, dropping the flush and the signal exit code.
     if (!exiting) {
       removeProcessHandlers();
-      clearPendingExit();
+      clearTransientNotice();
       for (const dispose of disposers) dispose();
       await followUpQueue.onIdle();
       // A suspended (idle/WAITING) root session is resumable: its flow record

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -441,12 +441,29 @@ export const taskDetailExecutionId = TASK_DETAIL_EXECUTION_ID;
 // transientNoticeSlice
 // ---------------------------------------------------------------------------
 
-/** Regenerable status-bar text, optionally with a structured resume target. */
-export interface TransientNotice {
-  readonly text: string;
-  readonly resumeId?: string;
-  readonly expiresAt: number;
-}
+/** Regenerable status-bar text with explicit behavior for exit confirmation. */
+export type TransientNotice =
+  | {
+      readonly kind: 'message';
+      readonly text: string;
+      readonly expiresAt: number;
+    }
+  | {
+      readonly kind: 'exit';
+      readonly text: string;
+      readonly resumeId?: string;
+      readonly expiresAt: number;
+    };
+
+type TransientNoticeOptions =
+  | { readonly kind?: 'message'; readonly ttlMs?: number }
+  | {
+      readonly kind: 'exit';
+      readonly resumeId?: string;
+      readonly ttlMs?: number;
+    };
+
+const DEFAULT_TRANSIENT_NOTICE_TTL_MS = 4_000;
 
 const TRANSIENT_NOTICE = signal<TransientNotice | undefined>(undefined);
 let transientNoticeTimer: ReturnType<typeof setTimeout> | undefined;
@@ -457,21 +474,28 @@ export const transientNotice = TRANSIENT_NOTICE;
 /** Show a regenerable status-bar notice for a bounded interval. */
 export function setTransientNotice(
   text: string,
-  options: { readonly resumeId?: string; readonly ttlMs?: number } = {},
+  options: TransientNoticeOptions = {},
 ): void {
-  const expiresAt = Date.now() + (options.ttlMs ?? 4_000);
-  const notice: TransientNotice = {
-    text,
-    expiresAt,
-    resumeId: options.resumeId,
-  };
+  const ttlMs = options.ttlMs ?? DEFAULT_TRANSIENT_NOTICE_TTL_MS;
+  const expiresAt = Date.now() + ttlMs;
+  const singleLineText = text.replaceAll(/[ \t]*\r?\n[ \t]*/g, ' · ').trim();
+  const notice: TransientNotice =
+    options.kind === 'exit'
+      ? {
+          kind: 'exit',
+          text: singleLineText,
+          expiresAt,
+          resumeId: options.resumeId,
+        }
+      : { kind: 'message', text: singleLineText, expiresAt };
   if (transientNoticeTimer) clearTimeout(transientNoticeTimer);
   TRANSIENT_NOTICE.set(notice);
   transientNoticeTimer = setTimeout(() => {
-    if (TRANSIENT_NOTICE.get()?.expiresAt === expiresAt) {
+    if (TRANSIENT_NOTICE.get() === notice) {
       TRANSIENT_NOTICE.set(undefined);
+      transientNoticeTimer = undefined;
     }
-  }, options.ttlMs ?? 4_000);
+  }, ttlMs);
   transientNoticeTimer.unref?.();
 }
 

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -438,19 +438,49 @@ const TASK_DETAIL_EXECUTION_ID = signal<string | undefined>(undefined);
 export const taskDetailExecutionId = TASK_DETAIL_EXECUTION_ID;
 
 // ---------------------------------------------------------------------------
-// exitHintSlice
+// transientNoticeSlice
 // ---------------------------------------------------------------------------
 
-// Ctrl-C-to-exit resume hint: whether the next exit should surface a resume
-// id, and which run it points at.
+/** Regenerable status-bar text, optionally with a structured resume target. */
+export interface TransientNotice {
+  readonly text: string;
+  readonly resumeId?: string;
+  readonly expiresAt: number;
+}
 
-const PENDING_EXIT_HINT = signal<boolean>(false);
-const PENDING_EXIT_RESUME_ID = signal<string | undefined>(undefined);
+const TRANSIENT_NOTICE = signal<TransientNotice | undefined>(undefined);
+let transientNoticeTimer: ReturnType<typeof setTimeout> | undefined;
 
-/** Whether the next exit should surface a resume hint. */
-export const pendingExitHint = PENDING_EXIT_HINT;
-/** Which run the pending exit hint's resume id points at. */
-export const pendingExitResumeId = PENDING_EXIT_RESUME_ID;
+/** Single status-bar notice slot; later notices replace earlier ones. */
+export const transientNotice = TRANSIENT_NOTICE;
+
+/** Show a regenerable status-bar notice for a bounded interval. */
+export function setTransientNotice(
+  text: string,
+  options: { readonly resumeId?: string; readonly ttlMs?: number } = {},
+): void {
+  const expiresAt = Date.now() + (options.ttlMs ?? 4_000);
+  const notice: TransientNotice = {
+    text,
+    expiresAt,
+    resumeId: options.resumeId,
+  };
+  if (transientNoticeTimer) clearTimeout(transientNoticeTimer);
+  TRANSIENT_NOTICE.set(notice);
+  transientNoticeTimer = setTimeout(() => {
+    if (TRANSIENT_NOTICE.get()?.expiresAt === expiresAt) {
+      TRANSIENT_NOTICE.set(undefined);
+    }
+  }, options.ttlMs ?? 4_000);
+  transientNoticeTimer.unref?.();
+}
+
+/** Remove the current status-bar notice, including its pending expiry timer. */
+export function clearTransientNotice(): void {
+  if (transientNoticeTimer) clearTimeout(transientNoticeTimer);
+  transientNoticeTimer = undefined;
+  TRANSIENT_NOTICE.set(undefined);
+}
 
 // ---------------------------------------------------------------------------
 // codexPreferenceSlice
@@ -530,7 +560,6 @@ export function resetCliState(
   slashPaletteOpen.set(false);
   reverseSearchOpen.set(false);
   taskDetailExecutionId.set(undefined);
-  pendingExitHint.set(false);
-  pendingExitResumeId.set(undefined);
+  clearTransientNotice();
   for (const resetHook of RESET_HOOKS) resetHook();
 }

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
@@ -23,6 +23,7 @@ import {
   resetCliState,
   patchStream,
   streams,
+  transientNotice,
 } from '@cli/chat/tui/state/cliState';
 import * as apiStatus from '@cli/runtime/apiStatus';
 import * as chatGptLogin from '@cli/runtime/chatgptLogin';
@@ -156,7 +157,9 @@ describe('handleTuiSlashCommand', () => {
 
     expect(activeForm.get()?.commandName).toBe('key');
     expect(JSON.stringify(activeForm.get())).not.toContain(secret);
-    expect(lastEntryText()).toContain('does not accept a key as an argument');
+    expect(transientNotice.get()?.text).toContain(
+      'does not accept a key as an argument',
+    );
     expect(JSON.stringify([...streams.get().values()])).not.toContain(secret);
   });
 
@@ -221,7 +224,9 @@ describe('handleTuiSlashCommand', () => {
       ),
     ).toBe(true);
     expect(activeForm.get()).toBeUndefined();
-    expect(lastEntryText()).toContain('Unknown command with protected input');
+    expect(transientNotice.get()?.text).toContain(
+      'Unknown command with protected input',
+    );
   });
 
   it('redacts arbitrary concatenated key input without forcing the key form', async () => {

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -1264,6 +1264,7 @@ describe('CLI StatusBar display model', () => {
       statusInput({
         status: STREAM_PHASE.RUNNING,
         transientNotice: {
+          kind: 'exit',
           text: 'Press Ctrl-C again to exit',
           resumeId: 'abc123',
           expiresAt: 1,
@@ -1286,6 +1287,7 @@ describe('CLI StatusBar display model', () => {
       statusInput({
         status: STREAM_PHASE.RUNNING,
         transientNotice: {
+          kind: 'exit',
           text: 'Press Ctrl-C again to exit',
           resumeId: 'abc123',
           expiresAt: 1,
@@ -1304,6 +1306,7 @@ describe('CLI StatusBar display model', () => {
       statusInput({
         status: STREAM_PHASE.RUNNING,
         transientNotice: {
+          kind: 'exit',
           text: 'Press Ctrl-C again to exit',
           resumeId: 'abc123',
           expiresAt: 1,
@@ -1325,6 +1328,26 @@ describe('CLI StatusBar display model', () => {
           '2 queued follow-ups will be discarded',
       ),
     ).toMatchObject({ color: 'red' });
+  });
+
+  it('does not describe queued follow-ups as discarded for ordinary notices', () => {
+    const display = buildStatusBarDisplay(
+      statusInput({
+        transientNotice: {
+          kind: 'message',
+          text: 'Signed in successfully',
+          expiresAt: 1,
+        },
+        queuedFollowUpMessages: ['Continue with the proof.'],
+      }),
+    );
+
+    expect(display.left.map(statusBarSegmentText)).toContain(
+      'Signed in successfully',
+    );
+    expect(display.left.map(statusBarSegmentText)).not.toContain(
+      '1 queued follow-up will be discarded',
+    );
   });
 
   it('compacts token usage to a percentage before dropping it on narrow widths', () => {
@@ -1354,6 +1377,7 @@ describe('CLI StatusBar display model', () => {
       statusInput({
         status: STREAM_PHASE.RUNNING,
         transientNotice: {
+          kind: 'exit',
           text: 'Press Ctrl-C again to exit',
           resumeId: 'abc123',
           expiresAt: 1,
@@ -1369,6 +1393,25 @@ describe('CLI StatusBar display model', () => {
     expect(display.bindings).toBe(
       'Resume this session with: texra resume abc123',
     );
+  });
+
+  it('keeps a transient notice visible beside an ephemeral badge', () => {
+    const display = buildStatusBarDisplay(
+      statusInput({
+        transcriptMode: 'ephemeral',
+        transientNotice: {
+          kind: 'message',
+          text: 'Sign-in failed; try again',
+          expiresAt: 1,
+        },
+        width: 29,
+      }),
+    );
+
+    expect(display.left.map(statusBarSegmentText)).toEqual([
+      '◆',
+      'Sign-in failed; try again',
+    ]);
   });
 
   it('uses portable Esc labels for meta shortcuts on macOS', () => {

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -25,8 +25,7 @@ function statusInput(
 ): StatusBarDisplayInput {
   return {
     status: STREAM_PHASE.WAITING,
-    pendingExitHint: false,
-    pendingExitResumeId: undefined,
+    transientNotice: undefined,
     bypass: NO_BYPASS,
     queuedFollowUpMessages: [],
     usage: undefined,
@@ -1264,8 +1263,11 @@ describe('CLI StatusBar display model', () => {
     const display = buildStatusBarDisplay(
       statusInput({
         status: STREAM_PHASE.RUNNING,
-        pendingExitHint: true,
-        pendingExitResumeId: 'abc123',
+        transientNotice: {
+          text: 'Press Ctrl-C again to exit',
+          resumeId: 'abc123',
+          expiresAt: 1,
+        },
       }),
     );
 
@@ -1283,8 +1285,11 @@ describe('CLI StatusBar display model', () => {
     const display = buildStatusBarDisplay(
       statusInput({
         status: STREAM_PHASE.RUNNING,
-        pendingExitHint: true,
-        pendingExitResumeId: 'abc123',
+        transientNotice: {
+          text: 'Press Ctrl-C again to exit',
+          resumeId: 'abc123',
+          expiresAt: 1,
+        },
         commandName: 'texra-local',
       }),
     );
@@ -1298,8 +1303,11 @@ describe('CLI StatusBar display model', () => {
     const display = buildStatusBarDisplay(
       statusInput({
         status: STREAM_PHASE.RUNNING,
-        pendingExitHint: true,
-        pendingExitResumeId: 'abc123',
+        transientNotice: {
+          text: 'Press Ctrl-C again to exit',
+          resumeId: 'abc123',
+          expiresAt: 1,
+        },
         queuedFollowUpMessages: [
           'Keep the proof under one page.',
           'Also mention the finite monoid argument.',
@@ -1345,8 +1353,11 @@ describe('CLI StatusBar display model', () => {
     const display = buildStatusBarDisplay(
       statusInput({
         status: STREAM_PHASE.RUNNING,
-        pendingExitHint: true,
-        pendingExitResumeId: 'abc123',
+        transientNotice: {
+          text: 'Press Ctrl-C again to exit',
+          resumeId: 'abc123',
+          expiresAt: 1,
+        },
         width: 29,
       }),
     );

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -18,8 +18,10 @@ import {
   removeStream,
   resetCliState,
   patchStream,
+  setTransientNotice,
   setStreamStatusInCliState,
   streams,
+  transientNotice,
 } from '@cli/chat/tui/state/cliState';
 import {
   allocateConversationBottomPanelRows,
@@ -117,6 +119,15 @@ afterEach(() => {
 });
 
 describe('cliState Phase 4 fields', () => {
+  it('normalizes transient notices to the status bar single-line contract', () => {
+    setTransientNotice('Usage: /login target\n       /login chatgpt --device');
+
+    expect(transientNotice.get()).toMatchObject({
+      kind: 'message',
+      text: 'Usage: /login target · /login chatgpt --device',
+    });
+  });
+
   it('initialises every new slice with empty subagent/process/todo/plan/bypass defaults', () => {
     patchStream(root, (s) => ({ ...s, status: 'running' }));
     const slice = streams.get().get(root);


### PR DESCRIPTION
Closes #8808.

Adds the single-slot TTL-backed transientNotice status-bar state, including the structured resume id used by the Ctrl-C exit hint. Guard guidance, protected-input notices, unknown-command suggestions, and parse usage now avoid scrollback.

Verification:
- npm run compile:fast
- npm test
- npm run lint
- targeted StatusBar and SlashCommandDispatch Vitest suites
- npm run typecheck remains blocked by pre-existing errors in runChatTui.tsx:817 and OpenAIResponseMetadata.vitest.ts:105; no errors arise from these changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI-only UX change: scrollback vs status bar for hints; exit and SIGINT behavior preserved via structured exit notices and existing sigint logic.
> 
> **Overview**
> Introduces **PR1** of the CLI slash-output ephemerality design: a single-slot, TTL-backed **`transientNotice`** in `cliState` (`setTransientNotice` / `clearTransientNotice`), replacing **`pendingExitHint`** / **`pendingExitResumeId`**.
> 
> **Status bar:** `StatusBar` and `statusBarDisplay` consume the structured notice (`kind: 'message' | 'exit'`, optional **`resumeId`**). Exit confirmation still uses an 800ms TTL; ordinary notices default to 4s. Multi-line text is normalized to one line; narrow layouts keep the notice visible via updated fitting logic. Queued follow-up discard warnings apply only when **`kind === 'exit'`**.
> 
> **Slash commands:** Usage strings, guard refusals, `/key` safety text, unknown-command suggestions, and similar **regenerable** feedback now call **`setTransientNotice`** instead of **`appendLocalAssistantTranscript`** in `handleSlashCommand`, `loginCommands`, and `apiModeCommands`. Real outcomes and errors still persist in scrollback.
> 
> **TUI lifecycle:** `runChatTui` arms exit via **`setTransientNotice`**, clears on teardown, and treats an armed exit as **`transientNotice?.kind === 'exit'`** for double Ctrl-C handling. **`resetCliState`** clears the notice.
> 
> Adds a design proposal doc and updates Vitest coverage for notice-based dispatch and status-bar display.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b911c51000865957923ef06ed75e5a3c59dddc4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->