### PR TITLE
refactor(trace): collapse the two identical ChildActivityEvent union arms

### DIFF
--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -146,13 +146,24 @@ export interface StatusEvent extends StageStamp {
   readonly substate?: StreamSubstate;
 }
 
-/** Session-owned child/process activity for a parent run stream. */
-interface ChildActivityEvent extends StageStamp {
+/** Fields shared by every {@link ChildActivityEvent} arm. */
+interface ChildActivityEventBase extends StageStamp {
   readonly type: 'child.activity';
-  readonly kind: 'subagents' | 'processes';
   readonly parentStreamId: StreamTabId;
   readonly items: readonly ActiveChildInfo[];
 }
+
+/**
+ * Session-owned child/process activity for a parent run stream. Kept as a
+ * `kind`-discriminated union (rather than one interface with
+ * `kind: 'subagents' | 'processes'`) so that
+ * `Extract<AgentEvent, { type: 'child.activity'; kind: K }>` still distributes
+ * to a single arm on the SDK surface — a conditional type splits union members
+ * but not an interface whose `kind` is itself a union.
+ */
+type ChildActivityEvent =
+  | (ChildActivityEventBase & { readonly kind: 'subagents' })
+  | (ChildActivityEventBase & { readonly kind: 'processes' });
 
 /** Incremental output from a child process owned by a parent run stream. */
 interface ProcessOutputEvent extends StageStamp {

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -147,19 +147,12 @@ export interface StatusEvent extends StageStamp {
 }
 
 /** Session-owned child/process activity for a parent run stream. */
-type ChildActivityEvent =
-  | (StageStamp & {
-      readonly type: 'child.activity';
-      readonly kind: 'subagents';
-      readonly parentStreamId: StreamTabId;
-      readonly items: readonly ActiveChildInfo[];
-    })
-  | (StageStamp & {
-      readonly type: 'child.activity';
-      readonly kind: 'processes';
-      readonly parentStreamId: StreamTabId;
-      readonly items: readonly ActiveChildInfo[];
-    });
+interface ChildActivityEvent extends StageStamp {
+  readonly type: 'child.activity';
+  readonly kind: 'subagents' | 'processes';
+  readonly parentStreamId: StreamTabId;
+  readonly items: readonly ActiveChildInfo[];
+}
 
 /** Incremental output from a child process owned by a parent run stream. */
 interface ProcessOutputEvent extends StageStamp {


### PR DESCRIPTION
## Summary

`ChildActivityEvent` in `src/agent/trace/events.ts` was a two-member union whose arms were byte-identical except for the `kind` discriminant (`'subagents'` vs `'processes'`) — the `type: 'child.activity'`, `parentStreamId`, and `items` fields were duplicated across both arms. This factors those shared fields into a `ChildActivityEventBase` interface and keeps the two `kind`-discriminated arms, removing the duplication with no behavior change.

> **Note (review follow-up):** the first commit collapsed the arms into a single interface with `kind: 'subagents' | 'processes'`. Codex correctly pointed out that this is *not* fully type-equivalent: `Extract<AgentEvent, { type: 'child.activity'; kind: 'subagents' }>` distributes over union members but does not split an interface whose `kind` is a union, so the collapsed form evaluated to `never` on the exported SDK surface. Commit `d34c815` switches to the base-interface + two-arm form, which removes the duplication *and* preserves `Extract`-by-`kind` distributivity.

## Issue acceptance gates

No dedicated issue. The `ChildActivityEvent` dedup was a follow-up item in the (closed) tracking issue #8736 but was never applied to this declaration; this PR finishes that one item. Surfaced while scanning the `storage-transcript` area for the recurring tech-debt rotation.

## Single source of truth

`ChildActivityEvent` (in the exported `AgentEvent` union, `src/agent/trace/events.ts`) remains the sole owner of the `child.activity` event shape. Its shared fields now live once, on `ChildActivityEventBase`, instead of being written twice.

## Duplication and abstraction budget

Removes the duplicated `type`/`parentStreamId`/`items` fields (previously declared in both arms). The one added type, `ChildActivityEventBase`, is not a pass-through layer — it is the discriminated union's shared-field base, consumed by both arms, and it carries an invariant: the two arms must stay a `kind`-discriminated union (not one interface) so `Extract`-by-`kind` keeps distributing on the SDK surface. That invariant is documented in the type's doc comment.

## Net elements (R6)

- Files: 0 added / 0 deleted (1 modified).
- Exported symbols: unchanged. Both `ChildActivityEvent` and the new `ChildActivityEventBase` are module-private; they reach consumers only through the exported `AgentEvent` union, whose members are unchanged.
- Types: +1 interface (`ChildActivityEventBase`); the union keeps its two arms.
- Net LoC: +4 (17 insertions, 13 deletions) — the shared fields collapse from two copies to one, offset by a doc comment recording the distributivity invariant.

## Consumer counts (R8)

No emit path or export was deleted or re-routed — the `child.activity` event and its `AgentEvent['type']` membership are unchanged, and the type's assignable value set and `Extract`-by-`kind` behavior are both preserved.
- Producers (2): `src/agent/runtime/executionRegistry.ts`, `packages/desktop/src/main/desktopAgentExecution.ts` — still emit a valid `kind`.
- Consumers narrowing on `event.kind` (still valid): `src/controllers/progressView/backend/events/ProgressFactApplier.ts`, plus CLI/transcript `case 'child.activity'` handlers.

## Host impact

Extension: none (typecheck green).

Desktop: none (typecheck green; producer in `desktopAgentExecution.ts` unaffected).

CLI: none (typecheck green; `subscribeRuntimeHost` / `runProgressRenderer` handlers unaffected).

## Scheduled refactoring

None. Completes the `ChildActivityEvent` line item from #8736; no new follow-up needed.

## Validation

- Distributivity proof: a scratch assertion confirms `Extract<AgentEvent, { type: 'child.activity'; kind: K }>` resolves to a real (non-`never`) arm for both `subagents` and `processes` — `tsc --noEmit` accepts it.
- `tsc --noEmit` green across all six projects: root core, test-kernel, extension (`texra`), CLI (`@texra-ai/cli`), trace-viewer, desktop.
- Vitest suites exercising `child.activity`: `ChildStreamProgressEvents`, `ExecutionRegistry`, `ProgressBackend` — all pass (113 total).
- `eslint src/agent/trace/events.ts` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSTZ4SX9tWb4sDy4p3Cf7w