### PR TITLE
feat: show declarative workflow task progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ All notable changes to this project will be documented in this file.
   unavailable members before launch.
 - **Codex runs show per-turn progress** — the progress view displays the thread
   ID, live turn status, elapsed time, and failures.
+- **Workflow scripts can show their complete task plan** — declared tasks
+  appear before execution and update in place as they run, finish, fail, or
+  are skipped.
 
 #### Bug Fixes
 

--- a/docs/proposals/2026-07-05-workflow-script-engine.md
+++ b/docs/proposals/2026-07-05-workflow-script-engine.md
@@ -38,20 +38,21 @@ export const meta = {
   name: 'draft-chapter',
   description: 'Draft sections in parallel, then merge with shared notation',
   phases: [{ title: 'Draft' }, { title: 'Merge' }],
+  tasks: [
+    { id: 'introduction', label: 'Draft introduction', phase: 'Draft' },
+    { id: 'results', label: 'Draft results', phase: 'Draft' },
+    { id: 'merge', label: 'Merge sections', phase: 'Merge' },
+  ],
 };
 phase('Draft');
-const drafts = await parallel(
-  args.sections.map(
-    (s) => () =>
-      agent(`Draft the "${s.title}" section.`, {
-        label: `draft:${s.title}`,
-        inputFiles: s.notes,
-      }),
-  ),
-);
+const drafts = await parallel([
+  () => agent('Draft the introduction.', { id: 'introduction' }),
+  () => agent('Draft the results.', { id: 'results' }),
+]);
 phase('Merge');
 const valid = drafts.filter(Boolean);
 return await agent('Merge these drafts, unify notation.', {
+  id: 'merge',
   agentName: 'merge',
   inputFiles: valid.flatMap((d) =>
     d.category === 'workflow' ? d.outputs.map((o) => o.absolutePath) : d.files,
@@ -61,6 +62,10 @@ return await agent('Merge these drafts, unify notation.', {
 
 ### Primitives
 
+- `meta.tasks` → an optional declarative plan of `{ id, label, phase? }`
+  records. When present, every `agent()` call references one record by `id`;
+  progress surfaces show the entire plan before execution and update each
+  record in place. Data-dependent workflows may omit it.
 - `agent(prompt, opts?)` → one subagent run; returns the typed result
   (`null` on failure). Options: `id`, `label`, `phase`, `agentName`,
   `inputFiles`. Otherwise-identical calls require distinct `id` values so

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -90,7 +90,7 @@ function renderConversationPaneEntry({
         />
       );
     }
-    if (entry.role === 'error') {
+    if (entry.role === 'error' || entry.role === 'workflowTask') {
       return (
         <BoundedTranscriptEntry
           colorEnabled={colorEnabled}

--- a/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
@@ -85,7 +85,12 @@ function PlainEntryRows({
   return (
     <Box {...boxProps}>
       <Text
-        color={entry.role === 'error' ? COLOR_ERROR : undefined}
+        color={
+          entry.role === 'error' ||
+          (entry.role === 'workflowTask' && entry.task.status === 'failed')
+            ? COLOR_ERROR
+            : undefined
+        }
         inverse={entry.role === 'user' && colorEnabled !== false}
       >
         {lines.join('\n')}
@@ -218,6 +223,7 @@ export const TranscriptEntry = memo(function TranscriptEntry({
           />
         </Box>
       );
+    case 'workflowTask':
     default:
       return (
         <PlainEntryRows

--- a/packages/cli/src/chat/tui/panes/transcriptEntries.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntries.ts
@@ -68,6 +68,7 @@ export function isRenderableTranscriptEntry(entry: ConversationEntry): boolean {
     case 'error':
     case 'user':
     case 'phase':
+    case 'workflowTask':
       return terminalVisibleTranscriptText(entry.text).trim().length > 0;
     case 'process':
     case 'tool':
@@ -142,7 +143,7 @@ export function splitTranscriptEntries(
       finalized.push(entry);
       continue;
     }
-    if (entry.role === 'tool') {
+    if (entry.role === 'tool' || entry.role === 'workflowTask') {
       pending.push(entry);
       continue;
     }

--- a/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
@@ -77,6 +77,13 @@ const ROLE_GEOMETRY = {
     marginBottomRows: USER_ENTRY_MARGIN_BOTTOM_ROWS,
     marginTopRows: USER_ENTRY_MARGIN_TOP_ROWS,
   },
+  workflowTask: {
+    firstPrefix: '',
+    continuationPrefix: '',
+    inset: 0,
+    marginBottomRows: 0,
+    marginTopRows: 0,
+  },
 } as const satisfies Record<TranscriptEntryRole, RoleGeometry>;
 
 export interface TranscriptEntryLayout extends RoleGeometry {

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -23,6 +23,7 @@ import {
   type StreamTabId,
   type TodoItem,
   type TokenUsageStats,
+  type WorkflowTaskProgress,
 } from '@shared/schemas';
 import type { AgentDelegationScope } from '@shared/schemas/agentRoster';
 import { isActivePhase } from '@shared/streams/streamStatus';
@@ -72,6 +73,11 @@ interface ConversationEntryBase {
  */
 export type ConversationEntry =
   | (ConversationEntryBase & { readonly role: 'assistant' | 'error' | 'user' })
+  | (ConversationEntryBase & {
+      readonly role: 'workflowTask';
+      /** Parsed task state retained for semantic settlement and styling. */
+      readonly task: WorkflowTaskProgress;
+    })
   | (ConversationEntryBase & {
       readonly role: 'phase';
       /** Phase title displayed in the group-header divider row. */

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -27,14 +27,11 @@ import {
   summarizeFollowupMessage,
 } from '@shared/subagentFollowup';
 import { normalizeToolUseData } from '@shared/toolUse';
+import { formatWorkflowTaskMetadataParts } from '@shared/copy/workflowTask';
 import { isActivePhase } from '@shared/streams/streamStatus';
 import { createFlushableDebounce } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
-import {
-  formatCompactDuration,
-  formatCostUsd,
-  truncateSummary,
-} from '@utils/text/stringUtils';
+import { truncateSummary } from '@utils/text/stringUtils';
 import { normalizeKnownHtmlForCliMarkdown } from '../render/htmlMarkdownNormalize';
 import {
   isRenderableTranscriptEntry,
@@ -354,18 +351,7 @@ function renderLogEntry(
     const parsed = WorkflowTaskProgressSchema.safeParse(entry.data);
     if (!parsed.success) return null;
     const task = parsed.data;
-    const metadata =
-      task.status === 'completed' || task.status === 'failed'
-        ? [
-            task.model,
-            task.durationMs === undefined
-              ? undefined
-              : formatCompactDuration(task.durationMs),
-            task.totalCostUsd === undefined
-              ? undefined
-              : `${formatCostUsd(task.totalCostUsd)} total`,
-          ].filter((part): part is string => part !== undefined)
-        : [];
+    const metadata = formatWorkflowTaskMetadataParts(task);
     const suffix = metadata.length > 0 ? ` · ${metadata.join(' · ')}` : '';
     const error = task.status === 'failed' ? ` — ${task.error}` : '';
     const text = `${WORKFLOW_TASK_STATUS_LABEL[task.status]}: ${task.label}${suffix}${error}`;

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -105,9 +105,9 @@ function workflowOperationalDescription(
     }
     if (
       entry.role === 'error' ||
+      entry.role === 'workflowTask' ||
       (entry.role === 'assistant' &&
-        (entry.messageType === MESSAGE_TYPES.DEFAULT ||
-          entry.messageType === MESSAGE_TYPES.WORKFLOW_TASK))
+        entry.messageType === MESSAGE_TYPES.DEFAULT)
     ) {
       const description = safeWorkflowOperationalSummary(entry.text);
       if (description) return description;
@@ -236,6 +236,9 @@ function entriesEqual(
       prev.phaseIndex === next.phaseIndex && prev.phaseTotal === next.phaseTotal
     );
   }
+  if (prev.role === 'workflowTask' && next.role === 'workflowTask') {
+    return isDeepStrictEqual(prev.task, next.task);
+  }
   return true;
 }
 
@@ -357,11 +360,11 @@ function renderLogEntry(
     const text = `${WORKFLOW_TASK_STATUS_LABEL[task.status]}: ${task.label}${suffix}${error}`;
     const next: ConversationEntry = {
       id: entry.id,
-      role: task.status === 'failed' ? 'error' : 'assistant',
+      role: 'workflowTask',
       text,
       messageType: entry.messageType,
-      finalized:
-        task.status === 'planned' || task.status === 'running' ? false : true,
+      finalized: prev?.finalized ?? false,
+      task,
     };
     return prev && entriesEqual(prev, next) ? prev : next;
   }
@@ -420,6 +423,7 @@ function renderLogEntry(
 // An entry is "settled" once its content can no longer change, so it is
 // safe to print once into `<Static>` scrollback:
 //   - user / error / process: fixed the moment they appear.
+//   - workflow task: fixed once its typed state reaches a terminal status.
 //   - assistant: frozen once the model emits a later entry (more text or a
 //     tool call). The trailing block may still be streaming.
 //   - tool: frozen once its result lands (status COMPLETED).
@@ -439,6 +443,8 @@ function isSettledEntry(
         entry.toolUse.status === TOOL_USE_STATUS.COMPLETED ||
         entry.toolUse.status === TOOL_USE_STATUS.FAILED
       );
+    case 'workflowTask':
+      return entry.task.status !== 'planned' && entry.task.status !== 'running';
     case 'assistant':
       return (
         !entry.pendingEmbeddedSubagentFollowup && index < entries.length - 1

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -16,6 +16,8 @@ import {
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
   TOOL_USE_STATUS,
+  WORKFLOW_TASK_STATUS_LABEL,
+  WorkflowTaskProgressSchema,
   type NormalizedToolUse,
   type StreamLogEntry,
   type StreamTabId,
@@ -28,7 +30,11 @@ import { normalizeToolUseData } from '@shared/toolUse';
 import { isActivePhase } from '@shared/streams/streamStatus';
 import { createFlushableDebounce } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
-import { truncateSummary } from '@utils/text/stringUtils';
+import {
+  formatCompactDuration,
+  formatCostUsd,
+  truncateSummary,
+} from '@utils/text/stringUtils';
 import { normalizeKnownHtmlForCliMarkdown } from '../render/htmlMarkdownNormalize';
 import {
   isRenderableTranscriptEntry,
@@ -60,6 +66,7 @@ const TRANSCRIPT_MESSAGE_TYPES = new Set<string>([
 const CHILD_STREAM_LOG_MESSAGE_TYPES = new Set<string>([
   ...TRANSCRIPT_MESSAGE_TYPES,
   MESSAGE_TYPES.DEFAULT,
+  MESSAGE_TYPES.WORKFLOW_TASK,
 ]);
 
 const LIVE_ACTIVITY_MESSAGE_TYPES = new Set<string>([
@@ -102,7 +109,8 @@ function workflowOperationalDescription(
     if (
       entry.role === 'error' ||
       (entry.role === 'assistant' &&
-        entry.messageType === MESSAGE_TYPES.DEFAULT)
+        (entry.messageType === MESSAGE_TYPES.DEFAULT ||
+          entry.messageType === MESSAGE_TYPES.WORKFLOW_TASK))
     ) {
       const description = safeWorkflowOperationalSummary(entry.text);
       if (description) return description;
@@ -340,6 +348,36 @@ function renderLogEntry(
     }
     toolUseSourceCache.set(next, entry.data);
     return next;
+  }
+
+  if (entry.messageType === MESSAGE_TYPES.WORKFLOW_TASK) {
+    const parsed = WorkflowTaskProgressSchema.safeParse(entry.data);
+    if (!parsed.success) return null;
+    const task = parsed.data;
+    const metadata =
+      task.status === 'completed' || task.status === 'failed'
+        ? [
+            task.model,
+            task.durationMs === undefined
+              ? undefined
+              : formatCompactDuration(task.durationMs),
+            task.totalCostUsd === undefined
+              ? undefined
+              : `${formatCostUsd(task.totalCostUsd)} total`,
+          ].filter((part): part is string => part !== undefined)
+        : [];
+    const suffix = metadata.length > 0 ? ` · ${metadata.join(' · ')}` : '';
+    const error = task.status === 'failed' ? ` — ${task.error}` : '';
+    const text = `${WORKFLOW_TASK_STATUS_LABEL[task.status]}: ${task.label}${suffix}${error}`;
+    const next: ConversationEntry = {
+      id: entry.id,
+      role: task.status === 'failed' ? 'error' : 'assistant',
+      text,
+      messageType: entry.messageType,
+      finalized:
+        task.status === 'planned' || task.status === 'running' ? false : true,
+    };
+    return prev && entriesEqual(prev, next) ? prev : next;
   }
 
   // Phase group headers finalize the moment they appear (like user/error

--- a/packages/cli/src/chat/tui/state/transcript.ts
+++ b/packages/cli/src/chat/tui/state/transcript.ts
@@ -132,7 +132,7 @@ export function clearLocalTranscript(): void {
 }
 
 /** Finalizes any entries that defer finalization to end-of-stream
- *  (assistant text and tool rows). Tool rows are included so that a
+ *  (assistant text, tool rows, and workflow tasks). Tool rows are included so that a
  *  fast-completing tool doesn't jump ahead of still-streaming assistant
  *  text in `<Static>` scrollback — see the deferral comment in
  *  `subscribeStreamLog.renderLogEntry`. */
@@ -143,7 +143,13 @@ export function finalizeAssistantTranscriptEntries(
     let changed = false;
     const entries = slice.entries.map((entry) => {
       if (entry.finalized) return entry;
-      if (entry.role !== 'assistant' && entry.role !== 'tool') return entry;
+      if (
+        entry.role !== 'assistant' &&
+        entry.role !== 'tool' &&
+        entry.role !== 'workflowTask'
+      ) {
+        return entry;
+      }
       changed = true;
       return { ...entry, finalized: true };
     });

--- a/packages/extension/resources/docs/agent-creation/tool_catalog.md
+++ b/packages/extension/resources/docs/agent-creation/tool_catalog.md
@@ -65,7 +65,10 @@ recommended groups at the bottom are a good starting point.
   `log`, `parallel`, `pipeline`, and `concat`. `agent(prompt, { schema })`, where
   `schema` is a JSON Schema object, runs a tool-use agent (name one via
   `agentName`) that finishes by calling `submit_output`; the call resolves to an
-  envelope whose `.structured` is the validated object. Present in the
+  envelope whose `.structured` is the validated object. The optional
+  `meta.tasks` plan declares task ids, labels, and phases so progress views can
+  show pending work before any model call starts; calls then reference those
+  records with `agent(prompt, { id })`. Present in the
   built-in `orchestrator` agent's tool list, but gated by the "Workflow
   Script" switch in Settings → Tools (off by default for new installs), which
   disables the tool for every agent regardless of its configured tool list.

--- a/packages/extension/src/progressView/frontend/formatters/index.ts
+++ b/packages/extension/src/progressView/frontend/formatters/index.ts
@@ -38,6 +38,7 @@ import {
   formatWebFetchTemplate,
   formatWebSearchTemplate,
 } from './logFormatters/toolFormatters/webFormatters';
+import { formatWorkflowTaskTemplate } from './logFormatters/workflowTaskFormatter';
 
 export { isStreamingTextLogMessage } from './baseLogFormatter';
 
@@ -141,6 +142,10 @@ const TEMPLATE_FORMATTERS: Record<string, TemplateFormatterFn | null> = {
   contextManagement: wrapWithErrorHandling(
     formatContextManagementTemplate,
     'context management',
+  ),
+  workflowTask: wrapWithErrorHandling(
+    formatWorkflowTaskTemplate,
+    'workflow task',
   ),
 
   // Special cases

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/workflowTaskFormatter.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/workflowTaskFormatter.ts
@@ -8,9 +8,9 @@ import {
   type LogMessageData,
   type WorkflowTaskProgress,
 } from '@shared/schemas';
+import { formatWorkflowTaskMetadataParts } from '@shared/copy/workflowTask';
 import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
 import { assertNever } from '@utils/core';
-import { formatCompactDuration, formatCostUsd } from '@utils/text/stringUtils';
 
 function statusIcon(task: WorkflowTaskProgress): TemplateResult {
   if (task.status === 'running') {
@@ -42,15 +42,7 @@ function terminalMetadata(
   task: WorkflowTaskProgress,
 ): TemplateResult | typeof nothing {
   if (task.status !== 'completed' && task.status !== 'failed') return nothing;
-  const parts = [
-    task.model,
-    task.durationMs === undefined
-      ? undefined
-      : formatCompactDuration(task.durationMs),
-    task.totalCostUsd === undefined
-      ? undefined
-      : `${formatCostUsd(task.totalCostUsd)} total`,
-  ].filter((part): part is string => part !== undefined);
+  const parts = formatWorkflowTaskMetadataParts(task);
   return parts.length > 0
     ? html`<span class="workflow-task-meta">${parts.join(' · ')}</span>`
     : nothing;

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/workflowTaskFormatter.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/workflowTaskFormatter.ts
@@ -1,0 +1,102 @@
+// Third-party imports
+import { html, nothing, type TemplateResult } from 'lit';
+
+// Local imports - shared contracts
+import {
+  WORKFLOW_TASK_STATUS_LABEL,
+  WorkflowTaskProgressSchema,
+  type LogMessageData,
+  type WorkflowTaskProgress,
+} from '@shared/schemas';
+import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+import { assertNever } from '@utils/core';
+import { formatCompactDuration, formatCostUsd } from '@utils/text/stringUtils';
+
+function statusIcon(task: WorkflowTaskProgress): TemplateResult {
+  if (task.status === 'running') {
+    return html`<wa-spinner aria-label="Running"></wa-spinner>`;
+  }
+  const icon = (() => {
+    switch (task.status) {
+      case 'planned':
+        return 'circle-outline';
+      case 'completed':
+      case 'cached':
+        return 'check';
+      case 'skipped':
+        return 'circle-stop';
+      case 'failed':
+        return 'error';
+      default:
+        return assertNever(task, 'Unhandled workflow task status');
+    }
+  })();
+  return html`<wa-icon
+    library=${TEXRA_ICON_LIBRARY}
+    name=${icon}
+    aria-hidden="true"
+  ></wa-icon>`;
+}
+
+function terminalMetadata(
+  task: WorkflowTaskProgress,
+): TemplateResult | typeof nothing {
+  if (task.status !== 'completed' && task.status !== 'failed') return nothing;
+  const parts = [
+    task.model,
+    task.durationMs === undefined
+      ? undefined
+      : formatCompactDuration(task.durationMs),
+    task.totalCostUsd === undefined
+      ? undefined
+      : `${formatCostUsd(task.totalCostUsd)} total`,
+  ].filter((part): part is string => part !== undefined);
+  return parts.length > 0
+    ? html`<span class="workflow-task-meta">${parts.join(' · ')}</span>`
+    : nothing;
+}
+
+function taskDetail(task: WorkflowTaskProgress): string | undefined {
+  if (task.status === 'failed') return task.error;
+  if (task.status === 'skipped' && task.reason === 'not-reached') {
+    return 'The workflow ended before this task was reached.';
+  }
+  return undefined;
+}
+
+/** Render one workflow task as a status card updated in place by log id. */
+export function formatWorkflowTaskTemplate(
+  message: LogMessageData,
+): TemplateResult {
+  const task = WorkflowTaskProgressSchema.parse(message.data);
+  const detail = taskDetail(task);
+
+  return html`
+    <div
+      class=${`workflow-task workflow-task--${task.status}`}
+      data-log-id=${message.id}
+      data-group-id=${message.groupId ?? ''}
+    >
+      <span class="workflow-task-icon">${statusIcon(task)}</span>
+      <span class="workflow-task-body">
+        <span class="workflow-task-title">${task.label}</span>
+        <span class="workflow-task-details">
+          ${
+            task.phase
+              ? html`<span class="workflow-task-phase">${task.phase}</span>`
+              : nothing
+          }
+          ${terminalMetadata(task)}
+        </span>
+        ${
+          detail
+            ? html`<span class="workflow-task-error">${detail}</span>`
+            : nothing
+        }
+      </span>
+      <span class="workflow-task-status"
+        >${WORKFLOW_TASK_STATUS_LABEL[task.status]}</span
+      >
+    </div>
+  `;
+}

--- a/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
@@ -45,6 +45,105 @@ export const logEntryStyles = css`
     font-style: italic;
   }
 
+  .workflow-task {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    align-items: start;
+    gap: var(--wa-space-2xs);
+    margin: var(--wa-space-3xs) 0;
+    padding: var(--wa-space-2xs) var(--wa-space-xs);
+    border: var(--border-thin) solid var(--wa-color-surface-border);
+    border-left: 3px solid var(--color-text-secondary);
+    border-radius: var(--border-radius);
+    background: var(--wa-color-surface-default);
+    content-visibility: auto;
+    contain-intrinsic-size: auto 42px;
+  }
+
+  .workflow-task--running {
+    border-left-color: var(--wa-color-focus);
+    background: var(--wa-color-neutral-fill-quiet);
+  }
+
+  .workflow-task--completed,
+  .workflow-task--cached {
+    border-left-color: var(--color-success);
+  }
+
+  .workflow-task--failed {
+    border-left-color: var(--color-error);
+    background: var(--wa-color-danger-fill-quiet);
+  }
+
+  .workflow-task--skipped {
+    opacity: var(--opacity-subtle);
+  }
+
+  .workflow-task-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.2em;
+    height: 1.2em;
+    margin-top: 0.1em;
+  }
+
+  .workflow-task-icon :is(wa-icon, wa-spinner) {
+    font-size: 1em;
+  }
+
+  .workflow-task-body {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    gap: calc(var(--wa-space-3xs) / 2);
+  }
+
+  .workflow-task-title {
+    overflow-wrap: anywhere;
+    font-weight: var(--wa-font-weight-semibold);
+  }
+
+  .workflow-task-details {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--wa-space-xs);
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm);
+  }
+
+  .workflow-task-phase::before {
+    content: 'Phase: ';
+  }
+
+  .workflow-task-error {
+    color: var(--color-error);
+    overflow-wrap: anywhere;
+  }
+
+  .workflow-task-status {
+    align-self: center;
+    padding: calc(var(--wa-space-3xs) / 2) var(--wa-space-2xs);
+    border-radius: 999px;
+    background: var(--wa-color-neutral-fill-quiet);
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm);
+    white-space: nowrap;
+  }
+
+  .workflow-task--running .workflow-task-status {
+    color: var(--wa-color-focus);
+  }
+
+  .workflow-task--completed .workflow-task-status,
+  .workflow-task--cached .workflow-task-status {
+    color: var(--color-success);
+  }
+
+  .workflow-task--failed .workflow-task-status {
+    color: var(--color-error);
+  }
+
   .log-reveal-row {
     display: flex;
     justify-content: center;

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -27,6 +27,7 @@ import type {
   UpdatePlanPayload,
   UpdateStreamUsagePayload,
   UpdateTodosPayload,
+  WorkflowTaskProgress,
 } from '@shared/schemas';
 import type { StreamTransitionCause } from '@shared/streams/streamStatus';
 import type { RunDescriptor } from '@shared/schemas/runDescriptor';
@@ -126,6 +127,16 @@ interface ToolEndEvent extends StageStamp {
   readonly status: ToolStatus;
   /** Subscriber-correlatable patch payload (output, summary, etc.). */
   readonly result?: unknown;
+}
+
+/**
+ * Correlatable workflow-script task state. The same `logId` is emitted as a
+ * task moves from its declared plan through execution to a terminal state.
+ */
+interface WorkflowTaskEvent extends StageStamp {
+  readonly type: 'workflow.task';
+  readonly logId: string;
+  readonly task: WorkflowTaskProgress;
 }
 
 /** Token-usage report. */
@@ -355,6 +366,7 @@ export type AgentEvent =
   | StageEndEvent
   | ToolStartEvent
   | ToolEndEvent
+  | WorkflowTaskEvent
   | UsageEvent
   | StatusEvent
   | ChildActivityEvent

--- a/src/agent/workflowScript/README.md
+++ b/src/agent/workflowScript/README.md
@@ -13,17 +13,25 @@ export const meta = {
   name: 'draft-chapter',
   description: 'Draft sections in parallel, then merge',
   phases: [{ title: 'Draft' }, { title: 'Merge' }],
+  tasks: [
+    { id: 'introduction', label: 'Draft introduction', phase: 'Draft' },
+    { id: 'results', label: 'Draft results', phase: 'Draft' },
+  ],
 };
 phase('Draft');
-const sections = await parallel(
-  args.sections.map(
-    (s) => () => agent(`Draft the "${s}" section.`, { label: `draft:${s}` }),
-  ),
-);
+const sections = await parallel([
+  () => agent('Draft the introduction.', { id: 'introduction' }),
+  () => agent('Draft the results.', { id: 'results' }),
+]);
 phase('Merge');
 return concat(sections, { separator: '\n\n' });
 ```
 
+- `meta.tasks` — optional declarative task plan. When present, each
+  `agent()` call must reference exactly one task with `{ id }`; its display
+  label and phase come only from the plan. Progress surfaces can therefore
+  show pending work before execution and update one task record in place.
+  Scripts whose call set is data-dependent may omit the plan.
 - `agent(prompt, opts?)` — one subagent run; resolves to the host runner's
   typed result, or `null` on failure (filter with `.filter(Boolean)`).
   `agent(prompt, { schema })`, where `schema` is a JSON Schema object, runs a

--- a/src/agent/workflowScript/runWorkflowScript.ts
+++ b/src/agent/workflowScript/runWorkflowScript.ts
@@ -17,6 +17,7 @@ import {
   type WorkflowScriptPhaseContext,
   type WorkflowScriptRunOptions,
   type WorkflowScriptRunResult,
+  type WorkflowScriptTask,
 } from './types';
 
 /**
@@ -226,6 +227,9 @@ export async function runWorkflowScript(
   let callCounter = 0;
   const issuedCallKeys = new Set<string>();
   const plannedPhases = meta.phases ?? [];
+  const plannedTasks = meta.tasks ?? [];
+  const plannedTasksById = new Map(plannedTasks.map((task) => [task.id, task]));
+  const issuedTaskIds = new Set<string>();
   let currentPhase: string | undefined;
   let fatalRunError: WorkflowRunAbortError | undefined;
 
@@ -258,6 +262,9 @@ export async function runWorkflowScript(
     retry: (index) => requestControl(index, 'retry'),
   };
   onControl?.(control);
+  if (plannedTasks.length > 0) {
+    emit({ type: 'plan', tasks: plannedTasks });
+  }
 
   const rememberFatalRunError = (error: unknown): WorkflowRunAbortError => {
     fatalRunError ??=
@@ -270,6 +277,7 @@ export async function runWorkflowScript(
 
   const recordJournalEntry = async (
     entry: WorkflowJournalEntry,
+    taskId: string,
     label: string,
     phaseContext: WorkflowScriptPhaseContext,
   ): Promise<void> => {
@@ -281,10 +289,11 @@ export async function runWorkflowScript(
       const fatal = rememberFatalRunError(new WorkflowRunAbortError(message));
       emit({
         type: 'agent:end',
+        taskId,
         index: entry.index,
         label,
         ...phaseContext,
-        cached: false,
+        outcome: 'failed',
         error: message,
       });
       throw fatal;
@@ -307,15 +316,55 @@ export async function runWorkflowScript(
         'agent(prompt, options?) requires a non-empty string prompt.',
       );
     }
-    const callOptions = normalizeAgentOptions(rawOptions, currentPhase);
-    const phaseContext = phaseContextFor(callOptions.phase);
+    const callOptions = normalizeAgentOptions(rawOptions);
     const index = callCounter;
     callCounter += 1;
 
+    let plannedTask: WorkflowScriptTask | undefined;
+    if (plannedTasks.length > 0) {
+      if (!callOptions.id) {
+        throw rememberFatalRunError(
+          new WorkflowRunAbortError(
+            'Every agent() call must reference a task from meta.tasks with a non-empty "id" option.',
+          ),
+        );
+      }
+      plannedTask = plannedTasksById.get(callOptions.id);
+      if (!plannedTask) {
+        throw rememberFatalRunError(
+          new WorkflowRunAbortError(
+            `agent() references undeclared task id "${callOptions.id}".`,
+          ),
+        );
+      }
+      if (callOptions.label !== undefined || callOptions.phase !== undefined) {
+        throw rememberFatalRunError(
+          new WorkflowRunAbortError(
+            `Task "${callOptions.id}" declares its label and phase in meta.tasks; do not duplicate them in agent() options.`,
+          ),
+        );
+      }
+      callOptions.label = plannedTask.label;
+      callOptions.phase = plannedTask.phase;
+    } else {
+      callOptions.phase ??= currentPhase;
+    }
+
     const label =
+      plannedTask?.label ??
       callOptions.label ??
       prompt.slice(0, LABEL_EXCERPT_LENGTH).replaceAll(/\s+/g, ' ').trim();
     const key = journalKey(prompt, callOptions);
+    const taskId = plannedTask?.id ?? callOptions.id ?? `call-${index}`;
+    if (issuedTaskIds.has(taskId)) {
+      throw rememberFatalRunError(
+        new WorkflowRunAbortError(
+          `Workflow task "${taskId}" may be issued only once per run.`,
+        ),
+      );
+    }
+    issuedTaskIds.add(taskId);
+    const phaseContext = phaseContextFor(callOptions.phase);
     if (issuedCallKeys.has(key)) {
       throw rememberFatalRunError(
         new WorkflowRunAbortError(
@@ -328,11 +377,10 @@ export async function runWorkflowScript(
     // Serialize (and round-trip deserialize) a result value for the journal,
     // emitting the matching `agent:end` failure event if it isn't
     // bridge-safe. Shared by the cached-replay and live-call paths below,
-    // which differ only in the source value, its label, and `cached`.
+    // which differ only in the source value.
     const journalValue = (
       value: unknown,
       valueLabel: string,
-      cached: boolean,
     ): { payload: string | undefined; normalizedResult: unknown } => {
       try {
         const payload = serializeBridgeValue(value, valueLabel);
@@ -340,10 +388,11 @@ export async function runWorkflowScript(
       } catch (error) {
         emit({
           type: 'agent:end',
+          taskId,
           index,
           label,
           ...phaseContext,
-          cached,
+          outcome: 'failed',
           error: toErrorMessage(error),
         });
         throw error;
@@ -355,15 +404,15 @@ export async function runWorkflowScript(
       const { payload, normalizedResult } = journalValue(
         prior.result,
         'Cached agent() result',
-        true,
       );
       journal.set(index, { ...prior, result: normalizedResult });
       emit({
         type: 'agent:end',
+        taskId,
         index,
         label,
         ...phaseContext,
-        cached: true,
+        outcome: 'cached',
       });
       return payload;
     }
@@ -401,7 +450,13 @@ export async function runWorkflowScript(
       callControllers.set(index, callController);
       if (!startEmitted) {
         startEmitted = true;
-        emit({ type: 'agent:start', index, label, ...phaseContext });
+        emit({
+          type: 'agent:start',
+          taskId,
+          index,
+          label,
+          ...phaseContext,
+        });
       }
 
       let result: unknown;
@@ -449,11 +504,11 @@ export async function runWorkflowScript(
       if (action === 'skip') {
         emit({
           type: 'agent:end',
+          taskId,
           index,
           label,
           ...phaseContext,
-          cached: false,
-          skipped: true,
+          outcome: 'skipped',
         });
         // First-class SKIPPED value, not journaled — a resume re-runs it.
         return JSON.stringify(WORKFLOW_SKIPPED_RESULT);
@@ -469,10 +524,11 @@ export async function runWorkflowScript(
         // and is deliberately NOT journaled, so a resume retries it.
         emit({
           type: 'agent:end',
+          taskId,
           index,
           label,
           ...phaseContext,
-          cached: false,
+          outcome: 'failed',
           error: toErrorMessage(attemptError.error),
           ...(resolvedModel !== undefined ? { model: resolvedModel } : {}),
           durationMs: Date.now() - startedAt,
@@ -485,19 +541,20 @@ export async function runWorkflowScript(
       const { payload, normalizedResult } = journalValue(
         result,
         'agent() result',
-        false,
       );
       await recordJournalEntry(
         { index, key, result: normalizedResult },
+        taskId,
         label,
         phaseContext,
       );
       emit({
         type: 'agent:end',
+        taskId,
         index,
         label,
         ...phaseContext,
-        cached: false,
+        outcome: 'completed',
         ...(resolvedModel !== undefined ? { model: resolvedModel } : {}),
         durationMs: Date.now() - startedAt,
       });
@@ -624,10 +681,7 @@ function deserializeBridgeValue(payload: string | undefined): unknown {
   return payload === undefined ? undefined : JSON.parse(payload);
 }
 
-function normalizeAgentOptions(
-  raw: unknown,
-  currentPhase: string | undefined,
-): WorkflowAgentCallOptions {
+function normalizeAgentOptions(raw: unknown): WorkflowAgentCallOptions {
   if (
     (raw !== undefined && raw !== null && typeof raw !== 'object') ||
     Array.isArray(raw)
@@ -681,6 +735,5 @@ function normalizeAgentOptions(
     }
     options.inputFiles = [...(source.inputFiles as string[])];
   }
-  options.phase ??= currentPhase;
   return options;
 }

--- a/src/agent/workflowScript/runWorkflowScript.ts
+++ b/src/agent/workflowScript/runWorkflowScript.ts
@@ -229,7 +229,7 @@ export async function runWorkflowScript(
   const plannedPhases = meta.phases ?? [];
   const plannedTasks = meta.tasks ?? [];
   const plannedTasksById = new Map(plannedTasks.map((task) => [task.id, task]));
-  const issuedTaskIds = new Set<string>();
+  const issuedPlannedTaskIds = new Set<string>();
   let currentPhase: string | undefined;
   let fatalRunError: WorkflowRunAbortError | undefined;
 
@@ -356,14 +356,16 @@ export async function runWorkflowScript(
       prompt.slice(0, LABEL_EXCERPT_LENGTH).replaceAll(/\s+/g, ' ').trim();
     const key = journalKey(prompt, callOptions);
     const taskId = plannedTask?.id ?? callOptions.id ?? `call-${index}`;
-    if (issuedTaskIds.has(taskId)) {
-      throw rememberFatalRunError(
-        new WorkflowRunAbortError(
-          `Workflow task "${taskId}" may be issued only once per run.`,
-        ),
-      );
+    if (plannedTask) {
+      if (issuedPlannedTaskIds.has(taskId)) {
+        throw rememberFatalRunError(
+          new WorkflowRunAbortError(
+            `Workflow task "${taskId}" may be issued only once per run.`,
+          ),
+        );
+      }
+      issuedPlannedTaskIds.add(taskId);
     }
-    issuedTaskIds.add(taskId);
     const phaseContext = phaseContextFor(callOptions.phase);
     if (issuedCallKeys.has(key)) {
       throw rememberFatalRunError(

--- a/src/agent/workflowScript/types.ts
+++ b/src/agent/workflowScript/types.ts
@@ -1,27 +1,77 @@
 import { z } from 'zod';
 
 const WorkflowScriptPhaseSchema = z.object({
-  title: z.string().min(1),
+  title: z.string().trim().min(1),
   detail: z.string().optional(),
 });
+
+const WorkflowScriptTaskSchema = z.strictObject({
+  /** Stable identity referenced by agent(..., { id }). */
+  id: z.string().trim().min(1),
+  /** Human-readable task name shown on progress surfaces. */
+  label: z.string().trim().min(1),
+  /** Optional declared phase; must name one of meta.phases when present. */
+  phase: z.string().trim().min(1).optional(),
+});
+
+export type WorkflowScriptTask = z.infer<typeof WorkflowScriptTaskSchema>;
 
 /**
  * The `export const meta = {...}` block every workflow script must begin
  * with. Must be a pure object literal — parsed and validated before the
  * script body ever runs.
  */
-export const WorkflowScriptMetaSchema = z.object({
-  name: z.string().min(1),
-  description: z.string().min(1),
-  whenToUse: z.string().optional(),
-  phases: z.array(WorkflowScriptPhaseSchema).optional(),
-  /** Whole-run wall clock, bounded; an explicit run option still wins. */
-  timeoutMs: z
-    .int()
-    .min(1_000)
-    .max(60 * 60 * 1000)
-    .optional(),
-});
+export const WorkflowScriptMetaSchema = z
+  .object({
+    name: z.string().min(1),
+    description: z.string().min(1),
+    whenToUse: z.string().optional(),
+    phases: z.array(WorkflowScriptPhaseSchema).optional(),
+    /**
+     * Declarative task plan. When present, every agent() call references one
+     * task by id; label and phase live here rather than being duplicated in
+     * executable code.
+     */
+    tasks: z.array(WorkflowScriptTaskSchema).optional(),
+    /** Whole-run wall clock, bounded; an explicit run option still wins. */
+    timeoutMs: z
+      .int()
+      .min(1_000)
+      .max(60 * 60 * 1000)
+      .optional(),
+  })
+  .superRefine((meta, context) => {
+    const phaseTitles = new Set<string>();
+    for (const [index, phase] of (meta.phases ?? []).entries()) {
+      if (phaseTitles.has(phase.title)) {
+        context.addIssue({
+          code: 'custom',
+          path: ['phases', index, 'title'],
+          message: `Duplicate phase title "${phase.title}".`,
+        });
+      }
+      phaseTitles.add(phase.title);
+    }
+
+    const taskIds = new Set<string>();
+    for (const [index, task] of (meta.tasks ?? []).entries()) {
+      if (taskIds.has(task.id)) {
+        context.addIssue({
+          code: 'custom',
+          path: ['tasks', index, 'id'],
+          message: `Duplicate task id "${task.id}".`,
+        });
+      }
+      taskIds.add(task.id);
+      if (task.phase !== undefined && !phaseTitles.has(task.phase)) {
+        context.addIssue({
+          code: 'custom',
+          path: ['tasks', index, 'phase'],
+          message: `Task phase "${task.phase}" is not declared in meta.phases.`,
+        });
+      }
+    }
+  });
 
 export type WorkflowScriptMeta = z.infer<typeof WorkflowScriptMetaSchema>;
 
@@ -93,7 +143,18 @@ export interface WorkflowScriptPhaseContext {
   phaseTotal?: number;
 }
 
+interface WorkflowScriptAgentEventBase extends WorkflowScriptPhaseContext {
+  /** Declarative task id, or a run-local id for an undeclared dynamic call. */
+  taskId: string;
+  index: number;
+  label: string;
+}
+
 export type WorkflowScriptEvent =
+  | {
+      type: 'plan';
+      tasks: readonly WorkflowScriptTask[];
+    }
   | {
       type: 'phase';
       title: string;
@@ -103,23 +164,33 @@ export type WorkflowScriptEvent =
       total?: number;
     }
   | { type: 'log'; message: string }
-  | (WorkflowScriptPhaseContext & {
+  | (WorkflowScriptAgentEventBase & {
       type: 'agent:start';
-      index: number;
-      label: string;
     })
-  | (WorkflowScriptPhaseContext & {
+  | (WorkflowScriptAgentEventBase & {
       type: 'agent:end';
-      index: number;
-      label: string;
-      cached: boolean;
-      error?: string;
+      outcome: 'cached';
+    })
+  | (WorkflowScriptAgentEventBase & {
+      type: 'agent:end';
+      outcome: 'completed';
       /** Child model resolved by the runner (live calls only). */
       model?: string;
       /** Host-measured wall time of the agent() call (live calls only). */
+      durationMs: number;
+    })
+  | (WorkflowScriptAgentEventBase & {
+      type: 'agent:end';
+      outcome: 'failed';
+      error: string;
+      /** Child model resolved by the runner, when resolution succeeded. */
+      model?: string;
+      /** Host-measured wall time, when an agent attempt began. */
       durationMs?: number;
-      /** Deliberately skipped via control.skip(index); not journaled. */
-      skipped?: boolean;
+    })
+  | (WorkflowScriptAgentEventBase & {
+      type: 'agent:end';
+      outcome: 'skipped';
     });
 
 /**

--- a/src/agent/workflowScript/types.ts
+++ b/src/agent/workflowScript/types.ts
@@ -1,20 +1,16 @@
 import { z } from 'zod';
 
+import {
+  WorkflowTaskIdentitySchema,
+  type WorkflowTaskIdentity,
+} from '@shared/schemas';
+
 const WorkflowScriptPhaseSchema = z.object({
   title: z.string().trim().min(1),
   detail: z.string().optional(),
 });
 
-const WorkflowScriptTaskSchema = z.strictObject({
-  /** Stable identity referenced by agent(..., { id }). */
-  id: z.string().trim().min(1),
-  /** Human-readable task name shown on progress surfaces. */
-  label: z.string().trim().min(1),
-  /** Optional declared phase; must name one of meta.phases when present. */
-  phase: z.string().trim().min(1).optional(),
-});
-
-export type WorkflowScriptTask = z.infer<typeof WorkflowScriptTaskSchema>;
+export type WorkflowScriptTask = WorkflowTaskIdentity;
 
 /**
  * The `export const meta = {...}` block every workflow script must begin
@@ -32,7 +28,7 @@ export const WorkflowScriptMetaSchema = z
      * task by id; label and phase live here rather than being duplicated in
      * executable code.
      */
-    tasks: z.array(WorkflowScriptTaskSchema).optional(),
+    tasks: z.array(WorkflowTaskIdentitySchema).optional(),
     /** Whole-run wall clock, bounded; an explicit run option still wins. */
     timeoutMs: z
       .int()

--- a/src/shared/copy/workflowTask.ts
+++ b/src/shared/copy/workflowTask.ts
@@ -1,0 +1,20 @@
+import type { WorkflowTaskProgress } from '@shared/schemas';
+import { formatCompactDuration, formatCostUsd } from '@utils/text/stringUtils';
+
+/**
+ * Canonical metadata copy for terminal workflow-task progress on every host.
+ */
+export function formatWorkflowTaskMetadataParts(
+  task: WorkflowTaskProgress,
+): string[] {
+  if (task.status !== 'completed' && task.status !== 'failed') return [];
+  return [
+    task.model,
+    task.durationMs === undefined
+      ? undefined
+      : formatCompactDuration(task.durationMs),
+    task.totalCostUsd === undefined
+      ? undefined
+      : `${formatCostUsd(task.totalCostUsd)} total`,
+  ].filter((part): part is string => part !== undefined);
+}

--- a/src/shared/schemas/index.ts
+++ b/src/shared/schemas/index.ts
@@ -20,6 +20,7 @@ export * from './stream';
 export * from './roundIndexed';
 export * from './output';
 export * from './progressEvents';
+export * from './workflowTaskProgress';
 
 // Layer 3: Depends on layer 2
 export * from './log';

--- a/src/shared/schemas/log.ts
+++ b/src/shared/schemas/log.ts
@@ -50,6 +50,7 @@ export const MESSAGE_TYPES = {
   INTERNAL: 'internal',
   CONTEXT_MANAGEMENT: 'contextManagement',
   CONTEXT_STATE: 'contextState',
+  WORKFLOW_TASK: 'workflowTask',
   DEFAULT: 'default',
 } as const;
 

--- a/src/shared/schemas/workflowTaskProgress.ts
+++ b/src/shared/schemas/workflowTaskProgress.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+
+const WorkflowTaskIdentitySchema = z.strictObject({
+  id: z.string().trim().min(1),
+  label: z.string().trim().min(1),
+  phase: z.string().trim().min(1).optional(),
+});
+
+const WorkflowTaskTerminalMetadataSchema = z.strictObject({
+  model: z.string().min(1).optional(),
+  durationMs: z.number().nonnegative().optional(),
+  totalCostUsd: z.number().nonnegative().optional(),
+});
+
+/**
+ * Canonical state of one declared or dynamically issued workflow-script task.
+ * The status discriminant prevents terminal-only metadata from appearing on a
+ * task that has not started.
+ */
+export const WorkflowTaskProgressSchema = z.discriminatedUnion('status', [
+  WorkflowTaskIdentitySchema.extend({
+    status: z.literal('planned'),
+  }),
+  WorkflowTaskIdentitySchema.extend({
+    status: z.literal('running'),
+  }),
+  WorkflowTaskIdentitySchema.extend({
+    status: z.literal('completed'),
+    ...WorkflowTaskTerminalMetadataSchema.shape,
+  }),
+  WorkflowTaskIdentitySchema.extend({
+    status: z.literal('cached'),
+  }),
+  WorkflowTaskIdentitySchema.extend({
+    status: z.literal('skipped'),
+    reason: z.enum(['not-reached', 'user']),
+  }),
+  WorkflowTaskIdentitySchema.extend({
+    status: z.literal('failed'),
+    error: z.string().min(1),
+    ...WorkflowTaskTerminalMetadataSchema.shape,
+  }),
+]);
+
+export type WorkflowTaskProgress = z.infer<typeof WorkflowTaskProgressSchema>;
+
+export const WORKFLOW_TASK_STATUS_LABEL = {
+  planned: 'Planned',
+  running: 'Running',
+  completed: 'Finished',
+  cached: 'Saved result',
+  skipped: 'Skipped',
+  failed: 'Failed',
+} as const satisfies Record<WorkflowTaskProgress['status'], string>;

--- a/src/shared/schemas/workflowTaskProgress.ts
+++ b/src/shared/schemas/workflowTaskProgress.ts
@@ -1,10 +1,24 @@
 import { z } from 'zod';
 
-const WorkflowTaskIdentitySchema = z.strictObject({
-  id: z.string().trim().min(1),
-  label: z.string().trim().min(1),
-  phase: z.string().trim().min(1).optional(),
+export const WorkflowTaskIdentitySchema = z.strictObject({
+  id: z
+    .string()
+    .trim()
+    .min(1)
+    .describe('Stable task identity referenced by workflow agent calls.'),
+  label: z
+    .string()
+    .trim()
+    .min(1)
+    .describe('Human-readable task name shown on progress surfaces.'),
+  phase: z
+    .string()
+    .trim()
+    .min(1)
+    .optional()
+    .describe('Optional declared workflow phase containing the task.'),
 });
+export type WorkflowTaskIdentity = z.infer<typeof WorkflowTaskIdentitySchema>;
 
 const WorkflowTaskTerminalMetadataSchema = z.strictObject({
   model: z.string().min(1).optional(),

--- a/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
@@ -32,6 +32,41 @@ describe('parseWorkflowScript', () => {
     expect(body).not.toContain('export ');
   });
 
+  it('validates the declarative task plan as part of workflow metadata', () => {
+    const { meta } = parseWorkflowScript(`export const meta = {
+  name: 'planned',
+  description: 'declares progress before execution',
+  phases: [{ title: 'Audit' }],
+  tasks: [{ id: 'core', label: 'Audit core', phase: 'Audit' }],
+}
+return null`);
+    expect(meta.tasks).toEqual([
+      { id: 'core', label: 'Audit core', phase: 'Audit' },
+    ]);
+
+    expect(() =>
+      parseWorkflowScript(`export const meta = {
+  name: 'duplicate',
+  description: 'invalid duplicate ids',
+  tasks: [
+    { id: 'same', label: 'First' },
+    { id: 'same', label: 'Second' },
+  ],
+}
+return null`),
+    ).toThrow(/Duplicate task id "same"/);
+
+    expect(() =>
+      parseWorkflowScript(`export const meta = {
+  name: 'unknown-phase',
+  description: 'invalid phase reference',
+  phases: [{ title: 'Known' }],
+  tasks: [{ id: 'task', label: 'Task', phase: 'Unknown' }],
+}
+return null`),
+    ).toThrow(/not declared in meta\.phases/);
+  });
+
   it('rejects scripts without a leading meta export', () => {
     expect(() => parseWorkflowScript(`return 1`)).toThrow(
       WorkflowScriptParseError,
@@ -101,6 +136,70 @@ describe('parseWorkflowScript', () => {
 });
 
 describe('runWorkflowScript', () => {
+  it('uses meta.tasks as the single source for task labels and phases', async () => {
+    const events: WorkflowScriptEvent[] = [];
+    const runner = vi.fn(echoRunner);
+    await runWorkflowScript({
+      script: `export const meta = {
+  name: 'planned-run',
+  description: 'runs a declared plan',
+  phases: [{ title: 'Audit' }],
+  tasks: [{ id: 'core', label: 'Audit core', phase: 'Audit' }],
+}
+return await agent('Inspect src', { id: 'core' })`,
+      runAgent: runner,
+      onEvent: (event) => events.push(event),
+    });
+
+    expect(events[0]).toEqual({
+      type: 'plan',
+      tasks: [{ id: 'core', label: 'Audit core', phase: 'Audit' }],
+    });
+    expect(runner.mock.calls[0][0].options).toMatchObject({
+      id: 'core',
+      label: 'Audit core',
+      phase: 'Audit',
+    });
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: 'agent:start',
+        taskId: 'core',
+        label: 'Audit core',
+        phase: 'Audit',
+      }),
+    );
+  });
+
+  it('rejects calls outside a declared plan and duplicated presentation data', async () => {
+    const plannedMeta = `export const meta = {
+  name: 'strict-plan',
+  description: 'requires task references',
+  tasks: [{ id: 'known', label: 'Known task' }],
+}
+`;
+    await expect(
+      runWorkflowScript({
+        script: `${plannedMeta}return await agent('missing id')`,
+        runAgent: echoRunner,
+      }),
+    ).rejects.toThrow(/must reference a task from meta\.tasks/);
+    await expect(
+      runWorkflowScript({
+        script: `${plannedMeta}return await agent('unknown', { id: 'other' })`,
+        runAgent: echoRunner,
+      }),
+    ).rejects.toThrow(/undeclared task id "other"/);
+    await expect(
+      runWorkflowScript({
+        script: `${plannedMeta}return await agent('duplicate', {
+  id: 'known',
+  label: 'Duplicated label',
+})`,
+        runAgent: echoRunner,
+      }),
+    ).rejects.toThrow(/do not duplicate them in agent\(\) options/);
+  });
+
   it('runs a script end-to-end with agent calls and args', async () => {
     const run = await runWorkflowScript({
       script: `${META}
@@ -221,7 +320,7 @@ return await parallel([
 ])`,
         runAgent: echoRunner,
       }),
-    ).rejects.toThrow(/require distinct non-empty "id" options/i);
+    ).rejects.toThrow(/may be issued only once per run/i);
   });
 
   it('passes typed workflow outputs into the next stage input files', async () => {
@@ -309,7 +408,7 @@ return await parallel([
         order.push(`checkpoint:${entry.index}`);
       },
       onEvent: (event) => {
-        if (event.type === 'agent:end' && !event.error) {
+        if (event.type === 'agent:end' && event.outcome !== 'failed') {
           order.push(`end:${event.index}`);
         }
       },
@@ -502,10 +601,11 @@ return b`,
     expect(events).toEqual([
       {
         type: 'agent:end',
+        taskId: 'call-0',
         index: 0,
         label: 'cached',
         phase: undefined,
-        cached: true,
+        outcome: 'failed',
         error: expect.stringMatching(/must be JSON-serializable/i),
       },
     ]);
@@ -593,6 +693,7 @@ return null`,
     });
     expect(events).toContainEqual({
       type: 'agent:start',
+      taskId: 'call-0',
       index: 0,
       label: 'labelled',
       phase: 'Work',
@@ -1114,16 +1215,18 @@ while (true) {}`,
     expect(events).toEqual([
       {
         type: 'agent:start',
+        taskId: 'call-0',
         index: 0,
         label: 'function-result',
         phase: undefined,
       },
       {
         type: 'agent:end',
+        taskId: 'call-0',
         index: 0,
         label: 'function-result',
         phase: undefined,
-        cached: false,
+        outcome: 'failed',
         error: expect.stringMatching(/must be JSON-serializable/i),
       },
     ]);
@@ -1362,11 +1465,11 @@ return 'incorrect success'`,
     expect(run.journal.map((entry) => entry.index).toSorted()).toEqual([0, 2]);
     expect(events).toContainEqual({
       type: 'agent:end',
+      taskId: 'b',
       index: 1,
       label: 'b',
       phase: undefined,
-      cached: false,
-      skipped: true,
+      outcome: 'skipped',
     });
   });
 

--- a/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
@@ -198,6 +198,16 @@ return await agent('Inspect src', { id: 'core' })`,
         runAgent: echoRunner,
       }),
     ).rejects.toThrow(/do not duplicate them in agent\(\) options/);
+
+    await expect(
+      runWorkflowScript({
+        script: `${plannedMeta}return await parallel([
+  () => agent('first use', { id: 'known' }),
+  () => agent('second use', { id: 'known' }),
+])`,
+        runAgent: echoRunner,
+      }),
+    ).rejects.toThrow(/may be issued only once per run/i);
   });
 
   it('runs a script end-to-end with agent calls and args', async () => {
@@ -302,6 +312,19 @@ return await parallel([
       'second',
     ]);
 
+    const reusedIdInvocations: WorkflowAgentInvocation[] = [];
+    await runWorkflowScript({
+      script: `${META}return await parallel([
+  () => agent('first prompt', { id: 'shared-id' }),
+  () => agent('second prompt', { id: 'shared-id' }),
+])`,
+      runAgent: (invocation) => {
+        reusedIdInvocations.push(invocation);
+        return echoRunner(invocation);
+      },
+    });
+    expect(reusedIdInvocations).toHaveLength(2);
+
     await expect(
       runWorkflowScript({
         script: `${META}return await parallel([
@@ -317,10 +340,10 @@ return await parallel([
         script: `${META}return await parallel([
   () => agent('same', { id: 'same-id' }),
   () => agent('same', { id: ' same-id ' }),
-])`,
+        ])`,
         runAgent: echoRunner,
       }),
-    ).rejects.toThrow(/may be issued only once per run/i);
+    ).rejects.toThrow(/require distinct non-empty "id" options/i);
   });
 
   it('passes typed workflow outputs into the next stage input files', async () => {

--- a/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
@@ -37,6 +37,19 @@ function stageId(events: readonly AgentEvent[], label: string): string {
   return event.id;
 }
 
+function workflowTaskEvent(
+  events: readonly AgentEvent[],
+  label: string,
+  status: string,
+): Extract<AgentEvent, { type: 'workflow.task' }> | undefined {
+  return events.find(
+    (event): event is Extract<AgentEvent, { type: 'workflow.task' }> =>
+      event.type === 'workflow.task' &&
+      event.task.label === label &&
+      event.task.status === status,
+  );
+}
+
 beforeEach(() => clearStoreCache());
 
 describe('workflow-script progress bridge', () => {
@@ -47,6 +60,7 @@ describe('workflow-script progress bridge', () => {
   name: 'planned-progress-test',
   description: 'tests planned workflow progress projection',
   phases: [{ title: 'Research' }, { title: 'Write' }],
+  tasks: [{ id: 'inspect', label: 'Inspect source', phase: 'Research' }],
 }`;
 
     await parent.within(() =>
@@ -57,7 +71,7 @@ describe('workflow-script progress bridge', () => {
 log('Preparing the workflow')
 phase('Research')
 log('Checking the source')
-return await agent('Inspect')`,
+return await agent('Inspect', { id: 'inspect' })`,
         runAgent: async () => 'done',
       }),
     );
@@ -70,6 +84,17 @@ return await agent('Inspect')`,
         stageId: parent.id,
       }),
     );
+    const planned = workflowTaskEvent(events, 'Inspect source', 'planned');
+    const completed = workflowTaskEvent(events, 'Inspect source', 'completed');
+    expect(planned).toMatchObject({
+      type: 'workflow.task',
+      stageId: parent.id,
+    });
+    expect(completed).toMatchObject({
+      type: 'workflow.task',
+      logId: planned?.logId,
+      stageId: phaseId,
+    });
     expect(events).toContainEqual(
       expect.objectContaining({
         type: 'stage.start',
@@ -97,6 +122,31 @@ return await agent('Inspect')`,
     );
   });
 
+  it('marks declared tasks not reached by the script as skipped', async () => {
+    const { trace, events } = recordingTrace();
+    await runPersistedWorkflowScriptWithProgress(trace, {
+      store: getExecutionStore(executionId),
+      checkpointId: 'not-reached-plan',
+      script: `export const meta = {
+  name: 'conditional-plan',
+  description: 'declares all possible work',
+  tasks: [
+    { id: 'used', label: 'Used task' },
+    { id: 'unused', label: 'Unused task' },
+  ],
+}
+return await agent('Run one', { id: 'used' })`,
+      runAgent: async () => 'done',
+    });
+
+    expect(workflowTaskEvent(events, 'Used task', 'completed')).toBeDefined();
+    expect(workflowTaskEvent(events, 'Unused task', 'skipped')).toMatchObject({
+      task: {
+        reason: 'not-reached',
+      },
+    });
+  });
+
   it('projects a cached completion without synthesizing a start event', async () => {
     const store = getExecutionStore(executionId);
     const script = `${meta}
@@ -119,16 +169,11 @@ return await agent('Read', { phase: 'Review' })`;
 
     const phaseId = stageId(events, 'Review');
     expect(runner).not.toHaveBeenCalled();
-    expect(events).toContainEqual(
-      expect.objectContaining({
-        type: 'log',
-        message: 'Using saved result: Read',
-        stageId: phaseId,
-      }),
-    );
-    expect(events).not.toContainEqual(
-      expect.objectContaining({ type: 'log', message: 'Running: Read' }),
-    );
+    expect(workflowTaskEvent(events, 'Read', 'cached')).toMatchObject({
+      type: 'workflow.task',
+      stageId: phaseId,
+    });
+    expect(workflowTaskEvent(events, 'Read', 'running')).toBeUndefined();
   });
 
   it('keeps phase counts when an agent opens the stage before phase()', async () => {
@@ -178,18 +223,16 @@ return await agent('Second')`;
       getLiveCostUsd: () => liveCostUsd,
     });
 
-    expect(events).toContainEqual(
-      expect.objectContaining({
-        type: 'log',
-        message: 'Finished: First ($0.050 total)',
-      }),
+    expect(workflowTaskEvent(events, 'First', 'completed')?.task).toMatchObject(
+      {
+        totalCostUsd: 0.05,
+      },
     );
-    expect(events).toContainEqual(
-      expect.objectContaining({
-        type: 'log',
-        message: 'Finished: Second ($0.100 total)',
-      }),
-    );
+    expect(
+      workflowTaskEvent(events, 'Second', 'completed')?.task,
+    ).toMatchObject({
+      totalCostUsd: 0.1,
+    });
 
     clearStoreCache();
     const replay = recordingTrace();
@@ -201,18 +244,9 @@ return await agent('Second')`;
       getLiveCostUsd: () => 0,
     });
 
-    expect(replay.events).toContainEqual(
-      expect.objectContaining({
-        type: 'log',
-        message: 'Using saved result: First',
-      }),
-    );
-    expect(replay.events).not.toContainEqual(
-      expect.objectContaining({
-        type: 'log',
-        message: expect.stringContaining('total)'),
-      }),
-    );
+    expect(
+      workflowTaskEvent(replay.events, 'First', 'cached')?.task,
+    ).not.toHaveProperty('totalCostUsd');
   });
 
   it('enriches live finish lines with the reported model and duration', async () => {
@@ -231,12 +265,12 @@ return await agent('Draft')`,
       getLiveCostUsd: () => liveCostUsd,
     });
 
-    const finish = events.find(
-      (event) =>
-        event.type === 'log' && event.message.startsWith('Finished: Draft'),
-    );
-    expect(finish?.type === 'log' ? finish.message : '').toMatch(
-      /^Finished: Draft · deepseekT · \d+s \(\$0\.020 total\)$/,
+    expect(workflowTaskEvent(events, 'Draft', 'completed')?.task).toMatchObject(
+      {
+        model: 'deepseekT',
+        durationMs: expect.any(Number),
+        totalCostUsd: 0.02,
+      },
     );
   });
 
@@ -254,14 +288,13 @@ return await agent('Unsuccessful')`,
     });
 
     const phaseId = stageId(events, 'Analysis');
-    expect(events).toContainEqual(
-      expect.objectContaining({
-        type: 'log',
-        level: 'error',
-        message: 'Failed: Unsuccessful - model unavailable',
-        stageId: phaseId,
-      }),
-    );
+    expect(workflowTaskEvent(events, 'Unsuccessful', 'failed')).toMatchObject({
+      type: 'workflow.task',
+      stageId: phaseId,
+      task: {
+        error: 'model unavailable',
+      },
+    });
     expect(events).toContainEqual({
       type: 'stage.end',
       id: phaseId,
@@ -294,20 +327,12 @@ return await parallel([
 
     const firstId = stageId(events, 'First');
     const secondId = stageId(events, 'Second');
-    expect(events).toContainEqual(
-      expect.objectContaining({
-        type: 'log',
-        message: 'Finished: slow',
-        stageId: firstId,
-      }),
-    );
-    expect(events).toContainEqual(
-      expect.objectContaining({
-        type: 'log',
-        message: 'Finished: fast',
-        stageId: secondId,
-      }),
-    );
+    expect(workflowTaskEvent(events, 'slow', 'completed')).toMatchObject({
+      stageId: firstId,
+    });
+    expect(workflowTaskEvent(events, 'fast', 'completed')).toMatchObject({
+      stageId: secondId,
+    });
   });
 
   it('does not move an unphased live call into a later phase', async () => {
@@ -322,11 +347,11 @@ return await pending`,
       runAgent: async () => 'done',
     });
 
-    const completion = events.find(
-      (event) =>
-        event.type === 'log' && event.message === 'Finished: before phase',
-    );
-    expect(completion).toMatchObject({ type: 'log', stageId: undefined });
+    const completion = workflowTaskEvent(events, 'before phase', 'completed');
+    expect(completion).toMatchObject({
+      type: 'workflow.task',
+      stageId: undefined,
+    });
     expect(completion).not.toMatchObject({ stageId: stageId(events, 'Later') });
   });
 
@@ -345,9 +370,12 @@ return await agent('Abort', { phase: 'Execution' })`,
     ).rejects.toThrow('fatal runner error');
 
     const phaseId = stageId(events, 'Execution');
-    expect(events).not.toContainEqual(
-      expect.objectContaining({ type: 'log', message: 'Finished: Abort' }),
-    );
+    expect(workflowTaskEvent(events, 'Abort', 'failed')).toMatchObject({
+      stageId: phaseId,
+      task: {
+        error: 'The workflow ended before this task completed.',
+      },
+    });
     expect(events).toContainEqual({
       type: 'stage.end',
       id: phaseId,

--- a/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
@@ -130,17 +130,21 @@ return await agent('Inspect', { id: 'inspect' })`,
       script: `export const meta = {
   name: 'conditional-plan',
   description: 'declares all possible work',
+  phases: [{ title: 'Research' }],
   tasks: [
-    { id: 'used', label: 'Used task' },
-    { id: 'unused', label: 'Unused task' },
+    { id: 'used', label: 'Used task', phase: 'Research' },
+    { id: 'unused', label: 'Unused task', phase: 'Research' },
   ],
 }
+phase('Research')
 return await agent('Run one', { id: 'used' })`,
       runAgent: async () => 'done',
     });
 
+    const researchStageId = stageId(events, 'Research');
     expect(workflowTaskEvent(events, 'Used task', 'completed')).toBeDefined();
     expect(workflowTaskEvent(events, 'Unused task', 'skipped')).toMatchObject({
+      stageId: researchStageId,
       task: {
         reason: 'not-reached',
       },

--- a/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.mts
+++ b/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.mts
@@ -1,5 +1,5 @@
 // A detached delegate_workflow_script run owns a child stream. Its phases and
-// per-agent log lines render through the focused-child viewport, while the
+// typed task records render through the focused-child viewport, while the
 // workflow-specific header identifies the kind of child execution.
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -65,16 +65,55 @@ afterEach(() => {
 });
 
 describe('CLI workflow-script child-stream transcript', () => {
-  it('renders phases and per-agent log lines from the run stream trace', async () => {
+  it('updates one visible task record from planned to completed', async () => {
     const runTrace = createRunTrace(STREAM_ID, defaultSession().transcripts);
     try {
+      runTrace.trace.emit({
+        type: 'workflow.task',
+        logId: 'introduction-task',
+        task: {
+          id: 'introduction',
+          label: 'Draft introduction',
+          phase: 'Draft sections',
+          status: 'planned',
+        },
+      });
+      syncStreamLog(STREAM_ID);
+      expect(
+        streams
+          .get()
+          .get(STREAM_ID)
+          ?.entries.find((entry) => entry.id === 'introduction-task')?.text,
+      ).toBe('Planned: Draft introduction');
+
       const phase = runTrace.trace.openStage('Draft sections', {
         id: 'draft-phase',
         kind: 'phase',
       });
-      runTrace.trace.info('Running: introduction', { stageId: phase.id });
-      runTrace.trace.info('Finished: introduction ($0.002 total)', {
+      runTrace.trace.emit({
+        type: 'workflow.task',
+        logId: 'introduction-task',
         stageId: phase.id,
+        task: {
+          id: 'introduction',
+          label: 'Draft introduction',
+          phase: 'Draft sections',
+          status: 'running',
+        },
+      });
+      runTrace.trace.emit({
+        type: 'workflow.task',
+        logId: 'introduction-task',
+        stageId: phase.id,
+        task: {
+          id: 'introduction',
+          label: 'Draft introduction',
+          phase: 'Draft sections',
+          status: 'completed',
+          model: 'deepseekT',
+          durationMs: 12_000,
+          totalCostUsd: 0.002,
+        },
       });
       phase.end('completed');
 
@@ -82,11 +121,14 @@ describe('CLI workflow-script child-stream transcript', () => {
 
       const entries = streams.get().get(STREAM_ID)?.entries ?? [];
       const texts = entries.map((entry) => entry.text);
-      // The phase group row surfaces its label; the agent lines surface as
-      // their own generic assistant rows — the parity bar for a focused run.
+      // The phase group row and the task's current state both surface.
       expect(texts).toContain('Draft sections');
-      expect(texts).toContain('Running: introduction');
-      expect(texts).toContain('Finished: introduction ($0.002 total)');
+      expect(texts).toContain(
+        'Finished: Draft introduction · deepseekT · 12s · $0.002 total',
+      );
+      expect(
+        entries.filter((entry) => entry.id === 'introduction-task'),
+      ).toHaveLength(1);
 
       // The phase group is a distinct `role: 'phase'` header, not a plain
       // assistant row, so the CLI can render it as a divider between phases.
@@ -146,8 +188,8 @@ describe('CLI workflow-script child-stream transcript', () => {
       const output = await renderStaticTranscript();
       // The phase header renders with its distinct diamond divider glyph.
       expect(output).toContain('◆ Draft sections');
-      expect(output).toContain('Running: introduction');
-      expect(output).toContain('Finished: introduction ($0.002 total)');
+      expect(output).toContain('Finished: Draft introduction');
+      expect(output).toContain('deepseekT · 12s · $0.002 total');
     } finally {
       runTrace.dispose();
     }

--- a/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.mts
+++ b/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.mts
@@ -65,6 +65,91 @@ afterEach(() => {
 });
 
 describe('CLI workflow-script child-stream transcript', () => {
+  it('keeps planned task rows live until their terminal state is printable', () => {
+    const runTrace = createRunTrace(STREAM_ID, defaultSession().transcripts);
+    try {
+      for (const [id, label] of [
+        ['core', 'Audit core'],
+        ['extension', 'Audit extension'],
+      ] as const) {
+        runTrace.trace.emit({
+          type: 'workflow.task',
+          logId: `${id}-task`,
+          task: { id, label, status: 'planned' },
+        });
+      }
+      syncStreamLog(STREAM_ID);
+
+      const plannedEntries = streams.get().get(STREAM_ID)?.entries ?? [];
+      expect(plannedEntries).toMatchObject([
+        {
+          id: 'core-task',
+          role: 'workflowTask',
+          finalized: false,
+          task: { id: 'core', status: 'planned' },
+        },
+        {
+          id: 'extension-task',
+          role: 'workflowTask',
+          finalized: false,
+          task: { id: 'extension', status: 'planned' },
+        },
+      ]);
+
+      const plannedItems = appendStaticTranscriptItems({
+        currentItems: [],
+        meta: SESSION_META,
+        scrollbackStreamId: STREAM_ID,
+        streams: streams.get(),
+      });
+      expect(plannedItems.filter((item) => item.kind === 'entry')).toHaveLength(
+        0,
+      );
+
+      runTrace.trace.emit({
+        type: 'workflow.task',
+        logId: 'core-task',
+        task: {
+          id: 'core',
+          label: 'Audit core',
+          status: 'completed',
+          model: 'deepseekT',
+        },
+      });
+      syncStreamLog(STREAM_ID);
+
+      const updatedEntries = streams.get().get(STREAM_ID)?.entries ?? [];
+      expect(updatedEntries).toMatchObject([
+        {
+          id: 'core-task',
+          finalized: true,
+          task: { status: 'completed' },
+          text: 'Finished: Audit core · deepseekT',
+        },
+        {
+          id: 'extension-task',
+          finalized: false,
+          task: { status: 'planned' },
+          text: 'Planned: Audit extension',
+        },
+      ]);
+
+      const updatedItems = appendStaticTranscriptItems({
+        currentItems: plannedItems,
+        meta: SESSION_META,
+        scrollbackStreamId: STREAM_ID,
+        streams: streams.get(),
+      });
+      expect(
+        updatedItems
+          .filter((item) => item.kind === 'entry')
+          .map((item) => item.entry.text),
+      ).toEqual(['Finished: Audit core · deepseekT']);
+    } finally {
+      runTrace.dispose();
+    }
+  });
+
   it('updates one visible task record from planned to completed', async () => {
     const runTrace = createRunTrace(STREAM_ID, defaultSession().transcripts);
     try {

--- a/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
+++ b/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
@@ -10,6 +10,7 @@ import type {
 } from '@progressView/frontend/components/messageIndex';
 import {
   LOG_LEVELS,
+  MESSAGE_TYPES,
   STREAM_PHASE,
   type LogMessageData,
   type TaskGroup,
@@ -427,12 +428,10 @@ describe('task-group-list status icon (#7993 step 3)', () => {
 
 // #8722 Phase 2b: a focused delegate_workflow_script run projects its phases
 // as `kind: 'phase'` groups with per-agent Running/Finished/Failed lines
-// beneath. This locks the extension progress view at parity with the CLI's
-// phase/per-agent rendering (#8739): the phase renders as a group header with
-// its label plus the one-based `(i/n)` position, the enriched per-agent lines
-// render under it, and a `Failed:` line keeps error-level styling.
+// beneath. The phase header and task cards are both derived from typed state;
+// the renderer does not parse status prefixes from prose.
 describe('task-group-list workflow-script phase rendering (#8722)', () => {
-  it('renders a phase group with its (i/n) header and per-agent lines beneath', async () => {
+  it('renders a phase group with its (i/n) header and task cards beneath', async () => {
     const run: TaskGroup = {
       id: 'run',
       name: 'Run: workflow',
@@ -452,17 +451,36 @@ describe('task-group-list workflow-script phase rendering (#8722)', () => {
     const messages: LogMessageData[] = [
       {
         id: 'agent-a',
-        text: 'Finished: reviewer · claude-opus-4 · 12.3s ($0.04)',
+        text: 'reviewer',
         timestamp: 3,
         level: LOG_LEVELS.INFO,
         groupId: 'phase-review',
+        messageType: MESSAGE_TYPES.WORKFLOW_TASK,
+        data: {
+          id: 'reviewer',
+          label: 'Review manuscript',
+          phase: 'Review',
+          status: 'completed',
+          model: 'claude-opus-4',
+          durationMs: 12_300,
+          totalCostUsd: 0.04,
+        },
       },
       {
         id: 'agent-b',
-        text: 'Failed: critic - timed out ($0.01 total)',
+        text: 'critic',
         timestamp: 4,
         level: LOG_LEVELS.ERROR,
         groupId: 'phase-review',
+        messageType: MESSAGE_TYPES.WORKFLOW_TASK,
+        data: {
+          id: 'critic',
+          label: 'Check argument',
+          phase: 'Review',
+          status: 'failed',
+          error: 'timed out',
+          totalCostUsd: 0.01,
+        },
       },
     ];
 
@@ -477,16 +495,18 @@ describe('task-group-list workflow-script phase rendering (#8722)', () => {
       ?.textContent?.trim();
     expect(title).toBe('Review (2/3)');
 
-    // The enriched per-agent lines render under the phase group, and the
-    // Failed line keeps error-level styling.
+    // Each task is one structured card with its status and terminal metadata.
     const content = list.shadowRoot?.querySelector(
       `#${GROUP_DOM_IDS.CONTENT_PREFIX}phase-review`,
     );
+    expect(content?.textContent).toContain('Review manuscript');
+    expect(content?.textContent).toContain('Finished');
     expect(content?.textContent).toContain(
-      'Finished: reviewer · claude-opus-4 · 12.3s ($0.04)',
+      'claude-opus-4 · 12s · $0.040 total',
     );
-    expect(content?.textContent).toContain('Failed: critic - timed out');
-    expect(content?.querySelector('.message-error')).not.toBeNull();
+    expect(content?.textContent).toContain('Check argument');
+    expect(content?.textContent).toContain('timed out');
+    expect(content?.querySelector('.workflow-task--failed')).not.toBeNull();
   });
 
   it('omits the (i/n) suffix when a phase group carries no counts', async () => {

--- a/src/test-kernel/shared/WorkflowTaskCopy.vitest.ts
+++ b/src/test-kernel/shared/WorkflowTaskCopy.vitest.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatWorkflowTaskMetadataParts } from '@shared/copy/workflowTask';
+
+describe('workflow task copy', () => {
+  it('uses one terminal metadata representation across hosts', () => {
+    expect(
+      formatWorkflowTaskMetadataParts({
+        id: 'draft',
+        label: 'Draft',
+        status: 'completed',
+        model: 'gpt56',
+        durationMs: 7_320,
+        totalCostUsd: 0.04,
+      }),
+    ).toEqual(['gpt56', '7s', '$0.040 total']);
+  });
+
+  it('does not attach terminal metadata to an active task', () => {
+    expect(
+      formatWorkflowTaskMetadataParts({
+        id: 'draft',
+        label: 'Draft',
+        status: 'running',
+      }),
+    ).toEqual([]);
+  });
+});

--- a/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
+++ b/src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts
@@ -250,6 +250,58 @@ describe('attachTranscriptRecorder response.finalized (issue #7086)', () => {
   });
 });
 
+describe('attachTranscriptRecorder workflow task state', () => {
+  it('updates one typed task entry from planned to completed', () => {
+    const trace = new TraceEmitter();
+    const store = StreamLogStore.ephemeral('test');
+    const streamId = 'stream:workflow-task' as StreamTabId;
+    store.ensureStream(streamId);
+    attachTranscriptRecorder(trace, store.acquireWriter(streamId, streamId));
+
+    trace.emit({
+      type: 'workflow.task',
+      logId: 'task-card',
+      task: {
+        id: 'audit-core',
+        label: 'Audit core',
+        phase: 'Audit',
+        status: 'planned',
+      },
+    });
+    trace.emit({
+      type: 'workflow.task',
+      logId: 'task-card',
+      stageId: 'phase-audit',
+      task: {
+        id: 'audit-core',
+        label: 'Audit core',
+        phase: 'Audit',
+        status: 'completed',
+        model: 'gpt56',
+        durationMs: 12_000,
+        totalCostUsd: 0.03,
+      },
+    });
+
+    const entries = store.get(streamId)?.getRange(0) ?? [];
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      id: 'task-card',
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: 'info',
+      groupId: 'phase-audit',
+      messageType: MESSAGE_TYPES.WORKFLOW_TASK,
+      text: 'Audit core',
+      data: {
+        status: 'completed',
+        model: 'gpt56',
+        durationMs: 12_000,
+        totalCostUsd: 0.03,
+      },
+    });
+  });
+});
+
 describe('attachTranscriptRecorder timer failure boundary', () => {
   it('latches a delayed write failure instead of throwing from the timer', () => {
     vi.useFakeTimers();

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -8,7 +8,12 @@ import {
   type WorkflowScriptRunResult,
 } from '@agent/workflowScript';
 import { AgentFinalResultSchema } from '@agent/runtime/AgentFinalResult';
-import { RUN_OUTCOME, type RunOutcome } from '@shared/schemas';
+import {
+  RUN_OUTCOME,
+  type RunOutcome,
+  type WorkflowTaskProgress,
+} from '@shared/schemas';
+import { generateShortId } from '@utils/core';
 import { formatCompactDuration, formatCostUsd } from '@utils/text/stringUtils';
 
 type WorkflowScriptRunWithProgressOptions = Omit<
@@ -107,7 +112,13 @@ export async function runPersistedWorkflowScriptWithProgress(
   const { getLiveCostUsd, onActivity, ...runOptions } = options;
   const parentStageId = trace.activeStageId();
   const phases = new Map<string, PhaseStage>();
-  const callPhases = new Map<number, string | undefined>();
+  const callPhases = new Map<string, string | undefined>();
+  const taskLogIds = new Map<string, string>();
+  const taskStates = new Map<string, WorkflowTaskProgress['status']>();
+  const taskDefinitions = new Map<
+    string,
+    Pick<WorkflowTaskProgress, 'id' | 'label' | 'phase'>
+  >();
   let currentPhase: string | undefined;
   let closed = false;
   let runOutcome: RunOutcome = RUN_OUTCOME.FAILED;
@@ -143,14 +154,37 @@ export async function runPersistedWorkflowScriptWithProgress(
     trace.info(message, { stageId });
     onActivity?.(message);
   };
-  const error = (message: string, stageId: string | undefined): void => {
-    trace.error(message, { stageId });
-    onActivity?.(message);
+  const emitTask = (
+    task: WorkflowTaskProgress,
+    stageId: string | undefined,
+  ): void => {
+    let logId = taskLogIds.get(task.id);
+    if (!logId) {
+      logId = `workflow-task-${generateShortId()}`;
+      taskLogIds.set(task.id, logId);
+    }
+    taskStates.set(task.id, task.status);
+    taskDefinitions.set(task.id, {
+      id: task.id,
+      label: task.label,
+      ...(task.phase !== undefined ? { phase: task.phase } : {}),
+    });
+    trace.emit({
+      type: 'workflow.task',
+      logId,
+      task,
+      stageId,
+    });
   };
 
   const project = (event: WorkflowScriptEvent): void => {
     if (closed) return;
     switch (event.type) {
+      case 'plan':
+        for (const task of event.tasks) {
+          emitTask({ ...task, status: 'planned' }, parentStageId);
+        }
+        break;
       case 'phase':
         currentPhase = event.title;
         phaseFor(event.title, event.index, event.total);
@@ -161,19 +195,31 @@ export async function runPersistedWorkflowScriptWithProgress(
         break;
       case 'agent:start': {
         const phaseTitle = event.phase ?? currentPhase;
-        callPhases.set(event.index, phaseTitle);
-        trace.info(`Running: ${event.label}`, {
-          stageId: stageIdFor(phaseTitle, event.phaseIndex, event.phaseTotal),
-        });
+        callPhases.set(event.taskId, phaseTitle);
+        const stageId = stageIdFor(
+          phaseTitle,
+          event.phaseIndex,
+          event.phaseTotal,
+        );
+        emitTask(
+          {
+            id: event.taskId,
+            label: event.label,
+            ...(phaseTitle !== undefined ? { phase: phaseTitle } : {}),
+            status: 'running',
+          },
+          stageId,
+        );
+        onActivity?.(`Running: ${event.label}`);
         break;
       }
       case 'agent:end': {
         // A recorded undefined means the live call started outside any phase;
         // only cached end-only events may use the phase active at replay time.
-        const phaseTitle = callPhases.has(event.index)
-          ? callPhases.get(event.index)
+        const phaseTitle = callPhases.has(event.taskId)
+          ? callPhases.get(event.taskId)
           : (event.phase ?? currentPhase);
-        callPhases.delete(event.index);
+        callPhases.delete(event.taskId);
         const stageId = stageIdFor(
           phaseTitle,
           event.phaseIndex,
@@ -181,31 +227,89 @@ export async function runPersistedWorkflowScriptWithProgress(
         );
         // Cached replays spend nothing, so their lines stay cost-free; live
         // onCost settles before agent:end, so the total here is current.
-        const spent = event.cached ? undefined : getLiveCostUsd?.();
+        const spent =
+          event.outcome === 'completed' || event.outcome === 'failed'
+            ? getLiveCostUsd?.()
+            : undefined;
         const total =
           spent === undefined ? '' : ` (${formatCostUsd(spent)} total)`;
         // Live calls carry the resolved child model plus host-measured wall
         // time; the duration rides alongside the model so it never appears as
         // a bare orphan. Cached replays report neither, so the suffix is empty.
-        const duration =
-          event.durationMs === undefined
-            ? ''
-            : ` · ${formatCompactDuration(event.durationMs)}`;
-        const metaSuffix =
-          event.model === undefined ? '' : ` · ${event.model}${duration}`;
-        if (event.error) {
-          if (phaseTitle) {
-            phaseFor(phaseTitle, event.phaseIndex, event.phaseTotal).failed =
-              true;
+        switch (event.outcome) {
+          case 'failed': {
+            if (phaseTitle) {
+              phaseFor(phaseTitle, event.phaseIndex, event.phaseTotal).failed =
+                true;
+            }
+            const task: WorkflowTaskProgress = {
+              id: event.taskId,
+              label: event.label,
+              ...(phaseTitle !== undefined ? { phase: phaseTitle } : {}),
+              status: 'failed',
+              error: event.error,
+              ...(event.model !== undefined ? { model: event.model } : {}),
+              ...(event.durationMs !== undefined
+                ? { durationMs: event.durationMs }
+                : {}),
+              ...(spent !== undefined ? { totalCostUsd: spent } : {}),
+            };
+            emitTask(task, stageId);
+            const duration =
+              event.durationMs === undefined
+                ? ''
+                : ` · ${formatCompactDuration(event.durationMs)}`;
+            const metaSuffix =
+              event.model === undefined ? '' : ` · ${event.model}${duration}`;
+            onActivity?.(
+              `Failed: ${event.label}${metaSuffix} - ${event.error}${total}`,
+            );
+            break;
           }
-          error(
-            `Failed: ${event.label}${metaSuffix} - ${event.error}${total}`,
-            stageId,
-          );
-        } else if (event.cached) {
-          info(`Using saved result: ${event.label}`, stageId);
-        } else {
-          info(`Finished: ${event.label}${metaSuffix}${total}`, stageId);
+          case 'cached':
+            emitTask(
+              {
+                id: event.taskId,
+                label: event.label,
+                ...(phaseTitle !== undefined ? { phase: phaseTitle } : {}),
+                status: 'cached',
+              },
+              stageId,
+            );
+            onActivity?.(`Using saved result: ${event.label}`);
+            break;
+          case 'skipped':
+            emitTask(
+              {
+                id: event.taskId,
+                label: event.label,
+                ...(phaseTitle !== undefined ? { phase: phaseTitle } : {}),
+                status: 'skipped',
+                reason: 'user',
+              },
+              stageId,
+            );
+            onActivity?.(`Skipped: ${event.label}`);
+            break;
+          case 'completed': {
+            emitTask(
+              {
+                id: event.taskId,
+                label: event.label,
+                ...(phaseTitle !== undefined ? { phase: phaseTitle } : {}),
+                status: 'completed',
+                ...(event.model !== undefined ? { model: event.model } : {}),
+                durationMs: event.durationMs,
+                ...(spent !== undefined ? { totalCostUsd: spent } : {}),
+              },
+              stageId,
+            );
+            const duration = ` · ${formatCompactDuration(event.durationMs)}`;
+            const metaSuffix =
+              event.model === undefined ? '' : ` · ${event.model}${duration}`;
+            onActivity?.(`Finished: ${event.label}${metaSuffix}${total}`);
+            break;
+          }
         }
         break;
       }
@@ -221,6 +325,29 @@ export async function runPersistedWorkflowScriptWithProgress(
     return result;
   } finally {
     closed = true;
+    for (const [taskId, status] of taskStates) {
+      const task = taskDefinitions.get(taskId);
+      if (!task) continue;
+      if (status === 'planned') {
+        emitTask(
+          {
+            ...task,
+            status: 'skipped',
+            reason: 'not-reached',
+          },
+          parentStageId,
+        );
+      } else if (status === 'running') {
+        emitTask(
+          {
+            ...task,
+            status: 'failed',
+            error: 'The workflow ended before this task completed.',
+          },
+          task.phase ? phases.get(task.phase)?.handle.id : parentStageId,
+        );
+      }
+    }
     for (const phase of phases.values()) {
       phase.handle.end(
         runOutcome === RUN_OUTCOME.COMPLETED && !phase.failed

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -176,6 +176,12 @@ export async function runPersistedWorkflowScriptWithProgress(
       stageId,
     });
   };
+  const finalStageIdFor = (
+    task: Pick<WorkflowTaskProgress, 'phase'>,
+  ): string | undefined =>
+    task.phase === undefined
+      ? parentStageId
+      : (phases.get(task.phase)?.handle.id ?? parentStageId);
 
   const project = (event: WorkflowScriptEvent): void => {
     if (closed) return;
@@ -335,7 +341,7 @@ export async function runPersistedWorkflowScriptWithProgress(
             status: 'skipped',
             reason: 'not-reached',
           },
-          parentStageId,
+          finalStageIdFor(task),
         );
       } else if (status === 'running') {
         emitTask(
@@ -344,7 +350,7 @@ export async function runPersistedWorkflowScriptWithProgress(
             status: 'failed',
             error: 'The workflow ended before this task completed.',
           },
-          task.phase ? phases.get(task.phase)?.handle.id : parentStageId,
+          finalStageIdFor(task),
         );
       }
     }

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -29,6 +29,7 @@ import {
   type LogLevel,
   type MessageType,
   type ToolUseLog,
+  type WorkflowTaskProgress,
 } from '@shared/schemas';
 import { generateShortId } from '@utils/core';
 
@@ -120,6 +121,7 @@ export function attachTranscriptRecorder(
   // rely on that distinction to tell a root run's terminal status apart from
   // a round's (see toStreamLifecycleStatus in packages/trace-viewer).
   const stageKinds = new Map<string, 'run' | 'round' | 'phase' | 'session'>();
+  const workflowTaskEntries = new Set<string>();
   // Id of the current model invocation's MODEL_RESPONSE stream entry, so a
   // subsequent `response.finalized` event (#7086) can upsert that entry's text
   // instead of appending a duplicate row. Set on `stream.start` for a
@@ -312,6 +314,31 @@ export function attachTranscriptRecorder(
               status: event.status,
             } as ToolUseLog,
           });
+          return;
+        }
+
+        case 'workflow.task': {
+          const level: LogLevel =
+            event.task.status === 'failed' ? 'error' : 'info';
+          const entry = {
+            level,
+            groupId: event.stageId,
+            messageType: MESSAGE_TYPES.WORKFLOW_TASK,
+            text: event.task.label,
+            data: event.task satisfies WorkflowTaskProgress,
+          };
+          if (workflowTaskEntries.has(event.logId)) {
+            writer.update(event.logId, entry);
+          } else {
+            workflowTaskEntries.add(event.logId);
+            writer.append({
+              id: event.logId,
+              type: STREAM_LOG_ENTRY_TYPES.LOG,
+              timestamp: Date.now(),
+              ...entry,
+              verbose: isDebugModeEnabled(),
+            });
+          }
           return;
         }
 

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -327,6 +327,7 @@ function conversationMessagesForEntry(entry: StreamLogEntry): unknown[] {
     case MESSAGE_TYPES.INTERNAL:
     case MESSAGE_TYPES.CONTEXT_MANAGEMENT:
     case MESSAGE_TYPES.CONTEXT_STATE:
+    case MESSAGE_TYPES.WORKFLOW_TASK:
     case MESSAGE_TYPES.DEFAULT:
       return [];
     default:


### PR DESCRIPTION
## Summary

- add an optional declarative `meta.tasks` plan whose task identifiers, labels, and phases form the single source of truth for workflow progress
- replace duplicate Running/Finished prose rows with one typed task record that moves through planned, running, completed, cached, skipped, or failed states
- render the same typed state as status cards in the extension and concise changing lines in the CLI
- close tasks that are not reached or whose workflow ends abnormally, preventing stale pending records and permanent spinners

## Design

The earlier projection encoded task state in human-readable strings. That hid future work, duplicated one call across several rows, and required presentation code to infer meaning from text. This change introduces a discriminated task-state schema at the runtime boundary. The transcript updates a record by correlation identifier, while renderers only display validated state.

Static workflows may declare `meta.tasks`; then every `agent()` call references one task by `id`, and presentation metadata is not duplicated in executable code. Data-dependent workflows may omit the plan and still receive typed live task records.

This pull request is stacked on #9119 because workflow-script stream identity must land first. It is deliberately separate from file context and model routing.

## Validation

- `npm run typecheck`
- `npm run lint -- --no-cache`
- `npm run check:dead-code-ratchet`
- `npm run compile:fast`
- `npm test` — 7,413 passed, 4 skipped
- focused workflow engine, progress bridge, transcript, extension rendering, and CLI rendering tests — 115 passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches workflow-script execution rules, trace/transcript persistence, and dual UI render paths; behavior changes for all workflow-script runs but is guarded by schema validation and broad tests.
> 
> **Overview**
> Workflow scripts can optionally declare **`meta.tasks`** so labels and phases live in one plan; when present, every **`agent()`** must use **`{ id }`** (no duplicated label/phase), the engine emits a **`plan`** event up front, and each call maps to a stable **`taskId`** with **`outcome`**-based **`agent:end`** events instead of a **`cached`** flag.
> 
> Progress is no longer inferred from **Running:/Finished:** log strings. A **`workflow.task`** trace event and **`MESSAGE_TYPES.WORKFLOW_TASK`** stream rows carry **`WorkflowTaskProgress`** (planned → running → completed/cached/skipped/failed), upserted by **`logId`**. The progress bridge and transcript recorder project that state; unreached planned tasks become **skipped (not-reached)** and still-running tasks fail if the run ends early.
> 
> The **VS Code** progress view renders status **cards**; the **CLI** adds a **`workflowTask`** transcript role with live updates until terminal settlement. Docs, changelog, and tests follow the new contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab9618dace235555ef4135eae335126f1a1e3cbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->