### PR TITLE
test: consolidate duplicated test helpers onto existing shared utilities

### DIFF
--- a/src/test-kernel/agent/AgentRegistryAlias.vitest.mts
+++ b/src/test-kernel/agent/AgentRegistryAlias.vitest.mts
@@ -27,6 +27,7 @@ import type { AgentDirectoriesPort } from '@platform/interfaces';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { createFakePlatform } from '@test/support/FakePlatform';
+import { createDeferred } from '@test/support/asyncTestUtils';
 
 const listRemoteAgents = vi.hoisted(() =>
   vi.fn(async () => [
@@ -78,17 +79,6 @@ const mutableAgentDirectories: AgentDirectoriesPort = {
   builtIn: () => activeAgentDirectories.builtIn(),
   builtInToolUse: () => activeAgentDirectories.builtInToolUse(),
 };
-
-function createDeferred<T = void>(): {
-  promise: Promise<T>;
-  resolve(value: T): void;
-} {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
-}
 
 /** Point the platform at the real bundled agent YAMLs, overriding any dir. */
 function useAgentDirectories(

--- a/src/test-kernel/agent/modelHandlers/AnthropicCacheBeta.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/AnthropicCacheBeta.vitest.ts
@@ -1,37 +1,39 @@
 // Third-party imports
-import { DEFAULT_MODEL_CAPABILITIES, ModelProvider } from 'llm-zoo';
+import { ModelProvider } from 'llm-zoo';
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports - agent model handlers
 import type { AgentTrace } from '@agent/trace';
 import { ModelHandlerAnthropic } from '@agent/modelHandlers/anthropic/modelHandlerAnthropic';
+import type { ToolDefinition } from '@model';
+import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 
 // Type imports
-import type { ToolDefinition } from '@model';
 import type Anthropic from '@anthropic-ai/sdk';
 import type { MessageParam } from '@anthropic-ai/sdk/resources/messages';
 
 const EXTENDED_CACHE_TTL_BETA = 'extended-cache-ttl-2025-04-11';
 
 function createHandler(): ModelHandlerAnthropic {
-  const handler = new ModelHandlerAnthropic({
-    name: 'test-anthropic',
-    label: 'Test Anthropic',
-    fullName: 'claude-test',
-    shortName: 'claude-test',
-    provider: ModelProvider.ANTHROPIC,
-    maxOutputTokens: 1024,
-    inputPrice: 0,
-    outputPrice: 0,
-    contextWindow: 200000,
-    capabilities: {
-      ...DEFAULT_MODEL_CAPABILITIES,
-      supportsPromptCaching: true,
-      supportsTokenCounting: true,
-      supportsReasoning: false,
-    },
-    openRouterOnly: false,
-  });
+  const handler = new ModelHandlerAnthropic(
+    buildTestModelConfig({
+      name: 'test-anthropic',
+      label: 'Test Anthropic',
+      fullName: 'claude-test',
+      shortName: 'claude-test',
+      provider: ModelProvider.ANTHROPIC,
+      maxOutputTokens: 1024,
+      inputPrice: 0,
+      outputPrice: 0,
+      contextWindow: 200000,
+      capabilities: {
+        supportsPromptCaching: true,
+        supportsTokenCounting: true,
+        supportsReasoning: false,
+      },
+      openRouterOnly: false,
+    }),
+  );
 
   handler.setLogger({
     streamId: 'test',

--- a/src/test-kernel/agent/modelHandlers/AnthropicCachePricing.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/AnthropicCachePricing.vitest.ts
@@ -1,27 +1,29 @@
 // Third-party imports
-import { DEFAULT_MODEL_CAPABILITIES, ModelProvider } from 'llm-zoo';
+import { ModelProvider } from 'llm-zoo';
 import { describe, expect, it } from 'vitest';
 
 // Local imports - agent model handlers
 import { ModelHandlerAnthropic } from '@agent/modelHandlers/anthropic/modelHandlerAnthropic';
+import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 
 function createHandler(): ModelHandlerAnthropic {
-  return new ModelHandlerAnthropic({
-    name: 'test-anthropic',
-    label: 'Test Anthropic',
-    fullName: 'claude-test',
-    shortName: 'claude-test',
-    provider: ModelProvider.ANTHROPIC,
-    maxOutputTokens: 1024,
-    inputPrice: 3,
-    outputPrice: 15,
-    contextWindow: 200000,
-    capabilities: {
-      ...DEFAULT_MODEL_CAPABILITIES,
-      supportsPromptCaching: true,
-    },
-    openRouterOnly: false,
-  });
+  return new ModelHandlerAnthropic(
+    buildTestModelConfig({
+      name: 'test-anthropic',
+      label: 'Test Anthropic',
+      fullName: 'claude-test',
+      shortName: 'claude-test',
+      provider: ModelProvider.ANTHROPIC,
+      maxOutputTokens: 1024,
+      inputPrice: 3,
+      outputPrice: 15,
+      contextWindow: 200000,
+      capabilities: {
+        supportsPromptCaching: true,
+      },
+      openRouterOnly: false,
+    }),
+  );
 }
 
 describe('Anthropic cache pricing', () => {

--- a/src/test-kernel/agent/modelHandlers/AnthropicStreamFailureLogging.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/AnthropicStreamFailureLogging.vitest.ts
@@ -1,35 +1,37 @@
 // Third-party imports
 import { BadRequestError as AnthropicBadRequestError } from '@anthropic-ai/sdk';
-import { DEFAULT_MODEL_CAPABILITIES, ModelProvider } from 'llm-zoo';
+import { ModelProvider } from 'llm-zoo';
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports - agent model handlers
 import { noopTrace, type AgentTrace } from '@agent/trace';
 import { ModelHandlerAnthropic } from '@agent/modelHandlers/anthropic/modelHandlerAnthropic';
+import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 
 // Type imports
 import type Anthropic from '@anthropic-ai/sdk';
 import type { MessageParam } from '@anthropic-ai/sdk/resources/messages';
 
 function createHandler(): ModelHandlerAnthropic {
-  const handler = new ModelHandlerAnthropic({
-    name: 'test-anthropic',
-    label: 'Test Anthropic',
-    fullName: 'claude-test',
-    shortName: 'claude-test',
-    provider: ModelProvider.ANTHROPIC,
-    maxOutputTokens: 1024,
-    inputPrice: 0,
-    outputPrice: 0,
-    contextWindow: 200000,
-    capabilities: {
-      ...DEFAULT_MODEL_CAPABILITIES,
-      supportsTokenCounting: false,
-      supportsReasoning: false,
-    },
-    // Keeps the unit test independent from the server-side key service.
-    openRouterOnly: true,
-  });
+  const handler = new ModelHandlerAnthropic(
+    buildTestModelConfig({
+      name: 'test-anthropic',
+      label: 'Test Anthropic',
+      fullName: 'claude-test',
+      shortName: 'claude-test',
+      provider: ModelProvider.ANTHROPIC,
+      maxOutputTokens: 1024,
+      inputPrice: 0,
+      outputPrice: 0,
+      contextWindow: 200000,
+      capabilities: {
+        supportsTokenCounting: false,
+        supportsReasoning: false,
+      },
+      // Keeps the unit test independent from the server-side key service.
+      openRouterOnly: true,
+    }),
+  );
 
   (handler as { getStreamingConfig: () => boolean }).getStreamingConfig = () =>
     true;

--- a/src/test-kernel/agent/modelHandlers/CodexEncryptedReasoning.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/CodexEncryptedReasoning.vitest.ts
@@ -1,16 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import {
-  DEFAULT_MODEL_CAPABILITIES,
-  type ModelConfig,
-  ModelProvider,
-  ReasoningEffort,
-} from 'llm-zoo';
+import { type ModelConfig, ModelProvider, ReasoningEffort } from 'llm-zoo';
 
 import type { AgentTrace } from '@agent/trace';
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/openai/modelHandlerOpenAIResponse';
 import { ModelHandlerCodex } from '@agent/modelHandlers/openai/modelHandlerCodex';
 import { AgentCategory } from '@shared/schemas/agent';
 import { setupPlatform } from '@test/support/setupPlatform';
+import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 import type { Response } from 'openai/resources/responses/responses';
 
 function loggerStub(): AgentTrace {
@@ -25,7 +21,7 @@ function loggerStub(): AgentTrace {
 }
 
 function config(): ModelConfig {
-  return {
+  return buildTestModelConfig({
     name: 'gpt-5.5',
     fullName: 'gpt-5.5',
     shortName: 'gpt-5.5',
@@ -38,13 +34,12 @@ function config(): ModelConfig {
     // Codex eligibility comes from the registry's codexSubscription flag
     // (see providerCapabilities.ts), not from tier/naming heuristics.
     capabilities: {
-      ...DEFAULT_MODEL_CAPABILITIES,
       supportsReasoning: true,
       reasoningEffort: ReasoningEffort.XHIGH,
     },
     openRouterOnly: false,
     codexSubscription: true,
-  };
+  });
 }
 
 function baseHandler(): ModelHandlerOpenAIResponse {

--- a/src/test-kernel/agent/modelHandlers/CodexExperimentalTransports.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/CodexExperimentalTransports.vitest.ts
@@ -1,15 +1,11 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import {
-  DEFAULT_MODEL_CAPABILITIES,
-  ModelProvider,
-  ReasoningEffort,
-  type ModelConfig,
-} from 'llm-zoo';
+import { ModelProvider, ReasoningEffort, type ModelConfig } from 'llm-zoo';
 
 import { ModelHandlerCodex } from '@agent/modelHandlers/openai/modelHandlerCodex';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { resetCodexCoordinator } from '@auth/codex';
 import { installPlatform } from '@test/support/setupPlatform';
+import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 
 // Protected/private surface exercised by these tests via a narrow cast.
 interface CodexInternals {
@@ -24,7 +20,7 @@ interface CodexInternals {
 }
 
 function config(): ModelConfig {
-  return {
+  return buildTestModelConfig({
     name: 'gpt-5.5',
     fullName: 'gpt-5.5',
     shortName: 'gpt-5.5',
@@ -37,13 +33,12 @@ function config(): ModelConfig {
     // Codex eligibility comes from the registry's codexSubscription flag
     // (see providerCapabilities.ts), not from tier/naming heuristics.
     capabilities: {
-      ...DEFAULT_MODEL_CAPABILITIES,
       supportsReasoning: true,
       reasoningEffort: ReasoningEffort.XHIGH,
     },
     openRouterOnly: false,
     codexSubscription: true,
-  };
+  });
 }
 
 function initPlatformWith(opts: {

--- a/src/test-kernel/agent/modelHandlers/CodexSubscriptionFallback.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/CodexSubscriptionFallback.vitest.ts
@@ -1,11 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import pDefer from 'p-defer';
-import {
-  DEFAULT_MODEL_CAPABILITIES,
-  ModelProvider,
-  ReasoningEffort,
-  type ModelConfig,
-} from 'llm-zoo';
+import { ModelProvider, ReasoningEffort, type ModelConfig } from 'llm-zoo';
 
 import { ModelHandlerCodex } from '@agent/modelHandlers/openai/modelHandlerCodex';
 import type { ModelCredentialRoute } from '@agent/types/ModelHandlerContracts';
@@ -23,6 +18,7 @@ import {
 } from '@model/providerCapabilities';
 import { AgentCategory } from '@shared/schemas/agent';
 import { installPlatform } from '@test/support/setupPlatform';
+import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 
 import type OpenAI from 'openai';
 import type { ResponseUsage } from 'openai/resources/responses/responses';
@@ -39,7 +35,7 @@ function initFakePlatformWithSubscription(
   });
 }
 
-const config: ModelConfig = {
+const config: ModelConfig = buildTestModelConfig({
   name: 'gpt55-test',
   label: 'GPT-5.5',
   fullName: 'gpt-5.5',
@@ -52,12 +48,11 @@ const config: ModelConfig = {
   // Codex eligibility comes from the registry's codexSubscription flag
   // (see providerCapabilities.ts), not from tier/naming heuristics.
   capabilities: {
-    ...DEFAULT_MODEL_CAPABILITIES,
     reasoningEffort: ReasoningEffort.XHIGH,
   },
   openRouterOnly: false,
   codexSubscription: true,
-};
+});
 
 // gpt-5.5 declares a 1,050,000-token window over the OpenAI API, but the Codex
 // subscription backend enforces a far smaller ceiling — the override must clamp

--- a/src/test-kernel/agent/modelHandlers/GoogleInteractionsLive.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/GoogleInteractionsLive.vitest.ts
@@ -1,14 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import {
-  DEFAULT_MODEL_CAPABILITIES,
-  ModelProvider,
-  type ModelConfig,
-} from 'llm-zoo';
+import { ModelProvider, type ModelConfig } from 'llm-zoo';
 import { GoogleGenAI } from '@google/genai';
 
 import type { AgentTrace } from '@agent/trace';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { ModelHandlerGoogleInteractions } from '@agent/modelHandlers/google/modelHandlerGoogleInteractions';
+import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 import * as configModule from '@utils/config/configUtils';
 import * as providerConfigModule from '@utils/config/providerConfig';
 import type { Interactions } from '@google/genai';
@@ -82,7 +79,7 @@ function recordingClient(real: GoogleGenAI): {
 }
 
 function liveConfig(): ModelConfig {
-  return {
+  return buildTestModelConfig({
     name: 'live-google-interactions',
     label: 'Live Google Interactions',
     fullName: MODEL,
@@ -93,12 +90,11 @@ function liveConfig(): ModelConfig {
     outputPrice: 0,
     contextWindow: 32768,
     capabilities: {
-      ...DEFAULT_MODEL_CAPABILITIES,
       supportsReasoning: false,
       supportsTokenCounting: false, // skip the extra countTokens round-trip
     },
     openRouterOnly: false,
-  };
+  });
 }
 
 function logger(): AgentTrace {

--- a/src/test-kernel/agent/modelHandlers/KimiTokenEstimation.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/KimiTokenEstimation.vitest.ts
@@ -4,17 +4,14 @@ import { strict as assert } from 'node:assert';
 // Third-party imports
 import OpenAI from 'openai';
 import { describe, expect, it, vi } from 'vitest';
-import {
-  DEFAULT_MODEL_CAPABILITIES,
-  type ModelConfig,
-  ModelProvider,
-} from 'llm-zoo';
+import { type ModelConfig, ModelProvider } from 'llm-zoo';
 
 // Local imports - handler under test
 import { ModelHandlerKimi } from '@agent/modelHandlers/openai/modelHandlerKimi';
+import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 
 function buildHandler(): ModelHandlerKimi {
-  const config: ModelConfig = {
+  const config: ModelConfig = buildTestModelConfig({
     name: 'kimi-test',
     label: 'Kimi Test',
     fullName: 'kimi-k2.5',
@@ -24,9 +21,8 @@ function buildHandler(): ModelHandlerKimi {
     inputPrice: 0,
     outputPrice: 0,
     contextWindow: 200000,
-    capabilities: { ...DEFAULT_MODEL_CAPABILITIES },
     openRouterOnly: false,
-  };
+  });
   return new ModelHandlerKimi(config);
 }
 

--- a/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelFactoryRouting.vitest.ts
@@ -4,7 +4,6 @@ import * as path from 'node:path';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
-  DEFAULT_MODEL_CAPABILITIES,
   MODEL_CONFIGS,
   ModelProvider,
   ReasoningEffort,
@@ -42,12 +41,13 @@ import {
 import { AgentCategory } from '@shared/schemas/agent';
 import { installPlatform } from '@test/support/setupPlatform';
 import type { FakePlatformOptions } from '@test/support/FakePlatform';
+import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 
 function modelConfig(
   provider: ModelProvider,
   caps: Partial<ModelConfig['capabilities']> = {},
 ): ModelConfig {
-  return {
+  return buildTestModelConfig({
     name: `test-${provider}`,
     label: `Test ${provider}`,
     fullName: `${provider}-test`,
@@ -57,9 +57,9 @@ function modelConfig(
     inputPrice: 0,
     outputPrice: 0,
     contextWindow: 128000,
-    capabilities: { ...DEFAULT_MODEL_CAPABILITIES, ...caps },
+    capabilities: caps,
     openRouterOnly: false,
-  };
+  });
 }
 
 // installPlatform dynamically imports @platform/platform at call time, so

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponseBackground.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponseBackground.vitest.ts
@@ -1,16 +1,13 @@
 // Third-party imports
 import { strict as assert } from 'node:assert';
 import { describe, it, afterEach, vi } from 'vitest';
-import {
-  DEFAULT_MODEL_CAPABILITIES,
-  type ModelConfig,
-  ModelProvider,
-} from 'llm-zoo';
+import { type ModelConfig, ModelProvider } from 'llm-zoo';
 
 // Local imports - agent
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { ModelHandlerCodex } from '@agent/modelHandlers/openai/modelHandlerCodex';
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/openai/modelHandlerOpenAIResponse';
+import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 import * as configModule from '@utils/config/configUtils';
 
 class UnsupportedBackgroundHandler extends ModelHandlerOpenAIResponse {
@@ -18,7 +15,7 @@ class UnsupportedBackgroundHandler extends ModelHandlerOpenAIResponse {
 }
 
 function createOpenAIConfig(name: string): ModelConfig {
-  return {
+  return buildTestModelConfig({
     name,
     label: name,
     fullName: name,
@@ -28,9 +25,8 @@ function createOpenAIConfig(name: string): ModelConfig {
     inputPrice: 0,
     outputPrice: 0,
     contextWindow: 1000,
-    capabilities: { ...DEFAULT_MODEL_CAPABILITIES },
     openRouterOnly: false,
-  };
+  });
 }
 
 describe('ModelHandlerOpenAIResponse background mode', () => {

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerReasoningCap.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerReasoningCap.vitest.ts
@@ -1,42 +1,39 @@
 // Third-party imports
 import { strict as assert } from 'node:assert';
 import { describe, it, afterEach, vi } from 'vitest';
-import {
-  DEFAULT_MODEL_CAPABILITIES,
-  type ModelConfig,
-  ModelProvider,
-  ReasoningEffort,
-} from 'llm-zoo';
+import { type ModelConfig, ModelProvider, ReasoningEffort } from 'llm-zoo';
 
 // Local imports - handler under test (concrete subclass exercising base-class
 // `getEffectiveReasoningEffort` — OpenRouterNative does not override it)
 import { ModelHandlerOpenRouterNative } from '@agent/modelHandlers/openrouter/modelHandlerOpenRouterNative';
 import { FREE_TIER, MAX_TIER, ULTRA_TIER } from '@auth/config';
+import * as serverKeysModule from '@auth/serverKeys';
+import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 
 // Modules to stub via vi.spyOn
-import * as serverKeysModule from '@auth/serverKeys';
 import * as providerConfigModule from '@utils/config/providerConfig';
 
 function buildGpt5Config(overrides: Partial<ModelConfig> = {}): ModelConfig {
-  return {
-    name: 'gpt5-mini',
-    label: 'GPT-5 Mini',
-    fullName: 'gpt-5-mini-2025-08-15',
-    shortName: 'gpt5-mini',
-    provider: ModelProvider.OPENAI,
-    maxOutputTokens: 16384,
-    inputPrice: 0,
-    outputPrice: 0,
-    contextWindow: 200000,
-    capabilities: {
-      ...DEFAULT_MODEL_CAPABILITIES,
-      supportsReasoningEffort: true,
-      reasoningEffort: ReasoningEffort.XHIGH,
+  return buildTestModelConfig(
+    {
+      name: 'gpt5-mini',
+      label: 'GPT-5 Mini',
+      fullName: 'gpt-5-mini-2025-08-15',
+      shortName: 'gpt5-mini',
+      provider: ModelProvider.OPENAI,
+      maxOutputTokens: 16384,
+      inputPrice: 0,
+      outputPrice: 0,
+      contextWindow: 200000,
+      capabilities: {
+        supportsReasoningEffort: true,
+        reasoningEffort: ReasoningEffort.XHIGH,
+      },
+      openRouterOnly: false,
+      openrouterFullName: 'openai/gpt-5-mini',
     },
-    openRouterOnly: false,
-    openrouterFullName: 'openai/gpt-5-mini',
-    ...overrides,
-  };
+    overrides,
+  );
 }
 
 describe('ModelHandler.getEffectiveReasoningEffort tier caps', () => {

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerVscodeLm.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerVscodeLm.vitest.ts
@@ -2,11 +2,7 @@
 import { Buffer } from 'node:buffer';
 
 // Third-party imports
-import {
-  DEFAULT_MODEL_CAPABILITIES,
-  ModelProvider,
-  type ModelConfig,
-} from 'llm-zoo';
+import { ModelProvider, type ModelConfig } from 'llm-zoo';
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
@@ -29,12 +25,13 @@ import {
   type LanguageModelResponsePart,
 } from '@platform/languageModel';
 import { isCredentialExhausted, type FileLocation } from '@shared/schemas';
+import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 
 function modelConfig(
   supportsFunctionCalling = true,
   supportsVision = true,
 ): ModelConfig {
-  return {
+  return buildTestModelConfig({
     name: 'copilot-test',
     label: 'Copilot Test',
     fullName: 'copilot-model-id',
@@ -45,13 +42,12 @@ function modelConfig(
     outputPrice: 0,
     contextWindow: 128_000,
     capabilities: {
-      ...DEFAULT_MODEL_CAPABILITIES,
       supportsFunctionCalling,
       supportsVision,
       supportsNativeAudio: true,
     },
     openRouterOnly: false,
-  };
+  });
 }
 
 const IMAGE_LOCATION: FileLocation = {

--- a/src/test-kernel/agent/modelHandlers/OpenAIRelayStreamCorrelation.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIRelayStreamCorrelation.vitest.ts
@@ -1,6 +1,6 @@
 // Third-party imports
 import OpenAI from 'openai';
-import { DEFAULT_MODEL_CAPABILITIES, ModelProvider } from 'llm-zoo';
+import { ModelProvider } from 'llm-zoo';
 import { describe, expect, it } from 'vitest';
 
 // Local imports
@@ -10,6 +10,7 @@ import {
   isUserAbort,
   normalizeProviderError,
 } from '@common/errors/sdkErrorUtils';
+import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 
 class TestModelHandlerOpenAI extends ModelHandlerOpenAI {
   runStreaming(client: OpenAI, signal?: AbortSignal) {
@@ -25,23 +26,24 @@ class TestModelHandlerOpenAI extends ModelHandlerOpenAI {
 }
 
 function createHandler(): TestModelHandlerOpenAI {
-  const handler = new TestModelHandlerOpenAI({
-    name: 'test-openai',
-    label: 'Test OpenAI',
-    fullName: 'gpt-test',
-    shortName: 'gpt-test',
-    provider: ModelProvider.OPENAI,
-    maxOutputTokens: 1024,
-    inputPrice: 0,
-    outputPrice: 0,
-    contextWindow: 128_000,
-    capabilities: {
-      ...DEFAULT_MODEL_CAPABILITIES,
-      supportsReasoning: false,
-      supportsTokenCounting: false,
-    },
-    openRouterOnly: true,
-  });
+  const handler = new TestModelHandlerOpenAI(
+    buildTestModelConfig({
+      name: 'test-openai',
+      label: 'Test OpenAI',
+      fullName: 'gpt-test',
+      shortName: 'gpt-test',
+      provider: ModelProvider.OPENAI,
+      maxOutputTokens: 1024,
+      inputPrice: 0,
+      outputPrice: 0,
+      contextWindow: 128_000,
+      capabilities: {
+        supportsReasoning: false,
+        supportsTokenCounting: false,
+      },
+      openRouterOnly: true,
+    }),
+  );
   handler.setLogger(noopTrace);
   return handler;
 }

--- a/src/test-kernel/agent/modelHandlers/OpenAIResponseBackgroundAbort.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIResponseBackgroundAbort.vitest.ts
@@ -1,6 +1,6 @@
 // Third-party imports
 import { APIUserAbortError } from 'openai';
-import { DEFAULT_MODEL_CAPABILITIES, ModelProvider } from 'llm-zoo';
+import { ModelProvider } from 'llm-zoo';
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
@@ -9,24 +9,26 @@ import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/openai/modelHan
 import { tagOpenAISdkError } from '@agent/modelHandlers/openai/openAISdkError';
 import { BackgroundPoller } from '@agent/modelHandlers/support/BackgroundPoller';
 import { isUserAbort } from '@common/errors/sdkErrorUtils';
+import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 
 // Third-party imports
 import type OpenAI from 'openai';
 
 function createHandler(): ModelHandlerOpenAIResponse {
-  const handler = new ModelHandlerOpenAIResponse({
-    name: 'test-gpt',
-    label: 'Test GPT',
-    fullName: 'gpt-test',
-    shortName: 'gpt-test',
-    provider: ModelProvider.OPENAI,
-    maxOutputTokens: 1024,
-    inputPrice: 0,
-    outputPrice: 0,
-    contextWindow: 200000,
-    capabilities: { ...DEFAULT_MODEL_CAPABILITIES },
-    openRouterOnly: false,
-  });
+  const handler = new ModelHandlerOpenAIResponse(
+    buildTestModelConfig({
+      name: 'test-gpt',
+      label: 'Test GPT',
+      fullName: 'gpt-test',
+      shortName: 'gpt-test',
+      provider: ModelProvider.OPENAI,
+      maxOutputTokens: 1024,
+      inputPrice: 0,
+      outputPrice: 0,
+      contextWindow: 200000,
+      openRouterOnly: false,
+    }),
+  );
   handler.setLogger({
     streamId: 'test',
     debug: vi.fn(),

--- a/src/test-kernel/auth/SupabaseClient.vitest.ts
+++ b/src/test-kernel/auth/SupabaseClient.vitest.ts
@@ -13,14 +13,7 @@ import {
 } from '@auth/relayToken';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import type { AuthTokenProvider } from '@auth/TokenProvider';
-
-function createDeferred(): { promise: Promise<void>; resolve: () => void } {
-  let resolve!: () => void;
-  const promise = new Promise<void>((resolvePromise) => {
-    resolve = resolvePromise;
-  });
-  return { promise, resolve };
-}
+import { createDeferred } from '@test/support/asyncTestUtils';
 
 async function withRelayTokenEnv(
   token: string,

--- a/src/test-kernel/auth/SupabaseSessionLifecycle.vitest.ts
+++ b/src/test-kernel/auth/SupabaseSessionLifecycle.vitest.ts
@@ -12,6 +12,7 @@ import {
   type SupabaseSessionStorage,
 } from '@auth/SupabaseSession';
 import { fetchWithTimeout } from '@auth/fetchWithTimeout';
+import { createDeferred } from '@test/support/asyncTestUtils';
 
 // Third-party imports
 import type {
@@ -78,17 +79,6 @@ function createClient(overrides?: Partial<Client['auth']>): Client {
       ...overrides,
     },
   } as unknown as Client;
-}
-
-function createDeferred(): {
-  promise: Promise<void>;
-  resolve: () => void;
-} {
-  let resolve!: () => void;
-  const promise = new Promise<void>((innerResolve) => {
-    resolve = innerResolve;
-  });
-  return { promise, resolve };
 }
 
 const COORDINATOR_CONFIG = {

--- a/src/test-kernel/desktop/DesktopAppLog.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAppLog.vitest.mts
@@ -1,14 +1,14 @@
 // Node imports
 import { Buffer } from 'node:buffer';
 import { randomUUID } from 'node:crypto';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 // Third-party imports
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - test support
+import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
 import {
   configureElectronTestStub,
   resetElectronTestStub,
@@ -36,20 +36,11 @@ describe('desktop app log', () => {
   afterEach(async () => {
     resetElectronTestStub();
     vi.restoreAllMocks();
-    const pathsToRemove = [...new Set(tempDirs.splice(0))];
-    await Promise.all(
-      pathsToRemove.map((path) => rm(path, { recursive: true, force: true })),
-    );
+    await cleanupTempDirs(tempDirs);
   });
 
-  async function makeTempDir(prefix: string): Promise<string> {
-    const tempDir = await mkdtemp(join(tmpdir(), prefix));
-    tempDirs.push(tempDir);
-    return tempDir;
-  }
-
   it('does not abort startup when the logs directory cannot be created', async () => {
-    const root = await makeTempDir('texra-electron-log-');
+    const root = await makeTempDir('texra-electron-log-', tempDirs);
     const userDataFile = join(root, 'userData-file');
     await writeFile(userDataFile, '');
     configureElectronTestStub({ userDataPath: userDataFile });
@@ -65,7 +56,7 @@ describe('desktop app log', () => {
   });
 
   it('truncates viewer snapshots by bytes and redacts log paths', async () => {
-    const root = await makeTempDir('texra-electron-log-');
+    const root = await makeTempDir('texra-electron-log-', tempDirs);
     const userDataPath = join(root, 'userData');
     const logsPath = join(userDataPath, 'logs');
     const logPath = join(logsPath, 'texra-desktop.log');

--- a/src/test-kernel/desktop/DesktopPreviewHost.vitest.mts
+++ b/src/test-kernel/desktop/DesktopPreviewHost.vitest.mts
@@ -1,9 +1,12 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import {
+  cleanupTempDirs,
+  makeTempDir as makeSharedTempDir,
+} from '@test/support/tempDirPlatform';
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
 
 interface DesktopPreviewHostModule {
@@ -58,16 +61,11 @@ describe('desktop preview host', () => {
     vi.doUnmock('@latex/latexToolchain');
     vi.doUnmock('node:fs/promises');
     vi.restoreAllMocks();
-    const dirs = tempDirs.splice(0);
-    await Promise.all(
-      dirs.map((dir) => rm(dir, { recursive: true, force: true })),
-    );
+    await cleanupTempDirs(tempDirs);
   });
 
   async function makeTempDir(): Promise<string> {
-    const dir = await mkdtemp(path.join(tmpdir(), 'texra-preview-host-'));
-    tempDirs.push(dir);
-    return dir;
+    return makeSharedTempDir('texra-preview-host-', tempDirs);
   }
 
   async function makeOverlayFixture(): Promise<{

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -8,6 +8,7 @@ import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
 import { DEFAULT_GIT_MARK_COMMITS } from '@shared/schemas/stateSettings';
 import { FakeStateStore } from '@test/support/FakePlatform';
 import { setupPlatform } from '@test/support/setupPlatform';
+import { createDeferred } from '@test/support/asyncTestUtils';
 import {
   isWorktreeSupportEnabled,
   setWorktreeSupportEnabled,
@@ -183,17 +184,6 @@ function flushAsyncWork(): Promise<void> {
   return new Promise((resolve) =>
     setImmediate(() => setImmediate(() => resolve())),
   );
-}
-
-function createDeferred(): {
-  promise: Promise<void>;
-  resolve(): void;
-} {
-  let resolve!: () => void;
-  const promise = new Promise<void>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
 }
 
 function commandOf(message: unknown): string | undefined {

--- a/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
@@ -20,6 +20,7 @@ import {
   type DesktopSupabaseAuthHost,
 } from '@desktop/main/desktopSupabaseAuth';
 import type { StateStore } from '@platform/interfaces';
+import { createDeferred } from '@test/support/asyncTestUtils';
 
 function createCoordinator() {
   const storedSession: { current: SupabaseSession | null } = { current: null };
@@ -153,14 +154,6 @@ function nonceFor(oauthClient: ReturnType<typeof createOAuthClient>): string {
   const redirectTo = call?.options?.redirectTo ?? '';
   const callback = parseDesktopProtocolCallback(redirectTo);
   return new URLSearchParams(callback?.query).get('app_nonce') ?? '';
-}
-
-function createDeferred<T>() {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((res) => {
-    resolve = res;
-  });
-  return { promise, resolve };
 }
 
 function installAuthenticatedSupabaseProvider() {

--- a/src/test-kernel/desktop/ElectronCompositionRoot.vitest.mts
+++ b/src/test-kernel/desktop/ElectronCompositionRoot.vitest.mts
@@ -1,20 +1,14 @@
 // Node imports
 import { execFileSync } from 'node:child_process';
-import {
-  mkdir,
-  mkdtemp,
-  readFile,
-  readdir,
-  rm,
-  writeFile,
-} from 'node:fs/promises';
-import { homedir, tmpdir } from 'node:os';
+import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
 import { join, relative, resolve } from 'node:path';
 
 // Third-party imports
 import { afterEach, describe, expect, it } from 'vitest';
 
 // Local imports - test support
+import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
 import {
   DESKTOP_SRC_DIR,
   REPO_ROOT,
@@ -98,18 +92,11 @@ function trackedTypeScriptConsumers(identifier: string): string[] {
 }
 
 describe('desktop composition root and launch environment', () => {
-  let tempDir: string | undefined;
+  const tempDirs: string[] = [];
 
   afterEach(async () => {
-    if (tempDir == null) return;
-    await rm(tempDir, { recursive: true, force: true });
-    tempDir = undefined;
+    await cleanupTempDirs(tempDirs);
   });
-
-  async function makeTempDir(): Promise<string> {
-    tempDir = await mkdtemp(join(tmpdir(), 'texra-electron-root-'));
-    return tempDir;
-  }
 
   async function createResourceTree(resourcesPath: string): Promise<void> {
     await Promise.all([
@@ -381,7 +368,7 @@ describe('desktop composition root and launch environment', () => {
   it('finds resources in configured, packaged, and monorepo development layouts', async () => {
     const { resolveResourcesPath } =
       await loadDesktopPlatformModule<PathsModule>('paths.ts');
-    const root = await makeTempDir();
+    const root = await makeTempDir('texra-electron-root-', tempDirs);
     const configuredResources = join(root, 'configured-resources');
     const appResources = join(root, 'app', 'resources');
     const packagedResources = join(root, 'electron-resources', 'resources');
@@ -430,7 +417,7 @@ describe('desktop composition root and launch environment', () => {
   it('requires bundled agent sources to be directories', async () => {
     const { resolveResourcesPath } =
       await loadDesktopPlatformModule<PathsModule>('paths.ts');
-    const root = await makeTempDir();
+    const root = await makeTempDir('texra-electron-root-', tempDirs);
     const incompleteResources = join(root, 'configured-resources');
     const fileBackedResources = join(root, 'file-backed-resources');
     const monorepoResources = join(root, 'packages', 'extension', 'resources');
@@ -462,7 +449,7 @@ describe('desktop composition root and launch environment', () => {
   it('throws with every checked resource candidate when resources are missing', async () => {
     const { resolveResourcesPath } =
       await loadDesktopPlatformModule<PathsModule>('paths.ts');
-    const root = await makeTempDir();
+    const root = await makeTempDir('texra-electron-root-', tempDirs);
     const mainDirname = join(root, 'packages', 'desktop', 'dist', 'main');
 
     expect(() =>

--- a/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
+++ b/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
@@ -12,6 +12,7 @@ import { AgentCategory } from '@shared/schemas/agent';
 import { AGENT_MODE_PRESETS } from '@shared/schemas/agentPresets';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
+import { createDeferred } from '@test/support/asyncTestUtils';
 
 // Local imports - desktop test paths
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
@@ -115,17 +116,6 @@ function flushAsyncWork(): Promise<void> {
   return new Promise((resolve) =>
     setImmediate(() => setImmediate(() => resolve())),
   );
-}
-
-function createDeferred(): {
-  promise: Promise<void>;
-  resolve(): void;
-} {
-  let resolve!: () => void;
-  const promise = new Promise<void>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
 }
 
 type RendererListener = (event: { sender: unknown }, message: unknown) => void;

--- a/src/test-kernel/desktop/ElectronPlatformAdapters.vitest.mts
+++ b/src/test-kernel/desktop/ElectronPlatformAdapters.vitest.mts
@@ -1,13 +1,5 @@
 // Node imports
-import {
-  mkdir,
-  mkdtemp,
-  readFile,
-  rm,
-  stat,
-  writeFile,
-} from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 // Third-party imports
@@ -20,6 +12,10 @@ import {
 } from '@platform/defaults/workspaceStorage';
 
 // Local imports - test support
+import {
+  cleanupTempDirs,
+  makeTempDir as makeSharedTempDir,
+} from '@test/support/tempDirPlatform';
 import {
   app as electronApp,
   configureElectronTestStub,
@@ -107,16 +103,11 @@ describe('desktop platform adapters', () => {
     if (stubUserDataPath != null) tempDirs.push(stubUserDataPath);
     resetElectronTestStub();
     vi.restoreAllMocks();
-    const pathsToRemove = [...new Set(tempDirs.splice(0))];
-    await Promise.all(
-      pathsToRemove.map((path) => rm(path, { recursive: true, force: true })),
-    );
+    await cleanupTempDirs(tempDirs);
   });
 
   async function makeTempDir(prefix: string): Promise<string> {
-    const tempDir = await mkdtemp(join(tmpdir(), prefix));
-    tempDirs.push(tempDir);
-    return tempDir;
+    return makeSharedTempDir(prefix, tempDirs);
   }
 
   async function loadSecrets(

--- a/src/test-kernel/model/ApiProviders.vitest.ts
+++ b/src/test-kernel/model/ApiProviders.vitest.ts
@@ -13,6 +13,7 @@ import {
   type ApiProvider,
 } from '@model/apiProviders';
 import type { PlatformSecrets } from '@platform/secrets';
+import { createDeferred } from '@test/support/asyncTestUtils';
 import { UnsetApiKeyTool } from '@tools/setup/UnsetApiKeyTool';
 import { setSetupPlatform } from '@tools/setup/platform';
 
@@ -64,17 +65,6 @@ function createSecrets(
       },
     },
   };
-}
-
-function createDeferred<T>(): {
-  promise: Promise<T>;
-  resolve: (value: T) => void;
-} {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
 }
 
 function setupApiKeyToolPlatform(

--- a/src/test-kernel/modelHandlers/ModelHandlerGoogle.vitest.ts
+++ b/src/test-kernel/modelHandlers/ModelHandlerGoogle.vitest.ts
@@ -9,26 +9,28 @@ import {
   createPartFromText,
   type Content,
 } from '@google/genai';
-import { DEFAULT_MODEL_CAPABILITIES, ModelProvider } from 'llm-zoo';
+import { ModelProvider } from 'llm-zoo';
 
 // Local imports - agent
 import type { AgentSetting } from '@agent/core/definition/AgentDataclass';
 import { ModelHandlerGoogleGenAI } from '@agent/modelHandlers/google/modelHandlerGoogleGenAI';
+import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 
 function createGoogleHandler(): ModelHandlerGoogleGenAI {
-  return new ModelHandlerGoogleGenAI({
-    name: 'test-google-model',
-    label: 'Test Google Model',
-    fullName: 'google/test',
-    shortName: 'google/test',
-    provider: ModelProvider.GOOGLE,
-    maxOutputTokens: 1024,
-    inputPrice: 0,
-    outputPrice: 0,
-    contextWindow: 4096,
-    capabilities: { ...DEFAULT_MODEL_CAPABILITIES },
-    openRouterOnly: false,
-  });
+  return new ModelHandlerGoogleGenAI(
+    buildTestModelConfig({
+      name: 'test-google-model',
+      label: 'Test Google Model',
+      fullName: 'google/test',
+      shortName: 'google/test',
+      provider: ModelProvider.GOOGLE,
+      maxOutputTokens: 1024,
+      inputPrice: 0,
+      outputPrice: 0,
+      contextWindow: 4096,
+      openRouterOnly: false,
+    }),
+  );
 }
 
 describe('ModelHandlerGoogleGenAI.shouldContinue', () => {

--- a/src/test-kernel/support/asyncTestUtils.ts
+++ b/src/test-kernel/support/asyncTestUtils.ts
@@ -51,3 +51,15 @@ export async function waitForRecordedEvent<TEvent extends string>(
   }
   throw new Error(`Timed out waiting for ${eventName}`);
 }
+
+/** Create a promise together with the resolver that settles it, for tests that need to control timing externally. */
+export function createDeferred<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}

--- a/src/test-kernel/support/tempDirPlatform.ts
+++ b/src/test-kernel/support/tempDirPlatform.ts
@@ -16,6 +16,19 @@ import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 import { createFakePlatform } from './FakePlatform';
 
 /**
+ * Creates a fresh temp directory and records it on `tempDirs` for later
+ * cleanup via `cleanupTempDirs`.
+ */
+export async function makeTempDir(
+  prefix: string,
+  tempDirs: string[],
+): Promise<string> {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(tempDir);
+  return tempDir;
+}
+
+/**
  * Creates a node-backed `FakePlatform` rooted in a fresh temp directory
  * (`<tempDir>/workspace` and `<tempDir>/storage`), and records the temp
  * directory on `tempDirs` for later cleanup via `cleanupTempDirs`.
@@ -24,8 +37,7 @@ export async function createTempDirPlatform(
   prefix: string,
   tempDirs: string[],
 ): Promise<Platform> {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.push(tempDir);
+  const tempDir = await makeTempDir(prefix, tempDirs);
   const workspaceDir = path.join(tempDir, 'workspace');
   const storageRoot = path.join(tempDir, 'storage');
   return createFakePlatform(

--- a/src/test-kernel/support/tempDirPlatform.ts
+++ b/src/test-kernel/support/tempDirPlatform.ts
@@ -54,7 +54,8 @@ export async function createTempDirPlatform(
 
 /** Removes every directory recorded by `createTempDirPlatform` (or pushed manually), then clears the list. */
 export async function cleanupTempDirs(tempDirs: string[]): Promise<void> {
+  const uniqueDirs = [...new Set(tempDirs.splice(0))];
   await Promise.all(
-    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+    uniqueDirs.map((dir) => rm(dir, { recursive: true, force: true })),
   );
 }


### PR DESCRIPTION
## Summary

Scheduled consolidation audit (`debt-audit`) flagged three independently-corroborated instances of hand-rolled test logic duplicating an existing shared utility. This PR lands the three that verified as genuine net gains at low risk; a fourth candidate (replacing `jsonStore.ts`'s `writeChains` promise-chain with the repo's `PQueue`-per-key idiom) was investigated but verified as a `WASH` (net +2 LoC, 0 element reduction) once the actual replacement body was reconstructed, so it was not included.

1. **`createDeferred()` dedup** — 7 vitest files each independently reimplemented the same "promise + captured external resolve" primitive with no shared export anywhere in the tree. Consolidated onto one generic export in `src/test-kernel/support/asyncTestUtils.ts`, which already holds `waitForCondition`/`pollForCondition`/`waitForRecordedEvent` as the established home for shared async test primitives.
2. **Desktop temp-dir helper dedup** — 4 desktop vitest files each independently reimplemented mkdtemp-and-track-for-cleanup next to `tempDirPlatform.ts`, whose `cleanupTempDirs()` export was already built for exactly this pairing. Added a matching `makeTempDir()` export and adopted it at all four call sites, including the two that needed real adaptation (`ElectronCompositionRoot` tracked a single `tempDir` variable rather than an array; `ElectronPlatformAdapters` pushes an extra `userDataPath` entry into the shared array).
3. **`ModelConfig` test-literal dedup** — 15 `modelHandlers` vitest files hand-rolled the same 10-field `ModelConfig` literal that `buildTestModelConfig()` (`src/test-kernel/support/modelConfigTestUtils.ts`) already covers and that 25 sibling files in the same directories already call. Swapped each literal for a `buildTestModelConfig(...)` call, dropping `capabilities` blocks that only spread `DEFAULT_MODEL_CAPABILITIES` with no overrides since the builder already defaults to it.

All changes are test-only; no production code paths were touched.

## Issue acceptance gates

No linked issue — this is a scheduled autonomous consolidation-audit routine. Acceptance gate: identify duplicate/custom-vs-native logic, verify each candidate is a genuine net gain, implement the verified ones, keep production code untouched.

## Single source of truth

- `createDeferred()` → `src/test-kernel/support/asyncTestUtils.ts` (new export, joining `waitForCondition`/`pollForCondition`/`waitForRecordedEvent`).
- `makeTempDir()` → `src/test-kernel/support/tempDirPlatform.ts` (new export, joining the existing `createTempDirPlatform`/`cleanupTempDirs`; `createTempDirPlatform` now calls `makeTempDir` internally instead of duplicating the `mkdtemp` + push logic).
- `ModelConfig` test fixtures → `buildTestModelConfig()` in `src/test-kernel/support/modelConfigTestUtils.ts` (pre-existing, now the sole source across all 40 modelHandlers test files instead of 25/40).

## Duplication and abstraction budget

Removed: 7 duplicate `createDeferred` function declarations, 4 duplicate mkdtemp+cleanup blocks, 15 duplicate 10-field `ModelConfig` literals. No new abstractions were introduced beyond the two small generic exports named above, both of which slot into an established "shared test-support home" pattern already in use at the same files.

## Net elements (R6)

- Files changed: 28 (diffstat: `228 insertions(+), 323 deletions(-)`, net −95 LoC)
- Exported symbols added: 2 (`createDeferred` in `asyncTestUtils.ts`, `makeTempDir` in `tempDirPlatform.ts`)
- Exported symbols removed: 0 (all removed `createDeferred`/temp-dir helpers were file-local, non-exported)
- Classes/interfaces/enums added or removed: 0

## Consumer counts (R8)

n/a — no emit path or export was deleted/re-routed; only new additive exports and internal test-file call-site swaps.

## Host impact

Extension: none (test-only)

Desktop: none (test-only — desktop *test* files were touched, no `packages/desktop/src` production code)

CLI: none (test-only)

## Scheduled refactoring

None. (The investigated-but-rejected `jsonStore.ts` `writeChains` → `PQueue` migration remains the standing target already named in `CLAUDE.md`/`AGENTS.md` — not addressed here since it verified as a wash, not a net gain, once the concrete replacement was reconstructed.)

## Validation

- `npx tsc --noEmit -p .` — clean, zero errors
- `npx eslint` on all 28 touched files — clean (one `import/order` autofix applied)
- `npx vitest run` scoped to all 26 touched test files — all passing (166 + 127 tests passed, 4 pre-existing live-only skips unaffected)
- `npm run check:dead-code-ratchet` — no new unused files/exports/types

---
_Generated by [Claude Code](https://claude.ai/code/session_01LPWwsTHj4vxnDcxyXQcAHc)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test code and shared test utilities; no runtime, auth, or model routing behavior is modified.
> 
> **Overview**
> **Test-only refactor** that removes repeated helpers across vitest suites and routes them through existing test-support modules (~95 fewer lines, no production changes).
> 
> Adds **`createDeferred`** to `asyncTestUtils.ts` and replaces seven file-local copies (agent registry, Supabase/auth, desktop IPC, API providers). Adds **`makeTempDir`** to `tempDirPlatform.ts` (used by `createTempDirPlatform` internally); four desktop tests now call it with **`cleanupTempDirs`**, which also **dedupes** paths before `rm`. **Fifteen** model-handler tests build fixtures via **`buildTestModelConfig`** instead of hand-rolled `ModelConfig` literals and redundant `DEFAULT_MODEL_CAPABILITIES` spreads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3befbf451073f20d9c5b02a67d7cf58fda9c9308. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->