### PR TITLE
feat(tools): let the agent read a running background command's live output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ All notable changes to this project will be documented in this file.
   available for demanding research and engineering tasks, replacing Opus 4.8
   as the default Anthropic model. Opus 5 keeps the full 1M context window and
   adaptive thinking.
+- **Agents can read a background command's output while it runs** — the
+  `executions` tool's `/executions/{id}/output` path returns a long build or
+  test run's stdout and stderr in arrival order, updating as the command
+  proceeds instead of only at completion. Reads default to the last 200 lines
+  and accept `view_range` to page back through the retained log, which stays
+  readable after the command finishes.
 
 #### Bug Fixes
 

--- a/src/shared/toolUse.ts
+++ b/src/shared/toolUse.ts
@@ -113,7 +113,7 @@ export function normalizeToolUseData(data: unknown): NormalizedToolUse | null {
 }
 
 // ============================================================================
-// Default tool timeouts
+// Shared tool limits
 // ============================================================================
 //
 // Shared between the tool implementations and the host UIs that display a
@@ -123,6 +123,14 @@ export function normalizeToolUseData(data: unknown): NormalizedToolUse | null {
 
 /** Default `bash` tool timeout (ms) when the model omits `timeout`. */
 export const BASH_TOOL_DEFAULT_TIMEOUT_MS = 120_000;
+
+/**
+ * Max chars a background `bash` run logs to its child stream before it stops
+ * logging and writes a single truncation notice. Lives here because the writer
+ * (`tools/bash.ts`) and the reader (`/executions/{id}/output`) must agree on
+ * the figure the output header reports.
+ */
+export const BASH_BACKGROUND_LOG_CAP_CHARS = 200_000;
 
 /** Default `executions wait` timeout (seconds) when the model omits `timeout`. */
 export const EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS = 300;

--- a/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
@@ -139,7 +139,7 @@ describe('ExecutionsTool /executions/{id}/output', () => {
 
     assert.equal(result.status, 'executed');
     const output = result.output ?? '';
-    assert.match(output, /^Output for \S+ \(bash, running/);
+    assert.match(output, /^Output for \S+ \(process, running/);
     assert.ok(output.includes('of 200,000 logged chars'));
     assert.ok(output.includes('[ 42%] Building CXX object src/foo.cc.o'));
     assert.ok(output.includes("err: warning: unused variable 'x'"));
@@ -182,6 +182,24 @@ describe('ExecutionsTool /executions/{id}/output', () => {
     const past = await readOutput(run.executionId, [900, 950]);
     assert.equal(past.status, 'executed');
     assert.ok((past.output ?? '').includes('No lines in the requested range'));
+
+    await run.finish();
+  });
+
+  it('treats a carriage-return progress redraw as separate lines', async () => {
+    // curl/pip/docker redraw with `\r` and no newline. Splitting on LF alone
+    // would make the whole progress bar one enormous line, so the bounded
+    // window would still hand back the entire log.
+    const run = await launchBackgroundRun((sink) => {
+      sink.onStdout?.('  0%\r 50%\r100%\r\ndownload complete\n');
+    });
+
+    const result = await readOutput(run.executionId);
+    const output = result.output ?? '';
+
+    assert.ok(output.includes('Showing lines 1-4 of 4.'));
+    assert.ok(output.includes('  0%'));
+    assert.ok(output.includes('download complete'));
 
     await run.finish();
   });

--- a/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
@@ -1,0 +1,289 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
+// Node imports
+import { strict as assert } from 'node:assert';
+
+// Third-party imports
+import { afterEach, describe, it, vi } from 'vitest';
+
+// Local imports
+import { registerExecution } from '@agent/storage';
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
+import { FileInteractionState } from '@agent/core/state/AgentWorkspaceState';
+import { withToolEnvironment } from '@agent/followUp/ToolFileInteractionContext';
+import * as toolUseFollowUp from '@agent/followUp/ToolUseFollowUp';
+import { defaultSession } from '@agent/runtime/SessionHandle';
+import type { StreamTabId } from '@shared/schemas';
+import type { ExecResult } from '@shared/schemas/opResults';
+import { setupPlatform } from '@test/support/setupPlatform';
+import { ExecutionsTool } from '@tools/ExecutionsTool';
+import { BashTool } from '@tools/bash';
+import { generateExecutionId } from '@utils/core';
+import * as execUtils from '@utils/system/execUtils';
+
+// Local file imports
+import {
+  createRecordingHost,
+  recordSessionEvents,
+} from '../agent/progressTestUtils';
+
+const PARENT_STREAM_ID = 'executions-output-parent' as StreamTabId;
+
+type ExecChunkSink = Pick<
+  Parameters<typeof execUtils.executeCommand>[1] & object,
+  'onStdout' | 'onStderr'
+>;
+
+interface BackgroundRun {
+  readonly executionId: string;
+  /** Settle the mocked process and wait for its completion follow-up. */
+  readonly finish: () => Promise<void>;
+}
+
+/**
+ * Launch a real background `bash` run whose mocked process emits `chunks`
+ * synchronously and then stays open until `finish()` — the only way to
+ * observe a mid-run read of the child stream's transcript log.
+ */
+async function launchBackgroundRun(
+  emit: (sink: ExecChunkSink) => void,
+): Promise<BackgroundRun> {
+  let release!: (result: ExecResult) => void;
+  const processExit = new Promise<ExecResult>((resolve) => {
+    release = resolve;
+  });
+
+  vi.spyOn(execUtils, 'executeCommand').mockImplementation(
+    async (_command, options = {}) => {
+      emit(options);
+      return processExit;
+    },
+  );
+  const followUp = vi
+    .spyOn(toolUseFollowUp, 'sendFollowUp')
+    .mockResolvedValue({ status: 'sent' });
+
+  const { host } = createRecordingHost();
+  const recorded = recordSessionEvents(defaultSession().events);
+  let launched;
+  try {
+    launched = await withToolEnvironment(
+      {
+        run: { runtimeHost: host, streamId: PARENT_STREAM_ID },
+        call: { tracker: new FileInteractionState() },
+      },
+      () =>
+        new BashTool().call({
+          command: 'make build',
+          run_in_background: true,
+        }),
+    );
+  } finally {
+    recorded.detach();
+  }
+
+  assert.equal(launched.status, 'executed');
+  const executionId = /Execution ID: (\S+)/.exec(launched.output ?? '')?.[1];
+  assert.ok(executionId, 'Background launch should report its execution ID');
+
+  return {
+    executionId,
+    finish: async () => {
+      release({
+        success: true,
+        stdout: null,
+        stderr: null,
+        timedOut: false,
+        exitCode: 0,
+      });
+      await vi.waitFor(() => {
+        assert.ok(
+          followUp.mock.calls.length > 0,
+          'Background run should deliver a completion follow-up',
+        );
+      });
+    },
+  };
+}
+
+function readOutput(
+  executionId: string,
+  viewRange?: [number, number],
+): Promise<{ status: string; output?: string; error?: string }> {
+  return new ExecutionsTool().call({
+    path: `/executions/${executionId}/output`,
+    ...(viewRange ? { view_range: viewRange } : {}),
+  });
+}
+
+describe('ExecutionsTool /executions/{id}/output', () => {
+  setupPlatform({
+    workspacePath: '/workspace',
+    config: { 'texra.toolUse.requireBashApproval': false },
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns a running background command output so far, with stderr marked', async () => {
+    const run = await launchBackgroundRun((sink) => {
+      sink.onStdout?.('[ 42%] Building CXX object src/foo.cc.o\n');
+      sink.onStderr?.("warning: unused variable 'x'\n");
+      sink.onStdout?.('[ 84%] Building CXX object src/bar.cc.o\n');
+    });
+
+    const result = await readOutput(run.executionId);
+
+    assert.equal(result.status, 'executed');
+    const output = result.output ?? '';
+    assert.match(output, /^Output for \S+ \(bash, running/);
+    assert.ok(output.includes('of 200,000 logged chars'));
+    assert.ok(output.includes('[ 42%] Building CXX object src/foo.cc.o'));
+    assert.ok(output.includes("err: warning: unused variable 'x'"));
+    assert.ok(output.includes('[ 84%] Building CXX object src/bar.cc.o'));
+    assert.ok(output.includes('[still running'));
+    // stdout rows must not be marked as stderr.
+    assert.ok(!output.includes('err: [ 42%]'));
+    // Arrival order, not stdout-then-stderr sections.
+    assert.ok(
+      output.indexOf("err: warning: unused variable 'x'") <
+        output.indexOf('[ 84%] Building CXX object src/bar.cc.o'),
+      'stdout/stderr interleaving must survive the projection',
+    );
+
+    await run.finish();
+  });
+
+  it('joins chunks that split a line and pages the projection with view_range', async () => {
+    const run = await launchBackgroundRun((sink) => {
+      // A single logical line delivered across two stdout chunks.
+      sink.onStdout?.('line1\nline2\nli');
+      sink.onStdout?.('ne3\nline4\nline5\n');
+    });
+
+    const full = await readOutput(run.executionId);
+    assert.ok(
+      (full.output ?? '').includes('line3'),
+      'A line split across chunks must be rejoined, not broken in two',
+    );
+
+    const paged = await readOutput(run.executionId, [2, 3]);
+    const output = paged.output ?? '';
+    assert.equal(paged.status, 'executed');
+    assert.ok(output.includes('Showing lines 2-3 of 5.'));
+    assert.ok(output.includes('line2'));
+    assert.ok(output.includes('line3'));
+    assert.ok(!output.includes('line1'));
+    assert.ok(!output.includes('line4'));
+
+    const past = await readOutput(run.executionId, [900, 950]);
+    assert.equal(past.status, 'executed');
+    assert.ok((past.output ?? '').includes('No lines in the requested range'));
+
+    await run.finish();
+  });
+
+  it('bounds a chatty log to its tail by default and says how to page back', async () => {
+    const lineCount = 1500;
+    const run = await launchBackgroundRun((sink) => {
+      sink.onStdout?.(
+        `${Array.from({ length: lineCount }, (_, i) => `line${i + 1}`).join('\n')}\n`,
+      );
+    });
+
+    const result = await readOutput(run.executionId);
+    const output = result.output ?? '';
+
+    assert.ok(
+      output.includes(`Showing lines 1301-${lineCount} of ${lineCount}`),
+      `Default window should be the last 200 lines, got: ${output.slice(0, 300)}`,
+    );
+    assert.ok(output.includes('the last 200 by default'));
+    assert.ok(output.includes('line1500'));
+    assert.ok(output.includes('line1301'));
+    assert.ok(!output.includes('line1300\n'));
+
+    // A wide view_range still cannot pull back an unbounded window.
+    const wide = await readOutput(run.executionId, [1, lineCount]);
+    const wideOutput = wide.output ?? '';
+    assert.ok(wideOutput.includes(`Showing lines 1-1000 of ${lineCount}`));
+    assert.ok(wideOutput.includes('capped at 1000 lines per read'));
+    assert.ok(wideOutput.includes('view_range: [1001, …]'));
+    assert.ok(wideOutput.includes('line1000'));
+    assert.ok(!wideOutput.includes('line1001'));
+
+    await run.finish();
+  });
+
+  it('still serves the retained log after the command finishes', async () => {
+    const run = await launchBackgroundRun((sink) => {
+      sink.onStdout?.('compiling\ndone\n');
+    });
+    await run.finish();
+
+    const result = await readOutput(run.executionId);
+    const output = result.output ?? '';
+
+    assert.equal(result.status, 'executed');
+    assert.ok(output.includes('compiling'));
+    assert.ok(output.includes('done'));
+    assert.ok(output.includes('[finished'));
+    assert.ok(
+      !output.includes('no longer available'),
+      'A finished-but-resident run must not claim its output was discarded',
+    );
+  });
+
+  it('points at /report when a process execution has no retained stream log', async () => {
+    const executionId = generateExecutionId();
+    await registerExecution(
+      executionId,
+      AgentConfigSchema.parse({
+        agent: 'bash',
+        instruction: 'sleep 1',
+        agentCategory: AgentCategory.ToolUse,
+      }),
+      'bash',
+      undefined,
+      'process',
+    );
+
+    const result = await readOutput(executionId);
+
+    assert.equal(result.status, 'executed');
+    assert.ok((result.output ?? '').includes('No retained output'));
+    assert.ok(
+      (result.output ?? '').includes(`/executions/${executionId}/report`),
+    );
+  });
+
+  it('points a non-process execution at /conversation instead of dumping its transcript', async () => {
+    const executionId = generateExecutionId();
+    await registerExecution(
+      executionId,
+      AgentConfigSchema.parse({
+        agent: 'chat',
+        instruction: 'Check the proof.',
+        agentCategory: AgentCategory.ToolUse,
+      }),
+      'chat',
+    );
+
+    const result = await readOutput(executionId);
+
+    assert.equal(result.status, 'executed');
+    assert.ok(
+      (result.output ?? '').includes(`/executions/${executionId}/conversation`),
+    );
+  });
+
+  it('errors on an unknown execution id', async () => {
+    const result = await readOutput(generateExecutionId());
+
+    assert.equal(result.status, 'error');
+    assert.ok((result.error ?? '').includes('Execution not found'));
+  });
+});

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -110,6 +110,14 @@ const OUTPUT_MAX_LINES = 1_000;
 /** Marks a projected line that the command wrote to stderr. */
 const OUTPUT_STDERR_PREFIX = 'err: ';
 
+/**
+ * Line break in captured terminal output. A bare CR counts: progress bars
+ * (curl, pip, docker) redraw with `\r` and no newline, so splitting on LF
+ * alone would collapse a whole build's progress into one enormous "line" and
+ * hand the caller the entire log however small the requested window was.
+ */
+const OUTPUT_LINE_BREAK = /\r\n|\r|\n/;
+
 interface ProcessOutputProjection {
   readonly lines: readonly string[];
   readonly chars: number;
@@ -149,10 +157,10 @@ function projectProcessOutput(
 
   const lines: string[] = [];
   for (const run of runs) {
-    // A chunk's trailing newline terminates its last line rather than opening
-    // an empty one; blank lines inside the chunk still survive the split.
-    const text = run.text.endsWith('\n') ? run.text.slice(0, -1) : run.text;
-    for (const line of text.split('\n')) {
+    // A trailing break terminates the last line rather than opening an empty
+    // one; blank lines inside the text still survive the split.
+    const text = run.text.replace(/\r\n$|[\r\n]$/, '');
+    for (const line of text.split(OUTPUT_LINE_BREAK)) {
       lines.push(run.stderr ? `${OUTPUT_STDERR_PREFIX}${line}` : line);
     }
   }
@@ -863,7 +871,10 @@ Use action: "subscribe" on /executions/{id} to receive future status and termina
       ? `[still running — re-read for more output, or use action='wait' on /executions/${executionId} to block until it finishes]`
       : `[finished — this is the retained log; /executions/${executionId}/report has the result summary]`;
     const out: string[] = [
-      `Output for ${executionId} (bash, ${formatStatusInfo(info)}) — ${chars.toLocaleString()} of ${BASH_BACKGROUND_LOG_CAP_CHARS.toLocaleString()} logged chars, ${lines.length.toLocaleString()} lines.`,
+      // `process` rather than a hardcoded `bash`: the category is what the
+      // guard above actually verified, and it stays true if another tool ever
+      // registers a process-kind execution.
+      `Output for ${executionId} (process, ${formatStatusInfo(info)}) — ${chars.toLocaleString()} of ${BASH_BACKGROUND_LOG_CAP_CHARS.toLocaleString()} logged chars, ${lines.length.toLocaleString()} lines.`,
     ];
 
     if (lines.length === 0) {

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -29,8 +29,16 @@ import {
 } from '@agent/runtime/RunContext';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { platform } from '@platform/platform';
-import { ExecutionIdSchema, type ExecutionId } from '@shared/schemas';
 import {
+  ExecutionIdSchema,
+  LOG_LEVELS,
+  MESSAGE_TYPES,
+  STREAM_LOG_ENTRY_TYPES,
+  type ExecutionId,
+  type StreamLogEntry,
+} from '@shared/schemas';
+import {
+  BASH_BACKGROUND_LOG_CAP_CHARS,
   EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS,
   EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS,
   EXECUTIONS_WAIT_MIN_TIMEOUT_SECONDS,
@@ -42,6 +50,7 @@ import { assertNoParentTraversal } from '@tools/pathResolution';
 import {
   readCompletedRunConversation,
   readCompletedRunTodos,
+  resolvePersistedStreamIdForExecution,
 } from '@transcript';
 import { AbsoluteFS, StorageFS } from '@utils/files';
 import { clamp, unique } from '@utils/core';
@@ -54,6 +63,7 @@ import { splitContentLines } from '@utils/text/stringUtils';
 // Local file imports
 import {
   formatListingLine,
+  formatStatusInfo,
   formatTodoHeader,
   formatTodoSection,
   getExecutionStatusInfo,
@@ -86,6 +96,69 @@ import {
   type ExecutionSummaryOptions,
 } from './executions/summaryFormat';
 import { formatSizedEntryLines } from './executions/fileListingFormat';
+
+// ============================================================================
+// Background command output
+// ============================================================================
+
+/** Lines returned by /executions/{id}/output when no view_range is given. */
+const OUTPUT_TAIL_LINES = 200;
+
+/** Hard ceiling on lines a single /output read returns, view_range included. */
+const OUTPUT_MAX_LINES = 1_000;
+
+/** Marks a projected line that the command wrote to stderr. */
+const OUTPUT_STDERR_PREFIX = 'err: ';
+
+interface ProcessOutputProjection {
+  readonly lines: readonly string[];
+  readonly chars: number;
+}
+
+/**
+ * Flatten a background command's transcript rows into display lines.
+ *
+ * Rows stay in append order — the only surviving record of how stdout and
+ * stderr actually interleaved. Consecutive rows on the same channel are
+ * concatenated before the split so a line straddling two chunk boundaries
+ * stays one line; `warn`/`error` rows are the stderr channel and every line
+ * they contribute is marked. Structured rows (usage, context state, tool
+ * frames) carry a non-default `messageType` and are dropped: this endpoint
+ * projects command output, not the run's own bookkeeping.
+ */
+function projectProcessOutput(
+  entries: readonly StreamLogEntry[],
+): ProcessOutputProjection {
+  const runs: { stderr: boolean; text: string }[] = [];
+  let chars = 0;
+
+  for (const entry of entries) {
+    if (entry.type !== STREAM_LOG_ENTRY_TYPES.LOG) continue;
+    if ((entry.messageType ?? MESSAGE_TYPES.DEFAULT) !== MESSAGE_TYPES.DEFAULT)
+      continue;
+    const text = entry.text;
+    if (!text) continue;
+
+    chars += text.length;
+    const stderr =
+      entry.level === LOG_LEVELS.WARN || entry.level === LOG_LEVELS.ERROR;
+    const open = runs.at(-1);
+    if (open && open.stderr === stderr) open.text += text;
+    else runs.push({ stderr, text });
+  }
+
+  const lines: string[] = [];
+  for (const run of runs) {
+    // A chunk's trailing newline terminates its last line rather than opening
+    // an empty one; blank lines inside the chunk still survive the split.
+    const text = run.text.endsWith('\n') ? run.text.slice(0, -1) : run.text;
+    for (const line of text.split('\n')) {
+      lines.push(run.stderr ? `${OUTPUT_STDERR_PREFIX}${line}` : line);
+    }
+  }
+
+  return { lines, chars };
+}
 
 // ============================================================================
 // Schema
@@ -177,6 +250,7 @@ Paths:
 - /executions/{id}/todos - Task list (tool-use subagents)
 - /executions/{id}/report - Result report (persists after context compaction)
 - /executions/{id}/result - Final result envelope (JSON) for chaining; process result for background commands
+- /executions/{id}/output - stdout/stderr of a background command, readable WHILE IT RUNS (report/result only exist once it finishes)
 - /executions/{id}/children - Child executions
 - /executions/{id}/files - Generated files (workflows only)
 - /executions/{id}/files/{path} - Read specific generated file (workflows only)
@@ -185,7 +259,7 @@ Paths:
 
 Use "current" as {id} to access the active execution.
 Use offset/limit to paginate the /executions listing (default: offset 0, limit 100).
-Use view_range: [start, end] to paginate conversation and file content.
+Use view_range: [start, end] to paginate conversation, file, and background-command output content.
 Use action: "wait" on /executions or /executions/{id} to wait for a status change instead of polling.
 Use action: "wait" with ids: ["id1", "id2", ...] on /executions to wait for any of the listed executions to change.
 Use action: "kill" on /executions/{id} to terminate a running execution.
@@ -252,13 +326,7 @@ Use action: "subscribe" on /executions/{id} to receive future status and termina
       case 'children':
         return this.showChildren(executionId);
       case 'output':
-        // Undocumented compatibility route. A background `bash` run streams its
-        // live output through its own child stream (`createChildStream` in
-        // `tools/bash.ts`), so this endpoint has nothing of its own to read.
-        return {
-          status: 'executed',
-          output: `Output for ${executionId} is no longer available (ephemeral output is cleaned up on completion). Use /executions/${executionId}/report to view the result summary.`,
-        };
+        return this.showOutput(executionId, input.view_range ?? undefined);
       case 'files':
         if (rest.length === 0) {
           return this.listFiles(executionId);
@@ -286,6 +354,7 @@ Use action: "subscribe" on /executions/{id} to receive future status and termina
         `- /executions/{id}/config       - Agent configuration\n` +
         `- /executions/{id}/report       - Result report (prose)\n` +
         `- /executions/{id}/result       - Final result envelope (JSON) for chaining\n` +
+        `- /executions/{id}/output       - Background command stdout/stderr (readable while running)\n` +
         `- /executions/{id}/conversation - Message history (subagents)\n` +
         `- /executions/{id}/todos        - Task list (tool-use subagents)\n` +
         `- /executions/{id}/children     - Child executions\n` +
@@ -733,6 +802,115 @@ Use action: "subscribe" on /executions/{id} to receive future status and termina
     const output = applyViewRange(formatConversation(conversation), viewRange);
 
     return { status: 'executed', output };
+  }
+
+  /**
+   * stdout/stderr of a background command, projected from the transcript log
+   * its child stream already writes (`createChildStream` in `tools/bash.ts`).
+   *
+   * This is the only route readable *while the command runs*: `/report` and
+   * `/result` are written at completion, and the completion follow-up carries
+   * only a 20-line preview, so without this the middle of a long build log is
+   * unreachable even after the run ends. Restricted to process executions —
+   * an agent run's rows are a model transcript, which `/conversation` already
+   * renders properly.
+   */
+  private async showOutput(
+    executionId: ExecutionId,
+    viewRange?: [number, number],
+  ): Promise<ToolResult> {
+    // A tracked handle is also the liveness fact: the shared terminal
+    // finalizer untracks it, so its presence means the command is still up.
+    const handle = currentSession().executions.getHandle(executionId);
+    const meta = await getExecutionStore(executionId).readMeta();
+    if (!meta && !handle) {
+      throw new ToolError(`Execution not found: ${executionId}`);
+    }
+    if (meta?.category !== 'process') {
+      return {
+        status: 'executed',
+        output:
+          `/executions/${executionId}/output is only available for background commands (bash with run_in_background). ` +
+          `Use /executions/${executionId}/conversation for an agent run's message history.`,
+      };
+    }
+
+    const transcripts = currentSession().transcripts;
+    const streamId =
+      handle instanceof AgentExecutionHandle
+        ? handle.childStreamId
+        : (
+            await resolvePersistedStreamIdForExecution(executionId, {
+              streamLogStore: transcripts,
+            })
+          )?.streamId;
+    // Resident while the command runs (an open writer refuses eviction); a
+    // released stream rehydrates from disk, and an ephemeral store no-ops.
+    if (streamId) await transcripts.ensureLoaded(streamId);
+    const log = streamId ? transcripts.get(streamId) : undefined;
+    if (!log) {
+      return {
+        status: 'executed',
+        output:
+          `No retained output for ${executionId} — its stream log is no longer available. ` +
+          `Use /executions/${executionId}/report for the result summary.`,
+      };
+    }
+
+    const { lines, chars } = projectProcessOutput(log.toJSON());
+    const info = getExecutionStatusInfo(executionId, meta.terminalStatus);
+    const footer = handle
+      ? `[still running — re-read for more output, or use action='wait' on /executions/${executionId} to block until it finishes]`
+      : `[finished — this is the retained log; /executions/${executionId}/report has the result summary]`;
+    const out: string[] = [
+      `Output for ${executionId} (bash, ${formatStatusInfo(info)}) — ${chars.toLocaleString()} of ${BASH_BACKGROUND_LOG_CAP_CHARS.toLocaleString()} logged chars, ${lines.length.toLocaleString()} lines.`,
+    ];
+
+    if (lines.length === 0) {
+      out.push('', footer);
+      return { status: 'executed', output: out.join('\n') };
+    }
+    out.push('Lines are in arrival order; `err:` marks one written to stderr.');
+
+    // Default to the tail, where a live build's news is; a view_range window
+    // is clamped so a wide request still can't return an unbounded log.
+    const first = viewRange
+      ? viewRange[0]
+      : Math.max(lines.length - OUTPUT_TAIL_LINES, 0) + 1;
+    const requestedLast = Math.min(
+      viewRange?.[1] ?? lines.length,
+      lines.length,
+    );
+    const last = Math.min(requestedLast, first + OUTPUT_MAX_LINES - 1);
+
+    if (first > last) {
+      out.push(
+        `No lines in the requested range; the log has ${lines.length} lines.`,
+        '',
+        footer,
+      );
+      return { status: 'executed', output: out.join('\n') };
+    }
+
+    let hint = '';
+    if (last < requestedLast) {
+      hint = ` (capped at ${OUTPUT_MAX_LINES} lines per read — continue from view_range: [${last + 1}, …])`;
+    } else if (!viewRange && first > 1) {
+      hint = ` (the last ${OUTPUT_TAIL_LINES} by default — use view_range to page earlier ones)`;
+    }
+    out.push(
+      `Showing lines ${first}-${last} of ${lines.length}${hint}.`,
+      '',
+      applyViewRange(lines.join('\n'), [first, last]),
+      '',
+      footer,
+    );
+
+    return {
+      status: 'executed',
+      summary: `Read lines ${first}-${last} of /executions/${executionId}/output`,
+      output: out.join('\n'),
+    };
   }
 
   private async listFiles(executionId: ExecutionId): Promise<ToolResult> {

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -32,7 +32,10 @@ import { releaseExecutionLeaseAfterArtifacts } from '@agent/runtime/executionOwn
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { tryPlatform } from '@platform/platform';
-import { BASH_TOOL_DEFAULT_TIMEOUT_MS } from '@shared/toolUse';
+import {
+  BASH_BACKGROUND_LOG_CAP_CHARS,
+  BASH_TOOL_DEFAULT_TIMEOUT_MS,
+} from '@shared/toolUse';
 import { type StreamTabId, type ExecutionId } from '@shared/schemas';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import {
@@ -76,8 +79,6 @@ const BACKGROUND_OUTPUT_TAIL_CHARS = 12_000;
  * recover it from the follow-up.
  */
 const BACKGROUND_OUTPUT_HEAD_CHARS = 1_000;
-/** Max chars logged to the child stream tab to prevent unbounded memory growth. */
-const BACKGROUND_LOG_CAP_CHARS = 200_000;
 const FOREGROUND_OUTPUT_HEAD_CHARS = TOOL_RESULT_TRUNCATION_HEAD_CHARS;
 const FOREGROUND_OUTPUT_TAIL_CHARS = TOOL_RESULT_TRUNCATION_TAIL_CHARS;
 const SHELL_BACKGROUNDING_PATTERN =
@@ -420,10 +421,10 @@ export class BashTool extends defineTool({
     const logChunk = (chunk: string, level: 'info' | 'warn'): void => {
       if (logCapReached) return;
       loggedChars += chunk.length;
-      if (loggedChars > BACKGROUND_LOG_CAP_CHARS) {
+      if (loggedChars > BASH_BACKGROUND_LOG_CAP_CHARS) {
         logCapReached = true;
         logger.warn(
-          `[Stream log truncated at ${(BACKGROUND_LOG_CAP_CHARS / 1000).toFixed(0)}k chars — tail available in follow-up result]`,
+          `[Stream log truncated at ${(BASH_BACKGROUND_LOG_CAP_CHARS / 1000).toFixed(0)}k chars — tail available in follow-up result]`,
         );
         return;
       }
@@ -678,6 +679,7 @@ export class BashTool extends defineTool({
         `Command launched in background.`,
         `Execution ID: ${executionId}`,
         `Stream tab: ${childStreamId}`,
+        `To read its output so far (works while it runs): executions tool with path=/executions/${executionId}/output`,
         `To wait for completion: executions tool with path=/executions/${executionId} action=wait`,
         'Result will be delivered as a follow-up message when complete.',
       ].join('\n'),


### PR DESCRIPTION
Closes #9169.

## What

`/executions/{id}/output` was an unconditional stub returning `Output for {id} is no longer available`. It is now a real, advertised route that projects the child stream's transcript log, so an agent can read a long `bash run_in_background` build/test log **while it is still running** — the one user-facing capability the dead-process retirement (#9139 / #9158 / #9167) left missing.

Verified chain the read sits on (re-checked at `bf2ae8f7f1`, not taken on faith from the issue): `bash.ts` `createChildStream(runKind:'process')` → deterministic `bash@tool#{executionId}` → `createRunTrace` → `attachTranscriptRecorder` → every stdout chunk `logger.info` / stderr chunk `logger.warn` → `STREAM_LOG_ENTRY_TYPES.LOG` rows in `StreamLog`. Residency while running is guaranteed by `requestEviction` refusing a stream with an open writer.

## Shape

```
Output for d297922456c6 (process, running (1s elapsed)) — 109 of 200,000 logged chars, 3 lines.
Lines are in arrival order; `err:` marks one written to stderr.
Showing lines 1-3 of 3.

[ 42%] Building CXX object src/foo.cc.o
err: warning: unused variable 'x'
[ 84%] Building CXX object src/bar.cc.o

[still running — re-read for more output, or use action='wait' on /executions/d297922456c6 to block until it finishes]
```

- **Arrival order preserved** — stdout and stderr interleave as they actually arrived, unlike the deleted `formatProcessOutputSections` which split them into two blocks and destroyed ordering. Consecutive same-channel rows are concatenated before the line split, so a line straddling two chunk boundaries stays one line (covered by a test).
- **Bounded** — default window is the last `200` lines and the header says so; `view_range` pages the full projection through the already-imported `applyViewRange`, clamped to `1,000` lines per read with a "continue from view_range: [N, …]" hint. Lines split on `\r\n | \r | \n`, so a bare-CR progress bar (curl, pip, docker) can't collapse a whole download into one enormous "line" that defeats the window.
- **Resolution, two branches** — live handle → `childStreamId`; once untracked → `resolvePersistedStreamIdForExecution` + `ensureLoaded`. A finished-but-retained log therefore still reads; only a genuinely gone log returns a pointer to `/report`, which retires the "no longer available" lie.
- **Guard** — restricted to process executions (`meta.category === 'process'`, persisted by `registerExecution(..., 'process')`, which only `bash` passes). I chose the restriction rather than "any child stream with a log" because an agent child stream's rows are a model transcript that `/conversation` already renders properly; dumping it as if it were command output would be actively misleading. Non-process ids get a one-line pointer to `/conversation`.
- **Discovery** — restored to the tool description path list, to the unknown-path error list, and to `view_range`'s doc line (all three removed by #9158). `getAvailablePaths` already advertised `output` for the `process` category, so the `/executions/{id}` summary was pointing at the stub. The background launch result now names the route too.

## Element accounting — honest net add

This is deliberately **outside #9138's reduce-elements constraint**, as the issue states.

| | |
|---|---|
| Production LOC | **+214 / −15** (net **+199**) |
| Test LOC | +307 (1 new test file, 8 cases) |
| New production files | 0 |
| New exports | 1 constant (`BASH_BACKGROUND_LOG_CAP_CHARS`), *moved* from `tools/bash.ts` to `@shared/toolUse` because the writer and the reader must agree on the figure the header reports — `check:dead-code-ratchet` unchanged at 18/18 |

The projection is a module-level non-exported function in `ExecutionsTool.ts` beside the route body — no single-caller formatter module (CLAUDE.md § abstraction guardrails; `executions/processOutputFormat.ts` was exactly that shape before #9158 deleted it).

## Nothing retired comes back

```
$ grep -rn "ProcessExecutionHandle\|ProcessOutputPoller\|process\.output\|outputPaths\|
   formatProcessOutputSections\|UPDATE_PROCESS_OUTPUT\|UpdateProcessOutputPayload\|
   UpdateActiveProcessesPayload" src packages
(no matches)
```

Pull-only: no new `AgentEvent`, no wire payload, no push channel, no `bus.emit`, no `ActiveChildInfoSchema` change, no temp-file polling, and `BASH_BACKGROUND_LOG_CAP_CHARS` is unchanged at 200,000.

## Tests

New `src/test-kernel/tools/ExecutionsToolOutput.vitest.ts` (8 cases) drives a **real** background `bash` launch whose mocked process emits chunks and then stays open, so the mid-run read is genuinely mid-run:

1. mid-run read — output so far, stderr marked, interleaving preserved, `[still running]` footer
2. chunk-split line rejoined + `view_range` paging (`Showing lines 2-3 of 5`)
3. out-of-range `view_range` → "No lines in the requested range"
4. bare-CR progress redraw → separate lines, not one collapsed line
5. 1,500-line log → default tail window `1301-1500` + the cap biting at 1,000 lines on a wide `view_range`
6. finished execution → retained log, `[finished]` footer, never "no longer available"
7. process execution with no retained log → pointer to `/report`
8. non-process execution → pointer to `/conversation`; unknown id → `Execution not found`

## Verification

All four gates run locally on this branch:

- `npm run typecheck` — clean (all six tsconfigs; needed the documented `COREPACK_ENABLE_PROJECT_SPEC=0 CI=true` workaround, and `pnpm-lock.yaml` was restored afterwards)
- `npm test` — **775 files passed | 1 skipped; 7,529 tests passed | 4 skipped**, no failures, nothing flaky (re-run in full after the `07db7c1` follow-up)
- `npm run lint` — clean
- `npm run check:dead-code-ratchet` — `18 current vs 18 baselined`, OK

https://claude.ai/code/session_01MQZ63FFrmojmG58wPJdYNH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds substantive executions-tool behavior and transcript projection logic agents rely on during long runs; bounded reads limit blast radius, but incorrect projection or stream resolution could mislead debugging.
> 
> **Overview**
> **Replaces the `/executions/{id}/output` stub** with a real route so agents can read a background `bash` run’s stdout/stderr **while it is still running**, from the child stream’s transcript log (the same path `run_in_background` already writes).
> 
> Projection keeps **arrival order** (stdout/stderr interleaved), prefixes stderr lines with `err:`, rejoins lines split across chunks, and splits on `\r` so progress redraws don’t become one giant line. Responses default to the **last 200 lines**, honor **`view_range`** with a **1,000-line cap** per read, and report progress against the shared **`BASH_BACKGROUND_LOG_CAP_CHARS`** (200k), now defined in `@shared/toolUse` for `bash.ts` and the reader.
> 
> Non-process executions get a pointer to `/conversation`; missing logs point to `/report`. Tool docs, error help, background launch text, and CHANGELOG are updated. New integration tests cover mid-run reads, paging, finished runs, and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07db7c18fcb707e3b38b97da96566cb4ce47aaa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


