### PR TITLE
fix(tools): guard delegation tool names

### DIFF
--- a/src/shared/constants/delegationTools.ts
+++ b/src/shared/constants/delegationTools.ts
@@ -3,6 +3,15 @@ import { AgentCategory } from '../schemas/agent';
 export const DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME =
   'delegate_workflow_script' as const;
 
+const CANONICAL_DELEGATION_TOOL_NAMES = [
+  'delegate_workflow',
+  DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+  'delegate_agent',
+] as const;
+
+export type CanonicalDelegationToolName =
+  (typeof CANONICAL_DELEGATION_TOOL_NAMES)[number];
+
 /**
  * Tools that delegate work to sub-agents.
  *
@@ -12,9 +21,7 @@ export const DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME =
  * Includes legacy aliases for historical log entries.
  */
 export const DELEGATION_TOOLS: ReadonlySet<string> = new Set([
-  'delegate_workflow',
-  DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
-  'delegate_agent',
+  ...CANONICAL_DELEGATION_TOOL_NAMES,
   'resume_agent',
   'propose_workflow',
   'propose_agent',

--- a/src/test-kernel/shared/DelegationTools.vitest.ts
+++ b/src/test-kernel/shared/DelegationTools.vitest.ts
@@ -1,5 +1,7 @@
+// Third-party imports
 import { expect, expectTypeOf, it } from 'vitest';
 
+// Local imports - delegation tool contracts
 import {
   DELEGATION_TOOLS,
   type CanonicalDelegationToolName,

--- a/src/test-kernel/shared/DelegationTools.vitest.ts
+++ b/src/test-kernel/shared/DelegationTools.vitest.ts
@@ -1,0 +1,22 @@
+import { expect, expectTypeOf, it } from 'vitest';
+
+import {
+  DELEGATION_TOOLS,
+  type CanonicalDelegationToolName,
+} from '@shared/constants/delegationTools';
+import type { RegisteredToolName } from '@tools/registry';
+
+it('keeps canonical delegation tool names registered', () => {
+  expectTypeOf<CanonicalDelegationToolName>().toMatchTypeOf<RegisteredToolName>();
+});
+
+it('preserves canonical and historical delegation tool names', () => {
+  expect([...DELEGATION_TOOLS]).toEqual([
+    'delegate_workflow',
+    'delegate_workflow_script',
+    'delegate_agent',
+    'resume_agent',
+    'propose_workflow',
+    'propose_agent',
+  ]);
+});

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -6,7 +6,10 @@ import {
   type ToolDefinition,
 } from '@model/ToolDefinition';
 import type { CanonicalToolDisplayName } from '@shared/tools/toolKind';
-import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
+import {
+  DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
+  type CanonicalDelegationToolName,
+} from '@shared/constants/delegationTools';
 
 // Local file imports
 import { BashTool } from './bash';
@@ -153,6 +156,11 @@ export type RegisteredToolName = keyof ReturnType<typeof createDefaultTools>;
 type AssertNever<T extends never> = T;
 type _CanonicalDisplayNamesAreRegistered = AssertNever<
   Exclude<CanonicalToolDisplayName, RegisteredToolName>
+>;
+
+/** Compile-time guard for canonical delegation names; historical aliases are excluded. */
+type _CanonicalDelegationNamesAreRegistered = AssertNever<
+  Exclude<CanonicalDelegationToolName, RegisteredToolName>
 >;
 
 /**


### PR DESCRIPTION
## Summary

- define canonical delegation tool names once while retaining historical aliases for log compatibility
- add a registry type guard so renamed or removed canonical delegation tools fail compilation
- preserve the delegation set's runtime contents and iteration order

## Verification

- `npm run typecheck`
- `npm run lint`
- focused delegation-tool tests
- mutation check confirms a renamed registry tool fails at the new type guard

Closes #9112

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor and type-level guards only; runtime delegation tool membership and order are explicitly preserved by tests.
> 
> **Overview**
> Canonical delegation tools (`delegate_workflow`, `delegate_workflow_script`, `delegate_agent`) are now defined once in shared constants and exported as `CanonicalDelegationToolName`, with `DELEGATION_TOOLS` built from that list plus unchanged historical aliases.
> 
> The tool registry gains a compile-time check (mirroring the existing display-name guard) so any canonical delegation name that is renamed or dropped from `createDefaultTools()` fails typecheck. New Vitest coverage locks the runtime set/order and asserts canonical names stay assignable to `RegisteredToolName`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af0a07c77e34736bccf3c02a1670bcd680ebead3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->