### PR TITLE
feat: expose agent skills controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ All notable changes to this project will be documented in this file.
 #### New Features
 
 - **Agent skills can be switched on or off from every interface** — the CLI
-  launcher and the extension or desktop Tools settings now control whether
-  tool-use agents receive TeXRA and imported skills.
+  launcher, the VS Code setting, and the desktop Tools settings now control
+  whether tool-use agents receive TeXRA and imported skills.
 - **Claude Opus 5 support** — the latest Opus 5 models (`opus5`, `opus5T`) are
   available for demanding research and engineering tasks, replacing Opus 4.8
   as the default Anthropic model. Opus 5 keeps the full 1M context window and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 #### New Features
 
+- **Agent skills can be switched on or off from every interface** — the CLI
+  launcher and the extension or desktop Tools settings now control whether
+  tool-use agents receive TeXRA and imported skills.
 - **Claude Opus 5 support** — the latest Opus 5 models (`opus5`, `opus5T`) are
   available for demanding research and engineering tasks, replacing Opus 4.8
   as the default Anthropic model. Opus 5 keeps the full 1M context window and

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -5,12 +5,10 @@ import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { platform } from '@platform/platform';
-import {
-  AGENT_SKILLS_CONFIG_KEY,
-  AGENT_SKILLS_ENABLED_DEFAULT,
-} from '@shared/schemas/agentSkills';
+import { AGENT_SKILLS_CONFIG_KEY } from '@shared/schemas/agentSkills';
+import { readAgentSkillsEnabled } from '@shared/settingsView/handlers/agentSkillsHandlers';
 import { getFirstRunDone } from '@shared/state/onboardingState';
-import { getConfig, updateConfig } from '@utils/config';
+import { updateConfig } from '@utils/config';
 
 import { firstRunSetupAgentOverride } from '../onboarding/setupContinuation';
 import { CliExitCode } from '../runtime/exitCodes';
