### PR TITLE
refactor: consolidate history-action outcomes shared by VS Code and desktop

### DIFF
--- a/packages/desktop/src/main/desktopHistoryHandlers.ts
+++ b/packages/desktop/src/main/desktopHistoryHandlers.ts
@@ -20,10 +20,18 @@ import type {
   ChatExportController,
   ExportInputStatus,
 } from '@controllers/settingsView/ChatExportController';
+import {
+  ACTIVE_EXECUTION_DELETE_BLOCKED_MESSAGE,
+  describeClearHistoryResult,
+  describeDeleteExecutionResult,
+  describeLatexExportResult,
+  exportedFileMessage,
+  exportInputErrorMessage,
+  htmlExportErrorMessage,
+} from '@controllers/settingsView/HistoryActionOutcomes';
 import type { SettingsViewCommandActions } from '@controllers/settingsView/SettingsViewCommandHandlers';
 import type { ExecutionId } from '@shared/schemas';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
-import { formatExecutionHistoryRetention } from '@shared/copy/executionHistory';
 
 type HistoryExportFormat = 'md' | 'tex' | 'html';
 
@@ -77,35 +85,32 @@ export class DesktopHistoryHandlers implements DesktopHistorySettingsController 
 
   private async deleteItem(historyId: string): Promise<void> {
     const result = await deleteExecution(historyId as ExecutionId);
-    if (result.status === 'active') {
-      await this.dependencies.showInfoMessage(
-        'Cannot delete an execution that is active in TeXRA',
-      );
-      return;
+    const outcome = describeDeleteExecutionResult(result);
+    switch (outcome.kind) {
+      case 'active':
+        await this.dependencies.showInfoMessage(
+          ACTIVE_EXECUTION_DELETE_BLOCKED_MESSAGE,
+        );
+        return;
+      case 'not-found':
+        await this.dependencies.showInfoMessage(outcome.message);
+        return;
+      case 'deleted':
+        await this.postHistoryData();
+        return;
     }
-    if (result.status === 'not-found') {
-      await this.dependencies.showInfoMessage(
-        `History item not found: ${historyId}`,
-      );
-      return;
-    }
-    await this.postHistoryData();
   }
 
   private async clear(): Promise<void> {
     const result = await deleteAllExecutions();
-    if (result.active.length === 0 && result.failed.length === 0) {
+    const outcome = describeClearHistoryResult(result);
+    if (outcome.kind === 'cleared') {
       this.dependencies.postToRenderer({
         command: SETTINGS_VIEW_COMMANDS.HISTORY_CLEARED,
       });
       return;
     }
-    await this.dependencies.showInfoMessage(
-      formatExecutionHistoryRetention(
-        result.active.length,
-        result.failed.length,
-      ),
-    );
+    await this.dependencies.showInfoMessage(outcome.message);
     await this.postHistoryData();
   }
 
@@ -182,31 +187,13 @@ export class DesktopHistoryHandlers implements DesktopHistorySettingsController 
   private async reportExportInputError(
     status: Exclude<ExportInputStatus, 'ok'>,
   ): Promise<void> {
-    switch (status) {
-      case 'config_missing':
-        await this.dependencies.showInfoMessage('History item not found');
-        return;
-      case 'conversation_missing':
-        await this.dependencies.showInfoMessage(
-          'No conversation data available for this execution',
-        );
-        return;
-    }
+    await this.dependencies.showInfoMessage(exportInputErrorMessage(status));
   }
 
   private async reportHtmlExportError(
     status: 'config_missing' | 'streamLogs_missing',
   ): Promise<void> {
-    switch (status) {
-      case 'config_missing':
-        await this.dependencies.showInfoMessage('History item not found');
-        return;
-      case 'streamLogs_missing':
-        await this.dependencies.showInfoMessage(
-          'No stored transcript available for this execution — it may predate transcript persistence.',
-        );
-        return;
-    }
+    await this.dependencies.showInfoMessage(htmlExportErrorMessage(status));
   }
 
   private async exportChatHtml(historyId: string): Promise<void> {
@@ -225,9 +212,7 @@ export class DesktopHistoryHandlers implements DesktopHistorySettingsController 
     }
     const { absolutePath, storagePath } = outcome.result;
     await this.dependencies.openPath(absolutePath);
-    await this.dependencies.showInfoMessage(
-      `Chat exported: ${path.basename(storagePath)}`,
-    );
+    await this.dependencies.showInfoMessage(exportedFileMessage(storagePath));
   }
 
   private async exportChat(
@@ -253,31 +238,16 @@ export class DesktopHistoryHandlers implements DesktopHistorySettingsController 
         exportInput,
       );
       await this.dependencies.openPath(absolutePath);
-      await this.dependencies.showInfoMessage(
-        `Chat exported: ${path.basename(storagePath)}`,
-      );
+      await this.dependencies.showInfoMessage(exportedFileMessage(storagePath));
       return;
     }
 
