### PR TITLE
feat(tools/codex): emit Codex thread and turn tool-cards during streamed turns

### DIFF
--- a/src/test-kernel/agent/followUp/CodexProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/CodexProgressEvents.vitest.ts
@@ -178,6 +178,7 @@ describe('codex progress events', () => {
             usage: {
               input_tokens: 5,
               cached_input_tokens: 0,
+              cache_write_input_tokens: 0,
               output_tokens: 2,
               reasoning_output_tokens: 0,
             },
@@ -225,4 +226,67 @@ describe('codex progress events', () => {
     ).input;
     expect(typeof turnInput?.wallTimeMs).toBe('number');
   });
+
+  it('finalizes the running turn card when the stream errors', async () => {
+    const store = StreamLogStore.ephemeral('test');
+    await store.clear();
+
+    const logger = createRunTrace(streamId, store).trace;
+    const thread = {
+      runStreamed: async () => ({
+        events: streamEvents([
+          { type: 'turn.started' },
+          { type: 'error', message: 'boom' },
+        ]),
+      }),
+    } as unknown as Thread;
+
+    await expect(
+      runStreamedTurn(thread, 'Do the thing', streamId, logger),
+    ).rejects.toThrow('boom');
+
+    const turnEntry = findTurnEntry(store);
+    expect(turnEntry).toMatchObject({
+      toolName: CODEX_TURN_TOOL,
+      input: { state: 'failed' },
+      error: 'boom',
+      isError: true,
+    });
+  });
+
+  it('finalizes the running turn card when the stream ends without a terminal turn event', async () => {
+    const store = StreamLogStore.ephemeral('test');
+    await store.clear();
+
+    const logger = createRunTrace(streamId, store).trace;
+    const thread = {
+      runStreamed: async () => ({
+        // No turn.completed / turn.failed — the loop exits with the card open.
+        events: streamEvents([{ type: 'turn.started' }]),
+      }),
+    } as unknown as Thread;
+
+    await runStreamedTurn(thread, 'Do the thing', streamId, logger);
+
+    const turnEntry = findTurnEntry(store);
+    // Even without an error message the card is marked as an error so the
+    // progress view renders failure chrome instead of a success check.
+    expect(turnEntry).toMatchObject({
+      toolName: CODEX_TURN_TOOL,
+      input: { state: 'failed' },
+      isError: true,
+    });
+    expect(turnEntry).not.toHaveProperty('error');
+  });
 });
+
+function findTurnEntry(
+  store: StreamLogStore,
+): Record<string, unknown> | undefined {
+  const log = store.get(streamId);
+  const entries = log?.getRange(0, log.head) ?? [];
+  return entries
+    .filter((entry) => entry.messageType === MESSAGE_TYPES.TOOL_USE)
+    .map((entry) => entry.data as Record<string, unknown>)
+    .find((data) => data.toolName === CODEX_TURN_TOOL);
+}

--- a/src/test-kernel/agent/followUp/CodexProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/CodexProgressEvents.vitest.ts
@@ -13,6 +13,7 @@ import type {
 import { MESSAGE_TYPES } from '@shared/schemas';
 import { publishAgentCliStreamUsage } from '@tools/agentCliShared';
 import { publishCodexTodos, runStreamedTurn } from '@tools/codex';
+import { CODEX_THREAD_TOOL, CODEX_TURN_TOOL } from '@tools/codexShared';
 import { createRunTrace, StreamLogStore } from '@transcript';
 
 // Local file imports
@@ -156,5 +157,72 @@ describe('codex progress events', () => {
       output: 'building...\ndone',
       status: 'completed',
     });
+  });
+
+  it('emits Codex thread and turn cards across the turn lifecycle', async () => {
+    const store = StreamLogStore.ephemeral('test');
+    await store.clear();
+
+    const logger = createRunTrace(streamId, store).trace;
+    const thread = {
+      runStreamed: async () => ({
+        events: streamEvents([
+          { type: 'thread.started', thread_id: 'thread_abc' },
+          { type: 'turn.started' },
+          {
+            type: 'item.completed',
+            item: { id: 'msg-1', type: 'agent_message', text: 'Done.' },
+          },
+          {
+            type: 'turn.completed',
+            usage: {
+              input_tokens: 5,
+              cached_input_tokens: 0,
+              output_tokens: 2,
+              reasoning_output_tokens: 0,
+            },
+          },
+        ]),
+      }),
+    } as unknown as Thread;
+
+    const result = await runStreamedTurn(
+      thread,
+      'Do the thing',
+      streamId,
+      logger,
+    );
+
+    expect(result.finalResponse).toBe('Done.');
+
+    const log = store.get(streamId);
+    const entries = log?.getRange(0, log.head) ?? [];
+    const toolEntries = entries.filter(
+      (entry) => entry.messageType === MESSAGE_TYPES.TOOL_USE,
+    );
+
+    // A one-shot thread card, then a running->completed turn card.
+    expect(
+      toolEntries.map(
+        (entry) => (entry.data as { toolName?: string }).toolName,
+      ),
+    ).toEqual([CODEX_THREAD_TOOL, CODEX_TURN_TOOL]);
+
+    expect(toolEntries[0].data).toMatchObject({
+      toolName: CODEX_THREAD_TOOL,
+      input: { threadId: 'thread_abc' },
+      status: 'completed',
+    });
+
+    expect(toolEntries[1].data).toMatchObject({
+      toolName: CODEX_TURN_TOOL,
+      input: { state: 'completed' },
+      status: 'completed',
+    });
+
+    const turnInput = (
+      toolEntries[1].data as { input?: { wallTimeMs?: number } }
+    ).input;
+    expect(typeof turnInput?.wallTimeMs).toBe('number');
   });
 });

