### PR TITLE
refactor: share tool JSON schema options

### DIFF
--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -7,6 +7,11 @@ import * as logger from '@logger/logUtils';
 // Type imports
 import type { ToolDefinition } from '@model';
 import type { LanguageModelToolDefinition } from '@platform/languageModel';
+
+// Local imports - shared
+import { TOOL_JSON_SCHEMA_OPTIONS } from '@shared/tools/toolJsonSchema';
+
+// Type imports - third-party
 import type {
   Tool as AnthropicTool,
   ToolUnion,
@@ -150,11 +155,10 @@ export function convertToolSchema(
 ): JSONSchemaObject | null {
   let schema: JSONSchemaObject | null;
   if (def.zodSchema) {
-    schema = toJSONSchema(def.zodSchema, {
-      target: 'draft-2020-12',
-      unrepresentable: 'any',
-      io: 'input',
-    }) as JSONSchemaObject;
+    schema = toJSONSchema(
+      def.zodSchema,
+      TOOL_JSON_SCHEMA_OPTIONS,
+    ) as JSONSchemaObject;
   } else {
     schema = (def.parameters ?? null) as JSONSchemaObject | null;
   }

--- a/src/shared/tools/toolJsonSchema.ts
+++ b/src/shared/tools/toolJsonSchema.ts
@@ -1,6 +1,9 @@
+// Type imports - third-party
+import type { core } from 'zod';
+
 /** Zod conversion options shared by tool definitions and provider adapters. */
 export const TOOL_JSON_SCHEMA_OPTIONS = Object.freeze({
   target: 'draft-2020-12',
   unrepresentable: 'any',
   io: 'input',
-} as const);
+} as const satisfies core.ToJSONSchemaParams);

--- a/src/shared/tools/toolJsonSchema.ts
+++ b/src/shared/tools/toolJsonSchema.ts
@@ -1,0 +1,6 @@
+/** Zod conversion options shared by tool definitions and provider adapters. */
+export const TOOL_JSON_SCHEMA_OPTIONS = Object.freeze({
+  target: 'draft-2020-12',
+  unrepresentable: 'any',
+  io: 'input',
+} as const);

--- a/src/test-kernel/architecture/SharedLiteralImmutability.vitest.ts
+++ b/src/test-kernel/architecture/SharedLiteralImmutability.vitest.ts
@@ -7,6 +7,7 @@ import { WORKSPACE_STORAGE_LAYOUT } from '@common/storage/storageLayout';
 import { LATEXDIFF_CITATION_TEXT_COMMAND_EXCLUSIONS } from '@latex/latexdiff/diffCommandExecutor';
 import { MATH_MARKUP_OPTIONS } from '@latex/latexdiff/mathMarkup';
 import { API_KEY_PROVIDER_IDS } from '@shared/constants/providers';
+import { TOOL_JSON_SCHEMA_OPTIONS } from '@shared/tools/toolJsonSchema';
 import { ARXIV_CONSTANTS, CROSSREF_CONSTANTS } from '@tools/citation/constants';
 import { DEFAULT_POLLING_BACKOFF_CONFIG } from '@tools/github/PollingSourceBase';
 import { GoalStore } from '@tools/goal/goalStore';
@@ -47,6 +48,7 @@ const SHARED_LITERALS = [
   ],
   ['MATH_MARKUP_OPTIONS', MATH_MARKUP_OPTIONS],
   ['API_KEY_PROVIDER_IDS', API_KEY_PROVIDER_IDS],
+  ['TOOL_JSON_SCHEMA_OPTIONS', TOOL_JSON_SCHEMA_OPTIONS],
 ] as const;
 
 describe('shared literal exports', () => {

--- a/src/tools/core/define.ts
+++ b/src/tools/core/define.ts
@@ -4,16 +4,18 @@ import { toJSONSchema, type ZodType } from 'zod';
 // Type imports
 import type { ToolDefinition } from '@model';
 
+// Local imports - shared
+import { TOOL_JSON_SCHEMA_OPTIONS } from '@shared/tools/toolJsonSchema';
+
 // Local file imports
 import { BaseTool } from './base';
 
 /** Convert a tool's Zod input schema into the JSON Schema `parameters` every `ToolDefinition` carries. */
 export function toToolParameters(schema: ZodType): Record<string, unknown> {
-  return toJSONSchema(schema, {
-    target: 'draft-2020-12',
-    unrepresentable: 'any',
-    io: 'input',
-  }) as Record<string, unknown>;
+  return toJSONSchema(schema, TOOL_JSON_SCHEMA_OPTIONS) as Record<
+    string,
+    unknown
+  >;
 }
 
 /**


### PR DESCRIPTION
## Summary

Consolidates the Zod-to-JSON-Schema conversion policy used for LLM tool input schemas. Tool definitions and provider adapters now consume one frozen, Zod-typed options object.

## Issue acceptance gates

Closes #9113.

- Both identified tool-schema call sites use the same options object.
- The values remain `draft-2020-12`, `unrepresentable: 'any'`, and `io: 'input'`.
- Zod type-checks the shared literal directly.
- Existing generated-schema behavior is unchanged.

## Single source of truth

`src/shared/tools/toolJsonSchema.ts` owns `TOOL_JSON_SCHEMA_OPTIONS` for tool input schemas.

The similar literal in `agentCreatorFlow.ts` is intentionally outside this ownership boundary: it generates documentation/schema references for agent YAML rather than LLM tool parameters. Reusing a tool-named policy there would couple distinct domains and make future divergence harder to express.

## Duplication and abstraction budget

Removed two independently editable inline option objects. Added one flat shared constant with two production consumers; no wrapper, pass-through helper, or new control-flow layer.

## Net elements (R6)

- Files: 1 added, 3 modified
- Exported symbols: 1 added (`TOOL_JSON_SCHEMA_OPTIONS`)
- Classes/interfaces/enums: none
- Net LoC: +17 (27 added, 10 removed)
- Deleted duplication: 2 inline Zod option objects

## Consumer counts (R8)

n/a — no emit path or export was deleted or rerouted. The new constant has 2 production consumers; the test-only third consumer verifies immutability.

## Host impact

Extension: No behavior change; shared tool-schema generation uses the same option values.

Desktop: No behavior change; shared tool-schema generation uses the same option values.

CLI: No behavior change; shared tool-schema generation uses the same option values.

## Scheduled refactoring

None. The agent-YAML documentation conversion site is intentionally a separate domain policy.

## Validation

- `npm run typecheck`
- `npm run lint`
- 24 focused tool-conversion tests
- 19 shared-literal immutability tests
- representative schema-equivalence checks
- `git diff --check`
