### PR TITLE
fix(cli): retire PDF estimates after compaction

### DIFF
--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -205,6 +205,13 @@ export class ModelHandlerAnthropic extends ModelHandler<
       const contentBlocks = message.content;
       if (!Array.isArray(contentBlocks)) continue;
 
+      if (
+        contentBlocks.some(
+          (block) => (block as { type?: unknown }).type === 'compaction',
+        )
+      ) {
+        liveFileIds.clear();
+      }
       for (const block of extractDocumentBlocks(contentBlocks)) {
         const source = block.source as
           { type: string; file_id?: string } | undefined;

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
@@ -1209,6 +1209,49 @@ describe('ModelHandlerAnthropic message guards', () => {
     assert.deepEqual(activityStates, ['started', 'finished']);
   });
 
+  it('drops tracked PDF pages covered by the latest compaction block', () => {
+    const handler = createAnthropicHandler({ supportsNativePdf: true });
+    const target = handler as unknown as {
+      uploadedPdfPageCounts: Map<string, number>;
+      pruneTrackedPdfPages(messages: MessageParam[]): void;
+    };
+    target.uploadedPdfPageCounts.set('file_before_compaction', 50);
+    target.uploadedPdfPageCounts.set('file_after_compaction', 2);
+
+    target.pruneTrackedPdfPages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'document',
+            source: { type: 'file', file_id: 'file_before_compaction' },
+          },
+        ] as unknown as ContentBlockParam[],
+      },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'compaction', content: '<summary>state</summary>' },
+          { type: 'text', text: 'Compacted.', citations: null },
+        ] as unknown as ContentBlockParam[],
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'document',
+            source: { type: 'file', file_id: 'file_after_compaction' },
+          },
+        ] as unknown as ContentBlockParam[],
+      },
+    ]);
+
+    assert.deepEqual(
+      [...target.uploadedPdfPageCounts.entries()],
+      [['file_after_compaction', 2]],
+    );
+  });
+
   it.each([
     {
       label: 'large',


### PR DESCRIPTION
## Summary

- clear tracked Anthropic PDF page counts when the retained history reaches a newer compaction block
- keep file references added after that compaction in the fallback estimate
- cover the before/after-compaction boundary with a focused regression test

## Root cause

PR #9100 summed every tracked uploaded PDF that remained anywhere in the local message history. Anthropic appends its native compaction block to that retained history rather than replacing the earlier messages, so a PDF covered by the compaction summary could remain counted and make later turns repeatedly predict another compaction.

## User impact

After a PDF-backed session compacts, later small turns no longer show a spurious `compacting...` cycle because of documents already summarized by the latest compaction block. PDFs attached after compaction are still counted.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run compile:fast`
- `npm test` (769 files passed, 7,371 tests passed; expected skips only)
- focused Anthropic handler suite (41 tests passed)
- Prettier on changed files
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to PDF tracking for compaction heuristics in the Anthropic handler, with a focused unit test and no auth or data-path changes.
> 
> **Overview**
> Fixes **spurious compaction UI** on Anthropic turns after server-side compaction when PDFs were in the conversation.
> 
> `pruneTrackedPdfPages` now treats each **`compaction` block** as a boundary: when scanning message history in order, hitting compaction **clears** the set of “live” uploaded PDF file IDs, then only document `file_id` references **after** that block stay in `uploadedPdfPageCounts`. Pre-compaction PDFs that still appear in retained history no longer inflate the fallback input-token estimate (`getTrackedPdfPageCount()` × per-page estimate), which was causing repeated `compacting...` on small follow-ups.
> 
> A regression test covers history with a document before compaction, a compaction assistant block, and a document after—only the post-compaction file remains tracked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c055f9f21b04afdf572b38a667a911134468c45e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->