### PR TITLE
fix(settings): keep Kimi K3 catalogue placement stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.39.8] - Unreleased
+
+### Extension (VS Code)
+
+#### Bug Fixes
+
+- **Kimi K3 stays easy to find when its route changes** — the model remains
+  under Moonshot while showing whether requests use Moonshot, Kimi Code, or
+  OpenRouter.
+
 ## [0.39.7] - 2026-07-20
 
 ### Shared (all surfaces)

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.styles.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.styles.ts
@@ -195,6 +195,11 @@ export const modelSelectionListStyles: CSSResult = css`
     margin-left: auto;
   }
 
+  .model-route {
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-xs);
+  }
+
   .reasoning-level-select {
     flex-shrink: 0;
     width: 120px;

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -229,6 +229,11 @@ export class ModelSelectionList extends LitElement {
         >
           <span class="model-name">${model.label}</span>
           <span class="model-shortname">(${model.name})</span>
+          ${
+            model.routeLabel
+              ? html`<span class="model-route">· ${model.routeLabel}</span>`
+              : nothing
+          }
           ${this.renderAvailabilityIcon(model)}
           ${
             isExpensiveModel(model.provider, model.name)

--- a/src/controllers/settingsView/SettingsModelSelectionController.ts
+++ b/src/controllers/settingsView/SettingsModelSelectionController.ts
@@ -187,7 +187,10 @@ export class SettingsModelSelectionController {
       const item: ModelSelectionItem = {
         name,
         label: option.label,
-        provider: option.provider ?? config.provider,
+        // Catalogue placement is a stable registry fact. `option.provider`
+        // describes the effective request route and may change with credentials.
+        provider: resolveModelSource(config) ?? config.provider,
+        routeLabel: option.routeLabel,
         enabled: enabledSet.has(name),
         deprecated: config.deprecated ?? false,
         contextWindow: option.context,

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -471,8 +471,21 @@ async function buildModelOptionData(
         outputPrice: availability.providerCapabilities.outputPrice,
       }
     : config;
+  let routeLabel: string | undefined;
+  if (
+    isKimiSubscriptionEligible(rawConfig) &&
+    !isKimiCodeExclusiveModel(rawConfig)
+  ) {
+    if (shouldRouteModelThroughOpenRouter(config, ctx.useOpenRouter)) {
+      routeLabel = 'Via OpenRouter';
+    } else {
+      const source = resolveModelSource(config) ?? config.provider;
+      routeLabel = `Via ${PROVIDER_DISPLAY_NAMES[source] ?? source}`;
+    }
+  }
   return {
     ...buildBaseModelOption(model, optionConfig, config),
+    ...(routeLabel ? { routeLabel } : {}),
     availability: availability.kind,
     availabilityLabel: availability.label,
     requiresKey: availability.requiresKey,

--- a/src/shared/schemas/mainView/state.ts
+++ b/src/shared/schemas/mainView/state.ts
@@ -63,13 +63,16 @@ const ModelAvailabilityKindSchema = z.enum([
 export type ModelAvailabilityKind = z.infer<typeof ModelAvailabilityKindSchema>;
 
 /**
- * Resolved per-model availability under the active API mode. Computed once by
+ * Resolved per-model access under the active API mode. Computed once by
  * `computeModelOptionsData` and shared verbatim across hosts (CLI picker,
- * extension Models tab) so availability is never re-derived at render time.
+ * extension Models tab) so availability and routing are never re-derived at
+ * render time.
  */
 export const ModelAvailabilityFieldsSchema = z.object({
   availability: ModelAvailabilityKindSchema.optional(),
   availabilityLabel: z.string().optional(),
+  /** Effective request route for a model that can use multiple backends. */
+  routeLabel: z.string().optional(),
   requiresKey: z.boolean().optional(),
   disabled: z.boolean().optional(),
 });

--- a/src/test-kernel/controllers/SettingsModelSelectionController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsModelSelectionController.vitest.ts
@@ -113,6 +113,32 @@ describe('SettingsModelSelectionController', () => {
     });
   });
 
+  it('keeps Kimi K3 under Moonshot while preserving its effective route', async () => {
+    const controller = new SettingsModelSelectionController({
+      state: createState(),
+      resolveModelOptions: async (models) =>
+        (await resolveModelOptions(models)).map((option) =>
+          option.value === 'kimi3'
+            ? {
+                ...option,
+                provider: 'kimiCode',
+                routeLabel: 'Via Kimi Code',
+              }
+            : option,
+        ),
+      getRuntimeModelEntries: NO_RUNTIME_MODELS,
+    });
+
+    expect(
+      (await controller.buildSelectionData()).models.find(
+        (model) => model.name === 'kimi3',
+      ),
+    ).toMatchObject({
+      provider: 'moonshot',
+      routeLabel: 'Via Kimi Code',
+    });
+  });
+
   it('moves a stale helper fallback when disabling the effective helper model', async () => {
     const state = createState({
       enabledModels: ['gpt55', 'sonnet46T'],

--- a/src/test-kernel/model/ComputeModelOptions.vitest.ts
+++ b/src/test-kernel/model/ComputeModelOptions.vitest.ts
@@ -518,6 +518,7 @@ describe('computeModelOptionsData Kimi Code routing (dual-backend kimi3)', () =>
     );
     expect(model).toMatchObject({
       provider: 'moonshot',
+      routeLabel: 'Via Moonshot',
       availability: 'provider-key',
       disabled: false,
     });
@@ -533,6 +534,7 @@ describe('computeModelOptionsData Kimi Code routing (dual-backend kimi3)', () =>
     // the conservative tier context cap, not the open platform's 1M / paid rate.
     expect(model).toMatchObject({
       provider: 'kimiCode',
+      routeLabel: 'Via Kimi Code',
       availability: 'provider-key',
       disabled: false,
       cost: '$0.000/$0.000',
@@ -547,7 +549,30 @@ describe('computeModelOptionsData Kimi Code routing (dual-backend kimi3)', () =>
     );
     expect(model).toMatchObject({
       provider: 'moonshot',
+      routeLabel: 'Via Moonshot',
       availability: 'provider-key',
+      disabled: false,
+    });
+  });
+
+  it('reports OpenRouter without changing the Kimi K3 registry identity', async () => {
+    const access = {
+      ...createModelOptionsAccess(
+        {
+          useIncludedAccess: false,
+          relayQuotaExceeded: false,
+          quotaAutoSwitched: false,
+        },
+        { [apiKeySecretName('openRouter')]: 'sk-openrouter' },
+      ),
+      useOpenRouter: true,
+    };
+    const [model] = await computeModelOptionsData(['kimi3'], access);
+
+    expect(model).toMatchObject({
+      provider: 'moonshot',
+      routeLabel: 'Via OpenRouter',
+      availability: 'openrouter-key',
       disabled: false,
     });
   });

--- a/src/test-kernel/settings/ModelSelectionProviderKeys.vitest.ts
+++ b/src/test-kernel/settings/ModelSelectionProviderKeys.vitest.ts
@@ -119,4 +119,30 @@ describe('ModelSelectionList provider key status', () => {
       ],
     ]);
   });
+
+  it('shows an effective route without changing the provider group', async () => {
+    const list = await renderModelSelectionList((el) => {
+      el.models = [
+        {
+          ...deepseekModel,
+          name: 'kimi3',
+          label: 'Kimi K3',
+          provider: 'moonshot',
+          routeLabel: 'Via Kimi Code',
+        },
+      ];
+    });
+
+    list
+      .shadowRoot!.querySelector<HTMLElement>('.provider-group-toggle')
+      ?.click();
+    await list.updateComplete;
+
+    expect(
+      list.shadowRoot!.querySelector('.provider-group-name')?.textContent,
+    ).toContain('Moonshot');
+    expect(
+      list.shadowRoot!.querySelector('.model-route')?.textContent,
+    ).toContain('Via Kimi Code');
+  });
 });


### PR DESCRIPTION
Closes #9012

## Summary

- keeps Kimi K3 in its stable Moonshot catalogue section when the selected request route changes
- shows the effective route as secondary text for Kimi models that can use more than one backend
- preserves model keys, enabled state, provider routing, and wire identifiers

## Verification

- focused Vitest suites: 57 tests passed
- npm run typecheck
- npm run compile:fast
- npm run lint (one pre-existing warning outside this change)
- npm run check:dead-code-ratchet
- targeted Prettier check
- independent adversarial review

## Size

119 lines added, 3 removed; net +116 lines, chiefly tests. No changelog entry is required beyond the user-visible bug fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and model-option metadata only; routing logic is unchanged aside from display labels and stable provider grouping.
> 
> **Overview**
> **Kimi K3 stays under Moonshot in Settings** even when requests are routed through Kimi Code, OpenRouter, or Moonshot. Catalogue grouping now uses the stable registry source (`resolveModelSource`) instead of the effective-route `provider` from `computeModelOptionsData`.
> 
> **Effective route is shown as secondary text** — `computeModelOptionsData` adds an optional `routeLabel` (e.g. `Via Kimi Code`, `Via OpenRouter`) for Kimi subscription–eligible, non–Kimi-Code-exclusive models, and the VS Code Models list renders it after the model name. Shared `ModelOptionData` / availability schema documents the field so CLI and extension share one computed snapshot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be21069798aa1345745c1f5c87b9d3fa779801dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->