### PR TITLE
refactor(runtime): delete the dead mediaAttachmentKinds export

### DIFF
--- a/src/agent/runtime/mediaVisionWarning.ts
+++ b/src/agent/runtime/mediaVisionWarning.ts
@@ -1,4 +1,3 @@
-import type { MediaAttachmentKind } from '@shared/schemas';
 import { getMimeType } from '@utils/files';
 import type { ModelCapabilities } from 'llm-zoo';
 
@@ -6,21 +5,6 @@ type MediaVisionWarningKind = 'attached' | 'pasted';
 
 function needsVision(filePath: string): boolean {
   return !getMimeType(filePath)?.startsWith('audio/');
-}
-
-/**
- * Classify each attached media file as `image` or `document` (everything
- * non-image) by its MIME type — the same coarse split
- * `normalizeConversationForExport` renders attachment markers for. Feeds the
- * `userMessage` transcript row's attachment markers (#7508): kind + count
- * only, never bytes.
- */
-export function mediaAttachmentKinds(
-  mediaFiles: readonly string[] | undefined,
-): MediaAttachmentKind[] {
-  return (mediaFiles ?? []).map((filePath) =>
-    getMimeType(filePath)?.startsWith('image/') ? 'image' : 'document',
-  );
 }
 
 export function countMediaFilesNeedingVision(

--- a/src/test-kernel/agent/runtime/mediaVisionWarning.vitest.ts
+++ b/src/test-kernel/agent/runtime/mediaVisionWarning.vitest.ts
@@ -5,7 +5,6 @@ import { describe, expect, it } from 'vitest';
 import {
   countMediaFilesNeedingVision,
   formatMediaNeedsVisionWarning,
-  mediaAttachmentKinds,
   shouldWarnMediaNeedsVision,
 } from '@agent/runtime/mediaVisionWarning';
 
@@ -52,20 +51,5 @@ describe('media vision warnings', () => {
     expect(formatMediaNeedsVisionWarning(2, 'pasted')).toBe(
       'Model has no vision support — 2 pasted media files are not sent to the model. Switch to a vision-capable model to use them.',
     );
-  });
-
-  // #7508: classifies each attached file as image/document (kind only, no
-  // bytes) so the userMessage transcript row can carry attachment markers.
-  describe('mediaAttachmentKinds', () => {
-    it('classifies image files as image and everything else as document', () => {
-      expect(
-        mediaAttachmentKinds(['figure.png', 'notes.pdf', 'voice.mp3']),
-      ).toEqual(['image', 'document', 'document']);
-    });
-
-    it('returns an empty array for no media files', () => {
-      expect(mediaAttachmentKinds(undefined)).toEqual([]);
-      expect(mediaAttachmentKinds([])).toEqual([]);
-    });
   });
 });


### PR DESCRIPTION
## Summary

`mediaAttachmentKinds` in `src/agent/runtime/mediaVisionWarning.ts` was an exported helper with **zero production callers** — its only references were in its own unit test. Its doc comment claimed it feeds the `userMessage` transcript row's attachment markers (#7508), but that computation actually lives in the independent private function `mediaAttachmentKindsFromEntries` in `ModelHandler.ts` (defined at `:174`, used at `:918`), which operates on message entries rather than file paths. The export was superseded during an earlier change and never removed.

This deletes the function, its now-unused `MediaAttachmentKind` import, and the `describe('mediaAttachmentKinds')` test block that was its sole consumer.

## Issue acceptance gates

No tracked issue. Surfaced by the 2026-07-21 tech-debt tournament cycle (ledger #8974, area `agent-runtime`) as the single candidate that survived adversarial self-verification. The other candidates that cycle surfaced were dropped on verification and are **not** in this PR: `bestConnectionMethodAnthropic` (documented false positive — live in `connectionTests.ts`, adjudicated in `docs/proposals/agent-sdk-readiness-checkpoint-2026-07-09.md`), the `codexConfig` `CODEX_APPROVAL_POLICIES`/`CODEX_SANDBOX_MODES` consts (load-bearing `satisfies` fences against the OpenAI Codex SDK unions), `prepareExistingOutputContent` (documented planned reuse in `google-interactions-api-impl-spec.md`), and `createRunScope` (12 callers; inlining its `Object.freeze` would be net-positive LoC).

## Single source of truth

Transcript attachment-marker classification remains solely owned by `mediaAttachmentKindsFromEntries` in `ModelHandler.ts`. Removing the orphaned duplicate leaves one owner, not zero.

## Duplication and abstraction budget

Removes a vestigial second implementation of the image/document media split. No abstraction added; no pass-through introduced.

## Net elements (R6)

- Files: 2 changed, 0 added, 0 deleted (diffstat: `2 files changed, 32 deletions(-)`).
- Exported symbols: `-1` (`export function mediaAttachmentKinds`; `^[+-]export` over the diff = one `-export`, zero `+export`).
- Classes/interfaces/enums: 0.
- Net LoC: **-32** (-16 source, -16 test).

## Consumer counts (R8)

`mediaAttachmentKinds` production consumers: **0** (`rg '\bmediaAttachmentKinds\b' src packages` → only the definition and its test before this PR; the `ModelHandler.ts` hits are the unrelated private `mediaAttachmentKindsFromEntries`). No emit path or re-routing involved. Not present in `config/ratchets/knip-baseline.json`. The `MediaAttachmentKind` schema type stays live (still imported by `MediaExtractionNode.ts`, `followUpMessages.ts`, `attachmentMarkerVocabulary.ts`, `modelHandlerValidation.ts`).

## Host impact

Extension: none (dead export; no behavior change).

Desktop: none.

CLI: none.

## Scheduled refactoring

None.

## Validation

- `npx vitest run src/test-kernel/agent/runtime/mediaVisionWarning.vitest.ts` → 6/6 pass.
- `npm run typecheck` → exit 0 (all six project configs).
- `npx eslint` on both changed files → clean.
- `npm run check:dead-code-ratchet` → OK (18 vs 18 baselined; no new unused exports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wm5pDPGPZ1AfM43XbsJwBX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wm5pDPGPZ1AfM43XbsJwBX)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal only; no production callers and no behavior change to vision warnings or attachment markers.
> 
> **Overview**
> Removes the unused **`mediaAttachmentKinds`** helper from `mediaVisionWarning.ts` and drops its dedicated unit tests. That export duplicated the image/document split already handled in production by the private **`mediaAttachmentKindsFromEntries`** in `ModelHandler.ts`; nothing in the app imported the removed symbol.
> 
> Vision-warning behavior is unchanged: **`countMediaFilesNeedingVision`**, **`shouldWarnMediaNeedsVision`**, and **`formatMediaNeedsVisionWarning`** stay as-is.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 043b0ce8377a958316ef27d978fef08f7179a76c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->