### PR TITLE
fix: freeze shared literal exports

### DIFF
--- a/src/agent/runtime/AgentRuntimeHost.ts
+++ b/src/agent/runtime/AgentRuntimeHost.ts
@@ -32,6 +32,6 @@ export interface AgentRuntimeHost {
   ): void;
 }
 
-export const noopAgentRuntimeHost: AgentRuntimeHost = {
+export const noopAgentRuntimeHost: AgentRuntimeHost = Object.freeze({
   emit: () => {},
-};
+});

--- a/src/common/storage/storageLayout.ts
+++ b/src/common/storage/storageLayout.ts
@@ -1,5 +1,5 @@
 /** Root collection names shared by storage providers and persisted stores. */
-export const WORKSPACE_STORAGE_LAYOUT = {
+export const WORKSPACE_STORAGE_LAYOUT = Object.freeze({
   memory: 'memories',
   runs: 'executions',
   executionLeases: 'executionLeases',
@@ -8,4 +8,4 @@ export const WORKSPACE_STORAGE_LAYOUT = {
   streamData: 'streamData',
   streamLogs: 'streamLogs',
   original: 'original',
-} as const;
+} as const);

--- a/src/latex/latexdiff/diffCommandExecutor.ts
+++ b/src/latex/latexdiff/diffCommandExecutor.ts
@@ -32,7 +32,7 @@ const ERROR_MESSAGES = {
       : `Failed to run ${commandType}`,
 } as const;
 
-export const LATEXDIFF_CITATION_TEXT_COMMAND_EXCLUSIONS = [
+export const LATEXDIFF_CITATION_TEXT_COMMAND_EXCLUSIONS = Object.freeze([
   'cite\\*?',
   'citep\\*?',
   'citet\\*?',
@@ -47,7 +47,7 @@ export const LATEXDIFF_CITATION_TEXT_COMMAND_EXCLUSIONS = [
   'footcite\\*?',
   'supercite\\*?',
   'smartcite\\*?',
-] as const;
+] as const);
 
 export function buildLatexdiffTextCommandExclusionFlag(): string {
   return `--exclude-textcmd=${LATEXDIFF_CITATION_TEXT_COMMAND_EXCLUSIONS.join(',')}`;

--- a/src/latex/latexdiff/mathMarkup.ts
+++ b/src/latex/latexdiff/mathMarkup.ts
@@ -1,4 +1,9 @@
-export const MATH_MARKUP_OPTIONS = ['off', 'whole', 'coarse', 'fine'] as const;
+export const MATH_MARKUP_OPTIONS = Object.freeze([
+  'off',
+  'whole',
+  'coarse',
+  'fine',
+] as const);
 
 export type MathMarkupOption = (typeof MATH_MARKUP_OPTIONS)[number];
 

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -447,7 +447,7 @@ export const PROVIDER_VSCODE_SETTINGS: Record<
  * Provider IDs where users can configure direct API keys — the single source
  * for direct key-provider enumeration.
  */
-export const API_KEY_PROVIDER_IDS = [
+export const API_KEY_PROVIDER_IDS = Object.freeze([
   'openai',
   'anthropic',
   'openRouter',
@@ -460,7 +460,7 @@ export const API_KEY_PROVIDER_IDS = [
   'minimax',
   'glm',
   'meta',
-] as const;
+] as const);
 
 // ============================================================================
 // Model pricing hints

--- a/src/test-kernel/architecture/SharedLiteralImmutability.vitest.ts
+++ b/src/test-kernel/architecture/SharedLiteralImmutability.vitest.ts
@@ -1,0 +1,55 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports
+import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { WORKSPACE_STORAGE_LAYOUT } from '@common/storage/storageLayout';
+import { LATEXDIFF_CITATION_TEXT_COMMAND_EXCLUSIONS } from '@latex/latexdiff/diffCommandExecutor';
+import { MATH_MARKUP_OPTIONS } from '@latex/latexdiff/mathMarkup';
+import { API_KEY_PROVIDER_IDS } from '@shared/constants/providers';
+import { ARXIV_CONSTANTS, CROSSREF_CONSTANTS } from '@tools/citation/constants';
+import { DEFAULT_POLLING_BACKOFF_CONFIG } from '@tools/github/PollingSourceBase';
+import { GoalStore } from '@tools/goal/goalStore';
+import {
+  LEAN_FILE_COMMANDS,
+  LEAN_PROJECT_COMMANDS,
+  LEAN_SERVER_MODE_LABELS,
+} from '@tools/lean/leanTypes';
+import {
+  SETUP_PLATFORM_VSCODE_ONLY_TOOL_NAMES,
+  setupSecrets,
+  texraScopedConfig,
+} from '@tools/setup/platform';
+import { CORE_LATEX_TOOLS, IMAGE_TOOLS } from '@tools/setup/toolProbing';
+
+const SHARED_LITERALS = [
+  ['noopAgentRuntimeHost', noopAgentRuntimeHost],
+  ['DEFAULT_POLLING_BACKOFF_CONFIG', DEFAULT_POLLING_BACKOFF_CONFIG],
+  ['GoalStore', GoalStore],
+  ['setupSecrets', setupSecrets],
+  ['texraScopedConfig', texraScopedConfig],
+  ['ARXIV_CONSTANTS', ARXIV_CONSTANTS],
+  ['CROSSREF_CONSTANTS', CROSSREF_CONSTANTS],
+  ['LEAN_SERVER_MODE_LABELS', LEAN_SERVER_MODE_LABELS],
+  ['WORKSPACE_STORAGE_LAYOUT', WORKSPACE_STORAGE_LAYOUT],
+  ['LEAN_FILE_COMMANDS', LEAN_FILE_COMMANDS],
+  ['LEAN_PROJECT_COMMANDS', LEAN_PROJECT_COMMANDS],
+  ['CORE_LATEX_TOOLS', CORE_LATEX_TOOLS],
+  ['IMAGE_TOOLS', IMAGE_TOOLS],
+  [
+    'SETUP_PLATFORM_VSCODE_ONLY_TOOL_NAMES',
+    SETUP_PLATFORM_VSCODE_ONLY_TOOL_NAMES,
+  ],
+  [
+    'LATEXDIFF_CITATION_TEXT_COMMAND_EXCLUSIONS',
+    LATEXDIFF_CITATION_TEXT_COMMAND_EXCLUSIONS,
+  ],
+  ['MATH_MARKUP_OPTIONS', MATH_MARKUP_OPTIONS],
+  ['API_KEY_PROVIDER_IDS', API_KEY_PROVIDER_IDS],
+] as const;
+
+describe('shared literal exports', () => {
+  it.each(SHARED_LITERALS)('%s is frozen', (_name, value) => {
+    expect(Object.isFrozen(value)).toBe(true);
+  });
+});

--- a/src/test-kernel/architecture/SharedLiteralImmutability.vitest.ts
+++ b/src/test-kernel/architecture/SharedLiteralImmutability.vitest.ts
@@ -27,6 +27,7 @@ const SHARED_LITERALS = [
   ['DEFAULT_POLLING_BACKOFF_CONFIG', DEFAULT_POLLING_BACKOFF_CONFIG],
   ['GoalStore', GoalStore],
   ['setupSecrets', setupSecrets],
+  ['setupSecrets.providers', setupSecrets.providers],
   ['texraScopedConfig', texraScopedConfig],
   ['ARXIV_CONSTANTS', ARXIV_CONSTANTS],
   ['CROSSREF_CONSTANTS', CROSSREF_CONSTANTS],

--- a/src/test-kernel/model/ApiProviders.vitest.ts
+++ b/src/test-kernel/model/ApiProviders.vitest.ts
@@ -14,7 +14,24 @@ import {
 } from '@model/apiProviders';
 import type { PlatformSecrets } from '@platform/secrets';
 import { UnsetApiKeyTool } from '@tools/setup/UnsetApiKeyTool';
-import { setSetupPlatform, setupSecrets } from '@tools/setup/platform';
+import { setSetupPlatform } from '@tools/setup/platform';
+
+const setupSecretsMocks = vi.hoisted(() => ({
+  deleteApiKey: vi.fn<(provider: ApiProvider) => Promise<void>>(),
+  hasUsableApiKey: vi.fn<(provider: ApiProvider) => Promise<boolean>>(),
+  storedApiKeyExists: vi.fn<(provider: ApiProvider) => Promise<boolean>>(),
+}));
+
+vi.mock('@tools/setup/platform', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tools/setup/platform')>();
+  return {
+    ...actual,
+    setupSecrets: {
+      ...actual.setupSecrets,
+      ...setupSecretsMocks,
+    },
+  };
+});
 
 function createSecrets(
   initial: Record<string, string> = {},
@@ -64,18 +81,16 @@ function setupApiKeyToolPlatform(
   store: Map<string, string>,
   envProviders: ReadonlySet<ApiProvider> = new Set(),
 ): void {
-  vi.spyOn(setupSecrets, 'deleteApiKey').mockImplementation(
-    async (provider) => {
-      store.delete(apiKeySecretName(provider));
-    },
-  );
-  vi.spyOn(setupSecrets, 'hasUsableApiKey').mockImplementation(
+  setupSecretsMocks.deleteApiKey.mockImplementation(async (provider) => {
+    store.delete(apiKeySecretName(provider));
+  });
+  setupSecretsMocks.hasUsableApiKey.mockImplementation(
     async (provider) =>
       (store.get(apiKeySecretName(provider))?.trim().length ?? 0) > 0 ||
       envProviders.has(provider),
   );
-  vi.spyOn(setupSecrets, 'storedApiKeyExists').mockImplementation(
-    async (provider) => store.has(apiKeySecretName(provider)),
+  setupSecretsMocks.storedApiKeyExists.mockImplementation(async (provider) =>
+    store.has(apiKeySecretName(provider)),
   );
   setSetupPlatform({
     host: 'cli',
@@ -89,6 +104,9 @@ function setupApiKeyToolPlatform(
 describe('API provider key caches', () => {
   beforeEach(() => {
     invalidateApiKeyCache();
+    setupSecretsMocks.deleteApiKey.mockReset();
+    setupSecretsMocks.hasUsableApiKey.mockReset();
+    setupSecretsMocks.storedApiKeyExists.mockReset();
   });
 
   afterEach(() => {

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -11,6 +11,16 @@ import * as path from 'node:path';
 // Third-party imports
 import { describe, expect, it, vi } from 'vitest';
 
+vi.mock('@tools/goal', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tools/goal')>();
+  return {
+    ...actual,
+    // ProgressBackend tests replace cleanup methods to exercise failures.
+    // The GoalStore suite separately tests the canonical frozen singleton.
+    GoalStore: { ...actual.GoalStore },
+  };
+});
+
 // Local imports
 import type { AgentEvent } from '@agent/trace';
 import {

--- a/src/test-kernel/tools/setup/ConfigTools.vitest.ts
+++ b/src/test-kernel/tools/setup/ConfigTools.vitest.ts
@@ -3,7 +3,29 @@ import { strict as assert } from 'node:assert';
 import { afterEach, describe, it, vi } from 'vitest';
 
 import { ReadConfigTool, UpdateConfigTool } from '@tools/setup/ConfigTools';
-import { texraScopedConfig } from '@tools/setup/platform';
+
+const mocks = vi.hoisted(() => ({
+  get: vi.fn<(key: string) => unknown>(),
+  update:
+    vi.fn<
+      (
+        key: string,
+        value: unknown,
+        target: 'user' | 'workspace',
+      ) => Promise<void>
+    >(),
+}));
+
+vi.mock('@tools/setup/platform', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tools/setup/platform')>();
+  return {
+    ...actual,
+    texraScopedConfig: {
+      get: mocks.get,
+      update: mocks.update,
+    },
+  };
+});
 
 interface UpdateRecord {
   key: string;
@@ -17,18 +39,17 @@ function createPlatform(initial: Record<string, unknown> = {}): {
 } {
   const store: Record<string, unknown> = { ...initial };
   const updates: UpdateRecord[] = [];
-  vi.spyOn(texraScopedConfig, 'get').mockImplementation((key) => store[key]);
-  vi.spyOn(texraScopedConfig, 'update').mockImplementation(
-    async (key, value, target) => {
-      updates.push({ key, value, target });
-      store[key] = value;
-    },
-  );
+  mocks.get.mockImplementation((key) => store[key]);
+  mocks.update.mockImplementation(async (key, value, target) => {
+    updates.push({ key, value, target });
+    store[key] = value;
+  });
   return { store, updates };
 }
 
 afterEach(() => {
-  vi.restoreAllMocks();
+  mocks.get.mockReset();
+  mocks.update.mockReset();
 });
 
 describe('ConfigTools — read_config', () => {

--- a/src/test-kernel/tools/setup/CredentialReporting.vitest.ts
+++ b/src/test-kernel/tools/setup/CredentialReporting.vitest.ts
@@ -1,37 +1,44 @@
 // Third-party imports
 import { strict as assert } from 'node:assert';
-import { afterEach, describe, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, it, vi } from 'vitest';
 
 // Local imports
 import { ProbeEnvironmentTool } from '@tools/setup/ProbeEnvironmentTool';
 import { VerifySetupTool } from '@tools/setup/VerifySetupTool';
 import * as setupPlatformModule from '@tools/setup/platform';
-import { setSetupPlatform, setupSecrets } from '@tools/setup/platform';
+import { setSetupPlatform } from '@tools/setup/platform';
 
 // Local file imports
 import { createFakeSetupPlatform } from './fixtures';
 
-const ORIGINAL_PROVIDERS = setupSecrets.providers;
+const mocks = vi.hoisted(() => ({
+  apiKeyOrigin: vi.fn<() => Promise<'secret' | 'env' | 'none' | 'unknown'>>(),
+  anyUsableCredentialExists: vi.fn<() => Promise<boolean>>(),
+}));
+
+vi.mock('@tools/setup/platform', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tools/setup/platform')>();
+  return {
+    ...actual,
+    setupSecrets: {
+      ...actual.setupSecrets,
+      providers: ['deepseek'],
+      apiKeyOrigin: mocks.apiKeyOrigin,
+      anyUsableCredentialExists: mocks.anyUsableCredentialExists,
+    },
+  };
+});
 
 function installSetupPlatformWithSecrets(options: {
-  providers?: typeof setupSecrets.providers;
-  apiKeyOrigin?: typeof setupSecrets.apiKeyOrigin;
-  anyUsableCredentialExists?: typeof setupSecrets.anyUsableCredentialExists;
+  apiKeyOrigin?: () => Promise<'secret' | 'env' | 'none' | 'unknown'>;
+  anyUsableCredentialExists?: () => Promise<boolean>;
 }): void {
   setSetupPlatform(createFakeSetupPlatform());
-  if (options.providers) {
-    Object.defineProperty(setupSecrets, 'providers', {
-      configurable: true,
-      value: options.providers,
-    });
-  }
   if (options.apiKeyOrigin) {
-    vi.spyOn(setupSecrets, 'apiKeyOrigin').mockImplementation(
-      options.apiKeyOrigin,
-    );
+    mocks.apiKeyOrigin.mockImplementation(options.apiKeyOrigin);
   }
   if (options.anyUsableCredentialExists) {
-    vi.spyOn(setupSecrets, 'anyUsableCredentialExists').mockImplementation(
+    mocks.anyUsableCredentialExists.mockImplementation(
       options.anyUsableCredentialExists,
     );
   }
@@ -39,7 +46,7 @@ function installSetupPlatformWithSecrets(options: {
 
 function installChatGptOnlySetupPlatform(): void {
   setSetupPlatform(createFakeSetupPlatform());
-  vi.spyOn(setupSecrets, 'anyUsableCredentialExists').mockResolvedValue(true);
+  mocks.anyUsableCredentialExists.mockResolvedValue(true);
   vi.spyOn(
     setupPlatformModule,
     'getChatGptSubscriptionStatus',
@@ -60,30 +67,28 @@ async function assertAuthPrecedesCredentialProbe(
       };
     },
   );
-  vi.spyOn(setupSecrets, 'anyUsableCredentialExists').mockImplementation(
-    async () => {
-      calls.push('credential');
-      return false;
-    },
-  );
+  mocks.anyUsableCredentialExists.mockImplementation(async () => {
+    calls.push('credential');
+    return false;
+  });
 
   await run();
 
   assert.deepEqual(calls, ['auth', 'credential']);
 }
 
+beforeEach(() => {
+  mocks.apiKeyOrigin.mockReset().mockResolvedValue('none');
+  mocks.anyUsableCredentialExists.mockReset().mockResolvedValue(false);
+});
+
 afterEach(() => {
   vi.restoreAllMocks();
-  Object.defineProperty(setupSecrets, 'providers', {
-    configurable: true,
-    value: ORIGINAL_PROVIDERS,
-  });
 });
 
 describe('setup credential reporting', () => {
   it('reports the active host and provider-key origin without secret values', async () => {
     installSetupPlatformWithSecrets({
-      providers: ['deepseek'],
       async apiKeyOrigin() {
         return 'env';
       },
@@ -121,7 +126,6 @@ describe('setup credential reporting', () => {
 
   it('keeps probing when one provider key origin is unavailable', async () => {
     installSetupPlatformWithSecrets({
-      providers: ['openai'],
       async apiKeyOrigin() {
         throw new Error('Keychain unavailable');
       },

--- a/src/test-kernel/tools/setup/ListApiKeysTool.vitest.ts
+++ b/src/test-kernel/tools/setup/ListApiKeysTool.vitest.ts
@@ -9,7 +9,6 @@ import { apiKeySecretName } from '@model/apiProviders';
 import { GITHUB_TOKEN_STORAGE_KEY } from '@tools/github/githubAuth';
 import { ListApiKeysTool } from '@tools/setup/ListApiKeysTool';
 
-const FAKE_PROVIDERS = ['anthropic', 'openai'] as const;
 const mocks = vi.hoisted(() => ({
   listStoredKeys: vi.fn<() => Promise<readonly string[]>>(),
 }));

--- a/src/test-kernel/tools/setup/ListApiKeysTool.vitest.ts
+++ b/src/test-kernel/tools/setup/ListApiKeysTool.vitest.ts
@@ -2,25 +2,34 @@
 import { strict as assert } from 'node:assert';
 
 // Third-party imports
-import { afterEach, describe, it, vi } from 'vitest';
+import { beforeEach, describe, it, vi } from 'vitest';
 
 // Local imports
 import { apiKeySecretName } from '@model/apiProviders';
 import { GITHUB_TOKEN_STORAGE_KEY } from '@tools/github/githubAuth';
 import { ListApiKeysTool } from '@tools/setup/ListApiKeysTool';
-import { setupSecrets } from '@tools/setup/platform';
 
 const FAKE_PROVIDERS = ['anthropic', 'openai'] as const;
-const ORIGINAL_PROVIDERS = setupSecrets.providers;
+const mocks = vi.hoisted(() => ({
+  listStoredKeys: vi.fn<() => Promise<readonly string[]>>(),
+}));
+
+vi.mock('@tools/setup/platform', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tools/setup/platform')>();
+  return {
+    ...actual,
+    setupSecrets: {
+      ...actual.setupSecrets,
+      providers: ['anthropic', 'openai'],
+      listStoredKeys: mocks.listStoredKeys,
+    },
+  };
+});
 
 function installPlatform(
   listStoredKeys: () => Promise<readonly string[]>,
 ): void {
-  Object.defineProperty(setupSecrets, 'providers', {
-    configurable: true,
-    value: FAKE_PROVIDERS,
-  });
-  vi.spyOn(setupSecrets, 'listStoredKeys').mockImplementation(listStoredKeys);
+  mocks.listStoredKeys.mockImplementation(listStoredKeys);
 }
 
 function installPlatformWithKeys(keys: readonly string[]): void {
@@ -29,12 +38,8 @@ function installPlatformWithKeys(keys: readonly string[]): void {
 
 const tool = new ListApiKeysTool();
 
-afterEach(() => {
-  vi.restoreAllMocks();
-  Object.defineProperty(setupSecrets, 'providers', {
-    configurable: true,
-    value: ORIGINAL_PROVIDERS,
-  });
+beforeEach(() => {
+  mocks.listStoredKeys.mockReset();
 });
 
 describe('list_api_keys tool', () => {

--- a/src/tools/citation/constants.ts
+++ b/src/tools/citation/constants.ts
@@ -8,7 +8,7 @@ import { CrossrefClient as CrossrefApiClient } from '@jamesgopsill/crossref-clie
 export const CrossrefClient = new CrossrefApiClient();
 
 // arXiv API constants
-export const ARXIV_CONSTANTS = {
+export const ARXIV_CONSTANTS = Object.freeze({
   /** Maximum number of results allowed per arXiv search request */
   MAX_RESULTS: 50,
   /** Default number of results for arXiv searches */
@@ -17,14 +17,14 @@ export const ARXIV_CONSTANTS = {
   MAX_AUTHORS: 50,
   /** arXiv API rate limit: approximately 1 request per 3 seconds */
   RATE_LIMIT_DELAY_MS: 3000,
-} as const;
+} as const);
 
 // Crossref API constants
-export const CROSSREF_CONSTANTS = {
+export const CROSSREF_CONSTANTS = Object.freeze({
   /** Maximum number of results allowed per Crossref search request */
   MAX_ROWS: 100,
   /** Default number of results for Crossref searches */
   DEFAULT_ROWS: 10,
   /** Crossref API is more lenient, but add conservative delay to be respectful */
   RATE_LIMIT_DELAY_MS: 1000,
-} as const;
+} as const);

--- a/src/tools/github/PollingSourceBase.ts
+++ b/src/tools/github/PollingSourceBase.ts
@@ -54,14 +54,14 @@ type SuccessfulConditionalResponse<T> = Extract<
   { status: 200 }
 >;
 
-export const DEFAULT_POLLING_BACKOFF_CONFIG = {
+export const DEFAULT_POLLING_BACKOFF_CONFIG = Object.freeze({
   backoffBaseMs: 60_000,
   backoffMaxMs: 3_600_000,
   maxFailureDurationMs: 24 * 3_600_000,
 } satisfies Pick<
   PollingSourceConfig,
   'backoffBaseMs' | 'backoffMaxMs' | 'maxFailureDurationMs'
->;
+>);
 
 interface DedupedResourceOptions<T, Id> {
   getId(item: T): Id;

--- a/src/tools/goal/goalStore.ts
+++ b/src/tools/goal/goalStore.ts
@@ -193,7 +193,7 @@ export function subscribeGoalStateChanges(
   );
 }
 
-export const GoalStore = {
+export const GoalStore = Object.freeze({
   /**
    * Get the goal for a stream, or null when none exists.
    *
@@ -348,4 +348,4 @@ export const GoalStore = {
     );
     await GoalStore.forgetMany(streamIds, session);
   },
-};
+});

--- a/src/tools/lean/leanTypes.ts
+++ b/src/tools/lean/leanTypes.ts
@@ -13,11 +13,14 @@ import type { GenericDiagnostic } from '@utils/diagnostics/diagnosticFormatting'
 export const LEAN4_EXTENSION_ID = 'leanprover.lean4';
 
 /** Per-file commands surfaced by `lean_file`. */
-export const LEAN_FILE_COMMANDS = ['restart', 'refresh_dependencies'] as const;
+export const LEAN_FILE_COMMANDS = Object.freeze([
+  'restart',
+  'refresh_dependencies',
+] as const);
 export type LeanFileCommand = (typeof LEAN_FILE_COMMANDS)[number];
 
 /** Project-scope commands surfaced by `lean_project`. */
-export const LEAN_PROJECT_COMMANDS = [
+export const LEAN_PROJECT_COMMANDS = Object.freeze([
   // Server commands
   'restart_server',
   'stop_server',
@@ -31,14 +34,14 @@ export const LEAN_PROJECT_COMMANDS = [
   'install_deps',
   'update_elan',
   'select_toolchain',
-] as const;
+] as const);
 export type LeanProjectCommand = (typeof LEAN_PROJECT_COMMANDS)[number];
 
 /** Human-readable label for each server mode (used in the dashboard surface). */
-export const LEAN_SERVER_MODE_LABELS = {
+export const LEAN_SERVER_MODE_LABELS = Object.freeze({
   'vscode-extension': LEAN4_EXTENSION_ID,
   'direct-lsp': 'direct LSP',
-} as const;
+} as const);
 
 // LSP contracts
 

--- a/src/tools/setup/platform.ts
+++ b/src/tools/setup/platform.ts
@@ -104,11 +104,11 @@ export interface SetupPlatform {
 }
 
 /** Setup tools that require a VS Code-specific adapter. */
-export const SETUP_PLATFORM_VSCODE_ONLY_TOOL_NAMES = [
+export const SETUP_PLATFORM_VSCODE_ONLY_TOOL_NAMES = Object.freeze([
   'invoke_command',
   'install_vscode_extension',
   'send_to_terminal',
-] as const;
+] as const);
 
 function assertTexraScopedKey(key: string): void {
   if (!key.startsWith('texra.')) {
@@ -151,23 +151,25 @@ export async function getSetupAuthStatus(): Promise<{
 }
 
 /** Value-free credential capability exposed to setup tools. */
-export const setupSecrets: SetupSecretsAdapter = {
-  providers: API_PROVIDERS,
-  deleteApiKey: (provider) =>
-    currentPlatform().secrets.delete(apiKeySecretName(provider)),
-  hasUsableApiKey: (provider) =>
-    hasUsableApiKey(currentPlatform().secrets, provider),
-  apiKeyOrigin: (provider) =>
-    lookupApiKeyOrigin(currentPlatform().secrets, provider),
-  storedApiKeyExists: async (provider) =>
-    (await currentPlatform().secrets.listStoredKeys()).includes(
-      apiKeySecretName(provider),
-    ),
-  anyUsableCredentialExists: () =>
-    hasUsableSetupCredential(currentPlatform().secrets),
-  gitHubTokenExists: () => resolveGitHubTokenSource(currentPlatform().secrets),
-  listStoredKeys: () => currentPlatform().secrets.listStoredKeys(),
-};
+export const setupSecrets: SetupSecretsAdapter =
+  Object.freeze<SetupSecretsAdapter>({
+    providers: API_PROVIDERS,
+    deleteApiKey: (provider) =>
+      currentPlatform().secrets.delete(apiKeySecretName(provider)),
+    hasUsableApiKey: (provider) =>
+      hasUsableApiKey(currentPlatform().secrets, provider),
+    apiKeyOrigin: (provider) =>
+      lookupApiKeyOrigin(currentPlatform().secrets, provider),
+    storedApiKeyExists: async (provider) =>
+      (await currentPlatform().secrets.listStoredKeys()).includes(
+        apiKeySecretName(provider),
+      ),
+    anyUsableCredentialExists: () =>
+      hasUsableSetupCredential(currentPlatform().secrets),
+    gitHubTokenExists: () =>
+      resolveGitHubTokenSource(currentPlatform().secrets),
+    listStoredKeys: () => currentPlatform().secrets.listStoredKeys(),
+  });
 
 /** Subscription access reported separately from provider API keys. */
 export async function getChatGptSubscriptionStatus(): Promise<{
@@ -187,7 +189,7 @@ export async function getChatGptSubscriptionStatus(): Promise<{
 }
 
 /** Configuration operations scoped to `texra.*` keys. */
-export const texraScopedConfig = {
+export const texraScopedConfig = Object.freeze({
   get(key: string): unknown {
     assertTexraScopedKey(key);
     return currentPlatform().config.get(key);
@@ -204,7 +206,7 @@ export const texraScopedConfig = {
       target === 'workspace' ? 'workspace' : 'global',
     );
   },
-};
+});
 
 let override: SetupPlatform | undefined;
 

--- a/src/tools/setup/toolProbing.ts
+++ b/src/tools/setup/toolProbing.ts
@@ -12,7 +12,7 @@ import { BinaryResolver } from '@utils/system/binaryResolver';
  * Keep both the tool descriptions (ProbeEnvironmentTool / VerifySetupTool)
  * aligned with these lists — they appear verbatim in the LLM prompt.
  */
-export const CORE_LATEX_TOOLS = [
+export const CORE_LATEX_TOOLS = Object.freeze([
   'pdflatex',
   'latexmk',
   'latexindent',
@@ -20,9 +20,9 @@ export const CORE_LATEX_TOOLS = [
   'texcount',
   'perl',
   'gs',
-] as const;
+] as const);
 
-export const IMAGE_TOOLS = ['gm', 'magick'] as const;
+export const IMAGE_TOOLS = Object.freeze(['gm', 'magick'] as const);
 
 /**
  * Resolve a tool as installed by (1) the known-tool check which spawns


### PR DESCRIPTION
## Summary

- Freeze the 16 module-level object and array exports identified in #9059.
- Freeze the provider-ID array exposed through the setup-secrets adapter, so the adapter does not retain a mutable nested shared value.
- Adapt focused tests to mock their platform and goal-store boundaries instead of overwriting production singletons.
- Add an architecture regression test covering all 17 frozen exports.

## Why

TypeScript `readonly` and `as const` prevent mutation only during type checking. The exported values remained mutable at runtime, so one consumer could accidentally change process-wide constants or singleton methods for every other consumer. `Object.freeze` makes the existing shared-value contracts effective at runtime while preserving their current identities and singleton semantics.

## Impact

There is no intended user-visible behavior change. Attempts to mutate these shared exports are now rejected at runtime. Consumers that only read or call them continue to use the same interfaces.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (0 errors; one pre-existing unrelated warning)
- `npm test -- --reporter=dot` (760 files passed, 7,241 tests passed, 4 skipped)

Closes #9059

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No intended behavior change for readers of these exports; risk is limited to tests or code that relied on mutating shared literals at runtime.
> 
> **Overview**
> Wraps **17** module-level shared exports in `Object.freeze()` so `as const` / `readonly` contracts hold at runtime, not only in TypeScript. Affected surfaces include setup adapters (`setupSecrets`, `texraScopedConfig`), `GoalStore`, storage layout, LaTeX/Lean/citation constants, API provider IDs, and related tool lists.
> 
> Adds **`SharedLiteralImmutability.vitest.ts`** to assert each listed export is frozen. **Tests** that previously `spyOn`’d or `defineProperty`’d frozen singletons now use **`vi.mock`** on `@tools/setup/platform` (or a shallow `GoalStore` copy in `ProgressBackend` tests) so mocks don’t mutate production exports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f519fe7446397c51f02cc30cbb7f1fbecb75d5fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->