### PR TITLE
fix: handle Anthropic context window stops

### DIFF
--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -87,6 +87,8 @@ interface CycleTransientFields {
   responseObject?: unknown;
   /** Whether this cycle already retried once with forced context compaction. */
   contextWindowRecoveryAttempted?: boolean;
+  /** Ownership token for clearing this cycle's pending compaction request. */
+  contextWindowRecoveryRequestId?: number;
 }
 
 /**
@@ -370,8 +372,13 @@ class ResponseProcessNode<C> extends BaseNode<
     shared.stopReason = result.stopReason;
 
     if (!result.hasResponse) {
-      shared.processedResponse = undefined;
       shared.endTurn = false;
+      if (result.stopReason === ANTHROPIC_STOP.MODEL_CONTEXT_WINDOW_EXCEEDED) {
+        shared.processedResponse = '';
+        return FlowTransition.DEFAULT;
+      }
+
+      shared.processedResponse = undefined;
       shared.shouldStop = true;
       return FlowTransition.COMPLETE;
     }
@@ -481,7 +488,11 @@ class ResponseContinuationNode<C> extends BaseNode<
   ResponseCycleServices<C>
 > {
   async prep(shared: ResponseCycleShared): Promise<ContinuationPrepResult> {
-    if (shared.shouldStop || !shared.stopReason || !shared.processedResponse) {
+    if (
+      shared.shouldStop ||
+      !shared.stopReason ||
+      shared.processedResponse === undefined
+    ) {
       return { kind: 'skipped' };
     }
 
@@ -591,7 +602,7 @@ class ResponseContinuationNode<C> extends BaseNode<
       }
 
       shared.contextWindowRecoveryAttempted = true;
-      modelHandler.requestCompaction();
+      shared.contextWindowRecoveryRequestId = modelHandler.requestCompaction();
     } else if (!(shouldContinue || reachedTokenLimit)) {
       return FlowTransition.COMPLETE;
     }

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -15,6 +15,7 @@ import {
   SkippableNodeResult,
 } from '@agent/core/flows/CommonCycleTypes';
 import {
+  ANTHROPIC_STOP,
   isTokenLimitStopReason,
   type ProviderStopReason,
 } from '@agent/types/StopReasonTypes';
@@ -84,6 +85,8 @@ interface CycleTransientFields {
   systemPrompt?: string;
   /** Raw response from model (type unknown, not serialized) */
   responseObject?: unknown;
+  /** Whether this cycle already retried once with forced context compaction. */
+  contextWindowRecoveryAttempted?: boolean;
 }
 
 /**
@@ -206,6 +209,7 @@ type ContinuationNodeResult = SkippableNodeResult<{
   shouldStop: boolean;
   shouldContinue: boolean;
   reachedTokenLimit: boolean;
+  contextWindowExceeded: boolean;
 }>;
 
 export function responseCycleToolsForModel<C>(
@@ -419,6 +423,7 @@ class ResponseProcessNode<C> extends BaseNode<
       connector,
       result.processedResponse,
       workspace,
+      shared.responseObject,
     );
 
     if (result.useStreaming) {
@@ -506,6 +511,7 @@ class ResponseContinuationNode<C> extends BaseNode<
           shouldStop: true,
           shouldContinue: false,
           reachedTokenLimit: false,
+          contextWindowExceeded: false,
         },
       };
     }
@@ -525,6 +531,8 @@ class ResponseContinuationNode<C> extends BaseNode<
       setting,
     );
     const reachedTokenLimit = isTokenLimitStopReason(stopReason);
+    const contextWindowExceeded =
+      stopReason === ANTHROPIC_STOP.MODEL_CONTEXT_WINDOW_EXCEEDED;
 
     return {
       kind: 'success',
@@ -533,6 +541,7 @@ class ResponseContinuationNode<C> extends BaseNode<
         shouldStop,
         shouldContinue,
         reachedTokenLimit,
+        contextWindowExceeded,
       },
     };
   }
@@ -551,12 +560,39 @@ class ResponseContinuationNode<C> extends BaseNode<
       return FlowTransition.COMPLETE;
     }
 
-    const { shouldEndTurn, shouldStop, shouldContinue, reachedTokenLimit } =
-      execRes.value;
+    const {
+      shouldEndTurn,
+      shouldStop,
+      shouldContinue,
+      reachedTokenLimit,
+      contextWindowExceeded,
+    } = execRes.value;
     shared.endTurn = shouldEndTurn;
     shared.shouldStop = shouldStop;
 
-    if (shouldStop || !(shouldContinue || reachedTokenLimit)) {
+    if (shouldStop) {
+      return FlowTransition.COMPLETE;
+    }
+
+    if (contextWindowExceeded) {
+      if (shared.contextWindowRecoveryAttempted) {
+        logger.warn(
+          'Model context window still exceeded after forced compaction; stopping to avoid a futile retry.',
+        );
+        shared.shouldStop = true;
+        return FlowTransition.COMPLETE;
+      }
+      if (!modelHandler.supportsManualCompaction) {
+        logger.warn(
+          'Model context window exceeded, but compaction is unavailable; stopping to avoid a futile retry.',
+        );
+        shared.shouldStop = true;
+        return FlowTransition.COMPLETE;
+      }
+
+      shared.contextWindowRecoveryAttempted = true;
+      modelHandler.requestCompaction();
+    } else if (!(shouldContinue || reachedTokenLimit)) {
       return FlowTransition.COMPLETE;
     }
 
@@ -565,7 +601,11 @@ class ResponseContinuationNode<C> extends BaseNode<
       messageType: MESSAGE_TYPES.PROGRESS_STATUS,
     });
 
-    if (reachedTokenLimit) {
+    if (contextWindowExceeded) {
+      logger.info('Retrying after forcing model context compaction', {
+        messageType: MESSAGE_TYPES.PROGRESS_STATUS,
+      });
+    } else if (reachedTokenLimit) {
       logger.info('Continuing after hitting the model token limit', {
         messageType: MESSAGE_TYPES.PROGRESS_STATUS,
       });

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
@@ -92,17 +92,17 @@ export class ResponseCycleNode<C = unknown> extends Node<
       return { outcome: 'completed', endTurn: true };
     }
 
-    try {
-      const cycleShared: ResponseCycleShared = {
-        messages: initializedMessages,
-        outputLocation: prepRes.outputLocation,
-        endTurn: false,
-        shouldStop: false,
-        outputExists: false,
-      };
+    const cycleShared: ResponseCycleShared = {
+      messages: initializedMessages,
+      outputLocation: prepRes.outputLocation,
+      endTurn: false,
+      shouldStop: false,
+      outputExists: false,
+    };
+    const { modelHandler } = this.services;
 
+    try {
       const flow = createResponseCycleFlow<C>();
-      const { modelHandler } = this.services;
       flow.setServices(
         await withModelClient(
           {
@@ -151,6 +151,12 @@ export class ResponseCycleNode<C = unknown> extends Node<
         failureLogEmitted: false,
         ...buildFailedRetryInfo(error),
       };
+    } finally {
+      if (cycleShared.contextWindowRecoveryAttempted) {
+        modelHandler.clearCompactionRequest(
+          cycleShared.contextWindowRecoveryRequestId,
+        );
+      }
     }
   }
 

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
@@ -152,7 +152,7 @@ export class ResponseCycleNode<C = unknown> extends Node<
         ...buildFailedRetryInfo(error),
       };
     } finally {
-      if (cycleShared.contextWindowRecoveryAttempted) {
+      if (cycleShared.contextWindowRecoveryRequestId !== undefined) {
         modelHandler.clearCompactionRequest(
           cycleShared.contextWindowRecoveryRequestId,
         );

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -918,6 +918,7 @@ export abstract class ModelHandler<
    * attempted. Inert for handlers that don't run compaction.
    */
   protected compactionRequested = false;
