### PR TITLE
refactor(progressView): replace remaining native hover titles

### DIFF
--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -29,6 +29,7 @@ import { classMap } from 'lit/directives/class-map.js';
 // Side-effect imports - register WA icon component
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/relative-time/relative-time.js';
+import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 
 // Local imports
 import '@awesome.me/webawesome/dist/components/badge/badge.js';
@@ -293,15 +294,19 @@ export class BackgroundTasksPanel extends LitElement {
           ${repeat(
             this.inquiries,
             (thread) => thread.threadId,
-            (thread) => this.renderInquiryItem(thread),
+            (thread, index) => this.renderInquiryItem(thread, index),
           )}
         </div>
       </wa-details>
     `;
   }
 
-  private renderInquiryItem(thread: InquiryThreadUpdatedEvent): TemplateResult {
+  private renderInquiryItem(
+    thread: InquiryThreadUpdatedEvent,
+    index: number,
+  ): TemplateResult {
     const preview = thread.lastQuestionPreview || '(empty question)';
+    const idPrefix = `background-inquiry-${index}`;
     return html`
       <div class="task-item">
         <div class="task-header">
@@ -311,17 +316,22 @@ export class BackgroundTasksPanel extends LitElement {
             aria-hidden="true"
             class="task-icon task-icon--inquiry"
           ></wa-icon>
-          <span class="inquiry-id" title=${thread.threadId}
-            >${thread.threadId}</span
+          <span id="${idPrefix}-id" class="inquiry-id">${thread.threadId}</span>
+          <wa-tooltip for="${idPrefix}-id">${thread.threadId}</wa-tooltip>
+          <span id="${idPrefix}-description" class="task-description"
+            >${preview}</span
           >
-          <span class="task-description" title=${preview}>${preview}</span>
+          <wa-tooltip for="${idPrefix}-description">${preview}</wa-tooltip>
           <wa-relative-time
+            id="${idPrefix}-elapsed"
             class="task-elapsed"
             date=${thread.lastActivityIso}
-            title=${thread.lastActivityIso}
             format="narrow"
             sync
           ></wa-relative-time>
+          <wa-tooltip for="${idPrefix}-elapsed"
+            >${thread.lastActivityIso}</wa-tooltip
+          >
           <wa-badge
             class="task-status"
             variant=${inquiryStatusVariant(thread.status)}
@@ -363,14 +373,17 @@ export class BackgroundTasksPanel extends LitElement {
           ${repeat(
             children,
             (c) => c.executionId,
-            (c) => this.renderTaskItem(c),
+            (c, index) => this.renderTaskItem(c, index),
           )}
         </div>
       </wa-details>
     `;
   }
 
-  private renderTaskItem(child: ActiveChildInfo): TemplateResult {
+  private renderTaskItem(
+    child: ActiveChildInfo,
+    index: number,
+  ): TemplateResult {
     const icon = getTaskIcon(child);
     const childStreamId =
       child.kind === 'subagent' ? child.childStreamId : undefined;
@@ -379,6 +392,10 @@ export class BackgroundTasksPanel extends LitElement {
       ? this.streamById.get(childStreamId)?.description
       : undefined;
     const badge = taskStatusBadge(child);
+    const idPrefix = `background-subagent-${index}`;
+    const nameTooltip = isClickable
+      ? `Go to ${child.agentName}`
+      : child.agentName;
 
     return html`
       <div class="task-item">
@@ -394,11 +411,11 @@ export class BackgroundTasksPanel extends LitElement {
             })}
           ></wa-icon>
           <span
+            id="${idPrefix}-name"
             class=${classMap({
               'task-name': true,
               'task-name--clickable': isClickable,
             })}
-            title=${isClickable ? `Go to ${child.agentName}` : child.agentName}
             role=${isClickable ? 'link' : 'text'}
             tabindex=${isClickable ? '0' : '-1'}
             @click=${
@@ -418,11 +435,14 @@ export class BackgroundTasksPanel extends LitElement {
             }
             >${child.agentName}</span
           >
+          <wa-tooltip for="${idPrefix}-name">${nameTooltip}</wa-tooltip>
           ${
             description
-              ? html`<span class="task-description" title=${description}
-                  >(${description})</span
-                >`
+              ? html`<span id="${idPrefix}-description" class="task-description"
+                    >(${description})</span
+                  ><wa-tooltip for="${idPrefix}-description"
+                    >${description}</wa-tooltip
+                  >`
               : nothing
           }
           ${

--- a/packages/extension/src/progressView/frontend/components/ContextManagement.ts
+++ b/packages/extension/src/progressView/frontend/components/ContextManagement.ts
@@ -8,6 +8,7 @@ import { repeat } from 'lit/directives/repeat.js';
 // Side-effect imports - register WA components
 import '@awesome.me/webawesome/dist/components/details/details.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 
 // Local imports - shared styles
 import { designTokens, commonViewStyles } from '@shared/styles';
@@ -138,8 +139,8 @@ export class ContextManagement extends LitElement {
           ${repeat(
             this.items,
             (item) => item.label,
-            (item) => html`
-              <span class="stat-item" title=${item.label}>
+            (item, index) => html`
+              <span id="context-stat-${index}" class="stat-item">
                 <wa-icon
                   library=${TEXRA_ICON_LIBRARY}
                   name=${item.icon}
@@ -147,6 +148,7 @@ export class ContextManagement extends LitElement {
                 ></wa-icon>
                 ${item.value}
               </span>
+              <wa-tooltip for="context-stat-${index}">${item.label}</wa-tooltip>
             `,
           )}
           ${

--- a/packages/extension/src/progressView/frontend/components/FileList.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.ts
@@ -486,8 +486,8 @@ export class FileList extends LitElement {
         }
         <span class="file-name">
           <span
+            id="${idPrefix}-path"
             class="file-path clickable-link"
-            title=${tooltipPath}
             data-command=${PROGRESS_VIEW_COMMANDS.OPEN_FILE}
             data-file=${filePath}
             role="button"
@@ -496,6 +496,7 @@ export class FileList extends LitElement {
             <span class="file-dir">${dir}</span>
             <span class="file-basename">${basename}</span>
           </span>
+          <wa-tooltip for="${idPrefix}-path">${tooltipPath}</wa-tooltip>
         </span>
         ${diffStats}
         <div class="file-actions">

--- a/packages/extension/src/progressView/frontend/components/LatexdiffResults.ts
+++ b/packages/extension/src/progressView/frontend/components/LatexdiffResults.ts
@@ -9,6 +9,7 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 // Side-effect imports - register WA components
 import '@awesome.me/webawesome/dist/components/details/details.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 
 // Local imports - shared styles
 import { designTokens, commonViewStyles } from '@shared/styles';
@@ -106,7 +107,7 @@ export class LatexdiffResults extends LitElement {
     >`;
   }
 
-  private renderEntry(entry: DiffResultDisplay): TemplateResult {
+  private renderEntry(entry: DiffResultDisplay, index: number): TemplateResult {
     const {
       baseFile,
       revisedFile,
@@ -124,12 +125,9 @@ export class LatexdiffResults extends LitElement {
       baseRound === null ? displayName : `${displayName} [r${baseRound}]`;
     const revisedLabel = `[r${revisedRound}]`;
 
+    const entryId = `latexdiff-entry-${index}`;
     return html`
-      <li
-        class="detail-item"
-        data-run-id=${ifDefined(runId)}
-        title=${ifDefined(message)}
-      >
+      <li id=${entryId} class="detail-item" data-run-id=${ifDefined(runId)}>
         <wa-icon
           library=${TEXRA_ICON_LIBRARY}
           name=${icon}
@@ -144,6 +142,7 @@ export class LatexdiffResults extends LitElement {
         ></wa-icon>
         ${this.renderFileLink(revisedFile, revisedLabel)}
         (${this.renderFileLink(diffFile, 'diff')})
+        ${message ? html`<wa-tooltip for=${entryId}>${message}</wa-tooltip>` : nothing}
       </li>
     `;
   }
@@ -175,7 +174,7 @@ export class LatexdiffResults extends LitElement {
             this.entries,
             (entry, index) =>
               `${entry.baseFile}-${entry.revisedFile}-${entry.baseRound ?? 'base'}-${entry.revisedRound ?? 'rev'}-${index}`,
-            (entry) => this.renderEntry(entry),
+            (entry, index) => this.renderEntry(entry, index),
           )}
         </ul>
       </wa-details>

--- a/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -12,6 +12,7 @@ import '@awesome.me/webawesome/dist/components/badge/badge.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/select/select.js';
 import '@awesome.me/webawesome/dist/components/option/option.js';
+import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 
 // Local imports - shared styles
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
@@ -195,9 +196,10 @@ export class ProposalRequestPanel extends BaseApprovalPanel<'proposal'> {
       approveTitle: 'Approve (y)',
       rejectTitle: 'Reject (n)',
       trailingActions: renderLabeledActionButton({
+        id: 'proposal-setup-button',
         icon: 'reply',
         text: 'Setup',
-        title: 'Setup (s)',
+        tooltip: 'Setup (s)',
         action: 'setup',
         onClick: () => this.emitAction({ action: 'setup' }),
       }),
@@ -221,15 +223,18 @@ export class ProposalRequestPanel extends BaseApprovalPanel<'proposal'> {
     const workingDirectory = data.workingDirectory;
     if (!workingDirectory) return nothing;
     return html`<div
-      class="workflow-proposal__working-directory"
-      title=${workingDirectory}
-    >
-      <span class="workflow-proposal__file-label">Working directory:</span>
-      <span
-        class="workflow-proposal__file-name workflow-proposal__file-name--readonly workflow-proposal__file-name--wrap"
-        >${workingDirectory}</span
+        id="proposal-working-directory"
+        class="workflow-proposal__working-directory"
       >
-    </div>`;
+        <span class="workflow-proposal__file-label">Working directory:</span>
+        <span
+          class="workflow-proposal__file-name workflow-proposal__file-name--readonly workflow-proposal__file-name--wrap"
+          >${workingDirectory}</span
+        >
+      </div>
+      <wa-tooltip for="proposal-working-directory"
+        >${workingDirectory}</wa-tooltip
+      >`;
   }
 
   private renderProposalFiles(
@@ -264,6 +269,10 @@ export class ProposalRequestPanel extends BaseApprovalPanel<'proposal'> {
   ): TemplateResult | typeof nothing {
     if (files.length === 0) return nothing;
 
+    const idPrefix = `proposal-${label.toLowerCase()}`.replaceAll(
+      /[^a-z0-9_-]/g,
+      '-',
+    );
     return html`
       <div
         class="workflow-proposal__${label.toLowerCase()}-files"
@@ -276,15 +285,15 @@ export class ProposalRequestPanel extends BaseApprovalPanel<'proposal'> {
           (file) => file,
           (file, i) =>
             html`${i > 0 ? ', ' : ''}<span
+                id="${idPrefix}-file-${i}"
                 class="workflow-proposal__file-name${
                   clickable ? '' : ' workflow-proposal__file-name--readonly'
                 }"
-                title=${file}
                 data-file=${ifDefined(clickable ? file : undefined)}
                 role=${ifDefined(clickable ? 'button' : undefined)}
                 tabindex=${ifDefined(clickable ? '0' : undefined)}
                 >${getBasename(file)}</span
-              >`,
+              ><wa-tooltip for="${idPrefix}-file-${i}">${file}</wa-tooltip>`,
         )}
       </div>
     `;

--- a/packages/extension/src/progressView/frontend/components/QueuedFollowUps.ts
+++ b/packages/extension/src/progressView/frontend/components/QueuedFollowUps.ts
@@ -1,11 +1,11 @@
 // Third-party imports
-import { LitElement, html, css, type TemplateResult } from 'lit';
+import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { ifDefined } from 'lit/directives/if-defined.js';
 import { repeat } from 'lit/directives/repeat.js';
 
 // Side-effect imports - register WA icon component
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 
 // Local imports - shared styles
 import { designTokens, commonViewStyles } from '@shared/styles';
@@ -123,10 +123,11 @@ export class QueuedFollowUps extends LitElement {
           ${repeat(
             this.messages,
             (_message, index) => index,
-            (message) => {
+            (message, index) => {
               const { display, full } = this.truncateMessage(message);
+              const itemId = `queued-follow-up-${index}`;
               return html`
-                <div class="queued-follow-up-item" title=${ifDefined(full)}>
+                <div id=${itemId} class="queued-follow-up-item">
                   <wa-icon
                     library=${TEXRA_ICON_LIBRARY}
                     name="comment"
@@ -135,6 +136,7 @@ export class QueuedFollowUps extends LitElement {
                   ></wa-icon>
                   <span class="queued-follow-up-text">${display}</span>
                 </div>
+                ${full ? html`<wa-tooltip for=${itemId}>${full}</wa-tooltip>` : nothing}
               `;
             },
           )}

--- a/packages/extension/src/progressView/frontend/components/StreamHeader.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamHeader.ts
@@ -4,7 +4,6 @@ import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { consume } from '@lit/context';
 import { customElement, property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
-import { ifDefined } from 'lit/directives/if-defined.js';
 import { repeat } from 'lit/directives/repeat.js';
 
 // Local imports - shared styles
@@ -371,7 +370,8 @@ export class StreamHeader extends LitElement {
             ? this.superYoloActive
             : this.yoloActive),
         );
-        const title = isActive && btn.titleActive ? btn.titleActive : btn.title;
+        const tooltipText =
+          isActive && btn.titleActive ? btn.titleActive : btn.title;
         const className = [
           btn.className,
           hidden ? 'toolbar-button--hidden' : undefined,
@@ -382,8 +382,8 @@ export class StreamHeader extends LitElement {
         const { button, tooltip } = renderIconActionButtonParts({
           id: btn.id,
           icon: btn.icon as TeXRAIconName,
-          label: title,
-          tooltip: title,
+          label: tooltipText,
+          tooltip: tooltipText,
           className,
           disabled,
           ariaHidden: hidden,
@@ -407,10 +407,16 @@ export class StreamHeader extends LitElement {
               <span
                 id=${ELEMENT_IDS.ACTIVE_STREAM_NAME}
                 data-stream=${this.stream.name}
-                title=${ifDefined(this.stream.label || undefined)}
               >
                 ${this.stream.label || this.stream.name}
               </span>
+              ${
+                this.stream.label
+                  ? html`<wa-tooltip for=${ELEMENT_IDS.ACTIVE_STREAM_NAME}
+                      >${this.stream.label}</wa-tooltip
+                    >`
+                  : nothing
+              }
             </div>
             <span
               id=${ELEMENT_IDS.STATUS_INDICATOR}

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -74,7 +74,7 @@ function buildTooltip(
       ? (info.modelLabel ?? info.model)
       : undefined;
   const mainLine = [
-    info.label,
+    info.label || info.name,
     `Status: ${statusLabel}`,
     modelDisplay && `Model: ${modelDisplay}`,
     info.inputFile && `Input: ${info.inputFile}`,
@@ -155,6 +155,9 @@ export class StreamTab extends LitElement {
     const streamDecorator = this._streamDecorator;
     const hasChildren = this.childCount > 0 && !this.compact;
     const childStreamLabel = formatResultCount(this.childCount, 'child stream');
+    const childToggleLabel = this.expanded
+      ? 'Collapse child streams'
+      : childStreamLabel;
 
     return html`
       <div
@@ -170,29 +173,31 @@ export class StreamTab extends LitElement {
         ${
           hasChildren
             ? html`<wa-button
-                class="action-icon-button tab-expand"
-                appearance="plain"
-                variant="neutral"
-                size="small"
-                type="button"
-                data-stream=${stream.name}
-                data-action="toggle-children"
-                title=${
-                  this.expanded ? 'Collapse child streams' : childStreamLabel
-                }
-                aria-expanded=${this.expanded ? 'true' : 'false'}
-                >${waIcon('chevron-right')}</wa-button
-              >`
+                  id="stream-tab-expand-button"
+                  class="action-icon-button tab-expand"
+                  appearance="plain"
+                  variant="neutral"
+                  size="small"
+                  type="button"
+                  data-stream=${stream.name}
+                  data-action="toggle-children"
+                  aria-label=${childToggleLabel}
+                  aria-expanded=${this.expanded ? 'true' : 'false'}
+                  >${waIcon('chevron-right')}</wa-button
+                ><wa-tooltip for="stream-tab-expand-button"
+                  >${childToggleLabel}</wa-tooltip
+                >`
             : nothing
         }
         <button
+          id="stream-tab-select-button"
           class="tab"
           data-stream=${stream.name}
           data-action="select"
-          title=${tooltip}
+          aria-label=${tooltip}
         >
           <div class="tab-header">
-            <span class="tab-title"
+            <span id="stream-tab-title" class="tab-title"
               >${
                 stream.parentStreamId
                   ? html`<wa-icon
@@ -207,12 +212,12 @@ export class StreamTab extends LitElement {
             ${
               this.childCount > 0 && this.compact
                 ? html`<wa-icon
+                    id="stream-tab-compact-children"
                     library=${TEXRA_ICON_LIBRARY}
                     name="chevron-right"
                     class="compact-subagent-hint"
                     role="img"
                     aria-label=${childStreamLabel}
-                    title=${childStreamLabel}
                   ></wa-icon>`
                 : nothing
             }
@@ -256,25 +261,21 @@ export class StreamTab extends LitElement {
                       }</span
                     >
                     <wa-icon
+                      id="stream-tab-kind"
                       library=${TEXRA_ICON_LIBRARY}
                       name=${streamDecorator.icon}
                       class="stream-kind"
                       aria-hidden="true"
-                      title=${
-                        stream.kind === 'workflowScript'
-                          ? streamDecorator.label
-                          : `Category: ${streamDecorator.label}`
-                      }
                     ></wa-icon>
                     ${when(
                       stream.isRemote,
                       () => html`
                         <wa-icon
+                          id="stream-tab-remote"
                           library=${TEXRA_ICON_LIBRARY}
                           name=${AGENT_DECORATORS.properties.remote.icon}
                           class="remote-agent"
                           aria-hidden="true"
-                          title=${AGENT_DECORATORS.properties.remote.hint}
                         ></wa-icon>
                       `,
                     )}
@@ -282,6 +283,31 @@ export class StreamTab extends LitElement {
                 `
           }
         </button>
+        <wa-tooltip for="stream-tab-title">${tooltip}</wa-tooltip>
+        ${
+          this.childCount > 0 && this.compact
+            ? html`<wa-tooltip for="stream-tab-compact-children"
+                >${childStreamLabel}</wa-tooltip
+              >`
+            : nothing
+        }
+        ${
+          this.compact
+            ? nothing
+            : html`<wa-tooltip for="stream-tab-kind"
+                  >${
+                    stream.kind === 'workflowScript'
+                      ? streamDecorator.label
+                      : `Category: ${streamDecorator.label}`
+                  }</wa-tooltip
+                >${when(
+                  stream.isRemote,
+                  () =>
+                    html`<wa-tooltip for="stream-tab-remote"
+                      >${AGENT_DECORATORS.properties.remote.hint}</wa-tooltip
+                    >`,
+                )}`
+        }
         <wa-button
           id="stream-tab-delete-button"
           class="action-icon-button tab-delete"

--- a/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
@@ -100,9 +100,10 @@ export class ToolEditRequestPanel extends BaseBypassApprovalPanel<'toolEdit'> {
     return html`
       <div class="diff-dropdown">
         ${renderLabeledActionButton({
+          id: 'tool-edit-diff-button',
           icon: 'diff',
           text: diffLabel,
-          title: diffTitle,
+          tooltip: diffTitle,
           className: 'diff-main-button',
           onClick: this.handleDiffAction,
         })}
@@ -179,7 +180,7 @@ export class ToolEditRequestPanel extends BaseBypassApprovalPanel<'toolEdit'> {
         : `${parts.join(' / ')} ${lineLabel} changed`;
 
     return html`
-      <span class="approval-request__diff" title=${tooltip}>
+      <span id="tool-edit-diff-summary" class="approval-request__diff">
         ${when(
           added > 0,
           () =>
@@ -194,6 +195,7 @@ export class ToolEditRequestPanel extends BaseBypassApprovalPanel<'toolEdit'> {
         )}
         <span class="approval-request__diff-label">${total} ${lineLabel}</span>
       </span>
+      <wa-tooltip for="tool-edit-diff-summary">${tooltip}</wa-tooltip>
     `;
   }
 

--- a/packages/extension/src/progressView/frontend/components/UserMessage.ts
+++ b/packages/extension/src/progressView/frontend/components/UserMessage.ts
@@ -12,6 +12,7 @@ import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 
 // Side-effect imports - register WA icon component
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 
 // Local imports - shared styles
 import { compactIconActionButtonStyles } from '@shared/styles';
@@ -236,8 +237,11 @@ export class UserMessage extends LitElement {
                 class="user-message-icon"
                 aria-hidden="true"
               ></wa-icon>
-              <span class="user-message-timestamp" title=${tooltipTimestamp}
+              <span id="user-message-timestamp" class="user-message-timestamp"
                 >${timeDisplay}</span
+              >
+              <wa-tooltip for="user-message-timestamp"
+                >${tooltipTimestamp}</wa-tooltip
               >
             </span>
             ${renderIconActionButton({

--- a/packages/extension/src/progressView/frontend/components/WorktreeChip.ts
+++ b/packages/extension/src/progressView/frontend/components/WorktreeChip.ts
@@ -14,6 +14,7 @@ import { TEXRA_ICON_LIBRARY, waIcon } from '@shared/wa/webAwesomeIcons';
 
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/badge/badge.js';
+import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 
 const PR_STATE_LABEL: Record<WorktreePRState, string> = {
   [WORKTREE_PR_STATE.OPEN]: 'Open',
@@ -182,12 +183,14 @@ export class WorktreeChip extends LitElement {
 
   private renderPRPill(state: WorktreePRState): TemplateResult {
     return html`<wa-badge
-      class="pill"
-      variant=${PR_STATE_VARIANT[state]}
-      appearance="filled"
-      title=${`PR ${PR_STATE_LABEL[state]}`}
-      >${PR_STATE_LABEL[state]}</wa-badge
-    >`;
+        id="worktree-pr-state"
+        class="pill"
+        variant=${PR_STATE_VARIANT[state]}
+        appearance="filled"
+        >${PR_STATE_LABEL[state]}</wa-badge
+      ><wa-tooltip for="worktree-pr-state"
+        >PR ${PR_STATE_LABEL[state]}</wa-tooltip
+      >`;
   }
 
   private renderBranch(): TemplateResult | typeof nothing {
@@ -197,20 +200,21 @@ export class WorktreeChip extends LitElement {
     const tooltip = this.info.dirty
       ? `${branchKind} ${branch} (uncommitted changes)`
       : `${branchKind} ${branch}`;
-    return html`<span class="branch" title=${tooltip}>
-      ${waIcon('code-branch')}
-      <span class="branch-name">${branch}</span>
-      ${
-        this.info.dirty
-          ? html`<span
-                class="dirty-dot"
-                role="img"
-                aria-label="uncommitted changes"
-              ></span>
-              <span class="sr-only">uncommitted changes</span>`
-          : nothing
-      }
-    </span>`;
+    return html`<span id="worktree-branch" class="branch">
+        ${waIcon('code-branch')}
+        <span class="branch-name">${branch}</span>
+        ${
+          this.info.dirty
+            ? html`<span
+                  class="dirty-dot"
+                  role="img"
+                  aria-label="uncommitted changes"
+                ></span>
+                <span class="sr-only">uncommitted changes</span>`
+            : nothing
+        }
+      </span>
+      <wa-tooltip for="worktree-branch">${tooltip}</wa-tooltip>`;
   }
 
   private worktreeLabel(): string | undefined {
@@ -224,37 +228,41 @@ export class WorktreeChip extends LitElement {
     const titleAttr = pr.title ? `#${pr.number} ${pr.title}` : `#${pr.number}`;
     const showStats = pr.additions != null || pr.deletions != null;
     return html`
-      <span class="pr-number" title=${titleAttr}>#${pr.number}</span>
+      <span id="worktree-pr-number" class="pr-number">#${pr.number}</span>
+      <wa-tooltip for="worktree-pr-number">${titleAttr}</wa-tooltip>
       ${
         pr.title
-          ? html`<span class="pr-title" title=${pr.title}>${pr.title}</span>`
+          ? html`<span id="worktree-pr-title" class="pr-title">${pr.title}</span
+              ><wa-tooltip for="worktree-pr-title">${pr.title}</wa-tooltip>`
           : nothing
       }
       ${
         showStats
-          ? html`<span class="diff-stats" title="Lines changed">
-              ${
-                pr.additions != null
-                  ? html`<span class="diff-added">+${pr.additions}</span>`
-                  : nothing
-              }
-              ${
-                pr.deletions != null
-                  ? html`<span class="diff-removed">−${pr.deletions}</span>`
-                  : nothing
-              }
-            </span>`
+          ? html`<span id="worktree-diff-stats" class="diff-stats">
+                ${
+                  pr.additions != null
+                    ? html`<span class="diff-added">+${pr.additions}</span>`
+                    : nothing
+                }
+                ${
+                  pr.deletions != null
+                    ? html`<span class="diff-removed">−${pr.deletions}</span>`
+                    : nothing
+                }
+              </span>
+              <wa-tooltip for="worktree-diff-stats">Lines changed</wa-tooltip>`
           : nothing
       }
       ${
         pr.ciState
           ? html`<wa-icon
-              library=${TEXRA_ICON_LIBRARY}
-              name=${CI_ICON[ci]}
-              class=${classMap({ 'ci-icon': true, [`ci-${ci}`]: true })}
-              title=${CI_LABEL[ci]}
-              aria-label=${CI_LABEL[ci]}
-            ></wa-icon>`
+                id="worktree-ci-status"
+                library=${TEXRA_ICON_LIBRARY}
+                name=${CI_ICON[ci]}
+                class=${classMap({ 'ci-icon': true, [`ci-${ci}`]: true })}
+                aria-label=${CI_LABEL[ci]}
+              ></wa-icon>
+              <wa-tooltip for="worktree-ci-status">${CI_LABEL[ci]}</wa-tooltip>`
           : nothing
       }
     `;

--- a/src/test-kernel/progressView/BackgroundTasksPanel.vitest.mts
+++ b/src/test-kernel/progressView/BackgroundTasksPanel.vitest.mts
@@ -78,6 +78,10 @@ describe('background-tasks-panel', () => {
       (node) => node.textContent,
     );
     expect(names).toEqual(['reviewer', 'polisher']);
+    for (const name of shadow.querySelectorAll<HTMLElement>('.task-name')) {
+      expect(name.hasAttribute('title')).toBe(false);
+      expect(shadow.querySelector(`wa-tooltip[for="${name.id}"]`)).toBeTruthy();
+    }
 
     const rows = [...shadow.querySelectorAll('.task-item')];
     expect(rows.at(-1)?.textContent).toContain('1m 4s');

--- a/src/test-kernel/progressView/FileList.vitest.mts
+++ b/src/test-kernel/progressView/FileList.vitest.mts
@@ -188,6 +188,12 @@ describe('file-list keyboard activation', () => {
 
     const filePath = element.shadowRoot?.querySelector('.file-path');
     expect(filePath).toBeInstanceOf(HTMLElement);
+    expect(filePath?.hasAttribute('title')).toBe(false);
+    expect(
+      element.shadowRoot
+        ?.querySelector(`wa-tooltip[for="${filePath?.id}"]`)
+        ?.textContent?.trim(),
+    ).toBe('paper_revised.tex');
     dispatchSpace(filePath!);
 
     expect(actions).toEqual([

--- a/src/test-kernel/progressView/ProposalRequestPanel.vitest.mts
+++ b/src/test-kernel/progressView/ProposalRequestPanel.vitest.mts
@@ -98,6 +98,19 @@ describe('proposal-request-panel file-name keyboard activation', () => {
     posted = [];
   });
 
+  it('uses a shared tooltip for the direct Setup action', async () => {
+    const element = await mountPanel();
+    const setup = element.shadowRoot?.querySelector('#proposal-setup-button');
+
+    expect(setup).toBeTruthy();
+    expect(setup?.hasAttribute('title')).toBe(false);
+    expect(
+      element.shadowRoot
+        ?.querySelector('wa-tooltip[for="proposal-setup-button"]')
+        ?.textContent?.trim(),
+    ).toBe('Setup (s)');
+  });
+
   it('maps the menu and a shortcut to approve-all while y stays one-off', async () => {
     const element = await mountPanel();
     const actions = recordPermissionActions(element);
@@ -170,6 +183,10 @@ describe('proposal-request-panel file-name keyboard activation', () => {
     for (const name of names ?? []) {
       expect(name.getAttribute('role')).toBe('button');
       expect(name.getAttribute('tabindex')).toBe('0');
+      expect(name.hasAttribute('title')).toBe(false);
+      expect(
+        element.shadowRoot?.querySelector(`wa-tooltip[for="${name.id}"]`),
+      ).toBeTruthy();
     }
   });
 

--- a/src/test-kernel/progressView/RemainingTooltipContracts.vitest.mts
+++ b/src/test-kernel/progressView/RemainingTooltipContracts.vitest.mts
@@ -1,0 +1,99 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports
+import type { ContextManagement } from '@progressView/frontend/components/ContextManagement';
+import type { LatexdiffResults } from '@progressView/frontend/components/LatexdiffResults';
+import type { QueuedFollowUps } from '@progressView/frontend/components/QueuedFollowUps';
+
+// Local file imports
+import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
+
+function expectUniqueIds(root: ShadowRoot): void {
+  const ids = [...root.querySelectorAll<HTMLElement>('[id]')].map(
+    (element) => element.id,
+  );
+  expect(new Set(ids).size).toBe(ids.length);
+}
+
+describe('remaining progress-view tooltip contracts', () => {
+  useLitComponentTestDom(() =>
+    Promise.all([
+      import('@progressView/frontend/components/ContextManagement'),
+      import('@progressView/frontend/components/LatexdiffResults'),
+      import('@progressView/frontend/components/QueuedFollowUps'),
+    ]),
+  );
+
+  it('anchors repeated context-stat hints with indexed ids', async () => {
+    const element = document.createElement(
+      'context-management',
+    ) as ContextManagement;
+    element.items = [
+      { icon: 'history', label: 'Before', value: '10k' },
+      { icon: 'history', label: 'After', value: '5k' },
+    ];
+    document.body.append(element);
+    await element.updateComplete;
+
+    const shadow = element.shadowRoot!;
+    expect(shadow.querySelector('[title]')).toBeNull();
+    expectUniqueIds(shadow);
+    expect(
+      shadow.querySelector('wa-tooltip[for="context-stat-1"]')?.textContent,
+    ).toBe('After');
+  });
+
+  it('only adds the queued-message tooltip when text is truncated', async () => {
+    const full = 'x'.repeat(201);
+    const element = document.createElement(
+      'queued-follow-ups',
+    ) as QueuedFollowUps;
+    element.messages = ['short', full];
+    document.body.append(element);
+    await element.updateComplete;
+
+    const shadow = element.shadowRoot!;
+    expect(shadow.querySelector('[title]')).toBeNull();
+    expectUniqueIds(shadow);
+    expect(
+      shadow.querySelector('wa-tooltip[for="queued-follow-up-0"]'),
+    ).toBeNull();
+    expect(
+      shadow.querySelector('wa-tooltip[for="queued-follow-up-1"]')?.textContent,
+    ).toBe(full);
+  });
+
+  it('anchors latexdiff messages to their indexed rows', async () => {
+    const element = document.createElement(
+      'latexdiff-results',
+    ) as LatexdiffResults;
+    element.entries = [
+      {
+        baseFile: '/workspace/paper.tex',
+        revisedFile: '/workspace/paper-revised.tex',
+        diffFile: '/workspace/paper-diff.pdf',
+        displayName: 'paper.tex',
+        baseRound: null,
+        revisedRound: 1,
+        status: 'error',
+        message: 'LaTeXdiff failed',
+      },
+    ];
+    document.body.append(element);
+    await element.updateComplete;
+
+    const shadow = element.shadowRoot!;
+    expect(shadow.querySelector('[title]')).toBeNull();
+    expectUniqueIds(shadow);
+    const row = shadow.querySelector('#latexdiff-entry-0');
+    const tooltip = shadow.querySelector('wa-tooltip[for="latexdiff-entry-0"]');
+    expect(tooltip?.textContent).toBe('LaTeXdiff failed');
+    expect(tooltip?.parentElement).toBe(row);
+    expect(
+      [...(shadow.querySelector('.latexdiff-content')?.children ?? [])].every(
+        (child) => child.tagName === 'LI',
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/test-kernel/progressView/StreamHeader.vitest.mts
+++ b/src/test-kernel/progressView/StreamHeader.vitest.mts
@@ -127,6 +127,20 @@ describe('stream-header', () => {
    * status-indicator pattern.
    */
   describe('tooltips', () => {
+    it('anchors the truncated stream label via wa-tooltip[for]', async () => {
+      const element = await mount();
+      const name = element.shadowRoot?.querySelector(
+        `#${ELEMENT_IDS.ACTIVE_STREAM_NAME}`,
+      );
+
+      expect(name?.hasAttribute('title')).toBe(false);
+      expect(
+        element.shadowRoot
+          ?.querySelector(`wa-tooltip[for="${ELEMENT_IDS.ACTIVE_STREAM_NAME}"]`)
+          ?.textContent?.trim(),
+      ).toBe('Stream A');
+    });
+
     it('anchors the goal chip tooltip via wa-tooltip[for], not a native title', async () => {
       const element = await mount({
         goalActive: true,

--- a/src/test-kernel/progressView/StreamTabsExpandChevron.vitest.mts
+++ b/src/test-kernel/progressView/StreamTabsExpandChevron.vitest.mts
@@ -53,6 +53,84 @@ describe('stream-tab expand chevron', () => {
     expect(expandButton?.getAttribute('data-stream')).toBe('parent');
     expect(expandButton?.getAttribute('data-action')).toBe('toggle-children');
     expect(expandButton?.hasAttribute('aria-expanded')).toBe(true);
+    const expectedLabel =
+      expandButton?.getAttribute('aria-expanded') === 'true'
+        ? 'Collapse child streams'
+        : '1 child stream';
+    expect(expandButton?.getAttribute('aria-label')).toBe(expectedLabel);
+    expect(
+      parentTab?.shadowRoot
+        ?.querySelector('wa-tooltip[for="stream-tab-expand-button"]')
+        ?.textContent?.trim(),
+    ).toBe(expectedLabel);
+  });
+
+  it('identifies an unlabeled stream by name in the select aria-label', async () => {
+    const tabs = document.createElement('stream-tabs') as StreamTabs;
+    tabs.streams = [{ ...makeStream('unlabeled-stream'), label: '' }];
+    document.body.append(tabs);
+    await tabs.updateComplete;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const ariaLabel = tabs.shadowRoot
+      ?.querySelector('stream-tab')
+      ?.shadowRoot?.querySelector('#stream-tab-select-button')
+      ?.getAttribute('aria-label');
+    expect(ariaLabel).toContain('unlabeled-stream');
+  });
+
+  it('anchors the general hint to the title, not an ancestor of specific hints', async () => {
+    const tabs = document.createElement('stream-tabs') as StreamTabs;
+    tabs.streams = [
+      {
+        ...makeStream('remote'),
+        isRemote: true,
+        worktree: {
+          workingDirectory: '/tmp/texra/remote',
+          branch: 'remote',
+        },
+      },
+    ];
+    document.body.append(tabs);
+    await tabs.updateComplete;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const tab = tabs.shadowRoot?.querySelector('stream-tab');
+    const shadow = tab?.shadowRoot;
+    const title = shadow?.querySelector('#stream-tab-title');
+    const select = shadow?.querySelector('#stream-tab-select-button');
+
+    expect(
+      shadow?.querySelector('wa-tooltip[for="stream-tab-select-button"]'),
+    ).toBeNull();
+    expect(
+      shadow?.querySelector('wa-tooltip[for="stream-tab-title"]'),
+    ).toBeTruthy();
+    expect(select?.getAttribute('aria-label')).toContain('Status:');
+    expect(
+      title?.contains(shadow?.querySelector('#stream-tab-kind') ?? null),
+    ).toBe(false);
+    expect(
+      title?.contains(shadow?.querySelector('#stream-tab-remote') ?? null),
+    ).toBe(false);
+    expect(
+      title?.contains(shadow?.querySelector('worktree-chip') ?? null),
+    ).toBe(false);
+
+    tabs.compact = true;
+    tabs.childStreamsByParent = new Map([
+      ['remote', [makeStream('remote-child')]],
+    ]);
+    await tabs.updateComplete;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const compactShadow =
+      tabs.shadowRoot?.querySelector('stream-tab')?.shadowRoot;
+    expect(
+      compactShadow
+        ?.querySelector('#stream-tab-title')
+        ?.contains(compactShadow.querySelector('#stream-tab-compact-children')),
+    ).toBe(false);
   });
 
   it('renders workflow scripts as orchestration streams without a model', async () => {
@@ -78,6 +156,11 @@ describe('stream-tab expand chevron', () => {
 
     expect(model?.textContent?.trim()).toBe('');
     expect(kindIcon?.name).toBe('list-tree');
-    expect(kindIcon?.getAttribute('title')).toBe('Workflow Script');
+    expect(kindIcon?.hasAttribute('title')).toBe(false);
+    expect(
+      tab?.shadowRoot
+        ?.querySelector('wa-tooltip[for="stream-tab-kind"]')
+        ?.textContent?.trim(),
+    ).toBe('Workflow Script');
   });
 });

--- a/src/test-kernel/progressView/ToolEditRequestPanel.vitest.mts
+++ b/src/test-kernel/progressView/ToolEditRequestPanel.vitest.mts
@@ -71,6 +71,37 @@ describe('tool-edit-request-panel', () => {
     () => import('@progressView/frontend/components/ToolEditRequestPanel'),
   );
 
+  it('uses a shared tooltip for the direct diff action', async () => {
+    const element = await mountPanel(
+      createPermission({ originalContent: 'before', proposedContent: 'after' }),
+    );
+    const button = element.shadowRoot?.querySelector('#tool-edit-diff-button');
+
+    expect(button).toBeTruthy();
+    expect(button?.hasAttribute('title')).toBe(false);
+    expect(
+      element.shadowRoot
+        ?.querySelector('wa-tooltip[for="tool-edit-diff-button"]')
+        ?.textContent?.trim(),
+    ).toBe('Open inline diff (d)');
+  });
+
+  it('anchors the line-change hint with wa-tooltip instead of title', async () => {
+    const element = await mountPanel(
+      createPermission({ addedLines: 2, removedLines: 1 }),
+    );
+
+    const summary = element.shadowRoot?.querySelector(
+      '#tool-edit-diff-summary',
+    );
+    expect(summary?.hasAttribute('title')).toBe(false);
+    expect(
+      element.shadowRoot
+        ?.querySelector('wa-tooltip[for="tool-edit-diff-summary"]')
+        ?.textContent?.trim(),
+    ).toBe('+2 / -1 lines changed');
+  });
+
   it('renders inline diff when only proposed content is available', async () => {
     const element = await mountPanel(
       createPermission({

--- a/src/test-kernel/progressView/UserMessageStructuredDelivery.vitest.mts
+++ b/src/test-kernel/progressView/UserMessageStructuredDelivery.vitest.mts
@@ -65,5 +65,14 @@ describe('user-message structured delivery', () => {
         '.user-message-content.markdown-content',
       ),
     ).toBeFalsy();
+    const timestamp = element.shadowRoot?.querySelector(
+      '#user-message-timestamp',
+    );
+    expect(timestamp?.hasAttribute('title')).toBe(false);
+    expect(
+      element.shadowRoot?.querySelector(
+        'wa-tooltip[for="user-message-timestamp"]',
+      ),
+    ).toBeTruthy();
   });
 });

--- a/src/test-kernel/progressView/WorktreeChip.vitest.mts
+++ b/src/test-kernel/progressView/WorktreeChip.vitest.mts
@@ -20,6 +20,13 @@ const originalGlobals = {
   CSSStyleSheet: globalThis.CSSStyleSheet,
   Event: globalThis.Event,
   CustomEvent: globalThis.CustomEvent,
+  AbortController: globalThis.AbortController,
+  AbortSignal: globalThis.AbortSignal,
+  HTMLSlotElement: globalThis.HTMLSlotElement,
+  requestAnimationFrame: (globalThis as { requestAnimationFrame?: unknown })
+    .requestAnimationFrame,
+  cancelAnimationFrame: (globalThis as { cancelAnimationFrame?: unknown })
+    .cancelAnimationFrame,
   ResizeObserver: globalThis.ResizeObserver,
   Node: (globalThis as { Node?: unknown }).Node,
 };
@@ -44,6 +51,17 @@ function installDom(): void {
   globalThis.CSSStyleSheet = dom.window.CSSStyleSheet;
   globalThis.Event = dom.window.Event;
   globalThis.CustomEvent = dom.window.CustomEvent;
+  globalThis.AbortController = dom.window.AbortController;
+  globalThis.AbortSignal = dom.window.AbortSignal;
+  globalThis.HTMLSlotElement = dom.window.HTMLSlotElement;
+  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) =>
+    setTimeout(() => cb(performance.now()), 0) as unknown as number) as (
+    cb: FrameRequestCallback,
+  ) => number;
+  globalThis.cancelAnimationFrame = ((handle: number) =>
+    clearTimeout(handle as unknown as ReturnType<typeof setTimeout>)) as (
+    handle: number,
+  ) => void;
   globalThis.ResizeObserver = NoopResizeObserver;
   (globalThis as { Node: unknown }).Node = dom.window.Node;
   installAttachInternalsFallback(
@@ -64,11 +82,30 @@ function restoreDom(): void {
   globalThis.CSSStyleSheet = originalGlobals.CSSStyleSheet;
   globalThis.Event = originalGlobals.Event;
   globalThis.CustomEvent = originalGlobals.CustomEvent;
+  globalThis.AbortController = originalGlobals.AbortController;
+  globalThis.AbortSignal = originalGlobals.AbortSignal;
+  restoreOptionalGlobal('HTMLSlotElement', originalGlobals.HTMLSlotElement);
+  restoreOptionalGlobal(
+    'requestAnimationFrame',
+    originalGlobals.requestAnimationFrame,
+  );
+  restoreOptionalGlobal(
+    'cancelAnimationFrame',
+    originalGlobals.cancelAnimationFrame,
+  );
   globalThis.ResizeObserver = originalGlobals.ResizeObserver;
   if (originalGlobals.Node === undefined) {
     delete (globalThis as { Node?: unknown }).Node;
   } else {
     (globalThis as { Node: unknown }).Node = originalGlobals.Node;
+  }
+}
+
+function restoreOptionalGlobal(key: string, value: unknown): void {
+  if (value === undefined) {
+    delete (globalThis as Record<string, unknown>)[key];
+  } else {
+    (globalThis as Record<string, unknown>)[key] = value;
   }
 }
 
@@ -100,6 +137,32 @@ describe('worktree-chip', () => {
     });
 
     expect(element.shadowRoot?.textContent).toContain('issue-4018');
+  });
+
+  it('uses shared tooltips for PR metadata without duplicate ids', async () => {
+    const element = await mountChip({
+      workingDirectory: '/tmp/texra/issue-4018',
+      branch: 'issue-4018',
+      pr: {
+        number: 42,
+        state: 'open',
+        title: 'Tooltip migration',
+        additions: 3,
+        deletions: 1,
+        ciState: 'success',
+      },
+    });
+    const shadow = element.shadowRoot!;
+    const ids = [...shadow.querySelectorAll<HTMLElement>('[id]')].map(
+      (node) => node.id,
+    );
+
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(shadow.querySelector('[title]')).toBeNull();
+    expect(shadow.querySelectorAll('wa-tooltip')).toHaveLength(6);
+    expect(
+      shadow.querySelector('wa-tooltip[for="worktree-pr-title"]')?.textContent,
+    ).toBe('Tooltip migration');
   });
 
   it('exposes dirty state to assistive technology', async () => {


### PR DESCRIPTION
## Summary

- replace every remaining native `title=` hover hint in `progressView/frontend/components` with an anchored Web Awesome tooltip
- give repeated rows stable per-shadow-root IDs without changing truncation or displayed tooltip text
- avoid overlapping nested tooltip regions in stream tabs and preserve an accessible stream identity
- add focused DOM contracts for anchors, unique IDs, conditional tooltips, and valid list markup

Closes #9168.

## Net elements (R6)

- 20 files changed: 514 insertions, 109 deletions
- adds 1 focused test file and no production files
- adds 0 exported symbols, classes, interfaces, or enums
- introduces no new abstraction; all production changes reuse the existing Web Awesome tooltip component and action-button helper

## Consumer counts (R8)

- n/a — no exported API, emit path, or producer/consumer routing is added, removed, or changed
- each tooltip remains colocated with its existing rendered hint target inside the same component shadow root

## Review notes

The implementation was independently reviewed before opening this PR. Follow-up fixes:

- direct Setup and diff actions now opt into helper-rendered `wa-tooltip` rather than falling back to native titles
- the general stream-tab tooltip targets the title region, not the whole button containing independently hinted metadata
- unlabeled streams use `info.name` in the tooltip/accessibility label
- latexdiff tooltips remain inside their associated `<li>` elements

## Validation

- 9 focused progress-view test files: **52 tests passed**
- extension typecheck passed
- test-kernel typecheck passed
- scoped ESLint passed
- Prettier check passed
- acceptance scan: **0** native `title=` attributes in `packages/extension/src/progressView/frontend/components/*.ts`
- `git diff --check` passed
- independent final code review: no findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only tooltip and accessibility-label changes in the progress view with no backend or data-path impact; broad but mechanical with focused regression tests.
> 
> **Overview**
> Replaces the last native `title=` hover hints in progress-view Lit components with **Web Awesome `wa-tooltip`** anchored via stable `id` / `for` pairs, matching the pattern already used on stream header controls and file action buttons.
> 
> Repeated rows (inquiries, subagents, proposal files, context stats, queued messages, latexdiff entries) now get **per-index IDs** so each tooltip targets the right element without changing truncation or tooltip copy. Stream tabs move the summary hover to **`#stream-tab-title`** (not the whole select button), add separate tooltips for expand/kind/remote/compact-child hints, and use **`info.name` in `aria-label`/tooltip when `label` is empty**. Proposal and tool-edit panels pass **`tooltip`** (and button `id`) into shared labeled action helpers so Setup/diff actions don't fall back to native titles.
> 
> Tests assert **no `[title]`**, sibling `wa-tooltip[for=…]`, unique IDs where needed, conditional queued-follow-up tooltips, and latexdiff tooltips kept inside their `<li>` rows; worktree-chip tests gain jsdom globals required by `wa-tooltip`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d78e95597108114089bc704496cd3c6b3d8d54a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



