### PR TITLE
feat(cli): show nested subagent ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ All notable changes to this project will be documented in this file.
 
 ### CLI
 
+#### New Features
+
+- **Nested subagents remain visible** — a focused subagent reports how many
+  direct subagents it owns, including completed work that remains available in
+  its child list.
+
 #### Bug Fixes
 
 - **Model failures show their reason** — failed model requests now include a

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -2756,6 +2756,27 @@ const SCENARIOS = [
     ],
   },
   {
+    name: 'focused-subagent-shows-owned-children',
+    frame: 'viewport',
+    cols: 120,
+    rows: 18,
+    env: {
+      HARNESS_ENTRIES: '4',
+      HARNESS_CHILDREN: '1',
+      HARNESS_NESTED_CHILDREN: '1',
+      HARNESS_CAN_INTERRUPT: '1',
+    },
+    bootExpect: 'Tab children',
+    keys: ['\t', DOWN, DOWN, DOWN, '\r'],
+    expect: ['1 subagent', 'localChecker running', 'proof audit running'],
+    unexpect: [
+      'leanSolver',
+      'reviewer',
+      'signal read during notification phase',
+      'ERROR',
+    ],
+  },
+  {
     name: 'subagent-print-full-history',
     frame: 'scrollback',
     cols: 120,

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -21,9 +21,9 @@ import {
 } from '../state/cliState';
 import { chatTuiCanStopVisibleRun } from '../state/sessionRunState';
 import {
-  activeSubagentsFor,
   childStreamEntries as childStreamEntriesSignal,
   parentStream as parentStreamSignal,
+  visibleSubagentRows,
 } from '../state/childExecutions';
 import { useLiveNowMs } from '../state/useLiveNowMs';
 import { COLOR_ERROR } from '../ui/colors';
@@ -160,9 +160,9 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     queuedFollowUpMessages: statusSlice?.queuedFollowUpMessages ?? [],
     usage: statusSlice?.usage,
     roundStage: statusSlice?.roundStage,
-    activeSubagents:
+    subagents:
       target.displayStreamId !== undefined
-        ? activeSubagentsFor(
+        ? visibleSubagentRows(
             target.displayStreamId,
             childStreamEntries,
             streams,

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -87,7 +87,8 @@ export interface StatusBarDisplayInput {
   readonly queuedFollowUpMessages: readonly string[];
   readonly usage: TokenUsageStats | undefined;
   readonly roundStage: RoundStage | undefined;
-  readonly activeSubagents: number;
+  /** Retained and active direct subagents owned by the displayed stream. */
+  readonly subagents: number;
   readonly activeProcesses: number;
   readonly approvalDepth: number;
   readonly approvalKind?: ApprovalQueueStatusKind;
@@ -932,9 +933,10 @@ export function buildStatusBarDisplay(
   const queued = queuedFollowUpsCountSegment(input.queuedFollowUpMessages);
   if (queued) left.push(queued);
 
-  if (input.activeSubagents > 0) {
+  if (input.subagents > 0) {
     left.push({
-      text: `${input.activeSubagents} sub`,
+      text: `${input.subagents} subagent${input.subagents === 1 ? '' : 's'}`,
+      compactText: `${input.subagents} sub`,
       color: 'dim',
       compactPriority: STATUS_BAR_COMPACT_PRIORITY.activeSubagent,
     });

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -69,7 +69,7 @@ function statusInput(
     queuedFollowUpMessages: [],
     usage: undefined,
     roundStage: undefined,
-    activeSubagents: 0,
+    subagents: 0,
     activeProcesses: 0,
     approvalDepth: 0,
     model: 'deepseekT',
@@ -421,7 +421,7 @@ describe('CLI StatusBar display model', () => {
       statusInput({
         status: STREAM_PHASE.RUNNING,
         elapsedMs: 12_000,
-        activeSubagents: 1,
+        subagents: 1,
         childNavigationAvailable: true,
         streamFocusAvailable: true,
         modelAccess: 'included',
@@ -444,7 +444,7 @@ describe('CLI StatusBar display model', () => {
     const display = buildStatusBarDisplay(
       statusInput({
         status: STREAM_PHASE.RUNNING,
-        activeSubagents: 1,
+        subagents: 1,
         childNavigationAvailable: true,
         streamFocusAvailable: true,
         modelAccess: 'included',
@@ -458,6 +458,7 @@ describe('CLI StatusBar display model', () => {
     expect(display.bindings).not.toContain('scroll');
     expect(display.bindings).toContain('Tab children');
     expect(display.bindings).toContain('Ctrl-C stop root');
+    expect(display.left.map(statusBarSegmentText)).toContain('1 subagent');
   });
 
   it('advertises Shift-Enter for newline when the Kitty protocol is active', () => {
@@ -479,7 +480,7 @@ describe('CLI StatusBar display model', () => {
         ],
         usage: { inputTokens: 80_000, outputTokens: 25_000, cost: 0 },
         roundStage: { index: 1 },
-        activeSubagents: 2,
+        subagents: 2,
         activeProcesses: 1,
         approvalDepth: 3,
         childNavigationAvailable: true,
@@ -496,7 +497,7 @@ describe('CLI StatusBar display model', () => {
       'r2',
       '80k/1.0M (8%)',
       'queued 2',
-      '2 sub',
+      '2 subagents',
       '1 proc',
       '3 approvals',
     ]);
@@ -647,7 +648,7 @@ describe('CLI StatusBar display model', () => {
       statusInput({
         status: STREAM_PHASE.RUNNING,
         elapsedMs: 88_000,
-        activeSubagents: 3,
+        subagents: 3,
         activeProcesses: 1,
         childNavigationAvailable: true,
         streamFocusAvailable: true,
@@ -668,7 +669,7 @@ describe('CLI StatusBar display model', () => {
       statusInput({
         status: STREAM_PHASE.RUNNING,
         elapsedMs: 88_000,
-        activeSubagents: 3,
+        subagents: 3,
         activeProcesses: 1,
         childNavigationAvailable: true,
         streamFocusAvailable: true,
@@ -688,7 +689,7 @@ describe('CLI StatusBar display model', () => {
       statusInput({
         status: STREAM_PHASE.RUNNING,
         elapsedMs: 75_000,
-        activeSubagents: 3,
+        subagents: 3,
         activeProcesses: 1,
         childNavigationAvailable: true,
         streamFocusAvailable: true,
@@ -1145,7 +1146,7 @@ describe('CLI StatusBar display model', () => {
     const display = buildStatusBarDisplay(
       statusInput({
         status: STREAM_PHASE.RUNNING,
-        activeSubagents: 2,
+        subagents: 2,
         activeProcesses: 1,
         approvalDepth: 1,
         childNavigationAvailable: true,
@@ -1194,7 +1195,7 @@ describe('CLI StatusBar display model', () => {
     const display = buildStatusBarDisplay(
       statusInput({
         status: STREAM_PHASE.RUNNING,
-        activeSubagents: 3,
+        subagents: 3,
         activeProcesses: 1,
         childNavigationAvailable: true,
         streamFocusAvailable: true,
@@ -1211,7 +1212,7 @@ describe('CLI StatusBar display model', () => {
     const display = buildStatusBarDisplay(
       statusInput({
         status: STREAM_PHASE.RUNNING,
-        activeSubagents: 3,
+        subagents: 3,
         activeProcesses: 1,
         childNavigationAvailable: true,
         streamFocusAvailable: true,


### PR DESCRIPTION
## Summary

- show the focused stream's direct subagent count in the live CLI status line
- retain the count after a child finishes, matching the child list's retained session history
- preserve the compact `N sub` form on narrow terminals
- verify that focusing a subagent re-roots the child list on its own subagents and processes

## Motivation

A focused subagent could own further subagents, but its status line only counted children that were currently active. Once a child finished, the visible cue disappeared even though the child remained available through `Tab children`. This made nested orchestration appear flat or empty.

The status projection now derives its count from the same visible child rows as the child list. The existing child-list interaction remains the single detailed presentation surface; no new panel or state store is introduced.

## Validation

- `corepack pnpm --filter @texra-ai/cli validate:tui focused-subagent-shows-owned-children`
- `npx vitest run src/test-kernel/cli/StatusBar.vitest.mts src/test-kernel/cli/TuiStateAndFocus.vitest.mts` (191 tests passed)
- `npm run compile:fast`
- `npm run typecheck`
- `npm run lint` (no errors; one unrelated pre-existing warning)
- `npm test` (6,970 passed, 4 skipped; two pre-existing `RunChatSignalOwnership` timeouts reproduce on detached `origin/main`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only projection change in the CLI status bar and display tests; no auth, persistence, or execution logic changes.
> 
> **Overview**
> The CLI status bar **subagent count** now follows the same **visible child rows** as **Tab children**, so a focused parent (including a nested subagent) still shows how many **direct subagents** it owns after they finish, not only while they are actively running.
> 
> The count field is renamed from `activeSubagents` to **`subagents`**, and the label uses **`N subagent` / `N subagents`** on wide footers while keeping the compact **`N sub`** form when space is tight. A TUI harness scenario verifies that focusing a subagent shows its own child count and child list without surfacing the parent’s siblings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ebc9508fc270ec73a1d24e9c20224096110b756. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->