### PR TITLE
feat(cli): let arrow keys hand focus to the subagent list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,9 @@ All notable changes to this project will be documented in this file.
 
 #### New Features
 
+- **Arrow keys can move between chat and subagents** — when input history has
+  no further entry, Up or Down can focus the subagent list; Down past its final
+  row returns to the chat input. Tab remains available in both directions.
 - **Account changes stay visible without filling chat history** — sign-in,
   sign-out, and model-access forms now show their progress in place and leave
   only the final result in the conversation.

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -407,6 +407,12 @@ export function App(props: AppProps): React.JSX.Element {
   const cancelChildList = useCallback(() => {
     dispatchChildListSelection({ kind: 'blur' });
   }, []);
+  const focusChildList = useCallback(() => {
+    const firstChildValue = childListValues.at(0);
+    if (firstChildValue) {
+      dispatchChildListSelection({ kind: 'focus', value: firstChildValue });
+    }
+  }, [childListValues]);
   const focusSession = useCallback((streamId: StreamTabId) => {
     dispatchChildListSelection({ kind: 'focusStream', streamId });
     focusStreamAndPromoteApprovals(streamId);
@@ -610,10 +616,7 @@ export function App(props: AppProps): React.JSX.Element {
 
     // Tab transfers keyboard ownership from the input to the child list.
     if (key.tab) {
-      const firstChildValue = childListValues.at(0);
-      if (firstChildValue) {
-        dispatchChildListSelection({ kind: 'focus', value: firstChildValue });
-      }
+      focusChildList();
       return;
     }
 
@@ -666,6 +669,7 @@ export function App(props: AppProps): React.JSX.Element {
               disabled={inputDisabled}
               history={props.history}
               keyboardActive={!childListFocused}
+              onFocusChildList={focusChildList}
             />
             <StatusBar
               agentSelectionAvailable={agentSelectionAvailable}

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -669,7 +669,9 @@ export function App(props: AppProps): React.JSX.Element {
               disabled={inputDisabled}
               history={props.history}
               keyboardActive={!childListFocused}
-              onFocusChildList={focusChildList}
+              onFocusChildList={
+                focusShortcutsActive ? focusChildList : undefined
+              }
             />
             <StatusBar
               agentSelectionAvailable={agentSelectionAvailable}

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -63,6 +63,9 @@ export interface InputBarProps {
   readonly history?: InputHistory;
   /** Whether the input currently owns terminal keys. */
   readonly keyboardActive?: boolean;
+  /** Called when ↑/↓ history browsing hits its boundary (nothing further to
+   *  recall) with a child list available — hands keyboard ownership to it. */
+  readonly onFocusChildList?: () => void;
   /** Root-owned handle for draft-aware keyboard policy. */
   readonly controlRef?: React.Ref<InputBarHandle>;
 }
@@ -137,12 +140,22 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
   }, []);
   const historyRef = useRef(history);
   historyRef.current = history;
+  const onFocusChildListRef = useRef(props.onFocusChildList);
+  onFocusChildListRef.current = props.onFocusChildList;
   const browseHistory = useCallback((direction: -1 | 1) => {
     const entries = historyRef.current;
     const browse = historyBrowseRef.current;
-    if (!entries || (!browse && direction === 1)) return;
+    // Nothing further to recall in this direction — hand off to the child
+    // list rather than silently no-op-ing.
+    if (!entries || (!browse && direction === 1)) {
+      onFocusChildListRef.current?.();
+      return;
+    }
     const index = (browse?.index ?? entries.length()) + direction;
-    if (index < 0) return;
+    if (index < 0) {
+      onFocusChildListRef.current?.();
+      return;
+    }
     const savedDraft = browse?.savedDraft ?? draftValueRef.current;
     // Walking ↓ past the newest entry restores the pre-browse draft.
     const entry = entries.at(index);

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -432,6 +432,13 @@ export function SubagentList(
         items={items}
         maxVisibleItems={contentRows}
         onCancel={props.onCancel ?? (() => undefined)}
+        // This panel is a standalone focus target, not a cyclic menu: Down
+        // past the last row hands keyboard ownership back to the input
+        // (mirrors Tab) instead of wrapping to the top.
+        wrap={false}
+        onBoundaryEscape={(direction) => {
+          if (direction === 1) props.onCancel?.();
+        }}
         onHighlightChange={(value) => props.onSelectionChange?.(value)}
         onSelect={(value) => {
           const streamId = childListStreamId(value);

--- a/packages/cli/src/chat/tui/ui/Select.tsx
+++ b/packages/cli/src/chat/tui/ui/Select.tsx
@@ -50,6 +50,12 @@ export interface SelectProps<T> {
   readonly onHighlightChange?: (value: T) => void;
   /** Disable direct 1-9/a-z activation for arrow-only lists. */
   readonly hotkeys?: boolean;
+  /** Set false when this Select is a standalone focus target rather than a
+   *  cyclic menu: a move past either edge reports `onBoundaryEscape` instead
+   *  of wrapping. Defaults to true (existing wrap-around behavior). */
+  readonly wrap?: boolean;
+  /** Called when `wrap` is false and a move would cross the top/bottom edge. */
+  readonly onBoundaryEscape?: (direction: -1 | 1) => void;
   readonly renderItem?: (
     item: SelectItem<T>,
     state: {
@@ -294,6 +300,15 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
   });
 
   const moveHighlight = (direction: -1 | 1): void => {
+    const current = highlightRef.current;
+    if (
+      props.wrap === false &&
+      ((direction === 1 && current >= props.items.length - 1) ||
+        (direction === -1 && current <= 0))
+    ) {
+      props.onBoundaryEscape?.(direction);
+      return;
+    }
     const next = nextSelectHighlightIndex({
       direction,
       highlight: highlightRef.current,

--- a/packages/cli/src/chat/tui/ui/Select.tsx
+++ b/packages/cli/src/chat/tui/ui/Select.tsx
@@ -122,10 +122,12 @@ export function nextSelectHighlightIndex<T>({
   direction,
   highlight,
   items,
+  wrap = true,
 }: {
   readonly direction: -1 | 1;
   readonly highlight: number;
   readonly items: ReadonlyArray<SelectItem<T>>;
+  readonly wrap?: boolean;
 }): number {
   if (items.length === 0) return 0;
 
@@ -134,6 +136,9 @@ export function nextSelectHighlightIndex<T>({
     items.every((item) => item.disabled) ||
     items.every((item) => !item.disabled)
   ) {
+    if (!wrap) {
+      return clampIndex(clampedHighlight + direction, items.length);
+    }
     return nextWrappingHighlightIndex({
       direction,
       highlight: clampedHighlight,
@@ -301,19 +306,16 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
 
   const moveHighlight = (direction: -1 | 1): void => {
     const current = highlightRef.current;
-    if (
-      props.wrap === false &&
-      ((direction === 1 && current >= props.items.length - 1) ||
-        (direction === -1 && current <= 0))
-    ) {
+    const next = nextSelectHighlightIndex({
+      direction,
+      highlight: current,
+      items: props.items,
+      wrap: props.wrap,
+    });
+    if (props.wrap === false && next === current) {
       props.onBoundaryEscape?.(direction);
       return;
     }
-    const next = nextSelectHighlightIndex({
-      direction,
-      highlight: highlightRef.current,
-      items: props.items,
-    });
     highlightRef.current = next;
     setHighlight(next);
     const item = props.items[next];

--- a/src/test-kernel/cli/ChildListInteraction.vitest.mts
+++ b/src/test-kernel/cli/ChildListInteraction.vitest.mts
@@ -198,6 +198,84 @@ describe('CLI child list interaction', () => {
     }
   });
 
+  it('hands focus back to the input instead of wrapping past the last row', async () => {
+    const ink = (await import(cliRequire.resolve('ink'))) as any;
+    const React = ((await import(cliRequire.resolve('react'))) as any).default;
+    const root = 'root' as StreamTabId;
+    const child = 'child' as StreamTabId;
+    const onCancel = vi.fn();
+    const onSelectionChange = vi.fn();
+
+    const stdin = new FakeStdin();
+    const instance = ink.render(
+      React.createElement(SubagentList, {
+        keyboardActive: true,
+        maxRows: 5,
+        onCancel,
+        onSelectionChange,
+        selectedValue: childStreamListValue(child),
+        sessions: [session(root, true), session(child)],
+      }),
+      {
+        stdin,
+        stdout: new FakeStdout(),
+        interactive: true,
+        exitOnCtrlC: false,
+        patchConsole: false,
+      },
+    );
+
+    try {
+      await waitFor(() => stdin.listenerCount('readable') > 0);
+      stdin.write('[B');
+      await waitFor(() => onCancel.mock.calls.length === 1);
+
+      expect(onSelectionChange).not.toHaveBeenCalled();
+    } finally {
+      instance.unmount();
+    }
+  });
+
+  it('clamps instead of wrapping when ↑ is pressed at the first row', async () => {
+    const ink = (await import(cliRequire.resolve('ink'))) as any;
+    const React = ((await import(cliRequire.resolve('react'))) as any).default;
+    const root = 'root' as StreamTabId;
+    const child = 'child' as StreamTabId;
+    const onCancel = vi.fn();
+    const onSelectionChange = vi.fn();
+
+    const stdin = new FakeStdin();
+    const instance = ink.render(
+      React.createElement(SubagentList, {
+        keyboardActive: true,
+        maxRows: 5,
+        onCancel,
+        onSelectionChange,
+        selectedValue: childStreamListValue(root),
+        sessions: [session(root, true), session(child)],
+      }),
+      {
+        stdin,
+        stdout: new FakeStdout(),
+        interactive: true,
+        exitOnCtrlC: false,
+        patchConsole: false,
+      },
+    );
+
+    try {
+      await waitFor(() => stdin.listenerCount('readable') > 0);
+      stdin.write('[A');
+      // No state change to await for a no-op; give the event loop a turn.
+      await new Promise((resolve) => setTimeout(resolve, 30));
+
+      expect(onCancel).not.toHaveBeenCalled();
+      expect(onSelectionChange).not.toHaveBeenCalled();
+    } finally {
+      instance.unmount();
+    }
+  });
+
   it('opens and kills a selected process without printing stream output', async () => {
     const ink = (await import(cliRequire.resolve('ink'))) as any;
     const React = ((await import(cliRequire.resolve('react'))) as any).default;

--- a/src/test-kernel/cli/InputBar.vitest.mts
+++ b/src/test-kernel/cli/InputBar.vitest.mts
@@ -19,6 +19,7 @@ import {
   submitSlashCommandWhenReady,
   type InputBarHandle,
 } from '@cli/chat/tui/panes/InputBar';
+import type { InputHistory } from '@cli/chat/tui/history/inputHistory';
 import {
   registerSlashCommand,
   unregisterSlashCommand,
@@ -115,8 +116,88 @@ async function waitFor(
   }
 }
 
+function fakeHistory(entries: readonly string[]): InputHistory {
+  return {
+    push: async () => undefined,
+    reverseFind: () => undefined,
+    at: (index) => entries[index],
+    length: () => entries.length,
+  };
+}
+
 beforeEach(() => clipboardMock.attachClipboardImage.mockReset());
 afterEach(() => vi.clearAllMocks());
+
+describe('InputBar arrow-key child-list focus', () => {
+  it('falls through to the child list on ↓/↑ when there is no history to walk', async () => {
+    const ink = (await import(cliRequire.resolve('ink'))) as any;
+    const React = ((await import(cliRequire.resolve('react'))) as any).default;
+    const onFocusChildList = vi.fn();
+
+    const stdin = new FakeStdin();
+    const instance = ink.render(
+      React.createElement(InputBar, {
+        onSubmit: vi.fn(),
+        onFocusChildList,
+      }),
+      {
+        stdin,
+        stdout: new FakeStdout(),
+        interactive: true,
+        exitOnCtrlC: false,
+        patchConsole: false,
+      },
+    );
+
+    try {
+      await waitFor(() => stdin.listenerCount('readable') > 0);
+      stdin.write('[B');
+      await waitFor(() => onFocusChildList.mock.calls.length === 1);
+      stdin.write('[A');
+      await waitFor(() => onFocusChildList.mock.calls.length === 2);
+    } finally {
+      instance.unmount();
+    }
+  });
+
+  it('still recalls history on ↑ but hands off on an idle ↓', async () => {
+    const ink = (await import(cliRequire.resolve('ink'))) as any;
+    const React = ((await import(cliRequire.resolve('react'))) as any).default;
+    const onFocusChildList = vi.fn();
+    const history = fakeHistory(['first command', 'second command']);
+
+    const stdin = new FakeStdin();
+    const stdout = new FakeStdout();
+    const instance = ink.render(
+      React.createElement(InputBar, {
+        onSubmit: vi.fn(),
+        onFocusChildList,
+        history,
+      }),
+      {
+        stdin,
+        stdout,
+        interactive: true,
+        exitOnCtrlC: false,
+        patchConsole: false,
+      },
+    );
+
+    try {
+      await waitFor(() => stdin.listenerCount('readable') > 0);
+      // Idle Down has nothing to walk forward into — hands off immediately.
+      stdin.write('[B');
+      await waitFor(() => onFocusChildList.mock.calls.length === 1);
+      // Up still recalls the most recent entry rather than escaping.
+      stdin.write('[A');
+      await waitFor(() => stdout.buf.includes('second command'));
+
+      expect(onFocusChildList).toHaveBeenCalledTimes(1);
+    } finally {
+      instance.unmount();
+    }
+  });
+});
 
 describe('InputBar slash submit', () => {
   it('threads deferred echo through a palette-opened form', async () => {

--- a/src/test-kernel/cli/ModelListForm.vitest.mts
+++ b/src/test-kernel/cli/ModelListForm.vitest.mts
@@ -325,6 +325,25 @@ describe('CLI Select disabled-row focus', () => {
     ).toBe(1);
   });
 
+  it('reports disabled outer rows as non-wrapping boundaries', () => {
+    expect(
+      nextSelectHighlightIndex({
+        direction: -1,
+        highlight: 1,
+        items,
+        wrap: false,
+      }),
+    ).toBe(1);
+    expect(
+      nextSelectHighlightIndex({
+        direction: 1,
+        highlight: 2,
+        items,
+        wrap: false,
+      }),
+    ).toBe(2);
+  });
+
   it('keeps wraparound navigation for all-enabled lists', () => {
     const enabledItems = [
       { value: 'gemini', label: 'Gemini' },


### PR DESCRIPTION
## Summary
- Tab was the only way to move keyboard ownership between the input and the child/subagent list — not discoverable.
- Extends the existing ↑/↓ fallthrough chain in `InputBar` (multiline cursor move → history walk) one more link: when history browsing hits its boundary (nothing further to recall), it hands focus to the child list instead of silently no-op-ing. Down does this from idle drafting (the common case); Up does it once history is exhausted.
- `Select` gains an opt-in `wrap={false}` + `onBoundaryEscape` mode (default unchanged everywhere else); `SubagentList` uses it so ↓ past the last row hands focus back to the input, mirroring Tab's second press, instead of wrapping to the top.
- Tab keeps working exactly as before as the always-available fallback in both directions.

## Test plan
- [x] `npm run typecheck` (CLI + test-kernel tsconfig; full workspace run separately timed out on the unrelated, slow `packages/extension` step — not touched by this change)
- [x] `npx eslint` + `npx prettier --check` on all changed files
- [x] `npx vitest run src/test-kernel/cli/{InputBar,ChildListInteraction,ChildListSelection,SelectHotkeys,SubagentListDisplay,StatusBar}.vitest.mts` — 98/98 passing, including 4 new tests covering the boundary-escape behavior in both directions and the history-recall regression guard

https://claude.ai/code/session_01R1S4FXF7BEVuuQ7rocKncr

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI TUI keyboard navigation only; default `Select` wrap behavior is unchanged elsewhere, with targeted tests.
> 
> **Overview**
> **Arrow-key focus handoff** between the chat input and the subagent/child list extends what **Tab** already does. When **↑/↓** input-history browsing has nothing left to recall (idle **↓**, exhausted **↑**, or **↓** past the newest entry), focus moves to the child list instead of doing nothing. **Tab** still focuses the list; the shared `focusChildList` helper is used from both paths.
> 
> The subagent list uses a new **`Select`** mode with **`wrap={false}`** and **`onBoundaryEscape`**: **↓** past the last row blurs the list and returns focus to the input (mirroring a second **Tab**), without wrapping to the top. **↑** at the first row stays clamped.
> 
> CHANGELOG documents the behavior. Tests cover **InputBar** boundary handoff, history recall vs handoff, and **SubagentList** boundary escape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70523026dceceb873991f6128790f3fa8d082c5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->