### PR TITLE
fix(workflow): report per-task costs on task rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Workflow task costs now reflect each task's own spend** — task rows and
+  cards no longer show the workflow run's cumulative cost when each task
+  finishes.
 - **Large foreground shell commands use bounded memory** — command results
   retain useful diagnostics from the beginning and end without buffering the
   complete output in memory.

--- a/src/shared/copy/workflowTask.ts
+++ b/src/shared/copy/workflowTask.ts
@@ -25,7 +25,7 @@ export function formatWorkflowTaskMetadataParts(
       : formatCompactDuration(task.durationMs),
     task.totalCostUsd === undefined
       ? undefined
-      : `${formatCostUsd(task.totalCostUsd)} total`,
+      : formatCostUsd(task.totalCostUsd),
   ].filter((part): part is string => part !== undefined);
 }
 

--- a/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptProgressBridge.vitest.ts
@@ -505,22 +505,22 @@ return await agent('Review the argument', { id: 'review-task' })`;
     }
   });
 
-  it('renders the running total on live finish lines only', async () => {
+  it('renders each call cost on live finish lines only', async () => {
     const store = getExecutionStore(executionId);
     const script = `${meta}
 await agent('First')
 return await agent('Second')`;
     const { trace, events } = recordingTrace();
-    let liveCostUsd = 0;
+    const callCosts = new Map<number, number>();
     await runPersistedWorkflowScriptWithProgress(trace, {
       store,
       checkpointId: 'live-cost',
       script,
-      runAgent: async () => {
-        liveCostUsd += 0.05;
+      runAgent: async (invocation) => {
+        callCosts.set(invocation.index, 0.05);
         return 'done';
       },
-      getLiveCostUsd: () => liveCostUsd,
+      getCallCostUsd: (index) => callCosts.get(index),
     });
 
     expect(workflowTaskEvent(events, 'First', 'completed')?.task).toMatchObject(
@@ -531,7 +531,7 @@ return await agent('Second')`;
     expect(
       workflowTaskEvent(events, 'Second', 'completed')?.task,
     ).toMatchObject({
-      totalCostUsd: 0.1,
+      totalCostUsd: 0.05,
     });
 
     clearStoreCache();
@@ -541,7 +541,7 @@ return await agent('Second')`;
       checkpointId: 'live-cost',
       script,
       runAgent: vi.fn(() => Promise.reject(new Error('must not run'))),
-      getLiveCostUsd: () => 0,
+      getCallCostUsd: () => 0,
     });
 
     expect(
@@ -552,7 +552,6 @@ return await agent('Second')`;
   it('enriches live finish lines with the reported model and duration', async () => {
     const { trace, events } = recordingTrace();
     const activities: string[] = [];
-    let liveCostUsd = 0;
     await runPersistedWorkflowScriptWithProgress(trace, {
       store: getExecutionStore(executionId),
       checkpointId: 'model-duration',
@@ -560,10 +559,9 @@ return await agent('Second')`;
 return await agent('Draft')`,
       runAgent: async (invocation: WorkflowAgentInvocation) => {
         invocation.reportModel?.('deepseekT');
-        liveCostUsd += 0.02;
         return 'done';
       },
-      getLiveCostUsd: () => liveCostUsd,
+      getCallCostUsd: () => 0.02,
       onActivity: (line) => activities.push(line),
     });
 
@@ -575,9 +573,7 @@ return await agent('Draft')`,
       },
     );
     expect(activities).toContainEqual(
-      expect.stringMatching(
-        /^Finished: Draft · deepseekT · .+ · \$0\.020 total$/,
-      ),
+      expect.stringMatching(/^Finished: Draft · deepseekT · .+ · \$0\.020$/),
     );
   });
 
@@ -608,7 +604,7 @@ return await agent('Late skip')`,
       onControl: (handle) => {
         control = handle;
       },
-      getLiveCostUsd: () => 0.04,
+      getCallCostUsd: () => 0.04,
       onActivity: (line) => activities.push(line),
     });
 
