### PR TITLE
Part 2 of 3 for #9139: retire the process-output tail pipeline (wire, controllers, webview)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,12 +29,12 @@ All notable changes to this project will be documented in this file.
 
 ### CLI
 
-#### Changes
+#### Breaking Changes
 
-- **`--output-format ndjson` no longer lists a `updateProcessOutput` progress
-  record** — background shell output has been streamed as a normal child
-  stream since child tabs shipped, so this record was never emitted. Consumers
-  reading NDJSON progress records are unaffected.
+- **`--output-format ndjson` no longer documents a `updateProcessOutput`
+  record** — background shell output reaches the terminal through child
+  streams, so this record was never emitted. Scripts reading the NDJSON stream
+  need no change.
 
 #### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ All notable changes to this project will be documented in this file.
 
 ### CLI
 
+#### Changes
+
+- **`--output-format ndjson` no longer lists a `updateProcessOutput` progress
+  record** — background shell output has been streamed as a normal child
+  stream since child tabs shipped, so this record was never emitted. Consumers
+  reading NDJSON progress records are unaffected.
+
 #### New Features
 
 - **Workflow-script task rows show their status at a glance** — each task in

--- a/packages/cli/src/chat/tui/state/childControls.ts
+++ b/packages/cli/src/chat/tui/state/childControls.ts
@@ -42,8 +42,8 @@ export function childElapsed(
 }
 
 const EMPTY_TAIL_LINES: readonly string[] = [];
-// Tail objects are immutable and replaced wholesale by updateProcessOutput,
-// so the split is cached per object: the child list re-renders on every
+// Tail objects are immutable and replaced wholesale, so the split is cached
+// per object: the child list re-renders on every
 // stream-sync tick and would otherwise re-split up to 16 KB per process row.
 const processTailLinesCache = new WeakMap<
   ProcessOutputTail,

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -15,7 +15,6 @@ import {
   type NormalizedToolUse,
   type OutputFileInfo,
   type Plan,
-  type ProcessOutputTail,
   type RoundIndexed,
   type RoundStage,
   type StreamPhase,
@@ -33,7 +32,14 @@ import {
   resetChildStreamEntries,
 } from './childExecutions';
 
-export type { ProcessOutputTail };
+/**
+ * Tailed stdout/stderr for a background process, held per execution id in
+ * `StreamSlice.processOutput`. TUI-local state, not a wire contract.
+ */
+export interface ProcessOutputTail {
+  readonly stdout: string;
+  readonly stderr: string;
+}
 
 // ---------------------------------------------------------------------------
 // types

--- a/packages/cli/src/chat/tui/state/completedProcessTranscript.ts
+++ b/packages/cli/src/chat/tui/state/completedProcessTranscript.ts
@@ -15,7 +15,7 @@ import type {
   StreamSlice,
 } from './cliState';
 
-export const COMPLETED_PROCESS_TAIL_LINES = 20;
+const COMPLETED_PROCESS_TAIL_LINES = 20;
 
 function completedProcessTailLines(
   tail: ProcessOutputTail | undefined,

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -14,10 +14,7 @@ import {
   type UpdateRoundStagePayload,
   type UpdateStreamUsagePayload,
 } from '@shared/schemas';
-import {
-  reduceStreamMeta,
-  type StreamMetaCommand,
-} from '@shared/streams/streamMetaReducer';
+import { reduceStreamMeta } from '@shared/streams/streamMetaReducer';
 import { diffActiveChildren } from '@shared/streams/childActivityReducer';
 import { assertNever } from '@utils/core';
 
@@ -27,7 +24,6 @@ import {
   removeStream,
   patchStream,
   registerCliStateResetHook,
-  type StreamSlice,
 } from './cliState';
 import {
   applySubagentRoster,
@@ -177,10 +173,10 @@ function applyActiveProcesses(payload: UpdateActiveProcessesPayload): void {
       s,
       vanishedIds,
     );
-    const meta = applyStreamMeta(s, {
-      kind: 'activeProcesses',
-      processes: payload.processes,
-    });
+    const meta = reduceStreamMeta(
+      { activeProcesses: s.activeProcesses, processOutput: s.processOutput },
+      { kind: 'activeProcesses', processes: payload.processes },
+    );
     return {
       ...s,
       activeProcesses: meta.activeProcesses,
@@ -278,23 +274,6 @@ function refreshQueuedFollowUps(
       queuedFollowUpMessages: messages,
     };
   });
-}
-
-/**
- * Run one stream-meta command against a CLI slice. The shared reducer owns
- * only the active-process roster and pruning tails for vanished processes.
- */
-function applyStreamMeta(
-  s: StreamSlice,
-  command: StreamMetaCommand,
-): Pick<StreamSlice, 'activeProcesses' | 'processOutput'> {
-  return reduceStreamMeta(
-    {
-      activeProcesses: s.activeProcesses,
-      processOutput: s.processOutput,
-    },
-    command,
-  );
 }
 
 export function attachTuiRunFactSubscription(

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -10,7 +10,6 @@ import {
   type SetActiveStreamPayload,
   type StreamTabId,
   type UpdateActiveProcessesPayload,
-  type UpdateProcessOutputPayload,
   type UpdateQueuedFollowUpsPayload,
   type UpdateRoundStagePayload,
   type UpdateStreamUsagePayload,
@@ -191,18 +190,6 @@ function applyActiveProcesses(payload: UpdateActiveProcessesPayload): void {
   });
 }
 
-function applyProcessOutput(payload: UpdateProcessOutputPayload): void {
-  patchStream(payload.parentStreamId, (s) => ({
-    ...s,
-    processOutput: applyStreamMeta(s, {
-      kind: 'processOutput',
-      executionId: payload.executionId,
-      stdout: payload.stdout,
-      stderr: payload.stderr,
-    }).processOutput,
-  }));
-}
-
 function applyParentStream(payload: {
   childStreamId: StreamTabId;
   parentStreamId: StreamTabId | null;
@@ -273,14 +260,6 @@ function applyDirectTuiRunEvent(
         processes: [...event.items],
       });
       return true;
-    case 'process.output':
-      applyProcessOutput({
-        parentStreamId: event.parentStreamId,
-        executionId: event.executionId,
-        stdout: event.stdout,
-        stderr: event.stderr,
-      });
-      return true;
     default:
       return false;
   }
@@ -301,16 +280,9 @@ function refreshQueuedFollowUps(
   });
 }
 
-/** Cap on per-process tail length held in the signal map (UTF-16 code
- *  units, not bytes — markdown-it / ink work in JS strings). Beyond this
- *  the shared stream-meta reducer truncates at the head (exact cut, no
- *  `retainChars`) so the live pane never grows unbounded. */
-const PROCESS_TAIL_CHARS_MAX = 8 * 1024;
-const CLI_OUTPUT_CAP = { maxChars: PROCESS_TAIL_CHARS_MAX } as const;
-
 /**
- * Run one stream-meta command against a CLI slice with the CLI cap policy.
- * The shared reducer owns only process-tail capping and pruning.
+ * Run one stream-meta command against a CLI slice. The shared reducer owns
+ * only the active-process roster and pruning tails for vanished processes.
  */
 function applyStreamMeta(
   s: StreamSlice,
@@ -322,7 +294,6 @@ function applyStreamMeta(
       processOutput: s.processOutput,
     },
     command,
-    { outputCap: CLI_OUTPUT_CAP },
   );
 }
 
@@ -399,7 +370,6 @@ export function attachTuiRunFactSubscription(
         'usage',
         'stage.start',
         'child.activity',
-        'process.output',
       ],
     },
   );

