### PR TITLE
fix(approval): let cancellation cause win over tool-edit registry sweep

### DIFF
--- a/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
+++ b/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
@@ -19,6 +19,7 @@ import {
   proposalApprovals,
   setDelegatedWorkApprovalBypasses,
   setBashApprovalSessionBypass,
+  type ToolEditApprovalResult,
 } from '@tools/approval';
 
 const sid = (s: string): StreamTabId => s as StreamTabId;
@@ -55,6 +56,48 @@ describe('approval cleanup scope (SDK Step 7d residue #5)', () => {
       expect(isBashApprovalBypassedForStream(b)).toBe(true);
     } finally {
       cleanupApprovalsForStream(b);
+    }
+  });
+
+  it('lets the cancellation cause win over the tool-edit registry sweep (#9142)', () => {
+    // Mirrors nativeToolEditApproval.ts / desktopToolEditApproval.ts: a host
+    // adapter's own `cancel` and the session's tool-edit registry both settle
+    // the *same* entry through a shared, idempotent `settle` closure. Whoever
+    // calls it first determines the user-visible result.
+    const session = createTestSession();
+    const streamId = sid('s:cause-swallow');
+    let settled: ToolEditApprovalResult | undefined;
+    let isSettled = false;
+    const settle = (result: ToolEditApprovalResult): void => {
+      if (isSettled) return;
+      isSettled = true;
+      settled = result;
+    };
+
+    session.approvals.toolEdit.registerPending(streamId, {
+      streamId,
+      isSettled: () => isSettled,
+      settle,
+    });
+    session.useHostInteractions({
+      cancel: (selector = {}) => {
+        if (selector.streamId !== streamId) return;
+        settle({ accepted: false, userMessage: selector.cause });
+      },
+    });
+
+    try {
+      cleanupApprovalsForStream(streamId, session);
+      // Before #9142's reorder, the registry sweep ran first and settled a
+      // bare `{ accepted: false }`; the later `cancel` call then found the
+      // entry already settled and became a no-op.
+      expect(settled).toEqual({
+        accepted: false,
+        userMessage: 'Stream resources released.',
+      });
+    } finally {
+      session.approvals.toolEdit.unregisterPending(streamId);
+      session.dispose();
     }
   });
 

