### PR TITLE
refactor(build): use native esbuild aliases

### DIFF
--- a/packages/desktop/tsconfig.paths.json
+++ b/packages/desktop/tsconfig.paths.json
@@ -3,7 +3,6 @@
     "baseUrl": "../..",
     "paths": {
       "vscode-jsonrpc/node": ["node_modules/vscode-jsonrpc/lib/node/main"],
-      "@/*": ["packages/extension/src/*", "src/*"],
       "@shared/*": ["src/shared/*"],
       "@common/state": ["packages/extension/src/common/state"],
       "@common/state/*": ["packages/extension/src/common/state/*"],

--- a/packages/extension/esbuild.config.mjs
+++ b/packages/extension/esbuild.config.mjs
@@ -1,75 +1,8 @@
 // @ts-check
 import * as esbuild from 'esbuild';
-import * as path from 'path';
-import * as fs from 'fs';
-
-// Shared path aliases from tsconfig.json (single source of truth)
-import { aliases } from '../../scripts/aliases.mjs';
 
 const production = process.argv.includes('--production');
 const watch = process.argv.includes('--watch');
-
-// Sort aliases by length (longest first) to avoid partial matches
-const sortedAliases = Object.entries(aliases).sort(
-  ([a], [b]) => b.length - a.length,
-);
-
-/**
- * Resolve a path with TypeScript extensions
- */
-function resolveWithExtensions(basePath) {
-  const extensions = ['.ts', '.tsx', '.js', '.jsx', ''];
-
-  // Try as-is first (for paths that already have extension)
-  if (fs.existsSync(basePath) && fs.statSync(basePath).isFile()) {
-    return basePath;
-  }
-
-  // Try with extensions
-  for (const ext of extensions) {
-    const withExt = basePath + ext;
-    if (fs.existsSync(withExt) && fs.statSync(withExt).isFile()) {
-      return withExt;
-    }
-  }
-
-  // Try as directory with index file
-  if (fs.existsSync(basePath) && fs.statSync(basePath).isDirectory()) {
-    for (const ext of extensions) {
-      const indexPath = path.join(basePath, 'index' + ext);
-      if (fs.existsSync(indexPath) && fs.statSync(indexPath).isFile()) {
-        return indexPath;
-      }
-    }
-  }
-
-  return null;
-}
-
-/**
- * Plugin to resolve path aliases with TypeScript support
- */
-const aliasPlugin = {
-  name: 'alias',
-  setup(build) {
-    build.onResolve({ filter: /^[@~]/ }, (args) => {
-      for (const [alias, target] of sortedAliases) {
-        if (args.path === alias || args.path.startsWith(alias + '/')) {
-          const resolved = args.path.replace(alias, target);
-          const finalPath = resolveWithExtensions(resolved);
-
-          if (finalPath) {
-            return { path: finalPath };
-          }
-
-          // Let esbuild handle unresolved paths (will show error)
-          return { path: resolved };
-        }
-      }
-      return null;
-    });
-  },
-};
 
 /**
  * Plugin to log build progress
@@ -110,6 +43,7 @@ const extensionConfig = {
   // sdkErrorUtils relies on SDK error class/prototype names after bundling.
   keepNames: production,
   treeShaking: true,
+  tsconfig: './tsconfig.json',
   // Let esbuild resolve .ts files
   resolveExtensions: ['.ts', '.tsx', '.js', '.jsx', '.json'],
   external: [
@@ -119,7 +53,7 @@ const extensionConfig = {
     'utf-8-validate', // Optional native module
   ],
   loader: { '.tex': 'text', '.wasm': 'binary' },
-  plugins: [aliasPlugin, progressPlugin],
+  plugins: [progressPlugin],
   logLevel: 'warning',
   // Polyfill import.meta.url for ESM-only dependencies (e.g. @openai/codex-sdk)
   // bundled into CJS. Without this, esbuild replaces import.meta with {} and

--- a/packages/extension/tsconfig.json
+++ b/packages/extension/tsconfig.json
@@ -9,7 +9,6 @@
     "sourceMap": false,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*", "../../src/*"],
       "@shared/*": ["../../src/shared/*"],
       "@common/state": ["src/common/state"],
       "@common/state/*": ["src/common/state/*"],

--- a/scripts/aliasUtils.mjs
+++ b/scripts/aliasUtils.mjs
@@ -1,10 +1,10 @@
 /**
  * Utilities for deriving build-tool aliases from a package tsconfig.
  *
- * Note: callers (esbuild + Vite configs) pass the *root* repo dir, so the
- * single source of truth for build-time aliases is the root `tsconfig.json`.
- * `packages/extension/tsconfig.json` is only consulted by `tsc` for typecheck;
- * if the two diverge, builds will silently follow the root.
+ * Vite callers pass the *root* repo dir, so `loadAliases` reads the root
+ * `tsconfig.json` directly. Extension esbuild instead reads its generated
+ * package tsconfig; `sync-tsconfig-paths.mjs` keeps that map aligned with the
+ * root source of truth and its check mode rejects drift.
  */
 
 import { readFileSync } from 'node:fs';

--- a/scripts/aliases.mjs
+++ b/scripts/aliases.mjs
@@ -1,6 +1,6 @@
 /**
- * Shared path aliases derived from tsconfig.json.
- * Single source of truth for esbuild and Vite build configs.
+ * Shared path aliases derived from tsconfig.json for Vite build configs.
+ * Extension esbuild reads its generated package tsconfig directly.
  */
 
 import { resolve, dirname } from 'node:path';

--- a/src/test-kernel/desktop/BuildAliasConfig.vitest.mts
+++ b/src/test-kernel/desktop/BuildAliasConfig.vitest.mts
@@ -38,19 +38,21 @@ describe('build alias configuration', () => {
     expect(viteConfig).not.toContain('../extension/scripts/aliases.mjs');
   });
 
-  it('uses the root alias table for extension bundling', () => {
+  it('uses generated TypeScript paths for extension bundling', () => {
     const extensionViteConfig = readText('packages/extension/vite.config.ts');
     const extensionEsbuildConfig = readText(
       'packages/extension/esbuild.config.mjs',
     );
 
-    for (const config of [extensionViteConfig, extensionEsbuildConfig]) {
-      expect(config).toContain("from '../../scripts/aliases.mjs'");
-      expect(config).not.toContain("from './scripts/aliases.mjs'");
-    }
-
+    expect(extensionViteConfig).toContain("from '../../scripts/aliases.mjs'");
+    expect(extensionViteConfig).not.toContain("from './scripts/aliases.mjs'");
     expect(extensionViteConfig).not.toContain(
       '.mjs import works at runtime via Vite',
+    );
+    expect(extensionEsbuildConfig).toContain("tsconfig: './tsconfig.json'");
+    expect(extensionEsbuildConfig).not.toContain('aliasPlugin');
+    expect(extensionEsbuildConfig).not.toContain(
+      "from '../../scripts/aliases.mjs'",
     );
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,6 @@
     "baseUrl": ".",
     "paths": {
       "vscode-jsonrpc/node": ["node_modules/vscode-jsonrpc/lib/node/main"],
-      "@/*": ["packages/extension/src/*", "src/*"],
       "@shared/*": ["src/shared/*"],
       "@common/state": ["packages/extension/src/common/state"],
       "@common/state/*": ["packages/extension/src/common/state/*"],


### PR DESCRIPTION
Closes #8910.

## Summary

Delete the unused `@/*` path alias from the root TypeScript map and its two generated host copies. Replace the extension bundle's hand-rolled alias resolver with esbuild's native `tsconfig` option, so TypeScript and esbuild consume the same generated extension path map.

## Issue acceptance gates

- Remove the zero-consumer `@/*` alias from the root map.
- Regenerate the extension and desktop path maps through the canonical sync script.
- Preserve Vite's shared alias-table consumers; do not revisit the rejected tsconfig-inheritance design.
- Delete the extension-only alias plugin and filesystem resolver.
- Verify development, production, desktop, VSIX, and alias-drift gates.

## Single source of truth

`tsconfig.json` remains the source for generated host path maps. The extension esbuild build now reads `packages/extension/tsconfig.json` directly instead of reconstructing TypeScript resolution through a private plugin.

## Duplication and abstraction budget

No abstraction is added. The change deletes the extension-specific alias plugin, its resolution helper, its sorted alias copy, and the dead alias entry. Vite keeps using `scripts/aliases.mjs` because it has no native TypeScript-path resolver.

## Net elements (R6)

- Files: 6 changed, none added or deleted.
- Exported symbols: unchanged.
- Runtime/build elements: 4 deleted (`@/*`, `aliasPlugin`, `resolveWithExtensions`, `sortedAliases`), none added.
- LoC: 14 additions, 81 deletions, net -67.

## Consumer counts (R8)

- `@/*` imports: 0 across `src/` and `packages/` TypeScript sources.
- Generated alias rows removed: 2 host copies plus the root source row.
- Extension esbuild alias consumers: 1 private plugin replaced by the native `tsconfig` option.
- Vite alias-table consumers: unchanged.

## Host impact

Extension: Development and production bundles resolve aliases from the generated extension tsconfig; full packaging and VSIX verification pass.

Desktop: Its generated path map loses only the unused alias; desktop build artifacts pass verification.

CLI: No runtime or build behavior change.

## Scheduled refactoring

None. The rejected tsconfig-inheritance collapse remains explicitly out of scope, and the Vite alias generator remains load-bearing.

## Changelog

No entry: this is build-configuration simplification with no user-visible change.

## Validation

- `npm run check:tsconfig-paths`
- Alias configuration suites: 10 tests passed
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; one pre-existing warning)
- `npm run build:initial`
  - production extension and desktop builds
  - VSIX content verification
  - desktop artifact verification

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-configuration-only change with no runtime behavior or auth/data impact; validated by alias drift checks and full compile/VSIX gates.
> 
> **Overview**
> **Build alias simplification:** the unused `@/*` entry is removed from the root `tsconfig.json` and from the generated desktop/extension path maps (no imports used it).
> 
> **Extension host bundle:** esbuild no longer uses a hand-rolled `aliasPlugin`, filesystem extension resolver, or `scripts/aliases.mjs`. It now sets `tsconfig: './tsconfig.json'` so path aliases match the generated extension TypeScript map kept in sync by `sync-tsconfig-paths.mjs`.
> 
> **Unchanged:** Vite (desktop and extension webviews) still consumes `scripts/aliases.mjs` from the root tsconfig; comments and `BuildAliasConfig` tests are updated to document the split.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e391b00467f0102f034d91ba000cf8f822fd788. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

