### PR TITLE
feat: bind files to workflow scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to this project will be documented in this file.
   built-in Orchestrator supports planned fan-out, pipeline, and join runs.
   Workflow Script is an opt-in integration in the Tools dashboard and CLI
   `/tools`; disabling it applies to every agent.
+- **Workflow scripts can start from selected files** — launch files are
+  separated into editable inputs, read-only context, and media, then exposed
+  to the script as immutable launch context for its workflow-agent calls.
 
 #### Bug Fixes
 

--- a/packages/extension/resources/docs/agent-creation/tool_catalog.md
+++ b/packages/extension/resources/docs/agent-creation/tool_catalog.md
@@ -60,12 +60,16 @@ recommended groups at the bottom are a good starting point.
   asynchronously via the follow-up queue.
 - `delegate_workflow_script` — advanced opt-in tool for a durable sequence of
   workflow-agent calls with predetermined branching and fan-out. Pass a default
-  `agent`, the complete `script`, and optional JSON `args`. The script begins
-  with `export const meta = { name, description }` and can use `agent`, `phase`,
-  `log`, `parallel`, `pipeline`, and `concat`. `agent(prompt, { schema })`, where
-  `schema` is a JSON Schema object, runs a tool-use agent (name one via
-  `agentName`) that finishes by calling `submit_output`; the call resolves to an
-  envelope whose `.structured` is the validated object. Present in the
+  `agent`, the complete `script`, and optional JSON `args` and role-separated
+  `files`. The selected workspace files are fixed for the run and available
+  through the immutable `files.inputFiles`, `files.contextFiles`, and
+  `files.mediaFiles` arrays. The script begins with
+  `export const meta = { name, description }` and can use `agent`, `phase`,
+  `log`, `parallel`, `pipeline`, and `concat`. Workflow-agent calls accept the
+  same three file roles. `agent(prompt, { agentName, schema })` instead runs a
+  named tool-use agent with no file options; it finishes by calling
+  `submit_output`, and the call resolves to an envelope whose `.structured` is
+  the validated object. Present in the
   built-in `orchestrator` agent's tool list, but gated by the "Workflow
   Script" switch in Settings → Tools (off by default for new installs), which
   disables the tool for every agent regardless of its configured tool list.

--- a/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -259,7 +259,7 @@ export class ProposalRequestPanel extends BaseApprovalPanel<'proposal'> {
 
   private renderProposalFileList(
     label: string,
-    files: string[],
+    files: readonly string[],
     clickable: boolean,
   ): TemplateResult | typeof nothing {
     if (files.length === 0) return nothing;

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
@@ -40,7 +40,11 @@ import {
   CodexMcpToolOutputSchema,
   type CodexMcpToolOutput,
 } from '@shared/schemas/codex';
-import { getProposalFileGroups } from '@shared/schemas/proposalFields';
+import {
+  getProposalFileGroups,
+  type ProposalFileGroup,
+} from '@shared/schemas/proposalFields';
+import { WorkflowScriptFilesSchema } from '@shared/schemas/workflowScriptFiles';
 import type { ExecutionsToolInput } from '@tools/ExecutionsTool';
 import type { EditInput } from '@tools/EditTool';
 import type { TextEditorInput } from '@tools/TextEditorTool';
@@ -69,6 +73,20 @@ export type ToolSectionContext = {
   parsedOutput: unknown;
   outputText: string;
 };
+
+function buildFileGroupsSection(
+  fileGroups: readonly ProposalFileGroup[],
+): TemplateResult | undefined {
+  if (fileGroups.length === 0) return undefined;
+  // prettier-ignore
+  const fileItems = html`${fileGroups.flatMap((group) => group.files.map((file) => html`<li class="detail-item"><wa-icon library=${TEXRA_ICON_LIBRARY} name="file" aria-hidden="true"></wa-icon> <span class="${group.clickable ? 'file-link clickable-link' : 'file-label'}" data-file=${ifDefined(group.clickable ? file : undefined)} role=${ifDefined(group.clickable ? 'button' : undefined)} tabindex=${ifDefined(group.clickable ? '0' : undefined)}>${file}</span> <span class="file-source">(${group.label})</span></li>`))}`;
+  return buildToolUseSection(
+    'Files:',
+    html`<ul class="detail-list">
+      ${fileItems}
+    </ul>`,
+  );
+}
 
 function buildEditDiffInputSections(ctx: ToolSectionContext): TemplateResult[] {
   const { input, filePath, parsedOutput } = ctx;
@@ -312,12 +330,8 @@ function buildDelegationSections(ctx: ToolSectionContext): TemplateResult[] {
   }
 
   const fileGroups = getProposalFileGroups(delegateInput);
-  if (fileGroups.length > 0) {
-    // prettier-ignore
-    const fileItems = html`${fileGroups.flatMap((g) => g.files.map((f) => html`<li class="detail-item"><wa-icon library=${TEXRA_ICON_LIBRARY} name="file" aria-hidden="true"></wa-icon> <span class="${g.clickable ? 'file-link clickable-link' : 'file-label'}" data-file=${ifDefined(g.clickable ? f : undefined)} role=${ifDefined(g.clickable ? 'button' : undefined)} tabindex=${ifDefined(g.clickable ? '0' : undefined)}>${f}</span> <span class="file-source">(${g.label})</span></li>`))}`;
-    // prettier-ignore
-    sections.push(buildToolUseSection('Files:', html`<ul class="detail-list">${fileItems}</ul>`));
-  }
+  const filesSection = buildFileGroupsSection(fileGroups);
+  if (filesSection !== undefined) sections.push(filesSection);
   return sections;
 }
 
@@ -357,6 +371,12 @@ function buildWorkflowScriptSections(
       }),
     );
   }
+
+  const files = WorkflowScriptFilesSchema.safeParse(input.files);
+  const filesSection = files.success
+    ? buildFileGroupsSection(getProposalFileGroups(files.data))
+    : undefined;
+  if (filesSection !== undefined) sections.push(filesSection);
 
   const rawResult = isObject(parsedOutput) ? parsedOutput.output : parsedOutput;
   const { text: resultText, language: resultLanguage } =

--- a/src/agent/workflowScript/README.md
+++ b/src/agent/workflowScript/README.md
@@ -39,6 +39,10 @@ return concat(sections, { separator: '\n\n' });
 - `concat(parts, {separator}?)` — zero-token fan-in for text parts;
   drops `null`/`undefined` (failed stages) and empty strings.
 - `log(msg)` / `phase(title)` / `args` — progress + parameterization.
+- `files` — immutable, role-separated workspace files bound to the run:
+  `files.inputFiles` are editable, while `files.contextFiles` and
+  `files.mediaFiles` are read-only. Scripts choose the appropriate subset for
+  each workflow-agent call.
 
 ## Boundaries (deliberate for the prototype)
 

--- a/src/agent/workflowScript/index.ts
+++ b/src/agent/workflowScript/index.ts
@@ -12,8 +12,10 @@ export { WORKFLOW_SKIPPED_RESULT } from './types';
 export type {
   WorkflowAgentInvocation,
   WorkflowAgentRunner,
+  WorkflowEditAgentCallOptions,
   WorkflowJournalEntry,
   WorkflowScriptControl,
   WorkflowScriptEvent,
   WorkflowScriptRunResult,
+  WorkflowStructuredAgentCallOptions,
 } from './types';

--- a/src/agent/workflowScript/index.ts
+++ b/src/agent/workflowScript/index.ts
@@ -12,10 +12,8 @@ export { WORKFLOW_SKIPPED_RESULT } from './types';
 export type {
   WorkflowAgentInvocation,
   WorkflowAgentRunner,
-  WorkflowEditAgentCallOptions,
   WorkflowJournalEntry,
   WorkflowScriptControl,
   WorkflowScriptEvent,
   WorkflowScriptRunResult,
-  WorkflowStructuredAgentCallOptions,
 } from './types';

