### PR TITLE
refactor: share one jittered-backoff formula between ModelRetryGate and PollingSourceBase

### DIFF
--- a/src/agent/runtime/ModelRetryGate.ts
+++ b/src/agent/runtime/ModelRetryGate.ts
@@ -1,5 +1,6 @@
+import { jitteredExponentialBackoffMs } from '@utils/core';
+
 const MAX_BACKOFF_MS = 5 * 60 * 1000;
-const JITTER_FRACTION = 0.2;
 
 type RoutePhase = 'healthy' | 'cooling' | 'probing';
 
@@ -419,11 +420,6 @@ export class ModelRetryGate {
   }
 
   private backoffMs(baseBackoffMs: number, failures: number): number {
-    const exponential = Math.min(
-      MAX_BACKOFF_MS,
-      Math.max(0, baseBackoffMs) * 2 ** Math.max(0, failures - 1),
-    );
-    const jitter = 1 - JITTER_FRACTION + Math.random() * 2 * JITTER_FRACTION;
-    return Math.min(MAX_BACKOFF_MS, Math.round(exponential * jitter));
+    return jitteredExponentialBackoffMs(baseBackoffMs, failures, MAX_BACKOFF_MS);
   }
 }

--- a/src/tools/github/PollingSourceBase.ts
+++ b/src/tools/github/PollingSourceBase.ts
@@ -18,6 +18,7 @@ import { createChannelTrace } from '@agent/trace';
 import { appSignals } from '@eventBus/AppSignals';
 
 import type { Disposable } from '@platform/interfaces';
+import { jitteredExponentialBackoffMs } from '@utils/core';
 import {
   createBoundedIdSet,
   type BoundedIdSet,
@@ -384,14 +385,13 @@ export abstract class PollingSourceBase<
       return;
     }
     state.consecutiveFailures += 1;
