### PR TITLE
refactor(platform): consolidate JsonStore's file locking into fileLocks.ts

### DIFF
--- a/src/platform/defaults/fileLocks.ts
+++ b/src/platform/defaults/fileLocks.ts
@@ -1,82 +1,100 @@
 import { mkdir } from 'node:fs/promises';
 import * as path from 'node:path';
 
-import { lock } from 'proper-lockfile';
+import { lock, type LockOptions } from 'proper-lockfile';
 
 import { KeyedMutex } from '@utils/core/keyedMutex';
 
 import type { FileLockProvider } from '../interfaces';
 
-/** Match the execution-liveness horizon: shorter stalls do not prove death. */
-const LOCK_STALE_MS = 120_000;
-/** Refresh well before another process may classify a held lock as stale. */
-const LOCK_UPDATE_MS = 2_000;
-const LOCK_RETRIES = {
-  retries: 8,
-  factor: 1.5,
-  minTimeout: 25,
-  maxTimeout: 250,
-  randomize: true,
-} as const;
-
 const localLocks = new KeyedMutex<string>();
 
+/** Per-caller tuning for {@link createNodeFileLocks}. */
+export interface FileLockTuning {
+  /** Stale horizon in ms. Shorter stalls do not prove the holder is dead. */
+  staleMs: number;
+  /**
+   * Refresh interval in ms while the operation is still running. Omit to let
+   * `proper-lockfile` use its own default (`stale / 2`).
+   */
+  updateMs?: number;
+  retries: LockOptions['retries'];
+}
+
 /**
- * Native cross-process locks for local shared-storage paths.
- * `proper-lockfile` refreshes the lock mtime at `update` while the operation is
- * still running, so critical sections may safely exceed the stale horizon.
+ * Builds native cross-process locks for local shared-storage paths, with a
+ * caller-tunable stale/update/retry policy. `proper-lockfile` refreshes the
+ * lock mtime at `update` while the operation is still running, so critical
+ * sections may safely exceed the stale horizon.
  */
