### PR TITLE
fix(cli): make subscription preferences independent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,7 @@ jobs:
             --snapshot-dir "$GITHUB_WORKSPACE/artifacts/tui-frames" \
             edit-approval subagent-list-focus-full-frame hidden-root-approval-tab-return \
             orchestrate-launcher orchestrate-agent-submenu \
+            orchestrate-independent-subscription-preferences \
             orchestrate-delegated-history orchestrate-resume-submenu \
             compact-orchestrate-launcher single-run-liveness \
             agent-proposal-approve-all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,7 +166,8 @@ All notable changes to this project will be documented in this file.
 - **Kimi Code subscription joins model access** — the launcher and `/api` now
   offer Kimi Code alongside ChatGPT subscription, included TeXRA access, and
   personal API keys. Selecting it routes Kimi models through your Kimi Code
-  membership while other models fall back to your saved keys.
+  membership while other models use the independently selected included or
+  personal fallback.
 - **API keys and provider routing can be managed from `/config`** — masked key
   status and secure entry are available for every provider, with Kimi Code,
   provider region, and GLM Coding Plan preferences under "Models and providers".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,7 +167,8 @@ All notable changes to this project will be documented in this file.
   offer Kimi Code alongside ChatGPT subscription, included TeXRA access, and
   personal API keys. Selecting it routes Kimi models through your Kimi Code
   membership while other models use the independently selected included or
-  personal fallback.
+  personal fallback. ChatGPT and Kimi Code preferences can both be enabled,
+  and status views report each preference separately from the API fallback.
 - **API keys and provider routing can be managed from `/config`** — masked key
   status and secure entry are available for every provider, with Kimi Code,
   provider region, and GLM Coding Plan preferences under "Models and providers".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,9 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Kimi Code access is labeled as a subscription** — model pickers and
+  running-session status no longer describe Kimi Code membership usage as
+  personal API-key access.
 - **Model failures show their reason** — failed model requests now include a
   concise provider message and are no longer labeled as tool failures.
 - **Large multi-agent runs use substantially less memory** — inactive subagent

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -208,6 +208,8 @@ const SHOW_ORCHESTRATION_STATUS_LINES =
   process.env.HARNESS_ORCHESTRATION_STATUS_LINES !== '0';
 const SHOW_BOTH_SUBSCRIPTION_PREFERENCES =
   process.env.HARNESS_BOTH_SUBSCRIPTION_PREFERENCES === '1';
+const SHOW_KIMI_CODE_SUBSCRIPTION =
+  process.env.HARNESS_KIMI_CODE_SUBSCRIPTION === '1';
 const SHOW_DELEGATED_ORCHESTRATION_HISTORY =
   process.env.HARNESS_DELEGATED_ORCHESTRATION_HISTORY === '1';
 const SHOW_NO_RUNNABLE_ORCHESTRATION_MODELS =
@@ -500,15 +502,23 @@ const HARNESS_PRESET_PLANS = planCliMultiAgentPresets(
     toolUseAgents: HARNESS_ALL_TOOL_USE_AGENTS,
   },
 );
