### PR TITLE
fix: bound terminal-mode scrollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ All notable changes to this project will be documented in this file.
   as the default Anthropic model. Opus 5 keeps the full 1M context window and
   adaptive thinking.
 
+### Extension (VS Code) and Desktop
+
+#### Bug Fixes
+
+- **Long terminal-mode logs keep bounded recent scrollback** — the progress
+  view retains at most 4,000 complete lines and marks when earlier lines have
+  been removed.
+
 ## [0.39.8] - 2026-07-24
 
 ### Shared (all surfaces)
@@ -78,9 +86,6 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
-- **Long terminal streams keep recent output without unbounded memory use** —
-  terminal-mode logs retain the latest 4,000 complete lines and clearly mark
-  when earlier scrollback has been removed.
 - **Completed background tasks leave the session list** — finished shell tasks
   are removed after their results are saved instead of leaving stale tabs.
 - **Workflow-script sessions show their own identity** — scripted orchestration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,9 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Long terminal streams keep recent output without unbounded memory use** —
+  terminal-mode logs retain the latest 4,000 complete lines and clearly mark
+  when earlier scrollback has been removed.
 - **Completed background tasks leave the session list** — finished shell tasks
   are removed after their results are saved instead of leaving stale tabs.
 - **Workflow-script sessions show their own identity** — scripted orchestration

--- a/packages/extension/src/progressView/frontend/components/TerminalOutput.ts
+++ b/packages/extension/src/progressView/frontend/components/TerminalOutput.ts
@@ -6,6 +6,9 @@ import { Terminal } from '@xterm/xterm';
 import xtermStyles from '@xterm/xterm/css/xterm.css?inline';
 import { clamp } from '@utils/core';
 
