### PR TITLE
Consolidate duplicated empty-state text, spinner, and badge UI

### DIFF
--- a/packages/cli/src/onboarding/runOnboarding.tsx
+++ b/packages/cli/src/onboarding/runOnboarding.tsx
@@ -13,7 +13,6 @@
 // `texra run` / `--print` / piped output stay byte-identical (headless parity).
 
 import { render, Box, Text, useApp, useInput } from 'ink';
-import { Spinner } from '@inkjs/ui';
 import { useState } from 'react';
 
 import { platform } from '@platform/platform';
@@ -23,6 +22,7 @@ import { DEFAULT_OAUTH_PROVIDER } from '@auth/config';
 import { type OAuthProvider } from '@auth/sharedConfig';
 import { type SupabaseSession } from '@auth/SupabaseSession';
 import { useCancellableEffect } from '@cli/chat/tui/state/useCancellableEffect';
+import { LoadingIndicator } from '@cli/chat/tui/ui/LoadingIndicator';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { API_PROVIDERS, type ApiProvider } from '@model/apiProviders';
 import {
@@ -656,7 +656,7 @@ function RelayProgressFrame(props: {
         {props.children}
       </Box>
       <Box marginTop={1}>
-        <Spinner label={props.spinnerLabel} />
+        <LoadingIndicator label={props.spinnerLabel} />
       </Box>
     </Box>
   );

--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -198,9 +198,6 @@ export class BackgroundTasksPanel extends LitElement {
 
       .empty-message {
         padding: var(--wa-space-2xs) 0;
-        font-size: var(--font-size-sm);
-        color: var(--color-text-secondary);
-        font-style: italic;
       }
 
       /* Collapsible output per task — also a <wa-details>. */
@@ -407,7 +404,9 @@ export class BackgroundTasksPanel extends LitElement {
           ${
             !hasActive && hasFinished
               ? html`<div class="empty-message">
-                  All ${finishedCount} ${label.toLowerCase()} completed
+                  <em class="text-secondary"
+                    >All ${finishedCount} ${label.toLowerCase()} completed</em
+                  >
                 </div>`
               : nothing
           }

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.styles.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.styles.ts
@@ -143,8 +143,6 @@ export const agentSelectionPanelStyles: CSSResult = css`
     align-items: center;
     justify-content: center;
     height: 100%;
-    color: var(--color-text-secondary);
-    font-style: italic;
   }
 
   .agent-detail-header {
@@ -227,11 +225,6 @@ export const agentSelectionPanelStyles: CSSResult = css`
 
   wa-button.agent-count-link::part(base):hover {
     text-decoration: underline;
-  }
-
-  .agent-empty-message {
-    color: var(--color-text-secondary);
-    font-style: italic;
   }
 
   .agent-detail-path {

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -354,7 +354,9 @@ export class AgentSelectionPanel extends LitElement {
     if (!agent) {
       return html`
         <div class="agent-detail-pane">
-          <div class="agent-detail-empty">Select an agent to view details</div>
+          <div class="agent-detail-empty">
+            <em class="text-secondary">Select an agent to view details</em>
+          </div>
         </div>
       `;
     }
@@ -551,7 +553,7 @@ export class AgentSelectionPanel extends LitElement {
 
   override render(): TemplateResult {
     if (this.agents.length === 0) {
-      return html` <p class="agent-empty-message">No agents available.</p> `;
+      return html` <em class="text-secondary">No agents available.</em> `;
     }
 
     const enabledCount = this.agents.filter((a) => a.enabled).length;

--- a/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
@@ -13,6 +13,7 @@ import { waIcon } from '@shared/wa/webAwesomeIcons';
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/switch/switch.js';
+import '@awesome.me/webawesome/dist/components/tag/tag.js';
 
 // Local imports - shared schemas
 import type {
@@ -59,15 +60,6 @@ export class ModelsTab extends LitElement {
       }
       .keyless-source__title {
         font-weight: var(--font-weight-semibold);
-      }
-      .keyless-source__badge {
-        font-size: var(--font-size-xs);
-        text-transform: uppercase;
-        letter-spacing: 0;
-        opacity: 0.65;
-        border: 1px solid currentColor;
-        border-radius: var(--border-radius-small);
-        padding: 0 0.4em;
       }
       .keyless-source__hint {
         margin: var(--wa-space-2xs) 0 var(--wa-space-xs);
@@ -272,7 +264,7 @@ export class ModelsTab extends LitElement {
       <section id="chatgpt-subscription" class="keyless-source">
         <div class="keyless-source__header">
           <span class="keyless-source__title">ChatGPT subscription</span>
-          <span class="keyless-source__badge">experimental</span>
+          <wa-tag variant="neutral" size="small">experimental</wa-tag>
         </div>
         <p class="keyless-source__hint">
           Use OpenAI models through your ChatGPT Plus, Pro, or Team
@@ -359,7 +351,7 @@ export class ModelsTab extends LitElement {
       <section id="copilot-access" class="keyless-source">
         <div class="keyless-source__header">
           <span class="keyless-source__title">Copilot in VS Code</span>
-          <span class="keyless-source__badge">keyless</span>
+          <wa-tag variant="neutral" size="small">keyless</wa-tag>
         </div>
         <p class="keyless-source__hint">
           Use models supplied by your GitHub Copilot subscription. No provider


### PR DESCRIPTION
## Summary

A periodic UI-consistency audit (icons, inline styles/component duplication, CLI Ink usage) found the codebase largely clean, with a few small spots where components hand-rolled their own version of something a shared component/class already provides elsewhere in the repo. This PR fixes those:

- **CLI onboarding spinner**: `runOnboarding.tsx`'s relay sign-in step (`RelayProgressFrame`) rendered `@inkjs/ui`'s `<Spinner>`. The chat TUI's own `LoadingIndicator.tsx` carries a comment explaining it deliberately *replaces* that exact component, because `<Spinner>`'s ~80ms `setInterval` (via `cli-spinners`) runs outside the shared 1Hz clock the rest of the TUI ticks off — the per-component-interval anti-pattern the shared clock exists to avoid. `useLiveNowMs` (which `LoadingIndicator` uses) is a standalone hook with a module-scoped shared timer, so it works fine in onboarding's separate Ink root too. Swapped it in.
- **Duplicated "muted empty-state text" CSS**: `BackgroundTasksPanel.ts` (`.empty-message`) and `AgentSelectionPanel.styles.ts` (`.agent-detail-empty`, `.agent-empty-message`) each redeclared `color: var(--color-text-secondary); font-style: italic;` instead of reusing the existing `.text-secondary` class (already imported into all three files via `commonViewStyles`) combined with a semantic `<em>` tag for italics — the idiom already established in `MemoryItem.ts` ("This note is empty.", "Loading contents...", etc). Removed the duplicated declarations and switched the templates to the existing idiom.
- **Hand-rolled badge**: `ModelsTab.ts`'s "experimental"/"keyless" labels used a bespoke bordered `<span class="keyless-source__badge">` where every other settings tab (`AgentsTab.ts`, `MultiAgentTab.ts`, `LaTeXTab.ts`) uses `<wa-tag variant="neutral" size="small">` for the same kind of inline status label. Switched to match, and removed the now-unused CSS.

No behavior change — these are pure visual/markup normalization to the patterns already dominant elsewhere in the same files' own component families.

## Issue acceptance gates

No tracked issue; this is a proactive cleanup from a periodic UI-consistency review, addressing every actionable finding surfaced by that review.

## Single source of truth

- Onboarding's loading indicator now goes through `LoadingIndicator`/`useLiveNowMs` (`packages/cli/src/chat/tui/ui/LoadingIndicator.tsx`), the CLI's one shared-clock spinner implementation, instead of a second independent spinner mechanism.
- Muted empty-state text styling is now owned solely by `.text-secondary` in `src/shared/styles/commonViewStyles.ts`; the three touched components no longer keep their own copies of that declaration.
- Inline status-label styling (experimental/keyless) is now owned by the shared `wa-tag` component instead of a component-local CSS class.

## Duplication and abstraction budget

Removed duplication only; no new abstractions added. Deleted: one spinner mechanism (`@inkjs/ui`'s `<Spinner>` usage), three CSS blocks re-declaring `.text-secondary`'s color/font-style, one CSS block re-declaring `wa-tag`'s badge look. No new components, wrappers, or exports introduced — every fix routes through a pre-existing shared class/component that was already imported/available in the touched file.

## Net elements (R6)

5 files changed, 12 insertions(+), 26 deletions(-). No exported symbols added or removed (`^[+-]export` over the diff: none). No new classes/interfaces/enums.

## Consumer counts (R8)

n/a — no emit path or export was deleted or re-routed; all changes are local template/CSS edits within the same file.

## Host impact

Extension: `BackgroundTasksPanel` (progress view), `AgentSelectionPanel` and `ModelsTab` (settings view) — visual-only normalization, no behavior change.

Desktop: none (webview code is shared with the extension host; no desktop-specific files touched).

CLI: `runOnboarding.tsx`'s relay sign-in spinner now ticks off the same shared clock as the rest of the TUI instead of its own independent interval.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — passes clean across the whole workspace.
- `npm run lint` — 0 errors (1 pre-existing, unrelated warning in `AgentCreatorToolCatalogParity.vitest.mts`).
- Targeted `vitest run` on tests touching the changed components/flows (`BadgeStyleContracts`, `AgentSelectionPanelToggle`, `CopilotModelAccess`, `OnboardingFlow`, `OnboardingState`, `OnboardingGate`) — 6 files / 34 tests passed.
- Did not run the full `npm test` suite to completion (times out over 5 minutes in this environment); the changes are narrow CSS/markup/import swaps with no logic changes, and the targeted suites above cover every touched component.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DSZcNDrpf1BuRh3SMY2Ydu)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual/markup-only swaps with no logic, auth, or data-path changes; net deletion of duplicate CSS and a spinner dependency.
> 
> **Overview**
> **UI consistency cleanup** — no behavior changes; markup and styling now match patterns already used elsewhere in the CLI and extension.
> 
> **CLI onboarding** replaces `@inkjs/ui` `<Spinner>` in `RelayProgressFrame` with the shared `LoadingIndicator`, so relay sign-in progress uses the same 1Hz shared-clock spinner as the rest of the TUI instead of a separate ~80ms interval.
> 
> **Extension webviews** drop duplicated muted empty-state CSS (`color` + italic) in **Background Tasks** and **Agent selection** in favor of `<em class="text-secondary">`, matching other settings/progress panels. **Models** settings swap hand-rolled bordered spans for **experimental** / **keyless** labels to `<wa-tag variant="neutral" size="small">` like other settings tabs, and remove the unused `.keyless-source__badge` styles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfdd92a4cf4c27e3c8b7d92b492f8b8b6338d410. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->