### PR TITLE
fix(goals): surface malformed saved records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Malformed saved goals no longer disappear** — invalid persisted goal data
+  now surfaces an error instead of being treated as no goal and overwritten.
 - **Agent reviews no longer hide unreadable untracked files** — files removed
   during review collection are omitted normally, while permission and I/O
   failures stop the review with a clear error instead of producing incomplete

--- a/src/test-kernel/tools/GoalForget.vitest.ts
+++ b/src/test-kernel/tools/GoalForget.vitest.ts
@@ -50,6 +50,16 @@ describe('GoalStore.forget (abandon-on-delete contract)', () => {
     expect(next.status).toBe('active');
   });
 
+  it('treats only absent goal records as no goal', async () => {
+    const { platform } = await import('@platform/platform');
+    const state = platform().workspaceState;
+    const key = `goals:byStream:${STREAM_A}`;
+
+    expect(GoalStore.getForStream(STREAM_A)).toBeNull();
+    await state.update(key, null);
+    expect(GoalStore.getForStream(STREAM_A)).toBeNull();
+  });
+
   it('routes explicit-session forget notifications only to the passed session', async () => {
     const runSession = createTestSession();
     const explicitSession = createTestSession();
@@ -108,17 +118,27 @@ describe('GoalStore.forget (abandon-on-delete contract)', () => {
     }
   });
 
-  it('cleans up an unparseable blob (raw key presence, not parse success)', async () => {
+  it('surfaces an unparseable blob but still lets explicit cleanup remove it', async () => {
     const { platform } = await import('@platform/platform');
     const state = platform().workspaceState;
-    // An unparseable record normalizes to null on read, but its raw key
-    // must still be removed by forget.
     await state.update(`goals:byStream:${STREAM_A}`, { goalId: 'not-valid' });
-    expect(GoalStore.getForStream(STREAM_A)).toBeNull();
+    expect(() => GoalStore.getForStream(STREAM_A)).toThrow();
 
     await GoalStore.forget(STREAM_A);
 
     expect(state.get(`goals:byStream:${STREAM_A}`)).toBeUndefined();
+    expect(GoalStore.getForStream(STREAM_A)).toBeNull();
+  });
+
+  it('does not overwrite an unparseable record when starting a goal', async () => {
+    const { platform } = await import('@platform/platform');
+    const state = platform().workspaceState;
+    const malformed = { goalId: 'not-valid' };
+    const key = `goals:byStream:${STREAM_A}`;
+    await state.update(key, malformed);
+
+    await expect(GoalStore.start(STREAM_A, 'replacement')).rejects.toThrow();
+    expect(state.get(key)).toEqual(malformed);
   });
 
   it('forgetMany clears records and unparseable blobs', async () => {

--- a/src/test-kernel/tools/GoalForget.vitest.ts
+++ b/src/test-kernel/tools/GoalForget.vitest.ts
@@ -122,7 +122,9 @@ describe('GoalStore.forget (abandon-on-delete contract)', () => {
     const { platform } = await import('@platform/platform');
     const state = platform().workspaceState;
     await state.update(`goals:byStream:${STREAM_A}`, { goalId: 'not-valid' });
-    expect(() => GoalStore.getForStream(STREAM_A)).toThrow();
+    expect(() => GoalStore.getForStream(STREAM_A)).toThrow(
+      `Failed to parse persisted goal for stream "${STREAM_A}"`,
+    );
 
     await GoalStore.forget(STREAM_A);
 
@@ -139,6 +141,17 @@ describe('GoalStore.forget (abandon-on-delete contract)', () => {
 
     await expect(GoalStore.start(STREAM_A, 'replacement')).rejects.toThrow();
     expect(state.get(key)).toEqual(malformed);
+  });
+
+  it('identifies the malformed stream when listing goals', async () => {
+    const { platform } = await import('@platform/platform');
+    const state = platform().workspaceState;
+    await state.update('goals:index', [STREAM_A]);
+    await state.update(`goals:byStream:${STREAM_A}`, { goalId: 'not-valid' });
+
+    expect(() => GoalStore.list()).toThrow(
+      `Failed to parse persisted goal for stream "${STREAM_A}"`,
+    );
   });
 
   it('forgetMany clears records and unparseable blobs', async () => {

--- a/src/tools/goal/goalStore.ts
+++ b/src/tools/goal/goalStore.ts
@@ -68,9 +68,9 @@ function readRaw(streamId: StreamTabId): Goal | null {
   // does throw, surfacing the misuse.
   const state = tryWorkspaceState();
   if (!state) return null;
-  return GoalSchema.nullable()
-    .catch(null)
-    .parse(state.get<unknown>(streamKey(streamId)));
+  return (
+    GoalSchema.nullish().parse(state.get<unknown>(streamKey(streamId))) ?? null
+  );
 }
 
 async function writeRaw(goal: Goal): Promise<void> {
@@ -276,9 +276,8 @@ export const GoalStore = {
   async forget(streamId: StreamTabId, session?: SessionHandle): Promise<void> {
     const state = tryWorkspaceState();
     if (!state) return;
-    // Gate on raw key presence, not parse success — an unparseable blob
-    // (which `readRaw` normalizes to null) must still be cleaned up, or its
-    // key lingers forever.
+    // Gate on raw key presence, not parse success, so explicit cleanup can
+    // still remove an invalid record without first reading it.
     const existed = state.get<unknown>(streamKey(streamId)) != null;
     if (!existed) return;
     await Promise.all([

--- a/src/tools/goal/goalStore.ts
+++ b/src/tools/goal/goalStore.ts
@@ -68,9 +68,17 @@ function readRaw(streamId: StreamTabId): Goal | null {
   // does throw, surfacing the misuse.
   const state = tryWorkspaceState();
   if (!state) return null;
-  return (
-    GoalSchema.nullish().parse(state.get<unknown>(streamKey(streamId))) ?? null
-  );
+  const key = streamKey(streamId);
+  const raw = state.get<unknown>(key);
+  if (raw == null) return null;
+  const parsed = GoalSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new Error(
+      `Failed to parse persisted goal for stream "${streamId}" at storage key "${key}".`,
+      { cause: parsed.error },
+    );
+  }
+  return parsed.data;
 }
 
 async function writeRaw(goal: Goal): Promise<void> {
@@ -186,7 +194,11 @@ export function subscribeGoalStateChanges(
 }
 
 export const GoalStore = {
-  /** Get the goal for a stream, or null when none exists. */
+  /**
+   * Get the goal for a stream, or null when none exists.
+   *
+   * @throws When a present saved record does not match {@link GoalSchema}.
+   */
   getForStream(streamId: StreamTabId): Goal | null {
     return readRaw(streamId);
   },


### PR DESCRIPTION
## Summary

- parse persisted goal records with `GoalSchema` without a catch-all fallback
- preserve `null`/`undefined` as the only absent-record values
- prove malformed records surface and cannot be overwritten by `GoalStore.start()`

## Issue acceptance gates

Closes #8962.

- absent and explicitly null records still return `null`
- malformed present records throw schema validation errors
- starting a goal leaves a malformed present record untouched
- explicit forget operations can still delete malformed raw records

## Single source of truth

`GoalSchema` remains the sole persisted goal contract. `goalStore.readRaw()` now preserves its validation result instead of replacing validation failures with absence.

## Duplication and abstraction budget

No abstraction or duplicate validation path was added. The catch-all fallback was removed at the existing storage boundary.

## Net elements (R6)

n/a — bug fix with no new files, exports, classes, interfaces, or enums. Net +21 LoC is focused regression coverage and a changelog entry.

## Consumer counts (R8)

n/a — no export or event path changed.

## Host impact

Extension: malformed shared goal state now surfaces through the existing caller error path.

Desktop: same shared goal-store behavior.

CLI: same shared goal-store behavior.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (zero errors; one pre-existing warning in `AgentCreatorToolCatalogParity.vitest.mts`)
- `corepack pnpm exec vitest run src/test-kernel/tools/GoalForget.vitest.ts src/test-kernel/tools/GoalStoreConcurrency.vitest.ts` (11 passed)
- `npm test` (6,902 passed, 4 skipped)
- `git diff --check`
