### PR TITLE
fix: complete Opus 5 integration and docs

### DIFF
--- a/docs/.vitepress/components/IntegrationCard.vue
+++ b/docs/.vitepress/components/IntegrationCard.vue
@@ -64,7 +64,7 @@ import StatusPill from './StatusPill.vue';
         <div class="ic-srow">
           <dt>Model</dt>
           <dd>
-            <StatusPill variant="accent" shape="chip">Sonnet 4.6</StatusPill>
+            <StatusPill variant="accent" shape="chip">Sonnet 5</StatusPill>
           </dd>
         </div>
         <div class="ic-srow">

--- a/docs/.vitepress/components/MergeFlowHero.vue
+++ b/docs/.vitepress/components/MergeFlowHero.vue
@@ -74,7 +74,7 @@ import StatusPill from './StatusPill.vue';
     <div class="mf-agent">
       <wa-icon class="mf-agent-ic" library="texra" name="robot"></wa-icon>
       <span class="mf-agent-name">merge</span>
-      <StatusPill variant="accent" shape="chip">Claude Opus 4.8</StatusPill>
+      <StatusPill variant="accent" shape="chip">Claude Opus 5</StatusPill>
       <span class="mf-agent-sub">synthesizes a complete document</span>
     </div>
 

--- a/docs/guide/agent-integrations.md
+++ b/docs/guide/agent-integrations.md
@@ -82,7 +82,7 @@ delivery. The new prompt joins that Codex session as the next turn.
 
 | Setting              | Options                                                                                            | Default             | What it controls                                                              |
 | -------------------- | -------------------------------------------------------------------------------------------------- | ------------------- | ----------------------------------------------------------------------------- |
-| **Model**            | `Sonnet 4.6`, `Fable 5`, `Opus 4.8`, `Haiku 4.5`                                                   | `Sonnet 4.6`        | Which Claude model the delegated agent runs on. Agents may override per call. |
+| **Model**            | `Sonnet 4.6`, `Fable 5`, `Opus 5`, `Haiku 4.5`                                                     | `Sonnet 4.6`        | Which Claude model the delegated agent runs on. Agents may override per call. |
 | **Permission mode**  | `Prompt for risky actions`, `Auto-accept edits`, `Bypass all (dangerous)`, `Plan only (read-only)` | `Auto-accept edits` | How much the Claude Code child process may do before stopping to ask.         |
 | **Reasoning effort** | `Low`, `Medium`, `High`, `Extra high`, `Maximum`                                                   | `High`              | How deeply Claude deliberates before acting.                                  |
 

--- a/docs/guide/agent-integrations.md
+++ b/docs/guide/agent-integrations.md
@@ -82,7 +82,7 @@ delivery. The new prompt joins that Codex session as the next turn.
 
 | Setting              | Options                                                                                            | Default             | What it controls                                                              |
 | -------------------- | -------------------------------------------------------------------------------------------------- | ------------------- | ----------------------------------------------------------------------------- |
-| **Model**            | `Sonnet 4.6`, `Fable 5`, `Opus 5`, `Haiku 4.5`                                                     | `Sonnet 4.6`        | Which Claude model the delegated agent runs on. Agents may override per call. |
+| **Model**            | `Sonnet 5`, `Fable 5`, `Opus 5`, `Haiku 4.5`                                                       | `Sonnet 5`          | Which Claude model the delegated agent runs on. Agents may override per call. |
 | **Permission mode**  | `Prompt for risky actions`, `Auto-accept edits`, `Bypass all (dangerous)`, `Plan only (read-only)` | `Auto-accept edits` | How much the Claude Code child process may do before stopping to ask.         |
 | **Reasoning effort** | `Low`, `Medium`, `High`, `Extra high`, `Maximum`                                                   | `High`              | How deeply Claude deliberates before acting.                                  |
 

--- a/docs/guide/code-review.md
+++ b/docs/guide/code-review.md
@@ -268,7 +268,7 @@ The built-in defaults:
 | Provider   | Default model  |
 | ---------- | -------------- |
 | DeepSeek   | `deepseekproT` |
-| Anthropic  | `opus48T`      |
+| Anthropic  | `opus5T`       |
 | OpenAI     | `gpt55`        |
 | Google     | `gemini31p`    |
 | OpenRouter | `gptoss`       |
@@ -282,7 +282,7 @@ To override, add a repo **variable** — same place as secrets, but the
   provider.
 - `TEXRA_REVIEW_MODEL_DEFAULTS` — JSON map from provider id to default model
   id, used when you want provider-specific defaults. Example:
-  `{"deepseek":"deepseekproT","anthropic":"opus48T"}`.
+  `{"deepseek":"deepseekproT","anthropic":"opus5T"}`.
 
 The workflow above already passes both variables through, so adding the
 variable is all it takes.

--- a/docs/guide/code-review.md
+++ b/docs/guide/code-review.md
@@ -268,7 +268,7 @@ The built-in defaults:
 | Provider   | Default model  |
 | ---------- | -------------- |
 | DeepSeek   | `deepseekproT` |
-| Anthropic  | `opus5T`       |
+| Anthropic  | `opus48T`      |
 | OpenAI     | `gpt55`        |
 | Google     | `gemini31p`    |
 | OpenRouter | `gptoss`       |