+// Local imports - terminal policy
+import { TERMINAL_SCROLLBACK_LINES } from './terminalBuffer';
+
 const DEFAULT_THEME = {
   background: '#1e1e1e',
   foreground: '#cccccc',
@@ -31,8 +34,6 @@ const ANSI_COLOR_MAP = [
   ['brightCyan', '--texra-terminal-ansiBrightCyan'],
   ['brightWhite', '--texra-terminal-ansiBrightWhite'],
 ] as const;
-
-const MIN_SCROLLBACK = 4_000;
 
 /** Maximum visible rows before terminal scrolls internally. */
 const MAX_VISIBLE_ROWS = 20;
@@ -142,7 +143,7 @@ export class TerminalOutput extends LitElement {
     this.terminal = new Terminal({
       disableStdin: true,
       convertEol: true,
-      scrollback: MIN_SCROLLBACK,
+      scrollback: TERMINAL_SCROLLBACK_LINES,
       fontFamily,
       fontSize: 12,
       theme,
@@ -246,7 +247,7 @@ export class TerminalOutput extends LitElement {
           this.renderedRowCount,
           updatePlan,
         );
-        const scrollback = Math.max(MIN_SCROLLBACK, rowCount);
+        const scrollback = Math.max(TERMINAL_SCROLLBACK_LINES, rowCount);
         if (terminal.options.scrollback !== scrollback) {
           terminal.options = {
             ...terminal.options,

--- a/packages/extension/src/progressView/frontend/components/TerminalOutput.ts
+++ b/packages/extension/src/progressView/frontend/components/TerminalOutput.ts
@@ -6,9 +6,6 @@ import { Terminal } from '@xterm/xterm';
 import xtermStyles from '@xterm/xterm/css/xterm.css?inline';
 import { clamp } from '@utils/core';
 
-// Local imports - terminal policy
-import { TERMINAL_SCROLLBACK_LINES } from './terminalBuffer';
-
 const DEFAULT_THEME = {
   background: '#1e1e1e',
   foreground: '#cccccc',
@@ -34,6 +31,8 @@ const ANSI_COLOR_MAP = [
   ['brightCyan', '--texra-terminal-ansiBrightCyan'],
   ['brightWhite', '--texra-terminal-ansiBrightWhite'],
 ] as const;
+
+const MIN_SCROLLBACK = 4_000;
 
 /** Maximum visible rows before terminal scrolls internally. */
 const MAX_VISIBLE_ROWS = 20;
@@ -143,7 +142,7 @@ export class TerminalOutput extends LitElement {
     this.terminal = new Terminal({
       disableStdin: true,
       convertEol: true,
-      scrollback: TERMINAL_SCROLLBACK_LINES,
+      scrollback: MIN_SCROLLBACK,
       fontFamily,
       fontSize: 12,
       theme,
@@ -247,7 +246,7 @@ export class TerminalOutput extends LitElement {
           this.renderedRowCount,
           updatePlan,
         );
-        const scrollback = Math.max(TERMINAL_SCROLLBACK_LINES, rowCount);
+        const scrollback = Math.max(MIN_SCROLLBACK, rowCount);
         if (terminal.options.scrollback !== scrollback) {
           terminal.options = {
             ...terminal.options,

--- a/packages/extension/src/progressView/frontend/components/terminalBuffer.ts
+++ b/packages/extension/src/progressView/frontend/components/terminalBuffer.ts
@@ -10,6 +10,10 @@ const ANSI_ERASE_LINE_PATTERN = new RegExp(`${ESCAPE_CHARACTER}\\[\\d*K`, 'g');
 
 const MAX_TAIL = 65536;
 
+/** Number of recent processed lines retained by terminal renderers. */
+export const TERMINAL_SCROLLBACK_LINES = 4_000;
+const TRUNCATION_MARKER = `[truncated to last ${TERMINAL_SCROLLBACK_LINES} lines]\n`;
+
 /** Strip ANSI codes and simulate \r overwrite within each newline-delimited line. */
 export function processTerminalText(text: string): string {
   // Strip any real null bytes so \x00 is unambiguous as our internal sentinel.
@@ -54,8 +58,10 @@ export function processTerminalText(text: string): string {
 export class TerminalBuffer {
   /** Raw partial-line buffer: unprocessed bytes after the last '\n', capped at 64 KiB */
   private rawTail = '';
-  /** Processed complete lines for terminal mode (up to and including the last '\n') */
+  /** Recent processed complete lines (up to and including the last '\n'). */
   private committedLines = '';
+  private committedLineCount = 0;
+  private historyTruncated = false;
 
   /** Text node currently attached to the committed <pre>. */
   private committedTextNode: Text | null = null;
@@ -79,6 +85,8 @@ export class TerminalBuffer {
   rebuild(fullText: string): void {
     this.rawTail = '';
     this.committedLines = '';
+    this.committedLineCount = 0;
+    this.historyTruncated = false;
     this.needsReset = true;
     this.append(fullText);
   }
@@ -88,8 +96,11 @@ export class TerminalBuffer {
     const combined = this.rawTail + newRaw;
     const lastNl = combined.lastIndexOf('\n');
     if (lastNl >= 0) {
-      this.committedLines += processTerminalText(combined.slice(0, lastNl + 1));
+      const processed = processTerminalText(combined.slice(0, lastNl + 1));
+      this.committedLines += processed;
+      this.committedLineCount += this.countLines(processed);
       this.rawTail = combined.slice(lastNl + 1);
+      this.trimCommittedLines();
     } else {
       // No newline: keep raw bytes so split ANSI sequences and cross-chunk \r
       // overwrites are handled correctly at render time. Cap unconditionally:
@@ -100,6 +111,33 @@ export class TerminalBuffer {
           ? combined.slice(combined.length - MAX_TAIL)
           : combined;
     }
+  }
+
+  /** Keep only recent complete lines, matching the terminal renderer's scrollback. */
+  private trimCommittedLines(): void {
+    const linesToDrop = this.committedLineCount - TERMINAL_SCROLLBACK_LINES;
+    if (linesToDrop <= 0) return;
+
+    let retainedStart = this.historyTruncated ? TRUNCATION_MARKER.length : 0;
+    for (let dropped = 0; dropped < linesToDrop; dropped += 1) {
+      retainedStart = this.committedLines.indexOf('\n', retainedStart) + 1;
+    }
+
+    this.committedLines =
+      TRUNCATION_MARKER + this.committedLines.slice(retainedStart);
+    this.committedLineCount = TERMINAL_SCROLLBACK_LINES;
+    this.historyTruncated = true;
+    // The retained text now has a different prefix, so incremental DOM append
+    // is invalid even when the replacement happens to be longer.
+    this.needsReset = true;
+  }
+
+  private countLines(text: string): number {
+    let count = 0;
+    for (const char of text) {
+      if (char === '\n') count += 1;
+    }
+    return count;
   }
 
   /** Imperatively sync committedLines into the supplied <pre> element. */

--- a/packages/extension/src/progressView/frontend/components/terminalBuffer.ts
+++ b/packages/extension/src/progressView/frontend/components/terminalBuffer.ts
@@ -10,9 +10,10 @@ const ANSI_ERASE_LINE_PATTERN = new RegExp(`${ESCAPE_CHARACTER}\\[\\d*K`, 'g');
 
 const MAX_TAIL = 65536;
 
-/** Number of recent processed lines retained by terminal renderers. */
-export const TERMINAL_SCROLLBACK_LINES = 4_000;
-const TRUNCATION_MARKER = `[truncated to last ${TERMINAL_SCROLLBACK_LINES} lines]\n`;
+/** Maximum number of recent complete lines retained by TerminalBuffer. */
+export const TERMINAL_BUFFER_MAX_LINES = 4_000;
+const TERMINAL_BUFFER_RETAIN_LINES = 3_600;
+const TRUNCATION_MARKER = '[... earlier terminal output truncated ...]\n';
 
 /** Strip ANSI codes and simulate \r overwrite within each newline-delimited line. */
 export function processTerminalText(text: string): string {
@@ -99,24 +100,21 @@ export class TerminalBuffer {
       const processed = processTerminalText(combined.slice(0, lastNl + 1));
       this.committedLines += processed;
       this.committedLineCount += this.countLines(processed);
-      this.rawTail = combined.slice(lastNl + 1);
+      this.rawTail = this.capRawTail(combined.slice(lastNl + 1));
       this.trimCommittedLines();
     } else {
       // No newline: keep raw bytes so split ANSI sequences and cross-chunk \r
       // overwrites are handled correctly at render time. Cap unconditionally:
       // if the tail ends with \r (potential CRLF split) the cap still preserves
       // that trailing \r, so the next arriving \n is correctly joined into \r\n.
-      this.rawTail =
-        combined.length > MAX_TAIL
-          ? combined.slice(combined.length - MAX_TAIL)
-          : combined;
+      this.rawTail = this.capRawTail(combined);
     }
   }
 
-  /** Keep only recent complete lines, matching the terminal renderer's scrollback. */
+  /** Compact to a lower watermark so prefix replacement is amortized. */
   private trimCommittedLines(): void {
-    const linesToDrop = this.committedLineCount - TERMINAL_SCROLLBACK_LINES;
-    if (linesToDrop <= 0) return;
+    if (this.committedLineCount <= TERMINAL_BUFFER_MAX_LINES) return;
+    const linesToDrop = this.committedLineCount - TERMINAL_BUFFER_RETAIN_LINES;
 
     let retainedStart = this.historyTruncated ? TRUNCATION_MARKER.length : 0;
     for (let dropped = 0; dropped < linesToDrop; dropped += 1) {
@@ -125,11 +123,15 @@ export class TerminalBuffer {
 
     this.committedLines =
       TRUNCATION_MARKER + this.committedLines.slice(retainedStart);
-    this.committedLineCount = TERMINAL_SCROLLBACK_LINES;
+    this.committedLineCount = TERMINAL_BUFFER_RETAIN_LINES;
     this.historyTruncated = true;
     // The retained text now has a different prefix, so incremental DOM append
     // is invalid even when the replacement happens to be longer.
     this.needsReset = true;
+  }
+
+  private capRawTail(text: string): string {
+    return text.length > MAX_TAIL ? text.slice(text.length - MAX_TAIL) : text;
   }
 
   private countLines(text: string): number {

--- a/src/test-kernel/progressView/TerminalBuffer.vitest.ts
+++ b/src/test-kernel/progressView/TerminalBuffer.vitest.ts
@@ -1,0 +1,103 @@
+// Third-party imports
+import { beforeAll, describe, expect, it } from 'vitest';
+
+// Local imports - test utilities
+import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
+
+useLitComponentTestDom(
+  () => import('@progressView/frontend/components/terminalBuffer'),
+);
+
+const EXPECTED_SCROLLBACK_LINES = 4_000;
+const TRUNCATION_MARKER = `[truncated to last ${EXPECTED_SCROLLBACK_LINES} lines]\n`;
+
+let TerminalBuffer: typeof import('@progressView/frontend/components/terminalBuffer').TerminalBuffer;
+
+beforeAll(async () => {
+  ({ TerminalBuffer } =
+    await import('@progressView/frontend/components/terminalBuffer'));
+});
+
+function renderedText(buffer: InstanceType<typeof TerminalBuffer>): string {
+  const pre = document.createElement('pre');
+  buffer.sync(pre);
+  return pre.textContent ?? '';
+}
+
+function numberedLines(start: number, count: number): string {
+  return Array.from(
+    { length: count },
+    (_, index) => `line ${start + index}\n`,
+  ).join('');
+}
+
+describe('TerminalBuffer', () => {
+  it('preserves committed output below the scrollback limit', () => {
+    const buffer = new TerminalBuffer();
+
+    buffer.append('first\nsecond\npartial');
+
+    expect(renderedText(buffer)).toBe('first\nsecond\n');
+    expect(buffer.tail).toBe('partial');
+  });
+
+  it('evicts the oldest processed lines predictably above the limit', () => {
+    const buffer = new TerminalBuffer();
+    const pre = document.createElement('pre');
+    buffer.append(numberedLines(0, EXPECTED_SCROLLBACK_LINES));
+    buffer.sync(pre);
+
+    buffer.append(numberedLines(EXPECTED_SCROLLBACK_LINES, 2));
+    buffer.sync(pre);
+
+    const text = pre.textContent ?? '';
+    expect(text.startsWith(TRUNCATION_MARKER)).toBe(true);
+    expect(text).not.toContain('line 0\n');
+    expect(text).not.toContain('line 1\n');
+    expect(text).toContain('line 2\n');
+    expect(text.endsWith(`line ${EXPECTED_SCROLLBACK_LINES + 1}\n`)).toBe(true);
+  });
+
+  it('preserves CR overwrite and split ANSI handling when trimming', () => {
+    const buffer = new TerminalBuffer();
+    buffer.append(numberedLines(0, EXPECTED_SCROLLBACK_LINES - 1));
+    buffer.append('\x1b[3');
+    buffer.append('1mprogress 10%\x1b[0m\rprogress');
+    buffer.append(' done\nlast\n');
+
+    const text = renderedText(buffer);
+    expect(text.startsWith(TRUNCATION_MARKER)).toBe(true);
+    expect(text).not.toContain('line 0\n');
+    expect(text).toContain('progress done\nlast\n');
+    expect(text).not.toContain('\x1b');
+  });
+
+  it('keeps retained committed state bounded after repeated appends', () => {
+    const buffer = new TerminalBuffer();
+
+    for (let batch = 0; batch < 20; batch += 1) {
+      buffer.append(numberedLines(batch * 500, 500));
+    }
+
+    const text = renderedText(buffer);
+    const retainedLines = text.slice(TRUNCATION_MARKER.length).split('\n');
+    expect(text.startsWith(TRUNCATION_MARKER)).toBe(true);
+    expect(retainedLines).toHaveLength(EXPECTED_SCROLLBACK_LINES + 1);
+    expect(retainedLines[0]).toBe('line 6000');
+    expect(retainedLines.at(-2)).toBe('line 9999');
+  });
+
+  it('rebuild replaces truncated history and resets the DOM text', () => {
+    const buffer = new TerminalBuffer();
+    const pre = document.createElement('pre');
+    buffer.append(numberedLines(0, EXPECTED_SCROLLBACK_LINES + 1));
+    buffer.sync(pre);
+    expect(pre.textContent?.startsWith(TRUNCATION_MARKER)).toBe(true);
+
+    buffer.rebuild('replacement\npartial');
+    buffer.sync(pre);
+
+    expect(pre.textContent).toBe('replacement\n');
+    expect(buffer.tail).toBe('partial');
+  });
+});

--- a/src/test-kernel/progressView/TerminalBuffer.vitest.ts
+++ b/src/test-kernel/progressView/TerminalBuffer.vitest.ts
@@ -1,5 +1,11 @@
 // Third-party imports
-import { beforeAll, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
+
+// Local imports - component under test
+import {
+  TERMINAL_BUFFER_MAX_LINES,
+  TerminalBuffer,
+} from '@progressView/frontend/components/terminalBuffer';
 
 // Local imports - test utilities
 import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
@@ -8,17 +14,10 @@ useLitComponentTestDom(
   () => import('@progressView/frontend/components/terminalBuffer'),
 );
 
-const EXPECTED_SCROLLBACK_LINES = 4_000;
-const TRUNCATION_MARKER = `[truncated to last ${EXPECTED_SCROLLBACK_LINES} lines]\n`;
+const TRUNCATION_MARKER = '[... earlier terminal output truncated ...]\n';
+const RETAINED_AFTER_COMPACTION = 3_600;
 
-let TerminalBuffer: typeof import('@progressView/frontend/components/terminalBuffer').TerminalBuffer;
-
-beforeAll(async () => {
-  ({ TerminalBuffer } =
-    await import('@progressView/frontend/components/terminalBuffer'));
-});
-
-function renderedText(buffer: InstanceType<typeof TerminalBuffer>): string {
+function renderedText(buffer: TerminalBuffer): string {
   const pre = document.createElement('pre');
   buffer.sync(pre);
   return pre.textContent ?? '';
@@ -31,66 +30,115 @@ function numberedLines(start: number, count: number): string {
   ).join('');
 }
 
+function retainedLines(text: string): string[] {
+  const content = text.startsWith(TRUNCATION_MARKER)
+    ? text.slice(TRUNCATION_MARKER.length)
+    : text;
+  return content.endsWith('\n') ? content.slice(0, -1).split('\n') : [content];
+}
+
 describe('TerminalBuffer', () => {
-  it('preserves committed output below the scrollback limit', () => {
+  it('preserves committed output below the complete-line limit', () => {
     const buffer = new TerminalBuffer();
+    buffer.append(numberedLines(0, TERMINAL_BUFFER_MAX_LINES - 1));
 
-    buffer.append('first\nsecond\npartial');
-
-    expect(renderedText(buffer)).toBe('first\nsecond\n');
-    expect(buffer.tail).toBe('partial');
+    const text = renderedText(buffer);
+    expect(text.startsWith(TRUNCATION_MARKER)).toBe(false);
+    expect(retainedLines(text)).toHaveLength(TERMINAL_BUFFER_MAX_LINES - 1);
+    expect(retainedLines(text)[0]).toBe('line 0');
   });
 
-  it('evicts the oldest processed lines predictably above the limit', () => {
+  it('preserves committed output exactly at the complete-line limit', () => {
+    const buffer = new TerminalBuffer();
+    buffer.append(numberedLines(0, TERMINAL_BUFFER_MAX_LINES));
+
+    const text = renderedText(buffer);
+    expect(text.startsWith(TRUNCATION_MARKER)).toBe(false);
+    expect(retainedLines(text)).toHaveLength(TERMINAL_BUFFER_MAX_LINES);
+    expect(retainedLines(text).at(-1)).toBe(
+      `line ${TERMINAL_BUFFER_MAX_LINES - 1}`,
+    );
+  });
+
+  it('compacts to the lower watermark immediately above the limit', () => {
+    const buffer = new TerminalBuffer();
+    buffer.append(numberedLines(0, TERMINAL_BUFFER_MAX_LINES + 1));
+
+    const text = renderedText(buffer);
+    const lines = retainedLines(text);
+    expect(text.startsWith(TRUNCATION_MARKER)).toBe(true);
+    expect(lines).toHaveLength(RETAINED_AFTER_COMPACTION);
+    expect(lines[0]).toBe(
+      `line ${TERMINAL_BUFFER_MAX_LINES + 1 - RETAINED_AFTER_COMPACTION}`,
+    );
+    expect(lines.at(-1)).toBe(`line ${TERMINAL_BUFFER_MAX_LINES}`);
+  });
+
+  it('keeps only the lower-watermark suffix when one chunk is far over the limit', () => {
+    const buffer = new TerminalBuffer();
+    const totalLines = TERMINAL_BUFFER_MAX_LINES + 2_000;
+    buffer.append(numberedLines(0, totalLines));
+
+    const lines = retainedLines(renderedText(buffer));
+    expect(lines).toHaveLength(RETAINED_AFTER_COMPACTION);
+    expect(lines[0]).toBe(`line ${totalLines - RETAINED_AFTER_COMPACTION}`);
+    expect(lines.at(-1)).toBe(`line ${totalLines - 1}`);
+  });
+
+  it('amortizes compaction across repeated line-at-a-time appends', () => {
     const buffer = new TerminalBuffer();
     const pre = document.createElement('pre');
-    buffer.append(numberedLines(0, EXPECTED_SCROLLBACK_LINES));
+    buffer.append(numberedLines(0, TERMINAL_BUFFER_MAX_LINES + 1));
     buffer.sync(pre);
+    const nodeAfterFirstCompaction = pre.firstChild;
 
-    buffer.append(numberedLines(EXPECTED_SCROLLBACK_LINES, 2));
+    for (
+      let line = TERMINAL_BUFFER_MAX_LINES + 1;
+      line <= TERMINAL_BUFFER_MAX_LINES + 400;
+      line += 1
+    ) {
+      buffer.append(`line ${line}\n`);
+      buffer.sync(pre);
+      expect(pre.firstChild).toBe(nodeAfterFirstCompaction);
+    }
+
+    expect(retainedLines(pre.textContent ?? '')[0]).toBe('line 401');
+
+    buffer.append(`line ${TERMINAL_BUFFER_MAX_LINES + 401}\n`);
     buffer.sync(pre);
-
-    const text = pre.textContent ?? '';
-    expect(text.startsWith(TRUNCATION_MARKER)).toBe(true);
-    expect(text).not.toContain('line 0\n');
-    expect(text).not.toContain('line 1\n');
-    expect(text).toContain('line 2\n');
-    expect(text.endsWith(`line ${EXPECTED_SCROLLBACK_LINES + 1}\n`)).toBe(true);
+    expect(pre.firstChild).not.toBe(nodeAfterFirstCompaction);
+    expect(retainedLines(pre.textContent ?? '')[0]).toBe('line 802');
   });
 
-  it('preserves CR overwrite and split ANSI handling when trimming', () => {
+  it('preserves CR overwrite and split ANSI handling across compaction', () => {
     const buffer = new TerminalBuffer();
-    buffer.append(numberedLines(0, EXPECTED_SCROLLBACK_LINES - 1));
+    buffer.append(numberedLines(0, TERMINAL_BUFFER_MAX_LINES));
     buffer.append('\x1b[3');
     buffer.append('1mprogress 10%\x1b[0m\rprogress');
-    buffer.append(' done\nlast\n');
+    buffer.append(' done\n');
 
     const text = renderedText(buffer);
     expect(text.startsWith(TRUNCATION_MARKER)).toBe(true);
-    expect(text).not.toContain('line 0\n');
-    expect(text).toContain('progress done\nlast\n');
+    expect(retainedLines(text)[0]).toBe('line 401');
+    expect(text.endsWith('progress done\n')).toBe(true);
     expect(text).not.toContain('\x1b');
   });
 
-  it('keeps retained committed state bounded after repeated appends', () => {
+  it('caps an oversized partial tail that follows complete lines', () => {
     const buffer = new TerminalBuffer();
+    const oversizedTail = `discard${'x'.repeat(70_000)}`;
 
-    for (let batch = 0; batch < 20; batch += 1) {
-      buffer.append(numberedLines(batch * 500, 500));
-    }
+    buffer.append(`complete\n${oversizedTail}`);
 
-    const text = renderedText(buffer);
-    const retainedLines = text.slice(TRUNCATION_MARKER.length).split('\n');
-    expect(text.startsWith(TRUNCATION_MARKER)).toBe(true);
-    expect(retainedLines).toHaveLength(EXPECTED_SCROLLBACK_LINES + 1);
-    expect(retainedLines[0]).toBe('line 6000');
-    expect(retainedLines.at(-2)).toBe('line 9999');
+    expect(renderedText(buffer)).toBe('complete\n');
+    expect(buffer.tail).toHaveLength(65_536);
+    expect(buffer.tail).toBe('x'.repeat(65_536));
   });
 
-  it('rebuild replaces truncated history and resets the DOM text', () => {
+  it('rebuild replaces truncated history and resets line and tail state', () => {
     const buffer = new TerminalBuffer();
     const pre = document.createElement('pre');
-    buffer.append(numberedLines(0, EXPECTED_SCROLLBACK_LINES + 1));
+    buffer.append(numberedLines(0, TERMINAL_BUFFER_MAX_LINES + 1));
     buffer.sync(pre);
     expect(pre.textContent?.startsWith(TRUNCATION_MARKER)).toBe(true);
 


### PR DESCRIPTION
## Summary

- retain at most 4,000 processed complete lines in the progress-view terminal buffer
- compact to a 3,600-line lower watermark so prefix eviction and DOM replacement are amortized rather than repeated for every new line
- preserve ANSI stripping, carriage-return overwrite handling, partial chunks, and incremental DOM appends
- cap oversized partial tails in both newline and no-newline input paths
- mark terminal output when older scrollback has been removed

Closes #9040

## Validation

- focused terminal suites: 13 passed
- full test suite: 7,492 passed, 4 skipped
- full workspace typecheck passed
- full TypeScript lint passed
- extension compile passed
- formatting and patch whitespace checks passed

## Scope

This bounds the fallback `TerminalBuffer` identified by the issue. xterm retains its existing independent scrollback policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to progress-view terminal rendering and scrollback; behavior is covered by new unit tests with no auth or data-path changes.
> 
> **Overview**
> **Long terminal-mode logs in the progress view no longer grow without limit.** The fallback `TerminalBuffer` now keeps at most **4,000** processed complete lines and compacts to a **3,600-line** watermark so eviction is batched rather than on every new line.
> 
> When older scrollback is dropped, committed output is prefixed with **`[... earlier terminal output truncated ...]`**. Compaction forces a DOM reset so incremental `<pre>` updates stay correct after the prefix changes. Partial-line tails still cap at 64 KiB via a shared `capRawTail` helper.
> 
> **CHANGELOG** documents the fix for Extension and Desktop. New **Vitest** coverage exercises limits, large single chunks, amortized compaction, ANSI/`\r` behavior after trim, tail capping, and `rebuild` after truncation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc14b2525c2ea29d389ee2bc88cc2a3869c1083d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->