### PR TITLE
feat(tools): add a switch for the workflow script tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ All notable changes to this project will be documented in this file.
 
 - **The Mathematician team includes the critique workflow** — mathematical team
   runs can delegate a dedicated critical review directly.
-- **A switch for the workflow script tool** — the Tools dashboard (and CLI
-  `/tools`) now lists "Workflow Script" as a toggleable integration. Turning
-  it off removes `delegate_workflow_script` from every agent's tool list,
-  even agents whose configuration names it explicitly.
+- **The orchestrator agent can use scripted multi-agent pipelines** — the
+  built-in `orchestrator` agent now carries `delegate_workflow_script` for
+  fan-out/pipeline/join runs with a structure known up front. The Tools
+  dashboard (and CLI `/tools`) lists "Workflow Script" as a toggleable
+  integration, off by default for new installs; turning it off removes
+  `delegate_workflow_script` from every agent's tool list, even agents whose
+  configuration names it explicitly.
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
 
 - **The Mathematician team includes the critique workflow** — mathematical team
   runs can delegate a dedicated critical review directly.
+- **A switch for the workflow script tool** — the Tools dashboard (and CLI
+  `/tools`) now lists "Workflow Script" as a toggleable integration. Turning
+  it off removes `delegate_workflow_script` from every agent's tool list,
+  even agents whose configuration names it explicitly.
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,13 @@ All notable changes to this project will be documented in this file.
 
 - **The Mathematician team includes the critique workflow** — mathematical team
   runs can delegate a dedicated critical review directly.
-- **The orchestrator agent can use scripted multi-agent pipelines** — the
-  built-in `orchestrator` agent now carries `delegate_workflow_script` for
-  fan-out/pipeline/join runs with a structure known up front. The Tools
-  dashboard (and CLI `/tools`) lists "Workflow Script" as a toggleable
-  integration, off by default for new installs; turning it off removes
-  `delegate_workflow_script` from every agent's tool list, even agents whose
-  configuration names it explicitly.
+- **The orchestrator agent can run scripted multi-agent pipelines** — the
+  built-in Orchestrator agent now has access to Workflow Script, for
+  fan-out/pipeline/join runs whose structure is known up front. The Tools
+  dashboard (and CLI `/tools`) lists Workflow Script as a toggleable
+  integration, off by default for new installs; turning it off removes the
+  capability from every agent, even ones whose configuration enables it
+  explicitly.
 
 #### Bug Fixes
 

--- a/docs/supabase/SYNC_REFERENCE_AGENTS.sql
+++ b/docs/supabase/SYNC_REFERENCE_AGENTS.sql
@@ -196,7 +196,7 @@ VALUES (
   'tool-use/orchestrator.yaml',
   ARRAY['public'],
   'toolUse',
-  ARRAY['delegate_workflow', 'delegate_agent', 'executions', 'accept_run_files', 'todo_write', 'plan', 'read_file', 'write_file', 'edit_file', 'bash', 'glob', 'grep', 'extract_figures', 'extract_bib_entries', 'texcount', 'inquiry', 'codex', 'claude_code', 'github_subscription']
+  ARRAY['delegate_workflow', 'delegate_agent', 'executions', 'accept_run_files', 'delegate_workflow_script', 'todo_write', 'plan', 'read_file', 'write_file', 'edit_file', 'bash', 'glob', 'grep', 'extract_figures', 'extract_bib_entries', 'texcount', 'inquiry', 'codex', 'claude_code', 'github_subscription']
 )
 ON CONFLICT (name) DO UPDATE SET
   description    = EXCLUDED.description,

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -28,6 +28,7 @@ import {
 } from '@platform/defaults/nodeStorage';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { UsageLogService } from '@telemetry/UsageLogService';
+import { seedDisabledToolDefaults } from '@tools/toolAvailability';
 import { setSetupPlatform } from '@tools/setup/platform';
 import { getUseOpenRouter } from '@utils/config/providerConfig';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -291,6 +292,16 @@ export async function initCliPlatform(
         },
       }),
     );
