### PR TITLE
refactor: consolidate duplicate logic onto shared/native helpers

### DIFF
--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -25,6 +25,7 @@ import {
   filterNotNullish,
   formatCompactDuration,
   formatCompactTokenCount,
+  unique,
 } from '@utils/core';
 import { formatResultCount } from '@utils/text/stringUtils';
 
@@ -419,13 +420,11 @@ function fitStatusBarLeftSegments(
   }
 
   const compacted = [...segments];
-  const priorities = [
-    ...new Set(
-      compacted
-        .map((segment) => segment.compactPriority)
-        .filter(filterNotNullish),
-    ),
-  ].sort((a, b) => a - b);
+  const priorities = unique(
+    compacted
+      .map((segment) => segment.compactPriority)
+      .filter(filterNotNullish),
+  ).sort((a, b) => a - b);
 
   // Lowest-priority segments compact first; returns as soon as the row fits.
   const sweep = (

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -37,14 +37,14 @@ import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInte
 import { isPreferCodexSubscription } from '@auth/codex';
 import { getCliApiMode, setCliApiMode } from '@cli/runtime/apiAccessMode';
 import {
-  approvalPromptAllowed,
-  humanInputDenialFeedback,
+  askUserQuestionDenial,
   immediateDecision,
   immediateDecisionForApproval,
   isCliApiSwitchableRetry,
   isCliChatGptSubscriptionRetry,
   markApprovalDenied,
 } from '@cli/runtime/approvalAdapter';
+import { denyExternalInquiryIfNoHumanInput } from '@cli/runtime/approval/humanInputHandlers';
 import type { CliContext } from '@cli/runtime/cliContext';
 import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
 import {
@@ -651,15 +651,8 @@ async function requestUserQuestionInteraction(
   payload: HostUserQuestionRequest,
   context: CliContext,
 ): Promise<HostUserQuestionResult> {
-  if (!approvalPromptAllowed(context)) {
-    return {
-      submitted: false,
-      feedback: humanInputDenialFeedback(
-        context,
-        'User question requires human input; yolo mode cannot synthesize an answer.',
-      ),
-    };
-  }
+  const denial = askUserQuestionDenial(context);
+  if (denial) return denial;
 
   const decision = await enqueueTuiApproval({ kind: 'userQuestion', payload });
   markIfRejected(context, decision);
@@ -860,14 +853,7 @@ function handleExternalInquiry(
   const threadId = payload.threadId;
   if (!threadId) return;
 
-  if (!approvalPromptAllowed(context)) {
-    const feedback = humanInputDenialFeedback(
-      context,
-      'External inquiry requires human input; yolo mode cannot synthesize an external answer.',
-    );
-    void handleExternalInquiryAction({ action: 'drop', threadId, feedback });
-    return;
-  }
+  if (denyExternalInquiryIfNoHumanInput(threadId, context)) return;
   void enqueueTuiApproval({ kind: 'externalInquiry', payload }).then(
     (decision) => {
       markIfRejected(context, decision);

--- a/packages/cli/src/commands/_helpers/globalArgs.ts
+++ b/packages/cli/src/commands/_helpers/globalArgs.ts
@@ -6,6 +6,7 @@ import {
 } from '@cli/schemas/cliSettings';
 import { CliUsageError } from '@cli/runtime/cliContext';
 import { INTEROP_SKILL_DIRS } from '@skills/skillSources';
+import { unique } from '@utils/core';
 
 /**
  * Single source of truth for the global flags accepted by every TeXRA
@@ -256,13 +257,11 @@ export function rejectHeadlessOnlyFlags(
   rawArgs: readonly string[],
   commandName: string,
 ): void {
-  const labels = [
-    ...new Set(
-      rawArgs
-        .map(headlessOnlyFlagLabel)
-        .filter((label): label is string => label !== undefined),
-    ),
-  ];
+  const labels = unique(
+    rawArgs
+      .map(headlessOnlyFlagLabel)
+      .filter((label): label is string => label !== undefined),
+  );
   if (labels.length === 0) return;
 
   throw new CliUsageError(

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -4,6 +4,7 @@ import { InvalidAgentTeamError } from '@agent/index';
 import { readSetting } from '@shared/config/settingsAccess';
 import { agentKeyOf } from '@shared/schemas/agent';
 import { CLI_STATE_SETTINGS } from '@shared/schemas/stateSettings';
+import { unique } from '@utils/core';
 
 import {
   CliUsageError,
@@ -27,14 +28,12 @@ import { emitCliResult } from './_helpers/output';
 
 function parseAgentKeys(value: string | undefined): string[] {
   if (!value) return [];
-  return [
-    ...new Set(
-      value
-        .split(',')
-        .map((item) => item.trim())
-        .filter(Boolean),
-    ),
-  ];
+  return unique(
+    value
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean),
+  );
 }
 
 function formatConfigValue(value: unknown): string {

--- a/packages/cli/src/runtime/approval/approvalPolicy.ts
+++ b/packages/cli/src/runtime/approval/approvalPolicy.ts
@@ -1,3 +1,4 @@
+import type { HostUserQuestionResult } from '@agent/runtime/HostInteractions';
 import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
 import { isRelayMonthlyLimitMessage } from '@common/errors/sdkErrorUtils';
 import {
@@ -246,4 +247,23 @@ export function humanInputDenialFeedback(
   if (context.approvalPolicy === 'yolo') return yoloMessage;
   markApprovalDenied(context);
   return denyMessage(context.approvalPolicy);
+}
+
+/**
+ * Shared "no human input available" guard for user-question requests, used
+ * by both the headless adapter and the TUI approval queue. Returns the
+ * unsubmitted result to hand straight back to the caller, or `undefined`
+ * when a prompt is allowed and the caller should proceed.
+ */
+export function askUserQuestionDenial(
+  context: CliContext,
+): HostUserQuestionResult | undefined {
+  if (approvalPromptAllowed(context)) return undefined;
+  return {
+    submitted: false,
+    feedback: humanInputDenialFeedback(
+      context,
+      'User question requires human input; yolo mode cannot synthesize an answer.',
+    ),
+  };
 }

--- a/packages/cli/src/runtime/approval/humanInputHandlers.ts
+++ b/packages/cli/src/runtime/approval/humanInputHandlers.ts
@@ -15,6 +15,29 @@ const NON_TUI_EXTERNAL_INQUIRY_FEEDBACK =
   'resume them after the run finalizes. Use texra chat for the inquiry ' +
   'panel, or ask_user_question for synchronous CLI input.';
 
+const EXTERNAL_INQUIRY_YOLO_MESSAGE =
+  'External inquiry requires human input; yolo mode cannot synthesize an external answer.';
+
+/**
+ * Shared "no human input available" guard for external-inquiry requests,
+ * used by both the non-TUI handler below and the TUI approval queue. Drops
+ * the durable inquiry thread with denial feedback and returns `true` when
+ * denied; returns `false` when a prompt is allowed and the caller should
+ * proceed with its own (TUI vs. non-TUI) handling.
+ */
+export function denyExternalInquiryIfNoHumanInput(
+  threadId: string,
+  context: CliContext,
+): boolean {
+  if (approvalPromptAllowed(context)) return false;
+  const feedback = humanInputDenialFeedback(
+    context,
+    EXTERNAL_INQUIRY_YOLO_MESSAGE,
+  );
+  void handleExternalInquiryAction({ action: 'drop', threadId, feedback });
+  return true;
+}
+
 export function handleExternalInquiry(
   payload: RuntimeInteractionEventPayloads['showExternalInquiry'],
   context: CliContext,
@@ -26,14 +49,7 @@ export function handleExternalInquiry(
     return;
   }
 
-  if (!approvalPromptAllowed(context)) {
-    const feedback = humanInputDenialFeedback(
-      context,
-      'External inquiry requires human input; yolo mode cannot synthesize an external answer.',
-    );
-    void handleExternalInquiryAction({ action: 'drop', threadId, feedback });
-    return;
-  }
+  if (denyExternalInquiryIfNoHumanInput(threadId, context)) return;
 
   void handleExternalInquiryAction({
     action: 'drop',

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -30,8 +30,8 @@ import {
   type ApprovalDecision,
   type CliApprovalPromptHooks,
   askApproval,
+  askUserQuestionDenial,
   approvalPromptAllowed,
-  humanInputDenialFeedback,
   immediateDecision,
   immediateDecisionForApproval,
   markApprovalDenied,
@@ -49,6 +49,7 @@ import { parseUserQuestionAnswer } from './userQuestionAnswer';
 export {
   appendCliApiSwitchHint,
   approvalPromptAllowed,
+  askUserQuestionDenial,
   hasCliApprovalDenied,
   humanInputDenialFeedback,
   immediateDecision,
@@ -157,15 +158,8 @@ async function askHeadlessUserQuestion(
   context: CliContext,
   hooks: CliApprovalPromptHooks,
 ): Promise<HostUserQuestionResult> {
-  if (!approvalPromptAllowed(context)) {
-    return {
-      submitted: false,
-      feedback: humanInputDenialFeedback(
-        context,
-        'User question requires human input; yolo mode cannot synthesize an answer.',
-      ),
-    };
-  }
+  const denial = askUserQuestionDenial(context);
+  if (denial) return denial;
 
   const answers: UserQuestionAnswers = {};
   try {

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -8,6 +8,7 @@ import {
 } from '@model/runModelDecision';
 import type { ModelAvailabilityKind, ModelOptionData } from '@shared/schemas';
 import type { AgentCategory } from '@shared/schemas/agent';
+import { unique } from '@utils/core';
 
 // Local file imports
 import { resolveKnownCliModelId } from './cliConfig';
@@ -641,9 +642,9 @@ export async function selectCliRunnableModel(
           ]
         : [];
     });
-  const requestedModels = [
-    ...new Set(requestedCandidates.map((candidate) => candidate.model)),
-  ];
+  const requestedModels = unique(
+    requestedCandidates.map((candidate) => candidate.model),
+  );
   const hiddenEntries = await Promise.allSettled(
     requestedModels.map((model) =>
       loadCliModelAccessEntry(model, {

--- a/packages/extension/src/common/webview/resourceRoots.ts
+++ b/packages/extension/src/common/webview/resourceRoots.ts
@@ -27,16 +27,10 @@ export function getCombinedLocalResourceRoots(
   context: vscode.ExtensionContext,
   viewFolders: string[],
 ): vscode.Uri[] {
-  const seen = new Set<string>();
-  const roots: vscode.Uri[] = [];
-  for (const folder of viewFolders) {
-    for (const uri of getSharedLocalResourceRoots(context, folder)) {
-      const key = uri.toString();
-      if (!seen.has(key)) {
-        seen.add(key);
-        roots.push(uri);
-      }
-    }
-  }
-  return roots;
+  const byKey = new Map(
+    viewFolders
+      .flatMap((folder) => getSharedLocalResourceRoots(context, folder))
+      .map((uri) => [uri.toString(), uri] as const),
+  );
+  return [...byKey.values()];
 }

--- a/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
+++ b/packages/extension/src/progressView/frontend/components/FollowUpInput.ts
@@ -24,6 +24,7 @@ import {
 } from '@shared/utils/clipboardImages';
 import { isKnownUnsupported } from '@shared/utils/dispatcher';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
+import { filterNotNullish } from '@utils/core';
 import { generatePastedImageName } from '@utils/files/pastedImageUtils';
 import {
   archivedContext,
@@ -284,7 +285,7 @@ export class FollowUpInput extends LitElement {
           },
         ),
       )
-    ).filter((image): image is ExtractedClipboardImage => image !== undefined);
+    ).filter(filterNotNullish);
     if (pasteRevision !== transientState.imagePasteRevision) return;
     if (added.length === 0) return;
     const chipText = added.map(({ fileName }) => `[${fileName}]`).join(' ');

--- a/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -31,6 +31,7 @@ import {
 import { postMessage } from '@shared/hostBridge';
 import { markdownStyles } from '@shared/styles/markdownStyles';
 import {
+  readSelectValue,
   renderAgentOptions,
   renderModelOptions,
 } from '@shared/utils/selectTemplates';
@@ -51,21 +52,12 @@ import { proposalRequestPanelStyles } from './ProposalRequestPanel.styles';
 import { APPROVE_ALL_DELEGATED_WORK_ACTION } from '../events';
 import { processMarkdownContent } from '../formatters/markdownRenderer';
 import { getComposedPathElement } from '../utils';
-import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
 import type { PermissionState } from '../permissionState';
 
 function proposalIdOf(
   p: PermissionState | null | undefined,
 ): string | undefined {
   return p?.kind === PERMISSION_KIND.PROPOSAL ? p.data.proposalId : undefined;
-}
-
-// Read from currentTarget (the wa-select host) instead of target. wa-select can
-// retarget events from internal elements, and HTMLSelectElement is the wrong type
-// for this Web Component anyway.
-function readSelectValue(event: Event): string {
-  const select = event.currentTarget as WaSelect | null;
-  return typeof select?.value === 'string' ? select.value : '';
 }
 
 @customElement('proposal-request-panel')

--- a/packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts
+++ b/packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts
@@ -26,20 +26,14 @@ import { isTerminalOutcomePhase } from '@shared/streams/streamStatus';
 import { selectStyles } from '@shared/styles/selectStyles';
 import { isKnownUnsupported } from '@shared/utils/dispatcher';
 import {
+  readSelectValue,
   renderAgentOptions,
   renderModelOptions,
 } from '@shared/utils/selectTemplates';
 import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
 
 import { ProgressEvents } from '../events';
-import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
 import type { FollowupOptionsState } from '../store';
-
-/** Read the current value from a wa-select change event, defaulting to ''. */
-function readSelectValue(event: Event): string {
-  const select = event.currentTarget as WaSelect | null;
-  return typeof select?.value === 'string' ? select.value : '';
-}
 
 @customElement('workflow-tool-use-followup-section')
 export class WorkflowToolUseFollowupSection extends LitElement {

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/helpers.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/helpers.ts
@@ -21,7 +21,7 @@ import {
   EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS,
   EXECUTIONS_WAIT_MIN_TIMEOUT_SECONDS,
 } from '@shared/toolUse';
-import { isObject } from '@utils/core';
+import { clamp, isObject } from '@utils/core';
 import {
   collapseWhitespace,
   truncateWithEllipsis,
@@ -52,8 +52,9 @@ const TIMEOUT_GATED_BY_ACTION: Record<string, string> = {
 
 export function getExecutionsWaitTimeoutSeconds(timeout: unknown): number {
   return typeof timeout === 'number' && Number.isFinite(timeout)
-    ? Math.min(
-        Math.max(timeout, EXECUTIONS_WAIT_MIN_TIMEOUT_SECONDS),
+    ? clamp(
+        timeout,
+        EXECUTIONS_WAIT_MIN_TIMEOUT_SECONDS,
         EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS,
       )
     : EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS;

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -37,9 +37,9 @@ import {
   type ProviderKeyStatus,
   type ReasoningLevel,
 } from '@shared/schemas/settingsViewMessages';
+import { readSelectValue } from '@shared/utils/selectTemplates';
 import { modelSelectionListStyles } from './ModelSelectionList.styles';
 import { resolveProviderKeyRows } from './providerKeyRows';
-import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
 import type WaSwitch from '@awesome.me/webawesome/dist/components/switch/switch.js';
 
 interface ProviderGroup {
@@ -119,19 +119,14 @@ export class ModelSelectionList extends LitElement {
     this.expandedDeprecated = next;
   }
 
-  private readSelectValue(e: Event): string {
-    const select = e.currentTarget as WaSelect | null;
-    return typeof select?.value === 'string' ? select.value : '';
-  }
-
   private handleHelperModelChange(e: Event): void {
     postMessage(SETTINGS_VIEW_COMMANDS.SET_HELPER_MODEL, {
-      modelName: this.readSelectValue(e),
+      modelName: readSelectValue(e),
     });
   }
 
   private handleReasoningLevelChange(modelName: string, e: Event): void {
-    const value = this.readSelectValue(e);
+    const value = readSelectValue(e);
     postMessage(SETTINGS_VIEW_COMMANDS.SET_MODEL_REASONING_LEVEL, {
       modelName,
       level: value === '' ? null : value,

--- a/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/AIAgentsTab.ts
@@ -34,12 +34,12 @@ import {
 } from '@shared/schemas/stateSettings';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { CLAUDE_AGENT_DEFAULT_MODEL } from '@shared/schemas/agentCliSettings';
+import { readSelectValue } from '@shared/utils/selectTemplates';
 
 // Side-effect imports - register WA components
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/select/select.js';
 import '@awesome.me/webawesome/dist/components/option/option.js';
-import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
 
 // Side-effect: register tool card component
 import '../components/tools/ToolCard';
@@ -176,8 +176,7 @@ export class AIAgentsTab extends LitElement {
   @property({ type: String }) claudeAgentEffort: ClaudeAgentEffort = 'high';
 
   private postSelect(key: WorkspaceStateKey, e: Event): void {
-    const select = e.currentTarget as WaSelect | null;
-    const value = typeof select?.value === 'string' ? select.value : '';
+    const value = readSelectValue(e);
     if (value) {
       postMessage(SETTINGS_VIEW_COMMANDS.UPDATE_STATE_SETTING, { key, value });
     }

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -59,7 +59,7 @@ import {
 } from '@shared/constants/latex';
 
 // Local imports - shared utilities
-import { clamp, filterNotNullish } from '@utils/core';
+import { clampOptional, filterNotNullish } from '@utils/core';
 import { latexTabStyles } from './LaTeXTab.styles';
 import type WaSwitch from '@awesome.me/webawesome/dist/components/switch/switch.js';
 import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
@@ -783,10 +783,7 @@ export class LaTeXTab extends LitElement {
               // Coerce to integer first — paste / spinner can produce decimals
               // that the backend `.int()` schema would silently reject.
               const integer = Math.round(raw);
-              const clamped =
-                opts.max !== undefined
-                  ? clamp(integer, opts.min, opts.max)
-                  : Math.max(opts.min, integer);
+              const clamped = clampOptional(integer, opts.min, opts.max);
               this.dispatchSetConfigValue(opts.field, clamped);
             }}
             class="setting-number-input"

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -24,6 +24,7 @@ import { waIcon } from '@shared/wa/webAwesomeIcons';
 // Local imports - shared utils
 import {
   BROWSE_ALL_AGENTS_OPTION_VALUE,
+  readSelectValue,
   renderAgentOptions,
   renderModelOptions,
 } from '@shared/utils/selectTemplates';
@@ -190,9 +191,9 @@ export class InstructionPanel extends LitElement {
   }
 
   private handleModelChange(event: Event): void {
-    const select = event.currentTarget as WaSelect | null;
-    const value = typeof select?.value === 'string' ? select.value : '';
-    this.dispatchEvent(MainViewEvents.modelChange({ value }));
+    this.dispatchEvent(
+      MainViewEvents.modelChange({ value: readSelectValue(event) }),
+    );
   }
 
   private handleInput(event: Event): void {

--- a/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
+++ b/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
@@ -20,6 +20,7 @@ import {
   compactIconActionButtonStyles,
   designTokens,
 } from '@shared/styles';
+import { readSelectValue } from '@shared/utils/selectTemplates';
 import {
   renderIconActionButton,
   renderLabeledActionButtonParts,
@@ -27,7 +28,6 @@ import {
 import { type TeXRAIconName, waIcon } from '@shared/wa/webAwesomeIcons';
 import { MainViewEvents } from '../events';
 import { fileSelectLayoutStyles } from '../styles/fileSelectStyles';
-import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
 
 type LatexDiffsAction = LatexDiffsActionDetail['action'];
 
@@ -224,26 +224,21 @@ export class LatexDiffsSection extends LitElement {
     this.dispatchEvent(MainViewEvents.latexDiffsToggle({ visible }));
   }
 
-  private selectValue(event: Event): string {
-    const select = event.currentTarget as WaSelect | null;
-    return typeof select?.value === 'string' ? select.value : '';
-  }
-
   private handleBaseSelectChange(event: Event): void {
     this.dispatchEvent(
-      MainViewEvents.baseFileChange({ value: this.selectValue(event) }),
+      MainViewEvents.baseFileChange({ value: readSelectValue(event) }),
     );
   }
 
   private handleEditedSelectChange(event: Event): void {
     this.dispatchEvent(
-      MainViewEvents.editedFileChange({ value: this.selectValue(event) }),
+      MainViewEvents.editedFileChange({ value: readSelectValue(event) }),
     );
   }
 
   private handleCommitSelectChange(event: Event): void {
     this.dispatchEvent(
-      MainViewEvents.commitChange({ value: this.selectValue(event) }),
+      MainViewEvents.commitChange({ value: readSelectValue(event) }),
     );
   }
 

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -1,7 +1,6 @@
 /** Retry state management: Node retry config, error tracking, and retryable node base class. */
 
 import { StatusCodes } from 'http-status-codes';
-import { nanoid } from 'nanoid';
 
 import { Node } from '@agent/node';
 import { logErrorData, logProgressStatus, type AgentTrace } from '@agent/trace';
@@ -21,6 +20,7 @@ import {
   type RetryErrorInfo,
 } from '@shared/schemas';
 import { DEFAULT_CORE_SETTINGS } from '@shared/schemas/coreSettings';
+import { generateShortId } from '@utils/core';
 import { getConfig } from '@utils/config/configUtils';
 import { ensureError } from '@utils/errors/errorMessage';
 
@@ -310,7 +310,7 @@ export abstract class RetryableInvocationNode<
     const refreshClient = this.services.refreshClient;
     const interaction = session.interactions.requestRetry(
       {
-        requestId: `retry-${nanoid()}`,
+        requestId: `retry-${generateShortId()}`,
         streamId,
         operation: operationName,
         model: this.services.config.model,

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -1,5 +1,4 @@
 // Third-party imports
-import { nanoid } from 'nanoid';
 import {
   GoogleGenAI,
   FunctionCallingConfigMode,
@@ -43,6 +42,7 @@ import type {
   ToolFileAttachment,
   ToolResult,
 } from '@shared/schemas/toolResult';
+import { generateShortId } from '@utils/core';
 import { getShortDisplayPath } from '@utils/files';
 import { joinNonEmpty, pluralize } from '@utils/text/stringUtils';
 
@@ -862,7 +862,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       if (!call?.name) continue;
       results.push({
         provider: 'google',
-        callId: call.id ?? nanoid(),
+        callId: call.id ?? generateShortId(),
         name: call.name,
         input: call.args,
         raw: call,

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -1,5 +1,4 @@
 // Third-party imports
-import { nanoid } from 'nanoid';
 import {
   GoogleGenAI,
   PartMediaResolutionLevel,
@@ -45,7 +44,7 @@ import type {
   ToolResult,
 } from '@shared/schemas/toolResult';
 import { getShortDisplayPath } from '@utils/files';
-import { filterNotNull, isNonEmptyString } from '@utils/core';
+import { filterNotNull, generateShortId, isNonEmptyString } from '@utils/core';
 import { joinNonEmpty, pluralize } from '@utils/text/stringUtils';
 import { getConfig } from '@utils/config/configUtils';
 
@@ -1032,7 +1031,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
       if (step.type !== 'function_call') continue;
       results.push({
         provider: 'google',
-        callId: step.id ?? nanoid(),
+        callId: step.id ?? generateShortId(),
         name: step.name,
         input: step.arguments,
         // GoogleToolCall.raw is a chat `FunctionCall`; reconstruct the shape the
@@ -1235,7 +1234,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
     for (const call of calls) {
       steps.push({
         type: 'function_call',
-        id: call.callId ?? nanoid(),
+        id: call.callId ?? generateShortId(),
         name: call.name ?? '',
         arguments: (call.input ?? {}) as Record<string, unknown>,
       } satisfies FunctionCallStep);
@@ -1928,7 +1927,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
 
       const response: GoogleGenAIInteraction = {
         ...(completedInteraction ?? {}),
-        id: completedInteraction?.id ?? interactionId ?? nanoid(),
+        id: completedInteraction?.id ?? interactionId ?? generateShortId(),
         status,
         usage,
         steps:
@@ -2026,7 +2025,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
       } else if (slot.type === 'function_call') {
         steps.push({
           type: 'function_call',
-          id: slot.callId ?? nanoid(),
+          id: slot.callId ?? generateShortId(),
           name: slot.callName ?? '',
           arguments:
             slot.args ??

--- a/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
+++ b/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
@@ -7,7 +7,7 @@ import {
 // Local imports - utils
 import { isNonEmptyString } from '@utils/core';
 import { WorkspaceFS } from '@utils/files';
-import { appendTail } from '@utils/strings/appendTail';
+import { appendHead, appendTail } from '@utils/strings/appendTail';
 
 // Local imports - model handlers
 import {
@@ -102,18 +102,6 @@ export async function loadAttachmentBuffer(
 }
 
 /**
- * Keep the first `maxChars` UTF-16 code units of `text` without splitting a
- * surrogate pair at the cut point (the low half alone renders as `?`).
- */
-function takeHead(text: string, maxChars: number): string {
-  if (text.length <= maxChars) return text;
-  let cut = maxChars;
-  const code = text.charCodeAt(cut);
-  if (code >= 0xdc00 && code <= 0xdfff) cut -= 1;
-  return text.slice(0, cut);
-}
-
-/**
  * Fixed textual overhead of the message template below (labels, punctuation,
  * the elision marker, and the character-count numbers themselves) reserved
  * out of `maxLength` so head+tail content plus framing never balloons past
@@ -165,7 +153,7 @@ export function checkToolResultTextLimit(
 
   const headLen = Math.min(headBudget, text.length);
   const tailLen = Math.min(tailBudget, text.length - headLen);
-  const head = takeHead(text, headLen);
+  const head = appendHead('', text, headLen);
   const tail = tailLen > 0 ? appendTail('', text, tailLen) : '';
   const elidedChars = text.length - head.length - tail.length;
 
@@ -179,7 +167,9 @@ export function checkToolResultTextLimit(
   // exact accounting of the template above, so hard-trim as a last resort to
   // guarantee the maxLength invariant for every input — including maxLength
   // values too small to fit the template text at all.
-  return message.length > maxLength ? takeHead(message, maxLength) : message;
+  return message.length > maxLength
+    ? appendHead('', message, maxLength)
+    : message;
 }
 
 /**

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -15,7 +15,6 @@ import {
   type RoundIndexed,
 } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
-import { LATEX_CONFIG_RANGES } from '@shared/constants/latex';
 import {
   createRunStorageLocation,
   FlexibleFS,
@@ -30,7 +29,10 @@ import {
   publishCompiledPdfArtifact,
   type CompiledPdfArtifact,
 } from './compiledPdfArtifacts';
-import { resolveWorkspaceSourceDir } from './compileCheck';
+import {
+  getWorkflowAutoCompileTimeoutMs,
+  resolveWorkspaceSourceDir,
+} from './compileCheck';
 import { tryOperation } from './outputOperations';
 import type { RoundFileEntry, RoundFileMapping } from './types';
 
@@ -383,12 +385,7 @@ export class LatexDiffManager {
     );
     // Reuse the workflow compile-check timeout so a hanging diff build
     // gets killed by execa instead of orphaning latexmk/pdflatex.
-    const timeoutMs = Math.max(
-      LATEX_CONFIG_RANGES.workflowAutoCompileTimeoutMs.min,
-      readPlatformSetting<number>(
-        WorkspaceStateKey.WORKFLOW_AUTO_COMPILE_TIMEOUT_MS,
-      ),
-    );
+    const timeoutMs = getWorkflowAutoCompileTimeoutMs();
     // The diff `.tex` is written to `diff/r{round}/`, away from both the
     // revised round output and the live workspace source. Search the revised
     // round directory first so same-round sibling edits win, then fall back to

--- a/src/agent/output/compileCheck.ts
+++ b/src/agent/output/compileCheck.ts
@@ -53,6 +53,16 @@ export interface CompileCheckResult {
   compileResult?: CompileResult;
 }
 
+/** Workflow auto-compile timeout, floored at the config-range minimum. */
+export function getWorkflowAutoCompileTimeoutMs(): number {
+  return Math.max(
+    MIN_TIMEOUT_MS,
+    readPlatformSetting<number>(
+      WorkspaceStateKey.WORKFLOW_AUTO_COMPILE_TIMEOUT_MS,
+    ),
+  );
+}
+
 /**
  * Return a human-readable display name for an output file in compile messages.
  * Prefers the `source` field (which carries the original document name, e.g.
@@ -123,12 +133,7 @@ export async function runCompileCheck(
     return { failures: [], artifacts: [] };
   }
 
-  const timeoutMs = Math.max(
-    MIN_TIMEOUT_MS,
-    readPlatformSetting<number>(
-      WorkspaceStateKey.WORKFLOW_AUTO_COMPILE_TIMEOUT_MS,
-    ),
-  );
+  const timeoutMs = getWorkflowAutoCompileTimeoutMs();
   // compileRoot is created lazily on first failure so successful rounds leave
   // no trace — the orchestrator can use "no compile/*.log entries" as proof
   // the build succeeded.

--- a/src/agent/review/reviewDiff.ts
+++ b/src/agent/review/reviewDiff.ts
@@ -23,6 +23,7 @@ import {
 } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { platform } from '@platform/platform';
+import { unique } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { isDirectory, isSymlink } from '@utils/files/fsEntryType';
 import { makeMachineGitEnv } from '@utils/system/platformPaths';
@@ -235,18 +236,15 @@ export async function listBaseBranchCandidates(
     ]),
   ]);
   const current = headOut?.trim();
-  const seen = new Set<string>();
-  const candidates: BaseBranchCandidate[] = [];
-  for (const ref of [
-    ...splitOutputLines(localsOut ?? ''),
-    ...splitOutputLines(remotesOut ?? ''),
-  ]) {
-    // `origin/HEAD` is a symbolic alias, not a real branch to diff against.
-    if (!ref || ref === 'origin/HEAD' || seen.has(ref)) continue;
-    seen.add(ref);
-    candidates.push({ ref, current: ref === current });
-  }
-  return candidates;
+  return (
+    unique([
+      ...splitOutputLines(localsOut ?? ''),
+      ...splitOutputLines(remotesOut ?? ''),
+    ])
+      // `origin/HEAD` is a symbolic alias, not a real branch to diff against.
+      .filter((ref) => ref && ref !== 'origin/HEAD')
+      .map((ref) => ({ ref, current: ref === current }))
+  );
 }
 
 /**

--- a/src/agent/trace/TraceEmitter.ts
+++ b/src/agent/trace/TraceEmitter.ts
@@ -12,14 +12,13 @@
  */
 import { AsyncLocalStorage } from 'node:async_hooks';
 
-import { nanoid } from 'nanoid';
-
 import * as logger from '@logger/logUtils';
 import {
   RUN_OUTCOME,
   type RunOutcome,
   type UpdateStreamUsagePayload,
 } from '@shared/schemas';
+import { generateShortId } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import type {
@@ -222,7 +221,7 @@ export class TraceEmitter implements AgentTrace {
       return new SkippedStageHandle(this, parentId);
     }
 
-    const id = options.id ?? nanoid();
+    const id = options.id ?? generateShortId();
     this.emit({
       type: 'stage.start',
       id,
@@ -238,7 +237,7 @@ export class TraceEmitter implements AgentTrace {
   // ─── Streams ───────────────────────────────────────────────────────
 
   openStream(kind: StreamKind, options: StreamOptions = {}): StreamHandle {
-    const id = options.id ?? nanoid();
+    const id = options.id ?? generateShortId();
     const progressEnabled = options.progressViewEnabled ?? true;
 
     if (!progressEnabled) {

--- a/src/agent/trace/noopTrace.ts
+++ b/src/agent/trace/noopTrace.ts
@@ -2,9 +2,8 @@
  * No-op AgentTrace. Used as the default for SDK consumers who don't
  * subscribe to the run's event stream.
  */
-import { nanoid } from 'nanoid';
-
 import type { RunOutcome } from '@shared/schemas';
+import { generateShortId } from '@utils/core';
 
 import type {
   AgentTrace,
@@ -25,7 +24,7 @@ class NoopStageHandle implements StageHandle {
     return Promise.resolve(fn());
   }
   child(_label: string, _options?: StageOptions): StageHandle {
-    return new NoopStageHandle(nanoid());
+    return new NoopStageHandle(generateShortId());
   }
 }
 
@@ -57,9 +56,9 @@ export const noopTrace: AgentTrace = {
   responseFinalized: NOOP,
 
   openStage(_label, options) {
-    return new NoopStageHandle(options?.id ?? nanoid());
+    return new NoopStageHandle(options?.id ?? generateShortId());
   },
   openStream(_kind, options) {
-    return new NoopStreamHandle(options?.id ?? nanoid());
+    return new NoopStreamHandle(options?.id ?? generateShortId());
   },
 };

--- a/src/agent/trace/toolUseHelpers.ts
+++ b/src/agent/trace/toolUseHelpers.ts
@@ -13,7 +13,7 @@
  * helper functions but ultimately reduce to the same `toolStart` /
  * `toolEnd` emissions.
  */
-import { nanoid } from 'nanoid';
+import { generateShortId } from '@utils/core';
 
 import type { AgentTrace } from './AgentTrace';
 import type { ToolStatus } from './events';
@@ -34,7 +34,7 @@ export function startToolUseCard(
   input: unknown,
   stageId?: string,
 ): ToolUseCardRef {
-  const logId = nanoid();
+  const logId = generateShortId();
   const groupId = stageId ?? trace.activeStageId();
   trace.toolStart({ logId, toolName, input }, { stageId: groupId });
   return { logId, groupId };

--- a/src/agent/workflowScript/sandbox.ts
+++ b/src/agent/workflowScript/sandbox.ts
@@ -1,3 +1,6 @@
+// Node imports
+import { setImmediate as setImmediateAsync } from 'node:timers/promises';
+
 // Third-party imports
 import quickJsReleaseVariant from '@jitl/quickjs-wasmfile-release-sync';
 import quickJsWasm from '@jitl/quickjs-wasmfile-release-sync/wasm';
@@ -600,7 +603,7 @@ async function pumpJobs(
 
     if (executed === MAX_JOBS_PER_TURN || runtime.hasPendingJob()) {
       // Give host promises, sibling runtimes, and abort listeners a turn.
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      await setImmediateAsync();
       continue;
     }
 

--- a/src/common/files/fileListingRules.ts
+++ b/src/common/files/fileListingRules.ts
@@ -1,6 +1,5 @@
 import { DEFAULT_CORE_SETTINGS } from '@shared/schemas/coreSettings';
 import { getBasename, getFileStem, normalizeFilePath } from '@utils/core';
-import { getPathSegments } from '@utils/core/pathCore';
 
 import {
   LEGACY_AUXILIARY_KEYWORDS_KEY,
@@ -40,6 +39,10 @@ export interface PreparedFileFilters {
 }
 
 type ConfigReader = (key: string, fallback: string[]) => string[];
+
+function getPathSegments(filePath: string): string[] {
+  return normalizeFilePath(filePath).split('/');
+}
 
 function normalizeList(values: readonly string[]): string[] {
   return values

--- a/src/common/files/fileListingRules.ts
+++ b/src/common/files/fileListingRules.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_CORE_SETTINGS } from '@shared/schemas/coreSettings';
 import { getBasename, getFileStem, normalizeFilePath } from '@utils/core';
+import { getPathSegments } from '@utils/core/pathCore';
 
 import {
   LEGACY_AUXILIARY_KEYWORDS_KEY,
@@ -39,10 +40,6 @@ export interface PreparedFileFilters {
 }
 
 type ConfigReader = (key: string, fallback: string[]) => string[];
-
-function getPathSegments(filePath: string): string[] {
-  return normalizeFilePath(filePath).split('/');
-}
 
 function normalizeList(values: readonly string[]): string[] {
   return values

--- a/src/common/files/workspaceFileListing.ts
+++ b/src/common/files/workspaceFileListing.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
 
-import { normalizeFilePath } from '@utils/core';
+import { byString, byStringProp, normalizeFilePath } from '@utils/core';
 import { isDirectory, isFile } from '@utils/files/fsEntryType';
 
 import {
@@ -35,7 +35,7 @@ export async function listWorkspaceFiles(
     relativeDirectory: string,
   ): Promise<void> {
     const entries = await options.readDirectory(directory);
-    entries.sort(([left], [right]) => left.localeCompare(right));
+    entries.sort(byStringProp(([name]) => name));
 
     for (const [name, type] of entries) {
       const relativePath = normalizeFilePath(
@@ -57,5 +57,5 @@ export async function listWorkspaceFiles(
   }
 
   await visit(options.root, '');
-  return results.sort((left, right) => left.localeCompare(right));
+  return results.sort(byString);
 }

--- a/src/latex/extractFileDependencies.ts
+++ b/src/latex/extractFileDependencies.ts
@@ -12,6 +12,7 @@ import pMap from 'p-map';
 
 // Local imports
 import type { FileLocation } from '@shared/schemas';
+import { filterNotNull, unique } from '@utils/core';
 import { FlexibleFS } from '@utils/files';
 import { ensureExtension, joinLatexPath } from '@utils/core/pathCore';
 
@@ -86,7 +87,5 @@ export async function extractLatexFileDependencies(
     }),
   ]);
 
-  return [
-    ...new Set([...texResolved, ...bibResolved].filter((r) => r !== null)),
-  ];
+  return unique([...texResolved, ...bibResolved].filter(filterNotNull));
 }

--- a/src/latex/latexdiff/outputDiscovery.ts
+++ b/src/latex/latexdiff/outputDiscovery.ts
@@ -30,6 +30,7 @@ import {
   findRunDir,
   pathToLocation,
 } from '@utils/files';
+import { toNewestFirstByTimestamp } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { hasExtension } from '@utils/core/pathCore';
 import { isDirectory, isFile } from '@utils/files/fsEntryType';
@@ -213,8 +214,8 @@ export async function discoverLatestExecutionOutputs(query: {
     // matching execution.
     const normalizedInput = path.normalize(query.inputFile);
 
-    const candidates = executions
-      .filter(
+    const candidates = toNewestFirstByTimestamp(
+      executions.filter(
         (entry): entry is Extract<ExecutionListingEntry, { kind: 'agent' }> => {
           if (
             entry.kind !== 'agent' ||
@@ -229,8 +230,9 @@ export async function discoverLatestExecutionOutputs(query: {
             path.normalize(entryInput) === normalizedInput
           );
         },
-      )
-      .sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+      ),
+      (entry) => entry.timestamp,
+    );
 
     const snapshots = new StreamSnapshotStore();
     for (const candidate of candidates) {

--- a/src/model/runModelDecision.ts
+++ b/src/model/runModelDecision.ts
@@ -1,3 +1,5 @@
+import { filterNotNullish } from '@utils/core';
+
 const RUN_MODEL_PRECEDENCE = {
   'explicit-override': 0,
   environment: 1,
@@ -48,7 +50,7 @@ export function decideRunModel(
 ): RunModelDecision | null {
   const ordered = candidates
     .map(normalizeCandidate)
-    .filter((candidate) => candidate != null)
+    .filter(filterNotNullish)
     .toSorted(
       (left, right) =>
         RUN_MODEL_PRECEDENCE[left.reason] - RUN_MODEL_PRECEDENCE[right.reason],

--- a/src/shared/litControllers/TooltipController.ts
+++ b/src/shared/litControllers/TooltipController.ts
@@ -1,3 +1,5 @@
+import { clamp } from '@utils/core';
+
 /**
  * Tooltip delay in ms before showing (matches VS Code native tooltip timing).
  */
@@ -70,10 +72,7 @@ function show(anchor: Element): void {
 
     // Clamp to viewport edges
     const margin = 4;
-    left = Math.max(
-      margin,
-      Math.min(left, window.innerWidth - tooltipRect.width - margin),
-    );
+    left = clamp(left, margin, window.innerWidth - tooltipRect.width - margin);
 
     tooltipEl.style.left = `${left}px`;
     tooltipEl.style.top = `${rect.bottom + 4}px`;

--- a/src/shared/utils/selectTemplates.ts
+++ b/src/shared/utils/selectTemplates.ts
@@ -10,6 +10,18 @@ import { repeat } from 'lit/directives/repeat.js';
 import type { AgentOptionData, ModelOptionData } from '@shared/schemas';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { AGENT_DECORATORS, getModelProviderDecorator } from './icons';
+import type WaSelect from '@awesome.me/webawesome/dist/components/select/select.js';
+
+/**
+ * Read the current value from a `wa-select` change event, defaulting to ''.
+ * Reads from `currentTarget` (the wa-select host) instead of `target` — wa-
+ * select can retarget events from internal elements, and
+ * `HTMLSelectElement` is the wrong type for this Web Component anyway.
+ */
+export function readSelectValue(event: Event): string {
+  const select = event.currentTarget as WaSelect | null;
+  return typeof select?.value === 'string' ? select.value : '';
+}
 
 /**
  * Sentinel option value for the launcher dropdown's "Browse all agents…"

--- a/src/tools/github/annotationFetchBudget.ts
+++ b/src/tools/github/annotationFetchBudget.ts
@@ -18,6 +18,8 @@
  * queue-and-wait contract, which doesn't fit either requirement.
  */
 
+import { clamp } from '@utils/core';
+
 // Bound annotation endpoint traffic across all PR subscriptions in this
 // process. Pagination claims one unit per annotations page, so this budget
 // permits at most 3,000 annotation requests per hour, leaving room for the
@@ -77,10 +79,7 @@ export class AnnotationFetchBudget {
     nowMs = Date.now(),
   ): void {
     this.lastRefillMs = nowMs;
-    this.tokens = Math.max(
-      0,
-      Math.min(this.maxRequestsPerWindow, remainingRequests),
-    );
+    this.tokens = clamp(remainingRequests, 0, this.maxRequestsPerWindow);
   }
 }
 

--- a/src/tools/inquiry/externalInquiryResultFormatter.ts
+++ b/src/tools/inquiry/externalInquiryResultFormatter.ts
@@ -1,4 +1,6 @@
 // Local imports - inquiry storage
+import { unique } from '@utils/core';
+
 import type { ExternalInquiryThreadManifest } from './externalInquiryStorage';
 
 /**
@@ -11,17 +13,12 @@ export function collectKnownSessionLinks(
 ): string[] | undefined {
   if (!manifest) return undefined;
 
-  const known: string[] = [];
-  const seen = new Set<string>();
-
-  for (const turn of manifest.turns.toReversed()) {
-    if (turn.kind === 'open') continue;
-    for (const link of turn.sessionLinks ?? []) {
-      if (seen.has(link)) continue;
-      seen.add(link);
-      known.push(link);
-    }
-  }
+  const known = unique(
+    manifest.turns
+      .toReversed()
+      .filter((turn) => turn.kind !== 'open')
+      .flatMap((turn) => turn.sessionLinks ?? []),
+  );
 
   return known.length ? known : undefined;
 }


### PR DESCRIPTION
## Summary

Scheduled consolidation sweep: scanned `src/agent`, `src/utils`/`src/tools`/`src/shared`, `packages/cli`, and `packages/extension`/`packages/desktop` (via four parallel agents) for duplicated logic and hand-rolled code that already has a native or shared-utility equivalent. This PR applies the verified, low-risk findings:

- Route bare `nanoid()` calls through the existing `generateShortId()` wrapper (trace emitters, Google model handlers, `RetryState`) — 11 call sites across 6 files.
- Replace manual `Math.min(Math.max(...))` clamps with `clamp()`/`clampOptional()` from `@utils/core` (`TooltipController`, `annotationFetchBudget`, progressView `helpers.ts`, `LaTeXTab`).
- Replace manual `Set`-based dedupe loops with `unique()`/`filterNotNull(ish)` (review-diff base-branch discovery, external-inquiry session links, `extractFileDependencies`, four spots in the CLI).
- Replace hand-written `localeCompare` comparators with `byString`/`byStringProp` (`workspaceFileListing`).
- Drop a local `getPathSegments` duplicate in favor of the shared `pathCore` helper; drop a local `takeHead` duplicate in favor of the shared `appendHead`.
- Consolidate a compile-timeout-floor calculation duplicated verbatim between `compileCheck.ts` and `LatexDiffManager.ts` into one exported helper.
- Consolidate the byte-identical "no human input available" denial guards for `askUserQuestion` and `externalInquiry` — previously duplicated between the CLI's headless adapter and the TUI approval queue — into shared helpers in `approvalPolicy.ts` / `humanInputHandlers.ts`.
- Consolidate three byte-identical `readSelectValue()` helpers (progressView, settingsView) into one export in `@shared/utils/selectTemplates`.
- Swap a manual `Promise`-wrapped `setImmediate` for `node:timers/promises`, and a hand-rolled nested-loop URI dedupe for a `Map`-based one-liner.
- Reorder a redundant re-sort in `outputDiscovery.ts` onto the same `toNewestFirstByTimestamp` helper the upstream `listExecutions()` call already uses.

No behavior changes intended anywhere in this diff — every swap was verified to be semantically identical to the code it replaces (including edge cases like surrogate-pair cuts and empty-bound clamps) before applying it.

## Issue acceptance gates

No tracked issue — this is a scheduled housekeeping sweep, not a response to a filed issue.

## Single source of truth

- Non-schema-constrained id generation: `generateShortId()` (`@utils/core`), now used uniformly instead of ad hoc `nanoid()`.
- CLI "no human input available" policy for `askUserQuestion`: `askUserQuestionDenial()` (`approvalPolicy.ts`).
- CLI "no human input available" policy for external inquiry: `denyExternalInquiryIfNoHumanInput()` (`humanInputHandlers.ts`).
- `wa-select` change-event value extraction: `readSelectValue()` (`@shared/utils/selectTemplates`).
- Workflow auto-compile timeout floor: `getWorkflowAutoCompileTimeoutMs()` (`compileCheck.ts`).

## Duplication and abstraction budget

Removed: 11 duplicate `nanoid()` call sites, 4 duplicate `Math.min/Math.max` clamps, 6 duplicate dedupe loops, 2 duplicate comparators, 1 duplicate path-segment helper, 1 duplicate head-truncation helper, 1 duplicate compile-timeout calculation, 2 duplicate CLI approval-denial guards (headless vs. TUI), 3 duplicate `readSelectValue` helpers.

Added: 4 small exported helpers (`getWorkflowAutoCompileTimeoutMs`, `askUserQuestionDenial`, `denyExternalInquiryIfNoHumanInput`, `readSelectValue`), each collapsing 2–3 prior call sites and living in the module the call sites already imported from — no new pass-through layers, no new ports/facades.

## Net elements (R6)

34 files changed, +189/-204 lines (net **-15 LOC**). Exported-symbol delta: **+4 / -0** (the four helpers listed above; each clears the "single-caller" bar with 2–3 real callers before this PR).

## Consumer counts (R8)

n/a — no emit path, event key, or public export was deleted or re-routed; only internal duplicate implementations were collapsed onto existing or newly-shared helpers within the same module boundary.

## Host impact

Extension: 6 files (progressView/settingsView webview frontends + `common/webview/resourceRoots.ts`) — pure internal simplification, no UI/behavior change.

Desktop: none touched.

CLI: 8 files — internal simplification of the headless adapter, TUI approval queue, and a few command/runtime helpers; approval denial messages and control flow are unchanged, just de-duplicated.

## Scheduled refactoring

None — this sweep is itself the recurring scheduled task; no further follow-up is required from it.

## Validation

- `npm run typecheck` — clean across all workspace packages (extension, CLI, trace-viewer, desktop).
- `npm run lint` — 0 errors (1 pre-existing, unrelated warning in a test file untouched by this PR).
- `npm test` — 7071 passed, 1 pre-existing failure (`SystemUtils.vitest.ts` process-group-kill test) confirmed via `git stash` to fail identically on `main` before this change — unrelated sandbox/environment flake, not caused by this diff.
- `npm run check:dead-code-ratchet` — no new dead exports/files (18 baselined, 18 current).
- `npx prettier --check` on all changed files — clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MczHhfeXLePnG6q8YEXgVs)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with broad but mechanical call-site swaps; approval and human-input paths were deduplicated without changing policy semantics per PR intent.
> 
> **Overview**
> This PR is a **scheduled deduplication sweep** across CLI, extension, and core agent/utils code. It replaces ad hoc patterns with existing shared helpers rather than adding new product behavior.
> 
> **Shared utilities:** Inline `[...new Set(...)]` deduping becomes **`unique()`** (and related **`filterNotNull` / `filterNotNullish`**) in CLI commands, model access, review diff, LaTeX dependency extraction, status bar compaction, and external-inquiry link collection. **`Math.min`/`Math.max` clamps** move to **`clamp()`** / **`clampOptional()`** in tool formatters, tooltips, annotation budget, and LaTeX settings. Direct **`nanoid()`** call sites in trace emitters, Google handlers, and retry IDs now use **`generateShortId()`**. Tool-result head truncation drops a local **`takeHead`** in favor of **`appendHead`**.
> 
> **CLI approvals:** The same “no human input” guards for **`ask_user_question`** and **external inquiry** (previously duplicated in headless vs TUI paths) are centralized in **`askUserQuestionDenial()`** and **`denyExternalInquiryIfNoHumanInput()`**.
> 
> **Extension UI:** Three copies of **`readSelectValue`** for **`wa-select`** are merged into **`@shared/utils/selectTemplates`**.
> 
> **Other:** Workflow auto-compile timeout flooring is shared via **`getWorkflowAutoCompileTimeoutMs()`**; **`getCombinedLocalResourceRoots`** dedupes with a **`Map`**; workflow sandbox uses **`setImmediate`** from **`node:timers/promises`**; **`outputDiscovery`** sorts executions with **`toNewestFirstByTimestamp`** instead of a redundant re-sort.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50b4e55409f2ea166d803f0ee418547646a24c22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->