### PR TITLE
fix(tools): record accepted files as read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Accepted run files remain editable** — agents can continue editing accepted
+  workflow output without an unnecessary intervening file read.
 - **Credential setup stays private and matches the current app** — the setup
   assistant now distinguishes saved keys, environment variables, ChatGPT
   access, and included TeXRA access; it directs API-key entry to the current

--- a/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/AcceptRunFilesProgressEvents.vitest.ts
@@ -13,6 +13,7 @@ import { FileType, type FileStat } from '@platform/interfaces';
 // Local imports
 import { installPlatform } from '@test/support/setupPlatform';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { FileInteractionState } from '@agent/core/state/AgentWorkspaceState';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { withToolFileInteractionContext } from '@agent/followUp/ToolFileInteractionContext';
@@ -87,11 +88,12 @@ function runAccept(
   tool: AcceptRunFilesTool,
   host: AgentRuntimeHost,
   files: { path: string; original: string }[],
+  tracker = new FileInteractionState(),
 ) {
   return withRunContext(
     createRunContext({ runtimeHost: host, streamId, executionId }),
     () =>
-      withToolFileInteractionContext({ tracker: {} as never }, () =>
+      withToolFileInteractionContext({ tracker }, () =>
         tool.call({ execution_id: executionId, files }),
       ),
   );
@@ -157,6 +159,7 @@ describe('accept_run_files progress events', () => {
   it('publishes accepted workspace files through app signals', async () => {
     const explicit = createRecordingHost();
     const tool = new AcceptRunFilesTool();
+    const tracker = new FileInteractionState();
     const written: string[][] = [];
     const dispose = appSignals.on(
       'workspaceFilesWritten',
@@ -176,13 +179,17 @@ describe('accept_run_files progress events', () => {
 
     testApprovalHandler = async () => ({ accepted: true });
 
-    const result = await runAccept(tool, explicit.host, [
-      { path: 'output.tex', original: 'paper.tex' },
-    ]);
+    const result = await runAccept(
+      tool,
+      explicit.host,
+      [{ path: 'output.tex', original: 'paper.tex' }],
+      tracker,
+    );
 
     expect(result.status).toBe('executed');
     expect(explicit.events).toEqual([]);
     expect(written).toEqual([[`${workspacePath}/paper.tex`]]);
+    expect(tracker.hasRead('paper.tex')).toBe(true);
     dispose();
   });
 

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -288,64 +288,45 @@ interface WriteApprovedContentResult {
   baseContent: string;
 }
 
+/**
+ * Reconcile approved content with the current workspace file and mark the path
+ * as read after the operation succeeds, so every approved-write caller keeps
+ * the later-edit guard in sync.
+ */
 export async function writeApprovedContent(
   path: string,
   originalContent: string,
   finalContent: string,
 ): Promise<WriteApprovedContentResult> {
   const exists = await WorkspaceFS.exists(path);
-  if (!exists) {
-    await WorkspaceFS.write(path, finalContent);
-    return { appliedContent: finalContent, baseContent: '' };
+  let baseContent = '';
+  let appliedContent = finalContent;
+  let shouldWrite = true;
+
+  if (exists) {
+    // All content is already LF-normalized at the FS read boundary,
+    // so comparisons work directly without extra normalization.
+    const currentContent = await WorkspaceFS.read(path);
+    baseContent = currentContent;
+
+    if (currentContent === finalContent || originalContent === finalContent) {
+      appliedContent = currentContent;
+      shouldWrite = false;
+    } else if (currentContent !== originalContent) {
+      const { content: patchedContent, results } = applyPatchToText(
+        originalContent,
+        finalContent,
+        currentContent,
+      );
+      appliedContent = results.every(Boolean) ? patchedContent : finalContent;
+    }
   }
 
-  // All content is already LF-normalized at the FS read boundary,
-  // so comparisons work directly without extra normalization.
-  const currentContent = await WorkspaceFS.read(path);
-
-  if (currentContent === finalContent || originalContent === finalContent) {
-    return { appliedContent: currentContent, baseContent: currentContent };
+  if (shouldWrite) {
+    await WorkspaceFS.write(path, appliedContent);
   }
-
-  if (currentContent === originalContent) {
-    await WorkspaceFS.write(path, finalContent);
-    return { appliedContent: finalContent, baseContent: currentContent };
-  }
-
-  const { content: patchedContent, results } = applyPatchToText(
-    originalContent,
-    finalContent,
-    currentContent,
-  );
-
-  if (results.every(Boolean)) {
-    await WorkspaceFS.write(path, patchedContent);
-    return { appliedContent: patchedContent, baseContent: currentContent };
-  }
-
-  await WorkspaceFS.write(path, finalContent);
-  return { appliedContent: finalContent, baseContent: currentContent };
-}
-
-/**
- * `writeApprovedContent` plus the `recordToolFileRead` that must always
- * follow it — every edit tool marks the file "read" immediately after a
- * successful approved write so a later edit in the same run doesn't hit the
- * read-before-edit gate. Centralized because every call site paired these two
- * calls by hand and it's an easy one to forget.
- */
-async function writeAndRecordApprovedEdit(
-  path: string,
-  originalContent: string,
-  finalContent: string,
-): Promise<WriteApprovedContentResult> {
-  const result = await writeApprovedContent(
-    path,
-    originalContent,
-    finalContent,
-  );
   recordToolFileRead(path);
-  return result;
+  return { appliedContent, baseContent };
 }
 
 /**
@@ -440,9 +421,8 @@ interface WrittenApprovedEdit extends WriteApprovedContentResult {
 
 /**
  * Full approve-then-write handshake for a proposed edit: request approval,
- * then write the resolved content and record the file as read. Combines
- * `requestApprovedEditContent` + `writeAndRecordApprovedEdit`, the exact
- * pairing every straight-through edit call site previously hand-rolled.
+ * then write the resolved content. Combines the exact pairing every
+ * straight-through edit call site previously hand-rolled.
  * `beforeWrite` covers work that must happen only after acceptance, such as
  * creating a new file's parent directory.
  */
@@ -462,7 +442,7 @@ export async function requestAndWriteApprovedEdit(request: {
 
   await request.beforeWrite?.();
 
-  const written = await writeAndRecordApprovedEdit(
+  const written = await writeApprovedContent(
     request.path,
     request.originalContent,
     finalContent,


### PR DESCRIPTION
Closes #8928.

## Root cause

The approved-write operation had two callers, but its read-tracking invariant lived in a private wrapper used by only one of them. accept_run_files called the underlying write directly, so the later-edit guard did not know the accepted destination had already been read and written.

## Fix

- Make writeApprovedContent own read tracking after every successful approved write.
- Delete the now-redundant write-and-record wrapper.
- Exercise accept_run_files with a real FileInteractionState and lock the recorded destination path.
- Add the user-visible fix to the Unreleased changelog.

This makes the invariant hold by construction for every current and future caller and reduces the implementation by 11 net lines.

## Verification

- Focused Vitest: 2 files, 9 tests passed
- ESLint on touched TypeScript files
- Full workspace typecheck
- Prettier and git diff checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to tool approval write plumbing with a focused test; no auth or data-model changes.
> 
> **Overview**
> **Accepted run files stay editable** — after `accept_run_files` writes into the workspace, agents no longer hit the read-before-edit guard on those paths because read tracking was only applied on one approval-write code path.
> 
> **Centralized invariant** — `writeApprovedContent` now always calls `recordToolFileRead` after a successful reconcile/write, and the redundant `writeAndRecordApprovedEdit` wrapper is removed so every caller (including `accept_run_files` and `requestAndWriteApprovedEdit`) shares the same behavior.
> 
> **Regression test** — `accept_run_files` progress tests use a real `FileInteractionState` and assert the destination path is marked read after acceptance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d708dd090111f0f022b8223c0dcc080237784070. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->