### PR TITLE
Stage 4 of 4 for #9177: group a focused workflow run's agents by phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,11 @@ All notable changes to this project will be documented in this file.
   running, finished, saved-result, skipped, and failed, instead of every row
   looking alike. A task the run never reached now also explains itself the way
   the progress view already did.
+- **Focusing a workflow-script run groups its agents by phase** — the child
+  list now heads each group with `◆ Reduce (2/3)` and that phase's finished
+  task count, instead of listing every agent flat. Headers are dividers only:
+  arrow keys step over them, and the agent rows keep their existing elapsed,
+  tool-call, and token figures.
 
 ## [0.39.8] - 2026-07-24
 

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -4,7 +4,10 @@
 import { Box, Text } from 'ink';
 
 import { AgentCategory } from '@shared/schemas';
-import { workflowPhaseTaskProgress } from '@shared/copy/workflowTask';
+import {
+  formatWorkflowPhaseHeading,
+  workflowPhaseTaskProgress,
+} from '@shared/copy/workflowTask';
 import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 import { formatResultCount } from '@utils/text/stringUtils';
 
@@ -128,10 +131,6 @@ export function workflowRunStatusSummary(
 ): string | undefined {
   if (slice?.category !== AgentCategory.Workflow) return undefined;
   const phase = slice.entries.findLast((entry) => entry.role === 'phase');
-  const phaseCounts =
-    phase?.phaseIndex !== undefined && phase.phaseTotal !== undefined
-      ? ` (${phase.phaseIndex + 1}/${phase.phaseTotal})`
-      : '';
   const { done, total } = workflowPhaseTaskProgress(
     phase
       ? slice.entries.flatMap((entry) =>
@@ -144,7 +143,7 @@ export function workflowRunStatusSummary(
   const input = slice.files?.input.length ?? 0;
   const context = slice.files?.context.length ?? 0;
   const segments = [
-    ...(phase ? [`${phase.phaseLabel}${phaseCounts}`] : []),
+    ...(phase ? [formatWorkflowPhaseHeading(phase)] : []),
     ...(total > 0 ? [`${done}/${total} done`] : []),
     ...(input > 0 || context > 0
       ? [

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -20,9 +20,15 @@ import { truncateSummaryToWidth } from '../render/terminalText';
 import { childElapsed } from '../state/childControls';
 import {
   childListStreamId,
+  childPhaseListValue,
   childStreamListValue,
   type ChildListValue,
 } from '../state/childListSelection';
+import {
+  childPhaseGroupRows,
+  type ChildPhaseGroupRow,
+  type ChildPhaseHeader,
+} from '../state/childPhaseGroups';
 import { useLiveNowMs } from '../state/useLiveNowMs';
 import { COLOR_HINT } from '../ui/colors';
 import { POINTER, TICK } from '../ui/glyphs';
@@ -69,6 +75,41 @@ function RowMetadata({
 }
 
 const SUBAGENT_SUMMARY_MAX_COLUMNS = 100;
+
+/** Indent that lands the `◆` on the same column as a row's status marker
+ *  (`SessionRow` prints a 1-column pointer slot then a 3-column tick slot). */
+const PHASE_HEADER_INDENT = '    ';
+
+/** Non-selectable divider above one phase's rows. `done/total` right-aligns
+ *  into the metadata column when the panel is pinned to the terminal width,
+ *  and falls back inline below `CHILD_ROW_METADATA_MIN_COLUMNS` — the same
+ *  width gate the rows use to shed their own metadata column. */
+function PhaseHeaderRow({
+  header,
+  metadataColumn,
+}: {
+  readonly header: ChildPhaseHeader;
+  readonly metadataColumn: boolean;
+}): React.JSX.Element {
+  const progress = header.progress;
+  return (
+    <Box
+      flexDirection="row"
+      flexGrow={1}
+      height={1}
+      minWidth={0}
+      overflowY="hidden"
+    >
+      <Box minWidth={0} flexShrink={1}>
+        <Text dimColor wrap="truncate-end">
+          {`${PHASE_HEADER_INDENT}${header.label}`}
+          {!metadataColumn && progress ? ` · ${progress}` : ''}
+        </Text>
+      </Box>
+      {metadataColumn ? <RowMetadata text={progress} /> : null}
+    </Box>
+  );
+}
 
 function SessionRow({
   active,
@@ -169,6 +210,14 @@ function SessionRow({
   );
 }
 
+function childListRowValue(
+  row: ChildPhaseGroupRow<StreamView>,
+): ChildListValue {
+  return row.kind === 'header'
+    ? childPhaseListValue(row.header.phase)
+    : childStreamListValue(row.row.id);
+}
+
 export interface SubagentListProps {
   readonly keyboardActive?: boolean;
   readonly maxRows?: number;
@@ -206,20 +255,45 @@ export function SubagentList(
         .join(':') || undefined,
     [sessions],
   );
+  // The run's own transcript owns the phase outline and the task cards; it is
+  // the active stream whenever this list is rooted on it, so its entries are
+  // fully projected. `streamTreeEntries` already made same-phase rows
+  // contiguous, so this only inserts the dividers.
+  const listRootEntries = useMemo(
+    () =>
+      sessions.find((session) => session.id === props.listRootStreamId)?.slice
+        ?.entries,
+    [props.listRootStreamId, sessions],
+  );
+  const rows = useMemo(
+    () =>
+      childPhaseGroupRows({
+        rows: sessions,
+        phases: (listRootEntries ?? []).flatMap((entry) =>
+          entry.role === 'phase' ? [entry] : [],
+        ),
+        tasks: (listRootEntries ?? []).flatMap((entry) =>
+          entry.role === 'workflowTask' ? [entry.task] : [],
+        ),
+      }),
+    [listRootEntries, sessions],
+  );
   const items = useMemo(
     () =>
-      sessions.map((session) => ({
-        label: session.label,
-        value: childStreamListValue(session.id),
-      })),
-    [sessions],
-  );
-  const sessionsByValue = useMemo(
-    () =>
-      new Map(
-        sessions.map((session) => [childStreamListValue(session.id), session]),
+      rows.map((row) =>
+        row.kind === 'header'
+          ? {
+              label: row.header.label,
+              value: childListRowValue(row),
+              disabled: true,
+            }
+          : { label: row.row.label, value: childListRowValue(row) },
       ),
-    [sessions],
+    [rows],
+  );
+  const rowsByValue = useMemo(
+    () => new Map(rows.map((row) => [childListRowValue(row), row])),
+    [rows],
   );
   const nowMs = useLiveNowMs(liveElapsedKey !== undefined, liveElapsedKey);
   const { columns } = useWindowSize();
@@ -314,8 +388,18 @@ export function SubagentList(
           if (streamId) props.onFocusStream?.(streamId);
         }}
         renderItem={(item, state) => {
-          const session = sessionsByValue.get(item.value);
-          return session ? (
+          const row = rowsByValue.get(item.value);
+          if (!row) return null;
+          if (row.kind === 'header') {
+            return (
+              <PhaseHeaderRow
+                header={row.header}
+                metadataColumn={metadataColumn}
+              />
+            );
+          }
+          const session = row.row;
+          return (
             <SessionRow
               isListRoot={session.id === props.listRootStreamId}
               active={state.active}
@@ -326,7 +410,7 @@ export function SubagentList(
               pendingKinds={props.pendingApprovals?.get(session.id)}
               session={session}
             />
-          ) : null;
+          );
         }}
       />
     </Box>

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -257,8 +257,8 @@ export function SubagentList(
   );
   // The run's own transcript owns the phase outline and the task cards; it is
   // the active stream whenever this list is rooted on it, so its entries are
-  // fully projected. `streamTreeEntries` already made same-phase rows
-  // contiguous, so this only inserts the dividers.
+  // fully projected. `streamTreeEntries` already grouped these rows with the
+  // same rule, so this pass only inserts the dividers.
   const listRootEntries = useMemo(
     () =>
       sessions.find((session) => session.id === props.listRootStreamId)?.slice

--- a/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
@@ -2,6 +2,7 @@
 // budgeting, static scrollback, and print-once full output.
 
 import type { WorkflowTaskProgress } from '@shared/schemas';
+import { formatWorkflowPhaseHeading } from '@shared/copy/workflowTask';
 import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 import { renderAnsiMarkdown } from '../render/ansiMarkdown';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
@@ -236,13 +237,9 @@ function entryLines(
       return richProjection ? lines : wrapDisplayLines(lines, columns);
     }
     case 'phase': {
-      const suffix =
-        entry.phaseIndex !== undefined && entry.phaseTotal !== undefined
-          ? ` (${entry.phaseIndex + 1}/${entry.phaseTotal})`
-          : '';
       const geometry = ROLE_GEOMETRY.phase;
       return wrapWithPrefix(
-        `${STATUS_DIAMOND} ${entry.phaseLabel}${suffix}`,
+        `${STATUS_DIAMOND} ${formatWorkflowPhaseHeading(entry)}`,
         columns,
         geometry.firstPrefix,
         geometry.continuationPrefix,

--- a/packages/cli/src/chat/tui/state/childListSelection.ts
+++ b/packages/cli/src/chat/tui/state/childListSelection.ts
@@ -1,10 +1,22 @@
 // Local imports - shared stream identity
 import type { StreamTabId } from '@shared/schemas';
 
-export type ChildListValue = `stream:${string}`;
+/**
+ * A row identity in the child list. `stream:` rows are the selectable ones;
+ * `phase:` rows are the workflow-phase dividers the focused-run list inserts,
+ * which are `disabled` `Select` items and therefore never selected, never
+ * highlighted and never navigated onto. They exist only inside `SubagentList`'s
+ * own item list — the caller's `values` stay stream-only, so selection
+ * reconciliation can never fall back onto a divider.
+ */
+export type ChildListValue = `stream:${string}` | `phase:${string}`;
 
 export function childStreamListValue(streamId: StreamTabId): ChildListValue {
   return `stream:${streamId}`;
+}
+
+export function childPhaseListValue(phase: string): ChildListValue {
+  return `phase:${phase}`;
 }
 
 export function childListStreamId(

--- a/packages/cli/src/chat/tui/state/childPhaseGroups.ts
+++ b/packages/cli/src/chat/tui/state/childPhaseGroups.ts
@@ -1,0 +1,115 @@
+// Phase grouping for a focused workflow-script run's child rows.
+//
+// Two pure derivations with one owner, because they have to agree: the row
+// ORDER (consumed by `streamTreeEntries`, which also assigns the Alt+1..9
+// shortcut numbers — grouping in the renderer instead would silently
+// desynchronise a shortcut from the row it points at) and the divider rows the
+// list paints above each group. Same rows + tasks in, same groups out: no
+// clock, no synthetic ids, no dedup.
+
+// Local imports - shared workflow copy
+import type { WorkflowTaskProgress } from '@shared/schemas';
+import {
+  formatWorkflowPhaseHeading,
+  workflowPhaseTaskProgress,
+  type WorkflowPhaseHeading,
+} from '@shared/copy/workflowTask';
+
+// Local imports - TUI presentation
+import { STATUS_DIAMOND } from '../ui/glyphs';
+
+/** Phase divider heading one contiguous group of child rows. */
+export interface ChildPhaseHeader {
+  /** Phase title, and the group's identity. */
+  readonly phase: string;
+  /** `◆ Reduce (2/3)` — the transcript divider's copy, same owner. */
+  readonly label: string;
+  /** `1/3` task completion; absent when the phase declares no tasks. */
+  readonly progress?: string;
+}
+
+export type ChildPhaseGroupRow<T> =
+  | { readonly kind: 'header'; readonly header: ChildPhaseHeader }
+  | { readonly kind: 'row'; readonly row: T };
+
+/**
+ * Stable group-by: entries carrying the same phase become contiguous, ordered
+ * by each phase's first-seen position, with within-group order untouched.
+ * Entries with no phase keep their own position as their rank, so a list where
+ * nothing carries a phase sorts to itself — returned as the very same array,
+ * which is the root viewport's regression guard.
+ */
+export function orderChildIdsByPhase<T>(
+  ids: readonly T[],
+  phaseOf: (id: T) => string | undefined,
+): readonly T[] {
+  const firstSeen = new Map<string, number>();
+  for (const [index, id] of ids.entries()) {
+    const phase = phaseOf(id);
+    if (phase === undefined || firstSeen.has(phase)) continue;
+    firstSeen.set(phase, index);
+  }
+  if (firstSeen.size === 0) return ids;
+  return ids
+    .map((id, index) => {
+      const phase = phaseOf(id);
+      const rank =
+        phase === undefined ? index : (firstSeen.get(phase) ?? index);
+      return { id, index, rank };
+    })
+    .sort((a, b) => a.rank - b.rank || a.index - b.index)
+    .map((entry) => entry.id);
+}
+
+/**
+ * Insert a phase header above each contiguous group of rows that declare one.
+ * Rows without a phase pass through ungrouped and header-less, so a list where
+ * no row carries a phase yields exactly its own rows in order.
+ *
+ * `done/total` per header is the shared `workflowPhaseTaskProgress` fold over
+ * the run's task cards for that phase — one per logical `agent()` call. A
+ * durable retry registers a *new* child stream, so a retried call can leave two
+ * rows under a header whose count moves by one. That is the intended reading:
+ * headers count tasks, rows count attempts.
+ */
+export function childPhaseGroupRows<
+  T extends { readonly workflowPhase?: string },
+>(init: {
+  readonly rows: readonly T[];
+  readonly phases?: readonly WorkflowPhaseHeading[];
+  readonly tasks?: readonly WorkflowTaskProgress[];
+}): readonly ChildPhaseGroupRow<T>[] {
+  const headingByPhase = new Map<string, string>();
+  for (const phase of init.phases ?? []) {
+    headingByPhase.set(phase.phaseLabel, formatWorkflowPhaseHeading(phase));
+  }
+  const tasksByPhase = new Map<string, WorkflowTaskProgress[]>();
+  for (const task of init.tasks ?? []) {
+    if (task.phase === undefined) continue;
+    const bucket = tasksByPhase.get(task.phase);
+    if (bucket) bucket.push(task);
+    else tasksByPhase.set(task.phase, [task]);
+  }
+
+  const out: ChildPhaseGroupRow<T>[] = [];
+  let currentPhase: string | undefined;
+  for (const row of init.rows) {
+    const phase = row.workflowPhase;
+    if (phase !== undefined && phase !== currentPhase) {
+      const { done, total } = workflowPhaseTaskProgress(
+        tasksByPhase.get(phase) ?? [],
+      );
+      out.push({
+        kind: 'header',
+        header: {
+          phase,
+          label: `${STATUS_DIAMOND} ${headingByPhase.get(phase) ?? phase}`,
+          ...(total > 0 ? { progress: `${done}/${total}` } : {}),
+        },
+      });
+    }
+    currentPhase = phase;
+    out.push({ kind: 'row', row });
+  }
+  return out;
+}

--- a/packages/cli/src/chat/tui/state/childPhaseGroups.ts
+++ b/packages/cli/src/chat/tui/state/childPhaseGroups.ts
@@ -1,11 +1,12 @@
 // Phase grouping for a focused workflow-script run's child rows.
 //
-// Two pure derivations with one owner, because they have to agree: the row
-// ORDER (consumed by `streamTreeEntries`, which also assigns the Alt+1..9
-// shortcut numbers — grouping in the renderer instead would silently
-// desynchronise a shortcut from the row it points at) and the divider rows the
-// list paints above each group. Same rows + tasks in, same groups out: no
-// clock, no synthetic ids, no dedup.
+// Two pure derivations over one ordering rule, because they have to agree: the
+// row ORDER (applied by `streamTreeEntries`, which also assigns the Alt+1..9
+// shortcut numbers, so a shortcut cannot point at a different row than the one
+// a user counts to) and the divider rows the list paints above each group. The
+// divider pass re-applies that same rule, which is idempotent — that is what
+// makes it total on any input without giving order a second owner. Same rows +
+// tasks in, same groups out: no clock, no synthetic ids, no dedup.
 
 // Local imports - shared workflow copy
 import type { WorkflowTaskProgress } from '@shared/schemas';
@@ -35,9 +36,17 @@ export type ChildPhaseGroupRow<T> =
 /**
  * Stable group-by: entries carrying the same phase become contiguous, ordered
  * by each phase's first-seen position, with within-group order untouched.
- * Entries with no phase keep their own position as their rank, so a list where
- * nothing carries a phase sorts to itself — returned as the very same array,
- * which is the root viewport's regression guard.
+ *
+ * Entries carrying no phase sort ahead of every group, keeping their relative
+ * order. They cannot be left between or after groups: a divider only ever
+ * *opens* a group, so a phase-less entry trailing one would render directly
+ * under that group's rows and read as part of it — which is exactly what an
+ * `agent()` call issued outside any `phase()`, or a roster row from before the
+ * field existed, is not. Ahead of the first divider they belong to the run
+ * itself, which is also where the tree puts them.
+ *
+ * A list where nothing carries a phase sorts to itself — returned as the very
+ * same array, which is the root viewport's regression guard.
  */
 export function orderChildIdsByPhase<T>(
   ids: readonly T[],
@@ -53,18 +62,27 @@ export function orderChildIdsByPhase<T>(
   return ids
     .map((id, index) => {
       const phase = phaseOf(id);
-      const rank =
-        phase === undefined ? index : (firstSeen.get(phase) ?? index);
-      return { id, index, rank };
+      // Every group ranks by its first-seen index, so -1 is the phase-less
+      // block: ahead of all of them, and stable within itself.
+      const groupRank = phase === undefined ? undefined : firstSeen.get(phase);
+      return { id, index, rank: groupRank ?? -1 };
     })
     .sort((a, b) => a.rank - b.rank || a.index - b.index)
     .map((entry) => entry.id);
 }
 
 /**
- * Insert a phase header above each contiguous group of rows that declare one.
- * Rows without a phase pass through ungrouped and header-less, so a list where
- * no row carries a phase yields exactly its own rows in order.
+ * Insert a phase header above each group of rows that declare one. Rows
+ * carrying no phase pass through header-less ahead of every group, so a list
+ * where no row carries a phase yields exactly its own rows in order.
+ *
+ * Grouping is `orderChildIdsByPhase` — the same rule, and the same single
+ * implementation, that `streamTreeEntries` applies when it numbers the Alt+1..9
+ * shortcuts. It is idempotent, so re-applying it here to an already-ordered
+ * list is a no-op and the rendered order cannot drift from the shortcut order;
+ * applying it here rather than trusting the caller is what makes this pass
+ * total. Because groups are contiguous by construction, no phase can open a
+ * second header and no row can end up under a header it does not belong to.
  *
  * `done/total` per header is the shared `workflowPhaseTaskProgress` fold over
  * the run's task cards for that phase — one per logical `agent()` call. A
@@ -92,10 +110,16 @@ export function childPhaseGroupRows<
   }
 
   const out: ChildPhaseGroupRow<T>[] = [];
-  let currentPhase: string | undefined;
-  for (const row of init.rows) {
+  // The phase whose divider is the last one emitted. It only ever advances to
+  // the next group's phase — a phase-less row never reopens it, because the
+  // ordering above has already put every one of them ahead of the first group.
+  let openPhase: string | undefined;
+  for (const row of orderChildIdsByPhase(
+    init.rows,
+    (candidate) => candidate.workflowPhase,
+  )) {
     const phase = row.workflowPhase;
-    if (phase !== undefined && phase !== currentPhase) {
+    if (phase !== undefined && phase !== openPhase) {
       const { done, total } = workflowPhaseTaskProgress(
         tasksByPhase.get(phase) ?? [],
       );
@@ -107,8 +131,8 @@ export function childPhaseGroupRows<
           ...(total > 0 ? { progress: `${done}/${total}` } : {}),
         },
       });
+      openPhase = phase;
     }
-    currentPhase = phase;
     out.push({ kind: 'row', row });
   }
   return out;

--- a/packages/cli/src/chat/tui/state/streamViews.ts
+++ b/packages/cli/src/chat/tui/state/streamViews.ts
@@ -14,6 +14,7 @@ import {
   visibleSubagentRows,
   type ChildStreamEntries,
 } from './childExecutions';
+import { orderChildIdsByPhase } from './childPhaseGroups';
 import type { StreamSlice } from './cliState';
 
 export interface StreamView {
@@ -131,6 +132,15 @@ export function streamDisplayLabel(init: {
   );
 }
 
+/** Workflow-script phase owning a child stream, per the retained roster entry. */
+function streamWorkflowPhase(
+  childStreamEntries: ChildStreamEntries,
+  streamId: StreamTabId,
+): string | undefined {
+  const entry = childStreamEntries.get(streamId);
+  return entry?.kind === 'live' ? entry.summary?.workflowPhase : undefined;
+}
+
 export function streamViewForId(init: {
   readonly activeStreamId: StreamTabId | undefined;
   readonly childStreamEntries: ChildStreamEntries;
@@ -146,10 +156,7 @@ export function streamViewForId(init: {
     label: streamDisplayLabel(init),
     toolName:
       childEntry?.kind === 'live' ? childEntry.summary?.toolName : undefined,
-    workflowPhase:
-      childEntry?.kind === 'live'
-        ? childEntry.summary?.workflowPhase
-        : undefined,
+    workflowPhase: streamWorkflowPhase(init.childStreamEntries, init.streamId),
     parentId,
     parentLabel: parentId
       ? streamDisplayLabel({
@@ -182,11 +189,18 @@ export function streamTreeEntries(
   // then creation order), so the child list and its
   // Alt+1..9 shortcuts read top-to-bottom from most to least recently
   // started, keeping the row a user is most likely watching near the top.
-  const ordered = focusOrderDescendants(
-    root,
-    init.childStreamEntries,
-    init.streams,
-  ).toReversed();
+  // Grouping belongs here, not in the renderer: this loop also assigns the
+  // Alt+1..9 shortcut numbers, so one owner produces order, shortcuts and
+  // rendering and they cannot drift apart. A list where nothing carries a
+  // workflow phase groups to itself, leaving the root viewport untouched.
+  const ordered = orderChildIdsByPhase(
+    focusOrderDescendants(
+      root,
+      init.childStreamEntries,
+      init.streams,
+    ).toReversed(),
+    (id) => streamWorkflowPhase(init.childStreamEntries, id),
+  );
   const out: ActiveStreamTreeEntry[] = [];
   if (init.streams.has(root)) out.push({ id: root });
   for (const [index, id] of ordered.entries()) {

--- a/packages/cli/src/chat/tui/state/streamViews.ts
+++ b/packages/cli/src/chat/tui/state/streamViews.ts
@@ -189,9 +189,10 @@ export function streamTreeEntries(
   // then creation order), so the child list and its
   // Alt+1..9 shortcuts read top-to-bottom from most to least recently
   // started, keeping the row a user is most likely watching near the top.
-  // Grouping belongs here, not in the renderer: this loop also assigns the
-  // Alt+1..9 shortcut numbers, so one owner produces order, shortcuts and
-  // rendering and they cannot drift apart. A list where nothing carries a
+  // Grouping is applied here because this loop also assigns the Alt+1..9
+  // shortcut numbers, so the order a user sees and the numbers that select it
+  // come out of one pass. The divider pass re-applies the same rule, which is
+  // idempotent, so the two cannot drift apart. A list where nothing carries a
   // workflow phase groups to itself, leaving the root viewport untouched.
   const ordered = orderChildIdsByPhase(
     focusOrderDescendants(

--- a/src/shared/copy/workflowTask.ts
+++ b/src/shared/copy/workflowTask.ts
@@ -44,6 +44,30 @@ export function workflowPhaseTaskProgress(
   };
 }
 
+/** One workflow phase as its emitter names and orders it. */
+export interface WorkflowPhaseHeading {
+  readonly phaseLabel: string;
+  readonly phaseIndex?: number;
+  readonly phaseTotal?: number;
+}
+
+/**
+ * Canonical heading copy for one workflow phase (`Reduce (2/3)`), shared by
+ * every surface that names a phase: the transcript's `◆` divider, the live
+ * run-status band, and the focused run's child-list group headers. The leading
+ * glyph is left to the caller — the band deliberately carries none. The index
+ * is 0-based on the wire and 1-based in the copy.
+ */
+export function formatWorkflowPhaseHeading(
+  phase: WorkflowPhaseHeading,
+): string {
+  const counts =
+    phase.phaseIndex !== undefined && phase.phaseTotal !== undefined
+      ? ` (${phase.phaseIndex + 1}/${phase.phaseTotal})`
+      : '';
+  return `${phase.phaseLabel}${counts}`;
+}
+
 /**
  * The one explanatory-clause rule for a workflow task, shared by every host: a
  * failure reports its error, and a task the run never reached says so. A user

--- a/src/test-kernel/cli/ChildListInteraction.vitest.mts
+++ b/src/test-kernel/cli/ChildListInteraction.vitest.mts
@@ -1,3 +1,4 @@
+import stripAnsi from 'strip-ansi';
 import { describe, expect, it, vi } from 'vitest';
 
 import { SubagentList } from '@cli/chat/tui/panes/SubagentList';
@@ -5,6 +6,7 @@ import {
   childStreamListValue,
   type ChildListValue,
 } from '@cli/chat/tui/state/childListSelection';
+import { NO_BYPASS } from '@cli/chat/tui/state/cliState';
 import type { StreamView } from '@cli/chat/tui/state/streamViews';
 import { POINTER } from '@cli/chat/tui/ui/glyphs';
 import type { StreamTabId } from '@shared/schemas';
@@ -212,6 +214,204 @@ describe('CLI child list interaction', () => {
 
       expect(onCancel).not.toHaveBeenCalled();
       expect(onSelectionChange).not.toHaveBeenCalled();
+    } finally {
+      instance.unmount();
+    }
+  });
+});
+
+const workflowRun = 'workflow-run' as StreamTabId;
+const mapChild = 'map-child' as StreamTabId;
+const reduceChild = 'reduce-child' as StreamTabId;
+
+/** The focused run's own row: it owns the phase dividers and the task cards
+ *  the group headers fold, and it is the list root so it shows no summary. */
+function workflowRunSession(): StreamView {
+  return {
+    id: workflowRun,
+    label: 'workflow-script',
+    active: true,
+    slice: {
+      streamId: workflowRun,
+      category: undefined,
+      status: undefined,
+      runStartedAt: undefined,
+      description: undefined,
+      thinkingActive: false,
+      compactingActive: false,
+      usage: undefined,
+      cumulativeUsage: undefined,
+      conversation: undefined,
+      entries: [
+        {
+          id: 'phase-map',
+          text: 'Map',
+          finalized: true,
+          role: 'phase',
+          phaseLabel: 'Map',
+          phaseIndex: 0,
+          phaseTotal: 2,
+        },
+        {
+          id: 'task-extract',
+          text: 'Finished: Extract claims',
+          finalized: true,
+          role: 'workflowTask',
+          task: {
+            id: 'extract',
+            label: 'Extract claims',
+            phase: 'Map',
+            status: 'completed',
+          },
+        },
+        {
+          id: 'task-rank',
+          text: 'Running: Rank questions',
+          finalized: false,
+          role: 'workflowTask',
+          task: {
+            id: 'rank',
+            label: 'Rank questions',
+            phase: 'Map',
+            status: 'running',
+          },
+        },
+      ],
+      queuedFollowUpMessages: [],
+      todos: [],
+      plan: null,
+      bypass: NO_BYPASS,
+    },
+  };
+}
+
+function phasedChild(id: StreamTabId, workflowPhase: string): StreamView {
+  return { id, label: id, slice: undefined, active: false, workflowPhase };
+}
+
+/** `useWindowSize` reads the Ink stdout context rather than `renderToString`'s
+ *  layout width, so the metadata width gate can only be exercised through a
+ *  real render against a stdout of that width. */
+async function renderWorkflowListLines(
+  ink: Awaited<ReturnType<typeof loadInk>>['ink'],
+  React: Awaited<ReturnType<typeof loadInk>>['React'],
+  columns: number,
+): Promise<readonly string[]> {
+  const stdin = new FakeStdin();
+  const stdout = new FakeStdout(columns);
+  const instance = ink.render(
+    React.createElement(SubagentList, {
+      keyboardActive: false,
+      maxRows: 8,
+      listRootStreamId: workflowRun,
+      selectedValue: childStreamListValue(workflowRun),
+      sessions: [
+        workflowRunSession(),
+        phasedChild(mapChild, 'Map'),
+        phasedChild(reduceChild, 'Reduce'),
+      ],
+    }),
+    {
+      stdin,
+      stdout,
+      interactive: true,
+      exitOnCtrlC: false,
+      patchConsole: false,
+    },
+  );
+  try {
+    await waitFor(() => stdout.output.includes('Reduce'));
+    return stripAnsi(stdout.output).split('\n');
+  } finally {
+    instance.unmount();
+  }
+}
+
+/** Last frame's rendering of the one line matching `text`. */
+function lastLineWith(
+  lines: readonly string[],
+  text: string,
+): string | undefined {
+  return lines.findLast((line) => line.includes(text))?.trimEnd();
+}
+
+describe('CLI child list phase headers', () => {
+  it('heads each group and right-aligns its done/total at full width', async () => {
+    const { ink, React } = await loadInk();
+    const lines = await renderWorkflowListLines(ink, React, 100);
+
+    // `done/total` folds the run's own task cards for that phase, right-aligned
+    // into the same column the rows put their metadata in.
+    const mapHeader = lastLineWith(lines, 'Map (1/2)');
+    expect(mapHeader?.startsWith('     ◆ Map (1/2)')).toBe(true);
+    expect(mapHeader?.endsWith('1/2')).toBe(true);
+    expect(mapHeader).not.toContain('· 1/2');
+    // A phase with no task cards gets a header but no progress figure.
+    expect(lastLineWith(lines, '◆ Reduce')).toBe('     ◆ Reduce');
+  });
+
+  it('falls back to an inline done/total below the metadata width gate', async () => {
+    const { ink, React } = await loadInk();
+    const lines = await renderWorkflowListLines(ink, React, 56);
+
+    expect(lastLineWith(lines, 'Map (1/2)')).toBe('     ◆ Map (1/2) · 1/2');
+  });
+
+  it('never highlights or selects a phase header while navigating', async () => {
+    const { ink, React } = await loadInk();
+    const onFocusStream = vi.fn();
+    const onSelectionChange = vi.fn();
+    let selected: ChildListValue = childStreamListValue(workflowRun);
+
+    function Harness() {
+      const [value, setValue] = React.useState(selected) as [
+        ChildListValue,
+        (next: ChildListValue) => void,
+      ];
+      return React.createElement(SubagentList, {
+        keyboardActive: true,
+        maxRows: 8,
+        listRootStreamId: workflowRun,
+        onCancel: vi.fn(),
+        onFocusStream,
+        onSelectionChange: (next: ChildListValue) => {
+          selected = next;
+          onSelectionChange(next);
+          setValue(next);
+        },
+        selectedValue: value,
+        sessions: [
+          workflowRunSession(),
+          phasedChild(mapChild, 'Map'),
+          phasedChild(reduceChild, 'Reduce'),
+        ],
+      });
+    }
+
+    const stdin = new FakeStdin();
+    const instance = ink.render(React.createElement(Harness), {
+      stdin,
+      stdout: new FakeStdout(100),
+      interactive: true,
+      exitOnCtrlC: false,
+      patchConsole: false,
+    });
+
+    try {
+      await waitFor(() => stdin.listenerCount('readable') > 0);
+      // Row order is run, ◆ Map, map-child, ◆ Reduce, reduce-child: two Downs
+      // step over both dividers onto the two agent rows.
+      stdin.write('[B');
+      await waitFor(() => selected === childStreamListValue(mapChild));
+      stdin.write('[B');
+      await waitFor(() => selected === childStreamListValue(reduceChild));
+      stdin.write('\r');
+      await waitFor(() => onFocusStream.mock.calls.length === 1);
+
+      expect(onFocusStream).toHaveBeenCalledWith(reduceChild);
+      for (const [value] of onSelectionChange.mock.calls) {
+        expect(value).toMatch(/^stream:/);
+      }
     } finally {
       instance.unmount();
     }

--- a/src/test-kernel/cli/ChildPhaseGroups.vitest.mts
+++ b/src/test-kernel/cli/ChildPhaseGroups.vitest.mts
@@ -105,17 +105,34 @@ describe('CLI child phase grouping', () => {
     ]);
   });
 
-  it('keeps phase-less entries at their own rank between groups', () => {
-    const ids = ['p1', 'bare', 'p2'];
+  it('sorts phase-less entries ahead of every group, in their own order', () => {
+    // A divider only opens a group, so a phase-less entry left between or after
+    // groups would render under a header it has nothing to do with.
+    const ids = ['p1', 'bare-1', 'p2', 'bare-2'];
     const phases = new Map([
       ['p1', 'Map'],
       ['p2', 'Map'],
     ]);
     expect(orderChildIdsByPhase(ids, (id) => phases.get(id))).toEqual([
+      'bare-1',
+      'bare-2',
       'p1',
       'p2',
-      'bare',
     ]);
+  });
+
+  it('orders to a fixed point, so re-grouping a grouped list is a no-op', () => {
+    // `streamTreeEntries` orders and numbers the shortcuts; the divider pass
+    // re-applies this same rule. Idempotence is what stops the two disagreeing.
+    const ids = ['r1', 'bare', 'm1', 'r2'];
+    const phases = new Map([
+      ['r1', 'Reduce'],
+      ['r2', 'Reduce'],
+      ['m1', 'Map'],
+    ]);
+    const once = orderChildIdsByPhase(ids, (id) => phases.get(id));
+    expect(once).toEqual(['bare', 'r1', 'r2', 'm1']);
+    expect(orderChildIdsByPhase(once, (id) => phases.get(id))).toEqual(once);
   });
 
   it('heads each group with the shared phase heading and its task progress', () => {
@@ -179,6 +196,40 @@ describe('CLI child phase grouping', () => {
     ]);
   });
 
+  it('never leaves a phase-less row under a preceding group header', () => {
+    // An `agent()` call outside any `phase()`, and any roster row from before
+    // the field existed, carries no phase. A header opens a group and nothing
+    // closes one, so such a row must never be emitted after one.
+    const rows = childPhaseGroupRows({
+      rows: [
+        { id: 'a', workflowPhase: 'Map' },
+        { id: 'b', workflowPhase: 'Map' },
+        { id: 'bare' },
+      ],
+    });
+    expect(
+      rows.map((row) =>
+        row.kind === 'header' ? row.header.label : row.row.id,
+      ),
+    ).toEqual(['bare', '◆ Map', 'a', 'b']);
+  });
+
+  it('opens one header per phase even when a phase-less row splits it', () => {
+    const rows = childPhaseGroupRows({
+      rows: [
+        { id: 'a', workflowPhase: 'Map' },
+        { id: 'bare' },
+        { id: 'b', workflowPhase: 'Map' },
+      ],
+    });
+    expect(
+      rows.map((row) =>
+        row.kind === 'header' ? row.header.label : row.row.id,
+      ),
+    ).toEqual(['bare', '◆ Map', 'a', 'b']);
+    expect(rows.filter((row) => row.kind === 'header')).toHaveLength(1);
+  });
+
   it('counts one task per logical call even when a retry adds a row', () => {
     // A durable retry registers a *new* child stream under the same phase, so
     // the group holds two rows while its header counts the one task card.
@@ -216,6 +267,25 @@ describe('CLI child phase grouping', () => {
       { id: 'm1', shortcutIndex: 3 },
       { id: 'r2', shortcutIndex: 4 },
       { id: 'r1', shortcutIndex: 5 },
+    ]);
+  });
+
+  it('numbers the phase-less block first, ahead of every group', () => {
+    // Newest-first before grouping: bare2, m2, bare1, m1. The phase-less rows
+    // keep that relative order and lead, so no row is numbered under a divider
+    // it does not belong to, and Alt+N still counts visible agent rows.
+    const grouped = treeEntriesFor([
+      { id: 'm1', phase: 'Map' },
+      { id: 'bare1' },
+      { id: 'm2', phase: 'Map' },
+      { id: 'bare2' },
+    ]);
+    expect(grouped).toEqual([
+      { id: run },
+      { id: 'bare2', shortcutIndex: 1 },
+      { id: 'bare1', shortcutIndex: 2 },
+      { id: 'm2', shortcutIndex: 3 },
+      { id: 'm1', shortcutIndex: 4 },
     ]);
   });
 

--- a/src/test-kernel/cli/ChildPhaseGroups.vitest.mts
+++ b/src/test-kernel/cli/ChildPhaseGroups.vitest.mts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from 'vitest';
+
+import { NO_BYPASS, type StreamSlice } from '@cli/chat/tui/state/cliState';
+import {
+  childPhaseGroupRows,
+  orderChildIdsByPhase,
+} from '@cli/chat/tui/state/childPhaseGroups';
+import { streamTreeEntries } from '@cli/chat/tui/state/streamViews';
+import {
+  STREAM_PHASE,
+  type StreamTabId,
+  type WorkflowTaskProgress,
+} from '@shared/schemas';
+import { buildChildStreamEntries } from '@test/support/childStreamEntries';
+
+const run = 'run' as StreamTabId;
+
+function slice(streamId: StreamTabId): StreamSlice {
+  return {
+    streamId,
+    category: undefined,
+    status: undefined,
+    runStartedAt: undefined,
+    description: undefined,
+    thinkingActive: false,
+    compactingActive: false,
+    usage: undefined,
+    cumulativeUsage: undefined,
+    conversation: undefined,
+    entries: [],
+    queuedFollowUpMessages: [],
+    todos: [],
+    plan: null,
+    bypass: NO_BYPASS,
+  };
+}
+
+function task(
+  label: string,
+  phase: string,
+  status: 'completed' | 'running',
+): WorkflowTaskProgress {
+  return { id: label, label, phase, status };
+}
+
+/** Roster fixture: `agent()` grandchildren of one workflow-script run, in
+ *  creation order, each optionally stamped with its owning phase. */
+function workflowRunChildren(
+  children: readonly { readonly id: string; readonly phase?: string }[],
+) {
+  return buildChildStreamEntries({
+    parentStreamId: run,
+    retained: children.map((child) => ({
+      kind: 'subagent' as const,
+      executionId: `${child.id}-exec`,
+      agentName: 'writer',
+      childStreamId: child.id as StreamTabId,
+      status: STREAM_PHASE.COMPLETED,
+      ...(child.phase === undefined ? {} : { workflowPhase: child.phase }),
+    })),
+  });
+}
+
+function treeEntriesFor(
+  children: readonly { readonly id: string; readonly phase?: string }[],
+) {
+  const streams = new Map<StreamTabId, StreamSlice>([[run, slice(run)]]);
+  for (const child of children) {
+    streams.set(child.id as StreamTabId, slice(child.id as StreamTabId));
+  }
+  return streamTreeEntries({
+    activeStreamId: run,
+    childStreamEntries: workflowRunChildren(children),
+    parentStream: new Map(
+      children.map((child) => [child.id as StreamTabId, run]),
+    ),
+    rootStreamId: run,
+    streams,
+  });
+}
+
+describe('CLI child phase grouping', () => {
+  it('leaves a phase-less list untouched, array identity included', () => {
+    const ids = ['a', 'b', 'c'];
+    expect(orderChildIdsByPhase(ids, () => undefined)).toBe(ids);
+  });
+
+  it('makes same-phase entries contiguous by first-seen phase position', () => {
+    const ids = ['r1', 'm1', 'r2', 'm2', 'm3'];
+    const phases = new Map([
+      ['r1', 'Reduce'],
+      ['r2', 'Reduce'],
+      ['m1', 'Map'],
+      ['m2', 'Map'],
+      ['m3', 'Map'],
+    ]);
+    // `Reduce` is first-seen at position 0, `Map` at 1, and neither group's
+    // internal order moves.
+    expect(orderChildIdsByPhase(ids, (id) => phases.get(id))).toEqual([
+      'r1',
+      'r2',
+      'm1',
+      'm2',
+      'm3',
+    ]);
+  });
+
+  it('keeps phase-less entries at their own rank between groups', () => {
+    const ids = ['p1', 'bare', 'p2'];
+    const phases = new Map([
+      ['p1', 'Map'],
+      ['p2', 'Map'],
+    ]);
+    expect(orderChildIdsByPhase(ids, (id) => phases.get(id))).toEqual([
+      'p1',
+      'p2',
+      'bare',
+    ]);
+  });
+
+  it('heads each group with the shared phase heading and its task progress', () => {
+    const rows = childPhaseGroupRows({
+      rows: [
+        { id: 'run' },
+        { id: 'a', workflowPhase: 'Map' },
+        { id: 'b', workflowPhase: 'Map' },
+        { id: 'c', workflowPhase: 'Reduce' },
+      ],
+      phases: [
+        { phaseLabel: 'Map', phaseIndex: 0, phaseTotal: 3 },
+        { phaseLabel: 'Reduce', phaseIndex: 1, phaseTotal: 3 },
+      ],
+      tasks: [
+        task('extract-2', 'Map', 'completed'),
+        task('extract-3', 'Map', 'completed'),
+        task('merge', 'Reduce', 'running'),
+        task('rank', 'Reduce', 'running'),
+        task('draft', 'Reduce', 'running'),
+      ],
+    });
+
+    expect(
+      rows.map((row) =>
+        row.kind === 'header'
+          ? [row.header.label, row.header.progress]
+          : row.row.id,
+      ),
+    ).toEqual([
+      'run',
+      ['◆ Map (1/3)', '2/2'],
+      'a',
+      'b',
+      ['◆ Reduce (2/3)', '0/3'],
+      'c',
+    ]);
+  });
+
+  it('omits the counts suffix and the progress a phase has no data for', () => {
+    const rows = childPhaseGroupRows({
+      rows: [{ id: 'a', workflowPhase: 'Ad hoc' }],
+    });
+    expect(rows).toEqual([
+      {
+        kind: 'header',
+        header: { phase: 'Ad hoc', label: '◆ Ad hoc' },
+      },
+      { kind: 'row', row: { id: 'a', workflowPhase: 'Ad hoc' } },
+    ]);
+  });
+
+  it('emits no header for rows that carry no phase', () => {
+    const rows: readonly {
+      readonly id: string;
+      readonly workflowPhase?: string;
+    }[] = [{ id: 'a' }, { id: 'b' }];
+    expect(childPhaseGroupRows({ rows })).toEqual([
+      { kind: 'row', row: { id: 'a' } },
+      { kind: 'row', row: { id: 'b' } },
+    ]);
+  });
+
+  it('counts one task per logical call even when a retry adds a row', () => {
+    // A durable retry registers a *new* child stream under the same phase, so
+    // the group holds two rows while its header counts the one task card.
+    const rows = childPhaseGroupRows({
+      rows: [
+        { id: 'attempt-1', workflowPhase: 'Map' },
+        { id: 'attempt-2', workflowPhase: 'Map' },
+      ],
+      tasks: [task('extract', 'Map', 'completed')],
+    });
+    expect(rows.filter((row) => row.kind === 'header')).toHaveLength(1);
+    expect(rows.filter((row) => row.kind === 'row')).toHaveLength(2);
+    expect(
+      rows[0]?.kind === 'header' ? rows[0].header.progress : undefined,
+    ).toBe('1/1');
+  });
+
+  it('assigns Alt+1..9 from the grouped order, one owner for both', () => {
+    // Newest-first before grouping: m3, r2, m2, r1, m1. Grouping keeps that
+    // ordering rule — the newest row's phase heads the list and each group
+    // stays newest-first — and only makes each phase contiguous. Shortcuts are
+    // numbered from the grouped positions by the same function that produced
+    // them, so Alt+N and the visible order cannot drift apart.
+    const grouped = treeEntriesFor([
+      { id: 'm1', phase: 'Map' },
+      { id: 'r1', phase: 'Reduce' },
+      { id: 'm2', phase: 'Map' },
+      { id: 'r2', phase: 'Reduce' },
+      { id: 'm3', phase: 'Map' },
+    ]);
+    expect(grouped).toEqual([
+      { id: run },
+      { id: 'm3', shortcutIndex: 1 },
+      { id: 'm2', shortcutIndex: 2 },
+      { id: 'm1', shortcutIndex: 3 },
+      { id: 'r2', shortcutIndex: 4 },
+      { id: 'r1', shortcutIndex: 5 },
+    ]);
+  });
+
+  it('leaves a list with no workflow phase byte-identical to newest-first', () => {
+    expect(treeEntriesFor([{ id: 'a' }, { id: 'b' }, { id: 'c' }])).toEqual([
+      { id: run },
+      { id: 'c', shortcutIndex: 1 },
+      { id: 'b', shortcutIndex: 2 },
+      { id: 'a', shortcutIndex: 3 },
+    ]);
+  });
+});


### PR DESCRIPTION
Stage 4 of 4, the final stage. Builds on #9186 (per-task cost), #9185 (`phaseStage` on the run's row) and #9183 (the roster join), all merged.

Closes #9177.

## What changes

Focusing a workflow-script run listed its `agent()` grandchildren flat. Each group now gets a `◆ {phase} ({i}/{n})` divider carrying that phase's finished task count:

```
   ◆ Reduce (2/3)                                                            1/3
   ● editor completed · claude-sonnet-5 · tables    2m 03s · 9 tool calls · ↓15k
 › ● editor running · claude-sonnet-5 · conflicts    0m 48s · 3 tool calls · ↓4k
   ◆ Map (1/3)                                                               3/3
   ● writer completed · claude-sonnet-5 · §2        1m 41s · 7 tool calls · ↓12k
```

Rows keep their exact current shape — `elapsed · N tool calls · ↓tokens` — and still shed the metadata column below 60 columns.

## The four traps, each handled

1. **Headers are `Select` items with `disabled: true`.** No new list primitive, no change to row budgeting: `Select` already skips disabled rows in navigation (`nextSelectHighlightIndex`), refuses to select them (`isPlainReturnInput` / hotkey paths) and dims them. A header consumes one item slot and the existing `visibleSelectRange` windowing applies unchanged. The hidden-row `+N sessions` count still counts sessions only, so it is unaffected.
2. **Grouping reorders rows, which would desynchronise Alt+1..9.** The stable group-by is inside `streamTreeEntries` (`state/streamViews.ts`) — the same loop that assigns `shortcutIndex`, which `state/childControls.ts` reads back. One owner produces order, shortcuts and rendering. Covered by a test that Alt+N follows the grouped positions.
3. **`ChildListValue` widened** to `` `stream:${string}` | `phase:${string}` ``. Headers are inserted in `SubagentList`'s items memo **only**; `childListValues` in `App.tsx` stays stream-only, so `resolveChildSelectionValue`'s `values[0]` fallback can never land on a divider. `childListStreamId` already returned `undefined` for a non-`stream:` value, so skip/retry/kill/focus/print stay inert on a header.
4. **Right-aligned `done/total` is width-gated** at `CHILD_ROW_METADATA_MIN_COLUMNS` (60), because the panel is pinned to `columns` only then. Below 60 the header renders `◆ Map (1/2) · 1/2` inline, matching how rows shed their own metadata column. Both widths are tested.

`done/total` comes from the shared `workflowPhaseTaskProgress` (`src/shared/copy/workflowTask.ts`) applied to the focused run's task entries filtered by phase — no second fold, and that function is not forked.

## Ordering, spelled out

The issue's normative text is "a stable sort keyed by each phase's first-seen position, applied only to entries that carry a phase, with within-group order unchanged". `streamTreeEntries` is newest-first, so the **newest row's phase heads the list** and each group stays newest-first. The issue's ASCII mockup happens to show `Map` above `Reduce`; that is the opposite reading and would have required inverting the existing newest-first rule for phased lists only. I followed the normative text.

## The pure helper

`packages/cli/src/chat/tui/state/childPhaseGroups.ts` — two pure exports, both tested (`src/test-kernel/cli/ChildPhaseGroups.vitest.mts`):

- `orderChildIdsByPhase(ids, phaseOf)` — the stable group-by. When nothing carries a phase it returns **the same array object**, which is the root-viewport regression guard.
- `childPhaseGroupRows({ rows, phases, tasks })` — same rows + tasks in, same groups out. Generic over the row shape, so it does not import `StreamView` and there is no module cycle with `streamViews.ts`.

No `Date.now()`, no timer or interval, no synthetic ids, no dedup at render time.

## Regression guard

`ChildPhaseGroups.vitest.mts` asserts that a list where no child carries a `workflowPhase` produces exactly the pre-change entries **including shortcut assignment**, and that `orderChildIdsByPhase` returns its input array by identity in that case. A child with no phase renders ungrouped and header-less.

## Known, intended inconsistency (not fixed)

A durable retry runs under an attempt-specific execution id and registers a **new child stream**, so a retried call can leave **two rows under a header whose `done/total` counts one logical call** — task cards are keyed per logical call (`projectedTasks` by `progressId`), rows are per attempt. Headers count tasks, rows count attempts. This is documented in the helper's doc comment and pinned by a test rather than "fixed" in either direction.

## Small dedup carried along

The `(i/n)` suffix had two copies (`transcriptEntryLayout.ts`, `ConversationPane.tsx`) and this change would have made a third. It is now `formatWorkflowPhaseHeading` in `src/shared/copy/workflowTask.ts` beside the other workflow-copy owners, with three callers. Pure refactor: rendered output is unchanged, covered by the existing transcript and band tests.

## Verification

`npm run typecheck`, `npm test` (778 files, 7582 tests), `npm run lint`, `npm run check:dead-code-ratchet` — all green. Greps used `--include` covering `.ts`, `.tsx` and `.mts`.

**Headless parity:** the diff touches only `packages/cli/src/chat/tui/**` plus `src/shared/copy/workflowTask.ts` (one added export, no edit to any existing function). `packages/cli/src/runtime/sessionProgressSubscription.ts` is not in the diff; `texra run`, `--print` and `--output-format json|ndjson` are unaffected.

**Not done:** I did not drive the PTY harness at 100/80/72/64/56 columns resizing mid-run, as the issue's stage-4 verification note suggests. The width gate is covered by two rendering tests at 100 and 56 columns through a real Ink render (`useWindowSize` reads the stdout context, not `renderToString`'s layout width — worth knowing, the existing `it.each([120, 80, 64, 56])` suite in `SubagentListDisplay.vitest.mts` is really testing one width), but live resize behaviour is untested here.

https://claude.ai/code/session_01MQZ63FFrmojmG58wPJdYNH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI TUI presentation and list navigation only; selection reconciliation is explicitly kept on stream ids, with regression tests for unphased lists and shortcut order.
> 
> **Overview**
> **Focused workflow-script runs** no longer list every `agent()` grandchild flat. The child list inserts non-selectable **`◆ Phase (i/n)`** dividers with that phase’s **finished task count** (`done/total` from the run’s task cards), while agent rows keep their existing metadata.
> 
> **Ordering is unified** so shortcuts and UI cannot drift: `orderChildIdsByPhase` groups children by workflow phase (phase-less rows stay above groups), applied in **`streamTreeEntries`** for Alt+1..9 numbering and again in **`childPhaseGroupRows`** for dividers (idempotent). Phase headers are **disabled `Select` items**—arrow keys skip them; **`childListValues` in `App.tsx` stays stream-only** so selection reconciliation never lands on a divider.
> 
> **`formatWorkflowPhaseHeading`** centralizes phase title copy (e.g. `Reduce (2/3)`) for the transcript, live status band, and list headers, replacing duplicate suffix logic in **`ConversationPane`** and **`transcriptEntryLayout`**.
> 
> New coverage in **`ChildPhaseGroups.vitest.mts`** and **`ChildListInteraction.vitest.mts`** (width gate at 100 vs 56 columns, navigation, shortcut order).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eacfeba2640322b63502094451bd0d7c934acb99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->