### PR TITLE
chore: delete the inert HostInteractionOptions.timeoutMs option

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -13,9 +13,7 @@
 // Promise<ToolEditApprovalResult>, not a fire-and-forget event.
 
 import { nanoid } from 'nanoid';
-import pDefer from 'p-defer';
 import PQueue from 'p-queue';
-import pTimeout from 'p-timeout';
 
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import {
@@ -23,7 +21,6 @@ import {
   type HostBashApprovalRequest,
   type HostBashApprovalResult,
   type HostInteractionCancelSelector,
-  type HostInteractionOptions,
   type HostInteractions,
   type HostRetryInteractionOptions,
   type HostRetryRequest,
@@ -156,86 +153,27 @@ export function createTuiHostInteractions(
         ? { accepted: true, appliedContent: request.proposedContent }
         : { accepted: false, userMessage: decision.userMessage };
     },
-    requestBashApproval(request, options) {
+    requestBashApproval(request) {
       const requestId = `bash-${nanoid()}`;
-      return withInteractionTimeout(
-        () => requestBashInteraction(request, context, host, requestId),
-        options,
-        {
-          accepted: false,
-          userMessage: 'Approval request timed out.',
-          timedOut: true,
-        },
-        () =>
-          clearApprovalsWhere(
-            (payload) =>
-              payload.kind === 'bash' &&
-              payload.payload.requestId === requestId,
-            NEUTRAL_TIMEOUT_DECISION,
-          ),
-      );
+      return requestBashInteraction(request, context, host, requestId);
     },
-    requestPlanApproval(request, options) {
-      return withInteractionTimeout(
-        () => requestPlanInteraction(request, context),
-        options,
-        { action: 'timeout' },
-        () =>
-          clearApprovalsWhere(
-            (payload) =>
-              payload.kind === 'plan' &&
-              payload.payload.approvalId === request.approvalId,
-            NEUTRAL_TIMEOUT_DECISION,
-          ),
-      );
+    requestPlanApproval(request) {
+      return requestPlanInteraction(request, context);
     },
-    requestAgentProposal(request, options) {
-      return withInteractionTimeout(
-        () => requestProposalInteraction(request, context, host),
-        options,
-        { action: 'timeout' },
-        () =>
-          clearApprovalsWhere(
-            (payload) =>
-              payload.kind === 'proposal' &&
-              payload.payload.proposalId === request.proposalId,
-            NEUTRAL_TIMEOUT_DECISION,
-          ),
-      );
+    requestAgentProposal(request) {
+      return requestProposalInteraction(request, context, host);
     },
     requestRetry(request, options) {
-      return withInteractionTimeout(
-        () =>
-          requestRetryInteraction(
-            request,
-            context,
-            retryRoutes,
-            retryCredentialCommitQueue,
-            options,
-          ),
+      return requestRetryInteraction(
+        request,
+        context,
+        retryRoutes,
+        retryCredentialCommitQueue,
         options,
-        { action: 'timeout' },
-        () => {
-          settleRetryRoute(retryRoutes, request.streamId, {
-            action: 'timeout',
-          });
-          clearRetryApprovalsForStream(request.streamId);
-        },
       );
     },
-    askUserQuestion(request, options) {
-      return withInteractionTimeout(
-        () => requestUserQuestionInteraction(request, context),
-        options,
-        { submitted: false, feedback: 'Approval request timed out.' },
-        () =>
-          clearApprovalsWhere(
-            (payload) =>
-              payload.kind === 'userQuestion' &&
-              payload.payload.requestId === request.requestId,
-            NEUTRAL_TIMEOUT_DECISION,
-          ),
-      );
+    askUserQuestion(request) {
+      return requestUserQuestionInteraction(request, context);
     },
     openExternalInquiry(request) {
       return openExternalInquiryInteraction(request, context);
@@ -317,51 +255,6 @@ function prepareRetryClient(
   signal: AbortSignal,
 ): Promise<void> {
   return runRetryTask(() => prepare(selection, signal), signal);
-}
-
-const NEUTRAL_TIMEOUT_DECISION: ApprovalDecision = {
-  accepted: true,
-  userMessage: 'Approval request timed out.',
-};
-
-function validTimeoutMs(timeoutMs: number | undefined): number | undefined {
-  if (timeoutMs == null || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
-    return undefined;
-  }
-  return Math.max(1, Math.floor(timeoutMs));
-}
-
-/**
- * Race an interaction against `options.timeoutMs`, including any async work
- * the interaction does *before* it reaches the modal queue (e.g. the
- * auto-switch retry route's keychain lookup in `beforeQueue`). `start` is a
- * thunk rather than an already-created Promise so the timer is armed before
- * that work begins — a hanging pre-queue lookup still times out on schedule
- * instead of extending the interaction past the intended bound.
- */
-function withInteractionTimeout<T>(
-  start: () => Promise<T>,
-  options: HostInteractionOptions | undefined,
-  timeoutResult: T,
-  onTimeout: () => void,
-): Promise<T> {
-  const timeoutMs = validTimeoutMs(options?.timeoutMs);
-  if (timeoutMs == null) return start();
-
-  const interaction = pDefer<T>();
-  const timedInteraction = pTimeout(interaction.promise, {
-    milliseconds: timeoutMs,
-    fallback: () => {
-      onTimeout();
-      return timeoutResult;
-    },
-  });
-  try {
-    start().then(interaction.resolve, interaction.reject);
-  } catch (error) {
-    interaction.reject(error);
-  }
-  return timedInteraction;
 }
 
 function isActiveRetryRoute(

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -49,7 +49,6 @@ export type ToolNotificationHandler = (
 ) => void;
 
 export interface HostInteractionOptions {
-  readonly timeoutMs?: number;
   /** Internal identity used to cancel one forwarded presentation request. */
   readonly cancellationScope?: object;
 }

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
@@ -84,7 +84,6 @@ import {
   streams,
 } from '@cli/chat/tui/state/cliState';
 import { createTuiHostInteractions } from '@cli/chat/tui/state/subscribeApprovals';
-import { hasCliApprovalDenied } from '@cli/runtime/approvalAdapter';
 import type { CliContext } from '@cli/runtime/cliContext';
 import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
 import type { ApiProvider } from '@model/apiProviders';
@@ -1173,63 +1172,6 @@ describe('TUI retry approvals', () => {
     clearApprovals();
     await expect(result).resolves.toEqual({ action: 'cancel' });
     expect(currentApproval.get()).toBeUndefined();
-  });
-
-  it('times out an active plan approval modal', async () => {
-    const { cliContext, interactions } = tui();
-    const result = interactions.requestPlanApproval?.(
-      {
-        approvalId: 'plan-timeout',
-        streamId: 'plan-stream',
-        goalEnabled: false,
-        plan: { objective: 'Check the timeout path.' },
-      },
-      { timeoutMs: 10 },
-    );
-
-    await vi.waitFor(() => {
-      expect(currentApproval.get()?.payload).toMatchObject({
-        kind: 'plan',
-        payload: { approvalId: 'plan-timeout' },
-      });
-    });
-    await expect(result).resolves.toEqual({ action: 'timeout' });
-    expect(hasCliApprovalDenied(cliContext)).toBe(false);
-  });
-
-  it('times out an active retry modal', async () => {
-    mocks.hasUsableApiKey.mockResolvedValue(false);
-
-    const { cliContext, interactions } = tui();
-    const result = interactions.requestRetry?.(
-      relayRetry({ streamId: 'retry-timeout', provider: 'openai' }),
-      { timeoutMs: 100 },
-    );
-
-    await vi.waitFor(() => {
-      expect(currentApproval.get()?.payload).toMatchObject({
-        kind: 'retry',
-        payload: { streamId: 'retry-timeout' },
-      });
-    });
-    await expect(result).resolves.toEqual({ action: 'timeout' });
-    expect(hasCliApprovalDenied(cliContext)).toBe(false);
-  });
-
-  it('times out while a retry is still waiting on the keychain', async () => {
-    mocks.hasUsableApiKey.mockImplementation(
-      () => new Promise(() => undefined),
-    );
-
-    const { cliContext, interactions } = tui();
-    const result = interactions.requestRetry?.(
-      relayRetry({ streamId: 'lookup-timeout', provider: 'openai' }),
-      { timeoutMs: 10 },
-    );
-
-    await expect(result).resolves.toEqual({ action: 'timeout' });
-    expect(currentApproval.get()).toBeUndefined();
-    expect(hasCliApprovalDenied(cliContext)).toBe(false);
   });
 
   it('ignores stale auto-switch lookups after a newer retry replaces them', async () => {

--- a/src/test-kernel/cli/TuiHostInteractionsCancelForStream.vitest.mts
+++ b/src/test-kernel/cli/TuiHostInteractionsCancelForStream.vitest.mts
@@ -1,7 +1,6 @@
-// Regression coverage for #7306 (per-stream cancel only cancelled retry routes)
-// and #7307 (requestPlanApproval/requestAgentProposal/requestRetry dropped
-// HostInteractionOptions.timeoutMs). Both were flagged by bot review against
-// PR #7303 and left unaddressed at merge.
+// Regression coverage for #7306 (per-stream cancel only cancelled retry
+// routes), flagged by bot review against PR #7303 and left unaddressed at
+// merge.
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -16,12 +15,7 @@ import {
 import { createTuiHostInteractions } from '@cli/chat/tui/state/subscribeApprovals';
 import type { CliContext } from '@cli/runtime/cliContext';
 import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
-import {
-  AgentCategory,
-  type AgentProposal,
-  type Plan,
-  type UserQuestionPermission,
-} from '@shared/schemas';
+import { AgentCategory, type AgentProposal, type Plan } from '@shared/schemas';
 import { createTestCliContext } from '@test/cli/fixtures/cliContext';
 
 function context(): CliContext {
@@ -46,18 +40,6 @@ const proposal: AgentProposal = {
   instruction: 'Review the change.',
   memories: [],
 };
-const question: UserQuestionPermission = {
-  requestId: 'question-timeout',
-  allowBypass: false,
-  streamId: 'stream-a',
-  questions: [
-    {
-      question: 'Continue?',
-      options: [{ label: 'Yes' }, { label: 'No' }],
-    },
-  ],
-};
-
 afterEach(() => {
   clearApprovals();
 });
@@ -232,120 +214,6 @@ describe('createTuiHostInteractions().cancel', () => {
       });
       currentApproval.get()?.decide({ accepted: true });
       await expect(planResult).resolves.toEqual({ action: 'approve' });
-    } finally {
-      interactions.dispose?.();
-    }
-  });
-});
-
-describe('HostInteractionOptions.timeoutMs threading', () => {
-  it('accepts a positive fractional timeout', async () => {
-    const interactions = createTuiHostInteractions(host(), context());
-    try {
-      const result = interactions.requestPlanApproval?.(
-        {
-          approvalId: 'approval-fractional-timeout',
-          streamId: 'stream-a',
-          plan,
-          goalEnabled: false,
-        },
-        { timeoutMs: 0.5 },
-      );
-
-      await expect(result).resolves.toEqual({ action: 'timeout' });
-      expect(currentApproval.get()).toBeUndefined();
-    } finally {
-      interactions.dispose?.();
-    }
-  });
-
-  it('times out a plan approval that outlives timeoutMs without user input', async () => {
-    const interactions = createTuiHostInteractions(host(), context());
-    try {
-      const result = interactions.requestPlanApproval?.(
-        {
-          approvalId: 'approval-timeout',
-          streamId: 'stream-a',
-          plan,
-          goalEnabled: false,
-        },
-        { timeoutMs: 15 },
-      );
-
-      await expect(result).resolves.toEqual({ action: 'timeout' });
-      expect(currentApproval.get()).toBeUndefined();
-    } finally {
-      interactions.dispose?.();
-    }
-  });
-
-  it('times out an agent proposal that outlives timeoutMs without user input', async () => {
-    const interactions = createTuiHostInteractions(host(), context());
-    try {
-      const result = interactions.requestAgentProposal?.(
-        { proposalId: 'proposal-timeout', streamId: 'stream-a', ...proposal },
-        { timeoutMs: 15 },
-      );
-
-      await expect(result).resolves.toEqual({ action: 'timeout' });
-      expect(currentApproval.get()).toBeUndefined();
-    } finally {
-      interactions.dispose?.();
-    }
-  });
-
-  it('times out a retry request that outlives timeoutMs without user input', async () => {
-    const interactions = createTuiHostInteractions(host(), context());
-    try {
-      const result = interactions.requestRetry?.(
-        {
-          requestId: 'retry:timeout',
-          streamId: 'stream-a',
-          operation: 'Model invocation',
-        },
-        { timeoutMs: 15 },
-      );
-
-      await expect(result).resolves.toEqual({ action: 'timeout' });
-      expect(currentApproval.get()).toBeUndefined();
-    } finally {
-      interactions.dispose?.();
-    }
-  });
-
-  it('times out a bash approval that outlives timeoutMs without user input', async () => {
-    const interactions = createTuiHostInteractions(host(), context());
-    try {
-      const result = interactions.requestBashApproval?.(
-        { command: 'echo hi', streamId: 'stream-a' },
-        { timeoutMs: 15 },
-      );
-
-      // #7444: the timeout carries a distinct `timedOut: true` flag so it
-      // doesn't collapse into the same shape as an explicit user rejection.
-      await expect(result).resolves.toEqual({
-        accepted: false,
-        userMessage: 'Approval request timed out.',
-        timedOut: true,
-      });
-      expect(currentApproval.get()).toBeUndefined();
-    } finally {
-      interactions.dispose?.();
-    }
-  });
-
-  it('times out a user question that outlives timeoutMs without user input', async () => {
-    const interactions = createTuiHostInteractions(host(), context());
-    try {
-      const result = interactions.askUserQuestion?.(question, {
-        timeoutMs: 15,
-      });
-
-      await expect(result).resolves.toEqual({
-        submitted: false,
-        feedback: 'Approval request timed out.',
-      });
-      expect(currentApproval.get()).toBeUndefined();
     } finally {
       interactions.dispose?.();
     }


### PR DESCRIPTION
## What

Deletes `HostInteractionOptions.timeoutMs` and the CLI TUI machinery that honored it. Pure deletion — no behavior change, because the option was never set by any production caller, so the timer was never armed.

Implements **DR4** of `docs/proposals/2026-07-09-host-parity-audit.md` ("`HostInteractionOptions.timeoutMs` is fully inert"), also flagged as a do-now by the abstraction-calibration audit.

**This is not a revert of #7307/#7444.** Those PRs wired the TUI consumer correctly (per-kind threading, the distinct `timedOut: true` bash flag) against an option that no caller sets. The consumer was right; the option is the dead part.

## Go/no-go evidence: no production setter exists

Every `timeoutMs` occurrence in the repo, checked against `origin/main` @ `5fc03f9436`:

```
$ rg -n 'timeoutMs' src/agent/runtime/HostInteractions.ts
52:  readonly timeoutMs?: number;          # the declaration itself — zero core setters
```

Repo-wide (`rg -n 'timeoutMs' src packages -g '*.ts' -g '*.tsx'`, plus a second pass over `.mts`/`.mjs`) returns ~100 hits. Every one outside this contract belongs to an unrelated subsystem: `src/tools/bash.ts`, `src/tools/setup/SendToTerminalTool.ts`, `src/tools/timeouts.ts`, `src/hosts/uiHosts.ts` (`TerminalRunRequest`), `src/latex/latexdiff/diffCommandExecutor.ts`, `src/agent/workflowScript/*` (`meta.timeoutMs`), `src/agent/output/compileCheck.ts`, `src/auth/fetchWithTimeout.ts`, `packages/cli/src/runtime/updateChecker.ts`, `packages/desktop/src/main/*`, `packages/extension/src/frontend/*`, `src/test-kernel/support/asyncTestUtils.ts`. None of them constructs a `HostInteractionOptions`.

The only sites that touch **this** field:

| Site | Kind |
| --- | --- |
| `src/agent/runtime/HostInteractions.ts:52` | declaration |
| `packages/cli/src/chat/tui/state/subscribeApprovals.ts:327,342,348` | the CLI consumer |
| `src/test-kernel/cli/TuiHostInteractionsCancelForStream.vitest.mts` (6 tests) | **test-only** setter |
| `src/test-kernel/cli/TuiApprovalRetry.vitest.mts:1187,1206,1227` (3 tests) | **test-only** setter |

Confirmed from the other direction too — every construction site of an interaction options object was inspected (`rg -n 'HostInteractionOptions'` + `rg -n 'cancellationScope'` + all `.request*/.askUserQuestion(` call sites). Exactly **one** production call site passes a second argument at all:

- `src/agent/core/flows/RetryState.ts:354` → `{ prepareRetry }` only, directly under the comment `// No timeout: the retry panel waits indefinitely for the user's decision.`

Extension (`extensionHostInteractions.ts`) and desktop (`desktopHostInteractions.ts`, `desktopToolEditApproval.ts`) read only `options.cancellationScope`; neither ever read `timeoutMs`. No setting derives it either — the only timeout settings keys are `texra.workflow.autoCompileTimeoutMs` and `texra.latexdiff.timeoutMs`.

Git history (`git log -S 'withInteractionTimeout'`) shows three touches — `ce503b1dd7` (#7325, added the consumer), `21adbc3120` (#7327, fixed gaps in it), `cd89571dca` (the audit doc that rules it inert) — and `git log -S 'timeoutMs' -- src/agent/runtime/HostInteractions.ts` shows a single commit, `2c0155d4db` (#7303), which introduced the field. **The option was born without a setter and never gained one.** No user-visible timeout is removed by this PR.

## Net-element accounting

Constructs **added: 0**. Constructs **deleted: 9** (+ 9 tests):

| Deleted | Where |
| --- | --- |
| `HostInteractionOptions.timeoutMs` (interface member) | `HostInteractions.ts` |
| `withInteractionTimeout` (function) | `subscribeApprovals.ts` |
| `validTimeoutMs` (function) | `subscribeApprovals.ts` |
| `NEUTRAL_TIMEOUT_DECISION` (const, only used by the timeout callbacks) | `subscribeApprovals.ts` |
| `pDefer`, `pTimeout`, `type HostInteractionOptions` imports | `subscribeApprovals.ts` |
| `question` fixture + `UserQuestionPermission` / `hasCliApprovalDenied` imports | test files |
| `describe('HostInteractionOptions.timeoutMs threading')` — 6 tests | `TuiHostInteractionsCancelForStream.vitest.mts` |
| 3 `times out …` tests | `TuiApprovalRetry.vitest.mts` |

**Net LoC: +17 / −315 = −298.** No new exports (dead-code ratchet is a strict net deletion). `p-defer` and `p-timeout` stay in `package.json` — both still have many other consumers.

The five approval entry points are unwrapped in place and keep their exact return types and error handling: `requestRetry` still forwards `options` (for `prepareRetry`); the other four dropped a parameter they no longer read.

## Deliberate scope boundary

Left alone (would change result types, so out of scope for a pure-deletion PR): the now-unproducible `{ action: 'timeout' }` variants on `PlanApprovalResult` / `ProposalResult` / `RetrySettlement` and the `timedOut?: boolean` flag on `HostBashApprovalResult` (still read by `src/tools/approval/bashApproval.ts`). DR4 lists those dead branches as a follow-up.

## Verification

- `npm run typecheck` — clean (all 6 projects)
- `npx eslint` on the 4 changed files — clean; `prettier --check` — clean
- `npm run check:dead-code-ratchet` — `18 current vs 18 baselined`, OK
- CLI approval/TUI suites: `TuiHostInteractionsCancelForStream`, `TuiApprovalRetry`, `ApprovalQueue`, `ApprovalAdapter`, `PlanApproval`, `BashApproval`, `EditApproval` — **7 files, 88 tests passed**
- Core interaction suites: `SessionInteractions`, `SessionHandle`, `ApprovalCleanupScope`, `ToolEditApprovalGate`, `ApprovalRequestHandler`, `ApprovalRequestHandlerSet` — **6 files, 67 tests passed**

https://claude.ai/code/session_01XZ8Z6rhypTfkVq728XCcCd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure deletion of dead code with no production setter for `timeoutMs`; interactive approval behavior is unchanged in practice.
> 
> **Overview**
> Removes **`HostInteractionOptions.timeoutMs`** from the runtime contract and strips the CLI TUI layer that raced approval interactions against that timer (`withInteractionTimeout`, `validTimeoutMs`, `NEUTRAL_TIMEOUT_DECISION`, plus `p-defer` / `p-timeout` usage in `subscribeApprovals.ts`).
> 
> **Bash, plan, proposal, user-question, and retry** entry points now call their interaction helpers directly; **`requestRetry`** still accepts options for **`prepareRetry`** only. Result types still include timeout-shaped variants (`action: 'timeout'`, bash `timedOut`) but those paths are no longer reachable from the TUI via `timeoutMs`.
> 
> Test-only coverage for modal timeouts and the **`#7307`** timeout-threading regression block is removed; per-stream **cancel** tests remain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9fa418c584c63f16abf0fb1e332a2ae14235bdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->