@@ -626,9 +622,7 @@ return await agent('Late skip')`,
     });
     expect(activities).toContain('Running: Late skip');
     expect(activities).toContainEqual(
-      expect.stringMatching(
-        /^Skipped: Late skip · kimiK2 · .+ · \$0\.040 total$/,
-      ),
+      expect.stringMatching(/^Skipped: Late skip · kimiK2 · .+ · \$0\.040$/),
     );
   });
 
@@ -726,7 +720,7 @@ return await agent('Abort', { phase: 'Execution' })`,
           invocation.reportModel?.('abort-model');
           throw new WorkflowRunAbortError('fatal runner error');
         },
-        getLiveCostUsd: () => 0.06,
+        getCallCostUsd: () => 0.06,
         onActivity: (line) => activities.push(line),
       }),
     ).rejects.toThrow('fatal runner error');
@@ -748,7 +742,7 @@ return await agent('Abort', { phase: 'Execution' })`,
     });
     expect(activities).toContainEqual(
       expect.stringMatching(
-        /^Failed: Abort · abort-model · .+ · \$0\.060 total — fatal runner error$/,
+        /^Failed: Abort · abort-model · .+ · \$0\.060 — fatal runner error$/,
       ),
     );
   });
@@ -758,6 +752,9 @@ return await agent('Abort', { phase: 'Execution' })`,
     try {
       const { trace, events } = recordingTrace();
       const activities: string[] = [];
+      const getCallCostUsd = vi.fn((index: number) =>
+        index === 0 ? 0.03 : undefined,
+      );
       let markStarted: (() => void) | undefined;
       const started = new Promise<void>((resolve) => {
         markStarted = resolve;
@@ -772,7 +769,7 @@ return 'guest success'`,
           markStarted?.();
           return await new Promise<never>(() => undefined);
         },
-        getLiveCostUsd: () => 0.03,
+        getCallCostUsd,
         onActivity: (line) => activities.push(line),
       });
 
@@ -793,9 +790,10 @@ return 'guest success'`,
         id: phaseId,
         status: RUN_OUTCOME.FAILED,
       });
+      expect(getCallCostUsd).toHaveBeenCalledWith(0);
       expect(activities).toContain('Running: Orphaned');
       expect(activities).toContain(
-        'Failed: Orphaned · $0.030 total — The workflow ended before this task completed.',
+        'Failed: Orphaned · $0.030 — The workflow ended before this task completed.',
       );
     } finally {
       vi.useRealTimers();

--- a/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.mts
+++ b/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.mts
@@ -1034,7 +1034,7 @@ describe('CLI workflow-script child-stream transcript', () => {
       // The phase group row and the task's current state both surface.
       expect(texts).toContain('Draft sections');
       expect(texts).toContain(
-        'Finished: Draft introduction · deepseekT · 12s · $0.002 total',
+        'Finished: Draft introduction · deepseekT · 12s · $0.002',
       );
       expect(
         entries.filter((entry) => entry.id === 'introduction-task'),
@@ -1100,7 +1100,7 @@ describe('CLI workflow-script child-stream transcript', () => {
       // the task row carries its own per-status marker.
       expect(output).toContain('◆ Draft sections');
       expect(output).toContain('☑ Finished: Draft introduction');
-      expect(output).toContain('deepseekT · 12s · $0.002 total');
+      expect(output).toContain('deepseekT · 12s · $0.002');
     } finally {
       runTrace.dispose();
     }

--- a/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
+++ b/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
@@ -543,9 +543,7 @@ describe('task-group-list workflow-script phase rendering (#8722)', () => {
     );
     expect(content?.textContent).toContain('Review manuscript');
     expect(content?.textContent).toContain('Finished');
-    expect(content?.textContent).toContain(
-      'claude-opus-4 · 12s · $0.040 total',
-    );
+    expect(content?.textContent).toContain('claude-opus-4 · 12s · $0.040');
     expect(content?.textContent).toContain('Check argument');
     expect(content?.textContent).toContain('timed out');
     expect(content?.querySelector('.workflow-task--failed')).not.toBeNull();
@@ -562,7 +560,7 @@ describe('task-group-list workflow-script phase rendering (#8722)', () => {
     expect(notReached?.querySelector('.workflow-task-meta')).toBeNull();
     const userSkipped = content?.querySelector('[data-log-id="agent-d"]');
     expect(userSkipped?.textContent).toContain('Stopped review');
-    expect(userSkipped?.textContent).toContain('kimi-k2 · 2s · $0.020 total');
+    expect(userSkipped?.textContent).toContain('kimi-k2 · 2s · $0.020');
     expect(userSkipped?.querySelector('.workflow-task-detail')).toBeNull();
   });
 

--- a/src/test-kernel/shared/WorkflowTaskCopy.vitest.ts
+++ b/src/test-kernel/shared/WorkflowTaskCopy.vitest.ts
@@ -17,7 +17,7 @@ describe('workflow task copy', () => {
         durationMs: 7_320,
         totalCostUsd: 0.04,
       }),
-    ).toEqual(['gpt56', '7s', '$0.040 total']);
+    ).toEqual(['gpt56', '7s', '$0.040']);
   });
 
   it('does not attach terminal metadata to an active task', () => {
@@ -41,9 +41,7 @@ describe('workflow task copy', () => {
         durationMs: 7_320,
         totalCostUsd: 0.04,
       }),
-    ).toBe(
-      'Failed: Audit source · kimiK2 · 7s · $0.040 total — Runner stopped.',
-    );
+    ).toBe('Failed: Audit source · kimiK2 · 7s · $0.040 — Runner stopped.');
   });
 
   it('explains a task the run never reached on every textual host', () => {
@@ -95,6 +93,6 @@ describe('workflow task copy', () => {
         durationMs: 7_320,
         totalCostUsd: 0.04,
       }),
-    ).toBe('Skipped: Stopped review · kimiK2 · 7s · $0.040 total');
+    ).toBe('Skipped: Stopped review · kimiK2 · 7s · $0.040');
   });
 });