@@ -193,10 +191,7 @@ async function runOrchestration(context: CliContext): Promise<number> {
       includeMultiAgentLoginHint: !presetPlanSet.remoteAgentLoadAttempted,
       modelAccess: launcherModelAccess,
       account: accountStatus,
-      agentSkillsEnabled: getConfig<boolean>(
-        AGENT_SKILLS_CONFIG_KEY,
-        AGENT_SKILLS_ENABLED_DEFAULT,
-      ),
+      agentSkillsEnabled: readAgentSkillsEnabled(platform().config),
       presetLaunchBlockReason:
         launchContext.approvalPolicy === 'never'
           ? 'delegation-denied'

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -5,7 +5,12 @@ import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { platform } from '@platform/platform';
+import {
+  AGENT_SKILLS_CONFIG_KEY,
+  AGENT_SKILLS_ENABLED_DEFAULT,
+} from '@shared/schemas/agentSkills';
 import { getFirstRunDone } from '@shared/state/onboardingState';
+import { getConfig, updateConfig } from '@utils/config';
 
 import { firstRunSetupAgentOverride } from '../onboarding/setupContinuation';
 import { CliExitCode } from '../runtime/exitCodes';
@@ -188,6 +193,10 @@ async function runOrchestration(context: CliContext): Promise<number> {
       includeMultiAgentLoginHint: !presetPlanSet.remoteAgentLoadAttempted,
       modelAccess: launcherModelAccess,
       account: accountStatus,
+      agentSkillsEnabled: getConfig<boolean>(
+        AGENT_SKILLS_CONFIG_KEY,
+        AGENT_SKILLS_ENABLED_DEFAULT,
+      ),
       presetLaunchBlockReason:
         launchContext.approvalPolicy === 'never'
           ? 'delegation-denied'
@@ -331,6 +340,13 @@ async function runOrchestration(context: CliContext): Promise<number> {
           colorEnabled: context.stdoutColorEnabled,
           onError: writeErrorStderr,
         });
+        continue launcher;
+      }
+      case 'set-agent-skills': {
+        await updateConfig(AGENT_SKILLS_CONFIG_KEY, action.enabled);
+        writeTextStdout(
+          action.enabled ? 'Agent skills enabled.' : 'Agent skills disabled.',
+        );
         continue launcher;
       }
       case 'account': {

--- a/packages/cli/src/runtime/orchestration.ts
+++ b/packages/cli/src/runtime/orchestration.ts
@@ -48,6 +48,7 @@ export type CliOrchestrationAction =
   | { readonly kind: 'browse-teams' }
   | { readonly kind: 'browse-accounts' }
   | { readonly kind: 'configure-settings' }
+  | { readonly kind: 'set-agent-skills'; readonly enabled: boolean }
   | {
       readonly kind: 'account';
       readonly provider: CliAccountProvider;
@@ -84,6 +85,7 @@ export interface BuildCliOrchestrationItemsInput {
   readonly includeMultiAgentLoginHint?: boolean;
   readonly modelAccess?: CliModelAccessStatus;
   readonly account?: CliAccountStatus;
+  readonly agentSkillsEnabled?: boolean;
   readonly presetLaunchBlockReason?: CliPresetLaunchBlockReason;
 }
 
@@ -187,6 +189,18 @@ export function buildCliOrchestrationItems(
       value: { kind: 'browse-accounts' },
       label: 'Account',
       description: accountSummary(input.account),
+    });
+  }
+  if (input.agentSkillsEnabled !== undefined) {
+    items.push({
+      value: {
+        kind: 'set-agent-skills',
+        enabled: !input.agentSkillsEnabled,
+      },
+      label: 'Agent skills',
+      description: input.agentSkillsEnabled
+        ? 'On · TeXRA and imported skills available to tool-use agents'
+        : 'Off · tool-use agents receive no skills',
     });
   }
   items.push({

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -22,6 +22,10 @@ import {
   setBashApprovalEnabled,
   setWorkspaceAgentSetting,
 } from '@shared/settingsView/handlers/approvalHandlers';
+import {
+  buildAgentSkillsSettingsMessage,
+  setAgentSkillsEnabled,
+} from '@shared/settingsView/handlers/agentSkillsHandlers';
 import { buildSuperYoloMessage } from '@shared/settingsView/handlers/superYoloHandlers';
 import type { SettingsStatePorts } from '@shared/settingsView/types';
 import { GoalStore } from '@tools/goal';
@@ -175,6 +179,10 @@ export function createDesktopSettingsIpc(
     );
   }
 
+  function postAgentSkillsSettings(): void {
+    options.postToRenderer(buildAgentSkillsSettingsMessage(options.config));
+  }
+
   /**
    * Deliberate divergence from the extension: no `subscribeGoalStateChanges`
    * push hook here. The initial post below, the webview-ready re-post, and
@@ -205,6 +213,7 @@ export function createDesktopSettingsIpc(
     const modelSelectionDataPosted = postModelSelectionData();
     postSuperYoloEnabled();
     postApprovalSettings();
+    postAgentSkillsSettings();
     await Promise.all([
       goalListPosted,
       memoryEnabledPosted,
@@ -296,6 +305,11 @@ export function createDesktopSettingsIpc(
     postApprovalSettings();
   }
 
+  async function updateAgentSkillsEnabled(enabled: boolean): Promise<void> {
+    await setAgentSkillsEnabled(options.config, enabled);
+    postAgentSkillsSettings();
+  }
+
   async function updateBooleanWorkspaceSetting(
     key: WorkspaceStateKey,
     enabled: boolean,
@@ -384,6 +398,9 @@ export function createDesktopSettingsIpc(
     chatGpt: options.credentialSettingsController.chatGptActions,
     approval: {
       setBashApprovalEnabled: (enabled) => updateBashApprovalEnabled(enabled),
+    },
+    agentSkills: {
+      setEnabled: (enabled) => updateAgentSkillsEnabled(enabled),
     },
     stateSettings: {
       update: (key, value) => updateStateSetting(key, value),

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -834,7 +834,7 @@
           "texra.skills.enabled": {
             "type": "boolean",
             "default": true,
-            "description": "Discover imported skills and expose them to tool-use agent prompts",
+            "description": "Discover TeXRA and imported skills and expose them to tool-use agent prompts",
             "scope": "resource"
           }
         }

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -96,7 +96,7 @@ import {
 } from '@tools/toolAvailability';
 import { GoalStore, subscribeGoalStateChanges } from '@tools/goal';
 import { findExternalToolDef } from '@tools/externalToolDefs';
-import { StorageFS } from '@utils/files';
+import { StorageFS, WorkspaceFS } from '@utils/files';
 import { debounce } from '@utils/core';
 import { DEBOUNCE_OPTIONS_MS } from '@utils/config';
 import { hasExtension } from '@utils/core/pathCore';
@@ -840,7 +840,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     // than alarm. Re-send the persisted settings afterwards so the webview's
     // (optimistically-toggled) switch snaps back to the actual, unwritten
     // value instead of drifting from it.
-    if (!vscode.workspace.workspaceFolders?.length) {
+    if (!WorkspaceFS.getPath()) {
       void showLoggedInfoMessage(
         this.channel,
         'Bash approval is a per-workspace setting. Open a workspace folder before changing it.',
@@ -869,7 +869,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   }
 
   private async handleSetAgentSkillsEnabled(enabled: boolean): Promise<void> {
-    if (!vscode.workspace.workspaceFolders?.length) {
+    if (!WorkspaceFS.getPath()) {
       void showLoggedInfoMessage(
         this.channel,
         'Agent skills are a per-workspace setting. Open a workspace folder before changing them.',

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -79,6 +79,10 @@ import {
   setBashApprovalEnabled as setBashApprovalEnabledShared,
   setWorkspaceAgentSetting,
 } from '@shared/settingsView/handlers/approvalHandlers';
+import {
+  buildAgentSkillsSettingsMessage,
+  setAgentSkillsEnabled,
+} from '@shared/settingsView/handlers/agentSkillsHandlers';
 import { buildSuperYoloMessage } from '@shared/settingsView/handlers/superYoloHandlers';
 import {
   PROVIDER_DISPLAY_NAMES,
@@ -551,6 +555,9 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         setBashApprovalEnabled: (enabled) =>
           this.handleSetApprovalEnabled(enabled),
       },
+      agentSkills: {
+        setEnabled: (enabled) => this.handleSetAgentSkillsEnabled(enabled),
+      },
       stateSettings: {
         update: (key, value) => this.updateStateSetting(key, value),
       },
@@ -689,6 +696,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       this.chatgptHandlers.sendChatGptAuthStatus(webview),
       this.githubHandlers.sendPRSubscriptions(webview),
       this.sendApprovalSettings(webview),
+      this.sendAgentSkillsSettings(webview),
       this.latexHandlers.sendLatexSettingsStatus(webview),
       this.latexHandlers.sendLatexConfigValues(webview),
       this.sendInlineCriticismEnabled(webview),
@@ -850,6 +858,27 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       BASH_APPROVAL_CONFIG_TARGET,
     );
     await this.withActiveWebview((w) => this.sendApprovalSettings(w));
+  }
+
+  private async sendAgentSkillsSettings(
+    webview: vscode.Webview,
+  ): Promise<void> {
+    await webview.postMessage(
+      buildAgentSkillsSettingsMessage(platform().config),
+    );
+  }
+
+  private async handleSetAgentSkillsEnabled(enabled: boolean): Promise<void> {
+    if (!vscode.workspace.workspaceFolders?.length) {
+      void showLoggedInfoMessage(
+        this.channel,
+        'Agent skills are a per-workspace setting. Open a workspace folder before changing them.',
+      );
+      await this.withActiveWebview((w) => this.sendAgentSkillsSettings(w));
+      return;
+    }
+    await setAgentSkillsEnabled(platform().config, enabled);
+    await this.withActiveWebview((w) => this.sendAgentSkillsSettings(w));
   }
 
   private async updateAgentSetting(

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -59,6 +59,7 @@ import './components/profile/ProviderKeyModal';
 import { settingsViewHandlers } from './messageDispatcher';
 import {
   agentSubTab,
+  agentSkillsEnabled,
   allowOrchestratorKill,
   apiAccessMode,
   authenticated,
@@ -504,6 +505,7 @@ export class SettingsApp extends SettingsAppBase {
               .items=${toolDashboardItems.get()}
               .loaded=${toolDashboardLoaded.get()}
               .bashApprovalEnabled=${bashApprovalEnabled.get()}
+              .agentSkillsEnabled=${agentSkillsEnabled.get()}
               .showDesktopCrashReporting=${!isKnownUnsupported(
                 unsupportedCommands.get(),
                 SETTINGS_VIEW_COMMANDS.GET_DESKTOP_CRASH_REPORTING,

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -506,6 +506,7 @@ export class SettingsApp extends SettingsAppBase {
               .loaded=${toolDashboardLoaded.get()}
               .bashApprovalEnabled=${bashApprovalEnabled.get()}
               .agentSkillsEnabled=${agentSkillsEnabled.get()}
+              .showAgentSkillsSettings=${this.isDesktopHost}
               .showDesktopCrashReporting=${!isKnownUnsupported(
                 unsupportedCommands.get(),
                 SETTINGS_VIEW_COMMANDS.GET_DESKTOP_CRASH_REPORTING,

--- a/packages/extension/src/settingsView/frontend/messageDispatcher.ts
+++ b/packages/extension/src/settingsView/frontend/messageDispatcher.ts
@@ -12,6 +12,7 @@
 import type { SettingsViewOutboundHandlerRegistry } from '@shared/schemas';
 
 import { agentSelectionHandlers } from './slices/agentSelectionSlice';
+import { agentSkillsSettingsHandlers } from './slices/agentSkillsSettingsSlice';
 import { agentTeamsHandlers } from './slices/agentTeamsSlice';
 import { approvalSettingsHandlers } from './slices/approvalSettingsSlice';
 import { gitHandlers } from './slices/gitSlice';
@@ -33,6 +34,7 @@ export const settingsViewHandlers: SettingsViewOutboundHandlerRegistry = {
   ...profileHandlers,
   ...modelSelectionHandlers,
   ...agentSelectionHandlers,
+  ...agentSkillsSettingsHandlers,
   ...agentTeamsHandlers,
   ...multiAgentHandlers,
   ...approvalSettingsHandlers,

--- a/packages/extension/src/settingsView/frontend/settingsState.ts
+++ b/packages/extension/src/settingsView/frontend/settingsState.ts
@@ -153,6 +153,7 @@ export const detachSubagentsOnStop = trackedSignal(() => false);
 // Approval settings state
 // ---------------------------------------------------------------------------
 export const bashApprovalEnabled = trackedSignal(() => true);
+export const agentSkillsEnabled = trackedSignal(() => true);
 export const codexSandboxMode = trackedSignal<string>(() => 'workspace-write');
 export const codexReasoningEffort = trackedSignal<string>(() => 'high');
 export const codexApprovalPolicy = trackedSignal<string>(() => 'never');

--- a/packages/extension/src/settingsView/frontend/slices/agentSkillsSettingsSlice.ts
+++ b/packages/extension/src/settingsView/frontend/slices/agentSkillsSettingsSlice.ts
@@ -1,0 +1,10 @@
+import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
+import type { SettingsViewOutboundHandlerRegistry } from '@shared/schemas';
+
+import { agentSkillsEnabled } from '../settingsState';
+
+export const agentSkillsSettingsHandlers = {
+  [SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SKILLS_SETTINGS]: (data) => {
+    agentSkillsEnabled.set(data.enabled);
+  },
+} satisfies Partial<SettingsViewOutboundHandlerRegistry>;

--- a/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -196,6 +196,7 @@ export class ToolsTab extends LitElement {
   @property({ attribute: false }) items: ToolDashboardItem[] = [];
   @property({ type: Boolean }) loaded = false;
   @property({ type: Boolean }) bashApprovalEnabled = true;
+  @property({ type: Boolean }) agentSkillsEnabled = true;
   @property({ attribute: false }) showDesktopCrashReporting = false;
   @property({ attribute: false }) desktopCrashReportingEnabled = false;
   @property({ attribute: false }) desktopCrashReportingConfigured = false;
@@ -211,6 +212,10 @@ export class ToolsTab extends LitElement {
 
   private handleBashApprovalToggle = (e: Event): void => {
     this.postToggle(SETTINGS_VIEW_COMMANDS.SET_BASH_APPROVAL_ENABLED, e);
+  };
+
+  private handleAgentSkillsToggle = (e: Event): void => {
+    this.postToggle(SETTINGS_VIEW_COMMANDS.SET_AGENT_SKILLS_ENABLED, e);
   };
 
   private handleDesktopCrashReportingToggle = (e: Event): void => {
@@ -237,6 +242,23 @@ export class ToolsTab extends LitElement {
             @change=${this.handleBashApprovalToggle}
           >
             Require approval for shell commands &amp; agent sessions
+          </wa-switch>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderAgentSkillsSettings(): TemplateResult {
+    return html`
+      <div class="category-section">
+        <div class="category-header">${waIcon('robot')} Agent Skills</div>
+
+        <div class="setting-block">
+          <wa-switch
+            ?checked=${this.agentSkillsEnabled}
+            @change=${this.handleAgentSkillsToggle}
+          >
+            TeXRA and imported skills are available to tool-use agents
           </wa-switch>
         </div>
       </div>
@@ -397,7 +419,8 @@ export class ToolsTab extends LitElement {
           </div>
         </div>
 
-        ${this.renderApprovalSettings()} ${this.renderDesktopCrashReporting()}
+        ${this.renderAgentSkillsSettings()} ${this.renderApprovalSettings()}
+        ${this.renderDesktopCrashReporting()}
         ${CATEGORY_ORDER.filter((cat) => groups.has(cat)).map((cat) =>
           this.renderCategory(cat, groups.get(cat)!),
         )}

--- a/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -197,6 +197,7 @@ export class ToolsTab extends LitElement {
   @property({ type: Boolean }) loaded = false;
   @property({ type: Boolean }) bashApprovalEnabled = true;
   @property({ type: Boolean }) agentSkillsEnabled = true;
+  @property({ attribute: false }) showAgentSkillsSettings = false;
   @property({ attribute: false }) showDesktopCrashReporting = false;
   @property({ attribute: false }) desktopCrashReportingEnabled = false;
   @property({ attribute: false }) desktopCrashReportingConfigured = false;
@@ -248,7 +249,8 @@ export class ToolsTab extends LitElement {
     `;
   }
 
-  private renderAgentSkillsSettings(): TemplateResult {
+  private renderAgentSkillsSettings(): TemplateResult | typeof nothing {
+    if (!this.showAgentSkillsSettings) return nothing;
     return html`
       <div class="category-section">
         <div class="category-header">${waIcon('robot')} Agent Skills</div>

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -15,6 +15,10 @@ import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { FileListEntry } from '@shared/schemas';
 import type { AgentDelegationScope } from '@shared/schemas/agentRoster';
 import {
+  AGENT_SKILLS_CONFIG_KEY,
+  AGENT_SKILLS_ENABLED_DEFAULT,
+} from '@shared/schemas/agentSkills';
+import {
   loadRuntimeSkillCatalog,
   type SkillLoadIssue,
 } from '@skills/runtimeSkills';
@@ -192,7 +196,7 @@ export async function buildUserVars(
     // work for workflow agents. The settings toggle gives users a hard off
     // switch that skips discovery and leaves AVAILABLE_SKILLS empty.
     agentSetting.agentCategory === AgentCategory.ToolUse &&
-    getConfig<boolean>('texra.skills.enabled', true)
+    getConfig<boolean>(AGENT_SKILLS_CONFIG_KEY, AGENT_SKILLS_ENABLED_DEFAULT)
       ? loadRuntimeSkillCatalog()
       : Promise.resolve({ catalog: '', issues: [] }),
   ]);

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -17,6 +17,7 @@ import type { AgentDelegationScope } from '@shared/schemas/agentRoster';
 import {
   AGENT_SKILLS_CONFIG_KEY,
   AGENT_SKILLS_ENABLED_DEFAULT,
+  AgentSkillsEnabledSchema,
 } from '@shared/schemas/agentSkills';
 import {
   loadRuntimeSkillCatalog,
@@ -196,7 +197,9 @@ export async function buildUserVars(
     // work for workflow agents. The settings toggle gives users a hard off
     // switch that skips discovery and leaves AVAILABLE_SKILLS empty.
     agentSetting.agentCategory === AgentCategory.ToolUse &&
-    getConfig<boolean>(AGENT_SKILLS_CONFIG_KEY, AGENT_SKILLS_ENABLED_DEFAULT)
+    AgentSkillsEnabledSchema.parse(
+      getConfig<unknown>(AGENT_SKILLS_CONFIG_KEY, AGENT_SKILLS_ENABLED_DEFAULT),
+    )
       ? loadRuntimeSkillCatalog()
       : Promise.resolve({ catalog: '', issues: [] }),
   ]);

--- a/src/controllers/settingsView/SettingsViewCommandHandlers.ts
+++ b/src/controllers/settingsView/SettingsViewCommandHandlers.ts
@@ -159,6 +159,9 @@ export interface SettingsViewCommandActions {
   readonly approval: {
     readonly setBashApprovalEnabled: EnabledAction;
   };
+  readonly agentSkills: {
+    readonly setEnabled: EnabledAction;
+  };
   /**
    * Generic catalog-driven scalar-setting write. One action replaces the former
    * per-setting `gitAuthor.*` and `approval.setCodex*`/`setClaude*` handlers: the
@@ -400,6 +403,9 @@ export function createSettingsViewCommandHandlers(
       actions.approval.setBashApprovalEnabled,
       (data) => [data.enabled],
     ),
+    setAgentSkillsEnabled: mapAction(actions.agentSkills.setEnabled, (data) => [
+      data.enabled,
+    ]),
     updateStateSetting: mapAction(actions.stateSettings.update, (data) => [
       data.key,
       data.value,

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -343,6 +343,8 @@ export const SETTINGS_VIEW_CMD = {
   UPDATE_STATE_SETTING: 'updateStateSetting',
   // Approval settings commands
   SET_BASH_APPROVAL_ENABLED: 'setBashApprovalEnabled',
+  // Agent prompt context
+  SET_AGENT_SKILLS_ENABLED: 'setAgentSkillsEnabled',
   // Tool dashboard commands
   OPEN_TOOL_INSTALL_URL: 'openToolInstallUrl',
   INSTALL_TOOL_EXTENSION: 'installToolExtension',
@@ -400,6 +402,7 @@ export const SETTINGS_VIEW_COMMANDS = {
   UPDATE_SUPER_YOLO_ENABLED: 'updateSuperYoloEnabled',
   UPDATE_AGENT_MODE_PRESETS: 'updateAgentModePresets',
   UPDATE_APPROVAL_SETTINGS: 'updateApprovalSettings',
+  UPDATE_AGENT_SKILLS_SETTINGS: 'updateAgentSkillsSettings',
   UPDATE_TOOL_DASHBOARD: 'updateToolDashboard',
   UPDATE_GIT_AUTHOR_SETTINGS: 'updateGitAuthorSettings',
   UPDATE_LATEX_SETTINGS_STATUS: 'updateLatexSettingsStatus',

--- a/src/shared/schemas/agentSkills.ts
+++ b/src/shared/schemas/agentSkills.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+export const AGENT_SKILLS_CONFIG_KEY = 'texra.skills.enabled';
+export const AGENT_SKILLS_ENABLED_DEFAULT = true;
+
+/** Whether tool-use agents receive the available TeXRA and imported skills. */
+export const AgentSkillsEnabledSchema = z
+  .boolean()
+  .describe(
+    'Discover TeXRA and imported skills and expose them to tool-use agent prompts',
+  );
+
+/** Canonical persisted form; absence has the documented enabled default. */
+export const AgentSkillsSettingsSchema = z.strictObject({
+  enabled: AgentSkillsEnabledSchema.prefault(AGENT_SKILLS_ENABLED_DEFAULT),
+});

--- a/src/shared/schemas/coreSettings.ts
+++ b/src/shared/schemas/coreSettings.ts
@@ -1,6 +1,11 @@
 // Third-party imports
 import { z } from 'zod';
 
+import {
+  AGENT_SKILLS_ENABLED_DEFAULT,
+  AgentSkillsSettingsSchema,
+} from './agentSkills';
+
 export const CHATGPT_TOOL_USE_ONLY_DESCRIPTION =
   'Use your ChatGPT subscription for tool-use agents while workflow agents continue through your OpenAI API key or relay.';
 
@@ -258,7 +263,7 @@ export const DEFAULT_CORE_SETTINGS = {
     saveInputPrompt: false,
   },
   skills: {
-    enabled: true,
+    enabled: AGENT_SKILLS_ENABLED_DEFAULT,
   },
   toolUse: {
     requireEditApproval: true,
@@ -627,14 +632,7 @@ export const CoreSettingsShape = {
       ),
     })
     .prefault(DEFAULT_CORE_SETTINGS.debug),
