### PR TITLE
feat(cli): add API keys to /config and Kimi Code model access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ All notable changes to this project will be documented in this file.
 
 #### New Features
 
+- **Kimi Code subscription joins model access** — the launcher and `/api` now
+  offer Kimi Code alongside ChatGPT subscription, included TeXRA access, and
+  personal API keys. Selecting it routes Kimi models through your Kimi Code
+  membership while other models fall back to your saved keys.
+- **API keys can be set from `/config`** — a new "API keys" entry opens the
+  masked key-entry form for every provider, and a "Prefer Kimi Code" toggle
+  appears under "Models and providers".
 - **Nested subagents remain visible** — a focused subagent reports how many
   direct subagents it owns, including completed work that remains available in
   its child list.

--- a/docs/guide/texra-cli.md
+++ b/docs/guide/texra-cli.md
@@ -188,7 +188,8 @@ texra agents run review --input main.tex --instruction "Check the proof." --prin
 ```
 
 Slash commands inside the session: `/tools` lists and toggles integrations,
-`/api` switches between hosted and personal-key access, `/model` switches to
+`/api` switches between ChatGPT or Kimi Code subscriptions, hosted access,
+and personal-key access, `/model` switches to
 another model from the same provider mid-session (the change applies
 immediately and persists on resume), `/skills` lists available skills and
 applies one to your next request, and `/resume` restores a stored execution.

--- a/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
+++ b/packages/cli/src/chat/tui/commands/handleSlashCommand.ts
@@ -3,7 +3,10 @@ import { defaultSession } from '@agent/runtime/SessionHandle';
 import { formatCliApprovalPolicy } from '@cli/runtime/approvalPolicyText';
 import { resolveCliModelAccessRoute } from '@cli/runtime/modelAccessRoute';
 import { defaultShortcutModifierLabel } from '@cli/runtime/shortcutLabels';
-import { isCodexSubscriptionActive } from '@model/providerCapabilities';
+import {
+  isCodexSubscriptionActive,
+  isKimiCodeSubscriptionActive,
+} from '@model/providerCapabilities';
 import { GoalStore } from '@tools/goal';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -158,6 +161,10 @@ export async function handleTuiSlashCommand(
                 accessTarget.model,
                 accessTarget.category,
               );
+        const kimiCodeActive =
+          accessTarget.category === undefined
+            ? false
+            : await isKimiCodeSubscriptionActive(accessTarget.model);
         appendLocalAssistantTranscript(
           formatCliSessionStatus({
             agent: meta.agent || context.initialAgent,
@@ -166,6 +173,7 @@ export async function handleTuiSlashCommand(
             modelAccess: resolveCliModelAccessRoute({
               apiMode: meta.apiMode,
               subscriptionActive,
+              kimiCodeActive,
               usageRoute: slice?.usage?.usageRoute,
             }),
             approval: formatCliApprovalPolicy(context.getApprovalPolicy()),

--- a/packages/cli/src/chat/tui/commands/handlers/apiModeCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/apiModeCommands.ts
@@ -28,7 +28,8 @@ import {
 } from './slashContext';
 import { loadCliAccountStatusLines } from './statusAssembly';
 
-const MODEL_ACCESS_USAGE = 'Usage: /api chatgpt | included | personal | status';
+const MODEL_ACCESS_USAGE =
+  'Usage: /api chatgpt | kimi-code | included | personal | status';
 
 async function reconcileRootModelAfterApiModeChange(
   context: SlashCommandContext | undefined,

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -9,9 +9,13 @@ import {
 } from '@cli/runtime/loginOptions';
 import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
 import type { ApiProvider } from '@model/apiProviders';
+import { invalidateModelOptionsCache } from '@model/computeModelOptions';
+import { platform } from '@platform/platform';
 import { AgentCategory, type ExecutionId } from '@shared/schemas';
 import { PROVIDER_DISPLAY_NAMES } from '@shared/constants/providers';
 import type { SettingsStores } from '@shared/config/settingsAccess';
+import { GlobalStateKey } from '@shared/state/stateKeys';
+import { setPreferKimiCode } from '@utils/config/providerConfig';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { collapseWhitespace } from '@utils/text/stringUtils';
 
@@ -281,12 +285,20 @@ export function registerBuiltinSlashCommands(options?: {
     options?.onModelSelect ?? setCliSessionModelOverride;
   const onModelAccessSelect: ModelAccessSelectHandler =
     options?.onModelAccessSelect ??
-    ((route, output) => {
-      if (route !== 'chatgpt') {
-        // The Kimi Code route rides on personal API-key access underneath.
-        patchSessionMeta({
-          apiMode: route === 'kimi-code' ? 'personal' : route,
-        });
+    (async (route, output) => {
+      if (route === 'kimi-code') {
+        // Fallback for hosts without full wiring (the TUI harness, tests):
+        // mirror the state transition `selectCliModelAccessRoute` performs —
+        // production chat always supplies its own handler that routes there.
+        patchSessionMeta({ apiMode: 'personal' });
+        await setPreferKimiCode(true);
+        await platform().globalState.update(
+          GlobalStateKey.USE_OPENROUTER,
+          false,
+        );
+        invalidateModelOptionsCache();
+      } else if (route !== 'chatgpt') {
+        patchSessionMeta({ apiMode: route });
       }
       output.appendOutcome(`Model access set to ${route}.`);
     });
@@ -695,6 +707,11 @@ export function registerBuiltinSlashCommands(options?: {
               await options?.onError?.(error);
             },
             onApiModePersonal: async () => {
+              // A key save only needs the mode switch when leaving included
+              // access — already-personal sessions (including an active Kimi
+              // Code route) must not be treated as an explicit "Personal API
+              // keys" picker choice, which would clear the Kimi preference.
+              if (sessionMeta.get().apiMode === 'personal') return;
               await onModelAccessSelect(
                 'personal',
                 transcriptSlashCommandOutput,

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -282,7 +282,12 @@ export function registerBuiltinSlashCommands(options?: {
   const onModelAccessSelect: ModelAccessSelectHandler =
     options?.onModelAccessSelect ??
     ((route, output) => {
-      if (route !== 'chatgpt') patchSessionMeta({ apiMode: route });
+      if (route !== 'chatgpt') {
+        // The Kimi Code route rides on personal API-key access underneath.
+        patchSessionMeta({
+          apiMode: route === 'kimi-code' ? 'personal' : route,
+        });
+      }
       output.appendOutcome(`Model access set to ${route}.`);
     });
   const onApiKeySave: ApiKeySaveHandler =
@@ -555,7 +560,8 @@ export function registerBuiltinSlashCommands(options?: {
   });
   registerSlashCommand({
     name: 'api',
-    description: 'Choose ChatGPT, included TeXRA, or personal model access',
+    description:
+      'Choose ChatGPT, Kimi Code, included TeXRA, or personal model access',
     category: 'configuration',
     echo: 'ifPersists',
     argHandler: applyCliModelAccessSelection,

--- a/packages/cli/src/chat/tui/forms/CliConfigForm.tsx
+++ b/packages/cli/src/chat/tui/forms/CliConfigForm.tsx
@@ -1,5 +1,6 @@
 import { cliSettingsStores } from '@cli/runtime/settingsStores';
 import { applyCliGitAuthorConfig } from '@cli/runtime/gitAuthor';
+import { saveProviderApiKey } from '@cli/runtime/providerApiKey';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import {
   readSetting,
@@ -12,6 +13,7 @@ import { GlobalStateKey } from '@shared/state/stateKeys';
 
 import { AgentRosterForm } from './AgentRosterForm';
 import { ConfigForm, type ConfigFormProps } from './ConfigForm';
+import { ProviderApiKeyForm } from './ProviderApiKeyForm';
 import { ToolsListForm } from './ToolsListForm';
 
 export interface CliConfigFormProps {
@@ -46,11 +48,17 @@ export function createCliConfigFormProps(
         invalidateModelOptionsCache();
         if (value === true) await props.onApiModePersonal?.();
       }
+      if (entry.key === GlobalStateKey.KIMI_CODE_PREFER) {
+        invalidateModelOptionsCache();
+      }
     },
     resetValue: async (entry) => {
       await resetSetting(entry, stores, 'cli');
       if (entry.category === 'git') applyCliGitAuthorConfig(stores.config);
       if (entry.key === GlobalStateKey.USE_OPENROUTER) {
+        invalidateModelOptionsCache();
+      }
+      if (entry.key === GlobalStateKey.KIMI_CODE_PREFER) {
         invalidateModelOptionsCache();
       }
     },
@@ -60,6 +68,12 @@ export function createCliConfigFormProps(
         label: 'Agents',
         description: 'workspace roster and user default team',
       },
+      {
+        name: 'api-keys',
+        label: 'API keys',
+        description:
+          'set personal provider keys (OpenAI, Anthropic, Kimi Code, …)',
+      },
     ],
     formRenderers: {
       agents: (onBack) => (
@@ -67,6 +81,17 @@ export function createCliConfigFormProps(
           availableRows={props.availableRows}
           onClose={onBack}
           onError={props.onError}
+        />
+      ),
+      'api-keys': (onBack) => (
+        <ProviderApiKeyForm
+          availableRows={props.availableRows}
+          onSave={async (provider, key) => {
+            await saveProviderApiKey(provider, key);
+            await props.onApiModePersonal?.();
+          }}
+          onDone={onBack}
+          onCancel={onBack}
         />
       ),
       tools: (onBack) => (

--- a/packages/cli/src/chat/tui/forms/CliConfigForm.tsx
+++ b/packages/cli/src/chat/tui/forms/CliConfigForm.tsx
@@ -1,16 +1,19 @@
 import { cliSettingsStores } from '@cli/runtime/settingsStores';
 import { applyCliGitAuthorConfig } from '@cli/runtime/gitAuthor';
 import { saveProviderApiKey } from '@cli/runtime/providerApiKey';
-import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import {
   readSetting,
   resetSetting,
   writeSetting,
   type SettingsStores,
 } from '@shared/config/settingsAccess';
-import { CLI_STATE_SETTINGS } from '@shared/schemas/stateSettings';
+import {
+  CLI_STATE_SETTINGS,
+  stateSettingByKey,
+} from '@shared/schemas/stateSettings';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 
+import { refreshCodexPreferenceViews } from '../state/codexSubscription';
 import { AgentRosterForm } from './AgentRosterForm';
 import { ConfigForm, type ConfigFormProps } from './ConfigForm';
 import { ProviderApiKeyForm } from './ProviderApiKeyForm';
@@ -45,21 +48,27 @@ export function createCliConfigFormProps(
       await writeSetting(entry, value, stores, 'cli');
       if (entry.category === 'git') applyCliGitAuthorConfig(stores.config);
       if (entry.key === GlobalStateKey.USE_OPENROUTER) {
-        invalidateModelOptionsCache();
+        refreshCodexPreferenceViews();
         if (value === true) await props.onApiModePersonal?.();
       }
       if (entry.key === GlobalStateKey.KIMI_CODE_PREFER) {
-        invalidateModelOptionsCache();
+        // Dual-backend Kimi routing refuses the OpenRouter toggle, so enabling
+        // the preference here turns that toggle off like `/api kimi-code`.
+        if (value === true) {
+          const openRouter = stateSettingByKey(GlobalStateKey.USE_OPENROUTER);
+          if (openRouter) await writeSetting(openRouter, false, stores, 'cli');
+        }
+        refreshCodexPreferenceViews();
       }
     },
     resetValue: async (entry) => {
       await resetSetting(entry, stores, 'cli');
       if (entry.category === 'git') applyCliGitAuthorConfig(stores.config);
       if (entry.key === GlobalStateKey.USE_OPENROUTER) {
-        invalidateModelOptionsCache();
+        refreshCodexPreferenceViews();
       }
       if (entry.key === GlobalStateKey.KIMI_CODE_PREFER) {
-        invalidateModelOptionsCache();
+        refreshCodexPreferenceViews();
       }
     },
     formLinks: [

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -3,7 +3,10 @@ import { Badge } from '@inkjs/ui';
 import { useEffect, useState } from 'react';
 
 import { resolveCliModelAccessRoute } from '@cli/runtime/modelAccessRoute';
-import { isCodexSubscriptionActive } from '@model/providerCapabilities';
+import {
+  isCodexSubscriptionActive,
+  isKimiCodeSubscriptionActive,
+} from '@model/providerCapabilities';
 import { isActivePhase } from '@shared/streams/streamStatus';
 
 import { approvalQueueStatus } from '../state/approvalQueue';
@@ -85,7 +88,8 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
   const accessTarget = streamAccessTarget(statusSlice, sessionMeta);
 
   // Whether the selected stream's model/category would currently route through
-  // the ChatGPT subscription (preference + eligibility + signed in). The
+  // the ChatGPT subscription (preference + eligibility + signed in) or the Kimi
+  // Code coding endpoint (prefer switch + eligibility + stored key). The
   // completed usage snapshot supersedes this prospective value in the display.
   // Polling re-reads external config changes; an in-process access change also
   // bumps `codexPreferenceVersion` for an immediate refresh.
@@ -95,41 +99,51 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     readonly category: typeof accessTarget.category;
     readonly preferenceVersion: number;
     readonly active: boolean;
+    readonly kimiCodeActive: boolean;
   }>();
-  const subscriptionActive =
+  const resolutionCurrent =
     subscriptionResolution?.model === accessTarget.model &&
     subscriptionResolution.category === accessTarget.category &&
-    subscriptionResolution.preferenceVersion === codexPreferenceVersion
-      ? subscriptionResolution.active
-      : false;
+    subscriptionResolution.preferenceVersion === codexPreferenceVersion;
+  const subscriptionActive = resolutionCurrent
+    ? (subscriptionResolution?.active ?? false)
+    : false;
+  const kimiCodeActive = resolutionCurrent
+    ? (subscriptionResolution?.kimiCodeActive ?? false)
+    : false;
   const modelAccess = resolveCliModelAccessRoute({
     apiMode: sessionMeta.apiMode,
     subscriptionActive,
+    kimiCodeActive,
     usageRoute: statusSlice?.usage?.usageRoute,
   });
 
   useEffect(() => {
     let cancelled = false;
-    const resolve = (active: boolean): void => {
+    const resolve = (active: boolean, kimiActive: boolean): void => {
       if (cancelled) return;
       setSubscriptionResolution({
         ...accessTarget,
         preferenceVersion: codexPreferenceVersion,
         active,
+        kimiCodeActive: kimiActive,
       });
     };
     const agentCategory = accessTarget.category;
     if (agentCategory === undefined) {
-      resolve(false);
+      resolve(false, false);
       return;
     }
     let inFlight = false;
     const refresh = (): void => {
       if (inFlight) return; // Skip if the previous read has not resolved.
       inFlight = true;
-      void isCodexSubscriptionActive(accessTarget.model, agentCategory)
-        .then(resolve)
-        .catch(() => resolve(false))
+      void Promise.all([
+        isCodexSubscriptionActive(accessTarget.model, agentCategory),
+        isKimiCodeSubscriptionActive(accessTarget.model),
+      ])
+        .then(([active, kimiActive]) => resolve(active, kimiActive))
+        .catch(() => resolve(false, false))
         .finally(() => {
           inFlight = false;
         });

--- a/packages/cli/src/runtime/apiStatus.ts
+++ b/packages/cli/src/runtime/apiStatus.ts
@@ -65,13 +65,18 @@ export async function loadCliModelAccessOverview(
       access.chatGptSignedIn,
       access.chatGptAccountLabel,
     ),
+    `Kimi Code: ${
+      access.kimiCodeKeySet === true
+        ? 'key configured'
+        : 'no key (add with /key)'
+    }`,
     formatAccountStatusLine(
       'TeXRA',
       profile.authenticated,
       profile.accountLabel,
     ),
   ];
-  if (access.active === 'chatgpt') {
+  if (access.active === 'chatgpt' || access.active === 'kimi-code') {
     lines.push(`API fallback: ${formatCliModelAccessRoute(apiMode)}`);
   }
   if (profile.note) lines.push(profile.note);

--- a/packages/cli/src/runtime/modelAccessRoute.ts
+++ b/packages/cli/src/runtime/modelAccessRoute.ts
@@ -2,12 +2,14 @@ import type { UsageRoute } from '@shared/schemas';
 
 import { parseCliApiMode, type CliApiMode } from './apiAccessMode';
 
-export type CliModelAccessRoute = 'chatgpt' | 'included' | 'personal';
+export type CliModelAccessRoute =
+  'chatgpt' | 'kimi-code' | 'included' | 'personal';
 
 export interface CliModelAccessStatus {
   readonly active: CliModelAccessRoute;
   readonly chatGptSignedIn: boolean;
   readonly chatGptAccountLabel?: string;
+  readonly kimiCodeKeySet?: boolean;
   readonly texraSignedIn?: boolean;
 }
 
@@ -27,6 +29,10 @@ export function parseCliModelAccessRoute(
     case 'chatgpt':
     case 'subscription':
       return 'chatgpt';
+    case 'kimi':
+    case 'kimicode':
+    case 'kimi-code':
+      return 'kimi-code';
     default:
       return undefined;
   }
@@ -36,10 +42,12 @@ export function parseCliModelAccessRoute(
 export function resolveCliModelAccessRoute({
   apiMode,
   subscriptionActive,
+  kimiCodeActive,
   usageRoute,
 }: {
   readonly apiMode: CliApiMode;
   readonly subscriptionActive: boolean;
+  readonly kimiCodeActive?: boolean;
   readonly usageRoute?: UsageRoute;
 }): CliModelAccessRoute {
   if (usageRoute !== undefined) {
@@ -49,22 +57,29 @@ export function resolveCliModelAccessRoute({
       case 'relay':
         return 'included';
       case 'api-key':
-        return 'personal';
+        // Kimi Code usage reports as a plain API key; credit the subscription
+        // route when the prefer switch is on and a key is stored.
+        return kimiCodeActive === true ? 'kimi-code' : 'personal';
       default:
         return usageRoute satisfies never;
     }
   }
-  return subscriptionActive ? 'chatgpt' : apiMode;
+  if (subscriptionActive) return 'chatgpt';
+  if (kimiCodeActive === true) return 'kimi-code';
+  return apiMode;
 }
 
 export function shortCliModelAccessRoute(route: CliModelAccessRoute): string {
-  return route === 'chatgpt' ? 'subscription' : route;
+  if (route === 'chatgpt') return 'subscription';
+  return route;
 }
 
 export function formatCliModelAccessRoute(route: CliModelAccessRoute): string {
   switch (route) {
     case 'chatgpt':
       return 'ChatGPT subscription';
+    case 'kimi-code':
+      return 'Kimi Code subscription';
     case 'included':
       return 'Included TeXRA access';
     case 'personal':
@@ -79,12 +94,13 @@ export function formatCliModelAccessRouteInline(
   route: CliModelAccessRoute,
 ): string {
   const label = formatCliModelAccessRoute(route);
-  return route === 'chatgpt'
+  // Proper-noun labels keep their casing; plain labels lowercase like prose.
+  return route === 'chatgpt' || route === 'kimi-code'
     ? label
     : label.charAt(0).toLowerCase() + label.slice(1);
 }
 
-/** Build the canonical three choices shown by every model-access picker. */
+/** Build the canonical choices shown by every model-access picker. */
 export function buildCliModelAccessItems(
   status: CliModelAccessStatus,
 ): CliModelAccessItem[] {
@@ -97,11 +113,25 @@ export function buildCliModelAccessItems(
     chatGptDescription = 'Sign in with ChatGPT Plus/Pro/Team';
   }
 
+  let kimiCodeDescription: string;
+  if (status.kimiCodeKeySet !== true) {
+    kimiCodeDescription = 'Add a key with /key (kimi.com/code/console)';
+  } else if (status.active === 'kimi-code') {
+    kimiCodeDescription = 'On · key configured';
+  } else {
+    kimiCodeDescription = 'Off · key configured';
+  }
+
   return [
     {
       value: 'chatgpt',
       label: 'Prefer ChatGPT subscription',
       description: chatGptDescription,
+    },
+    {
+      value: 'kimi-code',
+      label: 'Prefer Kimi Code subscription',
+      description: kimiCodeDescription,
     },
     {
       value: 'included',

--- a/packages/cli/src/runtime/modelAccessRoute.ts
+++ b/packages/cli/src/runtime/modelAccessRoute.ts
@@ -57,15 +57,17 @@ export function resolveCliModelAccessRoute({
       case 'relay':
         return 'included';
       case 'api-key':
-        // Kimi Code usage reports as a plain API key; credit the subscription
-        // route when the prefer switch is on and a key is stored.
-        return kimiCodeActive === true ? 'kimi-code' : 'personal';
+        // Kimi Code usage records as a plain `api-key`; a completed request's
+        // route cannot change, so never relabel it from live preferences.
+        return 'personal';
       default:
         return usageRoute satisfies never;
     }
   }
   if (subscriptionActive) return 'chatgpt';
-  if (kimiCodeActive === true) return 'kimi-code';
+  // The Kimi Code route only describes personal access — under included
+  // access the relay owns eligible models.
+  if (kimiCodeActive === true && apiMode === 'personal') return 'kimi-code';
   return apiMode;
 }
 

--- a/packages/cli/src/runtime/modelAccessSelection.ts
+++ b/packages/cli/src/runtime/modelAccessSelection.ts
@@ -3,9 +3,14 @@ import {
   isPreferCodexSubscription,
   setPreferCodexSubscription,
 } from '@auth/codex';
+import { apiKeyExists } from '@model/apiProviders';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { platform } from '@platform/platform';
 import { GlobalStateKey } from '@shared/state/stateKeys';
+import {
+  getPreferKimiCode,
+  setPreferKimiCode,
+} from '@utils/config/providerConfig';
 
 import {
   chatGptAccountLabel,
@@ -41,12 +46,26 @@ export function contextForCliModelAccess(
 export async function readCliModelAccessStatus(
   apiMode: CliApiMode,
 ): Promise<CliModelAccessStatus> {
-  const chatGpt = await getCodexStatus();
+  const [chatGpt, kimiCodeKeySet] = await Promise.all([
+    getCodexStatus(),
+    apiKeyExists(platform().secrets, 'kimiCode'),
+  ]);
+  const chatGptActive = chatGpt.signedIn && isPreferCodexSubscription();
+  // The Kimi Code route is a personal-key route: it only describes the active
+  // access while the API fallback mode is personal and the prefer switch is on.
+  const kimiCodeActive =
+    !chatGptActive &&
+    apiMode === 'personal' &&
+    getPreferKimiCode() &&
+    kimiCodeKeySet;
+  let active: CliModelAccessStatus['active'] = apiMode;
+  if (chatGptActive) active = 'chatgpt';
+  else if (kimiCodeActive) active = 'kimi-code';
   return {
-    active:
-      chatGpt.signedIn && isPreferCodexSubscription() ? 'chatgpt' : apiMode,
+    active,
     chatGptSignedIn: chatGpt.signedIn,
     chatGptAccountLabel: chatGpt.email ?? chatGpt.accountId,
+    kimiCodeKeySet,
   };
 }
 
@@ -55,6 +74,9 @@ export async function selectCliApiModelAccessRoute(
   route: CliApiMode,
 ): Promise<CliModelAccessSelectionResult> {
   const update = await setPreferCodexSubscription(false);
+  // An explicit "personal keys" choice leaves the Kimi Code route; the prefer
+  // switch stays available under /config → Models and providers.
+  if (route === 'personal') await setPreferKimiCode(false);
   await setCliApiMode(route);
   return {
     apiMode: route,
@@ -72,8 +94,32 @@ export async function selectCliModelAccessRoute(
     readonly signal?: AbortSignal;
   },
 ): Promise<CliModelAccessSelectionResult> {
-  if (route !== 'chatgpt') {
+  if (route === 'included' || route === 'personal') {
     return selectCliApiModelAccessRoute(route);
+  }
+
+  if (route === 'kimi-code') {
+    // The Kimi Code API key is the subscription credential — there is no
+    // separate sign-in flow.
+    if (!(await apiKeyExists(platform().secrets, 'kimiCode'))) {
+      return {
+        apiMode: effectiveCliApiMode(context),
+        message:
+          'No Kimi Code API key configured — add one with /key or /config → API keys (get one at https://www.kimi.com/code/console).',
+      };
+    }
+    await setPreferCodexSubscription(false);
+    await setPreferKimiCode(true);
+    // Dual-backend Kimi routing requires the OpenRouter toggle off.
+    await platform().globalState.update(GlobalStateKey.USE_OPENROUTER, false);
+    // Non-Moonshot models fall back to the other personal keys.
+    await setCliApiMode('personal');
+    invalidateModelOptionsCache();
+    return {
+      apiMode: 'personal',
+      message:
+        'Prefer Kimi Code subscription enabled for Kimi models · fallback: personal API keys.',
+    };
   }
 
   const status = await getCodexStatus();

--- a/packages/cli/src/runtime/modelAccessSelection.ts
+++ b/packages/cli/src/runtime/modelAccessSelection.ts
@@ -9,6 +9,7 @@ import { platform } from '@platform/platform';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import {
   getPreferKimiCode,
+  getUseOpenRouter,
   setPreferKimiCode,
 } from '@utils/config/providerConfig';
 
@@ -52,11 +53,14 @@ export async function readCliModelAccessStatus(
   ]);
   const chatGptActive = chatGpt.signedIn && isPreferCodexSubscription();
   // The Kimi Code route is a personal-key route: it only describes the active
-  // access while the API fallback mode is personal and the prefer switch is on.
+  // access while the API fallback mode is personal, the prefer switch is on,
+  // and dispatch can actually honor it (OpenRouter off — dual-backend models
+  // refuse the coding endpoint while it is on).
   const kimiCodeActive =
     !chatGptActive &&
     apiMode === 'personal' &&
     getPreferKimiCode() &&
+    !getUseOpenRouter() &&
     kimiCodeKeySet;
   let active: CliModelAccessStatus['active'] = apiMode;
   if (chatGptActive) active = 'chatgpt';
@@ -74,9 +78,6 @@ export async function selectCliApiModelAccessRoute(
   route: CliApiMode,
 ): Promise<CliModelAccessSelectionResult> {
   const update = await setPreferCodexSubscription(false);
-  // An explicit "personal keys" choice leaves the Kimi Code route; the prefer
-  // switch stays available under /config → Models and providers.
-  if (route === 'personal') await setPreferKimiCode(false);
   await setCliApiMode(route);
   return {
     apiMode: route,
@@ -94,7 +95,15 @@ export async function selectCliModelAccessRoute(
     readonly signal?: AbortSignal;
   },
 ): Promise<CliModelAccessSelectionResult> {
-  if (route === 'included' || route === 'personal') {
+  if (route === 'included') {
+    return selectCliApiModelAccessRoute(route);
+  }
+
+  if (route === 'personal') {
+    // An explicit "personal keys" picker choice leaves the Kimi Code route;
+    // saving a key never clears the switch (see applyCliProviderApiKey), and
+    // the prefer toggle stays available under /config → Models and providers.
+    await setPreferKimiCode(false);
     return selectCliApiModelAccessRoute(route);
   }
 
@@ -108,7 +117,7 @@ export async function selectCliModelAccessRoute(
           'No Kimi Code API key configured — add one with /key or /config → API keys (get one at https://www.kimi.com/code/console).',
       };
     }
-    await setPreferCodexSubscription(false);
+    const update = await setPreferCodexSubscription(false);
     await setPreferKimiCode(true);
     // Dual-backend Kimi routing requires the OpenRouter toggle off.
     await platform().globalState.update(GlobalStateKey.USE_OPENROUTER, false);
@@ -117,8 +126,9 @@ export async function selectCliModelAccessRoute(
     invalidateModelOptionsCache();
     return {
       apiMode: 'personal',
-      message:
-        'Prefer Kimi Code subscription enabled for Kimi models · fallback: personal API keys.',
+      message: update.effective
+        ? `Prefer Kimi Code subscription enabled for Kimi models, but a more specific setting keeps ChatGPT subscription preferred (${update.target} config).`
+        : 'Prefer Kimi Code subscription enabled for Kimi models · fallback: personal API keys.',
     };
   }
 

--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -299,13 +299,18 @@ export function buildCliAgentItems(
 }
 
 function modelAccessItem(status: CliModelAccessStatus): CliOrchestrationItem {
+  let description: string;
+  if (status.active === 'chatgpt' && status.chatGptAccountLabel) {
+    description = `ChatGPT subscription · ${status.chatGptAccountLabel}`;
+  } else if (status.active === 'kimi-code') {
+    description = 'Kimi Code subscription · key configured';
+  } else {
+    description = formatCliModelAccessRoute(status.active);
+  }
   return {
     value: { kind: 'configure-model-access' },
     label: 'Model access',
-    description:
-      status.active === 'chatgpt' && status.chatGptAccountLabel
-        ? `ChatGPT subscription · ${status.chatGptAccountLabel}`
-        : formatCliModelAccessRoute(status.active),
+    description,
   };
 }
 

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -12,6 +12,7 @@ import {
   formatCodexAuthUnavailableMessage,
   isCodexSessionRoutable,
 } from '@auth/codex';
+import { getServerSideKeyService } from '@auth/serverKeys';
 import { AgentError } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { apiKeyExists } from '@model/apiProviders';
@@ -536,8 +537,12 @@ async function createModelHandlerForResolvedCompatibilityKey(
   // already carry the pinned coding baseUrl (the registry-fact predicates route
   // their key and endpoint automatically), so they keep `config` untouched.
   // Dual-backend `kimi3` is rerouted only while the "Prefer Kimi Code" switch
-  // is on and a key is stored, by swapping in a synthesized runtime config that
-  // the normal ModelHandlerKimi switch below then builds.
+  // is on, a key is stored, and the relay is not actually serving requests —
+  // under included (relay) access the relay owns eligible models, and the
+  // rerouted config's pinned coding `baseUrl` would outrank the relay URL
+  // while the credential layer still resolves a relay token (see
+  // resolveClientCredential). The reroute swaps in a synthesized runtime
+  // config that the normal ModelHandlerKimi switch below then builds.
   //
   // On the resume path `useOpenRouter` is derived from the compatibility key
   // (false unless it's `ModelHandlerOpenRouterNative`), not the live global
@@ -546,17 +551,26 @@ async function createModelHandlerForResolvedCompatibilityKey(
   // never `ModelHandlerKimi`. Reaching this branch therefore means the session
   // was a *direct* Kimi session, for which OpenRouter is irrelevant; honoring
   // the current Prefer-Kimi-Code + key on resume keeps a Kimi-Code-only user's
-  // resumed sessions runnable (they have no Moonshot key to fall back to).
+  // resumed sessions runnable when the relay cannot serve them (signed out or
+  // included access off — they have no Moonshot key to fall back to).
   if (
     compatibilityKey === 'ModelHandlerKimi' &&
     isKimiSubscriptionEligible(config)
   ) {
+    const serverSideKeyService = getServerSideKeyService();
+    // The relay only owns the model when included access is on AND the account
+    // can actually use it — a signed-out user with the default-on toggle must
+    // still reach their Kimi Code key, matching picker availability.
+    const includedAccess = serverSideKeyService.getUseIncludedModelAccess()
+      ? await serverSideKeyService.canUseServerSideKeys()
+      : false;
     const keySet = await apiKeyExists(platform().secrets, 'kimiCode');
     const route = resolveKimiCodeRoute(
       config,
       useOpenRouter,
       keySet,
       getPreferKimiCode(),
+      includedAccess,
     );
     if (route === 'kimiCode' && !isKimiCodeExclusiveModel(config)) {
       config = kimiCodeRuntimeConfig(config);

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -215,6 +215,9 @@ function effectiveKimiCodeConfig(
     ctx.useOpenRouter,
     ctx.kimiCodeKeySet,
     ctx.preferKimiCode,
+    // The relay only owns the model when included access can actually serve
+    // it — mirrors ModelFactory's dispatch facts.
+    ctx.useIncludedAccess && ctx.hasServerAccess,
   );
   if (route === 'kimiCode' && !isKimiCodeExclusiveModel(config)) {
     return kimiCodeRuntimeConfig(config);

--- a/src/model/kimiCodeSubscriptionRouting.ts
+++ b/src/model/kimiCodeSubscriptionRouting.ts
@@ -85,20 +85,27 @@ export function isKimiCodeExclusiveModel(
  *  - not eligible → `null`
  *  - exclusive → `'kimiCode'` when a key is set, else `null` (no other backend)
  *  - dual-backend → `'kimiCode'` only when the OpenRouter toggle is off, the
- *    "Prefer Kimi Code" switch is on, and a key is set; otherwise `null`
- *    (falls back to the Moonshot open platform).
+ *    relay is not serving the request (included access off or unavailable),
+ *    the "Prefer Kimi Code" switch is on, and a key is set; otherwise `null`
+ *    (falls back to the Moonshot open platform or the relay). The relay guard
+ *    keeps credential resolution coherent: a rerouted config pins the coding
+ *    `baseUrl`, which outranks the relay URL in `resolveBaseUrl` and would
+ *    send the relay token to the wrong host.
  */
 export function resolveKimiCodeRoute(
   config: KimiSubscriptionModelFields,
   useOpenRouter: boolean,
   keySet: boolean,
   preferKimiCode: boolean,
+  includedAccess: boolean,
 ): 'kimiCode' | null {
   if (!isKimiSubscriptionEligible(config)) return null;
   if (isKimiCodeExclusiveModel(config)) {
     return keySet ? 'kimiCode' : null;
   }
-  if (useOpenRouter || !preferKimiCode || !keySet) return null;
+  if (useOpenRouter || includedAccess || !preferKimiCode || !keySet) {
+    return null;
+  }
   return 'kimiCode';
 }
 

--- a/src/model/providerCapabilities.ts
+++ b/src/model/providerCapabilities.ts
@@ -5,6 +5,7 @@ import {
   isCodexSubscriptionToolUseOnly,
   isPreferCodexSubscription,
 } from '@auth/codex';
+import { getServerSideKeyService } from '@auth/serverKeys';
 import { platform } from '@platform/platform';
 import type { UsageRoute } from '@shared/schemas';
 import { AgentCategory } from '@shared/schemas/agent';
@@ -193,13 +194,19 @@ export async function isCodexSubscriptionActive(
  * Whether the model currently routes through the Kimi Code coding endpoint
  * (Moonshot coding subscription, authenticated by the Kimi Code API key).
  * Mirrors ModelFactory's dispatch facts: registry eligibility, the OpenRouter
- * toggle, a stored key, and the "Prefer Kimi Code" switch.
+ * toggle, included (relay) access, a stored key, and the "Prefer Kimi Code"
+ * switch.
  */
 export async function isKimiCodeSubscriptionActive(
   modelId: string,
 ): Promise<boolean> {
   const config = await resolveRuntimeModelConfig(modelId);
   if (!config || !isKimiSubscriptionEligible(config)) return false;
+  const serverSideKeyService = getServerSideKeyService();
+  // The relay only owns the model when included access can actually serve it.
+  const includedAccess = serverSideKeyService.getUseIncludedModelAccess()
+    ? await serverSideKeyService.canUseServerSideKeys()
+    : false;
   const keySet = await apiKeyExists(platform().secrets, 'kimiCode');
   return (
     resolveKimiCodeRoute(
@@ -207,6 +214,7 @@ export async function isKimiCodeSubscriptionActive(
       getUseOpenRouter(),
       keySet,
       getPreferKimiCode(),
+      includedAccess,
     ) === 'kimiCode'
   );
 }

--- a/src/model/providerCapabilities.ts
+++ b/src/model/providerCapabilities.ts
@@ -5,10 +5,19 @@ import {
   isCodexSubscriptionToolUseOnly,
   isPreferCodexSubscription,
 } from '@auth/codex';
+import { platform } from '@platform/platform';
 import type { UsageRoute } from '@shared/schemas';
 import { AgentCategory } from '@shared/schemas/agent';
-import { getUseOpenRouter } from '@utils/config/providerConfig';
+import {
+  getPreferKimiCode,
+  getUseOpenRouter,
+} from '@utils/config/providerConfig';
 
+import { apiKeyExists } from './apiProviders';
+import {
+  isKimiSubscriptionEligible,
+  resolveKimiCodeRoute,
+} from './kimiCodeSubscriptionRouting';
 import { resolveRuntimeModelConfig } from './runtimeModelRegistry';
 
 type ProviderAuthMode = 'chatgpt-subscription';
@@ -178,4 +187,26 @@ export async function isCodexSubscriptionActive(
   );
   if (!capabilities) return false;
   return isCodexSignedIn();
+}
+
+/**
+ * Whether the model currently routes through the Kimi Code coding endpoint
+ * (Moonshot coding subscription, authenticated by the Kimi Code API key).
+ * Mirrors ModelFactory's dispatch facts: registry eligibility, the OpenRouter
+ * toggle, a stored key, and the "Prefer Kimi Code" switch.
+ */
+export async function isKimiCodeSubscriptionActive(
+  modelId: string,
+): Promise<boolean> {
+  const config = await resolveRuntimeModelConfig(modelId);
+  if (!config || !isKimiSubscriptionEligible(config)) return false;
+  const keySet = await apiKeyExists(platform().secrets, 'kimiCode');
+  return (
+    resolveKimiCodeRoute(
+      config,
+      getUseOpenRouter(),
+      keySet,
+      getPreferKimiCode(),
+    ) === 'kimiCode'
+  );
 }

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -291,6 +291,15 @@ export const USE_OPENROUTER_PROVIDER_SETTING = {
   globalStateKey: GlobalStateKey.USE_OPENROUTER,
 } satisfies ProviderVscodeSettingDef;
 
+export const KIMI_CODE_PREFER_PROVIDER_SETTING = {
+  key: GlobalStateKey.KIMI_CODE_PREFER,
+  label: 'Prefer Kimi Code',
+  description:
+    'Route dual-backend Kimi models (K3) through the Kimi Code coding endpoint when a Kimi Code API key is set. The two coding-only models always use the key. When off, K3 uses the Moonshot open platform.',
+  defaultValue: false,
+  globalStateKey: GlobalStateKey.KIMI_CODE_PREFER,
+} satisfies ProviderVscodeSettingDef;
+
 /** VS Code config settings to surface per provider in the Models tab. */
 export const PROVIDER_VSCODE_SETTINGS: Record<
   string,
@@ -421,16 +430,7 @@ export const PROVIDER_VSCODE_SETTINGS: Record<
   // Keyed lowercase: getProviderVscodeSettings looks these up by
   // `provider.toLowerCase()`, so the camelCase `kimiCode` provider id resolves
   // here as `kimicode`. (The other entries' ids are already lowercase.)
-  kimicode: [
-    {
-      key: GlobalStateKey.KIMI_CODE_PREFER,
-      label: 'Prefer Kimi Code',
-      description:
-        'Route dual-backend Kimi models (K3) through the Kimi Code coding endpoint when a Kimi Code API key is set. The two coding-only models always use the key. When off, K3 uses the Moonshot open platform.',
-      defaultValue: false,
-      globalStateKey: GlobalStateKey.KIMI_CODE_PREFER,
-    },
-  ],
+  kimicode: [KIMI_CODE_PREFER_PROVIDER_SETTING],
   openrouter: [USE_OPENROUTER_PROVIDER_SETTING],
 };
 

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -9,6 +9,7 @@ import {
   LATEXDIFF_MATH_MARKUP_VALUES,
 } from '@shared/constants/latex';
 import {
+  KIMI_CODE_PREFER_PROVIDER_SETTING,
   PROVIDER_ENDPOINT_STATE_ENTRIES,
   USE_OPENROUTER_PROVIDER_SETTING,
 } from '@shared/constants/providers';
@@ -185,6 +186,12 @@ const OPENROUTER_ROUTING_RUNTIME_REACHABILITY = {
     'texra agents run <tool-use-agent> --model <openrouter-routable-model> --instruction "answer a short question"',
   through:
     'packages/cli/src/commands/agentsRun.ts -> packages/cli/src/runtime/runExecution.ts -> src/agent/runtime/ModelFactory.ts -> src/utils/config/providerConfig.ts',
+} satisfies CliRuntimeReachability;
+const KIMI_CODE_ROUTING_RUNTIME_REACHABILITY = {
+  command:
+    'texra agents run <tool-use-agent> --model kimi3 --instruction "answer a short question"',
+  through:
+    'packages/cli/src/commands/agentsRun.ts -> packages/cli/src/runtime/runExecution.ts -> src/agent/runtime/ModelFactory.ts -> src/model/kimiCodeSubscriptionRouting.ts',
 } satisfies CliRuntimeReachability;
 const PROVIDER_ENDPOINT_RUNTIME_REACHABILITY = {
   command:
@@ -546,6 +553,23 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     hosts: ['cli'],
     cliConsumer: 'src/utils/config/providerConfig.ts',
     cliRuntimeReachability: OPENROUTER_ROUTING_RUNTIME_REACHABILITY,
+  },
+
+  // --- Kimi Code routing -------------------------------------------------------
+  // The extension/desktop Models tab already surfaces this toggle through
+  // provider settings; the catalog row is CLI-only so later settings-view
+  // catalog rendering does not duplicate that existing control. Read by
+  // `getPreferKimiCode()` during model-handler dispatch.
+  {
+    key: GlobalStateKey.KIMI_CODE_PREFER,
+    schema: z.boolean().prefault(false),
+    title: KIMI_CODE_PREFER_PROVIDER_SETTING.label,
+    description: KIMI_CODE_PREFER_PROVIDER_SETTING.description,
+    category: 'model',
+    store: 'globalState',
+    hosts: ['cli'],
+    cliConsumer: 'src/agent/runtime/ModelFactory.ts',
+    cliRuntimeReachability: KIMI_CODE_ROUTING_RUNTIME_REACHABILITY,
   },
 
   // --- External tool integrations ------------------------------------------

--- a/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
@@ -893,6 +893,14 @@ describe('routing precedence: compat-key ↔ createModelHandler invariant', () =
       createModelHandler: create,
       activeModelHandlerCompatibilityKey: activeKey,
     } = await import('@agent/runtime/ModelFactory');
+    // Stub the relay service on the same fresh module instance the re-imported
+    // factory reads (static imports are desynced by this file's resetModules).
+    const { setServerSideKeyService: setService } =
+      await import('@auth/serverKeys');
+    setService({
+      getUseIncludedModelAccess: () => false,
+      canUseServerSideKeys: async () => false,
+    } as never);
 
     const mismatches: string[] = [];
     for (const [name, config] of Object.entries(MODEL_CONFIGS)) {
@@ -915,5 +923,54 @@ describe('routing precedence: compat-key ↔ createModelHandler invariant', () =
       }
     }
     expect(mismatches).toEqual([]);
+  });
+});
+
+describe('Kimi Code reroute under included access', () => {
+  const dualBackendKimi = {
+    ...modelConfig(ModelProvider.MOONSHOT),
+    kimiSubscription: true,
+  } as ModelConfig;
+
+  async function createKimiHandler(options: {
+    readonly includedAccess: boolean;
+  }): Promise<ModelConfig> {
+    // Re-import alongside a freshly-initialized platform — see the invariant
+    // test above for why this file cannot rely on the static factory import.
+    await installPlatform({
+      globalState: { 'texra.kimiCode.prefer': true },
+      secrets: { 'apiKey.kimiCode': 'test-kimi-code-key' },
+    });
+    const { createModelHandler: create } =
+      await import('@agent/runtime/ModelFactory');
+    const { setServerSideKeyService: setService } =
+      await import('@auth/serverKeys');
+    const { invalidateApiKeyCache } = await import('@model/apiProviders');
+    setService({
+      getUseIncludedModelAccess: () => options.includedAccess,
+      canUseServerSideKeys: async () => options.includedAccess,
+    } as never);
+    invalidateApiKeyCache();
+
+    const handler = await create(dualBackendKimi);
+    try {
+      return handler.config;
+    } finally {
+      handler.dispose();
+    }
+  }
+
+  it('does not reroute dual-backend Kimi models while the relay serves requests', async () => {
+    // The rerouted config pins the coding baseUrl, which outranks the relay
+    // URL in resolveBaseUrl while the credential layer resolves a relay
+    // token — under serving included access the config must stay untouched.
+    const config = await createKimiHandler({ includedAccess: true });
+    expect(config.baseUrl).toBeUndefined();
+    expect(config.fullName).toBe(dualBackendKimi.fullName);
+  });
+
+  it('reroutes to the coding endpoint when the relay cannot serve', async () => {
+    const config = await createKimiHandler({ includedAccess: false });
+    expect(config.baseUrl).toBe('https://api.kimi.com/coding/v1');
   });
 });

--- a/src/test-kernel/cli/ApiStatusLoad.vitest.mts
+++ b/src/test-kernel/cli/ApiStatusLoad.vitest.mts
@@ -71,6 +71,7 @@ describe('loadCliApiStatusLines', () => {
       active: 'chatgpt',
       chatGptSignedIn: true,
       chatGptAccountLabel: 'chatgpt@example.com',
+      kimiCodeKeySet: false,
     });
     mocks.getCliAuthProfile.mockResolvedValue({
       authenticated: true,
@@ -84,12 +85,34 @@ describe('loadCliApiStatusLines', () => {
         active: 'chatgpt',
         chatGptSignedIn: true,
         chatGptAccountLabel: 'chatgpt@example.com',
+        kimiCodeKeySet: false,
         texraSignedIn: true,
       },
       lines: [
         'model access: ChatGPT subscription',
         'ChatGPT: signed in as chatgpt@example.com',
+        'Kimi Code: no key (add with /key)',
         'TeXRA: signed in as texra@example.com',
+        'API fallback: Personal API keys',
+      ],
+    });
+  });
+
+  it('reports an active Kimi Code route with its personal fallback', async () => {
+    mocks.readCliModelAccessStatus.mockResolvedValue({
+      active: 'kimi-code',
+      chatGptSignedIn: false,
+      kimiCodeKeySet: true,
+    });
+
+    await expect(
+      loadCliModelAccessOverview({ apiMode: 'personal' }),
+    ).resolves.toMatchObject({
+      lines: [
+        'model access: Kimi Code subscription',
+        'ChatGPT: signed out',
+        'Kimi Code: key configured',
+        'TeXRA: signed out',
         'API fallback: Personal API keys',
       ],
     });

--- a/src/test-kernel/cli/ConfigForm.vitest.mts
+++ b/src/test-kernel/cli/ConfigForm.vitest.mts
@@ -434,6 +434,28 @@ describe('/config slash command wiring', () => {
     expect(invalidateModelOptionsCache).toHaveBeenCalledTimes(2);
   });
 
+  it('turns OpenRouter off when Prefer Kimi Code is enabled', async () => {
+    const { stores, globalState } = makeFakeSettingsStores();
+    await globalState.update(GlobalStateKey.USE_OPENROUTER, true);
+    registerBuiltinSlashCommands({ getConfigStores: () => stores });
+    openCliSlashCommandForm('config', '');
+
+    const props = renderConfigFormProps();
+    const preferKimiCode = entryByKey(GlobalStateKey.KIMI_CODE_PREFER);
+    await props.writeValue?.(preferKimiCode, true);
+
+    expect(globalState.get(GlobalStateKey.KIMI_CODE_PREFER)).toBe(true);
+    expect(props.readValue?.(entryByKey(GlobalStateKey.USE_OPENROUTER))).toBe(
+      false,
+    );
+    expect(invalidateModelOptionsCache).toHaveBeenCalled();
+
+    // Disabling the preference leaves the OpenRouter toggle untouched.
+    await globalState.update(GlobalStateKey.USE_OPENROUTER, true);
+    await props.writeValue?.(preferKimiCode, false);
+    expect(globalState.get(GlobalStateKey.USE_OPENROUTER)).toBe(true);
+  });
+
   it('delegates catalog form rows through the slash form registry', () => {
     registerBuiltinSlashCommands({
       getConfigStores: () => makeFakeSettingsStores().stores,
@@ -457,9 +479,12 @@ describe('/config slash command wiring', () => {
       { props?: { availableRows?: number } } | undefined;
     const agents = props.formRenderers?.agents?.(() => undefined) as
       { props?: { availableRows?: number } } | undefined;
+    const apiKeys = props.formRenderers?.['api-keys']?.(() => undefined) as
+      { props?: { availableRows?: number } } | undefined;
 
     expect(props.availableRows).toBe(20);
     expect(tools?.props?.availableRows).toBe(20);
     expect(agents?.props?.availableRows).toBe(20);
+    expect(apiKeys?.props?.availableRows).toBe(20);
   });
 });

--- a/src/test-kernel/cli/ConfigForm.vitest.mts
+++ b/src/test-kernel/cli/ConfigForm.vitest.mts
@@ -403,7 +403,7 @@ describe('/config slash command wiring', () => {
         if (route === 'chatgpt') return;
         sessionMeta.set({
           ...sessionMeta.get(),
-          apiMode: route,
+          apiMode: route === 'kimi-code' ? 'personal' : route,
         });
       },
     });

--- a/src/test-kernel/cli/ModelAccessSelection.vitest.mts
+++ b/src/test-kernel/cli/ModelAccessSelection.vitest.mts
@@ -24,16 +24,31 @@ const mocks = vi.hoisted(() => ({
   shouldUseChatGptDeviceCode: vi.fn(),
   signInCliChatGpt: vi.fn(),
   updateGlobalState: vi.fn(),
+  apiKeyExists: vi.fn(),
+  getPreferKimiCode: vi.fn(),
+  setPreferKimiCode: vi.fn(),
 }));
 
 vi.mock('@platform/platform', () => ({
-  platform: () => ({ globalState: { update: mocks.updateGlobalState } }),
+  platform: () => ({
+    globalState: { update: mocks.updateGlobalState },
+    secrets: {},
+  }),
 }));
 
 vi.mock('@auth/codex', () => ({
   getCodexStatus: mocks.getCodexStatus,
   isPreferCodexSubscription: mocks.isPreferCodexSubscription,
   setPreferCodexSubscription: mocks.setPreferCodexSubscription,
+}));
+
+vi.mock('@model/apiProviders', () => ({
+  apiKeyExists: mocks.apiKeyExists,
+}));
+
+vi.mock('@utils/config/providerConfig', () => ({
+  getPreferKimiCode: mocks.getPreferKimiCode,
+  setPreferKimiCode: mocks.setPreferKimiCode,
 }));
 
 vi.mock('@model/computeModelOptions', () => ({
@@ -70,12 +85,18 @@ beforeEach(() => {
   });
   mocks.setCliApiMode.mockResolvedValue(undefined);
   mocks.shouldUseChatGptDeviceCode.mockReturnValue(false);
+  mocks.apiKeyExists.mockResolvedValue(false);
+  mocks.getPreferKimiCode.mockReturnValue(false);
+  mocks.setPreferKimiCode.mockResolvedValue(undefined);
 });
 
 describe('CLI model access routes', () => {
-  it('parses the three routes and the subscription compatibility spelling', () => {
+  it('parses the routes and the compatibility spellings', () => {
     expect(parseCliModelAccessRoute('chatgpt')).toBe('chatgpt');
     expect(parseCliModelAccessRoute('subscription')).toBe('chatgpt');
+    expect(parseCliModelAccessRoute('kimi')).toBe('kimi-code');
+    expect(parseCliModelAccessRoute('kimicode')).toBe('kimi-code');
+    expect(parseCliModelAccessRoute('kimi-code')).toBe('kimi-code');
     expect(parseCliModelAccessRoute('included')).toBe('included');
     expect(parseCliModelAccessRoute('relay')).toBe('included');
     expect(parseCliModelAccessRoute('personal')).toBe('personal');
@@ -105,12 +126,44 @@ describe('CLI model access routes', () => {
     ).toBe('personal');
   });
 
+  it('credits api-key usage to Kimi Code only while that route is active', () => {
+    expect(
+      resolveCliModelAccessRoute({
+        apiMode: 'personal',
+        subscriptionActive: false,
+        kimiCodeActive: true,
+        usageRoute: 'api-key',
+      }),
+    ).toBe('kimi-code');
+    expect(
+      resolveCliModelAccessRoute({
+        apiMode: 'personal',
+        subscriptionActive: false,
+        kimiCodeActive: false,
+        usageRoute: 'api-key',
+      }),
+    ).toBe('personal');
+    expect(
+      resolveCliModelAccessRoute({
+        apiMode: 'included',
+        subscriptionActive: false,
+        kimiCodeActive: true,
+      }),
+    ).toBe('kimi-code');
+  });
+
   it('formats the shared access routes for detailed and compact surfaces', () => {
     expect(formatCliModelAccessRoute('chatgpt')).toBe('ChatGPT subscription');
+    expect(formatCliModelAccessRoute('kimi-code')).toBe(
+      'Kimi Code subscription',
+    );
     expect(formatCliModelAccessRoute('included')).toBe('Included TeXRA access');
     expect(formatCliModelAccessRoute('personal')).toBe('Personal API keys');
     expect(formatCliModelAccessRouteInline('chatgpt')).toBe(
       'ChatGPT subscription',
+    );
+    expect(formatCliModelAccessRouteInline('kimi-code')).toBe(
+      'Kimi Code subscription',
     );
     expect(formatCliModelAccessRouteInline('included')).toBe(
       'included TeXRA access',
@@ -119,6 +172,7 @@ describe('CLI model access routes', () => {
       'personal API keys',
     );
     expect(shortCliModelAccessRoute('chatgpt')).toBe('subscription');
+    expect(shortCliModelAccessRoute('kimi-code')).toBe('kimi-code');
   });
 
   it('applies a launcher access choice to the launched session', () => {
@@ -144,13 +198,93 @@ describe('CLI model access routes', () => {
       active: 'chatgpt',
       chatGptSignedIn: true,
       chatGptAccountLabel: 'user@example.com',
+      kimiCodeKeySet: false,
     });
 
     mocks.getCodexStatus.mockResolvedValue({ signedIn: false });
     await expect(readCliModelAccessStatus('included')).resolves.toEqual({
       active: 'included',
       chatGptSignedIn: false,
+      chatGptAccountLabel: undefined,
+      kimiCodeKeySet: false,
     });
+  });
+
+  it('reports Kimi Code only for personal access with prefer switch and key', async () => {
+    mocks.apiKeyExists.mockResolvedValue(true);
+    mocks.getPreferKimiCode.mockReturnValue(true);
+
+    await expect(readCliModelAccessStatus('personal')).resolves.toEqual({
+      active: 'kimi-code',
+      chatGptSignedIn: false,
+      chatGptAccountLabel: undefined,
+      kimiCodeKeySet: true,
+    });
+
+    // Included access keeps the prefer switch dormant in the background.
+    await expect(readCliModelAccessStatus('included')).resolves.toMatchObject({
+      active: 'included',
+      kimiCodeKeySet: true,
+    });
+
+    // A missing key falls back to plain personal access.
+    mocks.apiKeyExists.mockResolvedValue(false);
+    await expect(readCliModelAccessStatus('personal')).resolves.toMatchObject({
+      active: 'personal',
+      kimiCodeKeySet: false,
+    });
+  });
+
+  it('enables Kimi Code routing on a personal fallback when a key exists', async () => {
+    mocks.apiKeyExists.mockResolvedValue(true);
+
+    const result = await selectCliModelAccessRoute(context, 'kimi-code', {
+      writeProgress: vi.fn(),
+    });
+
+    expect(mocks.setPreferCodexSubscription).toHaveBeenCalledWith(false);
+    expect(mocks.setPreferKimiCode).toHaveBeenCalledWith(true);
+    expect(mocks.updateGlobalState).toHaveBeenCalledWith(
+      'texra.useOpenRouter',
+      false,
+    );
+    expect(mocks.setCliApiMode).toHaveBeenCalledWith('personal');
+    expect(mocks.invalidateModelOptionsCache).toHaveBeenCalledOnce();
+    expect(result).toEqual({
+      apiMode: 'personal',
+      message:
+        'Prefer Kimi Code subscription enabled for Kimi models · fallback: personal API keys.',
+    });
+  });
+
+  it('guides to key entry when Kimi Code is selected without a key', async () => {
+    const result = await selectCliModelAccessRoute(context, 'kimi-code', {
+      writeProgress: vi.fn(),
+    });
+
+    expect(mocks.setPreferKimiCode).not.toHaveBeenCalled();
+    expect(mocks.setCliApiMode).not.toHaveBeenCalled();
+    expect(result.apiMode).toBe('personal');
+    expect(result.message).toContain('No Kimi Code API key configured');
+    expect(result.message).toContain('https://www.kimi.com/code/console');
+  });
+
+  it('leaves the Kimi Code route when personal access is chosen explicitly', async () => {
+    await selectCliModelAccessRoute(context, 'personal', {
+      writeProgress: vi.fn(),
+    });
+
+    expect(mocks.setPreferKimiCode).toHaveBeenCalledWith(false);
+    expect(mocks.setCliApiMode).toHaveBeenCalledWith('personal');
+  });
+
+  it('keeps the Kimi Code prefer switch when included access is chosen', async () => {
+    await selectCliModelAccessRoute(context, 'included', {
+      writeProgress: vi.fn(),
+    });
+
+    expect(mocks.setPreferKimiCode).not.toHaveBeenCalled();
+    expect(mocks.setCliApiMode).toHaveBeenCalledWith('included');
   });
 
   it('switches API-based routes through one policy boundary', async () => {

--- a/src/test-kernel/cli/ModelAccessSelection.vitest.mts
+++ b/src/test-kernel/cli/ModelAccessSelection.vitest.mts
@@ -26,6 +26,7 @@ const mocks = vi.hoisted(() => ({
   updateGlobalState: vi.fn(),
   apiKeyExists: vi.fn(),
   getPreferKimiCode: vi.fn(),
+  getUseOpenRouter: vi.fn(),
   setPreferKimiCode: vi.fn(),
 }));
 
@@ -48,6 +49,7 @@ vi.mock('@model/apiProviders', () => ({
 
 vi.mock('@utils/config/providerConfig', () => ({
   getPreferKimiCode: mocks.getPreferKimiCode,
+  getUseOpenRouter: mocks.getUseOpenRouter,
   setPreferKimiCode: mocks.setPreferKimiCode,
 }));
 
@@ -87,6 +89,7 @@ beforeEach(() => {
   mocks.shouldUseChatGptDeviceCode.mockReturnValue(false);
   mocks.apiKeyExists.mockResolvedValue(false);
   mocks.getPreferKimiCode.mockReturnValue(false);
+  mocks.getUseOpenRouter.mockReturnValue(false);
   mocks.setPreferKimiCode.mockResolvedValue(undefined);
 });
 
@@ -126,7 +129,9 @@ describe('CLI model access routes', () => {
     ).toBe('personal');
   });
 
-  it('credits api-key usage to Kimi Code only while that route is active', () => {
+  it('never relabels recorded api-key usage from live preferences', () => {
+    // A completed request's route cannot change — `api-key` usage stays
+    // personal even while the Kimi Code route is currently active.
     expect(
       resolveCliModelAccessRoute({
         apiMode: 'personal',
@@ -134,22 +139,25 @@ describe('CLI model access routes', () => {
         kimiCodeActive: true,
         usageRoute: 'api-key',
       }),
-    ).toBe('kimi-code');
+    ).toBe('personal');
+  });
+
+  it('describes a prospective Kimi Code route only for personal access', () => {
     expect(
       resolveCliModelAccessRoute({
         apiMode: 'personal',
         subscriptionActive: false,
-        kimiCodeActive: false,
-        usageRoute: 'api-key',
+        kimiCodeActive: true,
       }),
-    ).toBe('personal');
+    ).toBe('kimi-code');
+    // Under included access the relay owns eligible models.
     expect(
       resolveCliModelAccessRoute({
         apiMode: 'included',
         subscriptionActive: false,
         kimiCodeActive: true,
       }),
-    ).toBe('kimi-code');
+    ).toBe('included');
   });
 
   it('formats the shared access routes for detailed and compact surfaces', () => {
@@ -233,6 +241,15 @@ describe('CLI model access routes', () => {
       active: 'personal',
       kimiCodeKeySet: false,
     });
+
+    // OpenRouter suppresses dual-backend Kimi Code dispatch, so the route is
+    // not reported active while the toggle is on.
+    mocks.apiKeyExists.mockResolvedValue(true);
+    mocks.getUseOpenRouter.mockReturnValue(true);
+    await expect(readCliModelAccessStatus('personal')).resolves.toMatchObject({
+      active: 'personal',
+      kimiCodeKeySet: true,
+    });
   });
 
   it('enables Kimi Code routing on a personal fallback when a key exists', async () => {
@@ -276,6 +293,32 @@ describe('CLI model access routes', () => {
 
     expect(mocks.setPreferKimiCode).toHaveBeenCalledWith(false);
     expect(mocks.setCliApiMode).toHaveBeenCalledWith('personal');
+  });
+
+  it('preserves the Kimi prefer switch on the key-save path', async () => {
+    // Saving or rotating a key is a credential operation, not an explicit
+    // "Personal API keys" picker choice — it must not clear the preference.
+    await selectCliApiModelAccessRoute('personal');
+
+    expect(mocks.setPreferKimiCode).not.toHaveBeenCalled();
+    expect(mocks.setCliApiMode).toHaveBeenCalledWith('personal');
+  });
+
+  it('reports when a more specific setting keeps ChatGPT preferred over Kimi', async () => {
+    mocks.apiKeyExists.mockResolvedValue(true);
+    mocks.setPreferCodexSubscription.mockResolvedValue({
+      effective: true,
+      target: 'workspace',
+    });
+
+    const result = await selectCliModelAccessRoute(context, 'kimi-code', {
+      writeProgress: vi.fn(),
+    });
+
+    expect(mocks.setPreferKimiCode).toHaveBeenCalledWith(true);
+    expect(result.message).toContain(
+      'keeps ChatGPT subscription preferred (workspace config)',
+    );
   });
 
   it('keeps the Kimi Code prefer switch when included access is chosen', async () => {

--- a/src/test-kernel/cli/Orchestration.vitest.mts
+++ b/src/test-kernel/cli/Orchestration.vitest.mts
@@ -321,6 +321,11 @@ describe('CLI orchestration items', () => {
         description: 'Off · researcher@example.com',
       },
       {
+        value: 'kimi-code',
+        label: 'Prefer Kimi Code subscription',
+        description: 'Add a key with /key (kimi.com/code/console)',
+      },
+      {
         value: 'included',
         label: 'Included TeXRA access',
         description: 'Use your TeXRA account',
@@ -331,6 +336,43 @@ describe('CLI orchestration items', () => {
         description: 'Use keys configured on this computer',
       },
     ]);
+  });
+
+  it('describes the Kimi Code route by key state and activity', () => {
+    expect(
+      buildCliModelAccessItems({
+        active: 'personal',
+        chatGptSignedIn: false,
+        kimiCodeKeySet: true,
+      })[1],
+    ).toEqual({
+      value: 'kimi-code',
+      label: 'Prefer Kimi Code subscription',
+      description: 'Off · key configured',
+    });
+    expect(
+      buildCliModelAccessItems({
+        active: 'kimi-code',
+        chatGptSignedIn: false,
+        kimiCodeKeySet: true,
+      })[1].description,
+    ).toBe('On · key configured');
+
+    const items = buildCliOrchestrationItems({
+      presetPlans: [],
+      history: [],
+      toolUseAgents: [],
+      modelAccess: {
+        active: 'kimi-code',
+        chatGptSignedIn: false,
+        kimiCodeKeySet: true,
+      },
+    });
+    expect(items[1]).toEqual({
+      label: 'Model access',
+      description: 'Kimi Code subscription · key configured',
+      value: { kind: 'configure-model-access' },
+    });
   });
 
   it('offers account management as one startup row with provider actions', () => {
@@ -374,7 +416,7 @@ describe('CLI orchestration items', () => {
         active: 'personal',
         chatGptSignedIn: false,
         texraSignedIn: false,
-      })[1]?.description,
+      }).find((item) => item.value === 'included')?.description,
     ).toBe('Sign in through Account to use included models');
   });
 

--- a/src/test-kernel/model/KimiSubscriptionRouting.vitest.ts
+++ b/src/test-kernel/model/KimiSubscriptionRouting.vitest.ts
@@ -66,25 +66,40 @@ describe('resolveKimiCodeRoute', () => {
         false,
         true,
         true,
+        false,
       ),
     ).toBeNull();
   });
 
-  it('routes exclusive models whenever a key is set, ignoring both toggles', () => {
-    // key + prefer off + openRouter on: still routes (no other backend).
-    expect(resolveKimiCodeRoute(exclusive, true, true, false)).toBe('kimiCode');
+  it('routes exclusive models whenever a key is set, ignoring the toggles', () => {
+    // key + prefer off + openRouter on + included on: still routes (no other
+    // backend exists for coding-only models, and they never allow the relay).
+    expect(resolveKimiCodeRoute(exclusive, true, true, false, true)).toBe(
+      'kimiCode',
+    );
     // no key: cannot route.
-    expect(resolveKimiCodeRoute(exclusive, false, false, true)).toBeNull();
+    expect(
+      resolveKimiCodeRoute(exclusive, false, false, true, false),
+    ).toBeNull();
   });
 
   it('routes dual-backend only with prefer on, a key set, and OpenRouter off', () => {
-    expect(resolveKimiCodeRoute(dual, false, true, true)).toBe('kimiCode');
+    expect(resolveKimiCodeRoute(dual, false, true, true, false)).toBe(
+      'kimiCode',
+    );
     // prefer off → open platform.
-    expect(resolveKimiCodeRoute(dual, false, true, false)).toBeNull();
+    expect(resolveKimiCodeRoute(dual, false, true, false, false)).toBeNull();
     // no key → open platform.
-    expect(resolveKimiCodeRoute(dual, false, false, true)).toBeNull();
+    expect(resolveKimiCodeRoute(dual, false, false, true, false)).toBeNull();
     // OpenRouter on → open-router path wins.
-    expect(resolveKimiCodeRoute(dual, true, true, true)).toBeNull();
+    expect(resolveKimiCodeRoute(dual, true, true, true, false)).toBeNull();
+  });
+
+  it('leaves dual-backend models to the relay under included access', () => {
+    // Included (relay) access owns eligible models: the rerouted config's
+    // pinned coding baseUrl would outrank the relay URL while the credential
+    // layer resolves a relay token, so the reroute must not happen.
+    expect(resolveKimiCodeRoute(dual, false, true, true, true)).toBeNull();
   });
 });
 

--- a/src/test-kernel/shared/stateSettings.vitest.ts
+++ b/src/test-kernel/shared/stateSettings.vitest.ts
@@ -103,6 +103,7 @@ const EXPECTED_DEFAULTS: Record<string, unknown> = {
   [GlobalStateKey.WEBSOCKET_OPENAI]: false,
   ...PROVIDER_ENDPOINT_DEFAULTS,
   [GlobalStateKey.USE_OPENROUTER]: false,
+  [GlobalStateKey.KIMI_CODE_PREFER]: false,
   [GlobalStateKey.DISABLED_TOOLS]: [],
 };
 
@@ -355,6 +356,8 @@ describe('state settings catalog', () => {
     //    runs (and lets the Codex backend attempt WebSocket).
     //  - provider endpoints are read by the proxy resolver used by CLI model
     //    handlers before falling back to provider defaults.
+    //  - the Kimi Code prefer switch is read by ModelFactory when dispatching
+    //    dual-backend Kimi models in CLI runs.
     // auto-open-pdf (no CLI opener), latexdiff, and the formatter are
     // intentionally excluded. Changing the CLI roster must be a deliberate edit
     // here, not an accident of flipping `hosts`.
@@ -379,6 +382,7 @@ describe('state settings catalog', () => {
         ),
         GlobalStateKey.WEBSOCKET_OPENAI,
         GlobalStateKey.USE_OPENROUTER,
+        GlobalStateKey.KIMI_CODE_PREFER,
         GlobalStateKey.DISABLED_TOOLS,
       ].sort(),
     );

--- a/src/utils/config/providerConfig.ts
+++ b/src/utils/config/providerConfig.ts
@@ -153,9 +153,15 @@ export function getGLMCodingPlan(): boolean {
  * Whether the user opted to route dual-backend Kimi models (K3) through the
  * Kimi Code coding endpoint when a Kimi Code API key is set. The two
  * coding-only Kimi models always use that key regardless of this switch.
+ * Catalog-modeled (see `stateSettings.ts`), so the default comes from the
+ * schema via the shared accessor.
  */
 export function getPreferKimiCode(): boolean {
-  return read(GlobalStateKey.KIMI_CODE_PREFER, false);
+  return readPlatformSetting<boolean>(GlobalStateKey.KIMI_CODE_PREFER);
+}
+
+export async function setPreferKimiCode(enabled: boolean): Promise<void> {
+  await tryGlobalState()?.update(GlobalStateKey.KIMI_CODE_PREFER, enabled);
 }
 
 /**


### PR DESCRIPTION
## Summary

Two CLI gaps closed:

1. **API keys in `/config`** — the settings panel had endpoint overrides and toggles but no way to set provider keys. A new top-level **API keys** entry (next to Agents) opens the existing masked key-entry form for all 12 providers; saving a key switches to personal mode, matching `/key`. A **Prefer Kimi Code** toggle also appears under *Models and providers* (CLI-only catalog row reusing the extension's setting definition).

2. **Kimi Code subscription in model access** — the launcher menu and `/api` offered only `chatgpt | included | personal`. A new **Prefer Kimi Code subscription** route enables the existing Kimi Code (Moonshot coding-subscription) routing: it sets the prefer switch, disables OpenRouter, and keeps personal keys as the fallback for non-Moonshot models. With no key stored it changes nothing and points to `/key` or `/config → API keys`. Note: there is no OAuth flow for Kimi Code in this codebase — the Kimi Code API key from kimi.com/code/console *is* the subscription credential.

Behavior details:

- `/api kimi-code` (aliases `kimi`, `kimicode`) selects the route; choosing *Personal API keys* explicitly leaves it.
- Launcher home row shows `Model access — Kimi Code subscription · key configured`; `/api status` adds a `Kimi Code:` line and an API-fallback line when active.
- Status bar and `/status` credit `api-key` usage to Kimi Code while the route is active (via new `isKimiCodeSubscriptionActive` mirroring `isCodexSubscriptionActive`).

## Test plan

- [x] `npm run format`
- [x] `npm run typecheck`
- [x] `npm run lint` (0 errors)
- [x] `npm test` — 754 files / 7085 tests passed
- New/extended coverage: route parse/format/resolve, selection with and without a stored key, status precedence, picker items, launcher description, `/api status` lines, and the `stateSettings` guardrail allowlist for the new catalog row.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches model dispatch, relay vs Kimi Code credential routing, and CLI access selection—wrong guards could mis-route requests or show incorrect access labels, though behavior is heavily tested.
> 
> **Overview**
> **Kimi Code subscription** is now a first-class model-access choice alongside ChatGPT, included TeXRA, and personal keys. `/api` accepts `kimi-code` (and aliases); the launcher and status surfaces show key state, active route, and fallback when ChatGPT or Kimi Code is preferred. Selecting the route turns on **Prefer Kimi Code**, forces **personal** API mode for non-Moonshot fallbacks, and turns **OpenRouter** off; explicit **personal** clears the Kimi preference, while saving keys no longer does.
> 
> **`/config`** gains an **API keys** sub-form (masked entry for all providers) and a CLI-only **Prefer Kimi Code** row under models; enabling it also disables OpenRouter, matching `/api kimi-code`.
> 
> **Routing** now skips Kimi Code reroute while **included (relay) access** can actually serve the model, so coding `baseUrl` does not fight relay credentials. `resolveKimiCodeRoute`, `ModelFactory`, model options, and new `isKimiCodeSubscriptionActive` share that guard; tests cover relay-on vs relay-off behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20d2d629f622101a00c988f7911c535352ebe0c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->