### PR TITLE
docs: remove duplicated 0.39.8 release note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,8 +76,6 @@ All notable changes to this project will be documented in this file.
 - **Overleaf projects can be cloned from the terminal** — `texra clone`
   accepts an Overleaf or ShareLaTeX project URL or project ID, securely stores
   the Git token, and can create an optional destination directory.
-  accepts an Overleaf or ShareLaTeX project URL or project ID, stores the Git
-  token securely, and clones into an empty working directory.
 - **Context compaction is visible while it runs** — the terminal status bar
   shows a compacting indicator while conversation history is being summarized.
 - **Kimi Code subscription joins model access** — the launcher and `/api` now


### PR DESCRIPTION
## Summary

- remove the duplicated continuation in the 0.39.8 Overleaf CLI release note
- preserve the complete user-facing description of project IDs, secure token storage, and optional destinations

## Why

The finalized 0.39.8 changelog accidentally repeated the sentence with slightly different wording. Shipping it as-is would make the public release notes read as a malformed duplicate.

## Impact

The 0.39.8 release notes now contain one concise, accurate Overleaf clone entry. Runtime behavior is unchanged.

## Validation

- `corepack pnpm exec prettier --check CHANGELOG.md`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only CHANGELOG edit; no code or runtime behavior changes.
> 
> **Overview**
> **Fixes malformed 0.39.8 release notes** for the CLI `texra clone` Overleaf feature.
> 
> The **Overleaf projects can be cloned from the terminal** bullet no longer repeats the same idea twice with slightly different wording. It is now a **single sentence** that still covers project URLs/IDs, secure Git token storage, and optional destination directories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1fd32908523c3bd87f06a5743f0ddf8f03d2071. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->