### PR TITLE
feat: add forced final structured-output turn

### DIFF
--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -13,6 +13,7 @@ import {
 } from '@agent/types/ProviderMessage';
 import type { ProviderStopReason } from '@agent/types/StopReasonTypes';
 import type { ProviderUsage } from '@agent/core/usage/ResponseUsage';
+import type { FinalTool } from '@agent/types/ModelHandlerContracts';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import { maybeSaveDebugObject } from '@agent/utils/debugMessageSaver';
 import { RetryErrorInfoSchema } from '@shared/schemas';
@@ -58,6 +59,7 @@ export interface BaseInvocationPrepResult {
   shouldStop: boolean;
   messages: ProviderMessage[];
   systemPrompt?: string;
+  finalTool?: FinalTool;
 }
 
 /** Base success data returned from model/tool invocations. */

--- a/src/agent/core/flows/CycleServices.ts
+++ b/src/agent/core/flows/CycleServices.ts
@@ -9,7 +9,10 @@ import type { IToolRegistry } from '@agent/core/tools/ToolTypes';
 import type { IToolUseSession } from '@agent/core/flows/IToolUseSession';
 import type { BaseFlowContextInit } from '@agent/core/flows/BaseFlowServices';
 import type { IModelHandler } from '@agent/types/IModelHandler';
-import type { SdkToolCall } from '@agent/types/ModelHandlerContracts';
+import type {
+  FinalTool,
+  SdkToolCall,
+} from '@agent/types/ModelHandlerContracts';
 import type { ProviderMessage } from '@agent/types/ProviderMessage';
 import type { TaskRunFileService } from '@utils/files';
 
@@ -86,6 +89,8 @@ export interface ResponseCycleServices<
  * fields before running the round.
  */
 export interface ToolUseRoundServices<C = unknown> extends CycleRunServices<C> {
+  /** Terminal tool available for the optional provider-native final turn. */
+  readonly finalTool?: FinalTool;
   /** Session for injecting queued user messages after tool dispatch. */
   readonly session?: IToolUseSession;
   /** Callback when a queued follow-up is consumed (clears UI display). */

--- a/src/agent/core/flows/ModelInvocationNode.ts
+++ b/src/agent/core/flows/ModelInvocationNode.ts
@@ -10,6 +10,7 @@ import type {
   AgentCore,
   BaseFlowContextInit,
 } from '@agent/core/flows/BaseFlowServices';
+import type { FinalTool } from '@agent/types/ModelHandlerContracts';
 import { requiresFlowAutoRetry } from '@common/errors/sdkErrorUtils';
 import type { ToolDefinition } from '@model';
 
@@ -30,6 +31,10 @@ export interface ModelInvocationConfig<TShared, TServices> {
   ) => string | undefined;
   getEndTag?: (services: TServices) => string | undefined;
   getTools?: (services: TServices) => ToolDefinition[] | undefined;
+  getFinalTool?: (
+    shared: TShared,
+    services: TServices,
+  ) => FinalTool | undefined;
   storeResponse: (shared: TShared, response: unknown) => void;
   /**
    * Called after compaction to get additional context (e.g. active executions)
@@ -109,6 +114,7 @@ export class ModelInvocationNode<
       shouldStop: shared.shouldStop,
       messages: shared.messages,
       systemPrompt: this._config.getSystemPrompt?.(shared, this.services),
+      finalTool: this._config.getFinalTool?.(shared, this.services),
     };
   }
 
@@ -135,6 +141,7 @@ export class ModelInvocationNode<
         tools: this._config.getTools
           ? this._config.getTools(services)
           : services.setting.tools,
+        finalTool: prepRes.finalTool,
       });
 
       return {

--- a/src/agent/core/flows/ToolUseRoundFlow.ts
+++ b/src/agent/core/flows/ToolUseRoundFlow.ts
@@ -61,6 +61,7 @@ export function createToolUseRoundFlow<C>(): Flow<
       services.modelHandler.requiresPerCallSystemPrompt
         ? shared.systemPrompt
         : undefined,
+    getFinalTool: (shared) => shared.finalTool,
     storeResponse: (shared, response) => {
       shared.response = response;
     },

--- a/src/agent/core/flows/toolUseRound/ToolUseProcessNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseProcessNode.ts
@@ -22,6 +22,7 @@ import type { ToolUseRoundShared } from './roundShared';
 
 const BLANK_TOOL_RESULT_CONTINUATION =
   'The previous assistant turn after a tool result was blank. Continue now with the final answer or next required action.';
+const FINAL_TOOL_INSTRUCTION = 'Submit the final structured output now.';
 
 function hasToolResultContent(value: unknown): boolean {
   if (!Array.isArray(value)) return false;
@@ -224,9 +225,6 @@ export class ToolUseProcessNode<C> extends BaseNode<
         return FlowTransition.CONTINUE;
       }
 
-      shared.toolCalls = undefined;
-      shared.shouldStop = true;
-      shared.endTurn = true;
       if (execRes.text) {
         shared.messages.push(
           modelHandler.createAssistantMessageFromResponse(
@@ -249,6 +247,27 @@ export class ToolUseProcessNode<C> extends BaseNode<
       }
       workspace.resetServerToolContent();
       workspace.resetReasoning();
+
+      if (
+        this.services.finalTool &&
+        modelHandler.supportsForcedToolChoice &&
+        !shared.finalTool
+      ) {
+        const result = await appendFollowUpAsUserMessage(
+          shared.messages,
+          { text: FINAL_TOOL_INSTRUCTION, origin: 'synthetic' },
+          this.services,
+        );
+        shared.messages = result.messages;
+        shared.finalTool = this.services.finalTool;
+        shared.toolCalls = undefined;
+        advanceRound(shared);
+        return FlowTransition.CONTINUE;
+      }
+
+      shared.toolCalls = undefined;
+      shared.shouldStop = true;
+      shared.endTurn = true;
       return FlowTransition.COMPLETE;
     }
 

--- a/src/agent/core/flows/toolUseRound/ToolUseProcessNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseProcessNode.ts
@@ -179,6 +179,11 @@ export class ToolUseProcessNode<C> extends BaseNode<
       return FlowTransition.COMPLETE;
     }
 
+    // `finalTool` selects only the request whose response is being processed.
+    // Keep the separate attempted bit so a malformed/ignored forced response
+    // cannot force every later round or schedule a second final attempt.
+    shared.finalTool = undefined;
+
     workspace.serverToolContent.contentBlocks =
       execRes.serverToolContentBlocks ?? [];
     workspace.serverToolContent.lastAssistantContent =
@@ -251,7 +256,7 @@ export class ToolUseProcessNode<C> extends BaseNode<
       if (
         this.services.finalTool &&
         modelHandler.supportsForcedToolChoice &&
-        !shared.finalTool
+        !shared.finalToolAttempted
       ) {
         const result = await appendFollowUpAsUserMessage(
           shared.messages,
@@ -260,6 +265,7 @@ export class ToolUseProcessNode<C> extends BaseNode<
         );
         shared.messages = result.messages;
         shared.finalTool = this.services.finalTool;
+        shared.finalToolAttempted = true;
         shared.toolCalls = undefined;
         advanceRound(shared);
         return FlowTransition.CONTINUE;

--- a/src/agent/core/flows/toolUseRound/roundShared.ts
+++ b/src/agent/core/flows/toolUseRound/roundShared.ts
@@ -3,7 +3,10 @@ import { z } from 'zod';
 
 // Local imports - core flow primitives
 import { BaseCycleFieldsSchema } from '@agent/core/flows/CommonCycleTypes';
-import type { SdkToolCall } from '@agent/types/ModelHandlerContracts';
+import type {
+  FinalTool,
+  SdkToolCall,
+} from '@agent/types/ModelHandlerContracts';
 import { NormalizedUsageSchema } from '@agent/types/NormalizedUsage';
 
 /**
@@ -78,4 +81,6 @@ export interface ToolUseRoundShared extends ToolUseRoundFields {
   toolCalls?: SdkToolCall[];
   /** Current user instruction, refreshed when the round consumes user input. */
   currentUserInstruction?: string;
+  /** Named tool forced on this round's model request. */
+  finalTool?: FinalTool;
 }

