### PR TITLE
refactor(relay): derive providers from routing config

### DIFF
--- a/src/test-kernel/supabase/RelayModelAccess.vitest.ts
+++ b/src/test-kernel/supabase/RelayModelAccess.vitest.ts
@@ -5,6 +5,9 @@ import { strict as assert } from 'node:assert';
 import { MODEL_CONFIGS } from 'llm-zoo';
 import { describe, it, vi } from 'vitest';
 
+// Local imports - shared provider registry
+import { SERVER_SIDE_PROVIDER_IDS } from '@shared/constants/providers';
+
 // A retired model whose provider is not in RELAY_PROVIDERS (e.g. 'meta') is
 // not currently present in the pinned llm-zoo registry, so this synthetic
 // entry pins down the RETIRED_MODEL_PATTERNS derivation directly: it must
@@ -39,6 +42,13 @@ import {
 } from '../../../supabase/functions/relay/models';
 
 describe('relay tier model access', () => {
+  it('keeps client server-key providers aligned with relay routing', () => {
+    assert.deepEqual(
+      SERVER_SIDE_PROVIDER_IDS.toSorted(),
+      TIER_CONFIG.providers.toSorted(),
+    );
+  });
+
   it('limits Max to non-Ultra providers and keeps Ultra passthrough', () => {
     const maxModels = TIER_CONFIG.tiers.Max?.models;
     assert.ok(Array.isArray(maxModels));

--- a/src/test-kernel/supabase/RelayModelAccess.vitest.ts
+++ b/src/test-kernel/supabase/RelayModelAccess.vitest.ts
@@ -34,6 +34,7 @@ vi.mock('llm-zoo', async (importOriginal) => {
 import {
   FREE_TIER,
   MAX_TIER,
+  PROVIDER_CONFIGS,
   TIER_CONFIG,
   ULTRA_ONLY_PROVIDER_SET,
   ULTRA_TIER,
@@ -47,6 +48,10 @@ describe('relay tier model access', () => {
       SERVER_SIDE_PROVIDER_IDS.toSorted(),
       TIER_CONFIG.providers.toSorted(),
     );
+    assert.equal(Object.isFrozen(PROVIDER_CONFIGS), true);
+    for (const config of Object.values(PROVIDER_CONFIGS)) {
+      assert.equal(Object.isFrozen(config), true);
+    }
   });
 
   it('limits Max to non-Ultra providers and keeps Ultra passthrough', () => {

--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -72,6 +72,7 @@ import { cors } from '@hono/hono/cors';
 import { createClient } from '@supabase/supabase-js';
 import { resolveRelayCredential } from '../_shared/relayCiToken.ts';
 import {
+  PROVIDER_CONFIGS,
   TIER_CONFIG,
   TIER_SPENDING_LIMITS,
   getSpendingLimit,
@@ -179,76 +180,7 @@ const SKIP_RESPONSE_HEADERS = new Set([
 // Types
 // =============================================================================
 
-type AuthType = 'bearer' | 'x-api-key' | 'x-goog-api-key';
-
-interface ProviderConfig {
-  baseUrl: string;
-  envKey: string;
-  authType: AuthType;
-}
-
-type ProviderKey =
-  | 'openai'
-  | 'anthropic'
-  | 'google'
-  | 'xai'
-  | 'deepseek'
-  | 'moonshot'
-  | 'dashscope'
-  | 'minimax'
-  | 'glm';
-
-// =============================================================================
-// Provider Configuration
-// =============================================================================
-
-const PROVIDER_CONFIGS: Record<ProviderKey, ProviderConfig> = {
-  openai: {
-    baseUrl: 'https://api.openai.com',
-    envKey: 'OPENAI_API_KEY',
-    authType: 'bearer',
-  },
-  anthropic: {
-    baseUrl: 'https://api.anthropic.com',
-    envKey: 'ANTHROPIC_API_KEY',
-    authType: 'x-api-key',
-  },
-  google: {
-    baseUrl: 'https://generativelanguage.googleapis.com',
-    envKey: 'GOOGLE_API_KEY',
-    authType: 'x-goog-api-key',
-  },
-  xai: {
-    baseUrl: 'https://api.x.ai',
-    envKey: 'XAI_API_KEY',
-    authType: 'bearer',
-  },
-  deepseek: {
-    baseUrl: 'https://api.deepseek.com',
-    envKey: 'DEEPSEEK_API_KEY',
-    authType: 'bearer',
-  },
-  moonshot: {
-    baseUrl: 'https://api.moonshot.cn',
-    envKey: 'MOONSHOT_API_KEY',
-    authType: 'bearer',
-  },
-  dashscope: {
-    baseUrl: 'https://dashscope-intl.aliyuncs.com',
-    envKey: 'DASHSCOPE_API_KEY',
-    authType: 'bearer',
-  },
-  minimax: {
-    baseUrl: 'https://api.minimax.io',
-    envKey: 'MINIMAX_API_KEY',
-    authType: 'bearer',
-  },
-  glm: {
-    baseUrl: 'https://api.z.ai',
-    envKey: 'GLM_API_KEY',
-    authType: 'bearer',
-  },
-};
+type ProviderKey = keyof typeof PROVIDER_CONFIGS;
 
 // =============================================================================
 // Helper Functions

--- a/supabase/functions/relay/models.ts
+++ b/supabase/functions/relay/models.ts
@@ -64,6 +64,63 @@ export interface TierModelConfig {
 
 export type MinTier = 'free' | 'Max' | 'Ultra';
 
+type AuthType = 'bearer' | 'x-api-key' | 'x-goog-api-key';
+
+interface ProviderConfig {
+  baseUrl: string;
+  envKey: string;
+  authType: AuthType;
+}
+
+/** Provider routing metadata shared by relay discovery and forwarding. */
+export const PROVIDER_CONFIGS = {
+  openai: {
+    baseUrl: 'https://api.openai.com',
+    envKey: 'OPENAI_API_KEY',
+    authType: 'bearer',
+  },
+  anthropic: {
+    baseUrl: 'https://api.anthropic.com',
+    envKey: 'ANTHROPIC_API_KEY',
+    authType: 'x-api-key',
+  },
+  google: {
+    baseUrl: 'https://generativelanguage.googleapis.com',
+    envKey: 'GOOGLE_API_KEY',
+    authType: 'x-goog-api-key',
+  },
+  xai: {
+    baseUrl: 'https://api.x.ai',
+    envKey: 'XAI_API_KEY',
+    authType: 'bearer',
+  },
+  deepseek: {
+    baseUrl: 'https://api.deepseek.com',
+    envKey: 'DEEPSEEK_API_KEY',
+    authType: 'bearer',
+  },
+  moonshot: {
+    baseUrl: 'https://api.moonshot.cn',
+    envKey: 'MOONSHOT_API_KEY',
+    authType: 'bearer',
+  },
+  dashscope: {
+    baseUrl: 'https://dashscope-intl.aliyuncs.com',
+    envKey: 'DASHSCOPE_API_KEY',
+    authType: 'bearer',
+  },
+  minimax: {
+    baseUrl: 'https://api.minimax.io',
+    envKey: 'MINIMAX_API_KEY',
+    authType: 'bearer',
+  },
+  glm: {
+    baseUrl: 'https://api.z.ai',
+    envKey: 'GLM_API_KEY',
+    authType: 'bearer',
+  },
+} as const satisfies Record<string, ProviderConfig>;
+
 interface RelayModel {
   shortName: string;
   apiPattern: string;
@@ -127,17 +184,7 @@ function toRelayModel(config: ModelConfig): RelayModel {
 // =============================================================================
 
 // All providers the relay can actually forward to.
-const ALL_PROVIDERS = [
-  'openai',
-  'anthropic',
-  'google',
-  'deepseek',
-  'xai',
-  'moonshot',
-  'dashscope',
-  'minimax',
-  'glm',
-] as const;
+const ALL_PROVIDERS = Object.keys(PROVIDER_CONFIGS);
 const RELAY_PROVIDERS = new Set<string>(ALL_PROVIDERS);
 
 // Kimi Code membership models are pinned to Moonshot's coding endpoint and can

--- a/supabase/functions/relay/models.ts
+++ b/supabase/functions/relay/models.ts
@@ -73,53 +73,53 @@ interface ProviderConfig {
 }
 
 /** Provider routing metadata shared by relay discovery and forwarding. */
-export const PROVIDER_CONFIGS = {
-  openai: {
+export const PROVIDER_CONFIGS = Object.freeze({
+  openai: Object.freeze({
     baseUrl: 'https://api.openai.com',
     envKey: 'OPENAI_API_KEY',
     authType: 'bearer',
-  },
-  anthropic: {
+  }),
+  anthropic: Object.freeze({
     baseUrl: 'https://api.anthropic.com',
     envKey: 'ANTHROPIC_API_KEY',
     authType: 'x-api-key',
-  },
-  google: {
+  }),
+  google: Object.freeze({
     baseUrl: 'https://generativelanguage.googleapis.com',
     envKey: 'GOOGLE_API_KEY',
     authType: 'x-goog-api-key',
-  },
-  xai: {
+  }),
+  xai: Object.freeze({
     baseUrl: 'https://api.x.ai',
     envKey: 'XAI_API_KEY',
     authType: 'bearer',
-  },
-  deepseek: {
+  }),
+  deepseek: Object.freeze({
     baseUrl: 'https://api.deepseek.com',
     envKey: 'DEEPSEEK_API_KEY',
     authType: 'bearer',
-  },
-  moonshot: {
+  }),
+  moonshot: Object.freeze({
     baseUrl: 'https://api.moonshot.cn',
     envKey: 'MOONSHOT_API_KEY',
     authType: 'bearer',
-  },
-  dashscope: {
+  }),
+  dashscope: Object.freeze({
     baseUrl: 'https://dashscope-intl.aliyuncs.com',
     envKey: 'DASHSCOPE_API_KEY',
     authType: 'bearer',
-  },
-  minimax: {
+  }),
+  minimax: Object.freeze({
     baseUrl: 'https://api.minimax.io',
     envKey: 'MINIMAX_API_KEY',
     authType: 'bearer',
-  },
-  glm: {
+  }),
+  glm: Object.freeze({
     baseUrl: 'https://api.z.ai',
     envKey: 'GLM_API_KEY',
     authType: 'bearer',
-  },
-} as const satisfies Record<string, ProviderConfig>;
+  }),
+} as const satisfies Record<string, ProviderConfig>);
 
 interface RelayModel {
   shortName: string;


### PR DESCRIPTION
## Summary

Make the relay provider routing map the single source of truth for both request forwarding and advertised tier providers. Replace the client registry's comment-only synchronization rule with a test that compares its server-key providers to the relay set. The exported routing object and each nested provider entry are runtime-frozen so the shared source cannot be mutated by a consumer.

Closes #8885.

## Issue acceptance gates

- Relocates the pure `PROVIDER_CONFIGS` map to `models.ts`.
- Derives `ALL_PROVIDERS` from `Object.keys(PROVIDER_CONFIGS)`.
- Derives `ProviderKey` from `keyof typeof PROVIDER_CONFIGS`.
- Adds parity and immutability coverage in the existing `RelayModelAccess.vitest.ts` suite.
- Leaves `ULTRA_ONLY_PROVIDERS`, price gates, and Deno route fixtures unchanged.
- Keeps the Max-model deep-equality regression gate green.
- Acknowledges the static `TIER_CONFIG.providers` order normalization (`xai` before `deepseek`); the HTTP route already used routing-map order and all other consumers are order-insensitive.

## Single source of truth

`supabase/functions/relay/models.ts::PROVIDER_CONFIGS` now owns the relay provider set and routing metadata. Provider discovery, tier configuration, and request forwarding derive from that deeply frozen map.

## Duplication and abstraction budget

Deletes the independent nine-provider `ALL_PROVIDERS` literal and explicit nine-member `ProviderKey` union. No wrapper, facade, or pass-through layer was added; the routing data moved to the pure module already shared by relay configuration and tests.

## Net elements (R6)

- Files: 3 modified, 0 added, 0 deleted.
- Exported symbols: +1 `PROVIDER_CONFIGS`, consumed by `relay/index.ts`; no deleted exports.
- Classes/interfaces/enums: 0 net. `ProviderConfig` and `AuthType` relocate with the data; `ProviderKey` remains but becomes derived.
- Tests: +1 parity/immutability case in an existing file.
- Net LoC: -6 (75 additions, 81 deletions).

## Consumer counts (R8)

n/a for emit paths and export deletion. The new `PROVIDER_CONFIGS` export has one cross-file consumer (`relay/index.ts`); its provider set is also consumed locally by `models.ts`. The former routing map had three behavioral uses: enabled-provider discovery, provider lookup, and advertised relay providers; all now derive from the same object.

## Host impact

Extension: No behavior change; gains CI parity coverage for server-key provider metadata.

Desktop: No behavior change; gains the same shared parity coverage.

CLI: No behavior change.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm exec prettier --write src/test-kernel/supabase/RelayModelAccess.vitest.ts supabase/functions/relay/index.ts supabase/functions/relay/models.ts`
- `corepack pnpm exec vitest run src/test-kernel/supabase/RelayModelAccess.vitest.ts` (5 passed, including immutability assertions)
- `npm run typecheck`
- `npm run lint` (0 errors; 1 pre-existing unrelated warning)
- `npm run compile:fast`
- `npm run check:dead-code-ratchet`
- `npm test` on the first head before the runtime-freeze review fix (741 files passed, 1 skipped; 6,876 tests passed, 4 skipped)
- Deno route tests were not run locally because Deno is unavailable; the unchanged `providerTier_test.ts` fixture remains a required CI gate.
