### PR TITLE
feat(progress): itemize workflow tasks per phase with a shared done/total fold

### DIFF
--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -133,11 +133,13 @@ export function workflowRunStatusSummary(
       ? ` (${phase.phaseIndex + 1}/${phase.phaseTotal})`
       : '';
   const { done, total } = workflowPhaseTaskProgress(
-    slice.entries.flatMap((entry) =>
-      entry.role === 'workflowTask' && entry.task.phase === phase?.phaseLabel
-        ? [entry.task]
-        : [],
-    ),
+    phase
+      ? slice.entries.flatMap((entry) =>
+          entry.role === 'workflowTask' && entry.task.phase === phase.phaseLabel
+            ? [entry.task]
+            : [],
+        )
+      : [],
   );
   const input = slice.files?.input.length ?? 0;
   const context = slice.files?.context.length ?? 0;

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -4,6 +4,7 @@
 import { Box, Text } from 'ink';
 
 import { AgentCategory } from '@shared/schemas';
+import { workflowPhaseTaskProgress } from '@shared/copy/workflowTask';
 import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 import { formatResultCount } from '@utils/text/stringUtils';
 
@@ -116,19 +117,41 @@ function renderConversationPaneEntry({
   );
 }
 
-export function workflowInputContextSummary(
+/**
+ * One-line workflow status band. Phase progress leads so it survives
+ * `truncate-end` on a narrow terminal. The running `done/total` lives here
+ * rather than on the `◆` divider because that divider prints once into
+ * scrollback and can never be rewritten.
+ */
+export function workflowRunStatusSummary(
   slice: StreamSlice | undefined,
 ): string | undefined {
-  if (slice?.category !== AgentCategory.Workflow || !slice.files) {
-    return undefined;
-  }
-  const inputCount = slice.files.input.length;
-  const contextCount = slice.files.context.length;
-  if (inputCount === 0 && contextCount === 0) return undefined;
-  return [
-    `Input: ${formatResultCount(inputCount, 'file')}`,
-    `Context: ${formatResultCount(contextCount, 'file')}`,
-  ].join(' · ');
+  if (slice?.category !== AgentCategory.Workflow) return undefined;
+  const phase = slice.entries.findLast((entry) => entry.role === 'phase');
+  const phaseCounts =
+    phase?.phaseIndex !== undefined && phase.phaseTotal !== undefined
+      ? ` (${phase.phaseIndex + 1}/${phase.phaseTotal})`
+      : '';
+  const { done, total } = workflowPhaseTaskProgress(
+    slice.entries.flatMap((entry) =>
+      entry.role === 'workflowTask' && entry.task.phase === phase?.phaseLabel
+        ? [entry.task]
+        : [],
+    ),
+  );
+  const input = slice.files?.input.length ?? 0;
+  const context = slice.files?.context.length ?? 0;
+  const segments = [
+    ...(phase ? [`${phase.phaseLabel}${phaseCounts}`] : []),
+    ...(total > 0 ? [`${done}/${total} done`] : []),
+    ...(input > 0 || context > 0
+      ? [
+          `Input: ${formatResultCount(input, 'file')}`,
+          `Context: ${formatResultCount(context, 'file')}`,
+        ]
+      : []),
+  ];
+  return segments.length > 0 ? segments.join(' · ') : undefined;
 }
 
 export function ConversationPane(
@@ -145,7 +168,7 @@ export function ConversationPane(
     props.availableWidth !== undefined && props.width !== undefined
       ? Math.min(props.availableWidth, props.width)
       : (props.availableWidth ?? props.width);
-  const workflowMetadata = workflowInputContextSummary(slice);
+  const workflowMetadata = workflowRunStatusSummary(slice);
   const metadataRows =
     workflowMetadata &&
     maxRows > 0 &&

--- a/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
@@ -91,10 +91,12 @@ const ROLE_GEOMETRY = {
     marginTopRows: USER_ENTRY_MARGIN_TOP_ROWS,
   },
   workflowTask: {
-    // The first-line marker is per-status (WORKFLOW_TASK_STATUS_STYLE), so the
-    // role carries only the alignment used by wrapped continuation lines.
-    firstPrefix: '',
-    continuationPrefix: '  ',
+    // Two spaces nest the task under the `◆` phase divider that heads it. The
+    // first-line marker is per-status (WORKFLOW_TASK_STATUS_STYLE), so
+    // `firstPrefix` carries the indent alone and continuation lines add the
+    // marker's own width on top of it.
+    firstPrefix: '  ',
+    continuationPrefix: '    ',
     inset: 0,
     marginBottomRows: 0,
     marginTopRows: 0,
@@ -261,15 +263,17 @@ function entryLines(
         geometry.continuationPrefix,
       );
     }
-    case 'workflowTask':
+    case 'workflowTask': {
       // The status marker belongs to the layout, not the Ink row: the print-once
       // scrollback snapshot is built from these lines.
+      const geometry = ROLE_GEOMETRY.workflowTask;
       return wrapWithPrefix(
         entry.text,
         columns,
-        `${WORKFLOW_TASK_STATUS_STYLE[entry.task.status].marker} `,
-        ROLE_GEOMETRY.workflowTask.continuationPrefix,
+        `${geometry.firstPrefix}${WORKFLOW_TASK_STATUS_STYLE[entry.task.status].marker} `,
+        geometry.continuationPrefix,
       );
+    }
     default: {
       const geometry = ROLE_GEOMETRY[entry.role];
       return wrapWithPrefix(

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -11,13 +11,16 @@ import { repeat } from 'lit/directives/repeat.js';
 
 // Local imports - shared schemas
 import {
+  MESSAGE_TYPES,
   STREAM_PHASE,
   StreamPhaseSchema,
+  WorkflowTaskProgressSchema,
   type GettingStartedAction,
   type LogMessageData,
   type TaskGroup,
 } from '@shared/schemas';
 import { designTokens } from '@shared/styles';
+import { workflowPhaseTaskProgress } from '@shared/copy/workflowTask';
 import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 
 // Side-effect imports - register WA icon and spinner components
@@ -478,8 +481,32 @@ export class TaskGroupList extends LitElement {
     this.requestUpdate();
   }
 
+  /**
+   * `done/total` for a phase header, folded from the workflow-task cards the
+   * group already holds. A malformed row drops out (safeParse), matching how
+   * the card formatter guards itself. Nothing renders for a group with no
+   * task cards, so round and run headers are unaffected.
+   */
+  private renderGroupProgress(
+    group: TaskGroup,
+    messages: readonly LogMessageData[],
+  ): TemplateResult | typeof nothing {
+    if (group.kind !== 'phase') return nothing;
+    const tasks = messages.flatMap((message) => {
+      if (message.messageType !== MESSAGE_TYPES.WORKFLOW_TASK) return [];
+      const parsed = WorkflowTaskProgressSchema.safeParse(message.data);
+      return parsed.success ? [parsed.data] : [];
+    });
+    const { done, total } = workflowPhaseTaskProgress(tasks);
+    if (total === 0) return nothing;
+    return html`<span class="group-progress">${done}/${total}</span>`;
+  }
+
   /** Render child group header inline (only called for non-root groups) */
-  private renderGroupHeader(group: TaskGroup): TemplateResult {
+  private renderGroupHeader(
+    group: TaskGroup,
+    messages: readonly LogMessageData[],
+  ): TemplateResult {
     const formattedStartTime = getTimeFormatter().format(
       new Date(group.startTime),
     );
@@ -509,6 +536,7 @@ export class TaskGroupList extends LitElement {
         }
       </span>
       <span class="group-title">${group.name}${positionText}</span>
+      ${this.renderGroupProgress(group, messages)}
       <span class="group-time">
         <span class="group-start-time" data-start=${String(group.startTime)}>
           <wa-icon
@@ -579,7 +607,7 @@ export class TaskGroupList extends LitElement {
             [`is-${group.status}`]: true,
           })}
         >
-          ${this.renderGroupHeader(group)}
+          ${this.renderGroupHeader(group, messages)}
         </div>
         <div id=${contentId} class="log-group-content">
           ${

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/workflowTaskFormatter.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/workflowTaskFormatter.ts
@@ -66,14 +66,7 @@ export function formatWorkflowTaskTemplate(
       <span class="workflow-task-icon">${statusIcon(task)}</span>
       <span class="workflow-task-body">
         <span class="workflow-task-title">${task.label}</span>
-        <span class="workflow-task-details">
-          ${
-            task.phase
-              ? html`<span class="workflow-task-phase">${task.phase}</span>`
-              : nothing
-          }
-          ${terminalMetadata(task)}
-        </span>
+        ${terminalMetadata(task)}
         ${
           detail
             ? html`<span

--- a/packages/extension/src/progressView/frontend/styles/groupStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/groupStyles.ts
@@ -52,6 +52,15 @@ export const groupStyles = css`
     flex-grow: 1;
   }
 
+  /* Completed/declared task count for a phase header, right-aligned beside
+     the timestamps. */
+  .group-progress {
+    font-size: var(--font-size-sm);
+    font-variant-numeric: tabular-nums;
+    opacity: var(--opacity-subtle);
+    margin-left: var(--wa-space-2xs);
+  }
+
   .group-time {
     font-size: var(--font-size-sm);
     opacity: var(--opacity-subtle);

--- a/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
@@ -104,16 +104,11 @@ export const logEntryStyles = css`
     font-weight: var(--wa-font-weight-semibold);
   }
 
-  .workflow-task-details {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--wa-space-xs);
+  /* The card's phase is the group header it sits under, so the sub-label row
+     carries terminal metadata only. */
+  .workflow-task-meta {
     color: var(--color-text-secondary);
     font-size: var(--font-size-sm);
-  }
-
-  .workflow-task-phase::before {
-    content: 'Phase: ';
   }
 
   .workflow-task-detail {

--- a/src/shared/copy/workflowTask.ts
+++ b/src/shared/copy/workflowTask.ts
@@ -1,4 +1,5 @@
 import {
+  isTerminalWorkflowTaskProgress,
   WORKFLOW_TASK_STATUS_LABEL,
   type WorkflowTaskProgress,
 } from '@shared/schemas';
@@ -26,6 +27,21 @@ export function formatWorkflowTaskMetadataParts(
       ? undefined
       : `${formatCostUsd(task.totalCostUsd)} total`,
   ].filter((part): part is string => part !== undefined);
+}
+
+/**
+ * Completion fold for one phase's tasks, shared by every host so the terminal
+ * and the progress view can never disagree on what "done" counts. The caller
+ * selects the phase's tasks — each host already holds them in its own
+ * container, and matching them here would duplicate that ownership.
+ */
+export function workflowPhaseTaskProgress(
+  tasks: readonly WorkflowTaskProgress[],
+): { readonly done: number; readonly total: number } {
+  return {
+    done: tasks.filter((task) => isTerminalWorkflowTaskProgress(task)).length,
+    total: tasks.length,
+  };
 }
 
 /**

--- a/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
@@ -58,7 +58,7 @@ function workflowTaskEvent(
 beforeEach(() => clearStoreCache());
 
 describe('workflow-script progress bridge', () => {
-  it('keeps planned task cards in one stage across incremental updates', async () => {
+  it('keeps planned task cards in their phase stage across incremental updates', async () => {
     const { trace, events } = recordingTrace();
     const parent = trace.openStage('Parent');
     const plannedMeta = `export const meta = {
@@ -92,19 +92,21 @@ return await agent('Inspect', { id: 'inspect' })`,
     const planned = workflowTaskEvent(events, 'Inspect source', 'planned');
     const running = workflowTaskEvent(events, 'Inspect source', 'running');
     const completed = workflowTaskEvent(events, 'Inspect source', 'completed');
+    // One stable, phase-derived stage across the whole lifecycle: the card is
+    // classified into its phase group when it is planned and never moves.
     expect(planned).toMatchObject({
       type: 'workflow.task',
-      stageId: parent.id,
+      stageId: phaseId,
     });
     expect(running).toMatchObject({
       type: 'workflow.task',
       logId: planned?.logId,
-      stageId: parent.id,
+      stageId: phaseId,
     });
     expect(completed).toMatchObject({
       type: 'workflow.task',
       logId: planned?.logId,
-      stageId: parent.id,
+      stageId: phaseId,
     });
     expect(events).toContainEqual(
       expect.objectContaining({
@@ -166,6 +168,72 @@ return await agent('Run one', { id: 'used' })`,
     expect(activities).toContain(
       'Skipped: Unused task — The workflow ended before this task was reached.',
     );
+  });
+
+  it('opens and closes a declared phase the run never reached', async () => {
+    const { trace, events } = recordingTrace();
+    await runPersistedWorkflowScriptWithProgress(trace, {
+      store: getExecutionStore(executionId),
+      checkpointId: 'unreached-phase',
+      script: `export const meta = {
+  name: 'unreached-phase',
+  description: 'declares a phase the run never enters',
+  phases: [{ title: 'Research' }, { title: 'Write' }],
+  tasks: [
+    { id: 'used', label: 'Used task', phase: 'Research' },
+    { id: 'later', label: 'Later task', phase: 'Write' },
+  ],
+}
+phase('Research')
+return await agent('Run one', { id: 'used' })`,
+      runAgent: async () => 'done',
+    });
+
+    // The skipped card still belongs to its own phase group, so the sweep has
+    // to open that stage even though the script never entered it.
+    const writeId = stageId(events, 'Write');
+    expect(workflowTaskEvent(events, 'Later task', 'skipped')).toMatchObject({
+      stageId: writeId,
+      task: { reason: 'not-reached' },
+    });
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: 'stage.start',
+        id: writeId,
+        kind: 'phase',
+      }),
+    );
+    expect(events).toContainEqual({
+      type: 'stage.end',
+      id: writeId,
+      status: RUN_OUTCOME.COMPLETED,
+    });
+  });
+
+  it('keeps a phase-less declared task out of the phase active at call time', async () => {
+    const { trace, events } = recordingTrace();
+    await runPersistedWorkflowScriptWithProgress(trace, {
+      store: getExecutionStore(executionId),
+      checkpointId: 'phase-less-declared-task',
+      script: `export const meta = {
+  name: 'phase-less-declared-task',
+  description: 'declares a task with no phase',
+  phases: [{ title: 'Research' }],
+  tasks: [{ id: 'loose', label: 'Loose task' }],
+}
+phase('Research')
+return await agent('Run loose', { id: 'loose' })`,
+      runAgent: async () => 'done',
+    });
+
+    // meta.tasks[].phase is optional, so the plan can declare a task with no
+    // phase while a phase() is active. Its card must stay where it was first
+    // classified — a progress tree cannot move a card between groups.
+    for (const status of ['planned', 'running', 'completed'] as const) {
+      expect(workflowTaskEvent(events, 'Loose task', status)).toMatchObject({
+        stageId: undefined,
+      });
+    }
   });
 
   it('marks a planned task failed when the live-call cap refuses it', async () => {

--- a/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
@@ -12,6 +12,7 @@ import {
   type ExecutionId,
   type WorkflowTaskProgress,
 } from '@shared/schemas';
+import { workflowPhaseTaskProgress } from '@shared/copy/workflowTask';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { runPersistedWorkflowScriptWithProgress } from '@tools/delegation/workflowScriptRun';
 
@@ -53,6 +54,23 @@ function workflowTaskEvent(
       event.task.label === label &&
       event.task.status === status,
   );
+}
+
+/**
+ * The current card set, one entry per `logId` — what a host progress tree
+ * holds after applying every update.
+ */
+function latestWorkflowTaskEvents(
+  events: readonly AgentEvent[],
+): Extract<AgentEvent, { type: 'workflow.task' }>[] {
+  const byLogId = new Map<
+    string,
+    Extract<AgentEvent, { type: 'workflow.task' }>
+  >();
+  for (const event of events) {
+    if (event.type === 'workflow.task') byLogId.set(event.logId, event);
+  }
+  return [...byLogId.values()];
 }
 
 beforeEach(() => clearStoreCache());
@@ -228,12 +246,33 @@ return await agent('Run loose', { id: 'loose' })`,
 
     // meta.tasks[].phase is optional, so the plan can declare a task with no
     // phase while a phase() is active. Its card must stay where it was first
-    // classified — a progress tree cannot move a card between groups.
+    // classified — a progress tree cannot move a card between groups — and the
+    // payload every host folds `done/total` by must say the same thing, so a
+    // phase-less task is counted under no phase rather than under the wrong one.
     for (const status of ['planned', 'running', 'completed'] as const) {
       expect(workflowTaskEvent(events, 'Loose task', status)).toMatchObject({
         stageId: undefined,
       });
+      expect(
+        workflowTaskEvent(events, 'Loose task', status)?.task.phase,
+      ).toBeUndefined();
     }
+
+    // The two answers agree by construction: the phase whose group holds the
+    // card and the phase the shared fold reads off the payload are the same
+    // recorded value. Under the active phase both are empty.
+    const researchId = stageId(events, 'Research');
+    const latest = latestWorkflowTaskEvents(events);
+    expect(
+      workflowPhaseTaskProgress(
+        latest.flatMap((event) =>
+          event.task.phase === 'Research' ? [event.task] : [],
+        ),
+      ),
+    ).toEqual({ done: 0, total: 0 });
+    expect(latest.filter((event) => event.stageId === researchId)).toHaveLength(
+      0,
+    );
   });
 
   it('marks a planned task failed when the live-call cap refuses it', async () => {

--- a/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
@@ -275,6 +275,36 @@ return await agent('Run loose', { id: 'loose' })`,
     );
   });
 
+  it('does not fail an active phase for a failed phase-less declared task', async () => {
+    const { trace, events } = recordingTrace();
+    await runPersistedWorkflowScriptWithProgress(trace, {
+      store: getExecutionStore(executionId),
+      checkpointId: 'failed-phase-less-declared-task',
+      script: `export const meta = {
+  name: 'failed-phase-less-declared-task',
+  description: 'keeps a phase-less failure outside the active phase',
+  phases: [{ title: 'Research' }],
+  tasks: [{ id: 'loose', label: 'Loose task' }],
+}
+phase('Research')
+return await agent('Run loose', { id: 'loose' })`,
+      runAgent: async () => {
+        throw new Error('model unavailable');
+      },
+    });
+
+    const researchId = stageId(events, 'Research');
+    expect(workflowTaskEvent(events, 'Loose task', 'failed')).toMatchObject({
+      stageId: undefined,
+      task: { phase: undefined, error: 'model unavailable' },
+    });
+    expect(events).toContainEqual({
+      type: 'stage.end',
+      id: researchId,
+      status: RUN_OUTCOME.COMPLETED,
+    });
+  });
+
   it('marks a planned task failed when the live-call cap refuses it', async () => {
     const { trace, events } = recordingTrace();
     await expect(

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -460,14 +460,49 @@ describe('CLI conversation transcript splitting', () => {
       { id: 'a', label: 'Task', status: 'skipped', reason: 'user' },
       { id: 'a', label: 'Task', status: 'failed', error: 'Runner stopped.' },
     ];
-    const markers = tasks.map((task) =>
-      transcriptEntryLayout(
-        { id: 'a', role: 'workflowTask', text: 'Task', finalized: true, task },
-        { width: 80 },
-      ).lines[0]?.slice(0, 2),
+    const firstLines = tasks.map(
+      (task) =>
+        transcriptEntryLayout(
+          {
+            id: 'a',
+            role: 'workflowTask',
+            text: 'Task',
+            finalized: true,
+            task,
+          },
+          { width: 80 },
+        ).lines[0] ?? '',
     );
 
-    expect(markers).toEqual(['□ ', '☐ ', '☑ ', '✓ ', '⊘ ', '✗ ']);
+    // Every task row nests two columns under the `◆` phase divider heading it.
+    expect(firstLines.every((line) => line.startsWith('  '))).toBe(true);
+    expect(firstLines.map((line) => line.slice(2, 4))).toEqual([
+      '□ ',
+      '☐ ',
+      '☑ ',
+      '✓ ',
+      '⊘ ',
+      '✗ ',
+    ]);
+  });
+
+  it('aligns a wrapped task row under its own marker', () => {
+    const layout = transcriptEntryLayout(
+      {
+        id: 'a',
+        role: 'workflowTask',
+        text: `Finished: ${'w'.repeat(40)} ${'x'.repeat(40)}`,
+        finalized: true,
+        task: { id: 'a', label: 'Task', status: 'completed', durationMs: 1 },
+      },
+      { width: 40 },
+    );
+
+    expect(layout.lines[0]?.startsWith('  ☑ ')).toBe(true);
+    expect(layout.lines.slice(1).every((line) => line.startsWith('    '))).toBe(
+      true,
+    );
+    expect(layout.lines.length).toBeGreaterThan(1);
   });
 
   it('budgets live rich tool rows without reflowing their display lines', () => {

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -163,6 +163,56 @@ describe('CLI child list display model', () => {
     );
   });
 
+  it('leaves a phase-less task out of the active phase fold', () => {
+    // A declared task may carry no phase even while a phase is running. Its
+    // card is grouped at the run stage rather than in the phase, so the phase
+    // fold must not count it either — the bridge records the task's phase once
+    // and stamps both, so the count here can never name a phase the card is
+    // not in.
+    const slice = workflowAgentSlice('loose', {
+      files: { input: ['paper.tex'], context: [], media: [], output: [] },
+      entries: [
+        {
+          id: 'phase-map',
+          role: 'phase',
+          text: 'Map',
+          finalized: true,
+          phaseLabel: 'Map',
+          phaseIndex: 0,
+          phaseTotal: 2,
+        },
+        {
+          id: 'task-in-phase',
+          role: 'workflowTask',
+          text: 'Running: Map the seams',
+          finalized: false,
+          task: {
+            id: 'seams',
+            label: 'Map the seams',
+            phase: 'Map',
+            status: 'running',
+          },
+        },
+        {
+          id: 'task-loose',
+          role: 'workflowTask',
+          text: 'Finished: Loose task',
+          finalized: true,
+          task: {
+            id: 'loose',
+            label: 'Loose task',
+            status: 'completed',
+            durationMs: 1_000,
+          },
+        },
+      ],
+    });
+
+    expect(workflowRunStatusSummary(slice)).toBe(
+      'Map (1/2) · 0/1 done · Input: 1 file · Context: 0 files',
+    );
+  });
+
   it('prioritizes live workflow activity over metadata in a one-row viewport', async () => {
     const { ink, React } = await loadInk();
     const streamId = 'devise' as StreamTabId;

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -8,7 +8,7 @@ import {
 } from '@cli/chat/tui/panes/SubagentListDisplay';
 import {
   ConversationPane,
-  workflowInputContextSummary,
+  workflowRunStatusSummary,
 } from '@cli/chat/tui/panes/ConversationPane';
 import {
   SubagentList,
@@ -95,12 +95,72 @@ describe('CLI child list display model', () => {
       files: { input: [], context: [], media: [], output: [] },
     });
 
-    expect(workflowInputContextSummary(workflow)).toBe(
+    expect(workflowRunStatusSummary(workflow)).toBe(
       'Input: 2 files · Context: 1 file',
     );
-    expect(workflowInputContextSummary(toolUse)).toBeUndefined();
-    expect(workflowInputContextSummary(workflowWithoutInputs)).toBeUndefined();
-    expect(workflowInputContextSummary(undefined)).toBeUndefined();
+    expect(workflowRunStatusSummary(toolUse)).toBeUndefined();
+    expect(workflowRunStatusSummary(workflowWithoutInputs)).toBeUndefined();
+    expect(workflowRunStatusSummary(undefined)).toBeUndefined();
+  });
+
+  it('leads the workflow status band with the current phase and its task fold', () => {
+    const slice = workflowAgentSlice('itemized', {
+      files: { input: ['paper.tex'], context: [], media: [], output: [] },
+      entries: [
+        {
+          id: 'phase-map',
+          role: 'phase',
+          text: 'Map',
+          finalized: true,
+          phaseLabel: 'Map',
+          phaseIndex: 0,
+          phaseTotal: 3,
+        },
+        {
+          id: 'task-a',
+          role: 'workflowTask',
+          text: 'Finished: Map the seams',
+          finalized: true,
+          task: {
+            id: 'seams',
+            label: 'Map the seams',
+            phase: 'Map',
+            status: 'completed',
+            durationMs: 1_000,
+          },
+        },
+        {
+          id: 'task-b',
+          role: 'workflowTask',
+          text: 'Running: Read the contracts',
+          finalized: false,
+          task: {
+            id: 'contracts',
+            label: 'Read the contracts',
+            phase: 'Map',
+            status: 'running',
+          },
+        },
+        {
+          id: 'task-c',
+          role: 'workflowTask',
+          text: 'Planned: Draft the section',
+          finalized: false,
+          task: {
+            id: 'draft',
+            label: 'Draft the section',
+            phase: 'Write',
+            status: 'planned',
+          },
+        },
+      ],
+    });
+
+    // Only the current phase's tasks are folded, and the phase segment leads so
+    // it survives truncation on a narrow terminal.
+    expect(workflowRunStatusSummary(slice)).toBe(
+      'Map (1/3) · 1/2 done · Input: 1 file · Context: 0 files',
+    );
   });
 
   it('prioritizes live workflow activity over metadata in a one-row viewport', async () => {

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -163,6 +163,27 @@ describe('CLI child list display model', () => {
     );
   });
 
+  it('does not invent a phase fold for phase-less tasks', () => {
+    const slice = workflowAgentSlice('phase-less-only', {
+      entries: [
+        {
+          id: 'task-loose',
+          role: 'workflowTask',
+          text: 'Finished: Loose task',
+          finalized: true,
+          task: {
+            id: 'loose',
+            label: 'Loose task',
+            status: 'completed',
+            durationMs: 1_000,
+          },
+        },
+      ],
+    });
+
+    expect(workflowRunStatusSummary(slice)).toBeUndefined();
+  });
+
   it('leaves a phase-less task out of the active phase fold', () => {
     // A declared task may carry no phase even while a phase is running. Its
     // card is grouped at the run stage rather than in the phase, so the phase

--- a/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
+++ b/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
@@ -528,6 +528,15 @@ describe('task-group-list workflow-script phase rendering (#8722)', () => {
       ?.textContent?.trim();
     expect(title).toBe('Review (2/3)');
 
+    // The header also folds its own cards into a completion count. All four
+    // are terminal here (completed / failed / skipped x2).
+    const progress = list.shadowRoot
+      ?.querySelector(
+        `#${GROUP_DOM_IDS.HEADER_PREFIX}phase-review .group-progress`,
+      )
+      ?.textContent?.trim();
+    expect(progress).toBe('4/4');
+
     // Each task is one structured card with its status and terminal metadata.
     const content = list.shadowRoot?.querySelector(
       `#${GROUP_DOM_IDS.CONTENT_PREFIX}phase-review`,
@@ -575,9 +584,88 @@ describe('task-group-list workflow-script phase rendering (#8722)', () => {
 
     const list = await renderList([run, phase], []);
 
-    const title = list.shadowRoot
-      ?.querySelector(`#${GROUP_DOM_IDS.HEADER_PREFIX}phase-solo .group-title`)
-      ?.textContent?.trim();
-    expect(title).toBe('Solo phase');
+    const header = list.shadowRoot?.querySelector(
+      `#${GROUP_DOM_IDS.HEADER_PREFIX}phase-solo`,
+    );
+    expect(header?.querySelector('.group-title')?.textContent?.trim()).toBe(
+      'Solo phase',
+    );
+    // A phase holding no task cards has nothing to fold.
+    expect(header?.querySelector('.group-progress')).toBeNull();
+  });
+
+  it('tracks an in-flight phase fold and drops the redundant phase chip', async () => {
+    const run: TaskGroup = {
+      id: 'run',
+      name: 'Run: workflow',
+      startTime: 1,
+      status: STREAM_PHASE.RUNNING,
+    };
+    const phase: TaskGroup = {
+      id: 'phase-map',
+      name: 'Map',
+      startTime: 2,
+      status: STREAM_PHASE.RUNNING,
+      parentGroupId: 'run',
+      kind: 'phase',
+      index: 0,
+      total: 3,
+    };
+    const messages: LogMessageData[] = [
+      {
+        id: 'task-a',
+        text: 'seams',
+        timestamp: 3,
+        level: LOG_LEVELS.INFO,
+        groupId: 'phase-map',
+        messageType: MESSAGE_TYPES.WORKFLOW_TASK,
+        data: {
+          id: 'seams',
+          label: 'Map the seams',
+          phase: 'Map',
+          status: 'completed',
+          durationMs: 72_000,
+        },
+      },
+      {
+        id: 'task-b',
+        text: 'contracts',
+        timestamp: 4,
+        level: LOG_LEVELS.INFO,
+        groupId: 'phase-map',
+        messageType: MESSAGE_TYPES.WORKFLOW_TASK,
+        data: {
+          id: 'contracts',
+          label: 'Read the contracts',
+          phase: 'Map',
+          status: 'running',
+        },
+      },
+      // A malformed row must drop out of the fold rather than throw.
+      {
+        id: 'task-bad',
+        text: 'broken',
+        timestamp: 5,
+        level: LOG_LEVELS.INFO,
+        groupId: 'phase-map',
+        messageType: MESSAGE_TYPES.WORKFLOW_TASK,
+        data: { id: 'broken' },
+      },
+    ];
+
+    const list = await renderList([run, phase], messages);
+
+    const header = list.shadowRoot?.querySelector(
+      `#${GROUP_DOM_IDS.HEADER_PREFIX}phase-map`,
+    );
+    expect(header?.querySelector('.group-progress')?.textContent?.trim()).toBe(
+      '1/2',
+    );
+    // The enclosing header is the card's one home for its phase.
+    const content = list.shadowRoot?.querySelector(
+      `#${GROUP_DOM_IDS.CONTENT_PREFIX}phase-map`,
+    );
+    expect(content?.querySelector('.workflow-task-phase')).toBeNull();
+    expect(content?.querySelector('.workflow-task-details')).toBeNull();
   });
 });

--- a/src/test-kernel/shared/WorkflowTaskCopy.vitest.ts
+++ b/src/test-kernel/shared/WorkflowTaskCopy.vitest.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   formatWorkflowTaskMetadataParts,
   formatWorkflowTaskLine,
+  workflowPhaseTaskProgress,
 } from '@shared/copy/workflowTask';
 
 describe('workflow task copy', () => {
@@ -56,6 +57,31 @@ describe('workflow task copy', () => {
     ).toBe(
       'Skipped: Audit later — The workflow ended before this task was reached.',
     );
+  });
+
+  it('counts an empty phase as no work rather than complete', () => {
+    expect(workflowPhaseTaskProgress([])).toEqual({ done: 0, total: 0 });
+  });
+
+  it('counts every terminal status as done, not just completions', () => {
+    expect(
+      workflowPhaseTaskProgress([
+        { id: 'a', label: 'A', status: 'completed', durationMs: 1 },
+        { id: 'b', label: 'B', status: 'cached' },
+        { id: 'c', label: 'C', status: 'skipped', reason: 'not-reached' },
+        { id: 'd', label: 'D', status: 'failed', error: 'nope' },
+      ]),
+    ).toEqual({ done: 4, total: 4 });
+  });
+
+  it('leaves planned and running tasks outstanding', () => {
+    expect(
+      workflowPhaseTaskProgress([
+        { id: 'a', label: 'A', status: 'completed', durationMs: 1 },
+        { id: 'b', label: 'B', status: 'running' },
+        { id: 'c', label: 'C', status: 'planned' },
+      ]),
+    ).toEqual({ done: 1, total: 3 });
   });
 
   it('leaves a user skip without an explanatory clause', () => {

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -222,6 +222,12 @@ export async function runPersistedWorkflowScriptWithProgress(
       stageId: phase === undefined ? parentStageId : phaseStageIdFor(phase),
     });
   };
+  const recordedTaskPhase = (
+    task: Pick<WorkflowTaskProgress, 'id' | 'phase'>,
+  ): string | undefined => {
+    const projected = projectedTasks.get(task.id);
+    return projected ? projected.definition.phase : task.phase;
+  };
   const markPhaseFailed = (
     title: string | undefined,
     index?: number,
@@ -284,7 +290,6 @@ export async function runPersistedWorkflowScriptWithProgress(
         // Cached replays report none because they perform no live attempt.
         switch (event.outcome) {
           case 'failed': {
-            markPhaseFailed(phaseTitle, event.phaseIndex, event.phaseTotal);
             const task: WorkflowTaskProgress = {
               id: event.progressId,
               label: event.label,
@@ -297,6 +302,11 @@ export async function runPersistedWorkflowScriptWithProgress(
                 : {}),
               ...(spent !== undefined ? { totalCostUsd: spent } : {}),
             };
+            markPhaseFailed(
+              recordedTaskPhase(task),
+              event.phaseIndex,
+              event.phaseTotal,
+            );
             emitTask(task);
             recordTerminalActivity(task);
             break;

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -190,10 +190,13 @@ export async function runPersistedWorkflowScriptWithProgress(
     onActivity?.(formatWorkflowTaskLine(task));
   };
   /**
-   * A task's group is derived from the phase recorded on its first emission
-   * and never from the phase active when a later update arrives, so the same
-   * card cannot land in two groups: host progress trees classify a card once
-   * and cannot move it afterwards.
+   * The phase recorded on a task's first emission is the single owner of
+   * "which phase is this task in", and it stamps both halves of that answer:
+   * the `stageId` its card is grouped under, and the `phase` on the emitted
+   * payload that hosts fold `done/total` by. A later update carrying the phase
+   * active at call time never overrides it, so the group and the fold cannot
+   * drift apart, and the same card cannot land in two groups — host progress
+   * trees classify a card once and cannot move it afterwards.
    */
   const emitTask = (task: WorkflowTaskProgress): void => {
     let projected = projectedTasks.get(task.id);
@@ -215,7 +218,7 @@ export async function runPersistedWorkflowScriptWithProgress(
     trace.emit({
       type: 'workflow.task',
       logId: projected.logId,
-      task,
+      task: { ...task, phase },
       stageId: phase === undefined ? parentStageId : phaseStageIdFor(phase),
     });
   };

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -38,7 +38,6 @@ interface PhaseStage {
 
 interface ProjectedWorkflowTask {
   readonly logId: string;
-  readonly stageId: string | undefined;
   readonly definition: Pick<WorkflowTaskProgress, 'id' | 'label' | 'phase'>;
   status: WorkflowTaskProgress['status'];
 }
@@ -120,6 +119,7 @@ export async function runPersistedWorkflowScriptWithProgress(
   const { getLiveCostUsd, onActivity, ...runOptions } = options;
   const parentStageId = trace.activeStageId();
   const phases = new Map<string, PhaseStage>();
+  const phaseStageIds = new Map<string, string>();
   const callPhases = new Map<WorkflowScriptProgressId, string | undefined>();
   const projectedTasks = new Map<
     WorkflowScriptProgressId,
@@ -128,6 +128,21 @@ export async function runPersistedWorkflowScriptWithProgress(
   let currentPhase: string | undefined;
   let closed = false;
   let runOutcome: RunOutcome = RUN_OUTCOME.FAILED;
+
+  /**
+   * Stable stage id for a phase title, minted before the stage opens. A
+   * declared task can name the group it belongs to from the moment it is
+   * planned, while `stage.start` — which settles the divider's print order the
+   * instant it is emitted — still waits until the run actually reaches the
+   * phase, so a divider never prints above its own task rows.
+   */
+  const phaseStageIdFor = (title: string): string => {
+    const existing = phaseStageIds.get(title);
+    if (existing) return existing;
+    const id = generateShortId();
+    phaseStageIds.set(title, id);
+    return id;
+  };
 
   const phaseFor = (
     title: string,
@@ -138,6 +153,7 @@ export async function runPersistedWorkflowScriptWithProgress(
     if (existing) return existing;
     const phase = {
       handle: trace.openStage(title, {
+        id: phaseStageIdFor(title),
         kind: 'phase',
         parentId: parentStageId,
         index,
@@ -149,7 +165,12 @@ export async function runPersistedWorkflowScriptWithProgress(
     return phase;
   };
 
-  const stageIdFor = (
+  /**
+   * Open a phase stage once the run reaches it and answer the stage rows
+   * emitted from there belong to. Callers that only need the phase opened
+   * ignore the return: `emitTask` resolves a card's group itself.
+   */
+  const openPhaseStage = (
     phase: string | undefined,
     index?: number,
     total?: number,
@@ -168,15 +189,17 @@ export async function runPersistedWorkflowScriptWithProgress(
   ): void => {
     onActivity?.(formatWorkflowTaskLine(task));
   };
-  const emitTask = (
-    task: WorkflowTaskProgress,
-    stageId: string | undefined,
-  ): void => {
+  /**
+   * A task's group is derived from the phase recorded on its first emission
+   * and never from the phase active when a later update arrives, so the same
+   * card cannot land in two groups: host progress trees classify a card once
+   * and cannot move it afterwards.
+   */
+  const emitTask = (task: WorkflowTaskProgress): void => {
     let projected = projectedTasks.get(task.id);
     if (!projected) {
       projected = {
         logId: `workflow-task-${generateShortId()}`,
-        stageId,
         definition: {
           id: task.id,
           label: task.label,
@@ -188,11 +211,12 @@ export async function runPersistedWorkflowScriptWithProgress(
     } else {
       projected.status = task.status;
     }
+    const phase = projected.definition.phase;
     trace.emit({
       type: 'workflow.task',
       logId: projected.logId,
       task,
-      stageId: projected.stageId,
+      stageId: phase === undefined ? parentStageId : phaseStageIdFor(phase),
     });
   };
   const markPhaseFailed = (
@@ -210,7 +234,7 @@ export async function runPersistedWorkflowScriptWithProgress(
     switch (event.type) {
       case 'plan':
         for (const task of event.tasks) {
-          emitTask({ ...task, status: 'planned' }, parentStageId);
+          emitTask({ ...task, status: 'planned' });
         }
         break;
       case 'phase':
@@ -219,25 +243,20 @@ export async function runPersistedWorkflowScriptWithProgress(
         onActivity?.(`Phase: ${event.title}`);
         break;
       case 'log':
-        info(event.message, stageIdFor(currentPhase));
+        info(event.message, openPhaseStage(currentPhase));
         break;
       case 'agent:start': {
         const phaseTitle = event.phase ?? currentPhase;
         callPhases.set(event.progressId, phaseTitle);
-        const stageId = stageIdFor(
-          phaseTitle,
-          event.phaseIndex,
-          event.phaseTotal,
-        );
-        emitTask(
-          {
-            id: event.progressId,
-            label: event.label,
-            ...(phaseTitle !== undefined ? { phase: phaseTitle } : {}),
-            status: 'running',
-          },
-          stageId,
-        );
+        // Open the phase the moment the run reaches it; `emitTask` resolves
+        // the card's group on its own from the task's recorded phase.
+        openPhaseStage(phaseTitle, event.phaseIndex, event.phaseTotal);
+        emitTask({
+          id: event.progressId,
+          label: event.label,
+          ...(phaseTitle !== undefined ? { phase: phaseTitle } : {}),
+          status: 'running',
+        });
         onActivity?.(`Running: ${event.label}`);
         break;
       }
@@ -248,11 +267,8 @@ export async function runPersistedWorkflowScriptWithProgress(
           ? callPhases.get(event.progressId)
           : (event.phase ?? currentPhase);
         callPhases.delete(event.progressId);
-        const stageId = stageIdFor(
-          phaseTitle,
-          event.phaseIndex,
-          event.phaseTotal,
-        );
+        // A cached replay has no agent:start, so this is where its phase opens.
+        openPhaseStage(phaseTitle, event.phaseIndex, event.phaseTotal);
         // Cached replays spend nothing, so their lines stay cost-free; live
         // onCost settles before agent:end, so the total here is current.
         const spent =
@@ -278,20 +294,17 @@ export async function runPersistedWorkflowScriptWithProgress(
                 : {}),
               ...(spent !== undefined ? { totalCostUsd: spent } : {}),
             };
-            emitTask(task, stageId);
+            emitTask(task);
             recordTerminalActivity(task);
             break;
           }
           case 'cached':
-            emitTask(
-              {
-                id: event.progressId,
-                label: event.label,
-                ...(phaseTitle !== undefined ? { phase: phaseTitle } : {}),
-                status: 'cached',
-              },
-              stageId,
-            );
+            emitTask({
+              id: event.progressId,
+              label: event.label,
+              ...(phaseTitle !== undefined ? { phase: phaseTitle } : {}),
+              status: 'cached',
+            });
             onActivity?.(`Using saved result: ${event.label}`);
             break;
           case 'skipped': {
@@ -307,7 +320,7 @@ export async function runPersistedWorkflowScriptWithProgress(
                 : {}),
               ...(spent !== undefined ? { totalCostUsd: spent } : {}),
             };
-            emitTask(task, stageId);
+            emitTask(task);
             recordTerminalActivity(task);
             break;
           }
@@ -321,7 +334,7 @@ export async function runPersistedWorkflowScriptWithProgress(
               durationMs: event.durationMs,
               ...(spent !== undefined ? { totalCostUsd: spent } : {}),
             };
-            emitTask(task, stageId);
+            emitTask(task);
             recordTerminalActivity(task);
             break;
           }
@@ -342,18 +355,17 @@ export async function runPersistedWorkflowScriptWithProgress(
     return result;
   } finally {
     closed = true;
-    for (const {
-      definition: task,
-      stageId,
-      status,
-    } of projectedTasks.values()) {
+    for (const { definition: task, status } of projectedTasks.values()) {
       if (status === 'planned') {
+        // Open the declared phase the run never reached so its skipped cards
+        // still land under a header; the loop below then closes it.
+        openPhaseStage(task.phase);
         const skippedTask: WorkflowTaskProgress = {
           ...task,
           status: 'skipped',
           reason: 'not-reached',
         };
-        emitTask(skippedTask, stageId);
+        emitTask(skippedTask);
         recordTerminalActivity(skippedTask);
       } else if (status === 'running') {
         markPhaseFailed(task.phase);
@@ -365,7 +377,7 @@ export async function runPersistedWorkflowScriptWithProgress(
           error,
           ...(totalCostUsd !== undefined ? { totalCostUsd } : {}),
         };
-        emitTask(failedTask, stageId);
+        emitTask(failedTask);
         recordTerminalActivity(failedTask);
       }
     }


### PR DESCRIPTION
## Summary

Fixes workflow-task projection so a declared task belongs to its declared phase from its first `planned` event through its terminal update, then itemizes those cards under phase headers with a shared per-phase `done/total` fold in both hosts.

- `phaseStageIdFor(title)` memoizes the final stage id without opening the phase early; phase stages still open lazily so CLI settlement order is unchanged.
- `emitTask` records a task's phase on first emission and uses that same value for both `stageId` and the emitted `task.phase`. This preserves the Cursor fix originally landed in `d1cb7dc5f6`: phase-less declared tasks stay phase-less and cannot drift into the phase active at call time. Failed stages are now marked from that recorded phase too, so a failed phase-less task cannot fail an unrelated active phase. The CLI also emits no phase fold until a phase header exists, so phase-less-only work cannot produce a bare progress count.
- The progress view shows `done/total` on non-empty phase headers and removes the redundant per-card `Phase:` chip.
- The CLI keeps #9150/#9147's exhaustive six-status glyph/color table and marker composition while adding a two-space phase nest and four-space wrapped continuation alignment. The shared headless `formatWorkflowTaskLine` projection is unchanged.
- Rebased onto current `main` (`a1fa9fad4d`), including #9155/#9145 retained-child behavior. The rebase had no textual conflicts; the overlapping transcript semantics were reviewed explicitly rather than replaced.

Closes #9146.

## Issue acceptance gates

All #9146 acceptance gates are satisfied:

- `ProjectedWorkflowTask` has exactly `logId`, `definition`, and `status`; no `projected.stageId` remains.
- Planned/running/terminal updates retain one phase-derived stage id, never-reached phases are opened and closed around `not-reached` cards, and phase-less declarations remain outside active phase folds and failure status.
- `workflowPhaseTaskProgress` uses `isTerminalWorkflowTaskProgress`, has exactly two production consumers (CLI and extension), and direct empty/all-terminal/outstanding coverage.
- Phase headers render a safe-parsed live fold only when they contain workflow-task cards; redundant phase/detail classes are gone and `.workflow-task-meta` owns its styling.
- CLI rows use two-space nesting plus marker-width continuation alignment without adding a new role or pane; all six status glyphs/colors from #9150 remain exhaustive.
- `workflowRunStatusSummary` leads with current phase and progress, emits no phase fold without a phase header, and reserves at most one metadata row.
- No new files, schemas, wire fields, migrations, timers, state fields, or dead-code baseline entries; no changes under `src/shared/schemas/`.
- Workflow stream transcript tests confirm headless entry text remains unindented and chronology is unchanged.

The requested real-terminal/webview manual workflow was not run; host behavior is covered by the focused DOM/layout/transcript tests listed below.

## Single source of truth

- `ProjectedWorkflowTask.definition.phase` is the single owner of a projected task's phase. It stamps both the card's `stageId` and emitted `task.phase`.
- `workflowPhaseTaskProgress` in `src/shared/copy/workflowTask.ts` is the single owner of terminal-status completion folding across hosts.
- `WORKFLOW_TASK_STATUS_STYLE` remains the single exhaustive CLI owner of the six workflow-task marker/color pairs.

## Duplication and abstraction budget

One shared fold was added instead of separate CLI and extension implementations. The projection deleted the stored `stageId` field and the progress card deleted its duplicate phase chip, wrapper, CSS class, and pseudo-label. No pass-through layer, component, panel, viewport, schema, or file was added.

## Net elements (R6)

- Files: 13 modified, 0 added, 0 deleted.
- LoC: production `+182/-87` (net `+95`); tests `+436/-19` (net `+417`); total `+618/-106`.
- Exports: `workflowPhaseTaskProgress` added; `workflowInputContextSummary` renamed to `workflowRunStatusSummary` (net `+1`).
- Interfaces: `ProjectedWorkflowTask` loses one field; no interface/class/enum added.
- Schemas/wire fields: net 0.

## Consumer counts (R8)

- `workflowPhaseTaskProgress`: exactly 2 production consumers (`ConversationPane.tsx`, `TaskGroupList.ts`).
- `workflowRunStatusSummary`: 1 production consumer in `ConversationPane.tsx`; tests import it directly.
- Workflow-task trace event subscribers/wire shape: unchanged; only the existing `stageId` value is corrected.

## Host impact

Extension: phase disclosures contain their task cards and show live `done/total`; per-card phase duplication is removed.

Desktop: consumes the same extension progress-view components; no desktop-specific contract or schema changed.

CLI: phase task rows nest two spaces under `◆`, wrapped text aligns beneath the post-marker label, and the existing one-row workflow status band leads with phase progress. Six status glyphs/colors and headless text remain unchanged.

## Scheduled refactoring

None.

## Validation

Run after rebasing onto `a1fa9fad4d` and after formatting every PR-changed file:

- `pnpm exec prettier --check $(git diff --name-only origin/main...HEAD)` — pass.
- Focused Vitest run (workflow bridge, workflow stream transcript, subagent display, shared copy, TaskGroupList) — 5 files / 70 tests pass.
- `npm run typecheck` — pass (all six tsconfigs).
- `npm run lint` — pass.
- `npm run check:dead-code-ratchet` — pass, 18 current vs 18 baselined.
- `npm test` — 775 files / 7558 tests pass; 1 file / 4 tests skipped. One earlier rerun hit unrelated suite-load timeout contamination in `RunChatSignalOwnership`, `LegacyWorkflowOutput`, and `SystemUtils`; those files then passed directly (3 files / 35 tests), followed by the clean full result reported here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workflow-script progress projection (stage grouping, phase failure, cleanup sweeps) that both hosts consume; behavior is heavily tested but affects live run UX.
> 
> **Overview**
> Workflow tasks are **projected into their declared phase from the first `planned` event**, with one recorded `definition.phase` driving both `stageId` grouping and the emitted `task.phase` so CLI and progress view stay aligned. Phase stages still open lazily via memoized IDs; unreached phases open at cleanup for `not-reached` skips, and **phase-less declared tasks** stay on the run stage and no longer skew an active phase’s failure or completion fold.
> 
> A shared **`workflowPhaseTaskProgress`** fold powers **per-phase `done/total`** on extension phase headers and the CLI **`workflowRunStatusSummary`** band (phase position first, then progress, then input/context). Progress cards drop the redundant **Phase:** sub-label; CLI task rows **nest two spaces** under the `◆` divider with wrapped continuation alignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57065796ae4a038485f34d43a5093adc92724cf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->