### PR TITLE
fix: bound foreground subprocess output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ All notable changes to this project will be documented in this file.
   as the default Anthropic model. Opus 5 keeps the full 1M context window and
   adaptive thinking.
 
+#### Bug Fixes
+
+- **Large foreground shell commands use bounded memory** — command results
+  retain useful diagnostics from the beginning and end without buffering the
+  complete output in memory.
+
 ### Extension (VS Code) and Desktop
 
 #### Bug Fixes

--- a/src/shared/schemas/opResults.ts
+++ b/src/shared/schemas/opResults.ts
@@ -15,6 +15,8 @@ const ExecResultSchema = z.strictObject({
   timedOut: z.boolean().optional(),
   /** Exit code from the command (undefined if not available) */
   exitCode: z.int().optional(),
+  /** True when subprocess output exceeded the configured retained-output limit. */
+  outputLimitExceeded: z.boolean().optional(),
 });
 
 export type ExecResult = z.infer<typeof ExecResultSchema>;

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -282,6 +282,70 @@ describe('BashTool', () => {
     assert.equal(receivedSignal.aborted, false);
   });
 
+  it('incrementally retains bounded head and tail stdout across Unicode chunk boundaries', async () => {
+    const headMarker = 'HEAD🙂';
+    const tailMarker = 'TAIL🙂';
+    const emoji = '🙂';
+
+    vi.spyOn(execUtils, 'executeCommand').mockImplementation(
+      async (_command, options = {}) => {
+        assert.equal(options.buffer, false);
+        options.onStdout?.(`HEAD${emoji[0]}`);
+        options.onStdout?.(`${emoji[1]}\n`);
+        options.onStdout?.('x'.repeat(100_000));
+        options.onStdout?.(`\n${tailMarker}\n`);
+        return {
+          success: true,
+          stdout: null,
+          stderr: null,
+          timedOut: false,
+          exitCode: 0,
+        };
+      },
+    );
+
+    const result = await new BashTool().call({ command: 'large-output' });
+    assert.equal(result.status, 'executed');
+    const output = String(result.output);
+    assert.ok(output.startsWith(headMarker));
+    assert.ok(output.endsWith(tailMarker));
+    assert.match(output, /characters elided from stdout/);
+    assert.ok(!output.includes('x'.repeat(60_000)));
+    assert.ok(!output.includes('\ufffd'));
+    assert.ok(output.length < 55_000);
+  });
+
+  it('keeps bounded stderr and stdout separate and ordered on large failures', async () => {
+    vi.spyOn(execUtils, 'executeCommand').mockImplementation(
+      async (_command, options = {}) => {
+        options.onStdout?.('STDOUT_HEAD\n');
+        options.onStdout?.('o'.repeat(100_000));
+        options.onStdout?.('\nSTDOUT_TAIL');
+        options.onStderr?.('STDERR_HEAD\n');
+        options.onStderr?.('e'.repeat(100_000));
+        options.onStderr?.('\nSTDERR_TAIL');
+        return {
+          success: false,
+          stdout: null,
+          stderr: null,
+          timedOut: false,
+          exitCode: 9,
+        };
+      },
+    );
+
+    const result = await new BashTool().call({ command: 'large-failure' });
+    assert.equal(result.status, 'error');
+    const error = result.error ?? '';
+    assert.ok(error.includes('STDERR_HEAD'));
+    assert.ok(error.includes('STDERR_TAIL'));
+    assert.ok(error.includes('characters elided from stderr'));
+    assert.ok(error.includes('STDOUT_HEAD'));
+    assert.ok(error.includes('STDOUT_TAIL'));
+    assert.ok(error.includes('characters elided from stdout'));
+    assert.ok(error.indexOf('STDERR_HEAD') < error.indexOf('STDOUT_HEAD'));
+  });
+
   it('keeps result status out of visible tool log output', async () => {
     const runTrace = createRunTrace(
       'ToolStatusLogTest' as StreamTabId,

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -282,6 +282,142 @@ describe('BashTool', () => {
     assert.equal(receivedSignal.aborted, false);
   });
 
+  it.each([
+    { name: '50,000 characters', text: 'a'.repeat(50_000) },
+    { name: '50,001 characters', text: 'b'.repeat(50_001) },
+    { name: '52,000 characters', text: 'c'.repeat(52_000) },
+    { name: 'exactly 54,000 characters', text: 'd'.repeat(54_000) },
+  ])('reconstructs $name exactly without a marker', async ({ text }) => {
+    vi.spyOn(execUtils, 'executeCommand').mockImplementation(
+      async (_command, options = {}) => {
+        options.onStdout?.(text.slice(0, 777));
+        options.onStdout?.(text.slice(777));
+        return {
+          success: true,
+          stdout: null,
+          stderr: null,
+          timedOut: false,
+          exitCode: 0,
+        };
+      },
+    );
+
+    const result = await new BashTool().call({ command: 'boundary-output' });
+    assert.equal(result.output, text);
+    assert.ok(!String(result.output).includes('characters elided'));
+  });
+
+  it('marks exactly one character elided at 54,001 normalized characters', async () => {
+    const text = 'h'.repeat(4_000) + 'X' + 't'.repeat(50_000);
+    vi.spyOn(execUtils, 'executeCommand').mockImplementation(
+      async (_command, options = {}) => {
+        options.onStdout?.(text);
+        return {
+          success: true,
+          stdout: null,
+          stderr: null,
+          timedOut: false,
+          exitCode: 0,
+        };
+      },
+    );
+
+    const result = await new BashTool().call({ command: 'one-elided' });
+    assert.equal(
+      result.output,
+      `${'h'.repeat(4_000)}\n\n[... 1 characters elided from stdout ...]\n\n${'t'.repeat(50_000)}`,
+    );
+  });
+
+  it.each([
+    {
+      name: 'leading and trailing whitespace',
+      chunks: [' \t\n'.repeat(40_000), '  body', '  ', '\r\n'.repeat(40_000)],
+      expected: 'body',
+    },
+    {
+      name: 'all whitespace',
+      chunks: [' \t\n'.repeat(40_000), '\r\n'.repeat(40_000)],
+      expected: '',
+    },
+    {
+      name: 'internal whitespace',
+      chunks: ['  alpha', ' '.repeat(20_000), 'omega  '],
+      expected: `alpha${' '.repeat(20_000)}omega`,
+    },
+  ])('matches full-stream trim for $name', async ({ chunks, expected }) => {
+    vi.spyOn(execUtils, 'executeCommand').mockImplementation(
+      async (_command, options = {}) => {
+        for (const chunk of chunks) options.onStdout?.(chunk);
+        return {
+          success: true,
+          stdout: null,
+          stderr: null,
+          timedOut: false,
+          exitCode: 0,
+        };
+      },
+    );
+
+    const result = await new BashTool().call({ command: 'whitespace-output' });
+    assert.equal(result.output, expected);
+  });
+
+  it('counts only normalized internal whitespace as elided', async () => {
+    const internalWhitespace = ' '.repeat(60_000);
+    vi.spyOn(execUtils, 'executeCommand').mockImplementation(
+      async (_command, options = {}) => {
+        options.onStdout?.(`  A${internalWhitespace}`);
+        options.onStdout?.(`B${' '.repeat(100_000)}`);
+        return {
+          success: true,
+          stdout: null,
+          stderr: null,
+          timedOut: false,
+          exitCode: 0,
+        };
+      },
+    );
+
+    const result = await new BashTool().call({ command: 'whitespace-gap' });
+    const output = String(result.output);
+    assert.match(
+      output,
+      /\[\.\.\. 6,002 characters elided from stdout \.\.\.\]/,
+    );
+    assert.ok(output.startsWith(`A${' '.repeat(3_999)}`));
+    assert.ok(output.endsWith(`${' '.repeat(49_999)}B`));
+  });
+
+  it.each([
+    {
+      name: 'head boundary',
+      text: `${'a'.repeat(3_999)}🙂${'b'.repeat(60_000)}`,
+    },
+    {
+      name: 'tail boundary',
+      text: `${'a'.repeat(4_001)}🙂${'b'.repeat(50_000)}`,
+    },
+  ])('does not split surrogate pairs at the $name', async ({ text }) => {
+    vi.spyOn(execUtils, 'executeCommand').mockImplementation(
+      async (_command, options = {}) => {
+        options.onStdout?.(text);
+        return {
+          success: true,
+          stdout: null,
+          stderr: null,
+          timedOut: false,
+          exitCode: 0,
+        };
+      },
+    );
+
+    const result = await new BashTool().call({ command: 'unicode-boundary' });
+    const output = String(result.output);
+    assert.ok(!/[\ud800-\udbff](?![\udc00-\udfff])/.test(output));
+    assert.ok(!/(?<![\ud800-\udbff])[\udc00-\udfff]/.test(output));
+  });
+
   it('incrementally retains bounded head and tail stdout across Unicode chunk boundaries', async () => {
     const headMarker = 'HEAD🙂';
     const tailMarker = 'TAIL🙂';
@@ -434,13 +570,18 @@ describe('BashTool', () => {
       'x'.repeat(MAX_TOOL_RESULT_TEXT_LENGTH) +
       'TAIL_ERROR_DETAIL '.repeat(5000);
 
-    vi.spyOn(execUtils, 'executeCommand').mockResolvedValue({
-      success: false,
-      stdout: null,
-      stderr: hugeStderr,
-      timedOut: false,
-      exitCode: 1,
-    });
+    vi.spyOn(execUtils, 'executeCommand').mockImplementation(
+      async (_command, options = {}) => {
+        options.onStderr?.(hugeStderr);
+        return {
+          success: false,
+          stdout: null,
+          stderr: null,
+          timedOut: false,
+          exitCode: 1,
+        };
+      },
+    );
 
     const result = await new BashTool().call({ command: 'latexmk -pdf p.tex' });
     assert.equal(result.status, 'error');
@@ -771,6 +912,39 @@ describe('BashTool', () => {
       vi.mocked(execUtils.executeCommand).mock.calls[0]?.[0],
       'test -f proof.tex',
     );
+  });
+
+  it('keeps bounded streamed stdout and stderr in timeout feedback', async () => {
+    vi.spyOn(execUtils, 'executeCommand').mockImplementation(
+      async (_command, options = {}) => {
+        options.onStdout?.(`STDOUT_HEAD${'o'.repeat(100_000)}STDOUT_TAIL`);
+        options.onStderr?.(`STDERR_HEAD${'e'.repeat(100_000)}STDERR_TAIL`);
+        return {
+          success: false,
+          stdout: null,
+          stderr: null,
+          timedOut: true,
+          exitCode: 1,
+        };
+      },
+    );
+
+    const result = await new BashTool().call({
+      command: 'slow-command',
+      timeout: 1_000,
+    });
+    assert.equal(result.status, 'error');
+    const error = result.error ?? '';
+    assert.ok(error.startsWith('Foreground command timed out after 1s.'));
+    assert.match(
+      error,
+      /<stdout>STDOUT_HEAD[\s\S]*characters elided from stdout[\s\S]*STDOUT_TAIL<\/stdout>/,
+    );
+    assert.match(
+      error,
+      /<stderr>STDERR_HEAD[\s\S]*characters elided from stderr[\s\S]*STDERR_TAIL<\/stderr>/,
+    );
+    assert.ok(error.includes('run_in_background: true'));
   });
 
   it('finalizes deferred progress card when foreground bash is aborted', async () => {

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -381,9 +381,10 @@ describe('BashTool', () => {
 
     const result = await new BashTool().call({ command: 'whitespace-gap' });
     const output = String(result.output);
-    assert.match(
-      output,
-      /\[\.\.\. 6,002 characters elided from stdout \.\.\.\]/,
+    assert.ok(
+      output.includes(
+        `[... ${(6_002).toLocaleString()} characters elided from stdout ...]`,
+      ),
     );
     assert.ok(output.startsWith(`A${' '.repeat(3_999)}`));
     assert.ok(output.endsWith(`${' '.repeat(49_999)}B`));

--- a/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
+++ b/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
@@ -120,6 +120,35 @@ describe('BashTool error feedback', () => {
     expect(toolResult?.output).toContain('stdout failure guidance');
   });
 
+  it.each([
+    {
+      name: 'spawn failure',
+      stderr: 'spawn missing-command ENOENT',
+      exitCode: 127,
+    },
+    {
+      name: 'cancellation',
+      stderr: 'Command aborted by user',
+      exitCode: 130,
+    },
+  ])(
+    'preserves $name fallback diagnostics without stream chunks',
+    async ({ stderr, exitCode }) => {
+      stubBashApprovalDisabled();
+      vi.spyOn(execUtils, 'executeCommand').mockResolvedValueOnce({
+        success: false,
+        stdout: null,
+        stderr,
+        timedOut: false,
+        exitCode,
+      });
+
+      const result = await new BashTool().call({ command: 'missing-command' });
+      expect(result.status).toBe('error');
+      expect(result.error).toContain(stderr);
+    },
+  );
+
   it('rejects shell-level backgrounding before command execution', async () => {
     stubBashApprovalDisabled();
     const executeSpy = vi.spyOn(execUtils, 'executeCommand');

--- a/src/test-kernel/tools/grep.vitest.ts
+++ b/src/test-kernel/tools/grep.vitest.ts
@@ -78,6 +78,32 @@ describe('GrepTool execution', () => {
     expect(executeSpy.mock.calls[0]?.[1]?.maxBuffer).toBe(100_000_000);
   });
 
+  it('reports output-limit overflow without paginating partial matches', async () => {
+    vi.spyOn(execUtils, 'executeCommand').mockResolvedValue({
+      success: false,
+      stdout: 'partial-match-one\npartial-match-two',
+      stderr: 'maxBuffer exceeded',
+      timedOut: false,
+      exitCode: 2,
+      outputLimitExceeded: true,
+    });
+
+    const result = await new GrepTool().call({
+      pattern: 'item',
+      output_mode: 'content',
+      offset: 1,
+      head_limit: 1,
+    });
+
+    expect(result.status).toBe('error');
+    expect(result.error).toContain('retained-output ceiling');
+    expect(result.error).toContain('Narrow the search path or pattern');
+    expect(result.error).toContain('glob/type filters');
+    expect(result.error).toContain('Pagination with offset/head_limit');
+    expect(result.error).not.toContain('Regex error');
+    expect(result.error).not.toContain('partial-match');
+  });
+
   it('preserves ripgrep error classification', async () => {
     vi.spyOn(execUtils, 'executeCommand').mockResolvedValue({
       success: false,

--- a/src/test-kernel/tools/grep.vitest.ts
+++ b/src/test-kernel/tools/grep.vitest.ts
@@ -1,11 +1,13 @@
 // Third-party imports
 import { strict as assert } from 'node:assert';
-import { describe, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Standard library imports
 
 // Local imports
-import { buildArguments, type GrepInput } from '@tools/grep';
+import { setupPlatform } from '@test/support/setupPlatform';
+import { buildArguments, GrepTool, type GrepInput } from '@tools/grep';
+import * as execUtils from '@utils/system/execUtils';
 
 describe('buildArguments', () => {
   // output_mode is required after transform normalizes nullish to 'content'
@@ -40,5 +42,58 @@ describe('buildArguments', () => {
     assert.ok(!argsWithFalse.includes('--fixed-strings'));
     assert.ok(!argsWithNull.includes('--fixed-strings'));
     assert.ok(!argsWithUndefined.includes('--fixed-strings'));
+  });
+});
+
+describe('GrepTool execution', () => {
+  setupPlatform({ workspacePath: process.cwd() });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('preserves total-count and offset/head_limit pagination semantics', async () => {
+    const executeSpy = vi.spyOn(execUtils, 'executeCommand').mockResolvedValue({
+      success: true,
+      stdout: 'one\n\ntwo\nthree\nfour\n',
+      stderr: null,
+      timedOut: false,
+      exitCode: 0,
+    });
+
+    const result = await new GrepTool().call({
+      pattern: 'item',
+      output_mode: 'content',
+      offset: 1,
+      head_limit: 2,
+    });
+
+    expect(result).toMatchObject({
+      status: 'executed',
+      summary: expect.stringContaining('Found 2 of 4 matches'),
+    });
+    expect(result.output).toBe(
+      'two\nthree\n\n[Showing 2 of 4 results. Use offset=3 to see more.]',
+    );
+    expect(executeSpy.mock.calls[0]?.[1]?.maxBuffer).toBe(100_000_000);
+  });
+
+  it('preserves ripgrep error classification', async () => {
+    vi.spyOn(execUtils, 'executeCommand').mockResolvedValue({
+      success: false,
+      stdout: null,
+      stderr: 'regex parse error: unclosed group',
+      timedOut: false,
+      exitCode: 2,
+    });
+
+    const result = await new GrepTool().call({
+      pattern: '(',
+      output_mode: 'content',
+    });
+
+    expect(result.status).toBe('error');
+    expect(result.error).toContain('Regex error: regex parse error');
+    expect(result.error).toContain('literal: true');
   });
 });

--- a/src/test-kernel/tools/lean/LakeCommandsOutput.vitest.ts
+++ b/src/test-kernel/tools/lean/LakeCommandsOutput.vitest.ts
@@ -1,0 +1,38 @@
+// Third-party imports
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ execa: vi.fn() }));
+
+vi.mock('execa', () => ({ execa: mocks.execa }));
+
+// Local imports
+import { runLakeCommand } from '@tools/lean/direct/lakeCommands';
+
+describe('runLakeCommand output failures', () => {
+  beforeEach(() => {
+    mocks.execa.mockReset();
+  });
+
+  it('does not report maxBuffer overflow with partial stdout as success', async () => {
+    mocks.execa.mockResolvedValue({
+      failed: true,
+      isMaxBuffer: true,
+      exitCode: 0,
+      stdout: 'partial build output',
+      stderr: '',
+      shortMessage: 'Command failed: stdout maxBuffer exceeded',
+    });
+
+    const result = await runLakeCommand({
+      workspaceRoot: '/workspace',
+      lakeCommand: 'lake',
+      args: ['build'],
+    });
+
+    expect(result).toEqual({
+      exitCode: -1,
+      stdout: 'partial build output',
+      stderr: 'Command failed: stdout maxBuffer exceeded',
+    });
+  });
+});

--- a/src/test-kernel/tools/lean/LakeCommandsOutput.vitest.ts
+++ b/src/test-kernel/tools/lean/LakeCommandsOutput.vitest.ts
@@ -1,3 +1,10 @@
+/**
+ * Mocked execa-result normalization for states that are impractical to produce
+ * at small scale, especially `failed: true` + `isMaxBuffer: true` + exit 0.
+ * Kept separate from LeanTools.vitest.ts because this file's hoisted module
+ * mock would contaminate that suite's real Node subprocess integration tests.
+ */
+
 // Third-party imports
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 

--- a/src/test-kernel/tools/lean/LakeCommandsOutput.vitest.ts
+++ b/src/test-kernel/tools/lean/LakeCommandsOutput.vitest.ts
@@ -13,6 +13,30 @@ describe('runLakeCommand output failures', () => {
     mocks.execa.mockReset();
   });
 
+  it('keeps stderr empty for ordinary nonzero exits with stdout only', async () => {
+    mocks.execa.mockResolvedValue({
+      failed: true,
+      isMaxBuffer: false,
+      timedOut: false,
+      exitCode: 7,
+      stdout: 'build failed in target A',
+      stderr: '',
+      shortMessage: 'Command failed with exit code 7',
+    });
+
+    const result = await runLakeCommand({
+      workspaceRoot: '/workspace',
+      lakeCommand: 'lake',
+      args: ['build'],
+    });
+
+    expect(result).toEqual({
+      exitCode: 7,
+      stdout: 'build failed in target A',
+      stderr: '',
+    });
+  });
+
   it('does not report maxBuffer overflow with partial stdout as success', async () => {
     mocks.execa.mockResolvedValue({
       failed: true,

--- a/src/test-kernel/tools/lean/LeanTools.vitest.ts
+++ b/src/test-kernel/tools/lean/LeanTools.vitest.ts
@@ -185,7 +185,7 @@ describe('runLakeCommand mutex', () => {
     rmSync(workspaceB, { recursive: true, force: true });
   });
 
-  it('keeps the current 4 MiB tail cap and truncation marker', async () => {
+  it('keeps the current 4,194,304-character tail cap and truncation marker', async () => {
     const result = await runLakeCommand({
       workspaceRoot: workspaceA,
       lakeCommand: NODE,

--- a/src/test-kernel/tools/lean/LeanTools.vitest.ts
+++ b/src/test-kernel/tools/lean/LeanTools.vitest.ts
@@ -185,6 +185,54 @@ describe('runLakeCommand mutex', () => {
     rmSync(workspaceB, { recursive: true, force: true });
   });
 
+  it('keeps the current 4 MiB tail cap and truncation marker', async () => {
+    const result = await runLakeCommand({
+      workspaceRoot: workspaceA,
+      lakeCommand: NODE,
+      args: [
+        '-e',
+        `process.stdout.write('HEAD_MARKER' + 'x'.repeat(${4 * 1024 * 1024 + 100}) + 'TAIL_MARKER')`,
+      ],
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.startsWith('…[output truncated]…\n')).toBe(true);
+    expect(result.stdout).not.toContain('HEAD_MARKER');
+    expect(result.stdout.endsWith('TAIL_MARKER')).toBe(true);
+    expect(result.stdout.length).toBe(
+      4 * 1024 * 1024 + '…[output truncated]…\n'.length,
+    );
+  });
+
+  it('preserves non-zero exit diagnostics', async () => {
+    const result = await runLakeCommand({
+      workspaceRoot: workspaceA,
+      lakeCommand: NODE,
+      args: [
+        '-e',
+        `process.stdout.write('build context'); process.stderr.write('compile failed'); process.exit(7)`,
+      ],
+    });
+
+    expect(result).toEqual({
+      exitCode: 7,
+      stdout: 'build context',
+      stderr: 'compile failed',
+    });
+  });
+
+  it('preserves timeout diagnostics', async () => {
+    const result = await runLakeCommand({
+      workspaceRoot: workspaceA,
+      lakeCommand: NODE,
+      args: ['-e', 'setTimeout(() => {}, 60_000)'],
+      timeoutMs: 20,
+    });
+
+    expect(result.exitCode).toBe(-1);
+    expect(result.stderr).toContain('timed out after 20 milliseconds');
+  });
+
   it('serializes calls against the same workspace when `serialize: true`', async () => {
     const startedAt = performance.now();
     const [first, second] = await Promise.all([

--- a/src/test-kernel/utils/system/SystemUtils.vitest.ts
+++ b/src/test-kernel/utils/system/SystemUtils.vitest.ts
@@ -55,6 +55,9 @@ describe('executeCommand', () => {
     expectTypeOf<ExecuteCommandOptions['encoding']>().toEqualTypeOf<
       'utf8' | 'utf-8' | 'utf16le' | undefined
     >();
+    expectTypeOf<ExecuteCommandOptions['maxBuffer']>().toEqualTypeOf<
+      number | undefined
+    >();
     expectTypeOf<ExecuteCommandOptions['stdout']>().toEqualTypeOf<
       'pipe' | 'ignore' | 'inherit' | 'overlapped' | undefined
     >();
@@ -91,6 +94,28 @@ describe('executeCommand', () => {
     assert.ok(result.success);
     assert.strictEqual(result.stdout, 'fallback');
     assert.strictEqual(result.stderr, null);
+  });
+
+  it('decodes streamed Unicode split across byte chunks', async () => {
+    let streamed = '';
+    const result = await executeCommand(
+      [
+        process.execPath,
+        '-e',
+        `process.stdout.write(Buffer.from([0xf0, 0x9f])); ` +
+          `setTimeout(() => process.stdout.write(Buffer.from([0x99, 0x82])), 20);`,
+      ],
+      {
+        buffer: false,
+        onStdout: (chunk) => {
+          streamed += chunk;
+        },
+      },
+    );
+
+    assert.equal(result.success, true);
+    assert.equal(result.stdout, null);
+    assert.equal(streamed, '🙂');
   });
 
   it('aborts shell command process groups including children', async () => {

--- a/src/test-kernel/utils/system/SystemUtils.vitest.ts
+++ b/src/test-kernel/utils/system/SystemUtils.vitest.ts
@@ -118,6 +118,46 @@ describe('executeCommand', () => {
     assert.equal(streamed, '🙂');
   });
 
+  it('flushes pending multibyte stdout and stderr exactly once on stream close', async () => {
+    let streamedStdout = '';
+    let streamedStderr = '';
+    const result = await executeCommand(
+      [
+        process.execPath,
+        '-e',
+        `const fs = require('node:fs'); ` +
+          `fs.writeSync(1, Buffer.from([0xf0, 0x9f])); ` +
+          `fs.writeSync(2, Buffer.from([0xe2, 0x82])); ` +
+          `process.stdout.destroy(); process.stderr.destroy();`,
+      ],
+      {
+        buffer: false,
+        onStdout: (chunk) => {
+          streamedStdout += chunk;
+        },
+        onStderr: (chunk) => {
+          streamedStderr += chunk;
+        },
+      },
+    );
+
+    assert.equal(result.success, true);
+    assert.equal(streamedStdout, '\ufffd');
+    assert.equal(streamedStderr, '\ufffd');
+  });
+
+  it('reports maxBuffer overflow as an error instead of partial success', async () => {
+    const result = await executeCommand(
+      [process.execPath, '-e', `process.stdout.write('x'.repeat(10_000))`],
+      { maxBuffer: 64 },
+    );
+
+    assert.equal(result.success, false);
+    assert.equal(result.exitCode, 2);
+    assert.ok(result.stdout && result.stdout.length > 0);
+    assert.match(result.stderr ?? '', /maxBuffer exceeded/i);
+  });
+
   it('aborts shell command process groups including children', async () => {
     if (process.platform === 'win32') return;
 

--- a/src/test-kernel/utils/system/SystemUtils.vitest.ts
+++ b/src/test-kernel/utils/system/SystemUtils.vitest.ts
@@ -96,6 +96,20 @@ describe('executeCommand', () => {
     assert.strictEqual(result.stderr, null);
   });
 
+  it('keeps stderr empty for ordinary nonzero exits with stdout only', async () => {
+    const result = await executeCommand([
+      process.execPath,
+      '-e',
+      `process.stdout.write('failure details'); process.exit(7)`,
+    ]);
+
+    assert.equal(result.success, false);
+    assert.equal(result.exitCode, 7);
+    assert.equal(result.stdout, 'failure details');
+    assert.equal(result.stderr, null);
+    assert.equal(result.outputLimitExceeded, undefined);
+  });
+
   it('decodes streamed Unicode split across byte chunks', async () => {
     let streamed = '';
     const result = await executeCommand(
@@ -154,6 +168,7 @@ describe('executeCommand', () => {
 
     assert.equal(result.success, false);
     assert.equal(result.exitCode, 2);
+    assert.equal(result.outputLimitExceeded, true);
     assert.ok(result.stdout && result.stdout.length > 0);
     assert.match(result.stderr ?? '', /maxBuffer exceeded/i);
   });

--- a/src/test-kernel/utils/system/SystemUtils.vitest.ts
+++ b/src/test-kernel/utils/system/SystemUtils.vitest.ts
@@ -160,6 +160,30 @@ describe('executeCommand', () => {
     assert.equal(streamedStderr, '\ufffd');
   });
 
+  it('disables maxBuffer enforcement when buffering is disabled', async () => {
+    const outputChars = 10_000;
+    let streamedChars = 0;
+    const result = await executeCommand(
+      [
+        process.execPath,
+        '-e',
+        `process.stdout.write('x'.repeat(${outputChars}))`,
+      ],
+      {
+        buffer: false,
+        maxBuffer: 64,
+        onStdout: (chunk) => {
+          streamedChars += chunk.length;
+        },
+      },
+    );
+
+    assert.equal(result.success, true);
+    assert.equal(result.stdout, null);
+    assert.equal(streamedChars, outputChars);
+    assert.equal(result.outputLimitExceeded, undefined);
+  });
+
   it('reports maxBuffer overflow as an error instead of partial success', async () => {
     const result = await executeCommand(
       [process.execPath, '-e', `process.stdout.write('x'.repeat(10_000))`],

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -13,6 +13,10 @@ import {
   markOwnedExecutionLeaseUndurable,
   onOwnedExecutionLeaseLost,
 } from '@agent/storage/executionLease';
+import {
+  TOOL_RESULT_TRUNCATION_HEAD_CHARS,
+  TOOL_RESULT_TRUNCATION_TAIL_CHARS,
+} from '@agent/modelHandlers/contextManagementConstants';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import {
   getCurrentToolContexts,
@@ -74,6 +78,8 @@ const BACKGROUND_OUTPUT_TAIL_CHARS = 12_000;
 const BACKGROUND_OUTPUT_HEAD_CHARS = 1_000;
 /** Max chars logged to the child stream tab to prevent unbounded memory growth. */
 const BACKGROUND_LOG_CAP_CHARS = 200_000;
+const FOREGROUND_OUTPUT_HEAD_CHARS = TOOL_RESULT_TRUNCATION_HEAD_CHARS;
+const FOREGROUND_OUTPUT_TAIL_CHARS = TOOL_RESULT_TRUNCATION_TAIL_CHARS;
 const SHELL_BACKGROUNDING_PATTERN =
   /(?:^|[\s;])nohup\b[^\n;]*(?<![>&])&(?![>&])/;
 const SHELL_BACKGROUNDING_MESSAGE =
@@ -84,6 +90,47 @@ function backgroundBashTerminalStatus(success: boolean) {
   return projectRunOutcome(
     deriveRunOutcome({ failed: !success, cancelled: false }),
   ).executionStatus;
+}
+
+interface BoundedOutputCapture {
+  append(chunk: string): void;
+  text(streamName: 'stdout' | 'stderr'): string | null;
+}
+
+function createBoundedOutputCapture(
+  headChars: number,
+  tailChars: number,
+): BoundedOutputCapture {
+  let head = '';
+  let tail = '';
+  let totalChars = 0;
+
+  return {
+    append(chunk: string): void {
+      totalChars += chunk.length;
+      head = appendHead(head, chunk, headChars);
+      tail = appendTail(tail, chunk, tailChars);
+    },
+    text(streamName: 'stdout' | 'stderr'): string | null {
+      if (totalChars <= tail.length) return tail.trim() || null;
+
+      const elidedChars = Math.max(0, totalChars - head.length - tail.length);
+      const overlapChars = Math.max(0, head.length + tail.length - totalChars);
+      const nonOverlappingTail =
+        overlapChars > 0
+          ? appendTail('', tail, tail.length - overlapChars)
+          : tail;
+      const retained =
+        elidedChars > 0
+          ? `${head}
+
+[... ${elidedChars.toLocaleString()} characters elided from ${streamName} ...]
+
+${nonOverlappingTail}`
+          : head + nonOverlappingTail;
+      return retained.trim() || null;
+    },
+  };
 }
 
 const BashInputSchema = z.strictObject({
@@ -203,22 +250,40 @@ export class BashTool extends defineTool({
     ctx: ToolCallContext | undefined,
     cwd?: string,
   ): Promise<ToolResult> {
+    const stdout = createBoundedOutputCapture(
+      FOREGROUND_OUTPUT_HEAD_CHARS,
+      FOREGROUND_OUTPUT_TAIL_CHARS,
+    );
+    const stderr = createBoundedOutputCapture(
+      FOREGROUND_OUTPUT_HEAD_CHARS,
+      FOREGROUND_OUTPUT_TAIL_CHARS,
+    );
     const startedAt = Date.now();
     const result = await executeCommand(command, {
       cwd,
-      truncate: true,
+      buffer: false,
       timeout: timeoutMs,
-      onStdout: ctx?.hooks?.onToolOutput,
-      onStderr: ctx?.hooks?.onToolOutput,
+      onStdout: (chunk) => {
+        stdout.append(chunk);
+        ctx?.hooks?.onToolOutput?.(chunk);
+      },
+      onStderr: (chunk) => {
+        stderr.append(chunk);
+        ctx?.hooks?.onToolOutput?.(chunk);
+      },
       signal: ctx?.signal,
     });
+    // Spawn/cancellation diagnostics can come from executeCommand itself
+    // rather than either subprocess stream, so retain those as a fallback.
+    const retainedStdout = stdout.text('stdout') ?? result.stdout;
+    const retainedStderr = stderr.text('stderr') ?? result.stderr;
 
     if (result.timedOut) {
       const parts: string[] = [
         `Foreground command timed out after ${timeoutMs / 1000}s.`,
       ];
-      if (result.stdout) parts.push(`<stdout>${result.stdout}</stdout>`);
-      if (result.stderr) parts.push(`<stderr>${result.stderr}</stderr>`);
+      if (retainedStdout) parts.push(`<stdout>${retainedStdout}</stdout>`);
+      if (retainedStderr) parts.push(`<stderr>${retainedStderr}</stderr>`);
       parts.push(
         `To fix, either:\n` +
           `- Increase the timeout parameter up to 600s (600000ms): { "timeout": 600000 }\n` +
@@ -235,12 +300,12 @@ export class BashTool extends defineTool({
       return {
         status: 'executed',
         summary: `Executed: ${preview} (exit 0, ${duration})`,
-        output: result.stdout ?? '',
+        output: retainedStdout ?? '',
       };
     }
     // Many CLI tools (including latexmk) write errors to stdout, not stderr
     const errorOutput =
-      [result.stderr, result.stdout].filter(Boolean).join('\n') ||
+      [retainedStderr, retainedStdout].filter(Boolean).join('\n') ||
       'No error output available';
     throw new ToolError(`Command failed (${duration}): ${errorOutput}`);
   }

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -104,15 +104,60 @@ function createBoundedOutputCapture(
   let head = '';
   let tail = '';
   let totalChars = 0;
+  let hasNonWhitespace = false;
+  let pendingWhitespaceHead = '';
+  let pendingWhitespaceTail = '';
+  let pendingWhitespaceChars = 0;
+
+  const appendText = (text: string): void => {
+    totalChars += text.length;
+    head = appendHead(head, text, headChars);
+    tail = appendTail(tail, text, tailChars);
+  };
+
+  const appendPendingWhitespace = (text: string): void => {
+    if (!text) return;
+    pendingWhitespaceChars += text.length;
+    pendingWhitespaceHead = appendHead(pendingWhitespaceHead, text, headChars);
+    pendingWhitespaceTail = appendTail(pendingWhitespaceTail, text, tailChars);
+  };
+
+  const commitPendingWhitespace = (): void => {
+    if (pendingWhitespaceChars === 0) return;
+
+    totalChars += pendingWhitespaceChars;
+    head = appendHead(head, pendingWhitespaceHead, headChars);
+    tail =
+      pendingWhitespaceChars >= tailChars
+        ? pendingWhitespaceTail
+        : appendTail(tail, pendingWhitespaceTail, tailChars);
+    pendingWhitespaceHead = '';
+    pendingWhitespaceTail = '';
+    pendingWhitespaceChars = 0;
+  };
 
   return {
     append(chunk: string): void {
-      totalChars += chunk.length;
-      head = appendHead(head, chunk, headChars);
-      tail = appendTail(tail, chunk, tailChars);
+      let text = chunk;
+      if (!hasNonWhitespace) {
+        text = text.trimStart();
+        if (!text) return;
+        hasNonWhitespace = true;
+      }
+
+      const withoutTrailingWhitespace = text.trimEnd();
+      if (!withoutTrailingWhitespace) {
+        appendPendingWhitespace(text);
+        return;
+      }
+
+      commitPendingWhitespace();
+      appendText(withoutTrailingWhitespace);
+      appendPendingWhitespace(text.slice(withoutTrailingWhitespace.length));
     },
     text(streamName: 'stdout' | 'stderr'): string | null {
-      if (totalChars <= tail.length) return tail.trim() || null;
+      if (!hasNonWhitespace) return null;
+      if (totalChars <= tail.length) return tail || null;
 
       const elidedChars = Math.max(0, totalChars - head.length - tail.length);
       const overlapChars = Math.max(0, head.length + tail.length - totalChars);
@@ -120,15 +165,9 @@ function createBoundedOutputCapture(
         overlapChars > 0
           ? appendTail('', tail, tail.length - overlapChars)
           : tail;
-      const retained =
-        elidedChars > 0
-          ? `${head}
-
-[... ${elidedChars.toLocaleString()} characters elided from ${streamName} ...]
-
-${nonOverlappingTail}`
-          : head + nonOverlappingTail;
-      return retained.trim() || null;
+      return elidedChars > 0
+        ? `${head}\n\n[... ${elidedChars.toLocaleString()} characters elided from ${streamName} ...]\n\n${nonOverlappingTail}`
+        : head + nonOverlappingTail;
     },
   };
 }

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -70,7 +70,7 @@ const CHANNEL = 'GrepTool';
 // Pagination and total counts require draining all of ripgrep's output. Keep
 // execa 10's current per-stream ceiling explicit instead of coupling this
 // failure boundary to a dependency default or killing rg after one page.
-const GREP_MAX_BUFFER_BYTES = 100_000_000;
+const GREP_MAX_BUFFER_CHARS = 100_000_000;
 
 export function buildArguments(
   input: GrepInput,
@@ -144,11 +144,19 @@ export class GrepTool extends defineTool({
       cwd: root,
       channel: CHANNEL,
       truncate: false,
-      maxBuffer: GREP_MAX_BUFFER_BYTES,
+      maxBuffer: GREP_MAX_BUFFER_CHARS,
       // Cancellation for the owning agent run — parallel batches must be
       // able to terminate large-repo rg subprocesses on interrupt.
       signal: getCurrentToolCallContext()?.signal,
     });
+
+    if (result.outputLimitExceeded) {
+      throw new ToolError(
+        `Search output exceeded the ${GREP_MAX_BUFFER_CHARS.toLocaleString()}-character retained-output ceiling.\n` +
+          `Narrow the search path or pattern, or use glob/type filters. ` +
+          `Pagination with offset/head_limit does not avoid draining the total ripgrep output.`,
+      );
+    }
 
     // ripgrep exit codes: 0 = matches found, 1 = no matches, 2+ = error
     const exitCode = result.exitCode ?? (result.success ? 0 : 1);

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -67,6 +67,10 @@ const GrepInputSchema = z.strictObject({
 export type GrepInput = z.infer<typeof GrepInputSchema>;
 
 const CHANNEL = 'GrepTool';
+// Pagination and total counts require draining all of ripgrep's output. Keep
+// execa 10's current per-stream ceiling explicit instead of coupling this
+// failure boundary to a dependency default or killing rg after one page.
+const GREP_MAX_BUFFER_BYTES = 100_000_000;
 
 export function buildArguments(
   input: GrepInput,
@@ -140,6 +144,7 @@ export class GrepTool extends defineTool({
       cwd: root,
       channel: CHANNEL,
       truncate: false,
+      maxBuffer: GREP_MAX_BUFFER_BYTES,
       // Cancellation for the owning agent run — parallel batches must be
       // able to terminate large-repo rg subprocesses on interrupt.
       signal: getCurrentToolCallContext()?.signal,

--- a/src/tools/lean/direct/lakeCommands.ts
+++ b/src/tools/lean/direct/lakeCommands.ts
@@ -87,12 +87,16 @@ async function executeLake(
     windowsHide: true,
     stdin: 'ignore',
   });
+  const stdout = result.stdout ?? '';
   const stderr = result.stderr ?? '';
   const stderrOrMessage =
-    stderr || result.stdout ? stderr : (result.shortMessage ?? '');
+    stderr || (result.failed || !stdout ? (result.shortMessage ?? '') : '');
   return {
-    exitCode: result.exitCode ?? -1,
-    stdout: capOutput(result.stdout ?? ''),
+    exitCode:
+      result.failed && (!result.exitCode || result.isMaxBuffer)
+        ? -1
+        : (result.exitCode ?? -1),
+    stdout: capOutput(stdout),
     stderr: capOutput(stderrOrMessage),
   };
 }

--- a/src/tools/lean/direct/lakeCommands.ts
+++ b/src/tools/lean/direct/lakeCommands.ts
@@ -14,6 +14,11 @@ import { Mutex } from 'async-mutex';
 
 const LAKE_RUN_TIMEOUT_MS = 10 * 60 * 1000;
 const LAKE_MAX_OUTPUT_CHARS = 4 * 1024 * 1024;
+// Keep execa 10's current per-stream failure ceiling explicit. capOutput()
+// preserves successful chatty builds by retaining their last 4 MiB, while
+// this higher byte cap prevents a dependency-default change from silently
+// changing when a command is terminated for excessive output.
+const LAKE_PROCESS_MAX_BUFFER_BYTES = 100_000_000;
 
 // Keys are resolved workspace roots — a small bounded set per process lifetime,
 // so we don't bother evicting entries after release.
@@ -71,14 +76,14 @@ export async function runLakeCommand(
 async function executeLake(
   options: LakeCommandOptions,
 ): Promise<LakeCommandResult> {
-  // execa buffers stdout/stderr up to its default maxBuffer before resolving.
-  // capOutput() then trims the returned strings to LAKE_MAX_OUTPUT_CHARS. This
-  // avoids aborting chatty-but-successful builds at the cost of buffering more
-  // during the run.
+  // Lake remains buffer-then-cap deliberately: preserving the current tail
+  // result and complete exit diagnostics is simpler than duplicating bash's
+  // head/tail streaming policy for this serialized, lower-risk path.
   const result = await execa(options.lakeCommand, [...options.args], {
     cwd: options.workspaceRoot,
     timeout: options.timeoutMs ?? LAKE_RUN_TIMEOUT_MS,
     reject: false,
+    maxBuffer: LAKE_PROCESS_MAX_BUFFER_BYTES,
     windowsHide: true,
     stdin: 'ignore',
   });

--- a/src/tools/lean/direct/lakeCommands.ts
+++ b/src/tools/lean/direct/lakeCommands.ts
@@ -15,10 +15,10 @@ import { Mutex } from 'async-mutex';
 const LAKE_RUN_TIMEOUT_MS = 10 * 60 * 1000;
 const LAKE_MAX_OUTPUT_CHARS = 4 * 1024 * 1024;
 // Keep execa 10's current per-stream failure ceiling explicit. capOutput()
-// preserves successful chatty builds by retaining their last 4 MiB, while
-// this higher byte cap prevents a dependency-default change from silently
+// preserves successful chatty builds by retaining their last 4,194,304 characters, while
+// this higher character cap prevents a dependency-default change from silently
 // changing when a command is terminated for excessive output.
-const LAKE_PROCESS_MAX_BUFFER_BYTES = 100_000_000;
+const LAKE_PROCESS_MAX_BUFFER_CHARS = 100_000_000;
 
 // Keys are resolved workspace roots — a small bounded set per process lifetime,
 // so we don't bother evicting entries after release.
@@ -83,14 +83,19 @@ async function executeLake(
     cwd: options.workspaceRoot,
     timeout: options.timeoutMs ?? LAKE_RUN_TIMEOUT_MS,
     reject: false,
-    maxBuffer: LAKE_PROCESS_MAX_BUFFER_BYTES,
+    maxBuffer: LAKE_PROCESS_MAX_BUFFER_CHARS,
     windowsHide: true,
     stdin: 'ignore',
   });
   const stdout = result.stdout ?? '';
   const stderr = result.stderr ?? '';
+  const shouldUseShortMessage =
+    result.isMaxBuffer ||
+    result.exitCode === undefined ||
+    result.timedOut ||
+    !stdout;
   const stderrOrMessage =
-    stderr || (result.failed || !stdout ? (result.shortMessage ?? '') : '');
+    stderr || (shouldUseShortMessage ? (result.shortMessage ?? '') : '');
   return {
     exitCode:
       result.failed && (!result.exitCode || result.isMaxBuffer)

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -43,6 +43,28 @@ function normalizeEncoding(encoding: ExecEncoding = 'utf8'): ExecaTextEncoding {
   return encoding === 'utf-8' ? 'utf8' : encoding;
 }
 
+function subscribeDecodedOutput(
+  stream: NodeJS.ReadableStream,
+  encoding: ExecaTextEncoding,
+  onOutput: (chunk: string) => void,
+): void {
+  const decoder = new StringDecoder(encoding);
+  let finalized = false;
+  const finalize = (): void => {
+    if (finalized) return;
+    finalized = true;
+    const text = decoder.end();
+    if (text) onOutput(text);
+  };
+
+  stream.on('data', (chunk: Buffer | string) => {
+    const text = typeof chunk === 'string' ? chunk : decoder.write(chunk);
+    if (text) onOutput(text);
+  });
+  stream.once('end', finalize);
+  stream.once('close', finalize);
+}
+
 function commandEnv(
   workspacePath: string,
   envOverrides?: Record<string, string>,
@@ -356,26 +378,10 @@ export async function executeCommand(
 
     // Subscribe to stdout/stderr streams for live output if callbacks provided
     if (options.onStdout && subprocess.stdout) {
-      const decoder = new StringDecoder(encoding);
-      subprocess.stdout.on('data', (chunk: Buffer | string) => {
-        const text = typeof chunk === 'string' ? chunk : decoder.write(chunk);
-        if (text) options.onStdout!(text);
-      });
-      subprocess.stdout.on('end', () => {
-        const text = decoder.end();
-        if (text) options.onStdout!(text);
-      });
+      subscribeDecodedOutput(subprocess.stdout, encoding, options.onStdout);
     }
     if (options.onStderr && subprocess.stderr) {
-      const decoder = new StringDecoder(encoding);
-      subprocess.stderr.on('data', (chunk: Buffer | string) => {
-        const text = typeof chunk === 'string' ? chunk : decoder.write(chunk);
-        if (text) options.onStderr!(text);
-      });
-      subprocess.stderr.on('end', () => {
-        const text = decoder.end();
-        if (text) options.onStderr!(text);
-      });
+      subscribeDecodedOutput(subprocess.stderr, encoding, options.onStderr);
     }
 
     const result = await subprocess;
@@ -385,10 +391,15 @@ export async function executeCommand(
     // `shellAborted` covers the hand-rolled shell-form path; `isCanceled`
     // covers the array-form path, aborted natively via execa's `cancelSignal`.
     const aborted = shellAborted || (result.isCanceled ?? false);
-    const exitCode = result.exitCode ?? (aborted ? 130 : 1);
+    const maxBufferExceeded = result.isMaxBuffer ?? false;
+    const exitCode = maxBufferExceeded
+      ? 2
+      : (result.exitCode ?? (aborted ? 130 : 1));
     const timedOut = (result.timedOut ?? false) || shellTimedOut;
     const normalizedStderr =
-      aborted && !stderr ? 'Command aborted by user' : stderr;
+      aborted && !stderr
+        ? 'Command aborted by user'
+        : stderr || (result.failed ? (result.shortMessage ?? '') : '');
 
     if (!options.quiet) {
       logCommandStderr(logChannel, normalizedStderr, options.truncate);

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -82,25 +82,29 @@ function resultFromProcessOutput(
   stdout: string | null | undefined,
   stderr: string | null | undefined,
   exitCode: number,
-  timedOut = false,
+  flags: { timedOut?: boolean; outputLimitExceeded?: boolean } = {},
 ): ExecResult {
+  const timedOut = flags.timedOut ?? false;
   return {
-    success: exitCode === 0 && !timedOut,
+    success: exitCode === 0 && !timedOut && !flags.outputLimitExceeded,
     stdout: normalizeOutput(stdout),
     stderr: normalizeOutput(stderr),
     timedOut,
     exitCode,
+    ...(flags.outputLimitExceeded ? { outputLimitExceeded: true } : {}),
   };
 }
 
 function resultFromExecutionError(err: unknown): ExecResult {
   if (err instanceof ExecaError) {
+    const outputLimitExceeded = err.isMaxBuffer ?? false;
     return {
       success: false,
       stdout: normalizeOutput(`${err.stdout ?? ''}`),
       stderr: normalizeOutput(`${err.stderr || toErrorMessage(err)}`),
       timedOut: err.timedOut ?? false,
-      exitCode: err.exitCode ?? 127,
+      exitCode: outputLimitExceeded ? 2 : (err.exitCode ?? 127),
+      ...(outputLimitExceeded ? { outputLimitExceeded: true } : {}),
     };
   }
 
@@ -203,7 +207,7 @@ export async function executeCommand(
     onPid?: (pid: number) => void;
     /** Set to false to skip buffering stdout/stderr in memory (use with onStdout/onStderr). */
     buffer?: boolean;
-    /** Maximum bytes execa may buffer per output stream before terminating the process. */
+    /** Maximum decoded characters execa may retain per output stream before terminating the process. */
     maxBuffer?: number;
     stdout?: ExecOutput;
     stderr?: ExecOutput;
@@ -220,12 +224,7 @@ export async function executeCommand(
 
   try {
     if (options.signal?.aborted) {
-      return resultFromProcessOutput(
-        null,
-        'Command aborted by user',
-        130,
-        false,
-      );
+      return resultFromProcessOutput(null, 'Command aborted by user', 130);
     }
 
     const workspacePath = options.cwd ?? WorkspaceFS.getPath();
@@ -396,21 +395,21 @@ export async function executeCommand(
       ? 2
       : (result.exitCode ?? (aborted ? 130 : 1));
     const timedOut = (result.timedOut ?? false) || shellTimedOut;
+    const shouldUseShortMessage =
+      maxBufferExceeded || result.exitCode === undefined || timedOut;
     const normalizedStderr =
       aborted && !stderr
         ? 'Command aborted by user'
-        : stderr || (result.failed ? (result.shortMessage ?? '') : '');
+        : stderr || (shouldUseShortMessage ? (result.shortMessage ?? '') : '');
 
     if (!options.quiet) {
       logCommandStderr(logChannel, normalizedStderr, options.truncate);
     }
 
-    return resultFromProcessOutput(
-      stdout,
-      normalizedStderr,
-      exitCode,
+    return resultFromProcessOutput(stdout, normalizedStderr, exitCode, {
       timedOut,
-    );
+      outputLimitExceeded: maxBufferExceeded,
+    });
   } catch (err) {
     if (!options.quiet) {
       logger.error(
@@ -473,7 +472,7 @@ export function executeCommandSync(
       logCommandStderr(logChannel, stderr, options.truncate);
     }
 
-    return resultFromProcessOutput(stdout, stderr, exitCode, timedOut);
+    return resultFromProcessOutput(stdout, stderr, exitCode, { timedOut });
   } catch (err) {
     if (!options.quiet) {
       logger.error(

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -1,5 +1,6 @@
 // Third-party imports
 import * as path from 'node:path';
+import { StringDecoder } from 'node:string_decoder';
 
 import {
   execa,
@@ -180,6 +181,8 @@ export async function executeCommand(
     onPid?: (pid: number) => void;
     /** Set to false to skip buffering stdout/stderr in memory (use with onStdout/onStderr). */
     buffer?: boolean;
+    /** Maximum bytes execa may buffer per output stream before terminating the process. */
+    maxBuffer?: number;
     stdout?: ExecOutput;
     stderr?: ExecOutput;
     /** Abort signal used to terminate the subprocess and any shell children. */
@@ -209,15 +212,17 @@ export async function executeCommand(
     }
 
     const env = commandEnv(workspacePath, options.env);
+    const encoding = normalizeEncoding(options.encoding);
 
     const execaOptions: Options = {
       cwd: workspacePath,
       env,
-      encoding: normalizeEncoding(options.encoding),
+      encoding,
       timeout: options.timeout,
       reject: false,
       input: options.stdin,
       buffer: options.buffer,
+      maxBuffer: options.maxBuffer,
       stdout: options.stdout,
       stderr: options.stderr,
     };
@@ -351,13 +356,25 @@ export async function executeCommand(
 
     // Subscribe to stdout/stderr streams for live output if callbacks provided
     if (options.onStdout && subprocess.stdout) {
+      const decoder = new StringDecoder(encoding);
       subprocess.stdout.on('data', (chunk: Buffer | string) => {
-        options.onStdout!(String(chunk));
+        const text = typeof chunk === 'string' ? chunk : decoder.write(chunk);
+        if (text) options.onStdout!(text);
+      });
+      subprocess.stdout.on('end', () => {
+        const text = decoder.end();
+        if (text) options.onStdout!(text);
       });
     }
     if (options.onStderr && subprocess.stderr) {
+      const decoder = new StringDecoder(encoding);
       subprocess.stderr.on('data', (chunk: Buffer | string) => {
-        options.onStderr!(String(chunk));
+        const text = typeof chunk === 'string' ? chunk : decoder.write(chunk);
+        if (text) options.onStderr!(text);
+      });
+      subprocess.stderr.on('end', () => {
+        const text = decoder.end();
+        if (text) options.onStderr!(text);
       });
     }
 


### PR DESCRIPTION
## Summary

- stream foreground bash stdout and stderr without execa's full in-memory buffers
- retain independent 4,000-character heads and 50,000-character tails with exact omitted-character markers and prior trim semantics
- preserve live output, timeout, cancellation, spawn, and failure formatting, including Unicode split across chunks
- make grep and lake's existing execa 100,000,000-character ceilings explicit while preserving total-count pagination and lake tail diagnostics
- distinguish output-limit failures so grep never paginates partial results or mislabels them as regex errors
- surface maxBuffer failures correctly when execa returns `failed: true` with exit code 0

Closes #9052

## Validation

- focused subprocess suites: 74 passed
- full suite: 7,520 passed, 4 skipped
- full workspace typecheck passed
- full TypeScript lint passed
- `compile:fast` passed
- formatting and patch whitespace checks passed

## Per-call-site policy

- foreground bash: incremental bounded head/tail retention
- grep: drains to completion under an explicit ceiling because totals and pagination require the full result set
- lake: remains serialized buffer-then-cap under an explicit ceiling, preserving its existing 4,194,304-character tail contract

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core subprocess execution and bash tool output shaping used on every shell command; behavior is heavily tested but mistakes could truncate diagnostics or misclassify failures.
> 
> **Overview**
> **Foreground bash** no longer buffers full command output in memory. It runs with `buffer: false`, incrementally keeps a **4k head / 50k tail** per stdout and stderr (aligned with tool-result truncation), inserts exact **characters elided** markers, preserves trim/Unicode chunk semantics, and still forwards chunks to live hooks. Timeout and failure paths use the retained streams; spawn/cancel diagnostics from `executeCommand` still fall back when no stream data arrived.
> 
> **`executeCommand`** gains UTF-8-safe streaming via `StringDecoder`, optional **`maxBuffer`**, and an **`outputLimitExceeded`** flag on `ExecResult` when execa hits max buffer (treated as failure, exit code 2). Buffered mode enforces limits; **`buffer: false`** skips maxBuffer enforcement for streaming consumers.
> 
> **Grep** sets an explicit **100M** `maxBuffer` (pagination still needs the full ripgrep drain) and surfaces a dedicated error when output exceeds that ceiling instead of paginating partial matches or mislabeling regex failures.
> 
> **Lake commands** keep buffer-then-cap behavior but pin the same **100M** process ceiling and tighten failure handling so max-buffer / ambiguous exits are not reported as success with empty stderr.
> 
> Tests and changelog document the bounded-memory behavior and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 563cac6f15380312533b3c56a083dad81776ad60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Test organization

 is intentionally separate: it hoists an  mock to exercise synthetic maxBuffer result states (, , exit code 0).  uses real Node subprocesses for mutex, timeout, and retained-tail integration; sharing the hoisted mock would invalidate those tests or require disproportionate module-cache resets.