### PR TITLE
refactor(tests): consolidate Ink test harnesses

### DIFF
--- a/src/test-kernel/cli/AgentRosterForm.vitest.mts
+++ b/src/test-kernel/cli/AgentRosterForm.vitest.mts
@@ -1,7 +1,6 @@
-import { createRequire } from 'node:module';
-
 import { describe, expect, it } from 'vitest';
 
+import { loadInk } from '@test/support/inkTestHarness.mts';
 import type { AgentEntry } from '@agent/index';
 import {
   AgentRosterForm,
@@ -11,10 +10,6 @@ import {
   setChatDefaultAgent,
 } from '@cli/chat/tui/forms/AgentRosterForm';
 import { formatCliAgentRoster } from '@cli/runtime/agentRoster';
-
-const cliRequire = createRequire(
-  new URL('../../../packages/cli/package.json', import.meta.url),
-);
 
 const agents: AgentEntry[] = [
   {
@@ -35,8 +30,7 @@ const agents: AgentEntry[] = [
 
 describe('AgentRosterForm', () => {
   it('renders loading through the shared Ink indicator', async () => {
-    const ink = (await import(cliRequire.resolve('ink'))) as any;
-    const React = ((await import(cliRequire.resolve('react'))) as any).default;
+    const { ink, React } = await loadInk();
     const output = ink.renderToString(
       React.createElement(AgentRosterForm, { onClose: () => undefined }),
     );

--- a/src/test-kernel/cli/ChildListInteraction.vitest.mts
+++ b/src/test-kernel/cli/ChildListInteraction.vitest.mts
@@ -1,8 +1,11 @@
-import { EventEmitter } from 'node:events';
-import { createRequire } from 'node:module';
-
 import { describe, expect, it, vi } from 'vitest';
 
+import { waitForCondition as waitFor } from '@test/support/asyncTestUtils';
+import {
+  FakeStdin,
+  FakeStdout,
+  loadInk,
+} from '@test/support/inkTestHarness.mts';
 import { SubagentList } from '@cli/chat/tui/panes/SubagentList';
 import {
   childProcessListValue,
@@ -13,63 +16,13 @@ import type { StreamView } from '@cli/chat/tui/state/streamViews';
 import { POINTER } from '@cli/chat/tui/ui/glyphs';
 import type { StreamTabId } from '@shared/schemas';
 
-const cliRequire = createRequire(
-  new URL('../../../packages/cli/package.json', import.meta.url),
-);
-
-class FakeStdout extends EventEmitter {
-  readonly isTTY = true;
-  readonly columns = 100;
-  readonly rows = 24;
-  output = '';
-
-  write(chunk: string): boolean {
-    this.output += chunk;
-    return true;
-  }
-
-  getColorDepth(): number {
-    return 24;
-  }
-}
-
-class FakeStdin extends EventEmitter {
-  readonly isTTY = true;
-  private readonly chunks: string[] = [];
-
-  write(chunk: string): void {
-    this.chunks.push(chunk);
-    this.emit('readable');
-  }
-
-  read(): string | null {
-    return this.chunks.shift() ?? null;
-  }
-
-  ref(): void {}
-  unref(): void {}
-  pause(): void {}
-  resume(): void {}
-  setEncoding(): void {}
-  setRawMode(): void {}
-}
-
-async function waitFor(predicate: () => boolean): Promise<void> {
-  for (let attempt = 0; attempt < 100; attempt += 1) {
-    if (predicate()) return;
-    await new Promise((resolve) => setTimeout(resolve, 5));
-  }
-  throw new Error('Timed out waiting for child-list input');
-}
-
 function session(id: StreamTabId, active = false): StreamView {
   return { id, label: id, slice: undefined, active };
 }
 
 describe('CLI child list interaction', () => {
   it('renders no process highlight before the list receives a selection', async () => {
-    const ink = (await import(cliRequire.resolve('ink'))) as any;
-    const React = ((await import(cliRequire.resolve('react'))) as any).default;
+    const { ink, React } = await loadInk();
     const output = ink.renderToString(
       React.createElement(SubagentList, {
         activeProcesses: [
@@ -91,8 +44,7 @@ describe('CLI child list interaction', () => {
   });
 
   it('prints and kills only the selected active session, then focuses it', async () => {
-    const ink = (await import(cliRequire.resolve('ink'))) as any;
-    const React = ((await import(cliRequire.resolve('react'))) as any).default;
+    const { ink, React } = await loadInk();
     const root = 'root' as StreamTabId;
     const child = 'child' as StreamTabId;
     const onFocusStream = vi.fn();
@@ -126,7 +78,7 @@ describe('CLI child list interaction', () => {
     const stdin = new FakeStdin();
     const instance = ink.render(React.createElement(Harness), {
       stdin,
-      stdout: new FakeStdout(),
+      stdout: new FakeStdout(100),
       interactive: true,
       exitOnCtrlC: false,
       patchConsole: false,
@@ -155,8 +107,7 @@ describe('CLI child list interaction', () => {
   });
 
   it('skips and retries the focused subagent grandchild by execution id', async () => {
-    const ink = (await import(cliRequire.resolve('ink'))) as any;
-    const React = ((await import(cliRequire.resolve('react'))) as any).default;
+    const { ink, React } = await loadInk();
     const root = 'root' as StreamTabId;
     const child = 'child' as StreamTabId;
     const onSkipExecution = vi.fn();
@@ -177,7 +128,7 @@ describe('CLI child list interaction', () => {
       }),
       {
         stdin,
-        stdout: new FakeStdout(),
+        stdout: new FakeStdout(100),
         interactive: true,
         exitOnCtrlC: false,
         patchConsole: false,
@@ -199,8 +150,7 @@ describe('CLI child list interaction', () => {
   });
 
   it('hands focus back to the input instead of wrapping past the last row', async () => {
-    const ink = (await import(cliRequire.resolve('ink'))) as any;
-    const React = ((await import(cliRequire.resolve('react'))) as any).default;
+    const { ink, React } = await loadInk();
     const root = 'root' as StreamTabId;
     const child = 'child' as StreamTabId;
     const onCancel = vi.fn();
@@ -218,7 +168,7 @@ describe('CLI child list interaction', () => {
       }),
       {
         stdin,
-        stdout: new FakeStdout(),
+        stdout: new FakeStdout(100),
         interactive: true,
         exitOnCtrlC: false,
         patchConsole: false,
@@ -237,8 +187,7 @@ describe('CLI child list interaction', () => {
   });
 
   it('clamps instead of wrapping when ↑ is pressed at the first row', async () => {
-    const ink = (await import(cliRequire.resolve('ink'))) as any;
-    const React = ((await import(cliRequire.resolve('react'))) as any).default;
+    const { ink, React } = await loadInk();
     const root = 'root' as StreamTabId;
     const child = 'child' as StreamTabId;
     const onCancel = vi.fn();
@@ -256,7 +205,7 @@ describe('CLI child list interaction', () => {
       }),
       {
         stdin,
-        stdout: new FakeStdout(),
+        stdout: new FakeStdout(100),
         interactive: true,
         exitOnCtrlC: false,
         patchConsole: false,
@@ -277,8 +226,7 @@ describe('CLI child list interaction', () => {
   });
 
   it('opens and kills a selected process without printing stream output', async () => {
-    const ink = (await import(cliRequire.resolve('ink'))) as any;
-    const React = ((await import(cliRequire.resolve('react'))) as any).default;
+    const { ink, React } = await loadInk();
     const processValue = childProcessListValue('process-exec');
     const onKillExecution = vi.fn();
     const onOpenProcessDetail = vi.fn();
@@ -306,7 +254,7 @@ describe('CLI child list interaction', () => {
       }),
       {
         stdin,
-        stdout: new FakeStdout(),
+        stdout: new FakeStdout(100),
         interactive: true,
         exitOnCtrlC: false,
         patchConsole: false,

--- a/src/test-kernel/cli/InputBar.vitest.mts
+++ b/src/test-kernel/cli/InputBar.vitest.mts
@@ -1,11 +1,14 @@
-import { EventEmitter } from 'node:events';
-import { createRequire } from 'node:module';
-
 // Test composition imports
 import '@test/support/defaultSessionTestSetup';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { waitForCondition as waitFor } from '@test/support/asyncTestUtils';
+import {
+  FakeStdin,
+  FakeStdout,
+  loadInk,
+} from '@test/support/inkTestHarness.mts';
 import { ImagePasteQueue } from '@cli/chat/tui/input/imagePasteQueue';
 import { BaseTextInput } from '@cli/chat/tui/input/BaseTextInput';
 import {
@@ -37,47 +40,6 @@ const clipboardMock = vi.hoisted(() => ({
 
 vi.mock('@cli/runtime/clipboardImage', () => clipboardMock);
 
-const cliRequire = createRequire(
-  new URL('../../../packages/cli/package.json', import.meta.url),
-);
-
-class FakeStdout extends EventEmitter {
-  readonly isTTY = true;
-  readonly columns = 80;
-  readonly rows = 24;
-  buf = '';
-
-  write(chunk: string): boolean {
-    this.buf += chunk;
-    return true;
-  }
-
-  getColorDepth(): number {
-    return 24;
-  }
-}
-
-class FakeStdin extends EventEmitter {
-  readonly isTTY = true;
-  private readonly chunks: string[] = [];
-
-  write(chunk: string): void {
-    this.chunks.push(chunk);
-    this.emit('readable');
-  }
-
-  read(): string | null {
-    return this.chunks.shift() ?? null;
-  }
-
-  ref(): void {}
-  unref(): void {}
-  pause(): void {}
-  resume(): void {}
-  setEncoding(): void {}
-  setRawMode(): void {}
-}
-
 function deferred(): {
   readonly promise: Promise<void>;
   readonly resolve: () => void;
@@ -105,17 +67,6 @@ async function flushPromiseQueue(): Promise<void> {
   await Promise.resolve();
 }
 
-async function waitFor(
-  predicate: () => boolean,
-  timeoutMs = 2000,
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (!predicate()) {
-    if (Date.now() >= deadline) throw new Error('Timed out waiting for state');
-    await new Promise((resolve) => setTimeout(resolve, 10));
-  }
-}
-
 function fakeHistory(entries: readonly string[]): InputHistory {
   return {
     push: async () => undefined,
@@ -130,8 +81,7 @@ afterEach(() => vi.clearAllMocks());
 
 describe('InputBar arrow-key child-list focus', () => {
   it('falls through to the child list on ↓/↑ when there is no history to walk', async () => {
-    const ink = (await import(cliRequire.resolve('ink'))) as any;
-    const React = ((await import(cliRequire.resolve('react'))) as any).default;
+    const { ink, React } = await loadInk();
     const onFocusChildList = vi.fn();
 
     const stdin = new FakeStdin();
@@ -161,8 +111,7 @@ describe('InputBar arrow-key child-list focus', () => {
   });
 
   it('still recalls history on ↑ but hands off on an idle ↓', async () => {
-    const ink = (await import(cliRequire.resolve('ink'))) as any;
-    const React = ((await import(cliRequire.resolve('react'))) as any).default;
+    const { ink, React } = await loadInk();
     const onFocusChildList = vi.fn();
     const history = fakeHistory(['first command', 'second command']);
 
@@ -190,7 +139,7 @@ describe('InputBar arrow-key child-list focus', () => {
       await waitFor(() => onFocusChildList.mock.calls.length === 1);
       // Up still recalls the most recent entry rather than escaping.
       stdin.write('[A');
-      await waitFor(() => stdout.buf.includes('second command'));
+      await waitFor(() => stdout.output.includes('second command'));
 
       expect(onFocusChildList).toHaveBeenCalledTimes(1);
     } finally {
@@ -201,8 +150,7 @@ describe('InputBar arrow-key child-list focus', () => {
 
 describe('InputBar slash submit', () => {
   it('threads deferred echo through a palette-opened form', async () => {
-    const ink = (await import(cliRequire.resolve('ink'))) as any;
-    const React = ((await import(cliRequire.resolve('react'))) as any).default;
+    const { ink, React } = await loadInk();
     registerSlashCommand({
       name: 'model',
       description: 'Choose a model',
@@ -225,7 +173,7 @@ describe('InputBar slash submit', () => {
     try {
       await waitFor(() => stdin.listenerCount('readable') > 0);
       stdin.write('/model');
-      await waitFor(() => stdout.buf.includes('/model'));
+      await waitFor(() => stdout.output.includes('/model'));
       stdin.write('\r');
       await waitFor(() => activeForm.get()?.commandName === 'model');
 
@@ -349,8 +297,7 @@ describe('InputBar slash submit', () => {
 
 describe('InputBar draft discard', () => {
   it('clears a mounted foreground text input before exiting', async () => {
-    const ink = (await import(cliRequire.resolve('ink'))) as any;
-    const React = ((await import(cliRequire.resolve('react'))) as any).default;
+    const { ink, React } = await loadInk();
     const registry = createActiveDraftRegistry();
     const onExit = vi.fn();
     let currentValue = 'dialog answer';
@@ -440,8 +387,7 @@ describe('InputBar draft discard', () => {
   });
 
   it('discards a pending image submit from an otherwise empty mounted input', async () => {
-    const ink = (await import(cliRequire.resolve('ink'))) as any;
-    const React = ((await import(cliRequire.resolve('react'))) as any).default;
+    const { ink, React } = await loadInk();
     const firstPaste = deferredValue<{
       readonly ok: true;
       readonly path: string;
@@ -499,13 +445,13 @@ describe('InputBar draft discard', () => {
       await flushPromiseQueue();
 
       expect(submitted).toEqual([]);
-      expect(stdout.buf).not.toContain('[Image #1]');
-      expect(stdout.buf).not.toContain('Image paste failed');
+      expect(stdout.output).not.toContain('[Image #1]');
+      expect(stdout.output).not.toContain('Image paste failed');
 
-      stdout.buf = '';
+      stdout.output = '';
       stdin.write('\u0016');
-      await waitFor(() => stdout.buf.includes('[Image #1]'));
-      expect(stdout.buf).not.toContain('[Image #2]');
+      await waitFor(() => stdout.output.includes('[Image #1]'));
+      expect(stdout.output).not.toContain('[Image #2]');
       stdin.write('\r');
       await waitFor(() => submitted.length === 1);
 

--- a/src/test-kernel/cli/ModelAccessForm.vitest.mts
+++ b/src/test-kernel/cli/ModelAccessForm.vitest.mts
@@ -1,8 +1,11 @@
-import { EventEmitter } from 'node:events';
-import { createRequire } from 'node:module';
-
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { waitForCondition as waitFor } from '@test/support/asyncTestUtils';
+import {
+  FakeStdin,
+  FakeStdout,
+  loadInk,
+} from '@test/support/inkTestHarness.mts';
 import { ModelAccessForm } from '@cli/chat/tui/forms/ModelAccessForm';
 
 const loadCliModelAccessOverview = vi.hoisted(() => vi.fn());
@@ -12,52 +15,6 @@ vi.mock('@cli/runtime/apiStatus', async (importOriginal) => ({
   loadCliModelAccessOverview,
 }));
 
-const cliRequire = createRequire(
-  new URL('../../../packages/cli/package.json', import.meta.url),
-);
-
-class FakeStdout extends EventEmitter {
-  readonly isTTY = true;
-  readonly columns = 80;
-  readonly rows = 24;
-  output = '';
-
-  write(chunk: string): boolean {
-    this.output += chunk;
-    return true;
-  }
-
-  getColorDepth(): number {
-    return 24;
-  }
-}
-
-class FakeStdin extends EventEmitter {
-  readonly isTTY = true;
-
-  read(): null {
-    return null;
-  }
-
-  ref(): void {}
-  unref(): void {}
-  pause(): void {}
-  resume(): void {}
-  setEncoding(): void {}
-  setRawMode(): void {}
-}
-
-async function waitFor(
-  predicate: () => boolean,
-  timeoutMs = 2000,
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (!predicate()) {
-    if (Date.now() >= deadline) throw new Error('Timed out waiting for state');
-    await new Promise((resolve) => setTimeout(resolve, 10));
-  }
-}
-
 afterEach(() => vi.clearAllMocks());
 
 describe('ModelAccessForm status', () => {
@@ -65,8 +22,7 @@ describe('ModelAccessForm status', () => {
     loadCliModelAccessOverview.mockRejectedValue(
       new Error('model access unavailable'),
     );
-    const ink = (await import(cliRequire.resolve('ink'))) as any;
-    const React = ((await import(cliRequire.resolve('react'))) as any).default;
+    const { ink, React } = await loadInk();
     const stdout = new FakeStdout();
     const instance = ink.render(
       React.createElement(ModelAccessForm, {

--- a/src/test-kernel/cli/OnboardingFlow.vitest.mts
+++ b/src/test-kernel/cli/OnboardingFlow.vitest.mts
@@ -3,6 +3,8 @@ import { EventEmitter } from 'node:events';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { waitForCondition } from '@test/support/asyncTestUtils';
+
 const mocks = vi.hoisted(() => ({
   selectCliApiModelAccessRoute: vi.fn(),
   saveProviderApiKey: vi.fn(),
@@ -90,14 +92,10 @@ class FakeInput extends EventEmitter {
   }
 }
 
-async function waitFor(predicate: () => boolean): Promise<void> {
-  const deadline = Date.now() + 15_000;
-  while (Date.now() < deadline) {
-    if (predicate()) return;
-    await new Promise((resolve) => setTimeout(resolve, 10));
-  }
-  throw new Error('Timed out waiting for onboarding interaction');
-}
+const ONBOARDING_WAIT_OPTIONS = Object.freeze({
+  timeoutMs: 15_000,
+  timeoutMessage: 'Timed out waiting for onboarding interaction',
+});
 
 const originalStdin = Object.getOwnPropertyDescriptor(process, 'stdin');
 const originalStdout = Object.getOwnPropertyDescriptor(process, 'stdout');
@@ -162,17 +160,27 @@ describe('provider-key onboarding flow', () => {
     // Ink attaches its input stream before the active Select handler has
     // necessarily committed. Wait for both input attachment and the rendered
     // picker so the shortcut cannot be discarded during a loaded CI run.
-    await waitFor(
+    await waitForCondition(
       () =>
         stdin.listenerCount('readable') > 0 &&
         stdout.output.includes('Choose how to power model calls'),
+      ONBOARDING_WAIT_OPTIONS,
     );
     stdin.write('3');
-    await waitFor(() => stdout.output.includes('Choose your provider:'));
+    await waitForCondition(
+      () => stdout.output.includes('Choose your provider:'),
+      ONBOARDING_WAIT_OPTIONS,
+    );
     stdin.write('\r');
-    await waitFor(() => stdout.output.includes('enter your API key (hidden)'));
+    await waitForCondition(
+      () => stdout.output.includes('enter your API key (hidden)'),
+      ONBOARDING_WAIT_OPTIONS,
+    );
     stdin.write(providerKey);
-    await waitFor(() => stdout.output.includes('•'));
+    await waitForCondition(
+      () => stdout.output.includes('•'),
+      ONBOARDING_WAIT_OPTIONS,
+    );
     stdin.write('\r');
 
     await expect(resultPromise).resolves.toEqual({

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -3,12 +3,14 @@
 // Test composition imports
 import '@test/support/defaultSessionTestSetup';
 
-import { EventEmitter } from 'node:events';
-import { createRequire } from 'node:module';
-import { setTimeout as sleep } from 'node:timers/promises';
-
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { waitForCondition as waitFor } from '@test/support/asyncTestUtils';
+import {
+  FakeStdin,
+  FakeStdout,
+  loadInk,
+} from '@test/support/inkTestHarness.mts';
 import {
   findSlashCommand,
   listSlashCommands,
@@ -53,49 +55,6 @@ const INCLUDED_CHAT_SESSION: SessionMeta = {
   transcriptMode: 'persistent',
   version: 'test',
 };
-
-const cliRequire = createRequire(
-  new URL('../../../packages/cli/package.json', import.meta.url),
-);
-
-class FakeStdout extends EventEmitter {
-  readonly isTTY = true;
-  readonly columns = 80;
-  readonly rows = 24;
-  output = '';
-
-  write(chunk: string): boolean {
-    this.output += chunk;
-    return true;
-  }
-
-  getColorDepth(): number {
-    return 24;
-  }
-}
-
-class FakeStdin extends EventEmitter {
-  readonly isTTY = true;
-
-  read(): null {
-    return null;
-  }
-
-  ref(): void {}
-  unref(): void {}
-  pause(): void {}
-  resume(): void {}
-  setEncoding(): void {}
-  setRawMode(): void {}
-}
-
-async function waitFor(predicate: () => boolean): Promise<void> {
-  const deadline = Date.now() + 2000;
-  while (!predicate()) {
-    if (Date.now() >= deadline) throw new Error('Timed out waiting for state');
-    await sleep(10);
-  }
-}
 
 afterEach(() => {
   for (const cmd of [...listSlashCommands()]) unregisterSlashCommand(cmd.name);
@@ -642,7 +601,7 @@ describe('slashRegistry', () => {
     await waitFor(() => formProgress.get()?.status === 'succeeded');
     expect(formProgress.get()?.archiveCopyable).toBeTypeOf('function');
 
-    const ink = (await import(cliRequire.resolve('ink'))) as any;
+    const { ink } = await loadInk();
     const stdout = new FakeStdout();
     const instance = ink.render(
       activeForm.get()?.render(() => {}, 20),

--- a/src/test-kernel/cli/StaticBandResize.vitest.mts
+++ b/src/test-kernel/cli/StaticBandResize.vitest.mts
@@ -15,22 +15,20 @@ delete process.env.NO_COLOR;
 process.env.FORCE_COLOR = '3';
 
 // Node.js imports
-import { EventEmitter } from 'node:events';
-import { createRequire } from 'node:module';
-
 // Third-party imports
 import stripAnsi from 'strip-ansi';
 import { afterAll, describe, expect, it } from 'vitest';
 
 // Local imports
+import { pollForCondition } from '@test/support/asyncTestUtils';
+import {
+  FakeStdin,
+  FakeStdout,
+  loadInk,
+} from '@test/support/inkTestHarness.mts';
 import type { TuiRepaintOptions } from '@cli/chat/tui/render/tuiViewportController';
 import type { ConversationEntry } from '@cli/chat/tui/state/cliState';
 import { AgentCategory, type StreamTabId } from '@shared/schemas';
-import { delay } from '@utils/core';
-
-const cliRequire = createRequire(
-  new URL('../../../packages/cli/package.json', import.meta.url),
-);
 
 afterAll(() => {
   for (const [name, value] of Object.entries(ORIGINAL_COLOR_ENV)) {
@@ -38,34 +36,6 @@ afterAll(() => {
     else process.env[name] = value;
   }
 });
-
-class FakeStdout extends EventEmitter {
-  isTTY = true;
-  rows = 12;
-  buf = '';
-  constructor(public columns: number) {
-    super();
-  }
-  write(chunk: string): boolean {
-    this.buf += chunk;
-    return true;
-  }
-  getColorDepth(): number {
-    return 24;
-  }
-}
-
-class FakeStdin extends EventEmitter {
-  isTTY = false;
-  ref(): void {}
-  unref(): void {}
-  pause(): void {}
-  resume(): void {}
-  setEncoding(): void {}
-  read(): null {
-    return null;
-  }
-}
 
 function inverseBandWidths(output: string, text: string): readonly number[] {
   const widths: number[] = [];
@@ -97,24 +67,11 @@ function occurrences(text: string, needle: string): number {
   return text.split(needle).length - 1;
 }
 
-async function waitFor(
-  predicate: () => boolean,
-  timeoutMs: number,
-): Promise<boolean> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (predicate()) return true;
-    await delay(25);
-  }
-  return predicate();
-}
-
 describe('Static band resize', () => {
   it('replaces finalized transcript geometry at the new width', async () => {
     // Dynamic import so FORCE_COLOR is set first and the patched workspace Ink
     // (not a hoisted copy) is loaded.
-    const ink = (await import(cliRequire.resolve('ink'))) as any;
-    const React = ((await import(cliRequire.resolve('react'))) as any).default;
+    const { ink, React, requireFromInk } = await loadInk();
     const { createElement } = React;
     const { StaticConversationTranscript } =
       await import('@cli/chat/tui/panes/StaticConversationTranscript');
@@ -122,8 +79,7 @@ describe('Static band resize', () => {
       await import('@cli/chat/tui/state/cliState');
     const { createTranscriptPrintRequest } =
       await import('@cli/chat/tui/state/transcriptLines');
-    const inkRequire = createRequire(cliRequire.resolve('ink'));
-    const { clearTerminal } = inkRequire('ansi-escapes') as {
+    const { clearTerminal } = requireFromInk('ansi-escapes') as {
       readonly clearTerminal: string;
     };
     const streamId = 'resize-static-stream' as StreamTabId;
@@ -197,10 +153,10 @@ describe('Static band resize', () => {
       });
     }
 
-    const out = new FakeStdout(40);
+    const out = new FakeStdout(40, 12);
     const inst = ink.render(createElement(App), {
       stdout: out,
-      stdin: new FakeStdin(),
+      stdin: new FakeStdin(false),
       interactive: true,
       exitOnCtrlC: false,
       patchConsole: false,
@@ -208,26 +164,29 @@ describe('Static band resize', () => {
 
     try {
       expect(
-        await waitFor(
+        await pollForCondition(
           () =>
-            horizontalRuleWidths(out.buf).includes(40) &&
-            inverseBandWidths(out.buf, prompt).includes(38) &&
-            out.buf.includes(hiddenPrintLine),
-          5000,
+            horizontalRuleWidths(out.output).includes(40) &&
+            inverseBandWidths(out.output, prompt).includes(38) &&
+            out.output.includes(hiddenPrintLine),
+          { timeoutMs: 5000, intervalMs: 25 },
         ),
       ).toBe(true);
 
       // Widen: bump columns and fire the resize the patched Ink handler listens
       // for. Clear the recording so the final frame cannot pass using initial
       // output.
-      out.buf = '';
+      out.output = '';
       out.columns = 80;
       out.emit('resize');
 
-      expect(await waitFor(() => out.buf.includes(clearTerminal), 5000)).toBe(
-        true,
-      );
-      const frame = latestRepaintFrame(out.buf, clearTerminal);
+      expect(
+        await pollForCondition(() => out.output.includes(clearTerminal), {
+          timeoutMs: 5000,
+          intervalMs: 25,
+        }),
+      ).toBe(true);
+      const frame = latestRepaintFrame(out.output, clearTerminal);
       const ruleWidths = horizontalRuleWidths(frame);
       const bandWidths = inverseBandWidths(frame, prompt);
       const visibleFrame = stripAnsi(frame);
@@ -247,15 +206,13 @@ describe('Static band resize', () => {
   });
 
   it('replaces finalized execution rows when subagent labels arrive', async () => {
-    const ink = (await import(cliRequire.resolve('ink'))) as any;
-    const React = ((await import(cliRequire.resolve('react'))) as any).default;
+    const { ink, React, requireFromInk } = await loadInk();
     const { createElement } = React;
     const { StaticConversationTranscript } =
       await import('@cli/chat/tui/panes/StaticConversationTranscript');
     const { patchStream, resetCliState } =
       await import('@cli/chat/tui/state/cliState');
-    const inkRequire = createRequire(cliRequire.resolve('ink'));
-    const { clearTerminal } = inkRequire('ansi-escapes') as {
+    const { clearTerminal } = requireFromInk('ansi-escapes') as {
       readonly clearTerminal: string;
     };
     const streamId = 'execution-label-stream' as StreamTabId;
@@ -317,10 +274,10 @@ describe('Static band resize', () => {
       });
     }
 
-    const out = new FakeStdout(80);
+    const out = new FakeStdout(80, 12);
     const inst = ink.render(createElement(App, { labels: new Map() }), {
       stdout: out,
-      stdin: new FakeStdin(),
+      stdin: new FakeStdin(false),
       interactive: true,
       exitOnCtrlC: false,
       patchConsole: false,
@@ -328,21 +285,27 @@ describe('Static band resize', () => {
     inkRef.current = inst;
 
     try {
-      expect(await waitFor(() => out.buf.includes(executionPath), 5000)).toBe(
-        true,
-      );
+      expect(
+        await pollForCondition(() => out.output.includes(executionPath), {
+          timeoutMs: 5000,
+          intervalMs: 25,
+        }),
+      ).toBe(true);
 
-      out.buf = '';
+      out.output = '';
       inst.rerender(
         createElement(App, {
           labels: new Map([[executionId, 'reviewer']]),
         }),
       );
 
-      expect(await waitFor(() => out.buf.includes(clearTerminal), 5000)).toBe(
-        true,
-      );
-      const frame = stripAnsi(latestRepaintFrame(out.buf, clearTerminal));
+      expect(
+        await pollForCondition(() => out.output.includes(clearTerminal), {
+          timeoutMs: 5000,
+          intervalMs: 25,
+        }),
+      ).toBe(true);
+      const frame = stripAnsi(latestRepaintFrame(out.output, clearTerminal));
       expect(frame).toContain('executions (view: reviewer/report)');
       expect(frame).not.toContain(executionPath);
       expect(occurrences(frame, 'executions (view: reviewer/report)')).toBe(1);
@@ -353,8 +316,7 @@ describe('Static band resize', () => {
   });
 
   it('keeps resize subscriptions constant as tool history grows', async () => {
-    const ink = (await import(cliRequire.resolve('ink'))) as any;
-    const React = ((await import(cliRequire.resolve('react'))) as any).default;
+    const { ink, React } = await loadInk();
     const { createElement } = React;
     const { StaticConversationTranscript } =
       await import('@cli/chat/tui/panes/StaticConversationTranscript');
@@ -406,7 +368,7 @@ describe('Static band resize', () => {
       });
     }
 
-    const out = new FakeStdout(80);
+    const out = new FakeStdout(80, 12);
     let peakResizeListeners = 0;
     out.on('newListener', (event) => {
       if (event === 'resize') {
@@ -418,16 +380,19 @@ describe('Static band resize', () => {
     });
     const inst = ink.render(createElement(App), {
       stdout: out,
-      stdin: new FakeStdin(),
+      stdin: new FakeStdin(false),
       interactive: true,
       exitOnCtrlC: false,
       patchConsole: false,
     });
 
     try {
-      expect(await waitFor(() => out.buf.includes('result 69'), 5000)).toBe(
-        true,
-      );
+      expect(
+        await pollForCondition(() => out.output.includes('result 69'), {
+          timeoutMs: 5000,
+          intervalMs: 25,
+        }),
+      ).toBe(true);
       // One listener belongs to Ink's renderer and one to the App-level
       // useWindowSize subscription. Transcript length must not affect it.
       expect(peakResizeListeners).toBe(2);

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -1,7 +1,6 @@
-import { createRequire } from 'node:module';
-
 import { describe, expect, it } from 'vitest';
 
+import { loadInk } from '@test/support/inkTestHarness.mts';
 import {
   CHILD_STATUS_MARKER,
   childRowMetadataText,
@@ -21,10 +20,6 @@ import {
 } from '@cli/chat/tui/ui/Select';
 import type { StreamView } from '@cli/chat/tui/state/streamViews';
 import { AgentCategory, STREAM_PHASE, type StreamTabId } from '@shared/schemas';
-
-const cliRequire = createRequire(
-  new URL('../../../packages/cli/package.json', import.meta.url),
-);
 
 function session(id: string, active = false): StreamView {
   return {
@@ -236,8 +231,7 @@ describe('CLI child list display model', () => {
   });
 
   it('surfaces per-agent model, tool calls, and tokens for a focused run', async () => {
-    const ink = (await import(cliRequire.resolve('ink'))) as any;
-    const React = ((await import(cliRequire.resolve('react'))) as any).default;
+    const { ink, React } = await loadInk();
     const run = 'run' as StreamTabId;
     const agent = 'agent-1' as StreamTabId;
     const output: string = ink.renderToString(

--- a/src/test-kernel/cli/ToolUseRowPatch.vitest.mts
+++ b/src/test-kernel/cli/ToolUseRowPatch.vitest.mts
@@ -1,7 +1,6 @@
-import { createRequire } from 'node:module';
-
 import { describe, expect, it } from 'vitest';
 
+import { loadInk } from '@test/support/inkTestHarness.mts';
 import { toolDisplaySpanTextProps } from '@cli/chat/tui/panes/ToolUseRow';
 import {
   toolUseDisplayLines,
@@ -9,10 +8,6 @@ import {
 } from '@cli/chat/tui/panes/toolRenderers';
 import type { ConversationEntry } from '@cli/chat/tui/state/cliState';
 import { TOOL_USE_STATUS, type NormalizedToolUse } from '@shared/schemas';
-
-const cliRequire = createRequire(
-  new URL('../../../packages/cli/package.json', import.meta.url),
-);
 
 function toolUse(
   toolName: string,
@@ -43,8 +38,7 @@ async function renderBoundedTool(
   entry: NormalizedToolUse,
   maxRows: number,
 ): Promise<string> {
-  const ink = (await import(cliRequire.resolve('ink'))) as any;
-  const React = ((await import(cliRequire.resolve('react'))) as any).default;
+  const { ink, React } = await loadInk();
   const { BoundedTranscriptEntry } =
     await import('@cli/chat/tui/panes/TranscriptEntry');
   const transcriptEntry: ConversationEntry = {

--- a/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.mts
+++ b/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.mts
@@ -2,14 +2,13 @@
 // per-agent log lines render through the focused-child viewport, while the
 // workflow-specific header identifies the kind of child execution.
 
-import { createRequire } from 'node:module';
-
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import '@test/support/defaultSessionTestSetup';
 import { clearAllStreamStatusesForTest } from '@test/helpers/streamStatusTestUtils';
 
 import { createRunTrace } from '@transcript';
+import { loadInk } from '@test/support/inkTestHarness.mts';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import {
   StaticConversationTranscript,
@@ -29,10 +28,6 @@ import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegation
 // full log output surfaces when focused.
 const STREAM_ID = 'workflow-script#exec-1' as StreamTabId;
 const PARENT_STREAM_ID = 'parent' as StreamTabId;
-const cliRequire = createRequire(
-  new URL('../../../packages/cli/package.json', import.meta.url),
-);
-
 const SESSION_META = {
   agent: 'research',
   category: 'workflow',
@@ -47,8 +42,7 @@ const SESSION_META = {
 } as const;
 
 async function renderStaticTranscript(): Promise<string> {
-  const ink = (await import(cliRequire.resolve('ink'))) as any;
-  const React = ((await import(cliRequire.resolve('react'))) as any).default;
+  const { ink, React } = await loadInk();
   return ink.renderToString(
     React.createElement(StaticConversationTranscript, {
       ownerKey: 'root',

--- a/src/test-kernel/frontend/OutputFileRunFactSubscriptions.vitest.ts
+++ b/src/test-kernel/frontend/OutputFileRunFactSubscriptions.vitest.ts
@@ -1,8 +1,8 @@
 import { join } from 'node:path';
-import { setTimeout as sleep } from 'node:timers/promises';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { waitForCondition } from '@test/support/asyncTestUtils';
 import type {
   AddOutputFilesPayload,
   OutputFileInfo,
@@ -173,17 +173,6 @@ function disposeContext(context: {
   }
 }
 
-async function waitFor(
-  predicate: () => boolean,
-  message: string,
-): Promise<void> {
-  for (let i = 0; i < 20; i += 1) {
-    if (predicate()) return;
-    await sleep(10);
-  }
-  throw new Error(message);
-}
-
 describe('output-file run fact frontend subscriptions', () => {
   let tempDir: string | undefined;
 
@@ -245,11 +234,14 @@ describe('output-file run fact frontend subscriptions', () => {
     );
 
     emitAddOutputFilesRunFact(hub, addOutputFilesPayload(outputPath));
-    await waitFor(
+    await waitForCondition(
       () =>
         (mocks.diagnosticCollections.at(-1)?.items.get(outputPath) ?? [])
           .length > 0,
-      'inline criticism diagnostics were not refreshed',
+      {
+        timeoutMs: 200,
+        timeoutMessage: 'inline criticism diagnostics were not refreshed',
+      },
     );
     expect(
       mocks.diagnosticCollections.at(-1)?.items.get(outputPath),

--- a/src/test-kernel/support/asyncTestUtils.ts
+++ b/src/test-kernel/support/asyncTestUtils.ts
@@ -2,7 +2,42 @@
  * Shared async polling utilities for test suites.
  */
 
-import { setImmediate } from 'node:timers/promises';
+import { setImmediate, setTimeout as sleep } from 'node:timers/promises';
+
+interface PollOptions {
+  readonly timeoutMs?: number;
+  readonly intervalMs?: number;
+}
+
+interface WaitForConditionOptions extends PollOptions {
+  readonly timeoutMessage?: string;
+}
+
+/** Poll until a condition succeeds, or throw when its deadline expires. */
+export async function waitForCondition(
+  predicate: () => boolean,
+  {
+    timeoutMs = 2000,
+    intervalMs = 10,
+    timeoutMessage = 'Timed out waiting for state',
+  }: WaitForConditionOptions = {},
+): Promise<void> {
+  if (await pollForCondition(predicate, { timeoutMs, intervalMs })) return;
+  throw new Error(timeoutMessage);
+}
+
+/** Poll until a condition succeeds and report whether it met the deadline. */
+export async function pollForCondition(
+  predicate: () => boolean,
+  { timeoutMs = 2000, intervalMs = 10 }: PollOptions = {},
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return true;
+    await sleep(intervalMs);
+  }
+  return predicate();
+}
 
 /** Poll until a recorded event with the given name appears, or throw after 10 attempts. */
 export async function waitForRecordedEvent<TEvent extends string>(

--- a/src/test-kernel/support/inkTestHarness.mts
+++ b/src/test-kernel/support/inkTestHarness.mts
@@ -1,0 +1,67 @@
+// Standard library imports
+import { EventEmitter } from 'node:events';
+import { createRequire } from 'node:module';
+
+const cliRequire = createRequire(
+  new URL('../../../packages/cli/package.json', import.meta.url),
+);
+
+/** Load Ink and React from the CLI workspace that owns those dependencies. */
+export async function loadInk(): Promise<{
+  readonly ink: any;
+  readonly React: any;
+  readonly requireFromInk: ReturnType<typeof createRequire>;
+}> {
+  return {
+    ink: (await import(cliRequire.resolve('ink'))) as any,
+    React: ((await import(cliRequire.resolve('react'))) as any).default,
+    requireFromInk: createRequire(cliRequire.resolve('ink')),
+  };
+}
+
+/** Minimal writable TTY used by interactive Ink tests. */
+export class FakeStdout extends EventEmitter {
+  readonly isTTY = true;
+  output = '';
+
+  constructor(
+    public columns = 80,
+    public rows = 24,
+  ) {
+    super();
+  }
+
+  write(chunk: string): boolean {
+    this.output += chunk;
+    return true;
+  }
+
+  getColorDepth(): number {
+    return 24;
+  }
+}
+
+/** Minimal readable TTY used by interactive Ink tests. */
+export class FakeStdin extends EventEmitter {
+  private readonly chunks: string[] = [];
+
+  constructor(readonly isTTY = true) {
+    super();
+  }
+
+  write(chunk: string): void {
+    this.chunks.push(chunk);
+    this.emit('readable');
+  }
+
+  read(): string | null {
+    return this.chunks.shift() ?? null;
+  }
+
+  ref(): void {}
+  unref(): void {}
+  pause(): void {}
+  resume(): void {}
+  setEncoding(): void {}
+  setRawMode(): void {}
+}


### PR DESCRIPTION
## Summary

- resolve Ink and React from the CLI workspace through one shared test harness
- replace five duplicated fake-terminal pairs with configurable shared streams while leaving specialized process streams local
- centralize throwing and boolean polling semantics in the existing async test utilities
- remove 148 net lines and nine duplicated dependency-resolution blocks

This is the independent Ink/CLI half of #8899; #8945 merged the model-handler half.

## Issue acceptance gates

- shared Ink dependency loading replaces nine repeated `createRequire` blocks
- shared configurable terminal fakes replace five duplicated stdin/stdout pairs without absorbing specialized process streams
- shared polling utilities preserve throwing and boolean-returning semantics
- the full test suite, compile, lint, format, and dead-code ratchet pass

## Single source of truth

`src/test-kernel/support/inkTestHarness.mts` owns standard CLI Ink loading and in-memory terminal behavior. `src/test-kernel/support/asyncTestUtils.ts` owns reusable polling semantics.

## Duplication and abstraction budget

Deletes every replaced dependency-loader block, five fake-terminal pairs, and seven local polling helpers in the same PR. Specialized Ink patching and onboarding process streams remain local because their contracts differ.

## Net elements (R6)

- files: +1 / -0
- exported symbols: +5 / -0
- classes: +2 / -10
- interfaces: +2 / -0
- local polling helpers: +0 / -7
- net LoC: -148 (236 additions, 384 deletions across 13 files)

## Consumer counts (R8)

No emit path or existing export is deleted or rerouted. New shared consumers at exact head:

- `loadInk`: 9 test files
- `FakeStdout` and `FakeStdin`: 5 test files
- `waitForCondition`: 7 test files
- `pollForCondition`: 1 test file

## Host impact

Extension: test support only; runtime behavior unchanged.

Desktop: test support only; runtime behavior unchanged.

CLI: test support only; runtime behavior unchanged.

## Scheduled refactoring

None. Ink-internal patching and onboarding process streams intentionally remain suite-local.

## Validation

- `npm run format`
- `npm run compile:safe`
- `npm run lint -- --quiet`
- `npm test` (740 files passed, 1 skipped; 6,874 tests passed, 4 skipped)
- `npm run check:dead-code-ratchet` (22/22)

Closes #8899