### PR TITLE
test(desktop): canonicalize relaunch workspace path

### DIFF
--- a/packages/desktop/tests/e2e/settingsPersistence.spec.ts
+++ b/packages/desktop/tests/e2e/settingsPersistence.spec.ts
@@ -1,6 +1,7 @@
 import {
   mkdirSync,
   mkdtempSync,
+  realpathSync,
   readdirSync,
   readFileSync,
   rmSync,
@@ -46,7 +47,7 @@ function findWorkspaceStoragePath(input: {
   userDataPath: string;
   workspacePath: string;
 }): string {
-  const targetWorkspacePath = resolve(input.workspacePath);
+  const targetWorkspacePath = realpathSync(input.workspacePath);
 
   for (const storageRoot of readdirSync(input.userDataPath, {
     withFileTypes: true,


### PR DESCRIPTION
## Summary

- canonicalize the temporary workspace path before matching Electron workspace storage metadata
- keep the persisted sidecar comparison aligned with the physical path recorded by production

## Root cause

On macOS, temporary paths may be presented through `/var` while `realpath` resolves them to `/private/var`. Production records the physical workspace path, but the relaunch test compared it with the unresolved input path, so it could not find the storage bucket it had just created.

## Validation

- reproduced the focused Electron e2e failure before the change
- `pnpm --filter @texra/desktop exec playwright test tests/e2e/settingsPersistence.spec.ts --reporter=line`
- `npm run compile:fast`
- `npm run lint` (passes with one unrelated pre-existing warning)

Closes #8992

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to path canonicalization in one Playwright spec; no production behavior affected.
> 
> **Overview**
> Fixes a flaky/failing **settings persistence** Electron e2e on macOS by matching workspace storage the same way production does.
> 
> `findWorkspaceStoragePath` now uses **`realpathSync`** on the temp workspace path instead of **`resolve`**, so paths like `/var/...` compare equal to the physical `/private/var/...` stored in `_workspace.json`. The test can again locate the workspace bucket after relaunch when seeding memory fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ef16325fef7b4101e596ad3327c58df6394ecfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->