### PR TITLE
refactor: remove prompt barrel and inline single-caller helper

### DIFF
--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -3,7 +3,7 @@ import { dirname } from 'node:path';
 import { z } from 'zod';
 
 import { BaseNode, Flow } from '@agent/node';
-import { getSystemPromptWithRules } from '@agent/prompt';
+import { getSystemPromptWithRules } from '@agent/prompt/PromptBuilder';
 import { recordRound } from '@agent/core/state/AgentState';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import {

--- a/src/agent/implementations/flows/reflection/ReflectionServices.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionServices.ts
@@ -1,4 +1,4 @@
-import type { PromptBuilder } from '@agent/prompt';
+import type { PromptBuilder } from '@agent/prompt/PromptBuilder';
 import type { AgentWorkflowSetting } from '@agent/core/definition/AgentDataclass';
 import type { BaseFlowContextInit } from '@agent/core/flows/BaseFlowServices';
 import type { OutputState } from '@agent/output/outputState';

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -1,6 +1,6 @@
 import { getExecutionStore } from '@agent/storage';
 import type { StageHandle } from '@agent/trace';
-import { PromptBuilder } from '@agent/prompt';
+import { PromptBuilder } from '@agent/prompt/PromptBuilder';
 import {
   createOutputState,
   setActiveRun,

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
@@ -1,6 +1,6 @@
 import { Node } from '@agent/node';
 import { logUserMessage } from '@agent/trace';
-import { buildInitialToolUsePrompts } from '@agent/prompt';
+import { buildInitialToolUsePrompts } from '@agent/prompt/PromptBuilder';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { AgentRunStateSnapshotSchema } from '@agent/core/state/AgentState';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';

--- a/src/agent/prompt/index.ts
+++ b/src/agent/prompt/index.ts
@@ -1,1 +1,0 @@
-export * from './PromptBuilder';

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -8,10 +8,7 @@ import {
   type RunToolUseFlowResult,
 } from '@agent/implementations/flows/tooluse/runToolUseFlow';
 import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
-import {
-  runReflectionFlow,
-  type RunReflectionFlowResult,
-} from '@agent/implementations/flows/reflection/runReflectionFlow';
+import { runReflectionFlow } from '@agent/implementations/flows/reflection/runReflectionFlow';
 import { inferAndLogPersistedModelHandlerCompatibilityKey } from '@agent/runtime/modelHandlerCompatibilityInference';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { RoundFinalizedCallback } from '@agent/core/flows/BaseFlowServices';
@@ -70,24 +67,6 @@ import type { ToolUseResumeData } from './SessionResumeRetrieval';
 
 const CHANNEL = 'executeAgent';
 const logger = createChannelTrace(CHANNEL);
-
-/** Build a workflow AgentFlowResult from a reflection flow run. */
-function buildWorkflowFlowResult(
-  result: RunReflectionFlowResult,
-  executionId: ExecutionId,
-  streamId: StreamTabId,
-  memoryMisses: AgentFlowResult['memoryMisses'],
-): AgentFlowResult {
-  return {
-    category: 'workflow',
-    outcome: result.outcome,
-    outputs: roundOutputsToOutputSummaries(result.roundOutputs),
-    compileFailures: roundOutputsToCompileFailureSummaries(result.roundOutputs),
-    executionId,
-    streamId,
-    ...buildOptionalFlowResultFields(memoryMisses, result.totalCostUsd),
-  };
-}
 
 /** Build a tool-use AgentFlowResult from a tool-use flow run. */
 function buildToolUseFlowResult(
@@ -253,12 +232,18 @@ async function runReflectionAgent(
   } finally {
     detachInterruptHandler();
   }
-  return buildWorkflowFlowResult(
-    result,
-    runExecutionId,
-    runStreamId,
-    ctx.attachedMemoryMisses,
-  );
+  return {
+    category: 'workflow',
+    outcome: result.outcome,
+    outputs: roundOutputsToOutputSummaries(result.roundOutputs),
+    compileFailures: roundOutputsToCompileFailureSummaries(result.roundOutputs),
+    executionId: runExecutionId,
+    streamId: runStreamId,
+    ...buildOptionalFlowResultFields(
+      ctx.attachedMemoryMisses,
+      result.totalCostUsd,
+    ),
+  };
 }
 
 /** Toast payload shown when the progress view cannot be opened. */

--- a/src/test-kernel/agent/followUp/ToolUsePrepareNodeTranscriptLog.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUsePrepareNodeTranscriptLog.vitest.ts
@@ -2,7 +2,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
-import { buildInitialToolUsePrompts } from '@agent/prompt';
+import { buildInitialToolUsePrompts } from '@agent/prompt/PromptBuilder';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { AgentPromptSchema } from '@agent/core/definition/AgentDataclass';
 import { ToolUsePrepareNode } from '@agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode';

--- a/src/test-kernel/agent/prompt/PromptBuilder.vitest.ts
+++ b/src/test-kernel/agent/prompt/PromptBuilder.vitest.ts
@@ -3,7 +3,10 @@ import { strict as assert } from 'node:assert';
 import { describe, it } from 'vitest';
 
 // Type imports
-import { buildInitialToolUsePrompts, PromptBuilder } from '@agent/prompt';
+import {
+  buildInitialToolUsePrompts,
+  PromptBuilder,
+} from '@agent/prompt/PromptBuilder';
 import type { AgentPrompt } from '@agent/core/definition/AgentDataclass';
 
 describe('PromptBuilder', () => {

--- a/src/test-kernel/skills/RuntimeSkills.vitest.mts
+++ b/src/test-kernel/skills/RuntimeSkills.vitest.mts
@@ -4,7 +4,7 @@ import * as path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { buildInitialToolUsePrompts } from '@agent/prompt';
+import { buildInitialToolUsePrompts } from '@agent/prompt/PromptBuilder';
 import {
   formatRuntimeSkillActivation,
   loadRuntimeSkillCatalog,

--- a/src/tools/lean/direct/leanSession.ts
+++ b/src/tools/lean/direct/leanSession.ts
@@ -336,6 +336,9 @@ export class LeanSession {
     this.requireRpc();
     let existing = this.openFiles.get(absolute);
     if (existing && !options.forceReload) return;
+    // Uses fs/promises directly rather than platform().fs: this must read the
+    // same real on-disk bytes the spawned `lean --server` process itself sees,
+    // not a host's virtual/faked workspace fs.
     const text = await readFile(absolute, 'utf8').catch((error) => {
       throw new Error(`Failed to read ${absolute}: ${toErrorMessage(error)}`, {
         cause: error,


### PR DESCRIPTION
## Summary

Follow-up to an architecture audit (abstraction-layer violations) run against this repo's own documented boundaries — VS Code-free zones, event-bus discipline, platform decoupling, UI anti-patterns, and factory/wrapper discipline. Most of the codebase held up clean; this PR fixes the two genuine, low-severity findings:

1. **`src/agent/prompt/index.ts`** was a pure `export * from './PromptBuilder'` re-export barrel with no documented public surface — banned by AGENTS.md's "No convenience barrels" rule (barrels exist only for a documented public surface, like the trace-events SDK contract). Its 7 importers (4 non-test, 3 test) now import `@agent/prompt/PromptBuilder` directly.
2. **`buildWorkflowFlowResult`** in `src/agent/runtime/executeAgent.ts` was a module-private helper with exactly one call site (`runReflectionAgent`) — inlined per the single-caller-extraction rule.

A third candidate from the audit — a raw `fs/promises` read in `src/tools/lean/direct/leanSession.ts` that looked like it should go through `platform().fs` — turned out to be a **false positive** on closer inspection: `LeanSession.ensureFileOpen` must read the same on-disk bytes the spawned `lean --server` subprocess itself sees. Routing it through `platform().fs` broke `DirectLspAdapter.vitest.ts` (2 tests) because the global test harness fakes `platform().fs` with an in-memory filesystem by default, while this code needs real disk semantics. Reverted the behavioral change and instead added the missing justification comment, matching the sibling exception already documented next to it in `directLspAdapter.ts`.

## Issue acceptance gates

No tracked issue — ad hoc cleanup from a one-off architecture audit. Gates: barrel removed with all importers repointed; single-caller helper inlined; no behavior change to the Lean tool (comment-only).

## Single source of truth

`PromptBuilder.ts` was already the single source of truth for prompt-building symbols; this just removes the redundant re-export indirection pointing at it.

## Duplication and abstraction budget

Removed: one barrel file, one single-caller wrapper function. No new abstractions added.

## Net elements (R6)

10 files changed, +26/-36 (net -10 LOC). 1 file deleted (`src/agent/prompt/index.ts`). Exported symbols: 1 barrel re-export statement removed (`export * from './PromptBuilder'`); the underlying symbols (`getSystemPromptWithRules`, `PromptBuilder`, `buildInitialToolUsePrompts`) are unchanged, just imported from their defining file now. 1 unexported function (`buildWorkflowFlowResult`) removed via inlining.

## Consumer counts (R8)

`@agent/prompt` barrel: 7 grepped importers, all repointed to `@agent/prompt/PromptBuilder` in this PR (`ResponseCycleFlow.ts`, `ReflectionServices.ts`, `runReflectionFlow.ts`, `ToolUsePrepareNode.ts`, plus 3 test files). `buildWorkflowFlowResult`: 1 call site, inlined.

## Host impact

Extension: none — shared `src/agent/` core logic only.
Desktop: none — shared `src/agent/` core logic only.
CLI: none — shared `src/agent/` core logic only.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — clean across all workspace packages.
- `npm run lint` — clean.
- `npm run check:dead-code-ratchet` — no new unused exports (18 current vs 18 baselined).
- `npx vitest run` on all directly affected suites (Lean tools, prompt builder, follow-up prepare node, runtime skills, `dependencyDirection` architecture test) — all pass, including the `DirectLspAdapter.vitest.ts` regression that caught the false-positive fix.
- Full `npm test`: 1 pre-existing failure unrelated to this change (`SystemUtils.vitest.ts > aborts shell command process groups including children` — a process-group/signal-handling test that fails in this sandboxed container regardless of branch; not touched by this PR).


---
_Generated by [Claude Code](https://claude.ai/code/session_019xdBWGK3bzTezpCMGyqPpe)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-path and helper inlining only; Lean change is comment-only with intentional fs semantics unchanged.
> 
> **Overview**
> Architecture-audit cleanup with **no runtime behavior change** except documentation in Lean tooling.
> 
> **Prompt imports:** Deletes `src/agent/prompt/index.ts` and repoints seven call sites (agent flows, tool-use prepare, tests) from `@agent/prompt` to `@agent/prompt/PromptBuilder` so prompt symbols are imported from their defining module per the no-convenience-barrels rule.
> 
> **Reflection runtime:** Removes `buildWorkflowFlowResult` from `executeAgent.ts` and inlines the same `AgentFlowResult` object construction in `runReflectionAgent`.
> 
> **Lean LSP:** Adds a comment in `LeanSession.ensureFileOpen` explaining why `readFile` from `node:fs/promises` stays direct (must match bytes the spawned `lean --server` sees; `platform().fs` would break tests that fake the workspace filesystem).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 647e18fd01c659953f31deae43bd6dc73ebd6b9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->