### PR TITLE
fix(desktop): preserve host import ratchet

### DIFF
--- a/packages/desktop/src/main/desktopWindowTitle.ts
+++ b/packages/desktop/src/main/desktopWindowTitle.ts
@@ -5,10 +5,7 @@ import { basename } from 'node:path';
 import { type BrowserWindow } from 'electron';
 
 // Local imports
-import type { ExecutionRegistry } from '@agent/runtime/executionRegistry';
-import type { SessionHostInteractions } from '@agent/runtime/HostInteractions';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
-import type { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import { STREAM_PHASE } from '@shared/schemas';
 import {
   formatSessionTitle,
@@ -28,11 +25,9 @@ type DesktopTitleWindow = Pick<
 >;
 
 /** Derive aggregate activity from canonical process-session owners. */
-export function getDesktopSessionActivity(session: {
-  readonly executions: Pick<ExecutionRegistry, 'getAgentHandles'>;
-  readonly interactions: Pick<SessionHostInteractions, 'pendingCount'>;
-  readonly status: Pick<StreamStatusMachine, 'get'>;
-}): DesktopSessionActivity {
+export function getDesktopSessionActivity(
+  session: DesktopTitleSession,
+): DesktopSessionActivity {
   if (session.interactions.pendingCount > 0) return 'approval';
   const hasRunningAgent = session.executions.getAgentHandles().some(
     (handle) =>


### PR DESCRIPTION
## Summary

- remove two newly introduced desktop deep-import specifiers from the session-title projection
- derive the projection's narrow session type from the already-consumed `SessionHandle` contract
- restore the desktop host-import width ratchet without changing title behavior

## Context

PR #9025 merged before its final kernel shard completed. That shard subsequently reported that the desktop host's distinct `@agent/*` deep-import specifier count had increased from 27 to 28. The imports were type-only and redundant: `SessionHandle` already exposes the three required owners.

This correction deletes the direct `ExecutionRegistry` and `StreamStatusMachine` type edges rather than increasing the ratchet baseline.

## Verification

- desktop main TypeScript check
- focused ESLint
- desktop title tests
- host-agent deep-import ratchet test

Follow-up to #9025.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only import cleanup with no runtime logic changes to title projection.
> 
> **Overview**
> Restores the desktop host’s **@agent/** deep-import count after a follow-up to session-title work accidentally added redundant type-only edges to `ExecutionRegistry` and `StreamStatusMachine`.
> 
> `getDesktopSessionActivity` and related title helpers now take a **`DesktopTitleSession`** type defined as `Pick<SessionHandle, 'executions' | 'interactions' | 'status'>` instead of inlining picks against those deeper runtime types. **Window title behavior is unchanged**—only import boundaries and typing narrow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2632092482db011556a06dbec8e1d896cd1cdeb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->