### PR TITLE
fix(runtime): make the silent "no interaction host attached" park loud

### DIFF
--- a/src/agent/runtime/AgentRuntimeHost.ts
+++ b/src/agent/runtime/AgentRuntimeHost.ts
@@ -18,7 +18,10 @@ export interface AgentRuntimeEmitOptions {
  *
  * **Headless / SDK contract.** Not every event is required for execution. A
  * headless consumer can implement a partial host and safely ignore the
- * UI-oriented events — the run completes regardless. Two tiers:
+ * UI-oriented events — the run completes regardless, *provided something is
+ * attached*. `session.useHostInteractions({ cancel: () => {} })` is the
+ * minimum: it settles every request the host omits. Attaching nothing instead
+ * parks blocking requests indefinitely. Two tiers:
  *
  * - **Host interaction surface** (`RuntimeInteractionEventPayloads`): typed
  *   approval and user-question requests that may affect the agent loop.

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -632,7 +632,12 @@ export class SessionHostInteractions
         });
       }
     }
-    if (!active) return;
+    if (!active) {
+      for (const pending of this.pending) {
+        if (!pending.cancellationRequested) this.warnParked(pending);
+      }
+      return;
+    }
     for (const pending of this.pending) {
       if (!pending.cancellationRequested) this.dispatch(pending);
     }
@@ -667,14 +672,7 @@ export class SessionHostInteractions
   private dispatch(pending: PendingSessionInteraction): void {
     const attachment = this.activeAttachment;
     if (!attachment) {
-      // Only `enqueue` reaches this branch — re-dispatch runs behind an active
-      // attachment — so one park logs once, not once per dispatch attempt.
-      logger.warn(
-        `No interaction host is attached: parked the ${pending.kind} request ` +
-          `(stream ${pending.streamId ?? 'none'}) until one attaches. A ` +
-          'headless embedder must attach at least `{ cancel: () => {} }`, or ' +
-          'blocking requests never settle.',
-      );
+      this.warnParked(pending);
       return;
     }
     const version = this.attachmentVersion;
@@ -700,6 +698,19 @@ export class SessionHostInteractions
         this.rejectCurrentDispatch(pending, attachment, version, error);
       },
     );
