### PR TITLE
refactor: stream housekeeping cleanup

### DIFF
--- a/src/housekeeping/clean.ts
+++ b/src/housekeeping/clean.ts
@@ -40,44 +40,20 @@ export async function runCleanSingle(
   logger.debug(CHANNEL, `Using extensions: ${extensions}`);
 
   try {
-    let firstFile: string | undefined;
-    let deletedFile = false;
-
-    // Preserve the legacy safety rule that a lone match equal to the input
-    // document is not deleted, while retaining at most this one deferred path.
+    let foundFile = false;
     for await (const filePath of findFilesFromPatterns(
       inputDir,
       filePatterns,
       extensions,
     )) {
-      if (firstFile === undefined) {
-        firstFile = filePath;
-        continue;
-      }
-
-      if (!deletedFile && filePath === firstFile) {
-        continue;
-      }
-
-      if (!deletedFile) {
-        logger.debug(CHANNEL, `Deleting file: ${firstFile}`);
-        await WorkspaceFS.delete(firstFile);
-        deletedFile = true;
-      }
-
       logger.debug(CHANNEL, `Deleting file: ${filePath}`);
       await WorkspaceFS.delete(filePath);
-      deletedFile = true;
+      foundFile = true;
     }
 
-    if (firstFile === undefined || (!deletedFile && firstFile === inputFile)) {
+    if (!foundFile) {
       logger.warn(CHANNEL, `No matching files found to clean for ${inputFile}`);
       return { status: 'noFiles' };
-    }
-
-    if (!deletedFile) {
-      logger.debug(CHANNEL, `Deleting file: ${firstFile}`);
-      await WorkspaceFS.delete(firstFile);
     }
 
     logger.info(CHANNEL, `Cleanup complete for ${inputFile}`);

--- a/src/housekeeping/clean.ts
+++ b/src/housekeeping/clean.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { sync as globSync } from 'glob';
+import { globIterate } from 'glob';
 import { MODELS } from 'llm-zoo';
 
 // Internal imports
@@ -39,25 +39,47 @@ export async function runCleanSingle(
   const extensions = [...TEMP_EXTENSIONS, ...PACK_EXTENSIONS];
   logger.debug(CHANNEL, `Using extensions: ${extensions}`);
 
-  const filesToDelete = findFilesFromPatterns(
-    inputDir,
-    filePatterns,
-    extensions,
-  );
-
-  const onlyInputFileFound =
-    filesToDelete.length === 1 && filesToDelete[0] === inputFile;
-
-  if (onlyInputFileFound || filesToDelete.length === 0) {
-    logger.warn(CHANNEL, `No matching files found to clean for ${inputFile}`);
-    return { status: 'noFiles' };
-  }
-
   try {
-    logger.debug(CHANNEL, `Files to delete:\n${filesToDelete.join('\n')}`);
-    for (const filePath of filesToDelete) {
+    let firstFile: string | undefined;
+    let deletedFile = false;
+
+    // Preserve the legacy safety rule that a lone match equal to the input
+    // document is not deleted, while retaining at most this one deferred path.
+    for await (const filePath of findFilesFromPatterns(
+      inputDir,
+      filePatterns,
+      extensions,
+    )) {
+      if (firstFile === undefined) {
+        firstFile = filePath;
+        continue;
+      }
+
+      if (!deletedFile && filePath === firstFile) {
+        continue;
+      }
+
+      if (!deletedFile) {
+        logger.debug(CHANNEL, `Deleting file: ${firstFile}`);
+        await WorkspaceFS.delete(firstFile);
+        deletedFile = true;
+      }
+
+      logger.debug(CHANNEL, `Deleting file: ${filePath}`);
       await WorkspaceFS.delete(filePath);
+      deletedFile = true;
     }
+
+    if (firstFile === undefined || (!deletedFile && firstFile === inputFile)) {
+      logger.warn(CHANNEL, `No matching files found to clean for ${inputFile}`);
+      return { status: 'noFiles' };
+    }
+
+    if (!deletedFile) {
+      logger.debug(CHANNEL, `Deleting file: ${firstFile}`);
+      await WorkspaceFS.delete(firstFile);
+    }
+
     logger.info(CHANNEL, `Cleanup complete for ${inputFile}`);
     return { status: 'success' };
   } catch (err) {
@@ -114,13 +136,11 @@ export async function runCleanBuild(): Promise<void> {
     [...EXCLUDED_DIRS].filter((dir) => dir !== 'build'),
   );
 
-  const buildDirs = globSync('**/build', {
+  for await (const dir of globIterate('**/build', {
     cwd: workspacePath,
     ignore: ignorePatterns,
     nodir: false,
-  });
-
-  for (const dir of buildDirs) {
+  })) {
     try {
       await WorkspaceFS.delete(dir, { recursive: true, useTrash: false });
       logger.debug(CHANNEL, `Removed build directory: ${dir}`);
@@ -150,13 +170,14 @@ export async function runCleanOutput(): Promise<void> {
   // Round-folder layouts like `r0/output.tex` are intentionally excluded:
   // without an active run context they are indistinguishable from user-owned
   // revision folders. Toolbar cleanup removes task-run storage directly.
-  const files = globSync(`**/*_{${modelsPattern}}*.{tex,pdf,xml}`, {
-    cwd: workspacePath,
-    ignore: ignorePatterns,
-    nodir: true,
-  });
-
-  for (const file of files) {
+  for await (const file of globIterate(
+    `**/*_{${modelsPattern}}*.{tex,pdf,xml}`,
+    {
+      cwd: workspacePath,
+      ignore: ignorePatterns,
+      nodir: true,
+    },
+  )) {
     await WorkspaceFS.delete(file);
   }
 

--- a/src/housekeeping/latexdiff.ts
+++ b/src/housekeeping/latexdiff.ts
@@ -45,24 +45,33 @@ export async function runPackLatexdiffvc(
   const inputDir = path.dirname(inputFile);
   const filePatterns = [`${baseName}-diff${commitHash}`];
 
-  const mainFiles = findFilesFromPatterns(inputDir, filePatterns, [
+  const mainFiles = new Set<string>();
+  for await (const file of findFilesFromPatterns(inputDir, filePatterns, [
     '.tex',
     '.pdf',
-  ]);
-  const tempFiles = findFilesFromPatterns(
+  ])) {
+    mainFiles.add(file);
+  }
+
+  const tempFiles = new Set<string>();
+  for await (const file of findFilesFromPatterns(
     inputDir,
     filePatterns,
     TEMP_EXTENSIONS,
-  );
+  )) {
+    tempFiles.add(file);
+  }
 
-  if (mainFiles.length === 0 && tempFiles.length === 0) {
+  if (mainFiles.size === 0 && tempFiles.size === 0) {
     logger.warn(CHANNEL, 'No LaTeX diff files found to process');
     return { status: 'no-files', inputFile };
   }
 
   if (clean) {
-    for (const file of [...mainFiles, ...tempFiles]) {
-      await WorkspaceFS.delete(file);
+    for (const files of [mainFiles, tempFiles]) {
+      for (const file of files) {
+        await WorkspaceFS.delete(file);
+      }
     }
     logger.info(CHANNEL, 'Cleanup complete.');
     return { status: 'cleaned', inputFile };

--- a/src/housekeeping/pack.ts
+++ b/src/housekeeping/pack.ts
@@ -50,11 +50,14 @@ export async function runPackSingle(
   // Pack also matches the input document itself (it is copied, not moved).
   const filePatterns = [...targets.filePatterns, baseName];
 
-  const allFiles = findFilesFromPatterns(
+  const allFiles = new Set<string>();
+  for await (const file of findFilesFromPatterns(
     inputDir,
     filePatterns,
     PACK_EXTENSIONS,
-  );
+  )) {
+    allFiles.add(file);
+  }
 
   const movedFiles: string[] = [];
   const copiedFiles: string[] = [];
@@ -241,14 +244,13 @@ async function cleanupTempFiles(
   movedFiles: string[],
   copiedFiles: string[],
 ): Promise<void> {
-  const tempFiles = findFilesFromPatterns(
+  const skip = new Set([...movedFiles, ...copiedFiles]);
+
+  for await (const file of findFilesFromPatterns(
     inputDir,
     filePatterns,
     TEMP_EXTENSIONS,
-  );
-  const skip = new Set([...movedFiles, ...copiedFiles]);
-
-  for (const file of tempFiles) {
+  )) {
     if (!skip.has(file)) {
       await WorkspaceFS.delete(file);
     }

--- a/src/housekeeping/utils.ts
+++ b/src/housekeeping/utils.ts
@@ -191,6 +191,8 @@ export async function* findFilesFromPatterns(
         }
 
         if (foundExactMatch) {
+          // Exact extensions prefer the input directory; `build/` is only the
+          // fallback when the corresponding root-level artifact is absent.
           break;
         }
       }

--- a/src/housekeeping/utils.ts
+++ b/src/housekeeping/utils.ts
@@ -2,7 +2,7 @@
 import * as path from 'node:path';
 
 // Third-party imports
-import { sync as globSync } from 'glob';
+import { globIterate } from 'glob';
 
 // Local imports
 import { buildBetweenRoundDiffSuffix } from '@latex/latexdiff/diffFileNameManager';
@@ -144,11 +144,18 @@ export function resolveHousekeepingTargets(
   return { baseName, inputDir, filePatterns };
 }
 
-export function findFilesFromPatterns(
+/**
+ * Yield matching workspace files as they are discovered.
+ *
+ * Overlapping patterns may yield the same path more than once. Consumers that
+ * retain the complete result set must deduplicate it; cleanup consumers delete
+ * each yielded file before advancing, so later patterns cannot rediscover it.
+ */
+export async function* findFilesFromPatterns(
   inputDir: string,
   patterns: string[],
   extensions: string[],
-): string[] {
+): AsyncGenerator<string, void, void> {
   logger.debug(
     CHANNEL,
     `Finding files in ${inputDir} using patterns ${patterns} and extensions ${extensions}`,
@@ -156,7 +163,7 @@ export function findFilesFromPatterns(
 
   const workspacePath = WorkspaceFS.getPath();
   if (!workspacePath) {
-    return [];
+    return;
   }
 
   const searchDirs = [path.join(workspacePath, inputDir)];
@@ -164,30 +171,29 @@ export function findFilesFromPatterns(
     searchDirs.push(path.join(workspacePath, inputDir, 'build'));
   }
 
-  const results = new Set<string>();
-
   for (const pattern of patterns) {
     for (const ext of extensions) {
       const isGlob = ext.includes('*');
       for (const dir of searchDirs) {
-        const matches = globSync(path.join(dir, `${pattern}${ext}`), {
-          nodir: true,
-        });
-        if (matches.length === 0) continue;
+        let foundExactMatch = false;
+        for await (const match of globIterate(
+          path.join(dir, `${pattern}${ext}`),
+          { nodir: true },
+        )) {
+          const relativePath = WorkspaceFS.relativePath(match);
+          logger.debug(CHANNEL, `Found file: ${relativePath}`);
+          yield relativePath;
 
-        if (isGlob) {
-          for (const match of matches) {
-            results.add(WorkspaceFS.relativePath(match));
+          if (!isGlob) {
+            foundExactMatch = true;
+            break;
           }
-        } else {
-          results.add(WorkspaceFS.relativePath(matches[0]));
+        }
+
+        if (foundExactMatch) {
           break;
         }
       }
     }
   }
-
-  const found = [...results];
-  logger.debug(CHANNEL, `Found files: ${found.join(', ')}`);
-  return found;
 }

--- a/src/test-kernel/housekeeping/HousekeepingStreaming.vitest.ts
+++ b/src/test-kernel/housekeeping/HousekeepingStreaming.vitest.ts
@@ -1,9 +1,10 @@
 // Third-party imports
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Local imports
+import { WorkspaceFS } from '@utils/files';
 
 const mocks = vi.hoisted(() => ({
-  delete: vi.fn(),
-  getPath: vi.fn(() => '/workspace'),
   globIterate: vi.fn(),
 }));
 
@@ -16,18 +17,15 @@ vi.mock('llm-zoo', async (importActual) => ({
   MODELS: ['test-model'],
 }));
 
-vi.mock('@utils/files', () => ({
-  WorkspaceFS: {
-    delete: mocks.delete,
-    getPath: mocks.getPath,
-  },
-}));
-
 const { runCleanOutput } = await import('@housekeeping/clean');
 
 describe('housekeeping streaming cleanup', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('deletes each output before requesting the next match', async () => {
@@ -44,16 +42,19 @@ describe('housekeeping streaming cleanup', () => {
       yield 'second.tex';
     });
 
-    mocks.delete.mockImplementation(async (file: string) => {
-      if (file === 'first.tex') {
-        expect(requestedSecondMatch).toBe(false);
-        releaseSecondMatch?.();
-      }
-    });
+    vi.spyOn(WorkspaceFS, 'getPath').mockReturnValue('/workspace');
+    const deleteFile = vi
+      .spyOn(WorkspaceFS, 'delete')
+      .mockImplementation(async (file: string) => {
+        if (file === 'first.tex') {
+          expect(requestedSecondMatch).toBe(false);
+          releaseSecondMatch?.();
+        }
+      });
 
     await runCleanOutput();
 
-    expect(mocks.delete).toHaveBeenNthCalledWith(1, 'first.tex');
-    expect(mocks.delete).toHaveBeenNthCalledWith(2, 'second.tex');
+    expect(deleteFile).toHaveBeenNthCalledWith(1, 'first.tex');
+    expect(deleteFile).toHaveBeenNthCalledWith(2, 'second.tex');
   });
 });

--- a/src/test-kernel/housekeeping/HousekeepingStreaming.vitest.ts
+++ b/src/test-kernel/housekeeping/HousekeepingStreaming.vitest.ts
@@ -1,0 +1,59 @@
+// Third-party imports
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  delete: vi.fn(),
+  getPath: vi.fn(() => '/workspace'),
+  globIterate: vi.fn(),
+}));
+
+vi.mock('glob', () => ({
+  globIterate: mocks.globIterate,
+}));
+
+vi.mock('llm-zoo', async (importActual) => ({
+  ...(await importActual<typeof import('llm-zoo')>()),
+  MODELS: ['test-model'],
+}));
+
+vi.mock('@utils/files', () => ({
+  WorkspaceFS: {
+    delete: mocks.delete,
+    getPath: mocks.getPath,
+  },
+}));
+
+const { runCleanOutput } = await import('@housekeeping/clean');
+
+describe('housekeeping streaming cleanup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('deletes each output before requesting the next match', async () => {
+    let releaseSecondMatch: (() => void) | undefined;
+    const secondMatchReady = new Promise<void>((resolve) => {
+      releaseSecondMatch = resolve;
+    });
+    let requestedSecondMatch = false;
+
+    mocks.globIterate.mockImplementation(async function* () {
+      yield 'first.tex';
+      requestedSecondMatch = true;
+      await secondMatchReady;
+      yield 'second.tex';
+    });
+
+    mocks.delete.mockImplementation(async (file: string) => {
+      if (file === 'first.tex') {
+        expect(requestedSecondMatch).toBe(false);
+        releaseSecondMatch?.();
+      }
+    });
+
+    await runCleanOutput();
+
+    expect(mocks.delete).toHaveBeenNthCalledWith(1, 'first.tex');
+    expect(mocks.delete).toHaveBeenNthCalledWith(2, 'second.tex');
+  });
+});

--- a/src/test-kernel/shared/LegacyWorkflowOutput.vitest.ts
+++ b/src/test-kernel/shared/LegacyWorkflowOutput.vitest.ts
@@ -132,8 +132,10 @@ describe('filename-era workflow output grammar', () => {
   });
 
   it('deletes a file matched by overlapping legacy patterns only once', async () => {
+    const inputPath = path.join(workspacePath, 'paper.tex');
     const relativePath = 'paper_polish_r0_full_gpt-45.tex';
     const absolutePath = path.join(workspacePath, relativePath);
+    await writeFile(inputPath, 'source');
     await writeFile(absolutePath, 'fixture');
 
     await expect(
@@ -142,5 +144,6 @@ describe('filename-era workflow output grammar', () => {
     await expect(access(absolutePath)).rejects.toMatchObject({
       code: 'ENOENT',
     });
+    await expect(access(inputPath)).resolves.toBeUndefined();
   });
 });

--- a/src/test-kernel/shared/LegacyWorkflowOutput.vitest.ts
+++ b/src/test-kernel/shared/LegacyWorkflowOutput.vitest.ts
@@ -1,5 +1,5 @@
 // Node imports
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { access, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 
@@ -7,10 +7,12 @@ import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 // Local imports
+import { runCleanSingle } from '@housekeeping/clean';
 import {
   findFilesFromPatterns,
   resolveHousekeepingTargets,
 } from '@housekeeping/utils';
+import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import {
   getAgentFirstNameChunk,
   legacyWorkflowOutputRoundRegex,
@@ -27,10 +29,13 @@ describe('filename-era workflow output grammar', () => {
     workspacePath = await mkdtemp(
       path.join(tmpdir(), 'texra-legacy-workflow-output-'),
     );
-    await installPlatform({
-      config: { 'texra.agent.rounds': 2 },
-      workspacePath,
-    });
+    await installPlatform(
+      {
+        config: { 'texra.agent.rounds': 2 },
+        workspacePath,
+      },
+      { fs: nodeFilesystem },
+    );
   });
 
   afterEach(async () => {
@@ -111,15 +116,31 @@ describe('filename-era workflow output grammar', () => {
       throw new Error('Expected valid housekeeping targets');
     }
 
-    const found = findFilesFromPatterns(
+    const found = new Set<string>();
+    for await (const file of findFilesFromPatterns(
       targets.inputDir,
       targets.filePatterns,
       ['.tex'],
-    );
-    expect(found).toHaveLength(matching.length);
-    expect(found).toEqual(expect.arrayContaining(matching));
+    )) {
+      found.add(file);
+    }
+    expect(found.size).toBe(matching.length);
+    expect([...found]).toEqual(expect.arrayContaining(matching));
     for (const relativePath of nonMatching) {
       expect(found).not.toContain(relativePath);
     }
+  });
+
+  it('deletes a file matched by overlapping legacy patterns only once', async () => {
+    const relativePath = 'paper_polish_r0_full_gpt-45.tex';
+    const absolutePath = path.join(workspacePath, relativePath);
+    await writeFile(absolutePath, 'fixture');
+
+    await expect(
+      runCleanSingle('gpt-4.5', 'paper.tex', 'custom:polish_long'),
+    ).resolves.toEqual({ status: 'success' });
+    await expect(access(absolutePath)).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Replace synchronous workspace glob enumeration in housekeeping cleanup with the asynchronous `globIterate` API.
- Delete build directories, generated outputs, and temporary artifacts as each match is discovered.
- Keep pattern discovery as the single source of truth; packing paths collect into `Set` values only where later classification requires the complete result set.
- Preserve exact-pattern fallback behavior and overlapping-pattern handling.

## Why

The cleanup commands previously materialized every matching path before performing the first deletion. Peak memory and startup delay therefore grew with the total number of matches, even though cleanup itself only needs one path at a time.

The new iterator observes backpressure from each deletion. Cleanup retains no application-level collection of discovered paths, while packing retains complete sets only where its semantics require them.

## Impact

There is no intended change to which workspace artifacts are cleaned or packed. Cleanup now starts before traversal completes and no longer holds an application-level collection of all matching paths.

## Validation

- `npm run format`
- `npm run compile:safe`
- `npm run lint`
- Focused housekeeping tests: 11 passed
- Full Vitest suite: 760 files passed, 1 skipped; 7,226 tests passed, 4 skipped

## Duplication and abstraction budget

Pattern traversal remains centralized in one asynchronous generator. No wrapper or pass-through layer was added; complete result sets exist only in packing paths that require later classification.

## Net elements (R6)

- Files: 1 added, 5 modified, 0 deleted.
- Exported symbols: 0 added or removed; the existing `findFilesFromPatterns` contract became an asynchronous generator.
- Classes, interfaces, and enums: no change.
- Net lines: +100.

## Consumer counts (R8)

n/a — no export or event path was removed. All six consumers of `findFilesFromPatterns` (five production calls and one test call) were updated in this change.

Closes #9049

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches workspace deletion and packing discovery across housekeeping; behavior is intended to be equivalent but streaming and removal of the single-match input guard could surface edge cases in large or oddly named workspaces.
> 
> **Overview**
> Housekeeping file discovery no longer builds a full in-memory list before acting. **`findFilesFromPatterns`** is now an **async generator** backed by **`globIterate`** instead of synchronous **`globSync`**, and **`runCleanBuild`** / **`runCleanOutput`** iterate matches the same way.
> 
> **Cleanup** deletes each path as it is yielded, so traversal can apply backpressure and overlapping legacy patterns are safe because a file is removed before a later pattern can match it again. **`runCleanSingle`** no longer pre-scans to bail out when the only match would be the input document; it reports **`noFiles`** only when nothing is deleted.
> 
> **Pack** and **latexdiff** still need complete sets for move/copy vs delete classification, so those call sites accumulate into **`Set`** values while consuming the generator. Tests cover delete-before-next-match ordering and single deletion under overlapping patterns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70b780b59b5cf9c64bea0945db805b0805c83390. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->