### PR TITLE
Stage 1 of 4 for #9177: report a workflow task's own cost, not the run total

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **A workflow task's cost is now that task's own cost** — the figure on a
+  workflow-script task card and task line reported the whole run's spend at the
+  moment the task settled, so it grew down the list even when every task cost
+  the same. Each task now reports what its own `agent()` call spent, and the
+  now-redundant `total` qualifier is gone (`$0.020 total` → `$0.020`). The run's
+  cumulative cost still rolls up to the invoking agent's usage unchanged.
 - **Large foreground shell commands use bounded memory** — command results
   retain useful diagnostics from the beginning and end without buffering the
   complete output in memory.

--- a/src/shared/copy/workflowTask.ts
+++ b/src/shared/copy/workflowTask.ts
@@ -7,6 +7,8 @@ import { formatCompactDuration, formatCostUsd } from '@utils/text/stringUtils';
 
 /**
  * Canonical metadata copy for terminal workflow-task progress on every host.
+ * The cost is this task's own spend — a per-task row is read as that row's, so
+ * it carries no `total` qualifier and does not grow down a phase's card list.
  */
 export function formatWorkflowTaskMetadataParts(
   task: WorkflowTaskProgress,
@@ -25,7 +27,7 @@ export function formatWorkflowTaskMetadataParts(
       : formatCompactDuration(task.durationMs),
     task.totalCostUsd === undefined
       ? undefined
-      : `${formatCostUsd(task.totalCostUsd)} total`,
+      : formatCostUsd(task.totalCostUsd),
   ].filter((part): part is string => part !== undefined);
 }
 

--- a/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
@@ -505,24 +505,26 @@ return await agent('Review the argument', { id: 'review-task' })`;
     }
   });
 
-  it('renders the running total on live finish lines only', async () => {
+  it("bills each task its own call's cost, not the run total so far", async () => {
     const store = getExecutionStore(executionId);
     const script = `${meta}
 await agent('First')
 return await agent('Second')`;
     const { trace, events } = recordingTrace();
-    let liveCostUsd = 0;
+    const callCosts = new Map<number, number>();
     await runPersistedWorkflowScriptWithProgress(trace, {
       store,
       checkpointId: 'live-cost',
       script,
-      runAgent: async () => {
-        liveCostUsd += 0.05;
+      runAgent: async ({ index }: WorkflowAgentInvocation) => {
+        callCosts.set(index, (callCosts.get(index) ?? 0) + 0.05);
         return 'done';
       },
-      getLiveCostUsd: () => liveCostUsd,
+      getCallCostUsd: (index) => callCosts.get(index),
     });
 
+    // Two calls costing the same report the same, in either position: the
+    // second must not read as $0.10 just because it settled later.
     expect(workflowTaskEvent(events, 'First', 'completed')?.task).toMatchObject(
       {
         totalCostUsd: 0.05,
@@ -531,7 +533,7 @@ return await agent('Second')`;
     expect(
       workflowTaskEvent(events, 'Second', 'completed')?.task,
     ).toMatchObject({
-      totalCostUsd: 0.1,
+      totalCostUsd: 0.05,
     });
 
     clearStoreCache();
@@ -541,7 +543,8 @@ return await agent('Second')`;
       checkpointId: 'live-cost',
       script,
       runAgent: vi.fn(() => Promise.reject(new Error('must not run'))),
-      getLiveCostUsd: () => 0,
+      // A pure replay observes no attempt, so no call has a cost.
+      getCallCostUsd: () => undefined,
     });
 
     expect(
@@ -552,7 +555,6 @@ return await agent('Second')`;
   it('enriches live finish lines with the reported model and duration', async () => {
     const { trace, events } = recordingTrace();
     const activities: string[] = [];
-    let liveCostUsd = 0;
     await runPersistedWorkflowScriptWithProgress(trace, {
       store: getExecutionStore(executionId),
       checkpointId: 'model-duration',
@@ -560,10 +562,9 @@ return await agent('Second')`;
 return await agent('Draft')`,
       runAgent: async (invocation: WorkflowAgentInvocation) => {
         invocation.reportModel?.('deepseekT');
-        liveCostUsd += 0.02;
         return 'done';
       },
-      getLiveCostUsd: () => liveCostUsd,
+      getCallCostUsd: (index) => (index === 0 ? 0.02 : undefined),
       onActivity: (line) => activities.push(line),
     });
 
@@ -575,9 +576,7 @@ return await agent('Draft')`,
       },
     );
     expect(activities).toContainEqual(
-      expect.stringMatching(
-        /^Finished: Draft · deepseekT · .+ · \$0\.020 total$/,
-      ),
+      expect.stringMatching(/^Finished: Draft · deepseekT · .+ · \$0\.020$/),
     );
   });
 
@@ -608,7 +607,7 @@ return await agent('Late skip')`,
       onControl: (handle) => {
         control = handle;
       },
-      getLiveCostUsd: () => 0.04,
+      getCallCostUsd: (index) => (index === 0 ? 0.04 : undefined),
       onActivity: (line) => activities.push(line),
     });
 
