### PR TITLE
refactor(tools): close dead export exceptions

### DIFF
--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -297,66 +297,6 @@
       "name": "src/test-kernel/support/setupFakePlatform.ts"
     },
     {
-      "file": "src/tools/approval/index.ts",
-      "category": "types",
-      "name": "BashApprovalRequest"
-    },
-    {
-      "file": "src/tools/approval/index.ts",
-      "category": "types",
-      "name": "BashApprovalResult"
-    },
-    {
-      "file": "src/tools/approval/index.ts",
-      "category": "types",
-      "name": "WriteApprovedContentResult"
-    },
-    {
-      "file": "src/tools/approval/toolEditApproval.ts",
-      "category": "types",
-      "name": "ApprovedEditContent"
-    },
-    {
-      "file": "src/tools/github/checkRunsClient.ts",
-      "category": "types",
-      "name": "CheckRunsCachePage"
-    },
-    {
-      "file": "src/tools/goal/goalStore.ts",
-      "category": "types",
-      "name": "GoalStateChange"
-    },
-    {
-      "file": "src/tools/goal/index.ts",
-      "category": "types",
-      "name": "GoalStateChange"
-    },
-    {
-      "file": "src/tools/goal/index.ts",
-      "category": "types",
-      "name": "GoalStateChangeListener"
-    },
-    {
-      "file": "src/tools/lean/lspTypes.ts",
-      "category": "types",
-      "name": "LspMarkedString"
-    },
-    {
-      "file": "src/tools/lean/lspTypes.ts",
-      "category": "types",
-      "name": "LspMarkupContent"
-    },
-    {
-      "file": "src/tools/lean/lspTypes.ts",
-      "category": "types",
-      "name": "LspPosition"
-    },
-    {
-      "file": "src/tools/lean/lspTypes.ts",
-      "category": "types",
-      "name": "LspRange"
-    },
-    {
       "file": "src/transcript/index.ts",
       "category": "exports",
       "name": "unregisterFlushers"

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -23,7 +23,7 @@ const BashApprovalRequestSchema = z.object({
   cwd: z.string().nullish(),
   streamId: StreamTabIdSchema.nullish(),
 });
-export type BashApprovalRequest = z.infer<typeof BashApprovalRequestSchema>;
+type BashApprovalRequest = z.infer<typeof BashApprovalRequestSchema>;
 
 const BashApprovalResultSchema = z.object({
   accepted: z.boolean(),
@@ -31,7 +31,7 @@ const BashApprovalResultSchema = z.object({
   /** Distinguishes a host-side interaction timeout from an explicit reject. */
   timedOut: z.boolean().optional(),
 });
-export type BashApprovalResult = z.infer<typeof BashApprovalResultSchema>;
+type BashApprovalResult = z.infer<typeof BashApprovalResultSchema>;
 
 const DEFAULT_BASH_REJECTION_INSTRUCTION =
   'Do not retry this rejected command or another approval-gated shell command for the same check. ' +

--- a/src/tools/approval/index.ts
+++ b/src/tools/approval/index.ts
@@ -143,8 +143,6 @@ export {
   // Bash approval
   setBashApprovalSessionBypass,
   isBashApprovalBypassedForStream,
-  type BashApprovalRequest,
-  type BashApprovalResult,
 } from './bashApproval';
 
 export {
@@ -159,5 +157,4 @@ export {
   isApprovalBypassedForStream,
   type ToolEditApprovalRequest,
   type ToolEditApprovalResult,
-  type WriteApprovedContentResult,
 } from './toolEditApproval';

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -283,7 +283,7 @@ function formatUnifiedApprovalUserDiff(
   return `User adjustments to ${path}:\n\n\`\`\`diff\n${diffBody}\n\`\`\``;
 }
 
-export interface WriteApprovedContentResult {
+interface WriteApprovedContentResult {
   appliedContent: string;
   baseContent: string;
 }
@@ -386,7 +386,7 @@ export function buildApprovalRejectedResult(
   return result;
 }
 
-export interface ApprovedEditContent {
+interface ApprovedEditContent {
   approval: ToolEditApprovalResult;
   /** Content to write: the user's adjustments if any, else the proposal. */
   finalContent: string;

--- a/src/tools/github/checkRunsClient.ts
+++ b/src/tools/github/checkRunsClient.ts
@@ -41,10 +41,10 @@ const MAX_ANNOTATION_PAGES_PER_RUN = 50;
  * `lastTotalCount` is the most recent `total_count` from a 200 response; it
  * tells us how many pages to walk when page 1 returns 304.
  *
- * Exported as a standalone type so `SubscriptionState` can reference it
- * without `checkRunsClient` importing back from `PRPollingSource` (cycle).
+ * Kept as a standalone type so the per-page cache shape remains explicit
+ * without coupling it to poller subscription state.
  */
-export interface CheckRunsCachePage {
+interface CheckRunsCachePage {
   etag?: string;
   runs: GhCheckRun[];
 }

--- a/src/tools/goal/goalStore.ts
+++ b/src/tools/goal/goalStore.ts
@@ -25,11 +25,11 @@ const INDEX_KEY = 'goals:index';
 // without calling `forget()` leave dangling entries until next manual cleanup.
 const indexMutex = new Mutex();
 
-export interface GoalStateChange {
+interface GoalStateChange {
   readonly streamId: StreamTabId;
 }
 
-export type GoalStateChangeListener = (change: GoalStateChange) => void;
+type GoalStateChangeListener = (change: GoalStateChange) => void;
 
 function streamKey(streamId: StreamTabId): string {
   return `${STREAM_KEY_PREFIX}${streamId}`;

--- a/src/tools/goal/index.ts
+++ b/src/tools/goal/index.ts
@@ -1,8 +1,3 @@
 export { isGoalEnabled } from './goalFeatureFlag';
-export {
-  GoalStore,
-  subscribeGoalStateChanges,
-  type GoalStateChange,
-  type GoalStateChangeListener,
-} from './goalStore';
+export { GoalStore, subscribeGoalStateChanges } from './goalStore';
 export { setGoalSessionBashAutoApproval } from './goalAutoApproval';

--- a/src/tools/lean/lspTypes.ts
+++ b/src/tools/lean/lspTypes.ts
@@ -5,12 +5,12 @@
  * details of `vscode-languageserver-protocol`.
  */
 
-export type LspMarkupContent = {
+type LspMarkupContent = {
   kind: 'plaintext' | 'markdown' | string;
   value: string;
 };
 
-export type LspMarkedString = string | { language: string; value: string };
+type LspMarkedString = string | { language: string; value: string };
 
 export interface LspHover {
   contents: LspMarkedString | LspMarkupContent | LspMarkedString[];
@@ -29,12 +29,12 @@ export interface LspPublishDiagnosticsParams {
   diagnostics: LspDiagnostic[];
 }
 
-export interface LspRange {
+interface LspRange {
   start: LspPosition;
   end: LspPosition;
 }
 
-export interface LspPosition {
+interface LspPosition {
   line: number;
   character: number;
 }


### PR DESCRIPTION
## Summary

Remove 12 dead-export exceptions across approval, GitHub polling, goal state, and Lean LSP internals. The declarations remain file-local where they still describe implementation details, while dead barrel exports and their knip baseline entries are deleted.

Closes #8923.

## Issue acceptance gates

- Re-grepped all 11 symbol names on current `main`; each had zero consumers outside its declaring file and dead barrel re-export.
- Kept the active `HostBashApprovalRequest` contract untouched; it is distinct from the dead tools approval type.
- Removed all 12 matching entries from `config/ratchets/knip-baseline.json`.
- `npm run check:dead-code-ratchet` and `npm run typecheck` pass.

## Single source of truth

Each type is now owned only by the module that uses it. The approval and goal barrels expose only contracts with real consumers.

## Duplication and abstraction budget

No abstraction or duplication added. This narrows existing module contracts and deletes baseline exemptions that masked the unused exports.

## Net elements (R6)

- Files: 0 added, 0 deleted.
- Exported API elements: 0 added, 12 dead export sites deleted.
- Classes/interfaces/enums: 0 added, 0 deleted; affected declarations become file-local.
- Net LoC: -68 (`14` added / `82` deleted, including the corrected cache-type comment).

## Consumer counts (R8)

Repo-wide TypeScript grep found 0 external consumers for each affected symbol: `BashApprovalRequest`, `BashApprovalResult`, `WriteApprovedContentResult`, `ApprovedEditContent`, `CheckRunsCachePage`, `GoalStateChange`, `GoalStateChangeListener`, `LspMarkedString`, `LspMarkupContent`, `LspPosition`, and `LspRange`.

## Host impact

Extension: None; type/export surface only.

Desktop: None; type/export surface only.

CLI: None; type/export surface only.

## Scheduled refactoring

None. #8925 is an independent sibling issue and now will not need to relocate these four Lean baseline exceptions.

## Validation

- `npm run format`
- `npm run compile:fast`
- `npm run lint` (passes with one pre-existing warning in `AgentCreatorToolCatalogParity.vitest.mts`)
- `npm run check:dead-code-ratchet`
- `npm run typecheck`
- `npm test` (740 files passed, 1 skipped; 6,868 tests passed, 4 skipped)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Export-only cleanup with no runtime or host behavior changes; active approval and goal APIs remain exported.
> 
> **Overview**
> Narrows the public API by dropping **12 unused exported types** and their knip ratchet exemptions. Approval (`BashApprovalRequest` / `BashApprovalResult`, `WriteApprovedContentResult`, `ApprovedEditContent`), goal state (`GoalStateChange`, `GoalStateChangeListener`), GitHub check-runs (`CheckRunsCachePage`), and Lean LSP helpers (`LspPosition`, `LspRange`, etc.) stay in their defining modules but are no longer `export`ed or re-exported from `@tools/approval` and `@tools/goal` barrels.
> 
> **`config/ratchets/knip-baseline.json`** loses the matching baseline entries so the dead-code ratchet no longer masks those symbols. Still-exported approval contracts (`ToolEditApprovalRequest` / `ToolEditApprovalResult`, bypass helpers) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bfcf3f1f03cdb79a101afa2e0712d3d64bce745. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->