--- a/src/test-kernel/tools/codexConfig.vitest.ts
+++ b/src/test-kernel/tools/codexConfig.vitest.ts
@@ -291,6 +291,35 @@ describe('buildCodexTurnToolLog', () => {
       status: 'in_progress',
     });
   });
+
+  it('marks a failed turn as an error even without an error message', () => {
+    const log = buildCodexTurnToolLog({ state: 'failed' });
+
+    assert.deepEqual(log, {
+      toolName: CODEX_TURN_TOOL,
+      summary: 'Failed',
+      input: {
+        state: 'failed',
+      },
+      isError: true,
+      status: 'completed',
+    });
+  });
+
+  it('attaches the error message when a failed turn has one', () => {
+    const log = buildCodexTurnToolLog({ state: 'failed', error: 'boom' });
+
+    assert.deepEqual(log, {
+      toolName: CODEX_TURN_TOOL,
+      summary: 'Failed',
+      input: {
+        state: 'failed',
+      },
+      error: 'boom',
+      isError: true,
+      status: 'completed',
+    });
+  });
 });
 
 describe('buildCodexUsageStats', () => {

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -298,7 +298,10 @@ export async function runStreamedTurn(
   const itemLogRefs = new Map<string, CodexToolLogRef>();
 
   // The live "Codex Turn" card is opened on turn.started and closed on
-  // turn.completed / turn.failed with the measured wall time.
+  // turn.completed / turn.failed with the measured wall time. The finally
+  // below closes it on any other exit (stream error, abort, or an early stream
+  // end) so the progress view never keeps a spinning Running card after the
+  // turn is already dead. finalizeTurnCard is a no-op once the card is closed.
   let turnLogRef: CodexToolLogRef | null = null;
   let turnStartedMs = Date.now();
   const finalizeTurnCard = (state: 'completed' | 'failed', error?: string) => {
@@ -312,55 +315,60 @@ export async function runStreamedTurn(
     turnLogRef = null;
   };
 
-  for await (const event of events) {
-    switch (event.type) {
-      case 'thread.started':
-        emitToolUseCard(logger, buildCodexThreadToolLog(event));
-        break;
-      case 'turn.started':
-        turnStartedMs = Date.now();
-        turnLogRef = emitToolUseCard(
-          logger,
-          buildCodexTurnToolLog({ state: 'running' }),
-        );
-        break;
-      case 'item.started':
-      case 'item.updated':
-        publishCodexItemProgress({
-          item: event.item,
-          status: 'in_progress',
-          childStreamId,
-          logger,
-          refs: itemLogRefs,
-        });
-        break;
-      case 'item.completed': {
-        const { item } = event;
-        const wasRenderedAsProgress = publishCodexItemProgress({
-          item,
-          status: 'completed',
-          childStreamId,
-          logger,
-          refs: itemLogRefs,
-        });
-        if (!wasRenderedAsProgress) {
-          logCodexItem(item, childStreamId, logger);
+  try {
+    for await (const event of events) {
+      switch (event.type) {
+        case 'thread.started':
+          emitToolUseCard(logger, buildCodexThreadToolLog(event));
+          break;
+        case 'turn.started':
+          turnStartedMs = Date.now();
+          turnLogRef = emitToolUseCard(
+            logger,
+            buildCodexTurnToolLog({ state: 'running' }),
+          );
+          break;
+        case 'item.started':
+        case 'item.updated':
+          publishCodexItemProgress({
+            item: event.item,
+            status: 'in_progress',
+            childStreamId,
+            logger,
+            refs: itemLogRefs,
+          });
+          break;
+        case 'item.completed': {
+          const { item } = event;
+          const wasRenderedAsProgress = publishCodexItemProgress({
+            item,
+            status: 'completed',
+            childStreamId,
+            logger,
+            refs: itemLogRefs,
+          });
+          if (!wasRenderedAsProgress) {
+            logCodexItem(item, childStreamId, logger);
+          }
+          if (item.type === 'agent_message') {
+            responseParts.push(item.text);
+          }
+          break;
         }
-        if (item.type === 'agent_message') {
-          responseParts.push(item.text);
-        }
-        break;
+        case 'turn.completed':
+          usage = event.usage ?? null;
+          finalizeTurnCard('completed');
+          break;
+        case 'turn.failed':
+          finalizeTurnCard('failed', event.error.message);
+          throw new ToolError(event.error.message ?? 'Codex turn failed');
+        case 'error':
+          finalizeTurnCard('failed', event.message);
+          throw new ToolError(event.message ?? 'Codex stream error');
       }
-      case 'turn.completed':
-        usage = event.usage ?? null;
-        finalizeTurnCard('completed');
-        break;
-      case 'turn.failed':
-        finalizeTurnCard('failed', event.error.message);
-        throw new ToolError(event.error.message ?? 'Codex turn failed');
-      case 'error':
-        throw new ToolError(event.message ?? 'Codex stream error');
     }
+  } finally {
+    finalizeTurnCard('failed');
   }
 
   return {

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -78,7 +78,9 @@ import {
   buildCodexCommandToolLog,
   buildCodexFileChangeToolLog,
   buildCodexMcpToolLog,
+  buildCodexThreadToolLog,
   buildCodexTodoToolLog,
+  buildCodexTurnToolLog,
   buildCodexUsageStats,
 } from './codexShared';
 
@@ -295,8 +297,33 @@ export async function runStreamedTurn(
   let usage: RunResult['usage'] = null;
   const itemLogRefs = new Map<string, CodexToolLogRef>();
 
+  // The live "Codex Turn" card is opened on turn.started and closed on
+  // turn.completed / turn.failed with the measured wall time.
+  let turnLogRef: CodexToolLogRef | null = null;
+  let turnStartedMs = Date.now();
+  const finalizeTurnCard = (state: 'completed' | 'failed', error?: string) => {
+    if (!turnLogRef) return;
+    const { status = 'completed', ...rest } = buildCodexTurnToolLog({
+      state,
+      wallTimeMs: Date.now() - turnStartedMs,
+      ...(error != null && { error }),
+    });
+    endToolUseCard(logger, turnLogRef, rest, status);
+    turnLogRef = null;
+  };
+
   for await (const event of events) {
     switch (event.type) {
+      case 'thread.started':
+        emitToolUseCard(logger, buildCodexThreadToolLog(event));
+        break;
+      case 'turn.started':
+        turnStartedMs = Date.now();
+        turnLogRef = emitToolUseCard(
+          logger,
+          buildCodexTurnToolLog({ state: 'running' }),
+        );
+        break;
       case 'item.started':
       case 'item.updated':
         publishCodexItemProgress({
@@ -326,8 +353,10 @@ export async function runStreamedTurn(
       }
       case 'turn.completed':
         usage = event.usage ?? null;
+        finalizeTurnCard('completed');
         break;
       case 'turn.failed':
+        finalizeTurnCard('failed', event.error.message);
         throw new ToolError(event.error.message ?? 'Codex turn failed');
       case 'error':
         throw new ToolError(event.message ?? 'Codex stream error');

--- a/src/tools/codexShared.ts
+++ b/src/tools/codexShared.ts
@@ -208,11 +208,13 @@ export function buildCodexTurnToolLog(options?: {
     toolName: CODEX_TURN_TOOL,
     summary: codexTurnSummary(state),
     input,
-    ...(state === 'failed' &&
-      options?.error && {
-        error: options.error,
-        isError: true,
-      }),
+    // A failed turn is always an error card so the progress view shows failure
+    // chrome; the error message is attached when the caller has one (turn.failed
+    // / stream error) but omitted for abort or an early stream end.
+    ...(state === 'failed' && {
+      isError: true,
+      ...(options?.error && { error: options.error }),
+    }),
     status: state === 'running' ? 'in_progress' : 'completed',
   };
 }


### PR DESCRIPTION
## Summary

**Flipped from delete → wire up** (per maintainer decision on this PR). The Codex `codex_thread` / `codex_turn` tool-card feature was fully built (builders + Zod schemas + progress-view renderers + label/icon rows) but never connected to an emit path. Rather than delete the dead chain, this PR **wires it into `runStreamedTurn`** so the cards actually render.

The one genuinely new signal these cards add is **per-turn wall-time**, which no existing surface shows.

## What changed

`src/tools/codex.ts` — `runStreamedTurn` now handles two previously-ignored stream events and finalizes a live turn card:

- **`thread.started`** → a one-shot "Codex Thread / Thread ID" card via `buildCodexThreadToolLog` (fires once per new thread; resumed follow-ups don't re-emit it).
- **`turn.started`** → opens a live "Codex Turn" card in the `running` state (spinner) and stamps the turn start time.
- **`turn.completed`** → closes that card as `completed` with the measured wall time.
- **`turn.failed`** → closes the card as `failed` (with the error) before throwing the existing `ToolError`, so a failed turn is visible instead of only surfacing as a thrown error.

Wall-time is `Date.now() - turnStartedMs`, the same backend pattern used across `src/tools/delegation/`. The renderer's `getCodexTurnStateIcon` already returns the spinner glyph for the `running` state, so the live `running → completed` lifecycle matches the card's original design intent.

## Single source of truth

No ownership change. The tool-name constants and Zod schemas stay single-sourced in `@shared/schemas/codex` (re-exported from `@tools/codexShared`); the builders stay in `@tools/codexShared`; the renderers stay in `codexToolTemplates.ts`. This PR only adds the missing producer edges in `codex.ts`.

## Net elements (R6)

- **Files:** 2 changed (`src/tools/codex.ts`, `src/test-kernel/agent/followUp/CodexProgressEvents.vitest.ts`), 0 added, 0 deleted.
- **No new exported symbols, schemas, or abstractions** — only new `case` arms plus one local `finalizeTurnCard` closure (two call sites: completed + failed).
- Net LoC is additive (feature wiring + one test), not a deletion.

## Consumer counts (R8)

Adds emit sites, doesn't remove any: `buildCodexThreadToolLog` and `buildCodexTurnToolLog` go from **0 → 1** production caller each (`runStreamedTurn`). The `codex_thread` / `codex_turn` renderer-map, label, and icon entries — previously unreachable — now have a live producer. The unrelated `'codex_thread_id'` session-store key is untouched.

## Host impact

Extension: the Codex child-stream progress view now shows a thread-created card and a per-turn card (running → completed/failed, with duration).

Desktop: same — shares the webview progress-view formatters.

CLI: none directly — these are webview tool-cards; the CLI TUI renders tool-use logs through its own formatters and is unaffected by the new emit sites.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — clean across all 6 sub-projects.
- `npx vitest run src/test-kernel/tools src/test-kernel/agent/followUp` — 761 passed (111 files), including a new `runStreamedTurn` lifecycle test that asserts the thread + turn cards are emitted with the right tool names, states, and a numeric `wallTimeMs`.
- `npm run check:dead-code-ratchet` — OK, no new unused files/exports/types.
- `npm run lint` — 0 errors (1 pre-existing unrelated warning).
- `npx prettier --check` on both changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive progress-UI wiring on the Codex streaming path; existing throw behavior on turn/stream errors is preserved, with new tests for edge exits.
> 
> **Overview**
> **Wires the existing `codex_thread` / `codex_turn` tool-card builders into `runStreamedTurn`**, so Codex child-stream progress views show thread creation and a per-turn card with **wall time** on completion.
> 
> `runStreamedTurn` now reacts to **`thread.started`** (one-shot thread card), **`turn.started`** (opens a running turn card), and **`turn.completed` / `turn.failed` / stream `error`** (closes the turn card with measured duration or failure). A **`finally`** path closes any still-open turn card as **failed** when the stream ends without a terminal turn event (abort, early end), avoiding a stuck “Running” spinner.
> 
> **`buildCodexTurnToolLog`** now always sets **`isError: true`** for failed turns, even when no error string is provided, so the UI shows failure chrome. Tests cover the full lifecycle, stream errors, and message-less failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97d076857c34742d6658b5e151814096d354ba13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->