### PR TITLE
fix(cli): include PDF pages in compaction estimate

### DIFF
--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -173,6 +173,9 @@ const isBetaTextBlock = (
 const INTERLEAVED_THINKING_BETA: AnthropicBeta =
   'interleaved-thinking-2025-05-14';
 
+/** Anthropic's documented upper typical text-token estimate per PDF page. */
+const ANTHROPIC_PDF_TOKENS_PER_PAGE_ESTIMATE = 3_000;
+
 export class ModelHandlerAnthropic extends ModelHandler<
   MessageParam,
   BetaUsage,
@@ -722,9 +725,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     // Phase 4: EXECUTE - Dispatch through the provider's two SDK paths.
     // Non-streaming responses have no block-start event. Use the native count
-    // when available and the existing text heuristic otherwise; treating an
-    // unavailable count as either zero or definitely over threshold would miss
-    // large requests or label every small request as compaction.
+    // when available and otherwise combine the existing text heuristic with
+    // tracked PDF pages. Treating an unavailable count as either zero or
+    // definitely over threshold would miss large requests or label every small
+    // request as compaction.
     const compactionEdit = options.context_management?.edits?.find(
       (edit) => edit.type === 'compact_20260112',
     );
@@ -738,7 +742,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
           thinking: options.thinking,
           outputConfig: options.output_config,
         }),
-      );
+      ) +
+        this.getTrackedPdfPageCount() * ANTHROPIC_PDF_TOKENS_PER_PAGE_ESTIMATE;
     const nonStreamingCompactionExpected =
       !useStreaming &&
       compactionEdit?.trigger?.type === 'input_tokens' &&

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
@@ -1224,24 +1224,54 @@ describe('ModelHandlerAnthropic message guards', () => {
           ],
         },
       ],
+      trackedPdfPages: 0,
+      expectedAtRequest: ['started'],
+      expectedFinal: ['started', 'finished'],
+    },
+    {
+      label: 'file-backed',
+      messages: [
+        {
+          role: 'user' as const,
+          content: [
+            {
+              type: 'document' as const,
+              source: {
+                type: 'file' as const,
+                file_id: 'file_existing',
+              },
+              title: 'sample.pdf',
+            } as unknown as ContentBlockParam,
+          ],
+        },
+      ],
+      trackedPdfPages: 50,
       expectedAtRequest: ['started'],
       expectedFinal: ['started', 'finished'],
     },
     {
       label: 'small',
       messages: helloMessages(),
+      trackedPdfPages: 0,
       expectedAtRequest: [],
       expectedFinal: [],
     },
   ])(
     'uses a fallback estimate for a $label unmeasured non-streaming request',
-    async ({ messages, expectedAtRequest, expectedFinal }) => {
+    async ({ messages, trackedPdfPages, expectedAtRequest, expectedFinal }) => {
       const handler = createAnthropicHandler({
+        supportsNativePdf: true,
         supportsTokenCounting: false,
         supportsReasoning: false,
       });
       handler.config.fullName = 'claude-opus-4-6';
       handler.setAgentCategory(AgentCategory.ToolUse);
+      if (trackedPdfPages > 0) {
+        (handler as any).uploadedPdfPageCounts.set(
+          'file_existing',
+          trackedPdfPages,
+        );
+      }
 
       const activityStates: string[] = [];
       stubHandlerForTest(handler, {


### PR DESCRIPTION
## Summary

- Include tracked Anthropic PDF page counts in the fallback input-token estimate used for non-streaming compaction activity.
- Use Anthropic's documented upper typical estimate of 3,000 text tokens per PDF page.
- Add regression coverage for a 50-page Files API document crossing the compaction threshold.

## Why

This is a follow-up to #9096. Anthropic token counting is skipped for requests containing Files API document references. The text fallback can see only a `file_id`, so a large PDF could trigger native compaction without the CLI/TUI showing `compacting...`.

TeXRA already records page counts when it uploads PDFs. Incorporating that existing information accounts for file content without downloading the document or adding another network request.

## User impact

The CLI/TUI compaction indicator now also appears for large, tracked PDF-backed requests when Anthropic's token-count endpoint cannot be used, while small requests remain quiet.

## Validation

- `npx vitest run src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts` (40 tests)
- `npx eslint src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts`
- `npx tsc --noEmit`
- `npx tsc --noEmit -p tsconfig.test-kernel.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow UX/logging change to compaction activity prediction; no auth, billing, or request-shape changes beyond the estimate formula.
> 
> **Overview**
> **Non-streaming compaction indicator** for Anthropic now treats large PDF-backed requests more like large text requests when there is no measured input token count.
> 
> When `countTokens` is skipped (e.g. messages only reference a Files API `file_id`), the fallback that decides whether to show **compacting…** still used a JSON/text heuristic that barely reflects PDF size. The handler now adds **tracked upload page counts × 3,000** (Anthropic’s documented upper typical tokens per page) on top of that heuristic, reusing `uploadedPdfPageCounts` already maintained at upload time.
> 
> Regression coverage extends the existing unmeasured non-streaming compaction tests with a **50-page file-backed** case that crosses the compaction trigger without a huge text payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28fea93940eda71a91d2160bbe8c77834ca20a02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->