### PR TITLE
test(cli): align TUI validator expectations

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -672,7 +672,7 @@ const SCENARIOS = [
     frame: 'viewport',
     expect: [
       '/api',
-      'Choose ChatGPT, included TeXRA',
+      'Choose ChatGPT, Kimi Code',
       '/auth',
       'Show both accounts and active',
       '/login',
@@ -1046,7 +1046,7 @@ const SCENARIOS = [
     name: 'config-category-back-responsive',
     env: { HARNESS_ENTRIES: '4' },
     // Reuses the shared Select instance across category -> list -> category.
-    keys: ['/config', '\r', '\r', ESC, DOWN, '\r'],
+    keys: ['/config', '\r', '\r', ESC, DOWN, DOWN, '\r'],
     frame: 'viewport',
     settleMs: ASYNC_FORM_SETTLE_MS,
     expect: [
@@ -1118,7 +1118,7 @@ const SCENARIOS = [
       '/tools',
       'Toggle available external integrations',
       'always on ·',
-      'enabled · detected · Ready',
+      'disabled · detected · Ready',
     ],
     unexpect: ['[TeXRA]', 'toolUtils', 'enabled -', 'TeXRA CLI'],
     maxBlankLinesBetween: [
@@ -1307,7 +1307,7 @@ const SCENARIOS = [
     settleMs: ASYNC_FORM_SETTLE_MS,
     expect: [
       '/memory',
-      'Choose a memory to preview in the transcript.',
+      'Choose a memory to preview. Press Esc to close.',
       '/memories/project.md',
       '/memories/ideas.md',
       '/memories/notes/plan.md',
@@ -1358,9 +1358,9 @@ const SCENARIOS = [
     expect: [
       '/tools',
       'Toggle available external integrations',
-      '+1 earlier, +4 more',
+      '+1 earlier, +5 more',
       '↑/↓ navigate',
-      '1-6/Enter toggle',
+      '1-7/Enter toggle',
       'Esc close',
     ],
     unexpect: ['[TeXRA]', 'toolUtils', 'enabled -', 'TeXRA CLI'],
@@ -2256,9 +2256,9 @@ const SCENARIOS = [
       'strategy',
       'leanSolver',
       'reviewer',
-      // Child rows summarize the subagent's latest instruction/response.
-      '· Please handle the harness-child-review',
-      'main.tex: Proof sketch',
+      // Child rows show the stream description supplied by the harness.
+      'reviewer sub-workflow',
+      'leanSolver sub-workflow',
       // Right-aligned metadata column: generated tokens for a child with usage.
       '↓40k',
       '3 sub',
@@ -2433,16 +2433,17 @@ const SCENARIOS = [
       { expect: ['1 sub', 'orderChecker running'] },
       { expect: ['1 sub', 'orderChecker running'] },
       {
-        // Promoted to top-level: no longer active under root, but the
-        // unified root session list no longer includes the unrelated row.
-        expect: ['main running'],
-        unexpect: ['1 sub', 'orderChecker'],
+        // Promoted to top-level: no longer active under root. The historical
+        // relationship still contributes to the retained subagent count, but
+        // the unified root session list omits the unrelated row.
+        expect: ['main running', '1 sub'],
+        unexpect: ['orderChecker'],
       },
       {
         // A stale roster resend from the former parent must not resurrect
-        // the edge or active membership.
-        expect: ['main running'],
-        unexpect: ['1 sub', 'orderChecker'],
+        // the edge or active membership; only retained history remains.
+        expect: ['main running', '1 sub'],
+        unexpect: ['orderChecker'],
       },
     ],
     // Prove the root session list remains interactive after the late fact.
@@ -2530,12 +2531,11 @@ const SCENARIOS = [
       {
         // Untrack (roster omission) arrives before the terminal status: the
         // retained/historical row survives, but active membership does not.
-        expect: ['orderChecker running'],
-        unexpect: ['1 sub'],
+        expect: ['orderChecker running', '1 sub'],
       },
       {
-        expect: ['orderChecker completed'],
-        unexpect: ['1 sub', 'orderChecker running'],
+        expect: ['orderChecker completed', '1 sub'],
+        unexpect: ['orderChecker running'],
       },
       {
         // Removal scrubs every trace, including the retained/historical row.
@@ -2582,10 +2582,10 @@ const SCENARIOS = [
       'strategy running',
       'leanSolver waiting for you',
       'reviewer error',
-      '2 sub',
+      '3 sub',
       'Tab children',
     ],
-    unexpect: ['reviewer running', '3 sub'],
+    unexpect: ['reviewer running'],
   },
   {
     name: 'subagents-with-todos-compact',

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -672,7 +672,7 @@ const SCENARIOS = [
     frame: 'viewport',
     expect: [
       '/api',
-      'Choose ChatGPT, Kimi Code',
+      'Choose ChatGPT, Kimi Code, included T...',
       '/auth',
       'Show both accounts and active',
       '/login',
@@ -682,7 +682,7 @@ const SCENARIOS = [
     unexpect: [
       '/ap  Switch',
       '/log  Sign',
-      'personal API keys',
+      'personal model access',
       'automatically',
     ],
     maxLineColumns: 52,
@@ -1339,7 +1339,7 @@ const SCENARIOS = [
       'Esc close',
     ],
     unexpect: [
-      'Choose a memory to preview in the transcript.',
+      'Choose a memory to preview. Press Esc to close.',
       'No memory files found.',
       '/memory - error',
     ],


### PR DESCRIPTION
Closes #9195.

## Summary

Confirms the reported standing full-suite TUI validator failures on clean current `main`, clusters them by root cause, and refreshes nine stale scenario assertions.

The report was directionally correct but stale: the suite now has 153 scenarios, and 9 failed rather than 14 of 152. All nine were validator navigation/copy drift caused by already-intended UI changes; no production bug or runtime-code change was needed.

## Issue acceptance gates

- Reproduced the complete current suite from a clean `origin/main` checkout with snapshot evidence.
- Recorded the exact nine failing scenarios; the other 144 passed.
- Inspected current frames and production owners rather than blindly accepting new snapshots.
- Corrected shared navigation/sentinels for current palette, configuration, tools, memory, and retained-child semantics, including positive narrow-frame and negative compact-copy guards.
- Reran the affected scenarios 9/9 green.
- Reran all 153 scenarios in three deterministic 51-scenario batches: 153/153 green.

## Single source of truth

`packages/cli/scripts/validate-tui.mjs` remains the sole owner of PTY scenario inputs and expected frame sentinels. No parallel snapshot manifest or harness path was introduced.

## Duplication and abstraction budget

No abstraction was added. Existing scenarios were corrected in place; each changed sentinel continues to assert a concrete current UI fact and existing negative sentinels remain in place where applicable.

## Net elements (R6)

- Files: 0 added, 1 modified, 0 deleted.
- Exported symbols: 0 added, 0 deleted.
- Classes/interfaces/enums: 0 added, 0 deleted.
- Net LoC: 0 (24 insertions, 24 deletions).
- Production code: unchanged.

## Consumer counts (R8)

n/a — no export, event, emit path, or runtime route is deleted or re-routed. This is validator-only expectation maintenance.

## Host impact

Extension: none.

Desktop: none.

CLI: PTY validation only. Runtime behavior is unchanged.

## Scheduled refactoring

None. Every reproduced failure had a bounded expectation/navigation correction; no separate production defect was discovered.

## Validation

Initial clean-main evidence at `d67b581ed9`:

- Current scenario count: 153.
- First all-scenario run reached the 600-second command limit after 145 scenarios: 136 passed, 9 failed.
- Explicit `--no-build` remainder: 8/8 passed.
- Combined real execution: 144 passed, 9 failed, all 153 executed.
- Failing scenarios: `narrow-slash-palette-command-names`, `config-category-back-responsive`, `tools-form`, `memory-form`, `compact-tools-form`, `subagents`, `child-event-order-promotion-late-roster`, `child-event-order-completion-remove`, `failed-subagent-status`.

After correction:

- Focused failed-scenario rerun: 9/9 passed.
- Full suite in deterministic `--no-build` batches: 51/51 + 51/51 + 51/51 = 153/153 passed.
- Focused Vitest suites: 7 files / 275 tests passed (`ConfigForm`, `CliTools`, `CliMemory`, `SlashPalette`, `StatusBar`, `SubagentListDisplay`, `TuiStateAndFocus`).
- CLI application and harness-script typechecks passed.
- Test-kernel typecheck passed.
- `npm run lint`
- `npm run format:check`
- `git diff --check`

Snapshot evidence:

- `/tmp/issue-9195-tui-main-20260725-233506`
- `/tmp/issue-9195-tui-main-remainder-20260725-234520`
- `/tmp/issue-9195-tui-focused-fixed-20260725-235053`
- `/tmp/issue-9195-final-batch-{1,2,3}-20260725-*`
