### PR TITLE
Stage 3 of 4 for #9177: carry the workflow phase on the child roster

### DIFF
--- a/packages/cli/src/chat/tui/state/childExecutions.ts
+++ b/packages/cli/src/chat/tui/state/childExecutions.ts
@@ -205,7 +205,8 @@ function summaryUnchanged(
     a.executionId === b.executionId &&
     a.startedAt === b.startedAt &&
     a.elapsed === b.elapsed &&
-    a.toolName === b.toolName
+    a.toolName === b.toolName &&
+    a.workflowPhase === b.workflowPhase
   );
 }
 

--- a/packages/cli/src/chat/tui/state/streamViews.ts
+++ b/packages/cli/src/chat/tui/state/streamViews.ts
@@ -21,6 +21,8 @@ export interface StreamView {
   readonly label: string;
   /** Canonical spawning tool retained with the child execution. */
   readonly toolName?: string;
+  /** Workflow-script phase owning this child, when its parent runs a script. */
+  readonly workflowPhase?: string;
   readonly parentId?: StreamTabId;
   readonly parentLabel?: string;
   readonly slice: StreamSlice | undefined;
@@ -144,6 +146,10 @@ export function streamViewForId(init: {
     label: streamDisplayLabel(init),
     toolName:
       childEntry?.kind === 'live' ? childEntry.summary?.toolName : undefined,
+    workflowPhase:
+      childEntry?.kind === 'live'
+        ? childEntry.summary?.workflowPhase
+        : undefined,
     parentId,
     parentLabel: parentId
       ? streamDisplayLabel({

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -53,6 +53,13 @@ const logger = createChannelTrace('agentRunLifecycle');
 export interface RunFlowLifecycleOptions {
   isSubagent?: boolean;
   parentStreamId?: StreamTabId;
+  /**
+   * Workflow-script phase owning this run, stamped on the handle before it is
+   * tracked so the parent's very first child roster already groups the row.
+   * Deliberately not an `onRun` responsibility: `onRun` fires after `track()`
+   * has already emitted `child.activity`.
+   */
+  workflowPhase?: string;
   onError?: (error: unknown, result: AgentFlowResult) => void | Promise<void>;
   /**
    * Fires once with the live per-run handle, right after it is tracked (F-2) —
@@ -327,6 +334,10 @@ export async function runFlowWithLifecycle(
   if (executionLeaseScope) {
     handle.attachExecutionLeaseScope(executionLeaseScope);
   }
+  // Roster display fields must be on the handle BEFORE it is tracked:
+  // `track()` emits `child.activity` synchronously, so anything assigned
+  // later (e.g. from `onRun`) misses the parent's first roster snapshot.
+  if (options?.workflowPhase) handle.workflowPhase = options.workflowPhase;
   handle.enablePendingInterrupt();
   session.executions.track(handle);
   let leaseLost = false;

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -93,6 +93,14 @@ export class AgentExecutionHandle implements ExecutionHandle {
   toolName?: string;
 
   /**
+   * Workflow-script phase owning this run, when it is an `agent()` grandchild
+   * of a workflow-script run. Same mutable display-field slot as
+   * {@link toolName}, and set the same way: assigned between construction and
+   * `track()`, so the first roster emission already carries it.
+   */
+  workflowPhase?: string;
+
+  /**
    * The run's terminal outcome, settled exactly once (by the run lifecycle, or
    * by `finalizeChildStream` for non-lifecycle child streams) BEFORE the
    * execution is untracked. Always resolves — never rejects — so a consumer-less

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -303,6 +303,13 @@ export interface SubagentRunOptions {
   ) => void | Promise<void>;
   /** Fires once with the live per-run handle right after it is tracked (F-2). */
   onRun?: (handle: AgentRunHandle) => void | Promise<void>;
+  /**
+   * Workflow-script phase owning this run, when it is an `agent()` call inside
+   * a workflow script. Carried on the parent's child roster so a host can
+   * group grandchild rows by phase. Not settable from `onRun` — see
+   * `RunFlowLifecycleOptions.workflowPhase`.
+   */
+  workflowPhase?: string;
 }
 
 /** Options for executeAgent. */
@@ -438,6 +445,7 @@ export async function executeAgent(
           {
             isSubagent,
             parentStreamId: options.parentStreamId,
+            workflowPhase: options.workflowPhase,
             onError: options.onRunError,
             onRun: options.onRun,
           },
@@ -601,6 +609,7 @@ export async function resumeToolUseFromResumeData(
             {
               isSubagent,
               parentStreamId: options.parentStreamId,
+              workflowPhase: options.workflowPhase,
               onError: options.onRunError,
               onRun: options.onRun,
             },

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -708,6 +708,9 @@ export class ExecutionRegistry {
         elapsed: elapsed ?? null,
         childStreamId: handle.childStreamId,
         ...(handle.toolName ? { toolName: handle.toolName } : {}),
+        ...(handle.workflowPhase
+          ? { workflowPhase: handle.workflowPhase }
+          : {}),
       });
     }
     return result;

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -137,6 +137,7 @@ export async function resumeQueuedToolUseFromResumeData(
       runtimeUnavailableTools: options.runtimeUnavailableTools,
       parentStreamId:
         options.parentStreamId ?? resume.parentStreamId ?? undefined,
+      workflowPhase: options.workflowPhase,
       onFollowUpConsumed: () => {
         followUps = [];
         options.onFollowUpConsumed?.();

--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -42,6 +42,16 @@ const ActiveChildInfoBaseSchema = z.object({
   /** Tool that spawned this child (e.g. "bash", "codex"). Used for icon/label
    *  selection in the UI; may be set on either kind. */
   toolName: z.string().optional(),
+  /**
+   * Workflow-script phase that owns this child, when its parent is a
+   * workflow-script run. This is the only join key between a grandchild's
+   * roster row (which knows tokens/elapsed) and the run's task cards (which
+   * know `phase`) — `WorkflowTaskIdentity` carries no execution or stream id.
+   * Immutable per attempt: it is stamped on the handle before the first
+   * `child.activity` emission, so retained (finished) rows keep it. Optional
+   * so persisted rosters written before this field still parse.
+   */
+  workflowPhase: z.string().optional(),
 });
 
 /**

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -57,7 +57,11 @@ import {
 import { StorageFS } from '@utils/files';
 
 // Local file imports
-import { createRecordingHost, recordSessionEvents } from '../progressTestUtils';
+import {
+  createRecordingHost,
+  recordSessionEvents,
+  runEventsOfType,
+} from '../progressTestUtils';
 
 const storageMocks = vi.hoisted(() => ({
   finalizeExecution: vi.fn(
@@ -602,6 +606,58 @@ describe('runFlowWithLifecycle', () => {
       expect(staleCleanup).not.toHaveBeenCalled();
       expect(captured?.runWaitingCleanup()).toBe(false);
     } finally {
+      defaultSession().executions.untrack(executionId);
+      clearStreamStatusForTest(streamStatus, streamId);
+    }
+  });
+
+  it('carries workflowPhase on the first child roster emission', async () => {
+    const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
+      'lifecycle-workflow-phase',
+    );
+    const parentStreamId = 'parent-lifecycle-workflow-phase' as StreamTabId;
+    const recorded = recordSessionEvents(ctx.runScope.session.events, {
+      scope: 'run',
+      streamId: parentStreamId,
+      types: ['child.activity'],
+    });
+    // `track()` emits the roster synchronously, so onRun — which fires after
+    // tracking — is structurally too late to stamp a display field.
+    let rosterEmissionsBeforeOnRun = -1;
+
+    try {
+      await runFlowWithLifecycle(
+        ctx,
+        async () => ({
+          category: 'toolUse',
+          outcome: RUN_OUTCOME.COMPLETED,
+          executionId,
+          streamId,
+        }),
+        {
+          isSubagent: true,
+          parentStreamId,
+          workflowPhase: 'Reduce',
+          onRun: () => {
+            rosterEmissionsBeforeOnRun = runEventsOfType(
+              recorded.events,
+              'child.activity',
+            ).length;
+          },
+        },
+      );
+
+      const [firstRoster] = runEventsOfType(recorded.events, 'child.activity');
+      expect(firstRoster?.items).toEqual([
+        expect.objectContaining({
+          executionId,
+          childStreamId: streamId,
+          workflowPhase: 'Reduce',
+        }),
+      ]);
+      expect(rosterEmissionsBeforeOnRun).toBeGreaterThan(0);
+    } finally {
+      recorded.detach();
       defaultSession().executions.untrack(executionId);
       clearStreamStatusForTest(streamStatus, streamId);
     }

--- a/src/tools/delegation/inBandSubagentExecution.ts
+++ b/src/tools/delegation/inBandSubagentExecution.ts
@@ -75,6 +75,12 @@ interface InBandSubagentExecutionBaseOptions {
   readonly signal?: AbortSignal;
   readonly onStreamResolved?: (streamId: StreamTabId) => void;
   readonly onCost?: (totalCostUsd: number | undefined) => void | Promise<void>;
+  /**
+   * Workflow-script phase owning this child, when the caller is a
+   * workflow-script run. Rides to the child's roster row so a host can group
+   * grandchild rows by phase.
+   */
+  readonly workflowPhase?: string;
 }
 
 /** Options for the typed child API. Direct persisted parentage is required. */
@@ -510,6 +516,7 @@ async function executeInBand(
           isSubagent: true,
           enforceCategory: true,
           parentStreamId: options.parentStreamId,
+          workflowPhase: options.workflowPhase,
           approvalPromptsUnavailable: options.approvalPromptsUnavailable,
           runtimeUnavailableTools: options.runtimeUnavailableTools,
           stopAfterCycle: true,

--- a/src/tools/delegation/workflowScriptAgentRunner.ts
+++ b/src/tools/delegation/workflowScriptAgentRunner.ts
@@ -277,6 +277,11 @@ export function createWorkflowScriptAgentRunner(
             signal: invocation.signal,
             approvalPromptsUnavailable: parent.approvalPromptsUnavailable,
             runtimeUnavailableTools: parent.runtimeUnavailableTools,
+            // The engine settles the owning phase onto the call options before
+            // handing them here (declared task phase, else the phase active at
+            // call time), so this is a single-owner read rather than a
+            // reconstruction of the engine's rule.
+            workflowPhase: invocation.options.phase,
             // Live per-kind ancestry, matching LLM delegation: each approval
             // follows the parent's corresponding bypass. The run's own stream
             // inherits from the orchestrator, so nested delegation remains


### PR DESCRIPTION
Part of #9177. Stage 3 of 4 — the roster join. **Inert on its own**; stage 4 consumes it.

## What this adds

A workflow-script run's `agent()` grandchildren had no join key back to the run's task cards:
`WorkflowTaskIdentity` is `{id, label, phase}` with no `executionId` and no `streamId`
(`src/shared/schemas/workflowTaskProgress.ts`), while tokens and elapsed live on the grandchild's
*stream slice*. This adds an optional `workflowPhase` to the child roster entry and populates it
along the delegation path.

Hops 1-8 from the issue's **The join key** table (hop 9, the `streamTreeEntries` group-by, ships
with stage 4):

| # | File | Change |
| --- | --- | --- |
| 1 | `src/tools/delegation/workflowScriptAgentRunner.ts` | `workflowPhase: invocation.options.phase` on the object `prepare()` returns |
| 2 | `src/tools/delegation/inBandSubagentExecution.ts` | `workflowPhase?: string` on `InBandSubagentExecutionBaseOptions`; forwarded into the `executeAgent(...)` call |
| 3 | `src/agent/runtime/executeAgent.ts` | `workflowPhase?: string` on `SubagentRunOptions`; forwarded to `runFlowWithLifecycle` at both option sites |
| 4 | `src/agent/runtime/AgentRunLifecycle.ts` | `workflowPhase?: string` on `RunFlowLifecycleOptions`; assigned between handle construction and `track()` |
| 5 | `src/agent/runtime/ExecutionHandle.ts` | `workflowPhase?: string` — the same mutable display-field slot as `toolName`; no `AgentRunHandle` pick change |
| 6 | `src/agent/runtime/executionRegistry.ts` | spread in `collectChildSummary`, beside the existing `toolName` spread |
| 7 | `src/shared/schemas/streamState.ts` | `workflowPhase: z.string().optional()` on `ActiveChildInfoBaseSchema` |
| 8 | `packages/cli/src/chat/tui/state/streamViews.ts` | carried onto `StreamView` from `childEntry.summary`, exactly as `toolName` is |

## The ordering trap this stage exists to avoid

The phase is **not** set from `onRun`. `session.executions.track(handle)`
(`AgentRunLifecycle.ts:342`) emits `child.activity` **synchronously**
(`executionRegistry.ts:234-235`), while `options.onRun(handle)` runs afterwards (`:361-363`). A phase
assigned in `onRun` would miss the roster's *first* emission, leaving the row ungrouped until some
unrelated status change happened to re-emit the roster. So the assignment sits between construction
and `track()`, matching how `handle.toolName = options.toolName` is already set before
`trackAgentExecution` in `src/tools/childStream.ts:171`.

The new test asserts that directly, and I verified it is a real guard by mutation: moving the
assignment to after `track()` fails it with the phase missing from `items[0]`. It also records how
many `child.activity` emissions have already happened by the time `onRun` fires (`> 0`), so the
reason `onRun` is unusable is pinned rather than just described in a comment.

## Acceptance criteria

**Satisfied by this PR:**

- [x] *"The grandchild's roster row carries `workflowPhase` on the **first** `child.activity`
      emission for that child — asserted directly, since setting it after `track()` is the bug this
      design exists to avoid."* — `AgentRunLifecycle.vitest.ts`, `carries workflowPhase on the first
      child roster emission`.

**Deliberately left to later stages:**

- Stage 4 — grouped rows under `◆ {phase} ({i}/{n})`, header `done/total` from
  `workflowPhaseTaskProgress`, `streamTreeEntries` ordering + Alt+1..9 preservation, `ChildListValue`
  widening, the no-phase byte-identical guard, and the ≥60/<60 column behavior. **This PR renders
  nothing** — no UI file is touched.
- Stage 1 (per-task cost) and stage 2 (`phaseStage` on the run's row) are independent and untouched
  here.

## Notes / deviations worth a reviewer's eye

- **One site beyond the issue's table.** `src/agent/runtime/resumeQueuedToolUse.ts` hand-forwards
  fields into `resumeToolUseFromResumeData` rather than spreading, so adding `workflowPhase` to
  `SubagentRunOptions` (which `ResumeQueuedToolUseOptions` extends) would have left it silently
  dropped on that path — exactly the drift that interface's doc comment warns against. One
  forwarding line closes it. No caller sets it there today; it is inert but honest.
- **`summaryUnchanged` in `childExecutions.ts`** gained the field. That comparator documents itself
  as a field-by-field comparison of the roster summary; the value is immutable per attempt so this
  changes no behavior today, but leaving it out would be a latent hole.
- **Schema compatibility.** The field is `.optional()`, so persisted/replayed rosters written before
  it still parse through `fillLegacyActiveChildKind`. `SchemaMigrations.vitest.ts` passes unmodified
  — it is not in the diff.
- **Retained (finished) rows keep the value**: a settled child stays `kind: 'live'` with
  `active: false` and its `summary` (`Omit<SubagentChildInfo, 'childStreamId' | 'status'>`) is
  retained verbatim by the rest-spread in `applySubagentRoster`; the webview's retention path
  (`ProgressFactApplier.ts:631`) also spreads (`{ ...child, finishedAt }`), so nothing drops it.

## Verification

All four gates on this branch:

```
npm run typecheck              ✅
npm test                       ✅  777 files passed | 1 skipped, 7551 tests passed | 4 skipped
npm run lint                   ✅
npm run check:dead-code-ratchet ✅  18 current vs 18 baselined
```

Nothing was flaky; nothing needed an isolated re-run. `pnpm-lock.yaml` is **not** in the commit (the
`CI=true` typecheck workaround rewrote it; restored before committing).

https://claude.ai/code/session_01MQZ63FFrmojmG58wPJdYNH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes child-roster emission timing and the delegation/resume path; behavior is guarded by a first-emission test and the field is optional for backward-compatible parsing.
> 
> **Overview**
> Introduces an optional **`workflowPhase`** on active child roster entries so workflow-script **`agent()`** grandchildren can be correlated with task cards by phase (stage 4 will group UI on this; **no grouping UI ships here**).
> 
> The value is threaded from **`workflowScriptAgentRunner`** (`invocation.options.phase`) through in-band subagent execution and **`executeAgent`** into **`runFlowWithLifecycle`**, where it is assigned on **`AgentExecutionHandle`** **before** **`session.executions.track()`**—because **`track()`** emits **`child.activity` synchronously**, setting it in **`onRun`** would miss the first roster snapshot. The registry’s **`collectChildSummary`**, **`ActiveChildInfo`** schema, CLI **`StreamView`**, and **`summaryUnchanged`** all carry the field; **`resumeQueuedToolUse`** forwards it so resume does not drop it.
> 
> A lifecycle test asserts **`workflowPhase`** appears on the **first** **`child.activity`** emission.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1745783359456cd2708f43bc31e06db0397d792. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->