### PR TITLE
refactor: consolidate duplicated timeout/string helpers and AgentTrace test spies

### DIFF
--- a/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
+++ b/packages/extension/src/webview/frontend/components/LatexDiffsSection.ts
@@ -26,6 +26,7 @@ import {
   renderLabeledActionButtonParts,
 } from '@shared/wa/actionButtons';
 import { type TeXRAIconName, waIcon } from '@shared/wa/webAwesomeIcons';
+import { byString } from '@utils/core';
 import { MainViewEvents } from '../events';
 import { fileSelectLayoutStyles } from '../styles/fileSelectStyles';
 
@@ -292,7 +293,7 @@ export class LatexDiffsSection extends LitElement {
   }
 
   private renderFileOptions(options: string[]): TemplateResult {
-    const sortedOptions = options.toSorted((a, b) => a.localeCompare(b));
+    const sortedOptions = options.toSorted(byString);
     return html`
       <wa-option value="">None</wa-option>
       ${repeat(

--- a/src/agent/workflowScript/runWorkflowScript.ts
+++ b/src/agent/workflowScript/runWorkflowScript.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 
 import stableStringify from 'fast-json-stable-stringify';
 import PQueue from 'p-queue';
+import pTimeout from 'p-timeout';
 import {
   WorkflowScriptFilesSchema,
   type WorkflowScriptFiles,
@@ -684,17 +685,10 @@ export async function runWorkflowScript(
       // past its timeout by more than the grace period; stragglers beyond
       // it are orphaned (their journal entries may be lost, which resume
       // treats as a retry).
-      let graceTimer: NodeJS.Timeout | undefined;
-      try {
-        await Promise.race([
-          Promise.allSettled([...pendingAgentCalls]),
-          new Promise<void>((resolve) => {
-            graceTimer = setTimeout(resolve, DRAIN_GRACE_MS);
-          }),
-        ]);
-      } finally {
-        if (graceTimer) clearTimeout(graceTimer);
-      }
+      await pTimeout(Promise.allSettled([...pendingAgentCalls]), {
+        milliseconds: DRAIN_GRACE_MS,
+        fallback: () => undefined,
+      });
     }
   }
 

--- a/src/common/teams/TeamPlan.ts
+++ b/src/common/teams/TeamPlan.ts
@@ -17,6 +17,7 @@ import {
   type AgentModePreset,
 } from '@shared/schemas/agentPresets';
 import type { TeamOptionData } from '@shared/schemas/mainView/state';
+import { capitalize } from '@utils/text/stringUtils';
 
 import {
   preflightTeamAvailability,
@@ -548,7 +549,7 @@ function presetAgentAvailability(
 
 function formatTeamOptionDisabledReason(reason: string): string {
   if (reason === 'no runnable team root') return 'No runnable team lead.';
-  return `${reason.charAt(0).toUpperCase()}${reason.slice(1)}.`;
+  return `${capitalize(reason)}.`;
 }
 
 function lookupKey(value: string): string {

--- a/src/test-kernel/agent/modelHandlers/AnthropicCacheBeta.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/AnthropicCacheBeta.vitest.ts
@@ -3,10 +3,10 @@ import { ModelProvider } from 'llm-zoo';
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports - agent model handlers
-import type { AgentTrace } from '@agent/trace';
 import { ModelHandlerAnthropic } from '@agent/modelHandlers/anthropic/modelHandlerAnthropic';
 import type { ToolDefinition } from '@model';
 import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
+import { spiedTrace } from '@test/support/spiedTrace';
 
 // Type imports
 import type Anthropic from '@anthropic-ai/sdk';
@@ -35,14 +35,7 @@ function createHandler(): ModelHandlerAnthropic {
     }),
   );
 
-  handler.setLogger({
-    streamId: 'test',
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    domain: vi.fn(),
-  } as unknown as AgentTrace);
+  handler.setLogger(spiedTrace());
   (handler as { getStreamingConfig: () => boolean }).getStreamingConfig = () =>
     false;
   return handler;

--- a/src/test-kernel/agent/modelHandlers/BackgroundRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/BackgroundRunLifecycle.vitest.ts
@@ -3,21 +3,14 @@ import { describe, expect, it, vi } from 'vitest';
 import type { AgentTrace } from '@agent/trace';
 import { BackgroundRunLifecycle } from '@agent/modelHandlers/openai/BackgroundRunLifecycle';
 import { BackgroundPoller } from '@agent/modelHandlers/support/BackgroundPoller';
+import { spiedTrace } from '@test/support/spiedTrace';
 
 import type OpenAI from 'openai';
 import type { Response } from 'openai/resources/responses/responses';
 
-function trace(): AgentTrace {
-  return {
-    debug: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    domain: vi.fn(),
-  } as unknown as AgentTrace;
-}
-
-function createLifecycle(logger: AgentTrace = trace()): BackgroundRunLifecycle {
+function createLifecycle(
+  logger: AgentTrace = spiedTrace(),
+): BackgroundRunLifecycle {
   return new BackgroundRunLifecycle({
     logger: () => logger,
     provider: 'openai',
@@ -190,7 +183,7 @@ describe('BackgroundRunLifecycle.waitForCompletion', () => {
       pollIntervalMs: 0,
       maxDurationMs: 1000,
       isPending: (r) => lifecycle.isPending(r),
-      logger: trace(),
+      logger: spiedTrace(),
     });
     const client = {
       responses: {

--- a/src/test-kernel/agent/modelHandlers/CodexEncryptedReasoning.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/CodexEncryptedReasoning.vitest.ts
@@ -1,24 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import { type ModelConfig, ModelProvider, ReasoningEffort } from 'llm-zoo';
 
-import type { AgentTrace } from '@agent/trace';
+import { noopTrace } from '@agent/trace';
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/openai/modelHandlerOpenAIResponse';
 import { ModelHandlerCodex } from '@agent/modelHandlers/openai/modelHandlerCodex';
 import { AgentCategory } from '@shared/schemas/agent';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 import type { Response } from 'openai/resources/responses/responses';
-
-function loggerStub(): AgentTrace {
-  return {
-    streamId: 'test',
-    debug: () => undefined,
-    info: () => undefined,
-    warn: () => undefined,
-    error: () => undefined,
-    domain: () => undefined,
-  } as unknown as AgentTrace;
-}
 
 function config(): ModelConfig {
   return buildTestModelConfig({
@@ -44,14 +33,14 @@ function config(): ModelConfig {
 
 function baseHandler(): ModelHandlerOpenAIResponse {
   const h = new ModelHandlerOpenAIResponse(config());
-  h.setLogger(loggerStub());
+  h.setLogger(noopTrace);
   return h;
 }
 
 function codexHandler(): ModelHandlerCodex {
   const h = new ModelHandlerCodex(config());
   h.setAgentCategory(AgentCategory.ToolUse);
-  h.setLogger(loggerStub());
+  h.setLogger(noopTrace);
   return h;
 }
 

--- a/src/test-kernel/agent/modelHandlers/OpenAIResponseBackgroundAbort.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIResponseBackgroundAbort.vitest.ts
@@ -4,12 +4,12 @@ import { ModelProvider } from 'llm-zoo';
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
-import type { AgentTrace } from '@agent/trace';
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/openai/modelHandlerOpenAIResponse';
 import { tagOpenAISdkError } from '@agent/modelHandlers/openai/openAISdkError';
 import { BackgroundPoller } from '@agent/modelHandlers/support/BackgroundPoller';
 import { isUserAbort } from '@common/errors/sdkErrorUtils';
 import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
+import { spiedTrace } from '@test/support/spiedTrace';
 
 // Third-party imports
 import type OpenAI from 'openai';
@@ -29,14 +29,7 @@ function createHandler(): ModelHandlerOpenAIResponse {
       openRouterOnly: false,
     }),
   );
-  handler.setLogger({
-    streamId: 'test',
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    domain: vi.fn(),
-  } as unknown as AgentTrace);
+  handler.setLogger(spiedTrace());
   return handler;
 }
 
@@ -127,13 +120,7 @@ describe('OpenAI Responses background abort handling', () => {
       pollIntervalMs: 1,
       maxDurationMs: 0,
       isPending: (response) => response.status === 'in_progress',
-      logger: {
-        debug: vi.fn(),
-        info: vi.fn(),
-        warn: vi.fn(),
-        error: vi.fn(),
-        domain: vi.fn(),
-      } as unknown as AgentTrace,
+      logger: spiedTrace(),
     });
 
     const thrown = await target

--- a/src/test-kernel/agent/modelHandlers/OpenAIResponseWebSocketTransport.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/OpenAIResponseWebSocketTransport.vitest.ts
@@ -6,11 +6,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { WebSocketError } from 'openai/resources/responses/internal-base';
 
 // Local imports
-import type { AgentTrace } from '@agent/trace';
 import { OpenAIResponseWebSocketTransport } from '@agent/modelHandlers/openai/OpenAIResponseWebSocketTransport';
 import type { ResponseStreamProcessor } from '@agent/modelHandlers/openai/ResponseStreamProcessor';
 import { normalizeProviderError } from '@common/errors';
 import { detectSdkErrorMetadata } from '@common/errors/sdkErrorUtils';
+import { spiedTrace } from '@test/support/spiedTrace';
 
 // Third-party type imports
 import type OpenAI from 'openai';
@@ -49,17 +49,6 @@ vi.mock('openai/resources/responses/ws', () => ({
   },
 }));
 
-function createLogger(): AgentTrace {
-  return {
-    streamId: 'test',
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    domain: vi.fn(),
-  } as unknown as AgentTrace;
-}
-
 interface TransportInternals {
   wsConnection: FakeResponsesWS | null;
   getOrCreateWebSocket(
@@ -85,7 +74,7 @@ function createTransport(): OpenAIResponseWebSocketTransport {
     process: vi.fn(),
   } as unknown as ResponseStreamProcessor;
   return new OpenAIResponseWebSocketTransport({
-    logger: createLogger(),
+    logger: spiedTrace(),
     createStreamProcessor: vi.fn(() => processor),
   });
 }

--- a/src/test-kernel/agent/output/CompileCheck.vitest.ts
+++ b/src/test-kernel/agent/output/CompileCheck.vitest.ts
@@ -5,7 +5,6 @@ import * as path from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports
-import type { AgentTrace } from '@agent/trace';
 import { runCompileCheck } from '@agent/output/compileCheck';
 import { createOutputState, ensureRoundData } from '@agent/output/outputState';
 import type { CompileLatex2PdfResult } from '@latex/texTools';
@@ -16,6 +15,7 @@ import type {
 } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { installPlatform } from '@test/support/setupPlatform';
+import { spiedTrace } from '@test/support/spiedTrace';
 import {
   TaskRunFileService,
   createRunStorageLocation,
@@ -87,15 +87,6 @@ function seedMainTexOutput(executionId: ExecutionId) {
   return outputState;
 }
 
-function logger(): AgentTrace {
-  return {
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  } as unknown as AgentTrace;
-}
-
 function initLatexPlatform(files: Record<string, string>): Promise<void> {
   return installPlatform({
     files,
@@ -128,7 +119,7 @@ describe('runCompileCheck', () => {
       {
         fileService: new TaskRunFileService(executionId),
         outputState,
-        logger: logger(),
+        logger: spiedTrace(),
         streamId: 'compile-stream',
       },
       0,
@@ -166,7 +157,7 @@ describe('runCompileCheck', () => {
       {
         fileService: new TaskRunFileService(executionId),
         outputState,
-        logger: logger(),
+        logger: spiedTrace(),
         streamId: 'compile-stream',
       },
       0,
@@ -204,7 +195,7 @@ describe('runCompileCheck', () => {
       {
         fileService: new TaskRunFileService(executionId),
         outputState,
-        logger: logger(),
+        logger: spiedTrace(),
         streamId: 'compile-stream',
       },
       0,
@@ -247,7 +238,7 @@ describe('runCompileCheck', () => {
       {
         fileService: new TaskRunFileService(executionId),
         outputState,
-        logger: logger(),
+        logger: spiedTrace(),
         streamId: 'compile-stream',
       },
       0,
@@ -281,7 +272,7 @@ describe('runCompileCheck', () => {
     const ctx = {
       fileService: new TaskRunFileService(executionId),
       outputState,
-      logger: logger(),
+      logger: spiedTrace(),
       streamId: 'compile-stream',
     };
 
@@ -326,7 +317,7 @@ describe('runCompileCheck', () => {
       {
         fileService: new TaskRunFileService(executionId),
         outputState,
-        logger: logger(),
+        logger: spiedTrace(),
         streamId: 'compile-stream',
       },
       0,
@@ -368,7 +359,7 @@ describe('runCompileCheck', () => {
       {
         fileService: new TaskRunFileService(executionId),
         outputState,
-        logger: logger(),
+        logger: spiedTrace(),
         streamId: 'compile-stream',
       },
       0,
@@ -416,7 +407,7 @@ describe('runCompileCheck', () => {
         {
           fileService: new TaskRunFileService(executionId),
           outputState,
-          logger: logger(),
+          logger: spiedTrace(),
           streamId: 'compile-stream',
         },
         0,

--- a/src/test-kernel/agent/output/LatexCompileInputDirs.vitest.ts
+++ b/src/test-kernel/agent/output/LatexCompileInputDirs.vitest.ts
@@ -5,7 +5,6 @@ import * as path from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports
-import type { AgentTrace } from '@agent/trace';
 import {
   AgentCategory,
   AgentWorkflowSettingSchema,
@@ -23,6 +22,7 @@ import type {
 } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
 import { installPlatform } from '@test/support/setupPlatform';
+import { spiedTrace } from '@test/support/spiedTrace';
 import {
   TaskRunFileService,
   createExternalLocation,
@@ -81,15 +81,6 @@ function outputFile(
   };
 }
 
-function logger(): AgentTrace {
-  return {
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  } as unknown as AgentTrace;
-}
-
 function initLatexPlatform(files: Record<string, string>): Promise<void> {
   return installPlatform({
     files,
@@ -142,7 +133,7 @@ describe('workflow LaTeX compile input directories', () => {
       {
         fileService: new TaskRunFileService(executionId),
         outputState,
-        logger: logger(),
+        logger: spiedTrace(),
         streamId: 'compile-stream',
       },
       1,
@@ -179,7 +170,7 @@ describe('workflow LaTeX compile input directories', () => {
         {
           fileService: new TaskRunFileService(executionId),
           outputState,
-          logger: logger(),
+          logger: spiedTrace(),
           streamId: 'compile-stream',
         },
         2,
@@ -263,7 +254,7 @@ describe('workflow LaTeX compile input directories', () => {
       }),
       () => ({}),
       [],
-      logger(),
+      spiedTrace(),
       'diff-stream',
       new TaskRunFileService(executionId),
     );
@@ -318,7 +309,7 @@ describe('workflow LaTeX compile input directories', () => {
       }),
       () => ({}),
       [],
-      logger(),
+      spiedTrace(),
       'diff-stream',
       new TaskRunFileService(executionId),
     );
@@ -353,7 +344,7 @@ describe('workflow LaTeX compile input directories', () => {
   it('keeps a successful diff when publishing its PDF fails', async () => {
     const executionId = 'latexdiff-publish-failure';
     await initLatexPlatform({});
-    const trace = logger();
+    const trace = spiedTrace();
     const manager = new LatexDiffManager(
       AgentWorkflowSettingSchema.parse({
         agentCategory: AgentCategory.Workflow,

--- a/src/test-kernel/latex/LatexProcessingHelpers.vitest.ts
+++ b/src/test-kernel/latex/LatexProcessingHelpers.vitest.ts
@@ -1,20 +1,11 @@
 // Node imports
-import {
-  lstat,
-  mkdir,
-  mkdtemp,
-  readlink,
-  realpath,
-  writeFile,
-} from 'node:fs/promises';
-import * as os from 'node:os';
+import { lstat, mkdir, readlink, realpath, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 
 // Third-party imports
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports
-import type { AgentTrace } from '@agent/trace';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import {
   LatexMediaManager,
@@ -27,7 +18,8 @@ import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 import type { FileLocation } from '@shared/schemas';
 import type { ToolConfig } from '@shared/schemas/toolConfig';
 import { installPlatform as installFakePlatform } from '@test/support/setupPlatform';
-import { cleanupTempDirs } from '@test/support/tempDirPlatform';
+import { spiedTrace } from '@test/support/spiedTrace';
+import { cleanupTempDirs, makeTempDir } from '@test/support/tempDirPlatform';
 import {
   createExternalLocation,
   createWorkspaceLocation,
@@ -68,20 +60,9 @@ const compilePdfConfig: ToolConfig = {
   autoCompileInputPdf: true,
 };
 
-const logger = {
-  debug: vi.fn(),
-  info: vi.fn(),
-  warn: vi.fn(),
-  error: vi.fn(),
-} as unknown as AgentTrace;
+const logger = spiedTrace();
 
 const tempDirs: string[] = [];
-
-async function makeTempDir(): Promise<string> {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'texra-latex-media-'));
-  tempDirs.push(tempDir);
-  return tempDir;
-}
 
 function installPlatform(workspaceDir: string): Promise<void> {
   return installFakePlatform(
@@ -143,7 +124,7 @@ describe('LatexMediaManager PDF compilation', () => {
   });
 
   it('filters nullish compile results before adding media files', async () => {
-    const workspaceDir = await makeTempDir();
+    const workspaceDir = await makeTempDir('texra-latex-media-', tempDirs);
     await installPlatform(workspaceDir);
 
     const inputPaths = [
@@ -220,7 +201,9 @@ describe('LatexMediaManager figure baseDir resolution (issue #7228)', () => {
     // workspace root and the realpath'd baseDir it computes would disagree,
     // and mirrorWorkspaceFile would (correctly, but confusingly for this test)
     // classify the figure as external and skip mirroring it.
-    const tempDir = await realpath(await makeTempDir());
+    const tempDir = await realpath(
+      await makeTempDir('texra-latex-media-', tempDirs),
+    );
     const workspaceDir = path.join(tempDir, 'workspace');
     const storageRoot = path.join(tempDir, 'storage');
     const figureDir = path.join(workspaceDir, 'figures');

--- a/src/test-kernel/support/spiedTrace.ts
+++ b/src/test-kernel/support/spiedTrace.ts
@@ -1,0 +1,21 @@
+import { vi } from 'vitest';
+
+import type { AgentTrace } from '@agent/trace';
+import { noopTrace } from '@agent/trace';
+
+/**
+ * `noopTrace` with `debug`/`info`/`warn`/`error`/`domain` replaced by
+ * `vi.fn()` spies, for tests that assert on trace calls. Pass `overrides`
+ * to spy on additional members or stub others.
+ */
+export function spiedTrace(overrides?: Partial<AgentTrace>): AgentTrace {
+  return {
+    ...noopTrace,
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    domain: vi.fn(),
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary

Scheduled sweep for consolidation opportunities: custom logic that duplicates an existing shared utility, and reimplementations of things a native/stdlib method already does. This repo already runs frequent cleanup passes (see recent `refactor:`/`simplify:` history), so most categories I checked — deep clone, dedup, retry/backoff, deep-equality, stable stringify, promise timeout, UUID generation, LRU caches — were already consolidated. This PR lands the few genuine new findings from that sweep:

- `runWorkflowScript`'s post-abort agent-call drain hand-rolled a `Promise.race` + `setTimeout`/`clearTimeout` timeout race. `p-timeout` is already a dependency and this exact "wait, but give up after N ms" shape is already used via its `fallback` option in `UsageLogService.dispose()`. Swapped to match.
- `TeamPlan.formatTeamOptionDisabledReason` inlined `str.charAt(0).toUpperCase() + str.slice(1)` — an exact duplicate of the existing `capitalize()` helper.
- `LatexDiffsSection`'s file-option sort inlined `(a, b) => a.localeCompare(b)` instead of the existing `byString` comparator.
- Eight vitest files each independently reauthored the same `{ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), domain: vi.fn() } as unknown as AgentTrace` object to spy on trace calls. Added `spiedTrace()` (`noopTrace` with those five members replaced by spies, plus an `overrides` param) and migrated the call sites.
- `LatexProcessingHelpers.vitest.ts` had its own `makeTempDir()` that was a verbatim duplicate of the already-exported `tempDirPlatform.makeTempDir()` — switched to the shared one.
- `CodexEncryptedReasoning.vitest.ts`'s logger stub had no assertions on it at all (no `vi.fn()`), so it's replaced with the existing `noopTrace` rather than a spy.

## Issue acceptance gates

No linked issue — this is a scheduled consolidation sweep. Acceptance gate: identify and fix duplicate logic / non-native reimplementations that clear a "worth the churn" bar (2+ occurrences or an exact match to an existing helper), verified by typecheck + lint + full test suite.

## Single source of truth

- Timeout-with-fallback races now go through `p-timeout` everywhere they occur (`UsageLogService`, `runWorkflowScript`).
- String capitalization goes through `capitalize()` (`src/utils/text/stringUtils.ts`).
- Alphabetic string sorting goes through `byString()` (`src/utils/core/index.ts`).
- Spied `AgentTrace` test doubles go through `spiedTrace()` (`src/test-kernel/support/spiedTrace.ts`), built on the existing `noopTrace`.
- Scratch temp-dir creation in `LatexProcessingHelpers.vitest.ts` goes through the existing `tempDirPlatform.makeTempDir()`.

## Duplication and abstraction budget

Removed: 4 duplicated/inlined logic sites (timeout race, capitalize, localeCompare sort, temp-dir helper) and 8 duplicated AgentTrace spy literals. Added one small abstraction, `spiedTrace()`, justified by 8 call sites across independent test files (clears the "multiple callers" bar in CLAUDE.md's factory-discipline rule). No pass-through layers added.

## Net elements (R6)

12 files changed, 68 insertions(+), 135 deletions(-) — net -67 lines. One new exported symbol: `spiedTrace` in the new `src/test-kernel/support/spiedTrace.ts` (test-only, not part of the app's `@agent/*` surface). No classes/interfaces/enums added or removed.

## Consumer counts (R8)

No emit path or existing export was deleted or re-routed — all changes are new consumers of pre-existing exports (`p-timeout`, `capitalize`, `byString`, `noopTrace`, `tempDirPlatform.makeTempDir`) plus one new test-only helper. n/a.

## Host impact

Extension: `LatexDiffsSection.ts` (webview frontend) sort behavior unchanged, just delegated to the shared comparator.

Desktop: none.

CLI: none.

## Scheduled refactoring

None — this was itself a scheduled sweep; no further follow-up identified.

## Validation

- `npm run typecheck` — passes across all packages (root, extension, cli, trace-viewer, desktop).
- `npm run lint` — clean (one import/order violation from the `TeamPlan.ts` edit was auto-fixed).
- `npm test` (full vitest suite, 7638 tests) — 7627 passed, 9 skipped, 2 failures. Both failures are pre-existing environment flakiness unrelated to this diff, confirmed by reproducing them identically on unmodified `main` in this sandbox: a QuickJS memory-exhaustion test with a hard 3s wall-clock assertion, and a process-group-abort test that depends on real OS process-group semantics. All 8 directly touched test files pass in isolation, as do `TeamPlan.vitest.ts`, `LatexDiffsSectionActions.vitest.mts`, and `WorkflowScriptEngine.vitest.ts` (minus the same pre-existing flake).


---
_Generated by [Claude Code](https://claude.ai/code/session_015ViKuqKopDK4tWYgJSVNj3)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactoring only—delegating to existing helpers and test utilities with equivalent semantics; workflow drain timeout and UI sort/capitalize behavior should be unchanged.
> 
> **Overview**
> This PR is a consolidation sweep: duplicate one-offs are replaced with existing shared utilities, and repeated test doubles are centralized.
> 
> **Production code** uses `p-timeout` with `fallback` for the bounded post-abort drain of in-flight `agent()` calls in `runWorkflowScript` (replacing a hand-rolled `Promise.race` + timer). Team option disabled reasons use shared `capitalize()` instead of inline first-character uppercasing. LaTeX diff file options sort via shared `byString` instead of an inline `localeCompare` comparator.
> 
> **Tests** add test-only `spiedTrace()` (`noopTrace` with `vi.fn()` on the five log methods) and migrate eight vitest files off duplicated `AgentTrace` spy literals; `CodexEncryptedReasoning` uses `noopTrace` where nothing asserts on logging. `LatexProcessingHelpers` uses shared `makeTempDir` from `tempDirPlatform` instead of a local copy.
> 
> Net effect is roughly **−67 lines** with no intended behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aeb78928bab7ffece1096c972f7761bdd0c540e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->