### PR TITLE
fix(desktop): isolate goal list load failures

### DIFF
--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -1,3 +1,4 @@
+import { formatError } from '@common/errors';
 import { SettingsViewHost } from '@controllers/settingsView/SettingsViewHost';
 import {
   createSettingsViewCommandHandlers,
@@ -182,22 +183,30 @@ export function createDesktopSettingsIpc(
    * (or refreshing) the panel re-reads the store, so a live push adds a
    * subscription surface without a user-visible gain.
    */
-  function postGoalList(): void {
-    options.postToRenderer({
-      command: SETTINGS_VIEW_COMMANDS.UPDATE_GOAL_LIST,
-      items: [...GoalStore.list()],
-    });
+  async function postGoalList(): Promise<void> {
+    try {
+      options.postToRenderer({
+        command: SETTINGS_VIEW_COMMANDS.UPDATE_GOAL_LIST,
+        items: GoalStore.list(),
+      });
+    } catch (error) {
+      options.ui.onError(error);
+      await options.ui.showErrorMessage(
+        formatError('Failed to load goals', error),
+      );
+    }
   }
 
   async function postInitialSettingsData(): Promise<void> {
     postGitAuthorSettings();
     options.toolingSettingsController.postLatexConfigValues();
-    postGoalList();
+    const goalListPosted = postGoalList();
     const memoryEnabledPosted = postMemoryEnabled();
     const modelSelectionDataPosted = postModelSelectionData();
     postSuperYoloEnabled();
     postApprovalSettings();
     await Promise.all([
+      goalListPosted,
       memoryEnabledPosted,
       postMemoryData(),
       options.historySettingsController.postHistoryData(),

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -1,10 +1,13 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { MODEL_LIST_VERSION } from '@model/modelOptionsBasic';
 import type { StateStore } from '@platform/interfaces';
+import { platform } from '@platform/platform';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
+import type { StreamTabId } from '@shared/schemas';
 import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
 import { DEFAULT_GIT_MARK_COMMITS } from '@shared/schemas/stateSettings';
 import { FakeStateStore } from '@test/support/FakePlatform';
+import { setupPlatform } from '@test/support/setupPlatform';
 import {
   isWorktreeSupportEnabled,
   setWorktreeSupportEnabled,
@@ -425,6 +428,71 @@ describe('desktop settings IPC', () => {
     expect(posted.at(-1)).toEqual({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_GOAL_LIST,
       items: [],
+    });
+  });
+
+  describe('goal-list failures', () => {
+    setupPlatform();
+
+    const streamId = 'stream:desktop-settings-goal-list' as StreamTabId;
+    const goalKey = `goals:byStream:${streamId}`;
+    const malformed = { goalId: 'not-valid' };
+
+    async function seedMalformedGoal(): Promise<void> {
+      await platform().workspaceState.update('goals:index', [streamId]);
+      await platform().workspaceState.update(goalKey, malformed);
+    }
+
+    it('reports a malformed goal without throwing or posting a fallback list', async () => {
+      await seedMalformedGoal();
+      const showErrorMessage = vi.fn(async () => undefined);
+      const onError = vi.fn();
+      const { settings, posted } = createCapturedSettingsFixture({
+        ui: { showErrorMessage, onError },
+      });
+
+      expect(
+        settings.handleMessage({
+          command: SETTINGS_VIEW_COMMANDS.GET_GOAL_LIST,
+        }),
+      ).toBe(true);
+      await flushAsyncWork();
+
+      expect(onError).toHaveBeenCalledOnce();
+      expect(showErrorMessage).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `Failed to load goals: Failed to parse persisted goal for stream "${streamId}"`,
+        ),
+      );
+      expect(posted).not.toContainEqual(
+        expect.objectContaining({
+          command: SETTINGS_VIEW_COMMANDS.UPDATE_GOAL_LIST,
+        }),
+      );
+      expect(platform().workspaceState.get(goalKey)).toEqual(malformed);
+    });
+
+    it('continues initial settings delivery after a malformed goal', async () => {
+      await seedMalformedGoal();
+      const showErrorMessage = vi.fn(async () => undefined);
+      const postHistoryData = vi.fn(async () => undefined);
+      const { settings } = createSettingsFixture({
+        historySettingsController: createStubDesktopHistorySettingsController({
+          postHistoryData,
+        }),
+        ui: { showErrorMessage },
+      });
+
+      expect(
+        settings.handleMessage({
+          command: SETTINGS_VIEW_COMMANDS.WEBVIEW_READY,
+          view: 'settings',
+        }),
+      ).toBe(false);
+      await flushAsyncWork();
+
+      expect(showErrorMessage).toHaveBeenCalledOnce();
+      expect(postHistoryData).toHaveBeenCalledOnce();
     });
   });
 


### PR DESCRIPTION
## Summary

- give the existing desktop postGoalList method one owned read-and-delivery error boundary
- report malformed goal data through both the desktop log path and its visible error dialog
- keep unrelated initial settings delivery running after the goal-list failure
- preserve invalid saved data and avoid posting an invented fallback list
- remove the redundant copy of GoalStore.list(), which already returns a fresh array

## Issue acceptance gates

Closes #8967.

- valid desktop goal lists are posted unchanged
- malformed saved goals produce a visible stream-specific error
- no goal-list fallback is posted and the saved record remains untouched
- manual GET_GOAL_LIST does not throw out of the desktop dispatcher
- WEBVIEW_READY continues unrelated history/settings delivery

## Single source of truth

GoalStore remains the only persisted-data validator. The existing desktop postGoalList method now owns the host policy for reading, delivering, logging, and visibly reporting that one payload.

## Duplication and abstraction budget

No production abstraction, wrapper, export, class, interface, enum, command, or event was added. The fix deepens the existing sender and removes its redundant array copy.

## Net elements

Bug fix only: two existing files modified, zero elements added or removed. Production is +14/-6; focused regression coverage is +69.

## Consumer counts

No exported symbol or IPC contract changed. postGoalList remains consumed by the same two paths: manual GET_GOAL_LIST and initial WEBVIEW_READY delivery.

## Host impact

Desktop: goal-list corruption is visible and isolated from other settings.

Extension: unchanged; #8965 already owns the equivalent extension boundary.

CLI: unchanged.

## Changelog

No new entry. The existing unreleased shared bug-fix entry for malformed saved goals already describes the net released behavior; this PR completes that behavior for desktop without adding a commit-sequence bullet.

## Scheduled refactoring

None.

## Validation

- npm run format
- npm run typecheck
- npm run compile:fast
- npm run lint
- corepack pnpm exec vitest run src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts (21 passed)
- npm test (743 files passed, 1 skipped; 6,902 tests passed, 4 skipped)
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized desktop IPC error handling with no contract or persistence changes; only affects how corrupt goal data is reported during settings load.
> 
> **Overview**
> Desktop settings **goal list loading** now has a dedicated error boundary in `postGoalList`: failures from `GoalStore.list()` are logged and shown in a dialog (`Failed to load goals`), and **no** `UPDATE_GOAL_LIST` message is sent with a fallback.
> 
> `postGoalList` is **async** and included in the initial `WEBVIEW_READY` `Promise.all`, so a bad persisted goal does not stop other startup posts (e.g. history). The redundant `[...]` copy around `GoalStore.list()` was removed.
> 
> Regression tests cover malformed workspace goals: stream-specific error text, no list post, data unchanged, and continued initial delivery after failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a44a0c627b659981a10c38f165e0dc29492241c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->