### PR TITLE
fix: tighten relay refresh contract from #9073 review

### DIFF
--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -67,7 +67,7 @@ interface RetryableNodeServices {
     selection?: ModelCredentialSelection,
     signal?: AbortSignal,
   ) => Promise<void>;
-  clientCredentialRoute?: ModelCredentialRoute;
+  readonly clientCredentialRoute?: ModelCredentialRoute;
 }
 
 /**

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -626,6 +626,29 @@ describe('RetryState', () => {
       expect(operation).toHaveBeenCalledOnce();
     });
 
+    it('skips the relay client rebuild when the session refresh returns null', async () => {
+      const streamId =
+        'retry-state-proactive-relay-null-refresh' as StreamTabId;
+      const refreshClient = vi.fn(async () => undefined);
+      const { node } = createRetryNode(streamId, refreshClient, 'relay');
+      SupabaseClient.setTokenExpiry(Date.now() + 60_000);
+      // Refresh failed or no session: ensureFreshToken resolves null and the
+      // expiry clock stays inside the threshold, so no rotation is observed.
+      const ensureFreshToken = vi.fn(async () => null);
+      SupabaseClient.setAuthProvider(
+        createAuthTokenProvider({ ensureFreshToken }),
+      );
+
+      const operation = vi.fn(async () => 'response');
+      await expect(node.runWithAbort(operation)).resolves.toBe('response');
+
+      // No rebuild when no fresh token materialized — the reactive 401 path
+      // remains the net.
+      expect(ensureFreshToken).toHaveBeenCalledOnce();
+      expect(refreshClient).not.toHaveBeenCalled();
+      expect(operation).toHaveBeenCalledOnce();
+    });
+
     it('does no auth work for a relay client whose token is fresh', async () => {
       const streamId = 'retry-state-proactive-relay-fresh' as StreamTabId;
       const refreshClient = vi.fn(async () => undefined);


### PR DESCRIPTION
Follow-up to #9073 (route-gated proactive relay token refresh), addressing its two residual review observations:

1. **`readonly clientCredentialRoute`** on `RetryableNodeServices` — the route is captured when the handler builds the client; marking it readonly matches the `CycleServices` contract and prevents caller reassignment.
2. **Null-refresh test** — the proactive tests all mocked `ensureFreshToken` to return a token. This pins the failure path: refresh returns null → expiry clock stays inside the threshold → no rotation observed → client rebuild skipped, leaving the reactive 401 recovery as the net.

Verified: `RetryState.vitest.ts` 27/27, eslint, prettier, root + test-kernel tsc.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only contract tightening plus test coverage; no change to runtime retry logic beyond documenting existing null-refresh behavior.
> 
> **Overview**
> Follow-up tightening for proactive relay token refresh (#9073).
> 
> **`RetryableNodeServices`** now declares **`readonly clientCredentialRoute`**, matching how the route is fixed when the handler builds the client (same idea as `CycleServices`) so callers cannot reassign it.
> 
> Adds a **proactive relay** test where **`ensureFreshToken` resolves `null`**: expiry stays inside the threshold, **`refreshClient` is not called**, and the operation still runs once—leaving **reactive 401 recovery** as the fallback when refresh produces no new token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1351974fffcc2adca3d55456de311db8900ca71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->