### PR TITLE
fix(desktop): close process-session replay gaps

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -161,6 +161,7 @@ export class DesktopProgressBridge {
    * bookkeeping the extension uses, rather than a hand-rolled registry.
    */
   private unsubscribe: () => void = () => undefined;
+  private detachCompletedResult: () => void = () => undefined;
   private toolEditApprovals: DesktopToolEditApprovalController | undefined;
   private hostInteractions!: DesktopHostInteractions;
   private fileActions!: DesktopProgressFileActions;
@@ -262,6 +263,13 @@ export class DesktopProgressBridge {
     });
     this.state = this.backend.state;
     this.streamLogs = this.state.streamLogs;
+    const detachCompletedResult = this.session.onResult((event) => {
+      if (event.outcome === 'completed') this.options.host.onRunCompleted();
+    });
+    this.detachCompletedResult = () => {
+      detachCompletedResult();
+      this.detachCompletedResult = () => undefined;
+    };
     this.restartRepair = this.initializeCanonicalState(presentationHost);
   }
 
@@ -318,13 +326,8 @@ export class DesktopProgressBridge {
     this.agentProposalController = this.progressHost.agentProposalController;
     this.progressViewInboundHandlers = this.createProgressViewInboundHandlers();
     const backendSubscription = this.backend.setupEventListeners();
-    const unsubscribeResult = this.session.onResult((event) => {
-      if (event.outcome === 'completed') this.options.host.onRunCompleted();
-    });
-    this.unsubscribe = () => {
-      backendSubscription.dispose();
-      unsubscribeResult();
-    };
+    this.unsubscribe = () => backendSubscription.dispose();
+    this.replayActiveProcessOutput();
     if (this.disposed) {
       this.unsubscribe();
       return;
@@ -395,6 +398,36 @@ export class DesktopProgressBridge {
       }
     }
     this.presentationReady = true;
+  }
+
+  private replayActiveProcessOutput(): void {
+    // setupEventListeners() is already attached, so output produced after this
+    // synchronous snapshot boundary arrives live. No await may be introduced
+    // before the snapshot: retained output emitted before subscription must be
+    // replayed, while later output must not be included a second time.
+    const snapshots = this.session.executions.getActiveProcessOutputSnapshots();
+    for (const [executionId, output] of snapshots) {
+      if (this.disposed) return;
+      if (!output.stdout && !output.stderr) continue;
+      const handle = this.session.executions.getHandle(executionId);
+      if (!handle) continue;
+      const { parentStreamId } = handle;
+
+      // Sending an earlier process's output can synchronously re-enter host
+      // code. Validate each process against the current active child set so a
+      // process removed during that callback is never resurrected.
+      const stillActive = this.session.executions
+        .getActiveChildren(parentStreamId)
+        .processes.some((process) => process.executionId === executionId);
+      if (!stillActive) continue;
+      this.backend.factApplier.handleRunFact(parentStreamId, {
+        type: 'process.output',
+        parentStreamId,
+        executionId,
+        stdout: output.stdout,
+        stderr: output.stderr,
+      });
+    }
   }
 
   private createProgressViewHost(): ProgressViewHost {
@@ -663,6 +696,7 @@ export class DesktopProgressBridge {
     // Make this presentation sink inert before detaching resources owned by
     // the closing BrowserWindow.
     this.disposed = true;
+    this.detachCompletedResult();
     this.restartRepairRetry.dispose();
     // Detaching first advances the session's attachment generation. Any
     // cancellation produced while the old presenters are disposed is stale;

--- a/packages/desktop/src/main/desktopAgentResume.ts
+++ b/packages/desktop/src/main/desktopAgentResume.ts
@@ -107,10 +107,12 @@ function reportResumeFailure(
   streamId: StreamTabId,
   error: unknown,
   context: DesktopResumeContext,
+  lifecycleStarted: boolean,
 ): void {
   context.logger.error(`Failed to resume desktop stream ${streamId}`, {
     data: toLogData(error),
   });
+  if (lifecycleStarted) return;
   context.session.interactions.emit(
     'requestShowError',
     { message: `Resume failed: ${toErrorMessage(error)}` },
@@ -127,6 +129,7 @@ function resumeDesktopStream(
     context.isCancellationRequested() ||
     !context.session.transcripts.has(streamId);
   const runtimeHost = context.session.interactions;
+  let lifecycleStarted = false;
   return resolveAndResumeStream(streamId, {
     runtimeHost,
     streamStatus: context.session.status,
@@ -165,7 +168,11 @@ function resumeDesktopStream(
           runtimeUnavailableTools: DESKTOP_UNAVAILABLE_TOOLS,
           canAcquireResumeLease: () => !isResumeInvalidated(),
           isCancellationRequested: isResumeInvalidated,
-          onError: (error) => reportResumeFailure(streamId, error, context),
+          onRun: () => {
+            lifecycleStarted = true;
+          },
+          onError: (error) =>
+            reportResumeFailure(streamId, error, context, lifecycleStarted),
         },
       ),
     executeWorkflow: (config, executionId, modelHandlerCompatibilityKey) =>
@@ -176,14 +183,20 @@ function resumeDesktopStream(
           session: context.session,
           canAcquireResumeLease: () => !isResumeInvalidated(),
         },
-        { modelHandlerCompatibilityKey },
+        {
+          modelHandlerCompatibilityKey,
+          onLifecycleStart: () => {
+            lifecycleStarted = true;
+          },
+        },
       ),
     reportNoResumableSession: () =>
       context.session.interactions.showInfoMessage(
         'This run has no resumable session state. Start a new run instead.',
         { replayWhenAttached: true },
       ),
-    reportFailure: (id, error) => reportResumeFailure(id, error, context),
+    reportFailure: (id, error) =>
+      reportResumeFailure(id, error, context, lifecycleStarted),
     isCancellationRequested: isResumeInvalidated,
   });
 }

--- a/packages/extension/src/progressView/frontend/slices/streamMetaSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamMetaSlice.ts
@@ -15,6 +15,7 @@ import {
 } from '@shared/schemas';
 import {
   EMPTY_STREAM_META,
+  PROCESS_OUTPUT_MAX_CHARS,
   reduceStreamMeta,
 } from '@shared/streams/streamMetaReducer';
 import { compareByNewestCreationTime } from '@shared/streams/streamOrdering';
@@ -51,7 +52,10 @@ export function takePendingDescription(
  * per stdout/stderr, trimming to 80k when the cap is crossed so output can keep
  * appending for a while before the next reset. The shared reducer applies it.
  */
-const WEBVIEW_OUTPUT_CAP = { maxChars: 100_000, retainChars: 80_000 } as const;
+const WEBVIEW_OUTPUT_CAP = {
+  maxChars: PROCESS_OUTPUT_MAX_CHARS,
+  retainChars: 80_000,
+} as const;
 
 function upsertSortedStreamInfo(
   streams: Map<StreamTabId, StreamTabInfo>,

--- a/src/agent/runtime/ProcessOutputPoller.ts
+++ b/src/agent/runtime/ProcessOutputPoller.ts
@@ -5,8 +5,13 @@ import pMap from 'p-map';
 import * as logger from '@logger/logUtils';
 import { platform } from '@platform/platform';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
+import {
+  PROCESS_OUTPUT_MAX_CHARS,
+  type StreamProcessOutput,
+} from '@shared/streams/streamMetaReducer';
 import { delay } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
+import { appendTail } from '@utils/strings/appendTail';
 
 import type { ProcessExecutionHandle } from './ExecutionHandle';
 
@@ -40,6 +45,7 @@ interface FileReadState {
 interface OutputState {
   stdout: FileReadState;
   stderr: FileReadState;
+  output: StreamProcessOutput;
 }
 
 export class ProcessOutputPoller {
@@ -63,7 +69,21 @@ export class ProcessOutputPoller {
     this.processOutputs.set(handle.executionId, {
       handle,
     });
+    this.getOrCreateState(handle.executionId);
     this.reconcile();
+  }
+
+  /** Return detached stdout/stderr tails for every currently active process. */
+  getActiveOutputSnapshots(): ReadonlyMap<ExecutionId, StreamProcessOutput> {
+    const snapshots = new Map<ExecutionId, StreamProcessOutput>();
+    for (const executionId of this.processOutputs.keys()) {
+      const output = this.outputStates.get(executionId)?.output ?? {
+        stdout: '',
+        stderr: '',
+      };
+      snapshots.set(executionId, Object.freeze({ ...output }));
+    }
+    return snapshots;
   }
 
   unregister(executionId: string): void {
@@ -117,6 +137,7 @@ export class ProcessOutputPoller {
       state = {
         stdout: { offset: 0, decoder: new StringDecoder('utf8') },
         stderr: { offset: 0, decoder: new StringDecoder('utf8') },
+        output: { stdout: '', stderr: '' },
       };
       this.outputStates.set(executionId, state);
     }
@@ -248,11 +269,27 @@ export class ProcessOutputPoller {
   }
 
   private emitProcessOutput(payload: ProcessOutputPayload): void {
-    if (this.emitOutput) {
-      this.emitOutput(payload);
-      return;
+    if (!this.emitOutput) {
+      throw new Error('ProcessOutputPoller requires a process output emitter');
     }
-    throw new Error('ProcessOutputPoller requires a process output emitter');
+    this.emitOutput(payload);
+
+    // The emitter may synchronously unregister the process. Never recreate a
+    // tail after unregister/dispose has pruned it.
+    const state = this.outputStates.get(payload.executionId);
+    if (!state || !this.processOutputs.has(payload.executionId)) return;
+    state.output = {
+      stdout: appendTail(
+        state.output.stdout,
+        payload.stdout,
+        PROCESS_OUTPUT_MAX_CHARS,
+      ),
+      stderr: appendTail(
+        state.output.stderr,
+        payload.stderr,
+        PROCESS_OUTPUT_MAX_CHARS,
+      ),
+    };
   }
 }
 

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -30,6 +30,7 @@ import {
   type StreamPhase,
   type StreamTabId,
 } from '@shared/schemas';
+import type { StreamProcessOutput } from '@shared/streams/streamMetaReducer';
 import {
   isActivePhase,
   isInFlightPhase,
@@ -521,6 +522,14 @@ export class ExecutionRegistry {
 
   getActiveIds(): string[] {
     return [...this.handles.keys()];
+  }
+
+  /** Return detached output tails for every currently active process. */
+  getActiveProcessOutputSnapshots(): ReadonlyMap<
+    ExecutionId,
+    StreamProcessOutput
+  > {
+    return this.processOutput.getActiveOutputSnapshots();
   }
 
   /**

--- a/src/shared/streams/streamMetaReducer.ts
+++ b/src/shared/streams/streamMetaReducer.ts
@@ -9,8 +9,11 @@
 import type { ActiveChildInfo } from '@shared/schemas';
 import { appendTail } from '@utils/strings/appendTail';
 
+/** Maximum stdout/stderr tail length retained per active process. */
+export const PROCESS_OUTPUT_MAX_CHARS = 100_000;
+
 /** Per-execution captured stdout/stderr tail held in stream meta. */
-interface StreamProcessOutput {
+export interface StreamProcessOutput {
   readonly stdout: string;
   readonly stderr: string;
 }

--- a/src/test-kernel/agent/runtime/ProcessOutputPoller.vitest.ts
+++ b/src/test-kernel/agent/runtime/ProcessOutputPoller.vitest.ts
@@ -15,6 +15,7 @@ import {
 } from '@agent/runtime/ProcessOutputPoller';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import type { StreamTabId } from '@shared/schemas';
+import { PROCESS_OUTPUT_MAX_CHARS } from '@shared/streams/streamMetaReducer';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { delay } from '@utils/core';
 
@@ -115,6 +116,74 @@ describe('ProcessOutputPoller', () => {
     ]);
   });
 
+  it('accumulates incremental stdout and stderr snapshots in order', async () => {
+    const { host, emitOutput } = createRuntimeHost();
+    emitOutput(vi.fn());
+    const { handle, stdoutPath, stderrPath } = await makeProcessHandle(host);
+    poller.register(handle);
+
+    await poller.flush(handle);
+    await fs.appendFile(stdoutPath, 'out-2');
+    await fs.appendFile(stderrPath, 'err-2');
+    await poller.flush(handle);
+
+    expect(poller.getActiveOutputSnapshots().get(handle.executionId)).toEqual({
+      stdout: 'out-1out-2',
+      stderr: 'err-1err-2',
+    });
+  });
+
+  it('retains exactly the shared per-process output bound', async () => {
+    const { host, emitOutput } = createRuntimeHost();
+    emitOutput(vi.fn());
+    const stdout = `discard${'o'.repeat(PROCESS_OUTPUT_MAX_CHARS)}`;
+    const stderr = `discard${'e'.repeat(PROCESS_OUTPUT_MAX_CHARS)}`;
+    const { handle } = await makeProcessHandle(host, { stdout, stderr });
+    poller.register(handle);
+
+    await poller.flush(handle);
+
+    const snapshot = poller.getActiveOutputSnapshots().get(handle.executionId);
+    expect(snapshot?.stdout).toBe('o'.repeat(PROCESS_OUTPUT_MAX_CHARS));
+    expect(snapshot?.stderr).toBe('e'.repeat(PROCESS_OUTPUT_MAX_CHARS));
+  });
+
+  it('returns detached immutable snapshots', async () => {
+    const { host, emitOutput } = createRuntimeHost();
+    emitOutput(vi.fn());
+    const { handle } = await makeProcessHandle(host);
+    poller.register(handle);
+    await poller.flush(handle);
+
+    const snapshots = poller.getActiveOutputSnapshots();
+    const output = snapshots.get(handle.executionId);
+    (snapshots as Map<string, unknown>).clear();
+    expect(() => {
+      (output as { stdout: string }).stdout = 'mutated';
+    }).toThrow(TypeError);
+
+    expect(poller.getActiveOutputSnapshots().get(handle.executionId)).toEqual({
+      stdout: 'out-1',
+      stderr: 'err-1',
+    });
+  });
+
+  it('clears snapshots on unregister and dispose', async () => {
+    const { host, emitOutput } = createRuntimeHost();
+    emitOutput(vi.fn());
+    const { handle } = await makeProcessHandle(host);
+    poller.register(handle);
+    await poller.flush(handle);
+
+    poller.unregister(handle.executionId);
+    expect(poller.getActiveOutputSnapshots()).toEqual(new Map());
+
+    poller.register(handle);
+    await poller.flush(handle);
+    poller.dispose();
+    expect(poller.getActiveOutputSnapshots()).toEqual(new Map());
+  });
+
   it('polls handles whose output paths are assigned after registration', async () => {
     const { host, events, emitOutput } = createRuntimeHost();
     emitOutput((payload) => events.push({ event: 'process.output', payload }));
@@ -166,9 +235,14 @@ describe('ProcessOutputPoller', () => {
       stdout: incompleteEmoji,
       stderr: '',
     });
+    poller.register(handle);
 
     await poller.flush(handle);
 
     expect(events).toEqual([outputEvent('\uFFFD', '')]);
+    expect(poller.getActiveOutputSnapshots().get(handle.executionId)).toEqual({
+      stdout: '\uFFFD',
+      stderr: '',
+    });
   });
 });

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -5,7 +5,12 @@ import { access } from 'node:fs/promises';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports
-import { noopTrace, type AgentEvent, type AgentTrace } from '@agent/trace';
+import {
+  noopTrace,
+  type AgentEvent,
+  type AgentTrace,
+  type ResultEvent,
+} from '@agent/trace';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { SessionEvent, SessionFact } from '@agent/runtime/SessionEventHub';
 import type { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
@@ -204,6 +209,7 @@ type CreateBridgeOptions = {
   wakeQueuedFollowUpStream?: WakeQueuedFollowUpStream;
   showErrorMessage?: (message: string) => Promise<void> | void;
   showInfoMessage?: (message: string) => Promise<void> | void;
+  onRunCompleted?: () => void;
   openPath?: (filePath: string, line?: number) => Promise<void>;
   observeRendererMessage?: (message: unknown) => void;
   /** Captures `this.logger.error(...)` calls made by the bridge under test. */
@@ -236,6 +242,9 @@ type ProgressMessage = {
   };
   activeState?: unknown;
   permission?: { data?: { approvalId?: string } };
+  executionId?: string;
+  stdout?: string;
+  stderr?: string;
 };
 
 /** Shared fixture for the tool-use "search" agentConfig used across several
@@ -510,6 +519,9 @@ async function createBridge(
         ...(options.showInfoMessage
           ? { showInfoMessage: options.showInfoMessage }
           : {}),
+        ...(options.onRunCompleted
+          ? { onRunCompleted: options.onRunCompleted }
+          : {}),
         ...(options.openPath ? { openPath: options.openPath } : {}),
       }),
     },
@@ -668,6 +680,18 @@ function emitStatusFact(
   });
 }
 
+function completedRootResult(executionId: ExecutionId): ResultEvent {
+  return {
+    type: 'result',
+    outcome: RUN_OUTCOME.COMPLETED,
+    executionId,
+    streamId: 'onboarding-completed',
+    agentName: 'proofreader',
+    category: 'workflow',
+    isSubagent: false,
+  };
+}
+
 describe('DesktopProgressBridge', () => {
   afterEach(() => {
     vi.doUnmock('@agent/runtime/SessionResumeRetrieval');
@@ -698,6 +722,73 @@ describe('DesktopProgressBridge', () => {
       activeStream: 'parent',
       streams: [expect.objectContaining({ name: 'parent' })],
     });
+  });
+
+  it('reports a completed root result while canonical initialization is gated exactly once', async () => {
+    let releaseInitialization!: () => void;
+    let markInitializationStarted!: () => void;
+    const initializationStarted = new Promise<void>((resolve) => {
+      markInitializationStarted = resolve;
+    });
+    const initializationGate = new Promise<void>((resolve) => {
+      releaseInitialization = resolve;
+    });
+    const onRunCompleted = vi.fn();
+    const bridge = await createBridge([], {
+      deferReady: true,
+      detectWaitingStreams: vi.fn(async () => {
+        markInitializationStarted();
+        await initializationGate;
+        return new Set();
+      }),
+      onRunCompleted,
+    });
+    await initializationStarted;
+
+    const session = (bridge as unknown as { session: SessionHandle }).session;
+    session.publishRunEvent(
+      'onboarding-completed',
+      completedRootResult('onboarding-completed-1' as ExecutionId),
+    );
+    expect(onRunCompleted).toHaveBeenCalledOnce();
+
+    releaseInitialization();
+    await bridge.waitUntilReady();
+    expect(onRunCompleted).toHaveBeenCalledOnce();
+  });
+
+  it('detaches the completed-result listener when disposed during initialization', async () => {
+    let releaseInitialization!: () => void;
+    let markInitializationStarted!: () => void;
+    const initializationStarted = new Promise<void>((resolve) => {
+      markInitializationStarted = resolve;
+    });
+    const initializationGate = new Promise<void>((resolve) => {
+      releaseInitialization = resolve;
+    });
+    const onRunCompleted = vi.fn();
+    const bridge = await createBridge([], {
+      deferReady: true,
+      detectWaitingStreams: vi.fn(async () => {
+        markInitializationStarted();
+        await initializationGate;
+        return new Set();
+      }),
+      onRunCompleted,
+    });
+    await initializationStarted;
+
+    bridge.dispose();
+    const session = (bridge as unknown as { session: SessionHandle }).session;
+    session.publishRunEvent(
+      'onboarding-completed',
+      completedRootResult('onboarding-completed-2' as ExecutionId),
+    );
+    expect(onRunCompleted).not.toHaveBeenCalled();
+
+    releaseInitialization();
+    await bridge.waitUntilReady();
+    expect(onRunCompleted).not.toHaveBeenCalled();
   });
 
   it('leaves output-file host events to the session run-fact path', async () => {
@@ -2766,13 +2857,17 @@ describe('DesktopProgressBridge', () => {
         bridgeA.dispose();
       };
 
-      const reopen = async (reopenedMessages: unknown[] = []) => {
+      const reopen = async (
+        reopenedMessages: unknown[] = [],
+        observeRendererMessage?: (message: unknown) => void,
+      ) => {
         close();
         const errorsB: string[] = [];
         const infosB: string[] = [];
         const bridgeB = new bridgeModule.DesktopProgressBridge(
           (message) => {
             reopenedMessages.push(message);
+            observeRendererMessage?.(message);
           },
           {
             session: processSession,
@@ -2822,6 +2917,239 @@ describe('DesktopProgressBridge', () => {
         trace,
       };
     }
+
+    async function trackOutputProcess(
+      owner: Awaited<ReturnType<typeof createProcessOwner>>,
+      executionId: ExecutionId,
+    ) {
+      const { platform } = await import('@platform/platform');
+      const stdout = `/${executionId}-stdout.log`;
+      const stderr = `/${executionId}-stderr.log`;
+      await Promise.all([
+        platform().fs.writeFile(stdout, Buffer.from('')),
+        platform().fs.writeFile(stderr, Buffer.from('')),
+      ]);
+
+      const processHandle = new owner.ProcessExecutionHandle(
+        executionId,
+        owner.handle.childStreamId,
+        'bash',
+        () => true,
+        owner.noopAgentRuntimeHost,
+      );
+      processHandle.toolName = 'bash';
+      processHandle.outputPaths = { stdout, stderr };
+      owner.processSession.executions.track(processHandle);
+
+      const flush = () =>
+        (
+          owner.processSession.executions as unknown as {
+            processOutput: {
+              flush(handle: typeof processHandle): Promise<void>;
+            };
+          }
+        ).processOutput.flush(processHandle);
+      const appendStdout = (text: string) =>
+        platform().fs.appendFile(stdout, Buffer.from(text));
+      const appendStderr = (text: string) =>
+        platform().fs.appendFile(stderr, Buffer.from(text));
+      return { appendStdout, appendStderr, flush };
+    }
+
+    function processOutputMessages(messages: unknown[]): ProgressMessage[] {
+      return progressMessages(
+        messages,
+        PROGRESS_VIEW_COMMANDS.UPDATE_PROCESS_OUTPUT,
+      );
+    }
+
+    it('replays detached active-process output once and then delivers live output once', async () => {
+      const streamId = 'process-output-reopen' as StreamTabId;
+      const executionId = 'ec01a0' as ExecutionId;
+      const processExecutionId = 'ec01a1' as ExecutionId;
+      const owner = await createProcessOwner({ streamId, executionId });
+      const output = await trackOutputProcess(owner, processExecutionId);
+
+      owner.close();
+      await Promise.all([
+        output.appendStdout('detached stdout'),
+        output.appendStderr('detached stderr'),
+      ]);
+      await output.flush();
+      expect(
+        owner.processSession.executions
+          .getActiveProcessOutputSnapshots()
+          .get(processExecutionId),
+      ).toEqual({
+        stdout: 'detached stdout',
+        stderr: 'detached stderr',
+      });
+
+      const messagesB: unknown[] = [];
+      const { bridgeB } = await owner.reopen(messagesB);
+      try {
+        expect(processOutputMessages(messagesB)).toEqual([
+          expect.objectContaining({
+            stream: streamId,
+            executionId: processExecutionId,
+            stdout: 'detached stdout',
+            stderr: 'detached stderr',
+          }),
+        ]);
+
+        bridgeB.syncFullView();
+        expect(
+          progressMessages(messagesB, PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS).at(
+            -1,
+          ),
+        ).toMatchObject({
+          streamStates: {
+            [streamId]: {
+              activeProcesses: [
+                expect.objectContaining({
+                  executionId: processExecutionId,
+                  agentName: 'bash',
+                  kind: 'process',
+                  toolName: 'bash',
+                }),
+              ],
+            },
+          },
+        });
+
+        await Promise.all([
+          output.appendStdout(' live stdout'),
+          output.appendStderr(' live stderr'),
+        ]);
+        await output.flush();
+        expect(processOutputMessages(messagesB)).toEqual([
+          expect.objectContaining({
+            executionId: processExecutionId,
+            stdout: 'detached stdout',
+            stderr: 'detached stderr',
+          }),
+          expect.objectContaining({
+            executionId: processExecutionId,
+            stdout: ' live stdout',
+            stderr: ' live stderr',
+          }),
+        ]);
+      } finally {
+        bridgeB.dispose();
+      }
+    });
+
+    it('has no loss or duplication across a gated subscribe-snapshot boundary', async () => {
+      const streamId = 'process-output-subscribe-boundary' as StreamTabId;
+      const executionId = 'ec01a2' as ExecutionId;
+      const processExecutionId = 'ec01a3' as ExecutionId;
+      let detectCount = 0;
+      let markReplacementLoadStarted!: () => void;
+      let releaseReplacementLoad!: () => void;
+      const replacementLoadStarted = new Promise<void>((resolve) => {
+        markReplacementLoadStarted = resolve;
+      });
+      const replacementLoadGate = new Promise<void>((resolve) => {
+        releaseReplacementLoad = resolve;
+      });
+      const detectWaitingStreams = vi.fn(async () => {
+        detectCount += 1;
+        if (detectCount === 1) return new Set<StreamTabId>();
+        markReplacementLoadStarted();
+        await replacementLoadGate;
+        return new Set<StreamTabId>();
+      });
+      const owner = await createProcessOwner({
+        streamId,
+        executionId,
+        detectWaitingStreams,
+      });
+      const output = await trackOutputProcess(owner, processExecutionId);
+      owner.close();
+
+      const messagesB: unknown[] = [];
+      let postBoundaryFlush: Promise<void> | undefined;
+      const reopening = owner.reopen(messagesB, (message) => {
+        const processOutput = message as ProgressMessage;
+        if (
+          processOutput.command !==
+            PROGRESS_VIEW_COMMANDS.UPDATE_PROCESS_OUTPUT ||
+          processOutput.stdout !== 'before subscription'
+        ) {
+          return;
+        }
+        postBoundaryFlush = (async () => {
+          await output.appendStdout('after snapshot');
+          await output.flush();
+        })();
+      });
+      await replacementLoadStarted;
+      await output.appendStdout('before subscription');
+      await output.flush();
+      expect(messagesB).toEqual([]);
+
+      releaseReplacementLoad();
+      const { bridgeB } = await reopening;
+      try {
+        await vi.waitFor(() => expect(postBoundaryFlush).toBeDefined());
+        await postBoundaryFlush;
+        expect(processOutputMessages(messagesB)).toEqual([
+          expect.objectContaining({
+            executionId: processExecutionId,
+            stdout: 'before subscription',
+            stderr: '',
+          }),
+          expect.objectContaining({
+            executionId: processExecutionId,
+            stdout: 'after snapshot',
+            stderr: '',
+          }),
+        ]);
+      } finally {
+        bridgeB.dispose();
+      }
+    });
+
+    it('does not replay retained output after the process unregisters', async () => {
+      const streamId = 'process-output-finished-before-reopen' as StreamTabId;
+      const executionId = 'ec01a4' as ExecutionId;
+      const processExecutionId = 'ec01a5' as ExecutionId;
+      const owner = await createProcessOwner({ streamId, executionId });
+      const output = await trackOutputProcess(owner, processExecutionId);
+
+      owner.close();
+      await output.appendStdout('finished while detached');
+      await output.flush();
+      owner.processSession.executions.untrack(processExecutionId);
+      await vi.waitFor(() => {
+        expect(
+          owner.processSession.executions
+            .getActiveProcessOutputSnapshots()
+            .has(processExecutionId),
+        ).toBe(false);
+      });
+
+      const messagesB: unknown[] = [];
+      const { bridgeB } = await owner.reopen(messagesB);
+      try {
+        expect(processOutputMessages(messagesB)).toEqual([]);
+        expect(
+          owner.processSession.executions.getActiveChildren(streamId).processes,
+        ).toEqual([]);
+        bridgeB.syncFullView();
+        expect(
+          progressMessages(messagesB, PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS).at(
+            -1,
+          ),
+        ).toMatchObject({
+          streamStates: {
+            [streamId]: { activeProcesses: [] },
+          },
+        });
+      } finally {
+        bridgeB.dispose();
+      }
+    });
 
     it('keeps a live transcript append made while replacement state loads', async () => {
       const streamId = 'process-stream-live-reopen' as StreamTabId;

--- a/src/test-kernel/desktop/DesktopAgentResume.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentResume.vitest.mts
@@ -5,10 +5,13 @@ import '@test/support/defaultSessionTestSetup';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports
+import type { ResultEvent } from '@agent/trace';
 import { ToolUseAgentConfigSchema } from '@agent/core/definition/AgentConfig';
+import * as AgentExecution from '@agent/runtime/executeAgent';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import * as SessionResumeRetrieval from '@agent/runtime/SessionResumeRetrieval';
 import * as AgentRunner from '@agent/runtime/runAgent';
+import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
 import { DesktopProcessResumeOwner } from '@desktop/main/desktopAgentResume';
 import {
   AgentCategory,
@@ -17,6 +20,7 @@ import {
   type StreamTabId,
 } from '@shared/schemas';
 import { createTestSession } from '@test/support/sessionTestUtils';
+import { createToolUseResumeData } from '@test/support/toolUseResumeTestUtils';
 import { StreamSnapshotStore } from '@transcript';
 
 const retrieveSessionResumeData = vi.spyOn(
@@ -24,6 +28,10 @@ const retrieveSessionResumeData = vi.spyOn(
   'retrieveSessionResumeData',
 );
 const runAgent = vi.spyOn(AgentRunner, 'runAgent');
+const resumeToolUseFromResumeData = vi.spyOn(
+  AgentExecution,
+  'resumeToolUseFromResumeData',
+);
 
 const stream = 'headless-resume' as StreamTabId;
 const executionId = 'abc123' as ExecutionId;
@@ -32,6 +40,39 @@ const config = ToolUseAgentConfigSchema.parse({
   model: 'deepseekproT',
   agentCategory: AgentCategory.ToolUse,
 });
+
+function failedResult(
+  category: ResultEvent['category'],
+  message: string,
+): ResultEvent {
+  return {
+    type: 'result',
+    outcome: RUN_OUTCOME.FAILED,
+    executionId,
+    streamId: stream,
+    agentName: 'proofreader',
+    category,
+    isSubagent: false,
+    error: { kind: 'unexpected', message },
+  };
+}
+
+function attachResultPresenter(
+  session: SessionHandle,
+  emit = vi.fn(),
+): { emit: ReturnType<typeof vi.fn>; detach(): void } {
+  const detachHost = session.useHostInteractions({ emit, cancel: vi.fn() });
+  const detachToast = attachTerminalResultToast(session, session.interactions, {
+    replayWhenAttached: true,
+  });
+  return {
+    emit,
+    detach() {
+      detachToast();
+      detachHost();
+    },
+  };
+}
 
 function createSnapshots(): StreamSnapshotStore {
   const snapshots = new StreamSnapshotStore();
@@ -61,6 +102,7 @@ function createResumeHarness(): {
 describe('desktop process resume owner', () => {
   beforeEach(() => {
     retrieveSessionResumeData.mockReset();
+    resumeToolUseFromResumeData.mockReset();
     runAgent.mockReset().mockResolvedValue({
       executionId,
       streamId: stream,
@@ -87,7 +129,7 @@ describe('desktop process resume owner', () => {
     }
   });
 
-  it('replays a headless resume failure to the next presentation once', async () => {
+  it('presents one fallback when workflow resume fails before lifecycle startup', async () => {
     retrieveSessionResumeData.mockResolvedValue({
       type: 'workflow',
       agentConfig: config,
@@ -95,29 +137,115 @@ describe('desktop process resume owner', () => {
     });
     runAgent.mockRejectedValue(new Error('launch failed'));
     const harness = createResumeHarness();
+    const presenter = attachResultPresenter(harness.session);
 
     try {
       await expect(harness.owner.tryResumeStream(stream)).resolves.toBe(false);
-      const firstEmit = vi.fn();
-      const detach = harness.session.useHostInteractions({
-        emit: firstEmit,
-        cancel: vi.fn(),
-      });
-      await Promise.resolve();
-      expect(firstEmit).toHaveBeenCalledOnce();
-      expect(firstEmit).toHaveBeenCalledWith('requestShowError', {
+      expect(presenter.emit).toHaveBeenCalledOnce();
+      expect(presenter.emit).toHaveBeenCalledWith('requestShowError', {
         message: 'Resume failed: launch failed',
       });
-
-      detach();
-      const secondEmit = vi.fn();
-      harness.session.useHostInteractions({
-        emit: secondEmit,
-        cancel: vi.fn(),
-      });
-      await Promise.resolve();
-      expect(secondEmit).not.toHaveBeenCalled();
     } finally {
+      presenter.detach();
+      harness.dispose();
+    }
+  });
+
+  it('leaves post-lifecycle workflow failure presentation to the terminal result', async () => {
+    retrieveSessionResumeData.mockResolvedValue({
+      type: 'workflow',
+      agentConfig: config,
+      executionId,
+    });
+    const harness = createResumeHarness();
+    runAgent.mockImplementation(async (_request, options) => {
+      await options.onRun?.({} as never);
+      harness.session.publishRunEvent(
+        stream,
+        failedResult('workflow', 'workflow lifecycle failed'),
+      );
+      throw new Error('workflow lifecycle failed');
+    });
+    const presenter = attachResultPresenter(harness.session);
+
+    try {
+      await expect(harness.owner.tryResumeStream(stream)).resolves.toBe(false);
+      expect(presenter.emit).toHaveBeenCalledOnce();
+      expect(presenter.emit).toHaveBeenCalledWith('requestShowError', {
+        message: 'workflow lifecycle failed',
+      });
+    } finally {
+      presenter.detach();
+      harness.dispose();
+    }
+  });
+
+  it('replays one detached post-lifecycle workflow failure on replacement', async () => {
+    retrieveSessionResumeData.mockResolvedValue({
+      type: 'workflow',
+      agentConfig: config,
+      executionId,
+    });
+    const harness = createResumeHarness();
+    runAgent.mockImplementation(async (_request, options) => {
+      await options.onRun?.({} as never);
+      harness.session.publishRunEvent(
+        stream,
+        failedResult('workflow', 'detached lifecycle failed'),
+      );
+      throw new Error('detached lifecycle failed');
+    });
+    attachResultPresenter(harness.session).detach();
+
+    try {
+      await expect(harness.owner.tryResumeStream(stream)).resolves.toBe(false);
+      const replacement = attachResultPresenter(harness.session);
+      await Promise.resolve();
+      expect(replacement.emit).toHaveBeenCalledOnce();
+      expect(replacement.emit).toHaveBeenCalledWith('requestShowError', {
+        message: 'detached lifecycle failed',
+      });
+      replacement.detach();
+
+      const secondReplacement = attachResultPresenter(harness.session);
+      await Promise.resolve();
+      expect(secondReplacement.emit).not.toHaveBeenCalled();
+      secondReplacement.detach();
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  it('leaves post-lifecycle tool-use failure presentation to the terminal result and restores follow-ups', async () => {
+    retrieveSessionResumeData.mockResolvedValue(
+      createToolUseResumeData({ streamId: stream, executionId }),
+    );
+    const harness = createResumeHarness();
+    harness.session.followUps.acquire(stream);
+    harness.session.followUps.enqueue(stream, { text: 'keep this queued' });
+    resumeToolUseFromResumeData.mockImplementation(
+      async (_resume, _runtimeHost, options) => {
+        await options?.onRun?.({} as never);
+        harness.session.publishRunEvent(
+          stream,
+          failedResult('toolUse', 'tool-use lifecycle failed'),
+        );
+        throw new Error('tool-use lifecycle failed');
+      },
+    );
+    const presenter = attachResultPresenter(harness.session);
+
+    try {
+      await expect(harness.owner.tryResumeStream(stream)).resolves.toBe(false);
+      expect(presenter.emit).toHaveBeenCalledOnce();
+      expect(presenter.emit).toHaveBeenCalledWith('requestShowError', {
+        message: 'tool-use lifecycle failed',
+      });
+      expect(harness.session.followUps.getAll(stream)).toEqual([
+        'keep this queued',
+      ]);
+    } finally {
+      presenter.detach();
       harness.dispose();
     }
   });


### PR DESCRIPTION
## Summary

- Give desktop resume failures a single presentation owner: explicit replayable fallback before lifecycle start, terminal `ResultEvent` afterward.
- Observe successful run completion from bridge construction onward so replacement-window onboarding cannot remain stale during canonical load or restart repair.
- Retain bounded process-owned stdout/stderr tails for active process handles and replay them once across desktop window recreation after live subscriptions attach.
- Share the existing 100,000-character process-output cap without changing the extension renderer's 100k→80k trimming policy.

This lands the final reviewed corrections from #8998 that completed just after that PR auto-merged.

## Net line accounting

- Production: +116 / -16 = **+100**
- Tests: +547 / -17 = **+530**
- Total: +663 / -33 = **+630**

No relocated production code. The production increase is bounded lifecycle state retained for active process handles plus explicit single-owner gates; the test increase is deterministic coverage for detached presentation races and both sides of the subscribe/snapshot boundary.

## Verification

- focused desktop execution, desktop resume, process-output poller, execution-registry, and terminal-toast suite: 129/129
- desktop typecheck
- test-kernel typecheck
- targeted ESLint
- targeted Prettier check
- `git diff --check`
- independent review: no blocking or should-fix findings

No public or persisted format change. No changelog entry is intended.

Closes #9018.
Part of #8868.
Follow-up to #8998 and #8979.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches desktop presentation timing (process output replay, early result observation, resume error routing) where races can cause loss or duplicate UI, though behavior is heavily covered by new tests.
> 
> **Overview**
> Fixes **process-session replay gaps** when the desktop progress window is recreated or canonical state is still loading.
> 
> **Process output:** `ProcessOutputPoller` now keeps **bounded per-process stdout/stderr tails** (shared `PROCESS_OUTPUT_MAX_CHARS`) and exposes them via `getActiveProcessOutputSnapshots()`. After `setupEventListeners()`, `DesktopProgressBridge` **replays retained output once** for still-active children, then continues with live events—without duplicating output across the subscribe/snapshot boundary or resurrecting finished processes.
> 
> **Run completion:** A **completed-root `onResult` listener** is attached at bridge construction (and detached on `dispose`) so `onRunCompleted` fires even while initialization is gated, fixing stale onboarding when a run finishes during canonical load.
> 
> **Resume errors:** Resume paths track **`lifecycleStarted`** so failures **before** lifecycle use one replayable `Resume failed: …` error, while failures **after** lifecycle are left to the **terminal `ResultEvent` / toast** path—avoiding double error UI.
> 
> The extension webview only **centralizes the 100k cap constant**; its 100k→80k trim behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a044266866eaf9eb9467a264cc9d274a4eb7efe0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->