--- a/src/agent/core/flows/toolUseRound/roundShared.ts
+++ b/src/agent/core/flows/toolUseRound/roundShared.ts
@@ -83,4 +83,6 @@ export interface ToolUseRoundShared extends ToolUseRoundFields {
   currentUserInstruction?: string;
   /** Named tool forced on this round's model request. */
   finalTool?: FinalTool;
+  /** Whether this cycle has already issued its one provider-native final turn. */
+  finalToolAttempted?: boolean;
 }

--- a/src/agent/implementations/flows/tooluse/ToolUseServices.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseServices.ts
@@ -2,6 +2,7 @@ import type { AgentToolUseSetting } from '@agent/core/definition/AgentDataclass'
 import type { BaseFlowContextInit } from '@agent/core/flows/BaseFlowServices';
 import type { IToolRegistry } from '@agent/core/tools/ToolTypes';
 import type { IToolUseSession } from '@agent/core/flows/IToolUseSession';
+import type { FinalTool } from '@agent/types/ModelHandlerContracts';
 import type { SubagentProgressUpdate, TodoItem } from '@shared/schemas';
 import type { TaskRunFileService } from '@utils/files';
 import type { PreparedShared, ToolUseRunShared } from './nodes/types';
@@ -12,6 +13,8 @@ export interface ToolUseServices<C = unknown> extends BaseFlowContextInit<C> {
   /** Run-storage-aware file locator; used to attach follow-up media files. */
   readonly fileService: TaskRunFileService;
   readonly toolRegistry: IToolRegistry;
+  /** Terminal tool available for the optional provider-native final turn. */
+  readonly finalTool?: FinalTool;
   readonly resumeShared: PreparedShared | null;
   readonly onFollowUpConsumed?: () => void;
   readonly onProgress?: (update: SubagentProgressUpdate) => void;

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -61,7 +61,7 @@ export class ToolUseCycleNode<C> extends Node<
 
   async exec(prepRes: CyclePrepResult): Promise<ToolUseCycleOutcome> {
     const { modelHandler } = this.services;
-    const { runScope } = useLaunchRunContext();
+    const { runScope, stopAfterCycle } = useLaunchRunContext();
     const { streamId } = runScope;
 
     if (prepRes.shouldSkipCycle) {
@@ -85,6 +85,10 @@ export class ToolUseCycleNode<C> extends Node<
       currentUserInstruction:
         typeof prepRes.userChannels.transient.INSTRUCTION === 'string'
           ? prepRes.userChannels.transient.INSTRUCTION
+          : undefined,
+      finalTool:
+        stopAfterCycle && modelHandler.supportsForcedToolChoice
+          ? this.services.finalTool
           : undefined,
     };
 

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -61,7 +61,7 @@ export class ToolUseCycleNode<C> extends Node<
 
   async exec(prepRes: CyclePrepResult): Promise<ToolUseCycleOutcome> {
     const { modelHandler } = this.services;
-    const { runScope, stopAfterCycle } = useLaunchRunContext();
+    const { runScope } = useLaunchRunContext();
     const { streamId } = runScope;
 
     if (prepRes.shouldSkipCycle) {
@@ -87,7 +87,9 @@ export class ToolUseCycleNode<C> extends Node<
           ? prepRes.userChannels.transient.INSTRUCTION
           : undefined,
       finalTool:
-        stopAfterCycle && modelHandler.supportsForcedToolChoice
+        modelHandler.supportsForcedToolChoice &&
+        this.services.setting.tools.length === 1 &&
+        this.services.setting.tools[0]?.name === this.services.finalTool?.name
           ? this.services.finalTool
           : undefined,
     };

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -75,6 +75,13 @@ export class ToolUseCycleNode<C> extends Node<
       return { outcome: 'skipped' };
     }
 
+    const finalTool =
+      modelHandler.supportsForcedToolChoice &&
+      this.services.setting.tools.length === 1 &&
+      this.services.setting.tools[0]?.name === this.services.finalTool?.name
+        ? this.services.finalTool
+        : undefined;
+
     const roundShared: ToolUseRoundShared = {
       messages: prepRes.messages,
       shouldStop: false,
@@ -86,12 +93,8 @@ export class ToolUseCycleNode<C> extends Node<
         typeof prepRes.userChannels.transient.INSTRUCTION === 'string'
           ? prepRes.userChannels.transient.INSTRUCTION
           : undefined,
-      finalTool:
-        modelHandler.supportsForcedToolChoice &&
-        this.services.setting.tools.length === 1 &&
-        this.services.setting.tools[0]?.name === this.services.finalTool?.name
-          ? this.services.finalTool
-          : undefined,
+      finalTool,
+      finalToolAttempted: finalTool !== undefined,
     };
 
     const flow = createToolUseRoundFlow<C>();

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -212,11 +212,13 @@ export async function runToolUseFlow<C = unknown>(
       ? input.config.outputSchema
       : undefined;
   let pendingStructuredOutput: ToolUseRunShared['structured'];
+  let finalTool: ToolUseServices<C>['finalTool'];
   let registry = baseRegistry;
   if (outputSchema) {
     const terminalTool = buildTerminalTool(outputSchema, (value) => {
       pendingStructuredOutput = value;
     });
+    finalTool = { name: terminalTool.definition.name };
     resolvedTools.push(terminalTool.definition);
     registry = buildTerminalToolRegistry(baseRegistry, terminalTool);
   }
@@ -228,6 +230,7 @@ export async function runToolUseFlow<C = unknown>(
     setting: { ...setting, tools: resolvedTools },
     session: sessionLifecycle,
     toolRegistry: registry,
+    finalTool,
     resumeShared: input.resume?.shared ?? null,
     persistTodos: (todos) => kv.writeTodos(todos),
     getPendingStructuredOutput: () => pendingStructuredOutput,

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -694,6 +694,11 @@ export abstract class ModelHandler<
     return false;
   }
 
+  /** Whether this provider can force one named tool on a model request. */
+  get supportsForcedToolChoice(): boolean {
+    return false;
+  }
+
   /**
    * Whether this handler needs the system prompt resupplied on every call via
    * `createResponse({ systemPrompt })`, rather than embedded once into

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -363,6 +363,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
     return tagAnthropicSdkError;
   }
 
+  override get supportsForcedToolChoice(): boolean {
+    return true;
+  }
+
   /** Enriches an Anthropic stream failure without hiding SDK or abort identity. */
   private decorateStreamError(
     error: unknown,
@@ -489,6 +493,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       endTag,
       signal,
       tools,
+      finalTool,
     } = requestOptions;
     // Get streaming config
     const useStreaming = this.getStreamingConfig();
@@ -571,7 +576,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
         useDynamicFiltering: getAnthropicDynamicFiltering(),
       });
 
-      options.tool_choice = { type: 'auto' };
+      options.tool_choice = finalTool
+        ? { type: 'tool', name: finalTool.name }
+        : { type: 'auto' };
 
       // Models using adaptive thinking get interleaved thinking automatically.
       // Only add the beta header for older models that need it explicitly.

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -364,7 +364,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
   }
 
   override get supportsForcedToolChoice(): boolean {
-    return true;
+    // Anthropic rejects named tool_choice when extended/adaptive thinking is
+    // enabled. Keep reasoning models on the ordinary terminal-tool floor.
+    return !this.capabilities.supportsReasoning;
   }
 
   /** Enriches an Anthropic stream failure without hiding SDK or abort identity. */
