### PR TITLE
refactor: share provider content-block type vocabulary

### DIFF
--- a/src/agent/export/normalizeConversation.ts
+++ b/src/agent/export/normalizeConversation.ts
@@ -21,6 +21,7 @@ import {
   isFunctionCallOutputItem,
 } from '@agent/modelHandlers/openai/openAIResponseContent';
 import { isResponseFunctionToolCallItem } from '@agent/modelHandlers/openai/responseStreamEvents';
+import { CONVERSATION_BLOCK_TYPES } from '@agent/types/ConversationBlockTypes';
 import {
   ANTHROPIC_SERVER_TOOL_BLOCK_TYPES,
   extractWebFetchResultFields,
@@ -64,18 +65,21 @@ const ContentBlockSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('output_text'), text: z.string().optional() }),
 
   // Anthropic extended-thinking / Google GenAI thought blocks.
-  z.object({ type: z.literal('thinking'), thinking: z.string().optional() }),
-  z.object({ type: z.literal('redacted_thinking') }),
+  z.object({
+    type: z.literal(CONVERSATION_BLOCK_TYPES.thinking),
+    thinking: z.string().optional(),
+  }),
+  z.object({ type: z.literal(CONVERSATION_BLOCK_TYPES.redactedThinking) }),
 
   // Tool call / tool result — shared by Anthropic, Google GenAI, and the
   // VS Code language-model bridge (see normalizeContentBlock).
   z.object({
-    type: z.literal('tool_use'),
+    type: z.literal(CONVERSATION_BLOCK_TYPES.toolUse),
     name: z.string().optional(),
     input: z.unknown().optional(),
   }),
   z.object({
-    type: z.literal('tool_result'),
+    type: z.literal(CONVERSATION_BLOCK_TYPES.toolResult),
     content: z.unknown().optional(),
   }),
 
