### PR TITLE
refactor: consolidate three custom implementations onto native/shared helpers

### DIFF
--- a/packages/cli/src/runtime/clipboardText.ts
+++ b/packages/cli/src/runtime/clipboardText.ts
@@ -1,6 +1,7 @@
 import { execFile } from 'node:child_process';
 import { platform as osPlatform } from 'node:os';
 import { basename } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
 import { promisify } from 'node:util';
 
 import clipboard from 'clipboardy';
@@ -87,9 +88,7 @@ const FALLBACK_REAP_DELAY_MS = 300;
 async function reapWedgedCopyHelpers(platform: NodeJS.Platform): Promise<void> {
   for (let sweep = 0; sweep < 2; sweep += 1) {
     if (sweep > 0) {
-      await new Promise((resolve) =>
-        setTimeout(resolve, FALLBACK_REAP_DELAY_MS),
-      );
+      await sleep(FALLBACK_REAP_DELAY_MS);
     }
     try {
       await (platform === 'win32'

--- a/packages/extension/src/progressView/frontend/components/RequestPanelsState.ts
+++ b/packages/extension/src/progressView/frontend/components/RequestPanelsState.ts
@@ -1,5 +1,6 @@
 // Local imports - shared utilities
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
+import { clampIndex } from '@utils/core';
 
 // Local imports - progress view component types
 import { permissionId, type PermissionState } from '../permissionState';
@@ -63,7 +64,7 @@ export function selectExternalInquiryKey(
   if (selectedKey && keys.includes(selectedKey)) return selectedKey;
 
   const previousIndex = selectedKey ? previousKeys.indexOf(selectedKey) : 0;
-  const fallbackIndex = Math.min(Math.max(previousIndex, 0), keys.length - 1);
+  const fallbackIndex = clampIndex(previousIndex, keys.length);
   return keys[fallbackIndex] ?? null;
 }
 

--- a/src/shared/utils/clipboardImages.ts
+++ b/src/shared/utils/clipboardImages.ts
@@ -40,15 +40,12 @@ export interface ExtractedClipboardImage {
 export function clipboardImageFiles(
   event: ClipboardEvent,
 ): Array<{ file: File; type: string }> {
-  const list = event.clipboardData?.items;
-  const images: Array<{ file: File; type: string }> = [];
-  for (let i = 0; i < (list?.length ?? 0); i++) {
-    const item = list?.[i];
-    if (!item || !item.type.startsWith('image/')) continue;
+  const items = [...(event.clipboardData?.items ?? [])];
+  return items.flatMap((item) => {
+    if (!item.type.startsWith('image/')) return [];
     const file = item.getAsFile();
-    if (file) images.push({ file, type: item.type });
-  }
-  return images;
+    return file ? [{ file, type: item.type }] : [];
+  });
 }
 
 /** Read a File to base64 (no data-URL prefix), or null on failure. */


### PR DESCRIPTION
## Summary

Scheduled scan for duplicated logic and custom reimplementations of native/stdlib functionality. Two research passes (duplicate-logic sweep, native-method sweep) covered `src/`, `packages/extension/src`, `packages/desktop/src`, `packages/cli/src`, and `packages/trace-viewer/src`. This is a disciplined codebase (Zod-first, explicit anti-premature-abstraction rules, and most near-duplicates already carry a comment explaining an intentional divergence), so the yield was small: three safe, mechanical swaps, each a single call site.

1. `packages/cli/src/runtime/clipboardText.ts` — `reapWedgedCopyHelpers` used a hand-rolled `new Promise((resolve) => setTimeout(resolve, ms))` for its 300ms fallback-reap delay. Swapped for `setTimeout as sleep` from `node:timers/promises`, the idiom already used in `src/auth/codex/codexDeviceLogin.ts`, `packages/cli/src/runtime/supabaseAuthDeviceCode.ts`, and `packages/cli/src/chat/tui/runChatTui.tsx` — and codified as the required pattern in AGENTS.md and the code-review checklist (`new Promise((resolve) => setTimeout(...))` in Node-only code is explicitly flagged).
2. `packages/extension/src/progressView/frontend/components/RequestPanelsState.ts` — `selectExternalInquiryKey`'s fallback-index computation (`Math.min(Math.max(previousIndex, 0), keys.length - 1)`) duplicated the existing `clampIndex(index, length)` helper in `src/utils/core/index.ts`, which does exactly this (including the `length <= 0` guard) and is already imported by sibling files in the same package (e.g. `packages/cli/src/chat/tui/ui/Select.tsx`).
3. `src/shared/utils/clipboardImages.ts` — `clipboardImageFiles` manually indexed a `DataTransferItemList` with a `for (let i = 0; ...)` loop to filter image items and collect files. Replaced with spread + `flatMap`.

No behavior change in any of the three — same delay, same clamping semantics, same filter/collect result.

## Issue acceptance gates

No tracked issue; this is a scheduled maintenance scan. Acceptance gate is self-imposed: each finding had to be a documented-safe, single-call-site, behavior-preserving swap onto an existing native method or already-established shared helper — not a new abstraction.

## Single source of truth

- Sleep delay: `node:timers/promises`' `setTimeout`, the repo's already-standard sleep idiom (no new helper introduced).
- Index clamping: `clampIndex` in `src/utils/core/index.ts`, already the canonical helper — `RequestPanelsState.ts` now uses it instead of re-deriving the same math.

## Duplication and abstraction budget

Removed duplication (a re-derived clamp expression, a re-derived Promise/setTimeout sleep, and a manual array-building loop); no new abstractions, helpers, or exports added.

## Net elements (R6)

3 files changed, 9 insertions(+), 12 deletions(-), net -3 LoC. No exported symbols added or removed (`git diff origin/main..HEAD | grep -E '^[+-].*export '` → no hits — only internal call-site changes).

## Consumer counts (R8)

n/a — no emit path, export, or public API re-routed; all three changes are internal to their function bodies.

## Host impact

Extension: `RequestPanelsState.ts` (progress-view frontend) — fallback external-inquiry-panel selection logic only, no behavior change.

Desktop: none.

CLI: `clipboardText.ts` — clipboard-write fallback-helper reap delay, no behavior change.

Also touches `src/shared/utils/clipboardImages.ts`, shared by both the main webview and progress-view paste handlers in the Extension host.

## Scheduled refactoring

None. The two research sweeps turned up no other safe candidates — remaining near-duplicates (retry/backoff variants, dedup helpers, `Object.assign` mutation sites, etc.) were read in full and are documented-intentional divergences, not consolidation opportunities.

## Validation

- `npm run typecheck` — passes across all workspaces (root, test-kernel, extension, cli, trace-viewer, desktop).
- `npm run lint` — 0 errors, 0 warnings on the changed files (one `unicorn/prefer-spread` warning surfaced during iteration and was fixed before commit).
- `npm test` (full Vitest suite, 7075 tests) — 1 pre-existing failure (`SystemUtils.vitest.ts > aborts shell command process groups including children`), confirmed present on `origin/main` before this change (via `git stash` + rerun) and unrelated to the touched files — a process-group-kill assertion that doesn't hold in this sandboxed container. All other tests pass, including the specific suites covering the three changed files (`ClipboardImages.vitest.ts`, `RequestPanelsState.vitest.ts`, `ClipboardText.vitest.mts`, `PasteHandler.vitest.ts`, and the full `progressView` suite).


---
_Generated by [Claude Code](https://claude.ai/code/session_012DGCWigfKGTjdDXxNMRaNX)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactors only; semantics are documented as unchanged and touch non-critical UI/clipboard helpers.
> 
> **Overview**
> Mechanical consolidation at three single call sites: no new APIs and no intended behavior change.
> 
> **CLI clipboard reap delay** — `reapWedgedCopyHelpers` now awaits `setTimeout` from `node:timers/promises` (aliased as `sleep`) instead of a hand-rolled `Promise` + `setTimeout` for the 300ms second sweep.
> 
> **Progress view inquiry selection** — `selectExternalInquiryKey` uses shared `clampIndex(previousIndex, keys.length)` instead of inline `Math.min` / `Math.max` for the fallback panel index.
> 
> **Clipboard image paste** — `clipboardImageFiles` builds the image list with spread + `flatMap` over clipboard items instead of a manual indexed loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5df953b3e36999fec95ff30afb2e005645b8c551. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->