### PR TITLE
fix(cli): make API-key retry switches coherent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,9 @@ All notable changes to this project will be documented in this file.
   navigation returns to the owning session after a subagent is stopped.
 - **API-key retries use the current saved key** — retrying after a relay or
   subscription limit rechecks the selected provider key before switching. If
-  no key is available, the CLI directs you to `/key`; a failed switch leaves
-  your access settings unchanged.
+  no key is available, the CLI directs you to `/key`. If a replacement client
+  cannot be prepared, the CLI restores the previous settings and reports any
+  setting whose persistence cannot be confirmed.
 
 ### Desktop
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ All notable changes to this project will be documented in this file.
   concise provider message and are no longer labeled as tool failures.
 - **Escape stops only the focused agent** — other running agents continue, and
   navigation returns to the owning session after a subagent is stopped.
+- **API-key retries use the current saved key** — retrying after a relay or
+  subscription limit rechecks the selected provider key before switching. If
+  no key is available, the CLI directs you to `/key`; a failed switch leaves
+  your access settings unchanged.
 
 ### Desktop
 

--- a/packages/cli/src/chat/tui/modals/RetryRequest.tsx
+++ b/packages/cli/src/chat/tui/modals/RetryRequest.tsx
@@ -4,21 +4,25 @@ import {
   isCliApiSwitchableRetry,
   isCliChatGptSubscriptionRetry,
 } from '@cli/runtime/approvalAdapter';
-import type { RetryPermission } from '@shared/schemas';
-
 import { ConfirmCard } from './ConfirmCard';
 import { COLOR_HINT, COLOR_WARNING } from '../ui/colors';
