### PR TITLE
fix(desktop): preserve lock import in ESM bundle

### DIFF
--- a/packages/desktop/tests/e2e/jsonStoreStartup.spec.ts
+++ b/packages/desktop/tests/e2e/jsonStoreStartup.spec.ts
@@ -17,14 +17,22 @@ test('desktop main bundle completes its locked startup write', async () => {
 
   try {
     launched = await launchTexraApp({ workspacePath, userDataPath });
+    // Source of truth: initializeElectronPlatform() opens this store in
+    // packages/desktop/src/main/platform/index.ts.
+    const globalStatePath = join(userDataPath, 'state', 'global.json');
     const globalState = JSON.parse(
-      readFileSync(join(userDataPath, 'state', 'global.json'), 'utf8'),
+      readFileSync(globalStatePath, 'utf8'),
     ) as Record<string, unknown>;
 
     expect(globalState.lastKnownVersion).toEqual(expect.any(String));
   } finally {
     if (launched) await closeTexraApp(launched);
-    rmSync(workspacePath, { recursive: true, force: true });
-    rmSync(userDataPath, { recursive: true, force: true });
+    for (const path of [workspacePath, userDataPath]) {
+      try {
+        rmSync(path, { recursive: true, force: true });
+      } catch {
+        // Best-effort cleanup must not hide the startup assertion failure.
+      }
+    }
   }
 });

--- a/packages/desktop/tests/e2e/jsonStoreStartup.spec.ts
+++ b/packages/desktop/tests/e2e/jsonStoreStartup.spec.ts
@@ -1,0 +1,30 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { expect, test } from '@playwright/test';
+
+import {
+  closeTexraApp,
+  launchTexraApp,
+  type LaunchedApp,
+} from './electronApp.js';
+
+test('desktop main bundle completes its locked startup write', async () => {
+  const workspacePath = mkdtempSync(join(tmpdir(), 'texra-e2e-workspace-'));
+  const userDataPath = mkdtempSync(join(tmpdir(), 'texra-e2e-user-data-'));
+  let launched: LaunchedApp | undefined;
+
+  try {
+    launched = await launchTexraApp({ workspacePath, userDataPath });
+    const globalState = JSON.parse(
+      readFileSync(join(userDataPath, 'state', 'global.json'), 'utf8'),
+    ) as Record<string, unknown>;
+
+    expect(globalState.lastKnownVersion).toEqual(expect.any(String));
+  } finally {
+    if (launched) await closeTexraApp(launched);
+    rmSync(workspacePath, { recursive: true, force: true });
+    rmSync(userDataPath, { recursive: true, force: true });
+  }
+});

