### PR TITLE
fix: render display math beside prose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Display equations render next to surrounding text** — bracketed and
+  dollar-delimited display mathematics no longer require blank lines before or
+  after the equation in agent responses.
 - **Kimi K3 stays easy to find when its route changes** — the model remains
   under Moonshot while showing whether requests use Moonshot, Kimi Code, or
   OpenRouter.

--- a/src/shared/markdown/texmathPlugin.ts
+++ b/src/shared/markdown/texmathPlugin.ts
@@ -16,12 +16,12 @@ export interface TexmathPluginOptions {
   readonly engineOptions?: Record<string, unknown>;
 }
 
-const PARAGRAPH_INTERRUPTION_CHAINS = [
+const PARAGRAPH_INTERRUPTION_CHAINS = Object.freeze([
   'paragraph',
   'reference',
   'blockquote',
   'list',
-];
+]);
 
 /** Allow configured display-math rules to interrupt an adjacent paragraph. */
 function addDisplayMathParagraphInterruptions(

--- a/src/shared/markdown/texmathPlugin.ts
+++ b/src/shared/markdown/texmathPlugin.ts
@@ -16,21 +16,32 @@ export interface TexmathPluginOptions {
   readonly engineOptions?: Record<string, unknown>;
 }
 
-// `markdown-it-texmath` only defines `\[...\]` as a *block* rule out of the
-// box; we want it inline too so the renderer is consistent across hosts.
-// `texmath.rules.brackets.inline` is process-global, so guard with an
-// idempotency flag.
-let inlineRuleInstalled = false;
-function ensureInlineDisplayRule(): void {
-  if (inlineRuleInstalled) return;
-  texmath.rules.brackets.inline.push({
-    name: 'math_inline_display',
-    rex: /\\\[([\s\S]+?)\\\]/gy,
-    tmpl: '<section><eqn>$1</eqn></section>',
-    tag: '\\[',
-    displayMode: true,
-  });
-  inlineRuleInstalled = true;
+const PARAGRAPH_INTERRUPTION_CHAINS = [
+  'paragraph',
+  'reference',
+  'blockquote',
+  'list',
+];
+
+/** Allow configured display-math rules to interrupt an adjacent paragraph. */
+function addDisplayMathParagraphInterruptions(
+  md: MarkdownItInstance,
+  delimiters: ReadonlyArray<string>,
+): void {
+  const blockRules = [
+    ...(delimiters.includes('dollars') ? texmath.rules.dollars.block : []),
+    ...(delimiters.includes('brackets') ? texmath.rules.brackets.block : []),
+    ...(delimiters.includes('beg_end') ? texmath.rules.beg_end.block : []),
+  ];
+
+  for (const [index, rule] of blockRules.entries()) {
+    md.block.ruler.before(
+      'paragraph',
+      `texmath_block_interrupt_${index}`,
+      texmath.block(rule),
+      { alt: PARAGRAPH_INTERRUPTION_CHAINS },
+    );
+  }
 }
 
 /**
@@ -40,12 +51,15 @@ function ensureInlineDisplayRule(): void {
 export function createTexmathPlugin(
   options: TexmathPluginOptions,
 ): (md: MarkdownItInstance) => MarkdownItInstance {
-  ensureInlineDisplayRule();
+  const delimiters = options.delimiters ?? ['dollars', 'brackets', 'beg_end'];
   type TexmathFn = Parameters<MarkdownItInstance['use']>[0];
-  return (md) =>
-    md.use(texmath as unknown as TexmathFn, {
+  return (md) => {
+    const configured = md.use(texmath as unknown as TexmathFn, {
       engine: options.engine,
-      delimiters: options.delimiters ?? ['dollars', 'brackets', 'beg_end'],
+      delimiters,
       katexOptions: options.engineOptions,
     });
+    addDisplayMathParagraphInterruptions(configured, delimiters);
+    return configured;
+  };
 }

--- a/src/test-kernel/progressView/MarkdownRendererSecurity.vitest.mts
+++ b/src/test-kernel/progressView/MarkdownRendererSecurity.vitest.mts
@@ -53,6 +53,89 @@ describe('processMarkdownContent renders math and code', () => {
     expect(doc.querySelector('.katex')).not.toBeNull();
   });
 
+  it.each([
+    {
+      context: 'prose',
+      markdown: [
+        'The coefficient is',
+        '\\[',
+        'c_{\\alpha\\beta}^{\\gamma}(L)=\\operatorname{Tr}(\\chi^L).',
+        '\\]',
+        'The next paragraph follows.',
+      ].join('\n'),
+    },
+    {
+      context: 'a heading',
+      markdown: [
+        '### Exact criterion',
+        '\\[',
+        'c_{\\alpha\\beta}^{\\gamma}(L)=\\operatorname{Tr}(\\chi^L).',
+        '\\]',
+        'The next paragraph follows.',
+      ].join('\n'),
+    },
+    {
+      context: 'a list item',
+      markdown: [
+        '- The coefficient is',
+        '  \\[',
+        '  c_{\\alpha\\beta}^{\\gamma}(L)=\\operatorname{Tr}(\\chi^L).',
+        '  \\]',
+        '  The next paragraph follows.',
+      ].join('\n'),
+    },
+    {
+      context: 'a block quotation',
+      markdown: [
+        '> The coefficient is',
+        '> \\[',
+        '> c_{\\alpha\\beta}^{\\gamma}(L)=\\operatorname{Tr}(\\chi^L).',
+        '> \\]',
+        '> The next paragraph follows.',
+      ].join('\n'),
+    },
+  ])(
+    'renders bracketed display math immediately after $context',
+    ({ markdown }) => {
+      const doc = renderToDocument(markdown);
+      const displayMath = doc.querySelector('.katex-display');
+
+      expect(displayMath).not.toBeNull();
+      expect(displayMath?.querySelector('annotation')?.textContent).toContain(
+        'c_{\\alpha\\beta}^{\\gamma}(L)',
+      );
+      expect(doc.body.textContent).not.toContain('\\[');
+      expect(doc.body.textContent).not.toContain('\\]');
+    },
+  );
+
+  it('keeps adjacent prose in separate paragraphs around display math', () => {
+    const rendered = processMarkdownContent(
+      ['Before', '\\[', 'x^2', '\\]', 'After'].join('\n'),
+    );
+
+    expect(rendered).toMatch(/^<p>Before<\/p>\n<section>/);
+    expect(rendered).toMatch(/<\/section><p>After<\/p>\n$/);
+  });
+
+  it('renders dollar display math immediately after prose', () => {
+    const doc = renderToDocument(
+      ['The coefficient is', '$$c(L)=1+\\lambda^L$$', 'Exactly.'].join('\n'),
+    );
+
+    expect(doc.querySelector('.katex-display')).not.toBeNull();
+    expect(doc.body.textContent).not.toContain('$$');
+  });
+
+  it('leaves display-math delimiters literal inside fenced code', () => {
+    const doc = renderToDocument(
+      ['```tex', '\\[', 'x^2', '\\]', '```'].join('\n'),
+    );
+
+    expect(doc.querySelector('.katex')).toBeNull();
+    expect(doc.querySelector('code')?.textContent).toContain('\\[\nx^2\n\\]');
+  });
+
   it('syntax-highlights a fenced code block instead of leaving it plain', () => {
     const doc = renderToDocument(
       [

--- a/src/types/ambient.d.ts
+++ b/src/types/ambient.d.ts
@@ -88,7 +88,7 @@ declare module 'markdown-it/lib/index.mjs' {
           beforeName: string,
           ruleName: string,
           rule: MarkdownItBlockRule,
-          options?: { alt?: string[] },
+          options?: { alt?: readonly string[] },
         ): void;
       };
     };

--- a/src/types/ambient.d.ts
+++ b/src/types/ambient.d.ts
@@ -82,6 +82,16 @@ declare module 'markdown-it/lib/index.mjs' {
 
   class MarkdownIt {
     constructor(options?: Record<string, unknown>);
+    block: {
+      ruler: {
+        before(
+          beforeName: string,
+          ruleName: string,
+          rule: MarkdownItBlockRule,
+          options?: { alt?: string[] },
+        ): void;
+      };
+    };
     renderer: {
       rules: Record<string, RenderRule | undefined>;
       render(tokens: unknown[], options: unknown, env: unknown): string;
@@ -94,6 +104,13 @@ declare module 'markdown-it/lib/index.mjs' {
   }
 
   export default MarkdownIt;
+
+  type MarkdownItBlockRule = (
+    state: unknown,
+    startLine: number,
+    endLine: number,
+    silent: boolean,
+  ) => boolean;
 }
 
 declare module 'markdown-it/lib/renderer.mjs' {
@@ -139,8 +156,16 @@ declare module 'markdown-it-texmath' {
   }
 
   interface Texmath {
+    block: (rule: TexmathRule) => MarkdownItBlockRule;
     rules: TexmathRules;
   }
+
+  type MarkdownItBlockRule = (
+    state: unknown,
+    startLine: number,
+    endLine: number,
+    silent: boolean,
+  ) => boolean;
 
   const texmath: Texmath;
   export = texmath;


### PR DESCRIPTION
## Summary

- register configured display-math rules as Markdown paragraph terminators
- remove the process-global inline display-math workaround
- cover bracketed and dollar-delimited equations next to prose, headings, lists, and block quotations
- preserve literal math delimiters inside fenced code

## Root cause

`markdown-it-texmath` registers display equations as block rules, but those rules do not participate in MarkdownIt's paragraph-termination chains. A display equation immediately following prose is therefore absorbed into the paragraph before the math block parser can see it. The previous workaround parsed bracketed display mathematics inline, which could emit a block `<section>` inside a paragraph.

The new rule reuses the package's own configured block recognizers as paragraph terminators. The existing block renderer then handles the equation without invalid block-inside-inline markup.

## User impact

Agent responses no longer need blank lines around standalone `\[...\]` or `$$...$$` equations in the progress view. Exported HTML uses proper block boundaries around surrounding prose.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (passes with one pre-existing warning in `AgentCreatorToolCatalogParity.vitest.mts`)
- `corepack pnpm exec vitest run src/test-kernel/progressView/MarkdownRendererSecurity.vitest.mts` — 12 tests passed
- `npm test` — 735 test files passed; 10 unrelated timeout-sensitive files failed under full-suite load. Nine passed when rerun serially. `RunChatSignalOwnership.vitest.mts` continued to time out independently of this renderer-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to shared markdown/texmath plugin and progress-view rendering; behavior is covered by new vitest cases and does not touch auth, persistence, or agent execution.
> 
> **Overview**
> **Display math no longer needs blank lines** around `\[...\]` or `$$...$$` in agent markdown. Bracketed and dollar display equations render as KaTeX blocks when they sit directly after prose, headings, list items, or blockquotes.
> 
> The fix **replaces a global inline `\[...\]` workaround** with paragraph-interruption rules: after `markdown-it-texmath` installs, each configured display-math block rule is registered on MarkdownIt’s block ruler so it can **terminate an in-progress paragraph** (and related chains). The normal block math renderer then runs, so surrounding text stays in separate `<p>` elements instead of swallowing the delimiters or nesting invalid block markup inside a paragraph.
> 
> **Tests** cover adjacent prose, headings, lists, blockquotes, dollar display math, HTML structure around equations, and unchanged literal delimiters inside fenced code. **Ambient types** add `block.ruler.before` and `texmath.block` for the new wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5377c74db8e782f9b44bacaff5d2a587b646fce7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->