### PR TITLE
fix(cli): keep post-launcher prompts alive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Team availability choices stay interactive after leaving the launcher** —
+  the CLI now waits for sign-in, continue, or cancel input instead of exiting
+  at the prompt.
 - **The child list drops its always-empty background-process rows** — the
   `N proc` status segment and the task-detail panel behind `Enter` were served
   by a roster no run could populate; background `bash` keeps its own child

--- a/packages/cli/src/runtime/logSinks.ts
+++ b/packages/cli/src/runtime/logSinks.ts
@@ -127,10 +127,18 @@ export function writeErrorStderr(error: unknown): void {
   writeTextStderr(toErrorMessage(error));
 }
 
-export async function askCliQuestion(question: string): Promise<string> {
+export async function askCliQuestion(
+  question: string,
+  input: NodeJS.ReadableStream & { ref?: () => void } = process.stdin,
+  output: NodeJS.WritableStream = process.stderr,
+): Promise<string> {
+  // Ink releases its ownership of stdin with `unref()` when a TUI exits.
+  // A following readline prompt must acquire its own live handle or Node can
+  // terminate while the top-level command is still awaiting the answer.
+  input.ref?.();
   const prompt = createInterface({
-    input: process.stdin,
-    output: process.stderr,
+    input,
+    output,
   });
   try {
     return await prompt.question(question);

--- a/src/test-kernel/cli/LogSinks.vitest.mts
+++ b/src/test-kernel/cli/LogSinks.vitest.mts
@@ -1,8 +1,15 @@
+// Node imports
+import { PassThrough } from 'node:stream';
+
 // Third-party imports
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
-import { isCliPipeClosureError, NdjsonStdoutSink } from '@cli/runtime/logSinks';
+import {
+  askCliQuestion,
+  isCliPipeClosureError,
+  NdjsonStdoutSink,
+} from '@cli/runtime/logSinks';
 import type { CliNdjsonRecord } from '@cli/schemas/cliOutput';
 
 function createStdoutStub(writeResults: boolean[] = [true]) {
@@ -118,5 +125,18 @@ describe('CLI pipe errors', () => {
       ),
     ).toBe(true);
     expect(isCliPipeClosureError(new Error('disk full'))).toBe(false);
+  });
+});
+
+describe('CLI questions', () => {
+  it('acquires stdin ownership before waiting for an answer', async () => {
+    const input = Object.assign(new PassThrough(), { ref: vi.fn() });
+    const output = new PassThrough();
+
+    const answer = askCliQuestion('Choose: ', input, output);
+    input.end('continue\n');
+
+    await expect(answer).resolves.toBe('continue');
+    expect(input.ref).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## What changed

- make the shared CLI question primitive acquire a live stdin reference before waiting for input
- cover stdin ownership with a focused regression test
- document the user-visible CLI fix in the changelog

## Root cause

Ink deliberately unreferences stdin when the launcher exits. The following readline prompt assumed stdin was still referenced, so Node could terminate with an unsettled top-level await while the CLI was visibly waiting for the team-availability choice.

The fix belongs in the shared prompt boundary: every line prompt now owns the stdin lifecycle it requires, rather than adding a team-launch-specific workaround.

## User impact

Team availability prompts now remain interactive after leaving the launcher, so users can sign in, continue with available members, or cancel normally.

## Validation

- exact PTY reproduction: Team → lean-project → model → continue; prompt stayed alive and returned to launcher without the Node warning
- `npm run format`
- `npm run compile:safe`
- `npm run lint`
- `npm test` (7,579 passed, 4 skipped)
- focused `LogSinks.vitest.mts` regression test
- bundled CLI build via `corepack pnpm run texra-local:build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to shared prompt plumbing with a regression test; no auth or data-path changes.
> 
> **Overview**
> Fixes a bug where **team availability prompts** (sign in / continue / cancel) could appear after leaving the Ink launcher but the process would exit before readline could read an answer, because Ink had **unref’d `stdin`** on TUI teardown.
> 
> The shared **`askCliQuestion`** helper now calls **`input.ref?.()`** before opening readline so the prompt holds a live stdin handle for any post-TUI line prompt (team preflight in `orchestrate`, headless approvals, etc.). Optional **`input` / `output` stream parameters** support tests without changing default `process.stdin` / `process.stderr` behavior.
> 
> Adds a focused regression in **`LogSinks.vitest.mts`** and documents the user-visible fix in **CHANGELOG**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65df291354bb34c63583bded921fe0fee7c58658. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->