-export const nodeFileLocks: FileLockProvider = {
-  async runExclusive<T>(
-    lockPath: string,
-    operation: () => Promise<T>,
-  ): Promise<T> {
-    const canonicalPath = path.resolve(lockPath);
-    return localLocks.runExclusive(canonicalPath, async () => {
-      await mkdir(path.dirname(canonicalPath), { recursive: true });
-      let compromised: Error | undefined;
-      const release = await lock(canonicalPath, {
-        realpath: false,
-        stale: LOCK_STALE_MS,
-        update: LOCK_UPDATE_MS,
-        retries: LOCK_RETRIES,
-        // proper-lockfile's default callback throws from its renewal timer,
-        // outside runExclusive's promise. Retain the failure and return it at
-        // this operation boundary instead of terminating the Node process.
-        onCompromised: (error) => {
-          compromised ??= error;
-        },
-      });
+export function createNodeFileLocks(tuning: FileLockTuning): FileLockProvider {
+  return {
+    async runExclusive<T>(
+      lockPath: string,
+      operation: () => Promise<T>,
+    ): Promise<T> {
+      const canonicalPath = path.resolve(lockPath);
+      return localLocks.runExclusive(canonicalPath, async () => {
+        await mkdir(path.dirname(canonicalPath), { recursive: true });
+        let compromised: Error | undefined;
+        const release = await lock(canonicalPath, {
+          realpath: false,
+          stale: tuning.staleMs,
+          ...(tuning.updateMs === undefined ? {} : { update: tuning.updateMs }),
+          retries: tuning.retries,
+          // proper-lockfile's default callback throws from its renewal timer,
+          // outside runExclusive's promise. Retain the failure and return it at
+          // this operation boundary instead of terminating the Node process.
+          onCompromised: (error) => {
+            compromised ??= error;
+          },
+        });
 
-      let value: T | undefined;
-      let operationFailure: unknown;
-      try {
-        value = await operation();
-      } catch (error) {
-        operationFailure = error;
-      }
+        let value: T | undefined;
+        let operationFailure: unknown;
+        try {
+          value = await operation();
+        } catch (error) {
+          operationFailure = error;
+        }
 
-      let releaseFailure: unknown;
-      try {
-        await release();
-      } catch (error) {
-        // A compromised lock has already been marked released internally.
-        // Its ERELEASED cleanup error carries less information than the
-        // original compromise and must not replace it.
-        if (!compromised) releaseFailure = error;
-      }
+        let releaseFailure: unknown;
+        try {
+          await release();
+        } catch (error) {
+          // A compromised lock has already been marked released internally.
+          // Its ERELEASED cleanup error carries less information than the
+          // original compromise and must not replace it.
+          if (!compromised) releaseFailure = error;
+        }
 
-      const failures = [operationFailure, compromised, releaseFailure].filter(
-        (error) => error !== undefined,
-      );
-      if (failures.length === 1) throw failures[0];
-      if (failures.length > 1) {
-        throw new AggregateError(
-          failures,
-          `File lock failed: ${canonicalPath}`,
+        const failures = [operationFailure, compromised, releaseFailure].filter(
+          (error) => error !== undefined,
         );
-      }
-      return value as T;
-    });
+        if (failures.length === 1) throw failures[0];
+        if (failures.length > 1) {
+          throw new AggregateError(
+            failures,
+            `File lock failed: ${canonicalPath}`,
+          );
+        }
+        return value as T;
+      });
+    },
+  };
+}
+
+/** Default-tuned provider for general local shared-storage paths. */
+export const nodeFileLocks: FileLockProvider = createNodeFileLocks({
+  // Match the execution-liveness horizon: shorter stalls do not prove death.
+  staleMs: 120_000,
+  // Refresh well before another process may classify a held lock as stale.
+  updateMs: 2_000,
+  retries: {
+    retries: 8,
+    factor: 1.5,
+    minTimeout: 25,
+    maxTimeout: 250,
+    randomize: true,
   },
-};
+});

--- a/src/platform/defaults/jsonStore.ts
+++ b/src/platform/defaults/jsonStore.ts
@@ -5,15 +5,32 @@ import writeFileAtomic from 'write-file-atomic';
 
 import { isFileNotFoundError } from '@common/errors';
 
-import type { StateStore } from '../interfaces';
+import type { FileLockProvider, StateStore } from '../interfaces';
 
-const LOCK_STALE_MS = 10_000;
-const LOCK_RETRY_OPTIONS = {
-  retries: 120,
-  factor: 1.2,
-  minTimeout: 10,
-  maxTimeout: 100,
-} as const;
+/**
+ * Cross-process lock for the read-modify-write flush below. Shares its
+ * mechanics (KeyedMutex in-process serialization, onCompromised handling,
+ * error aggregation) with `fileLocks.ts`'s other callers, tuned for this
+ * store's short, frequent flushes rather than long-running work. Loaded
+ * lazily, on first flush, so importing `JsonStore` doesn't pull in
+ * `proper-lockfile` before any write actually happens.
+ */
+let jsonStoreFileLocksPromise: Promise<FileLockProvider> | undefined;
+function getJsonStoreFileLocks(): Promise<FileLockProvider> {
+  jsonStoreFileLocksPromise ??= import('./fileLocks').then(
+    ({ createNodeFileLocks }) =>
+      createNodeFileLocks({
+        staleMs: 10_000,
+        retries: {
+          retries: 120,
+          factor: 1.2,
+          minTimeout: 10,
+          maxTimeout: 100,
+        },
+      }),
+  );
+  return jsonStoreFileLocksPromise;
+}
 
 type JsonRecord = Record<string, unknown>;
 
@@ -159,13 +176,8 @@ export class JsonStore implements StateStore {
     missingFallback: JsonRecord,
   ): Promise<void> {
     await ensureDir(dirname(this.filePath), this.options.mode);
-    const { default: properLockfile } = await import('proper-lockfile');
-    const release = await properLockfile.lock(this.filePath, {
-      realpath: false,
-      stale: LOCK_STALE_MS,
-      retries: LOCK_RETRY_OPTIONS,
-    });
-    try {
+    const fileLocks = await getJsonStoreFileLocks();
+    await fileLocks.runExclusive(this.filePath, async () => {
       const record = await readJsonRecord(this.filePath, missingFallback);
       if (value === undefined) {
         delete record[key];
@@ -179,9 +191,7 @@ export class JsonStore implements StateStore {
           ? undefined
           : { mode: this.options.mode },
       );
-    } finally {
-      await release();
-    }
+    });
   }
 }
 

--- a/src/test-kernel/desktop/JsonStoreLockCompromise.vitest.mts
+++ b/src/test-kernel/desktop/JsonStoreLockCompromise.vitest.mts
@@ -1,0 +1,68 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  lock: vi.fn(),
+}));
+
+vi.mock('proper-lockfile', () => ({ lock: mocks.lock }));
+
+// Local imports - test support
+import { loadPlatformDefaultsModule } from './loadPlatformDefaultsModule.mjs';
+
+interface JsonStore {
+  set(key: string, value: unknown): Promise<void>;
+}
+
+interface JsonStoreModule {
+  JsonStore: {
+    open(filePath: string): Promise<JsonStore>;
+  };
+}
+
+describe('JsonStore lock compromise boundary', () => {
+  let tempDir: string | undefined;
+
+  afterEach(async () => {
+    if (tempDir == null) return;
+    await rm(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
+  });
+
+  it('rejects set() through the compromise path instead of crashing the process', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'texra-json-store-compromise-'));
+    const filePath = join(tempDir, 'state.json');
+    await writeFile(filePath, '{}\n');
+
+    const compromised = Object.assign(new Error('lock directory disappeared'), {
+      code: 'ECOMPROMISED',
+    });
+    const alreadyReleased = Object.assign(new Error('lock already released'), {
+      code: 'ERELEASED',
+    });
+    mocks.lock.mockImplementationOnce(
+      async (
+        _path: string,
+        options: { onCompromised: (error: Error) => void },
+      ) => {
+        // Simulate proper-lockfile's renewal timer firing mid-flush: this
+        // must not throw synchronously (that would escape as an uncaught
+        // exception outside JsonStore.set()'s promise), and its error must
+        // still surface through set() rather than being silently dropped.
+        expect(() => options.onCompromised(compromised)).not.toThrow();
+        return async () => {
+          throw alreadyReleased;
+        };
+      },
+    );
+
+    const { JsonStore } =
+      await loadPlatformDefaultsModule<JsonStoreModule>('jsonStore.ts');
+    const store = await JsonStore.open(filePath);
+
+    await expect(store.set('key', 'value')).rejects.toBe(compromised);
+  });
+});


