### PR TITLE
fix(cli): require consent before Codex key fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,9 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **ChatGPT limits no longer switch credentials silently** — when subscription
+  usage is exhausted, the CLI shows the limit and reset warning and waits for
+  confirmation before retrying with a personal OpenAI API key.
 - **Edit previews open on the change** — approval previews now begin near the
   first added or removed line, so long wrapped context no longer hides the
   proposed edit below the fold.

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -155,6 +155,8 @@ const SHOW_BASH_APPROVAL = process.env.HARNESS_BASH_APPROVAL === '1';
 const SHOW_REPEATED_BASH_APPROVAL =
   process.env.HARNESS_REPEATED_BASH_APPROVAL === '1';
 const SHOW_RETRY_APPROVAL = process.env.HARNESS_RETRY_APPROVAL === '1';
+const RETRY_APPROVAL_CHATGPT =
+  process.env.HARNESS_RETRY_APPROVAL_CHATGPT === '1';
 const SHOW_EXTERNAL_INQUIRY = process.env.HARNESS_EXTERNAL_INQUIRY === '1';
 const SHOW_USER_QUESTION = process.env.HARNESS_USER_QUESTION === '1';
 const SHOW_PLAN_APPROVAL = process.env.HARNESS_PLAN_APPROVAL === '1';
