### PR TITLE
fix: release editor history after executions

### DIFF
--- a/src/test-kernel/tools/TextEditorToolHistoryCap.vitest.ts
+++ b/src/test-kernel/tools/TextEditorToolHistoryCap.vitest.ts
@@ -9,8 +9,12 @@ import { describe, it, beforeEach, afterEach } from 'vitest';
 
 // Local imports
 import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { AgentExecutionHandle } from '@agent/runtime/ExecutionHandle';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
-import { defaultSession } from '@agent/runtime/SessionHandle';
+import {
+  defaultSession,
+  type SessionHandle,
+} from '@agent/runtime/SessionHandle';
 import type { StreamTabId } from '@shared/schemas';
 import { installPlatform as installFakePlatform } from '@test/support/setupPlatform';
 import { TextEditorTool } from '@tools/TextEditorTool';
@@ -46,22 +50,31 @@ async function installPlatform(
   });
 }
 
-async function callTextEditor(tool: TextEditorTool, input: unknown) {
+async function callTextEditor(
+  tool: TextEditorTool,
+  input: unknown,
+  options: {
+    executionId?: string;
+    session?: SessionHandle;
+  } = {},
+) {
+  const executionId = options.executionId ?? EXECUTION_ID;
   return withRunContext(
     createRunContext({
       runtimeHost: noopAgentRuntimeHost,
-      streamId: `stream:${EXECUTION_ID}` as StreamTabId,
-      executionId: EXECUTION_ID,
+      streamId: `stream:${executionId}` as StreamTabId,
+      executionId,
+      session: options.session,
     }),
     () => tool.call(input),
   );
 }
 
 interface TextEditorToolInternals {
-  fileHistory: Map<string, string[]>;
+  fileHistory: Map<string, Map<string, string[]>>;
 }
 
-describe('TextEditorTool undo history cap', () => {
+describe('TextEditorTool undo history lifecycle', () => {
   beforeEach(async () => {
     await installPlatform();
     cleanupAllApprovals();
@@ -91,13 +104,13 @@ describe('TextEditorTool undo history cap', () => {
     assert.strictEqual(await WorkspaceFS.read('loop.tex'), `${EDIT_COUNT}\n`);
 
     const internals = tool as unknown as TextEditorToolInternals;
-    const key = [...internals.fileHistory.keys()].find((k) =>
-      k.endsWith('loop.tex'),
-    );
-    assert.ok(key, 'expected an undo-history entry for loop.tex');
+    const history = [
+      ...(internals.fileHistory.get(EXECUTION_ID)?.values() ?? []),
+    ].at(0);
+    assert.ok(history, 'expected an undo-history entry for loop.tex');
     assert.ok(
-      internals.fileHistory.get(key!)!.length <= 50,
-      `expected history capped at 50, got ${internals.fileHistory.get(key!)!.length}`,
+      history.length <= 50,
+      `expected history capped at 50, got ${history.length}`,
     );
 
     // The cap must never affect the one documented behavior: undoing the
@@ -111,5 +124,47 @@ describe('TextEditorTool undo history cap', () => {
       await WorkspaceFS.read('loop.tex'),
       `${EDIT_COUNT - 1}\n`,
     );
+  });
+
+  it('releases all snapshots when the owning execution completes', async () => {
+    await installPlatform({ '/workspace/lifecycle.tex': 'before\n' });
+    const tool = new TextEditorTool();
+    const session = defaultSession();
+    const streamId = `stream:${EXECUTION_ID}` as StreamTabId;
+    const handle = new AgentExecutionHandle(
+      EXECUTION_ID,
+      streamId,
+      streamId,
+      'orchestrator',
+      'toolUse',
+      noopAgentRuntimeHost,
+    );
+    session.executions.track(handle);
+
+    try {
+      const result = await callTextEditor(
+        tool,
+        {
+          command: 'str_replace',
+          path: 'lifecycle.tex',
+          old_str: 'before',
+          new_str: 'after',
+        },
+        { session },
+      );
+      assert.strictEqual(result.status, 'executed');
+
+      const internals = tool as unknown as TextEditorToolInternals;
+      assert.strictEqual(
+        [...(internals.fileHistory.get(EXECUTION_ID)?.values() ?? [])].at(0)
+          ?.length,
+        1,
+      );
+
+      session.executions.untrack(EXECUTION_ID);
+      assert.strictEqual(internals.fileHistory.has(EXECUTION_ID), false);
+    } finally {
+      session.executions.untrack(EXECUTION_ID);
+    }
   });
 });

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -7,7 +7,9 @@ import { z } from 'zod';
 // Local imports - tool definitions
 import {
   getRunContextExecutionId,
+  getRunContextSession,
   tryUseRunContext,
+  type RunContext,
 } from '@agent/runtime/RunContext';
 import { isTexFile } from '@common/files/fileTypeUtils';
 import * as logger from '@logger/logUtils';
@@ -88,19 +90,19 @@ export class TextEditorTool extends defineTool({
   // Tool API type
   private apiType: TextEditorApiType;
 
-  // File history for undo operations
-  private fileHistory: Map<string, string[]> = new Map();
+  // Undo snapshots owned by the execution that created them.
+  private fileHistory = new Map<string, Map<string, string[]>>();
+  private readonly observedExecutions = new Set<string>();
 
   /**
-   * Cap on retained full-file snapshots per (execution, file) key.
+   * Cap on retained full-file snapshots per execution and file.
    * `undo_edit` only ever pops the most recent snapshot (`history.at(-1)`),
    * so trimming the oldest entries beyond this depth never changes that
    * behavior — deep multi-level undo past this many edits in a single
    * execution isn't a documented or relied-upon usage pattern. Without this,
    * a long execution that edits the same file many times without ever
    * calling undo_edit retains every historical version of that file for the
-   * rest of the process's lifetime (fileHistory is a process-wide
-   * singleton, never cleared per-execution).
+   * lifetime of a long-running execution.
    */
   private static readonly MAX_HISTORY_PER_FILE = 50;
 
@@ -475,9 +477,10 @@ export class TextEditorTool extends defineTool({
     displayPath: string,
   ): Promise<ToolResult> {
     try {
-      const key = this.historyKey(filePath);
-      const history = this.fileHistory.get(key);
-      if (!history || history.length === 0) {
+      const executionId = this.currentExecutionId();
+      const executionHistory = this.fileHistory.get(executionId);
+      const history = executionHistory?.get(filePath);
+      if (!executionHistory || !history || history.length === 0) {
         throw new ToolError(`No edit history found for ${displayPath}.`);
       }
 
@@ -497,7 +500,10 @@ export class TextEditorTool extends defineTool({
         afterWrite: () => {
           history.pop();
           if (history.length === 0) {
-            this.fileHistory.delete(key);
+            executionHistory.delete(filePath);
+            if (executionHistory.size === 0) {
+              this.fileHistory.delete(executionId);
+            }
           }
         },
         present: ({ appliedContent }) => ({
@@ -511,29 +517,50 @@ export class TextEditorTool extends defineTool({
   }
 
   /**
-   * Scope undo history to the run that produced the edit. `fileHistory` is a
-   * process singleton (one TextEditorTool in the default registry), so keying by
-   * path alone bleeds edits across concurrent runs — a non-awaited subagent and
-   * its parent editing the same absolute path share the stack, so undo_edit could
-   * pop, or silently write to disk under YOLO, a foreign run's snapshot. Keying
-   * by the active run's executionId isolates them; with no run context
-   * (tests/manual) it collapses to the prior path-only behavior.
+   * Resolve the history owned by the active execution. With no run context,
+   * tests and one-shot manual calls share the legacy empty execution scope.
    */
-  private historyKey(filePath: string): string {
-    return `${getRunContextExecutionId(tryUseRunContext()) ?? ''}\u0000${filePath}`;
+  private currentExecutionId(): string {
+    return getRunContextExecutionId(tryUseRunContext()) ?? '';
   }
 
   private addToHistory(filePath: string, content: string): void {
-    const key = this.historyKey(filePath);
-    const history = this.fileHistory.get(key);
+    const context = tryUseRunContext();
+    const executionId = getRunContextExecutionId(context) ?? '';
+    let executionHistory = this.fileHistory.get(executionId);
+    if (!executionHistory) {
+      executionHistory = new Map();
+      this.fileHistory.set(executionId, executionHistory);
+      this.observeExecutionCompletion(executionId, context);
+    }
+
+    const history = executionHistory.get(filePath);
     if (history) {
       history.push(content);
       if (history.length > TextEditorTool.MAX_HISTORY_PER_FILE) {
         history.shift();
       }
     } else {
-      this.fileHistory.set(key, [content]);
+      executionHistory.set(filePath, [content]);
     }
+  }
+
+  /** Release all snapshots when their owning execution leaves the registry. */
+  private observeExecutionCompletion(
+    executionId: string,
+    context: RunContext | undefined,
+  ): void {
+    if (!executionId || this.observedExecutions.has(executionId)) return;
+
+    const registry = getRunContextSession(context)?.executions;
+    if (!registry?.getHandle(executionId)) return;
+
+    this.observedExecutions.add(executionId);
+    registry.addListener(executionId, (handle) => {
+      if (handle) return;
+      this.fileHistory.delete(executionId);
+      this.observedExecutions.delete(executionId);
+    });
   }
 
   private makeOutput(content: string, initLine: number = 1): string {

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -556,6 +556,7 @@ export class TextEditorTool extends defineTool({
     if (!registry?.getHandle(executionId)) return;
 
     this.observedExecutions.add(executionId);
+    // The registry releases persistent listeners after this terminal callback.
     registry.addListener(executionId, (handle) => {
       if (handle) return;
       this.fileHistory.delete(executionId);


### PR DESCRIPTION
## Summary
- organize undo snapshots by execution and file instead of composite string keys
- observe the owning execution through its existing session registry
- release every retained snapshot as soon as that execution is untracked

## Design
The editor owns its transient undo data and subscribes once to the lifecycle owner that already knows when an execution ends. This keeps cleanup at the ownership boundary and avoids a second global completion mechanism or a scan over encoded keys.

## Testing
- targeted TextEditorTool history lifecycle tests
- all TypeScript workspace configurations
- ESLint
- extension, webview, and trace-viewer builds
- full Vitest suite

Closes #9034

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes undo history ownership and lifecycle for a widely used approval-gated edit tool; incorrect cleanup or scoping could break undo or leak memory across executions.
> 
> **Overview**
> **TextEditorTool** undo snapshots are now keyed by **execution ID** and **file path** (nested maps) instead of a single composite string key, keeping isolation between concurrent runs while making cleanup straightforward.
> 
> On the first edit for a tracked execution, the tool registers a **session execution-registry listener** and drops that execution’s entire history (and observation state) when the handle is **untracked**—so long-lived processes no longer retain full-file snapshots after a run finishes. The per-file **50-snapshot cap** and **most-recent `undo_edit`** behavior are unchanged; tests were extended to assert history release on execution completion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e2fc87c60c4017121c05316a5ffd3bbb83d66ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->