### PR TITLE
refactor(runtime): drop ExecutionRegistry's unread stop-result union and runtime-host thread

### DIFF
--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -271,7 +271,6 @@ export function createChatSessionController(
     session.interruptedStreamId = session.streamId;
     defaultSession().executions.stopAgentStream(session.streamId, {
       detachActiveChildren: detachSubagentsOnStop(),
-      runtimeHost: session.runtimeHost,
     });
   };
 
@@ -771,7 +770,6 @@ export function createChatSessionController(
     }
     current.executions.stopAgentStream(streamId, {
       detachActiveChildren: true,
-      runtimeHost: session.runtimeHost,
     });
   };
 

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -240,7 +240,6 @@ export class DesktopProgressBridge {
           });
           this.session.executions.stopAgentStream(stream, {
             detachActiveChildren: detachSubagentsOnStop(),
-            runtimeHost: this.runtimeHost,
           });
         },
         cleanupDeletedStream: (stream) => {

--- a/packages/extension/src/commands/agent/agentCommands.ts
+++ b/packages/extension/src/commands/agent/agentCommands.ts
@@ -5,13 +5,11 @@ import * as vscode from 'vscode';
 import { detachSubagentsOnStop } from '@agent/runtime/detachSubagentsOnStop';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { notifyFollowUpSent } from '@agent/followUp/ToolUseFollowUp';
-import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import type { StreamTabId } from '@shared/schemas';
 
 export function stopAgent(streamId: StreamTabId): void {
   defaultSession().executions.stopAgentStream(streamId, {
     detachActiveChildren: detachSubagentsOnStop(),
-    runtimeHost: extensionAgentRuntimeHost,
   });
 }
 

--- a/packages/extension/src/frontend/review/AgentReviewRunController.ts
+++ b/packages/extension/src/frontend/review/AgentReviewRunController.ts
@@ -60,7 +60,6 @@ export class AgentReviewRunController {
     if (!handle) return;
     if (run.session.executions.getHandle(handle.executionId) !== handle) return;
     run.session.executions.stopAgentStream(handle.childStreamId, {
-      runtimeHost: handle.runtimeHost,
       detachActiveChildren: detachSubagentsOnStop(),
     });
   }

--- a/src/agent/runtime/ExecutionSubscriptionBinder.ts
+++ b/src/agent/runtime/ExecutionSubscriptionBinder.ts
@@ -14,7 +14,6 @@
 import { createChannelTrace } from '@agent/trace';
 import type { ExecutionHandle } from '@agent/runtime/ExecutionHandle';
 import type { ExecutionRegistry } from '@agent/runtime/executionRegistry';
-import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { sendFollowUp } from '@agent/followUp/ToolUseFollowUp';
 import type { StreamTabId } from '@shared/schemas';
 import { DELIVERY_TAG } from '@shared/deliveryTags';
@@ -85,7 +84,6 @@ class ExecutionSubscription implements Disposable {
   constructor(
     private readonly streamId: StreamTabId,
     handle: ExecutionHandle,
-    private readonly runtimeHost: AgentRuntimeHost,
     private readonly registry: Pick<
       ExecutionRegistry,
       'addListener' | 'getHandle' | 'getStatus'
@@ -207,11 +205,7 @@ export class ExecutionSubscriptionBinder {
    * not currently tracked — terminal executions cannot be subscribed (use
    * `executions view` to read the final report).
    */
-  bind(
-    streamId: StreamTabId,
-    executionId: string,
-    runtimeHost: AgentRuntimeHost,
-  ): void {
+  bind(streamId: StreamTabId, executionId: string): void {
     this.ensureReleaseHook();
 
     const handle = this.registry.getHandle(executionId);
@@ -231,7 +225,6 @@ export class ExecutionSubscriptionBinder {
     const subscription = new ExecutionSubscription(
       streamId,
       handle,
-      runtimeHost,
       this.registry,
       this.logger,
       () => this.removeBoundKey(streamId, executionId),

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -15,7 +15,6 @@ import {
   ExecutionLeaseLostError,
   markOwnedExecutionLeaseUndurable,
 } from '@agent/storage/executionLease';
-import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { SessionApprovals } from '@agent/runtime/streamApprovalQueue';
 import {
@@ -52,36 +51,8 @@ import { SessionEventHub } from './SessionEventHub';
 
 const logger = createChannelTrace('executionRegistry');
 
-export interface StopAgentStreamOptions {
-  readonly detachActiveChildren?: boolean;
-  readonly runtimeHost?: AgentRuntimeHost;
-}
-
-type StopAgentChildPolicy = 'cascade' | 'detach';
-
-export type StopAgentStreamResult =
-  | {
-      readonly kind: 'interrupted';
-      readonly streamId: StreamTabId;
-      readonly childPolicy: StopAgentChildPolicy;
-    }
-  | {
-      readonly kind: 'marked_stopped';
-      readonly streamId: StreamTabId;
-      readonly childPolicy: StopAgentChildPolicy;
-    }
-  | {
-      readonly kind: 'no_target';
-      readonly streamId: StreamTabId;
-      readonly childPolicy: StopAgentChildPolicy;
-    }
-  | {
-      readonly kind: 'missing_runtime_host';
-      readonly streamId: StreamTabId;
-      readonly childPolicy: 'detach';
-    };
-
-export interface KillExecutionOptions {
+/** Child policy shared by `kill()` and `stopAgentStream()`. */
+export interface ExecutionStopOptions {
   readonly detachActiveChildren?: boolean;
 }
 
@@ -510,7 +481,7 @@ export class ExecutionRegistry {
   }
 
   /** Terminate an execution via its handle. Returns true on success. */
-  kill(executionId: string, options: KillExecutionOptions = {}): boolean {
+  kill(executionId: string, options: ExecutionStopOptions = {}): boolean {
     const handle = this.handles.get(executionId);
     if (!handle) return false;
     const visited = new Set<string>();
@@ -518,11 +489,7 @@ export class ExecutionRegistry {
       options.detachActiveChildren === true &&
       handle instanceof AgentExecutionHandle
     ) {
-      this.detachActiveChildren(
-        handle.childStreamId,
-        handle.runtimeHost,
-        visited,
-      );
+      this.detachActiveChildren(handle.childStreamId, visited);
     }
     const result = this.terminate(handle, visited, {
       cascadeChildren: options.detachActiveChildren !== true,
@@ -649,7 +616,6 @@ export class ExecutionRegistry {
    */
   detachActiveChildren(
     parentStreamId: StreamTabId,
-    _runtimeHost: AgentRuntimeHost,
     visited: Set<string> = new Set(),
   ): void {
     for (const handle of this.handles.values()) {
@@ -676,25 +642,15 @@ export class ExecutionRegistry {
    */
   stopAgentStream(
     streamId: StreamTabId,
-    options: StopAgentStreamOptions = {},
-  ): StopAgentStreamResult {
+    options: ExecutionStopOptions = {},
+  ): void {
     const rootHandle = this.getAgentHandleByStream(streamId);
-    const runtimeHost = options.runtimeHost ?? rootHandle?.runtimeHost;
-    const childPolicy =
-      options.detachActiveChildren === true ? 'detach' : 'cascade';
     // Shared across the child sweep and the root cascade so each execution in
     // the chain is interrupted exactly once.
     const visited = new Set<string>();
 
     if (options.detachActiveChildren === true) {
-      if (!runtimeHost) {
-        return {
-          kind: 'missing_runtime_host',
-          streamId,
-          childPolicy: 'detach',
-        };
-      }
-      this.detachActiveChildren(streamId, runtimeHost, visited);
+      this.detachActiveChildren(streamId, visited);
     } else {
       this.interruptActiveChildren(streamId, visited, {
         cascadeChildren: true,
@@ -706,14 +662,12 @@ export class ExecutionRegistry {
           cascadeChildren: options.detachActiveChildren !== true,
         })
       : false;
-    if (stopped) {
-      return { kind: 'interrupted', streamId, childPolicy };
-    }
-    if (!runtimeHost) {
-      return { kind: 'no_target', streamId, childPolicy };
-    }
+    // `terminate()` already publishes CANCELLED for a stream it owned; an
+    // ownerless (or already-untracked) stream still needs the write. The
+    // stream-status machine rejects the transition out of a terminal phase,
+    // so a finished stream keeps its outcome.
+    if (stopped) return;
     this.cancelStreamStatus(streamId);
-    return { kind: 'marked_stopped', streamId, childPolicy };
   }
 
   /** Get active subagent and process children for a parent stream. */
@@ -753,19 +707,6 @@ export class ExecutionRegistry {
       s.delete(cb);
       if (s.size === 0) this.persistentListeners.delete(executionId);
     };
-  }
-
-  /**
-   * Observe the current handle immediately, then every replacement or removal.
-   * Registering before the initial read closes the usual get/listen race.
-   */
-  observeHandle(
-    executionId: string,
-    cb: (handle: ExecutionHandle | undefined) => void,
-  ): () => void {
-    const detach = this.addListener(executionId, cb);
-    cb(this.handles.get(executionId));
-    return detach;
   }
 
   /** Observe handle registrations, replacements, and removals across all ids. */

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -166,7 +166,7 @@ describe('executionRegistry', () => {
     }
   });
 
-  it('observes the current handle, replacements, and removal in order', () => {
+  it('observes handle replacements and removal in order', () => {
     const registry = new ExecutionRegistry();
     const executionId = 'exec-observe-handle';
     const streamId = 'stream-observe-handle' as StreamTabId;
@@ -192,14 +192,14 @@ describe('executionRegistry', () => {
     );
     registry.track(first);
     const seen: unknown[] = [];
-    const detach = registry.observeHandle(executionId, (handle) => {
+    const detach = registry.addListener(executionId, (handle) => {
       seen.push(handle);
     });
 
     registry.track(second);
     registry.untrack(executionId);
 
-    expect(seen).toEqual([first, second, undefined]);
+    expect(seen).toEqual([second, undefined]);
     expect(registrations).toEqual([first, second, undefined]);
     detach();
     detachRegistrations();
@@ -988,15 +988,7 @@ describe('executionRegistry', () => {
       childHandle.attachInterruptHandler({ interrupt: childInterrupt });
       registry.track(childHandle);
 
-      expect(
-        registry.stopAgentStream(rootStreamId, {
-          runtimeHost: explicit.host,
-        }),
-      ).toEqual({
-        kind: 'interrupted',
-        streamId: rootStreamId,
-        childPolicy: 'cascade',
-      });
+      registry.stopAgentStream(rootStreamId);
 
       expect(rootInterrupt).toHaveBeenCalledOnce();
       expect(childInterrupt).toHaveBeenCalledOnce();
@@ -1167,15 +1159,8 @@ describe('executionRegistry', () => {
       });
       registry.track(grandchildHandle);
 
-      expect(
-        registry.stopAgentStream(rootStreamId, {
-          detachActiveChildren: true,
-          runtimeHost: explicit.host,
-        }),
-      ).toEqual({
-        kind: 'interrupted',
-        streamId: rootStreamId,
-        childPolicy: 'detach',
+      registry.stopAgentStream(rootStreamId, {
+        detachActiveChildren: true,
       });
 
       expect(rootInterrupt).toHaveBeenCalledOnce();
@@ -1258,15 +1243,8 @@ describe('executionRegistry', () => {
       });
       registry.track(descendantHandle);
 
-      expect(
-        registry.stopAgentStream(childStreamId, {
-          detachActiveChildren: true,
-          runtimeHost: explicit.host,
-        }),
-      ).toEqual({
-        kind: 'interrupted',
-        streamId: childStreamId,
-        childPolicy: 'detach',
+      registry.stopAgentStream(childStreamId, {
+        detachActiveChildren: true,
       });
 
       expect(childInterrupt).toHaveBeenCalledOnce();
@@ -1289,8 +1267,7 @@ describe('executionRegistry', () => {
     }
   });
 
-  it('marks an ownerless stream stopped when a host can publish status', () => {
-    const explicit = createRecordingHost();
+  it('cancels an ownerless stream', () => {
     const streamStatus = new StreamStatusMachine();
     const events = new SessionEventHub();
     const recorded = recordSessionEvents(events, { scope: 'session' });
@@ -1298,15 +1275,8 @@ describe('executionRegistry', () => {
     const streamId = 'ownerless-stop-policy-test' as StreamTabId;
 
     try {
-      expect(
-        registry.stopAgentStream(streamId, {
-          runtimeHost: explicit.host,
-        }),
-      ).toEqual({
-        kind: 'marked_stopped',
-        streamId,
-        childPolicy: 'cascade',
-      });
+      registry.stopAgentStream(streamId);
+
       expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
       expect(
         sessionFactPayloads(recorded.events, 'updateStreamStatus').at(-1),
@@ -1319,18 +1289,17 @@ describe('executionRegistry', () => {
     }
   });
 
-  it('reports no target when no execution or host owns the stream', () => {
+  it('leaves an already-terminal stream phase untouched', () => {
     const streamStatus = new StreamStatusMachine();
     const registry = new ExecutionRegistry({ streamStatus });
-    const streamId = 'missing-stop-target-test' as StreamTabId;
+    const streamId = 'terminal-stop-policy-test' as StreamTabId;
 
     try {
-      expect(registry.stopAgentStream(streamId)).toEqual({
-        kind: 'no_target',
-        streamId,
-        childPolicy: 'cascade',
-      });
-      expect(streamStatus.get(streamId)).toBeUndefined();
+      seedStreamStatusForTest(streamStatus, streamId, STREAM_PHASE.COMPLETED);
+
+      registry.stopAgentStream(streamId);
+
+      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.COMPLETED);
     } finally {
       registry.dispose();
     }
@@ -1444,22 +1413,46 @@ describe('executionRegistry', () => {
     }
   });
 
-  it('reports a missing runtime host when detach cannot be applied', () => {
-    const registry = new ExecutionRegistry();
-    const streamId = 'missing-host-detach-stop-policy-test' as StreamTabId;
+  it('detaches children of an ownerless stream and cancels it', () => {
+    const explicit = createRecordingHost();
+    const streamStatus = new StreamStatusMachine();
+    const events = new SessionEventHub();
+    const recorded = recordSessionEvents(events, { scope: 'session' });
+    const registry = new ExecutionRegistry({ streamStatus, events });
+    const parentStreamId = 'parent-ownerless-detach-test' as StreamTabId;
+    const childStreamId = 'child-ownerless-detach-test' as StreamTabId;
+    const childInterrupt = vi.fn();
 
     try {
-      expect(
-        registry.stopAgentStream(streamId, {
-          detachActiveChildren: true,
-        }),
-      ).toEqual({
-        kind: 'missing_runtime_host',
-        streamId,
-        childPolicy: 'detach',
+      // No root handle owns `parentStreamId` — only a tracked child does.
+      const childHandle = createHandle(
+        'exec-child-ownerless-detach-test',
+        parentStreamId,
+        childStreamId,
+        explicit.host,
+      );
+      childHandle.attachInterruptHandler({ interrupt: childInterrupt });
+      registry.track(childHandle);
+
+      registry.stopAgentStream(parentStreamId, {
+        detachActiveChildren: true,
       });
+
+      expect(childInterrupt).not.toHaveBeenCalled();
+      expect(
+        registry.getAgentHandleByStream(childStreamId)?.parentStreamId,
+      ).toBe(childStreamId);
+      expect(
+        sessionFactPayloads(recorded.events, 'setParentStream'),
+      ).toContainEqual({
+        childStreamId,
+        parentStreamId: null,
+      });
+      expect(streamStatus.get(parentStreamId)).toBe(STREAM_PHASE.CANCELLED);
+      expect(streamStatus.get(childStreamId)).toBeUndefined();
     } finally {
       registry.dispose();
+      recorded.detach();
     }
   });
 
@@ -1785,7 +1778,7 @@ describe('executionRegistry', () => {
 
       registry.track(handle);
       expect(handle.deliveryTargetStreamId).toBe(parentStreamId);
-      registry.detachActiveChildren(parentStreamId, explicit.host);
+      registry.detachActiveChildren(parentStreamId);
       expect(handle.deliveryTargetStreamId).toBeUndefined();
 
       expect(
@@ -1828,7 +1821,7 @@ describe('executionRegistry', () => {
       ]);
       registry.track(handle);
 
-      registry.detachActiveChildren(parentStreamId, explicit.host);
+      registry.detachActiveChildren(parentStreamId);
       approvals.toolEdit.bypass.setBypass(parentStreamId, false);
 
       expect(approvals.toolEdit.bypass.isBypassed(childStreamId)).toBe(true);
@@ -1859,7 +1852,7 @@ describe('executionRegistry', () => {
       );
 
       registry.track(handle);
-      registry.detachActiveChildren(parentStreamId, explicit.host);
+      registry.detachActiveChildren(parentStreamId);
 
       expect(explicit.events).toEqual([]);
       expect(seen).toContainEqual({

--- a/src/test-kernel/agent/runtime/ExecutionSubscriptionBinder.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionSubscriptionBinder.vitest.ts
@@ -58,18 +58,18 @@ function setupBinder(executionId: string) {
     explicit.host,
   );
   registry.track(handle);
-  return { registry, releaseSource, logger, explicit, binder, executionId };
+  return { registry, releaseSource, logger, binder, executionId };
 }
 
 describe('ExecutionSubscriptionBinder', () => {
   it('owns bind and unbind state per stream/execution pair', () => {
-    const { registry, logger, explicit, binder, executionId } = setupBinder(
+    const { registry, logger, binder, executionId } = setupBinder(
       'exec-subscription-bind-test',
     );
 
     try {
-      binder.bind(streamId, executionId, explicit.host);
-      binder.bind(streamId, executionId, explicit.host);
+      binder.bind(streamId, executionId);
+      binder.bind(streamId, executionId);
 
       expect(binder.unbind(streamId, executionId)).toBe(true);
       expect(binder.unbind(streamId, executionId)).toBe(false);
@@ -81,11 +81,12 @@ describe('ExecutionSubscriptionBinder', () => {
   });
 
   it('disposes stream subscriptions when the follow-up queue is released', () => {
-    const { registry, releaseSource, explicit, binder, executionId } =
-      setupBinder('exec-subscription-release-test');
+    const { registry, releaseSource, binder, executionId } = setupBinder(
+      'exec-subscription-release-test',
+    );
 
     try {
-      binder.bind(streamId, executionId, explicit.host);
+      binder.bind(streamId, executionId);
 
       releaseSource.release(streamId);
 
@@ -97,11 +98,12 @@ describe('ExecutionSubscriptionBinder', () => {
   });
 
   it('unregisters the release observer when disposed', () => {
-    const { registry, releaseSource, explicit, binder, executionId } =
-      setupBinder('exec-subscription-dispose-test');
+    const { registry, releaseSource, binder, executionId } = setupBinder(
+      'exec-subscription-dispose-test',
+    );
 
     try {
-      binder.bind(streamId, executionId, explicit.host);
+      binder.bind(streamId, executionId);
 
       expect(releaseSource.hasObserver()).toBe(true);
       binder.dispose();

--- a/src/test-kernel/agent/runtime/ExecutionSubscriptionBinderSession.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionSubscriptionBinderSession.vitest.ts
@@ -89,7 +89,7 @@ describe('ExecutionSubscriptionBinder session routing', () => {
 
     try {
       registry.track(handle);
-      binder.bind(streamId, executionId, explicit.host);
+      binder.bind(streamId, executionId);
 
       registry.untrack(executionId);
       await settleDelivery();
@@ -143,7 +143,7 @@ describe('ExecutionSubscriptionBinder session routing', () => {
 
       try {
         registry.track(handle);
-        binder.bind(streamId, executionId, explicit.host);
+        binder.bind(streamId, executionId);
 
         registry.untrack(executionId);
         await settleDelivery();
@@ -191,7 +191,7 @@ describe('ExecutionSubscriptionBinder session routing', () => {
           session,
         }),
         () => {
-          binder.bind(streamId, executionId, explicit.host);
+          binder.bind(streamId, executionId);
           registry.untrack(executionId);
         },
       );
@@ -234,7 +234,7 @@ describe('ExecutionSubscriptionBinder session routing', () => {
     try {
       process.once('unhandledRejection', unhandledRejection);
       registry.track(handle);
-      binder.bind(streamId, executionId, explicit.host);
+      binder.bind(streamId, executionId);
 
       registry.untrack(executionId);
       await settleDelivery();

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -624,7 +624,6 @@ describe('createChatSessionController', () => {
     );
     expect(mocks.stopAgentStream).toHaveBeenCalledWith('stream-1', {
       detachActiveChildren: true,
-      runtimeHost,
     });
   });
 
@@ -646,7 +645,6 @@ describe('createChatSessionController', () => {
     });
     expect(mocks.stopAgentStream).toHaveBeenCalledWith('root-stream', {
       detachActiveChildren: true,
-      runtimeHost,
     });
     expect(mocks.workspaceGet).not.toHaveBeenCalled();
   });
@@ -669,7 +667,6 @@ describe('createChatSessionController', () => {
     });
     expect(mocks.stopAgentStream).toHaveBeenCalledWith('child-a', {
       detachActiveChildren: true,
-      runtimeHost,
     });
   });
 

--- a/src/test-kernel/frontend/AgentReviewRunController.vitest.ts
+++ b/src/test-kernel/frontend/AgentReviewRunController.vitest.ts
@@ -26,7 +26,6 @@ function createRunHarness() {
     const handle = {
       executionId,
       childStreamId: `review#${executionId}`,
-      runtimeHost: {},
     } as AgentRunHandle;
     currentHandle = handle;
     controller.bind(run, handle);

--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -1179,7 +1179,7 @@ describe('headless delegation', () => {
         // Detach happens between the loop capturing the handle (onRun, above)
         // and the loop delivering this turn's result (after this resolves) —
         // the same ordering a real stop-with-detach produces mid-turn.
-        defaultSession().executions.detachActiveChildren(parentStreamId, host);
+        defaultSession().executions.detachActiveChildren(parentStreamId);
         return {
           category: 'toolUse',
           outcome: STREAM_PHASE.WAITING,

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -592,11 +592,7 @@ Use action: "subscribe" on /executions/{id} to receive future status and termina
   }
 
   private handleSubscribe(executionId: ExecutionId): ToolResult {
-    const {
-      streamId,
-      runtimeHost,
-      context: ctx,
-    } = requireRunStream('subscribe');
+    const { streamId, context: ctx } = requireRunStream('subscribe');
     // Subscribing to your own execution would feed every status transition
     // back into the same session, creating a self-sustaining loop of
     // <execution-activity> follow-ups.
@@ -606,7 +602,7 @@ Use action: "subscribe" on /executions/{id} to receive future status and termina
       );
     }
     try {
-      currentSession().subscriptions.bind(streamId, executionId, runtimeHost);
+      currentSession().subscriptions.bind(streamId, executionId);
     } catch (err) {
       throw new ToolError(toErrorMessage(err));
     }


### PR DESCRIPTION
## This is a sanctioned behavior change, not dead-code removal

`stopAgentStream`'s `AgentRuntimeHost` parameter gated code that never read the host. The guard's meaning had drifted from "can we act" to "did the caller happen to hold a host object", and the arm it returned was thrown away by every caller. Removing it changes observable behavior in two places, both scoped to `cancelStreamStatus`:

1. **`detachActiveChildren: true` with no resolvable host** now performs the detach sweep + root terminate + CANCELLED write. Before, it returned `{kind:'missing_runtime_host'}` having done **nothing at all** — no child sweep, no root terminate, no CANCELLED write — and reported the failure only into a return value all five callers discard.
2. **No root handle *and* no resolvable host** now writes CANCELLED instead of returning `no_target` silently.

Only the CLI could trip case 1 (`session.runtimeHost` is optional and is cleared to `undefined` during finalize); the other four production callers always pass a defined host and are unaffected.

**Blast radius is bounded by `canTransitionStreamPhase`** (`src/shared/streams/streamStatus.ts`): `user-stop → CANCELLED` is permitted only from `undefined` or an in-flight phase, so an already-terminal stream keeps its outcome. The only genuinely new observable write is a CANCELLED phase for a stream the machine has never seen — which already happened for the *hosted* ownerless case, so this only extends it to hostless calls.

Both deltas are pinned by new tests (see below).

## What changed

**`src/agent/runtime/executionRegistry.ts`**
- Deleted `StopAgentStreamResult` (4-arm union) and `StopAgentChildPolicy`. `stopAgentStream` is now `: void` with a single bare early `return`.
- Deleted `runtimeHost` from the stop options, the `const runtimeHost = …` resolution, the `missing_runtime_host` guard, and the `no_target` branch.
- `detachActiveChildren` lost its never-read `_runtimeHost` parameter (arity 3 → 2).
- Merged `StopAgentStreamOptions` and `KillExecutionOptions` — structurally identical once `runtimeHost` left, and neither was imported by name anywhere — into one exported `ExecutionStopOptions` used by both `kill()` and `stopAgentStream()`.
- Deleted `observeHandle`, a 4-line wrapper over `addListener` whose only caller repo-wide was a test.
- Dropped the now-orphaned `import type { AgentRuntimeHost }`.

**`src/agent/runtime/ExecutionSubscriptionBinder.ts`** — `ExecutionSubscription` no longer stores a `runtimeHost` field no method read; `bind()` is 2-arg; orphaned import dropped.

**Host call sites** — `agentCommands.ts` (arg + the `extensionAgentRuntimeHost` import), `AgentReviewRunController.ts`, `chatSessionController.ts` (×2), `desktopAgentExecution.ts`, and `ExecutionsTool.ts` (the `runtimeHost` binding in the `requireRunStream('subscribe')` destructure + the third `bind()` argument).

`requireRunStream` itself is unchanged, so `handleSubscribe` keeps its existing host precondition — only the unused binding went. This matches how `DelegationTools.ts` already destructures the same helper.

**Tests**
- Deleted `'reports no target when no execution or host owns the stream'` — it asserted `streamStatus.get(streamId)` stays `undefined`, the *opposite* of the new semantics; the surviving assertion is already covered by the rewritten ownerless test.
- Replaced `'reports a missing runtime host when detach cannot be applied'` with **`'detaches children of an ownerless stream and cancels it'`** — no host option anywhere in it; asserts the tracked child is promoted to top-level, a `setParentStream` fact with `parentStreamId: null` is emitted, the child is *not* interrupted, and the parent stream reads CANCELLED.
- Added **`'leaves an already-terminal stream phase untouched'`** — seeds `COMPLETED`, stops, asserts the phase survives. Bounds the now-unconditional `cancelStreamStatus` write.
- **Rewrote, did not delete,** `'observes the current handle, replacements, and removal in order'` → `'observes handle replacements and removal in order'`. The same `it()` block also covers `addRegistrationListener`; `observeHandle` → `addListener` and `seen` becomes `[second, undefined]` (`addListener` doesn't fire the initial handle). The registration-listener assertions still run and still pass.
- Argument/assertion removal across `ExecutionRegistry.vitest.ts`, `ExecutionSubscriptionBinder.vitest.ts` (+ the now-unused `explicit` in `setupBinder` and its three destructures), `ExecutionSubscriptionBinderSession.vitest.ts`, `DelegationHeadless.vitest.mts`, `chatSessionController.vitest.mts` (three `toHaveBeenCalledWith` deep-equals the compiler cannot see), and `AgentReviewRunController.vitest.ts`.

## Element reduction actually achieved

| Counting unit | Before | After |
|---|---:|---:|
| Exported types on the stop/kill option surface | 3 | 1 |
| Non-exported helper type aliases (`StopAgentChildPolicy`) | 1 | 0 |
| Arms in the `stopAgentStream` result union | 4 | 0 (`void`) |
| `AgentRuntimeHost` params/fields on the stop→detach→subscribe path | 4 | 0 |
| `AgentRuntimeHost` args at production call sites | 6 | 0 |
| `AgentRuntimeHost` args at test call sites | 16 | 0 |
| Host-resolution / guard branches inside `stopAgentStream` | 4 | 0 |
| `return` statements in `stopAgentStream` | 4 object literals | 1 bare |
| Public registry observe/wait entry points | 5 | 4 |
| `import type { AgentRuntimeHost }` in the two runtime files | 2 | 0 |
| `import { extensionAgentRuntimeHost }` in `agentCommands.ts` | 1 | 0 |
| Tests pinning arms that no longer exist | 2 | 0 (2 new-semantics tests added) |

**Line counts (`git diff --stat`):** production **+15 / −91 = −76**; tests **+72 / −81 = −9** (net-negative *despite* adding two tests). Total **+87 / −172 = −85**.

## Verification

All four gates run locally, all green:

- `npm run typecheck` — all six tsconfigs (root, `tsconfig.test-kernel.json`, extension, CLI, trace-viewer, desktop). `tsconfig.test-kernel.json` is the one that catches the `detachActiveChildren` / `binder.bind` arity errors.
- `npm test` — **773 files / 7492 tests passed**, 1 file + 4 tests skipped. The only gate that catches the three `chatSessionController.vitest.mts` deep-equal assertions.
- `npm run lint` — clean.
- `npm run check:dead-code-ratchet` — `18 current vs 18 baselined`, no new findings. **No baseline entries added** (removing an export cannot add a knip finding, and nothing was newly orphaned).

**The behavior change is empirically pinned.** I temporarily re-added the old guard (`if (!rootHandle?.runtimeHost) return;`) and re-ran the suite: the new `'detaches children of an ownerless stream and cancels it'` test fails (1 failed / 37 passed), then passes again once reverted. It is a real regression test, not a restatement.

## Notes on scope

- Everything in the issue's "Explicitly NOT in scope" section was honoured: the `changeCallbacks` / `persistentListeners` merge, `addRegistrationListener`, `AgentExecutionHandle.runtimeHost`, `runChatTui.tsx`'s `kill()` call, and the historical proposal docs are all untouched.
- The one surviving `missing_runtime_host` string in the repo is `src/tools/delegation/subagentExecution.ts:86` — an unrelated `diagnostics.type` on the delegation tool's error result, not part of this union.
- Lands before #9139, which also edits `detachActiveChildren` and can rebase onto the 2-arg signature.

Closes #9140

https://claude.ai/code/session_01MQZ63FFrmojmG58wPJdYNH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core execution stop/teardown and changes observable behavior for hostless CLI stops and ownerless streams; blast radius is limited by stream-status transition rules and is covered by new/updated registry tests.
> 
> **Overview**
> **`stopAgentStream` and related stop APIs no longer take or depend on `AgentRuntimeHost`.** Callers (CLI, desktop, extension, `ExecutionsTool`) only pass `detachActiveChildren`; the registry no longer returns a four-arm result union—`stopAgentStream` is **`void`**.
> 
> **Behavior change (intentional):** Stops no longer no-op when no host was passed. **Detach-without-host** now runs the child detach sweep and can mark the stream **CANCELLED**; **ownerless streams** get **`cancelStreamStatus`** instead of a discarded `no_target` / `missing_runtime_host` result. Terminal phases stay unchanged (`canTransitionStreamPhase`).
> 
> **API cleanup:** `StopAgentStreamOptions` / `KillExecutionOptions` → shared **`ExecutionStopOptions`**; **`detachActiveChildren`** drops its unused host parameter; **`observeHandle`** removed (tests use **`addListener`**); **`ExecutionSubscriptionBinder.bind`** is two arguments (no stored host).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1886dcbed4aeb9d1ba903b1c83421853ac4ea09e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->