### PR TITLE
refactor(settings): preserve type export position

### DIFF
--- a/src/controllers/settingsView/ChatExportController.ts
+++ b/src/controllers/settingsView/ChatExportController.ts
@@ -20,6 +20,9 @@ import {
   generateExportFilename,
   type ChatExportInput,
 } from '@agent/export/chatExportFormatter';
+
+export type { ChatExportInput };
+
 import { compileLatex2Pdf } from '@latex/texTools';
 import type { ExecutionId } from '@shared/schemas';
 import {
@@ -28,8 +31,6 @@ import {
   type AssembleTraceResult,
 } from '@transcript';
 import { StorageFS, pathToLocation } from '@utils/files';
-
-export type { ChatExportInput };
 
 // ============================================================
 // Result types


### PR DESCRIPTION
## Summary

Restore the pre-#8947 placement of the ChatExportInput type re-export. The alias-ordering refactor was merged while its final review was landing; this follow-up makes that refactor's imports-and-comments-only safety contract literally true.

## Issue acceptance gates

Follow-up to the actionable review thread on #8947. The type re-export again remains between import declarations as it was before #8947; no issue acceptance gate remains incomplete.

## Single source of truth

ChatExportController.ts continues to re-export the formatter-owned ChatExportInput type; this change only restores the existing declaration's source position.

## Duplication and abstraction budget

No duplication or abstraction added.

## Net elements (R6)

- Files: 1 modified, 0 added, 0 deleted
- Exported symbols: 0 net
- Classes/interfaces/enums: 0 net
- Net LoC: +1 (blank-line separation around the restored declaration)

## Consumer counts (R8)

n/a — no export, emit path, or consumer is added, deleted, or rerouted.

## Host impact

Extension: No runtime behavior change.

Desktop: No runtime behavior change.

CLI: No runtime behavior change.

## Scheduled refactoring

None.

## Validation

- corepack pnpm exec prettier --write src/controllers/settingsView/ChatExportController.ts
- npm run lint -- --quiet
- npm run typecheck
- npm test -- --run src/test-kernel/scripts/AliasMapGeneration.vitest.ts (8 passed)
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Imports-only reordering with no runtime, API, or consumer path changes.
> 
> **Overview**
> **Restores** the `export type { ChatExportInput }` re-export in `ChatExportController.ts` to sit **immediately after** the `@agent/export/chatExportFormatter` import block, with the remaining imports (`compileLatex2Pdf`, schemas, transcript, files) **below** it—matching pre-#8947 layout.
> 
> No change to what is exported or how export runs; only **declaration order** and a blank line around the type re-export.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74ec6e9f5a5f9ca7309ccdb00b0a1950989fe45d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->