### PR TITLE
refactor(cli): declare slash dispatch in registry

### DIFF
--- a/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
+++ b/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
@@ -17,10 +17,7 @@ import {
   streams,
 } from '../state/cliState';
 import { terminalCapabilities } from '../state/terminalCapabilities';
-import {
-  appendLocalAssistantTranscript,
-  appendLocalUserTranscript,
-} from '../state/transcript';
+import { appendLocalAssistantTranscript } from '../state/transcript';
 import { formatSlashCommandHelp, GOAL_MODE_HELP } from './helpText';
 import { showCliAuthStatus } from './handlers/apiModeCommands';
 import { applyCliApprovalPolicySelection } from './handlers/approvalCommand';
@@ -28,7 +25,10 @@ import {
   openCanonicalSlashForm,
   type SlashCommandContext,
 } from './handlers/slashContext';
-import { openRegisteredCliSlashForm } from './slashForms';
+import {
+  appendSlashCommandEcho,
+  openRegisteredCliSlashForm,
+} from './slashForms';
 import {
   findSlashCommand,
   findRedactedSlashCommandInput,
@@ -38,10 +38,6 @@ import {
   suggestSlashCommand,
   type SlashCommand,
 } from './slashRegistry';
-
-function appendSlashCommandEcho(line: string): void {
-  if (!shouldRedactSlashInput(line)) appendLocalUserTranscript(line.trim());
-}
 
 /** Run a command body with centralized echo and error persistence. */
 async function runGuardedSlashCommand(
@@ -76,7 +72,11 @@ export async function handleTuiSlashCommand(
     setTransientNotice(
       `For safety, /${redactedIntent.name} accepts credentials only through its masked form.`,
     );
-    if (!openRegisteredCliSlashForm(redactedIntent, '')) {
+    if (
+      !openRegisteredCliSlashForm(redactedIntent, '', () =>
+        appendSlashCommandEcho(line),
+      )
+    ) {
       setTransientNotice(
         `/${redactedIntent.name} is not available in this CLI view yet.`,
       );
@@ -210,7 +210,11 @@ export async function handleTuiSlashCommand(
       return true;
     default: {
       if (registered) {
-        if (openRegisteredCliSlashForm(registered, parsed.remainder)) {
+        if (
+          openRegisteredCliSlashForm(registered, parsed.remainder, () =>
+            appendSlashCommandEcho(line),
+          )
+        ) {
           return true;
         }
         await runGuardedSlashCommand(

--- a/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
+++ b/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
@@ -88,15 +88,18 @@ export async function handleTuiSlashCommand(
   const rest = parsed.remainder.trim();
   const registered = findSlashCommand(command) ?? redactedIntent;
   const canonicalCommand = registered?.name ?? command;
-  if (rest && registered?.argHandler) {
-    await runGuardedSlashCommand(line, registered, () =>
-      registered.argHandler?.(rest, context),
+  const opensRegisteredForm =
+    registered?.formName !== undefined &&
+    (!rest || registered.formRemainders?.includes(rest.toLowerCase()));
+  if (opensRegisteredForm) {
+    openCanonicalSlashForm(registered.formName, registered, rest, () =>
+      appendSlashCommandEcho(line),
     );
     return true;
   }
-  if (!rest && registered?.formName) {
-    openCanonicalSlashForm(registered.formName, registered, rest, () =>
-      appendSlashCommandEcho(line),
+  if (rest && registered?.argHandler) {
+    await runGuardedSlashCommand(line, registered, () =>
+      registered.argHandler?.(rest, context),
     );
     return true;
   }

--- a/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
+++ b/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
@@ -1,7 +1,6 @@
 import { notifyFollowUpSent } from '@agent/followUp/ToolUseFollowUp';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { formatCliApprovalPolicy } from '@cli/runtime/approvalPolicyText';
-import { parseCliHistoryId } from '@cli/runtime/history';
 import { defaultShortcutModifierLabel } from '@cli/runtime/shortcutLabels';
 import { resolveCliModelAccessRoute } from '@cli/runtime/modelAccessRoute';
 import { isCodexSubscriptionActive } from '@model/codexSubscriptionActive';
@@ -17,24 +16,14 @@ import {
   streamAccessTarget,
   streams,
 } from '../state/cliState';
-import { chatTuiCanStartRootRun } from '../state/sessionRunState';
 import { terminalCapabilities } from '../state/terminalCapabilities';
 import {
   appendLocalAssistantTranscript,
   appendLocalUserTranscript,
 } from '../state/transcript';
 import { formatSlashCommandHelp, GOAL_MODE_HELP } from './helpText';
-import { applyInitialCliAgentSelection } from './handlers/agentModelCommands';
-import {
-  applyCliModelAccessSelection,
-  showCliAuthStatus,
-} from './handlers/apiModeCommands';
+import { showCliAuthStatus } from './handlers/apiModeCommands';
 import { applyCliApprovalPolicySelection } from './handlers/approvalCommand';
-import { loginFromChat, logoutFromChat } from './handlers/loginCommands';
-import {
-  showCliMemoryList,
-  showCliMemoryPreview,
-} from './handlers/memoryCommands';
 import {
   openCanonicalSlashForm,
   type SlashCommandContext,
@@ -47,15 +36,31 @@ import {
   parseSlashInput,
   shouldRedactSlashInput,
   suggestSlashCommand,
+  type SlashCommand,
 } from './slashRegistry';
 
-/** Run an async command body, surfacing any failure as a transcript message. */
+function appendSlashCommandEcho(line: string): void {
+  if (!shouldRedactSlashInput(line)) appendLocalUserTranscript(line.trim());
+}
+
+/** Run a command body with centralized echo and error persistence. */
 async function runGuardedSlashCommand(
+  line: string,
+  command: SlashCommand | undefined,
   action: () => void | Promise<void>,
+  persistsOnSuccess = true,
 ): Promise<void> {
+  let echoed = false;
+  const echo = (): void => {
+    if (echoed) return;
+    appendSlashCommandEcho(line);
+    echoed = true;
+  };
   try {
+    if (persistsOnSuccess && command?.echo === 'ifPersists') echo();
     await action();
   } catch (error: unknown) {
+    echo();
     appendLocalAssistantTranscript(toErrorMessage(error));
   }
 }
@@ -83,59 +88,37 @@ export async function handleTuiSlashCommand(
   const rest = parsed.remainder.trim();
   const registered = findSlashCommand(command) ?? redactedIntent;
   const canonicalCommand = registered?.name ?? command;
-  // Echo the slash input into the transcript so the user can see what they
-  // typed. Slash commands don't go through the agent run, so the usual
-  // USER_MESSAGE stream-log entry is never produced. Skip the echo for the
-  // exit commands (the TUI is tearing down); /clear still echoes because
-  // resetSessionForClear refuses while a run is active and surfaces an
-  // error — without the echo the user wouldn't see what triggered it.
-  if (
-    canonicalCommand !== 'exit' &&
-    canonicalCommand !== 'login' &&
-    !shouldRedactSlashInput(line)
-  ) {
-    appendLocalUserTranscript(line.trim());
+  if (rest && registered?.argHandler) {
+    await runGuardedSlashCommand(line, registered, () =>
+      registered.argHandler?.(rest, context),
+    );
+    return true;
+  }
+  if (!rest && registered?.formName) {
+    openCanonicalSlashForm(registered.formName, registered, rest, () =>
+      appendSlashCommandEcho(line),
+    );
+    return true;
   }
   switch (canonicalCommand) {
     case 'help': {
-      appendLocalAssistantTranscript(
-        formatSlashCommandHelp(listSlashCommands(), {
-          shortcutModifierLabel: defaultShortcutModifierLabel(),
-          shiftEnterNewline: terminalCapabilities.get().kittyKeyboard,
-        }),
+      await runGuardedSlashCommand(line, registered, () =>
+        appendLocalAssistantTranscript(
+          formatSlashCommandHelp(listSlashCommands(), {
+            shortcutModifierLabel: defaultShortcutModifierLabel(),
+            shiftEnterNewline: terminalCapabilities.get().kittyKeyboard,
+          }),
+        ),
       );
       return true;
     }
     case 'clear':
-      context.resetSession();
+      await runGuardedSlashCommand(line, registered, context.resetSession);
       return true;
     case 'exit':
       context.session.stopRequested = true;
       context.interruptActive();
       context.requestInputExit();
-      return true;
-    case 'agent':
-      if (!chatTuiCanStartRootRun(context.session) && rest) {
-        setTransientNotice(
-          'The agent is fixed for this chat session. Start a new chat to use a different agent.',
-        );
-      } else if (rest) {
-        applyInitialCliAgentSelection(rest, context);
-      } else {
-        openCanonicalSlashForm('agent', registered, rest);
-      }
-      return true;
-    case 'model':
-      openCanonicalSlashForm('model', registered, rest);
-      return true;
-    case 'api':
-      if (!rest) {
-        openCanonicalSlashForm('api', registered, rest);
-        return true;
-      }
-      await runGuardedSlashCommand(() =>
-        applyCliModelAccessSelection(rest, context),
-      );
       return true;
     case 'key':
       if (rest) {
@@ -146,34 +129,15 @@ export async function handleTuiSlashCommand(
       openCanonicalSlashForm('key', registered, '');
       return true;
     case 'auth':
-      await runGuardedSlashCommand(showCliAuthStatus);
-      return true;
-    case 'login':
-      if (!rest) {
-        openCanonicalSlashForm('login', registered, rest);
-        return true;
-      }
-      await loginFromChat(rest, context.cliContext);
-      return true;
-    case 'logout':
-      if (!rest) {
-        openCanonicalSlashForm('logout', registered, rest);
-        return true;
-      }
-      await logoutFromChat(rest);
-      return true;
-    case 'approval':
-      if (rest) {
-        applyCliApprovalPolicySelection(rest, context);
-      } else {
-        openCanonicalSlashForm('approval', registered, rest);
-      }
+      await runGuardedSlashCommand(line, registered, showCliAuthStatus);
       return true;
     case 'yolo':
-      applyCliApprovalPolicySelection(rest || 'yolo', context);
+      await runGuardedSlashCommand(line, registered, () =>
+        applyCliApprovalPolicySelection(rest || 'yolo', context),
+      );
       return true;
     case 'status':
-      await runGuardedSlashCommand(async () => {
+      await runGuardedSlashCommand(line, registered, async () => {
         const meta = sessionMeta.get();
         const activeStreamId = activeStreamIdSignal.get();
         const slice = activeStreamId
@@ -226,48 +190,35 @@ export async function handleTuiSlashCommand(
       });
       return true;
     case 'goal':
-      appendLocalAssistantTranscript(GOAL_MODE_HELP);
-      return true;
-    case 'resume': {
-      if (!rest) {
-        openCanonicalSlashForm('resume', registered, rest);
-        return true;
-      }
-      const id = parseCliHistoryId(rest);
-      if (!id) {
-        appendLocalAssistantTranscript(`Invalid execution id: ${rest}`);
-        return true;
-      }
-      await context.resumeExecution(id);
-      return true;
-    }
-    case 'memory':
-      await runGuardedSlashCommand(async () => {
-        if (!rest) {
-          openCanonicalSlashForm('memory', registered, rest);
-        } else if (rest.toLowerCase() === 'list') {
-          await showCliMemoryList();
-        } else {
-          await showCliMemoryPreview(rest);
-        }
-      });
+      await runGuardedSlashCommand(line, registered, () =>
+        appendLocalAssistantTranscript(GOAL_MODE_HELP),
+      );
       return true;
     case 'compact':
-      requestCliCompaction({
-        streamId: activeStreamIdSignal.get(),
-        requestManualCompaction: (streamId) =>
-          defaultSession().executions.requestManualCompaction(streamId),
-        notifyFollowUpSent,
-        appendTranscript: appendLocalAssistantTranscript,
-      });
+      await runGuardedSlashCommand(line, registered, () =>
+        requestCliCompaction({
+          streamId: activeStreamIdSignal.get(),
+          requestManualCompaction: (streamId) =>
+            defaultSession().executions.requestManualCompaction(streamId),
+          notifyFollowUpSent,
+          appendTranscript: appendLocalAssistantTranscript,
+        }),
+      );
       return true;
     default: {
       if (registered) {
         if (openRegisteredCliSlashForm(registered, parsed.remainder)) {
           return true;
         }
-        setTransientNotice(
-          `/${parsed.name} is registered but is not available in this CLI view yet.`,
+        await runGuardedSlashCommand(
+          line,
+          registered,
+          () => {
+            throw new Error(
+              `/${parsed.name} is registered but is not available in this CLI view yet.`,
+            );
+          },
+          false,
         );
       } else {
         const suggestion = suggestSlashCommand(command);

--- a/packages/cli/src/chat/tui/commands/handlers/agentModelCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/agentModelCommands.ts
@@ -17,6 +17,7 @@ import {
 import { chatTuiCanStartRootRun } from '@cli/chat/tui/state/sessionRunState';
 import { appendLocalAssistantTranscript } from '@cli/chat/tui/state/transcript';
 import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 import {
   CHAT_API_MODE_MODEL_RECOVERY,
   type SlashCommandContext,
@@ -116,7 +117,14 @@ export async function applyCliModelSelection(
 
   await activeFlow.switchModel(nextModel);
   setCliSessionModelOverride(nextModel);
-  await setCliHelperModel(nextModel);
+  try {
+    await setCliHelperModel(nextModel);
+  } catch (error: unknown) {
+    appendLocalAssistantTranscript(
+      `Model switched to ${nextModel}. Could not persist it as the default helper model: ${toErrorMessage(error)}`,
+    );
+    return;
+  }
 
   appendLocalAssistantTranscript(
     `Model switched to ${nextModel}. Future turns will use it.`,

--- a/packages/cli/src/chat/tui/commands/handlers/agentModelCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/agentModelCommands.ts
@@ -17,7 +17,6 @@ import {
 import { chatTuiCanStartRootRun } from '@cli/chat/tui/state/sessionRunState';
 import { appendLocalAssistantTranscript } from '@cli/chat/tui/state/transcript';
 import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
-import { toErrorMessage } from '@utils/errors/errorMessage';
 import {
   CHAT_API_MODE_MODEL_RECOVERY,
   type SlashCommandContext,
@@ -53,7 +52,7 @@ export function applyInitialCliAgentSelection(
 ): void {
   if (!chatTuiCanStartRootRun(context.session)) {
     appendLocalAssistantTranscript(
-      'Agent changes are only available before the first message. Use texra chat --agent <name> to choose a root agent in a new chat.',
+      'The agent is fixed for this chat session. Start a new chat to use a different agent.',
     );
     return;
   }
@@ -80,23 +79,19 @@ export async function applyCliModelSelection(
 ): Promise<void> {
   const nextModel = model.trim();
   if (chatTuiCanStartRootRun(context.session)) {
-    try {
-      const { apiMode } = sessionMeta.get();
-      const selection = await selectCliRunnableModel(nextModel, {
-        fallbackReason: 'explicit-override',
+    const { apiMode } = sessionMeta.get();
+    const selection = await selectCliRunnableModel(nextModel, {
+      fallbackReason: 'explicit-override',
+      apiMode,
+      noAvailableModelsMessage: formatCliNoAvailableModelsRecovery(
         apiMode,
-        noAvailableModelsMessage: formatCliNoAvailableModelsRecovery(
-          apiMode,
-          CHAT_API_MODE_MODEL_RECOVERY,
-        ),
-        agentCategory: AgentCategory.ToolUse,
-      });
-      await setCliHelperModel(selection.model);
-      setCliSessionModelOverride(selection.model);
-      appendLocalAssistantTranscript(`Root model set to ${selection.model}.`);
-    } catch (error: unknown) {
-      appendLocalAssistantTranscript(toErrorMessage(error));
-    }
+        CHAT_API_MODE_MODEL_RECOVERY,
+      ),
+      agentCategory: AgentCategory.ToolUse,
+    });
+    await setCliHelperModel(selection.model);
+    setCliSessionModelOverride(selection.model);
+    appendLocalAssistantTranscript(`Root model set to ${selection.model}.`);
     return;
   }
 
@@ -119,22 +114,9 @@ export async function applyCliModelSelection(
     return;
   }
 
-  try {
-    await activeFlow.switchModel(nextModel);
-    setCliSessionModelOverride(nextModel);
-  } catch (error: unknown) {
-    appendLocalAssistantTranscript(toErrorMessage(error));
-    return;
-  }
-
-  try {
-    await setCliHelperModel(nextModel);
-  } catch (error: unknown) {
-    appendLocalAssistantTranscript(
-      `Model switched to ${nextModel}. Could not persist it as the default helper model: ${toErrorMessage(error)}`,
-    );
-    return;
-  }
+  await activeFlow.switchModel(nextModel);
+  setCliSessionModelOverride(nextModel);
+  await setCliHelperModel(nextModel);
 
   appendLocalAssistantTranscript(
     `Model switched to ${nextModel}. Future turns will use it.`,

--- a/packages/cli/src/chat/tui/commands/handlers/loginCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/loginCommands.ts
@@ -130,15 +130,11 @@ export async function loginFromChat(
       : args;
   appendLocalAssistantTranscript(loginStartMessage(loginArgs));
 
-  try {
-    if (loginArgs.target === 'chatgpt') {
-      await loginToChatGptSubscription(loginArgs);
-      return;
-    }
-    await loginToTexraIncludedAccess(loginArgs);
-  } catch (error: unknown) {
-    appendLocalAssistantTranscript(toErrorMessage(error));
+  if (loginArgs.target === 'chatgpt') {
+    await loginToChatGptSubscription(loginArgs);
+    return;
   }
+  await loginToTexraIncludedAccess(loginArgs);
 }
 
 export async function logoutFromChat(input: string): Promise<void> {

--- a/packages/cli/src/chat/tui/commands/handlers/slashContext.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/slashContext.ts
@@ -40,7 +40,12 @@ export function openCanonicalSlashForm(
   commandName: string,
   registered: SlashCommand | undefined,
   remainder: string,
+  onPersist?: () => void,
 ): void {
-  if (registered && openRegisteredCliSlashForm(registered, remainder)) return;
+  if (
+    registered &&
+    openRegisteredCliSlashForm(registered, remainder, onPersist)
+  )
+    return;
   openCliSlashCommandForm(commandName, remainder);
 }

--- a/packages/cli/src/chat/tui/commands/handlers/slashContext.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/slashContext.ts
@@ -47,5 +47,5 @@ export function openCanonicalSlashForm(
     openRegisteredCliSlashForm(registered, remainder, onPersist)
   )
     return;
-  openCliSlashCommandForm(commandName, remainder);
+  openCliSlashCommandForm(commandName, remainder, onPersist);
 }

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -1,6 +1,7 @@
 // Registers the slash commands the input palette surfaces.
 
 import type { GetModelSwitchDisabledReason } from '@cli/runtime/modelAccess';
+import { parseCliHistoryId } from '@cli/runtime/history';
 import type { CliModelAccessRoute } from '@cli/runtime/modelAccessRoute';
 import type { CliLogoutTarget } from '@cli/runtime/loginOptions';
 import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
@@ -29,8 +30,20 @@ import {
   setCliSessionModelOverride,
 } from '../state/cliState';
 import { appendLocalAssistantTranscript } from '../state/transcript';
-import { applyCliProviderApiKey } from './handlers/apiModeCommands';
+import {
+  applyCliModelSelection,
+  applyInitialCliAgentSelection,
+} from './handlers/agentModelCommands';
+import {
+  applyCliModelAccessSelection,
+  applyCliProviderApiKey,
+} from './handlers/apiModeCommands';
+import { applyCliApprovalPolicySelection } from './handlers/approvalCommand';
 import { loginFromChat, logoutFromChat } from './handlers/loginCommands';
+import {
+  showCliMemoryList,
+  showCliMemoryPreview,
+} from './handlers/memoryCommands';
 import { registerSlashCommand, type SlashFormProps } from './slashRegistry';
 import { openCliSlashCommandForm } from './slashForms';
 
@@ -59,14 +72,19 @@ function formSelectionHandler<T>({
   action,
   onDone,
   onError,
+  onPersist,
+  echoOnPersist = false,
   completion = 'afterAction',
 }: {
   readonly action: (value: T) => void | Promise<void>;
   readonly onDone: (value: T) => void;
   readonly onError?: ErrorHandler;
+  readonly onPersist?: () => void;
+  readonly echoOnPersist?: boolean;
   readonly completion?: SelectionCompletion;
 }): (value: T) => void {
   return (value) => {
+    if (echoOnPersist) onPersist?.();
     if (completion === 'beforeAction') {
       onDone(value);
     }
@@ -76,7 +94,10 @@ function formSelectionHandler<T>({
     };
 
     void runAction()
-      .catch((error: unknown) => onError?.(error))
+      .catch((error: unknown) => {
+        if (!echoOnPersist) onPersist?.();
+        return onError?.(error);
+      })
       .finally(() => {
         if (completion === 'afterAction') {
           onDone(value);
@@ -153,6 +174,8 @@ export function registerBuiltinSlashCommands(options?: {
             selectable && canSelectModel()
               ? () => openModelSelectionForm()
               : props.onDone,
+          onPersist: props.onPersist,
+          echoOnPersist: props.echoOnPersist,
         })}
         onClose={() => props.onDone(undefined)}
       />
@@ -169,6 +192,8 @@ export function registerBuiltinSlashCommands(options?: {
           action: onModelAccessSelect,
           onDone: props.onDone,
           onError: options?.onError,
+          onPersist: props.onPersist,
+          echoOnPersist: props.echoOnPersist,
           completion: 'beforeAction',
         })}
         onCancel={() => props.onDone(undefined)}
@@ -186,6 +211,8 @@ export function registerBuiltinSlashCommands(options?: {
           action: (value) => options?.onApprovalPolicySelect?.(value),
           onDone: props.onDone,
           completion: 'beforeAction',
+          onPersist: props.onPersist,
+          echoOnPersist: props.echoOnPersist,
         })}
         onCancel={() => props.onDone(undefined)}
       />
@@ -221,6 +248,8 @@ export function registerBuiltinSlashCommands(options?: {
           onDone: props.onDone,
           onError: options?.onError,
           completion: 'beforeAction',
+          onPersist: props.onPersist,
+          echoOnPersist: props.echoOnPersist,
         })}
         onCancel={() => props.onDone(undefined)}
       />
@@ -236,6 +265,8 @@ export function registerBuiltinSlashCommands(options?: {
           onDone: props.onDone,
           onError: options?.onError,
           completion: 'beforeAction',
+          onPersist: props.onPersist,
+          echoOnPersist: props.echoOnPersist,
         })}
         onCancel={() => props.onDone(undefined)}
       />
@@ -257,6 +288,8 @@ export function registerBuiltinSlashCommands(options?: {
           action: onModelSelect,
           onDone: props.onDone,
           onError: options?.onError,
+          onPersist: props.onPersist,
+          echoOnPersist: props.echoOnPersist,
         })}
         onClose={() => props.onDone(undefined)}
       />
@@ -272,6 +305,8 @@ export function registerBuiltinSlashCommands(options?: {
           onDone: props.onDone,
           onError: options?.onError,
           completion: 'beforeAction',
+          onPersist: props.onPersist,
+          echoOnPersist: props.echoOnPersist,
         })}
         onClose={() => props.onDone(undefined)}
       />
@@ -287,6 +322,8 @@ export function registerBuiltinSlashCommands(options?: {
           onDone: props.onDone,
           onError: options?.onError,
           completion: 'beforeAction',
+          onPersist: props.onPersist,
+          echoOnPersist: props.echoOnPersist,
         })}
         onClose={() => props.onDone(undefined)}
       />
@@ -311,6 +348,8 @@ export function registerBuiltinSlashCommands(options?: {
           onDone: props.onDone,
           onError: options?.onError,
           completion: 'beforeAction',
+          onPersist: props.onPersist,
+          echoOnPersist: props.echoOnPersist,
         })}
         onClose={() => props.onDone(undefined)}
       />
@@ -321,17 +360,22 @@ export function registerBuiltinSlashCommands(options?: {
     name: 'help',
     description: 'Show available slash commands',
     category: 'session',
+    echo: 'never',
   });
   registerSlashCommand({
     name: 'clear',
     description: 'Start a fresh chat session',
     category: 'session',
+    echo: 'ifPersists',
   });
   registerSlashCommand({
     name: 'agent',
     description: 'List or choose the root agent',
     aliases: ['agents'],
     category: 'configuration',
+    echo: 'ifPersists',
+    argHandler: applyInitialCliAgentSelection,
+    formName: 'agent',
     formComponent: AgentListFormAdapter,
   });
   registerSlashCommand({
@@ -339,12 +383,18 @@ export function registerBuiltinSlashCommands(options?: {
     description: 'List available models',
     aliases: ['models'],
     category: 'configuration',
+    echo: 'ifPersists',
+    argHandler: applyCliModelSelection,
+    formName: 'model',
     formComponent: ModelListFormAdapter,
   });
   registerSlashCommand({
     name: 'api',
     description: 'Choose ChatGPT, included TeXRA, or personal model access',
     category: 'configuration',
+    echo: 'ifPersists',
+    argHandler: applyCliModelAccessSelection,
+    formName: 'api',
     formComponent: ModelAccessFormAdapter,
   });
   registerSlashCommand({
@@ -352,6 +402,8 @@ export function registerBuiltinSlashCommands(options?: {
     description: 'Add a provider API key with masked input',
     aliases: ['keys'],
     category: 'configuration',
+    echo: 'never',
+    formName: 'key',
     formComponent: ProviderApiKeyFormAdapter,
     formEscapeAction: 'close',
     redactInput: true,
@@ -360,23 +412,34 @@ export function registerBuiltinSlashCommands(options?: {
     name: 'auth',
     description: 'Show both accounts and active model access',
     category: 'account',
+    echo: 'ifPersists',
   });
   registerSlashCommand({
     name: 'login',
     description: 'Sign in to ChatGPT or Researcher Access',
     category: 'account',
+    echo: 'ifPersists',
+    argHandler: (remainder, context) =>
+      loginFromChat(remainder, context.cliContext),
+    formName: 'login',
     formComponent: LoginFormAdapter,
   });
   registerSlashCommand({
     name: 'logout',
     description: 'Sign out of one account or all accounts',
     category: 'account',
+    echo: 'ifPersists',
+    argHandler: logoutFromChat,
+    formName: 'logout',
     formComponent: LogoutFormAdapter,
   });
   registerSlashCommand({
     name: 'approval',
     description: 'Switch approval policy',
     category: 'configuration',
+    echo: 'ifPersists',
+    argHandler: applyCliApprovalPolicySelection,
+    formName: 'approval',
     formComponent: ApprovalPolicyFormAdapter,
     formEscapeAction: 'cancel',
   });
@@ -384,28 +447,44 @@ export function registerBuiltinSlashCommands(options?: {
     name: 'yolo',
     description: 'Auto-approve privileged actions',
     category: 'configuration',
+    echo: 'ifPersists',
   });
   registerSlashCommand({
     name: 'status',
     description: 'Show session details',
     category: 'session',
+    echo: 'ifPersists',
   });
   registerSlashCommand({
     name: 'goal',
     description: 'Explain autonomous goal mode',
     aliases: ['goals'],
     category: 'session',
+    echo: 'ifPersists',
   });
   registerSlashCommand({
     name: 'resume',
     description: 'Resume a previous session',
     category: 'session',
+    echo: 'ifPersists',
+    argHandler: async (remainder, context) => {
+      const id = parseCliHistoryId(remainder);
+      if (!id) throw new Error(`Invalid execution id: ${remainder}`);
+      await context.resumeExecution(id);
+    },
+    formName: 'resume',
     formComponent: ResumeListFormAdapter,
   });
   registerSlashCommand({
     name: 'memory',
     description: 'List stored memories',
     category: 'configuration',
+    echo: 'ifPersists',
+    argHandler: async (remainder) => {
+      if (remainder.toLowerCase() === 'list') await showCliMemoryList();
+      else await showCliMemoryPreview(remainder);
+    },
+    formName: 'memory',
     formComponent: MemoryListFormAdapter,
   });
   registerSlashCommand({
@@ -413,12 +492,16 @@ export function registerBuiltinSlashCommands(options?: {
     description: 'List available skills',
     aliases: ['skill'],
     category: 'configuration',
+    echo: 'never',
+    formName: 'skills',
     formComponent: SkillsListFormAdapter,
   });
   registerSlashCommand({
     name: 'tools',
     description: 'List or toggle external integrations',
     category: 'configuration',
+    echo: 'never',
+    formName: 'tools',
     formComponent: ToolsListFormAdapter,
   });
   // Only offer /config when the host wired the stores it reads/writes — a
@@ -446,6 +529,8 @@ export function registerBuiltinSlashCommands(options?: {
       description: 'View and toggle settings',
       aliases: ['settings'],
       category: 'configuration',
+      echo: 'never',
+      formName: 'config',
       formComponent: ConfigFormAdapter,
       formEscapeAction: 'close',
     });
@@ -454,11 +539,13 @@ export function registerBuiltinSlashCommands(options?: {
     name: 'compact',
     description: 'Request context compaction',
     category: 'session',
+    echo: 'ifPersists',
   });
   registerSlashCommand({
     name: 'exit',
     description: 'Exit the CLI session',
     aliases: ['quit'],
     category: 'session',
+    echo: 'never',
   });
 }

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -440,6 +440,7 @@ export function registerBuiltinSlashCommands(options?: {
     echo: 'ifPersists',
     argHandler: applyCliApprovalPolicySelection,
     formName: 'approval',
+    formRemainders: ['status'],
     formComponent: ApprovalPolicyFormAdapter,
     formEscapeAction: 'cancel',
   });
@@ -518,7 +519,10 @@ export function registerBuiltinSlashCommands(options?: {
             openExternalForm: (formName) =>
               openCliSlashCommandForm(formName, ''),
             onClose: () => props.onDone(undefined),
-            onError: options?.onError,
+            onError: async (error) => {
+              props.onPersist?.();
+              await options?.onError?.(error);
+            },
             onApiModePersonal: () => onModelAccessSelect('personal'),
           })}
         />

--- a/packages/cli/src/chat/tui/commands/slashForms.tsx
+++ b/packages/cli/src/chat/tui/commands/slashForms.tsx
@@ -5,6 +5,7 @@ import { findSlashCommand, type SlashCommand } from './slashRegistry';
 export function openRegisteredCliSlashForm(
   command: SlashCommand,
   remainder: string,
+  onPersist?: () => void,
 ): boolean {
   const Form = command.formComponent;
   if (!Form) return false;
@@ -15,6 +16,8 @@ export function openRegisteredCliSlashForm(
       <Form
         availableRows={availableRows}
         remainder={remainder.trimStart()}
+        onPersist={onPersist}
+        echoOnPersist={command.echo === 'ifPersists'}
         onDone={() => close()}
       />
     ),

--- a/packages/cli/src/chat/tui/commands/slashForms.tsx
+++ b/packages/cli/src/chat/tui/commands/slashForms.tsx
@@ -1,6 +1,15 @@
 import { activeForm } from '../state/cliState';
+import { appendLocalUserTranscript } from '../state/transcript';
 
-import { findSlashCommand, type SlashCommand } from './slashRegistry';
+import {
+  findSlashCommand,
+  shouldRedactSlashInput,
+  type SlashCommand,
+} from './slashRegistry';
+
+export function appendSlashCommandEcho(line: string): void {
+  if (!shouldRedactSlashInput(line)) appendLocalUserTranscript(line.trim());
+}
 
 export function openRegisteredCliSlashForm(
   command: SlashCommand,

--- a/packages/cli/src/chat/tui/commands/slashForms.tsx
+++ b/packages/cli/src/chat/tui/commands/slashForms.tsx
@@ -9,6 +9,12 @@ export function openRegisteredCliSlashForm(
 ): boolean {
   const Form = command.formComponent;
   if (!Form) return false;
+  let persisted = false;
+  const persist = (): void => {
+    if (persisted) return;
+    persisted = true;
+    onPersist?.();
+  };
   activeForm.set({
     commandName: command.name,
     escapeAction: command.formEscapeAction,
@@ -16,7 +22,7 @@ export function openRegisteredCliSlashForm(
       <Form
         availableRows={availableRows}
         remainder={remainder.trimStart()}
-        onPersist={onPersist}
+        onPersist={onPersist ? persist : undefined}
         echoOnPersist={command.echo === 'ifPersists'}
         onDone={() => close()}
       />
@@ -28,7 +34,10 @@ export function openRegisteredCliSlashForm(
 export function openCliSlashCommandForm(
   commandName: string,
   remainder: string,
+  onPersist?: () => void,
 ): boolean {
   const command = findSlashCommand(commandName);
-  return command ? openRegisteredCliSlashForm(command, remainder) : false;
+  return command
+    ? openRegisteredCliSlashForm(command, remainder, onPersist)
+    : false;
 }

--- a/packages/cli/src/chat/tui/commands/slashRegistry.ts
+++ b/packages/cli/src/chat/tui/commands/slashRegistry.ts
@@ -42,13 +42,8 @@ export interface SlashCommand {
   /** Additional exact remainders that open the canonical form. */
   readonly formRemainders?: readonly string[];
   /**
-   * Fire-and-forget handler. Receives the raw remainder of the command line
-   * (everything after the command name + whitespace).
-   */
-  readonly handler?: (remainder: string) => void;
-  /**
    * Optional structured-form renderer. When present, picking the command
-   * mounts this component instead of routing through `handler` / the input.
+   * mounts this component instead of routing through the input.
    */
   readonly formComponent?: React.ComponentType<SlashFormProps>;
   /**

--- a/packages/cli/src/chat/tui/commands/slashRegistry.ts
+++ b/packages/cli/src/chat/tui/commands/slashRegistry.ts
@@ -5,6 +5,8 @@ import {
   typoSuggestionThreshold,
 } from '@utils/text/editDistance';
 
+import type { SlashCommandContext } from './handlers/slashContext';
+
 /** Help-screen grouping. Uncategorized commands land in a trailing
  *  "Other" section, so plugin-style registrations stay visible. */
 export type SlashCommandCategory = 'session' | 'configuration' | 'account';
@@ -14,6 +16,8 @@ export type SlashCommandCategory = 'session' | 'configuration' | 'account';
  *  commit the user's selection or `onDone(undefined)` on cancel. */
 export interface SlashFormProps<T = unknown> {
   readonly onDone: (result: T | undefined) => void;
+  readonly onPersist?: () => void;
+  readonly echoOnPersist?: boolean;
   readonly remainder: string;
   readonly availableRows?: number;
 }
@@ -26,6 +30,15 @@ export interface SlashCommand {
   readonly aliases?: readonly string[];
   /** Where the command appears in the grouped `/help` listing. */
   readonly category?: SlashCommandCategory;
+  /** Dispatch policy for the typed command line in native scrollback. */
+  readonly echo?: 'ifPersists' | 'never';
+  /** Handle a non-empty command remainder. */
+  readonly argHandler?: (
+    remainder: string,
+    context: SlashCommandContext,
+  ) => void | Promise<void>;
+  /** Canonical structured form opened when the remainder is empty. */
+  readonly formName?: string;
   /**
    * Fire-and-forget handler. Receives the raw remainder of the command line
    * (everything after the command name + whitespace).

--- a/packages/cli/src/chat/tui/commands/slashRegistry.ts
+++ b/packages/cli/src/chat/tui/commands/slashRegistry.ts
@@ -39,6 +39,8 @@ export interface SlashCommand {
   ) => void | Promise<void>;
   /** Canonical structured form opened when the remainder is empty. */
   readonly formName?: string;
+  /** Additional exact remainders that open the canonical form. */
+  readonly formRemainders?: readonly string[];
   /**
    * Fire-and-forget handler. Receives the raw remainder of the command line
    * (everything after the command name + whitespace).

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -21,7 +21,10 @@ import {
 } from '../input/imagePasteQueue';
 import { ReverseSearch } from '../input/ReverseSearch';
 import { isCtrlInput } from '../input/inputKeys';
-import { openRegisteredCliSlashForm } from '../commands/slashForms';
+import {
+  appendSlashCommandEcho,
+  openRegisteredCliSlashForm,
+} from '../commands/slashForms';
 import { SlashPalette, slashPaletteOwnsArrows } from '../commands/SlashPalette';
 import { COLOR_BORDER, COLOR_HINT } from '../ui/colors';
 import { POINTER } from '../ui/glyphs';
@@ -38,7 +41,6 @@ import {
   reverseSearchOpen as reverseSearchOpenSignal,
   slashPaletteOpen,
 } from '../state/cliState';
-import { appendLocalUserTranscript } from '../state/transcript';
 import { useSignal } from '../state/useSignal';
 import type { CursorEdit } from '../input/textInputEditing';
 import type { InputHistory } from '../history/inputHistory';
@@ -297,11 +299,9 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
         // Structured forms own the screen — clear the input and let
         // the active-form signal mount the component (see App.tsx).
         clearDraft();
-        openRegisteredCliSlashForm(cmd, remainder, () => {
-          if (!shouldRedactSlashInput(commandLine)) {
-            appendLocalUserTranscript(commandLine.trim());
-          }
-        });
+        openRegisteredCliSlashForm(cmd, remainder, () =>
+          appendSlashCommandEcho(commandLine),
+        );
         return;
       }
       if (intent === 'submit') {

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -38,6 +38,7 @@ import {
   reverseSearchOpen as reverseSearchOpenSignal,
   slashPaletteOpen,
 } from '../state/cliState';
+import { appendLocalUserTranscript } from '../state/transcript';
 import { useSignal } from '../state/useSignal';
 import type { CursorEdit } from '../input/textInputEditing';
 import type { InputHistory } from '../history/inputHistory';
@@ -287,10 +288,20 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
       remainder: string,
     ): void => {
       if (cmd.formComponent) {
+        const commandLine = slashSubmitText(
+          draftValueRef.current,
+          cmd.name,
+          remainder,
+          typedName,
+        );
         // Structured forms own the screen — clear the input and let
         // the active-form signal mount the component (see App.tsx).
         clearDraft();
-        openRegisteredCliSlashForm(cmd, remainder);
+        openRegisteredCliSlashForm(cmd, remainder, () => {
+          if (!shouldRedactSlashInput(commandLine)) {
+            appendLocalUserTranscript(commandLine.trim());
+          }
+        });
         return;
       }
       if (intent === 'submit') {

--- a/src/test-kernel/cli/ConfigForm.vitest.mts
+++ b/src/test-kernel/cli/ConfigForm.vitest.mts
@@ -72,6 +72,7 @@ function renderConfigFormProps(): {
   ) => void | Promise<void>;
   resetValue?: (entry: StateSettingEntry) => void | Promise<void>;
   openForm?: (formName: string) => void;
+  onError?: (error: unknown) => void;
   formRenderers?: Readonly<
     Record<string, (onBack: () => void) => React.JSX.Element>
   >;
@@ -329,6 +330,23 @@ describe('/config slash command wiring', () => {
 
     expect(isStored(config, WorkspaceStateKey.GIT_MARK_COMMITS)).toBe(true);
     expect(props.readValue?.(markCommits)).toBe(false);
+  });
+
+  it('emits a deferred command echo before a configuration error', async () => {
+    const { stores } = makeFakeSettingsStores();
+    const events: string[] = [];
+    registerBuiltinSlashCommands({
+      getConfigStores: () => stores,
+      onError: () => {
+        events.push('error');
+      },
+    });
+    openCliSlashCommandForm('config', '', () => events.push('echo'));
+
+    await renderConfigFormProps().onError?.(new Error('write failed'));
+    await renderConfigFormProps().onError?.(new Error('write failed again'));
+
+    expect(events).toEqual(['echo', 'error', 'error']);
   });
 
   it('re-applies git author config so a toggle takes effect this session', async () => {

--- a/src/test-kernel/cli/InputBar.vitest.mts
+++ b/src/test-kernel/cli/InputBar.vitest.mts
@@ -1,6 +1,9 @@
 import { EventEmitter } from 'node:events';
 import { createRequire } from 'node:module';
 
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ImagePasteQueue } from '@cli/chat/tui/input/imagePasteQueue';
@@ -20,6 +23,12 @@ import {
   registerSlashCommand,
   unregisterSlashCommand,
 } from '@cli/chat/tui/commands/slashRegistry';
+import {
+  activeForm,
+  resetCliState,
+  streams,
+} from '@cli/chat/tui/state/cliState';
+import { CLI_LOCAL_STREAM_ID } from '@cli/chat/tui/state/transcript';
 
 const clipboardMock = vi.hoisted(() => ({
   attachClipboardImage: vi.fn(),
@@ -110,6 +119,55 @@ beforeEach(() => clipboardMock.attachClipboardImage.mockReset());
 afterEach(() => vi.clearAllMocks());
 
 describe('InputBar slash submit', () => {
+  it('threads deferred echo through a palette-opened form', async () => {
+    const ink = (await import(cliRequire.resolve('ink'))) as any;
+    const React = ((await import(cliRequire.resolve('react'))) as any).default;
+    registerSlashCommand({
+      name: 'model',
+      description: 'Choose a model',
+      echo: 'ifPersists',
+      formComponent: () => null,
+    });
+    const stdin = new FakeStdin();
+    const stdout = new FakeStdout();
+    const instance = ink.render(
+      React.createElement(InputBar, { onSubmit: vi.fn() }),
+      {
+        stdin,
+        stdout,
+        interactive: true,
+        exitOnCtrlC: false,
+        patchConsole: false,
+      },
+    );
+
+    try {
+      await waitFor(() => stdin.listenerCount('readable') > 0);
+      stdin.write('/model');
+      await waitFor(() => stdout.buf.includes('/model'));
+      stdin.write('\r');
+      await waitFor(() => activeForm.get()?.commandName === 'model');
+
+      const form = activeForm.get()?.render(() => undefined, 20) as {
+        props?: { onPersist?: () => void };
+      };
+      expect(streams.get().get(CLI_LOCAL_STREAM_ID)?.entries ?? []).toEqual([]);
+
+      form.props?.onPersist?.();
+
+      expect(
+        streams
+          .get()
+          .get(CLI_LOCAL_STREAM_ID)
+          ?.entries.map(({ role, text }) => ({ role, text })),
+      ).toEqual([{ role: 'user', text: '/model' }]);
+    } finally {
+      instance.unmount();
+      unregisterSlashCommand('model');
+      resetCliState();
+    }
+  });
+
   it('does not persist commands whose input may contain a credential', () => {
     registerSlashCommand({
       name: 'key',

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
@@ -12,6 +12,7 @@ import { type SlashCommandContext } from '@cli/chat/tui/commands/handlers/slashC
 import { registerBuiltinSlashCommands } from '@cli/chat/tui/commands/registerBuiltins';
 import {
   listSlashCommands,
+  registerSlashCommand,
   unregisterSlashCommand,
 } from '@cli/chat/tui/commands/slashRegistry';
 import { CLI_LOCAL_STREAM_ID } from '@cli/chat/tui/state/transcript';
@@ -107,7 +108,40 @@ function lastEntryText(
   return streams.get().get(streamId)?.entries.at(-1)?.text;
 }
 
+function localEntries() {
+  return streams.get().get(CLI_LOCAL_STREAM_ID)?.entries ?? [];
+}
+
 describe('handleTuiSlashCommand', () => {
+  it('does not leave command echoes for overlay-only commands', async () => {
+    registerBuiltinSlashCommands();
+    const context = createContext(createSession());
+
+    await handleTuiSlashCommand('/tools', context);
+    expect(localEntries()).toEqual([]);
+
+    await handleTuiSlashCommand('/help', context);
+    expect(localEntries().map((entry) => entry.role)).toEqual(['assistant']);
+  });
+
+  it('adds a lazy command echo before errors even under echo never', async () => {
+    registerSlashCommand({
+      name: 'unavailable',
+      description: 'Unavailable test command',
+      echo: 'never',
+    });
+
+    await handleTuiSlashCommand('/unavailable', createContext(createSession()));
+
+    expect(localEntries().map(({ role, text }) => ({ role, text }))).toEqual([
+      { role: 'user', text: '/unavailable' },
+      {
+        role: 'assistant',
+        text: '/unavailable is registered but is not available in this CLI view yet.',
+      },
+    ]);
+  });
+
   it('opens alias-addressed structured forms through the canonical command', async () => {
     registerBuiltinSlashCommands();
 

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
@@ -166,6 +166,19 @@ describe('handleTuiSlashCommand', () => {
     expect(activeForm.get()?.commandName).toBe('login');
   });
 
+  it('opens /approval status without an early transcript echo', async () => {
+    registerBuiltinSlashCommands();
+
+    const handled = await handleTuiSlashCommand(
+      '/approval status',
+      createContext(createSession()),
+    );
+
+    expect(handled).toBe(true);
+    expect(activeForm.get()?.commandName).toBe('approval');
+    expect(localEntries()).toEqual([]);
+  });
+
   it('opens the masked provider-key form through /key and /keys', async () => {
     registerBuiltinSlashCommands();
     const context = createContext(createSession());

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
@@ -142,6 +142,27 @@ describe('handleTuiSlashCommand', () => {
     ]);
   });
 
+  it('threads deferred echo through fallback registered forms', async () => {
+    registerSlashCommand({
+      name: 'custom-form',
+      description: 'Custom form',
+      echo: 'ifPersists',
+      formComponent: () => null,
+    });
+
+    await handleTuiSlashCommand('/custom-form', createContext(createSession()));
+    const form = activeForm.get()?.render(() => undefined, 20) as {
+      props?: { onPersist?: () => void };
+    };
+    expect(localEntries()).toEqual([]);
+
+    form.props?.onPersist?.();
+
+    expect(localEntries().map(({ role, text }) => ({ role, text }))).toEqual([
+      { role: 'user', text: '/custom-form' },
+    ]);
+  });
+
   it('opens alias-addressed structured forms through the canonical command', async () => {
     registerBuiltinSlashCommands();
 

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -357,6 +357,28 @@ describe('slashRegistry', () => {
     expect(modelNode.isClosed()).toBe(true);
   });
 
+  it('defers a form command echo until a persistent selection', async () => {
+    const events: string[] = [];
+    registerBuiltinSlashCommands({
+      onModelSelect: () => {
+        events.push('outcome');
+      },
+    });
+    const model = listSlashCommands().find((cmd) => cmd.name === 'model');
+    if (!model) throw new Error('Expected /model to be registered');
+
+    openRegisteredCliSlashForm(model, '', () => events.push('echo'));
+    expect(events).toEqual([]);
+
+    const modelNode = renderOpenForm<{
+      onSelect?: (value: string) => void;
+    }>();
+    modelNode.props?.onSelect?.('gpt55');
+    await settleFormSelection();
+
+    expect(events).toEqual(['echo', 'outcome']);
+  });
+
   it('routes model picker selection failures to the shared error handler', async () => {
     const errors: string[] = [];
     registerBuiltinSlashCommands({

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -379,6 +379,24 @@ describe('slashRegistry', () => {
     expect(events).toEqual(['echo', 'outcome']);
   });
 
+  it('preserves deferred echo through the command-name form helper', async () => {
+    const events: string[] = [];
+    registerBuiltinSlashCommands({
+      onModelSelect: () => {
+        events.push('outcome');
+      },
+    });
+
+    openCliSlashCommandForm('model', '', () => events.push('echo'));
+    const modelNode = renderOpenForm<{
+      onSelect?: (value: string) => void;
+    }>();
+    modelNode.props?.onSelect?.('gpt55');
+    await settleFormSelection();
+
+    expect(events).toEqual(['echo', 'outcome']);
+  });
+
   it('routes model picker selection failures to the shared error handler', async () => {
     const errors: string[] = [];
     registerBuiltinSlashCommands({


### PR DESCRIPTION
Closes #8809.

Moves picker-versus-argument dispatch and echo policy into the slash registry. Persistent commands now form command-to-outcome pairs, picker cancellation and pure overlays leave no orphan command row, and the guarded dispatcher owns error persistence with a lazy, redaction-safe echo.

The deferred-echo contract is preserved through both slash submission paths: ordinary command dispatch and forms opened directly from the InputBar palette. Form persistence is idempotent, so a kept-open form cannot duplicate its command echo after several failures. `/approval status` is registry-declared as a form-opening remainder, and configuration-form failures pass through the same lazy error-echo path.

## Design

The previous dispatcher repeated picker-versus-argument decisions and maintained a separate echo skip-list. This change makes the command registry the single source of truth for dispatch and transcript policy. The form boundary owns the single transition from an ephemeral interaction to a persistent outcome, while `runGuardedSlashCommand` remains the sole ordinary error sink. The one retained local catch describes a partial-success state after an active model has switched but persisting its helper-model default has failed.

## Net elements (R6)

- Added registry declarations for argument handlers, canonical forms, exact form-opening remainders, and echo policy.
- Added one idempotent deferred-persistence callback shared by both form-opening paths.
- Deleted seven hand-written picker-versus-argument dispatch branches, the global echo skip-list, and redundant handler catch tails.
- Net production change relative to the PR base: +240/-161 lines, or +79 lines. Tests are +164/-1 lines.

## Consumer counts (R8)

- `runGuardedSlashCommand`: 10 dispatch call sites.
- `formSelectionHandler`: 9 form adapters.
- Registry `argHandler`: 8 built-in commands.
- Registry `formRemainders`: 1 built-in command (`/approval status`), where the declaration prevents an orphan echo before the picker settles.
- Deferred `onPersist`: consumed through the registered-form opener by both `handleTuiSlashCommand` and `InputBar`, then by the 9 form adapters and the configuration error path.

## Verification

- `npm run typecheck`
- `npm test`
- `npm run lint`
- `npm run compile:fast`
- CLI `validate:tui` harness
- Targeted dispatch, registry, configuration-form, and InputBar suites: 92 tests

Headless commands are untouched; all changed runtime code is under `packages/cli/src/chat/tui/`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all TUI slash dispatch, transcript echo, and form wiring—behavior-sensitive UX—but coverage is broad in tests and scope is limited to `packages/cli/src/chat/tui/`.
> 
> **Overview**
> **Slash commands** now declare how they run and whether they appear in the transcript: `argHandler`, `formName`, `formRemainders`, and `echo` (`ifPersists` vs `never`) live on each registry entry instead of large `switch` branches and a hand-maintained skip list.
> 
> **`handleTuiSlashCommand`** routes empty or form-opening remainders (e.g. `/approval status`) to structured forms first, then remainder text to `argHandler`, and wraps the rest in **`runGuardedSlashCommand`** for shared echo-on-success/error and assistant error lines. Overlay-only commands no longer leave orphan user rows; failures can still echo the typed line once (including `echo: never` when nothing else persisted).
> 
> **Deferred echo** flows through **`appendSlashCommandEcho`** and idempotent **`onPersist`** from both dispatch and **InputBar** palette form opens, so scrollback updates only after a committed form selection or a failed action—not on cancel. Form adapters use **`echoOnPersist`** so config errors trigger the same lazy echo path.
> 
> Handler modules (**agent/model**, **login**) drop redundant try/catch where the guard now surfaces errors; agent messaging is slightly tightened.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c03de867ed41fc82f661af5a014bda893a4c8e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->