### PR TITLE
Add recurring tech-debt tournament mechanism (issue #8758 follow-up)

### DIFF
--- a/.claude/skills/tech-debt-tournament/SKILL.md
+++ b/.claude/skills/tech-debt-tournament/SKILL.md
@@ -27,8 +27,9 @@ cursor from a previous conversation turn.
    until every page has been read, and reduce each issue to a `"#N <title>"`
    string for the `knownIssues` argument. Pull requests are not dedupe records.
 
-3. **Run the workflow.** Call `Workflow` with `name: "tech-debt-tournament"`
-   (or `scriptPath: ".claude/workflows/tech-debt-tournament.mjs"`) and args:
+3. **Run the workflow.** Call Claude Code's `Workflow` tool with
+   `name: "tech-debt-tournament"` (or
+   `scriptPath: ".claude/workflows/tech-debt-tournament.mjs"`) and args:
 
    ```text
    {
@@ -44,6 +45,10 @@ cursor from a previous conversation turn.
 
    The workflow is entirely read-only: agents may inspect the repository but
    must not edit files or run state-changing commands.
+
+   This script targets Claude Code's Workflow runtime and its inline `schema`
+   option. Do not pass it to TeXRA's separate `delegate_workflow_script` tool;
+   that host intentionally uses fixed result envelopes and JSON output files.
 
 4. **Inspect the result.** The workflow returns
    `{ campaignDate, areasThisCycle, nextCursor, toFile, contested, rejected,

--- a/.claude/skills/tech-debt-tournament/SKILL.md
+++ b/.claude/skills/tech-debt-tournament/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: tech-debt-tournament
+description: Run one cycle of the recurring tech-debt tournament — reads rotation state from the ledger issue, runs the tech-debt-tournament workflow over a small rotating slice of the codebase, files a capped number of issues, updates the ledger. Use when invoked by the scheduled routine, or when the user explicitly asks to run a tech-debt tournament cycle.
+---
+
+# Tech-debt tournament (recurring, scoped)
+
+This is the repeatable version of the campaign that produced #8758 (12 deletion
+issues, ~-1k LoC, adversarially verified). Instead of one large sweep, it runs
+in small cycles: a rotating slice of the codebase per run, a small cap on
+issues filed per run. The mechanism exists so real, verified tech-debt issues
+accumulate every few days without another 27-agent mega-campaign each time.
+
+Ledger issue: **LionSR/TeXRA#8974** — holds the rotation cursor, the
+do-not-do list, and the cycle log. Always read it fresh; never trust a cached
+cursor from a previous conversation turn.
+
+## Steps
+
+1. **Read the ledger.** `mcp__github__issue_read` (method `get`) on #8974.
+   Parse `cursor`, `rotationSize`, the `areas` order list, and the current
+   do-not-do bullet list from the body.
+
+2. **Gather known issues for dedupe.** `mcp__github__search_issues` with
+   `query: "repo:LionSR/TeXRA label:tech-debt"` (state not restricted — a
+   recently closed tech-debt issue is still a real duplicate risk). Reduce
+   each hit to `"#N <title>"` strings; that is the `knownIssues` arg.
+
+3. **Run the workflow.** Call `Workflow` with `name: "tech-debt-tournament"`
+   (or `scriptPath: ".claude/workflows/tech-debt-tournament.mjs"`) and args:
+   ```
+   {
+     campaignDate: "<today's date, YYYY-MM-DD, from environment context>",
+     cursor: <ledger cursor>,
+     rotationSize: <ledger rotationSize, default 3>,
+     knownIssues: [...],
+     doNotDo: [...ledger do-not-do bullets...],
+     maxVerify: 8,
+     maxFile: 3
+   }
+   ```
+   The workflow is entirely read-only (no edits, no state-changing commands
+   inside any spawned agent) until this point — everything so far only reads
+   the repo and GitHub.
+
+4. **Inspect the result.** The workflow returns
+   `{ campaignDate, areasThisCycle, nextCursor, toFile, carriedForward,
+   contested, rejected, newDoNotDo, droppedAsKnown, droppedAsDoNotDo, merged,
+   seamCount }`. If `toFile` is empty, skip straight to step 7 (update the
+   ledger cycle log with zero filed — a quiet cycle is a valid outcome, don't
+   force filing to hit a quota).
+
+5. **File the issues.** For each candidate in `toFile`, in the same style as
+   the child issues under #8758 (e.g. #8746): `mcp__github__issue_write`
+   method `create`, `owner: LionSR`, `repo: TeXRA`, `title` from the
+   candidate (issue-style, e.g. `refactor(scope): <what ceases to exist>
+   (~-N LoC)`), `body` = the candidate's `spec` plus a short header noting
+   `From the <campaignDate> tech-debt tournament (adversarially verified).
+   Verdict: REAL_NET_GAIN, ~-<estLoc> LoC, -<estElements> elements, risk
+   <risk>.` and append any `corrections` from the verify phase as a
+   `**Verifier corrections**` section — these are hard scope requirements,
+   not suggestions. `labels: ["tech-debt", "source:claude", "risk:<risk>"]`.
+
+6. **Create the cycle's tracking issue and attach sub-issues.** One umbrella
+   issue per cycle (mirrors #8758's shape but scaled down):
+   title `tracking: tech-debt tournament <campaignDate> (<N> deletion
+   issue(s), ~-<total LoC> LoC)`, body summarizing `areasThisCycle`, the
+   filed issues, and — briefly — what was dropped (`droppedAsKnown`,
+   `droppedAsDoNotDo`, `contested`, `carriedForward`) so a human skimming it
+   understands why the count is small. Then `mcp__github__sub_issue_write`
+   method `add` for each filed issue under this tracking issue.
+
+7. **Update the ledger issue (#8974).** `mcp__github__issue_write` method
+   `update` on #8974:
+   - Set `cursor` to the workflow's `nextCursor`.
+   - Append any `newDoNotDo` entries to the do-not-do list (dedupe against
+     what's already there — don't duplicate an entry).
+   - Append one row to the cycle log table: date, `areasThisCycle`, filed
+     issue numbers, `carriedForward` titles (if any), new do-not-do entries
+     (if any).
+   - Keep the rest of the body intact — this is an update, not a rewrite of
+     the working rules section.
+
+8. **Report.** One short message: date, areas covered this cycle, links to
+   the filed issues and tracking issue (or "quiet cycle, nothing survived
+   verification" if `toFile` was empty), and the new cursor position for
+   context on what's next.
+
+## Guardrails
+
+- Never raise `maxFile`/`maxVerify`/`rotationSize` above the SKILL defaults
+  without the user explicitly asking for a bigger cycle — the whole point of
+  this mechanism is small, steady, low-drama batches, not recreating the
+  #8758 mega-campaign every few days.
+- Do not push any code in this skill. The tournament only produces issues;
+  implementing them is separate work (a normal PR-per-issue flow, same rules
+  as #8758's "Working rules for this campaign" section).
+- If `mcp__github__search_issues` or the ledger read fails, stop and report
+  rather than guessing at cursor/dedupe state — filing duplicate or
+  already-adjudicated issues is worse than skipping a cycle.

--- a/.claude/skills/tech-debt-tournament/SKILL.md
+++ b/.claude/skills/tech-debt-tournament/SKILL.md
@@ -17,78 +17,86 @@ cursor from a previous conversation turn.
 
 ## Steps
 
-1. **Read the ledger.** `mcp__github__issue_read` (method `get`) on #8974.
-   Parse `cursor`, `rotationSize`, the `areas` order list, and the current
-   do-not-do bullet list from the body.
+1. **Read the ledger.** Call `mcp__github__get_issue` for #8974. Parse
+   `cursor`, `rotationSize`, the ordered `areas` list, and the current
+   do-not-do bullets from the body.
 
-2. **Gather known issues for dedupe.** `mcp__github__search_issues` with
-   `query: "repo:LionSR/TeXRA label:tech-debt"` (state not restricted — a
-   recently closed tech-debt issue is still a real duplicate risk). Reduce
-   each hit to `"#N <title>"` strings; that is the `knownIssues` arg.
+2. **Gather known issues for dedupe.** Call `mcp__github__search_issues` with
+   `query: "repo:LionSR/TeXRA is:issue label:tech-debt"`. Do not restrict
+   state: a recently closed issue remains a duplicate risk. Follow pagination
+   until every page has been read, and reduce each issue to a `"#N <title>"`
+   string for the `knownIssues` argument. Pull requests are not dedupe records.
 
 3. **Run the workflow.** Call `Workflow` with `name: "tech-debt-tournament"`
    (or `scriptPath: ".claude/workflows/tech-debt-tournament.mjs"`) and args:
-   ```
+
+   ```text
    {
      campaignDate: "<today's date, YYYY-MM-DD, from environment context>",
      cursor: <ledger cursor>,
      rotationSize: <ledger rotationSize, default 3>,
+     areas: [...ledger area names in their persisted order...],
      knownIssues: [...],
      doNotDo: [...ledger do-not-do bullets...],
-     maxVerify: 8,
      maxFile: 3
    }
    ```
-   The workflow is entirely read-only (no edits, no state-changing commands
-   inside any spawned agent) until this point — everything so far only reads
-   the repo and GitHub.
+
+   The workflow is entirely read-only: agents may inspect the repository but
+   must not edit files or run state-changing commands.
 
 4. **Inspect the result.** The workflow returns
-   `{ campaignDate, areasThisCycle, nextCursor, toFile, carriedForward,
-   contested, rejected, newDoNotDo, droppedAsKnown, droppedAsDoNotDo, merged,
-   seamCount }`. If `toFile` is empty, skip straight to step 7 (update the
-   ledger cycle log with zero filed — a quiet cycle is a valid outcome, don't
-   force filing to hit a quota).
+   `{ campaignDate, areasThisCycle, nextCursor, toFile, contested, rejected,
+   newDoNotDo, droppedAsKnown, droppedAsDoNotDo, merged, seamCount }`. If
+   `toFile` is empty, skip to step 7 and record a quiet cycle. Do not force a
+   candidate through to meet a quota. Any candidate with a verifier correction
+   is `CONTESTED`, so every `toFile` spec survived with its scope and estimates
+   unchanged.
 
-5. **File the issues.** For each candidate in `toFile`, in the same style as
-   the child issues under #8758 (e.g. #8746): `mcp__github__issue_write`
-   method `create`, `owner: LionSR`, `repo: TeXRA`, `title` from the
-   candidate (issue-style, e.g. `refactor(scope): <what ceases to exist>
-   (~-N LoC)`), `body` = the candidate's `spec` plus a short header noting
-   `From the <campaignDate> tech-debt tournament (adversarially verified).
-   Verdict: REAL_NET_GAIN, ~-<estLoc> LoC, -<estElements> elements, risk
-   <risk>.` and append any `corrections` from the verify phase as a
-   `**Verifier corrections**` section — these are hard scope requirements,
-   not suggestions. `labels: ["tech-debt", "source:claude", "risk:<risk>"]`.
+5. **Create the tracking issue first.** This makes a partially completed run
+   recoverable. Call `mcp__github__create_issue` with:
 
-6. **Create the cycle's tracking issue and attach sub-issues.** One umbrella
-   issue per cycle (mirrors #8758's shape but scaled down):
-   title `tracking: tech-debt tournament <campaignDate> (<N> deletion
-   issue(s), ~-<total LoC> LoC)`, body summarizing `areasThisCycle`, the
-   filed issues, and — briefly — what was dropped (`droppedAsKnown`,
-   `droppedAsDoNotDo`, `contested`, `carriedForward`) so a human skimming it
-   understands why the count is small. Then `mcp__github__sub_issue_write`
-   method `add` for each filed issue under this tracking issue.
+   - Title: `Tracking: tech-debt tournament <campaignDate> (<N> deletion issue(s), ~-<total LoC> LoC)`.
+   - Labels: `tracking`, `tech-debt`, and `source:claude`.
+   - Body: `areasThisCycle` plus the planned child titles.
 
-7. **Update the ledger issue (#8974).** `mcp__github__issue_write` method
-   `update` on #8974:
-   - Set `cursor` to the workflow's `nextCursor`.
-   - Append any `newDoNotDo` entries to the do-not-do list (dedupe against
-     what's already there — don't duplicate an entry).
-   - Append one row to the cycle log table: date, `areasThisCycle`, filed
-     issue numbers, `carriedForward` titles (if any), new do-not-do entries
-     (if any).
-   - Keep the rest of the body intact — this is an update, not a rewrite of
-     the working rules section.
+   Capture the tracking issue number and integer REST database `id`; the `id`
+   is not its issue number and not its GraphQL `node_id`.
 
-8. **Report.** One short message: date, areas covered this cycle, links to
-   the filed issues and tracking issue (or "quiet cycle, nothing survived
-   verification" if `toFile` was empty), and the new cursor position for
-   context on what's next.
+6. **Create and attach each child.** For each candidate in `toFile`, call
+   `mcp__github__create_issue` in the style of #8758's children (for example,
+   #8746):
+
+   - Use the candidate title and spec.
+   - Prefix the body with `From the <campaignDate> tech-debt tournament
+     (adversarially verified). Verdict: REAL_NET_GAIN, ~-<estLoc> LoC,
+     -<estElements> elements, risk <risk>.`
+   - Apply `tech-debt`, `source:claude`, and `risk:<risk>` labels.
+
+   Capture the child's issue number and integer REST database `id`, then call
+   `mcp__github__add_sub_issue` with the tracking issue number and
+   `sub_issue_id: <child id>`. After every child is attached, call
+   `mcp__github__update_issue` to replace the tracking issue's planned list
+   with filed issue links and summarize `droppedAsKnown`, `droppedAsDoNotDo`,
+   and `contested` so a human can see why the cycle remained small.
+
+7. **Update ledger issue #8974.** Only after all creates and attachments
+   succeed, call `mcp__github__update_issue`:
+
+   - Set `cursor` to `nextCursor`.
+   - Append the plain-string `newDoNotDo` entries, deduplicated against the
+     existing do-not-do bullets.
+   - Append one cycle-log row with the date, `areasThisCycle`, filed issue
+     numbers, and new do-not-do entries.
+   - Preserve the rest of the body exactly.
+
+8. **Report.** Return the date, areas covered, links to the filed children and
+   tracking issue (or `quiet cycle, nothing survived verification`), and the
+   next cursor.
 
 ## Guardrails
 
-- Never raise `maxFile`/`maxVerify`/`rotationSize` above the SKILL defaults
+- Never raise `maxFile` or `rotationSize` above the skill defaults
   without the user explicitly asking for a bigger cycle — the whole point of
   this mechanism is small, steady, low-drama batches, not recreating the
   #8758 mega-campaign every few days.
@@ -98,3 +106,6 @@ cursor from a previous conversation turn.
 - If `mcp__github__search_issues` or the ledger read fails, stop and report
   rather than guessing at cursor/dedupe state — filing duplicate or
   already-adjudicated issues is worse than skipping a cycle.
+- If a child create or attachment fails, do not advance the ledger and do not
+  restart from scratch. Report the existing tracking issue and use its planned
+  child list to resume only the missing create or attach operations.

--- a/.claude/workflows/tech-debt-tournament.mjs
+++ b/.claude/workflows/tech-debt-tournament.mjs
@@ -3,7 +3,7 @@ export const meta = {
   description:
     'Recurring tech-debt tournament: seam mappers over a ROTATING slice of areas, architect lenses propose deletions, dedupe against known issues + do-not-do ledger, adversarial net-gain verification, output capped to a few issues per cycle.',
   whenToUse:
-    'Invoked by the tech-debt-tournament skill (scheduled campaign). Args: { campaignDate, cursor?, rotationSize?, knownIssues?, doNotDo?, areas?, maxFile? }. Deliberately scoped small per run (a handful of areas, a few issues filed) — breadth comes from repeated cycles rotating through areas, not from one large sweep.',
+    'Claude Code Workflow script invoked by the tech-debt-tournament skill (scheduled campaign); this is not a TeXRA delegate_workflow_script. Args: { campaignDate, cursor?, rotationSize?, knownIssues?, doNotDo?, areas?, maxFile? }. Deliberately scoped small per run (a handful of areas, a few issues filed) — breadth comes from repeated cycles rotating through areas, not from one large sweep.',
   phases: [
     { title: 'Map', detail: 'one read-only seam mapper per rotated area' },
     { title: 'Propose', detail: 'four architect lenses over all maps' },

--- a/.claude/workflows/tech-debt-tournament.mjs
+++ b/.claude/workflows/tech-debt-tournament.mjs
@@ -1,0 +1,386 @@
+export const meta = {
+  name: 'tech-debt-tournament',
+  description:
+    'Recurring tech-debt tournament: seam mappers over a ROTATING slice of areas, architect lenses propose deletions, dedupe against known issues + do-not-do ledger, adversarial net-gain verification, output capped to a few issues per cycle.',
+  whenToUse:
+    'Invoked by the tech-debt-tournament skill (scheduled campaign). Args: { campaignDate, cursor?, rotationSize?, knownIssues?, doNotDo?, areas?, maxVerify?, maxFile? }. Deliberately scoped small per run (a handful of areas, a few issues filed) — breadth comes from repeated cycles rotating through areas, not from one large sweep.',
+  phases: [
+    { title: 'Map', detail: 'one read-only seam mapper per rotated area' },
+    { title: 'Propose', detail: 'four architect lenses over all maps' },
+    { title: 'Dedupe', detail: 'merge + drop known issues and adjudicated do-not-dos' },
+    { title: 'Verify', detail: 'three adversarial refuters per candidate; majority refute kills' },
+  ],
+}
+
+// The driver (skill) passes campaignDate because Date is unavailable inside workflow scripts.
+const campaignDate = (args && args.campaignDate) || 'unknown-date'
+const knownIssues = (args && args.knownIssues) || [] // ["#8746 refactor(logger): ...", ...]
+const doNotDo = (args && args.doNotDo) || [] // ledger entries: adjudicated NET_LOSS / held-back items
+const MAX_VERIFY = (args && args.maxVerify) || 8
+// Hard cap on issues actually recommended for filing this cycle. Keep this small —
+// the point of running every few days is a steady trickle, not another 12-issue/-1k-LoC
+// mega campaign each time. Extra REAL_NET_GAIN survivors are returned as carriedForward,
+// not filed, so they aren't lost but also don't overshoot this cycle.
+const MAX_FILE = (args && args.maxFile) || 3
+
+const ALL_AREAS = [
+  { name: 'agent-runtime', paths: ['src/agent/runtime/', 'src/agent/core/'] },
+  { name: 'model-handlers', paths: ['src/agent/modelHandlers/', 'src/model/'] },
+  { name: 'flows-tools', paths: ['src/agent/implementations/', 'src/tools/'] },
+  { name: 'platform-infra', paths: ['src/platform/', 'src/logger/', 'src/eventBus/', 'src/utils/'] },
+  { name: 'storage-transcript', paths: ['src/agent/storage/', 'src/agent/trace/', 'src/transcript/'] },
+  { name: 'controllers-shared', paths: ['src/controllers/', 'src/shared/', 'src/hosts/'] },
+  { name: 'extension-host', paths: ['packages/extension/src/commands/', 'packages/extension/src/*.ts'] },
+  { name: 'webviews', paths: ['packages/extension/src/webview/', 'packages/extension/src/progressView/', 'packages/extension/src/settingsView/'] },
+  { name: 'cli', paths: ['packages/cli/src/'] },
+  { name: 'desktop', paths: ['packages/desktop/src/'] },
+]
+
+// Rotate a small slice of areas per cycle instead of sweeping the whole repo every run.
+// The driving skill persists `cursor` (a GitHub ledger issue) and advances it by
+// rotationSize each cycle, so full coverage happens over several cycles, not one.
+function rotateAreas(all, cursor, size) {
+  const start = ((cursor % all.length) + all.length) % all.length
+  const picked = []
+  for (let i = 0; i < Math.min(size, all.length); i++) picked.push(all[(start + i) % all.length])
+  return picked
+}
+
+const rotationSize = (args && args.rotationSize) || 3
+const cursor = (args && args.cursor) || 0
+const areas = (args && args.areas) || rotateAreas(ALL_AREAS, cursor, rotationSize)
+
+const SEAM_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    area: { type: 'string' },
+    seams: {
+      type: 'array',
+      maxItems: 15,
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          kind: {
+            type: 'string',
+            enum: [
+              'pass-through',
+              'dead-or-vestigial',
+              'ritual',
+              'duplicated-pipeline',
+              'legacy-arm',
+              'single-caller-helper',
+              'coupling-violation',
+              'config-never-set',
+              'other',
+            ],
+          },
+          what: { type: 'string', description: 'one sentence: the seam and why it smells' },
+          evidence: { type: 'string', description: 'file:line citations plus the grep/git command that proves it' },
+          estLoc: { type: 'number', description: 'estimated LoC removable (positive number)' },
+        },
+        required: ['kind', 'what', 'evidence', 'estLoc'],
+      },
+    },
+    healthy: { type: 'string', description: 'what you checked that is clean, so lenses do not waste time there' },
+  },
+  required: ['area', 'seams', 'healthy'],
+}
+
+function mapperPrompt(area) {
+  return [
+    `READ-ONLY seam-mapping task on the TeXRA repo (tech-debt tournament ${campaignDate}). DO NOT EDIT ANY FILE; run no state-changing commands.`,
+    ``,
+    `Map tech-debt seams in the "${area.name}" area: ${area.paths.join(', ')}`,
+    ``,
+    `Hunt for, with hard evidence (file:line, caller counts via ripgrep, LoC via wc/awk):`,
+    `- pass-throughs and one-call factories (the repo's abstraction-cost guardrails in CLAUDE.md/AGENTS.md)`,
+    `- dead or vestigial code: exports with zero callers, config knobs never set, feature arms never taken`,
+    `- rituals: call sites that all invoke something whose body is a no-op or already-lazy (e.g. the deleted logger.initialize ritual, #8746)`,
+    `- duplicated pipelines: the same concept implemented N times where one implementation could serve`,
+    `- legacy arms: dual-write/dual-read paths, migration leftovers, deprecated formats still branched on`,
+    `- coupling violations: vscode imports or host leakage inside VS Code-free zones (see CLAUDE.md list)`,
+    ``,
+    `Rules: max 15 seams, quality over quantity, each needs verifiable evidence you actually collected (run the greps; do not estimate from memory). Prefer deletion-shaped findings — the campaign currency is negative LoC and removed named elements. Note explicitly what you checked and found healthy.`,
+  ].join('\n')
+}
+
+const CANDIDATE_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    lens: { type: 'string' },
+    candidates: {
+      type: 'array',
+      maxItems: 8,
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          title: { type: 'string', description: 'issue-style title: refactor(scope): <what ceases to exist> (~-N LoC)' },
+          spec: { type: 'string', description: 'the full work spec: what ceases to exist (exact symbols/files), why zero or acceptable observable change, sequencing constraints' },
+          estLoc: { type: 'number', description: 'estimated net LoC removed (positive number)' },
+          estElements: { type: 'number', description: 'estimated named elements removed' },
+          risk: { type: 'string', enum: ['low', 'medium', 'high'] },
+          files: { type: 'array', items: { type: 'string' } },
+          area: { type: 'string' },
+        },
+        required: ['title', 'spec', 'estLoc', 'estElements', 'risk', 'files', 'area'],
+      },
+    },
+  },
+  required: ['lens', 'candidates'],
+}
+
+const LENSES = [
+  {
+    key: 'deletion-first',
+    brief:
+      'What can simply cease to exist? Favor candidates where the fix is deletion plus mechanical call-site cleanup, no replacement machinery. Reject anything whose "fix" adds a new abstraction.',
+  },
+  {
+    key: 'abstraction-cost',
+    brief:
+      'Apply the repo abstraction-cost guardrails: single-caller extractions, identity factories, pass-through layers, ports/facades that never earned a second implementation. Each candidate must name the caller-count grep that proves it.',
+  },
+  {
+    key: 'duplication',
+    brief:
+      'Same concept implemented N times (pipelines, encodings, vocabularies, state shapes). Only propose unification when one existing implementation can absorb the others with net-negative LoC — never a new third implementation.',
+  },
+  {
+    key: 'legacy-retirement',
+    brief:
+      'Dual-write/dual-read arms, migration leftovers, deprecated formats, decision reversals whose losing branch still ships. Candidates must state the compatibility story (persisted data, resume paths, headless parity).',
+  },
+]
+
+function lensPrompt(lens, mapsJson) {
+  return [
+    `READ-ONLY architect task on the TeXRA repo (tech-debt tournament ${campaignDate}). DO NOT EDIT ANY FILE.`,
+    ``,
+    `Lens: ${lens.key}. ${lens.brief}`,
+    ``,
+    `Below are seam maps produced by per-area mappers this run. Turn the strongest seams matching your lens into concrete, issue-ready deletion/refactor candidates. Re-verify every citation in the actual source before including it — mappers can be wrong, and a candidate with unverified evidence is worthless. You may also add candidates the mappers missed, if you verify them yourself.`,
+    ``,
+    `Seam maps:`,
+    mapsJson,
+    ``,
+    `Bar for inclusion: net LoC strictly negative after accounting for replacement code; behavior-preserving (or the behavior change is spelled out and trivially acceptable); spec concrete enough that an implementer needs no further discovery. Max 8 candidates; fewer strong ones beat many weak ones. Zero candidates is a valid answer.`,
+  ].join('\n')
+}
+
+const DEDUPE_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    kept: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          title: { type: 'string' },
+          spec: { type: 'string' },
+          estLoc: { type: 'number' },
+          estElements: { type: 'number' },
+          risk: { type: 'string', enum: ['low', 'medium', 'high'] },
+          files: { type: 'array', items: { type: 'string' } },
+          area: { type: 'string' },
+        },
+        required: ['title', 'spec', 'estLoc', 'estElements', 'risk', 'files', 'area'],
+      },
+    },
+    droppedAsKnown: { type: 'array', items: { type: 'string' }, description: 'candidate title -> which known issue it duplicates' },
+    droppedAsDoNotDo: { type: 'array', items: { type: 'string' }, description: 'candidate title -> which ledger entry bans it' },
+    merged: { type: 'array', items: { type: 'string' }, description: 'notes on candidates merged into one' },
+  },
+  required: ['kept', 'droppedAsKnown', 'droppedAsDoNotDo', 'merged'],
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    refuted: { type: 'boolean' },
+    confidence: { type: 'string', enum: ['low', 'medium', 'high'] },
+    reason: { type: 'string' },
+    corrections: {
+      type: 'string',
+      description: 'scope corrections an implementer MUST honor even if the candidate survives (e.g. "the 78-hit grep includes one doc comment"). Empty string if none.',
+    },
+  },
+  required: ['refuted', 'confidence', 'reason', 'corrections'],
+}
+
+const REFUTER_LENSES = [
+  {
+    key: 'net-loc',
+    brief:
+      'Attack the accounting. Recount callers with your own greps, price the replacement code honestly, include test churn. Refute if net LoC is not clearly negative or the element count is inflated.',
+  },
+  {
+    key: 'behavior-risk',
+    brief:
+      'Attack behavior preservation. Hunt for observable changes: persisted formats, resume/compatibilityKey paths, headless parity (texra run / --print byte-identical), webview contracts, error surfaces. Refute if any unaccounted observable change exists.',
+  },
+  {
+    key: 'load-bearing-precedent',
+    brief:
+      'Attack the premise. Is the indirection a contract (Platform port, PocketFlow hook, test seam)? Was this tried and reverted (search git log), or adjudicated in docs/proposals or the do-not-do ledger? Refute if the seam is load-bearing or previously rejected.',
+  },
+]
+
+function refuterPrompt(candidate, lens) {
+  return [
+    `READ-ONLY adversarial verification on the TeXRA repo. DO NOT EDIT ANY FILE. Your job is to REFUTE this tech-debt candidate; it only ships if it survives you. Default to refuted=true when uncertain.`,
+    ``,
+    `Refutation lens: ${lens.key}. ${lens.brief}`,
+    ``,
+    `Candidate: ${candidate.title}`,
+    `Claimed: ~-${candidate.estLoc} LoC, -${candidate.estElements} elements, risk ${candidate.risk}`,
+    `Files: ${candidate.files.join(', ')}`,
+    `Spec:`,
+    candidate.spec,
+    ``,
+    `Verify every claim against the actual source at HEAD. If the candidate survives but you found the spec's numbers or scope wrong, put the mandatory fixes in "corrections".`,
+  ].join('\n')
+}
+
+// ---- Phase 1: Map ----------------------------------------------------------
+phase('Map')
+log(
+  `Tournament ${campaignDate}: mapping ${areas.length} rotated area(s) [${areas.map((a) => a.name).join(', ')}] (cursor=${cursor}); ${knownIssues.length} known issues and ${doNotDo.length} ledger entries loaded for dedupe`,
+)
+
+const maps = (
+  await parallel(
+    areas.map((area) => () =>
+      agent(mapperPrompt(area), { label: `map:${area.name}`, phase: 'Map', schema: SEAM_SCHEMA }),
+    ),
+  )
+).filter(Boolean)
+
+const totalSeams = maps.reduce((n, m) => n + m.seams.length, 0)
+log(`Mapping done: ${totalSeams} seams across ${maps.length}/${areas.length} areas`)
+
+// ---- Phase 2: Propose (barrier justified: every lens reads all maps) -------
+phase('Propose')
+const mapsJson = JSON.stringify(
+  maps.map((m) => ({ area: m.area, seams: m.seams })),
+  null,
+  1,
+)
+
+const lensResults = (
+  await parallel(
+    LENSES.map((lens) => () =>
+      agent(lensPrompt(lens, mapsJson), { label: `lens:${lens.key}`, phase: 'Propose', schema: CANDIDATE_SCHEMA }),
+    ),
+  )
+).filter(Boolean)
+
+const rawCandidates = lensResults.flatMap((r) => r.candidates.map((c) => ({ ...c, lens: r.lens })))
+log(`Lenses proposed ${rawCandidates.length} raw candidates`)
+
+// ---- Phase 3: Dedupe (barrier justified: needs the full candidate set) -----
+phase('Dedupe')
+const dedupe = rawCandidates.length
+  ? await agent(
+      [
+        `Merge and dedupe tech-debt candidates for the TeXRA tournament ${campaignDate}. READ-ONLY; no edits.`,
+        ``,
+        `1. Merge near-duplicate candidates (same deletion proposed by different lenses) into the single strongest spec.`,
+        `2. Drop any candidate that duplicates an EXISTING issue below (report which). Titles will not match verbatim — judge by substance, and check the issue on GitHub or in the repo docs when unsure.`,
+        `3. Drop any candidate banned by the DO-NOT-DO ledger below (report which). Ledger entries are adjudicated verdicts; do not relitigate them here.`,
+        ``,
+        `Existing issues:`,
+        knownIssues.length ? knownIssues.map((s) => `- ${s}`).join('\n') : '- (none provided)',
+        ``,
+        `Do-not-do ledger:`,
+        doNotDo.length ? doNotDo.map((s) => `- ${s}`).join('\n') : '- (none provided)',
+        ``,
+        `Candidates (JSON):`,
+        JSON.stringify(rawCandidates, null, 1),
+      ].join('\n'),
+      { label: 'dedupe', phase: 'Dedupe', schema: DEDUPE_SCHEMA },
+    )
+  : { kept: [], droppedAsKnown: [], droppedAsDoNotDo: [], merged: [] }
+
+const ranked = [...dedupe.kept].sort((a, b) => b.estLoc - a.estLoc)
+const toVerify = ranked.slice(0, MAX_VERIFY)
+if (ranked.length > toVerify.length) {
+  log(`Capping verification at ${MAX_VERIFY}: dropping ${ranked.length - toVerify.length} lowest-LoC candidates: ${ranked
+    .slice(MAX_VERIFY)
+    .map((c) => c.title)
+    .join(' | ')}`)
+}
+log(`Dedupe done: ${dedupe.kept.length} kept, ${dedupe.droppedAsKnown.length} already tracked, ${dedupe.droppedAsDoNotDo.length} ledger-banned; verifying ${toVerify.length}`)
+
+// ---- Phase 4: Verify (pipeline: each candidate verifies independently) -----
+phase('Verify')
+const verified = await pipeline(toVerify, (candidate) =>
+  parallel(
+    REFUTER_LENSES.map((lens) => () =>
+      agent(refuterPrompt(candidate, lens), {
+        label: `verify:${lens.key}:${candidate.area}`,
+        phase: 'Verify',
+        schema: VERDICT_SCHEMA,
+      }),
+    ),
+  ).then((votes) => {
+    const cast = votes.filter(Boolean)
+    const refutes = cast.filter((v) => v.refuted)
+    return {
+      ...candidate,
+      verdict: cast.length >= 2 && refutes.length === 0 ? 'REAL_NET_GAIN' : refutes.length >= 2 ? 'NET_LOSS' : 'CONTESTED',
+      votes: cast,
+      corrections: cast.map((v) => v.corrections).filter((s) => s && s.trim()),
+    }
+  }),
+)
+
+const allSurvivors = verified.filter(Boolean).filter((c) => c.verdict === 'REAL_NET_GAIN')
+const rejected = verified.filter(Boolean).filter((c) => c.verdict === 'NET_LOSS')
+const contested = verified.filter(Boolean).filter((c) => c.verdict === 'CONTESTED')
+
+// Don't overshoot: file only the smallest/lowest-risk MAX_FILE survivors this cycle.
+// Smaller, easier-to-review PRs land faster than a wall of simultaneous refactors;
+// larger or lower-priority survivors carry over to be re-proposed (post-dedupe) next cycle.
+const riskRank = { low: 0, medium: 1, high: 2 }
+const bySafetyThenSize = [...allSurvivors].sort(
+  (a, b) => riskRank[a.risk] - riskRank[b.risk] || a.estLoc - b.estLoc,
+)
+const toFile = bySafetyThenSize.slice(0, MAX_FILE)
+const carriedForward = bySafetyThenSize.slice(MAX_FILE)
+if (carriedForward.length) {
+  log(`Filing cap ${MAX_FILE}: carrying ${carriedForward.length} verified survivor(s) forward instead of filing this cycle: ${carriedForward.map((c) => c.title).join(' | ')}`)
+}
+
+// NET_LOSS with a confident majority becomes a ledger entry so future sweeps stop re-proposing it.
+const newDoNotDo = rejected
+  .filter((c) => c.votes.filter((v) => v.refuted && v.confidence !== 'low').length >= 2)
+  .map((c) => ({
+    entry: `${c.title}: NET_LOSS (tournament ${campaignDate})`,
+    reasons: c.votes.filter((v) => v.refuted).map((v) => v.reason),
+  }))
+
+log(
+  `Verification done: ${allSurvivors.length} REAL_NET_GAIN (${toFile.length} to file, ~-${toFile.reduce((n, c) => n + c.estLoc, 0)} LoC), ${rejected.length} NET_LOSS, ${contested.length} contested (not filed)`,
+)
+
+return {
+  campaignDate,
+  areasThisCycle: areas.map((a) => a.name),
+  nextCursor: cursor + rotationSize,
+  toFile,
+  carriedForward,
+  contested,
+  rejected,
+  newDoNotDo,
+  droppedAsKnown: dedupe.droppedAsKnown,
+  droppedAsDoNotDo: dedupe.droppedAsDoNotDo,
+  merged: dedupe.merged,
+  seamCount: totalSeams,
+}