+  }
+
+  private warnParked(pending: PendingSessionInteraction): void {
+    try {
+      logger.warn(
+        `No interaction host is attached: parked the ${pending.kind} request ` +
+          `(stream ${pending.streamId ?? 'none'}) until one attaches. A ` +
+          'headless embedder must attach at least `{ cancel: () => {} }`, or ' +
+          'blocking requests never settle.',
+      );
+    } catch {
+      // A diagnostic sink must not reject or remove the request it describes.
+    }
   }
 
   private rejectCurrentDispatch(

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -666,7 +666,17 @@ export class SessionHostInteractions
 
   private dispatch(pending: PendingSessionInteraction): void {
     const attachment = this.activeAttachment;
-    if (!attachment) return;
+    if (!attachment) {
+      // Only `enqueue` reaches this branch — re-dispatch runs behind an active
+      // attachment — so one park logs once, not once per dispatch attempt.
+      logger.warn(
+        `No interaction host is attached: parked the ${pending.kind} request ` +
+          `(stream ${pending.streamId ?? 'none'}) until one attaches. A ` +
+          'headless embedder must attach at least `{ cancel: () => {} }`, or ' +
+          'blocking requests never settle.',
+      );
+      return;
+    }
     const version = this.attachmentVersion;
     let result: Promise<unknown> | undefined;
     try {

--- a/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
@@ -23,6 +23,7 @@ import {
   createDesktopHostInteractions,
   type DesktopHostInteractions,
 } from '@desktop/main/desktopHostInteractions';
+import { setOutputChannelFactory } from '@logger/logUtils';
 import {
   AgentCategory,
   type AgentProposal,
@@ -474,6 +475,61 @@ describe('session.interactions request bookkeeping (coordinator fold)', () => {
     expect(() => session.interactions.dispose()).toThrow('cancel failed');
     expect(dispose).toHaveBeenCalledOnce();
     session.dispose();
+  });
+
+  it('warns once when a request parks unattached, then redispatches it', async () => {
+    const lines: string[] = [];
+    setOutputChannelFactory(() => ({
+      appendLine: (message: string) => lines.push(message),
+    }));
+    const session = createTestSession();
+    const adapter = createControllablePlanAdapter();
+    const parkWarnings = (): string[] =>
+      lines.filter((line) => line.includes('No interaction host is attached'));
+    try {
+      const pending = session.interactions.requestPlanApproval({
+        approvalId: 'approval:parked-warning',
+        streamId,
+        plan,
+        goalEnabled: false,
+      });
+
+      expect(parkWarnings()).toHaveLength(1);
+      expect(parkWarnings()[0]).toContain('WARN');
+      expect(parkWarnings()[0]).toContain('plan');
+      expect(parkWarnings()[0]).toContain(streamId);
+
+      // Parking stays load-bearing: a host attaching later still replays the
+      // request exactly once (this is how a webview reload recovers a prompt).
+      session.useHostInteractions(adapter.interactions);
+      expect(adapter.requests).toHaveLength(1);
+      expect(
+        adapter.submit('approval:parked-warning', { action: 'approve' }),
+      ).toBe(true);
+      await expect(pending).resolves.toEqual({ action: 'approve' });
+      expect(parkWarnings()).toHaveLength(1);
+    } finally {
+      session.dispose();
+      setOutputChannelFactory(null);
+    }
+  });
+
+  it('settles against the documented minimal `{ cancel }` host', async () => {
+    const session = createTestSession();
+    session.useHostInteractions({ cancel: vi.fn() });
+    try {
+      await expect(
+        session.interactions.requestPlanApproval({
+          approvalId: 'approval:minimal-host',
+          streamId,
+          plan,
+          goalEnabled: false,
+        }),
+      ).resolves.toEqual({ action: 'reject' });
+      expect(session.interactions.pendingCount).toBe(0);
+    } finally {
+      session.dispose();
+    }
   });
 
   it('buffers a request made while no adapter is attached', async () => {

--- a/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
@@ -514,6 +514,44 @@ describe('session.interactions request bookkeeping (coordinator fold)', () => {
     }
   });
 
+  it('keeps a parked request pending when the diagnostic sink throws', async () => {
+    setOutputChannelFactory(() => ({
+      appendLine: () => {
+        throw new Error('diagnostic sink failed');
+      },
+    }));
+    const session = createTestSession();
+    const adapter = createControllablePlanAdapter();
+    try {
+      const pending = session.interactions
+        .requestPlanApproval({
+          approvalId: 'approval:throwing-warning',
+          streamId,
+          plan,
+          goalEnabled: false,
+        })
+        .then(
+          (result) => ({ status: 'resolved' as const, result }),
+          (error: unknown) => ({ status: 'rejected' as const, error }),
+        );
+
+      expect(session.interactions.pendingCount).toBe(1);
+      session.useHostInteractions(adapter.interactions);
+      expect(adapter.requests).toHaveLength(1);
+      expect(
+        adapter.submit('approval:throwing-warning', { action: 'approve' }),
+      ).toBe(true);
+      await expect(pending).resolves.toEqual({
+        status: 'resolved',
+        result: { action: 'approve' },
+      });
+      expect(session.interactions.pendingCount).toBe(0);
+    } finally {
+      session.dispose();
+      setOutputChannelFactory(null);
+    }
+  });
+
   it('settles against the documented minimal `{ cancel }` host', async () => {
     const session = createTestSession();
     session.useHostInteractions({ cancel: vi.fn() });
@@ -556,6 +594,10 @@ describe('session.interactions request bookkeeping (coordinator fold)', () => {
   });
 
   it('keeps a pending request across adapter detach and reattach', async () => {
+    const lines: string[] = [];
+    setOutputChannelFactory(() => ({
+      appendLine: (message: string) => lines.push(message),
+    }));
     const session = createTestSession();
     const first = createControllablePlanAdapter();
     const second = createControllablePlanAdapter();
@@ -575,6 +617,11 @@ describe('session.interactions request bookkeeping (coordinator fold)', () => {
       await Promise.resolve();
       expect(first.dispose).toHaveBeenCalledOnce();
       expect(pendingCounts).toEqual([1]);
+      expect(
+        lines.filter((line) =>
+          line.includes('No interaction host is attached'),
+        ),
+      ).toHaveLength(1);
 
       session.useHostInteractions(second.interactions);
       expect(second.requests).toHaveLength(1);
@@ -585,6 +632,7 @@ describe('session.interactions request bookkeeping (coordinator fold)', () => {
       expect(pendingCounts).toEqual([1, 0]);
     } finally {
       session.dispose();
+      setOutputChannelFactory(null);
     }
   });
 


### PR DESCRIPTION
## Failure

`SessionHostInteractions.enqueue` registers a response-bearing request before dispatching it. If no interaction host is attached, dispatch cannot settle the request, so it remains pending for later replay. Previously this necessary park was silent: an external embedder could await forever without a diagnostic.

A second transition has the same effect. If the active host detaches while a request is in flight, the request remains pending until another host attaches. That transition was also silent.

## Change

- Emit a warning whenever a non-cancelled request becomes parked with no active interaction host: both on initial enqueue and when the active host detaches.
- Treat the diagnostic as best-effort. A throwing host-provided log sink cannot reject the request or alter pending bookkeeping.
- Clarify the headless SDK contract on `AgentRuntimeHost`: attaching `session.useHostInteractions({ cancel: () => {} })` is the minimum host that settles omitted request methods; attaching nothing leaves blocking requests parked.

The warning names the interaction kind and stream identifier in the message itself, so it remains visible when debug data output is disabled.

## Parking semantics remain unchanged

The request is deliberately neither cancelled nor rejected when no host is attached. `activateCurrentAttachment` redispatches pending interactions when a host later attaches. This is required for webview reloads and delayed progress-view attachment: an approval request must survive until the user interface returns.

Thus the change makes the existing state transition observable without changing its lifecycle.

## No deduplication state

There are two distinct park transitions:

1. a request is enqueued while no host is attached;
2. the active host detaches while requests are pending.

Each transition emits one warning per affected request. Reattachment does not warn because an active host exists. The existing control flow provides this property, so no auxiliary set, identifier, or deduplication map is needed. The private `warnParked` helper keeps the message and the best-effort boundary in one place for the two callers.

## Tests

The regression tests verify that:

- an unattached request warns and remains resolvable after a later attachment;
- the documented minimal `{ cancel }` host settles omitted interactions;
- a throwing output sink cannot reject or remove a parked request;
- detaching the active host warns, while later reattachment still redispatches and resolves the request.

## Net-element accounting

| | |
|---|---|
| Constructs added | One private `warnParked` helper; no new public API, type, file, or persisted state. |
| Constructs deleted | 0 |
| Production LoC | +27 / -3, net +24 |
| Test LoC | +104 / -0 |
| Total | +131 / -3 |

## Explicitly out of scope

- Making all seven interaction request methods required. Their optionality is the intended partial-host contract.
- Settling requests merely because no host is attached. That would break replay after a user-interface reload.
- Restructuring the pending registry.

## Verification

- Focused runtime interaction suite: 26 tests passed.
- ESLint: passed.
- Root and test-kernel TypeScript checks: passed.
- Trace viewer, extension host, and all three webview production builds: passed.
- Exact-head repository CI is the merge gate.

https://claude.ai/code/session_01XZ8Z6rhypTfkVq728XCcCd
