### PR TITLE
harden(tools): bound and lock down sandbox structured-output schemas

### DIFF
--- a/src/test-kernel/tools/structuredOutput.vitest.ts
+++ b/src/test-kernel/tools/structuredOutput.vitest.ts
@@ -136,6 +136,18 @@ describe('normalizeStructuredOutputSchema', () => {
       normalizeStructuredOutputSchema({ type: 'object', properties: wide }),
     ).toThrow(/exceeds the .* limit/);
   });
+
+  it('rejects scalar-heavy schemas past the serialized-size cap', () => {
+    // A giant enum is only a couple of object nodes but a huge payload; the
+    // size cap catches what the node/depth caps cannot.
+    const choice = { enum: Array.from({ length: 200_000 }, (_, i) => `v${i}`) };
+    expect(() =>
+      normalizeStructuredOutputSchema({
+        type: 'object',
+        properties: { choice },
+      }),
+    ).toThrow(/byte size limit/);
+  });
 });
 
 describe('buildTerminalTool', () => {

--- a/src/test-kernel/tools/structuredOutput.vitest.ts
+++ b/src/test-kernel/tools/structuredOutput.vitest.ts
@@ -97,6 +97,45 @@ describe('normalizeStructuredOutputSchema', () => {
       }),
     ).not.toThrow();
   });
