### PR TITLE
fix: gate proactive token refresh on relay route (design B)

### DIFF
--- a/src/agent/core/flows/CycleServices.ts
+++ b/src/agent/core/flows/CycleServices.ts
@@ -11,6 +11,7 @@ import type { BaseFlowContextInit } from '@agent/core/flows/BaseFlowServices';
 import type { IModelHandler } from '@agent/types/IModelHandler';
 import type {
   FinalTool,
+  ModelCredentialRoute,
   ModelCredentialSelection,
   SdkToolCall,
 } from '@agent/types/ModelHandlerContracts';
@@ -22,6 +23,8 @@ import type { TaskRunFileService } from '@utils/files';
  * runs a `ModelInvocationNode`.
  *
  * - `client` is the provider SDK client for the run's active model.
+ * - `clientCredentialRoute` is the credential route that client captured
+ *   (e.g. `'relay'` vs `'api-key'`), read live from the model handler.
  * - `refreshClient` re-fetches it after a mid-run model switch so the retry
  *   path picks up the new handler.
  *
@@ -31,6 +34,7 @@ import type { TaskRunFileService } from '@utils/files';
  */
 export interface ModelClientServices<C = unknown> {
   readonly client: C;
+  readonly clientCredentialRoute?: ModelCredentialRoute | undefined;
   readonly refreshClient?: (
     selection?: ModelCredentialSelection,
     signal?: AbortSignal,
@@ -41,10 +45,11 @@ export interface ModelClientServices<C = unknown> {
  * Bridge the live model client into a cycle/round services object before the
  * outer node runs the inner flow.
  *
- * The `client` getter and `refreshClient` are defined on the **returned
- * literal** — never spread from a pre-evaluated object — so the relay-401
- * token-refresh path keeps live rebinding: `refreshClient()` re-fetches the
- * provider client after a mid-run model switch and the getter reflects it on
+ * The `client` and `clientCredentialRoute` getters plus `refreshClient` are
+ * defined on the **returned literal** — never spread from a pre-evaluated
+ * object — so the relay-401 token-refresh path keeps live rebinding:
+ * `refreshClient()` re-fetches the provider client after a mid-run model
+ * switch and the getters reflect it (and its captured credential route) on
  * the next read. Spreading the result of this call elsewhere would snapshot
  * `client` and silently break that liveness, so callers pass the result
  * straight to `flow.setServices(...)`.
@@ -58,6 +63,9 @@ export async function withModelClient<C, T extends object>(
     ...base,
     get client(): C {
       return client;
+    },
+    get clientCredentialRoute(): ModelCredentialRoute | undefined {
+      return modelHandler.getCredentialRouteForClient(client);
     },
     async refreshClient(
       selection: ModelCredentialSelection = 'configured',

--- a/src/agent/core/flows/ModelInvocationNode.ts
+++ b/src/agent/core/flows/ModelInvocationNode.ts
@@ -10,7 +10,10 @@ import type {
   AgentCore,
   BaseFlowContextInit,
 } from '@agent/core/flows/BaseFlowServices';
-import type { FinalTool } from '@agent/types/ModelHandlerContracts';
+import type {
+  FinalTool,
+  ModelCredentialRoute,
+} from '@agent/types/ModelHandlerContracts';
 import { requiresFlowAutoRetry } from '@common/errors/sdkErrorUtils';
 import type { ToolDefinition } from '@model';
 
@@ -63,6 +66,7 @@ type InvocationServices = Pick<
 > &
   Pick<BaseFlowContextInit, 'setAbortController'> & {
     readonly client: unknown;
+    readonly clientCredentialRoute?: ModelCredentialRoute;
     readonly refreshClient?: () => Promise<void>;
   };
 

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -6,7 +6,10 @@ import { Node } from '@agent/node';
 import { logErrorData, logProgressStatus, type AgentTrace } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { useLaunchRunContext } from '@agent/runtime/RunContext';
-import type { ModelCredentialSelection } from '@agent/types/ModelHandlerContracts';
+import type {
+  ModelCredentialRoute,
+  ModelCredentialSelection,
+} from '@agent/types/ModelHandlerContracts';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { normalizeProviderError } from '@common/errors';
 import {
@@ -64,6 +67,7 @@ interface RetryableNodeServices {
     selection?: ModelCredentialSelection,
     signal?: AbortSignal,
   ) => Promise<void>;
+  clientCredentialRoute?: ModelCredentialRoute;
 }
 
 /**
@@ -185,16 +189,27 @@ export abstract class RetryableInvocationNode<
     this.signal = controller.signal;
     services.setAbortController(controller);
 
-    // Proactive relay token refresh before the request
-    if (SupabaseClient.isTokenExpiringSoon()) {
-      services.logger.debug(
-        'Token nearing expiry, refreshing client proactively',
-      );
-      await tryRefreshClient(
-        services.refreshClient,
-        services.logger,
-        'proactive pre-invocation',
-      );
+    // Proactive relay token refresh before the request. Only relay-route
+    // clients present the Supabase session token, so only they consult the
+    // expiry clock — personal-key / openrouter / subscription clients must
+    // never rebuild for a credential the call doesn't use.
+    if (
+      services.clientCredentialRoute === 'relay' &&
+      SupabaseClient.isTokenExpiringSoon()
+    ) {
+      // Threshold-gated and mutex-deduped: refreshes the session (updating
+      // tokenExpiresAt) only when actually near expiry. For a configured CI
+      // relay token this is a cache-only read with no side effects.
+      await SupabaseClient.getRelayAccessToken();
+      // Rebuild only when the token actually rotated — rebuilding with the
+      // same JWT changes nothing, and is exactly the loop this branch caused.
+      if (!SupabaseClient.isTokenExpiringSoon()) {
+        await tryRefreshClient(
+          services.refreshClient,
+          services.logger,
+          'proactive pre-invocation',
+        );
+      }
     }
 
     try {

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -576,6 +576,13 @@ export abstract class ModelHandler<
     return client;
   }
 
+  /** Route of the credential a client built by this handler captured, if known. */
+  getCredentialRouteForClient(client: C): ModelCredentialRoute | undefined {
+    return typeof client === 'object' && client !== null
+      ? this.clientCredentialRoutes.get(client)
+      : undefined;
+  }
+
   /** Route currently executing, excluding the last completed attempt. */
   protected get activeCredentialRoute(): ModelCredentialRoute | undefined {
     return this.activeAttemptCredentialRoute;

--- a/src/agent/types/IModelHandler.ts
+++ b/src/agent/types/IModelHandler.ts
@@ -64,6 +64,7 @@ export type IModelHandler<
   | 'initializeOutputAndPrefill'
   | 'normalizeUsage'
   | 'getLastCredentialUsageRoute'
+  | 'getCredentialRouteForClient'
   | 'updateMessageContent'
   | 'shouldContinue'
   | 'checkStopConditions'

--- a/src/test-kernel/agent/modelHandlers/ModelClientRouteSnapshot.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelClientRouteSnapshot.vitest.ts
@@ -1,9 +1,16 @@
+import { ModelProvider } from 'llm-zoo';
 import pDefer from 'p-defer';
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import { withModelClient } from '@agent/core/flows/CycleServices';
+import { ModelHandlerGoogleGenAI } from '@agent/modelHandlers/google/modelHandlerGoogleGenAI';
 import type { IModelHandler } from '@agent/types/IModelHandler';
+import type { ModelCredentialRoute } from '@agent/types/ModelHandlerContracts';
+import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
+
+// Third-party imports
+import type { GoogleGenAI } from '@google/genai';
 
 interface TestClient {
   readonly route: 'configured' | 'personal';
@@ -17,6 +24,12 @@ function handler(
     getClient: vi.fn(async () => initial),
     refreshClient,
   } as unknown as IModelHandler;
+}
+
+class CredentialRouteProbe extends ModelHandlerGoogleGenAI {
+  tag(client: GoogleGenAI, route: ModelCredentialRoute): void {
+    this.rememberClientCredentialRoute(client, route);
+  }
 }
 
 describe('model client route publication', () => {
@@ -85,5 +98,41 @@ describe('model client route publication', () => {
       services.refreshClient?.('personal', controller.signal),
     ).rejects.toThrow('cancelled after construction');
     expect(services.client).toBe(initial);
+  });
+
+  it('reflects the current client route and rebinds after refresh swaps the client', async () => {
+    const initial = { route: 'configured' } as const;
+    const candidate = { route: 'personal' } as const;
+    const routes = new Map<TestClient, ModelCredentialRoute>([
+      [initial, 'relay'],
+      [candidate, 'api-key'],
+    ]);
+    const modelHandler = {
+      getClient: vi.fn(async () => initial),
+      refreshClient: vi.fn(async () => candidate),
+      getCredentialRouteForClient: vi.fn((client: TestClient) =>
+        routes.get(client),
+      ),
+    } as unknown as IModelHandler;
+    const services = await withModelClient({}, modelHandler);
+
+    expect(services.clientCredentialRoute).toBe('relay');
+
+    await services.refreshClient?.('personal');
+    expect(services.client).toBe(candidate);
+    expect(services.clientCredentialRoute).toBe('api-key');
+  });
+
+  it('returns the captured route for a tagged client and undefined for a foreign one', () => {
+    const probe = new CredentialRouteProbe(
+      buildTestModelConfig({ provider: ModelProvider.GOOGLE }),
+    );
+    const tagged = {} as GoogleGenAI;
+    probe.tag(tagged, 'relay');
+
+    expect(probe.getCredentialRouteForClient(tagged)).toBe('relay');
+    expect(
+      probe.getCredentialRouteForClient({} as GoogleGenAI),
+    ).toBeUndefined();
   });
 });

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -7,7 +7,15 @@ import '@test/support/defaultSessionTestSetup';
 
 // Third-party imports
 import { APIError as OpenAIAPIError } from 'openai';
-import { describe, expect, it, vi, type Mock } from 'vitest';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from 'vitest';
 
 // Local imports
 import { noopTrace, type AgentTrace } from '@agent/trace';
@@ -31,6 +39,14 @@ import {
   noopAgentRuntimeHost,
   type AgentRuntimeHost,
 } from '@agent/runtime/AgentRuntimeHost';
+import type { ModelCredentialRoute } from '@agent/types/ModelHandlerContracts';
+import {
+  RELAY_CI_TOKEN_PREFIX,
+  RELAY_TOKEN_ENV_VAR,
+  resetRelayTokenTierCacheForTests,
+} from '@auth/relayToken';
+import { SupabaseClient } from '@auth/SupabaseClient';
+import type { AuthTokenProvider } from '@auth/TokenProvider';
 import {
   attachContextWindowError,
   attachFlowAutoRetryRequired,
@@ -61,6 +77,7 @@ interface TestRetryServices {
   logger: AgentTrace;
   setAbortController: (ac: AbortController | null) => void;
   refreshClient?: () => Promise<void>;
+  clientCredentialRoute?: ModelCredentialRoute;
 }
 
 class ExposedRetryNode extends RetryableInvocationNode<
@@ -73,6 +90,10 @@ class ExposedRetryNode extends RetryableInvocationNode<
 
   promptFor(error: Error): Promise<unknown> {
     return this.handleManualRetryPrompt(error);
+  }
+
+  runWithAbort<T>(op: (signal: AbortSignal) => Promise<T>): Promise<T> {
+    return this.withAbortController(op);
   }
 
   fallbackFor(error: Error): unknown {
@@ -110,6 +131,7 @@ interface RetryNodeKit {
 function createRetryNode(
   streamId: StreamTabId,
   refreshClient?: () => Promise<void>,
+  clientCredentialRoute?: ModelCredentialRoute,
 ): RetryNodeKit {
   const streamStatus = new StreamStatusMachine();
   const requestRetry = vi.fn<RetryNodeKit['requestRetry']>();
@@ -124,6 +146,7 @@ function createRetryNode(
     logger: noopTrace,
     setAbortController: vi.fn(),
     refreshClient,
+    clientCredentialRoute,
   });
   return { node, session, streamStatus, requestRetry };
 }
@@ -183,7 +206,22 @@ function createModelInvocationNode(input: {
   } as never);
 }
 
+function createAuthTokenProvider(
+  overrides: Partial<AuthTokenProvider> = {},
+): AuthTokenProvider {
+  return {
+    whenReady: async () => {},
+    ensureFreshToken: async () => 'access-token',
+    getSessionTokens: async () => null,
+    ...overrides,
+  };
+}
+
 describe('RetryState', () => {
+  afterEach(() => {
+    SupabaseClient.resetForTests();
+  });
+
   it('records whether a failed invocation already emitted its canonical error', () => {
     const state: BaseCycleFields = {
       messages: [],
@@ -508,5 +546,124 @@ describe('RetryState', () => {
     } finally {
       clearStreamStatusForTest(streamStatus, streamId);
     }
+  });
+
+  describe('proactive relay token refresh', () => {
+    beforeEach(() => {
+      // A CI relay token exported in the shell would satisfy the non-forced
+      // getRelayAccessToken() read cache-only and skip the session refresh
+      // these cases exercise; pin it unset unless a case opts in.
+      vi.stubEnv(RELAY_TOKEN_ENV_VAR, '');
+    });
+
+    afterEach(() => {
+      vi.unstubAllEnvs();
+      resetRelayTokenTierCacheForTests();
+    });
+
+    it.each([
+      'api-key',
+      'openrouter',
+      'chatgpt-subscription',
+      undefined,
+    ] as const)(
+      'never rebuilds a client on route %s for an expiring session token',
+      async (route) => {
+        const streamId =
+          `retry-state-proactive-${route ?? 'unknown'}` as StreamTabId;
+        const refreshClient = vi.fn(async () => undefined);
+        const { node } = createRetryNode(streamId, refreshClient, route);
+        SupabaseClient.setTokenExpiry(Date.now() + 60_000);
+
+        const operation = vi.fn(async () => 'response');
+        await expect(node.runWithAbort(operation)).resolves.toBe('response');
+
+        expect(operation).toHaveBeenCalledOnce();
+        expect(refreshClient).not.toHaveBeenCalled();
+      },
+    );
+
+    it('rebuilds the relay client once when the session token rotates', async () => {
+      const streamId = 'retry-state-proactive-relay-rotation' as StreamTabId;
+      const refreshClient = vi.fn(async () => undefined);
+      const { node } = createRetryNode(streamId, refreshClient, 'relay');
+      SupabaseClient.setTokenExpiry(Date.now() + 60_000);
+      const ensureFreshToken = vi.fn(async () => {
+        // Simulate rotation: the refresh pushes the session expiry out.
+        SupabaseClient.setTokenExpiry(Date.now() + 3_600_000);
+        return 'fresh-session-token';
+      });
+      SupabaseClient.setAuthProvider(
+        createAuthTokenProvider({ ensureFreshToken }),
+      );
+
+      const operation = vi.fn(async () => 'response');
+      await expect(node.runWithAbort(operation)).resolves.toBe('response');
+
+      expect(ensureFreshToken).toHaveBeenCalledOnce();
+      expect(refreshClient).toHaveBeenCalledOnce();
+      expect(operation).toHaveBeenCalledOnce();
+    });
+
+    it('skips the relay client rebuild when the token did not rotate', async () => {
+      const streamId = 'retry-state-proactive-relay-stale' as StreamTabId;
+      const refreshClient = vi.fn(async () => undefined);
+      const { node } = createRetryNode(streamId, refreshClient, 'relay');
+      SupabaseClient.setTokenExpiry(Date.now() + 60_000);
+      // The provider answers with the stale token and leaves the expiry
+      // clock inside the threshold, so no rotation is observed.
+      const ensureFreshToken = vi.fn(async () => 'stale-session-token');
+      SupabaseClient.setAuthProvider(
+        createAuthTokenProvider({ ensureFreshToken }),
+      );
+
+      const operation = vi.fn(async () => 'response');
+      await expect(node.runWithAbort(operation)).resolves.toBe('response');
+
+      // No rebuild without rotation — the reactive 401 path remains the net.
+      expect(ensureFreshToken).toHaveBeenCalledOnce();
+      expect(refreshClient).not.toHaveBeenCalled();
+      expect(operation).toHaveBeenCalledOnce();
+    });
+
+    it('does no auth work for a relay client whose token is fresh', async () => {
+      const streamId = 'retry-state-proactive-relay-fresh' as StreamTabId;
+      const refreshClient = vi.fn(async () => undefined);
+      const { node } = createRetryNode(streamId, refreshClient, 'relay');
+      SupabaseClient.setTokenExpiry(Date.now() + 3_600_000);
+      const ensureFreshToken = vi.fn(async () => 'session-token');
+      SupabaseClient.setAuthProvider(
+        createAuthTokenProvider({ ensureFreshToken }),
+      );
+
+      const operation = vi.fn(async () => 'response');
+      await expect(node.runWithAbort(operation)).resolves.toBe('response');
+
+      expect(ensureFreshToken).not.toHaveBeenCalled();
+      expect(refreshClient).not.toHaveBeenCalled();
+      expect(operation).toHaveBeenCalledOnce();
+    });
+
+    it('makes no auth or rebuild calls for a CI-token relay client', async () => {
+      const streamId = 'retry-state-proactive-relay-ci-token' as StreamTabId;
+      const refreshClient = vi.fn(async () => undefined);
+      const { node } = createRetryNode(streamId, refreshClient, 'relay');
+      vi.stubEnv(RELAY_TOKEN_ENV_VAR, `${RELAY_CI_TOKEN_PREFIX}fakeci123`);
+      SupabaseClient.setTokenExpiry(Date.now() + 60_000);
+      const ensureFreshToken = vi.fn(async () => 'session-token');
+      SupabaseClient.setAuthProvider(
+        createAuthTokenProvider({ ensureFreshToken }),
+      );
+
+      const operation = vi.fn(async () => 'response');
+      await expect(node.runWithAbort(operation)).resolves.toBe('response');
+
+      // The configured CI token satisfies the non-forced read cache-only: the
+      // session is never consulted and the expiry clock stays stale, so the
+      // rebuild is skipped too.
+      expect(ensureFreshToken).not.toHaveBeenCalled();
+      expect(refreshClient).not.toHaveBeenCalled();
+      expect(operation).toHaveBeenCalledOnce();
+    });
   });
 });

--- a/src/test-kernel/auth/SupabaseClient.vitest.ts
+++ b/src/test-kernel/auth/SupabaseClient.vitest.ts
@@ -209,4 +209,20 @@ describe('SupabaseClient', () => {
       'host auth unavailable',
     );
   });
+
+  it('reports no expiry pressure when no token expiry is tracked', () => {
+    assert.equal(SupabaseClient.isTokenExpiringSoon(), false);
+  });
+
+  it('does not treat a token an hour out as expiring soon', () => {
+    SupabaseClient.setTokenExpiry(Date.now() + 3_600_000);
+
+    assert.equal(SupabaseClient.isTokenExpiringSoon(), false);
+  });
+
+  it('treats a token expiring within a minute as expiring soon', () => {
+    SupabaseClient.setTokenExpiry(Date.now() + 60_000);
+
+    assert.equal(SupabaseClient.isTokenExpiringSoon(), true);
+  });
 });


### PR DESCRIPTION
Implements the winning design from the token-refresh tournament: **B — route-gated explicit refresh** (design PR #9062; companions #9061, #9063).

## The bug

Before every model invocation, `RetryableInvocationNode.withAbortController` checked only `SupabaseClient.isTokenExpiringSoon()`. Once the Supabase session entered its last 30 minutes, personal-key users rebuilt the provider SDK client on **every invocation of every node** — the rebuild never touches the relay token, so the condition never cleared, and the log showed `Token nearing expiry, refreshing client proactively` every few seconds for up to 30 minutes.

## The fix (design A′)

- **Route gate**: the check fires only when the live client's captured credential route is `'relay'` — exposed as `ModelHandler.getCredentialRouteForClient()` (reads the existing #9030 `clientCredentialRoutes` WeakMap), added to the `IModelHandler` port `Pick`, and bridged as a live getter beside `client` in `withModelClient` (same closure/liveness discipline).
- **Explicit refresh**: instead of relying on an undocumented side effect of client construction, the branch calls non-forced `getRelayAccessToken()` (threshold-gated, mutex-deduped, cache-only for CI relay tokens — never `forceRefresh`, so CI-token rejection semantics are untouched).
- **Rebuild only on rotation**: the client is rebuilt only when the expiry clock actually cleared. Personal-key/OpenRouter/subscription users get zero auth calls and zero rebuilds; relay users get exactly one rebuild per expiry window; CI-token and offline-relay edges are no-ops, with reactive 401 recovery unchanged as the net.

## Verification

- New coverage: 8 proactive-path cases in `RetryState.vitest.ts` (route matrix, rotation, stale-token, fresh-token, CI-token gate), 3 `isTokenExpiringSoon` pins, 2 route-getter rebinding/accessor cases — **43/43 pass**, including a run with `TEXRA_RELAY_TOKEN` exported (a review-caught env-isolation gap, now stubbed).
- `tsc --noEmit` (root + test-kernel), eslint, prettier: clean on all 8 files.
- Full `npm test` not run locally; CI will cover it.
- Code-reviewed (read-only pass): no P1s; the single P2 (env-dependent tests) and both P3s were fixed before this PR.

Note: implemented and tested against a slightly older `main`, then rebased onto current `origin/main` (trivial merge — an unrelated `nanoid`→`generateShortId` import swap in the same file). Not stacked on the team-launcher PR #9070; the two are independent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches pre-invocation auth and client rebuild on every model call for relay users; behavior is narrowed and heavily tested, but mistakes could affect relay auth or cause unnecessary rebuilds.
> 
> **Overview**
> Fixes a loop where **every model invocation** rebuilt the SDK client whenever the Supabase session was in its last 30 minutes—even for **personal-key / OpenRouter / subscription** routes that never use that token.
> 
> **Credential route on the live client:** `ModelHandler.getCredentialRouteForClient()` reads the existing client→route map; `withModelClient` exposes it as a live `clientCredentialRoute` getter (same rebinding rules as `client`).
> 
> **Proactive refresh in `RetryableInvocationNode`:** Runs only when `clientCredentialRoute === 'relay'` and `isTokenExpiringSoon()`. It calls non-forced `getRelayAccessToken()`, then **`refreshClient` only if the expiry clock actually cleared** (real rotation). Reactive relay 401 handling is unchanged.
> 
> Tests cover route matrix, rotation vs stale token, fresh/CI relay tokens, route getter rebinding, and `isTokenExpiringSoon` thresholds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac464cbea272d5eee0acb4c80856b20e0f9e4357. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->