### PR TITLE
fix: define extension singleton lifetimes

### DIFF
--- a/packages/extension/src/common/state/worktreeMemento.ts
+++ b/packages/extension/src/common/state/worktreeMemento.ts
@@ -4,6 +4,11 @@ import type * as vscode from 'vscode';
 /**
  * A `vscode.Memento`-compatible wrapper that transparently shares selected
  * repository-level workspace keys across git worktrees.
+ *
+ * Shared values are durable repository settings, not a cache. Their global
+ * namespaces intentionally survive workspace removal and extension sessions so
+ * settings return when a repository is reopened, re-cloned at the same path,
+ * or becomes available again after removable storage is reattached.
  */
 export class WorktreeMemento implements vscode.Memento {
   constructor(

--- a/packages/extension/src/frontend/comments/inlineComments.ts
+++ b/packages/extension/src/frontend/comments/inlineComments.ts
@@ -34,6 +34,9 @@ const THREAD_CONTEXT_OPEN = 'texraInlineCommentOpen';
 const THREAD_CONTEXT_RESOLVED = 'texraInlineCommentResolved';
 
 let controller: vscode.CommentController | undefined;
+// Threads intentionally share the controller's lifetime. VS Code exposes no
+// event for a thread being closed or deleted, and resolved threads remain
+// user-visible, reopenable, and readable by the agent. `disable` owns cleanup.
 const threads = new Map<string, vscode.CommentThread>();
 let sequence = 0;
 

--- a/packages/extension/src/frontend/ui/fileDecorations.ts
+++ b/packages/extension/src/frontend/ui/fileDecorations.ts
@@ -44,6 +44,7 @@ class TeXRAFileDecorationProvider implements vscode.FileDecorationProvider {
   }
 
   dispose(): void {
+    this.touched.clear();
     this._onDidChange.dispose();
   }
 }

--- a/src/test-kernel/frontend/OutputFileRunFactSubscriptions.vitest.ts
+++ b/src/test-kernel/frontend/OutputFileRunFactSubscriptions.vitest.ts
@@ -212,6 +212,9 @@ describe('output-file run fact frontend subscriptions', () => {
     ).toMatchObject({ badge: 'T', tooltip: 'Modified by TeXRA' });
 
     disposeContext(context);
+    expect(
+      provider.provideFileDecoration(vscode.Uri.file(writtenPath)),
+    ).toBeUndefined();
   });
 
   it('refreshes inline criticism only for live run facts while enabled', async () => {


### PR DESCRIPTION
## Summary

- document that inline comment threads intentionally share the VS Code comment controller lifetime because resolved threads remain visible, listable, and reopenable and the API exposes no safe close/delete trigger
- document that worktree-memento namespaces hold durable repository settings rather than cache entries, so workspace removal or temporary filesystem absence is not a safe pruning signal
- clear file-decoration session paths at the provider's existing disposal boundary and cover the cleanup

Closes #9053

## Adjudication

The three collections have independent policies. Automatic LRU, age, resolve-time, filesystem-existence, or workspace-removal eviction would silently discard user-visible state or durable settings. The only safe cleanup added is at an existing ownership boundary.

## Validation

- focused suites: 7 tests passed
- extension and test-kernel TypeScript checks passed
- ESLint and Prettier checks passed on all changed files
- patch whitespace check passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation plus session-scoped cleanup on an existing dispose path; no auth, persistence, or user-setting semantics changes beyond clearing in-memory badge state.
> 
> **Overview**
> Clarifies **why** three extension-held collections must not be pruned automatically: inline comment threads live for the comment controller’s lifetime (resolved threads stay visible and VS Code offers no close/delete hook; `disable` clears them), and worktree-memento global keys are **durable repo settings**, not a cache that workspace removal or missing disks should trim.
> 
> The only behavioral change is in the file-decoration provider: **`dispose` now clears the session `touched` path set** so badges do not linger after the provider is torn down. A focused test asserts decorations disappear after subscription disposal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26fc955f82c9589fd0c20252b5db7a244dbeb127. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->