### PR TITLE
chore(runtime): warn on ambiguous default-session fallback

### DIFF
--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -422,6 +422,13 @@ export class SessionHandle {
 /** Live sessions whose background processes must be stopped at shutdown. */
 const liveSessions = new Set<SessionHandle>();
 
+function hasLiveNonDefaultSession(processDefault: SessionHandle): boolean {
+  for (const session of liveSessions) {
+    if (session !== processDefault) return true;
+  }
+  return false;
+}
+
 /** Stop background OS processes owned by every live runtime session. */
 export function killAllSessionBackgroundProcesses(): void {
   for (const session of liveSessions) {
@@ -474,16 +481,21 @@ export function defaultSession(): SessionHandle {
       'The default session has not been initialized. Call initializeDefaultSession() after opening its transcript store.',
     );
   }
+  const processDefault = cachedDefaultSession;
   if (
     !defaultSessionFallbackWarned &&
-    [...liveSessions].some((session) => session !== cachedDefaultSession)
+    hasLiveNonDefaultSession(processDefault)
   ) {
     defaultSessionFallbackWarned = true;
-    logger.warn(
-      'defaultSession() resolved while a non-default SessionHandle was live. Pass or propagate the owning session instead.',
-    );
+    try {
+      logger.warn(
+        'defaultSession() resolved while a non-default SessionHandle was live. Pass or propagate the owning session instead.',
+      );
+    } catch {
+      // Diagnostics must not break the sanctioned fallback.
+    }
   }
-  return cachedDefaultSession;
+  return processDefault;
 }
 
 /**

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -473,7 +473,9 @@ export function teardownDefaultSession(): void {
  *
  * Hosts must initialize it explicitly after opening transcript persistence.
  * Access before that composition step is a lifecycle error rather than an
- * implicit memory-only session.
+ * implicit memory-only session. If another session is live, retrieval emits at
+ * most one best-effort warning for the process lifetime, including across
+ * teardown and reinitialization of the default session.
  */
 export function defaultSession(): SessionHandle {
   if (!cachedDefaultSession) {

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -430,6 +430,7 @@ export function killAllSessionBackgroundProcesses(): void {
 }
 
 let cachedDefaultSession: SessionHandle | undefined;
+let defaultSessionFallbackWarned = false;
 
 export type DefaultSessionInit = Omit<SessionHandleInit, 'flushers'>;
 
@@ -471,6 +472,15 @@ export function defaultSession(): SessionHandle {
   if (!cachedDefaultSession) {
     throw new Error(
       'The default session has not been initialized. Call initializeDefaultSession() after opening its transcript store.',
+    );
+  }
+  if (
+    !defaultSessionFallbackWarned &&
+    [...liveSessions].some((session) => session !== cachedDefaultSession)
+  ) {
+    defaultSessionFallbackWarned = true;
+    logger.warn(
+      'defaultSession() resolved while a non-default SessionHandle was live. Pass or propagate the owning session instead.',
     );
   }
   return cachedDefaultSession;

--- a/src/test-kernel/agent/runtime/DefaultSessionLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/DefaultSessionLifecycle.vitest.ts
@@ -1,8 +1,97 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const channelTraceMocks = vi.hoisted(() => ({
+  warn: vi.fn(),
+}));
+
+vi.mock('@agent/trace', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@agent/trace')>();
+  return {
+    ...actual,
+    createChannelTrace: vi.fn(() => ({
+      ...actual.noopTrace,
+      warn: channelTraceMocks.warn,
+    })),
+  };
+});
+
+beforeEach(() => {
+  vi.resetModules();
+  channelTraceMocks.warn.mockReset();
+});
 
 describe('default session lifecycle', () => {
+  it('warns once only when a non-default session is live at resolution', async () => {
+    const {
+      SessionHandle,
+      defaultSession,
+      initializeDefaultSession,
+      teardownDefaultSession,
+    } = await import('@agent/runtime/SessionHandle');
+    const { StreamLogStore } = await import('@transcript');
+    const processDefault = initializeDefaultSession({
+      transcripts: StreamLogStore.ephemeral('process default'),
+    });
+
+    try {
+      expect(defaultSession()).toBe(processDefault);
+      expect(channelTraceMocks.warn).not.toHaveBeenCalled();
+
+      const disposedSession = new SessionHandle({
+        transcripts: StreamLogStore.ephemeral('disposed non-default'),
+      });
+      disposedSession.dispose();
+      expect(defaultSession()).toBe(processDefault);
+      expect(channelTraceMocks.warn).not.toHaveBeenCalled();
+
+      const liveSession = new SessionHandle({
+        transcripts: StreamLogStore.ephemeral('live non-default'),
+      });
+      try {
+        expect(defaultSession()).toBe(processDefault);
+        expect(defaultSession()).toBe(processDefault);
+        expect(channelTraceMocks.warn).toHaveBeenCalledOnce();
+        expect(channelTraceMocks.warn).toHaveBeenCalledWith(
+          'defaultSession() resolved while a non-default SessionHandle was live. Pass or propagate the owning session instead.',
+        );
+      } finally {
+        liveSession.dispose();
+      }
+    } finally {
+      teardownDefaultSession();
+    }
+  });
+
+  it('does not let a throwing warning sink break or repeat fallback resolution', async () => {
+    const warningFailure = new Error('warning sink failed');
+    channelTraceMocks.warn.mockImplementation(() => {
+      throw warningFailure;
+    });
+    const {
+      SessionHandle,
+      defaultSession,
+      initializeDefaultSession,
+      teardownDefaultSession,
+    } = await import('@agent/runtime/SessionHandle');
+    const { StreamLogStore } = await import('@transcript');
+    const processDefault = initializeDefaultSession({
+      transcripts: StreamLogStore.ephemeral('process default'),
+    });
+    const liveSession = new SessionHandle({
+      transcripts: StreamLogStore.ephemeral('live non-default'),
+    });
+
+    try {
+      expect(defaultSession()).toBe(processDefault);
+      expect(defaultSession()).toBe(processDefault);
+      expect(channelTraceMocks.warn).toHaveBeenCalledOnce();
+    } finally {
+      liveSession.dispose();
+      teardownDefaultSession();
+    }
+  });
+
   it('rejects access before explicit initialization', async () => {
-    vi.resetModules();
     const { defaultSession, initializeDefaultSession, teardownDefaultSession } =
       await import('@agent/runtime/SessionHandle');
     const { StreamLogStore } = await import('@transcript');
@@ -27,7 +116,6 @@ describe('default session lifecycle', () => {
   });
 
   it('can initialize again only after explicit teardown', async () => {
-    vi.resetModules();
     const {
       defaultSession,
       initializeDefaultSession,

--- a/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
@@ -24,6 +24,21 @@ import type { RunTraceFlushEntry } from '@transcript/runTrace';
 // Local file imports
 import { createRecordingHost } from '../progressTestUtils';
 
+const channelTraceMocks = vi.hoisted(() => ({
+  warn: vi.fn(),
+}));
+
+vi.mock('@agent/trace', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@agent/trace')>();
+  return {
+    ...actual,
+    createChannelTrace: vi.fn(() => ({
+      ...actual.noopTrace,
+      warn: channelTraceMocks.warn,
+    })),
+  };
+});
+
 const plan: Plan = { objective: 'Compose the per-session runtime owners.' };
 
 function activeTraceFlusher(flush: () => void): RunTraceFlushEntry {
@@ -47,6 +62,32 @@ function trackAgent(
   session.executions.track(handle);
   return handle;
 }
+
+describe('defaultSession fallback diagnostic', () => {
+  it('warns once only when a non-default session is live at resolution', () => {
+    channelTraceMocks.warn.mockClear();
+    const processDefault = defaultSession();
+
+    expect(channelTraceMocks.warn).not.toHaveBeenCalled();
+
+    const disposedSession = createTestSession();
+    disposedSession.dispose();
+    expect(defaultSession()).toBe(processDefault);
+    expect(channelTraceMocks.warn).not.toHaveBeenCalled();
+
+    const liveSession = createTestSession();
+    try {
+      expect(defaultSession()).toBe(processDefault);
+      expect(defaultSession()).toBe(processDefault);
+      expect(channelTraceMocks.warn).toHaveBeenCalledOnce();
+      expect(channelTraceMocks.warn).toHaveBeenCalledWith(
+        'defaultSession() resolved while a non-default SessionHandle was live. Pass or propagate the owning session instead.',
+      );
+    } finally {
+      liveSession.dispose();
+    }
+  });
+});
 
 describe('SessionHandle', () => {
   it('awaits artifact writers before disposal and leaves the live-session registry', async () => {

--- a/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
@@ -24,21 +24,6 @@ import type { RunTraceFlushEntry } from '@transcript/runTrace';
 // Local file imports
 import { createRecordingHost } from '../progressTestUtils';
 
-const channelTraceMocks = vi.hoisted(() => ({
-  warn: vi.fn(),
-}));
-
-vi.mock('@agent/trace', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@agent/trace')>();
-  return {
-    ...actual,
-    createChannelTrace: vi.fn(() => ({
-      ...actual.noopTrace,
-      warn: channelTraceMocks.warn,
-    })),
-  };
-});
-
 const plan: Plan = { objective: 'Compose the per-session runtime owners.' };
 
 function activeTraceFlusher(flush: () => void): RunTraceFlushEntry {
@@ -62,32 +47,6 @@ function trackAgent(
   session.executions.track(handle);
   return handle;
 }
-
-describe('defaultSession fallback diagnostic', () => {
-  it('warns once only when a non-default session is live at resolution', () => {
-    channelTraceMocks.warn.mockClear();
-    const processDefault = defaultSession();
-
-    expect(channelTraceMocks.warn).not.toHaveBeenCalled();
-
-    const disposedSession = createTestSession();
-    disposedSession.dispose();
-    expect(defaultSession()).toBe(processDefault);
-    expect(channelTraceMocks.warn).not.toHaveBeenCalled();
-
-    const liveSession = createTestSession();
-    try {
-      expect(defaultSession()).toBe(processDefault);
-      expect(defaultSession()).toBe(processDefault);
-      expect(channelTraceMocks.warn).toHaveBeenCalledOnce();
-      expect(channelTraceMocks.warn).toHaveBeenCalledWith(
-        'defaultSession() resolved while a non-default SessionHandle was live. Pass or propagate the owning session instead.',
-      );
-    } finally {
-      liveSession.dispose();
-    }
-  });
-});
 
 describe('SessionHandle', () => {
   it('awaits artifact writers before disposal and leaves the live-session registry', async () => {


### PR DESCRIPTION
## Summary

- warn once when process-default session resolution happens while another live session exists
- reuse the existing live-session ownership set with a non-allocating identity scan
- keep the diagnostic best-effort so a failed logging sink cannot change fallback behavior
- add module-isolated lifecycle coverage for default-only, disposed, live, repeated, and throwing-sink cases

## Design

`defaultSession()` remains the sanctioned compatibility seam. This adds observability at its single resolution boundary rather than threading a new required parameter surface or creating another session registry. Disposed sessions are already removed from `liveSessions`, so the existing owner set remains the single source of truth.

The once-only latch is set before logging. A broken warning sink is swallowed deliberately: diagnostics may not turn a valid initialized fallback into a runtime failure.

## Validation

- focused `SessionHandle` + `DefaultSessionLifecycle` suites: 18/18
- root TypeScript check
- test-kernel TypeScript check
- ESLint on changed production/test files
- Prettier check on changed files
- `git diff --check`
- independent review approved after both findings were fixed

Fixes #9214
Part of #7726

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diagnostic-only change on an existing resolution path; return value and session semantics are unchanged aside from a best-effort warn.
> 
> **Overview**
> Adds **one-time observability** when `defaultSession()` is used while a **non-default `SessionHandle` is still in `liveSessions`**, so callers are nudged to pass or propagate the owning session instead of silently hitting the process default.
> 
> Detection reuses the existing live-session set via a small identity scan (`hasLiveNonDefaultSession`); disposed sessions stay silent because they are already removed from that set. A **process-lifetime latch** ensures the warning fires at most once, including across default-session teardown/reinit. Logging is **best-effort** (errors from the trace sink are swallowed) so diagnostics cannot change fallback behavior.
> 
> **Tests** mock `@agent/trace`, reset modules per case, and cover default-only, disposed non-default, live non-default with repeated calls, and a throwing warning sink.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81c3e9bb990d99389b4cc4e3e11b26a52308f9b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->