### PR TITLE
refactor: delete client profile permissions

### DIFF
--- a/packages/cli/src/runtime/supabaseAuth.ts
+++ b/packages/cli/src/runtime/supabaseAuth.ts
@@ -276,7 +276,7 @@ export async function getCliSessionAccessToken(): Promise<string | null> {
  * env token's account instead.
  */
 export async function getCliSessionTier(): Promise<string> {
-  return (await SupabaseClient.getSessionAuthContext()).tier;
+  return SupabaseClient.getSessionAuthContext();
 }
 
 /**

--- a/packages/cli/src/runtime/supabaseAuth.ts
+++ b/packages/cli/src/runtime/supabaseAuth.ts
@@ -276,7 +276,7 @@ export async function getCliSessionAccessToken(): Promise<string | null> {
  * env token's account instead.
  */
 export async function getCliSessionTier(): Promise<string> {
-  return SupabaseClient.getSessionAuthContext();
+  return SupabaseClient.getSessionTier();
 }
 
 /**

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -5,18 +5,14 @@ import {
 } from '@supabase/supabase-js';
 import * as logger from '@logger/logUtils';
 import { ensureError, toErrorMessage } from '@utils/errors/errorMessage';
-import {
-  type UserAuthContext,
-  type UserTier,
-  UserAuthContextSchema,
-  TOKEN_REFRESH_THRESHOLD_MS,
-} from './config';
+import { type UserTier, TOKEN_REFRESH_THRESHOLD_MS } from './config';
 import {
   fetchRelayTokenStatus,
   getCachedRelayTokenState,
   getConfiguredRelayToken,
   markRelayTokenRejected,
 } from './relayToken';
+import { UserTierSchema } from './sharedConfig';
 import type { AuthTokenProvider, SessionTokens } from './TokenProvider';
 
 /**
@@ -292,16 +288,6 @@ export class SupabaseClient {
    * Returns the actual tier value: 'free', 'Max', or 'Ultra'.
    */
   static async getUserTier(): Promise<UserTier> {
-    const authContext = await this.getUserAuthContext();
-    return authContext.tier;
-  }
-
-  /**
-   * Get the user's authorization context including permissions.
-   * Permissions are visibility values the user can access.
-   * Tier is reserved for future API key access levels.
-   */
-  static async getUserAuthContext(): Promise<UserAuthContext> {
     // CI relay tokens are not GoTrue sessions, so the session profile query
     // can't run on them. The relay's tier-config endpoint resolves the token
     // to its owning user's tier — the only profile surface a relay-scoped
@@ -312,10 +298,7 @@ export class SupabaseClient {
       // A rejected token behaves as if unset (a stored session may still
       // provide the context); an unverifiable one gates conservatively.
       if (status.state !== 'invalid') {
-        return {
-          permissions: [],
-          tier: status.state === 'valid' ? status.tier : 'free',
-        };
+        return status.state === 'valid' ? status.tier : 'free';
       }
     }
 
@@ -323,16 +306,16 @@ export class SupabaseClient {
   }
 
   /**
-   * Authorization context from the stored GoTrue session only, ignoring any
+   * User tier from the stored GoTrue session only, ignoring any
    * configured CI relay token. Use when the operation itself runs on the
    * session (e.g. PostgREST usage reads), so its tier describes the account
    * whose data is being read rather than the relay credential.
    */
-  static async getSessionAuthContext(): Promise<UserAuthContext> {
-    const defaultContext: UserAuthContext = { permissions: [], tier: 'free' };
+  static async getSessionAuthContext(): Promise<UserTier> {
+    const defaultTier: UserTier = 'free';
 
     const tokens = await this.getSessionTokens();
-    if (!tokens) return defaultContext;
+    if (!tokens) return defaultTier;
 
     try {
       const client = this.getClient();
@@ -341,10 +324,10 @@ export class SupabaseClient {
         refresh_token: tokens.refreshToken,
       });
 
-      // Fetch tier and permissions from profiles
+      // Fetch the tier from profiles.
       const { data, error } = await client
         .from('profiles')
-        .select('tier, permissions')
+        .select('tier')
         .single();
 
       if (error || !data) {
@@ -352,26 +335,17 @@ export class SupabaseClient {
           'SupabaseClient',
           `Error fetching profile: ${error?.message || 'No data'}`,
         );
-        return defaultContext;
+        return defaultTier;
       }
 
-      // Parse with Zod schema - field-level .catch() preserves valid fields
-      return UserAuthContextSchema.parse(data);
+      return UserTierSchema.catch('free').parse(data.tier);
     } catch (error) {
       logger.error(
         'SupabaseClient',
-        `Error getting user auth context: ${toErrorMessage(error)}`,
+        `Error getting user tier: ${toErrorMessage(error)}`,
       );
-      return defaultContext;
+      return defaultTier;
     }
-  }
-
-  /**
-   * Get user's permissions as a flat array.
-   */
-  static async getUserPermissions(): Promise<string[]> {
-    const context = await this.getUserAuthContext();
-    return context.permissions;
   }
 
   /**

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -302,7 +302,7 @@ export class SupabaseClient {
       }
     }
 
-    return this.getSessionAuthContext();
+    return this.getSessionTier();
   }
 
   /**
@@ -311,7 +311,7 @@ export class SupabaseClient {
    * session (e.g. PostgREST usage reads), so its tier describes the account
    * whose data is being read rather than the relay credential.
    */
-  static async getSessionAuthContext(): Promise<UserTier> {
+  static async getSessionTier(): Promise<UserTier> {
     const defaultTier: UserTier = 'free';
 
     const tokens = await this.getSessionTokens();

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -6,12 +6,7 @@
  *
  * Similar to how GitHub Copilot works - users sign in to the official service.
  */
-import { z } from 'zod';
-import {
-  SUPABASE_CONFIG,
-  UserTierSchema,
-  type OAuthProvider,
-} from './sharedConfig';
+import { SUPABASE_CONFIG, type OAuthProvider } from './sharedConfig';
 export {
   AUTH_BRIDGE_URL,
   FREE_TIER,
@@ -37,30 +32,6 @@ export function isSupabaseConfigured(): boolean {
     !SUPABASE_CONFIG.url.includes('placeholder')
   );
 }
-
-// ============================================================================
-// User Groups & Permissions
-// ============================================================================
-
-/**
- * Permissions are just visibility values that the user can access.
- * E.g., ['researcher', 'math', 'cs'] means user can see agents with those visibility levels.
- * 'public' agents are always visible to authenticated users.
- *
- * Note: 'tier' column is reserved for future server-side API key access.
- */
-
-/**
- * User's authorization context.
- * Permissions are visibility values stored in profiles.permissions column.
- */
-export const UserAuthContextSchema = z.object({
-  /** Visibility values user can access: ['researcher', 'math', etc.] */
-  permissions: z.array(z.string()).catch([]),
-  /** User's tier (reserved for future API key access) */
-  tier: UserTierSchema.catch('free'),
-});
-export type UserAuthContext = z.infer<typeof UserAuthContextSchema>;
 
 /**
  * Default OAuth provider to use.

--- a/src/controllers/settingsView/ProfileMessageBuilder.ts
+++ b/src/controllers/settingsView/ProfileMessageBuilder.ts
@@ -60,7 +60,6 @@ export async function buildProfileMessage(
       authenticated: false,
       user: null,
       tier: FREE_TIER,
-      permissions: [],
       remoteAgents: [],
       apiAccessMode: 'personal',
       accessExpiresAt: null,
@@ -72,11 +71,8 @@ export async function buildProfileMessage(
   const user = await SupabaseClient.getUser();
 
   let tier = FREE_TIER;
-  let permissions: string[] = [];
   try {
-    const authContext = await SupabaseClient.getUserAuthContext();
-    tier = authContext.tier;
-    permissions = authContext.permissions;
+    tier = await SupabaseClient.getUserTier();
   } catch {
     // Keep the UI signed in even if profile metadata is temporarily unavailable.
   }
@@ -121,7 +117,6 @@ export async function buildProfileMessage(
     authenticated: true,
     user: { email: user?.email ?? 'N/A', id: user?.id ?? '' },
     tier,
-    permissions,
     remoteAgents,
     apiAccessMode,
     accessExpiresAt,

--- a/src/shared/schemas/profileViewMessages.ts
+++ b/src/shared/schemas/profileViewMessages.ts
@@ -101,7 +101,6 @@ export const UpdateProfileMessageSchema = z.object({
   authenticated: z.boolean(),
   user: ProfileUserSchema.nullable(),
   tier: z.string(),
-  permissions: z.array(z.string()),
   remoteAgents: z.array(RemoteAgentSchema),
   apiAccessMode: ApiAccessModeSchema,
   tierConstants: TierConstantsSchema,

--- a/src/test-kernel/cli/RelayTokens.vitest.mts
+++ b/src/test-kernel/cli/RelayTokens.vitest.mts
@@ -181,7 +181,7 @@ describe('TEXRA_RELAY_TOKEN consumption (CI relay tokens)', () => {
 
     // The resolved value itself must agree with the cache — not just the
     // cache in isolation — otherwise a caller that trusts the return value
-    // (getUserAuthContext, getCliAuthProfile) could still treat the
+    // (getUserTier, getCliAuthProfile) could still treat the
     // just-rejected token as usable.
     await expect(pending).resolves.toEqual({ state: 'invalid' });
 

--- a/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
@@ -178,10 +178,7 @@ function installAuthenticatedSupabaseProvider() {
     id: 'user-1',
     email: 'user@example.com',
   } as never);
-  vi.spyOn(SupabaseClient, 'getUserAuthContext').mockResolvedValue({
-    tier: 'free',
-    permissions: ['public'],
-  });
+  vi.spyOn(SupabaseClient, 'getUserTier').mockResolvedValue('free');
   return { ensureFreshToken };
 }
 
@@ -1050,7 +1047,6 @@ describe('desktop Supabase auth', () => {
       authenticated: true,
       user: { email: 'user@example.com', id: 'user-1' },
       tier: 'free',
-      permissions: ['public'],
       remoteAgents: [
         {
           name: 'remoteWriter',


### PR DESCRIPTION
## Summary

Delete the unused client-side profile-permissions concept and let `UserTier` be the complete result of tier lookup. The relay-token branch now lives directly in `SupabaseClient.getUserTier()`; session-only tier reads return `UserTier` without a wrapper object.

Product flag: `permissions` was documented as reserved for a future agent-visibility interface. This change deletes the client half of that possible feature. The database column and server-side row-level security remain untouched, so the concept is recoverable, but any future client interface must rebuild its contract deliberately.

## Issue acceptance gates

Closes #8875.

- Deletes `SupabaseClient.getUserPermissions`, which had no callers.
- Merges `SupabaseClient.getUserAuthContext` into `getUserTier`.
- Deletes `UserAuthContextSchema` and `UserAuthContext`.
- Removes `permissions` from `UpdateProfileMessageSchema` and both profile-message branches.
- Changes the profiles query from `tier, permissions` to `tier`.
- Retypes `getSessionAuthContext` to return `UserTier`.
- Leaves server RLS and the database column unchanged.

## Single source of truth

`SupabaseClient.getUserTier()` is now the sole public tier lookup spanning relay credentials and stored sessions. `UserTierSchema` remains the tier validation source.

## Duplication and abstraction budget

The authorization-context wrapper and its unused permissions path cease to exist. No replacement abstraction is introduced.

## Net elements (R6)

- Files: 0 added, 0 deleted.
- Exported symbols: 0 added, 2 deleted (`UserAuthContextSchema`, `UserAuthContext`).
- Other named elements: 3 deleted (`getUserPermissions`, `getUserAuthContext`, and the `UpdateProfileMessageSchema.permissions` field).
- Net elements: -5.
- Net LoC: -65 (18 additions, 83 deletions).

The profiles select-column change is an edit, not an element deletion.

## Consumer counts (R8)

- `getUserPermissions`: 0 callers before deletion.
- `UpdateProfileMessage.permissions`: 1 producer and 0 readers; the producer is removed.
- `getSessionAuthContext`: 1 external production caller, updated to consume the returned tier directly.
- `getUserAuthContext`: its live tier consumers are redirected to `getUserTier`; the remaining consumer was the deleted `getUserPermissions`.

## Host impact

Extension: Profile updates no longer carry the unread permissions field; tier and server-side authorization behavior are unchanged.

Desktop: The shared profile builder now reads `getUserTier` directly; its authenticated-profile test is updated.

CLI: Session-only tier lookup consumes `UserTier` directly. Relay-token tier behavior is preserved.

## Scheduled refactoring

None.

## Validation

- `corepack pnpm install --config.confirmModulesPurge=false`
- `npm run format`
- `npm run typecheck`
- `npm run lint` (passes with one pre-existing warning in `AgentCreatorToolCatalogParity.vitest.mts`)
- `npm run check:dead-code-ratchet`
- `npm test -- --run src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts src/test-kernel/cli/RelayTokens.vitest.mts` (42 tests passed)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletes dead client APIs and narrows profile payloads; tier and relay-token behavior stay the same with no auth or server policy changes.
> 
> **Overview**
> **Removes the unused client-side profile `permissions` path** and makes **`UserTier` the only result of tier lookup** across relay tokens and GoTrue sessions.
> 
> `SupabaseClient.getUserAuthContext()`, `getUserPermissions()`, and `UserAuthContext` / `UserAuthContextSchema` are deleted. **`getUserTier()`** now owns relay-token tier resolution and session fallback; **`getSessionAuthContext()`** is renamed to **`getSessionTier()`** and returns `UserTier` directly. The profiles query changes from `tier, permissions` to **`tier` only**, validated with `UserTierSchema`.
> 
> **Profile UI wire format:** `permissions` is dropped from `UpdateProfileMessageSchema` and from `buildProfileMessage` (authenticated and signed-out branches). **CLI** `getCliSessionTier()` calls `getSessionTier()` instead of the old session auth context helper. Tests are updated to mock `getUserTier` and no longer expect `permissions` on profile messages.
> 
> Server RLS and the database `permissions` column are **unchanged**; only the client contract is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79c44280aa743715a2ec4f8380b1d24df8896c10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->