### PR TITLE
feat(desktop): reflect session activity in window title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ All notable changes to this project will be documented in this file.
 - **Model failures show their reason** — failed model requests now include a
   concise provider message and are no longer labeled as tool failures.
 
+### Desktop
+
+#### New Features
+
+- **Window titles show session activity** — desktop windows indicate when
+  agents are running or waiting for approval, including after a macOS reopen.
+
 ## [0.39.7] - 2026-07-20
 
 ### Shared (all surfaces)

--- a/packages/cli/src/chat/tui/terminalTitle.ts
+++ b/packages/cli/src/chat/tui/terminalTitle.ts
@@ -1,6 +1,10 @@
 import { writeSync } from 'node:fs';
 import { basename } from 'node:path';
 
+import {
+  formatSessionTitle,
+  type SessionTitleState,
+} from '@shared/sessionTitle';
 import { isActivePhase } from '@shared/streams/streamStatus';
 import { sanitizePathSegment } from '@utils/text/sanitizePathSegment';
 
@@ -18,21 +22,16 @@ import { terminalCapabilities } from './state/terminalCapabilities';
 // eslint-disable-next-line no-control-regex -- stripping C0/C1 controls
 const TITLE_INVALID_CHARS = /[\x00-\x1f\x7f-\x9f]/g;
 
-type TerminalTitleState = 'idle' | 'running' | 'approval';
-
 /** Project-aware terminal title, optionally annotated with live TUI state. */
 export function terminalTitleText(
   cwd: string,
-  state: TerminalTitleState = 'idle',
+  state: SessionTitleState = 'idle',
 ): string {
   const project = sanitizePathSegment(basename(cwd), {
     invalidCharPattern: TITLE_INVALID_CHARS,
     replacement: '',
   });
-  let activity: string | undefined;
-  if (state === 'approval') activity = 'Approval needed';
-  if (state === 'running') activity = 'Running';
-  return ['TeXRA', activity, project].filter(Boolean).join(' — ');
+  return formatSessionTitle(project, state);
 }
 
 /** Write the title only when terminal capability discovery admitted OSC. */
@@ -45,7 +44,7 @@ function writeTerminalTitle(title: string): void {
   }
 }
 