--- a/packages/cli/src/runtime/cliNdjsonProgressEvents.ts
+++ b/packages/cli/src/runtime/cliNdjsonProgressEvents.ts
@@ -16,7 +16,6 @@ import type {
   UpdateCompileFailuresPayload,
   UpdateMissingOutputsPayload,
   UpdatePlanPayload,
-  UpdateProcessOutputPayload,
   UpdateQueuedFollowUpsPayload,
   UpdateRoundStagePayload,
   UpdateStreamDescriptionPayload,
@@ -59,7 +58,6 @@ export interface CliNdjsonProgressEventPayloads {
   goalPaused: GoalPausedPayload;
   updateActiveSubagents: UpdateActiveSubagentsPayload;
   updateActiveProcesses: UpdateActiveProcessesPayload;
-  updateProcessOutput: UpdateProcessOutputPayload;
   updateStreamDescription: UpdateStreamDescriptionPayload;
   setParentStream: SetParentStreamPayload;
 

--- a/packages/cli/src/runtime/sessionProgressSubscription.ts
+++ b/packages/cli/src/runtime/sessionProgressSubscription.ts
@@ -184,18 +184,6 @@ function projectCliRunFact(
     }
   }
 
-  if (event.type === 'process.output') {
-    return {
-      event: 'updateProcessOutput',
-      payload: {
-        parentStreamId: event.parentStreamId,
-        executionId: event.executionId,
-        stdout: event.stdout,
-        stderr: event.stderr,
-      },
-    };
-  }
-
   return undefined;
 }
 

--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -47,14 +47,9 @@ import {
   EMPTY_INQUIRY_THREADS,
   EMPTY_STREAM_BY_ID,
   inquiryThreadsContext,
-  processOutputContext,
   streamByIdContext,
   type StreamByIdMap,
 } from '../contexts/streamContexts';
-import { EMPTY_PROCESS_OUTPUTS, type ProcessOutputMap } from '../store';
-
-// Side-effect imports - sibling components
-import './TerminalOutput';
 
 // Web Awesome native components
 import '@awesome.me/webawesome/dist/components/details/details.js';
@@ -208,23 +203,6 @@ export class BackgroundTasksPanel extends LitElement {
       .section-label wa-icon {
         font-size: var(--font-size-xs);
       }
-
-      /* Collapsible output per task — also a <wa-details>. */
-      wa-details.task-output {
-        margin-left: calc(var(--wa-space-2xs) + var(--font-size-sm));
-      }
-
-      wa-details.task-output::part(header) {
-        font-size: var(--font-size-xs);
-        color: var(--color-text-secondary);
-      }
-
-      .output-container {
-        margin-top: var(--wa-space-3xs);
-        border: var(--border-thin) solid var(--color-border);
-        border-radius: var(--border-radius-small);
-        overflow: hidden;
-      }
     `,
   ];
 
@@ -234,10 +212,6 @@ export class BackgroundTasksPanel extends LitElement {
 
   /** Open state — auto-expands when active tasks appear, auto-collapses when all finish. */
   @state() open = false;
-
-  @consume({ context: processOutputContext, subscribe: true })
-  @state()
-  private processOutputs: ProcessOutputMap = EMPTY_PROCESS_OUTPUTS;
 
   @consume({ context: streamByIdContext, subscribe: true })
   @state()
@@ -408,7 +382,6 @@ export class BackgroundTasksPanel extends LitElement {
 
   private renderTaskItem(child: ActiveChildInfo): TemplateResult {
     const icon = getTaskIcon(child);
-    const entry = this.processOutputs.get(child.executionId);
     const childStreamId =
       child.kind === 'subagent' ? child.childStreamId : undefined;
     const isClickable = childStreamId !== undefined;
@@ -474,28 +447,7 @@ export class BackgroundTasksPanel extends LitElement {
             >${badge.text}</wa-badge
           >
         </div>
-        ${
-          entry?.stdout
-            ? this.renderOutputStream('stdout', entry.stdout)
-            : nothing
-        }
-        ${
-          entry?.stderr
-            ? this.renderOutputStream('stderr', entry.stderr)
-            : nothing
-        }
       </div>
-    `;
-  }
-
-  private renderOutputStream(label: string, text: string): TemplateResult {
-    return html`
-      <wa-details class="collapsible-quiet task-output" open>
-        <span slot="summary">${label}</span>
-        <div class="output-container">
-          <terminal-output .text=${text}></terminal-output>
-        </div>
-      </wa-details>
     `;
   }
 

