### PR TITLE
Refactor state reset mechanisms and type safety across views

### DIFF
--- a/packages/cli/src/chat/tui/state/transcriptLines.ts
+++ b/packages/cli/src/chat/tui/state/transcriptLines.ts
@@ -36,14 +36,33 @@ export function createTranscriptPrintRequest({
 
 // Wrapped-line cache keyed by the immutable entry object. Entries are
 // replaced (never mutated in place) when their content changes, so hits are
-// always current. Each entry can be rendered at several widths in the same
-// frame (terminal transcript, static row budget, task-detail panel), so keep
-// the width dimension inside the entry cache instead of letting callers thrash
-// a single slot.
+// always current, and the outer WeakMap needs no manual eviction: once an
+// entry is replaced/discarded, its cache slot (and everything nested under
+// it) becomes unreachable and is reclaimed with it. Each entry can be
+// rendered at several widths in the same frame (terminal transcript, static
+// row budget, task-detail panel), and occasionally under more than one
+// execution-labels snapshot (labels are a `computed()` signal that only
+// produces a new Map when the child-stream roster actually changes), so both
+// axes are folded into one composite key inside a flat `Map` nested one
+// level under the entry — GC-tied on the primary (entry) axis without the
+// extra WeakMap level for labels. `labelsToken` gives each distinct labels
+// object a small stable numeric id (itself WeakMap-backed, so retired labels
+// objects don't pin memory) to keep that composite key cheap to build.
 const EMPTY_EXECUTION_LABELS: ExecutionLabels = new Map();
+let nextLabelsToken = 0;
+const labelsTokens = new WeakMap<ExecutionLabels, number>();
+
+function labelsToken(executionLabels: ExecutionLabels): number {
+  const existing = labelsTokens.get(executionLabels);
+  if (existing !== undefined) return existing;
+  const token = nextLabelsToken++;
+  labelsTokens.set(executionLabels, token);
+  return token;
+}
+
 const entryLinesCache = new WeakMap<
   ConversationEntry,
-  WeakMap<ExecutionLabels, Map<number, readonly string[]>>
+  Map<string, readonly string[]>
 >();
 
 function transcriptEntryLines(
@@ -51,20 +70,15 @@ function transcriptEntryLines(
   cols: number,
   executionLabels: ExecutionLabels,
 ): readonly string[] {
-  const cachedByLabels = entryLinesCache.get(entry);
-  const cachedByCols = cachedByLabels?.get(executionLabels);
-  const cached = cachedByCols?.get(cols);
+  const key = `${labelsToken(executionLabels)}:${cols}`;
+  const cachedByEntry = entryLinesCache.get(entry);
+  const cached = cachedByEntry?.get(key);
   if (cached) return cached;
   const lines = computeTranscriptEntryLines(entry, cols, executionLabels);
-  if (cachedByCols) {
-    cachedByCols.set(cols, lines);
-  } else if (cachedByLabels) {
-    cachedByLabels.set(executionLabels, new Map([[cols, lines]]));
+  if (cachedByEntry) {
+    cachedByEntry.set(key, lines);
   } else {
-    entryLinesCache.set(
-      entry,
-      new WeakMap([[executionLabels, new Map([[cols, lines]])]]),
-    );
+    entryLinesCache.set(entry, new Map([[key, lines]]));
   }
   return lines;
 }

--- a/packages/cli/src/chat/tui/state/transcriptLines.ts
+++ b/packages/cli/src/chat/tui/state/transcriptLines.ts
@@ -60,6 +60,15 @@ function labelsToken(executionLabels: ExecutionLabels): number {
   return token;
 }
 
+// Cap each entry's composite-key slots so a long session with many terminal
+// resizes / labels-roster changes can't grow an entry's inner Map forever —
+// only the outer WeakMap's entry-level eviction is free (GC-tied); the
+// `${token}:${cols}` keys inside it are strong references the entry itself
+// won't drop on its own. In practice only the current width and the current
+// labels snapshot are re-rendered at once, so a small cap costs no realistic
+// hit rate.
+const MAX_LINES_PER_ENTRY = 4;
+
 const entryLinesCache = new WeakMap<
   ConversationEntry,
   Map<string, readonly string[]>
@@ -76,6 +85,10 @@ function transcriptEntryLines(
   if (cached) return cached;
   const lines = computeTranscriptEntryLines(entry, cols, executionLabels);
   if (cachedByEntry) {
+    if (cachedByEntry.size >= MAX_LINES_PER_ENTRY) {
+      const oldestKey = cachedByEntry.keys().next().value;
+      if (oldestKey !== undefined) cachedByEntry.delete(oldestKey);
+    }
     cachedByEntry.set(key, lines);
   } else {
     entryLinesCache.set(entry, new Map([[key, lines]]));

--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -22,6 +22,7 @@ import {
   type StreamSubstate,
   type StreamTabInfo,
 } from '@shared/schemas';
+import { deriveGoalState, type GoalStatus } from '@shared/schemas/goal';
 import {
   formatStreamStatusLabel,
   streamStatusDisplayKey,
@@ -468,12 +469,19 @@ export class StreamHeader extends LitElement {
   }
 
   private renderGoalChip(): TemplateResult | typeof nothing {
-    if (!this.goalActive) return nothing;
-    const isPaused = this.goalStatus === 'paused';
+    // `goalActive`/`goalStatus`/`goalObjective` are three independently-set
+    // properties (mirroring the wire/storage shape) — derive the canonical
+    // "status/objective only meaningful when active" union once here rather
+    // than guarding ad hoc.
+    const goal = deriveGoalState({
+      goalActive: this.goalActive,
+      goalStatus: (this.goalStatus || undefined) as GoalStatus | undefined,
+      goalObjective: this.goalObjective || undefined,
+    });
+    if (!goal.active) return nothing;
+    const isPaused = goal.status === 'paused';
     const label = isPaused ? 'Goal paused' : 'Goal';
-    const tooltip = this.goalObjective
-      ? `${label}: ${this.goalObjective}`
-      : label;
+    const tooltip = goal.objective ? `${label}: ${goal.objective}` : label;
     return html`<wa-badge
         id=${ELEMENT_IDS.GOAL_CHIP}
         class="goal-chip"

--- a/packages/extension/src/progressView/frontend/slices/permissionSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/permissionSlice.ts
@@ -9,6 +9,7 @@ import { create } from 'mutative';
 
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import type { ProgressViewOutboundHandlerRegistry } from '@shared/schemas';
+import { deriveGoalState } from '@shared/schemas/goal';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import { createBoundedIdSet } from '@utils/core/boundedIdSet';
 
@@ -100,13 +101,16 @@ export const permissionHandlers = {
   },
 
   [PROGRESS_VIEW_COMMANDS.GOAL_ACTIVE_UPDATED]: (data) => {
+    const goal = deriveGoalState({
+      goalActive: data.active,
+      goalStatus: data.status,
+      goalObjective: data.objective,
+    });
     updateToolUseState(data.stream, (prev) =>
       create(prev, (draft) => {
-        draft.goalActive = data.active;
-        draft.goalStatus = data.active ? (data.status ?? undefined) : undefined;
-        draft.goalObjective = data.active
-          ? (data.objective ?? undefined)
-          : undefined;
+        draft.goalActive = goal.active;
+        draft.goalStatus = goal.active ? goal.status : undefined;
+        draft.goalObjective = goal.active ? goal.objective : undefined;
       }),
     );
   },

--- a/packages/extension/src/progressView/frontend/slices/syncSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/syncSlice.ts
@@ -47,9 +47,9 @@ export const syncHandlers = {
       }));
     } else {
       const { workPlan, controls } = data;
-      // `controls.goal` is already the canonical GoalState-shaped union on
-      // the wire (GoalSyncSchema mirrors GoalState's discriminant/fields
-      // exactly) — no need to round-trip it through deriveGoalState.
+      // `controls.goal` is already GoalState (the wire schema imports
+      // GoalStateSchema directly from `@shared/schemas/goal`) — no need to
+      // round-trip it through deriveGoalState.
       const goal = controls.goal;
       updateToolUseState(data.stream, (prev) => ({
         ...prev,

--- a/packages/extension/src/progressView/frontend/slices/syncSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/syncSlice.ts
@@ -6,6 +6,7 @@ import {
   type ProgressViewOutboundHandlerRegistry,
   type StreamContentRenderPayload,
 } from '@shared/schemas';
+import { deriveGoalState } from '@shared/schemas/goal';
 
 // Local imports
 import {
@@ -48,6 +49,13 @@ export const syncHandlers = {
       }));
     } else {
       const { workPlan, controls } = data;
+      const goal = deriveGoalState({
+        goalActive: controls.goal.active,
+        goalStatus: controls.goal.active ? controls.goal.status : undefined,
+        goalObjective: controls.goal.active
+          ? controls.goal.objective
+          : undefined,
+      });
       updateToolUseState(data.stream, (prev) => ({
         ...prev,
         ...activeStateFields(data),
@@ -58,11 +66,9 @@ export const syncHandlers = {
         queuedFollowUps: workPlan.queuedFollowUps,
         toolEditBypass: controls.toolEditBypass,
         superYoloBypass: controls.superYoloBypass,
-        goalActive: controls.goal.active,
-        goalStatus: controls.goal.active ? controls.goal.status : undefined,
-        goalObjective: controls.goal.active
-          ? controls.goal.objective
-          : undefined,
+        goalActive: goal.active,
+        goalStatus: goal.active ? goal.status : undefined,
+        goalObjective: goal.active ? goal.objective : undefined,
       }));
     }
 

--- a/packages/extension/src/progressView/frontend/slices/syncSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/syncSlice.ts
@@ -6,8 +6,6 @@ import {
   type ProgressViewOutboundHandlerRegistry,
   type StreamContentRenderPayload,
 } from '@shared/schemas';
-import { deriveGoalState } from '@shared/schemas/goal';
-
 // Local imports
 import {
   updateParentStreamId,
@@ -49,13 +47,10 @@ export const syncHandlers = {
       }));
     } else {
       const { workPlan, controls } = data;
-      const goal = deriveGoalState({
-        goalActive: controls.goal.active,
-        goalStatus: controls.goal.active ? controls.goal.status : undefined,
-        goalObjective: controls.goal.active
-          ? controls.goal.objective
-          : undefined,
-      });
+      // `controls.goal` is already the canonical GoalState-shaped union on
+      // the wire (GoalSyncSchema mirrors GoalState's discriminant/fields
+      // exactly) — no need to round-trip it through deriveGoalState.
+      const goal = controls.goal;
       updateToolUseState(data.stream, (prev) => ({
         ...prev,
         ...activeStateFields(data),

--- a/packages/extension/src/settingsView/frontend/settingsState.ts
+++ b/packages/extension/src/settingsView/frontend/settingsState.ts
@@ -17,9 +17,19 @@
  * Singleton scope: only one Settings view per webview/page. If we ever need
  * multiple independent settings instances on the same page, this file must be
  * promoted to a per-instance store.
+ *
+ * Reset mechanism: every writable signal below is declared through
+ * `trackedSignal()` instead of the bare `signal()` import. `trackedSignal`
+ * records the signal's own default-value factory in `resetCallbacks` at the
+ * point of declaration, so `resetSettingsState()` can replay that single list
+ * instead of a hand-written, independently-ordered sequence of `.set()`
+ * calls. There is only one place that knows each signal's default — the
+ * `trackedSignal(() => ...)` call site — so a new signal can't be added
+ * without also being wired into the reset; forgetting the wrapper here would
+ * mean the signal isn't exported as reactive state at all.
  */
 
-import { signal } from '@shared/signals';
+import { Signal, signal } from '@shared/signals';
 import type {
   MemoryViewItem,
   HistoryItem,
@@ -63,115 +73,158 @@ const DEFAULT_CHATGPT_AUTH: ChatGptAuthStatus = {
 };
 
 // ---------------------------------------------------------------------------
+// Reset registry — populated by `trackedSignal` as each signal below is
+// declared. See the file-header note on the reset mechanism.
+// ---------------------------------------------------------------------------
+
+const resetCallbacks: Array<() => void> = [];
+
+/**
+ * Declares a writable signal and registers its reset callback in the same
+ * expression. `initialValue` is a factory (not a bare value) so every reset
+ * — like every fresh mount — constructs an independent value rather than
+ * reusing one shared object reference, matching how the previous hand-written
+ * resets spread mutable defaults (`{ ...DEFAULT_X }`) instead of assigning
+ * the constant directly.
+ */
+function trackedSignal<T>(initialValue: () => T): Signal.State<T> {
+  const s = signal(initialValue());
+  resetCallbacks.push(() => s.set(initialValue()));
+  return s;
+}
+
+// ---------------------------------------------------------------------------
 // Tab state
 // ---------------------------------------------------------------------------
-export const selectedTabIndex = signal(0);
+export const selectedTabIndex = trackedSignal(() => 0);
 
 // ---------------------------------------------------------------------------
 // Memory state
 // ---------------------------------------------------------------------------
-export const memoryItems = signal<MemoryViewItem[]>([]);
-export const memoryEnabled = signal(false);
-export const memoryToggleDisabled = signal(true);
+export const memoryItems = trackedSignal<MemoryViewItem[]>(() => []);
+export const memoryEnabled = trackedSignal(() => false);
+export const memoryToggleDisabled = trackedSignal(() => true);
 
 // ---------------------------------------------------------------------------
 // History state
 // ---------------------------------------------------------------------------
-export const historyItems = signal<HistoryItem[]>([]);
+export const historyItems = trackedSignal<HistoryItem[]>(() => []);
 
 // ---------------------------------------------------------------------------
 // Profile state
 // ---------------------------------------------------------------------------
-export const authenticated = signal(false);
-export const userEmail = signal('');
-export const tier = signal('free');
-export const apiAccessMode = signal<'included' | 'personal'>('personal');
-export const spendingStatus = signal<SpendingStatus | null>(null);
-export const quotaAutoSwitched = signal(false);
-export const providerKeyStatuses = signal<ProviderKeyStatus[]>([]);
-export const globalStreamingDefault = signal(true);
-export const providerKeyModal = signal<ProviderKeyModalTarget | null>(null);
+export const authenticated = trackedSignal(() => false);
+export const userEmail = trackedSignal(() => '');
+export const tier = trackedSignal(() => 'free');
+export const apiAccessMode = trackedSignal<'included' | 'personal'>(
+  () => 'personal',
+);
+export const spendingStatus = trackedSignal<SpendingStatus | null>(
+  () => null,
+);
+export const quotaAutoSwitched = trackedSignal(() => false);
+export const providerKeyStatuses = trackedSignal<ProviderKeyStatus[]>(
+  () => [],
+);
+export const globalStreamingDefault = trackedSignal(() => true);
+export const providerKeyModal = trackedSignal<ProviderKeyModalTarget | null>(
+  () => null,
+);
 
 // ---------------------------------------------------------------------------
 // Model selection state
 // ---------------------------------------------------------------------------
-export const modelSelectionItems = signal<ModelSelectionItem[]>([]);
-export const helperModel = signal(DEFAULT_HELPER_MODEL);
-export const preferShortModelNames = signal(false);
+export const modelSelectionItems = trackedSignal<ModelSelectionItem[]>(
+  () => [],
+);
+export const helperModel = trackedSignal(() => DEFAULT_HELPER_MODEL);
+export const preferShortModelNames = trackedSignal(() => false);
 
 // ---------------------------------------------------------------------------
 // Agent selection state
 // ---------------------------------------------------------------------------
-export const workflowAgents = signal<AgentSelectionItem[]>([]);
-export const toolUseAgents = signal<AgentSelectionItem[]>([]);
-export const customAgentDir = signal('');
-export const customAgentDirIsDefault = signal(true);
-export const agentSubTab = signal<AgentCategory | undefined>(undefined);
+export const workflowAgents = trackedSignal<AgentSelectionItem[]>(() => []);
+export const toolUseAgents = trackedSignal<AgentSelectionItem[]>(() => []);
+export const customAgentDir = trackedSignal(() => '');
+export const customAgentDirIsDefault = trackedSignal(() => true);
+export const agentSubTab = trackedSignal<AgentCategory | undefined>(
+  () => undefined,
+);
 
 // ---------------------------------------------------------------------------
 // Agent teams state
 // ---------------------------------------------------------------------------
-export const customPresets = signal<AgentModePreset[]>([]);
-export const orchestratorAgents = signal<string[]>([]);
+export const customPresets = trackedSignal<AgentModePreset[]>(() => []);
+export const orchestratorAgents = trackedSignal<string[]>(() => []);
 
 // ---------------------------------------------------------------------------
 // Multi-agent coordination state
 // ---------------------------------------------------------------------------
-export const reliabilitySettings = signal<NumberVscodeSetting[]>([]);
-export const allowOrchestratorKill = signal(true);
-export const detachSubagentsOnStop = signal(false);
+export const reliabilitySettings = trackedSignal<NumberVscodeSetting[]>(
+  () => [],
+);
+export const allowOrchestratorKill = trackedSignal(() => true);
+export const detachSubagentsOnStop = trackedSignal(() => false);
 
 // ---------------------------------------------------------------------------
 // Approval settings state
 // ---------------------------------------------------------------------------
-export const bashApprovalEnabled = signal(true);
-export const codexSandboxMode = signal<string>('workspace-write');
-export const codexReasoningEffort = signal<string>('high');
-export const codexApprovalPolicy = signal<string>('never');
-export const claudeAgentModel = signal<ClaudeAgentModel>(
-  CLAUDE_AGENT_DEFAULT_MODEL,
+export const bashApprovalEnabled = trackedSignal(() => true);
+export const codexSandboxMode = trackedSignal<string>(
+  () => 'workspace-write',
+);
+export const codexReasoningEffort = trackedSignal<string>(() => 'high');
+export const codexApprovalPolicy = trackedSignal<string>(() => 'never');
+export const claudeAgentModel = trackedSignal<ClaudeAgentModel>(
+  () => CLAUDE_AGENT_DEFAULT_MODEL,
 );
 export const claudeAgentPermissionMode =
-  signal<ClaudeAgentPermissionMode>('acceptEdits');
-export const claudeAgentEffort = signal<ClaudeAgentEffort>('high');
+  trackedSignal<ClaudeAgentPermissionMode>(() => 'acceptEdits');
+export const claudeAgentEffort = trackedSignal<ClaudeAgentEffort>(
+  () => 'high',
+);
 
 // ---------------------------------------------------------------------------
 // Tool dashboard state
 // ---------------------------------------------------------------------------
-export const toolDashboardItems = signal<ToolDashboardItem[]>([]);
-export const toolDashboardLoaded = signal(false);
+export const toolDashboardItems = trackedSignal<ToolDashboardItem[]>(() => []);
+export const toolDashboardLoaded = trackedSignal(() => false);
 
 // ---------------------------------------------------------------------------
 // Git author settings state
 // ---------------------------------------------------------------------------
-export const gitMarkCommits = signal(DEFAULT_GIT_MARK_COMMITS);
-export const gitAuthorName = signal(DEFAULT_GIT_AUTHOR_NAME);
-export const gitAuthorEmail = signal(DEFAULT_GIT_AUTHOR_EMAIL);
-export const gitWorktreeSupport = signal(false);
-export const gitSettingsLoaded = signal(false);
-export const githubTokenStatus = signal<'secret' | 'env' | 'none'>('none');
-export const chatgptAuth = signal<ChatGptAuthStatus>({
+export const gitMarkCommits = trackedSignal(() => DEFAULT_GIT_MARK_COMMITS);
+export const gitAuthorName = trackedSignal(() => DEFAULT_GIT_AUTHOR_NAME);
+export const gitAuthorEmail = trackedSignal(() => DEFAULT_GIT_AUTHOR_EMAIL);
+export const gitWorktreeSupport = trackedSignal(() => false);
+export const gitSettingsLoaded = trackedSignal(() => false);
+export const githubTokenStatus = trackedSignal<'secret' | 'env' | 'none'>(
+  () => 'none',
+);
+export const chatgptAuth = trackedSignal<ChatGptAuthStatus>(() => ({
   ...DEFAULT_CHATGPT_AUTH,
-});
-export const desktopCrashReportingEnabled = signal(false);
-export const desktopCrashReportingConfigured = signal(false);
-export const prSubscriptions = signal<readonly PRSubscriptionEntry[]>([]);
+}));
+export const desktopCrashReportingEnabled = trackedSignal(() => false);
+export const desktopCrashReportingConfigured = trackedSignal(() => false);
+export const prSubscriptions = trackedSignal<readonly PRSubscriptionEntry[]>(
+  () => [],
+);
 
 // ---------------------------------------------------------------------------
 // LaTeX settings state
 // ---------------------------------------------------------------------------
-export const latexSettingsStatus = signal({
+export const latexSettingsStatus = trackedSignal(() => ({
   ...DEFAULT_LATEX_SETTINGS_STATUS,
-});
-export const latexSettingsLoaded = signal(false);
-export const latexConfigValues = signal<LatexConfigValues>({});
-export const latexConfigValuesLoaded = signal(false);
-export const inlineCriticismEnabled = signal(false);
+}));
+export const latexSettingsLoaded = trackedSignal(() => false);
+export const latexConfigValues = trackedSignal<LatexConfigValues>(() => ({}));
+export const latexConfigValuesLoaded = trackedSignal(() => false);
+export const inlineCriticismEnabled = trackedSignal(() => false);
 
 // ---------------------------------------------------------------------------
 // Goal settings state
 // ---------------------------------------------------------------------------
-export const goalItems = signal<readonly Goal[]>([]);
+export const goalItems = trackedSignal<readonly Goal[]>(() => []);
 
 // ---------------------------------------------------------------------------
 // Derived capability view: commands the active host's inbound registry
@@ -182,77 +235,19 @@ export const goalItems = signal<readonly Goal[]>([]);
 // "not yet known" as unsupported so a control never flashes visible then
 // hidden once the real capability set lands.
 // ---------------------------------------------------------------------------
-export const unsupportedCommands = signal<ReadonlySet<string> | null>(null);
+export const unsupportedCommands = trackedSignal<ReadonlySet<string> | null>(
+  () => null,
+);
 
 // ---------------------------------------------------------------------------
 // Reset — module-level state is shared across remounts in the same JS context
-// (tests, hot reload). Mirrors `resetProgressState()` in progressState.ts.
+// (tests, hot reload). Mirrors `resetProgressState()` in progressState.ts in
+// intent (replay the one source of truth on remount); the mechanism differs
+// because these signals stay individually exported rather than living behind
+// one monolithic object signal — see the file-header note.
 // ---------------------------------------------------------------------------
 export function resetSettingsState(): void {
-  selectedTabIndex.set(0);
-
-  memoryItems.set([]);
-  memoryEnabled.set(false);
-  memoryToggleDisabled.set(true);
-
-  historyItems.set([]);
-
-  authenticated.set(false);
-  userEmail.set('');
-  tier.set('free');
-  apiAccessMode.set('personal');
-  spendingStatus.set(null);
-  quotaAutoSwitched.set(false);
-  providerKeyStatuses.set([]);
-  globalStreamingDefault.set(true);
-  providerKeyModal.set(null);
-
-  modelSelectionItems.set([]);
-  helperModel.set(DEFAULT_HELPER_MODEL);
-  preferShortModelNames.set(false);
-
-  workflowAgents.set([]);
-  toolUseAgents.set([]);
-  customAgentDir.set('');
-  customAgentDirIsDefault.set(true);
-  agentSubTab.set(undefined);
-
-  customPresets.set([]);
-  orchestratorAgents.set([]);
-
-  reliabilitySettings.set([]);
-  allowOrchestratorKill.set(true);
-  detachSubagentsOnStop.set(false);
-
-  bashApprovalEnabled.set(true);
-  codexSandboxMode.set('workspace-write');
-  codexReasoningEffort.set('high');
-  codexApprovalPolicy.set('never');
-  claudeAgentModel.set(CLAUDE_AGENT_DEFAULT_MODEL);
-  claudeAgentPermissionMode.set('acceptEdits');
-  claudeAgentEffort.set('high');
-
-  toolDashboardItems.set([]);
-  toolDashboardLoaded.set(false);
-
-  gitMarkCommits.set(DEFAULT_GIT_MARK_COMMITS);
-  gitAuthorName.set(DEFAULT_GIT_AUTHOR_NAME);
-  gitAuthorEmail.set(DEFAULT_GIT_AUTHOR_EMAIL);
-  gitWorktreeSupport.set(false);
-  gitSettingsLoaded.set(false);
-  githubTokenStatus.set('none');
-  chatgptAuth.set({ ...DEFAULT_CHATGPT_AUTH });
-  desktopCrashReportingEnabled.set(false);
-  desktopCrashReportingConfigured.set(false);
-  prSubscriptions.set([]);
-
-  latexSettingsStatus.set({ ...DEFAULT_LATEX_SETTINGS_STATUS });
-  latexSettingsLoaded.set(false);
-  latexConfigValues.set({});
-  latexConfigValuesLoaded.set(false);
-  inlineCriticismEnabled.set(false);
-
-  goalItems.set([]);
-
-  unsupportedCommands.set(null);
+  for (const reset of resetCallbacks) {
+    reset();
+  }
 }

--- a/packages/extension/src/settingsView/frontend/settingsState.ts
+++ b/packages/extension/src/settingsView/frontend/settingsState.ts
@@ -29,7 +29,7 @@
  * mean the signal isn't exported as reactive state at all.
  */
 
-import { Signal, signal } from '@shared/signals';
+import { createTrackedSignalRegistry } from '@shared/signals';
 import type {
   MemoryViewItem,
   HistoryItem,
@@ -77,21 +77,8 @@ const DEFAULT_CHATGPT_AUTH: ChatGptAuthStatus = {
 // declared. See the file-header note on the reset mechanism.
 // ---------------------------------------------------------------------------
 
-const resetCallbacks: Array<() => void> = [];
-
-/**
- * Declares a writable signal and registers its reset callback in the same
- * expression. `initialValue` is a factory (not a bare value) so every reset
- * — like every fresh mount — constructs an independent value rather than
- * reusing one shared object reference, matching how the previous hand-written
- * resets spread mutable defaults (`{ ...DEFAULT_X }`) instead of assigning
- * the constant directly.
- */
-function trackedSignal<T>(initialValue: () => T): Signal.State<T> {
-  const s = signal(initialValue());
-  resetCallbacks.push(() => s.set(initialValue()));
-  return s;
-}
+const { trackedSignal, resetAll: resetTrackedSignals } =
+  createTrackedSignalRegistry();
 
 // ---------------------------------------------------------------------------
 // Tab state
@@ -119,13 +106,9 @@ export const tier = trackedSignal(() => 'free');
 export const apiAccessMode = trackedSignal<'included' | 'personal'>(
   () => 'personal',
 );
-export const spendingStatus = trackedSignal<SpendingStatus | null>(
-  () => null,
-);
+export const spendingStatus = trackedSignal<SpendingStatus | null>(() => null);
 export const quotaAutoSwitched = trackedSignal(() => false);
-export const providerKeyStatuses = trackedSignal<ProviderKeyStatus[]>(
-  () => [],
-);
+export const providerKeyStatuses = trackedSignal<ProviderKeyStatus[]>(() => []);
 export const globalStreamingDefault = trackedSignal(() => true);
 export const providerKeyModal = trackedSignal<ProviderKeyModalTarget | null>(
   () => null,
@@ -170,9 +153,7 @@ export const detachSubagentsOnStop = trackedSignal(() => false);
 // Approval settings state
 // ---------------------------------------------------------------------------
 export const bashApprovalEnabled = trackedSignal(() => true);
-export const codexSandboxMode = trackedSignal<string>(
-  () => 'workspace-write',
-);
+export const codexSandboxMode = trackedSignal<string>(() => 'workspace-write');
 export const codexReasoningEffort = trackedSignal<string>(() => 'high');
 export const codexApprovalPolicy = trackedSignal<string>(() => 'never');
 export const claudeAgentModel = trackedSignal<ClaudeAgentModel>(
@@ -180,9 +161,7 @@ export const claudeAgentModel = trackedSignal<ClaudeAgentModel>(
 );
 export const claudeAgentPermissionMode =
   trackedSignal<ClaudeAgentPermissionMode>(() => 'acceptEdits');
-export const claudeAgentEffort = trackedSignal<ClaudeAgentEffort>(
-  () => 'high',
-);
+export const claudeAgentEffort = trackedSignal<ClaudeAgentEffort>(() => 'high');
 
 // ---------------------------------------------------------------------------
 // Tool dashboard state
@@ -247,7 +226,5 @@ export const unsupportedCommands = trackedSignal<ReadonlySet<string> | null>(
 // one monolithic object signal — see the file-header note.
 // ---------------------------------------------------------------------------
 export function resetSettingsState(): void {
-  for (const reset of resetCallbacks) {
-    reset();
-  }
+  resetTrackedSignals();
 }

--- a/packages/extension/src/webview/frontend/mainViewState.ts
+++ b/packages/extension/src/webview/frontend/mainViewState.ts
@@ -12,6 +12,15 @@
  * Singleton scope: only one Main view per webview/page. If we ever need
  * multiple independent main-view instances on the same page, this file must
  * be promoted to a per-instance store.
+ *
+ * Reset mechanism: every writable signal below is declared through
+ * `trackedSignal()` instead of the bare `signal()` import. `trackedSignal`
+ * records the signal's own default-value factory in `resetCallbacks` at the
+ * point of declaration, so `resetMainViewState()` can replay that single list
+ * instead of a hand-written, independently-ordered sequence of `.set()`
+ * calls. There is only one place that knows each signal's default — the
+ * `trackedSignal(() => ...)` call site — so a new signal can't be added
+ * without also being wired into the reset.
  */
 
 // Local imports - shared signals and schemas
@@ -56,40 +65,79 @@ export type { FileStateContextValue, SessionContextValue };
 export type WebviewOnboardingFunnelState = OnboardingFunnelState | 'pending';
 
 // ---------------------------------------------------------------------------
+// Reset registry — populated by `trackedSignal` as each signal below is
+// declared. See the file-header note on the reset mechanism.
+// ---------------------------------------------------------------------------
+
+const resetCallbacks: Array<() => void> = [];
+
+/**
+ * Declares a writable signal and registers its reset callback in the same
+ * expression. `initialValue` is a factory (not a bare value) so every reset
+ * — like every fresh mount — constructs an independent value rather than
+ * reusing one shared object reference, matching how the previous hand-written
+ * resets spread mutable defaults (`{ ...DEFAULT_X }`) instead of assigning
+ * the constant directly.
+ */
+function trackedSignal<T>(initialValue: () => T): Signal.State<T> {
+  const s = signal(initialValue());
+  resetCallbacks.push(() => s.set(initialValue()));
+  return s;
+}
+
+// ---------------------------------------------------------------------------
 // Session / agent / model / instruction state
 // ---------------------------------------------------------------------------
 
-export const sessionType$ = signal<SessionType>(DEFAULT_STATE.sessionType);
-export const launchTarget$ = signal<LaunchTarget>(DEFAULT_STATE.launchTarget);
-export const selectedTeamId$ = signal(DEFAULT_STATE.selectedTeamId);
-export const workflowAgent$ = signal(DEFAULT_STATE.workflowAgent);
-export const toolUseAgent$ = signal(DEFAULT_STATE.toolUseAgent);
-export const model$ = signal(DEFAULT_STATE.model);
-export const commit$ = signal(DEFAULT_STATE.commit);
-export const instruction$ = signal(DEFAULT_STATE.instruction);
-export const workflowInstruction$ = signal(DEFAULT_STATE.workflowInstruction);
-export const toolUseInstruction$ = signal(DEFAULT_STATE.toolUseInstruction);
-export const instructionPlaceholder$ = signal(
-  ONBOARDING_PLACEHOLDERS[DEFAULT_STATE.sessionType][0],
+export const sessionType$ = trackedSignal<SessionType>(
+  () => DEFAULT_STATE.sessionType,
+);
+export const launchTarget$ = trackedSignal<LaunchTarget>(
+  () => DEFAULT_STATE.launchTarget,
+);
+export const selectedTeamId$ = trackedSignal(
+  () => DEFAULT_STATE.selectedTeamId,
+);
+export const workflowAgent$ = trackedSignal(() => DEFAULT_STATE.workflowAgent);
+export const toolUseAgent$ = trackedSignal(() => DEFAULT_STATE.toolUseAgent);
+export const model$ = trackedSignal(() => DEFAULT_STATE.model);
+export const commit$ = trackedSignal(() => DEFAULT_STATE.commit);
+export const instruction$ = trackedSignal(() => DEFAULT_STATE.instruction);
+export const workflowInstruction$ = trackedSignal(
+  () => DEFAULT_STATE.workflowInstruction,
+);
+export const toolUseInstruction$ = trackedSignal(
+  () => DEFAULT_STATE.toolUseInstruction,
+);
+export const instructionPlaceholder$ = trackedSignal(
+  () => ONBOARDING_PLACEHOLDERS[DEFAULT_STATE.sessionType][0],
 );
 
 // ---------------------------------------------------------------------------
 // Document / file state
 // ---------------------------------------------------------------------------
 
-export const singleFiles$ = signal<SingleFiles>({ ...DEFAULT_SINGLE_FILES });
-export const fileOptions$ = signal<FileOptions>({ ...DEFAULT_FILE_OPTIONS });
-export const multiFiles$ = signal<MultiFiles>({ ...DEFAULT_MULTI_FILES });
-export const checkboxValues$ = signal<CheckboxValues>({
+export const singleFiles$ = trackedSignal<SingleFiles>(() => ({
+  ...DEFAULT_SINGLE_FILES,
+}));
+export const fileOptions$ = trackedSignal<FileOptions>(() => ({
+  ...DEFAULT_FILE_OPTIONS,
+}));
+export const multiFiles$ = trackedSignal<MultiFiles>(() => ({
+  ...DEFAULT_MULTI_FILES,
+}));
+export const checkboxValues$ = trackedSignal<CheckboxValues>(() => ({
   ...DEFAULT_CHECKBOX_VALUES,
-});
-export const isGitRepo$ = signal(true);
+}));
+export const isGitRepo$ = trackedSignal(() => true);
 
 // ---------------------------------------------------------------------------
 // LaTeX-diffs / files-panel UI state
 // ---------------------------------------------------------------------------
 
-export const latexdiffsVisible$ = signal(DEFAULT_STATE.latexdiffsVisible);
+export const latexdiffsVisible$ = trackedSignal(
+  () => DEFAULT_STATE.latexdiffsVisible,
+);
 /**
  * Tracks whether the workflow Files <wa-details> is open. Initialized to
  * match the initial session type and updated imperatively from
@@ -97,68 +145,75 @@ export const latexdiffsVisible$ = signal(DEFAULT_STATE.latexdiffsVisible);
  * binding `?open=${isWorkflow}` would force the section open on every render
  * pass, defeating user collapses.
  */
-export const fileSelectionOpen$ = signal(
-  DEFAULT_STATE.sessionType === SESSION_TYPES.WORKFLOW,
+export const fileSelectionOpen$ = trackedSignal(
+  () => DEFAULT_STATE.sessionType === SESSION_TYPES.WORKFLOW,
 );
 
 // ---------------------------------------------------------------------------
 // Model / agent catalog data
 // ---------------------------------------------------------------------------
 
-export const modelOptions$ = signal<ModelOptionData[]>([]);
-export const workflowModelOptions$ = signal<ModelOptionData[] | undefined>(
-  undefined,
+export const modelOptions$ = trackedSignal<ModelOptionData[]>(() => []);
+export const workflowModelOptions$ = trackedSignal<
+  ModelOptionData[] | undefined
+>(() => undefined);
+export const toolUseModelOptions$ = trackedSignal<
+  ModelOptionData[] | undefined
+>(() => undefined);
+export const workflowAgentOptions$ = trackedSignal<AgentOptionData[]>(
+  () => [],
 );
-export const toolUseModelOptions$ = signal<ModelOptionData[] | undefined>(
-  undefined,
-);
-export const workflowAgentOptions$ = signal<AgentOptionData[]>([]);
-export const toolUseAgentOptions$ = signal<AgentOptionData[]>([]);
-export const teamOptions$ = signal<TeamOptionData[]>([]);
+export const toolUseAgentOptions$ = trackedSignal<AgentOptionData[]>(() => []);
+export const teamOptions$ = trackedSignal<TeamOptionData[]>(() => []);
 
 // ---------------------------------------------------------------------------
 // Chat / voice state
 // ---------------------------------------------------------------------------
 
-export const isRecording$ = signal(false);
-export const isPolishing$ = signal(false);
+export const isRecording$ = trackedSignal(() => false);
+export const isPolishing$ = trackedSignal(() => false);
 
 /**
  * Last status line pushed to the InstructionPanel's visually-hidden aria-live
  * region (screen-reader announcements for launcher/target fallbacks). Not
  * persisted; cleared on remount.
  */
-export const statusAnnouncement$ = signal('');
+export const statusAnnouncement$ = trackedSignal(() => '');
 
 // ---------------------------------------------------------------------------
 // Banners / onboarding state
 // ---------------------------------------------------------------------------
 
-export const apiKeyBanner$ = signal<ApiKeyBannerState>({ visible: false });
-export const agentConfigBanner$ = signal<AgentConfigBannerState>({
+export const apiKeyBanner$ = trackedSignal<ApiKeyBannerState>(() => ({
   visible: false,
-});
-export const dependencyBanner$ = signal<DependencyBannerState>({
+}));
+export const agentConfigBanner$ = trackedSignal<AgentConfigBannerState>(
+  () => ({
+    visible: false,
+  }),
+);
+export const dependencyBanner$ = trackedSignal<DependencyBannerState>(() => ({
   visible: false,
-});
-export const gettingStartedVisible$ = signal(false);
+}));
+export const gettingStartedVisible$ = trackedSignal(() => false);
 // Session-only: the host re-sends SHOW_GETTING_STARTED_BANNER on file
 // refreshes, so dismissal is tracked separately and never persisted.
-export const gettingStartedDismissed$ = signal(false);
-export const sessionHintDismissed$ = signal(true);
-export const loginBannerVisible$ = signal(false);
+export const gettingStartedDismissed$ = trackedSignal(() => false);
+export const sessionHintDismissed$ = trackedSignal(() => true);
+export const loginBannerVisible$ = trackedSignal(() => false);
 // Onboarding funnel (PRD: agent-native onboarding). The host owns the real
 // state; 'pending' only suppresses first-paint launcher/welcome flashes until
 // SET_ONBOARDING_FUNNEL arrives.
-export const onboardingFunnelState$ =
-  signal<WebviewOnboardingFunnelState>('pending');
+export const onboardingFunnelState$ = trackedSignal<WebviewOnboardingFunnelState>(
+  () => 'pending',
+);
 
 // ---------------------------------------------------------------------------
 // Host-pushed debug flag (mirrored from MainApp's @state field in willUpdate
 // so the module-scope sessionContext$ derivation can observe it).
 // ---------------------------------------------------------------------------
 
-export const debugMode$ = signal(false);
+export const debugMode$ = trackedSignal(() => false);
 
 // ---------------------------------------------------------------------------
 // Derived read helpers
@@ -230,44 +285,12 @@ export const sessionContext$ = new Signal.Computed((): SessionContextValue => ({
  * mount starts from the same slate a fresh per-instance field set used to
  * provide. Main-view state is singleton-scoped per the file header, so the
  * reset is a per-mount slate, not multi-instance coordination.
+ *
+ * Replays `resetCallbacks`, populated by `trackedSignal` at each signal's
+ * declaration site above — see the file-header note on the reset mechanism.
  */
 export function resetMainViewState(): void {
-  sessionType$.set(DEFAULT_STATE.sessionType);
-  launchTarget$.set(DEFAULT_STATE.launchTarget);
-  selectedTeamId$.set(DEFAULT_STATE.selectedTeamId);
-  workflowAgent$.set(DEFAULT_STATE.workflowAgent);
-  toolUseAgent$.set(DEFAULT_STATE.toolUseAgent);
-  model$.set(DEFAULT_STATE.model);
-  commit$.set(DEFAULT_STATE.commit);
-  instruction$.set(DEFAULT_STATE.instruction);
-  workflowInstruction$.set(DEFAULT_STATE.workflowInstruction);
-  toolUseInstruction$.set(DEFAULT_STATE.toolUseInstruction);
-  instructionPlaceholder$.set(
-    ONBOARDING_PLACEHOLDERS[DEFAULT_STATE.sessionType][0],
-  );
-  singleFiles$.set({ ...DEFAULT_SINGLE_FILES });
-  fileOptions$.set({ ...DEFAULT_FILE_OPTIONS });
-  multiFiles$.set({ ...DEFAULT_MULTI_FILES });
-  checkboxValues$.set({ ...DEFAULT_CHECKBOX_VALUES });
-  isGitRepo$.set(true);
-  latexdiffsVisible$.set(DEFAULT_STATE.latexdiffsVisible);
-  fileSelectionOpen$.set(DEFAULT_STATE.sessionType === SESSION_TYPES.WORKFLOW);
-  modelOptions$.set([]);
-  workflowModelOptions$.set(undefined);
-  toolUseModelOptions$.set(undefined);
-  workflowAgentOptions$.set([]);
-  toolUseAgentOptions$.set([]);
-  teamOptions$.set([]);
-  isRecording$.set(false);
-  isPolishing$.set(false);
-  statusAnnouncement$.set('');
-  apiKeyBanner$.set({ visible: false });
-  agentConfigBanner$.set({ visible: false });
-  dependencyBanner$.set({ visible: false });
-  gettingStartedVisible$.set(false);
-  gettingStartedDismissed$.set(false);
-  sessionHintDismissed$.set(true);
-  loginBannerVisible$.set(false);
-  onboardingFunnelState$.set('pending');
-  debugMode$.set(false);
+  for (const reset of resetCallbacks) {
+    reset();
+  }
 }

--- a/packages/extension/src/webview/frontend/mainViewState.ts
+++ b/packages/extension/src/webview/frontend/mainViewState.ts
@@ -24,7 +24,7 @@
  */
 
 // Local imports - shared signals and schemas
-import { Signal, signal } from '@shared/signals';
+import { Signal, createTrackedSignalRegistry } from '@shared/signals';
 import type {
   AgentConfigBannerState,
   AgentOptionData,
@@ -69,21 +69,8 @@ export type WebviewOnboardingFunnelState = OnboardingFunnelState | 'pending';
 // declared. See the file-header note on the reset mechanism.
 // ---------------------------------------------------------------------------
 
-const resetCallbacks: Array<() => void> = [];
-
-/**
- * Declares a writable signal and registers its reset callback in the same
- * expression. `initialValue` is a factory (not a bare value) so every reset
- * — like every fresh mount — constructs an independent value rather than
- * reusing one shared object reference, matching how the previous hand-written
- * resets spread mutable defaults (`{ ...DEFAULT_X }`) instead of assigning
- * the constant directly.
- */
-function trackedSignal<T>(initialValue: () => T): Signal.State<T> {
-  const s = signal(initialValue());
-  resetCallbacks.push(() => s.set(initialValue()));
-  return s;
-}
+const { trackedSignal, resetAll: resetTrackedSignals } =
+  createTrackedSignalRegistry();
 
 // ---------------------------------------------------------------------------
 // Session / agent / model / instruction state
@@ -160,9 +147,7 @@ export const workflowModelOptions$ = trackedSignal<
 export const toolUseModelOptions$ = trackedSignal<
   ModelOptionData[] | undefined
 >(() => undefined);
-export const workflowAgentOptions$ = trackedSignal<AgentOptionData[]>(
-  () => [],
-);
+export const workflowAgentOptions$ = trackedSignal<AgentOptionData[]>(() => []);
 export const toolUseAgentOptions$ = trackedSignal<AgentOptionData[]>(() => []);
 export const teamOptions$ = trackedSignal<TeamOptionData[]>(() => []);
 
@@ -187,11 +172,9 @@ export const statusAnnouncement$ = trackedSignal(() => '');
 export const apiKeyBanner$ = trackedSignal<ApiKeyBannerState>(() => ({
   visible: false,
 }));
-export const agentConfigBanner$ = trackedSignal<AgentConfigBannerState>(
-  () => ({
-    visible: false,
-  }),
-);
+export const agentConfigBanner$ = trackedSignal<AgentConfigBannerState>(() => ({
+  visible: false,
+}));
 export const dependencyBanner$ = trackedSignal<DependencyBannerState>(() => ({
   visible: false,
 }));
@@ -204,9 +187,8 @@ export const loginBannerVisible$ = trackedSignal(() => false);
 // Onboarding funnel (PRD: agent-native onboarding). The host owns the real
 // state; 'pending' only suppresses first-paint launcher/welcome flashes until
 // SET_ONBOARDING_FUNNEL arrives.
-export const onboardingFunnelState$ = trackedSignal<WebviewOnboardingFunnelState>(
-  () => 'pending',
-);
+export const onboardingFunnelState$ =
+  trackedSignal<WebviewOnboardingFunnelState>(() => 'pending');
 
 // ---------------------------------------------------------------------------
 // Host-pushed debug flag (mirrored from MainApp's @state field in willUpdate
@@ -286,11 +268,10 @@ export const sessionContext$ = new Signal.Computed((): SessionContextValue => ({
  * provide. Main-view state is singleton-scoped per the file header, so the
  * reset is a per-mount slate, not multi-instance coordination.
  *
- * Replays `resetCallbacks`, populated by `trackedSignal` at each signal's
- * declaration site above — see the file-header note on the reset mechanism.
+ * Replays the tracked-signal registry populated by `trackedSignal` at each
+ * signal's declaration site above — see the file-header note on the reset
+ * mechanism.
  */
 export function resetMainViewState(): void {
-  for (const reset of resetCallbacks) {
-    reset();
-  }
+  resetTrackedSignals();
 }

--- a/src/agent/export/normalizeConversation.ts
+++ b/src/agent/export/normalizeConversation.ts
@@ -102,8 +102,12 @@ const ContentBlockSchema = z.discriminatedUnion('type', [
     content: z.array(WebSearchResultItemSchema).optional(),
   }),
   // `extractWebFetchResultFields` reads its fields off the raw block itself
-  // (it accepts `unknown`), so this variant only needs the discriminant.
-  z.object({
+  // (it accepts `unknown`), not off this schema's inferred type, so this
+  // variant only declares the discriminant. `looseObject` (not `object`)
+  // documents that undeclared fields are intentionally read elsewhere —
+  // and keeps that true if runtime `.parse()` is ever added to this schema
+  // (currently it isn't; see the module-level type-derivation-only note).
+  z.looseObject({
     type: z.literal(ANTHROPIC_SERVER_TOOL_BLOCK_TYPES.webFetchToolResult),
   }),
 ]);

--- a/src/agent/export/normalizeConversation.ts
+++ b/src/agent/export/normalizeConversation.ts
@@ -39,37 +39,74 @@ import type { ExportNode, UserPart } from './schemas';
 // Input schemas (implementation detail — not exported publicly)
 // ============================================================
 
-/**
- * Loose schema for API content blocks — accepts many optional fields.
- * Covers Anthropic, OpenAI Chat Completions, and OpenAI Response API formats.
- */
-const ContentBlockSchema = z.looseObject({
+/** One entry inside a `web_search_tool_result` block's `content` array. */
+const WebSearchResultItemSchema = z.object({
   type: z.string(),
-  text: z.string().optional(),
-  thinking: z.string().optional(),
-  name: z.string().optional(),
-  id: z.string().optional(),
-  input: z.unknown().optional(),
-  content: z.unknown().optional(),
-  source: z
-    .looseObject({ type: z.string(), media_type: z.string().optional() })
-    .optional(),
-  query: z.string().optional(),
-  search_results: z
-    .array(
-      z.looseObject({
-        title: z.string().optional(),
-        url: z.string().optional(),
-      }),
-    )
-    .optional(),
-  url: z.string().optional(),
   title: z.string().optional(),
-  page_content: z.string().optional(),
-  // OpenAI Response API fields
-  arguments: z.string().optional(),
-  output: z.string().optional(),
+  url: z.string().optional(),
 });
+
+/**
+ * Discriminated union of API content blocks across the four provider shapes
+ * this module normalizes (Anthropic, OpenAI Chat Completions, OpenAI
+ * Response API, Google GenAI — the latter via {@link googlePartToBlocks},
+ * which translates Google's field-based `Part` into these type-based
+ * blocks). Each variant declares only the fields that provider actually
+ * populates for that block kind, so the six consuming functions below can
+ * switch/narrow on `type` instead of re-deriving validity with ad hoc
+ * optional-field checks.
+ */
+const ContentBlockSchema = z.discriminatedUnion('type', [
+  // Plain text. Anthropic and Google GenAI use 'text'; OpenAI Response API
+  // splits it into 'input_text' (user) and 'output_text' (assistant).
+  z.object({ type: z.literal('text'), text: z.string().optional() }),
+  z.object({ type: z.literal('input_text'), text: z.string().optional() }),
+  z.object({ type: z.literal('output_text'), text: z.string().optional() }),
+
+  // Anthropic extended-thinking / Google GenAI thought blocks.
+  z.object({ type: z.literal('thinking'), thinking: z.string().optional() }),
+  z.object({ type: z.literal('redacted_thinking') }),
+
+  // Tool call / tool result — shared by Anthropic, Google GenAI, and the
+  // VS Code language-model bridge (see normalizeContentBlock).
+  z.object({
+    type: z.literal('tool_use'),
+    name: z.string().optional(),
+    input: z.unknown().optional(),
+  }),
+  z.object({
+    type: z.literal('tool_result'),
+    content: z.unknown().optional(),
+  }),
+
+  // Attachment markers: Anthropic ('image'/'document'), OpenAI Response API
+  // ('input_image'/'input_file'), OpenAI Chat Completions ('image_url'/
+  // 'file'). None of these carry fields this module reads — only `type`
+  // decides which attachment kind to render.
+  z.object({ type: z.literal('image') }),
+  z.object({ type: z.literal('input_image') }),
+  z.object({ type: z.literal('image_url') }),
+  z.object({ type: z.literal('document') }),
+  z.object({ type: z.literal('input_file') }),
+  z.object({ type: z.literal('file') }),
+
+  // Anthropic server-side tool blocks (the provider executes these, not a
+  // local tool handler).
+  z.object({
+    type: z.literal(ANTHROPIC_SERVER_TOOL_BLOCK_TYPES.serverToolUse),
+    name: z.string().optional(),
+    input: z.unknown().optional(),
+  }),
+  z.object({
+    type: z.literal(ANTHROPIC_SERVER_TOOL_BLOCK_TYPES.webSearchToolResult),
+    content: z.array(WebSearchResultItemSchema).optional(),
+  }),
+  // `extractWebFetchResultFields` reads its fields off the raw block itself
+  // (it accepts `unknown`), so this variant only needs the discriminant.
+  z.object({
+    type: z.literal(ANTHROPIC_SERVER_TOOL_BLOCK_TYPES.webFetchToolResult),
+  }),
+]);
 type ContentBlock = z.infer<typeof ContentBlockSchema>;
 
 const ConversationMessageSchema = z.looseObject({
@@ -174,7 +211,9 @@ function googlePartToBlocks(part: Part): ContentBlock[] {
   const blob = part.inlineData ?? part.fileData;
   if (blob && typeof blob === 'object') {
     const { mimeType } = blob as { mimeType?: string };
-    return [{ type: mimeType?.startsWith('image/') ? 'image' : 'document' }];
+    return mimeType?.startsWith('image/')
+      ? [{ type: 'image' }]
+      : [{ type: 'document' }];
   }
   return [];
 }
@@ -182,37 +221,42 @@ function googlePartToBlocks(part: Part): ContentBlock[] {
 function blocksToUserParts(blocks: ContentBlock[]): UserPart[] {
   const parts: UserPart[] = [];
   for (const b of blocks) {
-    // Anthropic: 'text', OpenAI Response API: 'input_text'
-    if ((b.type === 'text' || b.type === 'input_text') && b.text) {
-      parts.push({ type: 'text', text: b.text });
-    } else if (
-      b.type === 'image' ||
-      b.type === 'input_image' ||
-      b.type === 'image_url'
-    ) {
-      parts.push({ type: 'attachment', attachmentType: 'image' });
-    } else if (
-      b.type === 'document' ||
-      b.type === 'input_file' ||
-      b.type === 'file'
-    ) {
-      parts.push({ type: 'attachment', attachmentType: 'document' });
+    switch (b.type) {
+      // Anthropic: 'text', OpenAI Response API: 'input_text'
+      case 'text':
+      case 'input_text':
+        if (b.text) parts.push({ type: 'text', text: b.text });
+        break;
+      case 'image':
+      case 'input_image':
+      case 'image_url':
+        parts.push({ type: 'attachment', attachmentType: 'image' });
+        break;
+      case 'document':
+      case 'input_file':
+      case 'file':
+        parts.push({ type: 'attachment', attachmentType: 'document' });
+        break;
+      default:
+        break;
     }
   }
   return parts;
 }
 
 function extractToolResultText(block: ContentBlock): string | undefined {
-  if (block.type === 'tool_result') {
-    return typeof block.content === 'string'
-      ? block.content
-      : prettyJson(block.content);
+  switch (block.type) {
+    case 'tool_result':
+      return typeof block.content === 'string'
+        ? block.content
+        : prettyJson(block.content);
+    // Anthropic: 'text', OpenAI Response API: 'input_text'
+    case 'text':
+    case 'input_text':
+      return block.text || undefined;
+    default:
+      return undefined;
   }
-  // Anthropic: 'text', OpenAI Response API: 'input_text'
-  if ((block.type === 'text' || block.type === 'input_text') && block.text) {
-    return block.text;
-  }
-  return undefined;
 }
 
 function assistantBlockToNode(block: ContentBlock): ExportNode | null {
@@ -262,7 +306,7 @@ function assistantBlockToNode(block: ContentBlock): ExportNode | null {
 
     case ANTHROPIC_SERVER_TOOL_BLOCK_TYPES.webSearchToolResult: {
       if (!Array.isArray(block.content)) return null;
-      const results = (block.content as ContentBlock[])
+      const results = block.content
         .filter((e) => e.type === 'web_search_result' && e.url)
         .map((e) => ({ title: e.title ?? e.url!, url: e.url! }));
       return results.length ? { kind: 'web-search-results', results } : null;

--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -8,6 +8,7 @@ import {
   hasCompileFailures,
   hasRoundOutputs,
   getStorageKey,
+  roundsToPersisted,
   setCompileFailures,
   type OutputDependencies,
 } from '@agent/output/outputState';
@@ -224,7 +225,7 @@ export class OutputNode<C = unknown> extends Node<
       };
     }
 
-    outputState.rounds[currentRound] = {
+    outputState.rounds.set(currentRound, {
       round: currentRound,
       rawOutput: null,
       outputs: [],
@@ -235,7 +236,7 @@ export class OutputNode<C = unknown> extends Node<
         singleOutputFile: null,
         sourceLocation: null,
       },
-    };
+    });
 
     return {
       summary,
@@ -319,7 +320,7 @@ export class OutputNode<C = unknown> extends Node<
     }
 
     // Project the canonical live collection into PersistedFlow's cloned state.
-    shared.roundOutputs = outputState.rounds;
+    shared.roundOutputs = roundsToPersisted(outputState);
     if (execRes.compileResult) {
       shared.lastCompileResult = execRes.compileResult;
       const compileFailureContext = shouldUseCompileFailureRepairContext(

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -5,6 +5,7 @@ import {
   createOutputState,
   setActiveRun,
   getOutputFilesByRound,
+  roundsFromPersisted,
 } from '@agent/output/outputState';
 import { XmlOutputManager } from '@agent/output/XmlOutputManager';
 import { LatexDiffManager } from '@agent/output/LatexDiffManager';
@@ -233,7 +234,7 @@ export async function runReflectionFlow<C = unknown>(
     }
 
     // Hydrate the canonical live collection from the persisted round snapshot.
-    outputState.rounds = shared.roundOutputs;
+    outputState.rounds = roundsFromPersisted(shared.roundOutputs);
 
     const prepContextNode = new PrepareContextNode<C>();
     const texCountNode = new TeXCountNode<C>();

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -3,7 +3,6 @@ import { dirname } from 'node:path';
 
 // Third-party imports
 import {
-  type ModelConfig,
   ModelProvider,
   type ModelCapabilities,
   ReasoningEffort,
@@ -68,6 +67,7 @@ import {
   allowsModelRelay,
   resolveDirectModelApiKeyProvider,
   resolveModelSource,
+  type ResolvedModelConfig,
 } from '@model/openRouterRouting';
 import { isGpt5ModelName } from '@model/modelNames';
 import { getApiKey, type ApiProvider } from '@model/apiProviders';
@@ -108,6 +108,7 @@ import {
   resolveBaseUrl,
   shouldUseOpenRouter,
   usesServerSideKeysRoute,
+  type ProxyConfig,
 } from './support/ProxyConfigResolver';
 import { prepareExistingOutputContent } from './utils/fileContentUtils';
 
@@ -204,7 +205,7 @@ export abstract class ModelHandler<
   >();
   private activeAttemptCredentialRoute: ModelCredentialRoute | undefined;
   private lastAttemptCredentialRoute: ModelCredentialRoute | undefined;
-  public config: ModelConfig;
+  public config: ResolvedModelConfig;
   public capabilities: ModelCapabilities;
   public continueLimit: number;
   public inputTokenLimit: number;
@@ -262,7 +263,7 @@ export abstract class ModelHandler<
     return false;
   }
 
-  constructor(config: ModelConfig) {
+  constructor(config: ResolvedModelConfig) {
     this.config = { ...config };
     this.capabilities = structuredClone(config.capabilities);
     this.continueLimit = DEFAULT_CONTINUE_LIMIT;
@@ -513,18 +514,7 @@ export abstract class ModelHandler<
       );
       return {
         apiKey,
-        baseUrl: resolveBaseUrl({
-          provider: this.config.provider,
-          openRouterOnly: this.config.openRouterOnly,
-          customBaseUrl: this.config.baseUrl,
-          requiresResponsesAPI: this.config.requiresResponsesAPI,
-          forceDirectProvider: (
-            this.config as { forceDirectProvider?: boolean }
-          ).forceDirectProvider,
-          useServerSideKeys: true,
-          useOpenRouter: false,
-          logger: this.logger,
-        }),
+        baseUrl: resolveBaseUrl(this.buildProxyConfig(true, false)),
         route: 'relay',
       };
     }
@@ -552,18 +542,38 @@ export abstract class ModelHandler<
     );
     return {
       apiKey,
-      baseUrl: resolveBaseUrl({
-        provider: this.config.provider,
-        openRouterOnly: this.config.openRouterOnly,
-        customBaseUrl: this.config.baseUrl,
-        requiresResponsesAPI: this.config.requiresResponsesAPI,
-        forceDirectProvider: (this.config as { forceDirectProvider?: boolean })
-          .forceDirectProvider,
-        useServerSideKeys: false,
-        useOpenRouter,
-        logger: this.logger,
-      }),
+      baseUrl: resolveBaseUrl(this.buildProxyConfig(false, useOpenRouter)),
       route: useOpenRouter ? 'openrouter' : 'api-key',
+    };
+  }
+
+  /**
+   * Build the {@link ProxyConfig} route for the current config plus a
+   * caller-resolved server-side-keys / OpenRouter decision. A per-model
+   * custom base URL always wins over both, matching `resolveBaseUrl`'s
+   * documented precedence — encoding that choice here (rather than at each
+   * call site) is what keeps `useServerSideKeys` and `useOpenRouter` from
+   * ever being set together on the same `ProxyConfig`.
+   */
+  private buildProxyConfig(
+    useServerSideKeys: boolean,
+    useOpenRouter: boolean,
+  ): ProxyConfig {
+    if (this.config.baseUrl) {
+      return { route: 'custom', url: this.config.baseUrl, logger: this.logger };
+    }
+    if (useServerSideKeys) {
+      return {
+        route: 'serverSideKeys',
+        provider: this.config.provider,
+        logger: this.logger,
+      };
+    }
+    return {
+      route: 'direct',
+      provider: this.config.provider,
+      useOpenRouter,
+      logger: this.logger,
     };
   }
 
@@ -615,20 +625,14 @@ export abstract class ModelHandler<
   public getBaseUrl(): string | null {
     const activeRoute = this.activeAttemptCredentialRoute;
     // Use centralized check to ensure consistency with getApiKey()
-    // Pass the decision to resolveBaseUrl to avoid duplicate checks
-    return resolveBaseUrl({
-      provider: this.config.provider,
-      openRouterOnly: this.config.openRouterOnly,
-      customBaseUrl: this.config.baseUrl,
-      requiresResponsesAPI: this.config.requiresResponsesAPI,
-      forceDirectProvider: (this.config as { forceDirectProvider?: boolean })
-        .forceDirectProvider,
-      useServerSideKeys: this.shouldUseServerSideKeys(),
-      ...(activeRoute !== undefined && {
-        useOpenRouter: activeRoute === 'openrouter',
-      }),
-      logger: this.logger,
-    });
+    // Pass the decision along to avoid duplicate checks
+    const useOpenRouter =
+      activeRoute !== undefined
+        ? activeRoute === 'openrouter'
+        : shouldUseOpenRouter(this.config);
+    return resolveBaseUrl(
+      this.buildProxyConfig(this.shouldUseServerSideKeys(), useOpenRouter),
+    );
   }
 
   /** Log the resolved credential route and final wire request config. */

--- a/src/agent/modelHandlers/support/ProxyConfigResolver.ts
+++ b/src/agent/modelHandlers/support/ProxyConfigResolver.ts
@@ -55,16 +55,34 @@ const BASE_URLS: Record<ModelProvider, string | null> = {
   [ModelProvider.OTHERS]: null,
 };
 
-interface ProxyConfig {
-  provider: ModelProvider;
-  openRouterOnly: boolean;
-  customBaseUrl?: string; // Per-model custom base URL (overrides provider default)
-  requiresResponsesAPI?: boolean; // Models requiring direct API access (bypasses OpenRouter)
-  forceDirectProvider?: boolean; // Runtime replay override that bypasses OpenRouter
-  useServerSideKeys?: boolean; // Pre-computed by caller to avoid duplicated checks
-  useOpenRouter?: boolean; // Pre-computed by client construction for an atomic route snapshot
-  logger?: { debug: (message: string) => void };
-}
+type ProxyLogger = { debug: (message: string) => void };
+
+/**
+ * The base-URL route for one API request, as a discriminated union over
+ * `route` instead of a bag of optional booleans. Each variant carries exactly
+ * the fields `resolveBaseUrl` needs for that route, so a caller can no longer
+ * construct an ambiguous config (e.g. `useServerSideKeys: true` together with
+ * `useOpenRouter: true`) — the precedence documented on `resolveBaseUrl`
+ * (custom > server-side keys > everything else) is enforced by callers
+ * picking exactly one variant, not by priority-ordered `if` checks inside the
+ * resolver.
+ *
+ * The 'direct' variant covers the remaining precedence tiers (improved
+ * connection proxy, OpenRouter, per-provider custom endpoint, provider
+ * default): those aren't caller-selectable — which one applies depends on
+ * global settings and provider metadata resolved inside `resolveBaseUrl` —
+ * so they stay an internal cascade parameterized by `useOpenRouter`, the one
+ * fact every call site already knows.
+ */
+export type ProxyConfig =
+  | { route: 'custom'; url: string; logger?: ProxyLogger }
+  | { route: 'serverSideKeys'; provider: ModelProvider; logger?: ProxyLogger }
+  | {
+      route: 'direct';
+      provider: ModelProvider;
+      useOpenRouter: boolean;
+      logger?: ProxyLogger;
+    };
 
 /**
  * Determines whether OpenRouter should be used for API routing.
@@ -108,45 +126,60 @@ export function usesServerSideKeysRoute(
  * Resolves the base URL for API requests.
  *
  * Priority order (mutually exclusive):
- * 1. Custom base URL (per-model override)
- * 2. Server-side keys relay (experimental, for Ultra users)
+ * 1. Custom base URL (per-model override) — `route: 'custom'`
+ * 2. Server-side keys relay (experimental, for Ultra users) — `route: 'serverSideKeys'`
  * 3. Improved connection proxy (proxy.texra.ai)
  * 4. OpenRouter
  * 5. Per-provider custom endpoint (dashboard settings)
  * 6. Provider default URLs
  *
+ * Tiers 3-6 are the internal cascade of `route: 'direct'` (see
+ * {@link resolveDirectBaseUrl}): none of them is caller-selectable, since
+ * which one applies depends on global settings and provider metadata read
+ * here, not on a decision the caller has already made.
+ *
  * Note: Server-side keys and proxy.texra.ai are MUTUALLY EXCLUSIVE.
  * When server-side keys are enabled, the relay handles everything
- * and proxy.texra.ai is not used.
+ * and proxy.texra.ai is not used — enforced structurally here since
+ * `route: 'serverSideKeys'` and `route: 'direct'` cannot both be selected.
  */
 export function resolveBaseUrl(config: ProxyConfig): string | null {
-  // Per-model custom base URL takes highest precedence (e.g., temporary endpoints)
-  if (config.customBaseUrl) {
-    config.logger?.debug(
-      `Using custom base URL for model: ${config.customBaseUrl}`,
-    );
-    return config.customBaseUrl;
+  switch (config.route) {
+    // Per-model custom base URL (e.g., temporary endpoints).
+    case 'custom':
+      config.logger?.debug(`Using custom base URL for model: ${config.url}`);
+      return config.url;
+
+    // Server-side keys via relay (experimental feature for Ultra users).
+    // The caller (ModelHandler.shouldUseServerSideKeys) pre-computes this
+    // route to ensure consistency between URL routing and API key retrieval.
+    case 'serverSideKeys': {
+      const relayUrl = getServerSideKeyService().getRelayBaseUrl(
+        config.provider,
+      );
+      config.logger?.debug(
+        `Using server-side keys relay for ${config.provider}: ${relayUrl}`,
+      );
+      return relayUrl;
+    }
+
+    case 'direct':
+      return resolveDirectBaseUrl(config);
   }
+}
 
-  // Server-side keys via relay (experimental feature for Ultra users)
-  // IMPORTANT: This path is MUTUALLY EXCLUSIVE with proxy.texra.ai.
-  // When server-side keys are enabled, we use the Supabase Edge Function relay
-  // which handles everything directly - no intermediate proxy is used.
-  //
-  // The caller (ModelHandler.shouldUseServerSideKeys) pre-computes this decision
-  // to ensure consistency between URL routing and API key retrieval.
-  if (config.useServerSideKeys) {
-    const relayUrl = getServerSideKeyService().getRelayBaseUrl(config.provider);
-    config.logger?.debug(
-      `Using server-side keys relay for ${config.provider}: ${relayUrl}`,
-    );
-    return relayUrl;
-  }
-
-  // Below this point: standard routing (proxy.texra.ai, OpenRouter, or direct)
-  // These paths are only used when server-side keys are NOT enabled.
-
-  const useOpenRouter = config.useOpenRouter ?? shouldUseOpenRouter(config);
+/**
+ * The standard routing cascade used whenever neither a custom base URL nor
+ * server-side keys apply: improved-connection proxy (if enabled and the
+ * provider/route has a proxy path), then OpenRouter, then a per-provider
+ * dashboard endpoint, then provider defaults (including region toggles).
+ */
+function resolveDirectBaseUrl(config: {
+  provider: ModelProvider;
+  useOpenRouter: boolean;
+  logger?: ProxyLogger;
+}): string | null {
+  const { provider, useOpenRouter, logger } = config;
   const useImprovedConnection = getConfig<boolean>(
     'texra.model.useImprovedConnection',
     false,
@@ -160,17 +193,13 @@ export function resolveBaseUrl(config: ProxyConfig): string | null {
     const domain = normalizeUrl(customDomain || DEFAULT_PROXY_DOMAIN);
 
     if (!customDomain) {
-      config.logger?.debug(
-        `Using default proxy domain: ${DEFAULT_PROXY_DOMAIN}`,
-      );
+      logger?.debug(`Using default proxy domain: ${DEFAULT_PROXY_DOMAIN}`);
     }
 
     // OpenRouter uses 'openrouter' path; other providers use their configured paths
-    const path = useOpenRouter ? 'openrouter' : PROXY_PATHS[config.provider];
+    const path = useOpenRouter ? 'openrouter' : PROXY_PATHS[provider];
     if (path) {
-      config.logger?.debug(
-        `Using proxy for ${config.provider}: ${domain}/${path}`,
-      );
+      logger?.debug(`Using proxy for ${provider}: ${domain}/${path}`);
       return `https://${domain}/${path}`;
     }
   }
@@ -178,16 +207,14 @@ export function resolveBaseUrl(config: ProxyConfig): string | null {
   if (useOpenRouter) return 'https://openrouter.ai/api/v1';
 
   // Per-provider custom endpoint from dashboard settings (globalSM)
-  const customUrl = getProviderEndpoint(config.provider);
+  const customUrl = getProviderEndpoint(provider);
   if (customUrl) {
-    config.logger?.debug(
-      `Using custom base URL for ${config.provider}: ${customUrl}`,
-    );
+    logger?.debug(`Using custom base URL for ${provider}: ${customUrl}`);
     return `https://${normalizeUrl(customUrl)}`;
   }
 
   // Providers with dynamic region-based URLs
-  switch (config.provider) {
+  switch (provider) {
     case ModelProvider.DASHSCOPE: {
       const domain = getDashScopeUseChina()
         ? 'dashscope.aliyuncs.com'
@@ -217,6 +244,6 @@ export function resolveBaseUrl(config: ProxyConfig): string | null {
       return `https://${domain}${path}`;
     }
     default:
-      return BASE_URLS[config.provider];
+      return BASE_URLS[provider];
   }
 }

--- a/src/agent/output/lineageMapping.ts
+++ b/src/agent/output/lineageMapping.ts
@@ -101,9 +101,9 @@ export function traceFileLineage(
   baseFiles: FileLocation[],
   currRound: number,
 ): RoundFileMapping {
-  const currentOutputs = state.rounds[currRound]?.outputs ?? [];
+  const currentOutputs = state.rounds.get(currRound)?.outputs ?? [];
   const prevOutputs =
-    currRound > 0 ? (state.rounds[currRound - 1]?.outputs ?? []) : [];
+    currRound > 0 ? (state.rounds.get(currRound - 1)?.outputs ?? []) : [];
 
   const baseEntries = buildBaseEntries(baseFiles);
   const currentLocations = currentOutputs.map((entry) => entry.location);

--- a/src/agent/output/outputState.ts
+++ b/src/agent/output/outputState.ts
@@ -4,9 +4,11 @@
  * Manages mutable state for output files across rounds, including
  * round data, storage keys, and workspace preparation.
  *
- * `OutputState.rounds` is the canonical live collection. The reflection flow
- * hydrates it from persisted `roundOutputs` on startup and projects the same
- * array shape back before each round is persisted.
+ * `OutputState.rounds` is the canonical live collection, keyed by round
+ * index (`Map<number, RoundOutput>`). The reflection flow hydrates it from
+ * the persisted `roundOutputs` array on startup via `roundsFromPersisted`
+ * and projects it back to that array shape via `roundsToPersisted` before
+ * each round is persisted.
  */
 
 import type { AgentTrace, StageHandle } from '@agent/trace';
@@ -30,7 +32,7 @@ import {
 } from '@utils/files';
 
 export interface OutputState {
-  rounds: RoundOutput[];
+  rounds: Map<number, RoundOutput>;
   openedOutputs: Set<string>;
   storageKey: StorageKey | null;
   runPreparation: Promise<void> | null;
@@ -46,13 +48,41 @@ export interface OutputDependencies {
   runtimeHost: AgentRuntimeHost;
 }
 
-export function createOutputState(rounds: RoundOutput[] = []): OutputState {
+export function createOutputState(
+  rounds: Map<number, RoundOutput> = new Map(),
+): OutputState {
   return {
     rounds,
     openedOutputs: new Set(),
     storageKey: null,
     runPreparation: null,
   };
+}
+
+/**
+ * Build a live `rounds` map from the persisted array shape, keyed by each
+ * entry's own `round` field (not array index) so a hydration source with
+ * gaps still lands on the right round.
+ */
+export function roundsFromPersisted(
+  rounds: RoundOutput[],
+): Map<number, RoundOutput> {
+  return new Map(rounds.map((round) => [round.round, round]));
+}
+
+/**
+ * Project the live `rounds` map back to the persisted array shape, placing
+ * each entry at its own `round` index (not insertion order) — some
+ * consumers of the persisted shape (e.g. `getFilesForRound`) index it
+ * positionally by round number, and a round can in principle be absent
+ * without shifting the rounds after it.
+ */
+export function roundsToPersisted(state: OutputState): RoundOutput[] {
+  const result: RoundOutput[] = [];
+  for (const [round, data] of state.rounds) {
+    result[round] = data;
+  }
+  return result;
 }
 
 export async function withOutputStage<T>(
@@ -76,33 +106,32 @@ export function ensureRoundData(
   state: OutputState,
   round: number,
 ): RoundOutput {
-  let data = state.rounds[round];
-  if (!data) {
-    data = {
-      round,
-      rawOutput: null,
-      outputs: [],
-      compileFailures: [],
-      xmlSummary: OutputXmlSummarySchema.parse({}),
-    };
-    state.rounds[round] = data;
-  }
+  const existing = state.rounds.get(round);
+  if (existing) return existing;
+  const data: RoundOutput = {
+    round,
+    rawOutput: null,
+    outputs: [],
+    compileFailures: [],
+    xmlSummary: OutputXmlSummarySchema.parse({}),
+  };
+  state.rounds.set(round, data);
   return data;
 }
 
 export function hasRoundOutputs(state: OutputState, round: number): boolean {
-  return (state.rounds[round]?.outputs.length ?? 0) > 0;
+  return (state.rounds.get(round)?.outputs.length ?? 0) > 0;
 }
 
 export function hasCompileFailures(state: OutputState, round: number): boolean {
-  return (state.rounds[round]?.compileFailures.length ?? 0) > 0;
+  return (state.rounds.get(round)?.compileFailures.length ?? 0) > 0;
 }
 
 export function getOutputFilesByRound(
   state: OutputState,
 ): RoundIndexed<OutputFileInfo> {
   return Object.fromEntries(
-    state.rounds.flatMap((data) => [[data.round, data.outputs] as const]),
+    [...state.rounds].map(([round, data]) => [round, data.outputs] as const),
   );
 }
 

--- a/src/agent/runtime/AgentFinalResult.ts
+++ b/src/agent/runtime/AgentFinalResult.ts
@@ -140,7 +140,8 @@ export function buildAgentFinalResult(
     // did not pass one, so a populated flow result carries `structured` without
     // every caller re-threading it.
     const structured =
-      source.structured ?? (result as { structured?: unknown }).structured;
+      source.structured ??
+      (result.category === 'toolUse' ? result.structured : undefined);
     if (result.category === 'workflow') {
       return AgentFinalResultSchema.parse({
         category: result.category,

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -27,6 +27,7 @@ import { isGpt5ModelName } from '@model/modelNames';
 import {
   isOpenRouterRoutingUnsupported,
   shouldRouteModelThroughOpenRouter,
+  type ResolvedModelConfig,
 } from '@model/openRouterRouting';
 import {
   LANGUAGE_MODEL_PORT_ERROR_CODE,
@@ -50,9 +51,6 @@ type ModelHandlerConstructor = new (
 ) => ModelHandler<ProviderMessage>;
 
 type ProviderHandlerLoader = () => Promise<ModelHandlerConstructor>;
-type CompatibilityRoutedModelConfig = ModelConfig & {
-  readonly forceDirectProvider?: boolean;
-};
 
 interface ProviderHandlerRoute {
   readonly load: ProviderHandlerLoader | null;
@@ -404,7 +402,7 @@ function withCompatibilityRoutingMode(
     return { ...config, openRouterOnly: true };
   }
 
-  const routed: CompatibilityRoutedModelConfig = {
+  const routed: ResolvedModelConfig = {
     ...config,
     openRouterOnly: false,
     forceDirectProvider: true,

--- a/src/controllers/progressView/backend/state/ProgressViewState.ts
+++ b/src/controllers/progressView/backend/state/ProgressViewState.ts
@@ -30,6 +30,7 @@ import {
   PersistedState,
   createBackendStorage,
 } from '@shared/state/PersistedState';
+import { isProcessAgent } from '@shared/streams/agentKind';
 import { isActivePhase } from '@shared/streams/streamStatus';
 import { GoalStore } from '@tools/goal';
 import { StreamSnapshotStore, type StreamLogStore } from '@transcript';
@@ -45,19 +46,42 @@ import {
  *  mirroring `StreamSnapshotStore`'s own per-stream disk-read concurrency. */
 const LEGACY_INSTRUCTION_BACKFILL_CONCURRENCY = 8;
 
+/**
+ * Config-derived run details: undefined until the stream's `RunConfig`
+ * snapshot resolves (see `applySnapshotMetadata`), at which point `kind` and
+ * every field below are always populated together from that one `AgentConfig`
+ * — they can't drift independently of each other the way top-level
+ * `ProgressStreamMetadata` fields (set by separate calls at separate times)
+ * can. `kind` mirrors the process/agent distinction `buildStreamTabInfo`
+ * renders differently: a "process" stream runs a raw OS tool (e.g. the
+ * `bash` tool) and carries no meaningful model; an "agent" stream is an
+ * LLM-driven run and may carry `inputFile`/`model`.
+ */
+type ProgressStreamRunDetails =
+  | {
+      kind: 'process';
+      agent: string;
+      instruction: string;
+      workingDirectory?: string;
+    }
+  | {
+      kind: 'agent';
+      agent: string;
+      inputFile?: string;
+      model: string;
+      instruction: string;
+      workingDirectory?: string;
+    };
+
 /** Canonical current metadata used by every progress-view stream consumer. */
 export interface ProgressStreamMetadata {
-  agent?: string;
   agentCategory?: AgentCategory;
-  inputFile?: string;
   isRemote?: boolean;
   creationTimestamp: number;
   executionId?: ExecutionId;
   parentStreamId?: StreamTabId;
   description?: string;
-  model?: string;
-  instruction?: string;
-  workingDirectory?: string;
+  run?: ProgressStreamRunDetails;
 }
 
 /** Ephemeral session state per stream (not persisted). */
@@ -247,12 +271,23 @@ export class ProgressViewState {
   ): void {
     const config = this.snapshots.getRunConfig(stream);
     if (config) {
-      metadata.agent = config.agent;
       metadata.agentCategory = config.agentCategory;
-      metadata.inputFile = config.inputFiles?.at(0) ?? metadata.inputFile;
-      metadata.model = config.model;
-      metadata.instruction = config.instruction;
-      metadata.workingDirectory = config.workingDirectory ?? undefined;
+      const workingDirectory = config.workingDirectory ?? undefined;
+      metadata.run = isProcessAgent(config.agent)
+        ? {
+            kind: 'process',
+            agent: config.agent,
+            instruction: config.instruction,
+            workingDirectory,
+          }
+        : {
+            kind: 'agent',
+            agent: config.agent,
+            inputFile: config.inputFiles?.at(0),
+            model: config.model,
+            instruction: config.instruction,
+            workingDirectory,
+          };
     }
 
     metadata.executionId =

--- a/src/controllers/progressView/backend/streamInfoUtils.ts
+++ b/src/controllers/progressView/backend/streamInfoUtils.ts
@@ -49,7 +49,7 @@ export function buildStreamInfo(
   const category = matchesFilter(metadata.agentCategory, filter);
   if (category === null) return null;
 
-  const workingDirectory = metadata.workingDirectory;
+  const workingDirectory = metadata.run?.workingDirectory;
   let worktreeInfo;
   if (workingDirectory) {
     worktreeInfo = peekWorktreeInfo(workingDirectory);

--- a/src/controllers/progressView/backend/streamTabInfo.ts
+++ b/src/controllers/progressView/backend/streamTabInfo.ts
@@ -27,12 +27,23 @@ export interface StreamTabInfoInputs {
  */
 export function buildStreamTabInfo(inputs: StreamTabInfoInputs): StreamTabInfo {
   const { streamId, metadata } = inputs;
+  const { run } = metadata;
 
   const category = metadata.agentCategory ?? AgentCategory.Workflow;
 
-  const inputFile = metadata.inputFile ?? '';
-  const rawAgentName = metadata.agent ?? streamId.split('@')[0];
+  // `run` is undefined until the stream's RunConfig snapshot resolves (see
+  // `applySnapshotMetadata`); fall back to parsing the agent name out of the
+  // stream ID (format "agentName@timestamp") so an early render — e.g. a
+  // just-created bash child stream — still classifies correctly. Once `run`
+  // is set, its `kind` is authoritative: no more guessing from the name.
+  const rawAgentName = run?.agent ?? streamId.split('@')[0];
   const agentName = getCleanAgentName(rawAgentName);
+  const resolvedAgent = run?.agent ?? agentName;
+  const isProcessStream = run
+    ? run.kind === 'process'
+    : isProcessAgent(rawAgentName);
+
+  const inputFile = (run?.kind === 'agent' ? run.inputFile : undefined) ?? '';
 
   // Workflow agents include the input filename in the tab label so users
   // can tell parallel runs apart at a glance. Tool-use agents don't have
@@ -42,16 +53,10 @@ export function buildStreamTabInfo(inputs: StreamTabInfoInputs): StreamTabInfo {
       ? `${agentName}: ${path.basename(inputFile)}`
       : agentName;
 
-  // Process agents (e.g. bash) carry a synthetic AgentConfig whose `model`
-  // is the schema's prefault, not a real inference model — omit so the
-  // tab footer doesn't lie.
-  const resolvedAgent = metadata.agent ?? agentName;
-  const processAgent = isProcessAgent(resolvedAgent);
-
   // Surface the full untruncated command for process streams (description
   // is capped for tab/tooltip rendering).
   const command =
-    processAgent && metadata.instruction ? metadata.instruction : undefined;
+    run?.kind === 'process' && run.instruction ? run.instruction : undefined;
 
   // Canonical host-known status takes precedence because setActiveStream can
   // identify a remote run before its agent is present in the registry.
@@ -61,12 +66,12 @@ export function buildStreamTabInfo(inputs: StreamTabInfoInputs): StreamTabInfo {
   // Worktree context comes from one of two sources, in order:
   //   1. An explicit hint passed in by the caller (already resolved branch /
   //      dirty / PR info via `resolveWorktreeInfo`).
-  //   2. The agent config's `workingDirectory` override — surfaced as a
-  //      minimal chip carrying just the path until async resolution lands.
+  //   2. The run's `workingDirectory` — surfaced as a minimal chip carrying
+  //      just the path until async resolution lands.
   const worktree: WorktreeInfo | undefined =
     inputs.worktreeInfo ??
-    (metadata.workingDirectory
-      ? { workingDirectory: metadata.workingDirectory }
+    (run?.workingDirectory
+      ? { workingDirectory: run.workingDirectory }
       : undefined);
 
   const base = {
@@ -83,14 +88,21 @@ export function buildStreamTabInfo(inputs: StreamTabInfoInputs): StreamTabInfo {
     worktree,
   };
 
-  return processAgent
-    ? { ...base, kind: 'process', command }
-    : {
-        ...base,
-        kind: 'agent',
-        model: metadata.model,
-        modelLabel: metadata.model
-          ? (getRuntimeModelConfig(metadata.model)?.label ?? metadata.model)
-          : undefined,
-      };
+  if (isProcessStream) {
+    return { ...base, kind: 'process', command };
+  }
+
+  // Process agents (e.g. bash) carry a synthetic AgentConfig whose `model`
+  // is the schema's prefault, not a real inference model — the `process`
+  // variant of `ProgressStreamRunDetails` has no `model` field at all, so
+  // there's nothing to omit here; only the `agent` variant carries one.
+  const model = run?.kind === 'agent' ? run.model : undefined;
+  return {
+    ...base,
+    kind: 'agent',
+    model,
+    modelLabel: model
+      ? (getRuntimeModelConfig(model)?.label ?? model)
+      : undefined,
+  };
 }

--- a/src/controllers/settingsView/LatexRecommendedSettingsController.ts
+++ b/src/controllers/settingsView/LatexRecommendedSettingsController.ts
@@ -15,20 +15,41 @@ export interface LatexRecommendedSettingsControllerDeps {
   config: LatexRecommendedSettingsConfig;
 }
 
-/** Recommended LaTeX-related VS Code settings and their target values. */
-const LATEX_RECOMMENDED_SETTINGS: {
+/** A recommended setting whose target value is a single scalar. */
+interface LatexRecommendedScalarSetting {
+  kind: 'scalar';
   key: string;
-  value: unknown;
+  value: string;
+  field: LatexRecommendedSettingField;
+}
+
+/**
+ * A recommended setting whose target value is an object merged key-by-key
+ * into whatever the user already has set (rather than overwritten wholesale).
+ */
+interface LatexRecommendedObjectSetting {
+  kind: 'object';
+  key: string;
+  value: Record<string, unknown>;
   field: LatexRecommendedSettingField;
   /** Object keys from older TeXRA versions to migrate when writing. */
   legacyKeys?: string[];
-}[] = [
+}
+
+type LatexRecommendedSetting =
+  | LatexRecommendedScalarSetting
+  | LatexRecommendedObjectSetting;
+
+/** Recommended LaTeX-related VS Code settings and their target values. */
+const LATEX_RECOMMENDED_SETTINGS: LatexRecommendedSetting[] = [
   {
+    kind: 'scalar',
     key: 'latex-workshop.latex.outDir',
     value: '%DIR%/build/',
     field: 'outDir',
   },
   {
+    kind: 'object',
     key: 'explorer.autoRevealExclude',
     value: { '**/build/': true },
     field: 'autoRevealExclude',
@@ -43,9 +64,9 @@ export class LatexRecommendedSettingsController {
     field?: LatexRecommendedSettingField;
     reset: boolean;
   }): LatexRecommendedSettingUpdate[] {
-    return this.getTargets(input.field).map(({ key, value, legacyKeys }) => ({
-      key,
-      value: this.resolveUpdateValue(key, value, legacyKeys, input.reset),
+    return this.getTargets(input.field).map((setting) => ({
+      key: setting.key,
+      value: this.resolveUpdateValue(setting, input.reset),
     }));
   }
 
@@ -57,57 +78,54 @@ export class LatexRecommendedSettingsController {
     if (!this.deps.config.isExplicitlySet(setting.key)) return false;
 
     const current = this.deps.config.getConfig(setting.key);
-    if (typeof setting.value === 'object' && setting.value !== null) {
-      if (typeof current !== 'object' || current === null) return false;
-      const currentObject = current as Record<string, unknown>;
-      const recommended = setting.value as Record<string, unknown>;
-      return (
-        Object.entries(recommended).every(
-          ([key, value]) => currentObject[key] === value,
-        ) ||
-        (setting.legacyKeys?.some((key) => currentObject[key] !== undefined) ??
-          false)
-      );
+    if (setting.kind === 'scalar') {
+      return current === setting.value;
     }
-    return current === setting.value;
+
+    if (typeof current !== 'object' || current === null) return false;
+    const currentObject = current as Record<string, unknown>;
+    return (
+      Object.entries(setting.value).every(
+        ([key, value]) => currentObject[key] === value,
+      ) ||
+      (setting.legacyKeys?.some((key) => currentObject[key] !== undefined) ??
+        false)
+    );
   }
 
   private getTargets(
     field?: LatexRecommendedSettingField,
-  ): typeof LATEX_RECOMMENDED_SETTINGS {
+  ): LatexRecommendedSetting[] {
     return field
       ? LATEX_RECOMMENDED_SETTINGS.filter((setting) => setting.field === field)
       : LATEX_RECOMMENDED_SETTINGS;
   }
 
   private resolveUpdateValue(
-    key: string,
-    recommendedValue: unknown,
-    legacyKeys: string[] | undefined,
+    setting: LatexRecommendedSetting,
     reset: boolean,
   ): unknown {
-    if (typeof recommendedValue !== 'object' || recommendedValue === null) {
-      return reset ? undefined : recommendedValue;
+    if (setting.kind === 'scalar') {
+      return reset ? undefined : setting.value;
     }
 
-    const recommended = recommendedValue as Record<string, unknown>;
-    const globalValue = this.deps.config.getGlobalValue(key);
+    const globalValue = this.deps.config.getGlobalValue(setting.key);
     const remaining =
       typeof globalValue === 'object' && globalValue !== null
         ? { ...(globalValue as Record<string, unknown>) }
         : {};
 
-    for (const legacyKey of legacyKeys ?? []) {
+    for (const legacyKey of setting.legacyKeys ?? []) {
       delete remaining[legacyKey];
     }
 
     if (reset) {
-      for (const recommendedKey of Object.keys(recommended)) {
+      for (const recommendedKey of Object.keys(setting.value)) {
         delete remaining[recommendedKey];
       }
       return Object.keys(remaining).length > 0 ? remaining : undefined;
     }
 
-    return { ...remaining, ...recommended };
+    return { ...remaining, ...setting.value };
   }
 }

--- a/src/controllers/settingsView/LatexRecommendedSettingsController.ts
+++ b/src/controllers/settingsView/LatexRecommendedSettingsController.ts
@@ -37,8 +37,7 @@ interface LatexRecommendedObjectSetting {
 }
 
 type LatexRecommendedSetting =
-  | LatexRecommendedScalarSetting
-  | LatexRecommendedObjectSetting;
+  LatexRecommendedScalarSetting | LatexRecommendedObjectSetting;
 
 /** Recommended LaTeX-related VS Code settings and their target values. */
 const LATEX_RECOMMENDED_SETTINGS: LatexRecommendedSetting[] = [

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -459,7 +459,7 @@ async function buildModelOptionData(
 ): Promise<ModelOptionData> {
   const rawConfig = getRuntimeModelConfig(model);
   if (!rawConfig) {
-    return { kind: 'resolved', value: model, label: model };
+    return { value: model, label: model };
   }
   // Mirror ModelFactory: a dual-backend Kimi model routed to the coding
   // endpoint runs with the synthesized runtime config, so the row reflects it.
@@ -487,7 +487,6 @@ async function buildModelOptionData(
     }
   }
   return {
-    kind: 'resolved',
     ...buildBaseModelOption(model, optionConfig, config),
     ...(routeLabel ? { routeLabel } : {}),
     availability: availability.kind,

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -459,7 +459,7 @@ async function buildModelOptionData(
 ): Promise<ModelOptionData> {
   const rawConfig = getRuntimeModelConfig(model);
   if (!rawConfig) {
-    return { value: model, label: model };
+    return { kind: 'resolved', value: model, label: model };
   }
   // Mirror ModelFactory: a dual-backend Kimi model routed to the coding
   // endpoint runs with the synthesized runtime config, so the row reflects it.
@@ -487,6 +487,7 @@ async function buildModelOptionData(
     }
   }
   return {
+    kind: 'resolved',
     ...buildBaseModelOption(model, optionConfig, config),
     ...(routeLabel ? { routeLabel } : {}),
     availability: availability.kind,

--- a/src/model/kimiCodeSubscriptionRouting.ts
+++ b/src/model/kimiCodeSubscriptionRouting.ts
@@ -20,6 +20,8 @@
 
 import { ModelProvider, type ModelConfig } from 'llm-zoo';
 
+import { zeroCostAccessOverrides } from './subscriptionAccessOverrides';
+
 /** OpenAI-compatible base URL for the Kimi Code coding endpoint. */
 export const KIMI_CODE_BASE_URL = 'https://api.kimi.com/coding/v1';
 
@@ -134,11 +136,8 @@ export function kimiCodeRuntimeConfig(config: ModelConfig): ModelConfig {
     fullName: wireId,
     shortName: wireId,
     baseUrl: KIMI_CODE_BASE_URL,
-    inputPrice: 0,
-    outputPrice: 0,
-    contextWindow: Math.min(
-      KIMI_CODE_SUBSCRIPTION_CONTEXT_WINDOW,
-      config.contextWindow,
+    ...zeroCostAccessOverrides(
+      Math.min(KIMI_CODE_SUBSCRIPTION_CONTEXT_WINDOW, config.contextWindow),
     ),
   };
 }

--- a/src/model/modelOptionsBasic.ts
+++ b/src/model/modelOptionsBasic.ts
@@ -195,12 +195,17 @@ function buildModelHint(config: ModelConfig): string {
   return base;
 }
 
-/** Project a model config to the base option fields shared across views. */
+/**
+ * Project a model config to the base option fields shared across views.
+ * Shared by both the basic and resolved producers, so it deliberately leaves
+ * `kind` out — the caller stamps `'basic'` or `'resolved'` depending on
+ * whether availability has also been resolved.
+ */
 export function buildBaseModelOption(
   model: string,
   config: ModelConfig,
   hintConfig: ModelConfig = config,
-): ModelOptionData {
+): Omit<ModelOptionData, 'kind'> {
   return {
     value: model,
     label: config.label,
@@ -217,7 +222,7 @@ export function buildBasicModelOptionsData(
 ): ModelOptionData[] {
   return visibleModels.map((model) => {
     const config = getRuntimeModelConfig(model);
-    if (!config) return { value: model, label: model };
-    return buildBaseModelOption(model, config);
+    if (!config) return { kind: 'basic', value: model, label: model };
+    return { kind: 'basic', ...buildBaseModelOption(model, config) };
   });
 }

--- a/src/model/modelOptionsBasic.ts
+++ b/src/model/modelOptionsBasic.ts
@@ -195,17 +195,12 @@ function buildModelHint(config: ModelConfig): string {
   return base;
 }
 
-/**
- * Project a model config to the base option fields shared across views.
- * Shared by both the basic and resolved producers, so it deliberately leaves
- * `kind` out — the caller stamps `'basic'` or `'resolved'` depending on
- * whether availability has also been resolved.
- */
+/** Project a model config to the base option fields shared across views. */
 export function buildBaseModelOption(
   model: string,
   config: ModelConfig,
   hintConfig: ModelConfig = config,
-): Omit<ModelOptionData, 'kind'> {
+): ModelOptionData {
   return {
     value: model,
     label: config.label,
@@ -222,7 +217,7 @@ export function buildBasicModelOptionsData(
 ): ModelOptionData[] {
   return visibleModels.map((model) => {
     const config = getRuntimeModelConfig(model);
-    if (!config) return { kind: 'basic', value: model, label: model };
-    return { kind: 'basic', ...buildBaseModelOption(model, config) };
+    if (!config) return { value: model, label: model };
+    return buildBaseModelOption(model, config);
   });
 }

--- a/src/model/openRouterRouting.ts
+++ b/src/model/openRouterRouting.ts
@@ -3,11 +3,26 @@ import { isKimiCodeExclusiveModel } from './kimiCodeSubscriptionRouting';
 
 import type { ModelConfig } from 'llm-zoo';
 
+/**
+ * A {@link ModelConfig} carrying TeXRA's own runtime-only routing override.
+ * `forceDirectProvider` is not part of llm-zoo's registry shape — it is
+ * stamped onto a config by `ModelFactory.withCompatibilityRoutingMode` when
+ * rebuilding a handler for an already-persisted conversation format that must
+ * stay off OpenRouter even if the global OpenRouter toggle is later turned
+ * on. This module owns the field's meaning (see `isOpenRouterAccessSelected`
+ * below), so it is also the single declaration site: `ModelHandler.config`
+ * and every routing helper that reads the field import this type instead of
+ * re-declaring it locally.
+ */
+export type ResolvedModelConfig = ModelConfig & {
+  readonly forceDirectProvider?: boolean;
+};
+
 interface OpenRouterRoutingConfig {
   provider?: string;
   requiresResponsesAPI?: boolean;
   openRouterOnly: boolean;
-  forceDirectProvider?: boolean;
+  forceDirectProvider?: ResolvedModelConfig['forceDirectProvider'];
   capabilities?: Pick<ModelConfig['capabilities'], 'reasoningMode'>;
 }
 

--- a/src/model/providerCapabilities.ts
+++ b/src/model/providerCapabilities.ts
@@ -6,6 +6,7 @@ import {
   isPreferCodexSubscription,
 } from '@auth/codex';
 import { getServerSideKeyService } from '@auth/serverKeys';
+import { zeroCostAccessOverrides } from '@model/subscriptionAccessOverrides';
 import { platform } from '@platform/platform';
 import type { UsageRoute } from '@shared/schemas';
 import { AgentCategory } from '@shared/schemas/agent';
@@ -132,10 +133,10 @@ export function resolveProviderCapabilities({
 
   return {
     authMode: 'chatgpt-subscription',
-    contextWindow: Math.min(tokenLimits.contextWindow, model.contextWindow),
+    ...zeroCostAccessOverrides(
+      Math.min(tokenLimits.contextWindow, model.contextWindow),
+    ),
     inputTokenLimit: Math.min(tokenLimits.inputTokenLimit, model.contextWindow),
-    inputPrice: 0,
-    outputPrice: 0,
     usageRoute: 'chatgpt-subscription',
     openAIResponses: {
       backgroundMode: 'disabled',

--- a/src/model/runtimeModelRegistry.ts
+++ b/src/model/runtimeModelRegistry.ts
@@ -7,6 +7,7 @@ import {
 
 import type { ApiProvider } from '@model/apiProviders';
 import { resolveModelApiKeyProvider } from '@model/openRouterRouting';
+import { zeroCostAccessOverrides } from '@model/subscriptionAccessOverrides';
 import { platform } from '@platform/platform';
 
 import type {
@@ -80,9 +81,7 @@ function runtimeConfig(
     fullName: info.id,
     shortName: info.id,
     provider: ModelProvider.COPILOT,
-    contextWindow: info.maxInputTokens,
-    inputPrice: 0,
-    outputPrice: 0,
+    ...zeroCostAccessOverrides(info.maxInputTokens),
     openRouterOnly: false,
     openrouterFullName: undefined,
     vscodeLMFullName: info.id,

--- a/src/model/subscriptionAccessOverrides.ts
+++ b/src/model/subscriptionAccessOverrides.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared "billed by subscription, not per token" fact for a runtime model
+ * config: the access route is zero-cost per API call, and the caller has
+ * already resolved the context window actually available on that route.
+ *
+ * Every access route that hits this (Copilot LM API models, Kimi Code,
+ * ChatGPT/Codex subscription) hand-writes the identical `inputPrice: 0,
+ * outputPrice: 0` pair; only that pair is genuinely duplicated. The
+ * `contextWindow` cap formula differs per route (an external API's own
+ * limit, a fixed subscription-tier constant, a `Math.min` against the base
+ * registry window, …), so callers compute it themselves and pass the
+ * resolved value in rather than have this helper guess at a formula.
+ */
+export function zeroCostAccessOverrides(contextWindow: number): {
+  readonly inputPrice: 0;
+  readonly outputPrice: 0;
+  readonly contextWindow: number;
+} {
+  return { inputPrice: 0, outputPrice: 0, contextWindow };
+}

--- a/src/shared/schemas/goal.ts
+++ b/src/shared/schemas/goal.ts
@@ -36,6 +36,37 @@ export function isGoalInFlight(
   return goal != null;
 }
 
+/**
+ * Canonical goal-state shape: status/objective only exist while a goal is
+ * active. Mirrors `ProgressStreamControls`'s goal member
+ * (`src/controllers/progressView/backend/events/ProgressFactApplier.ts`),
+ * which is the authoritative source this type is derived from.
+ */
+export type GoalState =
+  | { active: false }
+  | { active: true; status: GoalStatus; objective: string };
+
+/**
+ * Single source of truth for the "status/objective are only meaningful while
+ * a goal is active" invariant. Wire messages and `ToolUseStreamState`
+ * (`streamState.ts`) can't carry the canonical discriminated union directly
+ * (three independently-optional fields on the wire), so every reader of that
+ * flattened shape — frontend slices, UI components — must call this instead
+ * of re-deriving the active/status/objective guard ad hoc at each site.
+ */
+export function deriveGoalState(input: {
+  goalActive?: boolean;
+  goalStatus?: GoalStatus;
+  goalObjective?: string;
+}): GoalState {
+  if (!input.goalActive) return { active: false };
+  return {
+    active: true,
+    status: input.goalStatus ?? 'active',
+    objective: input.goalObjective ?? '',
+  };
+}
+
 export const GoalSchema = z.object({
   goalId: z.string().min(1),
   streamId: StreamTabIdSchema,

--- a/src/shared/schemas/goal.ts
+++ b/src/shared/schemas/goal.ts
@@ -38,12 +38,20 @@ export function isGoalInFlight(
 
 /**
  * Canonical goal-state shape: status/objective only exist while a goal is
- * active. Mirrors `ProgressStreamControls`'s goal member
- * (`src/controllers/progressView/backend/events/ProgressFactApplier.ts`),
- * which is the authoritative source this type is derived from.
+ * active. This is the one definition of that union — `outbound.ts`'s
+ * SYNC_STREAM_CONTENT wire schema imports `GoalStateSchema` directly rather
+ * than re-declaring the same discriminated union under a different name, so
+ * there's exactly one place the shape can drift.
  */
-export type GoalState =
-  { active: false } | { active: true; status: GoalStatus; objective: string };
+export const GoalStateSchema = z.discriminatedUnion('active', [
+  z.strictObject({ active: z.literal(false) }),
+  z.strictObject({
+    active: z.literal(true),
+    status: GoalStatusSchema,
+    objective: z.string(),
+  }),
+]);
+export type GoalState = z.infer<typeof GoalStateSchema>;
 
 /**
  * Single source of truth for the "status/objective are only meaningful while

--- a/src/shared/schemas/goal.ts
+++ b/src/shared/schemas/goal.ts
@@ -43,8 +43,7 @@ export function isGoalInFlight(
  * which is the authoritative source this type is derived from.
  */
 export type GoalState =
-  | { active: false }
-  | { active: true; status: GoalStatus; objective: string };
+  { active: false } | { active: true; status: GoalStatus; objective: string };
 
 /**
  * Single source of truth for the "status/objective are only meaningful while

--- a/src/shared/schemas/mainView/state.ts
+++ b/src/shared/schemas/mainView/state.ts
@@ -86,11 +86,12 @@ export const ModelOptionDataSchema = PickerOptionBaseSchema.extend({
    * Distinguishes a basic static-config projection (`buildBasicModelOptionsData`,
    * no availability fields populated) from a fully resolved row
    * (`buildModelOptionData`, availability/routing resolved against the active
-   * API mode). Added additively alongside the still-optional availability
-   * fields below — narrow with `if (row.kind === 'resolved')` rather than
-   * treating this as a replacement for those checks.
+   * API mode). Optional so existing construction sites (tests, fixtures)
+   * stay valid — narrow with `if (row.kind === 'resolved')` rather than
+   * treating this as a replacement for the still-optional availability
+   * fields below.
    */
-  kind: z.enum(['basic', 'resolved']),
+  kind: z.enum(['basic', 'resolved']).optional(),
   provider: z.string().optional(),
   context: z.string().optional(),
   cost: z.string().optional(),

--- a/src/shared/schemas/mainView/state.ts
+++ b/src/shared/schemas/mainView/state.ts
@@ -82,6 +82,15 @@ export const ModelAvailabilityFieldsSchema = z.object({
   disabled: z.boolean().optional(),
 });
 export const ModelOptionDataSchema = PickerOptionBaseSchema.extend({
+  /**
+   * Distinguishes a basic static-config projection (`buildBasicModelOptionsData`,
+   * no availability fields populated) from a fully resolved row
+   * (`buildModelOptionData`, availability/routing resolved against the active
+   * API mode). Added additively alongside the still-optional availability
+   * fields below — narrow with `if (row.kind === 'resolved')` rather than
+   * treating this as a replacement for those checks.
+   */
+  kind: z.enum(['basic', 'resolved']),
   provider: z.string().optional(),
   context: z.string().optional(),
   cost: z.string().optional(),

--- a/src/shared/schemas/mainView/state.ts
+++ b/src/shared/schemas/mainView/state.ts
@@ -82,16 +82,6 @@ export const ModelAvailabilityFieldsSchema = z.object({
   disabled: z.boolean().optional(),
 });
 export const ModelOptionDataSchema = PickerOptionBaseSchema.extend({
-  /**
-   * Distinguishes a basic static-config projection (`buildBasicModelOptionsData`,
-   * no availability fields populated) from a fully resolved row
-   * (`buildModelOptionData`, availability/routing resolved against the active
-   * API mode). Optional so existing construction sites (tests, fixtures)
-   * stay valid — narrow with `if (row.kind === 'resolved')` rather than
-   * treating this as a replacement for the still-optional availability
-   * fields below.
-   */
-  kind: z.enum(['basic', 'resolved']).optional(),
   provider: z.string().optional(),
   context: z.string().optional(),
   cost: z.string().optional(),

--- a/src/shared/schemas/progressView/outbound.ts
+++ b/src/shared/schemas/progressView/outbound.ts
@@ -11,7 +11,7 @@ import {
   type HandlerRegistry,
 } from '@shared/utils/dispatcher';
 import { ThemeSchema } from '../commonViewMessages';
-import { GoalStatusSchema } from '../goal';
+import { GoalStateSchema, GoalStatusSchema } from '../goal';
 import { AgentCategory } from '../agent';
 
 import { StreamTabIdSchema } from '../identifiers';
@@ -326,15 +326,6 @@ const WorkflowStreamContentMessageSchema = z.strictObject({
   }),
 });
 
-const GoalSyncSchema = z.discriminatedUnion('active', [
-  z.strictObject({ active: z.literal(false) }),
-  z.strictObject({
-    active: z.literal(true),
-    status: GoalStatusSchema,
-    objective: z.string(),
-  }),
-]);
-
 const ToolUseStreamContentMessageSchema = z.strictObject({
   ...StreamContentRenderFields,
   kind: z.literal(AgentCategory.ToolUse),
@@ -346,7 +337,7 @@ const ToolUseStreamContentMessageSchema = z.strictObject({
   controls: z.strictObject({
     toolEditBypass: z.boolean(),
     superYoloBypass: z.boolean(),
-    goal: GoalSyncSchema,
+    goal: GoalStateSchema,
   }),
 });
 

--- a/src/shared/signals.ts
+++ b/src/shared/signals.ts
@@ -21,3 +21,35 @@ export function select<S, T>(
 ): Signal.Computed<T> {
   return new Signal.Computed(() => selector(source.get()));
 }
+
+/**
+ * Creates an independent `trackedSignal`/`resetAll` pair for a state module.
+ * `trackedSignal` declares a writable signal and registers its reset
+ * callback in the same expression, so a module's `resetAll()` can replay
+ * every signal's own default-value factory instead of a hand-written,
+ * independently-ordered sequence of `.set()` calls that can drift from the
+ * declaration list. `initialValue` is a factory (not a bare value) so every
+ * reset — like every fresh mount — constructs an independent value rather
+ * than reusing one shared object reference.
+ *
+ * Each caller gets its own registry (the callbacks array is captured in the
+ * closure below), so multiple state modules can each call this once at
+ * module scope without sharing reset state.
+ */
+export function createTrackedSignalRegistry() {
+  const resetCallbacks: Array<() => void> = [];
+
+  function trackedSignal<T>(initialValue: () => T): Signal.State<T> {
+    const s = signal(initialValue());
+    resetCallbacks.push(() => s.set(initialValue()));
+    return s;
+  }
+
+  function resetAll(): void {
+    for (const reset of resetCallbacks) {
+      reset();
+    }
+  }
+
+  return { trackedSignal, resetAll };
+}

--- a/src/shared/streams/streamMetadata.ts
+++ b/src/shared/streams/streamMetadata.ts
@@ -1,32 +1,27 @@
+import { z } from 'zod';
+
 import {
+  AgentCategorySchema,
   DEFAULT_CONVERSATION_PROGRESS,
   DEFAULT_FINISHED_CHILD_COUNT,
   DEFAULT_STREAM_METADATA_STATUS,
-  type ActiveChildInfo,
-  type AgentCategory,
-  type ConversationProgress,
-  type RoundStage,
+  StreamMetadataSchema,
   type StreamMetadata,
-  type StreamLifecycleStatus,
-  type StreamSubstate,
 } from '@shared/schemas';
 
 /**
  * Host-neutral stream metadata builder used by the extension and desktop
- * progress backends before sending UPDATE_STREAMS payloads.
+ * progress backends before sending UPDATE_STREAMS payloads. Derived from
+ * `StreamMetadataSchema` (every field optional except `kind`) rather than
+ * hand-duplicated, so it can't drift from the wire schema.
  */
-export interface StreamMetadataInputs {
-  kind: AgentCategory;
-  status?: StreamLifecycleStatus;
-  substate?: StreamSubstate;
-  lastTimestamp?: number;
-  conversationProgress?: ConversationProgress;
-  roundStage?: RoundStage | null;
-  activeSubagents?: ActiveChildInfo[];
-  finishedSubagentCount?: number;
-  activeProcesses?: ActiveChildInfo[];
-  finishedProcessCount?: number;
-}
+export const StreamMetadataInputsSchema = StreamMetadataSchema.partial().extend(
+  {
+    kind: AgentCategorySchema,
+  },
+);
+
+export type StreamMetadataInputs = z.infer<typeof StreamMetadataInputsSchema>;
 
 export function buildStreamMetadata(
   inputs: StreamMetadataInputs,

--- a/src/shared/streams/streamMetadata.ts
+++ b/src/shared/streams/streamMetadata.ts
@@ -15,11 +15,9 @@ import {
  * `StreamMetadataSchema` (every field optional except `kind`) rather than
  * hand-duplicated, so it can't drift from the wire schema.
  */
-export const StreamMetadataInputsSchema = StreamMetadataSchema.partial().extend(
-  {
-    kind: AgentCategorySchema,
-  },
-);
+const StreamMetadataInputsSchema = StreamMetadataSchema.partial().extend({
+  kind: AgentCategorySchema,
+});
 
 export type StreamMetadataInputs = z.infer<typeof StreamMetadataInputsSchema>;
 

--- a/src/test-kernel/agent/modelHandlers/MoonshotBaseUrl.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/MoonshotBaseUrl.vitest.ts
@@ -10,11 +10,13 @@ import { installPlatform } from '@test/support/setupPlatform';
 function moonshotConfig(
   overrides: { customBaseUrl?: string } = {},
 ): Parameters<typeof resolveBaseUrl>[0] {
+  if (overrides.customBaseUrl) {
+    return { route: 'custom', url: overrides.customBaseUrl };
+  }
   return {
+    route: 'direct',
     provider: ModelProvider.MOONSHOT,
-    openRouterOnly: false,
-    useServerSideKeys: false,
-    ...overrides,
+    useOpenRouter: false,
   };
 }
 

--- a/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
@@ -211,7 +211,9 @@ describe('output progress events', () => {
           payload: { location: openedLocation, preserveFocus: true },
         },
       ]);
-      expect(shared.roundOutputs).toBe(outputState.rounds);
+      // Round 0 was never populated in this fixture; the projection must
+      // keep round 1's data at index 1 rather than compacting it to index 0.
+      expect(shared.roundOutputs[0]).toBeUndefined();
       expect(shared.roundOutputs[1]?.outputs).toEqual([restoredFileInfo]);
     } finally {
       projected.dispose();

--- a/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
+++ b/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
@@ -565,12 +565,11 @@ describe('desktop main-view IPC', () => {
       },
     }));
     vi.doMock('@model/computeModelOptions', () => ({
-      // `label` and `kind` are required by `ModelOptionDataSchema`
-      // (PickerOptionBaseSchema plus the basic/resolved discriminant) —
+      // `label` is required by `ModelOptionDataSchema` (PickerOptionBaseSchema) —
       // `postToRenderer` now runs the SET_MODEL_OPTIONS payload through it
       // (dev/test only), so the stub must match the real shape.
       computeModelOptionsData: vi.fn(async () => [
-        { kind: 'resolved', value: 'fresh-model', label: 'Fresh Model' },
+        { value: 'fresh-model', label: 'Fresh Model' },
       ]),
     }));
     const { ELECTRON_WEBVIEW_PUSH_CHANNEL, installDesktopMainViewIpc } =

--- a/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
+++ b/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
@@ -565,11 +565,12 @@ describe('desktop main-view IPC', () => {
       },
     }));
     vi.doMock('@model/computeModelOptions', () => ({
-      // `label` is required by `ModelOptionDataSchema` (PickerOptionBaseSchema)
-      // — `postToRenderer` now runs the SET_MODEL_OPTIONS payload through it
+      // `label` and `kind` are required by `ModelOptionDataSchema`
+      // (PickerOptionBaseSchema plus the basic/resolved discriminant) —
+      // `postToRenderer` now runs the SET_MODEL_OPTIONS payload through it
       // (dev/test only), so the stub must match the real shape.
       computeModelOptionsData: vi.fn(async () => [
-        { value: 'fresh-model', label: 'Fresh Model' },
+        { kind: 'resolved', value: 'fresh-model', label: 'Fresh Model' },
       ]),
     }));
     const { ELECTRON_WEBVIEW_PUSH_CHANNEL, installDesktopMainViewIpc } =

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -2211,10 +2211,12 @@ describe('ProgressBackend', () => {
 
     try {
       backend.state.streamLogs.ensureStream(stream);
+      // Provisional patches only ever carry agentCategory/isRemote in
+      // production (see ProgressFactApplier.handleSetActiveStream) — agent/
+      // inputFile/model come exclusively from the RunConfig-derived `run`
+      // union, set atomically by applySnapshotMetadata.
       backend.state.updateStreamMetadata(stream, {
-        agent: 'provisional-workflow',
         agentCategory: AgentCategory.Workflow,
-        inputFile: 'draft.tex',
         isRemote: true,
         creationTimestamp: 123,
       });
@@ -2225,17 +2227,19 @@ describe('ProgressBackend', () => {
       );
       // A late provisional event cannot replace task-state authority.
       backend.state.updateStreamMetadata(stream, {
-        agent: 'late-workflow',
         agentCategory: AgentCategory.Workflow,
       });
 
       expect(backend.state.getStreamMetadata(stream)).toMatchObject({
-        agent: 'search',
         agentCategory: AgentCategory.ToolUse,
-        model: 'deepseekproT',
         isRemote: true,
         creationTimestamp: 123,
         executionId,
+        run: expect.objectContaining({
+          kind: 'agent',
+          agent: 'search',
+          model: 'deepseekproT',
+        }),
       });
 
       const toolUseInfos = buildStreamInfos(backend.state, 'toolUse');

--- a/src/test-kernel/progressView/streamInfoUtils.vitest.ts
+++ b/src/test-kernel/progressView/streamInfoUtils.vitest.ts
@@ -64,7 +64,7 @@ describe('buildStreamTabInfo', () => {
     const info = buildStreamTabInfo({
       streamId: 'search@deepseek#exec',
       metadata: {
-        agent: 'search',
+        run: { kind: 'agent', agent: 'search', model: '', instruction: '' },
         agentCategory: AgentCategory.ToolUse,
         isRemote: true,
         creationTimestamp: 1,

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -1,5 +1,6 @@
 // Third-party imports
 import ky, { HTTPError } from 'ky';
+import { AbortError } from 'p-retry';
 import { z } from 'zod';
 
 // Internal imports
@@ -32,23 +33,50 @@ const WebSearchInputSchema = z.strictObject({
 
 export type WebSearchInput = z.infer<typeof WebSearchInputSchema>;
 
+// ============================================================================
+// Response schemas (DuckDuckGo is an external network boundary — validate it)
+// ============================================================================
+
+/**
+ * `RelatedTopics` entries are self-referential (a topic group nests further
+ * `Topics`), so the interface is kept and the recursive schema is annotated
+ * against it (z.lazy) — matching the house pattern in
+ * `src/tools/zotero/bbtClient.ts` (`BbtCollectionChainSchema`).
+ */
 interface DuckDuckGoResult {
   Text?: string;
   FirstURL?: string;
   Topics?: DuckDuckGoResult[];
 }
 
-interface DuckDuckGoResponse {
-  Abstract?: string;
-  AbstractText?: string;
-  AbstractURL?: string;
-  AbstractSource?: string;
-  Heading?: string;
-  RelatedTopics?: DuckDuckGoResult[];
-  Infobox?: {
-    content?: Array<{ label?: string; value?: string }>;
-  };
-}
+const DuckDuckGoResultSchema: z.ZodType<DuckDuckGoResult> = z.lazy(() =>
+  z.looseObject({
+    Text: z.string().optional(),
+    FirstURL: z.string().optional(),
+    Topics: z.array(DuckDuckGoResultSchema).optional(),
+  }),
+);
+
+const DuckDuckGoInfoboxContentItemSchema = z.looseObject({
+  label: z.string().optional(),
+  value: z.string().optional(),
+});
+
+const DuckDuckGoResponseSchema = z.looseObject({
+  Abstract: z.string().optional(),
+  AbstractText: z.string().optional(),
+  AbstractURL: z.string().optional(),
+  AbstractSource: z.string().optional(),
+  Heading: z.string().optional(),
+  RelatedTopics: z.array(DuckDuckGoResultSchema).optional(),
+  Infobox: z
+    .looseObject({
+      content: z.array(DuckDuckGoInfoboxContentItemSchema).optional(),
+    })
+    .nullish(),
+});
+
+type DuckDuckGoResponse = z.infer<typeof DuckDuckGoResponseSchema>;
 
 export class WebSearchTool extends defineTool({
   name: 'web_search',
@@ -80,7 +108,19 @@ export class WebSearchTool extends defineTool({
             signal: joinAbortSignal(DDG_TIMEOUT_MS, cancelSignal),
             retry: 0,
           });
-          return (await response.json()) as DuckDuckGoResponse;
+          const raw = await response.json();
+          // Validate the body at the boundary. A malformed shape is not
+          // transient, so abort retries and let the outer catch below
+          // surface it as a tool error.
+          const parsed = DuckDuckGoResponseSchema.safeParse(raw);
+          if (!parsed.success) {
+            throw new AbortError(
+              new Error(
+                `Unexpected DuckDuckGo response shape: ${z.prettifyError(parsed.error)}`,
+              ),
+            );
+          }
+          return parsed.data;
         },
         { retries: DDG_RETRIES, minTimeout: 500, cancelSignal },
       );
@@ -121,20 +161,17 @@ export class WebSearchTool extends defineTool({
     function extractTopics(topics: DuckDuckGoResult[], limit: number): void {
       for (const item of topics) {
         if (results.length >= limit) break;
-        if (
-          typeof item.Text === 'string' &&
-          typeof item.FirstURL === 'string'
-        ) {
+        if (item.Text && item.FirstURL) {
           results.push(`${item.Text} (${item.FirstURL})`);
         }
         // Handle nested topic groups
-        if (Array.isArray(item.Topics)) {
+        if (item.Topics) {
           extractTopics(item.Topics, limit);
         }
       }
     }
 
-    if (Array.isArray(data.RelatedTopics)) {
+    if (data.RelatedTopics) {
       extractTopics(data.RelatedTopics, max_results);
     }
 

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -44,34 +44,34 @@ export type WebSearchInput = z.infer<typeof WebSearchInputSchema>;
  * `src/tools/zotero/bbtClient.ts` (`BbtCollectionChainSchema`).
  */
 interface DuckDuckGoResult {
-  Text?: string;
-  FirstURL?: string;
-  Topics?: DuckDuckGoResult[];
+  Text?: string | null;
+  FirstURL?: string | null;
+  Topics?: DuckDuckGoResult[] | null;
 }
 
 const DuckDuckGoResultSchema: z.ZodType<DuckDuckGoResult> = z.lazy(() =>
   z.looseObject({
-    Text: z.string().optional(),
-    FirstURL: z.string().optional(),
-    Topics: z.array(DuckDuckGoResultSchema).optional(),
+    Text: z.string().nullish(),
+    FirstURL: z.string().nullish(),
+    Topics: z.array(DuckDuckGoResultSchema).nullish(),
   }),
 );
 
 const DuckDuckGoInfoboxContentItemSchema = z.looseObject({
-  label: z.string().optional(),
-  value: z.string().optional(),
+  label: z.string().nullish(),
+  value: z.string().nullish(),
 });
 
 const DuckDuckGoResponseSchema = z.looseObject({
-  Abstract: z.string().optional(),
-  AbstractText: z.string().optional(),
-  AbstractURL: z.string().optional(),
-  AbstractSource: z.string().optional(),
-  Heading: z.string().optional(),
-  RelatedTopics: z.array(DuckDuckGoResultSchema).optional(),
+  Abstract: z.string().nullish(),
+  AbstractText: z.string().nullish(),
+  AbstractURL: z.string().nullish(),
+  AbstractSource: z.string().nullish(),
+  Heading: z.string().nullish(),
+  RelatedTopics: z.array(DuckDuckGoResultSchema).nullish(),
   Infobox: z
     .looseObject({
-      content: z.array(DuckDuckGoInfoboxContentItemSchema).optional(),
+      content: z.array(DuckDuckGoInfoboxContentItemSchema).nullish(),
     })
     .nullish(),
 });


### PR DESCRIPTION
## Summary

This PR consolidates and improves state reset mechanisms across the extension and desktop hosts by introducing a `trackedSignal()` wrapper that automatically registers reset callbacks at signal declaration time. It also strengthens type safety in several modules by replacing loose object schemas with discriminated unions, extracting shared constants, and clarifying ownership of config-derived state.

Key changes:
1. **Settings and main-view state**: Replace hand-written reset sequences with auto-registered `trackedSignal()` callbacks, eliminating the risk of forgetting to wire a new signal into the reset.
2. **Content block schemas**: Replace `looseObject` with a discriminated union over `type`, making valid block kinds explicit and enabling exhaustive pattern matching.
3. **Proxy config routing**: Convert `ProxyConfig` from a bag of optional booleans to a discriminated union (`route: 'custom' | 'serverSideKeys' | 'direct'`), preventing ambiguous configurations.
4. **Progress stream metadata**: Introduce `ProgressStreamRunDetails` union to clarify that agent/inputFile/model are only meaningful when `RunConfig` resolves, not as independent optional fields.
5. **Output state**: Change `rounds` from `RoundOutput[]` to `Map<number, RoundOutput>` keyed by round index, with helper functions `roundsFromPersisted()` and `roundsToPersisted()` for hydration/projection.
6. **Goal state**: Extract `GoalState` discriminated union and `deriveGoalState()` function to enforce the invariant that status/objective only exist while a goal is active.
7. **Shared constants**: Extract `zeroCostAccessOverrides` for subscription-based models (Copilot LM API, Kimi Code, ChatGPT/Codex) to avoid duplication.
8. **Stream metadata builder**: Derive `StreamMetadataInputs` from `StreamMetadataSchema` to prevent drift.

## Issue acceptance gates

N/A — this is a refactoring/consolidation PR with no new features or bug fixes.

## Single source of truth

- **State reset**: `trackedSignal()` wrapper in `settingsState.ts` and `mainViewState.ts` — each signal's default is declared once at the call site, and reset callbacks are auto-registered.
- **Content block kinds**: `ContentBlockSchema` discriminated union in `normalizeConversation.ts` — all valid block types and their fields are declared in one place.
- **Proxy routing**: `ProxyConfig` discriminated union in `ProxyConfigResolver.ts` — the route decision (custom/serverSideKeys/direct) is explicit, not inferred from optional flags.
- **Progress stream run details**: `ProgressStreamRunDetails` union in `ProgressViewState.ts` — agent/inputFile/model are only present when `RunConfig` resolves.
- **Output rounds**: `Map<number, RoundOutput>` in `outputState.ts` with `roundsFromPersisted()` / `roundsToPersisted()` — round indexing is explicit and consistent.
- **Goal state**: `GoalState` union and `deriveGoalState()` in `goal.ts` — the active/status/objective invariant is enforced at one call site.
- **Subscription access overrides**: `zeroCostAccessOverrides` in `subscriptionAccessOverrides.ts` — shared `inputPrice: 0, outputPrice: 0` fact for all subscription-based routes.

## Duplication and abstraction budget

**Removed duplication:**
- Hand-written reset sequences in `settingsState.ts` and `mainViewState.ts` replaced with auto-registered callbacks — eliminates the risk of adding a signal without wiring it into reset.
- Loose `ContentBlockSchema` with ad hoc optional-field checks replaced with discriminated union — enables exhaustive pattern matching and makes valid block kinds explicit.
- Repeated `inputPrice: 0, outputPrice: 0` pairs across subscription-model configs consolidated into `zeroCostAccessOverrides`.
- Hand-duplicated `StreamMetadataInputs` interface replaced with derivation from `StreamMetadataSchema` — prevents schema drift.

**New abstractions:**
- `trackedSignal<T>

https://claude.ai/code/session_01MSCcb3JbPULhr3fz4SCKvp

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches progress metadata wiring, reflection output persistence, and API base-URL resolution—areas where subtle regressions could affect tabs or model calls, though behavior is largely preserved with updated tests.
> 
> **Overview**
> **State reset:** Settings and main webview modules now declare signals via `createTrackedSignalRegistry()` / `trackedSignal()`, so `resetSettingsState()` and `resetMainViewState()` replay registered default factories instead of long hand-maintained `.set()` lists.
> 
> **Goal state:** Adds `GoalStateSchema` and `deriveGoalState()` in `@shared/schemas/goal`, wires the progress view (header, permission slice, outbound sync) to that invariant, and reuses `GoalStateSchema` on the wire instead of a duplicate union.
> 
> **Progress stream metadata:** Replaces loose top-level `agent` / `model` / `instruction` fields with a `run` union (`process` vs `agent`) populated from `RunConfig` in `applySnapshotMetadata`; tab building and tests follow the new shape so provisional patches can't overwrite run details.
> 
> **Agent output:** Live `OutputState.rounds` becomes `Map<number, RoundOutput>` with `roundsFromPersisted` / `roundsToPersisted` so sparse round indices survive hydration; reflection `OutputNode` projects through those helpers.
> 
> **Model routing:** `ProxyConfig` is a `route: 'custom' | 'serverSideKeys' | 'direct'` union; `ModelHandler` builds it via `buildProxyConfig`, and `ResolvedModelConfig` centralizes `forceDirectProvider`. Subscription-priced models share `zeroCostAccessOverrides`.
> 
> **Export normalization:** `ContentBlockSchema` becomes a discriminated union on `type`, with switch-based consumers instead of loose optional-field checks.
> 
> **Smaller changes:** CLI transcript line cache uses a bounded composite key (width + execution-labels token); DuckDuckGo responses are Zod-validated in `WebSearchTool`; `buildAgentFinalResult` only reads `structured` from tool-use flow results; LaTeX recommended settings distinguish scalar vs object updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9701b7bd27d31c469b9967feeb8f0119c535db9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->