### PR TITLE
fix: distinguish workflow script streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ All notable changes to this project will be documented in this file.
 
 - **Completed background tasks leave the session list** — finished shell tasks
   are removed after their results are saved instead of leaving stale tabs.
+- **Workflow-script sessions show their own identity** — scripted orchestration
+  runs display the script name and type instead of appearing as the default
+  worker agent.
 
 ### Extension (VS Code)
 

--- a/packages/desktop/src/renderer/desktopCommandPalette.ts
+++ b/packages/desktop/src/renderer/desktopCommandPalette.ts
@@ -312,6 +312,7 @@ function toStreamPaletteEntry(stream: StreamTabInfo): CommandPaletteEntry {
     meta:
       stream.description ||
       stream.agent ||
+      (stream.kind === 'workflowScript' ? stream.workflowName : undefined) ||
       (stream.kind === 'agent' ? stream.modelLabel : undefined) ||
       'Stream',
     category: 'Streams',

--- a/packages/extension/src/progressView/frontend/components/StreamTab.styles.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTab.styles.ts
@@ -140,7 +140,7 @@ export const streamTabStyles = css`
   }
 
   .tab-meta .remote-agent,
-  .tab-meta .agent-category {
+  .tab-meta .stream-kind {
     margin-left: var(--wa-space-2xs);
   }
 

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -38,7 +38,11 @@ import '@awesome.me/webawesome/dist/components/relative-time/relative-time.js';
 import './WorktreeChip';
 import { formatRelativeTime } from '@shared/utils/string';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
-import { TEXRA_ICON_LIBRARY, waIcon } from '@shared/wa/webAwesomeIcons';
+import {
+  TEXRA_ICON_LIBRARY,
+  type TeXRAIconName,
+  waIcon,
+} from '@shared/wa/webAwesomeIcons';
 import { renderEmptyState } from '@shared/wa/emptyState';
 import { formatResultCount } from '@utils/text/stringUtils';
 import { layoutStyles } from '../styles/logStyles';
@@ -114,7 +118,10 @@ export class StreamTab extends LitElement {
   /** Whether the child list is expanded. */
   @property({ type: Boolean, reflect: true }) expanded = false;
 
-  private _agentDecorator = getAgentCategoryDecorator('toolUse');
+  private _streamDecorator: {
+    readonly icon: TeXRAIconName;
+    readonly label: string;
+  } = getAgentCategoryDecorator('toolUse');
   private _tooltip = '';
 
   protected override willUpdate(changed: PropertyValues): void {
@@ -126,7 +133,10 @@ export class StreamTab extends LitElement {
     )
       return;
     if (changed.has('info')) {
-      this._agentDecorator = getAgentCategoryDecorator(this.info.agentCategory);
+      this._streamDecorator =
+        this.info.kind === 'workflowScript'
+          ? AGENT_DECORATORS.streamKinds.workflowScript
+          : getAgentCategoryDecorator(this.info.agentCategory);
     }
     const status = this.status || DEFAULT_STREAM_METADATA_STATUS;
     const statusLabel =
@@ -142,7 +152,7 @@ export class StreamTab extends LitElement {
     const status = this.status || DEFAULT_STREAM_METADATA_STATUS;
     const statusKey = streamStatusDisplayKey(status, this.substate) ?? status;
     const tooltip = this._tooltip;
-    const agentDecorator = this._agentDecorator;
+    const streamDecorator = this._streamDecorator;
     const hasChildren = this.childCount > 0 && !this.compact;
     const childStreamLabel = formatResultCount(this.childCount, 'child stream');
 
@@ -247,10 +257,14 @@ export class StreamTab extends LitElement {
                     >
                     <wa-icon
                       library=${TEXRA_ICON_LIBRARY}
-                      name=${agentDecorator.icon}
-                      class="agent-category"
+                      name=${streamDecorator.icon}
+                      class="stream-kind"
                       aria-hidden="true"
-                      title=${`Category: ${agentDecorator.label}`}
+                      title=${
+                        stream.kind === 'workflowScript'
+                          ? streamDecorator.label
+                          : `Category: ${streamDecorator.label}`
+                      }
                     ></wa-icon>
                     ${when(
                       stream.isRemote,

--- a/packages/extension/src/progressView/frontend/progressState.ts
+++ b/packages/extension/src/progressView/frontend/progressState.ts
@@ -267,7 +267,11 @@ const activeIsToolUse$ = new Signal.Computed(() => {
 const subagentExecutionLabels$ = new Signal.Computed((): ExecutionLabels => {
   const labels = new Map<string, string>();
   for (const child of streamById$.get().values()) {
-    if (child.kind !== 'agent' || !child.parentStreamId || !child.executionId) {
+    if (
+      child.kind === 'process' ||
+      !child.parentStreamId ||
+      !child.executionId
+    ) {
       continue;
     }
     const label = child.label.trim();

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -279,6 +279,7 @@ function emitRunStart(ctx: AgentLaunchContext): void {
     executionId,
     agent: ctx.config.agent,
     category: ctx.setting.agentCategory,
+    kind: 'agent',
   });
   ctx.logger.emit({ type: 'run.start', descriptor });
   ctx.logger.emit({

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -382,6 +382,7 @@ export const RUN_FACT_EVENT_TYPES = Object.freeze([
   'updateMissingOutputs',
   'updateCompileFailures',
   'goalPaused',
+  'run.start',
   'run.config',
   'usage',
   'status',

--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -111,6 +111,20 @@ export class ProgressFactApplier {
    */
   private readonly runFactHandlers: RunFactHandlers = {
     usage: (_streamId, event) => this.handleUpdateStreamUsage(event.payload),
+    'run.start': (_streamId, event) => {
+      const streamId = event.descriptor.streamId;
+      if (this.stateOwnership === 'backend') {
+        this.state.snapshots.setRunDescriptor(event.descriptor);
+      }
+      this.state.refreshStreamMetadataFromSnapshot(streamId);
+      if (this.webviewUpdater.isAvailable()) {
+        this.webviewUpdater.updateStreamMetadata(
+          this.state,
+          streamId,
+          this.state.streamStatus.getAllStreamStates(),
+        );
+      }
+    },
     'run.config': (_streamId, event) =>
       this.handleSetTaskState({
         streamId: event.streamId,

--- a/src/controllers/progressView/backend/state/ProgressViewState.ts
+++ b/src/controllers/progressView/backend/state/ProgressViewState.ts
@@ -52,10 +52,10 @@ const LEGACY_INSTRUCTION_BACKFILL_CONCURRENCY = 8;
  * every field below are always populated together from that one `AgentConfig`
  * — they can't drift independently of each other the way top-level
  * `ProgressStreamMetadata` fields (set by separate calls at separate times)
- * can. `kind` mirrors the process/agent distinction `buildStreamTabInfo`
- * renders differently: a "process" stream runs a raw OS tool (e.g. the
- * `bash` tool) and carries no meaningful model; an "agent" stream is an
- * LLM-driven run and may carry `inputFile`/`model`.
+ * can. `kind` mirrors the three owners `buildStreamTabInfo` renders
+ * differently: a `process` runs a raw OS tool, an `agent` is LLM-driven, and
+ * a `workflowScript` is a deterministic orchestration container whose worker
+ * agents run in child streams.
  */
 type ProgressStreamRunDetails =
   | {
@@ -69,6 +69,12 @@ type ProgressStreamRunDetails =
       agent: string;
       inputFile?: string;
       model: string;
+      instruction: string;
+      workingDirectory?: string;
+    }
+  | {
+      kind: 'workflowScript';
+      workflowName: string;
       instruction: string;
       workingDirectory?: string;
     };
@@ -271,23 +277,37 @@ export class ProgressViewState {
   ): void {
     const config = this.snapshots.getRunConfig(stream);
     if (config) {
-      metadata.agentCategory = config.agentCategory;
+      const descriptor = this.snapshots.getRunDescriptor(stream);
+      const identityName = descriptor?.agent ?? config.agent;
+      const runKind =
+        descriptor?.kind ??
+        (isProcessAgent(config.agent) ? 'process' : 'agent');
+      metadata.agentCategory = descriptor?.category ?? config.agentCategory;
       const workingDirectory = config.workingDirectory ?? undefined;
-      metadata.run = isProcessAgent(config.agent)
-        ? {
-            kind: 'process',
-            agent: config.agent,
-            instruction: config.instruction,
-            workingDirectory,
-          }
-        : {
-            kind: 'agent',
-            agent: config.agent,
-            inputFile: config.inputFiles?.at(0),
-            model: config.model,
-            instruction: config.instruction,
-            workingDirectory,
-          };
+      if (runKind === 'workflowScript') {
+        metadata.run = {
+          kind: 'workflowScript',
+          workflowName: identityName,
+          instruction: config.instruction,
+          workingDirectory,
+        };
+      } else if (runKind === 'process') {
+        metadata.run = {
+          kind: 'process',
+          agent: identityName,
+          instruction: config.instruction,
+          workingDirectory,
+        };
+      } else {
+        metadata.run = {
+          kind: 'agent',
+          agent: identityName,
+          inputFile: config.inputFiles?.at(0),
+          model: config.model,
+          instruction: config.instruction,
+          workingDirectory,
+        };
+      }
     }
 
     metadata.executionId =

--- a/src/controllers/progressView/backend/streamTabInfo.ts
+++ b/src/controllers/progressView/backend/streamTabInfo.ts
@@ -36,12 +36,16 @@ export function buildStreamTabInfo(inputs: StreamTabInfoInputs): StreamTabInfo {
   // stream ID (format "agentName@timestamp") so an early render — e.g. a
   // just-created bash child stream — still classifies correctly. Once `run`
   // is set, its `kind` is authoritative: no more guessing from the name.
-  const rawAgentName = run?.agent ?? streamId.split('@')[0];
-  const agentName = getCleanAgentName(rawAgentName);
-  const resolvedAgent = run?.agent ?? agentName;
+  const rawIdentityName =
+    run?.kind === 'workflowScript'
+      ? run.workflowName
+      : (run?.agent ?? streamId.split('@')[0]);
+  const identityName = getCleanAgentName(rawIdentityName);
+  const resolvedAgent =
+    run?.kind === 'workflowScript' ? undefined : (run?.agent ?? identityName);
   const isProcessStream = run
     ? run.kind === 'process'
-    : isProcessAgent(rawAgentName);
+    : isProcessAgent(rawIdentityName);
 
   const inputFile = (run?.kind === 'agent' ? run.inputFile : undefined) ?? '';
 
@@ -50,8 +54,8 @@ export function buildStreamTabInfo(inputs: StreamTabInfoInputs): StreamTabInfo {
   // a single canonical input file, so we just show the agent name.
   const label =
     category !== AgentCategory.ToolUse && inputFile
-      ? `${agentName}: ${path.basename(inputFile)}`
-      : agentName;
+      ? `${identityName}: ${path.basename(inputFile)}`
+      : identityName;
 
   // Surface the full untruncated command for process streams (description
   // is capped for tab/tooltip rendering).
@@ -61,7 +65,7 @@ export function buildStreamTabInfo(inputs: StreamTabInfoInputs): StreamTabInfo {
   // Canonical host-known status takes precedence because setActiveStream can
   // identify a remote run before its agent is present in the registry.
   const isRemote =
-    metadata.isRemote ?? (rawAgentName ? isRemoteAgent(rawAgentName) : false);
+    metadata.isRemote ?? (resolvedAgent ? isRemoteAgent(resolvedAgent) : false);
 
   // Worktree context comes from one of two sources, in order:
   //   1. An explicit hint passed in by the caller (already resolved branch /
@@ -77,7 +81,7 @@ export function buildStreamTabInfo(inputs: StreamTabInfoInputs): StreamTabInfo {
   const base = {
     name: streamId,
     label,
-    agent: resolvedAgent,
+    ...(resolvedAgent ? { agent: resolvedAgent } : {}),
     agentCategory: category,
     isRemote,
     inputFile,
@@ -90,6 +94,13 @@ export function buildStreamTabInfo(inputs: StreamTabInfoInputs): StreamTabInfo {
 
   if (isProcessStream) {
     return { ...base, kind: 'process', command };
+  }
+  if (run?.kind === 'workflowScript') {
+    return {
+      ...base,
+      kind: 'workflowScript',
+      workflowName: run.workflowName,
+    };
   }
 
   // Process agents (e.g. bash) carry a synthetic AgentConfig whose `model`

--- a/src/shared/schemas/runDescriptor.ts
+++ b/src/shared/schemas/runDescriptor.ts
@@ -5,6 +5,9 @@ import { ExecutionIdSchema, StreamTabIdSchema } from './identifiers';
 
 export const RUN_DESCRIPTOR_SCHEMA_VERSION = 1;
 
+export const RunKindSchema = z.enum(['agent', 'process', 'workflowScript']);
+export type RunKind = z.infer<typeof RunKindSchema>;
+
 const RunConfigReferenceSchema = z.strictObject({
   kind: z.literal('executionConfig'),
   executionId: ExecutionIdSchema,
@@ -17,6 +20,11 @@ export const RunDescriptorSchema = z.strictObject({
   executionId: ExecutionIdSchema,
   agent: z.string().min(1),
   category: AgentCategorySchema,
+  /**
+   * What owns the stream. Optional only for descriptors written before this
+   * field existed; every new descriptor supplies it explicitly.
+   */
+  kind: RunKindSchema.optional(),
   configRef: RunConfigReferenceSchema,
 });
 
@@ -27,6 +35,7 @@ export function buildRunDescriptor(input: {
   executionId: z.infer<typeof ExecutionIdSchema>;
   agent: string;
   category: z.infer<typeof AgentCategorySchema>;
+  kind: RunKind;
 }): RunDescriptor {
   return RunDescriptorSchema.parse({
     schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
@@ -34,6 +43,7 @@ export function buildRunDescriptor(input: {
     executionId: input.executionId,
     agent: input.agent,
     category: input.category,
+    kind: input.kind,
     configRef: {
       kind: 'executionConfig',
       executionId: input.executionId,

--- a/src/shared/schemas/runDescriptor.ts
+++ b/src/shared/schemas/runDescriptor.ts
@@ -5,7 +5,7 @@ import { ExecutionIdSchema, StreamTabIdSchema } from './identifiers';
 
 export const RUN_DESCRIPTOR_SCHEMA_VERSION = 1;
 
-export const RunKindSchema = z.enum(['agent', 'process', 'workflowScript']);
+const RunKindSchema = z.enum(['agent', 'process', 'workflowScript']);
 export type RunKind = z.infer<typeof RunKindSchema>;
 
 const RunConfigReferenceSchema = z.strictObject({

--- a/src/shared/schemas/stream.ts
+++ b/src/shared/schemas/stream.ts
@@ -343,10 +343,11 @@ const StreamTabInfoBaseSchema = z.object({
 });
 
 /**
- * Discriminated on `kind`: a stream tab is either a live LLM-driven "agent"
- * run (carries `model`/`modelLabel`) or a raw OS "process" stream such as the
- * `bash` tool (carries `command`, no meaningful model). Renderers switch on
- * `kind` instead of probing which of `model`/`command` happens to be set.
+ * Discriminated on `kind`: a stream tab is a live LLM-driven `agent`, a raw
+ * OS `process`, or a deterministic `workflowScript` orchestration container.
+ * Only agents carry model metadata; only processes carry commands; workflow
+ * scripts carry their immutable script name. Renderers switch on `kind`
+ * instead of inferring ownership from whichever optional field is present.
  */
 export const StreamTabInfoSchema = z.discriminatedUnion('kind', [
   StreamTabInfoBaseSchema.extend({
@@ -359,6 +360,11 @@ export const StreamTabInfoSchema = z.discriminatedUnion('kind', [
     /** Full, untruncated command that spawned this stream; used by the
      * process stream view. */
     command: z.string().optional(),
+  }),
+  StreamTabInfoBaseSchema.extend({
+    kind: z.literal('workflowScript'),
+    /** Immutable `meta.name` of the orchestration script. */
+    workflowName: z.string(),
   }),
 ]);
 export type StreamTabInfo = z.infer<typeof StreamTabInfoSchema>;

--- a/src/shared/utils/icons.ts
+++ b/src/shared/utils/icons.ts
@@ -90,6 +90,9 @@ export const AGENT_DECORATORS = {
     workflow: { icon: 'symbol-method', label: 'Workflow' },
     toolUse: { icon: 'tools', label: 'Tool Use' },
   },
+  streamKinds: {
+    workflowScript: { icon: 'list-tree', label: 'Workflow Script' },
+  },
 } as const;
 
 type AgentCategory = keyof typeof AGENT_DECORATORS.agentCategories;

--- a/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
@@ -66,6 +66,7 @@ function startCodexChild(
     runtimeHost: host,
     streamPrefix: 'codex',
     streamCategory: AgentCategory.ToolUse,
+    runKind: 'agent',
     agentName: 'codex',
     description,
     config,
@@ -145,6 +146,7 @@ describe('child stream progress events', () => {
           runtimeHost: host,
           streamPrefix: 'bash',
           streamCategory: AgentCategory.ToolUse,
+          runKind: 'process',
           agentName: 'test-agent',
           description: 'Run a background bash command',
           config,
@@ -173,6 +175,7 @@ describe('child stream progress events', () => {
         runtimeHost: active.host,
         streamPrefix: 'bash',
         streamCategory: AgentCategory.ToolUse,
+        runKind: 'process',
         agentName: 'test-agent',
         description: 'Run a background bash command',
         config,
@@ -257,6 +260,7 @@ describe('child stream progress events', () => {
         runtimeHost: active.host,
         streamPrefix: 'workflow-script',
         streamCategory: AgentCategory.Workflow,
+        runKind: 'workflowScript',
         agentName: 'draft-sections',
         description: 'Run a named child task',
         config,
@@ -276,6 +280,7 @@ describe('child stream progress events', () => {
         runtimeHost: active.host,
         streamPrefix: 'workflow-script',
         streamCategory: AgentCategory.Workflow,
+        runKind: 'workflowScript',
         agentName: 'draft-sections',
         description: 'Resume the named child task',
         config,
@@ -310,6 +315,55 @@ describe('child stream progress events', () => {
     }
   });
 
+  it('emits workflow-script identity independently of its worker config', async () => {
+    const active = createRecordingHost();
+    const recorded = recordSessionEvents(defaultSession().events);
+    const workerConfig = {
+      ...config,
+      agent: 'generic',
+      agentCategory: AgentCategory.Workflow,
+    };
+
+    try {
+      const childStream = createChildStream(
+        workflowRelaunchExecutionId,
+        parentStreamId,
+        {
+          runtimeHost: active.host,
+          streamPrefix: 'workflow-script',
+          streamCategory: AgentCategory.Workflow,
+          runKind: 'workflowScript',
+          agentName: 'repo-cleanup-readonly-pilot-2026-07-24',
+          description: 'Audit the repository without editing',
+          config: workerConfig,
+          toolName: DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+        },
+      );
+
+      expect(runEventsOfType(recorded.events, 'run.start')).toContainEqual(
+        expect.objectContaining({
+          descriptor: expect.objectContaining({
+            agent: 'repo-cleanup-readonly-pilot-2026-07-24',
+            category: AgentCategory.Workflow,
+            kind: 'workflowScript',
+          }),
+        }),
+      );
+      expect(
+        defaultSession().executions.getAgentHandleByStream(
+          workflowRelaunchChildStreamId,
+        ),
+      ).toMatchObject({
+        agentName: 'repo-cleanup-readonly-pilot-2026-07-24',
+        category: AgentCategory.Workflow,
+      });
+
+      await childStream.finalize();
+    } finally {
+      recorded.detach();
+    }
+  });
+
   it('publishes child stream activation through the session fact hub', async () => {
     const active = createRecordingHost();
     const facts: unknown[] = [];
@@ -324,6 +378,7 @@ describe('child stream progress events', () => {
         runtimeHost: active.host,
         streamPrefix: 'bash',
         streamCategory: AgentCategory.ToolUse,
+        runKind: 'process',
         agentName: 'test-agent',
         description: 'Run a background bash command',
         config,
@@ -368,6 +423,7 @@ describe('child stream progress events', () => {
           runtimeHost: active.host,
           streamPrefix: 'bash',
           streamCategory: AgentCategory.ToolUse,
+          runKind: 'process',
           agentName: 'test-agent',
           description: 'Run a background bash command',
           config,
@@ -399,6 +455,7 @@ describe('child stream progress events', () => {
         runtimeHost: active.host,
         streamPrefix: 'bash',
         streamCategory: AgentCategory.ToolUse,
+        runKind: 'process',
         agentName: 'test-agent',
         description: 'Run a background bash command',
         config,

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -43,6 +43,7 @@ import * as logger from '@logger/logUtils';
 import {
   AgentCategory,
   type ActiveChildInfo,
+  buildRunDescriptor,
   type CompileFailure,
   type InquiryThreadUpdatedEvent,
   LOG_LEVELS,
@@ -2212,9 +2213,9 @@ describe('ProgressBackend', () => {
     try {
       backend.state.streamLogs.ensureStream(stream);
       // Provisional patches only ever carry agentCategory/isRemote in
-      // production (see ProgressFactApplier.handleSetActiveStream) — agent/
-      // inputFile/model come exclusively from the RunConfig-derived `run`
-      // union, set atomically by applySnapshotMetadata.
+      // production (see ProgressFactApplier.handleSetActiveStream). Identity
+      // comes from the immutable descriptor; input/model details come from
+      // RunConfig and are assembled atomically by applySnapshotMetadata.
       backend.state.updateStreamMetadata(stream, {
         agentCategory: AgentCategory.Workflow,
         isRemote: true,
@@ -2266,6 +2267,59 @@ describe('ProgressBackend', () => {
         action: 'render',
         kind: AgentCategory.ToolUse,
       });
+    } finally {
+      backend.dispose();
+    }
+  });
+
+  it('models a workflow-script container separately from its default worker agent', () => {
+    const { backend } = createRecordingBackend();
+    const stream = 'workflow-script#f10a11' as StreamTabId;
+    const executionId = 'f10a11' as ExecutionId;
+
+    try {
+      backend.state.streamLogs.ensureStream(stream);
+      backend.state.snapshots.setRunDescriptor(
+        buildRunDescriptor({
+          streamId: stream,
+          executionId,
+          agent: 'repo-cleanup-readonly-pilot-2026-07-24',
+          category: AgentCategory.Workflow,
+          kind: 'workflowScript',
+        }),
+      );
+      backend.state.setStreamTaskState(
+        stream,
+        {
+          agentConfig: {
+            agent: 'generic',
+            model: 'gpt-5.6-sol',
+            agentCategory: AgentCategory.Workflow,
+            instruction:
+              "Workflow script 'repo-cleanup-readonly-pilot-2026-07-24'",
+          },
+        } as TaskState,
+        executionId,
+      );
+
+      expect(backend.state.getStreamMetadata(stream).run).toEqual({
+        kind: 'workflowScript',
+        workflowName: 'repo-cleanup-readonly-pilot-2026-07-24',
+        instruction: "Workflow script 'repo-cleanup-readonly-pilot-2026-07-24'",
+      });
+      const workflowInfos = buildStreamInfos(backend.state, 'workflow');
+      expect(workflowInfos).toContainEqual(
+        expect.objectContaining({
+          name: stream,
+          label: 'repo-cleanup-readonly-pilot-2026-07-24',
+          kind: 'workflowScript',
+          workflowName: 'repo-cleanup-readonly-pilot-2026-07-24',
+          agentCategory: AgentCategory.Workflow,
+        }),
+      );
+      const workflowScript = workflowInfos.find((info) => info.name === stream);
+      expect(workflowScript).not.toHaveProperty('agent');
+      expect(workflowScript).not.toHaveProperty('model');
     } finally {
       backend.dispose();
     }

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -2272,41 +2272,49 @@ describe('ProgressBackend', () => {
     }
   });
 
-  it('models a workflow-script container separately from its default worker agent', () => {
-    const { backend } = createRecordingBackend();
+  it('models a workflow-script container from the extension event subscription', async () => {
+    const target = createIsolatedRecordingBackend();
+    const { backend, session } = target;
+    const subscription = backend.setupEventListeners();
     const stream = 'workflow-script#f10a11' as StreamTabId;
     const executionId = 'f10a11' as ExecutionId;
+    const descriptor = buildRunDescriptor({
+      streamId: stream,
+      executionId,
+      agent: 'repo-cleanup-readonly-pilot-2026-07-24',
+      category: AgentCategory.Workflow,
+      kind: 'workflowScript',
+    });
 
     try {
       backend.state.streamLogs.ensureStream(stream);
-      backend.state.snapshots.setRunDescriptor(
-        buildRunDescriptor({
-          streamId: stream,
-          executionId,
-          agent: 'repo-cleanup-readonly-pilot-2026-07-24',
-          category: AgentCategory.Workflow,
+      session.events.emit({
+        scope: 'run',
+        streamId: stream,
+        event: { type: 'run.start', descriptor },
+      });
+      emitRunConfig(target, stream, executionId, {
+        agentConfig: {
+          agent: 'generic',
+          model: 'gpt-5.6-sol',
+          agentCategory: AgentCategory.Workflow,
+          instruction:
+            "Workflow script 'repo-cleanup-readonly-pilot-2026-07-24'",
+          inputFiles: [],
+          contextFiles: [],
+          mediaFiles: [],
+          outputFiles: [],
+        },
+      } as TaskState);
+
+      await vi.waitFor(() =>
+        expect(backend.state.getStreamMetadata(stream).run).toEqual({
           kind: 'workflowScript',
+          workflowName: 'repo-cleanup-readonly-pilot-2026-07-24',
+          instruction:
+            "Workflow script 'repo-cleanup-readonly-pilot-2026-07-24'",
         }),
       );
-      backend.state.setStreamTaskState(
-        stream,
-        {
-          agentConfig: {
-            agent: 'generic',
-            model: 'gpt-5.6-sol',
-            agentCategory: AgentCategory.Workflow,
-            instruction:
-              "Workflow script 'repo-cleanup-readonly-pilot-2026-07-24'",
-          },
-        } as TaskState,
-        executionId,
-      );
-
-      expect(backend.state.getStreamMetadata(stream).run).toEqual({
-        kind: 'workflowScript',
-        workflowName: 'repo-cleanup-readonly-pilot-2026-07-24',
-        instruction: "Workflow script 'repo-cleanup-readonly-pilot-2026-07-24'",
-      });
       const workflowInfos = buildStreamInfos(backend.state, 'workflow');
       expect(workflowInfos).toContainEqual(
         expect.objectContaining({
@@ -2321,7 +2329,9 @@ describe('ProgressBackend', () => {
       expect(workflowScript).not.toHaveProperty('agent');
       expect(workflowScript).not.toHaveProperty('model');
     } finally {
+      subscription.dispose();
       backend.dispose();
+      session.dispose();
     }
   });
 

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -28,12 +28,14 @@ import {
   type DeleteExecutionOptions,
   type DeleteExecutionResult,
 } from '@agent/storage';
+import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
 import {
   type RunFactEventName,
   type RunFactPayloads,
 } from '@agent/runtime/runFactEvents';
 import type { TaskState } from '@agent/core/state/TaskState';
+import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 import { buildStreamInfos } from '@controllers/progressView/backend/streamInfoUtils';
 import {
   ProgressBackend,
@@ -2293,19 +2295,20 @@ describe('ProgressBackend', () => {
         streamId: stream,
         event: { type: 'run.start', descriptor },
       });
-      emitRunConfig(target, stream, executionId, {
-        agentConfig: {
-          agent: 'generic',
-          model: 'gpt-5.6-sol',
-          agentCategory: AgentCategory.Workflow,
-          instruction:
-            "Workflow script 'repo-cleanup-readonly-pilot-2026-07-24'",
-          inputFiles: [],
-          contextFiles: [],
-          mediaFiles: [],
-          outputFiles: [],
-        },
-      } as TaskState);
+      emitRunConfig(
+        target,
+        stream,
+        executionId,
+        agentConfigToTaskState(
+          AgentConfigSchema.parse({
+            agent: 'generic',
+            model: 'gpt-5.6-sol',
+            agentCategory: AgentCategory.Workflow,
+            instruction:
+              "Workflow script 'repo-cleanup-readonly-pilot-2026-07-24'",
+          }),
+        ),
+      );
 
       await vi.waitFor(() =>
         expect(backend.state.getStreamMetadata(stream).run).toEqual({

--- a/src/test-kernel/progressView/ProgressExecutionLabels.vitest.ts
+++ b/src/test-kernel/progressView/ProgressExecutionLabels.vitest.ts
@@ -38,6 +38,17 @@ const completedSibling: StreamTabInfo = {
   executionId: 'sub-2',
 };
 
+const completedWorkflowScript: StreamTabInfo = {
+  kind: 'workflowScript',
+  name: 'repo-cleanup#workflow-1',
+  label: 'repo-cleanup-readonly-pilot-2026-07-24',
+  workflowName: 'repo-cleanup-readonly-pilot-2026-07-24',
+  agentCategory: AgentCategory.Workflow,
+  creationTimestamp: 3,
+  executionId: 'workflow-1',
+  parentStreamId: 'parent',
+};
+
 afterEach(resetProgressState);
 
 describe('progress executions labels', () => {
@@ -91,5 +102,20 @@ describe('progress executions labels', () => {
     });
 
     expect(logContext$.get().subagentExecutionLabels?.size).toBe(0);
+  });
+
+  it('labels child workflow-script executions with the script name', () => {
+    appState.set({
+      ...createInitialState(),
+      activeStreamId: 'parent',
+      streamById: new Map<string, StreamTabInfo>([
+        ['parent', parent],
+        [completedWorkflowScript.name, completedWorkflowScript],
+      ]),
+    });
+
+    expect(logContext$.get().subagentExecutionLabels?.get('workflow-1')).toBe(
+      'repo-cleanup-readonly-pilot-2026-07-24',
+    );
   });
 });

--- a/src/test-kernel/progressView/StreamHeader.vitest.mts
+++ b/src/test-kernel/progressView/StreamHeader.vitest.mts
@@ -15,7 +15,11 @@ import { DELEGATION_APPROVAL_COPY } from '@shared/copy/delegationApproval';
 // Local file imports
 import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
 
-function baseStream(overrides: Partial<StreamTabInfo> = {}): StreamTabInfo {
+type AgentStreamTabInfo = Extract<StreamTabInfo, { kind: 'agent' }>;
+
+function baseStream(
+  overrides: Partial<AgentStreamTabInfo> = {},
+): AgentStreamTabInfo {
   return {
     kind: 'agent',
     name: 'stream-a',

--- a/src/test-kernel/progressView/StreamTabsExpandChevron.vitest.mts
+++ b/src/test-kernel/progressView/StreamTabsExpandChevron.vitest.mts
@@ -54,4 +54,30 @@ describe('stream-tab expand chevron', () => {
     expect(expandButton?.getAttribute('data-action')).toBe('toggle-children');
     expect(expandButton?.hasAttribute('aria-expanded')).toBe(true);
   });
+
+  it('renders workflow scripts as orchestration streams without a model', async () => {
+    const tabs = document.createElement('stream-tabs') as StreamTabs;
+    tabs.streams = [
+      {
+        kind: 'workflowScript',
+        name: 'workflow-script#abc123',
+        label: 'repo-cleanup-readonly-pilot-2026-07-24',
+        workflowName: 'repo-cleanup-readonly-pilot-2026-07-24',
+        agentCategory: AgentCategory.Workflow,
+        creationTimestamp: 1,
+      },
+    ];
+    document.body.append(tabs);
+    await tabs.updateComplete;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const tab = tabs.shadowRoot?.querySelector('stream-tab');
+    const model = tab?.shadowRoot?.querySelector('.model');
+    const kindIcon = tab?.shadowRoot?.querySelector('.stream-kind') as
+      (Element & { name?: string }) | null;
+
+    expect(model?.textContent?.trim()).toBe('');
+    expect(kindIcon?.name).toBe('list-tree');
+    expect(kindIcon?.getAttribute('title')).toBe('Workflow Script');
+  });
 });

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -340,6 +340,53 @@ describe('StreamSnapshotStore', () => {
     expect(goalPausedOnly.runUsage).toEqual({});
   });
 
+  it('treats run.start as authoritative after run.config synthesizes identity', async () => {
+    const events = new SessionEventHub();
+    const writer = new StreamSnapshotStore();
+    const detach = writer.attachSessionEvents(events);
+    const executionId = 'a1b2c3d4' as ExecutionId;
+    const taskState = toolUseTaskState('worker-agent');
+    const workflowDescriptor = buildRunDescriptor({
+      streamId: STREAM,
+      executionId,
+      agent: 'workflow-script',
+      category: AgentCategory.Workflow,
+      kind: 'workflowScript',
+    });
+
+    events.emit({
+      scope: 'run',
+      streamId: STREAM,
+      event: {
+        type: 'run.config',
+        streamId: STREAM,
+        executionId,
+        config: taskState.agentConfig,
+      },
+    });
+    expect(writer.getRunDescriptor(STREAM)).toMatchObject({
+      agent: 'worker-agent',
+      kind: 'agent',
+    });
+
+    events.emit({
+      scope: 'run',
+      streamId: STREAM,
+      event: {
+        type: 'run.start',
+        descriptor: workflowDescriptor,
+      },
+    });
+    detach();
+    await writer.flush();
+
+    expect(writer.getRunDescriptor(STREAM)).toEqual(workflowDescriptor);
+    const reader = new StreamSnapshotStore();
+    await reader.load([STREAM]);
+    expect(reader.getExecutionId(STREAM)).toBe(executionId);
+    expect(reader.getRunDescriptor(STREAM)).toEqual(workflowDescriptor);
+  });
+
   it('returns an empty (valid) snapshot for a stream with no sidecar', async () => {
     const snap = await new StreamSnapshotStore().read(STREAM);
     expect(snap.streamId).toBe(STREAM);

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -8,7 +8,10 @@ import { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import { TaskStateSchema, type TaskState } from '@agent/core/state/TaskState';
 import type { Platform } from '@platform/platform';
 import { resolveRunStoragePath } from '@platform/defaults/workspaceStorage';
-import { RUN_DESCRIPTOR_SCHEMA_VERSION } from '@shared/schemas';
+import {
+  RUN_DESCRIPTOR_SCHEMA_VERSION,
+  buildRunDescriptor,
+} from '@shared/schemas';
 import type {
   CompileFailure,
   ExecutionId,
@@ -193,6 +196,20 @@ describe('StreamSnapshotStore', () => {
       scope: 'run',
       streamId: STREAM,
       event: {
+        type: 'run.start',
+        descriptor: buildRunDescriptor({
+          streamId: STREAM,
+          executionId,
+          agent: 'session-label',
+          category: AgentCategory.ToolUse,
+          kind: 'agent',
+        }),
+      },
+    });
+    events.emit({
+      scope: 'run',
+      streamId: STREAM,
+      event: {
         type: 'run.config',
         streamId: STREAM,
         executionId,
@@ -312,8 +329,9 @@ describe('StreamSnapshotStore', () => {
     expect(reader.getRunDescriptor(STREAM)).toMatchObject({
       streamId: STREAM,
       executionId,
-      agent: 'session-search',
+      agent: 'session-label',
       category: AgentCategory.ToolUse,
+      kind: 'agent',
     });
 
     const goalPausedOnly = await new StreamSnapshotStore().read(OTHER_STREAM);

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -191,6 +191,7 @@ export async function launchAgentCliSession(
       childStream = createChildStream(executionId, params.parentStreamId, {
         streamPrefix: params.streamPrefix,
         streamCategory: AgentCategory.ToolUse,
+        runKind: 'agent',
         agentName: params.agentName,
         description: params.description,
         config: params.config,

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -278,6 +278,7 @@ export class BashTool extends defineTool({
         childStream = createChildStream(executionId, parentStreamId, {
           streamPrefix: 'bash@tool',
           streamCategory: AgentCategory.ToolUse,
+          runKind: 'process',
           agentName: 'bash',
           description: command,
           config: syntheticConfig,

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -15,7 +15,12 @@ import {
 } from '@agent/runtime/SessionHandle';
 import { classifyAgentError } from '@common/errors';
 import { RUN_OUTCOME, STREAM_PHASE, buildRunDescriptor } from '@shared/schemas';
-import type { ExecutionId, StreamTabId, StorageKey } from '@shared/schemas';
+import type {
+  ExecutionId,
+  RunKind,
+  StreamTabId,
+  StorageKey,
+} from '@shared/schemas';
 import { deriveRunOutcome } from '@shared/streams/streamStatus';
 import { createRunTrace } from '@transcript';
 import { formatDuration } from '@utils/core';
@@ -26,6 +31,7 @@ interface CreateChildStreamOptions {
   runtimeHost: AgentRuntimeHost;
   streamPrefix: string;
   streamCategory: AgentCategory;
+  runKind: RunKind;
   agentName: string;
   description: string;
   config: AgentConfig;
@@ -126,8 +132,9 @@ export function createChildStream(
     descriptor: buildRunDescriptor({
       streamId: childStreamId,
       executionId,
-      agent: options.config.agent,
-      category: options.config.agentCategory,
+      agent: options.agentName,
+      category: options.streamCategory,
+      kind: options.runKind,
     }),
   });
   runTrace.trace.emit({
@@ -153,7 +160,7 @@ export function createChildStream(
     parentStreamId,
     childStreamId,
     options.agentName,
-    'toolUse',
+    options.streamCategory,
     runtimeHost,
     runTrace.trace,
   );

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -179,6 +179,7 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
           {
             streamPrefix: STREAM_PREFIX,
             streamCategory: AgentCategory.Workflow,
+            runKind: 'workflowScript',
             agentName: meta.name,
             description: meta.description,
             config: runConfig,

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -1499,11 +1499,10 @@ export class StreamSnapshotStore {
   setRunDescriptor(descriptor: RunDescriptor): void {
     const stream = descriptor.streamId;
     const record = this.getOrCreateRecord(stream);
-    const identity = record.runDescriptor ?? descriptor;
-    record.runDescriptor = identity;
+    record.runDescriptor = descriptor;
     this.queueMetaPatch(stream, {
-      executionId: identity.executionId,
-      runDescriptor: identity,
+      executionId: descriptor.executionId,
+      runDescriptor: descriptor,
     });
   }
 

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -61,6 +61,7 @@ import {
   type WorkPlanSnapshot,
 } from '@shared/schemas';
 import { getCleanAgentName } from '@shared/schemas/agent';
+import { isProcessAgent } from '@shared/streams/agentKind';
 import { mapToRecord, normalizeFilePath } from '@utils/core';
 import { StorageFS } from '@utils/files';
 import { isDirectory } from '@utils/files/fsEntryType';
@@ -218,6 +219,7 @@ function descriptorFromConfig(
     executionId,
     agent: config.agent,
     category: config.agentCategory,
+    kind: isProcessAgent(config.agent) ? 'process' : 'agent',
   });
 }
 
@@ -437,6 +439,9 @@ export class StreamSnapshotStore {
         const { event } = sessionEvent;
 
         switch (event.type) {
+          case 'run.start':
+            this.setRunDescriptor(event.descriptor);
+            return;
           case 'run.config':
             this.setTaskState(
               event.streamId,
@@ -470,6 +475,7 @@ export class StreamSnapshotStore {
       {
         scope: 'run',
         types: [
+          'run.start',
           'run.config',
           'usage',
           'updateTodos',
@@ -1473,13 +1479,31 @@ export class StreamSnapshotStore {
     const config = taskState.agentConfig;
     const record = this.getOrCreateRecord(stream);
     record.runConfig = config;
-    const descriptor = executionId
-      ? descriptorFromConfig(stream, executionId, config)
-      : undefined;
+    const descriptor =
+      record.runDescriptor ??
+      (executionId
+        ? descriptorFromConfig(stream, executionId, config)
+        : undefined);
     if (descriptor) record.runDescriptor = descriptor;
     this.queueMetaPatch(stream, {
       ...(executionId ? { executionId } : {}),
       ...(descriptor ? { runDescriptor: descriptor } : {}),
+    });
+  }
+
+  /**
+   * Persist the immutable identity emitted at run start. Later `run.config`
+   * facts may change model or instruction, but cannot rename or recategorize
+   * the stream.
+   */
+  setRunDescriptor(descriptor: RunDescriptor): void {
+    const stream = descriptor.streamId;
+    const record = this.getOrCreateRecord(stream);
+    const identity = record.runDescriptor ?? descriptor;
+    record.runDescriptor = identity;
+    this.queueMetaPatch(stream, {
+      executionId: identity.executionId,
+      runDescriptor: identity,
     });
   }
 


### PR DESCRIPTION
## Summary

- represent deterministic workflow-script containers as a distinct `workflowScript` stream kind
- preserve immutable run identity separately from mutable worker configuration
- display the workflow script's `meta.name` and a dedicated workflow-script icon
- omit model metadata from the container while retaining model information on its child agents
- preserve the correct workflow category on the execution handle

## Root cause

A detached workflow script used the selected default workflow agent to construct its persisted `AgentConfig`. Progress metadata then treated that mutable configuration as the stream's identity, so a script whose default worker was `generic` appeared as a `generic` workflow agent and advertised the parent's model. The run descriptor was described as immutable, but `run.config` facts reconstructed and replaced it.

This change makes the run descriptor the source of immutable stream identity and keeps `AgentConfig` responsible only for mutable execution details such as model, instruction, and input file. The stream schema now distinguishes LLM agents, operating-system processes, and deterministic workflow-script containers.

## User impact

Workflow-script sessions now show the script name and type in the session tree. They no longer look like the default worker agent or claim to run the worker's model. Child workflow agents continue to show their own names and models.

## Validation

- `corepack pnpm run typecheck`
- `corepack pnpm run compile:fast`
- `corepack pnpm run lint`
- `corepack pnpm test` — 7,407 passed, 4 skipped
- focused persistence, progress, child-stream, and Lit component tests — 141 passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches run identity, snapshot persistence, and progress metadata across hosts; behavior change is user-visible but scoped to stream labeling and descriptor precedence, with broad test coverage.
> 
> **Overview**
> **Workflow-script orchestration** is modeled as its own stream kind (`workflowScript`) instead of looking like the default worker agent.
> 
> Run descriptors now carry an explicit **`kind`** (`agent` | `process` | `workflowScript`). Child streams set it at creation; **`run.start`** is treated as a durable run fact and **overrides** identity that `run.config` might have synthesized from mutable `AgentConfig`. Progress metadata and **`StreamTabInfo`** branch on `kind`: workflow containers expose **`workflowName`**, omit **`agent`**/model fields, and use a dedicated tab icon; worker agents and bash processes are unchanged.
> 
> UI surfaces updated include stream tabs (extension), command palette meta (desktop), and subagent execution labels (workflow scripts included). **`WorkflowScriptTool`** and **`createChildStream`** emit script **`agentName`** on the descriptor while worker config stays separate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6efdbb6969b22f80714b1693305747a7a9c7edea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->