### PR TITLE
refactor(review): align issue tool with output spine

### DIFF
--- a/src/test-kernel/tools/ReportReviewIssueTool.vitest.ts
+++ b/src/test-kernel/tools/ReportReviewIssueTool.vitest.ts
@@ -49,6 +49,36 @@ describe('ReportReviewIssueTool', () => {
     });
   });
 
+  it('streams each finding to the sink immediately and unchanged', async () => {
+    const sink = vi.fn<ReportReviewIssueSink>(() => ({ accepted: true }));
+    setReportReviewIssueSink(sink);
+    const tool = new ReportReviewIssueTool();
+    const first = { ...REPORT, endLine: 7 };
+    const second = {
+      ...REPORT,
+      file: 'src/y.ts',
+      startLine: 11,
+      title: 'Dropped result',
+    };
+
+    await tool.call(first);
+
+    expect(sink).toHaveBeenCalledTimes(1);
+    expect(sink).toHaveBeenLastCalledWith({
+      ...first,
+      suggestion: undefined,
+    });
+
+    await tool.call(second);
+
+    expect(sink).toHaveBeenCalledTimes(2);
+    expect(sink).toHaveBeenLastCalledWith({
+      ...second,
+      endLine: undefined,
+      suggestion: undefined,
+    });
+  });
+
   it('normalizes null optional fields to undefined for the sink', async () => {
     const sink = vi.fn<ReportReviewIssueSink>(() => ({ accepted: true }));
     setReportReviewIssueSink(sink);

--- a/src/tools/ReportReviewIssueTool.ts
+++ b/src/tools/ReportReviewIssueTool.ts
@@ -12,6 +12,7 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 
 // Local file imports
 import { defineTool } from './core/define';
+import { normalizeStructuredOutputSchema } from './structuredOutput';
 
 const CHANNEL = 'ReportReviewIssueTool';
 
@@ -68,12 +69,15 @@ const ReportReviewIssueInputSchema = z.strictObject({
 });
 
 type ReportReviewIssueInput = z.infer<typeof ReportReviewIssueInputSchema>;
+const NormalizedReportReviewIssueSchema = normalizeStructuredOutputSchema(
+  ReportReviewIssueInputSchema,
+);
 
 export class ReportReviewIssueTool extends defineTool({
   name: 'report_review_issue',
   description:
     'Report one finding from an agent review of the current change set. The issue appears in the Agent Review panel and as an editor diagnostic with quick fixes. Only accepted while an agent review session is collecting issues.',
-  schema: ReportReviewIssueInputSchema,
+  schema: NormalizedReportReviewIssueSchema.zodSchema,
 }) {
   protected async execute(input: ReportReviewIssueInput): Promise<ToolResult> {
     try {

--- a/src/tools/structuredOutput.ts
+++ b/src/tools/structuredOutput.ts
@@ -9,9 +9,9 @@ import type { ToolResult } from '@shared/schemas/toolResult';
 // Local file imports
 import { defineTool } from './core/define';
 
-type StructuredOutputSchema = {
+type StructuredOutputSchema<TSchema extends z.ZodType = z.ZodType> = {
   readonly jsonSchema: Record<string, unknown>;
-  readonly zodSchema: z.ZodType;
+  readonly zodSchema: TSchema;
 };
 
 const JsonValueSchema = z.json();
@@ -78,6 +78,12 @@ function assertNoHostRegex(schema: unknown): void {
  * and sandbox JSON Schema land on the same Zod validation path and the same
  * provider-facing object schema conversion.
  */
+export function normalizeStructuredOutputSchema<TSchema extends z.ZodType>(
+  input: TSchema,
+): StructuredOutputSchema<TSchema>;
+export function normalizeStructuredOutputSchema(
+  input: z.ZodType | Record<string, unknown>,
+): StructuredOutputSchema;
 export function normalizeStructuredOutputSchema(
   input: z.ZodType | Record<string, unknown>,
 ): StructuredOutputSchema {


### PR DESCRIPTION
## Summary

- route `report_review_issue` through the shared structured-output schema normalizer before the ordinary `defineTool` / `BaseTool` validation path
- preserve the concrete Zod schema type across normalization, so existing tools can use the boundary without casts or widened execute inputs
- lock the existing per-finding behavior with a parity test: each call reaches the host sink immediately and unchanged

The review tool already used the same Zod validator as `submit_output`, but it bypassed the structured-output entry point. That made the shared spine a convention rather than an enforced construction path. The normalizer also erased the concrete Zod type, which discouraged typed tools from consuming it directly. This change fixes that boundary instead of adding a review-specific adapter.

## Issue acceptance gates

- #8834: `report_review_issue` now enters through `normalizeStructuredOutputSchema` and continues through the existing `defineTool` / `BaseTool` validation path.
- Per-finding streaming remains one tool call and one sink delivery at a time; a two-finding parity test verifies immediate, unchanged delivery.
- The existing host sink and live-diagnostics path remain intact. No aggregate findings array is introduced.

## Single source of truth

`normalizeStructuredOutputSchema` remains the one boundary that normalizes live Zod and sandbox JSON Schema inputs. Its Zod overload now preserves the concrete input schema type, while `defineTool` / `BaseTool` remains the one runtime validation path.

## Duplication and abstraction budget

The change removes a construction-path exception: the review tool no longer wires its Zod schema around the shared structured-output boundary. No adapter, wrapper layer, or review-specific validator was added. The overload owns one invariant only: a live Zod schema exits normalization with the same concrete type and object identity.

## Net elements (R6)

- Files: 3 modified, 0 added, 0 deleted.
- Exported symbols: 0 added, 0 removed; the existing `normalizeStructuredOutputSchema` export gains a type-preserving overload.
- Classes / interfaces / enums: 0 added, 0 removed.
- Net LoC: 43 insertions, 3 deletions = +40, of which 30 lines are the per-finding parity test.

## Consumer counts (R8)

n/a — no export or event/emit path is deleted or re-routed. The existing review sink has the same setter and the same single call site inside `ReportReviewIssueTool.execute`.

## Host impact

Extension: Agent Review continues publishing each accepted finding through the existing sink and live diagnostics; only schema construction is aligned.

Desktop: No behavior change; the default unavailable-host rejection remains unchanged.

CLI: No behavior change; the default unavailable-host rejection remains unchanged.

## Scheduled refactoring

None. A separate structured review summary/verdict remains outside #8834 and is not needed for this alignment.

## Validation

- `npm run format`
- all six typecheck targets (root, test kernel, extension, CLI, trace viewer, desktop)
- `npm run lint` (zero errors; one unrelated existing warning)
- `npm run compile:fast`
- `npm run check:dead-code-ratchet`
- `npm test` — 741 files passed, 1 skipped; 6,872 tests passed, 4 skipped

Closes #8834.
