### PR TITLE
fix(cli): account for file compaction input

### DIFF
--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -197,9 +197,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
   }
 
   /**
-   * Removes entries from uploadedPdfPageCounts whose file IDs are no longer
-   * referenced in the current messages. This keeps the tracked total accurate
-   * after server-side compaction drops old messages.
+   * Removes page counts and token estimates for file IDs no longer referenced
+   * in the current messages. This keeps both caches accurate after server-side
+   * compaction drops old messages.
    */
   private pruneTrackedFileMetadata(messages: MessageParam[]): void {
     const liveFileIds = new Set<string>();
@@ -263,6 +263,14 @@ export class ModelHandlerAnthropic extends ModelHandler<
     );
     let total = 0;
     for (const fileId of fileIds) {
+      signal?.throwIfAborted();
+      const pageEstimate =
+        (this.uploadedPdfPageCounts.get(fileId) ?? 0) * tokensPerPdfPage;
+      if (pageEstimate > 0) {
+        total += pageEstimate;
+        continue;
+      }
+
       let sizeEstimate = this.fileTokenEstimates.get(fileId);
       if (sizeEstimate === undefined) {
         try {
@@ -276,15 +284,14 @@ export class ModelHandlerAnthropic extends ModelHandler<
           sizeEstimate = Math.ceil(metadata.size_bytes / 4);
           this.fileTokenEstimates.set(fileId, sizeEstimate);
         } catch (error) {
+          signal?.throwIfAborted();
           this.logger.debug(
             'Unable to estimate Anthropic file-reference tokens.',
-            { data: error },
+            { data: { fileId, error } },
           );
         }
       }
-      const pageEstimate =
-        (this.uploadedPdfPageCounts.get(fileId) ?? 0) * tokensPerPdfPage;
-      total += Math.max(sizeEstimate ?? 0, pageEstimate);
+      total += sizeEstimate ?? 0;
     }
     return total;
   }

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -276,7 +276,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
         try {
           const metadata = await client.beta.files.retrieveMetadata(
             fileId,
-            undefined,
+            { betas: [FILES_API_BETA] },
             { signal, maxRetries: 0 },
           );
           // Match the shared no-tokenizer heuristic without materializing a

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -246,26 +246,29 @@ export class ModelHandlerAnthropic extends ModelHandler<
     messages: MessageParam[],
     signal?: AbortSignal,
   ): Promise<number> {
-    const fileIds = new Set<string>();
+    const fileReferenceCounts = new Map<string, number>();
     for (const message of messages) {
       if (!Array.isArray(message.content)) continue;
       for (const block of extractDocumentBlocks(message.content)) {
         const source = block.source as
           { type: string; file_id?: string } | undefined;
         if (source?.type === 'file' && source.file_id) {
-          fileIds.add(source.file_id);
+          fileReferenceCounts.set(
+            source.file_id,
+            (fileReferenceCounts.get(source.file_id) ?? 0) + 1,
+          );
         }
       }
     }
 
     let total = 0;
-    for (const fileId of fileIds) {
+    for (const [fileId, referenceCount] of fileReferenceCounts) {
       signal?.throwIfAborted();
       const pageEstimate =
         (this.uploadedPdfPageCounts.get(fileId) ?? 0) *
         ANTHROPIC_PDF_TOKENS_PER_PAGE_ESTIMATE;
       if (pageEstimate > 0) {
-        total += pageEstimate;
+        total += pageEstimate * referenceCount;
         continue;
       }
 
@@ -289,7 +292,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
           );
         }
       }