@@ -83,12 +87,12 @@ const ContentBlockSchema = z.discriminatedUnion('type', [
   // ('input_image'/'input_file'), OpenAI Chat Completions ('image_url'/
   // 'file'). None of these carry fields this module reads — only `type`
   // decides which attachment kind to render.
-  z.object({ type: z.literal('image') }),
-  z.object({ type: z.literal('input_image') }),
-  z.object({ type: z.literal('image_url') }),
-  z.object({ type: z.literal('document') }),
-  z.object({ type: z.literal('input_file') }),
-  z.object({ type: z.literal('file') }),
+  z.object({ type: z.literal(CONVERSATION_BLOCK_TYPES.image) }),
+  z.object({ type: z.literal(CONVERSATION_BLOCK_TYPES.inputImage) }),
+  z.object({ type: z.literal(CONVERSATION_BLOCK_TYPES.imageUrl) }),
+  z.object({ type: z.literal(CONVERSATION_BLOCK_TYPES.document) }),
+  z.object({ type: z.literal(CONVERSATION_BLOCK_TYPES.inputFile) }),
+  z.object({ type: z.literal(CONVERSATION_BLOCK_TYPES.file) }),
 
   // Anthropic server-side tool blocks (the provider executes these, not a
   // local tool handler).
@@ -231,14 +235,14 @@ function blocksToUserParts(blocks: ContentBlock[]): UserPart[] {
       case 'input_text':
         if (b.text) parts.push({ type: 'text', text: b.text });
         break;
-      case 'image':
-      case 'input_image':
-      case 'image_url':
+      case CONVERSATION_BLOCK_TYPES.image:
+      case CONVERSATION_BLOCK_TYPES.inputImage:
+      case CONVERSATION_BLOCK_TYPES.imageUrl:
         parts.push({ type: 'attachment', attachmentType: 'image' });
         break;
-      case 'document':
-      case 'input_file':
-      case 'file':
+      case CONVERSATION_BLOCK_TYPES.document:
+      case CONVERSATION_BLOCK_TYPES.inputFile:
+      case CONVERSATION_BLOCK_TYPES.file:
         parts.push({ type: 'attachment', attachmentType: 'document' });
         break;
       default:
@@ -250,7 +254,7 @@ function blocksToUserParts(blocks: ContentBlock[]): UserPart[] {
 
 function extractToolResultText(block: ContentBlock): string | undefined {
   switch (block.type) {
-    case 'tool_result':
+    case CONVERSATION_BLOCK_TYPES.toolResult:
       return typeof block.content === 'string'
         ? block.content
         : prettyJson(block.content);
@@ -263,10 +267,16 @@ function extractToolResultText(block: ContentBlock): string | undefined {
   }
 }
 
+// Non-text tags are shared with the `formatConversationBlock` switch in
+// `@agent/storage/conversationFormat` via `CONVERSATION_BLOCK_TYPES`
+// (`@agent/types/ConversationBlockTypes`) and `ANTHROPIC_SERVER_TOOL_BLOCK_TYPES`
+// (`@agent/types/ServerToolTypes`) — both switches must recognize the same
+// tags, just into different output shapes (a structured `ExportNode` here
+// vs. a truncated marker string there).
 function assistantBlockToNode(block: ContentBlock): ExportNode | null {
   switch (block.type) {
-    case 'thinking':
-    case 'redacted_thinking':
+    case CONVERSATION_BLOCK_TYPES.thinking:
+    case CONVERSATION_BLOCK_TYPES.redactedThinking:
       return null;
 
     // Anthropic: 'text', OpenAI Response API: 'output_text'
@@ -276,14 +286,14 @@ function assistantBlockToNode(block: ContentBlock): ExportNode | null {
         ? { kind: 'assistant-text', text: block.text }
         : null;
 
-    case 'tool_use':
+    case CONVERSATION_BLOCK_TYPES.toolUse:
       return {
         kind: 'tool-call',
         name: block.name ?? 'unknown',
         input: prettyJson(block.input ?? {}),
       };
 
-    case 'tool_result':
+    case CONVERSATION_BLOCK_TYPES.toolResult:
       return {
         kind: 'tool-result',
         text:
@@ -293,11 +303,7 @@ function assistantBlockToNode(block: ContentBlock): ExportNode | null {
       };
 
     // Anthropic server-side tool blocks (the provider executes these, not a
-    // local tool handler). Shares the `ANTHROPIC_SERVER_TOOL_BLOCK_TYPES`
-    // vocabulary with the `formatConversationBlock` switch in
-    // `@agent/storage/conversationFormat` — both classify the same three
-    // live Anthropic block types, just into different output shapes (a
-    // structured `ExportNode` here vs. a truncated marker string there).
+    // local tool handler).
     case ANTHROPIC_SERVER_TOOL_BLOCK_TYPES.serverToolUse:
       if (block.name === 'web_search') {
         const query =

--- a/src/agent/storage/conversationFormat.ts
+++ b/src/agent/storage/conversationFormat.ts
@@ -22,6 +22,7 @@
  * truncation for the CLI). Provider-native message and content recognition is
  * shared here.
  */
+import { CONVERSATION_BLOCK_TYPES } from '@agent/types/ConversationBlockTypes';
 import {
   ANTHROPIC_SERVER_TOOL_BLOCK_TYPES,
   extractWebFetchResultFields,
@@ -85,7 +86,8 @@ function hasProviderReasoningBlock(content: unknown): boolean {
 function isProviderReasoningBlock(block: unknown): boolean {
   return (
     isObject(block) &&
-    (block.type === 'thinking' || block.type === 'redacted_thinking')
+    (block.type === CONVERSATION_BLOCK_TYPES.thinking ||
+      block.type === CONVERSATION_BLOCK_TYPES.redactedThinking)
   );
 }
 
@@ -263,21 +265,29 @@ function formatConversationBlock(
     );
   }
 
+  // Non-text tags are shared with the `assistantBlockToNode` switch in
+  // `@agent/export/normalizeConversation` via `CONVERSATION_BLOCK_TYPES`
+  // (`@agent/types/ConversationBlockTypes`) and `ANTHROPIC_SERVER_TOOL_BLOCK_TYPES`
+  // (`@agent/types/ServerToolTypes`) — both switches must recognize the same
+  // tags, just into different output shapes (a truncated marker string here
+  // vs. a structured `ExportNode` there). `text`/`input_text`/`output_text`
+  // are the exception: they're caught by the duck-typed `block.text` check
+  // above, not by an explicit case here.
   switch (block.type) {
     case 'text':
       // A recognized text block whose `text` failed the duck-type check
       // above (missing/non-string) — render empty, not its JSON form.
       return truncate(asText(block.text), options.textLimit, marker);
-    case 'image':
-    case 'image_url':
-    case 'input_image':
+    case CONVERSATION_BLOCK_TYPES.image:
+    case CONVERSATION_BLOCK_TYPES.imageUrl:
+    case CONVERSATION_BLOCK_TYPES.inputImage:
       return '[image attachment]';
-    case 'document':
-    case 'file':
-    case 'input_file':
+    case CONVERSATION_BLOCK_TYPES.document:
+    case CONVERSATION_BLOCK_TYPES.file:
+    case CONVERSATION_BLOCK_TYPES.inputFile:
       return '[document attachment]';
-    case 'thinking':
-    case 'redacted_thinking':
+    case CONVERSATION_BLOCK_TYPES.thinking:
+    case CONVERSATION_BLOCK_TYPES.redactedThinking:
       return options.hideProviderReasoning
         ? ''
         : truncate(
@@ -285,20 +295,16 @@ function formatConversationBlock(
             options.toolBlockLimit,
             marker,
           );
-    case 'tool_use':
+    case CONVERSATION_BLOCK_TYPES.toolUse:
       return formatToolUseMarker(
         asText(block.name) || 'unknown',
         block.input,
         options,
       );
-    case 'tool_result':
+    case CONVERSATION_BLOCK_TYPES.toolResult:
       return formatToolResultMarker(block.content, options);
     // Anthropic server-side tool blocks (the provider executes these, not a
-    // local tool handler). Shares the `ANTHROPIC_SERVER_TOOL_BLOCK_TYPES`
-    // vocabulary with the `assistantBlockToNode` switch in
-    // `@agent/export/normalizeConversation` — both classify the same three
-    // live Anthropic block types, just into different output shapes (a
-    // truncated marker string here vs. a structured `ExportNode` there).
+    // local tool handler).
     case ANTHROPIC_SERVER_TOOL_BLOCK_TYPES.serverToolUse:
       return formatToolUseMarker(
         asText(block.name) || 'unknown',

--- a/src/agent/types/ConversationBlockTypes.ts
+++ b/src/agent/types/ConversationBlockTypes.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared provider content-block `type` tag vocabulary.
+ *
+ * Single source of truth for the non-server-tool block-type literals that
+ * both `assistantBlockToNode`/`ContentBlockSchema`
+ * (`@agent/export/normalizeConversation`) and `formatConversationBlock`
+ * (`@agent/storage/conversationFormat`) must recognize by exact string —
+ * image/document attachment markers, provider "thinking" blocks, and local
+ * tool-call/tool-result blocks. Both modules read these tags off raw
+ * provider wire data (Anthropic, OpenAI Chat Completions, OpenAI Response
+ * API), so a hand-typed literal that drifts between the two files (e.g. a
+ * typo, or a new provider alias added to only one switch) fails silently
+ * instead of at compile time. Importing from here instead of repeating the
+ * strings turns that drift into a single edit site.
+ *
+ * `text`/`input_text`/`output_text` are deliberately NOT included: those are
+ * genuinely handled differently in the two consumers (normalizeConversation
+ * distinguishes user vs. assistant text roles per literal; conversationFormat
+ * recognizes them structurally via a `typeof block.text === 'string'` check
+ * that runs before its `type` switch, not via an explicit case per literal),
+ * so unifying them here would encode a symmetry that doesn't actually hold.
+ *
+ * The three Anthropic server-tool block types (`server_tool_use`,
+ * `web_search_tool_result`, `web_fetch_tool_result`) are the same kind of
+ * shared vocabulary but already live in
+ * `ANTHROPIC_SERVER_TOOL_BLOCK_TYPES` (`@agent/types/ServerToolTypes`) —
+ * not duplicated here.
+ */
+export const CONVERSATION_BLOCK_TYPES = Object.freeze({
+  // Anthropic and Google GenAI extended-thinking / thought blocks.
+  thinking: 'thinking',
+  redactedThinking: 'redacted_thinking',
+
+  // Local tool-call / tool-result blocks (Anthropic, Google GenAI, and the
+  // VS Code language-model bridge normalize into this shape).
+  toolUse: 'tool_use',
+  toolResult: 'tool_result',
+
+  // Image attachment markers: Anthropic ('image'), OpenAI Response API
+  // ('input_image'), OpenAI Chat Completions ('image_url').
+  image: 'image',
+  inputImage: 'input_image',
+  imageUrl: 'image_url',
+
+  // Document attachment markers: Anthropic ('document'), OpenAI Response API
+  // ('input_file'), OpenAI Chat Completions ('file').
+  document: 'document',
+  inputFile: 'input_file',
+  file: 'file',
+} as const);


### PR DESCRIPTION
## Summary

A scheduled data-structure-complexity audit flagged that `assistantBlockToNode`/`ContentBlockSchema` (`src/agent/export/normalizeConversation.ts`, chat export) and `formatConversationBlock` (`src/agent/storage/conversationFormat.ts`, execution/CLI history) each hand-duplicated the same non-text provider content-block `type` literals — `image`/`input_image`/`image_url`, `document`/`input_file`/`file`, `thinking`/`redacted_thinking`, `tool_use`, `tool_result` — as raw strings across two independently-maintained switch statements, with nothing catching a typo or a new provider alias added to only one side.

This PR extracts those literals into `CONVERSATION_BLOCK_TYPES`, a single frozen constant object (`src/agent/types/ConversationBlockTypes.ts`) both modules now import and switch on — the same pattern the codebase already uses for the three Anthropic server-tool block types (`ANTHROPIC_SERVER_TOOL_BLOCK_TYPES` in `@agent/types/ServerToolTypes`). Pure refactor: identical literal values, identical control flow, no behavior change.

`text`/`input_text`/`output_text` are deliberately **not** included in the shared constant. They're genuinely handled differently between the two consumers: `normalizeConversation.ts` distinguishes user- vs. assistant-role text per literal, while `conversationFormat.ts` recognizes them structurally via a `typeof block.text === 'string'` duck-type check that runs *before* its `type` switch, not via an explicit case per literal. Unifying them would have encoded a symmetry the two modules don't actually share — investigated and intentionally scoped out rather than papered over.

A second Medium finding from the same audit (`ProviderMessage`'s non-discriminated union + the legacy-session duck-typing fallback in `modelHandlerCompatibilityInference.ts`) was investigated and intentionally **not** touched here: a prior deep audit (`docs/proposals/agent-sdk-readiness-checkpoint-2026-07-21.md`) already reviewed this exact helper, confirmed it's a legitimate 4-caller tested pattern, and explicitly flagged that retiring it requires a persisted-transcript migration or compatibility-key-retirement policy decision — out of scope for an unattended refactor PR, and explicitly marked "do not re-flag."

## Issue acceptance gates

No tracked issue — this PR originates from a scheduled data-structure-complexity audit's Medium-severity finding #1 (duplicated block-type classification switches). Gate: both switches recognize the shared vocabulary through one imported source instead of independently hand-typed literals.

## Single source of truth

`CONVERSATION_BLOCK_TYPES` (`src/agent/types/ConversationBlockTypes.ts`) now owns the non-text provider content-block type-tag vocabulary, alongside the pre-existing `ANTHROPIC_SERVER_TOOL_BLOCK_TYPES` for the three server-tool tags. Both `normalizeConversation.ts` and `conversationFormat.ts` import from it rather than repeating string literals.

## Duplication and abstraction budget

Removed: ~10 hand-duplicated string literals per file (20 total occurrences collapsed to one canonical declaration each). Added: one small constant module with 2 real callers (already required by the abstraction-cost guardrail). No new pass-through layers, no factories, no class — just a shared value export.

## Net elements (R6)

Files: +1 (`ConversationBlockTypes.ts`, 48 lines), 2 modified. Exported symbols: +1 (`CONVERSATION_BLOCK_TYPES`). Diffstat: 3 files changed, 104 insertions(+), 42 deletions(-). No classes/interfaces/enums added.

## Consumer counts (R8)

n/a — no emit path, export, or public API was deleted or re-routed. Both existing consumers were updated in place to import the new shared constant; call sites and behavior are unchanged.

## Host impact

Extension: none (host-agnostic `src/agent/` module, no host-specific code touched).

Desktop: none.

CLI: none — `formatConversation` (used by `texra history`) is unaffected behaviorally; verified via `ExecutionsConversationFormat.vitest.ts`.

## Scheduled refactoring

None.

## Validation

- `npx vitest run src/test-kernel/commands/history/normalizeConversation.vitest.ts src/test-kernel/tools/ExecutionsConversationFormat.vitest.ts` — 56/56 passing.
- `npx vitest run src/test-kernel/agent src/test-kernel/tools src/test-kernel/commands` — 2579/2580 passing (1 pre-existing, unrelated failure: a QuickJS timing assertion in `WorkflowScriptEngine.vitest.ts` flaky on this environment, untouched by this change).
- `npm run typecheck` — clean across the full workspace (extension, CLI, desktop, trace-viewer).
- `npx eslint` on all three changed/added files — clean.
- `npm run check:dead-code-ratchet` — no new unused exports (18 baseline, 18 current).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nu8Knzydsv9m34m4d4cKkT)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only: same string values and control flow, limited to conversation parsing/formatting with existing test coverage.
> 
> **Overview**
> Introduces **`CONVERSATION_BLOCK_TYPES`** (`src/agent/types/ConversationBlockTypes.ts`) as the single source of truth for shared provider content-block `type` strings (thinking, tool use/result, image/document attachment aliases).
> 
> **`normalizeConversation.ts`** and **`conversationFormat.ts`** now import that constant for their Zod schema literals and `switch` cases instead of duplicating the same raw strings in two places. **`text` / `input_text` / `output_text`** stay as local literals because export vs. history formatting treat them differently.
> 
> Comments in both modules document that these switches must stay aligned with **`ANTHROPIC_SERVER_TOOL_BLOCK_TYPES`**—same tags, different output shapes. No runtime behavior change; compile-time drift prevention only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a9f8ba67116f879b36099f53264c89fb325bf21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->