### PR TITLE
fix(modelHandlers): keep attachment summaries on parallel tool calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Parallel tool calls keep their attachment summaries** — when an
+  OpenAI-family or OpenRouter model made several tool calls in one turn, the
+  follow-up message dropped the note listing files the tools produced, so the
+  model could not see or read those attachments. Summaries are now included for
+  parallel calls exactly as they are for single calls.
 - **Malformed saved goals report a clear dashboard error** — invalid goal data
   no longer disappears or gets overwritten, and unrelated settings continue
   loading.

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -67,10 +67,7 @@ import {
   extractReasoningDelta as extractReasoningDeltaFromChunk,
 } from './openAIChatHelpers';
 import { toOpenAITools } from '../toolConversion';
-import {
-  formatAttachmentSummary,
-  formatToolResultAsText,
-} from '../utils/toolAttachmentUtils';
+import { formatToolResultTextWithAttachments } from '../utils/toolAttachmentUtils';
 import { ModelHandler } from '../ModelHandler';
 import {
   BaseReasoningStreamAggregator,
@@ -1263,15 +1260,14 @@ export class ModelHandlerOpenAI<
     );
 
     // Build tool result as plain text - JSON wastes tokens
-    const attachmentSummary =
-      this.canProcessToolResultAttachments && attachments.length > 0
-        ? formatAttachmentSummary(attachments)
-        : undefined;
-
     const resultMsg: ChatCompletionToolMessageParam = {
       role: 'tool',
       tool_call_id: toolCall.id,
-      content: formatToolResultAsText(result, attachmentSummary),
+      content: formatToolResultTextWithAttachments(
+        result,
+        attachments,
+        this.canProcessToolResultAttachments,
+      ),
     };
     return [callMsg, resultMsg];
   }
@@ -1310,7 +1306,11 @@ export class ModelHandlerOpenAI<
     const toolResultMessages = toolCalls.map((call, i) => ({
       role: 'tool' as const,
       tool_call_id: call.id,
-      content: formatToolResultAsText(entries[i].result),
+      content: formatToolResultTextWithAttachments(
+        entries[i].result,
+        entries[i].attachments,
+        this.canProcessToolResultAttachments,
+      ),
     }));
 
     return [callMsg, ...toolResultMessages];

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -57,10 +57,7 @@ import {
   insertMediaIntoChatUserMessage,
   prependTextToChatUserMessage,
 } from '../openai/openAIMessageUtils';
-import {
-  formatAttachmentSummary,
-  formatToolResultAsText,
-} from '../utils/toolAttachmentUtils';
+import { formatToolResultTextWithAttachments } from '../utils/toolAttachmentUtils';
 import { extractTextFromReasoningDetails } from '../utils/openRouterReasoning';
 import {
   OpenRouterStreamAggregator,
@@ -674,15 +671,14 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
       ...(text ? { content: text } : {}),
     } as ChatMessages;
 
-    const attachmentSummary =
-      this.canProcessToolResultAttachments && attachments.length > 0
-        ? formatAttachmentSummary(attachments)
-        : undefined;
-
     const resultMsg: ChatMessages = {
       role: 'tool',
       toolCallId: call.callId,
-      content: formatToolResultAsText(result, attachmentSummary),
+      content: formatToolResultTextWithAttachments(
+        result,
+        attachments,
+        this.canProcessToolResultAttachments,
+      ),
     } as ChatMessages;
 
     return [callMsg, resultMsg];
@@ -706,11 +702,15 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     } as ChatMessages;
 
     const resultMsgs: ChatMessages[] = entries.map(
-      ({ call, result }) =>
+      ({ call, result, attachments }) =>
         ({
           role: 'tool',
           toolCallId: call.callId,
-          content: formatToolResultAsText(result),
+          content: formatToolResultTextWithAttachments(
+            result,
+            attachments,
+            this.canProcessToolResultAttachments,
+          ),
         }) as ChatMessages,
     );
 

--- a/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
+++ b/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
@@ -245,3 +245,26 @@ export function formatToolResultAsText(
 
   return combined;
 }
