### PR TITLE
refactor: remove dead auth and relay surfaces

### DIFF
--- a/packages/cli/src/runtime/supabaseAuth.ts
+++ b/packages/cli/src/runtime/supabaseAuth.ts
@@ -260,7 +260,7 @@ export async function getCliSessionAccessToken(): Promise<string | null> {
  * limit must use this tier — `getCliAuthProfile().tier` may describe the
  * env token's account instead.
  */
-export async function getCliSessionTier(): Promise<string> {
+async function getCliSessionTier(): Promise<string> {
   return SupabaseClient.getSessionTier();
 }
 

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -375,9 +375,4 @@ export class SupabaseClient {
   static async canAccessRemoteAgentCatalog(): Promise<boolean> {
     return (await this.getAccessToken()) !== null;
   }
-
-  /** Get configuration for re-initialization. */
-  static getConfig(): { url: string; publicKey: string } | null {
-    return this.config;
-  }
 }

--- a/src/auth/tier/types.ts
+++ b/src/auth/tier/types.ts
@@ -31,8 +31,6 @@ export const UserAccessStatusSchema = z.object({
   accessExpiresAt: z.string().nullable(),
   /** Whether access is currently expired */
   isExpired: z.boolean(),
-  /** Days until expiration (negative if expired, null if no expiration) */
-  daysRemaining: z.number().nullable(),
 });
 export type UserAccessStatus = z.infer<typeof UserAccessStatusSchema>;
 

--- a/src/model/runtimeModelRegistry.ts
+++ b/src/model/runtimeModelRegistry.ts
@@ -192,11 +192,6 @@ export function availableRuntimeModelIds(): readonly string[] {
     .map(([id]) => id);
 }
 
-/** All compatible editor-supplied models, including models awaiting consent. */
-export function runtimeModelIds(): readonly string[] {
-  return [...runtimeModels.keys()];
-}
-
 /** Access state reported by the editor for a discovered runtime model. */
 export function runtimeModelAccess(
   model: string,

--- a/src/test-kernel/model/RuntimeModelRegistry.vitest.ts
+++ b/src/test-kernel/model/RuntimeModelRegistry.vitest.ts
@@ -17,7 +17,7 @@ import {
   requestRuntimeModelAccess,
   resolveRuntimeModelConfig,
   runtimeModelAccess,
-  runtimeModelIds,
+  runtimeModelConfigEntries,
 } from '@model/runtimeModelRegistry';
 import type {
   LanguageModelInfo,
@@ -161,7 +161,6 @@ describe('runtime model registry', () => {
     await refreshRuntimeModelRegistry();
 
     expect(availableRuntimeModelIds()).toEqual([]);
-    expect(runtimeModelIds()).toEqual(['copilot:sonnet46']);
     expect(runtimeModelAccess('copilot:sonnet46')).toBe('unavailable');
     expect(getRuntimeModelConfig('copilot:sonnet46')).toBeDefined();
   });
@@ -370,6 +369,8 @@ describe('runtime model registry', () => {
     );
 
     await expect(discoveredRuntimeModelConfigEntries()).resolves.toEqual([]);
-    expect(runtimeModelIds()).toEqual([]);
+    expect(
+      runtimeModelConfigEntries().some(([id]) => id.startsWith('copilot:')),
+    ).toBe(false);
   });
 });

--- a/src/test-kernel/supabase/RelayReasoningCaps.vitest.ts
+++ b/src/test-kernel/supabase/RelayReasoningCaps.vitest.ts
@@ -7,7 +7,7 @@ import {
   FREE_TIER,
   MAX_TIER,
   ULTRA_TIER,
-} from '../../../supabase/functions/relay/tierConstants';
+} from '../../../supabase/functions/relay/models';
 
 const TIER_CAPS = {
   [FREE_TIER]: 'medium',

--- a/src/test-kernel/supabase/RelayRequestLimits.vitest.ts
+++ b/src/test-kernel/supabase/RelayRequestLimits.vitest.ts
@@ -8,7 +8,6 @@ import { describe, it, vi } from 'vitest';
 import {
   FREE_TIER_MAX_OUTPUT_TOKENS,
   FREE_TIER_REQUEST_BODY_LIMIT_BYTES,
-  checkRequestBodySizeLimit,
   clampFreeTierMaxOutputTokens,
   formatRequestBytes,
   readRequestBodyWithinSizeLimit,
@@ -84,33 +83,6 @@ function createGateClient(
 describe('relay free-tier request limits', () => {
   it('allows four concurrent free-tier requests', () => {
     assert.equal(getRequestLimits('free').concurrent, 4);
-  });
-
-  it('rejects free-tier request bodies over the byte cap', () => {
-    assert.deepEqual(checkRequestBodySizeLimit('abc', 3), {
-      allowed: true,
-      limitBytes: 3,
-      requestBytes: 3,
-    });
-    assert.deepEqual(checkRequestBodySizeLimit('abcd', 3), {
-      allowed: false,
-      limitBytes: 3,
-      requestBytes: 4,
-    });
-  });
-
-  it('counts UTF-8 bytes rather than JavaScript string length', () => {
-    const result = checkRequestBodySizeLimit('€', 2);
-
-    assert.equal(result.allowed, false);
-    assert.equal(result.requestBytes, 3);
-  });
-
-  it('uses existing byte lengths for binary request bodies', () => {
-    const result = checkRequestBodySizeLimit(new Uint8Array([0, 255, 1]), 2);
-
-    assert.equal(result.allowed, false);
-    assert.equal(result.requestBytes, 3);
   });
 
   it('reads accepted request streams without changing bytes', async () => {

--- a/supabase/functions/_shared/relayCiToken.ts
+++ b/supabase/functions/_shared/relayCiToken.ts
@@ -22,7 +22,7 @@ export const RELAY_CI_TOKEN_PREFIX = 'texra_relay_';
 /** Refresh last_used_at at most this often to avoid per-request writes. */
 const LAST_USED_REFRESH_MS = 60 * 1000;
 
-export function isRelayCiToken(token: string): boolean {
+function isRelayCiToken(token: string): boolean {
   return token.startsWith(RELAY_CI_TOKEN_PREFIX);
 }
 
@@ -43,7 +43,7 @@ export type CiTokenAuthResult =
  * Validate a CI relay token: hash lookup, revocation, expiry, and scope.
  * Refreshes last_used_at (throttled) as audit metadata on success.
  */
-export async function authenticateRelayCiToken(
+async function authenticateRelayCiToken(
   adminClient: SupabaseClient<any>,
   token: string,
   requiredScope = 'relay',

--- a/supabase/functions/relay/diagnostics.ts
+++ b/supabase/functions/relay/diagnostics.ts
@@ -15,31 +15,7 @@ const SAFE_REQUEST_ID_RE = /^[A-Za-z0-9._:-]{1,200}$/;
 type RelayRequestBody =
   string | Uint8Array | ReadableStream<Uint8Array> | null | undefined;
 
-function utf8ByteLength(value: string): number {
-  let bytes = 0;
-  for (let i = 0; i < value.length; i += 1) {
-    const codeUnit = value.charCodeAt(i);
-    if (codeUnit < 0x80) {
-      bytes += 1;
-    } else if (codeUnit < 0x800) {
-      bytes += 2;
-    } else if (
-      codeUnit >= 0xd800 &&
-      codeUnit <= 0xdbff &&
-      i + 1 < value.length &&
-      value.charCodeAt(i + 1) >= 0xdc00 &&
-      value.charCodeAt(i + 1) <= 0xdfff
-    ) {
-      bytes += 4;
-      i += 1;
-    } else {
-      bytes += 3;
-    }
-  }
-  return bytes;
-}
-
-export interface RelayFailureDiagnostic {
+interface RelayFailureDiagnostic {
   relayRequestId: string;
   provider: string;
   model: string | null;
@@ -96,7 +72,8 @@ export function getRelayRequestBytes(
   contentLength: string | null,
 ): number | null {
   if (body == null) return 0;
-  if (typeof body === 'string') return utf8ByteLength(body);
+  if (typeof body === 'string')
+    return new TextEncoder().encode(body).byteLength;
   if (body instanceof Uint8Array) return body.byteLength;
 
   if (contentLength == null || contentLength.trim() === '') return null;

--- a/supabase/functions/relay/models.ts
+++ b/supabase/functions/relay/models.ts
@@ -18,9 +18,11 @@
 
 import { MODEL_CONFIGS, type ModelConfig } from 'llm-zoo';
 import { normalizeModelName, stripProviderPrefix } from './modelNames.ts';
-import { FREE_TIER, MAX_TIER, ULTRA_TIER } from './tierConstants.ts';
 
-export { FREE_TIER, MAX_TIER, ULTRA_TIER };
+/** Tier value constants shared by relay modules. */
+export const ULTRA_TIER = 'Ultra';
+export const MAX_TIER = 'Max';
+export const FREE_TIER = 'free';
 
 // =============================================================================
 // Types

--- a/supabase/functions/relay/requestGate.ts
+++ b/supabase/functions/relay/requestGate.ts
@@ -30,7 +30,7 @@ export type RelayRequestSlot =
       decision: GateDecision;
     };
 
-export const RELAY_SLOT_REFRESH_INTERVAL_MS = 60_000;
+const RELAY_SLOT_REFRESH_INTERVAL_MS = 60_000;
 
 class RelayRequestSlotLostError extends Error {
   constructor() {

--- a/supabase/functions/relay/requestLimits.ts
+++ b/supabase/functions/relay/requestLimits.ts
@@ -15,8 +15,6 @@ const BYTES_PER_MIB = BYTES_PER_KIB * 1024;
 export const FREE_TIER_REQUEST_BODY_LIMIT_BYTES = 2 * BYTES_PER_MIB;
 export const FREE_TIER_MAX_OUTPUT_TOKENS = 8192;
 
-const textEncoder = new TextEncoder();
-
 export interface RequestBodySizeCheck {
   allowed: boolean;
   limitBytes: number;
@@ -26,28 +24,6 @@ export interface RequestBodySizeCheck {
 export type RequestBodyReadResult =
   | (RequestBodySizeCheck & { allowed: true; body: Uint8Array })
   | (RequestBodySizeCheck & { allowed: false; body: null });
-
-export type RequestBodyForSizeCheck =
-  string | ArrayBuffer | ArrayBufferView | null;
-
-function requestBodyByteLength(body: RequestBodyForSizeCheck): number {
-  if (body == null) return 0;
-  if (typeof body === 'string') return textEncoder.encode(body).byteLength;
-  return body.byteLength;
-}
-
-export function checkRequestBodySizeLimit(
-  body: RequestBodyForSizeCheck,
-  limitBytes: number = FREE_TIER_REQUEST_BODY_LIMIT_BYTES,
-): RequestBodySizeCheck {
-  const requestBytes = requestBodyByteLength(body);
-
-  return {
-    allowed: requestBytes <= limitBytes,
-    limitBytes,
-    requestBytes,
-  };
-}
 
 function concatChunks(chunks: Uint8Array[], byteLength: number): Uint8Array {
   const body = new Uint8Array(byteLength);

--- a/supabase/functions/relay/tierConstants.ts
+++ b/supabase/functions/relay/tierConstants.ts
@@ -1,4 +1,0 @@
-/** Tier value constants shared by relay modules. */
-export const ULTRA_TIER = 'Ultra';
-export const MAX_TIER = 'Max';
-export const FREE_TIER = 'free';


### PR DESCRIPTION
## Summary

Remove dead surfaces from the three places the dead-export ratchet cannot fully observe: class static members, the unscanned Deno tree, and exports retained only by tests. The client and relay behavior is unchanged. The relay portion is explicitly deployment-pending and must ride the next planned relay deployment; this pull request does not deploy it.

Closes #8877.

## Issue acceptance gates

- Delete the zero-caller `SupabaseClient.getConfig()` static.
- Delete `runtimeModelIds()` and rewrite its two test assertions using the adjacent access/config facts and `runtimeModelConfigEntries()`.
- Delete the unused relay request-size checker type, helper, public function, and their isolated tests; streamed request enforcement remains unchanged.
- Delete the handwritten UTF-8 byte counter and use `TextEncoder` at its sole call site.
- Move the three relay tier constants into `models.ts`, delete `tierConstants.ts`, and retarget `RelayReasoningCaps.vitest.ts`.
- Remove the client-only `daysRemaining` schema field. The relay deliberately continues to emit it; Zod strips the now-unknown field, and no client code reads it.
- Make `getCliSessionTier`, `isRelayCiToken`, `authenticateRelayCiToken`, `RELAY_SLOT_REFRESH_INTERVAL_MS`, and `RelayFailureDiagnostic` file-local.
- Re-run the free-tier and Ultra-only relay fences, Deno checking, linting, and relay tests.
- Record the three dead-code-ratchet blind spots on tracker #8787.

## Single source of truth

`supabase/functions/relay/models.ts` owns the relay tier constants it already exports. Streamed request-body enforcement remains solely in `readRequestBodyWithinSizeLimit`. The runtime registry exposes entries and access facts rather than a second test-only identifier list.

## Duplication and abstraction budget

One file, eight dead elements, five unnecessary export modifiers, and four tests of a dead helper are removed. One standard-library byte-count expression replaces a private 23-line implementation. No abstraction is added.

## Net elements (R6)

- Files: 0 added, 1 deleted.
- Source lines: 16 added, 104 deleted; net **-88 LoC**.
- Elements: net **-9**, following the issue's verifier convention: eight symbols/files cease to exist, while five surviving symbols become file-local and are counted as public-surface reductions.

## Consumer counts (R8)

- `SupabaseClient.getConfig`: 0 callers.
- `runtimeModelIds`: 0 production callers; 2 test-only assertions rewritten.
- Relay request-size checker trio: 0 production callers; isolated tests deleted.
- `utf8ByteLength`: 1 internal caller, replaced directly.
- `tierConstants.ts`: 2 importers, both retargeted to `models.ts` (production and `RelayReasoningCaps`).
- `daysRemaining`: 0 client readers; relay production unchanged.
- Five de-exported symbols: same-file consumers only.

## Host impact

Extension: Dead static and client schema fields are removed; behavior is unchanged.

Desktop: Shared client cleanup only; behavior is unchanged.

CLI: One helper becomes file-local; behavior is unchanged.

Relay: Source cleanup is behavior-preserving but **requires the next planned edge-function deployment**. No deployment is performed by this pull request. Before that deployment, re-run the free-tier request gates and Ultra-only provider/model fences.

## Scheduled refactoring

Deployment follow-up: include the relay source changes in the next coordinated edge-function deployment. Do not deploy solely for this cleanup.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint` (passes with the pre-existing `AgentCreatorToolCatalogParity.vitest.mts:44` warning)
- `npm run check:dead-code-ratchet`
- 74 focused Vitest tests across runtime registry, CLI auth, relay request limits, reasoning caps, model access, and shared-config parity
- `deno check index.ts *_test.ts`
- `deno lint`
- `deno test --allow-env` (8/8 relay enforcement tests pass)
- `npm run compile:fast`
- No deployment performed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Removals are zero-caller or test-only rewrites; runtime paths (stream body limits, relay gating, auth) are unchanged. Relay edits need the next planned deployment to take effect in production.
> 
> **Overview**
> Behavior-preserving cleanup that **shrinks public API surface** and deletes unused code across the client, CLI, and relay edge functions (~88 net LoC removed).
> 
> **Client:** Drops unused `SupabaseClient.getConfig()`, the `runtimeModelIds()` export (tests now assert via `runtimeModelAccess` / `runtimeModelConfigEntries`), and **`daysRemaining`** from `UserAccessStatusSchema` (relay may still send it; Zod strips unknown fields).
> 
> **CLI:** `getCliSessionTier` is file-local; still used by `resolveCliUsageTier` for CI relay usage tier resolution.
> 
> **Relay (deploy with next edge release):** Tier constants move from deleted `tierConstants.ts` into `models.ts`. Removes the unused synchronous `checkRequestBodySizeLimit` path; **streamed** enforcement via `readRequestBodyWithinSizeLimit` is unchanged. Replaces a custom UTF-8 byte counter in diagnostics with `TextEncoder`. Several symbols (`isRelayCiToken`, `authenticateRelayCiToken`, `RELAY_SLOT_REFRESH_INTERVAL_MS`, `RelayFailureDiagnostic`) are de-exported to module scope only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d49606f4a01369b426a0e14bbf033c22b65af14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->