### PR TITLE
feat(cli): show workflow run details

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,7 @@ jobs:
             orchestrate-launcher orchestrate-agent-submenu \
             orchestrate-delegated-history orchestrate-resume-submenu \
             compact-orchestrate-launcher single-run-liveness \
-            agent-proposal-approve-all
+            agent-proposal-approve-all workflow-timeline
 
       - name: Upload CLI TUI smoke frames
         if: always()

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -26,7 +26,6 @@ import {
   defaultSession,
   initializeDefaultSession,
 } from '@agent/runtime/SessionHandle';
-import { createRunTrace } from '@transcript';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { platform, tryPlatform } from '@platform/platform';
 import { MEMORY_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
@@ -58,7 +57,7 @@ import {
 } from '@shared/streams/streamStatus';
 import { GoalStore } from '@tools/goal';
 import { buildContinuationText } from '@tools/inquiry/inquiryContinuation';
-import { StreamLogStore } from '@transcript';
+import { createRunTrace, StreamLogStore } from '@transcript';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { App } from '../src/chat/tui/App';

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -26,6 +26,7 @@ import {
   defaultSession,
   initializeDefaultSession,
 } from '@agent/runtime/SessionHandle';
+import { createRunTrace } from '@transcript';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { platform, tryPlatform } from '@platform/platform';
 import { MEMORY_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
@@ -161,6 +162,7 @@ import type { CliModelAccess } from '../src/runtime/modelAccess';
 import type { InputHistory } from '../src/chat/tui/history/inputHistory';
 
 const STREAM_ID = 'harness-stream-1';
+const SHOW_WORKFLOW_TIMELINE = process.env.HARNESS_WORKFLOW_TIMELINE === '1';
 const HARNESS_APPROVAL_USAGE = 'Usage: /approval [ask | never | yolo]';
 const HARNESS_YOLO_USAGE = 'Usage: /yolo [ask | never | yolo]';
 const ENTRY_COUNT = Number(process.env.HARNESS_ENTRIES ?? '15');
@@ -1147,6 +1149,7 @@ function harnessInitialStreamStatus(
 }
 
 function harnessInitialEntries(): ConversationEntry[] {
+  if (SHOW_WORKFLOW_TIMELINE) return [];
   if (SHOW_REJECTED_BASH_TOOL) return makeRejectedBashToolEntries();
   if (SHOW_LONG_TOOL_OUTPUT) return makeLongToolOutputEntries();
   if (SHOW_ASSISTANT_TOOL_PREAMBLE) return makeAssistantToolPreambleEntries();
@@ -1182,6 +1185,123 @@ if (SHOW_LIVE_TOOL_ONLY) {
 
 if (SHOW_SUBAGENT_FOLLOWUPS) {
   seedSubagentFollowupTranscript();
+}
+
+function seedWorkflowTimeline(): void {
+  const executionId = 'harness-workflow-timeline' as ExecutionId;
+  const childStreamId = 'workflow#harness-workflow-timeline' as StreamTabId;
+  defaultSession().events.emit({
+    scope: 'session',
+    event: {
+      type: 'setActiveStream',
+      payload: {
+        streamId: childStreamId,
+        agentCategory: AgentCategory.Workflow,
+        suppressViewSwitch: true,
+      },
+    },
+  });
+  emitChildEventOrderRoster(STREAM_ID, [
+    {
+      kind: 'subagent',
+      executionId,
+      agentName: 'repositoryAudit',
+      childStreamId,
+      toolName: 'delegate_workflow_script',
+    },
+  ]);
+  emitChildEventOrderEdge(childStreamId, STREAM_ID);
+  transitionChildEventOrderRunning(childStreamId);
+  // Mirror a user focusing the running child before its terminal transition.
+  // `subscribeStreamStatus` must return this focus to the owner below.
+  activeStreamIdSignal.set(childStreamId);
+
+  const output = {
+    source: 'paper.tex',
+    location: {
+      kind: 'runStorage' as const,
+      executionId,
+      relativePath: 'r1/paper.tex',
+      absolutePath: '/private/tmp/texra-harness/r1/paper.tex',
+    },
+    round: 0,
+    lineage: null,
+    diff: null,
+  };
+  const runTrace = createRunTrace(childStreamId, defaultSession().transcripts);
+  const runStage = runTrace.trace.openStage('Repository audit', {
+    id: 'harness-workflow-run',
+    kind: 'run',
+  });
+  const roundStage = runTrace.trace.openStage('Round 1', {
+    id: 'harness-workflow-round-1',
+    index: 0,
+    kind: 'round',
+    parent: runStage,
+    total: 2,
+  });
+
+  roundStage.end('completed');
+  defaultSession().events.emit({
+    scope: 'run',
+    streamId: childStreamId,
+    event: {
+      type: 'addOutputFiles',
+      executionId,
+      filesByRound: { 0: [output] },
+      streamId: childStreamId,
+    },
+  });
+  defaultSession().events.emit({
+    scope: 'run',
+    streamId: childStreamId,
+    event: {
+      type: 'updateCompileFailures',
+      executionId,
+      filesByRound: {
+        0: [
+          {
+            round: 0,
+            displayName: 'paper.tex',
+            output: output.location,
+            log: {
+              kind: 'runStorage',
+              executionId,
+              relativePath: 'r1/paper.log',
+              absolutePath: '/private/tmp/texra-harness/r1/paper.log',
+            },
+            logRelativePath: 'r1/paper.log',
+          },
+        ],
+      },
+      streamId: childStreamId,
+    },
+  });
+  const secondRoundStage = runTrace.trace.openStage('Round 2', {
+    id: 'harness-workflow-round-2',
+    index: 1,
+    kind: 'round',
+    parent: runStage,
+    total: 2,
+  });
+  secondRoundStage.end('completed');
+  runStage.end('completed');
+  syncStreamLog(childStreamId);
+  transitionChildEventOrderTerminal(childStreamId);
+  emitChildEventOrderRoster(STREAM_ID, []);
+  runTrace.dispose();
+
+  if (activeStreamIdSignal.get() !== STREAM_ID) {
+    throw new Error('Completed workflow child did not return focus to owner');
+  }
+  const retained = visibleSubagentRows(
+    STREAM_ID,
+    childStreamEntries.get(),
+    streams.get(),
+  );
+  if (!retained.some((child) => child.childStreamId === childStreamId)) {
+    throw new Error('Completed workflow child was not retained for refocus');
+  }
 }
 
 // One child stream, its attachment/roster/edge/status/removal facts driven
@@ -2161,11 +2281,18 @@ inkRef.current = ink;
 
 HARNESS_DISPOSERS.push(subscribeStreamStatus());
 
-if (CHILD_EVENT_ORDER) {
+if (CHILD_EVENT_ORDER || SHOW_WORKFLOW_TIMELINE) {
   // Mirror real CLI startup: `runChatTui.tsx` installs
   // `subscribeStreamStatus()` and the run-fact subscription once per TUI
   // session.
   HARNESS_DISPOSERS.push(attachTuiRunFactSubscription(defaultSession().events));
+}
+
+if (SHOW_WORKFLOW_TIMELINE) {
+  seedWorkflowTimeline();
+}
+
+if (CHILD_EVENT_ORDER) {
   void runChildEventOrderFixture(ink, CHILD_EVENT_ORDER).catch((error) => {
     process.stderr.write(
       `[tui-harness] HARNESS_CHILD_EVENT_ORDER failed: ${toErrorMessage(error)}\n`,

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -142,6 +142,31 @@ const SCENARIOS = [
     ],
   },
   {
+    name: 'workflow-timeline',
+    frame: 'scrollback',
+    rows: 24,
+    cols: 100,
+    env: {
+      HARNESS_ENTRIES: '0',
+      HARNESS_WORKFLOW_TIMELINE: '1',
+    },
+    bootExpect: 'Tab children',
+    keys: ['\t', DOWN, '\r'],
+    expect: [
+      'repositoryAudit completed',
+      'Generated files',
+      'paper.tex',
+      'Compile check failed',
+      'paper.log',
+    ],
+    expectPatterns: [/r0.*completed/, /r1.*completed/],
+    ordered: [
+      { before: 'r0', after: 'Generated files' },
+      { before: 'Generated files', after: 'Compile check failed' },
+      { before: 'Compile check failed', after: 'r1 (2/2) completed' },
+    ],
+  },
+  {
     name: 'live-tool-only-spacing',
     frame: 'scrollback',
     env: {

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -193,7 +193,9 @@ export function createChatSessionController(
   // projecting status, output, and approval-related facts after the root
   // promise settles. Installing this once also avoids duplicate projections
   // when another root starts while an earlier detached child is still alive.
-  disposers.push(attachTuiRunFactSubscription(defaultSession().events));
+  disposers.push(
+    attachTuiRunFactSubscription(defaultSession().events, snapshotStore),
+  );
 
   const activateAgentConfig = (
     config: Pick<

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -27,6 +27,7 @@ import {
 import { ToolUseRow } from './ToolUseRow';
 import { splitTranscriptEntries } from './transcriptEntries';
 import {
+  estimateLiveTranscriptEntryRows,
   estimateTranscriptEntryRows,
   selectTranscriptEntriesForViewport,
 } from './transcriptViewport';
@@ -186,7 +187,7 @@ export function ConversationPane(
         Math.max(0, maxRows - metadataRows),
         Math.max(
           MIN_PENDING_ROWS,
-          estimateTranscriptEntryRows(
+          estimateLiveTranscriptEntryRows(
             newestPendingEntry,
             props.width,
             props.subagentExecutionLabels,

--- a/packages/cli/src/chat/tui/panes/ConversationPane.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationPane.tsx
@@ -30,6 +30,10 @@ import {
   estimateTranscriptEntryRows,
   selectTranscriptEntriesForViewport,
 } from './transcriptViewport';
+import {
+  selectWorkflowRunDetailLines,
+  WorkflowRunDetails,
+} from './WorkflowRunDetails';
 
 const DEFAULT_TRANSCRIPT_ROWS = 24;
 const MIN_PENDING_ROWS = 1;
@@ -176,14 +180,38 @@ export function ConversationPane(
     (displayEntries.length === 0 || maxRows > 1)
       ? 1
       : 0;
+  const newestPendingEntry = displayEntries.at(-1);
+  const pendingRowReserve = newestPendingEntry
+    ? Math.min(
+        Math.max(0, maxRows - metadataRows),
+        Math.max(
+          MIN_PENDING_ROWS,
+          estimateTranscriptEntryRows(
+            newestPendingEntry,
+            props.width,
+            props.subagentExecutionLabels,
+          ),
+        ),
+      )
+    : 0;
+  const detailCapacity = Math.max(
+    0,
+    maxRows - metadataRows - pendingRowReserve,
+  );
+  const visibleWorkflowDetails =
+    slice?.category === AgentCategory.Workflow
+      ? selectWorkflowRunDetailLines(slice, detailCapacity)
+      : [];
+  const detailRows = visibleWorkflowDetails.length;
   const visibleEntries = selectTranscriptEntriesForViewport(
     displayEntries,
-    Math.max(0, maxRows - metadataRows),
+    Math.max(0, maxRows - metadataRows - detailRows),
     props.width,
     props.subagentExecutionLabels,
   );
   const visibleRows =
     metadataRows +
+    detailRows +
     (visibleEntries.entries.length > 0
       ? Math.max(MIN_PENDING_ROWS, visibleEntries.usedRows)
       : 0);
@@ -200,6 +228,10 @@ export function ConversationPane(
           </Text>
         </Box>
       ) : null}
+      <WorkflowRunDetails
+        lines={visibleWorkflowDetails}
+        width={metadataWidth}
+      />
       {visibleEntries.entries.map((entry) =>
         renderConversationPaneEntry({
           colorEnabled: props.colorEnabled,

--- a/packages/cli/src/chat/tui/panes/WorkflowRunDetails.tsx
+++ b/packages/cli/src/chat/tui/panes/WorkflowRunDetails.tsx
@@ -1,0 +1,359 @@
+// Focused, read-only workflow run details.
+//
+// Task-group lifecycle comes from the StreamLog; generated files and warnings
+// come from the canonical round-indexed artifact facts. This component only
+// joins and renders those facts—it does not infer or mutate workflow state.
+
+import { Box, Text } from 'ink';
+
+import {
+  STREAM_PHASE,
+  roundIndexedEntries,
+  type TaskGroup,
+  type TaskGroupStatus,
+} from '@shared/schemas';
+import { formatStreamStatusLabel } from '@shared/streams/streamStatusDisplay';
+import { formatDuration } from '@utils/text/stringUtils';
+
+import { safeTerminalText } from '../state/transcriptLines';
+import {
+  COLOR_BORDER,
+  COLOR_ERROR,
+  COLOR_SUCCESS,
+  COLOR_WARNING,
+} from '../ui/colors';
+import {
+  CROSS,
+  SKIP_CIRCLE,
+  STATUS_DOT,
+  TICK,
+  TODO_PENDING,
+  WARNING,
+} from '../ui/glyphs';
+import type { StreamSlice } from '../state/cliState';
+
+type WorkflowRunDetailTone =
+  'neutral' | 'muted' | 'success' | 'warning' | 'error';
+
+export interface WorkflowRunDetailLine {
+  readonly key: string;
+  readonly text: string;
+  readonly tone: WorkflowRunDetailTone;
+  readonly role: 'lifecycle' | 'outputHeading' | 'output' | 'alert';
+}
+
+type WorkflowRunFacts = Pick<
+  StreamSlice,
+  | 'taskGroups'
+  | 'outputFilesByRound'
+  | 'missingOutputsByRound'
+  | 'compileFailuresByRound'
+>;
+
+interface WorkflowRunDetailGroup {
+  readonly key: string;
+  readonly lines: readonly WorkflowRunDetailLine[];
+  readonly priority: number;
+  readonly planned: boolean;
+}
+
+const TASK_GROUP_APPEARANCE = {
+  [STREAM_PHASE.RUNNING]: { marker: STATUS_DOT, tone: 'neutral' },
+  [STREAM_PHASE.COMPLETED]: { marker: TICK, tone: 'success' },
+  [STREAM_PHASE.CANCELLED]: { marker: SKIP_CIRCLE, tone: 'muted' },
+  [STREAM_PHASE.FAILED]: { marker: CROSS, tone: 'error' },
+} as const satisfies Record<
+  TaskGroupStatus,
+  { readonly marker: string; readonly tone: WorkflowRunDetailTone }
+>;
+
+const LINE_COLORS = {
+  neutral: undefined,
+  muted: COLOR_BORDER,
+  success: COLOR_SUCCESS,
+  warning: COLOR_WARNING,
+  error: COLOR_ERROR,
+} as const satisfies Record<WorkflowRunDetailTone, string | undefined>;
+
+function taskGroupLine(group: TaskGroup, label: string): WorkflowRunDetailLine {
+  const appearance = TASK_GROUP_APPEARANCE[group.status];
+  const duration =
+    group.endTime !== undefined
+      ? ` · ${formatDuration(group.endTime - group.startTime)}`
+      : '';
+  return {
+    key: `group:${group.id}`,
+    text: `${appearance.marker} ${safeTerminalText(label)} ${formatStreamStatusLabel(group.status, { style: 'cli' })}${duration}`,
+    tone: appearance.tone,
+    role: 'lifecycle',
+  };
+}
+
+function roundLabel(round: number, total: number | undefined): string {
+  return total === undefined
+    ? `r${round}`
+    : `r${round} (${round + 1}/${total})`;
+}
+
+/**
+ * Produce stable, one-row descriptions for the focused workflow viewport.
+ * Phase groups stay in the transcript as dividers. This summary owns run and
+ * round lifecycle, generated artifacts, and any other lifecycle group that
+ * cannot be associated safely with an indexed round.
+ */
+export function workflowRunDetailLines(
+  facts: WorkflowRunFacts | undefined,
+): WorkflowRunDetailLine[] {
+  return workflowRunDetailGroups(facts).flatMap((group) => group.lines);
+}
+
+function lifecyclePriority(
+  status: TaskGroupStatus | undefined,
+  currentRound: boolean,
+  planned: boolean,
+): number {
+  if (status === STREAM_PHASE.FAILED) return 0;
+  if (status === STREAM_PHASE.RUNNING) return 1;
+  if (currentRound) return 2;
+  if (!planned) return 3;
+  return 5;
+}
+
+function workflowRunDetailGroups(
+  facts: WorkflowRunFacts | undefined,
+): WorkflowRunDetailGroup[] {
+  if (!facts) return [];
+
+  const groups: WorkflowRunDetailGroup[] = [];
+  for (const group of facts.taskGroups) {
+    const indexedRound = group.kind === 'round' && group.index !== undefined;
+    if (group.kind !== 'phase' && !indexedRound) {
+      groups.push({
+        key: `lifecycle:${group.id}`,
+        lines: [
+          taskGroupLine(
+            group,
+            group.name || (group.kind === 'run' ? 'Workflow' : group.id),
+          ),
+        ],
+        priority: lifecyclePriority(group.status, false, false) + 1,
+        planned: false,
+      });
+    }
+  }
+
+  const roundGroups = new Map<number, TaskGroup>();
+  const rounds = new Set<number>();
+  for (const group of facts.taskGroups) {
+    const index = group.kind === 'round' ? group.index : undefined;
+    if (index === undefined) continue;
+    roundGroups.set(index, group);
+    rounds.add(index);
+    if (group.total !== undefined) {
+      for (let round = 0; round < group.total; round += 1) rounds.add(round);
+    }
+  }
+  for (const [round] of roundIndexedEntries(facts.outputFilesByRound)) {
+    rounds.add(round);
+  }
+  for (const [round] of roundIndexedEntries(facts.missingOutputsByRound)) {
+    rounds.add(round);
+  }
+  for (const [round] of roundIndexedEntries(facts.compileFailuresByRound)) {
+    rounds.add(round);
+  }
+
+  const plannedTotal = Math.max(
+    0,
+    ...[...roundGroups.values()].flatMap((group) =>
+      group.total === undefined ? [] : [group.total],
+    ),
+  );
+  const currentRound = Math.max(-1, ...roundGroups.keys());
+  for (const round of [...rounds].toSorted((left, right) => left - right)) {
+    const group = roundGroups.get(round);
+    const planned = group === undefined && round < plannedTotal;
+    const lines: WorkflowRunDetailLine[] = [];
+    if (group) {
+      lines.push(taskGroupLine(group, roundLabel(round, group.total)));
+    } else {
+      const label = planned
+        ? `${roundLabel(round, plannedTotal)} planned`
+        : `${roundLabel(round, undefined)} results`;
+      lines.push({
+        key: `round:${round}`,
+        text: `${TODO_PENDING} ${label}`,
+        tone: 'muted',
+        role: 'lifecycle',
+      });
+    }
+
+    const outputs = facts.outputFilesByRound[round] ?? [];
+    if (outputs.length > 0) {
+      lines.push({
+        key: `outputs:${round}`,
+        text: `  Generated files`,
+        tone: 'muted',
+        role: 'outputHeading',
+      });
+      for (const [index, file] of outputs.entries()) {
+        const path =
+          file.location.kind === 'external'
+            ? file.location.absolutePath
+            : file.location.relativePath;
+        const diff =
+          file.diff === null
+            ? ''
+            : ` (+${file.diff.added ?? 0} -${file.diff.removed ?? 0})`;
+        lines.push({
+          key: `output:${round}:${file.location.absolutePath}:${index}`,
+          text: `    › ${safeTerminalText(path)}${diff}`,
+          tone: 'neutral',
+          role: 'output',
+        });
+      }
+    }
+    for (const [index, path] of (
+      facts.missingOutputsByRound[round] ?? []
+    ).entries()) {
+      lines.push({
+        key: `missing:${round}:${path}:${index}`,
+        text: `  ${WARNING} r${round} · Missing expected output: ${safeTerminalText(path)}`,
+        tone: 'warning',
+        role: 'alert',
+      });
+    }
+    for (const [index, failure] of (
+      facts.compileFailuresByRound[round] ?? []
+    ).entries()) {
+      lines.push({
+        key: `compile:${round}:${failure.log.absolutePath}:${index}`,
+        text: `  ${CROSS} r${round} · Compile check failed: ${safeTerminalText(failure.displayName)} · ${safeTerminalText(failure.logRelativePath)}`,
+        tone: 'error',
+        role: 'alert',
+      });
+    }
+    groups.push({
+      key: `round:${round}`,
+      lines,
+      priority: lifecyclePriority(
+        group?.status,
+        group !== undefined && round === currentRound,
+        planned,
+      ),
+      planned,
+    });
+  }
+
+  return groups;
+}
+
+/**
+ * Select a compact, structurally valid workflow summary for a constrained
+ * viewport. Alerts and the current lifecycle receive space before future
+ * plans; an artifact is never shown without its round and section headings.
+ */
+export function selectWorkflowRunDetailLines(
+  facts: WorkflowRunFacts | undefined,
+  capacity: number,
+): WorkflowRunDetailLine[] {
+  if (capacity <= 0) return [];
+  const groups = workflowRunDetailGroups(facts);
+  const allLines = groups.flatMap((group) => group.lines);
+  if (allLines.length <= capacity) return allLines;
+
+  const selected = new Map<string, Set<number>>();
+  let remaining = capacity;
+  const rankedGroups = groups.toSorted(
+    (left, right) => left.priority - right.priority,
+  );
+  const hasLine = (group: WorkflowRunDetailGroup, index: number): boolean =>
+    selected.get(group.key)?.has(index) ?? false;
+  const addLine = (group: WorkflowRunDetailGroup, index: number): boolean => {
+    if (remaining <= 0 || hasLine(group, index)) return false;
+    const indices = selected.get(group.key) ?? new Set<number>();
+    indices.add(index);
+    selected.set(group.key, indices);
+    remaining -= 1;
+    return true;
+  };
+  const addWithLifecycle = (
+    group: WorkflowRunDetailGroup,
+    index: number,
+  ): boolean => {
+    const required = hasLine(group, 0) ? 1 : 2;
+    // Alert text carries its rN identity, so the alert remains meaningful
+    // alone when only one physical row is available.
+    if (remaining < required) return addLine(group, index);
+    addLine(group, 0);
+    return addLine(group, index);
+  };
+
+  // First preserve actionable errors, then warnings, together with their
+  // round whenever capacity permits.
+  for (const tone of ['error', 'warning'] as const) {
+    for (const group of rankedGroups) {
+      for (const [index, line] of group.lines.entries()) {
+        if (line.role === 'alert' && line.tone === tone) {
+          addWithLifecycle(group, index);
+        }
+      }
+    }
+  }
+
+  // Then retain active, failed, current, and completed lifecycle context.
+  for (const group of rankedGroups) {
+    if (!group.planned) addLine(group, 0);
+  }
+
+  // Generated paths require both their round and "Generated files" heading.
+  for (const group of rankedGroups) {
+    const headingIndex = group.lines.findIndex(
+      (line) => line.role === 'outputHeading',
+    );
+    if (headingIndex < 0) continue;
+    for (const [index, line] of group.lines.entries()) {
+      if (line.role !== 'output') continue;
+      const required =
+        (hasLine(group, 0) ? 0 : 1) +
+        (hasLine(group, headingIndex) ? 0 : 1) +
+        1;
+      if (remaining < required) break;
+      addLine(group, 0);
+      addLine(group, headingIndex);
+      addLine(group, index);
+    }
+  }
+
+  // Planned rounds are useful orientation, but never displace live evidence.
+  for (const group of rankedGroups) {
+    if (group.planned) addLine(group, 0);
+  }
+
+  return groups.flatMap((group) => {
+    const indices = selected.get(group.key);
+    return indices
+      ? group.lines.filter((_line, index) => indices.has(index))
+      : [];
+  });
+}
+
+export function WorkflowRunDetails({
+  lines,
+  width,
+}: {
+  readonly lines: readonly WorkflowRunDetailLine[];
+  readonly width?: number;
+}): React.JSX.Element {
+  return (
+    <>
+      {lines.map((line) => (
+        <Box key={line.key} height={1} overflowY="hidden" width={width}>
+          <Text color={LINE_COLORS[line.tone]} wrap="truncate-end">
+            {line.text}
+          </Text>
+        </Box>
+      ))}
+    </>
+  );
+}

--- a/packages/cli/src/chat/tui/panes/WorkflowRunDetails.tsx
+++ b/packages/cli/src/chat/tui/panes/WorkflowRunDetails.tsx
@@ -95,18 +95,6 @@ function roundLabel(round: number, total: number | undefined): string {
     : `r${round} (${round + 1}/${total})`;
 }
 
-/**
- * Produce stable, one-row descriptions for the focused workflow viewport.
- * Phase groups stay in the transcript as dividers. This summary owns run and
- * round lifecycle, generated artifacts, and any other lifecycle group that
- * cannot be associated safely with an indexed round.
- */
-export function workflowRunDetailLines(
-  facts: WorkflowRunFacts | undefined,
-): WorkflowRunDetailLine[] {
-  return workflowRunDetailGroups(facts).flatMap((group) => group.lines);
-}
-
 function lifecyclePriority(
   status: TaskGroupStatus | undefined,
   currentRound: boolean,

--- a/packages/cli/src/chat/tui/panes/transcriptViewport.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptViewport.ts
@@ -30,7 +30,7 @@ export function estimateTranscriptEntryRows(
   );
 }
 
-function estimateLiveTranscriptEntryRows(
+export function estimateLiveTranscriptEntryRows(
   entry: ConversationEntry,
   width?: number,
   executionLabels?: ExecutionLabels,

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -107,6 +107,7 @@ import {
   stoppedFocusedChildFollowUpMessage as focusedChildStoppedMessage,
   type FocusedChildFollowUpRoute,
 } from './state/focusedChildFollowUp';
+import { subscribeStreamArtifacts } from './state/subscribeStreamArtifacts';
 import { subscribeStreamLog } from './state/subscribeStreamLog';
 import { subscribeStreamStatus } from './state/subscribeStreamStatus';
 import { discoverTerminalCapabilities } from './state/terminalCapabilities';
@@ -434,6 +435,7 @@ export async function runChat(
   const terminalTitleUpdates = installTerminalTitleUpdates(context.cwd);
   disposers.push(terminalTitleUpdates.dispose);
   disposers.push(subscribeStreamLog());
+  disposers.push(subscribeStreamArtifacts(snapshotStore));
   disposers.push(subscribeStreamStatus());
 
   const session: TuiSession = {

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -9,6 +9,7 @@ import type { CliApiMode } from '@cli/runtime/apiAccessMode';
 import type { RunModelDecisionReason } from '@model/runModelDecision';
 import {
   AgentCategory,
+  type CompileFailure,
   type ConversationProgress,
   type MessageType,
   type NormalizedToolUse,
@@ -20,6 +21,7 @@ import {
   type StreamPhase,
   type StreamSubstate,
   type StreamTabId,
+  type TaskGroup,
   type TodoItem,
   type TokenUsageStats,
   type WorkflowTaskProgress,
@@ -153,8 +155,12 @@ export interface StreamSlice {
   /** Normalized run files received with `run.config`. Absent until that fact
    *  arrives; each category may then be empty. */
   readonly files?: StreamFileMetadata | undefined;
-  /** Canonical streamed workflow outputs, preserving every announced round. */
-  readonly outputFilesByRound?: RoundIndexed<OutputFileInfo> | undefined;
+  /** Canonical workflow artifacts, merged from live facts and durable sidecars. */
+  readonly outputFilesByRound: RoundIndexed<OutputFileInfo>;
+  readonly missingOutputsByRound: RoundIndexed<string>;
+  readonly compileFailuresByRound: RoundIndexed<CompileFailure>;
+  /** Run/round/phase lifecycle projected from the canonical StreamLog. */
+  readonly taskGroups: readonly TaskGroup[];
   readonly status: StreamPhase | undefined;
   readonly substate?: StreamSubstate;
   /** Epoch ms when this stream last entered `RUNNING`; cleared on any other
@@ -225,7 +231,10 @@ function emptySlice(streamId: StreamTabId): StreamSlice {
     substate: undefined,
     runStartedAt: undefined,
     description: undefined,
-    outputFilesByRound: undefined,
+    outputFilesByRound: {},
+    missingOutputsByRound: {},
+    compileFailuresByRound: {},
+    taskGroups: [],
     thinkingActive: false,
     compactingActive: false,
     usage: undefined,
@@ -252,6 +261,36 @@ function emptySlice(streamId: StreamTabId): StreamSlice {
 
 const STREAMS = signal<ReadonlyMap<StreamTabId, StreamSlice>>(new Map());
 const RETIRED_STREAMS = new Set<StreamTabId>();
+const STREAM_ARTIFACT_REVISIONS = new Map<
+  StreamTabId,
+  StreamArtifactRevision
+>();
+
+/**
+ * Source revisions for destructive artifact mutations that cannot be encoded
+ * by spreading a round-indexed value over a cold snapshot.
+ */
+export interface StreamArtifactRevision {
+  readonly missingOutputsReset: number;
+}
+
+/** Capture an immutable revision value for an asynchronous artifact read. */
+export function streamArtifactRevision(
+  streamId: StreamTabId,
+): StreamArtifactRevision {
+  return {
+    missingOutputsReset:
+      STREAM_ARTIFACT_REVISIONS.get(streamId)?.missingOutputsReset ?? 0,
+  };
+}
+
+/** Record that every persisted missing-output round before this point is stale. */
+export function recordMissingOutputsReset(streamId: StreamTabId): void {
+  const current = streamArtifactRevision(streamId);
+  STREAM_ARTIFACT_REVISIONS.set(streamId, {
+    missingOutputsReset: current.missingOutputsReset + 1,
+  });
+}
 
 /** Per-stream state map, keyed by `StreamTabId`. */
 export const streams = STREAMS;
@@ -565,6 +604,7 @@ export function bumpCodexPreferenceVersion(): void {
 // for its former children — can resurrect it.
 
 export function removeStream(streamId: StreamTabId): void {
+  STREAM_ARTIFACT_REVISIONS.delete(streamId);
   const current = streams.get();
   if (current.has(streamId)) {
     const out = new Map(current);
@@ -619,6 +659,7 @@ export function resetCliState(
 ): void {
   CLI_STATE_GENERATION += 1;
   RETIRED_STREAMS.clear();
+  STREAM_ARTIFACT_REVISIONS.clear();
   for (const streamId of streams.get().keys()) RETIRED_STREAMS.add(streamId);
   sessionMeta.set(nextSessionMeta);
   activeStreamId.set(undefined);

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -6,6 +6,7 @@ import { defaultSession } from '@agent/runtime/SessionHandle';
 import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import {
   type ActiveChildInfo,
+  type ClearMissingOutputsPayload,
   type GoalPausedPayload,
   type SetActiveStreamPayload,
   type StreamTabId,
@@ -14,13 +15,15 @@ import {
   type UpdateRoundStagePayload,
   type UpdateStreamUsagePayload,
 } from '@shared/schemas';
+import type { StreamSnapshotStore } from '@transcript';
 import { assertNever } from '@utils/core';
 
 import {
   activeStreamId,
   getCliStateGeneration,
-  removeStream,
   patchStream,
+  recordMissingOutputsReset,
+  removeStream,
   registerCliStateResetHook,
 } from './cliState';
 import {
@@ -165,6 +168,30 @@ function applyOutputFiles(
   });
 }
 
+function applyMissingOutputs(
+  event: Extract<AgentEvent, { type: 'updateMissingOutputs' }>,
+): void {
+  patchStream(event.streamId, (s) => ({
+    ...s,
+    missingOutputsByRound: {
+      ...s.missingOutputsByRound,
+      ...event.filesByRound,
+    },
+  }));
+}
+
+function applyCompileFailures(
+  event: Extract<AgentEvent, { type: 'updateCompileFailures' }>,
+): void {
+  patchStream(event.streamId, (s) => ({
+    ...s,
+    compileFailuresByRound: {
+      ...s.compileFailuresByRound,
+      ...event.filesByRound,
+    },
+  }));
+}
+
 function applyActiveSubagents(payload: {
   parentStreamId: StreamTabId;
   children: readonly ActiveChildInfo[];
@@ -177,6 +204,34 @@ function applyParentStream(payload: {
   parentStreamId: StreamTabId | null;
 }): void {
   setParentStream(payload.childStreamId, payload.parentStreamId);
+}
+
+type MissingOutputTargetResolver = Pick<
+  StreamSnapshotStore,
+  'findWorkflowStreamsMatching'
+>;
+
+function applyClearMissingOutputs(
+  payload: ClearMissingOutputsPayload,
+  targetResolver: MissingOutputTargetResolver | undefined,
+): void {
+  let targets: readonly StreamTabId[] = [];
+  if (payload.streamId) {
+    targets = [payload.streamId];
+  } else if (payload.streamConfig && targetResolver) {
+    targets = targetResolver.findWorkflowStreamsMatching(payload.streamConfig);
+  }
+  for (const streamId of targets) {
+    // The empty map is a destructive reset, not a round patch. Record its
+    // source revision even when the current map is already empty so a cold
+    // read that started before this fact cannot restore older disk warnings.
+    recordMissingOutputsReset(streamId);
+    patchStream(streamId, (slice) =>
+      Object.keys(slice.missingOutputsByRound).length === 0
+        ? slice
+        : { ...slice, missingOutputsByRound: {} },
+    );
+  }
 }
 
 function applyDirectTuiRunEvent(
@@ -215,8 +270,11 @@ function applyDirectTuiRunEvent(
       applyOutputFiles(event);
       return true;
     case 'updateMissingOutputs':
+      applyMissingOutputs(event);
+      return true;
     case 'updateCompileFailures':
-      return false;
+      applyCompileFailures(event);
+      return true;
     case 'stage.start':
       if (event.kind === 'phase') {
         applyPhaseStage({
@@ -270,6 +328,7 @@ function refreshQueuedFollowUps(
 
 export function attachTuiRunFactSubscription(
   events: SessionEventHub,
+  missingOutputTargets?: MissingOutputTargetResolver,
 ): () => void {
   let generation = getCliStateGeneration();
   const detachResetHook = registerCliStateResetHook(() => {
@@ -309,8 +368,10 @@ export function attachTuiRunFactSubscription(
           return;
         case 'goalStateChanged':
         case 'inquiryThreadUpdated':
-        case 'clearMissingOutputs':
         case 'updateStreamStatus':
+          return;
+        case 'clearMissingOutputs':
+          applyClearMissingOutputs(fact.payload, missingOutputTargets);
           return;
       }
       assertNever(fact, 'Unhandled TUI session fact');

--- a/packages/cli/src/chat/tui/state/subscribeStreamArtifacts.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamArtifacts.ts
@@ -33,8 +33,10 @@ export type StreamArtifactReader = Pick<
 function streamCanReceiveArtifacts(
   streamId: StreamTabId,
   generation: number,
+  focusIsCurrent: () => boolean,
 ): boolean {
   return (
+    focusIsCurrent() &&
     generation === getCliStateGeneration() &&
     activeStreamId.get() === streamId &&
     !isCliStreamRetired(streamId) &&
@@ -75,6 +77,7 @@ function mergeArtifactSnapshot(
 async function hydrateFocusedStream(
   store: StreamArtifactReader,
   streamId: StreamTabId,
+  focusIsCurrent: () => boolean,
 ): Promise<void> {
   const generation = getCliStateGeneration();
   const artifactRevision = streamArtifactRevision(streamId);
@@ -83,10 +86,14 @@ async function hydrateFocusedStream(
     // claim an authoritative complete stream set and evict sibling state.
     await store.preload([streamId]);
     const snapshot = await store.read(streamId);
-    if (!streamCanReceiveArtifacts(streamId, generation)) return;
+    if (!streamCanReceiveArtifacts(streamId, generation, focusIsCurrent)) {
+      return;
+    }
     mergeArtifactSnapshot(streamId, snapshot, artifactRevision);
   } catch (error) {
-    if (!streamCanReceiveArtifacts(streamId, generation)) return;
+    if (!streamCanReceiveArtifacts(streamId, generation, focusIsCurrent)) {
+      return;
+    }
     setTransientNotice(
       `Could not load workflow artifacts: ${toErrorMessage(error)}`,
     );
@@ -104,13 +111,26 @@ export function subscribeStreamArtifacts(
   store: StreamArtifactReader,
 ): () => void {
   let previous = activeStreamId.get();
-  if (previous) void hydrateFocusedStream(store, previous);
+  let focusRevision = 0;
+  const hydrate = (streamId: StreamTabId): void => {
+    const revision = ++focusRevision;
+    void hydrateFocusedStream(
+      store,
+      streamId,
+      () => focusRevision === revision,
+    );
+  };
+  if (previous) hydrate(previous);
 
   return subscribeToSignalChanges([activeStreamId], () => {
     const next = activeStreamId.get();
     const changed = next !== previous;
     previous = next;
-    if (!next || !changed) return;
-    void hydrateFocusedStream(store, next);
+    if (!changed) return;
+    if (!next) {
+      focusRevision += 1;
+      return;
+    }
+    hydrate(next);
   });
 }

--- a/packages/cli/src/chat/tui/state/subscribeStreamArtifacts.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamArtifacts.ts
@@ -1,0 +1,116 @@
+// Restore durable workflow artifacts when a stream becomes focused.
+//
+// Live run facts and the snapshot store share the same round-indexed shape.
+// The focused-stream load therefore merges once at this boundary, with newer
+// live rounds taking precedence over the disk snapshot.
+
+import type { StreamTabId, StreamSnapshot } from '@shared/schemas';
+import type { StreamSnapshotStore } from '@transcript';
+import { toErrorMessage } from '@utils/errors/errorMessage';
+
+import {
+  activeStreamId,
+  getCliStateGeneration,
+  isCliStreamRetired,
+  patchStream,
+  setTransientNotice,
+  streamArtifactRevision,
+  type StreamArtifactRevision,
+} from './cliState';
+import { isChildStreamRemoved } from './childExecutions';
+import { subscribeToSignalChanges } from './signalSubscription';
+
+type StreamArtifactSnapshot = Pick<
+  StreamSnapshot,
+  'outputFilesByRound' | 'missingOutputsByRound' | 'compileFailuresByRound'
+>;
+
+export type StreamArtifactReader = Pick<
+  StreamSnapshotStore,
+  'preload' | 'read'
+>;
+
+function streamCanReceiveArtifacts(
+  streamId: StreamTabId,
+  generation: number,
+): boolean {
+  return (
+    generation === getCliStateGeneration() &&
+    activeStreamId.get() === streamId &&
+    !isCliStreamRetired(streamId) &&
+    !isChildStreamRemoved(streamId)
+  );
+}
+
+function mergeArtifactSnapshot(
+  streamId: StreamTabId,
+  snapshot: StreamArtifactSnapshot,
+  revisionAtStart: StreamArtifactRevision,
+): void {
+  const currentRevision = streamArtifactRevision(streamId);
+  patchStream(streamId, (slice) => {
+    const missingOutputsByRound =
+      currentRevision.missingOutputsReset ===
+      revisionAtStart.missingOutputsReset
+        ? {
+            ...snapshot.missingOutputsByRound,
+            ...slice.missingOutputsByRound,
+          }
+        : slice.missingOutputsByRound;
+    return {
+      ...slice,
+      outputFilesByRound: {
+        ...snapshot.outputFilesByRound,
+        ...slice.outputFilesByRound,
+      },
+      missingOutputsByRound,
+      compileFailuresByRound: {
+        ...snapshot.compileFailuresByRound,
+        ...slice.compileFailuresByRound,
+      },
+    };
+  });
+}
+
+async function hydrateFocusedStream(
+  store: StreamArtifactReader,
+  streamId: StreamTabId,
+): Promise<void> {
+  const generation = getCliStateGeneration();
+  const artifactRevision = streamArtifactRevision(streamId);
+  try {
+    // `preload` warms only this stream. `load([streamId])` would incorrectly
+    // claim an authoritative complete stream set and evict sibling state.
+    await store.preload([streamId]);
+    const snapshot = await store.read(streamId);
+    if (!streamCanReceiveArtifacts(streamId, generation)) return;
+    mergeArtifactSnapshot(streamId, snapshot, artifactRevision);
+  } catch (error) {
+    if (!streamCanReceiveArtifacts(streamId, generation)) return;
+    setTransientNotice(
+      `Could not load workflow artifacts: ${toErrorMessage(error)}`,
+    );
+  }
+}
+
+/**
+ * Hydrate artifacts for the initial and subsequently focused streams.
+ *
+ * A late disk read cannot resurrect a retired/removed stream. If focus moves
+ * while I/O is pending, the stale result is discarded; returning to that
+ * stream starts a fresh read.
+ */
+export function subscribeStreamArtifacts(
+  store: StreamArtifactReader,
+): () => void {
+  let previous = activeStreamId.get();
+  if (previous) void hydrateFocusedStream(store, previous);
+
+  return subscribeToSignalChanges([activeStreamId], () => {
+    const next = activeStreamId.get();
+    const changed = next !== previous;
+    previous = next;
+    if (!next || !changed) return;
+    void hydrateFocusedStream(store, next);
+  });
+}

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -29,6 +29,7 @@ import {
 import { normalizeToolUseData } from '@shared/toolUse';
 import { formatWorkflowTaskLine } from '@shared/copy/workflowTask';
 import { isActivePhase } from '@shared/streams/streamStatus';
+import { projectTaskGroupsFromStreamLog } from '@shared/streams/taskGroupProjection';
 import { createFlushableDebounce } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { truncateSummary } from '@utils/text/stringUtils';
@@ -245,8 +246,7 @@ function entriesEqual(
  * A phase group header — the `stage.start`/`stage.end` rows a workflow-script
  * run emits per `phase()` (recorded as GROUP_START then upserted in place to
  * GROUP_END with `data.kind === 'phase'`). Detected by `kind`, not entry
- * `type`, so the header keeps its distinct role after the phase closes. Round,
- * run, and session groups (other `kind` values) fall through to plain rows.
+ * `type`, so the header keeps its distinct role after the phase closes.
  */
 function phaseGroupData(
   entry: StreamLogEntry,
@@ -418,11 +418,28 @@ function renderLogEntry(
     return prev && entriesEqual(prev, next) ? prev : next;
   }
 
+  // Run/round/session lifecycle rows are projected into `taskGroups`, whose
+  // focused workflow renderer joins them with artifacts. They are not prose
+  // and must not also appear as assistant transcript rows.
+  if (
+    entry.type === STREAM_LOG_ENTRY_TYPES.GROUP_START ||
+    entry.type === STREAM_LOG_ENTRY_TYPES.GROUP_END
+  ) {
+    return null;
+  }
+
   const text = entry.text ?? '';
   const role = logEntryRole(entry.messageType);
   const assistantTranscript =
     role === 'assistant' ? trimAssistantTranscriptLead(text) : undefined;
-  const renderedText = renderLogEntryText(role, text, entry.data);
+  let renderedText = renderLogEntryText(role, text, entry.data);
+  if (
+    role === 'assistant' &&
+    entry.messageType === MESSAGE_TYPES.DEFAULT &&
+    entry.type === STREAM_LOG_ENTRY_TYPES.LOG
+  ) {
+    renderedText = redactSecrets(safeTerminalText(renderedText));
+  }
   // Assistant text is promoted by `finalizeSettledPrefix` once the model
   // moves on to a later entry; inherit the prior flag here so a re-sync
   // can't de-finalize an already-promoted block. User/error rows can't
@@ -647,6 +664,7 @@ export function syncStreamLog(
   if (!log) return;
 
   const allEntries = log.getRange(0);
+  const taskGroups = projectTaskGroupsFromStreamLog(allEntries);
   const thinkingActive = latestLogActivityIsThinking(allEntries);
   const compactingActive = latestCompactionActivityIsRunning(allEntries);
   const transcriptMessageTypes = transcriptMessageTypesForStream(streamId);
@@ -676,10 +694,16 @@ export function syncStreamLog(
     for (const entry of allEntries) {
       const messageType = entry.messageType ?? '';
       const transcriptCandidate = transcriptMessageTypes.has(messageType);
-      if (
-        !transcriptCandidate &&
-        (!workflowOperationalOnly || messageType !== MESSAGE_TYPES.DEFAULT)
-      ) {
+      const workflowDefaultLog =
+        workflowOperationalOnly &&
+        entry.type === STREAM_LOG_ENTRY_TYPES.LOG &&
+        entry.level !== 'debug' &&
+        messageType === MESSAGE_TYPES.DEFAULT;
+      const workflowPhaseHeader =
+        workflowOperationalOnly &&
+        messageType === MESSAGE_TYPES.DEFAULT &&
+        phaseGroupData(entry) !== null;
+      if (!transcriptCandidate && !workflowDefaultLog && !workflowPhaseHeader) {
         continue;
       }
       const rendered = renderLogEntry(entry, existing.get(entry.id));
@@ -695,17 +719,15 @@ export function syncStreamLog(
       // transcript. Detached workflow-script runs intentionally keep their
       // full child log, including Running/Finished and error rows. A phase
       // uses the DEFAULT message type, but remains an operational row.
-      if (
-        !transcriptCandidate &&
-        !(workflowOperationalOnly && rendered.role === 'phase')
-      ) {
+      if (!transcriptCandidate && !workflowDefaultLog && !workflowPhaseHeader) {
         continue;
       }
       if (
         workflowOperationalOnly &&
         rendered.role !== 'tool' &&
         rendered.role !== 'phase' &&
-        rendered.role !== 'error'
+        rendered.role !== 'error' &&
+        !workflowDefaultLog
       ) {
         continue;
       }
@@ -771,7 +793,8 @@ export function syncStreamLog(
         ) &&
         slice.description === description &&
         slice.thinkingActive === thinkingActive &&
-        slice.compactingActive === compactingActive
+        slice.compactingActive === compactingActive &&
+        isDeepStrictEqual(slice.taskGroups, taskGroups)
       ) {
         return slice;
       }
@@ -781,6 +804,7 @@ export function syncStreamLog(
         entries: compactEntries,
         thinkingActive,
         compactingActive,
+        taskGroups,
       };
     }
 
@@ -798,7 +822,8 @@ export function syncStreamLog(
       !changed &&
       slice.description === description &&
       slice.thinkingActive === thinkingActive &&
-      slice.compactingActive === compactingActive
+      slice.compactingActive === compactingActive &&
+      isDeepStrictEqual(slice.taskGroups, taskGroups)
     ) {
       return slice;
     }
@@ -808,6 +833,7 @@ export function syncStreamLog(
       entries: next,
       thinkingActive,
       compactingActive,
+      taskGroups,
     };
   });
 

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -326,6 +326,7 @@ function computeFinalized(
 function renderLogEntry(
   entry: StreamLogEntry,
   prev: ConversationEntry | undefined,
+  projectLifecycleToTaskGroups: boolean,
 ): ConversationEntry | null {
   if (entry.messageType === MESSAGE_TYPES.TOOL_USE) {
     // Cache hit: same `data` reference as last sync, no re-normalize.
@@ -418,12 +419,13 @@ function renderLogEntry(
     return prev && entriesEqual(prev, next) ? prev : next;
   }
 
-  // Run/round/session lifecycle rows are projected into `taskGroups`, whose
-  // focused workflow renderer joins them with artifacts. They are not prose
-  // and must not also appear as assistant transcript rows.
+  // Workflow run/round/session lifecycle rows are projected into `taskGroups`,
+  // whose focused renderer joins them with artifacts. Other full-log children
+  // have no such renderer, so their lifecycle headings remain transcript rows.
   if (
-    entry.type === STREAM_LOG_ENTRY_TYPES.GROUP_START ||
-    entry.type === STREAM_LOG_ENTRY_TYPES.GROUP_END
+    projectLifecycleToTaskGroups &&
+    (entry.type === STREAM_LOG_ENTRY_TYPES.GROUP_START ||
+      entry.type === STREAM_LOG_ENTRY_TYPES.GROUP_END)
   ) {
     return null;
   }
@@ -706,7 +708,11 @@ export function syncStreamLog(
       if (!transcriptCandidate && !workflowDefaultLog && !workflowPhaseHeader) {
         continue;
       }
-      const rendered = renderLogEntry(entry, existing.get(entry.id));
+      const rendered = renderLogEntry(
+        entry,
+        existing.get(entry.id),
+        slice.category === AgentCategory.Workflow,
+      );
       if (!rendered) continue;
       if (workflowOperationalOnly) {
         workflowDescriptionCandidates.push({
@@ -719,9 +725,6 @@ export function syncStreamLog(
       // transcript. Detached workflow-script runs intentionally keep their
       // full child log, including Running/Finished and error rows. A phase
       // uses the DEFAULT message type, but remains an operational row.
-      if (!transcriptCandidate && !workflowDefaultLog && !workflowPhaseHeader) {
-        continue;
-      }
       if (
         workflowOperationalOnly &&
         rendered.role !== 'tool' &&

--- a/packages/extension/src/progressView/frontend/slices/logSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/logSlice.ts
@@ -3,53 +3,18 @@ import { create } from 'mutative';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import {
   ContextStateDataSchema,
-  END_GROUP_STATUS,
-  GroupLogPayloadSchema,
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
-  STREAM_PHASE,
-  TaskGroupStatusSchema,
   type ContextStateData,
-  type EndGroupStatus,
   type LogMessageData,
   type ProgressViewOutboundHandlerRegistry,
   type StreamLogEntry,
   type StreamLogTextDelta,
-  type TaskGroupStatus,
 } from '@shared/schemas';
+import { upsertTaskGroupFromStreamLog } from '@shared/streams/taskGroupProjection';
 
 import { appState } from '../progressState';
 import type { StreamLogs, StreamState } from '../store';
-
-/**
- * A `GROUP_END` row's `data.status` carries either the native `TaskGroupStatus`
- * (the `StreamPhase` running/completed/cancelled/failed subset) every
- * live/persisted producer writes (§8.2, #7993 step 3's reader retype), or
- * the legacy 2-value `EndGroupStatus` a pre-cutover exported trace file's
- * raw entries still carry — the standalone trace-viewer's `replayTrace()`
- * forwards `trace.entries` verbatim into this same `LOG_DELTA` pipeline, a
- * permanent second boundary (docs/proposals/session-scoped-runtime-
- * architecture.md §8.3). `GroupLogPayloadSchema.status` already validated
- * `value` against the union of both vocabularies upstream, so the native
- * arm here is a `safeParse`-based narrow rather than a hand-rolled type
- * guard; the legacy arm maps a value UP to the same native value
- * `StreamLogStore.parsePersistedEntries` produces for the same on-disk
- * string (`'stopped'` -> `completed`, the documented lossy default; `'error'`
- * -> `failed`) so a task group renders identically whether it arrived live,
- * from a rehydrated stream, or forwarded raw by the trace-viewer. A value
- * that is neither vocabulary (malformed data) falls back to the
- * caller-supplied default, as before.
- */
-function taskGroupEndStatus(
-  value: TaskGroupStatus | EndGroupStatus | undefined,
-  fallback: TaskGroupStatus,
-): TaskGroupStatus {
-  const native = TaskGroupStatusSchema.safeParse(value);
-  if (native.success) return native.data;
-  if (value === END_GROUP_STATUS.STOPPED) return STREAM_PHASE.COMPLETED;
-  if (value === END_GROUP_STATUS.ERROR) return STREAM_PHASE.FAILED;
-  return fallback;
-}
 
 function asContextStateData(data: unknown): ContextStateData | undefined {
   return ContextStateDataSchema.optional().catch(undefined).parse(data);
@@ -68,80 +33,6 @@ function toLogMessage(entry: StreamLogEntry): LogMessageData {
   };
 }
 
-function updateTaskGroups(
-  streamState: StreamState,
-  taskGroupIndex: Map<string, number>,
-  entry: StreamLogEntry,
-): boolean {
-  const payload = GroupLogPayloadSchema.catch({}).parse(entry.data);
-  const cachedIndex = taskGroupIndex.get(entry.id);
-  const groupIndex =
-    cachedIndex !== undefined &&
-    streamState.taskGroups[cachedIndex]?.id === entry.id
-      ? cachedIndex
-      : streamState.taskGroups.findIndex((g) => g.id === entry.id);
-
-  if (groupIndex >= 0 && groupIndex !== cachedIndex) {
-    taskGroupIndex.set(entry.id, groupIndex);
-  }
-
-  if (entry.type === STREAM_LOG_ENTRY_TYPES.GROUP_START) {
-    // `GROUP_START` only ever carries the native `TaskGroupStatus`
-    // vocabulary (never the legacy `EndGroupStatus` — a run hasn't ended
-    // yet), so narrow rather than fold.
-    const startStatus = TaskGroupStatusSchema.safeParse(payload.status);
-    const nextGroup = {
-      id: entry.id,
-      name: entry.text ?? payload.name ?? entry.id,
-      startTime: entry.timestamp,
-      status: startStatus.success ? startStatus.data : STREAM_PHASE.RUNNING,
-      ...(entry.groupId ? { parentGroupId: entry.groupId } : {}),
-      ...(payload.kind ? { kind: payload.kind } : {}),
-      ...(payload.index !== undefined ? { index: payload.index } : {}),
-      ...(payload.total !== undefined ? { total: payload.total } : {}),
-    };
-
-    if (groupIndex === -1) {
-      taskGroupIndex.set(entry.id, streamState.taskGroups.length);
-      streamState.taskGroups.push(nextGroup);
-    } else {
-      streamState.taskGroups[groupIndex] = nextGroup;
-    }
-    return true;
-  }
-
-  if (entry.type !== STREAM_LOG_ENTRY_TYPES.GROUP_END) {
-    return false;
-  }
-
-  const status = taskGroupEndStatus(payload.status, STREAM_PHASE.COMPLETED);
-  const endTime = payload.endTime;
-
-  if (groupIndex === -1) {
-    taskGroupIndex.set(entry.id, streamState.taskGroups.length);
-    streamState.taskGroups.push({
-      id: entry.id,
-      name: entry.text ?? entry.id,
-      startTime: entry.timestamp,
-      status,
-      ...(entry.groupId ? { parentGroupId: entry.groupId } : {}),
-      ...(payload.kind ? { kind: payload.kind } : {}),
-      ...(payload.index !== undefined ? { index: payload.index } : {}),
-      ...(payload.total !== undefined ? { total: payload.total } : {}),
-      ...(endTime !== undefined ? { endTime } : {}),
-    });
-  } else {
-    const current = streamState.taskGroups[groupIndex];
-    streamState.taskGroups[groupIndex] = {
-      ...current,
-      status,
-      ...(endTime !== undefined ? { endTime } : {}),
-    };
-  }
-
-  return true;
-}
-
 function applyEntry(
   entry: StreamLogEntry,
   streamLogs: StreamLogs,
@@ -153,8 +44,8 @@ function applyEntry(
     return { logChanged: false, stateChanged: false };
   }
 
-  let stateChanged = updateTaskGroups(
-    streamState,
+  let stateChanged = upsertTaskGroupFromStreamLog(
+    streamState.taskGroups,
     streamLogs.taskGroupIndex,
     entry,
   );

--- a/src/shared/schemas/taskGroup.ts
+++ b/src/shared/schemas/taskGroup.ts
@@ -27,10 +27,10 @@ export type TaskGroup = z.infer<typeof TaskGroupSchema>;
 /**
  * Shape of `StreamLogEntry.data` on `group-start`/`group-end` entries: a
  * partial `TaskGroup` (only the fields the producer chose to send this
- * update). Single source of truth for the frontend's group-tracking reducer
- * (`logSlice.ts`), which previously re-derived `status`/`kind` membership
- * with hand-rolled type guards duplicating `TaskGroupStatusSchema`/
- * `StageKindSchema`.
+ * update). Single source of truth for the host-neutral task-group projection
+ * (`shared/streams/taskGroupProjection.ts`), which otherwise would re-derive
+ * `status`/`kind` membership with hand-rolled type guards duplicating
+ * `TaskGroupStatusSchema`/`StageKindSchema`.
  *
  * Each field validates (and recovers via `.catch(undefined)`) independently
  * so one invalid field — e.g. an unrecognized `status` from an older/newer
@@ -48,10 +48,10 @@ export type TaskGroup = z.infer<typeof TaskGroupSchema>;
  * (docs/proposals/2026-07-03-session-scoped-runtime-architecture.md §8.3). Now that
  * `TaskGroupStatus` is itself retyped to the native vocabulary, `RunOutcome`
  * is a strict subset of it and needs no separate union member; only the
- * still-disjoint legacy `EndGroupStatus` vocabulary does. `logSlice.ts`'s
- * `taskGroupEndStatus` maps a legacy value UP to the native value it
- * corresponds to; a value in neither vocabulary still falls back to
- * `undefined` here, same as any other field.
+ * still-disjoint legacy `EndGroupStatus` vocabulary does. The shared
+ * projection maps a legacy value UP to the native value it corresponds to;
+ * a value in neither vocabulary still falls back to `undefined` here, same
+ * as any other field.
  */
 export const GroupLogPayloadSchema = z.looseObject({
   status: z

--- a/src/shared/streams/taskGroupProjection.ts
+++ b/src/shared/streams/taskGroupProjection.ts
@@ -1,0 +1,161 @@
+// Host-neutral projection of task-group lifecycle rows from a StreamLog.
+//
+// The extension applies entries incrementally as LOG_DELTA messages arrive,
+// while the CLI also needs to rebuild the same task groups from persisted
+// entries. Both paths use this module so ordering, legacy status recovery,
+// and orphan GROUP_END behavior remain identical.
+
+import {
+  END_GROUP_STATUS,
+  GroupLogPayloadSchema,
+  STREAM_LOG_ENTRY_TYPES,
+  STREAM_PHASE,
+  TaskGroupStatusSchema,
+  type EndGroupStatus,
+  type StreamLogEntry,
+  type TaskGroup,
+  type TaskGroupStatus,
+} from '@shared/schemas';
+
+/**
+ * Normalize the two status vocabularies that can occur on a GROUP_END row.
+ *
+ * Current producers write `TaskGroupStatus`. A trace exported before the
+ * status migration can still contain the legacy `EndGroupStatus`, so the
+ * read projection maps it to the same canonical value used by persistence.
+ */
+function taskGroupEndStatus(
+  value: TaskGroupStatus | EndGroupStatus | undefined,
+  fallback: TaskGroupStatus,
+): TaskGroupStatus {
+  const native = TaskGroupStatusSchema.safeParse(value);
+  if (native.success) return native.data;
+  if (value === END_GROUP_STATUS.STOPPED) return STREAM_PHASE.COMPLETED;
+  if (value === END_GROUP_STATUS.ERROR) return STREAM_PHASE.FAILED;
+  return fallback;
+}
+
+/**
+ * Recover the exact zero-based `rN` round labels written before typed stage
+ * metadata was persisted. Human-facing `Round N` labels have not had one
+ * stable indexing convention, so they remain unclassified rather than being
+ * assigned a guessed index.
+ */
+function taskGroupStageMetadata(
+  name: string,
+  kind: TaskGroup['kind'],
+  index: number | undefined,
+): Pick<TaskGroup, 'kind' | 'index'> {
+  const legacyMatch =
+    kind === undefined || kind === 'round' ? /^r(\d+)$/.exec(name) : null;
+  const inferredRoundIndex = legacyMatch
+    ? Number.parseInt(legacyMatch[1], 10)
+    : undefined;
+  const normalizedKind =
+    kind ?? (inferredRoundIndex !== undefined ? 'round' : undefined);
+  const normalizedIndex = index ?? inferredRoundIndex;
+  return {
+    ...(normalizedKind !== undefined ? { kind: normalizedKind } : {}),
+    ...(normalizedIndex !== undefined ? { index: normalizedIndex } : {}),
+  };
+}
+
+/**
+ * Apply one StreamLog entry to an existing task-group projection.
+ *
+ * Returns `true` exactly when the entry is a task-group lifecycle row. The
+ * array and index are mutated together so incremental consumers retain O(1)
+ * replacement while callers rebuilding from a complete log obtain the same
+ * result through `projectTaskGroupsFromStreamLog`.
+ */
+export function upsertTaskGroupFromStreamLog(
+  taskGroups: TaskGroup[],
+  taskGroupIndex: Map<string, number>,
+  entry: StreamLogEntry,
+): boolean {
+  if (
+    entry.type !== STREAM_LOG_ENTRY_TYPES.GROUP_START &&
+    entry.type !== STREAM_LOG_ENTRY_TYPES.GROUP_END
+  ) {
+    return false;
+  }
+
+  const payload = GroupLogPayloadSchema.catch({}).parse(entry.data);
+  const cachedIndex = taskGroupIndex.get(entry.id);
+  const groupIndex =
+    cachedIndex !== undefined && taskGroups[cachedIndex]?.id === entry.id
+      ? cachedIndex
+      : taskGroups.findIndex((group) => group.id === entry.id);
+
+  if (groupIndex >= 0 && groupIndex !== cachedIndex) {
+    taskGroupIndex.set(entry.id, groupIndex);
+  }
+
+  if (entry.type === STREAM_LOG_ENTRY_TYPES.GROUP_START) {
+    // GROUP_START only carries the native status vocabulary because the run
+    // has not ended. Invalid or absent values therefore mean "running".
+    const startStatus = TaskGroupStatusSchema.safeParse(payload.status);
+    const name = entry.text ?? payload.name ?? entry.id;
+    const nextGroup: TaskGroup = {
+      id: entry.id,
+      name,
+      startTime: entry.timestamp,
+      status: startStatus.success ? startStatus.data : STREAM_PHASE.RUNNING,
+      ...(entry.groupId ? { parentGroupId: entry.groupId } : {}),
+      ...taskGroupStageMetadata(name, payload.kind, payload.index),
+      ...(payload.total !== undefined ? { total: payload.total } : {}),
+    };
+
+    if (groupIndex === -1) {
+      taskGroupIndex.set(entry.id, taskGroups.length);
+      taskGroups.push(nextGroup);
+    } else {
+      taskGroups[groupIndex] = nextGroup;
+    }
+    return true;
+  }
+
+  const status = taskGroupEndStatus(payload.status, STREAM_PHASE.COMPLETED);
+  const endTime = payload.endTime;
+
+  if (groupIndex === -1) {
+    const name = entry.text ?? entry.id;
+    taskGroupIndex.set(entry.id, taskGroups.length);
+    taskGroups.push({
+      id: entry.id,
+      name,
+      startTime: entry.timestamp,
+      status,
+      ...(entry.groupId ? { parentGroupId: entry.groupId } : {}),
+      ...taskGroupStageMetadata(name, payload.kind, payload.index),
+      ...(payload.total !== undefined ? { total: payload.total } : {}),
+      ...(endTime !== undefined ? { endTime } : {}),
+    });
+  } else {
+    const current = taskGroups[groupIndex];
+    taskGroups[groupIndex] = {
+      ...current,
+      status,
+      ...(endTime !== undefined ? { endTime } : {}),
+    };
+  }
+
+  return true;
+}
+
+/**
+ * Project canonical task groups from a complete or partial StreamLog.
+ *
+ * Entries are applied in iteration order. Later rows with the same group ID
+ * replace or complete earlier rows, matching the extension's live reducer.
+ */
+export function projectTaskGroupsFromStreamLog(
+  entries: Iterable<StreamLogEntry>,
+): TaskGroup[] {
+  const taskGroups: TaskGroup[] = [];
+  const taskGroupIndex = new Map<string, number>();
+  for (const entry of entries) {
+    upsertTaskGroupFromStreamLog(taskGroups, taskGroupIndex, entry);
+  }
+  return taskGroups;
+}

--- a/src/test-kernel/cli/ChildControls.vitest.mts
+++ b/src/test-kernel/cli/ChildControls.vitest.mts
@@ -36,6 +36,10 @@ function slice(overrides: Partial<StreamSlice> = {}): StreamSlice {
     plan: null,
     bypass: NO_BYPASS,
     ...overrides,
+    outputFilesByRound: overrides.outputFilesByRound ?? {},
+    missingOutputsByRound: overrides.missingOutputsByRound ?? {},
+    compileFailuresByRound: overrides.compileFailuresByRound ?? {},
+    taskGroups: overrides.taskGroups ?? [],
   };
 }
 

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -1492,6 +1492,10 @@ function sliceWithEntries(
     plan: null,
     bypass: { bash: false, toolEdit: false, superYolo: false },
     ...init,
+    outputFilesByRound: init.outputFilesByRound ?? {},
+    missingOutputsByRound: init.missingOutputsByRound ?? {},
+    compileFailuresByRound: init.compileFailuresByRound ?? {},
+    taskGroups: init.taskGroups ?? [],
   };
 }
 

--- a/src/test-kernel/cli/ConversationPane.vitest.mts
+++ b/src/test-kernel/cli/ConversationPane.vitest.mts
@@ -30,6 +30,7 @@ import {
   type TuiRepaintOptions,
 } from '@cli/chat/tui/render/tuiViewportController';
 import {
+  estimateLiveTranscriptEntryRows,
   estimateTranscriptEntryRows,
   selectTranscriptEntriesForViewport,
 } from '@cli/chat/tui/panes/transcriptViewport';
@@ -399,6 +400,7 @@ describe('CLI conversation transcript splitting', () => {
       width,
     );
 
+    expect(estimateLiveTranscriptEntryRows(assistant, width)).toBe(liveRows);
     expect(selected.usedRows).toBe(liveRows);
     expect(selected.rowLimits.has('a1')).toBe(false);
   });
@@ -503,6 +505,9 @@ describe('CLI conversation transcript splitting', () => {
     });
 
     expect(liveLayout.lines).toHaveLength(2);
+    expect(estimateTranscriptEntryRows(tool, 20)).toBeGreaterThan(
+      estimateLiveTranscriptEntryRows(tool, 20),
+    );
     expect(selectTranscriptEntriesForViewport([tool], 20, 20).usedRows).toBe(
       transcriptEntryLayoutRows(liveLayout),
     );

--- a/src/test-kernel/cli/ResumeHint.vitest.mts
+++ b/src/test-kernel/cli/ResumeHint.vitest.mts
@@ -35,6 +35,10 @@ function makeSlice(
     bypass: NO_BYPASS,
     ...over,
     streamId: over.streamId as StreamTabId,
+    outputFilesByRound: over.outputFilesByRound ?? {},
+    missingOutputsByRound: over.missingOutputsByRound ?? {},
+    compileFailuresByRound: over.compileFailuresByRound ?? {},
+    taskGroups: over.taskGroups ?? [],
   };
 }
 

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -71,6 +71,10 @@ function workflowAgentSlice(
     plan: null,
     bypass: { bash: false, toolEdit: false, superYolo: false },
     ...overrides,
+    outputFilesByRound: overrides.outputFilesByRound ?? {},
+    missingOutputsByRound: overrides.missingOutputsByRound ?? {},
+    compileFailuresByRound: overrides.compileFailuresByRound ?? {},
+    taskGroups: overrides.taskGroups ?? [],
   };
 }
 

--- a/src/test-kernel/cli/SubscribeStreamArtifacts.vitest.mts
+++ b/src/test-kernel/cli/SubscribeStreamArtifacts.vitest.mts
@@ -1,0 +1,199 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { SessionEventHub } from '@agent/runtime/SessionEventHub';
+import {
+  activeStreamId,
+  patchStream,
+  removeStream,
+  resetCliState,
+  streams,
+} from '@cli/chat/tui/state/cliState';
+import {
+  subscribeStreamArtifacts,
+  type StreamArtifactReader,
+} from '@cli/chat/tui/state/subscribeStreamArtifacts';
+import { attachTuiRunFactSubscription } from '@cli/chat/tui/state/subscribeRuntimeHost';
+import type { StreamSnapshot, StreamTabId } from '@shared/schemas';
+
+const STREAM_A = 'workflow#a' as StreamTabId;
+const STREAM_B = 'workflow#b' as StreamTabId;
+
+function snapshot(
+  streamId: StreamTabId,
+  artifacts: Pick<
+    StreamSnapshot,
+    'outputFilesByRound' | 'missingOutputsByRound' | 'compileFailuresByRound'
+  >,
+): StreamSnapshot {
+  return {
+    schemaVersion: 1,
+    streamId,
+    todos: [],
+    plan: null,
+    planSummary: null,
+    runUsage: {},
+    conversationProgress: { toolCallCount: 0 },
+    subagents: [],
+    ...artifacts,
+  };
+}
+
+async function flushSignals(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+afterEach(() => {
+  resetCliState();
+});
+
+describe('subscribeStreamArtifacts', () => {
+  it('preloads the focused stream and lets newer live rounds win', async () => {
+    let resolveRead: (value: StreamSnapshot) => void = () => undefined;
+    const readPromise = new Promise<StreamSnapshot>((resolve) => {
+      resolveRead = resolve;
+    });
+    const reader = {
+      preload: vi.fn(async () => undefined),
+      read: vi.fn(() => readPromise),
+    } as StreamArtifactReader;
+
+    patchStream(STREAM_A, (slice) => slice);
+    activeStreamId.set(STREAM_A);
+    const dispose = subscribeStreamArtifacts(reader);
+    await flushSignals();
+
+    patchStream(STREAM_A, (slice) => ({
+      ...slice,
+      missingOutputsByRound: { 0: ['live.tex'] },
+    }));
+    resolveRead(
+      snapshot(STREAM_A, {
+        outputFilesByRound: {},
+        missingOutputsByRound: { 0: ['stale.tex'], 1: ['disk.tex'] },
+        compileFailuresByRound: {},
+      }),
+    );
+    await flushSignals();
+
+    expect(reader.preload).toHaveBeenCalledWith([STREAM_A]);
+    expect(streams.get().get(STREAM_A)?.missingOutputsByRound).toEqual({
+      0: ['live.tex'],
+      1: ['disk.tex'],
+    });
+    dispose();
+  });
+
+  it('does not restore disk warnings after a live clear during hydration', async () => {
+    let resolveRead: (value: StreamSnapshot) => void = () => undefined;
+    const readPromise = new Promise<StreamSnapshot>((resolve) => {
+      resolveRead = resolve;
+    });
+    const reader = {
+      preload: vi.fn(async () => undefined),
+      read: vi.fn(() => readPromise),
+    } as StreamArtifactReader;
+    const hub = new SessionEventHub();
+
+    patchStream(STREAM_A, (slice) => ({
+      ...slice,
+      missingOutputsByRound: { 0: ['old-live.tex'] },
+    }));
+    activeStreamId.set(STREAM_A);
+    const disposeArtifacts = subscribeStreamArtifacts(reader);
+    const disposeFacts = attachTuiRunFactSubscription(hub);
+    await flushSignals();
+
+    hub.emit({
+      scope: 'session',
+      event: {
+        type: 'clearMissingOutputs',
+        payload: { streamId: STREAM_A },
+      },
+    });
+    resolveRead(
+      snapshot(STREAM_A, {
+        outputFilesByRound: {},
+        missingOutputsByRound: { 0: ['stale-disk.tex'] },
+        compileFailuresByRound: {},
+      }),
+    );
+    await flushSignals();
+
+    expect(streams.get().get(STREAM_A)?.missingOutputsByRound).toEqual({});
+    disposeFacts();
+    disposeArtifacts();
+  });
+
+  it('discards a read after focus moves to another stream', async () => {
+    let resolveA: (value: StreamSnapshot) => void = () => undefined;
+    const readA = new Promise<StreamSnapshot>((resolve) => {
+      resolveA = resolve;
+    });
+    const reader = {
+      preload: vi.fn(async () => undefined),
+      read: vi.fn((streamId: StreamTabId) =>
+        streamId === STREAM_A
+          ? readA
+          : Promise.resolve(
+              snapshot(STREAM_B, {
+                outputFilesByRound: {},
+                missingOutputsByRound: {},
+                compileFailuresByRound: {},
+              }),
+            ),
+      ),
+    } as StreamArtifactReader;
+
+    activeStreamId.set(STREAM_A);
+    const dispose = subscribeStreamArtifacts(reader);
+    await flushSignals();
+    activeStreamId.set(STREAM_B);
+    await flushSignals();
+    resolveA(
+      snapshot(STREAM_A, {
+        outputFilesByRound: {},
+        missingOutputsByRound: { 0: ['late.tex'] },
+        compileFailuresByRound: {},
+      }),
+    );
+    await flushSignals();
+
+    expect(streams.get().get(STREAM_A)).toBeUndefined();
+    expect(streams.get().get(STREAM_B)?.missingOutputsByRound).toEqual({});
+    dispose();
+  });
+
+  it('cannot resurrect a removed or reset stream after a late read', async () => {
+    for (const retire of [
+      () => removeStream(STREAM_A),
+      () => resetCliState(),
+    ]) {
+      let resolveRead: (value: StreamSnapshot) => void = () => undefined;
+      const readPromise = new Promise<StreamSnapshot>((resolve) => {
+        resolveRead = resolve;
+      });
+      const reader = {
+        preload: vi.fn(async () => undefined),
+        read: vi.fn(() => readPromise),
+      } as StreamArtifactReader;
+
+      activeStreamId.set(STREAM_A);
+      const dispose = subscribeStreamArtifacts(reader);
+      await flushSignals();
+      retire();
+      resolveRead(
+        snapshot(STREAM_A, {
+          outputFilesByRound: {},
+          missingOutputsByRound: { 0: ['late.tex'] },
+          compileFailuresByRound: {},
+        }),
+      );
+      await flushSignals();
+
+      expect(streams.get().has(STREAM_A)).toBe(false);
+      dispose();
+      resetCliState();
+    }
+  });
+});

--- a/src/test-kernel/cli/SubscribeStreamArtifacts.vitest.mts
+++ b/src/test-kernel/cli/SubscribeStreamArtifacts.vitest.mts
@@ -164,6 +164,64 @@ describe('subscribeStreamArtifacts', () => {
     dispose();
   });
 
+  it('discards the first read when a completed stream is refocused', async () => {
+    const pendingA: Array<(value: StreamSnapshot) => void> = [];
+    const reader = {
+      preload: vi.fn(async () => undefined),
+      read: vi.fn((streamId: StreamTabId) =>
+        streamId === STREAM_A
+          ? new Promise<StreamSnapshot>((resolve) => {
+              pendingA.push(resolve);
+            })
+          : Promise.resolve(
+              snapshot(STREAM_B, {
+                outputFilesByRound: {},
+                missingOutputsByRound: {},
+                compileFailuresByRound: {},
+              }),
+            ),
+      ),
+    } as StreamArtifactReader;
+
+    patchStream(STREAM_A, (slice) => ({ ...slice }));
+    activeStreamId.set(STREAM_A);
+    const dispose = subscribeStreamArtifacts(reader);
+    await flushSignals();
+    activeStreamId.set(STREAM_B);
+    await flushSignals();
+    activeStreamId.set(STREAM_A);
+    await flushSignals();
+
+    expect(pendingA).toHaveLength(2);
+    const [resolveStale, resolveFresh] = pendingA;
+    if (!resolveStale || !resolveFresh) {
+      throw new Error('Expected two pending reads for the refocused stream');
+    }
+
+    resolveStale(
+      snapshot(STREAM_A, {
+        outputFilesByRound: {},
+        missingOutputsByRound: { 0: ['stale.tex'] },
+        compileFailuresByRound: {},
+      }),
+    );
+    await flushSignals();
+    expect(streams.get().get(STREAM_A)?.missingOutputsByRound).toEqual({});
+
+    resolveFresh(
+      snapshot(STREAM_A, {
+        outputFilesByRound: {},
+        missingOutputsByRound: { 0: ['fresh.tex'] },
+        compileFailuresByRound: {},
+      }),
+    );
+    await flushSignals();
+    expect(streams.get().get(STREAM_A)?.missingOutputsByRound).toEqual({
+      0: ['fresh.tex'],
+    });
+    dispose();
+  });
+
   it('cannot resurrect a removed or reset stream after a late read', async () => {
     for (const retire of [
       () => removeStream(STREAM_A),

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -1820,7 +1820,7 @@ describe('CLI transcript state', () => {
     expect(slice?.description).toBe('synthetic workflow error');
   });
 
-  it('derives workflow descriptions from operational rows without exposing prose', () => {
+  it('admits ordinary workflow logs without exposing unsafe terminal text', () => {
     patchStream(child1, (slice) => ({
       ...slice,
       category: AgentCategory.Workflow,
@@ -1846,7 +1846,16 @@ describe('CLI transcript state', () => {
     expect(slice?.description).not.toContain(secret);
     expect(slice?.description).not.toContain('\u001b');
     expect(slice?.description).not.toContain('\u0007');
-    expect(slice?.entries).toEqual([]);
+    expect(slice?.entries).toMatchObject([
+      {
+        role: 'assistant',
+        messageType: MESSAGE_TYPES.DEFAULT,
+        text: 'Preparing proof audit API_KEY=[redacted]',
+      },
+    ]);
+    expect(JSON.stringify(slice?.entries)).not.toContain(
+      'raw workflow model response',
+    );
 
     logger.info('tool activity', {
       messageType: MESSAGE_TYPES.TOOL_USE,
@@ -1895,13 +1904,17 @@ describe('CLI transcript state', () => {
     slice = streams.get().get(child1);
     expect(slice?.description).toBe('Proof audit failed');
     expect(slice?.entries.map(({ role }) => role)).toEqual([
+      'assistant',
       'tool',
       'tool',
       'phase',
       'error',
     ]);
     expect(JSON.stringify(slice)).not.toContain('workflow prompt');
-    expect(JSON.stringify(slice)).not.toContain('Preparing proof audit');
+    expect(JSON.stringify(slice)).toContain(
+      'Preparing proof audit API_KEY=[redacted]',
+    );
+    expect(JSON.stringify(slice)).not.toContain(secret);
     expect(JSON.stringify(slice)).not.toContain('raw workflow model response');
   });
 
@@ -2993,6 +3006,96 @@ describe('subscribeRuntimeHost run facts', () => {
           }),
         ],
       });
+    } finally {
+      detach();
+    }
+  });
+
+  it('projects missing-output and compile facts and clears matching warnings', () => {
+    const hub = new SessionEventHub();
+    const detach = attachTuiRunFactSubscription(hub, {
+      findWorkflowStreamsMatching: () => [root],
+    });
+
+    try {
+      hub.emit({
+        scope: 'run',
+        streamId: root,
+        event: {
+          type: 'updateMissingOutputs',
+          streamId: root,
+          filesByRound: { 0: ['missing.tex'] },
+        },
+      });
+      hub.emit({
+        scope: 'run',
+        streamId: root,
+        event: {
+          type: 'updateCompileFailures',
+          streamId: root,
+          filesByRound: {
+            0: [
+              {
+                round: 0,
+                displayName: 'paper.pdf',
+                output: {
+                  kind: 'external',
+                  absolutePath: '/tmp/paper.pdf',
+                },
+                log: {
+                  kind: 'external',
+                  absolutePath: '/tmp/paper.log',
+                },
+                logRelativePath: 'paper.log',
+              },
+            ],
+          },
+        },
+      });
+
+      expect(streams.get().get(root)).toMatchObject({
+        missingOutputsByRound: { 0: ['missing.tex'] },
+        compileFailuresByRound: {
+          0: [expect.objectContaining({ displayName: 'paper.pdf' })],
+        },
+      });
+
+      hub.emit({
+        scope: 'session',
+        event: {
+          type: 'clearMissingOutputs',
+          payload: { streamId: root },
+        },
+      });
+      expect(streams.get().get(root)?.missingOutputsByRound).toEqual({});
+
+      hub.emit({
+        scope: 'run',
+        streamId: root,
+        event: {
+          type: 'updateMissingOutputs',
+          streamId: root,
+          filesByRound: { 1: ['again.tex'] },
+        },
+      });
+      hub.emit({
+        scope: 'session',
+        event: {
+          type: 'clearMissingOutputs',
+          payload: {
+            streamConfig: {
+              agent: 'correct',
+              model: 'deepseekT',
+              inputFile: 'paper.tex',
+            },
+          },
+        },
+      });
+
+      expect(streams.get().get(root)?.missingOutputsByRound).toEqual({});
+      expect(streams.get().get(root)?.compileFailuresByRound[0]).toHaveLength(
+        1,
+      );
     } finally {
       detach();
     }

--- a/src/test-kernel/cli/WorkflowRunDetails.vitest.mts
+++ b/src/test-kernel/cli/WorkflowRunDetails.vitest.mts
@@ -1,10 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { ConversationPane } from '@cli/chat/tui/panes/ConversationPane';
-import {
-  selectWorkflowRunDetailLines,
-  workflowRunDetailLines,
-} from '@cli/chat/tui/panes/WorkflowRunDetails';
+import { selectWorkflowRunDetailLines } from '@cli/chat/tui/panes/WorkflowRunDetails';
 import {
   activeStreamId,
   patchStream,
@@ -22,6 +19,12 @@ import { projectTaskGroupsFromStreamLog } from '@shared/streams/taskGroupProject
 import { loadInk } from '@test/support/inkTestHarness.mts';
 
 const STREAM_ID = 'workflow#details' as StreamTabId;
+
+function workflowRunDetailLines(
+  facts: Parameters<typeof selectWorkflowRunDetailLines>[0],
+) {
+  return selectWorkflowRunDetailLines(facts, Number.MAX_SAFE_INTEGER);
+}
 
 afterEach(() => {
   resetCliState();

--- a/src/test-kernel/cli/WorkflowRunDetails.vitest.mts
+++ b/src/test-kernel/cli/WorkflowRunDetails.vitest.mts
@@ -1,0 +1,307 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { ConversationPane } from '@cli/chat/tui/panes/ConversationPane';
+import {
+  selectWorkflowRunDetailLines,
+  workflowRunDetailLines,
+} from '@cli/chat/tui/panes/WorkflowRunDetails';
+import {
+  activeStreamId,
+  patchStream,
+  resetCliState,
+} from '@cli/chat/tui/state/cliState';
+import {
+  AgentCategory,
+  LOG_LEVELS,
+  MESSAGE_TYPES,
+  STREAM_LOG_ENTRY_TYPES,
+  STREAM_PHASE,
+  type StreamTabId,
+} from '@shared/schemas';
+import { projectTaskGroupsFromStreamLog } from '@shared/streams/taskGroupProjection';
+import { loadInk } from '@test/support/inkTestHarness.mts';
+
+const STREAM_ID = 'workflow#details' as StreamTabId;
+
+afterEach(() => {
+  resetCliState();
+});
+
+describe('workflowRunDetailLines', () => {
+  it('joins lifecycle, planned rounds, generated files, and warnings', () => {
+    const lines = workflowRunDetailLines({
+      taskGroups: [
+        {
+          id: 'run',
+          name: 'Repository audit',
+          kind: 'run',
+          startTime: 1_000,
+          endTime: 10_000,
+          status: STREAM_PHASE.COMPLETED,
+        },
+        {
+          id: 'r0',
+          name: 'r0',
+          kind: 'round',
+          index: 0,
+          total: 2,
+          startTime: 2_000,
+          endTime: 9_200,
+          status: STREAM_PHASE.COMPLETED,
+        },
+      ],
+      outputFilesByRound: {
+        0: [
+          {
+            source: 'paper.tex',
+            round: 0,
+            location: {
+              kind: 'workspace',
+              absolutePath: '/workspace/output/paper.tex',
+              relativePath: 'output/paper.tex',
+            },
+            lineage: null,
+            diff: { added: 12, removed: 3 },
+          },
+        ],
+      },
+      missingOutputsByRound: { 0: ['appendix.tex'] },
+      compileFailuresByRound: {
+        0: [
+          {
+            round: 0,
+            displayName: 'paper.pdf',
+            output: {
+              kind: 'external',
+              absolutePath: '/tmp/paper.pdf',
+            },
+            log: {
+              kind: 'external',
+              absolutePath: '/tmp/paper.log',
+            },
+            logRelativePath: 'paper.log',
+          },
+        ],
+      },
+    });
+
+    expect(lines.map((line) => line.text)).toEqual([
+      '✓ Repository audit completed · 9s',
+      '✓ r0 (1/2) completed · 7s',
+      '  Generated files',
+      '    › output/paper.tex (+12 -3)',
+      '  ⚠ r0 · Missing expected output: appendix.tex',
+      '  ✗ r0 · Compile check failed: paper.pdf · paper.log',
+      '□ r1 (2/2) planned',
+    ]);
+    expect(lines.map((line) => line.tone)).toEqual([
+      'success',
+      'success',
+      'muted',
+      'neutral',
+      'warning',
+      'error',
+      'muted',
+    ]);
+  });
+
+  it('renders a normalized rN round and sanitizes terminal controls', () => {
+    const lines = workflowRunDetailLines({
+      taskGroups: projectTaskGroupsFromStreamLog([
+        {
+          seqNo: 1,
+          id: 'legacy-r3',
+          type: STREAM_LOG_ENTRY_TYPES.GROUP_START,
+          level: LOG_LEVELS.INFO,
+          timestamp: 0,
+          text: 'r3',
+          data: { status: STREAM_PHASE.RUNNING },
+        },
+      ]),
+      outputFilesByRound: {},
+      missingOutputsByRound: { 3: ['bad\u001b[31m.tex'] },
+      compileFailuresByRound: {},
+    });
+
+    expect(lines.map((line) => line.text)).toEqual([
+      '● r3 running',
+      '  ⚠ r3 · Missing expected output: bad.tex',
+    ]);
+  });
+
+  it('shows a round-qualified alert when only one detail row fits', () => {
+    const [line] = selectWorkflowRunDetailLines(
+      {
+        taskGroups: [
+          {
+            id: 'r0',
+            name: 'r0',
+            kind: 'round',
+            index: 0,
+            startTime: 0,
+            endTime: 1_000,
+            status: STREAM_PHASE.COMPLETED,
+          },
+        ],
+        outputFilesByRound: {},
+        missingOutputsByRound: { 0: ['missing.tex'] },
+        compileFailuresByRound: {
+          0: [
+            {
+              round: 0,
+              displayName: 'paper.pdf',
+              output: {
+                kind: 'external',
+                absolutePath: '/tmp/paper.pdf',
+              },
+              log: {
+                kind: 'external',
+                absolutePath: '/tmp/paper.log',
+              },
+              logRelativePath: 'paper.log',
+            },
+          ],
+        },
+      },
+      1,
+    );
+
+    expect(line?.text).toBe(
+      '  ✗ r0 · Compile check failed: paper.pdf · paper.log',
+    );
+    expect(line?.role).toBe('alert');
+  });
+
+  it.each([
+    ['unclassified', undefined],
+    ['round without an index', 'round'],
+    ['session stage', 'session'],
+  ] as const)('keeps a %s lifecycle group visible', (_case, kind) => {
+    const lines = workflowRunDetailLines({
+      taskGroups: projectTaskGroupsFromStreamLog([
+        {
+          seqNo: 1,
+          id: 'legacy-round',
+          type: STREAM_LOG_ENTRY_TYPES.GROUP_END,
+          level: LOG_LEVELS.INFO,
+          timestamp: 0,
+          text: 'Round 3',
+          data: { status: 'stopped', endTime: 1_000, kind },
+        },
+      ]),
+      outputFilesByRound: {},
+      missingOutputsByRound: {},
+      compileFailuresByRound: {},
+    });
+
+    expect(lines.map((line) => line.text)).toEqual([
+      '✓ Round 3 completed · 1s',
+    ]);
+  });
+
+  it('budgets detail rows together with the live transcript viewport', async () => {
+    patchStream(STREAM_ID, (slice) => ({
+      ...slice,
+      category: AgentCategory.Workflow,
+      status: STREAM_PHASE.RUNNING,
+      taskGroups: [
+        {
+          id: 'r0',
+          name: 'r0',
+          kind: 'round',
+          index: 0,
+          total: 4,
+          startTime: 0,
+          status: STREAM_PHASE.RUNNING,
+        },
+      ],
+      entries: [
+        {
+          id: 'live',
+          role: 'assistant',
+          text: 'live workflow log',
+          messageType: MESSAGE_TYPES.DEFAULT,
+          finalized: false,
+        },
+      ],
+    }));
+    activeStreamId.set(STREAM_ID);
+
+    const { ink, React } = await loadInk();
+    const output = ink.renderToString(
+      React.createElement(ConversationPane, {
+        maxRows: 4,
+        width: 80,
+        availableWidth: 80,
+      }),
+      { columns: 80 },
+    );
+    const rows = output.split('\n');
+
+    expect(rows).toHaveLength(4);
+    expect(output).toContain('r0 (1/4) running');
+    expect(output).toContain('r1 (2/4) planned');
+    expect(output).toContain('r2 (3/4) planned');
+    expect(output).toContain('live workflow log');
+    expect(output).not.toContain('r3 (4/4) planned');
+  });
+
+  it('keeps warning context ahead of generated files and future plans', () => {
+    const lines = selectWorkflowRunDetailLines(
+      {
+        taskGroups: [
+          {
+            id: 'r0',
+            name: 'r0',
+            kind: 'round',
+            index: 0,
+            total: 2,
+            startTime: 0,
+            endTime: 1,
+            status: STREAM_PHASE.COMPLETED,
+          },
+        ],
+        outputFilesByRound: {
+          0: [
+            {
+              source: 'paper.tex',
+              round: 0,
+              location: {
+                kind: 'workspace',
+                absolutePath: '/workspace/paper.tex',
+                relativePath: 'paper.tex',
+              },
+              lineage: null,
+              diff: null,
+            },
+          ],
+        },
+        missingOutputsByRound: {},
+        compileFailuresByRound: {
+          0: [
+            {
+              round: 0,
+              displayName: 'paper.pdf',
+              output: {
+                kind: 'external',
+                absolutePath: '/tmp/paper.pdf',
+              },
+              log: {
+                kind: 'external',
+                absolutePath: '/tmp/paper.log',
+              },
+              logRelativePath: 'paper.log',
+            },
+          ],
+        },
+      },
+      3,
+    );
+
+    expect(lines.map((line) => line.text)).toEqual([
+      '✓ r0 (1/2) completed · 1s',
+      '  ✗ r0 · Compile check failed: paper.pdf · paper.log',
+      '□ r1 (2/2) planned',
+    ]);
+  });
+});

--- a/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.mts
+++ b/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.mts
@@ -26,6 +26,7 @@ import { appendLocalAssistantTranscript } from '@cli/chat/tui/state/transcript';
 import { createTranscriptPrintRequest } from '@cli/chat/tui/state/transcriptLines';
 import { projectStreamTranscript } from '@cli/chat/tui/state/transcriptProjection';
 import {
+  AgentCategory,
   MESSAGE_TYPES,
   STREAM_PHASE,
   TOOL_USE_STATUS,
@@ -70,7 +71,11 @@ beforeEach(async () => {
   resetCliState();
   clearAllStreamStatusesForTest(defaultSession().status);
   await defaultSession().transcripts.clear();
-  patchStream(STREAM_ID, (slice) => ({ ...slice, model: 'deepseekT' }));
+  patchStream(STREAM_ID, (slice) => ({
+    ...slice,
+    category: AgentCategory.Workflow,
+    model: 'deepseekT',
+  }));
 });
 
 afterEach(() => {
@@ -78,6 +83,33 @@ afterEach(() => {
 });
 
 describe('CLI workflow-script child-stream transcript', () => {
+  it('keeps lifecycle headings for full-log SDK children', () => {
+    const sdkStreamId = 'claude@agent-sdk#exec-1' as StreamTabId;
+    patchStream(sdkStreamId, (slice) => ({
+      ...slice,
+      category: AgentCategory.ToolUse,
+      model: 'claude-sonnet',
+    }));
+    const runTrace = createRunTrace(sdkStreamId, defaultSession().transcripts);
+    try {
+      runTrace.trace.openStage('Claude SDK session', {
+        id: 'sdk-session',
+        kind: 'session',
+      });
+      syncStreamLog(sdkStreamId);
+
+      expect(
+        streams
+          .get()
+          .get(sdkStreamId)
+          ?.entries.map((entry) => entry.text),
+      ).toContain('Claude SDK session');
+    } finally {
+      runTrace.dispose();
+      defaultSession().status.clearStream(sdkStreamId);
+    }
+  });
+
   it('keeps planned task rows live until their terminal state is printable', () => {
     const runTrace = createRunTrace(STREAM_ID, defaultSession().transcripts);
     try {

--- a/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.mts
+++ b/src/test-kernel/cli/WorkflowScriptStreamTranscript.vitest.mts
@@ -928,7 +928,7 @@ describe('CLI workflow-script child-stream transcript', () => {
     }
   });
 
-  it('keeps an immutable round header ahead of its later log rows', async () => {
+  it('projects round lifecycle separately from its ordinary log rows', async () => {
     const runTrace = createRunTrace(STREAM_ID, defaultSession().transcripts);
     try {
       const round = runTrace.trace.openStage('Round one', {
@@ -961,15 +961,19 @@ describe('CLI workflow-script child-stream transcript', () => {
           .filter((item) => item.kind === 'entry')
           .map((item) => item.entry.text);
 
-      expect(entryTexts(incrementalItems)).toEqual([
-        'Round one',
-        'Round work completed',
-      ]);
+      expect(entryTexts(incrementalItems)).toEqual(['Round work completed']);
       expect(entryTexts(coldItems)).toEqual(entryTexts(incrementalItems));
+      expect(streams.get().get(STREAM_ID)?.taskGroups).toMatchObject([
+        {
+          id: 'round-one',
+          name: 'Round one',
+          kind: 'round',
+          status: STREAM_PHASE.COMPLETED,
+        },
+      ]);
       const output = await renderStaticTranscript();
-      expect(output.indexOf('Round one')).toBeLessThan(
-        output.indexOf('Round work completed'),
-      );
+      expect(output).not.toContain('Round one');
+      expect(output).toContain('Round work completed');
     } finally {
       runTrace.dispose();
     }

--- a/src/test-kernel/progressView/LogDeltaTextDeltas.vitest.ts
+++ b/src/test-kernel/progressView/LogDeltaTextDeltas.vitest.ts
@@ -24,6 +24,7 @@ import {
   type StreamTabId,
 } from '@shared/schemas';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+import { projectTaskGroupsFromStreamLog } from '@shared/streams/taskGroupProjection';
 import { assertSupported } from '@shared/utils/dispatcher';
 
 /** Seed the shared appState singleton and return a live reader over it. */
@@ -282,4 +283,39 @@ describe('LOG_DELTA GROUP_END task-group status (#7993 step 3)', () => {
       expect(taskGroups?.[0]?.status).toBe(expectedStatus);
     },
   );
+
+  it('preserves an ambiguous Round N group identically to the shared cold reader', () => {
+    const streamId = 'stream-a' as StreamTabId;
+    const state = createInitialState();
+    state.activeStreamId = streamId;
+    state.streamStates.set(streamId, createStreamState(AgentCategory.Workflow));
+    const getState = seedState(state);
+    const legacyRound = {
+      ...groupEndEntry('legacy-round', 'stopped'),
+      text: 'Round 2',
+    };
+
+    dispatch(logHandlers, {
+      command: PROGRESS_VIEW_COMMANDS.LOG_DELTA,
+      streamId,
+      entries: [legacyRound],
+      updates: [],
+      textDeltas: [],
+    });
+
+    const extensionTaskGroups =
+      getState().streamStates.get(streamId)?.taskGroups;
+    expect(extensionTaskGroups).toEqual(
+      projectTaskGroupsFromStreamLog([legacyRound]),
+    );
+    expect(extensionTaskGroups).toMatchObject([
+      {
+        id: 'legacy-round',
+        name: 'Round 2',
+        status: RUN_OUTCOME.COMPLETED,
+      },
+    ]);
+    expect(extensionTaskGroups?.[0]?.kind).toBeUndefined();
+    expect(extensionTaskGroups?.[0]?.index).toBeUndefined();
+  });
 });

--- a/src/test-kernel/shared/TaskGroupProjection.vitest.ts
+++ b/src/test-kernel/shared/TaskGroupProjection.vitest.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  LOG_LEVELS,
+  RUN_OUTCOME,
+  STREAM_LOG_ENTRY_TYPES,
+  STREAM_PHASE,
+  type StreamLogEntry,
+} from '@shared/schemas';
+import {
+  projectTaskGroupsFromStreamLog,
+  upsertTaskGroupFromStreamLog,
+} from '@shared/streams/taskGroupProjection';
+
+interface GroupEntryOverrides {
+  readonly groupId?: string;
+  readonly text?: string;
+  readonly data?: unknown;
+}
+
+function entry(
+  id: string,
+  type:
+    | typeof STREAM_LOG_ENTRY_TYPES.GROUP_START
+    | typeof STREAM_LOG_ENTRY_TYPES.GROUP_END,
+  overrides: GroupEntryOverrides = {},
+): StreamLogEntry {
+  return {
+    seqNo: type === STREAM_LOG_ENTRY_TYPES.GROUP_START ? 1 : 2,
+    id,
+    type,
+    level: LOG_LEVELS.INFO,
+    timestamp: type === STREAM_LOG_ENTRY_TYPES.GROUP_START ? 100 : 200,
+    ...overrides,
+  };
+}
+
+describe('task-group StreamLog projection', () => {
+  it('projects group metadata and completes groups in source order', () => {
+    const taskGroups = projectTaskGroupsFromStreamLog([
+      entry('run-1', STREAM_LOG_ENTRY_TYPES.GROUP_START, {
+        text: 'Run: auditor',
+        data: { status: STREAM_PHASE.RUNNING, kind: 'run' },
+      }),
+      entry('round-1', STREAM_LOG_ENTRY_TYPES.GROUP_START, {
+        groupId: 'run-1',
+        text: 'Round 1',
+        data: {
+          status: STREAM_PHASE.RUNNING,
+          kind: 'round',
+          index: 1,
+          total: 2,
+        },
+      }),
+      entry('round-1', STREAM_LOG_ENTRY_TYPES.GROUP_END, {
+        groupId: 'run-1',
+        text: 'Round 1',
+        data: {
+          status: RUN_OUTCOME.COMPLETED,
+          kind: 'round',
+          endTime: 180,
+        },
+      }),
+    ]);
+
+    expect(taskGroups).toEqual([
+      {
+        id: 'run-1',
+        name: 'Run: auditor',
+        startTime: 100,
+        status: STREAM_PHASE.RUNNING,
+        kind: 'run',
+      },
+      {
+        id: 'round-1',
+        name: 'Round 1',
+        startTime: 100,
+        endTime: 180,
+        status: RUN_OUTCOME.COMPLETED,
+        parentGroupId: 'run-1',
+        kind: 'round',
+        index: 1,
+        total: 2,
+      },
+    ]);
+  });
+
+  it.each([
+    ['stopped', RUN_OUTCOME.COMPLETED],
+    ['error', RUN_OUTCOME.FAILED],
+    ['invalid', RUN_OUTCOME.COMPLETED],
+  ] as const)('normalizes legacy end status %s', (status, expected) => {
+    const [taskGroup] = projectTaskGroupsFromStreamLog([
+      entry('run-1', STREAM_LOG_ENTRY_TYPES.GROUP_END, {
+        text: 'Run: auditor',
+        data: { status, endTime: 200 },
+      }),
+    ]);
+
+    expect(taskGroup).toEqual({
+      id: 'run-1',
+      name: 'Run: auditor',
+      startTime: 200,
+      endTime: 200,
+      status: expected,
+    });
+  });
+
+  it('repairs a stale index before incrementally updating an existing group', () => {
+    const taskGroups = projectTaskGroupsFromStreamLog([
+      entry('run-1', STREAM_LOG_ENTRY_TYPES.GROUP_START, {
+        text: 'Run: auditor',
+      }),
+    ]);
+    const staleIndex = new Map([['run-1', 4]]);
+
+    expect(
+      upsertTaskGroupFromStreamLog(
+        taskGroups,
+        staleIndex,
+        entry('run-1', STREAM_LOG_ENTRY_TYPES.GROUP_END, {
+          data: { status: RUN_OUTCOME.FAILED, endTime: 250 },
+        }),
+      ),
+    ).toBe(true);
+    expect(staleIndex.get('run-1')).toBe(0);
+    expect(taskGroups).toHaveLength(1);
+    expect(taskGroups[0]?.status).toBe(RUN_OUTCOME.FAILED);
+    expect(taskGroups[0]?.endTime).toBe(250);
+  });
+
+  it('normalizes an exact zero-based rN label at the shared boundary', () => {
+    const lifecycle = entry('legacy-round', STREAM_LOG_ENTRY_TYPES.GROUP_END, {
+      text: 'r3',
+      data: { status: 'stopped', endTime: 200 },
+    });
+    const batch = projectTaskGroupsFromStreamLog([lifecycle]);
+    const incremental: typeof batch = [];
+
+    expect(
+      upsertTaskGroupFromStreamLog(
+        incremental,
+        new Map<string, number>(),
+        lifecycle,
+      ),
+    ).toBe(true);
+    expect(batch).toEqual(incremental);
+    expect(batch).toMatchObject([
+      {
+        id: 'legacy-round',
+        kind: 'round',
+        index: 3,
+        status: RUN_OUTCOME.COMPLETED,
+      },
+    ]);
+  });
+
+  it('does not guess an index for an ambiguous human-facing Round N label', () => {
+    const [group] = projectTaskGroupsFromStreamLog([
+      entry('legacy-round', STREAM_LOG_ENTRY_TYPES.GROUP_END, {
+        text: 'Round 3',
+        data: { status: 'stopped', endTime: 200 },
+      }),
+    ]);
+
+    expect(group).toMatchObject({
+      id: 'legacy-round',
+      name: 'Round 3',
+      status: RUN_OUTCOME.COMPLETED,
+    });
+    expect(group?.kind).toBeUndefined();
+    expect(group?.index).toBeUndefined();
+  });
+
+  it('ignores ordinary log rows', () => {
+    const taskGroups = projectTaskGroupsFromStreamLog([
+      {
+        seqNo: 1,
+        id: 'message-1',
+        type: STREAM_LOG_ENTRY_TYPES.LOG,
+        level: LOG_LEVELS.INFO,
+        timestamp: 100,
+        text: 'ordinary message',
+      },
+    ]);
+
+    expect(taskGroups).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

The terminal client now gives a selected workflow child a read-only detail view instead of reducing the run to one status line. It shows planned, running, and completed rounds; generated files and diffs; missing outputs; and compilation warnings or errors. A completed child remains in the session list and can be focused again after control returns to the workflow owner.

## Design

The extension and terminal client now derive task groups from `src/shared/streams/taskGroupProjection.ts`. This is the single projection of structured workflow task facts; neither host reconstructs task state from rendered text.

Terminal-only artifact hydration is kept separate in `subscribeStreamArtifacts.ts`. It reads persisted artifact sidecars for the focused run, guards against stale asynchronous results after clear, focus changes, generation changes, or removal, and supplies immutable detail data to the renderer. The renderer only selects and displays the most informative rows.

Ordinary `AgentTrace` lifecycle entries are retained for workflow children and sanitized before terminal display. Ambiguous legacy text such as `Round N` remains visible but is not assigned a fabricated round index.

## User-visible behavior

- The selected workflow child shows its planned work before all tasks have started.
- Round and run completion remain visible after the child finishes.
- Generated paths and diffs, missing outputs, and compilation findings appear in the detail view.
- Errors and warnings take precedence in a short viewport while headings remain visible.
- Tab, Down, and Enter can return to a completed child after owner focus is restored.

## Validation

- `npm run typecheck`
- `npm run lint`
- focused workflow, projection, artifact, focus, and transcript tests
- PTY scenario: `node scripts/validate-tui.mjs workflow-timeline`
- full Vitest on the pre-rebase branch: 7,544 passed, 4 skipped
- current-main comparison: 7,583 passed; the remaining four ten-second timeouts reproduce on unchanged main under the same local machine load
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches TUI stream subscriptions, async artifact hydration, and destructive missing-output clears; behavior is heavily tested but regressions could affect workflow focus UX or stale warning display.
> 
> **Overview**
> Adds a **read-only workflow detail block** in the CLI conversation pane when a workflow child is focused: round/run lifecycle, generated files (with diffs), missing outputs, and compile failures, with **viewport-aware line selection** so alerts and current rounds win in a short terminal.
> 
> **State and facts:** `StreamSlice` now always carries `taskGroups`, round-indexed outputs, missing outputs, and compile failures. Live run facts are applied in `attachTuiRunFactSubscription` (including `clearMissingOutputs` via snapshot-store stream matching and revision guards so stale disk hydration cannot resurrect cleared warnings). **`subscribeStreamArtifacts`** merges persisted sidecars on focus, with discard rules for focus changes, reset, and stream removal.
> 
> **Transcript vs details:** Workflow streams project lifecycle from the StreamLog into `taskGroups` (via new shared **`taskGroupProjection`**, also replacing duplicate logic in the extension progress view) and **stop rendering run/round group rows in the transcript**; ordinary workflow log lines stay in the transcript with terminal sanitization. Non-workflow children still show lifecycle as transcript rows.
> 
> **Validation:** New unit tests, a TUI harness `workflow-timeline` fixture, and CI `validate:tui` scenario (Tab into completed child, ordered round/output/compile lines).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c69739cf99758ed1bb77ee8d71fa48b1733d3f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->