-      total += sizeEstimate ?? 0;
+      total += (sizeEstimate ?? 0) * referenceCount;
     }
     return total;
   }

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -274,12 +274,14 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
       let sizeEstimate = this.fileTokenEstimates.get(fileId);
       if (sizeEstimate === undefined) {
+        let metadataFallback: number | undefined;
         try {
           const metadata = await client.beta.files.retrieveMetadata(
             fileId,
             { betas: [FILES_API_BETA] },
             { signal, maxRetries: 0 },
           );
+          metadataFallback = Math.ceil(metadata.size_bytes / 4);
           if (metadata.mime_type === 'application/pdf') {
             const response = await client.beta.files.download(
               fileId,
@@ -294,6 +296,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
                 this.uploadedPdfPageCounts.set(fileId, pageCount);
                 sizeEstimate =
                   pageCount * ANTHROPIC_PDF_TOKENS_PER_PAGE_ESTIMATE;
+              } else {
+                sizeEstimate = metadataFallback;
+                this.fileTokenEstimates.set(fileId, sizeEstimate);
               }
             } finally {
               wipeBuffer(buffer);
@@ -301,11 +306,17 @@ export class ModelHandlerAnthropic extends ModelHandler<
           } else {
             // Match the shared no-tokenizer heuristic without materializing a
             // string as large as the remote document.
-            sizeEstimate = Math.ceil(metadata.size_bytes / 4);
+            sizeEstimate = metadataFallback;
             this.fileTokenEstimates.set(fileId, sizeEstimate);
           }
         } catch (error) {
           signal?.throwIfAborted();
+          if (metadataFallback !== undefined) {
+            // A PDF that cannot be downloaded or parsed must still contribute
+            // a stable fallback without repeating the failed body request.
+            sizeEstimate = metadataFallback;
+            this.fileTokenEstimates.set(fileId, sizeEstimate);
+          }
           this.logger.debug(
             'Unable to estimate Anthropic file-reference tokens.',
             { data: { fileId, error } },

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -1,4 +1,5 @@
 // Node imports
+import { Buffer } from 'node:buffer';
 import { basename } from 'node:path';
 
 // Third-party imports
@@ -74,6 +75,7 @@ import {
   describeAttachments,
   formatAttachmentSummaryFromNotes,
   formatToolResultAsText,
+  wipeBuffer,
 } from '../utils/toolAttachmentUtils';
 import { tagAnthropicSdkError } from './anthropicSdkError';
 import {
@@ -91,6 +93,7 @@ import {
   enforceCacheControlLimit,
 } from './anthropicContextManagement';
 import {
+  countPdfPagesFromBuffer,
   extractDocumentBlocks,
   analyzeDocumentSources,
   replaceDocumentDataWithUploads,
@@ -277,10 +280,30 @@ export class ModelHandlerAnthropic extends ModelHandler<
             { betas: [FILES_API_BETA] },
             { signal, maxRetries: 0 },
           );
-          // Match the shared no-tokenizer heuristic without materializing a
-          // string as large as the remote document.
-          sizeEstimate = Math.ceil(metadata.size_bytes / 4);
-          this.fileTokenEstimates.set(fileId, sizeEstimate);
+          if (metadata.mime_type === 'application/pdf') {
+            const response = await client.beta.files.download(
+              fileId,
+              { betas: [FILES_API_BETA] },
+              { signal, maxRetries: 0 },
+            );
+            const buffer = Buffer.from(await response.arrayBuffer());
+            try {
+              signal?.throwIfAborted();
+              const pageCount = await countPdfPagesFromBuffer(buffer);
+              if (pageCount > 0) {
+                this.uploadedPdfPageCounts.set(fileId, pageCount);
+                sizeEstimate =
+                  pageCount * ANTHROPIC_PDF_TOKENS_PER_PAGE_ESTIMATE;
+              }
+            } finally {
+              wipeBuffer(buffer);
+            }
+          } else {
+            // Match the shared no-tokenizer heuristic without materializing a
+            // string as large as the remote document.
+            sizeEstimate = Math.ceil(metadata.size_bytes / 4);
+            this.fileTokenEstimates.set(fileId, sizeEstimate);
+          }
         } catch (error) {
           signal?.throwIfAborted();
           this.logger.debug(

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -179,6 +179,9 @@ const INTERLEAVED_THINKING_BETA: AnthropicBeta =
 /** Anthropic's documented upper typical text-token estimate per PDF page. */
 const ANTHROPIC_PDF_TOKENS_PER_PAGE_ESTIMATE = 3_000;
 
+/** Keeps resumed-PDF inspection bounded before the model request begins. */
+const MAX_PDF_PAGE_COUNT_DOWNLOAD_BYTES = 1024 * 1024;
+
 /** Counts live Files API references after the latest compaction boundary. */
 function collectFileReferenceCounts(
   messages: MessageParam[],
@@ -282,7 +285,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
             { signal, maxRetries: 0 },
           );
           metadataFallback = Math.ceil(metadata.size_bytes / 4);
-          if (metadata.mime_type === 'application/pdf') {
+          if (
+            metadata.mime_type === 'application/pdf' &&
+            metadata.size_bytes <= MAX_PDF_PAGE_COUNT_DOWNLOAD_BYTES
+          ) {
             const response = await client.beta.files.download(
               fileId,
               { betas: [FILES_API_BETA] },
@@ -305,7 +311,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
             }
           } else {
             // Match the shared no-tokenizer heuristic without materializing a
-            // string as large as the remote document.
+            // large remote document. Small PDFs are inspected to avoid using
+            // compressed bytes as a misleading page-count proxy.
             sizeEstimate = metadataFallback;
             this.fileTokenEstimates.set(fileId, sizeEstimate);
           }

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -186,6 +186,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
 > {
   /** Tracks PDF page counts for files uploaded to the Anthropic Files API. */
   private uploadedPdfPageCounts = new Map<string, number>();
+  /** Caches file-size token estimates for references that countTokens rejects. */
+  private fileTokenEstimates = new Map<string, number>();
 
   /** Sum of all tracked PDF page counts across uploaded files. */
   private getTrackedPdfPageCount(): number {
@@ -199,7 +201,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
    * referenced in the current messages. This keeps the tracked total accurate
    * after server-side compaction drops old messages.
    */
-  private pruneTrackedPdfPages(messages: MessageParam[]): void {
+  private pruneTrackedFileMetadata(messages: MessageParam[]): void {
     const liveFileIds = new Set<string>();
     for (const message of messages) {
       const contentBlocks = message.content;
@@ -226,6 +228,65 @@ export class ModelHandlerAnthropic extends ModelHandler<
         this.uploadedPdfPageCounts.delete(fileId);
       }
     }
+    for (const fileId of this.fileTokenEstimates.keys()) {
+      if (!liveFileIds.has(fileId)) {
+        this.fileTokenEstimates.delete(fileId);
+      }
+    }
+  }
+
+  /**
+   * Estimates the context consumed by Files API references from their metadata.
+   * Anthropic cannot count requests containing file sources, while serializing
+   * the file_id alone omits the document. Cache the best available estimate so
+   * repeated tool-use rounds do not add a metadata request per file.
+   */
+  private async estimateFileReferenceTokens(
+    client: Anthropic,
+    messages: MessageParam[],
+    signal?: AbortSignal,
+  ): Promise<number> {
+    const fileIds = new Set<string>();
+    for (const message of messages) {
+      if (!Array.isArray(message.content)) continue;
+      for (const block of extractDocumentBlocks(message.content)) {
+        const source = block.source as
+          { type: string; file_id?: string } | undefined;
+        if (source?.type === 'file' && source.file_id) {
+          fileIds.add(source.file_id);
+        }
+      }
+    }
+
+    const tokensPerPdfPage = Math.ceil(
+      this.getEffectiveContextWindow() / this.getMaxPdfPages(),
+    );
+    let total = 0;
+    for (const fileId of fileIds) {
+      let sizeEstimate = this.fileTokenEstimates.get(fileId);
+      if (sizeEstimate === undefined) {
+        try {
+          const metadata = await client.beta.files.retrieveMetadata(
+            fileId,
+            undefined,
+            { signal, maxRetries: 0 },
+          );
+          // Match the shared no-tokenizer heuristic without materializing a
+          // string as large as the remote document.
+          sizeEstimate = Math.ceil(metadata.size_bytes / 4);
+          this.fileTokenEstimates.set(fileId, sizeEstimate);
+        } catch (error) {
+          this.logger.debug(
+            'Unable to estimate Anthropic file-reference tokens.',
+            { data: error },
+          );
+        }
+      }
+      const pageEstimate =
+        (this.uploadedPdfPageCounts.get(fileId) ?? 0) * tokensPerPdfPage;
+      total += Math.max(sizeEstimate ?? 0, pageEstimate);
+    }
+    return total;
   }
 
   /** Returns the PDF page limit based on the model's effective context window. */
@@ -536,8 +597,11 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     // Prune tracked PDF page counts for file IDs no longer in messages
     // (e.g. after server-side compaction drops old messages)
-    if (this.uploadedPdfPageCounts.size > 0) {
-      this.pruneTrackedPdfPages(messages);
+    if (
+      this.uploadedPdfPageCounts.size > 0 ||
+      this.fileTokenEstimates.size > 0
+    ) {
+      this.pruneTrackedFileMetadata(messages);
     }
 
     // Phase 1: BUILD - Construct provider-specific request parameters
@@ -739,18 +803,25 @@ export class ModelHandlerAnthropic extends ModelHandler<
     const compactionEdit = options.context_management?.edits?.find(
       (edit) => edit.type === 'compact_20260112',
     );
+    const fileReferenceTokens =
+      measuredInputTokens === undefined &&
+      !useStreaming &&
+      compactionEdit?.trigger?.type === 'input_tokens' &&
+      hasFileReference
+        ? await this.estimateFileReferenceTokens(client, messages, signal)
+        : 0;
     const inputTokensForCompaction =
       measuredInputTokens ??
-      estimateTokensFromText(
-        JSON.stringify({
-          messages: options.messages,
-          system: options.system,
-          tools: options.tools,
-          thinking: options.thinking,
-          outputConfig: options.output_config,
-        }),
-      ) +
-        this.getTrackedPdfPageCount() * ANTHROPIC_PDF_TOKENS_PER_PAGE_ESTIMATE;
+      fileReferenceTokens +
+        estimateTokensFromText(
+          JSON.stringify({
+            messages: options.messages,
+            system: options.system,
+            tools: options.tools,
+            thinking: options.thinking,
+            outputConfig: options.output_config,
+          }),
+        );
     const nonStreamingCompactionExpected =
       !useStreaming &&
       compactionEdit?.trigger?.type === 'input_tokens' &&

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -258,14 +258,12 @@ export class ModelHandlerAnthropic extends ModelHandler<
       }
     }
 
-    const tokensPerPdfPage = Math.ceil(
-      this.getEffectiveContextWindow() / this.getMaxPdfPages(),
-    );
     let total = 0;
     for (const fileId of fileIds) {
       signal?.throwIfAborted();
       const pageEstimate =
-        (this.uploadedPdfPageCounts.get(fileId) ?? 0) * tokensPerPdfPage;
+        (this.uploadedPdfPageCounts.get(fileId) ?? 0) *
+        ANTHROPIC_PDF_TOKENS_PER_PAGE_ESTIMATE;
       if (pageEstimate > 0) {
         total += pageEstimate;
         continue;

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -601,7 +601,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     const documentAnalysis = analyzeDocumentSources(messages);
     let hasFileReference = documentAnalysis.hasFileSource;
 
-    // Prune tracked PDF page counts for file IDs no longer in messages
+    // Prune tracked file metadata for file IDs no longer in messages
     // (e.g. after server-side compaction drops old messages)
     if (
       this.uploadedPdfPageCounts.size > 0 ||

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -176,6 +176,33 @@ const INTERLEAVED_THINKING_BETA: AnthropicBeta =
 /** Anthropic's documented upper typical text-token estimate per PDF page. */
 const ANTHROPIC_PDF_TOKENS_PER_PAGE_ESTIMATE = 3_000;
 
+/** Counts live Files API references after the latest compaction boundary. */
+function collectFileReferenceCounts(
+  messages: MessageParam[],
+): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const message of messages) {
+    const contentBlocks = message.content;
+    if (!Array.isArray(contentBlocks)) continue;
+
+    if (
+      contentBlocks.some(
+        (block) => (block as { type?: unknown }).type === 'compaction',
+      )
+    ) {
+      counts.clear();
+    }
+    for (const block of extractDocumentBlocks(contentBlocks)) {
+      const source = block.source as
+        { type: string; file_id?: string } | undefined;
+      if (source?.type === 'file' && source.file_id) {
+        counts.set(source.file_id, (counts.get(source.file_id) ?? 0) + 1);
+      }
+    }
+  }
+  return counts;
+}
+
 export class ModelHandlerAnthropic extends ModelHandler<
   MessageParam,
   BetaUsage,
@@ -202,26 +229,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
    * compaction drops old messages.
    */
   private pruneTrackedFileMetadata(messages: MessageParam[]): void {
-    const liveFileIds = new Set<string>();
-    for (const message of messages) {
-      const contentBlocks = message.content;
-      if (!Array.isArray(contentBlocks)) continue;
-
-      if (
-        contentBlocks.some(
-          (block) => (block as { type?: unknown }).type === 'compaction',
-        )
-      ) {
-        liveFileIds.clear();
-      }
-      for (const block of extractDocumentBlocks(contentBlocks)) {
-        const source = block.source as
-          { type: string; file_id?: string } | undefined;
-        if (source?.type === 'file' && source.file_id) {
-          liveFileIds.add(source.file_id);
-        }
-      }
-    }
+    const liveFileIds = collectFileReferenceCounts(messages);
 
     for (const fileId of this.uploadedPdfPageCounts.keys()) {
       if (!liveFileIds.has(fileId)) {
@@ -245,21 +253,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
     client: Anthropic,
     messages: MessageParam[],
     signal?: AbortSignal,
+    stopAtTokens = Number.POSITIVE_INFINITY,
   ): Promise<number> {
-    const fileReferenceCounts = new Map<string, number>();
-    for (const message of messages) {
-      if (!Array.isArray(message.content)) continue;
-      for (const block of extractDocumentBlocks(message.content)) {
-        const source = block.source as
-          { type: string; file_id?: string } | undefined;
-        if (source?.type === 'file' && source.file_id) {
-          fileReferenceCounts.set(
-            source.file_id,
-            (fileReferenceCounts.get(source.file_id) ?? 0) + 1,
-          );
-        }
-      }
-    }
+    const fileReferenceCounts = collectFileReferenceCounts(messages);
 
     let total = 0;
     for (const [fileId, referenceCount] of fileReferenceCounts) {
@@ -269,6 +265,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
         ANTHROPIC_PDF_TOKENS_PER_PAGE_ESTIMATE;
       if (pageEstimate > 0) {
         total += pageEstimate * referenceCount;
+        if (total >= stopAtTokens) break;
         continue;
       }
 
@@ -293,6 +290,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
         }
       }
       total += (sizeEstimate ?? 0) * referenceCount;
+      if (total >= stopAtTokens) break;
     }
     return total;
   }
@@ -811,29 +809,37 @@ export class ModelHandlerAnthropic extends ModelHandler<
     const compactionEdit = options.context_management?.edits?.find(
       (edit) => edit.type === 'compact_20260112',
     );
-    const fileReferenceTokens =
-      measuredInputTokens === undefined &&
-      !useStreaming &&
-      compactionEdit?.trigger?.type === 'input_tokens' &&
-      hasFileReference
-        ? await this.estimateFileReferenceTokens(client, messages, signal)
-        : 0;
-    const inputTokensForCompaction =
-      measuredInputTokens ??
-      fileReferenceTokens +
-        estimateTokensFromText(
-          JSON.stringify({
-            messages: options.messages,
-            system: options.system,
-            tools: options.tools,
-            thinking: options.thinking,
-            outputConfig: options.output_config,
-          }),
-        );
+    const compactionTrigger =
+      !useStreaming && compactionEdit?.trigger?.type === 'input_tokens'
+        ? compactionEdit.trigger.value
+        : undefined;
+    let inputTokensForCompaction = measuredInputTokens;
+    if (inputTokensForCompaction === undefined) {
+      const textTokens = estimateTokensFromText(
+        JSON.stringify({
+          messages: options.messages,
+          system: options.system,
+          tools: options.tools,
+          thinking: options.thinking,
+          outputConfig: options.output_config,
+        }),
+      );
+      const tokensUntilCompaction =
+        compactionTrigger === undefined ? 0 : compactionTrigger - textTokens;
+      const fileReferenceTokens =
+        hasFileReference && tokensUntilCompaction > 0
+          ? await this.estimateFileReferenceTokens(
+              client,
+              messages,
+              signal,
+              tokensUntilCompaction,
+            )
+          : 0;
+      inputTokensForCompaction = textTokens + fileReferenceTokens;
+    }
     const nonStreamingCompactionExpected =
-      !useStreaming &&
-      compactionEdit?.trigger?.type === 'input_tokens' &&
-      inputTokensForCompaction >= compactionEdit.trigger.value;
+      compactionTrigger !== undefined &&
+      inputTokensForCompaction >= compactionTrigger;
 
     if (nonStreamingCompactionExpected) {
       logCompactionActivity(this.logger, 'started');

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
@@ -1443,6 +1443,74 @@ describe('ModelHandlerAnthropic message guards', () => {
     assert.deepEqual(activityStates, ['started', 'finished']);
   });
 
+  it('prefers tracked PDF pages over compressed file size', async () => {
+    const handler = createAnthropicHandler({ supportsNativePdf: true });
+    const messages: MessageParam[] = [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'document',
+            source: { type: 'file', file_id: 'file_tracked' },
+          },
+        ] as unknown as ContentBlockParam[],
+      },
+    ];
+    const target = handler as unknown as {
+      uploadedPdfPageCounts: Map<string, number>;
+      estimateFileReferenceTokens(
+        client: unknown,
+        messages: MessageParam[],
+      ): Promise<number>;
+    };
+    target.uploadedPdfPageCounts.set('file_tracked', 1);
+    const retrieveMetadata = vi.fn(async () => ({ size_bytes: 800_000 }));
+
+    const estimate = await target.estimateFileReferenceTokens(
+      { beta: { files: { retrieveMetadata } } },
+      messages,
+    );
+
+    assert.equal(estimate, 2_000);
+    assert.equal(retrieveMetadata.mock.calls.length, 0);
+  });
+
+  it('stops file metadata estimation immediately after cancellation', async () => {
+    const handler = createAnthropicHandler({ supportsNativePdf: true });
+    const messages: MessageParam[] = [
+      {
+        role: 'user',
+        content: ['first', 'second'].map((fileId) => ({
+          type: 'document',
+          source: { type: 'file', file_id: fileId },
+        })) as unknown as ContentBlockParam[],
+      },
+    ];
+    const target = handler as unknown as {
+      estimateFileReferenceTokens(
+        client: unknown,
+        messages: MessageParam[],
+        signal: AbortSignal,
+      ): Promise<number>;
+    };
+    const controller = new AbortController();
+    const reason = new DOMException('cancelled', 'AbortError');
+    const retrieveMetadata = vi.fn(async () => {
+      controller.abort(reason);
+      throw reason;
+    });
+
+    await assert.rejects(
+      target.estimateFileReferenceTokens(
+        { beta: { files: { retrieveMetadata } } },
+        messages,
+        controller.signal,
+      ),
+      reason,
+    );
+    assert.equal(retrieveMetadata.mock.calls.length, 1);
+  });
+
   it('does not add native compaction context edit for non-Opus models', async () => {
     const handler = createAnthropicHandler({
       supportsTokenCounting: false,

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
@@ -238,6 +238,39 @@ function createCapturingAnthropicClient(model: string): {
   return { client, messageOptions };
 }
 
+interface AnthropicFileEstimateTarget {
+  uploadedPdfPageCounts: Map<string, number>;
+  estimateFileReferenceTokens(
+    client: unknown,
+    messages: MessageParam[],
+    signal?: AbortSignal,
+    stopAtTokens?: number,
+  ): Promise<number>;
+}
+
+function fileReferenceMessages(...fileIds: string[]): MessageParam[] {
+  return [
+    {
+      role: 'user',
+      content: fileIds.map((fileId) => ({
+        type: 'document',
+        source: { type: 'file', file_id: fileId },
+      })) as unknown as ContentBlockParam[],
+    },
+  ];
+}
+
+function createFileEstimateHarness(...fileIds: string[]): {
+  target: AnthropicFileEstimateTarget;
+  messages: MessageParam[];
+} {
+  const handler = createAnthropicHandler({ supportsNativePdf: true });
+  return {
+    target: handler as unknown as AnthropicFileEstimateTarget,
+    messages: fileReferenceMessages(...fileIds),
+  };
+}
+
 class PdfStubAnthropicHandler extends ModelHandlerAnthropic {
   private mediaContent: ContentBlockParam[] = [];
 
@@ -1486,24 +1519,7 @@ describe('ModelHandlerAnthropic message guards', () => {
   });
 
   it('recovers PDF page estimates for resumed file references', async () => {
-    const handler = createAnthropicHandler({ supportsNativePdf: true });
-    const messages: MessageParam[] = [
-      {
-        role: 'user',
-        content: [
-          {
-            type: 'document',
-            source: { type: 'file', file_id: 'file_resumed_pdf' },
-          },
-        ] as unknown as ContentBlockParam[],
-      },
-    ];
-    const target = handler as unknown as {
-      estimateFileReferenceTokens(
-        client: unknown,
-        messages: MessageParam[],
-      ): Promise<number>;
-    };
+    const { target, messages } = createFileEstimateHarness('file_resumed_pdf');
     const pdf = await PDFDocument.create();
     pdf.addPage();
     const pdfBytes = Uint8Array.from(await pdf.save());
@@ -1532,24 +1548,7 @@ describe('ModelHandlerAnthropic message guards', () => {
   });
 
   it('caches a size fallback when a resumed PDF cannot be parsed', async () => {
-    const handler = createAnthropicHandler({ supportsNativePdf: true });
-    const messages: MessageParam[] = [
-      {
-        role: 'user',
-        content: [
-          {
-            type: 'document',
-            source: { type: 'file', file_id: 'file_invalid_pdf' },
-          },
-        ] as unknown as ContentBlockParam[],
-      },
-    ];
-    const target = handler as unknown as {
-      estimateFileReferenceTokens(
-        client: unknown,
-        messages: MessageParam[],
-      ): Promise<number>;
-    };
+    const { target, messages } = createFileEstimateHarness('file_invalid_pdf');
     const retrieveMetadata = vi.fn(async () => ({
       mime_type: 'application/pdf',
       size_bytes: 800_000,
@@ -1575,29 +1574,10 @@ describe('ModelHandlerAnthropic message guards', () => {
   });
 
   it('prefers tracked PDF pages over compressed file size', async () => {
-    const handler = createAnthropicHandler({ supportsNativePdf: true });
-    const messages: MessageParam[] = [
-      {
-        role: 'user',
-        content: [
-          {
-            type: 'document',
-            source: { type: 'file', file_id: 'file_tracked' },
-          },
-          {
-            type: 'document',
-            source: { type: 'file', file_id: 'file_tracked' },
-          },
-        ] as unknown as ContentBlockParam[],
-      },
-    ];
-    const target = handler as unknown as {
-      uploadedPdfPageCounts: Map<string, number>;
-      estimateFileReferenceTokens(
-        client: unknown,
-        messages: MessageParam[],
-      ): Promise<number>;
-    };
+    const { target, messages } = createFileEstimateHarness(
+      'file_tracked',
+      'file_tracked',
+    );
     target.uploadedPdfPageCounts.set('file_tracked', 1);
     const retrieveMetadata = vi.fn(async (_fileId: string) => ({
       size_bytes: 800_000,
@@ -1613,28 +1593,10 @@ describe('ModelHandlerAnthropic message guards', () => {
   });
 
   it('counts repeated file references while caching their metadata', async () => {
-    const handler = createAnthropicHandler({ supportsNativePdf: true });
-    const messages: MessageParam[] = [
-      {
-        role: 'user',
-        content: [
-          {
-            type: 'document',
-            source: { type: 'file', file_id: 'file_repeated' },
-          },
-          {
-            type: 'document',
-            source: { type: 'file', file_id: 'file_repeated' },
-          },
-        ] as unknown as ContentBlockParam[],
-      },
-    ];
-    const target = handler as unknown as {
-      estimateFileReferenceTokens(
-        client: unknown,
-        messages: MessageParam[],
-      ): Promise<number>;
-    };
+    const { target, messages } = createFileEstimateHarness(
+      'file_repeated',
+      'file_repeated',
+    );
     const retrieveMetadata = vi.fn(async () => ({ size_bytes: 800_000 }));
 
     const estimate = await target.estimateFileReferenceTokens(
@@ -1647,7 +1609,7 @@ describe('ModelHandlerAnthropic message guards', () => {
   });
 
   it('ignores file references before the latest compaction boundary', async () => {
-    const handler = createAnthropicHandler({ supportsNativePdf: true });
+    const { target } = createFileEstimateHarness();
     const messages: MessageParam[] = [
       {
         role: 'user',
@@ -1674,12 +1636,6 @@ describe('ModelHandlerAnthropic message guards', () => {
         ] as unknown as ContentBlockParam[],
       },
     ];
-    const target = handler as unknown as {
-      estimateFileReferenceTokens(
-        client: unknown,
-        messages: MessageParam[],
-      ): Promise<number>;
-    };
     const retrieveMetadata = vi.fn(async (_fileId: string) => ({
       size_bytes: 800_000,
     }));
@@ -1695,24 +1651,10 @@ describe('ModelHandlerAnthropic message guards', () => {
   });
 
   it('stops metadata lookups once file estimates cross the trigger', async () => {
-    const handler = createAnthropicHandler({ supportsNativePdf: true });
-    const messages: MessageParam[] = [
-      {
-        role: 'user',
-        content: ['file_first', 'file_unneeded'].map((fileId) => ({
-          type: 'document',
-          source: { type: 'file', file_id: fileId },
-        })) as unknown as ContentBlockParam[],
-      },
-    ];
-    const target = handler as unknown as {
-      estimateFileReferenceTokens(
-        client: unknown,
-        messages: MessageParam[],
-        signal: AbortSignal | undefined,
-        stopAtTokens: number,
-      ): Promise<number>;
-    };
+    const { target, messages } = createFileEstimateHarness(
+      'file_first',
+      'file_unneeded',
+    );
     const retrieveMetadata = vi.fn(async (_fileId: string) => ({
       size_bytes: 800_000,
     }));
@@ -1730,23 +1672,7 @@ describe('ModelHandlerAnthropic message guards', () => {
   });
 
   it('stops file metadata estimation immediately after cancellation', async () => {
-    const handler = createAnthropicHandler({ supportsNativePdf: true });
-    const messages: MessageParam[] = [
-      {
-        role: 'user',
-        content: ['first', 'second'].map((fileId) => ({
-          type: 'document',
-          source: { type: 'file', file_id: fileId },
-        })) as unknown as ContentBlockParam[],
-      },
-    ];
-    const target = handler as unknown as {
-      estimateFileReferenceTokens(
-        client: unknown,
-        messages: MessageParam[],
-        signal: AbortSignal,
-      ): Promise<number>;
-    };
+    const { target, messages } = createFileEstimateHarness('first', 'second');
     const controller = new AbortController();
     const reason = new DOMException('cancelled', 'AbortError');
     const retrieveMetadata = vi.fn(async () => {

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
@@ -6,6 +6,7 @@ import * as path from 'node:path';
 
 // Third-party imports
 import { APIUserAbortError as AnthropicUserAbortError } from '@anthropic-ai/sdk';
+import { PDFDocument } from '@cantoo/pdf-lib';
 import { afterEach, describe, it, vi } from 'vitest';
 import {
   type ModelCapabilities,
@@ -1482,6 +1483,52 @@ describe('ModelHandlerAnthropic message guards', () => {
     await handler.createResponse({ client, messages, temperature: 0 });
 
     assert.deepEqual(activityStates, ['started', 'finished']);
+  });
+
+  it('recovers PDF page estimates for resumed file references', async () => {
+    const handler = createAnthropicHandler({ supportsNativePdf: true });
+    const messages: MessageParam[] = [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'document',
+            source: { type: 'file', file_id: 'file_resumed_pdf' },
+          },
+        ] as unknown as ContentBlockParam[],
+      },
+    ];
+    const target = handler as unknown as {
+      estimateFileReferenceTokens(
+        client: unknown,
+        messages: MessageParam[],
+      ): Promise<number>;
+    };
+    const pdf = await PDFDocument.create();
+    pdf.addPage();
+    const pdfBytes = Uint8Array.from(await pdf.save());
+    const retrieveMetadata = vi.fn(async () => ({
+      mime_type: 'application/pdf',
+      size_bytes: 800_000,
+    }));
+    const download = vi.fn(async () => ({
+      arrayBuffer: async () => pdfBytes.buffer,
+    }));
+    const client = { beta: { files: { retrieveMetadata, download } } };
+
+    const firstEstimate = await target.estimateFileReferenceTokens(
+      client,
+      messages,
+    );
+    const cachedEstimate = await target.estimateFileReferenceTokens(
+      client,
+      messages,
+    );
+
+    assert.equal(firstEstimate, 3_000);
+    assert.equal(cachedEstimate, 3_000);
+    assert.equal(retrieveMetadata.mock.calls.length, 1);
+    assert.equal(download.mock.calls.length, 1);
   });
 
   it('prefers tracked PDF pages over compressed file size', async () => {

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
@@ -1368,6 +1368,81 @@ describe('ModelHandlerAnthropic message guards', () => {
     },
   );
 
+  it('includes Files API document size in the unmeasured fallback', async () => {
+    const handler = createAnthropicHandler({
+      supportsNativePdf: true,
+      supportsTokenCounting: true,
+      supportsReasoning: false,
+    });
+    handler.config.fullName = 'claude-opus-4-6';
+    handler.setAgentCategory(AgentCategory.ToolUse);
+
+    const activityStates: string[] = [];
+    stubHandlerForTest(handler, {
+      info: (_message: string, options?: { data?: unknown }) => {
+        const data = options?.data as
+          { activity?: unknown; state?: unknown } | undefined;
+        if (
+          data?.activity === 'context_compaction' &&
+          typeof data.state === 'string'
+        ) {
+          activityStates.push(data.state);
+        }
+      },
+    });
+    stubCompactionThresholdPercent(75);
+
+    const messages: MessageParam[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Review this document.', citations: null },
+          {
+            type: 'document',
+            source: { type: 'file', file_id: 'file_large' },
+            title: 'large.pdf',
+          },
+        ] as unknown as ContentBlockParam[],
+      },
+    ];
+    const client = {
+      beta: {
+        files: {
+          retrieveMetadata: async (
+            fileId: string,
+            _params: unknown,
+            options: { maxRetries?: number },
+          ) => {
+            assert.equal(fileId, 'file_large');
+            assert.equal(options.maxRetries, 0);
+            return { size_bytes: 800_000 };
+          },
+        },
+        messages: {
+          countTokens: async () => {
+            throw new Error('file-source requests must not use countTokens');
+          },
+          create: async () => {
+            assert.deepEqual(activityStates, ['started']);
+            return {
+              id: 'msg',
+              type: 'message',
+              role: 'assistant',
+              model: 'claude-opus-4-6',
+              content: [{ type: 'text', text: 'ok' }],
+              stop_reason: 'end_turn',
+              usage: { input_tokens: 20_000, output_tokens: 1 },
+            };
+          },
+        },
+      },
+    } as any;
+
+    await handler.createResponse({ client, messages, temperature: 0 });
+
+    assert.deepEqual(activityStates, ['started', 'finished']);
+  });
+
   it('does not add native compaction context edit for non-Opus models', async () => {
     const handler = createAnthropicHandler({
       supportsTokenCounting: false,

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
@@ -1573,6 +1573,30 @@ describe('ModelHandlerAnthropic message guards', () => {
     assert.equal(download.mock.calls.length, 1);
   });
 
+  it('uses metadata without downloading a large resumed PDF', async () => {
+    const { target, messages } = createFileEstimateHarness('file_large_pdf');
+    const retrieveMetadata = vi.fn(async () => ({
+      mime_type: 'application/pdf',
+      size_bytes: 2 * 1024 * 1024,
+    }));
+    const download = vi.fn();
+    const client = { beta: { files: { retrieveMetadata, download } } };
+
+    const firstEstimate = await target.estimateFileReferenceTokens(
+      client,
+      messages,
+    );
+    const cachedEstimate = await target.estimateFileReferenceTokens(
+      client,
+      messages,
+    );
+
+    assert.equal(firstEstimate, 512 * 1024);
+    assert.equal(cachedEstimate, 512 * 1024);
+    assert.equal(retrieveMetadata.mock.calls.length, 1);
+    assert.equal(download.mock.calls.length, 0);
+  });
+
   it('prefers tracked PDF pages over compressed file size', async () => {
     const { target, messages } = createFileEstimateHarness(
       'file_tracked',

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
@@ -1209,16 +1209,19 @@ describe('ModelHandlerAnthropic message guards', () => {
     assert.deepEqual(activityStates, ['started', 'finished']);
   });
 
-  it('drops tracked PDF pages covered by the latest compaction block', () => {
+  it('drops tracked file metadata covered by the latest compaction block', () => {
     const handler = createAnthropicHandler({ supportsNativePdf: true });
     const target = handler as unknown as {
       uploadedPdfPageCounts: Map<string, number>;
-      pruneTrackedPdfPages(messages: MessageParam[]): void;
+      fileTokenEstimates: Map<string, number>;
+      pruneTrackedFileMetadata(messages: MessageParam[]): void;
     };
     target.uploadedPdfPageCounts.set('file_before_compaction', 50);
     target.uploadedPdfPageCounts.set('file_after_compaction', 2);
+    target.fileTokenEstimates.set('file_before_compaction', 150_000);
+    target.fileTokenEstimates.set('file_after_compaction', 6_000);
 
-    target.pruneTrackedPdfPages([
+    target.pruneTrackedFileMetadata([
       {
         role: 'user',
         content: [
@@ -1249,6 +1252,10 @@ describe('ModelHandlerAnthropic message guards', () => {
     assert.deepEqual(
       [...target.uploadedPdfPageCounts.entries()],
       [['file_after_compaction', 2]],
+    );
+    assert.deepEqual(
+      [...target.fileTokenEstimates.entries()],
+      [['file_after_compaction', 6_000]],
     );
   });
 
@@ -1453,6 +1460,10 @@ describe('ModelHandlerAnthropic message guards', () => {
             type: 'document',
             source: { type: 'file', file_id: 'file_tracked' },
           },
+          {
+            type: 'document',
+            source: { type: 'file', file_id: 'file_tracked' },
+          },
         ] as unknown as ContentBlockParam[],
       },
     ];
@@ -1471,8 +1482,42 @@ describe('ModelHandlerAnthropic message guards', () => {
       messages,
     );
 
-    assert.equal(estimate, 3_000);
+    assert.equal(estimate, 6_000);
     assert.equal(retrieveMetadata.mock.calls.length, 0);
+  });
+
+  it('counts repeated file references while caching their metadata', async () => {
+    const handler = createAnthropicHandler({ supportsNativePdf: true });
+    const messages: MessageParam[] = [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'document',
+            source: { type: 'file', file_id: 'file_repeated' },
+          },
+          {
+            type: 'document',
+            source: { type: 'file', file_id: 'file_repeated' },
+          },
+        ] as unknown as ContentBlockParam[],
+      },
+    ];
+    const target = handler as unknown as {
+      estimateFileReferenceTokens(
+        client: unknown,
+        messages: MessageParam[],
+      ): Promise<number>;
+    };
+    const retrieveMetadata = vi.fn(async () => ({ size_bytes: 800_000 }));
+
+    const estimate = await target.estimateFileReferenceTokens(
+      { beta: { files: { retrieveMetadata } } },
+      messages,
+    );
+
+    assert.equal(estimate, 400_000);
+    assert.equal(retrieveMetadata.mock.calls.length, 1);
   });
 
   it('stops file metadata estimation immediately after cancellation', async () => {

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
@@ -1375,6 +1375,40 @@ describe('ModelHandlerAnthropic message guards', () => {
     },
   );
 
+  it('skips file metadata after text already crosses the trigger', async () => {
+    const handler = createAnthropicHandler({
+      supportsNativePdf: true,
+      supportsTokenCounting: false,
+      supportsReasoning: false,
+    });
+    handler.config.fullName = 'claude-opus-4-6';
+    handler.setAgentCategory(AgentCategory.ToolUse);
+    stubHandlerForTest(handler);
+    stubCompactionThresholdPercent(75);
+
+    const retrieveMetadata = vi.fn(async (_fileId: string) => ({
+      size_bytes: 800_000,
+    }));
+    const { client } = createCapturingAnthropicClient('claude-opus-4-6');
+    client.beta.files = { retrieveMetadata };
+    const messages: MessageParam[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'x'.repeat(620_000), citations: null },
+          {
+            type: 'document',
+            source: { type: 'file', file_id: 'file_unneeded' },
+          },
+        ] as unknown as ContentBlockParam[],
+      },
+    ];
+
+    await handler.createResponse({ client, messages, temperature: 0 });
+
+    assert.equal(retrieveMetadata.mock.calls.length, 0);
+  });
+
   it('includes Files API document size in the unmeasured fallback', async () => {
     const handler = createAnthropicHandler({
       supportsNativePdf: true,
@@ -1475,7 +1509,9 @@ describe('ModelHandlerAnthropic message guards', () => {
       ): Promise<number>;
     };
     target.uploadedPdfPageCounts.set('file_tracked', 1);
-    const retrieveMetadata = vi.fn(async () => ({ size_bytes: 800_000 }));
+    const retrieveMetadata = vi.fn(async (_fileId: string) => ({
+      size_bytes: 800_000,
+    }));
 
     const estimate = await target.estimateFileReferenceTokens(
       { beta: { files: { retrieveMetadata } } },
@@ -1518,6 +1554,89 @@ describe('ModelHandlerAnthropic message guards', () => {
 
     assert.equal(estimate, 400_000);
     assert.equal(retrieveMetadata.mock.calls.length, 1);
+  });
+
+  it('ignores file references before the latest compaction boundary', async () => {
+    const handler = createAnthropicHandler({ supportsNativePdf: true });
+    const messages: MessageParam[] = [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'document',
+            source: { type: 'file', file_id: 'file_compacted' },
+          },
+        ] as unknown as ContentBlockParam[],
+      },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'compaction', content: '<summary>state</summary>' },
+        ] as unknown as ContentBlockParam[],
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'document',
+            source: { type: 'file', file_id: 'file_live' },
+          },
+        ] as unknown as ContentBlockParam[],
+      },
+    ];
+    const target = handler as unknown as {
+      estimateFileReferenceTokens(
+        client: unknown,
+        messages: MessageParam[],
+      ): Promise<number>;
+    };
+    const retrieveMetadata = vi.fn(async (_fileId: string) => ({
+      size_bytes: 800_000,
+    }));
+
+    const estimate = await target.estimateFileReferenceTokens(
+      { beta: { files: { retrieveMetadata } } },
+      messages,
+    );
+
+    assert.equal(estimate, 200_000);
+    assert.equal(retrieveMetadata.mock.calls.length, 1);
+    assert.equal(retrieveMetadata.mock.calls[0]?.[0], 'file_live');
+  });
+
+  it('stops metadata lookups once file estimates cross the trigger', async () => {
+    const handler = createAnthropicHandler({ supportsNativePdf: true });
+    const messages: MessageParam[] = [
+      {
+        role: 'user',
+        content: ['file_first', 'file_unneeded'].map((fileId) => ({
+          type: 'document',
+          source: { type: 'file', file_id: fileId },
+        })) as unknown as ContentBlockParam[],
+      },
+    ];
+    const target = handler as unknown as {
+      estimateFileReferenceTokens(
+        client: unknown,
+        messages: MessageParam[],
+        signal: AbortSignal | undefined,
+        stopAtTokens: number,
+      ): Promise<number>;
+    };
+    const retrieveMetadata = vi.fn(async (_fileId: string) => ({
+      size_bytes: 800_000,
+    }));
+
+    const estimate = await target.estimateFileReferenceTokens(
+      { beta: { files: { retrieveMetadata } } },
+      messages,
+      undefined,
+      100_000,
+    );
+
+    assert.equal(estimate, 200_000);
+    assert.equal(retrieveMetadata.mock.calls.length, 1);
+    assert.equal(retrieveMetadata.mock.calls[0]?.[0], 'file_first');
   });
 
   it('stops file metadata estimation immediately after cancellation', async () => {

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
@@ -1531,6 +1531,49 @@ describe('ModelHandlerAnthropic message guards', () => {
     assert.equal(download.mock.calls.length, 1);
   });
 
+  it('caches a size fallback when a resumed PDF cannot be parsed', async () => {
+    const handler = createAnthropicHandler({ supportsNativePdf: true });
+    const messages: MessageParam[] = [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'document',
+            source: { type: 'file', file_id: 'file_invalid_pdf' },
+          },
+        ] as unknown as ContentBlockParam[],
+      },
+    ];
+    const target = handler as unknown as {
+      estimateFileReferenceTokens(
+        client: unknown,
+        messages: MessageParam[],
+      ): Promise<number>;
+    };
+    const retrieveMetadata = vi.fn(async () => ({
+      mime_type: 'application/pdf',
+      size_bytes: 800_000,
+    }));
+    const download = vi.fn(async () => ({
+      arrayBuffer: async () => new TextEncoder().encode('not a PDF').buffer,
+    }));
+    const client = { beta: { files: { retrieveMetadata, download } } };
+
+    const firstEstimate = await target.estimateFileReferenceTokens(
+      client,
+      messages,
+    );
+    const cachedEstimate = await target.estimateFileReferenceTokens(
+      client,
+      messages,
+    );
+
+    assert.equal(firstEstimate, 200_000);
+    assert.equal(cachedEstimate, 200_000);
+    assert.equal(retrieveMetadata.mock.calls.length, 1);
+    assert.equal(download.mock.calls.length, 1);
+  });
+
   it('prefers tracked PDF pages over compressed file size', async () => {
     const handler = createAnthropicHandler({ supportsNativePdf: true });
     const messages: MessageParam[] = [

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
@@ -1471,7 +1471,7 @@ describe('ModelHandlerAnthropic message guards', () => {
       messages,
     );
 
-    assert.equal(estimate, 2_000);
+    assert.equal(estimate, 3_000);
     assert.equal(retrieveMetadata.mock.calls.length, 0);
   });
 


### PR DESCRIPTION
Follow-up to #9096 and its late post-merge review. The PDF-page support from #9100 is merged, and this branch is based on the current `main` used by the PR.

## What changed

- include Anthropic Files API document contents in the non-streaming compaction estimate, so the CLI can show compaction activity when remote files make the effective prompt large
- use tracked PDF pages at 3,000 tokens per page when available
- recover page counts for small PDFs in resumed sessions, while bounding pre-request downloads to 1 MiB and caching a metadata fallback for larger or unreadable PDFs
- fetch metadata at most once per file identifier, but count every repeated reference to that file
- estimate serialized text first and stop remote lookups once the compaction decision is known
- forward cancellation to metadata and download requests
- discard cached file estimates when a compaction boundary removes their references

## Root cause

The fallback estimator serialized only each `file_id`, not the corresponding remote document. A large file could therefore cause server-side compaction while the CLI estimated a small prompt and emitted no compaction activity marker. Repeated references, resumed PDF page counts, and bounded inspection required separate treatment to keep the estimate useful without adding unbounded work before each model request.

## Validation

- Anthropic handler suite: 51 tests passed
- complete Vitest suite: 7,382 tests passed, 4 skipped
- `npm run lint`
- `npm run typecheck`
- test-kernel TypeScript check
- `npm run compile:fast`
- Prettier check on changed files
- exact-head CI and all four automated reviews passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pre-request compaction heuristics and adds Files API metadata/download calls on the critical Anthropic path, though behavior is cached, bounded, and covered by new tests.
> 
> **Overview**
> Fixes **misleading compaction activity** on non-streaming Anthropic tool-use runs when conversations include **Files API** `file_id` documents: the fallback used to count only serialized `file_id` text (and tracked PDF pages from the current session), so large remote files could trigger server compaction while the CLI showed no **context_compaction** marker.
> 
> The handler now **`estimateFileReferenceTokens`**, which sums live references after the latest **compaction** boundary (including **repeated** refs), prefers tracked PDF page × 3k tokens, otherwise **retrieves metadata** once per file (cached in `fileTokenEstimates`), optionally downloads **small PDFs** for page count, and respects **abort** and **early stop** once the estimate crosses the compaction trigger. **`pruneTrackedFileMetadata`** clears both page and token caches when references disappear after compaction.
> 
> Compaction gating still uses native `countTokens` when possible; file metadata runs only when counting is skipped and text alone is still below the trigger.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c6f261973b27a2b4f5eb1992252ee88f31c1f16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->