+
+  it('rejects format, $ref, and prototype-polluting property keys', () => {
+    expect(() =>
+      normalizeStructuredOutputSchema({
+        type: 'object',
+        properties: { at: { type: 'string', format: 'email' } },
+      }),
+    ).toThrow(/cannot use format/);
+    expect(() =>
+      normalizeStructuredOutputSchema({
+        type: 'object',
+        properties: { child: { $ref: '#/$defs/x' } },
+      }),
+    ).toThrow(/cannot use \$ref/);
+    // Real sandbox schemas arrive via JSON.parse, which creates an own
+    // "__proto__" key (an object literal would set the prototype instead).
+    const polluting = JSON.parse(
+      '{"type":"object","properties":{"__proto__":{"type":"string"}}}',
+    ) as Record<string, unknown>;
+    expect(() => normalizeStructuredOutputSchema(polluting)).toThrow(
+      /cannot declare a "__proto__" property/,
+    );
+  });
+
+  it('rejects sandbox schemas past the depth and node caps', () => {
+    let deep: Record<string, unknown> = { type: 'string' };
+    for (let i = 0; i < 15; i += 1) {
+      deep = { type: 'object', properties: { next: deep } };
+    }
+    expect(() => normalizeStructuredOutputSchema(deep)).toThrow(
+      /nested deeper than/,
+    );
+
+    const wide: Record<string, unknown> = {};
+    for (let i = 0; i < 1100; i += 1) wide[`f${i}`] = { type: 'string' };
+    expect(() =>
+      normalizeStructuredOutputSchema({ type: 'object', properties: wide }),
+    ).toThrow(/exceeds the .* limit/);
+  });
 });
 
 describe('buildTerminalTool', () => {

--- a/src/tools/structuredOutput.ts
+++ b/src/tools/structuredOutput.ts
@@ -20,57 +20,105 @@ type JsonValue = z.infer<typeof JsonValueSchema>;
 /** Name of the synthetic tool the model calls to submit its final result. */
 const SUBMIT_OUTPUT_TOOL_NAME = 'submit_output';
 
-/**
- * JSON Schema authored inside a workflow sandbox is untrusted. Zod compiles
- * these keywords to host RegExp instances, where catastrophic backtracking
- * would escape the sandbox's execution limits.
- */
-function assertNoHostRegex(schema: unknown): void {
-  if (schema === null || typeof schema !== 'object') return;
-  if (Array.isArray(schema)) {
-    for (const child of schema) assertNoHostRegex(child);
-    return;
-  }
-  const record = schema as Record<string, unknown>;
-  if ('pattern' in record || 'patternProperties' in record) {
-    throw new Error(
-      'Structured output JSON Schema cannot use pattern or patternProperties.',
-    );
-  }
+// A sandbox schema crosses into host Zod compilation via z.fromJSONSchema, so
+// an unbounded tree is a host DoS. These caps keep compilation cheap; 12 levels
+// / 1000 nodes comfortably cover real structured-output shapes while refusing
+// pathological input.
+const MAX_SANDBOX_SCHEMA_DEPTH = 12;
+const MAX_SANDBOX_SCHEMA_NODES = 1000;
 
-  for (const key of [
-    'additionalItems',
-    'additionalProperties',
-    'contains',
-    'else',
-    'if',
-    'items',
-    'not',
-    'propertyNames',
-    'then',
-    'unevaluatedItems',
-    'unevaluatedProperties',
-  ]) {
-    assertNoHostRegex(record[key]);
-  }
-  for (const key of ['allOf', 'anyOf', 'oneOf', 'prefixItems']) {
-    const branches = record[key];
-    if (Array.isArray(branches)) {
-      for (const branch of branches) assertNoHostRegex(branch);
+// Property names that could reach Object.prototype when z.fromJSONSchema builds
+// the schema object.
+const FORBIDDEN_SCHEMA_PROPERTY_KEYS = [
+  '__proto__',
+  'constructor',
+  'prototype',
+];
+
+/**
+ * Guard a JSON Schema authored inside a workflow sandbox (untrusted) before it
+ * crosses into host Zod compilation via z.fromJSONSchema. Walking the schema it
+ * rejects: `pattern`/`patternProperties`/`format` (Zod compiles these to host
+ * RegExps, a catastrophic-backtracking ReDoS vector); `$ref`/`$dynamicRef`
+ * (external/recursive resolution surprises; inline the definition instead);
+ * prototype-polluting property keys; and trees past the node/depth caps.
+ */
+function assertSafeSandboxSchema(schema: unknown): void {
+  let nodeCount = 0;
+  const walk = (node: unknown, depth: number): void => {
+    if (node === null || typeof node !== 'object') return;
+    if (depth > MAX_SANDBOX_SCHEMA_DEPTH) {
+      throw new Error(
+        `Structured output JSON Schema is nested deeper than the ${MAX_SANDBOX_SCHEMA_DEPTH}-level limit.`,
+      );
     }
-  }
-  for (const key of [
-    '$defs',
-    'definitions',
-    'dependentSchemas',
-    'dependencies',
-    'properties',
-  ]) {
-    const schemas = record[key];
-    if (schemas !== null && typeof schemas === 'object') {
-      for (const child of Object.values(schemas)) assertNoHostRegex(child);
+    nodeCount += 1;
+    if (nodeCount > MAX_SANDBOX_SCHEMA_NODES) {
+      throw new Error(
+        `Structured output JSON Schema exceeds the ${MAX_SANDBOX_SCHEMA_NODES}-node limit.`,
+      );
     }
-  }
+    if (Array.isArray(node)) {
+      for (const child of node) walk(child, depth + 1);
+      return;
+    }
+    const record = node as Record<string, unknown>;
+    if ('pattern' in record || 'patternProperties' in record) {
+      throw new Error(
+        'Structured output JSON Schema cannot use pattern or patternProperties.',
+      );
+    }
+    if ('format' in record) {
+      throw new Error('Structured output JSON Schema cannot use format.');
+    }
+    if ('$ref' in record || '$dynamicRef' in record) {
+      throw new Error(
+        'Structured output JSON Schema cannot use $ref; inline the definition instead.',
+      );
+    }
+
+    for (const key of [
+      'additionalItems',
+      'additionalProperties',
+      'contains',
+      'else',
+      'if',
+      'items',
+      'not',
+      'propertyNames',
+      'then',
+      'unevaluatedItems',
+      'unevaluatedProperties',
+    ]) {
+      walk(record[key], depth + 1);
+    }
+    for (const key of ['allOf', 'anyOf', 'oneOf', 'prefixItems']) {
+      const branches = record[key];
+      if (Array.isArray(branches)) {
+        for (const branch of branches) walk(branch, depth + 1);
+      }
+    }
+    for (const key of [
+      '$defs',
+      'definitions',
+      'dependentSchemas',
+      'dependencies',
+      'properties',
+    ]) {
+      const schemas = record[key];
+      if (schemas !== null && typeof schemas === 'object') {
+        for (const name of Object.keys(schemas)) {
+          if (FORBIDDEN_SCHEMA_PROPERTY_KEYS.includes(name)) {
+            throw new Error(
+              `Structured output JSON Schema cannot declare a "${name}" property.`,
+            );
+          }
+        }
+        for (const child of Object.values(schemas)) walk(child, depth + 1);
+      }
+    }
+  };
+  walk(schema, 0);
 }
 
 /**
@@ -82,7 +130,7 @@ export function normalizeStructuredOutputSchema(
   input: z.ZodType | Record<string, unknown>,
 ): StructuredOutputSchema {
   const fromZod = input instanceof z.ZodType;
-  if (!fromZod) assertNoHostRegex(input);
+  if (!fromZod) assertSafeSandboxSchema(input);
   const zodSchema = fromZod ? input : (z.fromJSONSchema(input) as z.ZodType);
   const jsonSchema = convertToolSchema({
     name: SUBMIT_OUTPUT_TOOL_NAME,

--- a/src/tools/structuredOutput.ts
+++ b/src/tools/structuredOutput.ts
@@ -26,6 +26,11 @@ const SUBMIT_OUTPUT_TOOL_NAME = 'submit_output';
 // pathological input.
 const MAX_SANDBOX_SCHEMA_DEPTH = 12;
 const MAX_SANDBOX_SCHEMA_NODES = 1000;
+// The node/depth caps count object nodes only, so scalar-heavy keywords the
+// walker does not recurse into (a million-element `enum`, huge `required` /
+// `examples` / `description`) would still reach z.fromJSONSchema unbounded. A
+// serialized-size cap bounds the whole payload; 128 KiB dwarfs any real schema.
+const MAX_SANDBOX_SCHEMA_BYTES = 128 * 1024;
 
 // Property names that could reach Object.prototype when z.fromJSONSchema builds
 // the schema object.
@@ -44,6 +49,11 @@ const FORBIDDEN_SCHEMA_PROPERTY_KEYS = [
  * prototype-polluting property keys; and trees past the node/depth caps.
  */
 function assertSafeSandboxSchema(schema: unknown): void {
+  if (JSON.stringify(schema).length > MAX_SANDBOX_SCHEMA_BYTES) {
+    throw new Error(
+      `Structured output JSON Schema exceeds the ${MAX_SANDBOX_SCHEMA_BYTES}-byte size limit.`,
+    );
+  }
   let nodeCount = 0;
   const walk = (node: unknown, depth: number): void => {
     if (node === null || typeof node !== 'object') return;


### PR DESCRIPTION
Defense-in-depth for the untrusted structured-output schema boundary. Follow-up hardening on top of #8840.

Workflow scripts are sandboxed and untrusted; `agent(prompt, { schema })` passes a JSON Schema that crosses into host Zod compilation (`z.fromJSONSchema`). Main already rejects `pattern`/`patternProperties` (the primary ReDoS vector). This extends the same sandbox-only guard (renamed `assertSafeSandboxSchema`, applied only to non-Zod input in `normalizeStructuredOutputSchema`) with:

- **`format` and `$ref`/`$dynamicRef` rejection** — `format` compiles to host validators; `$ref` invites external/recursive resolution surprises. Inline definitions instead.
- **Prototype-pollution guard** — rejects `__proto__`/`constructor`/`prototype` property names anywhere in `properties`/`$defs`/`definitions`/`dependentSchemas`/`dependencies` (real sandbox schemas arrive via `JSON.parse`, which creates an own `__proto__` key).
- **Depth and node caps** (12 levels / 1000 nodes) — a huge or deeply nested schema would otherwise DoS host `z.fromJSONSchema` compilation.

Trusted host Zod callers are unaffected (the guard runs only on sandbox JSON Schema input).

## Testing

- `npm run typecheck` clean.
- `structuredOutput` suite: 16 pass (new cases: `format`/`$ref`/`__proto__` rejection, depth cap, node cap; existing "property named `pattern` is allowed" still passes).
- `WorkflowScriptEngine` suite: 74 pass (no schema-path regression).

Mocks/synthetic only, no live models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-focused boundary hardening on untrusted workflow schemas; behavior change only for sandbox JSON Schema callers that used forbidden keywords or oversized trees.
> 
> **Overview**
> **Extends the untrusted JSON Schema guard** in `normalizeStructuredOutputSchema` before host `z.fromJSONSchema` compilation. The old `assertNoHostRegex` walk is replaced by **`assertSafeSandboxSchema`**, which still blocks `pattern` / `patternProperties` and adds **`format`**, **`$ref` / `$dynamicRef`**, forbidden property names (`__proto__`, `constructor`, `prototype`), and **depth (12)**, **node (1000)**, and **serialized size (128 KiB)** limits.
> 
> Trusted **Zod** schemas skip the guard; only sandbox JSON Schema input is affected. Tests cover the new rejections and caps, including a large `enum` that bypasses node counting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f58afb02dda5cce338b7ed6f4e635d58d0840c7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->