@@ -626,9 +625,7 @@ return await agent('Late skip')`,
     });
     expect(activities).toContain('Running: Late skip');
     expect(activities).toContainEqual(
-      expect.stringMatching(
-        /^Skipped: Late skip · kimiK2 · .+ · \$0\.040 total$/,
-      ),
+      expect.stringMatching(/^Skipped: Late skip · kimiK2 · .+ · \$0\.040$/),
     );
   });
 
@@ -726,7 +723,7 @@ return await agent('Abort', { phase: 'Execution' })`,
           invocation.reportModel?.('abort-model');
           throw new WorkflowRunAbortError('fatal runner error');
         },
-        getLiveCostUsd: () => 0.06,
+        getCallCostUsd: (index) => (index === 0 ? 0.06 : undefined),
         onActivity: (line) => activities.push(line),
       }),
     ).rejects.toThrow('fatal runner error');
@@ -748,7 +745,7 @@ return await agent('Abort', { phase: 'Execution' })`,
     });
     expect(activities).toContainEqual(
       expect.stringMatching(
-        /^Failed: Abort · abort-model · .+ · \$0\.060 total — fatal runner error$/,
+        /^Failed: Abort · abort-model · .+ · \$0\.060 — fatal runner error$/,
       ),
     );
   });
@@ -772,7 +769,9 @@ return 'guest success'`,
           markStarted?.();
           return await new Promise<never>(() => undefined);
         },
-        getLiveCostUsd: () => 0.03,
+        // Index-aware: the cleanup path must resolve the abandoned call's own
+        // index from the still-live call it never settled.
+        getCallCostUsd: (index) => (index === 0 ? 0.03 : undefined),
         onActivity: (line) => activities.push(line),
       });
 
