### PR TITLE
feat(cli): add bounded reference pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,10 @@ All notable changes to this project will be documented in this file.
 - **Account changes stay visible without filling chat history** — sign-in,
   sign-out, and model-access forms now show their progress in place and leave
   only the final result in the conversation.
+- **Reference commands stay out of chat history** — `/help`, `/goal` help,
+  and memory lists or previews open in a temporary Esc-to-close pane when they
+  fit the terminal, while oversized output still falls back to searchable
+  scrollback.
 - **Model access and accounts have distinct CLI controls** — `/api` now offers
   ChatGPT subscription, included TeXRA access, and personal API keys in one
   picker; `/auth` reports both account sessions and the effective route; and

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -38,6 +38,7 @@ import {
 } from './appInteractionPolicy';
 import { ApprovalModal } from './modals/ApprovalModal';
 import { TaskDetailView } from './modals/TaskDetailView';
+import { InfoPane } from './panes/InfoPane';
 import { InputBar, type InputBarHandle } from './panes/InputBar';
 import { ConversationRegion } from './panes/ConversationRegion';
 import { StatusBar } from './panes/StatusBar';
@@ -68,12 +69,14 @@ import {
   rootStreamId as rootStreamIdSignal,
   activeForm as activeFormSignal,
   formProgress as formProgressSignal,
+  infoPane as infoPaneSignal,
   reverseSearchOpen as reverseSearchOpenSignal,
   slashPaletteOpen as slashPaletteOpenSignal,
   taskDetailExecutionId as taskDetailExecutionIdSignal,
   streams as streamsSignal,
   type StreamSlice,
 } from './state/cliState';
