### PR TITLE
refactor(utils): extract shared coalesceAsync for singleflight caching

### DIFF
--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -7,6 +7,7 @@ import type { PlatformSecrets } from '@platform/secrets';
 import type { ModelAvailabilityKind, ModelOptionData } from '@shared/schemas';
 import { AgentCategory } from '@shared/schemas/agent';
 import { PROVIDER_DISPLAY_NAMES } from '@shared/constants/providers';
+import { coalesceAsync } from '@utils/core';
 import {
   getPreferKimiCode,
   getUseOpenRouter,
@@ -547,31 +548,17 @@ export async function computeModelOptionsData(
   }
 
   const cacheKey = getModelOptionsCacheKey(models, options);
-  const cached = resolvedModelOptions.get(cacheKey);
-  if (cached) return cached;
-
-  const pending = pendingModelOptions.get(cacheKey);
-  if (pending) return pending;
-
-  const request = computeModelOptionsDataUncached(
-    models,
-    buildDefaultModelOptionsAccess(options),
-    true,
+  return coalesceAsync<string, ModelOptionData[]>(
+    resolvedModelOptions,
+    pendingModelOptions,
+    cacheKey,
+    () =>
+      computeModelOptionsDataUncached(
+        models,
+        buildDefaultModelOptionsAccess(options),
+        true,
+      ),
   );
-  pendingModelOptions.set(cacheKey, request);
-
-  try {
-    const data = await request;
-    // Only populate cache if no invalidation occurred while we were awaiting.
-    if (pendingModelOptions.get(cacheKey) === request) {
-      resolvedModelOptions.set(cacheKey, data);
-    }
-    return data;
-  } finally {
-    if (pendingModelOptions.get(cacheKey) === request) {
-      pendingModelOptions.delete(cacheKey);
-    }
-  }
 }
 
 function getModelOptionsCacheKey(

--- a/src/test-kernel/utils/UtilsCore.vitest.ts
+++ b/src/test-kernel/utils/UtilsCore.vitest.ts
@@ -300,6 +300,30 @@ describe('coalesceAsync', () => {
 
     expect(resolved.get('key')).toBeUndefined();
   });
+
+  it('propagates a rejection and clears the pending entry without caching', async () => {
+    const resolved = new Map<string, string>();
+    const pending = new Map<string, Promise<string>>();
+    const failure = new Error('compute failed');
+    const compute = async () => {
+      throw failure;
+    };
+
+    await expect(coalesceAsync(resolved, pending, 'key', compute)).rejects.toBe(
+      failure,
+    );
+
+    expect(pending.has('key')).toBe(false);
+    expect(resolved.has('key')).toBe(false);
+
+    // A subsequent call must recompute rather than replay the failed promise.
+    let recomputeCount = 0;
+    await coalesceAsync(resolved, pending, 'key', async () => {
+      recomputeCount++;
+      return 'recovered';
+    });
+    expect(recomputeCount).toBe(1);
+  });
 });
 
 describe('deriveExecutionId', () => {

--- a/src/test-kernel/utils/UtilsCore.vitest.ts
+++ b/src/test-kernel/utils/UtilsCore.vitest.ts
@@ -5,6 +5,7 @@ import * as assert from 'node:assert';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  coalesceAsync,
   createFlushableDebounce,
   delay,
   ensureArray,
@@ -236,6 +237,68 @@ describe('KeyedMutex', () => {
     await expect(
       mutex.runExclusive('shared', async () => 'recovered'),
     ).resolves.toBe('recovered');
+  });
+});
+
+describe('coalesceAsync', () => {
+  it('shares one in-flight computation across concurrent callers', async () => {
+    const resolved = new Map<string, string>();
+    const pending = new Map<string, Promise<string>>();
+    let computeCount = 0;
+    let releaseCompute!: () => void;
+    const blocked = new Promise<void>((resolve) => {
+      releaseCompute = resolve;
+    });
+    const compute = async () => {
+      computeCount++;
+      await blocked;
+      return 'value';
+    };
+
+    const first = coalesceAsync(resolved, pending, 'key', compute);
+    const second = coalesceAsync(resolved, pending, 'key', compute);
+    releaseCompute();
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      'value',
+      'value',
+    ]);
+    expect(computeCount).toBe(1);
+  });
+
+  it('serves subsequent calls from the resolved cache without recomputing', async () => {
+    const resolved = new Map<string, string>();
+    const pending = new Map<string, Promise<string>>();
+    let computeCount = 0;
+    const compute = async () => {
+      computeCount++;
+      return 'value';
+    };
+
+    await coalesceAsync(resolved, pending, 'key', compute);
+    await coalesceAsync(resolved, pending, 'key', compute);
+
+    expect(computeCount).toBe(1);
+  });
+
+  it('does not cache a result if the pending entry was invalidated mid-flight', async () => {
+    const resolved = new Map<string, string>();
+    const pending = new Map<string, Promise<string>>();
+    let releaseCompute!: () => void;
+    const blocked = new Promise<void>((resolve) => {
+      releaseCompute = resolve;
+    });
+    const compute = async () => {
+      await blocked;
+      return 'stale-value';
+    };
+
+    const request = coalesceAsync(resolved, pending, 'key', compute);
+    pending.clear(); // simulate an external invalidation racing the in-flight compute
+    releaseCompute();
+    await request;
+
+    expect(resolved.get('key')).toBeUndefined();
   });
 });
 

