### PR TITLE
refactor(approvals): remove redundant pending registry

### DIFF
--- a/packages/desktop/src/main/desktopToolEditApproval.ts
+++ b/packages/desktop/src/main/desktopToolEditApproval.ts
@@ -130,14 +130,6 @@ class DesktopToolEditApprovalControllerImpl implements DesktopToolEditApprovalCo
       };
       entry.isSettled = () => settled;
       this.pending.set(requestId, entry);
-      this.options.session.approvals.toolEdit.registerPending(requestId, {
-        // `streamId` is `.nullish()` on the tool schema (string | null |
-        // undefined); the approval registry expects `string | undefined`, so
-        // collapse null → undefined (matches nativeToolEditApproval).
-        streamId: request.streamId ?? undefined,
-        isSettled: () => settled,
-        settle: (value) => this.settle(requestId, value),
-      });
       this.showProgressPermission(
         this.options.session,
         requestId,
@@ -322,7 +314,6 @@ class DesktopToolEditApprovalControllerImpl implements DesktopToolEditApprovalCo
     if (!entry || entry.isSettled()) return;
 
     this.pending.delete(requestId);
-    this.options.session.approvals.toolEdit.unregisterPending(requestId);
     entry.settle(result);
     this.options.runtimeHost.emit('resolveToolEditPermission', { requestId });
     this.cleanupEntry(entry);

--- a/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
+++ b/packages/extension/src/frontend/approval/nativeToolEditApproval.ts
@@ -378,12 +378,6 @@ export async function nativeRequestApproval(
 
       pendingApprovals.set(requestId, entry);
       initializingApprovals.delete(requestId);
-      // Register with the owning session's registry for rejection tracking
-      options.session.approvals.toolEdit.registerPending(requestId, {
-        streamId: streamId ?? undefined,
-        isSettled: () => approvalSettled,
-        settle,
-      });
 
       // Closing the proposed diff tab (e.g. Ctrl+W) must resolve the approval
       // as a rejection. Without this the approval Promise would never settle
@@ -465,7 +459,6 @@ export async function nativeRequestApproval(
     // Get entry before deleting to access workspace temp cleanup functions
     const entry = pendingApprovals.get(requestId);
     pendingApprovals.delete(requestId);
-    options.session.approvals.toolEdit.unregisterPending(requestId);
     const currentDiffSession = entry?.diffSession ?? diffSession;
     if (currentDiffSession) {
       await diffViewHost.closeDiff(currentDiffSession);

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -404,9 +404,8 @@ export class SessionHandle {
   private teardownOwners(): void {
     this.subscriptions.dispose();
     this.executions.dispose();
-    // Settle any approval still pending in this session (rejected) and drop
-    // its bypass state before the interaction slot itself is torn down.
-    this.approvals.rejectAndClearAll();
+    // Drop bypass state before the interaction slot settles pending approvals.
+    this.approvals.clearAll();
     this.modelRetries.dispose();
     this.interactions.dispose();
     this.artifactFlushers.clear();

--- a/src/agent/runtime/streamApprovalQueue.ts
+++ b/src/agent/runtime/streamApprovalQueue.ts
@@ -3,12 +3,7 @@
  *
  * Encapsulates the shared concerns of bash and tool-edit approvals:
  *   - serialized request queues (one prompt at a time per stream)
- *   - registry of in-flight pending approvals keyed by request id
  *   - per-stream bypass state announced over a bound progress event
- *   - rejection on stream cleanup
- *
- * Parameterized by the approval result type so each controller can carry
- * domain-specific result fields (e.g. tool-edit appliedContent / userPatch).
  *
  * Controller instances live on {@link SessionApprovals}, one per
  * `SessionHandle` (#8144) — there is no process-global controller, so two
@@ -17,11 +12,9 @@
 
 import PQueue from 'p-queue';
 
-import type { ToolEditApprovalResult } from '@platform/interfaces';
 import type { StreamTabId } from '@shared/schemas';
 
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
-import type { HostBashApprovalResult } from './HostInteractions';
 
 /** Progress events that announce per-stream approval-bypass changes. */
 type ApprovalBypassEvent =
@@ -42,8 +35,8 @@ const ALL_BYPASS_ANCESTRY_KINDS: readonly BypassAncestryKind[] = [
  * Per-stream bypass state bound to the progress event that announces it.
  *
  * Single implementation behind the tool-edit, bash, and proposal (super-YOLO)
- * bypass toggles, so set/toggle/clear semantics and UI notification stay
- * uniform across approval kinds.
+ * bypass values, so set/clear semantics and UI notification stay uniform
+ * across approval kinds.
  *
  * A stream with no explicit bypass value of its own defers to its ancestor
  * chain (see `resolveParent`) rather than defaulting straight to `false` —
@@ -64,8 +57,6 @@ export interface StreamApprovalBypass {
     runtimeHost?: AgentRuntimeHost,
     options?: { silent?: boolean },
   ): void;
-  /** Toggle per-stream bypass, announce it, and return the new state. */
-  toggleBypass(streamId: StreamTabId, runtimeHost: AgentRuntimeHost): boolean;
   clearForStream(streamId: StreamTabId): void;
   clearAll(): void;
 }
@@ -118,15 +109,6 @@ function createStreamApprovalBypass(
   return {
     isBypassed: resolve,
     setBypass,
-    toggleBypass(streamId, runtimeHost) {
-      // Flip the *resolved* (ancestry-aware) state, not just this stream's
-      // own explicit entry — otherwise a stream inheriting `true` from a
-      // parent would toggle to an explicit `true` on the first press (no
-      // visible change) instead of turning bypass off.
-      const next = !resolve(streamId);
-      setBypass(streamId, next, runtimeHost);
-      return next;
-    },
     clearForStream(streamId) {
       byStream.delete(streamId);
     },
@@ -136,60 +118,26 @@ function createStreamApprovalBypass(
   };
 }
 
-interface PendingApproval<R extends { accepted: boolean }> {
-  streamId?: StreamTabId;
-  isSettled: () => boolean;
-  settle: (result: R) => void;
-}
-
-interface StreamApprovalController<R extends { accepted: boolean }> {
-  registerPending(id: string, entry: PendingApproval<R>): void;
-  unregisterPending(id: string): void;
+interface StreamApprovalController {
   bypass: StreamApprovalBypass;
   enqueue<T>(
     streamId: StreamTabId | undefined,
     run: () => Promise<T>,
   ): Promise<T>;
-  rejectPendingForStream(streamId: StreamTabId): void;
-  /**
-   * Reject pending entries with no concrete stream context (streamId is
-   * undefined or empty). The controller is session-owned, so this never
-   * reaches another session's streamless approvals.
-   */
-  rejectUnscopedPending(): void;
-  rejectAllPending(): void;
 }
 
-interface StreamApprovalControllerOptions<R extends { accepted: boolean }> {
-  rejectionResult: () => R;
+interface StreamApprovalControllerOptions {
   bypassEvent: ApprovalBypassEvent;
   resolveParent: (streamId: StreamTabId) => StreamTabId | undefined;
   resolveDescendants: (streamId: StreamTabId) => readonly StreamTabId[];
 }
 
-function createStreamApprovalController<R extends { accepted: boolean }>(
-  options: StreamApprovalControllerOptions<R>,
-): StreamApprovalController<R> {
-  const pending = new Map<string, PendingApproval<R>>();
+function createStreamApprovalController(
+  options: StreamApprovalControllerOptions,
+): StreamApprovalController {
   const queues = new Map<StreamTabId | undefined, PQueue>();
 
-  function rejectWhere(
-    predicate: (entry: PendingApproval<R>) => boolean,
-  ): void {
-    for (const entry of pending.values()) {
-      if (!entry.isSettled() && predicate(entry)) {
-        entry.settle(options.rejectionResult());
-      }
-    }
-  }
-
   return {
-    registerPending(id, entry) {
-      pending.set(id, entry);
-    },
-    unregisterPending(id) {
-      pending.delete(id);
-    },
     bypass: createStreamApprovalBypass(
       options.bypassEvent,
       options.resolveParent,
@@ -218,15 +166,6 @@ function createStreamApprovalController<R extends { accepted: boolean }>(
         }
       });
     },
-    rejectPendingForStream(streamId) {
-      rejectWhere((entry) => entry.streamId === streamId);
-    },
-    rejectUnscopedPending() {
-      rejectWhere((entry) => !entry.streamId);
-    },
-    rejectAllPending() {
-      rejectWhere(() => true);
-    },
   };
 }
 
@@ -237,8 +176,8 @@ function createStreamApprovalController<R extends { accepted: boolean }>(
  * `currentSession()`, host code passes its own session explicitly.
  */
 export interface SessionApprovals {
-  readonly toolEdit: StreamApprovalController<ToolEditApprovalResult>;
-  readonly bash: StreamApprovalController<HostBashApprovalResult>;
+  readonly toolEdit: StreamApprovalController;
+  readonly bash: StreamApprovalController;
   /**
    * Per-stream bypass for agent delegation proposals (super-YOLO). Proposals
    * settle through the run coordinators rather than a stream approval queue,
@@ -279,11 +218,9 @@ export interface SessionApprovals {
    */
   forgetStreamAncestry(streamId: StreamTabId): void;
   /**
-   * Reject every pending approval and clear all bypass + proposal state for
-   * this session. Used by session teardown and the session-wide
-   * `cleanupAllApprovals` sweep.
+   * Clear all bypass + proposal + ancestry state for this session.
    */
-  rejectAndClearAll(): void;
+  clearAll(): void;
 }
 
 export function createSessionApprovals(): SessionApprovals {
@@ -318,14 +255,12 @@ export function createSessionApprovals(): SessionApprovals {
       return descendants;
     };
 
-  const toolEdit = createStreamApprovalController<ToolEditApprovalResult>({
-    rejectionResult: () => ({ accepted: false }),
+  const toolEdit = createStreamApprovalController({
     bypassEvent: 'updateToolEditApprovalBypassState',
     resolveParent: resolveParentFor('toolEdit'),
     resolveDescendants: resolveDescendantsFor('toolEdit'),
   });
-  const bash = createStreamApprovalController<HostBashApprovalResult>({
-    rejectionResult: () => ({ accepted: false }),
+  const bash = createStreamApprovalController({
     bypassEvent: 'updateBashApprovalBypassState',
     resolveParent: resolveParentFor('bash'),
     resolveDescendants: resolveDescendantsFor('bash'),
@@ -383,9 +318,7 @@ export function createSessionApprovals(): SessionApprovals {
         graph.delete(streamId);
       }
     },
-    rejectAndClearAll() {
-      toolEdit.rejectAllPending();
-      bash.rejectAllPending();
+    clearAll() {
       toolEdit.bypass.clearAll();
       bash.bypass.clearAll();
       proposal.clearAll();

--- a/src/test-kernel/agent/followUp/ChildStreamYoloInheritance.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamYoloInheritance.vitest.ts
@@ -176,10 +176,7 @@ describe('child subagent stream approval inheritance', () => {
     expect(isApprovalBypassedForStream(roundTwo)).toBe(true);
   });
 
-  it('toggling a stream that only inherits bypass turns it off on the first press', () => {
-    // Toggle used to flip the stream's own (unset) explicit entry —
-    // `!undefined` — landing on an explicit `true` that looked like a no-op
-    // to the user. It must flip the *resolved* state instead.
+  it('an explicit child value overrides inherited bypass without touching the parent', () => {
     const { host } = createRecordingHost();
     const parent = 'stream:parent-toggle' as StreamTabId;
     const child = 'stream:child-toggle' as StreamTabId;
@@ -187,13 +184,9 @@ describe('child subagent stream approval inheritance', () => {
     configureDelegatedChildApprovals(child, parent);
     expect(isBashApprovalBypassedForStream(child)).toBe(true);
 
-    const first = currentSession().approvals.bash.bypass.toggleBypass(
-      child,
-      host,
-    );
-    expect(first).toBe(false);
+    setBashApprovalSessionBypass(child, false, host);
     expect(isBashApprovalBypassedForStream(child)).toBe(false);
-    // The parent's own bypass is untouched by the child's toggle.
+    // The parent's own bypass is untouched by the child's explicit value.
     expect(isBashApprovalBypassedForStream(parent)).toBe(true);
   });
 

--- a/src/test-kernel/agent/followUp/HumanPromptProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/HumanPromptProgressEvents.vitest.ts
@@ -218,12 +218,8 @@ describe('human prompt progress events', () => {
     const explicit = createRecordingHost();
     const streamId = 'stream:tool-edit-bypass' as StreamTabId;
 
-    const enabled = defaultSession().approvals.toolEdit.bypass.toggleBypass(
-      streamId,
-      explicit.host,
-    );
+    setToolEditApprovalSessionBypass(streamId, true, explicit.host);
 
-    expect(enabled).toBe(true);
     expect(explicit.events).toEqual([
       {
         event: 'updateToolEditApprovalBypassState',
@@ -236,12 +232,8 @@ describe('human prompt progress events', () => {
     const explicit = createRecordingHost();
     const streamId = 'stream:bash-bypass' as StreamTabId;
 
-    const enabled = defaultSession().approvals.bash.bypass.toggleBypass(
-      streamId,
-      explicit.host,
-    );
+    setBashApprovalSessionBypass(streamId, true, explicit.host);
 
-    expect(enabled).toBe(true);
     expect(explicit.events).toEqual([
       {
         event: 'updateBashApprovalBypassState',
@@ -332,9 +324,8 @@ describe('human prompt progress events', () => {
     const explicit = createRecordingHost();
     const streamId = 'stream:proposal-bypass' as StreamTabId;
 
-    const enabled = proposalApprovals().toggleBypass(streamId, explicit.host);
+    proposalApprovals().setBypass(streamId, true, explicit.host);
 
-    expect(enabled).toBe(true);
     expect(explicit.events).toEqual([
       {
         event: 'updateSuperYoloBypassState',

--- a/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
+++ b/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
@@ -795,11 +795,8 @@ describe('desktop tool edit approval', () => {
     'cleans pending entries and temp files when stream cleanup rejects a request',
     async () => {
       const tempRoot = await mkdtemp(path.join(tmpdir(), 'texra-approval-'));
-      const {
-        requestToolEditApproval,
-        cleanupApprovalsForStream,
-        desktopModule,
-      } = await loadApprovalModules();
+      const { cleanupApprovalsForStream, desktopModule } =
+        await loadApprovalModules();
       const runtimeHost = createRecordingRuntimeHost();
       const session = createTestSession();
       const controller = desktopModule.createDesktopToolEditApprovalController({
@@ -809,11 +806,16 @@ describe('desktop tool edit approval', () => {
         tempRoot,
       });
       useControllerApproval(controller);
+      session.useHostInteractions({
+        requestToolEditApproval: (request) =>
+          controller.requestApproval(request),
+        cancel: (selector) => controller.cancel(selector),
+      });
       const { shownToolEditPermissions: shown } = runtimeHost;
       const { resolvedToolEditPermissions: resolved } = runtimeHost;
 
       try {
-        const resultPromise = requestToolEditApproval({
+        const resultPromise = session.interactions.requestToolEditApproval({
           path: '/workspace/cleanup.tex',
           originalContent: 'old\n',
           proposedContent: 'new\n',
@@ -822,10 +824,13 @@ describe('desktop tool edit approval', () => {
         });
         await vi.waitFor(() => expect(shown).toHaveLength(1));
 
-        // Pending registries are session-owned: sweep the owning session.
+        // Pending interactions are session-owned: sweep the owning session.
         cleanupApprovalsForStream('stream-cleanup', session);
 
-        await expect(resultPromise).resolves.toMatchObject({ accepted: false });
+        await expect(resultPromise).resolves.toMatchObject({
+          accepted: false,
+          userMessage: 'Stream resources released.',
+        });
         expect(resolved).toEqual([{ requestId: shown[0].requestId }]);
         await waitForEmptyDir(tempRoot);
         expect(await readdir(tempRoot)).toEqual([]);

--- a/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
+++ b/src/test-kernel/tools/ApprovalCleanupScope.vitest.ts
@@ -19,22 +19,9 @@ import {
   proposalApprovals,
   setDelegatedWorkApprovalBypasses,
   setBashApprovalSessionBypass,
-  type ToolEditApprovalResult,
 } from '@tools/approval';
 
 const sid = (s: string): StreamTabId => s as StreamTabId;
-
-function createPending(id: string, settled: Set<string>, streamId = '') {
-  let isSettled = false;
-  return {
-    streamId: streamId as StreamTabId,
-    isSettled: () => isSettled,
-    settle: () => {
-      isSettled = true;
-      settled.add(id);
-    },
-  };
-}
 
 describe('approval cleanup scope (SDK Step 7d residue #5)', () => {
   it("per-stream cleanup leaves another stream's approval state intact", () => {
@@ -49,8 +36,8 @@ describe('approval cleanup scope (SDK Step 7d residue #5)', () => {
 
     try {
       // A desktop window deleting its own stream `a` scopes the sweep to `a`
-      // (this is what `deleteAllStreams` loops), so a sibling stream `b` keeps
-      // its pending approval / bypass state.
+      // (this is what `deleteAllStreams` loops), so a sibling stream `b`
+      // keeps its bypass state.
       cleanupApprovalsForStream(a);
       expect(isBashApprovalBypassedForStream(a)).toBe(false);
       expect(isBashApprovalBypassedForStream(b)).toBe(true);
@@ -59,78 +46,91 @@ describe('approval cleanup scope (SDK Step 7d residue #5)', () => {
     }
   });
 
-  it('lets the cancellation cause win over the tool-edit registry sweep (#9142)', () => {
-    // Mirrors nativeToolEditApproval.ts / desktopToolEditApproval.ts: a host
-    // adapter's own `cancel` and the session's tool-edit registry both settle
-    // the *same* entry through a shared, idempotent `settle` closure. Whoever
-    // calls it first determines the user-visible result.
+  it('settles a stream tool-edit approval with the cancellation cause', async () => {
     const session = createTestSession();
     const streamId = sid('s:cause-swallow');
-    let settled: ToolEditApprovalResult | undefined;
-    let isSettled = false;
-    const settle = (result: ToolEditApprovalResult): void => {
-      if (isSettled) return;
-      isSettled = true;
-      settled = result;
-    };
-
-    session.approvals.toolEdit.registerPending(streamId, {
-      streamId,
-      isSettled: () => isSettled,
-      settle,
-    });
+    const cancel = vi.fn();
     session.useHostInteractions({
-      cancel: (selector = {}) => {
-        if (selector.streamId !== streamId) return;
-        settle({ accepted: false, userMessage: selector.cause });
-      },
+      requestToolEditApproval: () => new Promise(() => {}),
+      cancel,
+    });
+    const pending = session.interactions.requestToolEditApproval({
+      path: 'paper.tex',
+      originalContent: 'old',
+      proposedContent: 'new',
+      sourceTool: 'edit_file',
+      streamId,
     });
 
     try {
       cleanupApprovalsForStream(streamId, session);
-      // Before #9142's reorder, the registry sweep ran first and settled a
-      // bare `{ accepted: false }`; the later `cancel` call then found the
-      // entry already settled and became a no-op.
-      expect(settled).toEqual({
+      await expect(pending).resolves.toEqual({
         accepted: false,
         userMessage: 'Stream resources released.',
       });
+      expect(cancel).toHaveBeenCalledWith({
+        streamId,
+        cause: 'Stream resources released.',
+      });
     } finally {
-      session.approvals.toolEdit.unregisterPending(streamId);
       session.dispose();
     }
   });
 
-  it('scopes streamless cleanup to the owning session', () => {
+  it('scopes streamless cleanup to the owning session', async () => {
     const sessionA = createTestSession();
     const sessionB = createTestSession();
     const cancelA = vi.fn();
-    sessionA.useHostInteractions({ cancel: cancelA });
-    const settled = new Set<string>();
+    const cancelB = vi.fn();
+    const pendingApproval = (): Promise<never> => new Promise(() => {});
+    sessionA.useHostInteractions({
+      requestToolEditApproval: pendingApproval,
+      requestBashApproval: pendingApproval,
+      cancel: cancelA,
+    });
+    sessionB.useHostInteractions({
+      requestToolEditApproval: pendingApproval,
+      requestBashApproval: pendingApproval,
+      cancel: cancelB,
+    });
 
     try {
-      sessionA.approvals.toolEdit.registerPending(
-        'tool-a',
-        createPending('tool-a', settled),
-      );
-      sessionB.approvals.toolEdit.registerPending(
-        'tool-b',
-        createPending('tool-b', settled),
-      );
-      sessionA.approvals.bash.registerPending(
-        'bash-a',
-        createPending('bash-a', settled),
-      );
-      sessionB.approvals.bash.registerPending(
-        'bash-b',
-        createPending('bash-b', settled),
-      );
+      const toolA = sessionA.interactions.requestToolEditApproval({
+        path: 'a.tex',
+        originalContent: 'old',
+        proposedContent: 'new',
+        sourceTool: 'edit_file',
+      });
+      const bashA = sessionA.interactions.requestBashApproval({
+        command: 'echo a',
+      });
+      const toolB = sessionB.interactions.requestToolEditApproval({
+        path: 'b.tex',
+        originalContent: 'old',
+        proposedContent: 'new',
+        sourceTool: 'edit_file',
+      });
+      const bashB = sessionB.interactions.requestBashApproval({
+        command: 'echo b',
+      });
+      let sessionBSettled = false;
+      void Promise.all([toolB, bashB]).then(() => {
+        sessionBSettled = true;
+      });
 
       cleanupUnscopedApprovals(sessionA);
 
-      // Only session A's streamless approvals are rejected; session B's stay
-      // pending even though they are equally streamless.
-      expect(settled).toEqual(new Set(['tool-a', 'bash-a']));
+      await expect(Promise.all([toolA, bashA])).resolves.toEqual([
+        {
+          accepted: false,
+          userMessage: 'Streamless approval cleanup.',
+        },
+        {
+          accepted: false,
+          userMessage: 'Streamless approval cleanup.',
+        },
+      ]);
+      expect(sessionBSettled).toBe(false);
       expect(cancelA).toHaveBeenCalledWith({
         streamId: null,
         cause: 'Streamless approval cleanup.',
@@ -138,14 +138,21 @@ describe('approval cleanup scope (SDK Step 7d residue #5)', () => {
 
       cleanupUnscopedApprovals(sessionB);
 
-      expect(settled).toEqual(
-        new Set(['tool-a', 'bash-a', 'tool-b', 'bash-b']),
-      );
+      await expect(Promise.all([toolB, bashB])).resolves.toEqual([
+        {
+          accepted: false,
+          userMessage: 'Streamless approval cleanup.',
+        },
+        {
+          accepted: false,
+          userMessage: 'Streamless approval cleanup.',
+        },
+      ]);
+      expect(cancelB).toHaveBeenCalledWith({
+        streamId: null,
+        cause: 'Streamless approval cleanup.',
+      });
     } finally {
-      sessionA.approvals.toolEdit.unregisterPending('tool-a');
-      sessionB.approvals.toolEdit.unregisterPending('tool-b');
-      sessionA.approvals.bash.unregisterPending('bash-a');
-      sessionB.approvals.bash.unregisterPending('bash-b');
       sessionA.dispose();
       sessionB.dispose();
     }
@@ -230,15 +237,20 @@ describe('session-owned approval state (#8144)', () => {
     }
   });
 
-  it('session disposal rejects its remaining pending approvals and clears bypass state', () => {
+  it('session disposal rejects its remaining pending approvals and clears bypass state', async () => {
     const session = createTestSession();
     const streamId = sid('s:appr-dispose');
-    const settled = new Set<string>();
-
-    session.approvals.toolEdit.registerPending(
-      'tool-dispose',
-      createPending('tool-dispose', settled, streamId),
-    );
+    session.useHostInteractions({
+      requestToolEditApproval: () => new Promise(() => {}),
+      cancel: vi.fn(),
+    });
+    const pending = session.interactions.requestToolEditApproval({
+      path: 'dispose.tex',
+      originalContent: 'old',
+      proposedContent: 'new',
+      sourceTool: 'edit_file',
+      streamId,
+    });
     setBashApprovalSessionBypass(streamId, true, noopAgentRuntimeHost, {
       silent: true,
       session,
@@ -246,7 +258,10 @@ describe('session-owned approval state (#8144)', () => {
 
     session.dispose();
 
-    expect(settled).toEqual(new Set(['tool-dispose']));
+    await expect(pending).resolves.toEqual({
+      accepted: false,
+      userMessage: 'Session disposed.',
+    });
     expect(isBashApprovalBypassedForStream(streamId, session)).toBe(false);
   });
 });

--- a/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
+++ b/src/test-kernel/tools/ToolEditApprovalGate.vitest.ts
@@ -356,41 +356,4 @@ describe('Tool edit approval gating', () => {
     assert.match(result.error ?? '', /old_str must not be empty/);
     assert.strictEqual(await WorkspaceFS.read('shared.tex'), 'alpha\n');
   });
-
-  it('toggles tool-edit bypass state and returns the new value', () => {
-    // Test toggle mechanics (per-stream state)
-    // Initially bypass is off (cleared in beforeEach)
-
-    // Toggle on - should return true
-    const enabledState =
-      defaultSession().approvals.toolEdit.bypass.toggleBypass(
-        TEST_STREAM_ID,
-        noopAgentRuntimeHost,
-      );
-    assert.strictEqual(enabledState, true, 'Toggle returns true when enabling');
-
-    // Toggle off - should return false
-    const disabledState =
-      defaultSession().approvals.toolEdit.bypass.toggleBypass(
-        TEST_STREAM_ID,
-        noopAgentRuntimeHost,
-      );
-    assert.strictEqual(
-      disabledState,
-      false,
-      'Toggle returns false when disabling',
-    );
-
-    // Toggle on again
-    const reenabledState =
-      defaultSession().approvals.toolEdit.bypass.toggleBypass(
-        TEST_STREAM_ID,
-        noopAgentRuntimeHost,
-      );
-    assert.strictEqual(
-      reenabledState,
-      true,
-      'Toggle returns true when re-enabling',
-    );
-  });
 });

--- a/src/tools/approval/index.ts
+++ b/src/tools/approval/index.ts
@@ -55,22 +55,17 @@ export function configureDelegatedChildApprovals(
 
 /**
  * Clean up all approval state for a deleted stream in the owning session.
- * Handles pending approvals (tool edits + bash), plan approvals, and YOLO mode state.
+ * Cancels pending host interactions and clears stream-scoped bypass state.
  */
 export function cleanupApprovalsForStream(
   streamId: StreamTabId,
   session: SessionHandle = defaultSession(),
 ): void {
   const { toolEdit, bash, proposal } = session.approvals;
-  // Cancel the host interaction first so its cause-carrying settlement wins;
-  // the registry sweep below is then a no-op via the idempotent
-  // `approvalSettled` guard instead of the one that determines the result.
   session.interactions.cancel({
     streamId,
     cause: 'Stream resources released.',
   });
-  toolEdit.rejectPendingForStream(streamId);
-  bash.rejectPendingForStream(streamId);
   session.approvals.forgetStreamAncestry(streamId);
   toolEdit.bypass.clearForStream(streamId);
   bash.bypass.clearForStream(streamId);
@@ -79,9 +74,9 @@ export function cleanupApprovalsForStream(
 
 /**
  * Release all agent resources held for a deleted stream: approval state
- * (pending approvals, bypass flags, pending host interactions) AND the
- * follow-up queue. These two always need to be cleared together when a stream is
- * removed, so this is the single function hosts should call instead of
+ * (bypass flags and pending host interactions) AND the follow-up queue. These
+ * two always need to be cleared together when a stream is removed, so this is
+ * the single function hosts should call instead of
  * combining {@link cleanupApprovalsForStream} + `session.followUps.release`
  * manually.
  *
@@ -97,29 +92,24 @@ export function releaseStreamResources(
 }
 
 /**
- * Reject pending tool-edit, bash, and user-question approvals in `session`
- * that have no concrete stream context (streamId is undefined or empty).
- * These would otherwise survive a per-stream
- * {@link cleanupApprovalsForStream} loop because they do not equal any
- * concrete StreamTabId. Bypass and proposal state are always streamId-keyed
- * and are not affected here.
+ * Cancel pending host interactions in `session` that have no concrete stream
+ * context (streamId is undefined or empty). These would otherwise survive a
+ * per-stream {@link cleanupApprovalsForStream} loop because they do not equal
+ * any concrete StreamTabId. Bypass and proposal state are always
+ * streamId-keyed and are not affected here.
  *
  * Desktop `deleteAllStreams` calls this after the per-stream sweep so that
  * an approval emitted without a concrete stream is rejected rather than left
- * pending with no UI prompt to answer. Approval registries are session-owned,
- * so sibling windows' streamless approvals stay intact.
+ * pending with no UI prompt to answer. Interaction state is session-owned, so
+ * sibling windows' streamless approvals stay intact.
  */
 export function cleanupUnscopedApprovals(
   session: SessionHandle = defaultSession(),
 ): void {
-  // Cancel first so its cause-carrying settlement wins over the registry
-  // sweep below (see `cleanupApprovalsForStream`).
   session.interactions.cancel({
     streamId: null,
     cause: 'Streamless approval cleanup.',
   });
-  session.approvals.toolEdit.rejectUnscopedPending();
-  session.approvals.bash.rejectUnscopedPending();
 }
 
 /**
@@ -135,7 +125,7 @@ export function cleanupUnscopedApprovals(
 export function cleanupAllApprovals(
   session: SessionHandle = defaultSession(),
 ): void {
-  session.approvals.rejectAndClearAll();
+  session.approvals.clearAll();
   session.interactions.cancel({ cause: 'All approvals cleared.' });
 }
 


### PR DESCRIPTION
## Summary

- remove the second in-flight approval registry from `StreamApprovalController`; `SessionHostInteractions` remains the single owner of pending requests
- remove the unused `toggleBypass` method and use explicit bypass values at every test call site
- rename the session-wide state reset from `rejectAndClearAll` to `clearAll`, since rejection belongs to the interaction owner
- replace registry-mechanics tests with cancellation-cause, disposal, and cross-session isolation tests against the real interaction port

Part of #9142 (PR 2 of 3). This deliberately does not close the issue; the inert CLI approval-event plane remains for PR 3.

## Design

The former controller map duplicated request ownership already provided by `SessionHostInteractions.pending`. It also produced weaker rejections without cancellation causes. Removing it leaves two distinct, necessary forms of state: the session interaction owner for request lifetime, and host presentation maps for diff sessions and temporary-file cleanup.

`StreamApprovalController` is now a small queue-and-bypass module with two members: `bypass` and generic `enqueue`. No replacement layer or factory was introduced.

## Validation

- `npm run typecheck`
- targeted approval suites: 10 files, 195 tests passed
- `npm run format`
- `npm run lint`
- `npm run check:dead-code-ratchet` — 18 current findings, equal to the unchanged baseline
- `npm run compile:fast`
- `npm test` — 7,631 passed, 4 skipped
- forbidden registry/toggle symbol search — zero matches

## Net elements

- files: 0 added, 10 modified, 0 deleted
- production lines: +28 / -122, net -94
- all lines: +141 / -268, net -127
- `StreamApprovalController` members: 7 → 2
- redundant pending registries: 1 removed
- `StreamApprovalBypass` members: 5 → 4
- generic approval-result declarations on controller types: 4 → 0
- exported symbols: unchanged

## Consumer counts

- removed `registerPending` / `unregisterPending`: two production registration pairs and test-only callers
- removed rejection sweeps: four cleanup calls plus two session-wide calls
- removed `toggleBypass`: zero production callers; four test callers replaced or removed
- renamed `rejectAndClearAll` → `clearAll`: two production consumers updated

## Host impact

- extension and desktop retain their host-owned presentation maps and cleanup paths
- CLI behavior and headless output are unchanged
- all three bypass progress-event assertions remain unchanged

## Scheduled refactoring

PR 3 of #9142 will separately remove the inert CLI approval-event router after this change merges.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches approval lifecycle and teardown paths where hung or wrongly rejected prompts would block the agent; behavior is intended to improve (cause-carrying cancellations) but is central to bash/tool-edit gating across hosts.
> 
> **Overview**
> Removes the duplicate in-flight approval map from `StreamApprovalController` so **`SessionHostInteractions` is the only owner** of pending tool-edit/bash requests. Extension and desktop hosts stop calling `registerPending` / `unregisterPending`; stream and session cleanup now **`interactions.cancel` with explicit causes** instead of registry rejection sweeps.
> 
> **`StreamApprovalController`** is narrowed to per-stream **`enqueue`** plus **bypass** state (ancestry unchanged). **`rejectAndClearAll`** becomes **`clearAll`** (bypass/ancestry only); **`toggleBypass`** is removed in favor of explicit **`setBypass`** at call sites.
> 
> Tests shift from registry mechanics to cancellation causes, disposal, and cross-session isolation via the real interaction port.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dd8e9ef3c5593b278b83e3457dbd7f06b026b98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->