+
+    // Seed first-install defaults (e.g. disabled tools) before anything
+    // writes CLI_BUNDLED_AGENTS_LAST_KNOWN_VERSION (the bundled-agent sync
+    // below), so upgrading users are not affected. Mirrors the
+    // extension/desktop ordering — same seeding function, CLI's own version
+    // key since the CLI tracks its bundled-agent version independently.
+    await seedDisabledToolDefaults(
+      GlobalStateKey.CLI_BUNDLED_AGENTS_LAST_KNOWN_VERSION,
+    );
+
     if (context.installSignalHandlers !== false) {
       installCliShutdownSignalHandlers(lifecycle);
     }

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -25,6 +25,7 @@ import { workspaceTexraConfigPath } from '@platform/defaults/nodeStorage';
 import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { configKeyVariants } from '@shared/config/configKeys';
+import { seedDisabledToolDefaults } from '@tools/toolAvailability';
 import { StreamSnapshotStore } from '@transcript';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -294,6 +295,11 @@ export async function initializeElectronPlatform(
     globalStateStore.get<string | undefined>(
       GlobalStateKey.LAST_KNOWN_VERSION,
     ) !== undefined;
+
+  // Seed first-install defaults (e.g. disabled tools) before anything writes
+  // LAST_KNOWN_VERSION, so upgrading users are not affected. Mirrors the
+  // extension's ordering (extension.ts) — same key, same seeding function.
+  await seedDisabledToolDefaults(GlobalStateKey.LAST_KNOWN_VERSION);
 
   const resourcesPath = resolveResourcesPath(mainDirname);
 

--- a/packages/extension/resources/docs/agent-creation/tool_catalog.md
+++ b/packages/extension/resources/docs/agent-creation/tool_catalog.md
@@ -66,7 +66,9 @@ recommended groups at the bottom are a good starting point.
   `schema` is a JSON Schema object, runs a tool-use agent (name one via
   `agentName`) that finishes by calling `submit_output`; the call resolves to an
   envelope whose `.structured` is the validated object. It is intentionally
-  absent from the recommended orchestrator set.
+  absent from the recommended orchestrator set. Also gated by the "Workflow
+  Script" switch in Settings → Tools, which disables the tool for every agent
+  regardless of its configured tool list.
 - `delegate_agent` — delegate to another tool-use agent. Pass `agent`,
   `model`, and `instruction` for a fresh run, or `execution_id` +
   `instruction` to resume a WAITING subagent.

--- a/packages/extension/resources/docs/agent-creation/tool_catalog.md
+++ b/packages/extension/resources/docs/agent-creation/tool_catalog.md
@@ -65,10 +65,10 @@ recommended groups at the bottom are a good starting point.
   `log`, `parallel`, `pipeline`, and `concat`. `agent(prompt, { schema })`, where
   `schema` is a JSON Schema object, runs a tool-use agent (name one via
   `agentName`) that finishes by calling `submit_output`; the call resolves to an
-  envelope whose `.structured` is the validated object. It is intentionally
-  absent from the recommended orchestrator set. Also gated by the "Workflow
-  Script" switch in Settings → Tools, which disables the tool for every agent
-  regardless of its configured tool list.
+  envelope whose `.structured` is the validated object. Present in the
+  built-in `orchestrator` agent's tool list, but gated by the "Workflow
+  Script" switch in Settings → Tools (off by default for new installs), which
+  disables the tool for every agent regardless of its configured tool list.
 - `delegate_agent` — delegate to another tool-use agent. Pass `agent`,
   `model`, and `instruction` for a fresh run, or `execution_id` +
   `instruction` to resume a WAITING subagent.
@@ -109,7 +109,9 @@ zotero_export`
 
 **Orchestrator agent:**
 `bash, read_file, write_file, glob, grep, delegate_workflow,
-delegate_agent, executions, accept_run_files, todo_write`
+delegate_agent, executions, accept_run_files, todo_write`, optionally
+`delegate_workflow_script` for pipelines with a predetermined fan-out/join
+structure (off by default — see above).
 
 **Computation agent:**
 `bash, read_file, write_file, glob, grep, wolfram`

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -40,7 +40,6 @@ import { SecretManager } from '@frontend/secretManager';
 import {
   copyDefaultAgents,
   configureLatexSettings,
-  initializeToolDefaults,
   migrateLatexConfigToStorage,
   registerAgentDirectoryRoots,
 } from '@frontend/setup';
@@ -100,7 +99,10 @@ import {
   SharedIssuePollingSource,
 } from '@tools/github';
 import { setSetupPlatform } from '@tools/setup';
-import { refreshToolAvailability } from '@tools/toolAvailability';
+import {
+  refreshToolAvailability,
+  seedDisabledToolDefaults,
+} from '@tools/toolAvailability';
 import { setOpenPdfOpener } from '@tools/OpenPdfTool';
 import { setOpenBuildDisplay } from '@tools/approval/latexPreview';
 import { setLeanLanguageServices } from '@tools/lean/leanLanguageServices';
@@ -319,7 +321,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Seed first-install defaults (e.g. disabled tools) before anything writes
   // LAST_KNOWN_VERSION, so upgrading users are not affected.
-  await initializeToolDefaults();
+  await seedDisabledToolDefaults(GlobalStateKey.LAST_KNOWN_VERSION);
 
   // Onboarding-funnel backfill (PRD: agent-native onboarding): upgraders who
   // already have a credential or run history must never see the welcome card

--- a/packages/extension/src/frontend/setup.ts
+++ b/packages/extension/src/frontend/setup.ts
@@ -24,7 +24,6 @@ import {
   LATEX_WORKSHOP_EXT_ID,
   type LatexConfigField,
 } from '@shared/constants/latex';
-import { EXTERNAL_TOOL_DEFS } from '@tools/externalToolDefs';
 import { updateConfig } from '@utils/config';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { registerExternalRoot } from '@utils/files/externalRoots';
@@ -35,35 +34,6 @@ import { extendEnvPath } from '@utils/system/platformPaths';
  * Increment this when changing which settings are auto-configured.
  */
 const LATEX_CONFIG_VERSION = 2;
-
-/**
- * Seed the disabled-tool list for first-time users only.
- *
- * Every tool group flagged `toggleable: true` in EXTERNAL_TOOL_DEFS is
- * treated as opt-in and seeded as disabled on a fresh install. Runs before
- * `copyDefaultAgents` (which writes `LAST_KNOWN_VERSION`); the combined
- * absence of that key and `DISABLED_TOOLS` is how we detect a new install
- * — existing upgrading users keep their list.
- */
-export async function initializeToolDefaults(): Promise<void> {
-  const lastKnownVersion = globalSM.get<string>(
-    GlobalStateKey.LAST_KNOWN_VERSION,
-  );
-  const disabledTools = globalSM.get<string[]>(GlobalStateKey.DISABLED_TOOLS);
-
-  if (lastKnownVersion !== undefined || disabledTools !== undefined) {
-    return;
-  }
-
-  const defaults = EXTERNAL_TOOL_DEFS.filter((def) => def.toggleable).map(
-    (def) => def.id,
-  );
-  await globalSM.update(GlobalStateKey.DISABLED_TOOLS, defaults);
-  logger.info(
-    'extension',
-    `First install — default-disabled toggleable tools: ${defaults.join(', ')}`,
-  );
-}
 
 /**
  * Reconciles bundled agents in global storage:

--- a/reference-agents/orchestrator.yaml
+++ b/reference-agents/orchestrator.yaml
@@ -8,6 +8,12 @@ settings:
     - delegate_agent
     - executions
     - accept_run_files
+    # Workflow script — advanced delegation for a pipeline whose fan-out and
+    # join structure is known in advance (see the tool description). Opt-in
+    # and disabled by default; enable in Dashboard → Tools ("Workflow
+    # Script"). When disabled by the user, resolveAgentTools() strips this
+    # from the model's tool list, same as github_subscription below.
+    - delegate_workflow_script
     - todo_write
     - plan
     - read_file
@@ -57,6 +63,8 @@ prompts:
     Choose delegate_workflow when the entire input file should be rewritten from start to finish in fixed rounds—the agent receives structured file parameters and produces a transformed version preserving structure and section order. Use this for uniform whole-document operations: grammar correction across an entire paper, style polishing a full draft, or merging documents. For challenging derivations and proofs in LaTeX documents, always use specialized workflow agents first—they have multi-round reasoning with reflection that produces more rigorous, self-contained results than an interactive agent editing in place. When writing instructions for derivation tasks, describe what needs to be derived and the context, but do not outline the derivation steps or sketch the answer—the truth comes from actually working through the calculations, not from a predetermined outline. Check the delegate_workflow tool description for a workflow agent matching the task before considering delegate_agent. Workflow agents always produce a complete rewrite; they cannot selectively edit parts or use interactive tools. If you want fresh content unrelated to existing structure, provide an empty template as input. See the delegate_workflow tool description for available workflow agents.
 
     Choose delegate_agent when the task benefits from interactive tool use—research, exploration, targeted edits to specific sections, or multi-step investigations that need file reading, search, or shell commands. Do not use interactive agents for tasks that a workflow agent can handle; workflows are more deterministic and produce version-controlled output files. Before choosing delegate_agent, always check whether a workflow agent (via delegate_workflow) can handle the task—workflows are preferred when they fit. When delegating to tool-use agents, check the delegate_agent tool description for the full list of available agents and choose the most specific specialized agent whose description matches the task. Treat the chat agent as fallback-only: do not use it for ordinary file edits, research, review, presentation work, simplification, LaTeX fixes, or any task covered by a named specialist. Use chat only when no specialized agent covers the work, and include that reason in the delegated instruction so the proposal is auditable.
+
+    If delegate_workflow_script is available (it is opt-in, disabled by default), reach for it only when you can already state the complete fan-out/pipeline/join structure up front — e.g. "correct these five chapters in parallel, then merge the results" — and the run should resume safely if interrupted. It is not a replacement for interactively choosing delegate_workflow/delegate_agent calls one at a time as results come in; for anything where the next step depends on judging an earlier result, keep delegating one call at a time instead.
 
     {{ CODEX_GUIDANCE }}
 

--- a/src/agent/workflowScript/README.md
+++ b/src/agent/workflowScript/README.md
@@ -122,6 +122,10 @@ subagent runner, durable checkpoint store, task-run file hand-off, progress
 projection, parent cancellation, and completed-journal cost settlement. It is
 registered but absent from every default agent configuration; explicitly adding
 the tool to an agent is the consent boundary for automated workflow fan-out.
+A second, global gate sits on top: the "Workflow Script" toggle in the Tools
+dashboard (`src/tools/externalToolDefs.ts`, id `workflow-script`) strips
+`delegate_workflow_script` from every agent's resolved tools when switched
+off, regardless of what any individual agent configuration names.
 
 Domain-specific structures should travel as JSON output files rather than
 per-call result schemas. Cost settlement covers completed logical calls retained

--- a/src/agent/workflowScript/README.md
+++ b/src/agent/workflowScript/README.md
@@ -119,13 +119,15 @@ return concat(sections, { separator: '\n\n' });
 
 The opt-in `delegate_workflow_script` tool composes the production in-band
 subagent runner, durable checkpoint store, task-run file hand-off, progress
-projection, parent cancellation, and completed-journal cost settlement. It is
-registered but absent from every default agent configuration; explicitly adding
-the tool to an agent is the consent boundary for automated workflow fan-out.
-A second, global gate sits on top: the "Workflow Script" toggle in the Tools
-dashboard (`src/tools/externalToolDefs.ts`, id `workflow-script`) strips
-`delegate_workflow_script` from every agent's resolved tools when switched
-off, regardless of what any individual agent configuration names.
+projection, parent cancellation, and completed-journal cost settlement. It
+ships in the built-in `orchestrator` agent's tool list
+(`reference-agents/orchestrator.yaml`); explicitly naming the tool in an
+agent's configuration is one half of the consent boundary for automated
+workflow fan-out. The other half is global: the "Workflow Script" toggle in
+the Tools dashboard (`src/tools/externalToolDefs.ts`, id `workflow-script`)
+strips `delegate_workflow_script` from every agent's resolved tools when
+switched off, regardless of what any individual agent configuration names —
+and new installs start with the switch off.
 
 Domain-specific structures should travel as JSON output files rather than
 per-call result schemas. Cost settlement covers completed logical calls retained

--- a/src/shared/state/stateKeys.ts
+++ b/src/shared/state/stateKeys.ts
@@ -77,7 +77,13 @@ export enum WorkspaceStateKey {
 
 export enum GlobalStateKey {
   LAST_KNOWN_VERSION = 'lastKnownVersion',
-  /** CLI-only bundled-agent sync marker; do not use as an install-age signal. */
+  /**
+   * CLI-only bundled-agent sync marker.
+   *
+   * This is not a cross-host install-age signal. Before the CLI's first
+   * bundled-agent sync, startup seeding may combine its absence with an absent
+   * `DISABLED_TOOLS` value to recognize a fresh CLI profile.
+   */
   CLI_BUNDLED_AGENTS_LAST_KNOWN_VERSION = 'texra.cli.bundledAgents.lastKnownVersion',
   MODEL_LIST_VERSION = 'modelListVersion',
   MEMORY_ENABLED = 'texra.memory.enabled',

--- a/src/test-kernel/agent/followUp/ToolUseToolResolution.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseToolResolution.vitest.ts
@@ -4,6 +4,8 @@ import { MapToolRegistry } from '@agent/core/tools/ToolTypes';
 import { resolveAgentTools } from '@agent/runtime/agentToolResolution';
 import { ToolInjectionRegistry } from '@agent/runtime/toolInjection';
 import type { ToolDefinition } from '@model';
+import { GlobalStateKey } from '@shared/state/stateKeys';
+import { installPlatform } from '@test/support/setupPlatform';
 import { DiagnosticsTool } from '@tools/DiagnosticsTool';
 import {
   DIAGNOSTICS_ADD_RUNTIME_CAPABILITY,
@@ -153,6 +155,27 @@ describe('tool-use tool resolution', () => {
     });
 
     expect(tools).toEqual([]);
+  });
+
+  it('drops the workflow script tool when its dashboard switch is disabled', async () => {
+    await installPlatform({
+      globalState: { [GlobalStateKey.DISABLED_TOOLS]: ['workflow-script'] },
+    });
+    try {
+      const registry = getDefaultToolRegistry();
+
+      const { tools } = await resolveAgentTools({
+        tools: toolDefs(['bash', 'delegate_workflow_script']),
+        registry,
+        logger,
+        toolInjections,
+        approvalPromptsUnavailable: false,
+      });
+
+      expect(tools.map((tool) => tool.name)).toEqual(['bash']);
+    } finally {
+      await installPlatform();
+    }
   });
 
   it('filters injected approval-gated tools when approval prompts are unavailable', async () => {

--- a/src/test-kernel/tools/ToolAvailabilitySeeding.vitest.ts
+++ b/src/test-kernel/tools/ToolAvailabilitySeeding.vitest.ts
@@ -1,0 +1,60 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports
+import { platform } from '@platform/platform';
+import { GlobalStateKey } from '@shared/state/stateKeys';
+import { installPlatform } from '@test/support/setupPlatform';
+import { EXTERNAL_TOOL_DEFS } from '@tools/externalToolDefs';
+import { seedDisabledToolDefaults } from '@tools/toolAvailability';
+
+const VERSION_KEY = 'test.lastKnownVersion';
+
+const EXPECTED_DEFAULTS = EXTERNAL_TOOL_DEFS.filter(
+  (def) => def.toggleable,
+).map((def) => def.id);
+
+describe('seedDisabledToolDefaults', () => {
+  it('seeds every toggleable tool as disabled on a genuinely fresh install', async () => {
+    await installPlatform({ globalState: {} });
+    try {
+      await seedDisabledToolDefaults(VERSION_KEY);
+
+      expect(platform().globalState.get(GlobalStateKey.DISABLED_TOOLS)).toEqual(
+        EXPECTED_DEFAULTS,
+      );
+    } finally {
+      await installPlatform();
+    }
+  });
+
+  it('does not seed for a host with a prior-install version marker', async () => {
+    await installPlatform({
+      globalState: { [VERSION_KEY]: '1.2.3' },
+    });
+    try {
+      await seedDisabledToolDefaults(VERSION_KEY);
+
+      expect(
+        platform().globalState.get(GlobalStateKey.DISABLED_TOOLS),
+      ).toBeUndefined();
+    } finally {
+      await installPlatform();
+    }
+  });
+
+  it('never overwrites an already-seeded DISABLED_TOOLS list, even an empty one', async () => {
+    await installPlatform({
+      globalState: { [GlobalStateKey.DISABLED_TOOLS]: [] },
+    });
+    try {
+      await seedDisabledToolDefaults(VERSION_KEY);
+
+      expect(platform().globalState.get(GlobalStateKey.DISABLED_TOOLS)).toEqual(
+        [],
+      );
+    } finally {
+      await installPlatform();
+    }
+  });
+});

--- a/src/test-kernel/tools/externalToolDefs.vitest.ts
+++ b/src/test-kernel/tools/externalToolDefs.vitest.ts
@@ -27,6 +27,15 @@ describe('external tool definitions', () => {
     ]);
   });
 
