### PR TITLE
refactor(desktop): require the lazy progress bridge source

### DIFF
--- a/packages/desktop/src/main/desktopProgressIpc.ts
+++ b/packages/desktop/src/main/desktopProgressIpc.ts
@@ -33,13 +33,10 @@ interface DesktopProgressIpcBridge {
   completeWebviewReady(): Promise<void>;
 }
 
-type DesktopProgressSource =
-  | { kind: 'eager'; progress: DesktopProgressIpcBridge }
-  | {
-      kind: 'lazy';
-      get(): DesktopProgressIpcBridge | undefined;
-      ensure(): Promise<DesktopProgressIpcBridge>;
-    };
+interface DesktopProgressSource {
+  get(): DesktopProgressIpcBridge | undefined;
+  ensure(): Promise<DesktopProgressIpcBridge>;
+}
 
 export interface DesktopProgressIpcOptions {
   source: DesktopProgressSource;
@@ -79,10 +76,6 @@ export function createDesktopProgressIpc(
       ));
 
   function withProgress(run: (progress: DesktopProgressIpcBridge) => void) {
-    if (options.source.kind === 'eager') {
-      run(options.source.progress);
-      return;
-    }
     const progress = options.source.get();
     if (progress) {
       run(progress);

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -948,7 +948,6 @@ function createWindow(options: {
   settingsIpcRef.current = settingsIpc;
   const progressIpc = createDesktopProgressIpc({
     source: {
-      kind: 'lazy',
       get: () => agentExecution?.progress,
       ensure: async () => (await getAgentExecution()).progress,
     },

--- a/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
@@ -37,13 +37,10 @@ interface DesktopProgressIpcBridgeStub {
 
 interface DesktopProgressIpcModule {
   createDesktopProgressIpc(options: {
-    source:
-      | { kind: 'eager'; progress: DesktopProgressIpcBridgeStub }
-      | {
-          kind: 'lazy';
-          get(): DesktopProgressIpcBridgeStub | undefined;
-          ensure(): Promise<DesktopProgressIpcBridgeStub>;
-        };
+    source: {
+      get(): DesktopProgressIpcBridgeStub | undefined;
+      ensure(): Promise<DesktopProgressIpcBridgeStub>;
+    };
     onUnsupportedCommand?: (
       message: { command: string },
       reason?: string,
@@ -72,8 +69,8 @@ function createProgress(
   };
 }
 
-function eagerSource(progress: DesktopProgressIpcBridgeStub) {
-  return { kind: 'eager' as const, progress };
+function readySource(progress: DesktopProgressIpcBridgeStub) {
+  return { get: () => progress, ensure: async () => progress };
 }
 
 describe('desktop Progress IPC', () => {
@@ -84,7 +81,7 @@ describe('desktop Progress IPC', () => {
 
   it('syncs Progress state on readiness while allowing shared view-state handling', async () => {
     const progress = createProgress();
-    const ipc = createDesktopProgressIpc({ source: eagerSource(progress) });
+    const ipc = createDesktopProgressIpc({ source: readySource(progress) });
 
     expect(
       ipc.handleMessage({
@@ -99,7 +96,7 @@ describe('desktop Progress IPC', () => {
 
   it('ignores main-view readiness broadcasts for Progress prompt replay', async () => {
     const progress = createProgress();
-    const ipc = createDesktopProgressIpc({ source: eagerSource(progress) });
+    const ipc = createDesktopProgressIpc({ source: readySource(progress) });
 
     expect(
       ipc.handleMessage({
@@ -115,7 +112,6 @@ describe('desktop Progress IPC', () => {
     const progress = createProgress();
     const ipc = createDesktopProgressIpc({
       source: {
-        kind: 'lazy',
         get: () => undefined,
         ensure: async () => progress,
       },
@@ -137,7 +133,7 @@ describe('desktop Progress IPC', () => {
     const progress = createProgress({
       [PROGRESS_VIEW_COMMANDS.SWITCH_STREAM]: switchStream,
     });
-    const ipc = createDesktopProgressIpc({ source: eagerSource(progress) });
+    const ipc = createDesktopProgressIpc({ source: readySource(progress) });
 
     expect(
       ipc.handleMessage({
@@ -158,7 +154,7 @@ describe('desktop Progress IPC', () => {
     });
     const ensure = vi.fn(async () => progress);
     const ipc = createDesktopProgressIpc({
-      source: { kind: 'lazy', get: () => undefined, ensure },
+      source: { get: () => undefined, ensure },
     });
 
     expect(
@@ -179,7 +175,7 @@ describe('desktop Progress IPC', () => {
   it('consumes recognized but unhandled commands with an explicit warning path', async () => {
     const onUnsupportedCommand = vi.fn();
     const ipc = createDesktopProgressIpc({
-      source: eagerSource(createProgress()),
+      source: readySource(createProgress()),
       onUnsupportedCommand,
     });
 
@@ -198,7 +194,7 @@ describe('desktop Progress IPC', () => {
   it('leaves shell-level pass-through commands for sibling desktop handlers', async () => {
     const onUnsupportedCommand = vi.fn();
     const ipc = createDesktopProgressIpc({
-      source: eagerSource(createProgress()),
+      source: readySource(createProgress()),
       onUnsupportedCommand,
     });
 
@@ -215,7 +211,7 @@ describe('desktop Progress IPC', () => {
     const error = new Error('dispatch failed');
     const onAsyncError = vi.fn();
     const ipc = createDesktopProgressIpc({
-      source: eagerSource(
+      source: readySource(
         createProgress({
           [PROGRESS_VIEW_COMMANDS.SWITCH_STREAM]: () => Promise.reject(error),
         }),
@@ -241,7 +237,7 @@ describe('desktop Progress IPC', () => {
       progressViewInboundHandlers: fillRegistry(),
     };
     const ipc = createDesktopProgressIpc({
-      source: eagerSource(progress),
+      source: readySource(progress),
       onAsyncError,
     });
 
@@ -258,7 +254,7 @@ describe('desktop Progress IPC', () => {
 
   it('ignores invalid Progress IPC payloads', async () => {
     const ipc = createDesktopProgressIpc({
-      source: eagerSource(createProgress()),
+      source: readySource(createProgress()),
     });
 
     expect(ipc.handleMessage({ command: 'not-a-progress-command' })).toBe(


### PR DESCRIPTION
## Summary

Desktop Progress IPC now accepts only the bridge source that production actually provides: a synchronous get operation for an already-loaded bridge and an asynchronous ensure operation for construction. The impossible eager discriminator and its test-only fixtures are removed without changing dispatch behavior.

Closes #8869

## Issue acceptance gates

- The eager DesktopProgressSource union arm and kind discriminator are deleted.
- The source contract provides only get and ensure.
- Already-loaded and not-yet-loaded behavior remain separate in the focused IPC suite.
- Already-loaded commands still dispatch synchronously.
- Missing-bridge commands are still claimed immediately, then dispatched after construction; construction errors retain the existing reporting path.
- WEBVIEW_READY still returns false and replays readiness after lazy construction.
- Pass-through commands, unsupported-command feedback, schema rejection, handler ordering, and disposal behavior are unchanged.
- No message-handler-chain or DesktopProgressBridge forwarding cleanup is included.
- No changelog entry is added.

## Single source of truth

DesktopProgressIpcOptions.source remains the sole bridge-acquisition contract. Its get result decides whether dispatch occurs immediately; ensure is used only when no bridge is loaded.

## Duplication and abstraction budget

The eager-or-lazy union, its discriminator branch, and the eager test representation are removed. No production facade, adapter, factory, compatibility shim, or replacement union is added. The existing repeated test fixture is rewritten as a ready source so tests exercise the same contract as production.

## Net elements (R4)

- Files: 3 modified, 0 added, 0 deleted.
- Production LoC: 4 additions, 12 deletions, net -8.
- Test LoC: 15 additions, 19 deletions, net -4.
- Total LoC: 19 additions, 31 deletions, net -12.
- Relocations: no runtime operations or files relocated; get, ensure, and all dispatch operations remain with their present owner.
- Exported symbols: 0 added, 0 removed.
- Named elements: the eager source arm, kind discriminator, eager progress property, and eagerSource test helper are removed. The test-only readySource fixture replaces eagerSource. DesktopProgressSource retains its name but changes from a union alias to the required source interface.
- Classes/enums: 0 added, 0 removed.

## Consumer counts (R8)

Repository-wide searches across .ts, .tsx, .mts, and .cts find one production source construction, in the desktop composition root, and one focused dynamic-import test module. Both are updated. No emit path or exported symbol is deleted or rerouted.

## Host impact

Extension: none.

Desktop: bridge acquisition exposes only the production lazy-source contract; runtime behavior is unchanged.

CLI: none.

## Scheduled refactoring

None. Broader desktop IPC-chain and progress-bridge forwarding changes are explicitly outside this issue.

## Validation

- npm run format
- npx prettier --write packages/desktop/src/main/desktopProgressIpc.ts packages/desktop/src/main/index.ts src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
- npm run typecheck
- npm run compile:fast
- npm run lint (0 errors; 1 pre-existing unrelated warning)
- npm run check:dead-code-ratchet
- npx vitest run src/test-kernel/desktop/DesktopProgressIpc.vitest.mts (10 passed)
- git diff --check
- Final simplification review: no additional layer, compatibility path, or behavior-neutral deletion remains within the verified scope.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small type and control-flow simplification in desktop IPC wiring; dispatch, pass-through, and lazy-load semantics are preserved and covered by existing tests.
> 
> **Overview**
> **Desktop Progress IPC** no longer models bridge acquisition as an eager-vs-lazy union with a `kind` discriminator. `DesktopProgressSource` is a single contract: **`get()`** for an already-loaded bridge and **`ensure()`** when construction is needed.
> 
> `withProgress` always uses that path (sync dispatch when `get()` returns a bridge, otherwise `ensure().then(...)` with the same error reporting). The desktop composition root drops the redundant `kind: 'lazy'` field; behavior is unchanged.
> 
> Tests replace **`eagerSource`** with **`readySource`** (`get` returns the stub, `ensure` resolves it) so fixtures match the production contract while still covering “already loaded” vs “load on first message” cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c14b2d0308121077832633542a11cc8666bcc9e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->