### PR TITLE
refactor(progress): centralize snapshot writes

### DIFF
--- a/src/controllers/progressView/backend/ProgressBackend.ts
+++ b/src/controllers/progressView/backend/ProgressBackend.ts
@@ -76,9 +76,9 @@ export interface ProgressBackendOptions {
   /** Session that owns this backend's coordination state (defaults to the process session). */
   session?: SessionHandle;
   /**
-   * `session` when the supplied snapshot store already has its own
-   * process-lifetime session-event subscription. The backend then projects
-   * facts without applying the same durable mutations a second time.
+   * `session` when the caller has already attached this snapshot store to the
+   * session event hub, already registered an artifact flusher for it, and
+   * already loaded/swept it at process start. See the #6981 retirement ledger.
    */
   stateOwnership?: 'backend' | 'session';
   /**
@@ -110,6 +110,7 @@ export class ProgressBackend {
   private readonly onSetActiveStream?: (
     payload: SetActiveStreamPayload,
   ) => void;
+  private readonly detachSnapshotEvents: () => void;
   private readonly detachArtifactFlusher: () => void;
   private readonly stateOwnership: 'backend' | 'session';
   private disposed = false;
@@ -131,6 +132,10 @@ export class ProgressBackend {
       this.session,
       options.stores,
     );
+    this.detachSnapshotEvents =
+      this.stateOwnership === 'session'
+        ? () => undefined
+        : this.state.snapshots.attachSessionEvents(this.session.events);
     this.detachArtifactFlusher =
       this.stateOwnership === 'session'
         ? () => undefined
@@ -162,7 +167,6 @@ export class ProgressBackend {
       ui.hasPendingPermissions,
       (stream) => this.deleteStream(stream),
       options.getStreamControls,
-      this.stateOwnership,
     );
     this.interactionHandler = new ProgressInteractionHandler(ui.callbacks);
     this.onSetActiveStream = options.onSetActiveStream;
@@ -355,6 +359,7 @@ export class ProgressBackend {
 
   dispose(): void {
     this.disposed = true;
+    this.detachSnapshotEvents();
     this.detachArtifactFlusher();
     this.webviewBridge.dispose();
   }

--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -5,10 +5,8 @@ import {
   type AgentTrace,
 } from '@agent/trace';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import type { TaskState } from '@agent/core/state/TaskState';
 import type { SessionFact } from '@agent/runtime/SessionEventHub';
 import type { StreamPhaseState } from '@agent/runtime/StreamStatusService';
-import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 import { WebviewBridge } from '@controllers/progressView/backend/WebviewBridge';
 import {
   ProgressViewState,
@@ -23,7 +21,6 @@ import {
   type AddOutputFilesPayload,
   type ClearMissingOutputsPayload,
   type ConversationProgress,
-  type ExecutionId,
   type GoalStatus,
   type InquiryThreadUpdatedEvent,
   type SetActiveStreamPayload,
@@ -53,12 +50,6 @@ import { withEventErrorHandling } from './errorHandling';
 
 /** Throttle interval for conversation progress webview pushes (ms). */
 const PROGRESS_THROTTLE_MS = 500;
-
-type SetTaskStateProgressFact = {
-  streamId: StreamTabId;
-  executionId?: ExecutionId;
-  taskState: TaskState;
-};
 
 export type ProgressEventSubscription = {
   dispose(): void;
@@ -113,9 +104,6 @@ export class ProgressFactApplier {
     usage: (_streamId, event) => this.handleUpdateStreamUsage(event.payload),
     'run.start': (_streamId, event) => {
       const streamId = event.descriptor.streamId;
-      if (this.stateOwnership === 'backend') {
-        this.state.snapshots.setRunDescriptor(event.descriptor);
-      }
       this.state.refreshStreamMetadataFromSnapshot(streamId);
       if (this.webviewUpdater.isAvailable()) {
         this.webviewUpdater.updateStreamMetadata(
@@ -126,11 +114,7 @@ export class ProgressFactApplier {
       }
     },
     'run.config': (_streamId, event) =>
-      this.handleSetTaskState({
-        streamId: event.streamId,
-        executionId: event.executionId,
-        taskState: agentConfigToTaskState(event.config),
-      }),
+      this.handleSetTaskState(event.streamId, event.config.agentCategory),
     status: (_streamId, event) =>
       this.setStreamStatus(
         event.streamId,
@@ -194,7 +178,6 @@ export class ProgressFactApplier {
       stream: StreamTabId,
     ) => void | Promise<void>,
     private readonly getStreamControls: GetProgressStreamControls = getDefaultProgressStreamControls,
-    private readonly stateOwnership: 'backend' | 'session' = 'backend',
   ) {
     this.logger = createChannelTrace('ProgressFactApplier');
   }
@@ -320,7 +303,7 @@ export class ProgressFactApplier {
     streamId,
     description,
   }: UpdateStreamDescriptionPayload): void {
-    this.state.setStreamDescription(streamId, description, this.stateOwnership);
+    this.state.setStreamDescription(streamId, description);
     if (this.webviewUpdater.isAvailable()) {
       this.webviewUpdater.updateStreamDescription(streamId, description);
     }
@@ -330,11 +313,7 @@ export class ProgressFactApplier {
     childStreamId,
     parentStreamId,
   }: SetParentStreamPayload): void {
-    this.state.setStreamParent(
-      childStreamId,
-      parentStreamId,
-      this.stateOwnership,
-    );
+    this.state.setStreamParent(childStreamId, parentStreamId);
     if (this.webviewUpdater.isAvailable()) {
       this.webviewUpdater.updateParentStream(
         childStreamId,
@@ -361,13 +340,7 @@ export class ProgressFactApplier {
     }
   }
 
-  public handleAddOutputFiles({
-    streamId,
-    filesByRound,
-  }: AddOutputFilesPayload): void {
-    if (this.stateOwnership === 'backend') {
-      this.state.snapshots.addOutputFiles(streamId, filesByRound);
-    }
+  public handleAddOutputFiles({ streamId }: AddOutputFilesPayload): void {
     this.sendIfActive(streamId, () => {
       const rounds = this.state.snapshots.getOutputFiles(streamId);
       this.webviewUpdater.updateFiles(streamId, {
@@ -378,11 +351,7 @@ export class ProgressFactApplier {
 
   public handleUpdateMissingOutputs({
     streamId,
-    filesByRound,
   }: UpdateMissingOutputsPayload): void {
-    if (this.stateOwnership === 'backend') {
-      this.state.snapshots.updateMissingOutputs(streamId, filesByRound);
-    }
     this.sendIfActive(streamId, () => {
       const rounds = this.state.snapshots.getMissingOutputs(streamId);
       this.webviewUpdater.updateMissingOutputs(streamId, {
@@ -393,11 +362,7 @@ export class ProgressFactApplier {
 
   public handleUpdateCompileFailures({
     streamId,
-    filesByRound,
   }: UpdateCompileFailuresPayload): void {
-    if (this.stateOwnership === 'backend') {
-      this.state.snapshots.updateCompileFailures(streamId, filesByRound);
-    }
     this.sendIfActive(streamId, () => {
       const rounds = this.state.snapshots.getCompileFailures(streamId);
       this.webviewUpdater.updateCompileFailures(streamId, {
@@ -419,9 +384,6 @@ export class ProgressFactApplier {
       targets = [];
     }
     for (const streamId of targets) {
-      if (this.stateOwnership === 'backend') {
-        this.state.snapshots.clearMissingOutputs(streamId);
-      }
       this.sendIfActive(streamId, () =>
         this.webviewUpdater.updateMissingOutputs(streamId, {
           reset: true,
@@ -432,34 +394,24 @@ export class ProgressFactApplier {
 
   public handleUpdateStreamUsage({
     streamId,
-    usage,
     storageKey,
   }: UpdateStreamUsagePayload): void {
-    const accumulated =
-      this.stateOwnership === 'backend'
-        ? this.state.snapshots.addUsage(streamId, storageKey, usage)
-        : this.state.snapshots.getRunUsage(streamId).get(storageKey);
-    void Promise.resolve(accumulated).then((nextUsage) => {
-      if (!nextUsage) return;
-      this.sendIfActive(streamId, () =>
-        this.webviewUpdater.updateRunUsage(streamId, storageKey, nextUsage),
-      );
-    });
+    const nextUsage = this.state.snapshots
+      .getRunUsage(streamId)
+      .get(storageKey);
+    if (!nextUsage) return;
+    this.sendIfActive(streamId, () =>
+      this.webviewUpdater.updateRunUsage(streamId, storageKey, nextUsage),
+    );
   }
 
   public handleUpdateTodos({ streamId, todos }: UpdateTodosPayload): void {
-    if (this.stateOwnership === 'backend') {
-      this.state.snapshots.setTodos(streamId, todos);
-    }
     this.sendIfActive(streamId, () =>
       this.webviewUpdater.updateTodos(streamId, todos),
     );
   }
 
   public handleUpdatePlan({ streamId, plan }: UpdatePlanPayload): void {
-    if (this.stateOwnership === 'backend') {
-      this.state.snapshots.setPlan(streamId, plan);
-    }
     if (this.webviewUpdater.isAvailable()) {
       this.webviewUpdater.updatePlan(streamId, plan);
     }
@@ -600,19 +552,12 @@ export class ProgressFactApplier {
     });
   }
 
-  public handleSetTaskState(data: SetTaskStateProgressFact): void {
-    const { streamId, executionId, taskState } = data;
+  private handleSetTaskState(
+    streamId: StreamTabId,
+    category: AgentCategory,
+  ): void {
     const isActiveStream = this.state.activeStream === streamId;
-    const category = taskState.agentConfig.agentCategory;
-
-    // Legacy compatibility payload. The snapshot store derives the current
-    // config and run descriptor from this but no longer writes meta.taskState.
-    this.state.setStreamTaskState(
-      streamId,
-      taskState,
-      executionId,
-      this.stateOwnership,
-    );
+    this.state.refreshStreamMetadataFromSnapshot(streamId);
 
     if (isActiveStream) {
       this.maybeUpdateFilterForCategory(category);

--- a/src/controllers/progressView/backend/state/ProgressViewState.ts
+++ b/src/controllers/progressView/backend/state/ProgressViewState.ts
@@ -4,7 +4,6 @@ import { z } from 'zod';
 import type { AgentTrace } from '@agent/trace';
 import { createChannelTrace } from '@agent/trace';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
-import type { TaskState } from '@agent/core/state/TaskState';
 import type { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import type { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import {
@@ -365,38 +364,15 @@ export class ProgressViewState {
     return metadata;
   }
 
-  setStreamTaskState(
-    stream: StreamTabId,
-    taskState: TaskState,
-    executionId?: ExecutionId,
-    stateOwnership: 'backend' | 'session' = 'backend',
-  ): void {
-    if (stateOwnership === 'backend') {
-      this.snapshots.setTaskState(stream, taskState, executionId);
-    }
-    this.refreshStreamMetadataFromSnapshot(stream);
-  }
-
   setStreamParent(
     stream: StreamTabId,
     parent: StreamTabId | null | undefined,
-    stateOwnership: 'backend' | 'session' = 'backend',
   ): void {
-    if (stateOwnership === 'backend') {
-      this.snapshots.setParentStream(stream, parent);
-    }
     const metadata = this.getOrCreateSession(stream).metadata;
     metadata.parentStreamId = parent ?? undefined;
   }
 
-  setStreamDescription(
-    stream: StreamTabId,
-    description: string,
-    stateOwnership: 'backend' | 'session' = 'backend',
-  ): void {
-    if (stateOwnership === 'backend') {
-      this.snapshots.setDescription(stream, description);
-    }
+  setStreamDescription(stream: StreamTabId, description: string): void {
     this.getOrCreateSession(stream).metadata.description = description;
   }
 

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -281,6 +281,32 @@ describe('ProgressBackend', () => {
     }
   });
 
+  it('attaches snapshot events before run-fact projection', () => {
+    const target = createIsolatedRecordingBackend();
+    const { backend, session } = target;
+    const subscription = backend.setupEventListeners();
+    const streamId = 'snapshot-before-projection' as StreamTabId;
+
+    try {
+      emitRunConfig(
+        target,
+        streamId,
+        'c40001' as ExecutionId,
+        toolUseTaskState('search', 'deepseekproT'),
+      );
+
+      expect(backend.state.getStreamMetadata(streamId).run).toMatchObject({
+        kind: 'agent',
+        agent: 'search',
+        model: 'deepseekproT',
+      });
+    } finally {
+      subscription.dispose();
+      backend.dispose();
+      session.dispose();
+    }
+  });
+
   it('applies active-stream facts before host navigation callbacks', () => {
     const session = createTestSession();
     const streamId = 'fact-before-route' as StreamTabId;
@@ -2049,7 +2075,7 @@ describe('ProgressBackend', () => {
       await backend.state.snapshots.load([]);
       backend.state.streamLogs.ensureStream(stream);
       backend.state.activeStream = stream;
-      backend.state.setStreamTaskState(
+      backend.state.snapshots.setTaskState(
         stream,
         toolUseTaskState('search', 'deepseekproT'),
         'abc123' as ExecutionId,
@@ -2223,11 +2249,12 @@ describe('ProgressBackend', () => {
         isRemote: true,
         creationTimestamp: 123,
       });
-      backend.state.setStreamTaskState(
+      backend.state.snapshots.setTaskState(
         stream,
         toolUseTaskState('search', 'deepseekproT'),
         executionId,
       );
+      backend.state.refreshStreamMetadataFromSnapshot(stream);
       // A late provisional event cannot replace task-state authority.
       backend.state.updateStreamMetadata(stream, {
         agentCategory: AgentCategory.Workflow,
@@ -2379,7 +2406,7 @@ describe('ProgressBackend', () => {
     try {
       await backend.state.snapshots.load([stream]);
       backend.state.streamLogs.ensureStream(stream);
-      backend.state.setStreamTaskState(
+      backend.state.snapshots.setTaskState(
         stream,
         toolUseTaskState('search', 'deepseekproT'),
         executionId,
@@ -2414,7 +2441,7 @@ describe('ProgressBackend', () => {
 
     try {
       backend.state.streamLogs.ensureStream(stream);
-      backend.state.setStreamTaskState(
+      backend.state.snapshots.setTaskState(
         stream,
         toolUseTaskState('search', 'deepseekproT'),
         executionId,
@@ -2457,7 +2484,7 @@ describe('ProgressBackend', () => {
 
     try {
       backend.state.streamLogs.ensureStream(stream);
-      backend.state.setStreamTaskState(
+      backend.state.snapshots.setTaskState(
         stream,
         toolUseTaskState('search', 'deepseekproT'),
         executionId,
@@ -2489,7 +2516,7 @@ describe('ProgressBackend', () => {
 
     try {
       backend.state.streamLogs.ensureStream(stream);
-      backend.state.setStreamTaskState(
+      backend.state.snapshots.setTaskState(
         stream,
         toolUseTaskState('search', 'deepseekproT'),
         executionId,
@@ -2518,7 +2545,7 @@ describe('ProgressBackend', () => {
     try {
       await backend.state.snapshots.load([stream]);
       backend.state.streamLogs.ensureStream(stream);
-      backend.state.setStreamTaskState(
+      backend.state.snapshots.setTaskState(
         stream,
         toolUseTaskState('search', 'deepseekproT'),
         executionId,
@@ -2619,7 +2646,7 @@ describe('ProgressBackend', () => {
     try {
       await backend.state.snapshots.load([stream]);
       backend.state.streamLogs.ensureStream(stream);
-      backend.state.setStreamTaskState(
+      backend.state.snapshots.setTaskState(
         stream,
         toolUseTaskState('search', 'deepseekproT'),
         executionId,
@@ -3120,7 +3147,7 @@ describe('ProgressBackend', () => {
 
     try {
       first.backend.state.streamLogs.ensureStream(stream);
-      first.backend.state.setStreamTaskState(
+      first.backend.state.snapshots.setTaskState(
         stream,
         toolUseTaskState('search', 'deepseekproT'),
         executionId,

--- a/src/test-kernel/progressView/StreamContentSync.vitest.ts
+++ b/src/test-kernel/progressView/StreamContentSync.vitest.ts
@@ -122,7 +122,7 @@ describe('progress view stream-content projection', () => {
     state.snapshots.addUsage(stream, runId, usage);
     state.snapshots.setTodos(stream, [todo]);
     state.snapshots.setPlan(stream, plan);
-    state.setStreamParent(stream, parentStream);
+    state.snapshots.setParentStream(stream, parentStream);
     state.updateStreamMetadata(stream, {
       agentCategory: AgentCategory.ToolUse,
     });


### PR DESCRIPTION
## Summary
- make `StreamSnapshotStore.attachSessionEvents` the sole durable writer for progress facts on every host
- attach and detach backend-owned stores in `ProgressBackend`, while preserving desktop's process-owned attach/flush/load lifecycle
- remove duplicate durable writes and ownership branching from `ProgressFactApplier` and projection state setters
- add synchronous writer-before-projection coverage and update direct durable test seeds

Production code is net **-74 lines** (26 insertions, 100 deletions).

## Validation
- focused progress/snapshot/desktop suites: 214 tests passed
- full suite: 7,529 tests passed, 4 skipped
- full six-project typecheck passed
- lint passed
- dead-code ratchet passed (18 findings, all baselined)
- extension fast compile passed

## Scheduled refactoring
The surviving `stateOwnership` attach/flush/load split is now recorded in #6981 with its removal trigger and known pre-seed usage window.

Closes #9144

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ordering and ownership of durable progress persistence and webview projection; incorrect attach/dispose or projection-before-write could cause stale UI or missed snapshot updates, though focused tests cover the writer-before-projection path.
> 
> **Overview**
> **Durable progress snapshot writes** now go through `StreamSnapshotStore.attachSessionEvents` on the session hub. `ProgressBackend` wires that subscription (and tears it down in `dispose`) for backend-owned stores, while `stateOwnership: 'session'` still skips attach/flush/load when the host already owns the store lifecycle.
> 
> **`ProgressFactApplier` and `ProgressViewState`** stop branching on `stateOwnership` to mutate snapshots. Run/session handlers **read** snapshot state and **push webview updates** only (outputs, usage, todos/plan, run config metadata refresh). Ephemeral metadata setters no longer call into the snapshot store for parent/description/task state.
> 
> Tests seed durable state via `snapshots.setTaskState` / `setParentStream` directly, and a new case asserts snapshot events apply **before** run-fact projection so metadata like `run.config` is visible after emit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa3dea486dcbc5f5853966ecb4149250da2695c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->