### PR TITLE
feat(cli): show subagent run files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ All notable changes to this project will be documented in this file.
 - **Nested subagents remain visible** — a focused subagent reports how many
   direct subagents it owns, including completed work that remains available in
   its child list.
+- **Subagent rows show their working files** — rows summarize attached input,
+  context, media, and output files; press `i` while selecting a row to inspect
+  the paths without leaving the conversation.
 
 #### Bug Fixes
 

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -180,6 +180,7 @@ export function App(props: AppProps): React.JSX.Element {
   const childListActiveStreamRef = useRef(activeStreamId);
   const childListFocused = childListSelection.focused;
   const selectedChildValue = childListSelection.selectedValue;
+  const childListRowExpanded = childListSelection.rowExpanded;
   const { columns, rows } = useWindowSize();
   const { exit } = useApp();
   const [transcriptPrints, setTranscriptPrints] = useState<
@@ -729,6 +730,7 @@ export function App(props: AppProps): React.JSX.Element {
           rootStreamId,
           slashPaletteOpen,
           childListFocused,
+          childListRowExpanded,
           sessionViews,
           selectedChildValue,
           streams,
@@ -747,6 +749,9 @@ export function App(props: AppProps): React.JSX.Element {
           taskDetailExecutionIdSignal.set(executionId)
         }
         onPrintStream={printStreamOutput}
+        onToggleChildRowExpand={() =>
+          dispatchChildListSelection({ kind: 'toggleRowExpand' })
+        }
         onChildSelectionChange={(value) =>
           dispatchChildListSelection({ kind: 'highlight', value })
         }

--- a/packages/cli/src/chat/tui/appLayout.ts
+++ b/packages/cli/src/chat/tui/appLayout.ts
@@ -148,6 +148,7 @@ export function allocateConversationBottomPanelRows({
   processCount = 0,
   sessionCount,
   childListFocused,
+  detailContentRows = 0,
   todosPlanContentRows,
   transcriptRows,
 }: {
@@ -155,6 +156,7 @@ export function allocateConversationBottomPanelRows({
   readonly processCount?: number;
   readonly sessionCount: number;
   readonly childListFocused: boolean;
+  readonly detailContentRows?: number;
   readonly todosPlanContentRows: number;
   readonly transcriptRows: number;
 }): {
@@ -165,7 +167,7 @@ export function allocateConversationBottomPanelRows({
   const childListRowCount = sessionCount + processCount;
   // The persistent child list owns one blank separator row above its Select.
   const sessionPanelContentRows =
-    childListRowCount > 0 ? childListRowCount + 1 : 0;
+    childListRowCount > 0 ? childListRowCount + detailContentRows + 1 : 0;
   // The todos/plan panel likewise owns a separator row above its checklist.
   const todosPanelContentRows =
     todosPlanContentRows > 0 ? todosPlanContentRows + 1 : 0;

--- a/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
@@ -32,11 +32,15 @@ import {
 } from './QueuedFollowUpsPanel';
 import { StaticConversationTranscript } from './StaticConversationTranscript';
 import { SubagentList } from './SubagentList';
+import { fileDetailLines } from './SubagentListDisplay';
 import { TodosPlanPanel, todosPlanPanelRowCount } from './TodosPlanPanel';
+import {
+  childListStreamId,
+  type ChildListValue,
+} from '../state/childListSelection';
 import type { ForegroundSurfaceKind } from '../appInteractionPolicy';
 import type { PendingApprovalKind } from '../state/approvalQueue';
 import type { ChildListTarget } from '../state/childControls';
-import type { ChildListValue } from '../state/childListSelection';
 import type { StreamSlice } from '../state/cliState';
 import type { TranscriptPrintRequest } from '../state/transcriptLines';
 import type { StreamView } from '../state/streamViews';
@@ -54,6 +58,7 @@ interface ConversationRegionSnapshot {
   readonly slashPaletteOpen: boolean;
   readonly selectedChildValue: ChildListValue | undefined;
   readonly childListFocused: boolean;
+  readonly childListRowExpanded: boolean;
   readonly sessionViews: readonly StreamView[];
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
   readonly subagentExecutionLabels: ExecutionLabels;
@@ -82,6 +87,7 @@ interface ConversationRegionProps {
   readonly onRetryExecution: (executionId: string) => void;
   readonly onOpenProcessDetail: (executionId: string) => void;
   readonly onPrintStream: (streamId: StreamTabId) => void;
+  readonly onToggleChildRowExpand: () => void;
 }
 
 export function ConversationRegion({
@@ -95,6 +101,7 @@ export function ConversationRegion({
   onRetryExecution,
   onOpenProcessDetail,
   onPrintStream,
+  onToggleChildRowExpand,
   onStaticTranscriptChange,
   renderFooterChrome,
   renderForegroundSurface,
@@ -176,6 +183,21 @@ export function ConversationRegion({
     hasTodosPlanPanel && activeSlice
       ? todosPlanPanelRowCount(activeSlice.todos, activeSlice.plan)
       : 0;
+  const selectedChildStreamId = childListStreamId(snapshot.selectedChildValue);
+  const selectedChildFiles = selectedChildStreamId
+    ? snapshot.streams.get(selectedChildStreamId)?.files
+    : undefined;
+  const selectedFileDetailLines = fileDetailLines(
+    selectedChildFiles,
+    Math.max(1, columns - 6),
+  );
+  const expandedFileDetailLines =
+    selectedFileDetailLines.length > 0
+      ? selectedFileDetailLines
+      : ['No file info for this row'];
+  const childDetailLines = snapshot.childListRowExpanded
+    ? expandedFileDetailLines
+    : [];
   const {
     bottomPanelRows: bottomPanelBudget,
     sessionPanelRows: subagentRows,
@@ -185,6 +207,7 @@ export function ConversationRegion({
     processCount: foregroundOpen ? 0 : activeProcesses.length,
     sessionCount: foregroundOpen ? 0 : snapshot.sessionViews.length,
     childListFocused: snapshot.childListFocused,
+    detailContentRows: childDetailLines.length,
     todosPlanContentRows,
     transcriptRows,
   });
@@ -262,6 +285,7 @@ export function ConversationRegion({
               onOpenProcessDetail={onOpenProcessDetail}
               onSelectionChange={onChildSelectionChange}
               onPrintStream={onPrintStream}
+              onToggleRowExpand={onToggleChildRowExpand}
               pendingApprovals={snapshot.pendingApprovals}
               listRootStreamId={snapshot.childListTarget.streamId}
               selectedValue={snapshot.selectedChildValue}
@@ -269,6 +293,7 @@ export function ConversationRegion({
               activeProcesses={activeProcesses}
               activeSubagentExecutionIds={snapshot.activeSubagentExecutionIds}
               processOutput={snapshot.childListTarget.slice?.processOutput}
+              detailLines={childDetailLines}
             />
             <TodosPlanPanel maxRows={todosPlanRows} />
           </Box>

--- a/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
@@ -32,7 +32,7 @@ import {
 } from './QueuedFollowUpsPanel';
 import { StaticConversationTranscript } from './StaticConversationTranscript';
 import { SubagentList } from './SubagentList';
-import { fileDetailLines } from './SubagentListDisplay';
+import { childFileDisplay } from './SubagentListDisplay';
 import { TodosPlanPanel, todosPlanPanelRowCount } from './TodosPlanPanel';
 import {
   childListStreamId,
@@ -187,10 +187,10 @@ export function ConversationRegion({
   const selectedChildFiles = selectedChildStreamId
     ? snapshot.streams.get(selectedChildStreamId)?.files
     : undefined;
-  const selectedFileDetailLines = fileDetailLines(
+  const selectedFileDetailLines = childFileDisplay(
     selectedChildFiles,
     Math.max(1, columns - 6),
-  );
+  ).detailLines;
   const expandedFileDetailLines =
     selectedFileDetailLines.length > 0
       ? selectedFileDetailLines

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -36,7 +36,7 @@ import { Select, visibleSelectRange } from '../ui/Select';
 import {
   CHILD_ROW_METADATA_MIN_COLUMNS,
   CHILD_STATUS_MARKER,
-  childFileBadgeText,
+  childFileDisplay,
   childRowMetadataText,
   childStatusColor,
   pendingApprovalRowSuffix,
@@ -148,7 +148,7 @@ function SessionRow({
   // this truncate-end text sheds inline elapsed (narrow mode only), the round,
   // and last the pending-approval kind. The metadata column never shrinks.
   const approvalSuffix = pendingApprovalRowSuffix(pendingKinds);
-  const fileBadge = childFileBadgeText(session.slice?.files);
+  const fileBadge = childFileDisplay(session.slice?.files).badge;
   const roundLabel = formatRoundStageLabel(session.slice?.roundStage);
   // The resolved model is per-agent identity (a workflow run's grandchildren
   // can each resolve a different model); the list-root row is the conversation

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -36,6 +36,7 @@ import { Select, visibleSelectRange } from '../ui/Select';
 import {
   CHILD_ROW_METADATA_MIN_COLUMNS,
   CHILD_STATUS_MARKER,
+  childFileBadgeText,
   childRowMetadataText,
   childStatusColor,
   pendingApprovalRowSuffix,
@@ -147,6 +148,7 @@ function SessionRow({
   // this truncate-end text sheds inline elapsed (narrow mode only), the round,
   // and last the pending-approval kind. The metadata column never shrinks.
   const approvalSuffix = pendingApprovalRowSuffix(pendingKinds);
+  const fileBadge = childFileBadgeText(session.slice?.files);
   const roundLabel = formatRoundStageLabel(session.slice?.roundStage);
   // The resolved model is per-agent identity (a workflow run's grandchildren
   // can each resolve a different model); the list-root row is the conversation
@@ -198,6 +200,11 @@ function SessionRow({
           <Text dimColor wrap="truncate-end">
             {` · ${truncateSummaryToWidth(summary, SUBAGENT_SUMMARY_MAX_COLUMNS)}`}
           </Text>
+        </Box>
+      ) : null}
+      {fileBadge ? (
+        <Box minWidth={0} flexShrink={3}>
+          <Text dimColor wrap="truncate-end">{` · ${fileBadge}`}</Text>
         </Box>
       ) : null}
       {focused ? <HiddenRowSummary text={hiddenRowSummary} /> : null}
@@ -259,6 +266,24 @@ function ProcessRow({
   );
 }
 
+/** Focus-local file details. The caller has already bounded the lines to the
+ *  rows left after preserving at least one visible child row. */
+function SubagentRowDetail({
+  lines,
+}: {
+  readonly lines: readonly string[];
+}): React.JSX.Element | null {
+  return lines.length > 0 ? (
+    <Box flexDirection="column" flexShrink={0} paddingLeft={4}>
+      {lines.map((line) => (
+        <Text key={line} dimColor wrap="truncate-end">
+          {line}
+        </Text>
+      ))}
+    </Box>
+  ) : null;
+}
+
 export interface SubagentListProps {
   readonly keyboardActive?: boolean;
   readonly maxRows?: number;
@@ -272,6 +297,7 @@ export interface SubagentListProps {
   readonly onOpenProcessDetail?: (executionId: string) => void;
   readonly onSelectionChange?: (value: ChildListValue) => void;
   readonly onPrintStream?: (streamId: StreamTabId) => void;
+  readonly onToggleRowExpand?: () => void;
   /** Pending approval kinds per stream id (see `pendingApprovalSummaries`,
    *  root bucket already folded onto the root stream id by the caller). */
   readonly pendingApprovals?: ReadonlyMap<
@@ -285,6 +311,8 @@ export interface SubagentListProps {
   readonly activeProcesses?: readonly ActiveChildInfo[];
   readonly activeSubagentExecutionIds?: ReadonlyMap<StreamTabId, string>;
   readonly processOutput?: ReadonlyMap<string, ProcessOutputTail>;
+  /** Preformatted details for the selected row; empty when it is collapsed. */
+  readonly detailLines?: readonly string[];
 }
 
 export function SubagentList(
@@ -344,6 +372,17 @@ export function SubagentList(
   const metadataColumn = columns >= CHILD_ROW_METADATA_MIN_COLUMNS;
   const contentRows =
     props.maxRows === undefined ? undefined : Math.max(0, props.maxRows - 1);
+  // Preserve at least one selected-row slot. On a tight terminal the detail
+  // therefore sheds rows before the list does.
+  const detailRows =
+    contentRows === undefined
+      ? (props.detailLines?.length ?? 0)
+      : Math.min(props.detailLines?.length ?? 0, Math.max(0, contentRows - 1));
+  const visibleDetailLines = (props.detailLines ?? []).slice(0, detailRows);
+  const listRows =
+    contentRows === undefined
+      ? undefined
+      : Math.max(0, contentRows - detailRows);
   const selectedIndex = Math.max(
     0,
     items.findIndex((item) => item.value === props.selectedValue),
@@ -351,7 +390,7 @@ export function SubagentList(
   const visibleRange = visibleSelectRange({
     highlight: selectedIndex,
     itemCount: items.length,
-    maxVisibleItems: contentRows,
+    maxVisibleItems: listRows,
   });
   const visibleValues = new Set(
     items.slice(visibleRange.start, visibleRange.end).map((item) => item.value),
@@ -379,6 +418,10 @@ export function SubagentList(
       if (key.ctrl || key.meta) return;
       const streamId = childListStreamId(props.selectedValue);
       const pressed = input.toLowerCase();
+      if (pressed === 'i') {
+        props.onToggleRowExpand?.();
+        return;
+      }
       if (pressed === 'v' && streamId) {
         props.onPrintStream?.(streamId);
         return;
@@ -431,7 +474,7 @@ export function SubagentList(
         hotkeys={false}
         isActive={props.keyboardActive}
         items={items}
-        maxVisibleItems={contentRows}
+        maxVisibleItems={listRows}
         onCancel={props.onCancel ?? (() => undefined)}
         // This panel is a standalone focus target, not a cyclic menu: Down
         // past the last row hands keyboard ownership back to the input
@@ -479,6 +522,7 @@ export function SubagentList(
           ) : null;
         }}
       />
+      <SubagentRowDetail lines={visibleDetailLines} />
     </Box>
   );
 }

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -275,8 +275,8 @@ function SubagentRowDetail({
 }): React.JSX.Element | null {
   return lines.length > 0 ? (
     <Box flexDirection="column" flexShrink={0} paddingLeft={4}>
-      {lines.map((line) => (
-        <Text key={line} dimColor wrap="truncate-end">
+      {lines.map((line, index) => (
+        <Text key={`${index}:${line}`} dimColor wrap="truncate-end">
           {line}
         </Text>
       ))}
@@ -418,7 +418,7 @@ export function SubagentList(
       if (key.ctrl || key.meta) return;
       const streamId = childListStreamId(props.selectedValue);
       const pressed = input.toLowerCase();
-      if (pressed === 'i') {
+      if (pressed === 'i' && streamId) {
         props.onToggleRowExpand?.();
         return;
       }

--- a/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
@@ -2,6 +2,9 @@
 import { formatCompactTokenCount } from '@utils/core';
 import { formatResultCount } from '@utils/text/stringUtils';
 
+// Local imports - TUI rendering and state
+import { truncateSummaryToWidth } from '../render/terminalText';
+
 // Local imports - TUI state and presentation
 import { isChildExecutionErrorStatus } from '../state/childExecutionStatus';
 import {
@@ -12,6 +15,7 @@ import {
 } from '../ui/colors';
 import { STATUS_DOT, TOKENS_GENERATED } from '../ui/glyphs';
 import type { PendingApprovalKind } from '../state/approvalQueue';
+import type { StreamFileMetadata } from '../state/cliState';
 
 export function childStatusColor(status: string | undefined): string {
   if (!status) return COLOR_SUCCESS;
@@ -83,4 +87,47 @@ export function pendingApprovalRowSuffix(
   if (kinds === undefined || first === undefined) return undefined;
   const label = PENDING_APPROVAL_ROW_LABELS[first];
   return kinds.length > 1 ? `${label} +${kinds.length - 1}` : label;
+}
+
+const FILE_CATEGORIES = [
+  ['input', 'in', 'Input'],
+  ['context', 'ctx', 'Context'],
+  ['media', 'media', 'Media'],
+  ['output', 'out', 'Output'],
+] as const satisfies readonly (readonly [
+  keyof StreamFileMetadata,
+  string,
+  string,
+])[];
+
+/** Compact, derived file counts for a child row. Empty categories consume no
+ *  horizontal space, and an absent run configuration produces no badge. */
+export function childFileBadgeText(
+  files: StreamFileMetadata | undefined,
+): string | undefined {
+  if (!files) return undefined;
+  const parts = FILE_CATEGORIES.flatMap(([key, badge]) =>
+    files[key].length > 0 ? [`${badge}:${files[key].length}`] : [],
+  );
+  return parts.length > 0 ? parts.join(' ') : undefined;
+}
+
+/** At most one bounded detail line per file role. Paths remain intact until
+ *  the terminal-width boundary, where the shared Unicode-aware truncator clips
+ *  the line. */
+export function fileDetailLines(
+  files: StreamFileMetadata | undefined,
+  maxColumns: number,
+): readonly string[] {
+  if (!files) return [];
+  return FILE_CATEGORIES.flatMap(([key, , label]) =>
+    files[key].length > 0
+      ? [
+          truncateSummaryToWidth(
+            `${label}  ${files[key].join(', ')}`,
+            maxColumns,
+          ),
+        ]
+      : [],
+  );
 }

--- a/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
@@ -100,34 +100,32 @@ const FILE_CATEGORIES = [
   string,
 ])[];
 
-/** Compact, derived file counts for a child row. Empty categories consume no
- *  horizontal space, and an absent run configuration produces no badge. */
-export function childFileBadgeText(
+/** Derive both file surfaces from one role ordering. Row callers omit
+ *  `detailMaxColumns` and therefore pay only for the compact badge; the
+ *  expanded panel requests its bounded detail lines from the same API. */
+export function childFileDisplay(
   files: StreamFileMetadata | undefined,
-): string | undefined {
-  if (!files) return undefined;
-  const parts = FILE_CATEGORIES.flatMap(([key, badge]) =>
-    files[key].length > 0 ? [`${badge}:${files[key].length}`] : [],
+  detailMaxColumns?: number,
+): {
+  readonly badge: string | undefined;
+  readonly detailLines: readonly string[];
+} {
+  if (!files) return { badge: undefined, detailLines: [] };
+  const populated = FILE_CATEGORIES.filter(([key]) => files[key].length > 0);
+  const badge = populated.map(
+    ([key, label]) => `${label}:${files[key].length}`,
   );
-  return parts.length > 0 ? parts.join(' ') : undefined;
-}
-
-/** At most one bounded detail line per file role. Paths remain intact until
- *  the terminal-width boundary, where the shared Unicode-aware truncator clips
- *  the line. */
-export function fileDetailLines(
-  files: StreamFileMetadata | undefined,
-  maxColumns: number,
-): readonly string[] {
-  if (!files) return [];
-  return FILE_CATEGORIES.flatMap(([key, , label]) =>
-    files[key].length > 0
-      ? [
+  const detailLines =
+    detailMaxColumns === undefined
+      ? []
+      : populated.map(([key, , label]) =>
           truncateSummaryToWidth(
             `${label}  ${files[key].join(', ')}`,
-            maxColumns,
+            detailMaxColumns,
           ),
-        ]
-      : [],
-  );
+        );
+  return {
+    badge: badge.length > 0 ? badge.join(' ') : undefined,
+    detailLines,
+  };
 }

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -604,6 +604,10 @@ function childListBindingsText(
     selectionKind === 'stream'
       ? keyHintText({ key: 'v', action: 'full output' })
       : undefined;
+  const fileInfoBinding =
+    selectionKind === 'stream'
+      ? keyHintText({ key: 'i', action: 'files' })
+      : undefined;
   const killBinding = selectionKillable
     ? keyHintText({ key: 'k', action: 'kill' })
     : undefined;
@@ -618,6 +622,7 @@ function childListBindingsText(
       keyHintText({ key: 'Up/Down', action: 'select' }),
       enterBinding,
       fullOutputBinding,
+      fileInfoBinding,
       killBinding,
       skipBinding,
       retryBinding,

--- a/packages/cli/src/chat/tui/state/childListSelection.ts
+++ b/packages/cli/src/chat/tui/state/childListSelection.ts
@@ -30,6 +30,7 @@ export function childListProcessId(
 export interface ChildListSelectionState {
   readonly focused: boolean;
   readonly selectedValue: ChildListValue | undefined;
+  readonly rowExpanded: boolean;
 }
 
 type ChildListSelectionAction =
@@ -37,6 +38,7 @@ type ChildListSelectionAction =
   | { readonly kind: 'focus'; readonly value?: ChildListValue }
   | { readonly kind: 'focusStream'; readonly streamId: StreamTabId }
   | { readonly kind: 'highlight'; readonly value: ChildListValue }
+  | { readonly kind: 'toggleRowExpand' }
   | {
       readonly kind: 'syncActiveStream';
       readonly streamId: StreamTabId;
@@ -51,6 +53,7 @@ type ChildListSelectionAction =
 export const INITIAL_CHILD_LIST_SELECTION: ChildListSelectionState = {
   focused: false,
   selectedValue: undefined,
+  rowExpanded: false,
 };
 
 function resolveChildSelectionValue(
@@ -74,19 +77,27 @@ export function reduceChildListSelection(
 ): ChildListSelectionState {
   switch (action.kind) {
     case 'blur':
-      return { ...state, focused: false };
+      return { ...state, focused: false, rowExpanded: false };
     case 'focus':
       return {
         focused: true,
         selectedValue: state.selectedValue ?? action.value,
+        rowExpanded: false,
       };
     case 'focusStream':
       return {
         focused: false,
         selectedValue: childStreamListValue(action.streamId),
+        rowExpanded: false,
       };
     case 'highlight':
-      return { ...state, selectedValue: action.value };
+      return action.value === state.selectedValue
+        ? state
+        : { ...state, selectedValue: action.value, rowExpanded: false };
+    case 'toggleRowExpand':
+      return state.focused
+        ? { ...state, rowExpanded: !state.rowExpanded }
+        : state;
     case 'syncActiveStream':
       return {
         ...state,
@@ -95,6 +106,7 @@ export function reduceChildListSelection(
           undefined,
           action.streamId,
         ),
+        rowExpanded: false,
       };
     case 'reconcile': {
       if (action.values.length === 0) return state;
@@ -105,7 +117,7 @@ export function reduceChildListSelection(
       );
       return selectedValue === state.selectedValue
         ? state
-        : { ...state, selectedValue };
+        : { ...state, selectedValue, rowExpanded: false };
     }
   }
 }

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -119,6 +119,15 @@ export interface BypassState {
   readonly superYolo: boolean;
 }
 
+/** File roles attached to one agent run. Kept as one optional value so the
+ *  transcript slice does not duplicate derived counts alongside the paths. */
+export interface StreamFileMetadata {
+  readonly input: readonly string[];
+  readonly context: readonly string[];
+  readonly media: readonly string[];
+  readonly output: readonly string[];
+}
+
 export interface StreamSlice {
   readonly streamId: StreamTabId;
   /** Model identity captured from setTaskState for this specific stream. */
@@ -127,6 +136,9 @@ export interface StreamSlice {
    *  from `setTaskState` or `setActiveStream`. Lets the exit hint list only
    *  resumable tool-use subagents (workflows don't resume). */
   readonly category: AgentCategory | undefined;
+  /** Normalized run files received with `run.config`. Absent until that fact
+   *  arrives; each category may then be empty. */
+  readonly files?: StreamFileMetadata | undefined;
   readonly status: StreamPhase | undefined;
   readonly substate?: StreamSubstate;
   /** Epoch ms when this stream last entered `RUNNING`; cleared on any other

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -87,13 +87,34 @@ function applySetActiveStream(payload: SetActiveStreamPayload): void {
 
 function applyRunConfig(streamId: StreamTabId, config: AgentConfig): void {
   patchStream(streamId, (s) => {
-    if (s.model === config.model && s.category === config.agentCategory) {
+    const files = {
+      input: config.inputFiles,
+      context: config.contextFiles,
+      media: config.mediaFiles,
+      output: config.outputFiles,
+    };
+    const sameFiles =
+      s.files !== undefined &&
+      (Object.keys(files) as (keyof typeof files)[]).every((key) => {
+        const previous = s.files?.[key] ?? [];
+        const next = files[key];
+        return (
+          previous.length === next.length &&
+          previous.every((path, index) => path === next[index])
+        );
+      });
+    if (
+      s.model === config.model &&
+      s.category === config.agentCategory &&
+      sameFiles
+    ) {
       return s;
     }
     return {
       ...s,
       model: config.model,
       category: config.agentCategory,
+      files,
     };
   });
 }

--- a/src/test-kernel/cli/ChildListInteraction.vitest.mts
+++ b/src/test-kernel/cli/ChildListInteraction.vitest.mts
@@ -21,6 +21,37 @@ function session(id: StreamTabId, active = false): StreamView {
 }
 
 describe('CLI child list interaction', () => {
+  it('toggles file details with i while the list owns the keyboard', async () => {
+    const { ink, React } = await loadInk();
+    const onToggleRowExpand = vi.fn();
+    const stdin = new FakeStdin();
+    const instance = ink.render(
+      React.createElement(SubagentList, {
+        keyboardActive: true,
+        maxRows: 4,
+        onToggleRowExpand,
+        selectedValue: childStreamListValue('root' as StreamTabId),
+        sessions: [session('root' as StreamTabId, true)],
+      }),
+      {
+        stdin,
+        stdout: new FakeStdout(100),
+        interactive: true,
+        exitOnCtrlC: false,
+        patchConsole: false,
+      },
+    );
+
+    try {
+      await waitFor(() => stdin.listenerCount('readable') > 0);
+      stdin.write('i');
+      await waitFor(() => onToggleRowExpand.mock.calls.length === 1);
+      expect(onToggleRowExpand).toHaveBeenCalledOnce();
+    } finally {
+      instance.unmount();
+    }
+  });
+
   it('renders no process highlight before the list receives a selection', async () => {
     const { ink, React } = await loadInk();
     const output = ink.renderToString(

--- a/src/test-kernel/cli/ChildListInteraction.vitest.mts
+++ b/src/test-kernel/cli/ChildListInteraction.vitest.mts
@@ -262,6 +262,7 @@ describe('CLI child list interaction', () => {
     const onKillExecution = vi.fn();
     const onOpenProcessDetail = vi.fn();
     const onPrintStream = vi.fn();
+    const onToggleRowExpand = vi.fn();
 
     const stdin = new FakeStdin();
     const instance = ink.render(
@@ -281,6 +282,7 @@ describe('CLI child list interaction', () => {
         onOpenProcessDetail,
         onSelectionChange: vi.fn(),
         onPrintStream,
+        onToggleRowExpand,
         selectedValue: processValue,
       }),
       {
@@ -294,6 +296,7 @@ describe('CLI child list interaction', () => {
 
     try {
       await waitFor(() => stdin.listenerCount('readable') > 0);
+      stdin.write('i');
       stdin.write('v');
       stdin.write('k');
       await waitFor(() => onKillExecution.mock.calls.length === 1);
@@ -301,6 +304,7 @@ describe('CLI child list interaction', () => {
       await waitFor(() => onOpenProcessDetail.mock.calls.length === 1);
 
       expect(onPrintStream).not.toHaveBeenCalled();
+      expect(onToggleRowExpand).not.toHaveBeenCalled();
       expect(onKillExecution).toHaveBeenCalledWith('process-exec');
       expect(onOpenProcessDetail).toHaveBeenCalledWith('process-exec');
     } finally {

--- a/src/test-kernel/cli/ChildListSelection.vitest.mts
+++ b/src/test-kernel/cli/ChildListSelection.vitest.mts
@@ -57,13 +57,18 @@ describe('CLI child list selection', () => {
       main,
     );
 
-    expect(state).toEqual({ focused: true, selectedValue: processValue });
+    expect(state).toEqual({
+      focused: true,
+      selectedValue: processValue,
+      rowExpanded: false,
+    });
   });
 
   it('preserves selection while hidden and restores it when rows return', () => {
     const selected: ChildListSelectionState = {
       focused: true,
       selectedValue: strategyValue,
+      rowExpanded: false,
     };
     const hidden = reconcileSelection(selected, [], main);
     const restored = reconcileSelection(
@@ -78,7 +83,7 @@ describe('CLI child list selection', () => {
 
   it('selects the owner when lifecycle completion changes the active stream', () => {
     const state = reduceChildListSelection(
-      { focused: true, selectedValue: strategyValue },
+      { focused: true, selectedValue: strategyValue, rowExpanded: true },
       {
         kind: 'syncActiveStream',
         streamId: main,
@@ -86,12 +91,16 @@ describe('CLI child list selection', () => {
       },
     );
 
-    expect(state).toEqual({ focused: true, selectedValue: mainValue });
+    expect(state).toEqual({
+      focused: true,
+      selectedValue: mainValue,
+      rowExpanded: false,
+    });
   });
 
   it('clears a stale row when the active stream is not in the projected list', () => {
     const state = reduceChildListSelection(
-      { focused: true, selectedValue: strategyValue },
+      { focused: true, selectedValue: strategyValue, rowExpanded: true },
       {
         kind: 'syncActiveStream',
         streamId: main,
@@ -99,12 +108,20 @@ describe('CLI child list selection', () => {
       },
     );
 
-    expect(state).toEqual({ focused: true, selectedValue: undefined });
+    expect(state).toEqual({
+      focused: true,
+      selectedValue: undefined,
+      rowExpanded: false,
+    });
   });
 
   it('falls back to the active stream and then the first row', () => {
     let state = reconcileSelection(
-      { focused: true, selectedValue: childProcessListValue('gone') },
+      {
+        focused: true,
+        selectedValue: childProcessListValue('gone'),
+        rowExpanded: false,
+      },
       [processValue, mainValue],
       main,
     );
@@ -126,14 +143,49 @@ describe('CLI child list selection', () => {
       kind: 'focus',
       value: processValue,
     });
-    expect(state).toEqual({ focused: true, selectedValue: processValue });
+    expect(state).toEqual({
+      focused: true,
+      selectedValue: processValue,
+      rowExpanded: false,
+    });
   });
 
   it('returns input after a stream is focused', () => {
     const state = reduceChildListSelection(
-      { focused: true, selectedValue: processValue },
+      { focused: true, selectedValue: processValue, rowExpanded: true },
       { kind: 'focusStream', streamId: strategy },
     );
-    expect(state).toEqual({ focused: false, selectedValue: strategyValue });
+    expect(state).toEqual({
+      focused: false,
+      selectedValue: strategyValue,
+      rowExpanded: false,
+    });
+  });
+
+  it('expands only while focused and closes details when selection changes', () => {
+    let state = reduceChildListSelection(
+      {
+        focused: true,
+        selectedValue: mainValue,
+        rowExpanded: false,
+      },
+      { kind: 'toggleRowExpand' },
+    );
+    expect(state.rowExpanded).toBe(true);
+
+    state = reduceChildListSelection(state, {
+      kind: 'highlight',
+      value: strategyValue,
+    });
+    expect(state).toEqual({
+      focused: true,
+      selectedValue: strategyValue,
+      rowExpanded: false,
+    });
+
+    state = reduceChildListSelection(state, { kind: 'blur' });
+    expect(reduceChildListSelection(state, { kind: 'toggleRowExpand' })).toBe(
+      state,
+    );
   });
 });

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -258,6 +258,7 @@ describe('CLI StatusBar display model', () => {
     expect(display.bindings).toContain('Up/Down select');
     expect(display.bindings).toContain('Enter focus');
     expect(display.bindings).toContain('v full output');
+    expect(display.bindings).toContain('i files');
     expect(display.bindings).toContain('k kill');
     expect(display.bindings).toContain('Tab input');
     expect(display.bindings).toContain('Esc input');
@@ -278,6 +279,7 @@ describe('CLI StatusBar display model', () => {
     expect(display.bindings).toContain('Enter details');
     expect(display.bindings).toContain('k kill');
     expect(display.bindings).not.toContain('v full output');
+    expect(display.bindings).not.toContain('i files');
   });
 
   it('shows foreground actions while a list-owned surface is open', () => {

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -2,10 +2,9 @@ import { describe, expect, it } from 'vitest';
 
 import {
   CHILD_STATUS_MARKER,
-  childFileBadgeText,
+  childFileDisplay,
   childRowMetadataText,
   childStatusColor,
-  fileDetailLines,
   pendingApprovalRowSuffix,
 } from '@cli/chat/tui/panes/SubagentListDisplay';
 import {
@@ -73,17 +72,20 @@ describe('CLI child list display model', () => {
       output: ['Main.olean'],
     };
 
-    expect(childFileBadgeText(files)).toBe('in:2 ctx:1 out:1');
-    expect(fileDetailLines(files, 80)).toEqual([
+    expect(childFileDisplay(files).badge).toBe('in:2 ctx:1 out:1');
+    expect(childFileDisplay(files, 80).detailLines).toEqual([
       'Input src/Main.lean, src/Lemma.lean',
       'Context notes/proof.md',
       'Output Main.olean',
     ]);
-    expect(childFileBadgeText(undefined)).toBeUndefined();
+    expect(childFileDisplay(undefined)).toEqual({
+      badge: undefined,
+      detailLines: [],
+    });
     expect(
-      childFileBadgeText({ input: [], context: [], media: [], output: [] }),
+      childFileDisplay({ input: [], context: [], media: [], output: [] }).badge,
     ).toBeUndefined();
-    expect(fileDetailLines(files, 20)).toEqual([
+    expect(childFileDisplay(files, 20).detailLines).toEqual([
       'Input src/Main.lean…',
       'Context notes/proof…',
       'Output Main.olean',

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest';
 
 import {
   CHILD_STATUS_MARKER,
+  childFileBadgeText,
   childRowMetadataText,
   childStatusColor,
+  fileDetailLines,
   pendingApprovalRowSuffix,
 } from '@cli/chat/tui/panes/SubagentListDisplay';
 import {
@@ -63,6 +65,31 @@ function workflowAgentSlice(
 }
 
 describe('CLI child list display model', () => {
+  it('formats only populated run-file categories for badges and details', () => {
+    const files = {
+      input: ['src/Main.lean', 'src/Lemma.lean'],
+      context: ['notes/proof.md'],
+      media: [],
+      output: ['Main.olean'],
+    };
+
+    expect(childFileBadgeText(files)).toBe('in:2 ctx:1 out:1');
+    expect(fileDetailLines(files, 80)).toEqual([
+      'Input src/Main.lean, src/Lemma.lean',
+      'Context notes/proof.md',
+      'Output Main.olean',
+    ]);
+    expect(childFileBadgeText(undefined)).toBeUndefined();
+    expect(
+      childFileBadgeText({ input: [], context: [], media: [], output: [] }),
+    ).toBeUndefined();
+    expect(fileDetailLines(files, 20)).toEqual([
+      'Input src/Main.lean…',
+      'Context notes/proof…',
+      'Output Main.olean',
+    ]);
+  });
+
   it('keeps status markers steady and status colors independent of focus', () => {
     expect(CHILD_STATUS_MARKER).toBe('● ');
     expect(childStatusColor(undefined)).toBe('green');
@@ -312,5 +339,33 @@ describe('CLI child list display model', () => {
     expect(output).toContain('bash running · gpt56');
     expect(output).toContain('5 tool calls');
     expect(output).toContain('↓40k');
+  });
+
+  it('renders a run-file badge as the least-essential row suffix', async () => {
+    const { ink, React } = await loadInk();
+    const run = 'run' as StreamTabId;
+    const output = ink.renderToString(
+      React.createElement(SubagentList, {
+        maxRows: 3,
+        sessions: [
+          {
+            id: run,
+            label: 'devise',
+            active: true,
+            slice: workflowAgentSlice('run', {
+              files: {
+                input: ['Main.lean', 'Lemma.lean'],
+                context: ['notes.md'],
+                media: [],
+                output: [],
+              },
+            }),
+          },
+        ],
+      }),
+      { columns: 100 },
+    );
+
+    expect(output).toContain('devise completed · in:2 ctx:1');
   });
 });

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -590,6 +590,23 @@ describe('CLI TUI row allocation', () => {
     });
   });
 
+  it('charges expanded file details to the existing child-panel budget', () => {
+    expect(
+      allocateConversationBottomPanelRows({
+        maxRows: 10,
+        sessionCount: 2,
+        childListFocused: true,
+        detailContentRows: 4,
+        todosPlanContentRows: 0,
+        transcriptRows: 20,
+      }),
+    ).toEqual({
+      bottomPanelRows: 7,
+      sessionPanelRows: 7,
+      todosPlanRows: 0,
+    });
+  });
+
   it('reserves a separator row above the todos panel', () => {
     // 2 todos + separator = 3 rows when the transcript allows it.
     expect(
@@ -2629,10 +2646,10 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
             agentCategory: AgentCategory.ToolUse,
             model: 'kimi26T',
             instruction: 'Check the enumeration independently.',
-            inputFiles: [],
-            contextFiles: [],
+            inputFiles: ['src/Main.lean'],
+            contextFiles: ['notes/proof.md'],
             mediaFiles: [],
-            outputFiles: [],
+            outputFiles: ['build/Main.olean'],
             editedFile: null,
             editedFiles: [],
             toolConfig: DEFAULT_TOOL_CONFIG,
@@ -2653,6 +2670,12 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
       expect(streams.get().get(root)).toMatchObject({
         model: 'kimi26T',
         category: AgentCategory.ToolUse,
+        files: {
+          input: ['src/Main.lean'],
+          context: ['notes/proof.md'],
+          media: [],
+          output: ['build/Main.olean'],
+        },
         conversation: { toolCallCount: 3 },
       });
     } finally {


### PR DESCRIPTION
## Summary

- retain normalized input, context, media, and output paths from each run configuration in the CLI stream slice
- show compact file counts on subagent rows and reveal bounded path details with `i`
- charge expanded details to the existing bottom-panel row budget and close them when focus or selection changes

## Design

The stream slice stores one canonical file-role object. Counts are derived at display time, avoiding parallel path and count state. The detail view uses the existing child-panel allocation and always preserves at least one visible child row. Headless JSON and NDJSON output are unchanged.

## Validation

- `npm run format`
- `npm run typecheck` (clean full run before the final test-only edits)
- file-scoped ESLint on all changed TypeScript files
- `npm run compile:fast`
- focused Vitest coverage: 32 passing assertions across file retention, formatting, row rendering, selection lifecycle, keyboard interaction, status help, and panel allocation

Closes #9021

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI TUI presentation and local selection state only; file paths are already in run config, with no new persistence or security-sensitive behavior.
> 
> **Overview**
> **Subagent rows in the CLI child list now surface run file roles** without leaving the conversation.
> 
> Each stream slice stores normalized **input, context, media, and output** paths from `run.config`. Rows get a compact suffix (e.g. `in:2 ctx:1 out:1`). With the list focused, **`i` toggles** a detail block under the selection with truncated paths; the status bar advertises **`i files`** for stream rows (not process rows). Expanded details count against the existing bottom-panel row budget, and expansion **resets** on blur, selection change, or focus moves.
> 
> Headless JSON/NDJSON output is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1898fa687f9929504617db3e99c416494c0ddc24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->