### PR TITLE
refactor: collapse duplicated serialization, model-trait, and dialog logic

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -398,6 +398,33 @@ function createWindow(options: {
   const showInfoMessage = async (message: string) => {
     await dialog.showMessageBox(window, { type: 'info', message });
   };
+  /**
+   * Sole owner of the "team has unavailable hosted members" prompt. Both the
+   * main-view launch path and the settings path route here so the two can't
+   * drift apart in wording or button labels again.
+   */
+  const chooseTeamAvailability = async (
+    unavailableNames: readonly string[],
+    presetName?: string,
+  ): Promise<'sign-in' | 'continue' | 'cancel'> => {
+    const { response } = await dialog.showMessageBox(window, {
+      type: 'warning',
+      message: formatUnavailableTeamMembersMessage(
+        unavailableNames,
+        presetName,
+      ),
+      buttons: [
+        TEAM_LAUNCH_SIGN_IN_LABEL,
+        TEAM_LAUNCH_CONTINUE_LABEL,
+        TEAM_LAUNCH_CANCEL_LABEL,
+      ],
+      defaultId: 0,
+      cancelId: 2,
+    });
+    if (response === 0) return 'sign-in';
+    if (response === 1) return 'continue';
+    return 'cancel';
+  };
   // Lightweight update check (issue #7682, arm b): at most once/day, notifies
   // at most once per release via a native dialog linking to the GitHub
   // release page. Not a full updater — no download, no install, no feed
@@ -475,6 +502,15 @@ function createWindow(options: {
     }
     ipc.postToRenderer(message);
     return true;
+  };
+  /**
+   * Fire-and-forget post for controllers that don't act on delivery. The
+   * bridge's own `webContents.isDestroyed()` no-op (see above) is the guard
+   * here; only callers that branch on delivery need
+   * {@link postToRendererIfAlive}.
+   */
+  const postToRenderer = (message: unknown): void => {
+    ipcRef.current?.postToRenderer(message);
   };
   const previewHost = createDesktopPreviewHost({
     shell,
@@ -613,22 +649,8 @@ function createWindow(options: {
       });
       return result.response === 0;
     },
-    chooseTeamAvailability: async (unavailableNames) => {
-      const result = await dialog.showMessageBox(window, {
-        type: 'warning',
-        message: formatUnavailableTeamMembersMessage(unavailableNames),
-        buttons: [
-          TEAM_LAUNCH_SIGN_IN_LABEL,
-          TEAM_LAUNCH_CONTINUE_LABEL,
-          TEAM_LAUNCH_CANCEL_LABEL,
-        ],
-        defaultId: 0,
-        cancelId: 2,
-      });
-      if (result.response === 0) return 'sign-in';
-      if (result.response === 1) return 'continue';
-      return 'cancel';
-    },
+    chooseTeamAvailability: (unavailableNames) =>
+      chooseTeamAvailability(unavailableNames),
     signInForRemoteAgentCatalog,
     showInfoMessage,
     showErrorMessage,
@@ -681,7 +703,7 @@ function createWindow(options: {
     return agentExecutionLoad;
   };
   const fileSelection = createDesktopFileSelection({
-    postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
+    postToRenderer,
     showOpenFileDialog: async (options) => {
       const result = await dialog.showOpenDialog(window, {
         title: options.title,
@@ -736,26 +758,12 @@ function createWindow(options: {
       },
     },
     renderer: {
-      postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
+      postToRenderer,
     },
     prompts: {
       promptText: (input) => promptController.request(input),
-      chooseTeamAvailability: async ({ presetName, unavailableNames }) => {
-        const result = await dialog.showMessageBox(window, {
-          type: 'warning',
-          message: `Team "${presetName}" has unavailable TeXRA-hosted members: ${unavailableNames.join(', ')}.`,
-          buttons: [
-            'Sign in to TeXRA',
-            'Continue with available members',
-            'Cancel',
-          ],
-          defaultId: 0,
-          cancelId: 2,
-        });
-        if (result.response === 0) return 'sign-in';
-        if (result.response === 1) return 'continue';
-        return 'cancel';
-      },
+      chooseTeamAvailability: ({ presetName, unavailableNames }) =>
+        chooseTeamAvailability(unavailableNames, presetName),
     },
     remoteCatalog: {
       canAccess: () => SupabaseClient.canAccessRemoteAgentCatalog(),
@@ -770,7 +778,7 @@ function createWindow(options: {
       config: platform().config,
       secrets: platform().secrets,
       renderer: {
-        postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
+        postToRenderer,
       },
       prompt: {
         input: (input) =>
@@ -850,7 +858,7 @@ function createWindow(options: {
       workspaceState: platform().workspaceState,
       globalState: platform().globalState,
       renderer: {
-        postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
+        postToRenderer,
       },
       dashboard: {
         buildItems: buildDefaultToolDashboardItems,
@@ -885,7 +893,7 @@ function createWindow(options: {
       state: platform().globalState,
       secrets: platform().secrets,
       renderer: {
-        postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
+        postToRenderer,
       },
       prompt: {
         input: (input) =>
@@ -919,7 +927,7 @@ function createWindow(options: {
   };
   const historySettingsController = new DesktopHistoryHandlers({
     resourcesPath: options.resourcesPath,
-    postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
+    postToRenderer,
     // Rerun and restore use the same host-neutral owners as the extension,
     // reached through the desktop execution bridge instead of VS Code commands.
     runExecution: (request) =>
@@ -957,7 +965,7 @@ function createWindow(options: {
     reportAsyncError(error);
   }
   const settingsIpc = createDesktopSettingsIpc({
-    postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
+    postToRenderer,
     agentSettingsController,
     crashReportingSettingsController,
     credentialSettingsController,
@@ -996,7 +1004,7 @@ function createWindow(options: {
     openOnboardingReadyGate = resolve;
   });
   const onboardingIpc = createDesktopOnboardingIpc(
-    { postToRenderer: (message) => ipcRef.current?.postToRenderer(message) },
+    { postToRenderer },
     {
       hasCredential: probeCredential,
       readyGate: onboardingReadyGate,
@@ -1125,7 +1133,7 @@ function createWindow(options: {
     onError: reportAsyncError,
   });
   const shellActions = createDesktopShellActions(
-    { postToRenderer: (message) => ipcRef.current?.postToRenderer(message) },
+    { postToRenderer },
     {
       getCustomAgentDirectory: () => platform().agentDirectories.custom(),
       openExternalUrl: previewHost.openExternal,

--- a/src/agent/modelHandlers/anthropic/anthropicThinking.ts
+++ b/src/agent/modelHandlers/anthropic/anthropicThinking.ts
@@ -43,60 +43,143 @@ const THINKING_TEMPERATURE_EXCLUDED_PATTERNS = [
   'claude-mythos-',
 ];
 
-const isClaudeOpus46 = (fullName: string): boolean =>
-  fullName.startsWith(OPUS_46_FULLNAME);
-
-const isClaudeOpus47 = (fullName: string): boolean =>
-  fullName.startsWith(OPUS_47_FULLNAME);
-
-const isClaudeOpus48 = (fullName: string): boolean =>
-  fullName.startsWith(OPUS_48_FULLNAME);
-
-const isClaudeOpus5 = (fullName: string): boolean =>
-  fullName.startsWith(OPUS_5_FULLNAME);
-
-const isClaudeSonnet46 = (fullName: string): boolean =>
-  fullName.startsWith(SONNET_46_FULLNAME);
-
-const isClaudeSonnet5 = (fullName: string): boolean =>
-  fullName.startsWith(SONNET_5_FULLNAME);
+/** Per-family request traits, selected by `fullName` prefix. */
+interface AnthropicModelTraits {
+  /** Adaptive thinking via the effort parameter, rather than budget_tokens. */
+  adaptiveThinking: boolean;
+  /** Anthropic's native server-side context compaction. */
+  compactionEligible: boolean;
+  /**
+   * Highest effort tier the family accepts. `'xhigh'` families take the
+   * distinct "extra" tier the SDK added in 0.100.0; `'max'` families predate
+   * that split and fold a requested `xhigh` into `max`; `'high'` families cap
+   * there.
+   */
+  maxEffort: NonNullable<BetaOutputConfig['effort']> &
+    ('high' | 'max' | 'xhigh');
+  /**
+   * Whether `display: 'summarized'` must be requested. These families default
+   * to `'omitted'`, which would suppress reasoning output entirely.
+   */
+  summarizedDisplay: boolean;
+}
 
 /**
- * Mythos-class models (Fable 5 and Mythos 5) share one request surface: adaptive
- * thinking is always on, manual budget_tokens and `thinking: {type: "disabled"}`
- * both return 400, raw chain-of-thought is never returned (display defaults to
- * "omitted"), and sampling parameters are rejected. They also support the same
- * effort tiers as Opus 4.8 and Opus 5 (including the distinct "xhigh").
+ * One row per model family, replacing the five hand-maintained boolean chains
+ * these traits used to be spread across. Adding a model is a single new row
+ * instead of an edit to every predicate that happens to list its siblings —
+ * the drift mode that made the old chains easy to get subtly wrong.
+ *
+ * Mythos-class models (Fable 5, Mythos 5) share one request surface: adaptive
+ * thinking is always on, manual budget_tokens and `thinking: {type:
+ * "disabled"}` both return 400, raw chain-of-thought is never returned, and
+ * sampling parameters are rejected. They accept the same effort tiers as
+ * Opus 4.8 / Opus 5.
  */
-const isMythosClass = (fullName: string): boolean =>
-  fullName.startsWith(FABLE_5_FULLNAME) ||
-  fullName.startsWith(MYTHOS_5_FULLNAME);
+const ANTHROPIC_MODEL_TRAITS: ReadonlyArray<
+  readonly [prefix: string, traits: AnthropicModelTraits]
+> = [
+  [
+    OPUS_46_FULLNAME,
+    {
+      adaptiveThinking: true,
+      compactionEligible: true,
+      maxEffort: 'max',
+      summarizedDisplay: false,
+    },
+  ],
+  [
+    OPUS_47_FULLNAME,
+    {
+      adaptiveThinking: true,
+      compactionEligible: true,
+      maxEffort: 'max',
+      summarizedDisplay: true,
+    },
+  ],
+  [
+    OPUS_48_FULLNAME,
+    {
+      adaptiveThinking: true,
+      compactionEligible: true,
+      maxEffort: 'xhigh',
+      summarizedDisplay: true,
+    },
+  ],
+  [
+    OPUS_5_FULLNAME,
+    {
+      adaptiveThinking: true,
+      compactionEligible: true,
+      maxEffort: 'xhigh',
+      summarizedDisplay: true,
+    },
+  ],
+  [
+    SONNET_46_FULLNAME,
+    {
+      adaptiveThinking: true,
+      compactionEligible: true,
+      maxEffort: 'high',
+      summarizedDisplay: false,
+    },
+  ],
+  [
+    SONNET_5_FULLNAME,
+    {
+      adaptiveThinking: true,
+      compactionEligible: true,
+      maxEffort: 'xhigh',
+      summarizedDisplay: true,
+    },
+  ],
+  [
+    FABLE_5_FULLNAME,
+    {
+      adaptiveThinking: true,
+      compactionEligible: true,
+      maxEffort: 'xhigh',
+      summarizedDisplay: true,
+    },
+  ],
+  [
+    MYTHOS_5_FULLNAME,
+    {
+      adaptiveThinking: true,
+      compactionEligible: true,
+      maxEffort: 'xhigh',
+      summarizedDisplay: true,
+    },
+  ],
+];
+
+/** Traits for models with no matching row: manual thinking, capped at 'high'. */
+const DEFAULT_MODEL_TRAITS: AnthropicModelTraits = {
+  adaptiveThinking: false,
+  compactionEligible: false,
+  maxEffort: 'high',
+  summarizedDisplay: false,
+};
+
+function traitsFor(fullName: string): AnthropicModelTraits {
+  return (
+    ANTHROPIC_MODEL_TRAITS.find(([prefix]) =>
+      fullName.startsWith(prefix),
+    )?.[1] ?? DEFAULT_MODEL_TRAITS
+  );
+}
 
 /**
  * Whether this model supports adaptive thinking with the effort parameter.
- * Per Anthropic docs, Opus 4.6, Opus 4.7, Opus 4.8, Opus 5, Sonnet 4.6,
- * Sonnet 5, and the Mythos-class models support adaptive thinking. Opus 4.7+,
- * Sonnet 5, and Mythos-class models only accept adaptive thinking — manual
- * budget_tokens returns 400.
+ * Opus 4.7+, Sonnet 5, and Mythos-class models only accept adaptive thinking —
+ * manual budget_tokens returns 400.
  */
 export const supportsAdaptiveThinking = (fullName: string): boolean =>
-  isClaudeOpus46(fullName) ||
-  isClaudeOpus47(fullName) ||
-  isClaudeOpus48(fullName) ||
-  isClaudeOpus5(fullName) ||
-  isClaudeSonnet46(fullName) ||
-  isClaudeSonnet5(fullName) ||
-  isMythosClass(fullName);
+  traitsFor(fullName).adaptiveThinking;
 
 /** Whether this model supports Anthropic's native server-side context compaction. */
 export const isCompactionEligibleModel = (fullName: string): boolean =>
-  isClaudeOpus46(fullName) ||
-  isClaudeOpus47(fullName) ||
-  isClaudeOpus48(fullName) ||
-  isClaudeOpus5(fullName) ||
-  isClaudeSonnet46(fullName) ||
-  isClaudeSonnet5(fullName) ||
-  isMythosClass(fullName);
+  traitsFor(fullName).compactionEligible;
 
 /**
  * Whether temperature must be removed when thinking is enabled.
@@ -124,35 +207,17 @@ export function mapAnthropicEffort(
     return 'high';
   }
 
+  const { maxEffort } = traitsFor(fullName);
   switch (reasoningEffort) {
     case 'max':
-      // The top tier ("Max"). Opus 4.6/4.7/4.8/5, Sonnet 5, and Mythos-class
-      // models all accept Anthropic's 'max' effort; everything else caps at
-      // 'high'.
-      return isClaudeOpus5(fullName) ||
-        isClaudeOpus48(fullName) ||
-        isClaudeOpus47(fullName) ||
-        isClaudeOpus46(fullName) ||
-        isClaudeSonnet5(fullName) ||
-        isMythosClass(fullName)
-        ? 'max'
-        : 'high';
+      // The top tier ("Max"). Every family that accepts anything above 'high'
+      // accepts 'max'; the rest cap at 'high'.
+      return maxEffort === 'high' ? 'high' : 'max';
     case 'xhigh':
-      // Opus 4.8/5, Sonnet 5, and the Mythos-class models expose the distinct
-      // 'xhigh' ("extra") effort tier the SDK added in 0.100.0, which is exactly
-      // what TeXRA's "Extra High" selector means — map to it directly. Opus
-      // 4.6/4.7 predate the tier split and only accept 'max'; everything else
-      // caps at 'high'.
-      if (
-        isClaudeOpus5(fullName) ||
-        isClaudeOpus48(fullName) ||
-        isClaudeSonnet5(fullName) ||
-        isMythosClass(fullName)
-      )
-        return 'xhigh';
-      return isClaudeOpus46(fullName) || isClaudeOpus47(fullName)
-        ? 'max'
-        : 'high';
+      // TeXRA's "Extra High" maps straight to the family's ceiling: 'xhigh'
+      // where the SDK 0.100.0 tier split exists, 'max' on the families that
+      // predate it, 'high' everywhere else.
+      return maxEffort;
     case 'high':
       return 'high';
     case 'medium':
@@ -212,14 +277,10 @@ export function buildThinkingConfig({
     // all). Request 'summarized' so thinking still streams to the user — older
     // adaptive-thinking models (Opus 4.6, Sonnet 4.6) already emit reasoning by
     // default and are unaffected.
-    const thinking: ThinkingConfigResult['thinking'] =
-      isClaudeOpus47(fullName) ||
-      isClaudeOpus48(fullName) ||
-      isClaudeOpus5(fullName) ||
-      isClaudeSonnet5(fullName) ||
-      isMythosClass(fullName)
-        ? { type: 'adaptive', display: 'summarized' }
-        : { type: 'adaptive' };
+    const thinking: ThinkingConfigResult['thinking'] = traitsFor(fullName)
+      .summarizedDisplay
+      ? { type: 'adaptive', display: 'summarized' }
+      : { type: 'adaptive' };
 
     return { thinking, outputConfig: { effort }, removeTemperature };
   }

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -214,6 +214,19 @@ function collectFileReferenceCounts(
   return counts;
 }
 
+/**
+ * Build a text content block.
+ *
+ * Nine sites used to hand-roll this literal with an `as ContentBlockParam`
+ * cast. The cast was never needed — `citations` and `cache_control` are both
+ * optional on `TextBlockParam` — it only suppressed the union inference that
+ * an explicit return type resolves. Naming the constructor keeps the shape in
+ * one place and keeps the unchecked cast out of the file.
+ */
+function textBlock(text: string): ContentBlockParam {
+  return { type: 'text', text };
+}
+
 export class ModelHandlerAnthropic extends ModelHandler<
   MessageParam,
   BetaUsage,
@@ -1224,7 +1237,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
   protected createAssistantMessageForPrefillText(text: string): MessageParam {
     return {
       role: 'assistant',
-      content: [{ type: 'text', text } as ContentBlockParam],
+      content: [textBlock(text)],
     };
   }
 
@@ -1236,23 +1249,20 @@ export class ModelHandlerAnthropic extends ModelHandler<
     if (placement === 'continuation') {
       messages.push({
         role: 'user',
-        content: [{ type: 'text', text } as ContentBlockParam],
+        content: [textBlock(text)],
       });
       return;
     }
 
     const lastMessage = messages.at(-1);
     if (lastMessage && Array.isArray(lastMessage.content)) {
-      lastMessage.content.push({
-        type: 'text',
-        text,
-      } as ContentBlockParam);
+      lastMessage.content.push(textBlock(text));
       return;
     }
 
     messages.push({
       role: 'user',
-      content: [{ type: 'text', text } as ContentBlockParam],
+      content: [textBlock(text)],
     });
   }
 
@@ -1290,17 +1300,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
         }
       }
 
-      targetMessage.content.push({
-        type: 'text',
-        text,
-      } as ContentBlockParam);
+      targetMessage.content.push(textBlock(text));
     } else {
-      targetMessage.content = [
-        {
-          type: 'text',
-          text: options.fallbackText ?? text,
-        } as ContentBlockParam,
-      ];
+      targetMessage.content = [textBlock(options.fallbackText ?? text)];
     }
 
     if (options.afterContinuationPrompt) {
@@ -1350,10 +1352,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       workspaceState.resetReasoning();
     }
 
-    content.push({
-      type: 'text',
-      text: workspaceState.assembly.accumulatedOutput,
-    } as ContentBlockParam);
+    content.push(textBlock(workspaceState.assembly.accumulatedOutput));
 
     return { role: 'assistant', content };
   }
@@ -1733,10 +1732,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       if (firstTextBlock) {
         firstTextBlock.text = text + firstTextBlock.text;
       } else {
-        lastUserMsg.content.unshift({
-          type: 'text',
-          text,
-        } as ContentBlockParam);
+        lastUserMsg.content.unshift(textBlock(text));
       }
     }
   }
@@ -1757,10 +1753,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     if (formattedMedia.length === 0) return [];
 
     if (typeof lastUserMsg.content === 'string') {
-      lastUserMsg.content = [
-        ...formattedMedia,
-        { type: 'text', text: lastUserMsg.content } as ContentBlockParam,
-      ];
+      lastUserMsg.content = [...formattedMedia, textBlock(lastUserMsg.content)];
     } else if (Array.isArray(lastUserMsg.content)) {
       lastUserMsg.content.unshift(...formattedMedia);
     }

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -2030,6 +2030,32 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    * WebSocket transport path: a persistent connection for lower-latency
    * tool-use loops. Polls to completion if the response comes back pending.
    */
+  /**
+   * Poll a still-pending response through to completion.
+   *
+   * All three transport paths can land on a pending response — background mode
+   * by design, the streaming and WebSocket paths when the stream ends before
+   * the response finishes (e.g. a relay timeout on a slow request). The
+   * retrieve-and-wait handling is identical; only the diagnostic differs, so
+   * the caller supplies that via `onPending`.
+   */
+  private async awaitPendingResponse(
+    response: Response,
+    client: OpenAI,
+    signal: AbortSignal | undefined,
+    retrieveParams: ResponseRetrieveParamsNonStreaming | undefined,
+    onPending: () => void,
+  ): Promise<Response> {
+    if (!this.backgroundLifecycle.isPending(response)) return response;
+    onPending();
+    return this.backgroundLifecycle.waitForCompletion(
+      client,
+      response,
+      signal,
+      retrieveParams,
+    );
+  }
+
   private async executeWebSocketPath(
     params: ResponseCreateParamsBase,
     client: OpenAI,
@@ -2045,20 +2071,20 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     const processor = wsResult.processor;
 
     // Safety net: handle unexpected pending status (shouldn't happen without background mode)
-    if (this.backgroundLifecycle.isPending(response)) {
-      this.logger.debug(
-        'WebSocket response ended with pending status — polling for completion',
-        {
-          data: { responseId: response.id, status: response.status },
-        },
-      );
-      response = await this.backgroundLifecycle.waitForCompletion(
-        client,
-        response,
-        signal,
-        responseRetrieveParamsFor(params),
-      );
-    }
+    response = await this.awaitPendingResponse(
+      response,
+      client,
+      signal,
+      responseRetrieveParamsFor(params),
+      () => {
+        this.logger.debug(
+          'WebSocket response ended with pending status — polling for completion',
+          {
+            data: { responseId: response.id, status: response.status },
+          },
+        );
+      },
+    );
 
     // The Codex backend leaves the completed response's output empty; rebuild
     // it from the streamed items/text, mirroring the HTTP streaming path, so
@@ -2187,20 +2213,21 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       // If the stream ended before the response completed (e.g., relay timeout
       // during slow GPT-5 requests), poll until it finishes instead of silently
       // returning an incomplete response.
-      if (this.backgroundLifecycle.isPending(response)) {
-        this.logger.debug(
-          'Streaming response ended with pending status - polling for completion',
-          {
-            data: { responseId: response.id, status: response.status },
-          },
-        );
-        response = await this.backgroundLifecycle.waitForCompletion(
-          client,
-          response,
-          signal,
-          retrieveParams,
-        );
-      }
+      const streamed = response;
+      response = await this.awaitPendingResponse(
+        streamed,
+        client,
+        signal,
+        retrieveParams,
+        () => {
+          this.logger.debug(
+            'Streaming response ended with pending status - polling for completion',
+            {
+              data: { responseId: streamed.id, status: streamed.status },
+            },
+          );
+        },
+      );
 
       this.rebuildSparseResponseOutput(response, streamedItems, streamedText);
 
@@ -2256,13 +2283,19 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     // This can happen in two cases:
     // 1. Background mode explicitly enabled (expected)
     // 2. Server-side latency when using previous_response_id (unexpected but handled)
-    if (this.backgroundLifecycle.isPending(response)) {
-      if (useBackgroundResponses) {
-        logProgressStatus(
-          this.logger,
-          'Running OpenAI in background mode; polling for completion (this may take longer than usual).',
-        );
-      } else {
+    response = await this.awaitPendingResponse(
+      response,
+      client,
+      signal,
+      responseRetrieveParamsFor(params),
+      () => {
+        if (useBackgroundResponses) {
+          logProgressStatus(
+            this.logger,
+            'Running OpenAI in background mode; polling for completion (this may take longer than usual).',
+          );
+          return;
+        }
         this.logger.debug(
           'Response returned with pending status despite non-background mode; polling for completion',
           {
@@ -2273,14 +2306,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
             },
           },
         );
-      }
-      response = await this.backgroundLifecycle.waitForCompletion(
-        client,
-        response,
-        signal,
-        responseRetrieveParamsFor(params),
-      );
-    }
+      },
+    );
 
     this.finalizeResponse(
       response,

--- a/src/auth/codex/CodexSessionCoordinator.ts
+++ b/src/auth/codex/CodexSessionCoordinator.ts
@@ -7,6 +7,10 @@
  * network or a real keychain. Stays `vscode`-free; the loopback server,
  * browser-open, and device-code UI live in the host layer and call into here.
  */
+// Third-party imports
+import PQueue from 'p-queue';
+
+// Local imports
 import { safeParseJson } from '@common/parsing/safeParseJson';
 import {
   CODEX_AUTHORIZE_URL,
@@ -78,7 +82,7 @@ export class CodexSessionCoordinator {
    * writes means a write enqueued after a session replacement can never land
    * before the replacement's own write.
    */
-  private sessionMutations: Promise<void> = Promise.resolve();
+  private readonly sessionMutations = new PQueue({ concurrency: 1 });
   private sessionGeneration = 0;
 
   constructor(init: CodexSessionCoordinatorInit) {
@@ -110,15 +114,13 @@ export class CodexSessionCoordinator {
   }
 
   /**
-   * Chain `op` after every previously queued session-storage write so
+   * Queue `op` behind every previously requested session-storage write so
    * replacement (login/sign-out) and refresh-originated writes settle in the
-   * order they were requested. The chain link is established synchronously
-   * (before the first `await`), so ordering is captured at call time.
+   * order they were requested. Enqueueing happens synchronously (before the
+   * first `await`), so ordering is captured at call time.
    */
   private mutateSession(op: () => Promise<void>): Promise<void> {
-    const mutation = this.sessionMutations.then(op);
-    this.sessionMutations = mutation.catch(() => undefined);
-    return mutation;
+    return this.sessionMutations.add(op);
   }
 
   /**
@@ -131,7 +133,7 @@ export class CodexSessionCoordinator {
   }> {
     while (true) {
       const generation = this.sessionGeneration;
-      await this.sessionMutations;
+      await this.sessionMutations.onIdle();
       const session = await this.loadSession();
       if (generation === this.sessionGeneration) {
         return { generation, session };

--- a/src/common/teams/TeamPlan.ts
+++ b/src/common/teams/TeamPlan.ts
@@ -429,10 +429,19 @@ export function formatTeamUnavailableMessage(
   return `Team "${teamId}" is unavailable: ${unavailableNames.join(', ')}.`;
 }
 
+/**
+ * Prompt shown before launching a team that has unavailable hosted members.
+ *
+ * `teamId` is optional because the two hosts reach this prompt with different
+ * context: the main-view launch path already displays the team being launched,
+ * while the settings path names it inline.
+ */
 export function formatUnavailableTeamMembersMessage(
   unavailableNames: readonly string[],
+  teamId?: string,
 ): string {
-  return `This team has unavailable TeXRA-hosted members: ${unavailableNames.join(', ')}.`;
+  const subject = teamId === undefined ? 'This team' : `Team "${teamId}"`;
+  return `${subject} has unavailable TeXRA-hosted members: ${unavailableNames.join(', ')}.`;
 }
 
 export function formatPartialTeamLaunchMessage(

--- a/src/test-kernel/agent/modelHandlers/AnthropicThinking.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/AnthropicThinking.vitest.ts
@@ -87,6 +87,40 @@ describe('supportsAdaptiveThinking / isCompactionEligibleModel', () => {
   });
 });
 
+// The per-family traits above are driven by one prefix-keyed table. Pin the
+// full effort cross-product so a new row (or a reordered prefix) can't shift
+// an existing family's ceiling unnoticed — the drift mode the table replaced.
+describe('effort ceilings across every known family', () => {
+  const EXPECTED_CEILINGS: ReadonlyArray<
+    readonly [model: string, onMax: string, onXhigh: string]
+  > = [
+    [OPUS_46, 'max', 'max'],
+    [OPUS_47, 'max', 'max'],
+    [OPUS_48, 'max', 'xhigh'],
+    [OPUS_5, 'max', 'xhigh'],
+    [SONNET_46, 'high', 'high'],
+    [SONNET_5, 'max', 'xhigh'],
+    [FABLE_5, 'max', 'xhigh'],
+    [MYTHOS_5, 'max', 'xhigh'],
+    [SONNET_35, 'high', 'high'],
+  ];
+
+  it.each(EXPECTED_CEILINGS)(
+    '%s maps max -> %s and xhigh -> %s',
+    (model, onMax, onXhigh) => {
+      expect(mapAnthropicEffort(model, ReasoningEffort.MAX)).toBe(onMax);
+      expect(mapAnthropicEffort(model, ReasoningEffort.XHIGH)).toBe(onXhigh);
+    },
+  );
+
+  it('matches a versioned model id the same way as its bare family prefix', () => {
+    expect(
+      mapAnthropicEffort(`${OPUS_48}-20260115`, ReasoningEffort.XHIGH),
+    ).toBe('xhigh');
+    expect(supportsAdaptiveThinking(`${SONNET_5}-20260115`)).toBe(true);
+  });
+});
+
 describe('requiresNoTemperatureWithThinking', () => {
   it('is true for all Claude 4 families, Opus 5, Sonnet 5, and Mythos-class models', () => {
     expect(requiresNoTemperatureWithThinking(OPUS_48)).toBe(true);


### PR DESCRIPTION
## Summary

A tech-debt audit of the repo surfaced a handful of places where the same decision is written out several times. This PR takes the low-risk subset: cases where the duplication is mechanical, the correct single source already exists in-tree, and behavior can be held fixed by the existing suite.

Two of the clusters had already drifted rather than merely being repetitive:

- **A user-visible drift bug.** The desktop app has two copies of the "team has unavailable hosted members" prompt. One used the shared formatter and the `TEAM_LAUNCH_*` label constants; the other hand-rolled the message and hardcoded `Sign in to TeXRA` / `Continue with available members` against the constants' `Sign In to TeXRA` / `Continue with Available Members`. The same condition rendered two different dialogs depending on which path you reached it from.
- **A latent persistence bug.** The workflow-script checkpoint writer chained every write onto the previous promise (`writeQueue = writeQueue.then(...)`). After one failed write the chain stayed rejected, so every later `persistEntry` both skipped its write and rejected — checkpoint persistence was disabled for the rest of the run by a single transient failure. Queued tasks are now independent.

The remaining clusters are duplication without a current bug: six hand-rolled promise chains, five hand-maintained boolean chains over the same model list, nine copies of one closure, three copies of a poll block, and nine unnecessary type casts.

Deliberately **not** included: the two large structural items the audit ranked highest — extracting a `CompactionCoordinator` out of `modelHandlerOpenAIResponse.ts` (~400 lines) and unifying `StreamLogStore`'s eight parallel per-stream collections. Both are M/L-effort changes to delicate retry and crash-recovery code and want their own PRs with dedicated coverage. See *Scheduled refactoring*.

## Issue acceptance gates

No tracking issue — this came out of a codebase debt audit rather than a filed issue. No acceptance gates to satisfy.

## Single source of truth

| Fact / decision | Now owned by |
| --- | --- |
| Serializing async work per key | `KeyedMutex` (`@utils/core/keyedMutex`), already the owner for 5 other callers |
| Serializing async work, unkeyed | `p-queue` at `concurrency: 1`, matching 7 existing call sites |
| Per-family Anthropic request traits (adaptive thinking, compaction eligibility, effort ceiling, summarized display) | `ANTHROPIC_MODEL_TRAITS` in `anthropicThinking.ts` |
| The "unavailable hosted members" prompt text and buttons | `formatUnavailableTeamMembersMessage` + `TEAM_LAUNCH_*` in `src/common/teams/TeamPlan.ts` |
| Rendering that prompt on desktop | one `chooseTeamAvailability` closure in `main/index.ts` |
| Polling a pending OpenAI response to completion | `awaitPendingResponse` in `modelHandlerOpenAIResponse.ts` |
| Anthropic text content-block shape | `textBlock()` in `modelHandlerAnthropic.ts` |

## Duplication and abstraction budget

**Removed**

- 6 hand-rolled promise chains, each re-deriving "hold a promise, reassign to `prev.then(op)`, swallow rejections, delete the map entry on settle": `jsonStore` `writeChains`, `executionLifecycle` `metaWriteQueues`, `ToolUseCycleNode` `todoPersistChain`, workflow-script `writeQueue`, `agentRegistry` `refreshQueue`, `CodexSessionCoordinator` `sessionMutations`. AGENTS.md/CLAUDE.md already named the first two as standing migration targets; the pattern had since spread to four more.
- 5 boolean chains over the same model list (`supportsAdaptiveThinking`, `isCompactionEligibleModel`, `mapAnthropicEffort`'s `'max'` and `'xhigh'` cases, `buildThinkingConfig`'s display gate), each listing a slightly different subset of the same families.
- 9 copies of `(message) => ipcRef.current?.postToRenderer(message)`.
- 3 copies of the `isPending` / `waitForCompletion` block across the websocket, streaming, and non-streaming transports.
- 9 `as ContentBlockParam` casts on hand-built text blocks.
- 1 drifted dialog implementation.

**No new shared abstraction was added.** The keyed sites route to `KeyedMutex`, which already existed with 5 consumers — deliberately *not* a new p-queue-backed keyed wrapper, since a second keyed primitive would recreate exactly the duplication this PR removes. `async-mutex` stays a dependency regardless (4 other direct users), so re-basing `KeyedMutex` on p-queue would have churned 5 working consumers for no gain.

The four new constructs are all file-local and own a stated invariant, not pass-throughs: `AnthropicModelTraits` / `ANTHROPIC_MODEL_TRAITS` / `traitsFor` (one row per family, so adding a model is a new row rather than an edit to five predicates that mention its siblings), `textBlock` (one text-block shape), `awaitPendingResponse` (one poll-to-completion path, diagnostic supplied by caller), and one `chooseTeamAvailability` closure (one prompt).

## Net elements (R6)

- **Files:** 12 changed, 0 added, 0 deleted. `368 insertions(+), 247 deletions(-)`.
- **Exported symbols:** net **0** — `git diff | grep -E '^[+-]export'` returns nothing. No export surface change, so no ratchet impact.
- **Classes/interfaces/enums:** +1 interface (`AnthropicModelTraits`, file-local). No classes or enums added or removed.
- **Net LoC:** **+121**, broken down:
  - Pure dedup files: +196 / −170 = **+26**. Roughly flat — extracted helpers carry doc comments explaining the invariant they own.
  - Trait table: **+61**. Trades five compact-but-drift-prone boolean chains for one explicit table. Deliberately verbose; the win is one edit point per model, not fewer lines.
  - Tests: **+34**.

This PR is close to LoC-neutral by design. The value is in removing duplicate *decision points* and fixing the two bugs above, not in line deletion — the line-heavy structural extractions are the deferred items below.

## Consumer counts (R8)

No emit path or export was deleted or re-routed; export delta is 0. Grepped counts for the internals that changed shape:

- `writeChains` — 1 consumer (`enqueueFlush`), file-local.
- `metaWriteQueues` — 1 consumer (`enqueueMetaUpdate`), file-local; `enqueueMetaUpdate` itself has 2 in-file callers, both unchanged in signature.
- `refreshQueue` — 1 consumer (`refresh`), file-local.
- `sessionMutations` — 2 consumers (`mutateSession`, `loadStableSession`), both file-local and both updated.
- `isClaudeOpus46/47/48/5`, `isClaudeSonnet46/5`, `isMythosClass` — 0 external consumers; all 7 were file-local `const`s used only by the 5 chains they've been folded into.
- `formatUnavailableTeamMembersMessage` — 2 call sites (extension, desktop), both verified; the added parameter is optional, so the extension caller is untouched.

## Host impact

**Extension:** No behavior change. Only `src/common/teams/TeamPlan.ts` is shared, and the added `teamId` parameter is optional — `executionHandlers.ts` keeps its existing "This team has…" wording.

**Desktop:** One user-visible fix — the settings-path team dialog now shows `Sign In to TeXRA` / `Continue with Available Members`, matching the launch path and the rest of the app. Message text is unchanged on both paths (`Team "X" has…` on the settings path, `This team has…` on the launch path). `postToRenderer` dedup is behavior-preserving: those nine sites rely on the bridge's own destroyed-`webContents` no-op, documented beside `postToRendererIfAlive`, which stays separate because its callers branch on delivery.

**CLI:** No behavior change. Touched core (`jsonStore`, `executionLifecycle`, `agentRegistry`, workflow-script persistence) is shared, but the serialization semantics are equivalent — FIFO by call order, a failed task rejecting only its own caller.

## Scheduled refactoring

Follow-ups identified by the same audit, intentionally out of scope here:

1. **Extract a `CompactionCoordinator`** from `modelHandlerOpenAIResponse.ts` (~510 lines of compaction inline in a 2974-line file). A collaborator mirroring the existing, clean `ResponseChainState` / `BackgroundRunLifecycle`. M effort; the retry/fingerprint logic is delicate.
2. **Unify `StreamLogStore`'s 8 parallel per-stream collections** into one `records` map. `StreamSnapshotStore` already proved this fix and documents the bug (#7892) that motivated it; `StreamLogStore` never got the same treatment and carries the identical risk. M effort, ~1,600 lines of existing tests to lean on.
3. **Decompose the four `createResponseImpl` god-functions** (OpenAI ~427L, Anthropic ~312L, Google GenAI ~285L, Google Interactions ~207L) into named phases. Net-neutral on LoC; the win is testability.
4. **Google handler message-construction dedup** (~8 near-identical method pairs across the two Google handlers).

No issues filed yet — happy to open them if you want these tracked.

## Validation

- `npm run typecheck` — clean (all six projects: root, test-kernel, extension, CLI, trace-viewer, desktop).
- `npm run lint` — clean.
- `npm run format` — applied.
- `npm run check:dead-code-ratchet` — `18 current vs 18 baselined`, no new findings.
- `npx vitest run` (full suite, 776 files / 7,572 tests) — **7,561 passed**, 9 skipped, with 2 known-unrelated failures triaged:
  - `SystemUtils.vitest.ts > aborts shell command process groups` — reproduced on a clean `git stash` of this branch, so **pre-existing** and environmental (process-group teardown in a container).
  - `WorkflowScriptEngine.vitest.ts > guest memory exhaustion` — a wall-clock assertion (`< 3000ms`, observed 3560ms) that fails only under full-suite parallel load; passes in isolation with these changes applied, and passed in a subsequent full run. Load-dependent flake, not a regression.
- Behavior-preservation on the riskiest change (the Anthropic trait table) is pinned by the pre-existing 221-line `AnthropicThinking.vitest.ts` — which covers every family and passed unmodified — plus a new cross-product test asserting the `max`/`xhigh` ceiling for all 9 known model ids and for versioned ids.
- The `textBlock` change caught a real behavior difference mid-review: an initial version added `citations: null` to match other paths, which broke 4 assertions. `citations` turns out to be optional on `TextBlockParam`, so the casts were never needed; the constructor now emits the exact prior shape and those tests pass unmodified.

Not run: the desktop app was not launched manually. The changed desktop paths are dialog wiring and IPC closure binding, both covered by typecheck and the desktop test suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ckko7rcgLLP6Rj5VEmPM7Y)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly refactors with behavior held by existing tests; the meaningful user-facing change is desktop team dialog label consistency. Anthropic and OpenAI paths are consolidation without new features.
> 
> **Overview**
> Consolidates repeated **decision points** across desktop, model handlers, and auth so behavior stays aligned without changing the public API.
> 
> **Desktop** routes both team-launch and settings paths through one `chooseTeamAvailability` closure that uses `formatUnavailableTeamMembersMessage` and `TEAM_LAUNCH_*` labels—fixing drift where the settings path used different button text. `formatUnavailableTeamMembersMessage` gains an optional `teamId` for inline naming. Nine IPC sites share a single `postToRenderer` helper.
> 
> **Anthropic** replaces five parallel model-family boolean chains with `ANTHROPIC_MODEL_TRAITS` / `traitsFor` (adaptive thinking, compaction, effort ceiling, summarized display). `textBlock()` centralizes text content blocks and drops unnecessary `ContentBlockParam` casts. Tests add an effort-ceiling cross-product for all known families.
> 
> **OpenAI Responses** pulls identical pending-response polling from WebSocket, streaming, and non-streaming paths into `awaitPendingResponse`.
> 
> **Codex OAuth** serializes session-storage writes with `p-queue` at concurrency 1 instead of a hand-rolled promise chain (`onIdle` for stable reads).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad15ebb4977c2308f23ef56b78c0736bd9c5fb95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->