### PR TITLE
fix(cli): distinguish model-request and tool failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ All notable changes to this project will be documented in this file.
   under Moonshot while showing whether requests use Moonshot, Kimi Code, or
   OpenRouter.
 
+### CLI
+
+#### Bug Fixes
+
+- **Model failures show their reason** — failed model requests now include a
+  concise provider message and are no longer labeled as tool failures.
+
 ## [0.39.7] - 2026-07-20
 
 ### Shared (all surfaces)

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -892,7 +892,7 @@ function makeRetryApprovalPayload(): RetryPermission {
   if (RETRY_APPROVAL_CHATGPT) {
     return {
       streamId: STREAM_ID,
-      operation: 'Tool-use call',
+      operation: 'Model request',
       errorMessage: 'ChatGPT subscription usage limit reached. Resets in 2h.',
       errorDetails: {
         exhaustionReason: 'chatgpt-subscription',
@@ -903,7 +903,7 @@ function makeRetryApprovalPayload(): RetryPermission {
   }
   return {
     streamId: STREAM_ID,
-    operation: 'Tool-use call',
+    operation: 'Model request',
     errorMessage: 'HTTP 429 Too Many Requests',
     errorDetails: {
       exhaustionReason: 'relay-limit',

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -7,7 +7,9 @@ import { isDeepStrictEqual } from 'node:util';
 
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { appendCliApiSwitchHint } from '@cli/runtime/approvalAdapter';
+import { redactSecrets } from '@logger/redaction';
 import {
+  ErrorLogDataSchema,
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
   TOOL_USE_STATUS,
@@ -23,11 +25,13 @@ import {
 } from '@shared/subagentFollowup';
 import { flushPendingRunTraces } from '@transcript';
 import { createFlushableDebounce } from '@utils/core';
+import { truncateSummary } from '@utils/text/stringUtils';
 import { normalizeKnownHtmlForCliMarkdown } from '../render/htmlMarkdownNormalize';
 import {
   isRenderableTranscriptEntry,
   trimAssistantTranscriptLead,
 } from '../panes/transcriptEntries';
+import { TOOL_OUTPUT_CORNER } from '../ui/glyphs';
 import {
   activeStreamId,
   getCliStateGeneration,
@@ -37,6 +41,9 @@ import {
 } from './cliState';
 import { isChildStreamRemoved } from './childExecutions';
 import { isFinalTranscriptStatus } from './transcript';
+import { safeTerminalText } from './transcriptLines';
+
+const MAX_ERROR_DETAIL_LENGTH = 240;
 
 const TRANSCRIPT_MESSAGE_TYPES = new Set<string>([
   MESSAGE_TYPES.ERROR,
@@ -212,14 +219,27 @@ function logEntryRole(
 function renderLogEntryText(
   role: 'assistant' | 'error' | 'user',
   text: string,
+  data: unknown,
 ): string {
   switch (role) {
     case 'assistant':
       return normalizeKnownHtmlForCliMarkdown(
         trimAssistantTranscriptLead(text),
       );
-    case 'error':
-      return appendCliApiSwitchHint(text);
+    case 'error': {
+      const safeSummary = redactSecrets(safeTerminalText(text));
+      const parsed = ErrorLogDataSchema.safeParse(data);
+      if (!parsed.success) return appendCliApiSwitchHint(safeSummary);
+
+      const detail = truncateSummary(
+        redactSecrets(safeTerminalText(parsed.data.message)),
+        MAX_ERROR_DETAIL_LENGTH,
+      );
+      const withDetail = detail
+        ? `${safeSummary}\n${TOOL_OUTPUT_CORNER} ${detail}`
+        : safeSummary;
+      return appendCliApiSwitchHint(withDetail, parsed.data.exhaustionReason);
+    }
     case 'user':
       return summarizeFollowupMessage(text);
   }
@@ -297,7 +317,7 @@ function renderLogEntry(
   const role = logEntryRole(entry.messageType);
   const assistantTranscript =
     role === 'assistant' ? trimAssistantTranscriptLead(text) : undefined;
-  const renderedText = renderLogEntryText(role, text);
+  const renderedText = renderLogEntryText(role, text, entry.data);
   // Assistant text is promoted by `finalizeSettledPrefix` once the model
   // moves on to a later entry; inherit the prior flag here so a re-sync
   // can't de-finalize an already-promoted block. User/error rows can't

--- a/packages/cli/src/chat/tui/state/transcriptLines.ts
+++ b/packages/cli/src/chat/tui/state/transcriptLines.ts
@@ -148,7 +148,8 @@ const UNSAFE_TERMINAL_CONTROLS =
   // eslint-disable-next-line no-control-regex -- terminal output must exclude C0/C1 controls
   /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]/g;
 
-function safeTerminalText(text: string): string {
+/** Remove terminal control sequences while preserving printable text and line breaks. */
+export function safeTerminalText(text: string): string {
   return stripAnsi(text)
     .replaceAll('\r\n', '\n')
     .replaceAll('\r', '\n')

--- a/packages/cli/src/runtime/approval/approvalPolicy.ts
+++ b/packages/cli/src/runtime/approval/approvalPolicy.ts
@@ -3,6 +3,7 @@ import { isRelayMonthlyLimitMessage } from '@common/errors/sdkErrorUtils';
 import {
   isChatGptSubscriptionLimitError,
   isCredentialExhausted,
+  type ExhaustionReason,
   type ApprovalDecision as SharedApprovalDecision,
 } from '@shared/schemas';
 
@@ -64,8 +65,13 @@ export function isCliApiSwitchableRetry(
   );
 }
 
-export function appendCliApiSwitchHint(text: string): string {
-  if (!isRelayMonthlyLimitMessage(text)) return text;
+export function appendCliApiSwitchHint(
+  text: string,
+  exhaustionReason?: ExhaustionReason,
+): string {
+  if (exhaustionReason !== 'relay-limit' && !isRelayMonthlyLimitMessage(text)) {
+    return text;
+  }
   if (text.includes('/api personal')) return text;
   return [text, CLI_PERSONAL_API_RETRY_HINT].join('\n');
 }

--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -30,7 +30,10 @@ export const BaseCycleFieldsSchema = z.object({
   lastError: RetryErrorInfoSchema.optional(),
 });
 
-export type BaseCycleFields = z.infer<typeof BaseCycleFieldsSchema>;
+/** Runtime cycle fields, including non-persisted failure-log bookkeeping. */
+export type BaseCycleFields = z.infer<typeof BaseCycleFieldsSchema> & {
+  failureLogEmitted?: boolean;
+};
 
 /** Result type for nodes that can be skipped based on flow state. */
 export type SkippableNodeResult<T> =
@@ -46,6 +49,7 @@ export function resetCycleState<T extends BaseCycleFields>(
   state.responseTimeMs = undefined;
   state.stopReason = undefined;
   state.lastError = undefined;
+  state.failureLogEmitted = undefined;
 
   for (const field of additionalFields) {
     state[field] = undefined as T[typeof field];

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -78,6 +78,8 @@ type CycleFields = z.infer<typeof CycleFieldsSchema>;
  * stored in shared state.
  */
 interface CycleTransientFields {
+  /** Whether RetryState already emitted the canonical structured failure. */
+  failureLogEmitted?: boolean;
   /** System prompt for model (regenerated from agent prompt each cycle) */
   systemPrompt?: string;
   /** Raw response from model (type unknown, not serialized) */

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -50,7 +50,7 @@ interface ManualRetryPromptResult {
 /** success: model response | failed: retries exhausted | cancelled: user cancelled | skipped: shouldStop was true */
 export type InvocationResult<TSuccess> =
   | ({ kind: 'success' } & TSuccess)
-  | ({ kind: 'failed' } & RetryErrorInfo)
+  | ({ kind: 'failed'; failureLogEmitted: boolean } & RetryErrorInfo)
   | { kind: 'cancelled' }
   | { kind: 'skipped' };
 
@@ -93,6 +93,7 @@ export abstract class RetryableInvocationNode<
   protected _userCancelled = false;
   protected _hasAttemptedTokenRefresh = false;
   protected _persistent401Error: Error | null = null;
+  protected _failureLogEmitted = false;
 
   constructor() {
     const config = getNodeRetryConfig();
@@ -106,6 +107,7 @@ export abstract class RetryableInvocationNode<
     cloned._userCancelled = false;
     cloned._hasAttemptedTokenRefresh = false;
     cloned._persistent401Error = null;
+    cloned._failureLogEmitted = false;
     return cloned;
   }
 
@@ -228,6 +230,7 @@ export abstract class RetryableInvocationNode<
   }
 
   async _exec(prepRes: unknown): Promise<unknown> {
+    this._failureLogEmitted = false;
     const config = getNodeRetryConfig();
     let maxRetries = config.maxRetries;
 
@@ -248,6 +251,7 @@ export abstract class RetryableInvocationNode<
     }
 
     if (result.shouldRetry) {
+      this._failureLogEmitted = false;
       this._persistent401Error = null;
       this._hasAttemptedTokenRefresh = false;
       // Always refresh the client on manual retry. The user may have
@@ -281,6 +285,7 @@ export abstract class RetryableInvocationNode<
     }
 
     logErrorData(logger, `${operationName} failed`, formatted);
+    this._failureLogEmitted = true;
 
     streamStatus.transition(streamId, STREAM_PHASE.WAITING, 'wait', {
       trace: logger,
@@ -341,7 +346,9 @@ export abstract class RetryableInvocationNode<
 
   protected getFallbackResult(
     error: Error,
-  ): { kind: 'cancelled' } | ({ kind: 'failed' } & RetryErrorInfo) {
+  ):
+    | { kind: 'cancelled' }
+    | ({ kind: 'failed'; failureLogEmitted: boolean } & RetryErrorInfo) {
     if (this._userCancelled || isUserAbort(error)) {
       return { kind: 'cancelled' };
     }
@@ -353,9 +360,11 @@ export abstract class RetryableInvocationNode<
         `${this.getOperationName()} failed (no retry available)`,
         formatted,
       );
+      this._failureLogEmitted = true;
     }
     return {
       kind: 'failed',
+      failureLogEmitted: this._failureLogEmitted,
       ...toRetryErrorInfo(formatted),
     };
   }
@@ -372,7 +381,12 @@ interface InvocationResultHandlerOptions {
 /** Returns narrowed success result or null (flow stopped). Records error for failures. */
 export function handleInvocationResult<T extends { response: unknown }>(
   result: InvocationResult<T>,
-  state: { shouldStop: boolean; endTurn: boolean; lastError?: RetryErrorInfo },
+  state: {
+    shouldStop: boolean;
+    endTurn: boolean;
+    lastError?: RetryErrorInfo;
+    failureLogEmitted?: boolean;
+  },
   options: InvocationResultHandlerOptions,
 ): (T & { kind: 'success' }) | null {
   const { logger, operationName } = options;
@@ -382,8 +396,12 @@ export function handleInvocationResult<T extends { response: unknown }>(
     return null;
   }
 
-  function stop(lastError: RetryErrorInfo | undefined): null {
+  function stop(
+    lastError: RetryErrorInfo | undefined,
+    failureLogEmitted = false,
+  ): null {
     state.lastError = lastError;
+    state.failureLogEmitted = failureLogEmitted;
     state.shouldStop = true;
     state.endTurn = false;
     return null;
@@ -394,8 +412,8 @@ export function handleInvocationResult<T extends { response: unknown }>(
   }
 
   if (result.kind === 'failed') {
-    const { kind: _, ...errorInfo } = result;
-    return stop(errorInfo);
+    const { kind: _, failureLogEmitted, ...errorInfo } = result;
+    return stop(errorInfo, failureLogEmitted);
   }
 
   if (!result.response) {
@@ -407,5 +425,6 @@ export function handleInvocationResult<T extends { response: unknown }>(
   }
 
   state.lastError = undefined;
+  state.failureLogEmitted = undefined;
   return result;
 }

--- a/src/agent/core/flows/ToolUseRoundFlow.ts
+++ b/src/agent/core/flows/ToolUseRoundFlow.ts
@@ -51,7 +51,7 @@ export function createToolUseRoundFlow<C>(): Flow<
     ToolUseRoundShared,
     ToolUseRoundServices<C>
   >({
-    operationName: 'Tool-use call',
+    operationName: 'Model request',
     streaming: true,
     // Only resupply for providers that need it per-call (Anthropic, Google).
     // Providers that embed the system prompt into `messages` at session init

--- a/src/agent/core/flows/toolUseRound/roundShared.ts
+++ b/src/agent/core/flows/toolUseRound/roundShared.ts
@@ -77,6 +77,8 @@ type ToolUseRoundFields = z.infer<typeof ToolUseRoundFieldsSchema>;
  * - Immutable services: `this.services` (ToolUseRoundServices)
  */
 export interface ToolUseRoundShared extends ToolUseRoundFields {
+  /** Whether RetryState already emitted the canonical structured failure. */
+  failureLogEmitted?: boolean;
   /** Tool calls with proper typing (schema uses z.unknown()) */
   toolCalls?: SdkToolCall[];
   /** Current user instruction, refreshed when the round consumes user input. */

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
@@ -38,6 +38,7 @@ type CycleOutcome =
       error: Error;
       userRetryable: boolean;
       lastError?: RetryErrorInfo;
+      failureLogEmitted: boolean;
     };
 
 export class ResponseCycleNode<C = unknown> extends Node<
@@ -122,6 +123,7 @@ export class ResponseCycleNode<C = unknown> extends Node<
           error: new Error(cycleShared.lastError.message),
           userRetryable: cycleShared.lastError.userRetryable,
           lastError: cycleShared.lastError,
+          failureLogEmitted: cycleShared.failureLogEmitted ?? false,
         };
       }
       // A round is `cancelled` only when the run was genuinely interrupted —
@@ -146,6 +148,7 @@ export class ResponseCycleNode<C = unknown> extends Node<
       return {
         outcome: 'failed',
         error: ensureError(error),
+        failureLogEmitted: false,
         ...buildFailedRetryInfo(error),
       };
     }
@@ -155,7 +158,12 @@ export class ResponseCycleNode<C = unknown> extends Node<
     _prepRes: CyclePrepInput,
     error: Error,
   ): Promise<CycleOutcome> {
-    return { outcome: 'failed', error, ...buildFailedRetryInfo(error) };
+    return {
+      outcome: 'failed',
+      error,
+      failureLogEmitted: false,
+      ...buildFailedRetryInfo(error),
+    };
   }
 
   async post(
@@ -168,7 +176,9 @@ export class ResponseCycleNode<C = unknown> extends Node<
     shared.outputLocation = prepRes.outputLocation;
 
     if (execRes.outcome === 'failed') {
-      logger.error(`Response cycle failed: ${execRes.error.message}`);
+      if (!execRes.failureLogEmitted) {
+        logger.error(`Response cycle failed: ${execRes.error.message}`);
+      }
       shared.lastError = execRes.lastError ?? {
         message: execRes.error.message,
         userRetryable: execRes.userRetryable,

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -34,6 +34,7 @@ type ToolUseCycleOutcome =
       message: string;
       userRetryable: boolean;
       lastError?: RetryErrorInfo;
+      failureLogEmitted: boolean;
     };
 
 export class ToolUseCycleNode<C> extends Node<
@@ -159,6 +160,7 @@ export class ToolUseCycleNode<C> extends Node<
           message: lastError.message,
           userRetryable: lastError.userRetryable,
           lastError,
+          failureLogEmitted: roundShared.failureLogEmitted ?? false,
         };
       }
       if (roundOutcome === RUN_OUTCOME.CANCELLED) {
@@ -185,6 +187,7 @@ export class ToolUseCycleNode<C> extends Node<
     return {
       outcome: 'failed',
       message: error.message,
+      failureLogEmitted: false,
       ...buildFailedRetryInfo(error),
     };
   }
@@ -237,13 +240,14 @@ export class ToolUseCycleNode<C> extends Node<
           message: execRes.message,
           userRetryable: execRes.userRetryable,
         };
-        // Surface the failure in the transcript. Without this the WaitNode
-        // resets lastError when the user sends a follow-up (see
-        // ToolUseWaitNode.post), so a recurring failure (e.g. missing API
-        // key) leaves the agent stuck in "idle" with no visible reason.
-        this.services.logger.error(execRes.message, {
-          messageType: MESSAGE_TYPES.ERROR,
-        });
+        if (!execRes.failureLogEmitted) {
+          // Outer cycle failures have not passed through RetryState's
+          // structured error logger. Surface them before WaitNode resets
+          // lastError on a follow-up.
+          this.services.logger.error(execRes.message, {
+            messageType: MESSAGE_TYPES.ERROR,
+          });
+        }
         break;
       case 'cancelled':
         shared.userCancelledRetry = true;

--- a/src/common/errors/sdkError/providerErrorFormat.ts
+++ b/src/common/errors/sdkError/providerErrorFormat.ts
@@ -1,3 +1,6 @@
+import stableStringify from 'fast-json-stable-stringify';
+
+import { safeParseJson } from '@common/parsing/safeParseJson';
 import {
   type ErrorContext,
   type ErrorLogData,
@@ -26,6 +29,7 @@ import {
   detectStatusCode,
   detectStatusText,
   getErrorClassNames,
+  pickStringField,
   safeGetReasonPhrase,
 } from './errorInspection';
 import {
@@ -59,13 +63,67 @@ function describeHttpError(
   err: unknown,
   statusCode: number | undefined,
   extractedMessage: string | undefined,
+  rawErrorBody: unknown,
 ): { statusText: string | undefined; message: string } {
   const statusText = detectStatusText(err, statusCode);
   const fallbackMessage = statusCode
     ? safeGetReasonPhrase(statusCode)
     : undefined;
+  const bodyMessage =
+    pickStringField(rawErrorBody, 'message') ??
+    pickStringField(
+      typeof rawErrorBody === 'object' && rawErrorBody !== null
+        ? (rawErrorBody as { error?: unknown }).error
+        : undefined,
+      'message',
+    );
+  // Some SDKs stringify the complete response body into Error.message when
+  // the body has no scalar message. Keep that body on rawErrorBody for
+  // diagnostics, but do not promote its serialization to user-facing text.
+  let wrapperMessageContainsRawBody = false;
+  if (extractedMessage !== undefined && rawErrorBody !== undefined) {
+    if (typeof rawErrorBody === 'string') {
+      wrapperMessageContainsRawBody =
+        extractedMessage === rawErrorBody ||
+        extractedMessage.includes(JSON.stringify(rawErrorBody));
+    }
+
+    if (typeof rawErrorBody === 'object' && rawErrorBody !== null) {
+      try {
+        const serializedRawBody = JSON.stringify(rawErrorBody);
+        wrapperMessageContainsRawBody =
+          serializedRawBody.length > 2 &&
+          extractedMessage.includes(serializedRawBody);
+      } catch {
+        // Non-serializable diagnostic bodies cannot have been JSON-stringified
+        // into the SDK wrapper message by the path guarded here.
+      }
+
+      if (!wrapperMessageContainsRawBody) {
+        const opening = Array.isArray(rawErrorBody) ? '[' : '{';
+        const closing = Array.isArray(rawErrorBody) ? ']' : '}';
+        const start = extractedMessage.indexOf(opening);
+        const end = extractedMessage.lastIndexOf(closing);
+        if (start >= 0 && end > start) {
+          const embeddedBody = safeParseJson(
+            extractedMessage.slice(start, end + 1),
+          ).unwrapOr(undefined);
+          try {
+            wrapperMessageContainsRawBody =
+              stableStringify(embeddedBody) === stableStringify(rawErrorBody);
+          } catch {
+            // Circular or otherwise non-JSON diagnostics cannot match a JSON
+            // fragment parsed from the wrapper message.
+          }
+        }
+      }
+    }
+  }
   const finalMessage =
-    extractedMessage ?? fallbackMessage ?? 'Provider request failed';
+    (wrapperMessageContainsRawBody ? undefined : extractedMessage) ??
+    bodyMessage ??
+    fallbackMessage ??
+    'Provider request failed';
   const message = statusCode
     ? `HTTP ${statusCode}${statusText ? ` ${statusText}` : ''} – ${finalMessage}`
     : finalMessage;
@@ -121,6 +179,7 @@ function matchSdkError(
     err,
     statusCode,
     extractErrorMessage(err),
+    rawErrorBody,
   );
 
   if (!statusCode) {
@@ -282,6 +341,7 @@ export function formatProviderHttpError(err: unknown): ProviderError {
     err,
     statusCode,
     extractedMessage,
+    rawErrorBody,
   );
   // No status code on an unrecognized error likely means a network-level failure
   // (DNS, proxy, TLS, etc.) — show retry button for safety.

--- a/src/test-kernel/agent/ResponseCycleCancellation.vitest.ts
+++ b/src/test-kernel/agent/ResponseCycleCancellation.vitest.ts
@@ -1,9 +1,15 @@
 // Third-party imports
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Scripted state the mocked ResponseCycleFlow writes back onto the cycle shared
 // object, so each test controls the post-run `shouldStop` / `endTurn` flags.
-const flowState = vi.hoisted(() => ({ shouldStop: false, endTurn: false }));
+const flowState = vi.hoisted(() => ({
+  shouldStop: false,
+  endTurn: false,
+  lastError: undefined as
+    { message: string; userRetryable: boolean } | undefined,
+  failureLogEmitted: false,
+}));
 
 // Replace the inner cycle flow with a stub that just applies the scripted flags.
 // This isolates ResponseCycleNode's outcome *classification* from the full
@@ -11,9 +17,16 @@ const flowState = vi.hoisted(() => ({ shouldStop: false, endTurn: false }));
 vi.mock('@agent/core/flows/ResponseCycleFlow', () => ({
   createResponseCycleFlow: () => ({
     setServices() {},
-    async run(shared: { shouldStop: boolean; endTurn: boolean }) {
+    async run(shared: {
+      shouldStop: boolean;
+      endTurn: boolean;
+      lastError?: { message: string; userRetryable: boolean };
+      failureLogEmitted?: boolean;
+    }) {
       shared.shouldStop = flowState.shouldStop;
       shared.endTurn = flowState.endTurn;
+      shared.lastError = flowState.lastError;
+      shared.failureLogEmitted = flowState.failureLogEmitted;
     },
   }),
 }));
@@ -60,7 +73,16 @@ function reflectionShared(): ReflectionFlowShared {
   };
 }
 
-function makeNode(checkInterruption: () => boolean): ResponseCycleNode {
+function makeNode(
+  checkInterruption: () => boolean,
+  logger: {
+    error: ReturnType<typeof vi.fn>;
+    debug: ReturnType<typeof vi.fn>;
+  } = {
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+): ResponseCycleNode {
   return new ResponseCycleNode().setServices({
     getOutputFileLocation: async () => outputLocation,
     checkInterruption,
@@ -69,6 +91,7 @@ function makeNode(checkInterruption: () => boolean): ResponseCycleNode {
     },
     config: {},
     setting: {},
+    logger,
   } as unknown as ReflectionServices);
 }
 
@@ -79,6 +102,13 @@ async function runCycle(checkInterruption: () => boolean) {
 }
 
 describe('ResponseCycleNode outcome classification', () => {
+  beforeEach(() => {
+    flowState.shouldStop = false;
+    flowState.endTurn = false;
+    flowState.lastError = undefined;
+    flowState.failureLogEmitted = false;
+  });
+
   it('does NOT cancel a stop-without-end-of-turn when the run is not interrupted', async () => {
     // The regression: a round that stopped (e.g. a completed response whose
     // terminal reason was not recognized as end-of-turn, or a token/continuation
@@ -111,5 +141,47 @@ describe('ResponseCycleNode outcome classification', () => {
     if (result.outcome === 'completed') {
       expect(result.endTurn).toBe(true);
     }
+  });
+
+  it('does not repeat a model failure already logged by RetryState', async () => {
+    flowState.shouldStop = true;
+    flowState.lastError = {
+      message: 'HTTP 503 Service Unavailable',
+      userRetryable: true,
+    };
+    flowState.failureLogEmitted = true;
+    const logger = { error: vi.fn(), debug: vi.fn() };
+    const node = makeNode(() => false, logger);
+    const shared = reflectionShared();
+    const prep = await node.prep(shared);
+
+    const result = await node.exec(prep);
+    await node.post(shared, prep, result);
+
+    expect(result).toMatchObject({
+      outcome: 'failed',
+      failureLogEmitted: true,
+    });
+    expect(shared.lastError).toBe(flowState.lastError);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('logs a model failure not emitted by the inner retry boundary', async () => {
+    flowState.shouldStop = true;
+    flowState.lastError = {
+      message: 'Model response was empty',
+      userRetryable: false,
+    };
+    const logger = { error: vi.fn(), debug: vi.fn() };
+    const node = makeNode(() => false, logger);
+    const shared = reflectionShared();
+    const prep = await node.prep(shared);
+
+    const result = await node.exec(prep);
+    await node.post(shared, prep, result);
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'Response cycle failed: Model response was empty',
+    );
   });
 });

--- a/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
@@ -205,6 +205,7 @@ describe('tool-use progress events', () => {
       outcome: 'failed',
       message: 'Model claude-opus-4-7 not found',
       userRetryable: false,
+      failureLogEmitted: false,
     });
 
     expect(transition).toBe(FlowTransition.DEFAULT);
@@ -215,6 +216,30 @@ describe('tool-use progress events', () => {
     expect(error).toHaveBeenCalledWith('Model claude-opus-4-7 not found', {
       messageType: MESSAGE_TYPES.ERROR,
     });
+  });
+
+  it('does not repeat a failed model request already logged by RetryState', async () => {
+    const prepRes = createPrepResult(AgentWorkspaceState.create());
+    const shared: Partial<ToolUseRunShared> = {};
+    const error = vi.fn();
+    const node = new ToolUseCycleNode().setServices({
+      logger: { error },
+    } as unknown as ToolUseServices);
+
+    const lastError = {
+      message: 'HTTP 503 Service Unavailable',
+      userRetryable: true,
+    };
+    await node.post(shared as ToolUseRunShared, prepRes, {
+      outcome: 'failed',
+      message: lastError.message,
+      userRetryable: lastError.userRetryable,
+      lastError,
+      failureLogEmitted: true,
+    });
+
+    expect(shared.lastError).toBe(lastError);
+    expect(error).not.toHaveBeenCalled();
   });
 
   it('persists a completed cycle structured result in shared state', async () => {

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -13,7 +13,10 @@ import { describe, expect, it, vi, type Mock } from 'vitest';
 import { noopTrace, type AgentTrace } from '@agent/trace';
 import type { BaseCycleFields } from '@agent/core/flows/CommonCycleTypes';
 import { ModelInvocationNode } from '@agent/core/flows/ModelInvocationNode';
-import { RetryableInvocationNode } from '@agent/core/flows/RetryState';
+import {
+  RetryableInvocationNode,
+  handleInvocationResult,
+} from '@agent/core/flows/RetryState';
 import { tagOpenAISdkError } from '@agent/modelHandlers/openai/openAISdkError';
 import type {
   HostRetryRequest,
@@ -63,7 +66,7 @@ class ExposedRetryNode extends RetryableInvocationNode<
   TestRetryServices
 > {
   protected getOperationName(): string {
-    return 'Tool-use call';
+    return 'Model request';
   }
 
   promptFor(error: Error): Promise<unknown> {
@@ -155,6 +158,50 @@ function createModelInvocationNode(input: {
 }
 
 describe('RetryState', () => {
+  it('records whether a failed invocation already emitted its canonical error', () => {
+    const state: BaseCycleFields = {
+      messages: [],
+      shouldStop: false,
+      endTurn: true,
+    };
+
+    const result = handleInvocationResult(
+      {
+        kind: 'failed',
+        message: 'HTTP 503 Service Unavailable',
+        userRetryable: true,
+        failureLogEmitted: true,
+      },
+      state,
+      { logger: noopTrace, operationName: 'Model request' },
+    );
+
+    expect(result).toBeNull();
+    expect(state.lastError).toEqual({
+      message: 'HTTP 503 Service Unavailable',
+      userRetryable: true,
+    });
+    expect(state.failureLogEmitted).toBe(true);
+  });
+
+  it('leaves an empty model response available for the outer error logger', () => {
+    const state: BaseCycleFields = {
+      messages: [],
+      shouldStop: false,
+      endTurn: true,
+    };
+
+    const result = handleInvocationResult(
+      { kind: 'success', response: undefined },
+      state,
+      { logger: noopTrace, operationName: 'Model request' },
+    );
+
+    expect(result).toBeNull();
+    expect(state.lastError?.message).toContain('Model response was empty');
+    expect(state.failureLogEmitted).toBe(false);
+  });
+
   it('falls back to the canonical coreSettings default when texra.model.retry.maxAttempts is unset', () => {
     const node = new ExposedRetryNode();
 
@@ -171,6 +218,24 @@ describe('RetryState', () => {
 
     expect(node.shouldAutoRetry(abort)).toBe(false);
     expect(node.fallbackFor(abort)).toEqual({ kind: 'cancelled' });
+  });
+
+  it('does not claim an unprompted retryable fallback was already logged', () => {
+    const node = new ExposedRetryNode();
+    const error = new OpenAIAPIError(
+      503,
+      { message: 'transient provider failure' },
+      'transient provider failure',
+      undefined,
+    );
+    tagOpenAISdkError(error, 'openai');
+
+    expect(node.fallbackFor(error)).toMatchObject({
+      kind: 'failed',
+      message: 'HTTP 503 Service Unavailable – 503 transient provider failure',
+      userRetryable: true,
+      failureLogEmitted: false,
+    });
   });
 
   it('auto-retries a status-less OpenAI server_error response', () => {
@@ -256,7 +321,7 @@ describe('RetryState', () => {
       expect(requestRetry).toHaveBeenCalledWith(
         expect.objectContaining({
           streamId,
-          operation: 'Tool-use call',
+          operation: 'Model request',
           model: 'copilot:sonnet46',
         }),
         undefined,
@@ -355,6 +420,7 @@ describe('RetryState', () => {
       expect(node.fallbackFor(error)).toMatchObject({
         kind: 'failed',
         message: 'stream dropped before first token',
+        failureLogEmitted: true,
       });
     } finally {
       clearStreamStatusForTest(streamStatus, streamId);

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.mts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.mts
@@ -61,7 +61,7 @@ const credentialExhaustedRetry: RuntimeInteractionEventPayloads['showRetryReques
     requestId: 'relay-limit-retry',
     streamId:
       'test-stream' as RuntimeInteractionEventPayloads['showRetryRequest']['streamId'],
-    operation: 'Tool-use call',
+    operation: 'Model request',
     errorMessage: 'HTTP 429 Too Many Requests',
     errorDetails: {
       exhaustionReason: 'relay-limit',

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -63,6 +63,7 @@ import {
   selectTranscriptEntriesForViewport,
 } from '@cli/chat/tui/panes/transcriptViewport';
 import { splitTranscriptEntries } from '@cli/chat/tui/panes/transcriptEntries';
+import { transcriptEntryLayout } from '@cli/chat/tui/panes/transcriptEntryLayout';
 import { renderAnsiMarkdown } from '@cli/chat/tui/render/ansiMarkdown';
 import {
   chatTuiCanInterruptActiveRun,
@@ -1476,6 +1477,163 @@ describe('CLI transcript state', () => {
       role: 'error',
       text: 'Model request failed',
       finalized: true,
+    });
+  });
+
+  it('shows the canonical safe reason below a model-request failure', () => {
+    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    logger.error('Model request failed (no retry available)', {
+      messageType: MESSAGE_TYPES.ERROR,
+      data: {
+        message: 'HTTP 400 Bad Request – status code without a body',
+        provider: 'openai',
+        userRetryable: false,
+        rawErrorBody: { apiKey: 'secret-must-not-render' },
+      },
+    });
+
+    syncStreamLog(root);
+
+    const entries = streams.get().get(root)?.entries ?? [];
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      role: 'error',
+      text: [
+        'Model request failed (no retry available)',
+        '⎿ HTTP 400 Bad Request – status code without a body',
+      ].join('\n'),
+      finalized: true,
+    });
+    expect(entries[0]?.text).not.toContain('secret-must-not-render');
+    expect(transcriptEntryLayout(entries[0]!, { width: 80 }).lines).toEqual([
+      '! Model request failed (no retry available)',
+      '  ⎿ HTTP 400 Bad Request – status code without a body',
+    ]);
+  });
+
+  it('keeps the error summary when structured error data is malformed', () => {
+    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    logger.error('Model request failed', {
+      messageType: MESSAGE_TYPES.ERROR,
+      data: {
+        message: { nested: 'not a canonical message' },
+        rawErrorBody: { apiKey: 'secret-must-not-render' },
+        userRetryable: 'sometimes',
+      },
+    });
+
+    syncStreamLog(root);
+
+    const entries = streams.get().get(root)?.entries ?? [];
+    expect(entries[0]?.text).toBe('Model request failed');
+  });
+
+  it('removes terminal control sequences from model-error reasons', () => {
+    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    logger.error('Model request failed', {
+      messageType: MESSAGE_TYPES.ERROR,
+      data: {
+        message:
+          '\u001b[31mProvider failed\u001b[0m\u0007 \n retry later\u0085',
+        userRetryable: false,
+      },
+    });
+
+    syncStreamLog(root);
+
+    const text = streams.get().get(root)?.entries[0]?.text ?? '';
+    expect(text).toBe('Model request failed\n⎿ Provider failed retry later');
+    expect(text).not.toContain('\u001b');
+    expect(text).not.toContain('\u0007');
+    expect(text).not.toContain('\u0085');
+  });
+
+  it('redacts credentials embedded in the canonical provider message', () => {
+    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    const secret = 'sk-provider-redaction-example-1234567890abcdef';
+    const ansiSplitSecret = `${secret.slice(0, 12)}\u001b[31m${secret.slice(12)}\u001b[0m`;
+    logger.error(`Model request failed with Bearer ${ansiSplitSecret}`, {
+      messageType: MESSAGE_TYPES.ERROR,
+      data: {
+        message: `Connection failed with API_KEY=${ansiSplitSecret} and Bearer ${ansiSplitSecret}`,
+        userRetryable: false,
+      },
+    });
+
+    syncStreamLog(root);
+
+    const text = streams.get().get(root)?.entries[0]?.text ?? '';
+    expect(text).toContain('Model request failed with Bearer [redacted]');
+    expect(text).toContain('API_KEY=[redacted]');
+    expect(text).toContain('Bearer [redacted]');
+    expect(text).not.toContain(secret);
+  });
+
+  it('collapses and bounds long multiline model-error reasons', () => {
+    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    logger.error('Model request failed', {
+      messageType: MESSAGE_TYPES.ERROR,
+      data: {
+        message: `First line\n  second line\t${'x'.repeat(300)}`,
+        userRetryable: false,
+      },
+    });
+
+    syncStreamLog(root);
+
+    const entries = streams.get().get(root)?.entries ?? [];
+    const lines = entries[0]?.text.split('\n') ?? [];
+    expect(lines).toHaveLength(2);
+    expect(lines[1]).toMatch(/^⎿ First line second line x+…$/);
+    expect([...lines[1]!.slice('⎿ '.length)]).toHaveLength(240);
+  });
+
+  it('adds the personal-API hint once from structured relay-limit data', () => {
+    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    logger.error('Model request failed', {
+      messageType: MESSAGE_TYPES.ERROR,
+      data: {
+        message: `${'x'.repeat(300)} Monthly spending limit reached.`,
+        exhaustionReason: 'relay-limit',
+        userRetryable: false,
+      },
+    });
+
+    syncStreamLog(root);
+    syncStreamLog(root);
+
+    const text = streams.get().get(root)?.entries[0]?.text ?? '';
+    expect(text).toContain('\n⎿ ');
+    expect(text).not.toContain('Monthly spending limit reached.');
+    expect(text.match(/\/api personal/g)).toHaveLength(1);
+  });
+
+  it('keeps actual tool failures on the tool-row renderer', () => {
+    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    logger.error('Actual tool failed', {
+      messageType: MESSAGE_TYPES.TOOL_USE,
+      data: {
+        toolName: 'bash',
+        input: { command: 'false' },
+        error: 'The shell command exited with status 1.',
+        status: 'failed',
+        message: 'must not become a model-error continuation',
+      },
+    });
+
+    syncStreamLog(root);
+
+    const entries = streams.get().get(root)?.entries ?? [];
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      role: 'tool',
+      text: '',
+      toolUse: {
+        toolName: 'bash',
+        errorText: 'The shell command exited with status 1.',
+        isError: true,
+        status: 'failed',
+      },
     });
   });
 

--- a/src/test-kernel/common/SdkErrorUtils.vitest.mts
+++ b/src/test-kernel/common/SdkErrorUtils.vitest.mts
@@ -384,6 +384,133 @@ describe('formatProviderHttpError', () => {
     expect(formatted.userRetryable).toBe(false);
   });
 
+  it('does not promote a serialized provider response body into the message', () => {
+    const privatePrompt = 'private request body content';
+    const body = {
+      request: { prompt: privatePrompt },
+      authorization: 'opaque credential',
+    };
+    const error = new OpenAIBadRequestError(
+      400,
+      body,
+      `400 ${JSON.stringify(body)}`,
+      new Headers(),
+    );
+    tagOpenAISdkError(error, 'openai');
+
+    const formatted = formatProviderHttpError(error);
+
+    expect(formatted.message).toBe('HTTP 400 Bad Request – Bad Request');
+    expect(formatted.message).not.toContain(privatePrompt);
+    expect(formatted.message).not.toContain('opaque credential');
+    expect(formatted.rawErrorBody).toEqual(body);
+  });
+
+  it('does not promote a pretty-printed provider response body into the message', () => {
+    const privatePrompt = 'private pretty-printed request content';
+    const body = {
+      request: { prompt: privatePrompt },
+      authorization: 'opaque pretty-printed credential',
+    };
+    const reorderedBody = {
+      authorization: body.authorization,
+      request: body.request,
+    };
+    const error = new Error(
+      `400 ${JSON.stringify(reorderedBody, null, 2)}`,
+    ) as Error & { error: unknown };
+    error.error = body;
+    attachSdkErrorMetadata(error, {
+      provider: 'openai',
+      kind: 'bad_request',
+      statusCode: 400,
+    });
+
+    const formatted = formatProviderHttpError(error);
+
+    expect(formatted.message).toBe('HTTP 400 Bad Request – Bad Request');
+    expect(formatted.message).not.toContain(privatePrompt);
+    expect(formatted.message).not.toContain('opaque pretty-printed credential');
+    expect(formatted.rawErrorBody).toEqual(body);
+  });
+
+  it('retains a useful wrapper explanation when the raw body is plain text', () => {
+    const error = new Error(
+      'The provider rejected this request because the model is unavailable.',
+    ) as Error & { error: unknown };
+    error.error = 'upstream plain-text response';
+    attachSdkErrorMetadata(error, {
+      provider: 'openai',
+      kind: 'bad_request',
+      statusCode: 400,
+    });
+
+    const formatted = formatProviderHttpError(error);
+
+    expect(formatted.message).toBe(
+      'HTTP 400 Bad Request – The provider rejected this request because the model is unavailable.',
+    );
+    expect(formatted.rawErrorBody).toBe('upstream plain-text response');
+  });
+
+  it('does not promote a serialized plain-text response body into the message', () => {
+    const privateBody = 'private prompt and opaque authorization';
+    const error = new OpenAIBadRequestError(
+      400,
+      privateBody,
+      'ignored by the OpenAI error constructor',
+      new Headers(),
+    );
+    tagOpenAISdkError(error, 'openai');
+
+    const formatted = formatProviderHttpError(error);
+
+    expect(formatted.message).toBe('HTTP 400 Bad Request – Bad Request');
+    expect(formatted.message).not.toContain(privateBody);
+    expect(formatted.rawErrorBody).toBe(privateBody);
+  });
+
+  it('formats cyclic diagnostic bodies without throwing', () => {
+    const body: { kind: string; self?: unknown } = { kind: 'provider-error' };
+    body.self = body;
+    const error = new Error(
+      'The provider failed while reporting {"kind":"provider-error"}.',
+    ) as Error & { error: unknown };
+    error.error = body;
+    attachSdkErrorMetadata(error, {
+      provider: 'openai',
+      kind: 'bad_request',
+      statusCode: 400,
+    });
+
+    const formatted = formatProviderHttpError(error);
+
+    expect(formatted.message).toBe(
+      'HTTP 400 Bad Request – The provider failed while reporting {"kind":"provider-error"}.',
+    );
+    expect(formatted.rawErrorBody).toBe(body);
+  });
+
+  it('retains a wrapper explanation that does not serialize its response body', () => {
+    const body = { code: 'unsupported_response_format' };
+    const error = new Error(
+      'The selected model does not support this response format.',
+    ) as Error & { error: unknown };
+    error.error = body;
+    attachSdkErrorMetadata(error, {
+      provider: 'openai',
+      kind: 'bad_request',
+      statusCode: 400,
+    });
+
+    const formatted = formatProviderHttpError(error);
+
+    expect(formatted.message).toBe(
+      'HTTP 400 Bad Request – The selected model does not support this response format.',
+    );
+    expect(formatted.rawErrorBody).toEqual(body);
+  });
+
   it('classifies OpenAI insufficient_quota bodies as credential exhaustion', () => {
     const error = new Error('quota exhausted') as Error & { error: unknown };
     error.error = {


### PR DESCRIPTION
Closes #9011

## Summary

- labels provider and network failures as model-request failures instead of tool-use failures
- shows one concise, bounded reason beneath the failure while actual tool execution failures remain tool rows
- makes the retry boundary own canonical failure emission, preventing duplicate error rows in tool-use and reflection runs without renderer-time content comparison
- preserves structured quota guidance even when the provider message is truncated
- sanitizes terminal controls and credentials, and prevents compact, formatted, and plain-text SDK response-body serializations from becoming user-visible error text while preserving distinct safe explanations

## Verification

- full Vitest suite: 6,940 passed, 4 skipped
- focused Vitest suites: 252 passed
- npm run typecheck
- npm run compile:fast
- npm run lint (one pre-existing warning outside this change)
- npm run check:dead-code-ratchet
- targeted ESLint and Prettier checks
- repeated adversarial reviews and a final code-simplifier pass

## Size

- production: 154 additions, 26 deletions; net +128
- tests: 456 additions, 8 deletions; net +448
- changelog: 7 additions
- total: 617 additions, 34 deletions; net +583

The visible change is recorded under the 0.39.8 CLI and Extension bug fixes. No persisted or public wire format changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-visible error handling, credential redaction, and provider message selection across agent retry paths and the CLI transcript; scope is focused but touches security-sensitive display logic.
> 
> **Overview**
> **Model and provider failures are no longer mislabeled as tool-use failures.** The tool-use round's model invocation is named **Model request** (retry UI, harness, tests), so quota and HTTP errors read as model-request problems while real tool execution errors still render as tool rows.
> 
> **CLI error transcript rows are richer and safer.** When structured error log data is present, the summary line is followed by a bounded, redacted provider reason (terminal controls stripped, secrets redacted). Relay monthly-limit hints can attach from `exhaustionReason` even when the provider message is truncated. Malformed structured data falls back to the summary only.
> 
> **Duplicate failure logs are avoided.** `RetryState` tracks whether it already emitted the canonical structured error (`failureLogEmitted`); outer **ResponseCycle** / **ToolUseCycle** nodes skip a second `logger.error` when that flag is set.
> 
> **User-facing HTTP error strings are tightened.** `describeHttpError` no longer promotes SDK-serialized full response bodies (or wrapper text that embeds the raw body) into the message; it prefers scalar `message` fields on the body when the wrapper is just JSON dump, while keeping useful plain-text explanations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b5e3b237dec7858c64ff525674fbcfc8aa412b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->