@@ -576,9 +578,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
         useDynamicFiltering: getAnthropicDynamicFiltering(),
       });
 
-      options.tool_choice = finalTool
-        ? { type: 'tool', name: finalTool.name }
-        : { type: 'auto' };
+      options.tool_choice =
+        finalTool && this.supportsForcedToolChoice
+          ? { type: 'tool', name: finalTool.name }
+          : { type: 'auto' };
 
       // Models using adaptive thinking get interleaved thinking automatically.
       // Only add the beta header for older models that need it explicitly.

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -2,6 +2,7 @@
 import { nanoid } from 'nanoid';
 import {
   GoogleGenAI,
+  FunctionCallingConfigMode,
   FinishReason,
   ThinkingLevel,
   PartMediaResolutionLevel,
@@ -255,6 +256,10 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     return tagGoogleSdkError;
   }
 
+  override get supportsForcedToolChoice(): boolean {
+    return true;
+  }
+
   /** Creates a Google response after SDK-boundary error tagging is installed. */
   protected override async createResponseImpl(
     options: CreateResponseOptions<Content, GoogleGenAI>,
@@ -267,6 +272,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       endTag,
       signal,
       tools,
+      finalTool,
     } = options;
     if (messages.length === 0) {
       this.logger.error('Cannot create response from empty messages array.');
@@ -307,6 +313,14 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     const googleTools = tools?.length ? toGoogleTools(tools) : undefined;
     if (googleTools?.length) {
       generationConfig.tools = googleTools;
+      if (finalTool) {
+        generationConfig.toolConfig = {
+          functionCallingConfig: {
+            mode: FunctionCallingConfigMode.ANY,
+            allowedFunctionNames: [finalTool.name],
+          },
+        };
+      }
     }
 
     const chatParams: CreateChatParameters = {

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -1389,6 +1389,10 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
     }
   }
 
