### PR TITLE
feat(cli): show prepared context images in the TUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,9 @@ All notable changes to this project will be documented in this file.
   running, finished, saved-result, skipped, and failed, instead of every row
   looking alike. A task the run never reached now also explains itself the way
   the progress view already did.
+- **Loaded images are visible in the terminal transcript** — image and PDF
+  inputs show their file path and size after they are prepared as context
+  media.
 
 ## [0.39.8] - 2026-07-24
 

--- a/packages/cli/src/chat/tui/panes/loadedImageDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/loadedImageDisplay.ts
@@ -1,0 +1,53 @@
+// Local imports - shared formatting
+import { formatBytes } from '@shared/utils/string';
+import { collapseWhitespace } from '@utils/text/stringUtils';
+
+// Local imports - CLI TUI rendering
+import {
+  safeTerminalText,
+  textDisplayWidth,
+  truncateSummaryToWidth,
+  truncateToWidth,
+} from '../render/terminalText';
+
+// Local imports - CLI TUI glyphs
+import { POINTER } from '../ui/glyphs';
+import type { LoadedImage } from '../state/cliState';
+
+/** The one terminal-text representation of an image prepared as context media. */
+function loadedImageDisplayBody(
+  image: LoadedImage,
+  maxColumns?: number,
+): string {
+  const prefix = '[image] ';
+  const suffix = ` (${formatBytes(image.sizeBytes)})`;
+  const safePath = collapseWhitespace(safeTerminalText(image.path));
+  const body = `${prefix}${safePath}${suffix}`;
+  if (maxColumns === undefined || textDisplayWidth(body) <= maxColumns) {
+    return body;
+  }
+
+  const pathColumns =
+    maxColumns - textDisplayWidth(prefix) - textDisplayWidth(suffix);
+  if (pathColumns > 0) {
+    return `${prefix}${truncateSummaryToWidth(safePath, pathColumns)}${suffix}`;
+  }
+  return truncateToWidth(body, Math.max(1, maxColumns));
+}
+
+export function loadedImageDisplayLines(
+  images: readonly LoadedImage[],
+  maxColumns?: number,
+): readonly string[] {
+  const pointer = `${POINTER} `;
+  const bodyColumns =
+    maxColumns === undefined
+      ? undefined
+      : Math.max(1, maxColumns - textDisplayWidth(pointer));
+  return images.map((image) => {
+    const line = `${pointer}${loadedImageDisplayBody(image, bodyColumns)}`;
+    return maxColumns === undefined
+      ? line
+      : truncateToWidth(line, Math.max(1, maxColumns));
+  });
+}

--- a/packages/cli/src/chat/tui/panes/transcriptEntries.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntries.ts
@@ -70,6 +70,8 @@ export function isRenderableTranscriptEntry(entry: ConversationEntry): boolean {
     case 'phase':
     case 'workflowTask':
       return terminalVisibleTranscriptText(entry.text).trim().length > 0;
+    case 'media':
+      return entry.images.length > 0;
     case 'tool':
       return true;
   }

--- a/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
@@ -25,6 +25,7 @@ import {
   USER_ENTRY_PREFIX,
 } from '../ui/glyphs';
 import { isInquiryContinuationText } from './transcriptEntries';
+import { loadedImageDisplayLines } from './loadedImageDisplay';
 import { toolUseDisplayLines, toolUseMarginBottomRows } from './toolRenderers';
 import type { ConversationEntry } from '../state/cliState';
 
@@ -58,6 +59,13 @@ const ROLE_GEOMETRY = {
     firstPrefix: ERROR_ENTRY_PREFIX,
     continuationPrefix: ' '.repeat(ERROR_ENTRY_PREFIX.length),
     inset: 2,
+    marginBottomRows: 0,
+    marginTopRows: 0,
+  },
+  media: {
+    firstPrefix: '',
+    continuationPrefix: '  ',
+    inset: 0,
     marginBottomRows: 0,
     marginTopRows: 0,
   },
@@ -236,6 +244,8 @@ function entryLines(
       // terminal row. Other modes paint the wrapped text projection directly.
       return richProjection ? lines : wrapDisplayLines(lines, columns);
     }
