### PR TITLE
fix(inquiry): surface unreadable history storage

### DIFF
--- a/src/test-kernel/tools/InquiryStorage.vitest.ts
+++ b/src/test-kernel/tools/InquiryStorage.vitest.ts
@@ -55,6 +55,29 @@ describe('InquiryStorage', () => {
     logUtils.setOutputChannelFactory(null);
   });
 
+  it('treats a missing inquiry history directory as empty', async () => {
+    await expect(listOpenThreads()).resolves.toEqual([]);
+  });
+
+  it('surfaces inquiry history directory read failures', async () => {
+    const platform = (await import('@platform/platform')).platform();
+    const threadsDir = `${platform.storage.getGlobalStoragePath()}/ei_threads`;
+    const readDirectorySpy = vi
+      .spyOn(platform.fs, 'readDirectory')
+      .mockRejectedValueOnce(
+        Object.assign(new Error('inquiry history is unreadable'), {
+          code: 'EACCES',
+        }),
+      );
+
+    try {
+      await expect(listOpenThreads()).rejects.toMatchObject({ code: 'EACCES' });
+      expect(readDirectorySpy).toHaveBeenCalledWith(threadsDir);
+    } finally {
+      readDirectorySpy.mockRestore();
+    }
+  });
+
   it('opens, answers, and resolves a thread end-to-end', async () => {
     const opened = await recordOpenQuestion({
       parentStreamId: STREAM_A,

--- a/src/tools/inquiry/externalInquiryStorage.ts
+++ b/src/tools/inquiry/externalInquiryStorage.ts
@@ -849,9 +849,13 @@ function manifestToSummary(
 }
 
 async function listAllManifests(): Promise<ExternalInquiryThreadManifest[]> {
-  // A missing/unreadable threads directory means no threads.
+  // A missing threads directory means no threads. Operational storage
+  // failures must remain observable instead of masquerading as empty history.
   const entries = await GlobalStorageFS.readDir(THREADS_DIR).catch(
-    (): [string, number][] => [],
+    (error: unknown): [string, number][] => {
+      if (isFileNotFoundError(error)) return [];
+      throw error;
+    },
   );
 
   const reads = entries.flatMap(([name, type]) => {


### PR DESCRIPTION
## Summary

Treat only a missing inquiry-history directory as empty. Permission, I/O, and other storage failures now propagate through the existing caller error path instead of appearing as no history.

## Issue acceptance gates

Fixes #8950.

- Only a recognized file-not-found error returns an empty inquiry list.
- Other directory-read failures propagate to the existing caller error path.
- Tests distinguish a missing directory from an operational read failure.
- Existing corrupt or schema-invalid manifest behavior remains unchanged and loud.
- No wrapper, fallback layer, or duplicated error predicate was added.

## Single source of truth

`listAllManifests` remains the storage-boundary owner of the empty-directory decision and reuses the shared `isFileNotFoundError` predicate.

## Duplication and abstraction budget

No abstraction or duplicate error logic was added. The existing storage boundary now preserves the missing-versus-unreadable distinction directly.

## Net elements (R6)

- Files: 2 modified, 0 added, 0 deleted.
- Exported symbols: 0 added, 0 deleted.
- Classes/interfaces/enums: 0 added, 0 deleted.
- Net LoC: +27 (29 additions, 2 deletions).

## Consumer counts (R8)

n/a: no export or event path was deleted or rerouted.

## Host impact

Extension: Inquiry history storage failures are surfaced through the existing error path instead of displayed as empty history.

Desktop: Shared inquiry storage semantics improve; no desktop-specific UI change.

CLI: Shared inquiry storage semantics improve; no CLI-specific UI change.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `git diff --check`
- `npx vitest run src/test-kernel/tools/InquiryStorage.vitest.ts` (17 passed)
- `npm run lint -- --quiet`
- `npm run compile:safe`
- `npm run check:dead-code-ratchet` (22 current / 22 baseline)
- `npm test -- --reporter=dot` (740 passed, 1 skipped test files; 6876 passed, 4 skipped tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change at the inquiry storage boundary with tests; behavior improves observability without new APIs or auth/data-path changes.
> 
> **Overview**
> **Inquiry history listing** no longer treats every `ei_threads` directory read failure as “no threads.” Only **missing** storage (via shared `isFileNotFoundError`) still yields an empty list; permission, I/O, and other errors **reject** from `listAllManifests` and flow through existing callers (e.g. `listOpenThreads`).
> 
> Vitest adds coverage for the **fresh empty** case and for **EACCES** on `readDirectory`, asserting the error propagates with the expected code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b11d6e4378e6084c59312740e3a2a8a96caa69d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->