### PR TITLE
refactor(cli): give the workflow phase heading one owner

### DIFF
--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -4,7 +4,10 @@
 import { Box, Text } from 'ink';
 
 import { AgentCategory } from '@shared/schemas';
-import { workflowPhaseTaskProgress } from '@shared/copy/workflowTask';
+import {
+  formatWorkflowPhaseHeading,
+  workflowPhaseTaskProgress,
+} from '@shared/copy/workflowTask';
 import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 import { formatResultCount } from '@utils/text/stringUtils';
 
@@ -128,10 +131,6 @@ export function workflowRunStatusSummary(
 ): string | undefined {
   if (slice?.category !== AgentCategory.Workflow) return undefined;
   const phase = slice.entries.findLast((entry) => entry.role === 'phase');
-  const phaseCounts =
-    phase?.phaseIndex !== undefined && phase.phaseTotal !== undefined
-      ? ` (${phase.phaseIndex + 1}/${phase.phaseTotal})`
-      : '';
   const { done, total } = workflowPhaseTaskProgress(
     phase
       ? slice.entries.flatMap((entry) =>
@@ -144,7 +143,7 @@ export function workflowRunStatusSummary(
   const input = slice.files?.input.length ?? 0;
   const context = slice.files?.context.length ?? 0;
   const segments = [
-    ...(phase ? [`${phase.phaseLabel}${phaseCounts}`] : []),
+    ...(phase ? [formatWorkflowPhaseHeading(phase)] : []),
     ...(total > 0 ? [`${done}/${total} done`] : []),
     ...(input > 0 || context > 0
       ? [

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -10,7 +10,11 @@ import {
   type StreamTabId,
   type WorkflowTaskProgress,
 } from '@shared/schemas';
-import { workflowPhaseTaskProgress } from '@shared/copy/workflowTask';
+import {
+  formatWorkflowPhaseHeading,
+  workflowPhaseTaskProgress,
+  type WorkflowPhaseHeading,
+} from '@shared/copy/workflowTask';
 import {
   formatPhaseStageLabel,
   formatRoundStageLabel,
@@ -76,10 +80,7 @@ function RowMetadata({
 
 const SUBAGENT_SUMMARY_MAX_COLUMNS = 100;
 
-interface PhaseHeaderDetails {
-  readonly label: string;
-  readonly index?: number;
-  readonly total?: number;
+interface PhaseHeaderDetails extends WorkflowPhaseHeading {
   readonly progress?: string;
 }
 
@@ -90,17 +91,13 @@ function PhaseHeader({
   readonly details: PhaseHeaderDetails;
   readonly metadataColumn: boolean;
 }): React.JSX.Element {
-  const position =
-    details.index !== undefined && details.total !== undefined
-      ? ` (${details.index + 1}/${details.total})`
-      : '';
   const inlineProgress =
     !metadataColumn && details.progress ? ` · ${details.progress}` : '';
   return (
     <Box flexDirection="row" flexGrow={1} minWidth={0}>
       <Box minWidth={0} flexShrink={1}>
         <Text dimColor wrap="truncate-end">
-          {`    ${STATUS_DIAMOND} ${details.label}${position}${inlineProgress}`}
+          {`    ${STATUS_DIAMOND} ${formatWorkflowPhaseHeading(details)}${inlineProgress}`}
         </Text>
       </Box>
       {metadataColumn && details.progress ? (
@@ -259,16 +256,14 @@ export function SubagentList(
       rootSession?.slice?.category === AgentCategory.Workflow
         ? rootSession.slice.entries
         : [];
-    const phasePositions = new Map<
-      string,
-      { readonly index?: number; readonly total?: number }
-    >();
+    const phaseHeadings = new Map<string, WorkflowPhaseHeading>();
     const tasksByPhase = new Map<string, WorkflowTaskProgress[]>();
     for (const entry of entries) {
       if (entry.role === 'phase') {
-        phasePositions.set(entry.phaseLabel, {
-          index: entry.phaseIndex,
-          total: entry.phaseTotal,
+        phaseHeadings.set(entry.phaseLabel, {
+          phaseLabel: entry.phaseLabel,
+          phaseIndex: entry.phaseIndex,
+          phaseTotal: entry.phaseTotal,
         });
       } else if (
         entry.role === 'workflowTask' &&
@@ -301,12 +296,9 @@ export function SubagentList(
         const value = childPhaseListValue(headerOrdinal++);
         const tasks = tasksByPhase.get(phase) ?? [];
         const { done, total } = workflowPhaseTaskProgress(tasks);
-        const position = phasePositions.get(phase);
         nextItems.push({ label: phase, value, disabled: true });
         nextHeaders.set(value, {
-          label: phase,
-          index: position?.index,
-          total: position?.total,
+          ...(phaseHeadings.get(phase) ?? { phaseLabel: phase }),
           ...(total > 0 ? { progress: `${done}/${total}` } : {}),
         });
       }

--- a/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts
@@ -2,6 +2,7 @@
 // budgeting, static scrollback, and print-once full output.
 
 import type { WorkflowTaskProgress } from '@shared/schemas';
+import { formatWorkflowPhaseHeading } from '@shared/copy/workflowTask';
 import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 import { renderAnsiMarkdown } from '../render/ansiMarkdown';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
@@ -236,13 +237,9 @@ function entryLines(
       return richProjection ? lines : wrapDisplayLines(lines, columns);
     }
     case 'phase': {
-      const suffix =
-        entry.phaseIndex !== undefined && entry.phaseTotal !== undefined
-          ? ` (${entry.phaseIndex + 1}/${entry.phaseTotal})`
-          : '';
       const geometry = ROLE_GEOMETRY.phase;
       return wrapWithPrefix(
-        `${STATUS_DIAMOND} ${entry.phaseLabel}${suffix}`,
+        `${STATUS_DIAMOND} ${formatWorkflowPhaseHeading(entry)}`,
         columns,
         geometry.firstPrefix,
         geometry.continuationPrefix,

--- a/src/shared/copy/workflowTask.ts
+++ b/src/shared/copy/workflowTask.ts
@@ -44,6 +44,32 @@ export function workflowPhaseTaskProgress(
   };
 }
 
+/** One workflow phase as its emitter names and orders it. */
+export interface WorkflowPhaseHeading {
+  readonly phaseLabel: string;
+  /** 0-based phase order within the run, when the emitter provides it. */
+  readonly phaseIndex?: number;
+  /** Total phase count for the run, when the emitter provides it. */
+  readonly phaseTotal?: number;
+}
+
+/**
+ * Canonical heading copy for one workflow phase (`Reduce (2/3)`), shared by
+ * every surface that names a phase: the transcript's `◆` divider, the live
+ * run-status band, and the focused run's child-list group headers. The leading
+ * glyph is left to the caller — the band deliberately carries none. The index
+ * is 0-based on the wire and 1-based in the copy.
+ */
+export function formatWorkflowPhaseHeading(
+  phase: WorkflowPhaseHeading,
+): string {
+  const counts =
+    phase.phaseIndex !== undefined && phase.phaseTotal !== undefined
+      ? ` (${phase.phaseIndex + 1}/${phase.phaseTotal})`
+      : '';
+  return `${phase.phaseLabel}${counts}`;
+}
+
 /**
  * The one explanatory-clause rule for a workflow task, shared by every host: a
  * failure reports its error, and a task the run never reached says so. A user


### PR DESCRIPTION
## Summary

The `{phase} ({i}/{n})` heading suffix was constructed in **three** places on `main`:

| # | Site | Line at `72fd0641f8` |
|---|------|----------------------|
| 1 | Transcript `◆` phase divider | `packages/cli/src/chat/tui/panes/transcriptEntryLayout.ts:239-242` |
| 2 | Live workflow status band | `packages/cli/src/chat/tui/panes/ConversationPane.tsx:131-134` |
| 3 | Focused child-list phase headers (added by #9188) | `packages/cli/src/chat/tui/panes/SubagentList.tsx:93-96` |

All three were the same rule spelled out three times — including the 0-based-wire → 1-based-copy conversion, exactly the kind of detail that drifts when only one copy gets touched.

**3 constructions → 1.** They now call `formatWorkflowPhaseHeading` in `src/shared/copy/workflowTask.ts`. The leading glyph stays with the caller — the status band deliberately carries none, and the two `◆` surfaces indent differently.

## Issue acceptance gates

No issue. Follow-on cleanup of the copy duplication that #9188 (Stage 4 of #9177) introduced as its third construction.

## Single source of truth

`src/shared/copy/workflowTask.ts` — already the single-owner shared copy module both hosts use (`formatWorkflowTaskLine`, `workflowPhaseTaskProgress`, `workflowTaskDetail`). Workflow **phase** heading copy now lives beside workflow **task** copy in that same owner.

## Duplication and abstraction budget

Removed: three inline constructions of one copy rule. No new abstraction layer — one function added to an existing owner module, with three consumers in this PR. `SubagentList`'s `PhaseHeaderDetails` now `extends WorkflowPhaseHeading` instead of restating the same three fields under different names (`label`/`index`/`total`), which also retires the inline anonymous type on the local phase-position map.

## Net elements (R6)

| Construct | Added | Deleted | Net |
|---|---|---|---|
| Files (diffstat) | 0 | 0 | 0 (4 modified) |
| Exported symbols (`^[+-]export` over the diff) | 2 (`formatWorkflowPhaseHeading`, `WorkflowPhaseHeading`) | 0 | **+2** |
| Classes / interfaces / enums | 1 (`WorkflowPhaseHeading`) | 0 | +1 (`PhaseHeaderDetails` shrinks from 4 own fields to 1) |
| Copy-rule constructions | 0 | 3 | **−3** |
| Net LoC | +46 | −32 | **+14** |

Of the +46 added lines, **+26** is the new shared function and its doc comment in `workflowTask.ts`; the three call sites are net **−12**. The element trade is +2 exports / +1 interface for −3 duplicated constructions and −4 restated fields.

## Consumer counts (R8)

n/a for deletions — no emit path or export is deleted or re-routed by this PR. For the two **added** exports (grepped across `src/` and `packages/`, `--include='*.ts' --include='*.tsx' --include='*.mts'`):

- `formatWorkflowPhaseHeading` — **3** consumers, all in this PR: `transcriptEntryLayout.ts`, `ConversationPane.tsx`, `SubagentList.tsx`.
- `WorkflowPhaseHeading` (type) — **2** consumers, both in `SubagentList.tsx` (`PhaseHeaderDetails extends …`, and the `phaseHeadings` map value type).

Neither is a single-caller extraction, and `npm run check:dead-code-ratchet` needs no new baseline entry.

## Host impact

Extension: none — no extension file touched; `workflowTask.ts` gains an export the extension does not import.

Desktop: none.

CLI: the only host touched. Rendered output is unchanged (see Validation). Headless parity is unaffected: no touched code runs on the `texra run` / `--print` / `--output-format json|ndjson` path, and no timers, `Date.now()`, synthetic ids, or render-time dedup are introduced.

## Scheduled refactoring

None.

## Validation

**Byte-identical output.** This is a pure refactor; no rendered string changes.

- `formatWorkflowPhaseHeading` returns `` `${phaseLabel}${counts}` `` with the identical `phaseIndex !== undefined && phaseTotal !== undefined ? \` (${phaseIndex + 1}/${phaseTotal})\` : ''` expression the three call sites each had.
- In `SubagentList`, `phaseHeadings.get(phase)?.phaseLabel` is the map key, i.e. `phase` itself, so the label is unchanged; a miss falls back to `{ phaseLabel: phase }`, matching the old unconditional `label: phase` with `index`/`total` undefined.

**Proof: every existing test that asserts a rendered heading passes unmodified** — no test file is touched by this PR (`git diff --stat` lists four source files only). Those assertions include:

- `src/test-kernel/cli/SubagentListDisplay.vitest.mts:164` — `'Map (1/3) · 1/2 done · Input: 1 file · Context: 0 files'`
- `src/test-kernel/cli/SubagentListDisplay.vitest.mts:838-864` — group headers `… (1/2)`, `'Reduce (2/2) · 0/1'`, and their order
- `src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.mts:385,1101` — `'◆ Cancellation audit'`, `'◆ Draft sections'`
- `src/test-kernel/cli/ConversationPane.vitest.mts:451-476` — task rows nested under the divider

Checks run locally on this branch:

- `npm run typecheck` — clean
- `npm test` — **777 files passed / 1 skipped, 7576 tests passed / 4 skipped**, no test edited
- `npm run lint` — clean
- `npm run check:dead-code-ratchet` — `18 current vs 18 baselined`, no new findings
- `npx prettier --check` on the four touched files — clean

`pnpm-lock.yaml` was reverted after install; `git status` shows only the four source files.

## Note on #9189

Open PR #9189 also touches `SubagentList.tsx`, but only inserts a comment block above `let previousPhase` (`:282-289`); this PR edits the header construction below it (`:296-302`). Both are based on `main` and are not stacked — whichever lands second may need a trivial context rebase.

https://claude.ai/code/session_01MQZ63FFrmojmG58wPJdYNH
