### PR TITLE
refactor: fold texra.showAgents into the typed command registry

### DIFF
--- a/packages/extension/src/commands/extensionCommandHandlers.ts
+++ b/packages/extension/src/commands/extensionCommandHandlers.ts
@@ -41,6 +41,12 @@ const SetApiKeyArgSchema = z.enum(API_PROVIDERS).optional();
 const CreateAgentWithAIArgSchema = AgentCategorySchema.optional();
 
 /**
+ * Optional `AgentCategory` argument for `texra.showAgents`, selecting which
+ * agent-category sub-tab opens under Settings > Agents.
+ */
+const ShowAgentsArgSchema = AgentCategorySchema.optional();
+
+/**
  * Optional `{ inPlace }` argument for `texra.showProgressView`. The
  * legacy registration accepted any argument shape and only honoured the
  * `inPlace` boolean — `z.unknown()` here preserves that best-effort
@@ -84,9 +90,8 @@ export type ExtensionRegistryCommandId =
 
 /**
  * Runtime mirror of `ExtensionRegistryCatalogCommandId`, used by tests to
- * assert `EXTENSION_COMMAND_HANDLERS` / `EXTENSION_PARAMETERIZED_HANDLERS`
- * register every catalog entry tagged `extensionRegistry: true` (and flag
- * strays that no longer belong).
+ * assert `EXTENSION_COMMAND_HANDLERS` registers every catalog entry tagged
+ * `extensionRegistry: true` (and flag strays that no longer belong).
  */
 export const EXTENSION_REGISTRY_CATALOG_COMMAND_IDS: readonly ExtensionRegistryCatalogCommandId[] =
   commandCatalog
@@ -271,28 +276,16 @@ export const EXTENSION_COMMAND_HANDLERS = {
     (actions: ExtensionCommandActions, input) =>
       awaitTrue(actions.execute(input)),
   ),
+  'texra.showAgents': definedHandler(
+    ShowAgentsArgSchema,
+    (actions: ExtensionCommandActions, subTab) =>
+      awaitTrue(actions.showSettings(SETTINGS_TAB.AGENTS, subTab)),
+  ),
 } as const satisfies Record<
-  Exclude<ExtensionRegistryCommandId, 'texra.showAgents'>,
-  // The typed handlers (`openDoc`, `stopAgent`, `compactResponse`) carry
+  ExtensionRegistryCommandId,
+  // The typed handlers (`openDoc`, `stopAgent`, `compactResponse`, …) carry
   // their own argument shapes via `definedHandler`. Matching the registry
   // map's per-entry TArgs widening (`any`) keeps inference per entry
   // without unifying every entry on `unknown`.
   CommandHandler<ExtensionCommandActions, any>
->;
-
-// `texra.showAgents` accepts an optional `AgentCategory` argument from
-// `executeCommand` callers, so it can't share the no-arg `CommandHandler`
-// signature. It's still routed through the same actions interface — the
-// only difference is that the VS Code registration forwards the argument.
-//
-// FOLLOW_UP: This bespoke parameterized map can be replaced with the
-// `definedHandler` typed-args helper in `@shared/commands/registry` once
-// the surrounding parameterized commands (pack/clean/compare/etc.) are
-// migrated through that path. Keeping it as-is for now to minimize churn.
-export const EXTENSION_PARAMETERIZED_HANDLERS = {
-  'texra.showAgents': (actions, subTab?: AgentCategory) =>
-    actions.showSettings(SETTINGS_TAB.AGENTS, subTab),
-} satisfies Record<
-  Extract<ExtensionRegistryCommandId, 'texra.showAgents'>,
-  (actions: ExtensionCommandActions, arg?: AgentCategory) => Promise<void>
 >;

--- a/packages/extension/src/commands/extensionCommandSurface.ts
+++ b/packages/extension/src/commands/extensionCommandSurface.ts
@@ -60,14 +60,12 @@ import { signInWithChatGptSubscription } from '@frontend/auth/codexSubscriptionS
 import { runCleanBuild, runCleanOutput } from '@housekeeping';
 import type { SettingsViewProvider } from '@settingsView/SettingsViewProvider';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
-import type { AgentCategory } from '@shared/schemas/agent';
 import { dispatchCommandFromRegistry } from '@shared/commands/registry';
 import { SETTINGS_QUERY } from '@utils/config';
 
 // Local file imports
 import {
   EXTENSION_COMMAND_HANDLERS,
-  EXTENSION_PARAMETERIZED_HANDLERS,
   type ExtensionCommandActions,
 } from './extensionCommandHandlers';
 
