### PR TITLE
refactor(progressView): route hand-rolled wa-icon markup through waIcon()

### DIFF
--- a/packages/extension/src/progressView/frontend/components/ContextManagement.ts
+++ b/packages/extension/src/progressView/frontend/components/ContextManagement.ts
@@ -12,21 +12,21 @@ import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 
 // Local imports - shared styles
 import { designTokens, commonViewStyles } from '@shared/styles';
-import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+import { waIcon, type TeXRAIconName } from '@shared/wa/webAwesomeIcons';
 
 // Local imports - progress view helpers
 import { buildDetailsSummary } from '../formatters/htmlBuilders';
 
 /** Stat item to display */
 export interface StatItem {
-  icon: string;
+  icon: TeXRAIconName;
   label: string;
   value: string;
 }
 
 /** Action configuration */
 export interface ActionConfig {
-  icon: string;
+  icon: TeXRAIconName;
   label: string;
   color: string;
 }
@@ -141,12 +141,7 @@ export class ContextManagement extends LitElement {
             (item) => item.label,
             (item, index) => html`
               <span id="context-stat-${index}" class="stat-item">
-                <wa-icon
-                  library=${TEXRA_ICON_LIBRARY}
-                  name=${item.icon}
-                  aria-hidden="true"
-                ></wa-icon>
-                ${item.value}
+                ${waIcon(item.icon)} ${item.value}
               </span>
               <wa-tooltip for="context-stat-${index}">${item.label}</wa-tooltip>
             `,
@@ -156,12 +151,7 @@ export class ContextManagement extends LitElement {
               ? html`
                   <div class="summary-block">
                     <div class="summary-title">
-                      <wa-icon
-                        library=${TEXRA_ICON_LIBRARY}
-                        name="note"
-                        aria-hidden="true"
-                      ></wa-icon>
-                      Compaction summary
+                      ${waIcon('note')} Compaction summary
                     </div>
                     <pre class="summary-text">${this.summary}</pre>
                   </div>

--- a/packages/extension/src/progressView/frontend/formatters/constants.ts
+++ b/packages/extension/src/progressView/frontend/formatters/constants.ts
@@ -132,7 +132,7 @@ export const TOOL_LABEL_MAP: Record<string, string> = {
  * Maps tool names to wa-icon names (codicon-style aliases supported via the
  * shared TeXRA icon library).
  */
-export const TOOL_ICON_MAP: Record<string, string> = {
+export const TOOL_ICON_MAP: Record<string, TeXRAIconName> = {
   // File operations
   read_file: 'file',
   write_file: 'new-file',

--- a/packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts
+++ b/packages/extension/src/progressView/frontend/formatters/htmlBuilders.ts
@@ -18,7 +18,7 @@ import type { FileListEntry } from '@shared/schemas';
 import { hljs } from '@shared/highlighting/hljs';
 
 // Local imports - shared utilities
-import { TEXRA_ICON_LIBRARY, waIcon } from '@shared/wa/webAwesomeIcons';
+import { waIcon, type TeXRAIconName } from '@shared/wa/webAwesomeIcons';
 import { getBasename } from '@utils/core';
 
 // Local imports - formatter helpers
@@ -140,7 +140,7 @@ export const SPINNER_ICON_NAME = '__spinner__';
 /** Options for building a details summary header. */
 export interface DetailsSummaryOptions {
   /** wa-icon name (codicon-style aliases supported), or {@link SPINNER_ICON_NAME}. */
-  iconName: string;
+  iconName: TeXRAIconName | typeof SPINNER_ICON_NAME;
   label: string;
   labelClass?: string;
   timestamp?: { display: string; tooltip: string };
@@ -170,10 +170,10 @@ export function buildDetailsSummary(
     copyButton,
     extraContent,
   } = options;
-  // prettier-ignore
-  const iconTemplate = iconName === SPINNER_ICON_NAME
-    ? html`<wa-spinner class="icon"></wa-spinner>`
-    : html`<wa-icon library=${TEXRA_ICON_LIBRARY} name=${iconName} class="icon" aria-hidden="true"></wa-icon>`;
+  const iconTemplate =
+    iconName === SPINNER_ICON_NAME
+      ? html`<wa-spinner class="icon"></wa-spinner>`
+      : waIcon(iconName, { className: 'icon' });
   // prettier-ignore
   const timestampTemplate = timestamp
     ? html` <span class="timestamp" title=${timestamp.tooltip}>${timestamp.display}</span>`
@@ -204,7 +204,7 @@ export function buildFileListRender(files: FileListEntry[]): {
     const sourceText = file.sourceDisplay ?? source;
 
     // prettier-ignore
-    return html`<li class="detail-item" title=${filePath}><wa-icon library=${TEXRA_ICON_LIBRARY} name=${iconName} aria-hidden="true"></wa-icon> <span class="file-link clickable-link" data-file=${filePath} role="button" tabindex="0">${fileName}</span>${file.varName ? html` <span class="file-var">[${file.varName}]</span>` : ''}${showSource ? html` <span class="file-source">(${sourceText})</span>` : ''}</li>`;
+    return html`<li class="detail-item" title=${filePath}>${waIcon(iconName)} <span class="file-link clickable-link" data-file=${filePath} role="button" tabindex="0">${fileName}</span>${file.varName ? html` <span class="file-var">[${file.varName}]</span>` : ''}${showSource ? html` <span class="file-source">(${sourceText})</span>` : ''}</li>`;
   })}`;
 
   const loadedFiles = files.filter((file) => file.ok).length;
@@ -216,7 +216,10 @@ export function buildFileListRender(files: FileListEntry[]): {
 }
 
 /** Get appropriate wa-icon name for a tool. */
-export function getToolIconName(toolName: string, isError = false): string {
+export function getToolIconName(
+  toolName: string,
+  isError = false,
+): TeXRAIconName {
   if (isError) return 'error';
   return TOOL_ICON_MAP[toolName] ?? 'wrench';
 }
@@ -284,7 +287,7 @@ export function buildCodeBlock(
   // prettier-ignore
   const languageBadge = showLanguage ? html`<span class="code-block-language">${getLanguageLabel(language)}</span>` : nothing;
   // prettier-ignore
-  const copyButton = showCopy ? html`<wa-button class="code-block-copy" appearance="plain" variant="neutral" size="small" type="button" title="Copy to clipboard" aria-label="Copy to clipboard" data-copy-id=${registerCopyContent(text)} data-copy-type="code-block"><wa-icon library=${TEXRA_ICON_LIBRARY} name="copy" aria-hidden="true"></wa-icon></wa-button>` : nothing;
+  const copyButton = showCopy ? html`<wa-button class="code-block-copy" appearance="plain" variant="neutral" size="small" type="button" title="Copy to clipboard" aria-label="Copy to clipboard" data-copy-id=${registerCopyContent(text)} data-copy-type="code-block">${waIcon('copy')}</wa-button>` : nothing;
   // prettier-ignore
   const codeTemplate = html`<pre class=${classMap(preClasses)}><code>${isHighlighted ? unsafeHTML(highlighted) : text}</code></pre>`;
   // prettier-ignore
@@ -310,7 +313,7 @@ export function buildFileLinkWithLines(
   const displayText = fileName + lineInfo;
 
   // prettier-ignore
-  return html`<span class="file-link clickable-link" data-file=${filePath} data-file-line=${ifDefined(startLine)} role="button" tabindex="0"><wa-icon library=${TEXRA_ICON_LIBRARY} name="file" aria-hidden="true"></wa-icon> ${displayText}</span>`;
+  return html`<span class="file-link clickable-link" data-file=${filePath} data-file-line=${ifDefined(startLine)} role="button" tabindex="0">${waIcon('file')} ${displayText}</span>`;
 }
 
 // ============================================================================
@@ -324,7 +327,7 @@ export function buildMemoryPathDisplay(
   if (!memoryPath) return nothing;
   const fileName = getBasename(memoryPath) || memoryPath;
   // prettier-ignore
-  return html`<span class="memory-path"><wa-icon library=${TEXRA_ICON_LIBRARY} name="database" aria-hidden="true"></wa-icon> ${fileName} <span class="file-source">(${memoryPath})</span></span>`;
+  return html`<span class="memory-path">${waIcon('database')} ${fileName} <span class="file-source">(${memoryPath})</span></span>`;
 }
 
 // ============================================================================
@@ -337,7 +340,7 @@ export function buildExecutionsPathDisplay(
 ): TemplateResult | typeof nothing {
   if (!execPath) return nothing;
   // prettier-ignore
-  return html`<span class="memory-path"><wa-icon library=${TEXRA_ICON_LIBRARY} name="history" aria-hidden="true"></wa-icon> ${execPath}</span>`;
+  return html`<span class="memory-path">${waIcon('history')} ${execPath}</span>`;
 }
 
 // ============================================================================

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/bannerFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/bannerFormatters.ts
@@ -17,6 +17,7 @@ import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 
 // Local imports - shared schemas
 import type { LogMessageData } from '@shared/schemas';
+import type { TeXRAIconName } from '@shared/wa/webAwesomeIcons';
 
 // Local imports - formatter helpers
 import { formatDisplayTimestamp } from '../timestampUtils';
@@ -28,7 +29,7 @@ import type { FormatResult } from '../baseLogFormatter';
 const BANNER_CONFIG: Record<
   string,
   {
-    iconName: string;
+    iconName: TeXRAIconName;
     labelText: string;
     copyTitle: string;
     contentClass: string;

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts
@@ -15,7 +15,7 @@ import {
   CodexTodoToolInputSchema,
   CodexTurnToolInputSchema,
 } from '@shared/schemas/codex';
-import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+import { waIcon, type TeXRAIconName } from '@shared/wa/webAwesomeIcons';
 import { formatDuration } from '@utils/core';
 
 // Local imports - formatter helpers
@@ -30,7 +30,10 @@ import '@awesome.me/webawesome/dist/components/badge/badge.js';
 import '@awesome.me/webawesome/dist/components/divider/divider.js';
 
 type RenderableSection = TemplateResult | typeof nothing | undefined | null;
-type BadgeData = { iconName: string; label: string };
+type BadgeData = {
+  iconName: TeXRAIconName | typeof SPINNER_ICON_NAME;
+  label: string;
+};
 type CodexToolRenderer = (input: unknown) => TemplateResult | typeof nothing;
 
 /** Lenient schema for parsing codex tool input in the renderer. */
@@ -45,10 +48,10 @@ type CodexFileChangeToolInput = z.infer<typeof CodexFileChangeToolInputSchema>;
 type CodexTodoToolInput = z.infer<typeof CodexTodoToolInputSchema>;
 
 function renderBadge({ iconName, label }: BadgeData): TemplateResult {
-  // prettier-ignore
-  const iconTemplate = iconName === SPINNER_ICON_NAME
-    ? html`<wa-spinner></wa-spinner>`
-    : html`<wa-icon library=${TEXRA_ICON_LIBRARY} name=${iconName} aria-hidden="true"></wa-icon>`;
+  const iconTemplate =
+    iconName === SPINNER_ICON_NAME
+      ? html`<wa-spinner></wa-spinner>`
+      : waIcon(iconName);
   // prettier-ignore
   return html`<wa-badge variant="neutral" appearance="filled">${iconTemplate} ${label}</wa-badge>`;
 }
@@ -97,14 +100,14 @@ function renderCodexPromptSection(input: CodexInputDisplay): RenderableSection {
 }
 
 function renderCodexModeSection(input: CodexInputDisplay): RenderableSection {
-  const badges = [
-    ...(input.sandbox_mode
-      ? [{ iconName: 'shield', label: input.sandbox_mode }]
-      : []),
-    ...(input.thread_id
-      ? [{ iconName: 'comment-discussion', label: 'follow-up' }]
-      : []),
-  ];
+  const badges: BadgeData[] = [
+    input.sandbox_mode
+      ? { iconName: 'shield', label: input.sandbox_mode }
+      : null,
+    input.thread_id
+      ? { iconName: 'comment-discussion', label: 'follow-up' }
+      : null,
+  ].filter((badge): badge is BadgeData => badge != null);
 
   return renderBadgeSection('Mode:', badges);
 }
@@ -137,11 +140,7 @@ function renderCodexFileChangeItem(
 ): TemplateResult {
   return html`
     <li class="detail-item">
-      <wa-icon
-        library=${TEXRA_ICON_LIBRARY}
-        name="file"
-        aria-hidden="true"
-      ></wa-icon>
+      ${waIcon('file')}
       <span
         class="file-link clickable-link"
         data-file=${change.path}
@@ -224,11 +223,7 @@ function renderCodexTodoItem(item: {
 }): TemplateResult {
   return html`
     <li class="detail-item">
-      <wa-icon
-        library=${TEXRA_ICON_LIBRARY}
-        name=${item.completed ? 'pass-filled' : 'circle-large-outline'}
-        aria-hidden="true"
-      ></wa-icon>
+      ${waIcon(item.completed ? 'pass-filled' : 'circle-large-outline')}
       <span>${item.text}</span>
     </li>
   `;
@@ -271,7 +266,9 @@ function renderCodexTodoContent(
   ]);
 }
 
-function getCodexTurnStateIcon(state: string): string {
+function getCodexTurnStateIcon(
+  state: string,
+): TeXRAIconName | typeof SPINNER_ICON_NAME {
   switch (state) {
     case 'failed':
       return 'error';

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/contextManagementFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/contextManagementFormatters.ts
@@ -19,6 +19,7 @@ import {
   type ContextManagementData,
   type LogMessageData,
 } from '@shared/schemas';
+import type { TeXRAIconName } from '@shared/wa/webAwesomeIcons';
 import { formatCompactTokenCount } from '@utils/core';
 
 // Local imports - formatter helpers
@@ -41,7 +42,7 @@ const TOKENS_FREED_ACTIONS = new Set([
 /** Action display configuration. */
 const ACTION_CONFIG: Record<
   string,
-  { icon: string; label: string; color: string }
+  { icon: TeXRAIconName; label: string; color: string }
 > = {
   compaction: {
     icon: 'fold',

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/dataFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/dataFormatters.ts
@@ -27,7 +27,7 @@ import {
   type LogMessageData,
 } from '@shared/schemas';
 import { OUTPUT_DOCUMENTS_TAG } from '@shared/schemas/output';
-import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+import { waIcon, type TeXRAIconName } from '@shared/wa/webAwesomeIcons';
 import { formatCompactTokenCount, getBasename } from '@utils/core';
 import { formatCostUsd } from '@utils/text/stringUtils';
 
@@ -68,7 +68,7 @@ export function formatFileListTemplate(
 function renderXmlLink(xmlFile: string) {
   const xmlFileName = getBasename(xmlFile);
   // prettier-ignore
-  return html`<div class="xml-link-container"><wa-icon library=${TEXRA_ICON_LIBRARY} name="file-code" aria-hidden="true"></wa-icon> <span>Open XML to check tag consistency:</span> <span class="file-link clickable-link" data-file=${xmlFile} role="button" tabindex="0">${xmlFileName}</span> <span class="document-tag">(Expected &lt;${OUTPUT_DOCUMENTS_TAG}&gt; block)</span></div>`;
+  return html`<div class="xml-link-container">${waIcon('file-code')} <span>Open XML to check tag consistency:</span> <span class="file-link clickable-link" data-file=${xmlFile} role="button" tabindex="0">${xmlFileName}</span> <span class="document-tag">(Expected &lt;${OUTPUT_DOCUMENTS_TAG}&gt; block)</span></div>`;
 }
 
 /** Format missing outputs entry as TemplateResult. */
@@ -95,7 +95,7 @@ export function formatMissingOutputsTemplate(
   const listItems = missing.map((f) => {
     const filePath = String(f);
     const basename = getBasename(filePath);
-    return html`<li class="detail-item" title=${filePath}><wa-icon library=${TEXRA_ICON_LIBRARY} name="warning" aria-hidden="true"></wa-icon> <span class="file-link clickable-link" data-file=${filePath} role="button" tabindex="0">${basename}</span></li>`;
+    return html`<li class="detail-item" title=${filePath}>${waIcon('warning')} <span class="file-link clickable-link" data-file=${filePath} role="button" tabindex="0">${basename}</span></li>`;
   });
   // prettier-ignore
   return html`<wa-details appearance="plain" icon-placement="start" class="banner-details file-list-details" ?open=${shouldOpen}>${buildDetailsSummary({
@@ -138,7 +138,7 @@ type NumericExtendedTokenUsageStatsKey = {
 /** Configuration for a statistics field: [key, icon, label, formatter]. */
 type StatFieldConfig = readonly [
   key: NumericExtendedTokenUsageStatsKey,
-  icon: string,
+  icon: TeXRAIconName,
   label: string,
   formatter: (value: number) => string,
 ];

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/messageFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/messageFormatters.ts
@@ -24,7 +24,7 @@ import {
   type ErrorLogData,
   type LogMessageData,
 } from '@shared/schemas';
-import { TEXRA_ICON_LIBRARY, waIcon } from '@shared/wa/webAwesomeIcons';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 // Local imports - formatter helpers
 import { stringifyWithLanguage } from '../parseUtils';
@@ -142,7 +142,7 @@ export function formatErrorTemplate(message: LogMessageData): FormatResult {
   // (::part(icon)); banner-details--no-toggle hides that part when there's
   // nothing to expand, replacing the old inline visibility:hidden style.
   // prettier-ignore
-  const summaryTemplate = html`<div slot="summary" class="details-summary"><wa-icon library=${TEXRA_ICON_LIBRARY} name="error" class="icon" aria-hidden="true"></wa-icon>${labelSpan}${copyButton}</div>`;
+  const summaryTemplate = html`<div slot="summary" class="details-summary">${waIcon('error', { className: 'icon' })}${labelSpan}${copyButton}</div>`;
   // prettier-ignore
   return html`<wa-details appearance="plain" icon-placement="start" class=${classMap({
     'banner-details': true,

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -24,7 +24,7 @@ import {
   DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
   DELEGATION_TOOL_CATEGORY,
 } from '@shared/constants/delegationTools';
-import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+import { waIcon, type TeXRAIconName } from '@shared/wa/webAwesomeIcons';
 import { toolDisplayKind } from '@shared/tools/toolKind';
 import { deriveToolInputPreview } from '@shared/tools/toolInputPreview';
 import {
@@ -88,7 +88,7 @@ export function formatToolUseTemplate(
   // Determine display state
   const isInProgress = status === 'in_progress';
   const showAsError = normalizedToolLog.isError && !isUserFeedback;
-  let iconName: string;
+  let iconName: TeXRAIconName | typeof SPINNER_ICON_NAME;
   if (isUserFeedback) {
     iconName = 'comment';
   } else if (isInProgress) {
@@ -207,7 +207,7 @@ export function formatToolUseTemplate(
   // stopSummaryToggleKeydown for why the keydown path additionally needs an
   // explicit stopPropagation.
   // prettier-ignore
-  const extraContent = html`${timerTemplate ?? nothing}${proposalId ? html`<button type="button" class="proposal-restore-link proposal-banner-setup" data-proposal-id=${proposalId} title="Setup this proposal configuration" @keydown=${stopSummaryToggleKeydown}><wa-icon library=${TEXRA_ICON_LIBRARY} name="reply" aria-hidden="true"></wa-icon> Setup</button>` : nothing}`;
+  const extraContent = html`${timerTemplate ?? nothing}${proposalId ? html`<button type="button" class="proposal-restore-link proposal-banner-setup" data-proposal-id=${proposalId} title="Setup this proposal configuration" @keydown=${stopSummaryToggleKeydown}>${waIcon('reply')} Setup</button>` : nothing}`;
 
   // prettier-ignore
   return html`<wa-details appearance="plain" icon-placement="start" class=${classMap({

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
@@ -31,7 +31,7 @@ import {
 } from '@progressView/frontend/formatters/constants';
 import { toolDisplayKind } from '@shared/tools/toolKind';
 import { EXECUTIONS_DEFAULT_ACTION } from '@shared/tools/executionsDisplay';
-import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+import { waIcon, type TeXRAIconName } from '@shared/wa/webAwesomeIcons';
 import {
   DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME,
   DELEGATION_TOOLS,
@@ -79,7 +79,7 @@ function buildFileGroupsSection(
 ): TemplateResult | undefined {
   if (fileGroups.length === 0) return undefined;
   // prettier-ignore
-  const fileItems = html`${fileGroups.flatMap((group) => group.files.map((file) => html`<li class="detail-item"><wa-icon library=${TEXRA_ICON_LIBRARY} name="file" aria-hidden="true"></wa-icon> <span class="${group.clickable ? 'file-link clickable-link' : 'file-label'}" data-file=${ifDefined(group.clickable ? file : undefined)} role=${ifDefined(group.clickable ? 'button' : undefined)} tabindex=${ifDefined(group.clickable ? '0' : undefined)}>${file}</span> <span class="file-source">(${group.label})</span></li>`))}`;
+  const fileItems = html`${fileGroups.flatMap((group) => group.files.map((file) => html`<li class="detail-item">${waIcon('file')} <span class="${group.clickable ? 'file-link clickable-link' : 'file-label'}" data-file=${ifDefined(group.clickable ? file : undefined)} role=${ifDefined(group.clickable ? 'button' : undefined)} tabindex=${ifDefined(group.clickable ? '0' : undefined)}>${file}</span> <span class="file-source">(${group.label})</span></li>`))}`;
   return buildToolUseSection(
     'Files:',
     html`<ul class="detail-list">
@@ -280,7 +280,7 @@ function buildAcceptRunFilesSections(
         ? html` <span class="file-stats"><span class="added">+${edit.lineChanges.added}</span><span class="removed">-${edit.lineChanges.removed}</span></span>`
         : nothing;
       // prettier-ignore
-      return html`<li class="detail-item"><wa-icon library=${TEXRA_ICON_LIBRARY} name="file" aria-hidden="true"></wa-icon> <span class="file-link clickable-link" data-file=${dest} role="button" tabindex="0">${dest}</span>${isMapped ? html` <span class="file-source">(from ${source})</span>` : nothing}${diffStats}</li>`;
+      return html`<li class="detail-item">${waIcon('file')} <span class="file-link clickable-link" data-file=${dest} role="button" tabindex="0">${dest}</span>${isMapped ? html` <span class="file-source">(from ${source})</span>` : nothing}${diffStats}</li>`;
     })}`;
     // prettier-ignore
     sections.push(buildToolUseSection('Files:', html`<ul class="detail-list">${fileItems}</ul>`));
@@ -326,7 +326,7 @@ function buildDelegationSections(ctx: ToolSectionContext): TemplateResult[] {
     extractFlags.push('Extract TikZ');
   if (extractFlags.length > 0) {
     // prettier-ignore
-    sections.push(buildToolUseSection('Extraction:', html`${extractFlags.map((f) => html`<wa-badge variant="neutral" appearance="filled"><wa-icon library=${TEXRA_ICON_LIBRARY} name="file-media" aria-hidden="true"></wa-icon> ${f}</wa-badge>`)}`));
+    sections.push(buildToolUseSection('Extraction:', html`${extractFlags.map((f) => html`<wa-badge variant="neutral" appearance="filled">${waIcon('file-media')} ${f}</wa-badge>`)}`));
   }
 
   const fileGroups = getProposalFileGroups(delegateInput);
@@ -432,7 +432,7 @@ function buildMcpSections(ctx: ToolSectionContext): TemplateResult[] {
   const otherBlocks = contentBlocks.filter((block) => !isMcpTextBlock(block));
 
   if (typeof mcpOutput?.status === 'string') {
-    let statusIconName: string;
+    let statusIconName: TeXRAIconName | typeof SPINNER_ICON_NAME;
     if (mcpOutput.status === 'failed') {
       statusIconName = 'error';
     } else if (mcpOutput.status === 'in_progress') {
@@ -440,10 +440,10 @@ function buildMcpSections(ctx: ToolSectionContext): TemplateResult[] {
     } else {
       statusIconName = 'check';
     }
-    // prettier-ignore
-    const statusIconTemplate = statusIconName === SPINNER_ICON_NAME
-      ? html`<wa-spinner></wa-spinner>`
-      : html`<wa-icon library=${TEXRA_ICON_LIBRARY} name=${statusIconName} aria-hidden="true"></wa-icon>`;
+    const statusIconTemplate =
+      statusIconName === SPINNER_ICON_NAME
+        ? html`<wa-spinner></wa-spinner>`
+        : waIcon(statusIconName);
     // prettier-ignore
     sections.push(buildToolUseSection('Status:', html`<wa-badge variant="neutral" appearance="filled">${statusIconTemplate} ${mcpOutput.status}</wa-badge>`));
     renderedMcpOutput = true;

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/webFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/webFormatters.ts
@@ -23,14 +23,14 @@ import {
   WebFetchPayloadSchema,
   type LogMessageData,
 } from '@shared/schemas';
-import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+import { waIcon, type TeXRAIconName } from '@shared/wa/webAwesomeIcons';
 import { tryParseUrl } from '@utils/core';
 import { buildBannerContent, joinWithSeparator } from './helpers';
 
 /** Wrap formatted tool content in the shared collapsible banner shell. */
 function buildToolUseDetails(opts: {
   message: LogMessageData;
-  iconName: string;
+  iconName: TeXRAIconName | typeof SPINNER_ICON_NAME;
   label: string;
   isError: boolean;
   content: TemplateResult;
@@ -54,7 +54,7 @@ const STATUS_SUFFIXES: Record<string, string> = {
 };
 
 // Web search status-based wa-icon names; SPINNER_ICON_NAME triggers a spinner.
-const STATUS_ICONS: Record<string, string> = {
+const STATUS_ICONS: Record<string, TeXRAIconName | typeof SPINNER_ICON_NAME> = {
   failed: 'error',
   in_progress: SPINNER_ICON_NAME,
 };
@@ -94,7 +94,7 @@ export function formatWebSearchTemplate(
     // result with no safe URL should read as inert text, not a dead link).
     // prettier-ignore
     const resultItems = (results ?? []).map(
-      (r) => html`<li class="detail-item"><wa-icon library=${TEXRA_ICON_LIBRARY} name="link" aria-hidden="true"></wa-icon> ${r.url ? html`<a href=${r.url} class="web-search-link" target="_blank" rel="noopener noreferrer">${r.title ?? r.domain ?? r.url}</a>` : html`<span class="web-search-link">${r.title ?? r.domain ?? ''}</span>`}${r.domain ? html` <span class="file-source">(${r.domain})</span>` : ''}</li>`,
+      (r) => html`<li class="detail-item">${waIcon('link')} ${r.url ? html`<a href=${r.url} class="web-search-link" target="_blank" rel="noopener noreferrer">${r.title ?? r.domain ?? r.url}</a>` : html`<span class="web-search-link">${r.title ?? r.domain ?? ''}</span>`}${r.domain ? html` <span class="file-source">(${r.domain})</span>` : ''}</li>`,
     );
     // prettier-ignore
     const resultsTemplate = html`<span class="file-list-summary">Results (${resultCount})</span><ul class="detail-list">${resultItems}</ul>`;

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/workflowTaskFormatter.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/workflowTaskFormatter.ts
@@ -12,14 +12,14 @@ import {
   formatWorkflowTaskMetadataParts,
   workflowTaskDetail,
 } from '@shared/copy/workflowTask';
-import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+import { waIcon, type TeXRAIconName } from '@shared/wa/webAwesomeIcons';
 import { assertNever } from '@utils/core';
 
 function statusIcon(task: WorkflowTaskProgress): TemplateResult {
   if (task.status === 'running') {
     return html`<wa-spinner aria-label="Running"></wa-spinner>`;
   }
-  const icon = (() => {
+  const icon: TeXRAIconName = (() => {
     switch (task.status) {
       case 'planned':
         return 'circle-outline';
@@ -34,11 +34,7 @@ function statusIcon(task: WorkflowTaskProgress): TemplateResult {
         return assertNever(task, 'Unhandled workflow task status');
     }
   })();
-  return html`<wa-icon
-    library=${TEXRA_ICON_LIBRARY}
-    name=${icon}
-    aria-hidden="true"
-  ></wa-icon>`;
+  return waIcon(icon);
 }
 
 function terminalMetadata(


### PR DESCRIPTION
## Summary

A scheduled UI-consistency audit found that the progress-view **formatters** build `<wa-icon>` markup by hand in ~14 places instead of calling the shared `waIcon()` helper (`@shared/wa/webAwesomeIcons`), even though most of the same files already import and correctly use `waIcon()` elsewhere. This routes all of them through the single helper and tightens the icon-name types that had regressed to plain `string` along the way.

## Issue acceptance gates

No tracked issue — surfaced by a scheduled codebase-consistency review, not a bug report. Acceptance gate is self-defined and **scoped to `formatters/` + `ContextManagement.ts`** (not the whole `progressView/frontend/` tree): every hand-authored `<wa-icon library=${TEXRA_ICON_LIBRARY} name=...>` template in `packages/extension/src/progressView/frontend/formatters/` and `components/ContextManagement.ts` now goes through `waIcon()`, and every `iconName`/`icon` field that fed one of those templates is typed `TeXRAIconName` (or `TeXRAIconName | typeof SPINNER_ICON_NAME`) instead of `string`.

**Not in scope / follow-up candidates:** 14 files under `packages/extension/src/progressView/frontend/components/` still use the same hand-rolled `<wa-icon library=${TEXRA_ICON_LIBRARY}>` pattern and are untouched by this diff: `TodoList.ts`, `UsagePanel.ts`, `WorktreeChip.ts`, `LatexdiffResults.ts`, `TaskGroupList.ts`, `BackgroundTasksPanel.ts`, `ExternalInquiryPanel.ts`, `ProposalRequestPanel.ts`, `QueuedFollowUps.ts`, `FileList.ts`, `RequestPanels.ts`, `StreamTabs.ts`, `UserMessage.ts`, `WorkflowToolUseFollowupSection.ts`. A future pass should cover these the same way.

## Single source of truth

`waIcon()` in `src/shared/wa/webAwesomeIcons.ts` is already the canonical `<wa-icon>` constructor (per AGENTS.md). This PR removes the parallel hand-rolled construction path that had grown up alongside it in the formatters layer — no new module introduced.

## Duplication and abstraction budget

Removed: ~14 duplicated inline `<wa-icon library=... name=... aria-hidden="true">` constructions across 8 formatter/component files, all collapsed onto the existing `waIcon()` call. No new abstraction added.

## Net elements (R6)

12 files changed, 72 insertions(+), 84 deletions(-) — net negative LoC. No exported symbols added or removed; two exports changed signature only (`TOOL_ICON_MAP`'s value type, `getToolIconName`'s return type), both narrowed from `string` to `TeXRAIconName`.

## Consumer counts (R8)

n/a — no emit path or export was deleted or re-routed, only retyped/inlined at existing call sites.

## Host impact

Extension: `packages/extension/src/progressView/frontend/formatters/**` and `components/ContextManagement.ts` — icon rendering behavior is unchanged (same icon names, same `aria-hidden`/library attributes via `waIcon()`'s equivalent output); this is a construction-path consolidation, not a visual change.

Desktop: none (desktop reuses these same extension components; not touched directly).

CLI: none.

## Scheduled refactoring

Follow-up: apply the same `waIcon()` conversion to the 14 `components/*.ts` files listed above (currently untouched, same hand-rolled pattern). No issue filed yet.

## Validation

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npx vitest run src/test-kernel/progressView` — 52 files / 430 tests passed
- `npx vitest run` (full suite) — 780 passed / 2 failed; both failures are pre-existing, timing-sensitive tests unrelated to this change (QuickJS memory-exhaustion timing, process-group abort timing), also called out as flaky in the just-opened #9216.
