### PR TITLE
fix(settings): surface goal list refresh errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Goal loading failures stay visible in the dashboard** — invalid saved goal
+  data now shows a clear error without interrupting unrelated settings.
 - **Malformed saved goals no longer disappear** — invalid persisted goal data
   now surfaces an error instead of being treated as no goal and overwritten.
 - **Agent reviews no longer hide unreadable untracked files** — files removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,10 +38,9 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
-- **Goal loading failures stay visible in the dashboard** — invalid saved goal
-  data now shows a clear error without interrupting unrelated settings.
-- **Malformed saved goals no longer disappear** — invalid persisted goal data
-  now surfaces an error instead of being treated as no goal and overwritten.
+- **Malformed saved goals report a clear dashboard error** — invalid goal data
+  no longer disappears or gets overwritten, and unrelated settings continue
+  loading.
 - **Agent reviews no longer hide unreadable untracked files** — files removed
   during review collection are omitted normally, while permission and I/O
   failures stop the review with a clear error instead of producing incomplete

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -611,10 +611,14 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   }
 
   public async sendGoalList(webview: vscode.Webview): Promise<void> {
-    await webview.postMessage({
-      command: SETTINGS_VIEW_COMMANDS.UPDATE_GOAL_LIST,
-      items: [...GoalStore.list()],
-    });
+    try {
+      await webview.postMessage({
+        command: SETTINGS_VIEW_COMMANDS.UPDATE_GOAL_LIST,
+        items: GoalStore.list(),
+      });
+    } catch (error) {
+      await showLoggedErrorMessage(this.channel, 'Failed to load goals', error);
+    }
   }
 
   private handleRunToolCommand(

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -612,10 +612,13 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
 
   public async sendGoalList(webview: vscode.Webview): Promise<void> {
     try {
-      await webview.postMessage({
+      const delivered = await webview.postMessage({
         command: SETTINGS_VIEW_COMMANDS.UPDATE_GOAL_LIST,
         items: GoalStore.list(),
       });
+      if (!delivered) {
+        throw new Error('settings webview is no longer available');
+      }
     } catch (error) {
       await showLoggedErrorMessage(this.channel, 'Failed to load goals', error);
     }

--- a/src/test-kernel/settings/SettingsGoalList.vitest.ts
+++ b/src/test-kernel/settings/SettingsGoalList.vitest.ts
@@ -1,0 +1,83 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as vscode from 'vscode';
+
+import { SettingsViewMessageHandler } from '@settingsView/SettingsViewMessageHandler';
+import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
+import type { StreamTabId } from '@shared/schemas';
+import { setupPlatform } from '@test/support/setupPlatform';
+import { GoalStore } from '@tools/goal';
+
+const STREAM_ID = 'stream:settings-goal-list' as StreamTabId;
+const GOAL_KEY = `goals:byStream:${STREAM_ID}`;
+
+type GoalListHarness = Pick<SettingsViewMessageHandler, 'sendGoalList'>;
+
+function createHandlerHarness(): GoalListHarness {
+  const handler = Object.create(SettingsViewMessageHandler.prototype);
+  Reflect.set(handler, 'channel', 'SettingsViewMessageHandler');
+  return handler as GoalListHarness;
+}
+
+function createWebview(): vscode.Webview {
+  return {
+    postMessage: vi.fn(async () => true),
+  } as unknown as vscode.Webview;
+}
+
+describe('settings goal list', () => {
+  setupPlatform();
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it('posts valid goals unchanged', async () => {
+    const goal = await GoalStore.start(STREAM_ID, 'Finish the settings fix.');
+    const webview = createWebview();
+
+    await createHandlerHarness().sendGoalList(webview);
+
+    expect(webview.postMessage).toHaveBeenCalledWith({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_GOAL_LIST,
+      items: [goal],
+    });
+  });
+
+  it('reports a malformed goal without posting a fallback list', async () => {
+    const { platform } = await import('@platform/platform');
+    const malformed = { goalId: 'not-valid' };
+    await platform().workspaceState.update('goals:index', [STREAM_ID]);
+    await platform().workspaceState.update(GOAL_KEY, malformed);
+    const webview = createWebview();
+    const showErrorMessage = vi.spyOn(vscode.window, 'showErrorMessage');
+
+    await expect(
+      createHandlerHarness().sendGoalList(webview),
+    ).resolves.toBeUndefined();
+
+    expect(showErrorMessage).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `Failed to load goals: Failed to parse persisted goal for stream "${STREAM_ID}"`,
+      ),
+    );
+    expect(webview.postMessage).not.toHaveBeenCalled();
+    expect(platform().workspaceState.get(GOAL_KEY)).toEqual(malformed);
+  });
+
+  it('reports goal-list delivery failures through the same boundary', async () => {
+    const webview = createWebview();
+    vi.mocked(webview.postMessage).mockRejectedValue(
+      new Error('webview disposed'),
+    );
+    const showErrorMessage = vi.spyOn(vscode.window, 'showErrorMessage');
+
+    await expect(
+      createHandlerHarness().sendGoalList(webview),
+    ).resolves.toBeUndefined();
+
+    expect(showErrorMessage).toHaveBeenCalledWith(
+      'Failed to load goals: webview disposed',
+    );
+  });
+});

--- a/src/test-kernel/settings/SettingsGoalList.vitest.ts
+++ b/src/test-kernel/settings/SettingsGoalList.vitest.ts
@@ -65,7 +65,21 @@ describe('settings goal list', () => {
     expect(platform().workspaceState.get(GOAL_KEY)).toEqual(malformed);
   });
 
-  it('reports goal-list delivery failures through the same boundary', async () => {
+  it('reports a dropped goal-list delivery through the same boundary', async () => {
+    const webview = createWebview();
+    vi.mocked(webview.postMessage).mockResolvedValue(false);
+    const showErrorMessage = vi.spyOn(vscode.window, 'showErrorMessage');
+
+    await expect(
+      createHandlerHarness().sendGoalList(webview),
+    ).resolves.toBeUndefined();
+
+    expect(showErrorMessage).toHaveBeenCalledWith(
+      'Failed to load goals: settings webview is no longer available',
+    );
+  });
+
+  it('reports rejected goal-list deliveries through the same boundary', async () => {
     const webview = createWebview();
     vi.mocked(webview.postMessage).mockRejectedValue(
       new Error('webview disposed'),


### PR DESCRIPTION
## Summary

- give the extension goal-list sender one owned error boundary
- show malformed-storage and webview-delivery failures through the existing settings error UI
- preserve malformed records and avoid posting an invented fallback list
- remove a redundant copy of the already-new goal array

## Issue acceptance gates

Closes #8964.

- valid goals are posted unchanged
- malformed saved goals show their stream-specific error
- failures post no empty replacement and leave the stored record untouched
- the sender resolves after reporting, so automatic refreshes do not create unhandled rejections or abort unrelated initial settings

## Single source of truth

`SettingsViewMessageHandler.sendGoalList()` now owns both goal-list delivery and its user-visible error policy for every extension caller. `GoalStore` remains the sole persisted-data validator.

## Duplication and abstraction budget

No production abstraction was added. Moving the policy into the existing sender avoids separate catches in automatic, initial, and manual refresh call sites; the redundant `[...GoalStore.list()]` copy was removed.

## Net elements (R6)

n/a — bug fix with one focused test file, no new exports, classes, interfaces, enums, or production modules. Production code is +8/−4; tests are +83; changelog is +2.

## Consumer counts (R8)

n/a — no export, command, or event path changed.

## Host impact

Extension: goal-list failures are shown once and no longer reject background or initial settings refreshes.

Desktop: unchanged; its settings IPC already has a host-owned error reporter.

CLI: unchanged.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (zero errors; one pre-existing warning in `AgentCreatorToolCatalogParity.vitest.mts`)
- `corepack pnpm exec vitest run src/test-kernel/settings/SettingsGoalList.vitest.ts src/test-kernel/tools/GoalForget.vitest.ts` (13 passed)
- `npm test` (6,906 passed, 4 skipped)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized extension settings UI path with defensive error handling and new Vitest coverage; no auth, persistence schema, or shared API contract changes beyond clearer failure behavior.
> 
> **Overview**
> **Settings goal list** now has a single error boundary in `sendGoalList()`: malformed persisted goals, failed `postMessage` delivery (`false`), and webview disposal/rejection all show **Failed to load goals** via the existing settings error UI and **resolve without throwing**, so automatic refreshes and unrelated initial settings load are not aborted.
> 
> On success, valid goals are still posted unchanged (the redundant `[...GoalStore.list()]` copy was removed). On failure, **no** empty or invented list is posted and malformed workspace records are **left untouched**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9883c0e3991282e4f411baa0d50d392245bb6374. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->