### PR TITLE
fix(tools): preserve background output row boundaries

### DIFF
--- a/src/shared/toolUse.ts
+++ b/src/shared/toolUse.ts
@@ -132,6 +132,25 @@ export const BASH_TOOL_DEFAULT_TIMEOUT_MS = 120_000;
  */
 export const BASH_BACKGROUND_LOG_CAP_CHARS = 200_000;
 
+const BASH_BACKGROUND_OUTPUT_SOURCE_KEY = 'backgroundBashOutputSource';
+export type BackgroundBashOutputSource = 'stdout' | 'stderr';
+
+/** Metadata attached only to stdout/stderr chunks from background `bash`. */
+export function backgroundBashOutputData(
+  source: BackgroundBashOutputSource,
+): Record<string, BackgroundBashOutputSource> {
+  return { [BASH_BACKGROUND_OUTPUT_SOURCE_KEY]: source };
+}
+
+/** Identify persisted LOG rows written from background command output chunks. */
+export function getBackgroundBashOutputSource(
+  data: unknown,
+): BackgroundBashOutputSource | undefined {
+  if (!isObject(data)) return undefined;
+  const source = data[BASH_BACKGROUND_OUTPUT_SOURCE_KEY];
+  return source === 'stdout' || source === 'stderr' ? source : undefined;
+}
+
 /** Default `executions wait` timeout (seconds) when the model omits `timeout`. */
 export const EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS = 300;
 

--- a/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
@@ -15,7 +15,12 @@ import { FileInteractionState } from '@agent/core/state/AgentWorkspaceState';
 import { withToolEnvironment } from '@agent/followUp/ToolFileInteractionContext';
 import * as toolUseFollowUp from '@agent/followUp/ToolUseFollowUp';
 import { defaultSession } from '@agent/runtime/SessionHandle';
-import type { StreamTabId } from '@shared/schemas';
+import {
+  LOG_LEVELS,
+  MESSAGE_TYPES,
+  STREAM_LOG_ENTRY_TYPES,
+  type StreamTabId,
+} from '@shared/schemas';
 import type { ExecResult } from '@shared/schemas/opResults';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { ExecutionsTool } from '@tools/ExecutionsTool';
