### PR TITLE
refactor(progressView): standardize hover hints on wa-tooltip

### DIFF
--- a/packages/extension/src/progressView/frontend/components/FileList.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.ts
@@ -473,12 +473,15 @@ export class FileList extends LitElement {
         ${
           failure
             ? html`<wa-icon
-                library=${TEXRA_ICON_LIBRARY}
-                name="warning"
-                class="compile-warning"
-                title="Compile check failed"
-                aria-label="Compile check failed"
-              ></wa-icon>`
+                  id="${idPrefix}-compile-warning"
+                  library=${TEXRA_ICON_LIBRARY}
+                  name="warning"
+                  class="compile-warning"
+                  aria-label="Compile check failed"
+                ></wa-icon>
+                <wa-tooltip for="${idPrefix}-compile-warning"
+                  >Compile check failed</wa-tooltip
+                >`
             : nothing
         }
         <span class="file-name">

--- a/packages/extension/src/progressView/frontend/components/RequestPanels.ts
+++ b/packages/extension/src/progressView/frontend/components/RequestPanels.ts
@@ -19,9 +19,10 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { keyed } from 'lit/directives/keyed.js';
 import { repeat } from 'lit/directives/repeat.js';
 
-// Side-effect imports - register WA icon and button components
+// Side-effect imports - register WA icon, button, and tooltip components
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/button/button.js';
+import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 
 // Local imports - shared styles
 import {
@@ -253,9 +254,9 @@ export class RequestPanels extends LitElement {
     const nav = html`
       <div class="external-inquiry-requests__nav">
         <wa-button
+          id="ei-prev-btn"
           appearance="plain"
           size="small"
-          title="Previous inquiry"
           ?disabled=${index === 0}
           @click=${this._eiPrev}
         >
@@ -265,13 +266,14 @@ export class RequestPanels extends LitElement {
             aria-hidden="true"
           ></wa-icon>
         </wa-button>
+        <wa-tooltip for="ei-prev-btn">Previous inquiry</wa-tooltip>
         <span class="external-inquiry-requests__counter">
           ${index + 1} / ${perms.length}
         </span>
         <wa-button
+          id="ei-next-btn"
           appearance="plain"
           size="small"
-          title="Next inquiry"
           ?disabled=${index === perms.length - 1}
           @click=${this._eiNext}
         >
@@ -281,6 +283,7 @@ export class RequestPanels extends LitElement {
             aria-hidden="true"
           ></wa-icon>
         </wa-button>
+        <wa-tooltip for="ei-next-btn">Next inquiry</wa-tooltip>
       </div>
     `;
 

--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -527,8 +527,8 @@ export class StreamHeader extends LitElement {
 
     return html`
       <span
+        id=${ELEMENT_IDS.PARENT_LINK}
         class="parent-link"
-        title="Go to parent: ${displayName}"
         role="button"
         tabindex="0"
         @click=${this.navigateToParent}
@@ -536,6 +536,9 @@ export class StreamHeader extends LitElement {
       >
         ${waIcon('arrow-left')} ${displayName}
       </span>
+      <wa-tooltip for=${ELEMENT_IDS.PARENT_LINK}
+        >Go to parent: ${displayName}</wa-tooltip
+      >
     `;
   }
 

--- a/packages/extension/src/progressView/frontend/components/UsagePanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UsagePanel.ts
@@ -360,14 +360,14 @@ export class UsagePanel extends LitElement {
             >Compaction at ${COMPACTION_THRESHOLD}%</wa-tooltip
           >
         </span>
-        <wa-tooltip for="usage-context-gauge"
-          >${clamped.toFixed(0)}% context used</wa-tooltip
-        >
         <span class="context-state__value">
           ${formatCompactTokenCount(inputTokens)} /
           ${formatCompactTokenCount(contextWindow)}
         </span>
       </span>
+      <wa-tooltip for="usage-context-gauge"
+        >${clamped.toFixed(0)}% context used</wa-tooltip
+      >
     `;
   }
 

--- a/packages/extension/src/progressView/frontend/components/UsagePanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UsagePanel.ts
@@ -7,6 +7,7 @@ import { when } from 'lit/directives/when.js';
 // Side-effect imports - register WA components
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/progress-bar/progress-bar.js';
+import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 
 // Local imports - shared schemas
 import type { TokenUsageStats, UsageRoute } from '@shared/schemas';
@@ -240,57 +241,72 @@ export class UsagePanel extends LitElement {
       <span class="run-summary__label">Total usage:</span>
       <span class="run-summary__value">
         <wa-icon
+          id="usage-input-icon"
           library=${TEXRA_ICON_LIBRARY}
           name="arrow-up"
-          title="Input tokens"
           aria-hidden="true"
         ></wa-icon
-        >${formatCompactTokenCount(inputTokens)}
+        >${formatCompactTokenCount(inputTokens)}<wa-tooltip
+          for="usage-input-icon"
+          >Input tokens</wa-tooltip
+        >
         ${when(
           cacheRead > 0,
           () =>
             html` ·
               <wa-icon
+                id="usage-cache-read-icon"
                 library=${TEXRA_ICON_LIBRARY}
                 name="cloud-download"
-                title="Cache read tokens (discounted)"
                 aria-hidden="true"
-              ></wa-icon>
-              ${formatCompactTokenCount(cacheRead)}`,
+              ></wa-icon
+              >${formatCompactTokenCount(cacheRead)}<wa-tooltip
+                for="usage-cache-read-icon"
+                >Cache read tokens (discounted)</wa-tooltip
+              >`,
         )}
         ${when(
           cacheMiss > 0,
           () =>
             html` ·
               <wa-icon
+                id="usage-cache-miss-icon"
                 library=${TEXRA_ICON_LIBRARY}
                 name="cloud-upload"
-                title="Cache miss tokens (full price)"
                 aria-hidden="true"
-              ></wa-icon>
-              ${formatCompactTokenCount(cacheMiss)}`,
+              ></wa-icon
+              >${formatCompactTokenCount(cacheMiss)}<wa-tooltip
+                for="usage-cache-miss-icon"
+                >Cache miss tokens (full price)</wa-tooltip
+              >`,
         )}
         ${when(
           cacheWrite > 0,
           () =>
             html` ·
               <wa-icon
+                id="usage-cache-write-icon"
                 library=${TEXRA_ICON_LIBRARY}
                 name="database"
-                title="Cache creation tokens (1.25x cost)"
                 aria-hidden="true"
-              ></wa-icon>
-              ${formatCompactTokenCount(cacheWrite)}`,
+              ></wa-icon
+              >${formatCompactTokenCount(cacheWrite)}<wa-tooltip
+                for="usage-cache-write-icon"
+                >Cache creation tokens (1.25x cost)</wa-tooltip
+              >`,
         )}
         ·
         <wa-icon
+          id="usage-output-icon"
           library=${TEXRA_ICON_LIBRARY}
           name="arrow-down"
-          title="Output tokens"
           aria-hidden="true"
         ></wa-icon
-        >${formatCompactTokenCount(outputTokens)} ·
-        ${this.renderCostRoute(cost)}
+        >${formatCompactTokenCount(outputTokens)}<wa-tooltip
+          for="usage-output-icon"
+          >Output tokens</wa-tooltip
+        >
+        · ${this.renderCostRoute(cost)}
       </span>
     `;
   }
@@ -302,16 +318,17 @@ export class UsagePanel extends LitElement {
 
     if (badge.subscription && cost === 0) {
       return html`<span
-        class="run-summary__route run-summary__route--free"
-        title=${badge.title}
-        >Free · ${badge.label}</span
-      >`;
+          id="usage-route-badge"
+          class="run-summary__route run-summary__route--free"
+          >Free · ${badge.label}</span
+        ><wa-tooltip for="usage-route-badge">${badge.title}</wa-tooltip>`;
     }
 
     return html`${formatCostUsd(cost)} ·
-      <span class="run-summary__route" title=${badge.title}>
+      <span id="usage-route-badge" class="run-summary__route">
         ${badge.label}
-      </span>`;
+      </span>
+      <wa-tooltip for="usage-route-badge">${badge.title}</wa-tooltip>`;
   }
 
   private renderContext(): TemplateResult | typeof nothing {
@@ -321,7 +338,7 @@ export class UsagePanel extends LitElement {
     const clamped = clamp(utilizationPercent, 0, 100);
 
     return html`
-      <span class="context-gauge" title="${clamped.toFixed(0)}% context used">
+      <span id="usage-context-gauge" class="context-gauge">
         <wa-icon
           library=${TEXRA_ICON_LIBRARY}
           name="window"
@@ -335,11 +352,17 @@ export class UsagePanel extends LitElement {
             style=${styleMap({ '--indicator-color': fillColor(clamped) })}
           ></wa-progress-bar>
           <span
+            id="usage-compaction-tick"
             class="context-gauge__tick"
             style=${styleMap({ left: `${COMPACTION_THRESHOLD}%` })}
-            title="Compaction at ${COMPACTION_THRESHOLD}%"
           ></span>
+          <wa-tooltip for="usage-compaction-tick"
+            >Compaction at ${COMPACTION_THRESHOLD}%</wa-tooltip
+          >
         </span>
+        <wa-tooltip for="usage-context-gauge"
+          >${clamped.toFixed(0)}% context used</wa-tooltip
+        >
         <span class="context-state__value">
           ${formatCompactTokenCount(inputTokens)} /
           ${formatCompactTokenCount(contextWindow)}

--- a/packages/extension/src/progressView/frontend/constants.ts
+++ b/packages/extension/src/progressView/frontend/constants.ts
@@ -11,6 +11,7 @@ export const ELEMENT_IDS = {
   GENERATED_FILES_COLLAPSIBLE: 'generatedFilesCollapsible',
   STREAM_TABS: 'streamTabs',
   ACTIVE_STREAM_NAME: 'activeStreamName',
+  PARENT_LINK: 'parentLink',
   STATUS_INDICATOR: 'statusIndicator',
   GOAL_CHIP: 'goalChip',
   PROGRESS_BADGE: 'progressBadge',


### PR DESCRIPTION
## Summary

A scheduled UI-consistency audit found that most of `progressView/frontend` already standardizes hover hints on the shared `<wa-tooltip for=...>` pattern (e.g. `FileList`'s action buttons, `StreamHeader`'s status indicator/goal chip/progress badge), but four components mixed in the native HTML `title="..."` attribute instead. This PR converts the `title=` occurrences that came out of that audit pass in `FileList.ts`, `StreamHeader.ts`, `RequestPanels.ts`, and `UsagePanel.ts` to `<wa-tooltip>`.

**Correction (post-review):** the original audit's file list was incomplete. `StreamHeader.ts:410` and `FileList.ts:490` still carry native `title=`, and several more components in this directory (`WorktreeChip.ts`, `StreamTabs.ts`, `BackgroundTasksPanel.ts`, `UserMessage.ts`, `LatexdiffResults.ts`, `ToolEditRequestPanel.ts`, `QueuedFollowUps.ts`, `ContextManagement.ts`, `ProposalRequestPanel.ts`) mix the two patterns too. This PR does **not** close out the inconsistency — it fixes the subset the original audit actually flagged. The remainder is tracked in #9168 rather than bundled in here, since several of those are truncated-text tooltips on multi-instance-per-shadow-root components (`BackgroundTasksPanel`, `StreamTabs`) that need their own id-safety and UX check.

## Issue acceptance gates

Tracked as a follow-up in #9168 for the remaining files. This PR's gate: the four components it touches (`FileList`, `StreamHeader`, `RequestPanels`, `UsagePanel`) no longer mix `title=` and `wa-tooltip` for the specific hints this diff changes — it is not a claim that the whole directory is converted.

## Single source of truth

No new coordinator — `<wa-tooltip for=...>` was already the established pattern in this tree; this PR removes some of the remaining exceptions to it (see #9168 for the rest). One new shared DOM id, `ELEMENT_IDS.PARENT_LINK`, was added to the existing `ELEMENT_IDS` registry in `progressView/frontend/constants.ts` (the file that already owns every other cross-referenced element id in this view) rather than a new local literal.

## Duplication and abstraction budget

Removed duplication: two divergent hover-hint mechanisms (`title=` vs `wa-tooltip`) collapse to one, for the hints this diff touches. No new component or abstraction was introduced — every fix reuses the existing `<wa-tooltip>` custom element and `for`-id wiring already present in the same files.

## Net elements (R6)

Diffstat: 5 files changed, 68 insertions(+), 35 deletions(-). No new exported symbols, classes, or files — one new key (`PARENT_LINK`) added to the existing exported `ELEMENT_IDS` object.

## Consumer counts (R8)

n/a — no emit path or export was removed or re-routed.

## Host impact

Extension: `packages/extension/src/progressView/frontend/components/{FileList,StreamHeader,RequestPanels,UsagePanel}.ts` now render consistent `<wa-tooltip>` hover hints instead of native `title=`, for the hints in scope.

Desktop: inherits the fix automatically — `packages/desktop` imports these same components via the `@progressView/*` path alias rather than forking them.

CLI: not applicable (Ink-based TUI, no webview components).

## Scheduled refactoring

Follow-up filed: #9168 tracks the remaining native `title=` occurrences in `progressView/frontend/components` that this PR doesn't touch.

## Validation

- `npm run typecheck` — clean
- `npx eslint` on all changed files — clean
- `npx prettier --check` on all changed files (auto-formatted once, tight `wa-icon`/`wa-tooltip` whitespace gluing verified in the diff)
- `npm run check:dead-code-ratchet` — no new unused exports/files
- `npx vitest run` (full suite) — passing; no dedicated component-render tests exist for these Lit components, so this is a markup-only, no-logic-change refactor verified by type/lint/format checks plus manual review of the rendered template structure
- Addressed Cursor Bugbot's nested-tooltip finding on `UsagePanel.ts` (commit 7458438): the gauge's `<wa-tooltip>` was a descendant of its own `for` target, causing overlapping hints on hover; moved to a true sibling