### PR TITLE
fix: inherit delegation approval in suborchestrators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ All notable changes to this project will be documented in this file.
   directly to supported models.
 - **Parent agents can inspect generated workflow files directly** — delegated
   workflows make every output available for follow-up review.
+- **Nested orchestrators respect delegated-task auto-approval** — enabling
+  automatic delegation on a parent now lets its suborchestrators continue
+  delegating without additional permission prompts.
 - **Latexdiff artifacts with short abbreviated commit hashes are recognized
   consistently** — a generated `basename-diffHASH.tex` file with a 4-5
   character hash is now reliably treated as a diff artifact everywhere

--- a/src/agent/runtime/streamApprovalQueue.ts
+++ b/src/agent/runtime/streamApprovalQueue.ts
@@ -251,14 +251,13 @@ export interface SessionApprovals {
    * parent's bypass state whenever the child has no explicit value of its
    * own. Ancestry is tracked separately per kind — linking `bash` does NOT
    * also let the child inherit `toolEdit` or `proposal` bypass — so a
-   * delegation that only wants some kinds to follow the parent can't
-   * accidentally grant super-YOLO auto-approval too.
+   * delegation that only wants some kinds to follow the parent cannot grant
+   * unrelated approvals accidentally.
    *
    * Used for delegated subagent streams (parent = the orchestrator stream,
-   * `kinds: ['bash', 'toolEdit']` — each kind follows the parent's own bypass
-   * live, while `proposal` stays unlinked so a child's own delegations still
-   * prompt; see `configureDelegatedChildApprovals`) and, in the CLI,
-   * successive conversation rounds (parent = the previous round's root
+   * all kinds, so complete delegated-task approval remains effective through
+   * nested orchestrators; see `configureDelegatedChildApprovals`) and, in the
+   * CLI, successive conversation rounds (parent = the previous round's root
    * stream, all kinds — a CLI round should carry forward whichever bypasses
    * were on) — both mint a fresh `StreamTabId` that would otherwise start
    * every bypass kind ungated.

--- a/src/test-kernel/agent/followUp/ChildStreamYoloInheritance.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamYoloInheritance.vitest.ts
@@ -262,19 +262,19 @@ describe('child subagent stream approval inheritance', () => {
     expect(isApprovalBypassedForStream(parent)).toBe(false);
   });
 
-  it('does not let delegation ancestry also grant super-YOLO proposal bypass', () => {
-    // Delegation links bash + tool-edit only. Proposal (super-YOLO) bypass is
-    // deliberately unlinked, so a child's own delegations still prompt unless
-    // granted on the child explicitly.
+  it('propagates delegated-task approval through nested orchestrators', () => {
     const { host } = createRecordingHost();
     const parent = 'stream:parent-super-yolo' as StreamTabId;
-    const child = 'stream:child-no-proposal' as StreamTabId;
+    const child = 'stream:child-orchestrator' as StreamTabId;
+    const grandchild = 'stream:grandchild-orchestrator' as StreamTabId;
     proposalApprovals().setBypass(parent, true, host);
 
     configureDelegatedChildApprovals(child, parent);
+    configureDelegatedChildApprovals(grandchild, child);
 
     expect(proposalApprovals().isBypassed(parent)).toBe(true);
-    expect(proposalApprovals().isBypassed(child)).toBe(false);
+    expect(proposalApprovals().isBypassed(child)).toBe(true);
+    expect(proposalApprovals().isBypassed(grandchild)).toBe(true);
   });
 
   it('keeps ancestry graphs independent per bypass kind', () => {

--- a/src/tools/approval/index.ts
+++ b/src/tools/approval/index.ts
@@ -15,8 +15,8 @@ import {
 import type { StreamTabId } from '@shared/schemas';
 
 /**
- * Link a freshly resolved child subagent stream to its parent for bash and
- * tool-edit bypass resolution.
+ * Link a freshly resolved child subagent stream to its parent for approval
+ * bypass resolution.
  *
  * A child delegated by a parent that auto-runs bash or auto-approves edits
  * should do the same — and should keep following the parent when either
@@ -26,10 +26,9 @@ import type { StreamTabId } from '@shared/schemas';
  * bypass kind, so the CLI's distinct AUTO-BASH / AUTO-APPROVE grants are
  * respected: a parent with AUTO-BASH but edits still gated propagates only
  * bash, and fresh streams default to gated either way. Delegation-proposal
- * (super-YOLO) bypass is deliberately NOT linked — a child's own delegations
- * still prompt unless granted on the child explicitly (and
- * `setDelegatedWorkApprovalBypasses` pins the child's own explicit entries,
- * so that grant survives the parent later re-gating).
+ * bypass is linked as well, so complete delegated-task approval remains
+ * effective when an orchestrator delegates to another orchestrator. A child
+ * may still override any inherited approval explicitly.
  */
 export type DelegatedChildApprovalPolicy = 'inherit' | 'auto-approved';
 
@@ -40,10 +39,7 @@ export function configureDelegatedChildApprovals(
   session: SessionHandle = currentSession(),
 ): void {
   if (parentStreamId) {
-    session.approvals.registerStreamParent(childStreamId, parentStreamId, [
-      'bash',
-      'toolEdit',
-    ]);
+    session.approvals.registerStreamParent(childStreamId, parentStreamId);
   }
   if (policy === 'auto-approved') {
     session.approvals.toolEdit.bypass.setBypass(

--- a/src/tools/delegation/subagentExecution.ts
+++ b/src/tools/delegation/subagentExecution.ts
@@ -114,10 +114,9 @@ export async function executeSubagent(
   const workingDirectory = childConfigPayload.workingDirectory ?? undefined;
 
   const inheritChildStreamApprovals = (resolvedStreamId: StreamTabId): void => {
-    // Live per-kind ancestry: bash and tool-edit each follow the parent's own
-    // bypass, so a bash-only parent (CLI AUTO-BASH without AUTO-APPROVE) still
-    // propagates only bash, and a YOLO toggle on the parent mid-run reaches
-    // already-launched children.
+    // Live per-kind ancestry: each approval follows the parent's corresponding
+    // bypass, so a partial grant propagates only that grant, while complete
+    // delegated-task approval also reaches nested orchestrators.
     configureDelegatedChildApprovals(
       resolvedStreamId,
       orchestratorStreamId,

--- a/src/tools/delegation/workflowScriptAgentRunner.ts
+++ b/src/tools/delegation/workflowScriptAgentRunner.ts
@@ -221,10 +221,10 @@ export function createWorkflowScriptAgentRunner(
             signal: invocation.signal,
             approvalPromptsUnavailable: parent.approvalPromptsUnavailable,
             runtimeUnavailableTools: parent.runtimeUnavailableTools,
-            // Live per-kind ancestry, matching LLM delegation: bash and
-            // tool-edit each follow the parent's own bypass; proposal stays
-            // unlinked so a child's own delegations still prompt. The run's own
-            // stream inherits from the orchestrator, so this stays transitive.
+            // Live per-kind ancestry, matching LLM delegation: each approval
+            // follows the parent's corresponding bypass. The run's own stream
+            // inherits from the orchestrator, so nested delegation remains
+            // transitive.
             onStreamResolved: (resolvedStreamId) => {
               configureDelegatedChildApprovals(
                 resolvedStreamId,


### PR DESCRIPTION
## Summary

- propagate delegated-task auto-approval through child-stream ancestry
- allow nested orchestrators to delegate without repeated permission prompts
- preserve independent command, edit, and delegation approval overrides

## Design

The approval ancestry already models command, edit, and delegation permissions independently, but delegated child streams linked only the first two. This made complete delegated-task approval a shallow setting: it stopped at the first suborchestrator. The change uses the existing per-kind ancestry for all three permissions, preserving the current interface and transitive behavior without adding another approval path.

## Tests

- corepack pnpm exec vitest run src/test-kernel/agent/followUp/ChildStreamYoloInheritance.vitest.ts src/test-kernel/tools/DelegationTools.vitest.ts src/test-kernel/tools/DelegationHeadless.vitest.mts src/test-kernel/tools/SubagentExecutionChildStreamId.vitest.ts src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts src/test-kernel/tools/WorkflowScriptTool.vitest.ts
- corepack pnpm run typecheck
- corepack pnpm run compile:fast
- corepack pnpm run lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes delegation approval inheritance (user-facing permission behavior), but reuses the established per-kind ancestry model with expanded tests rather than a new approval path.
> 
> **Overview**
> **Nested orchestrators now honor full delegated-task auto-approval.** Previously `configureDelegatedChildApprovals` registered parent ancestry only for bash and tool-edit, so super-YOLO / delegation-proposal bypass stopped at the first sub-orchestrator. It now calls `registerStreamParent` with the default **all three** bypass kinds (`toolEdit`, `bash`, `proposal`), using the existing per-kind graphs—partial CLI grants (e.g. AUTO-BASH only) still propagate only that kind, and children can override any inherited bypass explicitly.
> 
> Docs and changelog are updated to match; the inheritance test now expects parent → child → grandchild proposal bypass instead of blocking proposal inheritance on purpose.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb44a7d68936d40f3dcb4b1f435c0c0ef676b04b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->