### PR TITLE
refactor(transcript): share clearMissingOutputs target resolution; make work-plan reads degrade loudly

### DIFF
--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -351,16 +351,7 @@ export class ProgressFactApplier {
   }
 
   public handleClearMissingOutputs(payload: ClearMissingOutputsPayload): void {
-    let targets: StreamTabId[];
-    if (payload.streamId) {
-      targets = [payload.streamId];
-    } else if (payload.streamConfig) {
-      targets = this.state.snapshots.findWorkflowStreamsMatching(
-        payload.streamConfig,
-      );
-    } else {
-      targets = [];
-    }
+    const targets = this.state.snapshots.resolveMissingOutputTargets(payload);
     for (const streamId of targets) {
       this.sendIfActive(streamId, () =>
         this.webviewUpdater.updateMissingOutputs(streamId, {

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { getExecutionStore } from '@agent/storage';
 import { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import { TaskStateSchema, type TaskState } from '@agent/core/state/TaskState';
+import * as logUtils from '@logger/logUtils';
 import type { Platform } from '@platform/platform';
 import { resolveRunStoragePath } from '@platform/defaults/workspaceStorage';
 import {
@@ -392,6 +393,30 @@ describe('StreamSnapshotStore', () => {
     expect(snap.todos).toEqual([]);
     expect(snap.plan).toBeNull();
     expect(snap.runUsage).toEqual({});
+  });
+
+  it('degrades a structurally unreadable work plan to empty LOUDLY (not via a silent .catch)', async () => {
+    const warnSpy = vi.spyOn(logUtils, 'warn').mockImplementation(() => {});
+    const dir = streamDataDir(STREAM);
+    await StorageFS.ensureDir(dir);
+    // A non-object top-level shape survives the `!raw` guard but fails the
+    // object parse — the exact corruption the old whole-object `.catch`
+    // swallowed without a trace.
+    await StorageFS.write(
+      path.join(dir, 'workPlan.json'),
+      JSON.stringify(['not', 'a', 'work plan']),
+    );
+
+    const snap = await new StreamSnapshotStore().read(STREAM);
+
+    expect(snap.todos).toEqual([]);
+    expect(snap.plan).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(
+      'StreamSnapshotStore',
+      expect.stringContaining('unreadable persisted work plan'),
+      expect.anything(),
+    );
+    warnSpy.mockRestore();
   });
 
   it('migrates the legacy nested {runId:{round}} shape to flat ONCE at the load entry', async () => {

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -492,12 +492,9 @@ export class StreamSnapshotStore {
         if (sessionEvent.scope !== 'session') return;
         switch (sessionEvent.event.type) {
           case 'clearMissingOutputs': {
-            const { streamId, streamConfig } = sessionEvent.event.payload;
-            let targets: StreamTabId[] = [];
-            if (streamId) targets = [streamId];
-            else if (streamConfig) {
-              targets = this.findWorkflowStreamsMatching(streamConfig);
-            }
+            const targets = this.resolveMissingOutputTargets(
+              sessionEvent.event.payload,
+            );
             for (const target of targets) this.clearMissingOutputs(target);
             return;
           }
@@ -1641,6 +1638,24 @@ export class StreamSnapshotStore {
       result.push(stream);
     }
     return result;
+  }
+
+  /**
+   * Resolve a `clearMissingOutputs` target descriptor to the stream tabs it
+   * affects: an explicit `streamId`, else every workflow tab matching
+   * `streamConfig`, else none. Shared by this store's own session-event handler
+   * and the progress-view `ProgressFactApplier` so the resolution rule lives in
+   * exactly one place.
+   */
+  resolveMissingOutputTargets(target: {
+    streamId?: StreamTabId;
+    streamConfig?: WorkflowStreamMatch;
+  }): StreamTabId[] {
+    if (target.streamId) return [target.streamId];
+    if (target.streamConfig) {
+      return this.findWorkflowStreamsMatching(target.streamConfig);
+    }
+    return [];
   }
 
   // ==========================================================================

--- a/src/transcript/streamSnapshotRead.ts
+++ b/src/transcript/streamSnapshotRead.ts
@@ -141,7 +141,11 @@ export async function readLegacyInstruction(
  * (returns empty) rather than coerced, so we never consume a future shape's
  * fields as v1 — this is the single forward-compat gate. Within a known
  * version, `PersistedWorkPlanSchema`'s per-field `.catch` keeps one corrupt
- * value from nuking the rest instead of throwing and aborting the read.
+ * value from nuking the rest. A structurally unreadable file (a non-object
+ * shape that survives the `!raw` guard) degrades to an empty plan LOUDLY —
+ * warned and diagnosable — rather than via a silent whole-object `.catch`
+ * default, matching the read-side degradation handling in
+ * {@link assembleSnapshot}.
  */
 function readPersistedWorkPlan(raw: unknown): WorkPlanSnapshot {
   if (!raw) return EMPTY_WORK_PLAN;
@@ -150,10 +154,16 @@ function readPersistedWorkPlan(raw: unknown): WorkPlanSnapshot {
       ? raw.schemaVersion
       : STREAM_SNAPSHOT_SCHEMA_VERSION;
   if (version > STREAM_SNAPSHOT_SCHEMA_VERSION) return EMPTY_WORK_PLAN;
-  return PersistedWorkPlanSchema.catch({
-    schemaVersion: STREAM_SNAPSHOT_SCHEMA_VERSION,
-    ...EMPTY_WORK_PLAN,
-  }).parse(raw);
+  const result = PersistedWorkPlanSchema.safeParse(raw);
+  if (!result.success) {
+    logger.warn(
+      CHANNEL,
+      'Discarding unreadable persisted work plan; using empty.',
+      { data: result.error },
+    );
+    return EMPTY_WORK_PLAN;
+  }
+  return result.data;
 }
 
 /** Read every per-stream sidecar file ONCE, flattening any legacy nested data. */


### PR DESCRIPTION
## Summary

Two small, related cleanups in the transcript/progress subsystem, surfaced by a tech-debt audit of the repo:

1. **Dedupe `clearMissingOutputs` target resolution.** The rule that maps a `clearMissingOutputs` payload to its affected stream tabs — explicit `streamId`, else every workflow tab matching `streamConfig`, else none — was copy-pasted in two places: `StreamSnapshotStore`'s own session-event handler and `ProgressFactApplier.handleClearMissingOutputs`. Both ultimately call `findWorkflowStreamsMatching` on the same `StreamSnapshotStore`. Extracted a single `StreamSnapshotStore.resolveMissingOutputTargets()` and routed both callers through it.

2. **Make persisted work-plan reads degrade loudly.** `readPersistedWorkPlan` wrapped the whole-object parse in a Zod `.catch(EMPTY_WORK_PLAN)`, which silently swallowed a structurally corrupt `workPlan.json` (todos/plan vanish, nothing logged) — the exact "silent degradation" the repo's design guardrails forbid. Replaced it with `safeParse` + a `logger.warn`, matching the read-side degradation handling already used by the sibling `assembleSnapshot()`. The **intentional** per-field `.catch` guards inside `PersistedWorkPlanSchema` (which keep one corrupt field from nuking the rest) are left untouched.

## Issue acceptance gates

No tracked issue — this is a proactive tech-debt cleanup. Self-imposed gates: (a) no behavior change for the dedup beyond call-site consolidation; (b) corrupt persisted work-plan now warns instead of silently emptying; both covered by tests below.

## Single source of truth

`StreamSnapshotStore.resolveMissingOutputTargets()` now owns the payload→target-tabs resolution rule for `clearMissingOutputs`. Loud read-side degradation of the persisted work plan lives in `readPersistedWorkPlan` (`streamSnapshotRead.ts`), consistent with `assembleSnapshot`.

## Duplication and abstraction budget

Removed one of two copies of the target-resolution block (~9 lines each) by extracting a method with **two** in-repo consumers (not a single-caller extraction). No pass-through layer added — the method contains the real branching logic that previously lived inline. The CLI's `applyClearMissingOutputs` (`packages/cli/.../subscribeRuntimeHost.ts`) deliberately keeps its own variant: it takes an **optional** narrow `Pick<StreamSnapshotStore, 'findWorkflowStreamsMatching'>` resolver that may be absent, so folding it into the full-store helper would add branching rather than remove it.

## Net elements (R6)

- Files: 4 changed, 0 added, 0 deleted.
- Module-level exported symbols: **0 net** (`^[+-]export` over the diff is empty). `resolveMissingOutputTargets` is a new public method on the already-exported `StreamSnapshotStore` class, with two consumers.
- Classes/interfaces/enums: 0 net.
- Net LoC: **+41** (+62 / -21), of which +25 is the new test.

## Consumer counts (R8)

No emit path or export was deleted or re-routed. `resolveMissingOutputTargets` consumers: 2 (`StreamSnapshotStore` session-event handler, `ProgressFactApplier.handleClearMissingOutputs`). `findWorkflowStreamsMatching` retains its remaining callers (CLI resolver + the new method). Otherwise: n/a.

## Host impact

Extension: progress-view fact application goes through the shared helper; work-plan corruption now warns. No API/wire change.

Desktop: same shared core; no host-specific change.

CLI: unaffected — keeps its own optional-resolver variant by design (see abstraction budget).

## Scheduled refactoring

None. Larger audit items (model-handler lifecycle dedup, the 3-way event-dispatcher registry, a loud `bestEffort` helper for silent catches) are out of scope for this focused PR.

## Validation

- `npm run typecheck` — clean.
- `npx eslint` on all changed files — clean.
- `npm run check:dead-code-ratchet` — OK (18 vs 18 baselined, no new unused exports).
- `npx vitest run src/test-kernel/transcript src/test-kernel/progressView src/test-kernel/controllers` — **871 tests pass**, including a new test asserting the corrupt-work-plan path warns and returns empty rather than swallowing silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V7mZwinm5D4fFKTRGEyMbP

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7mZwinm5D4fFKTRGEyMbP)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized refactor and read-path logging with no API or wire changes; behavior is intended to match prior resolution rules and empty-plan fallback.
> 
> **Overview**
> Consolidates **clearMissingOutputs** target resolution into `StreamSnapshotStore.resolveMissingOutputTargets()` and routes both the store’s session-event handler and `ProgressFactApplier.handleClearMissingOutputs` through it (explicit `streamId`, else workflow tabs matching `streamConfig`, else none). Behavior should be unchanged aside from removing duplicated branching.
> 
> **Persisted work-plan reads** in `readPersistedWorkPlan` no longer use a silent Zod whole-object `.catch` for structurally invalid `workPlan.json`; they use `safeParse` plus a `logger.warn` and still return an empty plan. Per-field `.catch` on `PersistedWorkPlanSchema` is unchanged. A new test covers the array-shaped corruption case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8865a3c6350fcd0251ea129dcef4b9b29788dd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->