--- a/.claude/workflows/tech-debt-tournament.mjs
+++ b/.claude/workflows/tech-debt-tournament.mjs
@@ -3,7 +3,7 @@ export const meta = {
   description:
     'Recurring tech-debt tournament: seam mappers over a ROTATING slice of areas, architect lenses propose deletions, dedupe against known issues + do-not-do ledger, adversarial net-gain verification, output capped to a few issues per cycle.',
   whenToUse:
-    'Invoked by the tech-debt-tournament skill (scheduled campaign). Args: { campaignDate, cursor?, rotationSize?, knownIssues?, doNotDo?, areas?, maxVerify?, maxFile? }. Deliberately scoped small per run (a handful of areas, a few issues filed) — breadth comes from repeated cycles rotating through areas, not from one large sweep.',
+    'Invoked by the tech-debt-tournament skill (scheduled campaign). Args: { campaignDate, cursor?, rotationSize?, knownIssues?, doNotDo?, areas?, maxFile? }. Deliberately scoped small per run (a handful of areas, a few issues filed) — breadth comes from repeated cycles rotating through areas, not from one large sweep.',
   phases: [
     { title: 'Map', detail: 'one read-only seam mapper per rotated area' },
     { title: 'Propose', detail: 'four architect lenses over all maps' },
@@ -12,16 +12,50 @@ export const meta = {
   ],
 }
 
-// The driver (skill) passes campaignDate because Date is unavailable inside workflow scripts.
-const campaignDate = (args && args.campaignDate) || 'unknown-date'
-const knownIssues = (args && args.knownIssues) || [] // ["#8746 refactor(logger): ...", ...]
-const doNotDo = (args && args.doNotDo) || [] // ledger entries: adjudicated NET_LOSS / held-back items
-const MAX_VERIFY = (args && args.maxVerify) || 8
-// Hard cap on issues actually recommended for filing this cycle. Keep this small —
-// the point of running every few days is a steady trickle, not another 12-issue/-1k-LoC
-// mega campaign each time. Extra REAL_NET_GAIN survivors are returned as carriedForward,
-// not filed, so they aren't lost but also don't overshoot this cycle.
-const MAX_FILE = (args && args.maxFile) || 3
+const input = args && typeof args === 'object' ? args : {}
+
+function readInteger(name, fallback, min, max = Number.MAX_SAFE_INTEGER) {
+  const value = input[name]
+  if (value == null) return fallback
+  if (
+    (typeof value !== 'number' && typeof value !== 'string') ||
+    (typeof value === 'string' && !value.trim())
+  ) {
+    throw new Error(`${name} must be a number or numeric string`)
+  }
+  const parsed = Number(value)
+  if (!Number.isSafeInteger(parsed) || parsed < min || parsed > max) {
+    throw new Error(`${name} must be an integer between ${min} and ${max}; received ${String(value)}`)
+  }
+  return parsed
+}
+
+function readStringArray(name, fallback = []) {
+  const value = input[name]
+  if (value == null) return fallback
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== 'string' || !entry.trim())) {
+    throw new Error(`${name} must be an array of non-empty strings`)
+  }
+  return value
+}
+
+function requireStageResults(results, stage) {
+  const missingIndex = results.findIndex((result) => !result)
+  if (missingIndex !== -1) {
+    throw new Error(`${stage} agent ${missingIndex + 1}/${results.length} returned no result; aborting the cycle`)
+  }
+  return results
+}
+
+// The driver passes campaignDate because Date is unavailable inside workflow scripts.
+const campaignDate = typeof input.campaignDate === 'string' && input.campaignDate.trim()
+  ? input.campaignDate
+  : 'unknown-date'
+const knownIssues = readStringArray('knownIssues') // ["#8746 refactor(logger): ...", ...]
+const doNotDo = readStringArray('doNotDo') // adjudicated NET_LOSS / held-back ledger entries
+// One cap owns both verification fan-out and issue filing. With the default, a cycle
+// launches at most 3 mappers + 4 lenses + 1 deduper + 9 refuters = 17 agents.
+const MAX_FILE = readInteger('maxFile', 3, 1, 8)
 
 const ALL_AREAS = [
   { name: 'agent-runtime', paths: ['src/agent/runtime/', 'src/agent/core/'] },
@@ -30,7 +64,15 @@ const ALL_AREAS = [
   { name: 'platform-infra', paths: ['src/platform/', 'src/logger/', 'src/eventBus/', 'src/utils/'] },
   { name: 'storage-transcript', paths: ['src/agent/storage/', 'src/agent/trace/', 'src/transcript/'] },
   { name: 'controllers-shared', paths: ['src/controllers/', 'src/shared/', 'src/hosts/'] },
-  { name: 'extension-host', paths: ['packages/extension/src/commands/', 'packages/extension/src/*.ts'] },
+  {
+    name: 'extension-host',
+    paths: [
+      'packages/extension/src/commands/',
+      'packages/extension/src/MainViewProvider.ts',
+      'packages/extension/src/commands.ts',
+      'packages/extension/src/extension.ts',
+    ],
+  },
   { name: 'webviews', paths: ['packages/extension/src/webview/', 'packages/extension/src/progressView/', 'packages/extension/src/settingsView/'] },
   { name: 'cli', paths: ['packages/cli/src/'] },
   { name: 'desktop', paths: ['packages/desktop/src/'] },
@@ -46,9 +88,24 @@ function rotateAreas(all, cursor, size) {
   return picked
 }
 
-const rotationSize = (args && args.rotationSize) || 3
-const cursor = (args && args.cursor) || 0
-const areas = (args && args.areas) || rotateAreas(ALL_AREAS, cursor, rotationSize)
+const areaByName = new Map(ALL_AREAS.map((area) => [area.name, area]))
+const areaNames = readStringArray(
+  'areas',
+  ALL_AREAS.map((area) => area.name),
+)
+if (new Set(areaNames).size !== areaNames.length) {
+  throw new Error('areas must not contain duplicate names')
+}
+const orderedAreas = areaNames.map((name) => {
+  const area = areaByName.get(name)
+  if (!area) throw new Error(`Unknown tournament area: ${name}`)
+  return area
+})
+if (!orderedAreas.length) throw new Error('areas must contain at least one configured area')
+
+const rotationSize = readInteger('rotationSize', 3, 1, orderedAreas.length)
+const cursor = readInteger('cursor', 0, 0)
+const areas = rotateAreas(orderedAreas, cursor, rotationSize)
 
 const SEAM_SCHEMA = {
   type: 'object',
@@ -208,7 +265,7 @@ const VERDICT_SCHEMA = {
     reason: { type: 'string' },
     corrections: {
       type: 'string',
-      description: 'scope corrections an implementer MUST honor even if the candidate survives (e.g. "the 78-hit grep includes one doc comment"). Empty string if none.',
+      description: 'mandatory scope or estimate correction; any non-empty value makes the candidate contested and not fileable. Empty string if none.',
     },
   },
   required: ['refuted', 'confidence', 'reason', 'corrections'],
@@ -254,13 +311,14 @@ log(
   `Tournament ${campaignDate}: mapping ${areas.length} rotated area(s) [${areas.map((a) => a.name).join(', ')}] (cursor=${cursor}); ${knownIssues.length} known issues and ${doNotDo.length} ledger entries loaded for dedupe`,
 )
 
-const maps = (
+const maps = requireStageResults(
   await parallel(
     areas.map((area) => () =>
       agent(mapperPrompt(area), { label: `map:${area.name}`, phase: 'Map', schema: SEAM_SCHEMA }),
     ),
-  )
-).filter(Boolean)
+  ),
+  'Map',
+)
 
 const totalSeams = maps.reduce((n, m) => n + m.seams.length, 0)
 log(`Mapping done: ${totalSeams} seams across ${maps.length}/${areas.length} areas`)
@@ -273,13 +331,14 @@ const mapsJson = JSON.stringify(
   1,
 )
 
-const lensResults = (
+const lensResults = requireStageResults(
   await parallel(
     LENSES.map((lens) => () =>
       agent(lensPrompt(lens, mapsJson), { label: `lens:${lens.key}`, phase: 'Propose', schema: CANDIDATE_SCHEMA }),
     ),
-  )
-).filter(Boolean)
+  ),
+  'Propose',
+)
 
 const rawCandidates = lensResults.flatMap((r) => r.candidates.map((c) => ({ ...c, lens: r.lens })))
 log(`Lenses proposed ${rawCandidates.length} raw candidates`)
@@ -287,32 +346,40 @@ log(`Lenses proposed ${rawCandidates.length} raw candidates`)
 // ---- Phase 3: Dedupe (barrier justified: needs the full candidate set) -----
 phase('Dedupe')
 const dedupe = rawCandidates.length
-  ? await agent(
+  ? requireStageResults(
       [
-        `Merge and dedupe tech-debt candidates for the TeXRA tournament ${campaignDate}. READ-ONLY; no edits.`,
-        ``,
-        `1. Merge near-duplicate candidates (same deletion proposed by different lenses) into the single strongest spec.`,
-        `2. Drop any candidate that duplicates an EXISTING issue below (report which). Titles will not match verbatim — judge by substance, and check the issue on GitHub or in the repo docs when unsure.`,
-        `3. Drop any candidate banned by the DO-NOT-DO ledger below (report which). Ledger entries are adjudicated verdicts; do not relitigate them here.`,
-        ``,
-        `Existing issues:`,
-        knownIssues.length ? knownIssues.map((s) => `- ${s}`).join('\n') : '- (none provided)',
-        ``,
-        `Do-not-do ledger:`,
-        doNotDo.length ? doNotDo.map((s) => `- ${s}`).join('\n') : '- (none provided)',
-        ``,
-        `Candidates (JSON):`,
-        JSON.stringify(rawCandidates, null, 1),
-      ].join('\n'),
-      { label: 'dedupe', phase: 'Dedupe', schema: DEDUPE_SCHEMA },
-    )
+        await agent(
+          [
+            `Merge and dedupe tech-debt candidates for the TeXRA tournament ${campaignDate}. READ-ONLY; no edits.`,
+            ``,
+            `1. Merge near-duplicate candidates (same deletion proposed by different lenses) into the single strongest spec.`,
+            `2. Drop any candidate that duplicates an EXISTING issue below (report which). Titles will not match verbatim — judge by substance, and check the issue on GitHub or in the repo docs when unsure.`,
+            `3. Drop any candidate banned by the DO-NOT-DO ledger below (report which). Ledger entries are adjudicated verdicts; do not relitigate them here.`,
+            ``,
+            `Existing issues:`,
+            knownIssues.length ? knownIssues.map((s) => `- ${s}`).join('\n') : '- (none provided)',
+            ``,
+            `Do-not-do ledger:`,
+            doNotDo.length ? doNotDo.map((s) => `- ${s}`).join('\n') : '- (none provided)',
+            ``,
+            `Candidates (JSON):`,
+            JSON.stringify(rawCandidates, null, 1),
+          ].join('\n'),
+          { label: 'dedupe', phase: 'Dedupe', schema: DEDUPE_SCHEMA },
+        ),
+      ],
+      'Dedupe',
+    )[0]
   : { kept: [], droppedAsKnown: [], droppedAsDoNotDo: [], merged: [] }
 
