### PR TITLE
refactor(cli): share account status assembly

### DIFF
--- a/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
+++ b/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
@@ -2,8 +2,6 @@ import { notifyFollowUpSent } from '@agent/followUp/ToolUseFollowUp';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { formatCliApprovalPolicy } from '@cli/runtime/approvalPolicyText';
 import { defaultShortcutModifierLabel } from '@cli/runtime/shortcutLabels';
-import { resolveCliModelAccessRoute } from '@cli/runtime/modelAccessRoute';
-import { isCodexSubscriptionActive } from '@model/codexSubscriptionActive';
 import { GoalStore } from '@tools/goal';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -25,6 +23,7 @@ import {
   openCanonicalSlashForm,
   type SlashCommandContext,
 } from './handlers/slashContext';
+import { loadCliStatusAssembly } from './handlers/statusAssembly';
 import {
   appendSlashCommandEcho,
   openRegisteredCliSlashForm,
@@ -150,23 +149,20 @@ export async function handleTuiSlashCommand(
           model: meta.model || context.initialModel,
           category: meta.category,
         });
-        const subscriptionActive =
-          accessTarget.category === undefined
-            ? false
-            : await isCodexSubscriptionActive(
-                accessTarget.model,
-                accessTarget.category,
-              );
+        const status = await loadCliStatusAssembly({
+          apiMode: meta.apiMode,
+          target: {
+            model: accessTarget.model,
+            category: accessTarget.category,
+            usageRoute: slice?.usage?.usageRoute,
+          },
+        });
         appendLocalAssistantTranscript(
           formatCliSessionStatus({
             agent: meta.agent || context.initialAgent,
             model: accessTarget.model,
             teamName: meta.teamName,
-            modelAccess: resolveCliModelAccessRoute({
-              apiMode: meta.apiMode,
-              subscriptionActive,
-              usageRoute: slice?.usage?.usageRoute,
-            }),
+            modelAccess: status.modelAccess,
             approval: formatCliApprovalPolicy(context.getApprovalPolicy()),
             approvalBypasses: slice?.bypass,
             status: slice?.status ?? 'not started',

--- a/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
+++ b/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
@@ -1,7 +1,9 @@
 import { notifyFollowUpSent } from '@agent/followUp/ToolUseFollowUp';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { formatCliApprovalPolicy } from '@cli/runtime/approvalPolicyText';
+import { resolveCliModelAccessRoute } from '@cli/runtime/modelAccessRoute';
 import { defaultShortcutModifierLabel } from '@cli/runtime/shortcutLabels';
+import { isCodexSubscriptionActive } from '@model/codexSubscriptionActive';
 import { GoalStore } from '@tools/goal';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -23,7 +25,6 @@ import {
   openCanonicalSlashForm,
   type SlashCommandContext,
 } from './handlers/slashContext';
-import { loadCliStatusAssembly } from './handlers/statusAssembly';
 import {
   appendSlashCommandEcho,
   openRegisteredCliSlashForm,
@@ -149,20 +150,23 @@ export async function handleTuiSlashCommand(
           model: meta.model || context.initialModel,
           category: meta.category,
         });
-        const status = await loadCliStatusAssembly({
-          apiMode: meta.apiMode,
-          target: {
-            model: accessTarget.model,
-            category: accessTarget.category,
-            usageRoute: slice?.usage?.usageRoute,
-          },
-        });
+        const subscriptionActive =
+          accessTarget.category === undefined
+            ? false
+            : await isCodexSubscriptionActive(
+                accessTarget.model,
+                accessTarget.category,
+              );
         appendLocalAssistantTranscript(
           formatCliSessionStatus({
             agent: meta.agent || context.initialAgent,
             model: accessTarget.model,
             teamName: meta.teamName,
-            modelAccess: status.modelAccess,
+            modelAccess: resolveCliModelAccessRoute({
+              apiMode: meta.apiMode,
+              subscriptionActive,
+              usageRoute: slice?.usage?.usageRoute,
+            }),
             approval: formatCliApprovalPolicy(context.getApprovalPolicy()),
             approvalBypasses: slice?.bypass,
             status: slice?.status ?? 'not started',

--- a/packages/cli/src/chat/tui/commands/handlers/apiModeCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/apiModeCommands.ts
@@ -1,9 +1,5 @@
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { type CliApiMode } from '@cli/runtime/apiAccessMode';
-import {
-  loadCliApiStatusLines,
-  loadCliModelAccessOverview,
-} from '@cli/runtime/apiStatus';
 import { setCliHelperModel } from '@cli/runtime/initPlatform';
 import { refreshCodexPreferenceViews } from '@cli/chat/tui/state/codexSubscription';
 import {
@@ -32,6 +28,7 @@ import {
   CHAT_API_MODE_MODEL_RECOVERY,
   type SlashCommandContext,
 } from './slashContext';
+import { loadCliStatusAssembly } from './statusAssembly';
 
 const MODEL_ACCESS_USAGE = 'Usage: /api chatgpt | included | personal | status';
 
@@ -104,16 +101,11 @@ export async function applyCliModelAccessSelection(
 
   if (!normalized || normalized === 'status') {
     const apiMode = sessionMeta.get().apiMode;
-    const [{ lines }, apiStatusLines] = await Promise.all([
-      loadCliModelAccessOverview({ apiMode }),
-      loadCliApiStatusLines({ apiMode }),
-    ]);
-    const detailLines = apiStatusLines
-      .slice(2)
-      .filter((line) => !lines.includes(line));
-    appendLocalAssistantTranscript(
-      [...lines, ...detailLines, MODEL_ACCESS_USAGE].join('\n'),
-    );
+    const status = await loadCliStatusAssembly({
+      apiMode,
+      includeApiDetails: true,
+    });
+    appendLocalAssistantTranscript(status.lines.join('\n'));
     return;
   }
 
@@ -134,8 +126,9 @@ export async function applyCliModelAccessSelection(
 }
 
 export async function showCliAuthStatus(): Promise<void> {
-  const { lines } = await loadCliModelAccessOverview({
+  const status = await loadCliStatusAssembly({
     apiMode: sessionMeta.get().apiMode,
+    includeApiDetails: true,
   });
-  appendLocalAssistantTranscript(lines.join('\n'));
+  appendLocalAssistantTranscript(status.lines.join('\n'));
 }

--- a/packages/cli/src/chat/tui/commands/handlers/apiModeCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/apiModeCommands.ts
@@ -28,7 +28,7 @@ import {
   CHAT_API_MODE_MODEL_RECOVERY,
   type SlashCommandContext,
 } from './slashContext';
-import { loadCliStatusAssembly } from './statusAssembly';
+import { loadCliAccountStatusLines } from './statusAssembly';
 
 const MODEL_ACCESS_USAGE = 'Usage: /api chatgpt | included | personal | status';
 
@@ -101,11 +101,11 @@ export async function applyCliModelAccessSelection(
 
   if (!normalized || normalized === 'status') {
     const apiMode = sessionMeta.get().apiMode;
-    const status = await loadCliStatusAssembly({
+    const lines = await loadCliAccountStatusLines({
       apiMode,
       includeApiDetails: true,
     });
-    appendLocalAssistantTranscript(status.lines.join('\n'));
+    appendLocalAssistantTranscript(lines.join('\n'));
     return;
   }
 
@@ -126,9 +126,9 @@ export async function applyCliModelAccessSelection(
 }
 
 export async function showCliAuthStatus(): Promise<void> {
-  const status = await loadCliStatusAssembly({
+  const lines = await loadCliAccountStatusLines({
     apiMode: sessionMeta.get().apiMode,
     includeApiDetails: true,
   });
-  appendLocalAssistantTranscript(status.lines.join('\n'));
+  appendLocalAssistantTranscript(lines.join('\n'));
 }

--- a/packages/cli/src/chat/tui/commands/handlers/loginCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/loginCommands.ts
@@ -4,10 +4,7 @@ import {
 } from '@cli/chat/tui/state/codexSubscription';
 import { sessionMeta, setTransientNotice } from '@cli/chat/tui/state/cliState';
 import { appendLocalAssistantTranscript } from '@cli/chat/tui/state/transcript';
-import {
-  loadCliApiStatusLines,
-  loadCliModelAccessOverview,
-} from '@cli/runtime/apiStatus';
+import { loadCliApiStatusLines } from '@cli/runtime/apiStatus';
 import {
   chatGptAccountLabel,
   chatGptSignOutPreferenceMessage,
@@ -36,6 +33,7 @@ import { formatCliDeviceAuthMessage } from '@cli/runtime/supabaseAuthDeviceCode'
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { setCliSessionApiMode } from './apiModeCommands';
+import { loadCliStatusAssembly } from './statusAssembly';
 
 const CHAT_LOGIN_USAGE = [
   'Usage: /login [texra [github | google]] [--no-browser] [--device] [--select-account] [--login-hint <account>]',
@@ -179,13 +177,13 @@ export async function logoutFromChat(input: string): Promise<void> {
   }
 
   try {
-    const { lines: statusLines } = await loadCliModelAccessOverview({
+    const status = await loadCliStatusAssembly({
       apiMode: sessionMeta.get().apiMode,
     });
-    lines.push(...statusLines);
+    lines.push(...status.lines);
   } catch (error: unknown) {
     lines.push(toErrorMessage(error));
   }
 
-  appendLocalAssistantTranscript(lines.join('\n'));
+  appendLocalAssistantTranscript(lines.join(' · '));
 }

--- a/packages/cli/src/chat/tui/commands/handlers/loginCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/loginCommands.ts
@@ -33,7 +33,7 @@ import { formatCliDeviceAuthMessage } from '@cli/runtime/supabaseAuthDeviceCode'
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { setCliSessionApiMode } from './apiModeCommands';
-import { loadCliStatusAssembly } from './statusAssembly';
+import { loadCliAccountStatusLines } from './statusAssembly';
 
 const CHAT_LOGIN_USAGE = [
   'Usage: /login [texra [github | google]] [--no-browser] [--device] [--select-account] [--login-hint <account>]',
@@ -177,10 +177,10 @@ export async function logoutFromChat(input: string): Promise<void> {
   }
 
   try {
-    const status = await loadCliStatusAssembly({
+    const statusLines = await loadCliAccountStatusLines({
       apiMode: sessionMeta.get().apiMode,
     });
-    lines.push(...status.lines);
+    lines.push(...statusLines);
   } catch (error: unknown) {
     lines.push(toErrorMessage(error));
   }

--- a/packages/cli/src/chat/tui/commands/handlers/statusAssembly.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/statusAssembly.ts
@@ -17,6 +17,24 @@ export async function loadCliStatusAssembly(options: {
     readonly usageRoute?: UsageRoute;
   };
 }) {
+  if (options.target) {
+    const subscriptionActive =
+      options.target.category === undefined
+        ? false
+        : await isCodexSubscriptionActive(
+            options.target.model,
+            options.target.category,
+          );
+    return {
+      lines: [],
+      modelAccess: resolveCliModelAccessRoute({
+        apiMode: options.apiMode,
+        subscriptionActive,
+        usageRoute: options.target.usageRoute,
+      }),
+    };
+  }
+
   const [overview, apiStatusLines] = await Promise.all([
     loadCliModelAccessOverview({ apiMode: options.apiMode }),
     options.includeApiDetails
@@ -26,22 +44,11 @@ export async function loadCliStatusAssembly(options: {
   const detailLines = apiStatusLines
     .slice(2)
     .filter((line) => !overview.lines.includes(line));
-  let subscriptionActive = overview.access.active === 'chatgpt';
-  if (options.target) {
-    subscriptionActive =
-      options.target.category === undefined
-        ? false
-        : await isCodexSubscriptionActive(
-            options.target.model,
-            options.target.category,
-          );
-  }
   return {
     lines: [...overview.lines, ...detailLines],
     modelAccess: resolveCliModelAccessRoute({
       apiMode: options.apiMode,
-      subscriptionActive,
-      usageRoute: options.target?.usageRoute,
+      subscriptionActive: overview.access.active === 'chatgpt',
     }),
   };
 }

--- a/packages/cli/src/chat/tui/commands/handlers/statusAssembly.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/statusAssembly.ts
@@ -1,0 +1,47 @@
+import type { CliApiMode } from '@cli/runtime/apiAccessMode';
+import {
+  loadCliApiStatusLines,
+  loadCliModelAccessOverview,
+} from '@cli/runtime/apiStatus';
+import { resolveCliModelAccessRoute } from '@cli/runtime/modelAccessRoute';
+import { isCodexSubscriptionActive } from '@model/codexSubscriptionActive';
+import type { AgentCategory, UsageRoute } from '@shared/schemas';
+
+/** Load the canonical account/access snapshot used by TUI status commands. */
+export async function loadCliStatusAssembly(options: {
+  readonly apiMode: CliApiMode;
+  readonly includeApiDetails?: boolean;
+  readonly target?: {
+    readonly model: string;
+    readonly category: AgentCategory | undefined;
+    readonly usageRoute?: UsageRoute;
+  };
+}) {
+  const [overview, apiStatusLines] = await Promise.all([
+    loadCliModelAccessOverview({ apiMode: options.apiMode }),
+    options.includeApiDetails
+      ? loadCliApiStatusLines({ apiMode: options.apiMode })
+      : Promise.resolve([]),
+  ]);
+  const detailLines = apiStatusLines
+    .slice(2)
+    .filter((line) => !overview.lines.includes(line));
+  let subscriptionActive = overview.access.active === 'chatgpt';
+  if (options.target) {
+    subscriptionActive =
+      options.target.category === undefined
+        ? false
+        : await isCodexSubscriptionActive(
+            options.target.model,
+            options.target.category,
+          );
+  }
+  return {
+    lines: [...overview.lines, ...detailLines],
+    modelAccess: resolveCliModelAccessRoute({
+      apiMode: options.apiMode,
+      subscriptionActive,
+      usageRoute: options.target?.usageRoute,
+    }),
+  };
+}

--- a/packages/cli/src/chat/tui/commands/handlers/statusAssembly.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/statusAssembly.ts
@@ -3,38 +3,12 @@ import {
   loadCliApiStatusLines,
   loadCliModelAccessOverview,
 } from '@cli/runtime/apiStatus';
-import { resolveCliModelAccessRoute } from '@cli/runtime/modelAccessRoute';
-import { isCodexSubscriptionActive } from '@model/codexSubscriptionActive';
-import type { AgentCategory, UsageRoute } from '@shared/schemas';
 
-/** Load the canonical account/access snapshot used by TUI status commands. */
-export async function loadCliStatusAssembly(options: {
+/** Load the canonical account snapshot used by TUI account commands. */
+export async function loadCliAccountStatusLines(options: {
   readonly apiMode: CliApiMode;
   readonly includeApiDetails?: boolean;
-  readonly target?: {
-    readonly model: string;
-    readonly category: AgentCategory | undefined;
-    readonly usageRoute?: UsageRoute;
-  };
-}) {
-  if (options.target) {
-    const subscriptionActive =
-      options.target.category === undefined
-        ? false
-        : await isCodexSubscriptionActive(
-            options.target.model,
-            options.target.category,
-          );
-    return {
-      lines: [],
-      modelAccess: resolveCliModelAccessRoute({
-        apiMode: options.apiMode,
-        subscriptionActive,
-        usageRoute: options.target.usageRoute,
-      }),
-    };
-  }
-
+}): Promise<string[]> {
   const [overview, apiStatusLines] = await Promise.all([
     loadCliModelAccessOverview({ apiMode: options.apiMode }),
     options.includeApiDetails
@@ -44,11 +18,5 @@ export async function loadCliStatusAssembly(options: {
   const detailLines = apiStatusLines
     .slice(2)
     .filter((line) => !overview.lines.includes(line));
-  return {
-    lines: [...overview.lines, ...detailLines],
-    modelAccess: resolveCliModelAccessRoute({
-      apiMode: options.apiMode,
-      subscriptionActive: overview.access.active === 'chatgpt',
-    }),
-  };
+  return [...overview.lines, ...detailLines];
 }

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
@@ -570,6 +570,7 @@ describe('handleTuiSlashCommand', () => {
 
   it('reports the access route that produced the focused stream usage', async () => {
     registerBuiltinSlashCommands();
+    const overview = vi.spyOn(apiStatus, 'loadCliModelAccessOverview');
     const session = createSession();
     const streamId = 'stream-access' as StreamTabId;
     activeStreamId.set(streamId);
@@ -591,6 +592,7 @@ describe('handleTuiSlashCommand', () => {
     const statusText = lastEntryText(streamId);
     expect(statusText).toContain('model access: Included TeXRA access');
     expect(statusText).not.toContain('model access: ChatGPT subscription');
+    expect(overview).not.toHaveBeenCalled();
   });
 
   it('surfaces status lookup failures without rejecting', async () => {

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
@@ -374,7 +374,8 @@ describe('handleTuiSlashCommand', () => {
     const context = createContext(createSession());
 
     await handleTuiSlashCommand('/auth', context);
-    expect(lastEntryText()).toContain('model access: ChatGPT subscription');
+    const authStatusText = lastEntryText();
+    expect(authStatusText).toContain('model access: ChatGPT subscription');
 
     await handleTuiSlashCommand('/api status', context);
     const apiStatusText = lastEntryText();
@@ -383,6 +384,7 @@ describe('handleTuiSlashCommand', () => {
     expect(apiStatusText).toContain(
       'included usage this month: 25% used, 75% remaining',
     );
+    expect(apiStatusText).toBe(authStatusText);
     expect(overview).toHaveBeenCalledTimes(2);
   });
 
@@ -436,6 +438,7 @@ describe('handleTuiSlashCommand', () => {
     expect(entry).toContain('Signed out of TeXRA.');
     expect(entry).toContain('Signed out of ChatGPT.');
     expect(entry).toContain('ChatGPT subscription disabled for Codex models.');
+    expect(entry).not.toContain('\n');
   });
 
   it('opens an account-specific sign-out chooser for bare /logout', async () => {


### PR DESCRIPTION
## Summary

Account-oriented CLI commands now assemble their status lines through one focused helper. `/auth` and `/api status` show the same complete snapshot, while `/logout` reuses the overview in its single physical outcome line. Session `/status` continues to resolve model access locally from the active stream and does not fetch account data.

Closes #8810.

## Issue acceptance gates

- `/auth` and bare or `status` `/api` use the same account-status lines.
- `/logout` reuses the same overview without duplicating assembly logic.
- `/status` preserves its existing text, stream usage-route precedence, and local-only data access.
- The shared helper has one mode and one return shape; session-route resolution is not hidden behind an unrelated account API.

## Single source of truth

`loadCliAccountStatusLines` in `statusAssembly.ts` owns TUI account snapshot assembly and optional API-detail deduplication. The `/status` arm in `handleSlashCommand.ts` remains the source of truth for active-session route resolution.

## Duplication and abstraction budget

Three hand-built account-status tails were replaced by one helper with three callers. Review removed the initial dual-purpose target mode, leaving no half-unused return fields or pass-through session abstraction.

## Net elements (R6)

- Files: 1 added, 4 modified.
- LoC: +41 / -23, net +18, including tests.
- Exports: one added (`loadCliAccountStatusLines`); no classes, schemas, interfaces, or enums added.

## Consumer counts (R8)

- `loadCliAccountStatusLines`: 3 production call sites (`/auth`, `/api` status, and logout assembly).
- Session model-access resolution: 1 local `/status` path; deliberately not extracted.

## Host impact

Extension: None.

Desktop: None.

CLI: Account status dumps are consistent; session status remains local and unchanged.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck`
- `npm test`
- `npm run lint`
- `npm run compile:fast`
- `vitest run src/test-kernel/cli/SlashCommandDispatch.vitest.mts` (26 tests)
