### PR TITLE
fix: check Overleaf clone preconditions before auth

### DIFF
--- a/src/latex/overleafClone.ts
+++ b/src/latex/overleafClone.ts
@@ -135,14 +135,14 @@ export async function cloneOverleafProject(
   workspacePath: string,
   ports: OverleafCloneWorkflowPorts,
 ): Promise<OverleafCloneOutcome> {
-  const token = await resolveOverleafToken(remote, ports);
-  if (token.status !== 'ready') return token;
-
   const preconditionFailure = await checkOverleafClonePreconditions(
     workspacePath,
     ports,
   );
   if (preconditionFailure) return preconditionFailure;
+
+  const token = await resolveOverleafToken(remote, ports);
+  if (token.status !== 'ready') return token;
 
   const remoteUrl = buildAuthenticatedRemoteUrl(remote, token.credential);
   const label = remote.isOverleaf ? 'Overleaf' : 'ShareLaTeX';

--- a/src/test-kernel/latex/OverleafClone.vitest.ts
+++ b/src/test-kernel/latex/OverleafClone.vitest.ts
@@ -96,31 +96,43 @@ describe('cloneOverleafProject', () => {
     ).resolves.toEqual({ status: 'success' });
 
     const blockedPorts = createPorts({
+      getStoredToken: vi.fn(async () => undefined),
       listWorkspaceEntries: vi.fn(async () => ['paper.tex']),
+      promptToken: vi.fn(async () => 'olp_prompted'),
     });
     await expect(
       cloneOverleafProject(REMOTE, '/workspace', blockedPorts),
     ).resolves.toEqual({ status: 'workspaceNotEmpty' });
     expect(blockedPorts.showWorkspaceNotEmpty).toHaveBeenCalledOnce();
+    expect(blockedPorts.promptToken).not.toHaveBeenCalled();
+    expect(blockedPorts.storeToken).not.toHaveBeenCalled();
     expect(blockedPorts.runClone).not.toHaveBeenCalled();
   });
 
   it('returns explicit outcomes for unavailable git and unreadable workspaces', async () => {
     const gitMissingPorts = createPorts({
+      getStoredToken: vi.fn(async () => undefined),
       isGitAvailable: vi.fn(() => false),
+      promptToken: vi.fn(async () => 'olp_prompted'),
     });
     await expect(
       cloneOverleafProject(REMOTE, '/workspace', gitMissingPorts),
     ).resolves.toEqual({ status: 'gitMissing' });
+    expect(gitMissingPorts.promptToken).not.toHaveBeenCalled();
+    expect(gitMissingPorts.storeToken).not.toHaveBeenCalled();
 
     const unreadablePorts = createPorts({
+      getStoredToken: vi.fn(async () => undefined),
       listWorkspaceEntries: vi.fn(async () => {
         throw new Error('permission denied');
       }),
+      promptToken: vi.fn(async () => 'olp_prompted'),
     });
     await expect(
       cloneOverleafProject(REMOTE, '/workspace', unreadablePorts),
     ).resolves.toEqual({ status: 'workspaceUnreadable' });
+    expect(unreadablePorts.promptToken).not.toHaveBeenCalled();
+    expect(unreadablePorts.storeToken).not.toHaveBeenCalled();
     expect(unreadablePorts.showWorkspaceUnreadable).toHaveBeenCalledWith(
       expect.objectContaining({ message: 'permission denied' }),
     );


### PR DESCRIPTION
## Summary

- check Git availability and destination workspace state before resolving Overleaf credentials
- avoid prompting for or storing a token when cloning cannot proceed
- cover unavailable Git, unreadable workspaces, and nonempty workspaces

## Root cause

The clone workflow resolved credentials before checking local clone preconditions, so users could be prompted for a token even though the clone would immediately be rejected.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint`
- `npm test` (777 files passed, 7,578 tests passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small control-flow reorder in the clone workflow with no auth or data-model changes; behavior improves UX on failure paths only.
> 
> **Overview**
> **`cloneOverleafProject`** now runs **local clone preconditions** (Git on PATH, readable/empty workspace) **before** resolving or prompting for Overleaf credentials.
> 
> Users are no longer asked for a token when the clone would fail anyway—e.g. missing Git, a nonempty workspace, or an unreadable destination. Tests assert that **`promptToken`** and **`storeToken`** are not invoked on those early-exit paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a5123e6b3ee84dfa49f47a9c7b1f2fafd488807. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->