-const ranked = [...dedupe.kept].sort((a, b) => b.estLoc - a.estLoc)
-const toVerify = ranked.slice(0, MAX_VERIFY)
+const riskRank = { low: 0, medium: 1, high: 2 }
+const ranked = dedupe.kept.toSorted(
+  (a, b) => riskRank[a.risk] - riskRank[b.risk] || a.estLoc - b.estLoc,
+)
+const toVerify = ranked.slice(0, MAX_FILE)
 if (ranked.length > toVerify.length) {
-  log(`Capping verification at ${MAX_VERIFY}: dropping ${ranked.length - toVerify.length} lowest-LoC candidates: ${ranked
-    .slice(MAX_VERIFY)
+  log(`Capping this cycle at ${MAX_FILE}: not selecting ${ranked.length - toVerify.length} additional candidate(s): ${ranked
+    .slice(MAX_FILE)
     .map((c) => c.title)
     .join(' | ')}`)
 }
@@ -320,51 +387,54 @@ log(`Dedupe done: ${dedupe.kept.length} kept, ${dedupe.droppedAsKnown.length} al
 
 // ---- Phase 4: Verify (pipeline: each candidate verifies independently) -----
 phase('Verify')
-const verified = await pipeline(toVerify, (candidate) =>
-  parallel(
-    REFUTER_LENSES.map((lens) => () =>
-      agent(refuterPrompt(candidate, lens), {
-        label: `verify:${lens.key}:${candidate.area}`,
-        phase: 'Verify',
-        schema: VERDICT_SCHEMA,
-      }),
-    ),
-  ).then((votes) => {
-    const cast = votes.filter(Boolean)
-    const refutes = cast.filter((v) => v.refuted)
-    return {
-      ...candidate,
-      verdict: cast.length >= 2 && refutes.length === 0 ? 'REAL_NET_GAIN' : refutes.length >= 2 ? 'NET_LOSS' : 'CONTESTED',
-      votes: cast,
-      corrections: cast.map((v) => v.corrections).filter((s) => s && s.trim()),
-    }
-  }),
+const verified = requireStageResults(
+  await pipeline(toVerify, (candidate) =>
+    parallel(
+      REFUTER_LENSES.map((lens) => () =>
+        agent(refuterPrompt(candidate, lens), {
+          label: `verify:${lens.key}:${candidate.area}`,
+          phase: 'Verify',
+          schema: VERDICT_SCHEMA,
+        }),
+      ),
+    ).then((votes) => {
+      const cast = requireStageResults(votes, `Verify ${candidate.title}`)
+      const refutes = cast.filter((v) => v.refuted)
+      const corrections = cast.map((v) => v.corrections).filter((text) => text && text.trim())
+      let verdict = 'CONTESTED'
+      if (refutes.length >= 2) verdict = 'NET_LOSS'
+      else if (refutes.length === 0 && corrections.length === 0) verdict = 'REAL_NET_GAIN'
+      return {
+        ...candidate,
+        verdict,
+        votes: cast,
+        corrections,
+      }
+    }),
+  ),
+  'Verify',
 )
 
-const allSurvivors = verified.filter(Boolean).filter((c) => c.verdict === 'REAL_NET_GAIN')
-const rejected = verified.filter(Boolean).filter((c) => c.verdict === 'NET_LOSS')
-const contested = verified.filter(Boolean).filter((c) => c.verdict === 'CONTESTED')
+const allSurvivors = verified.filter((candidate) => candidate.verdict === 'REAL_NET_GAIN')
+const rejected = verified.filter((candidate) => candidate.verdict === 'NET_LOSS')
+const contested = verified.filter((candidate) => candidate.verdict === 'CONTESTED')
 
-// Don't overshoot: file only the smallest/lowest-risk MAX_FILE survivors this cycle.
-// Smaller, easier-to-review PRs land faster than a wall of simultaneous refactors;
-// larger or lower-priority survivors carry over to be re-proposed (post-dedupe) next cycle.
-const riskRank = { low: 0, medium: 1, high: 2 }
-const bySafetyThenSize = [...allSurvivors].sort(
+// Every verified survivor is filed. The single pre-verification cap guarantees this
+// cannot exceed MAX_FILE and avoids a second persisted carry-forward queue.
+const toFile = allSurvivors.toSorted(
   (a, b) => riskRank[a.risk] - riskRank[b.risk] || a.estLoc - b.estLoc,
 )
-const toFile = bySafetyThenSize.slice(0, MAX_FILE)
-const carriedForward = bySafetyThenSize.slice(MAX_FILE)
-if (carriedForward.length) {
-  log(`Filing cap ${MAX_FILE}: carrying ${carriedForward.length} verified survivor(s) forward instead of filing this cycle: ${carriedForward.map((c) => c.title).join(' | ')}`)
-}
 
 // NET_LOSS with a confident majority becomes a ledger entry so future sweeps stop re-proposing it.
 const newDoNotDo = rejected
   .filter((c) => c.votes.filter((v) => v.refuted && v.confidence !== 'low').length >= 2)
-  .map((c) => ({
-    entry: `${c.title}: NET_LOSS (tournament ${campaignDate})`,
-    reasons: c.votes.filter((v) => v.refuted).map((v) => v.reason),
-  }))
+  .map(
+    (c) =>
+      `${c.title}: NET_LOSS (tournament ${campaignDate}) — ${c.votes
+        .filter((vote) => vote.refuted)
+        .map((vote) => vote.reason.replaceAll(/\s+/g, ' ').trim())
+        .join('; ')}`,
+  )
 
 log(
   `Verification done: ${allSurvivors.length} REAL_NET_GAIN (${toFile.length} to file, ~-${toFile.reduce((n, c) => n + c.estLoc, 0)} LoC), ${rejected.length} NET_LOSS, ${contested.length} contested (not filed)`,
@@ -373,9 +443,8 @@ log(
 return {
   campaignDate,
   areasThisCycle: areas.map((a) => a.name),
-  nextCursor: cursor + rotationSize,
+  nextCursor: cursor + areas.length,
   toFile,
-  carriedForward,
   contested,
   rejected,
   newDoNotDo,

--- a/.claude/workflows/tech-debt-tournament.mjs
+++ b/.claude/workflows/tech-debt-tournament.mjs
@@ -374,7 +374,7 @@ const dedupe = rawCandidates.length
 
 const riskRank = { low: 0, medium: 1, high: 2 }
 const ranked = dedupe.kept.toSorted(
-  (a, b) => riskRank[a.risk] - riskRank[b.risk] || a.estLoc - b.estLoc,
+  (a, b) => riskRank[a.risk] - riskRank[b.risk] || b.estLoc - a.estLoc,
 )
 const toVerify = ranked.slice(0, MAX_FILE)
 if (ranked.length > toVerify.length) {
@@ -422,7 +422,7 @@ const contested = verified.filter((candidate) => candidate.verdict === 'CONTESTE
 // Every verified survivor is filed. The single pre-verification cap guarantees this
 // cannot exceed MAX_FILE and avoids a second persisted carry-forward queue.
 const toFile = allSurvivors.toSorted(
-  (a, b) => riskRank[a.risk] - riskRank[b.risk] || a.estLoc - b.estLoc,
+  (a, b) => riskRank[a.risk] - riskRank[b.risk] || b.estLoc - a.estLoc,
 )
 
 // NET_LOSS with a confident majority becomes a ledger entry so future sweeps stop re-proposing it.


### PR DESCRIPTION
## Purpose

Add a recurring, small-batch version of the #8758 tech-debt audit. Each cycle rotates through a ledger-defined slice of the repository, deduplicates candidates against existing issues and adjudicated exclusions, and adversarially verifies at most three candidates before filing.

## Contract

- Issue #8974 owns the cursor, area order, do-not-do entries, and cycle log.
- The workflow owns canonical area-to-path definitions and resolves the ledger's ordered names against them.
- One `maxFile` cap owns both verification fan-out and filing, limiting the default cycle to at most 17 agent calls.
- Every agent stage fails closed; partial mapper, lens, dedupe, or verifier results cannot advance the cursor.
- Any verifier correction makes a candidate contested, so filed specs never contain already-known stale claims.
- The driver creates a labeled `Tracking:` issue before children, retains each child's REST database ID for native sub-issue attachment, and updates the ledger only after all writes succeed.

This removes the unimplemented carry-forward queue instead of adding another persisted state format: candidates outside the single cycle cap are simply not verified or promised for filing.

## Review fixes

- Coerce and validate numeric ledger inputs before cursor arithmetic.
- Pass the ledger's area ordering into the workflow.
- Use real GitHub MCP operation names, issue-only paginated dedupe search, and explicit REST-ID attachment instructions.
- Return do-not-do entries in the ledger's plain-string shape.
- Replace the extension-host glob with explicit paths.
- Fail rather than silently treating missing agent outputs as successful coverage.

## Validation

- Executed the workflow in a local stub harness with string-valued cursor/rotation inputs and a reordered area list; verified numeric cursor advancement and filing output.
- `prettier --check` on both added files.
- `git diff --check`.

Follow-up to #8758. Uses ledger #8974.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds only Claude automation assets (skill + workflow); no application runtime, auth, or data-path changes.
> 
> **Overview**
> Introduces a **repeatable, small-batch** follow-up to the #8758 tech-debt campaign: automation that rotates through repo areas, adversarially verifies deletion candidates, and files at most a few issues per cycle instead of one large sweep.
> 
> **`.claude/skills/tech-debt-tournament/SKILL.md`** defines the driver: read rotation state from ledger issue **#8974**, paginate existing `tech-debt` issues for dedupe, invoke the workflow, then create a tracking issue and verified child issues (with sub-issue links) and advance the ledger only after all GitHub writes succeed. Guardrails cover fail-closed ledger reads, no code pushes, and resumable partial runs.
> 
> **`.claude/workflows/tech-debt-tournament.mjs`** implements the read-only pipeline: per-area seam mappers on a cursor-rotated slice, four architect lenses, dedupe against `knownIssues` and `doNotDo`, then three refuters per candidate (majority refute → `NET_LOSS`; any correction → `CONTESTED`, not filed). A single **`maxFile`** cap bounds verification fan-out and filing (~17 agents at default). The workflow owns canonical area→path maps, validates numeric ledger inputs, fails if any agent returns empty, and returns `newDoNotDo` strings for rejected proposals—explicitly **not** for TeXRA’s `delegate_workflow_script` host.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fca6572ffd5d21f716fa04733fde63870383e079. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->