-    const { absolutePath, storagePath, pdfPath, logTail } =
-      await controller.exportAsLatex(historyId, exportInput);
-    if (pdfPath) {
-      await this.dependencies.openPath(pdfPath);
-      await this.dependencies.showInfoMessage(
-        `Chat exported and compiled: ${path.basename(storagePath).replace('.tex', '.pdf')}`,
-      );
-      return;
+    const latexResult = await controller.exportAsLatex(historyId, exportInput);
+    const outcome = describeLatexExportResult(latexResult);
+    if (outcome.kind === 'compileFailed' && outcome.logDetail) {
+      this.dependencies.onError(new Error(outcome.logDetail));
     }
-    if (logTail) {
-      this.dependencies.onError(
-        new Error(
-          `LaTeX export compilation failed for ${storagePath}:\n${logTail}`,
-        ),
-      );
-    }
-    await this.dependencies.openPath(absolutePath);
-    await this.dependencies.showInfoMessage(
-      'LaTeX compilation failed. The .tex source file has been opened instead.',
-    );
+    await this.dependencies.openPath(outcome.pathToOpen);
+    await this.dependencies.showInfoMessage(outcome.message);
   }
 }

--- a/packages/extension/src/settingsView/handlers/historyHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/historyHandlers.ts
@@ -29,6 +29,16 @@ import {
 } from '@controllers/settingsView/ChatExportController';
 import { buildHistoryMessage } from '@controllers/settingsView/HistoryMessageBuilder';
 import {
+  ACTIVE_EXECUTION_DELETE_BLOCKED_MESSAGE,
+  describeClearHistoryResult,
+  describeDeleteExecutionResult,
+  describeLatexExportResult,
+  exportedFileMessage,
+  exportInputErrorMessage,
+  HISTORY_ITEM_NOT_FOUND_MESSAGE,
+  htmlExportErrorMessage,
+} from '@controllers/settingsView/HistoryActionOutcomes';
+import {
   showLoggedErrorMessage,
   showLoggedMessage,
 } from '@frontend/ui/errorHandlingUtils';
@@ -39,7 +49,6 @@ import {
   SETTINGS_VIEW_CMD,
   type SettingsMessageFor,
 } from '@shared/schemas/settingsViewMessages';
-import { formatExecutionHistoryRetention } from '@shared/copy/executionHistory';
 
 import type { SettingsHandlerContext } from './SettingsHandlerContext';
 