@@ -887,6 +889,18 @@ function makeBashApprovalPayload(index = 1) {
 }
 
 function makeRetryApprovalPayload(): RetryPermission {
+  if (RETRY_APPROVAL_CHATGPT) {
+    return {
+      streamId: STREAM_ID,
+      operation: 'Tool-use call',
+      errorMessage: 'ChatGPT subscription usage limit reached. Resets in 2h.',
+      errorDetails: {
+        exhaustionReason: 'chatgpt-subscription',
+        isRelayError: false,
+        statusCode: 429,
+      },
+    };
+  }
   return {
     streamId: STREAM_ID,
     operation: 'Tool-use call',

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -2154,6 +2154,27 @@ const SCENARIOS = [
     unexpect: ['Feedback to send with rejection', 'send note', '/model models'],
   },
   {
+    name: 'retry-approval-chatgpt',
+    frame: 'scrollback',
+    cols: 120,
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_RETRY_APPROVAL: '1',
+      HARNESS_RETRY_APPROVAL_CHATGPT: '1',
+    },
+    bootExpect: '· Ctrl-C ',
+    expect: [
+      'Retry the failed call?',
+      'ChatGPT subscription usage limit reached. Resets in 2h.',
+      'Press k to switch from your ChatGPT subscription to your OpenAI API key before retrying.',
+      'retry',
+      'give up',
+      'use API key and retry',
+      '1 approval',
+    ],
+    unexpect: ['Feedback to send with rejection', 'send note', '/model models'],
+  },
+  {
     name: 'retry-approval-reject',
     frame: 'viewport',
     cols: 120,

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -85,10 +85,11 @@ async function hasUsablePersonalKey(provider: ApiProvider): Promise<boolean> {
 }
 
 /**
- * When a retry is triggered by relay exhaustion or ChatGPT-subscription
- * limits, and the stored personal key is not the broken credential, switch
- * to personal keys and retry without showing the modal — matching the
- * progress-view API-key retry behaviour.
+ * When a retry is triggered by relay exhaustion and the stored personal key is
+ * not the broken credential, switch to personal keys and retry without showing
+ * the modal. ChatGPT-subscription limits always require an explicit decision:
+ * changing credential ownership must not hide the quota warning or silently
+ * spend API-key quota.
  *
  * Returns the auto-switch decision, or `undefined` when the modal is needed
  * (no usable key stored, direct-key failure, or unknown provider).
@@ -97,6 +98,7 @@ async function maybeAutoSwitchRetry(
   payload: RuntimeInteractionEventPayloads['showRetryRequest'],
 ): Promise<ApprovalDecision | undefined> {
   if (!isCliApiSwitchableRetry(payload)) return undefined;
+  if (isCliChatGptSubscriptionRetry(payload)) return undefined;
 
   const details = payload.errorDetails;
   // Upstream credit depletion means the stored direct key IS the broken
@@ -104,14 +106,10 @@ async function maybeAutoSwitchRetry(
   // auto-switch to the stored value.
   if (isUpstreamCreditDepletedError(details)) return undefined;
 
-  // ChatGPT-subscription exhaustion -> the user needs an OpenAI key.
-  // Relay exhaustion -> use the provider from error details when known;
+  // Relay exhaustion uses the provider from error details when known;
   // provider-less relay failures can use any configured personal key.
-  const isChatGptSubscription = isCliChatGptSubscriptionRetry(payload);
   let providers: readonly ApiProvider[];
-  if (isChatGptSubscription) {
-    providers = ['openai'];
-  } else if (details?.provider) {
+  if (details?.provider) {
     providers = isApiProvider(details.provider) ? [details.provider] : [];
   } else {
     providers = API_PROVIDERS;
@@ -128,7 +126,6 @@ async function maybeAutoSwitchRetry(
   return {
     accepted: true,
     apiMode: 'personal',
-    ...(isChatGptSubscription ? { disableChatGptSubscription: true } : {}),
   };
 }
 

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
@@ -457,7 +457,7 @@ describe('TUI retry approvals', () => {
     expect(currentApproval.get()).toBeUndefined();
   });
 
-  it('auto-switches ChatGPT subscription retries to an OpenAI API key', async () => {
+  it('requires an explicit decision before switching a ChatGPT subscription retry to an API key', async () => {
     mocks.lookupApiKey.mockImplementation(
       async (_secrets, provider: ApiProvider) =>
         provider === 'openai' ? 'sk-openai' : undefined,
@@ -467,17 +467,54 @@ describe('TUI retry approvals', () => {
     const result = interactions.requestRetry?.(chatGptSubscriptionRetry('s3'));
 
     await vi.waitFor(() => {
-      expect(mocks.setCliApiMode).toHaveBeenCalledWith('personal');
-      expect(mocks.setCliCodexSubscription).toHaveBeenCalledWith(false);
+      expect(currentApproval.get()?.payload).toMatchObject({
+        kind: 'retry',
+        payload: {
+          streamId: 's3',
+          errorMessage: 'ChatGPT subscription usage limit reached.',
+        },
+      });
     });
+    expect(mocks.lookupApiKey).not.toHaveBeenCalled();
+    expect(mocks.setCliApiMode).not.toHaveBeenCalled();
+    expect(mocks.setCliCodexSubscription).not.toHaveBeenCalled();
+
+    currentApproval.get()?.decide({
+      accepted: true,
+      apiMode: 'personal',
+      disableChatGptSubscription: true,
+    });
+
     await expect(result).resolves.toEqual({
       action: 'retry',
       feedback: undefined,
     });
+    expect(mocks.setCliApiMode).toHaveBeenCalledWith('personal');
+    expect(mocks.setCliCodexSubscription).toHaveBeenCalledWith(false);
     expect(currentApproval.get()).toBeUndefined();
-    expect(mocks.lookupApiKey.mock.calls.map((call) => call[1])).toEqual([
-      'openai',
-    ]);
+  });
+
+  it('retries ChatGPT subscription access without changing credentials when the ordinary retry action is chosen', async () => {
+    const { interactions } = tui();
+    const result = interactions.requestRetry?.(
+      chatGptSubscriptionRetry('subscription-retry'),
+    );
+
+    await vi.waitFor(() => {
+      expect(currentApproval.get()?.payload).toMatchObject({
+        kind: 'retry',
+        payload: { streamId: 'subscription-retry' },
+      });
+    });
+    currentApproval.get()?.decide({ accepted: true });
+
+    await expect(result).resolves.toEqual({
+      action: 'retry',
+      feedback: undefined,
+    });
+    expect(mocks.lookupApiKey).not.toHaveBeenCalled();
+    expect(mocks.setCliApiMode).not.toHaveBeenCalled();
+    expect(mocks.setCliCodexSubscription).not.toHaveBeenCalled();
   });
 
   it('invalidates pre-queue retry lookups when approvals are cleared', async () => {


### PR DESCRIPTION
## Summary

Keep ChatGPT subscription quota exhaustion visible in the interactive CLI instead of silently switching to a stored OpenAI API key. The existing retry panel now remains the decision point: ordinary retry keeps the subscription route, while the explicit API-key action changes credentials and retries.

Closes #8908.

## Issue acceptance gates

- ChatGPT quota exhaustion always shows the existing limit/reset warning and retry panel, even when an OpenAI key is stored.
- No OpenAI key lookup or credential mutation happens before the user chooses the API-key action.
- Ordinary retry leaves the ChatGPT preference and API mode unchanged.
- Non-interactive credential-exhaustion policy remains fail-closed and does not switch credentials.
- Relay exhaustion keeps its existing auto-switch behavior.
- A real PTY scenario verifies the visible ChatGPT warning and explicit action.

## Single source of truth

The retry approval decision remains the only owner allowed to change ChatGPT subscription preference and CLI API mode. maybeAutoSwitchRetry is now relay-only.

## Duplication and abstraction budget

Removes ChatGPT credential switching from the automatic fallback branch and reuses the existing retry panel, side-effect handler, error classifier, and reset-message formatter. Adds no production abstraction.

## Net elements (R6)

- Files: 5 modified.
- Exported symbols: none added or removed.
- Classes/interfaces/enums: none added or removed.
- LoC: +89 / -17, primarily regression and PTY coverage.

## Consumer counts (R8)

n/a — no export or event path is deleted. The existing retry decision path is retained and made mandatory for ChatGPT exhaustion.

## Host impact

Extension: No behavior change.

Desktop: No behavior change.

CLI: Warns and waits for explicit consent before switching a depleted ChatGPT subscription request to a personal OpenAI key.

## Scheduled refactoring

None. OpenAI documents account/rateLimits/read on Codex app-server, but the installed Codex SDK does not expose that protocol surface. The request response remains the authoritative quota verdict rather than adding a spawned-process preflight path.

## Validation

- npm run format
- npm run typecheck
- npm run lint (0 errors; one pre-existing warning in AgentCreatorToolCatalogParity.vitest.mts)
- npm run compile:fast
- Focused tests: 4 files, 54 tests passed
- CI=true npm run validate:tui -- retry-approval-chatgpt
- Full npm test: 737 files passed and 1 skipped; three unrelated 10-second startup timeouts under concurrent load. ElectronMainViewIpc passed on immediate focused rerun; MainAppPersistenceRestore and StaticBandResize both passed with their normal timeout after cache warm-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes interactive credential routing on a common failure path (429/subscription limits); behavior is well-tested but affects billing and which API is used after retries.
> 
> **Overview**
> **ChatGPT subscription quota exhaustion no longer auto-switches to a stored OpenAI API key.** The CLI always shows the existing retry panel with the limit/reset message; relay exhaustion still uses the prior silent personal-key fallback when a usable key exists.
> 
> In `maybeAutoSwitchRetry`, an early return for `isCliChatGptSubscriptionRetry` removes lookup, `setCliApiMode('personal')`, and `disableChatGptSubscription` until the user explicitly chooses the API-key action (`k` / use API key and retry). A plain **retry** leaves subscription preference and API mode unchanged.
> 
> Coverage adds a ChatGPT-shaped TUI harness scenario, a `validate:tui` case for the subscription warning copy, and tests that assert modal-first behavior plus credential mutation only after explicit approval.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edf48e7a607a838d64f731cb6c64d603e5cd5a5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->