### PR TITLE
test(cli): make TUI widths explicit

### DIFF
--- a/src/test-kernel/cli/AgentRosterForm.vitest.mts
+++ b/src/test-kernel/cli/AgentRosterForm.vitest.mts
@@ -10,7 +10,6 @@ import {
   setChatDefaultAgent,
 } from '@cli/chat/tui/forms/AgentRosterForm';
 import { formatCliAgentRoster } from '@cli/runtime/agentRoster';
-import { waitForCondition as waitFor } from '@test/support/asyncTestUtils';
 import {
   loadInk,
   renderWithTerminalSize,

--- a/src/test-kernel/cli/AgentRosterForm.vitest.mts
+++ b/src/test-kernel/cli/AgentRosterForm.vitest.mts
@@ -1,3 +1,4 @@
+import stripAnsi from 'strip-ansi';
 import { describe, expect, it } from 'vitest';
 
 import type { AgentEntry } from '@agent/index';
@@ -9,7 +10,11 @@ import {
   setChatDefaultAgent,
 } from '@cli/chat/tui/forms/AgentRosterForm';
 import { formatCliAgentRoster } from '@cli/runtime/agentRoster';
-import { loadInk } from '@test/support/inkTestHarness.mts';
+import { waitForCondition as waitFor } from '@test/support/asyncTestUtils';
+import {
+  loadInk,
+  renderWithTerminalSize,
+} from '@test/support/inkTestHarness.mts';
 
 const agents: AgentEntry[] = [
   {
@@ -31,11 +36,26 @@ const agents: AgentEntry[] = [
 describe('AgentRosterForm', () => {
   it('renders loading through the shared Ink indicator', async () => {
     const { ink, React } = await loadInk();
-    const output = ink.renderToString(
+    const { instance, stdout } = renderWithTerminalSize(
+      ink,
       React.createElement(AgentRosterForm, { onClose: () => undefined }),
+      80,
     );
 
-    expect(output).toMatch(/[|/\\-]\s+Loading agent roster\.\.\./);
+    try {
+      await waitFor(() => stdout.output.includes('Loading agent roster...'));
+      const loadingLines = stripAnsi(stdout.output)
+        .split('\n')
+        .filter((line) => line.includes('Loading agent roster...'));
+      const loadingCopy = loadingLines[0]
+        ?.replace(/^│\s*/, '')
+        .replace(/\s*│$/, '');
+
+      expect(loadingLines).toHaveLength(1);
+      expect(loadingCopy).toMatch(/^[|/\\-] Loading agent roster\.\.\.$/);
+    } finally {
+      instance.unmount();
+    }
   });
 
   it('offers chat defaults only from the effective tool-use roster', () => {

--- a/src/test-kernel/cli/AgentRosterForm.vitest.mts
+++ b/src/test-kernel/cli/AgentRosterForm.vitest.mts
@@ -1,5 +1,5 @@
 import stripAnsi from 'strip-ansi';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import type { AgentEntry } from '@agent/index';
 import {
@@ -36,6 +36,7 @@ const agents: AgentEntry[] = [
 describe('AgentRosterForm', () => {
   it('renders loading through the shared Ink indicator', async () => {
     const { ink, React } = await loadInk();
+    vi.useFakeTimers();
     const { instance, stdout } = renderWithTerminalSize(
       ink,
       React.createElement(AgentRosterForm, { onClose: () => undefined }),
@@ -43,7 +44,7 @@ describe('AgentRosterForm', () => {
     );
 
     try {
-      await waitFor(() => stdout.output.includes('Loading agent roster...'));
+      await vi.advanceTimersByTimeAsync(100);
       const loadingLines = stripAnsi(stdout.output)
         .split('\n')
         .filter((line) => line.includes('Loading agent roster...'));
@@ -55,6 +56,7 @@ describe('AgentRosterForm', () => {
       expect(loadingCopy).toMatch(/^[|/\\-] Loading agent roster\.\.\.$/);
     } finally {
       instance.unmount();
+      vi.useRealTimers();
     }
   });
 

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -502,7 +502,7 @@ describe('CLI child list display model', () => {
     ).toBe('45s');
   });
 
-  it('uses the explicit terminal width for agent row metadata', async () => {
+  it('renders agent row metadata correctly at an explicit terminal width', async () => {
     const { ink, React } = await loadInk();
     const run = 'run' as StreamTabId;
     const bash = 'bash-1' as StreamTabId;

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -33,9 +33,8 @@ import { AgentCategory, STREAM_PHASE, type StreamTabId } from '@shared/schemas';
 import { waitForCondition as waitFor } from '@test/support/asyncTestUtils';
 import { buildChildStreamEntries } from '@test/support/childStreamEntries';
 import {
-  FakeStdin,
-  FakeStdout,
   loadInk,
+  renderWithTerminalSize,
 } from '@test/support/inkTestHarness.mts';
 
 function session(id: string, active = false): StreamView {
@@ -503,7 +502,7 @@ describe('CLI child list display model', () => {
     ).toBe('45s');
   });
 
-  it('omits the model from bash rows while retaining agent row details', async () => {
+  it('uses the explicit terminal width for agent row metadata', async () => {
     const { ink, React } = await loadInk();
     const run = 'run' as StreamTabId;
     const bash = 'bash-1' as StreamTabId;
@@ -564,23 +563,31 @@ describe('CLI child list display model', () => {
       rootStreamId: run,
       streams,
     });
-    const output: string = ink.renderToString(
+    const { instance, stdout } = renderWithTerminalSize(
+      ink,
       React.createElement(SubagentList, {
         listRootStreamId: run,
         maxRows: 6,
         keyboardActive: false,
         sessions,
       }),
-      { columns: 100 },
+      100,
     );
 
-    expect(sessions.find(({ id }) => id === bash)?.toolName).toBe('bash');
-    expect(sessions.find(({ id }) => id === agent)?.toolName).toBeUndefined();
-    expect(output.match(/bash running/g)).toHaveLength(2);
-    expect(output).not.toContain('gemini35f');
-    expect(output).toContain('bash running · gpt56');
-    expect(output).toContain('5 tool calls');
-    expect(output).toContain('↓40k');
+    try {
+      await waitFor(() => stdout.output.includes('5 tool calls'));
+      const output = stripAnsi(stdout.output);
+
+      expect(sessions.find(({ id }) => id === bash)?.toolName).toBe('bash');
+      expect(sessions.find(({ id }) => id === agent)?.toolName).toBeUndefined();
+      expect(output.match(/bash running/g)).toHaveLength(2);
+      expect(output).not.toContain('gemini35f');
+      expect(output).toContain('bash running · gpt56');
+      expect(output).toContain('5 tool calls');
+      expect(output).toContain('↓40k');
+    } finally {
+      instance.unmount();
+    }
   });
 
   it('keeps run-file metadata out of the compact row', async () => {
@@ -904,20 +911,14 @@ describe('CLI child list display model', () => {
     ];
 
     async function renderAtColumns(columns: number): Promise<string> {
-      const stdout = new FakeStdout(columns);
-      const instance = ink.render(
+      const { instance, stdout } = renderWithTerminalSize(
+        ink,
         React.createElement(SubagentList, {
           listRootStreamId: run,
           maxRows: 10,
           sessions,
         }),
-        {
-          stdin: new FakeStdin(false),
-          stdout,
-          interactive: true,
-          exitOnCtrlC: false,
-          patchConsole: false,
-        },
+        columns,
       );
       try {
         await waitFor(() => stdout.output.includes(freeFormPhase));

--- a/src/test-kernel/support/inkTestHarness.mts
+++ b/src/test-kernel/support/inkTestHarness.mts
@@ -41,6 +41,27 @@ export class FakeStdout extends EventEmitter {
   }
 }
 
+/** Render against an explicit terminal size and return handles for assertions
+ *  and cleanup. Use this for components that read `useWindowSize()`:
+ *  `renderToString(..., { columns })` sizes Yoga but leaves that hook reading
+ *  the ambient process stdout. */
+export function renderWithTerminalSize(
+  ink: any,
+  node: any,
+  columns: number,
+  rows = 24,
+): { readonly instance: any; readonly stdout: FakeStdout } {
+  const stdout = new FakeStdout(columns, rows);
+  const instance = ink.render(node, {
+    stdin: new FakeStdin(false),
+    stdout,
+    interactive: true,
+    exitOnCtrlC: false,
+    patchConsole: false,
+  });
+  return { instance, stdout };
+}
+
 /** Minimal readable TTY used by interactive Ink tests. */
 export class FakeStdin extends EventEmitter {
   private readonly chunks: string[] = [];


### PR DESCRIPTION
Closes #9194.

## Summary

Makes `useWindowSize()`-sensitive Ink tests use an explicit fake terminal rather than the ambient process width.

Ink's `renderToString(node, { columns })` only sizes the Yoga root; it does not install the stdout context consumed by `useWindowSize()`. The canonical test harness now exposes `renderWithTerminalSize(...)`, backed by the existing `FakeStdout`, and the affected SubagentList and AgentRoster tests render through it with explicit cleanup.

## Issue acceptance gates

- Width-gated metadata behavior is exercised at an explicit 100 columns and passes even when ambient `COLUMNS=50`.
- The exact 59/60-column phase-progress boundary uses separate explicit fake terminals.
- The AgentRoster loading test no longer wraps or fails under ambient `COLUMNS=20`; fake timers freeze its append-only capture below the spinner tick boundary.
- Tests that only exercise prop-driven/Yoga layout remain on `renderToString`; no broad rewrite or global environment mutation was added.
- The canonical helper documents why `renderToString({columns})` is insufficient for `useWindowSize()` branches.

## Single source of truth

`src/test-kernel/support/inkTestHarness.mts` owns explicit terminal-size rendering for Ink tests through `renderWithTerminalSize(...)`, reusing the existing `FakeStdin` and `FakeStdout` fixtures.

## Duplication and abstraction budget

One shared helper replaces two copies of the full interactive Ink render options and prevents a third affected test from reproducing them. It owns one non-obvious invariant: the Yoga width and stdout-context width must come from the same explicit terminal fixture.

## Net elements (R6)

- Files: 0 added, 3 modified, 0 deleted.
- Exported symbols: +1 (`renderWithTerminalSize`), 0 deleted.
- Classes/interfaces/enums: 0 added, 0 deleted.
- Net LoC: +43 (68 insertions, 25 deletions).
- Production code: unchanged.

## Consumer counts (R8)

n/a for deletions — no export, emit path, or event is removed/re-routed. The new helper has 3 call sites across 2 affected test files in this PR.

## Host impact

Extension: none.

Desktop: none.

CLI: tests only; runtime behavior is unchanged.

## Scheduled refactoring

None. Nearby `renderToString` uses were audited; remaining cases either test explicit prop/Yoga layout, do not assert a `useWindowSize()` branch, or already use fake stdout.

## Validation

- Before the fix, `COLUMNS=50 ... SubagentListDisplay.vitest.mts` failed 1/25 because the 100-column metadata test observed ambient width 50.
- `COLUMNS=20 ... AgentRosterForm.vitest.mts` — 6/6 passed; reviewer stress run passed 20/20 repetitions.
- `COLUMNS=140 ... AgentRosterForm.vitest.mts` — 6/6 passed.
- `COLUMNS=50 ... SubagentListDisplay.vitest.mts` — 25/25 passed.
- `COLUMNS=140 ... SubagentListDisplay.vitest.mts ChildListInteraction.vitest.mts` — 32/32 passed.
- normal environment focused suites — 32/32 passed.
- full `src/test-kernel/cli` suite under ordinary ambient width — 147 files / 1,969 tests passed in independent review.
- `corepack pnpm exec tsc --noEmit -p tsconfig.test-kernel.json`
- `corepack pnpm --filter @texra-ai/cli typecheck`
- `npm run lint`
- `npm run format:check`
- `git diff --check`