--- a/src/tools/approval/index.ts
+++ b/src/tools/approval/index.ts
@@ -62,16 +62,19 @@ export function cleanupApprovalsForStream(
   session: SessionHandle = defaultSession(),
 ): void {
   const { toolEdit, bash, proposal } = session.approvals;
+  // Cancel the host interaction first so its cause-carrying settlement wins;
+  // the registry sweep below is then a no-op via the idempotent
+  // `approvalSettled` guard instead of the one that determines the result.
+  session.interactions.cancel({
+    streamId,
+    cause: 'Stream resources released.',
+  });
   toolEdit.rejectPendingForStream(streamId);
   bash.rejectPendingForStream(streamId);
   session.approvals.forgetStreamAncestry(streamId);
   toolEdit.bypass.clearForStream(streamId);
   bash.bypass.clearForStream(streamId);
   proposal.clearForStream(streamId);
-  session.interactions.cancel({
-    streamId,
-    cause: 'Stream resources released.',
-  });
 }
 
 /**
@@ -109,12 +112,14 @@ export function releaseStreamResources(
 export function cleanupUnscopedApprovals(
   session: SessionHandle = defaultSession(),
 ): void {
-  session.approvals.toolEdit.rejectUnscopedPending();
-  session.approvals.bash.rejectUnscopedPending();
+  // Cancel first so its cause-carrying settlement wins over the registry
+  // sweep below (see `cleanupApprovalsForStream`).
   session.interactions.cancel({
     streamId: null,
     cause: 'Streamless approval cleanup.',
   });
+  session.approvals.toolEdit.rejectUnscopedPending();
+  session.approvals.bash.rejectUnscopedPending();
 }
 
 /**


### PR DESCRIPTION
## What changed

Scoped, standalone fix from #9142 — PR 1 of 3, deliberately shipped alone (no deletion work).

`src/tools/approval/index.ts` swept the (redundant) tool-edit/bash pending
registries **before** calling `session.interactions.cancel()` in both
`cleanupApprovalsForStream` and `cleanupUnscopedApprovals`. The registry sweep
settles a bare `{ accepted: false }` via the *same* shared, idempotent
`settle` closure that `nativeToolEditApproval.ts` / `desktopToolEditApproval.ts`
register with the host adapter's own `cancel`. Because the sweep ran first,
by the time `cancel()` ran with its cause (`'Stream resources released.'` /
`'Streamless approval cleanup.'`), the `approvalSettled` guard made it a
no-op — so a user watching a stream/window close never learned *why* their
pending tool-edit approval vanished; the model just saw a bare rejection.

Fix: reorder both functions so `session.interactions.cancel(...)` runs
**first**. Its cause-carrying settlement now wins, and the later registry
sweep becomes the no-op instead (via the same idempotent guard, just now on
the other side).

This is a pure 2-line move in each function — no deletions, no renames, no
new types. Per the issue, PR 1 stands alone and survives a revert of PR 2
(deleting the redundant `StreamApprovalController` registries), since
reverting PR 2 restores the pre-PR-1 statement ordering.

## Element reduction

None claimed for this PR — it is a behavior-only reorder (2 statements moved
in each of 2 functions), not a deletion PR. The registry deletions and their
LOC reduction are PR 2's scope, filed separately per the issue.

`git diff --shortstat`:
```
2 files changed, 54 insertions(+), 6 deletions(-)
```

The `+54/-6` is dominated by a new regression test (48 lines); production code in `index.ts` is a pure reorder (11 insertions / 6 deletions, net +5 for explanatory comments, 0 new statements).

## Test added

`src/test-kernel/tools/ApprovalCleanupScope.vitest.ts` — new test
`'lets the cancellation cause win over the tool-edit registry sweep (#9142)'`.

This is a white-box unit test that mirrors the *actual* production mechanism
(a single shared, idempotent `settle` closure registered both with the
session's tool-edit registry and invoked directly by the host adapter's own
`cancel`), rather than a full end-to-end desktop/extension integration test.
I verified during development that an end-to-end test through the full
`HostInteractions`-wrapped desktop bridge does **not** reliably discriminate
this fix: `HostInteractions.cancel()`'s own independent registry-1 fallback
(a separate, correct mechanism — not the bug) wins an unrelated microtask
race regardless of statement order, masking the very difference this PR
fixes. The white-box test isolates the actual mechanism the issue describes
and is confirmed to fail on the pre-fix ordering and pass on the fix:

```
# pre-fix (stashed the index.ts change back to the original order):
AssertionError: expected { accepted: false } to deeply equal { accepted: false, …(1) }
- Expected
+ Received
  {
    "accepted": false,
-   "userMessage": "Stream resources released.",
  }

# post-fix: passes
```

## Verification

- `npm run typecheck` — all six tsconfigs (root, test-kernel, extension, CLI, trace-viewer, desktop) pass, exit 0.
- `npm test` — 773 files passed, 1 skipped; 7493 tests passed, 4 skipped. No failures, no new skips introduced by this change.
- `npm run lint` — passes, exit 0.
- `npm run check:dead-code-ratchet` — passes: 18 current findings vs 18 baselined (unchanged), `config/ratchets/knip-baseline.json` untouched.

Targeted suites (all pass) also re-run: `ApprovalCleanupScope`, `ToolEditApprovalGate`, `HumanPromptProgressEvents`, `ChildStreamYoloInheritance`, `SessionInteractions`, `ApprovalAdapter`, `NativeToolEditApproval`, `DesktopToolEditApproval`, `DesktopAgentExecution`, `ExtensionHostInteractions`, `PlanToolWorkPlanState`, `ToolUseWaitNode`.

## Scope notes

Per the issue, this PR does **not** touch:
- The `StreamApprovalController` registry deletions, `toggleBypass`, or the `R`-generic collapse (PR 2).
- The CLI's inert approval-event plane / `isRuntimeInteractionEvent` (PR 3).
- `setApprovalBypassState` / bypass-announcement channels (explicitly refuted as in-scope — single host, optional, called with `?.`).

Closes #9142.

https://claude.ai/code/session_01MQZ63FFrmojmG58wPJdYNH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 0b97f4366b75af37148afd0ad3fa5e3dcf196626. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