--- a/src/agent/workflowScript/parseScript.ts
+++ b/src/agent/workflowScript/parseScript.ts
@@ -114,7 +114,7 @@ export function parseWorkflowScript(source: string): ParsedWorkflowScript {
 
   if (rejectsModuleLoading(program)) {
     throw new WorkflowScriptParseError(
-      'Workflow scripts cannot import modules; use only the injected primitives (agent, parallel, pipeline, concat, log, phase, args).',
+      'Workflow scripts cannot import modules; use only the injected primitives (agent, parallel, pipeline, concat, log, phase, args, files).',
     );
   }
 

--- a/src/agent/workflowScript/persistence.ts
+++ b/src/agent/workflowScript/persistence.ts
@@ -3,6 +3,10 @@ import { z } from 'zod';
 
 // Local imports - storage
 import type { ExecutionKVStore } from '@agent/storage/ExecutionKVStore';
+import {
+  WorkflowScriptFilesSchema,
+  type WorkflowScriptFiles,
+} from '@shared/schemas/workflowScriptFiles';
 import { KeyedMutex } from '@utils/core';
 
 // Local imports - workflow script
@@ -34,6 +38,7 @@ const WorkflowScriptCheckpointSchema = z
     schemaVersion: z.literal(WORKFLOW_SCRIPT_CHECKPOINT_SCHEMA_VERSION),
     script: z.string().min(1),
     args: PersistedJsonValueSchema,
+    files: WorkflowScriptFilesSchema.prefault({}),
     journal: z.array(PersistedWorkflowJournalEntrySchema),
   })
   .superRefine(({ journal }, context) => {
@@ -61,6 +66,7 @@ type PersistedWorkflowJournalEntry = z.infer<
 export interface WorkflowScriptCheckpoint {
   readonly script: string;
   readonly args: unknown;
+  readonly files: WorkflowScriptFiles;
   readonly journal: WorkflowJournalEntry[];
 }
 
@@ -153,6 +159,7 @@ export async function readWorkflowScriptCheckpoint(
   return {
     script: checkpoint.script,
     args: decodeJsonValue(checkpoint.args),
+    files: checkpoint.files,
     journal: orderedJournal(checkpoint.journal.map(decodeJournalEntry)),
   };
 }
@@ -170,6 +177,7 @@ export async function writeWorkflowScriptCheckpoint(
       schemaVersion: WORKFLOW_SCRIPT_CHECKPOINT_SCHEMA_VERSION,
       script: checkpoint.script,
       args: encodeJsonValue(checkpoint.args),
+      files: checkpoint.files,
       journal: orderedJournal(checkpoint.journal).map(encodeJournalEntry),
     });
   } catch (error) {
@@ -204,6 +212,7 @@ async function runPersistedWorkflowScriptLocked(
     checkpointId: _checkpointId,
     script: requestedScript,
     args: requestedArgs,
+    files: requestedFiles,
     ...runOptions
   } = options;
   const prior = await readWorkflowScriptCheckpoint(store, checkpointId);
@@ -234,6 +243,10 @@ async function runPersistedWorkflowScriptLocked(
     Object.hasOwn(options, 'args') || prior === null
       ? decodeJsonValue(encodedRequestedArgs)
       : prior.args;
+  const files =
+    Object.hasOwn(options, 'files') || prior === null
+      ? WorkflowScriptFilesSchema.parse(requestedFiles ?? {})
+      : prior.files;
 
   const journalByIndex = new Map(
     (prior?.journal ?? []).map((entry) => [entry.index, entry]),
@@ -241,6 +254,7 @@ async function runPersistedWorkflowScriptLocked(
   await writeWorkflowScriptCheckpoint(store, checkpointId, {
     script,
     args,
+    files,
     journal: orderedJournal(journalByIndex.values()),
   });
 
@@ -254,6 +268,7 @@ async function runPersistedWorkflowScriptLocked(
       writeWorkflowScriptCheckpoint(store, checkpointId, {
         script,
         args,
+        files,
         journal: snapshot,
       }),
     );
@@ -265,6 +280,7 @@ async function runPersistedWorkflowScriptLocked(
       ...runOptions,
       script,
       args,
+      files,
       journal: prior?.journal,
       onJournalEntry: persistEntry,
     });
@@ -273,6 +289,7 @@ async function runPersistedWorkflowScriptLocked(
     await writeWorkflowScriptCheckpoint(store, checkpointId, {
       script,
       args,
+      files,
       journal: result.journal,
     });
     return result;

--- a/src/agent/workflowScript/runWorkflowScript.ts
+++ b/src/agent/workflowScript/runWorkflowScript.ts
@@ -311,7 +311,14 @@ export async function runWorkflowScript(
         'agent(prompt, options?) requires a non-empty string prompt.',
       );
     }
-    const callOptions = normalizeAgentOptions(rawOptions, currentPhase);
+    let callOptions: WorkflowAgentCallOptions;
+    try {
+      callOptions = normalizeAgentOptions(rawOptions, currentPhase);
+    } catch (error) {
+      throw rememberFatalRunError(
+        new WorkflowRunAbortError(toErrorMessage(error), { cause: error }),
+      );
+    }
     const phaseContext = phaseContextFor(callOptions.phase);
     const index = callCounter;
     callCounter += 1;

--- a/src/agent/workflowScript/runWorkflowScript.ts
+++ b/src/agent/workflowScript/runWorkflowScript.ts
@@ -2,6 +2,10 @@ import { createHash } from 'node:crypto';
 
 import stableStringify from 'fast-json-stable-stringify';
 import PQueue from 'p-queue';
+import {
+  WorkflowScriptFilesSchema,
+  type WorkflowScriptFiles,
+} from '@shared/schemas/workflowScriptFiles';
 import { normalizeStructuredOutputSchema } from '@tools/structuredOutput';
 import { isNonEmptyString } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -506,6 +510,8 @@ export async function runWorkflowScript(
   }
 
   const argsJson = serializeBridgeValue(options.args, 'Workflow args');
+  const files = WorkflowScriptFilesSchema.parse(options.files ?? {});
+  const filesJson = stableStringify(files);
   const abortFromParent = () => runAbort.abort(options.signal?.reason);
   options.signal?.addEventListener('abort', abortFromParent, { once: true });
   if (options.signal?.aborted) abortFromParent();
@@ -547,6 +553,7 @@ export async function runWorkflowScript(
           },
         },
         argsJson,
+        filesJson,
         realmPreludes: [ORCHESTRATION_PRELUDE],
       },
       {
@@ -639,7 +646,12 @@ function normalizeAgentOptions(
   // cheap defensive copy that also keeps this function safe if it is ever
   // called with a value that did not come through the bridge.
   const source = structuredClone(raw ?? {}) as Record<string, unknown>;
-  const options: WorkflowAgentCallOptions = {};
+  const common: {
+    id?: string;
+    label?: string;
+    phase?: string;
+    agentName?: string;
+  } = {};
   for (const field of ['id', 'label', 'phase', 'agentName'] as const) {
     const value = source[field];
     if (value === undefined) continue;
@@ -647,22 +659,25 @@ function normalizeAgentOptions(
       const requirement = field === 'id' ? 'a non-empty string' : 'a string';
       throw new Error(`agent() option "${field}" must be ${requirement}.`);
     }
-    options[field] = field === 'id' ? value.trim() : value;
+    common[field] = field === 'id' ? value.trim() : value;
   }
+  common.phase ??= currentPhase;
+
+  let schema: Record<string, unknown> | undefined;
   if (Object.hasOwn(source, 'schema')) {
-    const schema = source.schema;
+    const rawSchema = source.schema;
     if (
-      schema === null ||
-      typeof schema !== 'object' ||
-      Array.isArray(schema)
+      rawSchema === null ||
+      typeof rawSchema !== 'object' ||
+      Array.isArray(rawSchema)
     ) {
       throw new Error(
         'agent() option "schema" must be a plain JSON Schema object.',
       );
     }
     try {
-      options.schema = normalizeStructuredOutputSchema(
-        schema as Record<string, unknown>,
+      schema = normalizeStructuredOutputSchema(
+        rawSchema as Record<string, unknown>,
       ).jsonSchema;
     } catch (error) {
       throw new Error(
@@ -670,17 +685,52 @@ function normalizeAgentOptions(
       );
     }
   }
-  if (source.inputFiles !== undefined) {
-    if (
-      !Array.isArray(source.inputFiles) ||
-      source.inputFiles.some((file) => !isNonEmptyString(file))
-    ) {
+
+  const requestedFiles = {
+    ...(source.inputFiles !== undefined && {
+      inputFiles: source.inputFiles,
+    }),
+    ...(source.contextFiles !== undefined && {
+      contextFiles: source.contextFiles,
+    }),
+    ...(source.mediaFiles !== undefined && {
+      mediaFiles: source.mediaFiles,
+    }),
+  };
+  let files: WorkflowScriptFiles;
+  try {
+    files = WorkflowScriptFilesSchema.parse(requestedFiles);
+  } catch (error) {
+    throw new Error(
+      `agent() options "inputFiles", "contextFiles", and "mediaFiles" must be arrays of non-empty strings: ${toErrorMessage(error)}`,
+    );
+  }
+  const hasFileOptions = Object.keys(requestedFiles).length > 0;
+
+  if (schema !== undefined) {
+    if (hasFileOptions) {
       throw new Error(
-        'agent() option "inputFiles" must be an array of non-empty strings.',
+        'agent() structured-output calls cannot use file options; inputFiles, contextFiles, and mediaFiles belong to workflow-agent calls.',
       );
     }
-    options.inputFiles = [...(source.inputFiles as string[])];
+    if (common.agentName === undefined) {
+      throw new Error(
+        'agent() structured-output calls must name a tool-use agent with "agentName".',
+      );
+    }
+    return {
+      ...common,
+      agentName: common.agentName,
+      schema,
+    };
   }
-  options.phase ??= currentPhase;
-  return options;
+
+  return {
+    ...common,
+    ...(source.inputFiles !== undefined && { inputFiles: files.inputFiles }),
+    ...(source.contextFiles !== undefined && {
+      contextFiles: files.contextFiles,
+    }),
+    ...(source.mediaFiles !== undefined && { mediaFiles: files.mediaFiles }),
+  };
 }

--- a/src/agent/workflowScript/sandbox.ts
+++ b/src/agent/workflowScript/sandbox.ts
@@ -27,6 +27,8 @@ export interface SandboxHostBridge {
   syncFns: Record<string, (args: unknown[]) => string | undefined>;
   /** JSON payload for the `args` global; undefined installs `args` as undefined. */
   argsJson: string | undefined;
+  /** JSON payload for the immutable, role-separated `files` global. */
+  filesJson: string;
   /** Trusted realm-side orchestration primitives installed before the body. */
   realmPreludes?: string[];
 }
@@ -207,6 +209,9 @@ const BRIDGE_PRELUDE = `
     });
   }
   define('args', config.argsJson === undefined ? undefined : parseJson(config.argsJson));
+  const files = parseJson(config.filesJson);
+  Object.values(files).forEach(Object.freeze);
+  define('files', Object.freeze(files));
 
   let delivered = false;
   return function (value, isError) {
@@ -540,6 +545,7 @@ function installHostBridge(
       asyncNames: Object.keys(bridge.asyncFns),
       syncNames: Object.keys(bridge.syncFns),
       argsJson: bridge.argsJson,
+      filesJson: bridge.filesJson,
     }),
   );
   setGlobal(context, '__wfBridgeConfig', config);

--- a/src/agent/workflowScript/types.ts
+++ b/src/agent/workflowScript/types.ts
@@ -46,7 +46,7 @@ interface WorkflowAgentFileOptions {
 }
 
 /** A script call to a file-editing workflow agent. */
-export interface WorkflowEditAgentCallOptions
+interface WorkflowEditAgentCallOptions
   extends WorkflowAgentCallBaseOptions, WorkflowAgentFileOptions {
   /** Named TeXRA agent to run; defaults to the host runner's choice. */
   agentName?: string;
@@ -54,7 +54,7 @@ export interface WorkflowEditAgentCallOptions
 }
 
 /** A script call to a tool-use agent that returns a structured value. */
-export interface WorkflowStructuredAgentCallOptions extends WorkflowAgentCallBaseOptions {
+interface WorkflowStructuredAgentCallOptions extends WorkflowAgentCallBaseOptions {
   /** Structured calls must name a tool-use agent explicitly. */
   agentName: string;
   inputFiles?: never;

--- a/src/agent/workflowScript/types.ts
+++ b/src/agent/workflowScript/types.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import type { WorkflowScriptFiles } from '@shared/schemas/workflowScriptFiles';
+
 const WorkflowScriptPhaseSchema = z.object({
   title: z.string().min(1),
   detail: z.string().optional(),
@@ -25,26 +27,51 @@ export const WorkflowScriptMetaSchema = z.object({
 
 export type WorkflowScriptMeta = z.infer<typeof WorkflowScriptMetaSchema>;
 
-/** Options accepted by the script-facing `agent()` primitive. */
-export interface WorkflowAgentCallOptions {
+interface WorkflowAgentCallBaseOptions {
   /** Stable identity when otherwise-identical calls occur more than once. */
   id?: string;
   /** Display label for progress UIs; defaults to a prompt excerpt. */
   label?: string;
   /** Progress group; defaults to the `phase()` active at call time. */
   phase?: string;
+}
+
+interface WorkflowAgentFileOptions {
+  /** Workspace or run-storage files the workflow agent may rewrite. */
+  inputFiles?: WorkflowScriptFiles['inputFiles'];
+  /** Read-only supporting documents for the workflow agent. */
+  contextFiles?: WorkflowScriptFiles['contextFiles'];
+  /** Read-only visual or audio inputs for the workflow agent. */
+  mediaFiles?: WorkflowScriptFiles['mediaFiles'];
+}
+
+/** A script call to a file-editing workflow agent. */
+export interface WorkflowEditAgentCallOptions
+  extends WorkflowAgentCallBaseOptions, WorkflowAgentFileOptions {
   /** Named TeXRA agent to run; defaults to the host runner's choice. */
   agentName?: string;
-  /** Workspace or run-storage files bound as the child's input files. */
-  inputFiles?: string[];
+  schema?: never;
+}
+
+/** A script call to a tool-use agent that returns a structured value. */
+export interface WorkflowStructuredAgentCallOptions extends WorkflowAgentCallBaseOptions {
+  /** Structured calls must name a tool-use agent explicitly. */
+  agentName: string;
+  inputFiles?: never;
+  contextFiles?: never;
+  mediaFiles?: never;
   /**
    * Plain JSON Schema object describing the structured result the call must
    * produce. Its presence routes the call to a tool-use agent that finishes by
    * submitting a validated value, surfaced on the result's `.structured`.
    * Participates in the journal key, so resume stays correct.
    */
-  schema?: Record<string, unknown>;
+  schema: Record<string, unknown>;
 }
+
+/** Options accepted by the script-facing `agent()` primitive. */
+export type WorkflowAgentCallOptions =
+  WorkflowEditAgentCallOptions | WorkflowStructuredAgentCallOptions;
 
 export interface WorkflowAgentInvocation {
   /** 0-based call sequence number; also the journal key position. */
@@ -155,6 +182,8 @@ export interface WorkflowScriptRunOptions {
   script: string;
   /** Exposed verbatim to the script as the global `args`. */
   args?: unknown;
+  /** Exposed to the script as the immutable global `files` object. */
+  files?: WorkflowScriptFiles;
   runAgent: WorkflowAgentRunner;
   /** Parent cancellation signal; aborts guest execution and active agents. */
   signal?: AbortSignal;

--- a/src/shared/schemas/proposalFields.ts
+++ b/src/shared/schemas/proposalFields.ts
@@ -26,16 +26,18 @@ export const WorkflowSpecificFieldsSchema = FileFieldsSchema.extend({
   toolConfig: ToolConfigSchema,
 });
 
-const ProposalFileFieldsSchema = FileFieldsSchema.extend({
-  memories: z.array(z.string()),
-});
-
 /** File fields shape used by all three rendering sites (toolFormatters, RequestPanels, PermissionCard). */
-type FileFields = Partial<z.infer<typeof ProposalFileFieldsSchema>>;
+interface FileFields {
+  readonly inputFiles?: readonly string[];
+  readonly contextFiles?: readonly string[];
+  readonly mediaFiles?: readonly string[];
+  readonly outputFiles?: readonly string[];
+  readonly memories?: readonly string[];
+}
 
 export interface ProposalFileGroup {
   label: string;
-  files: string[];
+  files: readonly string[];
   /** When false, files are virtual paths that should not be opened via workspace file commands. */
   clickable: boolean;
 }

--- a/src/shared/schemas/workflowScriptFiles.ts
+++ b/src/shared/schemas/workflowScriptFiles.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+const WorkflowScriptFileListSchema = z.array(z.string().min(1)).readonly();
+
+/** Files bound to a workflow-script run, separated by workflow-agent role. */
+export const WorkflowScriptFilesSchema = z
+  .strictObject({
+    inputFiles: WorkflowScriptFileListSchema.prefault([]),
+    contextFiles: WorkflowScriptFileListSchema.prefault([]),
+    mediaFiles: WorkflowScriptFileListSchema.prefault([]),
+  })
+  .readonly();
+
+export type WorkflowScriptFiles = z.infer<typeof WorkflowScriptFilesSchema>;

--- a/src/shared/schemas/workflowScriptFiles.ts
+++ b/src/shared/schemas/workflowScriptFiles.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
 
-const WorkflowScriptFileListSchema = z.array(z.string().min(1)).readonly();
+const WorkflowScriptFileListSchema = z
+  .array(z.string().trim().min(1))
+  .readonly();
 
 /** Files bound to a workflow-script run, separated by workflow-agent role. */
 export const WorkflowScriptFilesSchema = z

--- a/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   resolveChildRunOutput: vi.fn(),
   runStorageLocationFromAnyAbsolutePath: vi.fn(),
   assertWorkflowFilesExist: vi.fn(),
+  rejectOversizedBibAttachments: vi.fn(),
   configureDelegatedChildApprovals: vi.fn(),
 }));
 
@@ -61,6 +62,10 @@ vi.mock('@utils/files/taskRunStorage', () => ({
 
 vi.mock('@tools/delegation/workflowFileValidation', () => ({
   assertWorkflowFilesExist: mocks.assertWorkflowFilesExist,
+}));
+
+vi.mock('@tools/delegation/inputFields', () => ({
+  rejectOversizedBibAttachments: mocks.rejectOversizedBibAttachments,
 }));
 
 const parentExecutionId = 'aaaaaa111111' as ExecutionId;
@@ -149,6 +154,7 @@ describe('createWorkflowScriptAgentRunner', () => {
     }));
     mocks.selectAvailableDelegationModel.mockResolvedValue('child-model');
     mocks.assertWorkflowFilesExist.mockResolvedValue(undefined);
+    mocks.rejectOversizedBibAttachments.mockResolvedValue(null);
     mocks.runStorageLocationFromAnyAbsolutePath.mockReturnValue(undefined);
     mocks.executeStableSubagentInBand.mockImplementation(async (options) => {
       mocks.preparedOptions.push(await options.prepare());
@@ -178,6 +184,9 @@ describe('createWorkflowScriptAgentRunner', () => {
     ]);
     expect(mocks.assertWorkflowFilesExist).toHaveBeenCalledWith([
       { label: 'Context file', files: ['notes.tex'] },
+    ]);
+    expect(mocks.rejectOversizedBibAttachments).toHaveBeenCalledWith([
+      'notes.tex',
     ]);
     expect(mocks.assertWorkflowFilesExist).toHaveBeenCalledWith([
       { label: 'Media file', files: ['figure.pdf'] },
@@ -290,6 +299,36 @@ describe('createWorkflowScriptAgentRunner', () => {
     ).rejects.toMatchObject({
       name: 'WorkflowRunAbortError',
       message: expect.stringContaining(placeholder),
+    });
+    expect(mocks.preparedOptions).toHaveLength(0);
+  });
+
+  it('makes oversized bibliography context run-fatal before launch', async () => {
+    const message =
+      'large.bib is over the 100 KiB limit. Extract the needed entries first.';
+    mocks.rejectOversizedBibAttachments.mockResolvedValue({
+      status: 'error',
+      summary: 'Rejected oversized BibTeX attachment',
+      error: message,
+      diagnostics: {
+        type: 'oversized_bib_attachment',
+        path: 'large.bib',
+        sizeBytes: 102_401,
+        limitBytes: 102_400,
+      },
+    });
+    const runner = defaultRunner();
+
+    await expect(
+      runner(
+        invocation({
+          inputFiles: ['draft.tex'],
+          contextFiles: ['large.bib'],
+        }),
+      ),
+    ).rejects.toMatchObject({
+      name: 'WorkflowRunAbortError',
+      message,
     });
     expect(mocks.preparedOptions).toHaveLength(0);
   });

--- a/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptAgentRunner.vitest.ts
@@ -157,7 +157,11 @@ describe('createWorkflowScriptAgentRunner', () => {
   });
 
   it('uses delegation policy and executes a direct in-band child', async () => {
-    const call = invocation({ inputFiles: ['paper.tex'] });
+    const call = invocation({
+      inputFiles: ['paper.tex'],
+      contextFiles: ['notes.tex'],
+      mediaFiles: ['figure.pdf'],
+    });
     const runner = defaultRunner();
 
     await expect(runner(call)).resolves.toBe(result);
@@ -171,6 +175,12 @@ describe('createWorkflowScriptAgentRunner', () => {
     );
     expect(mocks.assertWorkflowFilesExist).toHaveBeenCalledWith([
       { label: 'Input file', files: ['paper.tex'] },
+    ]);
+    expect(mocks.assertWorkflowFilesExist).toHaveBeenCalledWith([
+      { label: 'Context file', files: ['notes.tex'] },
+    ]);
+    expect(mocks.assertWorkflowFilesExist).toHaveBeenCalledWith([
+      { label: 'Media file', files: ['figure.pdf'] },
     ]);
     expect(mocks.selectAvailableDelegationModel).toHaveBeenCalledWith({
       parentModel: 'parent-model',
@@ -199,6 +209,8 @@ describe('createWorkflowScriptAgentRunner', () => {
           model: 'child-model',
           instruction: 'Draft the section.',
           inputFiles: ['paper.tex'],
+          contextFiles: ['notes.tex'],
+          mediaFiles: ['figure.pdf'],
           workingDirectory: '/workspace',
           delegationAgentScope: {
             workflowAgentKeys: ['builtInWorkflow:correct'],
@@ -547,6 +559,10 @@ describe('createWorkflowScriptAgentRunner', () => {
         }),
       }),
     );
+    expect(
+      (mocks.preparedOptions[0] as { configPayload: object }).configPayload,
+    ).not.toHaveProperty('inputFiles');
+    expect(mocks.assertWorkflowFilesExist).not.toHaveBeenCalled();
   });
 
   it('exempts a schema call from the workflow empty-files guard', async () => {
@@ -575,24 +591,6 @@ describe('createWorkflowScriptAgentRunner', () => {
         configPayload: expect.objectContaining({ agentCategory: 'toolUse' }),
       }),
     );
-  });
-
-  it('aborts a schema call that omits agentName', async () => {
-    const schema = { type: 'object', additionalProperties: false };
-    const runner = defaultRunner();
-
-    // The workflow default 'correct' is a document editor with no tool-use
-    // counterpart, so a schema call must name a tool-use agent explicitly
-    // rather than silently reuse the workflow default under the tool-use
-    // category.
-    await expect(runner(invocation({ schema }))).rejects.toMatchObject({
-      name: 'WorkflowRunAbortError',
-      message: expect.stringMatching(
-        /must name a tool-use agent via agentName/,
-      ),
-    });
-    expect(mocks.preparedOptions).toHaveLength(0);
-    expect(mocks.requireVisibleAgent).not.toHaveBeenCalled();
   });
 
   it('leaves onChildActive untouched when a recovered attempt runs no live work', async () => {

--- a/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
@@ -681,6 +681,38 @@ return null`,
     ).rejects.toThrow(/must name a tool-use agent/);
   });
 
+  it('does not let fan-out swallow invalid structured-call declarations', async () => {
+    await expect(
+      runWorkflowScript({
+        script: `${META}return await parallel([
+  () => agent('x', { schema: { type: 'object' } }),
+])`,
+        runAgent: echoRunner,
+      }),
+    ).rejects.toMatchObject({
+      name: 'WorkflowRunAbortError',
+      message: expect.stringContaining('must name a tool-use agent'),
+    });
+    await expect(
+      runWorkflowScript({
+        script: `${META}return await pipeline(
+  [1],
+  () => agent('x', {
+    agentName: 'assistant',
+    schema: { type: 'object' },
+    inputFiles: ['paper.tex'],
+  }),
+)`,
+        runAgent: echoRunner,
+      }),
+    ).rejects.toMatchObject({
+      name: 'WorkflowRunAbortError',
+      message: expect.stringContaining(
+        'structured-output calls cannot use file options',
+      ),
+    });
+  });
+
   it('accepts a schema option and drops the obsolete outputSchema option', async () => {
     const seen: WorkflowAgentInvocation[] = [];
     const runner = vi.fn((invocation: WorkflowAgentInvocation) => {

--- a/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
@@ -116,6 +116,32 @@ return [a, b]`,
     expect(run.meta.name).toBe('test-flow');
   });
 
+  it('exposes launch files as immutable script context', async () => {
+    const run = await runWorkflowScript({
+      script: `${META}
+return {
+  files,
+  frozen: Object.isFrozen(files) &&
+    Object.values(files).every(Object.isFrozen),
+}`,
+      files: {
+        inputFiles: ['paper.tex'],
+        contextFiles: ['references.bib'],
+        mediaFiles: ['figure.pdf'],
+      },
+      runAgent: echoRunner,
+    });
+
+    expect(run.result).toEqual({
+      files: {
+        inputFiles: ['paper.tex'],
+        contextFiles: ['references.bib'],
+        mediaFiles: ['figure.pdf'],
+      },
+      frozen: true,
+    });
+  });
+
   it('passes a structured result from agent({ schema }) to the script and keys the journal by schema', async () => {
     const schema = {
       type: 'object',
@@ -126,7 +152,7 @@ return [a, b]`,
     const keys: string[] = [];
     const run = await runWorkflowScript({
       script: `${META}
-const withSchema = await agent('draft', { schema: args.schema })
+const withSchema = await agent('draft', { agentName: 'assistant', schema: args.schema })
 const plain = await agent('draft')
 return { structured: withSchema.structured, plain }`,
       args: { schema },
@@ -631,7 +657,28 @@ return null`,
         script: `${META}return await agent('x', { inputFiles: [''] })`,
         runAgent: echoRunner,
       }),
-    ).rejects.toThrow(/inputFiles.*array of non-empty strings/);
+    ).rejects.toThrow(/inputFiles.*arrays of non-empty strings/);
+  });
+
+  it('separates workflow file options from structured tool-use calls', async () => {
+    await expect(
+      runWorkflowScript({
+        script: `${META}return await agent('x', {
+  agentName: 'assistant',
+  schema: { type: 'object' },
+  contextFiles: ['notes.tex'],
+})`,
+        runAgent: echoRunner,
+      }),
+    ).rejects.toThrow(/structured-output calls cannot use file options/);
+    await expect(
+      runWorkflowScript({
+        script: `${META}return await agent('x', {
+  schema: { type: 'object' },
+})`,
+        runAgent: echoRunner,
+      }),
+    ).rejects.toThrow(/must name a tool-use agent/);
   });
 
   it('accepts a schema option and drops the obsolete outputSchema option', async () => {
@@ -642,7 +689,7 @@ return null`,
     });
     await runWorkflowScript({
       script: `${META}
-await agent('a', { schema: { type: 'object' } })
+await agent('a', { agentName: 'assistant', schema: { type: 'object' } })
 return await agent('b', { outputSchema: { type: 'object' } })`,
       runAgent: runner,
     });
@@ -832,7 +879,12 @@ Promise.resolve().then(() => {
   Promise.resolve().then(() => { while (true) {} })
 })
 return 'delivered'`,
-      { asyncFns: {}, syncFns: {}, argsJson: undefined },
+      {
+        asyncFns: {},
+        syncFns: {},
+        argsJson: undefined,
+        filesJson: '{"inputFiles":[],"contextFiles":[],"mediaFiles":[]}',
+      },
       {
         filename: 'delivered-before-deadline.workflow.js',
         timeoutMs: 40,
@@ -1068,6 +1120,7 @@ while (true) {}`,
           asyncFns: { agent: () => hostResult },
           syncFns: {},
           argsJson: undefined,
+          filesJson: '{"inputFiles":[],"contextFiles":[],"mediaFiles":[]}',
         },
         {
           filename: 'late-host-promise.workflow.js',
@@ -1096,6 +1149,7 @@ while (true) {}`,
           asyncFns: { agent: async () => '{' },
           syncFns: {},
           argsJson: undefined,
+          filesJson: '{"inputFiles":[],"contextFiles":[],"mediaFiles":[]}',
         },
         { filename: 'malformed-host-result.workflow.js', timeoutMs: 1_000 },
       ),
@@ -1143,7 +1197,12 @@ while (true) {}`,
     await expect(
       runScriptInSandbox(
         `return args`,
-        { asyncFns: {}, syncFns: {}, argsJson: '{' },
+        {
+          asyncFns: {},
+          syncFns: {},
+          argsJson: '{',
+          filesJson: '{"inputFiles":[],"contextFiles":[],"mediaFiles":[]}',
+        },
         { filename: 'malformed-args.workflow.js', timeoutMs: 1_000 },
       ),
     ).rejects.toThrow(/expecting property name|JSON|unexpected end/i);

--- a/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
@@ -658,6 +658,12 @@ return null`,
         runAgent: echoRunner,
       }),
     ).rejects.toThrow(/inputFiles.*arrays of non-empty strings/);
+    await expect(
+      runWorkflowScript({
+        script: `${META}return await agent('x', { inputFiles: ['   '] })`,
+        runAgent: echoRunner,
+      }),
+    ).rejects.toThrow(/inputFiles.*arrays of non-empty strings/);
   });
 
   it('separates workflow file options from structured tool-use calls', async () => {

--- a/src/test-kernel/agent/WorkflowScriptPersistence.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptPersistence.vitest.ts
@@ -94,9 +94,26 @@ describe('workflow-script persistence', () => {
       writeWorkflowScriptCheckpoint(store, 'invalid-write', {
         script,
         args: undefined,
+        files: { inputFiles: [], contextFiles: [], mediaFiles: [] },
         journal: [{ index: 0, key: '0000000000000000', result: () => 1 }],
       }),
     ).rejects.toBeInstanceOf(WorkflowScriptPersistenceError);
+  });
+
+  it('normalizes checkpoints created before launch files were persisted', async () => {
+    const store = getExecutionStore(executionId);
+    await store.write(workflowScriptCheckpointKvKey('legacy-files'), {
+      schemaVersion: 1,
+      script,
+      args: { kind: 'undefined' },
+      journal: [],
+    });
+
+    await expect(
+      readWorkflowScriptCheckpoint(store, 'legacy-files'),
+    ).resolves.toMatchObject({
+      files: { inputFiles: [], contextFiles: [], mediaFiles: [] },
+    });
   });
 
   it('accepts script drift: unchanged calls replay, changed calls re-run', async () => {
@@ -165,6 +182,7 @@ return await agent('none')`;
     await writeWorkflowScriptCheckpoint(store, ' call-with-space ', {
       script,
       args: undefined,
+      files: { inputFiles: [], contextFiles: [], mediaFiles: [] },
       journal: [],
     });
 
@@ -187,6 +205,7 @@ return await agent('none')`;
     await writeWorkflowScriptCheckpoint(store, checkpointId, {
       script,
       args: undefined,
+      files: { inputFiles: [], contextFiles: [], mediaFiles: [] },
       journal: [],
     });
     await expect(
@@ -226,6 +245,47 @@ return await agent(args.topic)`;
     await expect(
       readWorkflowScriptCheckpoint(store, 'args-restart'),
     ).resolves.toMatchObject({ args: { topic: 'geometry' } });
+  });
+
+  it('persists launch files and restores them when a restart omits them', async () => {
+    const store = getExecutionStore(executionId);
+    const inputScript = `export const meta = {
+  name: 'inputs-restart',
+  description: 'restores persisted launch files',
+}
+return files`;
+    await runPersistedWorkflowScript({
+      store,
+      checkpointId: 'inputs-restart',
+      script: inputScript,
+      files: {
+        inputFiles: ['paper.tex'],
+        contextFiles: ['notes.tex'],
+        mediaFiles: ['figure.pdf'],
+      },
+      runAgent: vi.fn(),
+    });
+
+    const restarted = await runPersistedWorkflowScript({
+      store,
+      checkpointId: 'inputs-restart',
+      runAgent: vi.fn(),
+    });
+
+    expect(restarted.result).toEqual({
+      inputFiles: ['paper.tex'],
+      contextFiles: ['notes.tex'],
+      mediaFiles: ['figure.pdf'],
+    });
+    await expect(
+      readWorkflowScriptCheckpoint(store, 'inputs-restart'),
+    ).resolves.toMatchObject({
+      files: {
+        inputFiles: ['paper.tex'],
+        contextFiles: ['notes.tex'],
+        mediaFiles: ['figure.pdf'],
+      },
+    });
   });
 
   it('adopts new arguments on resume and keeps the journal', async () => {

--- a/src/test-kernel/agent/WorkflowScriptSandboxBundle.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptSandboxBundle.vitest.ts
@@ -75,7 +75,12 @@ import { runScriptInSandbox } from ${JSON.stringify(sandboxPath)};
 async function main() {
   const result = await runScriptInSandbox(
     'return 42',
-    { asyncFns: {}, syncFns: {}, argsJson: undefined },
+    {
+      asyncFns: {},
+      syncFns: {},
+      argsJson: undefined,
+      filesJson: '{"inputFiles":[],"contextFiles":[],"mediaFiles":[]}',
+    },
     { filename: 'bundle-smoke.workflow.js', timeoutMs: 1_000 },
   );
   console.log(result);

--- a/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
+++ b/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
@@ -65,6 +65,11 @@ return { papers, question: args.question };`;
             paperIds: ['2401.00001', '2401.00002'],
             question: 'Which assumptions differ?',
           },
+          files: {
+            inputFiles: ['paper.tex'],
+            contextFiles: ['references.bib'],
+            mediaFiles: ['figure.pdf'],
+          },
         },
         output: {
           status: 'executed',
@@ -92,13 +97,19 @@ return { papers, question: args.question };`;
 
     expect(details?.open).toBe(true);
     expect(container.querySelector('wa-icon[name="list-tree"]')).not.toBeNull();
-    expect(labels).toEqual(['Agent:', 'Script:', 'Args:', 'Result:']);
+    expect(labels).toEqual(['Agent:', 'Script:', 'Args:', 'Files:', 'Result:']);
     expect(container.textContent).toContain('research');
     expect(scriptBlock?.querySelector('code')?.textContent).toBe(script);
     expect(scriptBlock?.textContent).toContain('JavaScript');
     expect(argsBlock?.querySelector('code')?.textContent).toContain(
       '"question": "Which assumptions differ?"',
     );
+    expect(container.textContent).toContain('paper.tex');
+    expect(container.textContent).toContain('references.bib');
+    expect(container.textContent).toContain('figure.pdf');
+    expect(container.textContent).toContain('(Input)');
+    expect(container.textContent).toContain('(Context)');
+    expect(container.textContent).toContain('(Media)');
     expect(container.textContent).toContain('"compared":2');
     expect(container.textContent).not.toContain('journal');
     expect(container.querySelector('.proposal-banner-setup')).toBeNull();

--- a/src/test-kernel/tools/DelegationTools.vitest.ts
+++ b/src/test-kernel/tools/DelegationTools.vitest.ts
@@ -84,10 +84,7 @@ describe('DelegationTools', () => {
   it('rejects context .bib files larger than 100KB', async () => {
     WorkspaceFS.stat = async () => stat(100 * 1024 + 1);
 
-    const result = await rejectOversizedBibAttachments({
-      ...BASE_INPUT,
-      contextFiles: ['references.bib'],
-    });
+    const result = await rejectOversizedBibAttachments(['references.bib']);
 
     assert.strictEqual(result?.status, 'error');
     assert.strictEqual(result?.summary, 'Rejected oversized BibTeX attachment');
@@ -106,10 +103,10 @@ describe('DelegationTools', () => {
   it('rejects context .bib files in the multi-list larger than 100KB', async () => {
     WorkspaceFS.stat = async () => stat(150 * 1024);
 
-    const result = await rejectOversizedBibAttachments({
-      ...BASE_INPUT,
-      contextFiles: ['paper.tex', 'bibliography/main.bib'],
-    });
+    const result = await rejectOversizedBibAttachments([
+      'paper.tex',
+      'bibliography/main.bib',
+    ]);
 
     assert.strictEqual(result?.status, 'error');
     assert.deepStrictEqual(result?.diagnostics, {
@@ -123,10 +120,7 @@ describe('DelegationTools', () => {
   it('allows .bib files at the 100KB limit', async () => {
     WorkspaceFS.stat = async () => stat(100 * 1024);
 
-    const result = await rejectOversizedBibAttachments({
-      ...BASE_INPUT,
-      contextFiles: ['library.bib'],
-    });
+    const result = await rejectOversizedBibAttachments(['library.bib']);
 
     assert.strictEqual(result, null);
   });
@@ -138,10 +132,10 @@ describe('DelegationTools', () => {
       return stat(500 * 1024);
     };
 
-    const result = await rejectOversizedBibAttachments({
-      ...BASE_INPUT,
-      contextFiles: ['paper.tex', 'preamble.tex'],
-    });
+    const result = await rejectOversizedBibAttachments([
+      'paper.tex',
+      'preamble.tex',
+    ]);
 
     assert.strictEqual(result, null);
     assert.strictEqual(statCalled, false);

--- a/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
@@ -241,6 +241,29 @@ describe('WorkflowScriptTool', () => {
     );
   });
 
+  it('rejects an oversized bibliography bound as workflow context', async () => {
+    await WorkspaceFS.write('large.bib', 'x'.repeat(100 * 1024 + 1));
+
+    const result = await callTool(undefined, {
+      inputFiles: ['paper.tex'],
+      contextFiles: ['large.bib'],
+      mediaFiles: [],
+    });
+
+    expect(result).toMatchObject({
+      status: 'error',
+      summary: 'Rejected oversized BibTeX attachment',
+      diagnostics: {
+        type: 'oversized_bib_attachment',
+        path: 'large.bib',
+        sizeBytes: 100 * 1024 + 1,
+        limitBytes: 100 * 1024,
+      },
+    });
+    expect(mocks.registerExecution).not.toHaveBeenCalled();
+    expect(mocks.startChildRunLoop).not.toHaveBeenCalled();
+  });
+
   it('registers checkpoint files when a resume omits files', async () => {
     const resumeScript = script.replace("name: 'tool-test'", "name: 'resume'");
     const files = {

--- a/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
@@ -3,8 +3,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { setupPlatform } from '@test/support/setupPlatform';
 import { TraceEmitter } from '@agent/trace';
-import { deriveWorkflowScriptCheckpointId } from '@agent/workflowScript';
-import { ExecutionLeaseActiveError } from '@agent/storage';
+import {
+  deriveWorkflowScriptCheckpointId,
+  writeWorkflowScriptCheckpoint,
+} from '@agent/workflowScript';
+import { ExecutionLeaseActiveError, getExecutionStore } from '@agent/storage';
 import { withToolFileInteractionContext } from '@agent/followUp/ToolFileInteractionContext';
 import type { LaunchRunContext } from '@agent/runtime/RunContext';
 import { withRunContext } from '@agent/runtime/RunContext';
@@ -234,6 +237,39 @@ describe('WorkflowScriptTool', () => {
         mediaFiles: ['figure.pdf'],
       }),
       'tool-test',
+      executionId,
+    );
+  });
+
+  it('registers checkpoint files when a resume omits files', async () => {
+    const resumeScript = script.replace("name: 'tool-test'", "name: 'resume'");
+    const files = {
+      inputFiles: ['paper.tex'],
+      contextFiles: ['references.bib'],
+      mediaFiles: ['figure.pdf'],
+    } as const satisfies WorkflowScriptFiles;
+    await writeWorkflowScriptCheckpoint(
+      getExecutionStore(executionId),
+      checkpointIdFor('resume'),
+      {
+        script: resumeScript,
+        args: undefined,
+        files,
+        journal: [],
+      },
+    );
+
+    const result = await callTool(resumeScript);
+
+    expect(result.status).toBe('executed');
+    expect(mocks.registerExecution).toHaveBeenCalledWith(
+      runExecutionIdFor('resume'),
+      expect.objectContaining({
+        inputFiles: ['paper.tex'],
+        contextFiles: ['references.bib'],
+        mediaFiles: ['figure.pdf'],
+      }),
+      'resume',
       executionId,
     );
   });

--- a/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
@@ -9,12 +9,14 @@ import { withToolFileInteractionContext } from '@agent/followUp/ToolFileInteract
 import type { LaunchRunContext } from '@agent/runtime/RunContext';
 import { withRunContext } from '@agent/runtime/RunContext';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
+import type { WorkflowScriptFiles } from '@shared/schemas/workflowScriptFiles';
 import {
   DELEGATION_AVAILABILITY_CATEGORY,
   DELEGATION_TOOL_CATEGORY,
   DELEGATION_TOOLS,
 } from '@shared/constants/delegationTools';
 import { deriveExecutionId } from '@utils/core/idHash';
+import { WorkspaceFS } from '@utils/files';
 
 setupPlatform({ storagePath: '/storage', workspacePath: '/workspace' });
 
@@ -91,7 +93,7 @@ function runExecutionIdFor(name: string): ExecutionId {
   return deriveExecutionId({ checkpointId: checkpointIdFor(name) });
 }
 
-async function callTool(overrideScript?: string) {
+async function callTool(overrideScript?: string, files?: WorkflowScriptFiles) {
   return withRunContext(parentContext(), () =>
     withToolFileInteractionContext(
       {
@@ -104,13 +106,18 @@ async function callTool(overrideScript?: string) {
         new WorkflowScriptTool().call({
           agent: 'correct',
           script: overrideScript ?? script,
+          ...(files ? { files } : {}),
         }),
     ),
   );
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   vi.clearAllMocks();
+  await WorkspaceFS.ensureDir('.');
+  await WorkspaceFS.write('paper.tex', '\\documentclass{article}');
+  await WorkspaceFS.write('references.bib', '@book{example}');
+  await WorkspaceFS.write('figure.pdf', 'pdf');
   mocks.registerExecution.mockResolvedValue(undefined);
   mocks.createChildStream.mockImplementation((runId: ExecutionId): unknown => ({
     childStreamId: `workflow-script#${runId}` as StreamTabId,
@@ -208,6 +215,27 @@ describe('WorkflowScriptTool', () => {
     });
     expect(result.output).toContain(`Execution ID: ${runExecutionId}`);
     expect(result.output).toContain('same meta.name');
+  });
+
+  it('validates and persists files bound to the workflow run', async () => {
+    const files = {
+      inputFiles: ['paper.tex'],
+      contextFiles: ['references.bib'],
+      mediaFiles: ['figure.pdf'],
+    } as const satisfies WorkflowScriptFiles;
+    const result = await callTool(undefined, files);
+
+    expect(result.status).toBe('executed');
+    expect(mocks.registerExecution).toHaveBeenCalledWith(
+      runExecutionIdFor('tool-test'),
+      expect.objectContaining({
+        inputFiles: ['paper.tex'],
+        contextFiles: ['references.bib'],
+        mediaFiles: ['figure.pdf'],
+      }),
+      'tool-test',
+      executionId,
+    );
   });
 
   it('regenerates the same run id across relaunches of one meta.name', async () => {

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -143,7 +143,9 @@ Example: agent=correct, inputFiles=["paper.tex"], extractFigures=true, instructi
       { label: 'Media file', files: input.mediaFiles },
     ]);
 
-    const oversizedBibRejection = await rejectOversizedBibAttachments(input);
+    const oversizedBibRejection = await rejectOversizedBibAttachments(
+      input.contextFiles,
+    );
     if (oversizedBibRejection) return oversizedBibRejection;
 
     // Extraction flags map to toolConfig, flowing through the proposal UI and

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -34,6 +34,7 @@ import { deriveExecutionId } from '@utils/core/idHash';
 // Local file imports
 import { createWorkflowScriptAgentRunner } from './workflowScriptAgentRunner';
 import { createWorkflowScriptStrategy } from './workflowScriptStrategy';
+import { rejectOversizedBibAttachments } from './inputFields';
 import { assertWorkflowFilesExist } from './workflowFileValidation';
 
 const WorkflowScriptToolInputSchema = z.strictObject({
@@ -130,6 +131,10 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
       { label: 'Workflow context file', files: files.contextFiles },
       { label: 'Workflow media file', files: files.mediaFiles },
     ]);
+    const oversizedBibRejection = await rejectOversizedBibAttachments(
+      files.contextFiles,
+    );
+    if (oversizedBibRejection) return oversizedBibRejection;
 
     // The run executionId is deterministic from the checkpoint identity, NOT a
     // fresh random id: a relaunch with the same meta.name regenerates the same

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -11,6 +11,7 @@ import {
 import {
   deriveWorkflowScriptCheckpointId,
   parseWorkflowScript,
+  readWorkflowScriptCheckpoint,
 } from '@agent/workflowScript';
 import { captureOwnedExecutionLease } from '@agent/storage/executionLease';
 import {
@@ -111,17 +112,24 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
     // is the durable identity; per-entry prompt/options hashes in the journal
     // keep replays honest when the script evolves.
     const { meta } = parseWorkflowScript(input.script);
-    const files = WorkflowScriptFilesSchema.parse(input.files ?? {});
-    await assertWorkflowFilesExist([
-      { label: 'Workflow input file', files: files.inputFiles },
-      { label: 'Workflow context file', files: files.contextFiles },
-      { label: 'Workflow media file', files: files.mediaFiles },
-    ]);
     const checkpointId = deriveWorkflowScriptCheckpointId({
       name: meta.name,
       defaultAgent: input.agent,
       parentExecutionId: runScope.executionId,
     });
+    const store = getExecutionStore(runScope.executionId);
+    const priorCheckpoint =
+      input.files == null
+        ? await readWorkflowScriptCheckpoint(store, checkpointId)
+        : null;
+    const files = WorkflowScriptFilesSchema.parse(
+      input.files ?? priorCheckpoint?.files ?? {},
+    );
+    await assertWorkflowFilesExist([
+      { label: 'Workflow input file', files: files.inputFiles },
+      { label: 'Workflow context file', files: files.contextFiles },
+      { label: 'Workflow media file', files: files.mediaFiles },
+    ]);
 
     // The run executionId is deterministic from the checkpoint identity, NOT a
     // fresh random id: a relaunch with the same meta.name regenerates the same
@@ -129,7 +137,6 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
     // anchor and resume still replays completed calls (#8712). The journal
     // itself stays on the orchestrator store, where the checkpoint lives.
     const runExecutionId = deriveExecutionId({ checkpointId });
-    const store = getExecutionStore(runScope.executionId);
 
     // Captured now, while the launching tool call's ALS frame is live, so the
     // detached run can still roll its cost into the parent after this call
@@ -227,7 +234,7 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
             checkpointId,
             script: input.script,
             args: input.args,
-            ...(input.files != null && { files }),
+            files,
             name: meta.name,
             workflowControls: runScope.session.workflowControls,
             createRunAgent: (hooks) =>

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -20,6 +20,7 @@ import {
 import { startChildRunLoop } from '@agent/runtime/childRunLoop';
 import { getCurrentToolContexts } from '@agent/followUp/ToolFileInteractionContext';
 import { AgentCategory, type StreamTabId } from '@shared/schemas';
+import { WorkflowScriptFilesSchema } from '@shared/schemas/workflowScriptFiles';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
 import { DEFAULT_AGENT_MODEL } from '@shared/constants/providers';
@@ -32,6 +33,7 @@ import { deriveExecutionId } from '@utils/core/idHash';
 // Local file imports
 import { createWorkflowScriptAgentRunner } from './workflowScriptAgentRunner';
 import { createWorkflowScriptStrategy } from './workflowScriptStrategy';
+import { assertWorkflowFilesExist } from './workflowFileValidation';
 
 const WorkflowScriptToolInputSchema = z.strictObject({
   agent: z
@@ -48,6 +50,9 @@ const WorkflowScriptToolInputSchema = z.strictObject({
     .json()
     .nullish()
     .describe('JSON arguments exposed to the script as the global args value.'),
+  files: WorkflowScriptFilesSchema.nullish().describe(
+    'Workspace files bound to the workflow run by role and exposed to the script as the immutable global files object.',
+  ),
 });
 
 type WorkflowScriptToolInput = z.infer<typeof WorkflowScriptToolInputSchema>;
@@ -66,19 +71,22 @@ export class WorkflowScriptTool extends defineTool({
   slow: true,
   description: `Run a deterministic JavaScript workflow that coordinates workflow agents. Workflow agents edit or produce FILES: each agent() call resolves to a result envelope { category: 'workflow', outcome, outputs, diffs, compileFailures, cost } listing the files it produced, never prose. Use this when the complete fan-out, pipeline, and join structure is known in advance and should resume safely after interruption.
 
-Script rules: start with export const meta = { name, description }; no imports or require (only the injected primitives exist: agent, phase, log, parallel, pipeline, concat, and the args global). agent(), parallel(), and pipeline() return Promises: ALWAYS await them. agent(prompt, options) options: inputFiles (REQUIRED for file-editing agents; workspace paths, or a previous call's output paths to chain stages), agentName (another visible workflow agent; defaults to this tool's agent field), id (distinguish otherwise-identical calls), label, phase. A failed call inside parallel()/pipeline() resolves to null; filter with .filter(Boolean).
+Script rules: start with export const meta = { name, description }; no imports or require (only the injected primitives exist: agent, phase, log, parallel, pipeline, concat, args, and files). The tool's files field binds workspace files to the whole run as files.inputFiles (editable), files.contextFiles (read-only documents), and files.mediaFiles (read-only visual or audio inputs). agent(), parallel(), and pipeline() return Promises: ALWAYS await them. A workflow agent() call may use inputFiles, contextFiles, and mediaFiles; inputFiles is REQUIRED unless the agent declares default outputs. Paths may name workspace files, launch files, or a previous call's outputs. It may also use agentName (another visible workflow agent; defaults to this tool's agent field), id, label, and phase. A failed call inside parallel()/pipeline() resolves to null; filter with .filter(Boolean).
 
-Structured output: agent(prompt, { schema }) where schema is a JSON Schema object runs a tool-use agent (name one via agentName; the default agent field is a file editor with no tool-use counterpart) that finishes by calling submit_output with a value matching schema. The call resolves to an envelope whose .structured is the validated object rather than edited files.
+Structured output: agent(prompt, { agentName, schema }) runs a tool-use agent that finishes by calling submit_output with a value matching the JSON Schema. Structured calls do not accept file options and must name the tool-use agent explicitly. The call resolves to an envelope whose .structured is the validated object rather than edited files.
 
 Async: this tool returns immediately with an execution ID and runs the workflow as its own detached execution. The script's return value plus the run log (phases, log() lines, per-call outcomes with cost) are delivered back as a follow-up message when the run completes. Check intermediate progress with the executions tool (path=/executions/<id>, action=wait).
 
 Example:
 export const meta = { name: 'fix-drafts', description: 'Fix typos in two drafts', timeoutMs: 1800000 }
 phase('Fix')
-const results = await parallel([
-  () => agent('Fix spelling errors only.', { inputFiles: ['draft1.tex'] }),
-  () => agent('Fix spelling errors only.', { inputFiles: ['draft2.tex'] }),
-])
+const results = await parallel(files.inputFiles.map((file) => () =>
+  agent('Fix spelling errors only.', {
+    inputFiles: [file],
+    contextFiles: files.contextFiles,
+    mediaFiles: files.mediaFiles,
+  })
+))
 const correctedFiles = results
   .filter(Boolean)
   .flatMap((result) => result.outputs.map((output) => output.absolutePath))
@@ -103,6 +111,12 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
     // is the durable identity; per-entry prompt/options hashes in the journal
     // keep replays honest when the script evolves.
     const { meta } = parseWorkflowScript(input.script);
+    const files = WorkflowScriptFilesSchema.parse(input.files ?? {});
+    await assertWorkflowFilesExist([
+      { label: 'Workflow input file', files: files.inputFiles },
+      { label: 'Workflow context file', files: files.contextFiles },
+      { label: 'Workflow media file', files: files.mediaFiles },
+    ]);
     const checkpointId = deriveWorkflowScriptCheckpointId({
       name: meta.name,
       defaultAgent: input.agent,
@@ -131,6 +145,9 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
       agentCategory: AgentCategory.Workflow,
       model: parent.model ?? DEFAULT_AGENT_MODEL,
       instruction: `Workflow script '${meta.name}'`,
+      inputFiles: [...files.inputFiles],
+      contextFiles: [...files.contextFiles],
+      mediaFiles: [...files.mediaFiles],
       ...(runScope.workingDirectory !== undefined && {
         workingDirectory: runScope.workingDirectory,
       }),
@@ -210,6 +227,7 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
             checkpointId,
             script: input.script,
             args: input.args,
+            ...(input.files != null && { files }),
             name: meta.name,
             workflowControls: runScope.session.workflowControls,
             createRunAgent: (hooks) =>

--- a/src/tools/delegation/inputFields.ts
+++ b/src/tools/delegation/inputFields.ts
@@ -188,13 +188,11 @@ function isBibFile(filePath: string): boolean {
   return hasExtension(filePath, '.bib');
 }
 
-/** Reject workflow proposals that attach oversized bibliography files. */
+/** Reject delegated workflow context that attaches oversized bibliography files. */
 export async function rejectOversizedBibAttachments(
-  input: WorkflowAgentInput,
-): Promise<ToolResult | null> {
-  const bibFiles = input.contextFiles
-    .filter(isNonEmptyString)
-    .filter(isBibFile);
+  contextFiles: readonly string[],
+): Promise<Extract<ToolResult, { status: 'error' }> | null> {
+  const bibFiles = contextFiles.filter(isNonEmptyString).filter(isBibFile);
 
   for (const bibFile of bibFiles) {
     const stats = await WorkspaceFS.stat(bibFile);

--- a/src/tools/delegation/workflowScriptAgentRunner.ts
+++ b/src/tools/delegation/workflowScriptAgentRunner.ts
@@ -19,6 +19,7 @@ import {
   executeStableSubagentInBand,
   SubagentDurabilityError,
 } from './inBandSubagentExecution';
+import { rejectOversizedBibAttachments } from './inputFields';
 import {
   requireVisibleAgent,
   selectAvailableDelegationModel,
@@ -187,6 +188,11 @@ export function createWorkflowScriptAgentRunner(
                   invocation.options.mediaFiles ?? [],
                 ),
               ]);
+            const oversizedBibRejection =
+              await rejectOversizedBibAttachments(contextFiles);
+            if (oversizedBibRejection) {
+              throw new WorkflowRunAbortError(oversizedBibRejection.error);
+            }
             // Run-storage references can disappear during recovery. Validate
             // the resolved inputs, not merely the paths supplied by the script,
             // so a stale reference cannot launch a useless empty-envelope run.

--- a/src/tools/delegation/workflowScriptAgentRunner.ts
+++ b/src/tools/delegation/workflowScriptAgentRunner.ts
@@ -25,8 +25,9 @@ import {
 } from './proposalFlow';
 import { assertWorkflowFilesExist } from './workflowFileValidation';
 
-async function resolveInvocationInputFiles(
+async function resolveInvocationFileList(
   parentExecutionId: LaunchRunContext['runScope']['executionId'],
+  label: string,
   files: readonly string[],
 ): Promise<string[]> {
   const references = files.map((file) => ({
@@ -36,9 +37,7 @@ async function resolveInvocationInputFiles(
   const workspaceFiles = references
     .filter((reference) => !reference.runStorage)
     .map((reference) => reference.file);
-  await assertWorkflowFilesExist([
-    { label: 'Input file', files: workspaceFiles },
-  ]);
+  await assertWorkflowFilesExist([{ label, files: workspaceFiles }]);
   const resolved = await Promise.all(
     references.map(async ({ file, runStorage }) => {
       if (!runStorage) return file;
@@ -48,7 +47,7 @@ async function resolveInvocationInputFiles(
       } catch (error) {
         throw new WorkflowRunAbortError(
           formatError(
-            `Workflow run-storage input could not be resolved: ${file}`,
+            `Workflow ${label} could not be resolved: ${file}`,
             error,
           ),
           { cause: error },
@@ -56,8 +55,8 @@ async function resolveInvocationInputFiles(
       }
       if (!output) {
         throw new WorkflowRunAbortError(
-          `Workflow run-storage input could not be resolved: ${file}; ` +
-            'pass options.inputFiles with files that still exist.',
+          `Workflow ${label} could not be resolved: ${file}; ` +
+            'pass a matching workflow file option whose files still exist.',
         );
       }
       return output.absolutePath;
@@ -129,81 +128,8 @@ export function createWorkflowScriptAgentRunner(
           hooks?.onChildActive?.(executionId, invocation, true);
         },
         prepare: async () => {
-          // A `schema` option routes the call to a tool-use agent that
-          // finishes by submitting a validated structured value; otherwise it
-          // is an ordinary workflow-edit agent. The category parameterizes
-          // agent resolution, model selection, and the launched config.
-          const schema = invocation.options.schema;
-          const category =
-            schema !== undefined
-              ? AgentCategory.ToolUse
-              : AgentCategory.Workflow;
-          // A schema call runs a tool-use agent, so it must name one: the
-          // workflow default (this tool's `agent` field) is a document editor
-          // with no same-named tool-use counterpart, and resolving it under the
-          // tool-use category would fail with a confusing "Unknown toolUse
-          // agent". Fail loudly here instead of silently substituting an
-          // unrelated general agent.
-          if (
-            schema !== undefined &&
-            invocation.options.agentName === undefined
-          ) {
-            throw new WorkflowRunAbortError(
-              `Structured-output agent() calls must name a tool-use agent via ` +
-                `agentName: the workflow default '${defaultAgentName}' is a ` +
-                `document editor with no tool-use counterpart.`,
-            );
-          }
-          const requestedAgent =
-            invocation.options.agentName ?? defaultAgentName;
-          const agent = requireVisibleAgent(
-            category,
-            requestedAgent,
-            runScope.delegationAgentScope ?? undefined,
-          );
-          const [model, inputFiles] = await Promise.all([
-            selectAvailableDelegationModel({
-              parentModel: parent.model,
-              agentCategory: category,
-            }),
-            resolveInvocationInputFiles(
-              run.executionId,
-              invocation.options.inputFiles ?? [],
-            ),
-          ]);
-          // Surface the resolved child model so the engine can attach it to
-          // this call's `agent:end` progress event.
-          invocation.reportModel?.(model);
-          // Run-storage references can disappear during recovery. Validate
-          // the resolved inputs, not merely the paths supplied by the script,
-          // so a stale reference cannot launch a useless empty-envelope run.
-          // Run-fatal, not a per-call failure: a plain error would resolve
-          // this agent() to null inside parallel()/pipeline(), silently
-          // filtering away the very misuse this guard exists to surface.
-          // A schema call runs a tool-use agent whose result is the submitted
-          // value, not edited files, so this workflow-edit guard is exempt.
-          if (
-            schema === undefined &&
-            inputFiles.length === 0 &&
-            (agent.defaultOutputFiles ?? []).length === 0
-          ) {
-            throw new WorkflowRunAbortError(
-              `Workflow agent '${agent.name}' edits files: pass options.inputFiles ` +
-                `with files that still exist (its result carries output files and ` +
-                `diffs, not response text).`,
-            );
-          }
-          const categoryFields =
-            schema !== undefined
-              ? { agentCategory: AgentCategory.ToolUse, outputSchema: schema }
-              : { agentCategory: AgentCategory.Workflow };
-          const configPayload: AgentConfigPayload = {
-            agent: agent.name,
-            agentSource: agent.source,
-            model,
+          const sharedConfigFields = {
             instruction: invocation.prompt,
-            inputFiles,
-            ...categoryFields,
             ...(runScope.workingDirectory !== undefined && {
               workingDirectory: runScope.workingDirectory,
             }),
@@ -211,9 +137,91 @@ export function createWorkflowScriptAgentRunner(
               delegationAgentScope: runScope.delegationAgentScope,
             }),
           };
+          let configPayload: AgentConfigPayload;
+          let agentName: string;
+
+          if (invocation.options.schema !== undefined) {
+            const agent = requireVisibleAgent(
+              AgentCategory.ToolUse,
+              invocation.options.agentName,
+              runScope.delegationAgentScope ?? undefined,
+            );
+            const model = await selectAvailableDelegationModel({
+              parentModel: parent.model,
+              agentCategory: AgentCategory.ToolUse,
+            });
+            agentName = agent.name;
+            configPayload = {
+              ...sharedConfigFields,
+              agent: agent.name,
+              agentSource: agent.source,
+              model,
+              agentCategory: AgentCategory.ToolUse,
+              outputSchema: invocation.options.schema,
+            };
+          } else {
+            const agent = requireVisibleAgent(
+              AgentCategory.Workflow,
+              invocation.options.agentName ?? defaultAgentName,
+              runScope.delegationAgentScope ?? undefined,
+            );
+            const [model, inputFiles, contextFiles, mediaFiles] =
+              await Promise.all([
+                selectAvailableDelegationModel({
+                  parentModel: parent.model,
+                  agentCategory: AgentCategory.Workflow,
+                }),
+                resolveInvocationFileList(
+                  run.executionId,
+                  'Input file',
+                  invocation.options.inputFiles ?? [],
+                ),
+                resolveInvocationFileList(
+                  run.executionId,
+                  'Context file',
+                  invocation.options.contextFiles ?? [],
+                ),
+                resolveInvocationFileList(
+                  run.executionId,
+                  'Media file',
+                  invocation.options.mediaFiles ?? [],
+                ),
+              ]);
+            // Run-storage references can disappear during recovery. Validate
+            // the resolved inputs, not merely the paths supplied by the script,
+            // so a stale reference cannot launch a useless empty-envelope run.
+            // Run-fatal, not a per-call failure: a plain error would resolve
+            // this agent() to null inside parallel()/pipeline(), silently
+            // filtering away the very misuse this guard exists to surface.
+            if (
+              inputFiles.length === 0 &&
+              (agent.defaultOutputFiles ?? []).length === 0
+            ) {
+              throw new WorkflowRunAbortError(
+                `Workflow agent '${agent.name}' edits files: pass options.inputFiles ` +
+                  `with files that still exist (its result carries output files and ` +
+                  `diffs, not response text).`,
+              );
+            }
+            agentName = agent.name;
+            configPayload = {
+              ...sharedConfigFields,
+              agent: agent.name,
+              agentSource: agent.source,
+              model,
+              inputFiles,
+              contextFiles,
+              mediaFiles,
+              agentCategory: AgentCategory.Workflow,
+            };
+          }
+
+          // Surface the resolved child model so the engine can attach it to
+          // this call's `agent:end` progress event.
+          invocation.reportModel?.(configPayload.model);
           return {
             configPayload,
-            agentName: agent.name,
+            agentName,
             parentExecutionId: run.executionId,
             parentStreamId: run.streamId,
             runtimeHost: runScope.runtimeHost,

--- a/src/tools/delegation/workflowScriptStrategy.ts
+++ b/src/tools/delegation/workflowScriptStrategy.ts
@@ -27,6 +27,7 @@ import type {
 import type { ExecutionId } from '@shared/schemas';
 import { DELIVERY_TAG } from '@shared/deliveryTags';
 import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
+import type { WorkflowScriptFiles } from '@shared/schemas/workflowScriptFiles';
 import {
   formatChildRunDelivery,
   formatChildRunError,
@@ -88,6 +89,8 @@ export interface WorkflowScriptStrategyParams {
   readonly script: string;
   /** JSON arguments; `null`/`undefined` retains the checkpoint's arguments. */
   readonly args: unknown;
+  /** Role-separated files exposed as immutable workflow launch context. */
+  readonly files?: WorkflowScriptFiles;
   /** Durable identity (`meta.name`) — used in the resume hint on failure. */
   readonly name: string;
   /**
@@ -167,6 +170,9 @@ export function createWorkflowScriptStrategy(
           checkpointId: params.checkpointId,
           script: params.script,
           ...(params.args != null && { args: params.args }),
+          ...(params.files !== undefined && {
+            files: params.files,
+          }),
           signal: abortController.signal,
           runAgent,
           getLiveCostUsd: () => liveCostUsd,


### PR DESCRIPTION
## Summary

- add a role-separated `files` launch contract for workflow scripts
- expose editable inputs, read-only context, and media through one immutable sandbox value
- persist the launch context with the durable workflow checkpoint and restore it on resume
- display selected launch files by role in workflow-script tool details
- separate workflow-agent calls from structured tool-use calls with a typed union

## Design

Workflow-script file context previously had no run-level representation. Adding only an `inputFiles` list would also have conflated editable files with read-only context and media, while the existing `agent()` option type mixed workflow agents and structured tool-use agents.

The change introduces one shared Zod schema for the three workflow file roles. The tool boundary, engine, checkpoint store, runner, and progress renderer all use that schema. The sandbox exposes the validated value as the deeply immutable `files` object.

Workflow-agent calls may declare `inputFiles`, `contextFiles`, and `mediaFiles`. Structured calls are a separate union member: they require `agentName` and `schema`, reject file options at the script boundary, and produce a tool-use launch payload with no file fields. Ordinary `delegate_agent` launches are unchanged.

## User impact

A workflow script can start from selected workspace files and assign the appropriate subsets to its worker agents. Editable documents, read-only references, and media remain visibly distinct throughout launch, execution, persistence, and display.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint`
- `npm test` — 7,408 passed, 4 skipped
- focused workflow-script, persistence, runner, sandbox, strategy, and progress tests — 168 passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches delegation launch, sandbox globals, checkpoint persistence, and child agent config—important paths but guarded by schema validation, tests, and backward-compatible empty file defaults.
> 
> **Overview**
> Workflow scripts can now take a **`files`** argument on `delegate_workflow_script` with **input** (editable), **context** (read-only), and **media** lists. That launch context is validated at the tool boundary, registered on the detached run, **persisted in the durable checkpoint** (with empty defaults for legacy checkpoints), and exposed in the sandbox as a **frozen `files` global** alongside `args`.
> 
> **`agent()`** options are split into workflow file-editing calls (`inputFiles` / `contextFiles` / `mediaFiles`) versus **structured tool-use** calls (`agentName` + `schema`, no file options). Invalid combinations abort the run (including inside `parallel`/`pipeline`). The runner forwards all three file roles to child workflow agents and applies **oversized `.bib` rejection** on context files at both tool launch and per-call.
> 
> Progress UI and docs show launch files by role; structured `agent({ schema })` examples now require an explicit **`agentName`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88f52d5a38865738c73f6c2aa04f55a8aea574c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->