### PR TITLE
test(progress): make retained-status projection regression effective

### DIFF
--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -3491,22 +3491,24 @@ describe('retained finished children', () => {
         subagent('doomed', { childStreamId }),
       ]);
       backend.factApplier.updateChildRoster(PARENT, []);
+      // Transition only the authoritative status machine. Deliberately avoid
+      // `setStreamStatus`, which also caches the terminal status into the
+      // retained row and would let this test pass without the projection.
       backend.state.streamStatus.transitionToTerminal(
         childStreamId,
         STREAM_PHASE.FAILED,
       );
-      await backend.factApplier.setStreamStatus(
-        childStreamId,
+      expect(backend.state.getStreamState(PARENT)?.subagents?.[0]?.status).toBe(
+        STREAM_PHASE.RUNNING,
+      );
+      expect(backend.state.streamStatus.get(childStreamId)).toBe(
         STREAM_PHASE.FAILED,
       );
-      // Auto-close/deletion can clear the child's status-machine entry before
-      // a later structural rebuild. The retained row must keep the outcome.
-      backend.state.streamStatus.clearStream(childStreamId);
       messages.length = 0;
 
       // A structural rebuild (view reopen, theme change, filter switch) is the
-      // frontend's other writer of `subagents`; it must not ship the stale
-      // stamped status back over the resolved one.
+      // frontend's other writer of `subagents`; it must overlay the stale row
+      // with the authoritative status-machine outcome.
       backend.webviewUpdater.sendStreamMetadata(
         backend.state,
         backend.factApplier.getAllStreamStates(),


### PR DESCRIPTION
Closes #9192.

## What changed

Repairs the retained-child structural-sync regression so the status machine is the only source of the terminal outcome:

- transitions the child directly to `FAILED` in `ProgressViewState.streamStatus`;
- deliberately avoids `ProgressFactApplier.setStreamStatus`, which would also cache `failed` into the retained row;
- keeps the status-machine entry alive;
- asserts before sync that the retained row is still `running` while the authoritative machine reads `failed`;
- verifies both structural metadata send paths project `failed`.

This now guards the load-bearing `WebviewUpdater` → `ProgressViewState.projectChildRosters` boundary rather than passing through the cached-row fallback.

## Net elements (R6)

- 1 test file changed: 9 insertions, 7 deletions.
- Adds no production code, file, symbol, helper, type, schema, or state.
- Replaces an ineffective fixture arrangement with one that discriminates the production seam it names.

## Consumer counts (R8)

- n/a — no API, producer, consumer, event, or routing surface changed.

## Verification

- `ProgressBackend.vitest.ts`: 74 tests passed.
- Test-kernel TypeScript check passed.
- ESLint, Prettier, and `git diff --check` passed.
- Mutation proof: replacing the structural `projectChildRosters` call with raw state makes this exact test fail (`1 failed, 73 skipped`); restoring production makes all 74 pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adjusts a regression test fixture and assertions; runtime behavior is unchanged.
> 
> **Overview**
> **Test-only change** to the “keeps the resolved terminal status on a later structural sync” case in `ProgressBackend.vitest.ts`.
> 
> The fixture now forces a real mismatch: roster drop leaves a retained subagent row at **`running`**, while **`streamStatus`** alone is moved to **`failed`** via `transitionToTerminal`. It **no longer** calls `setStreamStatus` (which would stamp `failed` onto the retained row) or clears the child from the status machine.
> 
> New **pre-sync** expectations lock in that stale row vs authoritative machine split. Comments are updated to state that `sendStreamMetadata` / `updateStreamMetadata` must **project** `failed` through `projectChildRosters`, not rely on cached row status.
> 
> No production code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d4ee8839b8cf5d43400d89637dd06d544d92ce8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->