### PR TITLE
docs: disambiguate VS Code-free webview frontend/ paths in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,8 +60,12 @@ repo and the first thing to check on any diff.
 
 **VS Code-free zones** — must NOT import `vscode`:
 `src/agent/`, `src/model/`, `src/latex/`, `src/tools/`, `src/controllers/`,
-`src/shared/`, `src/replacement/`, `src/eventBus/`, `src/hosts/`, and all
-webview frontends (`packages/extension/src/*/frontend/`).
+`src/shared/`, `src/replacement/`, `src/eventBus/`, `src/hosts/`, and the
+webview frontends — `packages/extension/src/webview/frontend/`,
+`packages/extension/src/progressView/frontend/`, and
+`packages/extension/src/settingsView/frontend/`. Do not confuse these with
+`packages/extension/src/frontend/` (no view-name segment), which is the
+top-level extension-host frontend below and is VS Code-allowed.
 
 **VS Code-allowed zones** — platform wiring belongs here:
 `packages/extension/src/extension.ts` (calls `initPlatform()` exactly once),


### PR DESCRIPTION
## Summary

Scheduled structural-debt audit of the repo for confusing/overlapping responsibilities. Actual code boundaries turned out to be solid (no `vscode` imports leaked into any VS Code-free zone, no unauthorized `bus.emit`, no duplicate retry/queue implementations, no single-caller factories) — the one real finding was in the *documentation* of the VS Code-coupling boundary itself, CLAUDE.md's highest-signal rule.

CLAUDE.md described the VS Code-free "webview frontends" zone as `packages/extension/src/*/frontend/`, three lines above listing `packages/extension/src/frontend/` (the top-level extension-host frontend, 46 files, all VS Code-allowed) as part of the VS Code-*allowed* zone. The two directories share the `frontend/` name but have opposite import rules, and the shorthand glob reads as if it covers both — a real trap for a human or an AI auditing the boundary by eye, or writing a loose `**/frontend/**` grep instead of the precise, already-correct enforcement.

## Issue acceptance gates

No linked issue — this is a scheduled proactive audit. Acceptance gate (self-imposed): resolve the doc contradiction without touching any enforced/runtime path.

## Single source of truth

`eslint.config.mjs` (lines ~68-70, 93) and `src/test-kernel/architecture/dependencyDirection.vitest.ts` already enumerate the three webview frontend directories explicitly (`webview/frontend`, `progressView/frontend`, `settingsView/frontend`) rather than a wildcard — those remain the enforced source of truth. This PR only brings CLAUDE.md's prose in line with what those already encode, instead of introducing a second, looser description of the boundary.

## Duplication and abstraction budget

No duplication removed or added — this is a doc-only clarification, no code or abstraction changes.

## Net elements (R6)

n/a — doc-only change (CLAUDE.md), no exported symbols, no files added/removed.

## Consumer counts (R8)

n/a — no emit path or export was deleted or re-routed.

## Host impact

Extension: none (doc-only; no source files touched).

Desktop: none.

CLI: none.

## Scheduled refactoring

None. (Considered and rejected: renaming `packages/extension/src/frontend/` to remove the name collision entirely — e.g. to `packages/extension/src/host/` — which would touch ~84 import sites plus the `@frontend/*` tsconfig alias in two tsconfig files. That's a much larger mechanical diff for the same practical benefit the enforcement code already has correctly in place, so it wasn't pursued here.)

## Validation

- Confirmed via `grep` that the actual boundary enforcement (`eslint.config.mjs`, `dependencyDirection.vitest.ts`) already lists the three webview `frontend/` directories explicitly and is unaffected by this change.
- Confirmed 0 `vscode` imports in the three webview frontend dirs and 46 in the top-level `packages/extension/src/frontend/`, matching the documented (and now clarified) split.
- No code changes; `npm run typecheck` / `npm test` not run since only prose in CLAUDE.md changed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01C9W4EAQYpr9o3AGenGekLV)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prose-only change in CLAUDE.md with no code, config, or enforcement edits.
> 
> **Overview**
> **Documentation-only** update to the repo’s highest-signal rule: which zones must not import `vscode`.
> 
> The VS Code-free “webview frontends” list no longer uses the shorthand `packages/extension/src/*/frontend/`. It now names **`webview/frontend`**, **`progressView/frontend`**, and **`settingsView/frontend`**, and adds an explicit note that **`packages/extension/src/frontend/`** (no view-name segment) is the extension-host frontend and remains **VS Code-allowed**—avoiding the trap where both trees end in `frontend/` but have opposite import rules.
> 
> No runtime or enforcement changes; `eslint.config.mjs` already enumerates the same three webview paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ea989ae017eecd92fdcfff0a8810c7d3db57d72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->