### PR TITLE
feat(cli): render all six workflow-task statuses distinctly in the TUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ All notable changes to this project will be documented in this file.
   view retains at most 4,000 complete lines and marks when earlier lines have
   been removed.
 
+### CLI
+
+#### New Features
+
+- **Workflow-script task rows show their status at a glance** — each task in
+  the terminal transcript carries its own marker and color for planned,
+  running, finished, saved-result, skipped, and failed, instead of every row
+  looking alike. A task the run never reached now also explains itself the way
+  the progress view already did.
+
 ## [0.39.8] - 2026-07-24
 
 ### Shared (all surfaces)

--- a/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
+++ b/packages/cli/src/chat/tui/panes/TranscriptEntry.tsx
@@ -17,6 +17,7 @@ import { childStatusColor } from './SubagentListDisplay';
 import { ToolUseRow } from './ToolUseRow';
 import {
   LIVE_TAIL_ROWS,
+  WORKFLOW_TASK_STATUS_STYLE,
   boundedTranscriptEntryLayout,
   transcriptEntryLayout,
   type TranscriptEntryLayout,
@@ -82,15 +83,19 @@ function PlainEntryRows({
     );
   }
 
+  // Workflow-task rows carry the same status color as their layout marker, so
+  // the six statuses stay distinguishable at a glance.
+  let rowColor: string | undefined;
+  if (entry.role === 'error') {
+    rowColor = COLOR_ERROR;
+  } else if (entry.role === 'workflowTask' && colorEnabled !== false) {
+    rowColor = WORKFLOW_TASK_STATUS_STYLE[entry.task.status].color;
+  }
+
   return (
     <Box {...boxProps}>
       <Text
-        color={
-          entry.role === 'error' ||
-          (entry.role === 'workflowTask' && entry.task.status === 'failed')
-            ? COLOR_ERROR
-            : undefined
-        }
+        color={rowColor}
         inverse={entry.role === 'user' && colorEnabled !== false}
       >
         {lines.join('\n')}

--- a/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
@@ -1,13 +1,26 @@
 // Declarative conversation-entry geometry shared by Ink renderers, viewport
 // budgeting, static scrollback, and print-once full output.
 
+import type { WorkflowTaskProgress } from '@shared/schemas';
 import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 import { renderAnsiMarkdown } from '../render/ansiMarkdown';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
 import { completedProcessDisplayLines } from '../state/completedProcessTranscript';
 import {
+  COLOR_BORDER,
+  COLOR_ERROR,
+  COLOR_HINT,
+  COLOR_SUCCESS,
+} from '../ui/colors';
+import {
+  CROSS,
   ERROR_ENTRY_PREFIX,
+  SKIP_CIRCLE,
   STATUS_DIAMOND,
+  TICK,
+  TODO_ACTIVE,
+  TODO_DONE,
+  TODO_PENDING,
   TOOL_OUTPUT_CORNER,
   USER_ENTRY_PREFIX,
 } from '../ui/glyphs';
@@ -78,17 +91,41 @@ const ROLE_GEOMETRY = {
     marginTopRows: USER_ENTRY_MARGIN_TOP_ROWS,
   },
   workflowTask: {
+    // The first-line marker is per-status (WORKFLOW_TASK_STATUS_STYLE), so the
+    // role carries only the alignment used by wrapped continuation lines.
     firstPrefix: '',
-    continuationPrefix: '',
+    continuationPrefix: '  ',
     inset: 0,
     marginBottomRows: 0,
     marginTopRows: 0,
   },
 } as const satisfies Record<TranscriptEntryRole, RoleGeometry>;
 
-export interface TranscriptEntryLayout extends RoleGeometry {
+/**
+ * Marker glyph + color per workflow-task status. Steady glyphs only — an
+ * animated `running` marker would need a per-component timer, which repaints
+ * the whole live region for no added information (see CHILD_STATUS_MARKER).
+ * Exhaustive on purpose: a seventh status must break this build rather than
+ * render an undefined marker.
+ */
+export const WORKFLOW_TASK_STATUS_STYLE = {
+  planned: { marker: TODO_PENDING, color: undefined },
+  running: { marker: TODO_ACTIVE, color: COLOR_HINT },
+  completed: { marker: TODO_DONE, color: COLOR_SUCCESS },
+  cached: { marker: TICK, color: COLOR_SUCCESS },
+  skipped: { marker: SKIP_CIRCLE, color: COLOR_BORDER },
+  failed: { marker: CROSS, color: COLOR_ERROR },
+} as const satisfies Record<
+  WorkflowTaskProgress['status'],
+  { readonly marker: string; readonly color: string | undefined }
+>;
+
+export interface TranscriptEntryLayout {
   readonly columns: number;
+  readonly inset: number;
   readonly lines: readonly string[];
+  readonly marginBottomRows: number;
+  readonly marginTopRows: number;
   readonly role: TranscriptEntryRole;
 }
 
@@ -224,6 +261,15 @@ function entryLines(
         geometry.continuationPrefix,
       );
     }
+    case 'workflowTask':
+      // The status marker belongs to the layout, not the Ink row: the print-once
+      // scrollback snapshot is built from these lines.
+      return wrapWithPrefix(
+        entry.text,
+        columns,
+        `${WORKFLOW_TASK_STATUS_STYLE[entry.task.status].marker} `,
+        ROLE_GEOMETRY.workflowTask.continuationPrefix,
+      );
     default: {
       const geometry = ROLE_GEOMETRY[entry.role];
       return wrapWithPrefix(
@@ -267,7 +313,6 @@ export function transcriptEntryLayout(
   }
   const columns = transcriptColumns(width, inset);
   return {
-    ...base,
     columns,
     lines: entryLines(
       entry,

--- a/packages/cli/src/chat/tui/ui/glyphs.ts
+++ b/packages/cli/src/chat/tui/ui/glyphs.ts
@@ -28,6 +28,12 @@ export const TODO_DONE = '☑';
 export const TODO_ACTIVE = '☐';
 export const TODO_PENDING = '□';
 
+/** Terminal-failure marker; the ✗/✓ counterpart to TICK. */
+export const CROSS = '✗';
+
+/** Work deliberately not done: a user skip or a task the run never reached. */
+export const SKIP_CIRCLE = '⊘';
+
 /** Transcript row prefixes (trailing space included for the gutter). User rows
  *  (and the default fallback) reuse the same chevron as selects (POINTER) so the
  *  look stays consistent; error rows use a bang. Assistant rows carry no prefix

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/workflowTaskFormatter.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/workflowTaskFormatter.ts
@@ -8,7 +8,10 @@ import {
   type LogMessageData,
   type WorkflowTaskProgress,
 } from '@shared/schemas';
-import { formatWorkflowTaskMetadataParts } from '@shared/copy/workflowTask';
+import {
+  formatWorkflowTaskMetadataParts,
+  workflowTaskDetail,
+} from '@shared/copy/workflowTask';
 import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
 import { assertNever } from '@utils/core';
 
@@ -47,31 +50,12 @@ function terminalMetadata(
     : nothing;
 }
 
-type WorkflowTaskDetail =
-  | { readonly kind: 'error'; readonly text: string }
-  | { readonly kind: 'note'; readonly text: string };
-
-function taskDetail(
-  task: WorkflowTaskProgress,
-): WorkflowTaskDetail | undefined {
-  if (task.status === 'failed') {
-    return { kind: 'error', text: task.error };
-  }
-  if (task.status === 'skipped' && task.reason === 'not-reached') {
-    return {
-      kind: 'note',
-      text: 'The workflow ended before this task was reached.',
-    };
-  }
-  return undefined;
-}
-
 /** Render one workflow task as a status card updated in place by log id. */
 export function formatWorkflowTaskTemplate(
   message: LogMessageData,
 ): TemplateResult {
   const task = WorkflowTaskProgressSchema.parse(message.data);
-  const detail = taskDetail(task);
+  const detail = workflowTaskDetail(task);
 
   return html`
     <div

--- a/src/shared/copy/workflowTask.ts
+++ b/src/shared/copy/workflowTask.ts
@@ -29,11 +29,30 @@ export function formatWorkflowTaskMetadataParts(
 }
 
 /**
+ * The one explanatory-clause rule for a workflow task, shared by every host: a
+ * failure reports its error, and a task the run never reached says so. A user
+ * skip is self-explanatory and gets no clause.
+ */
+export function workflowTaskDetail(
+  task: WorkflowTaskProgress,
+): { readonly kind: 'error' | 'note'; readonly text: string } | undefined {
+  if (task.status === 'failed') return { kind: 'error', text: task.error };
+  if (task.status === 'skipped' && task.reason === 'not-reached') {
+    return {
+      kind: 'note',
+      text: 'The workflow ended before this task was reached.',
+    };
+  }
+  return undefined;
+}
+
+/**
  * Canonical plain-text projection for workflow-task progress on every host.
  */
 export function formatWorkflowTaskLine(task: WorkflowTaskProgress): string {
   const metadata = formatWorkflowTaskMetadataParts(task);
   const suffix = metadata.length > 0 ? ` · ${metadata.join(' · ')}` : '';
-  const detail = task.status === 'failed' ? ` — ${task.error}` : '';
-  return `${WORKFLOW_TASK_STATUS_LABEL[task.status]}: ${task.label}${suffix}${detail}`;
+  const detail = workflowTaskDetail(task);
+  const explanation = detail ? ` — ${detail.text}` : '';
+  return `${WORKFLOW_TASK_STATUS_LABEL[task.status]}: ${task.label}${suffix}${explanation}`;
 }

--- a/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
@@ -163,7 +163,9 @@ return await agent('Run one', { id: 'used' })`,
         reason: 'not-reached',
       },
     });
-    expect(activities).toContain('Skipped: Unused task');
+    expect(activities).toContain(
+      'Skipped: Unused task — The workflow ended before this task was reached.',
+    );
   });
 
   it('marks a planned task failed when the live-call cap refuses it', async () => {

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -58,6 +58,7 @@ import {
   type NormalizedToolUse,
   type RunOutcome,
   type StreamTabId,
+  type WorkflowTaskProgress,
 } from '@shared/schemas';
 import { buildChildStreamEntries } from '@test/support/childStreamEntries';
 
@@ -419,17 +420,18 @@ describe('CLI conversation transcript splitting', () => {
     expect(selected.rowLimits.has('a1')).toBe(false);
   });
 
-  it('derives prefixes, insets, margins, and row counts from one layout', () => {
+  it('derives insets, margins, prefixed lines, and row counts from one layout', () => {
     const user = entry('u1', 'user', 'x'.repeat(77), true);
     const userLayout = transcriptEntryLayout(user, { width: 80 });
     expect(userLayout).toMatchObject({
       columns: 78,
-      continuationPrefix: '  ',
-      firstPrefix: '› ',
       inset: 2,
       marginBottomRows: 1,
       marginTopRows: 1,
     });
+    // Row prefixes are baked into the lines, not advertised as layout fields.
+    expect(userLayout.lines[0]?.startsWith('› ')).toBe(true);
+    expect(userLayout.lines[1]?.startsWith('  ')).toBe(true);
     expect(userLayout.lines).toHaveLength(2);
     expect(transcriptEntryLayoutRows(userLayout)).toBe(4);
     expect(estimateTranscriptEntryRows(user, 80)).toBe(
@@ -447,6 +449,25 @@ describe('CLI conversation transcript splitting', () => {
     expect(estimateTranscriptEntryRows(tool, 80)).toBe(
       transcriptEntryLayoutRows(toolLayout),
     );
+  });
+
+  it('gives every workflow-task status its own steady marker', () => {
+    const tasks: readonly WorkflowTaskProgress[] = [
+      { id: 'a', label: 'Task', status: 'planned' },
+      { id: 'a', label: 'Task', status: 'running' },
+      { id: 'a', label: 'Task', status: 'completed' },
+      { id: 'a', label: 'Task', status: 'cached' },
+      { id: 'a', label: 'Task', status: 'skipped', reason: 'user' },
+      { id: 'a', label: 'Task', status: 'failed', error: 'Runner stopped.' },
+    ];
+    const markers = tasks.map((task) =>
+      transcriptEntryLayout(
+        { id: 'a', role: 'workflowTask', text: 'Task', finalized: true, task },
+        { width: 80 },
+      ).lines[0]?.slice(0, 2),
+    );
+
+    expect(markers).toEqual(['□ ', '☐ ', '☑ ', '✓ ', '⊘ ', '✗ ']);
   });
 
   it('budgets live rich tool rows without reflowing their display lines', () => {

--- a/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.mts
+++ b/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.mts
@@ -335,14 +335,18 @@ describe('CLI workflow-script child-stream transcript', () => {
         staticItems
           .filter((item) => item.kind === 'entry')
           .map((item) => item.entry.text),
-      ).toEqual(['Skipped: Audit later']);
+      ).toEqual([
+        'Skipped: Audit later — The workflow ended before this task was reached.',
+      ]);
       expect(
         staticItems
           .filter((item) => item.kind === 'entry')
           .map((item) => item.entry.id),
       ).toEqual(['cancelled-planned-task']);
       const output = await renderStaticTranscript();
-      expect(output).toContain('Skipped: Audit later');
+      // The skipped marker distinguishes the row from a finished or failed one.
+      expect(output).toContain('⊘ Skipped: Audit later');
+      expect(output).toContain('The workflow ended before this task was');
       expect(output).not.toContain('Planned: Audit later');
     } finally {
       runTrace.dispose();
@@ -1092,9 +1096,10 @@ describe('CLI workflow-script child-stream transcript', () => {
       });
 
       const output = await renderStaticTranscript();
-      // The phase header renders with its distinct diamond divider glyph.
+      // The phase header renders with its distinct diamond divider glyph, and
+      // the task row carries its own per-status marker.
       expect(output).toContain('◆ Draft sections');
-      expect(output).toContain('Finished: Draft introduction');
+      expect(output).toContain('☑ Finished: Draft introduction');
       expect(output).toContain('deepseekT · 12s · $0.002 total');
     } finally {
       runTrace.dispose();

--- a/src/test-kernel/shared/WorkflowTaskCopy.vitest.ts
+++ b/src/test-kernel/shared/WorkflowTaskCopy.vitest.ts
@@ -44,4 +44,31 @@ describe('workflow task copy', () => {
       'Failed: Audit source · kimiK2 · 7s · $0.040 total — Runner stopped.',
     );
   });
+
+  it('explains a task the run never reached on every textual host', () => {
+    expect(
+      formatWorkflowTaskLine({
+        id: 'audit',
+        label: 'Audit later',
+        status: 'skipped',
+        reason: 'not-reached',
+      }),
+    ).toBe(
+      'Skipped: Audit later — The workflow ended before this task was reached.',
+    );
+  });
+
+  it('leaves a user skip without an explanatory clause', () => {
+    expect(
+      formatWorkflowTaskLine({
+        id: 'review',
+        label: 'Stopped review',
+        status: 'skipped',
+        reason: 'user',
+        model: 'kimiK2',
+        durationMs: 7_320,
+        totalCostUsd: 0.04,
+      }),
+    ).toBe('Skipped: Stopped review · kimiK2 · 7s · $0.040 total');
+  });
 });


### PR DESCRIPTION
## What changed

A workflow-script run emits six task statuses; the CLI transcript distinguished
exactly one of them. `ROLE_GEOMETRY.workflowTask` had an empty first prefix and
`PlainEntryRows` colored only `status === 'failed'`, so `planned`, `running`,
`completed`, `cached` and `skipped` all rendered as identical default-foreground
text. This gives each status a marker and a color, and closes the second half of
the same gap: the "this task was never reached" explanation existed in the
webview only.

**One presentation table, compiler-exhaustive.**
`WORKFLOW_TASK_STATUS_STYLE` (`packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts`)
is declared `as const satisfies Record<WorkflowTaskProgress['status'], …>`, so a
seventh status breaks the build rather than rendering an undefined marker. The
hardcoded `status === 'failed'` branch in `TranscriptEntry.tsx` is gone.

| Status | Marker | Color | Why |
| --- | --- | --- | --- |
| `planned` | `□` `TODO_PENDING` | none | the "not started" glyph the todo panel already uses |
| `running` | `☐` `TODO_ACTIVE` | `COLOR_HINT` | identical to the todo panel's in-progress row |
| `completed` | `☑` `TODO_DONE` | `COLOR_SUCCESS` | same |
| `cached` | `✓` `TICK` | `COLOR_SUCCESS` | success-colored but lighter than `☑`, so a reused result reads as "already had this" |
| `skipped` | `⊘` `SKIP_CIRCLE` (new) | `COLOR_BORDER` | mirrors the webview `circle-stop` icon and the documented gray convention (a stop is neither success nor failure) |
| `failed` | `✗` `CROSS` (new) | `COLOR_ERROR` | keeps today's red; `✗` U+2717 is the counterpart of the already-used `✓` U+2713 |

All six are steady glyphs. An animated `running` marker would need a
per-component timer, which the shared-Clock rule bans and which
`CHILD_STATUS_MARKER` documents as previously forcing twice-a-second repaints of
the whole live region for zero information. Both new constants are
single-UTF-16-code-unit BMP codepoints, because `wrapWithPrefix` budgets width
in code units.

The marker is composed into the **layout lines**, not into the Ink component,
because `state/transcriptLines.ts` builds the Ctrl-T / `v` print-once scrollback
snapshot from `fullTranscriptEntryLayout(...).lines` — a component-only glyph
would silently vanish from that snapshot. `PlainEntryRows` is edited in place,
so every row stays inside the existing `EntryErrorBoundary`, and it stays
stateless (props in → JSX out).

**One owner for the explanatory clause.** `workflowTaskDetail` in
`src/shared/copy/workflowTask.ts` now owns the rule that both hosts were
implementing separately and disagreeing on. `formatWorkflowTaskLine` consumes it
and the webview's local `taskDetail` / `type WorkflowTaskDetail` are deleted; the
webview keeps its `--error` / `--note` class split by reading `detail.kind`, so
its rendering is unchanged.

**The note belongs in shared copy, not webview-only** (the decision the issue
asked to justify): (a) it is user-facing copy and the module's stated contract is
canonical copy "on every host"; (b) webview-only would leave the `failed → error`
rule duplicated in two files forever, which is the actual debt; (c)
`formatWorkflowTaskLine`'s other consumer is the `delegate_workflow_script` tool
result, where "the workflow ended before this task was reached" is exactly the
disambiguation the parent model needs to tell a not-reached task from a user
skip. A `reason: 'user'` skip still gets no clause.

**Layout type stops lying.** `TranscriptEntryLayout` no longer extends
`RoleGeometry`. With a per-status marker, `firstPrefix` on a workflow-task layout
would report `''` while the row actually starts `☑ `, so both prefix fields are
dropped from the exported type and the `...base` spread is replaced by the six
fields consumers really read.

## Element reduction actually achieved

| Unit | Before | After |
| --- | --- | --- |
| Files created / deleted | — | 0 / 0 (10 edited: 5 prod, 4 test, CHANGELOG) |
| CLI statuses with a distinct visual channel | 1 of 6 | 6 of 6 |
| Hardcoded single-status render branches in `TranscriptEntry.tsx` | 1 | 0 |
| Owners of the "extra explanatory clause" rule | 2 | 1 |
| Statuses whose CLI line lacks the webview's explanation | 1 | 0 |
| Module-local symbols in `workflowTaskFormatter.ts` | 4 | 2 |
| Named types describing a task detail | 1 | 0 |
| Fields on the exported `TranscriptEntryLayout` | 8 | 6 |
| Exported constants in `ui/glyphs.ts` | 13 | 15 |
| Exported symbols in `src/shared/copy/workflowTask.ts` | 2 | 3 |
| Exported symbols in `panes/transcriptEntryLayout.ts` | 8 | 9 |

**Stated plainly, no hiding: this is net +59 production lines** (+91 / −32 across
the five production files) and roughly net +1 exported symbol repo-wide. The
user-visible defect is six statuses collapsed into one channel, which cannot be
fixed by deleting code; the reduction that *is* available here is taken in full —
two owners of the detail rule collapse to one, the hardcoded single-status branch
collapses into one exhaustive table, and the two layout fields that this change
makes provably wrong are deleted rather than left advertised.

## Headless parity

`texra run`, `--print` and `--output-format json|ndjson` are unaffected by the
glyph/color work, by construction: `CROSS`, `SKIP_CIRCLE` and
`WORKFLOW_TASK_STATUS_STYLE` are referenced only under
`packages/cli/src/chat/tui/`, and `transcriptEntryLayout` has exactly three
importers, all in that tree. The shared-copy change (the not-reached note) does
reach headless output — that is the point: it is plain text with no ANSI and no
glyph, and it moves both the TTY and non-TTY paths in lockstep.
`CliNdjsonRecordContract` passes unchanged.

## Verification

- `npm run typecheck` — clean across all six tsconfigs (root, test-kernel,
  extension, CLI, trace-viewer, desktop).
- `npm test` — 773 files / 7,494 tests passed, 4 skipped.
- `npm run lint` — clean.
- `npm run check:dead-code-ratchet` — 18 findings vs 18 baselined, no new unused
  exports (every new export has a real importer, so no baseline change was
  needed).
- Glyph safety checked directly: `□ ☐ ☑ ✓ ⊘ ✗` are all 1 UTF-16 code unit
  (U+25A1 / U+2610 / U+2611 / U+2713 / U+2298 / U+2717), so `wrapWithPrefix`'s
  code-unit width budget stays exact.

Tests updated / added: rendered-frame assertions for `☑ Finished: …` and
`⊘ Skipped: …`, a table test pinning all six markers as distinct, shared-copy
cases pinning the not-reached line *and* that a `reason: 'user'` skip gets no
clause, and the two existing exact-string assertions that this change alters.

Not done (per the issue's out-of-scope list): per-phase `done/total` counters,
webview icon/colour changes, a `--note` CSS rule, animating `running`, dimming
completed rows, and any change to `WORKFLOW_TASK_STATUS_LABEL`.

One deviation from the issue's enumeration, called out for the reviewer: the
issue's deletion list asserted nothing read `firstPrefix`/`continuationPrefix`
off the layout, but `src/test-kernel/cli/ConversationPane.vitest.mts` asserted
both fields via `toMatchObject`. That assertion is replaced with one that checks
the prefixes where they now live — in `layout.lines`.

Closes #9147

https://claude.ai/code/session_01MQZ63FFrmojmG58wPJdYNH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation and shared string formatting in the CLI TUI and workflow copy module; no auth, persistence, or execution-path changes beyond richer plain-text lines.
> 
> **Overview**
> **CLI workflow-script transcripts** now show each of the six task statuses (`planned`, `running`, `completed`, `cached`, `skipped`, `failed`) with its own glyph and color via an exhaustive `WORKFLOW_TASK_STATUS_STYLE` table. Markers are baked into **layout lines** (so Ctrl-T / static scrollback match the live TUI), and `PlainEntryRows` tints the whole row from that table instead of only coloring `failed`.
> 
> **Shared copy** adds `workflowTaskDetail` so failure messages and the “workflow ended before this task was reached” note live in one place. `formatWorkflowTaskLine` uses it (including headless/tool text), and the progress webview drops its duplicate `taskDetail` helper.
> 
> `TranscriptEntryLayout` no longer exposes misleading `firstPrefix` / `continuationPrefix` fields; workflow tasks get continuation indent and new `CROSS` / `SKIP_CIRCLE` glyphs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 082a5bdc1449079bd9da5b543c1917cc0264d967. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->