+  override get supportsForcedToolChoice(): boolean {
+    return true;
+  }
+
   protected override async createResponseImpl(
     options: CreateResponseOptions<Step, GoogleGenAI>,
   ): Promise<CreateResponseResult<GoogleGenAIInteraction, Step>> {
@@ -1400,6 +1404,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
       endTag,
       signal,
       tools,
+      finalTool,
     } = options;
     if (messages.length === 0) {
       this.logger.error('Cannot create response from empty messages array.');
@@ -1414,6 +1419,9 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
     const interactionsTools = tools?.length
       ? this.toInteractionsTools(tools)
       : undefined;
+    if (finalTool && interactionsTools) {
+      generationConfig.tool_choice = finalTool.name;
+    }
 
     // Phase: COUNT + VALIDATE — adjust max_output_tokens to fit the context
     // window. Estimate on the FULL local transcript (conservative — see

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -581,6 +581,10 @@ export class ModelHandlerOpenAI<
     return tagOpenAISdkError;
   }
 
+  override get supportsForcedToolChoice(): boolean {
+    return true;
+  }
+
   /** Creates a chat completion after SDK-boundary error tagging is installed. */
   protected override async createResponseImpl(
     options: CreateResponseOptions<ChatCompletionMessageParam, OpenAI>,
@@ -593,6 +597,7 @@ export class ModelHandlerOpenAI<
       endTag,
       signal,
       tools,
+      finalTool,
     } = options;
 
     // Phase 0: COMPACT - Apply the shared trigger before building the request.
@@ -620,6 +625,12 @@ export class ModelHandlerOpenAI<
       endTag,
       tools,
     );
+    if (finalTool && tools?.length) {
+      baseParams.tool_choice = {
+        type: 'function',
+        function: { name: finalTool.name },
+      };
+    }
 
     // Phase 2: COUNT - Estimate input tokens if handler supports it
     // Phase 3: VALIDATE - Adjust max_tokens if needed

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -1494,11 +1494,22 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     }
   }
 
