### PR TITLE
fix(glob): preserve match metadata failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **File searches no longer hide unreadable matches** — inaccessible matching
+  files now surface a search error instead of appearing as the oldest results,
+  while files removed during the search are omitted normally.
 - **Accepted run files remain editable** — agents can continue editing accepted
   workflow output without an unnecessary intervening file read.
 - **Between-round LaTeX diffs work with current runs** — users who enable

--- a/src/test-kernel/tools/GlobTool.vitest.ts
+++ b/src/test-kernel/tools/GlobTool.vitest.ts
@@ -2,21 +2,22 @@ import { mkdtemp, rm, utimes, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { platform } from '@platform/platform';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
-import { createFakePlatform } from '@test/support/FakePlatform';
-import { setupPlatform } from '@test/support/setupPlatform';
+import { installPlatform } from '@test/support/setupPlatform';
 import { GlobTool } from '@tools/glob';
-
-let workspacePath = '';
 
 function fsError(code: string, message: string): Error {
   return Object.assign(new Error(message), { code });
 }
 
-function failStatFor(fileName: string, error: Error): void {
+function failStatFor(
+  workspacePath: string,
+  fileName: string,
+  error: Error,
+): void {
   const fs = platform().fs;
   const stat = fs.stat.bind(fs);
   const targetPath = path.join(workspacePath, fileName);
@@ -26,9 +27,12 @@ function failStatFor(fileName: string, error: Error): void {
   });
 }
 
-describe('GlobTool match metadata', () => {
-  beforeEach(async () => {
-    workspacePath = await mkdtemp(path.join(tmpdir(), 'texra-glob-tool-'));
+async function withGlobWorkspace(
+  run: (workspacePath: string) => Promise<void>,
+): Promise<void> {
+  const workspacePath = await mkdtemp(path.join(tmpdir(), 'texra-glob-tool-'));
+  await installPlatform({ workspacePath }, { fs: nodeFilesystem });
+  try {
     await Promise.all(
       [
         'new.tex',
@@ -40,50 +44,70 @@ describe('GlobTool match metadata', () => {
     );
     await utimes(path.join(workspacePath, 'old.tex'), 1, 1);
     await utimes(path.join(workspacePath, 'new.tex'), 2, 2);
-  });
-  setupPlatform(() =>
-    createFakePlatform({ workspacePath }, { fs: nodeFilesystem }),
-  );
-  afterEach(async () => {
+    await run(workspacePath);
+  } finally {
     vi.restoreAllMocks();
+    await installPlatform();
     await rm(workspacePath, { recursive: true, force: true });
-  });
+  }
+}
 
+describe('GlobTool match metadata', () => {
   it('orders matches by modification time', async () => {
-    const result = await new GlobTool().call({ pattern: '{old,new}.tex' });
+    await withGlobWorkspace(async () => {
+      const result = await new GlobTool().call({ pattern: '{old,new}.tex' });
 
-    expect(result.status).toBe('executed');
-    expect(result.output?.indexOf('new.tex')).toBeLessThan(
-      result.output?.indexOf('old.tex') ?? -1,
-    );
+      expect(result.status).toBe('executed');
+      expect(result.output?.indexOf('new.tex')).toBeLessThan(
+        result.output?.indexOf('old.tex') ?? -1,
+      );
+    });
   });
 
   it('omits a match that disappears before metadata lookup', async () => {
-    failStatFor('vanished.tex', fsError('ENOENT', 'match disappeared'));
+    await withGlobWorkspace(async (workspacePath) => {
+      failStatFor(
+        workspacePath,
+        'vanished.tex',
+        fsError('ENOENT', 'match disappeared'),
+      );
 
-    const result = await new GlobTool().call({ pattern: 'vanished.tex' });
+      const result = await new GlobTool().call({ pattern: 'vanished.tex' });
 
-    expect(result).toMatchObject({ status: 'executed' });
-    expect(result.output).toContain('(no matches)');
+      expect(result).toMatchObject({ status: 'executed' });
+      expect(result.output).toContain('(no matches)');
+    });
   });
 
   it('omits a match whose parent is no longer a directory', async () => {
-    failStatFor('blocked.tex', fsError('ENOTDIR', 'parent changed'));
+    await withGlobWorkspace(async (workspacePath) => {
+      failStatFor(
+        workspacePath,
+        'blocked.tex',
+        fsError('ENOTDIR', 'parent changed'),
+      );
 
-    const result = await new GlobTool().call({ pattern: 'blocked.tex' });
+      const result = await new GlobTool().call({ pattern: 'blocked.tex' });
 
-    expect(result).toMatchObject({ status: 'executed' });
-    expect(result.output).toContain('(no matches)');
+      expect(result).toMatchObject({ status: 'executed' });
+      expect(result.output).toContain('(no matches)');
+    });
   });
 
   it('surfaces operational stat failures through the tool boundary', async () => {
-    failStatFor('unreadable.tex', fsError('EACCES', 'match is unreadable'));
+    await withGlobWorkspace(async (workspacePath) => {
+      failStatFor(
+        workspacePath,
+        'unreadable.tex',
+        fsError('EACCES', 'match is unreadable'),
+      );
 
-    await expect(
-      new GlobTool().call({ pattern: 'unreadable.tex' }),
-    ).resolves.toMatchObject({
-      status: 'error',
-      error: 'match is unreadable',
+      await expect(
+        new GlobTool().call({ pattern: 'unreadable.tex' }),
+      ).resolves.toMatchObject({
+        status: 'error',
+        error: 'match is unreadable',
+      });
     });
   });
 });

--- a/src/test-kernel/tools/GlobTool.vitest.ts
+++ b/src/test-kernel/tools/GlobTool.vitest.ts
@@ -1,0 +1,89 @@
+import { mkdtemp, rm, utimes, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { platform } from '@platform/platform';
+import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+import { createFakePlatform } from '@test/support/FakePlatform';
+import { setupPlatform } from '@test/support/setupPlatform';
+import { GlobTool } from '@tools/glob';
+
+let workspacePath = '';
+
+function fsError(code: string, message: string): Error {
+  return Object.assign(new Error(message), { code });
+}
+
+function failStatFor(fileName: string, error: Error): void {
+  const fs = platform().fs;
+  const stat = fs.stat.bind(fs);
+  const targetPath = path.join(workspacePath, fileName);
+  vi.spyOn(fs, 'stat').mockImplementation(async (candidate) => {
+    if (candidate === targetPath) throw error;
+    return stat(candidate);
+  });
+}
+
+describe('GlobTool match metadata', () => {
+  beforeEach(async () => {
+    workspacePath = await mkdtemp(path.join(tmpdir(), 'texra-glob-tool-'));
+    await Promise.all(
+      [
+        'new.tex',
+        'old.tex',
+        'vanished.tex',
+        'blocked.tex',
+        'unreadable.tex',
+      ].map((name) => writeFile(path.join(workspacePath, name), name)),
+    );
+    await utimes(path.join(workspacePath, 'old.tex'), 1, 1);
+    await utimes(path.join(workspacePath, 'new.tex'), 2, 2);
+  });
+  setupPlatform(() =>
+    createFakePlatform({ workspacePath }, { fs: nodeFilesystem }),
+  );
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(workspacePath, { recursive: true, force: true });
+  });
+
+  it('orders matches by modification time', async () => {
+    const result = await new GlobTool().call({ pattern: '{old,new}.tex' });
+
+    expect(result.status).toBe('executed');
+    expect(result.output?.indexOf('new.tex')).toBeLessThan(
+      result.output?.indexOf('old.tex') ?? -1,
+    );
+  });
+
+  it('omits a match that disappears before metadata lookup', async () => {
+    failStatFor('vanished.tex', fsError('ENOENT', 'match disappeared'));
+
+    const result = await new GlobTool().call({ pattern: 'vanished.tex' });
+
+    expect(result).toMatchObject({ status: 'executed' });
+    expect(result.output).toContain('(no matches)');
+  });
+
+  it('omits a match whose parent is no longer a directory', async () => {
+    failStatFor('blocked.tex', fsError('ENOTDIR', 'parent changed'));
+
+    const result = await new GlobTool().call({ pattern: 'blocked.tex' });
+
+    expect(result).toMatchObject({ status: 'executed' });
+    expect(result.output).toContain('(no matches)');
+  });
+
+  it('surfaces operational stat failures through the tool boundary', async () => {
+    failStatFor('unreadable.tex', fsError('EACCES', 'match is unreadable'));
+
+    await expect(
+      new GlobTool().call({ pattern: 'unreadable.tex' }),
+    ).resolves.toMatchObject({
+      status: 'error',
+      error: 'match is unreadable',
+    });
+  });
+});

--- a/src/test-kernel/tools/GlobTool.vitest.ts
+++ b/src/test-kernel/tools/GlobTool.vitest.ts
@@ -1,12 +1,19 @@
+// Node imports
 import { mkdtemp, rm, utimes, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 
+// Third-party imports
 import { describe, expect, it, vi } from 'vitest';
 
+// Local imports - platform
 import { platform } from '@platform/platform';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+
+// Local imports - test support
 import { installPlatform } from '@test/support/setupPlatform';
+
+// Local imports - tools
 import { GlobTool } from '@tools/glob';
 
 function fsError(code: string, message: string): Error {
@@ -58,9 +65,10 @@ describe('GlobTool match metadata', () => {
       const result = await new GlobTool().call({ pattern: '{old,new}.tex' });
 
       expect(result.status).toBe('executed');
-      expect(result.output?.indexOf('new.tex')).toBeLessThan(
-        result.output?.indexOf('old.tex') ?? -1,
-      );
+      expect(result.output).toContain('new.tex');
+      expect(result.output).toContain('old.tex');
+      const output = result.output ?? '';
+      expect(output.indexOf('new.tex')).toBeLessThan(output.indexOf('old.tex'));
     });
   });
 

--- a/src/tools/glob.ts
+++ b/src/tools/glob.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 
 // Local imports
 import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
+import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
 import { ToolError, ToolResult } from '@shared/schemas/toolResult';
 import { getGitignoreMatcher } from '@tools/gitignore';
 import { formatToolOutput } from '@tools/formatting';
@@ -95,8 +96,15 @@ export class GlobTool extends defineTool({
           return null;
         }
 
-        const stat = await WorkspaceFS.stat(resolved.fsPath).catch(() => null);
-        return { relativePath, mtime: stat?.mtime ?? 0 };
+        try {
+          const stat = await WorkspaceFS.stat(resolved.fsPath);
+          return { relativePath, mtime: stat.mtime };
+        } catch (error) {
+          if (isFileNotFoundError(error) || isNotADirectoryError(error)) {
+            return null;
+          }
+          throw error;
+        }
       },
     );
 


### PR DESCRIPTION
## Summary

- omit glob matches that disappear between discovery and metadata lookup
- propagate permission and other operational stat failures through the existing tool error boundary
- cover modification-time ordering, ENOENT, ENOTDIR, and EACCES with focused real-filesystem tests

Fixes #8958.

## Root cause and design

The glob metadata stage collapsed every `stat` failure into a synthetic epoch timestamp, making inaccessible files look like valid old matches. The fix classifies the error at that existing boundary: absence-shaped races return no match; all other errors propagate to `BaseTool.call`, which already owns structured tool errors.

No wrapper, facade, exported helper, or extra execution layer was introduced. Match discovery, gitignore filtering, path containment, cancellation, output formatting, and deterministic sorting remain in their existing owners.

## Validation

- red/green focused suite: three error-path cases failed before the production change and all four tests pass after it
- targeted Prettier formatting
- `npm run lint -- --quiet`
- root TypeScript typecheck
- test-kernel TypeScript typecheck
- full Vitest suite: 743 files passed, 1 skipped; 6,893 tests passed, 4 skipped
- after review-driven test hardening: focused suite, lint, and root/test-kernel typechecks passed
- `git diff --check`

The exact-head clean CI artifact build remains the build gate for the isolated worktree.

## Change size

- production and changelog: +13/-2
- focused tests: +121/-0
- total: +134/-2, net +132
