### PR TITLE
fix(latex): support between-round diffs in current runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ All notable changes to this project will be documented in this file.
 
 - **Accepted run files remain editable** — agents can continue editing accepted
   workflow output without an unnecessary intervening file read.
+- **Between-round LaTeX diffs work with current runs** — users who enable
+  between-round comparisons now receive them for current saved runs and active
+  agent sessions instead of a round-number extraction error.
 - **Credential setup stays private and matches the current app** — the setup
   assistant now distinguishes saved keys, environment variables, ChatGPT
   access, and included TeXRA access; it directs API-key entry to the current

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -237,6 +237,8 @@ export class LatexDiffManager {
               this.latexdiffService.runDiffBetweenRounds(
                 base,
                 revised,
+                currRound - 1,
+                currRound,
                 undefined,
                 {
                   cwd,

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -2,7 +2,6 @@ import * as path from 'node:path';
 
 import { z } from 'zod';
 
-import { extractLastRoundMatch } from '@agent/utils/mergeFileUtils';
 import { formatError } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import type { FileLocation } from '@shared/schemas';
@@ -251,6 +250,8 @@ export class LaTeXdiffService {
   async runDiffBetweenRounds(
     firstLocation: FileLocation,
     secondLocation: FileLocation,
+    fromRound: number,
+    toRound: number,
     mathMarkup?: MathMarkupOption,
     options?: { cwd?: string; outputDirectory?: string },
   ): Promise<LaTeXdiffResult> {
@@ -261,21 +262,7 @@ export class LaTeXdiffService {
         return { success: false, message };
       }
 
-      const firstRoundMatch = extractLastRoundMatch(firstLocation.absolutePath);
-      const secondRoundMatch = extractLastRoundMatch(
-        secondLocation.absolutePath,
-      );
-
-      if (!firstRoundMatch || !secondRoundMatch) {
-        const message = 'Could not extract round numbers from file names';
-        logger.warn(this.channel, message);
-        return { success: false, message };
-      }
-
-      const diffSuffix = buildBetweenRoundDiffSuffix(
-        secondRoundMatch[1],
-        firstRoundMatch[1],
-      );
+      const diffSuffix = buildBetweenRoundDiffSuffix(toRound, fromRound);
       return await this.runDiff(
         firstLocation,
         secondLocation,

--- a/src/latex/latexdiff/diffOperations.ts
+++ b/src/latex/latexdiff/diffOperations.ts
@@ -8,6 +8,7 @@ import * as path from 'node:path';
 
 // Local imports
 import { platform } from '@platform/platform';
+import { getSafeDocumentRelativePath } from '@agent/utils/outputFileUtils';
 import type { MathMarkupOption } from '@latex/latexdiff/mathMarkup';
 import * as logger from '@logger/logUtils';
 import {
@@ -21,12 +22,7 @@ import {
   midEraWorkflowOutputStem,
   parseWorkflowOutputRoundDir,
 } from '@shared/constants/workflowOutput';
-import {
-  WorkspaceFS,
-  FlexibleFS,
-  getComparablePath,
-  pathToLocation,
-} from '@utils/files';
+import { WorkspaceFS, FlexibleFS, pathToLocation } from '@utils/files';
 import { hasExtension } from '@utils/core/pathCore';
 import { isDirectory, isFile, isSymlink } from '@utils/files/fsEntryType';
 
@@ -38,8 +34,8 @@ import type {
   DiffRunResult,
 } from './types';
 
-function getFileLabel(info: OutputFileInfo): string {
-  return info.source ?? path.basename(getComparablePath(info.location));
+function getCanonicalSource(info: OutputFileInfo): string {
+  return getSafeDocumentRelativePath(info.source);
 }
 
 async function executeDiffOperations(
@@ -123,7 +119,8 @@ export async function runLatexdiffFromMetadata(params: {
   for (const [round, infos] of roundIndexedEntries(rounds)) {
     for (const info of infos) {
       const base = getEffectiveDiffBase(info.lineage);
-      const description = `${getFileLabel(info)} (r${round})`;
+      const source = getCanonicalSource(info);
+      const description = `${source} (r${round})`;
 
       if (!base) {
         immediateResults.push({
@@ -143,10 +140,9 @@ export async function runLatexdiffFromMetadata(params: {
         round,
       });
 
-      const key = info.source;
-      const group = groupedBySource.get(key) ?? [];
+      const group = groupedBySource.get(source) ?? [];
       group.push({ round, info });
-      groupedBySource.set(key, group);
+      groupedBySource.set(source, group);
     }
   }
 
@@ -158,7 +154,7 @@ export async function runLatexdiffFromMetadata(params: {
         const current = group[index];
         const base = previous.info.location;
         const revised = current.info.location;
-        const description = `${getFileLabel(current.info)} (r${previous.round}→r${current.round})`;
+        const description = `${getCanonicalSource(current.info)} (r${previous.round}→r${current.round})`;
 
         operations.push({
           type: 'between-rounds',

--- a/src/latex/latexdiff/diffOperations.ts
+++ b/src/latex/latexdiff/diffOperations.ts
@@ -86,6 +86,8 @@ async function executeDiffOperations(
         : await LaTeXdiffService.runDiffBetweenRounds(
             operation.base,
             operation.revised,
+            operation.fromRound,
+            operation.toRound,
             mathMarkup,
             { cwd: operation.cwd },
           );
@@ -141,7 +143,7 @@ export async function runLatexdiffFromMetadata(params: {
         round,
       });
 
-      const key = getComparablePath(info.location);
+      const key = info.source;
       const group = groupedByRelative.get(key) ?? [];
       group.push({ round, info });
       groupedByRelative.set(key, group);

--- a/src/latex/latexdiff/diffOperations.ts
+++ b/src/latex/latexdiff/diffOperations.ts
@@ -115,7 +115,7 @@ export async function runLatexdiffFromMetadata(params: {
   const workspaceCwd = WorkspaceFS.getPath();
   const immediateResults: DiffRunResult[] = [];
   const operations: DiffOperation[] = [];
-  const groupedByRelative = new Map<
+  const groupedBySource = new Map<
     string,
     Array<{ round: number; info: OutputFileInfo }>
   >();
@@ -144,14 +144,14 @@ export async function runLatexdiffFromMetadata(params: {
       });
 
       const key = info.source;
-      const group = groupedByRelative.get(key) ?? [];
+      const group = groupedBySource.get(key) ?? [];
       group.push({ round, info });
-      groupedByRelative.set(key, group);
+      groupedBySource.set(key, group);
     }
   }
 
   if (generateBetweenRoundDiffs) {
-    for (const group of groupedByRelative.values()) {
+    for (const group of groupedBySource.values()) {
       group.sort((a, b) => a.round - b.round);
       for (let index = 1; index < group.length; index += 1) {
         const previous = group[index - 1];

--- a/src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts
+++ b/src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts
@@ -10,8 +10,10 @@ import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
 import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 import { installPlatform } from '@test/support/setupPlatform';
 import { cleanupTempDirs } from '@test/support/tempDirPlatform';
+import type { ExecutionId, OutputFileInfo } from '@shared/schemas';
 import {
   createExternalLocation,
+  createRunStorageLocation,
   createWorkspaceLocation,
   getRunDir,
   TaskRunFileService,
@@ -118,6 +120,75 @@ describe('LaTeXdiffService shadow output', () => {
     await expect(
       readFile(path.join(sourceDir, 'revised_diff.tex'), 'utf8'),
     ).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('generates between-round diffs for modern run-storage paths', async () => {
+    const tempDir = await makeTempDir('texra-latexdiff-rounds-');
+    const workspaceDir = path.join(tempDir, 'workspace');
+    const executionId: ExecutionId = 'abcdef';
+    const firstDir = path.join(tempDir, 'executions', executionId, 'r1');
+    const secondDir = path.join(tempDir, 'executions', executionId, 'r2');
+    const basePath = path.join(workspaceDir, 'paper.tex');
+    const firstPath = path.join(firstDir, 'paper.tex');
+    const secondPath = path.join(secondDir, 'paper.tex');
+    const document = (body: string) =>
+      `\\documentclass{article}\n\\begin{document}\n${body}\n\\end{document}\n`;
+
+    await Promise.all([
+      mkdir(workspaceDir, { recursive: true }),
+      mkdir(firstDir, { recursive: true }),
+      mkdir(secondDir, { recursive: true }),
+    ]);
+    await Promise.all([
+      writeFile(basePath, document('base')),
+      writeFile(firstPath, document('round one')),
+      writeFile(secondPath, document('round two')),
+    ]);
+    await installNodeBackedPlatform(
+      workspaceDir,
+      path.join(tempDir, 'storage'),
+    );
+
+    const base = createWorkspaceLocation(basePath, 'paper.tex');
+    const first = createRunStorageLocation(
+      firstPath,
+      'r1/paper.tex',
+      executionId,
+    );
+    const second = createRunStorageLocation(
+      secondPath,
+      'r2/paper.tex',
+      executionId,
+    );
+    const output = (round: number, location: typeof first): OutputFileInfo => ({
+      source: 'paper.tex',
+      location,
+      round,
+      lineage: { original: base, diffBase: null, diffFile: null },
+      diff: null,
+    });
+    const { runLatexdiffFromMetadata } =
+      await import('@latex/latexdiff/diffOperations');
+
+    const result = await runLatexdiffFromMetadata({
+      rounds: { 1: [output(1, first)], 2: [output(2, second)] },
+      generateBetweenRoundDiffs: true,
+      progress: { report: vi.fn() },
+    });
+
+    expect(result).toMatchObject({ totalOperations: 3 });
+    expect(result.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          success: true,
+          description: 'paper.tex (r1→r2)',
+          diffFileName: 'paper_diffr2r1.tex',
+        }),
+      ]),
+    );
+    await expect(
+      readFile(path.join(firstDir, 'paper_diffr2r1.tex'), 'utf8'),
+    ).resolves.toContain('changed');
   });
 
   it('restores flattened BibTeX blocks to the source bibliography directive', async () => {

--- a/src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts
+++ b/src/test-kernel/latex/LatexdiffShadowStorage.vitest.ts
@@ -160,8 +160,12 @@ describe('LaTeXdiffService shadow output', () => {
       'r2/paper.tex',
       executionId,
     );
-    const output = (round: number, location: typeof first): OutputFileInfo => ({
-      source: 'paper.tex',
+    const output = (
+      round: number,
+      location: typeof first,
+      source = 'paper.tex',
+    ): OutputFileInfo => ({
+      source,
       location,
       round,
       lineage: { original: base, diffBase: null, diffFile: null },
@@ -171,7 +175,7 @@ describe('LaTeXdiffService shadow output', () => {
       await import('@latex/latexdiff/diffOperations');
 
     const result = await runLatexdiffFromMetadata({
-      rounds: { 1: [output(1, first)], 2: [output(2, second)] },
+      rounds: { 1: [output(1, first)], 2: [output(2, second, './paper.tex')] },
       generateBetweenRoundDiffs: true,
       progress: { report: vi.fn() },
     });


### PR DESCRIPTION
## Summary

- Pass between-round numbers through the existing diff operation contract.
- Group saved-run outputs by their stable source path instead of round-specific storage paths.
- Cover the current `executions/{id}/r{round}/` layout end to end.

## Root cause

Both production callers already own the relevant rounds, but `runDiffBetweenRounds` discarded that information and tried to reconstruct it from legacy `_rN_` filename tokens. Current run storage puts the round in a directory, so opted-in between-round diffs either were never grouped for the manual metadata path or failed with a round-number extraction error in active sessions.

The diff service now receives the two rounds explicitly. This removes the obsolete re-derivation and its failure branch without adding a wrapper or new abstraction.

## User impact

Users who enable between-round LaTeX comparisons now receive them for current saved runs and active agent sessions. Legacy flat-layout naming remains unchanged.

## Validation

- `npm test -- src/test-kernel/latex/` — 88 passed
- `npm run typecheck`
- `npm run lint` — no errors; one pre-existing warning
- `npm run compile:fast`
- `npm run check:dead-code-ratchet`
- Prettier check on all changed files

Closes #8916

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped LaTeX diff bug fix with explicit round parameters and a regression test; no auth, data, or broad workflow behavior changes beyond between-round diff pairing and naming.
> 
> **Overview**
> **Between-round LaTeX diffs** now work for modern run storage (`executions/{id}/r{N}/`) and active agent sessions. Callers pass **`fromRound` / `toRound`** into `runDiffBetweenRounds` instead of inferring rounds from legacy `_rN_` filename tokens, which failed when rounds live only in directory names.
> 
> Saved-run metadata grouping for optional between-round diffs now keys outputs by **canonical document source** (`getSafeDocumentRelativePath`), so the same logical file across rounds (e.g. `paper.tex` vs `./paper.tex`) is paired correctly even when storage paths differ.
> 
> A kernel test covers metadata-driven between-round diffs on current run-storage paths; the changelog documents the user-visible fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d55ce6986823cfdf636289458e8326e99e7cc6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->