### PR TITLE
fix(desktop): guard resumed session ownership

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -16,7 +16,7 @@ import type {
   AgentRuntimeEventPayloads,
   AgentRuntimeHost,
 } from '@agent/runtime/AgentRuntimeHost';
-import { terminalResultToast } from '@agent/runtime/terminalResultToast';
+import { trackTerminalResultPresentation } from '@agent/runtime/terminalResultToast';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import {
   presentFollowUpWakeResult,
@@ -312,13 +312,10 @@ export class DesktopProgressBridge {
         const logger = this.logger;
         const runtimeHost = this.runtimeHost;
         let executionId: string | undefined;
-        let terminalRejectionHandled = false;
-        const unsubscribeResult = this.session.onResult((event) => {
-          if (event.executionId !== executionId) return;
-          terminalRejectionHandled =
-            terminalResultToast(event) !== null ||
-            event.error?.kind === 'abort';
-        });
+        const terminalResult = trackTerminalResultPresentation(
+          this.session,
+          (event) => event.executionId === executionId,
+        );
         void this.runExecution(request, {
           suppressErrorNotification: true,
           onRun: (handle) => {
@@ -329,13 +326,13 @@ export class DesktopProgressBridge {
             logger.error('Desktop merge execution failed', {
               data: toLogData(error),
             });
-            if (!terminalRejectionHandled) {
+            if (!terminalResult.isHandled()) {
               runtimeHost.emit('requestShowError', {
                 message: `Merge failed: ${toErrorMessage(error)}`,
               });
             }
           })
-          .finally(unsubscribeResult);
+          .finally(terminalResult.dispose);
       },
       listWorkspaceCandidateFiles: () => this.listWorkspaceCandidateFiles(),
     });

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -16,7 +16,7 @@ import type {
   AgentRuntimeEventPayloads,
   AgentRuntimeHost,
 } from '@agent/runtime/AgentRuntimeHost';
-import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
+import { terminalResultToast } from '@agent/runtime/terminalResultToast';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import {
   presentFollowUpWakeResult,
@@ -191,7 +191,6 @@ export class DesktopProgressBridge {
   private readonly session: SessionHandle;
   /** Detaches this window's presentation from process-owned interactions. */
   private detachHostInteractions: () => void = () => undefined;
-  private detachResultToast: () => void = () => undefined;
 
   constructor(
     private readonly postToRenderer: (message: unknown) => boolean | void,
@@ -312,23 +311,31 @@ export class DesktopProgressBridge {
       startExecution: (request) => {
         const logger = this.logger;
         const runtimeHost = this.runtimeHost;
-        let lifecycleStarted = false;
-        void this.runExecution(request, {
-          onLifecycleStart: () => {
-            lifecycleStarted = true;
-          },
-        }).catch((error: unknown) => {
-          logger.error('Desktop merge execution failed', {
-            data: toLogData(error),
-          });
-          // Once the lifecycle starts, the process-session result listener
-          // owns the one terminal error presentation.
-          if (!lifecycleStarted) {
-            runtimeHost.emit('requestShowError', {
-              message: `Merge failed: ${toErrorMessage(error)}`,
-            });
-          }
+        let executionId: string | undefined;
+        let terminalRejectionHandled = false;
+        const unsubscribeResult = this.session.onResult((event) => {
+          if (event.executionId !== executionId) return;
+          terminalRejectionHandled =
+            terminalResultToast(event) !== null ||
+            event.error?.kind === 'abort';
         });
+        void this.runExecution(request, {
+          suppressErrorNotification: true,
+          onRun: (handle) => {
+            executionId = handle.executionId;
+          },
+        })
+          .catch((error: unknown) => {
+            logger.error('Desktop merge execution failed', {
+              data: toLogData(error),
+            });
+            if (!terminalRejectionHandled) {
+              runtimeHost.emit('requestShowError', {
+                message: `Merge failed: ${toErrorMessage(error)}`,
+              });
+            }
+          })
+          .finally(unsubscribeResult);
       },
       listWorkspaceCandidateFiles: () => this.listWorkspaceCandidateFiles(),
     });
@@ -361,18 +368,6 @@ export class DesktopProgressBridge {
     // first render can be enabled.
     await this.options.sessionStores.waitForPendingStreamDeletions();
     if (this.disposed) return;
-    const detachResultToast = attachTerminalResultToast(
-      this.session,
-      this.runtimeHost,
-      { replayWhenAttached: true },
-    );
-    // Missed-result replay is synchronous for the same reason as approval
-    // replay above; never publish a disposer after this presentation closed.
-    if (this.disposed) {
-      detachResultToast();
-      return;
-    }
-    this.detachResultToast = detachResultToast;
     // Close the load→subscribe gap. The process-owned snapshot listener may
     // have accepted metadata facts while restart repair was in flight; now
     // that live subscriptions are established, overlay that canonical state
@@ -674,7 +669,6 @@ export class DesktopProgressBridge {
     this.detachHostInteractions();
     this.toolEditApprovals?.dispose();
     this.clearDesktopPresentationState();
-    this.detachResultToast();
     this.unsubscribe();
     this.backend.dispose();
     this.workflowFileActions?.clearAllBackups();

--- a/packages/desktop/src/main/desktopAgentLaunch.ts
+++ b/packages/desktop/src/main/desktopAgentLaunch.ts
@@ -1,5 +1,6 @@
 // Agent imports
 import type { ValidatedExecutionRequest } from '@agent/core/state/executionRequests';
+import type { AgentRunHandle } from '@agent/runtime/ExecutionHandle';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { ModelHandlerCompatibilityKey } from '@agent/runtime/modelHandlerCompatibilityKey';
 import { selectAutoOpenFinalOutput } from '@agent/runtime/selectAutoOpenFinalOutput';
@@ -20,13 +21,15 @@ export interface DesktopAgentLaunchContext {
   readonly ready: Promise<void>;
   readonly session: SessionHandle;
   /** Resume-only canonical admission checked under the execution lease lock. */
-  readonly canAcquireResumeLease?: () => boolean;
+  readonly canAcquireResumeLease?: () => boolean | Promise<boolean>;
 }
 
 export interface DesktopAgentLaunchOptions {
   readonly modelHandlerCompatibilityKey?: ModelHandlerCompatibilityKey | null;
-  /** Reports that the run lifecycle now owns terminal error presentation. */
-  readonly onLifecycleStart?: () => void;
+  /** Observe the concrete run identity used by process-session result events. */
+  readonly onRun?: (handle: AgentRunHandle) => void | Promise<void>;
+  /** The caller owns presentation for failures before the run lifecycle. */
+  readonly suppressErrorNotification?: boolean;
 }
 
 /** Start a desktop run with process-owned dependencies only. */
@@ -43,7 +46,8 @@ export async function launchDesktopAgent(
     session: context.session,
     runtimeUnavailableTools: DESKTOP_UNAVAILABLE_TOOLS,
     modelHandlerCompatibilityKey: options.modelHandlerCompatibilityKey,
-    onRun: options.onLifecycleStart,
+    onRun: options.onRun,
+    suppressErrorNotification: options.suppressErrorNotification,
     ...(context.canAcquireResumeLease && {
       canAcquireResumeLease: context.canAcquireResumeLease,
     }),

--- a/packages/desktop/src/main/desktopAgentResume.ts
+++ b/packages/desktop/src/main/desktopAgentResume.ts
@@ -8,7 +8,7 @@ import {
   resolveAndResumeStream,
 } from '@agent/runtime/resolveAndResumeStream';
 import { resumeQueuedToolUseFromResumeData } from '@agent/runtime/resumeQueuedToolUse';
-import { terminalResultToast } from '@agent/runtime/terminalResultToast';
+import { trackTerminalResultPresentation } from '@agent/runtime/terminalResultToast';
 
 // Shared imports
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
@@ -124,12 +124,10 @@ function resumeDesktopStream(
   context: DesktopResumeContext,
 ): Promise<boolean> {
   if (!context.session.transcripts.has(streamId)) return Promise.resolve(false);
-  let terminalRejectionHandled = false;
-  const unsubscribeResult = context.session.onResult((event) => {
-    if (event.streamId !== streamId) return;
-    terminalRejectionHandled =
-      terminalResultToast(event) !== null || event.error?.kind === 'abort';
-  });
+  const terminalResult = trackTerminalResultPresentation(
+    context.session,
+    (event) => event.streamId === streamId,
+  );
   let authoritativeStreamMissing = false;
   const isResumeInvalidated = (): boolean =>
     context.isCancellationRequested() ||
@@ -144,7 +142,7 @@ function resumeDesktopStream(
     return !isResumeInvalidated();
   };
   const reportUnhandledFailure = (id: StreamTabId, error: unknown): void => {
-    if (!terminalRejectionHandled) reportResumeFailure(id, error, context);
+    if (!terminalResult.isHandled()) reportResumeFailure(id, error, context);
   };
   const runtimeHost = context.session.interactions;
   return resolveAndResumeStream(streamId, {
@@ -208,5 +206,5 @@ function resumeDesktopStream(
       ),
     reportFailure: reportUnhandledFailure,
     isCancellationRequested: isResumeInvalidated,
-  }).finally(unsubscribeResult);
+  }).finally(terminalResult.dispose);
 }

--- a/packages/desktop/src/main/desktopAgentResume.ts
+++ b/packages/desktop/src/main/desktopAgentResume.ts
@@ -8,6 +8,7 @@ import {
   resolveAndResumeStream,
 } from '@agent/runtime/resolveAndResumeStream';
 import { resumeQueuedToolUseFromResumeData } from '@agent/runtime/resumeQueuedToolUse';
+import { terminalResultToast } from '@agent/runtime/terminalResultToast';
 
 // Shared imports
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
@@ -125,9 +126,30 @@ function resumeDesktopStream(
   context: DesktopResumeContext,
 ): Promise<boolean> {
   if (!context.session.transcripts.has(streamId)) return Promise.resolve(false);
+  let terminalRejectionHandled = false;
+  const unsubscribeResult = context.session.onResult((event) => {
+    if (event.streamId !== streamId) return;
+    terminalRejectionHandled =
+      terminalResultToast(event) !== null || event.error?.kind === 'abort';
+  });
+  let authoritativeStreamMissing = false;
   const isResumeInvalidated = (): boolean =>
     context.isCancellationRequested() ||
+    authoritativeStreamMissing ||
     !context.session.transcripts.has(streamId);
+  const canAcquireResumeLease = async (): Promise<boolean> => {
+    if (isResumeInvalidated()) return false;
+    if (!(await context.session.transcripts.hasAuthoritativeStream(streamId))) {
+      authoritativeStreamMissing = true;
+      return false;
+    }
+    return !isResumeInvalidated();
+  };
+  const reportUnhandledFailure = (id: StreamTabId, error: unknown): void => {
+    if (!terminalRejectionHandled) {
+      reportResumeFailure(id, error, context, lifecycleStarted);
+    }
+  };
   const runtimeHost = context.session.interactions;
   let lifecycleStarted = false;
   return resolveAndResumeStream(streamId, {
@@ -166,13 +188,12 @@ function resumeDesktopStream(
         {
           session: context.session,
           runtimeUnavailableTools: DESKTOP_UNAVAILABLE_TOOLS,
-          canAcquireResumeLease: () => !isResumeInvalidated(),
+          canAcquireResumeLease,
           isCancellationRequested: isResumeInvalidated,
           onRun: () => {
             lifecycleStarted = true;
           },
-          onError: (error) =>
-            reportResumeFailure(streamId, error, context, lifecycleStarted),
+          onError: (error) => reportUnhandledFailure(streamId, error),
         },
       ),
     executeWorkflow: (config, executionId, modelHandlerCompatibilityKey) =>
@@ -181,11 +202,12 @@ function resumeDesktopStream(
         {
           ready: Promise.resolve(),
           session: context.session,
-          canAcquireResumeLease: () => !isResumeInvalidated(),
+          canAcquireResumeLease,
         },
         {
           modelHandlerCompatibilityKey,
-          onLifecycleStart: () => {
+          suppressErrorNotification: true,
+          onRun: () => {
             lifecycleStarted = true;
           },
         },
@@ -195,8 +217,7 @@ function resumeDesktopStream(
         'This run has no resumable session state. Start a new run instead.',
         { replayWhenAttached: true },
       ),
-    reportFailure: (id, error) =>
-      reportResumeFailure(id, error, context, lifecycleStarted),
+    reportFailure: reportUnhandledFailure,
     isCancellationRequested: isResumeInvalidated,
-  });
+  }).finally(unsubscribeResult);
 }

--- a/packages/desktop/src/main/desktopAgentResume.ts
+++ b/packages/desktop/src/main/desktopAgentResume.ts
@@ -108,12 +108,10 @@ function reportResumeFailure(
   streamId: StreamTabId,
   error: unknown,
   context: DesktopResumeContext,
-  lifecycleStarted: boolean,
 ): void {
   context.logger.error(`Failed to resume desktop stream ${streamId}`, {
     data: toLogData(error),
   });
-  if (lifecycleStarted) return;
   context.session.interactions.emit(
     'requestShowError',
     { message: `Resume failed: ${toErrorMessage(error)}` },
@@ -146,12 +144,9 @@ function resumeDesktopStream(
     return !isResumeInvalidated();
   };
   const reportUnhandledFailure = (id: StreamTabId, error: unknown): void => {
-    if (!terminalRejectionHandled) {
-      reportResumeFailure(id, error, context, lifecycleStarted);
-    }
+    if (!terminalRejectionHandled) reportResumeFailure(id, error, context);
   };
   const runtimeHost = context.session.interactions;
-  let lifecycleStarted = false;
   return resolveAndResumeStream(streamId, {
     runtimeHost,
     streamStatus: context.session.status,
@@ -190,9 +185,6 @@ function resumeDesktopStream(
           runtimeUnavailableTools: DESKTOP_UNAVAILABLE_TOOLS,
           canAcquireResumeLease,
           isCancellationRequested: isResumeInvalidated,
-          onRun: () => {
-            lifecycleStarted = true;
-          },
           onError: (error) => reportUnhandledFailure(streamId, error),
         },
       ),
@@ -207,9 +199,6 @@ function resumeDesktopStream(
         {
           modelHandlerCompatibilityKey,
           suppressErrorNotification: true,
-          onRun: () => {
-            lifecycleStarted = true;
-          },
         },
       ),
     reportNoResumableSession: () =>

--- a/packages/desktop/src/main/desktopAgentResume.ts
+++ b/packages/desktop/src/main/desktopAgentResume.ts
@@ -104,21 +104,6 @@ async function resolveDesktopResumeState(
   };
 }
 
-function reportResumeFailure(
-  streamId: StreamTabId,
-  error: unknown,
-  context: DesktopResumeContext,
-): void {
-  context.logger.error(`Failed to resume desktop stream ${streamId}`, {
-    data: toLogData(error),
-  });
-  context.session.interactions.emit(
-    'requestShowError',
-    { message: `Resume failed: ${toErrorMessage(error)}` },
-    { replayWhenAttached: true },
-  );
-}
-
 function resumeDesktopStream(
   streamId: StreamTabId,
   context: DesktopResumeContext,
@@ -142,7 +127,15 @@ function resumeDesktopStream(
     return !isResumeInvalidated();
   };
   const reportUnhandledFailure = (id: StreamTabId, error: unknown): void => {
-    if (!terminalResult.isHandled()) reportResumeFailure(id, error, context);
+    context.logger.error(`Failed to resume desktop stream ${id}`, {
+      data: toLogData(error),
+    });
+    if (terminalResult.isHandled()) return;
+    context.session.interactions.emit(
+      'requestShowError',
+      { message: `Resume failed: ${toErrorMessage(error)}` },
+      { replayWhenAttached: true },
+    );
   };
   const runtimeHost = context.session.interactions;
   return resolveAndResumeStream(streamId, {

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -23,6 +23,7 @@ import {
 } from '@agent/index/agentRegistry';
 import { registerAgentShutdownHandlers } from '@agent/runtime/agentShutdown';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
+import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import {
@@ -1233,6 +1234,11 @@ if (protocolLifecycle.shouldContinue) {
       const { lifecycle } = platformInit;
       const transcripts = await StreamLogStore.open();
       const processSession = new SessionHandle({ transcripts });
+      const detachTerminalResultToast = attachTerminalResultToast(
+        processSession,
+        processSession.interactions,
+        { replayWhenAttached: true },
+      );
       let disposeProcessStores = (): void => undefined;
       let disposeAgentResumeHandler = (): void => undefined;
       let sessionStores!: SessionStores;
@@ -1248,6 +1254,7 @@ if (protocolLifecycle.shouldContinue) {
       );
       lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () => {
         disposeAgentResumeHandler();
+        detachTerminalResultToast();
         disposeProcessStores();
         processSession.dispose();
       });

--- a/src/agent/runtime/AgentRuntimeHost.ts
+++ b/src/agent/runtime/AgentRuntimeHost.ts
@@ -6,6 +6,11 @@ export type AgentRuntimeEventPayloads = RuntimeInteractionEventPayloads &
 
 export type AgentRuntimeEvent = keyof AgentRuntimeEventPayloads;
 
+export interface AgentRuntimeEmitOptions {
+  /** Retain a presentation event until a temporarily detached UI returns. */
+  readonly replayWhenAttached?: boolean;
+}
+
 /**
  * The direct host-event sink the agent core emits through during a run. Hosts
  * (VS Code extension, CLI, desktop, or an SDK embedder) implement `emit` and
@@ -29,6 +34,7 @@ export interface AgentRuntimeHost {
   emit<K extends AgentRuntimeEvent>(
     event: K,
     payload: AgentRuntimeEventPayloads[K],
+    options?: AgentRuntimeEmitOptions,
   ): void;
 }
 

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -15,6 +15,7 @@ import type {
 } from '@shared/schemas';
 import type { GenericDiagnostic } from '@utils/diagnostics/diagnosticFormatting';
 import type {
+  AgentRuntimeEmitOptions,
   AgentRuntimeEvent,
   AgentRuntimeEventPayloads,
   AgentRuntimeHost,
@@ -63,12 +64,6 @@ export interface HostRetryInteractionOptions extends HostInteractionOptions {
     selection: ModelCredentialSelection,
     signal?: AbortSignal,
   ) => Promise<void>;
-}
-
-/** Delivery policy for a notification owned by a process session. */
-interface SessionPresentationOptions {
-  /** Retain the notice for the next attachment instead of dropping it now. */
-  readonly replayWhenAttached?: boolean;
 }
 
 export type PlanApprovalResult =
@@ -415,7 +410,7 @@ export class SessionHostInteractions
   emit<K extends AgentRuntimeEvent>(
     event: K,
     payload: AgentRuntimeEventPayloads[K],
-    options: SessionPresentationOptions = {},
+    options: AgentRuntimeEmitOptions = {},
   ): void {
     const active = this.activeAttachment;
     if (active) {
@@ -441,7 +436,7 @@ export class SessionHostInteractions
 
   showInfoMessage(
     message: string,
-    options: SessionPresentationOptions = {},
+    options: AgentRuntimeEmitOptions = {},
   ): Promise<void> | void {
     const active = this.activeAttachment;
     if (active) return active.interactions.showInfoMessage?.(message);

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -316,6 +316,8 @@ export interface SubagentRunOptions {
 export interface ExecuteAgentOptions extends SubagentRunOptions {
   /** Host services used by the runtime to report progress/UI events. */
   runtimeHost: AgentRuntimeHost;
+  /** The caller owns presentation for failures before the run lifecycle. */
+  suppressErrorNotification?: boolean;
   /** When true, proposal tools are filtered out to prevent nesting. */
   isSubagent?: boolean;
   /**
@@ -382,7 +384,8 @@ export async function executeAgent(
       onBeforeActivation: options.onStreamResolved,
       suppressViewSwitch: options.isSubagent,
       enforceCategory: options.enforceCategory,
-      suppressErrorNotification: options.isSubagent,
+      suppressErrorNotification:
+        options.suppressErrorNotification ?? options.isSubagent,
       session: options.session,
       modelHandlerCompatibilityKey: options.modelHandlerCompatibilityKey,
     });
@@ -468,7 +471,7 @@ export async function executeAgent(
 
 export interface ResumeToolUseFromResumeDataOptions extends SubagentRunOptions {
   /** Recheck canonical admission atomically while acquiring the resumed lease. */
-  readonly canAcquireResumeLease?: () => boolean;
+  readonly canAcquireResumeLease?: () => boolean | Promise<boolean>;
   /**
    * Take messages queued after the initial drain. The flow invokes this once
    * after attaching its live context and before resuming the persisted cursor.

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -21,7 +21,7 @@ import type { AgentRuntimeHost } from './AgentRuntimeHost';
 
 export interface ResumeQueuedToolUseOptions extends SubagentRunOptions {
   /** Recheck canonical admission atomically while acquiring the resumed lease. */
-  readonly canAcquireResumeLease?: () => boolean;
+  readonly canAcquireResumeLease?: () => boolean | Promise<boolean>;
   /** Query a caller-owned stop request at the resumed flow attachment boundary. */
   readonly isCancellationRequested?: () => boolean;
   /**

--- a/src/agent/runtime/runAgent.ts
+++ b/src/agent/runtime/runAgent.ts
@@ -29,6 +29,7 @@ import type { AgentFlowResult, WorkflowFlowResult } from './AgentFlowResult';
 export interface RunAgentOptions extends Pick<
   ExecuteAgentOptions,
   | 'runtimeHost'
+  | 'suppressErrorNotification'
   | 'enforceCategory'
   | 'stopAfterCycle'
   | 'approvalPromptsUnavailable'
@@ -46,7 +47,7 @@ export interface RunAgentOptions extends Pick<
   onExecutionLeaseAcquired?: (scope: OwnedExecutionLeaseScope) => void;
   registerExecution?: boolean;
   /** Recheck canonical admission atomically while acquiring a resumed lease. */
-  canAcquireResumeLease?: () => boolean;
+  canAcquireResumeLease?: () => boolean | Promise<boolean>;
   /**
    * Opt-in set by the "fix LaTeX" VS Code actions (Fix-Compilation command, the
    * progress-view compile fixer): run the launched agent on the configured

--- a/src/agent/runtime/terminalResultToast.ts
+++ b/src/agent/runtime/terminalResultToast.ts
@@ -98,6 +98,26 @@ export function terminalResultToast(
   }
 }
 
+/**
+ * Track whether a matching terminal result has already claimed failure
+ * presentation for a caller that otherwise needs a direct fallback.
+ */
+export function trackTerminalResultPresentation(
+  session: SessionHandle,
+  matches: (event: ResultEvent) => boolean,
+): { isHandled(): boolean; dispose(): void } {
+  let handled = false;
+  const dispose = session.onResult((event) => {
+    if (!matches(event)) return;
+    handled =
+      terminalResultToast(event) !== null || event.error?.kind === 'abort';
+  });
+  return {
+    isHandled: () => handled,
+    dispose,
+  };
+}
+
 /** Returns a detach disposer; callers detach when the run/host tears down. */
 export function attachTerminalResultToast(
   session: SessionHandle,

--- a/src/agent/runtime/terminalResultToast.ts
+++ b/src/agent/runtime/terminalResultToast.ts
@@ -108,9 +108,9 @@ export function attachTerminalResultToast(
     (event) => {
       const toast = terminalResultToast(event);
       if (toast?.type === 'instruction') {
-        runtimeHost.emit('requestShowInstruction', toast.payload);
+        runtimeHost.emit('requestShowInstruction', toast.payload, options);
       } else if (toast?.type === 'error') {
-        runtimeHost.emit('requestShowError', toast.payload);
+        runtimeHost.emit('requestShowError', toast.payload, options);
       }
     },
     options.replayWhenAttached ? { replayMissed: true } : undefined,

--- a/src/agent/storage/executionLease.ts
+++ b/src/agent/storage/executionLease.ts
@@ -227,30 +227,36 @@ function forgetOwnedLease(
   }
 }
 
-async function performHeartbeat(lease: OwnedExecutionLease): Promise<void> {
-  await withLeaseLock(
+async function heartbeat(
+  lease: OwnedExecutionLease,
+  canContinue?: () => boolean | Promise<boolean>,
+): Promise<'owned' | 'lost' | 'cancelled'> {
+  return withLeaseLock(
     lease.executionId,
     async () => {
       const current = await readLease(lease.executionId, lease.storageRoot);
       if (current?.ownerToken !== lease.ownerToken) {
         forgetOwnedLease(lease, { notifyLoss: true });
-        return;
+        return 'lost';
       }
+      if ((await canContinue?.()) === false) return 'cancelled';
       await writeLease(
         { ...current, heartbeatAt: Date.now() },
         lease.storageRoot,
       );
       lease.lastConfirmedHeartbeatAt = Date.now();
+      return 'owned';
     },
     lease.storageRoot,
   );
 }
 
-function heartbeat(lease: OwnedExecutionLease): Promise<void> {
+function renewHeartbeat(lease: OwnedExecutionLease): Promise<void> {
   if (lease.releasing) return Promise.resolve();
   if (lease.heartbeatInFlight) return lease.heartbeatInFlight;
 
-  const work = performHeartbeat(lease)
+  const work = heartbeat(lease)
+    .then(() => undefined)
     .catch((error: unknown) => {
       if (handleHeartbeatFailure(lease, error)) throw error;
     })
@@ -323,7 +329,7 @@ function rememberOwnership(
       for (const owned of ownedLeases.values()) {
         // heartbeat() records and classifies its own failure before rejecting;
         // the interval consumes that rejection because it has no caller.
-        void heartbeat(owned).catch(() => undefined);
+        void renewHeartbeat(owned).catch(() => undefined);
       }
     }, EXECUTION_LEASE_HEARTBEAT_MS);
     heartbeatTimer.unref();
@@ -433,7 +439,7 @@ export async function renewOwnedExecutionLease(
   if (!lease || lease.releasing || !currentScopeOwnsLease(lease)) {
     throw new ExecutionLeaseLostError(executionId);
   }
-  await heartbeat(lease);
+  await renewHeartbeat(lease);
   if (
     lease.releasing ||
     ownedLeases.get(ownershipKey(lease.storageRoot, executionId)) !== lease
@@ -485,21 +491,20 @@ function acquireExecutionLease(
 function acquireExecutionLease(
   executionId: ExecutionId,
   mode: 'resume',
-  canAcquire?: () => boolean,
+  canAcquire?: () => boolean | Promise<boolean>,
 ): Promise<'acquired' | 'existing' | 'cancelled'>;
 async function acquireExecutionLease(
   executionId: ExecutionId,
   mode: 'fresh' | 'resume',
-  canAcquire?: () => boolean,
+  canAcquire?: () => boolean | Promise<boolean>,
 ): Promise<'acquired' | 'existing' | 'cancelled'> {
   const root = storageRoot();
   const key = ownershipKey(root, executionId);
   const existingOwnership = ownedLeases.get(key);
   if (mode === 'resume' && existingOwnership) {
-    await heartbeat(existingOwnership);
-    if (ownedLeases.get(key) === existingOwnership) {
-      return canAcquire?.() === false ? 'cancelled' : 'existing';
-    }
+    const heartbeatResult = await heartbeat(existingOwnership, canAcquire);
+    if (heartbeatResult === 'cancelled') return 'cancelled';
+    if (heartbeatResult === 'owned') return 'existing';
   }
 
   return withLeaseLock(
@@ -514,7 +519,7 @@ async function acquireExecutionLease(
       if (liveness.status === 'active') {
         throw new ExecutionLeaseActiveError(executionId, liveness.heartbeatAt);
       }
-      if (canAcquire?.() === false) return 'cancelled' as const;
+      if ((await canAcquire?.()) === false) return 'cancelled' as const;
       const ownerToken = randomUUID();
       if (existingOwnership) forgetOwnedLease(existingOwnership);
       await writeLease(
@@ -544,7 +549,7 @@ export function acquireFreshExecutionLease(
 /** Establish ownership before a persisted execution is resumed. */
 export function acquireResumedExecutionLease(
   executionId: ExecutionId,
-  canAcquire?: () => boolean,
+  canAcquire?: () => boolean | Promise<boolean>,
 ): Promise<'acquired' | 'existing' | 'cancelled'> {
   return acquireExecutionLease(executionId, 'resume', canAcquire);
 }

--- a/src/agent/storage/executionLease.ts
+++ b/src/agent/storage/executionLease.ts
@@ -502,7 +502,23 @@ async function acquireExecutionLease(
   const key = ownershipKey(root, executionId);
   const existingOwnership = ownedLeases.get(key);
   if (mode === 'resume' && existingOwnership) {
-    const heartbeatResult = await heartbeat(existingOwnership, canAcquire);
+    let heartbeatResult: Awaited<ReturnType<typeof heartbeat>> | undefined;
+    try {
+      heartbeatResult = await heartbeat(existingOwnership, canAcquire);
+    } catch (error) {
+      if (handleHeartbeatFailure(existingOwnership, error)) throw error;
+      if (
+        ownedLeases.get(key) === existingOwnership &&
+        !existingOwnership.releasing
+      ) {
+        const admitted = await withLeaseLock(
+          executionId,
+          async () => (await canAcquire?.()) !== false,
+          root,
+        );
+        return admitted ? 'existing' : 'cancelled';
+      }
+    }
     if (heartbeatResult === 'cancelled') return 'cancelled';
     if (heartbeatResult === 'owned') return 'existing';
   }
@@ -520,6 +536,7 @@ async function acquireExecutionLease(
         throw new ExecutionLeaseActiveError(executionId, liveness.heartbeatAt);
       }
       if ((await canAcquire?.()) === false) return 'cancelled' as const;
+      const acquiredAt = Date.now();
       const ownerToken = randomUUID();
       if (existingOwnership) forgetOwnedLease(existingOwnership);
       await writeLease(
@@ -527,8 +544,8 @@ async function acquireExecutionLease(
           version: 1,
           executionId,
           ownerToken,
-          acquiredAt: now,
-          heartbeatAt: now,
+          acquiredAt,
+          heartbeatAt: acquiredAt,
         },
         root,
       );

--- a/src/test-kernel/agent/storage/ExecutionLease.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionLease.vitest.ts
@@ -169,6 +169,45 @@ describe('cross-process execution leases', () => {
     expect(maintenanceEntered).toBe(true);
   });
 
+  it('timestamps a resumed lease after asynchronous admission completes', async () => {
+    vi.useFakeTimers({ now: new Date('2026-07-25T12:00:00.000Z') });
+    const executionId = 'd86450' as ExecutionId;
+    const expectedHeartbeat = Date.now() + EXECUTION_LEASE_STALE_MS + 1_000;
+
+    try {
+      await expect(
+        acquireResumedExecutionLease(executionId, async () => {
+          await vi.advanceTimersByTimeAsync(EXECUTION_LEASE_STALE_MS + 1_000);
+          return true;
+        }),
+      ).resolves.toBe('acquired');
+      ownedExecutionIds.add(executionId);
+
+      const persisted = JSON.parse(
+        await StorageFS.read(leasePath(executionId)),
+      ) as { acquiredAt: number; heartbeatAt: number };
+      expect(persisted).toMatchObject({
+        acquiredAt: expectedHeartbeat,
+        heartbeatAt: expectedHeartbeat,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('retains existing ownership through a transient resume heartbeat failure', async () => {
+    const executionId = 'd86451' as ExecutionId;
+    await acquire(executionId);
+    vi.spyOn(platform().fileLocks, 'runExclusive').mockRejectedValueOnce(
+      new Error('temporary filesystem failure'),
+    );
+
+    await expect(
+      acquireResumedExecutionLease(executionId, () => true),
+    ).resolves.toBe('existing');
+    expect(ownsExecutionLease(executionId)).toBe(true);
+  });
+
   it('keeps resumed ownership live until terminal lifecycle release', async () => {
     const executionId = 'd86440' as ExecutionId;
     await writeExecution(executionId);

--- a/src/test-kernel/agent/storage/ExecutionLease.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionLease.vitest.ts
@@ -140,6 +140,35 @@ describe('cross-process execution leases', () => {
     });
   });
 
+  it('holds the execution lock while awaiting canonical resume admission', async () => {
+    const executionId = 'd8644f' as ExecutionId;
+    let finishAdmission!: (admitted: boolean) => void;
+    let markAdmissionStarted!: () => void;
+    const admissionStarted = new Promise<void>((resolve) => {
+      markAdmissionStarted = resolve;
+    });
+    const admission = new Promise<boolean>((resolve) => {
+      finishAdmission = resolve;
+    });
+    const acquisition = acquireResumedExecutionLease(executionId, () => {
+      markAdmissionStarted();
+      return admission;
+    });
+    await admissionStarted;
+
+    let maintenanceEntered = false;
+    const maintenance = runWithInactiveExecutionLease(executionId, async () => {
+      maintenanceEntered = true;
+    });
+    await Promise.resolve();
+    expect(maintenanceEntered).toBe(false);
+
+    finishAdmission(false);
+    await expect(acquisition).resolves.toBe('cancelled');
+    await maintenance;
+    expect(maintenanceEntered).toBe(true);
+  });
+
   it('keeps resumed ownership live until terminal lifecycle release', async () => {
     const executionId = 'd86440' as ExecutionId;
     await writeExecution(executionId);

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -334,8 +334,8 @@ async function loadBridgeModule(options: CreateBridgeOptions = {}): Promise<{
         }
       }
 
-      async exists(): Promise<boolean> {
-        return false;
+      async exists(key: string): Promise<boolean> {
+        return kvStoreBacking.has(this.key(key));
       }
 
       async modifiedAt(): Promise<number | undefined> {
@@ -476,6 +476,13 @@ async function createBridge(
     await progressSnapshotStore.flush();
   }
   const session = createSession(transcripts);
+  const { attachTerminalResultToast } =
+    await import('@agent/runtime/terminalResultToast');
+  const detachTerminalResultToast = attachTerminalResultToast(
+    session,
+    session.interactions,
+    { replayWhenAttached: true },
+  );
   const { SessionStores } =
     await import('@controllers/progressView/backend/state/SessionStores');
   const { releaseStreamResources } = await import('@tools/approval');
@@ -530,6 +537,7 @@ async function createBridge(
     dispose: () => {
       bridge.dispose();
       disposeResumeHandler();
+      detachTerminalResultToast();
       detachSnapshotEvents();
       session.dispose();
     },
@@ -1387,9 +1395,14 @@ describe('DesktopProgressBridge', () => {
 
   it('presents a merge failure that occurs before lifecycle startup', async () => {
     const failure = new Error('model setup failed');
-    const runAgent = vi.fn(async () => {
-      throw failure;
-    });
+    const runAgent = vi.fn(
+      async (
+        _request: unknown,
+        _options: Parameters<RunExecutionRequest>[1],
+      ) => {
+        throw failure;
+      },
+    );
     const showErrorMessage = vi.fn(async () => undefined);
     const bridge = await createBridge([], { runAgent, showErrorMessage });
 
@@ -1402,15 +1415,31 @@ describe('DesktopProgressBridge', () => {
         'Merge failed: model setup failed',
       ),
     );
+    expect(runAgent.mock.calls[0]?.[1].suppressErrorNotification).toBe(true);
   });
 
-  it('leaves a terminal merge failure to the session result presenter', async () => {
+  it('presents a terminal merge failure exactly once from its result', async () => {
+    const mergeExecutionId = 'merge-terminal-failure';
+    const mergeStreamId = 'merge-terminal-stream';
     const runAgent = vi.fn(
       async (
         _request: unknown,
         options: Parameters<RunExecutionRequest>[1],
       ) => {
-        await options.onRun?.({});
+        await options.onRun?.({ executionId: mergeExecutionId });
+        options.session.publishRunEvent(mergeStreamId, {
+          type: 'result',
+          outcome: RUN_OUTCOME.FAILED,
+          executionId: mergeExecutionId,
+          streamId: mergeStreamId,
+          agentName: 'proofreader',
+          category: 'workflow',
+          isSubagent: false,
+          error: {
+            kind: 'unexpected',
+            message: 'merge execution failed',
+          },
+        });
         throw new Error('merge execution failed');
       },
     );
@@ -1421,9 +1450,46 @@ describe('DesktopProgressBridge', () => {
       config: workflowTaskState().agentConfig,
     });
 
-    await vi.waitFor(() => expect(runAgent).toHaveBeenCalledOnce());
-    await settleProgressEvents();
-    expect(showErrorMessage).not.toHaveBeenCalled();
+    await vi.waitFor(() =>
+      expect(showErrorMessage).toHaveBeenCalledWith('merge execution failed'),
+    );
+    expect(showErrorMessage).toHaveBeenCalledOnce();
+  });
+
+  it('presents a post-result merge failure when the result completed', async () => {
+    const mergeExecutionId = 'merge-post-result-failure';
+    const mergeStreamId = 'merge-post-result-stream';
+    const runAgent = vi.fn(
+      async (
+        _request: unknown,
+        options: Parameters<RunExecutionRequest>[1],
+      ) => {
+        await options.onRun?.({ executionId: mergeExecutionId });
+        options.session.publishRunEvent(mergeStreamId, {
+          type: 'result',
+          outcome: RUN_OUTCOME.COMPLETED,
+          executionId: mergeExecutionId,
+          streamId: mergeStreamId,
+          agentName: 'proofreader',
+          category: 'workflow',
+          isSubagent: false,
+        });
+        throw new Error('artifact flush failed');
+      },
+    );
+    const showErrorMessage = vi.fn(async () => undefined);
+    const bridge = await createBridge([], { runAgent, showErrorMessage });
+
+    bridge.fileActions.host.startExecution({
+      config: workflowTaskState().agentConfig,
+    });
+
+    await vi.waitFor(() =>
+      expect(showErrorMessage).toHaveBeenCalledWith(
+        'Merge failed: artifact flush failed',
+      ),
+    );
+    expect(showErrorMessage).toHaveBeenCalledOnce();
   });
 
   it('does not expose the desktop bridge before transcript opening settles', async () => {
@@ -2742,6 +2808,13 @@ describe('DesktopProgressBridge', () => {
       transcripts.ensureStream(streamId);
       await transcripts.flush();
       const processSession = createSession(transcripts);
+      const { attachTerminalResultToast } =
+        await import('@agent/runtime/terminalResultToast');
+      const detachTerminalResultToast = attachTerminalResultToast(
+        processSession,
+        processSession.interactions,
+        { replayWhenAttached: true },
+      );
       const { initializeDesktopProcessStores } =
         await import('@desktop/main/desktopProcessStores');
       const progressSnapshotStore = createProgressSnapshotStore();
@@ -2873,6 +2946,7 @@ describe('DesktopProgressBridge', () => {
         dispose: () => {
           for (const bridge of presentationBridges) bridge.dispose();
           disposeResumeHandler();
+          detachTerminalResultToast();
           processStores.dispose();
           processSession.dispose();
         },

--- a/src/test-kernel/desktop/DesktopAgentResume.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentResume.vitest.mts
@@ -11,6 +11,7 @@ import * as AgentExecution from '@agent/runtime/executeAgent';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import * as SessionResumeRetrieval from '@agent/runtime/SessionResumeRetrieval';
 import * as AgentRunner from '@agent/runtime/runAgent';
+import { ResumeAdmissionCancelledError } from '@agent/runtime/resumeAdmission';
 import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
 import { DesktopProcessResumeOwner } from '@desktop/main/desktopAgentResume';
 import {
@@ -62,13 +63,9 @@ function attachResultPresenter(
   emit = vi.fn(),
 ): { emit: ReturnType<typeof vi.fn>; detach(): void } {
   const detachHost = session.useHostInteractions({ emit, cancel: vi.fn() });
-  const detachToast = attachTerminalResultToast(session, session.interactions, {
-    replayWhenAttached: true,
-  });
   return {
     emit,
     detach() {
-      detachToast();
       detachHost();
     },
   };
@@ -89,11 +86,17 @@ function createResumeHarness(): {
   session.transcripts.ensureStream(stream);
   const owner = new DesktopProcessResumeOwner();
   const detach = owner.attach({ session, snapshots: createSnapshots() });
+  const detachTerminalResultToast = attachTerminalResultToast(
+    session,
+    session.interactions,
+    { replayWhenAttached: true },
+  );
   return {
     owner,
     session,
     dispose() {
       detach();
+      detachTerminalResultToast();
       session.dispose();
     },
   };
@@ -137,7 +140,7 @@ describe('desktop process resume owner', () => {
     });
     runAgent.mockRejectedValue(new Error('launch failed'));
     const harness = createResumeHarness();
-    const presenter = attachResultPresenter(harness.session);
+    let presenter = attachResultPresenter(harness.session);
 
     try {
       await expect(harness.owner.tryResumeStream(stream)).resolves.toBe(false);
@@ -145,6 +148,11 @@ describe('desktop process resume owner', () => {
       expect(presenter.emit).toHaveBeenCalledWith('requestShowError', {
         message: 'Resume failed: launch failed',
       });
+      expect(runAgent.mock.calls[0]?.[1].suppressErrorNotification).toBe(true);
+
+      presenter.detach();
+      presenter = attachResultPresenter(harness.session);
+      expect(presenter.emit).not.toHaveBeenCalled();
     } finally {
       presenter.detach();
       harness.dispose();
@@ -250,6 +258,75 @@ describe('desktop process resume owner', () => {
     }
   });
 
+  it('does not duplicate a terminal resume failure presentation', async () => {
+    retrieveSessionResumeData.mockResolvedValue({
+      type: 'workflow',
+      agentConfig: config,
+      executionId,
+    });
+    const harness = createResumeHarness();
+    runAgent.mockImplementation(async (_request, options) => {
+      options.session?.publishRunEvent(stream, {
+        type: 'result',
+        outcome: RUN_OUTCOME.FAILED,
+        executionId,
+        streamId: stream,
+        agentName: 'proofreader',
+        category: 'workflow',
+        isSubagent: false,
+        error: { kind: 'unexpected', message: 'terminal resume failed' },
+      });
+      throw new Error('terminal resume failed');
+    });
+
+    try {
+      await expect(harness.owner.tryResumeStream(stream)).resolves.toBe(false);
+      const emit = vi.fn();
+      harness.session.useHostInteractions({ emit, cancel: vi.fn() });
+      await Promise.resolve();
+      expect(emit).toHaveBeenCalledOnce();
+      expect(emit).toHaveBeenCalledWith('requestShowError', {
+        message: 'terminal resume failed',
+      });
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  it('reports a resume failure that follows a completed terminal result', async () => {
+    retrieveSessionResumeData.mockResolvedValue({
+      type: 'workflow',
+      agentConfig: config,
+      executionId,
+    });
+    const harness = createResumeHarness();
+    runAgent.mockImplementation(async (_request, options) => {
+      options.session?.publishRunEvent(stream, {
+        type: 'result',
+        outcome: RUN_OUTCOME.COMPLETED,
+        executionId,
+        streamId: stream,
+        agentName: 'proofreader',
+        category: 'workflow',
+        isSubagent: false,
+      });
+      throw new Error('final artifact flush failed');
+    });
+
+    try {
+      await expect(harness.owner.tryResumeStream(stream)).resolves.toBe(false);
+      const emit = vi.fn();
+      harness.session.useHostInteractions({ emit, cancel: vi.fn() });
+      await Promise.resolve();
+      expect(emit).toHaveBeenCalledOnce();
+      expect(emit).toHaveBeenCalledWith('requestShowError', {
+        message: 'Resume failed: final artifact flush failed',
+      });
+    } finally {
+      harness.dispose();
+    }
+  });
+
   it('rejects a termination-triggered wake after shutdown disables resume', async () => {
     const harness = createResumeHarness();
 
@@ -308,6 +385,43 @@ describe('desktop process resume owner', () => {
       await expect(resume).resolves.toBe(false);
       expect(runAgent).not.toHaveBeenCalled();
       expect(harness.session.transcripts.has(stream)).toBe(false);
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  it('rejects a stale process store after another process deletes the stream', async () => {
+    retrieveSessionResumeData.mockResolvedValue({
+      type: 'workflow',
+      agentConfig: config,
+      executionId,
+    });
+    const harness = createResumeHarness();
+    vi.spyOn(
+      harness.session.transcripts,
+      'hasAuthoritativeStream',
+    ).mockResolvedValue(false);
+    runAgent.mockImplementation(async (_request, options) => {
+      if ((await options.canAcquireResumeLease?.()) === false) {
+        throw new ResumeAdmissionCancelledError(executionId);
+      }
+      return {
+        executionId,
+        streamId: stream,
+        category: 'workflow',
+        outcome: RUN_OUTCOME.COMPLETED,
+        outputs: [],
+        compileFailures: [],
+      };
+    });
+
+    try {
+      await expect(harness.owner.tryResumeStream(stream)).resolves.toBe(false);
+      expect(harness.session.transcripts.has(stream)).toBe(true);
+
+      const emit = vi.fn();
+      harness.session.useHostInteractions({ emit, cancel: vi.fn() });
+      expect(emit).not.toHaveBeenCalled();
     } finally {
       harness.dispose();
     }

--- a/src/test-kernel/desktop/DesktopAgentResume.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentResume.vitest.mts
@@ -266,6 +266,7 @@ describe('desktop process resume owner', () => {
     });
     const harness = createResumeHarness();
     runAgent.mockImplementation(async (_request, options) => {
+      await options.onRun?.({} as never);
       options.session?.publishRunEvent(stream, {
         type: 'result',
         outcome: RUN_OUTCOME.FAILED,
@@ -301,6 +302,7 @@ describe('desktop process resume owner', () => {
     });
     const harness = createResumeHarness();
     runAgent.mockImplementation(async (_request, options) => {
+      await options.onRun?.({} as never);
       options.session?.publishRunEvent(stream, {
         type: 'result',
         outcome: RUN_OUTCOME.COMPLETED,

--- a/src/test-kernel/desktop/desktopAgentExecutionTestHarness.mts
+++ b/src/test-kernel/desktop/desktopAgentExecutionTestHarness.mts
@@ -25,9 +25,11 @@ export type RunExecutionRequest = (
         },
         streamId: string,
       ): () => void;
+      publishRunEvent(streamId: string, event: unknown): void;
     };
     runtimeUnavailableTools?: readonly string[];
     onRun?: (handle: unknown) => void | Promise<void>;
+    suppressErrorNotification?: boolean;
   },
 ) => Promise<void>;
 

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -342,6 +342,26 @@ describe('StreamLogStore load', () => {
     expect(storage.fullLogReads()).toBe(2);
   });
 
+  it('distinguishes another process deletion from a stale local summary', async () => {
+    const logs: Record<string, unknown> = { alpha: [] };
+    mockStorage({ logs, summaries: {} });
+
+    const staleProcessStore = await StreamLogStore.open();
+    expect(staleProcessStore.has('alpha')).toBe(true);
+    await expect(
+      staleProcessStore.hasAuthoritativeStream('alpha'),
+    ).resolves.toBe(true);
+
+    // A different process commits deletion while this store retains the
+    // summary it loaded at startup.
+    delete logs.alpha;
+
+    expect(staleProcessStore.has('alpha')).toBe(true);
+    await expect(
+      staleProcessStore.hasAuthoritativeStream('alpha'),
+    ).resolves.toBe(false);
+  });
+
   it('opens a read-only store without creating directories or writing caches', async () => {
     const storage = mockStorage({
       logs: { alpha: [logEntry('alpha', 1, 200)] },

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -270,6 +270,17 @@ export class StreamLogStore {
     return this.summaries.has(streamId);
   }
 
+  /**
+   * Recheck the authoritative transcript source rather than this instance's
+   * cached summary. Resume admission uses this while holding the execution
+   * lease lock, so another process cannot delete a stream and have a stale
+   * in-memory store recreate it afterwards.
+   */
+  async hasAuthoritativeStream(streamId: StreamTabId): Promise<boolean> {
+    if (this.mode.kind === 'ephemeral') return this.has(streamId);
+    return this.kv.exists(streamId);
+  }
+
   keys(): StreamTabId[] {
     return [...this.summaries.keys()];
   }


### PR DESCRIPTION
## Summary

- fence desktop resume admission with an authoritative transcript lookup under the execution lease lock
- own terminal-result presentation at the desktop process-session lifetime instead of the BrowserWindow lifetime
- suppress duplicate resume and merge fallbacks once an actionable terminal result owns presentation
- preserve detached-window replay, cancellation, and post-result cleanup failures

Closes #9204

## Design

The resume path previously treated a process-local transcript summary as authoritative. This leaked persistence state into admission logic and allowed a stale process to recreate a stream deleted elsewhere. `StreamLogStore` now hides the backing-store distinction behind one authoritative existence query, and the execution-lease module accepts the asynchronous predicate while it owns the existing coordination lock.

Terminal-result presentation now follows the already process-owned `SessionHandle`. BrowserWindow bridges retain only window presentation and subscriptions. `AgentRuntimeHost` is the single source of truth for the detached-presentation delivery option. The final review corrections removed the obsolete lifecycle-start fallback gate and centralized stateful terminal-result tracking in `terminalResultToast.ts`.

## Size

Production and test changes together: +450 / -109 lines (net +341). No files were relocated.

## Verification

- `npm run format` (pre-commit hook)
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint`
- `npm run check:dead-code-ratchet`
- focused desktop, lease, transcript, session-interaction, and terminal-result tests, including the 27-test lease suite after the final review corrections
- complete `npm test`: 7,490 passed; 25 tests and 6 setup hooks timed out under unrestricted worker concurrency
- bounded rerun of all 21 affected files: 20 files and 241 tests passed; the remaining two CLI signal-ownership tests passed when run alone with a 30-second timeout (27.70 seconds total test time)

The complete-run failures were distributed across unrelated CLI, UI, desktop packaging, polling, and shared utility tests and were dominated by the common 10-second timeout. The changed focused suites pass under their standard timeouts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches execution-lease acquisition, multi-process transcript consistency, and user-visible error presentation on resume/merge paths—important but covered by focused tests.
> 
> **Overview**
> **Resume admission** now re-checks transcript existence against durable storage (`hasAuthoritativeStream`) inside an async `canAcquireResumeLease` hook, evaluated while the execution lease lock is held. Stale in-memory summaries can no longer admit a resume after another process deletes the stream; lease heartbeats and resume acquisition accept async predicates and timestamp leases after admission completes.
> 
> **Terminal failure UX** moves from per-`BrowserWindow` `attachTerminalResultToast` to the process `SessionHandle` in desktop `index.ts`. Merge and resume paths use `trackTerminalResultPresentation` plus `suppressErrorNotification` so runtime toasts and caller fallbacks do not double-notify; post-result cleanup failures still get a direct error when no terminal result claimed presentation.
> 
> **API cleanup:** `AgentRuntimeEmitOptions` (`replayWhenAttached`) is shared on `AgentRuntimeHost`; desktop launch swaps `onLifecycleStart` for `onRun` to bind fallback logic to `executionId`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d007df0cf0381f456743231638f79b6c94d42e6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

