### PR TITLE
fix(agent): keep OpenAI Responses websocket error listener bound while idle

### DIFF
--- a/src/agent/modelHandlers/openai/OpenAIResponseWebSocketTransport.ts
+++ b/src/agent/modelHandlers/openai/OpenAIResponseWebSocketTransport.ts
@@ -82,17 +82,7 @@ export class OpenAIResponseWebSocketTransport {
   /** Keepalive interval for the WebSocket connection. */
   private wsKeepaliveInterval: ReturnType<typeof setInterval> | null = null;
 
-  /**
-   * Bound for the pooled connection's whole lifetime, not just while a
-   * request is in flight. Without this, a server-pushed error while idle
-   * between requests (e.g. `websocket_connection_limit_reached` at the
-   * 60-minute mark) has zero listeners on the emitter, and Node treats an
-   * unhandled `'error'` event as a fatal unhandled rejection, crashing the
-   * process. `executeViaWebSocket`'s per-request `onWsError` still settles
-   * the in-flight promise when one exists (registered after this handler,
-   * so it still fires); this one only needs to invalidate the connection so
-   * the next `execute()` reconnects.
-   */
+  /** Invalidate pooled sockets that emit errors between requests. */
   private readonly onIdleWsError = (error: WebSocketError): void => {
     this.logger.debug('WebSocket connection error — invalidating', {
       data: { message: error.message },

--- a/src/agent/modelHandlers/openai/OpenAIResponseWebSocketTransport.ts
+++ b/src/agent/modelHandlers/openai/OpenAIResponseWebSocketTransport.ts
@@ -82,6 +82,24 @@ export class OpenAIResponseWebSocketTransport {
   /** Keepalive interval for the WebSocket connection. */
   private wsKeepaliveInterval: ReturnType<typeof setInterval> | null = null;
 
+  /**
+   * Bound for the pooled connection's whole lifetime, not just while a
+   * request is in flight. Without this, a server-pushed error while idle
+   * between requests (e.g. `websocket_connection_limit_reached` at the
+   * 60-minute mark) has zero listeners on the emitter, and Node treats an
+   * unhandled `'error'` event as a fatal unhandled rejection, crashing the
+   * process. `executeViaWebSocket`'s per-request `onWsError` still settles
+   * the in-flight promise when one exists (registered after this handler,
+   * so it still fires); this one only needs to invalidate the connection so
+   * the next `execute()` reconnects.
+   */
+  private readonly onIdleWsError = (error: WebSocketError): void => {
+    this.logger.debug('WebSocket connection error — invalidating', {
+      data: { message: error.message },
+    });
+    this.closeWebSocket();
+  };
+
   constructor(private readonly deps: OpenAIResponseWebSocketTransportDeps) {}
 
   private get logger(): AgentTrace {
@@ -174,6 +192,7 @@ export class OpenAIResponseWebSocketTransport {
 
     this.wsConnection = ws;
     this.wsConnectionCreatedAt = Date.now();
+    ws.on('error', this.onIdleWsError);
     this.startWsKeepalive(ws);
 
     this.logger.debug('WebSocket connection established');
@@ -397,6 +416,7 @@ export class OpenAIResponseWebSocketTransport {
     this.stopWsKeepalive();
     const wsConnection = this.wsConnection;
     if (wsConnection) {
+      wsConnection.off('error', this.onIdleWsError);
       closeQuietly(wsConnection);
       // A graceful `close()` only sends the close frame and waits for the
       // server's reply, so the underlying socket stays an active handle and

--- a/src/agent/modelHandlers/openai/OpenAIResponseWebSocketTransport.ts
+++ b/src/agent/modelHandlers/openai/OpenAIResponseWebSocketTransport.ts
@@ -81,14 +81,8 @@ export class OpenAIResponseWebSocketTransport {
   private wsConnectionCreatedAt = 0;
   /** Keepalive interval for the WebSocket connection. */
   private wsKeepaliveInterval: ReturnType<typeof setInterval> | null = null;
-
-  /** Invalidate pooled sockets that emit errors between requests. */
-  private readonly onIdleWsError = (error: WebSocketError): void => {
-    this.logger.debug('WebSocket connection error — invalidating', {
-      data: { message: error.message },
-    });
-    this.closeWebSocket();
-  };
+  /** Socket whose request-specific listeners currently own error settlement. */
+  private activeRequestSocket: ResponsesWS | null = null;
 
   constructor(private readonly deps: OpenAIResponseWebSocketTransportDeps) {}
 
@@ -182,7 +176,19 @@ export class OpenAIResponseWebSocketTransport {
 
     this.wsConnection = ws;
     this.wsConnectionCreatedAt = Date.now();
-    ws.on('error', this.onIdleWsError);
+    // The SDK rejects globally when an error has no listener, so every socket
+    // keeps this guard even after it leaves the pool. Capturing `ws` prevents a
+    // late orphan error from invalidating a newer connection. During a request,
+    // its listener owns settlement and this guard deliberately stays passive.
+    ws.on('error', (error) => {
+      if (this.wsConnection !== ws || this.activeRequestSocket === ws) {
+        return;
+      }
+      this.logger.debug('WebSocket connection error — invalidating', {
+        data: { message: error.message },
+      });
+      this.closeWebSocket();
+    });
     this.startWsKeepalive(ws);
 
     this.logger.debug('WebSocket connection established');
@@ -210,6 +216,7 @@ export class OpenAIResponseWebSocketTransport {
     }
 
     const processor = this.deps.createStreamProcessor();
+    this.activeRequestSocket = ws;
     // Accumulate text deltas so we can attach a tail to the error on reject,
     // mirroring the HTTP streaming path. Without this, a WebSocket failure
     // mid-response would lose any text that had already been generated.
@@ -360,6 +367,9 @@ export class OpenAIResponseWebSocketTransport {
       };
 
       const cleanup = (): void => {
+        if (this.activeRequestSocket === ws) {
+          this.activeRequestSocket = null;
+        }
         signal?.removeEventListener('abort', onAbort);
         ws.off('event', onEvent);
         ws.off('response.completed', onCompleted);
@@ -406,7 +416,11 @@ export class OpenAIResponseWebSocketTransport {
     this.stopWsKeepalive();
     const wsConnection = this.wsConnection;
     if (wsConnection) {
-      wsConnection.off('error', this.onIdleWsError);
+      // Clear ownership before physical teardown. The SDK may emit another
+      // error synchronously from close/terminate; the socket-bound guard then
+      // absorbs it without recursing or touching a later connection.
+      this.wsConnection = null;
+      this.wsConnectionCreatedAt = 0;
       closeQuietly(wsConnection);
       // A graceful `close()` only sends the close frame and waits for the
       // server's reply, so the underlying socket stays an active handle and
@@ -418,8 +432,6 @@ export class OpenAIResponseWebSocketTransport {
       } catch {
         /* already closed */
       }
-      this.wsConnection = null;
-      this.wsConnectionCreatedAt = 0;
       this.logger.debug('WebSocket connection closed');
     }
   }

--- a/src/test-kernel/agent/modelHandlers/OpenAIResponseWebSocketTransport.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIResponseWebSocketTransport.vitest.ts
@@ -8,6 +8,7 @@ import { WebSocketError } from 'openai/resources/responses/internal-base';
 // Local imports
 import type { AgentTrace } from '@agent/trace';
 import { OpenAIResponseWebSocketTransport } from '@agent/modelHandlers/openai/OpenAIResponseWebSocketTransport';
+import type { ResponseStreamProcessor } from '@agent/modelHandlers/openai/ResponseStreamProcessor';
 
 // Third-party type imports
 import type OpenAI from 'openai';
@@ -62,6 +63,11 @@ interface TransportInternals {
     client: OpenAI,
     signal?: AbortSignal,
   ): Promise<FakeResponsesWS>;
+  executeViaWebSocket(
+    ws: FakeResponsesWS,
+    params: unknown,
+    signal?: AbortSignal,
+  ): Promise<unknown>;
 }
 
 function internals(
@@ -71,9 +77,13 @@ function internals(
 }
 
 function createTransport(): OpenAIResponseWebSocketTransport {
+  const processor = {
+    abort: vi.fn(),
+    process: vi.fn(),
+  } as unknown as ResponseStreamProcessor;
   return new OpenAIResponseWebSocketTransport({
     logger: createLogger(),
-    createStreamProcessor: vi.fn(),
+    createStreamProcessor: vi.fn(() => processor),
   });
 }
 
@@ -113,18 +123,31 @@ describe('OpenAIResponseWebSocketTransport idle connection errors', () => {
     expect(createdSockets).toHaveLength(2);
   });
 
-  it('unregisters the idle listener from a disposed connection', async () => {
-    // Each fresh ResponsesWS gets its own `onIdleWsError` registration;
-    // dispose() must strip it from the outgoing connection object. Otherwise
-    // a stray late event on that now-orphaned socket would call
-    // closeWebSocket() again and could tear down a connection established
-    // afterward, since `onIdleWsError` always acts on the transport's
-    // *current* `wsConnection`, not the specific socket that fired.
+  it('keeps late errors on an orphan isolated from a later connection', async () => {
     const transport = createTransport();
-    const ws = await internals(transport).getOrCreateWebSocket(fakeClient);
+    const first = await internals(transport).getOrCreateWebSocket(fakeClient);
 
     transport.dispose();
+    const second = await internals(transport).getOrCreateWebSocket(fakeClient);
 
-    expect(ws.listenerCount('error')).toBe(0);
+    expect(() =>
+      first.emit('error', new WebSocketError('late orphan error', null)),
+    ).not.toThrow();
+    expect(internals(transport).wsConnection).toBe(second);
+    expect(second.socket.platformSocket.terminate).not.toHaveBeenCalled();
+  });
+
+  it('preserves the request error when closing emits synchronously', async () => {
+    const transport = createTransport();
+    const ws = await internals(transport).getOrCreateWebSocket(fakeClient);
+    ws.close.mockImplementation(() => {
+      ws.socket.emit('close', 1006, Buffer.from('closed'));
+    });
+
+    const request = internals(transport).executeViaWebSocket(ws, {});
+    const error = new WebSocketError('request failed', null);
+    ws.emit('error', error);
+
+    await expect(request).rejects.toBe(error);
   });
 });

--- a/src/test-kernel/agent/modelHandlers/OpenAIResponseWebSocketTransport.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIResponseWebSocketTransport.vitest.ts
@@ -1,0 +1,126 @@
+import { EventEmitter } from 'node:events';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { WebSocketError } from 'openai/resources/responses/internal-base';
+import type { AgentTrace } from '@agent/trace';
+import { OpenAIResponseWebSocketTransport } from '@agent/modelHandlers/openai/OpenAIResponseWebSocketTransport';
+
+import type OpenAI from 'openai';
+
+const WS_OPEN = 1;
+
+const { createdSockets } = vi.hoisted(() => ({
+  createdSockets: [] as InstanceType<typeof FakeResponsesWS>[],
+}));
+
+class FakeSocket extends EventEmitter {
+  readyState = WS_OPEN;
+  platformSocket = { terminate: vi.fn(), ping: vi.fn() };
+  close = vi.fn();
+}
+
+// Mirrors the surface OpenAIResponseWebSocketTransport touches on the real
+// `ResponsesWS`: a top-level emitter for connection-scoped events
+// (`error`, `event`, `response.*`) plus a nested `.socket` for handshake and
+// raw-connection state. Constructed already OPEN so `getOrCreateWebSocket`
+// resolves synchronously without needing to wait for an `'open'` event.
+class FakeResponsesWS extends EventEmitter {
+  socket = new FakeSocket();
+  send = vi.fn();
+  close = vi.fn();
+}
+
+vi.mock('openai/resources/responses/ws', () => ({
+  ResponsesWS: class {
+    constructor() {
+      const ws = new FakeResponsesWS();
+      createdSockets.push(ws);
+      return ws;
+    }
+  },
+}));
+
+function createLogger(): AgentTrace {
+  return {
+    streamId: 'test',
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    domain: vi.fn(),
+  } as unknown as AgentTrace;
+}
+
+interface TransportInternals {
+  wsConnection: FakeResponsesWS | null;
+  getOrCreateWebSocket(
+    client: OpenAI,
+    signal?: AbortSignal,
+  ): Promise<FakeResponsesWS>;
+}
+
+function internals(
+  transport: OpenAIResponseWebSocketTransport,
+): TransportInternals {
+  return transport as unknown as TransportInternals;
+}
+
+function createTransport(): OpenAIResponseWebSocketTransport {
+  return new OpenAIResponseWebSocketTransport({
+    logger: createLogger(),
+    createStreamProcessor: vi.fn(),
+  });
+}
+
+const fakeClient = {} as unknown as OpenAI;
+
+describe('OpenAIResponseWebSocketTransport idle connection errors', () => {
+  beforeEach(() => {
+    createdSockets.length = 0;
+  });
+
+  it('does not crash the process when the pooled connection errors with no request in flight', async () => {
+    const transport = createTransport();
+    const ws = await internals(transport).getOrCreateWebSocket(fakeClient);
+
+    // Node throws synchronously on `emit('error', ...)` when the emitter has
+    // zero 'error' listeners — this is exactly the unhandled-rejection crash
+    // observed in production (`websocket_connection_limit_reached` firing on
+    // an idle connection between requests). A persistent listener bound at
+    // connection time must prevent that.
+    expect(() =>
+      ws.emit('error', new WebSocketError('connection limit reached', null)),
+    ).not.toThrow();
+  });
+
+  it('invalidates the connection so the next execute() reconnects', async () => {
+    const transport = createTransport();
+    const first = await internals(transport).getOrCreateWebSocket(fakeClient);
+    expect(internals(transport).wsConnection).toBe(first);
+
+    first.emit('error', new WebSocketError('connection limit reached', null));
+
+    expect(internals(transport).wsConnection).toBeNull();
+    expect(first.socket.platformSocket.terminate).toHaveBeenCalled();
+
+    const second = await internals(transport).getOrCreateWebSocket(fakeClient);
+    expect(second).not.toBe(first);
+    expect(createdSockets).toHaveLength(2);
+  });
+
+  it('unregisters the idle listener from a disposed connection', async () => {
+    // Each fresh ResponsesWS gets its own `onIdleWsError` registration;
+    // dispose() must strip it from the outgoing connection object. Otherwise
+    // a stray late event on that now-orphaned socket would call
+    // closeWebSocket() again and could tear down a connection established
+    // afterward, since `onIdleWsError` always acts on the transport's
+    // *current* `wsConnection`, not the specific socket that fired.
+    const transport = createTransport();
+    const ws = await internals(transport).getOrCreateWebSocket(fakeClient);
+
+    transport.dispose();
+
+    expect(ws.listenerCount('error')).toBe(0);
+  });
+});

--- a/src/test-kernel/agent/modelHandlers/OpenAIResponseWebSocketTransport.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIResponseWebSocketTransport.vitest.ts
@@ -1,11 +1,15 @@
+// Node imports
 import { EventEmitter } from 'node:events';
 
+// Third-party imports
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-
 import { WebSocketError } from 'openai/resources/responses/internal-base';
+
+// Local imports
 import type { AgentTrace } from '@agent/trace';
 import { OpenAIResponseWebSocketTransport } from '@agent/modelHandlers/openai/OpenAIResponseWebSocketTransport';
 
+// Third-party type imports
 import type OpenAI from 'openai';
 
 const WS_OPEN = 1;


### PR DESCRIPTION
## Summary

- Bind a persistent `'error'` listener on the pooled OpenAI Responses WebSocket connection at creation time, not just for the duration of an in-flight request
- Remove that listener on `closeWebSocket()`/`dispose()` so a torn-down connection can't tear down a later reconnect

## Root cause

`OpenAIResponseWebSocketTransport` reuses one WebSocket connection across turns and proactively reconnects it 5 minutes before the server's 60-minute limit — but only at the start of the *next* request. The `'error'` listener (`onWsError`) was bound only for the duration of an in-flight request and removed in that request's `cleanup()`. Between requests — while the CLI is idle, or during a long subagent delegation where this connection sits unused — no listener was attached. When the server pushed `websocket_connection_limit_reached` on an idle socket in that window, Node treated the zero-listener `'error'` event as an unhandled rejection and crashed the whole process.

## Fix

A persistent `onIdleWsError` listener is now bound whenever a connection is established, independent of the per-request handler. It just invalidates the connection (closes it) so the next `execute()` reconnects. The per-request `onWsError` still settles the in-flight promise when a request exists — since it's registered after the persistent handler, it still fires in the same event dispatch.

## Evidence

Captured from a real session (`error.txt` tail — fatal `websocket_connection_limit_reached`, process exit). Found while auditing PR #9010 (CLI transcript memory fix), which addresses a separate heap-growth issue and doesn't touch this path. Filed as #9013.

Also ran a dedicated sweep across `agent/modelHandlers`, `agent/runtime`, `tools`, `transcript`, and the CLI TUI state for the same crash pattern (unhandled EventEmitter `'error'`) and for listener/timer/Map leaks — this is the only reused/pooled connection object in the codebase; no recurrence found elsewhere.

## Validation

- `npm run typecheck` — clean across all packages
- `npx eslint` on both changed files — clean
- `npx prettier --check` — clean
- New test file (`OpenAIResponseWebSocketTransport.vitest.ts`, 3 tests) — passing
- `npx vitest run src/test-kernel/agent/modelHandlers` — 538 passed, 4 skipped, no regressions

Fixes #9013.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent model transport error handling on a reused connection; behavior is narrow and covered by new tests, but failures here can still break OpenAI WebSocket turns.
> 
> **Overview**
> Fixes process crashes when the OpenAI Responses **pooled WebSocket** errors between requests (e.g. `websocket_connection_limit_reached`).
> 
> **`OpenAIResponseWebSocketTransport`** now registers a **persistent `error` listener** when a connection is created. On idle errors it logs and invalidates the pool via `closeWebSocket()` so the next `execute()` opens a fresh socket. **`activeRequestSocket`** marks sockets with in-flight work so the guard does not compete with per-request `onWsError` settlement. **`closeWebSocket()`** clears `wsConnection` before teardown so synchronous errors during close cannot recurse or affect a replacement connection.
> 
> Adds **`OpenAIResponseWebSocketTransport.vitest.ts`** covering idle errors (no throw), reconnect after invalidation, orphan-socket isolation, and in-request error preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce2f1a219a2388d1ae8a40fe74c90086beb98ae8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->