--- a/src/platform/defaults/jsonStore.ts
+++ b/src/platform/defaults/jsonStore.ts
@@ -1,6 +1,7 @@
 import { chmod, mkdir, readFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 
+import { lock } from 'proper-lockfile';
 import writeFileAtomic from 'write-file-atomic';
 
 import { isFileNotFoundError } from '@common/errors';
@@ -159,7 +160,6 @@ export class JsonStore implements StateStore {
     missingFallback: JsonRecord,
   ): Promise<void> {
     await ensureDir(dirname(this.filePath), this.options.mode);
-    const { lock } = await import('proper-lockfile');
     const release = await lock(this.filePath, {
       realpath: false,
       stale: LOCK_STALE_MS,

--- a/src/platform/defaults/jsonStore.ts
+++ b/src/platform/defaults/jsonStore.ts
@@ -1,7 +1,6 @@
 import { chmod, mkdir, readFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 
-import { lock } from 'proper-lockfile';
 import writeFileAtomic from 'write-file-atomic';
 
 import { isFileNotFoundError } from '@common/errors';
@@ -160,7 +159,8 @@ export class JsonStore implements StateStore {
     missingFallback: JsonRecord,
   ): Promise<void> {
     await ensureDir(dirname(this.filePath), this.options.mode);
-    const release = await lock(this.filePath, {
+    const { default: properLockfile } = await import('proper-lockfile');
+    const release = await properLockfile.lock(this.filePath, {
       realpath: false,
       stale: LOCK_STALE_MS,
       retries: LOCK_RETRY_OPTIONS,

--- a/src/test-kernel/desktop/JsonStore.vitest.mts
+++ b/src/test-kernel/desktop/JsonStore.vitest.mts
@@ -19,7 +19,7 @@ import { build } from 'esbuild';
 import { afterEach, describe, expect, it } from 'vitest';
 
 // Local imports - test support
-import { repoPath } from './desktopTestPaths.mjs';
+import { moduleFileUrl, repoPath } from './desktopTestPaths.mjs';
 import { loadPlatformDefaultsModule } from './loadPlatformDefaultsModule.mjs';
 
 const require = createRequire(import.meta.url);
@@ -144,6 +144,35 @@ describe('shared JsonStore', () => {
     expect(JSON.parse(await readFile(filePath, 'utf8'))).toEqual({
       fromA: 'a',
       fromB: 'b',
+    });
+  });
+
+  it('keeps the lock function callable in a split ESM bundle', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'texra-json-store-bundle-'));
+    const outdir = join(tempDir, 'bundle');
+    await build({
+      entryPoints: {
+        jsonStore: repoPath('src', 'platform', 'defaults', 'jsonStore.ts'),
+      },
+      bundle: true,
+      format: 'esm',
+      splitting: true,
+      platform: 'node',
+      outdir,
+      outExtension: { '.js': '.mjs' },
+      logLevel: 'silent',
+    });
+
+    const { JsonStore } = (await import(
+      moduleFileUrl(join(outdir, 'jsonStore.mjs'))
+    )) as JsonStoreModule;
+    const filePath = join(tempDir, 'state.json');
+    const store = await JsonStore.open(filePath);
+
+    await store.set('persisted', true);
+
+    expect(JSON.parse(await readFile(filePath, 'utf8'))).toEqual({
+      persisted: true,
     });
   });
 


### PR DESCRIPTION
## Summary

- consume `proper-lockfile` through its lazy default CommonJS namespace so esbuild preserves the callable API in the split desktop ESM bundle
- keep the dependency lazy because its lock-cleanup registration owns process signal listeners; eager loading would violate CLI signal ownership
- execute both a split ESM `JsonStore` bundle and the real Electron main bundle in regression tests
- verify the actual startup path completes its locked `lastKnownVersion` write before exposing the window

Closes #8989

## Validation

- `corepack pnpm exec vitest run src/test-kernel/desktop/JsonStore.vitest.mts` (12/12)
- `corepack pnpm exec vitest run src/test-kernel/cli/RunChatSignalOwnership.vitest.mts` (2/2)
- `corepack pnpm --filter @texra/desktop build:main`
- `corepack pnpm --filter @texra/desktop exec playwright test tests/e2e/jsonStoreStartup.spec.ts --reporter=line` (1/1)
- real Electron launcher trajectory (1/1)
- `corepack pnpm exec tsc --noEmit`
- `npm run compile:fast`
- `npm run lint` (0 errors; one pre-existing warning)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cross-process file locking on the desktop persistence path; change is small but failure modes affect startup state writes.
> 
> **Overview**
> Fixes **desktop startup persistence** when `JsonStore` is bundled as split ESM: the lazy `proper-lockfile` import now uses the module’s **default export** (`properLockfile.lock`) so esbuild keeps a callable lock API instead of a broken namespace re-export.
> 
> Adds regression coverage at two levels: a **Vitest** case that esbuild-bundles `jsonStore` with splitting and asserts a write succeeds, and a **Playwright** e2e that launches the real Electron main bundle and checks `userData/state/global.json` contains `lastKnownVersion` after startup (locked write on the real path).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7febe4376000f704f98039eb3788524b8a8c3e4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->