### PR TITLE
fix(cli): keep phase-less child rows out of a phase group

### DIFF
--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -277,6 +277,13 @@ export function SubagentList(
 
     const nextItems: SelectItem<ChildListValue>[] = [];
     const nextHeaders = new Map<ChildListValue, PhaseHeaderDetails>();
+    // A header only ever *opens* a group; nothing closes one. That is sound
+    // only because `sessions` arrives from `streamTreeViews`, whose
+    // `groupWorkflowPhaseEntries` makes same-phase rows contiguous and puts
+    // every phase-less row ahead of the first group — so no row can land under
+    // a header it does not belong to, and no phase can open a second header.
+    // Order has one owner: do not re-sort here, it would desynchronise the
+    // Alt+1..9 numbers `streamTreeEntries` assigns from the rows on screen.
     let previousPhase: string | undefined;
     let headerOrdinal = 0;
     for (const session of sessions) {

--- a/packages/cli/src/chat/tui/state/streamViews.ts
+++ b/packages/cli/src/chat/tui/state/streamViews.ts
@@ -174,21 +174,31 @@ interface StreamTreeViewInput {
 }
 
 /** Stable group-by for phase-tagged rows. Each phase occupies its first-seen
- *  position, untagged rows remain standalone, and row order within a phase is
- *  unchanged. Return the original list when grouping is inapplicable. */
+ *  position and row order within a phase is unchanged.
+ *
+ *  Untagged rows are partitioned *ahead* of every group rather than left at
+ *  their own position, keeping their relative order. They cannot sit between or
+ *  after groups: the list only ever *opens* a group with a `◆ {phase}` header
+ *  and paints no closing boundary, so an untagged row trailing a group would
+ *  render directly under that group's rows and read as part of a phase it does
+ *  not belong to — which is what an `agent()` call issued outside any `phase()`,
+ *  or a roster row from before the field existed, is not. Ahead of the first
+ *  header they belong to the run itself, which is also where the tree puts them,
+ *  and it costs no terminal row (a closing divider would cost one per boundary).
+ *
+ *  Return the original list when grouping is inapplicable. */
 export function groupWorkflowPhaseEntries<
   T extends { readonly workflowPhase?: string },
 >(entries: readonly T[]): readonly T[] {
+  const untagged: T[] = [];
   const groups: T[][] = [];
   const phaseGroups = new Map<string, T[]>();
-  let hasWorkflowPhase = false;
   for (const entry of entries) {
     const phase = entry.workflowPhase;
     if (phase === undefined) {
-      groups.push([entry]);
+      untagged.push(entry);
       continue;
     }
-    hasWorkflowPhase = true;
     let group = phaseGroups.get(phase);
     if (!group) {
       group = [];
@@ -197,7 +207,7 @@ export function groupWorkflowPhaseEntries<
     }
     group.push(entry);
   }
-  return hasWorkflowPhase ? groups.flat() : entries;
+  return groups.length > 0 ? [...untagged, ...groups.flat()] : entries;
 }
 
 export function streamTreeEntries(

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -170,6 +170,20 @@ describe('CLI child controls', () => {
     expect(groupWorkflowPhaseEntries(ordered)).toBe(ordered);
   });
 
+  // A header opens a group and nothing closes one, so an untagged row left
+  // between or after groups would render under a phase it is not part of.
+  it('partitions untagged rows ahead of every phase group', () => {
+    expect(
+      groupWorkflowPhaseEntries([
+        { id: 'a', workflowPhase: 'Map' },
+        { id: 'b', workflowPhase: undefined },
+        { id: 'c', workflowPhase: 'Map' },
+        { id: 'd', workflowPhase: undefined },
+        { id: 'e', workflowPhase: 'Reduce' },
+      ]).map(({ id }) => id),
+    ).toEqual(['b', 'd', 'a', 'c', 'e']);
+  });
+
   it('stably groups phases before assigning visible shortcut indices', () => {
     const ids = ['a', 'b', 'c', 'd', 'e'].map((id) => id as StreamTabId);
     const [a, b, c, d, e] = ids as [
@@ -243,11 +257,13 @@ describe('CLI child controls', () => {
         rootStreamId: root,
         streams,
       }),
+      // `d` carries no phase, so it heads the list rather than trailing the
+      // `Map` group, whose header would otherwise appear to own it.
     ).toEqual([
       { id: root },
-      { id: e, shortcutIndex: 1 },
-      { id: b, shortcutIndex: 2 },
-      { id: d, shortcutIndex: 3 },
+      { id: d, shortcutIndex: 1 },
+      { id: e, shortcutIndex: 2 },
+      { id: b, shortcutIndex: 3 },
       { id: c, shortcutIndex: 4 },
       { id: a, shortcutIndex: 5 },
     ]);
@@ -258,10 +274,10 @@ describe('CLI child controls', () => {
       rootStreamId: root,
       streams,
     });
-    expect(views.map(({ id }) => id)).toEqual([root, e, b, d, c, a]);
+    expect(views.map(({ id }) => id)).toEqual([root, d, e, b, c, a]);
     expect(views.find(({ id }) => id === b)).toMatchObject({
       parentId: undefined,
-      shortcutIndex: 2,
+      shortcutIndex: 3,
       workflowPhase: 'Map',
     });
     expect(
@@ -270,7 +286,7 @@ describe('CLI child controls', () => {
         childStreamEntries: entries,
         parentStream,
         streams,
-        zeroBasedIndex: 1,
+        zeroBasedIndex: 2,
       }),
     ).toBe(b);
   });

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -658,6 +658,99 @@ describe('CLI child list display model', () => {
     },
   );
 
+  // A `◆ {phase}` header opens a group and nothing closes one, so a row that
+  // carries no phase must never be painted after one — an `agent()` call issued
+  // outside any `phase()`, or a roster row from before the field existed, would
+  // otherwise read as belonging to the phase above it. Driven through
+  // `streamTreeViews`, the one owner of row order, rather than a hand-ordered
+  // `sessions` array, so it guards the production path.
+  it('never renders a phase-less row beneath a phase header', async () => {
+    const { ink, React } = await loadInk();
+    const run = 'run' as StreamTabId;
+    const mapAgent = 'map-agent' as StreamTabId;
+    const looseAgent = 'loose-agent' as StreamTabId;
+    const reduceAgent = 'reduce-agent' as StreamTabId;
+    const children = [reduceAgent, looseAgent, mapAgent];
+    const streams = new Map<StreamTabId, StreamSlice>([
+      [run, workflowAgentSlice('run', { status: STREAM_PHASE.RUNNING })],
+      ...children.map(
+        (id) =>
+          [
+            id,
+            workflowAgentSlice(id, { status: STREAM_PHASE.RUNNING }),
+          ] as const,
+      ),
+    ]);
+    const childStreamEntries = buildChildStreamEntries({
+      parentStreamId: run,
+      // Oldest first, as the roster retains them; the list reverses to
+      // newest-first, which is what interleaves `loose` between the groups.
+      retained: [
+        {
+          kind: 'subagent',
+          executionId: 'reduce-exec',
+          agentName: 'reduce-agent',
+          childStreamId: reduceAgent,
+          status: STREAM_PHASE.RUNNING,
+          workflowPhase: 'Reduce',
+        },
+        {
+          kind: 'subagent',
+          executionId: 'loose-exec',
+          agentName: 'loose-agent',
+          childStreamId: looseAgent,
+          status: STREAM_PHASE.RUNNING,
+        },
+        {
+          kind: 'subagent',
+          executionId: 'map-exec',
+          agentName: 'map-agent',
+          childStreamId: mapAgent,
+          status: STREAM_PHASE.RUNNING,
+          workflowPhase: 'Map',
+        },
+      ],
+    });
+    const sessions = streamTreeViews({
+      activeStreamId: run,
+      childStreamEntries,
+      parentStream: new Map(children.map((id) => [id, run] as const)),
+      rootStreamId: run,
+      streams,
+    });
+    const output: string = stripAnsi(
+      ink.renderToString(
+        React.createElement(SubagentList, {
+          listRootStreamId: run,
+          maxRows: 10,
+          sessions,
+        }),
+        { columns: 100 },
+      ),
+    );
+
+    expect(output).toContain('◆ Map');
+    expect(output).toContain('◆ Reduce');
+    expect(output).toContain('loose-agent running');
+    // The phase-less row sits above every header, so no header can be read as
+    // owning it.
+    expect(output.indexOf('loose-agent running')).toBeLessThan(
+      output.indexOf('◆'),
+    );
+    // One header per phase, and each group's rows still follow its own header.
+    expect(output.split('◆ Map')).toHaveLength(2);
+    expect(output.split('◆ Reduce')).toHaveLength(2);
+    expect(output.indexOf('◆ Map')).toBeLessThan(
+      output.indexOf('map-agent running'),
+    );
+    expect(output.indexOf('map-agent running')).toBeLessThan(
+      output.indexOf('◆ Reduce'),
+    );
+    expect(output.indexOf('◆ Reduce')).toBeLessThan(
+      output.indexOf('reduce-agent running'),
+    );
+  });
+
   it('does not group a list root by its inherited workflow phase', async () => {
     const { ink, React } = await loadInk();
     const run = 'nested-workflow' as StreamTabId;
@@ -785,6 +878,10 @@ describe('CLI child list display model', () => {
           ],
         }),
       },
+      // Phase-less rows head the list, as `groupWorkflowPhaseEntries` orders
+      // them — never between or after groups, where the header above would
+      // appear to own them.
+      { ...session(loose), label: 'unphased', parentId: run },
       {
         ...session(mapRetry),
         label: 'writer-retry',
@@ -798,7 +895,6 @@ describe('CLI child list display model', () => {
         parentId: run,
         workflowPhase: freeFormPhase,
       },
-      { ...session(loose), label: 'unphased', parentId: run },
       {
         ...session(reduce),
         label: 'editor',
@@ -851,6 +947,9 @@ describe('CLI child list display model', () => {
     expect(wideOutput.split(freeFormPhase)).toHaveLength(2);
     expect(wideOutput).toContain('writer-retry');
     expect(wideOutput).toContain('writer-attempt');
+    expect(wideOutput.indexOf('unphased')).toBeLessThan(
+      wideOutput.indexOf(`${freeFormPhase} (1/2)`),
+    );
     expect(wideOutput.indexOf(`${freeFormPhase} (1/2)`)).toBeLessThan(
       wideOutput.indexOf('writer-retry'),
     );
@@ -858,9 +957,6 @@ describe('CLI child list display model', () => {
       wideOutput.indexOf('writer-attempt'),
     );
     expect(wideOutput.indexOf('writer-attempt')).toBeLessThan(
-      wideOutput.indexOf('unphased'),
-    );
-    expect(wideOutput.indexOf('unphased')).toBeLessThan(
       wideOutput.indexOf('Reduce (2/2)'),
     );
   });


### PR DESCRIPTION
Follow-up to #9188 (stage 4 of 4 for #9177, merged). The feature landed with a
defect that its own review round never saw, because Cursor Bugbot found it on the
parallel implementation in #9187 (Medium severity) rather than on the branch that
merged. #9187 is redundant against `main` and now closed; this is the one piece
of it worth keeping.

## The defect, on `main`

`groupWorkflowPhaseEntries` (`packages/cli/src/chat/tui/state/streamViews.ts`)
pushed each untagged row as **its own standalone group at its original iteration
position**, while phase rows accumulated into a group created at that phase's
first-seen position:

```ts
if (phase === undefined) { groups.push([entry]); continue; }
```

So `[A(Map), B(no phase), C(Map)]` flattened to `[A, C, B]`, and an untagged row
could land between or after phase groups.

`SubagentList.tsx` only ever **opens** a group — it pushes a `◆ {phase}` header
when `phase !== previousPhase` and paints no end-of-group boundary. `B` therefore
rendered directly beneath a group's rows with nothing separating it, and read as
belonging to that phase:

```
   ◆ Map (1/2)                                                             1/2
   ● writer running · claude-sonnet-5             0m 48s · 3 tool calls · ↓4k
   ● helper running · claude-sonnet-5             0m 12s · 1 tool call · ↓1k   <- no phase
   ◆ Reduce (2/2)                                                          0/1
```

This hits `agent()` calls issued outside any `phase()`, and roster rows that
predate the `workflowPhase` field. The existing suite encoded the bug rather than
catching it: `ChildControls.vitest.mts` asserted the order `e, b, d, c, a` with
the unphased `d` between the two groups, and the width-boundary fixture in
`SubagentListDisplay.vitest.mts` hand-ordered `unphased` between `Map` and
`Reduce` and asserted that position.

## The fix: partition, not a closing divider

Untagged rows now rank **ahead of every group**, keeping their relative order,
instead of ranking by their own position.

Chosen over emitting an end-of-group boundary because it costs **zero terminal
rows**: a closing divider spends a row per boundary, and a trailing untagged
block would still need one however the rows are ordered. It also reads as the
tree is shaped — a call outside any `phase()` belongs to the run itself, so its
row sits directly under the run's own row, above the first divider.

**The trade-off, taken knowingly.** The list is newest-first, so putting untagged
rows first means a stale roster row predating the field floats to the top rather
than staying where its age puts it. That is the price of the zero-row option, and
it is the right price here: the alternative — leaving such a row where recency
puts it — is exactly what filed a row under a phase it has nothing to do with,
and a wrong grouping is a worse lie than an out-of-order row. Within the untagged
block, relative order is untouched.

## Constraints held

- **A list where no row carries a phase stays byte-identical to `main`**,
  including Alt+1..9 assignment: the early return still hands back the original
  `entries` array, and the identity assertion (`toBe(ordered)`) is untouched and
  green.
- **Order and `shortcutIndex` keep one owner**: `streamTreeEntries` groups and
  numbers in the same pass, so Alt+N still selects the Nth *visible* row.
  `SubagentList` does not re-sort — it now carries a comment saying why it may
  rely on the contiguity the ordering owner guarantees, since "open a group,
  never close one" is only sound under that invariant.
- `done/total` still comes from the shared `workflowPhaseTaskProgress`; no second
  fold, no fork.
- Headers stay non-selectable `disabled: true` `Select` items; `childListValues`
  in `App.tsx` stays stream-only.
- Rows keep `elapsed · N tool calls · ↓tokens` and still shed the metadata column
  below 60 columns — the width-boundary test is unchanged in what it asserts.
- Pure helper: no `Date.now()`, no timers, no synthetic ids, no dedup at render
  time.
- **Headless parity**: the diff touches only
  `packages/cli/src/chat/tui/state/streamViews.ts`,
  `packages/cli/src/chat/tui/panes/SubagentList.tsx` and two test files.
  `texra run`, `--print` and `--output-format json|ndjson` are untouched.

## Regression guard, with teeth

Three tests, each verified failing against the previous helper and passing with
it — fix stashed, suite run, fix restored, suite re-run:

- `partitions untagged rows ahead of every phase group` — the pure helper. Failed
  with `expected [a, c, b, d, e] to deeply equal [b, d, a, c, e]`.
- `stably groups phases before assigning visible shortcut indices` — the existing
  test, updated: the unphased row heads the list and the Alt+1..9 numbers follow
  it. Failed on the entry list.
- `never renders a phase-less row beneath a phase header` — the exact reported
  scenario as a **real Ink render**, driven through `streamTreeViews` (the one
  owner of row order) rather than a hand-ordered `sessions` array, so it guards
  the production path rather than a fixture. Failed with
  `expected 64 to be less than 26`: the phase-less row was painted well after the
  first `◆`.

The width-boundary fixture no longer hand-orders an unphased row between two
groups — a shape the ordering owner can no longer produce — so it stops
enshrining the defect. Its width assertions are unchanged.

## Not changed

No `CHANGELOG.md` entry: #9188 is unreleased (`0.39.9 - Unreleased`), so this bug
never shipped, and the existing feature bullet still describes the behaviour
correctly.

`formatWorkflowPhaseHeading` — the `({i}/{n})` copy dedup that #9187 carried
along — is deliberately **not** ported here. It is a pure refactor with identical
rendered output and no bearing on this defect; it belongs in its own PR if it is
wanted at all.

## Verification

`npm run typecheck`, `npm test` (778 files, 7583 tests), `npm run lint`,
`npm run check:dead-code-ratchet` — all green. `pnpm-lock.yaml` reverted before
committing; `git status` shows only the four intended files. Greps used
`--include` covering `.ts`, `.tsx` and `.mts`.

Not done: I did not drive the PTY harness at multiple widths. The new guard is a
real Ink render at 100 columns, and the pre-existing 60/59-column pair still
covers the metadata-column gate.

https://claude.ai/code/session_01MQZ63FFrmojmG58wPJdYNH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI TUI display ordering only; behavior when no phases is unchanged, with focused regression tests on the production `streamTreeViews` path.
> 
> **Overview**
> Fixes a **workflow child-list ordering bug** where rows without `workflowPhase` could appear under a `◆ {phase}` header and look like they belonged to that phase.
> 
> **`groupWorkflowPhaseEntries`** now collects untagged rows and emits them **before all phase groups** (relative order within that block unchanged), instead of leaving each untagged row at its iteration position between groups. Lists with no phased rows still return the original array unchanged.
> 
> **`SubagentList`** gains comments explaining why open-ended phase headers are safe only when order comes from `streamTreeViews` / that helper—no re-sort in the pane, so Alt+1..9 stays aligned with `streamTreeEntries`.
> 
> Tests add a pure partition case, update shortcut-index expectations, add an Ink render through `streamTreeViews`, and stop fixtures that assumed the old (buggy) interleaving.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48dead876e6b6f80e06ffbf24852fe3939669212. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->