### PR TITLE
test(cli): use terminal ellipsis in palette sentinel

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -748,7 +748,7 @@ const SCENARIOS = [
     frame: 'viewport',
     expect: [
       '/api',
-      'Choose ChatGPT, Kimi Code, included T...',
+      'Choose ChatGPT, Kimi Code, included T…',
       '/auth',
       'Show both accounts and active',
       '/login',


### PR DESCRIPTION
Follow-up required to finish #9195 after PR #9208 merged before its final review correction landed.

## Summary

Changes the narrow slash-palette validator's truncation sentinel from three ASCII periods (`...`) to the single Unicode ellipsis (`…`) the terminal renderer actually emits.

PR #9208 strengthened this sentinel to cover the visible `included TeXRA` remainder, but was squash-merged while that one-character mismatch was still present. Runtime behavior is unchanged.

## Issue acceptance gates

- The strengthened narrow `/api` description positively asserts the actual rendered frame: `Choose ChatGPT, Kimi Code, included T…`.
- The scenario passes against current `main` plus this fix.
- The current hidden suffix remains guarded separately by `unexpect: ['personal model access']` from #9208.

## Single source of truth

The validator sentinel now matches the production terminal ellipsis (`ELLIPSIS = '…'`) used by CLI truncation.

## Duplication and abstraction budget

No abstraction or duplication added; one existing expectation character is corrected in place.

## Net elements (R6)

- Files: 0 added, 1 modified, 0 deleted.
- Exported symbols/classes/interfaces/enums: 0.
- Net LoC: 0 (1 insertion, 1 deletion).
- Production code: unchanged.

## Consumer counts (R8)

n/a — no export, event, emit path, or route changes.

## Host impact

Extension: none.

Desktop: none.

CLI: test validator only; runtime behavior is unchanged.

## Scheduled refactoring

None.

## Validation

- `node scripts/validate-tui.mjs --no-build --snapshot-dir /tmp/issue-9195-review-fixes-2 narrow-slash-palette-command-names compact-memory-form` — 2/2 passed.
- Root `npm run lint` passed.
- Prettier check passed.
- `git diff --check` passed.
- Independent review traced the rendered glyph to production truncation and found no issue.