+  override get supportsForcedToolChoice(): boolean {
+    return true;
+  }
+
   protected override async createResponseImpl(
     options: CreateResponseOptions<ResponseInputItem, OpenAI>,
   ): Promise<CreateResponseResult<Response, ResponseInputItem>> {
-    const { client, messages, temperature, systemPrompt, signal, tools } =
-      options;
+    const {
+      client,
+      messages,
+      temperature,
+      systemPrompt,
+      signal,
+      tools,
+      finalTool,
+    } = options;
 
     if (this.backgroundLifecycle.hasPendingResume()) {
       const resumeContext: ResponseFinalizeContext = {
@@ -1798,7 +1809,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       max_output_tokens: maxOutputTokens,
       store: this.storesResponsesServerSide,
       ...(convertedTools?.length && {
-        tool_choice: 'auto' as const,
+        tool_choice: finalTool
+          ? ({ type: 'function', name: finalTool.name } as const)
+          : ('auto' as const),
         parallel_tool_calls: parallelToolCalls,
       }),
     };

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -193,6 +193,10 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     return tagOpenRouterSdkError;
   }
 
+  override get supportsForcedToolChoice(): boolean {
+    return true;
+  }
+
   /** Creates an OpenRouter response after SDK-boundary error tagging is installed. */
   protected override async createResponseImpl(
     options: CreateResponseOptions<ChatMessages, OpenRouter>,
@@ -204,6 +208,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
       endTag,
       signal,
       tools,
+      finalTool,
     } = options;
 
     // Phase 0: COMPACT - Apply the shared trigger before building the request.
@@ -245,7 +250,9 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
 
     if (tools && tools.length > 0) {
       request.tools = toOpenAITools(tools);
-      request.toolChoice = 'auto';
+      request.toolChoice = finalTool
+        ? { type: 'function', function: { name: finalTool.name } }
+        : 'auto';
     }
 
     if (endTag) {

--- a/src/agent/types/IModelHandler.ts
+++ b/src/agent/types/IModelHandler.ts
@@ -46,6 +46,7 @@ export type IModelHandler<
   | 'setOutputStreaming'
   | 'isBackgroundModeActive'
   | 'supportsManualCompaction'
+  | 'supportsForcedToolChoice'
   | 'requiresPerCallSystemPrompt'
   | 'isAutoRetryManagedByProvider'
   | 'requestCompaction'

--- a/src/agent/types/ModelHandlerContracts.ts
+++ b/src/agent/types/ModelHandlerContracts.ts
@@ -51,6 +51,11 @@ export interface TokenValidationResult {
   utilizationPercent?: number;
 }
 
+/** Named terminal tool selected for a provider-native forced turn. */
+export interface FinalTool {
+  name: string;
+}
+
 /**
  * Options for creating a model response.
  * @template M - Provider-specific message type
@@ -73,6 +78,8 @@ export interface CreateResponseOptions<
   signal?: AbortSignal;
   /** Optional tool definitions for function calling */
   tools?: ToolDefinition[];
+  /** Specific terminal tool to force for this response, when supported. */
+  finalTool?: FinalTool;
 }
 
 /**

--- a/src/test-kernel/agent/core/FinalToolSynthesis.vitest.ts
+++ b/src/test-kernel/agent/core/FinalToolSynthesis.vitest.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createRunTrace, StreamLogStore } from '@transcript';
+import type { ToolUseRoundServices } from '@agent/core/flows/CycleServices';
+import {
+  createToolUseRoundFlow,
+  type ToolUseRoundShared,
+} from '@agent/core/flows/ToolUseRoundFlow';
+import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
+import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
+import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type { CreateResponseOptions } from '@agent/types/ModelHandlerContracts';
+import type { ProviderMessage } from '@agent/types/ProviderMessage';
+import { withTestRunContext } from '../progressTestUtils';
+
+function buildRound(supportsForcedToolChoice: boolean) {
+  const requests: CreateResponseOptions[] = [];
+  const createResponse = vi.fn(async (options: CreateResponseOptions) => {
+    requests.push(options);
+    return { response: { turn: requests.length } };
+  });
+  const modelHandler = {
+    addMediaToUserMessage: vi.fn(async () => []),
+    capabilities: { supportsVision: true },
+    createAssistantMessageFromResponse: vi.fn(
+      (_response: unknown, text: string) =>
+        ({ role: 'assistant', content: text }) as ProviderMessage,
+    ),
+    createResponse,
+    createUserFollowUpMessages: vi.fn(
+      async (messages: ProviderMessage[], text: string) => [
+        ...messages,
+        { role: 'user', content: text } as ProviderMessage,
+      ],
+    ),
+    extractAssistantContent: () => [],
+    extractResponse: (response: { turn: number }) => ({
+      text: response.turn === 1 ? 'Draft answer' : '',
+      usage: null,
+      stopReason: 'stop',
+    }),
+    extractServerToolData: () => ({
+      contentBlocks: [],
+      webFetchResults: [],
+      webSearchResults: [],
+    }),
+    extractToolUse: () => [],
+    getStreamingConfig: () => false,
+    isAutoRetryManagedByProvider: () => false,
+    isEndTurnStop: () => true,
+    processThinkingBlock: () => null,
+    setOutputStreaming: vi.fn(),
+    supportsForcedToolChoice,
+  };
+  const services = {
+    checkInterruption: () => false,
+    client: {},
+    config: { agent: 'test-agent', model: 'test-model' },
+    fileService: {
+      createLocation: (filePath: string) => ({ absolutePath: filePath }),
+    },
+    finalTool: { name: 'submit_output' },
+    logger: createRunTrace(
+      'FinalToolSynthesis',
+      StreamLogStore.ephemeral('test'),
+    ).trace,
+    modelHandler,
+    onRoundFinalized: vi.fn(),
+    run: AgentRunStateSnapshotSchema.parse({}),
+    session: { hasQueuedFollowUp: () => false },
+    setAbortController: vi.fn(),
+    setting: {
+      temperature: 0,
+      tools: [{ name: 'submit_output', description: 'Submit output' }],
+    },
+    workspace: AgentWorkspaceState.create(),
+  } as unknown as ToolUseRoundServices;
+  const shared: ToolUseRoundShared = {
+    messages: [{ role: 'user', content: 'Research this' }],
+    shouldStop: false,
+    endTurn: false,
+    roundIndex: 0,
+    roundResponseTimeMs: 0,
+  };
+
+  return { requests, services, shared };
+}
+
+describe('final-tool synthesis turn', () => {
+  it('keeps exploration unforced, then forces exactly one final turn', async () => {
+    const { requests, services, shared } = buildRound(true);
+
+    await withTestRunContext(noopAgentRuntimeHost, 'final-tool-synthesis', () =>
+      createToolUseRoundFlow().setServices(services).run(shared),
+    );
+
+    expect(requests.map((request) => request.finalTool)).toEqual([
+      undefined,
+      { name: 'submit_output' },
+    ]);
+    expect(shared.messages).toEqual([
+      { role: 'user', content: 'Research this' },
+      { role: 'assistant', content: 'Draft answer' },
+      { role: 'user', content: 'Submit the final structured output now.' },
+    ]);
+  });
+
+  it('uses the unforced floor when the provider cannot force tools', async () => {
+    const { requests, services, shared } = buildRound(false);
+
+    await withTestRunContext(noopAgentRuntimeHost, 'final-tool-floor', () =>
+      createToolUseRoundFlow().setServices(services).run(shared),
+    );
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.finalTool).toBeUndefined();
+  });
+});

--- a/src/test-kernel/agent/core/FinalToolSynthesis.vitest.ts
+++ b/src/test-kernel/agent/core/FinalToolSynthesis.vitest.ts
@@ -98,6 +98,8 @@ describe('final-tool synthesis turn', () => {
       undefined,
       { name: 'submit_output' },
     ]);
+    expect(shared.finalTool).toBeUndefined();
+    expect(shared.finalToolAttempted).toBe(true);
     expect(shared.messages).toEqual([
       { role: 'user', content: 'Research this' },
       { role: 'assistant', content: 'Draft answer' },

--- a/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
@@ -6,6 +6,7 @@ const roundFlowState = vi.hoisted(() => ({
   endTurn: false,
   lastError: undefined as
     { message: string; userRetryable: boolean } | undefined,
+  finalTool: undefined as { name: string } | undefined,
 }));
 
 vi.mock('@agent/core/flows/ToolUseRoundFlow', () => ({
@@ -15,7 +16,9 @@ vi.mock('@agent/core/flows/ToolUseRoundFlow', () => ({
       shouldStop: boolean;
       endTurn: boolean;
       lastError?: { message: string; userRetryable: boolean };
+      finalTool?: { name: string };
     }) {
+      roundFlowState.finalTool = shared.finalTool;
       shared.shouldStop = roundFlowState.shouldStop;
       shared.endTurn = roundFlowState.endTurn;
       shared.lastError = roundFlowState.lastError;
@@ -83,6 +86,38 @@ function createPrepResult(
 }
 
 describe('tool-use progress events', () => {
+  it('collapses a single-shot run to one forced final-tool round', async () => {
+    roundFlowState.shouldStop = false;
+    roundFlowState.endTurn = true;
+    roundFlowState.lastError = undefined;
+    roundFlowState.finalTool = undefined;
+    const { host } = createRecordingHost();
+    const logger = new TraceEmitter();
+    const streamId = 'stream:single-shot-final-tool' as StreamTabId;
+    const node = new ToolUseCycleNode().setServices({
+      streamId,
+      runtimeHost: host,
+      logger,
+      modelHandler: {
+        getClient: vi.fn(),
+        supportsForcedToolChoice: true,
+      },
+      finalTool: { name: 'submit_output' },
+      onRoundFinalized: vi.fn(),
+      config: { model: 'test-model', agent: 'test-agent' },
+      setting: { tools: [] },
+    } as unknown as ToolUseServices);
+
+    await withTestRunContext(
+      host,
+      streamId,
+      () => node.exec(createPrepResult(AgentWorkspaceState.create(), false)),
+      { stopAfterCycle: true },
+    );
+
+    expect(roundFlowState.finalTool).toEqual({ name: 'submit_output' });
+  });
+
   it('publishes skipped-cycle todo and plan events through the runtime host', async () => {
     const { host } = createRecordingHost();
     const logger = new TraceEmitter();

--- a/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
@@ -86,7 +86,7 @@ function createPrepResult(
 }
 
 describe('tool-use progress events', () => {
-  it('collapses a single-shot run to one forced final-tool round', async () => {
+  it('collapses a run whose only tool is the terminal tool to one forced round', async () => {
     roundFlowState.shouldStop = false;
     roundFlowState.endTurn = true;
     roundFlowState.lastError = undefined;
@@ -105,7 +105,38 @@ describe('tool-use progress events', () => {
       finalTool: { name: 'submit_output' },
       onRoundFinalized: vi.fn(),
       config: { model: 'test-model', agent: 'test-agent' },
-      setting: { tools: [] },
+      setting: { tools: [{ name: 'submit_output' }] },
+    } as unknown as ToolUseServices);
+
+    await withTestRunContext(host, streamId, () =>
+      node.exec(createPrepResult(AgentWorkspaceState.create(), false)),
+    );
+
+    expect(roundFlowState.finalTool).toEqual({ name: 'submit_output' });
+  });
+
+  it('does not force the first round of a headless run with exploration tools', async () => {
+    roundFlowState.shouldStop = false;
+    roundFlowState.endTurn = true;
+    roundFlowState.lastError = undefined;
+    roundFlowState.finalTool = undefined;
+    const { host } = createRecordingHost();
+    const logger = new TraceEmitter();
+    const streamId = 'stream:headless-final-tool' as StreamTabId;
+    const node = new ToolUseCycleNode().setServices({
+      streamId,
+      runtimeHost: host,
+      logger,
+      modelHandler: {
+        getClient: vi.fn(),
+        supportsForcedToolChoice: true,
+      },
+      finalTool: { name: 'submit_output' },
+      onRoundFinalized: vi.fn(),
+      config: { model: 'test-model', agent: 'test-agent' },
+      setting: {
+        tools: [{ name: 'read_file' }, { name: 'submit_output' }],
+      },
     } as unknown as ToolUseServices);
 
     await withTestRunContext(
@@ -115,7 +146,7 @@ describe('tool-use progress events', () => {
       { stopAfterCycle: true },
     );
 
-    expect(roundFlowState.finalTool).toEqual({ name: 'submit_output' });
+    expect(roundFlowState.finalTool).toBeUndefined();
   });
 
   it('publishes skipped-cycle todo and plan events through the runtime host', async () => {

--- a/src/test-kernel/agent/modelHandlers/GoogleGenAIStreamingText.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleGenAIStreamingText.vitest.ts
@@ -98,6 +98,40 @@ function createFakeClient(...chunks: GenerateContentResponse[]): any {
 }
 
 describe('ModelHandlerGoogleGenAI streaming text extraction', () => {
+  it('maps finalTool to an ANY function allow-list', async () => {
+    const streamRecords: StreamRecord[] = [];
+    const handler = createStreamingHandler(streamRecords);
+    let chatConfig: Record<string, unknown> | undefined;
+    const response = new GenerateContentResponse();
+    response.candidates = [];
+    const client = createFakeClient(response);
+    client.chats.create = (params: { config: Record<string, unknown> }) => {
+      chatConfig = params.config;
+      return {
+        sendMessageStream: async () =>
+          (async function* () {
+            yield response;
+          })(),
+      };
+    };
+
+    await handler.createResponse({
+      client,
+      messages: [{ role: 'user', parts: [createPartFromText('finish')] }],
+      temperature: 0,
+      tools: [{ name: 'submit_output', description: 'Submit output' }],
+      finalTool: { name: 'submit_output' },
+    });
+
+    expect(chatConfig?.toolConfig).toEqual({
+      functionCallingConfig: {
+        mode: 'ANY',
+        allowedFunctionNames: ['submit_output'],
+      },
+    });
+    expect(handler.supportsForcedToolChoice).toBe(true);
+  });
+
   it('does not read the Google SDK text getter for streamed function calls', async () => {
     const streamRecords: StreamRecord[] = [];
     const handler = createStreamingHandler(streamRecords);

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsToolUse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsToolUse.vitest.ts
@@ -125,6 +125,42 @@ describe('ModelHandlerGoogleInteractions tool use', () => {
     vi.restoreAllMocks();
   });
 
+  it('maps finalTool to the Interactions generation config', async () => {
+    disableServerState();
+    const handler = createHandler();
+    let captured:
+      Interactions.CreateModelInteractionParamsStreaming | undefined;
+    const client = {
+      interactions: {
+        create: async (
+          params: Interactions.CreateModelInteractionParamsStreaming,
+        ) => {
+          captured = params;
+          return (async function* () {
+            yield {
+              event_type: 'interaction.completed',
+              interaction: { id: 'int_final', status: 'completed', steps: [] },
+            } as Interactions.InteractionSSEEvent;
+          })();
+        },
+      },
+      models: {},
+    };
+
+    await handler.createResponse({
+      client: client as never,
+      messages: [
+        { type: 'user_input', content: [{ type: 'text', text: 'finish' }] },
+      ],
+      temperature: 0,
+      tools: [{ name: 'submit_output', description: 'Submit output' }],
+      finalTool: { name: 'submit_output' },
+    });
+
+    expect(captured?.generation_config?.tool_choice).toBe('submit_output');
+    expect(handler.supportsForcedToolChoice).toBe(true);
+  });
+
   it('accumulates parallel arguments_delta chunks and extracts tool calls', async () => {
     const handler = createHandler();
 

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
@@ -138,6 +138,30 @@ function getCacheMarker(block?: ContentBlockParam | ContentBlock): unknown {
   return (block as { cache_control?: unknown }).cache_control;
 }
 
+describe('ModelHandlerAnthropic forced tool choice', () => {
+  it('maps finalTool to a named Anthropic tool choice', async () => {
+    const handler = createAnthropicHandler();
+    stubHandlerForTest(handler);
+    const { client, messageOptions } = createCapturingAnthropicClient(
+      handler.config.fullName,
+    );
+
+    await handler.createResponse({
+      client,
+      messages: helloMessages(),
+      temperature: 0,
+      tools: [{ name: 'submit_output', description: 'Submit output' }],
+      finalTool: { name: 'submit_output' },
+    });
+
+    assert.deepEqual(messageOptions[0].tool_choice, {
+      type: 'tool',
+      name: 'submit_output',
+    });
+    assert.equal(handler.supportsForcedToolChoice, true);
+  });
+});
+
 /** Create a no-op logger stub for handler tests, with optional overrides. */
 function createLoggerStub(
   overrides?: Partial<Record<string, unknown>>,

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
@@ -160,6 +160,26 @@ describe('ModelHandlerAnthropic forced tool choice', () => {
     });
     assert.equal(handler.supportsForcedToolChoice, true);
   });
