### PR TITLE
fix(cli): preserve generated-history stat failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,9 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Generated-file history no longer invents empty files** — inaccessible run
+  artifacts now surface a history error instead of appearing as zero-byte
+  files, while files removed during the scan are omitted normally.
 - **ChatGPT limits no longer switch credentials silently** — when subscription
   usage is exhausted, the CLI shows the limit and reset warning and waits for
   confirmation before retrying with a personal OpenAI API key.

--- a/packages/cli/src/runtime/history/generatedFiles.ts
+++ b/packages/cli/src/runtime/history/generatedFiles.ts
@@ -2,7 +2,7 @@ import * as path from 'node:path';
 
 import { listExecutionWorkspaceFiles } from '@agent/storage';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
-import { isFileNotFoundError } from '@common/errors';
+import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
 import { safeParseJson } from '@common/parsing/safeParseJson';
 import type { ExecutionId } from '@shared/schemas';
 import { isKVFile as isHistoryKvFile } from '@tools/executions/executionKvFiles';
@@ -45,12 +45,17 @@ async function walkStorageDirectory(
     const rawRelative = relativePath ? path.join(relativePath, name) : name;
     const childPath = path.join(basePath, rawRelative);
     const entryIsDirectory = isDirectory(type);
-    const stat = await StorageFS.stat(childPath).catch(() => ({ size: 0 }));
-    files.push({
-      path: toPosixPath(rawRelative),
-      size: stat.size,
-      isDirectory: entryIsDirectory,
-    });
+    try {
+      const stat = await StorageFS.stat(childPath);
+      files.push({
+        path: toPosixPath(rawRelative),
+        size: stat.size,
+        isDirectory: entryIsDirectory,
+      });
+    } catch (error) {
+      if (isFileNotFoundError(error) || isNotADirectoryError(error)) continue;
+      throw error;
+    }
     if (entryIsDirectory && maxDepth > 1) {
       files.push(
         ...(await walkStorageDirectory(basePath, rawRelative, maxDepth - 1)),

--- a/src/test-kernel/cli/GeneratedHistoryFiles.vitest.ts
+++ b/src/test-kernel/cli/GeneratedHistoryFiles.vitest.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { listGeneratedFiles } from '@cli/runtime/history/generatedFiles';
+import { platform } from '@platform/platform';
+import type { ExecutionId } from '@shared/schemas';
+import { setupPlatform } from '@test/support/setupPlatform';
+
+const EXECUTION_ID = 'generated-history-test' as ExecutionId;
+const RUN_PATH = `/storage/executions/${EXECUTION_ID}`;
+
+function fsError(code: string, message: string): Error {
+  return Object.assign(new Error(message), { code });
+}
+
+function failStatFor(targetPath: string, error: Error): void {
+  const fs = platform().fs;
+  const stat = fs.stat.bind(fs);
+  vi.spyOn(fs, 'stat').mockImplementation(async (candidate) => {
+    if (candidate === targetPath) throw error;
+    return stat(candidate);
+  });
+}
+
+describe('listGeneratedFiles', () => {
+  setupPlatform({
+    storagePath: '/storage',
+    files: {
+      [`${RUN_PATH}/sub/nested.tex`]: 'nested',
+      [`${RUN_PATH}/z.tex`]: 'xyz',
+      [`${RUN_PATH}/vanished.tex`]: 'gone',
+      [`${RUN_PATH}/blocked.tex`]: 'blocked',
+      [`${RUN_PATH}/unreadable.tex`]: 'unreadable',
+    },
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('lists generated metadata in path order and omits concurrent disappearance', async () => {
+    failStatFor(
+      `${RUN_PATH}/vanished.tex`,
+      fsError('ENOENT', 'entry disappeared after readDir'),
+    );
+
+    await expect(listGeneratedFiles(EXECUTION_ID)).resolves.toEqual([
+      { path: 'blocked.tex', size: 7, isDirectory: false },
+      { path: 'sub', size: 0, isDirectory: true },
+      { path: 'sub/nested.tex', size: 6, isDirectory: false },
+      { path: 'unreadable.tex', size: 10, isDirectory: false },
+      { path: 'z.tex', size: 3, isDirectory: false },
+    ]);
+  });
+
+  it('omits an entry whose intermediate component is no longer a directory', async () => {
+    failStatFor(
+      `${RUN_PATH}/blocked.tex`,
+      fsError('ENOTDIR', 'parent path is no longer a directory'),
+    );
+
+    const files = await listGeneratedFiles(EXECUTION_ID);
+
+    expect(files.map((file) => file.path)).not.toContain('blocked.tex');
+  });
+
+  it('propagates operational stat failures', async () => {
+    const error = fsError('EACCES', 'generated file is unreadable');
+    failStatFor(`${RUN_PATH}/unreadable.tex`, error);
+
+    await expect(listGeneratedFiles(EXECUTION_ID)).rejects.toBe(error);
+  });
+});


### PR DESCRIPTION
## Summary

- omit generated-history entries that disappear between directory enumeration and metadata lookup
- propagate permission and other operational stat failures instead of fabricating zero-byte files
- cover normal metadata, sorting, recursion, ENOENT, ENOTDIR, and EACCES with focused tests

Fixes #8956.

## Root cause and design

The storage walker collapsed every `stat` failure into valid `{ size: 0 }` metadata. The fix keeps classification at the existing filesystem boundary: only absence-shaped races continue the walk, while all other errors reach the existing CLI history boundary. It adds no wrapper, facade, fallback chain, or exported helper.

The existing directory walk remains the single owner of depth limiting, KV-file filtering, path normalization, recursion, and ordering.

## Validation

- red/green focused test: all three cases failed before the production change and pass after it
- `npm run format`
- `npm run lint -- --quiet`
- root TypeScript typecheck
- test-kernel TypeScript typecheck
- CLI TypeScript typecheck
- full Vitest suite: 742 files passed, 1 skipped; 6,889 tests passed, 4 skipped
- `git diff --check`

`npm run compile:fast` could not start in the isolated worktree because pnpm refuses the validation-only symlinked dependency layout without a TTY (`ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`). The exact-head clean CI artifact build remains the build gate.

## Change size

- production and changelog: +15/-7
- focused tests: +69/-0
- total: +84/-7, net +77

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to CLI history file metadata during directory walks; improves correctness without touching auth, execution, or write paths.
> 
> **Overview**
> **Generated-file history** no longer treats every failed `stat` as a zero-byte file. The storage walk now **skips** entries that disappear between `readDir` and `stat` (`ENOENT`) or hit a path that is no longer a directory (`ENOTDIR`), and **rethrows** real operational failures (for example `EACCES`) so CLI history can surface an error instead of showing fake empty artifacts.
> 
> Focused tests cover sorted listing, race omission, `ENOTDIR` omission, and propagated permission errors. The unreleased CLI changelog notes the behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35c15c2ba1727cd1755a2a94b6a3531f0f0e24e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->