### PR TITLE
fix: bound five unrelated memory-usage findings from an audit sweep

### DIFF
--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -703,7 +703,16 @@ window.addEventListener('message', (event) => {
 // Wire <stream-tabs> + <stream-conversation> events to shared handlers
 // =============================================================================
 
+// Each guard below protects its wiring function against double-registration:
+// a bootstrap recovery attempt that itself fails re-renders the same
+// fallback UI, whose button re-invokes recoverFromBootstrapFallback()
+// against these same module-level railTabs/conversationView elements, which
+// never get recreated or torn down for the life of the renderer.
+let railTabsWired = false;
+
 function wireRailTabs(): void {
+  if (railTabsWired) return;
+  railTabsWired = true;
   railTabs.addEventListener('stream-switch', ((e: CustomEvent) => {
     handleStreamSwitch(e);
     // Switching to a stream pulls the user out of the launcher view.
@@ -720,7 +729,11 @@ function wireRailTabs(): void {
   railTabs.addEventListener('delete-all', handleDeleteAll as EventListener);
 }
 
+let conversationWired = false;
+
 function wireConversation(): void {
+  if (conversationWired) return;
+  conversationWired = true;
   conversationView.addEventListener(
     'stream-switch',
     handleStreamSwitch as EventListener,

--- a/packages/extension/src/frontend/latex/inlineCriticism.ts
+++ b/packages/extension/src/frontend/latex/inlineCriticism.ts
@@ -178,6 +178,18 @@ export function pushManualCriticism(entry: ManualCriticismEntry): boolean {
   );
 
   const existing = collection.get(uri) ?? [];
+  // This list is only ever cleared by the whole-feature enable/disable
+  // toggle, so a critique agent re-flagging the same line/message across
+  // repeated rounds would otherwise stack an unbounded number of identical
+  // squiggles. Skip re-adding an exact duplicate instead.
+  const isDuplicate = existing.some(
+    (d) =>
+      d.code === CODE_TOOL &&
+      d.range.start.line === range.start.line &&
+      d.message === diag.message,
+  );
+  if (isDuplicate) return true;
+
   collection.set(uri, [...existing, diag]);
   return true;
 }

--- a/packages/extension/src/progressView/frontend/components/LogList.ts
+++ b/packages/extension/src/progressView/frontend/components/LogList.ts
@@ -36,7 +36,7 @@ import { PersistedState } from '@shared/state/PersistedState';
 import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 import { ToggleStateStore } from '@shared/state/ToggleStateStore';
 import { copyWithFeedback } from '@shared/utils/clipboard';
-import { webviewStorage } from '../webviewStorage';
+import { logListStateKey, webviewStorage } from '../webviewStorage';
 import { getComposedPathElement } from '../utils';
 
 // Local imports - progress view contexts
@@ -213,7 +213,7 @@ export class LogList extends LitElement {
 
     const stateManager = new PersistedState(
       this.storage,
-      `logListState:${streamId}`,
+      logListStateKey(streamId),
       LogListStateSchema,
     );
     const toggleStates = new ToggleStateStore(() => {

--- a/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
@@ -45,6 +45,7 @@ import {
   removePermissionsForStream,
   updateParentStreamId,
 } from '../stateUtils';
+import { logListStateKey, webviewStorage } from '../webviewStorage';
 
 // ============================================================
 // Helpers
@@ -180,6 +181,7 @@ export const streamLifecycleHandlers = {
     clearCopyContentStore();
     clearProposalInputStore();
     deleteFollowUpInputTransientState(streamId);
+    webviewStorage.delete(logListStateKey(streamId));
 
     // Remove permissions for the deleted stream to prevent orphaned entries
     permissions$.set(removePermissionsForStream(permissions$.get(), streamId));
@@ -205,6 +207,13 @@ export const streamLifecycleHandlers = {
 
     // Clear all permissions — no streams means no valid permissions
     permissions$.set([]);
+
+    // Every remaining stream's persisted toggle state loses its only future
+    // consumer here (the stream itself is about to disappear from
+    // streamById below) — read the ids before the reset wipes them.
+    for (const streamId of appState.get().streamById.keys()) {
+      webviewStorage.delete(logListStateKey(streamId));
+    }
 
     appState.set(
       create(appState.get(), (draft) => {

--- a/packages/extension/src/progressView/frontend/webviewStorage.ts
+++ b/packages/extension/src/progressView/frontend/webviewStorage.ts
@@ -10,3 +10,12 @@ import { hostBridge } from '@shared/hostBridge';
 import { createWebviewStorage } from '@shared/state/PersistedState';
 
 export const webviewStorage = createWebviewStorage(hostBridge);
+
+/**
+ * Key format for LogList's per-stream toggle-state entries. Single owner so
+ * the creator (LogList) and the deleters (stream lifecycle handlers) can't
+ * drift apart.
+ */
+export function logListStateKey(streamId: string): string {
+  return `logListState:${streamId}`;
+}

--- a/packages/trace-viewer/src/main.ts
+++ b/packages/trace-viewer/src/main.ts
@@ -16,9 +16,9 @@ import {
   handleToolbarCommand,
 } from '@progressView/frontend/eventHandlers';
 
+import type { TraceDocument } from '@transcript';
 import { replayTrace } from './replayTrace';
 import { parseTraceData } from './traceDataSchema';
-import type { TraceDocument } from '@transcript';
 
 const root = document.querySelector<HTMLElement>('#app');
 if (root == null) throw new Error('Trace viewer root (#app) not found.');
@@ -57,8 +57,16 @@ conversationView.addEventListener(
  * a clear error here instead of failing deep inside `dispatchMessage`.
  */
 async function loadTrace(): Promise<TraceDocument> {
-  const inline = (window as { __TEXRA_TRACE__?: unknown }).__TEXRA_TRACE__;
-  if (inline) return parseTraceData(inline);
+  const globalWindow = window as { __TEXRA_TRACE__?: unknown };
+  const inline = globalWindow.__TEXRA_TRACE__;
+  if (inline) {
+    // Once consumed, drop the raw copy — nothing else reads this global, and
+    // this is a single-page app with no further navigation, so otherwise the
+    // whole raw trace document sits on `window` for the page's entire
+    // lifetime alongside whatever the progress-view store now holds.
+    delete globalWindow.__TEXRA_TRACE__;
+    return parseTraceData(inline);
+  }
 
   const params = new URLSearchParams(window.location.search);
   const file = params.get('trace') ?? 'trace.json';

--- a/src/agent/output/OutputFileProcessor.ts
+++ b/src/agent/output/OutputFileProcessor.ts
@@ -196,7 +196,6 @@ export class OutputFileProcessor {
       async () => {
         const rawContent = await FlexibleFS.read(rawOutput);
         const tagContents: Record<string, string[]> = {};
-        const documents: string[] = [];
 
         const documentEntries = extractMultipleTextFromTag(
           rawContent,
@@ -206,13 +205,6 @@ export class OutputFileProcessor {
           tagContents[OUTPUT_DOCUMENTS_TAG] = documentEntries.map((e) =>
             e.content.trim(),
           );
-
-          for (const entry of documentEntries) {
-            const nameAttr = entry.name ? ` name="${entry.name}"` : '';
-            documents.push(
-              `<${OUTPUT_DOCUMENTS_TAG}${nameAttr}>${entry.content.trim()}</${OUTPUT_DOCUMENTS_TAG}>`,
-            );
-          }
         } else {
           const singleDocument = extractTextFromTag(
             rawContent,
@@ -220,9 +212,6 @@ export class OutputFileProcessor {
           ).trim();
           if (singleDocument) {
             tagContents[OUTPUT_DOCUMENTS_TAG] = [singleDocument];
-            documents.push(
-              `<${OUTPUT_DOCUMENTS_TAG}>${singleDocument}</${OUTPUT_DOCUMENTS_TAG}>`,
-            );
           }
         }
 
@@ -234,9 +223,15 @@ export class OutputFileProcessor {
           tagContents.scratchpad = [scratchpadContent];
         }
 
+        // `documents` used to hold the same text again, re-wrapped in its
+        // XML tags — pure duplication of `tagContents[OUTPUT_DOCUMENTS_TAG]`
+        // with nothing reading either the tag-wrapped or bare form
+        // downstream. Every full-text round summary was cloned per node
+        // step (see persistedFlow.ts), so the duplicate copy cost grew with
+        // every round of every run.
         data.xmlSummary = {
           tagContents,
-          documents,
+          documents: [],
           singleOutputFile: singleFile,
           sourceLocation: rawOutput,
         };

--- a/src/shared/state/PersistedState.ts
+++ b/src/shared/state/PersistedState.ts
@@ -7,6 +7,7 @@ import { z } from 'zod';
 interface StateStorage {
   get(key: string): unknown;
   set(key: string, value: unknown): void;
+  delete(key: string): void;
 }
 
 /**
@@ -23,6 +24,9 @@ export function createBackendStorage(memento: {
   return {
     get: (key) => memento.get(key),
     set: (key, value) => void memento.update(key, value),
+    // A Memento key is removed by updating it to `undefined`; there is no
+    // separate delete API.
+    delete: (key) => void memento.update(key, undefined),
   };
 }
 
@@ -47,6 +51,10 @@ export function createWebviewStorage(hostBridge: {
     get: (key) => cache[key],
     set: (key, value) => {
       cache[key] = value;
+      hostBridge.setState(cache);
+    },
+    delete: (key) => {
+      delete cache[key];
       hostBridge.setState(cache);
     },
   };

--- a/src/test-kernel/progressView/ProgressViewMessageDispatcher.vitest.ts
+++ b/src/test-kernel/progressView/ProgressViewMessageDispatcher.vitest.ts
@@ -26,7 +26,11 @@ import {
   resetProgressState,
 } from '@progressView/frontend/progressState';
 import { dispatchMessage } from '@progressView/frontend/messageDispatcher';
-import type { StreamTabId } from '@shared/schemas';
+import {
+  logListStateKey,
+  webviewStorage,
+} from '@progressView/frontend/webviewStorage';
+import { AgentCategory, type StreamTabId } from '@shared/schemas';
 import { MAIN_VIEW_COMMANDS, PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import {
   dispatchProgressViewOutbound,
@@ -181,6 +185,51 @@ describe('progressView dispatchMessage (createDispatcher migration)', () => {
     expect(permissions$.get()).toEqual([]);
     expect(appState.get().streamById.size).toBe(0);
     expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("DELETE_ALL clears every remaining stream's persisted LogList toggle state", () => {
+    const streamId = 'stream-delete-all' as StreamTabId;
+    appState.get().streamById.set(streamId, {
+      kind: 'agent',
+      name: streamId,
+      label: 'stream-delete-all',
+      agentCategory: AgentCategory.Workflow,
+      creationTimestamp: 1,
+    });
+    webviewStorage.set(logListStateKey(streamId), {
+      groupToggleStates: [['group-1', true]],
+    });
+    expect(webviewStorage.get(logListStateKey(streamId))).toBeDefined();
+
+    const handled = dispatchMessage(
+      { command: PROGRESS_VIEW_COMMANDS.DELETE_ALL },
+      vi.fn(),
+    );
+
+    expect(handled).toBe(true);
+    expect(webviewStorage.get(logListStateKey(streamId))).toBeUndefined();
+  });
+
+  it("DELETE_STREAM clears that stream's persisted LogList toggle state", () => {
+    const streamId = 'stream-delete-one' as StreamTabId;
+    appState.get().streamById.set(streamId, {
+      kind: 'agent',
+      name: streamId,
+      label: 'stream-delete-one',
+      agentCategory: AgentCategory.Workflow,
+      creationTimestamp: 1,
+    });
+    webviewStorage.set(logListStateKey(streamId), {
+      groupToggleStates: [['group-1', true]],
+    });
+
+    const handled = dispatchMessage(
+      { command: PROGRESS_VIEW_COMMANDS.DELETE_STREAM, stream: streamId },
+      vi.fn(),
+    );
+
+    expect(handled).toBe(true);
+    expect(webviewStorage.get(logListStateKey(streamId))).toBeUndefined();
   });
 
   it('routes a malformed message to onError instead of throwing inside a handler body', () => {

--- a/src/test-kernel/tools/TextEditorToolHistoryCap.vitest.ts
+++ b/src/test-kernel/tools/TextEditorToolHistoryCap.vitest.ts
@@ -1,0 +1,115 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
+// Node imports
+import * as assert from 'node:assert';
+
+// Third-party imports
+import { describe, it, beforeEach, afterEach } from 'vitest';
+
+// Local imports
+import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
+import { defaultSession } from '@agent/runtime/SessionHandle';
+import type { StreamTabId } from '@shared/schemas';
+import { installPlatform as installFakePlatform } from '@test/support/setupPlatform';
+import { TextEditorTool } from '@tools/TextEditorTool';
+import {
+  cleanupAllApprovals,
+  type ToolEditApprovalRequest,
+  type ToolEditApprovalResult,
+} from '@tools/approval';
+import { WorkspaceFS } from '@utils/files';
+
+const EXECUTION_ID = 'history-cap-exec';
+
+let testApprovalHandler:
+  | ((request: ToolEditApprovalRequest) => Promise<ToolEditApprovalResult>)
+  | undefined;
+let detachHostInteractions = (): void => {};
+
+async function installPlatform(
+  files: Record<string, string | Uint8Array> = {},
+) {
+  testApprovalHandler = async () => ({ accepted: true });
+  await installFakePlatform({ workspacePath: '/workspace', files });
+  detachHostInteractions();
+  detachHostInteractions = defaultSession().useHostInteractions({
+    requestToolEditApproval: (request) => {
+      const handler = testApprovalHandler;
+      if (!handler) {
+        throw new Error('No test approval handler configured.');
+      }
+      return handler(request);
+    },
+    cancel: () => undefined,
+  });
+}
+
+async function callTextEditor(tool: TextEditorTool, input: unknown) {
+  return withRunContext(
+    createRunContext({
+      runtimeHost: noopAgentRuntimeHost,
+      streamId: `stream:${EXECUTION_ID}` as StreamTabId,
+      executionId: EXECUTION_ID,
+    }),
+    () => tool.call(input),
+  );
+}
+
+interface TextEditorToolInternals {
+  fileHistory: Map<string, string[]>;
+}
+
+describe('TextEditorTool undo history cap', () => {
+  beforeEach(async () => {
+    await installPlatform();
+    cleanupAllApprovals();
+  });
+
+  afterEach(() => {
+    testApprovalHandler = undefined;
+    detachHostInteractions();
+    detachHostInteractions = () => {};
+    cleanupAllApprovals();
+  });
+
+  it('bounds retained snapshots per file without breaking the most recent undo', async () => {
+    await installPlatform({ '/workspace/loop.tex': '0\n' });
+    const tool = new TextEditorTool();
+
+    const EDIT_COUNT = 60; // comfortably past MAX_HISTORY_PER_FILE (50)
+    for (let n = 0; n < EDIT_COUNT; n += 1) {
+      const result = await callTextEditor(tool, {
+        command: 'str_replace',
+        path: 'loop.tex',
+        old_str: `${n}`,
+        new_str: `${n + 1}`,
+      });
+      assert.strictEqual(result.status, 'executed');
+    }
+    assert.strictEqual(await WorkspaceFS.read('loop.tex'), `${EDIT_COUNT}\n`);
+
+    const internals = tool as unknown as TextEditorToolInternals;
+    const key = [...internals.fileHistory.keys()].find((k) =>
+      k.endsWith('loop.tex'),
+    );
+    assert.ok(key, 'expected an undo-history entry for loop.tex');
+    assert.ok(
+      internals.fileHistory.get(key!)!.length <= 50,
+      `expected history capped at 50, got ${internals.fileHistory.get(key!)!.length}`,
+    );
+
+    // The cap must never affect the one documented behavior: undoing the
+    // most recently applied edit.
+    const undo = await callTextEditor(tool, {
+      command: 'undo_edit',
+      path: 'loop.tex',
+    });
+    assert.strictEqual(undo.status, 'executed');
+    assert.strictEqual(
+      await WorkspaceFS.read('loop.tex'),
+      `${EDIT_COUNT - 1}\n`,
+    );
+  });
+});

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -91,6 +91,19 @@ export class TextEditorTool extends defineTool({
   // File history for undo operations
   private fileHistory: Map<string, string[]> = new Map();
 
+  /**
+   * Cap on retained full-file snapshots per (execution, file) key.
+   * `undo_edit` only ever pops the most recent snapshot (`history.at(-1)`),
+   * so trimming the oldest entries beyond this depth never changes that
+   * behavior — deep multi-level undo past this many edits in a single
+   * execution isn't a documented or relied-upon usage pattern. Without this,
+   * a long execution that edits the same file many times without ever
+   * calling undo_edit retains every historical version of that file for the
+   * rest of the process's lifetime (fileHistory is a process-wide
+   * singleton, never cleared per-execution).
+   */
+  private static readonly MAX_HISTORY_PER_FILE = 50;
+
   constructor(apiType: TextEditorApiType = 'text_editor_20250124') {
     const name = API_TYPE_TO_NAME[apiType];
     super({ name });
@@ -515,6 +528,9 @@ export class TextEditorTool extends defineTool({
     const history = this.fileHistory.get(key);
     if (history) {
       history.push(content);
+      if (history.length > TextEditorTool.MAX_HISTORY_PER_FILE) {
+        history.shift();
+      }
     } else {
       this.fileHistory.set(key, [content]);
     }


### PR DESCRIPTION
## Summary

A follow-up to the PR #9010 audit: ran a 10-agent memory-leak/waste sweep across every package **not** already covered by #9010 (desktop, extension webviews/host, trace-viewer, deeper agent/core/storage, tools/subprocess handling, CLI runtime, platform/eventBus, plus a cross-cutting "same data held twice" pass). All 18 candidate findings were independently re-verified against the real current code; 5 are fixed here. Each is independent, isolated, and changes no user-visible behavior.

- **`packages/desktop/src/renderer/main.ts`** — `wireRailTabs()`/`wireConversation()` bind DOM event listeners unconditionally. Normal startup wires once, but a bootstrap-recovery retry (its own failure re-showing the same fallback UI, whose button re-invokes recovery) could re-wire a second time on the same long-lived elements, stacking duplicate handlers. Added a guard matching the existing `shellWatcherInstalled` idempotency pattern already used a few lines away for the same recovery path.
- **`LogList.ts` / `webviewStorage.ts` / `streamLifecycleSlice.ts`** — every stream ever visited created a `logListState:<streamId>` entry in the shared webview-persisted-state blob, with no deletion path; the entry survived the stream's own DOM-cache eviction (LogList bounds that to 5) and even a full stream deletion. Added `delete()` to `StateStorage`/`PersistedState` (both backend and webview implementations) and wired the actual deletion into `DELETE_STREAM`/`DELETE_ALL` — the one point where a stream's toggle state genuinely has no future consumer.
- **`inlineCriticism.ts`** — `pushManualCriticism()` (backing the `diagnostics add` tool command) unconditionally appended every call to a per-file diagnostics array with no dedup and no cap; the array is only ever cleared by the whole-feature enable/disable toggle. A critique agent re-flagging the same line/message across repeated rounds would stack unbounded duplicate squiggles. Now skips re-adding an exact duplicate (same code/line/message).
- **`packages/trace-viewer/src/main.ts`** — the singlefile export mode's raw trace JSON sits on `window.__TEXRA_TRACE__` for the whole page lifetime after `parseTraceData` consumes it; nothing else reads it. Deleted after read.
- **`OutputFileProcessor.ts`** — `captureXmlSummary()` stored the model's extracted document text twice in the same `RoundOutput.xmlSummary` (bare in `tagContents[OUTPUT_DOCUMENTS_TAG]`, and again re-wrapped in XML tags in `documents`) — confirmed nothing downstream reads either field. Since `persistedFlow.ts` `structuredClone`s the entire flow shared state (which embeds every round's `xmlSummary`) on every single node step, this duplication's clone/serialize cost compounded across every round of every run. Stopped building the redundant `documents` copy; kept the one canonical `tagContents` representation.
- **`TextEditorTool.ts`** — `fileHistory` (undo history) is a process-wide singleton Map, keyed per execution+file, that only shrinks via explicit `undo_edit` calls. A long execution editing the same file many times without ever undoing retained every historical full-file snapshot forever. Capped the per-key array at 50 entries (oldest evicted first); `undo_edit` only ever pops the most recent entry, so this never changes that behavior.

## Investigated but not changed (reported as follow-ups)

- **`executionLease.ts`'s `fencedOwnershipKeys`** — genuinely unbounded (never pruned for abandoned/undurable executions that are never resumed), but the fence specifically exists to catch *lagging* async writers after abandonment; there's no safe "definitely done, nothing will reference this executionId again" moment to hook without either a TTL or reference-counting scheme. Fixing it risks reintroducing the exact cross-process race it guards against. Left as-is; needs a design decision, not a free fix.
- The cross-execution accumulation of `fileHistory` *keys* (as opposed to unbounded array length, fixed above) has the same "needs an execution-completion hook that doesn't exist yet" shape, but is now a much smaller residual per key.

## Validation

- `npx tsc --noEmit` — repo root, test-kernel, extension, trace-viewer, and desktop renderer tsconfigs all clean
- `npx eslint` on every changed/new file — clean
- `npx prettier --check` — clean
- New/extended tests: `TextEditorToolHistoryCap.vitest.ts` (new — cap behavior + undo still works), `ProgressViewMessageDispatcher.vitest.ts` (+2 — DELETE_STREAM/DELETE_ALL clear persisted LogList state)
- `npx vitest run` across `progressView`, `tools`, `agent/output`, `schemas/OutputSummaryTransforms`, `shared` — 172 files / 1290 tests passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted retention and deduplication fixes with no intended behavior change; covered by new/extended tests for storage cleanup and TextEditor undo cap.
> 
> **Overview**
> Follow-up to a memory audit: **five independent fixes** that trim retained data without changing user-visible behavior.
> 
> **Desktop** — `wireRailTabs` / `wireConversation` now register DOM listeners only once, so bootstrap recovery retries cannot stack duplicate handlers on the same long-lived elements.
> 
> **Progress view storage** — `StateStorage` gains `delete()`; per-stream `logListState:*` keys are removed on `DELETE_STREAM` / `DELETE_ALL` via a shared `logListStateKey()` helper (tests added).
> 
> **Extension** — inline criticism from the diagnostics tool skips exact duplicate squiggles on the same line/message.
> 
> **Trace viewer** — drops `window.__TEXRA_TRACE__` after the inline trace is parsed so the raw JSON is not kept for the page lifetime.
> 
> **Agent / tools** — `captureXmlSummary` stops duplicating document text in `xmlSummary.documents` (only `tagContents` is populated, cutting clone cost in persisted flows). **TextEditorTool** caps per-file undo snapshots at 50 while preserving undo of the latest edit (new vitest).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3621a724891c91fa01fc4d5fa116bb4005f0fb7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->