-const HARNESS_MODEL_ACCESS = SHOW_BOTH_SUBSCRIPTION_PREFERENCES
-  ? {
-      apiFallback: HARNESS_API_MODE,
-      preferences: { chatGpt: 'on' as const, kimiCode: 'on' as const },
-      chatGptSignedIn: true,
-      chatGptAccountLabel: 'harness@example.edu',
-      kimiCodeKeySet: true,
-    }
-  : undefined;
+const HARNESS_MODEL_ACCESS =
+  SHOW_BOTH_SUBSCRIPTION_PREFERENCES || SHOW_KIMI_CODE_SUBSCRIPTION
+    ? {
+        apiFallback: HARNESS_API_MODE,
+        preferences: {
+          chatGpt: SHOW_BOTH_SUBSCRIPTION_PREFERENCES
+            ? ('on' as const)
+            : ('off' as const),
+          kimiCode: 'on' as const,
+        },
+        chatGptSignedIn: SHOW_BOTH_SUBSCRIPTION_PREFERENCES,
+        ...(SHOW_BOTH_SUBSCRIPTION_PREFERENCES
+          ? { chatGptAccountLabel: 'harness@example.edu' }
+          : {}),
+        kimiCodeKeySet: true,
+      }
+    : undefined;
 const HARNESS_ORCHESTRATION_ITEMS = buildCliOrchestrationItems({
   presetPlans: HARNESS_PRESET_PLANS,
   history: HARNESS_ORCHESTRATION_HISTORY,
@@ -533,6 +543,7 @@ type HarnessModelFixture = Readonly<{
   value: string;
   label: string;
   availability: NonNullable<CliModelAccess['model']['availability']>;
+  provider?: string;
 }>;
 
 const HARNESS_ORCHESTRATION_MODEL_FIXTURES: readonly HarnessModelFixture[] = [
@@ -547,6 +558,16 @@ const HARNESS_ORCHESTRATION_MODEL_FIXTURES: readonly HarnessModelFixture[] = [
     label: 'DeepSeek V4 Flash',
     availability: 'provider-key',
   },
+  ...(SHOW_KIMI_CODE_SUBSCRIPTION
+    ? [
+        {
+          value: 'kimi3',
+          label: 'Kimi K3',
+          availability: 'provider-key' as const,
+          provider: 'kimiCode',
+        },
+      ]
+    : []),
 ];
 
 function isHarnessModelAvailable(

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -125,7 +125,7 @@ import {
   formatCliModelAccessRouteInline,
   resolveCliModelAccessRoute,
 } from '../src/runtime/modelAccessRoute';
-import { selectCliModelAccessRoute } from '../src/runtime/modelAccessSelection';
+import { updateCliModelAccess } from '../src/runtime/modelAccessSelection';
 import {
   formatCliApiStatusActionHint,
   formatCliAuthStatusLine,
@@ -206,6 +206,8 @@ const SHOW_WIDE_FIRST_CHILD_LINE =
 const SHOW_ORCHESTRATION = process.env.HARNESS_ORCHESTRATION === '1';
 const SHOW_ORCHESTRATION_STATUS_LINES =
   process.env.HARNESS_ORCHESTRATION_STATUS_LINES !== '0';
+const SHOW_BOTH_SUBSCRIPTION_PREFERENCES =
+  process.env.HARNESS_BOTH_SUBSCRIPTION_PREFERENCES === '1';
 const SHOW_DELEGATED_ORCHESTRATION_HISTORY =
   process.env.HARNESS_DELEGATED_ORCHESTRATION_HISTORY === '1';
 const SHOW_NO_RUNNABLE_ORCHESTRATION_MODELS =
@@ -498,10 +500,20 @@ const HARNESS_PRESET_PLANS = planCliMultiAgentPresets(
     toolUseAgents: HARNESS_ALL_TOOL_USE_AGENTS,
   },
 );
+const HARNESS_MODEL_ACCESS = SHOW_BOTH_SUBSCRIPTION_PREFERENCES
+  ? {
+      apiFallback: HARNESS_API_MODE,
+      preferences: { chatGpt: 'on' as const, kimiCode: 'on' as const },
+      chatGptSignedIn: true,
+      chatGptAccountLabel: 'harness@example.edu',
+      kimiCodeKeySet: true,
+    }
+  : undefined;
 const HARNESS_ORCHESTRATION_ITEMS = buildCliOrchestrationItems({
   presetPlans: HARNESS_PRESET_PLANS,
   history: HARNESS_ORCHESTRATION_HISTORY,
   toolUseAgents: HARNESS_VISIBLE_TOOL_USE_AGENT_ENTRIES,
+  modelAccess: HARNESS_MODEL_ACCESS,
 });
 const HARNESS_ORCHESTRATION_RESUME_ITEMS = buildCliResumeItems(
   HARNESS_ORCHESTRATION_HISTORY,
@@ -613,6 +625,7 @@ if (SHOW_ORCHESTRATION) {
           : []
       }
       apiMode={HARNESS_API_MODE}
+      modelAccess={HARNESS_MODEL_ACCESS}
       version="0.0.0-harness"
       statusLines={
         SHOW_ORCHESTRATION_STATUS_LINES
@@ -2073,25 +2086,27 @@ registerBuiltinSlashCommands({
       `Harness model selected. Future turns: ${model}.`,
     );
   },
-  onModelAccessSelect: (route) => {
-    if (route === 'chatgpt') {
+  onModelAccessSelect: (selection) => {
+    if (selection.kind === 'subscription-preference') {
+      if (selection.provider === 'kimi-code' && selection.state === 'on') {
+        return updateCliModelAccess(
+          { ...HARNESS_CLI_CONTEXT, apiMode: sessionMeta.get().apiMode },
+          selection,
+          { writeProgress: appendHarnessAssistantTranscript },
+        ).then((access) => {
+          sessionMeta.set({ ...sessionMeta.get(), apiMode: access.apiMode });
+          appendHarnessAssistantTranscript(access.message);
+        });
+      }
       appendHarnessAssistantTranscript(
-        'Model access set to ChatGPT subscription.',
+        `${selection.provider} preference set to ${selection.state}.`,
       );
       return;
     }
-    if (route === 'kimi-code') {
-      return selectCliModelAccessRoute(
-        { ...HARNESS_CLI_CONTEXT, apiMode: sessionMeta.get().apiMode },
-        route,
-        { writeProgress: appendHarnessAssistantTranscript },
-      ).then((access) => {
-        sessionMeta.set({ ...sessionMeta.get(), apiMode: access.apiMode });
-        appendHarnessAssistantTranscript(access.message);
-      });
-    }
-    sessionMeta.set({ ...sessionMeta.get(), apiMode: route });
-    appendHarnessAssistantTranscript(`API mode set to ${route}.`);
+    sessionMeta.set({ ...sessionMeta.get(), apiMode: selection.apiMode });
+    appendHarnessAssistantTranscript(
+      `API fallback set to ${selection.apiMode}.`,
+    );
   },
   onMemorySelect: (storagePath) => {
     appendHarnessAssistantTranscript(

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -403,6 +403,33 @@ const SCENARIOS = [
     unexpect: ['coder —', 'Resume aaaaaaaaaaaa'],
   },
   {
+    name: 'orchestrate-independent-subscription-preferences',
+    frame: 'scrollback',
+    env: {
+      HARNESS_ORCHESTRATION: '1',
+      HARNESS_BOTH_SUBSCRIPTION_PREFERENCES: '1',
+      HARNESS_VISIBLE_TOOL_USE_AGENTS: '',
+      HARNESS_VISIBLE_WORKFLOW_AGENTS: '',
+    },
+    bootExpect: 'Model access — ChatGPT On · Kimi On',
+    keys: ['3'],
+    exitKeys: [ESC, ESC],
+    expectExit: true,
+    expect: [
+      'Model access',
+      'Toggle subscription preferences or choose the API fallback.',
+      'Prefer ChatGPT subscrip',
+      'On · harness@example.edu',
+      'Prefer Kimi Code subscr',
+      'On · key configured',
+      'Included TeXRA access',
+      'Personal API keys',
+      '✓ 4. Personal API keys',
+      'Esc back',
+    ],
+    unexpect: ['✓ 1. Prefer ChatGPT', '✓ 2. Prefer Kimi Code'],
+  },
+  {
     name: 'orchestrate-delegated-history',
     frame: 'scrollback',
     env: {
@@ -1009,8 +1036,9 @@ const SCENARIOS = [
     settleMs: ASYNC_FORM_SETTLE_MS,
     expect: [
       '/api',
-      'model access:',
-      'ChatGPT:',
+      'ChatGPT preference:',
+      'Kimi Code preference:',
+      'API fallback:',
       'TeXRA:',
       'Personal API keys',
       'Included TeXRA access',
@@ -1242,7 +1270,7 @@ const SCENARIOS = [
     env: { HARNESS_ENTRIES: '4' },
     keys: ['/api', '\r', '31'],
     frame: 'viewport',
-    expect: ['API mode set to included.'],
+    expect: ['kimi-code preference set to on.'],
     unexpect: ['ServerSideKeyService not initialized'],
   },
   {
@@ -1252,7 +1280,7 @@ const SCENARIOS = [
     env: { HARNESS_ENTRIES: '4' },
     keys: ['/api', '\r', '1'],
     frame: 'viewport',
-    expect: ['Model access set to ChatGPT subscription.'],
+    expect: ['chatgpt preference set to on.'],
     unexpect: ['ServerSideKeyService not initialized'],
   },
   {

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -551,6 +551,26 @@ const SCENARIOS = [
     ],
   },
   {
+    name: 'orchestrate-kimi-code-model-pick',
+    frame: 'scrollback',
+    env: {
+      HARNESS_ORCHESTRATION: '1',
+      HARNESS_API_MODE: 'personal',
+      HARNESS_KIMI_CODE_SUBSCRIPTION: '1',
+    },
+    bootExpect: 'Start a session or configure model access.',
+    keys: ['\r'],
+    exitKeys: [ESC, ESC],
+    expectExit: true,
+    expect: [
+      'Model · Kimi Code subscription',
+      'DeepSeek V4 Flash — api: api key set',
+      'Kimi K3 — api: Kimi Code subscription',
+      'Esc back',
+    ],
+    unexpect: ['Model · Personal API keys', 'Kimi K3 — api: api key set'],
+  },
+  {
     name: 'orchestrate-model-pick-esc-back-reselect',
     frame: 'scrollback',
     env: {

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -516,7 +516,7 @@ const SCENARIOS = [
     exitKeys: [ESC, ESC],
     expectExit: true,
     expect: [
-      'Model · Included TeXRA access',
+      'Model',
       'Model for the first message.',
       'Sonnet 4.6 (Thinking) — included: available',
       'GPT-5.4 — included: available',
@@ -538,7 +538,7 @@ const SCENARIOS = [
     exitKeys: [ESC, ESC],
     expectExit: true,
     expect: [
-      'Model · Personal API keys',
+      'Model',
       'Model for the first message.',
       'DeepSeek V4 Flash — api: api key set',
       'Esc back',
@@ -563,12 +563,16 @@ const SCENARIOS = [
     exitKeys: [ESC, ESC],
     expectExit: true,
     expect: [
-      'Model · Kimi Code subscription',
+      'Model',
       'DeepSeek V4 Flash — api: api key set',
       'Kimi K3 — api: Kimi Code subscription',
       'Esc back',
     ],
-    unexpect: ['Model · Personal API keys', 'Kimi K3 — api: api key set'],
+    unexpect: [
+      'Model · Personal API keys',
+      'Model · Kimi Code subscription',
+      'Kimi K3 — api: api key set',
+    ],
   },
   {
     name: 'orchestrate-model-pick-esc-back-reselect',
@@ -583,7 +587,7 @@ const SCENARIOS = [
     exitKeys: [ESC, ESC],
     expectExit: true,
     expect: [
-      'Model · Personal API keys',
+      'Model',
       'Model for the first message.',
       'DeepSeek V4 Flash — api: api key set',
       'Esc back',

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -1270,7 +1270,7 @@ const SCENARIOS = [
     env: { HARNESS_ENTRIES: '4' },
     keys: ['/api', '\r', '31'],
     frame: 'viewport',
-    expect: ['kimi-code preference set to on.'],
+    expect: ['API fallback set to included.'],
     unexpect: ['ServerSideKeyService not initialized'],
   },
   {
@@ -1294,7 +1294,7 @@ const SCENARIOS = [
     keys: ['/api', '\r', '2'],
     frame: 'viewport',
     expect: ['Prefer Kimi Code subscription enabled'],
-    expectCollapsed: ['fallback: personal API keys'],
+    expectCollapsed: ['API fallback remains Personal API keys'],
     unexpect: [
       'No Kimi Code API key configured',
       'ServerSideKeyService not initialized',

--- a/packages/cli/src/chat/tui/commands/handlers/apiModeCommands.ts
+++ b/packages/cli/src/chat/tui/commands/handlers/apiModeCommands.ts
@@ -7,12 +7,15 @@ import {
   selectCliRunnableModel,
 } from '@cli/runtime/modelAccess';
 import { saveProviderApiKey } from '@cli/runtime/providerApiKey';
-import { parseCliModelAccessRoute } from '@cli/runtime/modelAccessRoute';
+import {
+  cliApiFallbackSelection,
+  parseCliModelAccessSelection,
+  type CliModelAccessSelection,
+} from '@cli/runtime/modelAccessRoute';
 import {
   contextForCliModelAccess,
   type CliModelAccessSelectionResult,
-  selectCliApiModelAccessRoute,
-  selectCliModelAccessRoute,
+  updateCliModelAccess,
 } from '@cli/runtime/modelAccessSelection';
 
 import { patchSessionMeta, sessionMeta } from '@cli/chat/tui/state/cliState';
@@ -84,7 +87,10 @@ export async function applyCliProviderApiKey(
   context?: SlashCommandContext,
 ): Promise<string | undefined> {
   await saveProviderApiKey(provider, key);
-  const access = await selectCliApiModelAccessRoute('personal');
+  const access = await updateCliModelAccess(
+    context?.cliContext,
+    cliApiFallbackSelection('personal'),
+  );
   const message = await completeModelAccessSelection(access, context);
   if (provider === 'kimiCode') {
     // The coding-only models route through the subscription automatically;
@@ -109,6 +115,41 @@ export function setCliSessionApiMode(apiMode: CliApiMode): void {
 }
 
 async function applyCliModelAccessSelectionWithSignal(
+  selection: CliModelAccessSelection,
+  context: SlashCommandContext | undefined,
+  output: SlashCommandOutput,
+  signal: AbortSignal,
+): Promise<void> {
+  const cliContext =
+    context == null
+      ? undefined
+      : contextForCliModelAccess(context.cliContext, sessionMeta.get().apiMode);
+  const access = await updateCliModelAccess(cliContext, selection, {
+    writeProgress: (message) =>
+      output.writeProgress(message, { copyable: true }),
+    signal,
+  });
+  output.appendOutcome(await completeModelAccessSelection(access, context));
+}
+
+export function applyCliModelAccessSelection(
+  selection: CliModelAccessSelection,
+  context: SlashCommandContext | undefined,
+  output: SlashCommandOutput = transcriptSlashCommandOutput,
+): Promise<void> & { readonly abort: () => void } {
+  const controller = new AbortController();
+  return Object.assign(
+    applyCliModelAccessSelectionWithSignal(
+      selection,
+      context,
+      output,
+      controller.signal,
+    ),
+    { abort: () => controller.abort() },
+  );
+}
+
+async function applyCliModelAccessInputWithSignal(
   routeInput: string,
   context: SlashCommandContext,
   output: SlashCommandOutput,
@@ -126,32 +167,28 @@ async function applyCliModelAccessSelectionWithSignal(
     return;
   }
 
-  const route = parseCliModelAccessRoute(normalized);
-  if (route) {
-    const access = await selectCliModelAccessRoute(
-      contextForCliModelAccess(context.cliContext, sessionMeta.get().apiMode),
-      route,
-      {
-        writeProgress: (message) =>
-          output.writeProgress(message, { copyable: true }),
-        signal,
-      },
+  const selection = parseCliModelAccessSelection(normalized);
+  if (selection) {
+    await applyCliModelAccessSelectionWithSignal(
+      selection,
+      context,
+      output,
+      signal,
     );
-    output.appendOutcome(await completeModelAccessSelection(access, context));
     return;
   }
 
   output.setNotice(MODEL_ACCESS_USAGE);
 }
 
-export function applyCliModelAccessSelection(
+export function applyCliModelAccessInput(
   routeInput: string,
   context: SlashCommandContext,
   output: SlashCommandOutput = transcriptSlashCommandOutput,
 ): Promise<void> & { readonly abort: () => void } {
   const controller = new AbortController();
   return Object.assign(
-    applyCliModelAccessSelectionWithSignal(
+    applyCliModelAccessInputWithSignal(
       routeInput,
       context,
       output,

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -2,20 +2,19 @@
 
 import type { GetModelSwitchDisabledReason } from '@cli/runtime/modelAccess';
 import { parseCliHistoryId } from '@cli/runtime/history';
-import type { CliModelAccessRoute } from '@cli/runtime/modelAccessRoute';
+import {
+  cliApiFallbackSelection,
+  type CliModelAccessSelection,
+} from '@cli/runtime/modelAccessRoute';
 import {
   type CliLogoutTarget,
   parseChatLoginSlashArgs,
 } from '@cli/runtime/loginOptions';
 import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
 import type { ApiProvider } from '@model/apiProviders';
-import { invalidateModelOptionsCache } from '@model/computeModelOptions';
-import { platform } from '@platform/platform';
 import { AgentCategory, type ExecutionId } from '@shared/schemas';
 import { PROVIDER_DISPLAY_NAMES } from '@shared/constants/providers';
 import type { SettingsStores } from '@shared/config/settingsAccess';
-import { GlobalStateKey } from '@shared/state/stateKeys';
-import { setPreferKimiCode } from '@utils/config/providerConfig';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { collapseWhitespace } from '@utils/text/stringUtils';
 
@@ -46,6 +45,7 @@ import {
   applyInitialCliAgentSelection,
 } from './handlers/agentModelCommands';
 import {
+  applyCliModelAccessInput,
   applyCliModelAccessSelection,
   applyCliProviderApiKey,
 } from './handlers/apiModeCommands';
@@ -74,7 +74,7 @@ type ModelSelectHandler = (value: string) => void | Promise<void>;
 type FormActionResult =
   void | (Promise<void> & { readonly abort?: () => void });
 type ModelAccessSelectHandler = (
-  value: CliModelAccessRoute,
+  value: CliModelAccessSelection,
   output: SlashCommandOutput,
 ) => FormActionResult;
 type ApiKeySaveHandler = (
@@ -284,23 +284,8 @@ export function registerBuiltinSlashCommands(options?: {
     options?.onModelSelect ?? setCliSessionModelOverride;
   const onModelAccessSelect: ModelAccessSelectHandler =
     options?.onModelAccessSelect ??
-    (async (route, output) => {
-      if (route === 'kimi-code') {
-        // Fallback for hosts without full wiring (the TUI harness, tests):
-        // mirror the state transition `selectCliModelAccessRoute` performs —
-        // production chat always supplies its own handler that routes there.
-        patchSessionMeta({ apiMode: 'personal' });
-        await setPreferKimiCode(true);
-        await platform().globalState.update(
-          GlobalStateKey.USE_OPENROUTER,
-          false,
-        );
-        invalidateModelOptionsCache();
-      } else if (route !== 'chatgpt') {
-        patchSessionMeta({ apiMode: route });
-      }
-      output.appendOutcome(`Model access set to ${route}.`);
-    });
+    ((selection, output) =>
+      applyCliModelAccessSelection(selection, undefined, output));
   const onApiKeySave: ApiKeySaveHandler =
     options?.onApiKeySave ?? applyCliProviderApiKey;
   const onLoginSelect: LoginSelectHandler =
@@ -358,7 +343,7 @@ export function registerBuiltinSlashCommands(options?: {
       <ModelAccessForm
         apiMode={current}
         availableRows={props.availableRows}
-        onSelect={formSelectionHandler<CliModelAccessRoute>({
+        onSelect={formSelectionHandler<CliModelAccessSelection>({
           action: onModelAccessSelect,
           onDone: props.onDone,
           onError: options?.onError,
@@ -575,7 +560,7 @@ export function registerBuiltinSlashCommands(options?: {
       'Choose ChatGPT, Kimi Code, included TeXRA, or personal model access',
     category: 'configuration',
     echo: 'ifPersists',
-    argHandler: applyCliModelAccessSelection,
+    argHandler: applyCliModelAccessInput,
     formName: 'api',
     formComponent: ModelAccessFormAdapter,
   });
@@ -709,7 +694,10 @@ export function registerBuiltinSlashCommands(options?: {
             // Code route) must not be treated as an explicit "Personal API
             // keys" picker choice, which would clear the Kimi preference.
             if (sessionMeta.get().apiMode === 'personal') return;
-            await onModelAccessSelect('personal', transcriptSlashCommandOutput);
+            await onModelAccessSelect(
+              cliApiFallbackSelection('personal'),
+              transcriptSlashCommandOutput,
+            );
           }}
         />
       );

--- a/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
+++ b/packages/cli/src/chat/tui/commands/registerBuiltins.tsx
@@ -690,9 +690,7 @@ export function registerBuiltinSlashCommands(options?: {
           }}
           onApiModePersonal={async () => {
             // A key save only needs the mode switch when leaving included
-            // access — already-personal sessions (including an active Kimi
-            // Code route) must not be treated as an explicit "Personal API
-            // keys" picker choice, which would clear the Kimi preference.
+            // access; already-personal sessions require no state change.
             if (sessionMeta.get().apiMode === 'personal') return;
             await onModelAccessSelect(
               cliApiFallbackSelection('personal'),

--- a/packages/cli/src/chat/tui/forms/ModelAccessForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelAccessForm.tsx
@@ -8,7 +8,9 @@ import {
 } from '@cli/runtime/apiStatus';
 import {
   buildCliModelAccessItems,
-  type CliModelAccessRoute,
+  cliApiFallbackSelection,
+  CLI_MODEL_ACCESS_DESCRIPTION,
+  type CliModelAccessSelection,
 } from '@cli/runtime/modelAccessRoute';
 
 import { useCancellableEffect } from '../state/useCancellableEffect';
@@ -18,7 +20,7 @@ import { ListForm } from './_shared/ListForm';
 interface ModelAccessFormProps {
   readonly apiMode: CliApiMode;
   readonly availableRows?: number;
-  readonly onSelect: (value: CliModelAccessRoute) => void;
+  readonly onSelect: (value: CliModelAccessSelection) => void;
   readonly onCancel: () => void;
 }
 
@@ -54,7 +56,8 @@ export function ModelAccessForm(
     status?.state === 'loaded'
       ? status.overview.access
       : {
-          active: props.apiMode,
+          apiFallback: props.apiMode,
+          preferences: { chatGpt: 'off', kimiCode: 'off' },
           chatGptSignedIn: false,
           texraSignedIn: false,
         },
@@ -69,12 +72,8 @@ export function ModelAccessForm(
       availableRows={props.availableRows}
       items={items}
       compactVisibleItems={items.length}
-      activeValue={
-        status?.state === 'loaded' ? status.overview.access.active : undefined
-      }
-      description={
-        <Text dimColor>Choose how model calls are authenticated.</Text>
-      }
+      activeValue={cliApiFallbackSelection(props.apiMode)}
+      description={<Text dimColor>{CLI_MODEL_ACCESS_DESCRIPTION}</Text>}
       detail={
         <Box marginTop={1} flexDirection="column">
           {detailLines === undefined ? (

--- a/packages/cli/src/chat/tui/forms/ModelAccessForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelAccessForm.tsx
@@ -52,16 +52,16 @@ export function ModelAccessForm(
     [props.apiMode],
   );
 
-  const items = buildCliModelAccessItems(
+  const items =
     status?.state === 'loaded'
-      ? status.overview.access
-      : {
-          apiFallback: props.apiMode,
-          preferences: { chatGpt: 'off', kimiCode: 'off' },
-          chatGptSignedIn: false,
-          texraSignedIn: false,
-        },
-  );
+      ? buildCliModelAccessItems({
+          kind: 'loaded',
+          access: status.overview.access,
+        })
+      : buildCliModelAccessItems({
+          kind: 'pending',
+          state: status?.state ?? 'loading',
+        });
   let detailLines: readonly string[] | undefined;
   if (status?.state === 'loaded') detailLines = status.overview.lines;
   if (status?.state === 'failed') detailLines = [status.message];

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -51,7 +51,7 @@ import { resolveChatDefaults } from '../runtime/chatDefaults';
 import {
   contextForCliModelAccess,
   readCliModelAccessStatus,
-  selectCliModelAccessRoute,
+  updateCliModelAccess,
 } from '../runtime/modelAccessSelection';
 import {
   chatGptSignOutPreferenceMessage,
@@ -342,9 +342,13 @@ async function runOrchestration(context: CliContext): Promise<number> {
                 `Signed out of ChatGPT.\n${chatGptSignOutPreferenceMessage(update)}`,
               );
             } else {
-              const result = await selectCliModelAccessRoute(
+              const result = await updateCliModelAccess(
                 launchContext,
-                'chatgpt',
+                {
+                  kind: 'subscription-preference',
+                  provider: 'chatgpt',
+                  state: 'on',
+                },
                 { writeProgress: writeTextStdout },
               );
               launcherApiModeOverride = result.apiMode;
@@ -364,7 +368,7 @@ async function runOrchestration(context: CliContext): Promise<number> {
       }
       case 'set-model-access': {
         try {
-          const result = await selectCliModelAccessRoute(
+          const result = await updateCliModelAccess(
             launchContext,
             action.access,
             { writeProgress: writeTextStdout },

--- a/packages/cli/src/onboarding/runOnboarding.tsx
+++ b/packages/cli/src/onboarding/runOnboarding.tsx
@@ -50,7 +50,8 @@ import { Select, type SelectItem } from '../chat/tui/ui/Select';
 import { type CliApiMode } from '../runtime/apiAccessMode';
 import { chatGptAccountLabel, signInCliChatGpt } from '../runtime/chatgptLogin';
 import { hasCliCredentialForApiMode } from '../runtime/credentialStatus';
-import { selectCliApiModelAccessRoute } from '../runtime/modelAccessSelection';
+import { cliApiFallbackSelection } from '../runtime/modelAccessRoute';
+import { updateCliModelAccess } from '../runtime/modelAccessSelection';
 import { saveProviderApiKey } from '../runtime/providerApiKey';
 import { writeTextStderr, writeTextStdout } from '../runtime/logSinks';
 import { CLI_OAUTH_PROVIDER_ITEMS } from '../runtime/oauthProviderDisplay';
@@ -407,7 +408,10 @@ function OnboardingApp(props: OnboardingAppProps): React.JSX.Element {
           void (async () => {
             try {
               await saveProviderApiKey(keyProvider, key);
-              const selection = await selectCliApiModelAccessRoute('personal');
+              const selection = await updateCliModelAccess(
+                undefined,
+                cliApiFallbackSelection('personal'),
+              );
               finish({
                 configured: true,
                 declined: false,

--- a/packages/cli/src/orchestration/runOrchestrationTui.tsx
+++ b/packages/cli/src/orchestration/runOrchestrationTui.tsx
@@ -18,8 +18,6 @@ import {
   buildCliModelAccessItems,
   cliApiFallbackSelection,
   CLI_MODEL_ACCESS_DESCRIPTION,
-  formatCliModelAccessRoute,
-  resolveCliModelAccessRoute,
   type CliModelAccessStatus,
 } from '../runtime/modelAccessRoute';
 import type { CliApiMode } from '../runtime/apiAccessMode';
@@ -308,15 +306,6 @@ export function OrchestrationApp(
   const modelStepSubtitle = isPendingTeam
     ? 'Runs the orchestrator agent and is the model it can choose for delegation.'
     : 'Model for the first message.';
-  const modelStepAccessRoute = resolveCliModelAccessRoute({
-    apiMode: props.apiMode,
-    subscriptionActive:
-      props.modelAccess?.preferences.chatGpt === 'on' &&
-      props.modelAccess.chatGptSignedIn,
-    kimiCodeActive:
-      props.modelAccess?.preferences.kimiCode === 'on' &&
-      props.modelAccess.kimiCodeKeySet === true,
-  });
   let headerLines: readonly string[];
   if (modelAccessOpen) {
     headerLines = ['Model access', CLI_MODEL_ACCESS_DESCRIPTION];
@@ -329,10 +318,7 @@ export function OrchestrationApp(
   } else if (accountOpen) {
     headerLines = ['Account', 'Log in or log out.'];
   } else if (pending) {
-    headerLines = [
-      `${modelStepTitle} · ${formatCliModelAccessRoute(modelStepAccessRoute)}`,
-      modelStepSubtitle,
-    ];
+    headerLines = [modelStepTitle, modelStepSubtitle];
   } else {
     headerLines = [`TeXRA v${props.version}`, ORCHESTRATION_LAUNCHER_SUBTITLE];
   }
@@ -537,10 +523,6 @@ export function OrchestrationApp(
       <Box flexDirection="column" paddingX={1}>
         <Text bold color="cyan">
           {modelStepTitle}
-          {' · '}
-          <Text dimColor>
-            {formatCliModelAccessRoute(modelStepAccessRoute)}
-          </Text>
         </Text>
         <Text dimColor>{modelStepSubtitle}</Text>
         <Box marginTop={1}>

--- a/packages/cli/src/orchestration/runOrchestrationTui.tsx
+++ b/packages/cli/src/orchestration/runOrchestrationTui.tsx
@@ -19,6 +19,7 @@ import {
   cliApiFallbackSelection,
   CLI_MODEL_ACCESS_DESCRIPTION,
   formatCliModelAccessRoute,
+  resolveCliModelAccessRoute,
   type CliModelAccessStatus,
 } from '../runtime/modelAccessRoute';
 import type { CliApiMode } from '../runtime/apiAccessMode';
@@ -307,6 +308,15 @@ export function OrchestrationApp(
   const modelStepSubtitle = isPendingTeam
     ? 'Runs the orchestrator agent and is the model it can choose for delegation.'
     : 'Model for the first message.';
+  const modelStepAccessRoute = resolveCliModelAccessRoute({
+    apiMode: props.apiMode,
+    subscriptionActive:
+      props.modelAccess?.preferences.chatGpt === 'on' &&
+      props.modelAccess.chatGptSignedIn,
+    kimiCodeActive:
+      props.modelAccess?.preferences.kimiCode === 'on' &&
+      props.modelAccess.kimiCodeKeySet === true,
+  });
   let headerLines: readonly string[];
   if (modelAccessOpen) {
     headerLines = ['Model access', CLI_MODEL_ACCESS_DESCRIPTION];
@@ -320,7 +330,7 @@ export function OrchestrationApp(
     headerLines = ['Account', 'Log in or log out.'];
   } else if (pending) {
     headerLines = [
-      `${modelStepTitle} · ${formatCliModelAccessRoute(props.apiMode)}`,
+      `${modelStepTitle} · ${formatCliModelAccessRoute(modelStepAccessRoute)}`,
       modelStepSubtitle,
     ];
   } else {
@@ -528,7 +538,9 @@ export function OrchestrationApp(
         <Text bold color="cyan">
           {modelStepTitle}
           {' · '}
-          <Text dimColor>{formatCliModelAccessRoute(props.apiMode)}</Text>
+          <Text dimColor>
+            {formatCliModelAccessRoute(modelStepAccessRoute)}
+          </Text>
         </Text>
         <Text dimColor>{modelStepSubtitle}</Text>
         <Box marginTop={1}>

--- a/packages/cli/src/orchestration/runOrchestrationTui.tsx
+++ b/packages/cli/src/orchestration/runOrchestrationTui.tsx
@@ -16,8 +16,9 @@ import {
 } from '../runtime/orchestration';
 import {
   buildCliModelAccessItems,
+  cliApiFallbackSelection,
+  CLI_MODEL_ACCESS_DESCRIPTION,
   formatCliModelAccessRoute,
-  type CliModelAccessRoute,
   type CliModelAccessStatus,
 } from '../runtime/modelAccessRoute';
 import type { CliApiMode } from '../runtime/apiAccessMode';
@@ -296,8 +297,6 @@ export function OrchestrationApp(
   const modelAccessItems = props.modelAccess
     ? buildCliModelAccessItems(props.modelAccess)
     : [];
-  const activeModelAccess: CliModelAccessRoute | undefined =
-    props.modelAccess?.active;
   const isPendingTeam = pending?.kind === 'preset';
   // Model-step header text, shared between the wrapped-row measurement in
   // `headerLines` and the styled render in the `pending` branch below.
@@ -307,10 +306,7 @@ export function OrchestrationApp(
     : 'Model for the first message.';
   let headerLines: readonly string[];
   if (modelAccessOpen) {
-    headerLines = [
-      'Model access',
-      'Choose how TeXRA should authenticate model calls.',
-    ];
+    headerLines = ['Model access', CLI_MODEL_ACCESS_DESCRIPTION];
   } else if (resumeOpen) {
     headerLines = ['Resume', 'Choose a previous session to continue.'];
   } else if (agentOpen) {
@@ -423,12 +419,12 @@ export function OrchestrationApp(
         <Text bold color="cyan">
           Model access
         </Text>
-        <Text dimColor>Choose how TeXRA should authenticate model calls.</Text>
+        <Text dimColor>{CLI_MODEL_ACCESS_DESCRIPTION}</Text>
         <Box marginTop={1}>
           <Select
             key="orchestration-model-access-picker"
             items={modelAccessItems}
-            activeValue={activeModelAccess}
+            activeValue={cliApiFallbackSelection(props.apiMode)}
             maxVisibleItems={layout.maxVisibleItems}
             showOverflow={layout.showOverflow}
             onSelect={(access) => finish({ kind: 'set-model-access', access })}

--- a/packages/cli/src/orchestration/runOrchestrationTui.tsx
+++ b/packages/cli/src/orchestration/runOrchestrationTui.tsx
@@ -295,7 +295,10 @@ export function OrchestrationApp(
   const teamOpen = step.kind === 'team';
   const accountOpen = step.kind === 'account';
   const modelAccessItems = props.modelAccess
-    ? buildCliModelAccessItems(props.modelAccess)
+    ? buildCliModelAccessItems({
+        kind: 'loaded',
+        access: props.modelAccess,
+      })
     : [];
   const isPendingTeam = pending?.kind === 'preset';
   // Model-step header text, shared between the wrapped-row measurement in

--- a/packages/cli/src/runtime/apiStatus.ts
+++ b/packages/cli/src/runtime/apiStatus.ts
@@ -6,6 +6,8 @@ import { formatPercent } from '@utils/text/stringUtils';
 
 import { getCliApiMode, type CliApiMode } from './apiAccessMode';
 import {
+  formatCliChatGptPreference,
+  formatCliKimiCodePreference,
   formatCliModelAccessRoute,
   formatCliModelAccessRouteInline,
   type CliModelAccessStatus,
@@ -64,26 +66,15 @@ export async function loadCliModelAccessOverview(
     getCliAuthProfile(),
   ]);
   const lines = [
-    `model access: ${formatCliModelAccessRoute(access.active)}`,
-    formatAccountStatusLine(
-      'ChatGPT',
-      access.chatGptSignedIn,
-      access.chatGptAccountLabel,
-    ),
-    `Kimi Code: ${
-      access.kimiCodeKeySet === true
-        ? 'key configured'
-        : 'no key (add with /key)'
-    }`,
+    `ChatGPT preference: ${formatCliChatGptPreference(access)}`,
+    `Kimi Code preference: ${formatCliKimiCodePreference(access)}`,
+    `API fallback: ${formatCliModelAccessRoute(access.apiFallback)}`,
     formatAccountStatusLine(
       'TeXRA',
       profile.authenticated,
       profile.accountLabel,
     ),
   ];
-  if (access.active === 'chatgpt' || access.active === 'kimi-code') {
-    lines.push(`API fallback: ${formatCliModelAccessRoute(apiMode)}`);
-  }
   if (profile.note) lines.push(profile.note);
   return {
     access: { ...access, texraSignedIn: profile.authenticated },

--- a/packages/cli/src/runtime/chatgptLogin.ts
+++ b/packages/cli/src/runtime/chatgptLogin.ts
@@ -77,17 +77,26 @@ export async function signInCliChatGpt(
   return loginWithLoopback({
     coordinator,
     openBrowser: async (url) => {
-      if (!init.noBrowser && (await tryOpenBrowser(url))) {
-        // Always print the link even after a successful launch: the
-        // loopback callback accepts the redirect from any browser, so a
-        // user whose ChatGPT session lives elsewhere can just copy it from
-        // the terminal instead of needing `--no-browser` ahead of time.
+      if (init.noBrowser) {
+        options.writeProgress(`ChatGPT sign-in URL:\n${url}`);
+        return;
+      }
+
+      // Publish the usable URL before awaiting the browser process. Some
+      // launchers remain open until the browser exits; the sign-in panel must
+      // not hide the only manual route behind that wait.
+      options.writeProgress(
+        `ChatGPT sign-in URL:\n${url}\nBrowser launch in progress...`,
+      );
+      if (await tryOpenBrowser(url)) {
         options.writeProgress(
-          `Opening your browser to sign in with ChatGPT. Using a different browser? Open this URL there instead:\n${url}`,
+          `ChatGPT sign-in URL:\n${url}\nBrowser opened; the same URL works in another browser.`,
         );
         return;
       }
-      options.writeProgress(`Open this URL to sign in with ChatGPT:\n${url}`);
+      options.writeProgress(
+        `ChatGPT sign-in URL:\n${url}\nAutomatic browser launch failed; the URL remains available above.`,
+      );
     },
     signal: options.signal,
   });

--- a/packages/cli/src/runtime/modelAccess.ts
+++ b/packages/cli/src/runtime/modelAccess.ts
@@ -274,7 +274,11 @@ export function formatModelStatusForCliMode(
   model: CliModelAccess,
   apiMode: CliApiMode,
 ): string {
-  if (apiMode === 'personal') return `api: ${model.status}`;
+  if (apiMode === 'personal') {
+    return model.model.provider === 'kimiCode'
+      ? 'api: Kimi Code subscription'
+      : `api: ${model.status}`;
+  }
 
   const availability = model.model.availability;
   if (availability == null) return `included: ${model.status}`;

--- a/packages/cli/src/runtime/modelAccessRoute.ts
+++ b/packages/cli/src/runtime/modelAccessRoute.ts
@@ -8,10 +8,10 @@ export const CLI_MODEL_ACCESS_DESCRIPTION =
 export type CliModelAccessRoute =
   'chatgpt' | 'kimi-code' | 'included' | 'personal';
 
-export type CliSubscriptionPreferenceState = 'off' | 'on';
-export type CliSubscriptionProvider = 'chatgpt' | 'kimi-code';
+type CliSubscriptionPreferenceState = 'off' | 'on';
+type CliSubscriptionProvider = 'chatgpt' | 'kimi-code';
 
-export interface CliSubscriptionPreferences {
+interface CliSubscriptionPreferences {
   readonly chatGpt: CliSubscriptionPreferenceState;
   readonly kimiCode: CliSubscriptionPreferenceState;
 }
@@ -27,10 +27,21 @@ export type CliModelAccessSelection =
       readonly apiMode: CliApiMode;
     };
 
-const cliApiFallbackSelections = {
-  included: { kind: 'api-fallback', apiMode: 'included' },
-  personal: { kind: 'api-fallback', apiMode: 'personal' },
-} as const satisfies Record<CliApiMode, CliModelAccessSelection>;
+type CliApiFallbackSelection = Extract<
+  CliModelAccessSelection,
+  { readonly kind: 'api-fallback' }
+>;
+
+const cliApiFallbackSelections = Object.freeze({
+  included: Object.freeze({
+    kind: 'api-fallback',
+    apiMode: 'included',
+  }),
+  personal: Object.freeze({
+    kind: 'api-fallback',
+    apiMode: 'personal',
+  }),
+} as const satisfies Record<CliApiMode, CliApiFallbackSelection>);
 
 export interface CliModelAccessStatus {
   readonly apiFallback: CliApiMode;
@@ -46,12 +57,23 @@ interface CliModelAccessItem {
   readonly value: CliModelAccessSelection;
   readonly label: string;
   readonly description: string;
+  readonly disabled?: boolean;
 }
+
+type CliModelAccessItemsInput =
+  | {
+      readonly kind: 'loaded';
+      readonly access: CliModelAccessStatus;
+    }
+  | {
+      readonly kind: 'pending';
+      readonly state: 'failed' | 'loading';
+    };
 
 /** Return the stable selection object for one API fallback. */
 export function cliApiFallbackSelection(
   apiMode: CliApiMode,
-): CliModelAccessSelection {
+): CliApiFallbackSelection {
   return cliApiFallbackSelections[apiMode];
 }
 
@@ -176,34 +198,61 @@ export function formatCliKimiCodePreference(
     : 'Off · key required to enable';
 }
 
+const cliSubscriptionAccessItems = [
+  {
+    provider: 'chatgpt',
+    preference: 'chatGpt',
+    label: 'Prefer ChatGPT subscription',
+    formatDescription: formatCliChatGptPreference,
+  },
+  {
+    provider: 'kimi-code',
+    preference: 'kimiCode',
+    label: 'Prefer Kimi Code subscription',
+    formatDescription: formatCliKimiCodePreference,
+  },
+] as const satisfies ReadonlyArray<{
+  readonly provider: CliSubscriptionProvider;
+  readonly preference: keyof CliSubscriptionPreferences;
+  readonly label: string;
+  readonly formatDescription: (status: CliModelAccessStatus) => string;
+}>;
+
 /** Build the canonical choices shown by every model-access picker. */
 export function buildCliModelAccessItems(
-  status: CliModelAccessStatus,
+  input: CliModelAccessItemsInput,
 ): CliModelAccessItem[] {
+  const status = input.kind === 'loaded' ? input.access : undefined;
+  let pendingDescription = '';
+  if (input.kind === 'pending') {
+    pendingDescription =
+      input.state === 'loading'
+        ? 'Loading current preference'
+        : 'Current preference unavailable';
+  }
+  const preferenceItems = cliSubscriptionAccessItems.map(
+    ({ formatDescription, label, preference, provider }) => {
+      const state: CliSubscriptionPreferenceState =
+        status?.preferences[preference] === 'on' ? 'off' : 'on';
+      return {
+        value: {
+          kind: 'subscription-preference' as const,
+          provider,
+          state,
+        },
+        label,
+        description: status ? formatDescription(status) : pendingDescription,
+        ...(status === undefined ? { disabled: true } : {}),
+      };
+    },
+  ) satisfies CliModelAccessItem[];
   return [
-    {
-      value: {
-        kind: 'subscription-preference',
-        provider: 'chatgpt',
-        state: status.preferences.chatGpt === 'on' ? 'off' : 'on',
-      },
-      label: 'Prefer ChatGPT subscription',
-      description: formatCliChatGptPreference(status),
-    },
-    {
-      value: {
-        kind: 'subscription-preference',
-        provider: 'kimi-code',
-        state: status.preferences.kimiCode === 'on' ? 'off' : 'on',
-      },
-      label: 'Prefer Kimi Code subscription',
-      description: formatCliKimiCodePreference(status),
-    },
+    ...preferenceItems,
     {
       value: cliApiFallbackSelection('included'),
       label: formatCliModelAccessRoute('included'),
       description:
-        status.texraSignedIn === false
+        status?.texraSignedIn === false
           ? 'Sign in through Account to use included models'
           : 'Use your TeXRA account',
     },

--- a/packages/cli/src/runtime/modelAccessRoute.ts
+++ b/packages/cli/src/runtime/modelAccessRoute.ts
@@ -2,11 +2,40 @@ import type { UsageRoute } from '@shared/schemas';
 
 import { parseCliApiMode, type CliApiMode } from './apiAccessMode';
 
+export const CLI_MODEL_ACCESS_DESCRIPTION =
+  'Toggle subscription preferences or choose the API fallback.';
+
 export type CliModelAccessRoute =
   'chatgpt' | 'kimi-code' | 'included' | 'personal';
 
+export type CliSubscriptionPreferenceState = 'off' | 'on';
+export type CliSubscriptionProvider = 'chatgpt' | 'kimi-code';
+
+export interface CliSubscriptionPreferences {
+  readonly chatGpt: CliSubscriptionPreferenceState;
+  readonly kimiCode: CliSubscriptionPreferenceState;
+}
+
+export type CliModelAccessSelection =
+  | {
+      readonly kind: 'subscription-preference';
+      readonly provider: CliSubscriptionProvider;
+      readonly state: CliSubscriptionPreferenceState;
+    }
+  | {
+      readonly kind: 'api-fallback';
+      readonly apiMode: CliApiMode;
+    };
+
+const cliApiFallbackSelections = {
+  included: { kind: 'api-fallback', apiMode: 'included' },
+  personal: { kind: 'api-fallback', apiMode: 'personal' },
+} as const satisfies Record<CliApiMode, CliModelAccessSelection>;
+
 export interface CliModelAccessStatus {
-  readonly active: CliModelAccessRoute;
+  readonly apiFallback: CliApiMode;
+  /** Independent provider preferences; either, both, or neither may be on. */
+  readonly preferences: CliSubscriptionPreferences;
   readonly chatGptSignedIn: boolean;
   readonly chatGptAccountLabel?: string;
   readonly kimiCodeKeySet?: boolean;
@@ -14,25 +43,40 @@ export interface CliModelAccessStatus {
 }
 
 interface CliModelAccessItem {
-  readonly value: CliModelAccessRoute;
+  readonly value: CliModelAccessSelection;
   readonly label: string;
   readonly description: string;
 }
 
-export function parseCliModelAccessRoute(
+/** Return the stable selection object for one API fallback. */
+export function cliApiFallbackSelection(
+  apiMode: CliApiMode,
+): CliModelAccessSelection {
+  return cliApiFallbackSelections[apiMode];
+}
+
+export function parseCliModelAccessSelection(
   input: string,
-): CliModelAccessRoute | undefined {
+): CliModelAccessSelection | undefined {
   const apiMode = parseCliApiMode(input);
-  if (apiMode) return apiMode;
+  if (apiMode) return cliApiFallbackSelection(apiMode);
 
   switch (input.trim().toLowerCase()) {
     case 'chatgpt':
     case 'subscription':
-      return 'chatgpt';
+      return {
+        kind: 'subscription-preference',
+        provider: 'chatgpt',
+        state: 'on',
+      };
     case 'kimi':
     case 'kimicode':
     case 'kimi-code':
-      return 'kimi-code';
+      return {
+        kind: 'subscription-preference',
+        provider: 'kimi-code',
+        state: 'on',
+      };
     default:
       return undefined;
   }
@@ -104,41 +148,59 @@ export function formatCliModelAccessRouteInline(
     : label.charAt(0).toLowerCase() + label.slice(1);
 }
 
+/** Format the ChatGPT preference independently of credential availability. */
+export function formatCliChatGptPreference(
+  status: CliModelAccessStatus,
+): string {
+  if (status.preferences.chatGpt === 'on' && status.chatGptSignedIn) {
+    return `On · ${status.chatGptAccountLabel ?? 'your account'}`;
+  }
+  if (status.chatGptSignedIn) {
+    return `Off · ${status.chatGptAccountLabel ?? 'your account'}`;
+  }
+  return status.preferences.chatGpt === 'on'
+    ? 'On · sign in required'
+    : 'Off · sign in required to enable';
+}
+
+/** Format the Kimi preference independently of key availability. */
+export function formatCliKimiCodePreference(
+  status: CliModelAccessStatus,
+): string {
+  if (status.preferences.kimiCode === 'on' && status.kimiCodeKeySet !== true) {
+    return 'On · key required';
+  }
+  if (status.preferences.kimiCode === 'on') return 'On · key configured';
+  return status.kimiCodeKeySet === true
+    ? 'Off · key configured'
+    : 'Off · key required to enable';
+}
+
 /** Build the canonical choices shown by every model-access picker. */
 export function buildCliModelAccessItems(
   status: CliModelAccessStatus,
 ): CliModelAccessItem[] {
-  let chatGptDescription: string;
-  if (status.active === 'chatgpt') {
-    chatGptDescription = `On · ${status.chatGptAccountLabel ?? 'your account'}`;
-  } else if (status.chatGptSignedIn) {
-    chatGptDescription = `Off · ${status.chatGptAccountLabel ?? 'your account'}`;
-  } else {
-    chatGptDescription = 'Sign in with ChatGPT Plus/Pro/Team';
-  }
-
-  let kimiCodeDescription: string;
-  if (status.kimiCodeKeySet !== true) {
-    kimiCodeDescription = 'Add a key with /key (kimi.com/code/console)';
-  } else if (status.active === 'kimi-code') {
-    kimiCodeDescription = 'On · key configured';
-  } else {
-    kimiCodeDescription = 'Off · key configured';
-  }
-
   return [
     {
-      value: 'chatgpt',
+      value: {
+        kind: 'subscription-preference',
+        provider: 'chatgpt',
+        state: status.preferences.chatGpt === 'on' ? 'off' : 'on',
+      },
       label: 'Prefer ChatGPT subscription',
-      description: chatGptDescription,
+      description: formatCliChatGptPreference(status),
     },
     {
-      value: 'kimi-code',
+      value: {
+        kind: 'subscription-preference',
+        provider: 'kimi-code',
+        state: status.preferences.kimiCode === 'on' ? 'off' : 'on',
+      },
       label: 'Prefer Kimi Code subscription',
-      description: kimiCodeDescription,
+      description: formatCliKimiCodePreference(status),
     },
     {
-      value: 'included',
+      value: cliApiFallbackSelection('included'),
       label: formatCliModelAccessRoute('included'),
       description:
         status.texraSignedIn === false
@@ -146,9 +208,18 @@ export function buildCliModelAccessItems(
           : 'Use your TeXRA account',
     },
     {
-      value: 'personal',
+      value: cliApiFallbackSelection('personal'),
       label: formatCliModelAccessRoute('personal'),
       description: 'Use keys configured on this computer',
     },
   ];
+}
+
+/** Compact configuration summary; observed per-request routes use UsageRoute. */
+export function formatCliModelAccessSummary(
+  status: CliModelAccessStatus,
+): string {
+  const chatGpt = status.preferences.chatGpt === 'on' ? 'On' : 'Off';
+  const kimiCode = status.preferences.kimiCode === 'on' ? 'On' : 'Off';
+  return `ChatGPT ${chatGpt} · Kimi ${kimiCode} · fallback: ${formatCliModelAccessRouteInline(status.apiFallback)}`;
 }

--- a/packages/cli/src/runtime/modelAccessSelection.ts
+++ b/packages/cli/src/runtime/modelAccessSelection.ts
@@ -9,7 +9,6 @@ import { platform } from '@platform/platform';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import {
   getPreferKimiCode,
-  getUseOpenRouter,
   setPreferKimiCode,
 } from '@utils/config/providerConfig';
 
@@ -20,12 +19,13 @@ import {
 } from './chatgptLogin';
 import {
   effectiveCliApiMode,
+  getCliApiMode,
   setCliApiMode,
   type CliApiMode,
 } from './apiAccessMode';
 import {
   formatCliModelAccessRoute,
-  type CliModelAccessRoute,
+  type CliModelAccessSelection,
   type CliModelAccessStatus,
 } from './modelAccessRoute';
 import type { CliContext } from './cliContext';
@@ -51,84 +51,78 @@ export async function readCliModelAccessStatus(
     getCodexStatus(),
     apiKeyExists(platform().secrets, 'kimiCode'),
   ]);
-  const chatGptActive = chatGpt.signedIn && isPreferCodexSubscription();
-  // The Kimi Code route is a personal-key route: it only describes the active
-  // access while the API fallback mode is personal, the prefer switch is on,
-  // and dispatch can actually honor it (OpenRouter off — dual-backend models
-  // refuse the coding endpoint while it is on).
-  const kimiCodeActive =
-    !chatGptActive &&
-    apiMode === 'personal' &&
-    getPreferKimiCode() &&
-    !getUseOpenRouter() &&
-    kimiCodeKeySet;
-  let active: CliModelAccessStatus['active'] = apiMode;
-  if (chatGptActive) active = 'chatgpt';
-  else if (kimiCodeActive) active = 'kimi-code';
+  const preferences = {
+    chatGpt: isPreferCodexSubscription() ? 'on' : 'off',
+    kimiCode: getPreferKimiCode() ? 'on' : 'off',
+  } as const;
   return {
-    active,
+    apiFallback: apiMode,
+    preferences,
     chatGptSignedIn: chatGpt.signedIn,
     chatGptAccountLabel: chatGpt.email ?? chatGpt.accountId,
     kimiCodeKeySet,
   };
 }
 
-/** Select an API-backed route and stop preferring ChatGPT subscription use. */
-export async function selectCliApiModelAccessRoute(
-  route: CliApiMode,
-): Promise<CliModelAccessSelectionResult> {
-  const update = await setPreferCodexSubscription(false);
-  await setCliApiMode(route);
-  return {
-    apiMode: route,
-    message: update.effective
-      ? `Model access remains on ChatGPT subscription because a more specific setting overrides ${update.target} config.`
-      : `Model access: ${formatCliModelAccessRoute(route)}.`,
-  };
+function selectedApiFallback(context: CliContext | undefined): CliApiMode {
+  return context ? effectiveCliApiMode(context) : getCliApiMode();
 }
 
-export async function selectCliModelAccessRoute(
-  context: CliContext,
-  route: CliModelAccessRoute,
+/** Apply one declarative preference or fallback transition. */
+export async function updateCliModelAccess(
+  context: CliContext | undefined,
+  selection: CliModelAccessSelection,
   options: {
     readonly writeProgress: (message: string) => void;
     readonly signal?: AbortSignal;
-  },
+  } = { writeProgress: () => undefined },
 ): Promise<CliModelAccessSelectionResult> {
-  if (route === 'included') {
-    return selectCliApiModelAccessRoute(route);
+  if (selection.kind === 'api-fallback') {
+    await setCliApiMode(selection.apiMode);
+    return {
+      apiMode: selection.apiMode,
+      message: `API fallback: ${formatCliModelAccessRoute(selection.apiMode)}.`,
+    };
   }
 
-  if (route === 'personal') {
-    // An explicit "personal keys" picker choice leaves the Kimi Code route;
-    // saving a key never clears the switch (see applyCliProviderApiKey), and
-    // the prefer toggle stays available under /config → Models and providers.
-    await setPreferKimiCode(false);
-    return selectCliApiModelAccessRoute(route);
-  }
+  const apiMode = selectedApiFallback(context);
+  if (selection.provider === 'kimi-code') {
+    if (selection.state === 'off') {
+      await setPreferKimiCode(false);
+      invalidateModelOptionsCache();
+      return {
+        apiMode,
+        message: 'Prefer Kimi Code subscription disabled for Kimi models.',
+      };
+    }
 
-  if (route === 'kimi-code') {
     // The Kimi Code API key is the subscription credential — there is no
     // separate sign-in flow.
     if (!(await apiKeyExists(platform().secrets, 'kimiCode'))) {
       return {
-        apiMode: effectiveCliApiMode(context),
+        apiMode,
         message:
           'No Kimi Code API key configured — add one with /key or /config → API keys (get one at https://www.kimi.com/code/console).',
       };
     }
-    const update = await setPreferCodexSubscription(false);
     await setPreferKimiCode(true);
     // Dual-backend Kimi routing requires the OpenRouter toggle off.
     await platform().globalState.update(GlobalStateKey.USE_OPENROUTER, false);
-    // Non-Moonshot models fall back to the other personal keys.
-    await setCliApiMode('personal');
     invalidateModelOptionsCache();
     return {
-      apiMode: 'personal',
+      apiMode,
+      message: `Prefer Kimi Code subscription enabled for Kimi models · API fallback remains ${formatCliModelAccessRoute(apiMode)}.`,
+    };
+  }
+
+  if (selection.state === 'off') {
+    const update = await setPreferCodexSubscription(false);
+    invalidateModelOptionsCache();
+    return {
+      apiMode,
       message: update.effective
-        ? `Prefer Kimi Code subscription enabled for Kimi models, but a more specific setting keeps ChatGPT subscription preferred (${update.target} config).`
-        : 'Prefer Kimi Code subscription enabled for Kimi models · fallback: personal API keys.',
+        ? `ChatGPT subscription preference remains enabled because a more specific setting overrides ${update.target} config.`
+        : 'Prefer ChatGPT subscription disabled for Codex models.',
     };
   }
 
@@ -139,7 +133,8 @@ export async function selectCliModelAccessRoute(
     const session = await signInCliChatGpt(
       {
         ...init,
-        device: shouldUseChatGptDeviceCode(context, init),
+        device:
+          context == null ? false : shouldUseChatGptDeviceCode(context, init),
       },
       options,
     );
@@ -150,7 +145,7 @@ export async function selectCliModelAccessRoute(
   await platform().globalState.update(GlobalStateKey.USE_OPENROUTER, false);
   invalidateModelOptionsCache();
   return {
-    apiMode: effectiveCliApiMode(context),
+    apiMode,
     message: update.effective
       ? `Prefer ChatGPT subscription enabled for Codex models (${accountLabel}).`
       : 'ChatGPT sign-in succeeded, but a more specific setting keeps subscription access disabled.',

--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -27,8 +27,8 @@ import {
   type CliModelPickerItem,
 } from './modelAccess';
 import {
-  formatCliModelAccessRoute,
-  type CliModelAccessRoute,
+  formatCliModelAccessSummary,
+  type CliModelAccessSelection,
   type CliModelAccessStatus,
 } from './modelAccessRoute';
 import type { CliApiMode } from './apiAccessMode';
@@ -56,7 +56,7 @@ export type CliOrchestrationAction =
   | { readonly kind: 'configure-model-access' }
   | {
       readonly kind: 'set-model-access';
-      readonly access: CliModelAccessRoute;
+      readonly access: CliModelAccessSelection;
     }
   | { readonly kind: 'help' }
   | { readonly kind: 'exit' };
@@ -287,18 +287,10 @@ export function buildCliAgentItems(
 }
 
 function modelAccessItem(status: CliModelAccessStatus): CliOrchestrationItem {
-  let description: string;
-  if (status.active === 'chatgpt' && status.chatGptAccountLabel) {
-    description = `ChatGPT subscription · ${status.chatGptAccountLabel}`;
-  } else if (status.active === 'kimi-code') {
-    description = 'Kimi Code subscription · key configured';
-  } else {
-    description = formatCliModelAccessRoute(status.active);
-  }
   return {
     value: { kind: 'configure-model-access' },
     label: 'Model access',
-    description,
+    description: formatCliModelAccessSummary(status),
   };
 }
 

--- a/src/test-kernel/cli/ApiStatusLoad.vitest.mts
+++ b/src/test-kernel/cli/ApiStatusLoad.vitest.mts
@@ -62,7 +62,8 @@ describe('loadCliApiStatusLines', () => {
     mocks.getCliSessionAccessToken.mockResolvedValue('session-token');
     mocks.resolveCliUsageTier.mockResolvedValue('free');
     mocks.readCliModelAccessStatus.mockResolvedValue({
-      active: 'personal',
+      apiFallback: 'personal',
+      preferences: { chatGpt: 'off', kimiCode: 'off' },
       chatGptSignedIn: false,
     });
     mocks.lookupApiKeyOrigin.mockResolvedValue('none');
@@ -240,9 +241,10 @@ describe('loadCliApiStatusLines', () => {
     expect(lines.filter((line) => line === profileNote)).toHaveLength(1);
   });
 
-  it('reports both accounts, the effective route, and its API fallback', async () => {
+  it('reports both preferences and the API fallback without collapsing them', async () => {
     mocks.readCliModelAccessStatus.mockResolvedValue({
-      active: 'chatgpt',
+      apiFallback: 'personal',
+      preferences: { chatGpt: 'on', kimiCode: 'off' },
       chatGptSignedIn: true,
       chatGptAccountLabel: 'chatgpt@example.com',
       kimiCodeKeySet: false,
@@ -256,25 +258,26 @@ describe('loadCliApiStatusLines', () => {
       loadCliModelAccessOverview({ apiMode: 'personal' }),
     ).resolves.toEqual({
       access: {
-        active: 'chatgpt',
+        apiFallback: 'personal',
+        preferences: { chatGpt: 'on', kimiCode: 'off' },
         chatGptSignedIn: true,
         chatGptAccountLabel: 'chatgpt@example.com',
         kimiCodeKeySet: false,
         texraSignedIn: true,
       },
       lines: [
-        'model access: ChatGPT subscription',
-        'ChatGPT: signed in as chatgpt@example.com',
-        'Kimi Code: no key (add with /key)',
-        'TeXRA: signed in as texra@example.com',
+        'ChatGPT preference: On · chatgpt@example.com',
+        'Kimi Code preference: Off · key required to enable',
         'API fallback: Personal API keys',
+        'TeXRA: signed in as texra@example.com',
       ],
     });
   });
 
-  it('reports an active Kimi Code route with its personal fallback', async () => {
+  it('reports Kimi and ChatGPT preference states separately', async () => {
     mocks.readCliModelAccessStatus.mockResolvedValue({
-      active: 'kimi-code',
+      apiFallback: 'personal',
+      preferences: { chatGpt: 'off', kimiCode: 'on' },
       chatGptSignedIn: false,
       kimiCodeKeySet: true,
     });
@@ -283,11 +286,10 @@ describe('loadCliApiStatusLines', () => {
       loadCliModelAccessOverview({ apiMode: 'personal' }),
     ).resolves.toMatchObject({
       lines: [
-        'model access: Kimi Code subscription',
-        'ChatGPT: signed out',
-        'Kimi Code: key configured',
-        'TeXRA: signed out',
+        'ChatGPT preference: Off · sign in required to enable',
+        'Kimi Code preference: On · key configured',
         'API fallback: Personal API keys',
+        'TeXRA: signed out',
       ],
     });
   });

--- a/src/test-kernel/cli/ChatgptLoginBrowser.vitest.mts
+++ b/src/test-kernel/cli/ChatgptLoginBrowser.vitest.mts
@@ -46,9 +46,11 @@ describe('signInCliChatGpt browser choice', () => {
       { writeProgress: (message) => progress.push(message) },
     );
 
-    expect(progress).toHaveLength(1);
+    expect(progress).toHaveLength(2);
     expect(progress[0]).toContain('https://auth.openai.com/authorize?x=1');
-    expect(progress[0]).toContain('different browser');
+    expect(progress[0]).toContain('Browser launch in progress');
+    expect(progress[1]).toContain('https://auth.openai.com/authorize?x=1');
+    expect(progress[1]).toContain('another browser');
   });
 
   it('prints only the URL when the browser fails to launch', async () => {
@@ -65,7 +67,8 @@ describe('signInCliChatGpt browser choice', () => {
     );
 
     expect(progress).toEqual([
-      'Open this URL to sign in with ChatGPT:\nhttps://auth.openai.com/authorize?x=2',
+      'ChatGPT sign-in URL:\nhttps://auth.openai.com/authorize?x=2\nBrowser launch in progress...',
+      'ChatGPT sign-in URL:\nhttps://auth.openai.com/authorize?x=2\nAutomatic browser launch failed; the URL remains available above.',
     ]);
   });
 
@@ -83,8 +86,33 @@ describe('signInCliChatGpt browser choice', () => {
 
     expect(mocks.tryOpenBrowser).not.toHaveBeenCalled();
     expect(progress).toEqual([
-      'Open this URL to sign in with ChatGPT:\nhttps://auth.openai.com/authorize?x=3',
+      'ChatGPT sign-in URL:\nhttps://auth.openai.com/authorize?x=3',
     ]);
+  });
+
+  it('publishes the URL before a slow browser launcher returns', async () => {
+    let finishLaunch: ((result: boolean) => void) | undefined;
+    mocks.tryOpenBrowser.mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        finishLaunch = resolve;
+      }),
+    );
+    mocks.loginWithLoopback.mockImplementation(async ({ openBrowser }) => {
+      await openBrowser('https://auth.openai.com/authorize?x=slow');
+      return loopbackSession();
+    });
+    const progress: string[] = [];
+
+    const signIn = signInCliChatGpt(
+      { device: false, noBrowser: false },
+      { writeProgress: (message) => progress.push(message) },
+    );
+
+    await vi.waitFor(() => {
+      expect(progress[0]).toContain('https://auth.openai.com/authorize?x=slow');
+    });
+    finishLaunch?.(true);
+    await signIn;
   });
 
   it('forwards interactive cancellation to both ChatGPT transports', async () => {

--- a/src/test-kernel/cli/ConfigForm.vitest.mts
+++ b/src/test-kernel/cli/ConfigForm.vitest.mts
@@ -33,6 +33,7 @@ import {
 import { registerBuiltinSlashCommands } from '@cli/chat/tui/commands/registerBuiltins';
 import { openCliSlashCommandForm } from '@cli/chat/tui/commands/slashForms';
 import { ConfigApp } from '@cli/config/runConfigTui';
+import type { CliModelAccessSelection } from '@cli/runtime/modelAccessRoute';
 import {
   activeForm,
   resetCliState,
@@ -799,15 +800,15 @@ describe('/config slash command wiring', () => {
       version: 'test',
     });
     const { stores } = makeFakeSettingsStores();
-    const selectedAccessRoutes: string[] = [];
+    const selectedAccessRoutes: CliModelAccessSelection[] = [];
     registerBuiltinSlashCommands({
       getConfigStores: () => stores,
-      onModelAccessSelect: (route) => {
-        selectedAccessRoutes.push(route);
-        if (route === 'chatgpt') return;
+      onModelAccessSelect: (selection) => {
+        selectedAccessRoutes.push(selection);
+        if (selection.kind === 'subscription-preference') return;
         sessionMeta.set({
           ...sessionMeta.get(),
-          apiMode: route === 'kimi-code' ? 'personal' : route,
+          apiMode: selection.apiMode,
         });
       },
     });
@@ -818,7 +819,9 @@ describe('/config slash command wiring', () => {
 
     await props.writeValue?.(openRouter, true);
 
-    expect(selectedAccessRoutes).toEqual(['personal']);
+    expect(selectedAccessRoutes).toEqual([
+      { kind: 'api-fallback', apiMode: 'personal' },
+    ]);
     expect(sessionMeta.get().apiMode).toBe('personal');
     expect(invalidateModelOptionsCache).toHaveBeenCalledOnce();
   });

--- a/src/test-kernel/cli/ModelAccessForm.vitest.mts
+++ b/src/test-kernel/cli/ModelAccessForm.vitest.mts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { ModelAccessForm } from '@cli/chat/tui/forms/ModelAccessForm';
+import { cliApiFallbackSelection } from '@cli/runtime/modelAccessRoute';
 import { waitForCondition as waitFor } from '@test/support/asyncTestUtils';
 import {
   FakeStdin,
@@ -18,20 +19,61 @@ vi.mock('@cli/runtime/apiStatus', async (importOriginal) => ({
 afterEach(() => vi.clearAllMocks());
 
 describe('ModelAccessForm status', () => {
-  it('does not mark an unverified API fallback active after loading fails', async () => {
+  it('keeps preference actions disabled while status is loading', async () => {
+    loadCliModelAccessOverview.mockReturnValue(new Promise(() => undefined));
+    const { ink, React } = await loadInk();
+    const stdin = new FakeStdin();
+    const stdout = new FakeStdout(120);
+    const onSelect = vi.fn();
+    const instance = ink.render(
+      React.createElement(ModelAccessForm, {
+        apiMode: 'included',
+        onSelect,
+        onCancel: () => undefined,
+      }),
+      {
+        stdin,
+        stdout,
+        interactive: true,
+        exitOnCtrlC: false,
+        patchConsole: false,
+      },
+    );
+
+    try {
+      await waitFor(() => stdout.output.includes('Loading current preference'));
+      expect(stdout.output).not.toContain('Off ·');
+
+      stdin.write('1');
+      await Promise.resolve();
+      expect(onSelect).not.toHaveBeenCalled();
+
+      stdin.write('3');
+      await waitFor(() => onSelect.mock.calls.length === 1);
+      expect(onSelect).toHaveBeenCalledWith(
+        cliApiFallbackSelection('included'),
+      );
+    } finally {
+      instance.unmount();
+    }
+  });
+
+  it('keeps preference actions disabled after status loading fails', async () => {
     loadCliModelAccessOverview.mockRejectedValue(
       new Error('model access unavailable'),
     );
     const { ink, React } = await loadInk();
-    const stdout = new FakeStdout();
+    const stdin = new FakeStdin();
+    const stdout = new FakeStdout(120);
+    const onSelect = vi.fn();
     const instance = ink.render(
       React.createElement(ModelAccessForm, {
         apiMode: 'included',
-        onSelect: () => undefined,
+        onSelect,
         onCancel: () => undefined,
       }),
       {
-        stdin: new FakeStdin(),
+        stdin,
         stdout,
         interactive: true,
         exitOnCtrlC: false,
@@ -43,9 +85,64 @@ describe('ModelAccessForm status', () => {
       await waitFor(() => loadCliModelAccessOverview.mock.calls.length > 0);
       await waitFor(() => stdout.output.includes('model access unavailable'));
       expect(stdout.output).toContain('model access unavailable');
-      expect(stdout.output).toContain('Sign in through Account');
-      expect(stdout.output).not.toContain('Use your TeXRA account');
-      expect(stdout.output).not.toContain('✓');
+      expect(stdout.output).toContain('Current preference unavailable');
+      expect(stdout.output).not.toContain('Off ·');
+      expect(stdout.output).toContain('✓ 3. Included TeXRA access');
+
+      stdin.write('2');
+      await Promise.resolve();
+      expect(onSelect).not.toHaveBeenCalled();
+
+      stdin.write('4');
+      await waitFor(() => onSelect.mock.calls.length === 1);
+      expect(onSelect).toHaveBeenCalledWith(
+        cliApiFallbackSelection('personal'),
+      );
+    } finally {
+      instance.unmount();
+    }
+  });
+
+  it('enables the correct declarative toggle after status loads', async () => {
+    loadCliModelAccessOverview.mockResolvedValue({
+      access: {
+        apiFallback: 'personal',
+        preferences: { chatGpt: 'on', kimiCode: 'on' },
+        chatGptSignedIn: true,
+        chatGptAccountLabel: 'user@example.com',
+        kimiCodeKeySet: true,
+        texraSignedIn: true,
+      },
+      lines: [],
+    });
+    const { ink, React } = await loadInk();
+    const stdin = new FakeStdin();
+    const stdout = new FakeStdout(120);
+    const onSelect = vi.fn();
+    const instance = ink.render(
+      React.createElement(ModelAccessForm, {
+        apiMode: 'personal',
+        onSelect,
+        onCancel: () => undefined,
+      }),
+      {
+        stdin,
+        stdout,
+        interactive: true,
+        exitOnCtrlC: false,
+        patchConsole: false,
+      },
+    );
+
+    try {
+      await waitFor(() => stdout.output.includes('On · user@example.com'));
+      stdin.write('1');
+      await waitFor(() => onSelect.mock.calls.length === 1);
+      expect(onSelect).toHaveBeenCalledWith({
+        kind: 'subscription-preference',
+        provider: 'chatgpt',
+        state: 'off',
+      });
     } finally {
       instance.unmount();
     }

--- a/src/test-kernel/cli/ModelAccessSelection.vitest.mts
+++ b/src/test-kernel/cli/ModelAccessSelection.vitest.mts
@@ -133,6 +133,16 @@ describe('CLI model access routes', () => {
     expect(parseCliModelAccessSelection('direct')).toBeUndefined();
   });
 
+  it('keeps canonical API fallback selections stable and immutable', () => {
+    const included = cliApiFallbackSelection('included');
+    const personal = cliApiFallbackSelection('personal');
+
+    expect(cliApiFallbackSelection('included')).toBe(included);
+    expect(cliApiFallbackSelection('personal')).toBe(personal);
+    expect(Object.isFrozen(included)).toBe(true);
+    expect(Object.isFrozen(personal)).toBe(true);
+  });
+
   it('uses observed access before prospective access preferences', () => {
     expect(
       resolveCliModelAccessRoute({
@@ -481,7 +491,7 @@ describe('CLI model access routes', () => {
     const status = await readCliModelAccessStatus('personal');
     expect(status.preferences).toEqual({ chatGpt: 'on', kimiCode: 'on' });
     expect(
-      buildCliModelAccessItems(status)
+      buildCliModelAccessItems({ kind: 'loaded', access: status })
         .slice(0, 2)
         .map((item) => item.description),
     ).toEqual(['On · user@example.com', 'On · key configured']);
@@ -529,7 +539,10 @@ describe('CLI model access routes', () => {
     });
 
     const status = await readCliModelAccessStatus('personal');
-    const [selection] = buildCliModelAccessItems(status);
+    const [selection] = buildCliModelAccessItems({
+      kind: 'loaded',
+      access: status,
+    });
     expect(selection?.description).toBe('On · sign in required');
     if (!selection) throw new Error('Expected ChatGPT preference item');
     await updateCliModelAccess(context, selection.value, {
@@ -543,7 +556,10 @@ describe('CLI model access routes', () => {
   it('turns off a stale Kimi preference without requiring a key', async () => {
     mocks.getPreferKimiCode.mockReturnValue(true);
     const status = await readCliModelAccessStatus('personal');
-    const selection = buildCliModelAccessItems(status)[1];
+    const selection = buildCliModelAccessItems({
+      kind: 'loaded',
+      access: status,
+    })[1];
     expect(selection?.description).toBe('On · key required');
     if (!selection) throw new Error('Expected Kimi preference item');
 

--- a/src/test-kernel/cli/ModelAccessSelection.vitest.mts
+++ b/src/test-kernel/cli/ModelAccessSelection.vitest.mts
@@ -3,13 +3,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   contextForCliModelAccess,
   readCliModelAccessStatus,
-  selectCliApiModelAccessRoute,
-  selectCliModelAccessRoute,
+  updateCliModelAccess,
 } from '@cli/runtime/modelAccessSelection';
 import {
+  buildCliModelAccessItems,
+  cliApiFallbackSelection,
   formatCliModelAccessRoute,
   formatCliModelAccessRouteInline,
-  parseCliModelAccessRoute,
+  parseCliModelAccessSelection,
   resolveCliModelAccessRoute,
   shortCliModelAccessRoute,
 } from '@cli/runtime/modelAccessRoute';
@@ -26,7 +27,6 @@ const mocks = vi.hoisted(() => ({
   updateGlobalState: vi.fn(),
   apiKeyExists: vi.fn(),
   getPreferKimiCode: vi.fn(),
-  getUseOpenRouter: vi.fn(),
   setPreferKimiCode: vi.fn(),
 }));
 
@@ -49,7 +49,6 @@ vi.mock('@model/apiProviders', () => ({
 
 vi.mock('@utils/config/providerConfig', () => ({
   getPreferKimiCode: mocks.getPreferKimiCode,
-  getUseOpenRouter: mocks.getUseOpenRouter,
   setPreferKimiCode: mocks.setPreferKimiCode,
 }));
 
@@ -89,22 +88,49 @@ beforeEach(() => {
   mocks.shouldUseChatGptDeviceCode.mockReturnValue(false);
   mocks.apiKeyExists.mockResolvedValue(false);
   mocks.getPreferKimiCode.mockReturnValue(false);
-  mocks.getUseOpenRouter.mockReturnValue(false);
   mocks.setPreferKimiCode.mockResolvedValue(undefined);
 });
 
 describe('CLI model access routes', () => {
   it('parses the routes and the compatibility spellings', () => {
-    expect(parseCliModelAccessRoute('chatgpt')).toBe('chatgpt');
-    expect(parseCliModelAccessRoute('subscription')).toBe('chatgpt');
-    expect(parseCliModelAccessRoute('kimi')).toBe('kimi-code');
-    expect(parseCliModelAccessRoute('kimicode')).toBe('kimi-code');
-    expect(parseCliModelAccessRoute('kimi-code')).toBe('kimi-code');
-    expect(parseCliModelAccessRoute('included')).toBe('included');
-    expect(parseCliModelAccessRoute('relay')).toBe('included');
-    expect(parseCliModelAccessRoute('personal')).toBe('personal');
-    expect(parseCliModelAccessRoute('byok')).toBe('personal');
-    expect(parseCliModelAccessRoute('direct')).toBeUndefined();
+    expect(parseCliModelAccessSelection('chatgpt')).toEqual({
+      kind: 'subscription-preference',
+      provider: 'chatgpt',
+      state: 'on',
+    });
+    expect(parseCliModelAccessSelection('subscription')).toEqual({
+      kind: 'subscription-preference',
+      provider: 'chatgpt',
+      state: 'on',
+    });
+    expect(parseCliModelAccessSelection('kimi')).toEqual({
+      kind: 'subscription-preference',
+      provider: 'kimi-code',
+      state: 'on',
+    });
+    expect(parseCliModelAccessSelection('kimicode')).toEqual({
+      kind: 'subscription-preference',
+      provider: 'kimi-code',
+      state: 'on',
+    });
+    expect(parseCliModelAccessSelection('kimi-code')).toEqual({
+      kind: 'subscription-preference',
+      provider: 'kimi-code',
+      state: 'on',
+    });
+    expect(parseCliModelAccessSelection('included')).toEqual(
+      cliApiFallbackSelection('included'),
+    );
+    expect(parseCliModelAccessSelection('relay')).toEqual(
+      cliApiFallbackSelection('included'),
+    );
+    expect(parseCliModelAccessSelection('personal')).toEqual(
+      cliApiFallbackSelection('personal'),
+    );
+    expect(parseCliModelAccessSelection('byok')).toEqual(
+      cliApiFallbackSelection('personal'),
+    );
+    expect(parseCliModelAccessSelection('direct')).toBeUndefined();
   });
 
   it('uses observed access before prospective access preferences', () => {
@@ -205,7 +231,7 @@ describe('CLI model access routes', () => {
     );
   });
 
-  it('reports ChatGPT only when sign-in and preference are both active', async () => {
+  it('reports the ChatGPT preference independently of sign-in', async () => {
     mocks.getCodexStatus.mockResolvedValue({
       signedIn: true,
       email: 'user@example.com',
@@ -213,7 +239,8 @@ describe('CLI model access routes', () => {
     mocks.isPreferCodexSubscription.mockReturnValue(true);
 
     await expect(readCliModelAccessStatus('included')).resolves.toEqual({
-      active: 'chatgpt',
+      apiFallback: 'included',
+      preferences: { chatGpt: 'on', kimiCode: 'off' },
       chatGptSignedIn: true,
       chatGptAccountLabel: 'user@example.com',
       kimiCodeKeySet: false,
@@ -221,73 +248,78 @@ describe('CLI model access routes', () => {
 
     mocks.getCodexStatus.mockResolvedValue({ signedIn: false });
     await expect(readCliModelAccessStatus('included')).resolves.toEqual({
-      active: 'included',
+      apiFallback: 'included',
+      preferences: { chatGpt: 'on', kimiCode: 'off' },
       chatGptSignedIn: false,
       chatGptAccountLabel: undefined,
       kimiCodeKeySet: false,
     });
   });
 
-  it('reports Kimi Code only for personal access with prefer switch and key', async () => {
+  it('reports the Kimi preference independently of key and fallback', async () => {
     mocks.apiKeyExists.mockResolvedValue(true);
     mocks.getPreferKimiCode.mockReturnValue(true);
 
     await expect(readCliModelAccessStatus('personal')).resolves.toEqual({
-      active: 'kimi-code',
+      apiFallback: 'personal',
+      preferences: { chatGpt: 'off', kimiCode: 'on' },
       chatGptSignedIn: false,
       chatGptAccountLabel: undefined,
       kimiCodeKeySet: true,
     });
 
-    // Included access keeps the prefer switch dormant in the background.
     await expect(readCliModelAccessStatus('included')).resolves.toMatchObject({
-      active: 'included',
+      apiFallback: 'included',
+      preferences: { chatGpt: 'off', kimiCode: 'on' },
       kimiCodeKeySet: true,
     });
 
-    // A missing key falls back to plain personal access.
     mocks.apiKeyExists.mockResolvedValue(false);
     await expect(readCliModelAccessStatus('personal')).resolves.toMatchObject({
-      active: 'personal',
+      apiFallback: 'personal',
+      preferences: { chatGpt: 'off', kimiCode: 'on' },
       kimiCodeKeySet: false,
-    });
-
-    // OpenRouter suppresses dual-backend Kimi Code dispatch, so the route is
-    // not reported active while the toggle is on.
-    mocks.apiKeyExists.mockResolvedValue(true);
-    mocks.getUseOpenRouter.mockReturnValue(true);
-    await expect(readCliModelAccessStatus('personal')).resolves.toMatchObject({
-      active: 'personal',
-      kimiCodeKeySet: true,
     });
   });
 
   it('enables Kimi Code routing on a personal fallback when a key exists', async () => {
     mocks.apiKeyExists.mockResolvedValue(true);
 
-    const result = await selectCliModelAccessRoute(context, 'kimi-code', {
-      writeProgress: vi.fn(),
-    });
+    const result = await updateCliModelAccess(
+      context,
+      {
+        kind: 'subscription-preference',
+        provider: 'kimi-code',
+        state: 'on',
+      },
+      { writeProgress: vi.fn() },
+    );
 
-    expect(mocks.setPreferCodexSubscription).toHaveBeenCalledWith(false);
+    expect(mocks.setPreferCodexSubscription).not.toHaveBeenCalled();
     expect(mocks.setPreferKimiCode).toHaveBeenCalledWith(true);
     expect(mocks.updateGlobalState).toHaveBeenCalledWith(
       'texra.useOpenRouter',
       false,
     );
-    expect(mocks.setCliApiMode).toHaveBeenCalledWith('personal');
+    expect(mocks.setCliApiMode).not.toHaveBeenCalled();
     expect(mocks.invalidateModelOptionsCache).toHaveBeenCalledOnce();
     expect(result).toEqual({
       apiMode: 'personal',
       message:
-        'Prefer Kimi Code subscription enabled for Kimi models · fallback: personal API keys.',
+        'Prefer Kimi Code subscription enabled for Kimi models · API fallback remains Personal API keys.',
     });
   });
 
   it('guides to key entry when Kimi Code is selected without a key', async () => {
-    const result = await selectCliModelAccessRoute(context, 'kimi-code', {
-      writeProgress: vi.fn(),
-    });
+    const result = await updateCliModelAccess(
+      context,
+      {
+        kind: 'subscription-preference',
+        provider: 'kimi-code',
+        state: 'on',
+      },
+      { writeProgress: vi.fn() },
+    );
 
     expect(mocks.setPreferKimiCode).not.toHaveBeenCalled();
     expect(mocks.setCliApiMode).not.toHaveBeenCalled();
@@ -296,85 +328,79 @@ describe('CLI model access routes', () => {
     expect(result.message).toContain('https://www.kimi.com/code/console');
   });
 
-  it('leaves the Kimi Code route when personal access is chosen explicitly', async () => {
-    await selectCliModelAccessRoute(context, 'personal', {
-      writeProgress: vi.fn(),
-    });
+  it('changes the personal fallback without changing either preference', async () => {
+    await updateCliModelAccess(context, cliApiFallbackSelection('personal'));
 
-    expect(mocks.setPreferKimiCode).toHaveBeenCalledWith(false);
+    expect(mocks.setPreferKimiCode).not.toHaveBeenCalled();
+    expect(mocks.setPreferCodexSubscription).not.toHaveBeenCalled();
     expect(mocks.setCliApiMode).toHaveBeenCalledWith('personal');
   });
 
   it('preserves the Kimi prefer switch on the key-save path', async () => {
     // Saving or rotating a key is a credential operation, not an explicit
     // "Personal API keys" picker choice — it must not clear the preference.
-    await selectCliApiModelAccessRoute('personal');
+    await updateCliModelAccess(context, cliApiFallbackSelection('personal'));
 
     expect(mocks.setPreferKimiCode).not.toHaveBeenCalled();
     expect(mocks.setCliApiMode).toHaveBeenCalledWith('personal');
   });
 
-  it('reports when a more specific setting keeps ChatGPT preferred over Kimi', async () => {
+  it('enables Kimi without changing the ChatGPT preference', async () => {
     mocks.apiKeyExists.mockResolvedValue(true);
-    mocks.setPreferCodexSubscription.mockResolvedValue({
-      effective: true,
-      target: 'workspace',
-    });
 
-    const result = await selectCliModelAccessRoute(context, 'kimi-code', {
-      writeProgress: vi.fn(),
-    });
+    const result = await updateCliModelAccess(
+      context,
+      {
+        kind: 'subscription-preference',
+        provider: 'kimi-code',
+        state: 'on',
+      },
+      { writeProgress: vi.fn() },
+    );
 
     expect(mocks.setPreferKimiCode).toHaveBeenCalledWith(true);
-    expect(result.message).toContain(
-      'keeps ChatGPT subscription preferred (workspace config)',
-    );
+    expect(mocks.setPreferCodexSubscription).not.toHaveBeenCalled();
+    expect(result.message).toContain('Kimi Code subscription enabled');
   });
 
   it('keeps the Kimi Code prefer switch when included access is chosen', async () => {
-    await selectCliModelAccessRoute(context, 'included', {
-      writeProgress: vi.fn(),
-    });
+    await updateCliModelAccess(context, cliApiFallbackSelection('included'));
 
     expect(mocks.setPreferKimiCode).not.toHaveBeenCalled();
     expect(mocks.setCliApiMode).toHaveBeenCalledWith('included');
   });
 
   it('switches API-based routes through one policy boundary', async () => {
-    const result = await selectCliModelAccessRoute(context, 'personal', {
-      writeProgress: vi.fn(),
-    });
+    const result = await updateCliModelAccess(
+      context,
+      cliApiFallbackSelection('personal'),
+    );
 
-    expect(mocks.setPreferCodexSubscription).toHaveBeenCalledWith(false);
+    expect(mocks.setPreferCodexSubscription).not.toHaveBeenCalled();
+    expect(mocks.setPreferKimiCode).not.toHaveBeenCalled();
     expect(mocks.setCliApiMode).toHaveBeenCalledWith('personal');
     expect(result).toEqual({
       apiMode: 'personal',
-      message: 'Model access: Personal API keys.',
+      message: 'API fallback: Personal API keys.',
     });
   });
 
-  it('reports when a more specific setting keeps ChatGPT active', async () => {
-    mocks.setPreferCodexSubscription.mockResolvedValue({
-      effective: true,
-      target: 'workspace',
-    });
+  it('preserves both enabled preferences while changing the API fallback', async () => {
+    await updateCliModelAccess(context, cliApiFallbackSelection('included'));
 
-    const result = await selectCliApiModelAccessRoute('personal');
-
-    expect(mocks.setPreferCodexSubscription).toHaveBeenCalledWith(false);
-    expect(mocks.setCliApiMode).toHaveBeenCalledWith('personal');
-    expect(result.message).toContain(
-      'remains on ChatGPT subscription because a more specific setting overrides workspace config',
-    );
+    expect(mocks.setPreferCodexSubscription).not.toHaveBeenCalled();
+    expect(mocks.setPreferKimiCode).not.toHaveBeenCalled();
+    expect(mocks.setCliApiMode).toHaveBeenCalledWith('included');
   });
 
   it('does not report an API route as selected when persistence fails', async () => {
     mocks.setCliApiMode.mockRejectedValue(new Error('Config write failed'));
 
-    await expect(selectCliApiModelAccessRoute('included')).rejects.toThrow(
-      'Config write failed',
-    );
-    expect(mocks.setPreferCodexSubscription).toHaveBeenCalledWith(false);
+    await expect(
+      updateCliModelAccess(context, cliApiFallbackSelection('included')),
+    ).rejects.toThrow('Config write failed');
+    expect(mocks.setPreferCodexSubscription).not.toHaveBeenCalled();
+    expect(mocks.setPreferKimiCode).not.toHaveBeenCalled();
   });
 
   it('signs in when needed and enables ChatGPT without an API key', async () => {
@@ -386,10 +412,15 @@ describe('CLI model access routes', () => {
     const writeProgress = vi.fn();
     const controller = new AbortController();
 
-    const result = await selectCliModelAccessRoute(context, 'chatgpt', {
-      writeProgress,
-      signal: controller.signal,
-    });
+    const result = await updateCliModelAccess(
+      context,
+      {
+        kind: 'subscription-preference',
+        provider: 'chatgpt',
+        state: 'on',
+      },
+      { writeProgress, signal: controller.signal },
+    );
 
     expect(mocks.signInCliChatGpt).toHaveBeenCalledWith(
       { device: false, noBrowser: false },
@@ -407,44 +438,120 @@ describe('CLI model access routes', () => {
     expect(result.apiMode).toBe('personal');
   });
 
-  it('keeps the ChatGPT route selected when it is already enabled', async () => {
+  it('turns off ChatGPT without changing the Kimi preference', async () => {
     mocks.getCodexStatus.mockResolvedValue({
       signedIn: true,
       email: 'user@example.com',
     });
     mocks.isPreferCodexSubscription.mockReturnValue(true);
     mocks.setPreferCodexSubscription.mockResolvedValue({
-      effective: true,
+      effective: false,
       target: 'global',
     });
 
-    const result = await selectCliModelAccessRoute(context, 'chatgpt', {
+    const result = await updateCliModelAccess(
+      context,
+      {
+        kind: 'subscription-preference',
+        provider: 'chatgpt',
+        state: 'off',
+      },
+      { writeProgress: vi.fn() },
+    );
+
+    expect(mocks.signInCliChatGpt).not.toHaveBeenCalled();
+    expect(mocks.setPreferCodexSubscription).toHaveBeenCalledWith(false);
+    expect(mocks.setPreferKimiCode).not.toHaveBeenCalled();
+    expect(mocks.invalidateModelOptionsCache).toHaveBeenCalledOnce();
+    expect(result).toEqual({
+      apiMode: 'personal',
+      message: 'Prefer ChatGPT subscription disabled for Codex models.',
+    });
+  });
+
+  it('represents both preferences as on and toggles each independently', async () => {
+    mocks.getCodexStatus.mockResolvedValue({
+      signedIn: true,
+      email: 'user@example.com',
+    });
+    mocks.isPreferCodexSubscription.mockReturnValue(true);
+    mocks.getPreferKimiCode.mockReturnValue(true);
+    mocks.apiKeyExists.mockResolvedValue(true);
+
+    const status = await readCliModelAccessStatus('personal');
+    expect(status.preferences).toEqual({ chatGpt: 'on', kimiCode: 'on' });
+    expect(
+      buildCliModelAccessItems(status)
+        .slice(0, 2)
+        .map((item) => item.description),
+    ).toEqual(['On · user@example.com', 'On · key configured']);
+
+    await updateCliModelAccess(
+      context,
+      {
+        kind: 'subscription-preference',
+        provider: 'kimi-code',
+        state: 'off',
+      },
+      { writeProgress: vi.fn() },
+    );
+    expect(mocks.setPreferKimiCode).toHaveBeenCalledWith(false);
+    expect(mocks.setPreferCodexSubscription).not.toHaveBeenCalled();
+
+    vi.clearAllMocks();
+    mocks.getCodexStatus.mockResolvedValue({
+      signedIn: true,
+      email: 'user@example.com',
+    });
+    mocks.isPreferCodexSubscription.mockReturnValue(true);
+    mocks.setPreferCodexSubscription.mockResolvedValue({
+      effective: false,
+      target: 'global',
+    });
+    await updateCliModelAccess(
+      context,
+      {
+        kind: 'subscription-preference',
+        provider: 'chatgpt',
+        state: 'off',
+      },
+      { writeProgress: vi.fn() },
+    );
+    expect(mocks.setPreferCodexSubscription).toHaveBeenCalledWith(false);
+    expect(mocks.setPreferKimiCode).not.toHaveBeenCalled();
+  });
+
+  it('turns off a stale signed-out preference without signing in', async () => {
+    mocks.isPreferCodexSubscription.mockReturnValue(true);
+    mocks.setPreferCodexSubscription.mockResolvedValue({
+      effective: false,
+      target: 'global',
+    });
+
+    const status = await readCliModelAccessStatus('personal');
+    const [selection] = buildCliModelAccessItems(status);
+    expect(selection?.description).toBe('On · sign in required');
+    if (!selection) throw new Error('Expected ChatGPT preference item');
+    await updateCliModelAccess(context, selection.value, {
       writeProgress: vi.fn(),
     });
 
     expect(mocks.signInCliChatGpt).not.toHaveBeenCalled();
-    expect(mocks.setPreferCodexSubscription).toHaveBeenCalledWith(true);
-    expect(mocks.invalidateModelOptionsCache).toHaveBeenCalledOnce();
-    expect(result).toEqual({
-      apiMode: 'personal',
-      message:
-        'Prefer ChatGPT subscription enabled for Codex models (user@example.com).',
-    });
+    expect(mocks.setPreferCodexSubscription).toHaveBeenCalledWith(false);
   });
 
-  it('signs in instead of toggling off a stale signed-out preference', async () => {
-    mocks.isPreferCodexSubscription.mockReturnValue(true);
-    mocks.signInCliChatGpt.mockResolvedValue({ email: 'user@example.com' });
-    mocks.setPreferCodexSubscription.mockResolvedValue({
-      effective: true,
-      target: 'global',
-    });
+  it('turns off a stale Kimi preference without requiring a key', async () => {
+    mocks.getPreferKimiCode.mockReturnValue(true);
+    const status = await readCliModelAccessStatus('personal');
+    const selection = buildCliModelAccessItems(status)[1];
+    expect(selection?.description).toBe('On · key required');
+    if (!selection) throw new Error('Expected Kimi preference item');
 
-    await selectCliModelAccessRoute(context, 'chatgpt', {
-      writeProgress: vi.fn(),
-    });
+    vi.clearAllMocks();
+    await updateCliModelAccess(context, selection.value);
 
-    expect(mocks.signInCliChatGpt).toHaveBeenCalledOnce();
-    expect(mocks.setPreferCodexSubscription).toHaveBeenCalledWith(true);
+    expect(mocks.apiKeyExists).not.toHaveBeenCalled();
+    expect(mocks.setPreferKimiCode).toHaveBeenCalledWith(false);
+    expect(mocks.setPreferCodexSubscription).not.toHaveBeenCalled();
   });
 });

--- a/src/test-kernel/cli/OnboardingFlow.vitest.mts
+++ b/src/test-kernel/cli/OnboardingFlow.vitest.mts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { waitForCondition } from '@test/support/asyncTestUtils';
 
 const mocks = vi.hoisted(() => ({
-  selectCliApiModelAccessRoute: vi.fn(),
+  updateCliModelAccess: vi.fn(),
   saveProviderApiKey: vi.fn(),
   writeTextStderr: vi.fn(),
   writeTextStdout: vi.fn(),
@@ -14,7 +14,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@cli/runtime/modelAccessSelection', () => ({
-  selectCliApiModelAccessRoute: mocks.selectCliApiModelAccessRoute,
+  updateCliModelAccess: mocks.updateCliModelAccess,
 }));
 
 vi.mock('@cli/runtime/providerApiKey', () => ({
@@ -115,7 +115,7 @@ function restoreProcessStream(
 beforeEach(() => {
   mocks.state.clear();
   mocks.saveProviderApiKey.mockReset().mockResolvedValue(undefined);
-  mocks.selectCliApiModelAccessRoute.mockReset();
+  mocks.updateCliModelAccess.mockReset();
   mocks.writeTextStderr.mockReset();
   mocks.writeTextStdout.mockReset();
 });
@@ -136,7 +136,7 @@ describe('provider-key onboarding flow', () => {
     const warning =
       'DISTINCTIVE OVERRIDE: workspace policy keeps ChatGPT subscription active.';
     const providerKey = 'sk-ant-integration-secret';
-    mocks.selectCliApiModelAccessRoute.mockResolvedValue({
+    mocks.updateCliModelAccess.mockResolvedValue({
       apiMode: 'personal',
       message: warning,
     });
@@ -191,7 +191,10 @@ describe('provider-key onboarding flow', () => {
       'anthropic',
       providerKey,
     );
-    expect(mocks.selectCliApiModelAccessRoute).toHaveBeenCalledWith('personal');
+    expect(mocks.updateCliModelAccess).toHaveBeenCalledWith(undefined, {
+      kind: 'api-fallback',
+      apiMode: 'personal',
+    });
     expect(mocks.writeTextStdout).toHaveBeenCalledWith(
       'Saved your Anthropic API key. Stored in TeXRA secrets as `apiKey.anthropic` (or set ANTHROPIC_API_KEY in your environment). ' +
         warning,

--- a/src/test-kernel/cli/Orchestration.vitest.mts
+++ b/src/test-kernel/cli/Orchestration.vitest.mts
@@ -370,7 +370,8 @@ describe('CLI orchestration items', () => {
 
   it('keeps model access directly below new chat and presents every access route', () => {
     const status = {
-      active: 'included' as const,
+      apiFallback: 'included' as const,
+      preferences: { chatGpt: 'off', kimiCode: 'off' } as const,
       chatGptSignedIn: true,
       chatGptAccountLabel: 'researcher@example.com',
     };
@@ -383,27 +384,35 @@ describe('CLI orchestration items', () => {
 
     expect(items[1]).toEqual({
       label: 'Model access',
-      description: 'Included TeXRA access',
+      description: 'ChatGPT Off · Kimi Off · fallback: included TeXRA access',
       value: { kind: 'configure-model-access' },
     });
     expect(buildCliModelAccessItems(status)).toEqual([
       {
-        value: 'chatgpt',
+        value: {
+          kind: 'subscription-preference',
+          provider: 'chatgpt',
+          state: 'on',
+        },
         label: 'Prefer ChatGPT subscription',
         description: 'Off · researcher@example.com',
       },
       {
-        value: 'kimi-code',
+        value: {
+          kind: 'subscription-preference',
+          provider: 'kimi-code',
+          state: 'on',
+        },
         label: 'Prefer Kimi Code subscription',
-        description: 'Add a key with /key (kimi.com/code/console)',
+        description: 'Off · key required to enable',
       },
       {
-        value: 'included',
+        value: { kind: 'api-fallback', apiMode: 'included' },
         label: 'Included TeXRA access',
         description: 'Use your TeXRA account',
       },
       {
-        value: 'personal',
+        value: { kind: 'api-fallback', apiMode: 'personal' },
         label: 'Personal API keys',
         description: 'Use keys configured on this computer',
       },
@@ -413,18 +422,24 @@ describe('CLI orchestration items', () => {
   it('describes the Kimi Code route by key state and activity', () => {
     expect(
       buildCliModelAccessItems({
-        active: 'personal',
+        apiFallback: 'personal',
+        preferences: { chatGpt: 'off', kimiCode: 'off' },
         chatGptSignedIn: false,
         kimiCodeKeySet: true,
       })[1],
     ).toEqual({
-      value: 'kimi-code',
+      value: {
+        kind: 'subscription-preference',
+        provider: 'kimi-code',
+        state: 'on',
+      },
       label: 'Prefer Kimi Code subscription',
       description: 'Off · key configured',
     });
     expect(
       buildCliModelAccessItems({
-        active: 'kimi-code',
+        apiFallback: 'personal',
+        preferences: { chatGpt: 'off', kimiCode: 'on' },
         chatGptSignedIn: false,
         kimiCodeKeySet: true,
       })[1].description,
@@ -435,16 +450,32 @@ describe('CLI orchestration items', () => {
       history: [],
       toolUseAgents: [],
       modelAccess: {
-        active: 'kimi-code',
+        apiFallback: 'personal',
+        preferences: { chatGpt: 'off', kimiCode: 'on' },
         chatGptSignedIn: false,
         kimiCodeKeySet: true,
       },
     });
     expect(items[1]).toEqual({
       label: 'Model access',
-      description: 'Kimi Code subscription · key configured',
+      description: 'ChatGPT Off · Kimi On · fallback: personal API keys',
       value: { kind: 'configure-model-access' },
     });
+  });
+
+  it('shows both subscription preferences as on simultaneously', () => {
+    const items = buildCliModelAccessItems({
+      apiFallback: 'personal',
+      preferences: { chatGpt: 'on', kimiCode: 'on' },
+      chatGptSignedIn: true,
+      chatGptAccountLabel: 'researcher@example.com',
+      kimiCodeKeySet: true,
+    });
+
+    expect(items.slice(0, 2).map(({ description }) => description)).toEqual([
+      'On · researcher@example.com',
+      'On · key configured',
+    ]);
   });
 
   it('offers account management as one startup row with provider actions', () => {
@@ -496,10 +527,15 @@ describe('CLI orchestration items', () => {
     ]);
     expect(
       buildCliModelAccessItems({
-        active: 'personal',
+        apiFallback: 'personal',
+        preferences: { chatGpt: 'off', kimiCode: 'off' },
         chatGptSignedIn: false,
         texraSignedIn: false,
-      }).find((item) => item.value === 'included')?.description,
+      }).find(
+        (item) =>
+          item.value.kind === 'api-fallback' &&
+          item.value.apiMode === 'included',
+      )?.description,
     ).toBe('Sign in through Account to use included models');
   });
 

--- a/src/test-kernel/cli/Orchestration.vitest.mts
+++ b/src/test-kernel/cli/Orchestration.vitest.mts
@@ -387,7 +387,9 @@ describe('CLI orchestration items', () => {
       description: 'ChatGPT Off · Kimi Off · fallback: included TeXRA access',
       value: { kind: 'configure-model-access' },
     });
-    expect(buildCliModelAccessItems(status)).toEqual([
+    expect(
+      buildCliModelAccessItems({ kind: 'loaded', access: status }),
+    ).toEqual([
       {
         value: {
           kind: 'subscription-preference',
@@ -422,10 +424,13 @@ describe('CLI orchestration items', () => {
   it('describes the Kimi Code route by key state and activity', () => {
     expect(
       buildCliModelAccessItems({
-        apiFallback: 'personal',
-        preferences: { chatGpt: 'off', kimiCode: 'off' },
-        chatGptSignedIn: false,
-        kimiCodeKeySet: true,
+        kind: 'loaded',
+        access: {
+          apiFallback: 'personal',
+          preferences: { chatGpt: 'off', kimiCode: 'off' },
+          chatGptSignedIn: false,
+          kimiCodeKeySet: true,
+        },
       })[1],
     ).toEqual({
       value: {
@@ -438,10 +443,13 @@ describe('CLI orchestration items', () => {
     });
     expect(
       buildCliModelAccessItems({
-        apiFallback: 'personal',
-        preferences: { chatGpt: 'off', kimiCode: 'on' },
-        chatGptSignedIn: false,
-        kimiCodeKeySet: true,
+        kind: 'loaded',
+        access: {
+          apiFallback: 'personal',
+          preferences: { chatGpt: 'off', kimiCode: 'on' },
+          chatGptSignedIn: false,
+          kimiCodeKeySet: true,
+        },
       })[1].description,
     ).toBe('On · key configured');
 
@@ -465,11 +473,14 @@ describe('CLI orchestration items', () => {
 
   it('shows both subscription preferences as on simultaneously', () => {
     const items = buildCliModelAccessItems({
-      apiFallback: 'personal',
-      preferences: { chatGpt: 'on', kimiCode: 'on' },
-      chatGptSignedIn: true,
-      chatGptAccountLabel: 'researcher@example.com',
-      kimiCodeKeySet: true,
+      kind: 'loaded',
+      access: {
+        apiFallback: 'personal',
+        preferences: { chatGpt: 'on', kimiCode: 'on' },
+        chatGptSignedIn: true,
+        chatGptAccountLabel: 'researcher@example.com',
+        kimiCodeKeySet: true,
+      },
     });
 
     expect(items.slice(0, 2).map(({ description }) => description)).toEqual([
@@ -527,10 +538,13 @@ describe('CLI orchestration items', () => {
     ]);
     expect(
       buildCliModelAccessItems({
-        apiFallback: 'personal',
-        preferences: { chatGpt: 'off', kimiCode: 'off' },
-        chatGptSignedIn: false,
-        texraSignedIn: false,
+        kind: 'loaded',
+        access: {
+          apiFallback: 'personal',
+          preferences: { chatGpt: 'off', kimiCode: 'off' },
+          chatGptSignedIn: false,
+          texraSignedIn: false,
+        },
       }).find(
         (item) =>
           item.value.kind === 'api-fallback' &&

--- a/src/test-kernel/cli/Orchestration.vitest.mts
+++ b/src/test-kernel/cli/Orchestration.vitest.mts
@@ -952,6 +952,35 @@ describe('CLI orchestration items', () => {
     ]);
   });
 
+  it('names Kimi Code subscription access in model rows', () => {
+    const kimi = modelAccess('kimi3', 'provider-key', true, 'api key set');
+    const view = orchestrationModelAccessView(
+      buildCliOrchestrationItems({
+        presetPlans: [readyPresetPlan()],
+        history: [],
+        toolUseAgents: [],
+      }),
+      [
+        {
+          ...kimi,
+          model: {
+            ...kimi.model,
+            provider: 'kimiCode',
+            routeLabel: 'Via Kimi Code',
+          },
+        },
+      ],
+      'personal',
+    );
+
+    expect(view.modelItems).toMatchObject([
+      {
+        value: 'kimi3',
+        description: 'api: Kimi Code subscription',
+      },
+    ]);
+  });
+
   it('keeps launcher rows active when model registry state is unknown', () => {
     const view = orchestrationModelAccessView(
       buildCliOrchestrationItems({

--- a/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
+++ b/src/test-kernel/cli/SlashCommandDispatch.vitest.mts
@@ -73,7 +73,11 @@ function createSession(): TuiSession {
 
 function mockModelAccessOverview(): void {
   vi.spyOn(apiStatus, 'loadCliModelAccessOverview').mockResolvedValue({
-    access: { active: 'personal', chatGptSignedIn: false },
+    access: {
+      apiFallback: 'personal',
+      preferences: { chatGpt: 'off', kimiCode: 'off' },
+      chatGptSignedIn: false,
+    },
     lines: ['model access: Personal API keys'],
   });
 }
@@ -433,13 +437,15 @@ describe('handleTuiSlashCommand', () => {
       .spyOn(apiStatus, 'loadCliModelAccessOverview')
       .mockResolvedValue({
         access: {
-          active: 'chatgpt',
+          apiFallback: 'personal',
+          preferences: { chatGpt: 'on', kimiCode: 'off' },
           chatGptSignedIn: true,
           texraSignedIn: true,
         },
         lines: [
-          'model access: ChatGPT subscription',
-          'ChatGPT: signed in',
+          'ChatGPT preference: On · your account',
+          'Kimi Code preference: Off · key required to enable',
+          'API fallback: Personal API keys',
           'TeXRA: signed in',
         ],
       });
@@ -457,7 +463,9 @@ describe('handleTuiSlashCommand', () => {
 
     await handleTuiSlashCommand('/auth', context);
     const authStatusText = lastEntryText();
-    expect(authStatusText).toContain('model access: ChatGPT subscription');
+    expect(authStatusText).toContain('ChatGPT preference: On');
+    expect(authStatusText).toContain('Kimi Code preference: Off');
+    expect(authStatusText).toContain('API fallback: Personal API keys');
     expect(authStatusText).toContain('tier: researcher');
     expect(authStatusText).toContain(
       'included usage this month: 25% used, 75% remaining',
@@ -465,7 +473,9 @@ describe('handleTuiSlashCommand', () => {
 
     await handleTuiSlashCommand('/api status', context);
     const apiStatusText = lastEntryText();
-    expect(apiStatusText).toContain('model access: ChatGPT subscription');
+    expect(apiStatusText).toContain('ChatGPT preference: On');
+    expect(apiStatusText).toContain('Kimi Code preference: Off');
+    expect(apiStatusText).toContain('API fallback: Personal API keys');
     expect(apiStatusText).toContain('tier: researcher');
     expect(apiStatusText).toContain(
       'included usage this month: 25% used, 75% remaining',
@@ -478,7 +488,7 @@ describe('handleTuiSlashCommand', () => {
     registerBuiltinSlashCommands();
     patchSessionMeta({ apiMode: 'personal' });
     const selection = vi
-      .spyOn(modelAccessSelection, 'selectCliModelAccessRoute')
+      .spyOn(modelAccessSelection, 'updateCliModelAccess')
       .mockResolvedValue({
         apiMode: 'personal',
         message: 'Model access: ChatGPT subscription.',
@@ -494,7 +504,11 @@ describe('handleTuiSlashCommand', () => {
 
     expect(selection).toHaveBeenCalledWith(
       expect.objectContaining({ apiMode: 'personal' }),
-      'chatgpt',
+      {
+        kind: 'subscription-preference',
+        provider: 'chatgpt',
+        state: 'on',
+      },
       expect.any(Object),
     );
     expect(lastEntryText()).toBe(
@@ -505,26 +519,30 @@ describe('handleTuiSlashCommand', () => {
 
   it('exposes cancellation while model access is signing in to ChatGPT', async () => {
     let receivedSignal: AbortSignal | undefined;
-    vi.spyOn(
-      modelAccessSelection,
-      'selectCliModelAccessRoute',
-    ).mockImplementation((_context, _route, options) => {
-      receivedSignal = options.signal;
-      return new Promise((_resolve, reject) => {
-        options.signal?.addEventListener(
-          'abort',
-          () => reject(options.signal?.reason),
-          { once: true },
-        );
-      });
-    });
+    vi.spyOn(modelAccessSelection, 'updateCliModelAccess').mockImplementation(
+      (_context, _selection, options) => {
+        if (!options) throw new Error('Expected selection options');
+        receivedSignal = options.signal;
+        return new Promise((_resolve, reject) => {
+          options.signal?.addEventListener(
+            'abort',
+            () => reject(options.signal?.reason),
+            { once: true },
+          );
+        });
+      },
+    );
     const output: SlashCommandOutput = {
       appendOutcome: vi.fn(),
       setNotice: vi.fn(),
       writeProgress: vi.fn(),
     };
     const completion = applyCliModelAccessSelection(
-      'chatgpt',
+      {
+        kind: 'subscription-preference',
+        provider: 'chatgpt',
+        state: 'on',
+      },
       createContext(createSession()),
       output,
     );

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -32,7 +32,10 @@ import {
   type SessionMeta,
 } from '@cli/chat/tui/state/cliState';
 import { CLI_LOCAL_STREAM_ID } from '@cli/chat/tui/state/transcript';
-import type { CliModelAccessRoute } from '@cli/runtime/modelAccessRoute';
+import {
+  cliApiFallbackSelection,
+  type CliModelAccessSelection,
+} from '@cli/runtime/modelAccessRoute';
 import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
 import { AgentCategory } from '@shared/schemas/agent';
 import {
@@ -454,9 +457,9 @@ describe('slashRegistry', () => {
     expect(openRegisteredCliSlashForm(api, '')).toBe(true);
 
     const apiNode = renderOpenForm<{
-      onSelect?: (value: CliModelAccessRoute) => void;
+      onSelect?: (value: CliModelAccessSelection) => void;
     }>();
-    apiNode.props?.onSelect?.('personal');
+    apiNode.props?.onSelect?.(cliApiFallbackSelection('personal'));
     await settleFormSelection();
 
     expect(errors).toEqual(['api mode failed']);
@@ -476,9 +479,9 @@ describe('slashRegistry', () => {
     expect(openRegisteredCliSlashForm(api, '')).toBe(true);
 
     const apiNode = renderOpenForm<{
-      onSelect?: (value: CliModelAccessRoute) => void;
+      onSelect?: (value: CliModelAccessSelection) => void;
     }>();
-    apiNode.props?.onSelect?.('personal');
+    apiNode.props?.onSelect?.(cliApiFallbackSelection('personal'));
     await settleFormSelection();
 
     expect(apiNode.isClosed()).toBe(false);
@@ -714,9 +717,9 @@ describe('slashRegistry', () => {
 
     expect(openRegisteredCliSlashForm(api, '')).toBe(true);
     const apiNode = renderOpenForm<{
-      onSelect?: (value: CliModelAccessRoute) => void;
+      onSelect?: (value: CliModelAccessSelection) => void;
     }>();
-    apiNode.props?.onSelect?.('personal');
+    apiNode.props?.onSelect?.(cliApiFallbackSelection('personal'));
     resetCliState(INCLUDED_CHAT_SESSION);
     selection.resolve();
     await settleFormSelection();


### PR DESCRIPTION
## Summary

The ChatGPT and Kimi Code subscription preferences are now independent switches. Either, both, or neither may be On. The API route is shown and changed separately as the fallback for requests that do not use a preferred subscription.

The terminal launcher, `/api` form, configuration summary, and detailed status now expose all three facts without collapsing them into one active route.

## User-visible behavior

- Turning ChatGPT On or Off does not write the Kimi Code preference.
- Turning Kimi Code On or Off does not write the ChatGPT preference.
- Choosing Included TeXRA access or Personal API keys changes only the API fallback.
- Both subscription rows can display On simultaneously.
- The selection mark identifies only the API fallback; preferences describe their own On/Off state.
- A stale On preference can be turned Off even when its credential is unavailable. ChatGPT displays `On · sign in required`; Kimi Code displays `On · key required`.
- Configuration summaries show both preferences and the fallback together.

## Design

`CliModelAccessSelection` is a discriminated desired-state value: either a provider preference with its requested state, or an API fallback with its requested mode. Menu rows therefore declare the state they will set rather than issuing an ambiguous route command.

`updateCliModelAccess` owns these transitions. The slash-command registry and launcher delegate to that boundary instead of duplicating preference, OpenRouter, and session writes. `CliModelAccessStatus` stores no synthetic active route; it contains the two preferences, the fallback, and credential availability.

Observed request accounting is unchanged. `usageRoute`, including `kimi-code-subscription`, remains the authoritative record of which access route a request actually used.

## Validation

- `corepack pnpm typecheck`
- `npm run lint`
- 180 focused tests across status, selection, configuration, orchestration, and slash-command dispatch
- five PTY scenarios, including simultaneous ChatGPT and Kimi Code preferences
- the independent-preferences PTY scenario is selected by Linux CI
- Prettier on every changed file
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how CLI users configure model authentication and subscription routing across launcher, slash commands, and onboarding, but behavior is heavily covered by tests and TUI smoke scenarios and does not alter per-request `usageRoute` accounting.
> 
> **Overview**
> **ChatGPT and Kimi Code subscription preferences are independent toggles**, with **included TeXRA** vs **personal API keys** as a separate **API fallback**. The CLI no longer treats model access as one mutually exclusive “active route.”
> 
> Launcher, `/api`, orchestration, and status views use **`CliModelAccessSelection`** (preference on/off or fallback mode) and **`updateCliModelAccess`** instead of route-only pickers. Summaries show both preferences plus fallback; the checkmark applies only to the fallback. Stale **On** preferences can be turned off without credentials. Kimi models in personal mode are labeled **Kimi Code subscription** when routed that way.
> 
> **ChatGPT sign-in** prints the URL before waiting on browser launch. Slash commands and onboarding route through the shared update path; duplicate preference logic in the registry is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2995d354e1df6869cc59e0fe8439f5953a783c7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->