### PR TITLE
fix(cli): single-source active-run liveness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,7 @@ jobs:
             edit-approval subagent-list-focus-full-frame hidden-root-approval-tab-return \
             orchestrate-launcher orchestrate-agent-submenu \
             orchestrate-delegated-history orchestrate-resume-submenu \
-            compact-orchestrate-launcher run-liveness-row
+            compact-orchestrate-launcher single-run-liveness
 
       - name: Upload CLI TUI smoke frames
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,10 +143,8 @@ All notable changes to this project will be documented in this file.
   now scrolls with the same ↑/↓ and PgUp/PgDn keys as command and delegation
   approvals, instead of silently truncating tall plans; all three approval
   bodies share identical scroll and overflow behavior.
-- **The chat transcript breathes and shows run activity** — a blank line now
-  always follows your message, and while the agent runs, an animated indicator
-  with elapsed time makes clear it is still working — not just while the model
-  is thinking.
+- **The chat transcript breathes** — a blank line now always follows your
+  message, keeping prompts visually separate from the agent's first action.
 - **Ctrl+C clears dialog text before stopping or exiting** — pressing Ctrl+C
   with text in a foreground dialog now clears that text; pressing it again
   keeps the existing response-stop or exit behavior.

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1096,17 +1096,16 @@ const SCENARIOS = [
     unexpect: ['Ctrl-C stop'],
   },
   {
-    // The liveness row shows for the whole active run (not just hidden
-    // reasoning) with a ticking elapsed time. The run starts 42s in the past,
-    // but frame settlement may advance the displayed second.
-    name: 'run-liveness-row',
+    // The status bar is the single owner of active-run liveness. The harness
+    // starts 42s in the past; frame settlement may advance the displayed
+    // second.
+    name: 'single-run-liveness',
     env: { HARNESS_ENTRIES: '4', HARNESS_TODOS: '1' },
     frame: 'viewport',
-    expect: ['✻ Working'],
     expectPatterns: [
-      RUNNING_STATUS_PATTERN,
-      /✻ Working\.{1,3}[ \t]+(?:4[2-9]s|5\ds|[1-9]\d*(?:m|h|d)(?: [1-9]\d*(?:s|m|h))?)/,
+      /◆ [-|\/\\] running (?:4[2-9]s|5\ds|[1-9]\d*(?:m|h|d)(?: [1-9]\d*(?:s|m|h))?)/,
     ],
+    unexpect: ['✻ Working', '✻ Thinking'],
   },
   {
     name: 'tools-form',

--- a/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
+++ b/packages/cli/src/chat/tui/modals/ConfirmCard.tsx
@@ -69,8 +69,9 @@ export function ConfirmCard({
   const [feedback, setFeedback] = useState('');
   const { columns } = useWindowSize();
   // A pending approval always needs the user's eyes on it — pulse the title
-  // at 1 Hz off the shared clock (same pattern as LoadingIndicator/
-  // LivenessRow) instead of a static line, so it's harder to miss.
+  // at 1 Hz off the shared clock (same pattern as LoadingIndicator and the
+  // status bar's running marker) instead of a static line, so it's harder to
+  // miss.
   const now = useLiveNowMs(true);
   const pulsedTitle = confirmCardPulsedTitle(now, title);
 

--- a/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
+++ b/packages/cli/src/chat/tui/modals/ConfirmCardState.ts
@@ -52,8 +52,8 @@ export interface ConfirmCardCompactHintLayout {
 /**
  * A pending approval always needs the user's eyes on it — prefix the title
  * with a 1 Hz solid/hollow blink (see `ui/glyphs.APPROVAL_PULSE_FRAMES`) off
- * the shared clock, same pattern as `LoadingIndicator`/`LivenessRow`, so the
- * card is harder to miss than a static line.
+ * the shared clock, same pattern as `LoadingIndicator` and the status bar's
+ * running marker, so the card is harder to miss than a static line.
  */
 export function confirmCardPulsedTitle(nowMs: number, title: string): string {
   return `${loadingFrameAt(nowMs, APPROVAL_PULSE_FRAMES)} ${title}`;

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -1,22 +1,16 @@
 // Transcript region for the current stream's in-flight assistant/tool rows.
 // Finalized history is owned by the static scrollback renderer.
 
-import { Box, Text } from 'ink';
+import { Box } from 'ink';
 
-import { isActivePhase } from '@shared/streams/streamStatus';
 import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
-import { formatCompactDuration } from '@utils/core';
 
 import {
   activeStreamId as activeStreamIdSignal,
   streams as streamsSignal,
-  thinkingIndicatorVisible,
   type ConversationEntry,
 } from '../state/cliState';
-import { useLiveNowMs } from '../state/useLiveNowMs';
 import { useSignal } from '../state/useSignal';
-import { loadingFrameAt } from '../ui/LoadingIndicator';
-import { THINKING_MARKER } from '../ui/glyphs';
 import { EntryErrorBoundary } from './EntryErrorBoundary';
 import {
   BoundedTranscriptEntry,
@@ -32,43 +26,6 @@ import {
 
 const DEFAULT_TRANSCRIPT_ROWS = 24;
 const MIN_PENDING_ROWS = 1;
-// Padded to a fixed width so the elapsed time doesn't jiggle as dots cycle.
-const LIVENESS_DOTS = ['.  ', '.. ', '...'] as const;
-
-/**
- * Liveness row shown for the whole active run, not just the hidden reasoning
- * phase: long tool calls and provider latency also stream nothing into the
- * transcript, and the pane must still answer "working or stalled?". The
- * label distinguishes hidden reasoning ("Thinking") from everything else
- * ("Working") and never shows the reasoning text itself; the ticking elapsed
- * time is the stall signal. Animated off the shared 1 Hz ticker — an
- * autonomous 80 ms spinner would repaint the whole live region at ~12 Hz
- * during exactly the phase where nothing else is streaming, while the shared
- * tick batches with the StatusBar's elapsed-seconds render.
- */
-function LivenessRow({
-  startedAtMs,
-  thinking,
-}: {
-  readonly startedAtMs: number | undefined;
-  readonly thinking: boolean;
-}): React.JSX.Element {
-  const now = useLiveNowMs(true, startedAtMs);
-  const dots = loadingFrameAt(now, LIVENESS_DOTS);
-  const elapsed =
-    startedAtMs === undefined
-      ? ''
-      : ` ${formatCompactDuration(now - startedAtMs)}`;
-  return (
-    <Box>
-      <Text dimColor>
-        {THINKING_MARKER} {thinking ? 'Thinking' : 'Working'}
-        {dots}
-        {elapsed}
-      </Text>
-    </Box>
-  );
-}
 
 export interface ConversationPaneProps {
   readonly width?: number;
@@ -161,29 +118,18 @@ export function ConversationPane(
   const slice = activeStreamId ? streams.get(activeStreamId) : undefined;
   const entries = slice?.entries ?? [];
   const displayEntries = splitTranscriptEntries(entries, slice?.status).pending;
-  const showLiveness = isActivePhase(slice?.status);
 
   const maxRows = props.maxRows ?? DEFAULT_TRANSCRIPT_ROWS;
-  // The liveness row is budgeted like any other live content: it takes one
-  // row off the entry viewport so the pane's explicit height never exceeds
-  // maxRows (an overflow would leak live rows into scrollback). Content
-  // outranks it: when a foreground panel squeezes the pane to a single row,
-  // pending entries keep that row and the StatusBar's running/elapsed
-  // segment carries liveness alone.
-  const livenessRows =
-    showLiveness && (maxRows > MIN_PENDING_ROWS || displayEntries.length === 0)
-      ? 1
-      : 0;
   const visibleEntries = selectTranscriptEntriesForViewport(
     displayEntries,
-    maxRows - livenessRows,
+    maxRows,
     props.width,
     props.subagentExecutionLabels,
   );
   const visibleRows =
-    (visibleEntries.entries.length > 0
+    visibleEntries.entries.length > 0
       ? Math.max(MIN_PENDING_ROWS, visibleEntries.usedRows)
-      : 0) + livenessRows;
+      : 0;
 
   // Keep stream order intact so in-flight text stays interleaved with tool rows.
   // The explicit height keeps the input bar pinned and prevents bursts from
@@ -199,12 +145,6 @@ export function ConversationPane(
           width: props.width,
         }),
       )}
-      {livenessRows > 0 ? (
-        <LivenessRow
-          startedAtMs={slice?.runStartedAt}
-          thinking={thinkingIndicatorVisible(slice)}
-        />
-      ) : null}
     </Box>
   );
 }

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -305,12 +305,16 @@ function statusBarInnerWidth(width: number | undefined): number | undefined {
 function fitTransientNoticeStatusBarLeftSegments(
   segments: readonly StatusBarSegment[],
   noticeIndex: number,
+  livenessIndex: number | undefined,
   width: number | undefined,
 ): readonly StatusBarSegment[] {
   const innerWidth = statusBarInnerWidth(width);
   if (innerWidth === undefined) return segments;
 
   const fitted = [...segments];
+  const notice = fitted[noticeIndex];
+  const liveness =
+    livenessIndex === undefined ? undefined : fitted[livenessIndex];
   while (
     fitted.length > noticeIndex + 1 &&
     statusBarSegmentsWidth(fitted) > innerWidth
@@ -318,19 +322,31 @@ function fitTransientNoticeStatusBarLeftSegments(
     fitted.pop();
   }
 
-  if (noticeIndex > 1 && statusBarSegmentsWidth(fitted) > innerWidth) {
-    fitted.splice(1, noticeIndex - 1);
+  if (statusBarSegmentsWidth(fitted) > innerWidth) {
+    for (let index = noticeIndex - 1; index > 0; index -= 1) {
+      if (fitted[index] !== liveness) fitted.splice(index, 1);
+    }
   }
 
-  const icon = fitted[0];
-  const prompt = fitted[1];
-  if (icon && prompt && statusBarSegmentsWidth(fitted) > innerWidth) {
-    const iconAndGapWidth = statusBarSegmentWidth(icon) + 1;
-    fitted[1] = {
-      ...prompt,
+  if (liveness?.compactText && statusBarSegmentsWidth(fitted) > innerWidth) {
+    const index = fitted.indexOf(liveness);
+    fitted[index] = { ...liveness, text: liveness.compactText };
+  }
+
+  const fittedNoticeIndex = notice ? fitted.indexOf(notice) : -1;
+  if (fittedNoticeIndex >= 0 && statusBarSegmentsWidth(fitted) > innerWidth) {
+    const fixedWidth = fitted.reduce(
+      (total, segment, index) =>
+        index === fittedNoticeIndex
+          ? total
+          : total + statusBarSegmentWidth(segment),
+      fitted.length - 1,
+    );
+    fitted[fittedNoticeIndex] = {
+      ...notice,
       text: truncateSummaryToWidth(
-        prompt.text,
-        Math.max(0, innerWidth - iconAndGapWidth),
+        notice.text,
+        Math.max(0, innerWidth - fixedWidth),
       ),
     };
   }
@@ -794,13 +810,19 @@ export function buildStatusBarDisplay(
 
   // A notice must not hide the only indication that an active run is still
   // alive. Keep that liveness compact so the notice remains the focal text.
+  let transientLivenessIndex: number | undefined;
   if (input.transientNotice && isActivePhase(input.status)) {
     const elapsed =
       input.elapsedMs === undefined
         ? ''
         : ` ${formatCompactDuration(input.elapsedMs)}`;
+    transientLivenessIndex = left.length;
     left.push({
       text: `${spinPrefix}${statusLabel}${elapsed}`,
+      compactText:
+        input.elapsedMs === undefined
+          ? 'run'
+          : `run ${formatCompactDuration(input.elapsedMs)}`,
       color: 'dim',
     });
   }
@@ -888,6 +910,7 @@ export function buildStatusBarDisplay(
       ? fitTransientNoticeStatusBarLeftSegments(
           left,
           transientNoticeIndex,
+          transientLivenessIndex,
           input.width,
         )
       : fitStatusBarLeftSegments(left, input.width);

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -862,19 +862,40 @@ export function buildStatusBarDisplay(
   // A notice must not hide the only indication that an active run is still
   // alive. Keep that liveness compact so the notice remains the focal text.
   let transientLivenessIndex: number | undefined;
-  if (input.transientNotice && isActivePhase(input.status)) {
-    const elapsed =
-      input.elapsedMs === undefined
-        ? ''
-        : ` ${formatCompactDuration(input.elapsedMs)}`;
-    transientLivenessIndex = left.length;
-    left.push({
-      text: `${spinPrefix}${statusLabel}${elapsed}`,
-      compactText:
+  if (input.transientNotice) {
+    if (isActivePhase(input.status)) {
+      const elapsed =
         input.elapsedMs === undefined
-          ? 'run'
-          : `run ${formatCompactDuration(input.elapsedMs)}`,
+          ? ''
+          : ` ${formatCompactDuration(input.elapsedMs)}`;
+      transientLivenessIndex = left.length;
+      left.push({
+        text: `${spinPrefix}${statusLabel}${elapsed}`,
+        compactText:
+          input.elapsedMs === undefined
+            ? 'run'
+            : `run ${formatCompactDuration(input.elapsedMs)}`,
+        color: 'dim',
+      });
+    }
+  } else {
+    left.push({
+      text: `${spinPrefix}${statusLabel}`,
       color: 'dim',
+    });
+    if (isActivePhase(input.status) && input.elapsedMs !== undefined) {
+      left.push({
+        text: formatCompactDuration(input.elapsedMs),
+        color: 'dim',
+        compactPriority: STATUS_BAR_COMPACT_PRIORITY.elapsed,
+      });
+    }
+  }
+  if (input.thinkingActive === true && isActivePhase(input.status)) {
+    left.push({
+      text: 'thinking...',
+      color: COLOR_WARNING,
+      compactPriority: STATUS_BAR_COMPACT_PRIORITY.thinking,
     });
   }
 
@@ -891,25 +912,6 @@ export function buildStatusBarDisplay(
       left.push({
         text: `${formatResultCount(queuedCount, 'queued follow-up')} will be discarded`,
         color: COLOR_ERROR,
-      });
-    }
-  } else {
-    left.push({
-      text: `${spinPrefix}${statusLabel}`,
-      color: 'dim',
-    });
-    if (isActivePhase(input.status) && input.elapsedMs !== undefined) {
-      left.push({
-        text: formatCompactDuration(input.elapsedMs),
-        color: 'dim',
-        compactPriority: STATUS_BAR_COMPACT_PRIORITY.elapsed,
-      });
-    }
-    if (input.thinkingActive === true && isActivePhase(input.status)) {
-      left.push({
-        text: 'thinking...',
-        color: COLOR_WARNING,
-        compactPriority: STATUS_BAR_COMPACT_PRIORITY.thinking,
       });
     }
   }

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -306,6 +306,7 @@ function fitTransientNoticeStatusBarLeftSegments(
   segments: readonly StatusBarSegment[],
   noticeIndex: number,
   livenessIndex: number | undefined,
+  discardWarningIndex: number | undefined,
   width: number | undefined,
 ): readonly StatusBarSegment[] {
   const innerWidth = statusBarInnerWidth(width);
@@ -313,24 +314,32 @@ function fitTransientNoticeStatusBarLeftSegments(
 
   const fitted = [...segments];
   const notice = fitted[noticeIndex];
-  const liveness =
+  let liveness =
     livenessIndex === undefined ? undefined : fitted[livenessIndex];
-  while (
-    fitted.length > noticeIndex + 1 &&
-    statusBarSegmentsWidth(fitted) > innerWidth
-  ) {
-    fitted.pop();
+  const discardWarning =
+    discardWarningIndex === undefined ? undefined : fitted[discardWarningIndex];
+
+  // Compact liveness before removing content. In particular, the queued-input
+  // discard warning is safety-critical and must not be displaced by the wider
+  // animated form of the running marker.
+  if (liveness?.compactText && statusBarSegmentsWidth(fitted) > innerWidth) {
+    const index = fitted.indexOf(liveness);
+    liveness = { ...liveness, text: liveness.compactText };
+    fitted[index] = liveness;
+  }
+
+  while (statusBarSegmentsWidth(fitted) > innerWidth) {
+    const removableIndex = fitted.findLastIndex(
+      (segment, index) => index > noticeIndex && segment !== discardWarning,
+    );
+    if (removableIndex < 0) break;
+    fitted.splice(removableIndex, 1);
   }
 
   if (statusBarSegmentsWidth(fitted) > innerWidth) {
     for (let index = noticeIndex - 1; index > 0; index -= 1) {
       if (fitted[index] !== liveness) fitted.splice(index, 1);
     }
-  }
-
-  if (liveness?.compactText && statusBarSegmentsWidth(fitted) > innerWidth) {
-    const index = fitted.indexOf(liveness);
-    fitted[index] = { ...liveness, text: liveness.compactText };
   }
 
   const fittedNoticeIndex = notice ? fitted.indexOf(notice) : -1;
@@ -828,6 +837,7 @@ export function buildStatusBarDisplay(
   }
 
   let transientNoticeIndex: number | undefined;
+  let discardWarningIndex: number | undefined;
   if (input.transientNotice) {
     transientNoticeIndex = left.length;
     left.push({ text: input.transientNotice.text, color: COLOR_WARNING });
@@ -835,6 +845,7 @@ export function buildStatusBarDisplay(
     if (input.transientNotice.kind === 'exit' && queuedCount > 0) {
       // Exiting drops queued follow-ups silently — warn before the user
       // confirms with the second Ctrl-C.
+      discardWarningIndex = left.length;
       left.push({
         text: `${formatResultCount(queuedCount, 'queued follow-up')} will be discarded`,
         color: COLOR_ERROR,
@@ -911,6 +922,7 @@ export function buildStatusBarDisplay(
           left,
           transientNoticeIndex,
           transientLivenessIndex,
+          discardWarningIndex,
           input.width,
         )
       : fitStatusBarLeftSegments(left, input.width);

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -782,6 +782,29 @@ export function buildStatusBarDisplay(
     });
   }
 
+  const statusLabel = formatCliStatusLabel(
+    input.status,
+    input.substate,
+    input.isChildStream,
+  );
+  const spinPrefix =
+    isActivePhase(input.status) && input.runningFrame
+      ? `${input.runningFrame} `
+      : '';
+
+  // A notice must not hide the only indication that an active run is still
+  // alive. Keep that liveness compact so the notice remains the focal text.
+  if (input.transientNotice && isActivePhase(input.status)) {
+    const elapsed =
+      input.elapsedMs === undefined
+        ? ''
+        : ` ${formatCompactDuration(input.elapsedMs)}`;
+    left.push({
+      text: `${spinPrefix}${statusLabel}${elapsed}`,
+      color: 'dim',
+    });
+  }
+
   let transientNoticeIndex: number | undefined;
   if (input.transientNotice) {
     transientNoticeIndex = left.length;
@@ -796,15 +819,6 @@ export function buildStatusBarDisplay(
       });
     }
   } else {
-    const statusLabel = formatCliStatusLabel(
-      input.status,
-      input.substate,
-      input.isChildStream,
-    );
-    const spinPrefix =
-      isActivePhase(input.status) && input.runningFrame
-        ? `${input.runningFrame} `
-        : '';
     left.push({
       text: `${spinPrefix}${statusLabel}`,
       color: 'dim',

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -39,7 +39,6 @@ import { KEY_HINT_SEPARATOR, keyHintText } from '../ui/KeyHints';
 import { STATUS_BAR_HORIZONTAL_PADDING } from '../ui/theme';
 import { formatResumeCommand } from '../state/resumeHint';
 import {
-  thinkingIndicatorVisible,
   type BypassState,
   type StreamSlice,
   type TransientNotice,
@@ -817,12 +816,7 @@ export function buildStatusBarDisplay(
         compactPriority: STATUS_BAR_COMPACT_PRIORITY.elapsed,
       });
     }
-    if (
-      thinkingIndicatorVisible({
-        status: input.status,
-        thinkingActive: input.thinkingActive === true,
-      })
-    ) {
+    if (input.thinkingActive === true && isActivePhase(input.status)) {
       left.push({
         text: 'thinking...',
         color: COLOR_WARNING,

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -314,6 +314,7 @@ function fitTransientNoticeStatusBarLeftSegments(
 
   const fitted = [...segments];
   const notice = fitted[noticeIndex];
+  let fittedNotice = notice;
   let liveness =
     livenessIndex === undefined ? undefined : fitted[livenessIndex];
   const discardWarning =
@@ -342,8 +343,11 @@ function fitTransientNoticeStatusBarLeftSegments(
     }
   }
 
-  const fittedNoticeIndex = notice ? fitted.indexOf(notice) : -1;
-  if (fittedNoticeIndex >= 0 && statusBarSegmentsWidth(fitted) > innerWidth) {
+  const fitNotice = (): void => {
+    const fittedNoticeIndex = fittedNotice ? fitted.indexOf(fittedNotice) : -1;
+    if (fittedNoticeIndex < 0 || statusBarSegmentsWidth(fitted) <= innerWidth) {
+      return;
+    }
     const fixedWidth = fitted.reduce(
       (total, segment, index) =>
         index === fittedNoticeIndex
@@ -351,10 +355,48 @@ function fitTransientNoticeStatusBarLeftSegments(
           : total + statusBarSegmentWidth(segment),
       fitted.length - 1,
     );
-    fitted[fittedNoticeIndex] = {
+    fittedNotice = {
       ...notice,
       text: truncateSummaryToWidth(
         notice.text,
+        Math.max(0, innerWidth - fixedWidth),
+      ),
+    };
+    fitted[fittedNoticeIndex] = fittedNotice;
+  };
+
+  fitNotice();
+
+  // At widths where the safety warning and liveness cannot coexist, the
+  // destructive-action warning wins. Refit the notice into the released room.
+  if (
+    discardWarning &&
+    liveness &&
+    statusBarSegmentsWidth(fitted) > innerWidth
+  ) {
+    fitted.splice(fitted.indexOf(liveness), 1);
+    liveness = undefined;
+    fitNotice();
+  }
+
+  // Extremely narrow terminals may not fit even the full discard warning.
+  // Drop the lower-priority confirmation text and truncate the warning so the
+  // status row never exceeds its layout budget.
+  if (discardWarning && statusBarSegmentsWidth(fitted) > innerWidth) {
+    const fittedNoticeIndex = fittedNotice ? fitted.indexOf(fittedNotice) : -1;
+    if (fittedNoticeIndex >= 0) fitted.splice(fittedNoticeIndex, 1);
+    const fittedWarningIndex = fitted.indexOf(discardWarning);
+    const fixedWidth = fitted.reduce(
+      (total, segment, index) =>
+        index === fittedWarningIndex
+          ? total
+          : total + statusBarSegmentWidth(segment),
+      fitted.length - 1,
+    );
+    fitted[fittedWarningIndex] = {
+      ...discardWarning,
+      text: truncateSummaryToWidth(
+        discardWarning.text,
         Math.max(0, innerWidth - fixedWidth),
       ),
     };

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -181,23 +181,6 @@ export function streamAccessTarget(
   };
 }
 
-/**
- * Shared gate for the "model is thinking" indicators (the StatusBar segment
- * and the conversation pane's liveness row) so the two can never disagree:
- * the hidden reasoning phase is only worth surfacing while the stream is
- * actually running — any final or waiting status supersedes it.
- */
-export function thinkingIndicatorVisible(
-  slice:
-    | {
-        readonly status: StreamPhase | undefined;
-        readonly thinkingActive: boolean;
-      }
-    | undefined,
-): boolean {
-  return slice?.thinkingActive === true && isActivePhase(slice.status);
-}
-
 export const NO_BYPASS: BypassState = {
   bash: false,
   toolEdit: false,

--- a/packages/cli/src/chat/tui/ui/LoadingIndicator.tsx
+++ b/packages/cli/src/chat/tui/ui/LoadingIndicator.tsx
@@ -1,10 +1,10 @@
 // Shared "work in progress" row for async transient states (list-form data
 // fetches, /api status loading). Animated off the shared 1 Hz ticker
-// (useLiveNowMs) — the same pattern ConversationPane's `LivenessRow` uses for
-// the active-run liveness row — instead of an autonomous per-component
-// interval. Replaces `@inkjs/ui`'s `<Spinner>`, whose own ~80ms `setInterval`
-// (driven by `cli-spinners`) runs completely outside the shared clock: the
-// exact per-component-interval anti-pattern the shared clock exists to avoid.
+// (useLiveNowMs) — the same clock the status bar uses for active-run liveness
+// — instead of an autonomous per-component interval. Replaces `@inkjs/ui`'s
+// `<Spinner>`, whose own ~80ms `setInterval` (driven by `cli-spinners`) runs
+// completely outside the shared clock: the exact per-component-interval
+// anti-pattern the shared clock exists to avoid.
 
 import { Box, Text } from 'ink';
 
@@ -18,8 +18,8 @@ import { useLiveNowMs } from '../state/useLiveNowMs';
 const LOADING_FRAMES = ['|', '/', '-', '\\'] as const;
 
 /** Current frame for a 1 Hz shared-clock rotation through `frames`, keyed off
- *  epoch ms from `useLiveNowMs` — the same computation `LoadingIndicator` and
- *  `ConversationPane`'s `LivenessRow` each do inline. */
+ *  epoch ms from `useLiveNowMs`; both `LoadingIndicator` and the status bar's
+ *  running marker use this projection. */
 export function loadingFrameAt(
   nowMs: number,
   frames: readonly string[] = LOADING_FRAMES,

--- a/packages/cli/src/chat/tui/ui/glyphs.ts
+++ b/packages/cli/src/chat/tui/ui/glyphs.ts
@@ -41,9 +41,6 @@ export const TOOL_OUTPUT_CORNER = '⎿';
 /** Generated-tokens marker in child-row metadata (`↓40k`). */
 export const TOKENS_GENERATED = '↓';
 
-/** Marker for the liveness row shown while a run is active. */
-export const THINKING_MARKER = '✻';
-
 /** 1 Hz solid/hollow blink pair for "your input is needed" prompts (approval
  *  modals) — deliberately distinct from STATUS_DOT (never animated) so the
  *  two never read as the same signal. Pair with `ui/LoadingIndicator`'s

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -38,7 +38,6 @@ import {
   resetCliState,
   patchStream,
   streams,
-  thinkingIndicatorVisible,
   type ConversationEntry,
   type StreamSlice,
 } from '@cli/chat/tui/state/cliState';
@@ -1345,36 +1344,6 @@ describe('CLI conversation transcript splitting', () => {
       { clearScrollback: true, preserveStatic: false },
       { clearScrollback: true },
     ]);
-  });
-
-  it('shows the thinking liveness row only while a running stream is thinking', () => {
-    expect(thinkingIndicatorVisible(undefined)).toBe(false);
-    expect(
-      thinkingIndicatorVisible(
-        sliceWithEntries(STREAM_ID, [], {
-          thinkingActive: true,
-          status: STREAM_PHASE.RUNNING,
-        }),
-      ),
-    ).toBe(true);
-    // Off once visible activity (or a final status) takes over — the row is
-    // a liveness signal for the silent reasoning phase only.
-    expect(
-      thinkingIndicatorVisible(
-        sliceWithEntries(STREAM_ID, [], {
-          thinkingActive: false,
-          status: STREAM_PHASE.RUNNING,
-        }),
-      ),
-    ).toBe(false);
-    expect(
-      thinkingIndicatorVisible(
-        sliceWithEntries(STREAM_ID, [], {
-          thinkingActive: true,
-          status: STREAM_PHASE.WAITING,
-        }),
-      ),
-    ).toBe(false);
   });
 
   it('detects generated inquiry continuation rows only', () => {

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -1,8 +1,6 @@
 // Test composition imports
 import '@test/support/defaultSessionTestSetup';
 
-import { createRequire } from 'node:module';
-
 import { describe, expect, it } from 'vitest';
 
 import { buildChildStreamEntries } from '@test/support/childStreamEntries';
@@ -37,7 +35,6 @@ import {
   selectTranscriptEntriesForViewport,
 } from '@cli/chat/tui/panes/transcriptViewport';
 import {
-  activeStreamId,
   resetCliState,
   patchStream,
   streams,
@@ -66,9 +63,6 @@ import {
 } from '@shared/schemas';
 
 const STREAM_ID = 'cli-test-stream' as StreamTabId;
-const cliRequire = createRequire(
-  new URL('../../../packages/cli/package.json', import.meta.url),
-);
 const SESSION_META = {
   agent: 'research',
   category: AgentCategory.ToolUse,
@@ -156,83 +150,6 @@ function processEntry(
     },
   };
 }
-
-async function renderConversationPane(maxRows = 2): Promise<string> {
-  const ink = (await import(cliRequire.resolve('ink'))) as any;
-  const React = ((await import(cliRequire.resolve('react'))) as any).default;
-  const { ConversationPane } =
-    await import('@cli/chat/tui/panes/ConversationPane');
-  return ink.renderToString(
-    React.createElement(ConversationPane, { maxRows, width: 80 }),
-  );
-}
-
-describe('CLI conversation pane liveness', () => {
-  it('renders working and thinking liveness labels for active runs', async () => {
-    resetCliState();
-    activeStreamId.set(STREAM_ID);
-    patchStream(STREAM_ID, (slice) => ({
-      ...slice,
-      status: STREAM_PHASE.RUNNING,
-      runStartedAt: Date.now() - 42_000,
-      thinkingActive: false,
-    }));
-
-    try {
-      const working = await renderConversationPane();
-      expect(working).toContain('Working');
-      expect(working).toMatch(/4[23]s/);
-
-      patchStream(STREAM_ID, (slice) => ({
-        ...slice,
-        thinkingActive: true,
-      }));
-      const thinking = await renderConversationPane();
-      expect(thinking).toContain('Thinking');
-      expect(thinking).not.toContain('Working');
-    } finally {
-      resetCliState();
-    }
-  });
-
-  it('omits elapsed time when an active run has no start timestamp', async () => {
-    resetCliState();
-    activeStreamId.set(STREAM_ID);
-    patchStream(STREAM_ID, (slice) => ({
-      ...slice,
-      status: STREAM_PHASE.RUNNING,
-      runStartedAt: undefined,
-    }));
-
-    try {
-      const output = await renderConversationPane();
-      expect(output).toContain('Working');
-      expect(output).not.toMatch(/\d+s/);
-    } finally {
-      resetCliState();
-    }
-  });
-
-  it('gives a single squeezed row to pending content instead of liveness', async () => {
-    resetCliState();
-    activeStreamId.set(STREAM_ID);
-    patchStream(STREAM_ID, (slice) => ({
-      ...slice,
-      status: STREAM_PHASE.RUNNING,
-      runStartedAt: Date.now() - 42_000,
-      entries: [toolEntry('tool', TOOL_USE_STATUS.IN_PROGRESS)],
-    }));
-
-    try {
-      const output = await renderConversationPane(1);
-      expect(output).toContain('Bash');
-      expect(output).not.toContain('Working');
-      expect(output).not.toContain('Thinking');
-    } finally {
-      resetCliState();
-    }
-  });
-});
 
 describe('CLI conversation transcript splitting', () => {
   it('keeps only explicit finalized entries in scrollback', () => {

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -1329,6 +1329,7 @@ describe('CLI StatusBar display model', () => {
 
     expect(display.left.map(statusBarSegmentText)).toEqual([
       '◆',
+      'running',
       'Press Ctrl-C again to exit',
       PERSONAL_API_MODE_LABEL,
     ]);
@@ -1403,6 +1404,28 @@ describe('CLI StatusBar display model', () => {
     expect(display.left.map(statusBarSegmentText)).not.toContain(
       '1 queued follow-up will be discarded',
     );
+  });
+
+  it('keeps compact run liveness visible beside transient notices', () => {
+    const display = buildStatusBarDisplay(
+      statusInput({
+        status: STREAM_PHASE.RUNNING,
+        runningFrame: '/',
+        elapsedMs: 45_000,
+        transientNotice: {
+          kind: 'message',
+          text: 'Unknown command: /wat',
+          expiresAt: 1,
+        },
+      }),
+    );
+
+    expect(display.left.map(statusBarSegmentText)).toEqual([
+      '◆',
+      '/ running 45s',
+      'Unknown command: /wat',
+      PERSONAL_API_MODE_LABEL,
+    ]);
   });
 
   it('compacts token usage to a percentage before dropping it on narrow widths', () => {

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -1428,6 +1428,30 @@ describe('CLI StatusBar display model', () => {
     ]);
   });
 
+  it('keeps queued-input discard warnings ahead of status details', () => {
+    const display = buildStatusBarDisplay(
+      statusInput({
+        status: STREAM_PHASE.RUNNING,
+        runningFrame: '/',
+        elapsedMs: 45_000,
+        transientNotice: {
+          kind: 'exit',
+          text: 'Press Ctrl-C again to exit',
+          expiresAt: 1,
+        },
+        queuedFollowUpMessages: ['Continue with the proof.'],
+        width: 80,
+      }),
+    );
+
+    expect(display.left.map(statusBarSegmentText)).toEqual([
+      '◆',
+      'run 45s',
+      'Press Ctrl-C again to exit',
+      '1 queued follow-up will be discarded',
+    ]);
+  });
+
   it('compacts token usage to a percentage before dropping it on narrow widths', () => {
     const input = statusInput({
       status: STREAM_PHASE.RUNNING,

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -1417,14 +1417,14 @@ describe('CLI StatusBar display model', () => {
           text: 'Unknown command: /wat',
           expiresAt: 1,
         },
+        width: 20,
       }),
     );
 
     expect(display.left.map(statusBarSegmentText)).toEqual([
       '◆',
-      '/ running 45s',
-      'Unknown command: /wat',
-      PERSONAL_API_MODE_LABEL,
+      'run 45s',
+      'Unknown…',
     ]);
   });
 
@@ -1466,7 +1466,8 @@ describe('CLI StatusBar display model', () => {
 
     expect(display.left.map(statusBarSegmentText)).toEqual([
       '◆',
-      'Press Ctrl-C again to ex…',
+      'run',
+      'Press Ctrl-C again t…',
     ]);
     expect(display.bindings).toBe(
       'Resume this session with: texra resume abc123',

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -1452,6 +1452,28 @@ describe('CLI StatusBar display model', () => {
     ]);
   });
 
+  it('bounds queued-input discard warnings in very narrow footers', () => {
+    const display = buildStatusBarDisplay(
+      statusInput({
+        status: STREAM_PHASE.RUNNING,
+        runningFrame: '/',
+        elapsedMs: 45_000,
+        transientNotice: {
+          kind: 'exit',
+          text: 'Press Ctrl-C again to exit',
+          expiresAt: 1,
+        },
+        queuedFollowUpMessages: ['Continue with the proof.'],
+        width: 30,
+      }),
+    );
+
+    expect(display.left.map(statusBarSegmentText)).toEqual([
+      '◆',
+      '1 queued follow-up will b…',
+    ]);
+  });
+
   it('compacts token usage to a percentage before dropping it on narrow widths', () => {
     const input = statusInput({
       status: STREAM_PHASE.RUNNING,

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -1428,6 +1428,26 @@ describe('CLI StatusBar display model', () => {
     ]);
   });
 
+  it('keeps thinking status visible during transient notices', () => {
+    const display = buildStatusBarDisplay(
+      statusInput({
+        status: STREAM_PHASE.RUNNING,
+        runningFrame: '/',
+        elapsedMs: 45_000,
+        thinkingActive: true,
+        transientNotice: {
+          kind: 'message',
+          text: 'Unknown command: /wat',
+          expiresAt: 1,
+        },
+      }),
+    );
+
+    expect(display.left.map(statusBarSegmentText)).toEqual(
+      expect.arrayContaining(['/ running 45s', 'thinking...']),
+    );
+  });
+
   it('keeps queued-input discard warnings ahead of status details', () => {
     const display = buildStatusBarDisplay(
       statusInput({


### PR DESCRIPTION
Closes #8920.

## What changed

- make the status bar the sole owner of active-run state, animation, thinking state, and elapsed time
- delete the redundant conversation-pane liveness row and its viewport reservation
- replace the old PTY smoke case with a single-owner assertion that requires running plus elapsed in the footer and forbids transcript Working/Thinking labels
- revise the unreleased changelog to describe the net transcript-spacing behavior

This is a root-cause simplification: ConversationPane no longer observes run phase, thinking state, timestamps, or the live clock. The patch removes 146 net lines rather than adding coordination between two renderers.

## Verification

- npm run format
- npm run typecheck
- npm run lint (0 errors; one pre-existing AgentCreatorToolCatalogParity warning)
- npm run compile:fast
- focused ConversationPane and StatusBar suite: 111 tests passed
- CI=true npm run validate:tui -- single-run-liveness
- full suite: 6,846 tests passed; six unrelated load-sensitive files exceeded their 10-second timeout under concurrent machine load
- rerun of those six files serially: five files passed; RunChatSignalOwnership still exceeded 10 seconds and reproduced identically on unchanged current main
- RunChatSignalOwnership with 30-second diagnostic headroom: 2 tests passed

Exact focused tests and the real PTY scenario were rerun after rebasing onto current origin/main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI TUI presentation and layout only; no auth, persistence, or run-control logic changes beyond how liveness is displayed.
> 
> **Overview**
> **Active-run liveness moves entirely to the status bar.** The conversation pane no longer renders a `Working` / `Thinking` row with animated dots and elapsed time, frees the row it used to reserve, and drops `thinkingIndicatorVisible` plus the `THINKING_MARKER` glyph.
> 
> **The footer owns run state during notices and narrow layouts.** While a transient notice is up, an active run still shows a compact spinner + status + elapsed (`run 45s` when squeezed). `thinking...` stays visible alongside notices. Exit-with-queued-follow-ups keeps the discard warning ahead of other segments; fitting logic compacts liveness first, then drops lower-priority pieces, and truncates the safety warning only on very narrow terminals.
> 
> **Tests and release notes follow the new contract.** TUI smoke `run-liveness-row` becomes `single-run-liveness` (footer pattern, no transcript `✻ Working` / `✻ Thinking`). Changelog no longer promises transcript run activity; it only describes spacing after user messages. Conversation-pane liveness tests are removed; status bar tests cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ab9f620cfe7ba856ed6422d0901896f675eb76a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->