+
+/**
+ * Build the plain-text tool-result body for chat-style handlers (OpenAI,
+ * OpenRouter), appending the standard metadata attachment summary when the
+ * handler can surface tool-result attachments and any are present.
+ *
+ * Shared by each handler's single and batched follow-up paths so the two can't
+ * drift: the batched paths previously inlined `formatToolResultAsText(result)`
+ * without the summary, so parallel tool calls silently dropped their attachment
+ * summaries. Routing both paths through one helper makes that class of bug
+ * structurally impossible.
+ */
+export function formatToolResultTextWithAttachments(
+  result: ToolResult,
+  attachments: ToolFileAttachment[],
+  canProcessAttachments: boolean,
+): string {
+  const attachmentSummary =
+    canProcessAttachments && attachments.length > 0
+      ? formatAttachmentSummary(attachments)
+      : undefined;
+  return formatToolResultAsText(result, attachmentSummary);
+}

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIToolUse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIToolUse.vitest.ts
@@ -93,6 +93,48 @@ describe('ModelHandlerOpenAI.extractToolUse', () => {
   });
 });
 
+describe('ModelHandlerOpenAI tool-result attachment summaries', () => {
+  const attachments = [{ path: 'chart.png', mimeType: 'image/png' }] as never;
+  const call = {
+    raw: {
+      id: 'call_1',
+      type: 'function',
+      function: { name: 'do_thing', arguments: '{}' },
+    },
+  } as never;
+  const result = { status: 'executed', output: 'done' } as const;
+
+  function newHandler() {
+    const handler = new ModelHandlerOpenAI(
+      buildTestModelConfig({
+        provider: ModelProvider.OPENAI,
+        capabilities: { supportsVision: false },
+      }),
+    );
+    handler.setLogger({ ...noopTrace });
+    return handler;
+  }
+
+  it('single follow-up path includes the attachment summary', async () => {
+    const messages = await newHandler().createToolUseFollowUpMessages(
+      undefined,
+      call,
+      result,
+      attachments,
+    );
+    const toolMsg = messages.find((m) => m.role === 'tool') as any;
+    assert.ok(String(toolMsg.content).includes('chart.png (image/png)'));
+  });
+
+  it('batched follow-up path includes the attachment summary — regression for parallel tool calls silently dropping it', async () => {
+    const messages = await newHandler().createBatchedToolUseFollowUpMessages([
+      { call, result, attachments },
+    ] as never);
+    const toolMsg = messages.find((m) => m.role === 'tool') as any;
+    assert.ok(String(toolMsg.content).includes('chart.png (image/png)'));
+  });
+});
+
 describe('ModelHandlerOpenAI forced tool choice', () => {
   it('maps finalTool to a named function choice', async () => {
     const handler = new ModelHandlerOpenAI(

--- a/src/test-kernel/agent/modelHandlers/utils/toolAttachmentUtils.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/utils/toolAttachmentUtils.vitest.ts
@@ -6,6 +6,7 @@ import { describe, it } from 'vitest';
 import {
   checkToolResultTextLimit,
   formatToolResultAsText,
+  formatToolResultTextWithAttachments,
 } from '@agent/modelHandlers/utils/toolAttachmentUtils';
 import { extractToolAttachments } from '@agent/core/tools/toolAttachmentExtraction';
 import {
@@ -13,6 +14,7 @@ import {
   TOOL_RESULT_TRUNCATION_HEAD_CHARS,
   TOOL_RESULT_TRUNCATION_TAIL_CHARS,
 } from '@agent/modelHandlers/contextManagementConstants';
+import type { ToolFileAttachment } from '@shared/schemas/toolResult';
 
 describe('checkToolResultTextLimit', () => {
   it('returns null for text within limit', () => {
@@ -161,6 +163,40 @@ describe('formatToolResultAsText', () => {
       output: normalOutput,
     });
     assert.equal(result, normalOutput);
+  });
+});
+
+describe('formatToolResultTextWithAttachments', () => {
+  const attachments: ToolFileAttachment[] = [
+    { path: 'chart.png', mimeType: 'image/png' },
+  ];
+
+  it('appends the attachment summary when the handler can process attachments', () => {
+    const result = formatToolResultTextWithAttachments(
+      { status: 'executed', output: 'done' },
+      attachments,
+      true,
+    );
+    assert.ok(result.includes('done'));
+    assert.ok(result.includes('chart.png (image/png)'));
+  });
+
+  it('omits the summary when the handler cannot process attachments', () => {
+    const result = formatToolResultTextWithAttachments(
+      { status: 'executed', output: 'done' },
+      attachments,
+      false,
+    );
+    assert.equal(result, 'done');
+  });
+
+  it('omits the summary when there are no attachments', () => {
+    const result = formatToolResultTextWithAttachments(
+      { status: 'executed', output: 'done' },
+      [],
+      true,
+    );
+    assert.equal(result, 'done');
   });
 });
 


### PR DESCRIPTION
## Summary

The OpenAI-family (`ModelHandlerOpenAI`, incl. DeepSeek/Kimi) and OpenRouter (`ModelHandlerOpenRouterNative`) handlers each carried **two** tool-follow-up builders: a single-call `createToolUseFollowUpMessages` and a batched `createBatchedToolUseFollowUpMessages` used when a model emits several tool calls in one turn. The two were meant to be identical but for the array shape — and had silently diverged.

The single path appended the tool-result **attachment summary** (the note listing files a tool produced, e.g. an extracted figure), gated on `canProcessToolResultAttachments`. The batched path called `formatToolResultAsText(result)` with **no** summary. As a result, when a model made parallel tool calls, the follow-up message dropped those attachment notes, so the model could not see or `read_file` the produced attachments.

This PR extracts one shared helper and routes all four sites (single + batched, each provider) through it, fixing the dropped summary and making the two paths structurally unable to drift again.

This was surfaced by a codebase debt audit; it was the one finding that was an outright correctness bug rather than pure cleanup, so it was taken first.

## Issue acceptance gates

No tracker issue — found via debt audit. Acceptance: batched parallel tool-call follow-ups now carry attachment summaries identically to single calls; covered by a regression test that fails on the pre-fix code.

## Single source of truth

`formatToolResultTextWithAttachments(result, attachments, canProcessAttachments)` in `src/agent/modelHandlers/utils/toolAttachmentUtils.ts` now owns the "plain-text tool-result body + gated metadata attachment summary" decision for the chat-style handlers, alongside the existing `formatToolResultAsText`.

## Duplication and abstraction budget

Removes the gated-summary idiom that was inlined at 4 sites (2 providers × single/batched) — two of which had drifted. The new helper has 4 callers, clearing the repo's multi-caller bar for a shared helper (no single-caller extraction). Google GenAI / Google Interactions / VscodeLm were deliberately left out: they already pass attachments through both paths and use a different summary variant/gating, so folding them in would change behavior, not remove duplication.

## Net elements (R6)

- Files: 6 changed (2 handlers, 1 util, 2 test files, CHANGELOG). No files added/deleted.
- Exported symbols: **+1** (`formatToolResultTextWithAttachments`); none removed.
- Classes/interfaces/enums: 0.
- Net LoC: +129 / −23 (the bulk is the two new test blocks; production code is roughly net-neutral — inline logic replaced by helper calls).

## Consumer counts (R8)

No emit path or export removed or re-routed. The two symbols dropped from the handler import lists (`formatAttachmentSummary`, `formatToolResultAsText`) remain exported and are still used by the Google/Vscode/Response handlers and tests. n/a otherwise.

## Host impact

Extension: Fixed — parallel-tool-call attachment summaries restored for OpenAI/OpenRouter models.

Desktop: Fixed — same shared core.

CLI: Fixed — same shared core.

## Scheduled refactoring

None. (The broader debt audit flagged larger, higher-risk items — model-handler streaming-skeleton dedup, transcript-store consolidation — but those are separate, out of scope here.)

## Validation

- `npm run typecheck` — clean (all projects).
- ESLint on changed files — clean.
- Prettier — clean.
- `vitest run` on `src/test-kernel/agent/modelHandlers`, `.../followUp`, `ToolUseDispatchParallel` — **689 passed / 4 skipped**, including the new unit test for the helper and the new regression test asserting the batched OpenAI follow-up carries the attachment summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012MguAYqW4pSa1PgpWoCFPF

---
_Generated by [Claude Code](https://claude.ai/code/session_012MguAYqW4pSa1PgpWoCFPF)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to tool-result message formatting for two chat-style handlers, with regression tests; no auth, persistence, or API contract changes.
> 
> **Overview**
> Fixes a **correctness bug** where **parallel tool calls** on OpenAI-family and OpenRouter models dropped the **attachment summary** (the note listing files a tool produced) in the follow-up `tool` message, so the model could not see or `read_file` those outputs. Single-call follow-ups already appended that summary when `canProcessToolResultAttachments` was true; the batched path only called `formatToolResultAsText(result)`.
> 
> Introduces **`formatToolResultTextWithAttachments`** in `toolAttachmentUtils` and routes **single and batched** follow-up builders in **`ModelHandlerOpenAI`** and **`ModelHandlerOpenRouterNative`** through it so the two paths cannot drift again. Google/Vscode handlers are unchanged (different attachment handling).
> 
> Adds unit/regression tests and a **CHANGELOG** bug-fix entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac7f629d36ed4b871efa21734b5b3c0e3ee698ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->