### PR TITLE
refactor(trace): derive viewer data from shared schema

### DIFF
--- a/packages/trace-viewer/src/traceDataSchema.ts
+++ b/packages/trace-viewer/src/traceDataSchema.ts
@@ -1,40 +1,16 @@
 /**
- * Runtime validation for trace data loaded by `main.ts`'s `loadTrace()` —
- * either fetched (`trace.json`) or inlined (`window.__TEXRA_TRACE__`).
- *
- * This is the trace-viewer's external boundary: the data was authored by
- * whatever TeXRA version produced the export (CLI, extension, or desktop),
- * and `main.ts` has no static guarantee it matches this build's expected
- * shape. Mirrors `TraceDocument` (`@transcript/traceAssembler`) field-for-
- * field while keeping runtime imports browser-safe. `@agent/*` schemas pull
- * extension/runtime dependencies into the trace-viewer bundle, so the agent
- * config and execution meta shapes are mirrored here with type-only
- * compatibility assertions against their source types.
+ * Runtime validation for trace data loaded from `trace.json` or
+ * `window.__TEXRA_TRACE__`. The shared document schema owns the format; this
+ * external boundary only tightens snapshot-version handling so a future
+ * snapshot is rejected instead of normalized as a legacy omission.
  */
 import { z } from 'zod';
 
-import type { ExecutionMeta } from '@agent/storage';
-import type { AgentConfig } from '@agent/core/definition/AgentConfig';
-import { AgentCategory, AgentSourceSchema } from '@shared/schemas/agent';
-import {
-  ExecutionIdSchema,
-  StreamTabIdSchema,
-} from '@shared/schemas/identifiers';
-import { NullableFileFieldsSchema } from '@shared/schemas/fileFields';
-import { StreamLogEntrySchema } from '@shared/schemas/log';
-import {
-  ExecutionStatusSchema,
-  RunOutcomeSchema,
-} from '@shared/schemas/stream';
+import { TraceDocumentSchema } from '@transcript/traceDocumentSchema';
 import {
   STREAM_SNAPSHOT_SCHEMA_VERSION,
   StreamSnapshotSchema,
 } from '@shared/schemas/streamSnapshot';
