### PR TITLE
fix(shared): consolidate CLI/progressView tool-input preview derivation

### DIFF
--- a/packages/cli/src/chat/tui/panes/toolRenderers.tsx
+++ b/packages/cli/src/chat/tui/panes/toolRenderers.tsx
@@ -14,6 +14,7 @@ import {
   executionsSubagentSummary,
   type ExecutionLabels,
 } from '@shared/tools/executionsDisplay';
+import { deriveToolInputPreview } from '@shared/tools/toolInputPreview';
 import { toolDisplayKind } from '@shared/tools/toolKind';
 import { isObject } from '@utils/core';
 import {
@@ -103,8 +104,9 @@ function elisionMarker(hiddenCount: number): string {
   return `… +${hiddenCount} lines (ctrl + t to print full output)`;
 }
 
-// Tool inputs vary in shape; show whichever of these "primary" fields
-// exists first. Order matters: earlier keys win.
+// Generic fallback for tools without a curated preview field in
+// `deriveToolInputPreview` (@shared/tools/toolInputPreview): show whichever
+// of these fields exists first. Order matters: earlier keys win.
 const PRIMARY_INPUT_KEYS = [
   'command',
   'code',
@@ -172,9 +174,14 @@ function displayToolName(toolName: string): string {
   return displayMcpToolName(toolName) ?? lastSegmentToolName(toolName);
 }
 
-function previewInput(input: unknown): string {
+function previewInput(toolName: string, input: unknown): string {
   if (typeof input === 'string') return input;
   if (input === undefined || input === null) return '';
+  const namedPreview = deriveToolInputPreview(
+    lastSegmentToolName(toolName).toLowerCase(),
+    input,
+  );
+  if (namedPreview) return namedPreview;
   if (isObject(input)) {
     for (const key of PRIMARY_INPUT_KEYS) {
       const value = input[key];
@@ -246,9 +253,10 @@ function toolHeaderPreview(
 ): string {
   if (maxPreview <= 0) return '';
   const headerSummary = summaryOverride ?? toolUse.headerSummary;
+  const inputPreview = previewInput(toolUse.toolName, toolUse.input);
   const sourceText = preferInputPreview
-    ? previewInput(toolUse.input) || headerSummary || ''
-    : headerSummary || previewInput(toolUse.input) || '';
+    ? inputPreview || headerSummary || ''
+    : headerSummary || inputPreview || '';
   return sourceText ? truncateSummaryToWidth(sourceText, maxPreview) : '';
 }
 

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -26,8 +26,8 @@ import {
 } from '@shared/constants/delegationTools';
 import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
 import { toolDisplayKind } from '@shared/tools/toolKind';
+import { deriveToolInputPreview } from '@shared/tools/toolInputPreview';
 import {
-  EXECUTIONS_DEFAULT_ACTION,
   executionsSubagentSummary,
   type ExecutionLabels,
 } from '@shared/tools/executionsDisplay';
@@ -111,21 +111,12 @@ export function formatToolUseTemplate(
     headerSummary = labeledExecutionSummary;
   }
   if (!headerSummary) {
-    if (toolName === 'executions' && isObject(input)) {
+    const inputPreview = deriveToolInputPreview(toolName, input);
+    if (inputPreview) {
       headerSummary =
-        `${input.action ?? EXECUTIONS_DEFAULT_ACTION} ${input.path ?? ''}`.trim();
-    } else if (
-      toolName === 'codex' &&
-      isObject(input) &&
-      typeof input.prompt === 'string'
-    ) {
-      headerSummary = truncateSummary(input.prompt, 60);
-    } else if (
-      toolName === 'bash' &&
-      isObject(input) &&
-      typeof input.command === 'string'
-    ) {
-      headerSummary = truncateSummary(input.command, 60);
+        toolName === 'executions'
+          ? inputPreview
+          : truncateSummary(inputPreview, 60);
     }
   }
   headerSummary = truncateHeaderSummary(headerSummary, 120);

--- a/src/shared/tools/toolInputPreview.ts
+++ b/src/shared/tools/toolInputPreview.ts
@@ -33,7 +33,10 @@ const TOOL_PREVIEW_INPUT_KEY: Readonly<Record<string, string>> = {
   codex: 'prompt',
 };
 
-/** Derive a one-line preview of `input` for the named tool. Returns `''`
+/** Derive a one-line preview of `input` for the named tool. `toolName` must
+ *  already be normalized (lowercased, provider prefix stripped, e.g.
+ *  `claude:Bash` -> `bash`) — callers own that normalization since it's
+ *  host-specific (see `lastSegmentToolName` in the CLI TUI). Returns `''`
  *  when the tool isn't one of the ones with a known preview field — callers
  *  fall back to their own host-specific default (a generic key search, or
  *  nothing at all). */

--- a/src/shared/tools/toolInputPreview.ts
+++ b/src/shared/tools/toolInputPreview.ts
@@ -1,0 +1,50 @@
+/**
+ * Derives a one-line preview of a tool call's `input`, for use as a
+ * header/summary fallback before the tool's own `summary` output exists
+ * (e.g. while it is still in progress) — shared by the CLI chat TUI
+ * (`packages/cli/src/chat/tui/panes/toolRenderers.tsx`) and the VS Code
+ * progress view
+ * (`packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts`).
+ *
+ * Both hosts used to hand-maintain their own tool-name-to-preview-field
+ * mapping and had quietly drifted: the CLI's generic fallback list had no
+ * entry for `codex`'s `prompt` field, so an in-flight `codex` call rendered
+ * raw `JSON.stringify(input)` in the TUI while the progress view already
+ * showed a clean truncated prompt. This module is the single source of
+ * truth for the tool-name-specific half of that mapping.
+ */
+import { isObject } from '@utils/core';
+
+import { EXECUTIONS_DEFAULT_ACTION } from './executionsDisplay';
+
+function executionsInputPreview(input: Record<string, unknown>): string {
+  const action =
+    typeof input.action === 'string' && input.action.trim()
+      ? input.action.trim()
+      : EXECUTIONS_DEFAULT_ACTION;
+  const path = typeof input.path === 'string' ? input.path : '';
+  return `${action} ${path}`.trim();
+}
+
+/** Preview field for tools whose most useful "what is this call doing" text
+ *  lives under one specific input key. */
+const TOOL_PREVIEW_INPUT_KEY: Readonly<Record<string, string>> = {
+  bash: 'command',
+  codex: 'prompt',
+};
+
+/** Derive a one-line preview of `input` for the named tool. Returns `''`
+ *  when the tool isn't one of the ones with a known preview field — callers
+ *  fall back to their own host-specific default (a generic key search, or
+ *  nothing at all). */
+export function deriveToolInputPreview(
+  toolName: string,
+  input: unknown,
+): string {
+  if (!isObject(input)) return '';
+  if (toolName === 'executions') return executionsInputPreview(input);
+  const key = TOOL_PREVIEW_INPUT_KEY[toolName];
+  if (!key) return '';
+  const value = input[key];
+  return typeof value === 'string' ? value : '';
+}

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -1375,8 +1375,8 @@ describe('CLI conversation transcript splitting', () => {
     );
 
     expect(lines).toEqual([
-      '● executions (/executions/3a780a389327/report)',
-      '● executions (/executions/3a780a389327/conversation)',
+      '● executions (view /executions/3a780a389327/report)',
+      '● executions (view /executions/3a780a389327/conversation)',
     ]);
   });
 
@@ -1391,7 +1391,7 @@ describe('CLI conversation transcript splitting', () => {
     );
 
     expect(lines).toEqual([
-      '● executions (/executions/3a780a389327/report)',
+      '● executions (view /executions/3a780a389327/report)',
       '',
       'Read the report.',
       '',

--- a/src/test-kernel/cli/ToolRenderers.vitest.mts
+++ b/src/test-kernel/cli/ToolRenderers.vitest.mts
@@ -71,6 +71,14 @@ describe('CLI tool display lines', () => {
     );
   });
 
+  it('previews a codex call by its prompt, not raw JSON, matching the progress view', () => {
+    const entry = toolUse('codex', { prompt: 'Summarize this proof.' });
+
+    expect(toolUseDisplayLines(entry)).toEqual([
+      '● codex (Summarize this proof.)',
+    ]);
+  });
+
   it('registers edit patch rendering before the universal fallback', () => {
     const entry = toolUse('Edit', {
       path: 'paper.tex',
@@ -127,7 +135,7 @@ describe('CLI tool display lines', () => {
     ).toEqual(['● executions (wait: reviewer, leanSolver)']);
   });
 
-  it('keeps the existing executions path for a background process', () => {
+  it('shows the action and path for a background process, matching the progress view', () => {
     const entry = toolUse('executions', {
       action: 'view',
       path: '/executions/process-1',
@@ -137,7 +145,7 @@ describe('CLI tool display lines', () => {
       toolUseDisplayLines(entry, {
         executionLabels: new Map([['sub-1', 'reviewer']]),
       }),
-    ).toEqual(['● executions (/executions/process-1)']);
+    ).toEqual(['● executions (view /executions/process-1)']);
   });
 
   it('keeps the resource path when labeling an executions target', () => {

--- a/src/test-kernel/shared/ToolInputPreview.vitest.ts
+++ b/src/test-kernel/shared/ToolInputPreview.vitest.ts
@@ -33,9 +33,7 @@ describe('deriveToolInputPreview', () => {
   });
 
   it('returns an empty string for unmapped tools', () => {
-    expect(deriveToolInputPreview('read_file', { path: 'paper.tex' })).toBe(
-      '',
-    );
+    expect(deriveToolInputPreview('read_file', { path: 'paper.tex' })).toBe('');
   });
 
   it('returns an empty string for non-object input', () => {

--- a/src/test-kernel/shared/ToolInputPreview.vitest.ts
+++ b/src/test-kernel/shared/ToolInputPreview.vitest.ts
@@ -1,0 +1,45 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - shared tools
+import { deriveToolInputPreview } from '@shared/tools/toolInputPreview';
+
+describe('deriveToolInputPreview', () => {
+  it('reads the command field for bash', () => {
+    expect(deriveToolInputPreview('bash', { command: 'npm test' })).toBe(
+      'npm test',
+    );
+  });
+
+  it('reads the prompt field for codex', () => {
+    expect(
+      deriveToolInputPreview('codex', { prompt: 'Summarize this proof.' }),
+    ).toBe('Summarize this proof.');
+  });
+
+  it('composes action and path for executions', () => {
+    expect(
+      deriveToolInputPreview('executions', {
+        action: 'view',
+        path: '/executions/process-1',
+      }),
+    ).toBe('view /executions/process-1');
+  });
+
+  it('defaults the executions action when omitted', () => {
+    expect(
+      deriveToolInputPreview('executions', { path: '/executions/abc' }),
+    ).toBe('view /executions/abc');
+  });
+
+  it('returns an empty string for unmapped tools', () => {
+    expect(deriveToolInputPreview('read_file', { path: 'paper.tex' })).toBe(
+      '',
+    );
+  });
+
+  it('returns an empty string for non-object input', () => {
+    expect(deriveToolInputPreview('bash', 'npm test')).toBe('');
+    expect(deriveToolInputPreview('bash', undefined)).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

Filed as part of a scheduled tech-debt sweep looking for overlapping/duplicated responsibilities across the codebase. Four parallel surveys covered `controllers/` vs `commands/`, `agent/core` vs `agent/runtime`, `tools/` vs `agent/core/tools`, and CLI-vs-webview state. Most of the codebase turned out unusually clean; the one **confirmed, observable bug** was here: the CLI chat TUI and the VS Code progress view each hand-maintained their own mapping of "which input field best previews a tool call before it has a `summary`" (codex's `prompt`, bash's `command`, executions' `action`+`path`), and the two copies had quietly drifted apart.

Concretely: the CLI's generic fallback list (`PRIMARY_INPUT_KEYS`) had no entry for codex's `prompt` field, so an in-flight `codex` tool call rendered raw `JSON.stringify(input)` in the terminal, while the progress view already showed a clean truncated prompt for the identical payload. The CLI's executions preview was also missing its action prefix (`/executions/…` instead of `view /executions/…`, again matching the progress view's own already-correct output).

This PR extracts the tool-name-specific half of that mapping into a new shared module, `@shared/tools/toolInputPreview`, and has both hosts call it instead of maintaining independent copies.

## Issue acceptance gates

No tracked issue — this is the direct output of a scheduled duplicate-responsibility audit; the "acceptance gate" is: (1) identify a concrete instance of duplicated logic causing observable drift, (2) consolidate it behind one shared function, (3) prove behavior converges via tests. All three are met (see Validation).

## Single source of truth

`deriveToolInputPreview` in `src/shared/tools/toolInputPreview.ts` now owns the tool-name → preview-field mapping for `bash`, `codex`, and `executions`. This follows the same pattern already established by `@shared/tools/toolKind` (`toolDisplayKind`), whose own header comment documents an earlier instance of this exact CLI/progressView drift.

## Duplication and abstraction budget

Removed: the progress view's inline `if (toolName === 'executions') … else if (toolName === 'codex') … else if (toolName === 'bash')` chain (`toolFormatters.ts`), and the CLI's implicit assumption that its generic `PRIMARY_INPUT_KEYS` fallback covered every tool needing a curated preview (it didn't — codex was missing). Both are replaced by one call into the shared function. No new abstraction beyond the single pure function; each host still owns its own truncation policy (CLI by terminal width via `toolHeaderPreviewBudget`, progress view by a fixed 60/120-char cap), since that difference is genuinely host-specific and not duplicated logic.

## Net elements (R6)

- Files: +1 (`src/shared/tools/toolInputPreview.ts`, 50 lines) source, +1 test file (`ToolInputPreview.vitest.ts`, 45 lines); no files deleted.
- Exported symbols: `+1` (`deriveToolInputPreview`); no exports removed (the progress view's `EXECUTIONS_DEFAULT_ACTION` import is dropped in favor of the shared function, but the constant itself remains exported from `executionsDisplay.ts` for its other caller).
- Net LoC: +127 / −25 across 6 files, but the two call sites shrink (progress view's fallback block goes from 15 lines of tool-name branching to 6 lines calling the shared function).

## Consumer counts (R8)

n/a — no emit path or export was deleted/re-routed; this only adds a new shared export and re-points two existing internal call sites at it.

## Host impact

Extension: `progressView`'s tool-card header preview is unchanged in output (same 3 tool names, same truncation) — pure refactor.

Desktop: no changes (desktop reuses the extension's `progressView`/`webview` frontends wholesale; confirmed during the audit that desktop does not reimplement this logic separately).

CLI: behavior fix — an in-flight `codex` tool call now previews its prompt instead of dumping raw JSON, and `executions` previews now include the action prefix, matching the progress view.

## Scheduled refactoring

None. The audit's other findings (a hand-maintained `DELEGATION_TOOLS` set without the compile-time guard that `toolKind.ts` uses; duplicated `toJSONSchema` conversion options between `src/tools/core/define.ts` and `src/agent/modelHandlers/toolConversion.ts`; a minor `core/tools/` README gap; a divergent API-key-entry prompt UX between the command-palette and Settings-Profile surfaces) were all judged lower-severity/lower-confidence than this one and are not addressed here — flagging for a maintainer to decide whether any warrant their own follow-up issue.

## Validation

- `npm run typecheck` — passes (extension, CLI, trace-viewer, desktop, test-kernel).
- `npx eslint` on all changed/added files — clean.
- `npm run check:dead-code-ratchet` — no new unused exports/files (18 baseline, unchanged).
- `npx vitest run` on `src/test-kernel/shared`, `src/test-kernel/cli`, `src/test-kernel/progressView` — all pass, including two pre-existing CLI tests updated to reflect the now-corrected (and progress-view-matching) output, plus two new tests (one for the shared module, one CLI regression test for the codex-prompt case).
- Full `npm test` — 7387 passed, 2 unrelated pre-existing failures (a QuickJS sandbox timing test and a process-group-abort timing test, both timing/environment-sensitive and untouched by this change).


---
_Generated by [Claude Code](https://claude.ai/code/session_017cDUsDCzLT8BMMiwNiAQFf)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only refactor with a small shared pure function; no auth, data, or runtime behavior beyond tool-row header text.
> 
> **Overview**
> Introduces **`deriveToolInputPreview`** in `@shared/tools/toolInputPreview` as the single mapping for **bash** (`command`), **codex** (`prompt`), and **executions** (`action` + `path`, with a default action).
> 
> The **CLI TUI** and **VS Code progress view** both call it instead of separate tool-name branches; the CLI still uses its generic `PRIMARY_INPUT_KEYS` fallback for other tools. **CLI behavior fixes:** in-flight **codex** rows show the prompt instead of raw JSON, and **executions** headers include the action prefix (e.g. `view /executions/…`), aligned with the progress view. Tests cover the shared helper and updated CLI expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdcc72405ade4d4b4017b9b3a68befe39b22ddd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->