### PR TITLE
fix: show selected workflow details in CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,8 @@ All notable changes to this project will be documented in this file.
   their final results.
 - **PDF attachments work with ChatGPT subscriptions** — documents can be sent
   directly to supported models.
-- **Workflow results include absolute output paths** — parent agents receive
-  the direct storage path for every generated file alongside its run-relative
-  path.
+- **Parent agents can inspect generated workflow files directly** — delegated
+  workflows make every output available for follow-up review.
 - **Latexdiff artifacts with short abbreviated commit hashes are recognized
   consistently** — a generated `basename-diffHASH.tex` file with a 4-5
   character hash is now reliably treated as a diff artifact everywhere

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ### Shared (all surfaces)
 
+#### New Features
+
+- **The Mathematician team includes the critique workflow** — mathematical team
+  runs can delegate a dedicated critical review directly.
+
 #### Bug Fixes
 
 - **Brief network interruptions no longer stop model turns immediately** —
@@ -14,6 +19,11 @@ All notable changes to this project will be documented in this file.
 - **Parallel runs finish reliably after long pauses** — delayed storage work
   no longer causes the application to exit while several agents are saving
   their final results.
+- **PDF attachments work with ChatGPT subscriptions** — documents sent directly
+  to the model are encoded in the form accepted by the Responses endpoint.
+- **Workflow results include absolute output paths** — parent agents receive
+  the direct storage path for every generated file alongside its run-relative
+  path.
 - **Latexdiff artifacts with short abbreviated commit hashes are recognized
   consistently** — a generated `basename-diffHASH.tex` file with a 4-5
   character hash is now reliably treated as a diff artifact everywhere
@@ -45,9 +55,10 @@ All notable changes to this project will be documented in this file.
 - **Nested subagents remain visible** — a focused subagent reports how many
   direct subagents it owns, including completed work that remains available in
   its child list.
-- **Subagent rows show their working files** — rows summarize attached input,
-  context, media, and output files; press `i` while selecting a row to inspect
-  the paths without leaving the conversation.
+- **Selected subagents show their working files and live workflow progress** —
+  selecting a child opens a separate detail surface for input, context, media,
+  latest-round output paths, round progress, and tool-call counts while the
+  child list remains compact; press `i` to hide or restore the details.
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ All notable changes to this project will be documented in this file.
 - **Parallel runs finish reliably after long pauses** — delayed storage work
   no longer causes the application to exit while several agents are saving
   their final results.
-- **PDF attachments work with ChatGPT subscriptions** — documents sent directly
-  to the model are encoded in the form accepted by the Responses endpoint.
+- **PDF attachments work with ChatGPT subscriptions** — documents can be sent
+  directly to supported models.
 - **Workflow results include absolute output paths** — parent agents receive
   the direct storage path for every generated file alongside its run-relative
   path.