@@ -177,11 +175,10 @@ export function createExtensionCommandActions(
 
 /*
  * Duplicate-registration audit (#3787 follow-up):
- * Every command id in `EXTENSION_COMMAND_HANDLERS` +
- * `EXTENSION_PARAMETERIZED_HANDLERS` has been verified to have no stale
- * `vscode.commands.registerCommand(...)` call elsewhere. The remaining
- * legacy `registerCommand` call sites all register ids NOT tagged
- * `extensionRegistry` in `commandCatalog` — they're legitimate VS
+ * Every command id in `EXTENSION_COMMAND_HANDLERS` has been verified to
+ * have no stale `vscode.commands.registerCommand(...)` call elsewhere.
+ * The remaining legacy `registerCommand` call sites all register ids NOT
+ * tagged `extensionRegistry` in `commandCatalog` — they're legitimate VS
  * Code-only handlers (file ops, git, latex tools, pack/clean variants).
  */
 
@@ -214,16 +211,6 @@ export function registerExtensionCommandRegistry(
           },
           rawArg,
         ),
-      ),
-    );
-  }
-
-  for (const id of Object.keys(
-    EXTENSION_PARAMETERIZED_HANDLERS,
-  ) as ReadonlyArray<keyof typeof EXTENSION_PARAMETERIZED_HANDLERS>) {
-    context.subscriptions.push(
-      vscode.commands.registerCommand(id, (arg?: AgentCategory) =>
-        EXTENSION_PARAMETERIZED_HANDLERS[id](actions, arg),
       ),
     );
   }

--- a/src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts
+++ b/src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts
@@ -5,7 +5,6 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   EXTENSION_COMMAND_HANDLERS,
   EXTENSION_HIDDEN_ALIASES,
-  EXTENSION_PARAMETERIZED_HANDLERS,
   EXTENSION_REGISTRY_CATALOG_COMMAND_IDS,
   type ExtensionCommandActions,
 } from '@commands/extensionCommandHandlers';