+  it('keeps the workflow script tool as a user-toggleable, always-available group', async () => {
+    const workflowScript = findExternalToolDef('workflow-script');
+
+    assert.ok(workflowScript, 'Workflow script tool definition should exist');
+    assert.strictEqual(workflowScript.toggleable, true);
+    assert.deepStrictEqual(workflowScript.tools, ['delegate_workflow_script']);
+    assert.strictEqual(await workflowScript.check(), true);
+  });
+
   it('shows TeXRA CLI as a detected but inactive integration', () => {
     const texraCli = findExternalToolDef('texra-cli');
 

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -54,7 +54,13 @@ type WorkflowScriptToolInput = z.infer<typeof WorkflowScriptToolInputSchema>;
 
 const STREAM_PREFIX = 'workflow-script';
 
-/** Execute a durable, deterministic workflow script from an opted-in agent. */
+/**
+ * Execute a durable, deterministic workflow script from an agent whose tool
+ * list names it. Gated by the "Workflow Script" dashboard switch (id
+ * `workflow-script` in {@link @tools/externalToolDefs}), which
+ * `resolveAgentTools()` enforces regardless of any agent's configured tools —
+ * new installs start with the switch off.
+ */
 export class WorkflowScriptTool extends defineTool({
   name: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
   slow: true,
@@ -78,9 +84,7 @@ const correctedFiles = results
   .flatMap((result) => result.outputs.map((output) => output.absolutePath))
 return await agent('Merge the corrected drafts.', { inputFiles: correctedFiles })
 
-Durability: the journal is keyed by meta.name within this session. If the run times out or is interrupted, call this tool again with the SAME meta.name: completed agent() calls replay for free (the script may be revised; only changed or unfinished calls execute). Use a new meta.name to start over. The default whole-run wall clock is 10 minutes; set meta.timeoutMs (1s to 60min) for longer runs.
-
-Tool inclusion is the opt-in boundary: do not add this tool to a default agent configuration.`,
+Durability: the journal is keyed by meta.name within this session. If the run times out or is interrupted, call this tool again with the SAME meta.name: completed agent() calls replay for free (the script may be revised; only changed or unfinished calls execute). Use a new meta.name to start over. The default whole-run wall clock is 10 minutes; set meta.timeoutMs (1s to 60min) for longer runs.`,
   schema: WorkflowScriptToolInputSchema,
 }) {
   protected async execute(input: WorkflowScriptToolInput): Promise<ToolResult> {

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -17,8 +17,8 @@ import { z } from 'zod';
 // Local imports
 import { apiKeyEnvName, lookupApiKeyOrigin } from '@model/apiProviders';
 import { platform } from '@platform/platform';
-import type { ToolCategory } from '@shared/schemas/settingsViewMessages';
 import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
+import type { ToolCategory } from '@shared/schemas/settingsViewMessages';
 import type { RegisteredToolName } from '@tools/registry';
 import { importCodexClass, findCodexBinaryPath } from '@tools/codexImport';
 import {

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -18,6 +18,7 @@ import { z } from 'zod';
 import { apiKeyEnvName, lookupApiKeyOrigin } from '@model/apiProviders';
 import { platform } from '@platform/platform';
 import type { ToolCategory } from '@shared/schemas/settingsViewMessages';
+import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
 import type { RegisteredToolName } from '@tools/registry';
 import { importCodexClass, findCodexBinaryPath } from '@tools/codexImport';
 import {
@@ -377,6 +378,19 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
       return lines.join('\n');
     },
   },
+  {
+    id: 'workflow-script',
+    tools: [DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME],
+    name: 'Workflow Script',
+    category: 'workflow',
+    description:
+      'Run deterministic JavaScript workflow scripts that fan out, pipeline, and join calls to sub-agents, resuming safely after interruption. An agent only gets this tool if its own configuration names it — this switch is an additional kill switch on top of that per-agent opt-in.',
+    configNotes:
+      'No local install required. Turning this off removes delegate_workflow_script from every agent tool list, even agents whose configuration names it explicitly.',
+    toggleable: true,
+    check: async () => true,
+  },
+
   {
     // ID kept as `github-pr-subscription` for back-compat with persisted
     // disabled-tool preferences. The user-facing name has expanded to

--- a/src/tools/toolAvailability.ts
+++ b/src/tools/toolAvailability.ts
@@ -14,6 +14,9 @@
 
 // Local imports
 import { appSignals } from '@eventBus/AppSignals';
+import * as logger from '@logger/logUtils';
+import { tryGlobalState } from '@platform/platform';
+import { GlobalStateKey } from '@shared/state/stateKeys';
 import type { RegisteredToolName } from '@tools/registry';
 import { EXTERNAL_TOOL_DEFS } from '@tools/externalToolDefs';
 import { getDisabledToolIds } from '@utils/config/constants';
@@ -55,6 +58,40 @@ export function getDisabledToolNames(): ReadonlySet<string> {
     for (const toolName of def.tools) disabled.add(toolName);
   }
   return disabled;
+}
+
+/**
+ * Seed the disabled-tool list for first-time users only, on any host.
+ *
+ * Every tool group flagged `toggleable: true` in EXTERNAL_TOOL_DEFS is
+ * treated as opt-in and seeded as disabled on a fresh install. Callers must
+ * invoke this after `initPlatform()` and before anything writes
+ * `versionStateKey` (each host's bundled-agent-directory sync) — the combined
+ * absence of that key and DISABLED_TOOLS is how a genuinely fresh install is
+ * told apart from an existing, upgrading user who simply never toggled a
+ * tool; re-seeding the latter would silently disable tools they already had
+ * enabled. `versionStateKey` differs per host (e.g. `LAST_KNOWN_VERSION` for
+ * the extension/desktop, `CLI_BUNDLED_AGENTS_LAST_KNOWN_VERSION` for the
+ * CLI) because each tracks its own bundled-agent version independently.
+ */
+export async function seedDisabledToolDefaults(
+  versionStateKey: string,
+): Promise<void> {
+  const state = tryGlobalState();
+  if (!state) return;
+
+  const lastKnownVersion = state.get<string>(versionStateKey);
+  const disabledTools = state.get<string[]>(GlobalStateKey.DISABLED_TOOLS);
+  if (lastKnownVersion !== undefined || disabledTools !== undefined) return;
+
+  const defaults = EXTERNAL_TOOL_DEFS.filter((def) => def.toggleable).map(
+    (def) => def.id,
+  );
+  await state.update(GlobalStateKey.DISABLED_TOOLS, defaults);
+  logger.info(
+    'toolAvailability',
+    `First install — default-disabled toggleable tools: ${defaults.join(', ')}`,
+  );
 }
 
 /**

--- a/src/utils/config/constants.ts
+++ b/src/utils/config/constants.ts
@@ -21,7 +21,8 @@ export const DEBOUNCE_OPTIONS_MS = 300; // Dropdown options refresh
 // Tool groups marked `toggleable: true` in EXTERNAL_TOOL_DEFS are treated
 // as opt-in: they're disabled for new users on first install, and the Tools
 // dashboard shows a toggle so the user can turn them on. Seeding happens in
-// `initializeToolDefaults()`; existing profiles are never re-seeded.
+// `seedDisabledToolDefaults()` during host startup; existing profiles are
+// never re-seeded.
 
 /** Determine whether tool-use session persistence is enabled. */
 export function getToolUsePersistenceEnabled(): boolean {


### PR DESCRIPTION
`delegate_workflow_script` was previously only gated by per-agent YAML
tool-list inclusion, with no runtime way to disable it. Register it as
a toggleable ExternalToolDef (id `workflow-script`), reusing the
existing Tools-dashboard/CLI-`/tools` switch mechanism already used by
Zotero, Codex, and Claude Code CLI. Toggling it off strips
`delegate_workflow_script` from every agent's resolved tools via the
existing disabled-tools enforcement in resolveAgentTools, regardless
of what any agent's configuration names — and it inherits the
existing first-install seeding that treats all toggleable tools as
opt-in by default for new installs.

Fixes #9080

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ky7Sqr9LxPn1wVocW4Kk8G

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global tool resolution and multi-host startup ordering for disabled tools; behavior mirrors existing toggleable integrations but affects orchestrator delegation when users enable the switch.
> 
> **Overview**
> **Workflow Script** is now a first-class, user-toggleable integration (`workflow-script` in `externalToolDefs`), like Zotero or Codex CLI. Turning it off in **Settings → Tools** (or CLI `/tools`) removes `delegate_workflow_script` from every agent’s resolved tool list via the existing disabled-tools path in `resolveAgentTools`, even when an agent YAML names the tool explicitly.
> 
> The built-in **orchestrator** lists `delegate_workflow_script` in `reference-agents/orchestrator.yaml` and remote-agent sync; new installs still start with the switch **off** because all `toggleable` integrations are seeded into `DISABLED_TOOLS` on first run.
> 
> **Startup seeding** moves out of extension-only `initializeToolDefaults` into shared `seedDisabledToolDefaults` in `@tools/toolAvailability`, invoked from extension, desktop, and CLI **before** each host writes its install/version marker (`LAST_KNOWN_VERSION` or `CLI_BUNDLED_AGENTS_LAST_KNOWN_VERSION`), so upgraders are not re-seeded. Docs, orchestrator prompt guidance, and tests cover the toggle, seeding, and tool resolution behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 151aea6fc89e100fd3f0226a827cc601ff38f560. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->