--- a/packages/extension/src/progressView/frontend/components/StreamConversation.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamConversation.ts
@@ -12,7 +12,6 @@ import { SignalWatcher } from '@shared/signals';
 // Local imports - progress view
 import {
   activeInquiries$,
-  activeProcessOutputs$,
   logContext$,
   permissions$,
   streamById$,
@@ -27,7 +26,6 @@ import {
   followUpEventSinkContext,
   inquiryThreadsContext,
   permissionsContext,
-  processOutputContext,
   streamByIdContext,
   streamLogContext,
   streamStateContext,
@@ -36,7 +34,6 @@ import {
   type StreamContextValue,
   type StreamLogContextValue,
 } from '../contexts/streamContexts';
-import { EMPTY_PROCESS_OUTPUTS, type ProcessOutputMap } from '../store';
 import type { PermissionState } from '../permissionState';
 
 // Side-effect imports - body components rendered below.
@@ -76,10 +73,6 @@ export class StreamConversation extends SignalWatcher(LitElement) {
   @state()
   private permissionsContextValue: PermissionState[] = [];
 
-  @provide({ context: processOutputContext })
-  @state()
-  private processOutputContextValue: ProcessOutputMap = EMPTY_PROCESS_OUTPUTS;
-
   @provide({ context: streamByIdContext })
   @state()
   private streamByIdContextValue: StreamByIdMap = EMPTY_STREAM_BY_ID;
@@ -109,7 +102,6 @@ export class StreamConversation extends SignalWatcher(LitElement) {
     this.streamContextValue = streamContext$.get();
     this.streamLogContextValue = logContext$.get();
     this.permissionsContextValue = permissions$.get();
-    this.processOutputContextValue = activeProcessOutputs$.get();
     this.streamByIdContextValue = streamById$.get();
     this.inquiryThreadsContextValue = activeInquiries$.get();
   }

--- a/packages/extension/src/progressView/frontend/contexts/streamContexts.ts
+++ b/packages/extension/src/progressView/frontend/contexts/streamContexts.ts
@@ -17,11 +17,7 @@ import type {
   TaskGroup,
 } from '@shared/schemas';
 import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
-import type {
-  FollowupOptionsState,
-  ProcessOutputMap,
-  StreamState,
-} from '../store';
+import type { FollowupOptionsState, StreamState } from '../store';
 
 // Local imports - progress view components
 import type { PermissionState } from '../permissionState';
@@ -105,15 +101,6 @@ export const streamLogContext = createContext<StreamLogContextValue>(
 
 export const permissionsContext = createContext<PermissionState[]>(
   'progress-permissions',
-);
-
-/**
- * Separate context for background process outputs — changes on every output chunk.
- * Only consumed by BackgroundTasksPanel, avoiding re-renders of other components.
- * Keyed by executionId → accumulated stdout/stderr.
- */
-export const processOutputContext = createContext<ProcessOutputMap>(
-  'progress-process-outputs',
 );
 
 export const EMPTY_INQUIRY_THREADS: InquiryThreadUpdatedEvent[] = [];

--- a/packages/extension/src/progressView/frontend/progressState.ts
+++ b/packages/extension/src/progressView/frontend/progressState.ts
@@ -31,11 +31,9 @@ import { setsEqual } from './utils';
 import { clearFollowUpInputTransientStateStore } from './followUpInputState';
 import {
   createInitialState,
-  EMPTY_PROCESS_OUTPUTS,
   EMPTY_STREAM_LOGS,
   getStreamState,
   isToolUseState,
-  type ProcessOutputMap,
   type StreamState,
 } from './store';
 import {
@@ -101,7 +99,6 @@ export const streamFilter$ = select(appState, (s) => s.streamFilter);
 export const streamStates$ = select(appState, (s) => s.streamStates);
 const streamLogs$ = select(appState, (s) => s.streamLogs);
 export const activeStreamId$ = select(appState, (s) => s.activeStreamId);
-const processOutputs$ = select(appState, (s) => s.processOutputs);
 const inquiries$ = select(appState, (s) => s.inquiries);
 const followupOptions$ = select(appState, (s) => s.followupOptionsByStream);
 
@@ -222,15 +219,6 @@ const activeStreamLogs$ = new Signal.Computed(() => {
   if (!info) return EMPTY_STREAM_LOGS;
   return streamLogs$.get().get(info.name) ?? EMPTY_STREAM_LOGS;
 });
-
-/** Only changes when the ACTIVE stream's process outputs change. */
-export const activeProcessOutputs$ = new Signal.Computed(
-  (): ProcessOutputMap => {
-    const info = activeStreamInfo$.get();
-    if (!info) return EMPTY_PROCESS_OUTPUTS;
-    return processOutputs$.get().get(info.name) ?? EMPTY_PROCESS_OUTPUTS;
-  },
-);
 
 // ---------------------------------------------------------------------------
 // Leaf selectors for logContext$.

--- a/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
@@ -220,7 +220,6 @@ export const streamLifecycleHandlers = {
         draft.streamById = new Map();
         draft.streamStates = new Map();
         draft.streamLogs = new Map();
-        draft.processOutputs = new Map();
         draft.followupOptionsByStream = new Map();
         draft.activeStreamId = null;
       }),

--- a/packages/extension/src/progressView/frontend/slices/streamMetaSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamMetaSlice.ts
@@ -1,6 +1,6 @@
 /**
  * Stream metadata handlers: UPDATE_STREAM_STATUS, UPDATE_STREAM_DESCRIPTION,
- * UPDATE_CONVERSATION_PROGRESS, UPDATE_STREAM_BADGES, UPDATE_PROCESS_OUTPUT.
+ * UPDATE_CONVERSATION_PROGRESS, UPDATE_STREAM_BADGES.
  */
 
 import { create } from 'mutative';
@@ -13,19 +13,9 @@ import {
   type StreamTabId,
   type StreamTabInfo,
 } from '@shared/schemas';
-import {
-  EMPTY_STREAM_META,
-  PROCESS_OUTPUT_MAX_CHARS,
-  reduceStreamMeta,
-} from '@shared/streams/streamMetaReducer';
 import { compareByNewestCreationTime } from '@shared/streams/streamOrdering';
 
-import {
-  EMPTY_PROCESS_OUTPUTS,
-  getStreamState,
-  isToolUseState,
-  type ProcessOutputMap,
-} from '../store';
+import { getStreamState, isToolUseState } from '../store';
 import {
   mergeBackendOwnedState,
   metadataToStreamStatePartial,
@@ -46,16 +36,6 @@ export function takePendingDescription(
   if (desc !== undefined) pendingDescriptions.delete(streamId);
   return desc;
 }
-
-/**
- * Per-output cap policy for the webview: keep at most 100k UTF-16 code units
- * per stdout/stderr, trimming to 80k when the cap is crossed so output can keep
- * appending for a while before the next reset. The shared reducer applies it.
- */
-const WEBVIEW_OUTPUT_CAP = {
-  maxChars: PROCESS_OUTPUT_MAX_CHARS,
-  retainChars: 80_000,
-} as const;
 
 function upsertSortedStreamInfo(
   streams: Map<StreamTabId, StreamTabInfo>,
@@ -200,49 +180,6 @@ export const streamMetaHandlers = {
       create(prev, (draft) => {
         draft.subagents = data.subagents;
         draft.processes = data.processes;
-      }),
-    );
-    // Prune output buffers for processes that just left the active list. Output
-    // lives in a separate store, so only `processOutput` is projected into the
-    // shared reducer and spliced back; an unchanged map skips the re-render.
-    // The roster also carries retained finished rows — pass only the live
-    // subset, or the prune would never fire again.
-    const prev = appState.get();
-    const current = prev.processOutputs.get(data.stream);
-    if (!current) return;
-    const { processOutput } = reduceStreamMeta(
-      { ...EMPTY_STREAM_META, processOutput: current },
-      {
-        kind: 'activeProcesses',
-        processes: data.processes.filter(
-          (child) => child.finishedAt === undefined,
-        ),
-      },
-      { outputCap: WEBVIEW_OUTPUT_CAP },
-    );
-    if (processOutput === current) return;
-    appState.set(
-      create(prev, (draft) => {
-        draft.processOutputs.set(
-          data.stream,
-          processOutput as ProcessOutputMap,
-        );
-      }),
-    );
-  },
-
-  [PROGRESS_VIEW_COMMANDS.UPDATE_PROCESS_OUTPUT]: (data) => {
-    const { stream, executionId, stdout, stderr } = data;
-    const prev = appState.get();
-    const current = prev.processOutputs.get(stream) ?? EMPTY_PROCESS_OUTPUTS;
-    const { processOutput } = reduceStreamMeta(
-      { ...EMPTY_STREAM_META, processOutput: current },
-      { kind: 'processOutput', executionId, stdout, stderr },
-      { outputCap: WEBVIEW_OUTPUT_CAP },
-    );
-    appState.set(
-      create(prev, (draft) => {
-        draft.processOutputs.set(stream, processOutput as ProcessOutputMap);
       }),
     );
   },

--- a/packages/extension/src/progressView/frontend/store.ts
+++ b/packages/extension/src/progressView/frontend/store.ts
@@ -5,7 +5,6 @@ import {
   type AgentCategoryFilter,
   type ContextStateData,
   type LogMessageData,
-  type ProcessOutputTail,
   type StreamState,
   type StreamTabInfo,
   type StreamTabId,
@@ -14,15 +13,6 @@ import {
   type ExternalInquiryThreadId,
 } from '@shared/schemas';
 import type { Draft } from 'mutative';
-
-/**
- * Background process outputs, keyed by executionId → accumulated stdout/stderr.
- * Defined here (not in contexts/streamContexts) so the store stays the single
- * home for state data shapes; the context object lives with the other contexts.
- */
-export type ProcessOutputMap = Map<string, ProcessOutputTail>;
-
-export const EMPTY_PROCESS_OUTPUTS: ProcessOutputMap = new Map();
 
 // Re-export schema types for components (single source of truth)
 export {
@@ -82,9 +72,6 @@ export interface ProgressState {
   streamStates: Map<StreamTabId, StreamState>;
   /** Log messages per stream — separated so log appends don't trigger meta context updates */
   streamLogs: Map<StreamTabId, StreamLogs>;
-  /** Background process outputs per stream — separated so output appends don't trigger meta context updates.
-   *  Outer key: streamId, inner key: executionId → { stdout, stderr }. */
-  processOutputs: Map<StreamTabId, ProcessOutputMap>;
   /** Workflow-result follow-up option data, keyed per stream. */
   followupOptionsByStream: Map<StreamTabId, FollowupOptionsState>;
   /** Durable external inquiry thread summaries, keyed by thread id. */
@@ -93,7 +80,7 @@ export interface ProgressState {
 
 /**
  * Delete one stream's entry from every per-stream map it owns
- * (`streamStates`, `streamLogs`, `processOutputs`, `followupOptionsByStream`).
+ * (`streamStates`, `streamLogs`, `followupOptionsByStream`).
  * Single owner of that key list so a removed/renamed/added map can't drift
  * out of sync between the lifecycle handlers that garbage-collect streams.
  * Does not touch `streamById` — callers that also drop the stream from the
@@ -106,7 +93,6 @@ export function deleteStreamState(
 ): void {
   draft.streamStates.delete(streamId);
   draft.streamLogs.delete(streamId);
-  draft.processOutputs.delete(streamId);
   draft.followupOptionsByStream.delete(streamId);
 }
 
@@ -124,7 +110,6 @@ export function createInitialState(): ProgressState {
     streamFilter: 'all',
     streamStates: new Map(),
     streamLogs: new Map(),
-    processOutputs: new Map(),
     followupOptionsByStream: new Map(),
     inquiries: new Map(),
   };

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -176,15 +176,6 @@ type ChildActivityEvent =
   | (ChildActivityEventBase & { readonly kind: 'subagents' })
   | (ChildActivityEventBase & { readonly kind: 'processes' });
 
-/** Incremental output from a child process owned by a parent run stream. */
-interface ProcessOutputEvent extends StageStamp {
-  readonly type: 'process.output';
-  readonly parentStreamId: StreamTabId;
-  readonly executionId: ExecutionId;
-  readonly stdout: string;
-  readonly stderr: string;
-}
-
 /** UI progress counters for a run, projected by hosts but not transcript logs. */
 interface ConversationProgressEvent extends StageStamp {
   readonly type: 'conversation.progress';
@@ -370,7 +361,6 @@ export type AgentEvent =
   | UsageEvent
   | StatusEvent
   | ChildActivityEvent
-  | ProcessOutputEvent
   | ConversationProgressEvent
   | RunFactEvent
   | ContextStateEvent
@@ -400,5 +390,4 @@ export const RUN_FACT_EVENT_TYPES = Object.freeze([
   'status',
   'stage.start',
   'child.activity',
-  'process.output',
 ] as const satisfies readonly AgentEvent['type'][]);

--- a/src/controllers/progressView/backend/WebviewUpdater.ts
+++ b/src/controllers/progressView/backend/WebviewUpdater.ts
@@ -294,21 +294,6 @@ export class WebviewUpdater {
     });
   }
 
-  updateProcessOutput(
-    stream: StreamTabId,
-    executionId: string,
-    stdout: string,
-    stderr: string,
-  ): void {
-    this.sendMessage({
-      command: PROGRESS_VIEW_COMMANDS.UPDATE_PROCESS_OUTPUT,
-      stream,
-      executionId,
-      stdout,
-      stderr,
-    });
-  }
-
   syncInquiryThreads(threads: InquiryThreadUpdatedEvent[]): void {
     this.sendMessage({
       command: PROGRESS_VIEW_COMMANDS.SYNC_INQUIRY_THREADS,

--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -32,7 +32,6 @@ import {
   type UpdateConversationProgressPayload,
   type UpdateMissingOutputsPayload,
   type UpdatePlanPayload,
-  type UpdateProcessOutputPayload,
   type UpdateQueuedFollowUpsPayload,
   type UpdateRoundStagePayload,
   type UpdateStreamDescriptionPayload,
@@ -161,13 +160,6 @@ export class ProgressFactApplier {
       this.updateChildRoster(event.parentStreamId, event.kind, [
         ...event.items,
       ]),
-    'process.output': (_streamId, event) =>
-      this.handleUpdateProcessOutput({
-        parentStreamId: event.parentStreamId,
-        executionId: event.executionId,
-        stdout: event.stdout,
-        stderr: event.stderr,
-      }),
   };
 
   constructor(
@@ -319,24 +311,6 @@ export class ProgressFactApplier {
       this.webviewUpdater.updateParentStream(
         childStreamId,
         parentStreamId ?? undefined,
-      );
-    }
-  }
-
-  public handleUpdateProcessOutput({
-    parentStreamId,
-    executionId,
-    stdout,
-    stderr,
-  }: UpdateProcessOutputPayload): void {
-    // Always send — output accumulates in frontend state per-stream,
-    // so it must not be dropped when the stream is inactive.
-    if (this.webviewUpdater.isAvailable()) {
-      this.webviewUpdater.updateProcessOutput(
-        parentStreamId,
-        executionId,
-        stdout,
-        stderr,
       );
     }
   }

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -163,7 +163,6 @@ export const PROGRESS_VIEW_COMMANDS = {
   UPDATE_ROUND_STAGE: 'updateRoundStage',
   UPDATE_STREAM_BADGES: 'updateStreamBadges',
   UPDATE_STREAM_DESCRIPTION: 'updateStreamDescription',
-  UPDATE_PROCESS_OUTPUT: 'updateProcessOutput',
   SYNC_INQUIRY_THREADS: 'syncInquiryThreads',
   UPDATE_INQUIRY_THREAD: 'updateInquiryThread',
   UPDATE_PARENT_STREAM: 'updateParentStream',

--- a/src/shared/schemas/progressEvents.ts
+++ b/src/shared/schemas/progressEvents.ts
@@ -129,14 +129,6 @@ export interface UpdateActiveProcessesPayload {
   processes: ActiveChildInfo[];
 }
 
-/** Incremental child-process output, projected from `process.output`. */
-export interface UpdateProcessOutputPayload {
-  parentStreamId: StreamTabId;
-  executionId: ExecutionId;
-  stdout: string;
-  stderr: string;
-}
-
 /**
  * An autonomous goal auto-paused after a failed cycle ended the autonomous
  * leg. Hosts surface this so a paused goal is distinguishable from a hang.

--- a/src/shared/schemas/progressView/data.ts
+++ b/src/shared/schemas/progressView/data.ts
@@ -30,18 +30,6 @@ export type ProgressViewPlacement = z.infer<typeof ProgressViewPlacementSchema>;
  */
 export const StreamScopedBaseSchema = z.object({ stream: StreamTabIdSchema });
 
-/**
- * Tailed stdout/stderr for a background process/execution. Single source of
- * truth for the shape carried over IPC (`UpdateProcessOutputMessageSchema`)
- * and mirrored in frontend state (CLI `ProcessOutputTail`, extension
- * `ProcessOutputMap` entries) so the three no longer drift independently.
- */
-export const ProcessOutputTailSchema = z.object({
-  stdout: z.string(),
-  stderr: z.string(),
-});
-export type ProcessOutputTail = z.infer<typeof ProcessOutputTailSchema>;
-
 // ============================================================
 // Progress View Data Schemas
 // ============================================================

--- a/src/shared/schemas/progressView/outbound.ts
+++ b/src/shared/schemas/progressView/outbound.ts
@@ -45,7 +45,6 @@ import { TodoItemSchema } from '../todo';
 import { RunUsageMapSchema, TokenUsageStatsSchema } from '../usage';
 import {
   AgentCategoryFilterSchema,
-  ProcessOutputTailSchema,
   ProgressViewPlacementSchema,
   StreamScopedBaseSchema,
 } from './data';
@@ -93,13 +92,6 @@ const UpdateStreamBadgesMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_BADGES),
   subagents: z.array(ActiveChildInfoSchema),
   processes: z.array(ActiveChildInfoSchema),
-});
-
-const UpdateProcessOutputMessageSchema = StreamScopedBaseSchema.extend(
-  ProcessOutputTailSchema.shape,
-).extend({
-  command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_PROCESS_OUTPUT),
-  executionId: z.string(),
 });
 
 const UpdateParentStreamMessageSchema = StreamScopedBaseSchema.extend({
@@ -407,7 +399,6 @@ export const ProgressViewOutboundMessageSchema = z.discriminatedUnion(
     UpdateConversationProgressMessageSchema,
     UpdateRoundStageMessageSchema,
     UpdateStreamBadgesMessageSchema,
-    UpdateProcessOutputMessageSchema,
     UpdateParentStreamMessageSchema,
     UpdateStreamDescriptionMessageSchema,
     UpdateStreamStatusMessageSchema,

--- a/src/shared/streams/streamMetaReducer.ts
+++ b/src/shared/streams/streamMetaReducer.ts
@@ -1,16 +1,12 @@
 // Host-neutral per-stream-meta reducer shared by the CLI TUI and the webview
 // progress view. It owns only the cross-host logic that was duplicated:
-// bounded per-process output tails and pruning vanished process tails. Verbatim
-// assignments stay in the host adapters.
+// setting the active-process roster and pruning tails for processes that
+// vanished. Verbatim assignments stay in the host adapters.
 //
 // NO host imports here (no vscode / electron / ink / immer): the reducer is a
 // pure function over plain values.
 
 import type { ActiveChildInfo } from '@shared/schemas';
-import { appendTail } from '@utils/strings/appendTail';
-
-/** Maximum stdout/stderr tail length retained per active process. */
-export const PROCESS_OUTPUT_MAX_CHARS = 100_000;
 
 /** Per-execution captured stdout/stderr tail held in stream meta. */
 interface StreamProcessOutput {
@@ -24,39 +20,14 @@ export interface StreamMeta {
   readonly processOutput: ReadonlyMap<string, StreamProcessOutput>;
 }
 
-export type StreamMetaCommand =
-  | {
-      readonly kind: 'processOutput';
-      readonly executionId: string;
-      readonly stdout: string;
-      readonly stderr: string;
-    }
-  // Sets the active-process list AND prunes output for processes that vanished.
-  | {
-      readonly kind: 'activeProcesses';
-      readonly processes: readonly ActiveChildInfo[];
-    };
-
-/**
- * Output-cap policy. Once a stream's stdout/stderr crosses `maxChars`, it is
- * trimmed to the last `retainChars` (default `maxChars`, i.e. an exact head-cut
- * at the cap). The CLI uses an exact cut; the webview trims to a lower
- * `retainChars` so output can keep appending before the next reset.
- */
-interface OutputCap {
-  readonly maxChars: number;
-  readonly retainChars?: number;
+/** Sets the active-process list AND prunes output for processes that vanished. */
+export interface StreamMetaCommand {
+  readonly kind: 'activeProcesses';
+  readonly processes: readonly ActiveChildInfo[];
 }
 
-export interface ReduceStreamMetaOptions {
-  readonly outputCap: OutputCap;
-}
-
-const EMPTY_OUTPUT: StreamProcessOutput = { stdout: '', stderr: '' };
-
 /**
- * An empty stream-meta slice. Hosts whose state is split across stores (the
- * webview keeps process output separate from the rest of stream meta) project
+ * An empty stream-meta slice. Hosts whose state is split across stores project
  * just the field a command touches over this default.
  */
 export const EMPTY_STREAM_META: StreamMeta = {
@@ -66,39 +37,24 @@ export const EMPTY_STREAM_META: StreamMeta = {
 
 /**
  * Apply one command to a stream-meta slice. Pure: never mutates `meta`, always
- * returns a fresh `StreamMeta` (with a fresh `processOutput` Map when output
- * changes), so callers can compare identities or copy fields into their store.
+ * returns a fresh `StreamMeta` (with a fresh `processOutput` Map when entries
+ * are pruned), so callers can compare identities or copy fields into their
+ * store.
  */
 export function reduceStreamMeta(
   meta: StreamMeta,
   command: StreamMetaCommand,
-  options: ReduceStreamMetaOptions,
 ): StreamMeta {
-  switch (command.kind) {
-    case 'processOutput': {
-      const { maxChars } = options.outputCap;
-      const retainChars = options.outputCap.retainChars ?? maxChars;
-      const prev = meta.processOutput.get(command.executionId) ?? EMPTY_OUTPUT;
-      const processOutput = new Map(meta.processOutput);
-      processOutput.set(command.executionId, {
-        stdout: appendTail(prev.stdout, command.stdout, maxChars, retainChars),
-        stderr: appendTail(prev.stderr, command.stderr, maxChars, retainChars),
-      });
-      return { ...meta, processOutput };
-    }
-    case 'activeProcesses': {
-      const live = new Set(command.processes.map((p) => p.executionId));
-      let pruned: Map<string, StreamProcessOutput> | undefined;
-      for (const id of meta.processOutput.keys()) {
-        if (live.has(id)) continue;
-        pruned ??= new Map(meta.processOutput);
-        pruned.delete(id);
-      }
-      return {
-        ...meta,
-        activeProcesses: command.processes,
-        processOutput: pruned ?? meta.processOutput,
-      };
-    }
+  const live = new Set(command.processes.map((p) => p.executionId));
+  let pruned: Map<string, StreamProcessOutput> | undefined;
+  for (const id of meta.processOutput.keys()) {
+    if (live.has(id)) continue;
+    pruned ??= new Map(meta.processOutput);
+    pruned.delete(id);
   }
+  return {
+    ...meta,
+    activeProcesses: command.processes,
+    processOutput: pruned ?? meta.processOutput,
+  };
 }

--- a/src/shared/streams/streamMetaReducer.ts
+++ b/src/shared/streams/streamMetaReducer.ts
@@ -21,7 +21,7 @@ export interface StreamMeta {
 }
 
 /** Sets the active-process list AND prunes output for processes that vanished. */
-export interface StreamMetaCommand {
+interface StreamMetaCommand {
   readonly kind: 'activeProcesses';
   readonly processes: readonly ActiveChildInfo[];
 }

--- a/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
+++ b/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
@@ -279,21 +279,6 @@ const PROGRESS_PROJECTION_CASES = {
     }),
     payload: { parentStreamId: streamId, processes: [process] },
   },
-  updateProcessOutput: {
-    source: runEvent({
-      type: 'process.output',
-      parentStreamId: streamId,
-      executionId: processExecutionId,
-      stdout: 'compiled paper.pdf\n',
-      stderr: '',
-    }),
-    payload: {
-      parentStreamId: streamId,
-      executionId: processExecutionId,
-      stdout: 'compiled paper.pdf\n',
-      stderr: '',
-    },
-  },
   updateStreamDescription: {
     source: sessionFact('updateStreamDescription', {
       streamId,

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -54,7 +54,6 @@ import { projectStreamTranscript } from '@cli/chat/tui/state/transcriptProjectio
 import { subscribeStreamStatus } from '@cli/chat/tui/state/subscribeStreamStatus';
 import { attachTuiRunFactSubscription } from '@cli/chat/tui/state/subscribeRuntimeHost';
 import {
-  COMPLETED_PROCESS_TAIL_LINES,
   buildCompletedProcessTranscript,
   completedProcessDisplayLines,
 } from '@cli/chat/tui/state/completedProcessTranscript';
@@ -2762,33 +2761,7 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
     }
   });
 
-  it('applies direct process.output events without host emission', () => {
-    const hub = new SessionEventHub();
-    const detach = attachTuiRunFactSubscription(hub);
-
-    try {
-      hub.emit({
-        scope: 'run',
-        streamId: root,
-        event: {
-          type: 'process.output',
-          parentStreamId: root,
-          executionId: 'exec-a',
-          stdout: 'stdout chunk',
-          stderr: 'stderr chunk',
-        },
-      });
-
-      expect(streams.get().get(root)?.processOutput.get('exec-a')).toEqual({
-        stdout: 'stdout chunk',
-        stderr: 'stderr chunk',
-      });
-    } finally {
-      detach();
-    }
-  });
-
-  it('applies direct child.activity(processes) completion and prunes output once', () => {
+  it('applies direct child.activity(processes) completion once', () => {
     const hub = new SessionEventHub();
     const detach = attachTuiRunFactSubscription(hub);
 
@@ -2807,28 +2780,6 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
         scope: 'run',
         streamId: root,
         event: {
-          type: 'process.output',
-          parentStreamId: root,
-          executionId: 'exec-a',
-          stdout: 'done line',
-          stderr: '',
-        },
-      });
-      hub.emit({
-        scope: 'run',
-        streamId: root,
-        event: {
-          type: 'process.output',
-          parentStreamId: root,
-          executionId: 'exec-b',
-          stdout: 'still running',
-          stderr: '',
-        },
-      });
-      hub.emit({
-        scope: 'run',
-        streamId: root,
-        event: {
           type: 'child.activity',
           kind: 'processes',
           parentStreamId: root,
@@ -2838,11 +2789,6 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
 
       const slice = streams.get().get(root);
       expect(slice?.activeProcesses).toEqual([runningProcessB]);
-      expect(slice?.processOutput.has('exec-a')).toBe(false);
-      expect(slice?.processOutput.get('exec-b')).toEqual({
-        stdout: 'still running',
-        stderr: '',
-      });
       expect(
         slice?.entries.filter((entry) => entry.role === 'process'),
       ).toHaveLength(1);
@@ -3306,16 +3252,12 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
     }
   });
 
-  it('persists a bounded completed-process transcript before pruning processOutput', () => {
+  it('persists a completed-process transcript entry when a process finishes', () => {
     const hub = new SessionEventHub();
     const detach = attachTuiRunFactSubscription(hub);
-    const lines = Array.from(
-      { length: COMPLETED_PROCESS_TAIL_LINES + 2 },
-      (_, index) => `line ${index + 1}`,
-    ).join('\n');
 
     try {
-      // Seed: two live processes with tail output.
+      // Seed: two live processes.
       hub.emit({
         scope: 'run',
         streamId: root,
@@ -3336,32 +3278,8 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
           ],
         },
       });
-      hub.emit({
-        scope: 'run',
-        streamId: root,
-        event: {
-          type: 'process.output',
-          parentStreamId: root,
-          executionId: 'exec-a',
-          stdout: lines,
-          stderr: 'stderr tail',
-        },
-      });
-      hub.emit({
-        scope: 'run',
-        streamId: root,
-        event: {
-          type: 'process.output',
-          parentStreamId: root,
-          executionId: 'exec-b',
-          stdout: 'B',
-          stderr: '',
-        },
-      });
-      expect(streams.get().get(root)?.processOutput.size).toBe(2);
 
-      // exec-a finishes: its output buffer must be dropped on the next
-      // active-processes update, after a durable transcript entry is added.
+      // exec-a finishes: a durable transcript entry is added for it.
       hub.emit({
         scope: 'run',
         streamId: root,
@@ -3375,10 +3293,6 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
         },
       });
       const slice = streams.get().get(root);
-      const out = streams.get().get(root)?.processOutput;
-      expect(out?.size).toBe(1);
-      expect(out?.has('exec-a')).toBe(false);
-      expect(out?.has('exec-b')).toBe(true);
 
       const processEntries =
         slice?.entries.filter((entry) => entry.role === 'process') ?? [];
@@ -3396,11 +3310,6 @@ describe('subscribeRuntimeHost.updateActiveProcesses', () => {
           isError: true,
         },
       });
-      expect(processEntries[0]?.process?.tailLines).toHaveLength(
-        COMPLETED_PROCESS_TAIL_LINES,
-      );
-      expect(processEntries[0]?.process?.tailLines.at(0)).toBe('line 4');
-      expect(processEntries[0]?.process?.tailLines.at(-1)).toBe('stderr tail');
 
       const split = splitTranscriptEntries(
         slice?.entries ?? [],

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -1878,18 +1878,6 @@ describe('ProgressBackend', () => {
       });
 
       target.session.events.emit({
-        scope: 'run',
-        streamId: parentStreamId,
-        event: {
-          type: 'process.output',
-          parentStreamId,
-          executionId,
-          stdout: 'hello',
-          stderr: '',
-        },
-      });
-
-      target.session.events.emit({
         scope: 'session',
         event: {
           type: 'updateQueuedFollowUps',

--- a/src/test-kernel/progressView/StreamMetaState.vitest.ts
+++ b/src/test-kernel/progressView/StreamMetaState.vitest.ts
@@ -19,7 +19,6 @@ import {
   createStreamState,
   STREAM_PHASE,
   STREAM_SUBSTATE,
-  STREAM_STATUS,
   type ProgressViewOutboundHandlerRegistry,
   type ProgressViewOutboundMessage,
   type StreamTabId,
@@ -31,32 +30,6 @@ import { assertSupported } from '@shared/utils/dispatcher';
 function seedState(initialState: ProgressState): () => ProgressState {
   appState.set(initialState);
   return () => appState.get();
-}
-
-function createProcessState(streamId: StreamTabId): ProgressState {
-  const state = createInitialState();
-  state.activeStreamId = streamId;
-  state.streamStates.set(
-    streamId,
-    createStreamState(AgentCategory.Workflow, {
-      processes: [
-        {
-          kind: 'process',
-          executionId: 'active-process',
-          agentName: 'bash',
-          status: STREAM_STATUS.RUNNING,
-        },
-      ],
-    } satisfies Partial<StreamState>),
-  );
-  state.processOutputs.set(
-    streamId,
-    new Map([
-      ['active-process', { stdout: 'old-active', stderr: '' }],
-      ['stale-process', { stdout: 'old-stale', stderr: '' }],
-    ]),
-  );
-  return state;
 }
 
 function dispatch(
@@ -81,7 +54,7 @@ function registerWorkflowStream(
   });
 }
 
-describe('process output frontend state', () => {
+describe('stream meta frontend state', () => {
   beforeEach(() => {
     resetProgressState();
   });
@@ -173,85 +146,6 @@ describe('process output frontend state', () => {
     expect(getState().activeStreamId).toBe(siblingId);
     expect(getState().streamFilter).toBe('toolUse');
     expect([...getState().streamById.keys()]).toEqual([siblingId, streamId]);
-  });
-
-  it('appends output without pruning sibling process entries', () => {
-    const streamId = 'stream-a' as StreamTabId;
-    const getState = seedState(createProcessState(streamId));
-
-    dispatch(streamMetaHandlers, {
-      command: PROGRESS_VIEW_COMMANDS.UPDATE_PROCESS_OUTPUT,
-      stream: streamId,
-      executionId: 'active-process',
-      stdout: '-new',
-      stderr: 'warn',
-    });
-
-    const outputs = getState().processOutputs.get(streamId);
-    expect(outputs?.get('active-process')).toEqual({
-      stdout: 'old-active-new',
-      stderr: 'warn',
-    });
-    expect(outputs?.get('stale-process')).toEqual({
-      stdout: 'old-stale',
-      stderr: '',
-    });
-  });
-
-  it('prunes stale process entries when badges change', () => {
-    const streamId = 'stream-a' as StreamTabId;
-    const getState = seedState(createProcessState(streamId));
-
-    dispatch(streamMetaHandlers, {
-      command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_BADGES,
-      stream: streamId,
-      subagents: [],
-      processes: [
-        {
-          kind: 'process',
-          executionId: 'active-process',
-          agentName: 'bash',
-          status: STREAM_STATUS.RUNNING,
-        },
-      ],
-    });
-
-    const outputs = getState().processOutputs.get(streamId);
-    expect(outputs?.has('active-process')).toBe(true);
-    expect(outputs?.has('stale-process')).toBe(false);
-  });
-
-  it('still prunes when the roster carries retained finished processes', () => {
-    const streamId = 'stream-a' as StreamTabId;
-    const getState = seedState(createProcessState(streamId));
-
-    // The retained finished row must not keep `stale-process` output alive:
-    // only the live subset feeds the prune.
-    dispatch(streamMetaHandlers, {
-      command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_BADGES,
-      stream: streamId,
-      subagents: [],
-      processes: [
-        {
-          kind: 'process',
-          executionId: 'active-process',
-          agentName: 'bash',
-          status: STREAM_STATUS.RUNNING,
-        },
-        {
-          kind: 'process',
-          executionId: 'stale-process',
-          agentName: 'bash',
-          status: STREAM_PHASE.COMPLETED,
-          finishedAt: 1,
-        },
-      ],
-    });
-
-    const outputs = getState().processOutputs.get(streamId);
-    expect(outputs?.has('active-process')).toBe(true);
-    expect(outputs?.has('stale-process')).toBe(false);
-    expect(getState().streamStates.get(streamId)?.processes).toHaveLength(2);
   });
 
   it('updates and clears stream substate with status changes', () => {

--- a/src/test-kernel/shared/SharedStreams.vitest.ts
+++ b/src/test-kernel/shared/SharedStreams.vitest.ts
@@ -264,137 +264,44 @@ describe('stream status display labels', () => {
 // StreamMetaReducer
 // ---------------------------------------------------------------------------
 
-const OPTS = { outputCap: { maxChars: 100 } } as const;
-
 function meta(overrides: Partial<StreamMeta> = {}): StreamMeta {
   return { ...EMPTY_STREAM_META, ...overrides };
 }
 
 describe('reduceStreamMeta', () => {
-  describe('processOutput cap policies', () => {
-    it('exact head-cut at the cap when retainChars is omitted (CLI policy)', () => {
-      const base = meta({
-        processOutput: new Map([['e', { stdout: '0123456789', stderr: '' }]]),
-      });
-      // combined = "0123456789abc" (13) > 5 → keep last 5 → "89abc".
-      const next = reduceStreamMeta(
-        base,
-        { kind: 'processOutput', executionId: 'e', stdout: 'abc', stderr: '' },
-        { outputCap: { maxChars: 5 } },
-      );
-      expect(next.processOutput.get('e')).toEqual({
-        stdout: '89abc',
-        stderr: '',
-      });
-    });
+  const active: ActiveChildInfo = {
+    kind: 'process',
+    executionId: 'active',
+    agentName: 'bash',
+  };
 
-    it('trims to retainChars once maxChars is crossed (webview 100k→80k policy)', () => {
-      const base = meta({
-        processOutput: new Map([['e', { stdout: '0123456789', stderr: '' }]]),
-      });
-      // combined length 13 > 10 → keep last 5 → "89abc".
-      const next = reduceStreamMeta(
-        base,
-        { kind: 'processOutput', executionId: 'e', stdout: 'abc', stderr: '' },
-        { outputCap: { maxChars: 10, retainChars: 5 } },
-      );
-      expect(next.processOutput.get('e')?.stdout).toBe('89abc');
+  it('sets the active list and prunes output for vanished processes', () => {
+    const base = meta({
+      activeProcesses: [],
+      processOutput: new Map([
+        ['active', { stdout: 'a', stderr: '' }],
+        ['stale', { stdout: 's', stderr: '' }],
+      ]),
     });
-
-    it('clamps retainChars to maxChars', () => {
-      const base = meta({
-        processOutput: new Map([['e', { stdout: '0123456789', stderr: '' }]]),
-      });
-      const next = reduceStreamMeta(
-        base,
-        { kind: 'processOutput', executionId: 'e', stdout: 'abc', stderr: '' },
-        { outputCap: { maxChars: 5, retainChars: 100 } },
-      );
-      expect(next.processOutput.get('e')?.stdout).toBe('89abc');
+    const next = reduceStreamMeta(base, {
+      kind: 'activeProcesses',
+      processes: [active],
     });
-
-    it('keeps appending up to maxChars before the next reset', () => {
-      const base = meta({
-        processOutput: new Map([['e', { stdout: '012345', stderr: '' }]]),
-      });
-      // combined "012345ab" (8) <= 10 → plain append, no reset yet.
-      const next = reduceStreamMeta(
-        base,
-        { kind: 'processOutput', executionId: 'e', stdout: 'ab', stderr: '' },
-        { outputCap: { maxChars: 10, retainChars: 5 } },
-      );
-      expect(next.processOutput.get('e')?.stdout).toBe('012345ab');
-    });
-
-    it('seeds a missing execution entry from empty', () => {
-      const next = reduceStreamMeta(
-        meta(),
-        {
-          kind: 'processOutput',
-          executionId: 'new',
-          stdout: 'hi',
-          stderr: 'e',
-        },
-        OPTS,
-      );
-      expect(next.processOutput.get('new')).toEqual({
-        stdout: 'hi',
-        stderr: 'e',
-      });
-    });
+    expect(next.activeProcesses).toEqual([active]);
+    expect(next.processOutput.has('active')).toBe(true);
+    expect(next.processOutput.has('stale')).toBe(false);
+    // Input is untouched.
+    expect(next).not.toBe(base);
+    expect(base.processOutput.has('stale')).toBe(true);
   });
 
-  describe('activeProcesses', () => {
-    const active: ActiveChildInfo = {
-      kind: 'process',
-      executionId: 'active',
-      agentName: 'bash',
-    };
-
-    it('sets the active list and prunes output for vanished processes', () => {
-      const base = meta({
-        activeProcesses: [],
-        processOutput: new Map([
-          ['active', { stdout: 'a', stderr: '' }],
-          ['stale', { stdout: 's', stderr: '' }],
-        ]),
-      });
-      const next = reduceStreamMeta(
-        base,
-        { kind: 'activeProcesses', processes: [active] },
-        OPTS,
-      );
-      expect(next.activeProcesses).toEqual([active]);
-      expect(next.processOutput.has('active')).toBe(true);
-      expect(next.processOutput.has('stale')).toBe(false);
-      // Input is untouched.
-      expect(base.processOutput.has('stale')).toBe(true);
+  it('keeps the same output-map identity when nothing is pruned', () => {
+    const output = new Map([['active', { stdout: 'a', stderr: '' }]]);
+    const base = meta({ processOutput: output });
+    const next = reduceStreamMeta(base, {
+      kind: 'activeProcesses',
+      processes: [active],
     });
-
-    it('keeps the same output-map identity when nothing is pruned', () => {
-      const output = new Map([['active', { stdout: 'a', stderr: '' }]]);
-      const base = meta({ processOutput: output });
-      const next = reduceStreamMeta(
-        base,
-        { kind: 'activeProcesses', processes: [active] },
-        OPTS,
-      );
-      expect(next.processOutput).toBe(output);
-    });
-  });
-
-  describe('purity', () => {
-    it('returns a fresh meta and map without mutating the input', () => {
-      const output = new Map([['e', { stdout: 'x', stderr: '' }]]);
-      const base = meta({ processOutput: output });
-      const next = reduceStreamMeta(
-        base,
-        { kind: 'processOutput', executionId: 'e', stdout: 'y', stderr: '' },
-        OPTS,
-      );
-      expect(next).not.toBe(base);
-      expect(next.processOutput).not.toBe(output);
-      expect(output.get('e')).toEqual({ stdout: 'x', stderr: '' });
-    });
+    expect(next.processOutput).toBe(output);
   });
 });

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -574,9 +574,8 @@ export function attachTranscriptRecorder(
           return;
 
         case 'child.activity':
-        case 'process.output':
-          // Stage 3a child/process facts replace legacy progress events for UI
-          // badges and process panes; they were not transcript rows before.
+          // Stage 3a child facts replace legacy progress events for UI badges;
+          // they were not transcript rows before.
           return;
 
         default: {


### PR DESCRIPTION
**Stacks on #9158** (base branch `agent/9139-dead-process-runtime`) — review that
one first; this diff is only the wire/controller/webview half on top of it.

**Part 2 of 3 for #9139.** Closes nothing; the issue closes with PR 3.

> I rebased #9158 onto current `main` (`a1fa9fad4d`) before branching, since
> #9155 had landed underneath it and touched the same `ProgressFactApplier` /
> `ProcessOutputState` ground. That rebase resolved one conflict in
> `DesktopAgentExecution.vitest.mts` in favour of #9158's deletions, and all
> four gates are green on the rebased #9158 as well.

## The deferred `process.output` arm, now unblocked

#9158 deliberately left `ProcessOutputEvent` in `AgentEvent`, because
`RUN_FACT_EVENT_TYPES` is `satisfies readonly AgentEvent['type'][]` and
`ProgressFactApplier.runFactHandlers` is a mapped type over that exact tuple —
so union, tuple and handler map only move together, and #9155 was rewriting
that file at the time. **#9155 merged (`a1fa9fad4d`), so the arm goes here**,
together with `TexraTranscriptRecorder`'s exhaustive `case 'process.output':`
under its `const _exhaustive: never` guard (B6).

## What this deletes, producer to renderer

| Layer | Removed |
| --- | --- |
| Trace | `ProcessOutputEvent`; its `AgentEvent` member; `'process.output'` from `RUN_FACT_EVENT_TYPES` (16 → 15) and from the CLI's own subscription filter; the exhaustive `case` in `TexraTranscriptRecorder` |
| Controllers | `ProgressFactApplier.handleUpdateProcessOutput` + its dispatch entry; `WebviewUpdater.updateProcessOutput` |
| Wire | `PROGRESS_VIEW_COMMANDS.UPDATE_PROCESS_OUTPUT`; `UpdateProcessOutputMessageSchema` + its `ProgressViewOutboundMessageSchema` member; `UpdateProcessOutputPayload` |
| CLI runtime | the `process.output` → `updateProcessOutput` projection in `sessionProgressSubscription`; the `updateProcessOutput` key in `CliNdjsonProgressEventPayloads` (B11) |
| Webview | `ProcessOutputMap`, `EMPTY_PROCESS_OUTPUTS`, `store.processOutputs` (+ its `deleteStreamState` / reset / init sites), `processOutputs$`, `activeProcessOutputs$`, `processOutputContext` and its `StreamConversation` provider, the `UPDATE_PROCESS_OUTPUT` slice handler, the prune block inside the badges handler, `BackgroundTasksPanel`'s `@consume`, `entry?.stdout` / `entry?.stderr` blocks, `renderOutputStream`, its `./TerminalOutput` side-effect import, and the now-unused `.task-output` / `.output-container` CSS |
| Shared reducer | the `processOutput` command arm and the whole cap policy that existed only for it — `PROCESS_OUTPUT_MAX_CHARS`, `OutputCap`, `ReduceStreamMetaOptions`, `EMPTY_OUTPUT`, the `appendTail` import, and both host cap constants (`WEBVIEW_OUTPUT_CAP`, `CLI_OUTPUT_CAP` / `PROCESS_TAIL_CHARS_MAX`) |
| Schemas | `ProcessOutputTailSchema` — see below |

`ProcessOutputTailSchema` had to go: with the wire message gone, nothing
imported the *schema* any more (only the inferred type), so
`check:dead-code-ratchet` flagged it, and B13 says delete rather than baseline.
Its last consumer is CLI TUI state, so `ProcessOutputTail` moves into
`cliState.ts` as a plain interface — it is UI state, not a wire contract. PR 3
deletes it with the rest of `StreamSlice`'s process fields.

The reducer keeps `reduceStreamMeta` with its single `activeProcesses` command:
the CLI still calls it for the roster, and it retires with the roster in PR 3.
A second commit inlines `subscribeRuntimeHost.applyStreamMeta` — with
`applyProcessOutput` gone it had exactly one caller and only projected a
`StreamSlice` into the reducer's shape.
`COMPLETED_PROCESS_TAIL_LINES` lost its last cross-module reference (a test
assertion that no longer has tail data to assert on) and is now file-local.

## Deliberately NOT here

- **`ActiveChildInfoSchema` stays a two-arm union** with
  `fillLegacyActiveChildKind` intact — the persisted-data trap (B2).
  `SchemaMigrations.vitest.ts` is unmodified and passing.
- **The `processes` roster half** (`child.activity{kind:'processes'}`, the
  `ChildActivityEvent` union collapse from B8, `StreamState.processes`,
  `ProgressViewState.projectChildRosters`, `replayTrace`, `runProgressRenderer`,
  `updateActiveProcesses`) — it has no producer after #9158, but removing it
  reaches straight into the CLI TUI panes, so it lands with **PR 3**.
- **The CLI TUI itself.** The only CLI files touched are the four the compiler
  forced: `subscribeRuntimeHost` (the `'process.output'` case became TS2367 per
  B3, so `applyProcessOutput` and the filter entry go with it),
  `sessionProgressSubscription`, `cliNdjsonProgressEvents`, and the two-line
  `applyStreamMeta` call-site change from dropping the cap argument.
- **`config/ratchets/knip-baseline.json` is unchanged** — nothing baselined.

## Behaviour

Nothing user-visible moves. `process.output` had **no production producer** as
of #9158 (the registry emitter and the desktop replay were its only two), so
every surface deleted here was already permanently empty: the webview's
`processOutputs` map, the `<terminal-output>` blocks under each Background Task
row, and the NDJSON record. Background bash in the progress view and the CLI is
served by `AgentExecutionHandle` child streams and is untouched — the
Background Tasks panel keeps `renderSection`, `renderTaskItem`, `getTaskIcon`,
`isAgentTool` and `.task-icon--process`, which do fire in production today (B7).

The one documented narrowing is the NDJSON vocabulary (B11): `[Unreleased]`
CHANGELOG entry added under **CLI**.

`ProcessOutputState.vitest.ts` is renamed to `StreamMetaState.vitest.ts` — all
three of its process-output tests leave and the remaining ones are about stream
metadata, status, round stage and parent-stream clearing.

## Element accounting

| Row from the issue's table | Target | This PR |
| --- | --- | --- |
| `AgentEvent` arms | −2 | **−1** (`ProcessOutputEvent`; the `ChildActivityEvent` collapse is PR 3) |
| `RUN_FACT_EVENT_TYPES` entries | 16 → 15 | **done** |
| `PROGRESS_VIEW_COMMANDS` entries | n → n−1 | **done** |
| Outbound wire schemas | 2 → 0 | **done** (`UpdateProcessOutputMessageSchema`, `ProcessOutputTailSchema`) |
| `progressEvents.ts` payload interfaces | 2 → 0 | **−1** (`UpdateProcessOutputPayload`; `UpdateActiveProcessesPayload` is PR 3) |
| NDJSON event keys | 2 → 0 | **−1** (`updateProcessOutput`) |
| Extension progress-view process elements | 9 → 0 | **−9, done** |
| `ActiveChildInfoSchema` union arms | 0 (held) | untouched, as required |

Net **−656 lines**: −346 production, −317 test, +7 CHANGELOG.

## Verification

All four gates green on this branch:

```
npm run typecheck             # six tsconfigs, incl. @texra/trace-viewer and @texra/desktop
npm test                      # 774 files / 7,525 tests passed, 1 file + 4 tests skipped
npm run lint
npm run check:dead-code-ratchet   # 18 findings vs 18 baselined; baseline file unchanged
```

Nothing was flaky; no test needed a re-run in isolation.

B9's uncovered file, `packages/cli/scripts/tui-harness.tsx`, was checked by
hand against `packages/cli/tsconfig.json`: **10 errors before this change, 10
after** — all pre-existing drift (`CliPlatformInitOptions`, `SessionMeta`,
`requestId`, `childStreamEntries`, `CliApiMode`), none related to process
output. Its three `slice.processOutput` reads still compile, since that field
survives into PR 3.

Re-grepped `.ts` / `.tsx` / `.mts` / `.mjs` / `.js` / `.json` / `.yaml` / `.md`
across `src/`, `packages/`, `scripts/` and `config/` for every deleted symbol:
zero hits outside `docs/`, which #9139 puts out of scope as historical design
records.

https://claude.ai/code/session_01MQZ63FFrmojmG58wPJdYNH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide deletion across trace, IPC, and progress UI, but behavior was already empty without a producer; main risk is NDJSON consumers or forks that still expected the documented event, and any missed references until PR 3 finishes CLI roster cleanup.
> 
> **Overview**
> **Retires the background-process stdout/stderr tail pipeline** that had no producer after the prior runtime work: the `process.output` run fact, `updateProcessOutput` NDJSON/progress payloads, `UPDATE_PROCESS_OUTPUT` IPC, and all extension progress-view state/UI that showed per-task `<terminal-output>` under Background Tasks.
> 
> The **shared `streamMetaReducer` no longer appends or caps tails**—only the `activeProcesses` roster update (and pruning vanished execution ids from any leftover map) remains for the CLI. **`ProcessOutputTail` moves off the wire** into CLI TUI-local `cliState` typing; **`ActiveChildInfo` / process roster** and CLI slice fields are intentionally left for PR 3.
> 
> **Documented breaking change:** `--output-format ndjson` no longer lists an `updateProcessOutput` record (it was never emitted; output goes through child streams). CHANGELOG adds that note plus unrelated extension scrollback wording from the same release section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2f132d98fc51f9e92b08631a8ef7dfcb7efae4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->