### PR TITLE
fix: scope execution writes to lease owners

### DIFF
--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -1,4 +1,7 @@
-import type { OwnedExecutionLeaseScope } from '@agent/storage';
+import {
+  ExecutionLeaseLostError,
+  type OwnedExecutionLeaseScope,
+} from '@agent/storage';
 import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
@@ -224,11 +227,13 @@ export async function executeCliRequest(
       settleLeaseScope = resolve;
     },
   );
-  const disposeShutdownStatus = ownedExecutionId
-    ? tryPlatform()?.lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, async () => {
-        shutdownInterrupted = true;
-        const runWithOwnership = await leaseScopeReady;
-        if (!runWithOwnership) return;
+  let shutdownStatusFinalized: Promise<void> | undefined;
+  const finalizeShutdownStatus = (): Promise<void> => {
+    if (!shutdownInterrupted || !ownedExecutionId) return Promise.resolve();
+    shutdownStatusFinalized ??= (async () => {
+      const runWithOwnership = await leaseScopeReady;
+      if (!runWithOwnership) return;
+      try {
         await runWithOwnership(() =>
           finalizeCliExecution(
             ownedExecutionId,
@@ -237,22 +242,18 @@ export async function executeCliRequest(
             reportShutdownFinalizationFailure,
           ),
         );
-      })
-    : undefined;
-  let shutdownStatusFinalized: Promise<void> | undefined;
-  const finalizeShutdownStatus = (): Promise<void> => {
-    shutdownStatusFinalized ??= (async () => {
-      if (shutdownInterrupted && ownedExecutionId) {
-        await finalizeCliExecution(
-          ownedExecutionId,
-          EXECUTION_STATUS.INTERRUPTED,
-          'preserve',
-          reportShutdownFinalizationFailure,
-        );
+      } catch (error) {
+        if (!(error instanceof ExecutionLeaseLostError)) throw error;
       }
     })();
     return shutdownStatusFinalized;
   };
+  const disposeShutdownStatus = ownedExecutionId
+    ? tryPlatform()?.lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, async () => {
+        shutdownInterrupted = true;
+        await finalizeShutdownStatus();
+      })
+    : undefined;
   const invoke = async (): Promise<ExecuteAgentResult> => {
     try {
       return await runAgent(request, {

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -1,3 +1,4 @@
+import type { OwnedExecutionLeaseScope } from '@agent/storage';
 import type { AgentConfigPayload } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
@@ -215,14 +216,26 @@ export async function executeCliRequest(
     shutdownFinalizationFailureReported = true;
     reportFinalizationFailure(error);
   };
+  let settleLeaseScope: (
+    scope: OwnedExecutionLeaseScope | undefined,
+  ) => void = () => undefined;
+  const leaseScopeReady = new Promise<OwnedExecutionLeaseScope | undefined>(
+    (resolve) => {
+      settleLeaseScope = resolve;
+    },
+  );
   const disposeShutdownStatus = ownedExecutionId
     ? tryPlatform()?.lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, async () => {
         shutdownInterrupted = true;
-        await finalizeCliExecution(
-          ownedExecutionId,
-          EXECUTION_STATUS.INTERRUPTED,
-          'preserve',
-          reportShutdownFinalizationFailure,
+        const runWithOwnership = await leaseScopeReady;
+        if (!runWithOwnership) return;
+        await runWithOwnership(() =>
+          finalizeCliExecution(
+            ownedExecutionId,
+            EXECUTION_STATUS.INTERRUPTED,
+            'preserve',
+            reportShutdownFinalizationFailure,
+          ),
         );
       })
     : undefined;
@@ -240,21 +253,31 @@ export async function executeCliRequest(
     })();
     return shutdownStatusFinalized;
   };
-  const invoke = (): Promise<ExecuteAgentResult> =>
-    runAgent(request, {
-      runtimeHost,
-      session,
-      enforceCategory: options.enforceCategory,
-      registerExecution: options.registerExecution,
-      openWorkflowOutput: options.openWorkflowOutput,
-      beforeLeaseRelease: finalizeShutdownStatus,
-      stopAfterCycle: options.stopAfterCycle,
-      approvalPromptsUnavailable: approvalPromptsUnavailable(runContext),
-      runtimeUnavailableTools: [
-        ...CLI_UNAVAILABLE_TOOLS,
-        ...(options.runtimeUnavailableTools ?? []),
-      ],
-    });
+  const invoke = async (): Promise<ExecuteAgentResult> => {
+    try {
+      return await runAgent(request, {
+        runtimeHost,
+        session,
+        enforceCategory: options.enforceCategory,
+        registerExecution: options.registerExecution,
+        openWorkflowOutput: options.openWorkflowOutput,
+        beforeLeaseRelease: finalizeShutdownStatus,
+        onExecutionLeaseAcquired: (runWithOwnership) => {
+          settleLeaseScope(runWithOwnership);
+        },
+        stopAfterCycle: options.stopAfterCycle,
+        approvalPromptsUnavailable: approvalPromptsUnavailable(runContext),
+        runtimeUnavailableTools: [
+          ...CLI_UNAVAILABLE_TOOLS,
+          ...(options.runtimeUnavailableTools ?? []),
+        ],
+      });
+    } finally {
+      // Unblock an in-flight shutdown when acquisition failed before a scope
+      // became available. Promise resolution is one-shot after success.
+      settleLeaseScope(undefined);
+    }
+  };
 
   let runResult:
     | { readonly ok: true; readonly result: ExecuteAgentResult }

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -9,13 +9,13 @@ import {
   type ResolvedAgent,
 } from '@agent/index';
 import {
+  createChannelTrace,
   logSdkError,
   logUserMessage,
   type AgentTrace,
   type StageHandle,
 } from '@agent/trace';
 import { getExecutionStore } from '@agent/storage';
-import { createChannelTrace } from '@agent/trace';
 import type { AgentCore } from '@agent/core/flows/BaseFlowServices';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -9,6 +9,7 @@ import { createChannelTrace } from '@agent/trace';
 import {
   markOwnedExecutionLeaseUndurable,
   onOwnedExecutionLeaseLost,
+  tryCaptureOwnedExecutionLease,
 } from '@agent/storage/executionLease';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
@@ -321,6 +322,10 @@ export async function runFlowWithLifecycle(
     runtimeHost,
     ctx.logger,
   );
+  const executionLeaseScope = tryCaptureOwnedExecutionLease(executionId);
+  if (executionLeaseScope) {
+    handle.attachExecutionLeaseScope(executionLeaseScope);
+  }
   handle.enablePendingInterrupt();
   session.executions.track(handle);
   let leaseLost = false;

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -9,7 +9,7 @@ import { createChannelTrace } from '@agent/trace';
 import {
   markOwnedExecutionLeaseUndurable,
   onOwnedExecutionLeaseLost,
-  tryCaptureOwnedExecutionLease,
+  captureOwnedExecutionLeaseIfPresent,
 } from '@agent/storage/executionLease';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
@@ -322,7 +322,7 @@ export async function runFlowWithLifecycle(
     runtimeHost,
     ctx.logger,
   );
-  const executionLeaseScope = tryCaptureOwnedExecutionLease(executionId);
+  const executionLeaseScope = captureOwnedExecutionLeaseIfPresent(executionId);
   if (executionLeaseScope) {
     handle.attachExecutionLeaseScope(executionLeaseScope);
   }

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -8,6 +8,7 @@
 import pDefer from 'p-defer';
 
 import type { AgentTrace, ResultEvent } from '@agent/trace';
+import type { OwnedExecutionLeaseScope } from '@agent/storage/executionLease';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { FollowUpQueueInput } from '@agent/followUp/FollowUpQueue';
@@ -86,6 +87,7 @@ export class AgentExecutionHandle implements ExecutionHandle {
   private waitingCleanupCompletion: Promise<void> = Promise.resolve();
   private _waitingTerminationStarted = false;
   private _executionLeaseLost = false;
+  private executionLeaseScope?: OwnedExecutionLeaseScope;
 
   /** Stable tool name for UI identification (e.g. "bash", "codex"). */
   toolName?: string;
@@ -230,6 +232,20 @@ export class AgentExecutionHandle implements ExecutionHandle {
 
   get executionLeaseLost(): boolean {
     return this._executionLeaseLost;
+  }
+
+  /** Bind deferred handle-owned work to the lease generation that created it. */
+  attachExecutionLeaseScope(scope: OwnedExecutionLeaseScope): void {
+    this.executionLeaseScope = scope;
+  }
+
+  /** Re-enter the creating lease generation from an external lifecycle call. */
+  runWithExecutionLease<T>(operation: () => T | Promise<T>): T | Promise<T> {
+    // Some in-memory/embedder runs deliberately have no durable lease. Their
+    // storage writes still pass through the execution-store write fence.
+    return this.executionLeaseScope
+      ? this.executionLeaseScope(operation)
+      : operation();
   }
 
   /**

--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -505,6 +505,9 @@ export function startChildRunLoop<TTurn>(
   // own run trace inside `runFlowWithLifecycle`), so this is a channel-only
   // fallback for the loop's own turn-summary/warning lines.
   const logger = childStream?.logger ?? createChannelTrace('childRunLoop');
+  // The code below is synchronous until the scoped loop task is spawned, so a
+  // lost generation fails before any queue, listener, stage, or loop exists.
+  runWithOwnedExecutionLease(executionId, () => undefined);
 
   const runSession = currentSession();
   const loop = new ChildRunInterruptible(runSession, childStreamId);

--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -14,6 +14,7 @@ import { createChannelTrace } from '@agent/trace';
 import {
   markOwnedExecutionLeaseUndurable,
   onOwnedExecutionLeaseLost,
+  runWithOwnedExecutionLease,
 } from '@agent/storage/executionLease';
 import {
   currentSession,
@@ -570,7 +571,7 @@ export function startChildRunLoop<TTurn>(
   // (#8093). Interim (non-terminal) turns wake inline, immediately, since no
   // finalize is pending for them.
   let pendingDelivery: PendingChildDelivery | undefined;
-  void (async () => {
+  void runWithOwnedExecutionLease(executionId, async () => {
     let runner: (ac: AbortController) => Promise<TTurn> = (ac) =>
       strategy.launch(ports, ac);
     try {
@@ -760,5 +761,5 @@ export function startChildRunLoop<TTurn>(
         }
       }
     }
-  })();
+  });
 }

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -24,6 +24,7 @@ import { hasPersistedParent } from '@agent/storage/executionLifecycle';
 import {
   abandonOwnedExecutionLease,
   acquireResumedExecutionLease,
+  captureOwnedExecutionLease,
   completeOwnedExecutionLease,
   releaseOwnedExecutionLeaseAfterFailure,
 } from '@agent/storage/executionLease';
@@ -351,12 +352,12 @@ export interface ExecuteAgentOptions extends SubagentRunOptions {
 
 export function executeAgent(
   config: AgentConfig,
-  executionId: ExecutionId | undefined,
+  executionId: ExecutionId,
   options: ExecuteAgentOptions & { allowWaitingResult: true },
 ): Promise<AgentFlowResult | WaitingToolUseFlowResult>;
 export function executeAgent(
   config: AgentConfig,
-  executionId: ExecutionId | undefined,
+  executionId: ExecutionId,
   options: ExecuteAgentOptions & { allowWaitingResult?: false | undefined },
 ): Promise<AgentFlowResult>;
 
@@ -368,96 +369,102 @@ export function executeAgent(
  */
 export async function executeAgent(
   config: AgentConfig,
-  executionId: ExecutionId | undefined,
+  executionId: ExecutionId,
   options: ExecuteAgentOptions,
 ): Promise<AgentRuntimeFlowResult> {
   if (options == null || options.runtimeHost == null) {
     throw new Error('executeAgent requires an explicit runtimeHost');
   }
 
-  const { runtimeHost } = options;
-  const ctx = await buildAgentLaunchContext({
-    config,
-    executionId,
-    runtimeHost,
-    onBeforeActivation: options.onStreamResolved,
-    enforceCategory: options.enforceCategory,
-    suppressErrorNotification: options.isSubagent,
-    session: options.session,
-    modelHandlerCompatibilityKey: options.modelHandlerCompatibilityKey,
-  });
-  const runContextOptions = {
-    approvalPromptsUnavailable: options.approvalPromptsUnavailable,
-    runtimeUnavailableTools: options.runtimeUnavailableTools,
-    stopAfterCycle: options.stopAfterCycle,
-  };
-  return withExecutionRunContext(ctx, runContextOptions, async () => {
-    const { setting, config } = ctx;
-    const {
-      streamId: runStreamId,
-      executionId: runExecutionId,
-      session: runSession,
-      runtimeHost: runRuntimeHost,
-    } = ctx.runScope;
-    const { isSubagent } = options;
-
-    // Start description generation concurrently with the run, but join it
-    // before the owner can release its execution lease. This prevents the
-    // metadata write from recreating an execution deleted by another host.
-    const sessionDescription = generateSessionDescription(
-      runExecutionId,
-      runStreamId,
+  const runWithOwnership = captureOwnedExecutionLease(executionId);
+  return await runWithOwnership(async () => {
+    const { runtimeHost } = options;
+    const ctx = await buildAgentLaunchContext({
       config,
-      runSession,
-    );
-    try {
-      const result = await runFlowWithLifecycle(
-        ctx,
-        async (handle, lifecycle) => {
-          // Pre-execution UI setup (RUNNING is set by runFlowWithLifecycle)
-          if (executionId) await ensureRunDir(executionId);
-          logger.info(`Starting task execution (streamId: ${runStreamId})`);
-          logger.info(`Input file: ${config.inputFiles[0] ?? '(none)'}`);
-          logger.debug('Task execution details', {
-            data: {
-              streamId: runStreamId,
-              agent: config.agent,
-              model: config.model,
-            },
-          });
-          logger.debug(`Output files: ${config.outputFiles?.length ?? 0}`);
-          // Subagents don't need to force-open the progress board or show notifications —
-          // the orchestrator's stream is already visible.
-          if (!isSubagent) {
-            runRuntimeHost.emit('requestEnsureProgressView', {
-              fallbackNotification: buildFallbackNotification(config),
-            });
-          }
-          logger.info('Executing agent', {
-            data: { agent: config.agent, model: config.model },
-          });
+      executionId,
+      runtimeHost,
+      onBeforeActivation: options.onStreamResolved,
+      enforceCategory: options.enforceCategory,
+      suppressErrorNotification: options.isSubagent,
+      session: options.session,
+      modelHandlerCompatibilityKey: options.modelHandlerCompatibilityKey,
+    });
+    const runContextOptions = {
+      approvalPromptsUnavailable: options.approvalPromptsUnavailable,
+      runtimeUnavailableTools: options.runtimeUnavailableTools,
+      stopAfterCycle: options.stopAfterCycle,
+    };
+    return withExecutionRunContext(ctx, runContextOptions, async () => {
+      const { setting, config } = ctx;
+      const {
+        streamId: runStreamId,
+        executionId: runExecutionId,
+        session: runSession,
+        runtimeHost: runRuntimeHost,
+      } = ctx.runScope;
+      const { isSubagent } = options;
 
-          if (setting.agentCategory === AgentCategory.ToolUse) {
-            return runToolUseAgent(ctx, handle, lifecycle, setting, options);
-          }
-          return runReflectionAgent(ctx, handle, setting);
-        },
-        {
-          isSubagent,
-          parentStreamId: options.parentStreamId,
-          onError: options.onRunError,
-          onRun: options.onRun,
-        },
+      // Start description generation concurrently with the run, but join it
+      // before the owner can release its execution lease. This prevents the
+      // metadata write from recreating an execution deleted by another host.
+      const sessionDescription = generateSessionDescription(
+        runExecutionId,
+        runStreamId,
+        config,
+        runSession,
       );
-      if (isWaitingFlowResult(result) && options.allowWaitingResult !== true) {
-        throw new Error(
-          'executeAgent received a non-terminal WAITING result without allowWaitingResult.',
+      try {
+        const result = await runFlowWithLifecycle(
+          ctx,
+          async (handle, lifecycle) => {
+            // Pre-execution UI setup (RUNNING is set by runFlowWithLifecycle)
+            await ensureRunDir(executionId);
+            logger.info(`Starting task execution (streamId: ${runStreamId})`);
+            logger.info(`Input file: ${config.inputFiles[0] ?? '(none)'}`);
+            logger.debug('Task execution details', {
+              data: {
+                streamId: runStreamId,
+                agent: config.agent,
+                model: config.model,
+              },
+            });
+            logger.debug(`Output files: ${config.outputFiles?.length ?? 0}`);
+            // Subagents don't need to force-open the progress board or show notifications —
+            // the orchestrator's stream is already visible.
+            if (!isSubagent) {
+              runRuntimeHost.emit('requestEnsureProgressView', {
+                fallbackNotification: buildFallbackNotification(config),
+              });
+            }
+            logger.info('Executing agent', {
+              data: { agent: config.agent, model: config.model },
+            });
+
+            if (setting.agentCategory === AgentCategory.ToolUse) {
+              return runToolUseAgent(ctx, handle, lifecycle, setting, options);
+            }
+            return runReflectionAgent(ctx, handle, setting);
+          },
+          {
+            isSubagent,
+            parentStreamId: options.parentStreamId,
+            onError: options.onRunError,
+            onRun: options.onRun,
+          },
         );
+        if (
+          isWaitingFlowResult(result) &&
+          options.allowWaitingResult !== true
+        ) {
+          throw new Error(
+            'executeAgent received a non-terminal WAITING result without allowWaitingResult.',
+          );
+        }
+        return result;
+      } finally {
+        await sessionDescription;
       }
-      return result;
-    } finally {
-      await sessionDescription;
-    }
+    });
   });
 }
 
@@ -500,130 +507,133 @@ export async function resumeToolUseFromResumeData(
   if (lease === 'cancelled') {
     throw new ResumeAdmissionCancelledError(resume.executionId);
   }
-  const modelHandlerCompatibilityKey =
-    resume.shared.modelHandlerCompatibilityKey ??
-    inferAndLogPersistedModelHandlerCompatibilityKey(
-      resume.agentConfig.model,
-      resume.shared.messages,
-      logger,
-    );
-  // Resolve persisted lineage before launch assembly activates the stream and
-  // transfers its resources. Storage failures must propagate without leaving
-  // an activated resume stream outside lifecycle cleanup.
-  let isSubagent: boolean;
-  let ctx: AgentLaunchContext;
-  try {
-    isSubagent = await hasPersistedParent(resume.executionId);
-    ctx = await buildAgentLaunchContext({
-      config: resume.agentConfig,
-      executionId: resume.executionId,
-      runtimeHost,
-      streamTabIdOverride: resume.streamId,
-      modelHandlerCompatibilityKey,
-      // resumeCommand surfaces its own warning toast on failure; skip the
-      // bus-level error to avoid double-notifying.
-      suppressErrorNotification: true,
-      session: options.session,
-    });
-  } catch (error) {
-    throw await releaseOwnedExecutionLeaseAfterFailure(
-      resume.executionId,
-      error,
-    );
-  }
-  const runContextOptions = {
-    approvalPromptsUnavailable: options.approvalPromptsUnavailable,
-    runtimeUnavailableTools: options.runtimeUnavailableTools,
-  };
-  const { setting } = ctx;
-  const {
-    streamId: runStreamId,
-    executionId: runExecutionId,
-    session: runSession,
-  } = ctx.runScope;
-
-  try {
-    const result = await withExecutionRunContext(
-      ctx,
-      runContextOptions,
-      async () => {
-        if (setting.agentCategory !== AgentCategory.ToolUse) {
-          // Keep this historical diagnostic byte-for-byte for external monitors.
-          throw new AgentError(
-            'Attempted to resume a non tool-use agent with resumeToolUseFromSnapshot.',
-          );
-        }
-
-        await runSession.transcripts.ensureLoaded(runStreamId);
-
-        const result = await runFlowWithLifecycle(
-          ctx,
-          async (handle, lifecycle) => {
-            const result = await runToolUseFlow(
-              {
-                ...ctx,
-                ...createInterruptCallbacks(),
-                onRoundFinalized: createUsageRecordingCallback(ctx),
-                setting,
-                resume,
-                drainedFollowUps: options.drainedFollowUps,
-                takePendingFollowUps: options.takePendingFollowUps,
-                // A persisted parent marks this execution as a subagent. Without
-                // this, the rebuilt system prompt would drop subagent-specific
-                // instructions (e.g. the shared /memories protocol) that the fresh
-                // run had included.
-                isSubagent,
-                onProgress: options.onProgress,
-                onFollowUpConsumed: wrapOnFollowUpConsumed(
-                  ctx,
-                  options.onFollowUpConsumed,
-                ),
-                onFlowRecordDisposition: (disposition) =>
-                  lifecycle.setFlowRecordDisposition(disposition),
-              },
-              undefined,
-              (flowContext) => {
-                handle.attachToolUseFlow(flowContext);
-                if (options.isCancellationRequested?.()) {
-                  options.onCancellationAtFlowAttachment?.();
-                  flowContext.interrupt();
-                }
-                return () => handle.detachToolUseFlow(flowContext);
-              },
-            );
-            return buildToolUseFlowResult(
-              result,
-              runExecutionId,
-              runStreamId,
-              ctx.attachedMemoryMisses,
-            );
-          },
-          {
-            isSubagent,
-            parentStreamId: options.parentStreamId,
-            onError: options.onRunError,
-            onRun: options.onRun,
-          },
-        );
-        return result;
-      },
-    );
-    if (!isWaitingFlowResult(result)) {
-      await flushOwnedExecutionArtifacts(runSession, resume.executionId);
-      await completeOwnedExecutionLease(resume.executionId);
-    }
-    return result;
-  } catch (error) {
+  const runWithOwnership = captureOwnedExecutionLease(resume.executionId);
+  return await runWithOwnership(async () => {
+    const modelHandlerCompatibilityKey =
+      resume.shared.modelHandlerCompatibilityKey ??
+      inferAndLogPersistedModelHandlerCompatibilityKey(
+        resume.agentConfig.model,
+        resume.shared.messages,
+        logger,
+      );
+    // Resolve persisted lineage before launch assembly activates the stream and
+    // transfers its resources. Storage failures must propagate without leaving
+    // an activated resume stream outside lifecycle cleanup.
+    let isSubagent: boolean;
+    let ctx: AgentLaunchContext;
     try {
-      await flushOwnedExecutionArtifacts(runSession, resume.executionId);
-    } catch (artifactError) {
-      abandonOwnedExecutionLease(resume.executionId);
-      throw new AggregateError(
-        [error, artifactError],
-        `Execution ${resume.executionId} failed and its final artifacts could not be persisted`,
+      isSubagent = await hasPersistedParent(resume.executionId);
+      ctx = await buildAgentLaunchContext({
+        config: resume.agentConfig,
+        executionId: resume.executionId,
+        runtimeHost,
+        streamTabIdOverride: resume.streamId,
+        modelHandlerCompatibilityKey,
+        // resumeCommand surfaces its own warning toast on failure; skip the
+        // bus-level error to avoid double-notifying.
+        suppressErrorNotification: true,
+        session: options.session,
+      });
+    } catch (error) {
+      throw await releaseOwnedExecutionLeaseAfterFailure(
+        resume.executionId,
+        error,
       );
     }
-    await completeOwnedExecutionLease(resume.executionId);
-    throw error;
-  }
+    const runContextOptions = {
+      approvalPromptsUnavailable: options.approvalPromptsUnavailable,
+      runtimeUnavailableTools: options.runtimeUnavailableTools,
+    };
+    const { setting } = ctx;
+    const {
+      streamId: runStreamId,
+      executionId: runExecutionId,
+      session: runSession,
+    } = ctx.runScope;
+
+    try {
+      const result = await withExecutionRunContext(
+        ctx,
+        runContextOptions,
+        async () => {
+          if (setting.agentCategory !== AgentCategory.ToolUse) {
+            // Keep this historical diagnostic byte-for-byte for external monitors.
+            throw new AgentError(
+              'Attempted to resume a non tool-use agent with resumeToolUseFromSnapshot.',
+            );
+          }
+
+          await runSession.transcripts.ensureLoaded(runStreamId);
+
+          const result = await runFlowWithLifecycle(
+            ctx,
+            async (handle, lifecycle) => {
+              const result = await runToolUseFlow(
+                {
+                  ...ctx,
+                  ...createInterruptCallbacks(),
+                  onRoundFinalized: createUsageRecordingCallback(ctx),
+                  setting,
+                  resume,
+                  drainedFollowUps: options.drainedFollowUps,
+                  takePendingFollowUps: options.takePendingFollowUps,
+                  // A persisted parent marks this execution as a subagent. Without
+                  // this, the rebuilt system prompt would drop subagent-specific
+                  // instructions (e.g. the shared /memories protocol) that the fresh
+                  // run had included.
+                  isSubagent,
+                  onProgress: options.onProgress,
+                  onFollowUpConsumed: wrapOnFollowUpConsumed(
+                    ctx,
+                    options.onFollowUpConsumed,
+                  ),
+                  onFlowRecordDisposition: (disposition) =>
+                    lifecycle.setFlowRecordDisposition(disposition),
+                },
+                undefined,
+                (flowContext) => {
+                  handle.attachToolUseFlow(flowContext);
+                  if (options.isCancellationRequested?.()) {
+                    options.onCancellationAtFlowAttachment?.();
+                    flowContext.interrupt();
+                  }
+                  return () => handle.detachToolUseFlow(flowContext);
+                },
+              );
+              return buildToolUseFlowResult(
+                result,
+                runExecutionId,
+                runStreamId,
+                ctx.attachedMemoryMisses,
+              );
+            },
+            {
+              isSubagent,
+              parentStreamId: options.parentStreamId,
+              onError: options.onRunError,
+              onRun: options.onRun,
+            },
+          );
+          return result;
+        },
+      );
+      if (!isWaitingFlowResult(result)) {
+        await flushOwnedExecutionArtifacts(runSession, resume.executionId);
+        await completeOwnedExecutionLease(resume.executionId);
+      }
+      return result;
+    } catch (error) {
+      try {
+        await flushOwnedExecutionArtifacts(runSession, resume.executionId);
+      } catch (artifactError) {
+        abandonOwnedExecutionLease(resume.executionId);
+        throw new AggregateError(
+          [error, artifactError],
+          `Execution ${resume.executionId} failed and its final artifacts could not be persisted`,
+        );
+      }
+      await completeOwnedExecutionLease(resume.executionId);
+      throw error;
+    }
+  });
 }

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -12,6 +12,7 @@ import {
 import { createChannelTrace, type ResultEvent } from '@agent/trace';
 import {
   completeOwnedExecutionLease,
+  ExecutionLeaseLostError,
   markOwnedExecutionLeaseUndurable,
 } from '@agent/storage/executionLease';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
@@ -969,37 +970,44 @@ export class ExecutionRegistry {
       isSubagent: handle.isChildExecution,
     };
     void this.finishWaitingTermination(handle, cancelledResult).catch(
-      (error: unknown) => {
+      async (error: unknown) => {
         const recoveryFailures = [error];
-        try {
-          markOwnedExecutionLeaseUndurable(handle.executionId);
-        } catch (recoveryError) {
-          recoveryFailures.push(recoveryError);
+        if (!(error instanceof ExecutionLeaseLostError)) {
+          try {
+            await handle.runWithExecutionLease(async () => {
+              markOwnedExecutionLeaseUndurable(handle.executionId);
+              handle.settleResult(cancelledResult);
+              const untracked = this.untrackIfCurrent(handle);
+              if (untracked) {
+                this.cancelStreamStatus(handle.childStreamId, handle);
+              }
+              if (untracked && !handle.isChildExecution) {
+                await this.releaseRootExecutionLease(handle.executionId);
+              }
+            });
+            logger.warn('Waiting-execution termination failed unexpectedly', {
+              data: { executionId: handle.executionId, recoveryFailures },
+            });
+            return;
+          } catch (recoveryError) {
+            recoveryFailures.push(recoveryError);
+          }
         }
+
+        // A former generation owns only its private result. It must not mark,
+        // release, untrack, or cancel a locally reacquired successor.
         try {
           handle.settleResult(cancelledResult);
         } catch (recoveryError) {
           recoveryFailures.push(recoveryError);
         }
         try {
-          this.untrackIfCurrent(handle);
+          const untracked = this.untrackIfCurrent(handle);
+          if (untracked) {
+            this.cancelStreamStatus(handle.childStreamId, handle);
+          }
         } catch (recoveryError) {
           recoveryFailures.push(recoveryError);
-        }
-        try {
-          this.cancelStreamStatus(handle.childStreamId, handle);
-        } catch (recoveryError) {
-          recoveryFailures.push(recoveryError);
-        }
-        if (!handle.isChildExecution) {
-          void this.releaseRootExecutionLease(handle.executionId).catch(
-            (recoveryError: unknown) => {
-              logger.warn(
-                'Waiting-execution recovery could not release ownership',
-                { data: { executionId: handle.executionId, recoveryError } },
-              );
-            },
-          );
         }
         logger.warn('Waiting-execution termination failed unexpectedly', {
           data: { executionId: handle.executionId, recoveryFailures },

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -1013,93 +1013,95 @@ export class ExecutionRegistry {
     handle: AgentExecutionHandle,
     cancelledResult: ResultEvent,
   ): Promise<void> {
-    try {
-      await handle.waitForWaitingCleanup();
-    } catch (error) {
-      // Transcript closure and terminal execution metadata are independent
-      // durable facts. Preserve the failed artifact fence, but still give the
-      // terminal status its own opportunity to reach disk.
-      markOwnedExecutionLeaseUndurable(handle.executionId);
-      logger.warn(
-        'Waiting-execution cleanup failed; continuing terminal persistence',
-        { data: { executionId: handle.executionId, error } },
-      );
-    }
+    return await handle.runWithExecutionLease(async () => {
+      try {
+        await handle.waitForWaitingCleanup();
+      } catch (error) {
+        // Transcript closure and terminal execution metadata are independent
+        // durable facts. Preserve the failed artifact fence, but still give the
+        // terminal status its own opportunity to reach disk.
+        markOwnedExecutionLeaseUndurable(handle.executionId);
+        logger.warn(
+          'Waiting-execution cleanup failed; continuing terminal persistence',
+          { data: { executionId: handle.executionId, error } },
+        );
+      }
 
-    if (this.handles.get(handle.executionId) !== handle) {
-      // `track` transfers the pending stop to a resumed successor. The old
-      // handle still needs its private result settled, but it no longer owns
-      // the shared stream, execution metadata, or lease.
-      handle.settleResult(cancelledResult);
-      return;
-    }
+      if (this.handles.get(handle.executionId) !== handle) {
+        // `track` transfers the pending stop to a resumed successor. The old
+        // handle still needs its private result settled, but it no longer owns
+        // the shared stream, execution metadata, or lease.
+        handle.settleResult(cancelledResult);
+        return;
+      }
 
-    if (handle.executionLeaseLost) {
-      logger.warn('Discarding a stopped waiting execution after lease loss', {
-        data: { executionId: handle.executionId },
-      });
-      // Settle the in-memory result only: the former owner must not publish or
-      // persist a terminal event, but this promise must resolve on every exit.
+      if (handle.executionLeaseLost) {
+        logger.warn('Discarding a stopped waiting execution after lease loss', {
+          data: { executionId: handle.executionId },
+        });
+        // Settle the in-memory result only: the former owner must not publish or
+        // persist a terminal event, but this promise must resolve on every exit.
+        handle.settleResult(cancelledResult);
+        this.untrackHandle(handle);
+        this.cancelStreamStatus(handle.childStreamId, handle);
+        return;
+      }
+
+      // Cleanup closes the suspended run's transcript group. Publish the
+      // terminal state only after that owned artifact is settled so every host
+      // observes one coherent cancellation boundary.
+      handle.trace?.emit(cancelledResult);
+      this.publishResult?.(cancelledResult, handle.childStreamId);
       handle.settleResult(cancelledResult);
       this.untrackHandle(handle);
       this.cancelStreamStatus(handle.childStreamId, handle);
-      return;
-    }
 
-    // Cleanup closes the suspended run's transcript group. Publish the
-    // terminal state only after that owned artifact is settled so every host
-    // observes one coherent cancellation boundary.
-    handle.trace?.emit(cancelledResult);
-    this.publishResult?.(cancelledResult, handle.childStreamId);
-    handle.settleResult(cancelledResult);
-    this.untrackHandle(handle);
-    this.cancelStreamStatus(handle.childStreamId, handle);
-
-    // No later result write is guaranteed here, including during RESUMING:
-    // the resume can fail before installing its own handle, while this method
-    // has already untracked the suspended one. Align the interim envelope only
-    // after durable terminal metadata exists. A turn that does continue will
-    // replace it with its own result.
-    try {
-      const result = await finalizeExecution({
-        executionId: handle.executionId,
-        terminalStatus: projectRunOutcome(RUN_OUTCOME.CANCELLED)
-          .executionStatus,
-        flowRecord: 'delete',
-      });
-      if (result.status === 'failed') {
-        markOwnedExecutionLeaseUndurable(handle.executionId);
-        logger.warn('Failed to finalize stopped waiting execution', {
-          data: {
-            executionId: handle.executionId,
-            stage: result.stage,
-            terminalStatusPersisted: result.terminalStatusPersisted,
-            error: result.error,
-          },
+      // No later result write is guaranteed here, including during RESUMING:
+      // the resume can fail before installing its own handle, while this method
+      // has already untracked the suspended one. Align the interim envelope only
+      // after durable terminal metadata exists. A turn that does continue will
+      // replace it with its own result.
+      try {
+        const result = await finalizeExecution({
+          executionId: handle.executionId,
+          terminalStatus: projectRunOutcome(RUN_OUTCOME.CANCELLED)
+            .executionStatus,
+          flowRecord: 'delete',
         });
-      }
-      if (result.terminalStatusPersisted) {
-        await synchronizeAgentResultOutcome(
-          handle.executionId,
-          RUN_OUTCOME.CANCELLED,
-        );
-      }
-    } catch (error) {
-      markOwnedExecutionLeaseUndurable(handle.executionId);
-      logger.warn('Waiting-execution finalizer rejected unexpectedly', {
-        data: { executionId: handle.executionId, error },
-      });
-    } finally {
-      if (!handle.isChildExecution) {
-        try {
-          await this.releaseRootExecutionLease(handle.executionId);
-        } catch (error) {
-          logger.warn('Waiting-execution artifact flush failed', {
-            data: { executionId: handle.executionId, error },
+        if (result.status === 'failed') {
+          markOwnedExecutionLeaseUndurable(handle.executionId);
+          logger.warn('Failed to finalize stopped waiting execution', {
+            data: {
+              executionId: handle.executionId,
+              stage: result.stage,
+              terminalStatusPersisted: result.terminalStatusPersisted,
+              error: result.error,
+            },
           });
         }
+        if (result.terminalStatusPersisted) {
+          await synchronizeAgentResultOutcome(
+            handle.executionId,
+            RUN_OUTCOME.CANCELLED,
+          );
+        }
+      } catch (error) {
+        markOwnedExecutionLeaseUndurable(handle.executionId);
+        logger.warn('Waiting-execution finalizer rejected unexpectedly', {
+          data: { executionId: handle.executionId, error },
+        });
+      } finally {
+        if (!handle.isChildExecution) {
+          try {
+            await this.releaseRootExecutionLease(handle.executionId);
+          } catch (error) {
+            logger.warn('Waiting-execution artifact flush failed', {
+              data: { executionId: handle.executionId, error },
+            });
+          }
+        }
       }
-    }
+    });
   }
 
   private streamStatusEmitOptions(

--- a/src/agent/runtime/runAgent.ts
+++ b/src/agent/runtime/runAgent.ts
@@ -5,7 +5,11 @@ import {
   finalizeExecution,
   registerExecution,
 } from '@agent/storage';
-import { markOwnedExecutionLeaseUndurable } from '@agent/storage/executionLease';
+import {
+  captureOwnedExecutionLease,
+  markOwnedExecutionLeaseUndurable,
+  type OwnedExecutionLeaseScope,
+} from '@agent/storage/executionLease';
 
 import type { ValidatedExecutionRequest } from '@agent/core/state/executionRequests';
 import { EXECUTION_STATUS, type ExecutionId } from '@shared/schemas';
@@ -38,6 +42,8 @@ export interface RunAgentOptions extends Pick<
   openWorkflowOutput?: (result: WorkflowFlowResult) => Promise<void>;
   /** Persist host-owned final artifacts while this run still owns its lease. */
   beforeLeaseRelease?: () => Promise<void>;
+  /** Bind host callbacks that may run outside the agent's async context. */
+  onExecutionLeaseAcquired?: (scope: OwnedExecutionLeaseScope) => void;
   registerExecution?: boolean;
   /** Recheck canonical admission atomically while acquiring a resumed lease. */
   canAcquireResumeLease?: () => boolean;
@@ -72,6 +78,7 @@ export async function runAgent(
   const {
     openWorkflowOutput,
     beforeLeaseRelease,
+    onExecutionLeaseAcquired,
     registerExecution: registerExecutionOption,
     canAcquireResumeLease,
     preferHelperModel,
@@ -109,93 +116,97 @@ export async function runAgent(
     }
   }
 
-  let lifecycleStarted = false;
-  let runResult: AgentFlowResult | undefined;
-  let runFailure: { error: unknown } | undefined;
-  let artifactsDurable = false;
-  const callerOnRun = executeAgentOptions.onRun;
-  try {
+  const runWithOwnership = captureOwnedExecutionLease(executionId);
+  onExecutionLeaseAcquired?.(runWithOwnership);
+  return await runWithOwnership(async () => {
+    let lifecycleStarted = false;
+    let runResult: AgentFlowResult | undefined;
+    let runFailure: { error: unknown } | undefined;
+    let artifactsDurable = false;
+    const callerOnRun = executeAgentOptions.onRun;
     try {
-      const result = await executeAgent(config, executionId, {
-        ...executeAgentOptions,
-        onRun: async (handle) => {
-          lifecycleStarted = true;
-          await callerOnRun?.(handle);
-        },
-      });
-      if (result.category === 'workflow') {
-        await openWorkflowOutput?.(result);
-      }
-      runResult = result;
-    } catch (error) {
-      runFailure = { error };
-      if (shouldRegister && !lifecycleStarted) {
-        try {
-          const finalization = await finalizeExecution({
-            executionId,
-            terminalStatus: EXECUTION_STATUS.ERROR,
-            flowRecord: 'delete',
-          });
-          if (finalization.status === 'failed') {
+      try {
+        const result = await executeAgent(config, executionId, {
+          ...executeAgentOptions,
+          onRun: async (handle) => {
+            lifecycleStarted = true;
+            await callerOnRun?.(handle);
+          },
+        });
+        if (result.category === 'workflow') {
+          await openWorkflowOutput?.(result);
+        }
+        runResult = result;
+      } catch (error) {
+        runFailure = { error };
+        if (shouldRegister && !lifecycleStarted) {
+          try {
+            const finalization = await finalizeExecution({
+              executionId,
+              terminalStatus: EXECUTION_STATUS.ERROR,
+              flowRecord: 'delete',
+            });
+            if (finalization.status === 'failed') {
+              markOwnedExecutionLeaseUndurable(executionId);
+              runFailure = {
+                error: new AggregateError(
+                  [error, finalization.error],
+                  `Execution ${executionId} failed before lifecycle startup and its error status could not be persisted`,
+                ),
+              };
+            }
+          } catch (finalizationError) {
             markOwnedExecutionLeaseUndurable(executionId);
             runFailure = {
               error: new AggregateError(
-                [error, finalization.error],
+                [error, finalizationError],
                 `Execution ${executionId} failed before lifecycle startup and its error status could not be persisted`,
               ),
             };
           }
-        } catch (finalizationError) {
-          markOwnedExecutionLeaseUndurable(executionId);
-          runFailure = {
-            error: new AggregateError(
-              [error, finalizationError],
-              `Execution ${executionId} failed before lifecycle startup and its error status could not be persisted`,
-            ),
-          };
         }
       }
-    }
 
-    const artifactFailures: unknown[] = [];
-    try {
-      await beforeLeaseRelease?.();
-    } catch (error) {
-      artifactFailures.push(error);
-    }
-    try {
-      await flushOwnedExecutionArtifacts(runSession, executionId);
-    } catch (error) {
-      artifactFailures.push(error);
-    }
-    artifactsDurable = artifactFailures.length === 0;
-    const artifactFailure =
-      artifactFailures.length === 1
-        ? artifactFailures[0]
-        : new AggregateError(
-            artifactFailures,
-            `Execution ${executionId} has multiple final artifact failures`,
-          );
-
-    if (runFailure) {
-      if (artifactFailures.length > 0) {
-        throw new AggregateError(
-          [runFailure.error, artifactFailure],
-          `Execution ${executionId} failed and its final artifacts could not be persisted`,
-        );
+      const artifactFailures: unknown[] = [];
+      try {
+        await beforeLeaseRelease?.();
+      } catch (error) {
+        artifactFailures.push(error);
       }
-      throw runFailure.error;
+      try {
+        await flushOwnedExecutionArtifacts(runSession, executionId);
+      } catch (error) {
+        artifactFailures.push(error);
+      }
+      artifactsDurable = artifactFailures.length === 0;
+      const artifactFailure =
+        artifactFailures.length === 1
+          ? artifactFailures[0]
+          : new AggregateError(
+              artifactFailures,
+              `Execution ${executionId} has multiple final artifact failures`,
+            );
+
+      if (runFailure) {
+        if (artifactFailures.length > 0) {
+          throw new AggregateError(
+            [runFailure.error, artifactFailure],
+            `Execution ${executionId} failed and its final artifacts could not be persisted`,
+          );
+        }
+        throw runFailure.error;
+      }
+      if (artifactFailures.length > 0) throw artifactFailure;
+      if (!runResult) {
+        throw new Error(`Execution ${executionId} finished without a result.`);
+      }
+      return runResult;
+    } finally {
+      if (artifactsDurable) {
+        await completeOwnedExecutionLease(executionId);
+      } else {
+        abandonOwnedExecutionLease(executionId);
+      }
     }
-    if (artifactFailures.length > 0) throw artifactFailure;
-    if (!runResult) {
-      throw new Error(`Execution ${executionId} finished without a result.`);
-    }
-    return runResult;
-  } finally {
-    if (artifactsDurable) {
-      await completeOwnedExecutionLease(executionId);
-    } else {
-      abandonOwnedExecutionLease(executionId);
-    }
-  }
+  });
 }

--- a/src/agent/storage/executionLease.ts
+++ b/src/agent/storage/executionLease.ts
@@ -415,6 +415,10 @@ export function captureOwnedExecutionLease(
 export function tryCaptureOwnedExecutionLease(
   executionId: ExecutionId,
 ): OwnedExecutionLeaseScope | undefined {
+  const key = ownershipKey(storageRoot(), executionId);
+  if (executionOwnership.getStore()?.has(key)) {
+    return captureOwnedExecutionLease(executionId);
+  }
   return ownsExecutionLease(executionId)
     ? captureOwnedExecutionLease(executionId)
     : undefined;

--- a/src/agent/storage/executionLease.ts
+++ b/src/agent/storage/executionLease.ts
@@ -411,6 +411,15 @@ export function captureOwnedExecutionLease(
   };
 }
 
+/** Capture ownership when this lifecycle is running under a leased execution. */
+export function tryCaptureOwnedExecutionLease(
+  executionId: ExecutionId,
+): OwnedExecutionLeaseScope | undefined {
+  return ownsExecutionLease(executionId)
+    ? captureOwnedExecutionLease(executionId)
+    : undefined;
+}
+
 /** Refresh and validate local ownership at a short durability boundary. */
 export async function renewOwnedExecutionLease(
   executionId: ExecutionId,

--- a/src/agent/storage/executionLease.ts
+++ b/src/agent/storage/executionLease.ts
@@ -56,6 +56,10 @@ export type ExecutionLeasePresence =
   | { readonly status: 'owned'; readonly heartbeatAt: number }
   | { readonly status: 'foreign'; readonly heartbeatAt: number };
 
+export type OwnedExecutionLeaseScope = <T>(
+  operation: () => T | Promise<T>,
+) => T | Promise<T>;
+
 export class ExecutionLeaseActiveError extends Error {
   constructor(
     readonly executionId: ExecutionId,
@@ -74,7 +78,7 @@ export class ExecutionLeaseLostError extends Error {
 }
 
 const ownedLeases = new Map<string, OwnedExecutionLease>();
-const fencedOwnershipKeys = new Set<string>();
+const executionOwnership = new AsyncLocalStorage<ReadonlyMap<string, string>>();
 const maintenanceExecutions = new AsyncLocalStorage<ReadonlySet<string>>();
 let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
 
@@ -84,6 +88,16 @@ function storageRoot(): string {
 
 function ownershipKey(root: string, executionId: ExecutionId): string {
   return `${root}\0${executionId}`;
+}
+
+/** Prevent an execution-owned continuation from acting on a later generation. */
+function currentScopeOwnsLease(lease: OwnedExecutionLease): boolean {
+  const ownership = executionOwnership.getStore();
+  return (
+    ownership === undefined ||
+    ownership.get(ownershipKey(lease.storageRoot, lease.executionId)) ===
+      lease.ownerToken
+  );
 }
 
 function leasePath(root: string, executionId: ExecutionId): string {
@@ -188,12 +202,11 @@ async function readPersistedExecutionLiveness(
 
 function forgetOwnedLease(
   lease: OwnedExecutionLease,
-  options: { notifyLoss?: boolean; fenceWrites?: boolean } = {},
+  options: { notifyLoss?: boolean } = {},
 ): void {
   const key = ownershipKey(lease.storageRoot, lease.executionId);
   if (ownedLeases.get(key) === lease) {
     ownedLeases.delete(key);
-    if (options.fenceWrites) fencedOwnershipKeys.add(key);
     lease.resolveReleased();
     if (options.notifyLoss) {
       for (const listener of lease.lossListeners) {
@@ -220,7 +233,7 @@ async function performHeartbeat(lease: OwnedExecutionLease): Promise<void> {
     async () => {
       const current = await readLease(lease.executionId, lease.storageRoot);
       if (current?.ownerToken !== lease.ownerToken) {
-        forgetOwnedLease(lease, { notifyLoss: true, fenceWrites: true });
+        forgetOwnedLease(lease, { notifyLoss: true });
         return;
       }
       await writeLease(
@@ -268,7 +281,7 @@ function handleHeartbeatFailure(
     hasErrorCode(error, 'ECOMPROMISED') ||
     Date.now() - lease.lastConfirmedHeartbeatAt > EXECUTION_LEASE_STALE_MS;
   if (ownershipUnprovable) {
-    forgetOwnedLease(lease, { notifyLoss: true, fenceWrites: true });
+    forgetOwnedLease(lease, { notifyLoss: true });
   }
   logger.warn(
     CHANNEL,
@@ -276,7 +289,7 @@ function handleHeartbeatFailure(
     {
       data: {
         error,
-        ownershipFenced: ownershipUnprovable,
+        ownershipLost: ownershipUnprovable,
       },
     },
   );
@@ -305,7 +318,6 @@ function rememberOwnership(
     durabilityFailed: false,
   };
   ownedLeases.set(ownershipKey(root, executionId), lease);
-  fencedOwnershipKeys.delete(ownershipKey(root, executionId));
   if (!heartbeatTimer) {
     heartbeatTimer = setInterval(() => {
       for (const owned of ownedLeases.values()) {
@@ -334,7 +346,9 @@ export function onOwnedExecutionLeaseLost(
 
 /** Whether this process still owns the lease in the active storage root. */
 export function ownsExecutionLease(executionId: ExecutionId): boolean {
-  return ownedLeases.has(ownershipKey(storageRoot(), executionId));
+  const key = ownershipKey(storageRoot(), executionId);
+  const lease = ownedLeases.get(key);
+  return lease !== undefined && currentScopeOwnsLease(lease);
 }
 
 async function runWithValidatedOwnership<T>(
@@ -346,7 +360,7 @@ async function runWithValidatedOwnership<T>(
     async () => {
       const current = await readLease(lease.executionId, lease.storageRoot);
       if (current?.ownerToken !== lease.ownerToken) {
-        forgetOwnedLease(lease, { notifyLoss: true, fenceWrites: true });
+        forgetOwnedLease(lease, { notifyLoss: true });
         throw new ExecutionLeaseLostError(lease.executionId);
       }
       return operation();
@@ -355,12 +369,55 @@ async function runWithValidatedOwnership<T>(
   );
 }
 
+/**
+ * Carry this process's exact lease generation through asynchronous run work.
+ * A continuation from a displaced owner keeps its original token and cannot
+ * borrow a later local owner's lease for the same execution id.
+ */
+export function runWithOwnedExecutionLease<T>(
+  executionId: ExecutionId,
+  operation: () => T | Promise<T>,
+): T | Promise<T> {
+  return captureOwnedExecutionLease(executionId)(operation);
+}
+
+/** Capture the current generation so a delayed lifecycle root cannot borrow its successor. */
+export function captureOwnedExecutionLease(
+  executionId: ExecutionId,
+): OwnedExecutionLeaseScope {
+  const root = storageRoot();
+  const key = ownershipKey(root, executionId);
+  const lease = ownedLeases.get(key);
+  if (!lease || lease.releasing) {
+    throw new ExecutionLeaseLostError(executionId);
+  }
+  const currentOwnership = executionOwnership.getStore();
+  const currentOwnerToken = currentOwnership?.get(key);
+  if (
+    currentOwnerToken !== undefined &&
+    currentOwnerToken !== lease.ownerToken
+  ) {
+    throw new ExecutionLeaseLostError(executionId);
+  }
+  const ownerToken = lease.ownerToken;
+  return <T>(operation: () => T | Promise<T>): T | Promise<T> => {
+    const currentLease = ownedLeases.get(key);
+    if (currentLease?.ownerToken !== ownerToken || currentLease.releasing) {
+      throw new ExecutionLeaseLostError(executionId);
+    }
+    const ownership = new Map(executionOwnership.getStore());
+    ownership.set(key, ownerToken);
+    return executionOwnership.run(ownership, operation);
+  };
+}
+
 /** Refresh and validate local ownership at a short durability boundary. */
 export async function renewOwnedExecutionLease(
   executionId: ExecutionId,
 ): Promise<void> {
-  const lease = ownedLeases.get(ownershipKey(storageRoot(), executionId));
-  if (!lease || lease.releasing) {
+  const key = ownershipKey(storageRoot(), executionId);
+  const lease = ownedLeases.get(key);
+  if (!lease || lease.releasing || !currentScopeOwnsLease(lease)) {
     throw new ExecutionLeaseLostError(executionId);
   }
   await heartbeat(lease);
@@ -381,14 +438,31 @@ export async function runWithExecutionLeaseWriteFence<T>(
   executionId: ExecutionId,
   operation: () => Promise<T>,
 ): Promise<T> {
-  const key = ownershipKey(storageRoot(), executionId);
+  const root = storageRoot();
+  const key = ownershipKey(root, executionId);
   if (maintenanceExecutions.getStore()?.has(key)) return operation();
   const lease = ownedLeases.get(key);
-  if (lease) return runWithValidatedOwnership(lease, operation);
-  if (fencedOwnershipKeys.has(key)) {
+  const ownerToken = executionOwnership.getStore()?.get(key);
+  if (lease && ownerToken === undefined) {
     throw new ExecutionLeaseLostError(executionId);
   }
-  return operation();
+  if (
+    ownerToken !== undefined &&
+    (lease?.ownerToken !== ownerToken || lease.releasing)
+  ) {
+    throw new ExecutionLeaseLostError(executionId);
+  }
+  if (lease) return runWithValidatedOwnership(lease, operation);
+  return withLeaseLock(
+    executionId,
+    async () => {
+      if (await readLease(executionId, root)) {
+        throw new ExecutionLeaseLostError(executionId);
+      }
+      return operation();
+    },
+    root,
+  );
 }
 
 function acquireExecutionLease(
@@ -467,7 +541,8 @@ export async function releaseOwnedExecutionLease(
   executionId: ExecutionId,
 ): Promise<void> {
   const ownerships = [...ownedLeases.values()].filter(
-    (lease) => lease.executionId === executionId,
+    (lease) =>
+      lease.executionId === executionId && currentScopeOwnsLease(lease),
   );
   await Promise.all(ownerships.map(releaseOwnership));
 }
@@ -480,7 +555,9 @@ export async function releaseOwnedExecutionLease(
 export function abandonOwnedExecutionLease(executionId: ExecutionId): void {
   const root = storageRoot();
   const lease = ownedLeases.get(ownershipKey(root, executionId));
-  if (lease) forgetOwnedLease(lease, { fenceWrites: true });
+  if (lease && currentScopeOwnsLease(lease)) {
+    forgetOwnedLease(lease);
+  }
 }
 
 /** Prevent release after a required execution artifact failed to persist. */
@@ -488,7 +565,9 @@ export function markOwnedExecutionLeaseUndurable(
   executionId: ExecutionId,
 ): void {
   const lease = ownedLeases.get(ownershipKey(storageRoot(), executionId));
-  if (lease) lease.durabilityFailed = true;
+  if (lease && currentScopeOwnsLease(lease)) {
+    lease.durabilityFailed = true;
+  }
 }
 
 /** Release a durable execution; otherwise stop renewal and retain its record. */
@@ -543,8 +622,6 @@ export async function waitForOwnedExecutionLeaseRelease(
 async function releaseOwnership(ownership: OwnedExecutionLease): Promise<void> {
   const root = ownership.storageRoot;
   const { executionId } = ownership;
-  let ownershipLost = false;
-  let releaseFailed = false;
   ownership.releasing = true;
   await ownership.heartbeatInFlight?.catch(() => undefined);
   if (ownedLeases.get(ownershipKey(root, executionId)) !== ownership) {
@@ -556,7 +633,6 @@ async function releaseOwnership(ownership: OwnedExecutionLease): Promise<void> {
       async () => {
         const current = await readLease(executionId, root);
         if (current?.ownerToken !== ownership.ownerToken) {
-          ownershipLost = true;
           return;
         }
         await StorageFS.delete(leasePath(root, executionId));
@@ -565,13 +641,10 @@ async function releaseOwnership(ownership: OwnedExecutionLease): Promise<void> {
     );
   } catch (error) {
     if (!isFileNotFoundError(error)) {
-      releaseFailed = true;
       throw error;
     }
   } finally {
-    forgetOwnedLease(ownership, {
-      fenceWrites: ownershipLost || releaseFailed,
-    });
+    forgetOwnedLease(ownership);
   }
 }
 
@@ -623,7 +696,7 @@ export async function runWithInactiveExecutionLease<T>(
         return { status: 'active', heartbeatAt: current.heartbeatAt };
       }
       if (local) {
-        forgetOwnedLease(local, { notifyLoss: true, fenceWrites: true });
+        forgetOwnedLease(local, { notifyLoss: true });
       }
       if (liveness.status === 'active') {
         return { status: 'active', heartbeatAt: liveness.heartbeatAt };

--- a/src/agent/storage/executionLease.ts
+++ b/src/agent/storage/executionLease.ts
@@ -411,8 +411,8 @@ export function captureOwnedExecutionLease(
   };
 }
 
-/** Capture ownership when this lifecycle is running under a leased execution. */
-export function tryCaptureOwnedExecutionLease(
+/** Return undefined only for an unleased run; stale ambient ownership throws. */
+export function captureOwnedExecutionLeaseIfPresent(
   executionId: ExecutionId,
 ): OwnedExecutionLeaseScope | undefined {
   const key = ownershipKey(storageRoot(), executionId);

--- a/src/agent/storage/executionLifecycle.ts
+++ b/src/agent/storage/executionLifecycle.ts
@@ -26,6 +26,7 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 import { getExecutionStore } from './ExecutionKVStore';
 import {
   acquireFreshExecutionLease,
+  captureOwnedExecutionLease,
   releaseOwnedExecutionLease,
 } from './executionLease';
 import { ResultMetaSchema } from './resultMeta';
@@ -123,54 +124,57 @@ export async function registerExecution(
   category?: string,
 ): Promise<void> {
   await acquireFreshExecutionLease(executionId);
-  try {
-    const timestamp = new Date().toISOString();
-    const store = getExecutionStore(executionId);
-    const meta = {
-      timestamp,
-      parentExecutionId,
-      ...(category ? { category } : {}),
-    };
-    const persistedConfig = normalizeWriterCategory(
-      pinExecutionWorkingDirectory(config),
-      agentName,
-    );
-
-    const writes: Promise<void>[] = [
-      store.writeConfig(persistedConfig),
-      store.writeMeta(meta),
-    ];
-    if (parentExecutionId) {
-      writes.push(
-        getExecutionStore(parentExecutionId).writeChild(executionId, {
-          agent: agentName,
-          timestamp,
-        }),
-      );
-    }
-
-    const results = await Promise.allSettled(writes);
-    const errors = results.flatMap((result) =>
-      result.status === 'rejected' ? [result.reason] : [],
-    );
-    if (errors.length === 1) throw errors[0];
-    if (errors.length > 1) {
-      throw new AggregateError(
-        errors,
-        `Multiple execution registration writes failed for ${executionId}`,
-      );
-    }
-  } catch (error) {
+  const runWithOwnership = captureOwnedExecutionLease(executionId);
+  await runWithOwnership(async () => {
     try {
-      await releaseOwnedExecutionLease(executionId);
-    } catch (releaseError) {
-      throw new AggregateError(
-        [error, releaseError],
-        `Execution registration and lease rollback failed for ${executionId}`,
+      const timestamp = new Date().toISOString();
+      const store = getExecutionStore(executionId);
+      const meta = {
+        timestamp,
+        parentExecutionId,
+        ...(category ? { category } : {}),
+      };
+      const persistedConfig = normalizeWriterCategory(
+        pinExecutionWorkingDirectory(config),
+        agentName,
       );
+
+      const writes: Promise<void>[] = [
+        store.writeConfig(persistedConfig),
+        store.writeMeta(meta),
+      ];
+      if (parentExecutionId) {
+        writes.push(
+          getExecutionStore(parentExecutionId).writeChild(executionId, {
+            agent: agentName,
+            timestamp,
+          }),
+        );
+      }
+
+      const results = await Promise.allSettled(writes);
+      const errors = results.flatMap((result) =>
+        result.status === 'rejected' ? [result.reason] : [],
+      );
+      if (errors.length === 1) throw errors[0];
+      if (errors.length > 1) {
+        throw new AggregateError(
+          errors,
+          `Multiple execution registration writes failed for ${executionId}`,
+        );
+      }
+    } catch (error) {
+      try {
+        await releaseOwnedExecutionLease(executionId);
+      } catch (releaseError) {
+        throw new AggregateError(
+          [error, releaseError],
+          `Execution registration and lease rollback failed for ${executionId}`,
+        );
+      }
+      throw error;
     }
-    throw error;
-  }
+  });
 }
 
 /**

--- a/src/agent/storage/executionListing.ts
+++ b/src/agent/storage/executionListing.ts
@@ -133,8 +133,7 @@ export async function listExecutions(): Promise<ExecutionListingEntry[]> {
   }
 
   if (!migrated) {
-    await migrateIfNeeded();
-    migrated = true;
+    migrated = await migrateIfNeeded();
   }
 
   const entries = await readDirOrEmpty(RUNS_STORAGE_DIR);
@@ -305,36 +304,39 @@ export async function deleteAllExecutions(): Promise<DeleteAllExecutionsResult> 
 // Legacy migration (runs once on first listExecutions() call)
 // ============================================================================
 
-async function migrateIfNeeded(): Promise<void> {
-  await migrateIndexJson();
-  await migrateWorkspaceState();
+async function migrateIfNeeded(): Promise<boolean> {
+  const indexMigrated = await migrateIndexJson();
+  const workspaceStateMigrated = await migrateWorkspaceState();
+  return indexMigrated && workspaceStateMigrated;
 }
 
 /** Migrate entries from executions/index.json into per-execution KV. */
-async function migrateIndexJson(): Promise<void> {
+async function migrateIndexJson(): Promise<boolean> {
   let items: unknown[];
   try {
     const raw = await StorageFS.readJson<unknown[]>(INDEX_PATH);
-    if (!Array.isArray(raw) || raw.length === 0) return;
+    if (!Array.isArray(raw) || raw.length === 0) return true;
     items = raw;
   } catch {
-    return; // File doesn't exist
+    return true; // File doesn't exist
   }
 
-  await backfillEntries(items);
+  if (!(await backfillEntries(items))) return false;
 
   try {
     await StorageFS.delete(INDEX_PATH);
+    return true;
   } catch (error) {
     logger.warn(
       CHANNEL,
       `Failed to delete legacy ${INDEX_PATH}: ${toErrorMessage(error)}`,
     );
+    return false;
   }
 }
 
 /** Migrate entries from workspace state into per-execution KV. */
-async function migrateWorkspaceState(): Promise<void> {
+async function migrateWorkspaceState(): Promise<boolean> {
   const workspace = platform().workspace;
   const paths = [
     workspace.getWorkspacePath(),
@@ -344,21 +346,27 @@ async function migrateWorkspaceState(): Promise<void> {
     ...new Set(paths.map((path) => getWorkspaceStorageKey(path))),
   ];
 
+  let migratedAll = true;
   for (const storageKey of storageKeys) {
     const legacy = platform().workspaceState.get<unknown[]>(storageKey, []);
     if (!Array.isArray(legacy) || legacy.length === 0) continue;
 
-    await backfillEntries(legacy);
+    if (!(await backfillEntries(legacy))) {
+      migratedAll = false;
+      continue;
+    }
 
     try {
       await platform().workspaceState.update(storageKey, []);
     } catch (error) {
+      migratedAll = false;
       logger.warn(
         CHANNEL,
         `Failed to clear workspace state key: ${toErrorMessage(error)}`,
       );
     }
   }
+  return migratedAll;
 }
 
 function getWorkspaceStorageKey(workspacePath: string | undefined): string {
@@ -371,11 +379,11 @@ function getWorkspaceStorageKey(workspacePath: string | undefined): string {
  * Backfill per-execution KV from legacy history entries.
  * Only writes if meta.json doesn't already exist (no overwriting).
  */
-async function backfillEntries(entries: unknown[]): Promise<void> {
-  await pMap(
+async function backfillEntries(entries: unknown[]): Promise<boolean> {
+  const migrated = await pMap(
     entries,
     async (rawEntry) => {
-      if (!rawEntry || typeof rawEntry !== 'object') return;
+      if (!rawEntry || typeof rawEntry !== 'object') return true;
 
       const candidate = rawEntry as {
         id?: ExecutionId;
@@ -386,32 +394,39 @@ async function backfillEntries(entries: unknown[]): Promise<void> {
       };
 
       const rawConfig = candidate.agentConfig ?? candidate.config;
-      if (!candidate.id || !candidate.timestamp || !rawConfig) return;
+      if (!candidate.id || !candidate.timestamp || !rawConfig) return true;
+      const executionId = candidate.id;
+      const timestamp = candidate.timestamp;
 
       let normalizedConfig: AgentConfig;
       try {
         normalizedConfig = AgentConfigSchema.parse(rawConfig);
       } catch {
         logger.warn(CHANNEL, `Skipping malformed legacy entry ${candidate.id}`);
-        return;
+        return true;
       }
 
-      const store = getExecutionStore(candidate.id);
-
-      // Don't overwrite existing KV data
-      if (await store.exists('meta')) return;
-
-      await Promise.all([
-        store.writeMeta({
-          timestamp: candidate.timestamp,
-          parentExecutionId: candidate.parentExecutionId,
-        }),
-        store.writeConfig(normalizedConfig),
-      ]);
+      const result = await runWithInactiveExecutionLease(
+        executionId,
+        async () => {
+          const store = getExecutionStore(executionId);
+          // Don't overwrite existing KV data.
+          if (await store.exists('meta')) return;
+          await Promise.all([
+            store.writeMeta({
+              timestamp,
+              parentExecutionId: candidate.parentExecutionId,
+            }),
+            store.writeConfig(normalizedConfig),
+          ]);
+        },
+      );
+      return result.status === 'performed';
     },
     {
       concurrency: EXECUTION_STORAGE_CONCURRENCY,
       stopOnError: false,
     },
   );
+  return migrated.every(Boolean);
 }

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -56,4 +56,5 @@ export {
   markOwnedExecutionLeaseUndurable,
   releaseOwnedExecutionLeaseAfterFailure,
   ExecutionLeaseActiveError,
+  type OwnedExecutionLeaseScope,
 } from './executionLease';

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -56,5 +56,6 @@ export {
   markOwnedExecutionLeaseUndurable,
   releaseOwnedExecutionLeaseAfterFailure,
   ExecutionLeaseActiveError,
+  ExecutionLeaseLostError,
   type OwnedExecutionLeaseScope,
 } from './executionLease';

--- a/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
@@ -89,10 +89,11 @@ describe('AgentLaunchContext', () => {
   it('projects model changes into the active run context', async () => {
     const explicit = createRecordingHost();
     const session = {} as SessionHandle;
+    const executionId = 'launch-context-execution';
     const runScope = createRunScope({
       runtimeHost: explicit.host,
       streamId: 'launch-context-stream',
-      executionId: 'launch-context-execution',
+      executionId,
       agentName: 'chat',
       session,
     });

--- a/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
+++ b/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
@@ -199,6 +199,28 @@ afterEach(() => {
 });
 
 describe('childRunLoop E2E fixtures', () => {
+  it('validates the captured lease before registering loop resources', () => {
+    const childStreamId = uniqueStreamId('lost-before-setup');
+    const { strategy, callCount } = createFakeStrategy();
+    mocks.runWithOwnedExecutionLease.mockImplementationOnce(() => {
+      throw new Error('lease generation lost');
+    });
+
+    expect(() =>
+      startChildRunLoop({
+        childStreamId,
+        parentStreamId: 'parent' as StreamTabId,
+        executionId: 'exec-lost-before-setup' as ExecutionId,
+        agentName: 'fake',
+        strategy,
+      }),
+    ).toThrow('lease generation lost');
+
+    expect(isChildRunLoopActive(childStreamId)).toBe(false);
+    expect(mocks.leaseLossListener).toBeUndefined();
+    expect(callCount()).toBe(0);
+  });
+
   it('interrupts an in-flight child when its execution lease is lost', async () => {
     const childStreamId = uniqueStreamId('lease-loss');
     const parentStreamId = 'parent' as StreamTabId;
@@ -211,10 +233,7 @@ describe('childRunLoop E2E fixtures', () => {
       agentName: 'fake',
       strategy,
     });
-    expect(mocks.runWithOwnedExecutionLease).toHaveBeenCalledWith(
-      'exec-lease-loss',
-      expect.any(Function),
-    );
+    expect(mocks.runWithOwnedExecutionLease).toHaveBeenCalledTimes(2);
     await vi.waitFor(() => expect(mocks.leaseLossListener).toBeDefined());
 
     mocks.leaseLossListener?.();

--- a/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
+++ b/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
@@ -19,6 +19,9 @@ const mocks = vi.hoisted(() => ({
   persistChildRunResultMeta: vi.fn(),
   enqueueChildRunFollowUp: vi.fn(),
   wakeChildRunFollowUp: vi.fn(),
+  runWithOwnedExecutionLease: vi.fn(
+    (_executionId: ExecutionId, operation: () => unknown) => operation(),
+  ),
   leaseLossListener: undefined as (() => void) | undefined,
 }));
 
@@ -31,6 +34,7 @@ vi.mock('@agent/storage', async (importOriginal) => ({
 vi.mock('@agent/storage/executionLease', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@agent/storage/executionLease')>()),
   markOwnedExecutionLeaseUndurable: vi.fn(),
+  runWithOwnedExecutionLease: mocks.runWithOwnedExecutionLease,
   onOwnedExecutionLeaseLost: vi.fn(
     (_executionId: ExecutionId, listener: () => void) => {
       mocks.leaseLossListener = listener;
@@ -207,6 +211,10 @@ describe('childRunLoop E2E fixtures', () => {
       agentName: 'fake',
       strategy,
     });
+    expect(mocks.runWithOwnedExecutionLease).toHaveBeenCalledWith(
+      'exec-lease-loss',
+      expect.any(Function),
+    );
     await vi.waitFor(() => expect(mocks.leaseLossListener).toBeDefined());
 
     mocks.leaseLossListener?.();

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -2,7 +2,10 @@
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
-import { getExecutionStore } from '@agent/storage';
+import {
+  getExecutionStore,
+  type OwnedExecutionLeaseScope,
+} from '@agent/storage';
 import type { AgentTrace } from '@agent/trace';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
@@ -84,9 +87,10 @@ function createHandle(
     agentName?: string;
     category?: AgentCategory;
     trace?: AgentTrace;
+    leaseScope?: OwnedExecutionLeaseScope;
   } = {},
 ): AgentExecutionHandle {
-  return new AgentExecutionHandle(
+  const handle = new AgentExecutionHandle(
     executionId,
     parentStreamId,
     childStreamId,
@@ -95,6 +99,10 @@ function createHandle(
     runtimeHost,
     overrides.trace,
   );
+  handle.attachExecutionLeaseScope(
+    overrides.leaseScope ?? ((operation) => operation()),
+  );
+  return handle;
 }
 
 describe('executionRegistry', () => {
@@ -399,6 +407,11 @@ describe('executionRegistry', () => {
     const childStreamId =
       'child-waiting-kill-publish-result-test' as StreamTabId;
     const trace: AgentTrace = { emit: vi.fn() } as unknown as AgentTrace;
+    const leaseScopeInvoked = vi.fn();
+    const leaseScope: OwnedExecutionLeaseScope = (operation) => {
+      leaseScopeInvoked();
+      return operation();
+    };
 
     try {
       const handle = createHandle(
@@ -406,7 +419,7 @@ describe('executionRegistry', () => {
         parentStreamId,
         childStreamId,
         createRecordingHost().host,
-        { trace },
+        { trace, leaseScope },
       );
       registry.track(handle);
       handle.registerWaitingCleanup(() => {});
@@ -419,6 +432,7 @@ describe('executionRegistry', () => {
 
       expect(registry.kill(executionId)).toBe(true);
       await handle.result;
+      expect(leaseScopeInvoked).toHaveBeenCalledOnce();
 
       expect(publishResult).toHaveBeenCalledExactlyOnceWith(
         expect.objectContaining({

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import {
+  ExecutionLeaseLostError,
   getExecutionStore,
   type OwnedExecutionLeaseScope,
 } from '@agent/storage';
@@ -561,6 +562,47 @@ describe('executionRegistry', () => {
       expect(publishResult).not.toHaveBeenCalled();
       expect(storageMocks.finalizeExecution).not.toHaveBeenCalled();
       expect(streamStatus.get(childStreamId)).toBe(STREAM_PHASE.WAITING);
+    } finally {
+      registry.dispose();
+    }
+  });
+
+  it('does not let lost-generation recovery mutate a successor handle or lease', async () => {
+    const streamStatus = new StreamStatusMachine();
+    const registry = new ExecutionRegistry({ streamStatus });
+    const releaseLease = vi.fn(async () => undefined);
+    registry.attachRootExecutionLeaseRelease(releaseLease);
+    const executionId = 'exec-waiting-lost-generation' as ExecutionId;
+    const streamId = 'stream-waiting-lost-generation' as StreamTabId;
+    const lostScope: OwnedExecutionLeaseScope = () => {
+      throw new ExecutionLeaseLostError(executionId);
+    };
+
+    try {
+      const previous = createHandle(
+        executionId,
+        streamId,
+        streamId,
+        createRecordingHost().host,
+        { leaseScope: lostScope },
+      );
+      registry.track(previous);
+      previous.registerWaitingCleanup(() => undefined);
+      seedStreamStatusForTest(streamStatus, streamId, STREAM_STATUS.WAITING);
+
+      expect(registry.kill(executionId)).toBe(true);
+      const successor = createHandle(
+        executionId,
+        streamId,
+        streamId,
+        createRecordingHost().host,
+      );
+      registry.track(successor);
+
+      await previous.result;
+      expect(registry.getHandle(executionId)).toBe(successor);
+      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.WAITING);
+      expect(releaseLease).not.toHaveBeenCalled();
     } finally {
       registry.dispose();
     }

--- a/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
+++ b/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
@@ -21,11 +21,18 @@ const mocks = vi.hoisted(() => ({
 vi.mock('@agent/storage/executionLease', () => ({
   abandonOwnedExecutionLease: mocks.abandonOwnedExecutionLease,
   acquireResumedExecutionLease: mocks.acquireResumedExecutionLease,
+  captureOwnedExecutionLease:
+    (_executionId: ExecutionId) => (operation: () => unknown) =>
+      operation(),
   completeOwnedExecutionLease: mocks.completeOwnedExecutionLease,
   renewOwnedExecutionLease: mocks.renewOwnedExecutionLease,
   runWithExecutionLeaseWriteFence: mocks.runWithExecutionLeaseWriteFence,
   releaseOwnedExecutionLeaseAfterFailure:
     mocks.releaseOwnedExecutionLeaseAfterFailure,
+  runWithOwnedExecutionLease: (
+    _executionId: ExecutionId,
+    operation: () => unknown,
+  ) => operation(),
 }));
 
 vi.mock('@agent/runtime/AgentLaunchContext', () => ({

--- a/src/test-kernel/agent/runtime/RunAgentOwnership.vitest.ts
+++ b/src/test-kernel/agent/runtime/RunAgentOwnership.vitest.ts
@@ -21,8 +21,15 @@ vi.mock('@agent/storage', () => ({
 }));
 
 vi.mock('@agent/storage/executionLease', () => ({
+  captureOwnedExecutionLease:
+    (_executionId: ExecutionId) => (operation: () => unknown) =>
+      operation(),
   markOwnedExecutionLeaseUndurable: mocks.markOwnedExecutionLeaseUndurable,
   renewOwnedExecutionLease: mocks.renewOwnedExecutionLease,
+  runWithOwnedExecutionLease: (
+    _executionId: ExecutionId,
+    operation: () => unknown,
+  ) => operation(),
 }));
 
 vi.mock('@agent/runtime/executeAgent', () => ({

--- a/src/test-kernel/agent/storage/ExecutionLease.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionLease.vitest.ts
@@ -25,6 +25,7 @@ import {
   renewOwnedExecutionLease,
   runWithInactiveExecutionLease,
   runWithOwnedExecutionLease,
+  tryCaptureOwnedExecutionLease,
   waitForOwnedExecutionLeaseRelease,
 } from '@agent/storage/executionLease';
 import { platform } from '@platform/platform';
@@ -321,6 +322,16 @@ describe('cross-process execution leases', () => {
     const executionId = 'e86445' as ExecutionId;
     await acquire(executionId);
     const runWithFirstOwner = captureOwnedExecutionLease(executionId);
+    let resumeFirstOwner = (): void => undefined;
+    const firstOwnerPaused = new Promise<void>((resolve) => {
+      resumeFirstOwner = resolve;
+    });
+    const delayedCapture = Promise.resolve(
+      runWithFirstOwner(async () => {
+        await firstOwnerPaused;
+        return tryCaptureOwnedExecutionLease(executionId);
+      }),
+    );
     await writeForeignLease(
       executionId,
       Date.now() - EXECUTION_LEASE_STALE_MS - 1,
@@ -328,13 +339,10 @@ describe('cross-process execution leases', () => {
     );
     await acquireResumedExecutionLease(executionId);
 
-    expect(() =>
-      runWithFirstOwner(() =>
-        getExecutionStore(executionId).writeMeta({
-          timestamp: '2026-07-16T12:00:00.000Z',
-        }),
-      ),
-    ).toThrow(ExecutionLeaseLostError);
+    resumeFirstOwner();
+    await expect(delayedCapture).rejects.toBeInstanceOf(
+      ExecutionLeaseLostError,
+    );
     expect(ownsExecutionLease(executionId)).toBe(true);
   });
 

--- a/src/test-kernel/agent/storage/ExecutionLease.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionLease.vitest.ts
@@ -25,7 +25,7 @@ import {
   renewOwnedExecutionLease,
   runWithInactiveExecutionLease,
   runWithOwnedExecutionLease,
-  tryCaptureOwnedExecutionLease,
+  captureOwnedExecutionLeaseIfPresent,
   waitForOwnedExecutionLeaseRelease,
 } from '@agent/storage/executionLease';
 import { platform } from '@platform/platform';
@@ -329,7 +329,7 @@ describe('cross-process execution leases', () => {
     const delayedCapture = Promise.resolve(
       runWithFirstOwner(async () => {
         await firstOwnerPaused;
-        return tryCaptureOwnedExecutionLease(executionId);
+        return captureOwnedExecutionLeaseIfPresent(executionId);
       }),
     );
     await writeForeignLease(

--- a/src/test-kernel/agent/storage/ExecutionLease.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionLease.vitest.ts
@@ -15,6 +15,7 @@ import {
   ExecutionLeaseLostError,
   abandonOwnedExecutionLease,
   acquireResumedExecutionLease,
+  captureOwnedExecutionLease,
   completeOwnedExecutionLease,
   inspectExecutionLease,
   markOwnedExecutionLeaseUndurable,
@@ -23,6 +24,7 @@ import {
   releaseOwnedExecutionLease,
   renewOwnedExecutionLease,
   runWithInactiveExecutionLease,
+  runWithOwnedExecutionLease,
   waitForOwnedExecutionLeaseRelease,
 } from '@agent/storage/executionLease';
 import { platform } from '@platform/platform';
@@ -247,26 +249,104 @@ describe('cross-process execution leases', () => {
     await acquire(executionId);
     const onLeaseLost = vi.fn();
     onOwnedExecutionLeaseLost(executionId, onLeaseLost);
+    await runWithOwnedExecutionLease(executionId, async () => {
+      await writeForeignLease(
+        executionId,
+        Date.now(),
+        '00000000-0000-4000-8000-000000000004',
+      );
+
+      await expect(
+        getExecutionStore(executionId).writeMeta({
+          timestamp: '2026-07-16T12:00:00.000Z',
+        }),
+      ).rejects.toBeInstanceOf(ExecutionLeaseLostError);
+
+      expect(onLeaseLost).toHaveBeenCalledOnce();
+      expect(ownsExecutionLease(executionId)).toBe(false);
+      await expect(
+        getExecutionStore(executionId).writeMeta({
+          timestamp: '2026-07-16T12:01:00.000Z',
+        }),
+      ).rejects.toBeInstanceOf(ExecutionLeaseLostError);
+    });
+    ownedExecutionIds.delete(executionId);
+  });
+
+  it('does not let a displaced continuation borrow a successor lease', async () => {
+    const executionId = 'e86444' as ExecutionId;
+    await acquire(executionId);
+    let startLateWrite = (): void => undefined;
+    const lateWriteGate = new Promise<void>((resolve) => {
+      startLateWrite = resolve;
+    });
+    const lateWrite = Promise.resolve(
+      runWithOwnedExecutionLease(executionId, async () => {
+        await lateWriteGate;
+        expect(ownsExecutionLease(executionId)).toBe(false);
+        markOwnedExecutionLeaseUndurable(executionId);
+        abandonOwnedExecutionLease(executionId);
+        await completeOwnedExecutionLease(executionId);
+        expect(() =>
+          runWithOwnedExecutionLease(executionId, () => undefined),
+        ).toThrow(ExecutionLeaseLostError);
+        await getExecutionStore(executionId).writeMeta({
+          timestamp: '2026-07-16T12:00:00.000Z',
+        });
+      }),
+    );
     await writeForeignLease(
       executionId,
-      Date.now(),
-      '00000000-0000-4000-8000-000000000004',
+      Date.now() - EXECUTION_LEASE_STALE_MS - 1,
+      '00000000-0000-4000-8000-000000000006',
     );
+    await acquireResumedExecutionLease(executionId);
+
+    startLateWrite();
+    await expect(lateWrite).rejects.toBeInstanceOf(ExecutionLeaseLostError);
+
+    await runWithOwnedExecutionLease(executionId, () =>
+      getExecutionStore(executionId).writeMeta({
+        timestamp: '2026-07-16T12:01:00.000Z',
+      }),
+    );
+    await expect(
+      getExecutionStore(executionId).readMeta(),
+    ).resolves.toMatchObject({
+      timestamp: '2026-07-16T12:01:00.000Z',
+    });
+  });
+
+  it('does not let a delayed lifecycle root capture a successor lease', async () => {
+    const executionId = 'e86445' as ExecutionId;
+    await acquire(executionId);
+    const runWithFirstOwner = captureOwnedExecutionLease(executionId);
+    await writeForeignLease(
+      executionId,
+      Date.now() - EXECUTION_LEASE_STALE_MS - 1,
+      '00000000-0000-4000-8000-000000000007',
+    );
+    await acquireResumedExecutionLease(executionId);
+
+    expect(() =>
+      runWithFirstOwner(() =>
+        getExecutionStore(executionId).writeMeta({
+          timestamp: '2026-07-16T12:00:00.000Z',
+        }),
+      ),
+    ).toThrow(ExecutionLeaseLostError);
+    expect(ownsExecutionLease(executionId)).toBe(true);
+  });
+
+  it('rejects unscoped writes while another owner has a lease', async () => {
+    const executionId = 'e86446' as ExecutionId;
+    await writeForeignLease(executionId, Date.now());
 
     await expect(
       getExecutionStore(executionId).writeMeta({
         timestamp: '2026-07-16T12:00:00.000Z',
       }),
     ).rejects.toBeInstanceOf(ExecutionLeaseLostError);
-
-    expect(onLeaseLost).toHaveBeenCalledOnce();
-    expect(ownsExecutionLease(executionId)).toBe(false);
-    await expect(
-      getExecutionStore(executionId).writeMeta({
-        timestamp: '2026-07-16T12:01:00.000Z',
-      }),
-    ).rejects.toBeInstanceOf(ExecutionLeaseLostError);
-    ownedExecutionIds.delete(executionId);
   });
 
   it('never overlaps heartbeat work for the same execution', async () => {

--- a/src/test-kernel/agent/storage/ExecutionListing.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionListing.vitest.ts
@@ -8,10 +8,12 @@ import {
 } from '@agent/storage';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { EXECUTION_LEASE_STALE_MS } from '@agent/storage/executionLease';
 import { platform } from '@platform/platform';
 import type { ExecutionId } from '@shared/schemas';
 import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
 import { installPlatform, setupPlatform } from '@test/support/setupPlatform';
+import { StorageFS } from '@utils/files';
 
 function config(agent: string): AgentConfig {
   return {
@@ -121,6 +123,43 @@ describe('execution listing normalization', () => {
     );
     clearStoreCache();
 
+    expect(await listExecutions()).toEqual([
+      expect.objectContaining({ id, kind: 'agent' }),
+    ]);
+    expect(platform().workspaceState.get(legacyKey, [])).toEqual([]);
+  });
+
+  it('retains active legacy history and migrates it after its lease is stale', async () => {
+    const id = 'abc778' as ExecutionId;
+    const legacyKey = 'texra.agentHistory./workspace';
+    const legacyEntry = {
+      id,
+      timestamp: '2026-07-15T13:01:00.000Z',
+      agentConfig: config('assistant'),
+    };
+    await installPlatform({
+      workspacePath: '/workspace',
+      workspaceState: { [legacyKey]: [legacyEntry] },
+    });
+    clearStoreCache();
+    await StorageFS.ensureDir('executionLeases');
+    const writeLease = (heartbeatAt: number) =>
+      StorageFS.writeAtomic(
+        `executionLeases/${id}.json`,
+        JSON.stringify({
+          version: 1,
+          executionId: id,
+          ownerToken: '00000000-0000-4000-8000-000000000008',
+          acquiredAt: heartbeatAt,
+          heartbeatAt,
+        }),
+      );
+
+    await writeLease(Date.now());
+    expect(await listExecutions()).toEqual([]);
+    expect(platform().workspaceState.get(legacyKey, [])).toEqual([legacyEntry]);
+
+    await writeLease(Date.now() - EXECUTION_LEASE_STALE_MS - 1);
     expect(await listExecutions()).toEqual([
       expect.objectContaining({ id, kind: 'agent' }),
     ]);

--- a/src/test-kernel/cli/HistoryStatus.vitest.ts
+++ b/src/test-kernel/cli/HistoryStatus.vitest.ts
@@ -5,6 +5,7 @@ import {
   registerExecution,
   getExecutionStore,
 } from '@agent/storage';
+import { releaseOwnedExecutionLease } from '@agent/storage/executionLease';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { flowKey } from '@agent/node/persistedFlow';
@@ -144,6 +145,7 @@ describe('CLI history status formatting', () => {
   it('does not mark invalid flow records as resumable', async () => {
     const id = 'abc123' as ExecutionId;
     await registerExecution(id, TOOL_USE_CONFIG, 'orchestrator', undefined);
+    await releaseOwnedExecutionLease(id);
     await getExecutionStore(id).write(flowKey(id), {
       flowName: 'test',
       params: {},
@@ -166,6 +168,7 @@ describe('CLI history status formatting', () => {
   it('does not mark non-tool-use flow records as CLI-resumable', async () => {
     const id = 'workflow-with-flow' as ExecutionId;
     await registerExecution(id, WORKFLOW_CONFIG, 'correct', undefined);
+    await releaseOwnedExecutionLease(id);
     await getExecutionStore(id).write(flowKey(id), {
       flowName: 'test',
       params: {},

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -154,11 +154,16 @@ function stubRunExecutionDeps(): void {
     terminalStatusPersisted: true,
     flowRecord: 'deleted',
   });
-  mocks.runAgent.mockResolvedValue({
-    category: 'toolUse',
-    executionId: 'exec-1',
-    outcome: 'completed',
-    streamId: 'stream-1',
+  mocks.runAgent.mockImplementation(async (_request, options) => {
+    options.onExecutionLeaseAcquired?.((operation: () => unknown) =>
+      operation(),
+    );
+    return {
+      category: 'toolUse',
+      executionId: 'exec-1',
+      outcome: 'completed',
+      streamId: 'stream-1',
+    };
   });
 }
 
@@ -643,18 +648,27 @@ describe('executeCliRequest', () => {
     let resolveRun:
       | ((result: Awaited<ReturnType<typeof mocks.runAgent>>) => void)
       | undefined;
-    mocks.runAgent.mockReturnValue(
-      new Promise((resolve) => {
+    const runWithOwnership = vi.fn((operation: () => unknown) => operation());
+    let publishLeaseScope:
+      ((scope: typeof runWithOwnership) => void) | undefined;
+    mocks.runAgent.mockImplementation(async (_request, options) => {
+      publishLeaseScope = options.onExecutionLeaseAcquired;
+      return new Promise((resolve) => {
         resolveRun = resolve;
-      }),
-    );
+      });
+    });
 
     const run = executeCliRequest(request, cliContext(), {
       registerExecution: true,
     });
+    await vi.waitFor(() => expect(publishLeaseScope).toBeDefined());
+    const shutdown = platform.lifecycle.runShutdown();
     await Promise.resolve();
-    await platform.lifecycle.runShutdown();
+    expect(mocks.finalizeExecution).not.toHaveBeenCalled();
+    publishLeaseScope?.(runWithOwnership);
+    await shutdown;
 
+    expect(runWithOwnership).toHaveBeenCalledOnce();
     expect(mocks.finalizeExecution).toHaveBeenCalledWith({
       executionId: 'exec-1',
       terminalStatus: EXECUTION_STATUS.INTERRUPTED,
@@ -684,6 +698,45 @@ describe('executeCliRequest', () => {
     });
   });
 
+  it('retains the shutdown interrupt when the captured lease is already lost', async () => {
+    const { initPlatform } = await import('@platform/platform');
+    const platform = createFakePlatform();
+    initPlatform(platform);
+    const { executeCliRequest } = await import('@cli/runtime/runExecution');
+    let resolveRun:
+      | ((result: Awaited<ReturnType<typeof mocks.runAgent>>) => void)
+      | undefined;
+    mocks.runAgent.mockImplementation(async (_request, options) => {
+      options.onExecutionLeaseAcquired?.(() => {
+        throw new Error('lease generation lost');
+      });
+      return new Promise((resolve) => {
+        resolveRun = resolve;
+      });
+    });
+
+    const run = executeCliRequest(baseRequest(), cliContext(), {
+      registerExecution: true,
+    });
+    await Promise.resolve();
+    await platform.lifecycle.runShutdown();
+    expect(mocks.finalizeExecution).not.toHaveBeenCalled();
+
+    resolveRun?.({
+      category: 'toolUse',
+      executionId: 'exec-1',
+      outcome: 'completed',
+      streamId: 'stream-1',
+    });
+    await run;
+
+    expect(mocks.finalizeExecution).toHaveBeenCalledWith({
+      executionId: 'exec-1',
+      terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+      flowRecord: 'preserve',
+    });
+  });
+
   it('closes the runtime host when shutdown finalization fails', async () => {
     const { initPlatform } = await import('@platform/platform');
     const platform = createFakePlatform();
@@ -699,11 +752,14 @@ describe('executeCliRequest', () => {
     let resolveRun:
       | ((result: Awaited<ReturnType<typeof mocks.runAgent>>) => void)
       | undefined;
-    mocks.runAgent.mockReturnValue(
-      new Promise((resolve) => {
+    mocks.runAgent.mockImplementation(async (_request, options) => {
+      options.onExecutionLeaseAcquired?.((operation: () => unknown) =>
+        operation(),
+      );
+      return new Promise((resolve) => {
         resolveRun = resolve;
-      }),
-    );
+      });
+    });
 
     const run = executeCliRequest(baseRequest(), cliContext(), {
       registerExecution: true,

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { ExecutionLeaseLostError } from '@agent/storage';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import type { CliContext } from '@cli/runtime/cliContext';
 import type { executeCliRequest } from '@cli/runtime/runExecution';
@@ -690,15 +691,10 @@ describe('executeCliRequest', () => {
         streamId: 'stream-1',
       },
     });
-    expect(mocks.finalizeExecution).toHaveBeenCalledTimes(2);
-    expect(mocks.finalizeExecution).toHaveBeenLastCalledWith({
-      executionId: 'exec-1',
-      terminalStatus: EXECUTION_STATUS.INTERRUPTED,
-      flowRecord: 'preserve',
-    });
+    expect(mocks.finalizeExecution).toHaveBeenCalledOnce();
   });
 
-  it('retains the shutdown interrupt when the captured lease is already lost', async () => {
+  it('does not finalize shutdown through a captured lease that is already lost', async () => {
     const { initPlatform } = await import('@platform/platform');
     const platform = createFakePlatform();
     initPlatform(platform);
@@ -708,7 +704,7 @@ describe('executeCliRequest', () => {
       | undefined;
     mocks.runAgent.mockImplementation(async (_request, options) => {
       options.onExecutionLeaseAcquired?.(() => {
-        throw new Error('lease generation lost');
+        throw new ExecutionLeaseLostError('exec-1');
       });
       return new Promise((resolve) => {
         resolveRun = resolve;
@@ -729,12 +725,7 @@ describe('executeCliRequest', () => {
       streamId: 'stream-1',
     });
     await run;
-
-    expect(mocks.finalizeExecution).toHaveBeenCalledWith({
-      executionId: 'exec-1',
-      terminalStatus: EXECUTION_STATUS.INTERRUPTED,
-      flowRecord: 'preserve',
-    });
+    expect(mocks.finalizeExecution).not.toHaveBeenCalled();
   });
 
   it('closes the runtime host when shutdown finalization fails', async () => {
@@ -787,7 +778,7 @@ describe('executeCliRequest', () => {
         streamId: 'stream-1',
       },
     });
-    expect(mocks.finalizeExecution).toHaveBeenCalledTimes(2);
+    expect(mocks.finalizeExecution).toHaveBeenCalledOnce();
     expect(mocks.emit).toHaveBeenCalledTimes(1);
     expect(mocks.close).toHaveBeenCalledTimes(1);
   });

--- a/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
@@ -54,6 +54,12 @@ vi.mock('@agent/storage', () => ({
   getExecutionStore: mocks.getExecutionStore,
 }));
 
+vi.mock('@agent/storage/executionLease', () => ({
+  captureOwnedExecutionLease:
+    (_executionId: ExecutionId) => (operation: () => unknown) =>
+      operation(),
+}));
+
 vi.mock('@utils/files/taskRunStorage', () => ({
   ensureRunDir: mocks.ensureRunDir,
 }));

--- a/src/test-kernel/tools/CodexResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/CodexResumeFallback.vitest.ts
@@ -50,6 +50,12 @@ vi.mock('@agent/storage', () => ({
   getExecutionStore: mocks.getExecutionStore,
 }));
 
+vi.mock('@agent/storage/executionLease', () => ({
+  captureOwnedExecutionLease:
+    (_executionId: ExecutionId) => (operation: () => unknown) =>
+      operation(),
+}));
+
 vi.mock('@utils/files/taskRunStorage', () => ({
   ensureRunDir: mocks.ensureRunDir,
 }));

--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -62,8 +62,14 @@ vi.mock('@agent/storage', () => ({
 
 vi.mock('@agent/storage/executionLease', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@agent/storage/executionLease')>()),
+  captureOwnedExecutionLease:
+    (_executionId: ExecutionId) => (operation: () => unknown) =>
+      operation(),
   markOwnedExecutionLeaseUndurable: vi.fn(),
   ownsExecutionLease: vi.fn(() => true),
+  runWithOwnedExecutionLease: vi.fn(
+    (_executionId: ExecutionId, operation: () => unknown) => operation(),
+  ),
 }));
 
 vi.mock('@agent/runtime/executionOwnership', () => ({

--- a/src/test-kernel/tools/NativeToolUseStrategy.vitest.ts
+++ b/src/test-kernel/tools/NativeToolUseStrategy.vitest.ts
@@ -49,6 +49,14 @@ vi.mock('@agent/storage', () => ({
   synchronizeAgentResultOutcome: mocks.synchronizeAgentResultOutcome,
 }));
 
+vi.mock('@agent/storage/executionLease', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@agent/storage/executionLease')>()),
+  runWithOwnedExecutionLease: (
+    _executionId: ExecutionId,
+    operation: () => unknown,
+  ) => operation(),
+}));
+
 vi.mock('@agent/runtime/executionOwnership', () => ({
   releaseExecutionLeaseAfterArtifacts: vi.fn(async () => {}),
 }));

--- a/src/test-kernel/tools/SubagentExecutionChildStreamId.vitest.ts
+++ b/src/test-kernel/tools/SubagentExecutionChildStreamId.vitest.ts
@@ -28,6 +28,12 @@ vi.mock('@agent/storage', () => ({
   registerExecution: mocks.registerExecution,
 }));
 
+vi.mock('@agent/storage/executionLease', () => ({
+  captureOwnedExecutionLease:
+    (_executionId: string) => (operation: () => unknown) =>
+      operation(),
+}));
+
 vi.mock('@agent/runtime/RunContext', () => {
   const readRunContextField = (context: any, field: string) =>
     context?.kind === 'launch' ? context.runScope[field] : context?.[field];

--- a/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
@@ -33,6 +33,13 @@ vi.mock('@agent/storage', async (importOriginal) => {
   return { ...actual, registerExecution: mocks.registerExecution };
 });
 
+vi.mock('@agent/storage/executionLease', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@agent/storage/executionLease')>()),
+  captureOwnedExecutionLease:
+    (_executionId: ExecutionId) => (operation: () => unknown) =>
+      operation(),
+}));
+
 vi.mock('@agent/runtime/childRunLoop', () => ({
   startChildRunLoop: mocks.startChildRunLoop,
 }));

--- a/src/test-kernel/transcript/executionStreamResolver.vitest.ts
+++ b/src/test-kernel/transcript/executionStreamResolver.vitest.ts
@@ -4,6 +4,7 @@ import { TaskStateSchema, type TaskState } from '@agent/core/state/TaskState';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { getExecutionStore } from '@agent/storage/ExecutionKVStore';
 import { registerExecution } from '@agent/storage/executionLifecycle';
+import { releaseOwnedExecutionLease } from '@agent/storage/executionLease';
 import type { Platform } from '@platform/platform';
 import {
   LOG_LEVELS,
@@ -266,6 +267,7 @@ describe('resolvePersistedStreamIdForExecution', () => {
     const executionId = 'abc555' as ExecutionId;
     const cachedStreamId = 'orchestrator@deepseekproT#abc555' as StreamTabId;
     await registerExecution(executionId, MINIMAL_CONFIG, 'orchestrator');
+    await releaseOwnedExecutionLease(executionId);
     await getExecutionStore(executionId).writeMeta({
       timestamp: new Date().toISOString(),
       streamId: cachedStreamId,
@@ -287,6 +289,7 @@ describe('resolvePersistedStreamIdForExecution', () => {
     const executionId = 'abc666' as ExecutionId;
     const streamId = 'orchestrator@deepseekproT#abc666' as StreamTabId;
     await registerExecution(executionId, MINIMAL_CONFIG, 'orchestrator');
+    await releaseOwnedExecutionLease(executionId);
 
     const store = new StreamSnapshotStore();
     store.setTaskState(streamId, taskState('orchestrator'), executionId);
@@ -314,6 +317,7 @@ describe('resolvePersistedStreamIdForExecution', () => {
       const parentStream = 'aOrchestrator@deepseekproT#abc777' as StreamTabId;
       const childStream = 'zBashTool@tool#abc777' as StreamTabId;
       await registerExecution(executionId, MINIMAL_CONFIG, 'orchestrator');
+      await releaseOwnedExecutionLease(executionId);
 
       const snapshotWriter = new StreamSnapshotStore();
       snapshotWriter.setTaskState(

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -6,6 +6,7 @@ import {
   releaseOwnedExecutionLeaseAfterFailure,
 } from '@agent/storage';
 import { type AgentTrace } from '@agent/trace';
+import { captureOwnedExecutionLease } from '@agent/storage/executionLease';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
@@ -182,33 +183,36 @@ export async function launchAgentCliSession(
   } catch {
     throw new ToolError(params.registerFailedMessage);
   }
+  const runWithOwnership = captureOwnedExecutionLease(executionId);
 
-  let childStream: ChildStream;
-  try {
-    childStream = createChildStream(executionId, params.parentStreamId, {
-      streamPrefix: params.streamPrefix,
-      streamCategory: AgentCategory.ToolUse,
-      agentName: params.agentName,
-      description: params.description,
-      config: params.config,
-      toolName: params.agentName,
-      runtimeHost: params.runtimeHost,
-    });
-    await params.startLoop({ childStream, executionId });
-  } catch (error) {
-    throw await releaseOwnedExecutionLeaseAfterFailure(executionId, error);
-  }
+  return await runWithOwnership(async () => {
+    let childStream: ChildStream;
+    try {
+      childStream = createChildStream(executionId, params.parentStreamId, {
+        streamPrefix: params.streamPrefix,
+        streamCategory: AgentCategory.ToolUse,
+        agentName: params.agentName,
+        description: params.description,
+        config: params.config,
+        toolName: params.agentName,
+        runtimeHost: params.runtimeHost,
+      });
+      await params.startLoop({ childStream, executionId });
+    } catch (error) {
+      throw await releaseOwnedExecutionLeaseAfterFailure(executionId, error);
+    }
 
-  return {
-    status: 'executed',
-    summary: params.summary,
-    output: [
-      params.launchedLine,
-      `Execution ID: ${executionId}`,
-      `Stream tab: ${childStream.childStreamId}`,
-      params.followUpLine,
-    ].join('\n'),
-  };
+    return {
+      status: 'executed',
+      summary: params.summary,
+      output: [
+        params.launchedLine,
+        `Execution ID: ${executionId}`,
+        `Stream tab: ${childStream.childStreamId}`,
+        params.followUpLine,
+      ].join('\n'),
+    };
+  });
 }
 
 /**

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -9,6 +9,7 @@ import {
   releaseOwnedExecutionLeaseAfterFailure,
 } from '@agent/storage';
 import {
+  captureOwnedExecutionLease,
   markOwnedExecutionLeaseUndurable,
   onOwnedExecutionLeaseLost,
 } from '@agent/storage/executionLease';
@@ -269,21 +270,23 @@ export class BashTool extends defineTool({
       parentExecutionId,
       'process',
     );
+    const runWithOwnership = captureOwnedExecutionLease(executionId);
 
-    let childStream: ReturnType<typeof createChildStream>;
-    try {
-      childStream = createChildStream(executionId, parentStreamId, {
-        streamPrefix: 'bash@tool',
-        streamCategory: AgentCategory.ToolUse,
-        agentName: 'bash',
-        description: command,
-        config: syntheticConfig,
-        toolName: 'bash',
-        runtimeHost,
-      });
-    } catch (error) {
-      throw await releaseOwnedExecutionLeaseAfterFailure(executionId, error);
-    }
+    const childStream = await runWithOwnership(async () => {
+      try {
+        return createChildStream(executionId, parentStreamId, {
+          streamPrefix: 'bash@tool',
+          streamCategory: AgentCategory.ToolUse,
+          agentName: 'bash',
+          description: command,
+          config: syntheticConfig,
+          toolName: 'bash',
+          runtimeHost,
+        });
+      } catch (error) {
+        throw await releaseOwnedExecutionLeaseAfterFailure(executionId, error);
+      }
+    });
     const { childStreamId, logger } = childStream;
     let stdoutTail = '';
     let stderrTail = '';
@@ -462,7 +465,7 @@ export class BashTool extends defineTool({
       await wakeParentFollowUp(enqueueResult);
     };
 
-    void (async () => {
+    void runWithOwnership(async () => {
       try {
         const outcome = await promise.then(
           (result) => ({ ok: true as const, result }),
@@ -556,7 +559,7 @@ export class BashTool extends defineTool({
           stopWatchingLease();
         }
       }
-    })();
+    });
 
     return {
       status: 'executed',

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -272,9 +272,10 @@ export class BashTool extends defineTool({
     );
     const runWithOwnership = captureOwnedExecutionLease(executionId);
 
-    const childStream = await runWithOwnership(async () => {
-      try {
-        return createChildStream(executionId, parentStreamId, {
+    let childStream!: ReturnType<typeof createChildStream>;
+    try {
+      runWithOwnership(() => {
+        childStream = createChildStream(executionId, parentStreamId, {
           streamPrefix: 'bash@tool',
           streamCategory: AgentCategory.ToolUse,
           agentName: 'bash',
@@ -283,10 +284,10 @@ export class BashTool extends defineTool({
           toolName: 'bash',
           runtimeHost,
         });
-      } catch (error) {
-        throw await releaseOwnedExecutionLeaseAfterFailure(executionId, error);
-      }
-    });
+      });
+    } catch (error) {
+      throw await releaseOwnedExecutionLeaseAfterFailure(executionId, error);
+    }
     const { childStreamId, logger } = childStream;
     let stdoutTail = '';
     let stderrTail = '';
@@ -325,42 +326,46 @@ export class BashTool extends defineTool({
     };
 
     const startedAt = Date.now();
-    const promise = executeCommand(command, {
-      cwd,
-      timeout: timeoutMs,
-      buffer: false,
-      onPid: (p) => {
-        session.setPid(p);
-      },
-      onStdout: (chunk) => {
-        stdoutTotalChars += chunk.length;
-        stdoutHead = appendHead(
-          stdoutHead,
-          chunk,
-          BACKGROUND_OUTPUT_HEAD_CHARS,
-        );
-        stdoutTail = appendTail(
-          stdoutTail,
-          chunk,
-          BACKGROUND_OUTPUT_TAIL_CHARS,
-        );
-        logChunk(chunk, 'info');
-      },
-      onStderr: (chunk) => {
-        stderrTotalChars += chunk.length;
-        stderrHead = appendHead(
-          stderrHead,
-          chunk,
-          BACKGROUND_OUTPUT_HEAD_CHARS,
-        );
-        stderrTail = appendTail(
-          stderrTail,
-          chunk,
-          BACKGROUND_OUTPUT_TAIL_CHARS,
-        );
-        logChunk(chunk, 'warn');
-      },
-    });
+    const promise = Promise.resolve(
+      runWithOwnership(() =>
+        executeCommand(command, {
+          cwd,
+          timeout: timeoutMs,
+          buffer: false,
+          onPid: (p) => {
+            session.setPid(p);
+          },
+          onStdout: (chunk) => {
+            stdoutTotalChars += chunk.length;
+            stdoutHead = appendHead(
+              stdoutHead,
+              chunk,
+              BACKGROUND_OUTPUT_HEAD_CHARS,
+            );
+            stdoutTail = appendTail(
+              stdoutTail,
+              chunk,
+              BACKGROUND_OUTPUT_TAIL_CHARS,
+            );
+            logChunk(chunk, 'info');
+          },
+          onStderr: (chunk) => {
+            stderrTotalChars += chunk.length;
+            stderrHead = appendHead(
+              stderrHead,
+              chunk,
+              BACKGROUND_OUTPUT_HEAD_CHARS,
+            );
+            stderrTail = appendTail(
+              stderrTail,
+              chunk,
+              BACKGROUND_OUTPUT_TAIL_CHARS,
+            );
+            logChunk(chunk, 'warn');
+          },
+        }),
+      ),
+    );
 
     const finalizeBackground = (
       options?: Parameters<typeof childStream.finalize>[0],

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -2,7 +2,7 @@
 import type { AgentTrace, StageHandle } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import { tryCaptureOwnedExecutionLease } from '@agent/storage/executionLease';
+import { captureOwnedExecutionLeaseIfPresent } from '@agent/storage/executionLease';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import {
   finalizeRunTerminal,
@@ -157,7 +157,7 @@ export function createChildStream(
     runtimeHost,
     runTrace.trace,
   );
-  const executionLeaseScope = tryCaptureOwnedExecutionLease(executionId);
+  const executionLeaseScope = captureOwnedExecutionLeaseIfPresent(executionId);
   if (executionLeaseScope) {
     handle.attachExecutionLeaseScope(executionLeaseScope);
   }

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -2,6 +2,7 @@
 import type { AgentTrace, StageHandle } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { tryCaptureOwnedExecutionLease } from '@agent/storage/executionLease';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import {
   finalizeRunTerminal,
@@ -156,6 +157,10 @@ export function createChildStream(
     runtimeHost,
     runTrace.trace,
   );
+  const executionLeaseScope = tryCaptureOwnedExecutionLease(executionId);
+  if (executionLeaseScope) {
+    handle.attachExecutionLeaseScope(executionLeaseScope);
+  }
   if (options.toolName) handle.toolName = options.toolName;
   // The process-owned snapshot listener persists both facts before handle
   // tracking; a later presentation replays them from the snapshot store during

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -12,6 +12,7 @@ import {
   deriveWorkflowScriptCheckpointId,
   parseWorkflowScript,
 } from '@agent/workflowScript';
+import { captureOwnedExecutionLease } from '@agent/storage/executionLease';
 import {
   AgentConfigSchema,
   type AgentConfigPayload,
@@ -159,73 +160,83 @@ Tool inclusion is the opt-in boundary: do not add this tool to a default agent c
         `Failed to launch workflow script '${meta.name}': ${toErrorMessage(error)}`,
       );
     }
+    const runWithOwnership = captureOwnedExecutionLease(runExecutionId);
 
-    // createChildStream is inside the lease-protected try: it runs after the
-    // deterministic run lease is held, so a throw here (missing subscribers,
-    // duplicate stream tab) must release the lease — otherwise the lease
-    // survives to its heartbeat timeout and a prompt relaunch is refused.
-    let runChildStreamId: StreamTabId;
-    try {
-      const childStream = createChildStream(runExecutionId, runScope.streamId, {
-        streamPrefix: STREAM_PREFIX,
-        streamCategory: AgentCategory.Workflow,
-        agentName: meta.name,
-        description: meta.description,
-        config: runConfig,
-        toolName: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
-        runtimeHost: runScope.runtimeHost,
-      });
-      runChildStreamId = childStream.childStreamId;
+    return await runWithOwnership(async () => {
+      // createChildStream is inside the lease-protected try: it runs after the
+      // deterministic run lease is held, so a throw here (missing subscribers,
+      // duplicate stream tab) must release the lease — otherwise the lease
+      // survives to its heartbeat timeout and a prompt relaunch is refused.
+      let runChildStreamId: StreamTabId;
+      try {
+        const childStream = createChildStream(
+          runExecutionId,
+          runScope.streamId,
+          {
+            streamPrefix: STREAM_PREFIX,
+            streamCategory: AgentCategory.Workflow,
+            agentName: meta.name,
+            description: meta.description,
+            config: runConfig,
+            toolName: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+            runtimeHost: runScope.runtimeHost,
+          },
+        );
+        runChildStreamId = childStream.childStreamId;
 
-      // The run's own stream inherits the orchestrator's bypass so grandchild
-      // agent() calls, which link to this stream, still resolve it transitively.
-      configureDelegatedChildApprovals(
-        runChildStreamId,
-        runScope.streamId,
-        'inherit',
-        runScope.session,
-      );
+        // The run's own stream inherits the orchestrator's bypass so grandchild
+        // agent() calls, which link to this stream, still resolve it transitively.
+        configureDelegatedChildApprovals(
+          runChildStreamId,
+          runScope.streamId,
+          'inherit',
+          runScope.session,
+        );
 
-      startChildRunLoop({
-        childStream,
-        childStreamId: runChildStreamId,
-        parentStreamId: runScope.streamId,
-        executionId: runExecutionId,
-        agentName: meta.name,
-        strategy: createWorkflowScriptStrategy({
+        startChildRunLoop({
+          childStream,
+          childStreamId: runChildStreamId,
+          parentStreamId: runScope.streamId,
           executionId: runExecutionId,
-          logger: childStream.logger,
-          store,
-          checkpointId,
-          script: input.script,
-          args: input.args,
-          name: meta.name,
-          workflowControls: runScope.session.workflowControls,
-          createRunAgent: (hooks) =>
-            createWorkflowScriptAgentRunner(
-              parent,
-              input.agent,
-              checkpointId,
-              { executionId: runExecutionId, streamId: runChildStreamId },
-              hooks,
-            ),
-        }),
-        recordCost,
-      });
-    } catch (error) {
-      throw await releaseOwnedExecutionLeaseAfterFailure(runExecutionId, error);
-    }
+          agentName: meta.name,
+          strategy: createWorkflowScriptStrategy({
+            executionId: runExecutionId,
+            logger: childStream.logger,
+            store,
+            checkpointId,
+            script: input.script,
+            args: input.args,
+            name: meta.name,
+            workflowControls: runScope.session.workflowControls,
+            createRunAgent: (hooks) =>
+              createWorkflowScriptAgentRunner(
+                parent,
+                input.agent,
+                checkpointId,
+                { executionId: runExecutionId, streamId: runChildStreamId },
+                hooks,
+              ),
+          }),
+          recordCost,
+        });
+      } catch (error) {
+        throw await releaseOwnedExecutionLeaseAfterFailure(
+          runExecutionId,
+          error,
+        );
+      }
 
-    return {
-      status: 'executed',
-      summary: `Launched workflow script '${meta.name}' (async)`,
-      output: [
-        `Workflow script '${meta.name}' launched. Its result and run log will be delivered automatically as a follow-up message when the run completes.`,
-        `Execution ID: ${runExecutionId}`,
-        `Stream tab: ${runChildStreamId}`,
-        `To check intermediate progress: executions tool with path=/executions/${runExecutionId} and action=wait (waits for next status change).`,
-        `To resume after a timeout or interruption: call this tool again with the same meta.name.`,
-      ].join('\n'),
-    };
+      return {
+        status: 'executed',
+        summary: `Launched workflow script '${meta.name}' (async)`,
+        output: [
+          `Workflow script '${meta.name}' launched. Its result and run log will be delivered automatically as a follow-up message when the run completes.`,
+          `Execution ID: ${runExecutionId}`,
+          `Stream tab: ${runChildStreamId}`,
+          `To check intermediate progress: executions tool with path=/executions/${runExecutionId} and action=wait (waits for next status change).`,
+          `To resume after a timeout or interruption: call this tool again with the same meta.name.`,
+        ].join('\n'),
+      };
+    });
   }
 }

--- a/src/tools/delegation/inBandSubagentExecution.ts
+++ b/src/tools/delegation/inBandSubagentExecution.ts
@@ -15,6 +15,7 @@ import {
   type ResultMeta,
 } from '@agent/storage';
 import {
+  captureOwnedExecutionLease,
   markOwnedExecutionLeaseUndurable,
   ownsExecutionLease,
 } from '@agent/storage/executionLease';
@@ -477,147 +478,168 @@ async function executeInBand(
     }
     throw cause;
   }
-  if (stableAttempt) {
+  const runWithOwnership = captureOwnedExecutionLease(executionId);
+  return await runWithOwnership(async () => {
+    let executionFailure: InBandExecutionFailure | undefined;
     try {
-      await writeStableSubagentAttempt(getExecutionStore(executionId), {
-        ...stableAttempt,
-        phase: 'launched',
-      });
-    } catch (cause) {
-      throw await releaseOwnedExecutionLeaseAfterFailure(
-        executionId,
-        new SubagentDurabilityError(
-          `Failed to mark subagent ${executionId} as launched.`,
-          { cause },
-        ),
-      );
-    }
-  }
+      if (stableAttempt) {
+        try {
+          await writeStableSubagentAttempt(getExecutionStore(executionId), {
+            ...stableAttempt,
+            phase: 'launched',
+          });
+        } catch (cause) {
+          throw await releaseOwnedExecutionLeaseAfterFailure(
+            executionId,
+            new SubagentDurabilityError(
+              `Failed to mark subagent ${executionId} as launched.`,
+              { cause },
+            ),
+          );
+        }
+      }
 
-  let runError: unknown;
-  let detachAbort = (): void => {};
-  let flowResult: AgentFlowResult;
-  try {
-    flowResult = await executeAgent(config, executionId, {
-      runtimeHost: options.runtimeHost,
-      session: options.session,
-      isSubagent: true,
-      enforceCategory: true,
-      parentStreamId: options.parentStreamId,
-      approvalPromptsUnavailable: options.approvalPromptsUnavailable,
-      runtimeUnavailableTools: options.runtimeUnavailableTools,
-      stopAfterCycle: true,
-      onStreamResolved: options.onStreamResolved,
-      onRunError: (error) => {
-        runError = error;
-      },
-      onRun: (handle) => {
-        detachAbort();
-        detachAbort = bindAbortSignal(options.signal, handle);
-      },
-    });
-  } catch (error) {
-    const errorResult = getAgentFlowErrorResult(error);
-    settleCost(errorResult?.totalCostUsd);
-    await persistFailure(
-      mode,
-      executionId,
-      stableAttempt,
-      options.agentName,
-      options.parentExecutionId,
-      config.agentCategory,
-      error,
-      errorResult,
-      startedAt,
-      workingDirectory,
-    );
-    throw error;
-  } finally {
-    detachAbort();
-  }
-
-  settleCost(flowResult.totalCostUsd);
-  if (flowResult.outcome === 'failed') {
-    const error = runError ?? new Error('Subagent ended with failed outcome.');
-    await persistFailure(
-      mode,
-      executionId,
-      stableAttempt,
-      options.agentName,
-      options.parentExecutionId,
-      config.agentCategory,
-      error,
-      flowResult,
-      startedAt,
-      workingDirectory,
-    );
-    throw error;
-  }
-
-  let built: BuiltSubagentResult;
-  try {
-    built = await buildSubagentResult(
-      executionId,
-      options.agentName,
-      flowResult,
-      {
-        startedAt,
-        workingDirectory,
-        parentExecutionId: options.parentExecutionId,
-      },
-    );
-  } catch (error) {
-    // The runtime has already finalized this child. A post-flow construction
-    // error must not rewrite a completed execution as failed or try to parse
-    // the same invalid flow data again through the failure-result builder.
-    if (mode === 'required-result') {
-      throw new SubagentDurabilityError(
-        `Failed to construct result for subagent ${executionId}.`,
-        { cause: error },
-      );
-    }
-    await persistReportBestEffort(
-      executionId,
-      formatSubagentError(executionId, options.agentName, error, {
-        wallTimeMs: Date.now() - startedAt,
-        workingDirectory,
-        memoryMisses: flowResult.memoryMisses,
-      }),
-    );
-    throw error;
-  }
-
-  let delivery: string | undefined;
-  if (mode === 'required-result') {
-    await persistResultMetaRequired(executionId, built.resultMeta);
-  } else {
-    try {
-      delivery = formatBuiltSubagentDelivery(
-        executionId,
-        options.agentName,
-        flowResult,
-        built,
-        workingDirectory,
-      );
-    } catch (error) {
-      await persistResultMetaBestEffort(executionId, built.resultMeta);
-      await persistReportBestEffort(
-        executionId,
-        formatSubagentError(executionId, options.agentName, error, {
-          wallTimeMs: built.wallTimeMs,
+      let runError: unknown;
+      let detachAbort = (): void => {};
+      let flowResult: AgentFlowResult;
+      try {
+        flowResult = await executeAgent(config, executionId, {
+          runtimeHost: options.runtimeHost,
+          session: options.session,
+          isSubagent: true,
+          enforceCategory: true,
+          parentStreamId: options.parentStreamId,
+          approvalPromptsUnavailable: options.approvalPromptsUnavailable,
+          runtimeUnavailableTools: options.runtimeUnavailableTools,
+          stopAfterCycle: true,
+          onStreamResolved: options.onStreamResolved,
+          onRunError: (error) => {
+            runError = error;
+          },
+          onRun: (handle) => {
+            detachAbort();
+            detachAbort = bindAbortSignal(options.signal, handle);
+          },
+        });
+      } catch (error) {
+        const errorResult = getAgentFlowErrorResult(error);
+        settleCost(errorResult?.totalCostUsd);
+        await persistFailure(
+          mode,
+          executionId,
+          stableAttempt,
+          options.agentName,
+          options.parentExecutionId,
+          config.agentCategory,
+          error,
+          errorResult,
+          startedAt,
           workingDirectory,
-          memoryMisses: flowResult.memoryMisses,
-        }),
-      );
-      throw error;
-    }
-    await persistDeliveryBestEffort(executionId, delivery, built.resultMeta);
-  }
+        );
+        throw error;
+      } finally {
+        detachAbort();
+      }
 
-  // Post-flow artifact construction deliberately reaches a terminal record.
-  // Cancellation observed here rejects the caller without changing that record.
-  options.signal?.throwIfAborted();
-  return { executionId, built, delivery };
+      settleCost(flowResult.totalCostUsd);
+      if (flowResult.outcome === 'failed') {
+        const error =
+          runError ?? new Error('Subagent ended with failed outcome.');
+        await persistFailure(
+          mode,
+          executionId,
+          stableAttempt,
+          options.agentName,
+          options.parentExecutionId,
+          config.agentCategory,
+          error,
+          flowResult,
+          startedAt,
+          workingDirectory,
+        );
+        throw error;
+      }
+
+      let built: BuiltSubagentResult;
+      try {
+        built = await buildSubagentResult(
+          executionId,
+          options.agentName,
+          flowResult,
+          {
+            startedAt,
+            workingDirectory,
+            parentExecutionId: options.parentExecutionId,
+          },
+        );
+      } catch (error) {
+        // The runtime has already finalized this child. A post-flow construction
+        // error must not rewrite a completed execution as failed or try to parse
+        // the same invalid flow data again through the failure-result builder.
+        if (mode === 'required-result') {
+          throw new SubagentDurabilityError(
+            `Failed to construct result for subagent ${executionId}.`,
+            { cause: error },
+          );
+        }
+        await persistReportBestEffort(
+          executionId,
+          formatSubagentError(executionId, options.agentName, error, {
+            wallTimeMs: Date.now() - startedAt,
+            workingDirectory,
+            memoryMisses: flowResult.memoryMisses,
+          }),
+        );
+        throw error;
+      }
+
+      let delivery: string | undefined;
+      if (mode === 'required-result') {
+        await persistResultMetaRequired(executionId, built.resultMeta);
+      } else {
+        try {
+          delivery = formatBuiltSubagentDelivery(
+            executionId,
+            options.agentName,
+            flowResult,
+            built,
+            workingDirectory,
+          );
+        } catch (error) {
+          await persistResultMetaBestEffort(executionId, built.resultMeta);
+          await persistReportBestEffort(
+            executionId,
+            formatSubagentError(executionId, options.agentName, error, {
+              wallTimeMs: built.wallTimeMs,
+              workingDirectory,
+              memoryMisses: flowResult.memoryMisses,
+            }),
+          );
+          throw error;
+        }
+        await persistDeliveryBestEffort(
+          executionId,
+          delivery,
+          built.resultMeta,
+        );
+      }
+
+      // Post-flow artifact construction deliberately reaches a terminal record.
+      // Cancellation observed here rejects the caller without changing that record.
+      options.signal?.throwIfAborted();
+      return { executionId, built, delivery };
+    } catch (error) {
+      markOwnedExecutionLeaseUndurable(executionId);
+      executionFailure = { error };
+      throw error;
+    } finally {
+      await releaseInBandExecutionLease(
+        options.session,
+        executionId,
+        executionFailure,
+      );
+    }
+  });
 }
 
 /** Recover a logical child first; resolve launch-only state only when needed. */
@@ -744,29 +766,16 @@ export async function executeStableSubagentInBand(
         `Prepared subagent ${executionId} changed its parent execution.`,
       );
     }
-    let executionFailure: InBandExecutionFailure | undefined;
-    try {
-      const completed = await executeInBand(
-        prepared,
-        'required-result',
-        executionId,
-        attempt,
-      );
-      return {
-        executionId: completed.executionId,
-        result: completed.built.result,
-      };
-    } catch (error) {
-      markOwnedExecutionLeaseUndurable(executionId);
-      executionFailure = { error };
-      throw error;
-    } finally {
-      await releaseInBandExecutionLease(
-        prepared.session,
-        executionId,
-        executionFailure,
-      );
-    }
+    const completed = await executeInBand(
+      prepared,
+      'required-result',
+      executionId,
+      attempt,
+    );
+    return {
+      executionId: completed.executionId,
+      result: completed.built.result,
+    };
   });
 }
 
@@ -775,30 +784,17 @@ export async function executeSubagentForDeliveryInBand(
   options: InBandSubagentDeliveryOptions,
 ): Promise<InBandSubagentDeliveryResult> {
   const executionId = generateExecutionId() as ExecutionId;
-  let executionFailure: InBandExecutionFailure | undefined;
-  try {
-    const completed = await executeInBand(
-      options,
-      'best-effort-delivery',
-      executionId,
-    );
-    if (completed.delivery === undefined) {
-      throw new Error('Subagent delivery was not constructed.');
-    }
-    return {
-      executionId: completed.executionId,
-      result: completed.built.result,
-      delivery: completed.delivery,
-    };
-  } catch (error) {
-    markOwnedExecutionLeaseUndurable(executionId);
-    executionFailure = { error };
-    throw error;
-  } finally {
-    await releaseInBandExecutionLease(
-      options.session,
-      executionId,
-      executionFailure,
-    );
+  const completed = await executeInBand(
+    options,
+    'best-effort-delivery',
+    executionId,
+  );
+  if (completed.delivery === undefined) {
+    throw new Error('Subagent delivery was not constructed.');
   }
+  return {
+    executionId: completed.executionId,
+    result: completed.built.result,
+    delivery: completed.delivery,
+  };
 }

--- a/src/tools/delegation/subagentExecution.ts
+++ b/src/tools/delegation/subagentExecution.ts
@@ -12,6 +12,7 @@ import {
   registerExecution,
   releaseOwnedExecutionLeaseAfterFailure,
 } from '@agent/storage';
+import { captureOwnedExecutionLease } from '@agent/storage/executionLease';
 import {
   AgentConfigSchema,
   type AgentConfigPayload,
@@ -161,87 +162,90 @@ export async function executeSubagent(
   const startedAt = Date.now();
   const config = AgentConfigSchema.parse(childConfigPayload);
   await registerExecution(executionId, config, agentName, parentExecutionId);
+  const runWithOwnership = captureOwnedExecutionLease(executionId);
 
-  const isToolUse = config.agentCategory === AgentCategory.ToolUse;
-  // Must match the id `buildAgentLaunchContext` actually reserves for this
-  // executionId (see AgentLaunchContext.ts's `reservedStreamId`), or the
-  // loop acquires the wrong follow-up queue/interrupt slot. That reservation
-  // uses the canonical config's agent/model — not the `agentName` parameter,
-  // which callers may resolve differently
-  // (e.g. an approved agent override's display name vs. its registry name).
-  // Derive from the exact same fields, not a parallel formula.
-  const childStreamId = getStreamTabId(config.agent, config.model, {
-    executionId,
-  });
-  const strategyParams = {
-    config,
-    agentCategoryExplicit: childConfigPayload.agentCategory !== undefined,
-    executionId,
-    agentName,
-    orchestratorStreamId,
-    parentSession,
-    runtimeHost,
-    startedAt,
-    workingDirectory,
-    approvalPromptsUnavailable: parentContext.approvalPromptsUnavailable,
-    runtimeUnavailableTools: parentContext.runtimeUnavailableTools,
-    onStreamResolved: inheritChildStreamApprovals,
-  };
+  return await runWithOwnership(async () => {
+    const isToolUse = config.agentCategory === AgentCategory.ToolUse;
+    // Must match the id `buildAgentLaunchContext` actually reserves for this
+    // executionId (see AgentLaunchContext.ts's `reservedStreamId`), or the
+    // loop acquires the wrong follow-up queue/interrupt slot. That reservation
+    // uses the canonical config's agent/model — not the `agentName` parameter,
+    // which callers may resolve differently
+    // (e.g. an approved agent override's display name vs. its registry name).
+    // Derive from the exact same fields, not a parallel formula.
+    const childStreamId = getStreamTabId(config.agent, config.model, {
+      executionId,
+    });
+    const strategyParams = {
+      config,
+      agentCategoryExplicit: childConfigPayload.agentCategory !== undefined,
+      executionId,
+      agentName,
+      orchestratorStreamId,
+      parentSession,
+      runtimeHost,
+      startedAt,
+      workingDirectory,
+      approvalPromptsUnavailable: parentContext.approvalPromptsUnavailable,
+      runtimeUnavailableTools: parentContext.runtimeUnavailableTools,
+      onStreamResolved: inheritChildStreamApprovals,
+    };
 
-  try {
-    if (isToolUse) {
-      const { createNativeToolUseStrategy } =
-        await import('./nativeToolUseStrategy');
-      startChildRunLoop({
-        childStreamId,
-        parentStreamId: orchestratorStreamId,
-        executionId,
-        agentName,
-        strategy: createNativeToolUseStrategy(strategyParams),
-        recordCost: settleSubagentCost,
-      });
-    } else {
-      const { createNativeWorkflowStrategy } =
-        await import('./nativeWorkflowStrategy');
-      startChildRunLoop({
-        childStreamId,
-        parentStreamId: orchestratorStreamId,
-        executionId,
-        agentName,
-        strategy: createNativeWorkflowStrategy(strategyParams),
-        recordCost: settleSubagentCost,
-      });
+    try {
+      if (isToolUse) {
+        const { createNativeToolUseStrategy } =
+          await import('./nativeToolUseStrategy');
+        startChildRunLoop({
+          childStreamId,
+          parentStreamId: orchestratorStreamId,
+          executionId,
+          agentName,
+          strategy: createNativeToolUseStrategy(strategyParams),
+          recordCost: settleSubagentCost,
+        });
+      } else {
+        const { createNativeWorkflowStrategy } =
+          await import('./nativeWorkflowStrategy');
+        startChildRunLoop({
+          childStreamId,
+          parentStreamId: orchestratorStreamId,
+          executionId,
+          agentName,
+          strategy: createNativeWorkflowStrategy(strategyParams),
+          recordCost: settleSubagentCost,
+        });
+      }
+    } catch (error) {
+      throw await releaseOwnedExecutionLeaseAfterFailure(executionId, error);
     }
-  } catch (error) {
-    throw await releaseOwnedExecutionLeaseAfterFailure(executionId, error);
-  }
 
-  const meta = options?.approvalMeta;
-  const metaLines: string[] = [];
-  if (meta) {
-    const modelInfo = meta.modelOverride
-      ? `Model: ${meta.modelOverride} (overridden from ${meta.requestedModel ?? 'default'})`
-      : `Model: ${childConfigPayload.model}`;
-    const agentInfo = meta.agentOverride
-      ? ` Agent: ${meta.agentOverride} (overridden from ${meta.requestedAgent ?? 'default'}).`
-      : '';
-    metaLines.push(
-      `Approval: ${meta.autoApproved ? 'auto-approved' : 'user-approved'}. ${modelInfo}.${agentInfo}`,
-    );
-  }
-  return {
-    status: 'executed',
-    summary: `Launched '${agentName}' (async)`,
-    output: [
-      `Subagent '${agentName}' launched. Result will be delivered automatically as a follow-up message when complete.`,
-      `Execution ID: ${executionId}`,
-      ...metaLines,
-      `To check intermediate progress: executions tool with path=/executions/${executionId} and action=wait (waits for next status change).`,
-      ...(isToolUse
-        ? [
-            `To send follow-up instructions after delivery: use delegate_agent with execution_id set to this ID.`,
-          ]
-        : []),
-    ].join('\n'),
-  };
+    const meta = options?.approvalMeta;
+    const metaLines: string[] = [];
+    if (meta) {
+      const modelInfo = meta.modelOverride
+        ? `Model: ${meta.modelOverride} (overridden from ${meta.requestedModel ?? 'default'})`
+        : `Model: ${childConfigPayload.model}`;
+      const agentInfo = meta.agentOverride
+        ? ` Agent: ${meta.agentOverride} (overridden from ${meta.requestedAgent ?? 'default'}).`
+        : '';
+      metaLines.push(
+        `Approval: ${meta.autoApproved ? 'auto-approved' : 'user-approved'}. ${modelInfo}.${agentInfo}`,
+      );
+    }
+    return {
+      status: 'executed',
+      summary: `Launched '${agentName}' (async)`,
+      output: [
+        `Subagent '${agentName}' launched. Result will be delivered automatically as a follow-up message when complete.`,
+        `Execution ID: ${executionId}`,
+        ...metaLines,
+        `To check intermediate progress: executions tool with path=/executions/${executionId} and action=wait (waits for next status change).`,
+        ...(isToolUse
+          ? [
+              `To send follow-up instructions after delivery: use delegate_agent with execution_id set to this ID.`,
+            ]
+          : []),
+      ].join('\n'),
+    };
+  });
 }


### PR DESCRIPTION
## Summary

- replace the process-global execution-id tombstone set with lease-generation capabilities carried through the existing async run context
- reject delayed work from a displaced owner even after the same process acquires a successor lease for that execution
- keep maintenance and unowned migration writes explicit without accumulating per-execution fence state

## Root cause

The old write fence remembered only an execution ID. That made the safety state unbounded, and deleting a fence when the same process reacquired the execution also meant a delayed continuation from the former owner could borrow the successor's lease.

Run work now carries the exact lease owner token in `AsyncLocalStorage`. Execution-store writes compare that captured generation with the currently owned lease. Once ownership changes, old continuations remain fenced by their own capability, while the process no longer needs a permanent collection of historical execution IDs.

Closes #9033

## Verification

- full Vitest suite: 7,072 passed, 4 skipped
- root and test-kernel TypeScript checks
- full ESLint: zero errors, one pre-existing warning
- Prettier and diff whitespace checks
- dead-code ratchet

`compile:fast` could not run from the detached worktree because pnpm attempted to purge its symlinked dependency directories without a TTY; exact-head CI will run the clean build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core execution lease semantics and every path that persists execution state; mistakes could allow cross-owner writes or block legitimate shutdown/resume finalization.
> 
> **Overview**
> Execution ownership is no longer tracked with a growing set of fenced execution IDs. **Lease generation** (owner token) is carried in `AsyncLocalStorage` via `captureOwnedExecutionLease` / `runWithOwnedExecutionLease`, and storage writes must match the active scope—so a delayed continuation from an old owner cannot use a successor lease in the same process.
> 
> **`runAgent` / `executeAgent`** wrap the full run in the captured scope; **`runAgent`** exposes `onExecutionLeaseAcquired` so the CLI can finalize **INTERRUPTED** status on shutdown only inside a still-valid lease (and skips finalization on `ExecutionLeaseLostError`).
> 
> **`AgentExecutionHandle`** stores an optional lease scope and routes waiting-termination / registry cleanup through `runWithExecutionLease`, with recovery paths that avoid mutating a re-tracked successor after lease loss.
> 
> Child loops, registration, subagent/bash/workflow launches, and resume paths are wrapped the same way. Lease helpers (`release`, `abandon`, write fence, `ownsExecutionLease`) are **scope-aware**; unscoped writes are rejected when a foreign lease exists on disk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 227ad440034379202e938a8c77df69cea7bfa0ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->