+
+  it('uses the unforced floor when Anthropic thinking is enabled', async () => {
+    const handler = createAnthropicHandler({ supportsReasoning: true });
+    stubHandlerForTest(handler);
+    const { client, messageOptions } = createCapturingAnthropicClient(
+      handler.config.fullName,
+    );
+
+    await handler.createResponse({
+      client,
+      messages: helloMessages(),
+      temperature: 0,
+      tools: [{ name: 'submit_output', description: 'Submit output' }],
+      finalTool: { name: 'submit_output' },
+    });
+
+    assert.deepEqual(messageOptions[0].tool_choice, { type: 'auto' });
+    assert.equal(handler.supportsForcedToolChoice, false);
+    assert.ok(messageOptions[0].thinking);
+  });
 });
 
 /** Create a no-op logger stub for handler tests, with optional overrides. */

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
@@ -294,6 +294,35 @@ describe('ModelHandlerOpenAIResponse.createResponse', () => {
     assert.equal(request?.parallel_tool_calls, true);
   });
 
+  it('maps finalTool to a named Responses function choice', async () => {
+    const handler = createHandler();
+    let request: Record<string, unknown> | undefined;
+    const tools: ToolDefinition[] = [
+      { name: 'submit_output', description: 'Submit output' },
+    ];
+
+    await handler.createResponse({
+      client: {
+        responses: {
+          create: async (params: Record<string, unknown>) => {
+            request = params;
+            return createResponse('resp-forced-tool', { input_tokens: 12 });
+          },
+        },
+      } as any,
+      messages: createMessages(1),
+      temperature: 0,
+      tools,
+      finalTool: { name: 'submit_output' },
+    });
+
+    assert.deepEqual(request?.tool_choice, {
+      type: 'function',
+      name: 'submit_output',
+    });
+    assert.equal(handler.supportsForcedToolChoice, true);
+  });
+
   it('rejects concurrent calls on the same handler instance', async () => {
     const handler = createHandler();
     let resolveCreate: (response: any) => void = () => undefined;

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIToolUse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIToolUse.vitest.ts
@@ -124,3 +124,35 @@ describe('ModelHandlerOpenAI.extractToolUse', () => {
     );
   });
 });