@@ -140,7 +145,11 @@ describe('ExecutionsTool /executions/{id}/output', () => {
     assert.equal(result.status, 'executed');
     const output = result.output ?? '';
     assert.match(output, /^Output for \S+ \(process, running/);
-    assert.ok(output.includes('of 200,000 logged chars'));
+    assert.match(
+      output,
+      /— [\d,]+ retained transcript chars; command-output cap 200,000 chars, 3 lines\./,
+    );
+    assert.ok(!output.includes('of 200,000 logged chars'));
     assert.ok(output.includes('[ 42%] Building CXX object src/foo.cc.o'));
     assert.ok(output.includes("err: warning: unused variable 'x'"));
     assert.ok(output.includes('[ 84%] Building CXX object src/bar.cc.o'));
@@ -155,6 +164,19 @@ describe('ExecutionsTool /executions/{id}/output', () => {
     );
 
     await run.finish();
+  });
+
+  it('keeps final unterminated stdout separate from completion lifecycle output', async () => {
+    const run = await launchBackgroundRun((sink) => {
+      sink.onStdout?.('tail without newline');
+    });
+    await run.finish();
+
+    const result = await readOutput(run.executionId);
+    const output = result.output ?? '';
+
+    assert.ok(output.includes('tail without newline\nCompleted in '));
+    assert.ok(!output.includes('tail without newlineCompleted in '));
   });
 
   it('joins chunks that split a line and pages the projection with view_range', async () => {
@@ -184,6 +206,84 @@ describe('ExecutionsTool /executions/{id}/output', () => {
     assert.ok((past.output ?? '').includes('No lines in the requested range'));
 
     await run.finish();
+  });
+
+  it('reconstructs split chunks, flushes source switches, and normalizes line breaks', async () => {
+    const run = await launchBackgroundRun((sink) => {
+      sink.onStdout?.('complete\r');
+      sink.onStdout?.('\n\npartial\r');
+      sink.onStderr?.('warn');
+      sink.onStderr?.('ing\r');
+      sink.onStderr?.('\n\nlast err\r');
+      sink.onStdout?.('tail');
+    });
+
+    const result = await readOutput(run.executionId);
+    const output = result.output ?? '';
+
+    assert.ok(output.includes('Showing lines 1-7 of 7.'));
+    assert.ok(
+      output.includes(
+        'complete\n\npartial\nerr: warning\nerr: \nerr: last err\ntail',
+      ),
+    );
+    assert.ok(!output.includes('\r'));
+    assert.equal(output.match(/^err: /gm)?.length, 3);
+
+    await run.finish();
+  });
+
+  it('renders consecutive untagged legacy rows standalone', async () => {
+    const executionId = generateExecutionId();
+    await registerExecution(
+      executionId,
+      AgentConfigSchema.parse({
+        agent: 'bash',
+        instruction: 'legacy command',
+        agentCategory: AgentCategory.ToolUse,
+      }),
+      'bash',
+      undefined,
+      'process',
+    );
+    const streamId = `bash@tool#${executionId}` as StreamTabId;
+    const transcripts = defaultSession().transcripts;
+    transcripts.ensureStream(streamId);
+    const writer = transcripts.acquireWriter(streamId, 'legacy-output-test');
+    const append = (
+      id: string,
+      text: string,
+      level: typeof LOG_LEVELS.INFO | typeof LOG_LEVELS.WARN = LOG_LEVELS.INFO,
+    ): void => {
+      writer.append({
+        id,
+        type: STREAM_LOG_ENTRY_TYPES.LOG,
+        level,
+        messageType: MESSAGE_TYPES.DEFAULT,
+        timestamp: Date.now(),
+        text,
+      });
+    };
+    append('legacy-one', 'legacy one');
+    append('legacy-two', 'legacy two');
+    append(
+      'legacy-warning',
+      'legacy warning\r\n\rlegacy tail\r',
+      LOG_LEVELS.WARN,
+    );
+    writer.close();
+
+    const result = await readOutput(executionId);
+    const output = result.output ?? '';
+
+    assert.ok(output.includes('Showing lines 1-5 of 5.'));
+    assert.ok(
+      output.includes(
+        'legacy one\nlegacy two\nerr: legacy warning\nerr: \nerr: legacy tail',
+      ),
+    );
+    assert.ok(!output.includes('legacy onelegacy two'));
+    assert.ok(!output.includes('\r'));
   });
 
   it('treats a carriage-return progress redraw as separate lines', async () => {

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -39,7 +39,9 @@ import {
 } from '@shared/schemas';
 import {
   BASH_BACKGROUND_LOG_CAP_CHARS,
+  type BackgroundBashOutputSource,
   EXECUTIONS_WAIT_DEFAULT_TIMEOUT_SECONDS,
+  getBackgroundBashOutputSource,
   EXECUTIONS_WAIT_MAX_TIMEOUT_SECONDS,
   EXECUTIONS_WAIT_MIN_TIMEOUT_SECONDS,
 } from '@shared/toolUse';
@@ -126,19 +128,36 @@ interface ProcessOutputProjection {
 /**
  * Flatten a background command's transcript rows into display lines.
  *
- * Rows stay in append order — the only surviving record of how stdout and
- * stderr actually interleaved. Consecutive rows on the same channel are
- * concatenated before the split so a line straddling two chunk boundaries
- * stays one line; `warn`/`error` rows are the stderr channel and every line
- * they contribute is marked. Structured rows (usage, context state, tool
- * frames) carry a non-default `messageType` and are dropped: this endpoint
- * projects command output, not the run's own bookkeeping.
+ * Tagged stdout/stderr chunks stay in append order and concatenate only while
+ * their source remains compatible, so chunk-split lines are reconstructed
+ * without crossing a stream switch. Untagged lifecycle and legacy rows flush
+ * any pending command fragment and render standalone. Structured rows (usage,
+ * context state, tool frames) carry a non-default `messageType` and are
+ * dropped: this endpoint projects command output, not run bookkeeping.
  */
 function projectProcessOutput(
   entries: readonly StreamLogEntry[],
 ): ProcessOutputProjection {
-  const runs: { stderr: boolean; text: string }[] = [];
+  const lines: string[] = [];
   let chars = 0;
+  let pendingText = '';
+  let pendingSource: BackgroundBashOutputSource | undefined;
+
+  const emitText = (text: string, stderr: boolean): void => {
+    // A trailing break terminates the last line rather than opening an empty
+    // one; blank lines inside the text still survive the split.
+    const normalized = text.replace(/\r\n$|[\r\n]$/, '');
+    for (const line of normalized.split(OUTPUT_LINE_BREAK)) {
+      lines.push(stderr ? `${OUTPUT_STDERR_PREFIX}${line}` : line);
+    }
+  };
+  const flushPending = (): void => {
+    if (pendingText && pendingSource) {
+      emitText(pendingText, pendingSource === 'stderr');
+    }
+    pendingText = '';
+    pendingSource = undefined;
+  };
 
   for (const entry of entries) {
     if (entry.type !== STREAM_LOG_ENTRY_TYPES.LOG) continue;
@@ -148,22 +167,21 @@ function projectProcessOutput(
     if (!text) continue;
 
     chars += text.length;
-    const stderr =
-      entry.level === LOG_LEVELS.WARN || entry.level === LOG_LEVELS.ERROR;
-    const open = runs.at(-1);
-    if (open && open.stderr === stderr) open.text += text;
-    else runs.push({ stderr, text });
-  }
-
-  const lines: string[] = [];
-  for (const run of runs) {
-    // A trailing break terminates the last line rather than opening an empty
-    // one; blank lines inside the text still survive the split.
-    const text = run.text.replace(/\r\n$|[\r\n]$/, '');
-    for (const line of text.split(OUTPUT_LINE_BREAK)) {
-      lines.push(run.stderr ? `${OUTPUT_STDERR_PREFIX}${line}` : line);
+    const source = getBackgroundBashOutputSource(entry.data);
+    if (!source) {
+      flushPending();
+      emitText(
+        text,
+        entry.level === LOG_LEVELS.WARN || entry.level === LOG_LEVELS.ERROR,
+      );
+      continue;
     }
+
+    if (pendingSource && pendingSource !== source) flushPending();
+    pendingSource = source;
+    pendingText += text;
   }
+  flushPending();
 
   return { lines, chars };
 }
@@ -874,7 +892,7 @@ Use action: "subscribe" on /executions/{id} to receive future status and termina
       // `process` rather than a hardcoded `bash`: the category is what the
       // guard above actually verified, and it stays true if another tool ever
       // registers a process-kind execution.
-      `Output for ${executionId} (process, ${formatStatusInfo(info)}) — ${chars.toLocaleString()} of ${BASH_BACKGROUND_LOG_CAP_CHARS.toLocaleString()} logged chars, ${lines.length.toLocaleString()} lines.`,
+      `Output for ${executionId} (process, ${formatStatusInfo(info)}) — ${chars.toLocaleString()} retained transcript chars; command-output cap ${BASH_BACKGROUND_LOG_CAP_CHARS.toLocaleString()} chars, ${lines.length.toLocaleString()} lines.`,
     ];
 
     if (lines.length === 0) {

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -35,6 +35,7 @@ import { tryPlatform } from '@platform/platform';
 import {
   BASH_BACKGROUND_LOG_CAP_CHARS,
   BASH_TOOL_DEFAULT_TIMEOUT_MS,
+  backgroundBashOutputData,
 } from '@shared/toolUse';
 import { type StreamTabId, type ExecutionId } from '@shared/schemas';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
@@ -428,7 +429,9 @@ export class BashTool extends defineTool({
         );
         return;
       }
-      logger[level](chunk);
+      logger[level](chunk, {
+        data: backgroundBashOutputData(level === 'warn' ? 'stderr' : 'stdout'),
+      });
     };
 
     const startedAt = Date.now();


### PR DESCRIPTION
## Summary

- tag only actual background stdout/stderr chunks through existing transcript `data` metadata
- concatenate chunk fragments only within the same source and flush before lifecycle/legacy rows
- preserve CRLF, bare-CR, blank-line, stderr-prefix, and arrival-order behavior
- report retained transcript characters separately from the unchanged command-output cap

Closes #9180.

## Why

PR #9175 concatenated consecutive same-level/default LOG rows. Because background chunks and child-stream lifecycle logs share that shape, stdout ending without a newline rendered as `tail without newlineCompleted in 1s`. Issue #9169 accepted lifecycle rows inline in order, not merged into command text.

## Net elements (R6)

- 4 files changed: 165 insertions, 26 deletions
- production: 63 insertions, 24 deletions, net +39 lines
- tests: 102 insertions, 2 deletions in the existing focused suite
- no new production files, MessageType/event/schema arms, process pipeline, or cap increase
- adds one source union type and two marker helpers in the existing shared tool-use module

## Consumer counts (R8)

- `backgroundBashOutputData`: 1 producer (`bash.ts`)
- `getBackgroundBashOutputSource`: 1 reader (`ExecutionsTool.ts`)
- both share the persisted marker key privately in `src/shared/toolUse.ts`; there is no duplicated protocol literal

## Validation

- focused output tests: 11/11 passed
- full suite: 777 files passed, 1 skipped; 7,553 tests passed, 4 skipped
- all workspace typechecks passed
- lint and formatting passed
- dead-code ratchet passed at unchanged 18/18
- forbidden retired-process symbol grep found no matches
- `git diff --check` passed
- independent code review: no findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how background process output is projected from transcripts—a user-facing executions path—but scope is limited to bash logging and output formatting with focused regression tests.
> 
> **Overview**
> Fixes background `/executions/{id}/output` merging command chunks with lifecycle logs (e.g. `tail without newlineCompleted in …`) after same-level LOG rows were concatenated.
> 
> **Background bash** now tags each stdout/stderr transcript chunk via shared `backgroundBashOutputData` metadata on log `data`. **`projectProcessOutput`** concatenates only within the same tagged source, flushes before untagged lifecycle or legacy rows, and still handles interleaving, CRLF/CR, and `err:` prefixes. The output header distinguishes **retained transcript chars** from the unchanged **command-output cap**.
> 
> Tests cover unterminated stdout vs completion text, source switches, legacy untagged rows, and the updated header wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d241712511d1e26dc552bc7ddc4426a29ec0bcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->