@@ -282,7 +282,8 @@ To override, add a repo **variable** — same place as secrets, but the
   provider.
 - `TEXRA_REVIEW_MODEL_DEFAULTS` — JSON map from provider id to default model
   id, used when you want provider-specific defaults. Example:
-  `{"deepseek":"deepseekproT","anthropic":"opus5T"}`.
+  `{"deepseek":"deepseekproT","anthropic":"opus5T"}`. This explicitly opts
+  Anthropic reviews into Opus 5; the action's built-in default remains `opus48T`.
 
 The workflow above already passes both variables through, so adding the
 variable is all it takes.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -94,9 +94,9 @@ Configure how TeXRA connects to AI model providers:
 
 ### Anthropic 1M Context Window
 
-Claude Fable 5, Opus 4.8, and Sonnet 4.6 include the full 1M context window at standard pricing. No opt-in setting or beta header is required — 1M context is enabled automatically. Up to 600 PDF pages per request are supported (100 for models with a 200K context window). Other Claude models use a 200K context window.
+Claude Fable 5, Opus 5, and Sonnet 4.6 include the full 1M context window at standard pricing. No opt-in setting or beta header is required — 1M context is enabled automatically. Up to 600 PDF pages per request are supported (100 for models with a 200K context window). Other Claude models use a 200K context window.
 
-Fable 5 and Opus 4.8 use adaptive thinking only — manual thinking budgets are not supported (on Fable 5, thinking is always on). TeXRA selects the appropriate thinking mode automatically based on the reasoning-effort level you pick in the Models tab (Low / Medium / High / Extra High / Max). On Opus 4.8, **Extra High** maps to Anthropic's `xhigh` ("extra") effort tier and **Max** maps to the top `max` tier — both are recommended for difficult tasks and long-running work, with Max reserved for the hardest, longest-horizon runs. The earlier Opus 4.6/4.7 models predate the `xhigh`/`max` split and accept only `max`, so both Extra High and Max collapse onto `max` there.
+Fable 5 and Opus 5 use adaptive thinking only — manual thinking budgets are not supported (on Fable 5, thinking is always on). TeXRA selects the appropriate thinking mode automatically based on the reasoning-effort level you pick in the Models tab (Low / Medium / High / Extra High / Max). On Opus 5, **Extra High** maps to Anthropic's `xhigh` ("extra") effort tier and **Max** maps to the top `max` tier — both are recommended for difficult tasks and long-running work, with Max reserved for the hardest, longest-horizon runs. The earlier Opus 4.6/4.7 models predate the `xhigh`/`max` split and accept only `max`, so both Extra High and Max collapse onto `max` there.
 
 ### Bibliography Settings
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -94,7 +94,7 @@ Configure how TeXRA connects to AI model providers:
 
 ### Anthropic 1M Context Window
 
-Claude Fable 5, Opus 5, and Sonnet 4.6 include the full 1M context window at standard pricing. No opt-in setting or beta header is required — 1M context is enabled automatically. Up to 600 PDF pages per request are supported (100 for models with a 200K context window). Other Claude models use a 200K context window.
+Claude Fable 5, Opus 5, Sonnet 5, and Sonnet 4.6 include the full 1M context window at standard pricing. No opt-in setting or beta header is required — 1M context is enabled automatically. Up to 600 PDF pages per request are supported (100 for models with a 200K context window). Other Claude models use a 200K context window.
 
 Fable 5 and Opus 5 use adaptive thinking only — manual thinking budgets are not supported (on Fable 5, thinking is always on). TeXRA selects the appropriate thinking mode automatically based on the reasoning-effort level you pick in the Models tab (Low / Medium / High / Extra High / Max). On Opus 5, **Extra High** maps to Anthropic's `xhigh` ("extra") effort tier and **Max** maps to the top `max` tier — both are recommended for difficult tasks and long-running work, with Max reserved for the hardest, longest-horizon runs. The earlier Opus 4.6/4.7 models predate the `xhigh`/`max` split and accept only `max`, so both Extra High and Max collapse onto `max` there.
 

