### PR TITLE
fix(files): preserve operational stat failures

### DIFF
--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -1722,8 +1722,8 @@ describe('StreamSnapshotStore', () => {
 
     await expect(store.stageDeleteStream(STREAM)).rejects.toBe(statError);
 
-    expect(await StorageFS.exists(liveDir)).toBe(true);
     statSpy.mockRestore();
+    expect(await StorageFS.exists(liveDir)).toBe(true);
     await store.deleteStream(STREAM);
   });
 

--- a/src/test-kernel/utils/files/FilesUtils.vitest.ts
+++ b/src/test-kernel/utils/files/FilesUtils.vitest.ts
@@ -16,6 +16,7 @@ import {
 } from 'vitest';
 import { z } from 'zod';
 import { isTexFile } from '@common/files/fileTypeUtils';
+import { platform } from '@platform/platform';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { getMimeType } from '@utils/files';
@@ -25,6 +26,46 @@ import { FlexibleFS } from '@utils/files/flexibleFS';
 import { WorkspaceFS } from '@utils/files/workspaceFS';
 import { RelativeFS } from '@utils/files/relativeFS';
 import { pastedImageFileName } from '@utils/files/pastedImageUtils';
+
+// ---------------------------------------------------------------------------
+// BaseFS stat predicates
+// ---------------------------------------------------------------------------
+
+describe('BaseFS stat predicates', () => {
+  setupPlatform();
+
+  it('returns ordinary predicate results for present and missing paths', async () => {
+    await AbsoluteFS.write('/present.txt', 'content');
+
+    await expect(AbsoluteFS.exists('/present.txt')).resolves.toBe(true);
+    await expect(AbsoluteFS.isFile('/present.txt')).resolves.toBe(true);
+    await expect(AbsoluteFS.isSymbolicLink('/present.txt')).resolves.toBe(
+      false,
+    );
+    await expect(AbsoluteFS.exists('/missing.txt')).resolves.toBe(false);
+    await expect(AbsoluteFS.isFile('/missing.txt')).resolves.toBe(false);
+    await expect(AbsoluteFS.isSymbolicLink('/missing.txt')).resolves.toBe(
+      false,
+    );
+  });
+
+  it.each([
+    ['exists', () => AbsoluteFS.exists('/unreadable')],
+    ['isFile', () => AbsoluteFS.isFile('/unreadable')],
+    ['isSymbolicLink', () => AbsoluteFS.isSymbolicLink('/unreadable')],
+  ])('propagates operational stat failures from %s', async (_name, run) => {
+    const error = Object.assign(new Error('path is unreadable'), {
+      code: 'EACCES',
+    });
+    const stat = vi.spyOn(platform().fs, 'stat').mockRejectedValueOnce(error);
+
+    try {
+      await expect(run()).rejects.toBe(error);
+    } finally {
+      stat.mockRestore();
+    }
+  });
+});
 
 // ---------------------------------------------------------------------------
 // WorkspaceFS