### PR DESCRIPTION
## Summary

Scheduled codebase audit for confusing/overlapping module responsibilities. The most significant, safely-fixable finding: `JsonStore.flush()` (`src/platform/defaults/jsonStore.ts`) reimplemented `proper-lockfile` cross-process locking independently of `nodeFileLocks` (`src/platform/defaults/fileLocks.ts`) — the exact abstraction that exists for this purpose (`FileLockProvider`). The two wrappers had silently-diverging stale/retry tuning (120s stale / 8 retries vs 10s stale / 120 retries) with no shared constant, so a future change to lock policy (e.g. for a slower filesystem or CI) was one edit away from landing in one call site and being forgotten in the other. More importantly, `JsonStore`'s hand-rolled wrapper had no `onCompromised` handler — `proper-lockfile`'s default behavior there is to `throw` from an internal renewal timer, **outside** any awaited promise, which can crash the process. `fileLocks.ts` had already fixed exactly this failure mode for `nodeFileLocks`; the fix never propagated to `JsonStore`'s independent copy.

This PR extracts `createNodeFileLocks(tuning)` from `fileLocks.ts` so both call sites share one locking implementation (in-process `KeyedMutex` serialization, the `onCompromised` safety net, error aggregation) while keeping each call site's own tuned stale/retry policy unchanged — `nodeFileLocks`'s tuning and `JsonStore`'s tuning are both preserved exactly as before, just built through the shared factory instead of two independent `proper-lockfile` wrappers.

Other overlap candidates were surveyed and deliberately left alone as either already-resolved (`src/shared` → `@agent/*` imports flagged in an earlier architecture audit are now down to 2 comment-only mentions, not real imports) or as load-bearing/out-of-scope for a single safe PR (two `ProgressViewMessageSender` types with the same name but different contracts in `src/controllers/progressView/backend/`; two "pack" pipelines in `src/housekeeping/`; business logic embedded in `src/shared/settingsView/handlers/`). Those are documented in this PR's description for follow-up but not touched here, since this codebase already runs a rigorous, adversarially-verified tech-debt rotation (#8787, #8974, #9138) and a single-session audit shouldn't duplicate or race that process on higher-risk items.

## Issue acceptance gates

No linked issue — this is a scheduled structural audit. Self-imposed gate: fix must be a genuine overlap (not a documented/intentional split), safe to land without a maintainer decision, and verified against the real test suite (not just typecheck).

## Single source of truth

