### PR TITLE
refactor(progress): remove inert forceRebuild state

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -253,7 +253,7 @@ export class DesktopProgressBridge {
           this.clearDesktopPresentationState();
           this.workflowFileActions.clearAllBackups();
         },
-        rebuildRenderedStreams: ({ syncActiveStream = true }) => {
+        rebuildRenderedStreams: ({ syncActiveStream }) => {
           const activeStream = this.updateStreamMetadata();
           if (syncActiveStream) this.syncStreamContent(activeStream);
         },

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -80,7 +80,6 @@ export class ProgressViewProvider extends BaseWebviewProvider {
   private _activePlacement: ProgressViewPlacement = 'sidebar';
   /** Set by disposePanelResources so showInSidebar knows replay is needed. */
   private _panelJustDisposed = false;
-  private _pendingUpdateOptions: { forceRebuild: boolean } | null = null;
   private readonly logger: AgentTrace;
   private readonly restartRepairRetry = new RestartRepairRetryScheduler();
 
@@ -136,7 +135,7 @@ export class ProgressViewProvider extends BaseWebviewProvider {
           this.messageHandler.cleanupDeletedStream(stream),
         cleanupDeletedStreams: (options) =>
           this.messageHandler.cleanupDeletedStreams(options),
-        rebuildRenderedStreams: (options) => this.syncFullView(options),
+        rebuildRenderedStreams: () => this.syncFullView(),
         activateStream: (stream) => this.setActiveStream(stream),
         notifyDeletionRetained: async (activeCount, failedCount) => {
           await vscode.window.showInformationMessage(
@@ -194,7 +193,7 @@ export class ProgressViewProvider extends BaseWebviewProvider {
       vscode.workspace.onDidChangeWorkspaceFolders(async () => {
         try {
           await this.backend.load();
-          this.syncFullView({ forceRebuild: true });
+          this.syncFullView();
         } catch (error) {
           this.logger.error(
             'Failed to reload transcripts after workspace change',
@@ -253,7 +252,6 @@ export class ProgressViewProvider extends BaseWebviewProvider {
 
   public resetSidebarReady(): void {
     this._sidebarReady = false;
-    this._pendingUpdateOptions = null;
   }
 
   /**
@@ -312,16 +310,10 @@ export class ProgressViewProvider extends BaseWebviewProvider {
     );
   }
 
-  public syncFullView(options?: { forceRebuild?: boolean }): void {
+  public syncFullView(): void {
     if (!this.getActiveWebview()) return;
 
-    if (!this.isActivePlacementReady()) {
-      const currentForce = this._pendingUpdateOptions?.forceRebuild ?? false;
-      this._pendingUpdateOptions = {
-        forceRebuild: currentForce || !!options?.forceRebuild,
-      };
-      return;
-    }
+    if (!this.isActivePlacementReady()) return;
 
     const theme =
       vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.Dark
@@ -363,8 +355,6 @@ export class ProgressViewProvider extends BaseWebviewProvider {
         this.backend.factApplier.syncStreamContent(activeStream);
       }
     }
-
-    this._pendingUpdateOptions = null;
   }
 
   public async markWebviewReady(
@@ -380,9 +370,8 @@ export class ProgressViewProvider extends BaseWebviewProvider {
       return;
     }
 
-    this._pendingUpdateOptions = null;
     this._panelJustDisposed = false;
-    this.syncFullView({ forceRebuild: true });
+    this.syncFullView();
     await this.replayPendingPrompts();
   }
 
@@ -425,7 +414,7 @@ export class ProgressViewProvider extends BaseWebviewProvider {
         this.logger.warn('Failed delayed restart repair', { data: error });
       });
     });
-    this.syncFullView({ forceRebuild: true });
+    this.syncFullView();
   }
 
   public isViewVisible(): boolean {
@@ -515,7 +504,7 @@ export class ProgressViewProvider extends BaseWebviewProvider {
     }
 
     if (this.isActivePlacementReady()) {
-      this.syncFullView({ forceRebuild: true });
+      this.syncFullView();
       // Only replay permissions when switching from editor → sidebar.
       // If already on sidebar, the webview already has the correct permissions;
       // replaying would cause duplicates.
@@ -529,7 +518,7 @@ export class ProgressViewProvider extends BaseWebviewProvider {
     if (this.isEditorMode()) {
       this.revealEditorPanel();
       if (this.isActivePlacementReady()) {
-        this.syncFullView({ forceRebuild: true });
+        this.syncFullView();
       }
       return;
     }
@@ -548,7 +537,7 @@ export class ProgressViewProvider extends BaseWebviewProvider {
       this._activePlacement = 'editor';
       await this.restoreSidebarToLauncher();
       this.revealEditorPanel();
-      this.syncFullView({ forceRebuild: true });
+      this.syncFullView();
       if (placementChanged) await this.replayPendingPrompts();
       return;
     }

--- a/src/controllers/progressView/backend/ProgressBackend.ts
+++ b/src/controllers/progressView/backend/ProgressBackend.ts
@@ -50,10 +50,7 @@ interface ProgressBackendLifecycleOptions {
   ): Promise<void> | void;
   cleanupDeletedStream(stream: StreamTabId): void;
   cleanupDeletedStreams(options: { allDeleted: boolean }): void;
-  rebuildRenderedStreams(options: {
-    forceRebuild: boolean;
-    syncActiveStream?: boolean;
-  }): void;
+  rebuildRenderedStreams(options: { syncActiveStream: boolean }): void;
   /** Desktop refreshes metadata after deleting an inactive stream. */
   refreshRenderedStreamsAfterDeletion?(): void;
   activateStream(stream: StreamTabId): Promise<void> | void;
@@ -213,7 +210,7 @@ export class ProgressBackend {
 
     const deletion = await this.state.clearStream(stream);
     if (deletion !== 'deleted') {
-      this.lifecycle.rebuildRenderedStreams({ forceRebuild: true });
+      this.lifecycle.rebuildRenderedStreams({ syncActiveStream: true });
       await this.notifyDeletionRetained(deletion);
       return;
     }
@@ -294,10 +291,7 @@ export class ProgressBackend {
         });
       }
     }
-    this.lifecycle.rebuildRenderedStreams({
-      forceRebuild: true,
-      syncActiveStream: !allDeleted,
-    });
+    this.lifecycle.rebuildRenderedStreams({ syncActiveStream: !allDeleted });
     if (!allDeleted) {
       await this.lifecycle.notifyDeletionRetained(
         retained.active.size,

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -698,7 +698,6 @@ describe('ProgressBackend', () => {
         command: PROGRESS_VIEW_COMMANDS.DELETE_ALL,
       });
       expect(lifecycle.rebuildRenderedStreams).toHaveBeenCalledWith({
-        forceRebuild: true,
         syncActiveStream: false,
       });
       expect(lifecycle.notifyDeletionRetained).not.toHaveBeenCalled();
@@ -815,7 +814,6 @@ describe('ProgressBackend', () => {
         command: PROGRESS_VIEW_COMMANDS.DELETE_ALL,
       });
       expect(lifecycle.rebuildRenderedStreams).toHaveBeenCalledWith({
-        forceRebuild: true,
         syncActiveStream: true,
       });
       expect(lifecycle.notifyDeletionRetained).toHaveBeenCalledWith(1, 0);
@@ -846,7 +844,7 @@ describe('ProgressBackend', () => {
 
       expect(lifecycle.cleanupDeletedStream).not.toHaveBeenCalled();
       expect(lifecycle.rebuildRenderedStreams).toHaveBeenCalledWith({
-        forceRebuild: true,
+        syncActiveStream: true,
       });
       expect(lifecycle.notifyDeletionRetained).toHaveBeenCalledWith(0, 1);
     } finally {


### PR DESCRIPTION
## Summary
- remove the inert `forceRebuild` option and `_pendingUpdateOptions` state from the progress-view lifecycle
- require both backend rebuild callers to pass `syncActiveStream` explicitly, preserving desktop behavior without a destructuring default
- keep extension behavior unchanged: it still performs a complete `syncFullView()` and intentionally ignores `syncActiveStream`

This is the independent PR1 half of #9143. It intentionally does **not** close the issue: the projector deletion in PR2 remains blocked on the explicit maintainer ruling and the #9139 sequencing requirement recorded there.

## Net elements (R6)
- total: 14 insertions, 33 deletions (net -19)
- production: 13 insertions, 30 deletions (net -17)
- removes one lifecycle option, one private field, five writes, and eight call-site arguments

## Consumer counts (R8)
- `rebuildRenderedStreams`: two backend callers, both now pass required `syncActiveStream` explicitly
- `syncFullView`: all extension callers now use the parameterless method
- no new exported symbols

## Validation
- focused ProgressBackend tests: 73 passed
- full suite: 7,558 passed, 4 skipped
- full six-project typecheck passed
- lint passed
- dead-code ratchet passed (18 findings, all baselined)
- extension fast compile passed
- Prettier and `git diff --check` passed

## Scheduled refactoring
The remaining `streamContentSync.ts` projector cleanup stays tracked by #9143 and must not land before the issue's maintainer-ruling and #9139 sequencing gates are satisfied.

Part of #9143

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lifecycle simplification with explicit sync flags; the only behavioral nuance is extension no longer queues full-view sync while the webview is not ready—call sites already retry on ready/markWebviewReady.
> 
> **Overview**
> Removes dead **`forceRebuild`** plumbing from the progress-view lifecycle and simplifies how hosts refresh the UI after stream deletion.
> 
> **`ProgressBackend`** now calls **`rebuildRenderedStreams`** with only **`syncActiveStream`** (required). Failed single-stream deletes and partial bulk deletes pass **`true`**; delete-all passes **`false`** so desktop can skip active transcript sync when nothing remains.
> 
> **Extension `ProgressViewProvider`** drops **`_pendingUpdateOptions`** and the **`forceRebuild`** argument on **`syncFullView()`**. If the active placement is not ready, sync returns immediately instead of coalescing a deferred rebuild. Lifecycle **`rebuildRenderedStreams`** always invokes parameterless **`syncFullView()`** and does not use **`syncActiveStream`**.
> 
> **Desktop** **`rebuildRenderedStreams`** no longer defaults **`syncActiveStream`** to true; callers must pass it explicitly (backend now does).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 081174ca3b1eb03f09ba65d183a786caf4fc3139. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->