+  private compactionRequestId = 0;
 
   /**
    * A successful client-side compaction whose generation request has not yet
@@ -947,9 +948,19 @@ export abstract class ModelHandler<
     return `${messages.length}:${last === undefined ? 0 : JSON.stringify(last).length}`;
   }
 
-  /** Request compaction on the next API call. */
-  requestCompaction(): void {
+  /** Request compaction on the next API call and return its ownership token. */
+  requestCompaction(): number {
     this.compactionRequested = true;
+    this.compactionRequestId += 1;
+    return this.compactionRequestId;
+  }
+
+  /** Cancel a pending compaction request when its owning flow is abandoned. */
+  clearCompactionRequest(requestId?: number): void {
+    if (requestId !== undefined && requestId !== this.compactionRequestId) {
+      return;
+    }
+    this.compactionRequested = false;
   }
 
   /**

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -868,7 +868,7 @@ export abstract class ModelHandler<
   /**
    * Whether this handler supports manual (user-requested) context compaction.
    * Each override computes this differently — Anthropic combines llm-zoo
-   * model-family eligibility with tool-use mode, OpenAI-family handlers gate
+   * model-family eligibility with workflow/tool-use mode, OpenAI-family handlers gate
    * on tool-use mode alone, OpenAIResponse reads the ChatGPT-subscription
    * profile with an OpenRouter-routing fallback, and GoogleInteractions is
    * unconditionally true — so no single capability-profile read replaces the
@@ -1657,6 +1657,7 @@ export abstract class ModelHandler<
     bestConnector: string,
     newResponse: string,
     workspaceState: AgentWorkspaceState,
+    _responseObject?: Resp,
   ): void {
     const text = bestConnector + newResponse;
 

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -955,9 +955,14 @@ export abstract class ModelHandler<
     return this.compactionRequestId;
   }
 
-  /** Cancel a pending compaction request when its owning flow is abandoned. */
-  clearCompactionRequest(requestId?: number): void {
-    if (requestId !== undefined && requestId !== this.compactionRequestId) {
+  /** Snapshot the ownership token for the currently pending request. */
+  protected getPendingCompactionRequestId(): number | undefined {
+    return this.compactionRequested ? this.compactionRequestId : undefined;
+  }
+
+  /** Clear a pending compaction request only while the caller still owns it. */
+  clearCompactionRequest(requestId: number): void {
+    if (requestId !== this.compactionRequestId) {
       return;
     }
     this.compactionRequested = false;

--- a/src/agent/modelHandlers/anthropic/anthropicContextManagement.ts
+++ b/src/agent/modelHandlers/anthropic/anthropicContextManagement.ts
@@ -107,7 +107,9 @@ export function setupContextManagement(
   isCompactionEligibleModel: boolean,
   forceCompaction: boolean,
 ): boolean {
-  if (!isToolUseMode) {
+  // Automatic context management is tool-use-only. A manual request also
+  // enables the same native compaction path for workflow recovery.
+  if (!isToolUseMode && !forceCompaction) {
     return false;
   }
 

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -774,10 +774,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
       isCompactionEligibleModel(this.config.fullName),
       this.compactionRequested,
     );
-    if (compactionConsumed) {
-      this.compactionRequested = false;
-    }
-
     // Phase 2: COUNT - Estimate input tokens using built params
     // Phase 3: VALIDATE - Adjust max_tokens if needed
     if (this.supportsTokenCounting && documentAnalysis.hasFileSource) {
@@ -902,6 +898,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
       if (nonStreamingCompactionExpected) {
         logCompactionActivity(this.logger, 'finished');
       }
+    }
+
+    if (compactionConsumed) {
+      this.compactionRequested = false;
     }
 
     // Log server-side compaction events when present in response content.
@@ -1044,11 +1044,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       return this.createAssistantMessage(text);
     }
 
-    const content = buildAnthropicAssistantContent(
-      responseObject,
-      { supportsPromptCaching: this.capabilities.supportsPromptCaching },
-      this.logger,
-    );
+    const content = this.extractAssistantContent(responseObject);
     return content.length > 0
       ? { role: 'assistant', content: content as ContentBlockParam[] }
       : this.createAssistantMessage(text);

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -764,6 +764,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       'texra.model.compactionThresholdPercent',
       DEFAULT_COMPACTION_THRESHOLD_PERCENT,
     );
+    const pendingCompactionRequestId = this.getPendingCompactionRequestId();
     const compactionConsumed = setupContextManagement(
       {
         options,
@@ -900,8 +901,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
       }
     }
 
-    if (compactionConsumed) {
-      this.compactionRequested = false;
+    if (compactionConsumed && pendingCompactionRequestId !== undefined) {
+      this.clearCompactionRequest(pendingCompactionRequestId);
     }
 
     // Log server-side compaction events when present in response content.

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -173,6 +173,11 @@ const isBetaTextBlock = (
 ): block is Extract<BetaContentBlock, { type: 'text' }> =>
   block.type === 'text';
 
+const hasSuccessfulBetaCompactionBlock = (message: BetaMessage): boolean =>
+  message.content.some(
+    (block) => block.type === 'compaction' && block.content !== null,
+  );
+
 const INTERLEAVED_THINKING_BETA: AnthropicBeta =
   'interleaved-thinking-2025-05-14';
 
@@ -342,15 +347,14 @@ export class ModelHandlerAnthropic extends ModelHandler<
   }
 
   /**
-   * Client-side compaction is available for tool-use sessions on models whose
-   * llm-zoo family is compaction-eligible. `isCompactionEligibleModel` is a
-   * `startsWith`-style model-family gate in `anthropicThinking.ts`; moving it
-   * to an llm-zoo capability flag is #7080's scope, not this predicate's own
-   * #7101 triage.
+   * Manual compaction is available for workflow and tool-use sessions on
+   * models whose llm-zoo family is compaction-eligible. Automatic compaction
+   * remains tool-use-only in `setupContextManagement`.
    */
   override get supportsManualCompaction(): boolean {
     return (
-      isCompactionEligibleModel(this.config.fullName) && this.isToolUseMode()
+      isCompactionEligibleModel(this.config.fullName) &&
+      (this.isWorkflowMode() || this.isToolUseMode())
     );
   }
 
@@ -1032,6 +1036,48 @@ export class ModelHandlerAnthropic extends ModelHandler<
     };
   }
 
+  override createAssistantMessageFromResponse(
+    responseObject: BetaMessage,
+    text: string,
+  ): MessageParam {
+    if (!hasSuccessfulBetaCompactionBlock(responseObject)) {
+      return this.createAssistantMessage(text);
+    }
+
+    const content = buildAnthropicAssistantContent(
+      responseObject,
+      { supportsPromptCaching: this.capabilities.supportsPromptCaching },
+      this.logger,
+    );
+    return content.length > 0
+      ? { role: 'assistant', content: content as ContentBlockParam[] }
+      : this.createAssistantMessage(text);
+  }
+
+  override updateMessageContent(
+    messages: MessageParam[],
+    bestConnector: string,
+    newResponse: string,
+    workspaceState: AgentWorkspaceState,
+    responseObject?: BetaMessage,
+  ): void {
+    if (responseObject && hasSuccessfulBetaCompactionBlock(responseObject)) {
+      messages.length = 0;
+      messages.push(
+        this.createAssistantMessageFromResponse(responseObject, newResponse),
+      );
+      return;
+    }
+
+    super.updateMessageContent(
+      messages,
+      bestConnector,
+      newResponse,
+      workspaceState,
+      responseObject,
+    );
+  }
+
   override extractAssistantText(message: MessageParam): string | undefined {
     if (message.role !== 'assistant') return undefined;
     if (typeof message.content === 'string') return message.content;
@@ -1334,7 +1380,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
       return false;
     }
 
-    // Continue if we hit max tokens OR stop sequence without an end tag
+    // Context-window overflow needs the response cycle's bounded compaction
+    // recovery, not an ordinary continuation prompt.
     const shouldContinue =
       (stopReason === ANTHROPIC_STOP.MAX_TOKENS ||
         stopReason === ANTHROPIC_STOP.STOP_SEQUENCE) &&

--- a/src/agent/types/IModelHandler.ts
+++ b/src/agent/types/IModelHandler.ts
@@ -51,6 +51,7 @@ export type IModelHandler<
   | 'supportsForcedToolChoice'
   | 'requiresPerCallSystemPrompt'
   | 'requestCompaction'
+  | 'clearCompactionRequest'
   | 'getEffectiveContextWindow'
   | 'requiresBatchedParallelToolResults'
   | 'setLogger'

--- a/src/agent/types/StopReasonTypes.ts
+++ b/src/agent/types/StopReasonTypes.ts
@@ -41,6 +41,7 @@ type MCPStopReason = (typeof MCP_STOP)[keyof typeof MCP_STOP];
 export const ANTHROPIC_STOP = {
   END_TURN: 'end_turn',
   MAX_TOKENS: 'max_tokens',
+  MODEL_CONTEXT_WINDOW_EXCEEDED: 'model_context_window_exceeded',
   STOP_SEQUENCE: 'stop_sequence',
   TOOL_USE: 'tool_use',
   PAUSE_TURN: 'pause_turn',
@@ -74,6 +75,7 @@ const TOKEN_LIMIT_STOP_REASONS: readonly ProviderStopReason[] = [
   OPENAI_CHAT_FINISH.LENGTH,
   OPENAI_COMPLETION_FINISH.LENGTH,
   ANTHROPIC_STOP.MAX_TOKENS,
+  ANTHROPIC_STOP.MODEL_CONTEXT_WINDOW_EXCEEDED,
   MCP_STOP.MAX_TOKENS,
   GOOGLE_FINISH.MAX_TOKENS,
 ];

--- a/src/test-kernel/agent/ResponseCycleCancellation.vitest.ts
+++ b/src/test-kernel/agent/ResponseCycleCancellation.vitest.ts
@@ -9,6 +9,8 @@ const flowState = vi.hoisted(() => ({
   lastError: undefined as
     { message: string; userRetryable: boolean } | undefined,
   failureLogEmitted: false,
+  contextWindowRecoveryAttempted: false,
+  contextWindowRecoveryRequestId: undefined as number | undefined,
 }));
 
 // Replace the inner cycle flow with a stub that just applies the scripted flags.
@@ -22,11 +24,17 @@ vi.mock('@agent/core/flows/ResponseCycleFlow', () => ({
       endTurn: boolean;
       lastError?: { message: string; userRetryable: boolean };
       failureLogEmitted?: boolean;
+      contextWindowRecoveryAttempted?: boolean;
+      contextWindowRecoveryRequestId?: number;
     }) {
       shared.shouldStop = flowState.shouldStop;
       shared.endTurn = flowState.endTurn;
       shared.lastError = flowState.lastError;
       shared.failureLogEmitted = flowState.failureLogEmitted;
+      shared.contextWindowRecoveryAttempted =
+        flowState.contextWindowRecoveryAttempted;
+      shared.contextWindowRecoveryRequestId =
+        flowState.contextWindowRecoveryRequestId;
     },
   }),
 }));