+
+describe('ModelHandlerOpenAI forced tool choice', () => {
+  it('maps finalTool to a named function choice', async () => {
+    const handler = new ModelHandlerOpenAI(buildConfig(ModelProvider.OPENAI));
+    handler.setLogger(createLoggerStub());
+    handler.getStreamingConfig = () => false;
+    let request: Record<string, unknown> | undefined;
+
+    await handler.createResponse({
+      client: {
+        chat: {
+          completions: {
+            create: async (params: Record<string, unknown>) => {
+              request = params;
+              return completionWithValidToolCall();
+            },
+          },
+        },
+      } as never,
+      messages: [{ role: 'user', content: 'finish' }],
+      temperature: 0,
+      tools: [{ name: 'submit_output', description: 'Submit output' }],
+      finalTool: { name: 'submit_output' },
+    });
+
+    assert.deepEqual(request?.tool_choice, {
+      type: 'function',
+      function: { name: 'submit_output' },
+    });
+    assert.equal(handler.supportsForcedToolChoice, true);
+  });
+});

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenRouterNative.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenRouterNative.vitest.ts
@@ -191,6 +191,27 @@ describe('ModelHandlerOpenRouterNative Moonshot fixed temperature', () => {
 
     assert.equal(sendCalls[0].temperature, 0.3);
   });
