### PR TITLE
Stage 4 of 4 for #9177: group focused workflow agents by phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@ All notable changes to this project will be documented in this file.
 
 #### New Features
 
+- **Focused workflow runs group agent rows by phase** — the child list now
+  separates workflow agents under phase headers with per-phase task progress,
+  while preserving keyboard shortcuts and compact layouts on narrow terminals.
 - **Workflow-script task rows show their status at a glance** — each task in
   the terminal transcript carries its own marker and color for planned,
   running, finished, saved-result, skipped, and failed, instead of every row

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -5,7 +5,12 @@ import { Box, Text, useInput, useWindowSize } from 'ink';
 import { useMemo } from 'react';
 
 // Local imports - shared stream state
-import type { StreamTabId } from '@shared/schemas';
+import {
+  AgentCategory,
+  type StreamTabId,
+  type WorkflowTaskProgress,
+} from '@shared/schemas';
+import { workflowPhaseTaskProgress } from '@shared/copy/workflowTask';
 import {
   formatPhaseStageLabel,
   formatRoundStageLabel,
@@ -20,13 +25,14 @@ import { truncateSummaryToWidth } from '../render/terminalText';
 import { childElapsed } from '../state/childControls';
 import {
   childListStreamId,
+  childPhaseListValue,
   childStreamListValue,
   type ChildListValue,
 } from '../state/childListSelection';
 import { useLiveNowMs } from '../state/useLiveNowMs';
 import { COLOR_HINT } from '../ui/colors';
-import { POINTER, TICK } from '../ui/glyphs';
-import { Select, visibleSelectRange } from '../ui/Select';
+import { POINTER, STATUS_DIAMOND, TICK } from '../ui/glyphs';
+import { Select, visibleSelectRange, type SelectItem } from '../ui/Select';
 import {
   CHILD_ROW_METADATA_MIN_COLUMNS,
   CHILD_STATUS_MARKER,
@@ -69,6 +75,45 @@ function RowMetadata({
 }
 
 const SUBAGENT_SUMMARY_MAX_COLUMNS = 100;
+
+interface PhaseHeaderDetails {
+  readonly label: string;
+  readonly index?: number;
+  readonly total?: number;
+  readonly progress?: string;
+}
+
+function PhaseHeader({
+  details,
+  metadataColumn,
+}: {
+  readonly details: PhaseHeaderDetails;
+  readonly metadataColumn: boolean;
+}): React.JSX.Element {
+  const position =
+    details.index !== undefined && details.total !== undefined
+      ? ` (${details.index + 1}/${details.total})`
+      : '';
+  const inlineProgress =
+    !metadataColumn && details.progress ? ` · ${details.progress}` : '';
+  return (
+    <Box flexDirection="row" flexGrow={1} minWidth={0}>
+      <Box minWidth={0} flexShrink={1}>
+        <Text dimColor wrap="truncate-end">
+          {`   ${STATUS_DIAMOND} ${details.label}${position}${inlineProgress}`}
+        </Text>
+      </Box>
+      {metadataColumn && details.progress ? (
+        <>
+          <Box flexGrow={1} />
+          <Box flexShrink={0}>
+            <Text dimColor>{`  ${details.progress}`}</Text>
+          </Box>
+        </>
+      ) : null}
+    </Box>
+  );
+}
 
 function SessionRow({
   active,
@@ -206,14 +251,72 @@ export function SubagentList(
         .join(':') || undefined,
     [sessions],
   );
-  const items = useMemo(
-    () =>
-      sessions.map((session) => ({
+  const { items, phaseHeadersByValue } = useMemo(() => {
+    const rootSession = sessions.find(
+      (session) => session.id === props.listRootStreamId,
+    );
+    const entries =
+      rootSession?.slice?.category === AgentCategory.Workflow
+        ? rootSession.slice.entries
+        : [];
+    const phasePositions = new Map<
+      string,
+      { readonly index?: number; readonly total?: number }
+    >();
+    const tasksByPhase = new Map<string, WorkflowTaskProgress[]>();
+    for (const entry of entries) {
+      if (entry.role === 'phase') {
+        phasePositions.set(entry.phaseLabel, {
+          index: entry.phaseIndex,
+          total: entry.phaseTotal,
+        });
+      } else if (
+        entry.role === 'workflowTask' &&
+        entry.task.phase !== undefined
+      ) {
+        const tasks = tasksByPhase.get(entry.task.phase);
+        if (tasks) tasks.push(entry.task);
+        else tasksByPhase.set(entry.task.phase, [entry.task]);
+      }
+    }
+
+    const nextItems: SelectItem<ChildListValue>[] = [];
+    const nextHeaders = new Map<ChildListValue, PhaseHeaderDetails>();
+    let previousPhase: string | undefined;
+    let headerOrdinal = 0;
+    for (const session of sessions) {
+      const item = {
         label: session.label,
         value: childStreamListValue(session.id),
-      })),
-    [sessions],
-  );
+      };
+      // The list root is context, not a grouped attempt. Likewise, only its
+      // direct children can belong to this focused workflow run's phases.
+      if (
+        session.id === props.listRootStreamId ||
+        session.parentId !== props.listRootStreamId
+      ) {
+        nextItems.push(item);
+        continue;
+      }
+      const phase = session.workflowPhase;
+      if (phase !== undefined && phase !== previousPhase) {
+        const value = childPhaseListValue(headerOrdinal++);
+        const tasks = tasksByPhase.get(phase) ?? [];
+        const { done, total } = workflowPhaseTaskProgress(tasks);
+        const position = phasePositions.get(phase);
+        nextItems.push({ label: phase, value, disabled: true });
+        nextHeaders.set(value, {
+          label: phase,
+          index: position?.index,
+          total: position?.total,
+          ...(total > 0 ? { progress: `${done}/${total}` } : {}),
+        });
+      }
+      nextItems.push(item);
+      previousPhase = phase;
+    }
+    return { items: nextItems, phaseHeadersByValue: nextHeaders };
+  }, [props.listRootStreamId, sessions]);
   const sessionsByValue = useMemo(
     () =>
       new Map(
@@ -314,6 +417,15 @@ export function SubagentList(
           if (streamId) props.onFocusStream?.(streamId);
         }}
         renderItem={(item, state) => {
+          const phaseHeader = phaseHeadersByValue.get(item.value);
+          if (phaseHeader) {
+            return (
+              <PhaseHeader
+                details={phaseHeader}
+                metadataColumn={metadataColumn}
+              />
+            );
+          }
           const session = sessionsByValue.get(item.value);
           return session ? (
             <SessionRow

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -289,12 +289,10 @@ export function SubagentList(
         label: session.label,
         value: childStreamListValue(session.id),
       };
-      // The list root is context, not a grouped attempt. Likewise, only its
-      // direct children can belong to this focused workflow run's phases.
-      if (
-        session.id === props.listRootStreamId ||
-        session.parentId !== props.listRootStreamId
-      ) {
+      // The list root is context, not a grouped attempt. Every other row
+      // already belongs to this root's visible current/retained descendant
+      // set, including historical children promoted away from the root.
+      if (session.id === props.listRootStreamId) {
         nextItems.push(item);
         continue;
       }

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -100,7 +100,7 @@ function PhaseHeader({
     <Box flexDirection="row" flexGrow={1} minWidth={0}>
       <Box minWidth={0} flexShrink={1}>
         <Text dimColor wrap="truncate-end">
-          {`   ${STATUS_DIAMOND} ${details.label}${position}${inlineProgress}`}
+          {`    ${STATUS_DIAMOND} ${details.label}${position}${inlineProgress}`}
         </Text>
       </Box>
       {metadataColumn && details.progress ? (

--- a/packages/cli/src/chat/tui/state/childListSelection.ts
+++ b/packages/cli/src/chat/tui/state/childListSelection.ts
@@ -1,10 +1,16 @@
 // Local imports - shared stream identity
 import type { StreamTabId } from '@shared/schemas';
 
-export type ChildListValue = `stream:${string}`;
+export type ChildListValue = `stream:${string}` | `phase:${number}`;
 
 export function childStreamListValue(streamId: StreamTabId): ChildListValue {
   return `stream:${streamId}`;
+}
+
+/** List-local structural identity for a disabled phase header. The ordinal
+ *  avoids encoding a free-form phase label into a delimiter-based key. */
+export function childPhaseListValue(ordinal: number): ChildListValue {
+  return `phase:${ordinal}`;
 }
 
 export function childListStreamId(

--- a/packages/cli/src/chat/tui/state/streamViews.ts
+++ b/packages/cli/src/chat/tui/state/streamViews.ts
@@ -173,6 +173,33 @@ interface StreamTreeViewInput {
   readonly streams: ReadonlyMap<StreamTabId, StreamSlice>;
 }
 
+/** Stable group-by for phase-tagged rows. Each phase occupies its first-seen
+ *  position, untagged rows remain standalone, and row order within a phase is
+ *  unchanged. Return the original list when grouping is inapplicable. */
+export function groupWorkflowPhaseEntries<
+  T extends { readonly workflowPhase?: string },
+>(entries: readonly T[]): readonly T[] {
+  const groups: T[][] = [];
+  const phaseGroups = new Map<string, T[]>();
+  let hasWorkflowPhase = false;
+  for (const entry of entries) {
+    const phase = entry.workflowPhase;
+    if (phase === undefined) {
+      groups.push([entry]);
+      continue;
+    }
+    hasWorkflowPhase = true;
+    let group = phaseGroups.get(phase);
+    if (!group) {
+      group = [];
+      phaseGroups.set(phase, group);
+      groups.push(group);
+    }
+    group.push(entry);
+  }
+  return hasWorkflowPhase ? groups.flat() : entries;
+}
+
 export function streamTreeEntries(
   init: StreamTreeViewInput,
 ): readonly ActiveStreamTreeEntry[] {
@@ -182,11 +209,18 @@ export function streamTreeEntries(
   // then creation order), so the child list and its
   // Alt+1..9 shortcuts read top-to-bottom from most to least recently
   // started, keeping the row a user is most likely watching near the top.
-  const ordered = focusOrderDescendants(
-    root,
-    init.childStreamEntries,
-    init.streams,
-  ).toReversed();
+  const ordered = groupWorkflowPhaseEntries(
+    focusOrderDescendants(root, init.childStreamEntries, init.streams)
+      .toReversed()
+      .map((id) => {
+        const entry = init.childStreamEntries.get(id);
+        return {
+          id,
+          workflowPhase:
+            entry?.kind === 'live' ? entry.summary?.workflowPhase : undefined,
+        };
+      }),
+  ).map((entry) => entry.id);
   const out: ActiveStreamTreeEntry[] = [];
   if (init.streams.has(root)) out.push({ id: root });
   for (const [index, id] of ordered.entries()) {

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -197,6 +197,7 @@ describe('CLI child controls', () => {
           childStreamId: b,
           status: STREAM_PHASE.RUNNING,
           workflowPhase: 'Map',
+          edgeParentStreamId: null,
         },
         {
           kind: 'subagent',
@@ -230,7 +231,9 @@ describe('CLI child controls', () => {
           [id, slice({ streamId: id, status: STREAM_PHASE.RUNNING })] as const,
       ),
     ]);
-    const parentStream = new Map(ids.map((id) => [id, root] as const));
+    const parentStream = new Map(
+      ids.filter((id) => id !== b).map((id) => [id, root] as const),
+    );
 
     expect(
       streamTreeEntries({
@@ -248,6 +251,19 @@ describe('CLI child controls', () => {
       { id: c, shortcutIndex: 4 },
       { id: a, shortcutIndex: 5 },
     ]);
+    const views = streamTreeViews({
+      activeStreamId: root,
+      childStreamEntries: entries,
+      parentStream,
+      rootStreamId: root,
+      streams,
+    });
+    expect(views.map(({ id }) => id)).toEqual([root, e, b, d, c, a]);
+    expect(views.find(({ id }) => id === b)).toMatchObject({
+      parentId: undefined,
+      shortcutIndex: 2,
+      workflowPhase: 'Map',
+    });
     expect(
       numericFocusTargetForActiveStream({
         activeStreamId: root,

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -6,7 +6,11 @@ import {
   resolveChildListTarget,
 } from '@cli/chat/tui/state/childControls';
 import { NO_BYPASS, type StreamSlice } from '@cli/chat/tui/state/cliState';
-import { streamTreeViews } from '@cli/chat/tui/state/streamViews';
+import {
+  groupWorkflowPhaseEntries,
+  streamTreeEntries,
+  streamTreeViews,
+} from '@cli/chat/tui/state/streamViews';
 import { STREAM_PHASE, type StreamTabId } from '@shared/schemas';
 import { buildChildStreamEntries } from '@test/support/childStreamEntries';
 
@@ -155,6 +159,104 @@ describe('CLI child controls', () => {
         zeroBasedIndex: 0,
       }),
     ).toBe(leaf);
+  });
+
+  it('returns phase-less ordering unchanged', () => {
+    const ordered = [
+      { id: 'newest', workflowPhase: undefined },
+      { id: 'oldest', workflowPhase: undefined },
+    ] as const;
+
+    expect(groupWorkflowPhaseEntries(ordered)).toBe(ordered);
+  });
+
+  it('stably groups phases before assigning visible shortcut indices', () => {
+    const ids = ['a', 'b', 'c', 'd', 'e'].map((id) => id as StreamTabId);
+    const [a, b, c, d, e] = ids as [
+      StreamTabId,
+      StreamTabId,
+      StreamTabId,
+      StreamTabId,
+      StreamTabId,
+    ];
+    const entries = buildChildStreamEntries({
+      parentStreamId: root,
+      retained: [
+        {
+          kind: 'subagent',
+          executionId: 'a-exec',
+          agentName: 'a',
+          childStreamId: a,
+          status: STREAM_PHASE.RUNNING,
+          workflowPhase: 'Reduce',
+        },
+        {
+          kind: 'subagent',
+          executionId: 'b-exec',
+          agentName: 'b',
+          childStreamId: b,
+          status: STREAM_PHASE.RUNNING,
+          workflowPhase: 'Map',
+        },
+        {
+          kind: 'subagent',
+          executionId: 'c-exec',
+          agentName: 'c',
+          childStreamId: c,
+          status: STREAM_PHASE.RUNNING,
+          workflowPhase: 'Reduce',
+        },
+        {
+          kind: 'subagent',
+          executionId: 'd-exec',
+          agentName: 'd',
+          childStreamId: d,
+          status: STREAM_PHASE.RUNNING,
+        },
+        {
+          kind: 'subagent',
+          executionId: 'e-exec',
+          agentName: 'e',
+          childStreamId: e,
+          status: STREAM_PHASE.RUNNING,
+          workflowPhase: 'Map',
+        },
+      ],
+    });
+    const streams = new Map<StreamTabId, StreamSlice>([
+      [root, slice({ streamId: root })],
+      ...ids.map(
+        (id) =>
+          [id, slice({ streamId: id, status: STREAM_PHASE.RUNNING })] as const,
+      ),
+    ]);
+    const parentStream = new Map(ids.map((id) => [id, root] as const));
+
+    expect(
+      streamTreeEntries({
+        activeStreamId: root,
+        childStreamEntries: entries,
+        parentStream,
+        rootStreamId: root,
+        streams,
+      }),
+    ).toEqual([
+      { id: root },
+      { id: e, shortcutIndex: 1 },
+      { id: b, shortcutIndex: 2 },
+      { id: d, shortcutIndex: 3 },
+      { id: c, shortcutIndex: 4 },
+      { id: a, shortcutIndex: 5 },
+    ]);
+    expect(
+      numericFocusTargetForActiveStream({
+        activeStreamId: root,
+        childStreamEntries: entries,
+        parentStream,
+        streams,
+        zeroBasedIndex: 1,
+      }),
+    ).toBe(b);
   });
 
   it('preserves Alt/Esc-number stream focus order', () => {

--- a/src/test-kernel/cli/ChildListInteraction.vitest.mts
+++ b/src/test-kernel/cli/ChildListInteraction.vitest.mts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { SubagentList } from '@cli/chat/tui/panes/SubagentList';
 import {
+  childPhaseListValue,
   childStreamListValue,
   type ChildListValue,
 } from '@cli/chat/tui/state/childListSelection';
@@ -136,6 +137,116 @@ describe('CLI child list interaction', () => {
 
       expect(onSkipExecution).toHaveBeenCalledWith('child-exec');
       expect(onRetryExecution).toHaveBeenCalledWith('child-exec');
+    } finally {
+      instance.unmount();
+    }
+  });
+
+  it('skips disabled phase headers during arrow navigation', async () => {
+    const { ink, React } = await loadInk();
+    const root = 'root' as StreamTabId;
+    const child = 'child' as StreamTabId;
+    const onFocusStream = vi.fn();
+    let selected = childStreamListValue(root);
+
+    function Harness() {
+      const [value, setValue] = React.useState(selected) as [
+        ChildListValue,
+        (next: ChildListValue) => void,
+      ];
+      return React.createElement(SubagentList, {
+        keyboardActive: true,
+        listRootStreamId: root,
+        maxRows: 5,
+        onCancel: vi.fn(),
+        onFocusStream,
+        onSelectionChange: (next: ChildListValue) => {
+          selected = next;
+          setValue(next);
+        },
+        selectedValue: value,
+        sessions: [
+          session(root, true),
+          {
+            ...session(child),
+            parentId: root,
+            workflowPhase: 'Map:review|draft',
+          },
+        ],
+      });
+    }
+
+    const stdin = new FakeStdin();
+    const stdout = new FakeStdout(100);
+    const instance = ink.render(React.createElement(Harness), {
+      stdin,
+      stdout,
+      interactive: true,
+      exitOnCtrlC: false,
+      patchConsole: false,
+    });
+
+    try {
+      await waitFor(
+        () =>
+          stdin.listenerCount('readable') > 0 &&
+          stdout.output.includes('◆ Map:review|draft'),
+      );
+      expect(stdout.output).toContain('◆ Map:review|draft');
+      stdin.write('\u001B[B');
+      await waitFor(() => selected === childStreamListValue(child));
+      stdin.write('\r');
+      await waitFor(() => onFocusStream.mock.calls.length === 1);
+
+      expect(onFocusStream).toHaveBeenCalledWith(child);
+    } finally {
+      instance.unmount();
+    }
+  });
+
+  it('keeps a controlled phase-header selection inert', async () => {
+    const { ink, React } = await loadInk();
+    const root = 'root' as StreamTabId;
+    const child = 'child' as StreamTabId;
+    const callbacks = {
+      onFocusStream: vi.fn(),
+      onKillExecution: vi.fn(),
+      onPrintStream: vi.fn(),
+      onRetryExecution: vi.fn(),
+      onSkipExecution: vi.fn(),
+    };
+    const stdin = new FakeStdin();
+    const instance = ink.render(
+      React.createElement(SubagentList, {
+        activeSubagentExecutionIds: new Map([[child, 'child-exec']]),
+        keyboardActive: true,
+        listRootStreamId: root,
+        maxRows: 5,
+        onCancel: vi.fn(),
+        selectedValue: childPhaseListValue(0),
+        sessions: [
+          session(root, true),
+          { ...session(child), parentId: root, workflowPhase: 'Map' },
+        ],
+        ...callbacks,
+      }),
+      {
+        stdin,
+        stdout: new FakeStdout(100),
+        interactive: true,
+        exitOnCtrlC: false,
+        patchConsole: false,
+      },
+    );
+
+    try {
+      await waitFor(() => stdin.listenerCount('readable') > 0);
+      for (const input of ['v', 'k', 's', 'r', '\r']) stdin.write(input);
+      await new Promise((resolve) => setTimeout(resolve, 30));
+
+      for (const callback of Object.values(callbacks)) {
+        expect(callback).not.toHaveBeenCalled();
+      }
     } finally {
       instance.unmount();
     }

--- a/src/test-kernel/cli/ChildListSelection.vitest.mts
+++ b/src/test-kernel/cli/ChildListSelection.vitest.mts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   childListStreamId,
+  childPhaseListValue,
   childStreamListValue,
   INITIAL_CHILD_LIST_SELECTION,
   reduceChildListSelection,
@@ -33,6 +34,8 @@ describe('CLI child list selection', () => {
   it('uses stable prefixed values for child rows', () => {
     expect(mainValue).toBe('stream:main');
     expect(childListStreamId(mainValue)).toBe(main);
+    expect(childPhaseListValue(2)).toBe('phase:2');
+    expect(childListStreamId(childPhaseListValue(2))).toBeUndefined();
     expect(childListStreamId(undefined)).toBeUndefined();
   });
 

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -832,11 +832,15 @@ describe('CLI child list display model', () => {
 
     const wideOutput = await renderAtColumns(60);
     const narrowOutput = await renderAtColumns(59);
-    const wideMapHeader = wideOutput
-      .split('\n')
-      .find((line) => line.includes(`${freeFormPhase} (1/2)`));
+    const wideLines = wideOutput.split('\n');
+    const wideMapHeader = wideLines.find((line) =>
+      line.includes(`${freeFormPhase} (1/2)`),
+    );
+    const wideMapRow = wideLines.find((line) => line.includes('writer-retry'));
 
     expect(wideMapHeader).toBeDefined();
+    expect(wideMapRow).toBeDefined();
+    expect(wideMapHeader?.indexOf('◆')).toBe(wideMapRow?.indexOf('●'));
     expect(wideMapHeader?.trimEnd().endsWith('1/1')).toBe(true);
     expect(wideMapHeader).not.toContain('(1/2) · 1/1');
     expect(narrowOutput).toContain(`${freeFormPhase} (1/2) · 1/1`);

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -788,7 +788,8 @@ describe('CLI child list display model', () => {
       {
         ...session(mapRetry),
         label: 'writer-retry',
-        parentId: run,
+        // Retained under the run, but promoted out of its current topology,
+        // so the projected view has no current parentId.
         workflowPhase: freeFormPhase,
       },
       {
@@ -850,6 +851,12 @@ describe('CLI child list display model', () => {
     expect(wideOutput.split(freeFormPhase)).toHaveLength(2);
     expect(wideOutput).toContain('writer-retry');
     expect(wideOutput).toContain('writer-attempt');
+    expect(wideOutput.indexOf(`${freeFormPhase} (1/2)`)).toBeLessThan(
+      wideOutput.indexOf('writer-retry'),
+    );
+    expect(wideOutput.indexOf('writer-retry')).toBeLessThan(
+      wideOutput.indexOf('writer-attempt'),
+    );
     expect(wideOutput.indexOf('writer-attempt')).toBeLessThan(
       wideOutput.indexOf('unphased'),
     );

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -1,3 +1,4 @@
+import stripAnsi from 'strip-ansi';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -12,6 +13,7 @@ import {
 } from '@cli/chat/tui/panes/ConversationPane';
 import { SubagentList } from '@cli/chat/tui/panes/SubagentList';
 import { textDisplayWidth } from '@cli/chat/tui/render/terminalText';
+import { childStreamListValue } from '@cli/chat/tui/state/childListSelection';
 import {
   activeStreamId,
   streams as streamsSignal,
@@ -28,8 +30,13 @@ import {
   type SelectItem,
 } from '@cli/chat/tui/ui/Select';
 import { AgentCategory, STREAM_PHASE, type StreamTabId } from '@shared/schemas';
+import { waitForCondition as waitFor } from '@test/support/asyncTestUtils';
 import { buildChildStreamEntries } from '@test/support/childStreamEntries';
-import { loadInk } from '@test/support/inkTestHarness.mts';
+import {
+  FakeStdin,
+  FakeStdout,
+  loadInk,
+} from '@test/support/inkTestHarness.mts';
 
 function session(id: string, active = false): StreamView {
   return {
@@ -650,6 +657,202 @@ describe('CLI child list display model', () => {
       expect(output).not.toContain('r2/3 · Reduce 2/3');
     },
   );
+
+  it('does not group a list root by its inherited workflow phase', async () => {
+    const { ink, React } = await loadInk();
+    const run = 'nested-workflow' as StreamTabId;
+    const child = 'ordinary-child' as StreamTabId;
+    const output: string = ink.renderToString(
+      React.createElement(SubagentList, {
+        listRootStreamId: run,
+        maxRows: 5,
+        sessions: [
+          {
+            id: run,
+            label: 'nested-workflow',
+            active: true,
+            workflowPhase: 'Inherited',
+            slice: workflowAgentSlice(run, {}),
+          },
+          { ...session(child), parentId: run },
+        ],
+      }),
+      { columns: 100 },
+    );
+
+    expect(output).toContain('nested-workflow');
+    expect(output).toContain('ordinary-child');
+    expect(output).not.toContain('◆ Inherited');
+  });
+
+  it('keeps the selected stream visible when headers consume row slots', async () => {
+    const { ink, React } = await loadInk();
+    const run = 'windowed-run' as StreamTabId;
+    const map = 'map-agent' as StreamTabId;
+    const reduce = 'reduce-agent' as StreamTabId;
+    const output: string = ink.renderToString(
+      React.createElement(SubagentList, {
+        listRootStreamId: run,
+        maxRows: 3,
+        selectedValue: childStreamListValue(reduce),
+        sessions: [
+          {
+            id: run,
+            label: 'windowed-run',
+            active: false,
+            slice: workflowAgentSlice(run, {}),
+          },
+          {
+            ...session(map),
+            parentId: run,
+            workflowPhase: 'Map',
+          },
+          {
+            ...session(reduce, true),
+            parentId: run,
+            workflowPhase: 'Reduce',
+          },
+        ],
+      }),
+      { columns: 100 },
+    );
+
+    expect(output).toContain('◆ Reduce');
+    expect(output).toContain('reduce-agent');
+    expect(output).not.toContain('windowed-run');
+    expect(output).not.toContain('map-agent');
+  });
+
+  it('switches phase progress layout at the exact width boundary', async () => {
+    const { ink, React } = await loadInk();
+    const run = 'run' as StreamTabId;
+    const mapRetry = 'map-retry' as StreamTabId;
+    const mapAttempt = 'map-attempt' as StreamTabId;
+    const loose = 'loose' as StreamTabId;
+    const reduce = 'reduce' as StreamTabId;
+    const freeFormPhase = 'Map:review|draft';
+    const sessions: StreamView[] = [
+      {
+        id: run,
+        label: 'workflow-script',
+        active: true,
+        slice: workflowAgentSlice('run', {
+          status: STREAM_PHASE.RUNNING,
+          entries: [
+            {
+              id: 'phase-map',
+              role: 'phase',
+              text: freeFormPhase,
+              finalized: true,
+              phaseLabel: freeFormPhase,
+              phaseIndex: 0,
+              phaseTotal: 2,
+            },
+            {
+              id: 'task-map',
+              role: 'workflowTask',
+              text: 'Finished: Review map',
+              finalized: true,
+              task: {
+                id: 'review-map',
+                label: 'Review map',
+                phase: freeFormPhase,
+                status: 'completed',
+                durationMs: 1_000,
+              },
+            },
+            {
+              id: 'phase-reduce',
+              role: 'phase',
+              text: 'Reduce',
+              finalized: true,
+              phaseLabel: 'Reduce',
+              phaseIndex: 1,
+              phaseTotal: 2,
+            },
+            {
+              id: 'task-reduce',
+              role: 'workflowTask',
+              text: 'Running: Merge map',
+              finalized: false,
+              task: {
+                id: 'merge-map',
+                label: 'Merge map',
+                phase: 'Reduce',
+                status: 'running',
+              },
+            },
+          ],
+        }),
+      },
+      {
+        ...session(mapRetry),
+        label: 'writer-retry',
+        parentId: run,
+        workflowPhase: freeFormPhase,
+      },
+      {
+        ...session(mapAttempt),
+        label: 'writer-attempt',
+        parentId: run,
+        workflowPhase: freeFormPhase,
+      },
+      { ...session(loose), label: 'unphased', parentId: run },
+      {
+        ...session(reduce),
+        label: 'editor',
+        parentId: run,
+        workflowPhase: 'Reduce',
+      },
+    ];
+
+    async function renderAtColumns(columns: number): Promise<string> {
+      const stdout = new FakeStdout(columns);
+      const instance = ink.render(
+        React.createElement(SubagentList, {
+          listRootStreamId: run,
+          maxRows: 10,
+          sessions,
+        }),
+        {
+          stdin: new FakeStdin(false),
+          stdout,
+          interactive: true,
+          exitOnCtrlC: false,
+          patchConsole: false,
+        },
+      );
+      try {
+        await waitFor(() => stdout.output.includes(freeFormPhase));
+        return stripAnsi(stdout.output);
+      } finally {
+        instance.unmount();
+      }
+    }
+
+    const wideOutput = await renderAtColumns(60);
+    const narrowOutput = await renderAtColumns(59);
+    const wideMapHeader = wideOutput
+      .split('\n')
+      .find((line) => line.includes(`${freeFormPhase} (1/2)`));
+
+    expect(wideMapHeader).toBeDefined();
+    expect(wideMapHeader?.trimEnd().endsWith('1/1')).toBe(true);
+    expect(wideMapHeader).not.toContain('(1/2) · 1/1');
+    expect(narrowOutput).toContain(`${freeFormPhase} (1/2) · 1/1`);
+    expect(narrowOutput).toContain('Reduce (2/2) · 0/1');
+    // Two attempt rows remain visible, but progress counts the one logical
+    // workflow task from the transcript rather than the retry rows.
+    expect(wideOutput.split(freeFormPhase)).toHaveLength(2);
+    expect(wideOutput).toContain('writer-retry');
+    expect(wideOutput).toContain('writer-attempt');
+    expect(wideOutput.indexOf('writer-attempt')).toBeLessThan(
+      wideOutput.indexOf('unphased'),
+    );
+    expect(wideOutput.indexOf('unphased')).toBeLessThan(
+      wideOutput.indexOf('Reduce (2/2)'),
+    );
+  });
 
   it('never shows both a phase and a round on one row', async () => {
     const { ink, React } = await loadInk();


### PR DESCRIPTION
Closes #9177.

Final stage (4 of 4) of the workflow-script progress work. Stages 1–3 already shipped per-task costs, the current phase on the run row, and the child-roster phase join.

## What this does

When a workflow-script run is focused, its direct agent rows are now grouped under disabled phase headers:

```text
   ◆ Map (1/3)                                                               3/3
   ● writer completed · claude-sonnet-5 · §2        1m 41s · 7 tool calls · ↓12k
   ◆ Reduce (2/3)                                                            1/3
 › ● editor running · claude-opus-5 · rank            0m 12s · 1 tool call · ↓1k
```

- Stable phase grouping happens in `streamTreeEntries` before shortcut indices are assigned, so Alt+1..9 follows the visible stream-row order.
- Phase-less lists retain their original order and shortcut assignment.
- Headers are disabled `Select` items, skipped by arrow navigation and inert for focus/print/kill/skip/retry actions.
- `done/total` reuses `workflowPhaseTaskProgress` over logical task entries; retry attempt rows remain visible without inflating task counts.
- Progress is right-aligned at 60+ columns and inline below 60 columns.
- Only direct children of a workflow list root participate. The root's inherited `workflowPhase` and deeper descendants cannot create misleading headers.
- Header values use list-local numeric ordinals rather than encoding free-form phase labels.

## Net elements (R6)

- 8 files changed: 616 insertions, 17 deletions.
- Production changes are confined to 3 existing CLI files; no production file was added.
- Adds one exported pure grouping helper and one exported phase-header value constructor; widens the existing `ChildListValue` union.
- Adds no class, interface, event, store, timer, interval, or host/wire surface.
- Most added lines are focused regression coverage for ordering, selection, terminal widths, clipping, retries, and nested-list scoping.

## Consumer counts (R8)

- `groupWorkflowPhaseEntries`: 1 production consumer (`streamTreeEntries`) plus direct unit coverage.
- `childPhaseListValue`: 1 production consumer (`SubagentList`) plus selection/interaction coverage.
- `workflowPhaseTaskProgress`: reuses the existing shared fold; no competing progress fold was added.
- `ChildListValue` remains consumed by the existing child-list selection/control path; non-`stream:` values continue to resolve to no stream id.

## Acceptance coverage

- Stable first-seen phase grouping with within-phase order preserved.
- Phase-less identity/order and shortcut-index regression guards.
- Mixed phased and unphased rows.
- Free-form phase labels and structural header identities.
- Disabled-header arrow skipping and stale controlled-selection action inertness.
- Exact 60/59-column presentation boundary.
- Constrained list window where headers consume rows while the selected stream remains visible.
- Logical task progress remains independent of retry attempt-row count.
- Workflow-category roots carrying an inherited phase do not create headers for an unrelated nested child list.

## Verification

- Focused Stage 4 suites: 47 tests passed.
- Final interaction suite: 7 tests passed after the last fixture correction.
- `npm run typecheck`: passed.
- `npm run lint`: passed.
- `npm run check:dead-code-ratchet`: passed (18 current / 18 baseline).
- `npm test`: 777 files passed, 1 skipped; 7,574 tests passed, 4 skipped (before the final test-only fixture correction).
- CLI and test-kernel package typechecks: passed.
- Changed-file Prettier checks and `git diff --check`: passed.

An independent code review found one root-row scoping defect before push; it was fixed and covered. The follow-up review approved production behavior and identified one non-exercising test fixture, which was corrected before this PR. Automated review then found a one-column header-gutter mismatch; commit `20798daa81` aligned the markers and added a direct render assertion. A later review caught promoted retained rows being excluded by current-parent filtering; `aaeefa8712` now excludes only the root itself and adds retained-row display/order/shortcut regressions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to CLI TUI child-list rendering and ordering; keyboard shortcuts and selection behavior are covered by new tests with no auth, data, or wire-format impact.
> 
> **Overview**
> **Focused workflow-script runs** now show direct child agent rows under **disabled phase headers** in the CLI child list, with phase position `(n/N)` and **done/total** task progress from the workflow transcript (retry attempt rows stay visible but do not inflate counts).
> 
> **Ordering and shortcuts** — `streamTreeEntries` applies new stable `groupWorkflowPhaseEntries` grouping by `workflowPhase` before Alt+1..9 indices are assigned; phase-less lists keep prior order. The list root is never treated as a grouped attempt, so an inherited phase on the root does not create misleading headers for nested children.
> 
> **Selection model** — `ChildListValue` gains `phase:${ordinal}` header identities; headers are skipped by arrow navigation and do not focus streams or respond to print/kill/skip/retry. Progress aligns right at **60+** columns and inlines on narrower terminals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aaeefa8712f4049adfc2b146c9fe612cac7d73da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


