### PR TITLE
refactor: prune dead cross-domain surfaces

### DIFF
--- a/config/ratchets/knip-baseline.json
+++ b/config/ratchets/knip-baseline.json
@@ -297,16 +297,6 @@
       "name": "src/test-kernel/support/setupFakePlatform.ts"
     },
     {
-      "file": "src/transcript/index.ts",
-      "category": "exports",
-      "name": "unregisterFlushers"
-    },
-    {
-      "file": "src/transcript/index.ts",
-      "category": "types",
-      "name": "StreamLogStoreMode"
-    },
-    {
       "file": "src/utils/files/taskRunStorage.ts",
       "category": "types",
       "name": "RunStorageEntryInspection"

--- a/packages/extension/src/commands/latex/latexdiffCommands.ts
+++ b/packages/extension/src/commands/latex/latexdiffCommands.ts
@@ -17,8 +17,6 @@ import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 import {
   runPackLatexdiffvc,
   runPackLatexdiffvcMultiple,
-  runCleanLatexdiffvc,
-  runCleanLatexdiffvcMultiple,
   type LatexdiffPackResult,
 } from '@housekeeping';
 import type { LaTeXdiffResult } from '@latex/latexdiff';
@@ -303,7 +301,7 @@ async function handleCleanLatexdiffvc(
         `Command called with: inputFile=${inputFile}, baseFile=${baseFile}, commitHash=${commitHash}`,
       );
       const fileToUse = baseFile ?? inputFile;
-      reportLatexdiff(await runCleanLatexdiffvc(fileToUse, commitHash));
+      reportLatexdiff(await runPackLatexdiffvc(fileToUse, commitHash, true));
     },
   );
 }
@@ -319,7 +317,7 @@ async function handleCleanLatexdiffvcMultiple(
       logger.debug(CHANNEL, `Command called with: commitHash=${commitHash}`);
       logger.debug(CHANNEL, `Input files: ${inputFiles.join(', ')}`);
       reportLatexdiff(
-        await runCleanLatexdiffvcMultiple(inputFiles, commitHash),
+        await runPackLatexdiffvcMultiple(inputFiles, commitHash, true),
       );
     },
   );

--- a/src/housekeeping/index.ts
+++ b/src/housekeeping/index.ts
@@ -9,7 +9,5 @@ export { runPackRunDir, runCleanRunDir } from './runDirOps';
 export {
   runPackLatexdiffvc,
   runPackLatexdiffvcMultiple,
-  runCleanLatexdiffvc,
-  runCleanLatexdiffvcMultiple,
   type LatexdiffPackResult,
 } from './latexdiff';

--- a/src/housekeeping/latexdiff.ts
+++ b/src/housekeeping/latexdiff.ts
@@ -126,17 +126,3 @@ export async function runPackLatexdiffvcMultiple(
   }
   return results;
 }
-
-export async function runCleanLatexdiffvc(
-  inputFile: string,
-  commitHash: string,
-): Promise<LatexdiffPackResult> {
-  return runPackLatexdiffvc(inputFile, commitHash, true);
-}
-
-export async function runCleanLatexdiffvcMultiple(
-  inputFiles: string[],
-  commitHash: string,
-): Promise<LatexdiffPackResult[]> {
-  return runPackLatexdiffvcMultiple(inputFiles, commitHash, true);
-}

--- a/src/replacement/engine.ts
+++ b/src/replacement/engine.ts
@@ -61,11 +61,6 @@ const replacementEngine = {
       : processed;
   },
 
-  /** Apply all configured regex-based replacement rules. */
-  applyRegex(text: string): string {
-    return applyReplacements(text, getAllReplacementsRegex()).trim();
-  },
-
   /**
    * Apply every replacement rule in the recommended order. Non-regex
    * replacements run before and after regex replacements to fix artifacts they

--- a/src/tools/arxiv/ArxivMetadataTool.ts
+++ b/src/tools/arxiv/ArxivMetadataTool.ts
@@ -2,13 +2,13 @@
 import { z } from 'zod';
 
 // Local imports - latex
+import { normaliseArxivIdentifier } from '@latex/arxivIdentifier';
 import { ArxivProcessor } from '@latex/arxivProcessor';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import {
   type ArxivPaperMetadata,
   createArxivClient,
   extractBasePaperMetadata,
-  normaliseArxivIdentifier,
 } from '@tools/latex/arxivShared';
 import { ARXIV_CONSTANTS } from '@tools/citation/constants';
 import { rateLimitedRequest } from '@tools/citation/rateLimiter';

--- a/src/tools/arxiv/ArxivSearchTool.ts
+++ b/src/tools/arxiv/ArxivSearchTool.ts
@@ -10,6 +10,7 @@ import {
 import { z } from 'zod';
 
 // Local imports
+import { normaliseArxivIdentifier } from '@latex/arxivIdentifier';
 import { warn } from '@logger/logUtils';
 import type { ToolResult } from '@shared/schemas/toolResult';
 import { requireNonEmptyString, wrapApiCall } from '@tools/utils';
@@ -20,7 +21,6 @@ import {
   type ArxivSearchResult,
   createArxivClient,
   extractBasePaperMetadata,
-  normaliseArxivIdentifier,
 } from '@tools/latex/arxivShared';
 import { pluralize } from '@utils/text/stringUtils';
 

--- a/src/tools/latex/arxivShared.ts
+++ b/src/tools/latex/arxivShared.ts
@@ -4,8 +4,6 @@ import { z } from 'zod';
 
 import { normaliseArxivIdentifier } from '@latex/arxivIdentifier';
 
-export { normaliseArxivIdentifier };
-
 /** Infer ArxivEntry type from the client's execute() return type */
 type ArxivEntry = Awaited<ReturnType<typeof arxivClient.execute>>[number];
 

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -53,7 +53,7 @@ interface ParsedPersistedEntries {
   preservedRawEntries: StreamLogPreservedRawEntry[];
 }
 