-import type { ApprovalDecision } from '../state/approvalQueue';
+import {
+  MISSING_OPENAI_KEY_RETRY_MESSAGE,
+  type ApprovalDecision,
+  type TuiRetryRequest,
+} from '../state/approvalQueue';
 
 export interface RetryRequestProps {
-  readonly payload: RetryPermission;
+  readonly payload: TuiRetryRequest;
   readonly onDecide: (decision: ApprovalDecision) => void;
 }
 
 export function RetryRequest(props: RetryRequestProps): React.JSX.Element {
   const subject = props.payload.errorMessage ?? props.payload.operation;
   const isChatGptSubscription = isCliChatGptSubscriptionRetry(props.payload);
-  const canSwitchToPersonalKey = isCliApiSwitchableRetry(props.payload);
+  const personalApiKeyAvailable = props.payload.personalApiKeyAvailable;
+  const canSwitchToPersonalKey =
+    isCliApiSwitchableRetry(props.payload) && personalApiKeyAvailable === true;
   // Both switches flip the api-mode to personal keys so the retry uses the
   // user's own key (not the relay JWT); the subscription switch additionally
   // turns off the "prefer ChatGPT subscription" preference.
@@ -28,6 +32,20 @@ export function RetryRequest(props: RetryRequestProps): React.JSX.Element {
   const switchHint = isChatGptSubscription
     ? 'Press k to switch from your ChatGPT subscription to your OpenAI API key before retrying.'
     : 'Press k to switch to personal API keys before retrying.';
+  let keyGuidance: React.JSX.Element | null = null;
+  if (
+    isCliApiSwitchableRetry(props.payload) &&
+    personalApiKeyAvailable !== true
+  ) {
+    keyGuidance = (
+      <Text color={COLOR_HINT}>
+        {props.payload.missingPersonalApiKeyMessage ??
+          MISSING_OPENAI_KEY_RETRY_MESSAGE}
+      </Text>
+    );
+  } else if (canSwitchToPersonalKey) {
+    keyGuidance = <Text color={COLOR_HINT}>{switchHint}</Text>;
+  }
   return (
     <ConfirmCard
       borderStyle="single"
@@ -52,9 +70,7 @@ export function RetryRequest(props: RetryRequestProps): React.JSX.Element {
       <Box marginY={1}>
         <Text dimColor>{subject}</Text>
       </Box>
-      {canSwitchToPersonalKey ? (
-        <Text color={COLOR_HINT}>{switchHint}</Text>
-      ) : null}
+      {keyGuidance}
     </ConfirmCard>
   );
 }

--- a/packages/cli/src/chat/tui/modals/RetryRequest.tsx
+++ b/packages/cli/src/chat/tui/modals/RetryRequest.tsx
@@ -4,6 +4,7 @@ import {
   isCliApiSwitchableRetry,
   isCliChatGptSubscriptionRetry,
 } from '@cli/runtime/approvalAdapter';
+import { isApiProvider } from '@model/apiProviders';
 import { ConfirmCard } from './ConfirmCard';
 import { COLOR_HINT, COLOR_WARNING } from '../ui/colors';
 import {
@@ -37,10 +38,15 @@ export function RetryRequest(props: RetryRequestProps): React.JSX.Element {
     isCliApiSwitchableRetry(props.payload) &&
     personalApiKeyAvailable !== true
   ) {
+    const requestedProvider = props.payload.errorDetails?.provider;
+    const provider =
+      requestedProvider && isApiProvider(requestedProvider)
+        ? requestedProvider
+        : undefined;
     keyGuidance = (
       <Text color={COLOR_HINT}>
         {props.payload.missingPersonalApiKeyMessage ??
-          missingApiKeyRetryMessage('openai')}
+          missingApiKeyRetryMessage(provider)}
       </Text>
     );
   } else if (canSwitchToPersonalKey) {

--- a/packages/cli/src/chat/tui/modals/RetryRequest.tsx
+++ b/packages/cli/src/chat/tui/modals/RetryRequest.tsx
@@ -7,10 +7,10 @@ import {
 import { ConfirmCard } from './ConfirmCard';
 import { COLOR_HINT, COLOR_WARNING } from '../ui/colors';
 import {
-  MISSING_OPENAI_KEY_RETRY_MESSAGE,
   type ApprovalDecision,
   type TuiRetryRequest,
 } from '../state/approvalQueue';
+import { missingApiKeyRetryMessage } from '../ui/retryCopy';
 
 export interface RetryRequestProps {
   readonly payload: TuiRetryRequest;
@@ -40,7 +40,7 @@ export function RetryRequest(props: RetryRequestProps): React.JSX.Element {
     keyGuidance = (
       <Text color={COLOR_HINT}>
         {props.payload.missingPersonalApiKeyMessage ??
-          MISSING_OPENAI_KEY_RETRY_MESSAGE}
+          missingApiKeyRetryMessage('openai')}
       </Text>
     );
   } else if (canSwitchToPersonalKey) {

--- a/packages/cli/src/chat/tui/state/approvalQueue.ts
+++ b/packages/cli/src/chat/tui/state/approvalQueue.ts
@@ -27,9 +27,6 @@ import { assertNever } from '@utils/core';
 export type ApprovalBypassKind = HostApprovalBypassKind;
 export type ApprovalQueueStatusKind = 'approval' | 'question' | 'request';
 
-export const MISSING_OPENAI_KEY_RETRY_MESSAGE =
-  'No OpenAI API key is configured. Press n to give up, then use `/key` to add one.';
-
 export type TuiRetryRequest = RetryPermission & {
   readonly personalApiKeyAvailable?: boolean;
   readonly missingPersonalApiKeyMessage?: string;

--- a/packages/cli/src/chat/tui/state/approvalQueue.ts
+++ b/packages/cli/src/chat/tui/state/approvalQueue.ts
@@ -27,12 +27,23 @@ import { assertNever } from '@utils/core';
 export type ApprovalBypassKind = HostApprovalBypassKind;
 export type ApprovalQueueStatusKind = 'approval' | 'question' | 'request';
 
+export const MISSING_OPENAI_KEY_RETRY_MESSAGE =
+  'No OpenAI API key is configured. Press n to give up, then use `/key` to add one.';
+
+export type TuiRetryRequest = RetryPermission & {
+  readonly personalApiKeyAvailable?: boolean;
+  readonly missingPersonalApiKeyMessage?: string;
+};
+
 export type ApprovalPayload =
   | { kind: 'bash'; payload: BashPermission }
   | { kind: 'toolEdit'; payload: ToolEditApprovalRequest }
   | { kind: 'plan'; payload: PlanApprovalPermission }
   | { kind: 'proposal'; payload: AgentProposalPermission }
-  | { kind: 'retry'; payload: RetryPermission }
+  | {
+      kind: 'retry';
+      payload: TuiRetryRequest;
+    }
   | { kind: 'externalInquiry'; payload: ExternalInquiryPermission }
   | { kind: 'userQuestion'; payload: UserQuestionPermission };
 

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -55,7 +55,6 @@ import {
 } from '@model/apiProviders';
 import { platform } from '@platform/platform';
 import { isUpstreamCreditDepletedError } from '@shared/schemas';
-import { PROVIDER_DISPLAY_NAMES } from '@shared/constants/providers';
 import {
   setBashApprovalSessionBypass,
   setDelegatedWorkApprovalBypasses,
@@ -74,12 +73,12 @@ import {
   clearApprovalsWhere,
   clearRetryApprovalsForStream,
   enqueueApproval,
-  MISSING_OPENAI_KEY_RETRY_MESSAGE,
   onApprovalsCleared,
   type ApprovalDecision,
   type ApprovalPayload,
   type TuiRetryRequest,
 } from './approvalQueue';
+import { missingApiKeyRetryMessage } from '../ui/retryCopy';
 
 // =========================================================================
 // Retry auto-switch: skip the modal when a usable personal key exists
@@ -514,18 +513,14 @@ async function requestRetryInteraction(
             : undefined;
         const personalApiKeyAvailable = provider
           ? await hasUsableApiKey(platform().secrets, provider).catch(
+              // A keychain failure must not permit an automatic credential switch.
               () => false,
             )
           : false;
-        const providerName = provider
-          ? (PROVIDER_DISPLAY_NAMES[provider] ?? provider)
-          : undefined;
         promptRequest = {
           ...request,
           personalApiKeyAvailable,
-          missingPersonalApiKeyMessage: providerName
-            ? `No ${providerName} API key is configured. Press n to give up, then use \`/key\` to add one.`
-            : 'The failed API provider could not be identified. Press n to give up, then use `/key` to verify the correct provider key.',
+          missingPersonalApiKeyMessage: missingApiKeyRetryMessage(provider),
         };
       }
       if (!isCurrent()) return;
@@ -666,9 +661,7 @@ async function applyRetrySideEffects(
   }
   const missingKeyMessage =
     request.missingPersonalApiKeyMessage ??
-    (requestedProvider === 'openai'
-      ? MISSING_OPENAI_KEY_RETRY_MESSAGE
-      : `No ${PROVIDER_DISPLAY_NAMES[requestedProvider] ?? requestedProvider} API key is configured. Press n to give up, then use \`/key\` to add one.`);
+    missingApiKeyRetryMessage(requestedProvider);
   const validateCurrentKey = async (): Promise<void> => {
     const keyExists = await apiKeyExistsUncached(
       platform().secrets,

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -553,6 +553,13 @@ async function requestRetryInteraction(
               prepareRetry: options?.prepareRetry,
             }),
           );
+        } else if (options?.prepareRetry) {
+          // Client construction is a read of process-wide credential state.
+          // Linearize it with credential writes so it cannot observe a route
+          // that a concurrent switch later rolls back.
+          await retryCredentialSwitchQueue.add(async () => {
+            if (isCurrent()) await options.prepareRetry?.();
+          });
         }
         if (!isCurrent()) return;
         resolve({ action: 'retry', feedback: decision.userMessage });

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -268,12 +268,16 @@ interface ActiveRetryRoute {
   readonly settle?: (result: RetryResult) => void;
 }
 
-// API mode and ChatGPT preference are process-wide. Keep their transactional
-// switch and rollback indivisible across concurrent stream retry decisions.
-const retryCredentialSwitchQueue = new PQueue({ concurrency: 1 });
+// API mode and ChatGPT preference are two persisted fields that form one user
+// choice. Serialize only their commit/rollback window; candidate construction
+// happens before this queue while the published preference remains unchanged.
+const retryCredentialCommitQueue = new PQueue({ concurrency: 1 });
 
 function prepareRetryClient(
   prepare: NonNullable<HostRetryInteractionOptions['prepareRetry']>,
+  selection: Parameters<
+    NonNullable<HostRetryInteractionOptions['prepareRetry']>
+  >[0],
   signal: AbortSignal,
 ): Promise<void> {
   signal.throwIfAborted();
@@ -281,7 +285,7 @@ function prepareRetryClient(
     const onAbort = () => reject(signal.reason);
     signal.addEventListener('abort', onAbort, { once: true });
     try {
-      prepare(signal).then(
+      prepare(selection, signal).then(
         () => {
           signal.removeEventListener('abort', onAbort);
           resolve();
@@ -599,26 +603,17 @@ async function requestRetryInteraction(
           decision.apiMode !== undefined ||
           decision.disableChatGptSubscription === true;
         if (changesCredentialRoute) {
-          await retryCredentialSwitchQueue.add(() =>
-            applyRetrySideEffects(decision, promptRequest, {
-              isCurrent,
-              prepareRetry: options?.prepareRetry,
-              preparationSignal: preparationController.signal,
-            }),
-          );
-        } else if (options?.prepareRetry) {
-          const prepareRetry = options.prepareRetry;
-          // Client construction is a read of process-wide credential state.
-          // Linearize it with credential writes so it cannot observe a route
-          // that a concurrent switch later rolls back.
-          await retryCredentialSwitchQueue.add(async () => {
-            if (isCurrent()) {
-              await prepareRetryClient(
-                prepareRetry,
-                preparationController.signal,
-              );
-            }
+          await switchRetryToPersonalCredentials(decision, promptRequest, {
+            isCurrent,
+            prepareRetry: options?.prepareRetry,
+            preparationSignal: preparationController.signal,
           });
+        } else if (options?.prepareRetry) {
+          await prepareRetryClient(
+            options.prepareRetry,
+            'configured',
+            preparationController.signal,
+          );
         }
         if (!isCurrent()) return;
         resolve({ action: 'retry', feedback: decision.userMessage });
@@ -708,7 +703,7 @@ function setTuiApprovalBypassState({
   }));
 }
 
-async function applyRetrySideEffects(
+async function switchRetryToPersonalCredentials(
   decision: ApprovalDecision,
   request: TuiRetryRequest,
   options: {
@@ -743,92 +738,98 @@ async function applyRetrySideEffects(
 
   await validateCurrentKey();
 
-  const previousApiMode = getCliApiMode();
-  const previousSubscriptionPreference = isPreferCodexSubscription();
-  let apiModeWriteStarted = false;
-  let subscriptionWriteStarted = false;
-  try {
-    if (decision.apiMode) {
-      apiModeWriteStarted = true;
-      await setCliApiMode(decision.apiMode);
-      if (!isCurrent()) throw new Error('Retry request was replaced.');
-    }
-    if (decision.disableChatGptSubscription) {
-      subscriptionWriteStarted = true;
-      const update = await setCliCodexSubscription(false);
-      if (update.effective) {
-        throw new Error(
-          'ChatGPT subscription remains enabled by a more specific setting.',
-        );
+  if (!options.prepareRetry) {
+    throw new Error('The model client cannot be refreshed for this retry.');
+  }
+  await prepareRetryClient(
+    options.prepareRetry,
+    'personal',
+    options.preparationSignal ?? new AbortController().signal,
+  );
+  if (!isCurrent()) throw new Error('Retry request was replaced.');
+
+  await retryCredentialCommitQueue.add(async () => {
+    if (!isCurrent()) throw new Error('Retry request was replaced.');
+    const previousApiMode = getCliApiMode();
+    const previousSubscriptionPreference = isPreferCodexSubscription();
+    let apiModeWriteStarted = false;
+    let subscriptionWriteStarted = false;
+    try {
+      if (decision.apiMode) {
+        apiModeWriteStarted = true;
+        await setCliApiMode(decision.apiMode);
+        if (!isCurrent()) throw new Error('Retry request was replaced.');
       }
-      if (!isCurrent()) throw new Error('Retry request was replaced.');
-    }
-    if (!options.prepareRetry) {
-      throw new Error('The model client cannot be refreshed for this retry.');
-    }
-    // Settings select the route used by getClient(), so construct only after
-    // they change. Revalidate once more in case the key changed during either
-    // persisted setting write, then invalidate before construction.
-    await validateCurrentKey();
-    await prepareRetryClient(
-      options.prepareRetry,
-      options.preparationSignal ?? new AbortController().signal,
-    );
-    // Commit invariant: no retry proceeds unless its final settings and live
-    // client agree. Publish the session-visible mode only after construction,
-    // avoiding a transient personal-mode UI state when preparation rolls back.
-    if (decision.apiMode) patchSessionMeta({ apiMode: decision.apiMode });
-  } catch (error) {
-    const rollbackFailures: Error[] = [];
-    if (subscriptionWriteStarted && !isPreferCodexSubscription()) {
-      try {
-        const update = await setCliCodexSubscription(
-          previousSubscriptionPreference,
-        );
-        if (update.effective !== previousSubscriptionPreference) {
+      if (decision.disableChatGptSubscription) {
+        subscriptionWriteStarted = true;
+        const update = await setCliCodexSubscription(false);
+        if (update.effective) {
           throw new Error(
-            `ChatGPT subscription preference remained ${String(update.effective)}.`,
+            'ChatGPT subscription remains enabled by a more specific setting.',
           );
         }
-      } catch (rollbackError) {
-        const persistenceContext =
-          isPreferCodexSubscription() === previousSubscriptionPreference
-            ? 'The previous ChatGPT subscription preference appears restored in memory, but persistence could not be confirmed'
-            : 'Could not restore the ChatGPT subscription preference';
-        rollbackFailures.push(
-          new Error(`${persistenceContext}: ${toErrorMessage(rollbackError)}`, {
-            cause: rollbackError,
-          }),
-        );
+        if (!isCurrent()) throw new Error('Retry request was replaced.');
       }
-    }
-    if (apiModeWriteStarted && getCliApiMode() === decision.apiMode) {
-      try {
-        await setCliApiMode(previousApiMode);
-        if (getCliApiMode() !== previousApiMode) {
-          throw new Error(`API mode remained ${getCliApiMode()}.`);
+      if (decision.apiMode) patchSessionMeta({ apiMode: decision.apiMode });
+      return;
+    } catch (error) {
+      const rollbackFailures: Error[] = [];
+      if (subscriptionWriteStarted && !isPreferCodexSubscription()) {
+        try {
+          const update = await setCliCodexSubscription(
+            previousSubscriptionPreference,
+          );
+          if (update.effective !== previousSubscriptionPreference) {
+            throw new Error(
+              `ChatGPT subscription preference remained ${String(update.effective)}.`,
+            );
+          }
+        } catch (rollbackError) {
+          const persistenceContext =
+            isPreferCodexSubscription() === previousSubscriptionPreference
+              ? 'The previous ChatGPT subscription preference appears restored in memory, but persistence could not be confirmed'
+              : 'Could not restore the ChatGPT subscription preference';
+          rollbackFailures.push(
+            new Error(
+              `${persistenceContext}: ${toErrorMessage(rollbackError)}`,
+              {
+                cause: rollbackError,
+              },
+            ),
+          );
         }
-      } catch (rollbackError) {
-        const persistenceContext =
-          getCliApiMode() === previousApiMode
-            ? 'The previous API mode appears restored in memory, but persistence could not be confirmed'
-            : 'Could not restore API mode';
-        rollbackFailures.push(
-          new Error(`${persistenceContext}: ${toErrorMessage(rollbackError)}`, {
-            cause: rollbackError,
-          }),
+      }
+      if (apiModeWriteStarted && getCliApiMode() === decision.apiMode) {
+        try {
+          await setCliApiMode(previousApiMode);
+          if (getCliApiMode() !== previousApiMode) {
+            throw new Error(`API mode remained ${getCliApiMode()}.`);
+          }
+        } catch (rollbackError) {
+          const persistenceContext =
+            getCliApiMode() === previousApiMode
+              ? 'The previous API mode appears restored in memory, but persistence could not be confirmed'
+              : 'Could not restore API mode';
+          rollbackFailures.push(
+            new Error(
+              `${persistenceContext}: ${toErrorMessage(rollbackError)}`,
+              {
+                cause: rollbackError,
+              },
+            ),
+          );
+        }
+      }
+      if (rollbackFailures.length > 0) {
+        throw new AggregateError(
+          [error, ...rollbackFailures],
+          `${toErrorMessage(error)} Previous access settings could not be fully restored: ${rollbackFailures.map(toErrorMessage).join(' ')}`,
+          { cause: error },
         );
       }
+      throw error;
     }
-    if (rollbackFailures.length > 0) {
-      throw new AggregateError(
-        [error, ...rollbackFailures],
-        `${toErrorMessage(error)} Previous access settings could not be fully restored: ${rollbackFailures.map(toErrorMessage).join(' ')}`,
-        { cause: error },
-      );
-    }
-    throw error;
-  }
+  });
 }
 
 function handleExternalInquiry(

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -14,6 +14,7 @@
 
 import { nanoid } from 'nanoid';
 import pDefer from 'p-defer';
+import PQueue from 'p-queue';
 import pTimeout from 'p-timeout';
 
 import { defaultSession } from '@agent/runtime/SessionHandle';
@@ -24,6 +25,7 @@ import {
   type HostInteractionCancelSelector,
   type HostInteractionOptions,
   type HostInteractions,
+  type HostRetryInteractionOptions,
   type HostRetryRequest,
   type HostUserQuestionRequest,
   type HostUserQuestionResult,
@@ -32,7 +34,8 @@ import {
   type RetryResult,
 } from '@agent/runtime/HostInteractions';
 import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
-import { setCliApiMode } from '@cli/runtime/apiAccessMode';
+import { isPreferCodexSubscription } from '@auth/codex';
+import { getCliApiMode, setCliApiMode } from '@cli/runtime/apiAccessMode';
 import {
   approvalPromptAllowed,
   humanInputDenialFeedback,
@@ -45,19 +48,21 @@ import {
 import type { CliContext } from '@cli/runtime/cliContext';
 import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
 import {
-  API_PROVIDERS,
-  lookupApiKey,
+  apiKeyExistsUncached,
+  hasUsableApiKey,
+  invalidateApiKeyCache,
   isApiProvider,
-  type ApiProvider,
 } from '@model/apiProviders';
 import { platform } from '@platform/platform';
 import { isUpstreamCreditDepletedError } from '@shared/schemas';
+import { PROVIDER_DISPLAY_NAMES } from '@shared/constants/providers';
 import {
   setBashApprovalSessionBypass,
   setDelegatedWorkApprovalBypasses,
   setToolEditApprovalSessionBypass,
 } from '@tools/approval';
 import { handleExternalInquiryAction } from '@tools/inquiry/ExternalInquiryTool';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { notify } from '../notifications/terminalNotifier';
 import { patchSessionMeta, patchStream } from './cliState';
@@ -69,20 +74,16 @@ import {
   clearApprovalsWhere,
   clearRetryApprovalsForStream,
   enqueueApproval,
+  MISSING_OPENAI_KEY_RETRY_MESSAGE,
   onApprovalsCleared,
   type ApprovalDecision,
   type ApprovalPayload,
+  type TuiRetryRequest,
 } from './approvalQueue';
 
 // =========================================================================
 // Retry auto-switch: skip the modal when a usable personal key exists
 // =========================================================================
-
-/** Check whether a usable personal API key is stored for a provider. */
-async function hasUsablePersonalKey(provider: ApiProvider): Promise<boolean> {
-  const key = await lookupApiKey(platform().secrets, provider);
-  return typeof key === 'string' && key.trim().length > 0;
-}
 
 /**
  * When a retry is triggered by relay exhaustion and the stored personal key is
@@ -95,7 +96,7 @@ async function hasUsablePersonalKey(provider: ApiProvider): Promise<boolean> {
  * (no usable key stored, direct-key failure, or unknown provider).
  */
 async function maybeAutoSwitchRetry(
-  payload: RuntimeInteractionEventPayloads['showRetryRequest'],
+  payload: TuiRetryRequest,
 ): Promise<ApprovalDecision | undefined> {
   if (!isCliApiSwitchableRetry(payload)) return undefined;
   if (isCliChatGptSubscriptionRetry(payload)) return undefined;
@@ -106,22 +107,7 @@ async function maybeAutoSwitchRetry(
   // auto-switch to the stored value.
   if (isUpstreamCreditDepletedError(details)) return undefined;
 
-  // Relay exhaustion uses the provider from error details when known;
-  // provider-less relay failures can use any configured personal key.
-  let providers: readonly ApiProvider[];
-  if (details?.provider) {
-    providers = isApiProvider(details.provider) ? [details.provider] : [];
-  } else {
-    providers = API_PROVIDERS;
-  }
-  if (providers.length === 0) return undefined;
-
-  const hasKey = (
-    await Promise.all(
-      providers.map((provider) => hasUsablePersonalKey(provider)),
-    )
-  ).some(Boolean);
-  if (!hasKey) return undefined;
+  if (payload.personalApiKeyAvailable !== true) return undefined;
 
   return {
     accepted: true,
@@ -216,7 +202,7 @@ export function createTuiHostInteractions(
     },
     requestRetry(request, options) {
       return withInteractionTimeout(
-        () => requestRetryInteraction(request, context, retryRoutes),
+        () => requestRetryInteraction(request, context, retryRoutes, options),
         options,
         { action: 'timeout' },
         () => {
@@ -281,6 +267,10 @@ interface ActiveRetryRoute {
   readonly routeId: symbol;
   readonly settle?: (result: RetryResult) => void;
 }
+
+// API mode and ChatGPT preference are process-wide. Keep their transactional
+// switch and rollback indivisible across concurrent stream retry decisions.
+const retryCredentialSwitchQueue = new PQueue({ concurrency: 1 });
 
 const NEUTRAL_TIMEOUT_DECISION: ApprovalDecision = {
   accepted: true,
@@ -495,6 +485,7 @@ async function requestRetryInteraction(
   request: HostRetryRequest,
   context: CliContext,
   retryRoutes: Map<string, ActiveRetryRoute>,
+  options: HostRetryInteractionOptions | undefined,
 ): Promise<RetryResult> {
   cancelRetryRoute(retryRoutes, request.streamId);
   const routeId = Symbol(request.streamId);
@@ -512,10 +503,38 @@ async function requestRetryInteraction(
     };
 
     void (async () => {
-      const decision = await decideWithPolicy(context, 'retry', request, {
-        beforeQueue: maybeAutoSwitchRetry,
-        isCurrent,
-      });
+      const immediate: ApprovalDecision | undefined =
+        immediateDecisionForApproval('showRetryRequest', request, context);
+      let promptRequest: TuiRetryRequest = request;
+      if (!immediate && isCliApiSwitchableRetry(request)) {
+        const requestedProvider = request.errorDetails?.provider;
+        const provider =
+          requestedProvider && isApiProvider(requestedProvider)
+            ? requestedProvider
+            : undefined;
+        const personalApiKeyAvailable = provider
+          ? await hasUsableApiKey(platform().secrets, provider).catch(
+              () => false,
+            )
+          : false;
+        const providerName = provider
+          ? (PROVIDER_DISPLAY_NAMES[provider] ?? provider)
+          : undefined;
+        promptRequest = {
+          ...request,
+          personalApiKeyAvailable,
+          missingPersonalApiKeyMessage: providerName
+            ? `No ${providerName} API key is configured. Press n to give up, then use \`/key\` to add one.`
+            : 'The failed API provider could not be identified. Press n to give up, then use `/key` to verify the correct provider key.',
+        };
+      }
+      if (!isCurrent()) return;
+      const decision =
+        immediate ??
+        (await decideWithPolicy(context, 'retry', promptRequest, {
+          beforeQueue: maybeAutoSwitchRetry,
+          isCurrent,
+        }));
       if (!isCurrent()) return;
       if (
         decision.accepted &&
@@ -529,11 +548,23 @@ async function requestRetryInteraction(
         return;
       }
       try {
-        await applyRetrySideEffects(decision, { isCurrent });
+        const changesCredentialRoute =
+          decision.apiMode !== undefined ||
+          decision.disableChatGptSubscription === true;
+        if (changesCredentialRoute) {
+          await retryCredentialSwitchQueue.add(() =>
+            applyRetrySideEffects(decision, promptRequest, {
+              isCurrent,
+              prepareRetry: options?.prepareRetry,
+            }),
+          );
+        }
         if (!isCurrent()) return;
         resolve({ action: 'retry', feedback: decision.userMessage });
-      } catch {
-        if (isCurrent()) resolve({ action: 'cancel' });
+      } catch (error) {
+        if (isCurrent()) {
+          resolve({ action: 'deny', reason: toErrorMessage(error) });
+        }
       } finally {
         finish();
       }
@@ -618,18 +649,122 @@ function setTuiApprovalBypassState({
 
 async function applyRetrySideEffects(
   decision: ApprovalDecision,
-  options: { isCurrent?: () => boolean } = {},
+  request: TuiRetryRequest,
+  options: {
+    isCurrent?: () => boolean;
+    prepareRetry?: () => Promise<void>;
+  } = {},
 ): Promise<void> {
   const isCurrent = () => options.isCurrent?.() ?? true;
   if (!isCurrent()) return;
-  if (decision.apiMode) {
-    await setCliApiMode(decision.apiMode);
-    if (!isCurrent()) return;
-    patchSessionMeta({ apiMode: decision.apiMode });
+
+  const requestedProvider = request.errorDetails?.provider;
+  if (!requestedProvider || !isApiProvider(requestedProvider)) {
+    throw new Error(
+      'The failed API provider could not be identified, so TeXRA did not change access settings.',
+    );
   }
-  if (decision.disableChatGptSubscription) {
-    await setCliCodexSubscription(false);
-    if (!isCurrent()) return;
+  const missingKeyMessage =
+    request.missingPersonalApiKeyMessage ??
+    (requestedProvider === 'openai'
+      ? MISSING_OPENAI_KEY_RETRY_MESSAGE
+      : `No ${PROVIDER_DISPLAY_NAMES[requestedProvider] ?? requestedProvider} API key is configured. Press n to give up, then use \`/key\` to add one.`);
+  const validateCurrentKey = async (): Promise<void> => {
+    const keyExists = await apiKeyExistsUncached(
+      platform().secrets,
+      requestedProvider,
+    );
+    if (!isCurrent()) throw new Error('Retry request was replaced.');
+    if (!keyExists) throw new Error(missingKeyMessage);
+    // The presentation check is deliberately cached. Drop that cache only
+    // after the uncached commit check so getClient() must read the current key.
+    invalidateApiKeyCache();
+  };
+
+  await validateCurrentKey();
+
+  const previousApiMode = getCliApiMode();
+  const previousSubscriptionPreference = isPreferCodexSubscription();
+  let apiModeWriteStarted = false;
+  let subscriptionWriteStarted = false;
+  try {
+    if (decision.apiMode) {
+      apiModeWriteStarted = true;
+      await setCliApiMode(decision.apiMode);
+      if (!isCurrent()) throw new Error('Retry request was replaced.');
+    }
+    if (decision.disableChatGptSubscription) {
+      subscriptionWriteStarted = true;
+      const update = await setCliCodexSubscription(false);
+      if (update.effective) {
+        throw new Error(
+          'ChatGPT subscription remains enabled by a more specific setting.',
+        );
+      }
+      if (!isCurrent()) throw new Error('Retry request was replaced.');
+    }
+    if (!options.prepareRetry) {
+      throw new Error('The model client cannot be refreshed for this retry.');
+    }
+    // Settings select the route used by getClient(), so construct only after
+    // they change. Revalidate once more in case the key changed during either
+    // persisted setting write, then invalidate before construction.
+    await validateCurrentKey();
+    await options.prepareRetry();
+    // Commit invariant: no retry proceeds unless its final settings and live
+    // client agree. Publish the session-visible mode only after construction,
+    // avoiding a transient personal-mode UI state when preparation rolls back.
+    if (decision.apiMode) patchSessionMeta({ apiMode: decision.apiMode });
+  } catch (error) {
+    const rollbackFailures: Error[] = [];
+    if (subscriptionWriteStarted) {
+      try {
+        const update = await setCliCodexSubscription(
+          previousSubscriptionPreference,
+        );
+        if (update.effective !== previousSubscriptionPreference) {
+          throw new Error(
+            `ChatGPT subscription preference remained ${String(update.effective)}.`,
+          );
+        }
+      } catch (rollbackError) {
+        const persistenceContext =
+          isPreferCodexSubscription() === previousSubscriptionPreference
+            ? 'The previous ChatGPT subscription preference appears restored in memory, but persistence could not be confirmed'
+            : 'Could not restore the ChatGPT subscription preference';
+        rollbackFailures.push(
+          new Error(`${persistenceContext}: ${toErrorMessage(rollbackError)}`, {
+            cause: rollbackError,
+          }),
+        );
+      }
+    }
+    if (apiModeWriteStarted) {
+      try {
+        await setCliApiMode(previousApiMode);
+        if (getCliApiMode() !== previousApiMode) {
+          throw new Error(`API mode remained ${getCliApiMode()}.`);
+        }
+      } catch (rollbackError) {
+        const persistenceContext =
+          getCliApiMode() === previousApiMode
+            ? 'The previous API mode appears restored in memory, but persistence could not be confirmed'
+            : 'Could not restore API mode';
+        rollbackFailures.push(
+          new Error(`${persistenceContext}: ${toErrorMessage(rollbackError)}`, {
+            cause: rollbackError,
+          }),
+        );
+      }
+    }
+    if (rollbackFailures.length > 0) {
+      throw new AggregateError(
+        [error, ...rollbackFailures],
+        `${toErrorMessage(error)} Previous access settings could not be fully restored: ${rollbackFailures.map(toErrorMessage).join(' ')}`,
+        { cause: error },
+      );
+    }
+    throw error;
   }
 }
 

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -122,6 +122,10 @@ export function createTuiHostInteractions(
   context: CliContext,
 ): HostInteractions {
   const retryRoutes = new Map<string, ActiveRetryRoute>();
+  // The two persisted access fields commit as one choice within this TUI
+  // lifetime. Keeping the queue session-owned prevents stale work leaking
+  // across disposed hosts or tests.
+  const retryCredentialCommitQueue = new PQueue({ concurrency: 1 });
   const disposeApprovalClearListener = onApprovalsCleared(() => {
     invalidateRetryRoutes(retryRoutes, { cancel: true });
   });
@@ -201,7 +205,14 @@ export function createTuiHostInteractions(
     },
     requestRetry(request, options) {
       return withInteractionTimeout(
-        () => requestRetryInteraction(request, context, retryRoutes, options),
+        () =>
+          requestRetryInteraction(
+            request,
+            context,
+            retryRoutes,
+            retryCredentialCommitQueue,
+            options,
+          ),
         options,
         { action: 'timeout' },
         () => {
@@ -268,27 +279,23 @@ interface ActiveRetryRoute {
   readonly settle?: (result: RetryResult) => void;
 }
 
-// API mode and ChatGPT preference are two persisted fields that form one user
-// choice. Serialize only their commit/rollback window; candidate construction
-// happens before this queue while the published preference remains unchanged.
-const retryCredentialCommitQueue = new PQueue({ concurrency: 1 });
-
-function prepareRetryClient(
-  prepare: NonNullable<HostRetryInteractionOptions['prepareRetry']>,
-  selection: Parameters<
-    NonNullable<HostRetryInteractionOptions['prepareRetry']>
-  >[0],
+function runRetryTask<T>(
+  start: () => Promise<T>,
   signal: AbortSignal,
-): Promise<void> {
+): Promise<T> {
   signal.throwIfAborted();
-  return new Promise<void>((resolve, reject) => {
-    const onAbort = () => reject(signal.reason);
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () =>
+      reject(
+        signal.reason ??
+          new DOMException('Retry preparation aborted.', 'AbortError'),
+      );
     signal.addEventListener('abort', onAbort, { once: true });
     try {
-      prepare(selection, signal).then(
-        () => {
+      start().then(
+        (value) => {
           signal.removeEventListener('abort', onAbort);
-          resolve();
+          resolve(value);
         },
         (error: unknown) => {
           signal.removeEventListener('abort', onAbort);
@@ -300,6 +307,16 @@ function prepareRetryClient(
       reject(error);
     }
   });
+}
+
+function prepareRetryClient(
+  prepare: NonNullable<HostRetryInteractionOptions['prepareRetry']>,
+  selection: Parameters<
+    NonNullable<HostRetryInteractionOptions['prepareRetry']>
+  >[0],
+  signal: AbortSignal,
+): Promise<void> {
+  return runRetryTask(() => prepare(selection, signal), signal);
 }
 
 const NEUTRAL_TIMEOUT_DECISION: ApprovalDecision = {
@@ -528,6 +545,7 @@ async function requestRetryInteraction(
   request: HostRetryRequest,
   context: CliContext,
   retryRoutes: Map<string, ActiveRetryRoute>,
+  retryCredentialCommitQueue: PQueue,
   options: HostRetryInteractionOptions | undefined,
 ): Promise<RetryResult> {
   cancelRetryRoute(retryRoutes, request.streamId);
@@ -607,6 +625,7 @@ async function requestRetryInteraction(
             isCurrent,
             prepareRetry: options?.prepareRetry,
             preparationSignal: preparationController.signal,
+            commitQueue: retryCredentialCommitQueue,
           });
         } else if (options?.prepareRetry) {
           await prepareRetryClient(
@@ -710,10 +729,12 @@ async function switchRetryToPersonalCredentials(
     isCurrent?: () => boolean;
     prepareRetry?: HostRetryInteractionOptions['prepareRetry'];
     preparationSignal?: AbortSignal;
-  } = {},
+    commitQueue: PQueue;
+  },
 ): Promise<void> {
   const isCurrent = () => options.isCurrent?.() ?? true;
   if (!isCurrent()) return;
+  const signal = options.preparationSignal ?? new AbortController().signal;
 
   const requestedProvider = request.errorDetails?.provider;
   if (!requestedProvider || !isApiProvider(requestedProvider)) {
@@ -725,9 +746,9 @@ async function switchRetryToPersonalCredentials(
     request.missingPersonalApiKeyMessage ??
     missingApiKeyRetryMessage(requestedProvider);
   const validateCurrentKey = async (): Promise<void> => {
-    const keyExists = await apiKeyExistsUncached(
-      platform().secrets,
-      requestedProvider,
+    const keyExists = await runRetryTask(
+      () => apiKeyExistsUncached(platform().secrets, requestedProvider),
+      signal,
     );
     if (!isCurrent()) throw new Error('Retry request was replaced.');
     if (!keyExists) throw new Error(missingKeyMessage);
@@ -741,14 +762,10 @@ async function switchRetryToPersonalCredentials(
   if (!options.prepareRetry) {
     throw new Error('The model client cannot be refreshed for this retry.');
   }
-  await prepareRetryClient(
-    options.prepareRetry,
-    'personal',
-    options.preparationSignal ?? new AbortController().signal,
-  );
+  await prepareRetryClient(options.prepareRetry, 'personal', signal);
   if (!isCurrent()) throw new Error('Retry request was replaced.');
 
-  await retryCredentialCommitQueue.add(async () => {
+  await options.commitQueue.add(async () => {
     if (!isCurrent()) throw new Error('Retry request was replaced.');
     const previousApiMode = getCliApiMode();
     const previousSubscriptionPreference = isPreferCodexSubscription();
@@ -756,13 +773,17 @@ async function switchRetryToPersonalCredentials(
     let subscriptionWriteStarted = false;
     try {
       if (decision.apiMode) {
+        const apiMode = decision.apiMode;
         apiModeWriteStarted = true;
-        await setCliApiMode(decision.apiMode);
+        await runRetryTask(() => setCliApiMode(apiMode), signal);
         if (!isCurrent()) throw new Error('Retry request was replaced.');
       }
       if (decision.disableChatGptSubscription) {
         subscriptionWriteStarted = true;
-        const update = await setCliCodexSubscription(false);
+        const update = await runRetryTask(
+          () => setCliCodexSubscription(false),
+          signal,
+        );
         if (update.effective) {
           throw new Error(
             'ChatGPT subscription remains enabled by a more specific setting.',

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -264,12 +264,39 @@ export function createTuiHostInteractions(
  */
 interface ActiveRetryRoute {
   readonly routeId: symbol;
+  readonly preparationController: AbortController;
   readonly settle?: (result: RetryResult) => void;
 }
 
 // API mode and ChatGPT preference are process-wide. Keep their transactional
 // switch and rollback indivisible across concurrent stream retry decisions.
 const retryCredentialSwitchQueue = new PQueue({ concurrency: 1 });
+
+function prepareRetryClient(
+  prepare: NonNullable<HostRetryInteractionOptions['prepareRetry']>,
+  signal: AbortSignal,
+): Promise<void> {
+  signal.throwIfAborted();
+  return new Promise<void>((resolve, reject) => {
+    const onAbort = () => reject(signal.reason);
+    signal.addEventListener('abort', onAbort, { once: true });
+    try {
+      prepare(signal).then(
+        () => {
+          signal.removeEventListener('abort', onAbort);
+          resolve();
+        },
+        (error: unknown) => {
+          signal.removeEventListener('abort', onAbort);
+          reject(error);
+        },
+      );
+    } catch (error) {
+      signal.removeEventListener('abort', onAbort);
+      reject(error);
+    }
+  });
+}
 
 const NEUTRAL_TIMEOUT_DECISION: ApprovalDecision = {
   accepted: true,
@@ -339,6 +366,7 @@ function settleRetryRoute(
   const route = retryRoutes.get(streamId);
   if (!route) return;
   retryRoutes.delete(streamId);
+  route.preparationController.abort(new Error('Retry request was replaced.'));
   route.settle?.(result);
 }
 
@@ -380,6 +408,18 @@ async function decideWithPolicy<
       : immediateDecision(context);
   if (policy) return policy;
 
+  return decideAfterImmediatePolicy(context, kind, payload, options);
+}
+
+async function decideAfterImmediatePolicy<
+  K extends 'bash' | 'plan' | 'proposal' | 'retry',
+  P,
+>(
+  context: CliContext,
+  kind: K,
+  payload: P,
+  options: RouteWithPolicyOptions<P> = {},
+): Promise<ApprovalDecision> {
   let autoDecision: ApprovalDecision | undefined;
   if (options.beforeQueue) {
     try {
@@ -488,11 +528,13 @@ async function requestRetryInteraction(
 ): Promise<RetryResult> {
   cancelRetryRoute(retryRoutes, request.streamId);
   const routeId = Symbol(request.streamId);
+  const preparationController = new AbortController();
   clearRetryApprovalsForStream(request.streamId);
 
   return await new Promise<RetryResult>((resolve) => {
     retryRoutes.set(request.streamId, {
       routeId,
+      preparationController,
       settle: resolve,
     });
     const isCurrent = () =>
@@ -511,22 +553,32 @@ async function requestRetryInteraction(
           requestedProvider && isApiProvider(requestedProvider)
             ? requestedProvider
             : undefined;
-        const personalApiKeyAvailable = provider
-          ? await hasUsableApiKey(platform().secrets, provider).catch(
-              // A keychain failure must not permit an automatic credential switch.
-              () => false,
-            )
-          : false;
+        let personalApiKeyAvailable = false;
+        let missingPersonalApiKeyMessage = missingApiKeyRetryMessage(provider);
+        if (provider) {
+          try {
+            personalApiKeyAvailable = await hasUsableApiKey(
+              platform().secrets,
+              provider,
+            );
+          } catch {
+            // A keychain failure must not permit an automatic credential switch.
+            missingPersonalApiKeyMessage = missingApiKeyRetryMessage(
+              provider,
+              'unavailable',
+            );
+          }
+        }
         promptRequest = {
           ...request,
           personalApiKeyAvailable,
-          missingPersonalApiKeyMessage: missingApiKeyRetryMessage(provider),
+          missingPersonalApiKeyMessage,
         };
       }
       if (!isCurrent()) return;
       const decision =
         immediate ??
-        (await decideWithPolicy(context, 'retry', promptRequest, {
+        (await decideAfterImmediatePolicy(context, 'retry', promptRequest, {
           beforeQueue: maybeAutoSwitchRetry,
           isCurrent,
         }));
@@ -551,14 +603,21 @@ async function requestRetryInteraction(
             applyRetrySideEffects(decision, promptRequest, {
               isCurrent,
               prepareRetry: options?.prepareRetry,
+              preparationSignal: preparationController.signal,
             }),
           );
         } else if (options?.prepareRetry) {
+          const prepareRetry = options.prepareRetry;
           // Client construction is a read of process-wide credential state.
           // Linearize it with credential writes so it cannot observe a route
           // that a concurrent switch later rolls back.
           await retryCredentialSwitchQueue.add(async () => {
-            if (isCurrent()) await options.prepareRetry?.();
+            if (isCurrent()) {
+              await prepareRetryClient(
+                prepareRetry,
+                preparationController.signal,
+              );
+            }
           });
         }
         if (!isCurrent()) return;
@@ -654,7 +713,8 @@ async function applyRetrySideEffects(
   request: TuiRetryRequest,
   options: {
     isCurrent?: () => boolean;
-    prepareRetry?: () => Promise<void>;
+    prepareRetry?: HostRetryInteractionOptions['prepareRetry'];
+    preparationSignal?: AbortSignal;
   } = {},
 ): Promise<void> {
   const isCurrent = () => options.isCurrent?.() ?? true;
@@ -710,14 +770,17 @@ async function applyRetrySideEffects(
     // they change. Revalidate once more in case the key changed during either
     // persisted setting write, then invalidate before construction.
     await validateCurrentKey();
-    await options.prepareRetry();
+    await prepareRetryClient(
+      options.prepareRetry,
+      options.preparationSignal ?? new AbortController().signal,
+    );
     // Commit invariant: no retry proceeds unless its final settings and live
     // client agree. Publish the session-visible mode only after construction,
     // avoiding a transient personal-mode UI state when preparation rolls back.
     if (decision.apiMode) patchSessionMeta({ apiMode: decision.apiMode });
   } catch (error) {
     const rollbackFailures: Error[] = [];
-    if (subscriptionWriteStarted) {
+    if (subscriptionWriteStarted && !isPreferCodexSubscription()) {
       try {
         const update = await setCliCodexSubscription(
           previousSubscriptionPreference,
@@ -739,7 +802,7 @@ async function applyRetrySideEffects(
         );
       }
     }
-    if (apiModeWriteStarted) {
+    if (apiModeWriteStarted && getCliApiMode() === decision.apiMode) {
       try {
         await setCliApiMode(previousApiMode);
         if (getCliApiMode() !== previousApiMode) {

--- a/packages/cli/src/chat/tui/ui/retryCopy.ts
+++ b/packages/cli/src/chat/tui/ui/retryCopy.ts
@@ -1,9 +1,15 @@
 import type { ApiProvider } from '@model/apiProviders';
 import { PROVIDER_DISPLAY_NAMES } from '@shared/constants/providers';
 
-export function missingApiKeyRetryMessage(provider?: ApiProvider): string {
+export function missingApiKeyRetryMessage(
+  provider?: ApiProvider,
+  availability: 'missing' | 'unavailable' = 'missing',
+): string {
   if (!provider) {
     return 'The failed API provider could not be identified. Press n to give up, then use `/key` to verify the correct provider key.';
   }
-  return `No ${PROVIDER_DISPLAY_NAMES[provider] ?? provider} API key is configured. Press n to give up, then use \`/key\` to add one.`;
+  const providerName = PROVIDER_DISPLAY_NAMES[provider] ?? provider;
+  return availability === 'unavailable'
+    ? `TeXRA could not check whether the ${providerName} API key is available. Press n to give up, then use \`/key\` to try again.`
+    : `No ${providerName} API key is configured. Press n to give up, then use \`/key\` to add one.`;
 }

--- a/packages/cli/src/chat/tui/ui/retryCopy.ts
+++ b/packages/cli/src/chat/tui/ui/retryCopy.ts
@@ -1,0 +1,9 @@
+import type { ApiProvider } from '@model/apiProviders';
+import { PROVIDER_DISPLAY_NAMES } from '@shared/constants/providers';
+
+export function missingApiKeyRetryMessage(provider?: ApiProvider): string {
+  if (!provider) {
+    return 'The failed API provider could not be identified. Press n to give up, then use `/key` to verify the correct provider key.';
+  }
+  return `No ${PROVIDER_DISPLAY_NAMES[provider] ?? provider} API key is configured. Press n to give up, then use \`/key\` to add one.`;
+}

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -7,6 +7,7 @@ import { Node } from '@agent/node';
 import { logErrorData, logProgressStatus, type AgentTrace } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { useLaunchRunContext } from '@agent/runtime/RunContext';
+import type { ModelCredentialSelection } from '@agent/types/ModelHandlerContracts';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { normalizeProviderError } from '@common/errors';
 import {
@@ -59,7 +60,10 @@ interface RetryableNodeServices {
   config: Pick<AgentConfig, 'model'>;
   logger: AgentTrace;
   setAbortController: (ac: AbortController | null) => void;
-  refreshClient?: (signal?: AbortSignal) => Promise<void>;
+  refreshClient?: (
+    selection?: ModelCredentialSelection,
+    signal?: AbortSignal,
+  ) => Promise<void>;
 }
 
 /**
@@ -67,7 +71,12 @@ interface RetryableNodeServices {
  * Logs success or failure; returns true if refresh was attempted and succeeded.
  */
 async function tryRefreshClient(
-  refreshClient: ((signal?: AbortSignal) => Promise<void>) | undefined,
+  refreshClient:
+    | ((
+        selection?: ModelCredentialSelection,
+        signal?: AbortSignal,
+      ) => Promise<void>)
+    | undefined,
   logger: AgentTrace,
   context: string,
 ): Promise<boolean> {
@@ -310,9 +319,9 @@ export abstract class RetryableInvocationNode<
       },
       refreshClient
         ? {
-            prepareRetry: async (signal) => {
+            prepareRetry: async (selection, signal) => {
               signal?.throwIfAborted();
-              await refreshClient(signal);
+              await refreshClient(selection, signal);
               signal?.throwIfAborted();
               clientPrepared = true;
             },

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -45,6 +45,7 @@ function getNodeRetryConfig(): { maxRetries: number; wait: number } {
 interface ManualRetryPromptResult {
   shouldRetry: boolean;
   userCancelled: boolean;
+  clientPrepared?: boolean;
 }
 
 /** success: model response | failed: retries exhausted | cancelled: user cancelled | skipped: shouldStop was true */
@@ -260,11 +261,13 @@ export abstract class RetryableInvocationNode<
       // credit-depletion flow), toggling included-access mode, rotating
       // a token after a relay 401, etc. Refreshing is cheap and keeps
       // the cached client in sync with current secrets/config.
-      await tryRefreshClient(
-        this.services.refreshClient,
-        this.services.logger,
-        'before manual retry',
-      );
+      if (result.clientPrepared !== true) {
+        await tryRefreshClient(
+          this.services.refreshClient,
+          this.services.logger,
+          'before manual retry',
+        );
+      }
     }
 
     return result.shouldRetry;
@@ -294,14 +297,26 @@ export abstract class RetryableInvocationNode<
       data: formatted.message ?? 'unknown error',
     });
     // No timeout: the retry panel waits indefinitely for the user's decision.
-    const interaction = session.interactions.requestRetry({
-      requestId: `retry-${nanoid()}`,
-      streamId,
-      operation: operationName,
-      model: this.services.config.model,
-      errorMessage: formatted.message,
-      errorDetails: formatted,
-    });
+    let clientPrepared = false;
+    const interaction = session.interactions.requestRetry(
+      {
+        requestId: `retry-${nanoid()}`,
+        streamId,
+        operation: operationName,
+        model: this.services.config.model,
+        errorMessage: formatted.message,
+        errorDetails: formatted,
+      },
+      {
+        prepareRetry: async () => {
+          if (!this.services.refreshClient) {
+            throw new Error('Model client refresh is unavailable');
+          }
+          await this.services.refreshClient();
+          clientPrepared = true;
+        },
+      },
+    );
     if (!interaction) {
       throw new Error('HostInteractions.requestRetry is required');
     }
@@ -312,7 +327,7 @@ export abstract class RetryableInvocationNode<
       streamStatus.transition(streamId, STREAM_PHASE.RUNNING, 'resume', {
         trace: logger,
       });
-      return { shouldRetry: true, userCancelled: false };
+      return { shouldRetry: true, userCancelled: false, clientPrepared };
     }
 
     if (result.action === 'deny') {

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -298,6 +298,7 @@ export abstract class RetryableInvocationNode<
     });
     // No timeout: the retry panel waits indefinitely for the user's decision.
     let clientPrepared = false;
+    const refreshClient = this.services.refreshClient;
     const interaction = session.interactions.requestRetry(
       {
         requestId: `retry-${nanoid()}`,
@@ -307,15 +308,14 @@ export abstract class RetryableInvocationNode<
         errorMessage: formatted.message,
         errorDetails: formatted,
       },
-      {
-        prepareRetry: async () => {
-          if (!this.services.refreshClient) {
-            throw new Error('Model client refresh is unavailable');
+      refreshClient
+        ? {
+            prepareRetry: async () => {
+              await refreshClient();
+              clientPrepared = true;
+            },
           }
-          await this.services.refreshClient();
-          clientPrepared = true;
-        },
-      },
+        : undefined,
     );
     if (!interaction) {
       throw new Error('HostInteractions.requestRetry is required');

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -59,7 +59,7 @@ interface RetryableNodeServices {
   config: Pick<AgentConfig, 'model'>;
   logger: AgentTrace;
   setAbortController: (ac: AbortController | null) => void;
-  refreshClient?: () => Promise<void>;
+  refreshClient?: (signal?: AbortSignal) => Promise<void>;
 }
 
 /**
@@ -67,7 +67,7 @@ interface RetryableNodeServices {
  * Logs success or failure; returns true if refresh was attempted and succeeded.
  */
 async function tryRefreshClient(
-  refreshClient: (() => Promise<void>) | undefined,
+  refreshClient: ((signal?: AbortSignal) => Promise<void>) | undefined,
   logger: AgentTrace,
   context: string,
 ): Promise<boolean> {
@@ -310,8 +310,10 @@ export abstract class RetryableInvocationNode<
       },
       refreshClient
         ? {
-            prepareRetry: async () => {
-              await refreshClient();
+            prepareRetry: async (signal) => {
+              signal?.throwIfAborted();
+              await refreshClient(signal);
+              signal?.throwIfAborted();
               clientPrepared = true;
             },
           }

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -1029,6 +1029,11 @@ export abstract class ModelHandler<
     return this.getClient(selection);
   }
 
+  /** Returns a client after routing changes; cached providers invalidate here. */
+  async refreshClient(): Promise<C> {
+    return this.getClient();
+  }
+
   /**
    * Provider-specific SDK error tagger. The base {@link createResponse}
    * template wraps {@link createResponseImpl} with this tagger so every thrown

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -1029,11 +1029,6 @@ export abstract class ModelHandler<
     return this.getClient(selection);
   }
 
-  /** Returns a client after routing changes; cached providers invalidate here. */
-  async refreshClient(): Promise<C> {
-    return this.getClient();
-  }
-
   /**
    * Provider-specific SDK error tagger. The base {@link createResponse}
    * template wraps {@link createResponseImpl} with this tagger so every thrown

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -1,4 +1,5 @@
 import { createChannelTrace } from '@agent/trace';
+import type { ModelCredentialSelection } from '@agent/types/ModelHandlerContracts';
 import type {
   ToolEditApprovalRequest,
   ToolEditApprovalResult,
@@ -58,7 +59,10 @@ export interface HostRetryInteractionOptions extends HostInteractionOptions {
    * A host that calls this successfully has prepared the next attempt; a
    * rejection leaves the caller's previous client unchanged.
    */
-  readonly prepareRetry?: (signal?: AbortSignal) => Promise<void>;
+  readonly prepareRetry?: (
+    selection: ModelCredentialSelection,
+    signal?: AbortSignal,
+  ) => Promise<void>;
 }
 
 /** Delivery policy for a notification owned by a process session. */

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -53,8 +53,12 @@ export interface HostInteractionOptions {
 }
 
 export interface HostRetryInteractionOptions extends HostInteractionOptions {
-  /** Prepare the model client that the approved retry will use. */
-  readonly prepareRetry?: () => Promise<void>;
+  /**
+   * Rebuild the caller's model client after a host-side credential change.
+   * A host that calls this successfully has prepared the next attempt; a
+   * rejection leaves the caller's previous client unchanged.
+   */
+  readonly prepareRetry?: (signal?: AbortSignal) => Promise<void>;
 }
 
 /** Delivery policy for a notification owned by a process session. */

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -52,6 +52,11 @@ export interface HostInteractionOptions {
   readonly cancellationScope?: object;
 }
 
+export interface HostRetryInteractionOptions extends HostInteractionOptions {
+  /** Prepare the model client that the approved retry will use. */
+  readonly prepareRetry?: () => Promise<void>;
+}
+
 /** Delivery policy for a notification owned by a process session. */
 interface SessionPresentationOptions {
   /** Retain the notice for the next attachment instead of dropping it now. */
@@ -314,7 +319,7 @@ export interface HostInteractions {
   ): Promise<ProposalResult> | undefined;
   requestRetry?(
     request: HostRetryRequest,
-    options?: HostInteractionOptions,
+    options?: HostRetryInteractionOptions,
   ): Promise<RetryResult> | undefined;
   askUserQuestion?(
     request: HostUserQuestionRequest,
@@ -490,7 +495,7 @@ export class SessionHostInteractions
 
   requestRetry(
     request: HostRetryRequest,
-    options?: HostInteractionOptions,
+    options?: HostRetryInteractionOptions,
   ): Promise<RetryResult> {
     return this.enqueue<RetryResult>(
       'retry',

--- a/src/test-kernel/agent/modelHandlers/GoogleClientRefresh.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleClientRefresh.vitest.ts
@@ -1,0 +1,103 @@
+import { ModelProvider } from 'llm-zoo';
+import { describe, expect, it } from 'vitest';
+
+// Local imports
+import { withModelClient } from '@agent/core/flows/CycleServices';
+import { ModelHandlerGoogleGenAI } from '@agent/modelHandlers/google/modelHandlerGoogleGenAI';
+import { ModelHandlerGoogleInteractions } from '@agent/modelHandlers/google/modelHandlerGoogleInteractions';
+import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
+
+// Third-party imports
+import type { GoogleGenAI } from '@google/genai';
+
+const GOOGLE_TEST_CONFIG = Object.freeze({
+  name: 'google-client-refresh',
+  label: 'Google client refresh',
+  fullName: 'gemini-3-pro-test',
+  shortName: 'gemini-3-pro-test',
+  provider: ModelProvider.GOOGLE,
+  contextWindow: 4096,
+  capabilities: Object.freeze({ supportsVision: true }),
+});
+
+type GoogleHandlerWithCache = {
+  googleClient: GoogleGenAI | null;
+};
+
+function setCachedClient(
+  handler: ModelHandlerGoogleGenAI | ModelHandlerGoogleInteractions,
+  client: GoogleGenAI,
+): void {
+  (handler as unknown as GoogleHandlerWithCache).googleClient = client;
+}
+
+class GoogleGenAIRefreshProbe extends ModelHandlerGoogleGenAI {
+  readonly replacement = {} as GoogleGenAI;
+  cacheSeenByGetClient: GoogleGenAI | null | undefined;
+
+  override async getClient(): Promise<GoogleGenAI> {
+    this.cacheSeenByGetClient = (
+      this as unknown as GoogleHandlerWithCache
+    ).googleClient;
+    return this.replacement;
+  }
+}
+
+class GoogleInteractionsRefreshProbe extends ModelHandlerGoogleInteractions {
+  readonly replacement = {} as GoogleGenAI;
+  cacheSeenByGetClient: GoogleGenAI | null | undefined;
+
+  override async getClient(): Promise<GoogleGenAI> {
+    this.cacheSeenByGetClient = (
+      this as unknown as GoogleHandlerWithCache
+    ).googleClient;
+    return this.replacement;
+  }
+}
+
+describe('Google client refresh', () => {
+  it('drops the native Google client cached under the previous key', async () => {
+    const handler = new GoogleGenAIRefreshProbe(
+      buildTestModelConfig(GOOGLE_TEST_CONFIG),
+    );
+    setCachedClient(handler, {} as GoogleGenAI);
+
+    await expect(handler.refreshClient()).resolves.toBe(handler.replacement);
+    expect(handler.cacheSeenByGetClient).toBeNull();
+  });
+
+  it('drops the Google Interactions client cached under the previous key', async () => {
+    const handler = new GoogleInteractionsRefreshProbe(
+      buildTestModelConfig(GOOGLE_TEST_CONFIG),
+    );
+    setCachedClient(handler, {} as GoogleGenAI);
+
+    await expect(handler.refreshClient()).resolves.toBe(handler.replacement);
+    expect(handler.cacheSeenByGetClient).toBeNull();
+  });
+
+  it('does not publish a replacement client after its preparation is cancelled', async () => {
+    const initial = {} as GoogleGenAI;
+    const replacement = {} as GoogleGenAI;
+    let finishRefresh: (() => void) | undefined;
+    const handler = new GoogleGenAIRefreshProbe(
+      buildTestModelConfig(GOOGLE_TEST_CONFIG),
+    );
+    handler.getClient = async () => initial;
+    handler.refreshClient = async () => {
+      await new Promise<void>((resolve) => {
+        finishRefresh = resolve;
+      });
+      return replacement;
+    };
+    const services = await withModelClient({}, handler);
+    const controller = new AbortController();
+
+    const refresh = services.refreshClient?.(controller.signal);
+    controller.abort(new Error('Retry preparation cancelled.'));
+    finishRefresh?.();
+
+    await expect(refresh).rejects.toThrow('Retry preparation cancelled.');
+    expect(services.client).toBe(initial);
+  });
+});

--- a/src/test-kernel/agent/modelHandlers/GoogleClientRefresh.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleClientRefresh.vitest.ts
@@ -93,7 +93,7 @@ describe('Google client refresh', () => {
     const services = await withModelClient({}, handler);
     const controller = new AbortController();
 
-    const refresh = services.refreshClient?.(controller.signal);
+    const refresh = services.refreshClient?.(undefined, controller.signal);
     controller.abort(new Error('Retry preparation cancelled.'));
     finishRefresh?.();
 

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -390,7 +390,7 @@ describe('RetryState', () => {
       refreshClient,
     );
     requestRetry.mockImplementationOnce(async (_request, options) => {
-      await options?.prepareRetry?.();
+      await options?.prepareRetry?.('configured');
       return { action: 'retry' };
     });
     node.seedPersistent401Guards();

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -375,7 +375,7 @@ describe('RetryState', () => {
           operation: 'Model request',
           model: 'copilot:sonnet46',
         }),
-        expect.objectContaining({ prepareRetry: expect.any(Function) }),
+        undefined,
       );
     } finally {
       clearStreamStatusForTest(streamStatus, streamId);

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -19,6 +19,7 @@ import {
 } from '@agent/core/flows/RetryState';
 import { tagOpenAISdkError } from '@agent/modelHandlers/openai/openAISdkError';
 import type {
+  HostRetryInteractionOptions,
   HostRetryRequest,
   RetryResult,
 } from '@agent/runtime/HostInteractions';
@@ -59,6 +60,7 @@ interface TestRetryServices {
   runtimeHost: AgentRuntimeHost;
   logger: AgentTrace;
   setAbortController: (ac: AbortController | null) => void;
+  refreshClient?: () => Promise<void>;
 }
 
 class ExposedRetryNode extends RetryableInvocationNode<
@@ -76,16 +78,39 @@ class ExposedRetryNode extends RetryableInvocationNode<
   fallbackFor(error: Error): unknown {
     return this.getFallbackResult(error);
   }
+
+  seedPersistent401Guards(): void {
+    this._persistent401Error = new Error('persistent relay 401');
+    this._hasAttemptedTokenRefresh = true;
+  }
+
+  persistent401Guards(): {
+    readonly error: Error | null;
+    readonly tokenRefreshAttempted: boolean;
+  } {
+    return {
+      error: this._persistent401Error,
+      tokenRefreshAttempted: this._hasAttemptedTokenRefresh,
+    };
+  }
 }
 
 interface RetryNodeKit {
   node: ExposedRetryNode;
   session: SessionHandle;
   streamStatus: StreamStatusMachine;
-  requestRetry: Mock<(request: HostRetryRequest) => Promise<RetryResult>>;
+  requestRetry: Mock<
+    (
+      request: HostRetryRequest,
+      options?: HostRetryInteractionOptions,
+    ) => Promise<RetryResult>
+  >;
 }
 
-function createRetryNode(streamId: StreamTabId): RetryNodeKit {
+function createRetryNode(
+  streamId: StreamTabId,
+  refreshClient?: () => Promise<void>,
+): RetryNodeKit {
   const streamStatus = new StreamStatusMachine();
   const requestRetry = vi.fn<RetryNodeKit['requestRetry']>();
   const session = sessionWithInteractions(
@@ -98,6 +123,7 @@ function createRetryNode(streamId: StreamTabId): RetryNodeKit {
     runtimeHost: noopAgentRuntimeHost,
     logger: noopTrace,
     setAbortController: vi.fn(),
+    refreshClient,
   });
   return { node, session, streamStatus, requestRetry };
 }
@@ -349,8 +375,40 @@ describe('RetryState', () => {
           operation: 'Model request',
           model: 'copilot:sonnet46',
         }),
-        undefined,
+        expect.objectContaining({ prepareRetry: expect.any(Function) }),
       );
+    } finally {
+      clearStreamStatusForTest(streamStatus, streamId);
+    }
+  });
+
+  it('lets the host prepare a replacement client without refreshing it twice', async () => {
+    const streamId = 'retry-state-prepared-client' as StreamTabId;
+    const refreshClient = vi.fn(async () => undefined);
+    const { node, session, streamStatus, requestRetry } = createRetryNode(
+      streamId,
+      refreshClient,
+    );
+    requestRetry.mockImplementationOnce(async (_request, options) => {
+      await options?.prepareRetry?.();
+      return { action: 'retry' };
+    });
+    node.seedPersistent401Guards();
+
+    try {
+      seedStreamStatusForTest(streamStatus, streamId, STREAM_STATUS.RUNNING);
+
+      await expect(
+        withRetryRunContext(streamId, session, () =>
+          node.retryPrompt(undefined, new Error('temporary provider failure')),
+        ),
+      ).resolves.toBe(true);
+
+      expect(refreshClient).toHaveBeenCalledOnce();
+      expect(node.persistent401Guards()).toEqual({
+        error: null,
+        tokenRefreshAttempted: false,
+      });
     } finally {
       clearStreamStatusForTest(streamStatus, streamId);
     }

--- a/src/test-kernel/cli/RetryRequest.vitest.mts
+++ b/src/test-kernel/cli/RetryRequest.vitest.mts
@@ -1,10 +1,24 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { ApprovalModal } from '@cli/chat/tui/modals/ApprovalModal';
 import { ConfirmCard } from '@cli/chat/tui/modals/ConfirmCard';
 import { RetryRequest } from '@cli/chat/tui/modals/RetryRequest';
+import {
+  clearApprovals,
+  currentApproval,
+  enqueueApproval,
+} from '@cli/chat/tui/state/approvalQueue';
 import type { StreamTabId } from '@shared/schemas';
+import { waitForCondition as waitFor } from '@test/support/asyncTestUtils';
+import {
+  FakeStdin,
+  FakeStdout,
+  loadInk,
+} from '@test/support/inkTestHarness.mts';
 
 describe('CLI retry request', () => {
+  afterEach(() => clearApprovals());
+
   it('uses immediate rejection with a plain give-up action', () => {
     const card = RetryRequest({
       payload: {
@@ -23,4 +37,104 @@ describe('CLI retry request', () => {
       rejectionMode: 'immediate',
     });
   });
+
+  it('settles the approval queue from a real terminal k input', async () => {
+    const { ink, React } = await loadInk();
+    const decision = enqueueApproval({
+      kind: 'retry',
+      payload: {
+        requestId: 'subscription-limit',
+        streamId: 'retry-stream' as StreamTabId,
+        operation: 'Tool-use call',
+        errorMessage: 'ChatGPT subscription usage limit reached.',
+        errorDetails: {
+          message: 'ChatGPT subscription usage limit reached.',
+          exhaustionReason: 'chatgpt-subscription',
+          provider: 'openai',
+        },
+        personalApiKeyAvailable: true,
+      },
+    });
+    const stdin = new FakeStdin();
+    const instance = ink.render(
+      React.createElement(ApprovalModal, {
+        pending: currentApproval.get(),
+      }),
+      {
+        stdin,
+        stdout: new FakeStdout(100),
+        interactive: true,
+        exitOnCtrlC: false,
+        patchConsole: false,
+      },
+    );
+
+    try {
+      await waitFor(() => stdin.listenerCount('readable') > 0);
+      stdin.write('k');
+      await expect(decision).resolves.toEqual({
+        accepted: true,
+        apiMode: 'personal',
+        disableChatGptSubscription: true,
+      });
+      expect(currentApproval.get()).toBeUndefined();
+    } finally {
+      instance.unmount();
+    }
+  });
+
+  it.each([
+    [
+      'subscription',
+      {
+        requestId: 'subscription-limit',
+        streamId: 'retry-stream' as StreamTabId,
+        operation: 'Tool-use call',
+        errorMessage: 'ChatGPT subscription usage limit reached.',
+        errorDetails: {
+          message: 'ChatGPT subscription usage limit reached.',
+          exhaustionReason: 'chatgpt-subscription' as const,
+          provider: 'openai',
+        },
+        personalApiKeyAvailable: false,
+      },
+      'OpenAI',
+    ],
+    [
+      'relay',
+      {
+        requestId: 'relay-limit',
+        streamId: 'retry-stream' as StreamTabId,
+        operation: 'Tool-use call',
+        errorMessage: 'Relay monthly limit reached.',
+        errorDetails: {
+          message: 'Relay monthly limit reached.',
+          exhaustionReason: 'relay-limit' as const,
+          isRelayError: true,
+          provider: 'anthropic',
+        },
+        personalApiKeyAvailable: false,
+        missingPersonalApiKeyMessage:
+          'No Anthropic API key is configured. Press n to give up, then use `/key` to add one.',
+      },
+      'Anthropic',
+    ],
+  ] as const)(
+    'hides the impossible %s switch and names the missing key',
+    async (_route, payload, provider) => {
+      const { ink, React } = await loadInk();
+      const output = ink.renderToString(
+        React.createElement(RetryRequest, {
+          payload,
+          onDecide: vi.fn(),
+        }),
+        { columns: 100 },
+      );
+
+      expect(output).toContain(`No ${provider} API key is configured.`);
+      expect(output).toContain('Press n to give up');
+      expect(output).toContain('/key');
+      expect(output).not.toContain('k use API key and retry');
+    },
+  );
 });

--- a/src/test-kernel/cli/RetryRequest.vitest.mts
+++ b/src/test-kernel/cli/RetryRequest.vitest.mts
@@ -137,4 +137,29 @@ describe('CLI retry request', () => {
       expect(output).not.toContain('k use API key and retry');
     },
   );
+
+  it('derives the fallback copy from the failed provider', async () => {
+    const { ink, React } = await loadInk();
+    const output = ink.renderToString(
+      React.createElement(RetryRequest, {
+        payload: {
+          requestId: 'anthropic-fallback',
+          streamId: 'retry-stream' as StreamTabId,
+          operation: 'Tool-use call',
+          errorDetails: {
+            message: 'Relay monthly limit reached.',
+            exhaustionReason: 'relay-limit',
+            isRelayError: true,
+            provider: 'anthropic',
+          },
+          personalApiKeyAvailable: false,
+        },
+        onDecide: vi.fn(),
+      }),
+      { columns: 100 },
+    );
+
+    expect(output).toContain('No Anthropic API key is configured.');
+    expect(output).not.toContain('OpenAI API key');
+  });
 });

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
@@ -1,15 +1,36 @@
 // Test composition imports
 import '@test/support/defaultSessionTestSetup';
 
-import { afterEach, describe, expect, it, onTestFinished, vi } from 'vitest';
+import pDefer from 'p-defer';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  onTestFinished,
+  vi,
+} from 'vitest';
 
 const mocks = vi.hoisted(() => ({
-  lookupApiKey: vi.fn(),
+  apiKeyExistsUncached: vi.fn(),
+  apiMode: 'included' as 'included' | 'personal',
+  hasUsableApiKey: vi.fn(),
+  invalidateApiKeyCache: vi.fn(),
+  preferSubscription: true,
   notify: vi.fn(),
   secrets: {},
-  setCliApiMode: vi.fn(async () => undefined),
-  setCliCodexSubscription: vi.fn(async () => undefined),
+  setCliApiMode: vi.fn(),
+  setCliCodexSubscription: vi.fn(),
 }));
+
+vi.mock('@auth/codex', async (importActual) => {
+  const actual = await importActual<typeof import('@auth/codex')>();
+  return {
+    ...actual,
+    isPreferCodexSubscription: () => mocks.preferSubscription,
+  };
+});
 
 vi.mock('@cli/chat/tui/notifications/terminalNotifier', () => ({
   notify: mocks.notify,
@@ -20,6 +41,7 @@ vi.mock('@cli/runtime/apiAccessMode', async (importActual) => {
     await importActual<typeof import('@cli/runtime/apiAccessMode')>();
   return {
     ...actual,
+    getCliApiMode: () => mocks.apiMode,
     setCliApiMode: mocks.setCliApiMode,
   };
 });
@@ -32,7 +54,9 @@ vi.mock('@model/apiProviders', async (importActual) => {
   const actual = await importActual<typeof import('@model/apiProviders')>();
   return {
     ...actual,
-    lookupApiKey: mocks.lookupApiKey,
+    apiKeyExistsUncached: mocks.apiKeyExistsUncached,
+    hasUsableApiKey: mocks.hasUsableApiKey,
+    invalidateApiKeyCache: mocks.invalidateApiKeyCache,
   };
 });
 
@@ -40,7 +64,10 @@ vi.mock('@platform/platform', () => ({
   platform: () => ({ secrets: mocks.secrets }),
 }));
 
-import type { HostInteractions } from '@agent/runtime/HostInteractions';
+import type {
+  HostInteractions,
+  HostRetryInteractionOptions,
+} from '@agent/runtime/HostInteractions';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
 import {
@@ -48,13 +75,19 @@ import {
   currentApproval,
   enqueueApproval,
   pendingApprovalSummaries,
+  type ApprovalDecision,
 } from '@cli/chat/tui/state/approvalQueue';
-import { resetCliState, streams } from '@cli/chat/tui/state/cliState';
+import {
+  patchSessionMeta,
+  resetCliState,
+  sessionMeta,
+  streams,
+} from '@cli/chat/tui/state/cliState';
 import { createTuiHostInteractions } from '@cli/chat/tui/state/subscribeApprovals';
 import { hasCliApprovalDenied } from '@cli/runtime/approvalAdapter';
 import type { CliContext } from '@cli/runtime/cliContext';
 import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
-import { API_PROVIDERS, type ApiProvider } from '@model/apiProviders';
+import type { ApiProvider } from '@model/apiProviders';
 import { AgentCategory } from '@shared/schemas';
 import { createTestCliContext } from '@test/cli/fixtures/cliContext';
 import { setGoalSessionBashAutoApproval } from '@tools/goal';
@@ -86,10 +119,20 @@ function tui(runtimeHost = host()): {
   readonly runtimeHost: CliRuntimeHost;
   readonly cliContext: CliContext;
   readonly interactions: HostInteractions;
+  readonly prepareRetry: ReturnType<typeof vi.fn>;
   readonly dispose: () => void;
 } {
   const cliContext = context();
-  const interactions = createTuiHostInteractions(runtimeHost, cliContext);
+  const hostInteractions = createTuiHostInteractions(runtimeHost, cliContext);
+  const prepareRetry = vi.fn(async () => undefined);
+  const interactions: HostInteractions = {
+    ...hostInteractions,
+    requestRetry: (request, options) =>
+      hostInteractions.requestRetry?.(request, {
+        prepareRetry,
+        ...options,
+      }),
+  };
   const detachInteractions = defaultSession().useHostInteractions(interactions);
   let disposed = false;
   const dispose = () => {
@@ -103,6 +146,7 @@ function tui(runtimeHost = host()): {
     runtimeHost,
     cliContext,
     interactions,
+    prepareRetry,
     dispose,
   };
 }
@@ -140,14 +184,79 @@ function chatGptSubscriptionRetry(
   } as RuntimeInteractionEventPayloads['showRetryRequest'];
 }
 
+function decideRetry(decision: ApprovalDecision): void {
+  const pending = currentApproval.get();
+  expect(pending?.payload.kind).toBe('retry');
+  pending?.decide(decision);
+}
+
+function expectNoCredentialChange(
+  prepareRetry: ReturnType<typeof vi.fn>,
+): void {
+  expect(mocks.invalidateApiKeyCache).not.toHaveBeenCalled();
+  expect(mocks.setCliApiMode).not.toHaveBeenCalled();
+  expect(mocks.setCliCodexSubscription).not.toHaveBeenCalled();
+  expect(prepareRetry).not.toHaveBeenCalled();
+}
+
+const PERSONAL_KEY_RETRY: ApprovalDecision = {
+  accepted: true,
+  apiMode: 'personal',
+  disableChatGptSubscription: true,
+};
+
+async function waitForRetryApproval(
+  payload: Record<string, unknown>,
+): Promise<void> {
+  await vi.waitFor(() => {
+    expect(currentApproval.get()?.payload).toMatchObject({
+      kind: 'retry',
+      payload,
+    });
+  });
+}
+
+async function beginSubscriptionSwitch(
+  interactions: HostInteractions,
+  streamId: string,
+  options?: HostRetryInteractionOptions,
+): Promise<{
+  readonly result: ReturnType<NonNullable<HostInteractions['requestRetry']>>;
+}> {
+  const result = interactions.requestRetry?.(
+    chatGptSubscriptionRetry(streamId),
+    options,
+  );
+  await waitForRetryApproval({ streamId });
+  decideRetry(PERSONAL_KEY_RETRY);
+  return { result };
+}
+
+beforeEach(() => {
+  mocks.apiMode = 'included';
+  patchSessionMeta({ apiMode: 'included' });
+  mocks.preferSubscription = true;
+  mocks.apiKeyExistsUncached.mockResolvedValue(true);
+  mocks.hasUsableApiKey.mockResolvedValue(false);
+  mocks.setCliApiMode.mockImplementation(async (mode) => {
+    mocks.apiMode = mode;
+  });
+  mocks.setCliCodexSubscription.mockImplementation(async (enabled) => {
+    mocks.preferSubscription = enabled;
+    return { effective: enabled, target: 'global' };
+  });
+});
+
 afterEach(() => {
   clearApprovals();
   cleanupAllApprovals();
   resetCliState();
-  mocks.lookupApiKey.mockReset();
+  mocks.apiKeyExistsUncached.mockReset();
+  mocks.hasUsableApiKey.mockReset();
+  mocks.invalidateApiKeyCache.mockReset();
   mocks.notify.mockReset();
-  mocks.setCliApiMode.mockClear();
-  mocks.setCliCodexSubscription.mockClear();
+  mocks.setCliApiMode.mockReset();
+  mocks.setCliCodexSubscription.mockReset();
 });
 
 describe('TUI retry approvals', () => {
@@ -429,33 +538,26 @@ describe('TUI retry approvals', () => {
     expect(isBashApprovalBypassedForStream(streamId)).toBe(false);
   });
 
-  it('auto-switches provider-less relay retries when any personal key exists', async () => {
-    const fallbackProvider =
-      API_PROVIDERS.find((provider) => provider !== 'openai') ??
-      API_PROVIDERS[0];
-    mocks.lookupApiKey.mockImplementation(
-      async (_secrets, provider: ApiProvider) =>
-        provider === fallbackProvider ? 'sk-test' : undefined,
-    );
-
-    const { interactions } = tui();
+  it('fails closed when a relay retry does not identify its provider', async () => {
+    mocks.hasUsableApiKey.mockResolvedValue(true);
+    const { interactions, prepareRetry } = tui();
     const result = interactions.requestRetry?.(relayRetry({ streamId: 's1' }));
 
-    await vi.waitFor(() => {
-      expect(mocks.setCliApiMode).toHaveBeenCalledWith('personal');
+    await waitForRetryApproval({
+      personalApiKeyAvailable: false,
+      missingPersonalApiKeyMessage: expect.stringContaining(
+        'provider could not be identified',
+      ),
     });
-    await expect(result).resolves.toEqual({
-      action: 'retry',
-      feedback: undefined,
-    });
-    expect(currentApproval.get()).toBeUndefined();
-    expect(mocks.lookupApiKey.mock.calls.map((call) => call[1])).toContain(
-      fallbackProvider,
-    );
+    decideRetry({ accepted: false });
+
+    await expect(result).resolves.toEqual({ action: 'cancel' });
+    expect(mocks.hasUsableApiKey).not.toHaveBeenCalled();
+    expectNoCredentialChange(prepareRetry);
   });
 
   it('falls back to the retry modal when API key lookup fails', async () => {
-    mocks.lookupApiKey.mockRejectedValue(new Error('keychain unavailable'));
+    mocks.hasUsableApiKey.mockRejectedValue(new Error('keychain unavailable'));
 
     const { interactions } = tui();
     const retry = relayRetry({ streamId: 's2', provider: 'openai' });
@@ -470,7 +572,7 @@ describe('TUI retry approvals', () => {
   });
 
   it('does not auto-switch when a retry provider is not an API provider', async () => {
-    mocks.lookupApiKey.mockResolvedValue('sk-test');
+    mocks.hasUsableApiKey.mockResolvedValue(true);
 
     const { interactions } = tui();
     const retry = relayRetry({
@@ -485,13 +587,12 @@ describe('TUI retry approvals', () => {
         payload: { streamId: 'unknown-provider' },
       });
     });
-    expect(mocks.lookupApiKey).not.toHaveBeenCalled();
+    expect(mocks.hasUsableApiKey).not.toHaveBeenCalled();
   });
 
   it('auto-switches relay retries detected by monthly-limit message fallback', async () => {
-    mocks.lookupApiKey.mockImplementation(
-      async (_secrets, provider: ApiProvider) =>
-        provider === 'openai' ? 'sk-openai' : undefined,
+    mocks.hasUsableApiKey.mockImplementation(
+      async (_secrets, provider: ApiProvider) => provider === 'openai',
     );
 
     const { interactions } = tui();
@@ -518,12 +619,11 @@ describe('TUI retry approvals', () => {
   });
 
   it('requires an explicit decision before switching a ChatGPT subscription retry to an API key', async () => {
-    mocks.lookupApiKey.mockImplementation(
-      async (_secrets, provider: ApiProvider) =>
-        provider === 'openai' ? 'sk-openai' : undefined,
+    mocks.hasUsableApiKey.mockImplementation(
+      async (_secrets, provider: ApiProvider) => provider === 'openai',
     );
 
-    const { interactions } = tui();
+    const { interactions, prepareRetry } = tui();
     const result = interactions.requestRetry?.(chatGptSubscriptionRetry('s3'));
 
     await vi.waitFor(() => {
@@ -532,18 +632,15 @@ describe('TUI retry approvals', () => {
         payload: {
           streamId: 's3',
           errorMessage: 'ChatGPT subscription usage limit reached.',
+          personalApiKeyAvailable: true,
         },
       });
     });
-    expect(mocks.lookupApiKey).not.toHaveBeenCalled();
+    expect(mocks.hasUsableApiKey).toHaveBeenCalledTimes(1);
     expect(mocks.setCliApiMode).not.toHaveBeenCalled();
     expect(mocks.setCliCodexSubscription).not.toHaveBeenCalled();
 
-    currentApproval.get()?.decide({
-      accepted: true,
-      apiMode: 'personal',
-      disableChatGptSubscription: true,
-    });
+    decideRetry(PERSONAL_KEY_RETRY);
 
     await expect(result).resolves.toEqual({
       action: 'retry',
@@ -551,7 +648,175 @@ describe('TUI retry approvals', () => {
     });
     expect(mocks.setCliApiMode).toHaveBeenCalledWith('personal');
     expect(mocks.setCliCodexSubscription).toHaveBeenCalledWith(false);
+    expect(mocks.hasUsableApiKey).toHaveBeenCalledTimes(1);
+    expect(mocks.apiKeyExistsUncached).toHaveBeenCalledWith(
+      mocks.secrets,
+      'openai',
+    );
+    expect(mocks.apiKeyExistsUncached).toHaveBeenCalledTimes(2);
+    expect(mocks.invalidateApiKeyCache).toHaveBeenCalledTimes(2);
+    expect(prepareRetry).toHaveBeenCalledOnce();
     expect(currentApproval.get()).toBeUndefined();
+  });
+
+  it('does not offer or apply the subscription switch without an OpenAI API key', async () => {
+    mocks.hasUsableApiKey.mockResolvedValue(false);
+
+    const { interactions, prepareRetry } = tui();
+    const result = interactions.requestRetry?.(
+      chatGptSubscriptionRetry('missing-openai-key'),
+    );
+
+    await waitForRetryApproval({
+      streamId: 'missing-openai-key',
+      personalApiKeyAvailable: false,
+    });
+    decideRetry({ accepted: false });
+
+    await expect(result).resolves.toEqual({ action: 'cancel' });
+    expectNoCredentialChange(prepareRetry);
+  });
+
+  it('does not mutate state when cancellation arrives during uncached validation', async () => {
+    mocks.hasUsableApiKey.mockResolvedValue(true);
+    const validation = pDefer<boolean>();
+    mocks.apiKeyExistsUncached.mockReturnValueOnce(validation.promise);
+
+    const { interactions, prepareRetry } = tui();
+    const { result } = await beginSubscriptionSwitch(
+      interactions,
+      'cancel-during-validation',
+    );
+    await vi.waitFor(() =>
+      expect(mocks.apiKeyExistsUncached).toHaveBeenCalledOnce(),
+    );
+
+    interactions.cancel({
+      streamId: 'cancel-during-validation',
+      kind: 'retry',
+    });
+    await expect(result).resolves.toEqual({ action: 'cancel' });
+    validation.resolve(true);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expectNoCredentialChange(prepareRetry);
+  });
+
+  it('rolls back both preferences when the personal-key client cannot be prepared', async () => {
+    mocks.hasUsableApiKey.mockResolvedValue(true);
+    const prepareRetry = vi.fn(async () => {
+      throw new Error('OpenAI client construction failed');
+    });
+
+    const { interactions } = tui();
+    const { result } = await beginSubscriptionSwitch(
+      interactions,
+      'client-refresh-failure',
+      { prepareRetry },
+    );
+
+    await expect(result).resolves.toEqual({
+      action: 'deny',
+      reason: 'OpenAI client construction failed',
+    });
+    expect(mocks.setCliApiMode.mock.calls.map(([mode]) => mode)).toEqual([
+      'personal',
+      'included',
+    ]);
+    expect(
+      mocks.setCliCodexSubscription.mock.calls.map(([enabled]) => enabled),
+    ).toEqual([false, true]);
+    expect(mocks.apiMode).toBe('included');
+    expect(mocks.preferSubscription).toBe(true);
+    expect(prepareRetry).toHaveBeenCalledOnce();
+  });
+
+  it('reports any preference that cannot be restored after preparation fails', async () => {
+    mocks.hasUsableApiKey.mockResolvedValue(true);
+    mocks.setCliCodexSubscription
+      .mockImplementationOnce(async (enabled: boolean) => {
+        mocks.preferSubscription = enabled;
+        return { effective: enabled, target: 'global' };
+      })
+      .mockRejectedValueOnce(new Error('settings storage unavailable'));
+    const prepareRetry = vi.fn(async () => {
+      throw new Error('OpenAI client construction failed');
+    });
+
+    const { interactions } = tui();
+    const { result } = await beginSubscriptionSwitch(
+      interactions,
+      'rollback-failure',
+      { prepareRetry },
+    );
+
+    await expect(result).resolves.toEqual({
+      action: 'deny',
+      reason: expect.stringContaining(
+        'Previous access settings could not be fully restored: Could not restore the ChatGPT subscription preference: settings storage unavailable',
+      ),
+    });
+    expect(mocks.apiMode).toBe('included');
+    expect(mocks.preferSubscription).toBe(false);
+  });
+
+  it('reports unconfirmed persistence when rollback restores memory before rejecting', async () => {
+    mocks.hasUsableApiKey.mockResolvedValue(true);
+    mocks.setCliApiMode
+      .mockImplementationOnce(async (mode) => {
+        mocks.apiMode = mode;
+      })
+      .mockImplementationOnce(async (mode) => {
+        mocks.apiMode = mode;
+        throw new Error('API mode storage unavailable');
+      });
+    const prepareRetry = vi.fn(async () => {
+      throw new Error('OpenAI client construction failed');
+    });
+
+    const { interactions } = tui();
+    const { result } = await beginSubscriptionSwitch(
+      interactions,
+      'rollback-persistence-failure',
+      { prepareRetry },
+    );
+
+    await expect(result).resolves.toEqual({
+      action: 'deny',
+      reason: expect.stringContaining(
+        'Previous access settings could not be fully restored: The previous API mode appears restored in memory, but persistence could not be confirmed: API mode storage unavailable',
+      ),
+    });
+    expect(mocks.apiMode).toBe('included');
+    expect(mocks.preferSubscription).toBe(true);
+    expect(prepareRetry).toHaveBeenCalledOnce();
+  });
+
+  it('keeps settings and the prepared client together when a replacement arrives at the commit point', async () => {
+    mocks.hasUsableApiKey.mockResolvedValue(true);
+    const preparation = pDefer<void>();
+    const prepareRetry = vi.fn(() => preparation.promise);
+
+    const { interactions } = tui();
+    const { result: first } = await beginSubscriptionSwitch(
+      interactions,
+      'commit-race',
+      { prepareRetry },
+    );
+    await vi.waitFor(() => expect(prepareRetry).toHaveBeenCalledOnce());
+    expect(sessionMeta.get().apiMode).toBe('included');
+
+    void interactions.requestRetry?.(chatGptSubscriptionRetry('commit-race'));
+    await expect(first).resolves.toEqual({ action: 'cancel' });
+    preparation.resolve();
+    await preparation.promise;
+    await vi.waitFor(() => expect(sessionMeta.get().apiMode).toBe('personal'));
+
+    expect(mocks.apiMode).toBe('personal');
+    expect(mocks.preferSubscription).toBe(false);
+    expect(mocks.setCliApiMode).toHaveBeenCalledTimes(1);
+    expect(mocks.setCliCodexSubscription).toHaveBeenCalledTimes(1);
   });
 
   it('retries ChatGPT subscription access without changing credentials when the ordinary retry action is chosen', async () => {
@@ -566,22 +831,54 @@ describe('TUI retry approvals', () => {
         payload: { streamId: 'subscription-retry' },
       });
     });
-    currentApproval.get()?.decide({ accepted: true });
+    decideRetry({ accepted: true });
 
     await expect(result).resolves.toEqual({
       action: 'retry',
       feedback: undefined,
     });
-    expect(mocks.lookupApiKey).not.toHaveBeenCalled();
+    expect(mocks.hasUsableApiKey).toHaveBeenCalledOnce();
     expect(mocks.setCliApiMode).not.toHaveBeenCalled();
     expect(mocks.setCliCodexSubscription).not.toHaveBeenCalled();
   });
 
+  it('does not queue an ordinary retry behind slow client preparation', async () => {
+    mocks.hasUsableApiKey.mockResolvedValue(true);
+    const preparation = pDefer<void>();
+    const prepareRetry = vi.fn(() => preparation.promise);
+    const { interactions } = tui();
+    const { result: switching } = await beginSubscriptionSwitch(
+      interactions,
+      'slow-switch',
+      { prepareRetry },
+    );
+    await vi.waitFor(() => expect(prepareRetry).toHaveBeenCalledOnce());
+
+    const ordinary = interactions.requestRetry?.({
+      requestId: 'ordinary-retry',
+      streamId: 'ordinary-stream',
+      operation: 'model request',
+      errorMessage: 'Temporary connection error.',
+    });
+    await waitForRetryApproval({ streamId: 'ordinary-stream' });
+    decideRetry({ accepted: true });
+
+    await expect(ordinary).resolves.toEqual({
+      action: 'retry',
+      feedback: undefined,
+    });
+    preparation.resolve();
+    await expect(switching).resolves.toEqual({
+      action: 'retry',
+      feedback: undefined,
+    });
+  });
+
   it('invalidates pre-queue retry lookups when approvals are cleared', async () => {
-    let resolveLookup: ((value: string | undefined) => void) | undefined;
-    mocks.lookupApiKey.mockImplementation(
+    let resolveLookup: ((value: boolean) => void) | undefined;
+    mocks.hasUsableApiKey.mockImplementation(
       () =>
-        new Promise<string | undefined>((resolve) => {
+        new Promise<boolean>((resolve) => {
           resolveLookup = resolve;
         }),
     );
@@ -593,7 +890,7 @@ describe('TUI retry approvals', () => {
     clearApprovals();
     await expect(result).resolves.toEqual({ action: 'cancel' });
 
-    resolveLookup?.('sk-after-interrupt');
+    resolveLookup?.(true);
     await Promise.resolve();
     await Promise.resolve();
 
@@ -602,10 +899,10 @@ describe('TUI retry approvals', () => {
   });
 
   it('invalidates pre-queue retry lookups when approvals are unbound', async () => {
-    let resolveLookup: ((value: string | undefined) => void) | undefined;
-    mocks.lookupApiKey.mockImplementation(
+    let resolveLookup: ((value: boolean) => void) | undefined;
+    mocks.hasUsableApiKey.mockImplementation(
       () =>
-        new Promise<string | undefined>((resolve) => {
+        new Promise<boolean>((resolve) => {
           resolveLookup = resolve;
         }),
     );
@@ -617,7 +914,7 @@ describe('TUI retry approvals', () => {
     dispose();
     await expect(result).resolves.toEqual({ action: 'cancel' });
 
-    resolveLookup?.('sk-after-unbind');
+    resolveLookup?.(true);
     await Promise.resolve();
     await Promise.resolve();
 
@@ -626,7 +923,7 @@ describe('TUI retry approvals', () => {
   });
 
   it('cancels an active retry modal when approvals are cleared', async () => {
-    mocks.lookupApiKey.mockResolvedValue(undefined);
+    mocks.hasUsableApiKey.mockResolvedValue(false);
 
     const { interactions } = tui();
     const result = interactions.requestRetry?.(
@@ -668,7 +965,7 @@ describe('TUI retry approvals', () => {
   });
 
   it('times out an active retry modal', async () => {
-    mocks.lookupApiKey.mockResolvedValue(undefined);
+    mocks.hasUsableApiKey.mockResolvedValue(false);
 
     const { cliContext, interactions } = tui();
     const result = interactions.requestRetry?.(
@@ -687,7 +984,9 @@ describe('TUI retry approvals', () => {
   });
 
   it('times out while a retry is still waiting on the keychain', async () => {
-    mocks.lookupApiKey.mockImplementation(() => new Promise(() => undefined));
+    mocks.hasUsableApiKey.mockImplementation(
+      () => new Promise(() => undefined),
+    );
 
     const { cliContext, interactions } = tui();
     const result = interactions.requestRetry?.(
@@ -701,15 +1000,15 @@ describe('TUI retry approvals', () => {
   });
 
   it('ignores stale auto-switch lookups after a newer retry replaces them', async () => {
-    let resolveFirstLookup: ((value: string | undefined) => void) | undefined;
-    mocks.lookupApiKey
+    let resolveFirstLookup: ((value: boolean) => void) | undefined;
+    mocks.hasUsableApiKey
       .mockImplementationOnce(
         () =>
-          new Promise<string | undefined>((resolve) => {
+          new Promise<boolean>((resolve) => {
             resolveFirstLookup = resolve;
           }),
       )
-      .mockResolvedValueOnce(undefined);
+      .mockResolvedValueOnce(false);
 
     const { interactions } = tui();
     void interactions.requestRetry?.(
@@ -734,7 +1033,7 @@ describe('TUI retry approvals', () => {
       });
     });
 
-    resolveFirstLookup?.('sk-stale');
+    resolveFirstLookup?.(true);
     await Promise.resolve();
     await Promise.resolve();
 
@@ -742,9 +1041,9 @@ describe('TUI retry approvals', () => {
   });
 
   it('clears an older retry modal when a newer retry auto-switches', async () => {
-    mocks.lookupApiKey
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce('sk-new');
+    mocks.hasUsableApiKey
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
 
     const { interactions } = tui();
     void interactions.requestRetry?.(
@@ -779,7 +1078,7 @@ describe('TUI retry approvals', () => {
   });
 
   it('replaces an older retry modal when a newer retry also needs input', async () => {
-    mocks.lookupApiKey.mockResolvedValue(undefined);
+    mocks.hasUsableApiKey.mockResolvedValue(false);
 
     const { interactions } = tui();
     void interactions.requestRetry?.(
@@ -812,19 +1111,14 @@ describe('TUI retry approvals', () => {
     });
   });
 
-  it('does not let a stale auto-switch failure cancel a newer retry', async () => {
-    let rejectFirstModeSwitch: ((error: Error) => void) | undefined;
-    mocks.lookupApiKey.mockResolvedValue('sk-test');
+  it('serializes a newer switch behind stale-switch rollback', async () => {
+    const firstModeSwitch = pDefer<undefined>();
+    mocks.hasUsableApiKey.mockResolvedValue(true);
     mocks.setCliApiMode
-      .mockImplementationOnce(
-        () =>
-          new Promise<undefined>((_resolve, reject) => {
-            rejectFirstModeSwitch = reject;
-          }),
-      )
+      .mockImplementationOnce(() => firstModeSwitch.promise)
       .mockResolvedValueOnce(undefined);
 
-    const { interactions } = tui();
+    const { interactions, prepareRetry } = tui();
     void interactions.requestRetry?.(
       relayRetry({
         streamId: 'same-stream',
@@ -843,16 +1137,20 @@ describe('TUI retry approvals', () => {
         message: 'second retry',
       }),
     );
-    await vi.waitFor(() => {
-      expect(mocks.setCliApiMode).toHaveBeenCalledTimes(2);
-    });
+    await Promise.resolve();
+    expect(mocks.setCliApiMode).toHaveBeenCalledTimes(1);
+
+    firstModeSwitch.reject(new Error('stale mode switch failed'));
     await expect(second).resolves.toEqual({
       action: 'retry',
       feedback: undefined,
     });
-
-    rejectFirstModeSwitch?.(new Error('stale mode switch failed'));
-    await Promise.resolve();
-    await Promise.resolve();
+    expect(mocks.setCliApiMode.mock.calls.map(([mode]) => mode)).toEqual([
+      'personal',
+      'included',
+      'personal',
+    ]);
+    expect(mocks.apiMode).toBe('personal');
+    expect(prepareRetry).toHaveBeenCalledOnce();
   });
 });

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
@@ -815,6 +815,46 @@ describe('TUI retry approvals', () => {
     expect(laterPrepare).toHaveBeenCalledOnce();
   });
 
+  it('rolls back a cancelled persistence write and releases the session commit queue', async () => {
+    mocks.hasUsableApiKey.mockResolvedValue(true);
+    mocks.setCliApiMode.mockImplementationOnce(async (mode) => {
+      mocks.apiMode = mode;
+      await new Promise<void>(() => {
+        // Simulate storage that never settles after updating in-memory state.
+      });
+    });
+    const { interactions } = tui();
+    const { result } = await beginSubscriptionSwitch(
+      interactions,
+      'stalled-mode-persistence',
+    );
+    await vi.waitFor(() => expect(mocks.setCliApiMode).toHaveBeenCalledOnce());
+    expect(mocks.apiMode).toBe('personal');
+
+    interactions.cancel({
+      streamId: 'stalled-mode-persistence',
+      kind: 'retry',
+      cause: 'Cancelled in test.',
+    });
+    await expect(result).resolves.toEqual({ action: 'cancel' });
+    await vi.waitFor(() => expect(mocks.apiMode).toBe('included'));
+
+    const laterPrepare = vi.fn(async () => undefined);
+    const later = interactions.requestRetry?.(
+      relayRetry({
+        streamId: 'after-stalled-persistence',
+        provider: 'openai',
+      }),
+      { prepareRetry: laterPrepare },
+    );
+    await expect(later).resolves.toEqual({
+      action: 'retry',
+      feedback: undefined,
+    });
+    expect(laterPrepare).toHaveBeenCalledOnce();
+    expect(mocks.apiMode).toBe('personal');
+  });
+
   it('reports any preference that cannot be restored after commit fails', async () => {
     mocks.hasUsableApiKey.mockResolvedValue(true);
     mocks.setCliCodexSubscription
@@ -1336,7 +1376,10 @@ describe('TUI retry approvals', () => {
       }),
     );
     await Promise.resolve();
-    expect(mocks.setCliApiMode).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() =>
+      expect(mocks.setCliApiMode).toHaveBeenCalledTimes(2),
+    );
+    expect(mocks.apiMode).toBe('included');
 
     firstModeSwitch.reject(new Error('stale mode switch failed'));
     await expect(second).resolves.toEqual({

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
@@ -842,7 +842,7 @@ describe('TUI retry approvals', () => {
     expect(mocks.setCliCodexSubscription).not.toHaveBeenCalled();
   });
 
-  it('does not queue an ordinary retry behind slow client preparation', async () => {
+  it('linearizes ordinary retry preparation after a successful credential switch', async () => {
     mocks.hasUsableApiKey.mockResolvedValue(true);
     const preparation = pDefer<void>();
     const prepareRetry = vi.fn(() => preparation.promise);
@@ -854,24 +854,145 @@ describe('TUI retry approvals', () => {
     );
     await vi.waitFor(() => expect(prepareRetry).toHaveBeenCalledOnce());
 
-    const ordinary = interactions.requestRetry?.({
-      requestId: 'ordinary-retry',
-      streamId: 'ordinary-stream',
-      operation: 'model request',
-      errorMessage: 'Temporary connection error.',
+    const ordinaryPrepare = vi.fn(async () => {
+      expect(mocks.apiMode).toBe('personal');
+      expect(mocks.preferSubscription).toBe(false);
     });
+    const ordinary = interactions.requestRetry?.(
+      {
+        requestId: 'ordinary-retry',
+        streamId: 'ordinary-stream',
+        operation: 'model request',
+        errorMessage: 'Temporary connection error.',
+      },
+      { prepareRetry: ordinaryPrepare },
+    );
     await waitForRetryApproval({ streamId: 'ordinary-stream' });
     decideRetry({ accepted: true });
 
-    await expect(ordinary).resolves.toEqual({
-      action: 'retry',
-      feedback: undefined,
-    });
+    await Promise.resolve();
+    expect(ordinaryPrepare).not.toHaveBeenCalled();
+
     preparation.resolve();
     await expect(switching).resolves.toEqual({
       action: 'retry',
       feedback: undefined,
     });
+    await expect(ordinary).resolves.toEqual({
+      action: 'retry',
+      feedback: undefined,
+    });
+    expect(ordinaryPrepare).toHaveBeenCalledOnce();
+  });
+
+  it('linearizes ordinary retry preparation after credential rollback', async () => {
+    mocks.hasUsableApiKey.mockResolvedValue(true);
+    const preparation = pDefer<void>();
+    const switchPrepare = vi.fn(async () => {
+      await preparation.promise;
+      throw new Error('replacement client failed');
+    });
+    const { interactions } = tui();
+    const { result: switching } = await beginSubscriptionSwitch(
+      interactions,
+      'failing-switch',
+      { prepareRetry: switchPrepare },
+    );
+    await vi.waitFor(() => expect(switchPrepare).toHaveBeenCalledOnce());
+
+    const ordinaryPrepare = vi.fn(async () => {
+      expect(mocks.apiMode).toBe('included');
+      expect(mocks.preferSubscription).toBe(true);
+    });
+    const ordinary = interactions.requestRetry?.(
+      {
+        requestId: 'ordinary-after-rollback',
+        streamId: 'ordinary-after-rollback',
+        operation: 'model request',
+        errorMessage: 'Temporary connection error.',
+      },
+      { prepareRetry: ordinaryPrepare },
+    );
+    await waitForRetryApproval({ streamId: 'ordinary-after-rollback' });
+    decideRetry({ accepted: true });
+    await Promise.resolve();
+    expect(ordinaryPrepare).not.toHaveBeenCalled();
+
+    preparation.resolve();
+    await expect(switching).resolves.toEqual({
+      action: 'deny',
+      reason: 'replacement client failed',
+    });
+    await expect(ordinary).resolves.toEqual({
+      action: 'retry',
+      feedback: undefined,
+    });
+    expect(ordinaryPrepare).toHaveBeenCalledOnce();
+  });
+
+  it('denies an ordinary retry when its replacement client cannot be prepared', async () => {
+    const { interactions } = tui();
+    const prepareRetry = vi.fn(async () => {
+      throw new Error('ordinary client refresh failed');
+    });
+    const ordinary = interactions.requestRetry?.(
+      {
+        requestId: 'ordinary-refresh-failure',
+        streamId: 'ordinary-refresh-failure',
+        operation: 'model request',
+        errorMessage: 'Temporary connection error.',
+      },
+      { prepareRetry },
+    );
+    await waitForRetryApproval({ streamId: 'ordinary-refresh-failure' });
+    decideRetry({ accepted: true });
+
+    await expect(ordinary).resolves.toEqual({
+      action: 'deny',
+      reason: 'ordinary client refresh failed',
+    });
+    expect(prepareRetry).toHaveBeenCalledOnce();
+    expect(mocks.setCliApiMode).not.toHaveBeenCalled();
+    expect(mocks.setCliCodexSubscription).not.toHaveBeenCalled();
+  });
+
+  it('skips queued ordinary preparation after that retry is cancelled', async () => {
+    mocks.hasUsableApiKey.mockResolvedValue(true);
+    const preparation = pDefer<void>();
+    const switchPrepare = vi.fn(() => preparation.promise);
+    const { interactions } = tui();
+    const { result: switching } = await beginSubscriptionSwitch(
+      interactions,
+      'switch-before-cancel',
+      { prepareRetry: switchPrepare },
+    );
+    await vi.waitFor(() => expect(switchPrepare).toHaveBeenCalledOnce());
+
+    const ordinaryPrepare = vi.fn(async () => undefined);
+    const ordinary = interactions.requestRetry?.(
+      {
+        requestId: 'cancelled-ordinary',
+        streamId: 'cancelled-ordinary',
+        operation: 'model request',
+        errorMessage: 'Temporary connection error.',
+      },
+      { prepareRetry: ordinaryPrepare },
+    );
+    await waitForRetryApproval({ streamId: 'cancelled-ordinary' });
+    decideRetry({ accepted: true });
+    interactions.cancel({
+      streamId: 'cancelled-ordinary',
+      kind: 'retry',
+      cause: 'Cancelled in test.',
+    });
+    await expect(ordinary).resolves.toEqual({ action: 'cancel' });
+
+    preparation.resolve();
+    await expect(switching).resolves.toEqual({
+      action: 'retry',
+      feedback: undefined,
+    });
+    expect(ordinaryPrepare).not.toHaveBeenCalled();
   });
 
   it('invalidates pre-queue retry lookups when approvals are cleared', async () => {

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
@@ -566,7 +566,12 @@ describe('TUI retry approvals', () => {
     await vi.waitFor(() => {
       expect(currentApproval.get()?.payload).toMatchObject({
         kind: 'retry',
-        payload: { streamId: 's2' },
+        payload: {
+          streamId: 's2',
+          personalApiKeyAvailable: false,
+          missingPersonalApiKeyMessage:
+            'TeXRA could not check whether the OpenAI API key is available. Press n to give up, then use `/key` to try again.',
+        },
       });
     });
   });
@@ -732,6 +737,86 @@ describe('TUI retry approvals', () => {
     expect(prepareRetry).toHaveBeenCalledOnce();
   });
 
+  it('does not roll back over a newer access selection', async () => {
+    mocks.hasUsableApiKey.mockResolvedValue(true);
+    const preparation = pDefer<void>();
+    const prepareRetry = vi.fn(async () => {
+      await preparation.promise;
+      throw new Error('OpenAI client construction failed');
+    });
+    const { interactions } = tui();
+    const { result } = await beginSubscriptionSwitch(
+      interactions,
+      'newer-access-selection',
+      { prepareRetry },
+    );
+    await vi.waitFor(() => expect(prepareRetry).toHaveBeenCalledOnce());
+    expect(mocks.apiMode).toBe('personal');
+    expect(mocks.preferSubscription).toBe(false);
+
+    // A later /api, /key, login, or logout selection owns these values now.
+    mocks.apiMode = 'included';
+    mocks.preferSubscription = true;
+    preparation.resolve();
+
+    await expect(result).resolves.toEqual({
+      action: 'deny',
+      reason: 'OpenAI client construction failed',
+    });
+    expect(mocks.setCliApiMode).toHaveBeenCalledTimes(1);
+    expect(mocks.setCliCodexSubscription).toHaveBeenCalledTimes(1);
+    expect(mocks.apiMode).toBe('included');
+    expect(mocks.preferSubscription).toBe(true);
+  });
+
+  it('cancels stalled preparation, restores its settings, and releases the retry queue', async () => {
+    mocks.hasUsableApiKey.mockResolvedValue(true);
+    const prepareRetry = vi.fn(
+      async (_signal?: AbortSignal) =>
+        await new Promise<void>(() => {
+          // Deliberately never settles: cancellation must release the queue.
+        }),
+    );
+    const { interactions } = tui();
+    const { result } = await beginSubscriptionSwitch(
+      interactions,
+      'stalled-preparation',
+      { prepareRetry },
+    );
+    await vi.waitFor(() => expect(prepareRetry).toHaveBeenCalledOnce());
+
+    interactions.cancel({
+      streamId: 'stalled-preparation',
+      kind: 'retry',
+      cause: 'Cancelled in test.',
+    });
+    await expect(result).resolves.toEqual({ action: 'cancel' });
+    expect(prepareRetry.mock.calls[0]?.[0]?.aborted).toBe(true);
+    await vi.waitFor(() => {
+      expect(mocks.apiMode).toBe('included');
+      expect(mocks.preferSubscription).toBe(true);
+    });
+
+    const laterPrepare = vi.fn(async () => undefined);
+    const later = interactions.requestRetry?.(
+      {
+        requestId: 'retry-after-stall',
+        streamId: 'retry-after-stall',
+        operation: 'model request',
+        errorMessage: 'Temporary connection error.',
+      },
+      { prepareRetry: laterPrepare },
+    );
+    await waitForRetryApproval({ streamId: 'retry-after-stall' });
+    decideRetry({ accepted: true });
+
+    await expect(later).resolves.toEqual({
+      action: 'retry',
+      feedback: undefined,
+    });
+    expect(laterPrepare).toHaveBeenCalledOnce();
+  });
+
   it('reports any preference that cannot be restored after preparation fails', async () => {
     mocks.hasUsableApiKey.mockResolvedValue(true);
     mocks.setCliCodexSubscription
@@ -793,7 +878,7 @@ describe('TUI retry approvals', () => {
     expect(prepareRetry).toHaveBeenCalledOnce();
   });
 
-  it('keeps settings and the prepared client together when a replacement arrives at the commit point', async () => {
+  it('rolls back a credential switch cancelled during client preparation', async () => {
     mocks.hasUsableApiKey.mockResolvedValue(true);
     const preparation = pDefer<void>();
     const prepareRetry = vi.fn(() => preparation.promise);
@@ -811,12 +896,19 @@ describe('TUI retry approvals', () => {
     await expect(first).resolves.toEqual({ action: 'cancel' });
     preparation.resolve();
     await preparation.promise;
-    await vi.waitFor(() => expect(sessionMeta.get().apiMode).toBe('personal'));
+    await vi.waitFor(() => {
+      expect(mocks.apiMode).toBe('included');
+      expect(mocks.preferSubscription).toBe(true);
+    });
 
-    expect(mocks.apiMode).toBe('personal');
-    expect(mocks.preferSubscription).toBe(false);
-    expect(mocks.setCliApiMode).toHaveBeenCalledTimes(1);
-    expect(mocks.setCliCodexSubscription).toHaveBeenCalledTimes(1);
+    expect(sessionMeta.get().apiMode).toBe('included');
+    expect(mocks.setCliApiMode.mock.calls.map(([mode]) => mode)).toEqual([
+      'personal',
+      'included',
+    ]);
+    expect(
+      mocks.setCliCodexSubscription.mock.calls.map(([enabled]) => enabled),
+    ).toEqual([false, true]);
   });
 
   it('retries ChatGPT subscription access without changing credentials when the ordinary retry action is chosen', async () => {
@@ -1236,8 +1328,13 @@ describe('TUI retry approvals', () => {
     const firstModeSwitch = pDefer<undefined>();
     mocks.hasUsableApiKey.mockResolvedValue(true);
     mocks.setCliApiMode
-      .mockImplementationOnce(() => firstModeSwitch.promise)
-      .mockResolvedValueOnce(undefined);
+      .mockImplementationOnce(async (mode) => {
+        mocks.apiMode = mode;
+        await firstModeSwitch.promise;
+      })
+      .mockImplementationOnce(async (mode) => {
+        mocks.apiMode = mode;
+      });
 
     const { interactions, prepareRetry } = tui();
     void interactions.requestRetry?.(

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
@@ -658,9 +658,10 @@ describe('TUI retry approvals', () => {
       mocks.secrets,
       'openai',
     );
-    expect(mocks.apiKeyExistsUncached).toHaveBeenCalledTimes(2);
-    expect(mocks.invalidateApiKeyCache).toHaveBeenCalledTimes(2);
+    expect(mocks.apiKeyExistsUncached).toHaveBeenCalledOnce();
+    expect(mocks.invalidateApiKeyCache).toHaveBeenCalledOnce();
     expect(prepareRetry).toHaveBeenCalledOnce();
+    expect(prepareRetry).toHaveBeenCalledWith('personal', expect.anything());
     expect(currentApproval.get()).toBeUndefined();
   });
 
@@ -708,7 +709,7 @@ describe('TUI retry approvals', () => {
     expectNoCredentialChange(prepareRetry);
   });
 
-  it('rolls back both preferences when the personal-key client cannot be prepared', async () => {
+  it('does not publish preferences when the personal-key client cannot be prepared', async () => {
     mocks.hasUsableApiKey.mockResolvedValue(true);
     const prepareRetry = vi.fn(async () => {
       throw new Error('OpenAI client construction failed');
@@ -725,19 +726,14 @@ describe('TUI retry approvals', () => {
       action: 'deny',
       reason: 'OpenAI client construction failed',
     });
-    expect(mocks.setCliApiMode.mock.calls.map(([mode]) => mode)).toEqual([
-      'personal',
-      'included',
-    ]);
-    expect(
-      mocks.setCliCodexSubscription.mock.calls.map(([enabled]) => enabled),
-    ).toEqual([false, true]);
+    expect(mocks.setCliApiMode).not.toHaveBeenCalled();
+    expect(mocks.setCliCodexSubscription).not.toHaveBeenCalled();
     expect(mocks.apiMode).toBe('included');
     expect(mocks.preferSubscription).toBe(true);
     expect(prepareRetry).toHaveBeenCalledOnce();
   });
 
-  it('does not roll back over a newer access selection', async () => {
+  it('leaves a newer access selection untouched when candidate construction fails', async () => {
     mocks.hasUsableApiKey.mockResolvedValue(true);
     const preparation = pDefer<void>();
     const prepareRetry = vi.fn(async () => {
@@ -751,8 +747,8 @@ describe('TUI retry approvals', () => {
       { prepareRetry },
     );
     await vi.waitFor(() => expect(prepareRetry).toHaveBeenCalledOnce());
-    expect(mocks.apiMode).toBe('personal');
-    expect(mocks.preferSubscription).toBe(false);
+    expect(mocks.apiMode).toBe('included');
+    expect(mocks.preferSubscription).toBe(true);
 
     // A later /api, /key, login, or logout selection owns these values now.
     mocks.apiMode = 'included';
@@ -763,18 +759,18 @@ describe('TUI retry approvals', () => {
       action: 'deny',
       reason: 'OpenAI client construction failed',
     });
-    expect(mocks.setCliApiMode).toHaveBeenCalledTimes(1);
-    expect(mocks.setCliCodexSubscription).toHaveBeenCalledTimes(1);
+    expect(mocks.setCliApiMode).not.toHaveBeenCalled();
+    expect(mocks.setCliCodexSubscription).not.toHaveBeenCalled();
     expect(mocks.apiMode).toBe('included');
     expect(mocks.preferSubscription).toBe(true);
   });
 
-  it('cancels stalled preparation, restores its settings, and releases the retry queue', async () => {
+  it('cancels stalled candidate construction without publishing settings', async () => {
     mocks.hasUsableApiKey.mockResolvedValue(true);
     const prepareRetry = vi.fn(
-      async (_signal?: AbortSignal) =>
+      async (_selection, _signal?: AbortSignal) =>
         await new Promise<void>(() => {
-          // Deliberately never settles: cancellation must release the queue.
+          // Deliberately never settles: cancellation must reject the wrapper.
         }),
     );
     const { interactions } = tui();
@@ -791,13 +787,15 @@ describe('TUI retry approvals', () => {
       cause: 'Cancelled in test.',
     });
     await expect(result).resolves.toEqual({ action: 'cancel' });
-    expect(prepareRetry.mock.calls[0]?.[0]?.aborted).toBe(true);
+    expect(prepareRetry.mock.calls[0]?.[1]?.aborted).toBe(true);
     await vi.waitFor(() => {
       expect(mocks.apiMode).toBe('included');
       expect(mocks.preferSubscription).toBe(true);
     });
 
-    const laterPrepare = vi.fn(async () => undefined);
+    const laterPrepare = vi.fn(async (selection) => {
+      expect(selection).toBe('configured');
+    });
     const later = interactions.requestRetry?.(
       {
         requestId: 'retry-after-stall',
@@ -817,17 +815,15 @@ describe('TUI retry approvals', () => {
     expect(laterPrepare).toHaveBeenCalledOnce();
   });
 
-  it('reports any preference that cannot be restored after preparation fails', async () => {
+  it('reports any preference that cannot be restored after commit fails', async () => {
     mocks.hasUsableApiKey.mockResolvedValue(true);
     mocks.setCliCodexSubscription
       .mockImplementationOnce(async (enabled: boolean) => {
         mocks.preferSubscription = enabled;
-        return { effective: enabled, target: 'global' };
+        throw new Error('subscription write failed');
       })
       .mockRejectedValueOnce(new Error('settings storage unavailable'));
-    const prepareRetry = vi.fn(async () => {
-      throw new Error('OpenAI client construction failed');
-    });
+    const prepareRetry = vi.fn(async () => undefined);
 
     const { interactions } = tui();
     const { result } = await beginSubscriptionSwitch(
@@ -846,7 +842,7 @@ describe('TUI retry approvals', () => {
     expect(mocks.preferSubscription).toBe(false);
   });
 
-  it('reports unconfirmed persistence when rollback restores memory before rejecting', async () => {
+  it('reports unconfirmed persistence when API-mode rollback restores memory before rejecting', async () => {
     mocks.hasUsableApiKey.mockResolvedValue(true);
     mocks.setCliApiMode
       .mockImplementationOnce(async (mode) => {
@@ -856,9 +852,10 @@ describe('TUI retry approvals', () => {
         mocks.apiMode = mode;
         throw new Error('API mode storage unavailable');
       });
-    const prepareRetry = vi.fn(async () => {
-      throw new Error('OpenAI client construction failed');
-    });
+    mocks.setCliCodexSubscription.mockRejectedValueOnce(
+      new Error('subscription storage unavailable'),
+    );
+    const prepareRetry = vi.fn(async () => undefined);
 
     const { interactions } = tui();
     const { result } = await beginSubscriptionSwitch(
@@ -878,7 +875,7 @@ describe('TUI retry approvals', () => {
     expect(prepareRetry).toHaveBeenCalledOnce();
   });
 
-  it('rolls back a credential switch cancelled during client preparation', async () => {
+  it('cancels a credential switch during candidate construction without settings writes', async () => {
     mocks.hasUsableApiKey.mockResolvedValue(true);
     const preparation = pDefer<void>();
     const prepareRetry = vi.fn(() => preparation.promise);
@@ -902,13 +899,8 @@ describe('TUI retry approvals', () => {
     });
 
     expect(sessionMeta.get().apiMode).toBe('included');
-    expect(mocks.setCliApiMode.mock.calls.map(([mode]) => mode)).toEqual([
-      'personal',
-      'included',
-    ]);
-    expect(
-      mocks.setCliCodexSubscription.mock.calls.map(([enabled]) => enabled),
-    ).toEqual([false, true]);
+    expect(mocks.setCliApiMode).not.toHaveBeenCalled();
+    expect(mocks.setCliCodexSubscription).not.toHaveBeenCalled();
   });
 
   it('retries ChatGPT subscription access without changing credentials when the ordinary retry action is chosen', async () => {
@@ -934,7 +926,7 @@ describe('TUI retry approvals', () => {
     expect(mocks.setCliCodexSubscription).not.toHaveBeenCalled();
   });
 
-  it('linearizes ordinary retry preparation after a successful credential switch', async () => {
+  it('keeps new ordinary retry preparation on the old route while a candidate is building', async () => {
     mocks.hasUsableApiKey.mockResolvedValue(true);
     const preparation = pDefer<void>();
     const prepareRetry = vi.fn(() => preparation.promise);
@@ -947,8 +939,8 @@ describe('TUI retry approvals', () => {
     await vi.waitFor(() => expect(prepareRetry).toHaveBeenCalledOnce());
 
     const ordinaryPrepare = vi.fn(async () => {
-      expect(mocks.apiMode).toBe('personal');
-      expect(mocks.preferSubscription).toBe(false);
+      expect(mocks.apiMode).toBe('included');
+      expect(mocks.preferSubscription).toBe(true);
     });
     const ordinary = interactions.requestRetry?.(
       {
@@ -962,22 +954,22 @@ describe('TUI retry approvals', () => {
     await waitForRetryApproval({ streamId: 'ordinary-stream' });
     decideRetry({ accepted: true });
 
-    await Promise.resolve();
-    expect(ordinaryPrepare).not.toHaveBeenCalled();
+    await expect(ordinary).resolves.toEqual({
+      action: 'retry',
+      feedback: undefined,
+    });
+    expect(ordinaryPrepare).toHaveBeenCalledOnce();
 
     preparation.resolve();
     await expect(switching).resolves.toEqual({
       action: 'retry',
       feedback: undefined,
     });
-    await expect(ordinary).resolves.toEqual({
-      action: 'retry',
-      feedback: undefined,
-    });
-    expect(ordinaryPrepare).toHaveBeenCalledOnce();
+    expect(mocks.apiMode).toBe('personal');
+    expect(mocks.preferSubscription).toBe(false);
   });
 
-  it('linearizes ordinary retry preparation after credential rollback', async () => {
+  it('lets an ordinary retry keep the old route while another candidate fails', async () => {
     mocks.hasUsableApiKey.mockResolvedValue(true);
     const preparation = pDefer<void>();
     const switchPrepare = vi.fn(async () => {
@@ -1007,19 +999,17 @@ describe('TUI retry approvals', () => {
     );
     await waitForRetryApproval({ streamId: 'ordinary-after-rollback' });
     decideRetry({ accepted: true });
-    await Promise.resolve();
-    expect(ordinaryPrepare).not.toHaveBeenCalled();
+    await expect(ordinary).resolves.toEqual({
+      action: 'retry',
+      feedback: undefined,
+    });
+    expect(ordinaryPrepare).toHaveBeenCalledOnce();
 
     preparation.resolve();
     await expect(switching).resolves.toEqual({
       action: 'deny',
       reason: 'replacement client failed',
     });
-    await expect(ordinary).resolves.toEqual({
-      action: 'retry',
-      feedback: undefined,
-    });
-    expect(ordinaryPrepare).toHaveBeenCalledOnce();
   });
 
   it('denies an ordinary retry when its replacement client cannot be prepared', async () => {
@@ -1048,19 +1038,14 @@ describe('TUI retry approvals', () => {
     expect(mocks.setCliCodexSubscription).not.toHaveBeenCalled();
   });
 
-  it('skips queued ordinary preparation after that retry is cancelled', async () => {
-    mocks.hasUsableApiKey.mockResolvedValue(true);
-    const preparation = pDefer<void>();
-    const switchPrepare = vi.fn(() => preparation.promise);
-    const { interactions } = tui();
-    const { result: switching } = await beginSubscriptionSwitch(
-      interactions,
-      'switch-before-cancel',
-      { prepareRetry: switchPrepare },
+  it('cancels ordinary retry preparation after approval', async () => {
+    const ordinaryPrepare = vi.fn(
+      async (_selection, _signal?: AbortSignal) =>
+        await new Promise<void>(() => {
+          // Cancellation settles the abort-aware wrapper around this task.
+        }),
     );
-    await vi.waitFor(() => expect(switchPrepare).toHaveBeenCalledOnce());
-
-    const ordinaryPrepare = vi.fn(async () => undefined);
+    const { interactions } = tui();
     const ordinary = interactions.requestRetry?.(
       {
         requestId: 'cancelled-ordinary',
@@ -1072,19 +1057,14 @@ describe('TUI retry approvals', () => {
     );
     await waitForRetryApproval({ streamId: 'cancelled-ordinary' });
     decideRetry({ accepted: true });
+    await vi.waitFor(() => expect(ordinaryPrepare).toHaveBeenCalledOnce());
     interactions.cancel({
       streamId: 'cancelled-ordinary',
       kind: 'retry',
       cause: 'Cancelled in test.',
     });
     await expect(ordinary).resolves.toEqual({ action: 'cancel' });
-
-    preparation.resolve();
-    await expect(switching).resolves.toEqual({
-      action: 'retry',
-      feedback: undefined,
-    });
-    expect(ordinaryPrepare).not.toHaveBeenCalled();
+    expect(ordinaryPrepare.mock.calls[0]?.[1]?.aborted).toBe(true);
   });
 
   it('invalidates pre-queue retry lookups when approvals are cleared', async () => {
@@ -1369,6 +1349,16 @@ describe('TUI retry approvals', () => {
       'personal',
     ]);
     expect(mocks.apiMode).toBe('personal');
-    expect(prepareRetry).toHaveBeenCalledOnce();
+    expect(prepareRetry).toHaveBeenCalledTimes(2);
+    expect(prepareRetry).toHaveBeenNthCalledWith(
+      1,
+      'personal',
+      expect.anything(),
+    );
+    expect(prepareRetry).toHaveBeenNthCalledWith(
+      2,
+      'personal',
+      expect.anything(),
+    );
   });
 });

--- a/src/test-kernel/cli/TuiRetryApiKeyCache.vitest.mts
+++ b/src/test-kernel/cli/TuiRetryApiKeyCache.vitest.mts
@@ -1,0 +1,153 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  apiMode: 'included' as 'included' | 'personal',
+  setCliApiMode: vi.fn(),
+}));
+
+vi.mock('@cli/runtime/apiAccessMode', async (importActual) => {
+  const actual =
+    await importActual<typeof import('@cli/runtime/apiAccessMode')>();
+  return {
+    ...actual,
+    getCliApiMode: () => mocks.apiMode,
+    setCliApiMode: mocks.setCliApiMode,
+  };
+});
+
+import { clearApprovals } from '@cli/chat/tui/state/approvalQueue';
+import { createTuiHostInteractions } from '@cli/chat/tui/state/subscribeApprovals';
+import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
+import {
+  apiKeySecretName,
+  invalidateApiKeyCache,
+  lookupApiKey,
+} from '@model/apiProviders';
+import { platform } from '@platform/platform';
+import { createTestCliContext } from '@test/cli/fixtures/cliContext';
+import { installPlatform } from '@test/support/setupPlatform';
+
+describe('TUI retry API-key cache boundary', () => {
+  beforeEach(async () => {
+    mocks.apiMode = 'included';
+    mocks.setCliApiMode.mockImplementation(async (mode) => {
+      mocks.apiMode = mode;
+    });
+    await installPlatform({
+      secrets: { [apiKeySecretName('openai')]: 'sk-old-current-key' },
+    });
+    invalidateApiKeyCache();
+  });
+
+  afterEach(() => {
+    clearApprovals();
+    invalidateApiKeyCache();
+    mocks.setCliApiMode.mockReset();
+  });
+
+  it('constructs the retry from a rotated key rather than the cached key', async () => {
+    await expect(lookupApiKey(platform().secrets, 'openai')).resolves.toBe(
+      'sk-old-current-key',
+    );
+    await platform().secrets.set(
+      apiKeySecretName('openai'),
+      'sk-rotated-current-key',
+    );
+    await expect(lookupApiKey(platform().secrets, 'openai')).resolves.toBe(
+      'sk-old-current-key',
+    );
+
+    const preparedKeys: Array<string | undefined> = [];
+    const interactions = createTuiHostInteractions(
+      {
+        emit: vi.fn(),
+        close: vi.fn(async () => undefined),
+      } as unknown as CliRuntimeHost,
+      createTestCliContext({
+        cwd: '/work',
+        mode: 'interactive',
+        approvalPolicy: 'ask',
+        version: 'test',
+        resourcesPath: '/resources',
+      }),
+    );
+    const result = interactions.requestRetry?.(
+      {
+        requestId: 'retry-rotated-key',
+        streamId: 'rotated-key',
+        operation: 'model request',
+        errorMessage: 'Relay monthly limit reached.',
+        errorDetails: {
+          message: 'Relay monthly limit reached.',
+          exhaustionReason: 'relay-limit',
+          isRelayError: true,
+          provider: 'openai',
+        },
+      },
+      {
+        prepareRetry: async () => {
+          preparedKeys.push(await lookupApiKey(platform().secrets, 'openai'));
+        },
+      },
+    );
+
+    await expect(result).resolves.toEqual({
+      action: 'retry',
+      feedback: undefined,
+    });
+    expect(preparedKeys).toEqual(['sk-rotated-current-key']);
+    expect(mocks.apiMode).toBe('personal');
+    interactions.dispose?.();
+  });
+
+  it('rejects a deleted key even when presentation cached it as present', async () => {
+    await expect(lookupApiKey(platform().secrets, 'openai')).resolves.toBe(
+      'sk-old-current-key',
+    );
+    await platform().secrets.delete(apiKeySecretName('openai'));
+
+    const prepareRetry = vi.fn(async () => undefined);
+    const interactions = createTuiHostInteractions(
+      {
+        emit: vi.fn(),
+        close: vi.fn(async () => undefined),
+      } as unknown as CliRuntimeHost,
+      createTestCliContext({
+        cwd: '/work',
+        mode: 'interactive',
+        approvalPolicy: 'ask',
+        version: 'test',
+        resourcesPath: '/resources',
+      }),
+    );
+    const result = interactions.requestRetry?.(
+      {
+        requestId: 'retry-deleted-key',
+        streamId: 'deleted-key',
+        operation: 'model request',
+        errorMessage: 'Relay monthly limit reached.',
+        errorDetails: {
+          message: 'Relay monthly limit reached.',
+          exhaustionReason: 'relay-limit',
+          isRelayError: true,
+          provider: 'openai',
+        },
+      },
+      {
+        prepareRetry,
+      },
+    );
+
+    await expect(result).resolves.toEqual({
+      action: 'deny',
+      reason:
+        'No OpenAI API key is configured. Press n to give up, then use `/key` to add one.',
+    });
+    expect(mocks.setCliApiMode).not.toHaveBeenCalled();
+    expect(prepareRetry).not.toHaveBeenCalled();
+    interactions.dispose?.();
+  });
+});

--- a/src/test-kernel/cli/TuiRetryApiKeyCache.vitest.mts
+++ b/src/test-kernel/cli/TuiRetryApiKeyCache.vitest.mts
@@ -88,7 +88,8 @@ describe('TUI retry API-key cache boundary', () => {
         },
       },
       {
-        prepareRetry: async () => {
+        prepareRetry: async (selection) => {
+          expect(selection).toBe('personal');
           preparedKeys.push(await lookupApiKey(platform().secrets, 'openai'));
         },
       },


### PR DESCRIPTION
Closes #8993. Part of #8868. Built on merged prerequisite #9030.

## Summary

The CLI now offers `k` only when the failed provider has a usable personal key. On approval it revalidates the current key, constructs an explicit personal-route client while global preferences still describe the old route, and publishes the API mode and ChatGPT preference only after construction succeeds.

Candidate failure or cancellation performs no authentication writes and does not authorize a retry. Persistence failure during the two-field preference commit rolls back what was written; an unconfirmed rollback is reported as a denial rather than retrying with uncertain state.

## Issue acceptance gates

- Hides the API-key action when no usable OpenAI key exists and shows actionable `/key` guidance.
- Revalidates the exact failed provider immediately before candidate construction.
- Builds the personal client before changing API mode or ChatGPT preference.
- Retries exactly once with the prepared client and skips the duplicate refresh.
- Fails closed on missing provider identity, construction failure, cancellation, or persistence uncertainty.
- Preserves ordinary retry, relay auto-switch, noninteractive policy, proactive refresh, and persistent-401 recovery.
- Includes key-present/key-absent integration coverage and an Ink stdin test that writes `k`.
- Adds the user-visible `0.39.8` changelog entry.

## Single source of truth

`switchRetryToPersonalCredentials()` owns the CLI transition order and preference commit/rollback. #9030's `ModelHandler.resolveClientCredential()` owns route construction, so the CLI requests `personal` or `configured` directly instead of temporarily changing settings to influence client creation.

## Duplication and abstraction budget

The old settings-first client refresh and its process-wide preparation queue were removed. Only the two persisted preference writes share a small serialized commit window. Key guidance is centralized in `missingApiKeyRetryMessage()` and the existing host retry port carries the intended route to the run-scoped client service.

## Net elements (R6)

- Diff over current `main`: 12 files, +1,475 / -163 lines, net +1,312 including the terminal, concurrency, rollback, and cache tests.
- Added three exported contracts/helpers: `HostRetryInteractionOptions`, `TuiRetryRequest`, and `missingApiKeyRetryMessage`.
- Deleted no exported contract. Added no production class, enum, facade, or process singleton.

## Consumer counts (R8)

n/a — no event emit path or existing export was deleted or rerouted.

## Host impact

Extension: shared retry/client contracts widen compatibly; no UI change.

Desktop: shared retry/client contracts widen compatibly; no UI change.

CLI: subscription and relay exhaustion now warn before switching credentials, hide impossible API-key actions, and commit preferences only after a personal client is ready.

## Scheduled refactoring

None. #9030 supplies the immutable route boundary this fix depends on.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; one unrelated existing warning)
- 83 focused route/retry/cache tests
- `CI=true` stdin and retry suites: 42 tests, including physical `k` input
- full Vitest run: 7,042 passed and 4 skipped; its sole failure was the newly introduced deep-import ratchet, which was then removed and the ratchet plus affected suites reran green
- `git diff --check`

The remaining exact-head GitHub CI and review results are the merge gate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes credential validation order, API mode and ChatGPT subscription persistence, and model client construction during manual retries—security- and quota-sensitive paths with complex concurrency and rollback behavior.
> 
> **Overview**
> **API-key retries** are reworked so switching off relay or ChatGPT subscription limits is safe and honest. The retry modal shows the `k` switch only when the **failed provider** has a usable personal key; otherwise it hides that action and points users to **`/key`** via shared copy in `missingApiKeyRetryMessage`.
> 
> On approval, **`switchRetryToPersonalCredentials`** uncached-checks the provider key, invalidates the presentation cache, calls the host **`prepareRetry('personal')`** while global API mode and subscription prefs are unchanged, then serializes persisting those prefs. Construction failure, cancellation, or unconfirmed rollback yields **`deny`** with a reason instead of a silent retry. Ordinary retries use **`prepareRetry('configured')`**; the agent skips a second refresh when the host already prepared the client.
> 
> Relay auto-switch no longer falls back to “any configured key” without a known provider. Extensive CLI, Ink, cache-boundary, and Google refresh tests cover races and rollback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67fe6889239413bf8907e9db0b2e88f4ab3cde72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->