### PR TITLE
refactor: replace server-key events with app signals

### DIFF
--- a/packages/extension/src/MainViewProvider.ts
+++ b/packages/extension/src/MainViewProvider.ts
@@ -8,7 +8,6 @@ import {
 } from '@controllers/onboarding/onboardingFunnel';
 import { refresh, computeAgentOptionsData, getAgent } from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import { getServerSideKeyService } from '@auth/serverKeys';
 
 // Local imports - common
 import { hasAnyUsableSetupCredential } from '@commands/setup';
@@ -21,6 +20,7 @@ import {
 } from '@common/webview';
 import { consumePendingState } from '@common/state';
 import { EXTENSION_CATEGORIES, getFilterExtensions } from '@common/files';
+import { appSignals } from '@eventBus/AppSignals';
 
 import { agentDirectories } from '@frontend/agents';
 import { loadMainViewModelOptions } from '@frontend/agents/optionsLoader';
@@ -132,11 +132,11 @@ export class MainViewProvider
       }
       void this.refreshOptionsAndView();
     });
-    this.context.subscriptions.push(
-      getServerSideKeyService().onDidChangeModelAccess(() => {
+    this.context.subscriptions.push({
+      dispose: appSignals.on('includedModelAccessChanged', () => {
         void this.refreshOptionsAndView();
       }),
-    );
+    });
   }
 
   /** Returns the sidebar webview, but only when in main mode. */

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -32,10 +32,7 @@ import {
 } from '@agent/runtime/SessionHandle';
 import { registerAgentShutdownHandlers } from '@agent/runtime/agentShutdown';
 import { initializePolishModel } from '@agent/runtime/polishModel';
-import {
-  getServerSideKeyService,
-  initializeServerSideKeyAccess,
-} from '@auth/serverKeys';
+import { initializeServerSideKeyAccess } from '@auth/serverKeys';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import {
   getAuthCallbackUri,
@@ -314,7 +311,6 @@ export async function activate(context: vscode.ExtensionContext) {
   FileLister.initialize(context);
   initializeServerSideKeyAccess({
     state: context.globalState,
-    subscriptions: context.subscriptions,
     logger,
   });
 
@@ -655,11 +651,11 @@ export async function activate(context: vscode.ExtensionContext) {
   onTexraAuthSessionsChanged(context, () => {
     void safeRefreshApiKeyStatus();
   });
-  context.subscriptions.push(
-    getServerSideKeyService().onDidChangeModelAccess(() => {
+  context.subscriptions.push({
+    dispose: appSignals.on('includedModelAccessChanged', () => {
       void safeRefreshApiKeyStatus();
     }),
-  );
+  });
 
   const statusBarUsageTracker = new StatusBarUsageTracker();
   const updateStatusBarTooltip = () => {

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -312,6 +312,9 @@ export async function activate(context: vscode.ExtensionContext) {
   initializeServerSideKeyAccess({
     state: context.globalState,
     logger,
+    notifyIncludedModelAccessChanged: (enabled) => {
+      appSignals.emit('includedModelAccessChanged', enabled);
+    },
   });
 
   // Seed first-install defaults (e.g. disabled tools) before anything writes

--- a/src/auth/serverKeys/ServerSideKeyService.ts
+++ b/src/auth/serverKeys/ServerSideKeyService.ts
@@ -14,7 +14,6 @@
  * - free tier: Included non-premium models (up to $3/M input)
  */
 
-import { appSignals } from '@eventBus/AppSignals';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { SupabaseClient } from '../SupabaseClient';
 import {
@@ -98,6 +97,9 @@ export class ServerSideKeyService {
     private readonly tierService: TierService,
     private readonly globalState: StateStore | null = null,
     private readonly logger: AuthServiceLogger = NOOP_AUTH_SERVICE_LOGGER,
+    private readonly notifyIncludedModelAccessChanged: (
+      enabled: boolean,
+    ) => void = () => {},
   ) {
     this.useIncludedModelAccess =
       this.globalState?.get<boolean>(USE_INCLUDED_ACCESS_KEY, true) ?? true;
@@ -142,7 +144,14 @@ export class ServerSideKeyService {
       // its own auth'd fetch in parallel with fetchAccessStatus(), and
       // an anonymous pre-fetch here would populate the 'anon' cache slot
       // rather than the 'auth' slot needed for the access check.
-      appSignals.emit('includedModelAccessChanged', value);
+      try {
+        this.notifyIncludedModelAccessChanged(value);
+      } catch (error) {
+        this.logger.error(
+          CHANNEL,
+          `Event listener failed: ${toErrorMessage(error)}`,
+        );
+      }
     }
   }
 

--- a/src/auth/serverKeys/ServerSideKeyService.ts
+++ b/src/auth/serverKeys/ServerSideKeyService.ts
@@ -14,7 +14,7 @@
  * - free tier: Included non-premium models (up to $3/M input)
  */
 
-import { EventEmitter } from 'node:events';
+import { appSignals } from '@eventBus/AppSignals';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { SupabaseClient } from '../SupabaseClient';
 import {
@@ -47,26 +47,6 @@ const RELAY_PATH_SUFFIXES: Partial<Record<ServerSideProvider, string>> = {
 /** Global state key for the "use included model access" preference. */
 const USE_INCLUDED_ACCESS_KEY = 'texra.useIncludedModelAccess';
 
-const SERVICE_EVENT = 'event';
-
-export interface ServerSideKeyDisposable {
-  dispose(): void;
-}
-
-export type ServerSideKeyEvent<T> = (
-  listener: (event: T) => unknown,
-  thisArgs?: unknown,
-  disposables?: ServerSideKeyDisposable[],
-) => ServerSideKeyDisposable;
-
-export type ServerSideKeyState = StateStore;
-
-export interface ServerSideKeyServiceInit {
-  state?: ServerSideKeyState;
-  subscriptions?: ServerSideKeyDisposable[];
-  logger?: AuthServiceLogger;
-}
-
 export interface ClearServerSideKeyCachesOptions {
   /**
    * Reset the per-session quota auto-switch guard. Use this only when the
@@ -80,40 +60,6 @@ export interface ClearServerSideKeyCachesOptions {
   preserveTierCache?: boolean;
   /** True when included access is being disabled by quota fallback. */
   quotaAutoSwitch?: boolean;
-}
-
-class NodeEventEmitter<T> implements ServerSideKeyDisposable {
-  private readonly emitter = new EventEmitter();
-
-  constructor(private readonly logger: AuthServiceLogger) {}
-
-  readonly event: ServerSideKeyEvent<T> = (listener, thisArgs, disposables) => {
-    const boundListener =
-      thisArgs === undefined ? listener : listener.bind(thisArgs);
-    this.emitter.on(SERVICE_EVENT, boundListener);
-    const disposable = {
-      dispose: () => this.emitter.off(SERVICE_EVENT, boundListener),
-    };
-    disposables?.push(disposable);
-    return disposable;
-  };
-
-  fire(event: T): void {
-    for (const listener of this.emitter.listeners(SERVICE_EVENT)) {
-      try {
-        listener(event);
-      } catch (error) {
-        this.logger.error(
-          CHANNEL,
-          `Event listener failed: ${toErrorMessage(error)}`,
-        );
-      }
-    }
-  }
-
-  dispose(): void {
-    this.emitter.removeAllListeners();
-  }
 }
 
 /**
@@ -145,52 +91,16 @@ export class ServerSideKeyService {
   private quotaAutoSwitchActive = false;
 
   // Settings
-  private useIncludedModelAccess = true;
-  private globalState: ServerSideKeyState | null = null;
-  private readonly _onDidChangeModelAccess: NodeEventEmitter<boolean>;
-  private readonly _onCacheCleared: NodeEventEmitter<ClearServerSideKeyCachesOptions>;
-  private readonly _tierServiceClearSubscription: ServerSideKeyDisposable;
-
-  readonly onDidChangeModelAccess: ServerSideKeyEvent<boolean>;
-  readonly onCacheCleared: ServerSideKeyEvent<ClearServerSideKeyCachesOptions>;
+  private useIncludedModelAccess: boolean;
 
   constructor(
     private readonly baseUrl: string,
     private readonly tierService: TierService,
+    private readonly globalState: StateStore | null = null,
     private readonly logger: AuthServiceLogger = NOOP_AUTH_SERVICE_LOGGER,
   ) {
-    this._onDidChangeModelAccess = new NodeEventEmitter<boolean>(this.logger);
-    this._onCacheCleared =
-      new NodeEventEmitter<ClearServerSideKeyCachesOptions>(this.logger);
-    this.onDidChangeModelAccess = this._onDidChangeModelAccess.event;
-    this.onCacheCleared = this._onCacheCleared.event;
-    this._tierServiceClearSubscription = this._onCacheCleared.event(
-      (options) => {
-        if (options.preserveTierCache) return;
-        this.tierService.clearCache();
-      },
-    );
-  }
-
-  /**
-   * Initialize the service with host-provided state and subscriptions.
-   * This enables settings persistence without coupling the service to VS Code.
-   */
-  initialize(options: ServerSideKeyServiceInit): void {
-    options.subscriptions?.push(
-      this._onDidChangeModelAccess,
-      this._onCacheCleared,
-      this._tierServiceClearSubscription,
-    );
-    this.globalState = options.state ?? null;
     this.useIncludedModelAccess =
       this.globalState?.get<boolean>(USE_INCLUDED_ACCESS_KEY, true) ?? true;
-  }
-
-  dispose(): void {
-    this._onDidChangeModelAccess.dispose();
-    this._onCacheCleared.dispose();
-    this._tierServiceClearSubscription.dispose();
   }
 
   private hasFullAccess(): boolean {
@@ -232,7 +142,7 @@ export class ServerSideKeyService {
       // its own auth'd fetch in parallel with fetchAccessStatus(), and
       // an anonymous pre-fetch here would populate the 'anon' cache slot
       // rather than the 'auth' slot needed for the access check.
-      this._onDidChangeModelAccess.fire(value);
+      appSignals.emit('includedModelAccessChanged', value);
     }
   }
 
@@ -250,7 +160,7 @@ export class ServerSideKeyService {
       this.quotaFlipApplied = false;
       this.quotaAutoSwitchActive = false;
     }
-    this._onCacheCleared.fire(options);
+    if (!options.preserveTierCache) this.tierService.clearCache();
   }
 
   isProviderOnServer(provider: string): boolean {

--- a/src/auth/serverKeys/index.ts
+++ b/src/auth/serverKeys/index.ts
@@ -15,10 +15,9 @@
 
 import { SUPABASE_CUSTOM_DOMAIN } from '../config';
 import { getTierService } from '../tier';
-import {
-  ServerSideKeyService,
-  type ServerSideKeyServiceInit,
-} from './ServerSideKeyService';
+import { ServerSideKeyService } from './ServerSideKeyService';
+import type { AuthServiceLogger } from '../serviceLogger';
+import type { StateStore } from '@platform/interfaces';
 
 // Types
 export { SERVER_SIDE_PROVIDERS, type ServerSideProvider } from './types';
@@ -56,15 +55,16 @@ export function setServerSideKeyService(service: ServerSideKeyService): void {
  * Initialize the server-side key access module.
  * Call this during extension activation.
  *
- * @param options - Host-provided state and subscriptions
+ * @param options - Host-provided state and logger
  */
-export function initializeServerSideKeyAccess(
-  options: ServerSideKeyServiceInit,
-): void {
+export function initializeServerSideKeyAccess(options: {
+  state?: StateStore;
+  logger?: AuthServiceLogger;
+}): void {
   _instance = new ServerSideKeyService(
     `https://${SUPABASE_CUSTOM_DOMAIN}`,
     getTierService(options.logger),
+    options.state ?? null,
     options.logger,
   );
-  _instance.initialize(options);
 }

--- a/src/auth/serverKeys/index.ts
+++ b/src/auth/serverKeys/index.ts
@@ -60,11 +60,13 @@ export function setServerSideKeyService(service: ServerSideKeyService): void {
 export function initializeServerSideKeyAccess(options: {
   state?: StateStore;
   logger?: AuthServiceLogger;
+  notifyIncludedModelAccessChanged?: (enabled: boolean) => void;
 }): void {
   _instance = new ServerSideKeyService(
     `https://${SUPABASE_CUSTOM_DOMAIN}`,
     getTierService(options.logger),
     options.state ?? null,
     options.logger,
+    options.notifyIncludedModelAccessChanged,
   );
 }

--- a/src/eventBus/AppSignals.ts
+++ b/src/eventBus/AppSignals.ts
@@ -39,6 +39,9 @@ export interface AppSignalPayloads {
   /** The editor's language-model catalogue or access permissions changed. */
   languageModelsChanged: undefined;
 
+  /** The included-model-access preference changed. */
+  includedModelAccessChanged: boolean;
+
   /**
    * One or more files were written directly to the workspace. Frontends can
    * badge or refresh those files without routing through a run-scoped channel.

--- a/src/eventBus/AppSignals.ts
+++ b/src/eventBus/AppSignals.ts
@@ -80,7 +80,17 @@ class AppSignals implements AppSignalsLike {
   }
 
   emit<K extends AppSignal>(event: K, payload: AppSignalPayloads[K]): void {
-    this.emitter.emit(event, payload);
+    let listenerFailed = false;
+    let firstError: unknown;
+    for (const listener of this.emitter.rawListeners(event)) {
+      try {
+        listener(payload);
+      } catch (error) {
+        if (!listenerFailed) firstError = error;
+        listenerFailed = true;
+      }
+    }
+    if (listenerFailed) throw firstError;
   }
 }
 

--- a/src/test-kernel/auth/ServerSideKeyService.vitest.ts
+++ b/src/test-kernel/auth/ServerSideKeyService.vitest.ts
@@ -4,16 +4,14 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 // Local imports - auth
 import { ULTRA_TIER } from '@auth/config';
 import { SupabaseClient } from '@auth/SupabaseClient';
-import {
-  ServerSideKeyService,
-  type ServerSideKeyState,
-} from '@auth/serverKeys/ServerSideKeyService';
+import { ServerSideKeyService } from '@auth/serverKeys/ServerSideKeyService';
 import type { TierService } from '@auth/tier/TierService';
 import { delay } from '@utils/core';
+import type { StateStore } from '@platform/interfaces';
 
 const USE_INCLUDED_ACCESS_KEY = 'texra.useIncludedModelAccess';
 
-class MemoryState implements ServerSideKeyState {
+class MemoryState implements StateStore {
   private readonly values = new Map<string, unknown>();
 
   constructor(initialValues: Record<string, unknown> = {}) {
@@ -110,9 +108,8 @@ function createQuotaExceededSetup(): {
   const service = new ServerSideKeyService(
     'https://example.test',
     tier.service,
+    state,
   );
-
-  service.initialize({ state });
 
   return { state, tier, service };
 }

--- a/src/test-kernel/auth/ServerSideKeyServiceSettings.vitest.ts
+++ b/src/test-kernel/auth/ServerSideKeyServiceSettings.vitest.ts
@@ -2,19 +2,15 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'vitest';
 
-// Standard library imports
-
 // Local imports - auth
-import type { AuthServiceLogger } from '@auth/serviceLogger';
-import {
-  ServerSideKeyService,
-  type ServerSideKeyState,
-} from '@auth/serverKeys/ServerSideKeyService';
+import { ServerSideKeyService } from '@auth/serverKeys/ServerSideKeyService';
 import type { TierService } from '@auth/tier/TierService';
+import { appSignals } from '@eventBus/AppSignals';
+import type { StateStore } from '@platform/interfaces';
 
 const USE_INCLUDED_ACCESS_KEY = 'texra.useIncludedModelAccess';
 
-class MemoryState implements ServerSideKeyState {
+class MemoryState implements StateStore {
   private readonly values = new Map<string, unknown>();
 
   constructor(initialValues: Record<string, unknown> = {}) {
@@ -84,18 +80,16 @@ function createTierService(): FakeTierService {
 
 function createService(
   tierService: TierService,
-  logger?: AuthServiceLogger,
+  state: StateStore | null = null,
 ): ServerSideKeyService {
-  return new ServerSideKeyService('https://example.test', tierService, logger);
+  return new ServerSideKeyService('https://example.test', tierService, state);
 }
 
 describe('ServerSideKeyService', () => {
   it('reads the included-access setting from host-provided state', () => {
     const tier = createTierService();
     const state = new MemoryState({ [USE_INCLUDED_ACCESS_KEY]: false });
-    const service = createService(tier.service);
-
-    service.initialize({ state });
+    const service = createService(tier.service, state);
 
     assert.equal(service.getUseIncludedModelAccess(), false);
   });
@@ -103,74 +97,21 @@ describe('ServerSideKeyService', () => {
   it('persists setting changes and fires change events', async () => {
     const tier = createTierService();
     const state = new MemoryState({ [USE_INCLUDED_ACCESS_KEY]: false });
-    const service = createService(tier.service);
+    const service = createService(tier.service, state);
     const changes: boolean[] = [];
-
-    service.initialize({ state });
-    service.onDidChangeModelAccess((value) => {
+    const dispose = appSignals.on('includedModelAccessChanged', (value) => {
       changes.push(value);
     });
 
-    await service.setUseIncludedModelAccess(true);
+    try {
+      await service.setUseIncludedModelAccess(true);
 
-    assert.equal(state.get(USE_INCLUDED_ACCESS_KEY, false), true);
-    assert.deepEqual(changes, [true]);
-    assert.equal(tier.clearCacheCalls, 1);
-    assert.equal(tier.getConfigCalls, 0);
-  });
-
-  it('supports host subscription disposal without VS Code types', async () => {
-    const tier = createTierService();
-    const service = createService(tier.service);
-    const subscriptions: Array<{ dispose(): void }> = [];
-    const changes: boolean[] = [];
-
-    service.initialize({ subscriptions });
-    const listener = service.onDidChangeModelAccess((value) => {
-      changes.push(value);
-    });
-
-    assert.equal(subscriptions.length, 3);
-
-    listener.dispose();
-    await service.setUseIncludedModelAccess(false);
-
-    assert.deepEqual(changes, []);
-  });
-
-  it('continues dispatching when one listener throws', async () => {
-    const tier = createTierService();
-    const state = new MemoryState({ [USE_INCLUDED_ACCESS_KEY]: false });
-    const errors: Array<{ channel: string; message: string }> = [];
-    const logger: AuthServiceLogger = {
-      info(channel, message) {
-        void channel;
-        void message;
-      },
-      error(channel, message) {
-        errors.push({ channel, message });
-      },
-    };
-    const service = createService(tier.service, logger);
-    const changes: boolean[] = [];
-
-    service.initialize({ state });
-    service.onDidChangeModelAccess(() => {
-      throw new Error('listener failed');
-    });
-    service.onDidChangeModelAccess((value) => {
-      changes.push(value);
-    });
-
-    await assert.doesNotReject(() => service.setUseIncludedModelAccess(true));
-
-    assert.deepEqual(changes, [true]);
-    assert.equal(state.get(USE_INCLUDED_ACCESS_KEY, false), true);
-    assert.deepEqual(errors, [
-      {
-        channel: 'ServerSideKeyService',
-        message: 'Event listener failed: listener failed',
-      },
-    ]);
+      assert.equal(state.get(USE_INCLUDED_ACCESS_KEY, false), true);
+      assert.deepEqual(changes, [true]);
+      assert.equal(tier.clearCacheCalls, 1);
+      assert.equal(tier.getConfigCalls, 0);
+    } finally {
+      dispose();
+    }
   });
 });

--- a/src/test-kernel/auth/ServerSideKeyServiceSettings.vitest.ts
+++ b/src/test-kernel/auth/ServerSideKeyServiceSettings.vitest.ts
@@ -81,8 +81,15 @@ function createTierService(): FakeTierService {
 function createService(
   tierService: TierService,
   state: StateStore | null = null,
+  notifyIncludedModelAccessChanged?: (enabled: boolean) => void,
 ): ServerSideKeyService {
-  return new ServerSideKeyService('https://example.test', tierService, state);
+  return new ServerSideKeyService(
+    'https://example.test',
+    tierService,
+    state,
+    undefined,
+    notifyIncludedModelAccessChanged,
+  );
 }
 
 describe('ServerSideKeyService', () => {
@@ -97,21 +104,41 @@ describe('ServerSideKeyService', () => {
   it('persists setting changes and fires change events', async () => {
     const tier = createTierService();
     const state = new MemoryState({ [USE_INCLUDED_ACCESS_KEY]: false });
-    const service = createService(tier.service, state);
     const changes: boolean[] = [];
-    const dispose = appSignals.on('includedModelAccessChanged', (value) => {
+    const service = createService(tier.service, state, (value) => {
       changes.push(value);
     });
 
-    try {
-      await service.setUseIncludedModelAccess(true);
+    await service.setUseIncludedModelAccess(true);
 
-      assert.equal(state.get(USE_INCLUDED_ACCESS_KEY, false), true);
-      assert.deepEqual(changes, [true]);
-      assert.equal(tier.clearCacheCalls, 1);
-      assert.equal(tier.getConfigCalls, 0);
+    assert.equal(state.get(USE_INCLUDED_ACCESS_KEY, false), true);
+    assert.deepEqual(changes, [true]);
+    assert.equal(tier.clearCacheCalls, 1);
+    assert.equal(tier.getConfigCalls, 0);
+  });
+
+  it('continues notifying after a listener fails', async () => {
+    const tier = createTierService();
+    const changes: boolean[] = [];
+    const service = createService(tier.service, null, (value) => {
+      appSignals.emit('includedModelAccessChanged', value);
+    });
+    const disposeFailing = appSignals.on('includedModelAccessChanged', () => {
+      throw new Error('listener failed');
+    });
+    const disposeRecording = appSignals.on(
+      'includedModelAccessChanged',
+      (value) => {
+        changes.push(value);
+      },
+    );
+
+    try {
+      await service.setUseIncludedModelAccess(false);
+      assert.deepEqual(changes, [false]);
     } finally {
-      dispose();
+      disposeFailing();
+      disposeRecording();
     }
   });
 });


### PR DESCRIPTION
## Summary

Deletes `ServerSideKeyService`'s private event-emitter imitation. Persistent state and an included-access notification function are now constructor dependencies; the extension composition root connects that function to the existing application signal bus. Cache invalidation is direct, and listener failures remain isolated.

Closes #8880.

## Issue acceptance gates

- Delete `NodeEventEmitter<T>`, `ServerSideKeyEvent<T>`, `ServerSideKeyDisposable`, `ServerSideKeyState`, and `ServerSideKeyServiceInit`.
- Delete the zero-subscriber cache event, its self-subscription, and its emitter fields.
- Delete `ServerSideKeyService.initialize()` and `dispose()`; persistent state is a constructor dependency.
- Clear the tier cache directly in `clearAllCaches()` unless `preserveTierCache` is set.
- Add the boolean `includedModelAccessChanged` application signal and emit it through a composition-root adapter only when the preference changes.
- Move the two production subscribers to `appSignals.on()` and register their cleanup functions as VS Code disposables.
- Preserve per-listener failure isolation: all signal listeners run, and the service logs the first dispatch failure without rejecting a persisted setting change.
- Rebase after #8881 so the constructor retains its canonical direct `SupabaseClient` authentication surface.

## Single source of truth

`src/eventBus/AppSignals.ts` owns cross-cutting application-signal dispatch. `ServerSideKeyService` owns cache invalidation and accepts its host notification boundary through construction.

## Duplication and abstraction budget

Deletes the private event class, two emitter instances, a self-subscription, two lifecycle methods, and their callback types. The existing signal bus replaces the only event with production subscribers. No pass-through module is added.

## Net elements (R6)

- Files: 0 added, 0 deleted.
- Source lines: 86 added, 188 deleted; net **-102 LoC**.
- Elements: net **-7** across the event class, callback/disposable/init/state types, dead cache-event surface, and lifecycle methods.

## Consumer counts (R8)

- `onDidChangeModelAccess`: exactly 2 production subscribers, both retargeted to `includedModelAccessChanged`.
- `onCacheCleared`: 0 external subscribers; deleted with its internal self-subscription.
- `ServerSideKeyService.dispose()`: 0 callers.
- Initialization subscription array: 1 extension host producer; deleted. Desktop and CLI supplied no subscriptions.

## Host impact

Extension: its two model-access refresh listeners subscribe to the application signal; cleanup remains registered with the extension context.

Desktop: construction receives state directly; no event subscriber changes.

CLI: construction receives state directly; no event subscriber changes.

## Scheduled refactoring

None. The required predecessor #8881 merged in #8893.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint` (passes with the pre-existing warning in `AgentCreatorToolCatalogParity.vitest.mts`)
- `npm run check:dead-code-ratchet`
- `npm run compile:fast`
- focused Vitest suites for the architectural edge ratchet and both server-side-key service suites (8/8)