-function currentTerminalTitleState(): TerminalTitleState {
+function currentTerminalTitleState(): SessionTitleState {
   if (approvalQueueStatus.get().depth > 0) return 'approval';
   const streamSlices = streams.get();
   const rootStreamId = rootRunStreamId.get();

--- a/packages/desktop/src/main/desktopWindowTitle.ts
+++ b/packages/desktop/src/main/desktopWindowTitle.ts
@@ -1,3 +1,4 @@
+// Node imports
 import { basename } from 'node:path';
 
 // Local imports
@@ -6,11 +7,15 @@ import type { SessionHostInteractions } from '@agent/runtime/HostInteractions';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import { STREAM_PHASE } from '@shared/schemas';
+import {
+  formatSessionTitle,
+  type SessionTitleState,
+} from '@shared/sessionTitle';
 
 // Third-party type imports
 import type { BrowserWindow } from 'electron';
 
-export type DesktopSessionActivity = 'approval' | 'running' | 'idle';
+export type DesktopSessionActivity = SessionTitleState;
 
 type DesktopTitleSession = Pick<
   SessionHandle,
@@ -38,29 +43,13 @@ export function getDesktopSessionActivity(session: {
   return hasRunningAgent ? 'running' : 'idle';
 }
 
-/** Format the exact native title copy for one process session. */
-export function formatDesktopWindowTitle(
-  activity: DesktopSessionActivity,
-  workspaceName?: string,
-): string {
-  let activitySegment: string | undefined;
-  if (activity === 'approval') activitySegment = 'Approval needed';
-  if (activity === 'running') activitySegment = 'Running';
-  return ['TeXRA', activitySegment, workspaceName || undefined]
-    .filter((segment): segment is string => segment !== undefined)
-    .join(' — ');
-}
-
 /** Compute the current title synchronously, including before a window opens. */
 export function getDesktopWindowTitle(
   session: DesktopTitleSession,
   workspacePath: string | undefined,
 ): string {
   const workspaceName = workspacePath ? basename(workspacePath) : undefined;
-  return formatDesktopWindowTitle(
-    getDesktopSessionActivity(session),
-    workspaceName,
-  );
+  return formatSessionTitle(workspaceName, getDesktopSessionActivity(session));
 }
 
 /**

--- a/packages/desktop/src/main/desktopWindowTitle.ts
+++ b/packages/desktop/src/main/desktopWindowTitle.ts
@@ -1,6 +1,9 @@
 // Node imports
 import { basename } from 'node:path';
 
+// Third-party imports
+import { type BrowserWindow } from 'electron';
+
 // Local imports
 import type { ExecutionRegistry } from '@agent/runtime/executionRegistry';
 import type { SessionHostInteractions } from '@agent/runtime/HostInteractions';
@@ -11,9 +14,6 @@ import {
   formatSessionTitle,
   type SessionTitleState,
 } from '@shared/sessionTitle';
-
-// Third-party type imports
-import type { BrowserWindow } from 'electron';
 
 export type DesktopSessionActivity = SessionTitleState;
 
@@ -88,9 +88,11 @@ export function installDesktopWindowTitle(
     disposePending();
     disposeStatus();
     disposeRegistrations();
-    window.webContents.removeListener(
-      'page-title-updated',
-      preventRendererTitle,
-    );
+    if (!window.webContents.isDestroyed()) {
+      window.webContents.removeListener(
+        'page-title-updated',
+        preventRendererTitle,
+      );
+    }
   };
 }

--- a/packages/desktop/src/main/desktopWindowTitle.ts
+++ b/packages/desktop/src/main/desktopWindowTitle.ts
@@ -1,0 +1,107 @@
+import { basename } from 'node:path';
+
+// Local imports
+import type { ExecutionRegistry } from '@agent/runtime/executionRegistry';
+import type { SessionHostInteractions } from '@agent/runtime/HostInteractions';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
+import type { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
+import { STREAM_PHASE } from '@shared/schemas';
+
+// Third-party type imports
+import type { BrowserWindow } from 'electron';
+
+export type DesktopSessionActivity = 'approval' | 'running' | 'idle';
+
+type DesktopTitleSession = Pick<
+  SessionHandle,
+  'executions' | 'interactions' | 'status'
+>;
+
+type DesktopTitleWindow = Pick<
+  BrowserWindow,
+  'getTitle' | 'setTitle' | 'webContents'
+>;
+
+/** Derive aggregate activity from canonical process-session owners. */
+export function getDesktopSessionActivity(session: {
+  readonly executions: Pick<ExecutionRegistry, 'getAgentHandles'>;
+  readonly interactions: Pick<SessionHostInteractions, 'pendingCount'>;
+  readonly status: Pick<StreamStatusMachine, 'get'>;
+}): DesktopSessionActivity {
+  if (session.interactions.pendingCount > 0) return 'approval';
+  const hasRunningAgent = session.executions
+    .getAgentHandles()
+    .some(
+      (handle) =>
+        session.status.get(handle.childStreamId) === STREAM_PHASE.RUNNING,
+    );
+  return hasRunningAgent ? 'running' : 'idle';
+}
+
+/** Format the exact native title copy for one process session. */
+export function formatDesktopWindowTitle(
+  activity: DesktopSessionActivity,
+  workspaceName?: string,
+): string {
+  let activitySegment: string | undefined;
+  if (activity === 'approval') activitySegment = 'Approval needed';
+  if (activity === 'running') activitySegment = 'Running';
+  return ['TeXRA', activitySegment, workspaceName || undefined]
+    .filter((segment): segment is string => segment !== undefined)
+    .join(' — ');
+}
+
+/** Compute the current title synchronously, including before a window opens. */
+export function getDesktopWindowTitle(
+  session: DesktopTitleSession,
+  workspacePath: string | undefined,
+): string {
+  const workspaceName = workspacePath ? basename(workspacePath) : undefined;
+  return formatDesktopWindowTitle(
+    getDesktopSessionActivity(session),
+    workspaceName,
+  );
+}
+
+/**
+ * Keep one BrowserWindow title synchronized with its process session.
+ * Renderer page titles are presentation content and cannot replace this
+ * host-owned projection.
+ */
+export function installDesktopWindowTitle(
+  window: DesktopTitleWindow,
+  session: DesktopTitleSession,
+  workspacePath: string | undefined,
+): () => void {
+  let currentTitle = window.getTitle();
+  let disposed = false;
+  const update = (): void => {
+    if (disposed) return;
+    const title = getDesktopWindowTitle(session, workspacePath);
+    if (title === currentTitle) return;
+    currentTitle = title;
+    window.setTitle(title);
+  };
+  const preventRendererTitle = (event: { preventDefault(): void }): void => {
+    event.preventDefault();
+  };
+
+  window.webContents.on('page-title-updated', preventRendererTitle);
+  const disposeRegistrations =
+    session.executions.addRegistrationListener(update);
+  const disposeStatus = session.status.onDidChange(update);
+  const disposePending = session.interactions.onPendingCountChange(update);
+  update();
+
+  return () => {
+    if (disposed) return;
+    disposed = true;
+    disposePending();
+    disposeStatus();
+    disposeRegistrations();
+    window.webContents.removeListener(
+      'page-title-updated',
+      preventRendererTitle,
+    );
+  };
+}

--- a/packages/desktop/src/main/desktopWindowTitle.ts
+++ b/packages/desktop/src/main/desktopWindowTitle.ts
@@ -15,7 +15,7 @@ import {
   type SessionTitleState,
 } from '@shared/sessionTitle';
 
-export type DesktopSessionActivity = SessionTitleState;
+type DesktopSessionActivity = SessionTitleState;
 
 type DesktopTitleSession = Pick<
   SessionHandle,

--- a/packages/desktop/src/main/desktopWindowTitle.ts
+++ b/packages/desktop/src/main/desktopWindowTitle.ts
@@ -24,7 +24,7 @@ type DesktopTitleSession = Pick<
 
 type DesktopTitleWindow = Pick<
   BrowserWindow,
-  'getTitle' | 'setTitle' | 'webContents'
+  'getTitle' | 'isDestroyed' | 'setTitle' | 'webContents'
 >;
 
 /** Derive aggregate activity from canonical process-session owners. */
@@ -34,12 +34,12 @@ export function getDesktopSessionActivity(session: {
   readonly status: Pick<StreamStatusMachine, 'get'>;
 }): DesktopSessionActivity {
   if (session.interactions.pendingCount > 0) return 'approval';
-  const hasRunningAgent = session.executions
-    .getAgentHandles()
-    .some(
-      (handle) =>
-        session.status.get(handle.childStreamId) === STREAM_PHASE.RUNNING,
-    );
+  const hasRunningAgent = session.executions.getAgentHandles().some(
+    (handle) =>
+      // Deliberately exact: provisional/restored and WAITING-like phases
+      // must not project a running native title.
+      session.status.get(handle.childStreamId) === STREAM_PHASE.RUNNING,
+  );
   return hasRunningAgent ? 'running' : 'idle';
 }
 
@@ -65,7 +65,7 @@ export function installDesktopWindowTitle(
   let currentTitle = window.getTitle();
   let disposed = false;
   const update = (): void => {
-    if (disposed) return;
+    if (disposed || window.isDestroyed()) return;
     const title = getDesktopWindowTitle(session, workspacePath);
     if (title === currentTitle) return;
     currentTitle = title;

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -95,6 +95,10 @@ import {
 } from './desktopSetupTerminal.js';
 import { createDesktopTerminalRunner } from './desktopTerminalRunner.js';
 import {
+  getDesktopWindowTitle,
+  installDesktopWindowTitle,
+} from './desktopWindowTitle.js';
+import {
   initializeDesktopSetupAuth,
   registerDesktopSetupSignIn,
 } from './desktopSetupAuth.js';
@@ -320,12 +324,16 @@ function createWindow(options: {
   /** See ElectronPlatformInitResult.resourcesPath. */
   resourcesPath: string;
 }): void {
+  const initialWindowTitle = getDesktopWindowTitle(
+    options.processSession,
+    options.workspacePath,
+  );
   const window = new BrowserWindow({
     width: 960,
     height: 680,
     minWidth: 720,
     minHeight: 520,
-    title: 'TeXRA',
+    title: initialWindowTitle,
     webPreferences: {
       preload: join(desktopMainDir, '../preload/index.cjs'),
       contextIsolation: true,
@@ -342,6 +350,11 @@ function createWindow(options: {
     },
   });
   mainWindow = window;
+  const disposeWindowTitle = installDesktopWindowTitle(
+    window,
+    options.processSession,
+    options.workspacePath,
+  );
   const reportAsyncError = (error: unknown) => console.error(error);
   installDesktopNavigationPolicy(window.webContents, {
     onAsyncError: reportAsyncError,
@@ -1142,6 +1155,7 @@ function createWindow(options: {
   );
   window.once('closed', () => {
     windowClosed = true;
+    disposeWindowTitle();
     presentationAbort.abort();
     executionsWatcher?.close();
     if (mainWindow === window) {

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -356,11 +356,24 @@ export class SessionHostInteractions
 {
   private readonly attachments: HostInteractionAttachment[] = [];
   private readonly pending = new Set<PendingSessionInteraction>();
+  private readonly pendingCountListeners = new Set<(count: number) => void>();
   private readonly pendingPresentationReplays: Array<
     (interactions: HostInteractions) => Promise<void> | void
   > = [];
   private attachmentVersion = 0;
   private disposed = false;
+
+  /** Number of response-bearing requests awaiting a host decision. */
+  get pendingCount(): number {
+    return this.pending.size;
+  }
+
+  /** Observe transitions between no pending requests and at least one. */
+  onPendingCountChange(listener: (count: number) => void): () => void {
+    if (this.disposed) return () => {};
+    this.pendingCountListeners.add(listener);
+    return () => this.pendingCountListeners.delete(listener);
+  }
 
   use(interactions: HostInteractions): () => void {
     if (this.disposed) {
@@ -520,7 +533,7 @@ export class SessionHostInteractions
 
     const settleFallbacks = (): void => {
       for (const pending of matching) {
-        if (!this.pending.delete(pending)) continue;
+        if (!this.deletePending(pending)) continue;
         pending.settle(pending.cancellationResult(selector.cause));
       }
     };
@@ -554,6 +567,7 @@ export class SessionHostInteractions
     }
     this.attachments.length = 0;
     this.pendingPresentationReplays.length = 0;
+    this.pendingCountListeners.clear();
     if (firstError !== undefined) throw firstError;
   }
 
@@ -582,6 +596,7 @@ export class SessionHostInteractions
         cancellationRequested: false,
       };
       this.pending.add(pending);
+      if (this.pending.size === 1) this.notifyPendingCountChange();
       this.dispatch(pending);
     });
   }
@@ -632,14 +647,14 @@ export class SessionHostInteractions
       return;
     }
     if (!result) {
-      this.pending.delete(pending);
+      this.deletePending(pending);
       pending.settle(pending.cancellationResult());
       return;
     }
     void result.then(
       (value) => {
         if (!this.isCurrentDispatch(pending, attachment, version)) return;
-        this.pending.delete(pending);
+        this.deletePending(pending);
         pending.settle(value);
       },
       (error: unknown) => {
@@ -655,8 +670,20 @@ export class SessionHostInteractions
     error: unknown,
   ): void {
     if (!this.isCurrentDispatch(pending, attachment, version)) return;
-    this.pending.delete(pending);
+    this.deletePending(pending);
     pending.reject(error);
+  }
+
+  private deletePending(pending: PendingSessionInteraction): boolean {
+    if (!this.pending.delete(pending)) return false;
+    if (this.pending.size === 0) this.notifyPendingCountChange();
+    return true;
+  }
+
+  private notifyPendingCountChange(): void {
+    for (const listener of this.pendingCountListeners) {
+      listener(this.pending.size);
+    }
   }
 
   private isCurrentDispatch(

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -690,7 +690,11 @@ export class SessionHostInteractions
 
   private notifyPendingCountChange(): void {
     for (const listener of this.pendingCountListeners) {
-      listener(this.pending.size);
+      try {
+        listener(this.pending.size);
+      } catch (error) {
+        logger.warn('Pending interaction observer failed', { data: error });
+      }
     }
   }
 

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -549,11 +549,19 @@ export class SessionHostInteractions
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
+    const cancellationCause = 'Session disposed.';
     let firstError: unknown;
     try {
-      this.cancel({ cause: 'Session disposed.' });
+      this.cancel({ cause: cancellationCause });
     } catch (error) {
       firstError = error;
+    }
+    // An attached adapter makes cancel's fallback asynchronous so that its
+    // own settlement can win. Session disposal is terminal, however: settle
+    // any requests still owned here before observers are removed.
+    for (const pending of [...this.pending]) {
+      if (!this.deletePending(pending)) continue;
+      pending.settle(pending.cancellationResult(cancellationCause));
     }
     this.attachmentVersion += 1;
     for (const attachment of this.attachments.toReversed()) {

--- a/src/shared/sessionTitle.ts
+++ b/src/shared/sessionTitle.ts
@@ -1,0 +1,14 @@
+export type SessionTitleState = 'idle' | 'running' | 'approval';
+
+/** Format the product title shared by native windows and terminal tabs. */
+export function formatSessionTitle(
+  project: string | undefined,
+  state: SessionTitleState = 'idle',
+): string {
+  let activity: string | undefined;
+  if (state === 'approval') activity = 'Approval needed';
+  if (state === 'running') activity = 'Running';
+  return ['TeXRA', activity, project || undefined]
+    .filter((segment): segment is string => segment !== undefined)
+    .join(' — ');
+}

--- a/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
@@ -730,6 +730,27 @@ describe('session.interactions request bookkeeping (coordinator fold)', () => {
     expect(pendingCounts).toEqual([1, 0]);
   });
 
+  it('does not let a pending observer interrupt request cleanup', async () => {
+    const session = createTestSession();
+    session.interactions.onPendingCountChange(() => {
+      throw new Error('title projection failed');
+    });
+    const pending = session.interactions.requestPlanApproval({
+      approvalId: 'approval:throwing-observer',
+      streamId,
+      plan,
+      goalEnabled: false,
+    });
+
+    expect(session.interactions.pendingCount).toBe(1);
+    session.dispose();
+
+    await expect(pending).resolves.toEqual({
+      action: 'reject',
+      feedback: 'Session disposed.',
+    });
+  });
+
   it('resolves a plan approval first-wins through the session slot', async () => {
     const { session, uiEvents, emitted, interactions } = createPortSession();
     try {

--- a/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
@@ -503,6 +503,10 @@ describe('session.interactions request bookkeeping (coordinator fold)', () => {
     const session = createTestSession();
     const first = createControllablePlanAdapter();
     const second = createControllablePlanAdapter();
+    const pendingCounts: number[] = [];
+    session.interactions.onPendingCountChange((count) =>
+      pendingCounts.push(count),
+    );
     try {
       const detach = session.useHostInteractions(first.interactions);
       const pending = session.interactions.requestPlanApproval({
@@ -514,6 +518,7 @@ describe('session.interactions request bookkeeping (coordinator fold)', () => {
       detach();
       await Promise.resolve();
       expect(first.dispose).toHaveBeenCalledOnce();
+      expect(pendingCounts).toEqual([1]);
 
       session.useHostInteractions(second.interactions);
       expect(second.requests).toHaveLength(1);
@@ -521,9 +526,79 @@ describe('session.interactions request bookkeeping (coordinator fold)', () => {
         true,
       );
       await expect(pending).resolves.toEqual({ action: 'approve' });
+      expect(pendingCounts).toEqual([1, 0]);
     } finally {
       session.dispose();
     }
+  });
+
+  it('observes every response-bearing request until cancellation', async () => {
+    const session = createTestSession();
+    const pendingCounts: number[] = [];
+    const stopObserving = session.interactions.onPendingCountChange((count) =>
+      pendingCounts.push(count),
+    );
+    const requests = [
+      session.interactions.requestToolEditApproval({
+        path: 'paper.tex',
+        originalContent: 'old',
+        proposedContent: 'new',
+        sourceTool: 'edit_file',
+        streamId,
+      }),
+      session.interactions.requestBashApproval({
+        command: 'lake build',
+        streamId,
+      }),
+      session.interactions.requestPlanApproval({
+        approvalId: 'approval:count',
+        streamId,
+        plan,
+        goalEnabled: false,
+      }),
+      session.interactions.requestAgentProposal({
+        proposalId: 'proposal:count',
+        streamId,
+        ...proposal,
+      }),
+      session.interactions.requestRetry({
+        requestId: 'retry:count',
+        streamId,
+        operation: 'model request',
+      }),
+      session.interactions.askUserQuestion({
+        requestId: 'question:count',
+        streamId,
+        allowBypass: false,
+        questions: [
+          {
+            question: 'Continue?',
+            options: [{ label: 'Yes' }, { label: 'No' }],
+          },
+        ],
+      }),
+    ];
+
+    expect(session.interactions.pendingCount).toBe(6);
+    expect(pendingCounts).toEqual([1]);
+
+    session.interactions.cancel({ cause: 'Test complete.' });
+    await Promise.all(requests);
+
+    expect(session.interactions.pendingCount).toBe(0);
+    expect(pendingCounts).toEqual([1, 0]);
+
+    stopObserving();
+    const ignored = session.interactions.requestPlanApproval({
+      approvalId: 'approval:after-observer-dispose',
+      streamId,
+      plan,
+      goalEnabled: false,
+    });
+    session.interactions.cancel({ cause: 'Test cleanup.' });
+    await ignored;
+    expect(pendingCounts).toHaveLength(2);
+    session.dispose();
   });
 
   it('drops ordinary one-way events emitted while no host is attached', async () => {

--- a/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
@@ -706,6 +706,30 @@ describe('session.interactions request bookkeeping (coordinator fold)', () => {
     });
   });
 
+  it('publishes the final pending boundary before disposal', async () => {
+    const session = createTestSession();
+    const adapter = createControllablePlanAdapter({ settleOnDispose: false });
+    const pendingCounts: number[] = [];
+    session.interactions.onPendingCountChange((count) =>
+      pendingCounts.push(count),
+    );
+    session.useHostInteractions(adapter.interactions);
+    const pending = session.interactions.requestPlanApproval({
+      approvalId: 'approval:dispose-attached',
+      streamId,
+      plan,
+      goalEnabled: false,
+    });
+
+    session.dispose();
+
+    await expect(pending).resolves.toEqual({
+      action: 'reject',
+      feedback: 'Session disposed.',
+    });
+    expect(pendingCounts).toEqual([1, 0]);
+  });
+
   it('resolves a plan approval first-wins through the session slot', async () => {
     const { session, uiEvents, emitted, interactions } = createPortSession();
     try {

--- a/src/test-kernel/desktop/DesktopWindowTitle.vitest.mts
+++ b/src/test-kernel/desktop/DesktopWindowTitle.vitest.mts
@@ -33,17 +33,22 @@ function createAgentHandle(id: string, streamId: StreamTabId) {
 function createWindow(initialTitle: string) {
   const webContents = new EventEmitter();
   let title = initialTitle;
+  let destroyed = false;
   const setTitle = vi.fn((nextTitle: string) => {
     title = nextTitle;
   });
   return {
     window: {
       getTitle: () => title,
+      isDestroyed: () => destroyed,
       setTitle,
       webContents: Object.assign(webContents, { isDestroyed: () => false }),
     },
     setTitle,
     webContents,
+    destroy: () => {
+      destroyed = true;
+    },
   };
 }
 
@@ -186,6 +191,26 @@ describe('desktop process-session window title', () => {
       const handle = createAgentHandle(
         'execution:after-close',
         'stream:after-close' as StreamTabId,
+      );
+      session.executions.trackAgentExecution(handle, {
+        status: STREAM_PHASE.RUNNING,
+      });
+      expect(view.setTitle).not.toHaveBeenCalled();
+    } finally {
+      dispose();
+      session.dispose();
+    }
+  });
+
+  it('does not write the native title after window destruction', () => {
+    const session = createTestSession();
+    const view = createWindow('TeXRA — geometry');
+    const dispose = installTitle(view.window, session);
+    try {
+      view.destroy();
+      const handle = createAgentHandle(
+        'execution:destroyed-window',
+        'stream:destroyed-window' as StreamTabId,
       );
       session.executions.trackAgentExecution(handle, {
         status: STREAM_PHASE.RUNNING,

--- a/src/test-kernel/desktop/DesktopWindowTitle.vitest.mts
+++ b/src/test-kernel/desktop/DesktopWindowTitle.vitest.mts
@@ -40,7 +40,7 @@ function createWindow(initialTitle: string) {
     window: {
       getTitle: () => title,
       setTitle,
-      webContents,
+      webContents: Object.assign(webContents, { isDestroyed: () => false }),
     },
     setTitle,
     webContents,

--- a/src/test-kernel/desktop/DesktopWindowTitle.vitest.mts
+++ b/src/test-kernel/desktop/DesktopWindowTitle.vitest.mts
@@ -1,0 +1,234 @@
+// Node imports
+import { EventEmitter } from 'node:events';
+
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { AgentExecutionHandle } from '@agent/runtime/ExecutionHandle';
+import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
+import {
+  formatDesktopWindowTitle,
+  getDesktopSessionActivity,
+  getDesktopWindowTitle,
+  installDesktopWindowTitle,
+} from '@desktop/main/desktopWindowTitle';
+import { STREAM_PHASE, type StreamTabId } from '@shared/schemas';
+import { seedStreamStatusForTest } from '@test/helpers/streamStatusTestUtils';
+import { createTestSession } from '@test/support/sessionTestUtils';
+
+function createAgentHandle(id: string, streamId: StreamTabId) {
+  return new AgentExecutionHandle(
+    id,
+    streamId,
+    streamId,
+    'test-agent',
+    AgentCategory.ToolUse,
+    noopAgentRuntimeHost,
+  );
+}
+
+function createWindow(initialTitle: string) {
+  const webContents = new EventEmitter();
+  let title = initialTitle;
+  const setTitle = vi.fn((nextTitle: string) => {
+    title = nextTitle;
+  });
+  return {
+    window: {
+      getTitle: () => title,
+      setTitle,
+      webContents,
+    },
+    setTitle,
+    webContents,
+  };
+}
+
+function installTitle(
+  window: ReturnType<typeof createWindow>['window'],
+  session: SessionHandle,
+  workspacePath = '/work/geometry',
+): () => void {
+  return installDesktopWindowTitle(
+    window as unknown as Parameters<typeof installDesktopWindowTitle>[0],
+    session,
+    workspacePath,
+  );
+}
+
+describe('desktop process-session window title', () => {
+  it('formats exact copy for absent and hostile workspace names', () => {
+    expect(formatDesktopWindowTitle('idle')).toBe('TeXRA');
+    expect(formatDesktopWindowTitle('running')).toBe('TeXRA — Running');
+    expect(formatDesktopWindowTitle('approval')).toBe(
+      'TeXRA — Approval needed',
+    );
+    expect(
+      formatDesktopWindowTitle('approval', 'draft — Running <script>.tex'),
+    ).toBe('TeXRA — Approval needed — draft — Running <script>.tex');
+  });
+
+  it('requires a registered agent with canonical RUNNING status', () => {
+    const session = createTestSession();
+    const orphanStream = 'stream:provisional-orphan' as StreamTabId;
+    const waitingStream = 'stream:waiting' as StreamTabId;
+    const waitingHandle = createAgentHandle('execution:waiting', waitingStream);
+    try {
+      seedStreamStatusForTest(
+        session.status,
+        orphanStream,
+        STREAM_PHASE.RUNNING,
+      );
+      expect(getDesktopSessionActivity(session)).toBe('idle');
+
+      session.executions.trackAgentExecution(waitingHandle, {
+        status: STREAM_PHASE.RUNNING,
+      });
+      session.executions.updateAgentExecutionStatus(
+        waitingHandle,
+        STREAM_PHASE.WAITING,
+      );
+      expect(getDesktopSessionActivity(session)).toBe('idle');
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it('remains running until the last of two live agents completes', () => {
+    const session = createTestSession();
+    const first = createAgentHandle(
+      'execution:first',
+      'stream:first' as StreamTabId,
+    );
+    const second = createAgentHandle(
+      'execution:second',
+      'stream:second' as StreamTabId,
+    );
+    try {
+      session.executions.trackAgentExecution(first, {
+        status: STREAM_PHASE.RUNNING,
+      });
+      session.executions.trackAgentExecution(second, {
+        status: STREAM_PHASE.RUNNING,
+      });
+      expect(getDesktopSessionActivity(session)).toBe('running');
+
+      session.executions.untrack(first.executionId);
+      expect(getDesktopSessionActivity(session)).toBe('running');
+
+      session.executions.untrack(second.executionId);
+      expect(getDesktopSessionActivity(session)).toBe('idle');
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it('gives approval precedence and returns to running or idle', async () => {
+    const session = createTestSession();
+    const streamId = 'stream:approval' as StreamTabId;
+    const handle = createAgentHandle('execution:approval', streamId);
+    try {
+      session.executions.trackAgentExecution(handle, {
+        status: STREAM_PHASE.RUNNING,
+      });
+      const firstApproval = session.interactions.requestPlanApproval({
+        approvalId: 'approval:running',
+        streamId,
+        plan: { objective: 'Check the title.' },
+        goalEnabled: false,
+      });
+      expect(getDesktopSessionActivity(session)).toBe('approval');
+
+      session.interactions.cancel({ cause: 'Decision recorded.' });
+      await firstApproval;
+      expect(getDesktopSessionActivity(session)).toBe('running');
+
+      session.executions.untrack(handle.executionId);
+      const secondApproval = session.interactions.requestPlanApproval({
+        approvalId: 'approval:idle',
+        streamId,
+        plan: { objective: 'Check the idle title.' },
+        goalEnabled: false,
+      });
+      expect(getDesktopSessionActivity(session)).toBe('approval');
+
+      session.interactions.cancel({ cause: 'Decision recorded.' });
+      await secondApproval;
+      expect(getDesktopSessionActivity(session)).toBe('idle');
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it('prevents renderer replacement, deduplicates writes, and disposes', () => {
+    const session = createTestSession();
+    const view = createWindow('TeXRA — geometry');
+    const dispose = installTitle(view.window, session);
+    try {
+      expect(view.setTitle).not.toHaveBeenCalled();
+
+      const event = { preventDefault: vi.fn() };
+      view.webContents.emit('page-title-updated', event, 'Renderer title');
+      expect(event.preventDefault).toHaveBeenCalledOnce();
+
+      seedStreamStatusForTest(
+        session.status,
+        'stream:orphan-update' as StreamTabId,
+        STREAM_PHASE.RUNNING,
+      );
+      expect(view.setTitle).not.toHaveBeenCalled();
+
+      dispose();
+      expect(view.webContents.listenerCount('page-title-updated')).toBe(0);
+      const handle = createAgentHandle(
+        'execution:after-close',
+        'stream:after-close' as StreamTabId,
+      );
+      session.executions.trackAgentExecution(handle, {
+        status: STREAM_PHASE.RUNNING,
+      });
+      expect(view.setTitle).not.toHaveBeenCalled();
+    } finally {
+      dispose();
+      session.dispose();
+    }
+  });
+
+  it('derives a pending approval on reopen and isolates process sessions', () => {
+    const firstSession = createTestSession();
+    const secondSession = createTestSession();
+    const streamId = 'stream:reopen' as StreamTabId;
+    try {
+      void firstSession.interactions.requestPlanApproval({
+        approvalId: 'approval:reopen',
+        streamId,
+        plan: { objective: 'Preserve this request across window detach.' },
+        goalEnabled: false,
+      });
+
+      expect(getDesktopWindowTitle(firstSession, '/work/geometry')).toBe(
+        'TeXRA — Approval needed — geometry',
+      );
+      expect(getDesktopWindowTitle(secondSession, '/work/algebra')).toBe(
+        'TeXRA — algebra',
+      );
+
+      const reopened = createWindow(
+        getDesktopWindowTitle(firstSession, '/work/geometry'),
+      );
+      const dispose = installTitle(
+        reopened.window,
+        firstSession,
+        '/work/geometry',
+      );
+      expect(reopened.setTitle).not.toHaveBeenCalled();
+      dispose();
+    } finally {
+      firstSession.dispose();
+      secondSession.dispose();
+    }
+  });
+});

--- a/src/test-kernel/desktop/DesktopWindowTitle.vitest.mts
+++ b/src/test-kernel/desktop/DesktopWindowTitle.vitest.mts
@@ -10,12 +10,12 @@ import { AgentExecutionHandle } from '@agent/runtime/ExecutionHandle';
 import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import {
-  formatDesktopWindowTitle,
   getDesktopSessionActivity,
   getDesktopWindowTitle,
   installDesktopWindowTitle,
 } from '@desktop/main/desktopWindowTitle';
 import { STREAM_PHASE, type StreamTabId } from '@shared/schemas';
+import { formatSessionTitle } from '@shared/sessionTitle';
 import { seedStreamStatusForTest } from '@test/helpers/streamStatusTestUtils';
 import { createTestSession } from '@test/support/sessionTestUtils';
 
@@ -61,14 +61,14 @@ function installTitle(
 
 describe('desktop process-session window title', () => {
   it('formats exact copy for absent and hostile workspace names', () => {
-    expect(formatDesktopWindowTitle('idle')).toBe('TeXRA');
-    expect(formatDesktopWindowTitle('running')).toBe('TeXRA — Running');
-    expect(formatDesktopWindowTitle('approval')).toBe(
+    expect(formatSessionTitle(undefined, 'idle')).toBe('TeXRA');
+    expect(formatSessionTitle(undefined, 'running')).toBe('TeXRA — Running');
+    expect(formatSessionTitle(undefined, 'approval')).toBe(
       'TeXRA — Approval needed',
     );
-    expect(
-      formatDesktopWindowTitle('approval', 'draft — Running <script>.tex'),
-    ).toBe('TeXRA — Approval needed — draft — Running <script>.tex');
+    expect(formatSessionTitle('draft — Running <script>.tex', 'approval')).toBe(
+      'TeXRA — Approval needed — draft — Running <script>.tex',
+    );
   });
 
   it('requires a registered agent with canonical RUNNING status', () => {

--- a/src/test-kernel/desktop/ElectronCompositionRoot.vitest.mts
+++ b/src/test-kernel/desktop/ElectronCompositionRoot.vitest.mts
@@ -131,7 +131,24 @@ describe('desktop composition root and launch environment', () => {
     );
     expect(source).toContain('presentationSignal: presentationAbort.signal');
 
+    const installWindowTitle = source.indexOf('installDesktopWindowTitle(');
+    const loadRendererUrl = source.indexOf(
+      'window.loadURL(',
+      installWindowTitle,
+    );
+    const loadRendererFile = source.indexOf(
+      'window.loadFile(',
+      installWindowTitle,
+    );
+    expect(installWindowTitle).toBeGreaterThanOrEqual(0);
+    expect(loadRendererUrl).toBeGreaterThan(installWindowTitle);
+    expect(loadRendererFile).toBeGreaterThan(installWindowTitle);
+
     const windowClose = source.indexOf("window.once('closed'");
+    const disposeWindowTitle = source.indexOf(
+      'disposeWindowTitle()',
+      windowClose,
+    );
     const abortPresentation = source.indexOf(
       'presentationAbort.abort()',
       windowClose,
@@ -140,7 +157,8 @@ describe('desktop composition root and launch environment', () => {
       'agentExecution.dispose()',
       windowClose,
     );
-    expect(abortPresentation).toBeGreaterThan(windowClose);
+    expect(disposeWindowTitle).toBeGreaterThan(windowClose);
+    expect(abortPresentation).toBeGreaterThan(disposeWindowTitle);
     expect(disposePresentation).toBeGreaterThan(abortPresentation);
 
     const shutdownBefore = source.indexOf(


### PR DESCRIPTION
## Summary

- derive the native Electron window title from the process-owned session, with approval taking precedence over live running agents
- preserve approval state across macOS window detach and reopen without adding renderer IPC state
- prevent renderer page titles from replacing the host-owned title and dispose all observers with the window presentation
- expose a narrow pending-interaction count observer on `SessionHostInteractions`

## Design

The desktop shell previously had a static title even though the process session already owned the relevant execution, status, and interaction state. The new title module reads those canonical owners directly. Running state is restricted to registered agent handles whose stream status is exactly `RUNNING`, so provisional restored status and `WAITING` sessions cannot create a false active title.

The window lifecycle installs the projection before renderer loading, suppresses `page-title-updated`, deduplicates native writes, and removes its listeners in the existing close path. No IPC or persisted format is added.

## Verification

- `npm run format`
- `npm run compile:fast`
- `npx tsc --noEmit -p packages/desktop/tsconfig.main.json`
- focused ESLint over all changed TypeScript files
- `npm run check:dead-code-ratchet`
- focused Vitest: 3 files, 41 tests passed

Closes #9008

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly cosmetic UI with focused runtime hooks; session disposal changes are covered by tests but touch interaction settlement on dispose.
> 
> **Overview**
> Desktop windows now show **idle**, **Running**, or **Approval needed** in the native title (with the workspace folder name), using the same `formatSessionTitle` helper as the CLI terminal tab titles.
> 
> A new main-process module reads the process-owned session—pending host interactions, registered agents whose stream status is exactly `RUNNING`, with approval taking precedence—and keeps `BrowserWindow` titles in sync via execution, status, and pending-count listeners. Renderer `page-title-updated` is blocked so the host-owned title is not overwritten; the installer runs before the renderer loads and is torn down when the window closes, including on macOS reopen when approvals can still be pending.
> 
> `SessionHostInteractions` exposes `pendingCount` and `onPendingCountChange` so desktop (and similar hosts) can react without new IPC; session disposal now settles any still-pending requests synchronously, and observer failures are isolated from request cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4277f530d4685c3d2f8144dd43bbb9af93341ad5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->