### PR TITLE
feat: unify model access and agent skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to this project will be documented in this file.
   built-in Orchestrator supports planned fan-out, pipeline, and join runs.
   Workflow Script is an opt-in integration in the Tools dashboard and CLI
   `/tools`; disabling it applies to every agent.
+- **Agent skill catalogs can be disabled per workspace** — the CLI launcher
+  and the extension and desktop Tools settings control whether TeXRA and
+  imported skills are supplied to agents.
 
 #### Bug Fixes
 
@@ -85,9 +88,9 @@ All notable changes to this project will be documented in this file.
 - **Context compaction is visible while it runs** — the terminal status bar
   shows a compacting indicator while conversation history is being summarized.
 - **Kimi Code subscription joins model access** — the launcher and `/api` now
-  offer Kimi Code alongside ChatGPT subscription, included TeXRA access, and
-  personal API keys. Selecting it routes Kimi models through your Kimi Code
-  membership while other models fall back to your saved keys.
+  expose ChatGPT and Kimi Code as independent preferences, with included TeXRA
+  access or personal API keys as the fallback for other models. Kimi models
+  routed through the membership are labelled as Kimi Code subscription access.
 - **API keys and provider routing can be managed from `/config`** — masked key
   status and secure entry are available for every provider, with Kimi Code,
   provider region, and GLM Coding Plan preferences under "Models and providers".
@@ -99,6 +102,12 @@ All notable changes to this project will be documented in this file.
   without filling the conversation with raw model prose.
 
 #### Bug Fixes
+
+- **ChatGPT browser sign-in always exposes its URL** — the terminal displays a
+  copyable sign-in link before attempting to open the browser.
+- **Kimi Code sessions keep their subscription label** — live and completed
+  terminal status no longer describes Kimi Code usage as personal API-key
+  access.
 
 - **Model failures show their reason** — failed model requests now include a
   concise provider message and are no longer labeled as tool failures.

