### PR TITLE
fix(ui): clarify delegated approval toolbar scope

### DIFF
--- a/packages/extension/src/progressView/frontend/constants.ts
+++ b/packages/extension/src/progressView/frontend/constants.ts
@@ -1,5 +1,6 @@
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import type { AgentCategoryFilter } from '@shared/schemas';
+import { DELEGATION_APPROVAL_COPY } from '@shared/copy/delegationApproval';
 
 /**
  * DOM element IDs used across the progress view.
@@ -140,7 +141,7 @@ const DELEGATED_WORK_APPROVAL_TOGGLE_BUTTON = Object.freeze({
   id: ELEMENT_IDS.SUPER_YOLO_TOGGLE_BTN,
   icon: 'rocket',
   command: PROGRESS_VIEW_COMMANDS.TOGGLE_SUPER_YOLO_BYPASS,
-  title: 'Auto-approve tasks, file edits, and commands in this stream',
+  title: DELEGATION_APPROVAL_COPY.progressViewToggle,
   titleActive:
     'Task, edit, and command auto-approval active — click to resume prompts',
   className: 'super-yolo-toggle-button',

--- a/src/shared/copy/delegationApproval.ts
+++ b/src/shared/copy/delegationApproval.ts
@@ -5,4 +5,6 @@ export const DELEGATION_APPROVAL_COPY = {
   cliCompactAction: 'pending + later actions in run',
   progressViewAction:
     'Approve all pending and later tasks, edits & commands in this run',
+  progressViewToggle:
+    'Auto-approve tasks, file edits, and commands in this run',
 } as const;

--- a/src/test-kernel/progressView/StreamHeader.vitest.mts
+++ b/src/test-kernel/progressView/StreamHeader.vitest.mts
@@ -10,6 +10,7 @@ import {
   STREAM_PHASE,
   type StreamTabInfo,
 } from '@shared/schemas';
+import { DELEGATION_APPROVAL_COPY } from '@shared/copy/delegationApproval';
 
 // Local file imports
 import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
@@ -189,6 +190,19 @@ describe('stream-header', () => {
         `wa-tooltip[for="${ELEMENT_IDS.STOP_STREAM_BTN}"]`,
       );
       expect(stopTooltip).toBeTruthy();
+    });
+
+    it('describes delegated-work approval with its run-scoped shared copy', async () => {
+      const element = await mount({
+        stream: baseStream({ agentCategory: AgentCategory.ToolUse }),
+      });
+
+      const tooltip = element.shadowRoot?.querySelector(
+        `wa-tooltip[for="${ELEMENT_IDS.SUPER_YOLO_TOGGLE_BTN}"]`,
+      );
+      expect(tooltip?.textContent?.trim()).toBe(
+        DELEGATION_APPROVAL_COPY.progressViewToggle,
+      );
     });
 
     it('dispatches toolbar-command with the button-specific command on click', async () => {


### PR DESCRIPTION
## Summary

- replace the final delegated-work toolbar tooltip that still exposed the internal “stream” term
- keep the toolbar label in the shared run-scoped approval copy used by the other approval controls
- render the tool-use header in a focused component test and verify its tooltip against that shared source

## Line accounting

- production: +4 / -1, net +3
- tests: +14 / -0, net +14
- total: +18 / -1, net +17
- relocated lines: 0

## Verification

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` — 0 errors; one unrelated pre-existing `prefer-string-replace-all` warning
- `npm run check:dead-code-ratchet` — 22 current findings versus 22 baselined
- `corepack pnpm exec vitest run src/test-kernel/progressView/StreamHeader.vitest.mts src/test-kernel/progressView/ApproveSplitButton.vitest.mts` — 14/14 tests
- focused tests repeated after rebasing on current `origin/main` — 14/14 tests

No approval behavior or persisted/wire format changes. No changelog entry is included.

Closes #8981

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and test-only changes; no approval behavior, persistence, or wire format updates.
> 
> **Overview**
> Aligns the **delegated-work auto-approval** toolbar tooltip with the other run-scoped approval strings by moving its label into shared `DELEGATION_APPROVAL_COPY.progressViewToggle` and wiring the progress view toggle to that constant.
> 
> The wording shifts from **“in this stream”** to **“in this run”**, matching how approval scope is described elsewhere. A `StreamHeader` test mounts the tool-use header and asserts the super-yolo toggle tooltip equals the shared copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adbe755c376a0b362ee9f96c528cef48415ec867. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->