### PR TITLE
fix(storage): make malformed child records observable

### DIFF
--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -273,9 +273,8 @@ class StorageFSKVStore extends KVStore implements ExecutionKVStore {
     const entries = await Promise.all(
       childKeys.map(async (key) => {
         const id = key.replace(CHILD_KEY_PREFIX, '') as ExecutionId;
-        const raw = await this.read(key);
-        const result = ChildRecordDataSchema.safeParse(raw);
-        return result.success ? { id, ...result.data } : null;
+        const data = await this.readValidated(key, ChildRecordDataSchema);
+        return data ? { id, ...data } : null;
       }),
     );
     return entries.filter(filterNotNull);

--- a/src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts
@@ -594,4 +594,35 @@ describe('ExecutionKVStore loud typed reads (#6966 bullet 5)', () => {
       { data: expect.any(Error) },
     );
   });
+
+  it('warns and omits a malformed child record', async () => {
+    const id = 'bad-child-record' as ExecutionId;
+    const childId = 'valid-child' as ExecutionId;
+    const store = getExecutionStore(id);
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    await store.writeChild(childId, {
+      agent: 'reviewer',
+      timestamp: '2026-07-20T00:00:00.000Z',
+    });
+    await store.write('child-malformed', {
+      agent: 42,
+      timestamp: '2026-07-20T00:00:00.000Z',
+    });
+
+    await expect(store.readChildren()).resolves.toEqual([
+      {
+        id: childId,
+        agent: 'reviewer',
+        timestamp: '2026-07-20T00:00:00.000Z',
+      },
+    ]);
+    expect(warnSpy).toHaveBeenCalledExactlyOnceWith(
+      'ExecutionKVStore',
+      expect.stringContaining(
+        `Failed to parse execution ${id} child-malformed.json`,
+      ),
+      { data: expect.any(Error) },
+    );
+  });
 });


### PR DESCRIPTION
## Root cause

`ExecutionKVStore.readChildren()` performed its own schema parse and silently filtered failures, bypassing the store's existing typed-read boundary. As a result, a malformed present child record looked the same as an absent record and left no diagnostic evidence.

## Change

- Route child records through the existing `readValidated()` boundary.
- Keep missing records quiet while warning once for malformed present records.
- Add regression coverage proving malformed children are reported and omitted while valid children remain readable.

This removes a duplicate validation path and makes the existing storage contract consistent; it does not introduce a new fallback or recovery layer.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; 1 pre-existing warning)
- `npm test` (743 files passed, 1 skipped; 6904 tests passed, 4 skipped)

Closes #8972
Follow-up to #7726
