### PR TITLE
feat(cli): keep account progress in forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,9 @@ All notable changes to this project will be documented in this file.
 
 #### New Features
 
+- **Account changes stay visible without filling chat history** — sign-in,
+  sign-out, and model-access forms now show their progress in place and leave
+  only the final result in the conversation.
 - **Model access and accounts have distinct CLI controls** — `/api` now offers
   ChatGPT subscription, included TeXRA access, and personal API keys in one
   picker; `/auth` reports both account sessions and the effective route; and

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -543,7 +543,6 @@ export function App(props: AppProps): React.JSX.Element {
     // interrupt-then-exit behavior without duplicating that process lifecycle.
     if (key.ctrl && input === 'c') {
       if (formBusy) {
-        props.onCtrlC?.();
         formProgress?.cancel();
         return;
       }

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -67,6 +67,7 @@ import {
   rootRunStartAvailable as rootRunStartAvailableSignal,
   rootStreamId as rootStreamIdSignal,
   activeForm as activeFormSignal,
+  formProgress as formProgressSignal,
   reverseSearchOpen as reverseSearchOpenSignal,
   slashPaletteOpen as slashPaletteOpenSignal,
   taskDetailExecutionId as taskDetailExecutionIdSignal,
@@ -156,10 +157,12 @@ export function App(props: AppProps): React.JSX.Element {
   const childStreamEntries = useSignal(childStreamEntriesSignal);
   const subagentExecutionLabels = useSignal(subagentExecutionLabelsSignal);
   const activeForm = useSignal(activeFormSignal);
+  const formProgress = useSignal(formProgressSignal);
   const slashPaletteOpen = useSignal(slashPaletteOpenSignal);
   const reverseSearchOpen = useSignal(reverseSearchOpenSignal);
   const taskDetailExecutionId = useSignal(taskDetailExecutionIdSignal);
   const rootRunStartAvailable = useSignal(rootRunStartAvailableSignal);
+  const formBusy = formProgress?.status === 'running';
   const pendingSummaries = useSignal(pendingApprovalSummaries);
   const [childListSelection, dispatchChildListSelection] = useReducer(
     reduceChildListSelection,
@@ -404,6 +407,7 @@ export function App(props: AppProps): React.JSX.Element {
   }, []);
   const foregroundKind = foregroundSurfaceKind({
     activeFormOpen: activeForm !== undefined,
+    formBusy,
     pendingApproval: activeApprovalVisible,
     taskDetailOpen: taskDetailProcess !== undefined,
   });
@@ -434,10 +438,10 @@ export function App(props: AppProps): React.JSX.Element {
         );
       }
       case 'form':
-        return activeForm?.render(
-          () => activeFormSignal.set(undefined),
-          availableRows,
-        );
+        return activeForm?.render(() => {
+          formProgressSignal.set(undefined);
+          activeFormSignal.set(undefined);
+        }, availableRows);
       case 'approval':
         return activeApprovalVisible && pending ? (
           <ApprovalModal pending={pending} availableRows={availableRows} />
@@ -538,6 +542,11 @@ export function App(props: AppProps): React.JSX.Element {
     // path used by terminals that deliver a signal; harnesses can fall back to
     // interrupt-then-exit behavior without duplicating that process lifecycle.
     if (key.ctrl && input === 'c') {
+      if (formBusy) {
+        props.onCtrlC?.();
+        formProgress?.cancel();
+        return;
+      }
       triggerAppCtrlC({
         discardDraft: () =>
           activeDraftRegistry.discard() ||
@@ -640,7 +649,9 @@ export function App(props: AppProps): React.JSX.Element {
               agentSelectionAvailable={agentSelectionAvailable}
               commandName={props.commandName}
               foregroundEscapeAction={foregroundEscapeAction({
-                activeFormEscapeAction: activeForm?.escapeAction,
+                activeFormEscapeAction: formBusy
+                  ? 'cancel'
+                  : activeForm?.escapeAction,
                 approvalKind,
                 foregroundKind,
               })}

--- a/packages/cli/src/chat/tui/appInteractionPolicy.ts
+++ b/packages/cli/src/chat/tui/appInteractionPolicy.ts
@@ -142,14 +142,17 @@ export type ForegroundSurfaceKind = 'taskDetail' | 'form' | 'approval';
 
 export function foregroundSurfaceKind({
   activeFormOpen,
+  formBusy,
   pendingApproval,
   taskDetailOpen,
 }: {
   readonly activeFormOpen: boolean;
+  readonly formBusy: boolean;
   readonly pendingApproval: boolean;
   readonly taskDetailOpen: boolean;
 }): ForegroundSurfaceKind | undefined {
   if (taskDetailOpen) return 'taskDetail';
+  if (pendingApproval && formBusy) return 'approval';
   if (activeFormOpen) return 'form';
   if (pendingApproval) return 'approval';
   return undefined;

--- a/packages/cli/src/chat/tui/commands/handlers/agentModelCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/agentModelCommands.ts
@@ -12,6 +12,7 @@ import {
 import {
   patchSessionMeta,
   sessionMeta,
+  setTransientNotice,
   setCliSessionModelOverride,
 } from '@cli/chat/tui/state/cliState';
 import { chatTuiCanStartRootRun } from '@cli/chat/tui/state/sessionRunState';
@@ -52,7 +53,7 @@ export function applyInitialCliAgentSelection(
   context: SlashCommandContext,
 ): void {
   if (!chatTuiCanStartRootRun(context.session)) {
-    appendLocalAssistantTranscript(
+    setTransientNotice(
       'The agent is fixed for this chat session. Start a new chat to use a different agent.',
     );
     return;
@@ -61,7 +62,7 @@ export function applyInitialCliAgentSelection(
   const nextAgent = agentName.trim();
   const usageError = chatToolUseAgentUsageError(nextAgent);
   if (usageError) {
-    appendLocalAssistantTranscript(usageError);
+    setTransientNotice(usageError);
     return;
   }
   patchSessionMeta({

--- a/packages/cli/src/chat/tui/commands/handlers/apiModeCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/apiModeCommands.ts
@@ -15,18 +15,16 @@ import {
   selectCliModelAccessRoute,
 } from '@cli/runtime/modelAccessSelection';
 
-import {
-  patchSessionMeta,
-  sessionMeta,
-  setTransientNotice,
-} from '@cli/chat/tui/state/cliState';
+import { patchSessionMeta, sessionMeta } from '@cli/chat/tui/state/cliState';
 import { chatTuiCanStartRootRun } from '@cli/chat/tui/state/sessionRunState';
-import { appendLocalAssistantTranscript } from '@cli/chat/tui/state/transcript';
 import type { ApiProvider } from '@model/apiProviders';
 import { toErrorMessage } from '@utils/errors/errorMessage';
+import { collapseWhitespace } from '@utils/text/stringUtils';
 import {
   CHAT_API_MODE_MODEL_RECOVERY,
+  type SlashCommandOutput,
   type SlashCommandContext,
+  transcriptSlashCommandOutput,
 } from './slashContext';
 import { loadCliAccountStatusLines } from './statusAssembly';
 
@@ -73,7 +71,9 @@ async function completeModelAccessSelection(
   } catch (error: unknown) {
     modelNotice = toErrorMessage(error);
   }
-  return [access.message, modelNotice].filter(Boolean).join('\n');
+  return collapseWhitespace(
+    [access.message, modelNotice].filter(Boolean).join(' · '),
+  );
 }
 
 /** Save a provider key, select personal access, and reconcile the root model. */
@@ -96,6 +96,7 @@ export function setCliSessionApiMode(apiMode: CliApiMode): void {
 export async function applyCliModelAccessSelection(
   routeInput: string,
   context: SlashCommandContext,
+  output: SlashCommandOutput = transcriptSlashCommandOutput,
 ): Promise<void> {
   const normalized = routeInput.trim().toLowerCase();
 
@@ -105,7 +106,7 @@ export async function applyCliModelAccessSelection(
       apiMode,
       includeApiDetails: true,
     });
-    appendLocalAssistantTranscript(lines.join('\n'));
+    output.appendOutcome(lines.join('\n'));
     return;
   }
 
@@ -114,15 +115,16 @@ export async function applyCliModelAccessSelection(
     const access = await selectCliModelAccessRoute(
       contextForCliModelAccess(context.cliContext, sessionMeta.get().apiMode),
       route,
-      { writeProgress: appendLocalAssistantTranscript },
+      {
+        writeProgress: (message) =>
+          output.writeProgress(message, { copyable: true }),
+      },
     );
-    appendLocalAssistantTranscript(
-      await completeModelAccessSelection(access, context),
-    );
+    output.appendOutcome(await completeModelAccessSelection(access, context));
     return;
   }
 
-  setTransientNotice(MODEL_ACCESS_USAGE);
+  output.setNotice(MODEL_ACCESS_USAGE);
 }
 
 export async function showCliAuthStatus(): Promise<void> {
@@ -130,5 +132,5 @@ export async function showCliAuthStatus(): Promise<void> {
     apiMode: sessionMeta.get().apiMode,
     includeApiDetails: true,
   });
-  appendLocalAssistantTranscript(lines.join('\n'));
+  transcriptSlashCommandOutput.appendOutcome(lines.join('\n'));
 }

--- a/packages/cli/src/chat/tui/commands/handlers/loginCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/loginCommands.ts
@@ -2,9 +2,7 @@ import {
   refreshCodexPreferenceViews,
   setCliCodexSubscription,
 } from '@cli/chat/tui/state/codexSubscription';
-import { sessionMeta, setTransientNotice } from '@cli/chat/tui/state/cliState';
-import { appendLocalAssistantTranscript } from '@cli/chat/tui/state/transcript';
-import { loadCliApiStatusLines } from '@cli/runtime/apiStatus';
+import { sessionMeta } from '@cli/chat/tui/state/cliState';
 import {
   chatGptAccountLabel,
   chatGptSignOutPreferenceMessage,
@@ -31,8 +29,13 @@ import {
 } from '@cli/runtime/supabaseAuth';
 import { formatCliDeviceAuthMessage } from '@cli/runtime/supabaseAuthDeviceCode';
 import { toErrorMessage } from '@utils/errors/errorMessage';
+import { collapseWhitespace } from '@utils/text/stringUtils';
 
 import { setCliSessionApiMode } from './apiModeCommands';
+import {
+  type SlashCommandOutput,
+  transcriptSlashCommandOutput,
+} from './slashContext';
 import { loadCliAccountStatusLines } from './statusAssembly';
 
 const CHAT_LOGIN_USAGE = [
@@ -41,7 +44,7 @@ const CHAT_LOGIN_USAGE = [
 ].join('\n');
 const CHAT_LOGOUT_USAGE = 'Usage: /logout chatgpt | texra | all';
 
-function loginStartMessage(args: CliLoginSlashArgs): string {
+export function loginStartMessage(args: CliLoginSlashArgs): string {
   if (args.target === 'chatgpt') {
     if (args.device) return 'Starting ChatGPT device-code sign-in.';
     if (args.noBrowser) return 'Starting ChatGPT sign-in.';
@@ -54,34 +57,34 @@ function loginStartMessage(args: CliLoginSlashArgs): string {
 
 async function loginToChatGptSubscription(
   args: Extract<CliLoginSlashArgs, { target: 'chatgpt' }>,
+  output: SlashCommandOutput,
 ): Promise<void> {
   const session = await signInCliChatGpt(args, {
-    writeProgress: appendLocalAssistantTranscript,
+    writeProgress: (message) =>
+      output.writeProgress(message, { copyable: true }),
   });
   const update = await setCliCodexSubscription(true);
 
-  appendLocalAssistantTranscript(
-    [
-      `Signed in with ChatGPT as ${chatGptAccountLabel(session)}.`,
-      update.effective
-        ? 'ChatGPT subscription enabled for Codex models.'
-        : `ChatGPT subscription preference is still disabled because a more specific setting overrides ${update.target} config.`,
-    ].join('\n'),
+  output.appendOutcome(
+    update.effective
+      ? `Signed in with ChatGPT as ${chatGptAccountLabel(session)} (Codex models enabled).`
+      : `Signed in with ChatGPT as ${chatGptAccountLabel(session)} (Codex models remain disabled because a more specific setting overrides ${update.target} config).`,
   );
 }
 
 async function loginToTexraIncludedAccess(
   args: CliTexraLoginSlashArgs,
+  output: SlashCommandOutput,
 ): Promise<void> {
   const accountWarning = githubSelectAccountWarning(args);
-  if (accountWarning) appendLocalAssistantTranscript(accountWarning);
+  if (accountWarning) output.writeProgress(accountWarning);
 
   const session = args.device
     ? await signInCliSupabaseDeviceCode({
         onDeviceCode: (authorization) => {
-          appendLocalAssistantTranscript(
-            formatCliDeviceAuthMessage(authorization),
-          );
+          output.writeProgress(formatCliDeviceAuthMessage(authorization), {
+            copyable: true,
+          });
         },
       })
     : await signInCliSupabase({
@@ -92,33 +95,33 @@ async function loginToTexraIncludedAccess(
         manualBrowserHint: '/login --no-browser',
         onAuthUrl: (url) => {
           if (args.noBrowser) {
-            appendLocalAssistantTranscript(formatCliManualAuthUrlMessage(url));
+            output.writeProgress(formatCliManualAuthUrlMessage(url), {
+              copyable: true,
+            });
           }
         },
       });
   setCliSessionApiMode('included');
-  appendLocalAssistantTranscript(
-    [
-      `Signed in as ${session.account.label}.`,
-      ...(await loadCliApiStatusLines({ apiMode: 'included' })),
-    ].join('\n'),
+  output.appendOutcome(
+    `Signed in with TeXRA as ${session.account.label} (included models enabled).`,
   );
 }
 
 export async function loginFromChat(
   input: string,
   context?: CliContext,
+  output: SlashCommandOutput = transcriptSlashCommandOutput,
 ): Promise<void> {
   const args = parseChatLoginSlashArgs(input);
   if (!args) {
-    setTransientNotice(CHAT_LOGIN_USAGE);
+    output.setNotice(CHAT_LOGIN_USAGE);
     return;
   }
 
   // Match the CLI `login` guard: reject `--device` + `--no-browser` from the
   // user's parsed flags before the ChatGPT path can auto-resolve `device`.
   if (hasLoginTransportConflict(args)) {
-    setTransientNotice(LOGIN_TRANSPORT_CONFLICT_MESSAGE);
+    output.setNotice(LOGIN_TRANSPORT_CONFLICT_MESSAGE);
     return;
   }
 
@@ -126,19 +129,22 @@ export async function loginFromChat(
     args.target === 'chatgpt' && context
       ? { ...args, device: shouldUseChatGptDeviceCode(context, args) }
       : args;
-  appendLocalAssistantTranscript(loginStartMessage(loginArgs));
+  output.writeProgress(loginStartMessage(loginArgs));
 
   if (loginArgs.target === 'chatgpt') {
-    await loginToChatGptSubscription(loginArgs);
+    await loginToChatGptSubscription(loginArgs, output);
     return;
   }
-  await loginToTexraIncludedAccess(loginArgs);
+  await loginToTexraIncludedAccess(loginArgs, output);
 }
 
-export async function logoutFromChat(input: string): Promise<void> {
+export async function logoutFromChat(
+  input: string,
+  output: SlashCommandOutput = transcriptSlashCommandOutput,
+): Promise<void> {
   const target = parseCliLogoutTarget(input);
   if (!target) {
-    setTransientNotice(CHAT_LOGOUT_USAGE);
+    output.setNotice(CHAT_LOGOUT_USAGE);
     return;
   }
 
@@ -185,5 +191,5 @@ export async function logoutFromChat(input: string): Promise<void> {
     lines.push(toErrorMessage(error));
   }
 
-  appendLocalAssistantTranscript(lines.join(' · '));
+  output.appendOutcome(collapseWhitespace(lines.join(' · ')));
 }

--- a/packages/cli/src/chat/tui/commands/handlers/slashContext.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/slashContext.ts
@@ -1,7 +1,9 @@
 import { type CliContext } from '@cli/runtime/cliContext';
 import { type CliNoAvailableModelsRecoveryOptions } from '@cli/runtime/modelAccess';
 import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
+import { setTransientNotice } from '@cli/chat/tui/state/cliState';
 import { type TuiSession } from '@cli/chat/tui/state/sessionRunState';
+import { appendLocalAssistantTranscript } from '@cli/chat/tui/state/transcript';
 import { type ExecutionId } from '@shared/schemas';
 
 import {
@@ -27,6 +29,23 @@ export interface SlashCommandContext {
   readonly resetSession: () => void;
   readonly resumeExecution: (id: ExecutionId) => Promise<void>;
 }
+
+/** Output boundary shared by direct slash dispatch and busy form submission. */
+export interface SlashCommandOutput {
+  readonly appendOutcome: (message: string) => void;
+  readonly setNotice: (message: string) => void;
+  readonly writeProgress: (
+    message: string,
+    options?: { readonly copyable?: boolean },
+  ) => void;
+}
+
+/** Direct command output remains in the ordinary TUI transcript. */
+export const transcriptSlashCommandOutput: SlashCommandOutput = {
+  appendOutcome: appendLocalAssistantTranscript,
+  setNotice: setTransientNotice,
+  writeProgress: (message) => appendLocalAssistantTranscript(message),
+};
 
 export const CHAT_API_MODE_MODEL_RECOVERY = {
   includedModeAction: 'switch to included TeXRA access with `/api included`',

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -142,10 +142,23 @@ function formSelectionHandler<T>({
         }
       };
       const title = busyTitle?.(value) ?? 'Working';
+      const archiveCopyable = (): void => {
+        const current = currentProgress();
+        if (!current?.copyableMessage) return;
+        if (echoOnPersist) onPersist?.();
+        appendLocalAssistantTranscript(current.copyableMessage);
+        formProgress.set({
+          ...current,
+          message: 'Authentication instructions were written to scrollback.',
+          copyableMessage: undefined,
+          archivedCopyableMessage: current.copyableMessage,
+        });
+      };
       formProgress.set({
         token,
         status: 'running',
         title,
+        archiveCopyable,
         cancel,
         dismiss: close,
       });
@@ -186,7 +199,7 @@ function formSelectionHandler<T>({
         .then(() => {
           const current = currentProgress();
           if (!current) return;
-          if (current.copyableMessage) {
+          if (current.copyableMessage || current.archivedCopyableMessage) {
             formProgress.set({ ...current, status: 'succeeded' });
           } else {
             close();
@@ -197,17 +210,19 @@ function formSelectionHandler<T>({
           if (!current) return;
           if (echoOnPersist) onPersist?.();
           const errorMessage = toErrorMessage(error);
-          const persistedError = current.copyableMessage
+          const copyableMessage =
+            current.copyableMessage ?? current.archivedCopyableMessage;
+          const persistedError = copyableMessage
             ? new Error(
                 `${collapseWhitespace(errorMessage)} · ${collapseWhitespace(
-                  current.copyableMessage,
+                  copyableMessage,
                 )}`,
               )
             : error;
           await onError?.(persistedError);
           current = currentProgress();
           if (!current) return;
-          if (current.copyableMessage) {
+          if (current.copyableMessage || current.archivedCopyableMessage) {
             formProgress.set({
               ...current,
               status: 'failed',

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -3,12 +3,17 @@
 import type { GetModelSwitchDisabledReason } from '@cli/runtime/modelAccess';
 import { parseCliHistoryId } from '@cli/runtime/history';
 import type { CliModelAccessRoute } from '@cli/runtime/modelAccessRoute';
-import type { CliLogoutTarget } from '@cli/runtime/loginOptions';
+import {
+  type CliLogoutTarget,
+  parseChatLoginSlashArgs,
+} from '@cli/runtime/loginOptions';
 import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
 import type { ApiProvider } from '@model/apiProviders';
 import { AgentCategory, type ExecutionId } from '@shared/schemas';
 import { PROVIDER_DISPLAY_NAMES } from '@shared/constants/providers';
 import type { SettingsStores } from '@shared/config/settingsAccess';
+import { toErrorMessage } from '@utils/errors/errorMessage';
+import { collapseWhitespace } from '@utils/text/stringUtils';
 
 import { ModelAccessForm } from '../forms/ModelAccessForm';
 import { AgentListForm } from '../forms/AgentListForm';
@@ -25,8 +30,11 @@ import { SkillsListForm, type SkillActivation } from '../forms/SkillsListForm';
 import { ToolsListForm } from '../forms/ToolsListForm';
 import {
   activeForm,
+  formProgress,
+  getCliStateGeneration,
   patchSessionMeta,
   sessionMeta,
+  setTransientNotice,
   setCliSessionModelOverride,
 } from '../state/cliState';
 import { appendLocalAssistantTranscript } from '../state/transcript';
@@ -39,7 +47,15 @@ import {
   applyCliProviderApiKey,
 } from './handlers/apiModeCommands';
 import { applyCliApprovalPolicySelection } from './handlers/approvalCommand';
-import { loginFromChat, logoutFromChat } from './handlers/loginCommands';
+import {
+  loginFromChat,
+  loginStartMessage,
+  logoutFromChat,
+} from './handlers/loginCommands';
+import {
+  type SlashCommandOutput,
+  transcriptSlashCommandOutput,
+} from './handlers/slashContext';
 import {
   showCliMemoryList,
   showCliMemoryPreview,
@@ -52,20 +68,29 @@ type ApprovalPolicySelectHandler = (
   value: CliApprovalPolicy,
 ) => void | Promise<void>;
 type ModelSelectHandler = (value: string) => void | Promise<void>;
+type FormActionResult =
+  void | (Promise<void> & { readonly abort?: () => void });
 type ModelAccessSelectHandler = (
   value: CliModelAccessRoute,
-) => void | Promise<void>;
+  output: SlashCommandOutput,
+) => FormActionResult;
 type ApiKeySaveHandler = (
   provider: ApiProvider,
   key: string,
 ) => string | void | Promise<string | void>;
-type LoginSelectHandler = (value: LoginFormValue) => void | Promise<void>;
-type LogoutSelectHandler = (value: CliLogoutTarget) => void | Promise<void>;
+type LoginSelectHandler = (
+  value: LoginFormValue,
+  output: SlashCommandOutput,
+) => FormActionResult;
+type LogoutSelectHandler = (
+  value: CliLogoutTarget,
+  output: SlashCommandOutput,
+) => FormActionResult;
 type MemorySelectHandler = (storagePath: string) => void | Promise<void>;
 type ResumeSelectHandler = (id: ExecutionId) => void | Promise<void>;
 type SkillSelectHandler = (value: SkillActivation) => void | Promise<void>;
 type ErrorHandler = (error: unknown) => void | Promise<void>;
-type SelectionCompletion = 'afterAction' | 'beforeAction';
+type SelectionCompletion = 'afterAction' | 'beforeAction' | 'busy';
 
 /** Build a form selection handler with consistent completion and errors. */
 function formSelectionHandler<T>({
@@ -75,22 +100,133 @@ function formSelectionHandler<T>({
   onPersist,
   echoOnPersist = false,
   completion = 'afterAction',
+  busyTitle,
+  abandonNotice = 'Operation abandoned; it may still complete.',
 }: {
-  readonly action: (value: T) => void | Promise<void>;
+  readonly action: (value: T, output: SlashCommandOutput) => FormActionResult;
   readonly onDone: (value: T) => void;
   readonly onError?: ErrorHandler;
   readonly onPersist?: () => void;
   readonly echoOnPersist?: boolean;
   readonly completion?: SelectionCompletion;
+  readonly busyTitle?: (value: T) => string;
+  readonly abandonNotice?: string;
 }): (value: T) => void {
   return (value) => {
+    if (completion === 'busy') {
+      const generation = getCliStateGeneration();
+      const token = Symbol('form submission');
+      const actionController: { abort?: () => void } = {};
+      const currentProgress = () => {
+        if (generation !== getCliStateGeneration()) return undefined;
+        const current = formProgress.get();
+        return current?.token === token ? current : undefined;
+      };
+      const close = (): void => {
+        if (!currentProgress()) return;
+        formProgress.set(undefined);
+        onDone(value);
+      };
+      const cancel = (): void => {
+        if (!currentProgress()) return;
+        const canAbort = actionController.abort !== undefined;
+        try {
+          actionController.abort?.();
+        } catch {
+          // Detaching must still restore the form boundary if abort fails.
+        }
+        formProgress.set(undefined);
+        onDone(value);
+        if (!canAbort && generation === getCliStateGeneration()) {
+          setTransientNotice(abandonNotice);
+        }
+      };
+      const title = busyTitle?.(value) ?? 'Working';
+      formProgress.set({
+        token,
+        status: 'running',
+        title,
+        cancel,
+        dismiss: close,
+      });
+
+      const output: SlashCommandOutput = {
+        appendOutcome: (message) => {
+          if (!currentProgress()) return;
+          if (echoOnPersist) onPersist?.();
+          appendLocalAssistantTranscript(message);
+          const current = currentProgress();
+          if (current) formProgress.set({ ...current, message });
+        },
+        setNotice: (message) => {
+          if (currentProgress()) setTransientNotice(message);
+        },
+        writeProgress: (message, options) => {
+          const current = currentProgress();
+          if (!current) return;
+          formProgress.set({
+            ...current,
+            message,
+            copyableMessage: options?.copyable
+              ? message
+              : current.copyableMessage,
+          });
+        },
+      };
+
+      let actionResult: FormActionResult;
+      try {
+        actionResult = action(value, output);
+      } catch (error: unknown) {
+        actionResult = Promise.reject(error);
+      }
+      if (actionResult?.abort) actionController.abort = actionResult.abort;
+
+      void Promise.resolve(actionResult)
+        .then(() => {
+          const current = currentProgress();
+          if (!current) return;
+          if (current.copyableMessage) {
+            formProgress.set({ ...current, status: 'succeeded' });
+          } else {
+            close();
+          }
+        })
+        .catch(async (error: unknown) => {
+          let current = currentProgress();
+          if (!current) return;
+          if (echoOnPersist) onPersist?.();
+          const errorMessage = toErrorMessage(error);
+          const persistedError = current.copyableMessage
+            ? new Error(
+                `${collapseWhitespace(errorMessage)} · ${collapseWhitespace(
+                  current.copyableMessage,
+                )}`,
+              )
+            : error;
+          await onError?.(persistedError);
+          current = currentProgress();
+          if (!current) return;
+          if (current.copyableMessage) {
+            formProgress.set({
+              ...current,
+              status: 'failed',
+              message: errorMessage,
+            });
+          } else {
+            close();
+          }
+        });
+      return;
+    }
+
     if (echoOnPersist) onPersist?.();
     if (completion === 'beforeAction') {
       onDone(value);
     }
 
     const runAction = async (): Promise<void> => {
-      await action(value);
+      await action(value, transcriptSlashCommandOutput);
     };
 
     void runAction()
@@ -130,15 +266,18 @@ export function registerBuiltinSlashCommands(options?: {
     options?.onModelSelect ?? setCliSessionModelOverride;
   const onModelAccessSelect: ModelAccessSelectHandler =
     options?.onModelAccessSelect ??
-    ((route) => {
+    ((route, output) => {
       if (route !== 'chatgpt') patchSessionMeta({ apiMode: route });
+      output.appendOutcome(`Model access set to ${route}.`);
     });
   const onApiKeySave: ApiKeySaveHandler =
     options?.onApiKeySave ?? applyCliProviderApiKey;
   const onLoginSelect: LoginSelectHandler =
-    options?.onLoginSelect ?? loginFromChat;
+    options?.onLoginSelect ??
+    ((value, output) => loginFromChat(value, undefined, output));
   const onLogoutSelect: LogoutSelectHandler =
-    options?.onLogoutSelect ?? logoutFromChat;
+    options?.onLogoutSelect ??
+    ((value, output) => logoutFromChat(value, output));
   const canSelectAgent = options?.canSelectAgent ?? (() => true);
   const canSelectModel = options?.canSelectModel ?? (() => true);
 
@@ -194,7 +333,10 @@ export function registerBuiltinSlashCommands(options?: {
           onError: options?.onError,
           onPersist: props.onPersist,
           echoOnPersist: props.echoOnPersist,
-          completion: 'beforeAction',
+          completion: 'busy',
+          busyTitle: () => 'Updating model access',
+          abandonNotice:
+            'Model access update abandoned; it may still complete.',
         })}
         onCancel={() => props.onDone(undefined)}
       />
@@ -247,7 +389,13 @@ export function registerBuiltinSlashCommands(options?: {
           action: onLoginSelect,
           onDone: props.onDone,
           onError: options?.onError,
-          completion: 'beforeAction',
+          completion: 'busy',
+          busyTitle: (value) => {
+            const args = parseChatLoginSlashArgs(value);
+            return args ? loginStartMessage(args) : 'Signing in';
+          },
+          abandonNotice:
+            'Sign-in abandoned; the browser flow may still complete.',
           onPersist: props.onPersist,
           echoOnPersist: props.echoOnPersist,
         })}
@@ -264,7 +412,9 @@ export function registerBuiltinSlashCommands(options?: {
           action: onLogoutSelect,
           onDone: props.onDone,
           onError: options?.onError,
-          completion: 'beforeAction',
+          completion: 'busy',
+          busyTitle: () => 'Signing out',
+          abandonNotice: 'Sign-out abandoned; it may still complete.',
           onPersist: props.onPersist,
           echoOnPersist: props.echoOnPersist,
         })}
@@ -429,7 +579,7 @@ export function registerBuiltinSlashCommands(options?: {
     description: 'Sign out of one account or all accounts',
     category: 'account',
     echo: 'ifPersists',
-    argHandler: logoutFromChat,
+    argHandler: (remainder) => logoutFromChat(remainder),
     formName: 'logout',
     formComponent: LogoutFormAdapter,
   });
@@ -523,7 +673,12 @@ export function registerBuiltinSlashCommands(options?: {
               props.onPersist?.();
               await options?.onError?.(error);
             },
-            onApiModePersonal: () => onModelAccessSelect('personal'),
+            onApiModePersonal: async () => {
+              await onModelAccessSelect(
+                'personal',
+                transcriptSlashCommandOutput,
+              );
+            },
           })}
         />
       );

--- a/packages/cli/src/chat/tui/commands/slashForms.tsx
+++ b/packages/cli/src/chat/tui/commands/slashForms.tsx
@@ -1,5 +1,12 @@
-import { activeForm } from '../state/cliState';
+import { Box, Text, useInput } from 'ink';
+
+import { isEscapeInput } from '../input/inputKeys';
+import { FormFrame } from '../forms/_shared/FormFrame';
+import { activeForm, formProgress, type FormProgress } from '../state/cliState';
 import { appendLocalUserTranscript } from '../state/transcript';
+import { COLOR_ERROR } from '../ui/colors';
+import { KeyHints } from '../ui/KeyHints';
+import { LoadingIndicator } from '../ui/LoadingIndicator';
 
 import {
   findSlashCommand,
@@ -9,6 +16,56 @@ import {
 
 export function appendSlashCommandEcho(line: string): void {
   if (!shouldRedactSlashInput(line)) appendLocalUserTranscript(line.trim());
+}
+
+/** Submit-side busy/settled surface for the active registered form. */
+function FormBusyFrame(props: {
+  readonly progress: FormProgress;
+}): React.JSX.Element {
+  const { progress } = props;
+  const settled = progress.status !== 'running';
+  useInput((input, key) => {
+    if (key.ctrl) return;
+    if (settled) {
+      progress.dismiss();
+      return;
+    }
+    if (isEscapeInput(input, key)) progress.cancel();
+  });
+
+  let titleSuffix = '';
+  if (progress.status === 'succeeded') titleSuffix = ' · complete';
+  if (progress.status === 'failed') titleSuffix = ' · error';
+  const spinnerFrozen = progress.copyableMessage !== undefined;
+  return (
+    <FormFrame
+      color={progress.status === 'failed' ? COLOR_ERROR : undefined}
+      title={`${progress.title}${titleSuffix}`}
+      showCloseHint={false}
+    >
+      {progress.status === 'running' && !spinnerFrozen ? (
+        <LoadingIndicator label={progress.message ?? 'working...'} />
+      ) : (
+        progress.message && <Text>{progress.message}</Text>
+      )}
+      {progress.copyableMessage &&
+        progress.copyableMessage !== progress.message && (
+          <Box marginTop={1}>
+            <Text>{progress.copyableMessage}</Text>
+          </Box>
+        )}
+      <Box marginTop={1}>
+        <KeyHints
+          hints={[
+            settled
+              ? { key: 'any key', action: 'close' }
+              : { key: 'Esc', action: 'cancel' },
+          ]}
+          confirmCancel={false}
+        />
+      </Box>
+    </FormFrame>
+  );
 }
 
 export function openRegisteredCliSlashForm(
@@ -24,18 +81,23 @@ export function openRegisteredCliSlashForm(
     persisted = true;
     onPersist?.();
   };
+  formProgress.set(undefined);
   activeForm.set({
     commandName: command.name,
     escapeAction: command.formEscapeAction,
-    render: (close, availableRows) => (
-      <Form
-        availableRows={availableRows}
-        remainder={remainder.trimStart()}
-        onPersist={onPersist ? persist : undefined}
-        echoOnPersist={command.echo === 'ifPersists'}
-        onDone={() => close()}
-      />
-    ),
+    render: (close, availableRows) => {
+      const progress = formProgress.get();
+      if (progress) return <FormBusyFrame progress={progress} />;
+      return (
+        <Form
+          availableRows={availableRows}
+          remainder={remainder.trimStart()}
+          onPersist={onPersist ? persist : undefined}
+          echoOnPersist={command.echo === 'ifPersists'}
+          onDone={close}
+        />
+      );
+    },
   });
   return true;
 }

--- a/packages/cli/src/chat/tui/commands/slashForms.tsx
+++ b/packages/cli/src/chat/tui/commands/slashForms.tsx
@@ -1,7 +1,9 @@
-import { Box, Text, useInput } from 'ink';
+import { Box, Text, useInput, useWindowSize } from 'ink';
+import { useLayoutEffect } from 'react';
 
 import { isEscapeInput } from '../input/inputKeys';
-import { FormFrame } from '../forms/_shared/FormFrame';
+import { FormFrame, formFrameWidth } from '../forms/_shared/FormFrame';
+import { textDisplayWidth } from '../render/terminalText';
 import { activeForm, formProgress, type FormProgress } from '../state/cliState';
 import { appendLocalUserTranscript } from '../state/transcript';
 import { COLOR_ERROR } from '../ui/colors';
@@ -21,8 +23,10 @@ export function appendSlashCommandEcho(line: string): void {
 /** Submit-side busy/settled surface for the active registered form. */
 function FormBusyFrame(props: {
   readonly progress: FormProgress;
+  readonly availableRows?: number;
 }): React.JSX.Element {
   const { progress } = props;
+  const { columns } = useWindowSize();
   const settled = progress.status !== 'running';
   useInput((input, key) => {
     if (key.ctrl) return;
@@ -36,19 +40,45 @@ function FormBusyFrame(props: {
   let titleSuffix = '';
   if (progress.status === 'succeeded') titleSuffix = ' · complete';
   if (progress.status === 'failed') titleSuffix = ' · error';
+  const title = `${progress.title}${titleSuffix}`;
+  const innerWidth = Math.max(1, formFrameWidth(columns) - 4);
+  const wrappedRows = (text: string): number =>
+    text.split('\n').reduce((rows, line) => {
+      const width = textDisplayWidth(line.replaceAll('\t', '    '));
+      return rows + Math.max(1, Math.ceil(width / innerWidth));
+    }, 0);
+  const copyableDoesNotFit =
+    progress.copyableMessage !== undefined &&
+    props.availableRows !== undefined &&
+    2 +
+      wrappedRows(title) +
+      wrappedRows(progress.message ?? 'working...') +
+      (progress.copyableMessage === progress.message
+        ? 0
+        : 1 + wrappedRows(progress.copyableMessage)) +
+      1 +
+      wrappedRows(settled ? 'any key close' : 'Esc cancel') >
+      props.availableRows;
+  useLayoutEffect(() => {
+    if (copyableDoesNotFit) progress.archiveCopyable?.();
+  }, [copyableDoesNotFit, progress]);
   const spinnerFrozen = progress.copyableMessage !== undefined;
+  const displayMessage = copyableDoesNotFit
+    ? 'Authentication instructions are being written to scrollback.'
+    : progress.message;
   return (
     <FormFrame
       color={progress.status === 'failed' ? COLOR_ERROR : undefined}
-      title={`${progress.title}${titleSuffix}`}
+      title={title}
       showCloseHint={false}
     >
       {progress.status === 'running' && !spinnerFrozen ? (
-        <LoadingIndicator label={progress.message ?? 'working...'} />
+        <LoadingIndicator label={displayMessage ?? 'working...'} />
       ) : (
-        progress.message && <Text>{progress.message}</Text>
+        displayMessage && <Text>{displayMessage}</Text>
       )}
-      {progress.copyableMessage &&
+      {!copyableDoesNotFit &&
+        progress.copyableMessage &&
         progress.copyableMessage !== progress.message && (
           <Box marginTop={1}>
             <Text>{progress.copyableMessage}</Text>
@@ -87,7 +117,11 @@ export function openRegisteredCliSlashForm(
     escapeAction: command.formEscapeAction,
     render: (close, availableRows) => {
       const progress = formProgress.get();
-      if (progress) return <FormBusyFrame progress={progress} />;
+      if (progress) {
+        return (
+          <FormBusyFrame progress={progress} availableRows={availableRows} />
+        );
+      }
       return (
         <Form
           availableRows={availableRows}

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -106,7 +106,6 @@ import {
   streams as streamsSignal,
   clearTransientNotice,
   setTransientNotice,
-  transientNotice as transientNoticeSignal,
 } from './state/cliState';
 import {
   childStreamEntries as childStreamEntriesSignal,
@@ -596,12 +595,12 @@ export async function runChat(
     getModelSwitchDisabledReason,
     onModelSelect: (nextModel) =>
       applyCliModelSelection(nextModel, slashCommandContext()),
-    onModelAccessSelect: (route) =>
-      applyCliModelAccessSelection(route, slashCommandContext()),
+    onModelAccessSelect: (route, output) =>
+      applyCliModelAccessSelection(route, slashCommandContext(), output),
     onApiKeySave: (provider, key) =>
       applyCliProviderApiKey(provider, key, slashCommandContext()),
-    onLoginSelect: (value) => loginFromChat(value, context),
-    onLogoutSelect: logoutFromChat,
+    onLoginSelect: (value, output) => loginFromChat(value, context, output),
+    onLogoutSelect: (value, output) => logoutFromChat(value, output),
     onMemorySelect: showCliMemoryPreview,
     onSkillSelect: activateSkillForNextMessage,
     onResumeSelect: (id: ExecutionId) => chatController.resume(id),
@@ -870,12 +869,19 @@ export async function runChat(
   );
   inkRef.current = ink;
 
+  // The notice is regenerable display state; replacing it must not change
+  // whether a second Ctrl-C confirms the exit already requested by the first.
+  let exitConfirmationExpiresAt = 0;
   const terminalJobControlSupported = supportsTerminalJobControl();
   // Set once a signal exit (exitNow) starts: its ink.unmount() resolves
   // waitUntilExit and re-enters the post-waitUntilExit finally, so the finally
   // guards on this to avoid draining persistence / printing the resume hint a
   // second time.
   let exiting = false;
+  const clearExitConfirmation = (): void => {
+    exitConfirmationExpiresAt = 0;
+    clearTransientNotice();
+  };
   const removeProcessHandlers = (): void => {
     process.off('SIGINT', handleSigint);
     process.off('SIGTERM', handleSigterm);
@@ -931,7 +937,7 @@ export async function runChat(
   const exitNow = (exitCode: number): void => {
     exiting = true;
     removeProcessHandlers();
-    clearTransientNotice();
+    clearExitConfirmation();
     ink.unmount();
     cleanupTerminalModes({ clearItermProgress });
     // Print the resume hint last, after Ink has torn down and the terminal modes
@@ -949,6 +955,7 @@ export async function runChat(
     ]).finally(() => process.exit(exitCode));
   };
   const armExit = (): void => {
+    exitConfirmationExpiresAt = Date.now() + EXIT_CONFIRMATION_TTL_MS;
     setTransientNotice('Press Ctrl-C again to exit', {
       kind: 'exit',
       resumeId: transcriptLifecycle.canResume ? session.executionId : undefined,
@@ -957,7 +964,7 @@ export async function runChat(
   };
   const handleSigint = (): void => {
     const sigintAction = chatTuiSigintAction({
-      exitArmed: transientNoticeSignal.get()?.kind === 'exit',
+      exitArmed: Date.now() < exitConfirmationExpiresAt,
       canStopActiveRun: canStopActiveRun(),
       resumableIdle: isResumableIdle(),
     });
@@ -1024,7 +1031,7 @@ export async function runChat(
   };
   function requestInputExit(): void {
     removeProcessHandlers();
-    clearTransientNotice();
+    clearExitConfirmation();
     ink.unmount();
   }
   // Ownership transfers right here, not any earlier: everything above this
@@ -1076,7 +1083,7 @@ export async function runChat(
     // async exit, dropping the flush and the signal exit code.
     if (!exiting) {
       removeProcessHandlers();
-      clearTransientNotice();
+      clearExitConfirmation();
       for (const dispose of disposers) dispose();
       await followUpQueue.onIdle();
       // A suspended (idle/WAITING) root session is resumable: its flow record

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -573,6 +573,8 @@ export interface FormProgress {
   readonly title: string;
   readonly message?: string;
   readonly copyableMessage?: string;
+  readonly archivedCopyableMessage?: string;
+  readonly archiveCopyable?: () => void;
   readonly cancel: () => void;
   readonly dismiss: () => void;
 }

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -566,6 +566,21 @@ export function registerCliStateResetHook(resetHook: () => void): void {
   RESET_HOOKS.add(resetHook);
 }
 
+/** Submit-side state for the one active slash form. */
+export interface FormProgress {
+  readonly token: symbol;
+  readonly status: 'running' | 'succeeded' | 'failed';
+  readonly title: string;
+  readonly message?: string;
+  readonly copyableMessage?: string;
+  readonly cancel: () => void;
+  readonly dismiss: () => void;
+}
+
+const FORM_PROGRESS = signal<FormProgress | undefined>(undefined);
+export const formProgress = FORM_PROGRESS;
+registerCliStateResetHook(() => FORM_PROGRESS.set(undefined));
+
 export function resetCliState(
   nextSessionMeta: SessionMeta = defaultSessionMeta(),
 ): void {

--- a/src/test-kernel/cli/AppInteractionPolicy.vitest.mts
+++ b/src/test-kernel/cli/AppInteractionPolicy.vitest.mts
@@ -100,6 +100,7 @@ function foregroundInput(
 ): ForegroundSurfaceInput {
   return {
     activeFormOpen: false,
+    formBusy: false,
     pendingApproval: true,
     taskDetailOpen: false,
     ...overrides,
@@ -294,10 +295,11 @@ describe('app interaction policy', () => {
     }
   });
 
-  it('prioritizes foreground surfaces ahead of approvals', () => {
+  it('lets approvals preempt only a busy form', () => {
     const cases = [
       [foregroundInput({ taskDetailOpen: true }), 'taskDetail'],
       [foregroundInput({ activeFormOpen: true }), 'form'],
+      [foregroundInput({ activeFormOpen: true, formBusy: true }), 'approval'],
       [foregroundInput(), 'approval'],
       [foregroundInput({ pendingApproval: false }), undefined],
     ] satisfies readonly (readonly [

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
@@ -411,6 +411,9 @@ describe('handleTuiSlashCommand', () => {
       'chatgpt',
       expect.any(Object),
     );
+    expect(lastEntryText()).toBe(
+      'Model access: ChatGPT subscription. · This model access setting applies to new chats. The current chat keeps its existing model connection.',
+    );
     expect(codexPreferenceVersion.get()).toBe(previousPreferenceVersion + 1);
   });
 

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -21,8 +21,10 @@ import {
 import { LOGIN_FORM_ITEMS } from '@cli/chat/tui/forms/LoginForm';
 import {
   activeForm,
+  formProgress,
   resetCliState,
   sessionMeta,
+  transientNotice,
   type SessionMeta,
 } from '@cli/chat/tui/state/cliState';
 import type { CliModelAccessRoute } from '@cli/runtime/modelAccessRoute';
@@ -450,7 +452,7 @@ describe('slashRegistry', () => {
     expect(apiNode.isClosed()).toBe(true);
   });
 
-  it('closes the model-access picker before an asynchronous action', async () => {
+  it('keeps model-access selection in a busy form until it settles', async () => {
     resetCliState(INCLUDED_CHAT_SESSION);
     const selection = deferredSelection();
     registerBuiltinSlashCommands({
@@ -468,7 +470,11 @@ describe('slashRegistry', () => {
     apiNode.props?.onSelect?.('personal');
     await settleFormSelection();
 
-    expect(apiNode.isClosed()).toBe(true);
+    expect(apiNode.isClosed()).toBe(false);
+    expect(formProgress.get()).toMatchObject({
+      status: 'running',
+      title: 'Updating model access',
+    });
 
     selection.resolve();
     await settleFormSelection();
@@ -505,7 +511,7 @@ describe('slashRegistry', () => {
     expect(keyNode.isClosed()).toBe(true);
   });
 
-  it('closes the login picker before running the selected login path', async () => {
+  it('closes the login form after the selected login path settles', async () => {
     const selected: string[] = [];
     let closed = false;
     let sawClosedBeforeLogin = false;
@@ -533,7 +539,151 @@ describe('slashRegistry', () => {
 
     expect(selected).toEqual(['chatgpt']);
     expect(closed).toBe(true);
-    expect(sawClosedBeforeLogin).toBe(true);
+    expect(sawClosedBeforeLogin).toBe(false);
+  });
+
+  it('holds a copyable login frame until the user dismisses it', async () => {
+    registerBuiltinSlashCommands({
+      onLoginSelect: (_value, output) => {
+        output.writeProgress('Open https://example.test/device', {
+          copyable: true,
+        });
+      },
+    });
+    const login = findSlashCommand('login');
+    if (!login) throw new Error('Expected /login to be registered');
+
+    expect(openRegisteredCliSlashForm(login, '')).toBe(true);
+    const loginNode = renderOpenForm<{
+      onSelect?: (value: string) => void;
+    }>();
+    loginNode.props?.onSelect?.('chatgpt');
+    await settleFormSelection();
+
+    expect(loginNode.isClosed()).toBe(false);
+    expect(formProgress.get()).toMatchObject({
+      status: 'succeeded',
+      message: 'Open https://example.test/device',
+      copyableMessage: 'Open https://example.test/device',
+    });
+
+    formProgress.get()?.dismiss();
+    expect(loginNode.isClosed()).toBe(true);
+  });
+
+  it('detaches a busy login and ignores its late completion', async () => {
+    const selection = deferredSelection();
+    registerBuiltinSlashCommands({
+      onLoginSelect: (_value, output) => {
+        output.writeProgress('Open https://example.test/device', {
+          copyable: true,
+        });
+        return selection.promise;
+      },
+    });
+    const login = findSlashCommand('login');
+    if (!login) throw new Error('Expected /login to be registered');
+
+    expect(openRegisteredCliSlashForm(login, '')).toBe(true);
+    const loginNode = renderOpenForm<{
+      onSelect?: (value: string) => void;
+    }>();
+    loginNode.props?.onSelect?.('chatgpt');
+    formProgress.get()?.cancel();
+
+    expect(loginNode.isClosed()).toBe(true);
+    expect(formProgress.get()).toBeUndefined();
+    expect(transientNotice.get()?.text).toContain('Sign-in abandoned');
+
+    selection.resolve();
+    await settleFormSelection();
+    expect(formProgress.get()).toBeUndefined();
+  });
+
+  it('keeps a failed login URL in its one persistent error', async () => {
+    const errors: string[] = [];
+    registerBuiltinSlashCommands({
+      onLoginSelect: (_value, output) => {
+        output.writeProgress('Open https://example.test/manual', {
+          copyable: true,
+        });
+        throw new Error('Sign-in failed');
+      },
+      onError: (error) => {
+        errors.push(toErrorMessage(error));
+      },
+    });
+    const login = findSlashCommand('login');
+    if (!login) throw new Error('Expected /login to be registered');
+
+    expect(openRegisteredCliSlashForm(login, '')).toBe(true);
+    const loginNode = renderOpenForm<{
+      onSelect?: (value: string) => void;
+    }>();
+    loginNode.props?.onSelect?.('chatgpt');
+    await settleFormSelection();
+
+    expect(errors).toEqual([
+      'Sign-in failed · Open https://example.test/manual',
+    ]);
+    expect(formProgress.get()).toMatchObject({
+      status: 'failed',
+      copyableMessage: 'Open https://example.test/manual',
+    });
+    expect(loginNode.isClosed()).toBe(false);
+  });
+
+  it('drops a busy form completion after CLI state reset', async () => {
+    const selection = deferredSelection();
+    const outcomes: string[] = [];
+    registerBuiltinSlashCommands({
+      onModelAccessSelect: async (_value, output) => {
+        await selection.promise;
+        output.appendOutcome('late outcome');
+        outcomes.push('action settled');
+      },
+    });
+    const api = findSlashCommand('api');
+    if (!api) throw new Error('Expected /api to be registered');
+
+    expect(openRegisteredCliSlashForm(api, '')).toBe(true);
+    const apiNode = renderOpenForm<{
+      onSelect?: (value: CliModelAccessRoute) => void;
+    }>();
+    apiNode.props?.onSelect?.('personal');
+    resetCliState(INCLUDED_CHAT_SESSION);
+    selection.resolve();
+    await settleFormSelection();
+
+    expect(outcomes).toEqual(['action settled']);
+    expect(formProgress.get()).toBeUndefined();
+    expect(apiNode.isClosed()).toBe(false);
+  });
+
+  it('calls an available abort hook when a busy form is cancelled', () => {
+    let aborted = false;
+    const selection = deferredSelection();
+    const completion = selection.promise as Promise<void> & {
+      abort?: () => void;
+    };
+    completion.abort = () => {
+      aborted = true;
+    };
+    registerBuiltinSlashCommands({
+      onLogoutSelect: () => completion,
+    });
+    const logout = findSlashCommand('logout');
+    if (!logout) throw new Error('Expected /logout to be registered');
+
+    expect(openRegisteredCliSlashForm(logout, '')).toBe(true);
+    const logoutNode = renderOpenForm<{
+      onSelect?: (value: 'all') => void;
+    }>();
+    logoutNode.props?.onSelect?.('all');
+    formProgress.get()?.cancel();
+
+    expect(aborted).toBe(true);
+    expect(transientNotice.get()).toBeUndefined();
   });
 
   it('closes the approval policy picker before applying the new policy', async () => {

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -1,5 +1,12 @@
 // Slash command registry and parse helpers.
 
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
+import { EventEmitter } from 'node:events';
+import { createRequire } from 'node:module';
+import { setTimeout as sleep } from 'node:timers/promises';
+
 import { afterEach, describe, expect, it } from 'vitest';
 
 import {
@@ -24,9 +31,11 @@ import {
   formProgress,
   resetCliState,
   sessionMeta,
+  streams,
   transientNotice,
   type SessionMeta,
 } from '@cli/chat/tui/state/cliState';
+import { CLI_LOCAL_STREAM_ID } from '@cli/chat/tui/state/transcript';
 import type { CliModelAccessRoute } from '@cli/runtime/modelAccessRoute';
 import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
 import { AgentCategory } from '@shared/schemas/agent';
@@ -44,6 +53,49 @@ const INCLUDED_CHAT_SESSION: SessionMeta = {
   transcriptMode: 'persistent',
   version: 'test',
 };
+
+const cliRequire = createRequire(
+  new URL('../../../packages/cli/package.json', import.meta.url),
+);
+
+class FakeStdout extends EventEmitter {
+  readonly isTTY = true;
+  readonly columns = 80;
+  readonly rows = 24;
+  output = '';
+
+  write(chunk: string): boolean {
+    this.output += chunk;
+    return true;
+  }
+
+  getColorDepth(): number {
+    return 24;
+  }
+}
+
+class FakeStdin extends EventEmitter {
+  readonly isTTY = true;
+
+  read(): null {
+    return null;
+  }
+
+  ref(): void {}
+  unref(): void {}
+  pause(): void {}
+  resume(): void {}
+  setEncoding(): void {}
+  setRawMode(): void {}
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 2000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error('Timed out waiting for state');
+    await sleep(10);
+  }
+}
 
 afterEach(() => {
   for (const cmd of [...listSlashCommands()]) unregisterSlashCommand(cmd.name);
@@ -569,6 +621,61 @@ describe('slashRegistry', () => {
 
     formProgress.get()?.dismiss();
     expect(loginNode.isClosed()).toBe(true);
+  });
+
+  it('moves a login instruction to scrollback when its frame cannot fit', async () => {
+    const instruction =
+      'Open https://example.test/device and enter verification code ABCD-EFGH';
+    registerBuiltinSlashCommands({
+      onLoginSelect: (_value, output) => {
+        output.writeProgress(instruction, { copyable: true });
+      },
+    });
+    const login = findSlashCommand('login');
+    if (!login) throw new Error('Expected /login to be registered');
+
+    expect(openRegisteredCliSlashForm(login, '')).toBe(true);
+    const loginNode = renderOpenForm<{
+      onSelect?: (value: string) => void;
+    }>();
+    loginNode.props?.onSelect?.('chatgpt');
+    await waitFor(() => formProgress.get()?.status === 'succeeded');
+    expect(formProgress.get()?.archiveCopyable).toBeTypeOf('function');
+
+    const ink = (await import(cliRequire.resolve('ink'))) as any;
+    const stdout = new FakeStdout();
+    const instance = ink.render(
+      activeForm.get()?.render(() => {}, 20),
+      {
+        stdin: new FakeStdin(),
+        stdout,
+        interactive: true,
+        exitOnCtrlC: false,
+        patchConsole: false,
+      },
+    );
+    try {
+      instance.rerender(activeForm.get()?.render(() => {}, 4));
+      await waitFor(
+        () => formProgress.get()?.archivedCopyableMessage === instruction,
+      );
+      await waitFor(() => stdout.output.includes('scrollback'));
+      expect(stdout.output).toContain('scrollback');
+      expect(formProgress.get()).toMatchObject({
+        status: 'succeeded',
+        message: 'Authentication instructions were written to scrollback.',
+        copyableMessage: undefined,
+        archivedCopyableMessage: instruction,
+      });
+      expect(
+        streams
+          .get()
+          .get(CLI_LOCAL_STREAM_ID)
+          ?.entries.map((entry) => entry.text),
+      ).toEqual([instruction]);
+    } finally {
+      instance.unmount();
+    }
   });
 
   it('detaches a busy login and ignores its late completion', async () => {


### PR DESCRIPTION
## Summary

Sign-in, sign-out, and model-access pickers now remain mounted while their asynchronous work runs. Progress appears in the form rather than the conversation, and only a single final outcome is archived. Authentication codes and manual URLs stop the spinner and remain visible until an explicit keypress so terminal selection remains stable.

Closes #8811.

## Issue acceptance gates

- Adds `completion: 'busy'` for login, logout, and model-access forms; instant forms retain `beforeAction`.
- Routes browser, device-code, authentication-URL, and model-access progress through the active form.
- Leaves headless runtime modules unchanged.
- Freezes repainting and holds the settled frame whenever copyable authentication text appeared.
- Drops stale progress, outcomes, and notices by form token and CLI-state generation.
- Esc and first Ctrl-C abort an abortable action or detach an unabortable action with a transient notice.
- Lets a pending approval preempt a running form and restores that form after the decision.
- Archives one physical outcome line; failed authentication includes the manual URL.
- Restores the notice-independent double-Ctrl-C deadline and fixed-session agent notice after the registry prerequisite overwrote those two notice invariants during integration.

## Single source of truth

`formProgress` in `cliState.ts` owns the active submit operation, including its identity, state, copyable text, cancellation, and dismissal. `SlashCommandOutput` is the output boundary that decides whether command text belongs in the form, a transient notice, or the persistent transcript.

## Duplication and abstraction budget

One busy branch in `formSelectionHandler` serves all three asynchronous pickers. The submit frame is file-local to the registered-form owner, while the output boundary has three command families. No single-caller shared component or pass-through factory was added.

## Net elements (R6)

- Files: 14 modified, none added.
- Production LoC: +370 / -86, net +284.
- Tests: +160 / -5, net +155.
- Total LoC: +530 / -91, net +439.
- Exports: five added (`loginStartMessage`, `SlashCommandOutput`, `transcriptSlashCommandOutput`, `FormProgress`, and `formProgress`); no classes or enums added.
- Interfaces: two added (`SlashCommandOutput` and `FormProgress`).

The larger-than-proposal net is principally explicit cancellation/generation gating and its regression coverage; the three progress producers and three form adapters share the same state and output boundary.

## Consumer counts (R8)

- `SlashCommandOutput`: 3 production command families (login, logout, model access), plus the transcript implementation.
- `formProgress`: 3 production owners (form selection, form rendering, and root interaction policy).
- Progress reroutes: ChatGPT sign-in, TeXRA device/manual authentication, and model-access sign-in all write through the shared boundary.
- No event key or external subscriber contract changes.

## Host impact

Extension: None.

Desktop: None.

CLI: Interactive slash forms gain in-place progress, stable code/URL display, cancellation, and approval preemption. Headless command output is unchanged.

## Scheduled refactoring

None. The present contract supports abortable promises and safely detaches operations whose runtime does not expose cancellation.

## Validation

- `npm run format` (pre-commit)
- `npm run typecheck`
- `npm run lint`
- `npm run compile:fast`
- `vitest run src/test-kernel/cli` (142 files, 1,821 tests)
- Focused form, slash-dispatch, state, and interaction-policy suites (199 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches interactive auth flows, foreground/input policy, and cancellation; headless paths are largely unchanged but form/async race handling is non-trivial.
> 
> **Overview**
> Account-related slash forms (**login**, **logout**, **model access**) now stay open while async work runs. Progress shows in a **`FormBusyFrame`** instead of streaming into chat; only the final outcome is written to the transcript.
> 
> A shared **`formProgress`** signal and **`SlashCommandOutput`** boundary route progress, notices, and outcomes either into the active form or the ordinary transcript (direct `/login` etc. unchanged). Copyable auth URLs/codes freeze the spinner and can move to scrollback when the frame is too small; Esc/Ctrl-C cancel or detach with an abandon notice.
> 
> **Approvals** can preempt a busy form. Double Ctrl-C exit confirmation no longer depends on transient notice state. Some agent/API notices use **`setTransientNotice`** instead of transcript spam.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbc659c7c0c11206ad1bede94d06da1557c1e392. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->