### PR TITLE
refactor: unify authentication logging

### DIFF
--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -20,7 +20,6 @@ import {
   getServerSideKeyService,
   initializeServerSideKeyAccess,
 } from '@auth/serverKeys';
-import type { AuthServiceLogger } from '@auth/serviceLogger';
 import type { AuthCallbackUriParts } from '@auth/core/authCallback';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { TEXRA_PROTOCOL } from '../desktopProtocol.js';
@@ -427,7 +426,7 @@ export function initializeDesktopServerSideKeyAccess(
 ): void {
   initializeServerSideKeyAccess({
     state: platform().globalState,
-    logger: createAuthServiceLogger(log),
+    logger: createSessionLog(log),
   });
 }
 
@@ -503,15 +502,6 @@ function createSessionLog(log: DesktopAuthLog): SupabaseSessionLog {
     debug: (source, message) => log.debug(`[${source}] ${message}`),
     info: (source, message) => log.info(`[${source}] ${message}`),
     warn: (source, message) => log.warn(`[${source}] ${message}`),
-    error: (source, message) => log.error(`[${source}] ${message}`),
-  };
-}
-
-function createAuthServiceLogger(
-  log: Pick<DesktopAuthLog, 'info' | 'error'>,
-): AuthServiceLogger {
-  return {
-    info: (source, message) => log.info(`[${source}] ${message}`),
     error: (source, message) => log.error(`[${source}] ${message}`),
   };
 }

--- a/src/auth/codex/CodexSessionCoordinator.ts
+++ b/src/auth/codex/CodexSessionCoordinator.ts
@@ -47,11 +47,6 @@ export interface CodexOAuthClient {
   refreshTokens(refreshToken: string): Promise<CodexTokenResponse>;
 }
 