--- a/docs/guide/intelligent-merge.md
+++ b/docs/guide/intelligent-merge.md
@@ -29,7 +29,7 @@ Access the merge functionality via the "LaTeXdiffs" section (<wa-icon library="t
 
 1.  **Select Base File**: Choose the original document you want to merge changes _into_ using the "Base File" dropdown (<wa-icon library="texra" name="file"></wa-icon> Base).
 2.  **Select Edited File**: Choose the document containing the suggested changes using the "Edited File" dropdown (<wa-icon library="texra" name="edit"></wa-icon> Edited).
-3.  **Choose Merge Model**: Select an appropriate language model from the main Model dropdown (<wa-icon library="texra" name="robot"></wa-icon> Model) below the instruction box. Models capable of strong reasoning (like Claude Opus 4.8, GPT-5.5, or Gemini 3.1 Pro) are recommended for complex merges.
+3.  **Choose Merge Model**: Select an appropriate language model from the main Model dropdown (<wa-icon library="texra" name="robot"></wa-icon> Model) below the instruction box. Models capable of strong reasoning (like Claude Opus 5, GPT-5.5, or Gemini 3.1 Pro) are recommended for complex merges.
 4.  **Click Merge**: Press the "Merge" button (<wa-icon library="texra" name="merge"></wa-icon>) located in the "Edited File" row.
 
 ::: info VS Code feature

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -297,7 +297,7 @@ Opening VS Code from a configured terminal provides the most reliable environmen
 
 3. **Use better models**:
    - Upgrade to more capable models for complex tasks
-   - Try Claude Opus 4.8 or GPT-5.5 for highest quality
+   - Try Claude Opus 5 or GPT-5.5 for highest quality
    - Match the model to your specific task
 
 4. **Reference materials**:

--- a/docs/guide/working-with-figures.md
+++ b/docs/guide/working-with-figures.md
@@ -174,7 +174,7 @@ Retrieves BibTeX records for every citation key found in the document.
 
 When you provide media files, they're handed to the model according to its capabilities:
 
-- **Vision models** (GPT-5.5, Claude Opus 4.8 / Sonnet 4.6, Gemini 3.1 Pro, …): images are encoded and attached to the prompt.
+- **Vision models** (GPT-5.5, Claude Opus 5 / Sonnet 4.6, Gemini 3.1 Pro, …): images are encoded and attached to the prompt.
 - **Audio models**: audio files are uploaded for transcription.
 - **Non-multimodal models**: only filenames are passed as context.
 

--- a/packages/cli/src/commands/latex.ts
+++ b/packages/cli/src/commands/latex.ts
@@ -191,11 +191,11 @@ export const latexdiffCommand = withUsageSections(
       title: 'EXAMPLES',
       rows: [
         [
-          'texra latexdiff revise -m claude-opus-5 -i paper.tex',
+          'texra latexdiff revise -m opus5T -i paper.tex',
           'diff the latest revise run of paper.tex against its pre-run base',
         ],
         [
-          'texra latexdiff revise -m claude-opus-5 -i paper.tex --between-rounds',
+          'texra latexdiff revise -m opus5T -i paper.tex --between-rounds',
           'also diff each round against the previous round',
         ],
       ],

--- a/packages/cli/src/commands/latex.ts
+++ b/packages/cli/src/commands/latex.ts
@@ -191,11 +191,11 @@ export const latexdiffCommand = withUsageSections(
       title: 'EXAMPLES',
       rows: [
         [
-          'texra latexdiff revise -m claude-opus-4-8 -i paper.tex',
+          'texra latexdiff revise -m claude-opus-5 -i paper.tex',
           'diff the latest revise run of paper.tex against its pre-run base',
         ],
         [
-          'texra latexdiff revise -m claude-opus-4-8 -i paper.tex --between-rounds',
+          'texra latexdiff revise -m claude-opus-5 -i paper.tex --between-rounds',
           'also diff each round against the previous round',
         ],
       ],

--- a/src/agent/modelHandlers/anthropic/anthropicThinking.ts
+++ b/src/agent/modelHandlers/anthropic/anthropicThinking.ts
@@ -17,23 +17,25 @@ import type {
 const OPUS_46_FULLNAME = 'claude-opus-4-6';
 const OPUS_47_FULLNAME = 'claude-opus-4-7';
 const OPUS_48_FULLNAME = 'claude-opus-4-8';
+const OPUS_5_FULLNAME = 'claude-opus-5';
 const SONNET_46_FULLNAME = 'claude-sonnet-4-6';
 const SONNET_5_FULLNAME = 'claude-sonnet-5';
 const FABLE_5_FULLNAME = 'claude-fable-5';
 const MYTHOS_5_FULLNAME = 'claude-mythos-5';
 
-// 1M context window is available natively for Opus 4.6, Opus 4.7, Opus 4.8,
-// Sonnet 4.6, and Sonnet 5 at standard pricing (no beta header needed). Context
-// window sizes come from llm-zoo. Other Claude models use 200K.
+// Native context-window sizes come from llm-zoo. Opus 4.6/4.7/4.8/5,
+// Sonnet 4.6/5, and the Mythos-class models have a 1M context window at
+// standard pricing (no beta header needed); other Claude models use 200K.
 
 /**
  * Model patterns that require temperature removal when thinking is enabled.
- * Per Anthropic docs, Claude 4 models don't support temperature with thinking.
- * Mythos-class models (Fable 5, Mythos 5) and Sonnet 5 reject sampling
- * parameters (temperature/top_p/top_k) outright, so they belong here too.
+ * Per Anthropic docs, Claude 4 and Opus 5 don't support temperature with
+ * thinking. Mythos-class models (Fable 5, Mythos 5) and Sonnet 5 reject all
+ * sampling parameters (temperature/top_p/top_k), so they belong here too.
  */
 const THINKING_TEMPERATURE_EXCLUDED_PATTERNS = [
   'claude-opus-4',
+  'claude-opus-5',
   'claude-sonnet-4',
   'claude-sonnet-5',
   'claude-haiku-4',
@@ -50,6 +52,9 @@ const isClaudeOpus47 = (fullName: string): boolean =>
 const isClaudeOpus48 = (fullName: string): boolean =>
   fullName.startsWith(OPUS_48_FULLNAME);
 
+const isClaudeOpus5 = (fullName: string): boolean =>
+  fullName.startsWith(OPUS_5_FULLNAME);
+
 const isClaudeSonnet46 = (fullName: string): boolean =>
   fullName.startsWith(SONNET_46_FULLNAME);
 
@@ -61,7 +66,7 @@ const isClaudeSonnet5 = (fullName: string): boolean =>
  * thinking is always on, manual budget_tokens and `thinking: {type: "disabled"}`
  * both return 400, raw chain-of-thought is never returned (display defaults to
  * "omitted"), and sampling parameters are rejected. They also support the same
- * effort tiers as Opus 4.8 (including the distinct "xhigh").
+ * effort tiers as Opus 4.8 and Opus 5 (including the distinct "xhigh").
  */
 const isMythosClass = (fullName: string): boolean =>
   fullName.startsWith(FABLE_5_FULLNAME) ||
@@ -69,14 +74,16 @@ const isMythosClass = (fullName: string): boolean =>
 
 /**
  * Whether this model supports adaptive thinking with the effort parameter.
- * Per Anthropic docs, Opus 4.6, Opus 4.7, Opus 4.8, Sonnet 4.6, Sonnet 5, and
- * the Mythos-class models support adaptive thinking. Opus 4.7+, Sonnet 5, and
- * Mythos-class only accept adaptive thinking — manual budget_tokens returns 400.
+ * Per Anthropic docs, Opus 4.6, Opus 4.7, Opus 4.8, Opus 5, Sonnet 4.6,
+ * Sonnet 5, and the Mythos-class models support adaptive thinking. Opus 4.7+,
+ * Sonnet 5, and Mythos-class models only accept adaptive thinking — manual
+ * budget_tokens returns 400.
  */
 export const supportsAdaptiveThinking = (fullName: string): boolean =>
   isClaudeOpus46(fullName) ||
   isClaudeOpus47(fullName) ||
   isClaudeOpus48(fullName) ||
+  isClaudeOpus5(fullName) ||
   isClaudeSonnet46(fullName) ||
   isClaudeSonnet5(fullName) ||
   isMythosClass(fullName);
@@ -86,13 +93,14 @@ export const isCompactionEligibleModel = (fullName: string): boolean =>
   isClaudeOpus46(fullName) ||
   isClaudeOpus47(fullName) ||
   isClaudeOpus48(fullName) ||
+  isClaudeOpus5(fullName) ||
   isClaudeSonnet46(fullName) ||
   isClaudeSonnet5(fullName) ||
   isMythosClass(fullName);
 
 /**
  * Whether temperature must be removed when thinking is enabled.
- * Claude 4 models don't support temperature alongside thinking.
+ * Claude 4 and Opus 5 don't support temperature alongside thinking.
  */
 export const requiresNoTemperatureWithThinking = (fullName: string): boolean =>
   THINKING_TEMPERATURE_EXCLUDED_PATTERNS.some((pattern) =>
@@ -104,7 +112,7 @@ export const requiresNoTemperatureWithThinking = (fullName: string): boolean =>
  * Maps the llm-zoo ReasoningEffort enum to Anthropic's effort levels.
  * Falls back to 'high' (the API default) when no specific effort is configured.
  * The above-'high' tiers are valid for Opus-tier, Sonnet 5, and Mythos-class
- * models: Opus 4.8, Sonnet 5, and the Mythos-class models (Fable 5, Mythos 5)
+ * models: Opus 4.8/5, Sonnet 5, and the Mythos-class models (Fable 5, Mythos 5)
  * accept both the distinct 'xhigh' ("extra") tier and the top 'max' tier, while
  * Opus 4.6/4.7 predate that split and only accept 'max'.
  */
@@ -118,10 +126,11 @@ export function mapAnthropicEffort(
 
   switch (reasoningEffort) {
     case 'max':
-      // The top tier ("Max"). Opus 4.8/4.7/4.6, Sonnet 5, and Mythos-class
+      // The top tier ("Max"). Opus 4.6/4.7/4.8/5, Sonnet 5, and Mythos-class
       // models all accept Anthropic's 'max' effort; everything else caps at
       // 'high'.
-      return isClaudeOpus48(fullName) ||
+      return isClaudeOpus5(fullName) ||
+        isClaudeOpus48(fullName) ||
         isClaudeOpus47(fullName) ||
         isClaudeOpus46(fullName) ||
         isClaudeSonnet5(fullName) ||
@@ -129,12 +138,13 @@ export function mapAnthropicEffort(
         ? 'max'
         : 'high';
     case 'xhigh':
-      // Opus 4.8, Sonnet 5, and the Mythos-class models expose the distinct
+      // Opus 4.8/5, Sonnet 5, and the Mythos-class models expose the distinct
       // 'xhigh' ("extra") effort tier the SDK added in 0.100.0, which is exactly
       // what TeXRA's "Extra High" selector means — map to it directly. Opus
       // 4.6/4.7 predate the tier split and only accept 'max'; everything else
       // caps at 'high'.
       if (
+        isClaudeOpus5(fullName) ||
         isClaudeOpus48(fullName) ||
         isClaudeSonnet5(fullName) ||
         isMythosClass(fullName)
@@ -176,7 +186,7 @@ interface ThinkingConfigResult {
 /**
  * Builds the thinking configuration for a create request.
  *
- * Adaptive-thinking models (Opus 4.6/4.7/4.8, Sonnet 4.6, Sonnet 5, and the
+ * Adaptive-thinking models (Opus 4.6/4.7/4.8/5, Sonnet 4.6, Sonnet 5, and
  * Mythos-class models Fable 5 / Mythos 5) use the effort parameter and let the
  * model decide its budget; interleaved thinking is enabled automatically. Older
  * models use a manual budget_tokens cap.
@@ -190,7 +200,7 @@ export function buildThinkingConfig({
   const removeTemperature = requiresNoTemperatureWithThinking(fullName);
 
   if (supportsAdaptiveThinking(fullName)) {
-    // Opus 4.6/4.7/4.8, Sonnet 4.6, Sonnet 5, and the Mythos-class models
+    // Opus 4.6/4.7/4.8/5, Sonnet 4.6, Sonnet 5, and the Mythos-class models
     // (Fable 5, Mythos 5): use adaptive thinking with the effort parameter.
     // Adaptive thinking lets the model decide when and how much to think, and
     // automatically enables interleaved thinking between tool calls.
@@ -205,6 +215,7 @@ export function buildThinkingConfig({
     const thinking: ThinkingConfigResult['thinking'] =
       isClaudeOpus47(fullName) ||
       isClaudeOpus48(fullName) ||
+      isClaudeOpus5(fullName) ||
       isClaudeSonnet5(fullName) ||
       isMythosClass(fullName)
         ? { type: 'adaptive', display: 'summarized' }

--- a/src/shared/config/settingsAccess.ts
+++ b/src/shared/config/settingsAccess.ts
@@ -62,7 +62,10 @@ export function readSetting(
   if (raw === undefined) {
     return settingDefault(entry);
   }
-  return entry.schema.catch(() => settingDefault(entry)).parse(raw);
+  const normalized = entry.normalizePersisted
+    ? entry.normalizePersisted(raw)
+    : raw;
+  return entry.schema.catch(() => settingDefault(entry)).parse(normalized);
 }
 
 /**

--- a/src/shared/schemas/agentCliSettings.ts
+++ b/src/shared/schemas/agentCliSettings.ts
@@ -67,7 +67,7 @@ export const parseCodexApprovalPolicy = parseEnumSetting(
 export const ClaudeAgentModelSchema = z.enum([
   'claude-sonnet-5',
   'claude-fable-5',
-  'claude-opus-4-8',
+  'claude-opus-5',
   'claude-haiku-4-5-20251001',
 ]);
 export type ClaudeAgentModel = z.infer<typeof ClaudeAgentModelSchema>;
@@ -76,7 +76,8 @@ export const CLAUDE_AGENT_DEFAULT_MODEL: ClaudeAgentModel = 'claude-sonnet-5';
 
 const RETIRED_CLAUDE_AGENT_MODELS: Readonly<Record<string, ClaudeAgentModel>> =
   {
-    'claude-opus-4-7': 'claude-opus-4-8',
+    'claude-opus-4-7': 'claude-opus-5',
+    'claude-opus-4-8': 'claude-opus-5',
     'claude-sonnet-4-6': 'claude-sonnet-5',
   };
 

--- a/src/shared/schemas/agentCliSettings.ts
+++ b/src/shared/schemas/agentCliSettings.ts
@@ -11,9 +11,10 @@ function parseEnumSetting<T extends string>(
   values: readonly T[],
   fallback: T,
   aliases?: Readonly<Record<string, T>>,
-): (raw: string) => T {
+): (raw: unknown) => T {
   const known = values as readonly string[];
-  return (raw: string): T => {
+  return (raw: unknown): T => {
+    if (typeof raw !== 'string') return fallback;
     if (known.includes(raw)) return raw as T;
     return aliases?.[raw] ?? fallback;
   };

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -360,7 +360,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
     hosts: ['vscode', 'desktop', 'cli'],
     cliConsumer: CLAUDE_AGENT_CONFIG_CONSUMER,
     cliRuntimeReachability: CLAUDE_AGENT_RUNTIME_REACHABILITY,
-    enumLabels: ['Sonnet 5', 'Fable 5', 'Opus 4.8', 'Haiku 4.5'],
+    enumLabels: ['Sonnet 5', 'Fable 5', 'Opus 5', 'Haiku 4.5'],
   },
   {
     key: WorkspaceStateKey.CLAUDE_AGENT_PERMISSION_MODE,

--- a/src/shared/schemas/stateSettings.ts
+++ b/src/shared/schemas/stateSettings.ts
@@ -25,6 +25,7 @@ import {
   ClaudeAgentEffortSchema,
   ClaudeAgentModelSchema,
   ClaudeAgentPermissionModeSchema,
+  parseClaudeAgentModel,
   CODEX_APPROVAL_POLICY_DEFAULT,
   CODEX_REASONING_EFFORT_DEFAULT,
   CODEX_SANDBOX_MODE_DEFAULT,
@@ -109,6 +110,11 @@ export interface StateSettingEntry {
    * when the key is absent. `schema.parse(undefined)` yields that default.
    */
   readonly schema: z.ZodType;
+  /**
+   * Optional normalization for legacy persisted values before schema validation.
+   * Keep migration mappings in the domain parser referenced here, not the row.
+   */
+  readonly normalizePersisted?: (raw: unknown) => unknown;
   /** Short label for compact settings UIs; falls back to the stripped key. */
   readonly title?: string;
   /** Human-readable description, shared across every host that renders it. */
@@ -353,6 +359,7 @@ export const STATE_SETTINGS: readonly StateSettingEntry[] = [
   {
     key: WorkspaceStateKey.CLAUDE_AGENT_MODEL,
     schema: ClaudeAgentModelSchema.prefault(CLAUDE_AGENT_DEFAULT_MODEL),
+    normalizePersisted: parseClaudeAgentModel,
     title: 'Claude Code model',
     description: 'Claude model selected for Claude Code agent sessions.',
     category: 'ai-agents',

--- a/src/test-kernel/agent/modelHandlers/AnthropicThinking.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/AnthropicThinking.vitest.ts
@@ -14,6 +14,7 @@ import {
 const OPUS_46 = 'claude-opus-4-6';
 const OPUS_47 = 'claude-opus-4-7';
 const OPUS_48 = 'claude-opus-4-8';
+const OPUS_5 = 'claude-opus-5';
 const SONNET_46 = 'claude-sonnet-4-6';
 const SONNET_5 = 'claude-sonnet-5';
 const FABLE_5 = 'claude-fable-5';
@@ -29,6 +30,7 @@ describe('mapAnthropicEffort', () => {
     expect(mapAnthropicEffort(OPUS_46, ReasoningEffort.MAX)).toBe('max');
     expect(mapAnthropicEffort(OPUS_47, ReasoningEffort.MAX)).toBe('max');
     expect(mapAnthropicEffort(OPUS_48, ReasoningEffort.MAX)).toBe('max');
+    expect(mapAnthropicEffort(OPUS_5, ReasoningEffort.MAX)).toBe('max');
     // Sonnet 5 accepts the top "max" tier like Opus.
     expect(mapAnthropicEffort(SONNET_5, ReasoningEffort.MAX)).toBe('max');
     // Sonnet 4.6 and older non-Opus models cap at "high".
@@ -41,8 +43,9 @@ describe('mapAnthropicEffort', () => {
     expect(mapAnthropicEffort(MYTHOS_5, ReasoningEffort.MAX)).toBe('max');
   });
 
-  it('maps "xhigh" to the distinct tier on Opus 4.8, Sonnet 5, and Mythos-class models', () => {
+  it('maps "xhigh" to the distinct tier on Opus 4.8/5, Sonnet 5, and Mythos-class models', () => {
     expect(mapAnthropicEffort(OPUS_48, ReasoningEffort.XHIGH)).toBe('xhigh');
+    expect(mapAnthropicEffort(OPUS_5, ReasoningEffort.XHIGH)).toBe('xhigh');
     expect(mapAnthropicEffort(SONNET_5, ReasoningEffort.XHIGH)).toBe('xhigh');
     expect(mapAnthropicEffort(FABLE_5, ReasoningEffort.XHIGH)).toBe('xhigh');
     expect(mapAnthropicEffort(MYTHOS_5, ReasoningEffort.XHIGH)).toBe('xhigh');
@@ -62,11 +65,12 @@ describe('mapAnthropicEffort', () => {
 });
 
 describe('supportsAdaptiveThinking / isCompactionEligibleModel', () => {
-  it('is true for Opus 4.6/4.7/4.8, Sonnet 4.6, Sonnet 5, and Mythos-class models', () => {
+  it('is true for Opus 4.6/4.7/4.8/5, Sonnet 4.6, Sonnet 5, and Mythos-class models', () => {
     for (const model of [
       OPUS_46,
       OPUS_47,
       OPUS_48,
+      OPUS_5,
       SONNET_46,
       SONNET_5,
       FABLE_5,
@@ -84,8 +88,9 @@ describe('supportsAdaptiveThinking / isCompactionEligibleModel', () => {
 });
 
 describe('requiresNoTemperatureWithThinking', () => {
-  it('is true for all Claude 4 families, Sonnet 5, and Mythos-class models', () => {
+  it('is true for all Claude 4 families, Opus 5, Sonnet 5, and Mythos-class models', () => {
     expect(requiresNoTemperatureWithThinking(OPUS_48)).toBe(true);
+    expect(requiresNoTemperatureWithThinking(OPUS_5)).toBe(true);
     expect(requiresNoTemperatureWithThinking(SONNET_46)).toBe(true);
     expect(requiresNoTemperatureWithThinking(SONNET_5)).toBe(true);
     expect(requiresNoTemperatureWithThinking('claude-haiku-4-5')).toBe(true);
@@ -99,6 +104,26 @@ describe('requiresNoTemperatureWithThinking', () => {
 });
 
 describe('buildThinkingConfig', () => {
+  it('uses adaptive thinking with summarized display and top effort tiers on Opus 5', () => {
+    for (const [reasoningEffort, effort] of [
+      [ReasoningEffort.XHIGH, 'xhigh'],
+      [ReasoningEffort.MAX, 'max'],
+    ] as const) {
+      const config = buildThinkingConfig({
+        fullName: OPUS_5,
+        reasoningEffort,
+        maxTokens: 128000,
+        useStreaming: true,
+      });
+      expect(config.thinking).toEqual({
+        type: 'adaptive',
+        display: 'summarized',
+      });
+      expect(config.outputConfig).toEqual({ effort });
+      expect(config.removeTemperature).toBe(true);
+    }
+  });
+
   it('uses adaptive thinking with summarized display on Opus 4.7+', () => {
     const config = buildThinkingConfig({
       fullName: OPUS_48,

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
@@ -10,6 +10,7 @@ import { PDFDocument } from '@cantoo/pdf-lib';
 import { afterEach, describe, it, vi } from 'vitest';
 import {
   type ModelCapabilities,
+  MODEL_CONFIGS,
   ModelProvider,
   ReasoningEffort,
 } from 'llm-zoo';
@@ -1222,6 +1223,68 @@ describe('ModelHandlerAnthropic message guards', () => {
       'max',
       "max reasoning effort should map to the top 'max' tier on Opus 4.8",
     );
+  });
+
+  it('sends the llm-zoo opus5T model with native Opus 5 thinking traits', async () => {
+    const handler = new ModelHandlerAnthropic(
+      buildTestModelConfig(MODEL_CONFIGS.opus5T, {
+        capabilities: {
+          supportsTokenCounting: false,
+          reasoningEffort: ReasoningEffort.XHIGH,
+        },
+      }),
+    );
+    handler.setAgentCategory(AgentCategory.ToolUse);
+    stubHandlerForTest(handler);
+
+    const { client, messageOptions } =
+      createCapturingAnthropicClient('claude-opus-5');
+    stubCompactionThresholdPercent(75);
+
+    await handler.createResponse({
+      client,
+      messages: helloMessages(),
+      temperature: 0.7,
+    });
+
+    const options = messageOptions[0] ?? {};
+    assert.equal(options.model, 'claude-opus-5');
+    assert.deepEqual(options.thinking, {
+      type: 'adaptive',
+      display: 'summarized',
+    });
+    assert.equal(options.output_config?.effort, 'xhigh');
+    assert.equal(options.temperature, undefined);
+    assert.ok(options.betas?.includes('compact-2026-01-12'));
+    assert.ok(
+      options.context_management?.edits?.some(
+        (edit: { type: string }) => edit.type === 'compact_20260112',
+      ),
+      'opus5T should be eligible for native compaction',
+    );
+  });
+
+  it('maps opus5T maximum reasoning to Anthropic max effort', async () => {
+    const handler = new ModelHandlerAnthropic(
+      buildTestModelConfig(MODEL_CONFIGS.opus5T, {
+        capabilities: {
+          supportsTokenCounting: false,
+          reasoningEffort: ReasoningEffort.MAX,
+        },
+      }),
+    );
+    stubHandlerForTest(handler);
+
+    const { client, messageOptions } =
+      createCapturingAnthropicClient('claude-opus-5');
+    await handler.createResponse({
+      client,
+      messages: helloMessages(),
+      temperature: 0.7,
+    });
+
+    assert.equal(messageOptions[0]?.output_config?.effort, 'max');
+    assert.equal(messageOptions[0]?.temperature, undefined);
   });
 
   it('round-trips forced compaction state into the next workflow invocation', async () => {

--- a/src/test-kernel/cli/CliRootArgs.vitest.mts
+++ b/src/test-kernel/cli/CliRootArgs.vitest.mts
@@ -1455,6 +1455,17 @@ describe('runCli usage output stream routing', () => {
     expect(stderr).toBe('');
   });
 
+  it('recommends the exact opus5T model id in latexdiff help examples', async () => {
+    const result = await runCli(['latexdiff', '--help']);
+    expect(result.exitCode).toBe(0);
+    expect(stdout).toContain('texra latexdiff revise -m opus5T -i paper.tex');
+    expect(stdout).toContain(
+      'texra latexdiff revise -m opus5T -i paper.tex --between-rounds',
+    );
+    expect(stdout).not.toContain('claude-opus-5');
+    expect(stderr).toBe('');
+  });
+
   it('shows EXAMPLES and a docs link in root --help', async () => {
     const result = await runCli(['--help']);
     expect(result.exitCode).toBe(0);

--- a/src/test-kernel/schemas/SharedSchemas.vitest.ts
+++ b/src/test-kernel/schemas/SharedSchemas.vitest.ts
@@ -45,7 +45,8 @@ describe('parseCodexApprovalPolicy', () => {
 
 describe('parseClaudeAgentModel', () => {
   it('maps retired selections to their current model', () => {
-    expect(parseClaudeAgentModel('claude-opus-4-7')).toBe('claude-opus-4-8');
+    expect(parseClaudeAgentModel('claude-opus-4-7')).toBe('claude-opus-5');
+    expect(parseClaudeAgentModel('claude-opus-4-8')).toBe('claude-opus-5');
     expect(parseClaudeAgentModel('claude-sonnet-4-6')).toBe('claude-sonnet-5');
   });
 

--- a/src/test-kernel/shared/stateSettings.vitest.ts
+++ b/src/test-kernel/shared/stateSettings.vitest.ts
@@ -305,7 +305,7 @@ describe('state settings catalog', () => {
     assert.deepEqual(labelsFor(WorkspaceStateKey.CLAUDE_AGENT_MODEL), [
       'claude-sonnet-5 — Sonnet 5',
       'claude-fable-5 — Fable 5',
-      'claude-opus-4-8 — Opus 4.8',
+      'claude-opus-5 — Opus 5',
       'claude-haiku-4-5-20251001 — Haiku 4.5',
     ]);
     assert.deepEqual(

--- a/src/test-kernel/shared/stateSettings.vitest.ts
+++ b/src/test-kernel/shared/stateSettings.vitest.ts
@@ -470,6 +470,16 @@ describe('settingsAccess', () => {
     );
   });
 
+  it('migrates retired Claude Agent models through the generic catalog read path', () => {
+    const entry = entryByKey(WorkspaceStateKey.CLAUDE_AGENT_MODEL);
+
+    for (const retiredModel of ['claude-opus-4-7', 'claude-opus-4-8']) {
+      const { stores, workspaceState } = makeFakeSettingsStores();
+      void workspaceState.update(entry.key, retiredModel);
+      assert.equal(readSetting(entry, stores, 'cli'), 'claude-opus-5');
+    }
+  });
+
   it('routes extension writes to the canonical store', async () => {
     const { stores, config, workspaceState } = makeFakeSettingsStores();
     const entry = entryByKey(WorkspaceStateKey.GIT_MARK_COMMITS);

--- a/src/test-kernel/tools/ClaudeAgentSchema.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentSchema.vitest.ts
@@ -1,0 +1,19 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - tool under test
+import { ClaudeAgentTool } from '@tools/claudeAgent';
+
+describe('ClaudeAgentTool schema', () => {
+  it('recommends current Claude Code models in the model field', () => {
+    const parameters = new ClaudeAgentTool().definition.parameters as {
+      properties?: Record<string, { description?: string }>;
+    };
+    const modelDescription = parameters.properties?.model?.description ?? '';
+
+    expect(modelDescription).toContain('claude-sonnet-5');
+    expect(modelDescription).toContain('claude-fable-5');
+    expect(modelDescription).toContain('claude-opus-5');
+    expect(modelDescription).not.toContain('claude-opus-4-8');
+  });
+});

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -116,7 +116,7 @@ const ClaudeAgentInputSchema = z.strictObject({
     .string()
     .nullish()
     .describe(
-      "Claude model to use (e.g. 'claude-sonnet-5', 'claude-fable-5', 'claude-opus-4-8'). Defaults to user-configured model.",
+      "Claude model to use (e.g. 'claude-sonnet-5', 'claude-fable-5', 'claude-opus-5'). Defaults to user-configured model.",
     ),
   effort: z
     .enum(CLAUDE_AGENT_EFFORT_LEVELS)

--- a/src/tools/claudeAgentConfig.ts
+++ b/src/tools/claudeAgentConfig.ts
@@ -36,7 +36,7 @@ import {
 } from './claudeAgentShared';
 
 // ============================================================================
-// Model — defaults to Sonnet 4.6; users can override per-call or via workspace state
+// Model — defaults to Sonnet 5; users can override per-call or via workspace state
 // ============================================================================
 
 export const getClaudeAgentModel: () => ClaudeAgentModel =


### PR DESCRIPTION
## Summary
- replace stale current-facing Opus 4.8 documentation and site references with Opus 5
- complete Opus 5 adaptive-thinking, native-compaction, Claude Code, and persisted-selection integration that the catalog update left incomplete
- use the exact `opus5T` identifier in CLI examples and add regression coverage for request shaping, settings migration, Claude Code schema, and help text

## Validation
- targeted suites: 146 tests passed across the Anthropic handler, settings, Claude Code, and CLI coverage
- full workspace typecheck passed
- docs build passed
- ESLint and Prettier passed for changed files
- `git diff --check` passed

Closes #9132

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Anthropic API request parameters for a new flagship model and migrates persisted Claude Code model selections; risk is mitigated by focused tests and mostly additive model branching.
> 
> **Overview**
> **Completes Opus 5** where the catalog update left gaps: `claude-opus-5` is treated like Opus 4.8+ for adaptive thinking (`xhigh`/`max` effort, summarized display, no temperature with thinking) and native context compaction.
> 
> **Claude Code** now surfaces **Opus 5** instead of Opus 4.8; persisted `claude-opus-4-7` / `claude-opus-4-8` values migrate to `claude-opus-5` on read via `normalizePersisted` on the Claude agent model setting. Tool schema copy and enum labels match.
> 
> **Docs and marketing UI** replace current-facing Opus 4.8 / Sonnet 4.6 references with Opus 5 / Sonnet 5 where appropriate; GitHub review docs note opting into `opus5T` via `TEXRA_REVIEW_MODEL_DEFAULTS` while the action default stays `opus48T`. **CLI** `latexdiff` help examples use `opus5T`.
> 
> Regression coverage spans thinking/effort mapping, Anthropic handler request shaping for `opus5T`, settings migration, Claude agent schema, and CLI help text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a47fbcb651006cffb2d2e1718f7c5bcc1a8fc0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->