### PR TITLE
refactor: remove dead surfaces across runtime boundaries

### DIFF
--- a/packages/cli/src/runtime/supabaseAuth.ts
+++ b/packages/cli/src/runtime/supabaseAuth.ts
@@ -260,7 +260,7 @@ export async function getCliSessionAccessToken(): Promise<string | null> {
  * limit must use this tier — `getCliAuthProfile().tier` may describe the
  * env token's account instead.
  */
-export async function getCliSessionTier(): Promise<string> {
+async function getCliSessionTier(): Promise<string> {
   return SupabaseClient.getSessionTier();
 }
 

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -375,9 +375,4 @@ export class SupabaseClient {
   static async canAccessRemoteAgentCatalog(): Promise<boolean> {
     return (await this.getAccessToken()) !== null;
   }
-
-  /** Get configuration for re-initialization. */
-  static getConfig(): { url: string; publicKey: string } | null {
-    return this.config;
-  }
 }

--- a/src/auth/tier/types.ts
+++ b/src/auth/tier/types.ts
@@ -31,8 +31,6 @@ export const UserAccessStatusSchema = z.object({
   accessExpiresAt: z.string().nullable(),
   /** Whether access is currently expired */
   isExpired: z.boolean(),
-  /** Days until expiration (negative if expired, null if no expiration) */
-  daysRemaining: z.number().nullable(),
 });
 export type UserAccessStatus = z.infer<typeof UserAccessStatusSchema>;
 

--- a/src/model/runtimeModelRegistry.ts
+++ b/src/model/runtimeModelRegistry.ts
@@ -192,11 +192,6 @@ export function availableRuntimeModelIds(): readonly string[] {
     .map(([id]) => id);
 }
 
-/** All compatible editor-supplied models, including models awaiting consent. */
-export function runtimeModelIds(): readonly string[] {
-  return [...runtimeModels.keys()];
-}
-
 /** Access state reported by the editor for a discovered runtime model. */
 export function runtimeModelAccess(
   model: string,

--- a/src/test-kernel/model/RuntimeModelRegistry.vitest.ts
+++ b/src/test-kernel/model/RuntimeModelRegistry.vitest.ts
@@ -17,7 +17,6 @@ import {
   requestRuntimeModelAccess,
   resolveRuntimeModelConfig,
   runtimeModelAccess,
-  runtimeModelIds,
 } from '@model/runtimeModelRegistry';
 import type {
   LanguageModelInfo,
@@ -161,7 +160,6 @@ describe('runtime model registry', () => {
     await refreshRuntimeModelRegistry();
 
     expect(availableRuntimeModelIds()).toEqual([]);
-    expect(runtimeModelIds()).toEqual(['copilot:sonnet46']);
     expect(runtimeModelAccess('copilot:sonnet46')).toBe('unavailable');
     expect(getRuntimeModelConfig('copilot:sonnet46')).toBeDefined();
   });
@@ -370,6 +368,5 @@ describe('runtime model registry', () => {
     );
 
     await expect(discoveredRuntimeModelConfigEntries()).resolves.toEqual([]);
-    expect(runtimeModelIds()).toEqual([]);
   });
 });

--- a/src/test-kernel/supabase/RelayReasoningCaps.vitest.ts
+++ b/src/test-kernel/supabase/RelayReasoningCaps.vitest.ts
@@ -7,7 +7,7 @@ import {
   FREE_TIER,
   MAX_TIER,
   ULTRA_TIER,
-} from '../../../supabase/functions/relay/tierConstants';
+} from '../../../supabase/functions/relay/models';
 
 const TIER_CAPS = {
   [FREE_TIER]: 'medium',

--- a/src/test-kernel/supabase/RelayRequestLimits.vitest.ts
+++ b/src/test-kernel/supabase/RelayRequestLimits.vitest.ts
@@ -8,7 +8,6 @@ import { describe, it, vi } from 'vitest';
 import {
   FREE_TIER_MAX_OUTPUT_TOKENS,
   FREE_TIER_REQUEST_BODY_LIMIT_BYTES,
-  checkRequestBodySizeLimit,
   clampFreeTierMaxOutputTokens,
   formatRequestBytes,
   readRequestBodyWithinSizeLimit,
@@ -84,33 +83,6 @@ function createGateClient(
 describe('relay free-tier request limits', () => {
   it('allows four concurrent free-tier requests', () => {
     assert.equal(getRequestLimits('free').concurrent, 4);
-  });
-
-  it('rejects free-tier request bodies over the byte cap', () => {
-    assert.deepEqual(checkRequestBodySizeLimit('abc', 3), {
-      allowed: true,
-      limitBytes: 3,
-      requestBytes: 3,
-    });
-    assert.deepEqual(checkRequestBodySizeLimit('abcd', 3), {
-      allowed: false,
-      limitBytes: 3,
-      requestBytes: 4,
-    });
-  });
-
-  it('counts UTF-8 bytes rather than JavaScript string length', () => {
-    const result = checkRequestBodySizeLimit('€', 2);
-
-    assert.equal(result.allowed, false);
-    assert.equal(result.requestBytes, 3);
-  });
-
-  it('uses existing byte lengths for binary request bodies', () => {
-    const result = checkRequestBodySizeLimit(new Uint8Array([0, 255, 1]), 2);
-
-    assert.equal(result.allowed, false);
-    assert.equal(result.requestBytes, 3);
   });
 
   it('reads accepted request streams without changing bytes', async () => {

--- a/supabase/functions/_shared/relayCiToken.ts
+++ b/supabase/functions/_shared/relayCiToken.ts
@@ -22,7 +22,7 @@ export const RELAY_CI_TOKEN_PREFIX = 'texra_relay_';
 /** Refresh last_used_at at most this often to avoid per-request writes. */
 const LAST_USED_REFRESH_MS = 60 * 1000;
 
-export function isRelayCiToken(token: string): boolean {
+function isRelayCiToken(token: string): boolean {
   return token.startsWith(RELAY_CI_TOKEN_PREFIX);
 }
 
@@ -43,7 +43,7 @@ export type CiTokenAuthResult =
  * Validate a CI relay token: hash lookup, revocation, expiry, and scope.
  * Refreshes last_used_at (throttled) as audit metadata on success.
  */
-export async function authenticateRelayCiToken(
+async function authenticateRelayCiToken(
   adminClient: SupabaseClient<any>,
   token: string,
   requiredScope = 'relay',

--- a/supabase/functions/relay/diagnostics.ts
+++ b/supabase/functions/relay/diagnostics.ts
@@ -15,31 +15,7 @@ const SAFE_REQUEST_ID_RE = /^[A-Za-z0-9._:-]{1,200}$/;
 type RelayRequestBody =
   string | Uint8Array | ReadableStream<Uint8Array> | null | undefined;
 
-function utf8ByteLength(value: string): number {
-  let bytes = 0;
-  for (let i = 0; i < value.length; i += 1) {
-    const codeUnit = value.charCodeAt(i);
-    if (codeUnit < 0x80) {
-      bytes += 1;
-    } else if (codeUnit < 0x800) {
-      bytes += 2;
-    } else if (
-      codeUnit >= 0xd800 &&
-      codeUnit <= 0xdbff &&
-      i + 1 < value.length &&
-      value.charCodeAt(i + 1) >= 0xdc00 &&
-      value.charCodeAt(i + 1) <= 0xdfff
-    ) {
-      bytes += 4;
-      i += 1;
-    } else {
-      bytes += 3;
-    }
-  }
-  return bytes;
-}
-
-export interface RelayFailureDiagnostic {
+interface RelayFailureDiagnostic {
   relayRequestId: string;
   provider: string;
   model: string | null;
@@ -96,7 +72,9 @@ export function getRelayRequestBytes(
   contentLength: string | null,
 ): number | null {
   if (body == null) return 0;
-  if (typeof body === 'string') return utf8ByteLength(body);
+  if (typeof body === 'string') {
+    return new TextEncoder().encode(body).byteLength;
+  }
   if (body instanceof Uint8Array) return body.byteLength;
 
   if (contentLength == null || contentLength.trim() === '') return null;

--- a/supabase/functions/relay/models.ts
+++ b/supabase/functions/relay/models.ts
@@ -18,9 +18,10 @@
 
 import { MODEL_CONFIGS, type ModelConfig } from 'llm-zoo';
 import { normalizeModelName, stripProviderPrefix } from './modelNames.ts';
-import { FREE_TIER, MAX_TIER, ULTRA_TIER } from './tierConstants.ts';
 
-export { FREE_TIER, MAX_TIER, ULTRA_TIER };
+export const ULTRA_TIER = 'Ultra';
+export const MAX_TIER = 'Max';
+export const FREE_TIER = 'free';
 
 // =============================================================================
 // Types

--- a/supabase/functions/relay/requestGate.ts
+++ b/supabase/functions/relay/requestGate.ts
@@ -30,7 +30,7 @@ export type RelayRequestSlot =
       decision: GateDecision;
     };
 
-export const RELAY_SLOT_REFRESH_INTERVAL_MS = 60_000;
+const RELAY_SLOT_REFRESH_INTERVAL_MS = 60_000;
 
 class RelayRequestSlotLostError extends Error {
   constructor() {

--- a/supabase/functions/relay/requestLimits.ts
+++ b/supabase/functions/relay/requestLimits.ts
@@ -15,8 +15,6 @@ const BYTES_PER_MIB = BYTES_PER_KIB * 1024;
 export const FREE_TIER_REQUEST_BODY_LIMIT_BYTES = 2 * BYTES_PER_MIB;
 export const FREE_TIER_MAX_OUTPUT_TOKENS = 8192;
 
-const textEncoder = new TextEncoder();
-
 export interface RequestBodySizeCheck {
   allowed: boolean;
   limitBytes: number;
@@ -26,28 +24,6 @@ export interface RequestBodySizeCheck {
 export type RequestBodyReadResult =
   | (RequestBodySizeCheck & { allowed: true; body: Uint8Array })
   | (RequestBodySizeCheck & { allowed: false; body: null });
-
-export type RequestBodyForSizeCheck =
-  string | ArrayBuffer | ArrayBufferView | null;
-
-function requestBodyByteLength(body: RequestBodyForSizeCheck): number {
-  if (body == null) return 0;
-  if (typeof body === 'string') return textEncoder.encode(body).byteLength;
-  return body.byteLength;
-}
-
-export function checkRequestBodySizeLimit(
-  body: RequestBodyForSizeCheck,
-  limitBytes: number = FREE_TIER_REQUEST_BODY_LIMIT_BYTES,
-): RequestBodySizeCheck {
-  const requestBytes = requestBodyByteLength(body);
-
-  return {
-    allowed: requestBytes <= limitBytes,
-    limitBytes,
-    requestBytes,
-  };
-}
 
 function concatChunks(chunks: Uint8Array[], byteLength: number): Uint8Array {
   const body = new Uint8Array(byteLength);

--- a/supabase/functions/relay/tierConstants.ts
+++ b/supabase/functions/relay/tierConstants.ts
@@ -1,4 +1,0 @@
-/** Tier value constants shared by relay modules. */
-export const ULTRA_TIER = 'Ultra';
-export const MAX_TIER = 'Max';
-export const FREE_TIER = 'free';


### PR DESCRIPTION
## Summary

Remove unused public surfaces across the runtime model registry, CLI auth, Supabase relay, and client tier schema. Replace the relay UTF-8 byte-count implementation with TextEncoder and move tier constants into the relay model module that owns tier classification.

Closes #8877.

## Issue acceptance gates

- Removes the identified unused class static, runtime registry export, Deno relay exports, and test-only request-size helper.
- Keeps live relay request-size enforcement and its boundary tests intact.
- Re-runs free-tier request-limit, reasoning-cap, shared-config, and runtime-model tests.
- Relay source changes ride the next planned relay deployment; this refactor does not trigger a deployment by itself.

## Single source of truth

supabase/functions/relay/models.ts now owns relay tier names alongside model tier classification. Native TextEncoder owns UTF-8 byte measurement.

## Duplication and abstraction budget

Deletes a constants forwarding module, a hand-written UTF-8 implementation, a test-only production helper, and unused exports. Adds no abstraction.

## Net elements (R6)

- Files: 12 modified, 1 deleted.
- Exported symbols: 12 removed and 3 added in the owning module, net -9.
- Classes/interfaces/enums: one exported interface made file-local; no new class, interface, or enum.
- LoC: +12 / -104, net -92.

## Consumer counts (R8)

Each removed public surface had zero production consumers outside its defining file. The deleted tierConstants module had one test consumer, repointed to the owning models module. The removed runtimeModelIds assertions were redundant with adjacent access/config and discovery-entry assertions.

## Host impact

Extension: Removes unused Supabase and runtime-model API surface; no behavior change.

Desktop: No behavior change.

CLI: Makes the session-tier helper file-local; no behavior change.

## Scheduled refactoring

None.

## Validation

- npm run format
- npm run typecheck
- npm run lint (0 errors; one pre-existing warning in AgentCreatorToolCatalogParity.vitest.mts)
- npm run check:dead-code-ratchet
- npm run compile:fast
- npm test: 741 passed, 1 skipped; 6,868 tests passed, 4 skipped
- Exact-head focused tests after rebasing onto current main: 4 files, 59 tests passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Net deletion of unused exports and helpers with tests updated; live relay body limits and usage-tier resolution paths are unchanged.
> 
> **Overview**
> Trims **unused public API** across the CLI, client auth, runtime model registry, and Supabase relay with **no intended runtime behavior change**.
> 
> **Client / CLI:** Drops `SupabaseClient.getConfig()` and makes `getCliSessionTier` file-local (still used by `resolveCliUsageTier`). Removes `runtimeModelIds()` and the unused `daysRemaining` field from `UserAccessStatusSchema`.
> 
> **Relay (Deno):** Deletes `tierConstants.ts` and defines `FREE_TIER` / `Max` / `Ultra` in `models.ts`. Stops exporting CI-token helpers and `RELAY_SLOT_REFRESH_INTERVAL_MS` where only in-module callers remain. Removes the unused `checkRequestBodySizeLimit` helper while keeping **`readRequestBodyWithinSizeLimit`** as the enforcement path. Replaces a hand-rolled UTF-8 byte counter in diagnostics with **`TextEncoder`**.
> 
> **Tests:** Repoint tier imports to `models.ts`, drop redundant `runtimeModelIds` / `checkRequestBodySizeLimit` coverage, and rely on existing stream-read and `getRelayRequestBytes` tests for size measurement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e0fda4729596eb473ad2cc72328380735ce98f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->