### PR TITLE
fix: retry raw fetch transport failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [0.39.8] - Unreleased
 
+### Shared (all surfaces)
+
+#### Bug Fixes
+
+- **Brief network interruptions no longer stop model turns immediately** —
+  requests retry automatically when a transport failure escapes the provider
+  client.
+
 ### Extension (VS Code)
 
 #### Bug Fixes

--- a/src/common/errors/sdkError/errorMetadata.ts
+++ b/src/common/errors/sdkError/errorMetadata.ts
@@ -79,11 +79,21 @@ export function attachFlowAutoRetryRequired(err: unknown): void {
   flowAutoRetryRequiredMetadata.attach(err, true);
 }
 
+/** Raw fetch failures have escaped the provider SDK's retry wrapper. Match
+ *  only the outer error: an SDK connection error may carry the same TypeError
+ *  as its cause after already exhausting the provider-managed retries. */
+function isRawFetchFailure(err: unknown): boolean {
+  return (
+    err instanceof TypeError &&
+    /^(?:fetch failed|failed to fetch)$/i.test(err.message.trim())
+  );
+}
+
 export function requiresFlowAutoRetry(err: unknown): boolean {
   return (
     findInCauseChain(err, (current) =>
       flowAutoRetryRequiredMetadata.detect(current) === true ? true : undefined,
-    ) ?? false
+    ) !== undefined || isRawFetchFailure(err)
   );
 }
 

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -274,6 +274,31 @@ describe('RetryState', () => {
     expect(node.shouldAutoRetry(streamError)).toBe(true);
   });
 
+  it('keeps flow-level auto-retry for a raw undici fetch failure', () => {
+    const node = createModelInvocationNode({
+      isAutoRetryManagedByProvider: () => true,
+    });
+    const transportError = Object.assign(
+      new Error('HTTP/2: "stream timeout after 300000"'),
+      { code: 'UND_ERR_INFO', name: 'InformationalError' },
+    );
+    const fetchError = new TypeError('fetch failed', {
+      cause: transportError,
+    });
+
+    expect(node.shouldAutoRetry(fetchError)).toBe(true);
+  });
+
+  it('does not duplicate provider retries for a wrapped fetch failure', () => {
+    const node = createModelInvocationNode({
+      isAutoRetryManagedByProvider: () => true,
+    });
+    const fetchError = new TypeError('fetch failed');
+    const sdkError = new Error('Connection error', { cause: fetchError });
+
+    expect(node.shouldAutoRetry(sdkError)).toBe(false);
+  });
+
   it('keeps flow-level auto-retry when the handler predicate excludes an error', () => {
     const node = createModelInvocationNode({
       isAutoRetryManagedByProvider: () => false,


### PR DESCRIPTION
## Summary

- route raw `fetch failed` transport errors through TeXRA’s existing bounded flow retry
- keep SDK-wrapped connection errors provider-owned so retries are not duplicated
- cover the observed undici HTTP/2 `UND_ERR_INFO` timeout shape

## Design

OpenAI and Anthropic handlers normally defer transient retries to their SDKs. A top-level `TypeError: fetch failed`, however, has escaped that SDK retry wrapper. The retry-ownership check now recognizes only that outer raw fetch shape; it deliberately does not search the cause chain, because an SDK error may retain the same TypeError after already exhausting its own retries.

No HTTP/2 client, dispatcher, or timeout setting is added. The observed stack originates in Node 26’s built-in undici transport, and lengthening its five-minute stream timeout would delay recovery.

## Validation

- `npm test -- --run src/test-kernel/agent/runtime/RetryState.vitest.ts` (17 passed)
- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint`

Closes #9014

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes retry eligibility for live model requests across all surfaces; logic is narrow (message-matched TypeError on the outer error only) and regression-tested, but misclassification could still affect retry storms or missed recovery.
> 
> **Overview**
> Brief network blips that surface as a top-level **`TypeError: fetch failed`** (including undici HTTP/2 stream timeouts) now qualify for TeXRA’s **bounded flow-level auto-retry**, even when the model handler normally defers retries to the provider SDK.
> 
> **`requiresFlowAutoRetry`** recognizes only that **outer** fetch shape—**not** the same `TypeError` buried under an SDK “Connection error” after provider retries are exhausted—so retries are not doubled. Changelog documents the shared-surface fix; **`RetryState`** tests cover the undici timeout case and the wrapped-failure guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 848785af8fd1352ac4c11d6ce90194d243c0346b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->