### PR TITLE
Stage 2 of 4 for #9177: show a running workflow's current phase on its row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ All notable changes to this project will be documented in this file.
   proceeds instead of only at completion. Reads default to the last 200 lines
   and accept `view_range` to page back through the retained log, which stays
   readable after the command finishes.
+- **A running workflow script shows its current phase from the parent's view**
+  — the run's row now reads `Reduce 2/3` beside its status, in the CLI's child
+  list and in the progress view's Background Tasks panel, so a long multi-phase
+  run is no longer indistinguishable at minute 2 and minute 38. Tool-use rows
+  keep showing their round (`r2/3`); no row shows both.
 
 #### Bug Fixes
 

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -7,6 +7,7 @@ import { useMemo } from 'react';
 // Local imports - shared stream state
 import type { StreamTabId } from '@shared/schemas';
 import {
+  formatPhaseStageLabel,
   formatRoundStageLabel,
   formatStreamStatusLabel,
 } from '@shared/streams/streamStatusDisplay';
@@ -105,7 +106,11 @@ function SessionRow({
   // this truncate-end text sheds inline elapsed (narrow mode only), the round,
   // and last the pending-approval kind. The metadata column never shrinks.
   const approvalSuffix = pendingApprovalRowSuffix(pendingKinds);
-  const roundLabel = formatRoundStageLabel(session.slice?.roundStage);
+  // A workflow-script run advances through phases, a tool-use run through
+  // rounds; one slot carries whichever this stream has.
+  const stageLabel =
+    formatPhaseStageLabel(session.slice?.phaseStage) ??
+    formatRoundStageLabel(session.slice?.roundStage);
   // The resolved model is per-agent identity (a workflow run's grandchildren
   // can each resolve a different model); the list-root row is the conversation
   // itself, whose model already rides the status bar. A background bash stream
@@ -146,7 +151,7 @@ function SessionRow({
           {session.label}
           {statusLabel ? ` ${statusLabel}` : ''}
           {approvalSuffix ? ` · ${approvalSuffix}` : ''}
-          {roundLabel ? ` · ${roundLabel}` : ''}
+          {stageLabel ? ` · ${stageLabel}` : ''}
           {modelLabel ? ` · ${modelLabel}` : ''}
           {!metadataColumn && elapsed ? ` · ${elapsed}` : ''}
         </Text>

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -13,6 +13,7 @@ import {
   type MessageType,
   type NormalizedToolUse,
   type OutputFileInfo,
+  type PhaseStage,
   type Plan,
   type RoundIndexed,
   type RoundStage,
@@ -176,6 +177,9 @@ export interface StreamSlice {
   readonly compactingActive: boolean;
   readonly conversation: ConversationProgress | undefined;
   readonly roundStage?: RoundStage | undefined;
+  /** Current workflow-script phase. Fills the same row slot as `roundStage`
+   *  — a run advances through phases or rounds, never both. */
+  readonly phaseStage?: PhaseStage | undefined;
   readonly entries: readonly ConversationEntry[];
   readonly queuedFollowUpMessages: readonly string[];
   readonly todos: readonly TodoItem[];
@@ -228,6 +232,7 @@ function emptySlice(streamId: StreamTabId): StreamSlice {
     cumulativeUsage: undefined,
     conversation: undefined,
     roundStage: undefined,
+    phaseStage: undefined,
     entries: [],
     queuedFollowUpMessages: [],
     todos: [],

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -9,6 +9,7 @@ import {
   type GoalPausedPayload,
   type SetActiveStreamPayload,
   type StreamTabId,
+  type UpdatePhaseStagePayload,
   type UpdateQueuedFollowUpsPayload,
   type UpdateRoundStagePayload,
   type UpdateStreamUsagePayload,
@@ -136,6 +137,22 @@ function applyRoundStage(payload: UpdateRoundStagePayload): void {
   });
 }
 
+function applyPhaseStage(payload: UpdatePhaseStagePayload): void {
+  patchStream(payload.streamId, (s) => {
+    if (
+      s.phaseStage?.label === payload.phaseStage.label &&
+      s.phaseStage?.index === payload.phaseStage.index &&
+      s.phaseStage?.total === payload.phaseStage.total
+    ) {
+      return s;
+    }
+    return {
+      ...s,
+      phaseStage: payload.phaseStage,
+    };
+  });
+}
+
 function applyOutputFiles(
   event: Extract<AgentEvent, { type: 'addOutputFiles' }>,
 ): void {
@@ -201,6 +218,19 @@ function applyDirectTuiRunEvent(
     case 'updateCompileFailures':
       return false;
     case 'stage.start':
+      if (event.kind === 'phase') {
+        applyPhaseStage({
+          streamId: fallbackStreamId,
+          phaseStage: {
+            label: event.label,
+            ...(event.index !== undefined ? { index: event.index } : {}),
+            ...(event.total !== undefined && event.total > 0
+              ? { total: event.total }
+              : {}),
+          },
+        });
+        return true;
+      }
       if (event.kind !== 'round') return false;
       applyRoundStage({
         streamId: fallbackStreamId,

--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -40,15 +40,19 @@ import {
   type InquiryThreadUpdatedEvent,
 } from '@shared/schemas';
 import { designTokens, commonViewStyles } from '@shared/styles';
+import { formatPhaseStageLabel } from '@shared/streams/streamStatusDisplay';
 import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
 import { ProgressEvents } from '../events';
 
 // Local imports - contexts
 import {
   EMPTY_INQUIRY_THREADS,
+  EMPTY_PHASE_STAGE_MAP,
   EMPTY_STREAM_BY_ID,
   inquiryThreadsContext,
+  phaseStagesContext,
   streamByIdContext,
+  type PhaseStageMap,
   type StreamByIdMap,
 } from '../contexts/streamContexts';
 
@@ -141,6 +145,18 @@ export class BackgroundTasksPanel extends LitElement {
         text-decoration-color: var(--wa-color-text-normal);
       }
 
+      /* Sits between the name and the description: a run's phase identifies
+         where it is, so it never shrinks and never wraps the row. */
+      .task-phase {
+        flex: 0 0 auto;
+        max-width: 10rem;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-size: var(--font-size-xs);
+        color: var(--color-text-secondary);
+      }
+
       .task-description {
         flex: 1 1 8rem;
         min-width: 0;
@@ -220,6 +236,12 @@ export class BackgroundTasksPanel extends LitElement {
   @consume({ context: inquiryThreadsContext, subscribe: true })
   @state()
   private inquiries: InquiryThreadUpdatedEvent[] = EMPTY_INQUIRY_THREADS;
+
+  /** Current phase per stream — a workflow-script run's row is otherwise
+   *  indistinguishable at minute 2 and minute 38 of the same run. */
+  @consume({ context: phaseStagesContext, subscribe: true })
+  @state()
+  private phaseStages: PhaseStageMap = EMPTY_PHASE_STAGE_MAP;
 
   /** Track previous active count to detect transitions. */
   private prevActiveCount = 0;
@@ -391,6 +413,9 @@ export class BackgroundTasksPanel extends LitElement {
     const description = childStreamId
       ? this.streamById.get(childStreamId)?.description
       : undefined;
+    const phaseLabel = childStreamId
+      ? formatPhaseStageLabel(this.phaseStages.get(childStreamId))
+      : undefined;
     const badge = taskStatusBadge(child);
     const idPrefix = `background-subagent-${index}`;
     const nameTooltip = isClickable
@@ -436,6 +461,15 @@ export class BackgroundTasksPanel extends LitElement {
             >${child.agentName}</span
           >
           <wa-tooltip for="${idPrefix}-name">${nameTooltip}</wa-tooltip>
+          ${
+            phaseLabel
+              ? html`<span id="${idPrefix}-phase" class="task-phase"
+                    >${phaseLabel}</span
+                  ><wa-tooltip for="${idPrefix}-phase"
+                    >${phaseLabel}</wa-tooltip
+                  >`
+              : nothing
+          }
           ${
             description
               ? html`<span id="${idPrefix}-description" class="task-description"

--- a/packages/extension/src/progressView/frontend/components/StreamConversation.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamConversation.ts
@@ -14,6 +14,7 @@ import {
   activeInquiries$,
   logContext$,
   permissions$,
+  phaseStages$,
   streamById$,
   streamContext$,
 } from '../progressState';
@@ -21,15 +22,18 @@ import {
   archivedContext,
   EMPTY_INQUIRY_THREADS,
   EMPTY_LOG_CONTEXT,
+  EMPTY_PHASE_STAGE_MAP,
   EMPTY_STREAM_BY_ID,
   EMPTY_STREAM_CONTEXT,
   followUpEventSinkContext,
   inquiryThreadsContext,
   permissionsContext,
+  phaseStagesContext,
   streamByIdContext,
   streamLogContext,
   streamStateContext,
   type FollowUpEventSink,
+  type PhaseStageMap,
   type StreamByIdMap,
   type StreamContextValue,
   type StreamLogContextValue,
@@ -82,6 +86,10 @@ export class StreamConversation extends SignalWatcher(LitElement) {
   private inquiryThreadsContextValue: InquiryThreadUpdatedEvent[] =
     EMPTY_INQUIRY_THREADS;
 
+  @provide({ context: phaseStagesContext })
+  @state()
+  private phaseStagesContextValue: PhaseStageMap = EMPTY_PHASE_STAGE_MAP;
+
   @provide({ context: followUpEventSinkContext })
   private readonly followUpEventSink: FollowUpEventSink = (event) => {
     this.dispatchEvent(event);
@@ -104,6 +112,7 @@ export class StreamConversation extends SignalWatcher(LitElement) {
     this.permissionsContextValue = permissions$.get();
     this.streamByIdContextValue = streamById$.get();
     this.inquiryThreadsContextValue = activeInquiries$.get();
+    this.phaseStagesContextValue = phaseStages$.get();
   }
 
   override render(): TemplateResult {

--- a/packages/extension/src/progressView/frontend/contexts/streamContexts.ts
+++ b/packages/extension/src/progressView/frontend/contexts/streamContexts.ts
@@ -11,6 +11,7 @@ import { createContext } from '@lit/context';
 import type {
   LogMessageData,
   InquiryThreadUpdatedEvent,
+  PhaseStage,
   StreamLifecycleStatus,
   StreamTabId,
   StreamTabInfo,
@@ -120,6 +121,20 @@ export const EMPTY_STREAM_BY_ID: StreamByIdMap = new Map();
 
 export const streamByIdContext = createContext<StreamByIdMap>(
   'progress-stream-by-id',
+);
+
+/**
+ * phaseStages context: Map<streamId, PhaseStage> for the streams currently in
+ * a workflow-script phase. Consumed by BackgroundTasksPanel, whose rows are
+ * *other* streams than the active one — `streamStateContext` only carries the
+ * active stream's state, so a child run's phase cannot be read from there.
+ */
+export type PhaseStageMap = ReadonlyMap<StreamTabId, PhaseStage>;
+
+export const EMPTY_PHASE_STAGE_MAP: PhaseStageMap = new Map();
+
+export const phaseStagesContext = createContext<PhaseStageMap>(
+  'progress-phase-stages',
 );
 
 /**

--- a/packages/extension/src/progressView/frontend/progressState.ts
+++ b/packages/extension/src/progressView/frontend/progressState.ts
@@ -170,10 +170,12 @@ export const pendingApprovalIds$ = new Signal.Computed(() => {
  * `permissions$.set([])` because that setter triggers `pendingApprovalIds$`
  * recomputation, which reads `_prevApprovalIds` for the stable-Set memo —
  * if we clear the cache after, the next read sees a stale prior Set and
- * returns it instead of the empty post-reset value.
+ * returns it instead of the empty post-reset value. `_prevPhaseStages` is
+ * the same memo over `appState`, so it is cleared before that setter too.
  */
 export function resetProgressState(): void {
   _prevApprovalIds = new Set();
+  _prevPhaseStages = EMPTY_PHASE_STAGE_MAP;
   clearFollowUpInputTransientStateStore();
   appState.set(createInitialState());
   placement.set('sidebar');
@@ -249,19 +251,42 @@ export const activeInquiries$ = new Signal.Computed(() => {
   return threads.length > 0 ? threads : EMPTY_INQUIRIES;
 });
 
+function samePhaseStages(left: PhaseStageMap, right: PhaseStageMap): boolean {
+  if (left.size !== right.size) return false;
+  for (const [streamId, stage] of left) {
+    const other = right.get(streamId);
+    if (
+      other === undefined ||
+      other.label !== stage.label ||
+      other.index !== stage.index ||
+      other.total !== stage.total
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
 /**
  * Current phase per stream, for streams that have one. Read by the Background
  * Tasks panel, whose rows are *other* streams — so unlike `activeStreamState$`
- * this deliberately spans every stream. Streams without a phase are omitted so
- * a session with no workflow-script run keeps the stable empty identity, and
- * its consumers never re-render on an unrelated stream's progress tick.
+ * this deliberately spans every stream, and therefore recomputes on *any*
+ * field of *any* stream (`streamStates$` changes identity on every progress
+ * tick). Returns a stable Map reference when the phases themselves are
+ * unchanged, mirroring `pendingApprovalIds$` above, so a run in flight does
+ * not re-render its consumers on unrelated ticks. Values are compared by
+ * content, not reference: an unchanged phase arrives as a fresh object each
+ * time a metadata patch crosses postMessage.
  */
+let _prevPhaseStages: PhaseStageMap = EMPTY_PHASE_STAGE_MAP;
 export const phaseStages$ = new Signal.Computed((): PhaseStageMap => {
   const stages = new Map<StreamTabId, PhaseStage>();
   for (const [streamId, state] of streamStates$.get()) {
     if (state.phaseStage) stages.set(streamId, state.phaseStage);
   }
-  return stages.size > 0 ? stages : EMPTY_PHASE_STAGE_MAP;
+  if (samePhaseStages(stages, _prevPhaseStages)) return _prevPhaseStages;
+  _prevPhaseStages = stages.size > 0 ? stages : EMPTY_PHASE_STAGE_MAP;
+  return _prevPhaseStages;
 });
 
 const activeIsToolUse$ = new Signal.Computed(() => {

--- a/packages/extension/src/progressView/frontend/progressState.ts
+++ b/packages/extension/src/progressView/frontend/progressState.ts
@@ -20,6 +20,7 @@ import {
   createStreamState,
   type ProgressViewPlacement,
   type InquiryThreadUpdatedEvent,
+  type PhaseStage,
   type StreamTabId,
   type StreamTabInfo,
   type TaskGroup,
@@ -38,7 +39,9 @@ import {
 } from './store';
 import {
   EMPTY_LOG_CONTEXT,
+  EMPTY_PHASE_STAGE_MAP,
   EMPTY_STREAM_CONTEXT,
+  type PhaseStageMap,
   type StreamContextValue,
   type StreamLogContextValue,
 } from './contexts/streamContexts';
@@ -244,6 +247,21 @@ export const activeInquiries$ = new Signal.Computed(() => {
     (thread) => thread.lastActivityIso,
   );
   return threads.length > 0 ? threads : EMPTY_INQUIRIES;
+});
+
+/**
+ * Current phase per stream, for streams that have one. Read by the Background
+ * Tasks panel, whose rows are *other* streams — so unlike `activeStreamState$`
+ * this deliberately spans every stream. Streams without a phase are omitted so
+ * a session with no workflow-script run keeps the stable empty identity, and
+ * its consumers never re-render on an unrelated stream's progress tick.
+ */
+export const phaseStages$ = new Signal.Computed((): PhaseStageMap => {
+  const stages = new Map<StreamTabId, PhaseStage>();
+  for (const [streamId, state] of streamStates$.get()) {
+    if (state.phaseStage) stages.set(streamId, state.phaseStage);
+  }
+  return stages.size > 0 ? stages : EMPTY_PHASE_STAGE_MAP;
 });
 
 const activeIsToolUse$ = new Signal.Computed(() => {

--- a/packages/extension/src/progressView/frontend/slices/streamStateMerge.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamStateMerge.ts
@@ -14,6 +14,9 @@ export function metadataToStreamStatePartial(
     ...(Object.hasOwn(metadata, 'roundStage') && {
       roundStage: metadata.roundStage ?? undefined,
     }),
+    ...(Object.hasOwn(metadata, 'phaseStage') && {
+      phaseStage: metadata.phaseStage ?? undefined,
+    }),
   } as Partial<StreamState>;
 }
 

--- a/src/controllers/progressView/backend/WebviewUpdater.ts
+++ b/src/controllers/progressView/backend/WebviewUpdater.ts
@@ -453,6 +453,7 @@ export class WebviewUpdater {
       lastTimestamp: state.streamLogs.getLastTimestamp(streamInfo.name),
       conversationProgress: current?.conversationProgress,
       roundStage: current?.roundStage,
+      phaseStage: current?.phaseStage,
       subagents: rosters?.subagents,
     });
   }

--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -31,6 +31,7 @@ import {
   type UpdateCompileFailuresPayload,
   type UpdateConversationProgressPayload,
   type UpdateMissingOutputsPayload,
+  type UpdatePhaseStagePayload,
   type UpdatePlanPayload,
   type UpdateQueuedFollowUpsPayload,
   type UpdateRoundStagePayload,
@@ -144,6 +145,18 @@ export class ProgressFactApplier {
         progress: event.progress,
       }),
     'stage.start': (streamId, event) => {
+      if (event.kind === 'phase') {
+        return this.handleUpdatePhaseStage({
+          streamId,
+          phaseStage: {
+            label: event.label,
+            ...(event.index !== undefined ? { index: event.index } : {}),
+            ...(event.total !== undefined && event.total > 0
+              ? { total: event.total }
+              : {}),
+          },
+        });
+      }
       if (event.kind !== 'round') return;
       return this.handleUpdateRoundStage({
         streamId,
@@ -580,6 +593,29 @@ export class ProgressFactApplier {
     ) {
       this.webviewUpdater.updateRoundStage(streamId, roundStage);
     }
+  }
+
+  /**
+   * A workflow-script run's phase is read from its *parent's* viewport (the
+   * Background Tasks row for that run), so unlike `roundStage` this cannot be
+   * pushed only for the active stream. It rides the existing per-stream
+   * metadata patch instead of a new targeted message: phases advance a
+   * handful of times per run, so the extra fields on the wire cost nothing
+   * and no new command has to be added to the outbound union.
+   */
+  private handleUpdatePhaseStage(data: UpdatePhaseStagePayload): void {
+    const { streamId, phaseStage } = data;
+    this.state.updateStreamState(streamId, (prev) => ({
+      ...prev,
+      phaseStage,
+    }));
+
+    if (!this.webviewUpdater.isAvailable()) return;
+    this.webviewUpdater.updateStreamMetadata(
+      this.state,
+      streamId,
+      this.state.streamStatus.getAllStreamStates(),
+    );
   }
 
   private flushProgressUpdates(): void {

--- a/src/controllers/progressView/backend/state/ProgressViewState.ts
+++ b/src/controllers/progressView/backend/state/ProgressViewState.ts
@@ -21,6 +21,7 @@ import {
   type AgentCategoryFilter,
   type ConversationProgress,
   type ExecutionId,
+  type PhaseStage,
   type RoundStage,
   type StreamTabId,
 } from '@shared/schemas';
@@ -112,6 +113,7 @@ export interface StreamExecutionState {
   kind: (typeof AgentCategory)[keyof typeof AgentCategory];
   conversationProgress: ConversationProgress;
   roundStage?: RoundStage;
+  phaseStage?: PhaseStage;
   /** Live children plus the finished ones retained for display (`finishedAt`
    *  set). */
   subagents: ActiveChildInfo[];
@@ -405,7 +407,8 @@ export class ProgressViewState {
     const needsReset =
       retainedSubagents.length > 0 ||
       current.conversationProgress.toolCallCount !== 0 ||
-      current.roundStage !== undefined;
+      current.roundStage !== undefined ||
+      current.phaseStage !== undefined;
 
     if (needsReset) {
       this._streamStates.set(stream, {
@@ -415,6 +418,7 @@ export class ProgressViewState {
         ),
         conversationProgress: { toolCallCount: 0 },
         roundStage: undefined,
+        phaseStage: undefined,
       });
     }
   }

--- a/src/shared/schemas/progressEvents.ts
+++ b/src/shared/schemas/progressEvents.ts
@@ -5,6 +5,7 @@ import type { RoundIndexed } from './roundIndexed';
 import type {
   ActiveChildInfo,
   ConversationProgress,
+  PhaseStage,
   RoundStage,
 } from './streamState';
 import type { StreamPhase, StreamSubstate } from './stream';
@@ -115,6 +116,13 @@ export interface UpdateConversationProgressPayload {
 export interface UpdateRoundStagePayload {
   streamId: StreamTabId;
   roundStage: RoundStage;
+}
+
+/** Phase advance within a workflow-script run, projected from `stage.start`
+ *  (kind 'phase'). */
+export interface UpdatePhaseStagePayload {
+  streamId: StreamTabId;
+  phaseStage: PhaseStage;
 }
 
 /** Active subagent roster, projected from `child.activity`. */

--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -95,6 +95,25 @@ export const RoundStageSchema = z.object({
 
 export type RoundStage = z.infer<typeof RoundStageSchema>;
 
+// Phase Stage (ephemeral phase label from typed stage.start metadata)
+//
+// A workflow-script run advances through named phases instead of numbered
+// rounds, so it fills this slot where a tool-use run fills `roundStage`. Both
+// are projected from the same `stage.start` fact, discriminated by its `kind`,
+// and a stream that opens phases never opens rounds.
+
+const PhaseStageSchema = z.object({
+  /** Phase title, free-form text from the workflow script. */
+  label: z.string(),
+  /** Zero-based position in the declared phase list. Absent for a phase the
+   *  script opened dynamically, which has no declared position. */
+  index: z.int().nonnegative().optional(),
+  /** Number of declared phases, when known. */
+  total: z.int().positive().optional(),
+});
+
+export type PhaseStage = z.infer<typeof PhaseStageSchema>;
+
 // Conversation Progress (tool-call counters updated during execution)
 
 export const ConversationProgressSchema = z.object({
@@ -121,6 +140,7 @@ export const BackendOwnedFieldsSchema = z.object({
     DEFAULT_CONVERSATION_PROGRESS,
   ),
   roundStage: RoundStageSchema.optional(),
+  phaseStage: PhaseStageSchema.optional(),
   /** Child roster — live entries plus the finished ones retained for display
    *  (`finishedAt` set). */
   subagents: z.array(ActiveChildInfoSchema).prefault([]),
@@ -128,6 +148,7 @@ export const BackendOwnedFieldsSchema = z.object({
 
 const BackendOwnedMetadataFieldsSchema = BackendOwnedFieldsSchema.extend({
   roundStage: RoundStageSchema.nullable().optional(),
+  phaseStage: PhaseStageSchema.nullable().optional(),
 });
 
 export const StreamMetadataSchema = BackendOwnedMetadataFieldsSchema.extend({

--- a/src/shared/streams/streamMetadata.ts
+++ b/src/shared/streams/streamMetadata.ts
@@ -32,6 +32,7 @@ export function buildStreamMetadata(
       ...DEFAULT_CONVERSATION_PROGRESS,
     },
     roundStage: inputs.roundStage ?? null,
+    phaseStage: inputs.phaseStage ?? null,
     subagents: inputs.subagents ?? [],
   };
 }

--- a/src/shared/streams/streamStatusDisplay.ts
+++ b/src/shared/streams/streamStatusDisplay.ts
@@ -6,6 +6,7 @@ import {
   StreamStatusSchema,
   streamStatusToPhase,
   streamStatusToSubstate,
+  type PhaseStage,
   type RoundStage,
   type StreamPhase,
   type StreamSubstate,
@@ -166,5 +167,19 @@ export function formatRoundStageLabel(
 ): string | undefined {
   if (stage === undefined) return undefined;
   const current = `r${stage.index + 1}`;
+  return stage.total !== undefined ? `${current}/${stage.total}` : current;
+}
+
+/** Compact phase progress label for a workflow-script run: `Reduce 2/3` when
+ *  the phase was declared with a position and a planned total, `Reduce 2` with
+ *  only a position, and the bare title for a dynamically opened phase.
+ *  Zero-based `index` renders one-based. Occupies the same row slot as
+ *  `formatRoundStageLabel` — a run opens phases or rounds, never both. */
+export function formatPhaseStageLabel(
+  stage: Readonly<PhaseStage> | undefined,
+): string | undefined {
+  if (stage === undefined) return undefined;
+  if (stage.index === undefined) return stage.label;
+  const current = `${stage.label} ${stage.index + 1}`;
   return stage.total !== undefined ? `${current}/${stage.total}` : current;
 }

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -605,4 +605,75 @@ describe('CLI child list display model', () => {
     expect(output).not.toContain('in:2');
     expect(output).not.toContain('ctx:1');
   });
+
+  it.each([120, 80, 64, 56])(
+    'shows a run its phase and a reflection stream its round at %i columns',
+    async (columns) => {
+      const { ink, React } = await loadInk();
+      const run = 'run' as StreamTabId;
+      const reflection = 'reflect' as StreamTabId;
+      const output: string = ink.renderToString(
+        React.createElement(SubagentList, {
+          maxRows: 4,
+          sessions: [
+            {
+              id: run,
+              label: 'workflow-script',
+              active: false,
+              slice: workflowAgentSlice('run', {
+                status: STREAM_PHASE.RUNNING,
+                phaseStage: { label: 'Reduce', index: 1, total: 3 },
+              }),
+            },
+            {
+              id: reflection,
+              label: 'reflect',
+              active: false,
+              slice: workflowAgentSlice('reflect', {
+                status: STREAM_PHASE.RUNNING,
+                roundStage: { index: 1, total: 3 },
+              }),
+            },
+          ],
+        }),
+        { columns },
+      );
+
+      // One line per row at every width — the phase takes the round's slot
+      // rather than adding one.
+      expect(
+        output.split('\n').filter((line) => line.includes('Reduce 2/3')),
+      ).toHaveLength(1);
+      expect(output).toContain('workflow-script running · Reduce 2/3');
+      expect(output).toContain('reflect running · r2/3');
+      expect(output).not.toContain('Reduce 2/3 · r2/3');
+      expect(output).not.toContain('r2/3 · Reduce 2/3');
+    },
+  );
+
+  it('never shows both a phase and a round on one row', async () => {
+    const { ink, React } = await loadInk();
+    const run = 'run' as StreamTabId;
+    const output: string = ink.renderToString(
+      React.createElement(SubagentList, {
+        maxRows: 3,
+        sessions: [
+          {
+            id: run,
+            label: 'workflow-script',
+            active: false,
+            slice: workflowAgentSlice('run', {
+              status: STREAM_PHASE.RUNNING,
+              phaseStage: { label: 'Reduce', index: 1, total: 3 },
+              roundStage: { index: 0, total: 9 },
+            }),
+          },
+        ],
+      }),
+      { columns: 100 },
+    );
+
+    expect(output).toContain('Reduce 2/3');
+    expect(output).not.toContain('r1/9');
+  });
 });

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -269,6 +269,78 @@ describe('cliState Phase 4 fields', () => {
     expect(parentStream.get().has(child1)).toBe(false);
   });
 
+  it('projects phase stages onto the run slice and leaves rounds alone', () => {
+    const hub = new SessionEventHub();
+    const detach = attachTuiRunFactSubscription(hub);
+
+    try {
+      hub.emit({
+        scope: 'run',
+        streamId: child1,
+        event: {
+          type: 'stage.start',
+          id: 'phase-2',
+          label: 'Reduce',
+          kind: 'phase',
+          index: 1,
+          total: 3,
+        },
+      });
+
+      expect(streams.get().get(child1)?.phaseStage).toEqual({
+        label: 'Reduce',
+        index: 1,
+        total: 3,
+      });
+      expect(streams.get().get(child1)?.roundStage).toBeUndefined();
+
+      hub.emit({
+        scope: 'run',
+        streamId: root,
+        event: {
+          type: 'stage.start',
+          id: 'round-2',
+          label: 'round 2',
+          kind: 'round',
+          index: 1,
+          total: 4,
+        },
+      });
+
+      expect(streams.get().get(root)?.roundStage).toEqual({
+        index: 1,
+        total: 4,
+      });
+      expect(streams.get().get(root)?.phaseStage).toBeUndefined();
+    } finally {
+      detach();
+    }
+  });
+
+  it('keeps a dynamically opened phase positionless', () => {
+    const hub = new SessionEventHub();
+    const detach = attachTuiRunFactSubscription(hub);
+
+    try {
+      hub.emit({
+        scope: 'run',
+        streamId: child1,
+        event: {
+          type: 'stage.start',
+          id: 'phase-x',
+          label: 'Cleanup',
+          kind: 'phase',
+        },
+      });
+
+      expect(streams.get().get(child1)?.phaseStage).toEqual({
+        label: 'Cleanup',
+      });
+    } finally {
+      detach();
+    }
+  });
+
   it('registers subagent parent edges when active child rows arrive', () => {
     const hub = new SessionEventHub();
     const detach = attachTuiRunFactSubscription(hub);

--- a/src/test-kernel/progressView/BackgroundTasksPanel.vitest.mts
+++ b/src/test-kernel/progressView/BackgroundTasksPanel.vitest.mts
@@ -3,9 +3,12 @@ import { describe, expect, it } from 'vitest';
 
 // Local imports
 import type { BackgroundTasksPanel } from '@progressView/frontend/components/BackgroundTasksPanel';
+import type { phaseStagesContext as PhaseStagesContext } from '@progressView/frontend/contexts/streamContexts';
+import type { StreamTabId } from '@shared/schemas';
 
 // Local file imports
 import { useLitComponentTestDom } from '../settings/litComponentTestUtils';
+import type { ContextProvider } from '@lit/context';
 
 interface StyledBackgroundTasksPanelConstructor extends CustomElementConstructor {
   readonly elementStyles: readonly (
@@ -13,10 +16,19 @@ interface StyledBackgroundTasksPanelConstructor extends CustomElementConstructor
   )[];
 }
 
+// @lit/context captures the global Event constructor at module scope, so it
+// and the context definitions can only be imported after the test DOM globals
+// are installed (that is what useLitComponentTestDom's hook does).
+let ContextProviderCtor: typeof ContextProvider;
+let phaseStagesContext: typeof PhaseStagesContext;
+
 describe('background-tasks-panel', () => {
-  useLitComponentTestDom(
-    () => import('@progressView/frontend/components/BackgroundTasksPanel'),
-  );
+  useLitComponentTestDom(async () => {
+    ({ ContextProvider: ContextProviderCtor } = await import('@lit/context'));
+    ({ phaseStagesContext } =
+      await import('@progressView/frontend/contexts/streamContexts'));
+    await import('@progressView/frontend/components/BackgroundTasksPanel');
+  });
 
   it('strips the redundant Web Awesome card around its contents', () => {
     const element = document.createElement(
@@ -97,6 +109,54 @@ describe('background-tasks-panel', () => {
     expect(shadow.textContent).toContain('1 done');
 
     element.remove();
+  });
+
+  it('labels a running workflow-script row with its current phase', async () => {
+    const element = document.createElement(
+      'background-tasks-panel',
+    ) as BackgroundTasksPanel;
+    element.subagents = [
+      {
+        kind: 'subagent',
+        executionId: 'exec-run',
+        childStreamId: 'workflow-run',
+        agentName: 'workflow-script',
+        status: 'running',
+      },
+      {
+        kind: 'subagent',
+        executionId: 'exec-plain',
+        childStreamId: 'plain-child',
+        agentName: 'reviewer',
+        status: 'running',
+      },
+    ];
+    const container = document.createElement('div');
+    document.body.append(container);
+    // A plain (non-ReactiveElement) provider host must be connected by hand.
+    new ContextProviderCtor(container, {
+      context: phaseStagesContext,
+      initialValue: new Map([
+        [
+          'workflow-run' as StreamTabId,
+          { label: 'Reduce', index: 1, total: 3 },
+        ],
+      ]),
+    }).hostConnected();
+    container.append(element);
+    await element.updateComplete;
+
+    const shadow = element.shadowRoot!;
+    const phases = [...shadow.querySelectorAll('.task-phase')].map(
+      (node) => node.textContent,
+    );
+    // Only the run carries a phase; a stream without one gains no span.
+    expect(phases).toEqual(['Reduce 2/3']);
+    const rows = [...shadow.querySelectorAll('.task-item')];
+    expect(rows[0]?.textContent).toContain('Reduce 2/3');
+    expect(rows[1]?.textContent).not.toContain('Reduce');
+
+    container.remove();
   });
 
   it('does not show success while a retained subagent status still lags', async () => {

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -984,6 +984,68 @@ describe('ProgressBackend', () => {
     }
   });
 
+  it('projects a workflow-script phase onto a non-active run stream', async () => {
+    const target = createIsolatedRecordingBackend();
+    const { backend, messages } = target;
+    const subscription = backend.setupEventListeners();
+    const run = 'workflow-run' as StreamTabId;
+
+    try {
+      emitActiveStream(target, {
+        streamId: 'root',
+        agentCategory: AgentCategory.ToolUse,
+      });
+      await vi.waitFor(() => expect(backend.state.activeStream).toBe('root'));
+      emitActiveStream(target, {
+        streamId: run,
+        agentCategory: AgentCategory.Workflow,
+        suppressViewSwitch: true,
+      });
+      await vi.waitFor(() =>
+        expect(backend.state.getStreamState(run)).toBeDefined(),
+      );
+      messages.length = 0;
+
+      target.session.events.emit({
+        scope: 'run',
+        streamId: run,
+        event: {
+          type: 'stage.start',
+          id: 'phase-2',
+          label: 'Reduce',
+          kind: 'phase',
+          index: 1,
+          total: 3,
+        },
+      });
+
+      // The parent's viewport reads this row, so the push must reach a stream
+      // that is not the active one.
+      expect(backend.state.activeStream).toBe('root');
+      await vi.waitFor(() =>
+        expect(backend.state.getStreamState(run)).toMatchObject({
+          phaseStage: { label: 'Reduce', index: 1, total: 3 },
+        }),
+      );
+      const patch = messages.find(
+        (message) =>
+          message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA &&
+          message.streamInfo.name === run,
+      );
+      if (patch?.command !== PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA) {
+        throw new Error('Expected a metadata patch for the run stream');
+      }
+      expect(patch.streamState).toMatchObject({
+        phaseStage: { label: 'Reduce', index: 1, total: 3 },
+        roundStage: null,
+      });
+    } finally {
+      subscription.dispose();
+      backend.dispose();
+      target.session.dispose();
+    }
+  });
+
   it('patches one stream for subagent registration and run-start metadata', async () => {
     const target = createIsolatedRecordingBackend();
     const { backend, messages, session } = target;

--- a/src/test-kernel/progressView/StreamMetaState.vitest.ts
+++ b/src/test-kernel/progressView/StreamMetaState.vitest.ts
@@ -254,6 +254,52 @@ describe('stream meta frontend state', () => {
     expect(getState().streamStates.get(streamId)?.roundStage).toBeUndefined();
   });
 
+  it('merges and clears a phase stage from a transport-safe metadata patch', () => {
+    const streamId = 'stream-a' as StreamTabId;
+    const state = createInitialState();
+    registerWorkflowStream(state, streamId);
+    const getState = seedState(state);
+
+    const patch = (
+      phaseStage: { label: string; index?: number; total?: number } | null,
+    ): ProgressViewOutboundMessage =>
+      JSON.parse(
+        JSON.stringify({
+          command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA,
+          streamInfo: {
+            name: streamId,
+            label: 'stream-a',
+            kind: 'agent',
+            agentCategory: AgentCategory.Workflow,
+            creationTimestamp: 1,
+          },
+          streamState: {
+            kind: AgentCategory.Workflow,
+            status: STREAM_PHASE.RUNNING,
+            conversationProgress: {
+              toolCallCount: 0,
+            },
+            roundStage: null,
+            phaseStage,
+            subagents: [],
+          },
+        } satisfies ProgressViewOutboundMessage),
+      ) as ProgressViewOutboundMessage;
+
+    dispatch(
+      streamMetaHandlers,
+      patch({ label: 'Reduce', index: 1, total: 3 }),
+    );
+    expect(getState().streamStates.get(streamId)?.phaseStage).toEqual({
+      label: 'Reduce',
+      index: 1,
+      total: 3,
+    });
+
+    dispatch(streamMetaHandlers, patch(null));
+    expect(getState().streamStates.get(streamId)?.phaseStage).toBeUndefined();
+  });
+
   it('clears round stage when synced content explicitly clears it', () => {
     const streamId = 'stream-a' as StreamTabId;
     const state = createInitialState();

--- a/src/test-kernel/progressView/StreamMetaState.vitest.ts
+++ b/src/test-kernel/progressView/StreamMetaState.vitest.ts
@@ -7,7 +7,9 @@ import { streamMetaHandlers } from '@progressView/frontend/slices/streamMetaSlic
 import { syncHandlers } from '@progressView/frontend/slices/syncSlice';
 import {
   appState,
+  phaseStages$,
   resetProgressState,
+  setStreamStateForId,
 } from '@progressView/frontend/progressState';
 import {
   createInitialState,
@@ -298,6 +300,58 @@ describe('stream meta frontend state', () => {
 
     dispatch(streamMetaHandlers, patch(null));
     expect(getState().streamStates.get(streamId)?.phaseStage).toBeUndefined();
+  });
+
+  it('keeps the phase-stage projection stable across unrelated stream ticks', () => {
+    const streamId = 'stream-a' as StreamTabId;
+    const otherId = 'stream-b' as StreamTabId;
+    const state = createInitialState();
+    registerWorkflowStream(state, streamId);
+    registerWorkflowStream(state, otherId);
+    state.streamStates.set(
+      streamId,
+      createStreamState(AgentCategory.Workflow, {
+        phaseStage: { label: 'Reduce', index: 1, total: 3 },
+      } satisfies Partial<StreamState>),
+    );
+    seedState(state);
+
+    const initial = phaseStages$.get();
+    expect(initial.get(streamId)).toEqual({
+      label: 'Reduce',
+      index: 1,
+      total: 3,
+    });
+
+    // An unrelated stream's progress tick rebuilds streamStates, so the
+    // projection recomputes — but its identity must not change, or every
+    // consumer re-renders on a tick that touched no phase.
+    setStreamStateForId(otherId, (prev) => ({
+      ...prev,
+      conversationProgress: { toolCallCount: 7 },
+    }));
+    expect(phaseStages$.get()).toBe(initial);
+
+    // A real phase advance does change identity.
+    setStreamStateForId(streamId, (prev) => ({
+      ...prev,
+      phaseStage: { label: 'Publish', index: 2, total: 3 },
+    }));
+    const advanced = phaseStages$.get();
+    expect(advanced).not.toBe(initial);
+    expect(advanced.get(streamId)).toEqual({
+      label: 'Publish',
+      index: 2,
+      total: 3,
+    });
+
+    // A structurally identical value arriving as a fresh object (every
+    // metadata patch that crosses postMessage) must not count as a change.
+    setStreamStateForId(streamId, (prev) => ({
+      ...prev,
+      phaseStage: { label: 'Publish', index: 2, total: 3 },
+    }));
+    expect(phaseStages$.get()).toBe(advanced);
   });
 
   it('clears round stage when synced content explicitly clears it', () => {

--- a/src/test-kernel/shared/SharedStreams.vitest.ts
+++ b/src/test-kernel/shared/SharedStreams.vitest.ts
@@ -12,6 +12,7 @@ import {
 import { diffActiveChildren } from '@shared/streams/childActivityReducer';
 import { buildStreamMetadata } from '@shared/streams/streamMetadata';
 import {
+  formatPhaseStageLabel,
   formatRoundStageLabel,
   formatStreamStatusLabel,
   streamStatusDisplayKey,
@@ -85,6 +86,7 @@ describe('buildStreamMetadata', () => {
       status: STREAM_STATUS.READY,
       conversationProgress: { toolCallCount: 0 },
       roundStage: null,
+      phaseStage: null,
       subagents: [],
     });
     expect(Object.hasOwn(metadata, 'substate')).toBe(true);
@@ -125,8 +127,18 @@ describe('buildStreamMetadata', () => {
       lastTimestamp: 123,
       conversationProgress: { toolCallCount: 5 },
       roundStage: { index: 1, total: 3 },
+      phaseStage: null,
       subagents: [child, finishedChild],
     });
+  });
+
+  it('carries a workflow-script phase for the run row', () => {
+    expect(
+      buildStreamMetadata({
+        kind: AgentCategory.Workflow,
+        phaseStage: { label: 'Reduce', index: 1, total: 3 },
+      }).phaseStage,
+    ).toEqual({ label: 'Reduce', index: 1, total: 3 });
   });
 });
 
@@ -145,6 +157,28 @@ describe('formatRoundStageLabel', () => {
 
   it('passes undefined through for streams without a round', () => {
     expect(formatRoundStageLabel(undefined)).toBeUndefined();
+  });
+});
+
+describe('formatPhaseStageLabel', () => {
+  it('renders the one-based phase over the declared total', () => {
+    expect(formatPhaseStageLabel({ label: 'Reduce', index: 1, total: 3 })).toBe(
+      'Reduce 2/3',
+    );
+  });
+
+  it('renders the bare position when no total was declared', () => {
+    expect(formatPhaseStageLabel({ label: 'Reduce', index: 1 })).toBe(
+      'Reduce 2',
+    );
+  });
+
+  it('renders only the title for a dynamically opened phase', () => {
+    expect(formatPhaseStageLabel({ label: 'Cleanup' })).toBe('Cleanup');
+  });
+
+  it('passes undefined through for streams without a phase', () => {
+    expect(formatPhaseStageLabel(undefined)).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Part of #9177. Stage 2 of 4 — `phaseStage` on the run's row, both hosts.

## The problem

A workflow-script run's row says `running` and nothing else, so a 3-phase,
40-minute run looks identical at minute 2 and minute 38 from the parent's
viewport. The data is already emitted and dropped: `trace.openStage(title,
{ kind: 'phase', index, total })` (`workflowScriptRun.ts`) produces a
`stage.start` fact carrying label/kind/index/total, and the projections all
bail on `if (event.kind !== 'round') return`.

## What this does

Adds a `phaseStage` sibling to `roundStage` on stream metadata, mirroring
`roundStage` hop for hop: schema → backend state → wire → merge → slice →
renderer. One shared `formatPhaseStageLabel` (`streamStatusDisplay.ts`) owns
the copy for both hosts.

```
   ● workflow-script running · Reduce 2/3 · claude-sonnet-5    4m 06s · ↓41k
```

- **CLI** — takes the slot `SubagentList.tsx` already gives
  `formatRoundStageLabel`, which is always empty for a workflow run (workflow
  runs emit phases, not rounds). The row stays one line.
- **Webview** — `BackgroundTasksPanel` gets the phase per row. See "One
  deviation" below for how, and why the route in the issue body does not work.
- **Formatting** — `Reduce 2/3` with a declared position and total, `Reduce 2`
  with only a position, and the bare title for a dynamically opened phase
  (`phase()` outside `meta.phases` carries neither index nor total). No
  truncation in the formatter — the CLI row already `truncate-end`s and the
  webview span already ellipsizes (open question 1 in the issue).

## Acceptance criteria this stage satisfies

- [x] A running workflow's row shows `{phase} {i}/{n}` in the CLI child list
      and in the Background Tasks panel, on one line, at every terminal width;
      a reflection stream's row still shows `r{i}/{n}`, and no row shows both.
      Asserted by an ink render test at 120 / 80 / 64 / 56 columns plus a
      both-fields-set row, and by a jsdom render test of the panel.
- [x] The CLI status bar does **not** gain a phase segment —
      `statusBarDisplay.ts` and `StatusBar.tsx` are not in the diff. When the
      run is focused, the workflow band already shows the phase *with*
      `done/total` in the same viewport.
- [x] `sessionProgressSubscription.ts` is untouched (`git diff --stat` does not
      list it), and headless output is byte-identical: that module is reached
      only from `runExecution.ts`, while `subscribeRuntimeHost.ts` is imported
      only by `chatSessionController.ts` → `runChatTui.tsx`.
- [x] The webview `<wa-details>` phase groups, their persisted open state, and
      `renderGroupProgress` are the same code path as before — `TaskGroupList.ts`
      is not in the diff.

## Deliberately left to later stages

- **Stage 1** (#9184, open) — per-task cost and retiring `getLiveCostUsd`. No
  file overlap with this branch.
- **Stage 3** (#9183, open) — the roster join (`workflowPhase` on
  `ActiveChildInfo`). Touches a different region of `streamState.ts`.
- **Stage 4** — phase-grouped grandchild rows in the focused CLI list,
  `streamTreeEntries` ordering, `ChildListValue` widening.

## One deviation from the issue body, and why

The issue proposed passing `.streamStates=${streamStates$.get()}` into
`<background-tasks-panel>` from `WorkflowStreamContent` / `ToolUseStreamContent`.
**That would render the field but never update it.** Those two components
extend `BaseStreamContent`, which is a plain `LitElement` — not a
`SignalWatcher` — so it re-renders only when `streamStateContext` changes, and
that context is fed by `activeStreamState$`, documented as *"Only changes when
the ACTIVE stream's state changes, not any stream"* (`progressState.ts`). A
workflow run's row lives in its **parent's** panel, so the run is precisely not
the active stream; its phase would land in `appState` and never reach the DOM.

Instead the panel consumes a narrow `phaseStagesContext`
(`Map<streamId, PhaseStage>`) provided by `StreamConversation`, which *is* a
`SignalWatcher` and already provides `streamByIdContext` to this same panel for
exactly the same reason. The backing `phaseStages$` selector omits streams
without a phase and returns a shared empty map when none has one, so a session
with no workflow-script run keeps a stable identity and re-renders exactly as
often as before this PR.

Same reason on the backend: `updateRoundStage` is gated to
`state.activeStream === streamId`, which would never fire for a child run, so
the phase push rides the existing `updateStreamMetadata` per-stream patch (no
new outbound command; phases advance a handful of times per run).

## Open questions from the issue, as answered here

1. **Truncate the phase label?** No — left to each host's existing truncation.
   The webview span additionally caps at `10rem` with a `wa-tooltip` carrying
   the full title, matching the standardized hover-hint idiom (#9166/#9178).
2. **Keep the last phase after a run settles?** Kept, mirroring `roundStage`,
   which is likewise not cleared on settle. `resetPerRunChildState` clears both
   when a *new* run starts on the same stream.
3. Retry/header-count semantics — stage 4.

## Verification

All four gates green on this branch:

```
npm run typecheck                # clean (workspace + 5 projects)
npm test                         # 777 files passed | 1 skipped, 7569 tests passed
npm run lint                     # clean
npm run check:dead-code-ratchet  # 18 current vs 18 baselined, no new findings
```

Nothing was flaky; the only failure at any point was the one expected
`buildStreamMetadata` `toEqual` needing `phaseStage: null`, updated in this PR.
`pnpm-lock.yaml` was restored after the `CI=true` typecheck workaround and is
not part of either commit.

### Follow-up commit: `phaseStages$` memo

Review found that the selector reused the shared empty map only when *no*
stream had a phase — so once a run was live (the case it exists for) it
allocated a fresh `Map` per recompute, and it recomputes on any field of any
stream. `bdbc9823af` caches the prior map and returns it when the phases are
unchanged, mirroring the `pendingApprovalIds$` stable-Set memo directly above
it, with a reset in `resetProgressState()`. Comparison is by content, not
reference, because an unchanged phase arrives as a fresh object every time a
metadata patch crosses postMessage. The regression test fails without the memo
(`expected Map to be Map // Object.is equality`).

https://claude.ai/code/session_01MQZ63FFrmojmG58wPJdYNH
