### PR TITLE
test(cli): finish driving the width that TUI width tests name

### DIFF
--- a/src/test-kernel/cli/ChildListInteraction.vitest.mts
+++ b/src/test-kernel/cli/ChildListInteraction.vitest.mts
@@ -13,6 +13,7 @@ import {
   FakeStdin,
   FakeStdout,
   loadInk,
+  renderOutputAtTerminalSize,
 } from '@test/support/inkTestHarness.mts';
 import { waitForCondition as waitFor } from '@test/support/asyncTestUtils';
 
@@ -23,13 +24,15 @@ function session(id: StreamTabId, active = false): StreamView {
 describe('CLI child list interaction', () => {
   it('renders no row highlight before the list receives a selection', async () => {
     const { ink, React } = await loadInk();
-    const output = ink.renderToString(
+    const output = await renderOutputAtTerminalSize(
+      ink,
       React.createElement(SubagentList, {
         sessions: [session('latexmk' as StreamTabId)],
         keyboardActive: false,
         maxRows: 3,
       }),
-      { columns: 100 },
+      100,
+      { until: (frame) => frame.includes('latexmk') },
     );
 
     expect(output).toContain('latexmk');

--- a/src/test-kernel/cli/RetryRequest.vitest.mts
+++ b/src/test-kernel/cli/RetryRequest.vitest.mts
@@ -14,6 +14,7 @@ import {
   FakeStdin,
   FakeStdout,
   loadInk,
+  renderOutputAtTerminalSize,
 } from '@test/support/inkTestHarness.mts';
 
 describe('CLI retry request', () => {
@@ -123,12 +124,14 @@ describe('CLI retry request', () => {
     'hides the impossible %s switch and names the missing key',
     async (_route, payload, provider) => {
       const { ink, React } = await loadInk();
-      const output = ink.renderToString(
+      const output = await renderOutputAtTerminalSize(
+        ink,
         React.createElement(RetryRequest, {
           payload,
           onDecide: vi.fn(),
         }),
-        { columns: 100 },
+        100,
+        { until: (frame) => frame.includes('API key is configured.') },
       );
 
       expect(output).toContain(`No ${provider} API key is configured.`);
@@ -140,7 +143,8 @@ describe('CLI retry request', () => {
 
   it('derives the fallback copy from the failed provider', async () => {
     const { ink, React } = await loadInk();
-    const output = ink.renderToString(
+    const output = await renderOutputAtTerminalSize(
+      ink,
       React.createElement(RetryRequest, {
         payload: {
           requestId: 'anthropic-fallback',
@@ -156,7 +160,8 @@ describe('CLI retry request', () => {
         },
         onDecide: vi.fn(),
       }),
-      { columns: 100 },
+      100,
+      { until: (frame) => frame.includes('API key is configured.') },
     );
 
     expect(output).toContain('No Anthropic API key is configured.');

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -1,4 +1,3 @@
-import stripAnsi from 'strip-ansi';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -30,11 +29,10 @@ import {
   type SelectItem,
 } from '@cli/chat/tui/ui/Select';
 import { AgentCategory, STREAM_PHASE, type StreamTabId } from '@shared/schemas';
-import { waitForCondition as waitFor } from '@test/support/asyncTestUtils';
 import { buildChildStreamEntries } from '@test/support/childStreamEntries';
 import {
   loadInk,
-  renderWithTerminalSize,
+  renderOutputAtTerminalSize,
 } from '@test/support/inkTestHarness.mts';
 
 function session(id: string, active = false): StreamView {
@@ -567,7 +565,7 @@ describe('CLI child list display model', () => {
       rootStreamId: run,
       streams,
     });
-    const { instance, stdout } = renderWithTerminalSize(
+    const output = await renderOutputAtTerminalSize(
       ink,
       React.createElement(SubagentList, {
         listRootStreamId: run,
@@ -576,28 +574,23 @@ describe('CLI child list display model', () => {
         sessions,
       }),
       100,
+      { until: (frame) => frame.includes('5 tool calls') },
     );
 
-    try {
-      await waitFor(() => stdout.output.includes('5 tool calls'));
-      const output = stripAnsi(stdout.output);
-
-      expect(sessions.find(({ id }) => id === bash)?.toolName).toBe('bash');
-      expect(sessions.find(({ id }) => id === agent)?.toolName).toBeUndefined();
-      expect(output.match(/bash running/g)).toHaveLength(2);
-      expect(output).not.toContain('gemini35f');
-      expect(output).toContain('bash running · gpt56');
-      expect(output).toContain('5 tool calls');
-      expect(output).toContain('↓40k');
-    } finally {
-      instance.unmount();
-    }
+    expect(sessions.find(({ id }) => id === bash)?.toolName).toBe('bash');
+    expect(sessions.find(({ id }) => id === agent)?.toolName).toBeUndefined();
+    expect(output.match(/bash running/g)).toHaveLength(2);
+    expect(output).not.toContain('gemini35f');
+    expect(output).toContain('bash running · gpt56');
+    expect(output).toContain('5 tool calls');
+    expect(output).toContain('↓40k');
   });
 
   it('keeps run-file metadata out of the compact row', async () => {
     const { ink, React } = await loadInk();
     const run = 'run' as StreamTabId;
-    const output = ink.renderToString(
+    const output = await renderOutputAtTerminalSize(
+      ink,
       React.createElement(SubagentList, {
         maxRows: 3,
         sessions: [
@@ -616,7 +609,7 @@ describe('CLI child list display model', () => {
           },
         ],
       }),
-      { columns: 100 },
+      100,
     );
 
     expect(output).toContain('devise completed');
@@ -630,7 +623,8 @@ describe('CLI child list display model', () => {
       const { ink, React } = await loadInk();
       const run = 'run' as StreamTabId;
       const reflection = 'reflect' as StreamTabId;
-      const output: string = ink.renderToString(
+      const output = await renderOutputAtTerminalSize(
+        ink,
         React.createElement(SubagentList, {
           maxRows: 4,
           sessions: [
@@ -654,7 +648,8 @@ describe('CLI child list display model', () => {
             },
           ],
         }),
-        { columns },
+        columns,
+        { until: (frame) => frame.includes('r2/3') },
       );
 
       // One line per row at every width — the phase takes the round's slot
@@ -729,15 +724,15 @@ describe('CLI child list display model', () => {
       rootStreamId: run,
       streams,
     });
-    const output: string = stripAnsi(
-      ink.renderToString(
-        React.createElement(SubagentList, {
-          listRootStreamId: run,
-          maxRows: 10,
-          sessions,
-        }),
-        { columns: 100 },
-      ),
+    const output = await renderOutputAtTerminalSize(
+      ink,
+      React.createElement(SubagentList, {
+        listRootStreamId: run,
+        maxRows: 10,
+        sessions,
+      }),
+      100,
+      { until: (frame) => frame.includes('◆ Reduce') },
     );
 
     expect(output).toContain('◆ Map');
@@ -766,7 +761,8 @@ describe('CLI child list display model', () => {
     const { ink, React } = await loadInk();
     const run = 'nested-workflow' as StreamTabId;
     const child = 'ordinary-child' as StreamTabId;
-    const output: string = ink.renderToString(
+    const output = await renderOutputAtTerminalSize(
+      ink,
       React.createElement(SubagentList, {
         listRootStreamId: run,
         maxRows: 5,
@@ -781,7 +777,8 @@ describe('CLI child list display model', () => {
           { ...session(child), parentId: run },
         ],
       }),
-      { columns: 100 },
+      100,
+      { until: (frame) => frame.includes('ordinary-child') },
     );
 
     expect(output).toContain('nested-workflow');
@@ -794,7 +791,8 @@ describe('CLI child list display model', () => {
     const run = 'windowed-run' as StreamTabId;
     const map = 'map-agent' as StreamTabId;
     const reduce = 'reduce-agent' as StreamTabId;
-    const output: string = ink.renderToString(
+    const output = await renderOutputAtTerminalSize(
+      ink,
       React.createElement(SubagentList, {
         listRootStreamId: run,
         maxRows: 3,
@@ -818,7 +816,8 @@ describe('CLI child list display model', () => {
           },
         ],
       }),
-      { columns: 100 },
+      100,
+      { until: (frame) => frame.includes('reduce-agent') },
     );
 
     expect(output).toContain('◆ Reduce');
@@ -915,7 +914,7 @@ describe('CLI child list display model', () => {
     ];
 
     async function renderAtColumns(columns: number): Promise<string> {
-      const { instance, stdout } = renderWithTerminalSize(
+      return renderOutputAtTerminalSize(
         ink,
         React.createElement(SubagentList, {
           listRootStreamId: run,
@@ -923,13 +922,8 @@ describe('CLI child list display model', () => {
           sessions,
         }),
         columns,
+        { until: (frame) => frame.includes(freeFormPhase) },
       );
-      try {
-        await waitFor(() => stdout.output.includes(freeFormPhase));
-        return stripAnsi(stdout.output);
-      } finally {
-        instance.unmount();
-      }
     }
 
     const wideOutput = await renderAtColumns(60);
@@ -969,7 +963,8 @@ describe('CLI child list display model', () => {
   it('never shows both a phase and a round on one row', async () => {
     const { ink, React } = await loadInk();
     const run = 'run' as StreamTabId;
-    const output: string = ink.renderToString(
+    const output = await renderOutputAtTerminalSize(
+      ink,
       React.createElement(SubagentList, {
         maxRows: 3,
         sessions: [
@@ -985,10 +980,67 @@ describe('CLI child list display model', () => {
           },
         ],
       }),
-      { columns: 100 },
+      100,
+      { until: (frame) => frame.includes('workflow-script') },
     );
 
     expect(output).toContain('Reduce 2/3');
     expect(output).not.toContain('r1/9');
   });
+
+  // The right-aligned metadata column is the one row element `SubagentList`
+  // drops purely on terminal width (`CHILD_ROW_METADATA_MIN_COLUMNS`), so it is
+  // what proves a width test drives the width it names: through
+  // `renderToString` both cases below lay out at the ambient terminal width
+  // instead, and whichever side of the threshold that width falls on is the
+  // only case actually exercised. Widths are spelled out rather than derived
+  // from the constant so that moving the threshold has to move the test.
+  it.each([
+    { columns: 60, metadataColumn: true },
+    { columns: 59, metadataColumn: false },
+  ])(
+    'renders the row metadata column at $columns columns: $metadataColumn',
+    async ({ columns, metadataColumn }) => {
+      const { ink, React } = await loadInk();
+      const run = 'run' as StreamTabId;
+      const child = 'child' as StreamTabId;
+      const output = await renderOutputAtTerminalSize(
+        ink,
+        React.createElement(SubagentList, {
+          listRootStreamId: run,
+          maxRows: 4,
+          sessions: [
+            {
+              id: run,
+              label: 'run',
+              active: false,
+              slice: workflowAgentSlice('run', {
+                status: STREAM_PHASE.RUNNING,
+              }),
+            },
+            {
+              id: child,
+              label: 'writer',
+              active: false,
+              parentId: run,
+              slice: workflowAgentSlice('child', {
+                status: STREAM_PHASE.RUNNING,
+                conversation: { toolCallCount: 5 },
+                cumulativeUsage: {
+                  inputTokens: 1000,
+                  outputTokens: 39_900,
+                  cost: 0,
+                },
+              }),
+            },
+          ],
+        }),
+        columns,
+        { until: (frame) => frame.includes('writer') },
+      );
+
+      expect(output).toContain('writer running');
+      expect(output.includes('5 tool calls · ↓40k')).toBe(metadataColumn);
+    },
+  );
 });

--- a/src/test-kernel/support/inkTestHarness.mts
+++ b/src/test-kernel/support/inkTestHarness.mts
@@ -28,7 +28,9 @@ export async function loadInk(): Promise<{
 /** Minimal writable TTY used by interactive Ink tests. */
 export class FakeStdout extends EventEmitter {
   readonly isTTY = true;
+  /** Append-only transcript. It does not model terminal erase/cursor controls. */
   output = '';
+  readonly writes: string[] = [];
 
   constructor(
     public columns = 80,
@@ -39,6 +41,7 @@ export class FakeStdout extends EventEmitter {
 
   write(chunk: string): boolean {
     this.output += chunk;
+    this.writes.push(chunk);
     return true;
   }
 
@@ -56,11 +59,14 @@ export function renderWithTerminalSize(
   node: any,
   columns: number,
   rows = 24,
+  options: { readonly debug?: boolean } = {},
 ): { readonly instance: any; readonly stdout: FakeStdout } {
   const stdout = new FakeStdout(columns, rows);
   const instance = ink.render(node, {
-    stdin: new FakeStdin(false),
+    // Debug renders may still mount useInput; let its raw-mode setup succeed.
+    stdin: new FakeStdin(options.debug ?? false),
     stdout,
+    debug: options.debug ?? false,
     interactive: true,
     exitOnCtrlC: false,
     patchConsole: false,
@@ -69,27 +75,38 @@ export function renderWithTerminalSize(
 }
 
 /** Render at an explicit terminal size, wait for the frame under test, and
- *  return what Ink wrote with ANSI stripped — the shape every test that only
+ *  return the current frame with ANSI stripped — the shape every test that only
  *  reads output wants, so the render / wait / unmount dance has one owner.
  *  Tests that drive keystrokes or their own clock keep the handles from
  *  `renderWithTerminalSize` instead.
  *
- *  `until` receives the same stripped output that is returned; it defaults to
- *  "Ink has painted something". */
+ *  This uses Ink's debug mode, where Ink 7.1.0 writes each render as a complete
+ *  frame instead of terminal cursor/erase updates. `until` receives the latest
+ *  painted frame, which is also returned; it defaults to "Ink has painted
+ *  something". */
 export async function renderOutputAtTerminalSize(
   ink: any,
   node: any,
   columns: number,
   options: { readonly until?: (output: string) => boolean } = {},
 ): Promise<string> {
-  const { instance, stdout } = renderWithTerminalSize(ink, node, columns);
+  const { instance, stdout } = renderWithTerminalSize(ink, node, columns, 24, {
+    debug: true,
+  });
   const settled =
     options.until ?? ((output: string) => output.trim().length > 0);
+  const currentFrame = (): string => {
+    for (let index = stdout.writes.length - 1; index >= 0; index -= 1) {
+      const frame = stripAnsi(stdout.writes[index] ?? '');
+      if (frame.trim().length > 0) return frame;
+    }
+    return '';
+  };
   try {
-    await waitForCondition(() => settled(stripAnsi(stdout.output)), {
+    await waitForCondition(() => settled(currentFrame()), {
       timeoutMessage: `Ink rendered no matching frame at ${columns} columns`,
     });
-    return stripAnsi(stdout.output);
+    return currentFrame();
   } finally {
     instance.unmount();
   }

--- a/src/test-kernel/support/inkTestHarness.mts
+++ b/src/test-kernel/support/inkTestHarness.mts
@@ -2,6 +2,12 @@
 import { EventEmitter } from 'node:events';
 import { createRequire } from 'node:module';
 
+// Third-party imports
+import stripAnsi from 'strip-ansi';
+
+// Local imports
+import { waitForCondition } from '@test/support/asyncTestUtils';
+
 const cliRequire = createRequire(
   new URL('../../../packages/cli/package.json', import.meta.url),
 );
@@ -60,6 +66,33 @@ export function renderWithTerminalSize(
     patchConsole: false,
   });
   return { instance, stdout };
+}
+
+/** Render at an explicit terminal size, wait for the frame under test, and
+ *  return what Ink wrote with ANSI stripped — the shape every test that only
+ *  reads output wants, so the render / wait / unmount dance has one owner.
+ *  Tests that drive keystrokes or their own clock keep the handles from
+ *  `renderWithTerminalSize` instead.
+ *
+ *  `until` receives the same stripped output that is returned; it defaults to
+ *  "Ink has painted something". */
+export async function renderOutputAtTerminalSize(
+  ink: any,
+  node: any,
+  columns: number,
+  options: { readonly until?: (output: string) => boolean } = {},
+): Promise<string> {
+  const { instance, stdout } = renderWithTerminalSize(ink, node, columns);
+  const settled =
+    options.until ?? ((output: string) => output.trim().length > 0);
+  try {
+    await waitForCondition(() => settled(stripAnsi(stdout.output)), {
+      timeoutMessage: `Ink rendered no matching frame at ${columns} columns`,
+    });
+    return stripAnsi(stdout.output);
+  } finally {
+    instance.unmount();
+  }
 }
 
 /** Minimal readable TTY used by interactive Ink tests. */

--- a/src/test-kernel/support/inkTestHarness.mts
+++ b/src/test-kernel/support/inkTestHarness.mts
@@ -95,18 +95,28 @@ export async function renderOutputAtTerminalSize(
   });
   const settled =
     options.until ?? ((output: string) => output.trim().length > 0);
-  const currentFrame = (): string => {
+  const currentFrame = (): string | undefined => {
     for (let index = stdout.writes.length - 1; index >= 0; index -= 1) {
-      const frame = stripAnsi(stdout.writes[index] ?? '');
-      if (frame.trim().length > 0) return frame;
+      const write = stdout.writes[index];
+      if (write === '') return '';
+      if (write === undefined) continue;
+      const frame = stripAnsi(write);
+      if (frame.length > 0) return frame;
     }
-    return '';
+    return undefined;
   };
+  const timeoutMessage = `Ink rendered no matching frame at ${columns} columns`;
   try {
-    await waitForCondition(() => settled(currentFrame()), {
-      timeoutMessage: `Ink rendered no matching frame at ${columns} columns`,
-    });
-    return currentFrame();
+    await waitForCondition(
+      () => {
+        const frame = currentFrame();
+        return frame !== undefined && settled(frame);
+      },
+      { timeoutMessage },
+    );
+    const frame = currentFrame();
+    if (frame === undefined) throw new Error(timeoutMessage);
+    return frame;
   } finally {
     instance.unmount();
   }

--- a/src/test-kernel/support/inkTestHarness.vitest.mts
+++ b/src/test-kernel/support/inkTestHarness.vitest.mts
@@ -26,4 +26,28 @@ describe('Ink test harness', () => {
 
     expect(output).toBe('new-frame');
   });
+
+  it('returns an empty current frame after an effect clears the output', async () => {
+    const { ink, React } = await loadInk();
+    let effectRan = false;
+
+    function ClearingComponent(): any {
+      const [visible, setVisible] = React.useState(true);
+      React.useEffect(() => {
+        effectRan = true;
+        setVisible(false);
+      }, []);
+      return visible ? React.createElement(ink.Text, null, 'old-frame') : null;
+    }
+
+    const output = await renderOutputAtTerminalSize(
+      ink,
+      React.createElement(ClearingComponent),
+      80,
+      { until: (frame) => frame === '' },
+    );
+
+    expect(effectRan).toBe(true);
+    expect(output).toBe('');
+  });
 });

--- a/src/test-kernel/support/inkTestHarness.vitest.mts
+++ b/src/test-kernel/support/inkTestHarness.vitest.mts
@@ -1,0 +1,29 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports
+import {
+  loadInk,
+  renderOutputAtTerminalSize,
+} from '@test/support/inkTestHarness.mts';
+
+describe('Ink test harness', () => {
+  it('returns only the current frame after an effect-driven repaint', async () => {
+    const { ink, React } = await loadInk();
+
+    function RepaintingComponent(): any {
+      const [frame, setFrame] = React.useState('old-frame');
+      React.useEffect(() => setFrame('new-frame'), []);
+      return React.createElement(ink.Text, null, frame);
+    }
+
+    const output = await renderOutputAtTerminalSize(
+      ink,
+      React.createElement(RepaintingComponent),
+      80,
+      { until: (frame) => frame.includes('new-frame') },
+    );
+
+    expect(output).toBe('new-frame');
+  });
+});


### PR DESCRIPTION
Follow-up to #9207 / #9194.

## Summary

Finishes moving every `useWindowSize()`-sensitive CLI test away from `ink.renderToString({columns})`, which sizes Yoga but leaves the hook reading ambient stdout.

Twelve snapshot-style sites in `SubagentListDisplay`, `RetryRequest`, and `ChildListInteraction` now use an explicit fake terminal. The canonical helper waits for and returns the **current** Ink frame, including after repaint or clearing, rather than an append-only transcript of stale frames.

## Issue acceptance gates

- All affected width-gated tests get both Yoga width and `useWindowSize()` width from the same `FakeStdout(columns)`.
- The 59/60-column metadata boundary is explicitly asserted and fails under off-by-one or threshold mutations.
- Focused suites pass identically under ambient `COLUMNS=40` and `COLUMNS=240`.
- Remaining `renderToString` call sites were audited and use prop-driven/Yoga width without `useWindowSize()`.
- Effect-driven `old-frame → new-frame` and `old-frame → empty` regressions prove the snapshot helper returns only the current frame.

## Single source of truth

`src/test-kernel/support/inkTestHarness.mts` owns explicit terminal rendering:

- `renderWithTerminalSize` retains handles for input/fake-clock tests.
- `renderOutputAtTerminalSize` builds on it for current-frame snapshot tests.

Ink debug mode is used only by the snapshot helper because Ink 7.1.0 emits each debug render as a complete frame; ordinary interactive writes are not misclassified as frames.

## Duplication and abstraction budget

One snapshot helper replaces twelve copies of render/wait/strip/unmount logic while reusing the existing render-options owner. The handle-returning primitive remains necessary for interactive and fake-clock callers.

## Net elements (R6)

- Files: 1 added, 4 modified, 0 deleted.
- Exported symbols: +1 (`renderOutputAtTerminalSize`), 0 deleted.
- Classes/interfaces/enums: 0 added or deleted.
- Net LoC: +139 (190 insertions, 51 deletions).
- Production code: unchanged.

## Consumer counts (R8)

n/a for deletions — no export, event, or runtime route is removed. `renderOutputAtTerminalSize` has 12 call sites across 3 suites; `renderWithTerminalSize` retains one external handle-based caller plus the shared helper's internal call.

## Host impact

Extension: none.

Desktop: none.

CLI: tests only; runtime behavior is unchanged.

## Scheduled refactoring

None. Pinning global `COLUMNS`/`LINES` was deliberately not bundled because explicit width at branch assertions fixes the cause without changing unrelated test environments.

## Validation

- Focused harness regression before current-frame fix reproduced stale `old-frame\nnew-frame`; now both repaint regressions pass.
- `COLUMNS=40`: 47/47 focused tests passed.
- `COLUMNS=240`: 47/47 focused tests passed.
- Mutation checks:
  - `columns >= threshold` → `columns > threshold` fails the 60-column and phase-boundary tests.
  - threshold 60 → 50 fails the 59-column and phase-boundary tests.
- Root, test-kernel, and CLI TypeScript checks passed.
- Repository lint passed.
- Prettier check passed.
- `git diff --check` passed.
- Independent final review approved current-frame, empty-frame, debug-mode, input, cleanup, and width semantics.
