### PR TITLE
refactor: dedupe data-structure duplication flagged by complexity audit

### DIFF
--- a/packages/extension/src/progressView/frontend/components/ToolUseStreamContent.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolUseStreamContent.ts
@@ -9,7 +9,7 @@ import { ProgressEvents } from '../events';
 import { getFollowUpInputTransientState } from '../followUpInputState';
 import { BaseStreamContent } from './BaseStreamContent';
 import { renderStreamHeader } from './streamHeaderView';
-import type { ToolUseStreamState } from '../store';
+import { isToolUseState, type ToolUseStreamState } from '../store';
 
 // Local imports - components
 
@@ -26,9 +26,8 @@ import './FollowUpInput';
 @customElement('tool-use-stream-content')
 export class ToolUseStreamContent extends BaseStreamContent {
   private get currentState(): ToolUseStreamState | null {
-    const ctx = this.streamContext;
-    if (!ctx.isToolUse || !ctx.streamState) return null;
-    return ctx.streamState as ToolUseStreamState;
+    const { streamState } = this.streamContext;
+    return streamState && isToolUseState(streamState) ? streamState : null;
   }
 
   override render(): TemplateResult | typeof nothing {

--- a/packages/extension/src/progressView/frontend/components/WorkflowStreamContent.ts
+++ b/packages/extension/src/progressView/frontend/components/WorkflowStreamContent.ts
@@ -8,7 +8,7 @@ import { customElement } from 'lit/decorators.js';
 import { hasOutputFiles } from '../stateUtils';
 import { BaseStreamContent } from './BaseStreamContent';
 import { renderStreamHeader } from './streamHeaderView';
-import type { WorkflowStreamState } from '../store';
+import { isWorkflowState, type WorkflowStreamState } from '../store';
 
 // Local imports - components
 
@@ -25,9 +25,8 @@ import './WorkflowHintBanner';
 @customElement('workflow-stream-content')
 export class WorkflowStreamContent extends BaseStreamContent {
   private get currentState(): WorkflowStreamState | null {
-    const ctx = this.streamContext;
-    if (ctx.isToolUse || !ctx.streamState) return null;
-    return ctx.streamState as WorkflowStreamState;
+    const { streamState } = this.streamContext;
+    return streamState && isWorkflowState(streamState) ? streamState : null;
   }
 
   override render(): TemplateResult | typeof nothing {

--- a/packages/extension/src/progressView/frontend/eventHandlers.ts
+++ b/packages/extension/src/progressView/frontend/eventHandlers.ts
@@ -11,7 +11,7 @@ import {
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 
 // Local imports - progress view
-import { firstStreamId, isToolUseState } from './store';
+import { deleteStreamState, firstStreamId, isToolUseState } from './store';
 import { deleteFollowUpInputTransientState } from './followUpInputState';
 import { addResolvedProposalId, removePrompt } from './slices/permissionSlice';
 import { updateToolUseState } from './stateUtils';
@@ -53,10 +53,7 @@ export function handleStreamDelete(
   // Optimistic removal: apply delete locally before notifying backend
   appState.set(
     create(appState.get(), (draft) => {
-      draft.streamStates.delete(streamId);
-      draft.streamLogs.delete(streamId);
-      draft.processOutputs.delete(streamId);
-      draft.followupOptionsByStream.delete(streamId);
+      deleteStreamState(draft, streamId);
       draft.streamById.delete(streamId);
       if (draft.activeStreamId === streamId) {
         draft.activeStreamId = firstStreamId(draft.streamById);

--- a/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
@@ -16,7 +16,12 @@ import {
   type StreamTabInfo,
 } from '@shared/schemas';
 
-import { firstStreamId, type ProgressState, type StreamState } from '../store';
+import {
+  deleteStreamState,
+  firstStreamId,
+  type ProgressState,
+  type StreamState,
+} from '../store';
 import {
   appState,
   permissions$,
@@ -96,10 +101,7 @@ function updateStreamInfo(
   return create(state, (draft) => {
     for (const key of draft.streamStates.keys()) {
       if (!newStreamById.has(key)) {
-        draft.streamStates.delete(key);
-        draft.streamLogs.delete(key);
-        draft.processOutputs.delete(key);
-        draft.followupOptionsByStream.delete(key);
+        deleteStreamState(draft, key);
       }
     }
 
@@ -185,10 +187,7 @@ export const streamLifecycleHandlers = {
     pendingDescriptions.delete(streamId);
     appState.set(
       create(appState.get(), (draft) => {
-        draft.streamStates.delete(streamId);
-        draft.streamLogs.delete(streamId);
-        draft.processOutputs.delete(streamId);
-        draft.followupOptionsByStream.delete(streamId);
+        deleteStreamState(draft, streamId);
         draft.streamById.delete(streamId);
         if (draft.activeStreamId === streamId) {
           draft.activeStreamId = null;

--- a/packages/extension/src/progressView/frontend/store.ts
+++ b/packages/extension/src/progressView/frontend/store.ts
@@ -1,4 +1,4 @@
-// Local imports
+// Third-party imports
 import {
   AgentCategory,
   createStreamState,
@@ -13,6 +13,9 @@ import {
   type InquiryThreadUpdatedEvent,
   type ExternalInquiryThreadId,
 } from '@shared/schemas';
+import type { Draft } from 'mutative';
+
+// Local imports
 
 /**
  * Background process outputs, keyed by executionId → accumulated stdout/stderr.
@@ -88,6 +91,25 @@ export interface ProgressState {
   followupOptionsByStream: Map<StreamTabId, FollowupOptionsState>;
   /** Durable external inquiry thread summaries, keyed by thread id. */
   inquiries: Map<ExternalInquiryThreadId, InquiryThreadUpdatedEvent>;
+}
+
+/**
+ * Delete one stream's entry from every per-stream map it owns
+ * (`streamStates`, `streamLogs`, `processOutputs`, `followupOptionsByStream`).
+ * Single owner of that key list so a removed/renamed/added map can't drift
+ * out of sync between the lifecycle handlers that garbage-collect streams.
+ * Does not touch `streamById` — callers that also drop the stream from the
+ * tab list delete that key themselves, since some callers (bulk snapshot
+ * sync) replace it wholesale instead.
+ */
+export function deleteStreamState(
+  draft: Draft<ProgressState>,
+  streamId: StreamTabId,
+): void {
+  draft.streamStates.delete(streamId);
+  draft.streamLogs.delete(streamId);
+  draft.processOutputs.delete(streamId);
+  draft.followupOptionsByStream.delete(streamId);
 }
 
 /** Return the first stream ID from a streamById Map, or null if empty. */

--- a/packages/extension/src/progressView/frontend/store.ts
+++ b/packages/extension/src/progressView/frontend/store.ts
@@ -1,4 +1,4 @@
-// Third-party imports
+// Shared imports
 import {
   AgentCategory,
   createStreamState,
@@ -14,8 +14,6 @@ import {
   type ExternalInquiryThreadId,
 } from '@shared/schemas';
 import type { Draft } from 'mutative';
-
-// Local imports
 
 /**
  * Background process outputs, keyed by executionId → accumulated stdout/stderr.

--- a/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
@@ -661,22 +661,25 @@ export class ToolUseDispatchNode<C> extends Node<
     // calls, batch all tool calls into a single message to preserve thought
     // signatures / reasoning_content.
     const { modelHandler } = this.services;
-    const batchedFollowUp = modelHandler.createBatchedToolUseFollowUpMessages;
     const shouldBatch =
       calls.length > 1 &&
       modelHandler.requiresBatchedParallelToolResults &&
-      batchedFollowUp !== undefined;
+      modelHandler.createBatchedToolUseFollowUpMessages !== undefined;
 
-    if (shouldBatch && batchedFollowUp) {
-      const followUpMsgs = await batchedFollowUp(
-        calls.map((call, index) => ({
-          call,
-          result: extracted[index].sanitizedResult,
-          attachments: extracted[index].attachments,
-        })),
-        workspace,
-        assistantText || undefined,
-      );
+    // Called through `modelHandler.` (not an extracted local reference) so
+    // provider implementations that read `this` internally (e.g. Google,
+    // OpenAI) keep their receiver bound.
+    if (shouldBatch && modelHandler.createBatchedToolUseFollowUpMessages) {
+      const followUpMsgs =
+        await modelHandler.createBatchedToolUseFollowUpMessages(
+          calls.map((call, index) => ({
+            call,
+            result: extracted[index].sanitizedResult,
+            attachments: extracted[index].attachments,
+          })),
+          workspace,
+          assistantText || undefined,
+        );
       shared.messages.push(...followUpMsgs);
     } else {
       for (const [index, execResult] of allResults.entries()) {

--- a/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
@@ -661,22 +661,22 @@ export class ToolUseDispatchNode<C> extends Node<
     // calls, batch all tool calls into a single message to preserve thought
     // signatures / reasoning_content.
     const { modelHandler } = this.services;
+    const batchedFollowUp = modelHandler.createBatchedToolUseFollowUpMessages;
     const shouldBatch =
       calls.length > 1 &&
       modelHandler.requiresBatchedParallelToolResults &&
-      !!modelHandler.createBatchedToolUseFollowUpMessages;
+      batchedFollowUp !== undefined;
 
-    if (shouldBatch) {
-      const followUpMsgs =
-        await modelHandler.createBatchedToolUseFollowUpMessages!(
-          calls.map((call, index) => ({
-            call,
-            result: extracted[index].sanitizedResult,
-            attachments: extracted[index].attachments,
-          })),
-          workspace,
-          assistantText || undefined,
-        );
+    if (shouldBatch && batchedFollowUp) {
+      const followUpMsgs = await batchedFollowUp(
+        calls.map((call, index) => ({
+          call,
+          result: extracted[index].sanitizedResult,
+          attachments: extracted[index].attachments,
+        })),
+        workspace,
+        assistantText || undefined,
+      );
       shared.messages.push(...followUpMsgs);
     } else {
       for (const [index, execResult] of allResults.entries()) {

--- a/src/agent/core/tools/toolAttachmentExtraction.ts
+++ b/src/agent/core/tools/toolAttachmentExtraction.ts
@@ -70,6 +70,11 @@ export function extractToolAttachments(
       continue;
     }
     if (key === 'diagnostics') {
+      // Sanitized results only carry the validation-error diagnostics shape
+      // (see ToolResultSharedFields.diagnostics); any other tool's
+      // diagnostics payload — or a validation-error payload whose `formatted`
+      // doesn't actually match FormattedZodIssueSchema — is dropped here
+      // rather than passed through untyped.
       const validationError = ValidationErrorDiagnosticsSchema.safeParse(value);
       if (validationError.success) {
         const { type, formatted } = validationError.data;

--- a/src/agent/core/tools/toolAttachmentExtraction.ts
+++ b/src/agent/core/tools/toolAttachmentExtraction.ts
@@ -5,7 +5,7 @@ import {
   ToolFileAttachmentSchema,
   type ToolResult,
   ToolResultSchema,
-  DIAGNOSTIC_TYPE_VALIDATION_ERROR,
+  ValidationErrorDiagnosticsSchema,
 } from '@shared/schemas/toolResult';
 
 const ERROR_PAYLOAD_STRIPPED_KEYS = new Set([
@@ -69,10 +69,11 @@ export function extractToolAttachments(
     if (status === 'error' && ERROR_PAYLOAD_STRIPPED_KEYS.has(key)) {
       continue;
     }
-    if (key === 'diagnostics' && value && typeof value === 'object') {
-      const diag = value as Record<string, unknown>;
-      if (diag.type === DIAGNOSTIC_TYPE_VALIDATION_ERROR && diag.formatted) {
-        sanitizedResult[key] = { type: diag.type, formatted: diag.formatted };
+    if (key === 'diagnostics') {
+      const validationError = ValidationErrorDiagnosticsSchema.safeParse(value);
+      if (validationError.success) {
+        const { type, formatted } = validationError.data;
+        sanitizedResult[key] = { type, formatted };
       }
       continue;
     }

--- a/src/agent/runtime/AgentFinalResult.ts
+++ b/src/agent/runtime/AgentFinalResult.ts
@@ -63,6 +63,44 @@ export const AgentFinalResultSchema = z.discriminatedUnion('category', [
 
 export type AgentFinalResult = z.infer<typeof AgentFinalResultSchema>;
 
+type ToolUseFinalTextFieldsSource = {
+  readonly response?: string;
+  readonly lastResponse?: string;
+  readonly files?: readonly string[];
+  readonly touchedFiles?: readonly string[];
+};
+
+/**
+ * Single source of truth for the ToolUse `AgentFlowResult` -> `AgentFinalResult`
+ * field rename (`lastResponse` -> `response`, `touchedFiles` -> `files`),
+ * shared by the live path here and the legacy-persisted path in
+ * `resultMeta.ts`'s `buildLegacyAgentFinalResult` so the rename can't drift
+ * between the two builders. Sources are consulted in priority order; within
+ * each source the canonical name wins over its legacy alias.
+ */
+function firstDefinedArray(
+  ...arrays: readonly (readonly string[] | undefined)[]
+): string[] | undefined {
+  const first = arrays.find((array) => array !== undefined);
+  return first ? [...first] : undefined;
+}
+
+export function projectToolUseFinalTextFields(
+  ...sourcesInPriorityOrder: readonly (
+    | ToolUseFinalTextFieldsSource
+    | undefined
+  )[]
+): { response?: string; files?: string[] } {
+  const projected = sourcesInPriorityOrder.map((source) => ({
+    response: source?.response ?? source?.lastResponse,
+    files: firstDefinedArray(source?.files, source?.touchedFiles),
+  }));
+  return {
+    response: projected.find((p) => p.response !== undefined)?.response,
+    files: projected.find((p) => p.files !== undefined)?.files,
+  };
+}
+
 type AgentFinalResultSource =
   | {
       readonly flowResult: AgentFlowResult;
@@ -118,8 +156,7 @@ export function buildAgentFinalResult(
     return AgentFinalResultSchema.parse({
       category: result.category,
       outcome,
-      response: result.lastResponse,
-      files: result.touchedFiles,
+      ...projectToolUseFinalTextFields(result),
       cost: result.totalCostUsd,
       structured,
     });

--- a/src/agent/runtime/AgentFinalResult.ts
+++ b/src/agent/runtime/AgentFinalResult.ts
@@ -70,6 +70,14 @@ type ToolUseFinalTextFieldsSource = {
   readonly touchedFiles?: readonly string[];
 };
 
+/** First defined array among `arrays`, shallow-copied. */
+function firstDefinedArray(
+  ...arrays: readonly (readonly string[] | undefined)[]
+): string[] | undefined {
+  const first = arrays.find((array) => array !== undefined);
+  return first ? [...first] : undefined;
+}
+
 /**
  * Single source of truth for the ToolUse `AgentFlowResult` -> `AgentFinalResult`
  * field rename (`lastResponse` -> `response`, `touchedFiles` -> `files`),
@@ -78,17 +86,9 @@ type ToolUseFinalTextFieldsSource = {
  * between the two builders. Sources are consulted in priority order; within
  * each source the canonical name wins over its legacy alias.
  */
-function firstDefinedArray(
-  ...arrays: readonly (readonly string[] | undefined)[]
-): string[] | undefined {
-  const first = arrays.find((array) => array !== undefined);
-  return first ? [...first] : undefined;
-}
-
 export function projectToolUseFinalTextFields(
   ...sourcesInPriorityOrder: readonly (
-    | ToolUseFinalTextFieldsSource
-    | undefined
+    ToolUseFinalTextFieldsSource | undefined
   )[]
 ): { response?: string; files?: string[] } {
   const projected = sourcesInPriorityOrder.map((source) => ({

--- a/src/agent/runtime/modelHandlerCompatibilityInference.ts
+++ b/src/agent/runtime/modelHandlerCompatibilityInference.ts
@@ -15,10 +15,21 @@ import {
   type ModelHandlerCompatibilityKey,
 } from './modelHandlerCompatibilityKey';
 
+/**
+ * Narrow an arbitrary value to a plain-object record, or `undefined` if it
+ * isn't one. `isObject` already narrows its own parameter, but narrowing
+ * `message: ProviderMessage` (a union of provider SDK types with no common
+ * shape) through it still leaves per-property access needing a cast — this
+ * wraps that once for every shape-sniffing call site below instead of each
+ * repeating `isObject(x) ? (x as Record<string, unknown>) : ...` by hand.
+ */
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return isObject(value) ? value : undefined;
+}
+
 function isGoogleGenAIContentMessage(message: ProviderMessage): boolean {
-  if (!isObject(message)) return false;
-  const record = message as Record<string, unknown>;
-  if ('type' in record) return false;
+  const record = asRecord(message);
+  if (!record || 'type' in record) return false;
   const role = record.role;
   if (role !== 'user' && role !== 'model' && role !== 'system') {
     return false;
@@ -27,8 +38,7 @@ function isGoogleGenAIContentMessage(message: ProviderMessage): boolean {
 }
 
 function isGoogleInteractionsStepMessage(message: ProviderMessage): boolean {
-  if (!isObject(message)) return false;
-  const type = (message as Record<string, unknown>).type;
+  const type = asRecord(message)?.type;
   return (
     type === 'user_input' ||
     type === 'model_output' ||
@@ -39,9 +49,8 @@ function isGoogleInteractionsStepMessage(message: ProviderMessage): boolean {
 }
 
 function isOpenRouterChatMessage(message: ProviderMessage): boolean {
-  if (!isObject(message)) return false;
-  const record = message as Record<string, unknown>;
-  if ('type' in record || 'parts' in record) return false;
+  const record = asRecord(message);
+  if (!record || 'type' in record || 'parts' in record) return false;
   const role = record.role;
   return (
     (role === 'system' ||
@@ -105,23 +114,20 @@ function stringValue(value: unknown): string | undefined {
 function currentModelFromRawSharedState(
   shared: Record<string, unknown>,
 ): string | undefined {
-  const stateSlices = shared.stateSlices;
-  if (!isObject(stateSlices)) return undefined;
-  const userChannels = stateSlices.userChannels;
-  if (!isObject(userChannels)) return undefined;
-  const transient = userChannels.transient;
-  const input = userChannels.input;
+  const userChannels = asRecord(asRecord(shared.stateSlices)?.userChannels);
+  if (!userChannels) return undefined;
+  const transient = asRecord(userChannels.transient);
+  const input = asRecord(userChannels.input);
   return (
-    (isObject(transient) ? stringValue(transient.MODEL) : undefined) ??
-    (isObject(input) ? stringValue(input.MODEL) : undefined)
+    (transient ? stringValue(transient.MODEL) : undefined) ??
+    (input ? stringValue(input.MODEL) : undefined)
   );
 }
 
 function unwrapSharedState(shared: unknown): Record<string, unknown> | null {
-  if (!isObject(shared)) return null;
-  return isObject(shared.state)
-    ? (shared.state as Record<string, unknown>)
-    : shared;
+  const record = asRecord(shared);
+  if (!record) return null;
+  return asRecord(record.state) ?? record;
 }
 
 export function inferPersistedFlowModelHandlerCompatibilityKey(

--- a/src/agent/storage/resultMeta.ts
+++ b/src/agent/storage/resultMeta.ts
@@ -5,6 +5,7 @@ import {
   ResultDiffSummarySchema,
   WorkflowAgentFinalResultSchema,
   buildAgentFinalResult,
+  projectToolUseFinalTextFields,
   type AgentFinalResult,
 } from '@agent/runtime/AgentFinalResult';
 import type { WorkflowFlowResult } from '@agent/runtime/AgentFlowResult';
@@ -253,16 +254,7 @@ function buildLegacyAgentFinalResult(
   return AgentFinalResultSchema.parse({
     category,
     outcome,
-    response:
-      nested?.response ??
-      nested?.lastResponse ??
-      outer.response ??
-      outer.lastResponse,
-    files:
-      nested?.files ??
-      nested?.touchedFiles ??
-      outer.files ??
-      outer.touchedFiles,
+    ...projectToolUseFinalTextFields(nested, outer),
     cost,
   });
 }

--- a/src/agent/trace/helpers.ts
+++ b/src/agent/trace/helpers.ts
@@ -194,16 +194,23 @@ export function logConversationProgress(
   trace.emit({ type: 'conversation.progress', progress: data, stageId });
 }
 
+/** Payload logged by {@link logMissingOutputs} for one round's unmatched
+ *  expected outputs. Distinct from `UpdateMissingOutputsPayload` (the
+ *  `updateMissingOutputs` run fact) — this is the human-facing transcript log. */
+interface MissingOutputsLogInfo {
+  missing: string[];
+  xmlFile: string | null;
+}
+
 /** Missing-outputs notification — counts `missing` entries for the label. */
 export function logMissingOutputs(
   trace: AgentTrace,
-  info: { missing?: unknown[] } & Record<string, unknown>,
+  info: MissingOutputsLogInfo,
   stageId?: string,
 ): void {
-  const count = Array.isArray(info.missing) ? info.missing.length : 0;
   trace.domain({
     key: 'missingOutputs',
-    text: `${formatResultCount(count, 'output file')} missing`,
+    text: `${formatResultCount(info.missing.length, 'output file')} missing`,
     data: info,
     stageId,
   });

--- a/src/shared/schemas/toolResult.ts
+++ b/src/shared/schemas/toolResult.ts
@@ -78,23 +78,31 @@ export const DIAGNOSTIC_TYPE_VALIDATION_ERROR = 'validation_error' as const;
  * Formatted Zod issue for model consumption.
  * Provides structured information that helps models self-correct.
  */
-export interface FormattedZodIssue {
-  path: string;
-  message: string;
-  expected?: unknown;
-  received?: unknown;
-  code?: string;
-}
+const FormattedZodIssueSchema = z.object({
+  path: z.string(),
+  message: z.string(),
+  expected: z.unknown().optional(),
+  received: z.unknown().optional(),
+  code: z.string().optional(),
+});
+export type FormattedZodIssue = z.infer<typeof FormattedZodIssueSchema>;
 
 /**
- * Structured validation error diagnostics.
- * Used to provide rich error information to models for self-correction.
+ * Structured validation error diagnostics. One of several shapes a tool's
+ * `ToolResult.diagnostics` may carry (see that field's own comment) — this is
+ * the one produced for Zod input-validation failures, used to provide rich
+ * error information to models for self-correction. `issues` stays
+ * `z.custom<ZodIssue>()` since `ZodIssue` is Zod's own internal type with no
+ * exported schema to compose against.
  */
-export interface ValidationErrorDiagnostics {
-  type: typeof DIAGNOSTIC_TYPE_VALIDATION_ERROR;
-  issues: ZodIssue[];
-  formatted: FormattedZodIssue[];
-}
+export const ValidationErrorDiagnosticsSchema = z.object({
+  type: z.literal(DIAGNOSTIC_TYPE_VALIDATION_ERROR),
+  issues: z.array(z.custom<ZodIssue>()),
+  formatted: z.array(FormattedZodIssueSchema),
+});
+export type ValidationErrorDiagnostics = z.infer<
+  typeof ValidationErrorDiagnosticsSchema
+>;
 
 /**
  * Format Zod issues into structured diagnostics for model consumption.
@@ -134,7 +142,13 @@ const ToolResultSharedFields = {
   userInstruction: z.string().optional(),
   /** User-provided patch content */
   userPatch: z.string().optional(),
-  /** Additional diagnostic information */
+  /**
+   * Additional diagnostic information. Deliberately `z.unknown()`: every tool
+   * shapes its own payload here (validation issues, severity counts, an
+   * unread-file reason, an error name, …), so there is no single schema to
+   * validate against. Consumers that care about one specific shape — e.g.
+   * {@link ValidationErrorDiagnosticsSchema} — parse it themselves.
+   */
   diagnostics: z.unknown().optional(),
   /** Summary added by handlers when attachments are available */
   attachmentSummary: z.string().optional(),


### PR DESCRIPTION
## Summary

Follow-up to a data-structure complexity audit run against this repo. Fixes seven concrete instances of accidental duplication/complexity the audit surfaced across the runtime, shared schemas, and the progress-view frontend — each verified by reading the actual call sites before changing anything, not just applying the audit's suggestion as-is (two of its suggestions turned out to be wrong or unsafe on closer inspection; see below).

## Issue acceptance gates

No tracked issue — ad hoc audit + refactor requested in-session. Gates applied per finding:

1. **`AgentFlowResult` → `AgentFinalResult` field rename duplicated in two builders** (`AgentFinalResult.ts` live path, `resultMeta.ts` legacy path) — fixed via a shared projector.
2. **Progress-view frontend: per-stream Map deletion duplicated at 3 call sites** — fixed via a shared helper.
3. **`ToolResult.diagnostics` cast + manual duck-typing at its one real consumer** — fixed by giving the one concrete shape (`ValidationErrorDiagnostics`) a real Zod schema and parsing it, while confirming (and now documenting) that the field itself must stay `z.unknown()` since ~8 other tools use it for unrelated shapes.
4. **`!` non-null assertion in `ToolUseDispatchNode.ts`** — fixed via a narrowable local binding.
5. **`as WorkflowStreamState`/`as ToolUseStreamState` casts gated by a separately-computed boolean** — fixed via the existing `isWorkflowState`/`isToolUseState` type guards.
6. **5 duplicated `isObject(x) ? (x as Record<string, unknown>) : ...` sites** in `modelHandlerCompatibilityInference.ts` — fixed via a 5-caller `asRecord()` helper.
7. **`logMissingOutputs`'s `{ missing?: unknown[] } & Record<string, unknown>` param** — fixed via a named type matching what callers actually pass.

## Single source of truth

- `projectToolUseFinalTextFields` (`AgentFinalResult.ts`) — the one place the `lastResponse`→`response` / `touchedFiles`→`files` rename is defined; both the live and legacy-persisted builders call it.
- `deleteStreamState` (`store.ts`) — the one place that knows every per-stream Map the progress-view frontend owns.
- `ValidationErrorDiagnosticsSchema` (`toolResult.ts`) — the one Zod-derived shape for the validation-error diagnostics payload; `FormattedZodIssue`/`ValidationErrorDiagnostics` are now `z.infer`'d instead of hand-duplicated interfaces.
- `asRecord()` (`modelHandlerCompatibilityInference.ts`) — the one place that narrows an arbitrary value to a record for this file's provider-message shape-sniffing.

## Duplication and abstraction budget

Removed: the 2-builder field-rename duplication (#1), the 3-site Map-deletion duplication (#2), the 5-site cast duplication (#6), and one hand-written-interface/Zod-SSOT violation (#3). All four new helpers have ≥2 real call sites today (`projectToolUseFinalTextFields`: 2, `deleteStreamState`: 3, `asRecord`: 5) — no single-caller extractions. No new ports, facades, or pass-through layers.

**Deliberately left alone**, after investigation showed the audit's initial read didn't hold up:
- **`ProgressStreamMetadata`'s many optional fields** — the audit suggested grouping the snapshot-sourced fields into a nested `runConfig` object. Turns out `agentCategory` is independently patched from a live provisional event (`ProgressFactApplier.handleSetActiveStream`) before the authoritative snapshot config exists, and `updateStreamMetadata` is called from ~15 sites including tests. Nesting would need partial-merge semantics per patch and touch every call site for an ambiguous readability win — not worth the regression risk.
- **`ToolUseRoundShared`'s flat, many-optional-field bag** — sits on the core tool-use round loop; restructuring into a discriminated union (as the audit suggested, citing `ResponseCycleFlow`'s own pattern) would ripple through every node in that flow. Left for a dedicated, test-heavy follow-up rather than a blind rewrite here.
- **`approvalQueue`'s manual `syncApprovalStatus()` call after each mutation** — correct at all 4 current call sites today; the audit itself said "not currently buggy." Adding a `mutateQueue()` wrapper now would be a speculative abstraction with no live bug to fix.

## Net elements (R6)

12 files changed, 164 insertions(+), 91 deletions(-). No new files.

Exported symbols (`^[+-]export` over the diff):
- `+function deleteStreamState` (store.ts) — new, 3 callers
- `+function projectToolUseFinalTextFields` (AgentFinalResult.ts) — new, 2 callers
- `-interface FormattedZodIssue` / `+type FormattedZodIssue = z.infer<...>` (toolResult.ts) — converted from hand-written interface to schema-derived type, same public name/shape
- `-interface ValidationErrorDiagnostics` / `+const ValidationErrorDiagnosticsSchema` + `+type ValidationErrorDiagnostics = z.infer<...>` (toolResult.ts) — same conversion, plus the new schema export

Net: +2 new exported helpers (each collapsing ≥2 duplicated call sites into one), 2 exported types converted from hand-written to schema-derived (no interface count change).

## Consumer counts (R8)

Not applicable — no emit path, export, or public API was deleted or re-routed. `ToolResult.diagnostics`'s wire type (`z.unknown()`) is unchanged; only its one validation-error consumer (`toolAttachmentExtraction.ts`) now parses instead of casting.

## Host impact

Extension: `packages/extension/src/progressView/frontend/*` — internal state-management cleanup only, no behavior change (verified by the full progress-view test suite, 377 tests passing).

Desktop: none (no desktop-specific files touched; `AgentFinalResult`/`resultMeta` changes are host-neutral and covered by the shared runtime tests).

CLI: none.

## Scheduled refactoring

None filed. The two skipped findings (`ProgressStreamMetadata`, `ToolUseRoundShared`) are documented above with the reasoning for leaving them; either could be revisited as a dedicated follow-up if a real bug or use case surfaces.

## Validation

- `npm run typecheck` — full workspace (root, test-kernel, extension, CLI, trace-viewer, desktop) — clean.
- `npx eslint` on all 12 changed files — clean (2 issues found and fixed during development: an import-order violation and a nested-ternary lint rule).
- Targeted `vitest` runs, all passing:
  - `src/test-kernel/progressView/` — 48 files, 377 tests
  - `AgentFinalResult.vitest.ts`, `AgentRunLifecycle.vitest.ts`, `SubagentResultMeta.vitest.ts`, `SubagentResults.vitest.ts`, `SubagentDeliveryStructured.vitest.ts`, `ChildRunDelivery.vitest.ts` — 73 tests
  - `ModelHandlerCompatibilityInference.vitest.ts`, `ToolUseDispatchParallel.vitest.ts`, `ToolUseDispatchInterruption.vitest.ts`, `ToolUseRoundFollowUpMedia.vitest.ts`, `ApprovalQueue.vitest.mts`, `BashToolErrorFeedback.vitest.ts`, `FileEditFlow.vitest.ts`, `Cancellation.vitest.ts` — 73 tests
- Full `npm test` suite kicked off as an additional check; not blocking this PR since every touched area's targeted suite plus a full-workspace typecheck already passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01241AikwcGX3F3HDaRrajMo)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only consolidation with targeted tests; no new APIs or wire-format changes, though agent result projection and tool-result sanitization paths were touched.
> 
> **Overview**
> Follow-up to a data-structure complexity audit: **seven duplication/complexity fixes** with shared helpers and stricter typing, without intended behavior changes.
> 
> **Progress view:** New `deleteStreamState` owns cleanup of all per-stream maps (`streamStates`, `streamLogs`, `processOutputs`, `followupOptionsByStream`) and replaces copy-pasted deletes in stream delete/sync paths. `ToolUseStreamContent` / `WorkflowStreamContent` narrow state with `isToolUseState` / `isWorkflowState` instead of separate flags plus casts.
> 
> **Agent runtime & persistence:** `projectToolUseFinalTextFields` centralizes the tool-use rename (`lastResponse`→`response`, `touchedFiles`→`files`) for both live `buildAgentFinalResult` and legacy `resultMeta` reads. `ToolUseDispatchNode` drops a non-null assertion on batched follow-up messages and always invokes the handler on `modelHandler` so provider `this` stays bound.
> 
> **Schemas & sanitization:** `ValidationErrorDiagnosticsSchema` (and schema-derived `FormattedZodIssue`) replace hand-written interfaces; `extractToolAttachments` **safeParse**s validation-error diagnostics instead of duck-typing. `modelHandlerCompatibilityInference` adds `asRecord()` for repeated record narrowing; `logMissingOutputs` gets an explicit `MissingOutputsLogInfo` payload type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09c0341c5f9ae8f2a22915bd7673c40f76e325d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->