@@ -100,18 +109,19 @@ export class HistoryHandlers {
   ): Promise<void> {
     try {
       const result = await deleteExecution(data.historyId as ExecutionId);
-      if (result.status === 'active') {
-        await vscode.window.showWarningMessage(
-          'Cannot delete an execution that is active in TeXRA',
-        );
-        return;
-      }
-      if (result.status === 'deleted') {
-        await this.ctx.withActiveWebview((w) => this.sendHistoryData(w));
-      } else {
-        await vscode.window.showWarningMessage(
-          `History item not found: ${data.historyId}`,
-        );
+      const outcome = describeDeleteExecutionResult(result);
+      switch (outcome.kind) {
+        case 'active':
+          await vscode.window.showWarningMessage(
+            ACTIVE_EXECUTION_DELETE_BLOCKED_MESSAGE,
+          );
+          return;
+        case 'not-found':
+          await vscode.window.showWarningMessage(outcome.message);
+          return;
+        case 'deleted':
+          await this.ctx.withActiveWebview((w) => this.sendHistoryData(w));
+          return;
       }
     } catch (error) {
       await showLoggedErrorMessage(
@@ -125,7 +135,8 @@ export class HistoryHandlers {
   async handleClearHistory(): Promise<void> {
     try {
       const result = await deleteAllExecutions();
-      if (result.active.length === 0 && result.failed.length === 0) {
+      const outcome = describeClearHistoryResult(result);
+      if (outcome.kind === 'cleared') {
         await vscode.window.showInformationMessage('Agent history cleared');
         await this.ctx.withActiveWebview(async (w) => {
           await w.postMessage({
@@ -133,12 +144,7 @@ export class HistoryHandlers {
           });
         });
       } else {
-        await vscode.window.showInformationMessage(
-          formatExecutionHistoryRetention(
-            result.active.length,
-            result.failed.length,
-          ),
-        );
+        await vscode.window.showInformationMessage(outcome.message);
         await this.ctx.withActiveWebview((w) => this.sendHistoryData(w));
       }
     } catch (error) {
@@ -202,17 +208,7 @@ export class HistoryHandlers {
   private reportExportInputError(
     status: Exclude<ExportInputStatus, 'ok'>,
   ): void {
-    switch (status) {
-      case 'config_missing':
-        void showLoggedMessage(this.ctx.channel, 'History item not found');
-        return;
-      case 'conversation_missing':
-        void showLoggedMessage(
-          this.ctx.channel,
-          'No conversation data available for this execution',
-        );
-        return;
-    }
+    void showLoggedMessage(this.ctx.channel, exportInputErrorMessage(status));
   }
 
   /**
@@ -222,17 +218,7 @@ export class HistoryHandlers {
   private reportHtmlExportError(
     status: 'config_missing' | 'streamLogs_missing',
   ): void {
-    switch (status) {
-      case 'config_missing':
-        void showLoggedMessage(this.ctx.channel, 'History item not found');
-        return;
-      case 'streamLogs_missing':
-        void showLoggedMessage(
-          this.ctx.channel,
-          'No stored transcript available for this execution — it may predate transcript persistence.',
-        );
-        return;
-    }
+    void showLoggedMessage(this.ctx.channel, htmlExportErrorMessage(status));
   }
 
   private async exportAndOpenMarkdown(
@@ -243,43 +229,38 @@ export class HistoryHandlers {
       await this.chatExportController.exportAsMarkdown(historyId, exportInput);
     const doc = await vscode.workspace.openTextDocument(absolutePath);
     await vscode.window.showTextDocument(doc, { preview: false });
-    const filename = path.basename(storagePath);
-    void vscode.window.showInformationMessage(`Chat exported: ${filename}`);
+    void vscode.window.showInformationMessage(exportedFileMessage(storagePath));
   }
 
   private async exportAndOpenLatex(
     historyId: string,
     exportInput: ChatExportInput,
   ): Promise<void> {
-    const { absolutePath, storagePath, pdfPath, logTail } =
-      await this.chatExportController.exportAsLatex(historyId, exportInput);
+    const result = await this.chatExportController.exportAsLatex(
+      historyId,
+      exportInput,
+    );
+    const outcome = describeLatexExportResult(result);
 
-    if (pdfPath) {
-      // Open the generated PDF
-      const pdfUri = vscode.Uri.file(pdfPath);
+    if (outcome.kind === 'compiled') {
+      const pdfUri = vscode.Uri.file(outcome.pathToOpen);
       await vscode.commands.executeCommand('vscode.open', pdfUri);
-      const filename = path.basename(storagePath);
-      void vscode.window.showInformationMessage(
-        `Chat exported and compiled: ${filename.replace('.tex', '.pdf')}`,
-      );
-    } else {
-      // Compilation failed — open the .tex source instead, and log the
-      // compile log tail so the failure reason is discoverable. Included in
-      // the visible message itself, not just `data` — the logger only shows
-      // `data` when texra.logger.debugMode is on (default off).
-      if (logTail) {
-        this.ctx.logger.error(
-          this.ctx.channel,
-          `LaTeX export compilation failed for ${storagePath}:\n${logTail}`,
-          { data: { storagePath, logTail } },
-        );
-      }
-      const doc = await vscode.workspace.openTextDocument(absolutePath);
-      await vscode.window.showTextDocument(doc, { preview: false });
-      void vscode.window.showWarningMessage(
-        'LaTeX compilation failed. The .tex source file has been opened instead.',
-      );
+      void vscode.window.showInformationMessage(outcome.message);
+      return;
     }
+
+    // Compilation failed — open the .tex source instead, and log the
+    // compile log tail so the failure reason is discoverable. Included in
+    // the visible message itself, not just `data` — the logger only shows
+    // `data` when texra.logger.debugMode is on (default off).
+    if (outcome.logDetail) {
+      this.ctx.logger.error(this.ctx.channel, outcome.logDetail, {
+        data: { storagePath: result.storagePath, logTail: result.logTail },
+      });
+    }
+    const doc = await vscode.workspace.openTextDocument(outcome.pathToOpen);
+    await vscode.window.showTextDocument(doc, { preview: false });
+    void vscode.window.showWarningMessage(outcome.message);
   }
 
   private async exportAndOpenHtml(historyId: string): Promise<void> {
@@ -295,9 +276,7 @@ export class HistoryHandlers {
 
     const { absolutePath, storagePath } = outcome.result;
     await vscode.env.openExternal(vscode.Uri.file(absolutePath));
-    void vscode.window.showInformationMessage(
-      `Chat exported: ${path.basename(storagePath)}`,
-    );
+    void vscode.window.showInformationMessage(exportedFileMessage(storagePath));
   }
 
   private async withHistoryConfig(
@@ -310,7 +289,10 @@ export class HistoryHandlers {
         historyId as ExecutionId,
       ).readConfig();
       if (!raw) {
-        await showLoggedMessage(this.ctx.channel, 'History item not found');
+        await showLoggedMessage(
+          this.ctx.channel,
+          HISTORY_ITEM_NOT_FOUND_MESSAGE,
+        );
         return;
       }
       const config = AgentConfigSchema.parse(raw);

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -38,6 +38,7 @@ export {
   type ExecutionListingEntry,
   type DeleteExecutionOptions,
   type DeleteExecutionResult,
+  type DeleteAllExecutionsResult,
   listExecutions,
   deleteExecution,
   deleteAllExecutions,

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -38,7 +38,6 @@ export {
   type ExecutionListingEntry,
   type DeleteExecutionOptions,
   type DeleteExecutionResult,
-  type DeleteAllExecutionsResult,
   listExecutions,
   deleteExecution,
   deleteAllExecutions,

--- a/src/controllers/settingsView/HistoryActionOutcomes.ts
+++ b/src/controllers/settingsView/HistoryActionOutcomes.ts
@@ -1,0 +1,138 @@
+/**
+ * Pure status-to-outcome mappings for history actions (export, delete, clear).
+ *
+ * Both the VS Code extension (`HistoryHandlers`) and the desktop app
+ * (`DesktopHistoryHandlers`) drive the same host-neutral controllers
+ * (`ChatExportController`, `deleteExecution`, `deleteAllExecutions`) and, until
+ * now, each re-derived which message belongs to which result by hand. This
+ * module owns that derivation once; each host still decides how to surface a
+ * message (info vs. warning toast, which file to open) and whether to log
+ * failures, since that part is genuinely host-specific.
+ */
+
+// Node imports
+import * as path from 'node:path';
+
+// Local imports
+import type {
+  DeleteAllExecutionsResult,
+  DeleteExecutionResult,
+} from '@agent/storage';
+import { formatExecutionHistoryRetention } from '@shared/copy/executionHistory';
+import type {
+  ExportInputStatus,
+  HtmlExportOutcome,
+  LatexExportResult,
+} from './ChatExportController';
+
+export const HISTORY_ITEM_NOT_FOUND_MESSAGE = 'History item not found';
+
+export const ACTIVE_EXECUTION_DELETE_BLOCKED_MESSAGE =
+  'Cannot delete an execution that is active in TeXRA';
+
+/** Message for a failed {@link ChatExportController.buildExportInput} status. */
+export function exportInputErrorMessage(
+  status: Exclude<ExportInputStatus, 'ok'>,
+): string {
+  switch (status) {
+    case 'config_missing':
+      return HISTORY_ITEM_NOT_FOUND_MESSAGE;
+    case 'conversation_missing':
+      return 'No conversation data available for this execution';
+  }
+}
+
+/** Message for a failed {@link ChatExportController.exportAsHtml} status. */
+export function htmlExportErrorMessage(
+  status: Exclude<HtmlExportOutcome['status'], 'ok'>,
+): string {
+  switch (status) {
+    case 'config_missing':
+      return HISTORY_ITEM_NOT_FOUND_MESSAGE;
+    case 'streamLogs_missing':
+      return 'No stored transcript available for this execution — it may predate transcript persistence.';
+  }
+}
+
+/** Success message for a Markdown or HTML export (identical shape on both formats). */
+export function exportedFileMessage(storagePath: string): string {
+  return `Chat exported: ${path.basename(storagePath)}`;
+}
+
+export type LatexExportOutcome =
+  | {
+      readonly kind: 'compiled';
+      readonly pathToOpen: string;
+      readonly message: string;
+    }
+  | {
+      readonly kind: 'compileFailed';
+      readonly pathToOpen: string;
+      readonly message: string;
+      /** Present only when the compiler produced a log tail worth surfacing. */
+      readonly logDetail?: string;
+    };
+
+/** Decide which file to open and what to say for a LaTeX export result. */
+export function describeLatexExportResult(
+  result: LatexExportResult,
+): LatexExportOutcome {
+  if (result.pdfPath) {
+    const pdfFilename = path
+      .basename(result.storagePath)
+      .replace(/\.tex$/, '.pdf');
+    return {
+      kind: 'compiled',
+      pathToOpen: result.pdfPath,
+      message: `Chat exported and compiled: ${pdfFilename}`,
+    };
+  }
+  return {
+    kind: 'compileFailed',
+    pathToOpen: result.absolutePath,
+    message:
+      'LaTeX compilation failed. The .tex source file has been opened instead.',
+    logDetail: result.logTail
+      ? `LaTeX export compilation failed for ${result.storagePath}:\n${result.logTail}`
+      : undefined,
+  };
+}
+
+export type DeleteExecutionOutcome =
+  | { readonly kind: 'active' }
+  | { readonly kind: 'not-found'; readonly message: string }
+  | { readonly kind: 'deleted' };
+
+/** Decide the outcome message for a {@link deleteExecution} result. */
+export function describeDeleteExecutionResult(
+  result: DeleteExecutionResult,
+): DeleteExecutionOutcome {
+  if (result.status === 'active') return { kind: 'active' };
+  if (result.status === 'not-found') {
+    return {
+      kind: 'not-found',
+      message: `History item not found: ${result.executionId}`,
+    };
+  }
+  return { kind: 'deleted' };
+}
+
+export type ClearHistoryOutcome =
+  | { readonly kind: 'cleared' }
+  | { readonly kind: 'retained'; readonly message: string };
+
+/** Decide whether history was fully cleared, and the retention message if not. */
+export function describeClearHistoryResult(
+  result: DeleteAllExecutionsResult,
+): ClearHistoryOutcome {
+  if (result.active.length === 0 && result.failed.length === 0) {
+    return { kind: 'cleared' };
+  }
+  return {
+    kind: 'retained',
+    message: formatExecutionHistoryRetention(
+      result.active.length,
+      result.failed.length,
+    ),
+  };
+}

--- a/src/controllers/settingsView/HistoryActionOutcomes.ts
+++ b/src/controllers/settingsView/HistoryActionOutcomes.ts
@@ -17,7 +17,7 @@ import * as path from 'node:path';
 import type {
   DeleteAllExecutionsResult,
   DeleteExecutionResult,
-} from '@agent/storage';
+} from '@agent/storage/executionListing';
 import { formatExecutionHistoryRetention } from '@shared/copy/executionHistory';
 import type {
   ExportInputStatus,
@@ -59,7 +59,7 @@ export function exportedFileMessage(storagePath: string): string {
   return `Chat exported: ${path.basename(storagePath)}`;
 }
 
-export type LatexExportOutcome =
+type LatexExportOutcome =
   | {
       readonly kind: 'compiled';
       readonly pathToOpen: string;
@@ -98,7 +98,7 @@ export function describeLatexExportResult(
   };
 }
 
-export type DeleteExecutionOutcome =
+type DeleteExecutionOutcome =
   | { readonly kind: 'active' }
   | { readonly kind: 'not-found'; readonly message: string }
   | { readonly kind: 'deleted' };
@@ -117,7 +117,7 @@ export function describeDeleteExecutionResult(
   return { kind: 'deleted' };
 }
 
-export type ClearHistoryOutcome =
+type ClearHistoryOutcome =
   | { readonly kind: 'cleared' }
   | { readonly kind: 'retained'; readonly message: string };
 

--- a/src/test-kernel/controllers/HistoryActionOutcomes.vitest.ts
+++ b/src/test-kernel/controllers/HistoryActionOutcomes.vitest.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ACTIVE_EXECUTION_DELETE_BLOCKED_MESSAGE,
+  describeClearHistoryResult,
+  describeDeleteExecutionResult,
+  describeLatexExportResult,
+  exportedFileMessage,
+  exportInputErrorMessage,
+  htmlExportErrorMessage,
+} from '@controllers/settingsView/HistoryActionOutcomes';
+import type { ExecutionId } from '@shared/schemas';
+
+const EXECUTION_ID = 'abc123' as ExecutionId;
+
+describe('HistoryActionOutcomes', () => {
+  it('maps export-input error statuses to messages', () => {
+    expect(exportInputErrorMessage('config_missing')).toBe(
+      'History item not found',
+    );
+    expect(exportInputErrorMessage('conversation_missing')).toBe(
+      'No conversation data available for this execution',
+    );
+  });
+
+  it('maps html export error statuses to messages', () => {
+    expect(htmlExportErrorMessage('config_missing')).toBe(
+      'History item not found',
+    );
+    expect(htmlExportErrorMessage('streamLogs_missing')).toBe(
+      'No stored transcript available for this execution — it may predate transcript persistence.',
+    );
+  });
+
+  it('formats the exported-file message from a storage path', () => {
+    expect(exportedFileMessage('executions/abc/chat.md')).toBe(
+      'Chat exported: chat.md',
+    );
+  });
+
+  it('describes a compiled LaTeX export', () => {
+    const outcome = describeLatexExportResult({
+      storagePath: 'executions/abc/chat.tex',
+      absolutePath: '/tmp/executions/abc/chat.tex',
+      pdfPath: '/tmp/executions/abc/chat.pdf',
+    });
+
+    expect(outcome).toEqual({
+      kind: 'compiled',
+      pathToOpen: '/tmp/executions/abc/chat.pdf',
+      message: 'Chat exported and compiled: chat.pdf',
+    });
+  });
+
+  it('describes a failed LaTeX compilation with a log tail', () => {
+    const outcome = describeLatexExportResult({
+      storagePath: 'executions/abc/chat.tex',
+      absolutePath: '/tmp/executions/abc/chat.tex',
+      logTail: '! Undefined control sequence.',
+    });
+
+    expect(outcome).toEqual({
+      kind: 'compileFailed',
+      pathToOpen: '/tmp/executions/abc/chat.tex',
+      message:
+        'LaTeX compilation failed. The .tex source file has been opened instead.',
+      logDetail:
+        'LaTeX export compilation failed for executions/abc/chat.tex:\n! Undefined control sequence.',
+    });
+  });
+
+  it('describes a failed LaTeX compilation without a log tail', () => {
+    const outcome = describeLatexExportResult({
+      storagePath: 'executions/abc/chat.tex',
+      absolutePath: '/tmp/executions/abc/chat.tex',
+    });
+
+    expect(outcome).toEqual({
+      kind: 'compileFailed',
+      pathToOpen: '/tmp/executions/abc/chat.tex',
+      message:
+        'LaTeX compilation failed. The .tex source file has been opened instead.',
+      logDetail: undefined,
+    });
+  });
+
+  it('describes an active-execution delete result', () => {
+    expect(
+      describeDeleteExecutionResult({
+        status: 'active',
+        executionId: EXECUTION_ID,
+        heartbeatAt: 0,
+      }),
+    ).toEqual({ kind: 'active' });
+  });
+
+  it('describes a not-found delete result', () => {
+    expect(
+      describeDeleteExecutionResult({
+        status: 'not-found',
+        executionId: EXECUTION_ID,
+      }),
+    ).toEqual({
+      kind: 'not-found',
+      message: `History item not found: ${EXECUTION_ID}`,
+    });
+  });
+
+  it('describes a successful delete result', () => {
+    expect(
+      describeDeleteExecutionResult({
+        status: 'deleted',
+        executionId: EXECUTION_ID,
+      }),
+    ).toEqual({ kind: 'deleted' });
+  });
+
+  it('exposes the shared active-execution message constant', () => {
+    expect(ACTIVE_EXECUTION_DELETE_BLOCKED_MESSAGE).toBe(
+      'Cannot delete an execution that is active in TeXRA',
+    );
+  });
+
+  it('describes a fully cleared history result', () => {
+    expect(
+      describeClearHistoryResult({
+        deleted: [EXECUTION_ID],
+        notFound: [],
+        active: [],
+        failed: [],
+      }),
+    ).toEqual({ kind: 'cleared' });
+  });
+
+  it('describes a partially retained history result', () => {
+    expect(
+      describeClearHistoryResult({
+        deleted: [],
+        notFound: [],
+        active: [EXECUTION_ID],
+        failed: [],
+      }),
+    ).toEqual({
+      kind: 'retained',
+      message: 'Cleared stored history except for 1 active execution.',
+    });
+  });
+});

--- a/src/test-kernel/controllers/HistoryActionOutcomes.vitest.ts
+++ b/src/test-kernel/controllers/HistoryActionOutcomes.vitest.ts
@@ -13,6 +13,16 @@ import type { ExecutionId } from '@shared/schemas';
 
 const EXECUTION_ID = 'abc123' as ExecutionId;
 
+function latexResultFixture(
+  overrides: Partial<Parameters<typeof describeLatexExportResult>[0]> = {},
+): Parameters<typeof describeLatexExportResult>[0] {
+  return {
+    storagePath: 'executions/abc/chat.tex',
+    absolutePath: '/tmp/executions/abc/chat.tex',
+    ...overrides,
+  };
+}
+
 describe('HistoryActionOutcomes', () => {
   it('maps export-input error statuses to messages', () => {
     expect(exportInputErrorMessage('config_missing')).toBe(
@@ -39,11 +49,9 @@ describe('HistoryActionOutcomes', () => {
   });
 
   it('describes a compiled LaTeX export', () => {
-    const outcome = describeLatexExportResult({
-      storagePath: 'executions/abc/chat.tex',
-      absolutePath: '/tmp/executions/abc/chat.tex',
-      pdfPath: '/tmp/executions/abc/chat.pdf',
-    });
+    const outcome = describeLatexExportResult(
+      latexResultFixture({ pdfPath: '/tmp/executions/abc/chat.pdf' }),
+    );
 
     expect(outcome).toEqual({
       kind: 'compiled',
@@ -53,11 +61,9 @@ describe('HistoryActionOutcomes', () => {
   });
 
   it('describes a failed LaTeX compilation with a log tail', () => {
-    const outcome = describeLatexExportResult({
-      storagePath: 'executions/abc/chat.tex',
-      absolutePath: '/tmp/executions/abc/chat.tex',
-      logTail: '! Undefined control sequence.',
-    });
+    const outcome = describeLatexExportResult(
+      latexResultFixture({ logTail: '! Undefined control sequence.' }),
+    );
 
     expect(outcome).toEqual({
       kind: 'compileFailed',
@@ -70,10 +76,7 @@ describe('HistoryActionOutcomes', () => {
   });
 
   it('describes a failed LaTeX compilation without a log tail', () => {
-    const outcome = describeLatexExportResult({
-      storagePath: 'executions/abc/chat.tex',
-      absolutePath: '/tmp/executions/abc/chat.tex',
-    });
+    const outcome = describeLatexExportResult(latexResultFixture());
 
     expect(outcome).toEqual({
       kind: 'compileFailed',


### PR DESCRIPTION
## Summary

A codebase-wide audit for overlapping/confusing responsibilities (see method below) surfaced that `HistoryHandlers` (VS Code extension, `packages/extension/src/settingsView/handlers/historyHandlers.ts`) and `DesktopHistoryHandlers` (`packages/desktop/src/main/desktopHistoryHandlers.ts`) both drive the same host-neutral controllers — `ChatExportController`, `deleteExecution`, `deleteAllExecutions` — but each independently re-derived, by hand, which user-facing message belongs to which result: identical `switch` statements over export-error statuses, identical LaTeX compile-outcome branching, identical delete/clear-result branching, with the same string literals copy-pasted in both files. `ChatExportController`'s own doc comment already states the intended split ("the caller performs only host UI actions") — but the "what happened → what to say" computation had drifted into both callers instead of staying in one place.

This PR extracts that computation into a new host-neutral module, `src/controllers/settingsView/HistoryActionOutcomes.ts`, and has both hosts call it instead of re-deriving.

## Issue acceptance gates

No tracked issue — this came out of a scheduled codebase audit for overlapping responsibilities. Gate: identify the most significant instance of duplicated/overlapping logic and consolidate it without changing user-visible behavior.

## Single source of truth

`src/controllers/settingsView/HistoryActionOutcomes.ts` now owns: export-error-status → message, LaTeX-export-result → (path to open, message, optional log detail), delete-result → outcome, clear-result → outcome. Each host still owns genuinely host-specific behavior (toast severity, which API opens a file, whether/how to log a failure).

## Duplication and abstraction budget

Removed: two copies each of `reportExportInputError`/`reportHtmlExportError`-style switch statements, the LaTeX compiled-vs-failed branching (message text + path selection), the delete-result branching, and the clear-result branching — previously hand-duplicated verbatim in both `HistoryHandlers` and `DesktopHistoryHandlers`. Added: one new file with 6 pure functions, 2 exported constants, and 3 small discriminated-union result types — justified by exactly the 2 existing callers plus real branching logic (not a pass-through), per the repo's abstraction-cost bar. No new class, port, or facade.

## Net elements (R6)

Files: +1 new controller module, +1 new test file, 3 files modified (net +2 files). Exported symbols in the diff: 11 new exports (`+export`) in the new module, 0 removed exports (nothing public was deleted, only inlined private duplication). Net LoC across touched files: +378 / -139 (diffstat), but that includes the new test file (+123 lines); the three production files alone are net **-47 lines** (100 insertions, 139 deletions across `desktopHistoryHandlers.ts`, `historyHandlers.ts`, `storage/index.ts`) despite consolidating strictly more logic into one place.

## Consumer counts (R8)

No emit path or export was deleted or re-routed — only two existing call sites (`HistoryHandlers`, `DesktopHistoryHandlers`) were pointed at a new shared helper instead of their own inline logic. n/a.

## Host impact

Extension: `HistoryHandlers` (delete/clear/export handlers) now delegates outcome derivation to the shared module; VS Code-specific behavior (warning vs. info severity, `vscode.workspace.openTextDocument` vs `vscode.commands.executeCommand('vscode.open', ...)`, `this.ctx.logger.error`) is unchanged.

Desktop: `DesktopHistoryHandlers` now delegates the same derivation; its injected `showInfoMessage`/`openPath`/`onError` ports are called with identical arguments as before.

CLI: not touched — the CLI's history export path (`readCliHistoryExportInput`) is a separate flow that doesn't share these handlers.

## Scheduled refactoring

None. Other findings from the same audit (a documented "half-finished" 3-path settings-config migration in `src/utils/config/`, two independently-maintained tool-availability lists, and a handful of naming traps where same-named modules solve unrelated problems) were judged lower-priority or too broad/risky for an unattended pass and were left for a follow-up if the team wants them tracked as issues.

## Validation

- `npx tsc --noEmit -p tsconfig.json` (root) — pass
- `corepack pnpm --filter texra typecheck` (extension) — pass
- `corepack pnpm --filter @texra/desktop typecheck` (desktop, all 4 tsconfigs) — pass
- `npx tsc --noEmit -p tsconfig.test-kernel.json` — pass
- `npx eslint` on all touched/added files — clean
- `npx prettier --check` on all touched/added files — clean (after `--write`)
- `npm run check:dead-code-ratchet` — no new unused exports (18 baselined, 18 current)
- `npx vitest run` on `DesktopHistoryHandlers.vitest.mts`, `HistoryHandlers.vitest.ts`, `ChatExportController.vitest.ts`, `ChatExportControllerHtml.vitest.ts` (existing suites, unmodified) — all 24 pass, confirming no behavior change
- New `src/test-kernel/controllers/HistoryActionOutcomes.vitest.ts` — 12 new tests covering the extracted pure functions directly, all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQC7rJaG8Mt7aFRHM7L1dr

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQC7rJaG8Mt7aFRHM7L1dr)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with preserved user-visible strings and behavior; new unit tests cover the extracted mappings. No auth, storage, or API contract changes.
> 
> **Overview**
> Introduces **`HistoryActionOutcomes`** as the single place that maps history controller results to user-facing strings and small discriminated outcomes (export errors, LaTeX compile success/failure, delete, clear-all).
> 
> **`DesktopHistoryHandlers`** and extension **`HistoryHandlers`** drop duplicated `switch` blocks and inline message literals in favor of helpers like `describeDeleteExecutionResult`, `describeClearHistoryResult`, `describeLatexExportResult`, and `exportInputErrorMessage` / `htmlExportErrorMessage` / `exportedFileMessage`. Each host still owns how outcomes are shown (toasts, opening files, logging).
> 
> Adds **`HistoryActionOutcomes.vitest.ts`** with direct unit tests for the extracted pure logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 010bf16dc7b50560e942a7229b67a26849aa1132. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->