### PR TITLE
refactor: remove two abstraction-boundary bypasses

### DIFF
--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -1,7 +1,5 @@
 /** Retry state management: Node retry config, error tracking, and retryable node base class. */
 
-import { StatusCodes } from 'http-status-codes';
-
 import { Node } from '@agent/node';
 import { logErrorData, logProgressStatus, type AgentTrace } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
@@ -14,6 +12,7 @@ import { SupabaseClient } from '@auth/SupabaseClient';
 import { normalizeProviderError } from '@common/errors';
 import {
   isProviderErrorAutoRetryable,
+  isUnauthorizedProviderError,
   isUserAbort,
 } from '@common/errors/sdkErrorUtils';
 import {
@@ -165,7 +164,7 @@ export abstract class RetryableInvocationNode<
       const retryFormatted = normalizeProviderError(retryErr);
       if (
         retryFormatted.isRelayError &&
-        retryFormatted.statusCode === StatusCodes.UNAUTHORIZED
+        isUnauthorizedProviderError(retryFormatted)
       ) {
         services.logger.debug(
           'Still 401 after token refresh, skipping auto-retries',
@@ -229,7 +228,7 @@ export abstract class RetryableInvocationNode<
       if (
         (formatted.isRelayError ||
           services.clientCredentialRoute === 'relay') &&
-        formatted.statusCode === StatusCodes.UNAUTHORIZED &&
+        isUnauthorizedProviderError(formatted) &&
         !this._hasAttemptedTokenRefresh
       ) {
         return this.attemptRelay401Recovery(err, operation, signal);

--- a/src/common/errors/sdkError/providerErrorFormat.ts
+++ b/src/common/errors/sdkError/providerErrorFormat.ts
@@ -637,7 +637,7 @@ export function isProviderErrorAutoRetryable(err: unknown): boolean {
   return (
     formatted.userRetryable &&
     formatted.exhaustionReason === undefined &&
-    formatted.statusCode !== StatusCodes.UNAUTHORIZED &&
+    !isUnauthorizedProviderError(formatted) &&
     formatted.statusCode !== StatusCodes.FORBIDDEN
   );
 }

--- a/src/common/errors/sdkError/providerErrorFormat.ts
+++ b/src/common/errors/sdkError/providerErrorFormat.ts
@@ -624,6 +624,11 @@ export function classifyWireRouteFailure(
   return { retryAfterMs: detectRetryAfterMs(chain) };
 }
 
+/** Whether a normalized provider error is a 401 (relay/auth token rejected). */
+export function isUnauthorizedProviderError(formatted: ProviderError): boolean {
+  return formatted.statusCode === StatusCodes.UNAUTHORIZED;
+}
+
 /** Whether repeating the same provider request can recover without user action. */
 export function isProviderErrorAutoRetryable(err: unknown): boolean {
   if (isUserAbort(err) || isContextWindowError(err)) return false;

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -42,6 +42,7 @@ export {
   formatProviderHttpError,
   normalizeProviderError,
   isProviderErrorAutoRetryable,
+  isUnauthorizedProviderError,
   isModelRateLimitFailure,
   isRelayProviderUnobservedFailure,
   isRelayRequestGateReachableFailure,

--- a/src/controllers/settingsView/ChatExportController.ts
+++ b/src/controllers/settingsView/ChatExportController.ts
@@ -30,7 +30,7 @@ import {
   injectStandaloneTrace,
   type AssembleTraceResult,
 } from '@transcript';
-import { StorageFS, pathToLocation } from '@utils/files';
+import { AbsoluteFS, StorageFS, pathToLocation } from '@utils/files';
 
 // ============================================================
 // Result types
@@ -171,14 +171,13 @@ export class ChatExportController {
     }
     const { trace } = traceResult;
 
-    const fsExtra = (await import('fs-extra')).default;
-    if (!(await fsExtra.pathExists(standaloneTemplatePath))) {
+    if (!(await AbsoluteFS.exists(standaloneTemplatePath))) {
       throw new Error(
         `Trace-viewer standalone bundle missing at ${standaloneTemplatePath} — ` +
           'rebuild the extension (npm run package:fast) so packages/trace-viewer builds.',
       );
     }
-    const template = await fsExtra.readFile(standaloneTemplatePath, 'utf8');
+    const template = await AbsoluteFS.read(standaloneTemplatePath);
     const html = injectStandaloneTrace(template, trace);
 
     const filename = generateExportFilename(


### PR DESCRIPTION
## Summary

Two small fixes surfaced by a scheduled abstraction-layer audit of the repo (checked against the layering rules in `CLAUDE.md`/`AGENTS.md`). The rest of the codebase came back clean — no VS Code imports in host-free zones, no raw `bus.emit` bypassing session ownership, `src/eventBus` scoped correctly, `src/shared`/`src/controllers` boundaries intact, no barrel or single-caller-factory violations.

1. `ChatExportController.exportAsHtml()` dynamically imported `fs-extra` to check/read the trace-viewer template, bypassing `platform().fs` even though the same method already writes its output through `StorageFS` two lines later. Now routes through `AbsoluteFS`, the same port `StorageFS` sits on.
2. `RetryState.ts` (`src/agent/core`, the host-agnostic domain model) imported `http-status-codes` directly and inlined two `StatusCodes.UNAUTHORIZED` checks for relay token-refresh recovery, duplicating the existing provider-error classification module (`isProviderErrorAutoRetryable`). Added `isUnauthorizedProviderError()` next to it so "what counts as a 401" lives in one place.

## Issue acceptance gates

n/a — self-initiated from a scheduled architecture audit, not tied to a filed issue.

## Single source of truth

- Filesystem access in `ChatExportController` now goes through `AbsoluteFS` exclusively (previously split between `AbsoluteFS`-backed `StorageFS` and a direct `fs-extra` import).
- 401/unauthorized classification for provider errors now lives in `src/common/errors/sdkError/providerErrorFormat.ts` (`isUnauthorizedProviderError`, alongside `isProviderErrorAutoRetryable`) instead of being duplicated inline in `RetryState.ts`.

## Duplication and abstraction budget

Removed duplication: two inline `StatusCodes.UNAUTHORIZED` comparisons in `RetryState.ts` collapsed into one shared predicate. No new layer or wrapper added — `isUnauthorizedProviderError` is a plain exported function co-located with the existing classifier it complements, re-exported through the pre-existing `@common/errors/sdkErrorUtils` barrel (already a documented public surface).

## Net elements (R6)

- Files changed: 4 (`+12/-8`)
- Exported symbols: `+1` (`isUnauthorizedProviderError`), `0` removed
- No new classes/interfaces/enums

## Consumer counts (R8)

n/a — no emit path or export was deleted or re-routed; only an inline duplicate check was replaced with an existing-style helper call at its 2 call sites.

## Host impact

Extension: `ChatExportController` is used by the Settings export flow; behavior unchanged, only the file-read path is now the module's standard one.

Desktop: none (module is host-neutral; no desktop-specific code touched).

CLI: none.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — clean (installed deps first; workspace `node_modules` wasn't present).
- `npx eslint` on all 4 changed files — clean.
- `npx vitest run` on the three relevant suites (`ChatExportController.vitest.ts`, `ChatExportControllerHtml.vitest.ts`, `RetryState.vitest.ts`) — 60/60 passed.
- `npm run check:dead-code-ratchet` — clean, no new unused exports.
- Full `npm test` was kicked off but did not finish within this session; the change is isolated to 4 files behind two narrow call sites, and the targeted suites plus typecheck/lint/ratchet checks above cover it.

---
_Generated by [Claude Code](https://claude.ai/code/session_013tPAetpAHNxsM5y1tmhbBn)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow refactors at existing call sites with equivalent checks and I/O paths; no auth or export behavior changes intended.
> 
> **Overview**
> Closes two layering audit findings without changing outward behavior.
> 
> **HTML export** — `exportAsHtml` no longer dynamically imports `fs-extra` for the trace-viewer template; existence and read go through **`AbsoluteFS`**, aligned with how the same flow already writes via **`StorageFS`**.
> 
> **Relay 401 handling** — **`RetryState`** drops a direct **`http-status-codes`** dependency and uses a shared **`isUnauthorizedProviderError`** helper for reactive token refresh and post-refresh failure detection. That predicate lives next to **`isProviderErrorAutoRetryable`** in provider error formatting and is re-exported from **`@common/errors/sdkErrorUtils`** so “counts as 401” stays in one place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11f7c271e72428249cbc7da9d23f3113d8d7d3ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->