--- a/src/test-kernel/utils/files/FilesUtils.vitest.ts
+++ b/src/test-kernel/utils/files/FilesUtils.vitest.ts
@@ -50,6 +50,23 @@ describe('BaseFS stat predicates', () => {
   });
 
   it.each([
+    ['exists', () => AbsoluteFS.exists('/file/child')],
+    ['isFile', () => AbsoluteFS.isFile('/file/child')],
+    ['isSymbolicLink', () => AbsoluteFS.isSymbolicLink('/file/child')],
+  ])('returns false for ENOTDIR from %s', async (_name, run) => {
+    const error = Object.assign(new Error('parent path is not a directory'), {
+      code: 'ENOTDIR',
+    });
+    const stat = vi.spyOn(platform().fs, 'stat').mockRejectedValueOnce(error);
+
+    try {
+      await expect(run()).resolves.toBe(false);
+    } finally {
+      stat.mockRestore();
+    }
+  });
+
+  it.each([
     ['exists', () => AbsoluteFS.exists('/unreadable')],
     ['isFile', () => AbsoluteFS.isFile('/unreadable')],
     ['isSymbolicLink', () => AbsoluteFS.isSymbolicLink('/unreadable')],

--- a/src/utils/files/baseFS.ts
+++ b/src/utils/files/baseFS.ts
@@ -2,6 +2,9 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
+// Common imports
+import { isFileNotFoundError } from '@common/errors';
+
 // Platform imports
 import { FileType, type FileStat } from '@platform/interfaces';
 import { platform } from '@platform/platform';
@@ -42,18 +45,25 @@ export abstract class BaseFS {
     return resolved;
   }
 
+  private static async statIfExists(
+    this: typeof BaseFS,
+    target: string,
+  ): Promise<FileStat | undefined> {
+    try {
+      return await this.stat(target);
+    } catch (error) {
+      if (isFileNotFoundError(error)) return undefined;
+      throw error;
+    }
+  }
+
   // ===== Async Methods =====
 
   public static async exists(
     this: typeof BaseFS,
     target: string,
   ): Promise<boolean> {
-    try {
-      await platform().fs.stat(this.preparePath(target));
-      return true;
-    } catch {
-      return false;
-    }
+    return (await this.statIfExists(target)) !== undefined;
   }
 
   public static async read(
@@ -181,24 +191,18 @@ export abstract class BaseFS {
     this: typeof BaseFS,
     target: string,
   ): Promise<boolean> {
-    try {
-      const stats = await this.stat(target);
-      return isFile(stats.type);
-    } catch {
-      return false;
-    }
+    const stats = await this.statIfExists(target);
+    return stats ? isFile(stats.type) : false;
   }
 
   public static async isSymbolicLink(
     this: typeof BaseFS,
     target: string,
   ): Promise<boolean> {
-    try {
-      const stats = await this.stat(target);
-      return (stats.type & FileType.SymbolicLink) === FileType.SymbolicLink;
-    } catch {
-      return false;
-    }
+    const stats = await this.statIfExists(target);
+    return stats
+      ? (stats.type & FileType.SymbolicLink) === FileType.SymbolicLink
+      : false;
   }
 
   // ===== Sync Methods =====

--- a/src/utils/files/baseFS.ts
+++ b/src/utils/files/baseFS.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 // Common imports
-import { isFileNotFoundError } from '@common/errors';
+import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
 
 // Platform imports
 import { FileType, type FileStat } from '@platform/interfaces';
@@ -52,7 +52,9 @@ export abstract class BaseFS {
     try {
       return await this.stat(target);
     } catch (error) {
-      if (isFileNotFoundError(error)) return undefined;
+      if (isFileNotFoundError(error) || isNotADirectoryError(error)) {
+        return undefined;
+      }
       throw error;
     }
   }


### PR DESCRIPTION
## Summary

- Preserve operational filesystem errors from the shared `BaseFS` predicates.
- Keep the existing `false` result only for recognized missing-path errors, including an invalid intermediate directory (`ENOTDIR`).
- Release an existing transcript-store stat mock before verifying real disk state.

## Issue acceptance gates

Fixes #8952.

- `exists`, `isFile`, and `isSymbolicLink` return `false` for recognized missing paths.
- Operational stat failures such as `EACCES` propagate to the existing error boundary.
- Focused tests cover both missing and unreadable paths.
- The policy lives in one shared helper rather than a wrapper, fallback, or duplicated predicate.
- Successful predicate behavior is unchanged.

## Single source of truth

`BaseFS.statIfExists` owns the missing-path versus operational-failure distinction and delegates error recognition to the existing `isFileNotFoundError` utility.

## Duplication and abstraction budget

One private helper with three consumers replaces three broad catch blocks. It owns one filesystem invariant and adds no public surface.

## Net elements (R6)

- Files: 3 modified, 0 added, 0 deleted.
- Exports: 0 added, 0 deleted.
- Classes/interfaces/enums: 0 added, 0 deleted.
- LoC: +83/-19, net +64, primarily focused regression coverage.

## Consumer counts (R8)

n/a: no export, event, or emit path is deleted or rerouted. The new private helper has three direct consumers.

## Host impact

Extension: Operational shared-filesystem failures now reach the existing error boundary; missing paths remain ordinary negative predicate results.

Desktop: Same shared `BaseFS` behavior as the extension.

CLI: Same shared `BaseFS` behavior as the extension.

## Scheduled refactoring

#7726 continues to track the remaining site-specific broad filesystem catches; this PR completes only the shared `BaseFS` policy item.

## Validation

- `npm run format`
- `npm run lint -- --quiet`
- `git diff --check`
- `npm test -- --run src/test-kernel/utils/files/FilesUtils.vitest.ts src/test-kernel/transcript/StreamSnapshotStore.vitest.ts --reporter=dot` (84 passed)
- `npm test -- --reporter=dot` (740 files passed, 1 skipped; 6,883 tests passed, 4 skipped)
- `npx tsc --noEmit`
- `npx tsc --noEmit -p tsconfig.test-kernel.json`
- Package typechecks for extension, CLI, desktop, and trace viewer
- `npm run check:dead-code-ratchet` (22 current / 22 baseline)
- Extension host, trace-viewer, and all three webview development builds
