### PR TITLE
refactor(desktop): release menu callbacks on close

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1144,6 +1144,9 @@ function createWindow(options: {
     executionsWatcher?.close();
     if (mainWindow === window) {
       mainWindow = null;
+      if (process.platform === 'darwin') {
+        Menu.setApplicationMenu(Menu.buildFromTemplate([{ role: 'appMenu' }]));
+      }
     }
     disposeAgentResumeHandler();
     agentExecutionShutdownRegistration?.dispose();

--- a/packages/desktop/tests/e2e/menuLifetime.spec.ts
+++ b/packages/desktop/tests/e2e/menuLifetime.spec.ts
@@ -1,0 +1,123 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { expect, test } from '@playwright/test';
+
+import {
+  closeTexraApp,
+  launchTexraApp,
+  type LaunchedApp,
+} from './electronApp.js';
+
+let launched: LaunchedApp | undefined;
+let userDataPath: string | undefined;
+
+test.afterEach(async () => {
+  if (launched) await closeTexraApp(launched);
+  launched = undefined;
+  try {
+    if (userDataPath) rmSync(userDataPath, { recursive: true, force: true });
+  } catch {
+    // Best-effort cleanup must not hide the lifetime assertion that failed.
+  }
+  userDataPath = undefined;
+});
+
+test('application menu releases a closed window and binds once to its replacement', async () => {
+  test.skip(
+    process.platform !== 'darwin',
+    'The application menu outlives the last window only on macOS.',
+  );
+  userDataPath = mkdtempSync(join(tmpdir(), 'texra-menu-lifetime-'));
+  launched = await launchTexraApp({ userDataPath });
+
+  const windowAId = await launched.app.evaluate(({ BrowserWindow, Menu }) => {
+    const window = BrowserWindow.getAllWindows()[0];
+    if (!window) throw new Error('Window A was not created');
+    const menu = Menu.getApplicationMenu();
+    if (!menu) throw new Error('Window A application menu was not installed');
+    return window.id;
+  });
+
+  await launched.page.close();
+  await expect.poll(() => launched?.app.windows().length).toBe(0);
+
+  const windowlessProbe = await launched.app.evaluate(
+    ({ BrowserWindow, Menu }, closedWindowId) => {
+      const menu = Menu.getApplicationMenu();
+      const showLogs = (menu?.items ?? [])
+        .flatMap((item) => item.submenu?.items ?? [])
+        .find((item) => item.label === 'Show Logs');
+      const appMenu = menu?.items.find((item) => item.role === 'appmenu');
+      const quit = appMenu?.submenu?.items.find((item) => item.role === 'quit');
+      showLogs?.click(showLogs, BrowserWindow.getFocusedWindow() ?? undefined, {
+        triggeredByAccelerator: false,
+      });
+      return {
+        closedWindowStillAttached: BrowserWindow.getAllWindows().some(
+          (window) => window.id === closedWindowId,
+        ),
+        processMenuInstalled: menu != null,
+        quitCommandInstalled: quit != null,
+        windowCommandInstalled: showLogs != null,
+      };
+    },
+    windowAId,
+  );
+  expect(windowlessProbe).toEqual({
+    closedWindowStillAttached: false,
+    processMenuInstalled: true,
+    quitCommandInstalled: true,
+    windowCommandInstalled: false,
+  });
+
+  const windowBPromise = launched.app.waitForEvent('window');
+  await launched.app.evaluate(({ app }) => {
+    app.emit('activate');
+  });
+  const windowB = await windowBPromise;
+  await windowB.waitForSelector('#app', { state: 'attached' });
+
+  await windowB.evaluate(() => {
+    document.body.dataset.menuRouteMessageCount = '0';
+    window.addEventListener('message', (event) => {
+      const message = event.data as { command?: unknown; route?: unknown };
+      if (message.command !== 'desktop:setRoute' || message.route !== 'logs') {
+        return;
+      }
+      const current = Number.parseInt(
+        document.body.dataset.menuRouteMessageCount ?? '0',
+        10,
+      );
+      document.body.dataset.menuRouteMessageCount = String(current + 1);
+    });
+  });
+
+  const replacementProbe = await launched.app.evaluate(
+    ({ BrowserWindow, Menu }, closedWindowId) => {
+      const window = BrowserWindow.getAllWindows()[0];
+      if (!window) throw new Error('Window B was not created');
+      const menu = Menu.getApplicationMenu();
+      const showLogs = (menu?.items ?? [])
+        .flatMap((item) => item.submenu?.items ?? [])
+        .find((item) => item.label === 'Show Logs');
+      if (!showLogs) throw new Error('Window B menu command was not installed');
+      showLogs.click(showLogs, window, { triggeredByAccelerator: false });
+      return {
+        closedWindowReused: window.id === closedWindowId,
+        windowBId: window.id,
+      };
+    },
+    windowAId,
+  );
+  expect(replacementProbe.closedWindowReused).toBe(false);
+  expect(replacementProbe.windowBId).not.toBe(windowAId);
+  await expect
+    .poll(() =>
+      windowB.evaluate(
+        () => document.body.dataset.menuRouteMessageCount ?? '0',
+      ),
+    )
+    .toBe('1');
+});


### PR DESCRIPTION
Closes #8987.

## What changed

- replace the last closed window menu with a native process-only macOS app menu, retaining Quit while releasing window callbacks
- keep cleanup at the existing window-ownership boundary, so a stale close callback cannot replace a newer window menu
- cover the actual Electron lifetime: close window A, prove the native app/Quit menu remains without window commands, reactivate the app, then prove one menu click routes exactly once to window B

This releases the retained global callback graph at its owner instead of adding weak references, callback guards, or a second menu registry.

## Verification

- `pnpm --filter @texra/desktop build`
- `pnpm --filter @texra/desktop typecheck`
- `pnpm --filter @texra/desktop exec playwright test tests/e2e/menuLifetime.spec.ts --reporter=line` (1 passed on macOS in 3.4s)
- `npm run format`
- `npm run compile:fast`
- `npm run lint` (0 errors; one pre-existing AgentCreatorToolCatalogParity warning)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, macOS-only menu lifecycle change at window close with targeted e2e coverage; no auth, data, or cross-platform behavior changes.
> 
> **Overview**
> On **macOS**, when the last main window closes, the app menu is swapped from the full `buildDesktopMenuTemplate(shellActions)` bar to a **native process-only** template (`{ role: 'appMenu' }`), so window-scoped menu callbacks are dropped while **Quit** stays available for the dock-only lifetime.
> 
> A new **Playwright e2e** (`menuLifetime.spec.ts`, darwin-only) closes window A, asserts window commands like **Show Logs** are gone but Quit remains, reactivates to create window B, and checks **Show Logs** routes exactly once to the new window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d758a17685816468932d52faa1ad549ab6414a8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->