### PR TITLE
fix(storage): preserve workspace-file stat failures

### DIFF
--- a/src/agent/storage/executionWorkspaceFiles.ts
+++ b/src/agent/storage/executionWorkspaceFiles.ts
@@ -1,6 +1,7 @@
 import * as path from 'node:path';
 
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
 import { AbsoluteFS } from '@utils/files';
 import { byStringProp, normalizeFilePath } from '@utils/core';
 import { isStrictlyWithin } from '@utils/core/pathCore';
@@ -15,7 +16,7 @@ export interface ExecutionWorkspaceFile {
 }
 
 export function resolveExecutionWorkspaceFilePath(
-  config: AgentConfig | null,
+  config: Pick<AgentConfig, 'workingDirectory'> | null,
   filePath: string,
 ): { readonly absolutePath: string; readonly path: string } | undefined {
   const workspaceRoot = config?.workingDirectory?.trim();
@@ -38,7 +39,7 @@ export function resolveExecutionWorkspaceFilePath(
 }
 
 export async function listExecutionWorkspaceFiles(
-  config: AgentConfig | null,
+  config: Pick<AgentConfig, 'workingDirectory'> | null,
   filePaths: readonly string[],
 ): Promise<ExecutionWorkspaceFile[]> {
   const files = new Map<string, ExecutionWorkspaceFile>();
@@ -46,10 +47,13 @@ export async function listExecutionWorkspaceFiles(
     const resolved = resolveExecutionWorkspaceFilePath(config, filePath);
     if (!resolved || files.has(resolved.path)) continue;
 
-    const stat = await AbsoluteFS.stat(resolved.absolutePath).catch(
-      () => undefined,
-    );
-    if (!stat) continue;
+    let stat;
+    try {
+      stat = await AbsoluteFS.stat(resolved.absolutePath);
+    } catch (error) {
+      if (isFileNotFoundError(error) || isNotADirectoryError(error)) continue;
+      throw error;
+    }
 
     files.set(resolved.path, {
       path: resolved.path,

--- a/src/agent/storage/executionWorkspaceFiles.ts
+++ b/src/agent/storage/executionWorkspaceFiles.ts
@@ -2,6 +2,7 @@ import * as path from 'node:path';
 
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
+import type { FileStat } from '@platform/interfaces';
 import { AbsoluteFS } from '@utils/files';
 import { byStringProp, normalizeFilePath } from '@utils/core';
 import { isStrictlyWithin } from '@utils/core/pathCore';
@@ -47,7 +48,7 @@ export async function listExecutionWorkspaceFiles(
     const resolved = resolveExecutionWorkspaceFilePath(config, filePath);
     if (!resolved || files.has(resolved.path)) continue;
 
-    let stat;
+    let stat: FileStat;
     try {
       stat = await AbsoluteFS.stat(resolved.absolutePath);
     } catch (error) {

--- a/src/test-kernel/agent/storage/ExecutionWorkspaceFiles.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionWorkspaceFiles.vitest.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { listExecutionWorkspaceFiles } from '@agent/storage';
+import { platform } from '@platform/platform';
+import { setupPlatform } from '@test/support/setupPlatform';
+import { AbsoluteFS } from '@utils/files';
+
+const CONFIG = { workingDirectory: '/workspace' };
+
+describe('listExecutionWorkspaceFiles', () => {
+  setupPlatform({ workspacePath: '/workspace' });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('lists unique contained entries in path order and omits missing paths', async () => {
+    await AbsoluteFS.createDir('/workspace/z-dir');
+    await AbsoluteFS.write('/workspace/a-file.tex', 'content');
+
+    await expect(
+      listExecutionWorkspaceFiles(CONFIG, [
+        'z-dir',
+        'missing.tex',
+        'a-file.tex',
+        'a-file.tex',
+        '../outside.tex',
+      ]),
+    ).resolves.toEqual([
+      {
+        path: 'a-file.tex',
+        displayPath: 'workspace/a-file.tex',
+        absolutePath: '/workspace/a-file.tex',
+        size: 7,
+        isDirectory: false,
+      },
+      {
+        path: 'z-dir',
+        displayPath: 'workspace/z-dir',
+        absolutePath: '/workspace/z-dir',
+        size: 0,
+        isDirectory: true,
+      },
+    ]);
+  });
+
+  it('omits a path whose intermediate component is not a directory', async () => {
+    const error = Object.assign(new Error('parent path is not a directory'), {
+      code: 'ENOTDIR',
+    });
+    vi.spyOn(platform().fs, 'stat').mockRejectedValueOnce(error);
+
+    await expect(
+      listExecutionWorkspaceFiles(CONFIG, ['file/child.tex']),
+    ).resolves.toEqual([]);
+  });
+
+  it('propagates operational stat failures', async () => {
+    const error = Object.assign(new Error('workspace file is unreadable'), {
+      code: 'EACCES',
+    });
+    vi.spyOn(platform().fs, 'stat').mockRejectedValueOnce(error);
+
+    await expect(
+      listExecutionWorkspaceFiles(CONFIG, ['unreadable.tex']),
+    ).rejects.toBe(error);
+  });
+});


### PR DESCRIPTION
## Summary

- Preserve operational stat failures while listing recorded workspace files.
- Continue omitting only absence-shaped paths (`ENOENT`, `FileNotFound`, and `ENOTDIR`).
- Narrow the listing helpers' configuration contract to the only field they use: `workingDirectory`.

## Issue acceptance gates

Fixes #8954.

- Missing and invalid-parent workspace paths remain omitted.
- Permission and other operational failures propagate to existing host error boundaries.
- Focused tests cover present files, directories, missing paths, invalid parents, duplicates, containment, sorting, and unreadable entries.
- Existing size and directory metadata behavior remains unchanged.

## Single source of truth

`listExecutionWorkspaceFiles` owns the listing decision: path-resolution/containment stays in `resolveExecutionWorkspaceFilePath`, while the listing boundary alone distinguishes absence from an operational stat failure using the existing error predicates.

## Duplication and abstraction budget

The broad catch is replaced directly at its existing boundary. No helper, wrapper, fallback, or public symbol was added. Both helpers now accept only the `workingDirectory` configuration field they consume.

## Net elements (R6)

- Files: 1 added, 1 modified, 0 deleted.
- Exports: 0 added, 0 deleted.
- Classes/interfaces/enums: 0 added, 0 deleted.
- LoC: +76/-6, net +70, primarily focused boundary coverage.

## Consumer counts (R8)

- `listExecutionWorkspaceFiles`: 2 production consumers (executions tool and CLI history), both remain source-compatible.
- `resolveExecutionWorkspaceFilePath`: 4 production call sites (the listing plus three executions-tool paths), all remain source-compatible.
- No export or event path was deleted or rerouted.

## Host impact

Extension: The executions tool now surfaces workspace stat failures through its existing tool-error path instead of reporting an incomplete listing.

Desktop: Same shared executions-tool behavior as the extension.

CLI: History details now surface operational workspace stat failures instead of silently omitting recorded files.

## Scheduled refactoring

#7726 continues to track the remaining site-specific P1.8 broad filesystem catches.

## Validation

- `npm run format`
- `npm run lint -- --quiet`
- `git diff --check`
- `npm test -- --run src/test-kernel/agent/storage/ExecutionWorkspaceFiles.vitest.ts --reporter=dot` (3 passed)
- `npm test -- --reporter=dot` (741 files passed, 1 skipped; 6,886 tests passed, 4 skipped)
- Root, test-kernel, extension, CLI, trace-viewer, and desktop typechecks
- `npm run check:dead-code-ratchet` (22 current / 22 baseline)
- `npm run compile:fast` was not run locally because pnpm refuses the symlinked worktree dependency layout without reinstalling it; exact-head CI runs the clean build-artifact gate.