@@ -795,7 +794,7 @@ return 'guest success'`,
       });
       expect(activities).toContain('Running: Orphaned');
       expect(activities).toContain(
-        'Failed: Orphaned · $0.030 total — The workflow ended before this task completed.',
+        'Failed: Orphaned · $0.030 — The workflow ended before this task completed.',
       );
     } finally {
       vi.useRealTimers();

--- a/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.mts
+++ b/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.mts
@@ -1034,7 +1034,7 @@ describe('CLI workflow-script child-stream transcript', () => {
       // The phase group row and the task's current state both surface.
       expect(texts).toContain('Draft sections');
       expect(texts).toContain(
-        'Finished: Draft introduction · deepseekT · 12s · $0.002 total',
+        'Finished: Draft introduction · deepseekT · 12s · $0.002',
       );
       expect(
         entries.filter((entry) => entry.id === 'introduction-task'),
@@ -1100,7 +1100,7 @@ describe('CLI workflow-script child-stream transcript', () => {
       // the task row carries its own per-status marker.
       expect(output).toContain('◆ Draft sections');
       expect(output).toContain('☑ Finished: Draft introduction');
-      expect(output).toContain('deepseekT · 12s · $0.002 total');
+      expect(output).toContain('deepseekT · 12s · $0.002');
     } finally {
       runTrace.dispose();
     }

--- a/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
+++ b/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
@@ -543,9 +543,7 @@ describe('task-group-list workflow-script phase rendering (#8722)', () => {
     );
     expect(content?.textContent).toContain('Review manuscript');
     expect(content?.textContent).toContain('Finished');
-    expect(content?.textContent).toContain(
-      'claude-opus-4 · 12s · $0.040 total',
-    );
+    expect(content?.textContent).toContain('claude-opus-4 · 12s · $0.040');
     expect(content?.textContent).toContain('Check argument');
     expect(content?.textContent).toContain('timed out');
     expect(content?.querySelector('.workflow-task--failed')).not.toBeNull();
@@ -562,7 +560,7 @@ describe('task-group-list workflow-script phase rendering (#8722)', () => {
     expect(notReached?.querySelector('.workflow-task-meta')).toBeNull();
     const userSkipped = content?.querySelector('[data-log-id="agent-d"]');
     expect(userSkipped?.textContent).toContain('Stopped review');
-    expect(userSkipped?.textContent).toContain('kimi-k2 · 2s · $0.020 total');
+    expect(userSkipped?.textContent).toContain('kimi-k2 · 2s · $0.020');
     expect(userSkipped?.querySelector('.workflow-task-detail')).toBeNull();
   });
 

--- a/src/test-kernel/shared/WorkflowTaskCopy.vitest.ts
+++ b/src/test-kernel/shared/WorkflowTaskCopy.vitest.ts
@@ -17,7 +17,7 @@ describe('workflow task copy', () => {
         durationMs: 7_320,
         totalCostUsd: 0.04,
       }),
-    ).toEqual(['gpt56', '7s', '$0.040 total']);
+    ).toEqual(['gpt56', '7s', '$0.040']);
   });
 
   it('does not attach terminal metadata to an active task', () => {
@@ -41,9 +41,7 @@ describe('workflow task copy', () => {
         durationMs: 7_320,
         totalCostUsd: 0.04,
       }),
-    ).toBe(
-      'Failed: Audit source · kimiK2 · 7s · $0.040 total — Runner stopped.',
-    );
+    ).toBe('Failed: Audit source · kimiK2 · 7s · $0.040 — Runner stopped.');
   });
 
   it('explains a task the run never reached on every textual host', () => {
@@ -95,6 +93,6 @@ describe('workflow task copy', () => {
         durationMs: 7_320,
         totalCostUsd: 0.04,
       }),
-    ).toBe('Skipped: Stopped review · kimiK2 · 7s · $0.040 total');
+    ).toBe('Skipped: Stopped review · kimiK2 · 7s · $0.040');
   });
 });

--- a/src/test-kernel/tools/WorkflowScriptStrategy.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptStrategy.vitest.ts
@@ -11,7 +11,7 @@ import {
 } from '@agent/workflowScript';
 import type { AgentFinalResult } from '@agent/runtime/AgentFinalResult';
 import { WorkflowControlRegistry } from '@agent/runtime/workflowControlRegistry';
-import type { ExecutionId } from '@shared/schemas';
+import type { ExecutionId, WorkflowTaskProgress } from '@shared/schemas';
 import { setupPlatform } from '@test/support/setupPlatform';
 import {
   createWorkflowScriptStrategy,
@@ -115,6 +115,44 @@ describe('createWorkflowScriptStrategy', () => {
     // The run log rides along so the invoking model sees what executed.
     expect(delivery).toContain('=== Run log ===');
     expect(delivery).toContain('Finished');
+  });
+
+  it('bills each task its own call while still settling the run total', async () => {
+    const ports = fakePorts();
+    const logger = new TraceEmitter();
+    const tasks: WorkflowTaskProgress[] = [];
+    logger.subscribe((event) => {
+      if (event.type === 'workflow.task') tasks.push(event.task);
+    });
+    const strategy = createWorkflowScriptStrategy(
+      strategyParams({
+        name: 'per-call-cost',
+        logger,
+        script: `export const meta = {
+  name: 'per-call-cost',
+  description: 'bills two equal calls',
+}
+await agent('First')
+return await agent('Second')`,
+        createRunAgent: (hooks) => async (invocation) => {
+          const result = { ...finalResult, cost: 0.05 };
+          hooks.onCost(invocation, result.cost);
+          return result;
+        },
+      }),
+    );
+
+    await strategy.launch(ports, new AbortController());
+
+    // Two calls costing the same report the same — the second is not $0.10
+    // just because the run had spent that much by the time it settled.
+    expect(
+      tasks
+        .filter((task) => task.status === 'completed')
+        .map((task) => task.totalCostUsd),
+    ).toEqual([0.05, 0.05]);
+    // The run-cumulative figure still reaches the parent's cost accounting.
+    expect(ports.recordCost).toHaveBeenCalledWith(expect.closeTo(0.1, 5));
   });
 
   it('replays a named checkpoint and settles zero for a pure resume', async () => {

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -21,8 +21,13 @@ type WorkflowScriptRunWithProgressOptions = Omit<
   PersistedWorkflowScriptRunOptions,
   'onEvent'
 > & {
-  /** Cumulative live spend across this run's children, for progress lines. */
-  readonly getLiveCostUsd?: () => number;
+  /**
+   * One call's own live spend, by the engine's 0-based call index. Progress
+   * lines are per task, so they report per call; the run total is settled
+   * separately onto the parent's usage. Undefined for a call that performed no
+   * live attempt (a journal replay), which therefore reports no cost at all.
+   */
+  readonly getCallCostUsd?: (index: number) => number | undefined;
   /**
    * Receives every progress line also written to the trace (phases, script
    * log() output, per-call outcomes) so the caller can hand the run log back
@@ -34,6 +39,12 @@ type WorkflowScriptRunWithProgressOptions = Omit<
 interface PhaseStage {
   readonly handle: StageHandle;
   failed: boolean;
+}
+
+interface LiveCall {
+  readonly phase: string | undefined;
+  /** 0-based engine call index — the key this call's cost is observed under. */
+  readonly index: number;
 }
 
 interface ProjectedWorkflowTask {
@@ -116,11 +127,17 @@ export async function runPersistedWorkflowScriptWithProgress(
   trace: AgentTrace,
   options: WorkflowScriptRunWithProgressOptions,
 ): Promise<WorkflowScriptRunResult> {
-  const { getLiveCostUsd, onActivity, ...runOptions } = options;
+  const { getCallCostUsd, onActivity, ...runOptions } = options;
   const parentStageId = trace.activeStageId();
   const phases = new Map<string, PhaseStage>();
   const phaseStageIds = new Map<string, string>();
-  const callPhases = new Map<WorkflowScriptProgressId, string | undefined>();
+  /**
+   * What the run knows about a call it has started but not yet settled: the
+   * phase it began in, and the engine call index its cost is billed under.
+   * Entries survive exactly until `agent:end`, so a call still present when the
+   * run tears down is one that never finished.
+   */
+  const liveCalls = new Map<WorkflowScriptProgressId, LiveCall>();
   const projectedTasks = new Map<
     WorkflowScriptProgressId,
     ProjectedWorkflowTask
@@ -256,7 +273,10 @@ export async function runPersistedWorkflowScriptWithProgress(
         break;
       case 'agent:start': {
         const phaseTitle = event.phase ?? currentPhase;
-        callPhases.set(event.progressId, phaseTitle);
+        liveCalls.set(event.progressId, {
+          phase: phaseTitle,
+          index: event.index,
+        });
         // Open the phase the moment the run reaches it; `emitTask` resolves
         // the card's group on its own from the task's recorded phase.
         openPhaseStage(phaseTitle, event.phaseIndex, event.phaseTotal);
@@ -272,19 +292,22 @@ export async function runPersistedWorkflowScriptWithProgress(
       case 'agent:end': {
         // A recorded undefined means the live call started outside any phase;
         // only cached end-only events may use the phase active at replay time.
-        const phaseTitle = callPhases.has(event.progressId)
-          ? callPhases.get(event.progressId)
+        const liveCall = liveCalls.get(event.progressId);
+        const phaseTitle = liveCall
+          ? liveCall.phase
           : (event.phase ?? currentPhase);
-        callPhases.delete(event.progressId);
+        liveCalls.delete(event.progressId);
         // A cached replay has no agent:start, so this is where its phase opens.
         openPhaseStage(phaseTitle, event.phaseIndex, event.phaseTotal);
         // Cached replays spend nothing, so their lines stay cost-free; live
-        // onCost settles before agent:end, so the total here is current.
+        // onCost settles before agent:end, so this call's spend is final here.
+        // Retried attempts share the engine index, so a retried call bills the
+        // work it discarded — the same reading the run's own total takes.
         const spent =
           event.outcome === 'completed' ||
           event.outcome === 'failed' ||
           event.outcome === 'skipped'
-            ? getLiveCostUsd?.()
+            ? getCallCostUsd?.(event.index)
             : undefined;
         // Live terminal events carry all attempt metadata known by the engine.
         // Cached replays report none because they perform no live attempt.
@@ -383,7 +406,10 @@ export async function runPersistedWorkflowScriptWithProgress(
       } else if (status === 'running') {
         markPhaseFailed(task.phase);
         const error = 'The workflow ended before this task completed.';
-        const totalCostUsd = getLiveCostUsd?.();
+        // Never settled, so its call is still live and still names its index.
+        const index = liveCalls.get(task.id)?.index;
+        const totalCostUsd =
+          index === undefined ? undefined : getCallCostUsd?.(index);
         const failedTask: WorkflowTaskProgress = {
           ...task,
           status: 'failed',

--- a/src/tools/delegation/workflowScriptStrategy.ts
+++ b/src/tools/delegation/workflowScriptStrategy.ts
@@ -139,7 +139,10 @@ export function createWorkflowScriptStrategy(
       // identity so discarded retry/skip/failure work is still billed while a
       // pure journal replay settles zero.
       const observedCosts = new Map<string, number>();
-      let liveCostUsd = 0;
+      // The same attempts folded by engine call index, which is what a per-task
+      // progress line reports. Kept beside the identity-keyed map rather than
+      // derived from it: journal reconciliation owns that key and must keep it.
+      const observedCallCosts = new Map<number, number>();
       // Live grandchild execution id → engine call index, maintained by the
       // runner's child-active hook. The identity bridge that lets an
       // execution-id-keyed host action reach the engine's index-keyed control.
@@ -152,7 +155,10 @@ export function createWorkflowScriptStrategy(
             identity,
             (observedCosts.get(identity) ?? 0) + cost,
           );
-          liveCostUsd += cost;
+          observedCallCosts.set(
+            invocation.index,
+            (observedCallCosts.get(invocation.index) ?? 0) + cost,
+          );
         },
         onChildActive: (grandchildExecutionId, invocation, active) => {
           if (active) {
@@ -176,7 +182,7 @@ export function createWorkflowScriptStrategy(
           }),
           signal: abortController.signal,
           runAgent,
-          getLiveCostUsd: () => liveCostUsd,
+          getCallCostUsd: (index) => observedCallCosts.get(index),
           onActivity: runLog.add,
           onControl: (control) => {
             // Translate an execution-id-keyed host request into an


### PR DESCRIPTION
Part of #9177 — the first of four stages.

## What was wrong

`WorkflowTaskProgress.totalCostUsd` was `getLiveCostUsd()`, the run-cumulative
live spend at the instant that task settled. An N-task run where every call cost
the same still read `$0.05`, `$0.10`, `$0.15` down the list. The ` total`
qualifier made the copy technically honest, but a number on a per-task row is
read as that row's.

## What changed

- The strategy's existing `onCost` handler folds the same attempts a second way,
  by the engine's 0-based call index (`observedCallCosts`).
  `runPersistedWorkflowScriptWithProgress` takes
  `getCallCostUsd(index): number | undefined` in place of `getLiveCostUsd()`.
  `agent:end` carries `event.index` directly; the cleanup path (a task still
  `running` when the run tears down) resolves its index from the call it never
  settled.
- **`observedCosts` and its `${index}:${key}` identity are untouched.**
  `sumCurrentWorkflowRunCost` consumes them at `workflowScriptStrategy.ts:212`
  and `:227` for journal reconciliation — that is a live consumer, and the run's
  cumulative figure still settles onto the parent through `ports.recordCost`.
  The new map is kept beside it rather than derived from it for exactly that
  reason.
- Retried and skipped attempts of one logical call share an engine index, so a
  task bills the work it discarded — the same reading the run's own total takes.
- Two same-key maps in the projector collapse into one: `callPhases` plus the
  index the cleanup path needs become `liveCalls`, holding both facts with the
  same set-at-`agent:start` / delete-at-`agent:end` lifecycle. (Net effect on
  the `has()` vs `get()` distinction that separates "recorded undefined phase"
  from "not recorded" is unchanged — the value is always an object when set.)
- The copy change lives in `formatWorkflowTaskMetadataParts`, still the only
  owner, so the webview card, the CLI transcript row, and the run log the
  invoking model sees all move together: `$0.020 total` → `$0.020`.
  Changelog entry added, since this is user-visible.

## Acceptance criteria this stage satisfies

- [x] Two `agent()` calls costing $0.05 each report `0.05` and `0.05`; the
      pinning test was rewritten with the opposite expectation and renamed to
      *"bills each task its own call's cost, not the run total so far"*.
- [x] No workflow task line or card renders the word `total`;
      `formatWorkflowTaskMetadataParts` remains the only owner of that copy.
- [x] `getLiveCostUsd` and the strategy's `liveCostUsd` accumulator no longer
      exist.

## Deliberately left to later stages

Everything else in #9177: `phaseStage` on the run's row (stage 2), the roster
`workflowPhase` join (stage 3, already open as #9183 — no file overlap with this
PR), and phase-grouped rows in the focused CLI list (stage 4). Also untouched:
the `cached`-replay under-reporting the issue lists as *"Not fixed here"* — a
cached arm carries no terminal metadata and reports no cost, exactly as before.

## Scope correction vs. the issue

The issue estimated stage 1 at 4 files / 2 test files. It is 9 files / **5** test
files. Two extra test files assert the rendered copy and were not listed:

- `src/test-kernel/progressView/TaskGroupListIndex.vitest.ts` (webview card text)
- `src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.mts` (CLI transcript
  row) — missed by the issue's grep and by my first sweep because it is `.mts`;
  the full suite caught it.

The `getLiveCostUsd` → `getCallCostUsd` rename touched the six call sites the
issue listed in `WorkflowScriptProgressBridge.vitest.ts` (`:523, :544, :566,
:611, :729, :775`) plus its two assertion flips, and no other assertion in that
file needed an edit. Three stubs were made index-aware (`(index) => index === 0
? … : undefined`) so they actually pin the index lookup rather than passing on a
constant — notably the abandoned-call cleanup path, whose index resolution is
the non-obvious one.

One test was added to `WorkflowScriptStrategy.vitest.ts` covering the criterion
through the real production wiring (`createWorkflowScriptStrategy`): two calls at
$0.05 report `[0.05, 0.05]` on their cards while `recordCost` still receives
`0.10` for the run. The bug lived in that wiring, so the run-level test alone
would not have caught it.

## Verification

`npm run typecheck`, `npm test` (7551 passed / 1 skipped file), `npm run lint`,
`npm run check:dead-code-ratchet` — all green on `df99b4b` (rebased onto current
`main`). No flakes; the one failure during the run was the genuine `.mts` copy
assertion above, fixed and re-verified in isolation and in the full suite.
`pnpm-lock.yaml` was reverted after the `CI=true` typecheck workaround and is
confirmed absent from the commit.

https://claude.ai/code/session_01MQZ63FFrmojmG58wPJdYNH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display and progress wiring change only; run-level cost rollup via recordCost and journal reconciliation maps are explicitly preserved.
> 
> **Overview**
> Workflow-script **task cards and finish lines** used to show **cumulative run spend** at the moment each task settled, so identical `$0.05` calls read as `$0.05`, `$0.10`, `$0.15` down the list. Each task now gets **`totalCostUsd` for its own `agent()` call** (by engine call index), and shared copy drops the **`total` suffix** (`$0.020 total` → `$0.020`) everywhere hosts render metadata.
> 
> **`runPersistedWorkflowScriptWithProgress`** takes **`getCallCostUsd(index)`** instead of **`getLiveCostUsd()`**; **`agent:end`** uses **`event.index`**, and tasks still **running** when the run tears down resolve cost from a **`liveCalls`** map (phase + index). The strategy folds the same **`onCost`** attempts into **`observedCallCosts`** by index while **`observedCosts`** / **`ports.recordCost`** still settle the **full run total** on the parent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5af4654466dcfbd736f3dc7f2167f0835c61108a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->