--- a/src/utils/core/index.ts
+++ b/src/utils/core/index.ts
@@ -210,6 +210,50 @@ export function createFlushableDebounce(
   };
 }
 
+/** Minimal read/write cache shape satisfied by LRUCache and plain Maps. */
+export interface AsyncCoalesceStore<Key, Value> {
+  get(key: Key): Value | undefined;
+  set(key: Key, value: Value): void;
+}
+
+/**
+ * Coalesce concurrent async requests for the same key: return a resolved
+ * value from `resolved` if present, otherwise share one in-flight promise
+ * per key via `pending` so concurrent callers await the same computation.
+ * Only caches the result (and clears the in-flight entry) if `pending`
+ * still points at this exact promise once it settles — this guards against
+ * an external `pending.clear()`/`resolved.clear()` invalidation racing the
+ * in-flight computation, which would otherwise let a stale result get
+ * cached after the fact.
+ */
+export async function coalesceAsync<Key, Value>(
+  resolved: AsyncCoalesceStore<Key, Value>,
+  pending: Map<Key, Promise<Value>>,
+  key: Key,
+  compute: () => Promise<Value>,
+): Promise<Value> {
+  const cached = resolved.get(key);
+  if (cached !== undefined) return cached;
+
+  const inFlight = pending.get(key);
+  if (inFlight) return inFlight;
+
+  const request = compute();
+  pending.set(key, request);
+
+  try {
+    const value = await request;
+    if (pending.get(key) === request) {
+      resolved.set(key, value);
+    }
+    return value;
+  } finally {
+    if (pending.get(key) === request) {
+      pending.delete(key);
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // comparators
 // ---------------------------------------------------------------------------

--- a/src/utils/git/worktreeInfo.ts
+++ b/src/utils/git/worktreeInfo.ts
@@ -15,6 +15,7 @@ import { LRUCache } from 'lru-cache';
 
 import type { WorktreeInfo } from '@shared/schemas';
 
+import { coalesceAsync } from '@utils/core';
 import { executeCommand } from '@utils/system/execUtils';
 
 const GIT_TIMEOUT_MS = 5_000;
@@ -51,17 +52,12 @@ export function peekWorktreeInfo(
 export async function resolveWorktreeInfo(
   workingDirectory: string,
 ): Promise<WorktreeInfo> {
-  const cached = cache.get(workingDirectory);
-  if (cached) return cached;
-
-  const pending = inflight.get(workingDirectory);
-  if (pending) return pending;
-
-  const probe = probeWorktree(workingDirectory).finally(() => {
-    inflight.delete(workingDirectory);
-  });
-  inflight.set(workingDirectory, probe);
-  return probe;
+  return coalesceAsync<string, WorktreeInfo>(
+    cache,
+    inflight,
+    workingDirectory,
+    () => probeWorktree(workingDirectory),
+  );
 }
 
 async function probeWorktree(workingDirectory: string): Promise<WorktreeInfo> {
@@ -70,13 +66,7 @@ async function probeWorktree(workingDirectory: string): Promise<WorktreeInfo> {
     readDirty(workingDirectory),
   ]);
 
-  const value: WorktreeInfo = {
-    workingDirectory,
-    branch,
-    dirty,
-  };
-  cache.set(workingDirectory, value);
-  return value;
+  return { workingDirectory, branch, dirty };
 }
 
 async function readBranch(cwd: string): Promise<string | undefined> {


### PR DESCRIPTION
## Summary

`resolveWorktreeInfo` (`src/utils/git/worktreeInfo.ts`) and `computeModelOptionsData` (`src/model/computeModelOptions.ts`) each hand-rolled the identical "singleflight" async-caching pattern independently: check a resolved TTL cache, share one in-flight promise per key across concurrent callers, and only populate the cache once the computation settles — with an invalidation-race guard so an external cache-clear mid-flight doesn't let a stale result get cached afterward. Extracted that pattern into one shared, tested helper (`coalesceAsync`) in `@utils/core` and switched both call sites to use it.

## Issue acceptance gates

No tracked issue — found via a direct codebase scan for consolidation opportunities (duplicate logic / hand-rolled patterns with an existing shared home). Gate: both call sites compile, typecheck, and their existing behavior (including the invalidation-race guard) is preserved and now covered by dedicated unit tests.

## Single source of truth

`coalesceAsync` in `src/utils/core/index.ts` now owns the "resolved cache + shared in-flight promise + invalidation-safe write" invariant. `resolveWorktreeInfo` and `computeModelOptionsData` are thin callers that just supply their own cache/pending-map/key/compute callback.

## Duplication and abstraction budget

Removed: two independent, subtly-concurrency-sensitive implementations of the same coalescing logic (one of which — `computeModelOptionsData` — had an invalidation-race guard the other lacked, meaning the pattern had already started to drift). The new abstraction owns exactly one invariant (coalesce-then-cache-if-still-current) and takes a minimal structural interface (`AsyncCoalesceStore`) rather than depending on `lru-cache` directly, so it composes with either an `LRUCache` or a plain `Map`. Two call sites justify the extraction per the repo's abstraction-cost guardrails (not a single-caller helper), and the logic is meaningful (concurrency-correctness), not a pass-through.

## Net elements (R6)

Files: 4 changed, 0 added/deleted (diffstat: `computeModelOptions.ts` +11/-24, `worktreeInfo.ts` +8/-18, `utils/core/index.ts` +44/-0, `UtilsCore.vitest.ts` +63/-0 new tests).
Exported symbols: +2 in `src/utils/core/index.ts` (`coalesceAsync` function, `AsyncCoalesceStore` interface). No exports removed.
Net LoC excluding the new test file: +21 (+44 new helper, −13 at the `computeModelOptions.ts` call site, −10 at the `worktreeInfo.ts` call site). Including the new `coalesceAsync` test suite: +84.

## Consumer counts (R8)

n/a — no emit path or export was deleted/re-routed; this only adds a new shared export and switches two existing internal call sites to use it in place of inline logic.

## Host impact

Extension: none (host-neutral utility; both call sites already ran in the extension host).

Desktop: none (same host-neutral utility; `resolveWorktreeInfo` also runs from the Electron main process per its module doc).

CLI: none (`computeModelOptionsData` is also invoked from CLI code paths; behavior unchanged).

## Scheduled refactoring

None — this is a complete, self-contained consolidation.

## Validation

- `npm run typecheck` — clean across all packages (extension, CLI, trace-viewer, desktop).
- `npx eslint <touched files>` — clean.
- `npx prettier --check <touched files>` — clean (after `--write`).
- `npm run check:dead-code-ratchet` — no new unused exports (18 baselined, 18 current).
- `npm test` — full suite: 7251 passed, 9 skipped, 1 failed. The one failure (`SystemUtils.vitest.ts > aborts shell command process groups including children`) is pre-existing and unrelated: reproduces identically on `HEAD` before this change (verified via `git stash`), a sandbox/process-signal-handling flake in this container, not touched by this diff.
- Added 3 new unit tests for `coalesceAsync` covering: concurrent-caller coalescing (single compute call), cache-hit short-circuit (no recompute), and the invalidation-race guard (external `pending.clear()` mid-flight prevents a stale cache write).

---
_Generated by [Claude Code](https://claude.ai/code/session_01S1hQTGAeQGjawYi3scKZeU)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with preserved semantics plus tests; worktree caching gains the same invalidation-race guard model options already had.
> 
> **Overview**
> Introduces **`coalesceAsync`** in `@utils/core` as the shared “resolved cache + one in-flight promise per key” helper, including a guard so results are only written if the pending entry is still the same promise after settlement (so mid-flight `pending`/`resolved` clears do not cache stale data).
> 
> **`computeModelOptionsData`** and **`resolveWorktreeInfo`** drop their inline singleflight logic and call the helper instead. Model-options caching behavior stays the same; worktree probing no longer writes the LRU inside **`probeWorktree`**—the helper owns populating the resolved store.
> 
> Adds a **`coalesceAsync`** unit suite (concurrent coalescing, cache hits, invalidation race, rejection/retry).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0c8849c5e9f7ef0225c665944cf540a9db4de1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->