### PR TITLE
refactor(modelHandlers): drop dead Google media stubs

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -1066,10 +1066,21 @@ export abstract class ModelHandler<
   ): Promise<M[]>;
 
   /**
-   * Formats image content into provider-specific message format.
+   * Formats media entries into provider-specific content blocks for the base
+   * {@link createMediaMessage} template. Providers that render media through
+   * that template override this; providers that override `createMediaMessage`
+   * wholesale (e.g. the Google handlers, which upload/inline media directly)
+   * never reach this path and inherit the default, which fails clearly rather
+   * than emitting a malformed payload if a future change ever routes media
+   * through the base template without supplying a conversion.
    * @returns Array of formatted image/document content objects
    */
-  abstract createMediaContent(mediaMessage: MediaEntry[]): Media[];
+  createMediaContent(_mediaMessage: MediaEntry[]): Media[] {
+    throw new Error(
+      `${this.constructor.name}.createMediaContent is not implemented — ` +
+        'override it, or override createMediaMessage to build media directly.',
+    );
+  }
 
   /**
    * Extracts the response text and metadata from the model's response object

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -665,20 +665,6 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     return this.uploadMediaEntries(entries);
   }
 
-  createMediaContent(_mediaMessage: MediaEntry[]): Part[] {
-    // Dead in practice: createMediaMessage() above is overridden to
-    // upload/inline entries directly and never calls this — it exists only
-    // to satisfy ModelHandler's abstract contract now that the base class
-    // types createMediaContent/createMediaForRound against the handler's
-    // `Part` media type (#7465). Throws rather than casting MediaEntry[] to
-    // Part[]: a future refactor that removes the createMediaMessage override
-    // above and starts actually calling this would otherwise silently send a
-    // malformed Part[] payload to the Google SDK instead of failing clearly.
-    throw new Error(
-      'ModelHandlerGoogleGenAI.createMediaContent is unreachable — media is built directly in createMediaMessage.',
-    );
-  }
-
   extractResponse(
     responseObject: GenerateContentResponse,
     endTag: string,

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -860,21 +860,6 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
     return this.uploadMediaEntries(entries);
   }
 
-  createMediaContent(_mediaMessage: MediaEntry[]): Content[] {
-    // Dead in practice: createMediaMessage() above is overridden to upload
-    // entries directly via uploadMediaEntries() and never calls this — it
-    // exists only to satisfy ModelHandler's abstract contract now that the
-    // base class types createMediaContent/createMediaForRound against the
-    // handler's `Content` media type (#7465). Throws rather than casting
-    // MediaEntry[] to Content[]: a future refactor that removes the
-    // createMediaMessage override above and starts actually calling this
-    // would otherwise silently send a malformed Content[] payload to the
-    // Google SDK instead of failing clearly.
-    throw new Error(
-      'ModelHandlerGoogleInteractions.createMediaContent is unreachable — media is built directly in createMediaMessage.',
-    );
-  }
-
   /** Build typed Content for media entries (inline ≤20 MB; uploaded uri otherwise). */
   private async uploadMediaEntries(entries: MediaEntry[]): Promise<Content[]> {
     const insertedEntries: MediaEntry[] = [];


### PR DESCRIPTION
## Summary

- Give `ModelHandler.createMediaContent` one fail-clearly base implementation.
- Delete the unreachable throwing overrides from both Google handlers.

## Root cause

The base `createMediaMessage` template is the only internal caller of
`createMediaContent`. The Google handlers replace `createMediaMessage` entirely
to upload or inline media themselves, so they never use the lower-level hook.
Making that hook abstract forced those handlers to carry dead methods solely to
satisfy the type contract.

The base class now owns the fallback contract. Providers that use the base media
template continue to override it; providers that own the higher-level media path
do not need placeholder methods. A future accidental call still fails clearly
instead of producing malformed provider content.

The unrelated SDK-readiness checkpoint was removed from this PR so the change is
single-purpose and its disputed audit claims do not ship with the code cleanup.

## Scope

- 3 source files changed
- 13 insertions, 31 deletions (net -18)
- no new exports, types, factories, or runtime behavior

## Validation

- Prettier on changed files: passed
- ESLint on changed files: passed
- Model-handler Vitest suites: 550 passed, 4 skipped
- Exact-head CI: pending