-  skills: z
-    .strictObject({
-      enabled: boolField(
-        DEFAULT_CORE_SETTINGS.skills.enabled,
-        'Discover imported skills and expose them to tool-use agent prompts',
-      ),
-    })
-    .prefault(DEFAULT_CORE_SETTINGS.skills),
+  skills: AgentSkillsSettingsSchema.prefault(DEFAULT_CORE_SETTINGS.skills),
   toolUse: z
     .strictObject({
       requireEditApproval: boolField(

--- a/src/shared/schemas/index.ts
+++ b/src/shared/schemas/index.ts
@@ -14,7 +14,6 @@ export * from './usage';
 export * from './contextManagement';
 export * from './spendingStatus';
 export * from './onboarding';
-export * from './agentSkills';
 
 // Layer 2: Depends on layer 1 only
 export * from './stream';

--- a/src/shared/schemas/index.ts
+++ b/src/shared/schemas/index.ts
@@ -14,6 +14,7 @@ export * from './usage';
 export * from './contextManagement';
 export * from './spendingStatus';
 export * from './onboarding';
+export * from './agentSkills';
 
 // Layer 2: Depends on layer 1 only
 export * from './stream';

--- a/src/shared/schemas/settingsView/data.ts
+++ b/src/shared/schemas/settingsView/data.ts
@@ -26,6 +26,7 @@ import {
   AgentSourceSchema,
 } from '../agent';
 import { AgentModePresetSchema } from '../agentPresets';
+import { AgentSkillsEnabledSchema } from '../agentSkills';
 import { ModelAvailabilityFieldsSchema } from '../mainView';
 import {
   NumberVscodeSettingSchema,
@@ -328,6 +329,15 @@ export type UpdateApprovalSettingsMessage = z.infer<
   typeof UpdateApprovalSettingsMessageSchema
 >;
 
+/** Outbound: backend → frontend agent skill-catalog setting. */
+const UpdateAgentSkillsSettingsMessageSchema = z.object({
+  command: z.literal(SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SKILLS_SETTINGS),
+  enabled: AgentSkillsEnabledSchema,
+});
+export type UpdateAgentSkillsSettingsMessage = z.infer<
+  typeof UpdateAgentSkillsSettingsMessageSchema
+>;
+
 // ============================================================
 // Git author settings data schema
 // ============================================================
@@ -529,6 +539,7 @@ const SettingsViewOutboundMessageSchema = z.discriminatedUnion('command', [
   UpdateSuperYoloEnabledMessageSchema,
   UpdateAgentModePresetsMessageSchema,
   UpdateApprovalSettingsMessageSchema,
+  UpdateAgentSkillsSettingsMessageSchema,
   UpdateToolDashboardMessageSchema,
   UpdateGitAuthorSettingsMessageSchema,
   UpdateGitHubTokenStatusMessageSchema,

--- a/src/shared/schemas/settingsView/inbound.ts
+++ b/src/shared/schemas/settingsView/inbound.ts
@@ -13,6 +13,7 @@ import {
 } from '@shared/utils/dispatcher';
 
 import { AgentCategorySchema, AgentSourceSchema } from '../agent';
+import { AgentSkillsEnabledSchema } from '../agentSkills';
 import { StreamTabIdSchema } from '../identifiers';
 import { commandOnly } from '../messageFactories';
 import { WebviewReadyMessageSchema } from '../commonViewMessages';
@@ -335,6 +336,11 @@ const SetBashApprovalEnabledMessageSchema = enabledFlag(
   CMD.SET_BASH_APPROVAL_ENABLED,
 );
 
+const SetAgentSkillsEnabledMessageSchema = z.object({
+  command: z.literal(CMD.SET_AGENT_SKILLS_ENABLED),
+  enabled: AgentSkillsEnabledSchema,
+});
+
 // Generic catalog-driven state-setting write. One flat branch (single outer
 // discriminator on `command`, per the SET_LATEX_CONFIG_VALUE precedent above)
 // carrying the canonical `STATE_SETTINGS` key and a loose value. Per-value
@@ -451,6 +457,8 @@ export const SettingsViewInboundMessageSchema = z.discriminatedUnion(
     OpenPRSubscriptionStreamMessageSchema,
     // Approval settings messages
     SetBashApprovalEnabledMessageSchema,
+    // Agent prompt context
+    SetAgentSkillsEnabledMessageSchema,
     // Generic catalog-driven state-setting write (git-author + agent controls)
     UpdateStateSettingMessageSchema,
     // Agent team messages

--- a/src/shared/settingsView/handlers/agentSkillsHandlers.ts
+++ b/src/shared/settingsView/handlers/agentSkillsHandlers.ts
@@ -1,0 +1,32 @@
+import type { ConfigProvider, ConfigTarget } from '@platform/interfaces';
+import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
+import {
+  AGENT_SKILLS_CONFIG_KEY,
+  AGENT_SKILLS_ENABLED_DEFAULT,
+} from '@shared/schemas/agentSkills';
+import type { UpdateAgentSkillsSettingsMessage } from '@shared/schemas/settingsViewMessages';
+
+export const AGENT_SKILLS_CONFIG_TARGET: ConfigTarget = 'workspace';
+
+export function buildAgentSkillsSettingsMessage(
+  config: ConfigProvider,
+): UpdateAgentSkillsSettingsMessage {
+  return {
+    command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SKILLS_SETTINGS,
+    enabled: config.get<boolean>(
+      AGENT_SKILLS_CONFIG_KEY,
+      AGENT_SKILLS_ENABLED_DEFAULT,
+    ),
+  };
+}
+
+export async function setAgentSkillsEnabled(
+  config: ConfigProvider,
+  enabled: boolean,
+): Promise<void> {
+  await config.update(
+    AGENT_SKILLS_CONFIG_KEY,
+    enabled,
+    AGENT_SKILLS_CONFIG_TARGET,
+  );
+}

--- a/src/shared/settingsView/handlers/agentSkillsHandlers.ts
+++ b/src/shared/settingsView/handlers/agentSkillsHandlers.ts
@@ -3,20 +3,24 @@ import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import {
   AGENT_SKILLS_CONFIG_KEY,
   AGENT_SKILLS_ENABLED_DEFAULT,
+  AgentSkillsEnabledSchema,
 } from '@shared/schemas/agentSkills';
 import type { UpdateAgentSkillsSettingsMessage } from '@shared/schemas/settingsViewMessages';
 
 export const AGENT_SKILLS_CONFIG_TARGET: ConfigTarget = 'workspace';
+
+export function readAgentSkillsEnabled(config: ConfigProvider): boolean {
+  return AgentSkillsEnabledSchema.parse(
+    config.get<unknown>(AGENT_SKILLS_CONFIG_KEY, AGENT_SKILLS_ENABLED_DEFAULT),
+  );
+}
 
 export function buildAgentSkillsSettingsMessage(
   config: ConfigProvider,
 ): UpdateAgentSkillsSettingsMessage {
   return {
     command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SKILLS_SETTINGS,
-    enabled: config.get<boolean>(
-      AGENT_SKILLS_CONFIG_KEY,
-      AGENT_SKILLS_ENABLED_DEFAULT,
-    ),
+    enabled: readAgentSkillsEnabled(config),
   };
 }
 

--- a/src/test-kernel/cli/Orchestration.vitest.mts
+++ b/src/test-kernel/cli/Orchestration.vitest.mts
@@ -410,6 +410,22 @@ describe('CLI orchestration items', () => {
     ]);
   });
 
+  it('presents agent skills as an independent launcher switch', () => {
+    const items = buildCliOrchestrationItems({
+      presetPlans: [],
+      history: [],
+      toolUseAgents: [],
+      agentSkillsEnabled: true,
+    });
+
+    expect(items.find((item) => item.label === 'Agent skills')).toEqual({
+      label: 'Agent skills',
+      description:
+        'On · TeXRA and imported skills available to tool-use agents',
+      value: { kind: 'set-agent-skills', enabled: false },
+    });
+  });
+
   it('describes the Kimi Code route by key state and activity', () => {
     expect(
       buildCliModelAccessItems({

--- a/src/test-kernel/controllers/SettingsViewCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/SettingsViewCommandHandlers.vitest.ts
@@ -104,6 +104,9 @@ function createActions(): SettingsViewCommandActions {
     approval: {
       setBashApprovalEnabled: action(),
     },
+    agentSkills: {
+      setEnabled: action(),
+    },
     stateSettings: {
       update: action(),
     },
@@ -208,6 +211,12 @@ describe('createSettingsViewCommandHandlers', () => {
       toolId: 'latex',
       kind: 'install',
     });
+
+    assertSupported(registry.setAgentSkillsEnabled)({
+      command: SETTINGS_VIEW_COMMANDS.SET_AGENT_SKILLS_ENABLED,
+      enabled: false,
+    });
+    expect(actions.agentSkills.setEnabled).toHaveBeenCalledWith(false);
 
     assertSupported(registry.requestModelAccess)({
       command: SETTINGS_VIEW_COMMANDS.REQUEST_MODEL_ACCESS,

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -4,6 +4,7 @@ import type { StateStore } from '@platform/interfaces';
 import { platform } from '@platform/platform';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import type { StreamTabId } from '@shared/schemas';
+import { AGENT_SKILLS_CONFIG_KEY } from '@shared/schemas/agentSkills';
 import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
 import { DEFAULT_GIT_MARK_COMMITS } from '@shared/schemas/stateSettings';
 import { FakeStateStore } from '@test/support/FakePlatform';
@@ -806,6 +807,36 @@ describe('desktop settings IPC', () => {
     ).toMatchObject({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_APPROVAL_SETTINGS,
       bashApprovalEnabled: false,
+    });
+  });
+
+  it('writes the agent-skills toggle and returns the shared setting message', async () => {
+    const config = new MemoryConfigStore();
+
+    const { settings, posted } = createCapturedSettingsFixture({
+      config,
+      ui: { onError: () => undefined },
+    });
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.SET_AGENT_SKILLS_ENABLED,
+        enabled: false,
+      }),
+    ).toBe(true);
+    await flushAsyncWork();
+
+    expect(config.values.get(AGENT_SKILLS_CONFIG_KEY)).toBe(false);
+    expect(config.updateTargets.get(AGENT_SKILLS_CONFIG_KEY)).toBe('workspace');
+    expect(
+      posted.find(
+        (message) =>
+          commandOf(message) ===
+          SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SKILLS_SETTINGS,
+      ),
+    ).toEqual({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SKILLS_SETTINGS,
+      enabled: false,
     });
   });
 

--- a/src/test-kernel/settings/AgentSkillsSettings.vitest.ts
+++ b/src/test-kernel/settings/AgentSkillsSettings.vitest.ts
@@ -1,0 +1,78 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports
+import type { ConfigInspection, ConfigTarget } from '@platform/interfaces';
+import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
+import {
+  AGENT_SKILLS_CONFIG_KEY,
+  AGENT_SKILLS_ENABLED_DEFAULT,
+} from '@shared/schemas/agentSkills';
+import {
+  AGENT_SKILLS_CONFIG_TARGET,
+  buildAgentSkillsSettingsMessage,
+  setAgentSkillsEnabled,
+} from '@shared/settingsView/handlers/agentSkillsHandlers';
+
+class RecordingConfigProvider {
+  value: boolean | undefined = AGENT_SKILLS_ENABLED_DEFAULT;
+  readonly updateCalls: Array<{
+    key: string;
+    value: unknown;
+    target: ConfigTarget | undefined;
+  }> = [];
+
+  get<T>(_key: string, defaultValue?: T): T {
+    return (this.value ?? defaultValue) as T;
+  }
+
+  async update<T>(key: string, value: T, target?: ConfigTarget): Promise<void> {
+    this.updateCalls.push({ key, value, target });
+  }
+
+  inspect<T = unknown>(_key: string): ConfigInspection<T> | undefined {
+    return undefined;
+  }
+
+  isExplicitlySet(): boolean {
+    return false;
+  }
+
+  watch(): { dispose(): void } {
+    return { dispose: () => undefined };
+  }
+}
+
+describe('agent skills settings', () => {
+  it('builds the shared extension and desktop settings message', () => {
+    const config = new RecordingConfigProvider();
+
+    expect(buildAgentSkillsSettingsMessage(config)).toEqual({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SKILLS_SETTINGS,
+      enabled: true,
+    });
+  });
+
+  it('uses the documented default when no setting is present', () => {
+    const config = new RecordingConfigProvider();
+    config.value = undefined;
+
+    expect(buildAgentSkillsSettingsMessage(config).enabled).toBe(
+      AGENT_SKILLS_ENABLED_DEFAULT,
+    );
+  });
+
+  it('persists the switch in workspace configuration', async () => {
+    const config = new RecordingConfigProvider();
+
+    await setAgentSkillsEnabled(config, false);
+
+    expect(config.updateCalls).toEqual([
+      {
+        key: AGENT_SKILLS_CONFIG_KEY,
+        value: false,
+        target: AGENT_SKILLS_CONFIG_TARGET,
+      },
+    ]);
+  });
+});

--- a/src/test-kernel/settings/AgentSkillsSettings.vitest.ts
+++ b/src/test-kernel/settings/AgentSkillsSettings.vitest.ts
@@ -2,7 +2,6 @@
 import { describe, expect, it } from 'vitest';
 
 // Local imports
-import type { ConfigInspection, ConfigTarget } from '@platform/interfaces';
 import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import {
   AGENT_SKILLS_CONFIG_KEY,
@@ -11,41 +10,16 @@ import {
 import {
   AGENT_SKILLS_CONFIG_TARGET,
   buildAgentSkillsSettingsMessage,
+  readAgentSkillsEnabled,
   setAgentSkillsEnabled,
 } from '@shared/settingsView/handlers/agentSkillsHandlers';
-
-class RecordingConfigProvider {
-  value: boolean | undefined = AGENT_SKILLS_ENABLED_DEFAULT;
-  readonly updateCalls: Array<{
-    key: string;
-    value: unknown;
-    target: ConfigTarget | undefined;
-  }> = [];
-
-  get<T>(_key: string, defaultValue?: T): T {
-    return (this.value ?? defaultValue) as T;
-  }
-
-  async update<T>(key: string, value: T, target?: ConfigTarget): Promise<void> {
-    this.updateCalls.push({ key, value, target });
-  }
-
-  inspect<T = unknown>(_key: string): ConfigInspection<T> | undefined {
-    return undefined;
-  }
-
-  isExplicitlySet(): boolean {
-    return false;
-  }
-
-  watch(): { dispose(): void } {
-    return { dispose: () => undefined };
-  }
-}
+import { FakeConfigProvider } from '@test/support/FakePlatform';
 
 describe('agent skills settings', () => {
   it('builds the shared extension and desktop settings message', () => {
-    const config = new RecordingConfigProvider();
+    const config = new FakeConfigProvider({
+      [AGENT_SKILLS_CONFIG_KEY]: true,
+    });
 
     expect(buildAgentSkillsSettingsMessage(config)).toEqual({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SKILLS_SETTINGS,
@@ -54,25 +28,30 @@ describe('agent skills settings', () => {
   });
 
   it('uses the documented default when no setting is present', () => {
-    const config = new RecordingConfigProvider();
-    config.value = undefined;
+    const config = new FakeConfigProvider();
 
     expect(buildAgentSkillsSettingsMessage(config).enabled).toBe(
       AGENT_SKILLS_ENABLED_DEFAULT,
     );
   });
 
+  it('rejects malformed present values at the configuration boundary', () => {
+    const config = new FakeConfigProvider({
+      [AGENT_SKILLS_CONFIG_KEY]: 'false',
+    });
+
+    expect(() => readAgentSkillsEnabled(config)).toThrow();
+  });
+
   it('persists the switch in workspace configuration', async () => {
-    const config = new RecordingConfigProvider();
+    const config = new FakeConfigProvider();
 
     await setAgentSkillsEnabled(config, false);
 
-    expect(config.updateCalls).toEqual([
-      {
-        key: AGENT_SKILLS_CONFIG_KEY,
-        value: false,
-        target: AGENT_SKILLS_CONFIG_TARGET,
-      },
-    ]);
+    expect(config.get(AGENT_SKILLS_CONFIG_KEY)).toBe(false);
+    expect(config.inspect(AGENT_SKILLS_CONFIG_KEY)).toMatchObject({
+      workspaceValue: false,
+    });
+    expect(AGENT_SKILLS_CONFIG_TARGET).toBe('workspace');
   });
 });

--- a/src/test-kernel/settings/AgentSkillsWorkspaceGuard.vitest.ts
+++ b/src/test-kernel/settings/AgentSkillsWorkspaceGuard.vitest.ts
@@ -1,0 +1,84 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
+// Third-party imports
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as vscode from 'vscode';
+
+const mocks = vi.hoisted(() => ({
+  setAgentSkillsEnabled: vi.fn(),
+  showLoggedInfoMessage: vi.fn(),
+}));
+
+vi.mock(
+  '@shared/settingsView/handlers/agentSkillsHandlers',
+  async (original) => {
+    const actual =
+      await original<
+        typeof import('@shared/settingsView/handlers/agentSkillsHandlers')
+      >();
+    return {
+      ...actual,
+      setAgentSkillsEnabled: mocks.setAgentSkillsEnabled,
+    };
+  },
+);
+
+vi.mock('@frontend/ui/errorHandlingUtils', async (original) => {
+  const actual =
+    await original<typeof import('@frontend/ui/errorHandlingUtils')>();
+  return {
+    ...actual,
+    showLoggedInfoMessage: mocks.showLoggedInfoMessage,
+  };
+});
+
+// Local imports
+import { SettingsViewMessageHandler } from '@settingsView/SettingsViewMessageHandler';
+
+type AgentSkillsHarness = {
+  handleSetAgentSkillsEnabled(enabled: boolean): Promise<void>;
+  sendAgentSkillsSettings: ReturnType<typeof vi.fn>;
+  withActiveWebview: (
+    fn: (webview: vscode.Webview) => Promise<void> | void,
+  ) => Promise<void>;
+};
+
+function createHarness(): AgentSkillsHarness {
+  const handler = Object.create(SettingsViewMessageHandler.prototype);
+  Reflect.set(handler, 'channel', 'SettingsViewMessageHandler');
+  Reflect.set(handler, 'sendAgentSkillsSettings', vi.fn());
+  Reflect.set(
+    handler,
+    'withActiveWebview',
+    async (fn: (webview: vscode.Webview) => Promise<void> | void) => {
+      await fn({} as vscode.Webview);
+    },
+  );
+  return handler as AgentSkillsHarness;
+}
+
+describe('agent skills workspace guard', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    Reflect.deleteProperty(vscode.workspace, 'workspaceFolders');
+  });
+
+  it('restores the switch without writing in an empty VS Code window', async () => {
+    Object.defineProperty(vscode.workspace, 'workspaceFolders', {
+      configurable: true,
+      value: undefined,
+    });
+    const handler = createHarness();
+
+    await handler.handleSetAgentSkillsEnabled(false);
+
+    expect(mocks.setAgentSkillsEnabled).not.toHaveBeenCalled();
+    expect(mocks.showLoggedInfoMessage).toHaveBeenCalledWith(
+      'SettingsViewMessageHandler',
+      'Agent skills are a per-workspace setting. Open a workspace folder before changing them.',
+    );
+    expect(handler.sendAgentSkillsSettings).toHaveBeenCalledOnce();
+  });
+});

--- a/src/test-kernel/settings/AgentSkillsWorkspaceGuard.vitest.ts
+++ b/src/test-kernel/settings/AgentSkillsWorkspaceGuard.vitest.ts
@@ -35,6 +35,9 @@ vi.mock('@frontend/ui/errorHandlingUtils', async (original) => {
 
 // Local imports
 import { SettingsViewMessageHandler } from '@settingsView/SettingsViewMessageHandler';
+import { setupPlatform } from '@test/support/setupPlatform';
+
+setupPlatform({ workspacePath: undefined });
 
 type AgentSkillsHarness = {
   handleSetAgentSkillsEnabled(enabled: boolean): Promise<void>;
@@ -60,16 +63,10 @@ function createHarness(): AgentSkillsHarness {
 
 describe('agent skills workspace guard', () => {
   afterEach(() => {
-    vi.restoreAllMocks();
     vi.clearAllMocks();
-    Reflect.deleteProperty(vscode.workspace, 'workspaceFolders');
   });
 
   it('restores the switch without writing in an empty VS Code window', async () => {
-    Object.defineProperty(vscode.workspace, 'workspaceFolders', {
-      configurable: true,
-      value: undefined,
-    });
     const handler = createHarness();
 
     await handler.handleSetAgentSkillsEnabled(false);

--- a/src/test-kernel/settings/ToolsTab.vitest.ts
+++ b/src/test-kernel/settings/ToolsTab.vitest.ts
@@ -34,10 +34,14 @@ function tool(
   };
 }
 
-async function mount(items: ToolDashboardItem[]): Promise<ToolsTab> {
+async function mount(
+  items: ToolDashboardItem[],
+  configure: (element: ToolsTab) => void = () => undefined,
+): Promise<ToolsTab> {
   const element = document.createElement('tools-tab') as ToolsTab;
   element.loaded = true;
   element.items = items;
+  configure(element);
   document.body.append(element);
   await element.updateComplete;
   return element;
@@ -77,8 +81,16 @@ describe('tools-tab availability summary', () => {
     expect(element.shadowRoot?.textContent).not.toContain('need setup');
   });
 
-  it('renders and updates the shared agent-skills switch', async () => {
+  it('leaves the VS Code setting as the extension editable surface', async () => {
     const element = await mount([]);
+
+    expect(element.shadowRoot?.textContent).not.toContain('Agent Skills');
+  });
+
+  it('renders and updates the shared agent-skills switch', async () => {
+    const element = await mount([], (toolsTab) => {
+      toolsTab.showAgentSkillsSettings = true;
+    });
     const skillSwitch = [
       ...(element.shadowRoot?.querySelectorAll('wa-switch') ?? []),
     ].find((candidate) =>

--- a/src/test-kernel/settings/ToolsTab.vitest.ts
+++ b/src/test-kernel/settings/ToolsTab.vitest.ts
@@ -1,8 +1,17 @@
 // Third-party imports
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  postMessage: vi.fn(),
+}));
+
+vi.mock('@shared/hostBridge', () => ({
+  postMessage: mocks.postMessage,
+}));
 
 // Local imports - component and schema types
 import type { ToolsTab } from '@settingsView/frontend/tabs/ToolsTab';
+import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
 import type { ToolDashboardItem } from '@shared/schemas/settingsViewMessages';
 
 // Local imports - test utilities
@@ -35,6 +44,10 @@ async function mount(items: ToolDashboardItem[]): Promise<ToolsTab> {
 }
 
 describe('tools-tab availability summary', () => {
+  beforeEach(() => {
+    mocks.postMessage.mockClear();
+  });
+
   it('uses an accessible Web Awesome progress ring', async () => {
     const element = await mount([
       tool('ready', 'available'),
@@ -62,5 +75,30 @@ describe('tools-tab availability summary', () => {
     expect((ring as { value?: number }).value).toBe(100);
     expect((ring as { label?: string }).label).toBe('2 of 2 tools available');
     expect(element.shadowRoot?.textContent).not.toContain('need setup');
+  });
+
+  it('renders and updates the shared agent-skills switch', async () => {
+    const element = await mount([]);
+    const skillSwitch = [
+      ...(element.shadowRoot?.querySelectorAll('wa-switch') ?? []),
+    ].find((candidate) =>
+      candidate.textContent?.includes(
+        'TeXRA and imported skills are available to tool-use agents',
+      ),
+    ) as (HTMLElement & { checked?: boolean }) | undefined;
+
+    expect(skillSwitch).toBeDefined();
+    expect(skillSwitch?.checked).toBe(true);
+
+    if (!skillSwitch) return;
+    skillSwitch.checked = false;
+    skillSwitch.dispatchEvent(
+      new Event('change', { bubbles: true, composed: true }),
+    );
+
+    expect(mocks.postMessage).toHaveBeenCalledWith(
+      SETTINGS_VIEW_COMMANDS.SET_AGENT_SKILLS_ENABLED,
+      { enabled: false },
+    );
   });
 });


### PR DESCRIPTION
## Summary

- adds an independent Agent Skills switch to the CLI launcher
- adds the same switch to the extension and desktop Tools settings
- uses one shared schema, default, configuration key, message contract, and host-neutral settings handler
- keeps skill discovery disabled at its source when the switch is off, so tool-use agents receive no skill catalog and no discovery work is performed
- preserves the enabled-by-default behavior for existing workspaces

## Design

The runtime setting already existed, but its key, default, host messages, and user controls were distributed or absent. This change makes the schema the source of truth and gives each host a thin adapter around the same shared setting handler. The extension retains the necessary empty-workspace guard because VS Code cannot write a workspace-scoped setting without an open folder.

The control is declarative in each interface:

- `On · TeXRA and imported skills available to tool-use agents`
- `Off · tool-use agents receive no skills`

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint`
- `npm run compile:fast`
- `npm run check:dead-code-ratchet`
- 71 focused CLI, desktop, extension, schema, dispatch, and component tests
- full Vitest run: 7,570 passed; one unrelated Lit setup hook timed out under concurrent load, and its 14-test file passed in isolation immediately afterward

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to a workspace-scoped feature flag and agent prompt context; no auth or data-path changes, and existing workspaces keep skills enabled by default.
> 
> **Overview**
> **Agent skills** can now be turned on or off from the **CLI launcher**, **desktop Tools** settings, and (on VS Code) the existing **`texra.skills.enabled`** workspace setting—wired through one shared schema (`agentSkills`), config key, IPC contract, and `agentSkillsHandlers`.
> 
> When the switch is **off**, tool-use agents skip runtime skill discovery entirely (`userVars` no longer calls `loadRuntimeSkillCatalog`), so prompts get an empty skill catalog with no discovery cost. **CLI** adds an “Agent skills” launcher row that flips the workspace config; **desktop** and **extension** hosts post `UPDATE_AGENT_SKILLS_SETTINGS` and handle `SET_AGENT_SKILLS_ENABLED`. The **Tools** tab switch is shown only on the **desktop** host (`showAgentSkillsSettings`); the VS Code extension keeps the native Skills setting as the editable surface and blocks writes when no workspace folder is open (same pattern as bash approval).
> 
> Copy now consistently refers to **TeXRA and imported** skills; default remains **enabled**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 396e85e9857d79ba518955a2a96ac59bda40bb28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->