### PR TITLE
fix(tools): disambiguate colliding formatIssueComment exports

### DIFF
--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -25,10 +25,10 @@ import {
   formatCIComplete,
   formatCIPassed,
   formatCIStarted,
-  formatIssueComment,
   formatMergeConflictDetected,
   formatMergeConflictResolved,
   formatPRClosed,
+  formatPRIssueComment,
   formatReview,
   formatReviewComment,
   formatSubscriptionError,
@@ -529,7 +529,7 @@ export class PRPollingSource extends PollingSourceBase<
       state.etags.issueComments = commentsRes.etag;
       state.issueComments.diff(commentsRes.data, (c) => {
         if (shouldDropBotEvent(c.user)) return;
-        this.emit(state, formatIssueComment(state.slug, pr.pullNumber, c));
+        this.emit(state, formatPRIssueComment(state.slug, pr.pullNumber, c));
       });
     }
 

--- a/src/tools/github/formatPREvent.ts
+++ b/src/tools/github/formatPREvent.ts
@@ -97,7 +97,16 @@ const annotationBlock = (a: GhCheckAnnotation): string => {
   return `[${level}] ${annotationLocation(a)}\n${title}${message}`;
 };
 
-export function formatIssueComment(
+/**
+ * GitHub delivers general PR comments over the same `issue_comment` webhook
+ * as plain-issue comments (a PR *is* an issue under the REST API). Named
+ * `formatPRIssueComment` — not `formatIssueComment` — to stay distinct from
+ * `formatIssueEvent.ts`'s same-signature `formatIssueComment`; the two are
+ * not interchangeable (wrong one renders `pulls/N` where `issues/N` is
+ * expected, or vice versa) and TypeScript can't catch the swap since both
+ * take `(slug: string, number: number, c: GhIssueComment): string`.
+ */
+export function formatPRIssueComment(
   slug: string,
   prNumber: number,
   c: GhIssueComment,


### PR DESCRIPTION
## Summary

Scheduled codebase audit for overlapping/confusing responsibilities. Four parallel surveys covered `src/agent/*` + `src/tools/*`, the extension UI layer (`commands/`, `webview/`, `progressView/`, `settingsView/`, `controllers/`), the CLI TUI (`packages/cli/`, `packages/desktop/`), and `src/platform/`/`src/shared/`/`src/eventBus/`/`src/skills/`. The codebase is generally disciplined — most apparent overlaps turned out to be deliberately layered and documented in place. This PR fixes the one clear, contained case of genuine duplicate logic with real bug risk; the rest are documented below for follow-up rather than bundled into this diff.

**The fix:** `src/tools/github/formatPREvent.ts` and `src/tools/github/formatIssueEvent.ts` each exported a function named `formatIssueComment` with the *identical* signature — `(slug: string, number: number, c: GhIssueComment): string` — differing only in whether they render a `pulls/N` or `issues/N` reference path (confirmed at `formatPREvent.ts:100` and `formatIssueEvent.ts:22`). `PRPollingSource.ts` imported its copy from `formatPREvent`; `IssuePollingSource.ts` imported its copy from `formatIssueEvent`. Because the signatures are structurally identical, TypeScript gives no protection against an editor auto-import or future edit pulling the wrong one — e.g. `IssuePollingSource.ts` accidentally resolving `formatIssueComment` from `formatPREvent.ts` would silently render every issue-comment notification as `owner/repo/pulls/N` instead of `owner/repo/issues/N`, with no type error and no test to catch it (there are no tests for either formatter file).

Renamed the PR-side export to `formatPRIssueComment` (PRs surface general comments over GitHub's `issue_comment` webhook, so the old name wasn't wrong, just collision-prone) and updated its one call site in `PRPollingSource.ts:532`. `formatIssueEvent.ts`'s `formatIssueComment` is untouched — it's correctly named for its own domain.

## Issue acceptance gates

- Two same-name, same-signature sibling exports that could be silently swapped with no compiler or test signal → renamed to remove the collision. Gate satisfied.

## Single source of truth

Comment formatting still funnels through the shared `formatCommentEvent`/`prRef`/`issueRef` helpers in `formatUtils.ts` (unchanged) — this PR only removes the ambiguous name at the two thin per-domain wrappers around that shared helper.

## Duplication and abstraction budget

No duplication removed or added; this is a naming-collision fix, not a logic consolidation (the two wrappers do genuinely different things — PR ref vs. issue ref — so merging them into one function would just reintroduce a caller-side conditional). No new abstraction.

## Net elements (R6)

`+1/-1` exported symbols (`formatIssueComment` → `formatPRIssueComment` in `formatPREvent.ts`), 2 files touched, 12 insertions / 3 deletions. Not a refactor/consolidate PR — n/a for full net-element accounting.

## Consumer counts (R8)

`formatIssueComment` (PR-side) had exactly one call site (`PRPollingSource.ts:532`), grepped and updated. `formatIssueComment` (issue-side, `IssuePollingSource.ts:205`) is untouched and still has its one call site.

## Host impact

Extension: none (repo-root `src/tools/` is host-neutral; no VS Code-specific surface touched).

Desktop: none.

CLI: none.

## Scheduled refactoring

Other findings from this audit, not addressed here (none rise to "most significant," each is small/independent, deferring to keep this diff minimal):

- **Extension-only manager-layer naming drift** (`packages/extension/src/webview/managers/` vs `packages/extension/src/settingsView/handlers/` vs `progressView/` with no such subfolder at all) — AGENTS.md's own worked example (`ProgressStreamLifecycleHost.ts` in a `progressView/managers/` folder) doesn't exist in the repo.
- **CLAUDE.md documents a deleted `packages/extension/src/commands/settings/` subdirectory** (removed in `772a560`); settings commands now live in the flat `extensionCommandHandlers.ts`/`extensionCommandSurface.ts`.
- **Two differently-scoped folders both named `settingsView/handlers`** (`src/shared/settingsView/handlers/` — host-neutral message builders — vs `packages/extension/src/settingsView/handlers/` — extension-only stateful classes). Legitimate split, ambiguous shared name.
- **CLAUDE.md claims `src/hosts/` covers clipboard**, but there's no clipboard port in `src/hosts/uiHosts.ts`; each host (webview, CLI) implements clipboard independently with no shared interface.

None of these are bundled here since each is either doc-only drift or a broader rename that deserves its own reviewable diff.

## Validation

- `npm run typecheck` — clean across all workspace packages (root, test-kernel, `texra` extension, `@texra-ai/cli`, `@texra/trace-viewer`, `@texra/desktop`).
- `npx eslint` on the four touched/related files — clean.
- Grepped for all `formatIssueComment` references repo-wide to confirm both call sites were updated correctly and no other consumer was missed.
- No existing test suite covers these formatter files (confirmed via glob), so this fix relies on the rename + typecheck to close the collision risk, not a new regression test — consistent with the file's existing convention of no dedicated unit tests for this format-string layer.

---
_Generated by [Claude Code](https://claude.ai/code/session_014t2m8AnxTZT6pjrMuuB4Sx)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Rename-only change with one call site updated; no runtime logic or security-sensitive paths modified.
> 
> **Overview**
> Renames the PR polling formatter **`formatIssueComment`** → **`formatPRIssueComment`** in `formatPREvent.ts` and updates its single call site in `PRPollingSource.ts`.
> 
> Both `formatPREvent.ts` and `formatIssueEvent.ts` previously exported **`formatIssueComment`** with the same signature but different link paths (`pulls/N` vs `issues/N`). The rename removes that collision so a wrong auto-import cannot silently mis-route notifications. A JSDoc block documents why the two helpers must stay separate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6f88b665e421fa2a7be57fcd50f69432817d565. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->