--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -186,7 +186,7 @@ export function App(props: AppProps): React.JSX.Element {
   const childListActiveStreamRef = useRef(activeStreamId);
   const childListFocused = childListSelection.focused;
   const selectedChildValue = childListSelection.selectedValue;
-  const childListRowExpanded = childListSelection.rowExpanded;
+  const childDetailsVisible = childListSelection.detailsVisible;
   const { columns, rows } = useWindowSize();
   const { exit } = useApp();
   const [transcriptPrints, setTranscriptPrints] = useState<
@@ -748,7 +748,7 @@ export function App(props: AppProps): React.JSX.Element {
           rootStreamId,
           slashPaletteOpen,
           childListFocused,
-          childListRowExpanded,
+          childDetailsVisible,
           sessionViews,
           selectedChildValue,
           streams,
@@ -767,8 +767,8 @@ export function App(props: AppProps): React.JSX.Element {
           taskDetailExecutionIdSignal.set(executionId)
         }
         onPrintStream={printStreamOutput}
-        onToggleChildRowExpand={() =>
-          dispatchChildListSelection({ kind: 'toggleRowExpand' })
+        onToggleChildDetails={() =>
+          dispatchChildListSelection({ kind: 'toggleDetails' })
         }
         onChildSelectionChange={(value) =>
           dispatchChildListSelection({ kind: 'highlight', value })

--- a/packages/cli/src/chat/tui/appLayout.ts
+++ b/packages/cli/src/chat/tui/appLayout.ts
@@ -162,6 +162,8 @@ export function allocateConversationBottomPanelRows({
 }): {
   readonly bottomPanelRows: number;
   readonly sessionPanelRows: number;
+  readonly childListRows: number;
+  readonly detailPanelRows: number;
   readonly todosPlanRows: number;
 } {
   const childListRowCount = sessionCount + processCount;
@@ -193,6 +195,8 @@ export function allocateConversationBottomPanelRows({
     return {
       bottomPanelRows: 0,
       sessionPanelRows: 0,
+      childListRows: 0,
+      detailPanelRows: 0,
       todosPlanRows: 0,
     };
   }
@@ -213,28 +217,37 @@ export function allocateConversationBottomPanelRows({
     sessionPanelContentRows > 0
       ? Math.max(minimumSessionRows, allocated.subagentRows)
       : 0;
-  const todosPlanRows = bottomPanelRows - sessionPanelRows;
+  let finalBottomPanelRows = bottomPanelRows;
+  let finalSessionPanelRows = sessionPanelRows;
+  let todosPlanRows = bottomPanelRows - sessionPanelRows;
   // A lone row cannot hold the separator plus content; hand it back instead
   // of rendering a dead blank line under the child list. When the child list
   // has rows above its own minimum, transfer one first so both panels remain
   // useful under a proportional split.
   if (todosPanelContentRows > 0 && todosPlanRows === 1) {
     if (sessionPanelRows > minimumSessionRows) {
-      return {
-        bottomPanelRows,
-        sessionPanelRows: sessionPanelRows - 1,
-        todosPlanRows: 2,
-      };
+      finalSessionPanelRows -= 1;
+      todosPlanRows = 2;
+    } else {
+      finalBottomPanelRows -= 1;
+      todosPlanRows = 0;
     }
-    return {
-      bottomPanelRows: bottomPanelRows - 1,
-      sessionPanelRows,
-      todosPlanRows: 0,
-    };
   }
+  const detailPanelCapacity = Math.max(
+    0,
+    finalSessionPanelRows - minimumSessionRows,
+  );
+  // A detail surface needs both its separator and at least one content row.
+  // Leave a lone spare row with the child list instead of reserving dead space.
+  const detailPanelRows =
+    detailPanelCapacity >= 2
+      ? Math.min(detailContentRows, detailPanelCapacity)
+      : 0;
   return {
-    bottomPanelRows,
-    sessionPanelRows,
+    bottomPanelRows: finalBottomPanelRows,
+    sessionPanelRows: finalSessionPanelRows,
+    childListRows: finalSessionPanelRows - detailPanelRows,
+    detailPanelRows,
     todosPlanRows,
   };
 }

--- a/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
@@ -31,8 +31,11 @@ import {
   queuedFollowUpPanelRowCount,
 } from './QueuedFollowUpsPanel';
 import { StaticConversationTranscript } from './StaticConversationTranscript';
+import {
+  selectedSubagentDetailLines,
+  SubagentDetailPanel,
+} from './SubagentDetailPanel';
 import { SubagentList } from './SubagentList';
-import { childFileDisplay } from './SubagentListDisplay';
 import { TodosPlanPanel, todosPlanPanelRowCount } from './TodosPlanPanel';
 import {
   childListStreamId,
@@ -58,7 +61,7 @@ interface ConversationRegionSnapshot {
   readonly slashPaletteOpen: boolean;
   readonly selectedChildValue: ChildListValue | undefined;
   readonly childListFocused: boolean;
-  readonly childListRowExpanded: boolean;
+  readonly childDetailsVisible: boolean;
   readonly sessionViews: readonly StreamView[];
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
   readonly subagentExecutionLabels: ExecutionLabels;
@@ -87,7 +90,7 @@ interface ConversationRegionProps {
   readonly onRetryExecution: (executionId: string) => void;
   readonly onOpenProcessDetail: (executionId: string) => void;
   readonly onPrintStream: (streamId: StreamTabId) => void;
-  readonly onToggleChildRowExpand: () => void;
+  readonly onToggleChildDetails: () => void;
 }
 
 export function ConversationRegion({
@@ -101,7 +104,7 @@ export function ConversationRegion({
   onRetryExecution,
   onOpenProcessDetail,
   onPrintStream,
-  onToggleChildRowExpand,
+  onToggleChildDetails,
   onStaticTranscriptChange,
   renderFooterChrome,
   renderForegroundSurface,
@@ -184,20 +187,20 @@ export function ConversationRegion({
       ? todosPlanPanelRowCount(activeSlice.todos, activeSlice.plan)
       : 0;
   const selectedChildStreamId = childListStreamId(snapshot.selectedChildValue);
-  const selectedChildFiles = selectedChildStreamId
-    ? snapshot.streams.get(selectedChildStreamId)?.files
+  const selectedChildSession = selectedChildStreamId
+    ? snapshot.sessionViews.find(({ id }) => id === selectedChildStreamId)
     : undefined;
-  const selectedFileDetailLines = childFileDisplay(
-    selectedChildFiles,
+  const selectedDetailLines = selectedSubagentDetailLines(
+    selectedChildSession,
     Math.max(1, columns - 6),
-  ).detailLines;
-  const expandedFileDetailLines =
-    selectedFileDetailLines.length > 0
-      ? selectedFileDetailLines
-      : ['No file info for this row'];
-  const childDetailLines = snapshot.childListRowExpanded
-    ? expandedFileDetailLines
-    : [];
+  );
+  const childDetailLines =
+    snapshot.childDetailsVisible && selectedChildSession
+      ? selectedDetailLines
+      : [];
+  // The detail view is a sibling of the list and owns its own separator row.
+  const childDetailPanelNeed =
+    childDetailLines.length > 0 ? childDetailLines.length + 1 : 0;
   const {
     bottomPanelRows: bottomPanelBudget,
     sessionPanelRows: subagentRows,
@@ -207,10 +210,16 @@ export function ConversationRegion({
     processCount: foregroundOpen ? 0 : activeProcesses.length,
     sessionCount: foregroundOpen ? 0 : snapshot.sessionViews.length,
     childListFocused: snapshot.childListFocused,
-    detailContentRows: childDetailLines.length,
+    detailContentRows: childDetailPanelNeed,
     todosPlanContentRows,
     transcriptRows,
   });
+  const childListMinimumRows = 2;
+  const detailPanelRows = Math.min(
+    childDetailPanelNeed,
+    Math.max(0, subagentRows - childListMinimumRows),
+  );
+  const childListRows = subagentRows - detailPanelRows;
   const conversationRows = transcriptRows - bottomPanelBudget;
   const childListHasRows =
     snapshot.sessionViews.length > 0 || activeProcesses.length > 0;
@@ -276,7 +285,7 @@ export function ConversationRegion({
           <Box flexDirection="column" overflowY="hidden">
             <SubagentList
               keyboardActive={snapshot.childListFocused && childListVisible}
-              maxRows={subagentRows}
+              maxRows={childListRows}
               onCancel={onCancelChildList}
               onFocusStream={onFocusSession}
               onKillExecution={onKillExecution}
@@ -285,7 +294,7 @@ export function ConversationRegion({
               onOpenProcessDetail={onOpenProcessDetail}
               onSelectionChange={onChildSelectionChange}
               onPrintStream={onPrintStream}
-              onToggleRowExpand={onToggleChildRowExpand}
+              onToggleDetails={onToggleChildDetails}
               pendingApprovals={snapshot.pendingApprovals}
               listRootStreamId={snapshot.childListTarget.streamId}
               selectedValue={snapshot.selectedChildValue}
@@ -293,7 +302,10 @@ export function ConversationRegion({
               activeProcesses={activeProcesses}
               activeSubagentExecutionIds={snapshot.activeSubagentExecutionIds}
               processOutput={snapshot.childListTarget.slice?.processOutput}
-              detailLines={childDetailLines}
+            />
+            <SubagentDetailPanel
+              lines={childDetailLines}
+              maxRows={detailPanelRows}
             />
             <TodosPlanPanel maxRows={todosPlanRows} />
           </Box>

--- a/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
@@ -204,6 +204,8 @@ export function ConversationRegion({
   const {
     bottomPanelRows: bottomPanelBudget,
     sessionPanelRows: subagentRows,
+    childListRows,
+    detailPanelRows,
     todosPlanRows,
   } = allocateConversationBottomPanelRows({
     maxRows: BOTTOM_PANEL_MAX_ROWS,
@@ -214,12 +216,6 @@ export function ConversationRegion({
     todosPlanContentRows,
     transcriptRows,
   });
-  const childListMinimumRows = 2;
-  const detailPanelRows = Math.min(
-    childDetailPanelNeed,
-    Math.max(0, subagentRows - childListMinimumRows),
-  );
-  const childListRows = subagentRows - detailPanelRows;
   const conversationRows = transcriptRows - bottomPanelBudget;
   const childListHasRows =
     snapshot.sessionViews.length > 0 || activeProcesses.length > 0;

--- a/packages/cli/src/chat/tui/panes/SubagentDetailPanel.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentDetailPanel.tsx
@@ -59,8 +59,8 @@ export function selectedSubagentDetailLines(
     .toReversed();
   if (outputRounds.length === 0) {
     const configuredOutputs = slice?.files?.output ?? [];
-    if (configuredOutputs.length > 0) {
-      lines.push(`Output: ${configuredOutputs.join(', ')}`);
+    for (const path of configuredOutputs) {
+      lines.push(`Output: ${path}`);
     }
   } else {
     for (const [round, files] of outputRounds) {

--- a/packages/cli/src/chat/tui/panes/SubagentDetailPanel.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentDetailPanel.tsx
@@ -53,9 +53,9 @@ export function selectedSubagentDetailLines(
     lines.push(`${label}: ${paths.join(', ')}`);
   }
 
-  const outputRounds = roundIndexedEntries(
-    slice?.outputFilesByRound ?? {},
-  ).filter(([, files]) => files.length > 0);
+  const outputRounds = roundIndexedEntries(slice?.outputFilesByRound ?? {})
+    .filter(([, files]) => files.length > 0)
+    .toReversed();
   if (outputRounds.length === 0) {
     const configuredOutputs = slice?.files?.output ?? [];
     if (configuredOutputs.length > 0) {

--- a/packages/cli/src/chat/tui/panes/SubagentDetailPanel.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentDetailPanel.tsx
@@ -1,0 +1,93 @@
+// Selected child-session facts shown separately from the compact child list.
+
+// Third-party imports
+import { Box, Text } from 'ink';
+
+// Local imports - shared stream display
+import { AgentCategory } from '@shared/schemas';
+import {
+  formatRoundStageLabel,
+  formatStreamStatusLabel,
+} from '@shared/streams/streamStatusDisplay';
+import { formatResultCount } from '@utils/text/stringUtils';
+
+// Local imports - TUI rendering and state
+import { truncateSummaryToWidth } from '../render/terminalText';
+import type { StreamView } from '../state/streamViews';
+
+const FILE_CATEGORIES = [
+  ['input', 'Input'],
+  ['context', 'Context'],
+  ['media', 'Media'],
+  ['output', 'Output'],
+] as const;
+
+/** Build the extension-style selected-stream summary used by the TUI. */
+export function selectedSubagentDetailLines(
+  session: StreamView | undefined,
+  maxColumns: number,
+): readonly string[] {
+  if (!session) return [];
+  const slice = session.slice;
+  let category = 'agent';
+  if (slice?.category === AgentCategory.Workflow) category = 'workflow agent';
+  if (slice?.category === AgentCategory.ToolUse) category = 'tool-use agent';
+  const lines = [`Selected ${category}: ${session.label}`];
+  const status = formatStreamStatusLabel(slice?.status, {
+    style: 'cli',
+    isChildStream: session.parentId !== undefined,
+    ...(slice?.substate ? { substate: slice.substate } : {}),
+  });
+  const round = formatRoundStageLabel(slice?.roundStage);
+  const toolCalls = slice?.conversation?.toolCallCount;
+  const progress = [
+    status,
+    round,
+    toolCalls ? formatResultCount(toolCalls, 'tool call') : undefined,
+  ].filter((part): part is string => part !== undefined);
+  if (progress.length > 0) lines.push(`Progress: ${progress.join(' · ')}`);
+
+  for (const [key, label] of FILE_CATEGORIES) {
+    const generated = key === 'output' ? slice?.generatedOutput : undefined;
+    const paths = generated?.paths ?? slice?.files?.[key] ?? [];
+    if (paths.length === 0) continue;
+    const roundLabel = generated ? ` r${generated.roundIndex + 1}` : '';
+    lines.push(`${label}${roundLabel}: ${paths.join(', ')}`);
+  }
+
+  return lines.map((line) => truncateSummaryToWidth(line, maxColumns));
+}
+
+export function SubagentDetailPanel({
+  lines,
+  maxRows,
+}: {
+  readonly lines: readonly string[];
+  /** Includes the blank separator row above the detail surface. */
+  readonly maxRows: number;
+}): React.JSX.Element | null {
+  const contentRows = Math.max(0, maxRows - 1);
+  if (contentRows === 0 || lines.length === 0) return null;
+
+  return (
+    <Box
+      flexDirection="column"
+      flexShrink={0}
+      height={contentRows}
+      marginTop={1}
+      overflowY="hidden"
+      paddingX={2}
+    >
+      {lines.slice(0, contentRows).map((line, index) => (
+        <Text
+          key={`${index}:${line}`}
+          bold={index === 0}
+          dimColor={index !== 0}
+          wrap="truncate-end"
+        >
+          {line}
+        </Text>
+      ))}
+    </Box>
+  );
+}

--- a/packages/cli/src/chat/tui/panes/SubagentDetailPanel.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentDetailPanel.tsx
@@ -49,8 +49,9 @@ export function selectedSubagentDetailLines(
 
   for (const [key, label] of FILE_CATEGORIES) {
     const paths = slice?.files?.[key] ?? [];
-    if (paths.length === 0) continue;
-    lines.push(`${label}: ${paths.join(', ')}`);
+    for (const path of paths) {
+      lines.push(`${label}: ${path}`);
+    }
   }
 
   const outputRounds = roundIndexedEntries(slice?.outputFilesByRound ?? {})

--- a/packages/cli/src/chat/tui/panes/SubagentDetailPanel.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentDetailPanel.tsx
@@ -5,6 +5,7 @@ import { Box, Text } from 'ink';
 
 // Local imports - shared stream display
 import { AgentCategory } from '@shared/schemas';
+import { roundIndexedEntries } from '@shared/schemas/roundIndexed';
 import {
   formatRoundStageLabel,
   formatStreamStatusLabel,
@@ -19,7 +20,6 @@ const FILE_CATEGORIES = [
   ['input', 'Input'],
   ['context', 'Context'],
   ['media', 'Media'],
-  ['output', 'Output'],
 ] as const;
 
 /** Build the extension-style selected-stream summary used by the TUI. */
@@ -48,11 +48,27 @@ export function selectedSubagentDetailLines(
   if (progress.length > 0) lines.push(`Progress: ${progress.join(' · ')}`);
 
   for (const [key, label] of FILE_CATEGORIES) {
-    const generated = key === 'output' ? slice?.generatedOutput : undefined;
-    const paths = generated?.paths ?? slice?.files?.[key] ?? [];
+    const paths = slice?.files?.[key] ?? [];
     if (paths.length === 0) continue;
-    const roundLabel = generated ? ` r${generated.roundIndex + 1}` : '';
-    lines.push(`${label}${roundLabel}: ${paths.join(', ')}`);
+    lines.push(`${label}: ${paths.join(', ')}`);
+  }
+
+  const outputRounds = roundIndexedEntries(
+    slice?.outputFilesByRound ?? {},
+  ).filter(([, files]) => files.length > 0);
+  if (outputRounds.length === 0) {
+    const configuredOutputs = slice?.files?.output ?? [];
+    if (configuredOutputs.length > 0) {
+      lines.push(`Output: ${configuredOutputs.join(', ')}`);
+    }
+  } else {
+    for (const [round, files] of outputRounds) {
+      lines.push(
+        `Output r${round + 1}: ${files
+          .map((file) => file.location.absolutePath)
+          .join(', ')}`,
+      );
+    }
   }
 
   return lines.map((line) => truncateSummaryToWidth(line, maxColumns));

--- a/packages/cli/src/chat/tui/panes/SubagentDetailPanel.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentDetailPanel.tsx
@@ -63,11 +63,9 @@ export function selectedSubagentDetailLines(
     }
   } else {
     for (const [round, files] of outputRounds) {
-      lines.push(
-        `Output r${round + 1}: ${files
-          .map((file) => file.location.absolutePath)
-          .join(', ')}`,
-      );
+      for (const file of files) {
+        lines.push(`Output r${round + 1}: ${file.location.absolutePath}`);
+      }
     }
   }
 

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -36,7 +36,6 @@ import { Select, visibleSelectRange } from '../ui/Select';
 import {
   CHILD_ROW_METADATA_MIN_COLUMNS,
   CHILD_STATUS_MARKER,
-  childFileDisplay,
   childRowMetadataText,
   childStatusColor,
   pendingApprovalRowSuffix,
@@ -148,7 +147,6 @@ function SessionRow({
   // this truncate-end text sheds inline elapsed (narrow mode only), the round,
   // and last the pending-approval kind. The metadata column never shrinks.
   const approvalSuffix = pendingApprovalRowSuffix(pendingKinds);
-  const fileBadge = childFileDisplay(session.slice?.files).badge;
   const roundLabel = formatRoundStageLabel(session.slice?.roundStage);
   // The resolved model is per-agent identity (a workflow run's grandchildren
   // can each resolve a different model); the list-root row is the conversation
@@ -200,11 +198,6 @@ function SessionRow({
           <Text dimColor wrap="truncate-end">
             {` · ${truncateSummaryToWidth(summary, SUBAGENT_SUMMARY_MAX_COLUMNS)}`}
           </Text>
-        </Box>
-      ) : null}
-      {fileBadge ? (
-        <Box minWidth={0} flexShrink={3}>
-          <Text dimColor wrap="truncate-end">{` · ${fileBadge}`}</Text>
         </Box>
       ) : null}
       {focused ? <HiddenRowSummary text={hiddenRowSummary} /> : null}
@@ -266,24 +259,6 @@ function ProcessRow({
   );
 }
 
-/** Focus-local file details. The caller has already bounded the lines to the
- *  rows left after preserving at least one visible child row. */
-function SubagentRowDetail({
-  lines,
-}: {
-  readonly lines: readonly string[];
-}): React.JSX.Element | null {
-  return lines.length > 0 ? (
-    <Box flexDirection="column" flexShrink={0} paddingLeft={4}>
-      {lines.map((line, index) => (
-        <Text key={`${index}:${line}`} dimColor wrap="truncate-end">
-          {line}
-        </Text>
-      ))}
-    </Box>
-  ) : null;
-}
-
 export interface SubagentListProps {
   readonly keyboardActive?: boolean;
   readonly maxRows?: number;
@@ -297,7 +272,7 @@ export interface SubagentListProps {
   readonly onOpenProcessDetail?: (executionId: string) => void;
   readonly onSelectionChange?: (value: ChildListValue) => void;
   readonly onPrintStream?: (streamId: StreamTabId) => void;
-  readonly onToggleRowExpand?: () => void;
+  readonly onToggleDetails?: () => void;
   /** Pending approval kinds per stream id (see `pendingApprovalSummaries`,
    *  root bucket already folded onto the root stream id by the caller). */
   readonly pendingApprovals?: ReadonlyMap<
@@ -311,8 +286,6 @@ export interface SubagentListProps {
   readonly activeProcesses?: readonly ActiveChildInfo[];
   readonly activeSubagentExecutionIds?: ReadonlyMap<StreamTabId, string>;
   readonly processOutput?: ReadonlyMap<string, ProcessOutputTail>;
-  /** Preformatted details for the selected row; empty when it is collapsed. */
-  readonly detailLines?: readonly string[];
 }
 
 export function SubagentList(
@@ -372,17 +345,6 @@ export function SubagentList(
   const metadataColumn = columns >= CHILD_ROW_METADATA_MIN_COLUMNS;
   const contentRows =
     props.maxRows === undefined ? undefined : Math.max(0, props.maxRows - 1);
-  // Preserve at least one selected-row slot. On a tight terminal the detail
-  // therefore sheds rows before the list does.
-  const detailRows =
-    contentRows === undefined
-      ? (props.detailLines?.length ?? 0)
-      : Math.min(props.detailLines?.length ?? 0, Math.max(0, contentRows - 1));
-  const visibleDetailLines = (props.detailLines ?? []).slice(0, detailRows);
-  const listRows =
-    contentRows === undefined
-      ? undefined
-      : Math.max(0, contentRows - detailRows);
   const selectedIndex = Math.max(
     0,
     items.findIndex((item) => item.value === props.selectedValue),
@@ -390,7 +352,7 @@ export function SubagentList(
   const visibleRange = visibleSelectRange({
     highlight: selectedIndex,
     itemCount: items.length,
-    maxVisibleItems: listRows,
+    maxVisibleItems: contentRows,
   });
   const visibleValues = new Set(
     items.slice(visibleRange.start, visibleRange.end).map((item) => item.value),
@@ -419,7 +381,7 @@ export function SubagentList(
       const streamId = childListStreamId(props.selectedValue);
       const pressed = input.toLowerCase();
       if (pressed === 'i' && streamId) {
-        props.onToggleRowExpand?.();
+        props.onToggleDetails?.();
         return;
       }
       if (pressed === 'v' && streamId) {
@@ -474,7 +436,7 @@ export function SubagentList(
         hotkeys={false}
         isActive={props.keyboardActive}
         items={items}
-        maxVisibleItems={listRows}
+        maxVisibleItems={contentRows}
         onCancel={props.onCancel ?? (() => undefined)}
         // This panel is a standalone focus target, not a cyclic menu: Down
         // past the last row hands keyboard ownership back to the input
@@ -522,7 +484,6 @@ export function SubagentList(
           ) : null;
         }}
       />
-      <SubagentRowDetail lines={visibleDetailLines} />
     </Box>
   );
 }

--- a/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/SubagentListDisplay.ts
@@ -2,9 +2,6 @@
 import { formatCompactTokenCount } from '@utils/core';
 import { formatResultCount } from '@utils/text/stringUtils';
 
-// Local imports - TUI rendering and state
-import { truncateSummaryToWidth } from '../render/terminalText';
-
 // Local imports - TUI state and presentation
 import { isChildExecutionErrorStatus } from '../state/childExecutionStatus';
 import {
@@ -15,7 +12,6 @@ import {
 } from '../ui/colors';
 import { STATUS_DOT, TOKENS_GENERATED } from '../ui/glyphs';
 import type { PendingApprovalKind } from '../state/approvalQueue';
-import type { StreamFileMetadata } from '../state/cliState';
 
 export function childStatusColor(status: string | undefined): string {
   if (!status) return COLOR_SUCCESS;
@@ -87,45 +83,4 @@ export function pendingApprovalRowSuffix(
   if (kinds === undefined || first === undefined) return undefined;
   const label = PENDING_APPROVAL_ROW_LABELS[first];
   return kinds.length > 1 ? `${label} +${kinds.length - 1}` : label;
-}
-
-const FILE_CATEGORIES = [
-  ['input', 'in', 'Input'],
-  ['context', 'ctx', 'Context'],
-  ['media', 'media', 'Media'],
-  ['output', 'out', 'Output'],
-] as const satisfies readonly (readonly [
-  keyof StreamFileMetadata,
-  string,
-  string,
-])[];
-
-/** Derive both file surfaces from one role ordering. Row callers omit
- *  `detailMaxColumns` and therefore pay only for the compact badge; the
- *  expanded panel requests its bounded detail lines from the same API. */
-export function childFileDisplay(
-  files: StreamFileMetadata | undefined,
-  detailMaxColumns?: number,
-): {
-  readonly badge: string | undefined;
-  readonly detailLines: readonly string[];
-} {
-  if (!files) return { badge: undefined, detailLines: [] };
-  const populated = FILE_CATEGORIES.filter(([key]) => files[key].length > 0);
-  const badge = populated.map(
-    ([key, label]) => `${label}:${files[key].length}`,
-  );
-  const detailLines =
-    detailMaxColumns === undefined
-      ? []
-      : populated.map(([key, , label]) =>
-          truncateSummaryToWidth(
-            `${label}  ${files[key].join(', ')}`,
-            detailMaxColumns,
-          ),
-        );
-  return {
-    badge: badge.length > 0 ? badge.join(' ') : undefined,
-    detailLines,
-  };
 }

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -605,7 +605,7 @@ function childListBindingsText(
       : undefined;
   const fileInfoBinding =
     selectionKind === 'stream'
-      ? keyHintText({ key: 'i', action: 'files' })
+      ? keyHintText({ key: 'i', action: 'details' })
       : undefined;
   const killBinding = selectionKillable
     ? keyHintText({ key: 'k', action: 'kill' })

--- a/packages/cli/src/chat/tui/state/childListSelection.ts
+++ b/packages/cli/src/chat/tui/state/childListSelection.ts
@@ -30,7 +30,9 @@ export function childListProcessId(
 export interface ChildListSelectionState {
   readonly focused: boolean;
   readonly selectedValue: ChildListValue | undefined;
-  readonly rowExpanded: boolean;
+  /** Stream details open automatically on selection and remain
+   *  user-toggleable while the child list owns the keyboard. */
+  readonly detailsVisible: boolean;
 }
 
 type ChildListSelectionAction =
@@ -38,7 +40,7 @@ type ChildListSelectionAction =
   | { readonly kind: 'focus'; readonly value?: ChildListValue }
   | { readonly kind: 'focusStream'; readonly streamId: StreamTabId }
   | { readonly kind: 'highlight'; readonly value: ChildListValue }
-  | { readonly kind: 'toggleRowExpand' }
+  | { readonly kind: 'toggleDetails' }
   | {
       readonly kind: 'syncActiveStream';
       readonly streamId: StreamTabId;
@@ -53,7 +55,7 @@ type ChildListSelectionAction =
 export const INITIAL_CHILD_LIST_SELECTION: ChildListSelectionState = {
   focused: false,
   selectedValue: undefined,
-  rowExpanded: false,
+  detailsVisible: false,
 };
 
 function resolveChildSelectionValue(
@@ -77,37 +79,46 @@ export function reduceChildListSelection(
 ): ChildListSelectionState {
   switch (action.kind) {
     case 'blur':
-      return { ...state, focused: false, rowExpanded: false };
-    case 'focus':
+      return { ...state, focused: false, detailsVisible: false };
+    case 'focus': {
+      const selectedValue = state.selectedValue ?? action.value;
       return {
         focused: true,
-        selectedValue: state.selectedValue ?? action.value,
-        rowExpanded: false,
+        selectedValue,
+        detailsVisible: childListStreamId(selectedValue) !== undefined,
       };
+    }
     case 'focusStream':
       return {
         focused: false,
         selectedValue: childStreamListValue(action.streamId),
-        rowExpanded: false,
+        detailsVisible: false,
       };
     case 'highlight':
       return action.value === state.selectedValue
         ? state
-        : { ...state, selectedValue: action.value, rowExpanded: false };
-    case 'toggleRowExpand':
+        : {
+            ...state,
+            selectedValue: action.value,
+            detailsVisible: childListStreamId(action.value) !== undefined,
+          };
+    case 'toggleDetails':
       return state.focused
-        ? { ...state, rowExpanded: !state.rowExpanded }
+        ? { ...state, detailsVisible: !state.detailsVisible }
         : state;
-    case 'syncActiveStream':
+    case 'syncActiveStream': {
+      const activeValue = resolveChildSelectionValue(
+        action.values,
+        undefined,
+        action.streamId,
+      );
       return {
         ...state,
-        selectedValue: resolveChildSelectionValue(
-          action.values,
-          undefined,
-          action.streamId,
-        ),
-        rowExpanded: false,
+        selectedValue: activeValue,
+        detailsVisible:
+          state.focused && childListStreamId(activeValue) !== undefined,
       };
+    }
     case 'reconcile': {
       if (action.values.length === 0) return state;
       const selectedValue = resolveChildSelectionValue(
@@ -117,7 +128,12 @@ export function reduceChildListSelection(
       );
       return selectedValue === state.selectedValue
         ? state
-        : { ...state, selectedValue, rowExpanded: false };
+        : {
+            ...state,
+            selectedValue,
+            detailsVisible:
+              state.focused && childListStreamId(selectedValue) !== undefined,
+          };
     }
   }
 }

--- a/packages/cli/src/chat/tui/state/childListSelection.ts
+++ b/packages/cli/src/chat/tui/state/childListSelection.ts
@@ -112,12 +112,14 @@ export function reduceChildListSelection(
         undefined,
         action.streamId,
       );
-      return {
-        ...state,
-        selectedValue: activeValue,
-        detailsVisible:
-          state.focused && childListStreamId(activeValue) !== undefined,
-      };
+      return activeValue === state.selectedValue
+        ? state
+        : {
+            ...state,
+            selectedValue: activeValue,
+            detailsVisible:
+              state.focused && childListStreamId(activeValue) !== undefined,
+          };
     }
     case 'reconcile': {
       if (action.values.length === 0) return state;

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -128,6 +128,14 @@ export interface StreamFileMetadata {
   readonly output: readonly string[];
 }
 
+/** Latest workflow outputs announced by the run, kept separately from the
+ *  configured output names so the selected-agent view can show the actual
+ *  absolute storage paths produced by the current round. */
+export interface GeneratedOutputMetadata {
+  readonly roundIndex: number;
+  readonly paths: readonly string[];
+}
+
 export interface StreamSlice {
   readonly streamId: StreamTabId;
   /** Model identity captured from setTaskState for this specific stream. */
@@ -139,6 +147,7 @@ export interface StreamSlice {
   /** Normalized run files received with `run.config`. Absent until that fact
    *  arrives; each category may then be empty. */
   readonly files?: StreamFileMetadata | undefined;
+  readonly generatedOutput?: GeneratedOutputMetadata | undefined;
   readonly status: StreamPhase | undefined;
   readonly substate?: StreamSubstate;
   /** Epoch ms when this stream last entered `RUNNING`; cleared on any other
@@ -208,6 +217,7 @@ function emptySlice(streamId: StreamTabId): StreamSlice {
     substate: undefined,
     runStartedAt: undefined,
     description: undefined,
+    generatedOutput: undefined,
     thinkingActive: false,
     usage: undefined,
     cumulativeUsage: undefined,

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -13,8 +13,10 @@ import {
   type ConversationProgress,
   type MessageType,
   type NormalizedToolUse,
+  type OutputFileInfo,
   type Plan,
   type ProcessOutputTail,
+  type RoundIndexed,
   type RoundStage,
   type StreamPhase,
   type StreamSubstate,
@@ -121,19 +123,11 @@ export interface BypassState {
 
 /** File roles attached to one agent run. Kept as one optional value so the
  *  transcript slice does not duplicate derived counts alongside the paths. */
-export interface StreamFileMetadata {
+interface StreamFileMetadata {
   readonly input: readonly string[];
   readonly context: readonly string[];
   readonly media: readonly string[];
   readonly output: readonly string[];
-}
-
-/** Latest workflow outputs announced by the run, kept separately from the
- *  configured output names so the selected-agent view can show the actual
- *  absolute storage paths produced by the current round. */
-export interface GeneratedOutputMetadata {
-  readonly roundIndex: number;
-  readonly paths: readonly string[];
 }
 
 export interface StreamSlice {
@@ -147,7 +141,8 @@ export interface StreamSlice {
   /** Normalized run files received with `run.config`. Absent until that fact
    *  arrives; each category may then be empty. */
   readonly files?: StreamFileMetadata | undefined;
-  readonly generatedOutput?: GeneratedOutputMetadata | undefined;
+  /** Canonical streamed workflow outputs, preserving every announced round. */
+  readonly outputFilesByRound?: RoundIndexed<OutputFileInfo> | undefined;
   readonly status: StreamPhase | undefined;
   readonly substate?: StreamSubstate;
   /** Epoch ms when this stream last entered `RUNNING`; cleared on any other
@@ -217,7 +212,7 @@ function emptySlice(streamId: StreamTabId): StreamSlice {
     substate: undefined,
     runStartedAt: undefined,
     description: undefined,
-    generatedOutput: undefined,
+    outputFilesByRound: undefined,
     thinkingActive: false,
     usage: undefined,
     cumulativeUsage: undefined,

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -148,23 +148,12 @@ function applyRoundStage(payload: UpdateRoundStagePayload): void {
 function applyOutputFiles(
   event: Extract<AgentEvent, { type: 'addOutputFiles' }>,
 ): void {
-  const latest = Object.entries(event.filesByRound)
-    .map(([round, files]) => ({
-      roundIndex: Number.parseInt(round, 10),
-      paths: files.map((file) => file.location.absolutePath),
-    }))
-    .toSorted((left, right) => left.roundIndex - right.roundIndex)
-    .at(-1);
-  if (!latest) return;
-
   patchStream(event.streamId, (s) => {
-    const previous = s.generatedOutput;
-    if (previous && previous.roundIndex > latest.roundIndex) return s;
-    const unchanged =
-      previous?.roundIndex === latest.roundIndex &&
-      previous.paths.length === latest.paths.length &&
-      previous.paths.every((path, index) => path === latest.paths[index]);
-    return unchanged ? s : { ...s, generatedOutput: latest };
+    const outputFilesByRound = {
+      ...s.outputFilesByRound,
+      ...event.filesByRound,
+    };
+    return { ...s, outputFilesByRound };
   });
 }
 

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -145,6 +145,29 @@ function applyRoundStage(payload: UpdateRoundStagePayload): void {
   });
 }
 
+function applyOutputFiles(
+  event: Extract<AgentEvent, { type: 'addOutputFiles' }>,
+): void {
+  const latest = Object.entries(event.filesByRound)
+    .map(([round, files]) => ({
+      roundIndex: Number.parseInt(round, 10),
+      paths: files.map((file) => file.location.absolutePath),
+    }))
+    .toSorted((left, right) => left.roundIndex - right.roundIndex)
+    .at(-1);
+  if (!latest) return;
+
+  patchStream(event.streamId, (s) => {
+    const previous = s.generatedOutput;
+    if (previous && previous.roundIndex > latest.roundIndex) return s;
+    const unchanged =
+      previous?.roundIndex === latest.roundIndex &&
+      previous.paths.length === latest.paths.length &&
+      previous.paths.every((path, index) => path === latest.paths[index]);
+    return unchanged ? s : { ...s, generatedOutput: latest };
+  });
+}
+
 function applyActiveSubagents(payload: {
   parentStreamId: StreamTabId;
   children: readonly ActiveChildInfo[];
@@ -231,6 +254,8 @@ function applyDirectTuiRunEvent(
       appendGoalPausedTranscriptNotice(event);
       return true;
     case 'addOutputFiles':
+      applyOutputFiles(event);
+      return true;
     case 'updateMissingOutputs':
     case 'updateCompileFailures':
       return false;

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -1300,7 +1300,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           createInputText(`Document: ${media.file_name}`),
           {
             type: 'input_file',
-            file_data: media.data,
+            file_data: toDataUrl(mediaType, media.data),
             filename: media.file_name,
           },
         ];

--- a/src/shared/schemas/agentPresets.ts
+++ b/src/shared/schemas/agentPresets.ts
@@ -170,7 +170,14 @@ export const AGENT_MODE_PRESETS: AgentModePreset[] = [
     description:
       'For math research -- attacking open problems, proofs, Lean 4 formalization, and LaTeX correction.',
     icon: 'symbol-number',
-    workflowAgents: ['correct', 'polish', 'generic', 'devise', 'apply'],
+    workflowAgents: [
+      'correct',
+      'polish',
+      'generic',
+      'devise',
+      'apply',
+      'criticize',
+    ],
     toolUseAgents: [
       'prover',
       'lean',
@@ -186,6 +193,7 @@ export const AGENT_MODE_PRESETS: AgentModePreset[] = [
       'generic',
       'devise',
       'apply',
+      'criticize',
       'lean',
       'simplifier',
       'progressCheck',

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
@@ -136,6 +136,31 @@ function createMessages(count: number): ResponseInputItem[] {
   })) as ResponseInputItem[];
 }
 
+describe('ModelHandlerOpenAIResponse.createMediaContent', () => {
+  it('sends inline PDFs as data URLs', () => {
+    const handler = createNonChainingHandler({ openRouterOnly: false });
+
+    assert.deepEqual(
+      handler.createMediaContent([
+        {
+          file_name: 'paper.pdf',
+          data: 'JVBERi0xLjc=',
+          media_type: 'application/pdf',
+          media_category: 'image',
+        },
+      ]),
+      [
+        { type: 'input_text', text: 'Document: paper.pdf' },
+        {
+          type: 'input_file',
+          file_data: 'data:application/pdf;base64,JVBERi0xLjc=',
+          filename: 'paper.pdf',
+        },
+      ],
+    );
+  });
+});
+
 describe('ModelHandlerOpenAIResponse.createResponse', () => {
   it('uses the client route instead of mutable OpenRouter configuration during an attempt', async () => {
     const handler = setupHandler(

--- a/src/test-kernel/cli/ChildListInteraction.vitest.mts
+++ b/src/test-kernel/cli/ChildListInteraction.vitest.mts
@@ -23,13 +23,13 @@ function session(id: StreamTabId, active = false): StreamView {
 describe('CLI child list interaction', () => {
   it('toggles file details with i while the list owns the keyboard', async () => {
     const { ink, React } = await loadInk();
-    const onToggleRowExpand = vi.fn();
+    const onToggleDetails = vi.fn();
     const stdin = new FakeStdin();
     const instance = ink.render(
       React.createElement(SubagentList, {
         keyboardActive: true,
         maxRows: 4,
-        onToggleRowExpand,
+        onToggleDetails,
         selectedValue: childStreamListValue('root' as StreamTabId),
         sessions: [session('root' as StreamTabId, true)],
       }),
@@ -45,8 +45,8 @@ describe('CLI child list interaction', () => {
     try {
       await waitFor(() => stdin.listenerCount('readable') > 0);
       stdin.write('i');
-      await waitFor(() => onToggleRowExpand.mock.calls.length === 1);
-      expect(onToggleRowExpand).toHaveBeenCalledOnce();
+      await waitFor(() => onToggleDetails.mock.calls.length === 1);
+      expect(onToggleDetails).toHaveBeenCalledOnce();
     } finally {
       instance.unmount();
     }
@@ -262,7 +262,7 @@ describe('CLI child list interaction', () => {
     const onKillExecution = vi.fn();
     const onOpenProcessDetail = vi.fn();
     const onPrintStream = vi.fn();
-    const onToggleRowExpand = vi.fn();
+    const onToggleDetails = vi.fn();
 
     const stdin = new FakeStdin();
     const instance = ink.render(
@@ -282,7 +282,7 @@ describe('CLI child list interaction', () => {
         onOpenProcessDetail,
         onSelectionChange: vi.fn(),
         onPrintStream,
-        onToggleRowExpand,
+        onToggleDetails,
         selectedValue: processValue,
       }),
       {
@@ -304,7 +304,7 @@ describe('CLI child list interaction', () => {
       await waitFor(() => onOpenProcessDetail.mock.calls.length === 1);
 
       expect(onPrintStream).not.toHaveBeenCalled();
-      expect(onToggleRowExpand).not.toHaveBeenCalled();
+      expect(onToggleDetails).not.toHaveBeenCalled();
       expect(onKillExecution).toHaveBeenCalledWith('process-exec');
       expect(onOpenProcessDetail).toHaveBeenCalledWith('process-exec');
     } finally {

--- a/src/test-kernel/cli/ChildListSelection.vitest.mts
+++ b/src/test-kernel/cli/ChildListSelection.vitest.mts
@@ -60,7 +60,7 @@ describe('CLI child list selection', () => {
     expect(state).toEqual({
       focused: true,
       selectedValue: processValue,
-      rowExpanded: false,
+      detailsVisible: false,
     });
   });
 
@@ -68,7 +68,7 @@ describe('CLI child list selection', () => {
     const selected: ChildListSelectionState = {
       focused: true,
       selectedValue: strategyValue,
-      rowExpanded: false,
+      detailsVisible: false,
     };
     const hidden = reconcileSelection(selected, [], main);
     const restored = reconcileSelection(
@@ -83,7 +83,7 @@ describe('CLI child list selection', () => {
 
   it('selects the owner when lifecycle completion changes the active stream', () => {
     const state = reduceChildListSelection(
-      { focused: true, selectedValue: strategyValue, rowExpanded: true },
+      { focused: true, selectedValue: strategyValue, detailsVisible: true },
       {
         kind: 'syncActiveStream',
         streamId: main,
@@ -94,13 +94,13 @@ describe('CLI child list selection', () => {
     expect(state).toEqual({
       focused: true,
       selectedValue: mainValue,
-      rowExpanded: false,
+      detailsVisible: true,
     });
   });
 
   it('clears a stale row when the active stream is not in the projected list', () => {
     const state = reduceChildListSelection(
-      { focused: true, selectedValue: strategyValue, rowExpanded: true },
+      { focused: true, selectedValue: strategyValue, detailsVisible: true },
       {
         kind: 'syncActiveStream',
         streamId: main,
@@ -111,7 +111,7 @@ describe('CLI child list selection', () => {
     expect(state).toEqual({
       focused: true,
       selectedValue: undefined,
-      rowExpanded: false,
+      detailsVisible: false,
     });
   });
 
@@ -120,7 +120,7 @@ describe('CLI child list selection', () => {
       {
         focused: true,
         selectedValue: childProcessListValue('gone'),
-        rowExpanded: false,
+        detailsVisible: false,
       },
       [processValue, mainValue],
       main,
@@ -146,32 +146,28 @@ describe('CLI child list selection', () => {
     expect(state).toEqual({
       focused: true,
       selectedValue: processValue,
-      rowExpanded: false,
+      detailsVisible: false,
     });
   });
 
   it('returns input after a stream is focused', () => {
     const state = reduceChildListSelection(
-      { focused: true, selectedValue: processValue, rowExpanded: true },
+      { focused: true, selectedValue: processValue, detailsVisible: true },
       { kind: 'focusStream', streamId: strategy },
     );
     expect(state).toEqual({
       focused: false,
       selectedValue: strategyValue,
-      rowExpanded: false,
+      detailsVisible: false,
     });
   });
 
-  it('expands only while focused and closes details when selection changes', () => {
+  it('shows stream files on focus and selection while preserving the toggle', () => {
     let state = reduceChildListSelection(
-      {
-        focused: true,
-        selectedValue: mainValue,
-        rowExpanded: false,
-      },
-      { kind: 'toggleRowExpand' },
+      { focused: false, selectedValue: mainValue, detailsVisible: false },
+      { kind: 'focus' },
     );
-    expect(state.rowExpanded).toBe(true);
+    expect(state.detailsVisible).toBe(true);
 
     state = reduceChildListSelection(state, {
       kind: 'highlight',
@@ -180,11 +176,14 @@ describe('CLI child list selection', () => {
     expect(state).toEqual({
       focused: true,
       selectedValue: strategyValue,
-      rowExpanded: false,
+      detailsVisible: true,
     });
 
+    state = reduceChildListSelection(state, { kind: 'toggleDetails' });
+    expect(state.detailsVisible).toBe(false);
+
     state = reduceChildListSelection(state, { kind: 'blur' });
-    expect(reduceChildListSelection(state, { kind: 'toggleRowExpand' })).toBe(
+    expect(reduceChildListSelection(state, { kind: 'toggleDetails' })).toBe(
       state,
     );
   });

--- a/src/test-kernel/cli/ChildListSelection.vitest.mts
+++ b/src/test-kernel/cli/ChildListSelection.vitest.mts
@@ -98,6 +98,21 @@ describe('CLI child list selection', () => {
     });
   });
 
+  it('preserves hidden details when active-stream sync keeps the same row', () => {
+    const hidden: ChildListSelectionState = {
+      focused: true,
+      selectedValue: mainValue,
+      detailsVisible: false,
+    };
+    const state = reduceChildListSelection(hidden, {
+      kind: 'syncActiveStream',
+      streamId: main,
+      values: [mainValue, strategyValue],
+    });
+
+    expect(state).toBe(hidden);
+  });
+
   it('clears a stale row when the active stream is not in the projected list', () => {
     const state = reduceChildListSelection(
       { focused: true, selectedValue: strategyValue, detailsVisible: true },

--- a/src/test-kernel/cli/MultiAgentPresets.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentPresets.vitest.mts
@@ -43,6 +43,13 @@ function findPreset(id: string) {
 }
 
 describe('CLI multi-agent presets', () => {
+  it('includes critical review in the mathematician team', () => {
+    const preset = findPreset('mathematician');
+
+    expect(preset.workflowAgents).toContain('criticize');
+    expect(preset.texraHostedAgents).toContain('criticize');
+  });
+
   it('preserves missing hosted provenance on a legacy custom preset', () => {
     const presets = cliMultiAgentPresets([
       {

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -258,7 +258,7 @@ describe('CLI StatusBar display model', () => {
     expect(display.bindings).toContain('Up/Down select');
     expect(display.bindings).toContain('Enter focus');
     expect(display.bindings).toContain('v full output');
-    expect(display.bindings).toContain('i files');
+    expect(display.bindings).toContain('i details');
     expect(display.bindings).toContain('k kill');
     expect(display.bindings).toContain('Tab input');
     expect(display.bindings).toContain('Esc input');
@@ -279,7 +279,7 @@ describe('CLI StatusBar display model', () => {
     expect(display.bindings).toContain('Enter details');
     expect(display.bindings).toContain('k kill');
     expect(display.bindings).not.toContain('v full output');
-    expect(display.bindings).not.toContain('i files');
+    expect(display.bindings).not.toContain('i details');
   });
 
   it('shows foreground actions while a list-owned surface is open', () => {

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -79,9 +79,35 @@ describe('CLI child list display model', () => {
       slice: workflowAgentSlice('devise', {
         status: STREAM_PHASE.RUNNING,
         files,
-        generatedOutput: {
-          roundIndex: 1,
-          paths: ['/tmp/executions/abc/r2/Main.lean'],
+        outputFilesByRound: {
+          0: [
+            {
+              source: 'Main.lean',
+              location: {
+                kind: 'runStorage',
+                executionId: 'exec-abc',
+                relativePath: 'r1/Main.lean',
+                absolutePath: '/tmp/executions/abc/r1/Main.lean',
+              },
+              round: 0,
+              lineage: null,
+              diff: null,
+            },
+          ],
+          1: [
+            {
+              source: 'Main.lean',
+              location: {
+                kind: 'runStorage',
+                executionId: 'exec-abc',
+                relativePath: 'r2/Main.lean',
+                absolutePath: '/tmp/executions/abc/r2/Main.lean',
+              },
+              round: 1,
+              lineage: null,
+              diff: null,
+            },
+          ],
         },
         roundStage: { index: 1, total: 3 },
         conversation: { toolCallCount: 2 },
@@ -93,6 +119,7 @@ describe('CLI child list display model', () => {
       'Progress: running · r2/3 · 2 tool calls',
       'Input: src/Main.lean, src/Lemma.lean',
       'Context: notes/proof.md',
+      'Output r1: /tmp/executions/abc/r1/Main.lean',
       'Output r2: /tmp/executions/abc/r2/Main.lean',
     ]);
     expect(selectedSubagentDetailLines(undefined, 100)).toEqual([]);

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -107,6 +107,18 @@ describe('CLI child list display model', () => {
               lineage: null,
               diff: null,
             },
+            {
+              source: 'Notes.lean',
+              location: {
+                kind: 'runStorage',
+                executionId: 'exec-abc',
+                relativePath: 'r2/Notes.lean',
+                absolutePath: '/tmp/executions/abc/r2/Notes.lean',
+              },
+              round: 1,
+              lineage: null,
+              diff: null,
+            },
           ],
         },
         roundStage: { index: 1, total: 3 },
@@ -120,6 +132,7 @@ describe('CLI child list display model', () => {
       'Input: src/Main.lean, src/Lemma.lean',
       'Context: notes/proof.md',
       'Output r2: /tmp/executions/abc/r2/Main.lean',
+      'Output r2: /tmp/executions/abc/r2/Notes.lean',
       'Output r1: /tmp/executions/abc/r1/Main.lean',
     ]);
     expect(selectedSubagentDetailLines(undefined, 100)).toEqual([]);

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -119,8 +119,8 @@ describe('CLI child list display model', () => {
       'Progress: running · r2/3 · 2 tool calls',
       'Input: src/Main.lean, src/Lemma.lean',
       'Context: notes/proof.md',
-      'Output r1: /tmp/executions/abc/r1/Main.lean',
       'Output r2: /tmp/executions/abc/r2/Main.lean',
+      'Output r1: /tmp/executions/abc/r1/Main.lean',
     ]);
     expect(selectedSubagentDetailLines(undefined, 100)).toEqual([]);
     expect(

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -137,6 +137,20 @@ describe('CLI child list display model', () => {
       'Output r1: /tmp/executions/abc/r1/Main.lean',
     ]);
     expect(selectedSubagentDetailLines(undefined, 100)).toEqual([]);
+    const configuredOutputSession: StreamView = {
+      ...detailSession,
+      slice: workflowAgentSlice('devise', {
+        files: {
+          ...files,
+          output: ['out/Main.lean', 'out/Notes.lean'],
+        },
+      }),
+    };
+    expect(
+      selectedSubagentDetailLines(configuredOutputSession, 100).filter((line) =>
+        line.startsWith('Output:'),
+      ),
+    ).toEqual(['Output: out/Main.lean', 'Output: out/Notes.lean']);
     expect(
       selectedSubagentDetailLines(detailSession, 20).every(
         (line) => line.length <= 20,

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -129,7 +129,8 @@ describe('CLI child list display model', () => {
     expect(selectedSubagentDetailLines(detailSession, 100)).toEqual([
       'Selected workflow agent: devise',
       'Progress: running · r2/3 · 2 tool calls',
-      'Input: src/Main.lean, src/Lemma.lean',
+      'Input: src/Main.lean',
+      'Input: src/Lemma.lean',
       'Context: notes/proof.md',
       'Output r2: /tmp/executions/abc/r2/Main.lean',
       'Output r2: /tmp/executions/abc/r2/Notes.lean',

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -2,11 +2,11 @@ import { describe, expect, it } from 'vitest';
 
 import {
   CHILD_STATUS_MARKER,
-  childFileDisplay,
   childRowMetadataText,
   childStatusColor,
   pendingApprovalRowSuffix,
 } from '@cli/chat/tui/panes/SubagentListDisplay';
+import { selectedSubagentDetailLines } from '@cli/chat/tui/panes/SubagentDetailPanel';
 import {
   SubagentList,
   compactChildRowText,
@@ -64,32 +64,43 @@ function workflowAgentSlice(
 }
 
 describe('CLI child list display model', () => {
-  it('formats only populated run-file categories for badges and details', () => {
+  it('formats selected workflow progress and files outside the list row', () => {
     const files = {
       input: ['src/Main.lean', 'src/Lemma.lean'],
       context: ['notes/proof.md'],
       media: [],
-      output: ['Main.olean'],
+      output: [],
+    };
+    const detailSession: StreamView = {
+      id: 'devise' as StreamTabId,
+      label: 'devise',
+      active: false,
+      parentId: 'main' as StreamTabId,
+      slice: workflowAgentSlice('devise', {
+        status: STREAM_PHASE.RUNNING,
+        files,
+        generatedOutput: {
+          roundIndex: 1,
+          paths: ['/tmp/executions/abc/r2/Main.lean'],
+        },
+        roundStage: { index: 1, total: 3 },
+        conversation: { toolCallCount: 2 },
+      }),
     };
 
-    expect(childFileDisplay(files).badge).toBe('in:2 ctx:1 out:1');
-    expect(childFileDisplay(files, 80).detailLines).toEqual([
-      'Input src/Main.lean, src/Lemma.lean',
-      'Context notes/proof.md',
-      'Output Main.olean',
+    expect(selectedSubagentDetailLines(detailSession, 100)).toEqual([
+      'Selected workflow agent: devise',
+      'Progress: running · r2/3 · 2 tool calls',
+      'Input: src/Main.lean, src/Lemma.lean',
+      'Context: notes/proof.md',
+      'Output r2: /tmp/executions/abc/r2/Main.lean',
     ]);
-    expect(childFileDisplay(undefined)).toEqual({
-      badge: undefined,
-      detailLines: [],
-    });
+    expect(selectedSubagentDetailLines(undefined, 100)).toEqual([]);
     expect(
-      childFileDisplay({ input: [], context: [], media: [], output: [] }).badge,
-    ).toBeUndefined();
-    expect(childFileDisplay(files, 20).detailLines).toEqual([
-      'Input src/Main.lean…',
-      'Context notes/proof…',
-      'Output Main.olean',
-    ]);
+      selectedSubagentDetailLines(detailSession, 20).every(
+        (line) => line.length <= 20,
+      ),
+    ).toBe(true);
   });
 
   it('keeps status markers steady and status colors independent of focus', () => {
@@ -343,7 +354,7 @@ describe('CLI child list display model', () => {
     expect(output).toContain('↓40k');
   });
 
-  it('renders a run-file badge as the least-essential row suffix', async () => {
+  it('keeps run-file metadata out of the compact row', async () => {
     const { ink, React } = await loadInk();
     const run = 'run' as StreamTabId;
     const output = ink.renderToString(
@@ -368,6 +379,8 @@ describe('CLI child list display model', () => {
       { columns: 100 },
     );
 
-    expect(output).toContain('devise completed · in:2 ctx:1');
+    expect(output).toContain('devise completed');
+    expect(output).not.toContain('in:2');
+    expect(output).not.toContain('ctx:1');
   });
 });

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -2739,12 +2739,38 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
     }
   });
 
-  it('streams latest-round absolute workflow outputs into selected-agent state', () => {
+  it('streams every workflow output round into selected-agent state', () => {
     const hub = new SessionEventHub();
     const detach = attachTuiRunFactSubscription(hub);
     const executionId = 'exec-output' as ExecutionId;
 
     try {
+      hub.emit({
+        scope: 'run',
+        streamId: root,
+        event: {
+          type: 'addOutputFiles',
+          streamId: root,
+          executionId,
+          filesByRound: {
+            0: [
+              {
+                source: 'draft.tex',
+                location: {
+                  kind: 'runStorage',
+                  executionId,
+                  relativePath: 'r1/draft.tex',
+                  absolutePath:
+                    '/tmp/texra/executions/exec-output/r1/draft.tex',
+                },
+                round: 0,
+                lineage: null,
+                diff: null,
+              },
+            ],
+          },
+        },
+      });
       hub.emit({
         scope: 'run',
         streamId: root,
@@ -2772,9 +2798,21 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
         },
       });
 
-      expect(streams.get().get(root)?.generatedOutput).toEqual({
-        roundIndex: 1,
-        paths: ['/tmp/texra/executions/exec-output/r2/paper.tex'],
+      expect(streams.get().get(root)?.outputFilesByRound).toEqual({
+        0: [
+          expect.objectContaining({
+            location: expect.objectContaining({
+              absolutePath: '/tmp/texra/executions/exec-output/r1/draft.tex',
+            }),
+          }),
+        ],
+        1: [
+          expect.objectContaining({
+            location: expect.objectContaining({
+              absolutePath: '/tmp/texra/executions/exec-output/r2/paper.tex',
+            }),
+          }),
+        ],
       });
     } finally {
       detach();

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -556,6 +556,8 @@ describe('CLI TUI row allocation', () => {
     ).toEqual({
       bottomPanelRows: 0,
       sessionPanelRows: 0,
+      childListRows: 0,
+      detailPanelRows: 0,
       todosPlanRows: 0,
     });
     expect(
@@ -570,6 +572,8 @@ describe('CLI TUI row allocation', () => {
     ).toEqual({
       bottomPanelRows: 0,
       sessionPanelRows: 0,
+      childListRows: 0,
+      detailPanelRows: 0,
       todosPlanRows: 0,
     });
   });
@@ -586,6 +590,8 @@ describe('CLI TUI row allocation', () => {
     ).toEqual({
       bottomPanelRows: 3,
       sessionPanelRows: 3,
+      childListRows: 3,
+      detailPanelRows: 0,
       todosPlanRows: 0,
     });
   });
@@ -603,6 +609,27 @@ describe('CLI TUI row allocation', () => {
     ).toEqual({
       bottomPanelRows: 7,
       sessionPanelRows: 7,
+      childListRows: 3,
+      detailPanelRows: 4,
+      todosPlanRows: 0,
+    });
+  });
+
+  it('keeps a lone unusable detail row with the child list', () => {
+    expect(
+      allocateConversationBottomPanelRows({
+        maxRows: 10,
+        sessionCount: 2,
+        childListFocused: true,
+        detailContentRows: 4,
+        todosPlanContentRows: 0,
+        transcriptRows: 3,
+      }),
+    ).toEqual({
+      bottomPanelRows: 3,
+      sessionPanelRows: 3,
+      childListRows: 3,
+      detailPanelRows: 0,
       todosPlanRows: 0,
     });
   });
@@ -650,6 +677,8 @@ describe('CLI TUI row allocation', () => {
     expect(allocation).toEqual({
       bottomPanelRows: 0,
       sessionPanelRows: 0,
+      childListRows: 0,
+      detailPanelRows: 0,
       todosPlanRows: 0,
     });
   });
@@ -666,6 +695,8 @@ describe('CLI TUI row allocation', () => {
     ).toEqual({
       bottomPanelRows: 10,
       sessionPanelRows: 8,
+      childListRows: 8,
+      detailPanelRows: 0,
       todosPlanRows: 2,
     });
   });
@@ -682,6 +713,8 @@ describe('CLI TUI row allocation', () => {
     ).toEqual({
       bottomPanelRows: 0,
       sessionPanelRows: 0,
+      childListRows: 0,
+      detailPanelRows: 0,
       todosPlanRows: 0,
     });
   });

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -2739,6 +2739,48 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
     }
   });
 
+  it('streams latest-round absolute workflow outputs into selected-agent state', () => {
+    const hub = new SessionEventHub();
+    const detach = attachTuiRunFactSubscription(hub);
+    const executionId = 'exec-output' as ExecutionId;
+
+    try {
+      hub.emit({
+        scope: 'run',
+        streamId: root,
+        event: {
+          type: 'addOutputFiles',
+          streamId: root,
+          executionId,
+          filesByRound: {
+            1: [
+              {
+                source: 'paper.tex',
+                location: {
+                  kind: 'runStorage',
+                  executionId,
+                  relativePath: 'r2/paper.tex',
+                  absolutePath:
+                    '/tmp/texra/executions/exec-output/r2/paper.tex',
+                },
+                round: 1,
+                lineage: null,
+                diff: null,
+              },
+            ],
+          },
+        },
+      });
+
+      expect(streams.get().get(root)?.generatedOutput).toEqual({
+        roundIndex: 1,
+        paths: ['/tmp/texra/executions/exec-output/r2/paper.tex'],
+      });
+    } finally {
+      detach();
+    }
+  });
+
   it('applies direct usage sequences exactly once', () => {
     const hub = new SessionEventHub();
     const detach = attachTuiRunFactSubscription(hub);

--- a/src/test-kernel/tools/SubagentResults.vitest.ts
+++ b/src/test-kernel/tools/SubagentResults.vitest.ts
@@ -254,8 +254,8 @@ describe('formatSubagentDelivery', () => {
         {
           round: 0,
           relativePath: 'paper.tex',
-          absolutePath: '/ws/paper.tex',
-          location: 'workspace',
+          absolutePath: '/storage/executions/abc123/paper.tex',
+          location: 'runStorage',
           originalPath: '/ws/.texra/paper.orig.tex',
           added: 3,
           removed: 1,
@@ -276,7 +276,10 @@ describe('formatSubagentDelivery', () => {
     );
     expect(delivery).toContain('read the output files directly');
     expect(delivery).toContain('<file path="paper.tex"');
-    expect(delivery).toContain('absolute-path="/ws/paper.tex"');
+    expect(delivery).toContain(
+      'read-path="/executions/abc123/files/paper.tex"',
+    );
+    expect(delivery).not.toContain('absolute-path=');
   });
 
   it('omits the diffs-unavailable element on clean deliveries', () => {

--- a/src/test-kernel/tools/SubagentResults.vitest.ts
+++ b/src/test-kernel/tools/SubagentResults.vitest.ts
@@ -276,6 +276,7 @@ describe('formatSubagentDelivery', () => {
     );
     expect(delivery).toContain('read the output files directly');
     expect(delivery).toContain('<file path="paper.tex"');
+    expect(delivery).toContain('absolute-path="/ws/paper.tex"');
   });
 
   it('omits the diffs-unavailable element on clean deliveries', () => {

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -49,18 +49,24 @@ export type SubagentResultMeta = Extract<ResultMeta, { producer: 'subagent' }>;
 
 /**
  * Format a single output file summary as XML. `path` remains run-relative for
- * acceptance tools; `absolute-path` points directly to the generated artifact.
+ * acceptance tools; `read-path` identifies the model-facing route to inspect
+ * the generated artifact.
  * When diff info is provided, includes a `diff` attribute pointing to the diff
  * file path (readable via /executions/{id}/files/...). Large changes are
  * flagged with `large-change="true"` but still include a diff file.
  */
 function formatOutputFile(
   o: OutputFileSummary,
+  executionId: ExecutionId,
   diffInfo?: ResultDiffSummary,
 ): string {
+  const readPath =
+    o.location === 'runStorage'
+      ? `/executions/${executionId}/files/${o.relativePath}`
+      : o.absolutePath;
   const attrs = [
     `path="${escapeAttr(o.relativePath)}"`,
-    `absolute-path="${escapeAttr(o.absolutePath)}"`,
+    `read-path="${escapeAttr(readPath)}"`,
     `location="${escapeAttr(o.location)}"`,
     o.originalPath !== null && `original="${escapeAttr(o.originalPath)}"`,
     o.added !== null && `added="${o.added}"`,
@@ -84,6 +90,7 @@ function formatOutputFile(
  */
 function formatWorkflowOutputs(
   outputs: OutputFileSummary[],
+  executionId: ExecutionId,
   diffInfos?: ReadonlyMap<string, ResultDiffSummary>,
 ): string[] {
   const rounds = new Set(outputs.map((o) => o.round));
@@ -91,7 +98,7 @@ function formatWorkflowOutputs(
     return [
       '<output-files>',
       ...outputs.map((o) =>
-        formatOutputFile(o, diffInfos?.get(o.absolutePath)),
+        formatOutputFile(o, executionId, diffInfos?.get(o.absolutePath)),
       ),
       '</output-files>',
     ];
@@ -103,7 +110,7 @@ function formatWorkflowOutputs(
     lines.push(`<round number="${round}">`);
     lines.push(
       ...roundFiles.map((o) =>
-        formatOutputFile(o, diffInfos?.get(o.absolutePath)),
+        formatOutputFile(o, executionId, diffInfos?.get(o.absolutePath)),
       ),
     );
     lines.push('</round>');
@@ -180,7 +187,13 @@ export function formatSubagentDelivery(
       const diffsByPath = new Map(
         result.diffs.map((diff) => [diff.path, diff] as const),
       );
-      lines.push(...formatWorkflowOutputs(result.outputs, diffsByPath));
+      lines.push(
+        ...formatWorkflowOutputs(
+          result.outputs,
+          options.executionId,
+          diffsByPath,
+        ),
+      );
     }
     if (result.compileFailures.length > 0) {
       lines.push('<compile-failures>');

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -48,7 +48,8 @@ export type SubagentResultMeta = Extract<ResultMeta, { producer: 'subagent' }>;
 // ============================================================================
 
 /**
- * Format a single output file summary as XML.
+ * Format a single output file summary as XML. `path` remains run-relative for
+ * acceptance tools; `absolute-path` points directly to the generated artifact.
  * When diff info is provided, includes a `diff` attribute pointing to the diff
  * file path (readable via /executions/{id}/files/...). Large changes are
  * flagged with `large-change="true"` but still include a diff file.
@@ -59,6 +60,7 @@ function formatOutputFile(
 ): string {
   const attrs = [
     `path="${escapeAttr(o.relativePath)}"`,
+    `absolute-path="${escapeAttr(o.absolutePath)}"`,
     `location="${escapeAttr(o.location)}"`,
     o.originalPath !== null && `original="${escapeAttr(o.originalPath)}"`,
     o.added !== null && `added="${o.added}"`,


### PR DESCRIPTION
## Summary

- keep the CLI child-session list compact and show the selected agent's files, live workflow round, and tool-call count in a separate detail surface
- stream latest-round generated files into the CLI with their absolute storage paths, and include an `absolute-path` attribute in workflow completion results while preserving the run-relative `path` used by acceptance tools
- encode inline PDF attachments as data URLs for ChatGPT subscription requests, preventing the Responses route from rejecting raw base64 `file_data`
- add the `criticize` workflow to the built-in Mathematician team

## Design

The selected-agent detail component now owns detailed presentation. Compact rows no longer format or allocate file metadata. The runtime subscription normalizes generated-output events once into per-stream state, so the renderer only displays the latest facts and does not reconstruct output locations.

This matches the extension surface: round and tool progress come from the same structured run events, while workflow files appear outside the stream list.

## Verification

- `npm run format`
- `npm run compile:fast`
- `npm run typecheck`
- `npm run lint` (no errors; one pre-existing warning in `AgentCreatorToolCatalogParity.vitest.mts`)
- `npm test` (759 files passed, 1 skipped; 7,216 tests passed, 4 skipped)
- focused regression suite (251 tests passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OpenAI media encoding and orchestrator-facing subagent result XML, plus a non-trivial CLI layout/state refactor; changes are covered by focused tests but affect provider and delegation surfaces.
> 
> **Overview**
> Refactors the **CLI child-session list** so rows stay compact: file badges and inline expand are removed in favor of a separate **detail panel** (toggle **`i`**) that shows status, round progress, tool-call count, input/context/media paths, and **per-round generated outputs** with absolute storage paths. Bottom-panel layout now splits **list vs detail** row budgets, and selecting a stream opens details automatically while the child list has focus.
> 
> The TUI runtime **merges `addOutputFiles` events** into per-stream `outputFilesByRound` state so the detail view can track workflow rounds without reconstructing paths.
> 
> **ChatGPT subscription PDFs** send inline `file_data` as **`data:application/pdf;base64,...`** instead of raw base64, matching what the Responses API expects.
> 
> **Mathematician** multi-agent preset adds the **`criticize`** workflow (and hosted agent).
> 
> Workflow completion XML for subagents gains a **`read-path`** attribute (e.g. `/executions/{id}/files/...` for run-storage outputs) so parent orchestrators can inspect generated files directly when diffs are unavailable—while run-relative **`path`** stays for acceptance tools.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 736b716149caed017742cc6bb8a4943a3fa6f00d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->