--- a/packages/cli/src/chat/tui/commands/handlers/apiModeCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/apiModeCommands.ts
@@ -93,7 +93,7 @@ export async function applyCliProviderApiKey(
     return collapseWhitespace(
       [
         message,
-        "Tip: the Kimi for Coding models use your subscription automatically; to route Kimi K3 through it too, enable 'Prefer Kimi Code' in /config.",
+        "Tip: the Kimi for Coding models use the subscription automatically. The 'Kimi Code subscription preference' setting routes Kimi K3 through it as well.",
       ]
         .filter(Boolean)
         .join(' · '),

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -571,8 +571,7 @@ export function registerBuiltinSlashCommands(options?: {
   });
   registerSlashCommand({
     name: 'api',
-    description:
-      'Choose ChatGPT, Kimi Code, included TeXRA, or personal model access',
+    description: 'Subscription preferences and fallback model access',
     category: 'configuration',
     echo: 'ifPersists',
     argHandler: applyCliModelAccessSelection,
@@ -704,10 +703,8 @@ export function registerBuiltinSlashCommands(options?: {
             await options?.onError?.(error);
           }}
           onApiModePersonal={async () => {
-            // A key save only needs the mode switch when leaving included
-            // access — already-personal sessions (including an active Kimi
-            // Code route) must not be treated as an explicit "Personal API
-            // keys" picker choice, which would clear the Kimi preference.
+            // A key save only needs the fallback switch when leaving included
+            // access. Subscription preferences remain independent.
             if (sessionMeta.get().apiMode === 'personal') return;
             await onModelAccessSelect('personal', transcriptSlashCommandOutput);
           }}

--- a/packages/cli/src/chat/tui/forms/ModelAccessForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelAccessForm.tsx
@@ -54,8 +54,19 @@ export function ModelAccessForm(
     status?.state === 'loaded'
       ? status.overview.access
       : {
-          active: props.apiMode,
-          chatGptSignedIn: false,
+          apiMode: props.apiMode,
+          chatGpt: {
+            signedIn: false,
+            email: null,
+            accountId: null,
+            preferSubscription: false,
+            subscriptionToolUseOnly: false,
+          },
+          kimiCode: {
+            keySet: false,
+            preferred: false,
+          },
+          personalApiKeySet: false,
           texraSignedIn: false,
         },
   );
@@ -70,10 +81,13 @@ export function ModelAccessForm(
       items={items}
       compactVisibleItems={items.length}
       activeValue={
-        status?.state === 'loaded' ? status.overview.access.active : undefined
+        status?.state === 'loaded' ? status.overview.access.apiMode : undefined
       }
       description={
-        <Text dimColor>Choose how model calls are authenticated.</Text>
+        <Text dimColor>
+          Subscription preferences are independent; fallback access applies to
+          other models.
+        </Text>
       }
       detail={
         <Box marginTop={1} flexDirection="column">

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -6,6 +6,11 @@ import { SupabaseClient } from '@auth/SupabaseClient';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { platform } from '@platform/platform';
 import { getFirstRunDone } from '@shared/state/onboardingState';
+import {
+  AGENT_SKILLS_CONFIG_KEY,
+  AGENT_SKILLS_ENABLED_DEFAULT,
+} from '@shared/schemas/agentSkills';
+import { getConfig, updateConfig } from '@utils/config';
 
 import { firstRunSetupAgentOverride } from '../onboarding/setupContinuation';
 import { CliExitCode } from '../runtime/exitCodes';
@@ -174,8 +179,9 @@ async function runOrchestration(context: CliContext): Promise<number> {
       texraSignedIn: authProfile.authenticated,
       texraAccountLabel: authProfile.accountLabel,
       texraCredentialSource: authProfile.credentialSource,
-      chatGptSignedIn: modelAccess.chatGptSignedIn,
-      chatGptAccountLabel: modelAccess.chatGptAccountLabel,
+      chatGptSignedIn: modelAccess.chatGpt.signedIn,
+      chatGptAccountLabel:
+        modelAccess.chatGpt.email ?? modelAccess.chatGpt.accountId ?? undefined,
     };
     const launcherModelAccess = {
       ...modelAccess,
@@ -188,6 +194,10 @@ async function runOrchestration(context: CliContext): Promise<number> {
       includeMultiAgentLoginHint: !presetPlanSet.remoteAgentLoadAttempted,
       modelAccess: launcherModelAccess,
       account: accountStatus,
+      agentSkillsEnabled: getConfig<boolean>(
+        AGENT_SKILLS_CONFIG_KEY,
+        AGENT_SKILLS_ENABLED_DEFAULT,
+      ),
       presetLaunchBlockReason:
         launchContext.approvalPolicy === 'never'
           ? 'delegation-denied'
@@ -331,6 +341,17 @@ async function runOrchestration(context: CliContext): Promise<number> {
           colorEnabled: context.stdoutColorEnabled,
           onError: writeErrorStderr,
         });
+        continue launcher;
+      }
+      case 'set-agent-skills': {
+        try {
+          await updateConfig(AGENT_SKILLS_CONFIG_KEY, action.enabled);
+          writeTextStdout(
+            action.enabled ? 'Agent skills enabled.' : 'Agent skills disabled.',
+          );
+        } catch (error: unknown) {
+          writeErrorStderr(error);
+        }
         continue launcher;
       }
       case 'account': {

--- a/packages/cli/src/orchestration/runOrchestrationTui.tsx
+++ b/packages/cli/src/orchestration/runOrchestrationTui.tsx
@@ -297,7 +297,7 @@ export function OrchestrationApp(
     ? buildCliModelAccessItems(props.modelAccess)
     : [];
   const activeModelAccess: CliModelAccessRoute | undefined =
-    props.modelAccess?.active;
+    props.modelAccess?.apiMode;
   const isPendingTeam = pending?.kind === 'preset';
   // Model-step header text, shared between the wrapped-row measurement in
   // `headerLines` and the styled render in the `pending` branch below.
@@ -309,7 +309,7 @@ export function OrchestrationApp(
   if (modelAccessOpen) {
     headerLines = [
       'Model access',
-      'Choose how TeXRA should authenticate model calls.',
+      'Subscription preferences are independent; fallback access applies to other models.',
     ];
   } else if (resumeOpen) {
     headerLines = ['Resume', 'Choose a previous session to continue.'];
@@ -423,7 +423,10 @@ export function OrchestrationApp(
         <Text bold color="cyan">
           Model access
         </Text>
-        <Text dimColor>Choose how TeXRA should authenticate model calls.</Text>
+        <Text dimColor>
+          Subscription preferences are independent; fallback access applies to
+          other models.
+        </Text>
         <Box marginTop={1}>
           <Select
             key="orchestration-model-access-picker"

--- a/packages/cli/src/runtime/apiAccessMode.ts
+++ b/packages/cli/src/runtime/apiAccessMode.ts
@@ -1,9 +1,14 @@
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { platform } from '@platform/platform';
+import {
+  ApiAccessModeSchema,
+  type ApiAccessMode,
+} from '@shared/schemas/modelAccess';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 
-export type CliApiMode = 'included' | 'personal';
+/** @deprecated Import the host-neutral `ApiAccessMode` type instead. */
+export type CliApiMode = ApiAccessMode;
 
 // Two canonical names per mode: the descriptive `included`/`personal` (used in
 // labels and config) plus the common shorthand `relay`/`byok` (accepted as
@@ -41,9 +46,10 @@ export function shortCliApiMode(mode: CliApiMode): string {
 
 export function parseCliApiMode(input: string): CliApiMode | undefined {
   const normalized = input.trim().toLowerCase();
-  return Object.hasOwn(CLI_API_MODE_BY_INPUT, normalized)
-    ? CLI_API_MODE_BY_INPUT[normalized as CliApiModeInput]
-    : undefined;
+  if (!Object.hasOwn(CLI_API_MODE_BY_INPUT, normalized)) return undefined;
+  return ApiAccessModeSchema.parse(
+    CLI_API_MODE_BY_INPUT[normalized as CliApiModeInput],
+  );
 }
 
 export async function enableCliIncludedModelAccess(): Promise<void> {

--- a/packages/cli/src/runtime/apiStatus.ts
+++ b/packages/cli/src/runtime/apiStatus.ts
@@ -63,15 +63,25 @@ export async function loadCliModelAccessOverview(
     readCliModelAccessStatus(apiMode),
     getCliAuthProfile(),
   ]);
+  const preferredSubscriptions = [
+    access.chatGpt.preferSubscription && access.chatGpt.signedIn
+      ? 'ChatGPT'
+      : undefined,
+    access.kimiCode.preferred && access.kimiCode.keySet
+      ? 'Kimi Code'
+      : undefined,
+  ].filter((value): value is string => value !== undefined);
   const lines = [
-    `model access: ${formatCliModelAccessRoute(access.active)}`,
+    preferredSubscriptions.length > 0
+      ? `subscription preferences: ${preferredSubscriptions.join(' + ')}`
+      : `model access: ${formatCliModelAccessRoute(apiMode)}`,
     formatAccountStatusLine(
       'ChatGPT',
-      access.chatGptSignedIn,
-      access.chatGptAccountLabel,
+      access.chatGpt.signedIn,
+      access.chatGpt.email ?? access.chatGpt.accountId ?? undefined,
     ),
     `Kimi Code: ${
-      access.kimiCodeKeySet === true
+      access.kimiCode.keySet === true
         ? 'key configured'
         : 'no key (add with /key)'
     }`,
@@ -81,7 +91,7 @@ export async function loadCliModelAccessOverview(
       profile.accountLabel,
     ),
   ];
-  if (access.active === 'chatgpt' || access.active === 'kimi-code') {
+  if (preferredSubscriptions.length > 0) {
     lines.push(`API fallback: ${formatCliModelAccessRoute(apiMode)}`);
   }
   if (profile.note) lines.push(profile.note);

--- a/packages/cli/src/runtime/apiStatus.ts
+++ b/packages/cli/src/runtime/apiStatus.ts
@@ -1,4 +1,7 @@
-import { API_PROVIDERS, lookupApiKeyOrigin } from '@model/apiProviders';
+import {
+  PERSONAL_API_KEY_PROVIDERS,
+  lookupApiKeyOrigin,
+} from '@model/apiProviders';
 import { platform } from '@platform/platform';
 import { PROVIDER_DISPLAY_NAMES } from '@shared/constants/providers';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -154,9 +157,13 @@ export function formatCliApiStatusActionHint(
 async function personalKeyProviders(): Promise<string[]> {
   const secrets = platform().secrets;
   const origins = await Promise.all(
-    API_PROVIDERS.map((provider) => lookupApiKeyOrigin(secrets, provider)),
+    PERSONAL_API_KEY_PROVIDERS.map((provider) =>
+      lookupApiKeyOrigin(secrets, provider),
+    ),
   );
-  return API_PROVIDERS.filter((_, index) => origins[index] !== 'none');
+  return PERSONAL_API_KEY_PROVIDERS.filter(
+    (_, index) => origins[index] !== 'none',
+  );
 }
 
 export interface CliApiStatus {

--- a/packages/cli/src/runtime/chatgptLogin.ts
+++ b/packages/cli/src/runtime/chatgptLogin.ts
@@ -77,17 +77,17 @@ export async function signInCliChatGpt(
   return loginWithLoopback({
     coordinator,
     openBrowser: async (url) => {
-      if (!init.noBrowser && (await tryOpenBrowser(url))) {
-        // Always print the link even after a successful launch: the
-        // loopback callback accepts the redirect from any browser, so a
-        // user whose ChatGPT session lives elsewhere can just copy it from
-        // the terminal instead of needing `--no-browser` ahead of time.
-        options.writeProgress(
-          `Opening your browser to sign in with ChatGPT. Using a different browser? Open this URL there instead:\n${url}`,
-        );
+      // Publish the actionable URL before browser launch. Process launch can
+      // stall on some desktops, and the terminal must not remain on a generic
+      // "opening browser" message with no path forward.
+      options.writeProgress(`ChatGPT sign-in URL:\n${url}`);
+      if (init.noBrowser) return;
+      if (await tryOpenBrowser(url)) {
         return;
       }
-      options.writeProgress(`Open this URL to sign in with ChatGPT:\n${url}`);
+      options.writeProgress(
+        `Browser launch unavailable. ChatGPT sign-in URL:\n${url}`,
+      );
     },
     signal: options.signal,
   });

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -274,6 +274,9 @@ export function formatModelStatusForCliMode(
   model: CliModelAccess,
   apiMode: CliApiMode,
 ): string {
+  if (model.model.availability === 'subscription-access') {
+    return model.status;
+  }
   if (apiMode === 'personal') return `api: ${model.status}`;
 
   const availability = model.model.availability;

--- a/packages/cli/src/runtime/modelAccessRoute.ts
+++ b/packages/cli/src/runtime/modelAccessRoute.ts
@@ -1,17 +1,18 @@
-import type { UsageRoute } from '@shared/schemas';
+import type {
+  ModelAccessRoute,
+  ModelAccessStatus,
+  UsageRoute,
+} from '@shared/schemas';
+import {
+  describeApiAccessModeStatus,
+  MODEL_ACCESS_PREFERENCE_LABELS,
+  MODEL_ACCESS_ROUTE_LABELS,
+} from '@shared/schemas/modelAccess';
 
 import { parseCliApiMode, type CliApiMode } from './apiAccessMode';
 
-export type CliModelAccessRoute =
-  'chatgpt' | 'kimi-code' | 'included' | 'personal';
-
-export interface CliModelAccessStatus {
-  readonly active: CliModelAccessRoute;
-  readonly chatGptSignedIn: boolean;
-  readonly chatGptAccountLabel?: string;
-  readonly kimiCodeKeySet?: boolean;
-  readonly texraSignedIn?: boolean;
-}
+export type CliModelAccessRoute = ModelAccessRoute;
+export type CliModelAccessStatus = ModelAccessStatus;
 
 interface CliModelAccessItem {
   readonly value: CliModelAccessRoute;
@@ -54,6 +55,8 @@ export function resolveCliModelAccessRoute({
     switch (usageRoute) {
       case 'chatgpt-subscription':
         return 'chatgpt';
+      case 'kimi-code-subscription':
+        return 'kimi-code';
       case 'relay':
         return 'included';
       case 'api-key':
@@ -65,9 +68,7 @@ export function resolveCliModelAccessRoute({
     }
   }
   if (subscriptionActive) return 'chatgpt';
-  // The Kimi Code route only describes personal access — under included
-  // access the relay owns eligible models.
-  if (kimiCodeActive === true && apiMode === 'personal') return 'kimi-code';
+  if (kimiCodeActive === true) return 'kimi-code';
   return apiMode;
 }
 
@@ -77,18 +78,7 @@ export function shortCliModelAccessRoute(route: CliModelAccessRoute): string {
 }
 
 export function formatCliModelAccessRoute(route: CliModelAccessRoute): string {
-  switch (route) {
-    case 'chatgpt':
-      return 'ChatGPT subscription';
-    case 'kimi-code':
-      return 'Kimi Code subscription';
-    case 'included':
-      return 'Included TeXRA access';
-    case 'personal':
-      return 'Personal API keys';
-    default:
-      return route satisfies never;
-  }
+  return MODEL_ACCESS_ROUTE_LABELS[route];
 }
 
 /** Sentence-fragment form derived from the canonical access label. */
@@ -107,18 +97,20 @@ export function buildCliModelAccessItems(
   status: CliModelAccessStatus,
 ): CliModelAccessItem[] {
   let chatGptDescription: string;
-  if (status.active === 'chatgpt') {
-    chatGptDescription = `On · ${status.chatGptAccountLabel ?? 'your account'}`;
-  } else if (status.chatGptSignedIn) {
-    chatGptDescription = `Off · ${status.chatGptAccountLabel ?? 'your account'}`;
+  const chatGptAccount =
+    status.chatGpt.email ?? status.chatGpt.accountId ?? 'your account';
+  if (status.chatGpt.preferSubscription && status.chatGpt.signedIn) {
+    chatGptDescription = `On · ${chatGptAccount}`;
+  } else if (status.chatGpt.signedIn) {
+    chatGptDescription = `Off · ${chatGptAccount}`;
   } else {
     chatGptDescription = 'Sign in with ChatGPT Plus/Pro/Team';
   }
 
   let kimiCodeDescription: string;
-  if (status.kimiCodeKeySet !== true) {
+  if (status.kimiCode.keySet !== true) {
     kimiCodeDescription = 'Add a key with /key (kimi.com/code/console)';
-  } else if (status.active === 'kimi-code') {
+  } else if (status.kimiCode.preferred) {
     kimiCodeDescription = 'On · key configured';
   } else {
     kimiCodeDescription = 'Off · key configured';
@@ -127,26 +119,23 @@ export function buildCliModelAccessItems(
   return [
     {
       value: 'chatgpt',
-      label: 'Prefer ChatGPT subscription',
+      label: MODEL_ACCESS_PREFERENCE_LABELS.chatgpt,
       description: chatGptDescription,
     },
     {
       value: 'kimi-code',
-      label: 'Prefer Kimi Code subscription',
+      label: MODEL_ACCESS_PREFERENCE_LABELS['kimi-code'],
       description: kimiCodeDescription,
     },
     {
       value: 'included',
       label: formatCliModelAccessRoute('included'),
-      description:
-        status.texraSignedIn === false
-          ? 'Sign in through Account to use included models'
-          : 'Use your TeXRA account',
+      description: describeApiAccessModeStatus('included', status),
     },
     {
       value: 'personal',
       label: formatCliModelAccessRoute('personal'),
-      description: 'Use keys configured on this computer',
+      description: describeApiAccessModeStatus('personal', status),
     },
   ];
 }

--- a/packages/cli/src/runtime/modelAccessSelection.ts
+++ b/packages/cli/src/runtime/modelAccessSelection.ts
@@ -1,15 +1,16 @@
 import {
+  getChatGptAuthStatus,
   getCodexStatus,
   isPreferCodexSubscription,
   setPreferCodexSubscription,
 } from '@auth/codex';
-import { apiKeyExists } from '@model/apiProviders';
+import { API_PROVIDERS, apiKeyExists } from '@model/apiProviders';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { platform } from '@platform/platform';
+import { ModelAccessStatusSchema } from '@shared/schemas/modelAccess';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import {
   getPreferKimiCode,
-  getUseOpenRouter,
   setPreferKimiCode,
 } from '@utils/config/providerConfig';
 
@@ -47,43 +48,34 @@ export function contextForCliModelAccess(
 export async function readCliModelAccessStatus(
   apiMode: CliApiMode,
 ): Promise<CliModelAccessStatus> {
-  const [chatGpt, kimiCodeKeySet] = await Promise.all([
-    getCodexStatus(),
+  const [chatGpt, kimiCodeKeySet, personalApiKeyStates] = await Promise.all([
+    getChatGptAuthStatus(),
     apiKeyExists(platform().secrets, 'kimiCode'),
+    Promise.all(
+      API_PROVIDERS.map((provider) =>
+        apiKeyExists(platform().secrets, provider),
+      ),
+    ),
   ]);
-  const chatGptActive = chatGpt.signedIn && isPreferCodexSubscription();
-  // The Kimi Code route is a personal-key route: it only describes the active
-  // access while the API fallback mode is personal, the prefer switch is on,
-  // and dispatch can actually honor it (OpenRouter off — dual-backend models
-  // refuse the coding endpoint while it is on).
-  const kimiCodeActive =
-    !chatGptActive &&
-    apiMode === 'personal' &&
-    getPreferKimiCode() &&
-    !getUseOpenRouter() &&
-    kimiCodeKeySet;
-  let active: CliModelAccessStatus['active'] = apiMode;
-  if (chatGptActive) active = 'chatgpt';
-  else if (kimiCodeActive) active = 'kimi-code';
-  return {
-    active,
-    chatGptSignedIn: chatGpt.signedIn,
-    chatGptAccountLabel: chatGpt.email ?? chatGpt.accountId,
-    kimiCodeKeySet,
-  };
+  return ModelAccessStatusSchema.parse({
+    apiMode,
+    chatGpt,
+    kimiCode: {
+      keySet: kimiCodeKeySet,
+      preferred: getPreferKimiCode(),
+    },
+    personalApiKeySet: personalApiKeyStates.some(Boolean),
+  });
 }
 
-/** Select an API-backed route and stop preferring ChatGPT subscription use. */
+/** Select the fallback used outside preferred subscription model families. */
 export async function selectCliApiModelAccessRoute(
   route: CliApiMode,
 ): Promise<CliModelAccessSelectionResult> {
-  const update = await setPreferCodexSubscription(false);
   await setCliApiMode(route);
   return {
     apiMode: route,
-    message: update.effective
-      ? `Model access remains on ChatGPT subscription because a more specific setting overrides ${update.target} config.`
-      : `Model access: ${formatCliModelAccessRoute(route)}.`,
+    message: `API fallback: ${formatCliModelAccessRoute(route)}.`,
   };
 }
 
@@ -100,14 +92,18 @@ export async function selectCliModelAccessRoute(
   }
 
   if (route === 'personal') {
-    // An explicit "personal keys" picker choice leaves the Kimi Code route;
-    // saving a key never clears the switch (see applyCliProviderApiKey), and
-    // the prefer toggle stays available under /config → Models and providers.
-    await setPreferKimiCode(false);
     return selectCliApiModelAccessRoute(route);
   }
 
   if (route === 'kimi-code') {
+    if (getPreferKimiCode()) {
+      await setPreferKimiCode(false);
+      invalidateModelOptionsCache();
+      return {
+        apiMode: effectiveCliApiMode(context),
+        message: 'Kimi Code subscription preference: Off.',
+      };
+    }
     // The Kimi Code API key is the subscription credential — there is no
     // separate sign-in flow.
     if (!(await apiKeyExists(platform().secrets, 'kimiCode'))) {
@@ -117,22 +113,29 @@ export async function selectCliModelAccessRoute(
           'No Kimi Code API key configured — add one with /key or /config → API keys (get one at https://www.kimi.com/code/console).',
       };
     }
-    const update = await setPreferCodexSubscription(false);
     await setPreferKimiCode(true);
     // Dual-backend Kimi routing requires the OpenRouter toggle off.
     await platform().globalState.update(GlobalStateKey.USE_OPENROUTER, false);
-    // Non-Moonshot models fall back to the other personal keys.
-    await setCliApiMode('personal');
     invalidateModelOptionsCache();
+    const apiMode = effectiveCliApiMode(context);
     return {
-      apiMode: 'personal',
-      message: update.effective
-        ? `Prefer Kimi Code subscription enabled for Kimi models, but a more specific setting keeps ChatGPT subscription preferred (${update.target} config).`
-        : 'Prefer Kimi Code subscription enabled for Kimi models · fallback: personal API keys.',
+      apiMode,
+      message: `Kimi Code subscription preference: On for Kimi models · fallback: ${formatCliModelAccessRoute(apiMode)}.`,
     };
   }
 
   const status = await getCodexStatus();
+  if (status.signedIn && isPreferCodexSubscription()) {
+    const update = await setPreferCodexSubscription(false);
+    invalidateModelOptionsCache();
+    return {
+      apiMode: effectiveCliApiMode(context),
+      message: update.effective
+        ? `ChatGPT subscription remains preferred because a more specific setting overrides ${update.target} config.`
+        : 'ChatGPT subscription preference: Off.',
+    };
+  }
+
   let accountLabel = status.email ?? status.accountId ?? 'your account';
   if (!status.signedIn) {
     const init = { device: false, noBrowser: false };
@@ -147,12 +150,11 @@ export async function selectCliModelAccessRoute(
   }
 
   const update = await setPreferCodexSubscription(true);
-  await platform().globalState.update(GlobalStateKey.USE_OPENROUTER, false);
   invalidateModelOptionsCache();
   return {
     apiMode: effectiveCliApiMode(context),
     message: update.effective
-      ? `Prefer ChatGPT subscription enabled for Codex models (${accountLabel}).`
+      ? `ChatGPT subscription preference: On for Codex models (${accountLabel}).`
       : 'ChatGPT sign-in succeeded, but a more specific setting keeps subscription access disabled.',
   };
 }

--- a/packages/cli/src/runtime/modelAccessSelection.ts
+++ b/packages/cli/src/runtime/modelAccessSelection.ts
@@ -4,7 +4,7 @@ import {
   isPreferCodexSubscription,
   setPreferCodexSubscription,
 } from '@auth/codex';
-import { API_PROVIDERS, apiKeyExists } from '@model/apiProviders';
+import { PERSONAL_API_KEY_PROVIDERS, apiKeyExists } from '@model/apiProviders';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { platform } from '@platform/platform';
 import { ModelAccessStatusSchema } from '@shared/schemas/modelAccess';
@@ -52,7 +52,7 @@ export async function readCliModelAccessStatus(
     getChatGptAuthStatus(),
     apiKeyExists(platform().secrets, 'kimiCode'),
     Promise.all(
-      API_PROVIDERS.map((provider) =>
+      PERSONAL_API_KEY_PROVIDERS.map((provider) =>
         apiKeyExists(platform().secrets, provider),
       ),
     ),
@@ -87,11 +87,7 @@ export async function selectCliModelAccessRoute(
     readonly signal?: AbortSignal;
   },
 ): Promise<CliModelAccessSelectionResult> {
-  if (route === 'included') {
-    return selectCliApiModelAccessRoute(route);
-  }
-
-  if (route === 'personal') {
+  if (route === 'included' || route === 'personal') {
     return selectCliApiModelAccessRoute(route);
   }
 

--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -1,6 +1,7 @@
 import type { AgentEntry } from '@agent/index';
 import type { ExecutionId } from '@shared/schemas';
 import { agentKeyOf } from '@shared/schemas/agent';
+import { describeApiAccessModeStatus } from '@shared/schemas/modelAccess';
 import { formatResultCount } from '@utils/text/stringUtils';
 
 import {
@@ -32,7 +33,6 @@ import {
   type CliModelAccessStatus,
 } from './modelAccessRoute';
 import type { CliApiMode } from './apiAccessMode';
-import { describeApiAccessModeStatus } from '@shared/schemas/modelAccess';
 
 export type CliOrchestrationAction =
   | { readonly kind: 'chat'; readonly agent?: string; readonly model?: string }
@@ -312,11 +312,9 @@ function modelAccessItem(status: CliModelAccessStatus): CliOrchestrationItem {
   ].filter((value): value is string => value !== undefined);
   const fallback = formatCliModelAccessRoute(status.apiMode);
   const fallbackStatus = describeApiAccessModeStatus(status.apiMode, status);
-  const inlineFallbackStatus =
-    fallbackStatus.charAt(0).toLowerCase() + fallbackStatus.slice(1);
   const description =
     subscriptions.length > 0
-      ? `${subscriptions.join(' + ')} · fallback: ${fallback} (${inlineFallbackStatus})`
+      ? `${subscriptions.join(' + ')} · fallback: ${fallback} (${fallbackStatus})`
       : `${fallback} · ${fallbackStatus}`;
   return {
     value: { kind: 'configure-model-access' },

--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -32,6 +32,7 @@ import {
   type CliModelAccessStatus,
 } from './modelAccessRoute';
 import type { CliApiMode } from './apiAccessMode';
+import { describeApiAccessModeStatus } from '@shared/schemas/modelAccess';
 
 export type CliOrchestrationAction =
   | { readonly kind: 'chat'; readonly agent?: string; readonly model?: string }
@@ -54,6 +55,7 @@ export type CliOrchestrationAction =
       readonly operation: CliAccountOperation;
     }
   | { readonly kind: 'configure-model-access' }
+  | { readonly kind: 'set-agent-skills'; readonly enabled: boolean }
   | {
       readonly kind: 'set-model-access';
       readonly access: CliModelAccessRoute;
@@ -85,6 +87,7 @@ export interface BuildCliOrchestrationItemsInput {
   readonly modelAccess?: CliModelAccessStatus;
   readonly account?: CliAccountStatus;
   readonly presetLaunchBlockReason?: CliPresetLaunchBlockReason;
+  readonly agentSkillsEnabled?: boolean;
 }
 
 type CliAccountProvider = 'chatgpt' | 'texra';
@@ -189,6 +192,18 @@ export function buildCliOrchestrationItems(
       description: accountSummary(input.account),
     });
   }
+  if (input.agentSkillsEnabled !== undefined) {
+    items.push({
+      value: {
+        kind: 'set-agent-skills',
+        enabled: !input.agentSkillsEnabled,
+      },
+      label: 'Agent skills',
+      description: input.agentSkillsEnabled
+        ? 'On · TeXRA and imported skills available to agents'
+        : 'Off · no skills supplied to agents',
+    });
+  }
   items.push({
     value: { kind: 'configure-settings' },
     label: 'Settings',
@@ -287,14 +302,22 @@ export function buildCliAgentItems(
 }
 
 function modelAccessItem(status: CliModelAccessStatus): CliOrchestrationItem {
-  let description: string;
-  if (status.active === 'chatgpt' && status.chatGptAccountLabel) {
-    description = `ChatGPT subscription · ${status.chatGptAccountLabel}`;
-  } else if (status.active === 'kimi-code') {
-    description = 'Kimi Code subscription · key configured';
-  } else {
-    description = formatCliModelAccessRoute(status.active);
-  }
+  const subscriptions = [
+    status.chatGpt.preferSubscription && status.chatGpt.signedIn
+      ? 'ChatGPT'
+      : undefined,
+    status.kimiCode.preferred && status.kimiCode.keySet
+      ? 'Kimi Code'
+      : undefined,
+  ].filter((value): value is string => value !== undefined);
+  const fallback = formatCliModelAccessRoute(status.apiMode);
+  const fallbackStatus = describeApiAccessModeStatus(status.apiMode, status);
+  const inlineFallbackStatus =
+    fallbackStatus.charAt(0).toLowerCase() + fallbackStatus.slice(1);
+  const description =
+    subscriptions.length > 0
+      ? `${subscriptions.join(' + ')} · fallback: ${fallback} (${inlineFallbackStatus})`
+      : `${fallback} · ${fallbackStatus}`;
   return {
     value: { kind: 'configure-model-access' },
     label: 'Model access',

--- a/packages/desktop/src/main/desktopCredentialSettingsController.ts
+++ b/packages/desktop/src/main/desktopCredentialSettingsController.ts
@@ -34,7 +34,7 @@ import {
   PROVIDER_URLS,
 } from '@shared/constants/providers';
 import { AgentCategory } from '@shared/schemas/agent';
-import type { ApiAccessMode } from '@shared/schemas/profileViewMessages';
+import type { ApiAccessMode } from '@shared/schemas/modelAccess';
 import { buildChatGptAuthStatusMessage } from '@shared/settingsView/handlers/chatGptHandlers';
 import type { SettingsStatePorts } from '@shared/settingsView/types';
 import { unsupported } from '@shared/utils/dispatcher';

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -22,6 +22,10 @@ import {
   setBashApprovalEnabled,
   setWorkspaceAgentSetting,
 } from '@shared/settingsView/handlers/approvalHandlers';
+import {
+  buildAgentSkillsSettingsMessage,
+  setAgentSkillsEnabled,
+} from '@shared/settingsView/handlers/agentSkillsHandlers';
 import { buildSuperYoloMessage } from '@shared/settingsView/handlers/superYoloHandlers';
 import type { SettingsStatePorts } from '@shared/settingsView/types';
 import { GoalStore } from '@tools/goal';
@@ -175,6 +179,10 @@ export function createDesktopSettingsIpc(
     );
   }
 
+  function postAgentSkillsSettings(): void {
+    options.postToRenderer(buildAgentSkillsSettingsMessage(options.config));
+  }
+
   /**
    * Deliberate divergence from the extension: no `subscribeGoalStateChanges`
    * push hook here. The initial post below, the webview-ready re-post, and
@@ -205,6 +213,7 @@ export function createDesktopSettingsIpc(
     const modelSelectionDataPosted = postModelSelectionData();
     postSuperYoloEnabled();
     postApprovalSettings();
+    postAgentSkillsSettings();
     await Promise.all([
       goalListPosted,
       memoryEnabledPosted,
@@ -384,6 +393,12 @@ export function createDesktopSettingsIpc(
     chatGpt: options.credentialSettingsController.chatGptActions,
     approval: {
       setBashApprovalEnabled: (enabled) => updateBashApprovalEnabled(enabled),
+    },
+    agentSkills: {
+      setEnabled: async (enabled) => {
+        await setAgentSkillsEnabled(options.config, enabled);
+        postAgentSkillsSettings();
+      },
     },
     stateSettings: {
       update: (key, value) => updateStateSetting(key, value),

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -834,7 +834,7 @@
           "texra.skills.enabled": {
             "type": "boolean",
             "default": true,
-            "description": "Discover imported skills and expose them to tool-use agent prompts",
+            "description": "Discover TeXRA and imported skills and expose them to agent prompts",
             "scope": "resource"
           }
         }

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -840,6 +840,16 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   }
 
   private async handleSetAgentSkillsEnabled(enabled: boolean): Promise<void> {
+    if (!vscode.workspace.workspaceFolders?.length) {
+      void showLoggedInfoMessage(
+        this.channel,
+        'Agent skills are a per-workspace setting. Open a workspace folder before changing them.',
+      );
+      await this.withActiveWebview((webview) =>
+        this.sendAgentSkillsSettings(webview),
+      );
+      return;
+    }
     await setAgentSkillsEnabled(platform().config, enabled);
     await this.withActiveWebview((webview) =>
       this.sendAgentSkillsSettings(webview),

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -79,6 +79,10 @@ import {
   setBashApprovalEnabled as setBashApprovalEnabledShared,
   setWorkspaceAgentSetting,
 } from '@shared/settingsView/handlers/approvalHandlers';
+import {
+  buildAgentSkillsSettingsMessage,
+  setAgentSkillsEnabled,
+} from '@shared/settingsView/handlers/agentSkillsHandlers';
 import { buildSuperYoloMessage } from '@shared/settingsView/handlers/superYoloHandlers';
 import {
   PROVIDER_DISPLAY_NAMES,
@@ -551,6 +555,9 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         setBashApprovalEnabled: (enabled) =>
           this.handleSetApprovalEnabled(enabled),
       },
+      agentSkills: {
+        setEnabled: (enabled) => this.handleSetAgentSkillsEnabled(enabled),
+      },
       stateSettings: {
         update: (key, value) => this.updateStateSetting(key, value),
       },
@@ -689,6 +696,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       this.chatgptHandlers.sendChatGptAuthStatus(webview),
       this.githubHandlers.sendPRSubscriptions(webview),
       this.sendApprovalSettings(webview),
+      this.sendAgentSkillsSettings(webview),
       this.latexHandlers.sendLatexSettingsStatus(webview),
       this.latexHandlers.sendLatexConfigValues(webview),
       this.sendInlineCriticismEnabled(webview),
@@ -820,6 +828,21 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         globalState: globalSM,
         config: platform().config,
       }),
+    );
+  }
+
+  private async sendAgentSkillsSettings(
+    webview: vscode.Webview,
+  ): Promise<void> {
+    await webview.postMessage(
+      buildAgentSkillsSettingsMessage(platform().config),
+    );
+  }
+
+  private async handleSetAgentSkillsEnabled(enabled: boolean): Promise<void> {
+    await setAgentSkillsEnabled(platform().config, enabled);
+    await this.withActiveWebview((webview) =>
+      this.sendAgentSkillsSettings(webview),
     );
   }
 

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -63,6 +63,7 @@ import {
   apiAccessMode,
   authenticated,
   bashApprovalEnabled,
+  agentSkillsEnabled,
   chatgptAuth,
   claudeAgentEffort,
   claudeAgentModel,
@@ -504,6 +505,7 @@ export class SettingsApp extends SettingsAppBase {
               .items=${toolDashboardItems.get()}
               .loaded=${toolDashboardLoaded.get()}
               .bashApprovalEnabled=${bashApprovalEnabled.get()}
+              .agentSkillsEnabled=${agentSkillsEnabled.get()}
               .showDesktopCrashReporting=${!isKnownUnsupported(
                 unsupportedCommands.get(),
                 SETTINGS_VIEW_COMMANDS.GET_DESKTOP_CRASH_REPORTING,

--- a/packages/extension/src/settingsView/frontend/components/profile/ApiAccessSection.styles.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ApiAccessSection.styles.ts
@@ -86,6 +86,11 @@ export const apiAccessSectionStyles: CSSResult = css`
     color: var(--wa-color-text-normal);
   }
 
+  .option-status {
+    color: var(--wa-color-text-normal);
+    font-size: var(--font-size-sm);
+  }
+
   .option-description {
     color: var(--color-text-secondary);
     font-size: var(--font-size-sm);

--- a/packages/extension/src/settingsView/frontend/components/profile/ApiAccessSection.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ApiAccessSection.ts
@@ -16,7 +16,12 @@ import '@awesome.me/webawesome/dist/components/radio-group/radio-group.js';
 
 // Local imports - shared copy
 import { PROMO_NOTICE_LONG } from '@shared/copy/promoNotice';
-import { API_ACCESS_MODE_OPTIONS } from '@shared/schemas/settingsViewMessages';
+import {
+  API_ACCESS_MODE_OPTIONS,
+  ApiAccessModeSchema,
+  describeApiAccessModeStatus,
+  type ApiAccessMode,
+} from '@shared/schemas/modelAccess';
 
 // Local imports - profile view styles
 import { apiAccessSectionStyles } from './ApiAccessSection.styles';
@@ -27,13 +32,17 @@ import type WaRadioGroup from '@awesome.me/webawesome/dist/components/radio-grou
 export class ApiAccessSection extends LitElement {
   static override styles = [designTokens, apiAccessSectionStyles];
 
-  @property({ attribute: false }) mode: 'included' | 'personal' = 'personal';
+  @property({ attribute: false }) mode: ApiAccessMode = 'personal';
+  @property({ type: Boolean }) texraSignedIn = false;
+  @property({ type: Boolean }) personalApiKeySet = false;
 
   private handleModeChange(event: Event): void {
     const target = event.currentTarget as WaRadioGroup | null;
-    const mode = target?.value === 'included' ? 'included' : 'personal';
-    if (mode !== this.mode) {
-      postMessage(SETTINGS_VIEW_COMMANDS.SET_API_ACCESS_MODE, { mode });
+    const result = ApiAccessModeSchema.safeParse(target?.value);
+    if (result.success && result.data !== this.mode) {
+      postMessage(SETTINGS_VIEW_COMMANDS.SET_API_ACCESS_MODE, {
+        mode: result.data,
+      });
     }
   }
 
@@ -49,9 +58,19 @@ export class ApiAccessSection extends LitElement {
         >
           ${API_ACCESS_MODE_OPTIONS.map(
             (option) => html`
-              <wa-radio class="api-access-option" value=${option.value}>
+              <wa-radio
+                class="api-access-option"
+                value=${option.value}
+                ?disabled=${option.value === 'included' && !this.texraSignedIn}
+              >
                 <span class="option-content">
                   <span class="option-title">${option.label}</span>
+                  <span class="option-status">
+                    ${describeApiAccessModeStatus(option.value, {
+                      texraSignedIn: this.texraSignedIn,
+                      personalApiKeySet: this.personalApiKeySet,
+                    })}
+                  </span>
                   <span class="option-description">
                     ${option.description}
                   </span>

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
@@ -26,6 +26,7 @@ import type {
   ProviderKeyStatus,
   ProviderVscodeSetting,
 } from '@shared/schemas/settingsViewMessages';
+import type { ApiAccessMode } from '@shared/schemas/modelAccess';
 import { createEvent } from '@shared/utils/events';
 import { providerKeyListStyles } from './ProviderKeyList.styles';
 import { resolveProviderKeyRows } from './providerKeyRows';
@@ -42,8 +43,7 @@ export class ProviderKeyList extends LitElement {
   ];
 
   @property({ attribute: false }) providerKeyStatuses: ProviderKeyStatus[] = [];
-  @property({ attribute: false }) apiAccessMode: 'included' | 'personal' =
-    'personal';
+  @property({ attribute: false }) apiAccessMode: ApiAccessMode = 'personal';
   @property({ attribute: false }) globalStreamingDefault = true;
 
   @state() private expandedProvider: string | null = null;

--- a/packages/extension/src/settingsView/frontend/components/profile/RelayQuotaMeter.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/RelayQuotaMeter.ts
@@ -29,7 +29,7 @@ function quotaNote(
 ): string | null {
   if (state === 'exhausted') {
     return autoSwitched
-      ? "Monthly relay quota reached — switched you to your own API keys. Toggle 'Use Included Access' back on to retry the relay."
+      ? 'Monthly relay quota reached — the fallback is now Personal API keys. Included TeXRA access becomes available again with renewed quota.'
       : 'Monthly relay quota reached. Switch to your own API keys to keep going.';
   }
   if (state === 'warning') {

--- a/packages/extension/src/settingsView/frontend/messageDispatcher.ts
+++ b/packages/extension/src/settingsView/frontend/messageDispatcher.ts
@@ -12,6 +12,7 @@
 import type { SettingsViewOutboundHandlerRegistry } from '@shared/schemas';
 
 import { agentSelectionHandlers } from './slices/agentSelectionSlice';
+import { agentSkillsSettingsHandlers } from './slices/agentSkillsSettingsSlice';
 import { agentTeamsHandlers } from './slices/agentTeamsSlice';
 import { approvalSettingsHandlers } from './slices/approvalSettingsSlice';
 import { gitHandlers } from './slices/gitSlice';
@@ -33,6 +34,7 @@ export const settingsViewHandlers: SettingsViewOutboundHandlerRegistry = {
   ...profileHandlers,
   ...modelSelectionHandlers,
   ...agentSelectionHandlers,
+  ...agentSkillsSettingsHandlers,
   ...agentTeamsHandlers,
   ...multiAgentHandlers,
   ...approvalSettingsHandlers,

--- a/packages/extension/src/settingsView/frontend/settingsState.ts
+++ b/packages/extension/src/settingsView/frontend/settingsState.ts
@@ -50,6 +50,7 @@ import {
   type ChatGptAuthStatus,
   DEFAULT_LATEX_SETTINGS_STATUS,
 } from '@shared/schemas/settingsViewMessages';
+import type { ApiAccessMode } from '@shared/schemas/modelAccess';
 import {
   DEFAULT_GIT_AUTHOR_NAME,
   DEFAULT_GIT_AUTHOR_EMAIL,
@@ -103,9 +104,7 @@ export const historyItems = trackedSignal<HistoryItem[]>(() => []);
 export const authenticated = trackedSignal(() => false);
 export const userEmail = trackedSignal(() => '');
 export const tier = trackedSignal(() => 'free');
-export const apiAccessMode = trackedSignal<'included' | 'personal'>(
-  () => 'personal',
-);
+export const apiAccessMode = trackedSignal<ApiAccessMode>(() => 'personal');
 export const spendingStatus = trackedSignal<SpendingStatus | null>(() => null);
 export const quotaAutoSwitched = trackedSignal(() => false);
 export const providerKeyStatuses = trackedSignal<ProviderKeyStatus[]>(() => []);
@@ -153,6 +152,7 @@ export const detachSubagentsOnStop = trackedSignal(() => false);
 // Approval settings state
 // ---------------------------------------------------------------------------
 export const bashApprovalEnabled = trackedSignal(() => true);
+export const agentSkillsEnabled = trackedSignal(() => true);
 export const codexSandboxMode = trackedSignal<string>(() => 'workspace-write');
 export const codexReasoningEffort = trackedSignal<string>(() => 'high');
 export const codexApprovalPolicy = trackedSignal<string>(() => 'never');

--- a/packages/extension/src/settingsView/frontend/slices/agentSkillsSettingsSlice.ts
+++ b/packages/extension/src/settingsView/frontend/slices/agentSkillsSettingsSlice.ts
@@ -1,0 +1,10 @@
+import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
+import type { SettingsViewOutboundHandlerRegistry } from '@shared/schemas';
+
+import { agentSkillsEnabled } from '../settingsState';
+
+export const agentSkillsSettingsHandlers = {
+  [SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SKILLS_SETTINGS]: (data) => {
+    agentSkillsEnabled.set(data.enabled);
+  },
+} satisfies Partial<SettingsViewOutboundHandlerRegistry>;

--- a/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
@@ -7,6 +7,7 @@ import { customElement, property } from 'lit/decorators.js';
 import { commonViewStyles, designTokens } from '@shared/styles';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import { postMessage } from '@shared/hostBridge';
+import { PERSONAL_API_KEY_PROVIDER_IDS } from '@shared/constants/providers';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 // Web Awesome icon bundle (side-effect import)
@@ -40,6 +41,10 @@ import '../components/profile/ProviderKeyList';
 import '../components/profile/ModelSelectionList';
 import '../components/profile/ReliabilitySettingsSection';
 import type WaSwitch from '@awesome.me/webawesome/dist/components/switch/switch.js';
+
+const PERSONAL_API_KEY_PROVIDER_SET = new Set<string>(
+  PERSONAL_API_KEY_PROVIDER_IDS,
+);
 
 @customElement('models-tab')
 export class ModelsTab extends LitElement {
@@ -217,7 +222,8 @@ export class ModelsTab extends LitElement {
 
   override render(): TemplateResult {
     const personalApiKeySet = this.providerKeyStatuses.some(
-      ({ status }) => status !== 'not-set',
+      ({ provider, status }) =>
+        PERSONAL_API_KEY_PROVIDER_SET.has(provider) && status !== 'not-set',
     );
     const apiAccessSection = html`<api-access-section
       .mode=${this.apiAccessMode}

--- a/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
@@ -22,6 +22,11 @@ import type {
   NumberVscodeSetting,
   ProviderKeyStatus,
 } from '@shared/schemas/settingsViewMessages';
+import {
+  MODEL_ACCESS_PREFERENCE_LABELS,
+  MODEL_ACCESS_ROUTE_LABELS,
+  type ApiAccessMode,
+} from '@shared/schemas/modelAccess';
 import type { SpendingStatus } from '@shared/schemas/spendingStatus';
 import { CHATGPT_TOOL_USE_ONLY_DESCRIPTION } from '@shared/schemas/coreSettings';
 
@@ -96,8 +101,7 @@ export class ModelsTab extends LitElement {
   ];
 
   @property({ attribute: false }) authenticated = false;
-  @property({ attribute: false }) apiAccessMode: 'included' | 'personal' =
-    'personal';
+  @property({ attribute: false }) apiAccessMode: ApiAccessMode = 'personal';
   @property({ attribute: false }) spendingStatus: SpendingStatus | null = null;
   @property({ type: Boolean }) quotaAutoSwitched = false;
   @property({ attribute: false }) providerKeyStatuses: ProviderKeyStatus[] = [];
@@ -154,8 +158,8 @@ export class ModelsTab extends LitElement {
     );
     const description =
       this.apiAccessMode === 'included'
-        ? 'Use included access, ChatGPT subscription for Codex models, or personal provider API keys.'
-        : 'Use ChatGPT subscription for Codex models, or configure personal API keys for OpenAI, Anthropic, Google, and other providers.';
+        ? 'Available routes include TeXRA access, ChatGPT subscription for Codex models, and personal provider API keys.'
+        : 'Available routes include ChatGPT subscription for Codex models and configured OpenAI, Anthropic, Google, or other provider keys.';
 
     const accessJump = this.authenticated
       ? html`<wa-button
@@ -212,11 +216,14 @@ export class ModelsTab extends LitElement {
   }
 
   override render(): TemplateResult {
-    const apiAccessSection = this.authenticated
-      ? html`<api-access-section
-          .mode=${this.apiAccessMode}
-        ></api-access-section>`
-      : nothing;
+    const personalApiKeySet = this.providerKeyStatuses.some(
+      ({ status }) => status !== 'not-set',
+    );
+    const apiAccessSection = html`<api-access-section
+      .mode=${this.apiAccessMode}
+      .texraSignedIn=${this.authenticated}
+      .personalApiKeySet=${personalApiKeySet}
+    ></api-access-section>`;
 
     const quotaMeter =
       this.authenticated && this.spendingStatus
@@ -263,12 +270,14 @@ export class ModelsTab extends LitElement {
     return html`
       <section id="chatgpt-subscription" class="keyless-source">
         <div class="keyless-source__header">
-          <span class="keyless-source__title">ChatGPT subscription</span>
+          <span class="keyless-source__title"
+            >${MODEL_ACCESS_ROUTE_LABELS.chatgpt}</span
+          >
           <wa-tag variant="neutral" size="small">experimental</wa-tag>
         </div>
         <p class="keyless-source__hint">
-          Use OpenAI models through your ChatGPT Plus, Pro, or Team
-          subscription. No OpenAI API key is needed.
+          OpenAI models can run through a ChatGPT Plus, Pro, or Team
+          subscription. This route does not require an OpenAI API key.
         </p>
         <p class="keyless-source__limit">
           ${waIcon('circle-info')}
@@ -282,7 +291,7 @@ export class ModelsTab extends LitElement {
             ?checked=${preferSubscription}
             @change=${this.handlePreferSubscriptionChange}
           >
-            Prefer ChatGPT subscription
+            ${MODEL_ACCESS_PREFERENCE_LABELS.chatgpt}
           </wa-switch>
         </div>
         <div class="keyless-source__setting">

--- a/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -196,6 +196,7 @@ export class ToolsTab extends LitElement {
   @property({ attribute: false }) items: ToolDashboardItem[] = [];
   @property({ type: Boolean }) loaded = false;
   @property({ type: Boolean }) bashApprovalEnabled = true;
+  @property({ type: Boolean }) agentSkillsEnabled = true;
   @property({ attribute: false }) showDesktopCrashReporting = false;
   @property({ attribute: false }) desktopCrashReportingEnabled = false;
   @property({ attribute: false }) desktopCrashReportingConfigured = false;
@@ -211,6 +212,10 @@ export class ToolsTab extends LitElement {
 
   private handleBashApprovalToggle = (e: Event): void => {
     this.postToggle(SETTINGS_VIEW_COMMANDS.SET_BASH_APPROVAL_ENABLED, e);
+  };
+
+  private handleAgentSkillsToggle = (e: Event): void => {
+    this.postToggle(SETTINGS_VIEW_COMMANDS.SET_AGENT_SKILLS_ENABLED, e);
   };
 
   private handleDesktopCrashReportingToggle = (e: Event): void => {
@@ -237,6 +242,23 @@ export class ToolsTab extends LitElement {
             @change=${this.handleBashApprovalToggle}
           >
             Require approval for shell commands &amp; agent sessions
+          </wa-switch>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderAgentSkillsSettings(): TemplateResult {
+    return html`
+      <div class="category-section">
+        <div class="category-header">${waIcon('robot')} Agent Skills</div>
+
+        <div class="setting-block">
+          <wa-switch
+            ?checked=${this.agentSkillsEnabled}
+            @change=${this.handleAgentSkillsToggle}
+          >
+            TeXRA and imported skills available to agents
           </wa-switch>
         </div>
       </div>
@@ -397,7 +419,8 @@ export class ToolsTab extends LitElement {
           </div>
         </div>
 
-        ${this.renderApprovalSettings()} ${this.renderDesktopCrashReporting()}
+        ${this.renderAgentSkillsSettings()} ${this.renderApprovalSettings()}
+        ${this.renderDesktopCrashReporting()}
         ${CATEGORY_ORDER.filter((cat) => groups.has(cat)).map((cat) =>
           this.renderCategory(cat, groups.get(cat)!),
         )}

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -80,6 +80,7 @@ import {
 } from '@model/openRouterRouting';
 import { isGpt5ModelName } from '@model/modelNames';
 import { getApiKey, type ApiProvider } from '@model/apiProviders';
+import { resolveUsageRoute } from '@model/usageRoute';
 import { platform } from '@platform/platform';
 import type { FileLocation, MediaAttachmentKind } from '@shared/schemas';
 import { MESSAGE_TYPES } from '@shared/schemas';
@@ -584,7 +585,7 @@ export abstract class ModelHandler<
     if (canRouteThroughRelay && serverSideKeyService?.wasQuotaAutoSwitched()) {
       throw new Error(
         `Model "${this.config.name}" cannot use the TeXRA relay because your monthly relay quota is exhausted. ` +
-          'Switch to "Use My Own Keys" via the TeXRA Profile panel, or wait for the next quota period.',
+          'The "Personal API keys" setting in the TeXRA Models panel provides direct access; otherwise, access resumes with the next quota period.',
       );
     }
 
@@ -732,17 +733,7 @@ export abstract class ModelHandler<
 
   /** Route tag for usage recorded after a successful attempt. */
   getLastCredentialUsageRoute(): NormalizedUsage['usageRoute'] {
-    switch (this.lastAttemptCredentialRoute) {
-      case 'chatgpt-subscription':
-        return 'chatgpt-subscription';
-      case 'relay':
-        return 'relay';
-      case 'api-key':
-      case 'openrouter':
-        return 'api-key';
-      default:
-        return undefined;
-    }
+    return resolveUsageRoute(this.config, this.lastAttemptCredentialRoute);
   }
 
   /** Resolve the key from the same atomic route used by client construction. */

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -12,7 +12,6 @@ import {
   formatCodexAuthUnavailableMessage,
   isCodexSessionRoutable,
 } from '@auth/codex';
-import { getServerSideKeyService } from '@auth/serverKeys';
 import { AgentError } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { apiKeyExists } from '@model/apiProviders';

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -534,13 +534,11 @@ async function createModelHandlerForResolvedCompatibilityKey(
   // backend model id, base URL, and credential change. Exclusive plan aliases
   // already carry the pinned coding baseUrl (the registry-fact predicates route
   // their key and endpoint automatically), so they keep `config` untouched.
-  // Dual-backend `kimi3` is rerouted only while the "Prefer Kimi Code" switch
-  // is on, a key is stored, and the relay is not actually serving requests —
-  // under included (relay) access the relay owns eligible models, and the
-  // rerouted config's pinned coding `baseUrl` would outrank the relay URL
-  // while the credential layer still resolves a relay token (see
-  // resolveClientCredential). The reroute swaps in a synthesized runtime
-  // config that the normal ModelHandlerKimi switch below then builds.
+  // Dual-backend `kimi3` is rerouted while the "Prefer Kimi Code" switch is
+  // on and a key is stored. This subscription preference takes precedence
+  // over the included/personal fallback. The synthesized config is a managed
+  // direct route, so credential resolution pairs its Kimi Code key with its
+  // pinned endpoint and does not consider the relay.
   //
   // On the resume path `useOpenRouter` is derived from the compatibility key
   // (false unless it's `ModelHandlerOpenRouterNative`), not the live global
@@ -555,20 +553,12 @@ async function createModelHandlerForResolvedCompatibilityKey(
     compatibilityKey === 'ModelHandlerKimi' &&
     isKimiSubscriptionEligible(config)
   ) {
-    const serverSideKeyService = getServerSideKeyService();
-    // The relay only owns the model when included access is on AND the account
-    // can actually use it — a signed-out user with the default-on toggle must
-    // still reach their Kimi Code key, matching picker availability.
-    const includedAccess = serverSideKeyService.getUseIncludedModelAccess()
-      ? await serverSideKeyService.canUseServerSideKeys()
-      : false;
     const keySet = await apiKeyExists(platform().secrets, 'kimiCode');
     const route = resolveKimiCodeRoute(
       config,
       useOpenRouter,
       keySet,
       getPreferKimiCode(),
-      includedAccess,
     );
     if (route === 'kimiCode' && !isKimiCodeExclusiveModel(config)) {
       config = kimiCodeRuntimeConfig(config);

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -3,6 +3,7 @@ import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { AgentRunStateSnapshot } from '@agent/core/state/AgentState';
 import type { RunUsageTotals } from '@agent/core/usage/RunUsageAccumulator';
 import { usesServerSideKeysRoute } from '@agent/modelHandlers/support/ProxyConfigResolver';
+import { resolveUsageRoute } from '@model/usageRoute';
 import type {
   ExtendedTokenUsageStats,
   StorageKey,
@@ -70,6 +71,7 @@ export interface UsageMonitorModelInfo {
     | 'name'
     | 'fullName'
     | 'inputPrice'
+    | 'baseUrl'
     | 'openRouterOnly'
     | 'requiresResponsesAPI'
   >;
@@ -235,7 +237,10 @@ export class UsageMonitor {
 
   private currentUsageRoute(): UsageRoute | undefined {
     try {
-      return this.usesRelayRoute() ? 'relay' : 'api-key';
+      return resolveUsageRoute(
+        this.modelInfo.config,
+        this.usesRelayRoute() ? 'relay' : 'api-key',
+      );
     } catch (error) {
       this.context.logger.debug('Usage route relay check failed', {
         data: error,

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -15,6 +15,10 @@ import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { FileListEntry } from '@shared/schemas';
 import type { AgentDelegationScope } from '@shared/schemas/agentRoster';
 import {
+  AGENT_SKILLS_CONFIG_KEY,
+  AGENT_SKILLS_ENABLED_DEFAULT,
+} from '@shared/schemas/agentSkills';
+import {
   loadRuntimeSkillCatalog,
   type SkillLoadIssue,
 } from '@skills/runtimeSkills';
@@ -192,7 +196,7 @@ export async function buildUserVars(
     // work for workflow agents. The settings toggle gives users a hard off
     // switch that skips discovery and leaves AVAILABLE_SKILLS empty.
     agentSetting.agentCategory === AgentCategory.ToolUse &&
-    getConfig<boolean>('texra.skills.enabled', true)
+    getConfig<boolean>(AGENT_SKILLS_CONFIG_KEY, AGENT_SKILLS_ENABLED_DEFAULT)
       ? loadRuntimeSkillCatalog()
       : Promise.resolve({ catalog: '', issues: [] }),
   ]);

--- a/src/auth/codex/codexAuthAccess.ts
+++ b/src/auth/codex/codexAuthAccess.ts
@@ -8,6 +8,7 @@
  */
 import * as logger from '@logger/logUtils';
 import { tryPlatform } from '@platform/platform';
+import type { ChatGptSubscriptionStatus } from '@shared/schemas/modelAccess';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { CODEX_SESSION_SECRET_KEY } from './codexConstants';
@@ -126,12 +127,7 @@ export async function isCodexSessionRoutable(): Promise<boolean> {
  * desktop hosts post the identical payload (the wire shape is validated by
  * `ChatGptAuthStatusSchema` at each host's boundary).
  */
-export async function getChatGptAuthStatus(): Promise<
-  CodexSessionStatus & {
-    preferSubscription: boolean;
-    subscriptionToolUseOnly: boolean;
-  }
-> {
+export async function getChatGptAuthStatus(): Promise<ChatGptSubscriptionStatus> {
   return {
     ...(await getCodexStatus()),
     preferSubscription: isPreferCodexSubscription(),

--- a/src/auth/codex/codexPreference.ts
+++ b/src/auth/codex/codexPreference.ts
@@ -6,6 +6,7 @@
  * of the user's API key.
  */
 import { tryPlatform } from '@platform/platform';
+import { GlobalStateKey } from '@shared/state/stateKeys';
 
 import type { ConfigTarget } from '@platform/interfaces';
 import {
@@ -67,5 +68,12 @@ export async function setCodexSubscriptionToolUseOnly(
 export async function setPreferCodexSubscription(
   enabled: boolean,
 ): Promise<CodexSubscriptionPreferenceUpdate> {
-  return writeCodexFlag(CODEX_PREFER_SUBSCRIPTION_KEY, enabled);
+  const update = await writeCodexFlag(CODEX_PREFER_SUBSCRIPTION_KEY, enabled);
+  if (update.effective) {
+    await tryPlatform()?.globalState.update(
+      GlobalStateKey.USE_OPENROUTER,
+      false,
+    );
+  }
+  return update;
 }

--- a/src/auth/codex/codexPreference.ts
+++ b/src/auth/codex/codexPreference.ts
@@ -5,10 +5,9 @@
  * ChatGPT, Codex-eligible OpenAI models route through the subscription instead
  * of the user's API key.
  */
+import type { ConfigTarget } from '@platform/interfaces';
 import { tryPlatform } from '@platform/platform';
 import { GlobalStateKey } from '@shared/state/stateKeys';
-
-import type { ConfigTarget } from '@platform/interfaces';
 import {
   CODEX_PREFER_SUBSCRIPTION_KEY,
   CODEX_SUBSCRIPTION_TOOL_USE_ONLY_KEY,
@@ -69,7 +68,7 @@ export async function setPreferCodexSubscription(
   enabled: boolean,
 ): Promise<CodexSubscriptionPreferenceUpdate> {
   const update = await writeCodexFlag(CODEX_PREFER_SUBSCRIPTION_KEY, enabled);
-  if (update.effective) {
+  if (enabled && update.effective) {
     await tryPlatform()?.globalState.update(
       GlobalStateKey.USE_OPENROUTER,
       false,

--- a/src/auth/codex/codexSessionTypes.ts
+++ b/src/auth/codex/codexSessionTypes.ts
@@ -90,7 +90,7 @@ export function formatCodexAuthUnavailableMessage(
   error: CodexAuthError,
 ): string {
   const action = error.needsReauth
-    ? 'Sign in with ChatGPT again, or turn off "Prefer ChatGPT subscription".'
-    : 'Try again in a moment, or turn off "Prefer ChatGPT subscription".';
+    ? 'A new ChatGPT sign-in or the "ChatGPT subscription preference" switch restores a valid route.'
+    : 'The route may recover shortly; the "ChatGPT subscription preference" switch controls whether TeXRA continues using it.';
   return `ChatGPT subscription unavailable: ${error.message} ${action}`;
 }

--- a/src/controllers/settingsView/ProfileMessageBuilder.ts
+++ b/src/controllers/settingsView/ProfileMessageBuilder.ts
@@ -23,11 +23,11 @@ import { FREE_TIER, ULTRA_TIER, MAX_TIER } from '@auth/config';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { PROFILE_VIEW_COMMANDS } from '@shared/ipc';
 import type {
-  ApiAccessMode,
   ProviderKeyStatus,
   RemoteAgent,
   UpdateProfileMessage,
 } from '@shared/schemas/profileViewMessages';
+import type { ApiAccessMode } from '@shared/schemas/modelAccess';
 import { getGlobalStreaming } from '@utils/config/providerConfig';
 
 export interface BuildProfileMessageDeps {

--- a/src/controllers/settingsView/SettingsProfileController.ts
+++ b/src/controllers/settingsView/SettingsProfileController.ts
@@ -1,12 +1,12 @@
 import type { StateStore } from '@platform/interfaces';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import type {
-  ApiAccessMode,
   NumberVscodeSetting,
   ProviderKeyStatus,
   ProviderVscodeSetting,
   UpdateProfileMessage,
 } from '@shared/schemas/profileViewMessages';
+import type { ApiAccessMode } from '@shared/schemas/modelAccess';
 import type { ProviderVscodeSettingDef } from '@shared/constants/providers';
 import { DEFAULT_CORE_SETTINGS } from '@shared/schemas/coreSettings';
 import { buildProfileMessage } from './ProfileMessageBuilder';
@@ -196,6 +196,15 @@ export class SettingsProfileController {
         providerSetting.globalStateKey,
         input.value,
       );
+      if (
+        providerSetting.globalStateKey === GlobalStateKey.KIMI_CODE_PREFER &&
+        input.value === true
+      ) {
+        await this.deps.globalState.update(
+          GlobalStateKey.USE_OPENROUTER,
+          false,
+        );
+      }
     } else {
       await this.deps.updateConfig(input.key, input.value);
     }

--- a/src/controllers/settingsView/SettingsViewCommandHandlers.ts
+++ b/src/controllers/settingsView/SettingsViewCommandHandlers.ts
@@ -159,6 +159,9 @@ export interface SettingsViewCommandActions {
   readonly approval: {
     readonly setBashApprovalEnabled: EnabledAction;
   };
+  readonly agentSkills: {
+    readonly setEnabled: EnabledAction;
+  };
   /**
    * Generic catalog-driven scalar-setting write. One action replaces the former
    * per-setting `gitAuthor.*` and `approval.setCodex*`/`setClaude*` handlers: the
@@ -400,6 +403,9 @@ export function createSettingsViewCommandHandlers(
       actions.approval.setBashApprovalEnabled,
       (data) => [data.enabled],
     ),
+    setAgentSkillsEnabled: mapAction(actions.agentSkills.setEnabled, (data) => [
+      data.enabled,
+    ]),
     updateStateSetting: mapAction(actions.stateSettings.update, (data) => [
       data.key,
       data.value,

--- a/src/model/apiProviders.ts
+++ b/src/model/apiProviders.ts
@@ -7,10 +7,14 @@
 import { LRUCache } from 'lru-cache';
 
 import type { PlatformSecrets } from '@platform/secrets';
-import { API_KEY_PROVIDER_IDS } from '@shared/constants/providers';
+import {
+  API_KEY_PROVIDER_IDS,
+  PERSONAL_API_KEY_PROVIDER_IDS,
+} from '@shared/constants/providers';
 import { isNonEmptyString } from '@utils/core';
 
 export const API_PROVIDERS = API_KEY_PROVIDER_IDS;
+export const PERSONAL_API_KEY_PROVIDERS = PERSONAL_API_KEY_PROVIDER_IDS;
 
 export type ApiProvider = (typeof API_PROVIDERS)[number];
 

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -6,6 +6,7 @@ import { platform } from '@platform/platform';
 import type { PlatformSecrets } from '@platform/secrets';
 import type { ModelAvailabilityKind, ModelOptionData } from '@shared/schemas';
 import { AgentCategory } from '@shared/schemas/agent';
+import { MODEL_ACCESS_ROUTE_LABELS } from '@shared/schemas/modelAccess';
 import { PROVIDER_DISPLAY_NAMES } from '@shared/constants/providers';
 import { coalesceAsync } from '@utils/core';
 import {
@@ -114,7 +115,7 @@ const AVAILABILITY_STATUS_FIELDS: Record<
     requiresKey: false,
   },
   'subscription-access': {
-    label: 'ChatGPT subscription',
+    label: MODEL_ACCESS_ROUTE_LABELS.chatgpt,
     available: true,
     requiresKey: false,
   },
@@ -216,9 +217,6 @@ function effectiveKimiCodeConfig(
     ctx.useOpenRouter,
     ctx.kimiCodeKeySet,
     ctx.preferKimiCode,
-    // The relay only owns the model when included access can actually serve
-    // it — mirrors ModelFactory's dispatch facts.
-    ctx.useIncludedAccess && ctx.hasServerAccess,
   );
   if (route === 'kimiCode' && !isKimiCodeExclusiveModel(config)) {
     return kimiCodeRuntimeConfig(config);
@@ -284,6 +282,23 @@ async function resolveModelAvailability(
         providerCapabilities: subscriptionCapabilities,
       };
     }
+  }
+
+  // Kimi Code is subscription access authenticated by its console key, not
+  // ordinary pay-per-token provider-key access. `effectiveKimiCodeConfig`
+  // pins both exclusive and preferred dual-backend models to this endpoint.
+  if (
+    resolveKimiCodeRoute(
+      config,
+      ctx.useOpenRouter,
+      ctx.kimiCodeKeySet,
+      ctx.preferKimiCode,
+    ) === 'kimiCode'
+  ) {
+    return {
+      ...availabilityStatus('subscription-access'),
+      label: MODEL_ACCESS_ROUTE_LABELS['kimi-code'],
+    };
   }
 
   // OpenRouter routing is intentionally outside included access; a configured

--- a/src/model/kimiCodeConstants.ts
+++ b/src/model/kimiCodeConstants.ts
@@ -1,0 +1,2 @@
+/** Membership endpoint used by Kimi Code subscription models. */
+export const KIMI_CODE_BASE_URL = 'https://api.kimi.com/coding/v1';

--- a/src/model/kimiCodeSubscriptionRouting.ts
+++ b/src/model/kimiCodeSubscriptionRouting.ts
@@ -23,8 +23,6 @@ import { ModelProvider, type ModelConfig } from 'llm-zoo';
 import { KIMI_CODE_BASE_URL } from './kimiCodeConstants';
 import { zeroCostAccessOverrides } from './subscriptionAccessOverrides';
 
-export { KIMI_CODE_BASE_URL } from './kimiCodeConstants';
-
 /**
  * Open-platform `fullName` → coding-endpoint wire ID. Exclusive plan aliases
  * already use their wire ID as `fullName` and pass through unchanged.

--- a/src/model/kimiCodeSubscriptionRouting.ts
+++ b/src/model/kimiCodeSubscriptionRouting.ts
@@ -20,10 +20,10 @@
 
 import { ModelProvider, type ModelConfig } from 'llm-zoo';
 
+import { KIMI_CODE_BASE_URL } from './kimiCodeConstants';
 import { zeroCostAccessOverrides } from './subscriptionAccessOverrides';
 
-/** OpenAI-compatible base URL for the Kimi Code coding endpoint. */
-export const KIMI_CODE_BASE_URL = 'https://api.kimi.com/coding/v1';
+export { KIMI_CODE_BASE_URL } from './kimiCodeConstants';
 
 /**
  * Open-platform `fullName` → coding-endpoint wire ID. Exclusive plan aliases
@@ -87,25 +87,21 @@ export function isKimiCodeExclusiveModel(
  *  - not eligible → `null`
  *  - exclusive → `'kimiCode'` when a key is set, else `null` (no other backend)
  *  - dual-backend → `'kimiCode'` only when the OpenRouter toggle is off, the
- *    relay is not serving the request (included access off or unavailable),
- *    the "Prefer Kimi Code" switch is on, and a key is set; otherwise `null`
- *    (falls back to the Moonshot open platform or the relay). The relay guard
- *    keeps credential resolution coherent: a rerouted config pins the coding
- *    `baseUrl`, which outranks the relay URL in `resolveBaseUrl` and would
- *    send the relay token to the wrong host.
+ *    "Prefer Kimi Code" switch is on, and a key is set; otherwise `null`
+ *    (falls back to the ordinary API-access route). A preferred subscription
+ *    is resolved before that fallback, just as ChatGPT subscription access is.
  */
 export function resolveKimiCodeRoute(
   config: KimiSubscriptionModelFields,
   useOpenRouter: boolean,
   keySet: boolean,
   preferKimiCode: boolean,
-  includedAccess: boolean,
 ): 'kimiCode' | null {
   if (!isKimiSubscriptionEligible(config)) return null;
   if (isKimiCodeExclusiveModel(config)) {
     return keySet ? 'kimiCode' : null;
   }
-  if (useOpenRouter || includedAccess || !preferKimiCode || !keySet) {
+  if (useOpenRouter || !preferKimiCode || !keySet) {
     return null;
   }
   return 'kimiCode';

--- a/src/model/providerCapabilities.ts
+++ b/src/model/providerCapabilities.ts
@@ -195,19 +195,13 @@ export async function isCodexSubscriptionActive(
  * Whether the model currently routes through the Kimi Code coding endpoint
  * (Moonshot coding subscription, authenticated by the Kimi Code API key).
  * Mirrors ModelFactory's dispatch facts: registry eligibility, the OpenRouter
- * toggle, included (relay) access, a stored key, and the "Prefer Kimi Code"
- * switch.
+ * toggle, a stored key, and the "Prefer Kimi Code" switch.
  */
 export async function isKimiCodeSubscriptionActive(
   modelId: string,
 ): Promise<boolean> {
   const config = await resolveRuntimeModelConfig(modelId);
   if (!config || !isKimiSubscriptionEligible(config)) return false;
-  const serverSideKeyService = getServerSideKeyService();
-  // The relay only owns the model when included access can actually serve it.
-  const includedAccess = serverSideKeyService.getUseIncludedModelAccess()
-    ? await serverSideKeyService.canUseServerSideKeys()
-    : false;
   const keySet = await apiKeyExists(platform().secrets, 'kimiCode');
   return (
     resolveKimiCodeRoute(
@@ -215,7 +209,6 @@ export async function isKimiCodeSubscriptionActive(
       getUseOpenRouter(),
       keySet,
       getPreferKimiCode(),
-      includedAccess,
     ) === 'kimiCode'
   );
 }

--- a/src/model/providerCapabilities.ts
+++ b/src/model/providerCapabilities.ts
@@ -5,7 +5,6 @@ import {
   isCodexSubscriptionToolUseOnly,
   isPreferCodexSubscription,
 } from '@auth/codex';
-import { getServerSideKeyService } from '@auth/serverKeys';
 import { zeroCostAccessOverrides } from '@model/subscriptionAccessOverrides';
 import { platform } from '@platform/platform';
 import type { UsageRoute } from '@shared/schemas';

--- a/src/model/usageRoute.ts
+++ b/src/model/usageRoute.ts
@@ -1,0 +1,27 @@
+import type { UsageRoute } from '@shared/schemas';
+
+import { KIMI_CODE_BASE_URL } from './kimiCodeConstants';
+
+type CredentialUsageRoute =
+  'api-key' | 'chatgpt-subscription' | 'openrouter' | 'relay';
+
+/** Preserve the product route represented by a lower-level credential route. */
+export function resolveUsageRoute(
+  config: { readonly baseUrl?: string },
+  credentialRoute: CredentialUsageRoute | undefined,
+): UsageRoute | undefined {
+  switch (credentialRoute) {
+    case 'chatgpt-subscription':
+      return 'chatgpt-subscription';
+    case 'relay':
+      return 'relay';
+    case 'api-key':
+      return config.baseUrl === KIMI_CODE_BASE_URL
+        ? 'kimi-code-subscription'
+        : 'api-key';
+    case 'openrouter':
+      return 'api-key';
+    default:
+      return undefined;
+  }
+}

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -462,6 +462,15 @@ export const API_KEY_PROVIDER_IDS = Object.freeze([
   'meta',
 ] as const);
 
+/**
+ * Provider credentials that constitute the personal API-key fallback.
+ * Kimi Code is omitted because its console key authenticates a subscription
+ * route that is selected independently of the API fallback.
+ */
+export const PERSONAL_API_KEY_PROVIDER_IDS = Object.freeze(
+  API_KEY_PROVIDER_IDS.filter((provider) => provider !== 'kimiCode'),
+);
+
 // ============================================================================
 // Model pricing hints
 // ============================================================================

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -351,9 +351,9 @@ export const GLM_CODING_PLAN_PROVIDER_SETTING = {
 
 export const KIMI_CODE_PREFER_PROVIDER_SETTING = {
   key: GlobalStateKey.KIMI_CODE_PREFER,
-  label: 'Prefer Kimi Code',
+  label: 'Kimi Code subscription preference',
   description:
-    'Route dual-backend Kimi models (K3) through the Kimi Code coding endpoint when a Kimi Code API key is set. The two coding-only models always use the key. When off, K3 uses the Moonshot open platform.',
+    'Dual-backend Kimi models (K3) use the Kimi Code endpoint when this preference and a Kimi Code key are present. Coding-only Kimi models always use the key. Otherwise, K3 uses the Moonshot open platform.',
   defaultValue: false,
   globalStateKey: GlobalStateKey.KIMI_CODE_PREFER,
 } satisfies ProviderVscodeSettingDef;

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -344,6 +344,8 @@ export const SETTINGS_VIEW_CMD = {
   UPDATE_STATE_SETTING: 'updateStateSetting',
   // Approval settings commands
   SET_BASH_APPROVAL_ENABLED: 'setBashApprovalEnabled',
+  // Agent prompt context
+  SET_AGENT_SKILLS_ENABLED: 'setAgentSkillsEnabled',
   // Tool dashboard commands
   OPEN_TOOL_INSTALL_URL: 'openToolInstallUrl',
   INSTALL_TOOL_EXTENSION: 'installToolExtension',
@@ -401,6 +403,7 @@ export const SETTINGS_VIEW_COMMANDS = {
   UPDATE_SUPER_YOLO_ENABLED: 'updateSuperYoloEnabled',
   UPDATE_AGENT_MODE_PRESETS: 'updateAgentModePresets',
   UPDATE_APPROVAL_SETTINGS: 'updateApprovalSettings',
+  UPDATE_AGENT_SKILLS_SETTINGS: 'updateAgentSkillsSettings',
   UPDATE_TOOL_DASHBOARD: 'updateToolDashboard',
   UPDATE_GIT_AUTHOR_SETTINGS: 'updateGitAuthorSettings',
   UPDATE_LATEX_SETTINGS_STATUS: 'updateLatexSettingsStatus',

--- a/src/shared/schemas/agentSkills.ts
+++ b/src/shared/schemas/agentSkills.ts
@@ -14,4 +14,3 @@ export const AgentSkillsEnabledSchema = z
 export const AgentSkillsSettingsSchema = z.strictObject({
   enabled: AgentSkillsEnabledSchema.prefault(AGENT_SKILLS_ENABLED_DEFAULT),
 });
-export type AgentSkillsSettings = z.infer<typeof AgentSkillsSettingsSchema>;

--- a/src/shared/schemas/agentSkills.ts
+++ b/src/shared/schemas/agentSkills.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+export const AGENT_SKILLS_CONFIG_KEY = 'texra.skills.enabled';
+export const AGENT_SKILLS_ENABLED_DEFAULT = true;
+
+/** Present agent-skills values must be explicit booleans at every boundary. */
+export const AgentSkillsEnabledSchema = z
+  .boolean()
+  .describe(
+    'Discover TeXRA and imported skills and expose them to agent prompts',
+  );
+
+/** Canonical persisted form; absence has the documented enabled default. */
+export const AgentSkillsSettingsSchema = z.strictObject({
+  enabled: AgentSkillsEnabledSchema.prefault(AGENT_SKILLS_ENABLED_DEFAULT),
+});
+export type AgentSkillsSettings = z.infer<typeof AgentSkillsSettingsSchema>;

--- a/src/shared/schemas/coreSettings.ts
+++ b/src/shared/schemas/coreSettings.ts
@@ -1,6 +1,11 @@
 // Third-party imports
 import { z } from 'zod';
 
+import {
+  AGENT_SKILLS_ENABLED_DEFAULT,
+  AgentSkillsSettingsSchema,
+} from './agentSkills';
+
 export const CHATGPT_TOOL_USE_ONLY_DESCRIPTION =
   'Use your ChatGPT subscription for tool-use agents while workflow agents continue through your OpenAI API key or relay.';
 
@@ -258,7 +263,7 @@ export const DEFAULT_CORE_SETTINGS = {
     saveInputPrompt: false,
   },
   skills: {
-    enabled: true,
+    enabled: AGENT_SKILLS_ENABLED_DEFAULT,
   },
   toolUse: {
     requireEditApproval: true,
@@ -627,14 +632,7 @@ export const CoreSettingsShape = {
       ),
     })
     .prefault(DEFAULT_CORE_SETTINGS.debug),
-  skills: z
-    .strictObject({
-      enabled: boolField(
-        DEFAULT_CORE_SETTINGS.skills.enabled,
-        'Discover imported skills and expose them to tool-use agent prompts',
-      ),
-    })
-    .prefault(DEFAULT_CORE_SETTINGS.skills),
+  skills: AgentSkillsSettingsSchema.prefault(DEFAULT_CORE_SETTINGS.skills),
   toolUse: z
     .strictObject({
       requireEditApproval: boolField(

--- a/src/shared/schemas/index.ts
+++ b/src/shared/schemas/index.ts
@@ -14,6 +14,8 @@ export * from './usage';
 export * from './contextManagement';
 export * from './spendingStatus';
 export * from './onboarding';
+export * from './modelAccess';
+export * from './agentSkills';
 
 // Layer 2: Depends on layer 1 only
 export * from './stream';

--- a/src/shared/schemas/modelAccess.ts
+++ b/src/shared/schemas/modelAccess.ts
@@ -17,13 +17,10 @@ export type ChatGptSubscriptionStatus = z.infer<
 >;
 
 /** Kimi Code subscription state shared by model-access presenters. */
-export const KimiCodeSubscriptionStatusSchema = z.object({
+const KimiCodeSubscriptionStatusSchema = z.object({
   keySet: z.boolean(),
   preferred: z.boolean(),
 });
-export type KimiCodeSubscriptionStatus = z.infer<
-  typeof KimiCodeSubscriptionStatusSchema
->;
 
 /** Complete model-access state, independent of any host or presentation. */
 export const ModelAccessStatusSchema = z.object({
@@ -35,7 +32,7 @@ export const ModelAccessStatusSchema = z.object({
 });
 export type ModelAccessStatus = z.infer<typeof ModelAccessStatusSchema>;
 
-export const ModelAccessRouteSchema = z.enum([
+const ModelAccessRouteSchema = z.enum([
   'chatgpt',
   'kimi-code',
   'included',

--- a/src/shared/schemas/modelAccess.ts
+++ b/src/shared/schemas/modelAccess.ts
@@ -1,0 +1,89 @@
+import { z } from 'zod';
+
+/** Mutually exclusive API fallback used outside preferred subscription routes. */
+export const ApiAccessModeSchema = z.enum(['included', 'personal']);
+export type ApiAccessMode = z.infer<typeof ApiAccessModeSchema>;
+
+/** ChatGPT subscription state shared by every settings surface. */
+export const ChatGptSubscriptionStatusSchema = z.object({
+  signedIn: z.boolean(),
+  email: z.string().nullish(),
+  accountId: z.string().nullish(),
+  preferSubscription: z.boolean(),
+  subscriptionToolUseOnly: z.boolean(),
+});
+export type ChatGptSubscriptionStatus = z.infer<
+  typeof ChatGptSubscriptionStatusSchema
+>;
+
+/** Kimi Code subscription state shared by model-access presenters. */
+export const KimiCodeSubscriptionStatusSchema = z.object({
+  keySet: z.boolean(),
+  preferred: z.boolean(),
+});
+export type KimiCodeSubscriptionStatus = z.infer<
+  typeof KimiCodeSubscriptionStatusSchema
+>;
+
+/** Complete model-access state, independent of any host or presentation. */
+export const ModelAccessStatusSchema = z.object({
+  apiMode: ApiAccessModeSchema,
+  chatGpt: ChatGptSubscriptionStatusSchema,
+  kimiCode: KimiCodeSubscriptionStatusSchema,
+  personalApiKeySet: z.boolean(),
+  texraSignedIn: z.boolean().optional(),
+});
+export type ModelAccessStatus = z.infer<typeof ModelAccessStatusSchema>;
+
+export const ModelAccessRouteSchema = z.enum([
+  'chatgpt',
+  'kimi-code',
+  'included',
+  'personal',
+]);
+export type ModelAccessRoute = z.infer<typeof ModelAccessRouteSchema>;
+
+export const MODEL_ACCESS_ROUTE_LABELS = {
+  chatgpt: 'ChatGPT subscription',
+  'kimi-code': 'Kimi Code subscription',
+  included: 'Included TeXRA access',
+  personal: 'Personal API keys',
+} as const satisfies Record<ModelAccessRoute, string>;
+
+export const MODEL_ACCESS_PREFERENCE_LABELS = {
+  chatgpt: `${MODEL_ACCESS_ROUTE_LABELS.chatgpt} preference`,
+  'kimi-code': `${MODEL_ACCESS_ROUTE_LABELS['kimi-code']} preference`,
+} as const;
+
+export const API_ACCESS_MODE_OPTIONS: readonly {
+  readonly value: ApiAccessMode;
+  readonly label: string;
+  readonly description: string;
+}[] = [
+  {
+    value: 'included',
+    label: MODEL_ACCESS_ROUTE_LABELS.included,
+    description:
+      'TeXRA supplies access automatically. OpenRouter models remain on the configured OpenRouter key. Personal provider keys offer separate quota and avoid relay caps.',
+  },
+  {
+    value: 'personal',
+    label: MODEL_ACCESS_ROUTE_LABELS.personal,
+    description:
+      'Configured OpenAI, Anthropic, and other provider keys use the corresponding provider account directly, including models outside Included TeXRA access.',
+  },
+] as const;
+
+export function describeApiAccessModeStatus(
+  mode: ApiAccessMode,
+  status: Pick<ModelAccessStatus, 'personalApiKeySet' | 'texraSignedIn'>,
+): string {
+  if (mode === 'included') {
+    return status.texraSignedIn === false
+      ? 'TeXRA account sign-in required'
+      : 'TeXRA account';
+  }
+  return status.personalApiKeySet
+    ? 'Provider API key configured'
+    : 'No provider API keys configured';
+}

--- a/src/shared/schemas/profileViewMessages.ts
+++ b/src/shared/schemas/profileViewMessages.ts
@@ -10,6 +10,7 @@ import { PROFILE_VIEW_COMMANDS } from '@shared/ipc';
 import { ProviderVscodeSettingDefSchema } from '@shared/constants/providers';
 import { AgentMetadataBaseSchema } from './agent';
 import { commandOnly } from './messageFactories';
+import { ApiAccessModeSchema } from './modelAccess';
 import { SpendingStatusSchema } from './spendingStatus';
 
 // ============================================================
@@ -32,27 +33,6 @@ const RemoteAgentSchema = AgentMetadataBaseSchema.extend({
   supportsMultipleOutput: z.boolean(),
 });
 export type RemoteAgent = z.infer<typeof RemoteAgentSchema>;
-
-const ApiAccessModeSchema = z.enum(['included', 'personal']);
-export type ApiAccessMode = z.infer<typeof ApiAccessModeSchema>;
-export const API_ACCESS_MODE_OPTIONS: readonly {
-  readonly value: ApiAccessMode;
-  readonly label: string;
-  readonly description: string;
-}[] = [
-  {
-    value: 'included',
-    label: 'Use Included Access',
-    description:
-      'Works automatically. No setup needed. Does not apply to OpenRouter — those models always use your OpenRouter key. Bring your own provider API keys to use more of your own quota and avoid relay caps.',
-  },
-  {
-    value: 'personal',
-    label: 'Use My Own Keys',
-    description:
-      'Provide your own API keys from OpenAI, Anthropic, etc. This uses your provider account directly for higher limits and models outside Included Access.',
-  },
-] as const;
 
 const TierConstantsSchema = z.object({
   ultra: z.string(),

--- a/src/shared/schemas/settingsView/data.ts
+++ b/src/shared/schemas/settingsView/data.ts
@@ -26,7 +26,12 @@ import {
   AgentSourceSchema,
 } from '../agent';
 import { AgentModePresetSchema } from '../agentPresets';
+import { AgentSkillsEnabledSchema } from '../agentSkills';
 import { ModelAvailabilityFieldsSchema } from '../mainView';
+import {
+  ChatGptSubscriptionStatusSchema,
+  type ChatGptSubscriptionStatus,
+} from '../modelAccess';
 import {
   NumberVscodeSettingSchema,
   UpdateProfileMessageSchema,
@@ -328,6 +333,15 @@ export type UpdateApprovalSettingsMessage = z.infer<
   typeof UpdateApprovalSettingsMessageSchema
 >;
 
+/** Outbound: backend → frontend agent skill-catalog setting. */
+const UpdateAgentSkillsSettingsMessageSchema = z.object({
+  command: z.literal(SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SKILLS_SETTINGS),
+  enabled: AgentSkillsEnabledSchema,
+});
+export type UpdateAgentSkillsSettingsMessage = z.infer<
+  typeof UpdateAgentSkillsSettingsMessageSchema
+>;
+
 // ============================================================
 // Git author settings data schema
 // ============================================================
@@ -352,18 +366,11 @@ const UpdateGitHubTokenStatusMessageSchema = z.object({
 });
 
 /** Outbound: backend → frontend ChatGPT-subscription sign-in status. */
-const ChatGptAuthStatusSchema = z.object({
-  signedIn: z.boolean(),
-  email: z.string().nullish(),
-  accountId: z.string().nullish(),
-  preferSubscription: z.boolean(),
-  subscriptionToolUseOnly: z.boolean(),
-});
-export type ChatGptAuthStatus = z.infer<typeof ChatGptAuthStatusSchema>;
+export type ChatGptAuthStatus = ChatGptSubscriptionStatus;
 
 const UpdateChatGptAuthStatusMessageSchema = z.object({
   command: z.literal(SETTINGS_VIEW_COMMANDS.UPDATE_CHATGPT_AUTH_STATUS),
-  status: ChatGptAuthStatusSchema,
+  status: ChatGptSubscriptionStatusSchema,
 });
 export type UpdateChatGptAuthStatusMessage = z.infer<
   typeof UpdateChatGptAuthStatusMessageSchema
@@ -529,6 +536,7 @@ const SettingsViewOutboundMessageSchema = z.discriminatedUnion('command', [
   UpdateSuperYoloEnabledMessageSchema,
   UpdateAgentModePresetsMessageSchema,
   UpdateApprovalSettingsMessageSchema,
+  UpdateAgentSkillsSettingsMessageSchema,
   UpdateToolDashboardMessageSchema,
   UpdateGitAuthorSettingsMessageSchema,
   UpdateGitHubTokenStatusMessageSchema,

--- a/src/shared/schemas/settingsView/inbound.ts
+++ b/src/shared/schemas/settingsView/inbound.ts
@@ -13,6 +13,7 @@ import {
 } from '@shared/utils/dispatcher';
 
 import { AgentCategorySchema, AgentSourceSchema } from '../agent';
+import { AgentSkillsEnabledSchema } from '../agentSkills';
 import { StreamTabIdSchema } from '../identifiers';
 import { commandOnly } from '../messageFactories';
 import { WebviewReadyMessageSchema } from '../commonViewMessages';
@@ -335,6 +336,11 @@ const SetBashApprovalEnabledMessageSchema = enabledFlag(
   CMD.SET_BASH_APPROVAL_ENABLED,
 );
 
+const SetAgentSkillsEnabledMessageSchema = z.object({
+  command: z.literal(CMD.SET_AGENT_SKILLS_ENABLED),
+  enabled: AgentSkillsEnabledSchema,
+});
+
 // Generic catalog-driven state-setting write. One flat branch (single outer
 // discriminator on `command`, per the SET_LATEX_CONFIG_VALUE precedent above)
 // carrying the canonical `STATE_SETTINGS` key and a loose value. Per-value
@@ -451,6 +457,8 @@ export const SettingsViewInboundMessageSchema = z.discriminatedUnion(
     OpenPRSubscriptionStreamMessageSchema,
     // Approval settings messages
     SetBashApprovalEnabledMessageSchema,
+    // Agent prompt context
+    SetAgentSkillsEnabledMessageSchema,
     // Generic catalog-driven state-setting write (git-author + agent controls)
     UpdateStateSettingMessageSchema,
     // Agent team messages

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -31,7 +31,6 @@ export { type MemoryViewItem, type MemoryPreview } from './memoryViewMessages';
 export { type HistoryItem } from './historyViewMessages';
 
 export {
-  API_ACCESS_MODE_OPTIONS,
   type ProviderKeyStatus,
   type ProviderVscodeSetting,
   type NumberVscodeSetting,

--- a/src/shared/schemas/usage.ts
+++ b/src/shared/schemas/usage.ts
@@ -21,6 +21,7 @@ export const UsageProviderSchema = z.enum([
 
 export const UsageRouteSchema = z.enum([
   'chatgpt-subscription',
+  'kimi-code-subscription',
   'relay',
   'api-key',
 ]);

--- a/src/shared/settingsView/handlers/agentSkillsHandlers.ts
+++ b/src/shared/settingsView/handlers/agentSkillsHandlers.ts
@@ -1,0 +1,32 @@
+import type { ConfigProvider, ConfigTarget } from '@platform/interfaces';
+import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
+import {
+  AGENT_SKILLS_CONFIG_KEY,
+  AGENT_SKILLS_ENABLED_DEFAULT,
+} from '@shared/schemas/agentSkills';
+import type { UpdateAgentSkillsSettingsMessage } from '@shared/schemas/settingsViewMessages';
+
+export const AGENT_SKILLS_CONFIG_TARGET: ConfigTarget = 'workspace';
+
+export function buildAgentSkillsSettingsMessage(
+  config: ConfigProvider,
+): UpdateAgentSkillsSettingsMessage {
+  return {
+    command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SKILLS_SETTINGS,
+    enabled: config.get<boolean>(
+      AGENT_SKILLS_CONFIG_KEY,
+      AGENT_SKILLS_ENABLED_DEFAULT,
+    ),
+  };
+}
+
+export async function setAgentSkillsEnabled(
+  config: ConfigProvider,
+  enabled: boolean,
+): Promise<void> {
+  await config.update(
+    AGENT_SKILLS_CONFIG_KEY,
+    enabled,
+    AGENT_SKILLS_CONFIG_TARGET,
+  );
+}

--- a/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
@@ -406,7 +406,7 @@ describe('OpenAI model handler routing', () => {
     await expect(createModelHandler(codexEligibleConfig)).rejects.toMatchObject(
       {
         name: 'AgentError',
-        message: expect.stringContaining('Try again in a moment'),
+        message: expect.stringContaining('route may recover shortly'),
         cause: { kind: 'transient' },
       },
     );
@@ -960,13 +960,9 @@ describe('Kimi Code reroute under included access', () => {
     }
   }
 
-  it('does not reroute dual-backend Kimi models while the relay serves requests', async () => {
-    // The rerouted config pins the coding baseUrl, which outranks the relay
-    // URL in resolveBaseUrl while the credential layer resolves a relay
-    // token — under serving included access the config must stay untouched.
+  it('prefers Kimi Code while included access is the fallback', async () => {
     const config = await createKimiHandler({ includedAccess: true });
-    expect(config.baseUrl).toBeUndefined();
-    expect(config.fullName).toBe(dualBackendKimi.fullName);
+    expect(config.baseUrl).toBe('https://api.kimi.com/coding/v1');
   });
 
   it('reroutes to the coding endpoint when the relay cannot serve', async () => {

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIClientDiagnostics.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIClientDiagnostics.vitest.ts
@@ -11,7 +11,7 @@ import type {
 import { ModelHandlerOpenAI } from '@agent/modelHandlers/openai/modelHandlerOpenAI';
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/openai/modelHandlerOpenAIResponse';
 import * as serverKeysModule from '@auth/serverKeys';
-import { KIMI_CODE_BASE_URL } from '@model/kimiCodeSubscriptionRouting';
+import { KIMI_CODE_BASE_URL } from '@model/kimiCodeConstants';
 import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 
 const MOONSHOT_BASE_URL = 'https://api.moonshot.ai/v1';

--- a/src/test-kernel/auth/CodexPreference.vitest.ts
+++ b/src/test-kernel/auth/CodexPreference.vitest.ts
@@ -100,4 +100,17 @@ describe('Codex subscription preference', () => {
       effectiveValue: false,
     });
   });
+
+  it('preserves OpenRouter when a more specific setting defeats disabling', async () => {
+    const config = new FolderOverrideConfigProvider(true);
+    await installPlatform({}, { config });
+    await platform().globalState.update(GlobalStateKey.USE_OPENROUTER, true);
+
+    const update = await setPreferCodexSubscription(false);
+
+    expect(update).toEqual({ effective: true, target: 'global' });
+    expect(
+      platform().globalState.get(GlobalStateKey.USE_OPENROUTER, false),
+    ).toBe(true);
+  });
 });

--- a/src/test-kernel/auth/CodexPreference.vitest.ts
+++ b/src/test-kernel/auth/CodexPreference.vitest.ts
@@ -14,6 +14,7 @@ import type {
   ConfigTarget,
   Disposable,
 } from '@platform/interfaces';
+import { GlobalStateKey } from '@shared/state/stateKeys';
 import { installPlatform } from '@test/support/setupPlatform';
 
 class FolderOverrideConfigProvider implements ConfigProvider {
@@ -74,6 +75,9 @@ describe('Codex subscription preference', () => {
 
     expect(update).toEqual({ effective: true, target: 'workspace' });
     expect(isPreferCodexSubscription()).toBe(true);
+    expect(
+      platform().globalState.get(GlobalStateKey.USE_OPENROUTER, true),
+    ).toBe(false);
     expect(
       platform().config.inspect(CODEX_PREFER_SUBSCRIPTION_KEY),
     ).toMatchObject({

--- a/src/test-kernel/cli/ApiStatusLoad.vitest.mts
+++ b/src/test-kernel/cli/ApiStatusLoad.vitest.mts
@@ -62,8 +62,16 @@ describe('loadCliApiStatusLines', () => {
     mocks.getCliSessionAccessToken.mockResolvedValue('session-token');
     mocks.resolveCliUsageTier.mockResolvedValue('free');
     mocks.readCliModelAccessStatus.mockResolvedValue({
-      active: 'personal',
-      chatGptSignedIn: false,
+      apiMode: 'personal',
+      chatGpt: {
+        signedIn: false,
+        email: null,
+        accountId: null,
+        preferSubscription: false,
+        subscriptionToolUseOnly: false,
+      },
+      kimiCode: { keySet: false, preferred: false },
+      personalApiKeySet: false,
     });
     mocks.lookupApiKeyOrigin.mockResolvedValue('none');
   });
@@ -242,10 +250,16 @@ describe('loadCliApiStatusLines', () => {
 
   it('reports both accounts, the effective route, and its API fallback', async () => {
     mocks.readCliModelAccessStatus.mockResolvedValue({
-      active: 'chatgpt',
-      chatGptSignedIn: true,
-      chatGptAccountLabel: 'chatgpt@example.com',
-      kimiCodeKeySet: false,
+      apiMode: 'personal',
+      chatGpt: {
+        signedIn: true,
+        email: 'chatgpt@example.com',
+        accountId: null,
+        preferSubscription: true,
+        subscriptionToolUseOnly: false,
+      },
+      kimiCode: { keySet: false, preferred: false },
+      personalApiKeySet: false,
     });
     mocks.getCliAuthProfile.mockResolvedValue({
       authenticated: true,
@@ -256,14 +270,20 @@ describe('loadCliApiStatusLines', () => {
       loadCliModelAccessOverview({ apiMode: 'personal' }),
     ).resolves.toEqual({
       access: {
-        active: 'chatgpt',
-        chatGptSignedIn: true,
-        chatGptAccountLabel: 'chatgpt@example.com',
-        kimiCodeKeySet: false,
+        apiMode: 'personal',
+        chatGpt: {
+          signedIn: true,
+          email: 'chatgpt@example.com',
+          accountId: null,
+          preferSubscription: true,
+          subscriptionToolUseOnly: false,
+        },
+        kimiCode: { keySet: false, preferred: false },
+        personalApiKeySet: false,
         texraSignedIn: true,
       },
       lines: [
-        'model access: ChatGPT subscription',
+        'subscription preferences: ChatGPT',
         'ChatGPT: signed in as chatgpt@example.com',
         'Kimi Code: no key (add with /key)',
         'TeXRA: signed in as texra@example.com',
@@ -274,16 +294,23 @@ describe('loadCliApiStatusLines', () => {
 
   it('reports an active Kimi Code route with its personal fallback', async () => {
     mocks.readCliModelAccessStatus.mockResolvedValue({
-      active: 'kimi-code',
-      chatGptSignedIn: false,
-      kimiCodeKeySet: true,
+      apiMode: 'personal',
+      chatGpt: {
+        signedIn: false,
+        email: null,
+        accountId: null,
+        preferSubscription: false,
+        subscriptionToolUseOnly: false,
+      },
+      kimiCode: { keySet: true, preferred: true },
+      personalApiKeySet: true,
     });
 
     await expect(
       loadCliModelAccessOverview({ apiMode: 'personal' }),
     ).resolves.toMatchObject({
       lines: [
-        'model access: Kimi Code subscription',
+        'subscription preferences: Kimi Code',
         'ChatGPT: signed out',
         'Kimi Code: key configured',
         'TeXRA: signed out',

--- a/src/test-kernel/cli/ApiStatusLoad.vitest.mts
+++ b/src/test-kernel/cli/ApiStatusLoad.vitest.mts
@@ -35,7 +35,7 @@ vi.mock('@cli/runtime/modelAccessSelection', () => ({
 }));
 
 vi.mock('@model/apiProviders', () => ({
-  API_PROVIDERS: ['deepseek'],
+  PERSONAL_API_KEY_PROVIDERS: ['deepseek'],
   lookupApiKeyOrigin: mocks.lookupApiKeyOrigin,
 }));
 

--- a/src/test-kernel/cli/ChatgptLoginBrowser.vitest.mts
+++ b/src/test-kernel/cli/ChatgptLoginBrowser.vitest.mts
@@ -47,11 +47,12 @@ describe('signInCliChatGpt browser choice', () => {
     );
 
     expect(progress).toHaveLength(1);
-    expect(progress[0]).toContain('https://auth.openai.com/authorize?x=1');
-    expect(progress[0]).toContain('different browser');
+    expect(progress[0]).toBe(
+      'ChatGPT sign-in URL:\nhttps://auth.openai.com/authorize?x=1',
+    );
   });
 
-  it('prints only the URL when the browser fails to launch', async () => {
+  it('prints the URL before reporting a failed browser launch', async () => {
     mocks.tryOpenBrowser.mockResolvedValue(false);
     mocks.loginWithLoopback.mockImplementation(async ({ openBrowser }) => {
       await openBrowser('https://auth.openai.com/authorize?x=2');
@@ -65,7 +66,8 @@ describe('signInCliChatGpt browser choice', () => {
     );
 
     expect(progress).toEqual([
-      'Open this URL to sign in with ChatGPT:\nhttps://auth.openai.com/authorize?x=2',
+      'ChatGPT sign-in URL:\nhttps://auth.openai.com/authorize?x=2',
+      'Browser launch unavailable. ChatGPT sign-in URL:\nhttps://auth.openai.com/authorize?x=2',
     ]);
   });
 
@@ -83,7 +85,7 @@ describe('signInCliChatGpt browser choice', () => {
 
     expect(mocks.tryOpenBrowser).not.toHaveBeenCalled();
     expect(progress).toEqual([
-      'Open this URL to sign in with ChatGPT:\nhttps://auth.openai.com/authorize?x=3',
+      'ChatGPT sign-in URL:\nhttps://auth.openai.com/authorize?x=3',
     ]);
   });
 

--- a/src/test-kernel/cli/ModelAccessForm.vitest.mts
+++ b/src/test-kernel/cli/ModelAccessForm.vitest.mts
@@ -43,8 +43,8 @@ describe('ModelAccessForm status', () => {
       await waitFor(() => loadCliModelAccessOverview.mock.calls.length > 0);
       await waitFor(() => stdout.output.includes('model access unavailable'));
       expect(stdout.output).toContain('model access unavailable');
-      expect(stdout.output).toContain('Sign in through Account');
-      expect(stdout.output).not.toContain('Use your TeXRA account');
+      expect(stdout.output).toContain('TeXRA account sign-in required');
+      expect(stdout.output).not.toContain('TeXRA account —');
       expect(stdout.output).not.toContain('✓');
     } finally {
       instance.unmount();

--- a/src/test-kernel/cli/ModelAccessSelection.vitest.mts
+++ b/src/test-kernel/cli/ModelAccessSelection.vitest.mts
@@ -16,6 +16,7 @@ import {
 import { createTestCliContext } from '@test/cli/fixtures/cliContext';
 
 const mocks = vi.hoisted(() => ({
+  getChatGptAuthStatus: vi.fn(),
   getCodexStatus: vi.fn(),
   isPreferCodexSubscription: vi.fn(),
   setPreferCodexSubscription: vi.fn(),
@@ -26,7 +27,6 @@ const mocks = vi.hoisted(() => ({
   updateGlobalState: vi.fn(),
   apiKeyExists: vi.fn(),
   getPreferKimiCode: vi.fn(),
-  getUseOpenRouter: vi.fn(),
   setPreferKimiCode: vi.fn(),
 }));
 
@@ -38,18 +38,19 @@ vi.mock('@platform/platform', () => ({
 }));
 
 vi.mock('@auth/codex', () => ({
+  getChatGptAuthStatus: mocks.getChatGptAuthStatus,
   getCodexStatus: mocks.getCodexStatus,
   isPreferCodexSubscription: mocks.isPreferCodexSubscription,
   setPreferCodexSubscription: mocks.setPreferCodexSubscription,
 }));
 
 vi.mock('@model/apiProviders', () => ({
+  API_PROVIDERS: ['kimiCode', 'openai'],
   apiKeyExists: mocks.apiKeyExists,
 }));
 
 vi.mock('@utils/config/providerConfig', () => ({
   getPreferKimiCode: mocks.getPreferKimiCode,
-  getUseOpenRouter: mocks.getUseOpenRouter,
   setPreferKimiCode: mocks.setPreferKimiCode,
 }));
 
@@ -80,6 +81,13 @@ const context = createTestCliContext({ apiMode: 'personal' });
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.getCodexStatus.mockResolvedValue({ signedIn: false });
+  mocks.getChatGptAuthStatus.mockResolvedValue({
+    signedIn: false,
+    email: null,
+    accountId: null,
+    preferSubscription: false,
+    subscriptionToolUseOnly: false,
+  });
   mocks.isPreferCodexSubscription.mockReturnValue(false);
   mocks.setPreferCodexSubscription.mockResolvedValue({
     effective: false,
@@ -89,7 +97,6 @@ beforeEach(() => {
   mocks.shouldUseChatGptDeviceCode.mockReturnValue(false);
   mocks.apiKeyExists.mockResolvedValue(false);
   mocks.getPreferKimiCode.mockReturnValue(false);
-  mocks.getUseOpenRouter.mockReturnValue(false);
   mocks.setPreferKimiCode.mockResolvedValue(undefined);
 });
 
@@ -142,7 +149,18 @@ describe('CLI model access routes', () => {
     ).toBe('personal');
   });
 
-  it('describes a prospective Kimi Code route only for personal access', () => {
+  it('preserves recorded Kimi Code subscription usage', () => {
+    expect(
+      resolveCliModelAccessRoute({
+        apiMode: 'personal',
+        subscriptionActive: false,
+        kimiCodeActive: false,
+        usageRoute: 'kimi-code-subscription',
+      }),
+    ).toBe('kimi-code');
+  });
+
+  it('describes a prospective Kimi Code route above either fallback', () => {
     expect(
       resolveCliModelAccessRoute({
         apiMode: 'personal',
@@ -150,14 +168,13 @@ describe('CLI model access routes', () => {
         kimiCodeActive: true,
       }),
     ).toBe('kimi-code');
-    // Under included access the relay owns eligible models.
     expect(
       resolveCliModelAccessRoute({
         apiMode: 'included',
         subscriptionActive: false,
         kimiCodeActive: true,
       }),
-    ).toBe('included');
+    ).toBe('kimi-code');
   });
 
   it('formats the shared access routes for detailed and compact surfaces', () => {
@@ -195,60 +212,77 @@ describe('CLI model access routes', () => {
     );
   });
 
-  it('reports ChatGPT only when sign-in and preference are both active', async () => {
-    mocks.getCodexStatus.mockResolvedValue({
+  it('reports the same ChatGPT status used by the extension', async () => {
+    mocks.getChatGptAuthStatus.mockResolvedValue({
       signedIn: true,
       email: 'user@example.com',
-    });
-    mocks.isPreferCodexSubscription.mockReturnValue(true);
-
-    await expect(readCliModelAccessStatus('included')).resolves.toEqual({
-      active: 'chatgpt',
-      chatGptSignedIn: true,
-      chatGptAccountLabel: 'user@example.com',
-      kimiCodeKeySet: false,
+      accountId: null,
+      preferSubscription: true,
+      subscriptionToolUseOnly: false,
     });
 
-    mocks.getCodexStatus.mockResolvedValue({ signedIn: false });
     await expect(readCliModelAccessStatus('included')).resolves.toEqual({
-      active: 'included',
-      chatGptSignedIn: false,
-      chatGptAccountLabel: undefined,
-      kimiCodeKeySet: false,
+      apiMode: 'included',
+      chatGpt: {
+        signedIn: true,
+        email: 'user@example.com',
+        accountId: null,
+        preferSubscription: true,
+        subscriptionToolUseOnly: false,
+      },
+      kimiCode: { keySet: false, preferred: false },
+      personalApiKeySet: false,
+    });
+
+    mocks.getChatGptAuthStatus.mockResolvedValue({
+      signedIn: false,
+      email: null,
+      accountId: null,
+      preferSubscription: true,
+      subscriptionToolUseOnly: false,
+    });
+    await expect(readCliModelAccessStatus('included')).resolves.toEqual({
+      apiMode: 'included',
+      chatGpt: {
+        signedIn: false,
+        email: null,
+        accountId: null,
+        preferSubscription: true,
+        subscriptionToolUseOnly: false,
+      },
+      kimiCode: { keySet: false, preferred: false },
+      personalApiKeySet: false,
     });
   });
 
-  it('reports Kimi Code only for personal access with prefer switch and key', async () => {
+  it('reports Kimi Code independently of the API fallback', async () => {
     mocks.apiKeyExists.mockResolvedValue(true);
     mocks.getPreferKimiCode.mockReturnValue(true);
 
     await expect(readCliModelAccessStatus('personal')).resolves.toEqual({
-      active: 'kimi-code',
-      chatGptSignedIn: false,
-      chatGptAccountLabel: undefined,
-      kimiCodeKeySet: true,
+      apiMode: 'personal',
+      chatGpt: {
+        signedIn: false,
+        email: null,
+        accountId: null,
+        preferSubscription: false,
+        subscriptionToolUseOnly: false,
+      },
+      kimiCode: { keySet: true, preferred: true },
+      personalApiKeySet: true,
     });
 
-    // Included access keeps the prefer switch dormant in the background.
+    // Included access remains the fallback beneath the Kimi preference.
     await expect(readCliModelAccessStatus('included')).resolves.toMatchObject({
-      active: 'included',
-      kimiCodeKeySet: true,
+      apiMode: 'included',
+      kimiCode: { keySet: true, preferred: true },
     });
 
     // A missing key falls back to plain personal access.
     mocks.apiKeyExists.mockResolvedValue(false);
     await expect(readCliModelAccessStatus('personal')).resolves.toMatchObject({
-      active: 'personal',
-      kimiCodeKeySet: false,
-    });
-
-    // OpenRouter suppresses dual-backend Kimi Code dispatch, so the route is
-    // not reported active while the toggle is on.
-    mocks.apiKeyExists.mockResolvedValue(true);
-    mocks.getUseOpenRouter.mockReturnValue(true);
-    await expect(readCliModelAccessStatus('personal')).resolves.toMatchObject({
-      active: 'personal',
-      kimiCodeKeySet: true,
+      apiMode: 'personal',
+      kimiCode: { keySet: false, preferred: true },
     });
   });
 
@@ -259,18 +293,18 @@ describe('CLI model access routes', () => {
       writeProgress: vi.fn(),
     });
 
-    expect(mocks.setPreferCodexSubscription).toHaveBeenCalledWith(false);
+    expect(mocks.setPreferCodexSubscription).not.toHaveBeenCalled();
     expect(mocks.setPreferKimiCode).toHaveBeenCalledWith(true);
     expect(mocks.updateGlobalState).toHaveBeenCalledWith(
       'texra.useOpenRouter',
       false,
     );
-    expect(mocks.setCliApiMode).toHaveBeenCalledWith('personal');
+    expect(mocks.setCliApiMode).not.toHaveBeenCalled();
     expect(mocks.invalidateModelOptionsCache).toHaveBeenCalledOnce();
     expect(result).toEqual({
       apiMode: 'personal',
       message:
-        'Prefer Kimi Code subscription enabled for Kimi models · fallback: personal API keys.',
+        'Kimi Code subscription preference: On for Kimi models · fallback: Personal API keys.',
     });
   });
 
@@ -286,12 +320,12 @@ describe('CLI model access routes', () => {
     expect(result.message).toContain('https://www.kimi.com/code/console');
   });
 
-  it('leaves the Kimi Code route when personal access is chosen explicitly', async () => {
+  it('preserves Kimi Code preference when personal fallback is selected', async () => {
     await selectCliModelAccessRoute(context, 'personal', {
       writeProgress: vi.fn(),
     });
 
-    expect(mocks.setPreferKimiCode).toHaveBeenCalledWith(false);
+    expect(mocks.setPreferKimiCode).not.toHaveBeenCalled();
     expect(mocks.setCliApiMode).toHaveBeenCalledWith('personal');
   });
 
@@ -304,21 +338,17 @@ describe('CLI model access routes', () => {
     expect(mocks.setCliApiMode).toHaveBeenCalledWith('personal');
   });
 
-  it('reports when a more specific setting keeps ChatGPT preferred over Kimi', async () => {
+  it('keeps ChatGPT and Kimi preferences independent', async () => {
     mocks.apiKeyExists.mockResolvedValue(true);
-    mocks.setPreferCodexSubscription.mockResolvedValue({
-      effective: true,
-      target: 'workspace',
-    });
+    mocks.isPreferCodexSubscription.mockReturnValue(true);
 
     const result = await selectCliModelAccessRoute(context, 'kimi-code', {
       writeProgress: vi.fn(),
     });
 
     expect(mocks.setPreferKimiCode).toHaveBeenCalledWith(true);
-    expect(result.message).toContain(
-      'keeps ChatGPT subscription preferred (workspace config)',
-    );
+    expect(mocks.setPreferCodexSubscription).not.toHaveBeenCalled();
+    expect(result.message).toContain('Kimi Code subscription preference: On');
   });
 
   it('keeps the Kimi Code prefer switch when included access is chosen', async () => {
@@ -335,27 +365,20 @@ describe('CLI model access routes', () => {
       writeProgress: vi.fn(),
     });
 
-    expect(mocks.setPreferCodexSubscription).toHaveBeenCalledWith(false);
+    expect(mocks.setPreferCodexSubscription).not.toHaveBeenCalled();
     expect(mocks.setCliApiMode).toHaveBeenCalledWith('personal');
     expect(result).toEqual({
       apiMode: 'personal',
-      message: 'Model access: Personal API keys.',
+      message: 'API fallback: Personal API keys.',
     });
   });
 
-  it('reports when a more specific setting keeps ChatGPT active', async () => {
-    mocks.setPreferCodexSubscription.mockResolvedValue({
-      effective: true,
-      target: 'workspace',
-    });
-
+  it('changes the fallback without changing ChatGPT preference', async () => {
     const result = await selectCliApiModelAccessRoute('personal');
 
-    expect(mocks.setPreferCodexSubscription).toHaveBeenCalledWith(false);
+    expect(mocks.setPreferCodexSubscription).not.toHaveBeenCalled();
     expect(mocks.setCliApiMode).toHaveBeenCalledWith('personal');
-    expect(result.message).toContain(
-      'remains on ChatGPT subscription because a more specific setting overrides workspace config',
-    );
+    expect(result.message).toBe('API fallback: Personal API keys.');
   });
 
   it('does not report an API route as selected when persistence fails', async () => {
@@ -364,7 +387,7 @@ describe('CLI model access routes', () => {
     await expect(selectCliApiModelAccessRoute('included')).rejects.toThrow(
       'Config write failed',
     );
-    expect(mocks.setPreferCodexSubscription).toHaveBeenCalledWith(false);
+    expect(mocks.setPreferCodexSubscription).not.toHaveBeenCalled();
   });
 
   it('signs in when needed and enables ChatGPT without an API key', async () => {
@@ -386,25 +409,21 @@ describe('CLI model access routes', () => {
       { signal: controller.signal, writeProgress },
     );
     expect(mocks.setPreferCodexSubscription).toHaveBeenCalledWith(true);
-    expect(mocks.updateGlobalState).toHaveBeenCalledWith(
-      'texra.useOpenRouter',
-      false,
-    );
     expect(mocks.invalidateModelOptionsCache).toHaveBeenCalledOnce();
     expect(result.message).toBe(
-      'Prefer ChatGPT subscription enabled for Codex models (user@example.com).',
+      'ChatGPT subscription preference: On for Codex models (user@example.com).',
     );
     expect(result.apiMode).toBe('personal');
   });
 
-  it('keeps the ChatGPT route selected when it is already enabled', async () => {
+  it('toggles off an enabled ChatGPT preference', async () => {
     mocks.getCodexStatus.mockResolvedValue({
       signedIn: true,
       email: 'user@example.com',
     });
     mocks.isPreferCodexSubscription.mockReturnValue(true);
     mocks.setPreferCodexSubscription.mockResolvedValue({
-      effective: true,
+      effective: false,
       target: 'global',
     });
 
@@ -413,12 +432,11 @@ describe('CLI model access routes', () => {
     });
 
     expect(mocks.signInCliChatGpt).not.toHaveBeenCalled();
-    expect(mocks.setPreferCodexSubscription).toHaveBeenCalledWith(true);
+    expect(mocks.setPreferCodexSubscription).toHaveBeenCalledWith(false);
     expect(mocks.invalidateModelOptionsCache).toHaveBeenCalledOnce();
     expect(result).toEqual({
       apiMode: 'personal',
-      message:
-        'Prefer ChatGPT subscription enabled for Codex models (user@example.com).',
+      message: 'ChatGPT subscription preference: Off.',
     });
   });
 

--- a/src/test-kernel/cli/ModelAccessSelection.vitest.mts
+++ b/src/test-kernel/cli/ModelAccessSelection.vitest.mts
@@ -45,7 +45,7 @@ vi.mock('@auth/codex', () => ({
 }));
 
 vi.mock('@model/apiProviders', () => ({
-  API_PROVIDERS: ['kimiCode', 'openai'],
+  PERSONAL_API_KEY_PROVIDERS: ['openai'],
   apiKeyExists: mocks.apiKeyExists,
 }));
 
@@ -256,7 +256,9 @@ describe('CLI model access routes', () => {
   });
 
   it('reports Kimi Code independently of the API fallback', async () => {
-    mocks.apiKeyExists.mockResolvedValue(true);
+    mocks.apiKeyExists.mockImplementation(
+      async (_secrets: unknown, provider: string) => provider === 'kimiCode',
+    );
     mocks.getPreferKimiCode.mockReturnValue(true);
 
     await expect(readCliModelAccessStatus('personal')).resolves.toEqual({
@@ -269,7 +271,7 @@ describe('CLI model access routes', () => {
         subscriptionToolUseOnly: false,
       },
       kimiCode: { keySet: true, preferred: true },
-      personalApiKeySet: true,
+      personalApiKeySet: false,
     });
 
     // Included access remains the fallback beneath the Kimi preference.

--- a/src/test-kernel/cli/Orchestration.vitest.mts
+++ b/src/test-kernel/cli/Orchestration.vitest.mts
@@ -30,7 +30,36 @@ import {
   type CliMultiAgentPreset,
   type CliMultiAgentPresetRunPlan,
 } from '@cli/runtime/multiAgentPresets';
-import type { ExecutionId } from '@shared/schemas';
+import type { ExecutionId, ModelAccessStatus } from '@shared/schemas';
+
+function modelAccessStatus(
+  overrides: {
+    apiMode?: ModelAccessStatus['apiMode'];
+    chatGpt?: Partial<ModelAccessStatus['chatGpt']>;
+    kimiCode?: Partial<ModelAccessStatus['kimiCode']>;
+    personalApiKeySet?: boolean;
+    texraSignedIn?: boolean;
+  } = {},
+): ModelAccessStatus {
+  return {
+    apiMode: overrides.apiMode ?? 'personal',
+    chatGpt: {
+      signedIn: false,
+      email: null,
+      accountId: null,
+      preferSubscription: false,
+      subscriptionToolUseOnly: false,
+      ...overrides.chatGpt,
+    },
+    kimiCode: {
+      keySet: false,
+      preferred: false,
+      ...overrides.kimiCode,
+    },
+    personalApiKeySet: overrides.personalApiKeySet ?? false,
+    texraSignedIn: overrides.texraSignedIn,
+  };
+}
 
 function historyEntry(
   id: string,
@@ -369,11 +398,10 @@ describe('CLI orchestration items', () => {
   });
 
   it('keeps model access directly below new chat and presents every access route', () => {
-    const status = {
-      active: 'included' as const,
-      chatGptSignedIn: true,
-      chatGptAccountLabel: 'researcher@example.com',
-    };
+    const status = modelAccessStatus({
+      apiMode: 'included',
+      chatGpt: { signedIn: true, email: 'researcher@example.com' },
+    });
     const items = buildCliOrchestrationItems({
       presetPlans: [],
       history: [],
@@ -383,66 +411,86 @@ describe('CLI orchestration items', () => {
 
     expect(items[1]).toEqual({
       label: 'Model access',
-      description: 'Included TeXRA access',
+      description: 'Included TeXRA access · TeXRA account',
       value: { kind: 'configure-model-access' },
     });
     expect(buildCliModelAccessItems(status)).toEqual([
       {
         value: 'chatgpt',
-        label: 'Prefer ChatGPT subscription',
+        label: 'ChatGPT subscription preference',
         description: 'Off · researcher@example.com',
       },
       {
         value: 'kimi-code',
-        label: 'Prefer Kimi Code subscription',
+        label: 'Kimi Code subscription preference',
         description: 'Add a key with /key (kimi.com/code/console)',
       },
       {
         value: 'included',
         label: 'Included TeXRA access',
-        description: 'Use your TeXRA account',
+        description: 'TeXRA account',
       },
       {
         value: 'personal',
         label: 'Personal API keys',
-        description: 'Use keys configured on this computer',
+        description: 'No provider API keys configured',
       },
     ]);
   });
 
+  it('presents agent skills as an independent launcher switch', () => {
+    const items = buildCliOrchestrationItems({
+      presetPlans: [],
+      history: [],
+      toolUseAgents: [],
+      agentSkillsEnabled: true,
+    });
+
+    expect(items.find((item) => item.label === 'Agent skills')).toEqual({
+      label: 'Agent skills',
+      description: 'On · TeXRA and imported skills available to agents',
+      value: { kind: 'set-agent-skills', enabled: false },
+    });
+  });
+
   it('describes the Kimi Code route by key state and activity', () => {
     expect(
-      buildCliModelAccessItems({
-        active: 'personal',
-        chatGptSignedIn: false,
-        kimiCodeKeySet: true,
-      })[1],
+      buildCliModelAccessItems(
+        modelAccessStatus({
+          apiMode: 'personal',
+          kimiCode: { keySet: true },
+          personalApiKeySet: true,
+        }),
+      )[1],
     ).toEqual({
       value: 'kimi-code',
-      label: 'Prefer Kimi Code subscription',
+      label: 'Kimi Code subscription preference',
       description: 'Off · key configured',
     });
     expect(
-      buildCliModelAccessItems({
-        active: 'kimi-code',
-        chatGptSignedIn: false,
-        kimiCodeKeySet: true,
-      })[1].description,
+      buildCliModelAccessItems(
+        modelAccessStatus({
+          apiMode: 'personal',
+          kimiCode: { keySet: true, preferred: true },
+          personalApiKeySet: true,
+        }),
+      )[1].description,
     ).toBe('On · key configured');
 
     const items = buildCliOrchestrationItems({
       presetPlans: [],
       history: [],
       toolUseAgents: [],
-      modelAccess: {
-        active: 'kimi-code',
-        chatGptSignedIn: false,
-        kimiCodeKeySet: true,
-      },
+      modelAccess: modelAccessStatus({
+        apiMode: 'personal',
+        kimiCode: { keySet: true, preferred: true },
+        personalApiKeySet: true,
+      }),
     });
     expect(items[1]).toEqual({
       label: 'Model access',
-      description: 'Kimi Code subscription · key configured',
+      description:
+        'Kimi Code · fallback: Personal API keys (provider API key configured)',
       value: { kind: 'configure-model-access' },
     });
   });
@@ -495,12 +543,13 @@ describe('CLI orchestration items', () => {
       }),
     ]);
     expect(
-      buildCliModelAccessItems({
-        active: 'personal',
-        chatGptSignedIn: false,
-        texraSignedIn: false,
-      }).find((item) => item.value === 'included')?.description,
-    ).toBe('Sign in through Account to use included models');
+      buildCliModelAccessItems(
+        modelAccessStatus({
+          apiMode: 'personal',
+          texraSignedIn: false,
+        }),
+      ).find((item) => item.value === 'included')?.description,
+    ).toBe('TeXRA account sign-in required');
   });
 
   it('does not offer to sign out an environment-managed relay token', () => {

--- a/src/test-kernel/cli/Orchestration.vitest.mts
+++ b/src/test-kernel/cli/Orchestration.vitest.mts
@@ -490,9 +490,23 @@ describe('CLI orchestration items', () => {
     expect(items[1]).toEqual({
       label: 'Model access',
       description:
-        'Kimi Code · fallback: Personal API keys (provider API key configured)',
+        'Kimi Code · fallback: Personal API keys (Provider API key configured)',
       value: { kind: 'configure-model-access' },
     });
+
+    const includedItems = buildCliOrchestrationItems({
+      presetPlans: [],
+      history: [],
+      toolUseAgents: [],
+      modelAccess: modelAccessStatus({
+        apiMode: 'included',
+        texraSignedIn: true,
+        kimiCode: { keySet: true, preferred: true },
+      }),
+    });
+    expect(includedItems[1]?.description).toBe(
+      'Kimi Code · fallback: Included TeXRA access (TeXRA account)',
+    );
   });
 
   it('offers account management as one startup row with provider actions', () => {

--- a/src/test-kernel/cli/RunChatSignalOwnership.vitest.mts
+++ b/src/test-kernel/cli/RunChatSignalOwnership.vitest.mts
@@ -449,7 +449,7 @@ describe('runChat signal ownership wiring', () => {
       kill.mockRestore();
       exit.mockRestore();
     }
-  });
+  }, 30_000);
 
   it('constructs the exact initial run configuration for a resumed team', async () => {
     const exitTui = deferred();
@@ -537,5 +537,5 @@ describe('runChat signal ownership wiring', () => {
       loadAgentsSpy.mockRestore();
       getVisibleAgentsSpy.mockRestore();
     }
-  });
+  }, 30_000);
 });

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
@@ -73,7 +73,18 @@ function createSession(): TuiSession {
 
 function mockModelAccessOverview(): void {
   vi.spyOn(apiStatus, 'loadCliModelAccessOverview').mockResolvedValue({
-    access: { active: 'personal', chatGptSignedIn: false },
+    access: {
+      apiMode: 'personal',
+      chatGpt: {
+        signedIn: false,
+        email: null,
+        accountId: null,
+        preferSubscription: false,
+        subscriptionToolUseOnly: false,
+      },
+      kimiCode: { keySet: false, preferred: false },
+      personalApiKeySet: false,
+    },
     lines: ['model access: Personal API keys'],
   });
 }
@@ -433,8 +444,16 @@ describe('handleTuiSlashCommand', () => {
       .spyOn(apiStatus, 'loadCliModelAccessOverview')
       .mockResolvedValue({
         access: {
-          active: 'chatgpt',
-          chatGptSignedIn: true,
+          apiMode: 'personal',
+          chatGpt: {
+            signedIn: true,
+            email: null,
+            accountId: null,
+            preferSubscription: true,
+            subscriptionToolUseOnly: false,
+          },
+          kimiCode: { keySet: false, preferred: false },
+          personalApiKeySet: false,
           texraSignedIn: true,
         },
         lines: [

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -16,7 +16,12 @@ import {
   streamAccessTarget,
   type StreamSlice,
 } from '@cli/chat/tui/state/cliState';
-import { AgentCategory, STREAM_PHASE, STREAM_SUBSTATE } from '@shared/schemas';
+import {
+  AgentCategory,
+  STREAM_PHASE,
+  STREAM_SUBSTATE,
+  type UsageRoute,
+} from '@shared/schemas';
 
 const PERSONAL_API_MODE_LABEL = shortCliApiMode('personal');
 
@@ -619,9 +624,7 @@ describe('CLI StatusBar display model', () => {
   });
 
   it('shows the route that produced usage instead of a stale access preference', () => {
-    const accessLabel = (
-      usageRoute: 'chatgpt-subscription' | 'relay' | 'api-key',
-    ): string[] =>
+    const accessLabel = (usageRoute: UsageRoute): string[] =>
       buildStatusBarDisplay(
         statusInput({
           modelAccess: resolveCliModelAccessRoute({
@@ -643,6 +646,8 @@ describe('CLI StatusBar display model', () => {
     expect(accessLabel('relay')).not.toContain('subscription');
     expect(accessLabel('api-key')).toContain('personal');
     expect(accessLabel('api-key')).not.toContain('subscription');
+    expect(accessLabel('kimi-code-subscription')).toContain('kimi-code');
+    expect(accessLabel('kimi-code-subscription')).not.toContain('personal');
   });
 
   it('keeps critical controls visible in narrow subagent sessions', () => {

--- a/src/test-kernel/controllers/SettingsProfileController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsProfileController.vitest.ts
@@ -177,8 +177,8 @@ describe('SettingsProfileController', () => {
     expect(invalidations.count).toBe(1);
   });
 
-  it('recomputes model options when Prefer Kimi Code is toggled', async () => {
-    const state = createState();
+  it('activates Kimi Code routing consistently with the CLI', async () => {
+    const state = createState({ [GlobalStateKey.USE_OPENROUTER]: true });
     const { controller, invalidations } = createController({ state });
 
     const updated = await controller.setProviderVscodeSetting({
@@ -192,6 +192,7 @@ describe('SettingsProfileController', () => {
       affectsModelAvailability: true,
     });
     expect(state.get(GlobalStateKey.KIMI_CODE_PREFER, false)).toBe(true);
+    expect(state.get(GlobalStateKey.USE_OPENROUTER, true)).toBe(false);
     expect(invalidations.count).toBe(1);
   });
 

--- a/src/test-kernel/controllers/SettingsViewCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/SettingsViewCommandHandlers.vitest.ts
@@ -104,6 +104,9 @@ function createActions(): SettingsViewCommandActions {
     approval: {
       setBashApprovalEnabled: action(),
     },
+    agentSkills: {
+      setEnabled: action(),
+    },
     stateSettings: {
       update: action(),
     },
@@ -208,6 +211,12 @@ describe('createSettingsViewCommandHandlers', () => {
       toolId: 'latex',
       kind: 'install',
     });
+
+    assertSupported(registry.setAgentSkillsEnabled)({
+      command: SETTINGS_VIEW_COMMANDS.SET_AGENT_SKILLS_ENABLED,
+      enabled: false,
+    });
+    expect(actions.agentSkills.setEnabled).toHaveBeenCalledWith(false);
 
     assertSupported(registry.requestModelAccess)({
       command: SETTINGS_VIEW_COMMANDS.REQUEST_MODEL_ACCESS,

--- a/src/test-kernel/model/ComputeModelOptions.vitest.ts
+++ b/src/test-kernel/model/ComputeModelOptions.vitest.ts
@@ -161,7 +161,8 @@ describe('computeModelOptionsData relay quota state', () => {
 
     expect(model).toMatchObject({
       provider: 'kimiCode',
-      availability: 'provider-key',
+      availability: 'subscription-access',
+      availabilityLabel: 'Kimi Code subscription',
       disabled: false,
     });
   });
@@ -535,7 +536,8 @@ describe('computeModelOptionsData Kimi Code routing (dual-backend kimi3)', () =>
     expect(model).toMatchObject({
       provider: 'kimiCode',
       routeLabel: 'Via Kimi Code',
-      availability: 'provider-key',
+      availability: 'subscription-access',
+      availabilityLabel: 'Kimi Code subscription',
       disabled: false,
       cost: '$0.000/$0.000',
       context: '262K',

--- a/src/test-kernel/model/KimiSubscriptionRouting.vitest.ts
+++ b/src/test-kernel/model/KimiSubscriptionRouting.vitest.ts
@@ -3,8 +3,8 @@ import { describe, expect, it } from 'vitest';
 import { ModelProvider } from 'llm-zoo';
 
 // Local imports
+import { KIMI_CODE_BASE_URL } from '@model/kimiCodeConstants';
 import {
-  KIMI_CODE_BASE_URL,
   isKimiCodeExclusiveModel,
   isKimiSubscriptionEligible,
   kimiCodeRuntimeConfig,

--- a/src/test-kernel/model/KimiSubscriptionRouting.vitest.ts
+++ b/src/test-kernel/model/KimiSubscriptionRouting.vitest.ts
@@ -66,40 +66,30 @@ describe('resolveKimiCodeRoute', () => {
         false,
         true,
         true,
-        false,
       ),
     ).toBeNull();
   });
 
   it('routes exclusive models whenever a key is set, ignoring the toggles', () => {
-    // key + prefer off + openRouter on + included on: still routes (no other
-    // backend exists for coding-only models, and they never allow the relay).
-    expect(resolveKimiCodeRoute(exclusive, true, true, false, true)).toBe(
-      'kimiCode',
-    );
+    // Key + preference off + OpenRouter on: still routes because no other
+    // backend exists for coding-only models.
+    expect(resolveKimiCodeRoute(exclusive, true, true, false)).toBe('kimiCode');
     // no key: cannot route.
-    expect(
-      resolveKimiCodeRoute(exclusive, false, false, true, false),
-    ).toBeNull();
+    expect(resolveKimiCodeRoute(exclusive, false, false, true)).toBeNull();
   });
 
   it('routes dual-backend only with prefer on, a key set, and OpenRouter off', () => {
-    expect(resolveKimiCodeRoute(dual, false, true, true, false)).toBe(
-      'kimiCode',
-    );
+    expect(resolveKimiCodeRoute(dual, false, true, true)).toBe('kimiCode');
     // prefer off → open platform.
-    expect(resolveKimiCodeRoute(dual, false, true, false, false)).toBeNull();
+    expect(resolveKimiCodeRoute(dual, false, true, false)).toBeNull();
     // no key → open platform.
-    expect(resolveKimiCodeRoute(dual, false, false, true, false)).toBeNull();
+    expect(resolveKimiCodeRoute(dual, false, false, true)).toBeNull();
     // OpenRouter on → open-router path wins.
-    expect(resolveKimiCodeRoute(dual, true, true, true, false)).toBeNull();
+    expect(resolveKimiCodeRoute(dual, true, true, true)).toBeNull();
   });
 
-  it('leaves dual-backend models to the relay under included access', () => {
-    // Included (relay) access owns eligible models: the rerouted config's
-    // pinned coding baseUrl would outrank the relay URL while the credential
-    // layer resolves a relay token, so the reroute must not happen.
-    expect(resolveKimiCodeRoute(dual, false, true, true, true)).toBeNull();
+  it('resolves the subscription before the independent API fallback', () => {
+    expect(resolveKimiCodeRoute(dual, false, true, true)).toBe('kimiCode');
   });
 });
 

--- a/src/test-kernel/model/UsageRoute.vitest.ts
+++ b/src/test-kernel/model/UsageRoute.vitest.ts
@@ -1,7 +1,7 @@
 import { ModelProvider } from 'llm-zoo';
 import { describe, expect, it } from 'vitest';
 
-import { KIMI_CODE_BASE_URL } from '@model/kimiCodeSubscriptionRouting';
+import { KIMI_CODE_BASE_URL } from '@model/kimiCodeConstants';
 import { resolveUsageRoute } from '@model/usageRoute';
 import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 

--- a/src/test-kernel/model/UsageRoute.vitest.ts
+++ b/src/test-kernel/model/UsageRoute.vitest.ts
@@ -1,0 +1,37 @@
+import { ModelProvider } from 'llm-zoo';
+import { describe, expect, it } from 'vitest';
+
+import { KIMI_CODE_BASE_URL } from '@model/kimiCodeSubscriptionRouting';
+import { resolveUsageRoute } from '@model/usageRoute';
+import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
+
+const OPENAI_CONFIG = buildTestModelConfig({
+  name: 'gpt-test',
+  label: 'GPT Test',
+  fullName: 'gpt-test',
+  provider: ModelProvider.OPENAI,
+  maxOutputTokens: 4096,
+});
+
+describe('usage route', () => {
+  it('distinguishes Kimi Code subscription usage from personal API keys', () => {
+    const kimiCodeConfig = buildTestModelConfig(OPENAI_CONFIG, {
+      provider: ModelProvider.MOONSHOT,
+      kimiSubscription: true,
+      baseUrl: KIMI_CODE_BASE_URL,
+    });
+
+    expect(resolveUsageRoute(kimiCodeConfig, 'api-key')).toBe(
+      'kimi-code-subscription',
+    );
+    expect(resolveUsageRoute(OPENAI_CONFIG, 'api-key')).toBe('api-key');
+  });
+
+  it('preserves ChatGPT, relay, and OpenRouter credential routes', () => {
+    expect(resolveUsageRoute(OPENAI_CONFIG, 'chatgpt-subscription')).toBe(
+      'chatgpt-subscription',
+    );
+    expect(resolveUsageRoute(OPENAI_CONFIG, 'relay')).toBe('relay');
+    expect(resolveUsageRoute(OPENAI_CONFIG, 'openrouter')).toBe('api-key');
+  });
+});

--- a/src/test-kernel/settings/AgentSkillsSettings.vitest.ts
+++ b/src/test-kernel/settings/AgentSkillsSettings.vitest.ts
@@ -1,0 +1,66 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports
+import type { ConfigInspection, ConfigTarget } from '@platform/interfaces';
+import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
+import {
+  AGENT_SKILLS_CONFIG_TARGET,
+  buildAgentSkillsSettingsMessage,
+  setAgentSkillsEnabled,
+} from '@shared/settingsView/handlers/agentSkillsHandlers';
+import { AGENT_SKILLS_CONFIG_KEY } from '@shared/schemas/agentSkills';
+
+class RecordingConfigProvider {
+  value = true;
+  readonly updateCalls: Array<{
+    key: string;
+    value: unknown;
+    target: ConfigTarget | undefined;
+  }> = [];
+
+  get<T>(_key: string, defaultValue?: T): T {
+    return (this.value ?? defaultValue) as T;
+  }
+
+  async update<T>(key: string, value: T, target?: ConfigTarget): Promise<void> {
+    this.updateCalls.push({ key, value, target });
+  }
+
+  inspect<T = unknown>(_key: string): ConfigInspection<T> | undefined {
+    return undefined;
+  }
+
+  isExplicitlySet(): boolean {
+    return false;
+  }
+
+  watch(): { dispose(): void } {
+    return { dispose: () => undefined };
+  }
+}
+
+describe('agent skills settings', () => {
+  it('builds the shared extension and desktop settings message', () => {
+    const config = new RecordingConfigProvider();
+
+    expect(buildAgentSkillsSettingsMessage(config)).toEqual({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SKILLS_SETTINGS,
+      enabled: true,
+    });
+  });
+
+  it('persists the switch in workspace configuration', async () => {
+    const config = new RecordingConfigProvider();
+
+    await setAgentSkillsEnabled(config, false);
+
+    expect(config.updateCalls).toEqual([
+      {
+        key: AGENT_SKILLS_CONFIG_KEY,
+        value: false,
+        target: AGENT_SKILLS_CONFIG_TARGET,
+      },
+    ]);
+  });
+});

--- a/src/test-kernel/settings/AgentSkillsWorkspaceGuard.vitest.ts
+++ b/src/test-kernel/settings/AgentSkillsWorkspaceGuard.vitest.ts
@@ -1,0 +1,84 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
+// Third-party imports
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as vscode from 'vscode';
+
+const mocks = vi.hoisted(() => ({
+  setAgentSkillsEnabled: vi.fn(),
+  showLoggedInfoMessage: vi.fn(),
+}));
+
+vi.mock(
+  '@shared/settingsView/handlers/agentSkillsHandlers',
+  async (original) => {
+    const actual =
+      await original<
+        typeof import('@shared/settingsView/handlers/agentSkillsHandlers')
+      >();
+    return {
+      ...actual,
+      setAgentSkillsEnabled: mocks.setAgentSkillsEnabled,
+    };
+  },
+);
+
+vi.mock('@frontend/ui/errorHandlingUtils', async (original) => {
+  const actual =
+    await original<typeof import('@frontend/ui/errorHandlingUtils')>();
+  return {
+    ...actual,
+    showLoggedInfoMessage: mocks.showLoggedInfoMessage,
+  };
+});
+
+// Local imports
+import { SettingsViewMessageHandler } from '@settingsView/SettingsViewMessageHandler';
+
+type AgentSkillsHarness = {
+  handleSetAgentSkillsEnabled(enabled: boolean): Promise<void>;
+  sendAgentSkillsSettings: ReturnType<typeof vi.fn>;
+  withActiveWebview: (
+    fn: (webview: vscode.Webview) => Promise<void> | void,
+  ) => Promise<void>;
+};
+
+function createHarness(): AgentSkillsHarness {
+  const handler = Object.create(SettingsViewMessageHandler.prototype);
+  Reflect.set(handler, 'channel', 'SettingsViewMessageHandler');
+  Reflect.set(handler, 'sendAgentSkillsSettings', vi.fn());
+  Reflect.set(
+    handler,
+    'withActiveWebview',
+    async (fn: (webview: vscode.Webview) => Promise<void> | void) => {
+      await fn({} as vscode.Webview);
+    },
+  );
+  return handler as AgentSkillsHarness;
+}
+
+describe('agent skills workspace guard', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    Reflect.deleteProperty(vscode.workspace, 'workspaceFolders');
+  });
+
+  it('restores the switch without writing in an empty VS Code window', async () => {
+    Object.defineProperty(vscode.workspace, 'workspaceFolders', {
+      configurable: true,
+      value: undefined,
+    });
+    const handler = createHarness();
+
+    await handler.handleSetAgentSkillsEnabled(false);
+
+    expect(mocks.setAgentSkillsEnabled).not.toHaveBeenCalled();
+    expect(mocks.showLoggedInfoMessage).toHaveBeenCalledWith(
+      'SettingsViewMessageHandler',
+      'Agent skills are a per-workspace setting. Open a workspace folder before changing them.',
+    );
+    expect(handler.sendAgentSkillsSettings).toHaveBeenCalledOnce();
+  });
+});

--- a/src/test-kernel/settings/ModelAccessCredentialClassification.vitest.ts
+++ b/src/test-kernel/settings/ModelAccessCredentialClassification.vitest.ts
@@ -1,0 +1,70 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  postMessage: vi.fn(),
+}));
+
+vi.mock('@shared/hostBridge', () => ({
+  postMessage: mocks.postMessage,
+}));
+
+// Local imports - shared schemas
+import type { ProviderKeyStatus } from '@shared/schemas/settingsViewMessages';
+
+// Local imports - test utilities
+import { useLitComponentTestDom } from './litComponentTestUtils';
+
+type ModelsTabElement = HTMLElement & {
+  providerKeyStatuses: ProviderKeyStatus[];
+  updateComplete: Promise<boolean>;
+};
+
+type ApiAccessSectionElement = HTMLElement & {
+  personalApiKeySet: boolean;
+};
+
+describe('model access credential classification', () => {
+  useLitComponentTestDom(() => import('@settingsView/frontend/tabs/ModelsTab'));
+
+  it('keeps a Kimi Code membership key separate from personal API keys', async () => {
+    const tab = document.createElement('models-tab') as ModelsTabElement;
+    tab.providerKeyStatuses = [
+      {
+        provider: 'kimiCode',
+        displayName: 'Kimi Code',
+        status: 'set',
+        keyUrl: 'https://www.kimi.com/code/console',
+        streaming: true,
+        customEndpoint: '',
+        supportsCustomEndpoint: false,
+        vscodeSettings: [],
+      },
+    ];
+    document.body.append(tab);
+    await tab.updateComplete;
+
+    const accessSection =
+      tab.shadowRoot?.querySelector<ApiAccessSectionElement>(
+        'api-access-section',
+      );
+    expect(accessSection?.personalApiKeySet).toBe(false);
+
+    tab.providerKeyStatuses = [
+      ...tab.providerKeyStatuses,
+      {
+        provider: 'openai',
+        displayName: 'OpenAI',
+        status: 'env',
+        keyUrl: 'https://platform.openai.com/api-keys',
+        streaming: true,
+        customEndpoint: '',
+        supportsCustomEndpoint: true,
+        vscodeSettings: [],
+      },
+    ];
+    await tab.updateComplete;
+
+    expect(accessSection?.personalApiKeySet).toBe(true);
+  });
+});

--- a/src/test-kernel/shared/ModelAccessSchema.vitest.ts
+++ b/src/test-kernel/shared/ModelAccessSchema.vitest.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  API_ACCESS_MODE_OPTIONS,
+  ApiAccessModeSchema,
+  describeApiAccessModeStatus,
+  MODEL_ACCESS_ROUTE_LABELS,
+  ModelAccessStatusSchema,
+} from '@shared/schemas/modelAccess';
+
+describe('shared model-access contract', () => {
+  it('defines the API fallback values and labels for every host', () => {
+    expect(ApiAccessModeSchema.options).toEqual(['included', 'personal']);
+    expect(
+      API_ACCESS_MODE_OPTIONS.map(({ value, label }) => ({ value, label })),
+    ).toEqual([
+      { value: 'included', label: MODEL_ACCESS_ROUTE_LABELS.included },
+      { value: 'personal', label: MODEL_ACCESS_ROUTE_LABELS.personal },
+    ]);
+  });
+
+  it('validates subscription, relay, and API-key status together', () => {
+    expect(
+      ModelAccessStatusSchema.parse({
+        apiMode: 'personal',
+        chatGpt: {
+          signedIn: true,
+          email: 'researcher@example.com',
+          accountId: null,
+          preferSubscription: true,
+          subscriptionToolUseOnly: false,
+        },
+        kimiCode: { keySet: true, preferred: true },
+        personalApiKeySet: true,
+        texraSignedIn: false,
+      }),
+    ).toMatchObject({
+      apiMode: 'personal',
+      personalApiKeySet: true,
+      texraSignedIn: false,
+    });
+  });
+
+  it('derives identical fallback status text for CLI and GUI', () => {
+    const status = { personalApiKeySet: false, texraSignedIn: false };
+
+    expect(describeApiAccessModeStatus('included', status)).toBe(
+      'TeXRA account sign-in required',
+    );
+    expect(describeApiAccessModeStatus('personal', status)).toBe(
+      'No provider API keys configured',
+    );
+  });
+});

--- a/src/test-kernel/shared/stateSettings.vitest.ts
+++ b/src/test-kernel/shared/stateSettings.vitest.ts
@@ -23,10 +23,8 @@ import {
   type SettingStore,
   type StateSettingEntry,
 } from '@shared/schemas/stateSettings';
-import {
-  API_ACCESS_MODE_OPTIONS,
-  REASONING_LEVEL_OPTIONS,
-} from '@shared/schemas/settingsViewMessages';
+import { REASONING_LEVEL_OPTIONS } from '@shared/schemas/settingsViewMessages';
+import { API_ACCESS_MODE_OPTIONS } from '@shared/schemas/modelAccess';
 import { PROVIDER_ENDPOINT_STATE_ENTRIES } from '@shared/constants/providers';
 import {
   readSetting,
@@ -345,8 +343,8 @@ describe('state settings catalog', () => {
         (option) => `${option.value} — ${option.label} — ${option.description}`,
       ),
       [
-        'included — Use Included Access — Works automatically. No setup needed. Does not apply to OpenRouter — those models always use your OpenRouter key. Bring your own provider API keys to use more of your own quota and avoid relay caps.',
-        'personal — Use My Own Keys — Provide your own API keys from OpenAI, Anthropic, etc. This uses your provider account directly for higher limits and models outside Included Access.',
+        'included — Included TeXRA access — TeXRA supplies access automatically. OpenRouter models remain on the configured OpenRouter key. Personal provider keys offer separate quota and avoid relay caps.',
+        'personal — Personal API keys — Configured OpenAI, Anthropic, and other provider keys use the corresponding provider account directly, including models outside Included TeXRA access.',
       ],
     );
   });


### PR DESCRIPTION
## Summary

- Treats ChatGPT and Kimi Code subscriptions as independent preferences above the included-access or personal-key fallback.
- Shares model-access, subscription-status, usage-route, and agent-skills schemas between the CLI, extension, and desktop hosts.
- Adds the Agent skills switch to the CLI launcher and the shared extension/desktop Tools view.
- Shows the ChatGPT sign-in URL before browser launch and preserves Kimi Code subscription status in live and completed terminal sessions.

## Design

The access audit found several sources of drift: host-local fallback unions, duplicated labels, separate ChatGPT status shapes, unchecked personal-key copy, and an API-key usage route that could not distinguish Kimi Code membership. The change places those facts in host-neutral schemas and route resolvers. Each host supplies authentication and credential facts, while shared code determines labels, availability text, and recorded access routes.

Subscription preferences no longer mutate the API fallback or each other. Enabling ChatGPT or Kimi Code disables OpenRouter consistently because those preferences select a more specific eligible route. Model rows in every host continue to use the shared model-option computation.

## Validation

- `npm run format`
- `npm run lint`
- `npx tsc --noEmit`
- `npm run compile:fast`
- `npm test`

This PR is stacked on #9123 and should be reviewed against `agent/workflow-script-task-progress`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes credential routing, usage labeling, and settings persistence across CLI and GUI; broad test coverage but touches auth and model dispatch paths.
> 
> **Overview**
> **Model access** is refactored so **ChatGPT** and **Kimi Code** are independent subscription preferences, with **included TeXRA** vs **personal API keys** as a separate fallback. Shared `@shared/schemas/modelAccess` drives CLI `/api`, launcher, and extension/desktop Models UI; toggling subscriptions no longer clears the other preference or forces fallback mode. **Kimi Code** can win over included relay when preferred; usage records **`kimi-code-subscription`** separately from personal keys.
> 
> **Agent skills** (`texra.skills.enabled`) get a workspace toggle on the CLI launcher and extension/desktop **Tools** tab, wired through shared handlers and IPC.
> 
> CLI polish: ChatGPT sign-in URL prints before browser launch; status copy reflects subscription vs API-key routes correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63bd26611157c83a2f9c6cf62865c6b51ee1fc32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->