### PR TITLE
docs: label workflow proposal snapshot

### DIFF
--- a/docs/proposals/2026-07-17-workflow-script-async-execution.local-before-pull.md
+++ b/docs/proposals/2026-07-17-workflow-script-async-execution.local-before-pull.md
@@ -1,5 +1,10 @@
 # Workflow script async execution: detach the run from the orchestrator turn
 
+> **Historical snapshot (not authoritative).** This file preserves the
+> local-before-pull state of the proposal. Refer to the
+> [canonical proposal](./2026-07-17-workflow-script-async-execution.md) for
+> the current, authoritative version.
+
 Status: audit + proposal → scoped to issues #8712 (core), #8713 (CLI cleanup)
 Date: 2026-07-17
 Prereqs shipped: durable named checkpoints (#8666/#8651), CLI progress projection (#8672), teachable contract + run log (#8681)


### PR DESCRIPTION
## Summary

This follow-up identifies `2026-07-17-workflow-script-async-execution.local-before-pull.md` as a historical, non-authoritative snapshot and links readers to the canonical workflow-script async-execution proposal. It preserves the requested timestamped filename and leaves the recorded proposal text unchanged.

This resolves the documentation ambiguity identified in the review of #9116.

## Validation

- `npm run format:check`
- `pre-commit run --all-files --verbose`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only clarification with no runtime, API, or behavioral changes.
> 
> **Overview**
> Adds a short **historical snapshot** notice at the top of `2026-07-17-workflow-script-async-execution.local-before-pull.md` so readers know it is not the live proposal and should use the [canonical doc](./2026-07-17-workflow-script-async-execution.md) instead.
> 
> The timestamped filename and the rest of the proposal text are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7b27bc6d8dcc51b7b1fc9105a8aed71db99c439. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->