+
+  it('maps finalTool to a named OpenRouter function choice', async () => {
+    const handler = new ModelHandlerOpenRouterNative(buildConfig());
+    (handler as any).setLogger(createLoggerStub());
+    (handler as any).getStreamingConfig = () => false;
+    const { client, sendCalls } = createSendStub();
+
+    await handler.createResponse({
+      client: client as any,
+      messages: [{ role: 'user', content: 'finish' }],
+      temperature: 0,
+      tools: [{ name: 'submit_output', description: 'Submit output' }],
+      finalTool: { name: 'submit_output' },
+    });
+
+    assert.deepEqual(sendCalls[0].toolChoice, {
+      type: 'function',
+      function: { name: 'submit_output' },
+    });
+    assert.equal(handler.supportsForcedToolChoice, true);
+  });
 });
 
 describe('ModelHandlerOpenRouterNative response mode discrimination', () => {

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerVscodeLm.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerVscodeLm.vitest.ts
@@ -268,6 +268,7 @@ describe('ModelHandlerVscodeLm streaming and tools', () => {
           parameters: { type: 'object', properties: {} },
         },
       ],
+      finalTool: { name: 'search' },
     });
 
     expect(response).toMatchObject({
@@ -295,6 +296,7 @@ describe('ModelHandlerVscodeLm streaming and tools', () => {
         input: { url: 'https://example.com' },
       },
     ]);
+    expect(handler.supportsForcedToolChoice).toBe(false);
     expect(port.sendRequest).toHaveBeenCalledWith(
       { vendor: ModelProvider.COPILOT, id: 'copilot-model-id' },
       [


### PR DESCRIPTION
## Summary

- add one optional final-synthesis transition after an unforced tool-use loop naturally completes
- force the terminal tool through native Anthropic, OpenAI Chat/Responses, OpenRouter, and both Google request shapes
- retain the ordinary terminal-tool contract as the correctness floor for providers such as VS Code LM
- collapse single-shot structured-output runs directly to their one forced turn

## Design

The terminal tool remains the single validation and completion boundary. Native forcing is only a per-handler request optimization: capable handlers expose one local capability getter, while the flow marks exactly one request with the terminal tool name. A synthetic user follow-up keeps provider histories valid and bounds the final turn without adding a parallel output path.

## Verification

- `npm run format`
- `npm run lint` (no errors; existing unrelated `unicorn/prefer-string-replace-all` warning)
- `npm run typecheck`
- `npm run compile:fast`
- `npm test` (741 files passed, 1 skipped; 6,869 tests passed, 4 skipped)

Closes #8831

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core tool-use round completion path and provider request shaping across several handlers; behavior is bounded to one forced attempt with an explicit fallback when forcing is unsupported.
> 
> **Overview**
> Adds an **optional provider-native final turn** after the normal tool-use loop ends naturally, so structured-output runs can nudge the model into calling the terminal `submit_output` tool instead of stopping on free text alone.
> 
> The flow threads a **`finalTool`** name from `runToolUseFlow` (when an `outputSchema` builds the terminal tool) through cycle/round services into **`ModelInvocationNode`**, which passes it on **`createResponse`**. **`ToolUseProcessNode`** may schedule **exactly one** follow-up round: a synthetic user instruction, `finalToolAttempted` guarding against repeats, and clearing `finalTool` after each processed response so bad forced replies cannot loop. **Single-tool** structured-output sessions start with that forced turn immediately; multi-tool runs stay unforced until the post-exploration end turn.
> 
> Model handlers expose **`supportsForcedToolChoice`** (Anthropic disables it when reasoning/thinking is on; VS Code LM stays on the unforced floor) and map `finalTool` to each API’s named tool choice (Anthropic, OpenAI Chat/Responses, OpenRouter, Google GenAI and Interactions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adeede9ed35fbebdf37815fd48b30590486a59c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->