`createNodeFileLocks` in `src/platform/defaults/fileLocks.ts` is now the single implementation of cross-process file locking (in-process serialization + `proper-lockfile` + `onCompromised` handling + error aggregation). Callers (`nodeFileLocks` for general shared-storage paths, `JsonStore`'s internal lock for its read-modify-write flush) supply only their own stale/retry tuning.

## Duplication and abstraction budget

Removed: a second, independently-tuned `proper-lockfile` wrapper in `jsonStore.ts` (raw `lock()`/`release()` calls, no `onCompromised` handling). Added: one factory function (`createNodeFileLocks`) and one tuning interface (`FileLockTuning`) — not a new abstraction layer, a parameterization of the one that already existed so it can serve a second caller with different tuning instead of being copy-pasted.

## Net elements (R6)

Files: 2 modified, 0 added/removed. Exported symbols: `+1` (`createNodeFileLocks`) `+1` type (`FileLockTuning`); `nodeFileLocks`'s export signature is unchanged. Net LoC: `+28` (111 insertions / 83 deletions) — the increase is JSDoc on the new tuning interface and the lazy-loader wrapper that preserves `JsonStore`'s prior dynamic-import behavior (see Validation); the duplicate lock/retry/error-aggregation logic itself is net-deleted from `jsonStore.ts`.

## Consumer counts (R8)

Not applicable — no emit path or export was deleted or re-routed. `FileLockProvider` (the interface both implementations satisfy) is unchanged; `nodeFileLocks`'s existing consumer (`nodeHost.ts`) is untouched.

## Host impact

Extension: not applicable (`JsonStore`/`fileLocks.ts` are Electron/CLI-only platform defaults; extension uses VS Code's own state APIs).

Desktop: uses `JsonStore` for settings/secrets persistence — locking behavior (retry/stale tuning) is unchanged; it now goes through the shared, better-tested lock implementation.

CLI: uses `JsonStore` for config/state/secrets — same as desktop, tuning unchanged, `onCompromised` safety net gained.

## Scheduled refactoring

None filed. Remaining findings from this audit (the `ProgressViewMessageSender` name collision, the `src/housekeeping` dual "pack" pipelines, and settings business logic in `src/shared/settingsView/handlers/`) are lower-confidence and/or higher-risk to fix blind in one session; leaving them for the existing debt-audit rotation (#8787/#8974) to pick up with its adversarial-verification process rather than filing possibly-redundant issues.

## Validation

- `npm run typecheck` — all 6 tsconfigs pass.
- `npx eslint src/platform/defaults/{fileLocks,jsonStore}.ts` — clean.
- `npx prettier --check` — clean.
- `npm run check:dead-code-ratchet` — 18/18 baseline, no new findings.
- `npx vitest run src/test-kernel/platform src/test-kernel/desktop src/test-kernel/cli` — full batch, 204 files / 2508 tests passed, 0 failures (initially caught a real regression here: turning `jsonStore.ts`'s dynamic `proper-lockfile` import into an eager static one shifted CLI-bootstrap module-load timing and broke `RunChatSignalOwnership.vitest.mts`'s signal-handler-order assertion, reproduced 3/3 runs; fixed by keeping the shared lock provider's construction lazy via dynamic `import('./fileLocks')` inside `flush()`, matching `JsonStore`'s original lazy-load behavior exactly — re-verified 3/3 passing runs afterward).
- Full workspace `npm run typecheck` (all 6 tsconfigs, including `@texra/trace-viewer` and `@texra/desktop`) — clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CHV7BEtF7YDEN23jeJepwa)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cross-process locking on settings/state persistence (JsonStore) with a behavioral change (compromise errors now surface through set()), though tuning is unchanged and tests cover the new path.
> 
> **Overview**
> **`JsonStore` no longer wraps `proper-lockfile` on its own.** Flushes now use the same `createNodeFileLocks` path as `nodeFileLocks`, with the store’s existing 10s stale / 120-retry tuning unchanged and a lazy dynamic import so bootstrap module-load timing stays the same.
> 
> **`fileLocks.ts` is parameterized instead of one fixed policy.** The prior `nodeFileLocks` implementation moves into `createNodeFileLocks(tuning)` plus a `FileLockTuning` type; `nodeFileLocks` is the same 120s stale / 2s update / 8-retry preset as before.
> 
> **Behavioral fix for `JsonStore`:** shared locking brings in **`onCompromised` handling** and the same error aggregation as other callers, so lock renewal failures reject `set()` instead of risking an uncaught throw from a timer. A vitest covers that compromise path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86dbe0b6816f19c9a57a95b3233ab0b5d16643ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->