### PR TITLE
feat(cli): show workflow input/context/output files on subagent rows

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -421,6 +421,9 @@ export function App(props: AppProps): React.JSX.Element {
     dispatchChildListSelection({ kind: 'focusStream', streamId });
     focusStreamAndPromoteApprovals(streamId);
   }, []);
+  const toggleRowExpand = useCallback(() => {
+    dispatchChildListSelection({ kind: 'toggleRowExpand' });
+  }, []);
   const foregroundKind = foregroundSurfaceKind({
     activeFormOpen: activeForm !== undefined,
     formBusy,
@@ -729,6 +732,7 @@ export function App(props: AppProps): React.JSX.Element {
           rootStreamId,
           slashPaletteOpen,
           childListFocused,
+          rowExpanded: childListSelection.rowExpanded,
           sessionViews,
           selectedChildValue,
           streams,
@@ -747,6 +751,7 @@ export function App(props: AppProps): React.JSX.Element {
           taskDetailExecutionIdSignal.set(executionId)
         }
         onPrintStream={printStreamOutput}
+        onToggleRowExpand={toggleRowExpand}
         onChildSelectionChange={(value) =>
           dispatchChildListSelection({ kind: 'highlight', value })
         }

--- a/packages/cli/src/chat/tui/appLayout.ts
+++ b/packages/cli/src/chat/tui/appLayout.ts
@@ -148,6 +148,7 @@ export function allocateConversationBottomPanelRows({
   processCount = 0,
   sessionCount,
   childListFocused,
+  detailContentRows = 0,
   todosPlanContentRows,
   transcriptRows,
 }: {
@@ -155,6 +156,10 @@ export function allocateConversationBottomPanelRows({
   readonly processCount?: number;
   readonly sessionCount: number;
   readonly childListFocused: boolean;
+  /** Rows the highlighted row's file-detail panel (`i` keybinding) wants,
+   *  when open. Folded into the child-list panel's own row need so it
+   *  competes for the same budget rather than adding a new ceiling. */
+  readonly detailContentRows?: number;
   readonly todosPlanContentRows: number;
   readonly transcriptRows: number;
 }): {
@@ -163,9 +168,12 @@ export function allocateConversationBottomPanelRows({
   readonly todosPlanRows: number;
 } {
   const childListRowCount = sessionCount + processCount;
-  // The persistent child list owns one blank separator row above its Select.
+  // The persistent child list owns one blank separator row above its Select,
+  // plus whatever the open file-detail panel wants.
   const sessionPanelContentRows =
-    childListRowCount > 0 ? childListRowCount + 1 : 0;
+    childListRowCount > 0
+      ? childListRowCount + 1 + Math.max(0, detailContentRows)
+      : 0;
   // The todos/plan panel likewise owns a separator row above its checklist.
   const todosPanelContentRows =
     todosPlanContentRows > 0 ? todosPlanContentRows + 1 : 0;

--- a/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
@@ -31,15 +31,22 @@ import {
   queuedFollowUpPanelRowCount,
 } from './QueuedFollowUpsPanel';
 import { StaticConversationTranscript } from './StaticConversationTranscript';
-import { SubagentList } from './SubagentList';
+import { SubagentList, SubagentRowDetail } from './SubagentList';
+import { fileDetailLines } from './SubagentListDisplay';
 import { TodosPlanPanel, todosPlanPanelRowCount } from './TodosPlanPanel';
 import type { ForegroundSurfaceKind } from '../appInteractionPolicy';
 import type { PendingApprovalKind } from '../state/approvalQueue';
 import type { ChildListTarget } from '../state/childControls';
-import type { ChildListValue } from '../state/childListSelection';
+import {
+  childListStreamId,
+  type ChildListValue,
+} from '../state/childListSelection';
 import type { StreamSlice } from '../state/cliState';
 import type { TranscriptPrintRequest } from '../state/transcriptLines';
 import type { StreamView } from '../state/streamViews';
+
+/** Bounds on the expand-on-focus file-detail panel's row need. */
+const DETAIL_PANEL_MAX_CONTENT_ROWS = 4;
 
 // Cap the bottom subagent/todos panels so they never crowd out the
 // conversation, even though they now render below the input bar.
@@ -54,6 +61,8 @@ interface ConversationRegionSnapshot {
   readonly slashPaletteOpen: boolean;
   readonly selectedChildValue: ChildListValue | undefined;
   readonly childListFocused: boolean;
+  /** Whether the highlighted row's file-detail panel (`i` keybinding) is open. */
+  readonly rowExpanded: boolean;
   readonly sessionViews: readonly StreamView[];
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
   readonly subagentExecutionLabels: ExecutionLabels;
@@ -82,6 +91,7 @@ interface ConversationRegionProps {
   readonly onRetryExecution: (executionId: string) => void;
   readonly onOpenProcessDetail: (executionId: string) => void;
   readonly onPrintStream: (streamId: StreamTabId) => void;
+  readonly onToggleRowExpand: () => void;
 }
 
 export function ConversationRegion({
@@ -95,6 +105,7 @@ export function ConversationRegion({
   onRetryExecution,
   onOpenProcessDetail,
   onPrintStream,
+  onToggleRowExpand,
   onStaticTranscriptChange,
   renderFooterChrome,
   renderForegroundSurface,
@@ -176,6 +187,22 @@ export function ConversationRegion({
     hasTodosPlanPanel && activeSlice
       ? todosPlanPanelRowCount(activeSlice.todos, activeSlice.plan)
       : 0;
+  // The highlighted row's file-detail panel only makes sense while a child
+  // row is actually highlighted — never for the list-root row (its file
+  // fields, if any, belong to the conversation the transcript already shows).
+  const expandedStreamId = snapshot.rowExpanded
+    ? childListStreamId(snapshot.selectedChildValue)
+    : undefined;
+  const expandedSlice =
+    expandedStreamId && expandedStreamId !== snapshot.childListTarget.streamId
+      ? snapshot.streams.get(expandedStreamId)
+      : undefined;
+  const detailWanted =
+    !foregroundOpen && snapshot.childListFocused && snapshot.rowExpanded;
+  const detailLines = detailWanted ? fileDetailLines(expandedSlice) : [];
+  const detailContentRows = detailWanted
+    ? clamp(Math.max(detailLines.length, 1), 1, DETAIL_PANEL_MAX_CONTENT_ROWS)
+    : 0;
   const {
     bottomPanelRows: bottomPanelBudget,
     sessionPanelRows: subagentRows,
@@ -185,6 +212,7 @@ export function ConversationRegion({
     processCount: foregroundOpen ? 0 : activeProcesses.length,
     sessionCount: foregroundOpen ? 0 : snapshot.sessionViews.length,
     childListFocused: snapshot.childListFocused,
+    detailContentRows,
     todosPlanContentRows,
     transcriptRows,
   });
@@ -192,6 +220,18 @@ export function ConversationRegion({
   const childListHasRows =
     snapshot.sessionViews.length > 0 || activeProcesses.length > 0;
   const childListVisible = childListHasRows && subagentRows > 1;
+  // subagentRows now covers the list plus any open detail panel; give the
+  // list what it actually needs first (never additive on top of the shared
+  // budget) and hand the remainder — up to what the detail panel asked
+  // for — to SubagentRowDetail. Starvation naturally yields 0 detail rows.
+  const childListNeededRows = childListHasRows
+    ? snapshot.sessionViews.length + activeProcesses.length + 1
+    : 0;
+  const listRows = Math.min(subagentRows, childListNeededRows);
+  const detailRows = Math.max(
+    0,
+    Math.min(detailContentRows, subagentRows - listRows),
+  );
   useLayoutEffect(() => {
     if (snapshot.childListFocused && !foregroundOpen && !childListVisible) {
       onCancelChildList();
@@ -253,13 +293,14 @@ export function ConversationRegion({
           <Box flexDirection="column" overflowY="hidden">
             <SubagentList
               keyboardActive={snapshot.childListFocused && childListVisible}
-              maxRows={subagentRows}
+              maxRows={listRows}
               onCancel={onCancelChildList}
               onFocusStream={onFocusSession}
               onKillExecution={onKillExecution}
               onSkipExecution={onSkipExecution}
               onRetryExecution={onRetryExecution}
               onOpenProcessDetail={onOpenProcessDetail}
+              onToggleRowExpand={onToggleRowExpand}
               onSelectionChange={onChildSelectionChange}
               onPrintStream={onPrintStream}
               pendingApprovals={snapshot.pendingApprovals}
@@ -270,6 +311,9 @@ export function ConversationRegion({
               activeSubagentExecutionIds={snapshot.activeSubagentExecutionIds}
               processOutput={snapshot.childListTarget.slice?.processOutput}
             />
+            {detailRows > 0 ? (
+              <SubagentRowDetail lines={detailLines} maxRows={detailRows} />
+            ) : null}
             <TodosPlanPanel maxRows={todosPlanRows} />
           </Box>
         ) : null}

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -36,6 +36,7 @@ import { Select, visibleSelectRange } from '../ui/Select';
 import {
   CHILD_ROW_METADATA_MIN_COLUMNS,
   CHILD_STATUS_MARKER,
+  childFileBadgeText,
   childRowMetadataText,
   childStatusColor,
   pendingApprovalRowSuffix,
@@ -168,6 +169,11 @@ function SessionRow({
   // the conversation itself — echoing its own last exchange there is noise
   // (and the root can itself be a nested subagent when focus is scoped).
   const summary = isListRoot ? undefined : session.slice?.description;
+  // Last in the identity text — the first thing Ink truncates under width
+  // pressure, so a busy narrow terminal sheds it before status/model/elapsed.
+  const fileBadges = isListRoot
+    ? undefined
+    : childFileBadgeText(session.slice?.fileCounts);
   return (
     <Box
       flexDirection="row"
@@ -191,6 +197,7 @@ function SessionRow({
           {roundLabel ? ` · ${roundLabel}` : ''}
           {modelLabel ? ` · ${modelLabel}` : ''}
           {!metadataColumn && elapsed ? ` · ${elapsed}` : ''}
+          {fileBadges ? ` · ${fileBadges}` : ''}
         </Text>
       </Box>
       {summary ? (
@@ -259,6 +266,36 @@ function ProcessRow({
   );
 }
 
+const FILE_DETAIL_FALLBACK_LINE = 'No file info for this row';
+
+/** Expand-on-focus (`i`) file detail panel for the highlighted row. Bounded
+ *  and stateless: `lines` is precomputed by the caller from the highlighted
+ *  row's `StreamSlice`, `maxRows` is whatever the shared bottom-panel row
+ *  budget allotted it. Always shows at least the fallback line when open, so
+ *  the keypress gives visible feedback rather than a silent no-op. */
+export function SubagentRowDetail({
+  lines,
+  maxRows,
+}: {
+  readonly lines: readonly string[];
+  readonly maxRows: number;
+}): React.JSX.Element | null {
+  if (maxRows <= 0) return null;
+  const rows =
+    lines.length > 0 ? lines.slice(0, maxRows) : [FILE_DETAIL_FALLBACK_LINE];
+  return (
+    <Box flexDirection="column" paddingX={1} overflowY="hidden">
+      {rows.map((line, index) => (
+        // Static formatted lines rendered together each pass — index keys
+        // are safe here, there is no insert/remove to preserve identity for.
+        <Text key={index} dimColor wrap="truncate-end">
+          {line}
+        </Text>
+      ))}
+    </Box>
+  );
+}
+
 export interface SubagentListProps {
   readonly keyboardActive?: boolean;
   readonly maxRows?: number;
@@ -270,6 +307,8 @@ export interface SubagentListProps {
   /** Retry the focused, in-flight workflow-script grandchild `agent()` call. */
   readonly onRetryExecution?: (executionId: string) => void;
   readonly onOpenProcessDetail?: (executionId: string) => void;
+  /** Toggle the highlighted row's file-detail panel (`i` keybinding). */
+  readonly onToggleRowExpand?: () => void;
   readonly onSelectionChange?: (value: ChildListValue) => void;
   readonly onPrintStream?: (streamId: StreamTabId) => void;
   /** Pending approval kinds per stream id (see `pendingApprovalSummaries`,
@@ -391,6 +430,10 @@ export function SubagentList(
         if (!executionId) return;
         if (pressed === 's') props.onSkipExecution?.(executionId);
         else props.onRetryExecution?.(executionId);
+        return;
+      }
+      if (pressed === 'i') {
+        props.onToggleRowExpand?.();
         return;
       }
       if (pressed !== 'k') return;

--- a/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
@@ -2,6 +2,9 @@
 import { formatCompactTokenCount } from '@utils/core';
 import { formatResultCount } from '@utils/text/stringUtils';
 
+// Local imports - TUI rendering
+import { truncateSummaryToWidth } from '../render/terminalText';
+
 // Local imports - TUI state and presentation
 import { isChildExecutionErrorStatus } from '../state/childExecutionStatus';
 import {
@@ -12,6 +15,7 @@ import {
 } from '../ui/colors';
 import { STATUS_DOT, TOKENS_GENERATED } from '../ui/glyphs';
 import type { PendingApprovalKind } from '../state/approvalQueue';
+import type { ChildFileCounts, StreamSlice } from '../state/cliState';
 
 export function childStatusColor(status: string | undefined): string {
   if (!status) return COLOR_SUCCESS;
@@ -83,4 +87,62 @@ export function pendingApprovalRowSuffix(
   if (kinds === undefined || first === undefined) return undefined;
   const label = PENDING_APPROVAL_ROW_LABELS[first];
   return kinds.length > 1 ? `${label} +${kinds.length - 1}` : label;
+}
+
+/** Compact `in:2 ctx:1` badge appended last in a session row's identity
+ *  text — the first segment Ink truncates under width pressure, so it can
+ *  never crowd out status/model/elapsed. Categories at zero (or the whole
+ *  count still unarrived) are omitted rather than shown as `in:0`. */
+export function childFileBadgeText(
+  counts: ChildFileCounts | undefined,
+): string | undefined {
+  if (!counts) return undefined;
+  const parts = [
+    counts.input > 0 ? `in:${counts.input}` : undefined,
+    counts.context > 0 ? `ctx:${counts.context}` : undefined,
+    counts.media > 0 ? `media:${counts.media}` : undefined,
+    counts.output > 0 ? `out:${counts.output}` : undefined,
+  ].filter((part): part is string => part !== undefined);
+  return parts.length > 0 ? parts.join(' ') : undefined;
+}
+
+export type ChildFileDetail = Pick<
+  StreamSlice,
+  'inputFiles' | 'contextFiles' | 'mediaFiles' | 'outputFiles'
+>;
+
+const FILE_DETAIL_LABELS: ReadonlyArray<{
+  readonly key: keyof ChildFileDetail;
+  readonly label: string;
+}> = [
+  { key: 'inputFiles', label: 'Input' },
+  { key: 'contextFiles', label: 'Context' },
+  { key: 'mediaFiles', label: 'Media' },
+  { key: 'outputFiles', label: 'Output' },
+];
+
+const FILE_DETAIL_LINE_MAX_COLUMNS = 100;
+
+/** Up to 4 short `Label: a, b, c` lines for the expand-on-focus file detail
+ *  panel — one per non-empty category, empty categories omitted. Returns
+ *  `[]` when no file data has arrived yet (the panel then shows its own
+ *  dim fallback line, so the `i` keypress always gives visible feedback).
+ *  `truncateSummaryToWidth` collapses whitespace, so the label/list gap is
+ *  a single space regardless of how it's written here. */
+export function fileDetailLines(
+  detail: ChildFileDetail | undefined,
+): readonly string[] {
+  if (!detail) return [];
+  const lines: string[] = [];
+  for (const { key, label } of FILE_DETAIL_LABELS) {
+    const files = detail[key];
+    if (!files || files.length === 0) continue;
+    lines.push(
+      truncateSummaryToWidth(
+        `${label}: ${files.join(', ')}`,
+        FILE_DETAIL_LINE_MAX_COLUMNS,
+      ),
+    );
+  }
+  return lines;
 }

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -604,6 +604,10 @@ function childListBindingsText(
     selectionKind === 'stream'
       ? keyHintText({ key: 'v', action: 'full output' })
       : undefined;
+  const filesBinding =
+    selectionKind === 'stream'
+      ? keyHintText({ key: 'i', action: 'files' })
+      : undefined;
   const killBinding = selectionKillable
     ? keyHintText({ key: 'k', action: 'kill' })
     : undefined;
@@ -618,6 +622,7 @@ function childListBindingsText(
       keyHintText({ key: 'Up/Down', action: 'select' }),
       enterBinding,
       fullOutputBinding,
+      filesBinding,
       killBinding,
       skipBinding,
       retryBinding,

--- a/packages/cli/src/chat/tui/state/childListSelection.ts
+++ b/packages/cli/src/chat/tui/state/childListSelection.ts
@@ -30,6 +30,10 @@ export function childListProcessId(
 export interface ChildListSelectionState {
   readonly focused: boolean;
   readonly selectedValue: ChildListValue | undefined;
+  /** Whether the highlighted row's file-detail panel (`i` keybinding) is
+   *  open. Scoped to "the currently highlighted row": reset on every focus
+   *  or selection change so it never survives a moved highlight. */
+  readonly rowExpanded: boolean;
 }
 
 type ChildListSelectionAction =
@@ -37,6 +41,7 @@ type ChildListSelectionAction =
   | { readonly kind: 'focus'; readonly value?: ChildListValue }
   | { readonly kind: 'focusStream'; readonly streamId: StreamTabId }
   | { readonly kind: 'highlight'; readonly value: ChildListValue }
+  | { readonly kind: 'toggleRowExpand' }
   | {
       readonly kind: 'syncActiveStream';
       readonly streamId: StreamTabId;
@@ -51,6 +56,7 @@ type ChildListSelectionAction =
 export const INITIAL_CHILD_LIST_SELECTION: ChildListSelectionState = {
   focused: false,
   selectedValue: undefined,
+  rowExpanded: false,
 };
 
 function resolveChildSelectionValue(
@@ -74,19 +80,23 @@ export function reduceChildListSelection(
 ): ChildListSelectionState {
   switch (action.kind) {
     case 'blur':
-      return { ...state, focused: false };
+      return { ...state, focused: false, rowExpanded: false };
     case 'focus':
       return {
         focused: true,
         selectedValue: state.selectedValue ?? action.value,
+        rowExpanded: false,
       };
     case 'focusStream':
       return {
         focused: false,
         selectedValue: childStreamListValue(action.streamId),
+        rowExpanded: false,
       };
     case 'highlight':
-      return { ...state, selectedValue: action.value };
+      return { ...state, selectedValue: action.value, rowExpanded: false };
+    case 'toggleRowExpand':
+      return { ...state, rowExpanded: !state.rowExpanded };
     case 'syncActiveStream':
       return {
         ...state,
@@ -95,6 +105,7 @@ export function reduceChildListSelection(
           undefined,
           action.streamId,
         ),
+        rowExpanded: false,
       };
     case 'reconcile': {
       if (action.values.length === 0) return state;
@@ -105,7 +116,7 @@ export function reduceChildListSelection(
       );
       return selectedValue === state.selectedValue
         ? state
-        : { ...state, selectedValue };
+        : { ...state, selectedValue, rowExpanded: false };
     }
   }
 }

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -119,6 +119,15 @@ export interface BypassState {
   readonly superYolo: boolean;
 }
 
+/** Per-category file counts captured from a stream's most recent
+ *  `'run.config'` fact. Drives the subagent row's compact file badge. */
+export interface ChildFileCounts {
+  readonly input: number;
+  readonly context: number;
+  readonly media: number;
+  readonly output: number;
+}
+
 export interface StreamSlice {
   readonly streamId: StreamTabId;
   /** Model identity captured from setTaskState for this specific stream. */
@@ -129,6 +138,18 @@ export interface StreamSlice {
   readonly category: AgentCategory | undefined;
   readonly status: StreamPhase | undefined;
   readonly substate?: StreamSubstate;
+  /** Per-category file counts from the stream's `'run.config'` fact; drives
+   *  the row's compact file badge (`in:2 ctx:1`). Absent until the fact
+   *  arrives, or if every category is empty. */
+  readonly fileCounts?: ChildFileCounts;
+  /** File paths from the same `'run.config'` fact, for the expand-on-focus
+   *  file detail panel (`i` keybinding). Only populated end-to-end today for
+   *  `inputFiles` on workflow-script `agent()` grandchildren; the other
+   *  three stay empty until the upstream DSL/runner gap is closed. */
+  readonly inputFiles?: readonly string[];
+  readonly contextFiles?: readonly string[];
+  readonly mediaFiles?: readonly string[];
+  readonly outputFiles?: readonly string[];
   /** Epoch ms when this stream last entered `RUNNING`; cleared on any other
    *  status. Drives the StatusBar's live elapsed-time segment so a long
    *  token-less "thinking" turn still shows liveness. */

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -27,6 +27,7 @@ import {
   getCliStateGeneration,
   removeStream,
   patchStream,
+  type ChildFileCounts,
   type StreamSlice,
 } from './cliState';
 import {
@@ -85,15 +86,66 @@ function applySetActiveStream(payload: SetActiveStreamPayload): void {
   }
 }
 
+function fileFieldCounts(config: AgentConfig): ChildFileCounts {
+  return {
+    input: config.inputFiles.length,
+    context: config.contextFiles.length,
+    media: config.mediaFiles.length,
+    output: config.outputFiles.length,
+  };
+}
+
+function sameFileCounts(
+  left: ChildFileCounts | undefined,
+  right: ChildFileCounts,
+): boolean {
+  return (
+    left !== undefined &&
+    left.input === right.input &&
+    left.context === right.context &&
+    left.media === right.media &&
+    left.output === right.output
+  );
+}
+
+function sameFileList(
+  left: readonly string[] | undefined,
+  right: readonly string[],
+): boolean {
+  return (
+    left !== undefined &&
+    left.length === right.length &&
+    left.every((item, index) => item === right[index])
+  );
+}
+
+// `run.config` already carries the full normalized AgentConfig — including
+// inputFiles/contextFiles/mediaFiles/outputFiles — for every child stream
+// (see AgentRunLifecycle.emitRunStart). Retaining the file fields here is
+// what feeds the subagent row's file badge and its expand-on-focus detail.
 function applyRunConfig(streamId: StreamTabId, config: AgentConfig): void {
   patchStream(streamId, (s) => {
-    if (s.model === config.model && s.category === config.agentCategory) {
+    const fileCounts = fileFieldCounts(config);
+    if (
+      s.model === config.model &&
+      s.category === config.agentCategory &&
+      sameFileCounts(s.fileCounts, fileCounts) &&
+      sameFileList(s.inputFiles, config.inputFiles) &&
+      sameFileList(s.contextFiles, config.contextFiles) &&
+      sameFileList(s.mediaFiles, config.mediaFiles) &&
+      sameFileList(s.outputFiles, config.outputFiles)
+    ) {
       return s;
     }
     return {
       ...s,
       model: config.model,
       category: config.agentCategory,
+      fileCounts,
+      inputFiles: config.inputFiles,
+      contextFiles: config.contextFiles,
+      mediaFiles: config.mediaFiles,
+      outputFiles: config.outputFiles,
     };
   });
 }

--- a/src/test-kernel/cli/ChildListInteraction.vitest.mts
+++ b/src/test-kernel/cli/ChildListInteraction.vitest.mts
@@ -149,6 +149,43 @@ describe('CLI child list interaction', () => {
     }
   });
 
+  it('toggles the highlighted row file-detail panel on i', async () => {
+    const { ink, React } = await loadInk();
+    const root = 'root' as StreamTabId;
+    const child = 'child' as StreamTabId;
+    const onToggleRowExpand = vi.fn();
+
+    const stdin = new FakeStdin();
+    const instance = ink.render(
+      React.createElement(SubagentList, {
+        keyboardActive: true,
+        maxRows: 5,
+        onCancel: vi.fn(),
+        onSelectionChange: vi.fn(),
+        onToggleRowExpand,
+        selectedValue: childStreamListValue(child),
+        sessions: [session(root, true), session(child)],
+      }),
+      {
+        stdin,
+        stdout: new FakeStdout(100),
+        interactive: true,
+        exitOnCtrlC: false,
+        patchConsole: false,
+      },
+    );
+
+    try {
+      await waitFor(() => stdin.listenerCount('readable') > 0);
+      stdin.write('i');
+      await waitFor(() => onToggleRowExpand.mock.calls.length === 1);
+
+      expect(onToggleRowExpand).toHaveBeenCalledOnce();
+    } finally {
+      instance.unmount();
+    }
+  });
+
   it('hands focus back to the input instead of wrapping past the last row', async () => {
     const { ink, React } = await loadInk();
     const root = 'root' as StreamTabId;

--- a/src/test-kernel/cli/ChildListSelection.vitest.mts
+++ b/src/test-kernel/cli/ChildListSelection.vitest.mts
@@ -57,13 +57,18 @@ describe('CLI child list selection', () => {
       main,
     );
 
-    expect(state).toEqual({ focused: true, selectedValue: processValue });
+    expect(state).toEqual({
+      focused: true,
+      selectedValue: processValue,
+      rowExpanded: false,
+    });
   });
 
   it('preserves selection while hidden and restores it when rows return', () => {
     const selected: ChildListSelectionState = {
       focused: true,
       selectedValue: strategyValue,
+      rowExpanded: false,
     };
     const hidden = reconcileSelection(selected, [], main);
     const restored = reconcileSelection(
@@ -78,7 +83,7 @@ describe('CLI child list selection', () => {
 
   it('selects the owner when lifecycle completion changes the active stream', () => {
     const state = reduceChildListSelection(
-      { focused: true, selectedValue: strategyValue },
+      { focused: true, selectedValue: strategyValue, rowExpanded: false },
       {
         kind: 'syncActiveStream',
         streamId: main,
@@ -86,12 +91,16 @@ describe('CLI child list selection', () => {
       },
     );
 
-    expect(state).toEqual({ focused: true, selectedValue: mainValue });
+    expect(state).toEqual({
+      focused: true,
+      selectedValue: mainValue,
+      rowExpanded: false,
+    });
   });
 
   it('clears a stale row when the active stream is not in the projected list', () => {
     const state = reduceChildListSelection(
-      { focused: true, selectedValue: strategyValue },
+      { focused: true, selectedValue: strategyValue, rowExpanded: false },
       {
         kind: 'syncActiveStream',
         streamId: main,
@@ -99,12 +108,41 @@ describe('CLI child list selection', () => {
       },
     );
 
-    expect(state).toEqual({ focused: true, selectedValue: undefined });
+    expect(state).toEqual({
+      focused: true,
+      selectedValue: undefined,
+      rowExpanded: false,
+    });
+  });
+
+  it('collapses the file-detail panel when the highlight moves to a new row', () => {
+    const expanded: ChildListSelectionState = {
+      focused: true,
+      selectedValue: mainValue,
+      rowExpanded: true,
+    };
+    expect(
+      reduceChildListSelection(expanded, { kind: 'toggleRowExpand' }),
+    ).toEqual({ focused: true, selectedValue: mainValue, rowExpanded: false });
+    expect(
+      reduceChildListSelection(expanded, {
+        kind: 'highlight',
+        value: strategyValue,
+      }),
+    ).toEqual({
+      focused: true,
+      selectedValue: strategyValue,
+      rowExpanded: false,
+    });
   });
 
   it('falls back to the active stream and then the first row', () => {
     let state = reconcileSelection(
-      { focused: true, selectedValue: childProcessListValue('gone') },
+      {
+        focused: true,
+        selectedValue: childProcessListValue('gone'),
+        rowExpanded: false,
+      },
       [processValue, mainValue],
       main,
     );
@@ -126,14 +164,22 @@ describe('CLI child list selection', () => {
       kind: 'focus',
       value: processValue,
     });
-    expect(state).toEqual({ focused: true, selectedValue: processValue });
+    expect(state).toEqual({
+      focused: true,
+      selectedValue: processValue,
+      rowExpanded: false,
+    });
   });
 
   it('returns input after a stream is focused', () => {
     const state = reduceChildListSelection(
-      { focused: true, selectedValue: processValue },
+      { focused: true, selectedValue: processValue, rowExpanded: true },
       { kind: 'focusStream', streamId: strategy },
     );
-    expect(state).toEqual({ focused: false, selectedValue: strategyValue });
+    expect(state).toEqual({
+      focused: false,
+      selectedValue: strategyValue,
+      rowExpanded: false,
+    });
   });
 });

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest';
 
 import {
   CHILD_STATUS_MARKER,
+  childFileBadgeText,
   childRowMetadataText,
   childStatusColor,
+  fileDetailLines,
   pendingApprovalRowSuffix,
 } from '@cli/chat/tui/panes/SubagentListDisplay';
 import {
@@ -234,6 +236,39 @@ describe('CLI child list display model', () => {
     ).toBe('45s');
   });
 
+  it('builds the compact file-count badge from non-zero categories only', () => {
+    expect(childFileBadgeText(undefined)).toBeUndefined();
+    expect(
+      childFileBadgeText({ input: 0, context: 0, media: 0, output: 0 }),
+    ).toBeUndefined();
+    expect(
+      childFileBadgeText({ input: 2, context: 1, media: 0, output: 0 }),
+    ).toBe('in:2 ctx:1');
+    expect(
+      childFileBadgeText({ input: 0, context: 0, media: 1, output: 3 }),
+    ).toBe('media:1 out:3');
+  });
+
+  it('builds one file-detail line per non-empty category, in a fixed order', () => {
+    expect(fileDetailLines(undefined)).toEqual([]);
+    expect(
+      fileDetailLines({
+        inputFiles: [],
+        contextFiles: [],
+        mediaFiles: [],
+        outputFiles: [],
+      }),
+    ).toEqual([]);
+    expect(
+      fileDetailLines({
+        inputFiles: ['a.tex', 'b.bib'],
+        contextFiles: [],
+        mediaFiles: undefined,
+        outputFiles: ['out.tex'],
+      }),
+    ).toEqual(['Input: a.tex, b.bib', 'Output: out.tex']);
+  });
+
   it('omits the model from bash rows while retaining agent row details', async () => {
     const { ink, React } = await loadInk();
     const run = 'run' as StreamTabId;
@@ -312,5 +347,56 @@ describe('CLI child list display model', () => {
     expect(output).toContain('bash running · gpt56');
     expect(output).toContain('5 tool calls');
     expect(output).toContain('↓40k');
+  });
+
+  it('shows the file-count badge on a child row and omits it on the list root', async () => {
+    const { ink, React } = await loadInk();
+    const run = 'run' as StreamTabId;
+    const agent = 'agent-1' as StreamTabId;
+    const streams = new Map<StreamTabId, StreamSlice>([
+      [run, workflowAgentSlice('run', { status: STREAM_PHASE.RUNNING })],
+      [
+        agent,
+        workflowAgentSlice('agent-1', {
+          model: 'gpt56',
+          status: STREAM_PHASE.RUNNING,
+          fileCounts: { input: 2, context: 1, media: 0, output: 0 },
+        }),
+      ],
+    ]);
+    const parentStream = new Map<StreamTabId, StreamTabId>([[agent, run]]);
+    const childStreamEntries = buildChildStreamEntries({
+      parentStreamId: run,
+      retained: [
+        {
+          kind: 'subagent',
+          executionId: 'agent-exec',
+          agentName: 'devise',
+          childStreamId: agent,
+          status: STREAM_PHASE.RUNNING,
+        },
+      ],
+    });
+    const sessions = streamTreeViews({
+      activeStreamId: run,
+      childStreamEntries,
+      parentStream,
+      rootStreamId: run,
+      streams,
+    });
+    const output: string = ink.renderToString(
+      React.createElement(SubagentList, {
+        listRootStreamId: run,
+        maxRows: 6,
+        keyboardActive: false,
+        sessions,
+      }),
+      { columns: 100 },
+    );
+
+    expect(output).toContain('gpt56 · in:2 ctx:1');
+    // The list-root row never shows a file badge, even if its own slice
+    // somehow carried file counts — it's the conversation, not a run.
+    expect(output.match(/in:2 ctx:1/g)).toHaveLength(1);
   });
 });

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -590,6 +590,38 @@ describe('CLI TUI row allocation', () => {
     });
   });
 
+  it('folds the file-detail panel into the child list panel need, not the cap', () => {
+    // Plenty of room: the list gets its own rows plus the detail rows it asked for.
+    expect(
+      allocateConversationBottomPanelRows({
+        maxRows: 10,
+        sessionCount: 2,
+        childListFocused: true,
+        detailContentRows: 3,
+        todosPlanContentRows: 0,
+        transcriptRows: 8,
+      }),
+    ).toEqual({ bottomPanelRows: 6, sessionPanelRows: 6, todosPlanRows: 0 });
+    // Starved budget: the detail request is folded in but never grows the
+    // overall cap — same bottomPanelRows ceiling as an unexpanded row.
+    const starved = allocateConversationBottomPanelRows({
+      maxRows: 10,
+      sessionCount: 2,
+      childListFocused: true,
+      detailContentRows: 4,
+      todosPlanContentRows: 3,
+      transcriptRows: 5,
+    });
+    const unexpanded = allocateConversationBottomPanelRows({
+      maxRows: 10,
+      sessionCount: 2,
+      childListFocused: true,
+      todosPlanContentRows: 3,
+      transcriptRows: 5,
+    });
+    expect(starved.bottomPanelRows).toBe(unexpanded.bottomPanelRows);
+  });
+
   it('reserves a separator row above the todos panel', () => {
     // 2 todos + separator = 3 rows when the transcript allows it.
     expect(


### PR DESCRIPTION
## Summary
- Fixes #9021. Each workflow-script `agent()` child row (`SubagentList.tsx`) now shows a compact `in:2 ctx:1` file-count badge, plus an `i`-keypress expand-on-focus panel with actual filenames — both sourced from the `run.config` fact, which already carried the file fields over the wire but had them silently discarded in `applyRunConfig`.
- The detail panel folds its row need into the existing bottom-panel budget (`allocateConversationBottomPanelRows`) instead of adding a new ceiling, and resets on any focus/selection change so it never survives a moved highlight.
- Zero headless-path impact: `texra run` / `--print` / `--output-format json|ndjson` never import any of the touched `chat/tui/` modules.
- Design was produced by a 6-agent Understand→Design→Judge workflow (mapped the CLI TUI vs. extension surfaces, scored 3 competing designs, synthesized a hybrid); a fourth "auto-inject a Static scrollback block on completion" option was explicitly rejected for breaking the user-triggered-only precedent Ctrl-T sets for `<Static>` content — noted as a deferred follow-up in the issue.
- Two upstream gaps are explicitly out of scope, called out in #9021: `contextFiles`/`outputFiles` aren't populated at all yet for workflow-script `agent()` calls (`WorkflowAgentCallOptions`/`createWorkflowScriptAgentRunner`), and the extension's compare/accept/merge Generated-Files parity isn't reproduced here (Static/bounded-panel content can't host live actions).

## Test plan
- [x] `npx vitest run` on the 5 affected suites (`ChildListSelection`, `ChildListInteraction`, `SubagentListDisplay`, `TuiStateAndFocus`, `StatusBar`) — 221/221 passing, including new coverage for the badge/detail formatters, the `toggleRowExpand` reducer action, the `i` keybinding, and the row-budget fold-in.
- [x] `tsc --noEmit -p tsconfig.test-kernel.json` — clean.
- [ ] CI: full monorepo `npm run typecheck` (local run was blocked by sustained ~55-65 machine load from unrelated concurrent jobs; the test-kernel tsc pass above type-checks the production `packages/cli` sources transitively via the `@cli/*` alias).

https://claude.ai/code/session_01Xs4F8Adxe7mrkNeEVBqHYJ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI TUI presentation and state only—no auth, persistence, or headless run behavior; file data was already on the wire via `run.config`.
> 
> **Overview**
> Workflow child rows in the CLI TUI now surface **per-run file metadata** from the existing `run.config` fact instead of discarding it in `applyRunConfig`.
> 
> Each non-root subagent row gets a compact badge (e.g. `in:2 ctx:1`) appended last so narrow terminals truncate it before status/model/elapsed. Pressing **`i`** while the child list is focused toggles a bounded **`SubagentRowDetail`** panel under the list with `Label: path, …` lines (or a fallback when data is missing). Expansion state lives in **`rowExpanded`** on child-list selection and **resets** on blur, focus, highlight, and reconcile so it never sticks to a different row.
> 
> Bottom-panel row allocation **folds** the detail panel’s height into the same budget as the child list (`detailContentRows` in `allocateConversationBottomPanelRows`); the status bar advertises **`i` → files** for stream rows. Scope is TUI-only; headless `texra run` paths are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7755b69d76ccca2a807ff92818f9b4ab9e594570. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->