-export type StreamLogStoreMode =
+type StreamLogStoreMode =
   | { readonly kind: 'persistent' }
   | { readonly kind: 'read-only' }
   | { readonly kind: 'ephemeral'; readonly reason: string };

--- a/src/transcript/index.ts
+++ b/src/transcript/index.ts
@@ -13,14 +13,12 @@ export {
   StreamLogStore,
   STREAM_LOGS_DIR,
   STREAM_LOG_SUMMARIES_DIR,
-  type StreamLogStoreMode,
 } from './StreamLogStore';
 export { StreamLog, type StreamLogAppendInput } from './StreamLog';
 export {
   createRunTrace,
   flushPendingRunTraces,
   getActiveFlushers,
-  unregisterFlushers,
   type RunTrace,
 } from './runTrace';
 export { streamDataDir } from './streamDataPaths';


### PR DESCRIPTION
## Summary

- delete the unused replacement-engine regex-only entry point
- remove two pass-through latexdiff cleanup wrappers and call the existing pack functions with their cleanup flag
- narrow transcript and arXiv exports to their actual owners
- remove the two matching dead-code baseline allowances

Closes #8915

## Issue acceptance gates

- [x] `replacementEngine.applyRegex` is deleted
- [x] latexdiff cleanup wrappers and barrel exports are deleted
- [x] extension cleanup commands use the existing pack APIs directly
- [x] `StreamLogStoreMode` is file-local
- [x] only the unused transcript barrel export of `unregisterFlushers` is removed
- [x] arXiv tools import identifier normalization from its source module
- [x] matching knip baseline entries are removed

## Single source of truth

Identifier normalization remains owned by `@latex/arxivIdentifier`; latexdiff cleanup remains one mode of the existing pack implementation; transcript internals remain owned by their defining modules.

## Duplication and abstraction budget

No abstractions or duplicate paths added. Two pass-through functions and three unnecessary public surfaces are removed.

## Net elements (R6)

- code elements: -6
- dead-code baseline allowances: -2
- files: 0

## Consumer counts (R8)

- `replacementEngine.applyRegex`: 0 consumers → removed
- each latexdiff cleanup wrapper: 1 consumer → removed; callers use existing pack APIs
- `StreamLogStoreMode` public export: 0 consumers → file-local
- transcript barrel `unregisterFlushers`: 0 consumers → removed; one intentional deep import remains
- arXiv shared re-export: 2 consumers → direct source imports

## Host impact

- extension: cleanup command dispatch now calls the existing pack functions directly
- desktop: no behavior change
- CLI: no behavior change

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run check:dead-code-ratchet`
- `npm run typecheck`
- `npm run lint` (0 errors; one pre-existing warning)
- `npm run compile:fast`
- focused Vitest: 4 files, 112 tests passed
- `npm test`: 740 files and 6,868 tests passed; expected skips only
- exact-head ratchet, focused tests, and typecheck rerun after rebase
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only deletion of unused exports and thin wrappers; extension cleanup still uses the same pack implementation with the cleanup flag.
> 
> **Overview**
> **Dead API and wrapper removal** with no intended behavior change beyond narrower import paths.
> 
> Removes the unused `replacementEngine.applyRegex` entry point. Deletes `runCleanLatexdiffvc` / `runCleanLatexdiffvcMultiple` and their `@housekeeping` barrel exports; VS Code **clean** latexdiff-vc commands now call `runPackLatexdiffvc` / `runPackLatexdiffvcMultiple` with `clean: true`.
> 
> Stops re-exporting `StreamLogStoreMode` and transcript-barrel `unregisterFlushers` (callers keep using `runTrace` directly). arXiv metadata/search tools import `normaliseArxivIdentifier` from `@latex/arxivIdentifier` instead of `@tools/latex/arxivShared`. Drops two matching **knip** baseline allowances.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4b9efa1d0aa208068234048c177316d4babcff0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->