### PR TITLE
fix: prevent runtime ownership races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file.
 - **Brief network interruptions no longer stop model turns immediately** —
   requests retry automatically when a transport failure escapes the provider
   client.
+- **Parallel runs finish reliably after long pauses** — delayed storage work
+  no longer causes the application to exit while several agents are saving
+  their final results.
 
 ### Extension (VS Code)
 
@@ -45,6 +48,9 @@ All notable changes to this project will be documented in this file.
   no key is available, the CLI directs you to `/key`. If a replacement client
   cannot be prepared, the CLI restores the previous settings and reports any
   setting whose persistence cannot be confirmed.
+- **Retry prompts keep their transcript available** — switching away from an
+  agent waiting for a retry no longer causes the CLI to exit when that agent
+  writes its next update.
 
 ### Desktop
 

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -493,7 +493,7 @@ export function subscribeStreamLog(): () => void {
       .ensureLoaded(nextActiveStreamId)
       .then(() => {
         if (generation === getCliStateGeneration()) {
-          syncStreamLog(nextActiveStreamId);
+          trySyncStreamLog(nextActiveStreamId);
         }
       })
       .catch((error: unknown) => {

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -23,7 +23,6 @@ import {
 } from '@shared/subagentFollowup';
 import { normalizeToolUseData } from '@shared/toolUse';
 import { isActivePhase } from '@shared/streams/streamStatus';
-import { flushPendingRunTraces } from '@transcript';
 import { createFlushableDebounce } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { truncateSummary } from '@utils/text/stringUtils';
@@ -443,6 +442,14 @@ function sortTranscriptCandidatesIfNeeded(
   return candidates;
 }
 
+function trySyncStreamLog(streamId: StreamTabId): void {
+  try {
+    syncStreamLog(streamId);
+  } catch (error) {
+    setTransientNotice(`Could not update transcript: ${toErrorMessage(error)}`);
+  }
+}
+
 export function subscribeStreamLog(): () => void {
   const store = defaultSession().transcripts;
   const pendingStreams = new Map<StreamTabId, number>();
@@ -457,7 +464,8 @@ export function subscribeStreamLog(): () => void {
     const streamIds = [...pendingStreams];
     pendingStreams.clear();
     for (const [id, generation] of streamIds) {
-      if (generation === getCliStateGeneration()) syncStreamLog(id);
+      if (generation !== getCliStateGeneration()) continue;
+      trySyncStreamLog(id);
     }
   }, STREAM_SYNC_THROTTLE_MS);
 
@@ -476,7 +484,7 @@ export function subscribeStreamLog(): () => void {
     previousActiveStreamId = nextActiveStreamId;
 
     if (previous && previous !== nextActiveStreamId) {
-      syncStreamLog(previous);
+      trySyncStreamLog(previous);
     }
     if (!nextActiveStreamId || nextActiveStreamId === previous) return;
 
@@ -518,8 +526,9 @@ export function syncStreamLog(
   // between two TUI sync ticks), the assistant text is still sitting in
   // an in-memory buffer and never reaches the transcript. Force any
   // pending flushers to materialize before we read.
-  flushPendingRunTraces();
-  const store = defaultSession().transcripts;
+  const session = defaultSession();
+  session.flushPendingTraces();
+  const store = session.transcripts;
   const log = store.get(streamId);
   if (!log) return;
 
@@ -628,7 +637,7 @@ export function syncStreamLog(
     return { ...slice, description, entries: next, thinkingActive };
   });
 
-  if (releaseAfterSync) store.releaseEntries(streamId);
+  if (releaseAfterSync) store.requestEviction(streamId);
 
   // Surface stream as active if we don't already have one — handles bare
   // `texra chat` where setActiveStream is the first signal the runtime emits.

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -300,12 +300,16 @@ async function assembleAgentLaunchContext(
   // runs outside any ALS, so it resolves to the process default. Either way the
   // child is tracked in the same session as its launcher.
   const session = input.session ?? currentSession();
-  await session.transcripts.ensureLoaded(streamId);
+  const transcriptWriter = await session.transcripts.loadAndAcquireWriter(
+    streamId,
+    executionId,
+  );
   const rawRunTrace = createRunTrace(
     streamId,
     session.transcripts,
     session.flushers,
     executionId,
+    transcriptWriter,
   );
   const runTrace = resources.ownRunTrace(rawRunTrace, () =>
     session.attachRunTrace(rawRunTrace.trace, streamId),

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -300,10 +300,12 @@ async function assembleAgentLaunchContext(
   // runs outside any ALS, so it resolves to the process default. Either way the
   // child is tracked in the same session as its launcher.
   const session = input.session ?? currentSession();
+  await session.transcripts.ensureLoaded(streamId);
   const rawRunTrace = createRunTrace(
     streamId,
     session.transcripts,
     session.flushers,
+    executionId,
   );
   const runTrace = resources.ownRunTrace(rawRunTrace, () =>
     session.attachRunTrace(rawRunTrace.trace, streamId),

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -433,6 +433,7 @@ export async function runFlowWithLifecycle(
             handle.executionId,
           );
           try {
+            if (handle.executionLeaseLost) return;
             writer.update(parentStageId, {
               type: STREAM_LOG_ENTRY_TYPES.GROUP_END,
               data: {

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -428,8 +428,7 @@ export async function runFlowWithLifecycle(
         // `beginRunStage` call, including on resume), so this can never
         // double-close a stage some other turn already ended.
         if (parentStageId) {
-          await session.transcripts.ensureLoaded(streamId);
-          const writer = session.transcripts.acquireWriter(
+          const writer = await session.transcripts.loadAndAcquireWriter(
             streamId,
             handle.executionId,
           );

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -407,8 +407,9 @@ export async function runFlowWithLifecycle(
       // of ExecutionRegistry.terminate() finding no interrupt target and
       // no-oping — see AgentRunLifecycle/ExecutionRegistry issue #7287.
       const parentStageId = ctx.parentStage.id;
-      handle.registerWaitingCleanup(() => {
+      handle.registerWaitingCleanup(async () => {
         session.followUps.release(streamId);
+        if (handle.executionLeaseLost) return;
         // Close this turn's "Run: ..." transcript group so a killed suspended
         // subagent doesn't leave it stuck at `running` forever (every other
         // terminal path reaches this via `finalizeRunTerminal`'s stage end,
@@ -427,14 +428,23 @@ export async function runFlowWithLifecycle(
         // `beginRunStage` call, including on resume), so this can never
         // double-close a stage some other turn already ended.
         if (parentStageId) {
-          session.transcripts.update(streamId, parentStageId, {
-            type: STREAM_LOG_ENTRY_TYPES.GROUP_END,
-            data: {
-              status: RUN_OUTCOME.CANCELLED,
-              endTime: Date.now(),
-              kind: 'run',
-            },
-          });
+          await session.transcripts.ensureLoaded(streamId);
+          const writer = session.transcripts.acquireWriter(
+            streamId,
+            handle.executionId,
+          );
+          try {
+            writer.update(parentStageId, {
+              type: STREAM_LOG_ENTRY_TYPES.GROUP_END,
+              data: {
+                status: RUN_OUTCOME.CANCELLED,
+                endTime: Date.now(),
+                kind: 'run',
+              },
+            });
+          } finally {
+            writer.close();
+          }
         }
       });
       return result;

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -84,6 +84,7 @@ export class AgentExecutionHandle implements ExecutionHandle {
   private pendingInterrupt = false;
   private waitingCleanups?: Set<() => void | Promise<void>>;
   private waitingCleanupCompletion: Promise<void> = Promise.resolve();
+  private _waitingTerminationStarted = false;
   private _executionLeaseLost = false;
 
   /** Stable tool name for UI identification (e.g. "bash", "codex"). */
@@ -279,6 +280,7 @@ export class AgentExecutionHandle implements ExecutionHandle {
   runWaitingCleanup(): boolean {
     const cleanups = this.waitingCleanups;
     if (!cleanups || cleanups.size === 0) return false;
+    this._waitingTerminationStarted = true;
     this.waitingCleanups = undefined;
     this.waitingCleanupCompletion = Promise.all(
       [...cleanups].map(async (cleanup) => cleanup()),
@@ -288,6 +290,10 @@ export class AgentExecutionHandle implements ExecutionHandle {
     // durable finalization but must not create an unhandled rejection.
     void this.waitingCleanupCompletion.catch(() => undefined);
     return true;
+  }
+
+  get waitingTerminationStarted(): boolean {
+    return this._waitingTerminationStarted;
   }
 
   waitForWaitingCleanup(): Promise<void> {

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -270,7 +270,6 @@ export class AgentExecutionHandle implements ExecutionHandle {
    */
   clearWaitingCleanup(): void {
     this.waitingCleanups = undefined;
-    this.waitingCleanupCompletion = Promise.resolve();
   }
 
   /**

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -82,7 +82,8 @@ export class AgentExecutionHandle implements ExecutionHandle {
   private toolUseFlowContext?: LiveToolUseFlowContext;
   private acceptsPendingInterrupt = false;
   private pendingInterrupt = false;
-  private waitingCleanups?: Set<() => void>;
+  private waitingCleanups?: Set<() => void | Promise<void>>;
+  private waitingCleanupCompletion: Promise<void> = Promise.resolve();
   private _executionLeaseLost = false;
 
   /** Stable tool name for UI identification (e.g. "bash", "codex"). */
@@ -256,7 +257,7 @@ export class AgentExecutionHandle implements ExecutionHandle {
    * covering the gap (see `childRunLoop.ts`'s own whole-lifetime
    * handler, which is the primary path for a loop-driven child).
    */
-  registerWaitingCleanup(cleanup: () => void): void {
+  registerWaitingCleanup(cleanup: () => void | Promise<void>): void {
     (this.waitingCleanups ??= new Set()).add(cleanup);
   }
 
@@ -269,6 +270,7 @@ export class AgentExecutionHandle implements ExecutionHandle {
    */
   clearWaitingCleanup(): void {
     this.waitingCleanups = undefined;
+    this.waitingCleanupCompletion = Promise.resolve();
   }
 
   /**
@@ -279,8 +281,18 @@ export class AgentExecutionHandle implements ExecutionHandle {
     const cleanups = this.waitingCleanups;
     if (!cleanups || cleanups.size === 0) return false;
     this.waitingCleanups = undefined;
-    for (const cleanup of cleanups) cleanup();
+    this.waitingCleanupCompletion = Promise.all(
+      [...cleanups].map(async (cleanup) => cleanup()),
+    ).then(() => undefined);
+    // The registry normally awaits this before terminal persistence. Retain a
+    // rejection handler for the lease-loss branch, which intentionally skips
+    // durable finalization but must not create an unhandled rejection.
+    void this.waitingCleanupCompletion.catch(() => undefined);
     return true;
+  }
+
+  waitForWaitingCleanup(): Promise<void> {
+    return this.waitingCleanupCompletion;
   }
 }
 

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -178,7 +178,21 @@ export class SessionHandle {
 
   /** Drain pending trace writes for this session's streams only. */
   flushPendingTraces(): void {
-    for (const flush of [...this.flushers]) flush();
+    const failures: unknown[] = [];
+    for (const flush of [...this.flushers]) {
+      try {
+        flush();
+      } catch (error) {
+        failures.push(error);
+      }
+    }
+    if (failures.length === 1) throw failures[0];
+    if (failures.length > 1) {
+      throw new AggregateError(
+        failures,
+        'Multiple session trace writers failed to flush',
+      );
+    }
   }
 
   /** Register a session-owned durable writer such as a snapshot store. */
@@ -340,19 +354,30 @@ export class SessionHandle {
    * Tear down everything this session owns. Order matters: drain this session's
    * pending trace writes, drop subscription disposers, dispose the execution
    * registry, settle pending host interactions via `interactions.dispose()`,
-   * and drop result listeners. Finally unregister this session's flusher set
-   * from the process-wide drain and deregister it from `liveSessions`, both in
-   * `finally` so a teardown throw cannot strand a disposed session.
+   * and drop result listeners. Deregistration from `liveSessions` happens even
+   * when either phase fails, and every collected failure returns only after
+   * teardown has been attempted.
    */
   dispose(): void {
     if (this.disposeStarted) return;
     this.disposeStarted = true;
 
+    const failures: unknown[] = [];
     try {
       this.flushPendingTraces();
+    } catch (error) {
+      failures.push(error);
+    }
+    try {
       this.teardownOwners();
+    } catch (error) {
+      failures.push(error);
     } finally {
       this.deregisterSession();
+    }
+    if (failures.length === 1) throw failures[0];
+    if (failures.length > 1) {
+      throw new AggregateError(failures, 'Session teardown failed');
     }
   }
 

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -107,8 +107,8 @@ export class SessionHandle {
   readonly transcripts: StreamLogStore;
   /** Session-owned follow-up queue owner. */
   readonly followUps: ToolUseFollowUpQueue;
-  /** This session's trace-flush callbacks (drained on dispose / shutdown). */
-  readonly flushers: Set<() => void>;
+  /** This session's execution-keyed trace flushers. */
+  readonly flushers: Map<string, () => void>;
   private readonly artifactFlushers = new Set<() => Promise<void>>();
   private pendingArtifactFlush: ArtifactFlushBatch | undefined;
   private artifactFlushWorkerRunning = false;
@@ -163,9 +163,9 @@ export class SessionHandle {
     this.approvals = approvals;
     this.workflowControls =
       init.workflowControls ?? new WorkflowControlRegistry();
-    // Every session owns exactly one trace-flusher set. There is no
+    // Every session owns exactly one trace-flusher map. There is no
     // process-wide registry: a host drains the session it is shutting down.
-    this.flushers = init.flushers ?? new Set<() => void>();
+    this.flushers = init.flushers ?? new Map<string, () => void>();
     executions.attachRootExecutionLeaseRelease((executionId) =>
       releaseExecutionLeaseAfterArtifacts(this, executionId),
     );
@@ -176,10 +176,16 @@ export class SessionHandle {
     return this.interactions.use(interactions);
   }
 
-  /** Drain pending trace writes for this session's streams only. */
-  flushPendingTraces(): void {
+  /** Drain one execution's pending trace, or every trace during shutdown. */
+  flushPendingTraces(ownerKey?: string): void {
     const failures: unknown[] = [];
-    for (const flush of [...this.flushers]) {
+    const flushers =
+      ownerKey === undefined
+        ? [...this.flushers.values()]
+        : [this.flushers.get(ownerKey)].filter(
+            (flush): flush is () => void => flush !== undefined,
+          );
+    for (const flush of flushers) {
       try {
         flush();
       } catch (error) {
@@ -201,8 +207,14 @@ export class SessionHandle {
     return () => this.artifactFlushers.delete(flush);
   }
 
-  /** Persist every buffered session artifact before execution ownership ends. */
-  flushArtifacts(): Promise<void> {
+  /** Persist one execution's trace plus the session's shared artifact stores. */
+  flushArtifacts(ownerKey?: string): Promise<void> {
+    let traceFailure: unknown;
+    try {
+      this.flushPendingTraces(ownerKey);
+    } catch (error) {
+      traceFailure = error;
+    }
     this.pendingArtifactFlush ??= createArtifactFlushBatch();
     const batch = this.pendingArtifactFlush;
     if (!this.artifactFlushWorkerRunning) {
@@ -211,7 +223,18 @@ export class SessionHandle {
         void this.drainArtifactFlushBatches();
       });
     }
-    return batch.promise;
+    if (traceFailure === undefined) return batch.promise;
+    return batch.promise.then(
+      () => {
+        throw traceFailure;
+      },
+      (artifactFailure: unknown) => {
+        throw new AggregateError(
+          [traceFailure, artifactFailure],
+          'Trace and shared artifact writers failed to flush',
+        );
+      },
+    );
   }
 
   /**
@@ -234,22 +257,12 @@ export class SessionHandle {
   }
 
   private async flushArtifactsOnce(): Promise<void> {
-    const failures: unknown[] = [];
-    for (const flush of [...this.flushers]) {
-      try {
-        flush();
-      } catch (error) {
-        failures.push(error);
-      }
-    }
     const writers = [() => this.transcripts.flush(), ...this.artifactFlushers];
     const results = await Promise.allSettled(
       writers.map((flush) => Promise.resolve().then(flush)),
     );
-    failures.push(
-      ...results.flatMap((result) =>
-        result.status === 'rejected' ? [result.reason] : [],
-      ),
+    const failures = results.flatMap((result) =>
+      result.status === 'rejected' ? [result.reason] : [],
     );
     if (failures.length === 1) throw failures[0];
     if (failures.length > 1) {

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -32,6 +32,7 @@ import type { AgentEvent, AgentTrace, ResultEvent } from '@agent/trace';
 import { createChannelTrace } from '@agent/trace';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import type { StreamTabId } from '@shared/schemas';
+import type { RunTraceFlushEntry } from '@transcript/runTrace';
 import type { StreamLogStore } from '@transcript/StreamLogStore';
 import { getRunContextSession, tryUseRunContext } from './RunContext';
 import { ExecutionRegistry } from './executionRegistry';
@@ -108,7 +109,7 @@ export class SessionHandle {
   /** Session-owned follow-up queue owner. */
   readonly followUps: ToolUseFollowUpQueue;
   /** This session's execution-keyed trace flushers. */
-  readonly flushers: Map<string, () => void>;
+  readonly flushers: Map<string, RunTraceFlushEntry>;
   private readonly artifactFlushers = new Set<() => Promise<void>>();
   private pendingArtifactFlush: ArtifactFlushBatch | undefined;
   private artifactFlushWorkerRunning = false;
@@ -165,7 +166,7 @@ export class SessionHandle {
       init.workflowControls ?? new WorkflowControlRegistry();
     // Every session owns exactly one trace-flusher map. There is no
     // process-wide registry: a host drains the session it is shutting down.
-    this.flushers = init.flushers ?? new Map<string, () => void>();
+    this.flushers = init.flushers ?? new Map<string, RunTraceFlushEntry>();
     executions.attachRootExecutionLeaseRelease((executionId) =>
       releaseExecutionLeaseAfterArtifacts(this, executionId),
     );
@@ -183,11 +184,11 @@ export class SessionHandle {
       ownerKey === undefined
         ? [...this.flushers.values()]
         : [this.flushers.get(ownerKey)].filter(
-            (flush): flush is () => void => flush !== undefined,
+            (entry): entry is RunTraceFlushEntry => entry !== undefined,
           );
-    for (const flush of flushers) {
+    for (const entry of flushers) {
       try {
-        flush();
+        entry.flush();
       } catch (error) {
         failures.push(error);
       }

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -32,8 +32,6 @@ import type { AgentEvent, AgentTrace, ResultEvent } from '@agent/trace';
 import { createChannelTrace } from '@agent/trace';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import type { StreamTabId } from '@shared/schemas';
-import { getActiveFlushers, unregisterFlushers } from '@transcript/runTrace';
-
 import type { StreamLogStore } from '@transcript/StreamLogStore';
 import { getRunContextSession, tryUseRunContext } from './RunContext';
 import { ExecutionRegistry } from './executionRegistry';
@@ -56,6 +54,22 @@ const logger = createChannelTrace('sessionHandle');
 interface ResultListenerRegistration {
   readonly listener: (event: ResultEvent) => void;
   readonly replayMissed: boolean;
+}
+
+interface ArtifactFlushBatch {
+  readonly promise: Promise<void>;
+  readonly resolve: () => void;
+  readonly reject: (error: unknown) => void;
+}
+
+function createArtifactFlushBatch(): ArtifactFlushBatch {
+  let resolve: () => void = () => undefined;
+  let reject: (error: unknown) => void = () => undefined;
+  const promise = new Promise<void>((settle, fail) => {
+    resolve = settle;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
 }
 
 function isReplayableTerminalResult(event: ResultEvent): boolean {
@@ -96,6 +110,8 @@ export class SessionHandle {
   /** This session's trace-flush callbacks (drained on dispose / shutdown). */
   readonly flushers: Set<() => void>;
   private readonly artifactFlushers = new Set<() => Promise<void>>();
+  private pendingArtifactFlush: ArtifactFlushBatch | undefined;
+  private artifactFlushWorkerRunning = false;
   /** Session-scoped host interaction owner. */
   readonly interactions: SessionHostInteractions;
   /** Session-owned approval queues, pending registries, and bypass state. */
@@ -147,9 +163,8 @@ export class SessionHandle {
     this.approvals = approvals;
     this.workflowControls =
       init.workflowControls ?? new WorkflowControlRegistry();
-    // A fresh session owns its own flusher set; the default session aliases
-    // the process-module set (`getActiveFlushers()`) so the process-wide
-    // shutdown drain (`flushPendingRunTraces()`) still reaches it.
+    // Every session owns exactly one trace-flusher set. There is no
+    // process-wide registry: a host drains the session it is shutting down.
     this.flushers = init.flushers ?? new Set<() => void>();
     executions.attachRootExecutionLeaseRelease((executionId) =>
       releaseExecutionLeaseAfterArtifacts(this, executionId),
@@ -173,7 +188,38 @@ export class SessionHandle {
   }
 
   /** Persist every buffered session artifact before execution ownership ends. */
-  async flushArtifacts(): Promise<void> {
+  flushArtifacts(): Promise<void> {
+    this.pendingArtifactFlush ??= createArtifactFlushBatch();
+    const batch = this.pendingArtifactFlush;
+    if (!this.artifactFlushWorkerRunning) {
+      this.artifactFlushWorkerRunning = true;
+      queueMicrotask(() => {
+        void this.drainArtifactFlushBatches();
+      });
+    }
+    return batch.promise;
+  }
+
+  /**
+   * Drain one current batch and, when calls arrived during it, one trailing
+   * batch at a time. This preserves each caller's durability boundary without
+   * repeating a full session flush for every execution ending in one burst.
+   */
+  private async drainArtifactFlushBatches(): Promise<void> {
+    while (this.pendingArtifactFlush) {
+      const batch = this.pendingArtifactFlush;
+      this.pendingArtifactFlush = undefined;
+      try {
+        await this.flushArtifactsOnce();
+        batch.resolve();
+      } catch (error) {
+        batch.reject(error);
+      }
+    }
+    this.artifactFlushWorkerRunning = false;
+  }
+
+  private async flushArtifactsOnce(): Promise<void> {
     const failures: unknown[] = [];
     for (const flush of [...this.flushers]) {
       try {
@@ -323,9 +369,8 @@ export class SessionHandle {
     this.missedTerminalResults.clear();
   }
 
-  /** Leave the process-wide trace drain and live-session registry. */
+  /** Leave the live-session registry. */
   private deregisterSession(): void {
-    unregisterFlushers(this.flushers);
     liveSessions.delete(this);
   }
 }
@@ -351,10 +396,7 @@ export function initializeDefaultSession(
   if (cachedDefaultSession) {
     throw new Error('The default session has already been initialized.');
   }
-  cachedDefaultSession = new SessionHandle({
-    ...init,
-    flushers: getActiveFlushers(),
-  });
+  cachedDefaultSession = new SessionHandle(init);
   return cachedDefaultSession;
 }
 

--- a/src/agent/runtime/executionOwnership.ts
+++ b/src/agent/runtime/executionOwnership.ts
@@ -1,18 +1,24 @@
 import {
   abandonOwnedExecutionLease,
   completeOwnedExecutionLease,
-  runWithOwnedExecutionLease,
+  renewOwnedExecutionLease,
 } from '@agent/storage/executionLease';
 import type { ExecutionId } from '@shared/schemas';
 
 import type { SessionHandle } from './SessionHandle';
 
-/** Persist session artifacts without allowing a former lease owner to write. */
+/**
+ * Persist session artifacts between two short owner-token validations.
+ * The durable lease remains fresh while the session drains, so no file lock
+ * needs to cover unrelated transcript and snapshot I/O.
+ */
 export async function flushOwnedExecutionArtifacts(
   session: SessionHandle,
   executionId: ExecutionId,
 ): Promise<void> {
-  await runWithOwnedExecutionLease(executionId, () => session.flushArtifacts());
+  await renewOwnedExecutionLease(executionId);
+  await session.flushArtifacts();
+  await renewOwnedExecutionLease(executionId);
 }
 
 /** End ownership only after every session-owned durable writer has drained. */

--- a/src/agent/runtime/executionOwnership.ts
+++ b/src/agent/runtime/executionOwnership.ts
@@ -17,7 +17,7 @@ export async function flushOwnedExecutionArtifacts(
   executionId: ExecutionId,
 ): Promise<void> {
   await renewOwnedExecutionLease(executionId);
-  await session.flushArtifacts();
+  await session.flushArtifacts(executionId);
   await renewOwnedExecutionLease(executionId);
 }
 

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -267,6 +267,18 @@ export class ExecutionRegistry {
   /** Register an execution handle. */
   track(handle: ExecutionHandle): void {
     this.assertActive();
+    const previous = this.handles.get(handle.executionId);
+    if (
+      previous instanceof AgentExecutionHandle &&
+      handle instanceof AgentExecutionHandle &&
+      previous.waitingTerminationStarted
+    ) {
+      // A resumed lifecycle can replace its suspended predecessor while the
+      // predecessor's asynchronous waiting cleanup is still in progress. The
+      // stop already claimed that execution, so carry it across the ownership
+      // handoff instead of allowing the successor to revive the run.
+      handle.interrupt();
+    }
     this.handles.set(handle.executionId, handle);
     if (handle instanceof AgentExecutionHandle) {
       if (handle.isChildExecution) {
@@ -1012,6 +1024,14 @@ export class ExecutionRegistry {
         'Waiting-execution cleanup failed; continuing terminal persistence',
         { data: { executionId: handle.executionId, error } },
       );
+    }
+
+    if (this.handles.get(handle.executionId) !== handle) {
+      // `track` transfers the pending stop to a resumed successor. The old
+      // handle still needs its private result settled, but it no longer owns
+      // the shared stream, execution metadata, or lease.
+      handle.settleResult(cancelledResult);
+      return;
     }
 
     if (handle.executionLeaseLost) {

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -956,7 +956,44 @@ export class ExecutionRegistry {
       category: handle.category,
       isSubagent: handle.isChildExecution,
     };
-    void this.finishWaitingTermination(handle, cancelledResult);
+    void this.finishWaitingTermination(handle, cancelledResult).catch(
+      (error: unknown) => {
+        const recoveryFailures = [error];
+        try {
+          markOwnedExecutionLeaseUndurable(handle.executionId);
+        } catch (recoveryError) {
+          recoveryFailures.push(recoveryError);
+        }
+        try {
+          handle.settleResult(cancelledResult);
+        } catch (recoveryError) {
+          recoveryFailures.push(recoveryError);
+        }
+        try {
+          this.untrackIfCurrent(handle);
+        } catch (recoveryError) {
+          recoveryFailures.push(recoveryError);
+        }
+        try {
+          this.cancelStreamStatus(handle.childStreamId, handle);
+        } catch (recoveryError) {
+          recoveryFailures.push(recoveryError);
+        }
+        if (!handle.isChildExecution) {
+          void this.releaseRootExecutionLease(handle.executionId).catch(
+            (recoveryError: unknown) => {
+              logger.warn(
+                'Waiting-execution recovery could not release ownership',
+                { data: { executionId: handle.executionId, recoveryError } },
+              );
+            },
+          );
+        }
+        logger.warn('Waiting-execution termination failed unexpectedly', {
+          data: { executionId: handle.executionId, recoveryFailures },
+        });
+      },
+    );
     return true;
   }
 

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -956,6 +956,27 @@ export class ExecutionRegistry {
       category: handle.category,
       isSubagent: handle.isChildExecution,
     };
+    void this.finishWaitingTermination(handle, cancelledResult);
+    return true;
+  }
+
+  private async finishWaitingTermination(
+    handle: AgentExecutionHandle,
+    cancelledResult: ResultEvent,
+  ): Promise<void> {
+    try {
+      await handle.waitForWaitingCleanup();
+    } catch (error) {
+      // Transcript closure and terminal execution metadata are independent
+      // durable facts. Preserve the failed artifact fence, but still give the
+      // terminal status its own opportunity to reach disk.
+      markOwnedExecutionLeaseUndurable(handle.executionId);
+      logger.warn(
+        'Waiting-execution cleanup failed; continuing terminal persistence',
+        { data: { executionId: handle.executionId, error } },
+      );
+    }
+
     if (handle.executionLeaseLost) {
       logger.warn('Discarding a stopped waiting execution after lease loss', {
         data: { executionId: handle.executionId },
@@ -965,73 +986,63 @@ export class ExecutionRegistry {
       handle.settleResult(cancelledResult);
       this.untrackHandle(handle);
       this.cancelStreamStatus(handle.childStreamId, handle);
-      return true;
+      return;
     }
+
+    // Cleanup closes the suspended run's transcript group. Publish the
+    // terminal state only after that owned artifact is settled so every host
+    // observes one coherent cancellation boundary.
     handle.trace?.emit(cancelledResult);
     this.publishResult?.(cancelledResult, handle.childStreamId);
     handle.settleResult(cancelledResult);
-    // No later result write is guaranteed here, including during RESUMING:
-    // the resume can fail before installing its own handle, while this method
-    // untracks the suspended one below. Align the interim envelope only after
-    // durable terminal metadata exists. A turn that does continue will replace
-    // it with its own result.
-    void (async () => {
-      try {
-        try {
-          await handle.waitForWaitingCleanup();
-        } catch (error) {
-          // Transcript closure and terminal execution metadata are independent
-          // durable facts. Preserve the failed artifact fence, but still give
-          // the terminal status its own opportunity to reach disk.
-          markOwnedExecutionLeaseUndurable(handle.executionId);
-          logger.warn(
-            'Waiting-execution cleanup failed; continuing terminal persistence',
-            { data: { executionId: handle.executionId, error } },
-          );
-        }
-        const result = await finalizeExecution({
-          executionId: handle.executionId,
-          terminalStatus: projectRunOutcome(RUN_OUTCOME.CANCELLED)
-            .executionStatus,
-          flowRecord: 'delete',
-        });
-        if (result.status === 'failed') {
-          markOwnedExecutionLeaseUndurable(handle.executionId);
-          logger.warn('Failed to finalize stopped waiting execution', {
-            data: {
-              executionId: handle.executionId,
-              stage: result.stage,
-              terminalStatusPersisted: result.terminalStatusPersisted,
-              error: result.error,
-            },
-          });
-        }
-        if (result.terminalStatusPersisted) {
-          await synchronizeAgentResultOutcome(
-            handle.executionId,
-            RUN_OUTCOME.CANCELLED,
-          );
-        }
-      } catch (error) {
-        markOwnedExecutionLeaseUndurable(handle.executionId);
-        logger.warn('Waiting-execution finalizer rejected unexpectedly', {
-          data: { executionId: handle.executionId, error },
-        });
-      } finally {
-        if (!handle.isChildExecution) {
-          try {
-            await this.releaseRootExecutionLease(handle.executionId);
-          } catch (error) {
-            logger.warn('Waiting-execution artifact flush failed', {
-              data: { executionId: handle.executionId, error },
-            });
-          }
-        }
-      }
-    })();
     this.untrackHandle(handle);
     this.cancelStreamStatus(handle.childStreamId, handle);
-    return true;
+
+    // No later result write is guaranteed here, including during RESUMING:
+    // the resume can fail before installing its own handle, while this method
+    // has already untracked the suspended one. Align the interim envelope only
+    // after durable terminal metadata exists. A turn that does continue will
+    // replace it with its own result.
+    try {
+      const result = await finalizeExecution({
+        executionId: handle.executionId,
+        terminalStatus: projectRunOutcome(RUN_OUTCOME.CANCELLED)
+          .executionStatus,
+        flowRecord: 'delete',
+      });
+      if (result.status === 'failed') {
+        markOwnedExecutionLeaseUndurable(handle.executionId);
+        logger.warn('Failed to finalize stopped waiting execution', {
+          data: {
+            executionId: handle.executionId,
+            stage: result.stage,
+            terminalStatusPersisted: result.terminalStatusPersisted,
+            error: result.error,
+          },
+        });
+      }
+      if (result.terminalStatusPersisted) {
+        await synchronizeAgentResultOutcome(
+          handle.executionId,
+          RUN_OUTCOME.CANCELLED,
+        );
+      }
+    } catch (error) {
+      markOwnedExecutionLeaseUndurable(handle.executionId);
+      logger.warn('Waiting-execution finalizer rejected unexpectedly', {
+        data: { executionId: handle.executionId, error },
+      });
+    } finally {
+      if (!handle.isChildExecution) {
+        try {
+          await this.releaseRootExecutionLease(handle.executionId);
+        } catch (error) {
+          logger.warn('Waiting-execution artifact flush failed', {
+            data: { executionId: handle.executionId, error },
+          });
+        }
+      }
+    }
   }
 
   private streamStatusEmitOptions(

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -970,11 +970,6 @@ export class ExecutionRegistry {
     handle.trace?.emit(cancelledResult);
     this.publishResult?.(cancelledResult, handle.childStreamId);
     handle.settleResult(cancelledResult);
-    const finalization = finalizeExecution({
-      executionId: handle.executionId,
-      terminalStatus: projectRunOutcome(RUN_OUTCOME.CANCELLED).executionStatus,
-      flowRecord: 'delete',
-    });
     // No later result write is guaranteed here, including during RESUMING:
     // the resume can fail before installing its own handle, while this method
     // untracks the suspended one below. Align the interim envelope only after
@@ -982,7 +977,13 @@ export class ExecutionRegistry {
     // it with its own result.
     void (async () => {
       try {
-        const result = await finalization;
+        await handle.waitForWaitingCleanup();
+        const result = await finalizeExecution({
+          executionId: handle.executionId,
+          terminalStatus: projectRunOutcome(RUN_OUTCOME.CANCELLED)
+            .executionStatus,
+          flowRecord: 'delete',
+        });
         if (result.status === 'failed') {
           markOwnedExecutionLeaseUndurable(handle.executionId);
           logger.warn('Failed to finalize stopped waiting execution', {

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -977,7 +977,18 @@ export class ExecutionRegistry {
     // it with its own result.
     void (async () => {
       try {
-        await handle.waitForWaitingCleanup();
+        try {
+          await handle.waitForWaitingCleanup();
+        } catch (error) {
+          // Transcript closure and terminal execution metadata are independent
+          // durable facts. Preserve the failed artifact fence, but still give
+          // the terminal status its own opportunity to reach disk.
+          markOwnedExecutionLeaseUndurable(handle.executionId);
+          logger.warn(
+            'Waiting-execution cleanup failed; continuing terminal persistence',
+            { data: { executionId: handle.executionId, error } },
+          );
+        }
         const result = await finalizeExecution({
           executionId: handle.executionId,
           terminalStatus: projectRunOutcome(RUN_OUTCOME.CANCELLED)

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -12,6 +12,7 @@ import {
   resumeToolUseFromResumeData,
   type SubagentRunOptions,
 } from './executeAgent';
+import { AgentExecutionHandle } from './ExecutionHandle';
 import { ResumeAdmissionCancelledError } from './resumeAdmission';
 import { defaultSession } from './SessionHandle';
 import type { ToolUseResumeData } from './SessionResumeRetrieval';
@@ -75,6 +76,14 @@ export async function resumeQueuedToolUseFromResumeData(
   const session = options.session ?? defaultSession();
   const streamStatus = session.status;
   const followUpsQueue = session.followUps;
+
+  const existingHandle = session.executions.getHandle(resume.executionId);
+  if (
+    existingHandle instanceof AgentExecutionHandle &&
+    existingHandle.waitingTerminationStarted
+  ) {
+    return false;
+  }
 
   followUpsQueue.acquire(streamId);
   streamStatus.transition(streamId, STREAM_PHASE.RUNNING, 'resume', {

--- a/src/agent/storage/executionLease.ts
+++ b/src/agent/storage/executionLease.ts
@@ -239,8 +239,7 @@ function heartbeat(lease: OwnedExecutionLease): Promise<void> {
 
   const work = performHeartbeat(lease)
     .catch((error: unknown) => {
-      handleHeartbeatFailure(lease, error);
-      throw error;
+      if (handleHeartbeatFailure(lease, error)) throw error;
     })
     .finally(() => {
       if (lease.heartbeatInFlight === work) {
@@ -264,7 +263,7 @@ function hasErrorCode(error: unknown, code: string): boolean {
 function handleHeartbeatFailure(
   lease: OwnedExecutionLease,
   error: unknown,
-): void {
+): boolean {
   const ownershipUnprovable =
     hasErrorCode(error, 'ECOMPROMISED') ||
     Date.now() - lease.lastConfirmedHeartbeatAt > EXECUTION_LEASE_STALE_MS;
@@ -281,6 +280,7 @@ function handleHeartbeatFailure(
       },
     },
   );
+  return ownershipUnprovable;
 }
 
 function rememberOwnership(

--- a/src/agent/storage/executionLease.ts
+++ b/src/agent/storage/executionLease.ts
@@ -44,6 +44,9 @@ interface OwnedExecutionLease {
   readonly released: Promise<void>;
   readonly resolveReleased: () => void;
   readonly lossListeners: Set<() => void>;
+  heartbeatInFlight: Promise<void> | undefined;
+  lastConfirmedHeartbeatAt: number;
+  releasing: boolean;
   durabilityFailed: boolean;
 }
 
@@ -211,7 +214,7 @@ function forgetOwnedLease(
   }
 }
 
-async function heartbeat(lease: OwnedExecutionLease): Promise<void> {
+async function performHeartbeat(lease: OwnedExecutionLease): Promise<void> {
   await withLeaseLock(
     lease.executionId,
     async () => {
@@ -224,8 +227,59 @@ async function heartbeat(lease: OwnedExecutionLease): Promise<void> {
         { ...current, heartbeatAt: Date.now() },
         lease.storageRoot,
       );
+      lease.lastConfirmedHeartbeatAt = Date.now();
     },
     lease.storageRoot,
+  );
+}
+
+function heartbeat(lease: OwnedExecutionLease): Promise<void> {
+  if (lease.releasing) return Promise.resolve();
+  if (lease.heartbeatInFlight) return lease.heartbeatInFlight;
+
+  const work = performHeartbeat(lease)
+    .catch((error: unknown) => {
+      handleHeartbeatFailure(lease, error);
+      throw error;
+    })
+    .finally(() => {
+      if (lease.heartbeatInFlight === work) {
+        lease.heartbeatInFlight = undefined;
+      }
+    });
+  lease.heartbeatInFlight = work;
+  return work;
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  if (error && typeof error === 'object') {
+    if ('code' in error && error.code === code) return true;
+    if (error instanceof AggregateError) {
+      return error.errors.some((nested) => hasErrorCode(nested, code));
+    }
+  }
+  return false;
+}
+
+function handleHeartbeatFailure(
+  lease: OwnedExecutionLease,
+  error: unknown,
+): void {
+  const ownershipUnprovable =
+    hasErrorCode(error, 'ECOMPROMISED') ||
+    Date.now() - lease.lastConfirmedHeartbeatAt > EXECUTION_LEASE_STALE_MS;
+  if (ownershipUnprovable) {
+    forgetOwnedLease(lease, { notifyLoss: true, fenceWrites: true });
+  }
+  logger.warn(
+    CHANNEL,
+    `Failed to heartbeat execution ${lease.executionId}: ${toErrorMessage(error)}`,
+    {
+      data: {
+        error,
+        ownershipFenced: ownershipUnprovable,
+      },
+    },
   );
 }
 
@@ -245,6 +299,9 @@ function rememberOwnership(
     released,
     resolveReleased,
     lossListeners: new Set(),
+    heartbeatInFlight: undefined,
+    lastConfirmedHeartbeatAt: Date.now(),
+    releasing: false,
     durabilityFailed: false,
   };
   ownedLeases.set(ownershipKey(root, executionId), lease);
@@ -252,18 +309,9 @@ function rememberOwnership(
   if (!heartbeatTimer) {
     heartbeatTimer = setInterval(() => {
       for (const owned of ownedLeases.values()) {
-        void heartbeat(owned).catch((error: unknown) => {
-          // A host that cannot renew the lease also cannot prove continued
-          // ownership to its peers. Ordinary execution persistence uses the
-          // same storage root and will normally fail on the same outage; keep
-          // the last lease record intact so peers remain fail-closed until the
-          // documented stale horizon rather than deleting it prematurely.
-          logger.warn(
-            CHANNEL,
-            `Failed to heartbeat execution ${owned.executionId}: ${toErrorMessage(error)}`,
-            { data: error },
-          );
-        });
+        // heartbeat() records and classifies its own failure before rejecting;
+        // the interval consumes that rejection because it has no caller.
+        void heartbeat(owned).catch(() => undefined);
       }
     }, EXECUTION_LEASE_HEARTBEAT_MS);
     heartbeatTimer.unref();
@@ -307,14 +355,18 @@ async function runWithValidatedOwnership<T>(
   );
 }
 
-/** Hold the coordination lock while an owned execution commits artifacts. */
-export async function runWithOwnedExecutionLease<T>(
+/** Refresh and validate local ownership at a short durability boundary. */
+export async function renewOwnedExecutionLease(
   executionId: ExecutionId,
-  operation: () => Promise<T>,
-): Promise<T> {
+): Promise<void> {
   const lease = ownedLeases.get(ownershipKey(storageRoot(), executionId));
-  if (!lease) throw new ExecutionLeaseLostError(executionId);
-  return runWithValidatedOwnership(lease, operation);
+  if (!lease || lease.releasing) {
+    throw new ExecutionLeaseLostError(executionId);
+  }
+  await heartbeat(lease);
+  if (ownedLeases.get(ownershipKey(lease.storageRoot, executionId)) !== lease) {
+    throw new ExecutionLeaseLostError(executionId);
+  }
 }
 
 /**
@@ -489,6 +541,12 @@ async function releaseOwnership(ownership: OwnedExecutionLease): Promise<void> {
   const root = ownership.storageRoot;
   const { executionId } = ownership;
   let ownershipLost = false;
+  let releaseFailed = false;
+  ownership.releasing = true;
+  await ownership.heartbeatInFlight?.catch(() => undefined);
+  if (ownedLeases.get(ownershipKey(root, executionId)) !== ownership) {
+    return;
+  }
   try {
     await withLeaseLock(
       executionId,
@@ -503,9 +561,14 @@ async function releaseOwnership(ownership: OwnedExecutionLease): Promise<void> {
       root,
     );
   } catch (error) {
-    if (!isFileNotFoundError(error)) throw error;
+    if (!isFileNotFoundError(error)) {
+      releaseFailed = true;
+      throw error;
+    }
   } finally {
-    forgetOwnedLease(ownership, { fenceWrites: ownershipLost });
+    forgetOwnedLease(ownership, {
+      fenceWrites: ownershipLost || releaseFailed,
+    });
   }
 }
 

--- a/src/agent/storage/executionLease.ts
+++ b/src/agent/storage/executionLease.ts
@@ -364,7 +364,10 @@ export async function renewOwnedExecutionLease(
     throw new ExecutionLeaseLostError(executionId);
   }
   await heartbeat(lease);
-  if (ownedLeases.get(ownershipKey(lease.storageRoot, executionId)) !== lease) {
+  if (
+    lease.releasing ||
+    ownedLeases.get(ownershipKey(lease.storageRoot, executionId)) !== lease
+  ) {
     throw new ExecutionLeaseLostError(executionId);
   }
 }

--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -45,7 +45,7 @@ import {
 import { isGoalInFlight } from '@shared/schemas/goal';
 import { buildStreamContentSync } from '@shared/streams/streamContentSync';
 import { diffActiveChildren } from '@shared/streams/childActivityReducer';
-import { isInFlightPhase } from '@shared/streams/streamStatus';
+import { isActivePhase } from '@shared/streams/streamStatus';
 import { GoalStore } from '@tools/goal';
 import { assertNever, mapToRecord } from '@utils/core';
 
@@ -829,12 +829,12 @@ export class ProgressFactApplier {
       this.state.streamLogs.mode.kind === 'persistent' &&
       this.state.streamLogs.has(streamId) &&
       !this.state.streamLogs.get(streamId);
-    if (isInFlightPhase(status)) {
+    if (isActivePhase(status)) {
       if (requiresPersistentRehydrate) {
         await this.state.streamLogs.ensureLoaded(streamId);
       }
     } else if (streamId !== this.state.activeStream) {
-      this.state.streamLogs.releaseEntries(streamId);
+      this.state.streamLogs.requestEviction(streamId);
     }
 
     const isNewRunningTransition =

--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -818,13 +818,8 @@ export class ProgressFactApplier {
     _previousStatus?: StreamPhase,
     substate?: StreamSubstate,
   ): Promise<void> {
-    // Keep memory bounded by stream status:
-    //  - returning to in-flight (e.g., background resume) eagerly rehydrates
-    //    previously-released entries so pending appends from the agent
-    //    runtime land on the full on-disk log instead of clobbering it via
-    //    an empty getOrCreate.
-    //  - leaving the in-flight set drops heavy entries; disk stays
-    //    authoritative and `setActiveStream` re-reads on demand.
+    // Active phases keep the full log resident for runtime writes. Inactive,
+    // unfocused streams release heavy entries and rehydrate on demand.
     const requiresPersistentRehydrate =
       this.state.streamLogs.mode.kind === 'persistent' &&
       this.state.streamLogs.has(streamId) &&

--- a/src/controllers/progressView/backend/state/ProgressViewState.ts
+++ b/src/controllers/progressView/backend/state/ProgressViewState.ts
@@ -542,33 +542,32 @@ export class ProgressViewState {
           const text = legacyInstruction.text.trim();
           if (!text) return;
 
-          await this.streamLogs.ensureLoaded(streamId);
-          const log = this.streamLogs.get(streamId);
-          if (!log) return;
-
-          const alreadyPresent = log
-            .getRange(0, log.head)
-            .some(
-              (entry) =>
-                entry.type === STREAM_LOG_ENTRY_TYPES.LOG &&
-                entry.messageType === MESSAGE_TYPES.USER_MESSAGE &&
-                entry.text?.trim() === text,
-            );
-          if (alreadyPresent) return;
-
-          const firstTimestamp = log.firstTimestamp;
-          const baseTimestamp =
-            legacyInstruction.timestamp ?? firstTimestamp ?? Date.now();
-          const timestamp =
-            firstTimestamp == null
-              ? baseTimestamp
-              : clamp(baseTimestamp, 0, firstTimestamp - 1);
-
-          const writer = this.streamLogs.acquireWriter(
+          const writer = await this.streamLogs.loadAndAcquireWriter(
             streamId,
             `legacy-instruction:${streamId}`,
           );
           try {
+            const log = this.streamLogs.get(streamId);
+            if (!log) return;
+
+            const alreadyPresent = log
+              .getRange(0, log.head)
+              .some(
+                (entry) =>
+                  entry.type === STREAM_LOG_ENTRY_TYPES.LOG &&
+                  entry.messageType === MESSAGE_TYPES.USER_MESSAGE &&
+                  entry.text?.trim() === text,
+              );
+            if (alreadyPresent) return;
+
+            const firstTimestamp = log.firstTimestamp;
+            const baseTimestamp =
+              legacyInstruction.timestamp ?? firstTimestamp ?? Date.now();
+            const timestamp =
+              firstTimestamp == null
+                ? baseTimestamp
+                : clamp(baseTimestamp, 0, firstTimestamp - 1);
+
             writer.append({
               id: `legacy-instruction:${streamId}:${timestamp}`,
               type: STREAM_LOG_ENTRY_TYPES.LOG,

--- a/src/controllers/progressView/backend/state/ProgressViewState.ts
+++ b/src/controllers/progressView/backend/state/ProgressViewState.ts
@@ -30,7 +30,7 @@ import {
   PersistedState,
   createBackendStorage,
 } from '@shared/state/PersistedState';
-import { isInFlightPhase } from '@shared/streams/streamStatus';
+import { isActivePhase } from '@shared/streams/streamStatus';
 import { GoalStore } from '@tools/goal';
 import { StreamSnapshotStore, type StreamLogStore } from '@transcript';
 import { clamp } from '@utils/core';
@@ -203,8 +203,8 @@ export class ProgressViewState {
    * call this on the stream being moved away from to close the loop.
    */
   releasePreviousActive(streamId: StreamTabId): void {
-    if (!isInFlightPhase(this.streamStatus.get(streamId))) {
-      this.streamLogs.releaseEntries(streamId);
+    if (!isActivePhase(this.streamStatus.get(streamId))) {
+      this.streamLogs.requestEviction(streamId);
     }
   }
 
@@ -564,15 +564,23 @@ export class ProgressViewState {
               ? baseTimestamp
               : clamp(baseTimestamp, 0, firstTimestamp - 1);
 
-          this.streamLogs.append(streamId, {
-            id: `legacy-instruction:${streamId}:${timestamp}`,
-            type: STREAM_LOG_ENTRY_TYPES.LOG,
-            level: LOG_LEVELS.INFO,
-            timestamp,
-            messageType: MESSAGE_TYPES.USER_MESSAGE,
-            text: legacyInstruction.text,
-            data: { source: 'legacyInstruction' },
-          });
+          const writer = this.streamLogs.acquireWriter(
+            streamId,
+            `legacy-instruction:${streamId}`,
+          );
+          try {
+            writer.append({
+              id: `legacy-instruction:${streamId}:${timestamp}`,
+              type: STREAM_LOG_ENTRY_TYPES.LOG,
+              level: LOG_LEVELS.INFO,
+              timestamp,
+              messageType: MESSAGE_TYPES.USER_MESSAGE,
+              text: legacyInstruction.text,
+              data: { source: 'legacyInstruction' },
+            });
+          } finally {
+            writer.close();
+          }
           restoredCount++;
         } catch (err) {
           this.logger.warn(

--- a/src/platform/defaults/fileLocks.ts
+++ b/src/platform/defaults/fileLocks.ts
@@ -3,9 +3,12 @@ import * as path from 'node:path';
 
 import { lock } from 'proper-lockfile';
 
+import { KeyedMutex } from '@utils/core/keyedMutex';
+
 import type { FileLockProvider } from '../interfaces';
 
-const LOCK_STALE_MS = 10_000;
+/** Match the execution-liveness horizon: shorter stalls do not prove death. */
+const LOCK_STALE_MS = 120_000;
 /** Refresh well before another process may classify a held lock as stale. */
 const LOCK_UPDATE_MS = 2_000;
 const LOCK_RETRIES = {
@@ -15,6 +18,8 @@ const LOCK_RETRIES = {
   maxTimeout: 250,
   randomize: true,
 } as const;
+
+const localLocks = new KeyedMutex<string>();
 
 /**
  * Native cross-process locks for local shared-storage paths.
@@ -26,17 +31,52 @@ export const nodeFileLocks: FileLockProvider = {
     lockPath: string,
     operation: () => Promise<T>,
   ): Promise<T> {
-    await mkdir(path.dirname(lockPath), { recursive: true });
-    const release = await lock(lockPath, {
-      realpath: false,
-      stale: LOCK_STALE_MS,
-      update: LOCK_UPDATE_MS,
-      retries: LOCK_RETRIES,
+    const canonicalPath = path.resolve(lockPath);
+    return localLocks.runExclusive(canonicalPath, async () => {
+      await mkdir(path.dirname(canonicalPath), { recursive: true });
+      let compromised: Error | undefined;
+      const release = await lock(canonicalPath, {
+        realpath: false,
+        stale: LOCK_STALE_MS,
+        update: LOCK_UPDATE_MS,
+        retries: LOCK_RETRIES,
+        // proper-lockfile's default callback throws from its renewal timer,
+        // outside runExclusive's promise. Retain the failure and return it at
+        // this operation boundary instead of terminating the Node process.
+        onCompromised: (error) => {
+          compromised ??= error;
+        },
+      });
+
+      let value: T | undefined;
+      let operationFailure: unknown;
+      try {
+        value = await operation();
+      } catch (error) {
+        operationFailure = error;
+      }
+
+      let releaseFailure: unknown;
+      try {
+        await release();
+      } catch (error) {
+        // A compromised lock has already been marked released internally.
+        // Its ERELEASED cleanup error carries less information than the
+        // original compromise and must not replace it.
+        if (!compromised) releaseFailure = error;
+      }
+
+      const failures = [operationFailure, compromised, releaseFailure].filter(
+        (error) => error !== undefined,
+      );
+      if (failures.length === 1) throw failures[0];
+      if (failures.length > 1) {
+        throw new AggregateError(
+          failures,
+          `File lock failed: ${canonicalPath}`,
+        );
+      }
+      return value as T;
     });
-    try {
-      return await operation();
-    } finally {
-      await release();
-    }
   },
 };

--- a/src/test-kernel/agent/RoundPersistedFlowCompileRepair.vitest.ts
+++ b/src/test-kernel/agent/RoundPersistedFlowCompileRepair.vitest.ts
@@ -247,7 +247,10 @@ describe('RoundPersistedFlow round outcome persistence (#8137)', () => {
       };
 
       store.ensureStream(streamId);
-      const recorder = attachTranscriptRecorder(logger, streamId, store);
+      const recorder = attachTranscriptRecorder(
+        logger,
+        store.acquireWriter(streamId, streamId),
+      );
 
       try {
         const run = flow.run(shared);

--- a/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
@@ -304,7 +304,10 @@ describe('tool-use round outcome persistence (#8023)', () => {
       const streamId = `stream:tool-use-round-${name}` as StreamTabId;
       const store = StreamLogStore.ephemeral('test');
       store.ensureStream(streamId);
-      const recorder = attachTranscriptRecorder(logger, streamId, store);
+      const recorder = attachTranscriptRecorder(
+        logger,
+        store.acquireWriter(streamId, streamId),
+      );
       const node = new ToolUseCycleNode().setServices({
         streamId,
         runtimeHost: host,

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -722,11 +722,13 @@ describe('runFlowWithLifecycle', () => {
         STREAM_PHASE.CANCELLED,
       );
       expect(followUpsRelease).toHaveBeenCalledWith(streamId);
-      expect(storageMocks.finalizeExecution).toHaveBeenCalledWith({
-        executionId,
-        terminalStatus: EXECUTION_STATUS.INTERRUPTED,
-        flowRecord: 'delete',
-      });
+      await vi.waitFor(() =>
+        expect(storageMocks.finalizeExecution).toHaveBeenCalledWith({
+          executionId,
+          terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+          flowRecord: 'delete',
+        }),
+      );
       // The kill path never resumes, so the per-suspension parent stage must
       // be closed here rather than dangling open forever. `ctx.parentStage`
       // is already desubscribed by this point (disposeTrace ran in the

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -691,6 +691,11 @@ describe('runFlowWithLifecycle', () => {
         streamId,
         STREAM_STATUS.WAITING,
       );
+      const waitingHandle = defaultSession().executions.getHandle(executionId);
+      expect(waitingHandle).toBeInstanceOf(AgentExecutionHandle);
+      if (!(waitingHandle instanceof AgentExecutionHandle)) {
+        throw new Error('Expected a suspended agent execution handle.');
+      }
 
       // runToolUseFlow's finally detaches this stream's interrupt handler but
       // (post #7286) preserves the follow-up queue for WAITING — it does not
@@ -702,6 +707,7 @@ describe('runFlowWithLifecycle', () => {
       // fall back to the waiting-cleanup registered above and actually tear
       // the execution down.
       expect(defaultSession().executions.kill(executionId)).toBe(true);
+      await waitingHandle.result;
 
       // The bypassed runFlowWithLifecycle can't emit the terminal result, so
       // terminateWaitingHandle must — trace subscribers would otherwise miss

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -760,6 +760,70 @@ describe('runFlowWithLifecycle', () => {
     }
   });
 
+  it('does not close a waiting transcript group after lease loss', async () => {
+    const { executionId, streamId, ctx } = lifecycleFixture(
+      'lifecycle-waiting-cleanup-lease-loss',
+    );
+    const transcripts = ctx.runScope.session.transcripts;
+    const transcriptsUpdate = vi.spyOn(transcripts, 'update');
+    transcriptsUpdate.mockClear();
+    storageMocks.finalizeExecution.mockClear();
+    const originalLoadAndAcquireWriter =
+      transcripts.loadAndAcquireWriter.bind(transcripts);
+    let markWriterLoadStarted = (): void => undefined;
+    const writerLoadStarted = new Promise<void>((resolve) => {
+      markWriterLoadStarted = resolve;
+    });
+    let releaseWriterLoad = (): void => undefined;
+    const writerLoadGate = new Promise<void>((resolve) => {
+      releaseWriterLoad = resolve;
+    });
+    vi.spyOn(transcripts, 'loadAndAcquireWriter').mockImplementationOnce(
+      async (requestedStreamId, ownerKey) => {
+        markWriterLoadStarted();
+        await writerLoadGate;
+        return originalLoadAndAcquireWriter(requestedStreamId, ownerKey);
+      },
+    );
+
+    try {
+      const result = await runFlowWithLifecycle(
+        ctx,
+        async () => ({
+          category: 'toolUse',
+          outcome: STREAM_PHASE.WAITING,
+          executionId,
+          streamId,
+        }),
+        { isSubagent: true },
+      );
+      expect(result.outcome).toBe(STREAM_PHASE.WAITING);
+      seedStreamStatusForTest(
+        defaultSession().status,
+        streamId,
+        STREAM_STATUS.WAITING,
+      );
+      const waitingHandle = defaultSession().executions.getHandle(executionId);
+      expect(waitingHandle).toBeInstanceOf(AgentExecutionHandle);
+      if (!(waitingHandle instanceof AgentExecutionHandle)) {
+        throw new Error('Expected a suspended agent execution handle.');
+      }
+
+      expect(defaultSession().executions.kill(executionId)).toBe(true);
+      await writerLoadStarted;
+      waitingHandle.markExecutionLeaseLost();
+      releaseWriterLoad();
+      await waitingHandle.result;
+
+      expect(transcriptsUpdate).not.toHaveBeenCalled();
+      expect(storageMocks.finalizeExecution).not.toHaveBeenCalled();
+    } finally {
+      releaseWriterLoad();
+      defaultSession().executions.untrack(executionId);
+      clearStreamStatusForTest(defaultSession().status, streamId);
+    }
+  });
+
   // The canonical outcome is decided once and projected three ways. This
   // matrix pins the projections for every terminal path — in particular that
   // a user stop (the no-throw `cancelled` exit, the dominant stop path)

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -498,6 +498,60 @@ describe('executionRegistry', () => {
     }
   });
 
+  it('hands a waiting stop to a successor tracked during cleanup', async () => {
+    storageMocks.finalizeExecution.mockClear();
+    const streamStatus = new StreamStatusMachine();
+    const publishResult = vi.fn();
+    const registry = new ExecutionRegistry({ streamStatus, publishResult });
+    const executionId = 'exec-waiting-stop-handoff' as ExecutionId;
+    const childStreamId = 'child-waiting-stop-handoff' as StreamTabId;
+    let finishCleanup = (): void => undefined;
+    const cleanupGate = new Promise<void>((resolve) => {
+      finishCleanup = resolve;
+    });
+
+    try {
+      const previous = createHandle(
+        executionId,
+        'parent-waiting-stop-handoff' as StreamTabId,
+        childStreamId,
+        createRecordingHost().host,
+      );
+      registry.track(previous);
+      previous.registerWaitingCleanup(() => cleanupGate);
+      seedStreamStatusForTest(
+        streamStatus,
+        childStreamId,
+        STREAM_STATUS.WAITING,
+      );
+
+      expect(registry.kill(executionId)).toBe(true);
+
+      const successor = createHandle(
+        executionId,
+        'parent-waiting-stop-handoff' as StreamTabId,
+        childStreamId,
+        createRecordingHost().host,
+      );
+      successor.enablePendingInterrupt();
+      registry.track(successor);
+
+      expect(successor.hasPendingInterrupt).toBe(true);
+      finishCleanup();
+      await expect(previous.result).resolves.toMatchObject({
+        type: 'result',
+        outcome: RUN_OUTCOME.CANCELLED,
+      });
+
+      expect(registry.getHandle(executionId)).toBe(successor);
+      expect(publishResult).not.toHaveBeenCalled();
+      expect(storageMocks.finalizeExecution).not.toHaveBeenCalled();
+      expect(streamStatus.get(childStreamId)).toBe(STREAM_PHASE.WAITING);
+    } finally {
+      registry.dispose();
+    }
+  });
+
   it('settles waiting termination when detached publication throws', async () => {
     const streamStatus = new StreamStatusMachine();
     const publishFailure = new Error('terminal subscriber failed');

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -333,7 +333,7 @@ describe('executionRegistry', () => {
     }
   });
 
-  it('falls back to a registered waiting-cleanup when a suspended handle has no live interrupt (issue #7287)', () => {
+  it('falls back to a registered waiting-cleanup when a suspended handle has no live interrupt (issue #7287)', async () => {
     // Regression: a native subagent suspended at WAITING has already had its
     // live interrupt context detached (runToolUseFlow's finally), while the
     // handle stays tracked for resume. Before the fix, terminate() found no
@@ -366,6 +366,7 @@ describe('executionRegistry', () => {
       );
 
       expect(registry.kill(executionId)).toBe(true);
+      await handle.result;
 
       expect(cleanup).toHaveBeenCalledOnce();
       expect(streamStatus.get(childStreamId)).toBe(STREAM_PHASE.CANCELLED);
@@ -417,6 +418,7 @@ describe('executionRegistry', () => {
       );
 
       expect(registry.kill(executionId)).toBe(true);
+      await handle.result;
 
       expect(publishResult).toHaveBeenCalledExactlyOnceWith(
         expect.objectContaining({
@@ -442,6 +444,55 @@ describe('executionRegistry', () => {
         outcome: RUN_OUTCOME.CANCELLED,
         executionId,
       });
+    } finally {
+      registry.dispose();
+    }
+  });
+
+  it('publishes a waiting cancellation after its transcript cleanup settles', async () => {
+    const streamStatus = new StreamStatusMachine();
+    const order: string[] = [];
+    const publishResult = vi.fn(() => order.push('publish'));
+    const registry = new ExecutionRegistry({ streamStatus, publishResult });
+    const executionId = 'exec-waiting-cleanup-order' as ExecutionId;
+    const childStreamId = 'child-waiting-cleanup-order' as StreamTabId;
+    let finishCleanup = (): void => undefined;
+    const cleanupGate = new Promise<void>((resolve) => {
+      finishCleanup = resolve;
+    });
+
+    try {
+      const handle = createHandle(
+        executionId,
+        'parent-waiting-cleanup-order' as StreamTabId,
+        childStreamId,
+        createRecordingHost().host,
+      );
+      registry.track(handle);
+      handle.registerWaitingCleanup(async () => {
+        await cleanupGate;
+        order.push('cleanup');
+      });
+      seedStreamStatusForTest(
+        streamStatus,
+        childStreamId,
+        STREAM_STATUS.WAITING,
+      );
+
+      expect(registry.kill(executionId)).toBe(true);
+      await Promise.resolve();
+      expect(publishResult).not.toHaveBeenCalled();
+      expect(registry.getHandle(executionId)).toBe(handle);
+      expect(streamStatus.get(childStreamId)).toBe(STREAM_PHASE.WAITING);
+
+      finishCleanup();
+      await expect(handle.result).resolves.toMatchObject({
+        type: 'result',
+        outcome: RUN_OUTCOME.CANCELLED,
+      });
+      expect(order).toEqual(['cleanup', 'publish']);
+      expect(registry.getHandle(executionId)).toBeUndefined();
+      expect(streamStatus.get(childStreamId)).toBe(STREAM_PHASE.CANCELLED);
     } finally {
       registry.dispose();
     }
@@ -735,6 +786,7 @@ describe('executionRegistry', () => {
       );
 
       expect(registry.kill(executionId)).toBe(true);
+      await handle.result;
 
       expect(cleanup).toHaveBeenCalledOnce();
       expect(registry.getHandle(executionId)).toBeUndefined();

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -498,6 +498,45 @@ describe('executionRegistry', () => {
     }
   });
 
+  it('settles waiting termination when detached publication throws', async () => {
+    const streamStatus = new StreamStatusMachine();
+    const publishFailure = new Error('terminal subscriber failed');
+    const registry = new ExecutionRegistry({
+      streamStatus,
+      publishResult: () => {
+        throw publishFailure;
+      },
+    });
+    const executionId = 'exec-waiting-publication-failure' as ExecutionId;
+    const childStreamId = 'child-waiting-publication-failure' as StreamTabId;
+
+    try {
+      const handle = createHandle(
+        executionId,
+        'parent-waiting-publication-failure' as StreamTabId,
+        childStreamId,
+        createRecordingHost().host,
+      );
+      registry.track(handle);
+      handle.registerWaitingCleanup(() => {});
+      seedStreamStatusForTest(
+        streamStatus,
+        childStreamId,
+        STREAM_STATUS.WAITING,
+      );
+
+      expect(registry.kill(executionId)).toBe(true);
+      await expect(handle.result).resolves.toMatchObject({
+        type: 'result',
+        outcome: RUN_OUTCOME.CANCELLED,
+      });
+      expect(registry.getHandle(executionId)).toBeUndefined();
+      expect(streamStatus.get(childStreamId)).toBe(STREAM_PHASE.CANCELLED);
+    } finally {
+      registry.dispose();
+    }
+  });
+
   it('settles and untracks a waiting handle when terminal metadata persistence fails', async () => {
     const streamStatus = new StreamStatusMachine();
     const registry = new ExecutionRegistry({ streamStatus });

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -97,6 +97,33 @@ function createHandle(
 }
 
 describe('executionRegistry', () => {
+  it('retains an in-progress waiting cleanup after registrations are cleared', async () => {
+    const handle = createHandle(
+      'exec-waiting-cleanup-completion',
+      'stream-waiting-cleanup-completion' as StreamTabId,
+      'stream-waiting-cleanup-completion' as StreamTabId,
+      createRecordingHost().host,
+    );
+    let finishCleanup: () => void = () => undefined;
+    const cleanupFinished = new Promise<void>((resolve) => {
+      finishCleanup = resolve;
+    });
+    handle.registerWaitingCleanup(() => cleanupFinished);
+
+    expect(handle.runWaitingCleanup()).toBe(true);
+    handle.clearWaitingCleanup();
+    let observedCompletion = false;
+    const observation = handle.waitForWaitingCleanup().then(() => {
+      observedCompletion = true;
+    });
+    await Promise.resolve();
+    expect(observedCompletion).toBe(false);
+
+    finishCleanup();
+    await observation;
+    expect(observedCompletion).toBe(true);
+  });
+
   it('settles without persisting a stopped waiting handle after lease loss', async () => {
     const streamStatus = new StreamStatusMachine();
     const registry = new ExecutionRegistry({ streamStatus });

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -27,6 +27,7 @@ import {
   type ExecutionId,
   type StreamTabId,
 } from '@shared/schemas';
+import { projectRunOutcome } from '@shared/streams/streamStatus';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { seedStreamStatusForTest } from '@test/helpers/streamStatusTestUtils';
 
@@ -501,6 +502,55 @@ describe('executionRegistry', () => {
         );
       });
       expect(storageMocks.synchronizeAgentResultOutcome).not.toHaveBeenCalled();
+    } finally {
+      registry.dispose();
+    }
+  });
+
+  it('persists a waiting stop after transcript cleanup fails', async () => {
+    const streamStatus = new StreamStatusMachine();
+    const registry = new ExecutionRegistry({ streamStatus });
+    const executionId = 'exec-waiting-cleanup-failure' as ExecutionId;
+    const parentStreamId = 'parent-waiting-cleanup-failure' as StreamTabId;
+    const childStreamId = 'child-waiting-cleanup-failure' as StreamTabId;
+    const cleanupError = new Error('transcript reload failed');
+    storageMocks.finalizeExecution.mockResolvedValueOnce({
+      status: 'durable',
+      terminalStatusPersisted: true,
+      flowRecord: 'deleted',
+    });
+    storageMocks.synchronizeAgentResultOutcome.mockResolvedValueOnce(undefined);
+    channelTraceMocks.warn.mockClear();
+
+    try {
+      const handle = createHandle(
+        executionId,
+        parentStreamId,
+        childStreamId,
+        createRecordingHost().host,
+      );
+      registry.track(handle);
+      handle.registerWaitingCleanup(() => Promise.reject(cleanupError));
+      seedStreamStatusForTest(
+        streamStatus,
+        childStreamId,
+        STREAM_STATUS.WAITING,
+      );
+
+      expect(registry.kill(executionId)).toBe(true);
+
+      await vi.waitFor(() => {
+        expect(storageMocks.finalizeExecution).toHaveBeenCalledWith({
+          executionId,
+          terminalStatus: projectRunOutcome(RUN_OUTCOME.CANCELLED)
+            .executionStatus,
+          flowRecord: 'delete',
+        });
+      });
+      expect(channelTraceMocks.warn).toHaveBeenCalledWith(
+        'Waiting-execution cleanup failed; continuing terminal persistence',
+        { data: { executionId, error: cleanupError } },
+      );
     } finally {
       registry.dispose();
     }

--- a/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
+++ b/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
@@ -9,10 +9,7 @@ const mocks = vi.hoisted(() => ({
   runFlowWithLifecycle: vi.fn(),
   runToolUseFlow: vi.fn(),
   acquireResumedExecutionLease: vi.fn(),
-  runWithOwnedExecutionLease: vi.fn(
-    async (_executionId: ExecutionId, operation: () => Promise<unknown>) =>
-      operation(),
-  ),
+  renewOwnedExecutionLease: vi.fn(),
   runWithExecutionLeaseWriteFence: vi.fn(
     async (_executionId: ExecutionId, operation: () => Promise<unknown>) =>
       operation(),
@@ -25,7 +22,7 @@ vi.mock('@agent/storage/executionLease', () => ({
   abandonOwnedExecutionLease: mocks.abandonOwnedExecutionLease,
   acquireResumedExecutionLease: mocks.acquireResumedExecutionLease,
   completeOwnedExecutionLease: mocks.completeOwnedExecutionLease,
-  runWithOwnedExecutionLease: mocks.runWithOwnedExecutionLease,
+  renewOwnedExecutionLease: mocks.renewOwnedExecutionLease,
   runWithExecutionLeaseWriteFence: mocks.runWithExecutionLeaseWriteFence,
   releaseOwnedExecutionLeaseAfterFailure:
     mocks.releaseOwnedExecutionLeaseAfterFailure,

--- a/src/test-kernel/agent/runtime/RunAgentOwnership.vitest.ts
+++ b/src/test-kernel/agent/runtime/RunAgentOwnership.vitest.ts
@@ -2,10 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   abandonOwnedExecutionLease: vi.fn(),
-  runWithOwnedExecutionLease: vi.fn(
-    async (_executionId: ExecutionId, operation: () => Promise<unknown>) =>
-      operation(),
-  ),
+  renewOwnedExecutionLease: vi.fn(),
   acquireResumedExecutionLease: vi.fn(),
   executeAgent: vi.fn(),
   finalizeExecution: vi.fn(),
@@ -16,7 +13,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('@agent/storage', () => ({
   abandonOwnedExecutionLease: mocks.abandonOwnedExecutionLease,
-  runWithOwnedExecutionLease: mocks.runWithOwnedExecutionLease,
+  renewOwnedExecutionLease: mocks.renewOwnedExecutionLease,
   acquireResumedExecutionLease: mocks.acquireResumedExecutionLease,
   completeOwnedExecutionLease: mocks.completeOwnedExecutionLease,
   finalizeExecution: mocks.finalizeExecution,
@@ -25,7 +22,7 @@ vi.mock('@agent/storage', () => ({
 
 vi.mock('@agent/storage/executionLease', () => ({
   markOwnedExecutionLeaseUndurable: mocks.markOwnedExecutionLeaseUndurable,
-  runWithOwnedExecutionLease: mocks.runWithOwnedExecutionLease,
+  renewOwnedExecutionLease: mocks.renewOwnedExecutionLease,
 }));
 
 vi.mock('@agent/runtime/executeAgent', () => ({
@@ -52,6 +49,7 @@ describe('runAgent execution ownership', () => {
     mocks.registerExecution.mockResolvedValue(undefined);
     mocks.acquireResumedExecutionLease.mockResolvedValue('acquired');
     mocks.completeOwnedExecutionLease.mockResolvedValue(undefined);
+    mocks.renewOwnedExecutionLease.mockResolvedValue(undefined);
     flushArtifacts.mockResolvedValue(undefined);
     mocks.finalizeExecution.mockResolvedValue({
       status: 'durable',

--- a/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
@@ -306,6 +306,26 @@ describe('SessionHandle', () => {
     expect(executions).toHaveBeenCalledOnce();
   });
 
+  it('finishes trace flushing and owner teardown before surfacing a flush failure', () => {
+    const session = createTestSession();
+    const failure = new Error('latched transcript failure');
+    const laterFlusher = vi.fn();
+    const interactions = vi.spyOn(session.interactions, 'dispose');
+    const subscriptions = vi.spyOn(session.subscriptions, 'dispose');
+    const executions = vi.spyOn(session.executions, 'dispose');
+    session.flushers.add(() => {
+      throw failure;
+    });
+    session.flushers.add(laterFlusher);
+
+    expect(() => session.dispose()).toThrow(failure);
+
+    expect(laterFlusher).toHaveBeenCalledOnce();
+    expect(interactions).toHaveBeenCalledOnce();
+    expect(subscriptions).toHaveBeenCalledOnce();
+    expect(executions).toHaveBeenCalledOnce();
+  });
+
   it('rejects execution work registered after disposal', () => {
     const session = createTestSession();
     const { host } = createRecordingHost();

--- a/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
@@ -18,7 +18,7 @@ import {
 import { AgentExecutionHandle } from '@agent/runtime/ExecutionHandle';
 import { type Plan, type StreamTabId } from '@shared/schemas';
 import { createTestSession } from '@test/support/sessionTestUtils';
-import { getActiveFlushers, StreamLogStore } from '@transcript';
+import { StreamLogStore } from '@transcript';
 
 // Local file imports
 import { createRecordingHost } from '../progressTestUtils';
@@ -122,6 +122,47 @@ describe('SessionHandle', () => {
     }
   });
 
+  it('coalesces durability calls made in the same synchronous burst', async () => {
+    const session = createTestSession();
+    const flush = vi
+      .spyOn(session.transcripts, 'flush')
+      .mockResolvedValue(undefined);
+    try {
+      const first = session.flushArtifacts();
+      const second = session.flushArtifacts();
+
+      expect(second).toBe(first);
+      await Promise.all([first, second]);
+      expect(flush).toHaveBeenCalledOnce();
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it('runs one trailing durability batch for calls arriving mid-flush', async () => {
+    const session = createTestSession();
+    let releaseFirst = (): void => undefined;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const flush = vi
+      .spyOn(session.transcripts, 'flush')
+      .mockImplementationOnce(() => firstGate)
+      .mockResolvedValue(undefined);
+    try {
+      const first = session.flushArtifacts();
+      await vi.waitFor(() => expect(flush).toHaveBeenCalledOnce());
+      const trailing = session.flushArtifacts();
+
+      expect(trailing).not.toBe(first);
+      releaseFirst();
+      await Promise.all([first, trailing]);
+      expect(flush).toHaveBeenCalledTimes(2);
+    } finally {
+      session.dispose();
+    }
+  });
+
   it('rejects a read-only transcript store', async () => {
     const transcripts = await StreamLogStore.openReadOnly();
 
@@ -134,10 +175,8 @@ describe('SessionHandle', () => {
     // No `Shared*`/`*Service` module export exists anymore — the process
     // default's owners are installed together by the test composition root.
     // What's left to verify is that repeated calls return the identical
-    // session (and therefore identical members), and that the flushers
-    // member still aliases the process-wide flush registry by identity
-    // (that accessor is intentionally NOT one of the deleted aliases — see
-    // `runTrace.ts`'s `getActiveFlushers`).
+    // session (and therefore identical members), including its one owned
+    // trace-flusher set.
     const first = defaultSession();
     const second = defaultSession();
     expect(second).toBe(first);
@@ -147,7 +186,7 @@ describe('SessionHandle', () => {
     expect(second.events).toBe(first.events);
     expect(second.transcripts).toBe(first.transcripts);
     expect(second.followUps).toBe(first.followUps);
-    expect(defaultSession().flushers).toBe(getActiveFlushers());
+    expect(second.flushers).toBe(first.flushers);
   });
 
   it('a fresh session shares no member with the default session', () => {
@@ -164,7 +203,7 @@ describe('SessionHandle', () => {
       expect(fresh.workflowControls).not.toBe(
         defaultSession().workflowControls,
       );
-      expect(fresh.flushers).not.toBe(getActiveFlushers());
+      expect(fresh.flushers).not.toBe(defaultSession().flushers);
     } finally {
       fresh.dispose();
     }

--- a/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
@@ -77,7 +77,7 @@ describe('SessionHandle', () => {
   it('drains trace, transcript, and registered artifact writers together', async () => {
     const session = createTestSession();
     const order: string[] = [];
-    session.flushers.add(() => order.push('trace'));
+    session.flushers.set('exec:trace', () => order.push('trace'));
     vi.spyOn(session.transcripts, 'flush').mockImplementation(async () => {
       order.push('transcript');
     });
@@ -86,12 +86,12 @@ describe('SessionHandle', () => {
     });
 
     try {
-      await session.flushArtifacts();
+      await session.flushArtifacts('exec:trace');
       expect(order).toEqual(['trace', 'transcript', 'snapshot']);
 
       order.length = 0;
       detach();
-      await session.flushArtifacts();
+      await session.flushArtifacts('exec:trace');
       expect(order).toEqual(['trace', 'transcript']);
     } finally {
       session.dispose();
@@ -118,6 +118,30 @@ describe('SessionHandle', () => {
       ]);
       expect(laterWriter).toHaveBeenCalledOnce();
     } finally {
+      session.dispose();
+    }
+  });
+
+  it("keeps one execution's trace failure out of sibling durability", async () => {
+    const session = createTestSession();
+    const traceError = new Error('broken trace');
+    session.flushers.set('exec:broken', () => {
+      throw traceError;
+    });
+    session.flushers.set('exec:sibling', vi.fn());
+    const sharedFlush = vi
+      .spyOn(session.transcripts, 'flush')
+      .mockResolvedValue(undefined);
+
+    try {
+      const broken = session.flushArtifacts('exec:broken');
+      const sibling = session.flushArtifacts('exec:sibling');
+
+      await expect(broken).rejects.toBe(traceError);
+      await expect(sibling).resolves.toBeUndefined();
+      expect(sharedFlush).toHaveBeenCalledOnce();
+    } finally {
+      session.flushers.delete('exec:broken');
       session.dispose();
     }
   });
@@ -313,10 +337,10 @@ describe('SessionHandle', () => {
     const interactions = vi.spyOn(session.interactions, 'dispose');
     const subscriptions = vi.spyOn(session.subscriptions, 'dispose');
     const executions = vi.spyOn(session.executions, 'dispose');
-    session.flushers.add(() => {
+    session.flushers.set('failed', () => {
       throw failure;
     });
-    session.flushers.add(laterFlusher);
+    session.flushers.set('later', laterFlusher);
 
     expect(() => session.dispose()).toThrow(failure);
 

--- a/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
@@ -19,11 +19,16 @@ import { AgentExecutionHandle } from '@agent/runtime/ExecutionHandle';
 import { type Plan, type StreamTabId } from '@shared/schemas';
 import { createTestSession } from '@test/support/sessionTestUtils';
 import { StreamLogStore } from '@transcript';
+import type { RunTraceFlushEntry } from '@transcript/runTrace';
 
 // Local file imports
 import { createRecordingHost } from '../progressTestUtils';
 
 const plan: Plan = { objective: 'Compose the per-session runtime owners.' };
+
+function activeTraceFlusher(flush: () => void): RunTraceFlushEntry {
+  return { state: 'active', flush };
+}
 
 function trackAgent(
   session: SessionHandle,
@@ -77,7 +82,10 @@ describe('SessionHandle', () => {
   it('drains trace, transcript, and registered artifact writers together', async () => {
     const session = createTestSession();
     const order: string[] = [];
-    session.flushers.set('exec:trace', () => order.push('trace'));
+    session.flushers.set(
+      'exec:trace',
+      activeTraceFlusher(() => order.push('trace')),
+    );
     vi.spyOn(session.transcripts, 'flush').mockImplementation(async () => {
       order.push('transcript');
     });
@@ -125,10 +133,13 @@ describe('SessionHandle', () => {
   it("keeps one execution's trace failure out of sibling durability", async () => {
     const session = createTestSession();
     const traceError = new Error('broken trace');
-    session.flushers.set('exec:broken', () => {
-      throw traceError;
-    });
-    session.flushers.set('exec:sibling', vi.fn());
+    session.flushers.set(
+      'exec:broken',
+      activeTraceFlusher(() => {
+        throw traceError;
+      }),
+    );
+    session.flushers.set('exec:sibling', activeTraceFlusher(vi.fn()));
     const sharedFlush = vi
       .spyOn(session.transcripts, 'flush')
       .mockResolvedValue(undefined);
@@ -337,10 +348,13 @@ describe('SessionHandle', () => {
     const interactions = vi.spyOn(session.interactions, 'dispose');
     const subscriptions = vi.spyOn(session.subscriptions, 'dispose');
     const executions = vi.spyOn(session.executions, 'dispose');
-    session.flushers.set('failed', () => {
-      throw failure;
-    });
-    session.flushers.set('later', laterFlusher);
+    session.flushers.set(
+      'failed',
+      activeTraceFlusher(() => {
+        throw failure;
+      }),
+    );
+    session.flushers.set('later', activeTraceFlusher(laterFlusher));
 
     expect(() => session.dispose()).toThrow(failure);
 

--- a/src/test-kernel/agent/runtime/SessionScope.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionScope.vitest.ts
@@ -56,8 +56,11 @@ describe('session-scoped trace flushers (SDK Step 7d PR 3)', () => {
       store,
       sessionB.flushers,
     );
-    sessionB.flushers.set('manual', () => {
-      drained += 1;
+    sessionB.flushers.set('manual', {
+      state: 'active',
+      flush: () => {
+        drained += 1;
+      },
     });
 
     defaultSession().flushPendingTraces();

--- a/src/test-kernel/agent/runtime/SessionScope.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionScope.vitest.ts
@@ -56,7 +56,7 @@ describe('session-scoped trace flushers (SDK Step 7d PR 3)', () => {
       store,
       sessionB.flushers,
     );
-    sessionB.flushers.add(() => {
+    sessionB.flushers.set('manual', () => {
       drained += 1;
     });
 

--- a/src/test-kernel/agent/runtime/SessionScope.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionScope.vitest.ts
@@ -15,12 +15,7 @@ import { sendFollowUp } from '@agent/followUp/ToolUseFollowUp';
 import { MESSAGE_TYPES, type Plan, type StreamTabId } from '@shared/schemas';
 import { createTestSession } from '@test/support/sessionTestUtils';
 import { cleanupAllApprovals } from '@tools/approval';
-import {
-  createRunTrace,
-  flushPendingRunTraces,
-  getActiveFlushers,
-  StreamLogStore,
-} from '@transcript';
+import { createRunTrace, StreamLogStore } from '@transcript';
 
 // Local file imports
 import { createRecordingHost } from '../progressTestUtils';
@@ -32,7 +27,7 @@ describe('session-scoped trace flushers (SDK Step 7d PR 3)', () => {
     const store = StreamLogStore.ephemeral('test');
     const sessionB = createTestSession();
     try {
-      const defaultBefore = getActiveFlushers().size;
+      const defaultBefore = defaultSession().flushers.size;
       const handle = createRunTrace(
         'stream:flusher-b' as StreamTabId,
         store,
@@ -41,9 +36,8 @@ describe('session-scoped trace flushers (SDK Step 7d PR 3)', () => {
 
       expect(sessionB.flushers.size).toBe(1);
       // The default (process) set did not gain this session's stream flush.
-      expect(getActiveFlushers().size).toBe(defaultBefore);
-      // The process-wide drain still reaches the registered session set.
-      expect(() => flushPendingRunTraces()).not.toThrow();
+      expect(defaultSession().flushers.size).toBe(defaultBefore);
+      expect(() => sessionB.flushPendingTraces()).not.toThrow();
 
       handle.dispose();
       expect(sessionB.flushers.size).toBe(0);
@@ -52,13 +46,12 @@ describe('session-scoped trace flushers (SDK Step 7d PR 3)', () => {
     }
   });
 
-  it("drops the disposed session's flusher set from the process-wide drain", () => {
+  it("does not drain another session's trace flushers", () => {
     const store = StreamLogStore.ephemeral('test');
     const sessionB = createTestSession();
     let drained = 0;
 
-    // Registers sessionB.flushers in the process-wide drain registry.
-    createRunTrace(
+    const handle = createRunTrace(
       'stream:flusher-dispose' as StreamTabId,
       store,
       sessionB.flushers,
@@ -67,16 +60,13 @@ describe('session-scoped trace flushers (SDK Step 7d PR 3)', () => {
       drained += 1;
     });
 
-    flushPendingRunTraces();
-    // While live, the session's set is reached by the process-wide drain.
-    expect(drained).toBeGreaterThan(0);
-
-    sessionB.dispose();
-
-    drained = 0;
-    flushPendingRunTraces();
-    // After dispose the set is unregistered — no longer iterated forever.
+    defaultSession().flushPendingTraces();
     expect(drained).toBe(0);
+
+    sessionB.flushPendingTraces();
+    expect(drained).toBeGreaterThan(0);
+    handle.dispose();
+    sessionB.dispose();
   });
 });
 

--- a/src/test-kernel/agent/runtime/resumeQueuedToolUse.vitest.ts
+++ b/src/test-kernel/agent/runtime/resumeQueuedToolUse.vitest.ts
@@ -4,6 +4,7 @@ import '@test/support/defaultSessionTestSetup';
 // Test support imports
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { FollowUpQueueInput } from '@agent/followUp/FollowUpQueue';
+import { AgentExecutionHandle } from '@agent/runtime/ExecutionHandle';
 import { ResumeAdmissionCancelledError } from '@agent/runtime/resumeAdmission';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { resumeQueuedToolUseFromResumeData } from '@agent/runtime/resumeQueuedToolUse';
@@ -29,7 +30,11 @@ import {
   clearStreamStatusForTest,
   seedStreamStatusForTest,
 } from '@test/helpers/streamStatusTestUtils';
-import { recordSessionEvents, sessionFactPayloads } from '../progressTestUtils';
+import {
+  createRecordingHost,
+  recordSessionEvents,
+  sessionFactPayloads,
+} from '../progressTestUtils';
 
 const STREAM = 'stream:tooluse-resume' as StreamTabId;
 const runtimeHost = { emit: vi.fn() };
@@ -114,6 +119,53 @@ describe('resumeQueuedToolUseFromResumeData', () => {
         'updateQueuedFollowUps',
       ),
     ).toContainEqual({ streamId: STREAM });
+  });
+
+  it('does not resume after waiting termination is claimed', async () => {
+    const session = createTestSession();
+    const executionId = 'exec-waiting-termination-claimed' as ExecutionId;
+    const resume = createToolUseResumeData({ executionId, streamId: STREAM });
+    let finishCleanup = (): void => undefined;
+    const cleanupGate = new Promise<void>((resolve) => {
+      finishCleanup = resolve;
+    });
+    const handle = new AgentExecutionHandle(
+      executionId,
+      'parent-waiting-termination-claimed' as StreamTabId,
+      STREAM,
+      'test-agent',
+      'toolUse',
+      createRecordingHost().host,
+    );
+
+    try {
+      session.executions.track(handle);
+      handle.registerWaitingCleanup(async () => cleanupGate);
+      seedStreamStatusForTest(session.status, STREAM, STREAM_STATUS.WAITING);
+      session.followUps.enqueue(
+        STREAM,
+        { text: 'do not resume' },
+        { force: true },
+      );
+
+      expect(session.executions.kill(executionId)).toBe(true);
+      expect(handle.waitingTerminationStarted).toBe(true);
+      await expect(
+        resumeQueuedToolUseFromResumeData(STREAM, resume, runtimeHost, {
+          session,
+          onError: vi.fn(),
+        }),
+      ).resolves.toBe(false);
+
+      expect(resumeToolUseFromResumeDataMock).not.toHaveBeenCalled();
+      expect(session.followUps.getAll(STREAM)).toEqual(['do not resume']);
+      expect(session.status.get(STREAM)).toBe(STREAM_PHASE.WAITING);
+    } finally {
+      handle.markExecutionLeaseLost();
+      finishCleanup();
+      await handle.result;
+      session.dispose();
+    }
   });
 
   it('seeds an explicit follow-up ahead of the queued items', async () => {

--- a/src/test-kernel/agent/storage/ExecutionLease.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionLease.vitest.ts
@@ -21,6 +21,7 @@ import {
   onOwnedExecutionLeaseLost,
   ownsExecutionLease,
   releaseOwnedExecutionLease,
+  renewOwnedExecutionLease,
   runWithInactiveExecutionLease,
   waitForOwnedExecutionLeaseRelease,
 } from '@agent/storage/executionLease';
@@ -297,6 +298,19 @@ describe('cross-process execution leases', () => {
       releaseHeartbeat();
       vi.useRealTimers();
     }
+  });
+
+  it('retains recent ownership through a transient heartbeat failure', async () => {
+    const executionId = 'e86442' as ExecutionId;
+    await acquire(executionId);
+    vi.spyOn(platform().fileLocks, 'runExclusive').mockRejectedValueOnce(
+      new Error('temporary filesystem failure'),
+    );
+
+    await expect(
+      renewOwnedExecutionLease(executionId),
+    ).resolves.toBeUndefined();
+    expect(ownsExecutionLease(executionId)).toBe(true);
   });
 
   it('serializes deletion with a racing lease acquisition', async () => {

--- a/src/test-kernel/agent/storage/ExecutionLease.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionLease.vitest.ts
@@ -313,6 +313,38 @@ describe('cross-process execution leases', () => {
     expect(ownsExecutionLease(executionId)).toBe(true);
   });
 
+  it('rejects renewal when release starts during its heartbeat', async () => {
+    const executionId = 'e86443' as ExecutionId;
+    await acquire(executionId);
+    const originalRunExclusive = platform().fileLocks.runExclusive.bind(
+      platform().fileLocks,
+    );
+    let markHeartbeatStarted = (): void => undefined;
+    const heartbeatStarted = new Promise<void>((resolve) => {
+      markHeartbeatStarted = resolve;
+    });
+    let releaseHeartbeat = (): void => undefined;
+    const heartbeatGate = new Promise<void>((resolve) => {
+      releaseHeartbeat = resolve;
+    });
+    vi.spyOn(platform().fileLocks, 'runExclusive').mockImplementationOnce(
+      async (lockPath, operation) => {
+        markHeartbeatStarted();
+        await heartbeatGate;
+        return originalRunExclusive(lockPath, operation);
+      },
+    );
+
+    const renewal = renewOwnedExecutionLease(executionId);
+    await heartbeatStarted;
+    const release = releaseOwnedExecutionLease(executionId);
+    releaseHeartbeat();
+
+    await expect(renewal).rejects.toBeInstanceOf(ExecutionLeaseLostError);
+    await release;
+    ownedExecutionIds.delete(executionId);
+  });
+
   it('serializes deletion with a racing lease acquisition', async () => {
     const executionId = 'f8644f' as ExecutionId;
     let allowDeletion: (() => void) | undefined;

--- a/src/test-kernel/agent/storage/ExecutionLease.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionLease.vitest.ts
@@ -268,6 +268,37 @@ describe('cross-process execution leases', () => {
     ownedExecutionIds.delete(executionId);
   });
 
+  it('never overlaps heartbeat work for the same execution', async () => {
+    const executionId = 'e86441' as ExecutionId;
+    vi.useFakeTimers();
+    let releaseHeartbeat = (): void => undefined;
+    try {
+      await acquire(executionId);
+      const originalRunExclusive = platform().fileLocks.runExclusive.bind(
+        platform().fileLocks,
+      );
+      const heartbeatGate = new Promise<void>((resolve) => {
+        releaseHeartbeat = resolve;
+      });
+      const runExclusive = vi
+        .spyOn(platform().fileLocks, 'runExclusive')
+        .mockImplementation(async (lockPath, operation) => {
+          await heartbeatGate;
+          return originalRunExclusive(lockPath, operation);
+        });
+
+      await vi.advanceTimersByTimeAsync(15_000);
+      for (let index = 0; index < 5; index += 1) await Promise.resolve();
+      expect(runExclusive).toHaveBeenCalledOnce();
+
+      await vi.advanceTimersByTimeAsync(45_000);
+      expect(runExclusive).toHaveBeenCalledOnce();
+    } finally {
+      releaseHeartbeat();
+      vi.useRealTimers();
+    }
+  });
+
   it('serializes deletion with a racing lease acquisition', async () => {
     const executionId = 'f8644f' as ExecutionId;
     let allowDeletion: (() => void) | undefined;

--- a/src/test-kernel/agent/trace/RunTraceStream.vitest.ts
+++ b/src/test-kernel/agent/trace/RunTraceStream.vitest.ts
@@ -7,18 +7,22 @@ import {
   type AgentTrace,
 } from '@agent/trace';
 import { MESSAGE_TYPES } from '@shared/schemas';
-import {
-  createRunTrace,
-  flushPendingRunTraces,
-  StreamLogStore,
-} from '@transcript';
+import { createRunTrace, StreamLogStore } from '@transcript';
 
 /** Run against a fresh, test-local store. */
 function withStore(
-  run: (store: StreamLogStore, logger: AgentTrace) => void,
+  run: (
+    store: StreamLogStore,
+    logger: AgentTrace,
+    flushPending: () => void,
+  ) => void,
 ): void {
   const store = StreamLogStore.ephemeral('test');
-  run(store, createRunTrace('stream', store).trace);
+  const flushers = new Set<() => void>();
+  const handle = createRunTrace('stream', store, flushers);
+  run(store, handle.trace, () => {
+    for (const flush of flushers) flush();
+  });
 }
 
 describe('AgentTrace stream output', () => {
@@ -29,7 +33,7 @@ describe('AgentTrace stream output', () => {
   it('coalesces streaming text updates and flushes on finalize', () => {
     vi.useFakeTimers();
 
-    withStore((store, logger) => {
+    withStore((store, logger, flushPending) => {
       const stream = logger.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
 
       stream.append('a');
@@ -64,14 +68,14 @@ describe('AgentTrace stream output', () => {
   it('drains pending stream updates for shutdown persistence', () => {
     vi.useFakeTimers();
 
-    withStore((store, logger) => {
+    withStore((store, logger, flushPending) => {
       const stream = logger.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
 
       stream.append('a');
       stream.append('b');
       expect((store.get('stream')?.getRange(0) ?? [])[0]?.text).toBe('a');
 
-      flushPendingRunTraces();
+      flushPending();
       expect((store.get('stream')?.getRange(0) ?? [])[0]?.text).toBe('ab');
       expect(vi.getTimerCount()).toBe(0);
 
@@ -100,7 +104,7 @@ describe('AgentTrace stream output', () => {
   });
 
   it('emits nothing for a deferred stream until the first chunk', () => {
-    withStore((store, logger) => {
+    withStore((store, logger, flushPending) => {
       const thinking = logger.openStream(MESSAGE_TYPES.THINKING, {
         deferStart: true,
       });
@@ -108,7 +112,7 @@ describe('AgentTrace stream output', () => {
       expect(store.get('stream')).toBeUndefined();
 
       thinking.append('reasoning delta');
-      flushPendingRunTraces();
+      flushPending();
 
       const entries = store.get('stream')?.getRange(0) ?? [];
       expect(entries).toHaveLength(1);

--- a/src/test-kernel/agent/trace/RunTraceStream.vitest.ts
+++ b/src/test-kernel/agent/trace/RunTraceStream.vitest.ts
@@ -8,6 +8,7 @@ import {
 } from '@agent/trace';
 import { MESSAGE_TYPES } from '@shared/schemas';
 import { createRunTrace, StreamLogStore } from '@transcript';
+import type { RunTraceFlushEntry } from '@transcript/runTrace';
 
 /** Run against a fresh, test-local store. */
 function withStore(
@@ -18,10 +19,10 @@ function withStore(
   ) => void,
 ): void {
   const store = StreamLogStore.ephemeral('test');
-  const flushers = new Map<string, () => void>();
+  const flushers = new Map<string, RunTraceFlushEntry>();
   const handle = createRunTrace('stream', store, flushers);
   run(store, handle.trace, () => {
-    for (const flush of flushers.values()) flush();
+    for (const entry of flushers.values()) entry.flush();
   });
 }
 

--- a/src/test-kernel/agent/trace/RunTraceStream.vitest.ts
+++ b/src/test-kernel/agent/trace/RunTraceStream.vitest.ts
@@ -18,10 +18,10 @@ function withStore(
   ) => void,
 ): void {
   const store = StreamLogStore.ephemeral('test');
-  const flushers = new Set<() => void>();
+  const flushers = new Map<string, () => void>();
   const handle = createRunTrace('stream', store, flushers);
   run(store, handle.trace, () => {
-    for (const flush of flushers) flush();
+    for (const flush of flushers.values()) flush();
   });
 }
 

--- a/src/test-kernel/cli/SubscribeStreamLogDispose.vitest.mts
+++ b/src/test-kernel/cli/SubscribeStreamLogDispose.vitest.mts
@@ -118,12 +118,12 @@ describe('subscribeStreamLog batching and dispose', () => {
     secondDispose();
   });
 
-  it('releases a dormant transcript whose focus load finishes late', async () => {
+  it('releases a completed transcript whose focus load finishes late', async () => {
     const store = defaultSession().transcripts;
     appendUserMessage(store, streamA, 'a-1', 'loaded late');
     patchStream(streamA, (slice) => ({
       ...slice,
-      status: STREAM_PHASE.WAITING,
+      status: STREAM_PHASE.COMPLETED,
     }));
 
     let finishLoad = (): void => {};
@@ -141,7 +141,7 @@ describe('subscribeStreamLog batching and dispose', () => {
     vi.spyOn(store, 'ensureLoaded').mockImplementation(async (streamId) => {
       if (streamId === streamA) await loadGate;
     });
-    const releaseEntries = vi.spyOn(store, 'releaseEntries');
+    const requestEviction = vi.spyOn(store, 'requestEviction');
     const dispose = subscribeStreamLog();
 
     activeStreamId.set(streamA);
@@ -156,7 +156,7 @@ describe('subscribeStreamLog batching and dispose', () => {
       description: 'loaded late',
       entries: [],
     });
-    expect(releaseEntries).toHaveBeenCalledWith(streamA);
+    expect(requestEviction).toHaveBeenCalledWith(streamA);
 
     dispose();
   });
@@ -165,7 +165,7 @@ describe('subscribeStreamLog batching and dispose', () => {
     const store = defaultSession().transcripts;
     appendUserMessage(store, streamB, 'b-1', 'starting');
     activeStreamId.set(streamA);
-    const releaseEntries = vi.spyOn(store, 'releaseEntries');
+    const requestEviction = vi.spyOn(store, 'requestEviction');
 
     syncStreamLog(streamB);
 
@@ -174,6 +174,21 @@ describe('subscribeStreamLog batching and dispose', () => {
       entries: [],
       status: undefined,
     });
-    expect(releaseEntries).not.toHaveBeenCalledWith(streamB);
+    expect(requestEviction).not.toHaveBeenCalledWith(streamB);
+  });
+
+  it('requests bounded residency for a hidden WAITING transcript', () => {
+    const store = defaultSession().transcripts;
+    appendUserMessage(store, streamB, 'b-1', 'waiting for retry');
+    patchStream(streamB, (slice) => ({
+      ...slice,
+      status: STREAM_PHASE.WAITING,
+    }));
+    activeStreamId.set(streamA);
+    const requestEviction = vi.spyOn(store, 'requestEviction');
+
+    syncStreamLog(streamB);
+
+    expect(requestEviction).toHaveBeenCalledWith(streamB);
   });
 });

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -111,7 +111,7 @@ type TestableBridge = Bridge & {
         text: string;
       },
     ): unknown;
-    releaseEntries(streamId: StreamTabId): void;
+    requestEviction(streamId: StreamTabId): void;
     reload(): Promise<void>;
     ensureLoaded(streamId: StreamTabId): Promise<void>;
     getUnfinishedStreamIds(): StreamTabId[];
@@ -2715,7 +2715,7 @@ describe('DesktopProgressBridge', () => {
     await (
       bridge as unknown as { session: SessionHandle }
     ).session.flushArtifacts();
-    bridge.streamLogs.releaseEntries(streamId);
+    bridge.streamLogs.requestEviction(streamId);
     await bridge.streamLogs.reload();
     await bridge.streamLogs.ensureLoaded(streamId);
 

--- a/src/test-kernel/logger/RunTraceDispose.vitest.ts
+++ b/src/test-kernel/logger/RunTraceDispose.vitest.ts
@@ -16,13 +16,13 @@ describe('createRunTrace dispose', () => {
 
   it('removes the flusher from its owning session set on dispose', () => {
     vi.useFakeTimers();
-    const flushers = new Set<() => void>();
+    const flushers = new Map<string, () => void>();
     const handle = createRunTrace('disposed-stream', store, flushers);
     const stream = handle.trace.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
 
     stream.append('a');
     // Chunk is throttled (49ms window), but the owning session set reaches it.
-    for (const flush of flushers) flush();
+    for (const flush of flushers.values()) flush();
     expect(store.get('disposed-stream')?.getRange(0)[0]?.text).toBe('a');
 
     handle.dispose();
@@ -33,7 +33,7 @@ describe('createRunTrace dispose', () => {
     // it through. The chunk would still flush via its own per-stream timer,
     // so we verify by sampling before the timer fires.
     stream.append('b');
-    for (const flush of flushers) flush();
+    for (const flush of flushers.values()) flush();
     // Only the 'a' chunk should be visible — the 'b' chunk hasn't been
     // pushed because the flusher was unregistered and the throttled timer
     // hasn't fired.

--- a/src/test-kernel/logger/RunTraceDispose.vitest.ts
+++ b/src/test-kernel/logger/RunTraceDispose.vitest.ts
@@ -1,11 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MESSAGE_TYPES } from '@shared/schemas';
-import {
-  createRunTrace,
-  flushPendingRunTraces,
-  StreamLogStore,
-} from '@transcript';
+import { createRunTrace, StreamLogStore } from '@transcript';
 
 describe('createRunTrace dispose', () => {
   let store: StreamLogStore;
@@ -18,26 +14,26 @@ describe('createRunTrace dispose', () => {
     vi.useRealTimers();
   });
 
-  it('removes the flusher from the global registry on dispose', () => {
+  it('removes the flusher from its owning session set on dispose', () => {
     vi.useFakeTimers();
-    const handle = createRunTrace('disposed-stream', store);
+    const flushers = new Set<() => void>();
+    const handle = createRunTrace('disposed-stream', store, flushers);
     const stream = handle.trace.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
 
     stream.append('a');
-    // Chunk is throttled (49ms window) — `flushPendingRunTraces` reaches it
-    // through the module-global `activeFlushers` set.
-    flushPendingRunTraces();
+    // Chunk is throttled (49ms window), but the owning session set reaches it.
+    for (const flush of flushers) flush();
     expect(store.get('disposed-stream')?.getRange(0)[0]?.text).toBe('a');
 
     handle.dispose();
 
     // After dispose: more chunks should not reach the store via the global
     // flusher (because the flusher was removed from `activeFlushers`).
-    // Append another chunk and confirm `flushPendingRunTraces` doesn't push
+    // Append another chunk and confirm the owning set no longer pushes
     // it through. The chunk would still flush via its own per-stream timer,
     // so we verify by sampling before the timer fires.
     stream.append('b');
-    flushPendingRunTraces();
+    for (const flush of flushers) flush();
     // Only the 'a' chunk should be visible — the 'b' chunk hasn't been
     // pushed because the flusher was unregistered and the throttled timer
     // hasn't fired.

--- a/src/test-kernel/logger/RunTraceDispose.vitest.ts
+++ b/src/test-kernel/logger/RunTraceDispose.vitest.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { MESSAGE_TYPES } from '@shared/schemas';
+import { MESSAGE_TYPES, type StreamTabId } from '@shared/schemas';
 import { createRunTrace, StreamLogStore } from '@transcript';
+import type { TranscriptWriter } from '@transcript/StreamLogStore';
 
 describe('createRunTrace dispose', () => {
   let store: StreamLogStore;
@@ -45,5 +46,62 @@ describe('createRunTrace dispose', () => {
     handle.dispose();
     // Calling dispose again should not throw and should be a no-op.
     expect(() => handle.dispose()).not.toThrow();
+  });
+
+  it('hands a latched cleanup failure to the execution durability flusher', () => {
+    vi.useFakeTimers();
+    const failure = new Error('delayed transcript write failed');
+    const writer: TranscriptWriter = {
+      streamId: 'failed-stream' as StreamTabId,
+      append: vi.fn((entry) => ({ ...entry, seqNo: 0 })),
+      update: vi.fn(),
+      appendText: vi.fn(() => {
+        throw failure;
+      }),
+      close: vi.fn(),
+    };
+    const flushers = new Map<string, () => void>();
+    const handle = createRunTrace(
+      writer.streamId,
+      store,
+      flushers,
+      'execution-failed',
+      writer,
+    );
+    const stream = handle.trace.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
+    stream.append('first');
+    stream.append('second');
+    vi.advanceTimersByTime(50);
+
+    expect(() => handle.dispose()).not.toThrow();
+    expect(flushers.has('execution-failed')).toBe(true);
+    expect(() => flushers.get('execution-failed')?.()).toThrow(failure);
+    expect(flushers.has('execution-failed')).toBe(false);
+    expect(writer.close).toHaveBeenCalledOnce();
+  });
+
+  it('closes a reserved writer when subscriber setup fails', () => {
+    const setupFailure = new Error('writer identity unavailable');
+    const close = vi.fn();
+    const writer = {
+      get streamId(): StreamTabId {
+        throw setupFailure;
+      },
+      append: vi.fn(),
+      update: vi.fn(),
+      appendText: vi.fn(),
+      close,
+    } satisfies TranscriptWriter;
+
+    expect(() =>
+      createRunTrace(
+        'setup-failed' as StreamTabId,
+        store,
+        new Map(),
+        'execution-setup-failed',
+        writer,
+      ),
+    ).toThrow(setupFailure);
+    expect(close).toHaveBeenCalledOnce();
   });
 });

--- a/src/test-kernel/logger/RunTraceDispose.vitest.ts
+++ b/src/test-kernel/logger/RunTraceDispose.vitest.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MESSAGE_TYPES, type StreamTabId } from '@shared/schemas';
 import { createRunTrace, StreamLogStore } from '@transcript';
+import type { RunTraceFlushEntry } from '@transcript/runTrace';
 import type { TranscriptWriter } from '@transcript/StreamLogStore';
 
 describe('createRunTrace dispose', () => {
@@ -17,13 +18,13 @@ describe('createRunTrace dispose', () => {
 
   it('removes the flusher from its owning session set on dispose', () => {
     vi.useFakeTimers();
-    const flushers = new Map<string, () => void>();
+    const flushers = new Map<string, RunTraceFlushEntry>();
     const handle = createRunTrace('disposed-stream', store, flushers);
     const stream = handle.trace.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
 
     stream.append('a');
     // Chunk is throttled (49ms window), but the owning session set reaches it.
-    for (const flush of flushers.values()) flush();
+    for (const entry of flushers.values()) entry.flush();
     expect(store.get('disposed-stream')?.getRange(0)[0]?.text).toBe('a');
 
     handle.dispose();
@@ -34,7 +35,7 @@ describe('createRunTrace dispose', () => {
     // it through. The chunk would still flush via its own per-stream timer,
     // so we verify by sampling before the timer fires.
     stream.append('b');
-    for (const flush of flushers.values()) flush();
+    for (const entry of flushers.values()) entry.flush();
     // Only the 'a' chunk should be visible — the 'b' chunk hasn't been
     // pushed because the flusher was unregistered and the throttled timer
     // hasn't fired.
@@ -48,7 +49,7 @@ describe('createRunTrace dispose', () => {
     expect(() => handle.dispose()).not.toThrow();
   });
 
-  it('hands a latched cleanup failure to the execution durability flusher', () => {
+  it('carries a latched cleanup failure through a successor trace', () => {
     vi.useFakeTimers();
     const failure = new Error('delayed transcript write failed');
     const writer: TranscriptWriter = {
@@ -60,7 +61,7 @@ describe('createRunTrace dispose', () => {
       }),
       close: vi.fn(),
     };
-    const flushers = new Map<string, () => void>();
+    const flushers = new Map<string, RunTraceFlushEntry>();
     const handle = createRunTrace(
       writer.streamId,
       store,
@@ -75,7 +76,16 @@ describe('createRunTrace dispose', () => {
 
     expect(() => handle.dispose()).not.toThrow();
     expect(flushers.has('execution-failed')).toBe(true);
-    expect(() => flushers.get('execution-failed')?.()).toThrow(failure);
+
+    const successor = createRunTrace(
+      writer.streamId,
+      store,
+      flushers,
+      'execution-failed',
+    );
+    expect(flushers.get('execution-failed')?.state).toBe('active');
+    expect(() => flushers.get('execution-failed')?.flush()).toThrow(failure);
+    expect(() => successor.dispose()).not.toThrow();
     expect(flushers.has('execution-failed')).toBe(false);
     expect(writer.close).toHaveBeenCalledOnce();
   });

--- a/src/test-kernel/platform/FileLockCompromise.vitest.mts
+++ b/src/test-kernel/platform/FileLockCompromise.vitest.mts
@@ -1,0 +1,45 @@
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  lock: vi.fn(),
+}));
+
+vi.mock('proper-lockfile', () => ({ lock: mocks.lock }));
+
+import { nodeFileLocks } from '@platform/defaults/fileLocks';
+
+describe('nodeFileLocks compromise boundary', () => {
+  it('rejects through runExclusive instead of throwing from the renewal callback', async () => {
+    const compromised = Object.assign(new Error('lock directory disappeared'), {
+      code: 'ECOMPROMISED',
+    });
+    const alreadyReleased = Object.assign(new Error('lock already released'), {
+      code: 'ERELEASED',
+    });
+    mocks.lock.mockImplementationOnce(
+      async (
+        _path: string,
+        _options: { onCompromised: (error: Error) => void },
+      ) => {
+        return async () => {
+          throw alreadyReleased;
+        };
+      },
+    );
+
+    const result = nodeFileLocks.runExclusive(
+      join(tmpdir(), 'texra-file-lock-compromise'),
+      async () => {
+        const options = mocks.lock.mock.calls[0]?.[1] as {
+          onCompromised: (error: Error) => void;
+        };
+        expect(() => options.onCompromised(compromised)).not.toThrow();
+      },
+    );
+
+    await expect(result).rejects.toBe(compromised);
+  });
+});

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -499,7 +499,10 @@ describe('ProgressBackend', () => {
     const active = 'active-workflow' as StreamTabId;
     const hidden = 'hidden-tool-use' as StreamTabId;
     const visible = 'visible-workflow' as StreamTabId;
-    const releaseEntries = vi.spyOn(backend.state.streamLogs, 'releaseEntries');
+    const requestEviction = vi.spyOn(
+      backend.state.streamLogs,
+      'requestEviction',
+    );
 
     try {
       // The unfiltered durable fallback selects the last stream (`hidden`),
@@ -523,7 +526,7 @@ describe('ProgressBackend', () => {
 
       expect(backend.state.activeStream).toBe(visible);
       expect(lifecycle.activateStream).toHaveBeenCalledWith(visible);
-      expect(releaseEntries).toHaveBeenCalledWith(hidden);
+      expect(requestEviction).toHaveBeenCalledWith(hidden);
     } finally {
       backend.dispose();
       session.dispose();
@@ -1967,7 +1970,7 @@ describe('ProgressBackend', () => {
   it('keeps resident background entries during an in-flight status update', async () => {
     const { backend } = createRecordingBackend();
     const stream = 'background-stream' as StreamTabId;
-    const releaseSpy = vi.spyOn(backend.state.streamLogs, 'releaseEntries');
+    const releaseSpy = vi.spyOn(backend.state.streamLogs, 'requestEviction');
 
     try {
       backend.state.streamLogs.ensureStream(stream);

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -381,6 +381,47 @@ describe('StreamLogStore load', () => {
     );
   });
 
+  it('reserves a writer across rehydration and a concurrent eviction', async () => {
+    let markReadStarted = (): void => undefined;
+    const readStarted = new Promise<void>((resolve) => {
+      markReadStarted = resolve;
+    });
+    let releaseRead = (): void => undefined;
+    const readGate = new Promise<void>((resolve) => {
+      releaseRead = resolve;
+    });
+    mockStorage({
+      logs: { alpha: [logEntry('alpha', 1, 100)] },
+      summaries: {
+        alpha: {
+          firstTimestamp: 100,
+          lastTimestamp: 100,
+          hasRunningGroup: false,
+        },
+      },
+      onLogRead: async () => {
+        markReadStarted();
+        await readGate;
+      },
+    });
+    const store = await StreamLogStore.open();
+    const writerPromise = store.loadAndAcquireWriter(
+      'alpha',
+      'execution-alpha',
+    );
+    await readStarted;
+
+    store.requestEviction('alpha');
+    releaseRead();
+    const writer = await writerPromise;
+
+    expect(store.get('alpha')?.size).toBe(1);
+    expect(() => writer.append(logEntry('alpha-live', 2, 200))).not.toThrow();
+    writer.close();
+    await store.flush();
+    expect(store.get('alpha')).toBeUndefined();
+  });
+
   it('keeps a requested eviction resident until its sequential write finishes', async () => {
     const storage = mockStorage({
       logs: {},

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -347,7 +347,7 @@ describe('StreamLogStore load', () => {
 
     store.ensureStream('empty-ephemeral');
     store.append('ephemeral-stream', logEntry('ephemeral-stream', 1, 100));
-    store.releaseEntries('ephemeral-stream');
+    store.requestEviction('ephemeral-stream');
     await store.flush();
 
     expect(store.mode).toEqual({
@@ -358,6 +358,43 @@ describe('StreamLogStore load', () => {
     expect(store.get('empty-ephemeral')?.size).toBe(0);
     expect(store.get('ephemeral-stream')?.size).toBe(1);
     expect(() => StreamLogStore.ephemeral('  ')).toThrow('requires a reason');
+  });
+
+  it('defers a requested eviction until the exact writer releases', async () => {
+    mockStorage({
+      logs: { alpha: [logEntry('alpha', 1, 100)] },
+      summaries: {},
+    });
+    const store = await StreamLogStore.open();
+    await store.ensureLoaded('alpha');
+    const writer = store.acquireWriter('alpha', 'execution-alpha');
+
+    store.requestEviction('alpha');
+    writer.append(logEntry('alpha-live', 2, 200));
+    await store.flush();
+
+    expect(store.get('alpha')?.size).toBe(2);
+    writer.close();
+    expect(store.get('alpha')).toBeUndefined();
+    expect(() => writer.append(logEntry('late', 3, 300))).toThrow(
+      'has been released',
+    );
+  });
+
+  it('keeps a same-owner successor valid after an older writer closes', () => {
+    const store = StreamLogStore.ephemeral('writer identity test');
+    const first = store.acquireWriter('alpha', 'execution-alpha');
+    const successor = store.acquireWriter('alpha', 'execution-alpha');
+
+    expect(() => store.acquireWriter('alpha', 'execution-beta')).toThrow(
+      'already owned by another writer',
+    );
+    first.close();
+    expect(() => first.append(logEntry('late', 1, 100))).toThrow(
+      'has been released',
+    );
+    expect(() => successor.append(logEntry('successor', 2, 200))).not.toThrow();
+    successor.close();
   });
 
   it('rejects when persistent storage cannot be opened', async () => {

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -469,6 +469,25 @@ describe('StreamLogStore load', () => {
     successor.close();
   });
 
+  it('preserves queued eviction across a same-owner successor', async () => {
+    mockStorage({
+      logs: { alpha: [logEntry('alpha', 1, 100)] },
+      summaries: {},
+    });
+    const store = await StreamLogStore.open();
+    await store.ensureLoaded('alpha');
+    const first = store.acquireWriter('alpha', 'execution-alpha');
+
+    store.requestEviction('alpha');
+    const successor = store.acquireWriter('alpha', 'execution-alpha');
+    first.close();
+    successor.append(logEntry('alpha-live', 2, 200));
+    await store.flush();
+    successor.close();
+
+    expect(store.get('alpha')).toBeUndefined();
+  });
+
   it('rejects when persistent storage cannot be opened', async () => {
     vi.spyOn(StorageFS, 'ensureDir').mockRejectedValue(
       new Error('storage permission denied'),

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -381,6 +381,37 @@ describe('StreamLogStore load', () => {
     );
   });
 
+  it('keeps a requested eviction resident until its sequential write finishes', async () => {
+    const storage = mockStorage({
+      logs: {},
+      summaries: {},
+      pauseLogWriteKey: 'alpha',
+    });
+    const store = await StreamLogStore.open();
+    const alphaWriter = store.acquireWriter('alpha', 'execution-alpha');
+    const betaWriter = store.acquireWriter('beta', 'execution-beta');
+    alphaWriter.append(logEntry('alpha', 1, 100));
+    betaWriter.append(logEntry('beta', 1, 200));
+
+    const flush = store.flush();
+    await storage.waitForPausedWrite();
+    store.requestEviction('beta');
+    betaWriter.close();
+
+    // Both dirty bits were moved into the active write batch. The explicit
+    // flushing guard must keep beta resident while the sequential writer is
+    // still blocked on alpha.
+    expect(store.get('beta')?.size).toBe(1);
+
+    storage.releasePausedWrite();
+    await flush;
+    expect(
+      storage.writes.get(storageFile(STREAM_LOGS_DIR, 'beta')),
+    ).toHaveLength(1);
+    expect(store.get('beta')).toBeUndefined();
+    alphaWriter.close();
+  });
+
   it('keeps a same-owner successor valid after an older writer closes', () => {
     const store = StreamLogStore.ephemeral('writer identity test');
     const first = store.acquireWriter('alpha', 'execution-alpha');

--- a/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
+++ b/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { TraceEmitter } from '@agent/trace';
 import {
@@ -18,7 +18,7 @@ describe('attachTranscriptRecorder StreamPhase-native group rows (#7993 step 2)'
     const store = StreamLogStore.ephemeral('test');
     const streamId = 'stream:group-start-native' as StreamTabId;
     store.ensureStream(streamId);
-    attachTranscriptRecorder(trace, streamId, store);
+    attachTranscriptRecorder(trace, store.acquireWriter(streamId, streamId));
 
     const stage = trace.openStage('r0', { kind: 'round' });
 
@@ -36,7 +36,7 @@ describe('attachTranscriptRecorder StreamPhase-native group rows (#7993 step 2)'
     const store = StreamLogStore.ephemeral('test');
     const streamId = 'stream:group-end-default-outcome' as StreamTabId;
     store.ensureStream(streamId);
-    attachTranscriptRecorder(trace, streamId, store);
+    attachTranscriptRecorder(trace, store.acquireWriter(streamId, streamId));
 
     const stage = trace.openStage('r0', { kind: 'round' });
     stage.end();
@@ -55,7 +55,7 @@ describe('attachTranscriptRecorder StreamPhase-native group rows (#7993 step 2)'
     const store = StreamLogStore.ephemeral('test');
     const streamId = 'stream:group-end-explicit-outcome' as StreamTabId;
     store.ensureStream(streamId);
-    attachTranscriptRecorder(trace, streamId, store);
+    attachTranscriptRecorder(trace, store.acquireWriter(streamId, streamId));
 
     const stage = trace.openStage('r0', { kind: 'round' });
     stage.end(RUN_OUTCOME.CANCELLED);
@@ -73,7 +73,7 @@ describe('attachTranscriptRecorder StreamPhase-native group rows (#7993 step 2)'
     const store = StreamLogStore.ephemeral('test');
     const streamId = 'stream:group-end-run-failure' as StreamTabId;
     store.ensureStream(streamId);
-    attachTranscriptRecorder(trace, streamId, store);
+    attachTranscriptRecorder(trace, store.acquireWriter(streamId, streamId));
 
     const stage = trace.openStage('r0', { kind: 'round' });
     await expect(
@@ -97,7 +97,7 @@ describe('attachTranscriptRecorder stage kind (issue #7267)', () => {
     const store = StreamLogStore.ephemeral('test');
     const streamId = 'stream:kind-preserved' as StreamTabId;
     store.ensureStream(streamId);
-    attachTranscriptRecorder(trace, streamId, store);
+    attachTranscriptRecorder(trace, store.acquireWriter(streamId, streamId));
 
     const round = trace.openStage('r0', { kind: 'round', index: 0 });
     round.end();
@@ -114,7 +114,7 @@ describe('attachTranscriptRecorder stage kind (issue #7267)', () => {
     const store = StreamLogStore.ephemeral('test');
     const streamId = 'stream:run-kind-preserved' as StreamTabId;
     store.ensureStream(streamId);
-    attachTranscriptRecorder(trace, streamId, store);
+    attachTranscriptRecorder(trace, store.acquireWriter(streamId, streamId));
 
     const runStage = trace.openStage('Run: agent', { kind: 'run' });
     runStage.end();
@@ -133,7 +133,7 @@ describe('attachTranscriptRecorder response.finalized (issue #7086)', () => {
     const store = StreamLogStore.ephemeral('test');
     const streamId = 'stream:upsert' as StreamTabId;
     store.ensureStream(streamId);
-    attachTranscriptRecorder(trace, streamId, store);
+    attachTranscriptRecorder(trace, store.acquireWriter(streamId, streamId));
 
     // The round's own stream writes raw provider text in real time...
     const output = trace.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
@@ -157,7 +157,7 @@ describe('attachTranscriptRecorder response.finalized (issue #7086)', () => {
     const store = StreamLogStore.ephemeral('test');
     const streamId = 'stream:append' as StreamTabId;
     store.ensureStream(streamId);
-    attachTranscriptRecorder(trace, streamId, store);
+    attachTranscriptRecorder(trace, store.acquireWriter(streamId, streamId));
 
     trace.responseFinalized('The answer is 2.');
 
@@ -174,7 +174,7 @@ describe('attachTranscriptRecorder response.finalized (issue #7086)', () => {
     const store = StreamLogStore.ephemeral('test');
     const streamId = 'stream:round-reset' as StreamTabId;
     store.ensureStream(streamId);
-    attachTranscriptRecorder(trace, streamId, store);
+    attachTranscriptRecorder(trace, store.acquireWriter(streamId, streamId));
 
     const round0 = trace.openStage('r0', { kind: 'round', index: 0 });
     const output = trace.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
@@ -206,7 +206,7 @@ describe('attachTranscriptRecorder response.finalized (issue #7086)', () => {
     const store = StreamLogStore.ephemeral('test');
     const streamId = 'stream:inner-round-reset' as StreamTabId;
     store.ensureStream(streamId);
-    attachTranscriptRecorder(trace, streamId, store);
+    attachTranscriptRecorder(trace, store.acquireWriter(streamId, streamId));
 
     const round = trace.openStage('r0', { kind: 'round', index: 0 });
     round.run(() => {
@@ -241,11 +241,42 @@ describe('attachTranscriptRecorder response.finalized (issue #7086)', () => {
     const store = StreamLogStore.ephemeral('test');
     const streamId = 'stream:empty' as StreamTabId;
     store.ensureStream(streamId);
-    attachTranscriptRecorder(trace, streamId, store);
+    attachTranscriptRecorder(trace, store.acquireWriter(streamId, streamId));
 
     trace.responseFinalized('');
 
     const entries = store.get(streamId)?.getRange(0) ?? [];
     expect(entries).toHaveLength(0);
+  });
+});
+
+describe('attachTranscriptRecorder timer failure boundary', () => {
+  it('latches a delayed write failure instead of throwing from the timer', () => {
+    vi.useFakeTimers();
+    const trace = new TraceEmitter();
+    const store = StreamLogStore.ephemeral('test');
+    const streamId = 'stream:timer-failure' as StreamTabId;
+    const writer = store.acquireWriter(streamId, streamId);
+    const appendText = writer.appendText.bind(writer);
+    const failure = new Error('delayed transcript write failed');
+    vi.spyOn(writer, 'appendText')
+      .mockImplementationOnce(appendText)
+      .mockImplementationOnce(() => {
+        throw failure;
+      });
+    const recorder = attachTranscriptRecorder(trace, writer);
+
+    try {
+      const output = trace.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
+      output.append('first');
+      output.append(' delayed');
+
+      expect(() => vi.advanceTimersByTime(50)).not.toThrow();
+      expect(() => recorder.flushPending()).toThrow(failure);
+      expect(() => recorder.unsubscribe()).toThrow(failure);
+    } finally {
+      writer.close();
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -94,6 +94,7 @@ export function createChildStream(
     childStreamId,
     session.transcripts,
     session.flushers,
+    executionId,
   );
   const detachSessionTrace = session.attachRunTrace(
     runTrace.trace,

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -363,7 +363,6 @@ export class StreamLogStore {
       throw new Error('A transcript writer requires a non-empty owner key.');
     }
 
-    this.pendingRelease.delete(streamId);
     if (
       !allowReleased &&
       this.mode.kind === 'persistent' &&
@@ -432,9 +431,9 @@ export class StreamLogStore {
   async ensureLoaded(streamId: StreamTabId): Promise<void> {
     if (this.mode.kind === 'ephemeral') return;
 
-    // Reactivation cancels any deferred release so the fresh agent work
-    // doesn't get evicted mid-run.
-    this.pendingRelease.delete(streamId);
+    // A direct read reactivates the stream. A writer-reserved load instead
+    // preserves an earlier eviction request until that writer closes.
+    if (!this.writers.has(streamId)) this.pendingRelease.delete(streamId);
     // Normally skip when already resident. A concurrent append may have
     // populated a fresh log before a rehydrate failed, so a retry must still
     // reunite it with persisted history before saves are re-enabled.

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -58,6 +58,19 @@ type StreamLogStoreMode =
   | { readonly kind: 'read-only' }
   | { readonly kind: 'ephemeral'; readonly reason: string };
 
+export interface TranscriptWriter {
+  readonly streamId: StreamTabId;
+  append(entry: StreamLogAppendInput): StreamLogEntry;
+  update(id: string, patch: StreamLogUpdatePatch): StreamLogEntry | undefined;
+  appendText(id: string, text: string): StreamLogEntry | undefined;
+  close(): void;
+}
+
+interface StreamWriterOwnership {
+  readonly ownerKey: string;
+  readonly tokens: Set<symbol>;
+}
+
 function summaryOf(logInstance: StreamLog): StreamLogSummary {
   return {
     firstTimestamp: logInstance.firstTimestamp,
@@ -141,7 +154,7 @@ export class StreamLogStore {
 
   /**
    * Lightweight summary per stream (first/last timestamp). Populated at open
-   * or reload and refreshed on append/update. Survives `releaseEntries` so sidebar
+   * or reload and refreshed on append/update. Survives eviction so sidebar
    * metadata stays available for streams whose heavy entries have been evicted.
    */
   private readonly summaries = new Map<StreamTabId, StreamLogSummary>();
@@ -158,11 +171,13 @@ export class StreamLogStore {
   private readonly flushing = new Set<StreamTabId>();
 
   /**
-   * Streams that went stale while still dirty, so `releaseEntries` deferred
-   * the memory drop until the next save flush. Reads + new appends clear the
-   * entry so a reactivated stream isn't evicted out from under the agent.
+   * Streams whose requested eviction is waiting for writers or persistence.
+   * A read or writer acquisition clears the request; otherwise the store
+   * evicts as soon as the remaining ownership and durability guards leave.
    */
   private readonly pendingRelease = new Set<StreamTabId>();
+  /** Exact mutation capabilities currently keeping a stream resident. */
+  private readonly writers = new Map<StreamTabId, StreamWriterOwnership>();
 
   /**
    * Streams whose rehydrate read from disk failed. While marked, saves skip
@@ -280,7 +295,7 @@ export class StreamLogStore {
    * first and actually evict afterwards; otherwise releases immediately.
    * Subsequent access must go through `ensureLoaded` to rehydrate.
    */
-  releaseEntries(streamId: StreamTabId): void {
+  requestEviction(streamId: StreamTabId): void {
     // Ephemeral entries have no durable copy from which they could be restored.
     if (this.mode.kind === 'ephemeral') return;
 
@@ -290,12 +305,16 @@ export class StreamLogStore {
       // queue the intent so it runs once the load completes. Otherwise the
       // rapid in-flight → stale flip would finish the load into memory
       // with no subsequent eviction trigger.
-      if (this.pendingLoads.has(streamId)) {
+      if (this.writers.has(streamId) || this.pendingLoads.has(streamId)) {
         this.pendingRelease.add(streamId);
       }
       return;
     }
-    if (this.dirtyStreamIds.has(streamId) || this.flushing.has(streamId)) {
+    if (
+      this.writers.has(streamId) ||
+      this.dirtyStreamIds.has(streamId) ||
+      this.flushing.has(streamId)
+    ) {
       this.pendingRelease.add(streamId);
       return;
     }
@@ -303,6 +322,78 @@ export class StreamLogStore {
     this.refreshSummary(streamId, logInstance);
     this.logs.delete(streamId);
     this.stateRevision += 1;
+  }
+
+  /**
+   * Rehydrate a stream and grant mutation authority to one logical execution.
+   * Exact tokens make close idempotent and prevent an obsolete handle from
+   * releasing a newer writer.
+   */
+  acquireWriter(streamId: StreamTabId, ownerKey: string): TranscriptWriter {
+    this.assertWritableStore('acquire a transcript writer');
+    if (!ownerKey.trim()) {
+      throw new Error('A transcript writer requires a non-empty owner key.');
+    }
+
+    this.pendingRelease.delete(streamId);
+    if (
+      this.mode.kind === 'persistent' &&
+      this.summaries.has(streamId) &&
+      !this.logs.has(streamId)
+    ) {
+      throw new Error(
+        `Cannot acquire a writer for released stream ${streamId}. Await ensureLoaded() first.`,
+      );
+    }
+
+    const current = this.writers.get(streamId);
+    if (current && current.ownerKey !== ownerKey) {
+      throw new Error(
+        `Transcript stream ${streamId} is already owned by another writer.`,
+      );
+    }
+    const ownership =
+      current ??
+      ({ ownerKey, tokens: new Set() } satisfies StreamWriterOwnership);
+    const token = Symbol(ownerKey);
+    ownership.tokens.add(token);
+    this.writers.set(streamId, ownership);
+    let closed = false;
+
+    const assertOwned = (): void => {
+      if (
+        closed ||
+        this.writers.get(streamId) !== ownership ||
+        !ownership.tokens.has(token)
+      ) {
+        throw new Error(`Transcript writer for ${streamId} has been released.`);
+      }
+    };
+
+    return {
+      streamId,
+      append: (entry) => {
+        assertOwned();
+        return this.append(streamId, entry);
+      },
+      update: (id, patch) => {
+        assertOwned();
+        return this.update(streamId, id, patch);
+      },
+      appendText: (id, text) => {
+        assertOwned();
+        return this.appendText(streamId, id, text);
+      },
+      close: () => {
+        if (closed) return;
+        closed = true;
+        if (this.writers.get(streamId) !== ownership) return;
+        ownership.tokens.delete(token);
+        if (ownership.tokens.size > 0) return;
+        this.writers.delete(streamId);
+        this.drainPendingReleases();
+      },
+    };
   }
 
   /**
@@ -359,7 +450,7 @@ export class StreamLogStore {
           this.logs.set(streamId, logInstance);
           this.stateRevision += 1;
           this.refreshSummary(streamId, logInstance);
-          // A `releaseEntries` that arrived while the load was in flight gets
+          // An eviction request that arrived while the load was in flight gets
           // queued; honor it now (unless a reactivation cleared the intent).
           if (this.pendingRelease.has(streamId)) {
             this.pendingRelease.delete(streamId);
@@ -397,8 +488,6 @@ export class StreamLogStore {
 
   append(streamId: StreamTabId, entry: StreamLogAppendInput): StreamLogEntry {
     this.assertWritableStream(streamId);
-    // New writes mean the stream is live again — cancel any deferred release.
-    this.pendingRelease.delete(streamId);
     if (
       this.mode.kind === 'persistent' &&
       this.summaries.has(streamId) &&
@@ -803,6 +892,7 @@ export class StreamLogStore {
     this.flushing.clear();
     this.loadFailed.clear();
     this.pendingLoads.clear();
+    this.writers.clear();
     this.writeTombstones.clear();
     this.clearing = false;
     this.stateRevision += 1;
@@ -931,6 +1021,7 @@ export class StreamLogStore {
     this.flushing.delete(streamId);
     this.loadFailed.delete(streamId);
     this.pendingLoads.delete(streamId);
+    this.writers.delete(streamId);
   }
 
   private forgetAllStreamState(): void {
@@ -941,6 +1032,7 @@ export class StreamLogStore {
     this.flushing.clear();
     this.loadFailed.clear();
     this.pendingLoads.clear();
+    this.writers.clear();
   }
 
   private assertWritableStore(operation: string): void {
@@ -1109,7 +1201,7 @@ export class StreamLogStore {
     log.debug(LOG_TAG, `Writing ${dirtyIds.length} dirty stream(s)`);
     const writeGeneration = this.writeGeneration;
 
-    // Mark these as mid-flush so `releaseEntries` defers — we need the
+    // Mark these as mid-flush so eviction defers — we need the
     // in-memory copy preserved until the write resolves, otherwise a failed
     // write can't re-mark the stream dirty (there'd be no log entries left).
     for (const streamId of dirtyIds) this.flushing.add(streamId);
@@ -1157,7 +1249,9 @@ export class StreamLogStore {
   private drainPendingReleases(): void {
     if (this.pendingRelease.size === 0) return;
     for (const streamId of [...this.pendingRelease]) {
-      if (this.dirtyStreamIds.has(streamId)) continue;
+      if (this.writers.has(streamId) || this.dirtyStreamIds.has(streamId)) {
+        continue;
+      }
       this.pendingRelease.delete(streamId);
       const logInstance = this.logs.get(streamId);
       if (!logInstance) continue;

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -330,6 +330,34 @@ export class StreamLogStore {
    * releasing a newer writer.
    */
   acquireWriter(streamId: StreamTabId, ownerKey: string): TranscriptWriter {
+    return this.createWriter(streamId, ownerKey, false);
+  }
+
+  /**
+   * Reserve mutation authority before rehydrating a released stream. The
+   * reservation keeps a concurrent eviction request pending until the caller
+   * receives and later closes the writer, so load and writer acquisition form
+   * one ownership transition instead of two raceable calls.
+   */
+  async loadAndAcquireWriter(
+    streamId: StreamTabId,
+    ownerKey: string,
+  ): Promise<TranscriptWriter> {
+    const writer = this.createWriter(streamId, ownerKey, true);
+    try {
+      await this.ensureLoaded(streamId);
+      return writer;
+    } catch (error) {
+      writer.close();
+      throw error;
+    }
+  }
+
+  private createWriter(
+    streamId: StreamTabId,
+    ownerKey: string,
+    allowReleased: boolean,
+  ): TranscriptWriter {
     this.assertWritableStore('acquire a transcript writer');
     if (!ownerKey.trim()) {
       throw new Error('A transcript writer requires a non-empty owner key.');
@@ -337,6 +365,7 @@ export class StreamLogStore {
 
     this.pendingRelease.delete(streamId);
     if (
+      !allowReleased &&
       this.mode.kind === 'persistent' &&
       this.summaries.has(streamId) &&
       !this.logs.has(streamId)
@@ -452,7 +481,10 @@ export class StreamLogStore {
           this.refreshSummary(streamId, logInstance);
           // An eviction request that arrived while the load was in flight gets
           // queued; honor it now (unless a reactivation cleared the intent).
-          if (this.pendingRelease.has(streamId)) {
+          if (
+            this.pendingRelease.has(streamId) &&
+            !this.writers.has(streamId)
+          ) {
             this.pendingRelease.delete(streamId);
             if (!this.dirtyStreamIds.has(streamId)) {
               this.logs.delete(streamId);

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -1249,7 +1249,11 @@ export class StreamLogStore {
   private drainPendingReleases(): void {
     if (this.pendingRelease.size === 0) return;
     for (const streamId of [...this.pendingRelease]) {
-      if (this.writers.has(streamId) || this.dirtyStreamIds.has(streamId)) {
+      if (
+        this.writers.has(streamId) ||
+        this.dirtyStreamIds.has(streamId) ||
+        this.flushing.has(streamId)
+      ) {
         continue;
       }
       this.pendingRelease.delete(streamId);

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -28,12 +28,11 @@ import {
   STREAM_PHASE,
   type LogLevel,
   type MessageType,
-  type StreamTabId,
   type ToolUseLog,
 } from '@shared/schemas';
 import { generateShortId } from '@utils/core';
 
-import { type StreamLogStore } from './StreamLogStore';
+import type { TranscriptWriter } from './StreamLogStore';
 
 const STREAM_UPDATE_THROTTLE_MS = 50;
 
@@ -101,10 +100,19 @@ export interface TranscriptRecorderHandle {
 
 export function attachTranscriptRecorder(
   trace: AgentTrace,
-  streamId: StreamTabId,
-  store: StreamLogStore,
+  writer: TranscriptWriter,
 ): TranscriptRecorderHandle {
+  const { streamId } = writer;
   const streams = new Map<string, StreamSinkState>();
+  let pendingFailure: unknown;
+  const recordFailure = (error: unknown): void => {
+    pendingFailure ??= error;
+    for (const state of streams.values()) {
+      if (state.updateTimer) clearTimeout(state.updateTimer);
+      state.updateTimer = null;
+      state.enabled = false;
+    }
+  };
   // stage.start's `kind` lives only on that event — `store.update` at
   // stage.end replaces `data` wholesale (see StreamLog.update), so without
   // this the persisted GROUP_END row would forget whether the stage was the
@@ -134,7 +142,7 @@ export function attachTranscriptRecorder(
     if (!state.enabled) return;
 
     if (!state.created) {
-      const appended = store.append(streamId, {
+      const appended = writer.append({
         id,
         type: STREAM_LOG_ENTRY_TYPES.LOG,
         level: state.level,
@@ -151,12 +159,12 @@ export function attachTranscriptRecorder(
     }
 
     if (!state.ended && pendingText.length > 0) {
-      store.appendText(streamId, id, pendingText);
+      writer.appendText(id, pendingText);
       return;
     }
 
     if (state.ended) {
-      store.update(streamId, id, {
+      writer.update(id, {
         text: state.buffer,
         data: { status: 'completed' },
       });
@@ -167,12 +175,22 @@ export function attachTranscriptRecorder(
     if (state.updateTimer) return;
     state.updateTimer = setTimeout(() => {
       state.updateTimer = null;
-      flushStream(state, id);
+      try {
+        flushStream(state, id);
+      } catch (error) {
+        recordFailure(error);
+      }
     }, STREAM_UPDATE_THROTTLE_MS);
   };
 
   const flushPending = (): void => {
-    for (const [id, state] of streams) flushStream(state, id);
+    if (pendingFailure !== undefined) throw pendingFailure;
+    try {
+      for (const [id, state] of streams) flushStream(state, id);
+    } catch (error) {
+      recordFailure(error);
+      throw error;
+    }
   };
 
   // Append a generic text LOG row. Centralizes the boilerplate shared by the
@@ -186,7 +204,7 @@ export function attachTranscriptRecorder(
     data?: unknown;
     verbose?: boolean;
   }): void => {
-    store.append(streamId, {
+    writer.append({
       id: generateShortId(),
       type: STREAM_LOG_ENTRY_TYPES.LOG,
       level: params.level ?? 'info',
@@ -200,276 +218,286 @@ export function attachTranscriptRecorder(
   };
 
   const subscriber: AgentTraceSubscriber = (event: AgentEvent) => {
-    switch (event.type) {
-      case 'log': {
-        const messageType = asMessageType(event.messageType);
-        if (!shouldEmit(event.level, messageType)) return;
-        appendLog({
-          level: event.level,
-          groupId: event.stageId,
-          messageType,
-          text: event.message,
-          data: event.data,
-          verbose: event.verbose,
-        });
-        return;
-      }
-
-      case 'stage.start':
-        if (event.kind) stageKinds.set(event.id, event.kind);
-        // A new round starts fresh: whatever MODEL_RESPONSE stream the
-        // previous round may have opened is no longer this round's to reuse.
-        if (event.kind === 'round') pendingModelResponseId = undefined;
-        store.append(streamId, {
-          id: event.id,
-          type: STREAM_LOG_ENTRY_TYPES.GROUP_START,
-          level: 'info',
-          timestamp: Date.now(),
-          groupId: event.parentId,
-          messageType: MESSAGE_TYPES.DEFAULT,
-          text: event.label,
-          data: {
-            status: STREAM_PHASE.RUNNING,
-            ...(event.kind ? { kind: event.kind } : {}),
-            ...(event.index !== undefined ? { index: event.index } : {}),
-            ...(event.total !== undefined ? { total: event.total } : {}),
-          },
-          verbose: isDebugModeEnabled(),
-        });
-        return;
-
-      case 'stage.end': {
-        const kind = stageKinds.get(event.id);
-        stageKinds.delete(event.id);
-        store.update(streamId, event.id, {
-          type: STREAM_LOG_ENTRY_TYPES.GROUP_END,
-          data: {
-            status: event.status ?? RUN_OUTCOME.COMPLETED,
-            endTime: Date.now(),
-            ...(kind ? { kind } : {}),
-          },
-        });
-        return;
-      }
-
-      case 'tool.start':
-        pendingModelResponseId = undefined;
-        // event.logId is the canonical id — SDK consumers correlate
-        // tool.start/end by it and the store entry shares the same id so
-        // callers can lookup with store.get(streamId).find(e => e.id === logId).
-        store.append(streamId, {
-          id: event.logId,
-          type: STREAM_LOG_ENTRY_TYPES.LOG,
-          level: 'info',
-          timestamp: Date.now(),
-          groupId: event.stageId,
-          messageType: MESSAGE_TYPES.TOOL_USE,
-          data: {
-            toolName: event.toolName,
-            input: redactToolInputForLog(event.toolName, event.input),
-            status: 'in_progress',
-          } satisfies ToolUseLog,
-          verbose: isDebugModeEnabled(),
-        });
-        return;
-
-      case 'tool.end': {
-        const result = (event.result ?? {}) as Partial<ToolUseLog>;
-        const redactedResult =
-          typeof result.toolName === 'string'
-            ? {
-                ...result,
-                input: redactToolInputForLog(result.toolName, result.input),
-              }
-            : result;
-        // Omit groupId on update — undefined would clobber the canonical
-        // value stamped at tool.start (deferred tools never copy the
-        // resolved id back into their ref).
-        store.update(streamId, event.logId, {
-          messageType: MESSAGE_TYPES.TOOL_USE,
-          data: {
-            ...redactedResult,
-            status: event.status,
-          } as ToolUseLog,
-        });
-        return;
-      }
-
-      case 'usage':
-        if (event.recordTranscript === false) return;
-        appendLog({
-          groupId: event.stageId,
-          messageType: MESSAGE_TYPES.STATISTICS,
-          text: `Usage - input: ${event.payload.usage.inputTokens}, output: ${event.payload.usage.outputTokens}`,
-          data: event.payload.usage,
-        });
-        return;
-
-      case 'status':
-        return;
-
-      case 'context.state': {
-        const utilizationPercent = computeUtilizationPercent(
-          event.inputTokens,
-          event.contextWindow,
-        );
-        appendLog({
-          groupId: event.stageId,
-          messageType: MESSAGE_TYPES.CONTEXT_STATE,
-          text: `Context: ${event.inputTokens}/${event.contextWindow} tokens (${utilizationPercent.toFixed(1)}%)`,
-          data: {
-            inputTokens: event.inputTokens,
-            contextWindow: event.contextWindow,
-            utilizationPercent,
-          },
-        });
-        return;
-      }
-
-      case 'stream.start': {
-        const state: StreamSinkState = {
-          buffer: '',
-          pending: [],
-          created: false,
-          ended: false,
-          enabled: true,
-          groupId: event.stageId,
-          level: 'info',
-          messageType: asMessageType(event.kind),
-          updateTimer: null,
-        };
-        streams.set(event.id, state);
-        if (state.messageType === MESSAGE_TYPES.MODEL_RESPONSE) {
-          pendingModelResponseId = event.id;
-        }
-        // The start IS the signal consumers care about — it marks the moment
-        // the phase began: a running THINKING entry drives the CLI's "model
-        // is thinking" indicator, and a running MODEL_RESPONSE entry says
-        // the response has started even when its content is withheld
-        // (phase-only workflow streams, hidden reasoning that never emits a
-        // chunk). Materialize the entry immediately; renderers already skip
-        // entries with empty text.
-        flushStream(state, event.id);
-        return;
-      }
-
-      case 'stream.chunk': {
-        const state = streams.get(event.id);
-        if (!state || !state.enabled) return;
-        state.pending.push(event.text);
-        // First content flushes immediately — the entry was materialized
-        // empty at stream.start, so without this the first paint would wait
-        // out the coalescing interval. Later chunks coalesce.
-        if (!state.created || state.buffer.length === 0) {
-          flushStream(state, event.id);
-        } else {
-          scheduleStreamUpdate(state, event.id);
-        }
-        return;
-      }
-
-      case 'stream.end': {
-        const state = streams.get(event.id);
-        if (!state) return;
-        if (typeof event.finalText === 'string') {
-          state.buffer = event.finalText;
-          state.pending = [];
-        }
-        state.ended = true;
-        flushStream(state, event.id);
-        streams.delete(event.id);
-        return;
-      }
-
-      case 'response.finalized': {
-        if (!event.text) return;
-        // Upsert by id, not by text: if this round's own MODEL_RESPONSE
-        // stream already wrote a (possibly raw, pre-replacement) entry,
-        // reconcile it to the authoritative text; otherwise this round never
-        // streamed (e.g. a non-streaming provider call), so append it fresh.
-        const correlatorId = pendingModelResponseId;
-        pendingModelResponseId = undefined;
-        if (correlatorId) {
-          store.update(streamId, correlatorId, {
-            text: event.text,
-            data: { status: 'completed' },
+    if (pendingFailure !== undefined) throw pendingFailure;
+    try {
+      switch (event.type) {
+        case 'log': {
+          const messageType = asMessageType(event.messageType);
+          if (!shouldEmit(event.level, messageType)) return;
+          appendLog({
+            level: event.level,
+            groupId: event.stageId,
+            messageType,
+            text: event.message,
+            data: event.data,
+            verbose: event.verbose,
           });
           return;
         }
-        appendLog({
-          groupId: event.stageId,
-          messageType: MESSAGE_TYPES.MODEL_RESPONSE,
-          text: event.text,
-        });
-        return;
-      }
 
-      case 'domain': {
-        // Subscribers that care about specific keys can switch on event.key.
-        // filesLoaded has a richer payload shape; format the text accordingly.
-        if (event.key === 'filesLoaded') {
-          const payload = event.data as
-            | { category?: string; entries?: ReadonlyArray<{ ok?: boolean }> }
-            | undefined;
-          const entries = payload?.entries ?? [];
-          const okCount = entries.filter((e) => e?.ok).length;
+        case 'stage.start':
+          if (event.kind) stageKinds.set(event.id, event.kind);
+          // A new round starts fresh: whatever MODEL_RESPONSE stream the
+          // previous round may have opened is no longer this round's to reuse.
+          if (event.kind === 'round') pendingModelResponseId = undefined;
+          writer.append({
+            id: event.id,
+            type: STREAM_LOG_ENTRY_TYPES.GROUP_START,
+            level: 'info',
+            timestamp: Date.now(),
+            groupId: event.parentId,
+            messageType: MESSAGE_TYPES.DEFAULT,
+            text: event.label,
+            data: {
+              status: STREAM_PHASE.RUNNING,
+              ...(event.kind ? { kind: event.kind } : {}),
+              ...(event.index !== undefined ? { index: event.index } : {}),
+              ...(event.total !== undefined ? { total: event.total } : {}),
+            },
+            verbose: isDebugModeEnabled(),
+          });
+          return;
+
+        case 'stage.end': {
+          const kind = stageKinds.get(event.id);
+          stageKinds.delete(event.id);
+          writer.update(event.id, {
+            type: STREAM_LOG_ENTRY_TYPES.GROUP_END,
+            data: {
+              status: event.status ?? RUN_OUTCOME.COMPLETED,
+              endTime: Date.now(),
+              ...(kind ? { kind } : {}),
+            },
+          });
+          return;
+        }
+
+        case 'tool.start':
+          pendingModelResponseId = undefined;
+          // event.logId is the canonical id — SDK consumers correlate
+          // tool.start/end by it and the store entry shares the same id so
+          // callers can lookup with store.get(streamId).find(e => e.id === logId).
+          writer.append({
+            id: event.logId,
+            type: STREAM_LOG_ENTRY_TYPES.LOG,
+            level: 'info',
+            timestamp: Date.now(),
+            groupId: event.stageId,
+            messageType: MESSAGE_TYPES.TOOL_USE,
+            data: {
+              toolName: event.toolName,
+              input: redactToolInputForLog(event.toolName, event.input),
+              status: 'in_progress',
+            } satisfies ToolUseLog,
+            verbose: isDebugModeEnabled(),
+          });
+          return;
+
+        case 'tool.end': {
+          const result = (event.result ?? {}) as Partial<ToolUseLog>;
+          const redactedResult =
+            typeof result.toolName === 'string'
+              ? {
+                  ...result,
+                  input: redactToolInputForLog(result.toolName, result.input),
+                }
+              : result;
+          // Omit groupId on update — undefined would clobber the canonical
+          // value stamped at tool.start (deferred tools never copy the
+          // resolved id back into their ref).
+          writer.update(event.logId, {
+            messageType: MESSAGE_TYPES.TOOL_USE,
+            data: {
+              ...redactedResult,
+              status: event.status,
+            } as ToolUseLog,
+          });
+          return;
+        }
+
+        case 'usage':
+          if (event.recordTranscript === false) return;
           appendLog({
             groupId: event.stageId,
-            messageType: MESSAGE_TYPES.FILE_LIST,
-            text: `Loading ${payload?.category ?? ''} (${okCount}/${entries.length})`,
-            data: entries,
+            messageType: MESSAGE_TYPES.STATISTICS,
+            text: `Usage - input: ${event.payload.usage.inputTokens}, output: ${event.payload.usage.outputTokens}`,
+            data: event.payload.usage,
+          });
+          return;
+
+        case 'status':
+          return;
+
+        case 'context.state': {
+          const utilizationPercent = computeUtilizationPercent(
+            event.inputTokens,
+            event.contextWindow,
+          );
+          appendLog({
+            groupId: event.stageId,
+            messageType: MESSAGE_TYPES.CONTEXT_STATE,
+            text: `Context: ${event.inputTokens}/${event.contextWindow} tokens (${utilizationPercent.toFixed(1)}%)`,
+            data: {
+              inputTokens: event.inputTokens,
+              contextWindow: event.contextWindow,
+              utilizationPercent,
+            },
           });
           return;
         }
-        appendLog({
-          groupId: event.stageId,
-          messageType: DOMAIN_MESSAGE_TYPE[event.key] ?? MESSAGE_TYPES.DEFAULT,
-          text: event.text ?? event.key,
-          data: event.data,
-        });
-        return;
+
+        case 'stream.start': {
+          const state: StreamSinkState = {
+            buffer: '',
+            pending: [],
+            created: false,
+            ended: false,
+            enabled: true,
+            groupId: event.stageId,
+            level: 'info',
+            messageType: asMessageType(event.kind),
+            updateTimer: null,
+          };
+          streams.set(event.id, state);
+          if (state.messageType === MESSAGE_TYPES.MODEL_RESPONSE) {
+            pendingModelResponseId = event.id;
+          }
+          // The start IS the signal consumers care about — it marks the moment
+          // the phase began: a running THINKING entry drives the CLI's "model
+          // is thinking" indicator, and a running MODEL_RESPONSE entry says
+          // the response has started even when its content is withheld
+          // (phase-only workflow streams, hidden reasoning that never emits a
+          // chunk). Materialize the entry immediately; renderers already skip
+          // entries with empty text.
+          flushStream(state, event.id);
+          return;
+        }
+
+        case 'stream.chunk': {
+          const state = streams.get(event.id);
+          if (!state || !state.enabled) return;
+          state.pending.push(event.text);
+          // First content flushes immediately — the entry was materialized
+          // empty at stream.start, so without this the first paint would wait
+          // out the coalescing interval. Later chunks coalesce.
+          if (!state.created || state.buffer.length === 0) {
+            flushStream(state, event.id);
+          } else {
+            scheduleStreamUpdate(state, event.id);
+          }
+          return;
+        }
+
+        case 'stream.end': {
+          const state = streams.get(event.id);
+          if (!state) return;
+          if (typeof event.finalText === 'string') {
+            state.buffer = event.finalText;
+            state.pending = [];
+          }
+          state.ended = true;
+          flushStream(state, event.id);
+          streams.delete(event.id);
+          return;
+        }
+
+        case 'response.finalized': {
+          if (!event.text) return;
+          // Upsert by id, not by text: if this round's own MODEL_RESPONSE
+          // stream already wrote a (possibly raw, pre-replacement) entry,
+          // reconcile it to the authoritative text; otherwise this round never
+          // streamed (e.g. a non-streaming provider call), so append it fresh.
+          const correlatorId = pendingModelResponseId;
+          pendingModelResponseId = undefined;
+          if (correlatorId) {
+            writer.update(correlatorId, {
+              text: event.text,
+              data: { status: 'completed' },
+            });
+            return;
+          }
+          appendLog({
+            groupId: event.stageId,
+            messageType: MESSAGE_TYPES.MODEL_RESPONSE,
+            text: event.text,
+          });
+          return;
+        }
+
+        case 'domain': {
+          // Subscribers that care about specific keys can switch on event.key.
+          // filesLoaded has a richer payload shape; format the text accordingly.
+          if (event.key === 'filesLoaded') {
+            const payload = event.data as
+              | { category?: string; entries?: ReadonlyArray<{ ok?: boolean }> }
+              | undefined;
+            const entries = payload?.entries ?? [];
+            const okCount = entries.filter((e) => e?.ok).length;
+            appendLog({
+              groupId: event.stageId,
+              messageType: MESSAGE_TYPES.FILE_LIST,
+              text: `Loading ${payload?.category ?? ''} (${okCount}/${entries.length})`,
+              data: entries,
+            });
+            return;
+          }
+          appendLog({
+            groupId: event.stageId,
+            messageType:
+              DOMAIN_MESSAGE_TYPE[event.key] ?? MESSAGE_TYPES.DEFAULT,
+            text: event.text ?? event.key,
+            data: event.data,
+          });
+          return;
+        }
+
+        case 'conversation.progress':
+        case 'updateTodos':
+        case 'updatePlan':
+        case 'addOutputFiles':
+        case 'updateMissingOutputs':
+        case 'updateCompileFailures':
+        case 'goalPaused':
+          return;
+
+        case 'result':
+          // The terminal outcome is consumed by hosts via `session.onResult`.
+          // The transcript already reflects completion through `stage.end`, so it
+          // adds no row here (keeps transcript output unchanged).
+          return;
+
+        case 'run.start':
+        case 'run.config':
+          // Run identity/config facts drive host state through the session plane.
+          // They are not transcript rows.
+          return;
+
+        case 'child.activity':
+        case 'process.output':
+          // Stage 3a child/process facts replace legacy progress events for UI
+          // badges and process panes; they were not transcript rows before.
+          return;
+
+        default: {
+          // Exhaustiveness check: adding a new event arm forces an error here.
+          const _exhaustive: never = event;
+          void _exhaustive;
+        }
       }
-
-      case 'conversation.progress':
-      case 'updateTodos':
-      case 'updatePlan':
-      case 'addOutputFiles':
-      case 'updateMissingOutputs':
-      case 'updateCompileFailures':
-      case 'goalPaused':
-        return;
-
-      case 'result':
-        // The terminal outcome is consumed by hosts via `session.onResult`.
-        // The transcript already reflects completion through `stage.end`, so it
-        // adds no row here (keeps transcript output unchanged).
-        return;
-
-      case 'run.start':
-      case 'run.config':
-        // Run identity/config facts drive host state through the session plane.
-        // They are not transcript rows.
-        return;
-
-      case 'child.activity':
-      case 'process.output':
-        // Stage 3a child/process facts replace legacy progress events for UI
-        // badges and process panes; they were not transcript rows before.
-        return;
-
-      default: {
-        // Exhaustiveness check: adding a new event arm forces an error here.
-        const _exhaustive: never = event;
-        void _exhaustive;
-      }
+    } catch (error) {
+      recordFailure(error);
+      throw error;
     }
   };
 
   const unsubscribe = trace.subscribe(subscriber);
   return {
     unsubscribe: () => {
-      flushPending();
-      unsubscribe();
+      try {
+        flushPending();
+      } finally {
+        unsubscribe();
+      }
     },
     flushPending,
   };

--- a/src/transcript/index.ts
+++ b/src/transcript/index.ts
@@ -15,12 +15,8 @@ export {
   STREAM_LOG_SUMMARIES_DIR,
 } from './StreamLogStore';
 export { StreamLog, type StreamLogAppendInput } from './StreamLog';
-export {
-  createRunTrace,
-  flushPendingRunTraces,
-  getActiveFlushers,
-  type RunTrace,
-} from './runTrace';
+export { createRunTrace, type RunTrace } from './runTrace';
+export type { TranscriptWriter } from './StreamLogStore';
 export { streamDataDir } from './streamDataPaths';
 export { StreamSnapshotStore } from './StreamSnapshotStore';
 export { assembleTrace, type AssembleTraceResult } from './traceAssembler';

--- a/src/transcript/index.ts
+++ b/src/transcript/index.ts
@@ -16,7 +16,6 @@ export {
 } from './StreamLogStore';
 export { StreamLog, type StreamLogAppendInput } from './StreamLog';
 export { createRunTrace, type RunTrace } from './runTrace';
-export type { TranscriptWriter } from './StreamLogStore';
 export { streamDataDir } from './streamDataPaths';
 export { StreamSnapshotStore } from './StreamSnapshotStore';
 export { assembleTrace, type AssembleTraceResult } from './traceAssembler';

--- a/src/transcript/runTrace.ts
+++ b/src/transcript/runTrace.ts
@@ -35,71 +35,38 @@ export interface RunTrace {
 export function createRunTrace(
   streamId: StreamTabId,
   store: StreamLogStore,
-  flushers: Set<() => void> = activeFlushers,
+  flushers: Set<() => void> = new Set(),
+  ownerKey: string = streamId,
 ): RunTrace {
+  const writer = store.acquireWriter(streamId, ownerKey);
   const trace = new TraceEmitter();
   const unsubscribeChannel = attachChannelSubscriber(trace, {
     channel: streamId,
     isAgent: true,
   });
-  const transcript = attachTranscriptRecorder(trace, streamId, store);
+  const transcript = attachTranscriptRecorder(trace, writer);
 
-  // Register the flush in the run's (session-scoped) set so the session can
-  // drain its own streams, and track the set so the process-wide shutdown
-  // hook (`flushPendingRunTraces()`) still reaches every session's streams.
+  // Register the flush in the run's session-scoped set so shutdown drains
+  // only the artifacts belonging to that session.
   flushers.add(transcript.flushPending);
-  flusherSets.add(flushers);
+
+  let disposed = false;
 
   return {
     trace,
     dispose: () => {
+      if (disposed) return;
+      disposed = true;
       flushers.delete(transcript.flushPending);
-      transcript.unsubscribe();
-      unsubscribeChannel();
+      try {
+        transcript.unsubscribe();
+      } finally {
+        try {
+          unsubscribeChannel();
+        } finally {
+          writer.close();
+        }
+      }
     },
   };
-}
-
-/** The default (process) session's flusher set; see `getActiveFlushers`. */
-const activeFlushers = new Set<() => void>();
-
-/**
- * Every flusher set handed to {@link createRunTrace}, so the process-wide drain
- * reaches non-default sessions too. The default set is always a member.
- */
-const flusherSets = new Set<Set<() => void>>([activeFlushers]);
-
-/**
- * Drain pending stream-chunk updates across every active run trace in every
- * session. Called by shutdown paths (progress view dispose, CLI exit) so
- * throttled stream writes hit the store before the process tears down.
- */
-export function flushPendingRunTraces(): void {
-  for (const set of flusherSets) {
-    for (const flush of [...set]) flush();
-  }
-}
-
-/**
- * Accessor for the process-default flusher set.
- *
- * Exposed so `SessionHandle` (in `@agent/runtime`) can alias the default
- * session's flushers to this exact set *by identity*. The dependency edge
- * must point this way only — `@transcript` never imports `@agent/runtime`
- * (the layering inversion that the SDK readiness work already removed) — so
- * the agent runtime reaches the set through this accessor, not the reverse.
- */
-export function getActiveFlushers(): Set<() => void> {
-  return activeFlushers;
-}
-
-/**
- * Drop a session's flusher set from the process-wide drain registry — called by
- * {@link SessionHandle.dispose} so a torn-down session's set is not iterated by
- * {@link flushPendingRunTraces} for the rest of the process lifetime. The
- * default (process) set is never removed: it lives for the whole process and
- * the default session is never disposed.
- */
-export function unregisterFlushers(set: Set<() => void>): void {
-  if (set !== activeFlushers) flusherSets.delete(set);
 }

--- a/src/transcript/runTrace.ts
+++ b/src/transcript/runTrace.ts
@@ -16,7 +16,7 @@ import {
 import type { StreamTabId } from '@shared/schemas';
 
 import { attachTranscriptRecorder } from './TexraTranscriptRecorder';
-import type { StreamLogStore } from './StreamLogStore';
+import type { StreamLogStore, TranscriptWriter } from './StreamLogStore';
 
 export interface RunTrace {
   readonly trace: AgentTrace;
@@ -37,8 +37,9 @@ export function createRunTrace(
   store: StreamLogStore,
   flushers: Set<() => void> = new Set(),
   ownerKey: string = streamId,
+  reservedWriter?: TranscriptWriter,
 ): RunTrace {
-  const writer = store.acquireWriter(streamId, ownerKey);
+  const writer = reservedWriter ?? store.acquireWriter(streamId, ownerKey);
   const trace = new TraceEmitter();
   const unsubscribeChannel = attachChannelSubscriber(trace, {
     channel: streamId,

--- a/src/transcript/runTrace.ts
+++ b/src/transcript/runTrace.ts
@@ -35,7 +35,7 @@ export interface RunTrace {
 export function createRunTrace(
   streamId: StreamTabId,
   store: StreamLogStore,
-  flushers: Set<() => void> = new Set(),
+  flushers: Map<string, () => void> = new Map(),
   ownerKey: string = streamId,
   reservedWriter?: TranscriptWriter,
 ): RunTrace {
@@ -47,9 +47,10 @@ export function createRunTrace(
   });
   const transcript = attachTranscriptRecorder(trace, writer);
 
-  // Register the flush in the run's session-scoped set so shutdown drains
+  // Register the flush by execution so durability boundaries drain only their
+  // own trace, while session shutdown can still drain every trace.
   // only the artifacts belonging to that session.
-  flushers.add(transcript.flushPending);
+  flushers.set(ownerKey, transcript.flushPending);
 
   let disposed = false;
 
@@ -58,7 +59,9 @@ export function createRunTrace(
     dispose: () => {
       if (disposed) return;
       disposed = true;
-      flushers.delete(transcript.flushPending);
+      if (flushers.get(ownerKey) === transcript.flushPending) {
+        flushers.delete(ownerKey);
+      }
       try {
         transcript.unsubscribe();
       } finally {

--- a/src/transcript/runTrace.ts
+++ b/src/transcript/runTrace.ts
@@ -23,6 +23,14 @@ export interface RunTrace {
   readonly dispose: () => void;
 }
 
+export type RunTraceFlushEntry =
+  | { readonly state: 'active'; readonly flush: () => void }
+  | {
+      readonly state: 'failed';
+      readonly error: unknown;
+      readonly flush: () => void;
+    };
+
 /**
  * Produce a trace wired with the standard agent-run subscribers: per-channel
  * channel output AND the transcript recorder.
@@ -35,12 +43,13 @@ export interface RunTrace {
 export function createRunTrace(
   streamId: StreamTabId,
   store: StreamLogStore,
-  flushers: Map<string, () => void> = new Map(),
+  flushers: Map<string, RunTraceFlushEntry> = new Map(),
   ownerKey: string = streamId,
   reservedWriter?: TranscriptWriter,
 ): RunTrace {
   const writer = reservedWriter ?? store.acquireWriter(streamId, ownerKey);
-  if (flushers.has(ownerKey)) {
+  const previousEntry = flushers.get(ownerKey);
+  if (previousEntry?.state === 'active') {
     const ownershipError = new Error(
       `Execution ${ownerKey} already owns a run trace.`,
     );
@@ -81,9 +90,31 @@ export function createRunTrace(
     throw error;
   }
 
+  const pendingFailures =
+    previousEntry?.state === 'failed' ? [previousEntry.error] : [];
+  const activeEntry: RunTraceFlushEntry = {
+    state: 'active',
+    flush: () => {
+      const failures: unknown[] = [];
+      try {
+        transcript.flushPending();
+      } catch (error) {
+        failures.push(error);
+      }
+      if (pendingFailures.length > 0) {
+        failures.push(...pendingFailures);
+        pendingFailures.length = 0;
+      }
+      if (failures.length === 1) throw failures[0];
+      if (failures.length > 1) {
+        throw new AggregateError(failures, 'Run trace flush failed');
+      }
+    },
+  };
+
   // Register the flush by execution so durability boundaries drain only their
   // own trace, while session shutdown can still drain every trace.
-  flushers.set(ownerKey, transcript.flushPending);
+  flushers.set(ownerKey, activeEntry);
 
   let disposed = false;
 
@@ -108,7 +139,8 @@ export function createRunTrace(
       } catch (error) {
         failures.push(error);
       }
-      if (flushers.get(ownerKey) !== transcript.flushPending) return;
+      if (flushers.get(ownerKey) !== activeEntry) return;
+      failures.unshift(...pendingFailures);
       if (failures.length === 0) {
         flushers.delete(ownerKey);
         return;
@@ -117,13 +149,17 @@ export function createRunTrace(
         failures.length === 1
           ? failures[0]
           : new AggregateError(failures, 'Run trace cleanup failed');
-      const handoffFailure = (): void => {
-        if (flushers.get(ownerKey) === handoffFailure) {
-          flushers.delete(ownerKey);
-        }
-        throw failure;
+      const failedEntry: RunTraceFlushEntry = {
+        state: 'failed',
+        error: failure,
+        flush: () => {
+          if (flushers.get(ownerKey) === failedEntry) {
+            flushers.delete(ownerKey);
+          }
+          throw failure;
+        },
       };
-      flushers.set(ownerKey, handoffFailure);
+      flushers.set(ownerKey, failedEntry);
     },
   };
 }

--- a/src/transcript/runTrace.ts
+++ b/src/transcript/runTrace.ts
@@ -40,16 +40,49 @@ export function createRunTrace(
   reservedWriter?: TranscriptWriter,
 ): RunTrace {
   const writer = reservedWriter ?? store.acquireWriter(streamId, ownerKey);
+  if (flushers.has(ownerKey)) {
+    const ownershipError = new Error(
+      `Execution ${ownerKey} already owns a run trace.`,
+    );
+    try {
+      writer.close();
+    } catch (cleanupError) {
+      throw new AggregateError(
+        [ownershipError, cleanupError],
+        'Duplicate run trace setup and cleanup failed',
+      );
+    }
+    throw ownershipError;
+  }
   const trace = new TraceEmitter();
-  const unsubscribeChannel = attachChannelSubscriber(trace, {
-    channel: streamId,
-    isAgent: true,
-  });
-  const transcript = attachTranscriptRecorder(trace, writer);
+  let unsubscribeChannel: (() => void) | undefined;
+  let transcript: ReturnType<typeof attachTranscriptRecorder>;
+  try {
+    unsubscribeChannel = attachChannelSubscriber(trace, {
+      channel: streamId,
+      isAgent: true,
+    });
+    transcript = attachTranscriptRecorder(trace, writer);
+  } catch (error) {
+    const failures = [error];
+    try {
+      unsubscribeChannel?.();
+    } catch (cleanupError) {
+      failures.push(cleanupError);
+    }
+    try {
+      writer.close();
+    } catch (cleanupError) {
+      failures.push(cleanupError);
+    }
+    if (failures.length > 1) {
+      throw new AggregateError(failures, 'Run trace setup and cleanup failed');
+    }
+    throw error;
+  }
 
   // Register the flush by execution so durability boundaries drain only their
   // own trace, while session shutdown can still drain every trace.
-  // only the artifacts belonging to that session.
   flushers.set(ownerKey, transcript.flushPending);
 
   let disposed = false;
@@ -59,18 +92,38 @@ export function createRunTrace(
     dispose: () => {
       if (disposed) return;
       disposed = true;
-      if (flushers.get(ownerKey) === transcript.flushPending) {
-        flushers.delete(ownerKey);
-      }
+      const failures: unknown[] = [];
       try {
         transcript.unsubscribe();
-      } finally {
-        try {
-          unsubscribeChannel();
-        } finally {
-          writer.close();
-        }
+      } catch (error) {
+        failures.push(error);
       }
+      try {
+        unsubscribeChannel();
+      } catch (error) {
+        failures.push(error);
+      }
+      try {
+        writer.close();
+      } catch (error) {
+        failures.push(error);
+      }
+      if (flushers.get(ownerKey) !== transcript.flushPending) return;
+      if (failures.length === 0) {
+        flushers.delete(ownerKey);
+        return;
+      }
+      const failure =
+        failures.length === 1
+          ? failures[0]
+          : new AggregateError(failures, 'Run trace cleanup failed');
+      const handoffFailure = (): void => {
+        if (flushers.get(ownerKey) === handoffFailure) {
+          flushers.delete(ownerKey);
+        }
+        throw failure;
+      };
+      flushers.set(ownerKey, handoffFailure);
     },
   };
 }


### PR DESCRIPTION
## Summary

- return compromised filesystem locks through the owning promise instead of throwing from a renewal timer
- serialize same-process lock users and use the execution-liveness horizon for stale-lock recovery
- replace broad lease-held artifact flushes with short ownership validations around session durability
- coalesce concurrent session flushes and remove the process-global transcript flusher registry
- give each live transcript an explicit, exact writer capability and defer eviction until its writer and durable writes have finished
- preserve suspended-run cleanup ordering while allowing independent terminal metadata to persist after transcript cleanup failure
- drain all session trace writers and runtime owners before surfacing teardown failures

## Root cause

The previous lifecycle distributed ownership among the filesystem lock library, a process-global flusher registry, execution leases, transcript timers, and view-driven eviction. A delayed lock-renewal failure could therefore throw outside the promise that acquired the lock and terminate Node. At the same time, independent finalizers could repeat whole-session flushes while holding a cross-process lease lock, and a view could evict transcript entries while a delayed writer still regarded the stream as live.

This change makes the ownership relations explicit:

1. one local mutex serializes each canonical filesystem lock path;
2. one single-flight heartbeat owns lease renewal for an execution;
3. one session owns its flusher set and coalesced durability batches;
4. one logical execution owns a transcript writer capability;
5. the store alone decides when a requested eviction is safe.

The result uses fewer global coordination elements and has one promise boundary for each asynchronous failure.

## Review follow-up

The review found three additional races, all now covered by regressions:

- an eviction requested during a sequential multi-stream flush could remove a later stream before its write began
- failed suspended-run transcript cleanup could prevent the independent terminal execution record from being persisted
- one latched trace failure could prevent later trace drains and runtime-owner teardown

The final head review passes and all review threads are resolved.

## Verification

- full Vitest suite: 7010 passed, 4 skipped
- TypeScript checks for all workspaces
- ESLint: zero errors
- extension and webview compilation
- repository formatting hook
- diff whitespace check

The lint run reports one pre-existing warning in AgentCreatorToolCatalogParity.vitest.mts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches execution leases, transcript persistence, parallel-run shutdown, and suspended-run kill/resume—core runtime paths where ordering bugs could drop data or strand agents.
> 
> **Overview**
> **Runtime and transcript ownership** are reworked so parallel agents and background saves cannot fight over the same stream or exit early. Transcript mutation goes through per-execution **writers** (`acquireWriter` / `loadAndAcquireWriter`); hosts call **`requestEviction`** instead of dropping memory immediately, and eviction waits until writers and in-flight persistence finish. Run traces register **execution-keyed** flushers on the session only—the process-wide `flushPendingRunTraces` registry is removed; the CLI and launch paths flush via **`session.flushPendingTraces()`**.
> 
> **Session durability** batches artifact flushes (coalescing bursts), can flush **one execution’s** trace without repeating a full session drain, and **`dispose`** still tears down owners even when a trace flush throws.
> 
> **Execution leases** use **`renewOwnedExecutionLease`** at short boundaries instead of holding the lease across whole `flushArtifacts` calls. Heartbeats are single-flight; prolonged or compromised renewal can fence ownership. **Waiting** subagent stops now **await async cleanup** (including transcript `GROUP_END` via writers) before publishing cancellation and finalizing metadata; resume is blocked while termination is in progress, and a successor handle inherits a pending stop.
> 
> **File locks** add a per-path in-process mutex, a longer stale horizon aligned with lease liveness, and **`onCompromised`** so renewal failures reject through `runExclusive` instead of crashing the process.
> 
> **CLI / progress UI** wrap transcript sync in try/catch, treat **WAITING** hidden streams as evictable, and use **`isActivePhase`** for residency rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc177e4e6a41ce3750a7835f798ce466c2c90777. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->