### PR TITLE
fix(build): include mts files in Knip scan

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -5,7 +5,7 @@
   "workspaces": {
     ".": {
       "entry": ["src/test-kernel/**/*.vitest.{ts,mts}", "scripts/**/*.mjs"],
-      "project": ["src/**/*.ts"],
+      "project": ["src/**/*.{ts,mts}"],
       "ignore": ["src/platform/index.ts"]
     },
     "packages/extension": {


### PR DESCRIPTION
Refs #8903.

## Summary

Include root-workspace `.mts` sources in Knip's project set. The test entry glob already admitted `.vitest.mts` files, but the project glob excluded every `.mts` helper from unused-file and unused-export analysis.

This PR implements the uncontested ship-now scope from #8903. The disputed 254-file extension rename remains outside this change and does not close the issue.

## Root cause

The root Knip workspace encoded two different TypeScript source conventions: entries matched `{ts,mts}`, while the project set matched only `ts`. As a result, five non-entry `.mts` helpers and the wider `.mts` test surface could not participate in the same dead-code analysis as `.ts` sources.

## Net elements (R6)

- Files changed: 1.
- Elements added or deleted: 0.
- LoC: 1 replacement; net 0.
- Guard coverage: 259 existing `.mts` files enter the root project set.

## Consumer counts (R8)

- Root `.mts` files: 259.
- Knip project globs widened: 1.
- Runtime, build, and package consumers changed: 0.

## Host impact

None. This only strengthens static dead-code coverage.

## Scheduled refactoring

The `.vitest.mts` rename remains maintainer-adjudicate per #8903's second verification pass. This PR neither chooses a canonical extension nor creates migration scaffolding.

## Changelog

No entry: this is build-tooling coverage with no user-visible effect.

## Validation

- `npx prettier --check knip.json`
- `npm run check:dead-code-ratchet`
  - 60 current findings versus 60 baselined
  - unused files 2, unused exports 32, unused types 25, duplicate exports 1
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line Knip config change with no runtime, build output, or consumer impact; only broadens dead-code analysis.
> 
> **Overview**
> Aligns the root workspace **Knip** `project` glob with how entries already treat TypeScript sources: `src/**/*.ts` becomes `src/**/*.{ts,mts}`.
> 
> Previously, `.vitest.mts` test entries were in scope but non-entry `.mts` helpers were excluded from unused-file and unused-export checks. **No runtime or package behavior changes**—only static analysis coverage for the root workspace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cdecb0bec60d0158cac7f2480b2100376d05a4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->