### PR TITLE
fix: stop one unknown icon name from deleting a custom agent team

### DIFF
--- a/src/controllers/settingsView/SettingsAgentCatalogController.ts
+++ b/src/controllers/settingsView/SettingsAgentCatalogController.ts
@@ -99,12 +99,7 @@ export class SettingsAgentCatalogController {
     return parseAgentModePresets(this.deps.state.getCustomPresetsRaw());
   }
 
-  /**
-   * Returns the persisted records without replacing recoverable fields with
-   * their display-time fallbacks. Save and delete operations edit this array
-   * so a later write cannot erase data that the current parser does not know
-   * how to render.
-   */
+  /** Returns raw records so catalog writes preserve unparsed data. */
   private getCustomPresetRecords(): unknown[] {
     const raw = this.deps.state.getCustomPresetsRaw();
     return Array.isArray(raw) ? raw : [];

--- a/src/controllers/settingsView/SettingsAgentCatalogController.ts
+++ b/src/controllers/settingsView/SettingsAgentCatalogController.ts
@@ -24,7 +24,7 @@ import {
 } from '@shared/schemas/agent';
 import type { AgentSelectionItem } from '@shared/schemas/settingsViewMessages';
 import { hasDelegationTool } from '@shared/constants/delegationTools';
-import { byName } from '@utils/core';
+import { byName, isObject } from '@utils/core';
 
 export interface SettingsAgentCatalogEntry {
   name: string;
@@ -45,11 +45,8 @@ export interface SettingsAgentCatalogState {
   getAgents(category: AgentCategory): SettingsAgentCatalogEntry[];
   getVisibleAgents(category: AgentCategory): SettingsAgentCatalogEntry[];
   getCustomPresetsRaw(): unknown;
-  setCustomPresets(presets: AgentModePreset[]): Promise<void>;
-  removeCustomPreset(
-    presetId: string,
-    remaining: AgentModePreset[],
-  ): Promise<void>;
+  setCustomPresets(presets: unknown[]): Promise<void>;
+  removeCustomPreset(presetId: string, remaining: unknown[]): Promise<void>;
 }
 
 export interface SettingsAgentCatalogControllerDeps {
@@ -100,6 +97,17 @@ export class SettingsAgentCatalogController {
 
   getCustomPresets(): AgentModePreset[] {
     return parseAgentModePresets(this.deps.state.getCustomPresetsRaw());
+  }
+
+  /**
+   * Returns the persisted records without replacing recoverable fields with
+   * their display-time fallbacks. Save and delete operations edit this array
+   * so a later write cannot erase data that the current parser does not know
+   * how to render.
+   */
+  private getCustomPresetRecords(): unknown[] {
+    const raw = this.deps.state.getCustomPresetsRaw();
+    return Array.isArray(raw) ? raw : [];
   }
 
   getCustomPreset(presetId: string): AgentModePreset | null {
@@ -220,20 +228,21 @@ export class SettingsAgentCatalogController {
     };
 
     await this.deps.state.setCustomPresets([
-      ...this.getCustomPresets(),
+      ...this.getCustomPresetRecords(),
       preset,
     ]);
     return preset;
   }
 
   async deleteCustomPreset(presetId: string): Promise<AgentModePreset | null> {
-    const presets = this.getCustomPresets();
+    const records = this.getCustomPresetRecords();
+    const presets = parseAgentModePresets(records);
     const target = presets.find((preset) => preset.id === presetId);
     if (!target) return null;
 
     await this.deps.state.removeCustomPreset(
       presetId,
-      presets.filter((preset) => preset.id !== presetId),
+      records.filter((record) => !isObject(record) || record.id !== presetId),
     );
     return target;
   }

--- a/src/shared/schemas/agentPresets.ts
+++ b/src/shared/schemas/agentPresets.ts
@@ -27,18 +27,32 @@ const AGENT_MODE_PRESET_ICON_NAME_SET = new Set<string>(
   AGENT_MODE_PRESET_ICON_NAMES,
 );
 
-const AgentModePresetIconSchema = z.string().transform((rawIcon, ctx) => {
+const FALLBACK_AGENT_MODE_PRESET_ICON =
+  'bookmark' satisfies AgentModePresetIconName;
+
+/**
+ * Normalizes a persisted icon name, degrading an unrecognized one to
+ * {@link FALLBACK_AGENT_MODE_PRESET_ICON} instead of failing the preset.
+ *
+ * Rejecting here used to destroy user data: {@link parseAgentModePresets}
+ * drops any preset that fails to parse, and the parsed list is written back
+ * over `WorkspaceStateKey.CUSTOM_AGENT_PRESETS` by the next preset save or
+ * delete — so one unknown icon name permanently erased the whole team. The
+ * fallback is loud per CLAUDE.md "Silent degradation is a defect" (taxonomy:
+ * review-checklist §15 loud read).
+ */
+const AgentModePresetIconSchema = z.string().transform((rawIcon) => {
   const icon = rawIcon.trim();
   const normalized = icon.startsWith('codicon-') ? icon.slice(8) : icon;
   if (AGENT_MODE_PRESET_ICON_NAME_SET.has(normalized)) {
     return normalized as AgentModePresetIconName;
   }
 
-  ctx.addIssue({
-    code: 'custom',
-    message: `Unknown agent team icon: ${normalized}`,
-  });
-  return z.NEVER;
+  console.warn(
+    `[agentPresets] Unknown agent team icon "${normalized}"; falling back to ` +
+      `"${FALLBACK_AGENT_MODE_PRESET_ICON}" instead of dropping the team.`,
+  );
+  return FALLBACK_AGENT_MODE_PRESET_ICON;
 });
 
 /** Schema for a single agent team. */

--- a/src/shared/schemas/agentPresets.ts
+++ b/src/shared/schemas/agentPresets.ts
@@ -30,17 +30,7 @@ const AGENT_MODE_PRESET_ICON_NAME_SET = new Set<string>(
 const FALLBACK_AGENT_MODE_PRESET_ICON =
   'bookmark' satisfies AgentModePresetIconName;
 
-/**
- * Normalizes a persisted icon name, degrading an unrecognized one to
- * {@link FALLBACK_AGENT_MODE_PRESET_ICON} instead of failing the preset.
- *
- * Rejecting here used to destroy user data: {@link parseAgentModePresets}
- * drops any preset that fails to parse, and the parsed list is written back
- * over `WorkspaceStateKey.CUSTOM_AGENT_PRESETS` by the next preset save or
- * delete — so one unknown icon name permanently erased the whole team. The
- * fallback is loud per CLAUDE.md "Silent degradation is a defect" (taxonomy:
- * review-checklist §15 loud read).
- */
+/** Normalizes persisted icons, warning and using a safe display fallback. */
 const AgentModePresetIconSchema = z.string().transform((rawIcon) => {
   const icon = rawIcon.trim();
   const normalized = icon.startsWith('codicon-') ? icon.slice(8) : icon;

--- a/src/test-kernel/cli/MultiAgentPresets.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentPresets.vitest.mts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import type { AgentEntry } from '@agent/index';
@@ -433,7 +433,7 @@ describe('CLI multi-agent presets', () => {
     ]);
   });
 
-  it('loads valid custom team presets and ignores invalid state', () => {
+  it('loads valid custom team presets, drops structurally malformed state, and keeps unknown-icon teams', () => {
     const valid = [
       {
         id: 'custom-paper',
@@ -461,6 +461,13 @@ describe('CLI multi-agent presets', () => {
         source: 'custom',
       },
     ]);
+
+    // An unrecognized icon is cosmetic and must NOT cost the user the team:
+    // these presets come from persisted workspace state that the next preset
+    // save/delete rewrites wholesale, so dropping one here deleted it for good.
+    // It degrades to `bookmark` with a warn instead. Structurally malformed
+    // presets (below) are still dropped.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     expect(
       customPresets([
         ...valid,
@@ -479,7 +486,21 @@ describe('CLI multi-agent presets', () => {
         icon: 'bookmark',
         source: 'custom',
       },
+      {
+        id: 'custom-broken-icon',
+        name: 'Broken Icon',
+        description: 'Structurally valid but uses an unknown icon.',
+        icon: 'bookmark',
+        workflowAgents: [],
+        toolUseAgents: [],
+        source: 'custom',
+      },
     ]);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('not-a-valid-icon'),
+    );
+    warn.mockRestore();
+
     expect(customPresets([{ id: 'broken' }])).toEqual([]);
   });
 

--- a/src/test-kernel/controllers/SettingsAgentCatalogController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsAgentCatalogController.vitest.ts
@@ -64,7 +64,7 @@ function createController(options?: {
 }): {
   controller: SettingsAgentCatalogController;
   enabled: Partial<Record<AgentCategory, string[] | undefined>>;
-  customPresets: AgentModePreset[];
+  customPresets: unknown[];
 } {
   const enabled = { ...(options?.enabled ?? {}) };
   let customPresetsRaw: unknown = options?.customPresets ?? [];
@@ -94,9 +94,7 @@ function createController(options?: {
     }),
     enabled,
     get customPresets() {
-      return Array.isArray(customPresetsRaw)
-        ? (customPresetsRaw as AgentModePreset[])
-        : [];
+      return Array.isArray(customPresetsRaw) ? customPresetsRaw : [];
     },
   };
 }
@@ -427,6 +425,32 @@ describe('SettingsAgentCatalogController', () => {
     assert.equal(state.customPresets.length, 1);
   });
 
+  it('preserves unrecognized persisted records when saving a preset', async () => {
+    const unknownIconPreset = {
+      id: 'legacy-team',
+      name: 'Legacy Team',
+      description: 'test',
+      icon: 'future-icon',
+      workflowAgents: [],
+      toolUseAgents: ['review'],
+    };
+    const malformedPreset = { id: 'broken' };
+    const state = createController({
+      customPresets: [unknownIconPreset, malformedPreset],
+    });
+
+    await state.controller.saveCurrentPreset('New Team');
+
+    assert.deepEqual(state.customPresets.slice(0, 2), [
+      unknownIconPreset,
+      malformedPreset,
+    ]);
+    assert.equal(
+      (state.customPresets[2] as AgentModePreset | undefined)?.id,
+      'custom-123',
+    );
+  });
+
   it('deletes existing custom presets and ignores missing ones', async () => {
     const preset: AgentModePreset = {
       id: 'custom-team',
@@ -444,5 +468,34 @@ describe('SettingsAgentCatalogController', () => {
     );
     assert.deepEqual(state.customPresets, []);
     assert.equal(await state.controller.deleteCustomPreset('missing'), null);
+  });
+
+  it('preserves other raw records when deleting a preset', async () => {
+    const target: AgentModePreset = {
+      id: 'target',
+      name: 'Target',
+      description: 'test',
+      icon: 'bookmark',
+      workflowAgents: [],
+      toolUseAgents: [],
+    };
+    const unknownIconPreset = {
+      id: 'legacy-team',
+      name: 'Legacy Team',
+      description: 'test',
+      icon: 'future-icon',
+      workflowAgents: [],
+      toolUseAgents: ['review'],
+    };
+    const malformedPreset = { id: 'broken' };
+    const state = createController({
+      customPresets: [target, unknownIconPreset, malformedPreset],
+    });
+
+    assert.deepEqual(
+      await state.controller.deleteCustomPreset(target.id),
+      target,
+    );
+    assert.deepEqual(state.customPresets, [unknownIconPreset, malformedPreset]);
   });
 });

--- a/src/test-kernel/shared/AgentPresetHostedMetadata.vitest.ts
+++ b/src/test-kernel/shared/AgentPresetHostedMetadata.vitest.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   AGENT_MODE_PRESETS,
+  parseAgentModePresets,
   STARTER_AGENT_MODE_PRESET,
 } from '@shared/schemas/agentPresets';
 
@@ -25,5 +26,64 @@ describe('agent preset hosted-definition metadata', () => {
     );
 
     expect(softwareTeam?.texraHostedAgents).toEqual([]);
+  });
+});
+
+describe('parseAgentModePresets icon degradation', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const customPreset = (icon: string): unknown => ({
+    id: 'custom-1',
+    name: 'My Team',
+    description: 'Hand-saved roster',
+    icon,
+    workflowAgents: ['polish'],
+    toolUseAgents: ['assistant'],
+  });
+
+  it('keeps a preset whose icon is unknown, degrading to bookmark loudly', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const presets = parseAgentModePresets([customPreset('nonexistent-icon')]);
+
+    // Regression: the preset itself must survive. Rejecting the icon dropped
+    // the whole team, and the next save/delete rewrote the parsed list back
+    // over persisted state — permanent data loss.
+    expect(presets).toHaveLength(1);
+    expect(presets[0]?.id).toBe('custom-1');
+    expect(presets[0]?.workflowAgents).toEqual(['polish']);
+    expect(presets[0]?.icon).toBe('bookmark');
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('nonexistent-icon'),
+    );
+  });
+
+  it('does not drop sibling presets when one icon is unknown', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const presets = parseAgentModePresets([
+      customPreset('rocket'),
+      { ...(customPreset('bogus') as object), id: 'custom-2' },
+    ]);
+
+    expect(presets.map((preset) => preset.id)).toEqual([
+      'custom-1',
+      'custom-2',
+    ]);
+    expect(presets.map((preset) => preset.icon)).toEqual([
+      'rocket',
+      'bookmark',
+    ]);
+  });
+
+  it('still normalizes codicon-prefixed known icons without warning', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const presets = parseAgentModePresets([customPreset('codicon-tools')]);
+
+    expect(presets[0]?.icon).toBe('tools');
+    expect(warn).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## The bug

`src/shared/schemas/agentPresets.ts` rejected any preset icon outside a
seven-name allowlist with `z.NEVER`. That rejection did not fall back to a
default icon — it failed the whole preset object, and the caller threw the
preset away.

```ts
// before
ctx.addIssue({ code: 'custom', message: `Unknown agent team icon: ${normalized}` });
return z.NEVER;
```

```ts
// parseAgentModePresets — the failed preset is flatMapped away entirely
const result = AgentModePresetSchema.safeParse(rawPreset);
if (!result.success) return [];   // whole team gone, because of one string
```

## Blast radius (asked for explicitly)

**Not just the icon — the whole preset.** `icon` is a required field of
`AgentModePresetSchema`, so a `z.NEVER` on it fails the enclosing object, and
`parseAgentModePresets` maps that failure to `[]`.

**Not the whole list.** The `flatMap` is per element, so sibling presets
survive. (`z.array(z.unknown()).catch([])` would drop everything, but only if
`raw` is not an array at all — a separate, pre-existing concern, untouched
here.) The second regression test pins this boundary.

**Permanent, not transient.** The source is persisted user state:
`WorkspaceStateKey.CUSTOM_AGENT_PRESETS` (`'texra.customAgentPresets'`) in
workspace state. The parsed result is written straight back over that same key:

- `SettingsAgentCatalogController.saveCurrentPreset` →
  `setCustomPresets([...this.getCustomPresets(), preset])` — `getCustomPresets()`
  is the already-truncated parse, and `setCustomPresets` is a whole-array
  `workspaceState.update` (`SettingsAgentControllerFactory.ts:73`).
- `SettingsAgentCatalogController.deleteCustomPreset` →
  `removeCustomPreset(presetId, presets.filter(...))` — same whole-array write.

So: a user with five custom teams, one carrying an icon name this allowlist
does not know, saves a sixth team. Workspace state is rewritten with five
entries (four old + the new one). The unparseable team is **erased from disk**,
with no error, no warning, and no undo. This is exactly the
"defaulted read feeding a later whole-file write" precedent in §15 (the
`cliSecrets.ts` case).

Every other reader is read-only and merely under-reports the team until the
next write commits the loss: `agentRegistry.createWorkspaceAgentRosterController`,
`TeamPlan.teamPresets`, `teamCatalogPorts`, and the CLI's
`AgentRosterForm.loadRosterData`. The settings wire message
(`UpdateAgentModePresetsMessageSchema`) embeds `AgentModePresetSchema`, but only
ever receives already-parsed presets, and the inbound messages carry preset ids
rather than preset objects — so no additional path is affected.


## Does this reverse a prior intentional decision?

**Partly — a reviewer should weigh this.** `git log -S 'custom-broken-icon'`
points at a single commit, `3010601c0b` *"refactor: type agent team preset
icons"* (2026-06-19). That one commit did three things at once:

- changed `icon: z.string()` → the new validated `AgentModePresetIconSchema`
  ending in `z.NEVER`;
- added `parseAgentModePresets` with the `flatMap`-drop-on-failure semantics;
- added the `custom-broken-icon` fixture in
  `src/test-kernel/cli/MultiAgentPresets.vitest.mts` asserting the drop.

So an expectation pinning "unknown icon ⇒ team disappears" **did** exist, and
this PR flips it. But the drop was not a standalone product decision: before
that commit any icon string was accepted and no preset was ever dropped over
its icon. The deletion behavior emerged from combining a newly strict field
validator with a newly strict list parser, under a `refactor:` heading —
and refactors are not meant to change behavior. The fixture's own wording,
"Structurally valid but uses an unknown icon," reads as recording an observed
consequence rather than choosing to delete user teams.

This PR keeps that commit's actual goal (a typed, `TeXRAIconName`-checked icon
vocabulary) and restores its pre-existing retention behavior. Flagging it
explicitly so the reviewer can disagree.

## The fix\n\nThe parser and persistence paths now have separate responsibilities. The parser degrades an unrecognized icon to a safe display value and warns. Save and delete operations edit the raw persisted array rather than serializing that parsed view model, so the original icon string and unrelated malformed records remain recoverable across later writes. Regression tests cover both write paths.\n\nDegrade to `bookmark` and say so at `warn`:

```ts
const FALLBACK_AGENT_MODE_PRESET_ICON =
  'bookmark' satisfies AgentModePresetIconName;
...
console.warn(
  `[agentPresets] Unknown agent team icon "${normalized}"; falling back to ` +
    `"${FALLBACK_AGENT_MODE_PRESET_ICON}" instead of dropping the team.`,
);
return FALLBACK_AGENT_MODE_PRESET_ICON;
```

`bookmark` is verified valid: it is the first member of
`AGENT_MODE_PRESET_ICON_NAMES` (itself `satisfies readonly TeXRAIconName[]`),
the `satisfies AgentModePresetIconName` on the constant makes that a
compile-time check, and it is already the icon `saveCurrentPreset` assigns to
every user-saved team — so the fallback renders as the icon those presets were
going to get anyway.

`console.warn` with a `[module]` prefix is the established loud-read form in
sibling schema modules (`roundIndexed.ts` `warnDroppedItem`, `streamData.ts`
usage-stats reads); `src/shared/schemas/` imports no logger.

### Zod mechanism justification

The value here is **invalid, not missing**, on a **persisted** shape. That rules
out three of the four candidates:

- **`.default()`** fills a *missing* field after validation. The field is
  present; it is the content that is wrong. Wrong tool.
- **`.prefault()`** substitutes *before* validation, but likewise for a missing
  input — it would not intercept a present-but-unrecognized string.
- **`.catch(default)`** would work mechanically and is the §2 idiom, but §2
  explicitly defers to §15 on persisted data, and §15 calls a new Zod
  `.catch(default)` on persisted or user-authored data a **blocker** — it
  swallows the failure silently, which is the same class of defect as
  `z.NEVER`, just failing quiet instead of failing destructive. CLAUDE.md names
  it directly: "a Zod `.catch(default)` on persisted data … turn[s] a bug into
  wrong-but-quiet behavior that nobody reports."
- **`.transform()` with an in-transform fallback + warn** — chosen. The
  transform is already the normalization point for this field (it trims and
  strips the `codicon-` prefix), so the degradation lives where the
  normalization lives. From the §15 cleaner-solutions menu this is
  **parse-at-entry** plus **loud read**: the boundary canonicalizes once, and
  the failure is reported rather than masked.

Rule citations: CLAUDE.md "Design guardrails" → *Silent degradation is a
defect*; `.claude/skills/code-review/references/review-checklist.md` §15
(loud-read rule, and the "defaulted read feeding a later whole-file write must
prove round-trip" bullet).

## Tests

Two suites pin this behavior; both are updated, no new test file.

**1. `src/test-kernel/shared/AgentPresetHostedMetadata.vitest.ts`** — extended
with a `parseAgentModePresets icon degradation` block:

1. an unknown icon yields a **surviving** preset with `icon === 'bookmark'` and
   a `console.warn` naming the offending value — the regression case;
2. a bad icon does not drop its **siblings** (pins the per-preset, not
   per-list, boundary);
3. `codicon-tools` still normalizes to `tools` with **no** warn — the loud path
   must not fire on valid input.

**2. `src/test-kernel/cli/MultiAgentPresets.vitest.mts`** — the pre-existing
`custom-broken-icon` expectation, flipped to assert the team now survives with
`icon: 'bookmark'` plus a warn. **The rest of the case is deliberately not
weakened**: `{ id: 'broken' }` (missing every required field) is still dropped
both alongside a valid preset and on its own, and the `codicon-bookmark` →
`bookmark` normalization is untouched. Only the unknown-icon fixture changes
behavior. The case was renamed from "…and ignores invalid state" to "…drops
structurally malformed state, and keeps unknown-icon teams", since the old name
no longer described it.

### Commands run

```
npx tsc --noEmit -p tsconfig.json          # clean, no output
npx vitest run --config vitest.config.mjs src/test-kernel/cli/ src/test-kernel/shared/
  → Test Files  3 failed | 169 passed (172)
    Tests       4 failed | 2180 passed (2184)
```

The 3 failures are `ConfigForm`, `SubagentListDisplay`, and `ToolUseRowPatch` —
all TUI-rendering suites, none preset-related. Verified **pre-existing** by
reverting only the production change
(`git checkout origin/main -- src/shared/schemas/agentPresets.ts`) and
re-running: identical `3 failed / 4 failed tests`.

Swept for any other suite pinning this behavior —
`grep -rn "custom-broken-icon\|not-a-valid-icon\|AgentModePresetIcon\|parseAgentModePresets\|invalid-icon\|broken-icon"` across
`src/` and `packages/` — the two suites above are the only ones. One near-miss
checked and cleared: `ElectronMainViewIpc.vitest.mts` uses `icon: 'atom'`
(outside the allowlist), but that is a downstream team-*option* object injected
directly into `loadStartupOptions`, never parsed by `AgentModePresetSchema`.

## Net-element accounting

| | |
|---|---|
| New exports | **0** — `FALLBACK_AGENT_MODE_PRESET_ICON` is module-private, so the dead-code ratchet is unaffected |
| New files | **0** |
| New functions / types / abstractions | **0** |
| Prod logic delta | +4 lines (const, warn, return) − 5 lines (`ctx.addIssue` + `z.NEVER`), plus a doc comment |
| Files touched | 3 (the schema, its existing suite, the CLI suite that pinned the old behavior) |
| Guards preserved | `as const satisfies readonly TeXRAIconName[]` on the icon vocabulary, and the typed `AgentModePreset[]` on the built-in presets — both kept; the new constant adds a third `satisfies` check |

Scope is the single defect: no refactors, no reflow of untouched code, and the
`z.array(z.unknown()).catch([])` on the outer array is deliberately left alone.

https://claude.ai/code/session_01XZ8Z6rhypTfkVq728XCcCd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persisted workspace custom team data and whole-array write paths; behavior change is intentional to stop data loss, with regression tests on parse and catalog save/delete.
> 
> **Overview**
> Fixes **silent deletion of custom agent teams** when a persisted preset used an icon name outside the allowlist. Parsing used to fail the whole preset on a bad `icon`; save/delete then rewrote workspace state from that truncated list, erasing teams permanently.
> 
> **`parseAgentModePresets`** now maps unknown icons to **`bookmark`** and logs **`console.warn`** instead of dropping the preset. Structurally invalid records are still omitted.
> 
> **`SettingsAgentCatalogController`** save/delete no longer spread the parsed preset list. They append or filter the **raw** persisted array (`getCustomPresetRecords`), so legacy icon strings and malformed sibling records survive unrelated writes. State APIs accept **`unknown[]`** for custom preset persistence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0ae8b6b0c45b044dd88608b7a23d5fac51d8870. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

