### PR TITLE
docs: correct the D4 status-arm premise and write the loud-degradation rule

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -18,9 +18,10 @@ A "no issues found" review on this repo is almost always wrong. CLAUDE.md and AG
 1. **Read [references/review-checklist.md](references/review-checklist.md).** Pick the categories that match the diff — don't grind through all of them.
 2. **Identify the change surface.** Run `git diff` (or `git diff main...HEAD`) and group changed files by zone: VS Code-free zones (`agent/`, `model/`, `latex/`, `tools/`, `controllers/`, `shared/`, `replacement/`, `eventBus/`, webview frontends) vs. VS Code-allowed zones (`extension.ts`, `commands/`, `frontend/`, `common/webview/`, `common/state/`, `auth/`, `platform/`).
 3. **Check the event-channel rule.** New run-scoped facts extend `AgentEvent` (trace); session-scoped facts extend `SessionFact`. Flag any new `bus.emit` from a VS Code-free zone and any new subscribe surface. The `src/tools` emit sites this rule once grandfathered have migrated to session-owned emission (`SessionHandle.events` / `SessionEventHub` in `src/agent/runtime/`), so a new direct `bus.emit` is a violation, not a grandfathered pattern. This does not restrict `appSignals.emit(...)` on the separate `AppSignals` bus (`src/eventBus/AppSignals.ts`) within its documented scope. Background: `docs/proposals/2026-06-10-error-pipeline-and-ownership.md`.
-4. **Verify, don't speculate.** Open every file before flagging. If you can't verify, mark it as a question, not a finding.
-5. **Order by severity.** Correctness/security → platform-decoupling → API-contract → maintainability. Cite `path:line` for every finding.
-6. **Skip the noise.** Don't comment on whitespace, missing JSDoc on private helpers, or anything CLAUDE.md says not to comment on.
+4. **Flag silent degradation.** A fallback that masks a failure is a defect unless it is loud (warn with the cause, and surface it). Grep the diff for `catch {`, `catch (_`, `.catch(() =>`, a Zod `.catch(` on persisted data, `??`/`||` over a failed read, and `default: return` in an event switch. Taxonomy and the accepted best-effort exceptions: checklist §15.
+5. **Verify, don't speculate.** Open every file before flagging. If you can't verify, mark it as a question, not a finding.
+6. **Order by severity.** Correctness/security → platform-decoupling → API-contract → maintainability. Cite `path:line` for every finding.
+7. **Skip the noise.** Don't comment on whitespace, missing JSDoc on private helpers, or anything CLAUDE.md says not to comment on.
 
 ## Output format
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,13 @@ services/shared-store split: AGENTS.md "Patterns across the codebase"
 - **UI anti-patterns.** Never compensate for data-model problems at render time
   (no `Date.now()`, synthetic IDs, or dedup in renderers — fix the upstream
   data). One home per user action; secondary surfaces show read-only status.
+- **Silent degradation is a defect.** A fallback that masks a failure must be
+  loud — log the cause at `warn` and surface it — or not exist. `catch {}`, a
+  `??` over a failed read, a Zod `.catch(default)` on persisted data, and a
+  `default: return` that quietly drops an unknown event all turn a bug into
+  wrong-but-quiet behavior that nobody reports. Taxonomy and the accepted
+  best-effort exceptions: §15 of
+  `.claude/skills/code-review/references/review-checklist.md`.
 - **Exports are contracts.** A new export needs a consumer in the same PR;
   `npm run check:dead-code-ratchet` enforces it against
   `config/ratchets/knip-baseline.json`.

--- a/docs/proposals/2026-07-09-state-of-the-architecture.md
+++ b/docs/proposals/2026-07-09-state-of-the-architecture.md
@@ -271,10 +271,37 @@ it costs more than it keeps.
 consumer must wire **both** arms: 10 production apply-sites for one fact
 (ProgressFactApplier ×2, desktop bridge ×2, CLI subscription ×3, plus the
 sanctioned in-process rail ×3). The split rule (trace-attached in-run vs not)
