### PR TITLE
refactor(test): reuse shared memory state store

### DIFF
--- a/src/test-kernel/settings/BashApprovalConfigTarget.vitest.ts
+++ b/src/test-kernel/settings/BashApprovalConfigTarget.vitest.ts
@@ -7,27 +7,12 @@ import * as path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 // Local imports
-import type {
-  ConfigInspection,
-  ConfigTarget,
-  StateStore,
-} from '@platform/interfaces';
+import type { ConfigInspection, ConfigTarget } from '@platform/interfaces';
+import { MemoryStateStore } from '@platform/defaults/memoryState';
 import {
   BASH_APPROVAL_CONFIG_TARGET,
   setBashApprovalEnabled,
 } from '@shared/settingsView/handlers/approvalHandlers';
-
-class MemoryStateStore implements StateStore {
-  private readonly values = new Map<string, unknown>();
-
-  get<T>(key: string, defaultValue?: T): T {
-    return (this.values.has(key) ? this.values.get(key) : defaultValue) as T;
-  }
-
-  async update(key: string, value: unknown): Promise<void> {
-    this.values.set(key, value);
-  }
-}
 
 class RecordingConfigProvider {
   readonly updateCalls: Array<{

--- a/src/test-kernel/settings/BashApprovalGlobalMigration.vitest.ts
+++ b/src/test-kernel/settings/BashApprovalGlobalMigration.vitest.ts
@@ -6,26 +6,14 @@ import type {
   ConfigInspection,
   ConfigProvider,
   ConfigTarget,
-  StateStore,
 } from '@platform/interfaces';
+import { MemoryStateStore } from '@platform/defaults/memoryState';
 import { BASH_APPROVAL_CONFIG_KEY } from '@shared/schemas/agentCliSettings';
 import {
   BASH_APPROVAL_CONFIG_TARGET,
   migrateLegacyGlobalBashApprovalOverride,
 } from '@shared/settingsView/handlers/approvalHandlers';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
-
-class MemoryStateStore implements StateStore {
-  private readonly values = new Map<string, unknown>();
-
-  get<T>(key: string, defaultValue?: T): T {
-    return (this.values.has(key) ? this.values.get(key) : defaultValue) as T;
-  }
-
-  async update(key: string, value: unknown): Promise<void> {
-    this.values.set(key, value);
-  }
-}
 
 /**
  * Minimal in-memory `ConfigProvider` with real workspace -> global fallback


### PR DESCRIPTION
## Summary\n\n- delete two byte-for-byte local MemoryStateStore test doubles\n- reuse the existing platform MemoryStateStore already used across the test kernel\n- keep behavior unchanged while removing 27 net lines and two duplicate state implementations\n\n## Validation\n\n- npm run format:check\n- npm run typecheck\n- npm run compile:fast\n- npm run lint (0 errors; one unrelated existing warning)\n- npm run check:dead-code-ratchet\n- focused Bash approval settings suites: 9/9 tests\n\nCloses #8985

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only import refactor with no runtime or security behavior changes.
> 
> **Overview**
> Removes duplicate in-test `MemoryStateStore` implementations from `BashApprovalConfigTarget.vitest.ts` and `BashApprovalGlobalMigration.vitest.ts`, and wires both suites to the shared `@platform/defaults/memoryState` helper already used elsewhere in the test kernel.
> 
> No production or approval-handler logic changes—only fewer lines and one canonical test double for workspace/global state in these settings tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3427b54e6775853207282b7df33ea35c21c3877. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->