--- a/src/test-kernel/tools/WorkflowScriptStrategy.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptStrategy.vitest.ts
@@ -317,6 +317,7 @@ function controllableRunAgent(config: {
   /** 1-based attempt that settles with finalResult; earlier attempts hang.
    *  Omit so every attempt hangs until a control action resolves it. */
   readonly succeedAtAttempt?: number;
+  readonly attemptCosts?: readonly number[];
 }): {
   readonly createRunAgent: WorkflowScriptStrategyParams['createRunAgent'];
   readonly attemptStarted: (attempt: number) => Promise<void>;
@@ -344,6 +345,8 @@ function controllableRunAgent(config: {
       reportCost = (cost) => hooks.onCost(invocation, cost);
       hooks.onChildActive(execId, invocation, true);
       gateFor(thisAttempt).resolve();
+      const attemptCost = config.attemptCosts?.[thisAttempt - 1];
+      if (attemptCost !== undefined) hooks.onCost(invocation, attemptCost);
       try {
         if (config.succeedAtAttempt !== thisAttempt) {
           // Hang until a control action aborts this attempt (skip/retry).
@@ -401,10 +404,21 @@ describe('createWorkflowScriptStrategy interactive controls', () => {
     const fake = controllableRunAgent({
       attemptExecutionIds: [grandchildExecutionId],
       succeedAtAttempt: 2,
+      attemptCosts: [0.1, 0.5],
+    });
+    const logger = new TraceEmitter();
+    const completedTaskCosts: number[] = [];
+    logger.subscribe((event) => {
+      if (event.type === 'workflow.task' && event.task.status === 'completed') {
+        if (event.task.totalCostUsd !== undefined) {
+          completedTaskCosts.push(event.task.totalCostUsd);
+        }
+      }
     });
     const strategy = createWorkflowScriptStrategy(
       strategyParams({
         name: 'strategy-test',
+        logger,
         createRunAgent: fake.createRunAgent,
       }),
     );
@@ -417,6 +431,8 @@ describe('createWorkflowScriptStrategy interactive controls', () => {
     // The second attempt settles with the real result, and the call ran twice.
     expect(turn.result).toMatchObject({ category: 'workflow', cost: 0.42 });
     expect(fake.attempts()).toBe(2);
+    expect(completedTaskCosts).toHaveLength(1);
+    expect(completedTaskCosts[0]).toBeCloseTo(0.6);
   });
 
   it('targets the attempt-specific execution id after a durable retry advances it', async () => {

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -21,8 +21,8 @@ type WorkflowScriptRunWithProgressOptions = Omit<
   PersistedWorkflowScriptRunOptions,
   'onEvent'
 > & {
-  /** Cumulative live spend across this run's children, for progress lines. */
-  readonly getLiveCostUsd?: () => number;
+  /** Accumulated live spend for one logical call, for progress lines. */
+  readonly getCallCostUsd?: (index: number) => number | undefined;
   /**
    * Receives every progress line also written to the trace (phases, script
    * log() output, per-call outcomes) so the caller can hand the run log back
@@ -116,11 +116,12 @@ export async function runPersistedWorkflowScriptWithProgress(
   trace: AgentTrace,
   options: WorkflowScriptRunWithProgressOptions,
 ): Promise<WorkflowScriptRunResult> {
-  const { getLiveCostUsd, onActivity, ...runOptions } = options;
+  const { getCallCostUsd, onActivity, ...runOptions } = options;
   const parentStageId = trace.activeStageId();
   const phases = new Map<string, PhaseStage>();
   const phaseStageIds = new Map<string, string>();
   const callPhases = new Map<WorkflowScriptProgressId, string | undefined>();
+  const callIndexes = new Map<WorkflowScriptProgressId, number>();
   const projectedTasks = new Map<
     WorkflowScriptProgressId,
     ProjectedWorkflowTask
@@ -257,6 +258,7 @@ export async function runPersistedWorkflowScriptWithProgress(
       case 'agent:start': {
         const phaseTitle = event.phase ?? currentPhase;
         callPhases.set(event.progressId, phaseTitle);
+        callIndexes.set(event.progressId, event.index);
         // Open the phase the moment the run reaches it; `emitTask` resolves
         // the card's group on its own from the task's recorded phase.
         openPhaseStage(phaseTitle, event.phaseIndex, event.phaseTotal);
@@ -276,15 +278,16 @@ export async function runPersistedWorkflowScriptWithProgress(
           ? callPhases.get(event.progressId)
           : (event.phase ?? currentPhase);
         callPhases.delete(event.progressId);
+        callIndexes.delete(event.progressId);
         // A cached replay has no agent:start, so this is where its phase opens.
         openPhaseStage(phaseTitle, event.phaseIndex, event.phaseTotal);
         // Cached replays spend nothing, so their lines stay cost-free; live
-        // onCost settles before agent:end, so the total here is current.
+        // onCost settles before agent:end, so the call cost here is current.
         const spent =
           event.outcome === 'completed' ||
           event.outcome === 'failed' ||
           event.outcome === 'skipped'
-            ? getLiveCostUsd?.()
+            ? getCallCostUsd?.(event.index)
             : undefined;
         // Live terminal events carry all attempt metadata known by the engine.
         // Cached replays report none because they perform no live attempt.
@@ -383,7 +386,9 @@ export async function runPersistedWorkflowScriptWithProgress(
       } else if (status === 'running') {
         markPhaseFailed(task.phase);
         const error = 'The workflow ended before this task completed.';
-        const totalCostUsd = getLiveCostUsd?.();
+        const callIndex = callIndexes.get(task.id);
+        const totalCostUsd =
+          callIndex === undefined ? undefined : getCallCostUsd?.(callIndex);
         const failedTask: WorkflowTaskProgress = {
           ...task,
           status: 'failed',

--- a/src/tools/delegation/workflowScriptStrategy.ts
+++ b/src/tools/delegation/workflowScriptStrategy.ts
@@ -139,7 +139,7 @@ export function createWorkflowScriptStrategy(
       // identity so discarded retry/skip/failure work is still billed while a
       // pure journal replay settles zero.
       const observedCosts = new Map<string, number>();
-      let liveCostUsd = 0;
+      const callCostsByIndex = new Map<number, number>();
       // Live grandchild execution id → engine call index, maintained by the
       // runner's child-active hook. The identity bridge that lets an
       // execution-id-keyed host action reach the engine's index-keyed control.
@@ -152,7 +152,10 @@ export function createWorkflowScriptStrategy(
             identity,
             (observedCosts.get(identity) ?? 0) + cost,
           );
-          liveCostUsd += cost;
+          callCostsByIndex.set(
+            invocation.index,
+            (callCostsByIndex.get(invocation.index) ?? 0) + cost,
+          );
         },
         onChildActive: (grandchildExecutionId, invocation, active) => {
           if (active) {
@@ -176,7 +179,7 @@ export function createWorkflowScriptStrategy(
           }),
           signal: abortController.signal,
           runAgent,
-          getLiveCostUsd: () => liveCostUsd,
+          getCallCostUsd: (index) => callCostsByIndex.get(index),
           onActivity: runLog.add,
           onControl: (control) => {
             // Translate an execution-id-keyed host request into an


### PR DESCRIPTION
## Summary

- accumulate workflow child cost by logical engine-call index alongside unchanged journal reconciliation
- attach each terminal task's own cost, including retry attempts, instead of the run-cumulative spend
- preserve the call index for tasks finalized when the run ends while they are still active
- remove the misleading `total` suffix through the existing shared task-copy formatter

Closes #9182. This is only Stage 1 of #9177; phase rows and grouping remain out of scope.

## Net elements (R6)

- 9 files changed: 63 insertions, 42 deletions
- production/changelog: 21 insertions, 10 deletions, net +11 lines
- tests: 42 insertions, 32 deletions
- adds no files, exports, schemas, events, or UI structure
- removes the progress-only cumulative `liveCostUsd` scalar and replaces one callback contract

## Consumer counts (R8)

- `getCallCostUsd`: one producer in `workflowScriptStrategy.ts`; two progress reads in `workflowScriptRun.ts` (terminal event and unfinished-task finalization)
- existing identity-keyed `observedCosts` / `sumCurrentWorkflowRunCost`: unchanged
- shared cost copy remains single-owned by `formatWorkflowTaskMetadataParts` and flows to the run log, CLI transcript, and progress-view card

## Validation

- focused workflow/progress suite: 6 files, 72 tests passed
- retry/finalization rerun: 2 files, 32 tests passed
- unchanged run-total accounting suite: 8 tests passed
- full suite: 777 files passed, 1 skipped; 7,553 tests passed, 4 skipped (`--maxWorkers=4`)
- all workspace typechecks passed
- lint, formatting, dead-code ratchet (18/18), and `git diff --check` passed
- acceptance greps found no `getLiveCostUsd`, progress-only `liveCostUsd`, or workflow-task `$... total` copy
- independent code review: no findings

The default-worker full-suite attempt hit an unrelated 10-second timeout in `RunChatSignalOwnership.vitest.mts`; that file passed alone (2/2), and the complete bounded-worker suite passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display and progress attribution only; journal-level run cost reconciliation is unchanged and coverage is broad in workflow/progress tests.
> 
> **Overview**
> Workflow task rows and finish lines now show **each agent call’s own spend** instead of the workflow run’s running total when a task completes, fails, or is skipped.
> 
> The progress bridge replaces **`getLiveCostUsd`** with **`getCallCostUsd(index)`**, tracks call index from `agent:start` through cleanup, and the strategy accumulates child cost **per engine call index** (retry attempts roll into that call). Shared task copy drops the **`total`** suffix on dollar amounts so CLI transcript, progress cards, and activity lines stay consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02700fe23ac4abf7ef0429a11a6cc281ca4951f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->