### PR TITLE
refactor(extension): delete the status bar's stream-phase mirror

### DIFF
--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -661,7 +661,10 @@ export async function activate(context: vscode.ExtensionContext) {
     }),
   });
 
-  const statusBarUsageTracker = new StatusBarUsageTracker();
+  const statusBarSession = defaultSession();
+  const statusBarUsageTracker = new StatusBarUsageTracker(
+    statusBarSession.status,
+  );
   const updateStatusBarTooltip = () => {
     if (!statusBarItem) return;
     const { cost, inputTokens, outputTokens } =
@@ -706,7 +709,7 @@ export async function activate(context: vscode.ExtensionContext) {
   };
 
   disposeStatusListener = subscribeStatusBarSessionEvents({
-    session: defaultSession(),
+    session: statusBarSession,
     tracker: statusBarUsageTracker,
     onStatusChanged: () => {
       updateStatusBarTooltip();

--- a/packages/extension/src/frontend/statusBar/StatusBarUsageTracker.ts
+++ b/packages/extension/src/frontend/statusBar/StatusBarUsageTracker.ts
@@ -1,9 +1,6 @@
 // Local imports - stream state
-import {
-  DEFAULT_STREAM_METADATA_STATUS,
-  type StreamLifecycleStatus,
-  type StreamPhase,
-} from '@shared/schemas';
+import type { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
+import type { StreamPhase } from '@shared/schemas';
 import { isActivePhase, isInFlightPhase } from '@shared/streams/streamStatus';
 import type { TokenUsageStats } from '@shared/schemas/usage';
 
@@ -19,47 +16,41 @@ const ZERO_USAGE: StatusBarUsageTotals = {
   outputTokens: 0,
 };
 
-function lifecyclePhase(
-  status: StreamLifecycleStatus,
-): StreamPhase | undefined {
-  return status === DEFAULT_STREAM_METADATA_STATUS ? undefined : status;
-}
-
-/** Tracks active streams and usage totals for the extension status bar. */
+/**
+ * Accumulates the live spend of the streams currently running in a session,
+ * for the extension status bar.
+ *
+ * The phase of each stream is *not* mirrored here: the session status plane
+ * that feeds this tracker is also the thing it asks "is this stream in flight"
+ * and "how many streams are active", so there is one writer of that fact.
+ */
 export class StatusBarUsageTracker {
-  private readonly activeStreams = new Set<string>();
-  private readonly streamStatuses = new Map<string, StreamLifecycleStatus>();
   private readonly usageByStream = new Map<string, StatusBarUsageTotals>();
 
-  public updateStreamStatus(
-    streamId: string,
-    status: StreamLifecycleStatus,
-  ): void {
-    const phase = lifecyclePhase(status);
-    if (isActivePhase(phase)) {
-      this.activeStreams.add(streamId);
-    } else {
-      this.activeStreams.delete(streamId);
-    }
+  constructor(
+    private readonly status: Pick<
+      StreamStatusMachine,
+      'entries' | 'isInFlight'
+    >,
+  ) {}
 
-    if (!isInFlightPhase(phase)) {
-      this.streamStatuses.delete(streamId);
-      this.usageByStream.delete(streamId);
-      return;
-    }
-
-    this.streamStatuses.set(streamId, status);
+  /**
+   * Drops a stream's accumulated spend once it leaves flight, so the status bar
+   * reports what the running streams have cost rather than a session total.
+   */
+  public updateStreamStatus(streamId: string, status: StreamPhase): void {
+    if (isInFlightPhase(status)) return;
+    this.usageByStream.delete(streamId);
   }
 
   /**
-   * Records a per-round usage delta only for streams known to be in flight.
-   * The runtime emits the in-flight status before usage for a round; unknown or
-   * terminated stream ids are ignored so stale async events cannot recreate
-   * completed streams.
+   * Records a per-round usage delta only for streams the session status plane
+   * reports as in flight. The runtime publishes the in-flight status before
+   * usage for a round; unknown or terminated stream ids are ignored so stale
+   * async events cannot recreate completed streams.
    */
   public recordUsage(streamId: string, usage: TokenUsageStats): boolean {
-    const status = this.streamStatuses.get(streamId);
-    if (status === undefined || !isInFlightPhase(lifecyclePhase(status))) {
+    if (!this.status.isInFlight(streamId)) {
       return false;
     }
 
@@ -73,7 +64,11 @@ export class StatusBarUsageTracker {
   }
 
   public get activeStreamCount(): number {
-    return this.activeStreams.size;
+    let count = 0;
+    for (const [, phase] of this.status.entries()) {
+      if (isActivePhase(phase)) count += 1;
+    }
+    return count;
   }
 
   public get totalUsage(): StatusBarUsageTotals {

--- a/packages/extension/src/frontend/statusBar/StatusBarUsageTracker.ts
+++ b/packages/extension/src/frontend/statusBar/StatusBarUsageTracker.ts
@@ -1,5 +1,5 @@
 // Local imports - stream state
-import type { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { StreamPhase } from '@shared/schemas';
 import { isActivePhase, isInFlightPhase } from '@shared/streams/streamStatus';
 import type { TokenUsageStats } from '@shared/schemas/usage';
@@ -29,7 +29,7 @@ export class StatusBarUsageTracker {
 
   constructor(
     private readonly status: Pick<
-      StreamStatusMachine,
+      SessionHandle['status'],
       'entries' | 'isInFlight'
     >,
   ) {}

--- a/src/test-kernel/frontend/StatusBarSessionEvents.vitest.ts
+++ b/src/test-kernel/frontend/StatusBarSessionEvents.vitest.ts
@@ -12,7 +12,7 @@ import { createTestSession } from '@test/support/sessionTestUtils';
 describe('subscribeStatusBarSessionEvents', () => {
   it('tracks stream status changes from the session status plane', () => {
     const session = createTestSession();
-    const tracker = new StatusBarUsageTracker();
+    const tracker = new StatusBarUsageTracker(session.status);
     const onStatusChanged = vi.fn();
     const onUsageChanged = vi.fn();
     const dispose = subscribeStatusBarSessionEvents({
@@ -30,13 +30,16 @@ describe('subscribeStatusBarSessionEvents', () => {
 
     dispose();
     session.status.transition('stream-a', STREAM_PHASE.COMPLETED, 'lifecycle');
-    expect(tracker.activeStreamCount).toBe(1);
+    // Disposal stops the status-bar refresh, not the underlying fact: the
+    // count is read live from the session status plane, so it still follows
+    // the terminal transition.
+    expect(tracker.activeStreamCount).toBe(0);
     expect(onStatusChanged).toHaveBeenCalledTimes(1);
   });
 
   it('records valid run usage events after an in-flight status', () => {
     const session = createTestSession();
-    const tracker = new StatusBarUsageTracker();
+    const tracker = new StatusBarUsageTracker(session.status);
     const onStatusChanged = vi.fn();
     const onUsageChanged = vi.fn();
     const dispose = subscribeStatusBarSessionEvents({
@@ -72,7 +75,7 @@ describe('subscribeStatusBarSessionEvents', () => {
 
   it('ignores usage for unknown streams', () => {
     const session = createTestSession();
-    const tracker = new StatusBarUsageTracker();
+    const tracker = new StatusBarUsageTracker(session.status);
     const onStatusChanged = vi.fn();
     const onUsageChanged = vi.fn();
     const dispose = subscribeStatusBarSessionEvents({

--- a/src/test-kernel/frontend/StatusBarUsageTracker.vitest.ts
+++ b/src/test-kernel/frontend/StatusBarUsageTracker.vitest.ts
@@ -7,10 +7,26 @@ import { StatusBarUsageTracker } from '@frontend/statusBar/StatusBarUsageTracker
 import { STREAM_PHASE } from '@shared/schemas/stream';
 import { STREAM_TRANSITION_CAUSE } from '@shared/streams/streamStatus';
 
+/** The tracker reads its phase facts from the status plane it is given. */
+function trackerOverStatusPlane(): {
+  status: StreamStatusMachine;
+  tracker: StatusBarUsageTracker;
+} {
+  const status = new StreamStatusMachine();
+  return { status, tracker: new StatusBarUsageTracker(status) };
+}
+
+function startStream(status: StreamStatusMachine, streamId: string): void {
+  status.transition(
+    streamId,
+    STREAM_PHASE.RUNNING,
+    STREAM_TRANSITION_CAUSE.LIFECYCLE,
+  );
+}
+
 describe('StatusBarUsageTracker', () => {
   it('ignores usage for streams without a known in-flight status', () => {
-    const status = new StreamStatusMachine();
-    const tracker = new StatusBarUsageTracker(status);
+    const { tracker } = trackerOverStatusPlane();
 
     expect(
       tracker.recordUsage('stream-a', {
@@ -27,13 +43,8 @@ describe('StatusBarUsageTracker', () => {
   });
 
   it('accumulates per-round usage deltas for an active stream', () => {
-    const status = new StreamStatusMachine();
-    const tracker = new StatusBarUsageTracker(status);
-    status.transition(
-      'stream-a',
-      STREAM_PHASE.RUNNING,
-      STREAM_TRANSITION_CAUSE.LIFECYCLE,
-    );
+    const { status, tracker } = trackerOverStatusPlane();
+    startStream(status, 'stream-a');
 
     expect(
       tracker.recordUsage('stream-a', {
@@ -57,13 +68,8 @@ describe('StatusBarUsageTracker', () => {
   });
 
   it('retains accumulated usage while a stream waits for follow-up input', () => {
-    const status = new StreamStatusMachine();
-    const tracker = new StatusBarUsageTracker(status);
-    status.transition(
-      'stream-a',
-      STREAM_PHASE.RUNNING,
-      STREAM_TRANSITION_CAUSE.LIFECYCLE,
-    );
+    const { status, tracker } = trackerOverStatusPlane();
+    startStream(status, 'stream-a');
     tracker.recordUsage('stream-a', {
       cost: 0.01,
       inputTokens: 10,
@@ -91,13 +97,8 @@ describe('StatusBarUsageTracker', () => {
   });
 
   it('ignores delayed usage after a stream reaches a final status', () => {
-    const status = new StreamStatusMachine();
-    const tracker = new StatusBarUsageTracker(status);
-    status.transition(
-      'stream-a',
-      STREAM_PHASE.RUNNING,
-      STREAM_TRANSITION_CAUSE.LIFECYCLE,
-    );
+    const { status, tracker } = trackerOverStatusPlane();
+    startStream(status, 'stream-a');
     tracker.recordUsage('stream-a', {
       cost: 0.01,
       inputTokens: 10,
@@ -150,21 +151,12 @@ describe('StatusBarUsageTracker', () => {
   });
 
   it('counts only the streams the session status plane reports as active', () => {
-    const status = new StreamStatusMachine();
-    const tracker = new StatusBarUsageTracker(status);
+    const { status, tracker } = trackerOverStatusPlane();
 
     expect(tracker.activeStreamCount).toBe(0);
 
-    status.transition(
-      'stream-a',
-      STREAM_PHASE.RUNNING,
-      STREAM_TRANSITION_CAUSE.LIFECYCLE,
-    );
-    status.transition(
-      'stream-b',
-      STREAM_PHASE.RUNNING,
-      STREAM_TRANSITION_CAUSE.LIFECYCLE,
-    );
+    startStream(status, 'stream-a');
+    startStream(status, 'stream-b');
     expect(tracker.activeStreamCount).toBe(2);
 
     // A stream cleared out of the status plane without a published phase

--- a/src/test-kernel/frontend/StatusBarUsageTracker.vitest.ts
+++ b/src/test-kernel/frontend/StatusBarUsageTracker.vitest.ts
@@ -2,12 +2,15 @@
 import { describe, expect, it } from 'vitest';
 
 // Local imports - stream state
+import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import { StatusBarUsageTracker } from '@frontend/statusBar/StatusBarUsageTracker';
-import { STREAM_STATUS } from '@shared/schemas/stream';
+import { STREAM_PHASE } from '@shared/schemas/stream';
+import { STREAM_TRANSITION_CAUSE } from '@shared/streams/streamStatus';
 
 describe('StatusBarUsageTracker', () => {
   it('ignores usage for streams without a known in-flight status', () => {
-    const tracker = new StatusBarUsageTracker();
+    const status = new StreamStatusMachine();
+    const tracker = new StatusBarUsageTracker(status);
 
     expect(
       tracker.recordUsage('stream-a', {
@@ -24,8 +27,13 @@ describe('StatusBarUsageTracker', () => {
   });
 
   it('accumulates per-round usage deltas for an active stream', () => {
-    const tracker = new StatusBarUsageTracker();
-    tracker.updateStreamStatus('stream-a', STREAM_STATUS.RUNNING);
+    const status = new StreamStatusMachine();
+    const tracker = new StatusBarUsageTracker(status);
+    status.transition(
+      'stream-a',
+      STREAM_PHASE.RUNNING,
+      STREAM_TRANSITION_CAUSE.LIFECYCLE,
+    );
 
     expect(
       tracker.recordUsage('stream-a', {
@@ -42,21 +50,32 @@ describe('StatusBarUsageTracker', () => {
       }),
     ).toBe(true);
 
+    expect(tracker.activeStreamCount).toBe(1);
     expect(tracker.totalUsage.cost).toBeCloseTo(0.03);
     expect(tracker.totalUsage.inputTokens).toBe(40);
     expect(tracker.totalUsage.outputTokens).toBe(60);
   });
 
   it('retains accumulated usage while a stream waits for follow-up input', () => {
-    const tracker = new StatusBarUsageTracker();
-    tracker.updateStreamStatus('stream-a', STREAM_STATUS.RUNNING);
+    const status = new StreamStatusMachine();
+    const tracker = new StatusBarUsageTracker(status);
+    status.transition(
+      'stream-a',
+      STREAM_PHASE.RUNNING,
+      STREAM_TRANSITION_CAUSE.LIFECYCLE,
+    );
     tracker.recordUsage('stream-a', {
       cost: 0.01,
       inputTokens: 10,
       outputTokens: 20,
     });
 
-    tracker.updateStreamStatus('stream-a', STREAM_STATUS.WAITING);
+    status.transition(
+      'stream-a',
+      STREAM_PHASE.WAITING,
+      STREAM_TRANSITION_CAUSE.WAIT,
+    );
+    tracker.updateStreamStatus('stream-a', STREAM_PHASE.WAITING);
 
     expect(tracker.activeStreamCount).toBe(0);
     expect(
@@ -72,16 +91,27 @@ describe('StatusBarUsageTracker', () => {
   });
 
   it('ignores delayed usage after a stream reaches a final status', () => {
-    const tracker = new StatusBarUsageTracker();
-    tracker.updateStreamStatus('stream-a', STREAM_STATUS.RUNNING);
+    const status = new StreamStatusMachine();
+    const tracker = new StatusBarUsageTracker(status);
+    status.transition(
+      'stream-a',
+      STREAM_PHASE.RUNNING,
+      STREAM_TRANSITION_CAUSE.LIFECYCLE,
+    );
     tracker.recordUsage('stream-a', {
       cost: 0.01,
       inputTokens: 10,
       outputTokens: 20,
     });
 
-    tracker.updateStreamStatus('stream-a', STREAM_STATUS.READY);
+    status.transition(
+      'stream-a',
+      STREAM_PHASE.COMPLETED,
+      STREAM_TRANSITION_CAUSE.LIFECYCLE,
+    );
+    tracker.updateStreamStatus('stream-a', STREAM_PHASE.COMPLETED);
 
+    expect(tracker.activeStreamCount).toBe(0);
     expect(tracker.totalUsage).toEqual({
       cost: 0,
       inputTokens: 0,
@@ -100,7 +130,11 @@ describe('StatusBarUsageTracker', () => {
       outputTokens: 0,
     });
 
-    tracker.updateStreamStatus('stream-a', STREAM_STATUS.RUNNING);
+    status.transition(
+      'stream-a',
+      STREAM_PHASE.RUNNING,
+      STREAM_TRANSITION_CAUSE.RESUME,
+    );
     expect(
       tracker.recordUsage('stream-a', {
         cost: 0.03,
@@ -113,5 +147,29 @@ describe('StatusBarUsageTracker', () => {
       inputTokens: 50,
       outputTokens: 60,
     });
+  });
+
+  it('counts only the streams the session status plane reports as active', () => {
+    const status = new StreamStatusMachine();
+    const tracker = new StatusBarUsageTracker(status);
+
+    expect(tracker.activeStreamCount).toBe(0);
+
+    status.transition(
+      'stream-a',
+      STREAM_PHASE.RUNNING,
+      STREAM_TRANSITION_CAUSE.LIFECYCLE,
+    );
+    status.transition(
+      'stream-b',
+      STREAM_PHASE.RUNNING,
+      STREAM_TRANSITION_CAUSE.LIFECYCLE,
+    );
+    expect(tracker.activeStreamCount).toBe(2);
+
+    // A stream cleared out of the status plane without a published phase
+    // change stops being counted; there is no second copy to go stale.
+    status.clearStream('stream-b');
+    expect(tracker.activeStreamCount).toBe(1);
   });
 });


### PR DESCRIPTION
## What

`StatusBarUsageTracker` mirrored "which streams are in flight, and in what phase" into two private collections — **while being fed from the runtime's own status plane**. That made a UI class a second writer of runtime state, purely to gate its own usage accumulation. This deletes the mirror and reads the fact from its owner.

## Net elements (R6)

**Deleted**

| Construct | Was |
| --- | --- |
| `activeStreams` | `private readonly Set<string>` |
| `streamStatuses` | `private readonly Map<string, StreamLifecycleStatus>` |
| `lifecyclePhase()` | module-local function |
| 2 imports | `DEFAULT_STREAM_METADATA_STATUS`, `type StreamLifecycleStatus` |

**Added**

| Construct | Is |
| --- | --- |
| `status` ctor param | `Pick<SessionHandle['status'], 'entries' \| 'isInFlight'>` |
| 1 type-only import | `type SessionHandle` |

Net: **−3 constructs** (two collections + one function) for **+1 injected reference**. No new exports, so nothing for the dead-code ratchet.

**LoC**

| File | +/− |
| --- | --- |
| `StatusBarUsageTracker.ts` | +33 / −38 |
| `extension.ts` | +5 / −2 |
| **production total** | **−2** |
| `StatusBarUsageTracker.vitest.ts` | +61 / −11 |
| `StatusBarSessionEvents.vitest.ts` | +7 / −4 |

The test growth is mechanical, not new surface: the unit test now drives a real `StreamStatusMachine` instead of poking the deleted mirror, and each `status.transition(stream, phase, cause)` is a 3-arg call that Prettier wraps to five lines. One genuinely new test (`counts only the streams the session status plane reports as active`) accounts for ~24 of those lines. Per AGENTS.md's "fixture rule of three", the repeated machine+tracker construction and the RUNNING/lifecycle transition are extracted to two file-local helpers rather than repeated five times each.

## Consumer counts (R8)

No event emitter or consumer path is deleted or rerouted. The existing status-change subscription remains the sole production caller of `updateStreamStatus`; it now performs only usage pruning, while the tracker reads phase and activity directly from the same session status machine. Repository-wide searches found no stale constructor or method call sites.

## Host→core boundary: no new deep import

A decoupling PR must not widen the host→core surface, so the injected reference is typed off a specifier the extension **already** imports.

The first push annotated it as `Pick<StreamStatusMachine, …>`, which pulled in `@agent/runtime/StreamStatusService` as a 42nd distinct `@agent/*` specifier and correctly failed the R-b host deep-import width ratchet. The baseline was **not** bumped — legitimizing a new specifier to land a cleanup would spend the SDK program's one enforcing gate, and that baseline is currently holding.

Instead the annotation is the indexed access `Pick<SessionHandle['status'], 'entries' | 'isInFlight'>`. `@agent/runtime/SessionHandle` is already in the extension's 41-entry baseline (the sibling `statusBarSessionEvents.ts` imports it), and `SessionHandle['status']` is declared as `StreamStatusMachine` — so this is the identical structural type with zero new specifiers.

Verified by re-running the ratchet's own AST scan over `packages/extension/src`: **41 specifiers, and the set is byte-identical to the baseline** — nothing added, nothing removed, the other 40 untouched.

## Semantic-equivalence argument

This is the reviewable part. Two swaps, each argued against the mirror it replaces.

### 1. The in-flight gate — `recordUsage`

Before, `streamStatuses` was written **only** on the in-flight branch of `updateStreamStatus` and deleted otherwise. So the map's key set was exactly

```
{ s : the last phase published for s was RUNNING or WAITING }
```

and the `status === undefined || !isInFlightPhase(...)` guard was that set's membership test (the second half was already redundant — nothing non-in-flight ever entered the map).

After, the gate is `session.status.isInFlight(streamId)`, i.e. `isInFlightPhase(machine.get(streamId))` over the machine's own `phases` map (plus reservations). Since `StreamStatusMachine.publishStatus` is called **after** `this.phases.set(...)` (`StreamStatusService.ts:138` before `:143`) and after `reservations.add(...)` in `tryAcquire` (`:77` before `:78`), every listener the mirror was built from fires with the machine already holding that phase. The two key sets coincide.

### 2. The count — `activeStreamCount`

`activeStreams` was `add` on `isActivePhase(phase)` and `delete` otherwise, so its member set was `{ s : last published phase for s === RUNNING }` (`isActivePhase` is `phase === RUNNING` only; `WAITING` is in-flight but not active). After, the count is `entries()` filtered by the same `isActivePhase` predicate. `entries()` is `getAll().entries()`, which is `phases` with in-flight reservations merged in as `RUNNING` — the same population, filtered by the same predicate.

Terminal phases stay in `phases` but fail `isActivePhase`, so retention does not inflate the count.

### Scoping (semantic gate 1)

Same session, same object. The tracker was fed from `defaultSession().status.onDidChange`; it now reads `defaultSession().status` directly. `extension.ts` hoists that into one `statusBarSession` local so the constructor and `subscribeStatusBarSessionEvents` provably get the same handle rather than two `defaultSession()` calls. Both the tracker and the subscription are created once in `activate()` and disposed through `context.subscriptions`, so there is no re-subscription path that could leave an injected machine stale.

### Pruning (semantic gate 2) — deliberately preserved

The pruning that makes the status-bar tooltip *live spend of running streams* rather than an all-time total is `usageByStream.delete(streamId)`, and it is **kept verbatim**. `updateStreamStatus` still exists for exactly that: it drops a stream's accumulated spend once its phase leaves flight. Only the `streamStatuses.delete` line — the phase mirror's pruning, whose sole purpose was to make the gate above work — is gone.

Per the standing ruling, the four token/usage accumulators (`RunUsageAccumulator`, `StreamSnapshotStore.usage`, this tracker's totals, and the webview `sessionUsage` / CLI `cumulativeUsage`) are four different facts, not four copies. **Nothing in this PR touches usage accounting.**

### Where the mirror and the machine genuinely differed

Three cases, all in the "the mirror goes stale, the machine is right" direction:

1. **`clearStream` / `clearAll`** drop a stream from `phases` without publishing. The mirror kept the stream's last phase forever; the machine drops it. If that stream was `RUNNING`, the old status bar showed a phantom `TeXRA: 1 active` with no way to clear it. In practice `ProgressViewState.clearStream` only reaches `streamStatus.clearStream` after `stores.deleteStream` returns `'deleted'`, and active streams are retained by that path — so this is phantom cleanup, not a live-count change.
2. **Silent reservation release** (`releaseIfReserved`, `StreamStatusService.ts:104`) removes a reservation without publishing when the rollback transition is rejected. Same direction.
3. **Pre-subscription streams** would be invisible to the mirror. Not reachable today — the subscription is set up in `activate()` before any run starts.

None of these make the new numbers larger or otherwise change what a user sees during a normal run.

### `lifecyclePhase`'s `'ready'` branch was unreachable

Confirmed. `lifecyclePhase` returned `undefined` iff `status === DEFAULT_STREAM_METADATA_STATUS` (`= STREAM_STATUS.READY = 'ready'`). Its only production caller is `statusBarSessionEvents.ts:25`, which passes `StreamStatusChange.status` — typed `StreamPhase`, whose members are `running | waiting | completed | cancelled | failed`. `'ready'` is not among them, so the branch could never be taken outside a test that called `updateStreamStatus` directly. `updateStreamStatus` is retyped from `StreamLifecycleStatus` to `StreamPhase` to make that structural, and the one test that passed `READY` now passes `COMPLETED` — same intent ("a final status"), reachable vocabulary.

`DEFAULT_STREAM_METADATA_STATUS` and `StreamLifecycleStatus` both retain many other consumers; no export is orphaned.

## Verification

Re-run in full after the boundary fix, on a clean `CI=true corepack pnpm install`:

| Command | Result |
| --- | --- |
| `npx tsc --noEmit` | **clean, 0 errors** |
| `npx vitest run src/test-kernel/architecture/` | **9 files / 58 tests passed** (includes the R-b ratchet that failed the first push) |
| `npx vitest run src/test-kernel/frontend/` | **14 files / 54 tests passed** |
| `npm run lint` | clean |
| `npm run check:dead-code-ratchet` | OK — 18 findings vs 18 baselined, no new unused files/exports/types |
| `npx prettier --check` (4 touched files) | clean |

### Unrelated pre-existing flake, for the record

While verifying I hit intermittent failures in `src/test-kernel/architecture/subsystemEdgeRatchet.vitest.ts` — a file this PR does not touch. It is **not** an assertion failure:

```
Error: Test timed out in 10000ms.
 ❯ src/test-kernel/architecture/subsystemEdgeRatchet.vitest.ts:360:3
```

That test does a full-tree AST scan measured at ~9s against the repo's `testTimeout: 10000`, so it tips over whenever the machine is loaded (it failed while a parallel `tsc` was running, and passed when idle). Re-run with `--testTimeout=120000` it passes 3/3, and both CI kernel shards are green. Flagging it as a latent perf flake worth its own issue; deliberately not fixed here to keep this PR scoped.

https://claude.ai/code/session_01XZ8Z6rhypTfkVq728XCcCd

