### PR TITLE
refactor(auth): delete redundant provider seams

### DIFF
--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -3,6 +3,7 @@ import { defineCommand, showUsage } from 'citty';
 import { platform } from '@platform/platform';
 import { getVisibleAgents } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { SupabaseClient } from '@auth/SupabaseClient';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { getFirstRunDone } from '@shared/state/onboardingState';
 
@@ -56,11 +57,7 @@ import {
   chatGptSignOutPreferenceMessage,
   signOutCliChatGpt,
 } from '../runtime/chatgptLogin';
-import {
-  getCliAuthProfile,
-  getCliAuthProvider,
-  signOutCliSupabase,
-} from '../runtime/supabaseAuth';
+import { getCliAuthProfile, signOutCliSupabase } from '../runtime/supabaseAuth';
 
 import { contextFromArgs } from './_helpers/context';
 import { withUsageSections } from './_helpers/dispatch';
@@ -220,7 +217,7 @@ async function runOrchestration(context: CliContext): Promise<number> {
       teamItems: buildCliTeamItems(presetPlanSet.plans, {
         includeLoginHint: !presetPlanSet.remoteAgentLoadAttempted,
         remoteAgentCatalogAvailable:
-          await getCliAuthProvider().canAccessRemoteAgentCatalog(),
+          await SupabaseClient.canAccessRemoteAgentCatalog(),
         launchBlockReason:
           launchContext.approvalPolicy === 'never'
             ? 'delegation-denied'
@@ -259,7 +256,7 @@ async function runOrchestration(context: CliContext): Promise<number> {
           plan: initialPlan,
           remoteCatalogRefreshAttempted: presetPlanSet.remoteAgentLoadAttempted,
           canAccessRemoteCatalog: () =>
-            getCliAuthProvider().canAccessRemoteAgentCatalog(),
+            SupabaseClient.canAccessRemoteAgentCatalog(),
           choose: async (names) => {
             writeTextStderr(
               `Team ${action.preset} has unavailable TeXRA-hosted members: ${names.join(', ')}.`,
@@ -282,7 +279,7 @@ async function runOrchestration(context: CliContext): Promise<number> {
             );
             return (
               code === CliExitCode.Success &&
-              (await getCliAuthProvider().canAccessRemoteAgentCatalog())
+              (await SupabaseClient.canAccessRemoteAgentCatalog())
             );
           },
           refresh: async () =>

--- a/packages/cli/src/runtime/agents.ts
+++ b/packages/cli/src/runtime/agents.ts
@@ -6,10 +6,10 @@ import {
 } from '@agent/index';
 import type { AgentEntry } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { SupabaseClient } from '@auth/SupabaseClient';
 import { formatResultCount } from '@utils/text/stringUtils';
 
 import { CliUsageError } from './cliContext';
-import { getCliAuthProvider } from './supabaseAuth';
 
 export interface CliAgentListOptions {
   readonly includeHidden?: boolean;
@@ -135,7 +135,7 @@ export async function resolveCliAgent(
 
   if (
     name.includes(':') ||
-    !(await getCliAuthProvider().canAccessRemoteAgentCatalog())
+    !(await SupabaseClient.canAccessRemoteAgentCatalog())
   ) {
     return agent;
   }

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -29,6 +29,7 @@ import {
   getServerSideKeyService,
   initializeServerSideKeyAccess,
 } from '@auth/serverKeys';
+import { SupabaseClient } from '@auth/SupabaseClient';
 
 // Local imports - logger
 import { setOutputChannelFactory } from '@logger/logUtils';
@@ -54,11 +55,7 @@ import { isCliResumeInFlight, tryResumeCliStream } from './agentResume';
 import { getCliSecrets } from './cliSecrets';
 import { isTexraCliEntrypointPath, readCliEntrypointPath } from './cliContext';
 import { flushNdjsonStdout, writeTextStderr } from './logSinks';
-import {
-  getCliAuthProvider,
-  initializeCliSupabaseAuth,
-  signInCliSupabase,
-} from './supabaseAuth';
+import { initializeCliSupabaseAuth, signInCliSupabase } from './supabaseAuth';
 import { createCliStateStores } from './cliStateStores';
 import { CliExitCode } from './exitCodes';
 
@@ -339,10 +336,10 @@ export async function initCliPlatform(
 
   if (!serverSideKeysInitialized) {
     initializeCliSupabaseAuth(cliPlatformLog, context.storageRoot);
-    initializeServerSideKeyAccess(
-      { state: tryPlatform()?.globalState, logger: cliPlatformLog },
-      getCliAuthProvider(),
-    );
+    initializeServerSideKeyAccess({
+      state: tryPlatform()?.globalState,
+      logger: cliPlatformLog,
+    });
     serverSideKeysInitialized = true;
   }
 
@@ -350,7 +347,7 @@ export async function initCliPlatform(
     host: 'cli',
     signIn: async () => {
       await signInCliSupabase({ openBrowser: true });
-      return getCliAuthProvider().canAccessRemoteAgentCatalog();
+      return SupabaseClient.canAccessRemoteAgentCatalog();
     },
   });
 
@@ -370,7 +367,7 @@ export async function initCliPlatform(
   let authed = false;
   if (!forcePersonalApiKeys) {
     try {
-      authed = await getCliAuthProvider().isAuthenticated();
+      authed = await SupabaseClient.isAuthenticated();
     } catch (error) {
       if (context.bestEffortIncludedModelAccess !== true) throw error;
       logAt(

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -1,3 +1,6 @@
+// Local imports - auth
+import { SupabaseClient } from '@auth/SupabaseClient';
+
 // Local imports - model surfaces
 import { computeModelOptionsData } from '@model/computeModelOptions';
 import {
@@ -9,7 +12,6 @@ import type { ModelAvailabilityKind, ModelOptionData } from '@shared/schemas';
 import type { AgentCategory } from '@shared/schemas/agent';
 
 import { resolveKnownCliModelId } from './cliConfig';
-import { getCliAuthProvider } from './supabaseAuth';
 import type { CliApiMode } from './apiAccessMode';
 
 export interface CliModelAccess {
@@ -377,9 +379,9 @@ async function includedAccessRequiresLogin(
 ): Promise<boolean> {
   if (options.apiMode !== 'included') return false;
   // An auth-state read failure means we can't prove a session, so require login.
-  const authenticated = await getCliAuthProvider()
-    .isAuthenticated()
-    .catch(() => false);
+  const authenticated = await SupabaseClient.isAuthenticated().catch(
+    () => false,
+  );
   return !authenticated;
 }
 

--- a/packages/cli/src/runtime/multiAgentRunPlan.ts
+++ b/packages/cli/src/runtime/multiAgentRunPlan.ts
@@ -1,5 +1,6 @@
 import { getAgentsByCategory, loadAgents, refresh } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { SupabaseClient } from '@auth/SupabaseClient';
 
 import { missingMultiAgentPresetMessage } from './agents';
 import { CliUsageError } from './cliContext';
@@ -14,7 +15,6 @@ import {
   type CliMultiAgentPreset,
   type CliMultiAgentPresetRunPlan,
 } from './multiAgentPresets';
-import { getCliAuthProvider } from './supabaseAuth';
 
 interface MultiAgentRunPlanInit {
   readonly preset: string;
@@ -116,10 +116,7 @@ async function reloadRemoteAgentsForGaps<T>(
   hasGaps: (value: T) => boolean,
   replan: () => T,
 ): Promise<RemoteAgentPlanReloadResult<T>> {
-  if (
-    hasGaps(value) &&
-    (await getCliAuthProvider().canAccessRemoteAgentCatalog())
-  ) {
+  if (hasGaps(value) && (await SupabaseClient.canAccessRemoteAgentCatalog())) {
     await refresh({ includeRemote: true });
     return { value: replan(), remoteAgentLoadAttempted: true };
   }

--- a/packages/cli/src/runtime/supabaseAuth.ts
+++ b/packages/cli/src/runtime/supabaseAuth.ts
@@ -95,14 +95,6 @@ const deferredAuthLog: LogBackend = {
   warn: (channel, message) => activeAuthLog?.warn(channel, message),
   error: (channel, message) => activeAuthLog?.error(channel, message),
 };
-const cliAuthProvider = {
-  isAuthenticated: () => SupabaseClient.isAuthenticated(),
-  canAccessRemoteAgentCatalog: () =>
-    SupabaseClient.canAccessRemoteAgentCatalog(),
-  getUserTier: () => SupabaseClient.getUserTier(),
-  getAccessToken: () => SupabaseClient.getRelayAccessToken(),
-};
-
 function getCliSupabaseAuthCoordinator(): SupabaseSessionCoordinator {
   return initializeCliSupabaseAuth();
 }
@@ -121,10 +113,6 @@ export function initializeCliSupabaseAuth(
     coordinatorSecrets = secrets;
   }
   return coordinator;
-}
-
-export function getCliAuthProvider() {
-  return cliAuthProvider;
 }
 
 export async function signInCliSupabase(

--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -422,17 +422,10 @@ export function createDesktopAuthCoordinator(options: {
 export function initializeDesktopServerSideKeyAccess(
   log: DesktopAuthLog,
 ): void {
-  initializeServerSideKeyAccess(
-    {
-      state: platform().globalState,
-      logger: createAuthServiceLogger(log),
-    },
-    {
-      isAuthenticated: () => SupabaseClient.isAuthenticated(),
-      getUserTier: () => SupabaseClient.getUserTier(),
-      getAccessToken: () => SupabaseClient.getRelayAccessToken(),
-    },
-  );
+  initializeServerSideKeyAccess({
+    state: platform().globalState,
+    logger: createAuthServiceLogger(log),
+  });
 }
 
 function clearDesktopServerSideKeyCaches(log: DesktopAuthLog): void {

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -312,18 +312,11 @@ export async function activate(context: vscode.ExtensionContext) {
   lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () => disposeDiffRefresh());
   await StorageFS.ensureDir(RUNS_STORAGE_DIR);
   FileLister.initialize(context);
-  initializeServerSideKeyAccess(
-    {
-      state: context.globalState,
-      subscriptions: context.subscriptions,
-      logger,
-    },
-    {
-      isAuthenticated: () => SupabaseClient.isAuthenticated(),
-      getUserTier: () => SupabaseClient.getUserTier(),
-      getAccessToken: () => SupabaseClient.getRelayAccessToken(),
-    },
-  );
+  initializeServerSideKeyAccess({
+    state: context.globalState,
+    subscriptions: context.subscriptions,
+    logger,
+  });
 
   // Seed first-install defaults (e.g. disabled tools) before anything writes
   // LAST_KNOWN_VERSION, so upgrading users are not affected.

--- a/src/auth/serverKeys/ServerSideKeyService.ts
+++ b/src/auth/serverKeys/ServerSideKeyService.ts
@@ -16,6 +16,7 @@
 
 import { EventEmitter } from 'node:events';
 import { toErrorMessage } from '@utils/errors/errorMessage';
+import { SupabaseClient } from '../SupabaseClient';
 import {
   SERVER_SIDE_CACHE_TTL_MS,
   ULTRA_TIER,
@@ -47,15 +48,6 @@ const RELAY_PATH_SUFFIXES: Partial<Record<ServerSideProvider, string>> = {
 const USE_INCLUDED_ACCESS_KEY = 'texra.useIncludedModelAccess';
 
 const SERVICE_EVENT = 'event';
-
-/**
- * Interface for authentication provider that can check auth state and get user tier.
- */
-export interface AuthProvider {
-  isAuthenticated(): Promise<boolean>;
-  getUserTier(): Promise<UserTier>;
-  getAccessToken(): Promise<string | null>;
-}
 
 export interface ServerSideKeyDisposable {
   dispose(): void;
@@ -164,7 +156,6 @@ export class ServerSideKeyService {
 
   constructor(
     private readonly baseUrl: string,
-    private readonly authProvider: AuthProvider,
     private readonly tierService: TierService,
     private readonly logger: AuthServiceLogger = NOOP_AUTH_SERVICE_LOGGER,
   ) {
@@ -275,10 +266,10 @@ export class ServerSideKeyService {
 
   private async fetchAccessStatus(): Promise<boolean> {
     try {
-      if (!(await this.authProvider.isAuthenticated())) {
+      if (!(await SupabaseClient.isAuthenticated())) {
         return this.setAccessDenied();
       }
-      const tier = await this.authProvider.getUserTier();
+      const tier = await SupabaseClient.getUserTier();
       this.accessResult = true;
       this.userTier = tier || FREE_TIER;
       return true;
@@ -317,7 +308,8 @@ export class ServerSideKeyService {
     }
 
     this.accessFetchPromise = (async () => {
-      const authToken = (await this.authProvider.getAccessToken()) ?? undefined;
+      const authToken =
+        (await SupabaseClient.getRelayAccessToken()) ?? undefined;
 
       const [hasAccess, tierConfig] = await Promise.all([
         this.fetchAccessStatus(),

--- a/src/auth/serverKeys/index.ts
+++ b/src/auth/serverKeys/index.ts
@@ -17,7 +17,6 @@ import { SUPABASE_CUSTOM_DOMAIN } from '../sharedConfig';
 import { getTierService } from '../tier';
 import {
   ServerSideKeyService,
-  type AuthProvider,
   type ServerSideKeyServiceInit,
 } from './ServerSideKeyService';
 
@@ -25,7 +24,7 @@ import {
 export { SERVER_SIDE_PROVIDERS, type ServerSideProvider } from './types';
 
 // Service class
-export { ServerSideKeyService, type AuthProvider };
+export { ServerSideKeyService };
 
 // ==========================================================================
 // Singleton Instance
@@ -58,15 +57,12 @@ export function setServerSideKeyService(service: ServerSideKeyService): void {
  * Call this during extension activation.
  *
  * @param options - Host-provided state and subscriptions
- * @param authProvider - Provider for authentication state checks
  */
 export function initializeServerSideKeyAccess(
   options: ServerSideKeyServiceInit,
-  authProvider: AuthProvider,
 ): void {
   _instance = new ServerSideKeyService(
     `https://${SUPABASE_CUSTOM_DOMAIN}`,
-    authProvider,
     getTierService(options.logger),
     options.logger,
   );

--- a/src/test-kernel/auth/ServerSideKeyService.vitest.ts
+++ b/src/test-kernel/auth/ServerSideKeyService.vitest.ts
@@ -1,11 +1,11 @@
 // Third-party imports
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - auth
-import { FREE_TIER, ULTRA_TIER, type UserTier } from '@auth/config';
+import { ULTRA_TIER } from '@auth/config';
+import { SupabaseClient } from '@auth/SupabaseClient';
 import {
   ServerSideKeyService,
-  type AuthProvider,
   type ServerSideKeyState,
 } from '@auth/serverKeys/ServerSideKeyService';
 import type { TierService } from '@auth/tier/TierService';
@@ -94,20 +94,6 @@ function createTierService(
   };
 }
 
-function createAuthProvider(
-  options: {
-    authenticated?: boolean;
-    tier?: UserTier;
-    accessToken?: string | null;
-  } = {},
-): AuthProvider {
-  return {
-    isAuthenticated: async () => options.authenticated ?? false,
-    getUserTier: async (): Promise<UserTier> => options.tier ?? FREE_TIER,
-    getAccessToken: async () => options.accessToken ?? null,
-  };
-}
-
 function createQuotaExceededSetup(): {
   state: MemoryState;
   tier: FakeTierService;
@@ -118,13 +104,11 @@ function createQuotaExceededSetup(): {
     providers: ['openai'],
     quotaExceeded: true,
   });
+  vi.spyOn(SupabaseClient, 'isAuthenticated').mockResolvedValue(true);
+  vi.spyOn(SupabaseClient, 'getUserTier').mockResolvedValue(ULTRA_TIER);
+  vi.spyOn(SupabaseClient, 'getRelayAccessToken').mockResolvedValue('token');
   const service = new ServerSideKeyService(
     'https://example.test',
-    createAuthProvider({
-      authenticated: true,
-      tier: ULTRA_TIER,
-      accessToken: 'token',
-    }),
     tier.service,
   );
 
@@ -134,6 +118,10 @@ function createQuotaExceededSetup(): {
 }
 
 describe('ServerSideKeyService quota fallback', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('does not repeat the quota auto-switch after manual re-enable', async () => {
     const { service } = createQuotaExceededSetup();
 

--- a/src/test-kernel/auth/ServerSideKeyServiceSettings.vitest.ts
+++ b/src/test-kernel/auth/ServerSideKeyServiceSettings.vitest.ts
@@ -5,11 +5,9 @@ import { describe, it } from 'vitest';
 // Standard library imports
 
 // Local imports - auth
-import { FREE_TIER, type UserTier } from '@auth/config';
 import type { AuthServiceLogger } from '@auth/serviceLogger';
 import {
   ServerSideKeyService,
-  type AuthProvider,
   type ServerSideKeyState,
 } from '@auth/serverKeys/ServerSideKeyService';
 import type { TierService } from '@auth/tier/TierService';
@@ -84,24 +82,11 @@ function createTierService(): FakeTierService {
   };
 }
 
-function createAuthProvider(): AuthProvider {
-  return {
-    isAuthenticated: async () => false,
-    getUserTier: async (): Promise<UserTier> => FREE_TIER,
-    getAccessToken: async () => null,
-  };
-}
-
 function createService(
   tierService: TierService,
   logger?: AuthServiceLogger,
 ): ServerSideKeyService {
-  return new ServerSideKeyService(
-    'https://example.test',
-    createAuthProvider(),
-    tierService,
-    logger,
-  );
+  return new ServerSideKeyService('https://example.test', tierService, logger);
 }
 
 describe('ServerSideKeyService', () => {

--- a/src/test-kernel/cli/AgentResolution.vitest.mts
+++ b/src/test-kernel/cli/AgentResolution.vitest.mts
@@ -2,12 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { AgentEntry } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { SupabaseClient } from '@auth/SupabaseClient';
 
 const mocks = vi.hoisted(() => ({
-  authProvider: {
-    isAuthenticated: vi.fn(),
-    canAccessRemoteAgentCatalog: vi.fn(),
-  },
   getAgent: vi.fn(),
   getAgentsByCategory: vi.fn(),
   getVisibleAgents: vi.fn(),
@@ -21,9 +18,11 @@ vi.mock('@agent/index', () => ({
   loadAgents: mocks.loadAgents,
 }));
 
-vi.mock('@cli/runtime/supabaseAuth', () => ({
-  getCliAuthProvider: () => mocks.authProvider,
-}));
+const isAuthenticatedSpy = vi.spyOn(SupabaseClient, 'isAuthenticated');
+const canAccessRemoteAgentCatalogSpy = vi.spyOn(
+  SupabaseClient,
+  'canAccessRemoteAgentCatalog',
+);
 
 function agent(
   name: string,
@@ -40,10 +39,10 @@ function agent(
 
 describe('CLI agent resolution', () => {
   beforeEach(() => {
-    mocks.authProvider.isAuthenticated.mockReset();
-    mocks.authProvider.isAuthenticated.mockResolvedValue(false);
-    mocks.authProvider.canAccessRemoteAgentCatalog.mockReset();
-    mocks.authProvider.canAccessRemoteAgentCatalog.mockResolvedValue(false);
+    isAuthenticatedSpy.mockReset();
+    isAuthenticatedSpy.mockResolvedValue(false);
+    canAccessRemoteAgentCatalogSpy.mockReset();
+    canAccessRemoteAgentCatalogSpy.mockResolvedValue(false);
     mocks.getAgent.mockReset();
     mocks.getAgentsByCategory.mockReset();
     mocks.getVisibleAgents.mockReset();
@@ -59,9 +58,7 @@ describe('CLI agent resolution', () => {
 
     expect(mocks.loadAgents).toHaveBeenCalledOnce();
     expect(mocks.loadAgents).toHaveBeenCalledWith({ includeRemote: false });
-    expect(
-      mocks.authProvider.canAccessRemoteAgentCatalog,
-    ).toHaveBeenCalledOnce();
+    expect(canAccessRemoteAgentCatalogSpy).toHaveBeenCalledOnce();
   });
 
   it('does a full registry load when the local registry misses', async () => {
@@ -75,15 +72,13 @@ describe('CLI agent resolution', () => {
       includeRemote: false,
     });
     expect(mocks.loadAgents).toHaveBeenNthCalledWith(2);
-    expect(
-      mocks.authProvider.canAccessRemoteAgentCatalog,
-    ).not.toHaveBeenCalled();
+    expect(canAccessRemoteAgentCatalogSpy).not.toHaveBeenCalled();
   });
 
   it('does not treat relay-only model access as remote-catalog access', async () => {
     const local = agent('lean');
-    mocks.authProvider.isAuthenticated.mockResolvedValue(true);
-    mocks.authProvider.canAccessRemoteAgentCatalog.mockResolvedValue(false);
+    isAuthenticatedSpy.mockResolvedValue(true);
+    canAccessRemoteAgentCatalogSpy.mockResolvedValue(false);
     mocks.getAgent.mockReturnValue(local);
     const { resolveCliAgent } = await import('@cli/runtime/agents');
 
@@ -93,13 +88,13 @@ describe('CLI agent resolution', () => {
     expect(mocks.loadAgents).toHaveBeenCalledWith({
       includeRemote: false,
     });
-    expect(mocks.authProvider.isAuthenticated).not.toHaveBeenCalled();
+    expect(isAuthenticatedSpy).not.toHaveBeenCalled();
   });
 
   it('uses launch target category for authenticated remote-priority reloads', async () => {
     const local = agent('lean');
     const remote = agent('lean', 'remote');
-    mocks.authProvider.canAccessRemoteAgentCatalog.mockResolvedValue(true);
+    canAccessRemoteAgentCatalogSpy.mockResolvedValue(true);
     mocks.getAgent.mockReturnValueOnce(local).mockReturnValueOnce(remote);
     const { resolveCliLaunchAgent } = await import('@cli/runtime/agents');
 
@@ -123,7 +118,7 @@ describe('CLI agent resolution', () => {
 
   it('does not apply remote priority to source-qualified agent names', async () => {
     const local = agent('local:lean');
-    mocks.authProvider.canAccessRemoteAgentCatalog.mockResolvedValue(true);
+    canAccessRemoteAgentCatalogSpy.mockResolvedValue(true);
     mocks.getAgent.mockReturnValue(local);
     const { resolveCliAgent } = await import('@cli/runtime/agents');
 
@@ -131,9 +126,7 @@ describe('CLI agent resolution', () => {
 
     expect(mocks.loadAgents).toHaveBeenCalledOnce();
     expect(mocks.loadAgents).toHaveBeenCalledWith({ includeRemote: false });
-    expect(
-      mocks.authProvider.canAccessRemoteAgentCatalog,
-    ).not.toHaveBeenCalled();
+    expect(canAccessRemoteAgentCatalogSpy).not.toHaveBeenCalled();
   });
 
   it('uses launch target category for local and remote-fallback lookups', async () => {

--- a/src/test-kernel/cli/AgentsRunCommand.vitest.mts
+++ b/src/test-kernel/cli/AgentsRunCommand.vitest.mts
@@ -11,7 +11,6 @@ const mocks = vi.hoisted(() => ({
   executeCliToolUseConfig: vi.fn(),
   withExpandedRunInputs: vi.fn(),
   initLocalCliPlatform: vi.fn(),
-  isAuthenticated: vi.fn(),
   resolveCliLaunchAgent: vi.fn(),
   selectCliRunModel: vi.fn(),
   writeErrorStderr: vi.fn(),
@@ -35,12 +34,6 @@ vi.mock('@agent/storage', () => ({
 
 vi.mock('@cli/runtime/initPlatform', () => ({
   initLocalCliPlatform: mocks.initLocalCliPlatform,
-}));
-
-vi.mock('@cli/runtime/supabaseAuth', () => ({
-  getCliAuthProvider: () => ({
-    isAuthenticated: mocks.isAuthenticated,
-  }),
 }));
 
 vi.mock('@cli/runtime/runModel', () => ({

--- a/src/test-kernel/cli/CliInitPlatform.vitest.mts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.mts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // Local imports
 import { UsageLogService } from '@telemetry/UsageLogService';
 import { resolveAndResumeStream } from '@agent/runtime/resolveAndResumeStream';
+import { SupabaseClient } from '@auth/SupabaseClient';
 import { setCliAgentResumeHandler } from '@cli/runtime/agentResume';
 import { initCliPlatform } from '@cli/runtime/initPlatform';
 import { setOutputChannelFactory } from '@logger/logUtils';
@@ -69,10 +70,6 @@ function spyOnSignalRegistration(): {
 }
 
 const mocks = vi.hoisted(() => ({
-  authProvider: {
-    isAuthenticated: vi.fn(),
-    canAccessRemoteAgentCatalog: vi.fn(),
-  },
   signInCliSupabase: vi.fn(),
   bootstrapNodeAgentDirectories: vi.fn(),
   createPlatformAgentDirectories: vi.fn(() => ({
@@ -107,7 +104,6 @@ vi.mock('@auth/serverKeys', () => ({
 }));
 
 vi.mock('@cli/runtime/supabaseAuth', () => ({
-  getCliAuthProvider: () => mocks.authProvider,
   initializeCliSupabaseAuth: mocks.initializeCliSupabaseAuth,
   signInCliSupabase: mocks.signInCliSupabase,
 }));
@@ -193,6 +189,12 @@ vi.mock('@tools/lean/direct/directLspAdapter', () => ({
   registerDirectLeanLanguageServices: vi.fn(),
 }));
 
+const isAuthenticatedSpy = vi.spyOn(SupabaseClient, 'isAuthenticated');
+const canAccessRemoteAgentCatalogSpy = vi.spyOn(
+  SupabaseClient,
+  'canAccessRemoteAgentCatalog',
+);
+
 function cliContext(
   overrides: Partial<Parameters<typeof initCliPlatform>[0]> = {},
 ): Parameters<typeof initCliPlatform>[0] {
@@ -218,7 +220,8 @@ describe('CLI platform init', () => {
       },
     });
     mocks.bootstrapNodeAgentDirectories.mockResolvedValue(undefined);
-    mocks.authProvider.canAccessRemoteAgentCatalog.mockResolvedValue(false);
+    isAuthenticatedSpy.mockResolvedValue(false);
+    canAccessRemoteAgentCatalogSpy.mockResolvedValue(false);
     mocks.serverSideKeyService.setUseIncludedModelAccess.mockResolvedValue(
       undefined,
     );
@@ -226,7 +229,7 @@ describe('CLI platform init', () => {
 
   it('uses the configured storage root for CLI secrets', async () => {
     mocks.tryPlatform.mockReturnValueOnce(undefined);
-    mocks.authProvider.isAuthenticated.mockResolvedValue(false);
+    isAuthenticatedSpy.mockResolvedValue(false);
 
     await initCliPlatform(
       cliContext({
@@ -252,7 +255,7 @@ describe('CLI platform init', () => {
     };
     mocks.tryPlatform.mockReturnValue({ globalState });
     mocks.tryPlatform.mockReturnValueOnce(undefined);
-    mocks.authProvider.isAuthenticated.mockResolvedValue(false);
+    isAuthenticatedSpy.mockResolvedValue(false);
 
     await initCliPlatform(
       cliContext({ version: '1.2.3', installSignalHandlers: false }),
@@ -271,7 +274,7 @@ describe('CLI platform init', () => {
   });
 
   it('marks the operator-terminal console sink as trusted', async () => {
-    mocks.authProvider.isAuthenticated.mockResolvedValue(false);
+    isAuthenticatedSpy.mockResolvedValue(false);
 
     await initCliPlatform(cliContext({ quietLogs: false }));
 
@@ -282,7 +285,7 @@ describe('CLI platform init', () => {
 
   it('installs a CLI agent resume port that delegates to the active handler', async () => {
     mocks.tryPlatform.mockReturnValueOnce(undefined);
-    mocks.authProvider.isAuthenticated.mockResolvedValue(false);
+    isAuthenticatedSpy.mockResolvedValue(false);
 
     await initCliPlatform(cliContext({ installSignalHandlers: false }));
 
@@ -345,7 +348,7 @@ describe('CLI platform init', () => {
       update: vi.fn().mockResolvedValue(undefined),
     };
     mocks.tryPlatform.mockReturnValue({ globalState });
-    mocks.authProvider.isAuthenticated.mockResolvedValueOnce(false);
+    isAuthenticatedSpy.mockResolvedValueOnce(false);
 
     await initCliPlatform(
       cliContext({
@@ -366,9 +369,7 @@ describe('CLI platform init', () => {
   });
 
   it('surfaces included-access auth probe failures by default', async () => {
-    mocks.authProvider.isAuthenticated.mockRejectedValueOnce(
-      new Error('auth offline'),
-    );
+    isAuthenticatedSpy.mockRejectedValueOnce(new Error('auth offline'));
 
     await expect(initCliPlatform(cliContext())).rejects.toThrow('auth offline');
     expect(
@@ -377,9 +378,7 @@ describe('CLI platform init', () => {
   });
 
   it('lets launcher init treat auth probe failures as no included access', async () => {
-    mocks.authProvider.isAuthenticated.mockRejectedValueOnce(
-      new Error('auth offline'),
-    );
+    isAuthenticatedSpy.mockRejectedValueOnce(new Error('auth offline'));
 
     await expect(
       initCliPlatform(cliContext({ bestEffortIncludedModelAccess: true })),
@@ -397,11 +396,11 @@ describe('CLI platform init', () => {
       update: vi.fn(),
     };
     mocks.tryPlatform.mockReturnValue({ globalState });
-    mocks.authProvider.isAuthenticated.mockResolvedValueOnce(true);
+    isAuthenticatedSpy.mockResolvedValueOnce(true);
 
     await initCliPlatform(cliContext());
 
-    expect(mocks.authProvider.isAuthenticated).not.toHaveBeenCalled();
+    expect(isAuthenticatedSpy).not.toHaveBeenCalled();
     expect(
       mocks.serverSideKeyService.setUseIncludedModelAccess,
     ).toHaveBeenCalledWith(false);
@@ -415,7 +414,7 @@ describe('CLI platform init', () => {
       update: vi.fn().mockResolvedValue(undefined),
     };
     mocks.tryPlatform.mockReturnValue({ globalState });
-    mocks.authProvider.isAuthenticated.mockResolvedValueOnce(true);
+    isAuthenticatedSpy.mockResolvedValueOnce(true);
 
     await initCliPlatform(cliContext({ apiMode: 'included' }));
 
@@ -424,14 +423,14 @@ describe('CLI platform init', () => {
       false,
     );
     expect(mocks.invalidateModelOptionsCache).toHaveBeenCalledOnce();
-    expect(mocks.authProvider.isAuthenticated).toHaveBeenCalledOnce();
+    expect(isAuthenticatedSpy).toHaveBeenCalledOnce();
     expect(
       mocks.serverSideKeyService.setUseIncludedModelAccess,
     ).toHaveBeenCalledWith(true);
   });
 
   it('registers CLI runtime skill sources through the shared Node host helper', async () => {
-    mocks.authProvider.isAuthenticated.mockResolvedValueOnce(false);
+    isAuthenticatedSpy.mockResolvedValueOnce(false);
 
     await initCliPlatform(
       cliContext({
@@ -453,8 +452,8 @@ describe('CLI platform init', () => {
   });
 
   it('wires setup sign-in to the existing CLI login implementation', async () => {
-    mocks.authProvider.isAuthenticated.mockResolvedValue(false);
-    mocks.authProvider.canAccessRemoteAgentCatalog.mockResolvedValue(true);
+    isAuthenticatedSpy.mockResolvedValue(false);
+    canAccessRemoteAgentCatalogSpy.mockResolvedValue(true);
     mocks.signInCliSupabase.mockResolvedValue({ account: { label: 'User' } });
 
     await initCliPlatform(cliContext());
@@ -492,7 +491,7 @@ describe('CLI platform interactive signal ownership', () => {
     vi.clearAllMocks();
     mocks.tryPlatform.mockReset();
     mocks.bootstrapNodeAgentDirectories.mockResolvedValue(undefined);
-    mocks.authProvider.isAuthenticated.mockResolvedValue(false);
+    isAuthenticatedSpy.mockResolvedValue(false);
   });
 
   it('initInteractiveCliPlatform keeps the platform handler live until an explicit handoff', async () => {

--- a/src/test-kernel/cli/ModelAccess.vitest.mts
+++ b/src/test-kernel/cli/ModelAccess.vitest.mts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { SupabaseClient } from '@auth/SupabaseClient';
 import {
   emptyModelListMessageForCliMode,
   findCliModelAccessEntry,
@@ -20,18 +21,8 @@ import { computeModelOptionsData } from '@model/computeModelOptions';
 import type { ModelOptionData } from '@shared/schemas';
 import { AgentCategory } from '@shared/schemas/agent';
 
-const mocks = vi.hoisted(() => ({
-  authProvider: {
-    isAuthenticated: vi.fn(),
-  },
-}));
-
 vi.mock('@model/computeModelOptions', () => ({
   computeModelOptionsData: vi.fn(),
-}));
-
-vi.mock('@cli/runtime/supabaseAuth', () => ({
-  getCliAuthProvider: () => mocks.authProvider,
 }));
 
 vi.mock('llm-zoo', async (importOriginal) => {
@@ -50,6 +41,7 @@ vi.mock('llm-zoo', async (importOriginal) => {
 });
 
 const computeModelOptionsDataMock = vi.mocked(computeModelOptionsData);
+const isAuthenticatedSpy = vi.spyOn(SupabaseClient, 'isAuthenticated');
 
 function model(
   value: string,
@@ -85,8 +77,8 @@ const INTERACTIVE_RECOVERY = {
 describe('CLI model access resolution', () => {
   beforeEach(() => {
     computeModelOptionsDataMock.mockReset();
-    mocks.authProvider.isAuthenticated.mockReset();
-    mocks.authProvider.isAuthenticated.mockResolvedValue(true);
+    isAuthenticatedSpy.mockReset();
+    isAuthenticatedSpy.mockResolvedValue(true);
   });
 
   it('keeps the requested model when it is currently runnable', async () => {
@@ -910,7 +902,7 @@ describe('CLI model access resolution', () => {
   });
 
   it('does not mask explicit retired models behind included login', async () => {
-    mocks.authProvider.isAuthenticated.mockResolvedValue(false);
+    isAuthenticatedSpy.mockResolvedValue(false);
     computeModelOptionsDataMock.mockResolvedValueOnce([
       modelOption('haiku3', {
         label: 'Haiku 3',
@@ -1056,7 +1048,7 @@ describe('CLI model access resolution', () => {
         disabled: true,
       }),
     ]);
-    mocks.authProvider.isAuthenticated.mockResolvedValueOnce(false);
+    isAuthenticatedSpy.mockResolvedValueOnce(false);
 
     await expect(
       getCliModelAccessList({ apiMode: 'included' }),
@@ -1084,7 +1076,7 @@ describe('CLI model access resolution', () => {
         disabled: false,
       }),
     ]);
-    mocks.authProvider.isAuthenticated.mockResolvedValueOnce(false);
+    isAuthenticatedSpy.mockResolvedValueOnce(false);
 
     await expect(
       getCliModelAccessList({ apiMode: 'included' }),
@@ -1110,7 +1102,7 @@ describe('CLI model access resolution', () => {
         disabled: true,
       }),
     ]);
-    mocks.authProvider.isAuthenticated.mockResolvedValueOnce(true);
+    isAuthenticatedSpy.mockResolvedValueOnce(true);
 
     await expect(
       getCliModelAccessList({ apiMode: 'included' }),

--- a/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentRunCommand.vitest.mts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createTestCliContext } from '@test/cli/fixtures/cliContext';
+import { SupabaseClient } from '@auth/SupabaseClient';
 import type { CliContext } from '@cli/runtime/cliContext';
 import { EXECUTION_STATUS, RUN_OUTCOME } from '@shared/schemas';
 
@@ -20,8 +21,6 @@ const mocks = vi.hoisted(() => ({
   getAgentsByCategory: vi.fn(),
   getVisibleAgents: vi.fn(),
   initCliPlatform: vi.fn(),
-  isAuthenticated: vi.fn(),
-  canAccessRemoteAgentCatalog: vi.fn(),
   loadAgents: vi.fn(),
   refreshAgents: vi.fn(),
   planCliMultiAgentPresets: vi.fn(),
@@ -59,13 +58,6 @@ vi.mock('@cli/runtime/logSinks', () => ({
 
 vi.mock('@cli/commands/_helpers/output', () => ({
   emitCliResult: mocks.emitCliResult,
-}));
-
-vi.mock('@cli/runtime/supabaseAuth', () => ({
-  getCliAuthProvider: () => ({
-    isAuthenticated: mocks.isAuthenticated,
-    canAccessRemoteAgentCatalog: mocks.canAccessRemoteAgentCatalog,
-  }),
 }));
 
 vi.mock('@cli/runtime/multiAgentPresets', () => {
@@ -115,6 +107,12 @@ vi.mock('@cli/runtime/runExecution', () => ({
 vi.mock('@cli/runtime/workflowInputs', () => ({
   withExpandedRunInputs: mocks.withExpandedRunInputs,
 }));
+
+const isAuthenticatedSpy = vi.spyOn(SupabaseClient, 'isAuthenticated');
+const canAccessRemoteAgentCatalogSpy = vi.spyOn(
+  SupabaseClient,
+  'canAccessRemoteAgentCatalog',
+);
 
 function cliContext(overrides: Partial<CliContext> = {}): CliContext {
   return createTestCliContext({
@@ -198,8 +196,8 @@ describe('CLI multi-agent run command', () => {
       workflowAgentKeys: [],
       toolUseAgentKeys: ['builtInToolUse:orchestrator'],
     });
-    mocks.isAuthenticated.mockResolvedValue(false);
-    mocks.canAccessRemoteAgentCatalog.mockResolvedValue(false);
+    isAuthenticatedSpy.mockResolvedValue(false);
+    canAccessRemoteAgentCatalogSpy.mockResolvedValue(false);
     mocks.executeCliToolUseConfig.mockResolvedValue({
       ok: true,
       result: {
@@ -286,7 +284,7 @@ describe('CLI multi-agent run command', () => {
     const { loadCliMultiAgentRunPlan } =
       await import('@cli/runtime/multiAgentRunPlan');
     mocks.cliMultiAgentPlanHasGaps.mockReturnValueOnce(true);
-    mocks.canAccessRemoteAgentCatalog.mockResolvedValueOnce(true);
+    canAccessRemoteAgentCatalogSpy.mockResolvedValueOnce(true);
 
     const result = await loadCliMultiAgentRunPlan({
       preset: 'mathematician',
@@ -306,8 +304,8 @@ describe('CLI multi-agent run command', () => {
     const { loadCliMultiAgentRunPlan } =
       await import('@cli/runtime/multiAgentRunPlan');
     mocks.cliMultiAgentPlanHasGaps.mockReturnValueOnce(true);
-    mocks.isAuthenticated.mockResolvedValueOnce(true);
-    mocks.canAccessRemoteAgentCatalog.mockResolvedValueOnce(false);
+    isAuthenticatedSpy.mockResolvedValueOnce(true);
+    canAccessRemoteAgentCatalogSpy.mockResolvedValueOnce(false);
 
     const result = await loadCliMultiAgentRunPlan({
       preset: 'mathematician',
@@ -317,7 +315,7 @@ describe('CLI multi-agent run command', () => {
     expect(mocks.loadAgents).toHaveBeenCalledOnce();
     expect(mocks.loadAgents).toHaveBeenCalledWith({ includeRemote: false });
     expect(mocks.refreshAgents).not.toHaveBeenCalled();
-    expect(mocks.isAuthenticated).not.toHaveBeenCalled();
+    expect(isAuthenticatedSpy).not.toHaveBeenCalled();
     expect(mocks.planCliMultiAgentPresetRun).toHaveBeenCalledTimes(1);
   });
 
@@ -325,7 +323,7 @@ describe('CLI multi-agent run command', () => {
     const { loadCliMultiAgentPresetPlanSet } =
       await import('@cli/runtime/multiAgentRunPlan');
     mocks.cliMultiAgentPlanHasGaps.mockReturnValueOnce(true);
-    mocks.canAccessRemoteAgentCatalog.mockResolvedValueOnce(true);
+    canAccessRemoteAgentCatalogSpy.mockResolvedValueOnce(true);
 
     const result = await loadCliMultiAgentPresetPlanSet([
       {
@@ -353,7 +351,7 @@ describe('CLI multi-agent run command', () => {
     mocks.cliMultiAgentPlanHasGaps
       .mockReturnValueOnce(true)
       .mockReturnValueOnce(false);
-    mocks.canAccessRemoteAgentCatalog.mockResolvedValueOnce(true);
+    canAccessRemoteAgentCatalogSpy.mockResolvedValueOnce(true);
     const { runMultiAgentPreset } = await import('@cli/commands/multiAgent');
 
     const exitCode = await runMultiAgentPreset(cliContext(), {

--- a/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
+++ b/src/test-kernel/cli/WorkflowRunCommand.vitest.mts
@@ -21,7 +21,6 @@ const mocks = vi.hoisted(() => {
     finalizeExecution: vi.fn(),
     withExpandedRunInputs: vi.fn(),
     initLocalCliPlatform: vi.fn(),
-    isAuthenticated: vi.fn(),
     resolveCliLaunchAgent: vi.fn(),
     selectCliRunModel: vi.fn(),
     writeErrorStderr: vi.fn(),
@@ -51,12 +50,6 @@ vi.mock('@utils/files', () => ({
 
 vi.mock('@cli/runtime/initPlatform', () => ({
   initLocalCliPlatform: mocks.initLocalCliPlatform,
-}));
-
-vi.mock('@cli/runtime/supabaseAuth', () => ({
-  getCliAuthProvider: () => ({
-    isAuthenticated: mocks.isAuthenticated,
-  }),
 }));
 
 vi.mock('@cli/runtime/runModel', () => ({


### PR DESCRIPTION
## Summary

Delete the redundant authentication-provider seams around included model access. `ServerSideKeyService` and CLI consumers now call the existing `SupabaseClient` contract directly; extension, desktop, and CLI no longer construct byte-identical adapter literals.

## Issue acceptance gates

Closes #8881.

- Deletes `AuthProvider` and removes it from `ServerSideKeyService` construction and the server-keys barrel.
- Deletes `cliAuthProvider` and `getCliAuthProvider`.
- Routes all production consumers directly through `SupabaseClient`.
- Preserves relay authorization through `SupabaseClient.getRelayAccessToken()`.
- Converts affected tests to the existing `vi.spyOn(SupabaseClient, ...)` seam and removes obsolete module mocks/fake providers.

## Single source of truth

`SupabaseClient` now exclusively owns authentication state, tier lookup, remote-catalog eligibility, and relay-token access. Hosts configure the real Supabase session coordinator once instead of supplying a second parallel auth object to server-key and CLI code.

## Duplication and abstraction budget

This deletes one port, four duplicate production implementations (three host literals plus the CLI object), and the corresponding fake-provider/test-mock layer. No replacement abstraction is added.

## Net elements (R6)

- Files: 18 modified, 0 added, 0 deleted.
- Exported symbols: 0 added, 2 deleted (`AuthProvider`, `getCliAuthProvider`).
- Other named declarations: 0 added, 3 deleted (`cliAuthProvider` and two test-local `createAuthProvider` helpers).
- Interfaces: 0 added, 1 deleted (`AuthProvider`, already counted above).
- Net LoC: -104 (114 additions, 218 deletions).

## Consumer counts (R8)

- `AuthProvider`: 3 production implementations and 2 test fake helpers removed; its 3 service method consumers now call `SupabaseClient` directly.
- `getCliAuthProvider`: 9 production call sites across 5 files rerouted; 6 test mock surfaces removed or converted to static spies.
- `initializeServerSideKeyAccess`: 3 host callers retained with the deleted provider argument removed.

## Host impact

Extension: Removes the activation-time auth adapter literal; included model access behavior is unchanged.

Desktop: Removes the desktop auth adapter literal; included model access behavior is unchanged.

CLI: Removes the CLI auth facade and routes authentication/catalog checks to `SupabaseClient`; behavior is unchanged.

## Scheduled refactoring

#8880 is intentionally sequenced after this PR because it rewrites the same `ServerSideKeyService` constructor while deleting the separate event subsystem.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint` (passes with one pre-existing warning in `AgentCreatorToolCatalogParity.vitest.mts`)
- `npm run check:dead-code-ratchet`
- Focused Vitest: 8 files, 110 tests passed
- `npm run compile:fast`
- `npm test`: 741 files passed, 1 skipped; 6,871 tests passed, 4 skipped

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches included-model access and relay auth across extension, desktop, and CLI, but behavior is intended to be unchanged with a single auth source of truth.
> 
> **Overview**
> Removes the **`AuthProvider`** port and **`getCliAuthProvider`** CLI facade so auth state, tier, remote-catalog eligibility, and relay tokens all go through **`SupabaseClient`** directly.
> 
> **`ServerSideKeyService`** no longer takes an injected provider; **`initializeServerSideKeyAccess`** only receives host state/logger (extension, desktop, CLI). CLI orchestration, agent resolution, model access, and multi-agent planning call **`SupabaseClient`** instead of **`getCliAuthProvider()`**. Session coordination in **`supabaseAuth.ts`** is unchanged; only the duplicate wrapper object is deleted.
> 
> Tests drop fake **`AuthProvider`** helpers and **`vi.mock('@cli/runtime/supabaseAuth')`** in favor of **`vi.spyOn(SupabaseClient, ...)`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb810333cf63f1de8875b34c68dffb7adf65a9a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->