### PR TITLE
fix(review): preserve untracked-file read failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Agent reviews no longer hide unreadable untracked files** — files removed
+  during review collection are omitted normally, while permission and I/O
+  failures stop the review with a clear error instead of producing incomplete
+  findings.
 - **File searches no longer hide unreadable matches** — inaccessible matching
   files now surface a search error instead of appearing as the oldest results,
   while files removed during the search are omitted normally.

--- a/src/agent/review/reviewDiff.ts
+++ b/src/agent/review/reviewDiff.ts
@@ -16,6 +16,7 @@ import * as path from 'node:path';
 import simpleGit, { type SimpleGit } from 'simple-git';
 
 // Local imports
+import { isFileNotFoundError } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { platform } from '@platform/platform';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -345,8 +346,12 @@ async function collectUntrackedDiffs(
           MAX_UNTRACKED_FILE_BYTES + 1,
         );
         return { file, content };
-      } catch {
-        return undefined; // Vanished or unreadable; skip.
+      } catch (error) {
+        if (isFileNotFoundError(error)) return undefined;
+        throw new Error(
+          `Could not read untracked file "${file}": ${toErrorMessage(error)}`,
+          { cause: error },
+        );
       }
     }),
   );
@@ -442,13 +447,23 @@ export async function collectReviewDiff(
   const submoduleFlag = includeSubmodules
     ? '--submodule=diff'
     : '--ignore-submodules=all';
-  const [diffText, nameOnly, untracked] = await Promise.all([
-    rawGit(sgRoot, ['diff', '--no-color', submoduleFlag, baseRef, '--']),
-    rawGit(sgRoot, ['diff', '--name-only', submoduleFlag, baseRef, '--']),
-    includeUntracked
-      ? collectUntrackedDiffs(sgRoot, repoRoot)
-      : Promise.resolve({ diff: '', files: [] }),
-  ]);
+  let collected: [
+    string | null,
+    string | null,
+    Awaited<ReturnType<typeof collectUntrackedDiffs>>,
+  ];
+  try {
+    collected = await Promise.all([
+      rawGit(sgRoot, ['diff', '--no-color', submoduleFlag, baseRef, '--']),
+      rawGit(sgRoot, ['diff', '--name-only', submoduleFlag, baseRef, '--']),
+      includeUntracked
+        ? collectUntrackedDiffs(sgRoot, repoRoot)
+        : Promise.resolve({ diff: '', files: [] }),
+    ]);
+  } catch (error) {
+    return { ok: false, reason: toErrorMessage(error) };
+  }
+  const [diffText, nameOnly, untracked] = collected;
   // A failed name-only diff must fail the collection too: issue reports are
   // validated against `changedFiles`, so an empty list alongside real diff
   // text would reject every finding as outside the change set.

--- a/src/agent/review/reviewDiff.ts
+++ b/src/agent/review/reviewDiff.ts
@@ -24,6 +24,7 @@ import {
 import * as logger from '@logger/logUtils';
 import { platform } from '@platform/platform';
 import { toErrorMessage } from '@utils/errors/errorMessage';
+import { isDirectory, isSymlink } from '@utils/files/fsEntryType';
 import { makeMachineGitEnv } from '@utils/system/platformPaths';
 import { splitContentLines, splitOutputLines } from '@utils/text/stringUtils';
 
@@ -344,42 +345,48 @@ async function collectUntrackedDiffs(
       const filePath = path.join(repoRoot, file);
       // One byte beyond the cap so buildUntrackedFileDiff still detects
       // and marks truncation for oversized files.
-      try {
-        const content = await platform().fs.readFileChunk(
-          filePath,
-          0,
-          MAX_UNTRACKED_FILE_BYTES + 1,
-        );
-        return { file, content };
-      } catch (error) {
-        if (isFileNotFoundError(error) || isNotADirectoryError(error)) {
-          // The path disappeared after Git listed it, so there is no evidence
-          // left for this review to collect.
-          return undefined;
-        }
-        if (isADirectoryError(error)) {
-          try {
-            // A non-symlink directory means the listed file was replaced.
-            if (!(await platform().fs.isSymlink(filePath))) return undefined;
-          } catch (recheckError) {
-            if (
-              isFileNotFoundError(recheckError) ||
-              isNotADirectoryError(recheckError)
-            ) {
-              // The path disappeared again while its type was rechecked.
-              return undefined;
-            }
-            throw new Error(
-              `Could not inspect untracked path "${file}": ${toErrorMessage(recheckError)}`,
-              { cause: recheckError },
-            );
+      for (const isRetry of [false, true]) {
+        try {
+          const content = await platform().fs.readFileChunk(
+            filePath,
+            0,
+            MAX_UNTRACKED_FILE_BYTES + 1,
+          );
+          return { file, content };
+        } catch (error) {
+          if (isFileNotFoundError(error) || isNotADirectoryError(error)) {
+            // The path disappeared after Git listed it, so there is no
+            // evidence left for this review to collect.
+            return undefined;
           }
+          if (isADirectoryError(error)) {
+            try {
+              const { type } = await platform().fs.stat(filePath);
+              // A real directory means the listed file was replaced. A file
+              // or symlink may have reappeared, so retry its read once.
+              if (isDirectory(type) && !isSymlink(type)) return undefined;
+              if (!isRetry) continue;
+            } catch (recheckError) {
+              if (
+                isFileNotFoundError(recheckError) ||
+                isNotADirectoryError(recheckError)
+              ) {
+                // The path disappeared again while its type was rechecked.
+                return undefined;
+              }
+              throw new Error(
+                `Could not inspect untracked path "${file}": ${toErrorMessage(recheckError)}`,
+                { cause: recheckError },
+              );
+            }
+          }
+          throw new Error(
+            `Could not read untracked file "${file}": ${toErrorMessage(error)}`,
+            { cause: error },
+          );
         }
-        throw new Error(
-          `Could not read untracked file "${file}": ${toErrorMessage(error)}`,
-          { cause: error },
-        );
       }
+      throw new Error(`Could not read untracked file "${file}"`);
     }),
   );
 

--- a/src/agent/review/reviewDiff.ts
+++ b/src/agent/review/reviewDiff.ts
@@ -337,11 +337,12 @@ async function collectUntrackedDiffs(
   const included = untracked.slice(0, MAX_UNTRACKED_FILES);
   const contents = await Promise.all(
     included.map(async (file) => {
+      const filePath = path.join(repoRoot, file);
       // One byte beyond the cap so buildUntrackedFileDiff still detects
       // and marks truncation for oversized files.
       try {
         const content = await platform().fs.readFileChunk(
-          path.join(repoRoot, file),
+          filePath,
           0,
           MAX_UNTRACKED_FILE_BYTES + 1,
         );
@@ -349,6 +350,22 @@ async function collectUntrackedDiffs(
       } catch (error) {
         if (isFileNotFoundError(error) || isNotADirectoryError(error)) {
           return undefined;
+        }
+        if ((error as { code?: string })?.code === 'EISDIR') {
+          try {
+            if (!(await platform().fs.isSymlink(filePath))) return undefined;
+          } catch (recheckError) {
+            if (
+              isFileNotFoundError(recheckError) ||
+              isNotADirectoryError(recheckError)
+            ) {
+              return undefined;
+            }
+            throw new Error(
+              `Could not inspect untracked path "${file}": ${toErrorMessage(recheckError)}`,
+              { cause: recheckError },
+            );
+          }
         }
         throw new Error(
           `Could not read untracked file "${file}": ${toErrorMessage(error)}`,

--- a/src/agent/review/reviewDiff.ts
+++ b/src/agent/review/reviewDiff.ts
@@ -16,7 +16,11 @@ import * as path from 'node:path';
 import simpleGit, { type SimpleGit } from 'simple-git';
 
 // Local imports
-import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
+import {
+  isADirectoryError,
+  isFileNotFoundError,
+  isNotADirectoryError,
+} from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { platform } from '@platform/platform';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -349,16 +353,20 @@ async function collectUntrackedDiffs(
         return { file, content };
       } catch (error) {
         if (isFileNotFoundError(error) || isNotADirectoryError(error)) {
+          // The path disappeared after Git listed it, so there is no evidence
+          // left for this review to collect.
           return undefined;
         }
-        if ((error as { code?: string })?.code === 'EISDIR') {
+        if (isADirectoryError(error)) {
           try {
+            // A non-symlink directory means the listed file was replaced.
             if (!(await platform().fs.isSymlink(filePath))) return undefined;
           } catch (recheckError) {
             if (
               isFileNotFoundError(recheckError) ||
               isNotADirectoryError(recheckError)
             ) {
+              // The path disappeared again while its type was rechecked.
               return undefined;
             }
             throw new Error(

--- a/src/agent/review/reviewDiff.ts
+++ b/src/agent/review/reviewDiff.ts
@@ -16,7 +16,7 @@ import * as path from 'node:path';
 import simpleGit, { type SimpleGit } from 'simple-git';
 
 // Local imports
-import { isFileNotFoundError } from '@common/errors';
+import { isFileNotFoundError, isNotADirectoryError } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { platform } from '@platform/platform';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -347,7 +347,9 @@ async function collectUntrackedDiffs(
         );
         return { file, content };
       } catch (error) {
-        if (isFileNotFoundError(error)) return undefined;
+        if (isFileNotFoundError(error) || isNotADirectoryError(error)) {
+          return undefined;
+        }
         throw new Error(
           `Could not read untracked file "${file}": ${toErrorMessage(error)}`,
           { cause: error },

--- a/src/common/errors/errorPredicates.ts
+++ b/src/common/errors/errorPredicates.ts
@@ -9,6 +9,11 @@ export function isNotADirectoryError(err: unknown): boolean {
   return (err as { code?: string })?.code === 'ENOTDIR';
 }
 
+/** Check if an error represents "the path is a directory, not a file". */
+export function isADirectoryError(err: unknown): boolean {
+  return (err as { code?: string })?.code === 'EISDIR';
+}
+
 /** Check if an error is "dynamic import couldn't find the module" (Node + ESM variants). */
 export function isModuleNotFoundError(err: unknown): boolean {
   const code = (err as { code?: string })?.code;

--- a/src/common/errors/index.ts
+++ b/src/common/errors/index.ts
@@ -10,6 +10,7 @@
  */
 export { formatError } from './errorFormatUtils';
 export {
+  isADirectoryError,
   isFileNotFoundError,
   isModuleNotFoundError,
   isNotADirectoryError,

--- a/src/test-kernel/agent/review/AgentReviewDiff.vitest.ts
+++ b/src/test-kernel/agent/review/AgentReviewDiff.vitest.ts
@@ -140,7 +140,7 @@ describe('collectReviewDiff (real git repository)', () => {
     expect(await realpath(value.repoRoot)).toBe(await realpath(repo));
   });
 
-  it.each(['ENOENT', 'FileNotFound'])(
+  it.each(['ENOENT', 'FileNotFound', 'ENOTDIR'])(
     'omits an untracked file that disappears with %s during collection',
     async (code) => {
       await writeFile(path.join(repo, 'vanished.txt'), 'temporary\n');

--- a/src/test-kernel/agent/review/AgentReviewDiff.vitest.ts
+++ b/src/test-kernel/agent/review/AgentReviewDiff.vitest.ts
@@ -205,6 +205,32 @@ describe('collectReviewDiff (real git repository)', () => {
     expect(value.changedFiles).toEqual([]);
   });
 
+  it('includes an untracked file that reappears during the type recheck', async () => {
+    const replacedPath = path.join(repo, 'reappeared.txt');
+    await writeFile(replacedPath, 'temporary\n');
+    const fs = platform().fs;
+    const readFileChunk = fs.readFileChunk.bind(fs);
+    let firstRead = true;
+    vi.spyOn(fs, 'readFileChunk').mockImplementation(
+      async (filePath, offset, length) => {
+        if (path.basename(filePath) === 'reappeared.txt' && firstRead) {
+          firstRead = false;
+          await rm(filePath);
+          await mkdir(filePath);
+          await rm(filePath, { recursive: true });
+          await writeFile(filePath, 'current evidence\n');
+          throw fsError('EISDIR', 'untracked file briefly became a directory');
+        }
+        return readFileChunk(filePath, offset, length);
+      },
+    );
+
+    const value = await collectDiffOrFail({ includeUntracked: true });
+
+    expect(value.diff).toContain('+current evidence');
+    expect(value.changedFiles).toEqual(['reappeared.txt']);
+  });
+
   it('does not hide an untracked symlink to a directory', async () => {
     const target = path.join(repo, 'target-dir');
     await mkdir(target);

--- a/src/test-kernel/agent/review/AgentReviewDiff.vitest.ts
+++ b/src/test-kernel/agent/review/AgentReviewDiff.vitest.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 
 // Third-party imports
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import {
@@ -14,11 +14,16 @@ import {
   listBaseBranchCandidates,
   type CollectReviewDiffOptions,
 } from '@agent/review/reviewDiff';
+import { platform } from '@platform/platform';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { executeCommand } from '@utils/system/execUtils';
 
 setupPlatform({ workspacePath: process.cwd() }, { fs: nodeFilesystem });
+
+function fsError(code: string, message: string): Error {
+  return Object.assign(new Error(message), { code });
+}
 
 describe('isPathInChangeSet', () => {
   it('matches exact files and paths under changed directories', () => {
@@ -91,8 +96,20 @@ describe('collectReviewDiff (real git repository)', () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await rm(repo, { recursive: true, force: true });
   });
+
+  function failUntrackedRead(file: string, error: Error): void {
+    const fs = platform().fs;
+    const readFileChunk = fs.readFileChunk.bind(fs);
+    vi.spyOn(fs, 'readFileChunk').mockImplementation(
+      async (filePath, offset, length) => {
+        if (path.basename(filePath) === file) throw error;
+        return readFileChunk(filePath, offset, length);
+      },
+    );
+  }
 
   /** Runs `collectReviewDiff` against the fixture repo and unwraps a success. */
   async function collectDiffOrFail(
@@ -121,6 +138,42 @@ describe('collectReviewDiff (real git repository)', () => {
     expect(value.changedFiles).toEqual(['paper.tex', 'scratch.txt']);
     expect(value.truncated).toBe(false);
     expect(await realpath(value.repoRoot)).toBe(await realpath(repo));
+  });
+
+  it.each(['ENOENT', 'FileNotFound'])(
+    'omits an untracked file that disappears with %s during collection',
+    async (code) => {
+      await writeFile(path.join(repo, 'vanished.txt'), 'temporary\n');
+      failUntrackedRead(
+        'vanished.txt',
+        fsError(code, 'untracked file disappeared'),
+      );
+
+      const value = await collectDiffOrFail({ includeUntracked: true });
+
+      expect(value.diff).toBe('');
+      expect(value.changedFiles).toEqual([]);
+    },
+  );
+
+  it('fails clearly when an untracked file cannot be read', async () => {
+    await writeFile(path.join(repo, 'secret.txt'), 'sensitive\n');
+    failUntrackedRead(
+      'secret.txt',
+      fsError('EACCES', 'untracked file is unreadable'),
+    );
+
+    const result = await collectReviewDiff({
+      cwd: repo,
+      includeUntracked: true,
+      includeSubmodules: true,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      reason:
+        'Could not read untracked file "secret.txt": untracked file is unreadable',
+    });
   });
 
   it('ignores inherited interactive git environment variables', async () => {

--- a/src/test-kernel/agent/review/AgentReviewDiff.vitest.ts
+++ b/src/test-kernel/agent/review/AgentReviewDiff.vitest.ts
@@ -1,5 +1,12 @@
 // Node imports
-import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises';
+import {
+  mkdir,
+  mkdtemp,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 
@@ -173,6 +180,50 @@ describe('collectReviewDiff (real git repository)', () => {
       ok: false,
       reason:
         'Could not read untracked file "secret.txt": untracked file is unreadable',
+    });
+  });
+
+  it('omits an untracked file replaced by a directory during collection', async () => {
+    const replacedPath = path.join(repo, 'replaced.txt');
+    await writeFile(replacedPath, 'temporary\n');
+    const fs = platform().fs;
+    const readFileChunk = fs.readFileChunk.bind(fs);
+    vi.spyOn(fs, 'readFileChunk').mockImplementation(
+      async (filePath, offset, length) => {
+        if (path.basename(filePath) === 'replaced.txt') {
+          await rm(filePath);
+          await mkdir(filePath);
+          throw fsError('EISDIR', 'untracked file became a directory');
+        }
+        return readFileChunk(filePath, offset, length);
+      },
+    );
+
+    const value = await collectDiffOrFail({ includeUntracked: true });
+
+    expect(value.diff).toBe('');
+    expect(value.changedFiles).toEqual([]);
+  });
+
+  it('does not hide an untracked symlink to a directory', async () => {
+    const target = path.join(repo, 'target-dir');
+    await mkdir(target);
+    await symlink(target, path.join(repo, 'linked-dir'));
+    failUntrackedRead(
+      'linked-dir',
+      fsError('EISDIR', 'untracked path resolves to a directory'),
+    );
+
+    const result = await collectReviewDiff({
+      cwd: repo,
+      includeUntracked: true,
+      includeSubmodules: true,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      reason:
+        'Could not read untracked file "linked-dir": untracked path resolves to a directory',
     });
   });
 


### PR DESCRIPTION
## Summary

- omit an untracked file only when it disappears while review evidence is being collected
- return a clear review-collection failure when an untracked file cannot be read
- distinguish file-to-directory races from genuine symlinks to directories
- cover missing, unreadable, and replacement-race paths in a real Git fixture

Fixes #8960.

## Root cause and design

The collector treated failure to list untracked files as fatal, but broadly swallowed every per-file read error. That violated the same completeness contract and allowed a review to report success with missing evidence.

The fix classifies errors at the existing file-read boundary: disappearance races remain benign, while operational read failures flow through the existing `CollectReviewDiffResult` failure path. An `EISDIR` result is rechecked through the existing filesystem port so only an actual file-to-directory replacement is omitted; a symlink to a directory remains visible as a failure. It adds no manager, facade, export, or persisted state.

## Change size

- production and changelog: +48 / -10
- tests: +106 / -2

## Validation

- `npm run format`
- workspace `npm run typecheck`
- `npm run compile:fast`
- `npm run lint -- --quiet`
- `npx vitest run src/test-kernel/agent/review/AgentReviewDiff.vitest.ts` (27 passed)
- `npm test` (6,896 passed, 4 skipped; 743 files passed, 1 skipped)
- `git diff --check`

Exact-head GitHub Actions checks remain the merge gate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to review diff collection and error classification; behavior is stricter (fail-fast on I/O) but does not touch auth, persistence, or broad agent runtime paths.
> 
> **Overview**
> **Agent review** no longer treats every unreadable untracked path as skippable. In `collectUntrackedDiffs`, disappearance races (`ENOENT` / `FileNotFound` / `ENOTDIR`) still omit the path; **permission and other read failures** abort collection with an explicit message via the existing `CollectReviewDiffResult` failure path.
> 
> **`EISDIR`** is handled with a `stat` recheck (new `isADirectoryError` helper): a path that became a real directory is omitted, a one-time retry covers a file that reappears after a brief race, and **symlinks to directories** still surface as read failures rather than being hidden.
> 
> `collectReviewDiff` wraps the parallel git/untracked gather in **try/catch** so those errors propagate instead of producing a successful review with missing untracked content. Changelog and **vitest** fixtures cover vanished, unreadable, directory-replacement, reappear, and symlink cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a0dfa4db526cb08526976bcd3289d34736687f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->