-    const backoffMs = Math.min(
-      this.config.backoffBaseMs * 2 ** (state.consecutiveFailures - 1),
+    // Jittered +/-20% so a network outage doesn't stampede every subscription
+    // back at exactly the same moment.
+    const actualDelayMs = jitteredExponentialBackoffMs(
+      this.config.backoffBaseMs,
+      state.consecutiveFailures,
       this.config.backoffMaxMs,
     );
-    // Jitter +/-20% so a network outage doesn't stampede every subscription
-    // back at exactly the same moment.
-    const jitter = 0.8 + Math.random() * 0.4;
-    const actualDelayMs = Math.round(backoffMs * jitter);
     state.skipPollUntilMs = now + actualDelayMs;
     if (now - state.lastSuccessAt >= this.config.maxFailureDurationMs) {
       this.logger.warn(

--- a/src/utils/core/index.ts
+++ b/src/utils/core/index.ts
@@ -338,6 +338,26 @@ export function roundTo(value: number, decimals: number): number {
   return Number(value.toFixed(decimals));
 }
 
+/**
+ * Compute a jittered exponential backoff delay: `baseMs * 2^(failures-1)`,
+ * capped at `maxMs`, then randomized by `+/-jitterFraction` and capped again
+ * so jitter can never push the result past `maxMs`. Shared by every retry/
+ * backoff loop in the codebase so the jitter formula only exists once.
+ */
+export function jitteredExponentialBackoffMs(
+  baseMs: number,
+  failures: number,
+  maxMs: number,
+  jitterFraction = 0.2,
+): number {
+  const exponential = Math.min(
+    maxMs,
+    Math.max(0, baseMs) * 2 ** Math.max(0, failures - 1),
+  );
+  const jitter = 1 - jitterFraction + Math.random() * 2 * jitterFraction;
+  return Math.min(maxMs, Math.round(exponential * jitter));
+}
+
 // ---------------------------------------------------------------------------
 // urlCore
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to a scheduled reinvented-wheel audit of the codebase. The audit's initial pass flagged several candidates for npm-package replacement; on closer reading of each file, most turned out to be well-justified, domain-specific code rather than naive reimplementations (details below). The one genuine duplication that survived scrutiny — the jittered-exponential-backoff formula, independently reimplemented in two files — is extracted here into a single shared helper.

`ModelRetryGate.backoffMs()` and `PollingSourceBase.handleFailure()` each computed `base * 2^(failures-1)` capped at a max, then applied `+/-20%` jitter, with the exact same formula written out by hand twice. Extracted to `jitteredExponentialBackoffMs()` in `src/utils/core/index.ts`; both call sites now call the shared function.

Behavior is unchanged for `ModelRetryGate`. For `PollingSourceBase`, the shared helper caps the result at `maxMs` *after* jitter as well as before — previously the cap only applied before jitter, so a `+20%` jitter roll could push the actual delay slightly past the configured `backoffMaxMs`. This is a minor correctness fix, not a behavior regression: the config name is `backoffMaxMs`, and the fix makes the cap match its name.

**Candidates investigated but not changed**, since forcing these through would have swapped correct, purpose-built code for objectively worse fits:
- `ModelRetryGate`/`PollingSourceBase` as whole-class circuit-breaker replacements (e.g. via `cockatiel`): both implement domain-specific concurrency semantics — hierarchical multi-route probe acquisition with version-based staleness (`ModelRetryGate`), and per-subscription polling lifecycle with GitHub-specific error taxonomy and a 24h detach gate (`PollingSourceBase`) — that a generic resilience library's per-call policy model doesn't express. `ModelRetryGate` was also recently and carefully tuned (#9101); rewriting it risked regressing that fix for no behavioral gain.
- `packages/cli/src/commands/_helpers/globalArgs.ts`'s manual argv scanning: solves pre-dispatch classification of global flags that can appear before any subcommand at any depth (for routing/reordering across a multi-level command tree) and collecting repeatable flags (`-i`/`-c` can repeat) into arrays — neither of which `citty`'s per-command `defineCommand` args cover natively.
- `contentSimilarity.ts`'s Markdown fence parser: ~15 lines of regex correctly implementing just the two CommonMark rules it needs (marker run-length match, closing length ≥ opening length), already handles nested same-marker fences, and shares its wrapper-stripping helper with a non-Markdown XML-tag stripper. Pulling in `micromark` would add a full document tokenizer for equivalent functionality and fragment that shared abstraction.
- `loginOptions.ts`'s `/login` slash-command tokenizer: a small, bespoke 4-flag parser with custom validation semantics (conflict messages, positional target routing) that citty doesn't provide out of the box.

## Issue acceptance gates

No tracked issue — ad hoc follow-up from a scheduled npm-replacement audit. Gate: extract the one confirmed duplicated formula without changing external behavior of either caller (validated by existing test suites).

## Single source of truth

`jitteredExponentialBackoffMs()` in `src/utils/core/index.ts` now owns the jittered-exponential-backoff formula for the whole codebase.

## Duplication and abstraction budget

Removed: two independent inline reimplementations of the same backoff/jitter arithmetic (~6 lines each). No new abstraction beyond one pure function with two existing callers — not a single-caller extraction.

## Net elements (R6)

3 files changed, +29/-13. +1 exported function (`jitteredExponentialBackoffMs`); 0 new classes/interfaces; 2 inline formulas deleted in favor of 2 call sites of the shared function. Net LoC: +16.

## Consumer counts (R8)

n/a — no emit path or export was removed or re-routed; a new shared helper was added with its 2 call sites updated in the same commit.

## Host impact

Extension: none (shared runtime code, no host-specific surface).

Desktop: none.

CLI: none (`PollingSourceBase` backs the GitHub polling tools used across all hosts; behavior only tightens the max-backoff cap as described above).

## Scheduled refactoring

None — the four investigated-but-not-changed candidates above are not queued as follow-ups; they were found to already be the right design for their use case.

## Validation

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npx vitest run src/test-kernel/tools/PollingSourceBase.vitest.ts src/test-kernel/agent/runtime/ModelRetryGate.vitest.ts` — 25/25 passed
- `npx vitest run` (full suite) — 7381/7391 passed, 1 pre-existing failure in `SystemUtils.vitest.ts` (process-group abort test, environment/sandbox-specific signal handling) unrelated to this diff and not touched by it

---
_Generated by [Claude Code](https://claude.ai/code/session_0133RJaAQzhEHExcwoL7KNjs)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor plus a minor backoff cap tightening; targeted tests cover both callers.
> 
> **Overview**
> Consolidates duplicated jittered exponential backoff math into **`jitteredExponentialBackoffMs()`** in `@utils/core`, replacing inline formulas in **`ModelRetryGate`** and **`PollingSourceBase`**.
> 
> **`ModelRetryGate`** behavior is unchanged. **`PollingSourceBase`** now applies **`backoffMaxMs`** after jitter as well as before, so a +20% roll can no longer exceed the configured max delay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adc4ba69757edd1e0811d64b1409fd75689cb96d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->