-export interface CodexLogger {
-  debug?(message: string): void;
-  warn?(message: string): void;
-}
-
 export interface CodexSessionStatus {
   signedIn: boolean;
   email?: string;
@@ -68,7 +63,6 @@ export interface CodexAuthorizeRequest {
 export interface CodexSessionCoordinatorInit {
   storage: CodexSessionStorage;
   client?: CodexOAuthClient;
-  log?: CodexLogger;
   /** Injectable clock for tests; defaults to Date.now. */
   now?: () => number;
 }
@@ -76,7 +70,6 @@ export interface CodexSessionCoordinatorInit {
 export class CodexSessionCoordinator {
   private readonly storage: CodexSessionStorage;
   private readonly client: CodexOAuthClient;
-  private readonly log?: CodexLogger;
   private readonly now: () => number;
   private refreshInFlight: Promise<CodexSession> | null = null;
   /**
@@ -94,7 +87,6 @@ export class CodexSessionCoordinator {
       exchangeAuthorizationCode: defaultExchange,
       refreshTokens: defaultRefresh,
     };
-    this.log = init.log;
     this.now = init.now ?? (() => Date.now());
   }
 
@@ -104,12 +96,10 @@ export class CodexSessionCoordinator {
     if (!raw) return null;
     const parsedJson = safeParseJson(raw);
     if (parsedJson.isErr()) {
-      this.log?.warn?.('Codex session storage was not valid JSON; ignoring.');
       return null;
     }
     const result = CodexSessionSchema.safeParse(parsedJson.value);
     if (!result.success) {
-      this.log?.warn?.('Codex session bundle failed validation; ignoring.');
       return null;
     }
     return result.data;
@@ -299,7 +289,6 @@ export class CodexSessionCoordinator {
         // whose store is queued behind it.
         await this.mutateSession(async () => {
           if (generation !== this.sessionGeneration) return;
-          this.log?.warn?.('Codex token refresh was rejected; signing out.');
           await this.storage.delete();
         });
       }

--- a/src/auth/codex/codexDeviceLogin.ts
+++ b/src/auth/codex/codexDeviceLogin.ts
@@ -7,10 +7,7 @@
 import { setTimeout as sleep } from 'node:timers/promises';
 
 import { CODEX_DEVICE_VERIFICATION_URL } from './codexConstants';
-import {
-  type CodexLogger,
-  type CodexSessionCoordinator,
-} from './CodexSessionCoordinator';
+import { type CodexSessionCoordinator } from './CodexSessionCoordinator';
 import { CodexAuthError, type CodexSession } from './codexSessionTypes';
 import {
   deviceUserCode,
@@ -33,7 +30,6 @@ export interface CodexDeviceLoginOptions {
   onPrompt: (prompt: CodexDevicePrompt) => void;
   /** Optional heartbeat called once per poll (e.g. to print a dot). */
   onPoll?: () => void;
-  log?: CodexLogger;
   signal?: AbortSignal;
 }
 

--- a/src/auth/codex/codexLoopbackLogin.ts
+++ b/src/auth/codex/codexLoopbackLogin.ts
@@ -14,10 +14,7 @@ import {
   CODEX_CALLBACK_PATH,
   CODEX_CALLBACK_PORT,
 } from './codexConstants';
-import {
-  type CodexLogger,
-  type CodexSessionCoordinator,
-} from './CodexSessionCoordinator';
+import { type CodexSessionCoordinator } from './CodexSessionCoordinator';
 import { type CodexSession } from './codexSessionTypes';
 
 const CALLBACK_TIMEOUT_MS = 5 * 60 * 1000;
@@ -38,7 +35,6 @@ export interface CodexLoopbackLoginOptions {
   coordinator: CodexSessionCoordinator;
   /** Open the consent URL in the user's browser. */
   openBrowser: (url: string) => void | Promise<void>;
-  log?: CodexLogger;
   signal?: AbortSignal;
 }
 
@@ -88,7 +84,7 @@ async function bindLoopbackServer(): Promise<{
 export async function loginWithLoopback(
   options: CodexLoopbackLoginOptions,
 ): Promise<CodexSession> {
-  const { coordinator, openBrowser, log, signal } = options;
+  const { coordinator, openBrowser, signal } = options;
   const { server, port } = await bindLoopbackServer();
   const authorize = coordinator.buildAuthorizeRequest(port);
   let callbackTimer: ReturnType<typeof setTimeout> | undefined;
@@ -157,7 +153,6 @@ export async function loginWithLoopback(
   });
 
   try {
-    log?.debug?.(`Opening ChatGPT sign-in on loopback port ${port}.`);
     await Promise.race([
       Promise.resolve(openBrowser(authorize.url)),
       cancellationPromise,

--- a/src/auth/serverKeys/ServerSideKeyService.ts
+++ b/src/auth/serverKeys/ServerSideKeyService.ts
@@ -191,7 +191,7 @@ export class ServerSideKeyService {
       return true;
     } catch (error) {
       // Denied by error (auth/network failure), not by policy — log so the two
-      // are distinguishable. The interface exposes only info/error levels.
+      // are distinguishable.
       this.logger.error?.(
         CHANNEL,
         `Access check failed, treating as denied: ${toErrorMessage(error)}`,

--- a/src/auth/serverKeys/ServerSideKeyService.ts
+++ b/src/auth/serverKeys/ServerSideKeyService.ts
@@ -22,10 +22,7 @@ import {
   FREE_TIER,
   type UserTier,
 } from '../config';
-import {
-  NOOP_AUTH_SERVICE_LOGGER,
-  type AuthServiceLogger,
-} from '../serviceLogger';
+import type { SupabaseSessionLog } from '../supabaseSessionTypes';
 import type { StateStore } from '@platform/interfaces';
 import type { TierService } from '../tier/TierService';
 import type { ServerSideProvider } from './types';
@@ -96,7 +93,7 @@ export class ServerSideKeyService {
     private readonly baseUrl: string,
     private readonly tierService: TierService,
     private readonly globalState: StateStore | null = null,
-    private readonly logger: AuthServiceLogger = NOOP_AUTH_SERVICE_LOGGER,
+    private readonly logger: SupabaseSessionLog = {},
     private readonly notifyIncludedModelAccessChanged: (
       enabled: boolean,
     ) => void = () => {},
@@ -147,7 +144,7 @@ export class ServerSideKeyService {
       try {
         this.notifyIncludedModelAccessChanged(value);
       } catch (error) {
-        this.logger.error(
+        this.logger.error?.(
           CHANNEL,
           `Event listener failed: ${toErrorMessage(error)}`,
         );
@@ -195,7 +192,7 @@ export class ServerSideKeyService {
     } catch (error) {
       // Denied by error (auth/network failure), not by policy — log so the two
       // are distinguishable. The interface exposes only info/error levels.
-      this.logger.error(
+      this.logger.error?.(
         CHANNEL,
         `Access check failed, treating as denied: ${toErrorMessage(error)}`,
       );
@@ -236,13 +233,13 @@ export class ServerSideKeyService {
       ]);
 
       if (this.tierService.isAccessExpired()) {
-        this.logger.info(CHANNEL, 'User access has expired');
+        this.logger.info?.(CHANNEL, 'User access has expired');
         this.accessResult = false;
         return false;
       }
 
       if (!this.hasFullAccess() && tierConfig === null) {
-        this.logger.info(
+        this.logger.info?.(
           CHANNEL,
           'Tier config unavailable for non-Ultra user, denying access',
         );
@@ -269,7 +266,7 @@ export class ServerSideKeyService {
         this.tierService.isQuotaExceeded()
       ) {
         this.quotaFlipApplied = true;
-        this.logger.info(
+        this.logger.info?.(
           CHANNEL,
           'Relay quota exhausted; switching useIncludedModelAccess off',
         );

--- a/src/auth/serverKeys/index.ts
+++ b/src/auth/serverKeys/index.ts
@@ -16,7 +16,7 @@
 import { SUPABASE_CUSTOM_DOMAIN } from '../config';
 import { getTierService } from '../tier';
 import { ServerSideKeyService } from './ServerSideKeyService';
-import type { AuthServiceLogger } from '../serviceLogger';
+import type { SupabaseSessionLog } from '../supabaseSessionTypes';
 import type { StateStore } from '@platform/interfaces';
 
 // Types
@@ -59,7 +59,7 @@ export function setServerSideKeyService(service: ServerSideKeyService): void {
  */
 export function initializeServerSideKeyAccess(options: {
   state?: StateStore;
-  logger?: AuthServiceLogger;
+  logger?: SupabaseSessionLog;
   notifyIncludedModelAccessChanged?: (enabled: boolean) => void;
 }): void {
   _instance = new ServerSideKeyService(

--- a/src/auth/serviceLogger.ts
+++ b/src/auth/serviceLogger.ts
@@ -1,9 +1,0 @@
-export interface AuthServiceLogger {
-  info(channel: string, message: string): void;
-  error(channel: string, message: string): void;
-}
-
-export const NOOP_AUTH_SERVICE_LOGGER: AuthServiceLogger = {
-  info() {},
-  error() {},
-};

--- a/src/auth/tier/TierService.ts
+++ b/src/auth/tier/TierService.ts
@@ -25,16 +25,13 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 import { formatResultCount } from '@utils/text/stringUtils';
 import { SERVER_SIDE_CACHE_TTL_MS, type UserTier } from '../config';
 import {
-  NOOP_AUTH_SERVICE_LOGGER,
-  type AuthServiceLogger,
-} from '../serviceLogger';
-import {
   TierModelConfigSchema,
   UserAccessStatusSchema,
   type TierModelConfig,
   type TierModelsConfig,
   type UserAccessStatus,
 } from './types';
+import type { SupabaseSessionLog } from '../supabaseSessionTypes';
 
 const CHANNEL = 'TierService';
 
@@ -91,7 +88,7 @@ export class TierService {
    */
   constructor(
     private readonly baseUrl: string,
-    private readonly logger: AuthServiceLogger = NOOP_AUTH_SERVICE_LOGGER,
+    private readonly logger: SupabaseSessionLog = {},
   ) {
     this.configCache = new LRUCache<
       TierCacheKey,
@@ -152,7 +149,7 @@ export class TierService {
     if (raw === undefined || raw === null) return null;
     const parsed = schema.safeParse(raw);
     if (parsed.success) return parsed.data;
-    this.logger.error(
+    this.logger.error?.(
       CHANNEL,
       `Invalid ${label} payload: ${z.prettifyError(parsed.error)}`,
     );
@@ -192,7 +189,7 @@ export class TierService {
       // A sign-out (clearCache) aborts the request; that is expected, so stay
       // quiet. Genuine network failures keep the previous error log.
       if (!signal.aborted) {
-        this.logger.error(
+        this.logger.error?.(
           CHANNEL,
           `Error fetching tier config: ${toErrorMessage(error)}`,
         );
@@ -202,12 +199,12 @@ export class TierService {
 
     if (!response.ok) {
       if (response.status === 404) {
-        this.logger.info(
+        this.logger.info?.(
           CHANNEL,
           'Tier-config endpoint not available, using defaults',
         );
       } else {
-        this.logger.error(
+        this.logger.error?.(
           CHANNEL,
           `Failed to fetch tier config: ${response.status}`,
         );
@@ -219,7 +216,7 @@ export class TierService {
     try {
       data = await response.json();
     } catch (error) {
-      this.logger.error(
+      this.logger.error?.(
         CHANNEL,
         `Failed to parse tier config JSON: ${toErrorMessage(error)}`,
       );
@@ -244,7 +241,7 @@ export class TierService {
 
     const parsed = TierModelConfigSchema.safeParse(data);
     if (!parsed.success) {
-      this.logger.error(
+      this.logger.error?.(
         CHANNEL,
         `Invalid tier config response: ${z.prettifyError(parsed.error)}`,
       );

--- a/src/auth/tier/index.ts
+++ b/src/auth/tier/index.ts
@@ -19,7 +19,7 @@
 
 import { SUPABASE_CUSTOM_DOMAIN } from '../config';
 import { TierService } from './TierService';
-import type { AuthServiceLogger } from '../serviceLogger';
+import type { SupabaseSessionLog } from '../supabaseSessionTypes';
 
 // Service class (internal use only)
 export { TierService };
@@ -33,7 +33,7 @@ let _instance: TierService | null = null;
 /**
  * Get the singleton TierService instance.
  */
-export function getTierService(logger?: AuthServiceLogger): TierService {
+export function getTierService(logger?: SupabaseSessionLog): TierService {
   if (!_instance) {
     _instance = new TierService(`https://${SUPABASE_CUSTOM_DOMAIN}`, logger);
   }


### PR DESCRIPTION
## Summary

Uses `SupabaseSessionLog` as the single logger contract for authentication services. This deletes the smaller overlapping `AuthServiceLogger` contract, its no-operation singleton, and the desktop adapter that duplicated `createSessionLog`.

The unused Codex logger interface, four injection fields, and four permanently inactive calls are also deleted. No caller supplied that logger.

Closes #8882.

## Issue acceptance gates

- Delete `src/auth/serviceLogger.ts`, `AuthServiceLogger`, and `NOOP_AUTH_SERVICE_LOGGER`.
- Type `TierService`, `ServerSideKeyService`, and their composition functions with `SupabaseSessionLog`.
- Use optional calls for all 11 service log sites.
- Delete desktop `createAuthServiceLogger` and reuse `createSessionLog`.
- Delete `CodexLogger`, all four Codex logger fields, and the four inactive log calls.
- Preserve host-neutral authentication code.

Contract note: `SupabaseSessionLog` has optional methods, so a future partial logger may omit error output. All current hosts provide full channel loggers; current production output is unchanged.

## Single source of truth

`SupabaseSessionLog` in `src/auth/supabaseSessionTypes.ts` is the sole authentication service logger contract.

## Duplication and abstraction budget

Deletes one overlapping interface, one no-operation singleton, one duplicate desktop adapter, and the entire unused Codex logging seam. No abstraction is added.

## Net elements (R6)

- Files: 1 deleted.
- Interfaces: 2 deleted (`AuthServiceLogger`, `CodexLogger`).
- Constants: 1 deleted (`NOOP_AUTH_SERVICE_LOGGER`).
- Functions: 1 deleted (`createAuthServiceLogger`).
- Net elements: -5.
- Net LoC: -45 (23 additions, 68 deletions).

## Consumer counts (R8)

- `AuthServiceLogger`: 5 importing consumers rerouted or removed.
- `NOOP_AUTH_SERVICE_LOGGER`: 2 consumers removed.
- `createAuthServiceLogger`: 1 caller replaced with `createSessionLog`.
- `CodexLogger`: 0 production or test producers; its four optional fields and four calls were inactive.
- No event or emit path changes.

## Host impact

Extension: no behavior change; its complete logger remains compatible.

Desktop: one shared adapter now supplies both session and server-key logging.

CLI: no behavior change; its complete logger remains compatible.

## Scheduled refactoring

None. The tier consolidation in #8876 can now proceed from this single logger contract.

## Validation

- `corepack pnpm install`
- `npm run format`
- `npm run typecheck`
- `npm run lint` (passes with one pre-existing warning in `AgentCreatorToolCatalogParity.vitest.mts`)
- `npm run check:dead-code-ratchet` (74/74)
- `npm run compile:fast`
- `corepack pnpm vitest run src/test-kernel/auth` (106/106)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only logging contract change; auth behavior is unchanged and current hosts still supply full loggers.
> 
> **Overview**
> **Unifies authentication service logging** on `SupabaseSessionLog` and removes parallel logger contracts and adapters.
> 
> `AuthServiceLogger`, `NOOP_AUTH_SERVICE_LOGGER`, and `src/auth/serviceLogger.ts` are deleted. `TierService`, `ServerSideKeyService`, and their init helpers now take `SupabaseSessionLog`; log calls use optional chaining (`info?`, `error?`) so a partial logger is safe. Desktop drops `createAuthServiceLogger` and passes the existing `createSessionLog` adapter into server-side key initialization as well.
> 
> The unused **Codex** logging seam is removed: `CodexLogger`, optional `log` fields on the coordinator and login flows, and the warn/debug calls that were never wired by callers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bb09d1eb591cb8f158cae2a64b98daeca04f67a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->