### PR TITLE
feat(cli): reflect live attention state in terminal title

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -117,8 +117,8 @@ import {
 } from './state/transcript';
 import {
   clearTerminalScrollback,
+  installTerminalTitleUpdates,
   installTerminalRestoreOnExit,
-  setTerminalTitle,
 } from './terminalCleanup';
 import {
   chatTuiCanInterruptActiveRun,
@@ -430,8 +430,9 @@ export async function runChat(
   disposers.push(installTerminalRestoreOnExit({ clearItermProgress }));
   // Cosmetic, but "texra-local" (a local dev binary's own name) or a bare
   // shell prompt in every tab makes a multi-session workflow hard to
-  // navigate — name the tab after the project instead.
-  setTerminalTitle(context.cwd);
+  // navigate. Keep the project name while surfacing live attention state.
+  const terminalTitleUpdates = installTerminalTitleUpdates(context.cwd);
+  disposers.push(terminalTitleUpdates.dispose);
   disposers.push(subscribeStreamLog());
   disposers.push(subscribeStreamStatus());
 
@@ -868,6 +869,8 @@ export async function runChat(
     detachSnapshotPersistence,
     repaintAfterTerminalResume: () =>
       viewportController.repaintAfterTerminalResume(),
+    suspendTerminalTitle: terminalTitleUpdates.suspend,
+    resumeTerminalTitle: terminalTitleUpdates.resume,
     canStopActiveRun,
     isResumableIdle,
     interruptActive,

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -117,9 +117,9 @@ import {
 } from './state/transcript';
 import {
   clearTerminalScrollback,
-  installTerminalTitleUpdates,
   installTerminalRestoreOnExit,
 } from './terminalCleanup';
+import { installTerminalTitleUpdates } from './terminalTitle';
 import {
   chatTuiCanInterruptActiveRun,
   chatTuiCanSelectModel,

--- a/packages/cli/src/chat/tui/sessionExitController.ts
+++ b/packages/cli/src/chat/tui/sessionExitController.ts
@@ -178,6 +178,7 @@ export function createSessionExitController(
     runCliPlatformShutdownSequence(tryPlatform()?.lifecycle);
   const exitNow = (exitCode: number): void => {
     exiting = true;
+    ctx.suspendTerminalTitle();
     removeProcessHandlers();
     clearExitConfirmation();
     ink.unmount();

--- a/packages/cli/src/chat/tui/sessionExitController.ts
+++ b/packages/cli/src/chat/tui/sessionExitController.ts
@@ -81,6 +81,10 @@ interface SessionExitControllerContext {
   readonly detachSnapshotPersistence: () => void;
   /** Repaint the TUI from a known origin after a `fg`/SIGCONT resume. */
   readonly repaintAfterTerminalResume: () => void;
+  /** Replace a live attention title with the idle project title while stopped. */
+  readonly suspendTerminalTitle: () => void;
+  /** Re-project live attention state after the shell returns control. */
+  readonly resumeTerminalTitle: () => void;
   /** Whether an actively-running turn can be stopped (vs idle/WAITING). */
   readonly canStopActiveRun: () => boolean;
   /** Whether the session is a resumable-idle exit (preserve the flow record). */
@@ -253,6 +257,7 @@ export function createSessionExitController(
   // re-raising SIGTSTP would just recurse.
   const handleSigtstp = (): void => {
     if (!terminalJobControlSupported) return;
+    ctx.suspendTerminalTitle();
     cleanupTerminalModes({ clearItermProgress: ctx.clearItermProgress });
     if (process.stdin.isTTY) process.stdin.setRawMode(false);
     process.kill(process.pid, 'SIGSTOP');
@@ -265,6 +270,7 @@ export function createSessionExitController(
   const handleSigcont = (): void => {
     if (process.stdin.isTTY) process.stdin.setRawMode(true);
     restoreTuiInputModes({ kittyKeyboard: ctx.kittyKeyboardEnabled });
+    ctx.resumeTerminalTitle();
     ctx.repaintAfterTerminalResume();
   };
   function requestInputExit(): void {

--- a/packages/cli/src/chat/tui/state/signalSubscription.ts
+++ b/packages/cli/src/chat/tui/state/signalSubscription.ts
@@ -1,0 +1,34 @@
+import { Signal } from '@lit-labs/signals';
+
+type WatchableSignal = Parameters<Signal.subtle.Watcher['watch']>[number];
+
+/**
+ * Subscribe to one or more signals outside their notification phase.
+ *
+ * Signal Watchers fire only once until re-armed, and their notification phase
+ * forbids signal reads. Coalesce notifications into one microtask so callers
+ * may safely read the current graph, then re-arm unless the subscription was
+ * disposed while that microtask was pending.
+ */
+export function subscribeToSignalChanges(
+  signals: readonly WatchableSignal[],
+  notify: () => void,
+): () => void {
+  let notifyPending = false;
+  let disposed = false;
+  const watcher = new Signal.subtle.Watcher(() => {
+    if (notifyPending) return;
+    notifyPending = true;
+    queueMicrotask(() => {
+      notifyPending = false;
+      if (disposed) return;
+      notify();
+      watcher.watch();
+    });
+  });
+  watcher.watch(...signals);
+  return () => {
+    disposed = true;
+    watcher.unwatch(...signals);
+  };
+}

--- a/packages/cli/src/chat/tui/state/useSignal.ts
+++ b/packages/cli/src/chat/tui/state/useSignal.ts
@@ -3,7 +3,9 @@
 // the same signals without pulling in a second state-management library.
 
 import { useCallback, useSyncExternalStore } from 'react';
-import { Signal } from '@lit-labs/signals';
+
+import { subscribeToSignalChanges } from './signalSubscription';
+import type { Signal } from '@lit-labs/signals';
 
 type ReadableSignal<T> = Signal.State<T> | Signal.Computed<T>;
 
@@ -44,23 +46,7 @@ type ReadableSignal<T> = Signal.State<T> | Signal.Computed<T>;
 export function useSignal<T>(signal: ReadableSignal<T>): T {
   const subscribe = useCallback(
     (notify: () => void) => {
-      let notifyPending = false;
-      let disposed = false;
-      const watcher = new Signal.subtle.Watcher(() => {
-        if (notifyPending) return;
-        notifyPending = true;
-        queueMicrotask(() => {
-          notifyPending = false;
-          if (disposed) return;
-          notify();
-          watcher.watch();
-        });
-      });
-      watcher.watch(signal);
-      return () => {
-        disposed = true;
-        watcher.unwatch(signal);
-      };
+      return subscribeToSignalChanges([signal], notify);
     },
     [signal],
   );

--- a/packages/cli/src/chat/tui/terminalCleanup.ts
+++ b/packages/cli/src/chat/tui/terminalCleanup.ts
@@ -1,16 +1,6 @@
 import { writeSync } from 'node:fs';
-import { basename } from 'node:path';
 
-import { Signal } from '@lit-labs/signals';
 import { kittyFlags } from 'ink';
-
-import { isActivePhase } from '@shared/streams/streamStatus';
-import { sanitizePathSegment } from '@utils/text/sanitizePathSegment';
-
-import { approvalQueueStatus } from './state/approvalQueue';
-import { rootRunPending, rootRunStreamId, streams } from './state/cliState';
-import { chatTuiCanStopActiveRun } from './state/sessionRunState';
-import { terminalCapabilities } from './state/terminalCapabilities';
 
 // Undo exactly the input/display modes the TUI turns on: mouse tracking
 // (1000/1003/1006), the kitty keyboard stack (<u), bracketed paste (2004), and
@@ -40,38 +30,6 @@ const REARM_INPUT_MODES = '\x1b[?2004h\x1b[?25l';
 // `<Static>` transcript lines persist in the primary-buffer scrollback.
 const CLEAR_SCREEN_AND_SCROLLBACK = '\x1b[2J\x1b[3J\x1b[H';
 const CLEAR_VISIBLE_SCREEN = '\x1b[2J\x1b[H';
-// Directory names can contain characters that would prematurely terminate
-// the OSC string (a stray BEL/ESC) or that some terminals in 8-bit mode
-// still interpret as escape-sequence introducers (the C1 range, e.g. 0x9d
-// as an 8-bit OSC); strip both C0 and C1 controls so a weird folder name
-// can't inject terminal escape sequences into the title.
-// eslint-disable-next-line no-control-regex -- stripping C0/C1 controls
-const TITLE_INVALID_CHARS = /[\x00-\x1f\x7f-\x9f]/g;
-
-/**
- * "TeXRA" alone when the cwd has no meaningful basename (e.g. filesystem
- * root, where `path.basename` returns `''`), else "TeXRA — <project folder>"
- * so a user running several sessions across different projects — the common
- * case here — can tell tabs apart at a glance instead of every tab reading
- * the launcher binary's own name (e.g. a local dev symlink like
- * `texra-local`).
- */
-type TerminalTitleState = 'idle' | 'running' | 'approval';
-
-export function terminalTitleText(
-  cwd: string,
-  state: TerminalTitleState = 'idle',
-): string {
-  const project = sanitizePathSegment(basename(cwd), {
-    invalidCharPattern: TITLE_INVALID_CHARS,
-    replacement: '',
-  });
-  let activity: string | undefined;
-  if (state === 'approval') activity = 'Approval needed';
-  if (state === 'running') activity = 'Running';
-  return ['TeXRA', activity, project].filter(Boolean).join(' — ');
-}
-
 export interface CleanupTerminalModesOptions {
   readonly clearItermProgress?: boolean;
 }
@@ -143,108 +101,4 @@ export function clearTerminalVisibleScreen(): void {
   } catch {
     // The terminal may have been closed mid-clear; nothing to do.
   }
-}
-
-/**
- * Set the terminal tab/window title via OSC 0. Gated on the same
- * `oscColorReports` capability the notifier uses for OSC 9/99 (see
- * `notifications/terminalNotifier.ts`): a terminal that didn't acknowledge
- * OSC support during DA1 discovery may garble an OSC sequence it doesn't
- * recognize rather than silently ignore it, and a title has no BEL-style
- * degrade to fall back to, so the safe move on an ungated terminal is to
- * leave the title alone entirely.
- */
-function writeTerminalTitle(title: string): void {
-  if (!terminalCapabilities.get().oscColorReports) return;
-  try {
-    writeSync(1, `\x1b]0;${title}\x07`);
-  } catch {
-    // The tab title is cosmetic; a write failure here isn't actionable.
-  }
-}
-
-function currentTerminalTitleState(): TerminalTitleState {
-  if (approvalQueueStatus.get().depth > 0) return 'approval';
-  const streamSlices = streams.get();
-  const rootStreamId = rootRunStreamId.get();
-  if (
-    chatTuiCanStopActiveRun({
-      runPending: rootRunPending.get(),
-      streamId: rootStreamId,
-      status: rootStreamId ? streamSlices.get(rootStreamId)?.status : undefined,
-    }) ||
-    [...streamSlices.values()].some((stream) => isActivePhase(stream.status))
-  ) {
-    return 'running';
-  }
-  return 'idle';
-}
-
-/**
- * Keep the terminal title synchronized with existing TUI state. Signal reads
- * run in a microtask because the signals polyfill forbids reads during a
- * Watcher notification; the single queued synchronization also coalesces
- * related state writes and suppresses duplicate OSC output.
- */
-export function installTerminalTitleUpdates(cwd: string) {
-  let disposed = false;
-  let suspended = false;
-  let synchronizationPending = false;
-  let lastTitle: string | undefined;
-  const synchronize = (): void => {
-    if (suspended) return;
-    const state = currentTerminalTitleState();
-    const title = terminalTitleText(cwd, state);
-    if (title === lastTitle) return;
-    lastTitle = title;
-    writeTerminalTitle(title);
-  };
-  const restoreIdleTitle = (): void => {
-    const idleTitle = terminalTitleText(cwd);
-    if (lastTitle === idleTitle) return;
-    lastTitle = idleTitle;
-    writeTerminalTitle(idleTitle);
-  };
-  const watcher = new Signal.subtle.Watcher(() => {
-    if (synchronizationPending) return;
-    synchronizationPending = true;
-    queueMicrotask(() => {
-      synchronizationPending = false;
-      if (disposed) return;
-      synchronize();
-      watcher.watch();
-    });
-  });
-  watcher.watch(approvalQueueStatus, rootRunPending, rootRunStreamId, streams);
-  synchronize();
-  // Synchronous signal exits bypass the normal disposer loop, but still emit
-  // `exit`; restore the title there as well as during graceful teardown.
-  process.on('exit', restoreIdleTitle);
-
-  const dispose = (): void => {
-    if (disposed) return;
-    disposed = true;
-    watcher.unwatch(
-      approvalQueueStatus,
-      rootRunPending,
-      rootRunStreamId,
-      streams,
-    );
-    process.off('exit', restoreIdleTitle);
-    restoreIdleTitle();
-  };
-
-  return {
-    suspend: () => {
-      if (disposed) return;
-      suspended = true;
-      restoreIdleTitle();
-    },
-    resume: () => {
-      if (disposed) return;
-      suspended = false;
-      synchronize();
-    },
-    dispose,
-  };
 }

--- a/packages/cli/src/chat/tui/terminalCleanup.ts
+++ b/packages/cli/src/chat/tui/terminalCleanup.ts
@@ -1,10 +1,15 @@
 import { writeSync } from 'node:fs';
 import { basename } from 'node:path';
 
+import { Signal } from '@lit-labs/signals';
 import { kittyFlags } from 'ink';
 
+import { isActivePhase } from '@shared/streams/streamStatus';
 import { sanitizePathSegment } from '@utils/text/sanitizePathSegment';
 
+import { approvalQueueStatus } from './state/approvalQueue';
+import { rootRunPending, rootRunStreamId, streams } from './state/cliState';
+import { chatTuiCanStopActiveRun } from './state/sessionRunState';
 import { terminalCapabilities } from './state/terminalCapabilities';
 
 // Undo exactly the input/display modes the TUI turns on: mouse tracking
@@ -51,12 +56,20 @@ const TITLE_INVALID_CHARS = /[\x00-\x1f\x7f-\x9f]/g;
  * the launcher binary's own name (e.g. a local dev symlink like
  * `texra-local`).
  */
-export function terminalTitleText(cwd: string): string {
+type TerminalTitleState = 'idle' | 'running' | 'approval';
+
+export function terminalTitleText(
+  cwd: string,
+  state: TerminalTitleState = 'idle',
+): string {
   const project = sanitizePathSegment(basename(cwd), {
     invalidCharPattern: TITLE_INVALID_CHARS,
     replacement: '',
   });
-  return project ? `TeXRA — ${project}` : 'TeXRA';
+  let activity: string | undefined;
+  if (state === 'approval') activity = 'Approval needed';
+  if (state === 'running') activity = 'Running';
+  return ['TeXRA', activity, project].filter(Boolean).join(' — ');
 }
 
 export interface CleanupTerminalModesOptions {
@@ -141,11 +154,97 @@ export function clearTerminalVisibleScreen(): void {
  * degrade to fall back to, so the safe move on an ungated terminal is to
  * leave the title alone entirely.
  */
-export function setTerminalTitle(cwd: string): void {
+function writeTerminalTitle(title: string): void {
   if (!terminalCapabilities.get().oscColorReports) return;
   try {
-    writeSync(1, `\x1b]0;${terminalTitleText(cwd)}\x07`);
+    writeSync(1, `\x1b]0;${title}\x07`);
   } catch {
     // The tab title is cosmetic; a write failure here isn't actionable.
   }
+}
+
+function currentTerminalTitleState(): TerminalTitleState {
+  if (approvalQueueStatus.get().depth > 0) return 'approval';
+  const streamSlices = streams.get();
+  const rootStreamId = rootRunStreamId.get();
+  if (
+    chatTuiCanStopActiveRun({
+      runPending: rootRunPending.get(),
+      streamId: rootStreamId,
+      status: rootStreamId ? streamSlices.get(rootStreamId)?.status : undefined,
+    }) ||
+    [...streamSlices.values()].some((stream) => isActivePhase(stream.status))
+  ) {
+    return 'running';
+  }
+  return 'idle';
+}
+
+/**
+ * Keep the terminal title synchronized with existing TUI state. Signal reads
+ * run in a microtask because the signals polyfill forbids reads during a
+ * Watcher notification; the single queued synchronization also coalesces
+ * related state writes and suppresses duplicate OSC output.
+ */
+export function installTerminalTitleUpdates(cwd: string) {
+  let disposed = false;
+  let suspended = false;
+  let synchronizationPending = false;
+  let lastTitle: string | undefined;
+  const synchronize = (): void => {
+    if (suspended) return;
+    const state = currentTerminalTitleState();
+    const title = terminalTitleText(cwd, state);
+    if (title === lastTitle) return;
+    lastTitle = title;
+    writeTerminalTitle(title);
+  };
+  const restoreIdleTitle = (): void => {
+    const idleTitle = terminalTitleText(cwd);
+    if (lastTitle === idleTitle) return;
+    lastTitle = idleTitle;
+    writeTerminalTitle(idleTitle);
+  };
+  const watcher = new Signal.subtle.Watcher(() => {
+    if (synchronizationPending) return;
+    synchronizationPending = true;
+    queueMicrotask(() => {
+      synchronizationPending = false;
+      if (disposed) return;
+      synchronize();
+      watcher.watch();
+    });
+  });
+  watcher.watch(approvalQueueStatus, rootRunPending, rootRunStreamId, streams);
+  synchronize();
+  // Synchronous signal exits bypass the normal disposer loop, but still emit
+  // `exit`; restore the title there as well as during graceful teardown.
+  process.on('exit', restoreIdleTitle);
+
+  const dispose = (): void => {
+    if (disposed) return;
+    disposed = true;
+    watcher.unwatch(
+      approvalQueueStatus,
+      rootRunPending,
+      rootRunStreamId,
+      streams,
+    );
+    process.off('exit', restoreIdleTitle);
+    restoreIdleTitle();
+  };
+
+  return {
+    suspend: () => {
+      if (disposed) return;
+      suspended = true;
+      restoreIdleTitle();
+    },
+    resume: () => {
+      if (disposed) return;
+      suspended = false;
+      synchronize();
+    },
+    dispose,
+  };
 }

--- a/packages/cli/src/chat/tui/terminalTitle.ts
+++ b/packages/cli/src/chat/tui/terminalTitle.ts
@@ -1,0 +1,113 @@
+import { writeSync } from 'node:fs';
+import { basename } from 'node:path';
+
+import { isActivePhase } from '@shared/streams/streamStatus';
+import { sanitizePathSegment } from '@utils/text/sanitizePathSegment';
+
+import { approvalQueueStatus } from './state/approvalQueue';
+import { rootRunPending, rootRunStreamId, streams } from './state/cliState';
+import { chatTuiCanStopActiveRun } from './state/sessionRunState';
+import { subscribeToSignalChanges } from './state/signalSubscription';
+import { terminalCapabilities } from './state/terminalCapabilities';
+
+// Directory names can contain characters that would prematurely terminate
+// the OSC string (a stray BEL/ESC) or that some terminals in 8-bit mode
+// still interpret as escape-sequence introducers (the C1 range, e.g. 0x9d
+// as an 8-bit OSC); strip both C0 and C1 controls so a weird folder name
+// can't inject terminal escape sequences into the title.
+// eslint-disable-next-line no-control-regex -- stripping C0/C1 controls
+const TITLE_INVALID_CHARS = /[\x00-\x1f\x7f-\x9f]/g;
+
+type TerminalTitleState = 'idle' | 'running' | 'approval';
+
+/** Project-aware terminal title, optionally annotated with live TUI state. */
+export function terminalTitleText(
+  cwd: string,
+  state: TerminalTitleState = 'idle',
+): string {
+  const project = sanitizePathSegment(basename(cwd), {
+    invalidCharPattern: TITLE_INVALID_CHARS,
+    replacement: '',
+  });
+  let activity: string | undefined;
+  if (state === 'approval') activity = 'Approval needed';
+  if (state === 'running') activity = 'Running';
+  return ['TeXRA', activity, project].filter(Boolean).join(' — ');
+}
+
+/** Write the title only when terminal capability discovery admitted OSC. */
+function writeTerminalTitle(title: string): void {
+  if (!terminalCapabilities.get().oscColorReports) return;
+  try {
+    writeSync(1, `\x1b]0;${title}\x07`);
+  } catch {
+    // The tab title is cosmetic; a write failure here isn't actionable.
+  }
+}
+
+function currentTerminalTitleState(): TerminalTitleState {
+  if (approvalQueueStatus.get().depth > 0) return 'approval';
+  const streamSlices = streams.get();
+  const rootStreamId = rootRunStreamId.get();
+  if (
+    chatTuiCanStopActiveRun({
+      runPending: rootRunPending.get(),
+      streamId: rootStreamId,
+      status: rootStreamId ? streamSlices.get(rootStreamId)?.status : undefined,
+    }) ||
+    [...streamSlices.values()].some((stream) => isActivePhase(stream.status))
+  ) {
+    return 'running';
+  }
+  return 'idle';
+}
+
+/** Keep the terminal title synchronized with existing TUI state. */
+export function installTerminalTitleUpdates(cwd: string) {
+  let disposed = false;
+  let suspended = false;
+  let lastTitle: string | undefined;
+  const synchronize = (): void => {
+    if (suspended) return;
+    const title = terminalTitleText(cwd, currentTerminalTitleState());
+    if (title === lastTitle) return;
+    lastTitle = title;
+    writeTerminalTitle(title);
+  };
+  const restoreIdleTitle = (): void => {
+    const idleTitle = terminalTitleText(cwd);
+    if (lastTitle === idleTitle) return;
+    lastTitle = idleTitle;
+    writeTerminalTitle(idleTitle);
+  };
+  const unsubscribe = subscribeToSignalChanges(
+    [approvalQueueStatus, rootRunPending, rootRunStreamId, streams],
+    synchronize,
+  );
+  synchronize();
+  // Synchronous signal exits bypass the normal disposer loop, but still emit
+  // `exit`; restore the title there as well as during graceful teardown.
+  process.on('exit', restoreIdleTitle);
+
+  const dispose = (): void => {
+    if (disposed) return;
+    disposed = true;
+    unsubscribe();
+    process.off('exit', restoreIdleTitle);
+    restoreIdleTitle();
+  };
+
+  return {
+    suspend: () => {
+      if (disposed) return;
+      suspended = true;
+      restoreIdleTitle();
+    },
+    resume: () => {
+      if (disposed) return;
+      suspended = false;
+      synchronize();
+    },
+    dispose,
+  };
+}

--- a/src/test-kernel/cli/RunChatSignalOwnership.vitest.mts
+++ b/src/test-kernel/cli/RunChatSignalOwnership.vitest.mts
@@ -28,6 +28,7 @@ const mocks = vi.hoisted(() => ({
   initCliPlatform: vi.fn(),
   initInteractiveCliPlatform: vi.fn(),
   installTerminalRestoreOnExit: vi.fn(),
+  installTerminalTitleUpdates: vi.fn(),
   loadInputHistory: vi.fn(),
   maybeRunCliOnboarding: vi.fn(),
   onSkillSelect: undefined as
@@ -36,6 +37,7 @@ const mocks = vi.hoisted(() => ({
   registerBuiltinSlashCommands: vi.fn(),
   render: vi.fn(),
   resolveChatDefaults: vi.fn(),
+  restoreTuiInputModes: vi.fn(),
   runCliPlatformShutdownSequence: vi.fn(),
   selectCliRunnableModel: vi.fn(),
   setCliHelperModel: vi.fn(),
@@ -43,6 +45,9 @@ const mocks = vi.hoisted(() => ({
   subscribeStreamLog: vi.fn(),
   subscribeStreamStatus: vi.fn(),
   supportsTerminalJobControl: vi.fn(),
+  terminalTitleDispose: vi.fn(),
+  terminalTitleResume: vi.fn(),
+  terminalTitleSuspend: vi.fn(),
   tuiOutputStreamForColor: vi.fn(),
   unmount: vi.fn(),
   waitUntilExit: vi.fn(),
@@ -124,6 +129,8 @@ vi.mock('@cli/chat/tui/terminalCleanup', async (importOriginal) => {
     ...actual,
     cleanupTerminalModes: mocks.cleanupTerminalModes,
     installTerminalRestoreOnExit: mocks.installTerminalRestoreOnExit,
+    installTerminalTitleUpdates: mocks.installTerminalTitleUpdates,
+    restoreTuiInputModes: mocks.restoreTuiInputModes,
     supportsTerminalJobControl: mocks.supportsTerminalJobControl,
   };
 });
@@ -240,6 +247,11 @@ describe('runChat signal ownership wiring', () => {
       oscColorReports: false,
     });
     mocks.installTerminalRestoreOnExit.mockReturnValue(() => undefined);
+    mocks.installTerminalTitleUpdates.mockReturnValue({
+      dispose: mocks.terminalTitleDispose,
+      resume: mocks.terminalTitleResume,
+      suspend: mocks.terminalTitleSuspend,
+    });
     mocks.subscribeStreamLog.mockReturnValue(() => undefined);
     mocks.subscribeStreamStatus.mockReturnValue(() => undefined);
     mocks.onSkillSelect = undefined;
@@ -268,6 +280,7 @@ describe('runChat signal ownership wiring', () => {
       mocks.callOrder.push('ink.render');
       return {
         clear: vi.fn(),
+        repaint: vi.fn(),
         rerender: vi.fn(),
         unmount: mocks.unmount,
         waitUntilExit: mocks.waitUntilExit,
@@ -276,7 +289,7 @@ describe('runChat signal ownership wiring', () => {
   });
 
   it('initializes the interactive platform and hands signal ownership to the mounted TUI', async () => {
-    const targetSignals = ['SIGINT', 'SIGTERM'] as const;
+    const targetSignals = ['SIGINT', 'SIGTERM', 'SIGTSTP', 'SIGCONT'] as const;
     type TargetSignal = (typeof targetSignals)[number];
     const baselineListeners = new Map(
       targetSignals.map(
@@ -288,9 +301,9 @@ describe('runChat signal ownership wiring', () => {
       event: string | symbol,
       listener: (...args: unknown[]) => void,
     ): void => {
-      if (event !== 'SIGINT' && event !== 'SIGTERM') return;
-      mocks.callOrder.push(`process.on:${event}`);
-      tuiListeners.set(event, listener);
+      if (!targetSignals.includes(event as TargetSignal)) return;
+      mocks.callOrder.push(`process.on:${String(event)}`);
+      tuiListeners.set(event as TargetSignal, listener);
     };
     const waitStarted = deferred();
     const exitTui = deferred();
@@ -308,6 +321,7 @@ describe('runChat signal ownership wiring', () => {
         onSubmit = element.props?.onSubmit;
         return {
           clear: vi.fn(),
+          repaint: vi.fn(),
           rerender: vi.fn(),
           unmount: mocks.unmount,
           waitUntilExit: mocks.waitUntilExit,
@@ -315,6 +329,8 @@ describe('runChat signal ownership wiring', () => {
       },
     );
     process.on('newListener', observeNewListener);
+    mocks.supportsTerminalJobControl.mockReturnValue(true);
+    const kill = vi.spyOn(process, 'kill').mockReturnValue(true);
 
     const agents = await import('@agent/index');
     const loadAgentsSpy = vi
@@ -346,6 +362,8 @@ describe('runChat signal ownership wiring', () => {
         'handOffCliShutdownSignalHandlers',
         'process.on:SIGINT',
         'process.on:SIGTERM',
+        'process.on:SIGTSTP',
+        'process.on:SIGCONT',
       ]);
 
       for (const signal of targetSignals) {
@@ -356,6 +374,17 @@ describe('runChat signal ownership wiring', () => {
           listener,
         ]);
       }
+
+      tuiListeners.get('SIGTSTP')?.();
+      expect(mocks.terminalTitleSuspend).toHaveBeenCalledTimes(1);
+      expect(mocks.cleanupTerminalModes).toHaveBeenCalledTimes(1);
+      expect(kill).toHaveBeenCalledWith(process.pid, 'SIGSTOP');
+
+      tuiListeners.get('SIGCONT')?.();
+      expect(mocks.restoreTuiInputModes).toHaveBeenCalledWith({
+        kittyKeyboard: false,
+      });
+      expect(mocks.terminalTitleResume).toHaveBeenCalledTimes(1);
 
       onSubmit?.('check the ordinary case', []);
       await vi.waitFor(() => expect(mocks.startRootRun).toHaveBeenCalled());
@@ -387,6 +416,7 @@ describe('runChat signal ownership wiring', () => {
       }
       loadAgentsSpy.mockRestore();
       getVisibleAgentsSpy.mockRestore();
+      kill.mockRestore();
     }
   });
 
@@ -402,6 +432,7 @@ describe('runChat signal ownership wiring', () => {
         onSubmit = element.props?.onSubmit;
         return {
           clear: vi.fn(),
+          repaint: vi.fn(),
           rerender: vi.fn(),
           unmount: mocks.unmount,
           waitUntilExit: mocks.waitUntilExit,

--- a/src/test-kernel/cli/RunChatSignalOwnership.vitest.mts
+++ b/src/test-kernel/cli/RunChatSignalOwnership.vitest.mts
@@ -331,6 +331,10 @@ describe('runChat signal ownership wiring', () => {
     process.on('newListener', observeNewListener);
     mocks.supportsTerminalJobControl.mockReturnValue(true);
     const kill = vi.spyOn(process, 'kill').mockReturnValue(true);
+    const exit = vi.spyOn(process, 'exit').mockImplementation(((code) => {
+      mocks.callOrder.push(`process.exit:${code}`);
+      return undefined as never;
+    }) as typeof process.exit);
 
     const agents = await import('@agent/index');
     const loadAgentsSpy = vi
@@ -396,10 +400,28 @@ describe('runChat signal ownership wiring', () => {
         workingDirectory: '/tmp/texra-chat',
       });
 
-      exitTui.resolve();
+      mocks.callOrder.length = 0;
+      mocks.terminalTitleSuspend.mockImplementationOnce(() => {
+        mocks.callOrder.push('terminalTitle.suspend');
+      });
+      mocks.unmount.mockImplementationOnce(() => {
+        mocks.callOrder.push('ink.unmount');
+        exitTui.resolve();
+      });
+      mocks.cleanupTerminalModes.mockImplementationOnce(() => {
+        mocks.callOrder.push('cleanupTerminalModes');
+      });
+      tuiListeners.get('SIGTERM')?.();
+      expect(mocks.callOrder.slice(0, 3)).toEqual([
+        'terminalTitle.suspend',
+        'ink.unmount',
+        'cleanupTerminalModes',
+      ]);
+
       await expect(runPromise).resolves.toEqual({
         exitCode: CliExitCode.Success,
       });
+      await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(143));
       for (const signal of targetSignals) {
         expect(process.listeners(signal)).toEqual(
           baselineListeners.get(signal) ?? [],
@@ -417,6 +439,7 @@ describe('runChat signal ownership wiring', () => {
       loadAgentsSpy.mockRestore();
       getVisibleAgentsSpy.mockRestore();
       kill.mockRestore();
+      exit.mockRestore();
     }
   });
 

--- a/src/test-kernel/cli/RunChatSignalOwnership.vitest.mts
+++ b/src/test-kernel/cli/RunChatSignalOwnership.vitest.mts
@@ -129,9 +129,17 @@ vi.mock('@cli/chat/tui/terminalCleanup', async (importOriginal) => {
     ...actual,
     cleanupTerminalModes: mocks.cleanupTerminalModes,
     installTerminalRestoreOnExit: mocks.installTerminalRestoreOnExit,
-    installTerminalTitleUpdates: mocks.installTerminalTitleUpdates,
     restoreTuiInputModes: mocks.restoreTuiInputModes,
     supportsTerminalJobControl: mocks.supportsTerminalJobControl,
+  };
+});
+
+vi.mock('@cli/chat/tui/terminalTitle', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@cli/chat/tui/terminalTitle')>();
+  return {
+    ...actual,
+    installTerminalTitleUpdates: mocks.installTerminalTitleUpdates,
   };
 });
 

--- a/src/test-kernel/cli/TerminalCleanup.vitest.mts
+++ b/src/test-kernel/cli/TerminalCleanup.vitest.mts
@@ -14,12 +14,14 @@ import {
   setStreamStatusInCliState,
 } from '@cli/chat/tui/state/cliState';
 import {
-  installTerminalTitleUpdates,
   installTerminalRestoreOnExit,
   supportsTerminalJobControl,
-  terminalTitleText,
   tuiInputModeRestoreSequence,
 } from '@cli/chat/tui/terminalCleanup';
+import {
+  installTerminalTitleUpdates,
+  terminalTitleText,
+} from '@cli/chat/tui/terminalTitle';
 import { STREAM_PHASE } from '@shared/schemas';
 
 vi.mock('node:fs', async (importOriginal) => ({

--- a/src/test-kernel/cli/TerminalCleanup.vitest.mts
+++ b/src/test-kernel/cli/TerminalCleanup.vitest.mts
@@ -4,12 +4,23 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { terminalCapabilities } from '@cli/chat/tui/state/terminalCapabilities';
 import {
+  approvalQueueStatus,
+  clearApprovals,
+} from '@cli/chat/tui/state/approvalQueue';
+import {
+  resetCliState,
+  rootRunPending,
+  rootRunStreamId,
+  setStreamStatusInCliState,
+} from '@cli/chat/tui/state/cliState';
+import {
+  installTerminalTitleUpdates,
   installTerminalRestoreOnExit,
-  setTerminalTitle,
   supportsTerminalJobControl,
   terminalTitleText,
   tuiInputModeRestoreSequence,
 } from '@cli/chat/tui/terminalCleanup';
+import { STREAM_PHASE } from '@shared/schemas';
 
 vi.mock('node:fs', async (importOriginal) => ({
   ...(await importOriginal()),
@@ -17,6 +28,8 @@ vi.mock('node:fs', async (importOriginal) => ({
 }));
 
 afterEach(() => {
+  clearApprovals();
+  resetCliState();
   vi.restoreAllMocks();
   // `writeSync` is a vi.fn() created inside the vi.mock() factory above, not
   // a vi.spyOn() wrapping a real implementation — restoreAllMocks() has no
@@ -44,6 +57,16 @@ describe('terminalTitleText', () => {
     expect(terminalTitleText('/')).toBe('TeXRA');
   });
 
+  it('adds running and approval labels before the project name', () => {
+    expect(terminalTitleText('/Users/ray/projects/coauthor', 'running')).toBe(
+      'TeXRA — Running — coauthor',
+    );
+    expect(terminalTitleText('/Users/ray/projects/coauthor', 'approval')).toBe(
+      'TeXRA — Approval needed — coauthor',
+    );
+    expect(terminalTitleText('/', 'running')).toBe('TeXRA — Running');
+  });
+
   it('strips control characters out of a hostile folder name', () => {
     expect(terminalTitleText('/tmp/evil\x07\x1b]0;pwned\x07')).toBe(
       'TeXRA — evil]0;pwned',
@@ -51,8 +74,8 @@ describe('terminalTitleText', () => {
   });
 });
 
-describe('setTerminalTitle', () => {
-  it('writes an OSC 0 title sequence on an OSC-capable terminal', () => {
+describe('installTerminalTitleUpdates', () => {
+  const enableOscTitles = (): void => {
     terminalCapabilities.set({
       kittyKeyboard: false,
       graphemeClusters: false,
@@ -60,24 +83,151 @@ describe('setTerminalTitle', () => {
       oscColorReports: true,
       discovered: true,
     });
+  };
+  const flushTitleUpdate = async (): Promise<void> => {
+    await Promise.resolve();
+  };
+  const expectLastTitle = (title: string): void => {
+    expect(writeSync).toHaveBeenLastCalledWith(1, `\x1b]0;${title}\x07`);
+  };
 
-    setTerminalTitle('/Users/ray/projects/coauthor');
+  it('shows root launch as running before the first stream status arrives', async () => {
+    enableOscTitles();
+    const updates = installTerminalTitleUpdates('/work/coauthor');
+    rootRunPending.set(true);
 
-    expect(writeSync).toHaveBeenCalledWith(1, '\x1b]0;TeXRA — coauthor\x07');
+    await flushTitleUpdate();
+
+    expectLastTitle('TeXRA — Running — coauthor');
+    updates.dispose();
   });
 
-  it('leaves the title alone on a terminal that never acknowledged OSC support', () => {
-    terminalCapabilities.set({
-      kittyKeyboard: false,
-      graphemeClusters: false,
-      bracketedPaste: false,
-      oscColorReports: false,
-      discovered: true,
+  it('stays running after the root id is published but before its status arrives', () => {
+    enableOscTitles();
+    rootRunPending.set(true);
+    rootRunStreamId.set('status-pending-root');
+
+    const updates = installTerminalTitleUpdates('/work/coauthor');
+
+    expectLastTitle('TeXRA — Running — coauthor');
+    updates.dispose();
+  });
+
+  it('uses every stream phase and gives queued approval precedence', async () => {
+    enableOscTitles();
+    const updates = installTerminalTitleUpdates('/work/coauthor');
+    rootRunPending.set(true);
+    rootRunStreamId.set('transition-root');
+    setStreamStatusInCliState({
+      streamId: 'transition-root',
+      status: STREAM_PHASE.WAITING,
     });
+    setStreamStatusInCliState({
+      streamId: 'transition-child',
+      status: STREAM_PHASE.RUNNING,
+    });
+    await flushTitleUpdate();
+    expectLastTitle('TeXRA — Running — coauthor');
 
-    setTerminalTitle('/Users/ray/projects/coauthor');
+    approvalQueueStatus.set({ depth: 1, kind: 'approval' });
+    await flushTitleUpdate();
+    expectLastTitle('TeXRA — Approval needed — coauthor');
 
+    approvalQueueStatus.set({ depth: 0, kind: 'approval' });
+    await flushTitleUpdate();
+    expectLastTitle('TeXRA — Running — coauthor');
+
+    setStreamStatusInCliState({
+      streamId: 'transition-child',
+      status: STREAM_PHASE.WAITING,
+    });
+    await flushTitleUpdate();
+    expectLastTitle('TeXRA — coauthor');
+    updates.dispose();
+  });
+
+  it('deduplicates unchanged title projections and resets an active title on teardown', async () => {
+    enableOscTitles();
+    const on = vi.spyOn(process, 'on');
+    const off = vi.spyOn(process, 'off');
+    const updates = installTerminalTitleUpdates('/work/coauthor');
+    const exitListener = on.mock.calls.find(([event]) => event === 'exit')?.[1];
+    setStreamStatusInCliState({
+      streamId: 'dedup-root',
+      status: STREAM_PHASE.RUNNING,
+    });
+    await flushTitleUpdate();
+    setStreamStatusInCliState({
+      streamId: 'dedup-child',
+      status: STREAM_PHASE.RUNNING,
+    });
+    await flushTitleUpdate();
+
+    expect(writeSync).toHaveBeenCalledTimes(2);
+    updates.dispose();
+    expect(writeSync).toHaveBeenCalledTimes(3);
+    expectLastTitle('TeXRA — coauthor');
+    expect(off).toHaveBeenCalledWith('exit', exitListener);
+  });
+
+  it('restores the idle title from the process-exit path', async () => {
+    enableOscTitles();
+    const on = vi.spyOn(process, 'on');
+    const updates = installTerminalTitleUpdates('/work/coauthor');
+    const exitListener = on.mock.calls.find(
+      ([event]) => event === 'exit',
+    )?.[1] as ((code: number) => void) | undefined;
+    setStreamStatusInCliState({
+      streamId: 'exit-root',
+      status: STREAM_PHASE.RUNNING,
+    });
+    await flushTitleUpdate();
+
+    exitListener?.(0);
+
+    expectLastTitle('TeXRA — coauthor');
+    expect(writeSync).toHaveBeenCalledTimes(3);
+    updates.dispose();
+    expect(writeSync).toHaveBeenCalledTimes(3);
+  });
+
+  it('shows the idle title while suspended and re-projects live state on resume', async () => {
+    enableOscTitles();
+    const updates = installTerminalTitleUpdates('/work/coauthor');
+    setStreamStatusInCliState({
+      streamId: 'suspend-root',
+      status: STREAM_PHASE.RUNNING,
+    });
+    await flushTitleUpdate();
+
+    updates.suspend();
+    expectLastTitle('TeXRA — coauthor');
+    approvalQueueStatus.set({ depth: 1, kind: 'approval' });
+    await flushTitleUpdate();
+    expect(writeSync).toHaveBeenCalledTimes(3);
+
+    updates.resume();
+    expectLastTitle('TeXRA — Approval needed — coauthor');
+    updates.dispose();
+  });
+
+  it('keeps sanitization and the OSC capability gate across live transitions', async () => {
+    const updates = installTerminalTitleUpdates(
+      '/tmp/evil\x07\x1b]0;pwned\x07',
+    );
+    rootRunPending.set(true);
+    await flushTitleUpdate();
+    updates.dispose();
     expect(writeSync).not.toHaveBeenCalled();
+
+    enableOscTitles();
+    const capableUpdates = installTerminalTitleUpdates(
+      '/tmp/evil\x07\x1b]0;pwned\x07',
+    );
+    rootRunPending.set(false);
+    await flushTitleUpdate();
+    expectLastTitle('TeXRA — evil]0;pwned');
+    capableUpdates.dispose();
   });
 });
 


### PR DESCRIPTION
## Summary

- preserve the idle `TeXRA — <project>` title while showing `Running` whenever the root launch is pending or any stream is active
- give queued human input precedence through `Approval needed`, then return immediately to the underlying running or idle projection
- restore the idle title on graceful teardown, process exit, and suspension, and re-project current state on resume
- retain OSC capability gating, path sanitization, and notification behavior while suppressing duplicate title writes

## Design

The projection reads the existing `approvalQueueStatus`, root-run signals, stream slices, `chatTuiCanStopActiveRun`, and `isActivePhase`; it introduces no second run or approval state. The root predicate intentionally covers both the interval before a stream id exists and the interval after the id is published but before its first status arrives.

`installTerminalTitleUpdates` has one composition-root caller, but it owns a substantive lifecycle boundary rather than forwarding values: full-title OSC deduplication, process-exit fallback, graceful disposal, and suspend/resume projection. The focused `terminalTitle.ts` module keeps this reactive presentation logic out of terminal mode cleanup and the Ink composition root.

The non-obvious Signal Watcher notification constraint, microtask coalescing, disposal guard, and re-arming now live in the two-consumer `subscribeToSignalChanges` primitive shared by React `useSignal` and the process-level title service. This removes lifecycle duplication without coupling terminal effects to React.

## Line accounting

- production: +164 / -68, net +96
- tests: +233 / -19, net +214
- total: +397 / -87, net +310
- relocated lines: 92 exact unchanged lines moved from `terminalCleanup.ts` into the focused title module

## Verification

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` — 0 errors; one unrelated pre-existing `prefer-string-replace-all` warning
- `npm run check:dead-code-ratchet` — 22 current findings versus 22 baselined
- focused terminal title and signal ownership suites — 18/18 tests
- broader CLI title/run-state/approval suites — 169/169 tests
- independent adversarial review after the suspend/resume correction — no findings
- focused signal-exit proof — terminal title reset precedes Ink unmount and terminal cleanup, with SIGTERM exit-code verification
- focused post-rebase rerun — 18/18 tests

No changelog entry is included because this issue explicitly requests none.

Closes #8980

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic terminal I/O and CLI lifecycle wiring only; no auth, data, or API surface changes. Risk is limited to title strings and teardown ordering around signals.
> 
> **Overview**
> Replaces the one-shot project tab title with **live terminal title updates** driven by existing TUI signals (approval queue depth, root-run pending/stream status, active stream phases).
> 
> Titles follow `TeXRA — [Running | Approval needed] — <project>`, with **approval taking precedence** over running. **OSC gating and path sanitization** are unchanged; duplicate OSC writes are skipped.
> 
> New `installTerminalTitleUpdates` owns signal watching (via shared `subscribeToSignalChanges`), suspend/resume around job control, and idle restoration on dispose, `process.exit`, and signal teardown. **Session exit** calls suspend before unmount on SIGTERM and on SIGTSTP; SIGCONT resumes live projection after terminal modes are restored.
> 
> `useSignal` now delegates watcher/microtask logic to the shared subscription helper (behavior preserved).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52bed42e0b623f5855e3bc5274c10b8399efcf47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->