@@ -82,12 +90,14 @@ function makeNode(
     error: vi.fn(),
     debug: vi.fn(),
   },
+  clearCompactionRequest: () => void = vi.fn(),
 ): ResponseCycleNode {
   return new ResponseCycleNode().setServices({
     getOutputFileLocation: async () => outputLocation,
     checkInterruption,
     modelHandler: {
       initializeOutputAndPrefill: async () => [false, []],
+      clearCompactionRequest,
     },
     config: {},
     setting: {},
@@ -107,6 +117,8 @@ describe('ResponseCycleNode outcome classification', () => {
     flowState.endTurn = false;
     flowState.lastError = undefined;
     flowState.failureLogEmitted = false;
+    flowState.contextWindowRecoveryAttempted = false;
+    flowState.contextWindowRecoveryRequestId = undefined;
   });
 
   it('does NOT cancel a stop-without-end-of-turn when the run is not interrupted', async () => {
@@ -141,6 +153,47 @@ describe('ResponseCycleNode outcome classification', () => {
     if (result.outcome === 'completed') {
       expect(result.endTurn).toBe(true);
     }
+  });
+
+  it('clears forced compaction when interruption abandons recovery', async () => {
+    flowState.shouldStop = true;
+    flowState.contextWindowRecoveryAttempted = true;
+    flowState.contextWindowRecoveryRequestId = 7;
+    const clearCompactionRequest = vi.fn();
+
+    const node = makeNode(
+      () => true,
+      { error: vi.fn(), debug: vi.fn() },
+      clearCompactionRequest,
+    );
+    const prep = await node.prep(reflectionShared());
+
+    const result = await node.exec(prep);
+
+    expect(result.outcome).toBe('cancelled');
+    expect(clearCompactionRequest).toHaveBeenCalledWith(7);
+  });
+
+  it('clears forced compaction after invocation retries are exhausted', async () => {
+    flowState.shouldStop = true;
+    flowState.contextWindowRecoveryAttempted = true;
+    flowState.contextWindowRecoveryRequestId = 7;
+    flowState.lastError = {
+      message: 'HTTP 503 Service Unavailable',
+      userRetryable: true,
+    };
+    const clearCompactionRequest = vi.fn();
+    const node = makeNode(
+      () => false,
+      { error: vi.fn(), debug: vi.fn() },
+      clearCompactionRequest,
+    );
+    const prep = await node.prep(reflectionShared());
+
+    const result = await node.exec(prep);
+
+    expect(result.outcome).toBe('failed');
+    expect(clearCompactionRequest).toHaveBeenCalledWith(7);
   });
 
   it('does not repeat a model failure already logged by RetryState', async () => {

--- a/src/test-kernel/agent/ResponseCycleContinuation.vitest.ts
+++ b/src/test-kernel/agent/ResponseCycleContinuation.vitest.ts
@@ -8,7 +8,11 @@ import {
 } from '@agent/core/flows/ResponseCycleFlow';
 import type { ResponseCycleServices } from '@agent/core/flows/CycleServices';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
-import { ANTHROPIC_STOP } from '@agent/types/StopReasonTypes';
+import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
+import {
+  ANTHROPIC_STOP,
+  type ProviderStopReason,
+} from '@agent/types/StopReasonTypes';
 import type { AgentFileLocation } from '@shared/schemas';
 
 const outputLocation: AgentFileLocation = {
@@ -30,15 +34,47 @@ function createShared(
   };
 }
 
-function getContinuationNode() {
+function getProcessNode() {
   const prepNode = createResponseCycleFlow().start;
   const invocationNode = prepNode.getNextNode();
   const processNode = invocationNode?.getNextNode();
-  const continuationNode = processNode?.getNextNode();
+  if (!processNode) {
+    throw new Error('Response cycle process node is not wired');
+  }
+  return processNode;
+}
+
+function getContinuationNode() {
+  const processNode = getProcessNode();
+  const continuationNode = processNode.getNextNode();
   if (!continuationNode) {
     throw new Error('Response cycle continuation node is not wired');
   }
   return continuationNode;
+}
+
+async function processEmptyResponse(stopReason: ProviderStopReason) {
+  const shared = createShared({ responseObject: {} });
+  const services = {
+    round: { responseTimeMs: 0 },
+    workspace: AgentWorkspaceState.create(),
+    logger: {
+      openStage: () => ({ run: (run: () => unknown) => run() }),
+      debug: vi.fn(),
+      info: vi.fn(),
+    },
+    modelHandler: {
+      processThinkingBlock: vi.fn(() => null),
+      getStreamingConfig: vi.fn(() => false),
+      extractResponse: vi.fn(() => ({ text: '', usage: {}, stopReason })),
+      normalizeUsage: vi.fn(() => undefined),
+    },
+  } as unknown as ResponseCycleServices<unknown>;
+  const node = getProcessNode().setServices(services);
+  const prepResult = await node.prep(shared);
+  const execResult = await node.exec(prepResult);
+  const action = await node.post(shared, prepResult, execResult);
+  return { shared, action };
 }
 
 function createServices(interrupted = false, supportsManualCompaction = false) {
@@ -49,7 +85,7 @@ function createServices(interrupted = false, supportsManualCompaction = false) {
     shouldStop: false,
   }));
   const shouldContinue = vi.fn(() => false);
-  const requestCompaction = vi.fn();
+  const requestCompaction = vi.fn(() => 7);
   const addContinueMessage = vi.fn();
   const services = {
     checkInterruption,
@@ -140,6 +176,49 @@ describe('response cycle continuation phases', () => {
     expect(action).toBe(FlowTransition.CONTINUE);
   });
 
+  it('passes an empty Anthropic context-window overflow to continuation', async () => {
+    const { shared, action } = await processEmptyResponse(
+      ANTHROPIC_STOP.MODEL_CONTEXT_WINDOW_EXCEEDED,
+    );
+
+    expect(shared).toMatchObject({
+      stopReason: ANTHROPIC_STOP.MODEL_CONTEXT_WINDOW_EXCEEDED,
+      processedResponse: '',
+      shouldStop: false,
+      endTurn: false,
+    });
+    expect(action).toBe(FlowTransition.DEFAULT);
+  });
+
+  it('retains ordinary empty-response safety', async () => {
+    const { shared, action } = await processEmptyResponse(
+      ANTHROPIC_STOP.END_TURN,
+    );
+
+    expect(shared).toMatchObject({
+      processedResponse: undefined,
+      shouldStop: true,
+      endTurn: false,
+    });
+    expect(action).toBe(FlowTransition.COMPLETE);
+  });
+
+  it('forces compaction for an Anthropic overflow with empty assistant text', async () => {
+    const shared = createShared({
+      stopReason: ANTHROPIC_STOP.MODEL_CONTEXT_WINDOW_EXCEEDED,
+      processedResponse: '',
+    });
+    const harness = createServices(false, true);
+    const node = getContinuationNode().setServices(harness.services);
+
+    const prepResult = await node.prep(shared);
+    const execResult = await node.exec(prepResult);
+    const action = await node.post(shared, prepResult, execResult);
+
+    expect(harness.requestCompaction).toHaveBeenCalledOnce();
+    expect(action).toBe(FlowTransition.CONTINUE);
+  });
+
   it('forces compaction before retrying an Anthropic context-window overflow', async () => {
     const shared = createShared({
       stopReason: ANTHROPIC_STOP.MODEL_CONTEXT_WINDOW_EXCEEDED,
@@ -153,6 +232,7 @@ describe('response cycle continuation phases', () => {
     const action = await node.post(shared, prepResult, execResult);
 
     expect(harness.requestCompaction).toHaveBeenCalledOnce();
+    expect(shared.contextWindowRecoveryRequestId).toBe(7);
     expect(harness.round.continuationCount).toBe(1);
     expect(harness.addContinueMessage).toHaveBeenCalledOnce();
     expect(action).toBe(FlowTransition.CONTINUE);

--- a/src/test-kernel/agent/ResponseCycleContinuation.vitest.ts
+++ b/src/test-kernel/agent/ResponseCycleContinuation.vitest.ts
@@ -8,6 +8,7 @@ import {
 } from '@agent/core/flows/ResponseCycleFlow';
 import type { ResponseCycleServices } from '@agent/core/flows/CycleServices';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
+import { ANTHROPIC_STOP } from '@agent/types/StopReasonTypes';
 import type { AgentFileLocation } from '@shared/schemas';
 
 const outputLocation: AgentFileLocation = {
@@ -40,7 +41,7 @@ function getContinuationNode() {
   return continuationNode;
 }
 
-function createServices(interrupted = false) {
+function createServices(interrupted = false, supportsManualCompaction = false) {
   const round = { continuationCount: 0 };
   const checkInterruption = vi.fn(() => interrupted);
   const checkStopConditions = vi.fn(() => ({
@@ -48,6 +49,7 @@ function createServices(interrupted = false) {
     shouldStop: false,
   }));
   const shouldContinue = vi.fn(() => false);
+  const requestCompaction = vi.fn();
   const addContinueMessage = vi.fn();
   const services = {
     checkInterruption,
@@ -56,10 +58,12 @@ function createServices(interrupted = false) {
     setting: {},
     config: {},
     workspace: {},
-    logger: { info: vi.fn() },
+    logger: { info: vi.fn(), warn: vi.fn() },
     modelHandler: {
+      supportsManualCompaction,
       checkStopConditions,
       shouldContinue,
+      requestCompaction,
       addContinueMessage,
     },
   } as unknown as ResponseCycleServices<unknown>;
@@ -70,6 +74,7 @@ function createServices(interrupted = false) {
     checkInterruption,
     checkStopConditions,
     shouldContinue,
+    requestCompaction,
     addContinueMessage,
   };
 }
@@ -133,6 +138,63 @@ describe('response cycle continuation phases', () => {
     expect(harness.round.continuationCount).toBe(1);
     expect(harness.addContinueMessage).toHaveBeenCalledOnce();
     expect(action).toBe(FlowTransition.CONTINUE);
+  });
+
+  it('forces compaction before retrying an Anthropic context-window overflow', async () => {
+    const shared = createShared({
+      stopReason: ANTHROPIC_STOP.MODEL_CONTEXT_WINDOW_EXCEEDED,
+      processedResponse: 'partial response',
+    });
+    const harness = createServices(false, true);
+    const node = getContinuationNode().setServices(harness.services);
+
+    const prepResult = await node.prep(shared);
+    const execResult = await node.exec(prepResult);
+    const action = await node.post(shared, prepResult, execResult);
+
+    expect(harness.requestCompaction).toHaveBeenCalledOnce();
+    expect(harness.round.continuationCount).toBe(1);
+    expect(harness.addContinueMessage).toHaveBeenCalledOnce();
+    expect(action).toBe(FlowTransition.CONTINUE);
+  });
+
+  it('stops instead of retrying a context-window overflow without compaction support', async () => {
+    const shared = createShared({
+      stopReason: ANTHROPIC_STOP.MODEL_CONTEXT_WINDOW_EXCEEDED,
+      processedResponse: 'partial response',
+    });
+    const harness = createServices();
+    const node = getContinuationNode().setServices(harness.services);
+
+    const prepResult = await node.prep(shared);
+    const execResult = await node.exec(prepResult);
+    const action = await node.post(shared, prepResult, execResult);
+
+    expect(harness.requestCompaction).not.toHaveBeenCalled();
+    expect(harness.round.continuationCount).toBe(0);
+    expect(harness.addContinueMessage).not.toHaveBeenCalled();
+    expect(harness.services.logger.warn).toHaveBeenCalledOnce();
+    expect(action).toBe(FlowTransition.COMPLETE);
+  });
+
+  it('stops when forced compaction did not clear the context overflow', async () => {
+    const shared = createShared({
+      stopReason: ANTHROPIC_STOP.MODEL_CONTEXT_WINDOW_EXCEEDED,
+      processedResponse: 'partial response',
+      contextWindowRecoveryAttempted: true,
+    });
+    const harness = createServices(false, true);
+    const node = getContinuationNode().setServices(harness.services);
+
+    const prepResult = await node.prep(shared);
+    const execResult = await node.exec(prepResult);
+    const action = await node.post(shared, prepResult, execResult);
+
+    expect(harness.requestCompaction).not.toHaveBeenCalled();
+    expect(harness.round.continuationCount).toBe(0);
+    expect(harness.addContinueMessage).not.toHaveBeenCalled();
+    expect(harness.services.logger.warn).toHaveBeenCalledOnce();
+    expect(action).toBe(FlowTransition.COMPLETE);
   });
 
   it('turns a ready response into a completed stop when interrupted', async () => {

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
@@ -25,6 +25,7 @@ import {
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import { ModelHandlerAnthropic } from '@agent/modelHandlers/anthropic/modelHandlerAnthropic';
 import type { AnthropicToolCall } from '@agent/types/ModelHandlerContracts';
+import { ANTHROPIC_STOP } from '@agent/types/StopReasonTypes';
 import {
   enforceCacheControlLimit,
   logContextManagementFromResponse,
@@ -115,6 +116,22 @@ function getCacheMarker(block?: ContentBlockParam | ContentBlock): unknown {
 
   return (block as { cache_control?: unknown }).cache_control;
 }
+
+describe('ModelHandlerAnthropic.shouldContinue', () => {
+  it('does not treat context-window recovery as an ordinary continuation', () => {
+    const handler = createAnthropicHandler();
+    handler.setLogger({ ...noopTrace });
+
+    assert.equal(
+      handler.shouldContinue(
+        ANTHROPIC_STOP.MODEL_CONTEXT_WINDOW_EXCEEDED,
+        'partial response',
+        {} as AgentSetting,
+      ),
+      false,
+    );
+  });
+});
 
 describe('ModelHandlerAnthropic auxiliary requests', () => {
   it('restores SDK retries for tool-result uploads outside the model gate', async () => {
@@ -1205,6 +1222,168 @@ describe('ModelHandlerAnthropic message guards', () => {
       'max',
       "max reasoning effort should map to the top 'max' tier on Opus 4.8",
     );
+  });
+
+  it('round-trips forced compaction state into the next workflow invocation', async () => {
+    const handler = createAnthropicHandler({
+      supportsAssistantPrefill: false,
+      supportsTokenCounting: false,
+      supportsReasoning: false,
+    });
+    handler.config.fullName = 'claude-opus-4-6';
+    handler.setAgentCategory(AgentCategory.Workflow);
+    stubHandlerForTest(handler);
+    stubCompactionThresholdPercent(0);
+
+    const messages = helloMessages();
+    const messageOptions: any[] = [];
+    const responses = [
+      {
+        content: [{ type: 'text', text: 'partial' }],
+        stop_reason: ANTHROPIC_STOP.MODEL_CONTEXT_WINDOW_EXCEEDED,
+      },
+      {
+        content: [
+          { type: 'compaction', content: '<summary>state</summary>' },
+          { type: 'text', text: 'after compaction' },
+        ],
+        stop_reason: ANTHROPIC_STOP.MAX_TOKENS,
+      },
+      {
+        content: [{ type: 'text', text: 'finished' }],
+        stop_reason: ANTHROPIC_STOP.END_TURN,
+      },
+    ];
+    const client = {
+      beta: {
+        messages: {
+          create: async (options: any) => {
+            messageOptions.push(options);
+            const response = responses.shift();
+            assert.ok(response);
+            return {
+              id: `msg-${messageOptions.length}`,
+              type: 'message',
+              role: 'assistant',
+              model: 'claude-opus-4-6',
+              usage: { input_tokens: 100_000, output_tokens: 10 },
+              ...response,
+            };
+          },
+        },
+      },
+    } as any;
+    const workspace = AgentWorkspaceState.create();
+    const setting = AgentSettingSchema.parse({
+      agentCategory: AgentCategory.Workflow,
+    });
+
+    const first = await handler.createResponse({
+      client,
+      messages,
+      temperature: 0,
+    });
+    const firstText = handler.extractResponse(first.response, '').text;
+    workspace.assembly.lastResponse = firstText;
+    workspace.assembly.accumulatedOutput = firstText;
+    handler.updateMessageContent(
+      messages,
+      '',
+      firstText,
+      workspace,
+      first.response,
+    );
+    handler.requestCompaction();
+    handler.addContinueMessage(messages, workspace, setting);
+
+    const second = await handler.createResponse({
+      client,
+      messages,
+      temperature: 0,
+    });
+    const secondText = handler.extractResponse(second.response, '').text;
+    workspace.assembly.lastResponse = secondText;
+    workspace.assembly.accumulatedOutput += secondText;
+    handler.updateMessageContent(
+      messages,
+      '',
+      secondText,
+      workspace,
+      second.response,
+    );
+    handler.addContinueMessage(messages, workspace, setting);
+
+    await handler.createResponse({ client, messages, temperature: 0 });
+
+    assert.equal(messageOptions[0].context_management, undefined);
+    const forcedEdits = messageOptions[1].context_management?.edits ?? [];
+    assert.equal(forcedEdits[0]?.type, 'compact_20260112');
+    assert.equal(forcedEdits[0]?.trigger?.value, 50_000);
+
+    const nextMessages = messageOptions[2].messages as MessageParam[];
+    assert.equal(nextMessages.length, 2);
+    assert.equal(nextMessages[0].role, 'assistant');
+    const assistantContent = nextMessages[0].content as any[];
+    assert.deepEqual(
+      assistantContent.map((block) => block.type),
+      ['compaction', 'text'],
+    );
+    assert.equal(assistantContent[0].content, '<summary>state</summary>');
+    assert.equal(assistantContent[1].text, 'after compaction');
+    assert.equal(
+      assistantContent.filter(
+        (block) => block.type === 'text' && block.text === 'after compaction',
+      ).length,
+      1,
+    );
+    assert.equal(nextMessages[1].role, 'user');
+    assert.match(
+      (nextMessages[1].content as Array<{ text?: string }>)[0]?.text ?? '',
+      /continue responding exactly from where you left/i,
+    );
+    assert.equal(JSON.stringify(nextMessages).includes('partial'), false);
+  });
+
+  it('keeps the prior transcript when Anthropic reports a null compaction block', () => {
+    const handler = createAnthropicHandler({
+      supportsAssistantPrefill: false,
+    });
+    handler.setLogger({ ...noopTrace });
+    const priorMessage: MessageParam = {
+      role: 'user',
+      content: [{ type: 'text', text: 'original request' }],
+    };
+    const messages = [priorMessage];
+    const workspace = AgentWorkspaceState.create();
+    workspace.assembly.accumulatedOutput = 'generated text';
+    const response = {
+      content: [
+        { type: 'compaction', content: null },
+        { type: 'text', text: 'generated text' },
+      ],
+    } as unknown as Parameters<
+      ModelHandlerAnthropic['updateMessageContent']
+    >[4];
+
+    handler.updateMessageContent(
+      messages,
+      '',
+      'generated text',
+      workspace,
+      response,
+    );
+
+    assert.equal(messages[0], priorMessage);
+    assert.equal(messages.length, 2);
+    assert.equal(JSON.stringify(messages).includes('original request'), true);
+  });
+
+  it('does not advertise forced compaction for unsupported Anthropic models', () => {
+    const handler = createAnthropicHandler();
+    handler.config.fullName = 'claude-sonnet-4-5';
+    handler.setAgentCategory(AgentCategory.Workflow);
+
+    assert.equal(handler.supportsManualCompaction, false);
   });
 
   it('uses the Anthropic minimum trigger for manual compaction requests', async () => {

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
@@ -1471,6 +1471,63 @@ describe('ModelHandlerAnthropic message guards', () => {
     );
   });
 
+  it('preserves a newer compaction request when an older request succeeds', async () => {
+    const handler = createAnthropicHandler({
+      supportsTokenCounting: false,
+      supportsReasoning: false,
+    });
+    handler.config.fullName = 'claude-opus-4-6';
+    handler.setAgentCategory(AgentCategory.Workflow);
+    stubHandlerForTest(handler);
+    stubCompactionThresholdPercent(0);
+
+    const messageOptions: any[] = [];
+    let resolveFirstResponse: ((response: any) => void) | undefined;
+    let markFirstRequestStarted: (() => void) | undefined;
+    const firstRequestStarted = new Promise<void>((resolve) => {
+      markFirstRequestStarted = resolve;
+    });
+    const firstResponse = new Promise<any>((resolve) => {
+      resolveFirstResponse = resolve;
+    });
+    const successfulResponse = {
+      id: 'msg',
+      type: 'message',
+      role: 'assistant',
+      model: 'claude-opus-4-6',
+      content: [{ type: 'text', text: 'ok' }],
+      stop_reason: 'end_turn',
+      usage: { input_tokens: 1, output_tokens: 1 },
+    };
+    const create = vi.fn(async (options: any) => {
+      messageOptions.push(options);
+      if (messageOptions.length === 1) {
+        markFirstRequestStarted?.();
+        return firstResponse;
+      }
+      return successfulResponse;
+    });
+    const client = { beta: { messages: { create } } } as any;
+    const request = {
+      client,
+      messages: helloMessages(),
+      temperature: 0,
+    };
+
+    handler.requestCompaction();
+    const inFlight = handler.createResponse(request);
+    await firstRequestStarted;
+    handler.requestCompaction();
+    resolveFirstResponse?.(successfulResponse);
+    await inFlight;
+    await handler.createResponse(request);
+
+    const firstEdits = messageOptions[0].context_management?.edits ?? [];
+    const nextEdits = messageOptions[1].context_management?.edits ?? [];
+    assert.equal(firstEdits[0]?.type, 'compact_20260112');
+    assert.equal(nextEdits[0]?.type, 'compact_20260112');
+  });
+
   it('does not leak an abandoned forced compaction into a later call', async () => {
     const handler = createAnthropicHandler({
       supportsTokenCounting: false,

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
@@ -1422,6 +1422,55 @@ describe('ModelHandlerAnthropic message guards', () => {
     );
   });
 
+  it('preserves forced compaction across a transient request retry', async () => {
+    const handler = createAnthropicHandler({
+      supportsTokenCounting: false,
+      supportsReasoning: false,
+    });
+    handler.config.fullName = 'claude-opus-4-6';
+    handler.setAgentCategory(AgentCategory.Workflow);
+    handler.requestCompaction();
+    stubHandlerForTest(handler);
+    stubCompactionThresholdPercent(0);
+
+    const messageOptions: any[] = [];
+    const create = vi.fn(async (options: any) => {
+      messageOptions.push(options);
+      if (messageOptions.length === 1) {
+        throw new Error('transient failure');
+      }
+      return {
+        id: 'msg',
+        type: 'message',
+        role: 'assistant',
+        model: 'claude-opus-4-6',
+        content: [{ type: 'text', text: 'ok' }],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 1, output_tokens: 1 },
+      };
+    });
+    const client = { beta: { messages: { create } } } as any;
+    const request = {
+      client,
+      messages: helloMessages(),
+      temperature: 0,
+    };
+
+    await assert.rejects(handler.createResponse(request), /transient failure/);
+    await handler.createResponse(request);
+    await handler.createResponse(request);
+
+    const firstEdits = messageOptions[0].context_management?.edits ?? [];
+    const retryEdits = messageOptions[1].context_management?.edits ?? [];
+    assert.equal(firstEdits[0]?.type, 'compact_20260112');
+    assert.equal(retryEdits[0]?.type, 'compact_20260112');
+    assert.equal(
+      messageOptions[2].context_management,
+      undefined,
+      'forced compaction should clear after a successful response',
+    );
+  });
+
   it('announces expected compaction after the measured count crosses the trigger', async () => {
     const handler = createAnthropicHandler({
       supportsTokenCounting: true,

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
@@ -1471,6 +1471,56 @@ describe('ModelHandlerAnthropic message guards', () => {
     );
   });
 
+  it('does not leak an abandoned forced compaction into a later call', async () => {
+    const handler = createAnthropicHandler({
+      supportsTokenCounting: false,
+      supportsReasoning: false,
+    });
+    handler.config.fullName = 'claude-opus-4-6';
+    handler.setAgentCategory(AgentCategory.Workflow);
+    stubHandlerForTest(handler);
+    stubCompactionThresholdPercent(0);
+
+    const abandonedRequestId = handler.requestCompaction();
+    handler.clearCompactionRequest(abandonedRequestId);
+    const { client, messageOptions } =
+      createCapturingAnthropicClient('claude-opus-4-6');
+
+    await handler.createResponse({
+      client,
+      messages: helloMessages(),
+      temperature: 0,
+    });
+
+    assert.equal(messageOptions[0].context_management, undefined);
+  });
+
+  it('does not let an older recovery clear a newer compaction request', async () => {
+    const handler = createAnthropicHandler({
+      supportsTokenCounting: false,
+      supportsReasoning: false,
+    });
+    handler.config.fullName = 'claude-opus-4-6';
+    handler.setAgentCategory(AgentCategory.Workflow);
+    stubHandlerForTest(handler);
+    stubCompactionThresholdPercent(0);
+
+    const abandonedRequestId = handler.requestCompaction();
+    handler.requestCompaction();
+    handler.clearCompactionRequest(abandonedRequestId);
+    const { client, messageOptions } =
+      createCapturingAnthropicClient('claude-opus-4-6');
+
+    await handler.createResponse({
+      client,
+      messages: helloMessages(),
+      temperature: 0,
+    });
+
+    const edits = messageOptions[0].context_management?.edits ?? [];
+    assert.equal(edits[0]?.type, 'compact_20260112');
+  });
+
   it('announces expected compaction after the measured count crosses the trigger', async () => {
     const handler = createAnthropicHandler({
       supportsTokenCounting: true,

--- a/src/test-kernel/agent/modelHandlers/stopReasonUtils.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/stopReasonUtils.vitest.ts
@@ -17,6 +17,10 @@ describe('isTokenLimitStopReason', () => {
     assert.equal(isTokenLimitStopReason(OPENAI_CHAT_FINISH.LENGTH), true);
     assert.equal(isTokenLimitStopReason(OPENAI_COMPLETION_FINISH.LENGTH), true);
     assert.equal(isTokenLimitStopReason(ANTHROPIC_STOP.MAX_TOKENS), true);
+    assert.equal(
+      isTokenLimitStopReason(ANTHROPIC_STOP.MODEL_CONTEXT_WINDOW_EXCEEDED),
+      true,
+    );
     assert.equal(isTokenLimitStopReason(MCP_STOP.MAX_TOKENS), true);
     assert.equal(isTokenLimitStopReason(GOOGLE_FINISH.MAX_TOKENS), true);
   });


### PR DESCRIPTION
## Summary

- recognize Anthropic's `model_context_window_exceeded` stop reason
- perform one bounded forced-compaction recovery instead of silently truncating or repeatedly retrying an overfull transcript
- round-trip successful Anthropic native compaction blocks into conversation state while preserving failed/null compactions

## Verification

- `npm run typecheck`
- `npm run lint`
- 93 focused and surrounding Vitest tests
- full `npm test` running locally

Closes #9120

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes conversation history replacement and continuation behavior on context overflow; mistakes could drop messages or retry without compacting, but behavior is bounded to one recovery attempt with extensive tests.
> 
> **Overview**
> Adds handling for Anthropic's **`model_context_window_exceeded`** stop reason so an empty overflow response no longer ends the cycle as a hard failure, and the continuation stage can run a **single bounded recovery** instead of treating it like a normal token-limit continuation.
> 
> **Response cycle:** When the model returns no text but that stop reason, the flow sets `processedResponse` to `''` and routes to continuation, which may call **`requestCompaction()`** once (if manual compaction is supported), bump continuation count, and retry; a second overflow or missing compaction support stops with a warning. **`shouldContinue`** on Anthropic explicitly does not treat this reason as ordinary continuation.
> 
> **Compaction plumbing:** `requestCompaction()` returns an ownership id; **`clearCompactionRequest(id)`** clears only matching requests (cleared after a successful API attempt on Anthropic, and in **`ResponseCycleNode`** `finally` on cancel/failure). **`setupContextManagement`** allows native compaction when **`forceCompaction`** is set even outside tool-use mode.
> 
> **Anthropic handler:** Manual compaction is enabled for **workflow** as well as tool-use on eligible models. Successful **`compaction`** blocks replace the message transcript via **`updateMessageContent`** / **`createAssistantMessageFromResponse`**; null compaction blocks keep the prior history. **`updateMessageContent`** now receives the raw response object for that path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2749afa43b8d3240886d16443c2c3cd8f3a2d3b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->