+import { appendLocalAssistantTranscript } from './state/transcript';
 import {
   activeSubagentsFor,
   childStreamEntries as childStreamEntriesSignal,
@@ -158,6 +161,7 @@ export function App(props: AppProps): React.JSX.Element {
   const subagentExecutionLabels = useSignal(subagentExecutionLabelsSignal);
   const activeForm = useSignal(activeFormSignal);
   const formProgress = useSignal(formProgressSignal);
+  const infoPane = useSignal(infoPaneSignal);
   const slashPaletteOpen = useSignal(slashPaletteOpenSignal);
   const reverseSearchOpen = useSignal(reverseSearchOpenSignal);
   const taskDetailExecutionId = useSignal(taskDetailExecutionIdSignal);
@@ -203,6 +207,7 @@ export function App(props: AppProps): React.JSX.Element {
   const foregroundOpen =
     activeApprovalVisible ||
     activeForm !== undefined ||
+    infoPane !== undefined ||
     taskDetailExecutionId !== undefined;
   const childInputDisabledMessage = focusedChildInputDisabledMessage({
     activeStreamId,
@@ -408,6 +413,7 @@ export function App(props: AppProps): React.JSX.Element {
   const foregroundKind = foregroundSurfaceKind({
     activeFormOpen: activeForm !== undefined,
     formBusy,
+    infoPaneOpen: infoPane !== undefined,
     pendingApproval: activeApprovalVisible,
     taskDetailOpen: taskDetailProcess !== undefined,
   });
@@ -417,6 +423,13 @@ export function App(props: AppProps): React.JSX.Element {
     approvalKind,
     kind: foregroundKind,
   });
+  const closeInfoPane = useCallback(() => infoPaneSignal.set(undefined), []);
+  const archiveInfoPane = useCallback(() => {
+    const current = infoPaneSignal.get();
+    if (!current) return;
+    infoPaneSignal.set(undefined);
+    appendLocalAssistantTranscript(current.lines.join('\n'));
+  }, []);
   function renderForegroundSurface(availableRows: number): React.ReactNode {
     switch (foregroundKind) {
       case 'taskDetail': {
@@ -442,6 +455,16 @@ export function App(props: AppProps): React.JSX.Element {
           formProgressSignal.set(undefined);
           activeFormSignal.set(undefined);
         }, availableRows);
+      case 'infoPane':
+        return infoPane ? (
+          <InfoPane
+            availableRows={availableRows}
+            lines={infoPane.lines}
+            onClose={closeInfoPane}
+            onOverflow={archiveInfoPane}
+            title={infoPane.title}
+          />
+        ) : null;
       case 'approval':
         return activeApprovalVisible && pending ? (
           <ApprovalModal pending={pending} availableRows={availableRows} />

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -68,6 +68,7 @@ import {
   rootRunStartAvailable as rootRunStartAvailableSignal,
   rootStreamId as rootStreamIdSignal,
   activeForm as activeFormSignal,
+  closeInfoPane,
   formProgress as formProgressSignal,
   infoPane as infoPaneSignal,
   reverseSearchOpen as reverseSearchOpenSignal,
@@ -423,11 +424,10 @@ export function App(props: AppProps): React.JSX.Element {
     approvalKind,
     kind: foregroundKind,
   });
-  const closeInfoPane = useCallback(() => infoPaneSignal.set(undefined), []);
   const archiveInfoPane = useCallback(() => {
     const current = infoPaneSignal.get();
     if (!current) return;
-    infoPaneSignal.set(undefined);
+    closeInfoPane();
     appendLocalAssistantTranscript(current.lines.join('\n'));
   }, []);
   function renderForegroundSurface(availableRows: number): React.ReactNode {

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -424,11 +424,10 @@ export function App(props: AppProps): React.JSX.Element {
     approvalKind,
     kind: foregroundKind,
   });
-  const archiveInfoPane = useCallback(() => {
-    const current = infoPaneSignal.get();
-    if (!current) return;
+  const archiveInfoPane = useCallback((lines: readonly string[]) => {
+    if (infoPaneSignal.get()?.lines !== lines) return;
     closeInfoPane();
-    appendLocalAssistantTranscript(current.lines.join('\n'));
+    appendLocalAssistantTranscript(lines.join('\n'));
   }, []);
   function renderForegroundSurface(availableRows: number): React.ReactNode {
     switch (foregroundKind) {
@@ -459,6 +458,7 @@ export function App(props: AppProps): React.JSX.Element {
         return infoPane ? (
           <InfoPane
             availableRows={availableRows}
+            colorEnabled={props.colorEnabled}
             lines={infoPane.lines}
             onClose={closeInfoPane}
             onOverflow={archiveInfoPane}

--- a/packages/cli/src/chat/tui/appInteractionPolicy.ts
+++ b/packages/cli/src/chat/tui/appInteractionPolicy.ts
@@ -138,22 +138,26 @@ export function digitFromMetaShortcut(value: string): number | undefined {
   return /^[1-9]$/.test(value) ? Number.parseInt(value, 10) : undefined;
 }
 
-export type ForegroundSurfaceKind = 'taskDetail' | 'form' | 'approval';
+export type ForegroundSurfaceKind =
+  'taskDetail' | 'form' | 'infoPane' | 'approval';
 
 export function foregroundSurfaceKind({
   activeFormOpen,
   formBusy,
+  infoPaneOpen,
   pendingApproval,
   taskDetailOpen,
 }: {
   readonly activeFormOpen: boolean;
   readonly formBusy: boolean;
+  readonly infoPaneOpen: boolean;
   readonly pendingApproval: boolean;
   readonly taskDetailOpen: boolean;
 }): ForegroundSurfaceKind | undefined {
   if (taskDetailOpen) return 'taskDetail';
   if (pendingApproval && formBusy) return 'approval';
   if (activeFormOpen) return 'form';
+  if (infoPaneOpen) return 'infoPane';
   if (pendingApproval) return 'approval';
   return undefined;
 }
@@ -186,6 +190,8 @@ export function foregroundEscapeAction({
       return activeFormEscapeAction ?? 'close';
     case 'taskDetail':
       return 'back';
+    case 'infoPane':
+      return 'close';
     case 'approval':
       return approvalKind === 'externalInquiry' ||
         approvalKind === 'userQuestion'
@@ -226,6 +232,8 @@ export function foregroundMaxRowsForKind({
       return TASK_DETAIL_FOREGROUND_MAX_ROWS;
     case 'form':
       return FORM_FOREGROUND_MAX_ROWS;
+    case 'infoPane':
+      return undefined;
     case 'approval':
       return approvalForegroundMaxRows(approvalKind);
     case undefined:

--- a/packages/cli/src/chat/tui/appInteractionPolicy.ts
+++ b/packages/cli/src/chat/tui/appInteractionPolicy.ts
@@ -157,8 +157,8 @@ export function foregroundSurfaceKind({
   if (taskDetailOpen) return 'taskDetail';
   if (pendingApproval && formBusy) return 'approval';
   if (activeFormOpen) return 'form';
-  if (infoPaneOpen) return 'infoPane';
   if (pendingApproval) return 'approval';
+  if (infoPaneOpen) return 'infoPane';
   return undefined;
 }
 

--- a/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
+++ b/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
@@ -45,7 +45,6 @@ async function runGuardedSlashCommand(
   line: string,
   command: SlashCommand | undefined,
   action: () => void | Promise<void>,
-  persistsOnSuccess = true,
 ): Promise<void> {
   let echoed = false;
   const echo = (): void => {
@@ -54,7 +53,7 @@ async function runGuardedSlashCommand(
     echoed = true;
   };
   try {
-    if (persistsOnSuccess && command?.echo === 'ifPersists') echo();
+    if (command?.echo === 'ifPersists') echo();
     await action();
   } catch (error: unknown) {
     echo();
@@ -106,18 +105,14 @@ export async function handleTuiSlashCommand(
   }
   switch (canonicalCommand) {
     case 'help': {
-      await runGuardedSlashCommand(
-        line,
-        registered,
-        () =>
-          openInfoPane(
-            '/help',
-            formatSlashCommandHelp(listSlashCommands(), {
-              shortcutModifierLabel: defaultShortcutModifierLabel(),
-              shiftEnterNewline: terminalCapabilities.get().kittyKeyboard,
-            }),
-          ),
-        false,
+      await runGuardedSlashCommand(line, registered, () =>
+        openInfoPane(
+          '/help',
+          formatSlashCommandHelp(listSlashCommands(), {
+            shortcutModifierLabel: defaultShortcutModifierLabel(),
+            shiftEnterNewline: terminalCapabilities.get().kittyKeyboard,
+          }),
+        ),
       );
       return true;
     }
@@ -199,11 +194,8 @@ export async function handleTuiSlashCommand(
       });
       return true;
     case 'goal':
-      await runGuardedSlashCommand(
-        line,
-        registered,
-        () => openInfoPane('/goal', GOAL_MODE_HELP),
-        false,
+      await runGuardedSlashCommand(line, registered, () =>
+        openInfoPane('/goal', GOAL_MODE_HELP),
       );
       return true;
     case 'compact':
@@ -226,16 +218,11 @@ export async function handleTuiSlashCommand(
         ) {
           return true;
         }
-        await runGuardedSlashCommand(
-          line,
-          registered,
-          () => {
-            throw new Error(
-              `/${parsed.name} is registered but is not available in this CLI view yet.`,
-            );
-          },
-          false,
-        );
+        await runGuardedSlashCommand(line, registered, () => {
+          throw new Error(
+            `/${parsed.name} is registered but is not available in this CLI view yet.`,
+          );
+        });
       } else {
         const suggestion = suggestSlashCommand(command);
         const didYouMean = suggestion

--- a/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
+++ b/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
@@ -11,6 +11,7 @@ import { formatCliSessionStatus } from '../sessionStatus';
 import { requestCliCompaction } from '../state/compactionRequest';
 import {
   activeStreamId as activeStreamIdSignal,
+  openInfoPane,
   sessionMeta,
   setTransientNotice,
   streamAccessTarget,
@@ -105,13 +106,18 @@ export async function handleTuiSlashCommand(
   }
   switch (canonicalCommand) {
     case 'help': {
-      await runGuardedSlashCommand(line, registered, () =>
-        appendLocalAssistantTranscript(
-          formatSlashCommandHelp(listSlashCommands(), {
-            shortcutModifierLabel: defaultShortcutModifierLabel(),
-            shiftEnterNewline: terminalCapabilities.get().kittyKeyboard,
-          }),
-        ),
+      await runGuardedSlashCommand(
+        line,
+        registered,
+        () =>
+          openInfoPane(
+            '/help',
+            formatSlashCommandHelp(listSlashCommands(), {
+              shortcutModifierLabel: defaultShortcutModifierLabel(),
+              shiftEnterNewline: terminalCapabilities.get().kittyKeyboard,
+            }),
+          ),
+        false,
       );
       return true;
     }
@@ -193,8 +199,11 @@ export async function handleTuiSlashCommand(
       });
       return true;
     case 'goal':
-      await runGuardedSlashCommand(line, registered, () =>
-        appendLocalAssistantTranscript(GOAL_MODE_HELP),
+      await runGuardedSlashCommand(
+        line,
+        registered,
+        () => openInfoPane('/goal', GOAL_MODE_HELP),
+        false,
       );
       return true;
     case 'compact':

--- a/packages/cli/src/chat/tui/commands/handlers/memoryCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/memoryCommands.ts
@@ -2,13 +2,13 @@ import {
   formatCliMemoryList,
   formatCliMemoryPreview,
 } from '@cli/runtime/memory';
-import { appendLocalAssistantTranscript } from '@cli/chat/tui/state/transcript';
+import { openInfoPane } from '@cli/chat/tui/state/cliState';
 import { loadMemoryItems } from '@tools/memory/memoryFileSystem';
 
 export async function showCliMemoryList(): Promise<void> {
-  appendLocalAssistantTranscript(formatCliMemoryList(await loadMemoryItems()));
+  openInfoPane('/memory list', formatCliMemoryList(await loadMemoryItems()));
 }
 
 export async function showCliMemoryPreview(inputPath: string): Promise<void> {
-  appendLocalAssistantTranscript(await formatCliMemoryPreview(inputPath));
+  openInfoPane('/memory preview', await formatCliMemoryPreview(inputPath));
 }

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -645,7 +645,7 @@ export function registerBuiltinSlashCommands(options?: {
     name: 'memory',
     description: 'List stored memories',
     category: 'configuration',
-    echo: 'ifPersists',
+    echo: 'never',
     argHandler: async (remainder) => {
       if (remainder.toLowerCase() === 'list') await showCliMemoryList();
       else await showCliMemoryPreview(remainder);

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -626,7 +626,7 @@ export function registerBuiltinSlashCommands(options?: {
     description: 'Explain autonomous goal mode',
     aliases: ['goals'],
     category: 'session',
-    echo: 'ifPersists',
+    echo: 'never',
   });
   registerSlashCommand({
     name: 'resume',

--- a/packages/cli/src/chat/tui/forms/MemoryListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/MemoryListForm.tsx
@@ -35,7 +35,7 @@ export function MemoryListForm(props: MemoryListFormProps): React.JSX.Element {
       }
       availableRows={props.availableRows}
       description={
-        <Text dimColor>Choose a memory to preview in the transcript.</Text>
+        <Text dimColor>Choose a memory to preview. Press Esc to close.</Text>
       }
       emptyMessage="No memory files found."
       selectMarginTop={1}

--- a/packages/cli/src/chat/tui/panes/InfoPane.tsx
+++ b/packages/cli/src/chat/tui/panes/InfoPane.tsx
@@ -1,0 +1,58 @@
+import { useEffect } from 'react';
+import { Text, useInput, useWindowSize } from 'ink';
+
+import { isEscapeInput } from '../input/inputKeys';
+import { textDisplayWidth } from '../render/terminalText';
+import { FormFrame, formFrameWidth } from '../forms/_shared/FormFrame';
+
+const INFO_PANE_CHROME_ROWS = 5;
+const INFO_PANE_HORIZONTAL_CHROME_COLUMNS = 4;
+
+export function infoPaneRequiredRows(
+  lines: readonly string[],
+  textWidth: number,
+): number {
+  const width = Math.max(1, textWidth);
+  return (
+    INFO_PANE_CHROME_ROWS +
+    lines.reduce(
+      (rows, line) =>
+        rows + Math.max(1, Math.ceil(textDisplayWidth(line) / width)),
+      0,
+    )
+  );
+}
+
+export interface InfoPaneProps {
+  readonly title: string;
+  readonly lines: readonly string[];
+  readonly availableRows: number;
+  readonly onClose: () => void;
+  readonly onOverflow: () => void;
+}
+
+/** Stateless, Esc-only reference text surface with a strict row budget. */
+export function InfoPane(props: InfoPaneProps): React.JSX.Element | null {
+  const { columns } = useWindowSize();
+  const textWidth =
+    formFrameWidth(columns) - INFO_PANE_HORIZONTAL_CHROME_COLUMNS;
+  const fits =
+    infoPaneRequiredRows(props.lines, textWidth) <= props.availableRows;
+
+  useInput((input, key) => {
+    if (fits && isEscapeInput(input, key)) props.onClose();
+  });
+
+  useEffect(() => {
+    // Archive after rendering rather than mutating transcript/signal state in
+    // the render path. The parent clears this pane in the same transition.
+    if (!fits) props.onOverflow();
+  }, [fits, props.onOverflow]);
+
+  if (!fits) return null;
+  return (
+    <FormFrame title={props.title}>
+      <Text wrap="wrap">{props.lines.join('\n')}</Text>
+    </FormFrame>
+  );
+}

--- a/packages/cli/src/chat/tui/panes/InfoPane.tsx
+++ b/packages/cli/src/chat/tui/panes/InfoPane.tsx
@@ -1,9 +1,12 @@
+// Third-party imports
 import { useEffect } from 'react';
-import { Text, useInput, useWindowSize } from 'ink';
+import { useInput, useWindowSize } from 'ink';
 
-import { isEscapeInput } from '../input/inputKeys';
-import { textDisplayWidth } from '../render/terminalText';
+// Local imports - TUI layout, input, and markdown rendering
 import { FormFrame, formFrameWidth } from '../forms/_shared/FormFrame';
+import { isEscapeInput } from '../input/inputKeys';
+import { renderAnsiMarkdown } from '../render/ansiMarkdown';
+import { Markdown } from '../render/Markdown';
 
 const INFO_PANE_CHROME_ROWS = 5;
 const INFO_PANE_HORIZONTAL_CHROME_COLUMNS = 4;
@@ -13,14 +16,11 @@ export function infoPaneRequiredRows(
   textWidth: number,
 ): number {
   const width = Math.max(1, textWidth);
-  return (
-    INFO_PANE_CHROME_ROWS +
-    lines.reduce(
-      (rows, line) =>
-        rows + Math.max(1, Math.ceil(textDisplayWidth(line) / width)),
-      0,
-    )
-  );
+  const rendered = renderAnsiMarkdown(lines.join('\n'), {
+    colorEnabled: false,
+    width,
+  });
+  return INFO_PANE_CHROME_ROWS + rendered.split('\n').length;
 }
 
 export interface InfoPaneProps {
@@ -52,7 +52,7 @@ export function InfoPane(props: InfoPaneProps): React.JSX.Element | null {
   if (!fits) return null;
   return (
     <FormFrame title={props.title}>
-      <Text wrap="wrap">{props.lines.join('\n')}</Text>
+      <Markdown content={props.lines.join('\n')} width={textWidth} />
     </FormFrame>
   );
 }

--- a/packages/cli/src/chat/tui/panes/InfoPane.tsx
+++ b/packages/cli/src/chat/tui/panes/InfoPane.tsx
@@ -1,26 +1,29 @@
 // Third-party imports
-import { useEffect } from 'react';
+import { useLayoutEffect } from 'react';
 import { useInput, useWindowSize } from 'ink';
 
 // Local imports - TUI layout, input, and markdown rendering
 import { FormFrame, formFrameWidth } from '../forms/_shared/FormFrame';
 import { isEscapeInput } from '../input/inputKeys';
 import { renderAnsiMarkdown } from '../render/ansiMarkdown';
+import { wrapAnsiToWidth } from '../render/ansiWrap';
 import { Markdown } from '../render/Markdown';
 
-const INFO_PANE_CHROME_ROWS = 5;
+const INFO_PANE_FIXED_CHROME_ROWS = 4;
 const INFO_PANE_HORIZONTAL_CHROME_COLUMNS = 4;
 
 export function infoPaneRequiredRows(
+  title: string,
   lines: readonly string[],
   textWidth: number,
 ): number {
   const width = Math.max(1, textWidth);
+  const titleRows = wrapAnsiToWidth(title, width).split('\n').length;
   const rendered = renderAnsiMarkdown(lines.join('\n'), {
     colorEnabled: false,
     width,
   });
-  return INFO_PANE_CHROME_ROWS + rendered.split('\n').length;
+  return INFO_PANE_FIXED_CHROME_ROWS + titleRows + rendered.split('\n').length;
 }
 
 export interface InfoPaneProps {
@@ -38,15 +41,16 @@ export function InfoPane(props: InfoPaneProps): React.JSX.Element | null {
   const textWidth =
     formFrameWidth(columns) - INFO_PANE_HORIZONTAL_CHROME_COLUMNS;
   const fits =
-    infoPaneRequiredRows(props.lines, textWidth) <= props.availableRows;
+    infoPaneRequiredRows(props.title, props.lines, textWidth) <=
+    props.availableRows;
 
   useInput((input, key) => {
     if (fits && isEscapeInput(input, key)) props.onClose();
   });
 
-  useEffect(() => {
-    // Archive after rendering rather than mutating transcript/signal state in
-    // the render path. The parent clears this pane in the same transition.
+  useLayoutEffect(() => {
+    // Archive before paint rather than committing an empty foreground frame.
+    // The parent clears this pane in the same transition.
     if (!fits) props.onOverflow(props.lines);
   }, [fits, props.lines, props.onOverflow]);
 

--- a/packages/cli/src/chat/tui/panes/InfoPane.tsx
+++ b/packages/cli/src/chat/tui/panes/InfoPane.tsx
@@ -27,8 +27,9 @@ export interface InfoPaneProps {
   readonly title: string;
   readonly lines: readonly string[];
   readonly availableRows: number;
+  readonly colorEnabled?: boolean;
   readonly onClose: () => void;
-  readonly onOverflow: () => void;
+  readonly onOverflow: (lines: readonly string[]) => void;
 }
 
 /** Stateless, Esc-only reference text surface with a strict row budget. */
@@ -46,13 +47,17 @@ export function InfoPane(props: InfoPaneProps): React.JSX.Element | null {
   useEffect(() => {
     // Archive after rendering rather than mutating transcript/signal state in
     // the render path. The parent clears this pane in the same transition.
-    if (!fits) props.onOverflow();
+    if (!fits) props.onOverflow(props.lines);
   }, [fits, props.lines, props.onOverflow]);
 
   if (!fits) return null;
   return (
     <FormFrame title={props.title}>
-      <Markdown content={props.lines.join('\n')} width={textWidth} />
+      <Markdown
+        colorEnabled={props.colorEnabled}
+        content={props.lines.join('\n')}
+        width={textWidth}
+      />
     </FormFrame>
   );
 }

--- a/packages/cli/src/chat/tui/panes/InfoPane.tsx
+++ b/packages/cli/src/chat/tui/panes/InfoPane.tsx
@@ -47,7 +47,7 @@ export function InfoPane(props: InfoPaneProps): React.JSX.Element | null {
     // Archive after rendering rather than mutating transcript/signal state in
     // the render path. The parent clears this pane in the same transition.
     if (!fits) props.onOverflow();
-  }, [fits, props.onOverflow]);
+  }, [fits, props.lines, props.onOverflow]);
 
   if (!fits) return null;
   return (

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -439,7 +439,7 @@ export const infoPane: Signal.Computed<InfoPaneContent | undefined> = computed(
 export function openInfoPane(title: string, text: string): void {
   INFO_PANE_QUEUE.set([
     ...INFO_PANE_QUEUE.get(),
-    { title, lines: text.split('\n') },
+    { title, lines: text.replaceAll('\r\n', '\n').split('\n') },
   ]);
 }
 

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -425,6 +425,19 @@ const ACTIVE_FORM: Signal.State<ActiveSlashForm | undefined> = signal<
 /** Active inline slash form, or `undefined` when the chat input owns the screen. */
 export const activeForm = ACTIVE_FORM;
 
+interface InfoPaneContent {
+  readonly title: string;
+  readonly lines: readonly string[];
+}
+
+const INFO_PANE = signal<InfoPaneContent | undefined>(undefined);
+export const infoPane = INFO_PANE;
+
+/** Open regenerable reference text in the foreground pane. */
+export function openInfoPane(title: string, text: string): void {
+  INFO_PANE.set({ title, lines: text.split('\n') });
+}
+
 /** True while the slash-command palette is mounted in the InputBar. App-level
  *  Tab handlers gate on this so palette-Tab (accept selection) doesn't double
  *  with stream-focus Tab. */
@@ -598,6 +611,7 @@ export function resetCliState(
   rootRunStreamId.set(undefined);
   resetChildStreamEntries();
   activeForm.set(undefined);
+  infoPane.set(undefined);
   slashPaletteOpen.set(false);
   reverseSearchOpen.set(false);
   taskDetailExecutionId.set(undefined);

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -3,7 +3,7 @@
  * focus, overlays, exit hints) lives here as signals; formerly one file per
  * slice under `cliState/`.
  */
-import { signal, type Signal } from '@lit-labs/signals';
+import { computed, signal, type Signal } from '@lit-labs/signals';
 import type { CliApiMode } from '@cli/runtime/apiAccessMode';
 import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
 import type { RunModelDecisionReason } from '@model/runModelDecision';
@@ -430,12 +430,22 @@ interface InfoPaneContent {
   readonly lines: readonly string[];
 }
 
-const INFO_PANE = signal<InfoPaneContent | undefined>(undefined);
-export const infoPane = INFO_PANE;
+const INFO_PANE_QUEUE = signal<readonly InfoPaneContent[]>([]);
+export const infoPane: Signal.Computed<InfoPaneContent | undefined> = computed(
+  () => INFO_PANE_QUEUE.get().at(0),
+);
 
 /** Open regenerable reference text in the foreground pane. */
 export function openInfoPane(title: string, text: string): void {
-  INFO_PANE.set({ title, lines: text.split('\n') });
+  INFO_PANE_QUEUE.set([
+    ...INFO_PANE_QUEUE.get(),
+    { title, lines: text.split('\n') },
+  ]);
+}
+
+/** Close the active reference pane and reveal any concurrently queued result. */
+export function closeInfoPane(): void {
+  INFO_PANE_QUEUE.set(INFO_PANE_QUEUE.get().slice(1));
 }
 
 /** True while the slash-command palette is mounted in the InputBar. App-level
@@ -611,7 +621,7 @@ export function resetCliState(
   rootRunStreamId.set(undefined);
   resetChildStreamEntries();
   activeForm.set(undefined);
-  infoPane.set(undefined);
+  INFO_PANE_QUEUE.set([]);
   slashPaletteOpen.set(false);
   reverseSearchOpen.set(false);
   taskDetailExecutionId.set(undefined);

--- a/src/test-kernel/cli/AppInteractionPolicy.vitest.mts
+++ b/src/test-kernel/cli/AppInteractionPolicy.vitest.mts
@@ -101,6 +101,7 @@ function foregroundInput(
   return {
     activeFormOpen: false,
     formBusy: false,
+    infoPaneOpen: false,
     pendingApproval: true,
     taskDetailOpen: false,
     ...overrides,
@@ -185,6 +186,7 @@ describe('app interaction policy', () => {
     const surfaceCases = [
       [{ kind: 'taskDetail' }, 12],
       [{ kind: 'form' }, 18],
+      [{ kind: 'infoPane' }, undefined],
     ] satisfies readonly (readonly [ForegroundRowsInput, number | undefined])[];
     const expectedByKind = {
       plan: undefined,
@@ -300,6 +302,7 @@ describe('app interaction policy', () => {
       [foregroundInput({ taskDetailOpen: true }), 'taskDetail'],
       [foregroundInput({ activeFormOpen: true }), 'form'],
       [foregroundInput({ activeFormOpen: true, formBusy: true }), 'approval'],
+      [foregroundInput({ infoPaneOpen: true }), 'infoPane'],
       [foregroundInput(), 'approval'],
       [foregroundInput({ pendingApproval: false }), undefined],
     ] satisfies readonly (readonly [
@@ -327,6 +330,7 @@ describe('app interaction policy', () => {
     const surfaceCases = [
       [{ foregroundKind: 'taskDetail' }, 'back'],
       [{ foregroundKind: 'form' }, 'close'],
+      [{ foregroundKind: 'infoPane' }, 'close'],
       [{ activeFormEscapeAction: 'cancel', foregroundKind: 'form' }, 'cancel'],
     ] satisfies readonly (readonly [ForegroundEscapeInput, string])[];
     const approvalCases = [

--- a/src/test-kernel/cli/AppInteractionPolicy.vitest.mts
+++ b/src/test-kernel/cli/AppInteractionPolicy.vitest.mts
@@ -302,7 +302,11 @@ describe('app interaction policy', () => {
       [foregroundInput({ taskDetailOpen: true }), 'taskDetail'],
       [foregroundInput({ activeFormOpen: true }), 'form'],
       [foregroundInput({ activeFormOpen: true, formBusy: true }), 'approval'],
-      [foregroundInput({ infoPaneOpen: true }), 'infoPane'],
+      [foregroundInput({ infoPaneOpen: true }), 'approval'],
+      [
+        foregroundInput({ infoPaneOpen: true, pendingApproval: false }),
+        'infoPane',
+      ],
       [foregroundInput(), 'approval'],
       [foregroundInput({ pendingApproval: false }), undefined],
     ] satisfies readonly (readonly [

--- a/src/test-kernel/cli/InfoPane.vitest.mts
+++ b/src/test-kernel/cli/InfoPane.vitest.mts
@@ -4,10 +4,14 @@ import { infoPaneRequiredRows } from '@cli/chat/tui/panes/InfoPane';
 
 describe('CLI InfoPane layout', () => {
   it('includes title, border, and close-hint chrome in its row budget', () => {
-    expect(infoPaneRequiredRows(['one', '', 'three'], 40)).toBe(8);
+    expect(infoPaneRequiredRows('Reference', ['one', '', 'three'], 40)).toBe(8);
   });
 
   it('falls back when long reference lines would wrap past the budget', () => {
-    expect(infoPaneRequiredRows(['1234567890'], 4)).toBe(8);
+    expect(infoPaneRequiredRows('Info', ['1234567890'], 4)).toBe(8);
+  });
+
+  it('includes wrapped title rows in the budget', () => {
+    expect(infoPaneRequiredRows('/memory preview', ['one'], 8)).toBe(7);
   });
 });

--- a/src/test-kernel/cli/InfoPane.vitest.mts
+++ b/src/test-kernel/cli/InfoPane.vitest.mts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { infoPaneRequiredRows } from '@cli/chat/tui/panes/InfoPane';
+
+describe('CLI InfoPane layout', () => {
+  it('includes title, border, and close-hint chrome in its row budget', () => {
+    expect(infoPaneRequiredRows(['one', '', 'three'], 40)).toBe(8);
+  });
+
+  it('falls back when long reference lines would wrap past the budget', () => {
+    expect(infoPaneRequiredRows(['1234567890'], 4)).toBe(8);
+  });
+});

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
@@ -23,6 +23,7 @@ import { CLI_LOCAL_STREAM_ID } from '@cli/chat/tui/state/transcript';
 import {
   activeForm,
   activeStreamId,
+  closeInfoPane,
   codexPreferenceVersion,
   infoPane,
   patchSessionMeta,
@@ -131,6 +132,7 @@ describe('handleTuiSlashCommand', () => {
     expect(infoPane.get()?.lines.join('\n')).toContain('**Keyboard**');
     expect(localEntries()).toEqual([]);
 
+    closeInfoPane();
     await handleTuiSlashCommand('/goal', context);
     expect(infoPane.get()).toMatchObject({ title: '/goal' });
     expect(infoPane.get()?.lines.join('\n')).toContain(
@@ -154,6 +156,8 @@ describe('handleTuiSlashCommand', () => {
     });
 
     await showCliMemoryPreview('note.md');
+    expect(infoPane.get()?.title).toBe('/memory list');
+    closeInfoPane();
     expect(infoPane.get()).toMatchObject({ title: '/memory preview' });
     expect(infoPane.get()?.lines).toContain('Remember this.');
     expect(localEntries()).toEqual([]);

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
@@ -8,6 +8,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createTestCliContext } from '@test/cli/fixtures/cliContext';
 import * as codexAuth from '@auth/codex';
 import { handleTuiSlashCommand } from '@cli/chat/tui/commands/handleSlashCommand';
+import {
+  showCliMemoryList,
+  showCliMemoryPreview,
+} from '@cli/chat/tui/commands/handlers/memoryCommands';
 import { type SlashCommandContext } from '@cli/chat/tui/commands/handlers/slashContext';
 import { registerBuiltinSlashCommands } from '@cli/chat/tui/commands/registerBuiltins';
 import {
@@ -20,6 +24,7 @@ import {
   activeForm,
   activeStreamId,
   codexPreferenceVersion,
+  infoPane,
   patchSessionMeta,
   resetCliState,
   patchStream,
@@ -39,6 +44,7 @@ import {
   type ExecutionId,
   type StreamTabId,
 } from '@shared/schemas';
+import * as memoryFileSystem from '@tools/memory/memoryFileSystem';
 
 afterEach(() => {
   for (const cmd of [...listSlashCommands()]) unregisterSlashCommand(cmd.name);
@@ -113,7 +119,7 @@ function localEntries() {
 }
 
 describe('handleTuiSlashCommand', () => {
-  it('does not leave command echoes for overlay-only commands', async () => {
+  it('opens reference commands without leaving transcript rows', async () => {
     registerBuiltinSlashCommands();
     const context = createContext(createSession());
 
@@ -121,7 +127,36 @@ describe('handleTuiSlashCommand', () => {
     expect(localEntries()).toEqual([]);
 
     await handleTuiSlashCommand('/help', context);
-    expect(localEntries().map((entry) => entry.role)).toEqual(['assistant']);
+    expect(infoPane.get()).toMatchObject({ title: '/help' });
+    expect(infoPane.get()?.lines.join('\n')).toContain('**Keyboard**');
+    expect(localEntries()).toEqual([]);
+
+    await handleTuiSlashCommand('/goal', context);
+    expect(infoPane.get()).toMatchObject({ title: '/goal' });
+    expect(infoPane.get()?.lines.join('\n')).toContain(
+      'Goal mode starts from an approved plan',
+    );
+    expect(localEntries()).toEqual([]);
+  });
+
+  it('opens memory list and preview output in the reference pane', async () => {
+    vi.spyOn(memoryFileSystem, 'loadMemoryItems').mockResolvedValue([]);
+    vi.spyOn(memoryFileSystem, 'loadMemoryPreview').mockResolvedValue({
+      storagePath: 'memory/note.md',
+      lineCount: 1,
+      preview: 'Remember this.',
+    });
+
+    await showCliMemoryList();
+    expect(infoPane.get()).toEqual({
+      title: '/memory list',
+      lines: ['No memory files found.'],
+    });
+
+    await showCliMemoryPreview('note.md');
+    expect(infoPane.get()).toMatchObject({ title: '/memory preview' });
+    expect(infoPane.get()?.lines).toContain('Remember this.');
+    expect(localEntries()).toEqual([]);
   });
 
   it('adds a lazy command echo before errors even under echo never', async () => {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -11,6 +11,8 @@ import { defaultSession } from '@agent/runtime/SessionHandle';
 import { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import {
   activeStreamId,
+  infoPane,
+  openInfoPane,
   rootRunPending,
   rootRunStartAvailable,
   rootRunStreamId,
@@ -119,6 +121,15 @@ afterEach(() => {
 });
 
 describe('cliState Phase 4 fields', () => {
+  it('clears foreground reference text with the session state', () => {
+    openInfoPane('/help', 'reference text');
+    expect(infoPane.get()).toBeDefined();
+
+    resetCliState();
+
+    expect(infoPane.get()).toBeUndefined();
+  });
+
   it('normalizes transient notices to the status bar single-line contract', () => {
     setTransientNotice('Usage: /login target\n       /login chatgpt --device');
 

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -132,10 +132,13 @@ describe('cliState Phase 4 fields', () => {
   });
 
   it('preserves multiple reference results until each is dismissed', () => {
-    openInfoPane('/memory list', 'first result');
+    openInfoPane('/memory list', 'first\r\nresult');
     openInfoPane('/memory preview', 'second result');
 
-    expect(infoPane.get()?.title).toBe('/memory list');
+    expect(infoPane.get()).toEqual({
+      title: '/memory list',
+      lines: ['first', 'result'],
+    });
     closeInfoPane();
     expect(infoPane.get()).toEqual({
       title: '/memory preview',

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -11,6 +11,7 @@ import { defaultSession } from '@agent/runtime/SessionHandle';
 import { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import {
   activeStreamId,
+  closeInfoPane,
   infoPane,
   openInfoPane,
   rootRunPending,
@@ -128,6 +129,18 @@ describe('cliState Phase 4 fields', () => {
     resetCliState();
 
     expect(infoPane.get()).toBeUndefined();
+  });
+
+  it('preserves multiple reference results until each is dismissed', () => {
+    openInfoPane('/memory list', 'first result');
+    openInfoPane('/memory preview', 'second result');
+
+    expect(infoPane.get()?.title).toBe('/memory list');
+    closeInfoPane();
+    expect(infoPane.get()).toEqual({
+      title: '/memory preview',
+      lines: ['second result'],
+    });
   });
 
   it('normalizes transient notices to the status bar single-line contract', () => {


### PR DESCRIPTION
Closes #8812

## Summary

Adds a bounded foreground pane for regenerable CLI reference text. `/help`,
`/goal`, `/memory list`, and memory previews now remain outside chat history
when they fit the terminal. Oversized Markdown is transferred to ordinary
scrollback before paint, where the terminal's existing search and navigation
remain available.

The pane accepts only Escape, contains no pager or search state, preserves the
session color setting, and queues concurrent asynchronous reference results so
that none can overwrite another. Pending approvals take precedence over the
reference pane.

## Issue acceptance gates

- #8812: adds the fourth `infoPane` foreground kind.
- The renderer is stateless and receives title, lines, and the available row
  budget; its only input action is Escape.
- Markdown row measurement includes word wrapping, title wrapping, borders,
  and the close hint.
- Content that exceeds the row budget is transferred to the existing
  scrollback path in a pre-paint layout effect.
- `/help`, `/goal`, `/memory list`, and memory preview use the pane without a
  successful command echo or transcript outcome.
- The active pane queue is cleared by the common CLI reset path.
- No headless command path was changed.

## Single source of truth

`cliState.ts` owns the ordered queue of pending reference panes. `InfoPane.tsx`
owns the single fit decision, using the same Markdown rendering and terminal
width as the visible pane.

## Duplication and abstraction budget

One foreground surface replaces four direct transcript-output paths. The new
surface has four initial callers and owns the invariant that reference text is
either fully visible in the pane or preserved in scrollback. The queue is part
of the same state boundary and prevents concurrent memory reads from replacing
one another; no pass-through layer or pager abstraction was added.

## Net elements (R6)

- Files: 2 added, 0 deleted; 13 changed in total.
- Exports: 6 added, 0 deleted (`InfoPane`, its props and row-budget function,
  and the pane state/open/close API). `ForegroundSurfaceKind` is extended in
  place.
- Classes/interfaces/enums: 2 interfaces added; no classes or enums added.
- Production and changelog: +144/-22 lines, net +122.
- Tests: +93/-2 lines, net +91.
- Total: +237/-24 lines, net +213.

## Consumer counts (R8)

n/a: no event key, subscriber, or export was deleted. Four reference-output
call sites were rerouted to the pane (`/help`, `/goal`, memory list, and memory
preview).

## Host impact

Extension: None.

Desktop: None.

CLI: Adds the bounded, Esc-only reference pane and scrollback fallback.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; one unrelated pre-existing warning)
- `corepack pnpm vitest run src/test-kernel/cli/InfoPane.vitest.mts src/test-kernel/cli/AppInteractionPolicy.vitest.mts src/test-kernel/cli/SlashCommandDispatch.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts` (163 tests passed)
- `corepack pnpm vitest run src/test-kernel/cli --maxWorkers=4` (143 files,
  1,827 tests passed)