-import { ToolConfigSchema } from '@shared/schemas/toolConfig';
-import { AgentDelegationScopeSchema } from '@shared/schemas/agentRoster';
-import type { TraceDocument } from '@transcript/traceAssembler';
-
-const TRACE_EXECUTION_META_SCHEMA_VERSION = 1;
 
 const TraceStreamSnapshotSchema = StreamSnapshotSchema.extend({
   schemaVersion: z
@@ -42,150 +18,13 @@ const TraceStreamSnapshotSchema = StreamSnapshotSchema.extend({
     .prefault(STREAM_SNAPSHOT_SCHEMA_VERSION),
 });
 
-const TraceAgentConfigSharedFieldsSchema = NullableFileFieldsSchema.extend({
-  agent: z.string(),
-  agentSource: AgentSourceSchema.nullish(),
-  model: z.string(),
-  instruction: z.string(),
-  rootUserInstruction: z.string().nullish(),
-  displayInstruction: z.string().nullish(),
-  editedFiles: z.array(z.string()),
-  toolConfig: ToolConfigSchema,
-  memories: z.array(z.string()),
-  workingDirectory: z.string().nullish(),
-  cliOutputFile: z.string().nullish(),
-  cliMultiAgentPresetId: z.string().nullish(),
-  delegationAgentScope: AgentDelegationScopeSchema.nullish(),
-});
-
-const TraceAgentConfigSchema = z
-  .discriminatedUnion('agentCategory', [
-    TraceAgentConfigSharedFieldsSchema.extend({
-      agentCategory: z.literal(AgentCategory.Workflow),
-    }),
-    TraceAgentConfigSharedFieldsSchema.extend({
-      agentCategory: z.literal(AgentCategory.ToolUse),
-      outputSchema: z.record(z.string(), z.unknown()).nullish(),
-    }),
-  ])
-  .superRefine((config, ctx) => {
-    if (config.outputFiles.length > config.inputFiles.length) {
-      ctx.addIssue({
-        code: 'custom',
-        path: ['outputFiles'],
-        message:
-          'Number of output files must not be greater than the number of input files.',
-      });
-    }
-  });
-
-const TraceExecutionMetaSchema = z.object({
-  schemaVersion: z.literal(TRACE_EXECUTION_META_SCHEMA_VERSION).prefault(1),
-  timestamp: z.string(),
-  parentExecutionId: ExecutionIdSchema.optional(),
-  terminalStatus: z.string().optional(),
-  outcome: RunOutcomeSchema.optional(),
-  category: z.string().optional(),
-  description: z.string().optional(),
-  streamId: StreamTabIdSchema.optional(),
-});
-
-export const TraceDataSchema = z.object({
-  executionId: ExecutionIdSchema,
-  streamId: StreamTabIdSchema,
-  config: TraceAgentConfigSchema,
-  meta: TraceExecutionMetaSchema.nullable(),
-  entries: z.array(StreamLogEntrySchema),
+export const TraceDataSchema = TraceDocumentSchema.extend({
   snapshot: TraceStreamSnapshotSchema,
-  terminalStatus: ExecutionStatusSchema.nullable(),
 });
 
 export type TraceData = z.infer<typeof TraceDataSchema>;
 
-/**
- * Compile-time check that this schema's inferred shape actually accepts what
- * `assembleTrace` produces — kept in sync with `TraceDocument` rather than a
- * hand-maintained duplicate, so a field added/renamed there surfaces here as
- * a type error instead of a silent validation gap.
- *
- * Uses the higher-order-function comparison form (as used by type-fest's
- * `IsEqual`) rather than mutual `extends`: for object types, a plain mutual-
- * `extends` check (`[A] extends [B] ? [B] extends [A] ? true : false : false`)
- * treats `{a: string}` and `{a: string; b?: number}` as equal, because a
- * value missing optional property `b` still satisfies both sides. Comparing
- * the types as `G extends A` / `G extends B` conditional-type constructors
- * instead is sensitive to that difference, so an added/removed optional
- * field on either side of the mirror fails this check.
- *
- * Both sides are run through `_Simplify` first, recursively, for two reasons
- * that are false-positive noise rather than real schema drift:
- *  - `AgentConfig` and `ExecutionMeta` are derived via `.superRefine()` /
- *    `.transform()` and end up as intersection types (e.g.
- *    `Base & { outcome?: RunOutcome }`) rather than plain object types. The
- *    HOF comparison treats an intersection and its structurally-identical
- *    flattened object type as *different* conditional-type constructors.
- *  - `TraceDocument` (an authored `interface`) declares its fields
- *    `readonly`, while the corresponding zod-inferred types are mutable. The
- *    HOF comparison is sensitive to that modifier even though it doesn't
- *    reflect an actual shape difference for our purposes, so `_Simplify`
- *    also strips `readonly` (`-readonly`) while preserving each key's
- *    optional/required modifier — the thing we actually want it to catch.
- * Arrays are passed through unsimplified (rather than mapped element-wise):
- * recursing into their element type isn't needed for these three mirrors and
- * empirically trips up the HOF check on unrelated, larger union element
- * types (e.g. `StreamLogEntry`) without adding any real coverage here.
- */
-type _AssertTrue<T extends true> = T;
-type _Simplify<T> = T extends readonly unknown[]
-  ? T
-  : T extends object
-    ? { -readonly [K in keyof T]: _Simplify<T[K]> }
-    : T;
-type _IsExact<A, B> =
-  (<G>() => G extends _Simplify<A> ? 1 : 2) extends <
-    G,
-  >() => G extends _Simplify<B> ? 1 : 2
-    ? true
-    : false;
-
-type _AssertTraceDataAcceptsTraceDocument = _AssertTrue<
-  _IsExact<TraceDocument, TraceData>
->;
-type _AssertTraceAgentConfigAcceptsAgentConfig = _AssertTrue<
-  _IsExact<AgentConfig, z.infer<typeof TraceAgentConfigSchema>>
->;
-type _AssertTraceExecutionMetaAcceptsExecutionMeta = _AssertTrue<
-  _IsExact<ExecutionMeta, z.infer<typeof TraceExecutionMetaSchema>>
->;
-
-/**
- * Regression coverage for #7265: `_IsExact`'s previous mutual-`extends` form
- * (`[A] extends [B] ? [B] extends [A] ? true : false : false`) considered
- * `{a: string}` and `{a: string; b?: number}` equal in both directions — a
- * value missing an optional property still structurally satisfies both
- * sides — so it silently missed an added/removed optional field on either
- * mirror. This checks the HOF form actually rejects both directions, and
- * still accepts identical shapes (no false positive from the fix itself).
- */
-type _AssertFalse<T extends false> = T;
-type _AssertCatchesAddedOptionalField = _AssertFalse<
-  _IsExact<{ a: string }, { a: string; b?: number }>
->;
-type _AssertCatchesRemovedOptionalField = _AssertFalse<
-  _IsExact<{ a: string; b?: number }, { a: string }>
->;
-type _AssertStillMatchesIdenticalOptionalShape = _AssertTrue<
-  _IsExact<{ a: string; b?: number }, { a: string; b?: number }>
->;
-
-/**
- * Parses raw trace data (from `fetch()` or `window.__TEXRA_TRACE__`) against
- * {@link TraceDataSchema}. Throws a descriptive error identifying the trace
- * file as malformed/incompatible rather than letting an arbitrary shape flow
- * into `replayTrace()` → `dispatchMessage()`, which assumes the shape is
- * already correct and would otherwise fail with a cryptic error deep inside
- * a handler.
- */
+/** Parse an exported trace before replaying it through the trusted UI path. */
 export function parseTraceData(raw: unknown): TraceData {
   const result = TraceDataSchema.safeParse(raw);
   if (!result.success) {

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -24,7 +24,6 @@ import {
   ExecutionMetaSchema,
   type ExecutionId,
   type ExecutionMeta,
-  type ExecutionMetaInput,
 } from '@shared/schemas';
 import { byString, filterNotNull, normalizeFilePath } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -74,6 +73,7 @@ export function isReservedKvKeyName(key: string): boolean {
 }
 
 const CHANNEL = 'ExecutionKVStore';
+type ExecutionMetaInput = z.input<typeof ExecutionMetaSchema>;
 
 // ============================================================================
 // Domain types — Zod schemas as source of truth

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -21,12 +21,10 @@ import {
 import { KVStore } from '@common/storage/KVStore';
 import * as logger from '@logger/logUtils';
 import {
-  ExecutionIdSchema,
-  RunOutcomeSchema,
-  StreamTabIdSchema,
-  executionStatusToRunOutcome,
+  ExecutionMetaSchema,
   type ExecutionId,
-  type RunOutcome,
+  type ExecutionMeta,
+  type ExecutionMetaInput,
 } from '@shared/schemas';
 import { byString, filterNotNull, normalizeFilePath } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -76,46 +74,10 @@ export function isReservedKvKeyName(key: string): boolean {
 }
 
 const CHANNEL = 'ExecutionKVStore';
-export const EXECUTION_META_SCHEMA_VERSION = 1;
 
 // ============================================================================
 // Domain types — Zod schemas as source of truth
 // ============================================================================
-
-/** Execution metadata stored alongside config at launch time. */
-const ExecutionMetaBaseSchema = z.object({
-  schemaVersion: z.literal(EXECUTION_META_SCHEMA_VERSION).prefault(1),
-  timestamp: z.string(),
-  parentExecutionId: ExecutionIdSchema.optional(),
-  /** Persisted when execution reaches a terminal state (success or error). */
-  terminalStatus: z.string().optional(),
-  /** Canonical terminal outcome; legacy meta files derive this from terminalStatus. */
-  outcome: RunOutcomeSchema.optional(),
-  /** Runtime category override (e.g. 'process' for background bash). */
-  category: z.string().optional(),
-  /** AI-generated summary of what the session aimed to accomplish. */
-  description: z.string().optional(),
-  /**
-   * The transcript stream this execution's data lives under, once resolved.
-   * Decide-once-carry-as-data cache for `resolvePersistedStreamIdForExecution`
-   * (`executionStreamResolver.ts`): absent on executions whose stream wasn't
-   * resolved yet (or predate this field), in which case the resolver falls
-   * back to its full meta-scan.
-   */
-  streamId: StreamTabIdSchema.optional(),
-});
-
-export const ExecutionMetaSchema = ExecutionMetaBaseSchema.transform(
-  (
-    meta,
-  ): z.infer<typeof ExecutionMetaBaseSchema> & { outcome?: RunOutcome } => {
-    const outcome =
-      meta.outcome ?? executionStatusToRunOutcome(meta.terminalStatus);
-    return outcome ? { ...meta, outcome } : meta;
-  },
-);
-export type ExecutionMeta = z.infer<typeof ExecutionMetaSchema>;
-export type ExecutionMetaInput = z.input<typeof ExecutionMetaSchema>;
 
 /** Shape of a persisted todo item from tool-use flow state. */
 const TodoEntrySchema = z.object({

--- a/src/agent/storage/executionLifecycle.ts
+++ b/src/agent/storage/executionLifecycle.ts
@@ -17,7 +17,6 @@ import {
   executionStatusToRunOutcome,
   type ExecutionId,
   type ExecutionMeta,
-  type ExecutionMetaInput,
   type ExecutionStatus,
   type RunOutcome,
   type StreamTabId,
@@ -127,8 +126,11 @@ export async function registerExecution(
   try {
     const timestamp = new Date().toISOString();
     const store = getExecutionStore(executionId);
-    const meta: ExecutionMetaInput = { timestamp, parentExecutionId };
-    if (category) meta.category = category;
+    const meta = {
+      timestamp,
+      parentExecutionId,
+      ...(category ? { category } : {}),
+    };
     const persistedConfig = normalizeWriterCategory(
       pinExecutionWorkingDirectory(config),
       agentName,

--- a/src/agent/storage/executionLifecycle.ts
+++ b/src/agent/storage/executionLifecycle.ts
@@ -16,17 +16,15 @@ import {
   RUN_OUTCOME,
   executionStatusToRunOutcome,
   type ExecutionId,
+  type ExecutionMeta,
+  type ExecutionMetaInput,
   type ExecutionStatus,
   type RunOutcome,
   type StreamTabId,
 } from '@shared/schemas';
 import { WorkspaceFS } from '@utils/files';
 import { toErrorMessage } from '@utils/errors/errorMessage';
-import {
-  type ExecutionMeta,
-  type ExecutionMetaInput,
-  getExecutionStore,
-} from './ExecutionKVStore';
+import { getExecutionStore } from './ExecutionKVStore';
 import {
   acquireFreshExecutionLease,
   releaseOwnedExecutionLease,

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -5,15 +5,19 @@
  */
 
 export {
-  EXECUTION_META_SCHEMA_VERSION,
   type ExecutionKVStore,
-  type ExecutionMeta,
   type TodoEntry,
   type ChildRecord,
   getExecutionStore,
   clearStoreCache,
   isReservedKvKeyName,
 } from './ExecutionKVStore';
+export {
+  EXECUTION_META_SCHEMA_VERSION,
+  ExecutionMetaSchema,
+  type ExecutionMeta,
+  type ExecutionMetaInput,
+} from '@shared/schemas/stream';
 export {
   buildCliWorkflowResultMeta,
   unwrapResultMeta,

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -14,9 +14,7 @@ export {
 } from './ExecutionKVStore';
 export {
   EXECUTION_META_SCHEMA_VERSION,
-  ExecutionMetaSchema,
   type ExecutionMeta,
-  type ExecutionMetaInput,
 } from '@shared/schemas/stream';
 export {
   buildCliWorkflowResultMeta,

--- a/src/agent/storage/resumability.ts
+++ b/src/agent/storage/resumability.ts
@@ -8,17 +8,15 @@ import {
 import * as logger from '@logger/logUtils';
 import {
   EXECUTION_STATUS,
+  ExecutionMetaSchema,
   RUN_OUTCOME,
   type ExecutionId,
+  type ExecutionMeta,
   type RunOutcome,
 } from '@shared/schemas';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
-import {
-  ExecutionMetaSchema,
-  getExecutionStore,
-  type ExecutionMeta,
-} from './ExecutionKVStore';
+import { getExecutionStore } from './ExecutionKVStore';
 
 const CHANNEL = 'Resumability';
 

--- a/src/shared/schemas/stream.ts
+++ b/src/shared/schemas/stream.ts
@@ -169,7 +169,6 @@ export const ExecutionMetaSchema = ExecutionMetaBaseSchema.transform(
   },
 );
 export type ExecutionMeta = z.infer<typeof ExecutionMetaSchema>;
-export type ExecutionMetaInput = z.input<typeof ExecutionMetaSchema>;
 
 export const STREAM_PHASE = {
   RUNNING: STREAM_STATUS.RUNNING,

--- a/src/shared/schemas/stream.ts
+++ b/src/shared/schemas/stream.ts
@@ -136,6 +136,41 @@ export const RUN_OUTCOME = {
 export const RunOutcomeSchema = z.enum(RUN_OUTCOME);
 export type RunOutcome = z.infer<typeof RunOutcomeSchema>;
 
+export const EXECUTION_META_SCHEMA_VERSION = 1;
+
+/** Execution metadata stored alongside config at launch time. */
+const ExecutionMetaBaseSchema = z.object({
+  schemaVersion: z.literal(EXECUTION_META_SCHEMA_VERSION).prefault(1),
+  timestamp: z.string(),
+  parentExecutionId: ExecutionIdSchema.optional(),
+  /** Persisted when execution reaches a terminal state (success or error). */
+  terminalStatus: z.string().optional(),
+  /** Canonical terminal outcome; legacy meta files derive this from terminalStatus. */
+  outcome: RunOutcomeSchema.optional(),
+  /** Runtime category override (e.g. 'process' for background bash). */
+  category: z.string().optional(),
+  /** AI-generated summary of what the session aimed to accomplish. */
+  description: z.string().optional(),
+  /**
+   * The transcript stream this execution's data lives under, once resolved.
+   * Decide-once-carry-as-data cache for the execution stream resolver: absent
+   * on executions whose stream wasn't resolved yet (or predate this field).
+   */
+  streamId: StreamTabIdSchema.optional(),
+});
+
+export const ExecutionMetaSchema = ExecutionMetaBaseSchema.transform(
+  (
+    meta,
+  ): z.infer<typeof ExecutionMetaBaseSchema> & { outcome?: RunOutcome } => {
+    const outcome =
+      meta.outcome ?? executionStatusToRunOutcome(meta.terminalStatus);
+    return outcome ? { ...meta, outcome } : meta;
+  },
+);
+export type ExecutionMeta = z.infer<typeof ExecutionMetaSchema>;
+export type ExecutionMetaInput = z.input<typeof ExecutionMetaSchema>;
+
 export const STREAM_PHASE = {
   RUNNING: STREAM_STATUS.RUNNING,
   WAITING: STREAM_STATUS.WAITING,

--- a/src/test-kernel/transcript/traceViewerSchema.vitest.ts
+++ b/src/test-kernel/transcript/traceViewerSchema.vitest.ts
@@ -17,6 +17,7 @@ import {
   STREAM_LOG_ENTRY_TYPES,
   type ExecutionId,
 } from '@shared/schemas';
+import { DEFAULT_AGENT_MODEL } from '@shared/constants/providers';
 import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
 import {
   parseTraceData,
@@ -107,13 +108,35 @@ describe('trace-viewer TraceDataSchema', () => {
     expect(result.success).toBe(false);
   });
 
-  it('ignores obsolete delegation depth in exported metadata', () => {
+  it('applies source config defaults to legacy traces', () => {
+    const legacyConfig: Partial<AgentConfig> = config();
+    delete legacyConfig.agent;
+    delete legacyConfig.model;
+    delete legacyConfig.instruction;
+
+    const parsed = TraceDataSchema.parse({
+      executionId: 'abcdef',
+      streamId: 'stream-1',
+      config: legacyConfig,
+      meta: null,
+      entries: [],
+      snapshot: { streamId: 'stream-1' },
+      terminalStatus: null,
+    });
+
+    expect(parsed.config.agent).toBe('correct');
+    expect(parsed.config.model).toBe(DEFAULT_AGENT_MODEL);
+    expect(parsed.config.instruction).toBe('');
+  });
+
+  it('normalizes legacy execution metadata', () => {
     const legacyTrace = {
       executionId: 'abcdef',
       streamId: 'stream-1',
       config: config(),
       meta: {
         timestamp: '2026-07-05T00:00:00.000Z',
+        terminalStatus: EXECUTION_STATUS.ERROR,
         delegationDepth: 2,
       },
       entries: [],
@@ -123,6 +146,7 @@ describe('trace-viewer TraceDataSchema', () => {
 
     const parsed = TraceDataSchema.parse(legacyTrace);
     expect(parsed.meta).not.toHaveProperty('delegationDepth');
+    expect(parsed.meta?.outcome).toBe('failed');
   });
 
   it('throws a clear, identifying error via parseTraceData for a malformed trace', () => {

--- a/src/transcript/index.ts
+++ b/src/transcript/index.ts
@@ -23,11 +23,8 @@ export {
 } from './runTrace';
 export { streamDataDir } from './streamDataPaths';
 export { StreamSnapshotStore } from './StreamSnapshotStore';
-export {
-  assembleTrace,
-  type AssembleTraceResult,
-  type TraceDocument,
-} from './traceAssembler';
+export { assembleTrace, type AssembleTraceResult } from './traceAssembler';
+export { TraceDocumentSchema, type TraceDocument } from './traceDocumentSchema';
 export {
   readCompletedRunConversation,
   readCompletedRunTodos,

--- a/src/transcript/index.ts
+++ b/src/transcript/index.ts
@@ -24,7 +24,7 @@ export {
 export { streamDataDir } from './streamDataPaths';
 export { StreamSnapshotStore } from './StreamSnapshotStore';
 export { assembleTrace, type AssembleTraceResult } from './traceAssembler';
-export { TraceDocumentSchema, type TraceDocument } from './traceDocumentSchema';
+export type { TraceDocument } from './traceDocumentSchema';
 export {
   readCompletedRunConversation,
   readCompletedRunTodos,

--- a/src/transcript/standaloneTraceHtml.ts
+++ b/src/transcript/standaloneTraceHtml.ts
@@ -7,7 +7,7 @@
  * comment). `main.ts`'s `loadTrace()` reads this global if present, before
  * falling back to fetching `trace.json`.
  */
-import type { TraceDocument } from './traceAssembler';
+import type { TraceDocument } from './traceDocumentSchema';
 
 const MODULE_SCRIPT_MARKER = '<script type="module"';
 

--- a/src/transcript/traceAssembler.ts
+++ b/src/transcript/traceAssembler.ts
@@ -9,32 +9,15 @@
  * discriminated-status pattern so callers can show a precise error instead of
  * a generic failure.
  */
-import { getExecutionStore, type ExecutionMeta } from '@agent/storage';
-import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import { getExecutionStore } from '@agent/storage';
 import { getStreamTabId } from '@agent/runtime/streamTab';
-import type {
-  ExecutionId,
-  ExecutionStatus,
-  StreamLogEntry,
-  StreamSnapshot,
-  StreamTabId,
-} from '@shared/schemas';
+import type { ExecutionId } from '@shared/schemas';
 import { runOutcomeToExecutionStatus } from '@shared/streams/streamStatus';
 
 import { StreamLogStore } from './StreamLogStore';
 import { StreamSnapshotStore } from './StreamSnapshotStore';
 import { resolvePersistedStreamIdForExecution } from './executionStreamResolver';
-
-export interface TraceDocument {
-  readonly executionId: ExecutionId;
-  readonly streamId: StreamTabId;
-  readonly config: AgentConfig;
-  readonly meta: ExecutionMeta | null;
-  readonly entries: StreamLogEntry[];
-  readonly snapshot: StreamSnapshot;
-  /** `null` when the execution predates outcome tracking or never reached a terminal state. */
-  readonly terminalStatus: ExecutionStatus | null;
-}
+import type { TraceDocument } from './traceDocumentSchema';
 
 export type AssembleTraceResult =
   | { readonly status: 'ok'; readonly trace: TraceDocument }

--- a/src/transcript/traceDocumentSchema.ts
+++ b/src/transcript/traceDocumentSchema.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
+import {
+  ExecutionIdSchema,
+  StreamTabIdSchema,
+} from '@shared/schemas/identifiers';
+import { StreamLogEntrySchema } from '@shared/schemas/log';
+import {
+  ExecutionMetaSchema,
+  ExecutionStatusSchema,
+} from '@shared/schemas/stream';
+import { StreamSnapshotSchema } from '@shared/schemas/streamSnapshot';
+
+/** Everything a static trace viewer needs to replay one finished execution. */
+export const TraceDocumentSchema = z.object({
+  executionId: ExecutionIdSchema,
+  streamId: StreamTabIdSchema,
+  config: AgentConfigSchema,
+  meta: ExecutionMetaSchema.nullable(),
+  entries: z.array(StreamLogEntrySchema),
+  snapshot: StreamSnapshotSchema,
+  /** `null` for executions that predate outcome tracking or never terminated. */
+  terminalStatus: ExecutionStatusSchema.nullable(),
+});
+
+export type TraceDocument = z.infer<typeof TraceDocumentSchema>;

--- a/src/transcript/traceDocumentSchema.ts
+++ b/src/transcript/traceDocumentSchema.ts
@@ -24,4 +24,4 @@ export const TraceDocumentSchema = z.object({
   terminalStatus: ExecutionStatusSchema.nullable(),
 });
 
-export type TraceDocument = z.infer<typeof TraceDocumentSchema>;
+export type TraceDocument = Readonly<z.infer<typeof TraceDocumentSchema>>;


### PR DESCRIPTION
## Summary

- move execution metadata validation to the shared schema layer while keeping only the storage contracts that have consumers
- derive `TraceDocument` from one `TraceDocumentSchema`; the viewer overrides only strict snapshot-version handling
- delete the hand-maintained agent/meta mirror, exactness fence, and dead compatibility exports

Legacy trace configs now use canonical config preprocessing/defaults, and legacy metadata derives canonical `outcome` from `terminalStatus`. Importing the canonical config adds about 2.44 kB raw / 0.89 kB gzip to the viewer bundle; both browser builds pass.

## Issue acceptance gates

Closes #8898.

- one schema now owns the writer/viewer trace shape
- execution metadata moved to a browser-safe shared schema without breaking live `@agent/storage` consumers
- the viewer still rejects incompatible future snapshot versions
- compatibility normalizations are disclosed and tested
- trace-viewer multi-file and standalone browser builds pass

## Single source of truth

`src/shared/schemas/stream.ts` owns execution metadata. `src/transcript/traceDocumentSchema.ts` composes the canonical trace document schema and derives its shallow-readonly TypeScript type. `packages/trace-viewer/src/traceDataSchema.ts` owns only the external-boundary snapshot-version policy.

## Duplication and abstraction budget

Removed the duplicated agent-config schema, execution-metadata schema, `_IsExact` fence, hand-authored `TraceDocument` shape, and four dead re-exports found by the CI ratchet. The one new schema module owns the cross-host document contract; it is not a pass-through wrapper.

## Net elements (R6)

- files: +1 / -0 / 10 modified
- exported contracts: +1 `TraceDocumentSchema`, -1 unused `ExecutionMetaInput`; the remaining metadata contracts and `TraceDocument` are relocations, not duplicates
- classes/interfaces/enums: -1 hand-authored interface, +0
- net LoC: +116 / -250 = -134

## Consumer counts (R8)

- `ExecutionMetaSchema`: 3 runtime consumer files, all routed directly to the shared owner
- `EXECUTION_META_SCHEMA_VERSION`: 3 test consumer files plus 1 live compatibility re-export through `@agent/storage`
- `TraceDocument`: 7 type-consuming files; the `@transcript` barrel path remains stable
- `TraceDocumentSchema`: 1 direct runtime viewer consumer; no unused barrel export
- no event or subscriber path changes

## Host impact

Extension: production/development bundles and webviews pass; exported traces retain strict future-snapshot rejection.

Desktop: no host-specific behavior change; typecheck and shared trace-viewer build pass.

CLI: standalone trace export uses the same derived document contract; full suite passes.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run typecheck` (rerun after rebase and export cleanup)
- `npm run lint` (0 errors; 1 unrelated existing warning)
- `npm run compile:fast`
- `npm run check:dead-code-ratchet` (60 current / 60 baseline)
- `npm test` (740 files passed, 6,874 tests passed)
- focused schema/storage suites (62 tests)
- trace-viewer Vite multi-file and standalone builds