### PR TITLE
fix(cli): omit model from bash session rows

### DIFF
--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -100,11 +100,8 @@ export function sessionHeaderIdentityLine(
       streamId: context.streamId,
       streams: context.streams,
     });
-    const childEntry = context.childStreamEntries?.get(context.streamId);
-    const toolName =
-      childEntry?.kind === 'live' ? childEntry.summary?.toolName : undefined;
     const streamKind =
-      toolName === DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME
+      view.toolName === DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME
         ? 'workflow script'
         : 'subagent';
     return `${streamKind}: ${view.label} · parent: ${view.parentLabel} · model: ${model}`;

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -151,8 +151,12 @@ function SessionRow({
   const roundLabel = formatRoundStageLabel(session.slice?.roundStage);
   // The resolved model is per-agent identity (a workflow run's grandchildren
   // can each resolve a different model); the list-root row is the conversation
-  // itself, whose model already rides the status bar.
-  const modelLabel = isListRoot ? undefined : session.slice?.model;
+  // itself, whose model already rides the status bar. A background bash stream
+  // inherits its parent's configuration, but the shell does not use a model.
+  const modelLabel =
+    !isListRoot && session.toolName !== 'bash'
+      ? session.slice?.model
+      : undefined;
   const metadata = metadataColumn
     ? childRowMetadataText({
         elapsed,

--- a/packages/cli/src/chat/tui/state/streamViews.ts
+++ b/packages/cli/src/chat/tui/state/streamViews.ts
@@ -19,6 +19,8 @@ import type { StreamSlice } from './cliState';
 export interface StreamView {
   readonly id: StreamTabId;
   readonly label: string;
+  /** Canonical spawning tool retained with the child execution. */
+  readonly toolName?: string;
   readonly parentId?: StreamTabId;
   readonly parentLabel?: string;
   readonly slice: StreamSlice | undefined;
@@ -136,9 +138,12 @@ export function streamViewForId(init: {
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
 }): StreamView {
   const parentId = init.parentStream.get(init.streamId);
+  const childEntry = init.childStreamEntries.get(init.streamId);
   return {
     id: init.streamId,
     label: streamDisplayLabel(init),
+    toolName:
+      childEntry?.kind === 'live' ? childEntry.summary?.toolName : undefined,
     parentId,
     parentLabel: parentId
       ? streamDisplayLabel({

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -12,13 +12,17 @@ import {
 } from '@cli/chat/tui/panes/SubagentList';
 import type { StreamSlice } from '@cli/chat/tui/state/cliState';
 import {
+  streamTreeViews,
+  type StreamView,
+} from '@cli/chat/tui/state/streamViews';
+import {
   nextSelectHighlightIndex,
   selectControlledHighlightIndex,
   visibleSelectRange,
   type SelectItem,
 } from '@cli/chat/tui/ui/Select';
-import type { StreamView } from '@cli/chat/tui/state/streamViews';
 import { AgentCategory, STREAM_PHASE, type StreamTabId } from '@shared/schemas';
+import { buildChildStreamEntries } from '@test/support/childStreamEntries';
 import { loadInk } from '@test/support/inkTestHarness.mts';
 
 function session(id: string, active = false): StreamView {
@@ -230,43 +234,82 @@ describe('CLI child list display model', () => {
     ).toBe('45s');
   });
 
-  it('surfaces per-agent model, tool calls, and tokens for a focused run', async () => {
+  it('omits the model from bash rows while retaining agent row details', async () => {
     const { ink, React } = await loadInk();
     const run = 'run' as StreamTabId;
+    const bash = 'bash-1' as StreamTabId;
     const agent = 'agent-1' as StreamTabId;
+    const streams = new Map<StreamTabId, StreamSlice>([
+      [run, workflowAgentSlice('run', { status: STREAM_PHASE.RUNNING })],
+      [
+        bash,
+        workflowAgentSlice('bash-1', {
+          model: 'gemini35f',
+          status: STREAM_PHASE.RUNNING,
+        }),
+      ],
+      [
+        agent,
+        workflowAgentSlice('agent-1', {
+          model: 'gpt56',
+          status: STREAM_PHASE.RUNNING,
+          conversation: { toolCallCount: 5 },
+          cumulativeUsage: {
+            inputTokens: 1000,
+            outputTokens: 39_900,
+            cost: 0,
+          },
+        }),
+      ],
+    ]);
+    const parentStream = new Map<StreamTabId, StreamTabId>([
+      [bash, run],
+      [agent, run],
+    ]);
+    const childStreamEntries = buildChildStreamEntries({
+      parentStreamId: run,
+      retained: [
+        {
+          kind: 'subagent',
+          executionId: 'bash-exec',
+          agentName: 'bash',
+          childStreamId: bash,
+          status: STREAM_PHASE.RUNNING,
+          toolName: 'bash',
+        },
+        {
+          kind: 'subagent',
+          executionId: 'agent-exec',
+          // A real agent may use the same visible label. Its canonical
+          // spawning tool, rather than that label, determines model display.
+          agentName: 'bash',
+          childStreamId: agent,
+          status: STREAM_PHASE.RUNNING,
+        },
+      ],
+    });
+    const sessions = streamTreeViews({
+      activeStreamId: run,
+      childStreamEntries,
+      parentStream,
+      rootStreamId: run,
+      streams,
+    });
     const output: string = ink.renderToString(
       React.createElement(SubagentList, {
         listRootStreamId: run,
         maxRows: 6,
         keyboardActive: false,
-        sessions: [
-          {
-            id: run,
-            label: 'workflow-run',
-            slice: workflowAgentSlice('run', { status: STREAM_PHASE.RUNNING }),
-            active: true,
-          },
-          {
-            id: agent,
-            label: 'coder',
-            slice: workflowAgentSlice('agent-1', {
-              model: 'claude-sonnet-4',
-              conversation: { toolCallCount: 5 },
-              cumulativeUsage: {
-                inputTokens: 1000,
-                outputTokens: 39_900,
-                cost: 0,
-              },
-            }),
-            active: false,
-          },
-        ],
+        sessions,
       }),
       { columns: 100 },
     );
 
-    expect(output).toContain('coder');
-    expect(output).toContain('claude-sonnet-4');
+    expect(sessions.find(({ id }) => id === bash)?.toolName).toBe('bash');
+    expect(sessions.find(({ id }) => id === agent)?.toolName).toBeUndefined();
+    expect(output.match(/bash running/g)).toHaveLength(2);
+    expect(output).not.toContain('gemini35f');
+    expect(output).toContain('bash running · gpt56');
     expect(output).toContain('5 tool calls');
     expect(output).toContain('↓40k');
   });


### PR DESCRIPTION
## Summary

- Carry the retained child stream's canonical spawning tool into the existing stream-view projection.
- Omit inherited model metadata only when the stream was actually spawned by the `bash` tool.
- Reuse that same canonical projection for transcript identity, deleting its duplicate child-roster lookup.

This deliberately does not infer identity from the visible label: a real agent named `bash` still displays its model. No wire or persisted format changes.

## Net line accounting

- Production: +12 / -6 = **+6**
- Tests: +69 / -26 = **+43**
- Total: +81 / -32 = **+49**

## Verification

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; one unrelated existing warning)
- `npm run check:dead-code-ratchet`
- focused Vitest: 69/69
- physical `subagents` PTY scenario
- `git diff --check`

No changelog entry was added: the released 0.39.7 section is unchanged, and there is no existing unreleased terminal-identity entry to amend.

Part of #8868.
Closes #9001.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI display-only changes in the TUI subagent list and transcript header; no wire format or persistence.
> 
> **Overview**
> **Stream views** now expose the retained child execution’s canonical **spawning tool** (`toolName`) on `StreamView`, so list and header logic share one projection instead of re-reading the child roster.
> 
> **Subagent list** rows skip the inherited **model** suffix only when that tool is `bash` (background shells don’t use a model). Agents that merely share the visible label `bash` still show their model.
> 
> **Transcript session header** reuses `streamViewForId` for workflow-script vs subagent wording, removing a duplicate `childStreamEntries` lookup.
> 
> Tests build real `streamTreeViews` fixtures to lock in bash vs agent behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 329df460b86dd2b5a4f87c1bac73c345251a66ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->