### PR TITLE
fix(desktop): reject stale cross-process resumes

### DIFF
--- a/packages/desktop/src/main/desktopAgentLaunch.ts
+++ b/packages/desktop/src/main/desktopAgentLaunch.ts
@@ -20,7 +20,7 @@ export interface DesktopAgentLaunchContext {
   readonly ready: Promise<void>;
   readonly session: SessionHandle;
   /** Resume-only canonical admission checked under the execution lease lock. */
-  readonly canAcquireResumeLease?: () => boolean;
+  readonly canAcquireResumeLease?: () => boolean | Promise<boolean>;
 }
 
 export interface DesktopAgentLaunchOptions {

--- a/packages/desktop/src/main/desktopAgentResume.ts
+++ b/packages/desktop/src/main/desktopAgentResume.ts
@@ -125,9 +125,19 @@ function resumeDesktopStream(
   context: DesktopResumeContext,
 ): Promise<boolean> {
   if (!context.session.transcripts.has(streamId)) return Promise.resolve(false);
+  let authoritativeStreamMissing = false;
   const isResumeInvalidated = (): boolean =>
     context.isCancellationRequested() ||
+    authoritativeStreamMissing ||
     !context.session.transcripts.has(streamId);
+  const canAcquireResumeLease = async (): Promise<boolean> => {
+    if (isResumeInvalidated()) return false;
+    if (!(await context.session.transcripts.hasAuthoritativeStream(streamId))) {
+      authoritativeStreamMissing = true;
+      return false;
+    }
+    return !isResumeInvalidated();
+  };
   const runtimeHost = context.session.interactions;
   let lifecycleStarted = false;
   return resolveAndResumeStream(streamId, {
@@ -166,7 +176,7 @@ function resumeDesktopStream(
         {
           session: context.session,
           runtimeUnavailableTools: DESKTOP_UNAVAILABLE_TOOLS,
-          canAcquireResumeLease: () => !isResumeInvalidated(),
+          canAcquireResumeLease,
           isCancellationRequested: isResumeInvalidated,
           onRun: () => {
             lifecycleStarted = true;
@@ -181,7 +191,7 @@ function resumeDesktopStream(
         {
           ready: Promise.resolve(),
           session: context.session,
-          canAcquireResumeLease: () => !isResumeInvalidated(),
+          canAcquireResumeLease,
         },
         {
           modelHandlerCompatibilityKey,

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -468,7 +468,7 @@ export async function executeAgent(
 
 export interface ResumeToolUseFromResumeDataOptions extends SubagentRunOptions {
   /** Recheck canonical admission atomically while acquiring the resumed lease. */
-  readonly canAcquireResumeLease?: () => boolean;
+  readonly canAcquireResumeLease?: () => boolean | Promise<boolean>;
   /**
    * Take messages queued after the initial drain. The flow invokes this once
    * after attaching its live context and before resuming the persisted cursor.

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -21,7 +21,7 @@ import type { AgentRuntimeHost } from './AgentRuntimeHost';
 
 export interface ResumeQueuedToolUseOptions extends SubagentRunOptions {
   /** Recheck canonical admission atomically while acquiring the resumed lease. */
-  readonly canAcquireResumeLease?: () => boolean;
+  readonly canAcquireResumeLease?: () => boolean | Promise<boolean>;
   /** Query a caller-owned stop request at the resumed flow attachment boundary. */
   readonly isCancellationRequested?: () => boolean;
   /**

--- a/src/agent/runtime/runAgent.ts
+++ b/src/agent/runtime/runAgent.ts
@@ -46,7 +46,7 @@ export interface RunAgentOptions extends Pick<
   onExecutionLeaseAcquired?: (scope: OwnedExecutionLeaseScope) => void;
   registerExecution?: boolean;
   /** Recheck canonical admission atomically while acquiring a resumed lease. */
-  canAcquireResumeLease?: () => boolean;
+  canAcquireResumeLease?: () => boolean | Promise<boolean>;
   /**
    * Opt-in set by the "fix LaTeX" VS Code actions (Fix-Compilation command, the
    * progress-view compile fixer): run the launched agent on the configured

--- a/src/agent/storage/executionLease.ts
+++ b/src/agent/storage/executionLease.ts
@@ -512,8 +512,18 @@ async function acquireExecutionLease(
       try {
         heartbeatResult = await performHeartbeat(existingOwnership, canAcquire);
       } catch (error) {
-        handleHeartbeatFailure(existingOwnership, error);
-        throw error;
+        if (handleHeartbeatFailure(existingOwnership, error)) throw error;
+        if (
+          ownedLeases.get(key) === existingOwnership &&
+          !existingOwnership.releasing
+        ) {
+          const admitted = await withLeaseLock(
+            executionId,
+            async () => (await canAcquire?.()) !== false,
+            root,
+          );
+          return admitted ? 'existing' : 'cancelled';
+        }
       }
     }
     if (heartbeatResult === 'cancelled') return 'cancelled';
@@ -533,6 +543,7 @@ async function acquireExecutionLease(
         throw new ExecutionLeaseActiveError(executionId, liveness.heartbeatAt);
       }
       if ((await canAcquire?.()) === false) return 'cancelled' as const;
+      const acquiredAt = Date.now();
       const ownerToken = randomUUID();
       if (existingOwnership) forgetOwnedLease(existingOwnership);
       await writeLease(
@@ -540,8 +551,8 @@ async function acquireExecutionLease(
           version: 1,
           executionId,
           ownerToken,
-          acquiredAt: now,
-          heartbeatAt: now,
+          acquiredAt,
+          heartbeatAt: acquiredAt,
         },
         root,
       );

--- a/src/agent/storage/executionLease.ts
+++ b/src/agent/storage/executionLease.ts
@@ -227,20 +227,27 @@ function forgetOwnedLease(
   }
 }
 
-async function performHeartbeat(lease: OwnedExecutionLease): Promise<void> {
-  await withLeaseLock(
+type HeartbeatResult = 'owned' | 'lost' | 'cancelled';
+
+async function performHeartbeat(
+  lease: OwnedExecutionLease,
+  canContinue?: () => boolean | Promise<boolean>,
+): Promise<HeartbeatResult> {
+  return withLeaseLock(
     lease.executionId,
     async () => {
       const current = await readLease(lease.executionId, lease.storageRoot);
       if (current?.ownerToken !== lease.ownerToken) {
         forgetOwnedLease(lease, { notifyLoss: true });
-        return;
+        return 'lost';
       }
+      if ((await canContinue?.()) === false) return 'cancelled';
       await writeLease(
         { ...current, heartbeatAt: Date.now() },
         lease.storageRoot,
       );
       lease.lastConfirmedHeartbeatAt = Date.now();
+      return 'owned';
     },
     lease.storageRoot,
   );
@@ -251,6 +258,7 @@ function heartbeat(lease: OwnedExecutionLease): Promise<void> {
   if (lease.heartbeatInFlight) return lease.heartbeatInFlight;
 
   const work = performHeartbeat(lease)
+    .then(() => undefined)
     .catch((error: unknown) => {
       if (handleHeartbeatFailure(lease, error)) throw error;
     })
@@ -485,21 +493,31 @@ function acquireExecutionLease(
 function acquireExecutionLease(
   executionId: ExecutionId,
   mode: 'resume',
-  canAcquire?: () => boolean,
+  canAcquire?: () => boolean | Promise<boolean>,
 ): Promise<'acquired' | 'existing' | 'cancelled'>;
 async function acquireExecutionLease(
   executionId: ExecutionId,
   mode: 'fresh' | 'resume',
-  canAcquire?: () => boolean,
+  canAcquire?: () => boolean | Promise<boolean>,
 ): Promise<'acquired' | 'existing' | 'cancelled'> {
   const root = storageRoot();
   const key = ownershipKey(root, executionId);
   const existingOwnership = ownedLeases.get(key);
   if (mode === 'resume' && existingOwnership) {
-    await heartbeat(existingOwnership);
-    if (ownedLeases.get(key) === existingOwnership) {
-      return canAcquire?.() === false ? 'cancelled' : 'existing';
+    if (existingOwnership.heartbeatInFlight) {
+      await existingOwnership.heartbeatInFlight;
     }
+    let heartbeatResult: HeartbeatResult = 'lost';
+    if (!existingOwnership.releasing) {
+      try {
+        heartbeatResult = await performHeartbeat(existingOwnership, canAcquire);
+      } catch (error) {
+        handleHeartbeatFailure(existingOwnership, error);
+        throw error;
+      }
+    }
+    if (heartbeatResult === 'cancelled') return 'cancelled';
+    if (heartbeatResult === 'owned') return 'existing';
   }
 
   return withLeaseLock(
@@ -514,7 +532,7 @@ async function acquireExecutionLease(
       if (liveness.status === 'active') {
         throw new ExecutionLeaseActiveError(executionId, liveness.heartbeatAt);
       }
-      if (canAcquire?.() === false) return 'cancelled' as const;
+      if ((await canAcquire?.()) === false) return 'cancelled' as const;
       const ownerToken = randomUUID();
       if (existingOwnership) forgetOwnedLease(existingOwnership);
       await writeLease(
@@ -544,7 +562,7 @@ export function acquireFreshExecutionLease(
 /** Establish ownership before a persisted execution is resumed. */
 export function acquireResumedExecutionLease(
   executionId: ExecutionId,
-  canAcquire?: () => boolean,
+  canAcquire?: () => boolean | Promise<boolean>,
 ): Promise<'acquired' | 'existing' | 'cancelled'> {
   return acquireExecutionLease(executionId, 'resume', canAcquire);
 }

--- a/src/test-kernel/agent/storage/ExecutionLease.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionLease.vitest.ts
@@ -169,6 +169,45 @@ describe('cross-process execution leases', () => {
     expect(maintenanceEntered).toBe(true);
   });
 
+  it('timestamps a resumed lease after asynchronous admission completes', async () => {
+    vi.useFakeTimers({ now: new Date('2026-07-25T12:00:00.000Z') });
+    const executionId = 'd86450' as ExecutionId;
+    const expectedHeartbeat = Date.now() + EXECUTION_LEASE_STALE_MS + 1_000;
+
+    try {
+      await expect(
+        acquireResumedExecutionLease(executionId, async () => {
+          await vi.advanceTimersByTimeAsync(EXECUTION_LEASE_STALE_MS + 1_000);
+          return true;
+        }),
+      ).resolves.toBe('acquired');
+      ownedExecutionIds.add(executionId);
+
+      const persisted = JSON.parse(
+        await StorageFS.read(leasePath(executionId)),
+      ) as { acquiredAt: number; heartbeatAt: number };
+      expect(persisted).toMatchObject({
+        acquiredAt: expectedHeartbeat,
+        heartbeatAt: expectedHeartbeat,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('retains existing ownership through a transient resume heartbeat failure', async () => {
+    const executionId = 'd86451' as ExecutionId;
+    await acquire(executionId);
+    vi.spyOn(platform().fileLocks, 'runExclusive').mockRejectedValueOnce(
+      new Error('temporary filesystem failure'),
+    );
+
+    await expect(
+      acquireResumedExecutionLease(executionId, () => true),
+    ).resolves.toBe('existing');
+    expect(ownsExecutionLease(executionId)).toBe(true);
+  });
+
   it('keeps resumed ownership live until terminal lifecycle release', async () => {
     const executionId = 'd86440' as ExecutionId;
     await writeExecution(executionId);

--- a/src/test-kernel/agent/storage/ExecutionLease.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionLease.vitest.ts
@@ -140,6 +140,35 @@ describe('cross-process execution leases', () => {
     });
   });
 
+  it('holds the execution lock while awaiting canonical resume admission', async () => {
+    const executionId = 'd8644f' as ExecutionId;
+    let finishAdmission!: (admitted: boolean) => void;
+    let markAdmissionStarted!: () => void;
+    const admissionStarted = new Promise<void>((resolve) => {
+      markAdmissionStarted = resolve;
+    });
+    const admission = new Promise<boolean>((resolve) => {
+      finishAdmission = resolve;
+    });
+    const acquisition = acquireResumedExecutionLease(executionId, () => {
+      markAdmissionStarted();
+      return admission;
+    });
+    await admissionStarted;
+
+    let maintenanceEntered = false;
+    const maintenance = runWithInactiveExecutionLease(executionId, async () => {
+      maintenanceEntered = true;
+    });
+    await Promise.resolve();
+    expect(maintenanceEntered).toBe(false);
+
+    finishAdmission(false);
+    await expect(acquisition).resolves.toBe('cancelled');
+    await maintenance;
+    expect(maintenanceEntered).toBe(true);
+  });
+
   it('keeps resumed ownership live until terminal lifecycle release', async () => {
     const executionId = 'd86440' as ExecutionId;
     await writeExecution(executionId);

--- a/src/test-kernel/desktop/DesktopAgentResume.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentResume.vitest.mts
@@ -11,6 +11,7 @@ import * as AgentExecution from '@agent/runtime/executeAgent';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import * as SessionResumeRetrieval from '@agent/runtime/SessionResumeRetrieval';
 import * as AgentRunner from '@agent/runtime/runAgent';
+import { ResumeAdmissionCancelledError } from '@agent/runtime/resumeAdmission';
 import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
 import { DesktopProcessResumeOwner } from '@desktop/main/desktopAgentResume';
 import {
@@ -308,6 +309,43 @@ describe('desktop process resume owner', () => {
       await expect(resume).resolves.toBe(false);
       expect(runAgent).not.toHaveBeenCalled();
       expect(harness.session.transcripts.has(stream)).toBe(false);
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  it('rejects a stale process store after another process deletes the stream', async () => {
+    retrieveSessionResumeData.mockResolvedValue({
+      type: 'workflow',
+      agentConfig: config,
+      executionId,
+    });
+    const harness = createResumeHarness();
+    vi.spyOn(
+      harness.session.transcripts,
+      'hasAuthoritativeStream',
+    ).mockResolvedValue(false);
+    runAgent.mockImplementation(async (_request, options) => {
+      if ((await options.canAcquireResumeLease?.()) === false) {
+        throw new ResumeAdmissionCancelledError(executionId);
+      }
+      return {
+        executionId,
+        streamId: stream,
+        category: 'workflow',
+        outcome: RUN_OUTCOME.COMPLETED,
+        outputs: [],
+        compileFailures: [],
+      };
+    });
+
+    try {
+      await expect(harness.owner.tryResumeStream(stream)).resolves.toBe(false);
+      expect(harness.session.transcripts.has(stream)).toBe(true);
+
+      const emit = vi.fn();
+      harness.session.useHostInteractions({ emit, cancel: vi.fn() });
+      expect(emit).not.toHaveBeenCalled();
     } finally {
       harness.dispose();
     }

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -342,6 +342,26 @@ describe('StreamLogStore load', () => {
     expect(storage.fullLogReads()).toBe(2);
   });
 
+  it('distinguishes another process deletion from a stale local summary', async () => {
+    const logs: Record<string, unknown> = { alpha: [] };
+    mockStorage({ logs, summaries: {} });
+
+    const staleProcessStore = await StreamLogStore.open();
+    expect(staleProcessStore.has('alpha')).toBe(true);
+    await expect(
+      staleProcessStore.hasAuthoritativeStream('alpha'),
+    ).resolves.toBe(true);
+
+    // A different process commits deletion while this store retains the
+    // summary it loaded at startup.
+    delete logs.alpha;
+
+    expect(staleProcessStore.has('alpha')).toBe(true);
+    await expect(
+      staleProcessStore.hasAuthoritativeStream('alpha'),
+    ).resolves.toBe(false);
+  });
+
   it('opens a read-only store without creating directories or writing caches', async () => {
     const storage = mockStorage({
       logs: { alpha: [logEntry('alpha', 1, 200)] },

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -270,6 +270,17 @@ export class StreamLogStore {
     return this.summaries.has(streamId);
   }
 
+  /**
+   * Recheck the durable transcript source rather than this process's cached
+   * summary. Resume admission uses this while holding the execution lease
+   * lock, so a stream deleted by another process cannot be recreated from a
+   * stale in-memory summary.
+   */
+  async hasAuthoritativeStream(streamId: StreamTabId): Promise<boolean> {
+    if (this.mode.kind === 'ephemeral') return this.has(streamId);
+    return this.kv.exists(streamId);
+  }
+
   keys(): StreamTabId[] {
     return [...this.summaries.keys()];
   }


### PR DESCRIPTION
## Summary

- rechecks the durable transcript before desktop resume admission instead of trusting a process-local summary
- performs that asynchronous check while holding the execution lease lock
- prevents a stale desktop process from recreating a stream deleted by another process
- preserves the still-relevant part of an otherwise superseded local lifecycle worktree

## Design

The execution lease remains the serialization point. Resume admission now accepts an asynchronous predicate, allowing the desktop to query the durable transcript while competing maintenance and deletion work is excluded. The ordinary in-memory lookup remains the inexpensive first check.

## Validation

- 78 focused execution-lease, transcript-store, and desktop-resume tests
- 7,581 repository tests passed; 4 skipped
- `npm run typecheck`
- `npm run lint`
- `npm run compile:fast`
- commit hooks: formatting, documentation boundary, and guidance-reference checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cross-process execution lease acquisition and desktop resume admission—critical coordination paths—but behavior is narrowly scoped to async canonical checks and adds regression tests.
> 
> **Overview**
> **Desktop resume admission** now re-checks durable transcript storage instead of trusting a process-local summary, so a stale desktop process cannot resurrect a stream another process deleted.
> 
> `StreamLogStore` adds **`hasAuthoritativeStream`**, which hits durable storage (`kv.exists`) while resume holds the execution lease lock. **`canAcquireResumeLease`** is now **`boolean | Promise<boolean>`** end-to-end (desktop launch/resume, `runAgent`, `executeAgent`, `resumeQueuedToolUse`). Desktop wires an async predicate that calls `hasAuthoritativeStream` and treats a missing authoritative stream as cancelled admission (no error toast).
> 
> **Execution lease** changes run that async admission **inside** the lease lock: heartbeats accept `canContinue`, resume acquisition awaits pending heartbeats, evaluates admission during heartbeat, and timestamps **`acquiredAt`/`heartbeatAt`** after async admission finishes. Transient heartbeat failures on re-resume can fall back to re-checking admission without dropping local ownership.
> 
> New tests cover authoritative vs stale `has`, lock held during async admission, lease timestamps, transient heartbeat resume, and desktop rejection when another process deleted the stream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5799262a59d78bc9a8e11eaf8cab5cbb86b2118. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->