### PR TITLE
refactor(shared/trace/utils): delete dead stream-status layer and three unused surfaces

### DIFF
--- a/src/agent/trace/AgentTrace.ts
+++ b/src/agent/trace/AgentTrace.ts
@@ -156,10 +156,6 @@ export interface AgentTrace {
   emit(event: AgentEvent): void;
   subscribe(subscriber: AgentTraceSubscriber): () => void;
   activeStageId(): string | undefined;
-  withStage<T>(
-    stageId: string | undefined,
-    fn: () => Promise<T> | T,
-  ): Promise<T>;
 
   // ─── Plain logging (sugar over emit) ────────────────────────────────
   debug(message: string, options?: LogOptions): void;

--- a/src/agent/trace/noopTrace.ts
+++ b/src/agent/trace/noopTrace.ts
@@ -40,8 +40,6 @@ export const noopTrace: AgentTrace = {
   emit: NOOP,
   subscribe: () => NOOP,
   activeStageId: () => undefined,
-  withStage: <T>(_id: string | undefined, fn: () => Promise<T> | T) =>
-    Promise.resolve(fn()),
 
   debug: NOOP,
   info: NOOP,

--- a/src/platform/defaults/globalStorage.ts
+++ b/src/platform/defaults/globalStorage.ts
@@ -1,8 +1,2 @@
-const GLOBAL_STORAGE_LAYOUT = {
-  customAgents: 'custom_agents',
-  externalInquiryThreads: 'ei_threads',
-} as const;
-
-export const CUSTOM_AGENTS_STORAGE_DIR = GLOBAL_STORAGE_LAYOUT.customAgents;
-export const EXTERNAL_INQUIRY_THREADS_DIR =
-  GLOBAL_STORAGE_LAYOUT.externalInquiryThreads;
+export const CUSTOM_AGENTS_STORAGE_DIR = 'custom_agents';
+export const EXTERNAL_INQUIRY_THREADS_DIR = 'ei_threads';

--- a/src/shared/schemas/stream.ts
+++ b/src/shared/schemas/stream.ts
@@ -37,7 +37,7 @@ export type StreamStatus = z.infer<typeof StreamStatusSchema>;
  * - INITIALIZING is neither `active` nor `terminal`: a brief pre-start state
  *   that ticks elapsed time and blocks acquisition, but runs no model calls.
  */
-export const STREAM_STATUS_TRAITS = {
+const STREAM_STATUS_TRAITS = {
   [STREAM_STATUS.RUNNING]: {
     active: true,
     inFlight: true,

--- a/src/shared/streams/streamStatus.ts
+++ b/src/shared/streams/streamStatus.ts
@@ -6,14 +6,9 @@ import {
   EXECUTION_STATUS,
   RUN_OUTCOME,
   STREAM_PHASE,
-  STREAM_STATUS,
-  STREAM_STATUS_TRAITS,
-  StreamPhaseSchema,
   type ExecutionStatus,
   type RunOutcome,
   type StreamPhase,
-  type StreamStatus,
-  type StreamStatusTrait,
 } from '@shared/schemas/stream';
 
 // ============================================================================
@@ -94,14 +89,6 @@ export function legacyEndGroupStatusForOutcome(
   return groupEndStatusForOutcome(outcome) === 'error' ? 'error' : 'stopped';
 }
 
-export function terminalStreamStatusForOutcome(
-  outcome: RunOutcome,
-): StreamStatus {
-  return groupEndStatusForOutcome(outcome) === 'error'
-    ? STREAM_STATUS.ERROR
-    : STREAM_STATUS.STOPPED;
-}
-
 // ============================================================================
 // StreamPhase transition algebra (stage 0 vocabulary only)
 // ============================================================================
@@ -136,10 +123,6 @@ export function isActivePhase(phase: StreamPhase | undefined): boolean {
 
 export function isInFlightPhase(phase: StreamPhase | undefined): boolean {
   return phase === STREAM_PHASE.RUNNING || phase === STREAM_PHASE.WAITING;
-}
-
-function isTerminalPhase(phase: StreamPhase | undefined): boolean {
-  return phase === STREAM_PHASE.WAITING || isTerminalOutcomePhase(phase);
 }
 
 export function canAcquireStreamReservation(
@@ -192,55 +175,4 @@ export function canTransitionStreamPhase(
           to === STREAM_PHASE.CANCELLED)
       );
   }
-}
-
-// ============================================================================
-// Status trait predicates (derived from STREAM_STATUS_TRAITS)
-// ============================================================================
-//
-// Membership lives in the declarative trait table in `@shared/schemas/stream`
-// (`STREAM_STATUS_TRAITS`); these are thin readers over it. Do not declare
-// new status lists by hand — add a trait column instead.
-
-/** Shared trait lookup: a `StreamPhase` value parses straight to the phase
- *  predicate, otherwise falls back to the legacy `StreamStatus` trait table. */
-function hasStatusTrait(
-  status: string | undefined,
-  phasePredicate: (phase: StreamPhase | undefined) => boolean,
-  trait: StreamStatusTrait,
-): boolean {
-  const phase = StreamPhaseSchema.safeParse(status);
-  if (phase.success) return phasePredicate(phase.data);
-  return (
-    status !== undefined &&
-    Object.hasOwn(STREAM_STATUS_TRAITS, status) &&
-    STREAM_STATUS_TRAITS[status as StreamStatus][trait]
-  );
-}
-
-/** Check if a status indicates active execution (running or resuming). */
-export function isActiveStatus(status: string | undefined): boolean {
-  return hasStatusTrait(status, isActivePhase, 'active');
-}
-
-/**
- * Statuses during which an agent cycle may still be appending to the stream
- * and it must not be evicted from memory or acquired by a new run.
- */
-export function isInFlightStatus(status: string | undefined): boolean {
-  return hasStatusTrait(status, isInFlightPhase, 'inFlight');
-}
-
-/** Check if a status is terminal (execution ended). */
-export function isTerminalStatus(status: string | undefined): boolean {
-  return hasStatusTrait(status, isTerminalPhase, 'terminal');
-}
-
-/** Check if elapsed-time displays should keep advancing for this status. */
-export function isLiveElapsedStatus(status: string | undefined): boolean {
-  return hasStatusTrait(
-    status,
-    (phase) => phase === STREAM_PHASE.RUNNING,
-    'liveElapsed',
-  );
 }

--- a/src/test-kernel/shared/RunOutcomeAlgebra.vitest.ts
+++ b/src/test-kernel/shared/RunOutcomeAlgebra.vitest.ts
@@ -18,15 +18,10 @@ import {
   canTransitionStreamPhase,
   deriveRunOutcome,
   groupEndStatusForOutcome,
-  isActiveStatus,
-  isInFlightStatus,
-  isLiveElapsedStatus,
-  isTerminalStatus,
   legacyEndGroupStatusForOutcome,
   projectRunOutcome,
   RUN_OUTCOME_PROJECTION,
   STREAM_TRANSITION_CAUSE,
-  terminalStreamStatusForOutcome,
   type StreamTransitionCause,
 } from '@shared/streams/streamStatus';
 
@@ -71,7 +66,7 @@ describe('run outcome algebra', () => {
   // read-side derive helper for the frozen CLI headless JSON's
   // `endGroupStatus` projection (packages/cli/src/runtime/terminalStatus.ts)
   // — the algebra itself is unchanged, so it still needs to stay correct.
-  it('derives folded legacy group-end and stream-status projections from one helper', () => {
+  it('derives folded legacy group-end projections from one helper', () => {
     expect(groupEndStatusForOutcome(RUN_OUTCOME.COMPLETED)).toBe('ok');
     expect(groupEndStatusForOutcome(RUN_OUTCOME.CANCELLED)).toBe('ok');
     expect(groupEndStatusForOutcome(RUN_OUTCOME.FAILED)).toBe('error');
@@ -83,16 +78,6 @@ describe('run outcome algebra', () => {
       'stopped',
     );
     expect(legacyEndGroupStatusForOutcome(RUN_OUTCOME.FAILED)).toBe('error');
-
-    expect(terminalStreamStatusForOutcome(RUN_OUTCOME.COMPLETED)).toBe(
-      STREAM_STATUS.STOPPED,
-    );
-    expect(terminalStreamStatusForOutcome(RUN_OUTCOME.CANCELLED)).toBe(
-      STREAM_STATUS.STOPPED,
-    );
-    expect(terminalStreamStatusForOutcome(RUN_OUTCOME.FAILED)).toBe(
-      STREAM_STATUS.ERROR,
-    );
   });
 
   it('fails loudly on an out-of-vocabulary outcome', () => {
@@ -224,29 +209,5 @@ describe('stream status trait table', () => {
         STREAM_STATUS.READY,
       ]),
     );
-  });
-
-  it('pins the deliberate oddballs', () => {
-    // WAITING is terminal (cycle ended, status bar idle) AND in-flight
-    // (follow-up appends to the same log; not acquirable by a new run).
-    expect(isTerminalStatus(STREAM_STATUS.WAITING)).toBe(true);
-    expect(isInFlightStatus(STREAM_STATUS.WAITING)).toBe(true);
-    // INITIALIZING is neither active nor terminal: pre-start, ticking
-    // elapsed time, blocking acquisition, running no model calls.
-    expect(isActiveStatus(STREAM_STATUS.INITIALIZING)).toBe(false);
-    expect(isTerminalStatus(STREAM_STATUS.INITIALIZING)).toBe(false);
-    expect(isInFlightStatus(STREAM_STATUS.INITIALIZING)).toBe(true);
-    expect(isLiveElapsedStatus(STREAM_STATUS.INITIALIZING)).toBe(true);
-  });
-
-  it('treats undefined as no status for every predicate', () => {
-    expect(isActiveStatus(undefined)).toBe(false);
-    expect(isInFlightStatus(undefined)).toBe(false);
-    expect(isLiveElapsedStatus(undefined)).toBe(false);
-    expect(isTerminalStatus(undefined)).toBe(false);
-  });
-
-  it('treats unknown child execution statuses as not live elapsed', () => {
-    expect(isLiveElapsedStatus('completed')).toBe(false);
   });
 });

--- a/src/test-kernel/utils/text/StringUtils.vitest.ts
+++ b/src/test-kernel/utils/text/StringUtils.vitest.ts
@@ -7,34 +7,12 @@ import {
   formatCompactDuration,
   formatCompactTokenCount,
   formatResultCount,
-  objectToLogString,
   pluralize,
   splitContentLines,
   splitOutputLines,
   tailWithEllipsis,
   truncateWithEllipsis,
 } from '@utils/text/stringUtils';
-
-describe('objectToLogString', () => {
-  it('serializes plain objects to compact JSON', () => {
-    expect(objectToLogString({ a: 1, b: 'x' })).toBe('{"a":1,"b":"x"}');
-  });
-
-  it('keeps diagnostic value for circular references instead of [object Object]', () => {
-    const obj: Record<string, unknown> = { a: 1 };
-    obj.self = obj;
-    const out = objectToLogString(obj);
-    expect(out).toContain('"a":1');
-    expect(out).toContain('[Circular]');
-    expect(out).not.toBe('[object Object]');
-  });
-
-  it('truncates oversized output and reports the original length', () => {
-    const out = objectToLogString({ blob: 'x'.repeat(50) }, 20);
-    expect(out).toMatch(/\.\.\. \(\d+ chars\)$/);
-    expect(out.length).toBeLessThan(50);
-  });
-});
 
 describe('splitContentLines', () => {
   it('normalizes CRLF and drops the phantom line after a trailing newline', () => {

--- a/src/utils/text/stringUtils.ts
+++ b/src/utils/text/stringUtils.ts
@@ -1,6 +1,5 @@
 import prettyMilliseconds from 'pretty-ms';
 import pluralizeWord from 'pluralize';
-import safeStringify from 'safe-stable-stringify';
 import { serializeError } from 'serialize-error';
 
 const graphemeSegmenter = new Intl.Segmenter(undefined, {
@@ -134,22 +133,6 @@ export function formatResultCount(
 /** UTC calendar date (`YYYY-MM-DD`) of a Date; defaults to now. */
 export function isoDateOnly(date: Date = new Date()): string {
   return date.toISOString().slice(0, 10);
-}
-
-export function objectToLogString(
-  obj: unknown,
-  maxLength: number = 1000,
-): string {
-  // `safe-stable-stringify` never throws on the inputs `JSON.stringify` chokes
-  // on: circular references become `"[Circular]"` and BigInt is handled, so a
-  // log line keeps its diagnostic value instead of collapsing to the useless
-  // `"[object Object]"` that the old `catch (_err) { return String(obj) }`
-  // produced. Returns `undefined` only for inputs with no JSON representation
-  // (e.g. a bare `undefined`), which we render as the string `"undefined"`.
-  const json = safeStringify(obj) ?? String(obj);
-  return json.length > maxLength
-    ? `${json.slice(0, maxLength)}... (${json.length} chars)`
-    : json;
 }
 
 /**


### PR DESCRIPTION
## Summary

Deletes verified dead code found by a read-only tech-debt scan of the `platform-infra`, `storage-transcript`, and `controllers-shared` areas (the current tech-debt-tournament rotation slice). Every symbol removed here had **zero production callers** — confirmed by repo-wide `ripgrep` over `src/` and `packages/` excluding tests — with the only references being the symbols' own unit tests. No behavior change.

Four independent removals:

- **`shared/streams/streamStatus.ts`** — drop the legacy string-`StreamStatus` trait layer that the `StreamPhase` predicates superseded: `isActiveStatus`, `isInFlightStatus`, `isTerminalStatus`, `isLiveElapsedStatus`, the private `hasStatusTrait`/`isTerminalPhase` helpers, and `terminalStreamStatusForOutcome`. The phase-based predicates (`isActivePhase`/`isInFlightPhase`/`isTerminalOutcomePhase`) remain the single live API. `STREAM_STATUS_TRAITS` in `schemas/stream.ts` loses its now-unused `export` (still used internally by `streamStatusesWithTrait`).
- **`agent/trace`** — demote `withStage` off the public `AgentTrace` interface and its `noopTrace` stub. It has no interface-typed callers; the only call sites reach it through the concrete `TraceEmitter` (`StageHandleImpl`/`SkippedStageHandle` hold `TraceEmitter`, not `AgentTrace`), which keeps it as a plain method.
- **`utils/text/stringUtils.ts`** — delete `objectToLogString` (test-only) and its now-orphaned `safe-stable-stringify` import.
- **`platform/defaults/globalStorage.ts`** — inline the `GLOBAL_STORAGE_LAYOUT` identity-indirection object into the two consts it fed.

Corresponding test cases are pruned.

## Issue acceptance gates

No tracked issue — these candidates came from a scheduled tech-debt scan whose issue-filing path was unavailable this cycle, so no umbrella issue was filed. Findings were verified directly (caller-count greps + full type/lint/test gates) rather than through the tournament's adversarial-verify phase.

## Single source of truth

- Stream liveness/terminality: the `StreamPhase` predicates in `shared/streams/streamStatus.ts` remain the sole API; the parallel string-status predicates are gone.
- Stream status trait membership: `STREAM_STATUS_TRAITS` + `streamStatusesWithTrait` in `schemas/stream.ts` stay the one trait table, now module-private.
- Stage scoping: `TraceEmitter` is the sole owner of `withStage`.

## Duplication and abstraction budget

Removes a superseded duplicate predicate family (string-status vs phase) and one identity-indirection object. No new abstraction added; no pass-through layers introduced.

## Net elements (R6)

- Files changed: 8 (0 added, 0 deleted)
- Exported symbols: **−7 net** (`isActiveStatus`, `isInFlightStatus`, `isTerminalStatus`, `isLiveElapsedStatus`, `terminalStreamStatusForOutcome`, `STREAM_STATUS_TRAITS`, `objectToLogString`); the two `globalStorage` consts are rewritten, not removed
- Interface members: −1 (`AgentTrace.withStage`) + its `noopTrace` stub
- Other named elements: −4 private (`hasStatusTrait`, `isTerminalPhase`, `GLOBAL_STORAGE_LAYOUT`, and the `safe-stable-stringify` default import)
- Net LoC: **−158** (4 insertions, 162 deletions)

## Consumer counts (R8)

All removed symbols: **0 production consumers** (ripgrep over `src`/`packages`, excluding `*.vitest.*` and `test-kernel/`). References were exclusively the symbols' own unit tests, which are pruned in this PR. `STREAM_STATUS_TRAITS`: 0 external importers after this change (used only within `schemas/stream.ts`), so it is de-exported rather than deleted. `withStage`: 3 internal call sites, all on the concrete `TraceEmitter` (`this.withStage`, `StageHandleImpl.within`, `SkippedStageHandle.within`) — unaffected.

## Host impact

Extension: none (dead code only).

Desktop: none.

CLI: none.

## Scheduled refactoring

None. Larger decision-gated candidates from the same scan (retiring the legacy result-meta dual-read parser, the one-shot execution-history migration) were intentionally left out — they need maintainer rulings on data retention / migration-window closure and are not behavior-preserving deletions.

## Validation

- `npm run typecheck` — pass (all 6 projects; root + test-kernel re-run after the final edit)
- `npm run lint` (changed files) — clean
- `npm run check:dead-code-ratchet` — pass (net −1 dead export vs baseline; no baseline edit needed)
- `npx vitest run` over the two directly-affected suites (48 tests) plus all 80 trace/stream-status-touching suites (1117 tests) — all pass

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013D6md9RZo8Bhp83kQKLVr3)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving deletion of symbols with no production callers; stream phase logic and TraceEmitter stage scoping are unchanged.
> 
> **Overview**
> Removes **verified dead code** (~158 lines) with no intended runtime behavior change.
> 
> **Stream status:** Drops the legacy string-`StreamStatus` predicate layer (`isActiveStatus`, `isInFlightStatus`, `isTerminalStatus`, `isLiveElapsedStatus`, `terminalStreamStatusForOutcome`, and related helpers) from `streamStatus.ts`. **StreamPhase** predicates and transition algebra stay the live API. `STREAM_STATUS_TRAITS` in `schemas/stream.ts` is no longer exported but still backs `streamStatusesWithTrait`.
> 
> **Tracing:** Removes `withStage` from the public `AgentTrace` interface and `noopTrace`; **`TraceEmitter`** keeps `withStage` for internal stage handles.
> 
> **Misc:** Deletes test-only `objectToLogString` and the `safe-stable-stringify` dependency; inlines `GLOBAL_STORAGE_LAYOUT` into the two `globalStorage` path constants.
> 
> Matching unit tests are pruned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d83d59767fe42ac3b41547dfaf35ef7e72a775f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->