@@ -73,10 +72,7 @@ function makeActions(): ExtensionCommandActions {
 
 describe('extension command registry — catalog-driven registration', () => {
   it('registers exactly the catalog ids tagged extensionRegistry, plus hidden aliases', () => {
-    const registered = [
-      ...Object.keys(EXTENSION_COMMAND_HANDLERS),
-      ...Object.keys(EXTENSION_PARAMETERIZED_HANDLERS),
-    ].sort();
+    const registered = Object.keys(EXTENSION_COMMAND_HANDLERS).sort();
     const expected = [
       ...EXTENSION_REGISTRY_CATALOG_COMMAND_IDS,
       ...EXTENSION_HIDDEN_ALIASES,
@@ -94,10 +90,7 @@ describe('extension command registry — catalog-driven registration', () => {
         .filter((entry) => entry.extensionRegistry === true)
         .map((entry) => entry.id),
     );
-    const registeredIds = new Set([
-      ...Object.keys(EXTENSION_COMMAND_HANDLERS),
-      ...Object.keys(EXTENSION_PARAMETERIZED_HANDLERS),
-    ]);
+    const registeredIds = new Set(Object.keys(EXTENSION_COMMAND_HANDLERS));
     for (const id of taggedIds) {
       expect(registeredIds.has(id)).toBe(true);
     }
@@ -179,15 +172,33 @@ describe('extension command surface — newly migrated commands (#3771, #3775, #
     );
   });
 
-  it('texra.showAgents (parameterized) passes the agents sub-tab', async () => {
+  it('texra.showAgents forwards parsed agent-category sub-tab', async () => {
     const actions = makeActions();
-    await EXTENSION_PARAMETERIZED_HANDLERS['texra.showAgents'](
+    const result = dispatchCommandFromRegistry(
+      'texra.showAgents',
+      EXTENSION_COMMAND_HANDLERS,
       actions,
+      undefined,
       'toolUse',
     );
+    await expect(Promise.resolve(result)).resolves.toBe(true);
     expect(actions.showSettings).toHaveBeenCalledExactlyOnceWith(
       SETTINGS_TAB.AGENTS,
       'toolUse',
+    );
+  });
+
+  it('texra.showAgents with no arg opens the agents tab without a sub-tab', async () => {
+    const actions = makeActions();
+    const result = dispatchCommandFromRegistry(
+      'texra.showAgents',
+      EXTENSION_COMMAND_HANDLERS,
+      actions,
+    );
+    await expect(Promise.resolve(result)).resolves.toBe(true);
+    expect(actions.showSettings).toHaveBeenCalledExactlyOnceWith(
+      SETTINGS_TAB.AGENTS,
+      undefined,
     );
   });
 


### PR DESCRIPTION
## Summary

Scheduled tech-debt audit of module/responsibility boundaries across the repo (orchestration layer, shared/wire-contract layer, host packages, tools/output/review layers). Most of the codebase held up well — three of four survey passes came back clean, with boundaries already enforced by prior debt-audit/tournament passes. The one concrete, self-flagged overlap found: `packages/extension/src/commands/extensionCommandHandlers.ts` maintained **two separate command-dispatch mechanisms** for the VS Code extension's command registry.

`EXTENSION_COMMAND_HANDLERS` routes every registry-driven command through the shared `dispatchCommandFromRegistry` (Zod arg validation, unhandled-command logging, consistent `boolean | Promise<boolean>` return so async rejections propagate — the bug fixed in #3782). `EXTENSION_PARAMETERIZED_HANDLERS` was a second, bespoke map holding just `texra.showAgents`, which bypassed all of that: no schema validation on its `AgentCategory` argument, no unhandled-command logging, and its own `vscode.commands.registerCommand` loop in `extensionCommandSurface.ts` duplicating the one right above it. The code's own comment already called this out as a `FOLLOW_UP` item, deferred "to minimize churn."

This PR does the deferred fold: `texra.showAgents` now goes through `definedHandler(AgentCategorySchema.optional(), ...)`, the same pattern already used by `texra.createAgentWithAI` for an identical optional-category argument. `EXTENSION_PARAMETERIZED_HANDLERS` and its registration loop are deleted.

## Issue acceptance gates

No tracked issue — this is a scheduled-audit finding, not project-requested work. Acceptance gate: `texra.showAgents` continues to open Settings > Agents with the correct sub-tab, validated through the same `dispatchCommandFromRegistry` path as every other typed command, with no second dispatch mechanism left in the file.

## Single source of truth

`EXTENSION_COMMAND_HANDLERS` (dispatched via `dispatchCommandFromRegistry`) is now the single registry for every extension command id, typed and untyped alike. `registerExtensionCommandRegistry` has one registration loop instead of two.

## Duplication and abstraction budget

Removed duplication: a second command-dispatch map, a second `vscode.commands.registerCommand` loop, and the bespoke `Exclude<ExtensionRegistryCommandId, 'texra.showAgents'>` carve-out in the `EXTENSION_COMMAND_HANDLERS` type constraint. No new abstraction added — `showAgents` reuses the existing `definedHandler` helper and the existing `AgentCategorySchema.optional()` pattern already used by `createAgentWithAI`.

## Net elements (R6)

3 files changed, 41 insertions(+), 50 deletions(-), net **-9 LoC**. Exported symbols: `-1` (`EXTENSION_PARAMETERIZED_HANDLERS` deleted); `+0` new exports. No new classes/interfaces/enums.

## Consumer counts (R8)

`EXTENSION_PARAMETERIZED_HANDLERS` had exactly 2 consumers before this change: `extensionCommandSurface.ts` (the second registration loop, removed) and `ExtensionCommandRegistry.vitest.ts` (the parameterized test, rewritten to use `dispatchCommandFromRegistry` like every other typed-arg test in that file). Grepped repo-wide post-change: zero remaining references to `EXTENSION_PARAMETERIZED_HANDLERS`.

## Host impact

Extension: `texra.showAgents` now validated/dispatched identically to every other registry command; user-visible behavior unchanged (same settings tab, same sub-tab argument).

Desktop: no change — desktop has its own `DesktopCommandActions`/menu registration, untouched by this PR.

CLI: no change — not part of the VS Code command registry.

## Scheduled refactoring

None. This was itself the deferred `FOLLOW_UP` from the original code comment.

## Validation

- `npx vitest run src/test-kernel/commands/ExtensionCommandRegistry.vitest.ts` — 61/61 passed.
- `npm run typecheck` — clean across extension, CLI, trace-viewer, and desktop tsconfigs.
- `npx eslint` on all three changed files — clean.
- `npm run check:dead-code-ratchet` — 18 findings vs. 18 baselined, no new dead exports (confirms the deleted export isn't orphaned elsewhere).


---
_Generated by [Claude Code](https://claude.ai/code/session_01PXZAsHa9PDKBzjXWTCwwP1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor with unchanged user-facing behavior (Settings > Agents, optional sub-tab); no auth, data, or desktop/CLI surface changes.
> 
> **Overview**
> **Unifies extension command dispatch** by moving `texra.showAgents` into `EXTENSION_COMMAND_HANDLERS` with `definedHandler(ShowAgentsArgSchema, …)`, matching `texra.createAgentWithAI` for an optional `AgentCategory` argument.
> 
> **Removes** `EXTENSION_PARAMETERIZED_HANDLERS`, the bespoke `Exclude<…, 'texra.showAgents'>` typing carve-out, and the extra `registerCommand` loop in `extensionCommandSurface.ts`. All registry commands now go through a single `dispatchCommandFromRegistry` path (Zod validation, consistent return shape, async rejection propagation).
> 
> **Tests** now assert `texra.showAgents` via `dispatchCommandFromRegistry` (with and without a sub-tab) instead of calling the deleted map directly; catalog/handler parity checks only consider `EXTENSION_COMMAND_HANDLERS`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e28589abfda6026fdc1794a91f01c994d53e109. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->