### PR TITLE
refactor: catalog-driven settings command + CLI exit-controller extraction

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -14,7 +14,7 @@ import { render, type Instance as InkInstance } from 'ink';
 import PQueue from 'p-queue';
 
 import { StreamSnapshotStore } from '@transcript';
-import { platform, tryPlatform } from '@platform/platform';
+import { platform } from '@platform/platform';
 import { getVisibleAgents, loadAgents } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { detachSubagentsOnStop } from '@agent/runtime/detachSubagentsOnStop';
@@ -32,9 +32,7 @@ import { firstRunSetupAgentOverride } from '@cli/onboarding/setupContinuation';
 import { resolveChatDefaults } from '@cli/runtime/chatDefaults';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import {
-  handOffCliShutdownSignalHandlers,
   initInteractiveCliPlatform,
-  runCliPlatformShutdownSequence,
   setCliHelperModel,
 } from '@cli/runtime/initPlatform';
 import {
@@ -43,7 +41,7 @@ import {
   type CliNoAvailableModelsRecoveryOptions,
   type CliRunnableModelResolution,
 } from '@cli/runtime/modelAccess';
-import { writeTextStderr, writeTextStdout } from '@cli/runtime/logSinks';
+import { writeTextStderr } from '@cli/runtime/logSinks';
 import { readCliMultiAgentPresetName } from '@cli/runtime/multiAgentPresets';
 import { initializeInteractiveTranscriptSession } from '@cli/runtime/transcriptSession';
 import { cliSettingsStores } from '@cli/runtime/settingsStores';
@@ -63,7 +61,6 @@ import { isActivePhase } from '@shared/streams/streamStatus';
 import { getFirstRunDone } from '@shared/state/onboardingState';
 import type { AgentDelegationScope } from '@shared/schemas/agentRoster';
 import { escapeText } from '@shared/utils/xmlEscape';
-import { assertNever } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import {
@@ -104,23 +101,13 @@ import {
   patchSessionMeta,
   sessionMeta as sessionMetaSignal,
   streams as streamsSignal,
-  clearTransientNotice,
-  setTransientNotice,
 } from './state/cliState';
-import {
-  childStreamEntries as childStreamEntriesSignal,
-  parentStream as parentStreamSignal,
-} from './state/childExecutions';
+import { parentStream as parentStreamSignal } from './state/childExecutions';
 import {
   focusedChildFollowUpRoute,
   stoppedFocusedChildFollowUpMessage as focusedChildStoppedMessage,
   type FocusedChildFollowUpRoute,
 } from './state/focusedChildFollowUp';
-import {
-  collectResumeTargets,
-  collectResumeUsage,
-  formatResumeHint,
-} from './state/resumeHint';
 import { subscribeStreamLog } from './state/subscribeStreamLog';
 import { subscribeStreamStatus } from './state/subscribeStreamStatus';
 import { onStreamStatusChange } from './state/streamStatus';
@@ -131,12 +118,9 @@ import {
   appendLocalUserTranscript,
 } from './state/transcript';
 import {
-  cleanupTerminalModes,
   clearTerminalScrollback,
   installTerminalRestoreOnExit,
-  restoreTuiInputModes,
   setTerminalTitle,
-  supportsTerminalJobControl,
 } from './terminalCleanup';
 import {
   chatTuiCanInterruptActiveRun,
@@ -144,15 +128,16 @@ import {
   chatTuiCanStartRootRun,
   chatTuiCanStopVisibleRun,
   chatTuiIsResumableIdleOnExit,
-  chatTuiSigintAction,
   clearTuiSessionRunState,
   markChatTuiRunCompleted,
   markChatTuiRunPending,
   type TuiSession,
 } from './state/sessionRunState';
+import {
+  createSessionExitController,
+  type SessionExitController,
+} from './sessionExitController';
 import type { SkillActivation } from './forms/SkillsListForm';
-
-const EXIT_CONFIRMATION_TTL_MS = 800;
 
 export interface ChatResult {
   exitCode: number;
@@ -367,6 +352,14 @@ export async function runChat(
     activeApprovalPolicy = policy;
     patchSessionMeta({ approvalPolicy: policy });
   };
+  // Owns signal handling + exit teardown; assigned once Ink has mounted (below).
+  // The lazily-invoked closures here reach it through this binding, so they see
+  // the initialized controller by the time the user can trigger them. `let` is
+  // required — the controller can't be built until Ink is mounted, which is far
+  // below these forward references — so prefer-const's single-write heuristic
+  // misfires here.
+  // eslint-disable-next-line prefer-const
+  let exitController: SessionExitController;
   // The slash-command context is identical at every call site; build it once
   // lazily so the closures it captures (interruptActive, resetSessionForClear,
   // chatController.resume) are all defined before the first use.
@@ -379,7 +372,7 @@ export async function runChat(
     initialAgent: agent,
     initialModel: model,
     interruptActive,
-    requestInputExit,
+    requestInputExit: () => exitController.requestInputExit(),
     getApprovalPolicy,
     setApprovalPolicy,
     canSelectModel: canSelectCurrentModel,
@@ -827,8 +820,8 @@ export async function runChat(
       commandName={context.commandName}
       onInterruptActive={interruptActive}
       onStaticTranscriptChange={viewportController.repaintTranscript}
-      onCtrlC={() => handleSigint()}
-      onSuspend={() => handleSigtstp()}
+      onCtrlC={() => exitController.handleSigint()}
+      onSuspend={() => exitController.handleSigtstp()}
       onKillExecution={(executionId) => {
         clearApprovals();
         defaultSession().executions.kill(executionId, {
@@ -870,184 +863,30 @@ export async function runChat(
   );
   inkRef.current = ink;
 
-  // The notice is regenerable display state; replacing it must not change
-  // whether a second Ctrl-C confirms the exit already requested by the first.
-  let exitConfirmationExpiresAt = 0;
-  const terminalJobControlSupported = supportsTerminalJobControl();
-  // Set once a signal exit (exitNow) starts: its ink.unmount() resolves
-  // waitUntilExit and re-enters the post-waitUntilExit finally, so the finally
-  // guards on this to avoid draining persistence / printing the resume hint a
-  // second time.
-  let exiting = false;
-  const clearExitConfirmation = (): void => {
-    exitConfirmationExpiresAt = 0;
-    clearTransientNotice();
-  };
-  const removeProcessHandlers = (): void => {
-    process.off('SIGINT', handleSigint);
-    process.off('SIGTERM', handleSigterm);
-    process.off('SIGHUP', handleSighup);
-    if (terminalJobControlSupported) {
-      process.off('SIGTSTP', handleSigtstp);
-      process.off('SIGCONT', handleSigcont);
-    }
-  };
-  // Persist the reopen hint to native scrollback: the main session plus each
-  // resumable tool-use subagent, so any route can be continued by its own id.
-  // Read the streams slice before resetCliState() clears it.
-  const printResumeHintOnExit = (): void => {
-    if (!transcriptLifecycle.canResume || !session.executionId) return;
-    const streams = streamsSignal.get();
-    const hint = formatResumeHint(
-      collectResumeTargets({
-        childStreamEntries: childStreamEntriesSignal.get(),
-        rootExecutionId: session.executionId,
-        streams,
-      }),
-      collectResumeUsage(streams),
-      context.commandName,
-      {
-        cwd: context.cwd,
-        processCwd: process.cwd(),
-        approvalPolicy: activeApprovalPolicy,
-      },
-    );
-    if (hint) writeTextStdout(`\n${hint}`);
-  };
-  // Materialize buffered trace chunks, then drain the debounced StreamLog disk
-  // writes so the tail of the session isn't lost (SAVE_DEBOUNCE_MS window).
-  // Persistent flushes have bounded retries; an explicitly ephemeral session
-  // has no disk work to drain.
-  const drainPersistence = async (): Promise<void> => {
-    try {
-      await artifactSession.flushArtifacts();
-    } finally {
-      detachSnapshotPersistence();
-    }
-  };
-  // These TUI exit paths call process.exit() directly, so bin/texra.ts's
-  // `finally` (which runs platform shutdown) never fires. Run the same
-  // shutdown sequence the (suppressed) platform SIGINT/SIGTERM handlers
-  // would have run — lifecycle shutdown (notably UsageLogService.dispose(),
-  // which flushes any queued usage entries) then the NDJSON flush — so it
-  // still happens once before the process dies. runCliPlatformShutdownSequence
-  // is idempotent-safe to call again, so the normal return path can still
-  // rely on bin/texra.ts's own `finally`.
-  const runPlatformShutdown = (): Promise<void> =>
-    runCliPlatformShutdownSequence(tryPlatform()?.lifecycle);
-  const exitNow = (exitCode: number): void => {
-    exiting = true;
-    removeProcessHandlers();
-    clearExitConfirmation();
-    ink.unmount();
-    cleanupTerminalModes({ clearItermProgress });
-    // Print the resume hint last, after Ink has torn down and the terminal modes
-    // are restored, so it lands at the bottom of the transcript and stays in
-    // scrollback (copyable). cleanupTerminalModes no longer disturbs the screen.
-    printResumeHintOnExit();
-    // Synchronous signal exits (SIGINT double-tap / SIGTERM / SIGHUP) own the
-    // whole teardown here (the finally skips when `exiting`), so drain
-    // persistence and run platform shutdown before exiting. allSettled never
-    // rejects, so a flush failure can't become an unhandled rejection under
-    // --unhandled-rejections=strict.
-    void Promise.allSettled([
-      drainPersistence(),
-      runPlatformShutdown(),
-    ]).finally(() => process.exit(exitCode));
-  };
-  const armExit = (): void => {
-    exitConfirmationExpiresAt = Date.now() + EXIT_CONFIRMATION_TTL_MS;
-    setTransientNotice('Press Ctrl-C again to exit', {
-      kind: 'exit',
-      resumeId: transcriptLifecycle.canResume ? session.executionId : undefined,
-      ttlMs: EXIT_CONFIRMATION_TTL_MS,
-    });
-  };
-  const handleSigint = (): void => {
-    const sigintAction = chatTuiSigintAction({
-      exitArmed: Date.now() < exitConfirmationExpiresAt,
-      canStopActiveRun: canStopActiveRun(),
-      resumableIdle: isResumableIdle(),
-    });
-    switch (sigintAction) {
-      case 'clean-exit':
-        session.stopRequested = true;
-        interruptActive();
-        requestInputExit();
-        return;
-      case 'force-exit':
-        exitNow(CliExitCode.Interrupted);
-        return;
-      case 'preserve-exit':
-        // Resumable-idle: exit WITHOUT interrupting. This preserves the
-        // suspended tool-use flow record (executions/<id>/flow-*.json) so
-        // `texra resume` can continue it. Preserve the session's current
-        // terminal status too; an intentional idle exit after a successful turn
-        // should not report SIGINT/130.
-        //
-        // exitNow() calls process.exit, leaving the flow on disk.
-        exitNow(session.runExitCode);
-        return;
-      case 'interrupt-and-arm-exit':
-        session.stopRequested = true;
-        interruptActive();
-        armExit();
-        return;
-      default:
-        assertNever(sigintAction, 'Unhandled chat TUI SIGINT action');
-    }
-  };
-  // Only interrupt an actively-running turn; an idle/WAITING session is left
-  // suspended so its flow record survives for resume (see handleSigint).
-  const handleTermSignal = (exitCode: number): void => {
-    if (canStopActiveRun()) {
-      session.stopRequested = true;
-      interruptActive();
-    }
-    exitNow(exitCode);
-  };
-  const handleSigterm = (): void => handleTermSignal(143);
-  const handleSighup = (): void => handleTermSignal(129);
-  // Suspend/resume (Ctrl-Z / `kill -TSTP` / `fg`). Raw mode keeps the tty
-  // driver from ever turning ^Z into a signal, so App's unified useInput
-  // routes the parsed Ctrl-Z here explicitly; external SIGTSTP lands in the
-  // same handler. Restore the terminal for the shell before stopping, then
-  // stop with SIGSTOP — this handler replaced the default stop action, so
-  // re-raising SIGTSTP would just recurse.
-  const handleSigtstp = (): void => {
-    if (!terminalJobControlSupported) return;
-    cleanupTerminalModes({ clearItermProgress });
-    if (process.stdin.isTTY) process.stdin.setRawMode(false);
-    process.kill(process.pid, 'SIGSTOP');
-  };
-  // On resume the shell restores only the termios snapshot from suspend time
-  // (non-raw, since handleSigtstp dropped raw mode first); the emulator-side
-  // modes were popped outright. Re-arm both, then repaint from a known origin
-  // — the shell prompt and `fg` echo have polluted the screen, so the same
-  // clear-and-reprint path as a width change is the only safe redraw.
-  const handleSigcont = (): void => {
-    if (process.stdin.isTTY) process.stdin.setRawMode(true);
-    restoreTuiInputModes({ kittyKeyboard: terminalCaps.kittyKeyboard });
-    viewportController.repaintAfterTerminalResume();
-  };
-  function requestInputExit(): void {
-    removeProcessHandlers();
-    clearExitConfirmation();
-    ink.unmount();
-  }
-  // Ownership transfers right here, not any earlier: everything above this
-  // line (initInteractiveCliPlatform, onboarding, model resolution) ran with
-  // the platform's own handler still live, so a signal during that window
-  // still got a graceful shutdown. This removes it and makes the handlers
-  // installed below the sole owner.
-  handOffCliShutdownSignalHandlers();
-  process.on('SIGINT', handleSigint);
-  process.on('SIGTERM', handleSigterm);
-  process.on('SIGHUP', handleSighup);
-  if (terminalJobControlSupported) {
-    process.on('SIGTSTP', handleSigtstp);
-    process.on('SIGCONT', handleSigcont);
-  }
+  exitController = createSessionExitController({
+    ink,
+    session,
+    commandName: context.commandName,
+    cwd: context.cwd,
+    canResume: transcriptLifecycle.canResume,
+    clearItermProgress,
+    kittyKeyboardEnabled: terminalCaps.kittyKeyboard,
+    disposers,
+    followUpQueue,
+    getApprovalPolicy,
+    flushArtifacts: () => artifactSession.flushArtifacts(),
+    detachSnapshotPersistence,
+    repaintAfterTerminalResume: () =>
+      viewportController.repaintAfterTerminalResume(),
+    canStopActiveRun,
+    isResumableIdle,
+    interruptActive,
+  });
+  // Transfer signal ownership from the platform handler and arm this session's
+  // handlers — not any earlier: everything above (initInteractiveCliPlatform,
+  // onboarding, model resolution) ran with the platform's own handler still
+  // live, so a signal during that window still got a graceful shutdown.
+  exitController.install();
 
   // Interactive resume: kick off the continued tool-use run now that Ink is
   // mounted (so the rehydrated transcript + streamed continuation render) and
@@ -1076,46 +915,7 @@ export async function runChat(
   try {
     await ink.waitUntilExit();
   } finally {
-    // A signal exit (SIGINT/SIGTERM/SIGHUP) runs exitNow(), which does the full
-    // teardown and process.exit()s itself; its ink.unmount() resolves
-    // waitUntilExit and re-enters this finally. Skip the entire graceful
-    // teardown in that case — re-running it would duplicate the drain / hint /
-    // cleanup, and the resumableIdle process.exit() below would race exitNow's
-    // async exit, dropping the flush and the signal exit code.
-    if (!exiting) {
-      removeProcessHandlers();
-      clearExitConfirmation();
-      for (const dispose of disposers) dispose();
-      await followUpQueue.onIdle();
-      // A suspended (idle/WAITING) root session is resumable: its flow record
-      // survives only if we DON'T interrupt the flow (interrupt clears it). See
-      // chatTuiIsResumableIdleOnExit for the live-flow check that distinguishes
-      // this state from a resume slot that is still rehydrating.
-      const resumableIdle = isResumableIdle();
-      if (session.runPromise && !session.runCompleted && !resumableIdle) {
-        session.stopRequested = true;
-        interruptActive();
-        // Only await a run we actually interrupted/finished. A resumableIdle run
-        // is parked at the WAIT node and its runPromise NEVER resolves, so
-        // awaiting it would hang the process here.
-        await session.runPromise;
-      }
-      await drainPersistence();
-      cleanupTerminalModes({ clearItermProgress });
-      // Print the resume hint after the terminal modes are restored, but before
-      // resetCliState() clears the stream tree the hint is built from.
-      printResumeHintOnExit();
-      resetCliState();
-      if (resumableIdle) {
-        // The dangling runPromise keeps the event loop alive, so a normal return
-        // would never let the process exit. Force-exit here, AFTER persistence
-        // is flushed and the resume hint is printed, preserving the suspended
-        // flow record on disk for `texra resume`. Run platform shutdown first
-        // so queued usage logs flush — bin/texra.ts's finally won't on exit().
-        await runPlatformShutdown();
-        process.exit(session.runExitCode);
-      }
-    }
+    await exitController.gracefulTeardown();
   }
   return { exitCode: session.runExitCode };
 }

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -133,10 +133,7 @@ import {
   markChatTuiRunPending,
   type TuiSession,
 } from './state/sessionRunState';
-import {
-  createSessionExitController,
-  type SessionExitController,
-} from './sessionExitController';
+import { createSessionExitController } from './sessionExitController';
 import type { SkillActivation } from './forms/SkillsListForm';
 
 export interface ChatResult {
@@ -352,14 +349,6 @@ export async function runChat(
     activeApprovalPolicy = policy;
     patchSessionMeta({ approvalPolicy: policy });
   };
-  // Owns signal handling + exit teardown; assigned once Ink has mounted (below).
-  // The lazily-invoked closures here reach it through this binding, so they see
-  // the initialized controller by the time the user can trigger them. `let` is
-  // required — the controller can't be built until Ink is mounted, which is far
-  // below these forward references — so prefer-const's single-write heuristic
-  // misfires here.
-  // eslint-disable-next-line prefer-const
-  let exitController: SessionExitController;
   // The slash-command context is identical at every call site; build it once
   // lazily so the closures it captures (interruptActive, resetSessionForClear,
   // chatController.resume) are all defined before the first use.
@@ -863,7 +852,7 @@ export async function runChat(
   );
   inkRef.current = ink;
 
-  exitController = createSessionExitController({
+  const exitController = createSessionExitController({
     ink,
     session,
     commandName: context.commandName,

--- a/packages/cli/src/chat/tui/sessionExitController.ts
+++ b/packages/cli/src/chat/tui/sessionExitController.ts
@@ -54,7 +54,7 @@ const EXIT_CONFIRMATION_TTL_MS = 800;
  * is a module-level import, so only these session-scoped bindings are threaded
  * through.
  */
-export interface SessionExitControllerContext {
+interface SessionExitControllerContext {
   /** The mounted Ink instance whose `unmount()` drives the exit. */
   readonly ink: InkInstance;
   /** Mutable run-state record shared with the rest of the session. */
@@ -90,7 +90,7 @@ export interface SessionExitControllerContext {
 }
 
 /** The exit-subsystem handles `runChat` wires into Ink props and its `finally`. */
-export interface SessionExitController {
+interface SessionExitController {
   /** SIGINT / Ctrl-C handler (double-tap-to-exit, or clean/force/preserve exit). */
   readonly handleSigint: () => void;
   /** SIGTSTP / Ctrl-Z handler (restore terminal, then SIGSTOP). */

--- a/packages/cli/src/chat/tui/sessionExitController.ts
+++ b/packages/cli/src/chat/tui/sessionExitController.ts
@@ -1,0 +1,344 @@
+// Signal handling, exit choreography, and terminal-teardown for the chat TUI.
+//
+// Extracted from runChatTui's `runChat` so the exit subsystem — the SIGINT/
+// SIGTERM/SIGHUP/SIGTSTP/SIGCONT handlers, the double-tap-to-exit confirmation,
+// and the two teardown paths (a synchronous signal exit vs the graceful
+// waitUntilExit teardown) — lives as one cohesive unit instead of ~14 closures
+// co-captured in the 870-line entry function. This is pure code motion: every
+// closure body is unchanged; the only difference is that the runtime session
+// values the closures used to capture directly now arrive via an explicit
+// {@link SessionExitControllerContext}.
+//
+// Teardown ownership (unchanged from the inline version): a signal exit runs
+// `exitNow()`, which does the full teardown and `process.exit()`s itself; its
+// `ink.unmount()` resolves `waitUntilExit` and re-enters `gracefulTeardown()`,
+// which no-ops via the `exiting` guard so the drain / hint / cleanup never run
+// twice.
+
+import { tryPlatform } from '@platform/platform';
+import { CliExitCode } from '@cli/runtime/exitCodes';
+import {
+  handOffCliShutdownSignalHandlers,
+  runCliPlatformShutdownSequence,
+} from '@cli/runtime/initPlatform';
+import { writeTextStdout } from '@cli/runtime/logSinks';
+import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
+import { assertNever } from '@utils/core';
+
+import {
+  resetCliState,
+  clearTransientNotice,
+  setTransientNotice,
+  streams as streamsSignal,
+} from './state/cliState';
+import { childStreamEntries as childStreamEntriesSignal } from './state/childExecutions';
+import {
+  collectResumeTargets,
+  collectResumeUsage,
+  formatResumeHint,
+} from './state/resumeHint';
+import { chatTuiSigintAction, type TuiSession } from './state/sessionRunState';
+import {
+  cleanupTerminalModes,
+  restoreTuiInputModes,
+  supportsTerminalJobControl,
+} from './terminalCleanup';
+import type PQueue from 'p-queue';
+import type { Instance as InkInstance } from 'ink';
+
+const EXIT_CONFIRMATION_TTL_MS = 800;
+
+/**
+ * Runtime session values the exit subsystem reads. Everything else it needs
+ * (signals, resume-hint formatters, terminal-mode helpers, platform shutdown)
+ * is a module-level import, so only these session-scoped bindings are threaded
+ * through.
+ */
+export interface SessionExitControllerContext {
+  /** The mounted Ink instance whose `unmount()` drives the exit. */
+  readonly ink: InkInstance;
+  /** Mutable run-state record shared with the rest of the session. */
+  readonly session: TuiSession;
+  /** `context.commandName` — names the resume command in the exit hint. */
+  readonly commandName: string;
+  /** `context.cwd` — the launch directory shown in the resume hint. */
+  readonly cwd: string;
+  /** Whether this session persists a resumable transcript. */
+  readonly canResume: boolean;
+  /** Clear iTerm2 progress on teardown (mirrors the render-time flag). */
+  readonly clearItermProgress: boolean;
+  /** Re-arm the Kitty keyboard protocol on SIGCONT when the terminal supports it. */
+  readonly kittyKeyboardEnabled: boolean;
+  /** Session-scoped subscriptions torn down on graceful exit. */
+  readonly disposers: ReadonlyArray<() => void>;
+  /** Follow-up delivery queue drained before a graceful exit returns. */
+  readonly followUpQueue: PQueue;
+  /** Reads the live approval policy for the resume hint. */
+  readonly getApprovalPolicy: () => CliApprovalPolicy;
+  /** Materialize buffered trace chunks + drain debounced StreamLog writes. */
+  readonly flushArtifacts: () => Promise<void>;
+  /** Detach the snapshot-persistence event/flusher wiring. */
+  readonly detachSnapshotPersistence: () => void;
+  /** Repaint the TUI from a known origin after a `fg`/SIGCONT resume. */
+  readonly repaintAfterTerminalResume: () => void;
+  /** Whether an actively-running turn can be stopped (vs idle/WAITING). */
+  readonly canStopActiveRun: () => boolean;
+  /** Whether the session is a resumable-idle exit (preserve the flow record). */
+  readonly isResumableIdle: () => boolean;
+  /** Stop the active run (clears the flow record). */
+  readonly interruptActive: () => void;
+}
+
+/** The exit-subsystem handles `runChat` wires into Ink props and its `finally`. */
+export interface SessionExitController {
+  /** SIGINT / Ctrl-C handler (double-tap-to-exit, or clean/force/preserve exit). */
+  readonly handleSigint: () => void;
+  /** SIGTSTP / Ctrl-Z handler (restore terminal, then SIGSTOP). */
+  readonly handleSigtstp: () => void;
+  /** Break the current input wait and unmount without a full teardown. */
+  readonly requestInputExit: () => void;
+  /** Hand off the platform signal owner and install this controller's handlers. */
+  readonly install: () => void;
+  /** The post-`waitUntilExit` graceful teardown (no-ops after a signal exit). */
+  readonly gracefulTeardown: () => Promise<void>;
+  /** Whether a signal exit has already begun (owns its own teardown). */
+  readonly isExiting: () => boolean;
+}
+
+export function createSessionExitController(
+  ctx: SessionExitControllerContext,
+): SessionExitController {
+  const { ink, session } = ctx;
+
+  // The notice is regenerable display state; replacing it must not change
+  // whether a second Ctrl-C confirms the exit already requested by the first.
+  let exitConfirmationExpiresAt = 0;
+  const terminalJobControlSupported = supportsTerminalJobControl();
+  // Set once a signal exit (exitNow) starts: its ink.unmount() resolves
+  // waitUntilExit and re-enters gracefulTeardown, which guards on this to avoid
+  // draining persistence / printing the resume hint a second time.
+  let exiting = false;
+  const clearExitConfirmation = (): void => {
+    exitConfirmationExpiresAt = 0;
+    clearTransientNotice();
+  };
+  const removeProcessHandlers = (): void => {
+    process.off('SIGINT', handleSigint);
+    process.off('SIGTERM', handleSigterm);
+    process.off('SIGHUP', handleSighup);
+    if (terminalJobControlSupported) {
+      process.off('SIGTSTP', handleSigtstp);
+      process.off('SIGCONT', handleSigcont);
+    }
+  };
+  // Persist the reopen hint to native scrollback: the main session plus each
+  // resumable tool-use subagent, so any route can be continued by its own id.
+  // Read the streams slice before resetCliState() clears it.
+  const printResumeHintOnExit = (): void => {
+    if (!ctx.canResume || !session.executionId) return;
+    const streams = streamsSignal.get();
+    const hint = formatResumeHint(
+      collectResumeTargets({
+        childStreamEntries: childStreamEntriesSignal.get(),
+        rootExecutionId: session.executionId,
+        streams,
+      }),
+      collectResumeUsage(streams),
+      ctx.commandName,
+      {
+        cwd: ctx.cwd,
+        processCwd: process.cwd(),
+        approvalPolicy: ctx.getApprovalPolicy(),
+      },
+    );
+    if (hint) writeTextStdout(`\n${hint}`);
+  };
+  // Materialize buffered trace chunks, then drain the debounced StreamLog disk
+  // writes so the tail of the session isn't lost (SAVE_DEBOUNCE_MS window).
+  // Persistent flushes have bounded retries; an explicitly ephemeral session
+  // has no disk work to drain.
+  const drainPersistence = async (): Promise<void> => {
+    try {
+      await ctx.flushArtifacts();
+    } finally {
+      ctx.detachSnapshotPersistence();
+    }
+  };
+  // These TUI exit paths call process.exit() directly, so bin/texra.ts's
+  // `finally` (which runs platform shutdown) never fires. Run the same
+  // shutdown sequence the (suppressed) platform SIGINT/SIGTERM handlers
+  // would have run — lifecycle shutdown (notably UsageLogService.dispose(),
+  // which flushes any queued usage entries) then the NDJSON flush — so it
+  // still happens once before the process dies. runCliPlatformShutdownSequence
+  // is idempotent-safe to call again, so the normal return path can still
+  // rely on bin/texra.ts's own `finally`.
+  const runPlatformShutdown = (): Promise<void> =>
+    runCliPlatformShutdownSequence(tryPlatform()?.lifecycle);
+  const exitNow = (exitCode: number): void => {
+    exiting = true;
+    removeProcessHandlers();
+    clearExitConfirmation();
+    ink.unmount();
+    cleanupTerminalModes({ clearItermProgress: ctx.clearItermProgress });
+    // Print the resume hint last, after Ink has torn down and the terminal modes
+    // are restored, so it lands at the bottom of the transcript and stays in
+    // scrollback (copyable). cleanupTerminalModes no longer disturbs the screen.
+    printResumeHintOnExit();
+    // Synchronous signal exits (SIGINT double-tap / SIGTERM / SIGHUP) own the
+    // whole teardown here (gracefulTeardown skips when `exiting`), so drain
+    // persistence and run platform shutdown before exiting. allSettled never
+    // rejects, so a flush failure can't become an unhandled rejection under
+    // --unhandled-rejections=strict.
+    void Promise.allSettled([
+      drainPersistence(),
+      runPlatformShutdown(),
+    ]).finally(() => process.exit(exitCode));
+  };
+  const armExit = (): void => {
+    exitConfirmationExpiresAt = Date.now() + EXIT_CONFIRMATION_TTL_MS;
+    setTransientNotice('Press Ctrl-C again to exit', {
+      kind: 'exit',
+      resumeId: ctx.canResume ? session.executionId : undefined,
+      ttlMs: EXIT_CONFIRMATION_TTL_MS,
+    });
+  };
+  const handleSigint = (): void => {
+    const sigintAction = chatTuiSigintAction({
+      exitArmed: Date.now() < exitConfirmationExpiresAt,
+      canStopActiveRun: ctx.canStopActiveRun(),
+      resumableIdle: ctx.isResumableIdle(),
+    });
+    switch (sigintAction) {
+      case 'clean-exit':
+        session.stopRequested = true;
+        ctx.interruptActive();
+        requestInputExit();
+        return;
+      case 'force-exit':
+        exitNow(CliExitCode.Interrupted);
+        return;
+      case 'preserve-exit':
+        // Resumable-idle: exit WITHOUT interrupting. This preserves the
+        // suspended tool-use flow record (executions/<id>/flow-*.json) so
+        // `texra resume` can continue it. Preserve the session's current
+        // terminal status too; an intentional idle exit after a successful turn
+        // should not report SIGINT/130.
+        //
+        // exitNow() calls process.exit, leaving the flow on disk.
+        exitNow(session.runExitCode);
+        return;
+      case 'interrupt-and-arm-exit':
+        session.stopRequested = true;
+        ctx.interruptActive();
+        armExit();
+        return;
+      default:
+        assertNever(sigintAction, 'Unhandled chat TUI SIGINT action');
+    }
+  };
+  // Only interrupt an actively-running turn; an idle/WAITING session is left
+  // suspended so its flow record survives for resume (see handleSigint).
+  const handleTermSignal = (exitCode: number): void => {
+    if (ctx.canStopActiveRun()) {
+      session.stopRequested = true;
+      ctx.interruptActive();
+    }
+    exitNow(exitCode);
+  };
+  const handleSigterm = (): void => handleTermSignal(143);
+  const handleSighup = (): void => handleTermSignal(129);
+  // Suspend/resume (Ctrl-Z / `kill -TSTP` / `fg`). Raw mode keeps the tty
+  // driver from ever turning ^Z into a signal, so App's unified useInput
+  // routes the parsed Ctrl-Z here explicitly; external SIGTSTP lands in the
+  // same handler. Restore the terminal for the shell before stopping, then
+  // stop with SIGSTOP — this handler replaced the default stop action, so
+  // re-raising SIGTSTP would just recurse.
+  const handleSigtstp = (): void => {
+    if (!terminalJobControlSupported) return;
+    cleanupTerminalModes({ clearItermProgress: ctx.clearItermProgress });
+    if (process.stdin.isTTY) process.stdin.setRawMode(false);
+    process.kill(process.pid, 'SIGSTOP');
+  };
+  // On resume the shell restores only the termios snapshot from suspend time
+  // (non-raw, since handleSigtstp dropped raw mode first); the emulator-side
+  // modes were popped outright. Re-arm both, then repaint from a known origin
+  // — the shell prompt and `fg` echo have polluted the screen, so the same
+  // clear-and-reprint path as a width change is the only safe redraw.
+  const handleSigcont = (): void => {
+    if (process.stdin.isTTY) process.stdin.setRawMode(true);
+    restoreTuiInputModes({ kittyKeyboard: ctx.kittyKeyboardEnabled });
+    ctx.repaintAfterTerminalResume();
+  };
+  function requestInputExit(): void {
+    removeProcessHandlers();
+    clearExitConfirmation();
+    ink.unmount();
+  }
+
+  const install = (): void => {
+    // Ownership transfers right here, not any earlier: everything before this
+    // (initInteractiveCliPlatform, onboarding, model resolution) ran with the
+    // platform's own handler still live, so a signal during that window still
+    // got a graceful shutdown. This removes it and makes the handlers installed
+    // below the sole owner.
+    handOffCliShutdownSignalHandlers();
+    process.on('SIGINT', handleSigint);
+    process.on('SIGTERM', handleSigterm);
+    process.on('SIGHUP', handleSighup);
+    if (terminalJobControlSupported) {
+      process.on('SIGTSTP', handleSigtstp);
+      process.on('SIGCONT', handleSigcont);
+    }
+  };
+
+  const gracefulTeardown = async (): Promise<void> => {
+    // A signal exit (SIGINT/SIGTERM/SIGHUP) runs exitNow(), which does the full
+    // teardown and process.exit()s itself; its ink.unmount() resolves
+    // waitUntilExit and re-enters here. Skip the entire graceful teardown in
+    // that case — re-running it would duplicate the drain / hint / cleanup, and
+    // the resumableIdle process.exit() below would race exitNow's async exit,
+    // dropping the flush and the signal exit code.
+    if (exiting) return;
+    removeProcessHandlers();
+    clearExitConfirmation();
+    for (const dispose of ctx.disposers) dispose();
+    await ctx.followUpQueue.onIdle();
+    // A suspended (idle/WAITING) root session is resumable: its flow record
+    // survives only if we DON'T interrupt the flow (interrupt clears it). See
+    // chatTuiIsResumableIdleOnExit for the live-flow check that distinguishes
+    // this state from a resume slot that is still rehydrating.
+    const resumableIdle = ctx.isResumableIdle();
+    if (session.runPromise && !session.runCompleted && !resumableIdle) {
+      session.stopRequested = true;
+      ctx.interruptActive();
+      // Only await a run we actually interrupted/finished. A resumableIdle run
+      // is parked at the WAIT node and its runPromise NEVER resolves, so
+      // awaiting it would hang the process here.
+      await session.runPromise;
+    }
+    await drainPersistence();
+    cleanupTerminalModes({ clearItermProgress: ctx.clearItermProgress });
+    // Print the resume hint after the terminal modes are restored, but before
+    // resetCliState() clears the stream tree the hint is built from.
+    printResumeHintOnExit();
+    resetCliState();
+    if (resumableIdle) {
+      // The dangling runPromise keeps the event loop alive, so a normal return
+      // would never let the process exit. Force-exit here, AFTER persistence is
+      // flushed and the resume hint is printed, preserving the suspended flow
+      // record on disk for `texra resume`. Run platform shutdown first so queued
+      // usage logs flush — bin/texra.ts's finally won't on exit().
+      await runPlatformShutdown();
+      process.exit(session.runExitCode);
+    }
+  };
+
+  return {
+    handleSigint,
+    handleSigtstp,
+    requestInputExit,
+    install,
+    gracefulTeardown,
+    isExiting: () => exiting,
+  };
+}

--- a/packages/cli/src/chat/tui/sessionExitController.ts
+++ b/packages/cli/src/chat/tui/sessionExitController.ts
@@ -101,8 +101,6 @@ export interface SessionExitController {
   readonly install: () => void;
   /** The post-`waitUntilExit` graceful teardown (no-ops after a signal exit). */
   readonly gracefulTeardown: () => Promise<void>;
-  /** Whether a signal exit has already begun (owns its own teardown). */
-  readonly isExiting: () => boolean;
 }
 
 export function createSessionExitController(
@@ -339,6 +337,5 @@ export function createSessionExitController(
     requestInputExit,
     install,
     gracefulTeardown,
-    isExiting: () => exiting,
   };
 }

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -7,6 +7,7 @@ import {
 import { SettingsViewHost } from '@controllers/settingsView/SettingsViewHost';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
+import { stateSettingByKey } from '@shared/schemas/stateSettings';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import {
   dispatchSettingsViewInbound,
@@ -259,6 +260,28 @@ export function createDesktopSettingsIpc(
     postApprovalSettings();
   }
 
+  /**
+   * Generic write path for scalar `STATE_SETTINGS` rows (git-author + external
+   * coding-agent controls). Validates against the catalog entry's own schema —
+   * ignoring an unknown key or a value the schema rejects — then delegates to the
+   * family updater, which owns the persist + rebroadcast. Routing is by catalog
+   * `category`, mirroring the extension host.
+   */
+  async function updateStateSetting(
+    key: string,
+    value: unknown,
+  ): Promise<void> {
+    const entry = stateSettingByKey(key);
+    if (!entry) return;
+    const parsed = entry.schema.safeParse(value);
+    if (!parsed.success) return;
+    if (entry.category === 'git') {
+      await updateGitAuthorSetting(key as WorkspaceStateKey, parsed.data);
+    } else {
+      await updateAgentSetting(key as WorkspaceStateKey, parsed.data as string);
+    }
+  }
+
   async function updateBashApprovalEnabled(enabled: boolean): Promise<void> {
     await setBashApprovalEnabled(
       { workspaceState, globalState, config: options.config },
@@ -283,10 +306,6 @@ export function createDesktopSettingsIpc(
   applyCurrentGitAuthorSettings();
 
   const StateKeys = WorkspaceStateKey;
-  const setGitAuthor = (key: WorkspaceStateKey, value: boolean | string) =>
-    updateGitAuthorSetting(key, value);
-  const setAgent = (key: WorkspaceStateKey, value: string) =>
-    updateAgentSetting(key, value);
 
   const settingsActions: SettingsViewCommandActions = {
     // WEBVIEW_READY is intercepted in handleMessage below, before reaching
@@ -334,14 +353,6 @@ export function createDesktopSettingsIpc(
         ),
     },
     agentSelection: options.agentSettingsController.actions,
-    gitAuthor: {
-      setMarkCommits: (enabled) =>
-        setGitAuthor(StateKeys.GIT_MARK_COMMITS, enabled),
-      setName: (name) => setGitAuthor(StateKeys.GIT_AUTHOR_NAME, name),
-      setEmail: (email) => setGitAuthor(StateKeys.GIT_AUTHOR_EMAIL, email),
-      setWorktreeSupport: (enabled) =>
-        setGitAuthor(StateKeys.GIT_WORKTREE_SUPPORT, enabled),
-    },
     githubSubscriptions: {
       getTokenStatus: unsupported(
         'GitHub PR subscriptions are not available in the desktop app yet.',
@@ -368,18 +379,9 @@ export function createDesktopSettingsIpc(
     chatGpt: options.credentialSettingsController.chatGptActions,
     approval: {
       setBashApprovalEnabled: (enabled) => updateBashApprovalEnabled(enabled),
-      setCodexSandboxMode: (mode) =>
-        setAgent(StateKeys.CODEX_SANDBOX_MODE, mode),
-      setCodexReasoningEffort: (effort) =>
-        setAgent(StateKeys.CODEX_REASONING_EFFORT, effort),
-      setCodexApprovalPolicy: (policy) =>
-        setAgent(StateKeys.CODEX_APPROVAL_POLICY, policy),
-      setClaudeAgentModel: (model) =>
-        setAgent(StateKeys.CLAUDE_AGENT_MODEL, model),
-      setClaudeAgentPermissionMode: (mode) =>
-        setAgent(StateKeys.CLAUDE_AGENT_PERMISSION_MODE, mode),
-      setClaudeAgentEffort: (effort) =>
-        setAgent(StateKeys.CLAUDE_AGENT_EFFORT, effort),
+    },
+    stateSettings: {
+      update: (key, value) => updateStateSetting(key, value),
     },
     tools: options.toolingSettingsController.toolsActions,
     latex: options.toolingSettingsController.latexActions,

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -7,7 +7,7 @@ import {
 import { SettingsViewHost } from '@controllers/settingsView/SettingsViewHost';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
-import { stateSettingByKey } from '@shared/schemas/stateSettings';
+import { resolveStateSettingWrite } from '@shared/settingsView/handlers/stateSettingWrite';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import {
   dispatchSettingsViewInbound,
@@ -262,29 +262,20 @@ export function createDesktopSettingsIpc(
 
   /**
    * Generic write path for scalar `STATE_SETTINGS` rows (git-author + external
-   * coding-agent controls). Validates against the catalog entry's own schema —
-   * ignoring an unknown key or a value the schema rejects — then delegates to the
-   * family updater, which owns the persist + rebroadcast. Routing is by catalog
-   * `category`, mirroring the extension host.
+   * coding-agent controls). The shared {@link resolveStateSettingWrite} owns the
+   * value validation + family classification (shared with the extension host);
+   * this host only dispatches the resolved family to its updater.
    */
   async function updateStateSetting(
     key: string,
     value: unknown,
   ): Promise<void> {
-    // A value-less message is a no-op: no clear-to-default semantics, and the
-    // catalog schemas `.prefault()`, so parsing `undefined` would silently reset
-    // the setting to its default.
-    if (value === undefined) return;
-    const entry = stateSettingByKey(key);
-    if (!entry) return;
-    const parsed = entry.schema.safeParse(value);
-    if (!parsed.success) return;
-    // Only the two families this settings view owns are routable; any other
-    // catalog category is ignored rather than mis-persisted via the agent path.
-    if (entry.category === 'git') {
-      await updateGitAuthorSetting(key as WorkspaceStateKey, parsed.data);
-    } else if (entry.category === 'ai-agents') {
-      await updateAgentSetting(key as WorkspaceStateKey, parsed.data as string);
+    const write = resolveStateSettingWrite(key, value);
+    if (!write) return;
+    if (write.family === 'git') {
+      await updateGitAuthorSetting(write.key, write.value);
+    } else {
+      await updateAgentSetting(write.key, write.value);
     }
   }
 

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -271,13 +271,19 @@ export function createDesktopSettingsIpc(
     key: string,
     value: unknown,
   ): Promise<void> {
+    // A value-less message is a no-op: no clear-to-default semantics, and the
+    // catalog schemas `.prefault()`, so parsing `undefined` would silently reset
+    // the setting to its default.
+    if (value === undefined) return;
     const entry = stateSettingByKey(key);
     if (!entry) return;
     const parsed = entry.schema.safeParse(value);
     if (!parsed.success) return;
+    // Only the two families this settings view owns are routable; any other
+    // catalog category is ignored rather than mis-persisted via the agent path.
     if (entry.category === 'git') {
       await updateGitAuthorSetting(key as WorkspaceStateKey, parsed.data);
-    } else {
+    } else if (entry.category === 'ai-agents') {
       await updateAgentSetting(key as WorkspaceStateKey, parsed.data as string);
     }
   }

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -64,6 +64,7 @@ import {
 } from '@model/apiProviders';
 import { revealProgressStream } from '@progressView/progressNavigation';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
+import { stateSettingByKey } from '@shared/schemas/stateSettings';
 import {
   dispatchSettingsViewInbound,
   type SettingsViewInboundHandlerRegistry,
@@ -353,10 +354,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
 
   private createHandlerRegistry(): SettingsViewInboundHandlerRegistry {
     const StateKeys = WorkspaceStateKey;
-    const setGitAuthor = (key: WorkspaceStateKey, value: boolean | string) =>
-      this.updateGitAuthorSetting(key, value);
-    const setAgent = (key: WorkspaceStateKey, value: string) =>
-      this.updateAgentSetting(key, value);
 
     const actions: SettingsViewCommandActions = {
       lifecycle: {
@@ -526,14 +523,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
             presetId,
           }),
       },
-      gitAuthor: {
-        setMarkCommits: (enabled) =>
-          setGitAuthor(StateKeys.GIT_MARK_COMMITS, enabled),
-        setName: (name) => setGitAuthor(StateKeys.GIT_AUTHOR_NAME, name),
-        setEmail: (email) => setGitAuthor(StateKeys.GIT_AUTHOR_EMAIL, email),
-        setWorktreeSupport: (enabled) =>
-          setGitAuthor(StateKeys.GIT_WORKTREE_SUPPORT, enabled),
-      },
       githubSubscriptions: {
         getTokenStatus: () =>
           this.withActiveWebview((w) =>
@@ -561,18 +550,9 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       approval: {
         setBashApprovalEnabled: (enabled) =>
           this.handleSetApprovalEnabled(enabled),
-        setCodexSandboxMode: (mode) =>
-          setAgent(StateKeys.CODEX_SANDBOX_MODE, mode),
-        setCodexReasoningEffort: (effort) =>
-          setAgent(StateKeys.CODEX_REASONING_EFFORT, effort),
-        setCodexApprovalPolicy: (policy) =>
-          setAgent(StateKeys.CODEX_APPROVAL_POLICY, policy),
-        setClaudeAgentModel: (model) =>
-          setAgent(StateKeys.CLAUDE_AGENT_MODEL, model),
-        setClaudeAgentPermissionMode: (mode) =>
-          setAgent(StateKeys.CLAUDE_AGENT_PERMISSION_MODE, mode),
-        setClaudeAgentEffort: (effort) =>
-          setAgent(StateKeys.CLAUDE_AGENT_EFFORT, effort),
+      },
+      stateSettings: {
+        update: (key, value) => this.updateStateSetting(key, value),
       },
       tools: {
         openInstallUrl: (url) => this.openExternalUrl(url),
@@ -875,6 +855,29 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       value,
     );
     await this.withActiveWebview((w) => this.sendApprovalSettings(w));
+  }
+
+  /**
+   * Generic write path for scalar `STATE_SETTINGS` rows (git-author + external
+   * coding-agent controls). Validates the value against the catalog entry's own
+   * schema — silently ignoring an unknown key or a value the schema rejects, so
+   * a malformed webview payload can never persist junk — then delegates to the
+   * family updater, which owns the persist + rebroadcast (and, for git, the
+   * `applyGitAuthorConfig()` side effect). Routing is by catalog `category`.
+   */
+  private async updateStateSetting(key: string, value: unknown): Promise<void> {
+    const entry = stateSettingByKey(key);
+    if (!entry) return;
+    const parsed = entry.schema.safeParse(value);
+    if (!parsed.success) return;
+    if (entry.category === 'git') {
+      await this.updateGitAuthorSetting(key as WorkspaceStateKey, parsed.data);
+    } else {
+      await this.updateAgentSetting(
+        key as WorkspaceStateKey,
+        parsed.data as string,
+      );
+    }
   }
 
   // ============================================================

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -64,7 +64,7 @@ import {
 } from '@model/apiProviders';
 import { revealProgressStream } from '@progressView/progressNavigation';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
-import { stateSettingByKey } from '@shared/schemas/stateSettings';
+import { resolveStateSettingWrite } from '@shared/settingsView/handlers/stateSettingWrite';
 import {
   dispatchSettingsViewInbound,
   type SettingsViewInboundHandlerRegistry,
@@ -859,32 +859,19 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
 
   /**
    * Generic write path for scalar `STATE_SETTINGS` rows (git-author + external
-   * coding-agent controls). Validates the value against the catalog entry's own
-   * schema — silently ignoring an unknown key or a value the schema rejects, so
-   * a malformed webview payload can never persist junk — then delegates to the
-   * family updater, which owns the persist + rebroadcast (and, for git, the
-   * `applyGitAuthorConfig()` side effect). Routing is by catalog `category`.
+   * coding-agent controls). The shared {@link resolveStateSettingWrite} owns the
+   * value validation + family classification (so it can't drift from the desktop
+   * host); this host only dispatches the resolved family to its updater, which
+   * owns the persist + rebroadcast (and, for git, the `applyGitAuthorConfig()`
+   * side effect).
    */
   private async updateStateSetting(key: string, value: unknown): Promise<void> {
-    // A value-less message is a no-op. This command has no clear-to-default
-    // semantics (unlike SET_LATEX_CONFIG_VALUE), and the catalog schemas use
-    // `.prefault()`, so parsing `undefined` would resolve to the default and
-    // silently reset the setting — reject it up front instead.
-    if (value === undefined) return;
-    const entry = stateSettingByKey(key);
-    if (!entry) return;
-    const parsed = entry.schema.safeParse(value);
-    if (!parsed.success) return;
-    // Only the two families this settings view owns are routable; any other
-    // catalog category (workflow, model, tools, …) is ignored rather than
-    // mis-persisted through the agent path or refreshing the wrong UI.
-    if (entry.category === 'git') {
-      await this.updateGitAuthorSetting(key as WorkspaceStateKey, parsed.data);
-    } else if (entry.category === 'ai-agents') {
-      await this.updateAgentSetting(
-        key as WorkspaceStateKey,
-        parsed.data as string,
-      );
+    const write = resolveStateSettingWrite(key, value);
+    if (!write) return;
+    if (write.family === 'git') {
+      await this.updateGitAuthorSetting(write.key, write.value);
+    } else {
+      await this.updateAgentSetting(write.key, write.value);
     }
   }
 

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -866,13 +866,21 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
    * `applyGitAuthorConfig()` side effect). Routing is by catalog `category`.
    */
   private async updateStateSetting(key: string, value: unknown): Promise<void> {
+    // A value-less message is a no-op. This command has no clear-to-default
+    // semantics (unlike SET_LATEX_CONFIG_VALUE), and the catalog schemas use
+    // `.prefault()`, so parsing `undefined` would resolve to the default and
+    // silently reset the setting — reject it up front instead.
+    if (value === undefined) return;
     const entry = stateSettingByKey(key);
     if (!entry) return;
     const parsed = entry.schema.safeParse(value);
     if (!parsed.success) return;
+    // Only the two families this settings view owns are routable; any other
+    // catalog category (workflow, model, tools, …) is ignored rather than
+    // mis-persisted through the agent path or refreshing the wrong UI.
     if (entry.category === 'git') {
       await this.updateGitAuthorSetting(key as WorkspaceStateKey, parsed.data);
-    } else {
+    } else if (entry.category === 'ai-agents') {
       await this.updateAgentSetting(
         key as WorkspaceStateKey,
         parsed.data as string,

--- a/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
@@ -175,11 +175,11 @@ export class AIAgentsTab extends LitElement {
   claudeAgentPermissionMode: ClaudeAgentPermissionMode = 'acceptEdits';
   @property({ type: String }) claudeAgentEffort: ClaudeAgentEffort = 'high';
 
-  private postSelect(command: string, key: string, e: Event): void {
+  private postSelect(key: WorkspaceStateKey, e: Event): void {
     const select = e.currentTarget as WaSelect | null;
     const value = typeof select?.value === 'string' ? select.value : '';
     if (value) {
-      postMessage(command, { [key]: value });
+      postMessage(SETTINGS_VIEW_COMMANDS.UPDATE_STATE_SETTING, { key, value });
     }
   }
 
@@ -210,34 +210,19 @@ export class AIAgentsTab extends LitElement {
           'Sandbox mode',
           this.codexSandboxMode,
           SANDBOX_MODE_OPTIONS,
-          (e) =>
-            this.postSelect(
-              SETTINGS_VIEW_COMMANDS.SET_CODEX_SANDBOX_MODE,
-              'mode',
-              e,
-            ),
+          (e) => this.postSelect(WorkspaceStateKey.CODEX_SANDBOX_MODE, e),
         )}
         ${this.renderSelectRow(
           'Reasoning effort',
           this.codexReasoningEffort,
           REASONING_EFFORT_OPTIONS,
-          (e) =>
-            this.postSelect(
-              SETTINGS_VIEW_COMMANDS.SET_CODEX_REASONING_EFFORT,
-              'effort',
-              e,
-            ),
+          (e) => this.postSelect(WorkspaceStateKey.CODEX_REASONING_EFFORT, e),
         )}
         ${this.renderSelectRow(
           'Approval policy',
           this.codexApprovalPolicy,
           APPROVAL_POLICY_OPTIONS,
-          (e) =>
-            this.postSelect(
-              SETTINGS_VIEW_COMMANDS.SET_CODEX_APPROVAL_POLICY,
-              'policy',
-              e,
-            ),
+          (e) => this.postSelect(WorkspaceStateKey.CODEX_APPROVAL_POLICY, e),
         )}
       </div>
     `;
@@ -250,34 +235,20 @@ export class AIAgentsTab extends LitElement {
           'Model',
           this.claudeAgentModel,
           CLAUDE_MODEL_OPTIONS,
-          (e) =>
-            this.postSelect(
-              SETTINGS_VIEW_COMMANDS.SET_CLAUDE_AGENT_MODEL,
-              'model',
-              e,
-            ),
+          (e) => this.postSelect(WorkspaceStateKey.CLAUDE_AGENT_MODEL, e),
         )}
         ${this.renderSelectRow(
           'Reasoning effort',
           this.claudeAgentEffort,
           CLAUDE_EFFORT_OPTIONS,
-          (e) =>
-            this.postSelect(
-              SETTINGS_VIEW_COMMANDS.SET_CLAUDE_AGENT_EFFORT,
-              'effort',
-              e,
-            ),
+          (e) => this.postSelect(WorkspaceStateKey.CLAUDE_AGENT_EFFORT, e),
         )}
         ${this.renderSelectRow(
           'Permission mode',
           this.claudeAgentPermissionMode,
           CLAUDE_PERMISSION_MODE_OPTIONS,
           (e) =>
-            this.postSelect(
-              SETTINGS_VIEW_COMMANDS.SET_CLAUDE_AGENT_PERMISSION_MODE,
-              'mode',
-              e,
-            ),
+            this.postSelect(WorkspaceStateKey.CLAUDE_AGENT_PERMISSION_MODE, e),
         )}
       </div>
     `;

--- a/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GitTab.ts
@@ -31,6 +31,7 @@ import {
   DEFAULT_GIT_AUTHOR_NAME,
   DEFAULT_GIT_AUTHOR_EMAIL,
 } from '@shared/schemas/stateSettings';
+import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import type WaInput from '@awesome.me/webawesome/dist/components/input/input.js';
 import type WaSwitch from '@awesome.me/webawesome/dist/components/switch/switch.js';
 
@@ -197,8 +198,9 @@ export class GitTab extends LitElement {
 
   private handleMarkCommitsToggle(event: Event): void {
     const target = event.target as WaSwitch | null;
-    postMessage(SETTINGS_VIEW_COMMANDS.SET_GIT_MARK_COMMITS, {
-      enabled: Boolean(target?.checked),
+    postMessage(SETTINGS_VIEW_COMMANDS.UPDATE_STATE_SETTING, {
+      key: WorkspaceStateKey.GIT_MARK_COMMITS,
+      value: Boolean(target?.checked),
     });
   }
 
@@ -206,7 +208,10 @@ export class GitTab extends LitElement {
     const target = event.target as WaInput | null;
     const name = target?.value?.trim();
     if (name) {
-      postMessage(SETTINGS_VIEW_COMMANDS.SET_GIT_AUTHOR_NAME, { name });
+      postMessage(SETTINGS_VIEW_COMMANDS.UPDATE_STATE_SETTING, {
+        key: WorkspaceStateKey.GIT_AUTHOR_NAME,
+        value: name,
+      });
     }
   }
 
@@ -214,7 +219,10 @@ export class GitTab extends LitElement {
     const target = event.target as WaInput | null;
     const email = target?.value?.trim();
     if (email) {
-      postMessage(SETTINGS_VIEW_COMMANDS.SET_GIT_AUTHOR_EMAIL, { email });
+      postMessage(SETTINGS_VIEW_COMMANDS.UPDATE_STATE_SETTING, {
+        key: WorkspaceStateKey.GIT_AUTHOR_EMAIL,
+        value: email,
+      });
     }
   }
 

--- a/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -16,6 +16,7 @@ import '@awesome.me/webawesome/dist/components/button/button.js';
 // Local imports - shared webview
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import { postMessage } from '@shared/hostBridge';
+import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 // Local imports - shared schemas
@@ -433,10 +434,10 @@ export class MultiAgentTab extends LitElement {
           <wa-switch
             ?checked=${this.worktreeSupport}
             @change=${(e: Event) =>
-              this.postToggle(
-                SETTINGS_VIEW_COMMANDS.SET_GIT_WORKTREE_SUPPORT,
-                e,
-              )}
+              postMessage(SETTINGS_VIEW_COMMANDS.UPDATE_STATE_SETTING, {
+                key: WorkspaceStateKey.GIT_WORKTREE_SUPPORT,
+                value: Boolean((e.target as WaSwitch | null)?.checked),
+              })}
           >
             Allow agents to work in git worktrees
           </wa-switch>

--- a/src/controllers/settingsView/SettingsViewCommandHandlers.ts
+++ b/src/controllers/settingsView/SettingsViewCommandHandlers.ts
@@ -139,12 +139,6 @@ export interface SettingsViewCommandActions {
     readonly saveModePreset: HandlerOrUnsupported;
     readonly deleteModePreset: StringAction;
   };
-  readonly gitAuthor: {
-    readonly setMarkCommits: EnabledAction;
-    readonly setName: StringAction;
-    readonly setEmail: StringAction;
-    readonly setWorktreeSupport: EnabledAction;
-  };
   readonly githubSubscriptions: {
     readonly getTokenStatus: HandlerOrUnsupported;
     readonly setToken: HandlerOrUnsupported;
@@ -164,12 +158,15 @@ export interface SettingsViewCommandActions {
   };
   readonly approval: {
     readonly setBashApprovalEnabled: EnabledAction;
-    readonly setCodexSandboxMode: StringAction;
-    readonly setCodexReasoningEffort: StringAction;
-    readonly setCodexApprovalPolicy: StringAction;
-    readonly setClaudeAgentModel: StringAction;
-    readonly setClaudeAgentPermissionMode: StringAction;
-    readonly setClaudeAgentEffort: StringAction;
+  };
+  /**
+   * Generic catalog-driven scalar-setting write. One action replaces the former
+   * per-setting `gitAuthor.*` and `approval.setCodex*`/`setClaude*` handlers: the
+   * host looks the key up in `STATE_SETTINGS`, validates the value, persists it,
+   * and rebroadcasts the owning family (git-author vs approval) by category.
+   */
+  readonly stateSettings: {
+    readonly update: HandlerOrUnsupported<[string, unknown]>;
   };
   readonly tools: {
     readonly openInstallUrl: StringAction;
@@ -374,20 +371,6 @@ export function createSettingsViewCommandHandlers(
       (data) => [data.presetId],
     ),
 
-    setGitMarkCommits: mapAction(actions.gitAuthor.setMarkCommits, (data) => [
-      data.enabled,
-    ]),
-    setGitAuthorName: mapAction(actions.gitAuthor.setName, (data) => [
-      data.name,
-    ]),
-    setGitAuthorEmail: mapAction(actions.gitAuthor.setEmail, (data) => [
-      data.email,
-    ]),
-    setGitWorktreeSupport: mapAction(
-      actions.gitAuthor.setWorktreeSupport,
-      (data) => [data.enabled],
-    ),
-
     getGitHubTokenStatus: actions.githubSubscriptions.getTokenStatus,
     setGitHubToken: actions.githubSubscriptions.setToken,
     removeGitHubToken: actions.githubSubscriptions.removeToken,
@@ -417,30 +400,10 @@ export function createSettingsViewCommandHandlers(
       actions.approval.setBashApprovalEnabled,
       (data) => [data.enabled],
     ),
-    setCodexSandboxMode: mapAction(
-      actions.approval.setCodexSandboxMode,
-      (data) => [data.mode],
-    ),
-    setCodexReasoningEffort: mapAction(
-      actions.approval.setCodexReasoningEffort,
-      (data) => [data.effort],
-    ),
-    setCodexApprovalPolicy: mapAction(
-      actions.approval.setCodexApprovalPolicy,
-      (data) => [data.policy],
-    ),
-    setClaudeAgentModel: mapAction(
-      actions.approval.setClaudeAgentModel,
-      (data) => [data.model],
-    ),
-    setClaudeAgentPermissionMode: mapAction(
-      actions.approval.setClaudeAgentPermissionMode,
-      (data) => [data.mode],
-    ),
-    setClaudeAgentEffort: mapAction(
-      actions.approval.setClaudeAgentEffort,
-      (data) => [data.effort],
-    ),
+    updateStateSetting: mapAction(actions.stateSettings.update, (data) => [
+      data.key,
+      data.value,
+    ]),
 
     openToolInstallUrl: mapAction(actions.tools.openInstallUrl, (data) => [
       data.url,

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -334,25 +334,21 @@ export const SETTINGS_VIEW_CMD = {
   APPLY_AGENT_MODE_PRESET: 'applyAgentModePreset',
   SAVE_AGENT_MODE_PRESET: 'saveAgentModePreset',
   DELETE_AGENT_MODE_PRESET: 'deleteAgentModePreset',
+  // Generic state-setting write. One catalog-driven command carries {key, value}
+  // for every scalar `STATE_SETTINGS` row (git-author + external-agent controls),
+  // replacing the former per-setting SET_* commands. The backend looks the key up
+  // in the catalog, validates the value against its schema, and rebroadcasts the
+  // owning family (see stateSettings.ts / settingsAccess.ts). Modeled on the
+  // existing SET_LATEX_CONFIG_VALUE precedent.
+  UPDATE_STATE_SETTING: 'updateStateSetting',
   // Approval settings commands
   SET_BASH_APPROVAL_ENABLED: 'setBashApprovalEnabled',
-  SET_CODEX_SANDBOX_MODE: 'setCodexSandboxMode',
-  SET_CODEX_REASONING_EFFORT: 'setCodexReasoningEffort',
-  SET_CODEX_APPROVAL_POLICY: 'setCodexApprovalPolicy',
-  SET_CLAUDE_AGENT_MODEL: 'setClaudeAgentModel',
-  SET_CLAUDE_AGENT_PERMISSION_MODE: 'setClaudeAgentPermissionMode',
-  SET_CLAUDE_AGENT_EFFORT: 'setClaudeAgentEffort',
   // Tool dashboard commands
   OPEN_TOOL_INSTALL_URL: 'openToolInstallUrl',
   INSTALL_TOOL_EXTENSION: 'installToolExtension',
   RECHECK_TOOL_STATUS: 'recheckToolStatus',
   TOGGLE_TOOL: 'toggleTool',
   RUN_TOOL_COMMAND: 'runToolCommand',
-  // Git settings commands
-  SET_GIT_MARK_COMMITS: 'setGitMarkCommits',
-  SET_GIT_AUTHOR_NAME: 'setGitAuthorName',
-  SET_GIT_AUTHOR_EMAIL: 'setGitAuthorEmail',
-  SET_GIT_WORKTREE_SUPPORT: 'setGitWorktreeSupport',
   // GitHub token commands (for PR subscription tool)
   GET_GITHUB_TOKEN_STATUS: 'getGitHubTokenStatus',
   UPDATE_GITHUB_TOKEN_STATUS: 'updateGitHubTokenStatus',

--- a/src/shared/schemas/settingsView/inbound.ts
+++ b/src/shared/schemas/settingsView/inbound.ts
@@ -40,14 +40,6 @@ import {
   SignInMessageSchema,
   SignOutMessageSchema,
 } from '../profileViewMessages';
-import {
-  ClaudeAgentEffortSchema,
-  ClaudeAgentModelSchema,
-  ClaudeAgentPermissionModeSchema,
-  CodexApprovalPolicySchema,
-  CodexReasoningEffortSchema,
-  CodexSandboxModeSchema,
-} from '../agentCliSettings';
 import { ReasoningLevelSchema } from './data';
 
 const CMD = SETTINGS_VIEW_CMD;
@@ -247,23 +239,6 @@ export type ToolCommandKind = z.infer<
   typeof RunToolCommandMessageSchema
 >['kind'];
 
-// Git author settings inbound messages
-const SetGitMarkCommitsMessageSchema = enabledFlag(CMD.SET_GIT_MARK_COMMITS);
-
-const SetGitAuthorNameMessageSchema = z.object({
-  command: z.literal(CMD.SET_GIT_AUTHOR_NAME),
-  name: z.string(),
-});
-
-const SetGitAuthorEmailMessageSchema = z.object({
-  command: z.literal(CMD.SET_GIT_AUTHOR_EMAIL),
-  email: z.string(),
-});
-
-const SetGitWorktreeSupportMessageSchema = enabledFlag(
-  CMD.SET_GIT_WORKTREE_SUPPORT,
-);
-
 // GitHub token messages (for PR subscription tool)
 const GetGitHubTokenStatusMessageSchema = commandOnly(
   CMD.GET_GITHUB_TOKEN_STATUS,
@@ -359,29 +334,17 @@ const SetInlineCriticismEnabledMessageSchema = enabledFlag(
 const SetBashApprovalEnabledMessageSchema = enabledFlag(
   CMD.SET_BASH_APPROVAL_ENABLED,
 );
-const SetCodexSandboxModeMessageSchema = z.object({
-  command: z.literal(CMD.SET_CODEX_SANDBOX_MODE),
-  mode: CodexSandboxModeSchema,
-});
-const SetCodexReasoningEffortMessageSchema = z.object({
-  command: z.literal(CMD.SET_CODEX_REASONING_EFFORT),
-  effort: CodexReasoningEffortSchema,
-});
-const SetCodexApprovalPolicyMessageSchema = z.object({
-  command: z.literal(CMD.SET_CODEX_APPROVAL_POLICY),
-  policy: CodexApprovalPolicySchema,
-});
-const SetClaudeAgentModelMessageSchema = z.object({
-  command: z.literal(CMD.SET_CLAUDE_AGENT_MODEL),
-  model: ClaudeAgentModelSchema,
-});
-const SetClaudeAgentPermissionModeMessageSchema = z.object({
-  command: z.literal(CMD.SET_CLAUDE_AGENT_PERMISSION_MODE),
-  mode: ClaudeAgentPermissionModeSchema,
-});
-const SetClaudeAgentEffortMessageSchema = z.object({
-  command: z.literal(CMD.SET_CLAUDE_AGENT_EFFORT),
-  effort: ClaudeAgentEffortSchema,
+
+// Generic catalog-driven state-setting write. One flat branch (single outer
+// discriminator on `command`, per the SET_LATEX_CONFIG_VALUE precedent above)
+// carrying the canonical `STATE_SETTINGS` key and a loose value. Per-value
+// validation happens in the backend handler via the entry's own schema
+// (`stateSettingByKey(key).schema`), so the union stays a plain flat branch and
+// never grows a nested per-key discriminator (which would crash the dispatcher).
+const UpdateStateSettingMessageSchema = z.object({
+  command: z.literal(CMD.UPDATE_STATE_SETTING),
+  key: z.string().min(1),
+  value: z.union([z.boolean(), z.number(), z.string(), z.null()]).optional(),
 });
 
 // Navigation inbound messages
@@ -470,11 +433,6 @@ export const SettingsViewInboundMessageSchema = z.discriminatedUnion(
     // Multi-Agent orchestration messages
     SetAllowOrchestratorKillMessageSchema,
     SetDetachSubagentsOnStopMessageSchema,
-    // Git author settings messages
-    SetGitMarkCommitsMessageSchema,
-    SetGitAuthorNameMessageSchema,
-    SetGitAuthorEmailMessageSchema,
-    SetGitWorktreeSupportMessageSchema,
     // GitHub token messages
     GetGitHubTokenStatusMessageSchema,
     SetGitHubTokenMessageSchema,
@@ -493,12 +451,8 @@ export const SettingsViewInboundMessageSchema = z.discriminatedUnion(
     OpenPRSubscriptionStreamMessageSchema,
     // Approval settings messages
     SetBashApprovalEnabledMessageSchema,
-    SetCodexSandboxModeMessageSchema,
-    SetCodexReasoningEffortMessageSchema,
-    SetCodexApprovalPolicyMessageSchema,
-    SetClaudeAgentModelMessageSchema,
-    SetClaudeAgentPermissionModeMessageSchema,
-    SetClaudeAgentEffortMessageSchema,
+    // Generic catalog-driven state-setting write (git-author + agent controls)
+    UpdateStateSettingMessageSchema,
     // Agent team messages
     ApplyAgentModePresetMessageSchema,
     SaveAgentModePresetMessageSchema,

--- a/src/shared/settingsView/handlers/stateSettingWrite.ts
+++ b/src/shared/settingsView/handlers/stateSettingWrite.ts
@@ -1,0 +1,64 @@
+// Shared routing decision for the generic `UPDATE_STATE_SETTING` command.
+//
+// The extension and desktop hosts each own the actual persist + rebroadcast per
+// family (git-author vs external-agent), but the decision of *whether* and *as
+// which family* to write a given {key, value} is identical and drift-prone.
+// This resolver owns that decision once so the two hosts can't diverge on the
+// subtle rules:
+//   - a value-less message is a no-op (the catalog schemas `.prefault()`, so
+//     parsing `undefined` would resolve to the default and silently reset the
+//     setting — this command has no clear-to-default semantics), and
+//   - only the git-author and external-agent categories are routable; any other
+//     catalog category is ignored rather than mis-persisted through the agent
+//     path or refreshing the wrong UI.
+
+import { stateSettingByKey } from '@shared/schemas/stateSettings';
+import type { WorkspaceStateKey } from '@shared/state/stateKeys';
+
+/**
+ * A validated, classified state-setting write, or `null` when the message must
+ * be ignored (value-less, unknown key, schema-rejected value, or a catalog
+ * category this settings view does not own). `git` values stay `unknown`
+ * (boolean or string); `agent` values are the string/enum the six external-agent
+ * settings all use.
+ */
+export type StateSettingWrite =
+  | {
+      readonly family: 'git';
+      readonly key: WorkspaceStateKey;
+      readonly value: unknown;
+    }
+  | {
+      readonly family: 'agent';
+      readonly key: WorkspaceStateKey;
+      readonly value: string;
+    }
+  | null;
+
+/**
+ * Validate a `{key, value}` write against the `STATE_SETTINGS` catalog and
+ * classify it into the owning family, or return `null` to ignore it. Hosts
+ * dispatch the returned family to their own updater; this function performs no
+ * I/O.
+ */
+export function resolveStateSettingWrite(
+  key: string,
+  value: unknown,
+): StateSettingWrite {
+  if (value === undefined) return null;
+  const entry = stateSettingByKey(key);
+  if (!entry) return null;
+  const parsed = entry.schema.safeParse(value);
+  if (!parsed.success) return null;
+  if (entry.category === 'git') {
+    return { family: 'git', key: key as WorkspaceStateKey, value: parsed.data };
+  }
+  if (entry.category === 'ai-agents') {
+    return {
+      family: 'agent',
+      key: key as WorkspaceStateKey,
+      value: parsed.data as string,
+    };
+  }
+  return null;
+}

--- a/src/shared/settingsView/handlers/stateSettingWrite.ts
+++ b/src/shared/settingsView/handlers/stateSettingWrite.ts
@@ -22,7 +22,7 @@ import type { WorkspaceStateKey } from '@shared/state/stateKeys';
  * (boolean or string); `agent` values are the string/enum the six external-agent
  * settings all use.
  */
-export type StateSettingWrite =
+type StateSettingWrite =
   | {
       readonly family: 'git';
       readonly key: WorkspaceStateKey;

--- a/src/test-kernel/controllers/SettingsViewCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/SettingsViewCommandHandlers.vitest.ts
@@ -86,12 +86,6 @@ function createActions(): SettingsViewCommandActions {
       saveModePreset: action(),
       deleteModePreset: action(),
     },
-    gitAuthor: {
-      setMarkCommits: action(),
-      setName: action(),
-      setEmail: action(),
-      setWorktreeSupport: action(),
-    },
     githubSubscriptions: {
       getTokenStatus: action(),
       setToken: action(),
@@ -109,12 +103,9 @@ function createActions(): SettingsViewCommandActions {
     },
     approval: {
       setBashApprovalEnabled: action(),
-      setCodexSandboxMode: action(),
-      setCodexReasoningEffort: action(),
-      setCodexApprovalPolicy: action(),
-      setClaudeAgentModel: action(),
-      setClaudeAgentPermissionMode: action(),
-      setClaudeAgentEffort: action(),
+    },
+    stateSettings: {
+      update: action(),
     },
     tools: {
       openInstallUrl: action(),
@@ -224,6 +215,16 @@ describe('createSettingsViewCommandHandlers', () => {
     });
     expect(actions.modelSelection.requestAccess).toHaveBeenCalledWith(
       'copilot:sonnet46',
+    );
+
+    assertSupported(registry.updateStateSetting)({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_STATE_SETTING,
+      key: 'texra.codexSandboxMode',
+      value: 'workspace-write',
+    });
+    expect(actions.stateSettings.update).toHaveBeenCalledWith(
+      'texra.codexSandboxMode',
+      'workspace-write',
     );
   });
 });

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -325,8 +325,9 @@ describe('desktop settings IPC', () => {
 
     expect(
       settings.handleMessage({
-        command: SETTINGS_VIEW_COMMANDS.SET_GIT_AUTHOR_NAME,
-        name: 'Desktop TeXRA',
+        command: SETTINGS_VIEW_COMMANDS.UPDATE_STATE_SETTING,
+        key: WorkspaceStateKey.GIT_AUTHOR_NAME,
+        value: 'Desktop TeXRA',
       }),
     ).toBe(true);
     await Promise.resolve();
@@ -341,8 +342,9 @@ describe('desktop settings IPC', () => {
 
     expect(
       settings.handleMessage({
-        command: SETTINGS_VIEW_COMMANDS.SET_GIT_MARK_COMMITS,
-        enabled: false,
+        command: SETTINGS_VIEW_COMMANDS.UPDATE_STATE_SETTING,
+        key: WorkspaceStateKey.GIT_MARK_COMMITS,
+        value: false,
       }),
     ).toBe(true);
     await Promise.resolve();
@@ -351,8 +353,9 @@ describe('desktop settings IPC', () => {
 
     expect(
       settings.handleMessage({
-        command: SETTINGS_VIEW_COMMANDS.SET_GIT_WORKTREE_SUPPORT,
-        enabled: true,
+        command: SETTINGS_VIEW_COMMANDS.UPDATE_STATE_SETTING,
+        key: WorkspaceStateKey.GIT_WORKTREE_SUPPORT,
+        value: true,
       }),
     ).toBe(true);
     await Promise.resolve();
@@ -889,9 +892,11 @@ describe('desktop settings IPC', () => {
     const { settings, posted } = createCapturedSettingsFixture();
 
     expect(settings.handleMessage({ command: 'unknown' })).toBe(false);
+    // Missing the required `key` — the inbound schema rejects it, so the
+    // dispatcher never claims the message.
     expect(
       settings.handleMessage({
-        command: SETTINGS_VIEW_COMMANDS.SET_GIT_AUTHOR_NAME,
+        command: SETTINGS_VIEW_COMMANDS.UPDATE_STATE_SETTING,
       }),
     ).toBe(false);
     expect(posted).toEqual([]);

--- a/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
+++ b/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
@@ -9,6 +9,7 @@ import {
   SETTINGS_VIEW_COMMANDS,
 } from '@shared/ipc';
 import { AgentCategory } from '@shared/schemas/agent';
+import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
 
 // Local imports - desktop test paths
@@ -246,7 +247,7 @@ describe('desktop main-view IPC', () => {
     const settings = {
       handleMessage: vi.fn(
         (message: { command: string }) =>
-          message.command === SETTINGS_VIEW_COMMANDS.SET_GIT_AUTHOR_NAME,
+          message.command === SETTINGS_VIEW_COMMANDS.UPDATE_STATE_SETTING,
       ),
     };
     const progress = {
@@ -321,13 +322,15 @@ describe('desktop main-view IPC', () => {
     rendererListener?.(
       { sender: webContents },
       {
-        command: SETTINGS_VIEW_COMMANDS.SET_GIT_AUTHOR_NAME,
-        name: 'TeXRA Bot',
+        command: SETTINGS_VIEW_COMMANDS.UPDATE_STATE_SETTING,
+        key: WorkspaceStateKey.GIT_AUTHOR_NAME,
+        value: 'TeXRA Bot',
       },
     );
     expect(settings.handleMessage).toHaveBeenCalledWith({
-      command: SETTINGS_VIEW_COMMANDS.SET_GIT_AUTHOR_NAME,
-      name: 'TeXRA Bot',
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_STATE_SETTING,
+      key: WorkspaceStateKey.GIT_AUTHOR_NAME,
+      value: 'TeXRA Bot',
     });
 
     rendererListener?.(


### PR DESCRIPTION
## Summary

Two independent, self-contained refactors that reduce moving parts, following a deeper audit of the repo's largest tech-debt areas. The work remains split by concern.

**1 — Settings: collapse 10 per-setting commands into one `UPDATE_STATE_SETTING`.**
The git-author and external-agent (Codex / Claude Code) scalar settings each threaded a dedicated `SET_*` command through five layers: an `ipc.ts` constant, an inbound Zod schema + union member, a controller action-interface method + registry mapping, a host handler, and a bespoke frontend `postMessage`. The state-settings catalog (`STATE_SETTINGS`) and a validated writer (`settingsAccess.ts`) already existed and back the CLI — the extension/desktop paths were paying a per-setting tax for no added behavior. Replaced those 10 commands (4 git + 6 approval scalars) with one catalog-driven `UPDATE_STATE_SETTING {key, value}`, modeled on the existing `SET_LATEX_CONFIG_VALUE` precedent. The generic handler validates the value against the catalog entry's own schema (silently ignoring unknown keys / schema-rejected values) and routes persist + rebroadcast to each host's existing per-family updater by catalog `category`, so write and refresh behavior are unchanged. `setBashApprovalEnabled` stays a dedicated command (config-scoped, non-catalog, special no-folder guard).

**4A — CLI: extract the session exit/signal subsystem from `runChat`.**
`runChat` was an ~870-line function holding ~14 co-captured closures for the SIGINT/SIGTERM/SIGHUP/SIGTSTP/SIGCONT handlers, the double-tap-to-exit confirmation, and the two teardown paths, with teardown scattered across the body. Lifted that subsystem into `createSessionExitController(ctx)` — pure code motion, every closure body unchanged, the captured session values now threaded through an explicit `SessionExitControllerContext`. `runChat`'s `finally` is now a single `gracefulTeardown()` call.

Deliberately **not** done (verified as low value during the deep dive): the `statusBarDisplay` fit-logic unification (only ~⅔ achievable byte-identically, untested, adds a new element that offsets the gain) and a `ToolResult`-builder/`ExecutionsTool` sweep (200-site churn saving ~1 line each; `ExecutionsTool`'s "duplicate wait helpers" already share one `waitWithTimeout`).

## Issue acceptance gates

Not tied to a tracked issue — this is a proactive tech-debt audit + the refactors it surfaced.

## Single source of truth

- Settings: the `STATE_SETTINGS` catalog (`src/shared/schemas/stateSettings.ts`) is now the single owner of every scalar setting's key → {store, validation schema, category}; the generic write path reads it via `stateSettingByKey` and `settingsAccess.writeSetting`'s validation contract. There is one command (`UPDATE_STATE_SETTING`), one schema, one controller action, and one per-host handler instead of ten of each.
- CLI: `createSessionExitController` (`packages/cli/src/chat/tui/sessionExitController.ts`) is the single owner of signal handling and exit/teardown ordering for the chat TUI.

## Duplication and abstraction budget

- **Removed:** 10 near-identical command constants, 10 inbound schema consts + union members, 10 controller action methods + registry mappings, and the per-host `gitAuthor`/approval-scalar action groups → one generic path per layer.
- **New abstraction (4A):** `SessionExitController` owns the invariant "a signal exit runs the full teardown and `process.exit()`s itself; the graceful `waitUntilExit` teardown no-ops in that case (via the `exiting` guard) so drain / hint / cleanup never run twice." It has multiple real consumers (App `onCtrlC`/`onSuspend`, the slash-command context, `install()`, the `finally`), so it is not a pass-through layer.

## Net elements (R6)

- Files: +2 (`sessionExitController.ts`, `stateSettingWrite.ts`); 12 modified. Diffstat: 14 files, +573 / −480.
- Exported symbols: +2 (`createSessionExitController`, `resolveStateSettingWrite`), −0. Each has real cross-file consumers; their support types remain file-local.
- Commands/schemas/handlers: **−9 command constants, −9 inbound schema consts + union members, −10 controller action methods, −10 registry mappings**, replaced by 1 of each.
- Net LoC: +93 overall, while `runChat` sheds 211 net lines and ~14 co-captured closures collapse into one stateful controller; the shared state-setting resolver removes the duplicated extension/desktop validation and routing decision.

## Consumer counts (R8)

- `UPDATE_STATE_SETTING` re-routes 10 former commands. Grepped subscribers of the removed constants before deletion: each `SET_*` had exactly 3 references (ipc.ts def, inbound schema, one frontend tab) plus its controller mapping — all migrated. No `SET_GIT_*`/`SET_CODEX_*`/`SET_CLAUDE_AGENT_*` references remain (grep clean).
- The controller extraction is intra-module code motion; the moved `@cli/*` exports it now imports (e.g. `handOffCliShutdownSignalHandlers`, `formatResumeHint`) keep their existing single consumer — usage moved from `runChatTui` to `sessionExitController`, so no export became unused (dead-code ratchet: 74 vs 74).

## Host impact

Extension: `UPDATE_STATE_SETTING` handler routes git/approval writes by catalog category to the existing `updateGitAuthorSetting`/`updateAgentSetting`; `GitTab`/`AIAgentsTab`/`MultiAgentTab` post the generic command. Behavior unchanged.

Desktop: mirrors the extension — same generic handler + category routing in `desktopSettingsIpc.ts`. The `SettingsViewCommandActions` interface change is compile-enforced across both hosts.

CLI: exit/signal subsystem extracted into `sessionExitController.ts`; no behavior change. Settings change is transport-only and does not affect the CLI `/config` path.

## Scheduled refactoring

None required. The audit's larger remaining targets (model-handler Google-base + `compactConversation` dedup; `claudeAgent`/`codex` parallel wrappers) are noted but out of scope here.

## Validation

- `npm run typecheck` — pass (all 6 projects).
- `npm run check:dead-code-ratchet` — pass (74 vs 74 baseline).
- `eslint` on all changed files — clean.
- Targeted tests: `SettingsViewCommandHandlers`, `DesktopSettingsIpc`, `ElectronMainViewIpc` (25 pass); full CLI suite (1844 pass).
- Full `npm test` — 6853 pass; the only 2 failures are in `SystemUtils.vitest.ts` (OS process-group abort timing), which **also fail on the base commit** in this sandbox and touch none of the changed files.
- Follow-up review fixes: all six project typechecks; focused lint; `RunChatSignalOwnership` plus the three affected settings suites (27 tests); `compile:fast`; dead-code ratchet — all pass.
- **Not run (needs a human):** the chat-TUI signal paths (Ctrl-C double-tap, Ctrl-Z/`fg`, SIGTERM/SIGHUP) have no automated coverage, so 4A warrants a manual smoke test of interactive exit/suspend/resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XuUXZTxueztFCpk8owR1wp)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Settings routing is shared across extension and desktop with silent no-ops on bad keys/values; CLI exit logic moved without automated signal tests, so interactive exit/suspend/resume deserves a manual smoke check.
> 
> **Overview**
> **Two independent refactors:** settings IPC consolidation and chat TUI exit/signal extraction. No intended behavior change on either path.
> 
> **Settings:** Replaces ten per-setting `SET_*` commands (git author + Codex/Claude scalar controls) with a single **`UPDATE_STATE_SETTING`** carrying `{ key, value }`. Extension and desktop hosts route writes through shared **`resolveStateSettingWrite`**, which validates against the **`STATE_SETTINGS`** catalog and dispatches to the existing git vs agent persist/rebroadcast paths. Settings tabs (`GitTab`, `AIAgentsTab`, `MultiAgentTab`) now post the generic command with **`WorkspaceStateKey`** values. **`setBashApprovalEnabled`** stays a dedicated command.
> 
> **CLI:** Moves SIGINT/SIGTERM/SIGHUP/SIGTSTP/SIGCONT handling, double-tap exit confirmation, resume hints, persistence drain, and the signal vs graceful teardown split from **`runChat`** into **`createSessionExitController`**. **`runChat`** wires Ink/slash-command callbacks to the controller and ends with **`gracefulTeardown()`** in `finally`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a589de188fa3bc2fb02001c3d129417876dfb155. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->