### PR TITLE
fix: extend Google classic stream timeout

### DIFF
--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -13,6 +13,7 @@ import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { SHUTDOWN_PHASE } from '@platform/interfaces';
 import { initPlatform, platform, tryPlatform } from '@platform/platform';
 import type { LifecycleHost } from '@platform/interfaces';
+import { installLongRunningModelFetch } from '@platform/defaults/longRunningModelTransport';
 import { JsonStore } from '@platform/defaults/jsonStore';
 import { createLifecycleHost } from '@platform/defaults/lifecycleHost';
 import {
@@ -240,6 +241,10 @@ export async function initCliPlatform(
   );
 
   if (!tryPlatform()) {
+    // Google classic generateContent hardwires global fetch. The standalone
+    // CLI can safely give it the same long-stream transport as other SDKs.
+    installLongRunningModelFetch();
+
     const configStore = await JsonStore.open(
       workspaceTexraConfigPath(cliWorkspaceCwd),
     );

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -12,6 +12,7 @@ import { DESKTOP_WORKSPACE_PATH_STATE_KEY } from '@desktop/workspacePath.js';
 import { initPlatform } from '@platform/platform';
 import { SHUTDOWN_PHASE } from '@platform/interfaces';
 import type { AgentResumePort, LifecycleHost } from '@platform/interfaces';
+import { installLongRunningModelFetch } from '@platform/defaults/longRunningModelTransport';
 import { JsonStore } from '@platform/defaults/jsonStore';
 import { createLifecycleHost } from '@platform/defaults/lifecycleHost';
 import {
@@ -104,6 +105,10 @@ export async function initializeElectronPlatform(
   mainDirname: string,
   agentResume: AgentResumePort,
 ): Promise<ElectronPlatformInitResult> {
+  // Google classic generateContent hardwires global fetch. Desktop owns this
+  // process, unlike the shared VS Code extension host, so replacement is safe.
+  installLongRunningModelFetch();
+
   // The default handler's console.error is mirrored into the desktop app log,
   // so shutdown-handler failures land at error severity like the other hosts.
   const lifecycle = createLifecycleHost();

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -8,14 +8,6 @@ import {
   type ModelCapabilities,
   ReasoningEffort,
 } from 'llm-zoo';
-import {
-  fetch as undiciFetch,
-  getGlobalDispatcher,
-  type Dispatcher,
-  type RequestInfo as UndiciRequestInfo,
-  type RequestInit as UndiciRequestInit,
-} from 'undici';
-
 // Local imports
 import type { AgentTrace } from '@agent/trace';
 import {
@@ -81,6 +73,10 @@ import {
 import { isGpt5ModelName } from '@model/modelNames';
 import { getApiKey, type ApiProvider } from '@model/apiProviders';
 import { platform } from '@platform/platform';
+import {
+  composeLongRunningModelDispatcher,
+  longRunningModelFetch,
+} from '@platform/defaults/longRunningModelTransport';
 import type { FileLocation, MediaAttachmentKind } from '@shared/schemas';
 import { MESSAGE_TYPES } from '@shared/schemas';
 import type {
@@ -121,72 +117,8 @@ import {
 } from './support/ProxyConfigResolver';
 import { prepareExistingOutputContent } from './utils/fileContentUtils';
 
-const MODEL_STREAM_INACTIVITY_TIMEOUT_MS = 30 * 60 * 1000;
-
-async function normalizeModelRequest(
-  input: RequestInfo | URL,
-  init?: RequestInit,
-): Promise<[UndiciRequestInfo, UndiciRequestInit]> {
-  if (!(input instanceof Request)) {
-    return [input as UndiciRequestInfo, init as UndiciRequestInit];
-  }
-
-  // OpenRouter supplies Node's native Request, while package Undici expects
-  // its own branded Request. Rebuild it from interoperable primitives here.
-  const request = new Request(input, init);
-  const body = request.body === null ? undefined : await request.arrayBuffer();
-  return [
-    request.url,
-    {
-      method: request.method,
-      headers: Object.fromEntries(request.headers.entries()),
-      redirect: request.redirect,
-      signal: request.signal,
-      ...(body === undefined ? {} : { body }),
-    },
-  ];
-}
-
-const withLongStreamTimeouts =
-  (dispatch: Dispatcher['dispatch']): Dispatcher['dispatch'] =>
-  (options, handler) =>
-    dispatch(
-      {
-        ...options,
-        bodyTimeout: MODEL_STREAM_INACTIVITY_TIMEOUT_MS,
-        headersTimeout: 10 * 60 * 1000,
-      },
-      handler,
-    );
-
-/** Composes the host's current dispatcher (proxy policy stays host-owned) with
- *  the long-stream timeouts. Composed per call so a runtime proxy change is
- *  honored by the next request. */
-function composeLongRunningDispatcher(): Dispatcher {
-  return getGlobalDispatcher().compose(withLongStreamTimeouts);
-}
-
-/**
- * Fetch transport with long-stream timeouts and the host's current proxy
- * policy.
- *
- * Deliberately package-undici fetch, not the SDKs' `fetchOptions.dispatcher`
- * seam over native fetch: pairing this package's fetch with this package's
- * composed dispatcher keeps the dispatch-handler interface version-locked,
- * where native fetch would couple our dispatcher to whatever undici the host
- * Node embeds. That same choice is why {@link normalizeModelRequest} exists —
- * package-undici fetch rejects native `Request` instances (OpenRouter's
- * HTTPClient passes one), so it is rebuilt from interoperable primitives.
- */
-const longRunningModelFetch: typeof fetch = async (input, init) => {
-  const [requestInput, requestInit] = await normalizeModelRequest(input, init);
-  // Undici implements the Web Fetch response contract at runtime, but its
-  // package-local types are not assignable to the DOM library's Response.
-  return undiciFetch(requestInput, {
-    ...requestInit,
-    dispatcher: composeLongRunningDispatcher(),
-  }) as unknown as Promise<Response>;
-};
+// Type imports
+import type { Dispatcher } from 'undici';
 
 /**
  * Generic SDK error tagging wrapper used by the base model handler.
@@ -372,7 +304,7 @@ export abstract class ModelHandler<
    * differs from the package version.
    */
   protected longRunningModelDispatcher(): Dispatcher {
-    return composeLongRunningDispatcher();
+    return composeLongRunningModelDispatcher();
   }
 
   public setLogger(logger: AgentTrace): void {

--- a/src/platform/defaults/longRunningModelTransport.ts
+++ b/src/platform/defaults/longRunningModelTransport.ts
@@ -1,0 +1,88 @@
+// Third-party imports
+import {
+  fetch as undiciFetch,
+  getGlobalDispatcher,
+  type Dispatcher,
+  type RequestInfo as UndiciRequestInfo,
+  type RequestInit as UndiciRequestInit,
+} from 'undici';
+
+const MODEL_STREAM_INACTIVITY_TIMEOUT_MS = 30 * 60 * 1000;
+const MODEL_RESPONSE_HEADERS_TIMEOUT_MS = 10 * 60 * 1000;
+
+async function normalizeModelRequest(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<[UndiciRequestInfo, UndiciRequestInit]> {
+  if (!(input instanceof Request)) {
+    return [input as UndiciRequestInfo, init as UndiciRequestInit];
+  }
+
+  // OpenRouter supplies Node's native Request, while package Undici expects
+  // its own branded Request. Rebuild it from interoperable primitives here.
+  const request = new Request(input, init);
+  const body = request.body === null ? undefined : await request.arrayBuffer();
+  return [
+    request.url,
+    {
+      method: request.method,
+      headers: Object.fromEntries(request.headers.entries()),
+      redirect: request.redirect,
+      signal: request.signal,
+      ...(body === undefined ? {} : { body }),
+    },
+  ];
+}
+
+const withLongStreamTimeouts =
+  (dispatch: Dispatcher['dispatch']): Dispatcher['dispatch'] =>
+  (options, handler) =>
+    dispatch(
+      {
+        ...options,
+        bodyTimeout: MODEL_STREAM_INACTIVITY_TIMEOUT_MS,
+        headersTimeout: MODEL_RESPONSE_HEADERS_TIMEOUT_MS,
+      },
+      handler,
+    );
+
+/** Composes the host's current dispatcher (proxy policy stays host-owned) with
+ *  the long-stream timeouts. Composed per call so a runtime proxy change is
+ *  honored by the next request. */
+export function composeLongRunningModelDispatcher(): Dispatcher {
+  return getGlobalDispatcher().compose(withLongStreamTimeouts);
+}
+
+/**
+ * Fetch transport with long-stream timeouts and the host's current proxy
+ * policy.
+ *
+ * Deliberately package-undici fetch, not the SDKs' `fetchOptions.dispatcher`
+ * seam over native fetch: pairing this package's fetch with this package's
+ * composed dispatcher keeps the dispatch-handler interface version-locked,
+ * where native fetch would couple our dispatcher to whatever undici the host
+ * Node embeds. That same choice is why {@link normalizeModelRequest} exists —
+ * package-undici fetch rejects native `Request` instances (OpenRouter's
+ * HTTPClient passes one), so it is rebuilt from interoperable primitives.
+ */
+export const longRunningModelFetch: typeof fetch = async (input, init) => {
+  const [requestInput, requestInit] = await normalizeModelRequest(input, init);
+  // Undici implements the Web Fetch response contract at runtime, but its
+  // package-local types are not assignable to the DOM library's Response.
+  return undiciFetch(requestInput, {
+    ...requestInit,
+    dispatcher: composeLongRunningModelDispatcher(),
+  }) as unknown as Promise<Response>;
+};
+
+/**
+ * Give SDKs that hardwire global fetch the model-stream timeout budget.
+ *
+ * Only standalone hosts may call this. In particular, the VS Code extension
+ * must not replace fetch for every extension sharing its host process. Google
+ * classic `generateContent` has no fetch injection seam, so CLI and desktop
+ * install the same transport used directly by the other model SDKs.
+ */
+export function installLongRunningModelFetch(): void {
+  globalThis.fetch = longRunningModelFetch;
+}

--- a/src/platform/defaults/longRunningModelTransport.ts
+++ b/src/platform/defaults/longRunningModelTransport.ts
@@ -9,6 +9,27 @@ import {
 
 const MODEL_STREAM_INACTIVITY_TIMEOUT_MS = 30 * 60 * 1000;
 const MODEL_RESPONSE_HEADERS_TIMEOUT_MS = 10 * 60 * 1000;
+const ROUTING_FETCH_MARKER = Symbol('texra.longRunningModelFetchRouter');
+type RoutingFetch = typeof fetch & { [ROUTING_FETCH_MARKER]?: true };
+
+function isGoogleClassicStreamingRequest(input: RequestInfo | URL): boolean {
+  let url: string;
+  if (typeof input === 'string') {
+    url = input;
+  } else if (input instanceof URL) {
+    url = input.href;
+  } else if (input instanceof Request) {
+    url = input.url;
+  } else {
+    return false;
+  }
+
+  try {
+    return new URL(url).pathname.endsWith(':streamGenerateContent');
+  } catch {
+    return false;
+  }
+}
 
 async function normalizeModelRequest(
   input: RequestInfo | URL,
@@ -76,13 +97,22 @@ export const longRunningModelFetch: typeof fetch = async (input, init) => {
 };
 
 /**
- * Give SDKs that hardwire global fetch the model-stream timeout budget.
+ * Route Google classic streaming generation through the model transport.
  *
  * Only standalone hosts may call this. In particular, the VS Code extension
- * must not replace fetch for every extension sharing its host process. Google
+ * must not wrap fetch for every extension sharing its host process. Google
  * classic `generateContent` has no fetch injection seam, so CLI and desktop
- * install the same transport used directly by the other model SDKs.
+ * intercept only its `:streamGenerateContent` action and preserve the host's
+ * fetch implementation for every unrelated request.
  */
 export function installLongRunningModelFetch(): void {
-  globalThis.fetch = longRunningModelFetch;
+  const hostFetch = globalThis.fetch as RoutingFetch;
+  if (hostFetch[ROUTING_FETCH_MARKER] === true) return;
+
+  const routingFetch: RoutingFetch = (input, init) =>
+    isGoogleClassicStreamingRequest(input)
+      ? longRunningModelFetch(input, init)
+      : hostFetch(input, init);
+  Object.defineProperty(routingFetch, ROUTING_FETCH_MARKER, { value: true });
+  globalThis.fetch = routingFetch;
 }

--- a/src/platform/defaults/longRunningModelTransport.ts
+++ b/src/platform/defaults/longRunningModelTransport.ts
@@ -109,10 +109,16 @@ export function installLongRunningModelFetch(): void {
   const hostFetch = globalThis.fetch as RoutingFetch;
   if (hostFetch[ROUTING_FETCH_MARKER] === true) return;
 
-  const routingFetch: RoutingFetch = (input, init) =>
-    isGoogleClassicStreamingRequest(input)
-      ? longRunningModelFetch(input, init)
-      : hostFetch(input, init);
+  const routingFetch: RoutingFetch = function (
+    this: unknown,
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> {
+    if (isGoogleClassicStreamingRequest(input)) {
+      return longRunningModelFetch(input, init);
+    }
+    return Reflect.apply(hostFetch, this, [input, init]);
+  };
   Object.defineProperty(routingFetch, ROUTING_FETCH_MARKER, { value: true });
   globalThis.fetch = routingFetch;
 }

--- a/src/platform/defaults/longRunningModelTransport.ts
+++ b/src/platform/defaults/longRunningModelTransport.ts
@@ -27,6 +27,7 @@ function isGoogleClassicStreamingRequest(input: RequestInfo | URL): boolean {
   try {
     return new URL(url).pathname.endsWith(':streamGenerateContent');
   } catch {
+    // Malformed input cannot identify a Google streaming endpoint.
     return false;
   }
 }

--- a/src/test-kernel/agent/modelHandlers/LongRunningModelFetch.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/LongRunningModelFetch.vitest.ts
@@ -1,5 +1,4 @@
 // Third-party imports
-import { ModelProvider } from 'llm-zoo';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const transportMocks = vi.hoisted(() => ({
@@ -17,32 +16,19 @@ vi.mock('undici', async (importOriginal) => {
 });
 
 // Local imports
-import { ModelHandlerOpenAI } from '@agent/modelHandlers/openai/modelHandlerOpenAI';
-import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
+import {
+  installLongRunningModelFetch,
+  longRunningModelFetch,
+} from '@platform/defaults/longRunningModelTransport';
 
 // Type imports
 import type { Dispatcher } from 'undici';
 
-class TestableModelHandler extends ModelHandlerOpenAI {
-  modelFetch(): typeof fetch {
-    return this.longRunningModelFetch;
-  }
-}
+const nativeFetch = globalThis.fetch;
 
-function modelFetch(): typeof fetch {
-  return new TestableModelHandler(
-    buildTestModelConfig({
-      name: 'transport-test',
-      label: 'Transport Test',
-      fullName: 'transport-test',
-      shortName: 'transport-test',
-      provider: ModelProvider.OPENAI,
-    }),
-  ).modelFetch();
-}
-
-describe('longRunningModelFetch', () => {
+describe('long-running model transport', () => {
   afterEach(() => {
+    globalThis.fetch = nativeFetch;
     vi.clearAllMocks();
   });
 
@@ -72,7 +58,7 @@ describe('longRunningModelFetch', () => {
       body: JSON.stringify({ prompt: 'hello' }),
     });
 
-    await expect(modelFetch()(request)).resolves.toBe(response);
+    await expect(longRunningModelFetch(request)).resolves.toBe(response);
 
     const [input, init] = transportMocks.undiciFetch.mock.calls[0] ?? [];
     expect(input).toBe('https://openrouter.example/v1/chat');
@@ -95,5 +81,11 @@ describe('longRunningModelFetch', () => {
       }),
       expect.anything(),
     );
+  });
+
+  it('installs the timeout-aware fetch for SDKs without an injection seam', () => {
+    installLongRunningModelFetch();
+
+    expect(globalThis.fetch).toBe(longRunningModelFetch);
   });
 });

--- a/src/test-kernel/agent/modelHandlers/LongRunningModelFetch.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/LongRunningModelFetch.vitest.ts
@@ -83,9 +83,97 @@ describe('long-running model transport', () => {
     );
   });
 
-  it('installs the timeout-aware fetch for SDKs without an injection seam', () => {
+  it('routes classic streamGenerateContent through the timeout-aware transport', async () => {
+    const baseDispatch = vi.fn(() => true);
+    let timeoutDispatcher: Dispatcher | undefined;
+    transportMocks.getGlobalDispatcher.mockReturnValue({
+      compose: vi.fn(
+        (
+          interceptor: (
+            dispatch: Dispatcher['dispatch'],
+          ) => Dispatcher['dispatch'],
+        ) => {
+          timeoutDispatcher = {
+            dispatch: interceptor(baseDispatch as Dispatcher['dispatch']),
+          } as Dispatcher;
+          return timeoutDispatcher;
+        },
+      ),
+    } as unknown as Dispatcher);
+    const priorFetch = vi.fn();
+    globalThis.fetch = priorFetch as typeof fetch;
+    const response = new Response(null, { status: 200 });
+    transportMocks.undiciFetch.mockResolvedValueOnce(response);
+
+    installLongRunningModelFetch();
+    const result = await globalThis.fetch(
+      'https://relay.example/custom/v1beta/models/gemini-3-pro:streamGenerateContent?alt=sse',
+      { method: 'POST', body: '{}' },
+    );
+
+    expect(result).toBe(response);
+    expect(priorFetch).not.toHaveBeenCalled();
+    expect(transportMocks.undiciFetch).toHaveBeenCalledOnce();
+    timeoutDispatcher?.dispatch(
+      { method: 'GET', origin: 'https://example.test', path: '/' },
+      {} as never,
+    );
+    expect(baseDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bodyTimeout: 30 * 60 * 1000,
+        headersTimeout: 10 * 60 * 1000,
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('delegates unrelated requests without changing their inputs or response', async () => {
+    const response = new Response('delegated');
+    const priorFetch = vi.fn().mockResolvedValueOnce(response);
+    globalThis.fetch = priorFetch as typeof fetch;
+    const request = new Request('https://example.test/upload');
+    const form = new FormData();
+    form.append('file', new Blob(['contents']), 'paper.tex');
+    const init: RequestInit = { method: 'POST', body: form };
+
+    installLongRunningModelFetch();
+    const result = await globalThis.fetch(request, init);
+
+    expect(priorFetch).toHaveBeenCalledOnce();
+    expect(priorFetch).toHaveBeenCalledWith(request, init);
+    expect(result).toBe(response);
+    expect(transportMocks.undiciFetch).not.toHaveBeenCalled();
+  });
+
+  it('does not stack routing wrappers when installed repeatedly', async () => {
+    const response = new Response(null, { status: 204 });
+    const priorFetch = vi.fn().mockResolvedValue(response);
+    globalThis.fetch = priorFetch as typeof fetch;
+
+    installLongRunningModelFetch();
+    const firstInstalledFetch = globalThis.fetch;
     installLongRunningModelFetch();
 
-    expect(globalThis.fetch).toBe(longRunningModelFetch);
+    expect(globalThis.fetch).toBe(firstInstalledFetch);
+    await globalThis.fetch('https://example.test/status');
+    expect(priorFetch).toHaveBeenCalledOnce();
+  });
+
+  it('wraps a newly installed host fetch without delegating to its old wrapper', async () => {
+    const firstHostFetch = vi.fn();
+    globalThis.fetch = firstHostFetch as typeof fetch;
+    installLongRunningModelFetch();
+    const oldRoutingFetch = globalThis.fetch;
+    const response = new Response('new owner');
+    const replacementHostFetch = vi.fn().mockResolvedValueOnce(response);
+    globalThis.fetch = replacementHostFetch as typeof fetch;
+
+    installLongRunningModelFetch();
+    const result = await globalThis.fetch('https://example.test/replaced');
+
+    expect(globalThis.fetch).not.toBe(oldRoutingFetch);
+    expect(replacementHostFetch).toHaveBeenCalledOnce();
+    expect(firstHostFetch).not.toHaveBeenCalled();
+    expect(result).toBe(response);
   });
 });

--- a/src/test-kernel/agent/modelHandlers/LongRunningModelFetch.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/LongRunningModelFetch.vitest.ts
@@ -127,20 +127,29 @@ describe('long-running model transport', () => {
     );
   });
 
-  it('delegates unrelated requests without changing their inputs or response', async () => {
+  it('delegates unrelated requests without changing their receiver, inputs, or response', async () => {
     const response = new Response('delegated');
-    const priorFetch = vi.fn().mockResolvedValueOnce(response);
+    const observedReceivers: unknown[] = [];
+    const priorFetch = vi.fn(function (this: unknown) {
+      observedReceivers.push(this);
+      return Promise.resolve(response);
+    });
     globalThis.fetch = priorFetch as typeof fetch;
+    const receiver = { owner: 'host-fetch' };
     const request = new Request('https://example.test/upload');
     const form = new FormData();
     form.append('file', new Blob(['contents']), 'paper.tex');
     const init: RequestInit = { method: 'POST', body: form };
 
     installLongRunningModelFetch();
-    const result = await globalThis.fetch(request, init);
+    const result = await Reflect.apply(globalThis.fetch, receiver, [
+      request,
+      init,
+    ]);
 
     expect(priorFetch).toHaveBeenCalledOnce();
     expect(priorFetch).toHaveBeenCalledWith(request, init);
+    expect(observedReceivers).toEqual([receiver]);
     expect(result).toBe(response);
     expect(transportMocks.undiciFetch).not.toHaveBeenCalled();
   });

--- a/src/test-kernel/cli/CliInitPlatform.vitest.mts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.mts
@@ -88,6 +88,7 @@ const mocks = vi.hoisted(() => ({
   },
   getCliSecrets: vi.fn(() => ({ kind: 'cli-secrets' })),
   invalidateModelOptionsCache: vi.fn(),
+  installLongRunningModelFetch: vi.fn(),
   tryPlatform: vi.fn(),
   // Collects callbacks registered via the (mocked) lifecycle host's onShutdown
   // so a test can run them and assert the usage-log dispose was wired.
@@ -96,6 +97,10 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('@agent/index/platformAgentDirectories', () => ({
   createPlatformAgentDirectories: mocks.createPlatformAgentDirectories,
+}));
+
+vi.mock('@platform/defaults/longRunningModelTransport', () => ({
+  installLongRunningModelFetch: mocks.installLongRunningModelFetch,
 }));
 
 vi.mock('@auth/serverKeys', () => ({
@@ -238,6 +243,7 @@ describe('CLI platform init', () => {
       }),
     );
 
+    expect(mocks.installLongRunningModelFetch).toHaveBeenCalledOnce();
     expect(mocks.getCliSecrets).toHaveBeenCalledWith('/tmp/texra-storage-root');
     expect(mocks.createNodePlatform).toHaveBeenCalledOnce();
     expect(mocks.initNodeAgentRuntime).toHaveBeenCalledOnce();

--- a/src/test-kernel/desktop/ElectronCompositionRoot.vitest.mts
+++ b/src/test-kernel/desktop/ElectronCompositionRoot.vitest.mts
@@ -290,6 +290,23 @@ describe('desktop composition root and launch environment', () => {
     ]);
   });
 
+  it('installs the long-running model fetch in the desktop process only', async () => {
+    const desktopPlatformSource = await readFile(
+      repoPath('packages', 'desktop', 'src', 'main', 'platform', 'index.ts'),
+      'utf8',
+    );
+    const extensionSource = await readFile(
+      repoPath('packages', 'extension', 'src', 'extension.ts'),
+      'utf8',
+    );
+
+    expect(desktopPlatformSource).toContain('installLongRunningModelFetch();');
+    expect(
+      desktopPlatformSource.indexOf('installLongRunningModelFetch();'),
+    ).toBeLessThan(desktopPlatformSource.indexOf('initPlatform('));
+    expect(extensionSource).not.toContain('installLongRunningModelFetch');
+  });
+
   it('repairs PATH before platform services and bundled agents are initialized', async () => {
     const source = await readFile(
       repoPath('packages', 'desktop', 'src', 'main', 'platform', 'index.ts'),


### PR DESCRIPTION
## Summary

- extract the existing long-running model transport into one host-neutral source of truth
- route Google classic `:streamGenerateContent` calls through the 30-minute inactivity / 10-minute headers transport in CLI and Electron desktop
- preserve the existing host fetch exactly for unrelated requests, including caller receiver, inputs, response identity, and repeated installation
- leave the shared VS Code extension host unchanged

Closes #9097

## Validation

- full Vitest suite: 7,445 passed, 4 skipped (initial implementation)
- focused transport/host suites: 40 passed; final review rerun 34 passed
- full workspace typecheck passed
- full TypeScript lint passed
- `compile:fast` passed
- dead-code ratchet and patch whitespace checks passed

## Review notes

Internal review caught and fixed two global-fetch compatibility risks before opening this PR: unrelated traffic is now selectively delegated to the prior host fetch, and its caller receiver is preserved with `Reflect.apply`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Process-global `fetch` patching in CLI/desktop is scoped to one Google endpoint but still affects all code in those processes; incorrect URL matching or delegation bugs could break unrelated HTTP. VS Code is excluded by design.
> 
> **Overview**
> **Fixes premature timeouts on Google classic streaming** by giving `:streamGenerateContent` the same long inactivity (30m) and headers (10m) transport other model SDKs already use.
> 
> The undici-based `longRunningModelFetch` / `composeLongRunningModelDispatcher` logic moves out of `ModelHandler` into `@platform/defaults/longRunningModelTransport`. Handlers keep importing that module unchanged in behavior.
> 
> **CLI and Electron desktop** call `installLongRunningModelFetch()` during platform init because Google’s classic client has no fetch injection hook—it hardwires `globalThis.fetch`. The installer wraps fetch only when the URL pathname ends with `:streamGenerateContent`; everything else goes to the prior host fetch with `Reflect.apply` (receiver preserved). Re-install is idempotent and can re-wrap if the host replaces fetch.
> 
> **The VS Code extension is intentionally unchanged**—a process-wide fetch wrapper would affect every extension in the shared host.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8395202cf9d904e91bdb061720ddfb31bd84236. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->