### PR TITLE
refactor: align usage-log wire schema

### DIFF
--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -206,7 +206,6 @@ export class UsageMonitor {
         outputTokens: roundOutputTokens,
         cachedInputTokens: roundCacheReadTokens,
         cacheMissInputTokens: roundCacheMissTokens.billing,
-        cacheCreationInputTokens: roundCacheCreationTokens,
         reasoningTokens: roundReasoningTokens,
         cost: roundCost,
         usageRoute,
@@ -265,7 +264,6 @@ export class UsageMonitor {
       | 'inputTokens'
       | 'outputTokens'
       | 'cachedInputTokens'
-      | 'cacheCreationInputTokens'
       | 'reasoningTokens'
       | 'cost'
     > & { cacheMissInputTokens: number; usageRoute?: UsageRoute },
@@ -288,8 +286,6 @@ export class UsageMonitor {
         cost: roundTo(usage.cost, 6),
         responseTimeMs: Math.round(totalResponseTimeMs),
         cachedInputTokens,
-        cacheMissInputTokens: usage.cacheMissInputTokens,
-        cacheCreationInputTokens: usage.cacheCreationInputTokens ?? 0,
         reasoningTokens: usage.reasoningTokens ?? 0,
         usedRelay,
         ...(usage.usageRoute != null && { usageRoute: usage.usageRoute }),

--- a/src/telemetry/UsageLogTypes.ts
+++ b/src/telemetry/UsageLogTypes.ts
@@ -20,16 +20,13 @@ const UsageLogStatsSchema = z.object({
   cost: z.number().nonnegative(),
   responseTimeMs: z.number().nonnegative().optional(),
   cachedInputTokens: z.int().nonnegative().optional(),
-  cacheMissInputTokens: z.int().nonnegative().optional(),
-  cacheCreationInputTokens: z.int().nonnegative().optional(),
   reasoningTokens: z.int().nonnegative().optional(),
 });
 
 /**
  * Field names here intentionally follow this wire schema, not
- * `NormalizedUsage`'s (e.g. `cacheCreationInputTokens` vs.
- * `cacheCreationTokens`) — this is the persisted/billing log contract, so
- * renaming it isn't free. Callers building a log payload from
+ * `NormalizedUsage`'s — this is the persisted/billing log contract, so
+ * renaming fields isn't free. Callers building a log payload from
  * `NormalizedUsage` should type their intermediate object as (a `Pick` of)
  * `UsageLogStats` rather than hand-duplicating this field list.
  */


### PR DESCRIPTION
## Summary

Remove the two usage-log cache fields that the server schema has always stripped. The client continues to report cache-miss input as `inputTokens`, so billing and relay spend-cap accounting are unchanged.

The explicit product choice is delete versus add: either delete these client fields, or add corresponding server columns and a parity fence. This pull request takes the issue's default, deletion, because `cacheMissInputTokens` duplicates `inputTokens` byte-for-byte and no server-side cache-write analytics contract currently exists. If such analytics are wanted later, both halves should be introduced deliberately.

## Issue acceptance gates

Closes #8883.

- Deletes only the two client-transmitted fields absent from the server schema.
- Preserves the `cacheMissInputTokens` parameter that supplies canonical `inputTokens`.
- Preserves internal cache-read/cache-write usage fields and interface reporting.
- Requires no edge-function deployment.

## Single source of truth

`UsageLogStatsSchema` in `src/telemetry/UsageLogTypes.ts` remains the client wire contract and now agrees with the server's accepted field set.

## Duplication and abstraction budget

The redundant `cacheMissInputTokens` wire member and the silently discarded `cacheCreationInputTokens` wire member cease to exist. No abstraction or replacement field is added.

## Net elements (R6)

- Files: 0 added, 0 deleted.
- Exported symbols: 0 added, 0 deleted.
- Schema elements: 0 added, 2 deleted (`cacheMissInputTokens`, `cacheCreationInputTokens`).
- Net LoC: -7 (2 additions, 9 deletions).

## Consumer counts (R8)

- Server consumers of either deleted key: 0; `supabase/functions/log-usage/usageValidation.ts` accepts neither.
- Client wire construction sites: 1 for each field, both removed.
- Internal normalized-usage consumers are unchanged.

## Host impact

Extension: Usage logs omit two fields the server already discarded; accounting is unchanged.

Desktop: Same shared usage-log behavior as the extension.

CLI: Same shared usage-log behavior as the extension.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint` (passes with one pre-existing warning in `AgentCreatorToolCatalogParity.vitest.mts`)
- `npm run check:dead-code-ratchet`
- `npm test -- --run src/test-kernel/telemetry/UsageLogService.vitest.ts src/test-kernel/agent/runtime/UsageMonitorLastTotals.vitest.ts packages/cli/src/test/CliInitPlatform.vitest.mts` (14 tests passed; Vitest selected the two matching root suites)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema and payload cleanup only; canonical billing still uses `inputTokens` and internal cache resolution is unchanged.
> 
> **Overview**
> Aligns the client **usage-log wire contract** with what the server already accepts by removing **`cacheMissInputTokens`** and **`cacheCreationInputTokens`** from `UsageLogStatsSchema` and from the payload built in `UsageMonitor.logToBackend`.
> 
> **Billing and relay spend-cap behavior stay the same:** cache-miss input is still computed internally (`resolveRoundCacheMissTokens`) and sent as **`inputTokens`** on the log entry. UI/trace usage stats (including optional cache-read, cache-miss display, and cache-creation fields) are unchanged—only the redundant backend wire members are gone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea063e9f33f732e83c857a467bf16a004e9218e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->