-is invisible in types. Corrected reader-set: the trace `'status'` arm has
-**zero persistence/replay consumers** — `TexraTranscriptRecorder.ts:301-302`
-explicitly drops it, `replayTrace.ts:94-121` derives status elsewhere; after
-deleting the three projector trace-arms the arm is consumer-less.
+is invisible in types. Corrected reader-set **as measured at the pinned
+`4b402d75a`**: the trace `'status'` arm had **zero persistence/replay
+consumers** — the recorder's arm was a bare `case 'status': return;`,
+`replayTrace.ts:94-121` derives status elsewhere; after deleting the three
+projector trace-arms the arm would have been consumer-less.
+
+> **Amended 2026-07-25 — the zero-persistence-consumer premise no longer holds
+> at HEAD, and option (i)(b) is withdrawn.** #9127 (`d93885e6e4`, 2026-07-24)
+> replaced the recorder's no-op arm with a load-bearing persistence consumer:
+> `src/transcript/TexraTranscriptRecorder.ts:389-426` reads the trace
+> `'status'` arm and, on `WAITING` or any terminal outcome phase, closes the
+> transcript boundary, flushes every open stream, and settles still-open tool
+> rows as failed ("The stream ended before this tool completed."); `RUNNING`
+> reopens the boundary. Covered by
+> `src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts:284` ("assigns
+> source settlement order before terminal status projection"). Deleting the
+> trace arm now silently drops those durable settlements, so retaining it is
+> forced rather than the documented bet the recommendation argued for.
+>
+> The rest of the measurement still holds at HEAD, with line drift only:
+> `publishStatus` is `StreamStatusService.ts:291-324`, and its two
+> cross-process arms are mutually exclusive — `options.trace?.emit(event)`
+> (`:309`) whenever a trace is attached, the `updateStreamStatus` session fact
+> only under `!options.trace && options.events` (`:312-320`) — while
+> in-process listeners are notified either way (`:321-323`). That asymmetry is
+> the "D4 status dual rail" the trackers reference and it is real. The three
+> projector trace-arms are `ProgressFactApplier.ts:124-130`,
+> `sessionProgressSubscription.ts:76-87`, and `runProgressRenderer.ts:197-199`;
+> the recorder is a **fourth** reader and is not a projector — a diff that
+> deletes "the three consumer trace-arms" must leave it alone. Re-measure
+> before acting on D4.
 
 **Verdict.** Stage 5 landed the emitter but left every shared projector
 dual-wired; the design doc's "make updateStreamStatus a projection"
@@ -283,13 +310,18 @@ dual-wired; the design doc's "make updateStreamStatus a projection"
 **Options.** (i) Delete the three consumer trace-arms + the emitter guard so
 the session fact is the sole cross-process status channel (net −30..−40 LoC),
 **and** rule explicitly on the then-consumer-less trace arm: (a) retain as the
-per-run SDK contract (a documented bet, tolerating an unconsumed arm) or (b)
-delete the arm too. (ii) Status quo — rejected: silent-miss class with
+per-run SDK contract (a documented bet, tolerating an unconsumed arm) or ~~(b)
+delete the arm too~~ (withdrawn 2026-07-25 — the recorder consumes it).
+(ii) Status quo — rejected: silent-miss class with
 works-in-extension-broken-elsewhere lineage.
 
 **Recommendation.** (i)+(a) — the per-run trace is the natural SDK
 subscription shape (§7), but the retention must be argued as that bet, not on
-false replay grounds. **Constraint:** guard-drop + projector-arm deletion in
+false replay grounds. **Amended 2026-07-25:** (a) is now the only surviving
+option and needs no bet — the trace arm has a persistence consumer, so
+retention is forced. The atomic-PR constraint below still binds, and the diff
+must not touch `TexraTranscriptRecorder`'s arm.
+**Constraint:** guard-drop + projector-arm deletion in
 ONE atomic PR (both arms currently project onto the same public CLI event —
 any dual window duplicates headless NDJSON output, a parity invariant).
 **Unblocks:** the "new consumer wires one channel" rule; removes the last
@@ -950,8 +982,11 @@ D4's atomic status completion; v0.41 prefix retirement. D2 option B lands the
 consumer-contract suite as the **executable** surface definition (one suite,
 shared with NS-1's embedder smoke). _Existing trackers:_ #6968 (Stage-5
 close-out), #6890 (toolEdit channel), #6982/#6984 (sweeps), micro A2/A5/A6
-rows in #7636's follow-up set. _New decision needed:_ the D4 trace-arm ruling
-(one paragraph, this week).
+rows in #7636's follow-up set. _New decision needed:_ ~~the D4 trace-arm
+ruling (one paragraph, this week)~~ — settled by fact 2026-07-25: #9127 gave
+the trace `'status'` arm a persistence consumer
+(`TexraTranscriptRecorder.ts:389-426`), so it is retained. See the D4
+amendment.
 
 **Step 2 — CLI as the canonical example (gate: Step 1's port shape frozen).**
 NS-1's nodeHost consolidation (agent-dir bootstrap folded; skill-sources fold


### PR DESCRIPTION
Two guidance changes. No production code touched.

## 1. A false premise in the D4 recommendation, corrected before anyone executes it

`docs/proposals/2026-07-09-state-of-the-architecture.md` §D4 recommends deleting the trace `'status'` consumer arms, and argues the arm can then be retained-or-deleted on the grounds that it has **zero persistence/replay consumers**.

That was true when the doc was written. It is false at HEAD.

| | at the doc's pin `4b402d75a` | at HEAD |
|---|---|---|
| `TexraTranscriptRecorder` `'status'` arm | `case 'status': return;` (verified via `git show 04a167bd83`) | `TexraTranscriptRecorder.ts:389-426` — real logic |

#9127 (`d93885e6e4`, 2026-07-24) replaced the recorder's no-op with a load-bearing persistence consumer. On `WAITING` or any terminal outcome phase it closes the transcript boundary, flushes every open stream, and settles still-open tool rows as failed (`"The stream ended before this tool completed."`); `RUNNING` reopens the boundary. Regression-covered at `src/test-kernel/transcript/TexraTranscriptRecorder.vitest.ts:284`.

Executing the recommendation as written would have deleted the arm and silently dropped those durable settlements — exactly the failure mode the doc elsewhere calls the silent-miss class.

The passage is **corrected in place, not rewritten**: the original measurement stays, explicitly scoped to its pin, with a dated amendment below it. Option (i)(b) ("delete the arm too") is struck and marked withdrawn; the §7 step-list line that still called for "the D4 trace-arm ruling (one paragraph, this week)" is marked settled by fact.

### Re-verified while in there, at HEAD

The "D4 status dual rail" both trackers reference **is real**, and the doc describes it accurately (line drift only — `publishStatus` is now `StreamStatusService.ts:291-324`, not `:288-321`):

- `options.trace?.emit(event)` — `StreamStatusService.ts:309`, whenever a trace is attached
- the `updateStreamStatus` session fact — `:312-320`, only under `!options.trace && options.events`
- in-process listeners — `:321-323`, notified either way

The two cross-process arms are mutually exclusive, and the split is invisible in types. The amendment also pins the surviving reader set so a future executor can't mistake one for another: the three **projectors** are `ProgressFactApplier.ts:124-130`, `sessionProgressSubscription.ts:76-87`, `runProgressRenderer.ts:197-199` — and the recorder is a **fourth** reader that is not a projector and must be left alone.

## 2. FB-2 — the loud-degradation rule (#7726)

#7726's premise is "failures must degrade loudly", and FB-2 asked for that as a written rule. Verified gap: `grep -icE 'loud|mask|degrade|silent'` gives **0** hits in `.claude/skills/code-review/SKILL.md`, and CLAUDE.md's 3 hits are all unrelated ("fail silently" for command registration, "silent default" inside the Zod `.catch` note, "silently freeze" for the docs deploy).

One correction to the premise handed to me: the rule is **not** entirely unwritten. A detailed taxonomy already exists at `.claude/skills/code-review/references/review-checklist.md` §15 (M1-M6 masking classes, the `catch {}` blocker, the loud-reads rule). What was missing is that nothing surfaced it — CLAUDE.md never mentions it, and the review workflow only reaches it if the reviewer picks that category off the checklist. So this adds two pointers rather than a new body of rules:

- **CLAUDE.md** — one bullet under Design guardrails, next to the other standing bans, referencing §15 for the taxonomy.
- **code-review SKILL.md** — one workflow step, in the same shape as the existing event-channel step (step 3), which is likewise a CLAUDE.md rule inlined because it's high-signal.

Kept deliberately short: these files are tight by design and a rule nobody reads is worse than none.

## Verification

`npm run typecheck` (with `CI=true`, per the known `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY` gotcha), `npm run lint`, `npm run check:dead-code-ratchet`, `prettier --check`, `scripts/check-guidance-refs.mjs`, and `docs/scripts/check-root-docs.mjs` all pass. Every `file:line` above was opened at this branch's HEAD after the rebase.

Docs boundary: the edited file is under `docs/proposals/`, already excluded by `docs/.vitepress/publicDocs.js`. No new root-level doc.

`npm test` is red on this machine, and **not** because of this PR — the diff is three markdown files. Every failure is an exact 10s/20s/30s timeout multiple under a load average of ~90 (sibling agents). Confirmed by running three failing files with and without the change: `Tests 7 failed | 1 passed` **identically both ways**.

https://claude.ai/code/session_01MQZ63FFrmojmG58wPJdYNH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown and contributor guidance only; no runtime, auth, or data-path behavior changes.
> 
> **Overview**
> **Documentation only** — no production code changes.
> 
> The architecture proposal **§D4** is amended in place: the old claim that the trace `'status'` arm had zero persistence consumers is scoped to pin `4b402d75a`, with a **2026-07-25** note that **#9127** made `TexraTranscriptRecorder` a real consumer (`:389-426`). Option **(i)(b)** (delete the arm) is withdrawn; retention is **forced**, and future D4 work must not remove the recorder arm while still deleting the three **projector** trace-arms. Line refs for `publishStatus` and the §7 “D4 trace-arm ruling” item are updated to **settled**.
> 
> **Loud-degradation (FB-2 / #7726):** `CLAUDE.md` adds a design-guardrail bullet (masking fallbacks must warn and surface, or not exist), pointing to **review-checklist §15**. The **code-review** skill gains workflow step **4** to grep diffs for silent-degradation patterns (`catch {}`, Zod `.catch` on persisted data, etc.) with the same §15 reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76e497ca948f2bcfa9b8f127748d604f9a819a13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->