+    case 'media':
+      return loadedImageDisplayLines(entry.images, columns);
     case 'phase': {
       const geometry = ROLE_GEOMETRY.phase;
       return wrapWithPrefix(

--- a/packages/cli/src/chat/tui/render/terminalText.ts
+++ b/packages/cli/src/chat/tui/render/terminalText.ts
@@ -1,6 +1,20 @@
 import stringWidth from 'string-width';
+import stripAnsi from 'strip-ansi';
 
 import { collapseWhitespace } from '@utils/text/stringUtils';
+
+const UNSAFE_TERMINAL_CONTROLS =
+  // eslint-disable-next-line no-control-regex -- terminal output must exclude C0/C1 controls
+  /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]/g;
+
+/** Remove terminal control sequences while preserving printable text and line breaks. */
+export function safeTerminalText(text: string): string {
+  return stripAnsi(text)
+    .replaceAll('\r\n', '\n')
+    .replaceAll('\r', '\n')
+    .replaceAll('\t', '  ')
+    .replaceAll(UNSAFE_TERMINAL_CONTROLS, '');
+}
 
 export function textDisplayWidth(text: string): number {
   return stringWidth(text);

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -81,6 +81,11 @@ type ConversationEntryOrigin =
       readonly syntheticAfterSettlementSeqNo: number;
     };
 
+export interface LoadedImage {
+  readonly path: string;
+  readonly sizeBytes: number;
+}
+
 /**
  * Discriminated on `role` so `toolUse` is required exactly for the rows that
  * need it, instead of an independently-optional field every consumer has to
@@ -108,6 +113,10 @@ export type ConversationEntry = ConversationEntryOrigin &
     | (ConversationEntryBase & {
         readonly role: 'tool';
         readonly toolUse: NormalizedToolUse;
+      })
+    | (ConversationEntryBase & {
+        readonly role: 'media';
+        readonly images: readonly LoadedImage[];
       })
   );
 

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -12,6 +12,7 @@ import {
   AgentCategory,
   CompactionActivityDataSchema,
   ErrorLogDataSchema,
+  FileListEntrySchema,
   GroupLogPayloadSchema,
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
@@ -33,6 +34,7 @@ import { createFlushableDebounce } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { truncateSummary } from '@utils/text/stringUtils';
 import { normalizeKnownHtmlForCliMarkdown } from '../render/htmlMarkdownNormalize';
+import { safeTerminalText } from '../render/terminalText';
 import {
   isRenderableTranscriptEntry,
   trimAssistantTranscriptLead,
@@ -45,16 +47,44 @@ import {
   patchStream,
   setTransientNotice,
   type ConversationEntry,
+  type LoadedImage,
 } from './cliState';
 import { isChildStreamRemoved } from './childExecutions';
 import { subscribeToSignalChanges } from './signalSubscription';
 import { isFinalTranscriptStatus } from './transcript';
-import { safeTerminalText } from './transcriptLines';
 
 const MAX_ERROR_DETAIL_LENGTH = 240;
 
+function projectFileListImages(data: unknown): LoadedImage[] {
+  if (!Array.isArray(data)) return [];
+
+  const images: LoadedImage[] = [];
+  const seen = new Set<string>();
+  for (const candidate of data) {
+    const entry = FileListEntrySchema.safeParse(candidate);
+    if (
+      !entry.success ||
+      !entry.data.ok ||
+      entry.data.media?.kind !== 'image'
+    ) {
+      continue;
+    }
+    if (!entry.data.path.trim()) continue;
+    const image = {
+      path: entry.data.path,
+      sizeBytes: entry.data.media.sizeBytes,
+    };
+    const key = `${image.path}\u0000${image.sizeBytes}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    images.push(image);
+  }
+  return images;
+}
+
 const TRANSCRIPT_MESSAGE_TYPES = new Set<string>([
   MESSAGE_TYPES.ERROR,
+  MESSAGE_TYPES.FILE_LIST,
   MESSAGE_TYPES.MODEL_RESPONSE,
   MESSAGE_TYPES.TOOL_USE,
   MESSAGE_TYPES.USER_MESSAGE,
@@ -230,6 +260,9 @@ function entriesEqual(
   if (prev.role === 'tool' && next.role === 'tool') {
     return toolUseEqual(prev.toolUse, next.toolUse);
   }
+  if (prev.role === 'media' && next.role === 'media') {
+    return isDeepStrictEqual(prev.images, next.images);
+  }
   if (prev.role === 'phase' && next.role === 'phase') {
     return (
       prev.phaseIndex === next.phaseIndex && prev.phaseTotal === next.phaseTotal
@@ -327,6 +360,24 @@ function renderLogEntry(
   entry: StreamLogEntry,
   prev: ConversationEntry | undefined,
 ): ConversationEntry | null {
+  if (entry.messageType === MESSAGE_TYPES.FILE_LIST) {
+    const images = projectFileListImages(entry.data);
+    if (images.length === 0) return null;
+    const next: ConversationEntry = {
+      id: entry.id,
+      sourceSeqNo: entry.seqNo,
+      role: 'media',
+      text: '',
+      messageType: MESSAGE_TYPES.FILE_LIST,
+      finalized: true,
+      ...(entry.settlementSeqNo !== undefined
+        ? { settlementSeqNo: entry.settlementSeqNo }
+        : {}),
+      images,
+    };
+    return prev && entriesEqual(prev, next) ? prev : next;
+  }
+
   if (entry.messageType === MESSAGE_TYPES.TOOL_USE) {
     // Cache hit: same `data` reference as last sync, no re-normalize.
     // Promotion to `<Static>` is decided later by `finalizeSettledPrefix`
@@ -463,6 +514,7 @@ function isSettledEntry(
     case 'user':
     case 'error':
     case 'phase':
+    case 'media':
       return true;
     case 'tool':
       return (
@@ -668,6 +720,7 @@ export function syncStreamLog(
         (!workflowOperationalOnly ||
           entry.role === 'tool' ||
           entry.role === 'phase' ||
+          entry.role === 'media' ||
           entry.role === 'error'),
     );
     const streamFinal = isFinalTranscriptStatus(slice.status);
@@ -705,6 +758,7 @@ export function syncStreamLog(
         workflowOperationalOnly &&
         rendered.role !== 'tool' &&
         rendered.role !== 'phase' &&
+        rendered.role !== 'media' &&
         rendered.role !== 'error'
       ) {
         continue;

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -55,6 +55,10 @@ import { isFinalTranscriptStatus } from './transcript';
 
 const MAX_ERROR_DETAIL_LENGTH = 240;
 
+/**
+ * Project successful local context-media preparation. FILE_LIST does not
+ * claim that a remote provider subsequently accepted the attachment.
+ */
 function projectFileListImages(data: unknown): LoadedImage[] {
   if (!Array.isArray(data)) return [];
 

--- a/packages/cli/src/chat/tui/state/transcriptLines.ts
+++ b/packages/cli/src/chat/tui/state/transcriptLines.ts
@@ -2,11 +2,11 @@
 // for print-once terminal output. Unlike the finalized scrollback and the live
 // region, this renders every tool-output line.
 
-import stripAnsi from 'strip-ansi';
 import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 
 import { isRenderableTranscriptEntry } from '../panes/transcriptEntries';
 import { fullTranscriptEntryLayout } from '../panes/transcriptEntryLayout';
+import { safeTerminalText } from '../render/terminalText';
 import type { ConversationEntry, StreamSlice } from './cliState';
 
 export interface TranscriptPrintRequest {
@@ -169,19 +169,6 @@ export function transcriptToLines(
     previousLines = lines;
   }
   return out;
-}
-
-const UNSAFE_TERMINAL_CONTROLS =
-  // eslint-disable-next-line no-control-regex -- terminal output must exclude C0/C1 controls
-  /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]/g;
-
-/** Remove terminal control sequences while preserving printable text and line breaks. */
-export function safeTerminalText(text: string): string {
-  return stripAnsi(text)
-    .replaceAll('\r\n', '\n')
-    .replaceAll('\r', '\n')
-    .replaceAll('\t', '  ')
-    .replaceAll(UNSAFE_TERMINAL_CONTROLS, '');
 }
 
 /** Format one immutable request for the terminal's static scrollback. */

--- a/src/agent/modelHandlers/google/googleHandlerShared.ts
+++ b/src/agent/modelHandlers/google/googleHandlerShared.ts
@@ -179,6 +179,8 @@ interface UploadGoogleMediaEntriesOptions<T> {
   onInsertedEntry?: (entry: MediaEntry) => void;
 }
 
+type GoogleMediaUploadSummary = Pick<MediaFileResult, 'path' | 'ok'>;
+
 /**
  * Shared media-attachment pipeline for the two Google handlers. Entries are
  * sent inline when small enough, otherwise uploaded through the File API.
@@ -201,7 +203,7 @@ export async function uploadGoogleMediaEntries<T>(
   } = options;
   const client = await getClient();
   const parts: T[] = [];
-  const summaries: MediaFileResult[] = [];
+  const summaries: GoogleMediaUploadSummary[] = [];
   const failures: string[] = [];
 
   for (const entry of entries) {

--- a/src/agent/modelHandlers/support/MediaAttachmentProcessor.ts
+++ b/src/agent/modelHandlers/support/MediaAttachmentProcessor.ts
@@ -9,11 +9,11 @@ import pMap from 'p-map';
 import { logFilesLoaded, type AgentTrace } from '@agent/trace';
 import type { MediaEntry } from '@agent/utils/mediaTypes';
 import { getSdkErrorMessage } from '@common/errors';
-import type { FileLocation } from '@shared/schemas';
+import type { FileLocation, LoadedMediaMetadata } from '@shared/schemas';
 
 // Local imports - utils
 import { ensureArray } from '@utils/core';
-import { AbsoluteFS, getMimeType, getShortDisplayPath } from '@utils/files';
+import { AbsoluteFS, getComparablePath, getMimeType } from '@utils/files';
 import { getExtensionLowercase } from '@utils/core/pathCore';
 import {
   countPdfPages,
@@ -25,10 +25,19 @@ import type { ModelCapabilities } from 'llm-zoo';
 /**
  * Result of loading a media file.
  * @property path - Display path for logging/UI (workspace-relative for workspace files,
- *   basename for external files). NOT the absolute path used for file operations.
+ *   absolute for external files). This is not used for file operations.
  * @property ok - Whether the file was successfully loaded
  */
-export type MediaFileResult = { path: string; ok: boolean };
+export type MediaFileResult =
+  | {
+      path: string;
+      ok: true;
+      media: LoadedMediaMetadata;
+    }
+  | {
+      path: string;
+      ok: false;
+    };
 
 type ProcessImageResult = {
   kind: 'image';
@@ -186,7 +195,7 @@ export class MediaAttachmentProcessor {
         }
       } else {
         const { location, reason } = loadResult;
-        const displayPath = getShortDisplayPath(location);
+        const displayPath = getComparablePath(location);
         this.logger.error(
           `Failed to load media entry for ${displayPath}: ${getSdkErrorMessage(reason)}`,
           {
@@ -216,7 +225,9 @@ export class MediaAttachmentProcessor {
     location: FileLocation,
   ): Promise<{ entry?: MediaEntry | MediaEntry[]; result: MediaFileResult }> {
     const absolutePath = location.absolutePath;
-    const displayPath = getShortDisplayPath(location);
+    // Workspace/run-storage paths remain concise and relative; external media
+    // keeps its absolute path so a terminal row identifies the actual file.
+    const displayPath = getComparablePath(location);
     const fileExistsResult = await AbsoluteFS.exists(absolutePath);
 
     if (!fileExistsResult) {
@@ -265,7 +276,15 @@ export class MediaAttachmentProcessor {
 
       return {
         entry,
-        result: { path: displayPath, ok: true },
+        result: {
+          path: displayPath,
+          ok: true,
+          media: {
+            kind: processed.kind,
+            mimeType: processed.mediaType,
+            sizeBytes: fileSize,
+          },
+        },
       };
     } catch (err) {
       this.logger.error(

--- a/src/shared/schemas/log.ts
+++ b/src/shared/schemas/log.ts
@@ -78,6 +78,25 @@ export const STREAM_LOG_ENTRY_TYPES = {
 
 const StreamLogEntryTypeSchema = z.enum(STREAM_LOG_ENTRY_TYPES);
 
+const LoadedMediaMetadataSchema = z.discriminatedUnion('kind', [
+  z.object({
+    /**
+     * Visual model input, including PDFs handled natively or rendered into
+     * pages. The TUI's `[image]` label describes this model-facing category,
+     * not merely an `image/*` filesystem MIME type.
+     */
+    kind: z.literal('image'),
+    mimeType: z.string().min(1),
+    sizeBytes: z.int().nonnegative(),
+  }),
+  z.object({
+    kind: z.literal('audio'),
+    mimeType: z.string().min(1),
+    sizeBytes: z.int().nonnegative(),
+  }),
+]);
+export type LoadedMediaMetadata = z.infer<typeof LoadedMediaMetadataSchema>;
+
 export const FileListEntrySchema = z.object({
   path: z.string(),
   ok: z.boolean(),
@@ -85,6 +104,8 @@ export const FileListEntrySchema = z.object({
   sourceDisplay: z.string().optional(),
   varName: z.string().optional(),
   internal: z.boolean().optional(),
+  /** Present only when this file was loaded through the media pipeline. */
+  media: LoadedMediaMetadataSchema.optional(),
 });
 
 export type FileListEntry = z.infer<typeof FileListEntrySchema>;

--- a/src/test-kernel/agent/modelHandlers/support/MediaAttachmentProcessor.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/support/MediaAttachmentProcessor.vitest.ts
@@ -19,7 +19,7 @@ import {
 import { attachProviderError } from '@common/errors/sdkErrorUtils';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { setupPlatform } from '@test/support/setupPlatform';
-import { AbsoluteFS, pathToLocation, getShortDisplayPath } from '@utils/files';
+import { AbsoluteFS, getComparablePath, pathToLocation } from '@utils/files';
 
 interface MediaLogRecorder extends AgentTrace {
   debugMessages: string[];
@@ -175,7 +175,7 @@ describe('MediaAttachmentProcessor', () => {
   it('processes PDF fixtures using native ingestion when supported', async () => {
     const pdfPath = await createPdfFixture();
     const pdfLocation = pathToLocation(pdfPath);
-    const displayPath = getShortDisplayPath(pdfLocation);
+    const displayPath = getComparablePath(pdfLocation);
     const { logger, stub } = createMediaLogRecorder();
     const processor = createProcessor(logger, {
       supportsVision: true,
@@ -184,7 +184,22 @@ describe('MediaAttachmentProcessor', () => {
 
     const { entries, results } = await processor.loadEntries([pdfLocation]);
 
-    assert.deepEqual(results, [{ path: displayPath, ok: true }]);
+    assert.deepEqual(results, [
+      {
+        path: displayPath,
+        ok: true,
+        media: {
+          kind: 'image',
+          mimeType: 'application/pdf',
+          sizeBytes: fs.statSync(pdfPath).size,
+        },
+      },
+    ]);
+    assert.equal(
+      displayPath,
+      pdfPath,
+      'external media keeps its absolute path',
+    );
     assert.equal(entries.length, 1, 'expected a single PDF entry');
 
     const [entry] = entries;
@@ -206,7 +221,7 @@ describe('MediaAttachmentProcessor', () => {
   it('processes native audio fixtures into audio media entries', async () => {
     const audioPath = createAudioFixture();
     const audioLocation = pathToLocation(audioPath);
-    const displayPath = getShortDisplayPath(audioLocation);
+    const displayPath = getComparablePath(audioLocation);
     const { logger, stub } = createMediaLogRecorder();
     const processor = createProcessor(
       logger,
@@ -218,7 +233,17 @@ describe('MediaAttachmentProcessor', () => {
 
     const { entries, results } = await processor.loadEntries([audioLocation]);
 
-    assert.deepEqual(results, [{ path: displayPath, ok: true }]);
+    assert.deepEqual(results, [
+      {
+        path: displayPath,
+        ok: true,
+        media: {
+          kind: 'audio',
+          mimeType: 'audio/wav',
+          sizeBytes: fs.statSync(audioPath).size,
+        },
+      },
+    ]);
     assert.equal(entries.length, 1, 'expected a single audio entry');
 
     const [entry] = entries;
@@ -232,6 +257,37 @@ describe('MediaAttachmentProcessor', () => {
     assert.equal(stub.fileListEntries.length, 1, 'should log processed audio');
   });
 
+  it('keeps loaded workspace media relative in its typed result', async () => {
+    const relativePath = 'documents/workspace.pdf';
+    const mediaPath = await createPdfFixture();
+    const sizeBytes = fs.statSync(mediaPath).size;
+    const location = {
+      kind: 'workspace',
+      absolutePath: mediaPath,
+      relativePath,
+    } as const;
+    const { logger, stub } = createMediaLogRecorder();
+    const processor = createProcessor(logger, {
+      supportsVision: true,
+      supportsNativePdf: true,
+    });
+
+    const { results } = await processor.loadEntries([location]);
+
+    assert.deepEqual(stub.errorMessages, []);
+    assert.deepEqual(results, [
+      {
+        path: relativePath,
+        ok: true,
+        media: {
+          kind: 'image',
+          mimeType: 'application/pdf',
+          sizeBytes,
+        },
+      },
+    ]);
+  });
+
   for (const [extension, mediaType] of [
     ['.opus', 'audio/opus'],
     ['.l16', 'audio/l16'],
@@ -241,7 +297,7 @@ describe('MediaAttachmentProcessor', () => {
     it(`processes ${extension} audio with provider-supported MIME type`, async () => {
       const audioPath = createRawAudioFixture(extension);
       const audioLocation = pathToLocation(audioPath);
-      const displayPath = getShortDisplayPath(audioLocation);
+      const displayPath = getComparablePath(audioLocation);
       const { logger } = createMediaLogRecorder();
       const processor = createProcessor(
         logger,
@@ -253,7 +309,17 @@ describe('MediaAttachmentProcessor', () => {
 
       const { entries, results } = await processor.loadEntries([audioLocation]);
 
-      assert.deepEqual(results, [{ path: displayPath, ok: true }]);
+      assert.deepEqual(results, [
+        {
+          path: displayPath,
+          ok: true,
+          media: {
+            kind: 'audio',
+            mimeType: mediaType,
+            sizeBytes: fs.statSync(audioPath).size,
+          },
+        },
+      ]);
       assert.equal(entries.length, 1, 'expected a single audio entry');
 
       const [entry] = entries;
@@ -268,7 +334,7 @@ describe('MediaAttachmentProcessor', () => {
   it('reports empty media fixtures as failed loads', async () => {
     const emptyPath = createEmptyFixture();
     const emptyLocation = pathToLocation(emptyPath);
-    const displayPath = getShortDisplayPath(emptyLocation);
+    const displayPath = getComparablePath(emptyLocation);
     const { logger, stub } = createMediaLogRecorder();
     const processor = createProcessor(logger, { supportsVision: true });
 
@@ -292,7 +358,7 @@ describe('MediaAttachmentProcessor', () => {
   it('keeps SDK-specific media load errors in the visible log message', async () => {
     const mediaPath = createTempFile('sdk-error.png', Buffer.from('not-png'));
     const mediaLocation = pathToLocation(mediaPath);
-    const displayPath = getShortDisplayPath(mediaLocation);
+    const displayPath = getComparablePath(mediaLocation);
     const { logger, stub } = createMediaLogRecorder();
     const processor = createProcessor(logger, { supportsVision: true });
     const originalExists = absoluteFsAny.exists;

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -29,6 +29,7 @@ import {
   createTuiViewportController,
   type TuiRepaintOptions,
 } from '@cli/chat/tui/render/tuiViewportController';
+import { textDisplayWidth } from '@cli/chat/tui/render/terminalText';
 import {
   estimateTranscriptEntryRows,
   selectTranscriptEntriesForViewport,
@@ -506,6 +507,25 @@ describe('CLI conversation transcript splitting', () => {
     expect(selectTranscriptEntriesForViewport([tool], 20, 20).usedRows).toBe(
       transcriptEntryLayoutRows(liveLayout),
     );
+  });
+
+  it('clips a standalone loaded-image event to one transcript row', () => {
+    const media: ConversationEntry = {
+      id: 'media-1',
+      role: 'media',
+      text: '',
+      finalized: true,
+      images: [
+        {
+          path: '/private/tmp/plot-with-a-long-name.png',
+          sizeBytes: 8704,
+        },
+      ],
+    };
+    const layout = transcriptEntryLayout(media, { width: 24 });
+
+    expect(layout.lines).toEqual(['› [image] /pr… (8.5 KiB)']);
+    expect(textDisplayWidth(layout.lines[0] ?? '')).toBe(24);
   });
 
   it('keeps bounded rich display rows unwrapped', () => {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -1437,6 +1437,77 @@ describe('CLI transcript state', () => {
     );
   });
 
+  it('renders typed loaded images once and excludes ordinary file lists', () => {
+    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    logger.domain({
+      key: 'filesLoaded',
+      data: {
+        category: 'all',
+        entries: [
+          {
+            path: '/private/tmp/loaded.png',
+            ok: true,
+            media: {
+              kind: 'image',
+              mimeType: 'image/png',
+              sizeBytes: 8704,
+            },
+          },
+          {
+            path: '/private/tmp/loaded.png',
+            ok: true,
+            media: {
+              kind: 'image',
+              mimeType: 'image/png',
+              sizeBytes: 8704,
+            },
+          },
+          {
+            path: '/private/tmp/paper.pdf',
+            ok: true,
+            media: {
+              kind: 'image',
+              mimeType: 'application/pdf',
+              sizeBytes: 8192,
+            },
+          },
+          {
+            path: '/private/tmp/audio.wav',
+            ok: true,
+            media: {
+              kind: 'audio',
+              mimeType: 'audio/wav',
+              sizeBytes: 4096,
+            },
+          },
+          {
+            path: 'paper.tex',
+            ok: true,
+            source: 'inputFiles',
+          },
+        ],
+      },
+    });
+
+    syncStreamLog(root);
+    syncStreamLog(root);
+
+    const entries = streams.get().get(root)?.entries ?? [];
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      role: 'media',
+      finalized: true,
+      images: [
+        { path: '/private/tmp/loaded.png', sizeBytes: 8704 },
+        { path: '/private/tmp/paper.pdf', sizeBytes: 8192 },
+      ],
+    });
+    expect(transcriptEntryLayout(entries[0]).lines).toEqual([
+      '› [image] /private/tmp/loaded.png (8.5 KiB)',
+      '› [image] /private/tmp/paper.pdf (8 KiB)',
+    ]);
+  });
+
   it('summarizes subagent protocol continuations in the visible transcript', () => {
     const logger = createRunTrace(root, defaultSession().transcripts).trace;
     logger.info('Please solve the problem.', {

--- a/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.mts
+++ b/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.mts
@@ -928,6 +928,87 @@ describe('CLI workflow-script child-stream transcript', () => {
     }
   });
 
+  it('keeps cold static FILE_LIST order equal to incremental settlement order', async () => {
+    const runTrace = createRunTrace(STREAM_ID, defaultSession().transcripts);
+    try {
+      runTrace.trace.toolStart({
+        logId: 'audit-tool',
+        toolName: 'bash',
+        input: { command: 'pwd' },
+      });
+      runTrace.trace.domain({
+        key: 'filesLoaded',
+        data: {
+          category: 'all',
+          entries: [
+            {
+              path: '/private/tmp/loaded.png',
+              ok: true,
+              media: {
+                kind: 'image',
+                mimeType: 'image/png',
+                sizeBytes: 8704,
+              },
+            },
+          ],
+        },
+      });
+      syncStreamLog(STREAM_ID);
+
+      let incrementalItems = appendStaticTranscriptItems({
+        currentItems: [],
+        meta: SESSION_META,
+        scrollbackStreamId: STREAM_ID,
+        streams: streams.get(),
+      });
+      const firstEntries = incrementalItems.filter(
+        (item) => item.kind === 'entry',
+      );
+      expect(firstEntries.map((item) => item.entry.role)).toEqual(['media']);
+
+      runTrace.trace.toolEnd({
+        logId: 'audit-tool',
+        status: TOOL_USE_STATUS.COMPLETED,
+        result: {
+          toolName: 'bash',
+          input: { command: 'pwd' },
+          output: '/tmp/project',
+        },
+      });
+      syncStreamLog(STREAM_ID);
+      incrementalItems = appendStaticTranscriptItems({
+        currentItems: incrementalItems,
+        meta: SESSION_META,
+        scrollbackStreamId: STREAM_ID,
+        streams: streams.get(),
+      });
+      const coldItems = appendStaticTranscriptItems({
+        currentItems: [],
+        meta: SESSION_META,
+        scrollbackStreamId: STREAM_ID,
+        streams: streams.get(),
+      });
+      const entries = (
+        items: ReturnType<typeof appendStaticTranscriptItems>,
+      ): readonly ConversationEntry[] =>
+        items.filter((item) => item.kind === 'entry').map((item) => item.entry);
+
+      expect(entries(incrementalItems).map((entry) => entry.role)).toEqual([
+        'media',
+        'tool',
+      ]);
+      expect(entries(coldItems).map((entry) => entry.id)).toEqual(
+        entries(incrementalItems).map((entry) => entry.id),
+      );
+      const output = await renderStaticTranscript();
+      expect(output.indexOf('[image] /private/tmp/loaded.png')).toBeLessThan(
+        output.indexOf('bash'),
+      );
+    } finally {
+      runTrace.dispose();
+    }
+  });
+
   it('keeps an immutable round header ahead of its later log rows', async () => {
     const runTrace = createRunTrace(STREAM_ID, defaultSession().transcripts);
     try {


### PR DESCRIPTION
## Summary

The terminal transcript now shows concise, terminal-safe rows such as `› [image] figures/result.png (8.5 KiB)` when an image or PDF has been successfully read and prepared as context media. This covers configured, pasted, and workflow context files.

`read_file` keeps its ordinary textual tool presentation. No special exclusion is required: that tool does not emit the context-media `FILE_LIST` event used by this view.

## Single source of truth

`MediaAttachmentProcessor` remains the owner of successful context-media preparation. It adds typed media kind, MIME type, and byte size to the existing structured `FILE_LIST` entry. The extension already consumes this event family; the terminal client now projects the same fact into a vivid transcript row.

The renderer does not infer model visibility from paths, MIME strings, or rendered text. It displays only successful structured entries and sanitizes paths for terminal control characters and width.

## Scope discipline

The earlier version also introduced provider-wide receipts for arbitrary tool-result attachments. Review showed that this was a separate feature and was inconsistent with the extension surface. That migration has been removed. The final change is one commit, 15 files, and +444/-32 lines, rather than 64 files and +2465/-335 lines.

A `FILE_LIST` event proves successful local preparation as context media; it does not claim that a remote provider subsequently accepted the attachment. User-facing wording follows that distinction.

## Validation

- 207 focused tests covering media preparation, live and reconstructed transcript ordering, terminal width, and workflow context files
- full workspace type checking before the final rebase; CLI type checking after conflict resolution
- full lint before the final rebase; ESLint on every conflict-resolved file afterward
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI transcript and display-path formatting changes only; media metadata extends an existing log schema without touching auth, billing, or provider upload behavior beyond typing.
> 
> **Overview**
> **Loaded image and PDF inputs now appear in the CLI transcript** after they are successfully prepared as context media. Each row looks like `› [image] path (8.5 KiB)`, with terminal-safe paths, width-aware truncation, and no change to ordinary non-media `FILE_LIST` rows.
> 
> **`MediaAttachmentProcessor` is the source of truth:** successful loads attach typed `media` metadata (`kind`, `mimeType`, `sizeBytes`) to structured `FILE_LIST` entries. The TUI projects only successful visual media (`kind: 'image'`, including PDFs) into new `media` conversation entries; audio and plain file-list entries are excluded. External media paths use full absolute paths in the display string; workspace media stays relative.
> 
> **Supporting plumbing:** `safeTerminalText` moves to shared terminal rendering; workflow-focused child streams still show `media` rows; settlement and cold-rebuild ordering are covered by tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23dce2d23aa25c77922d982c38c5209ef8781f18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->