### PR TITLE
fix(cli): register the agent shutdown handlers

### DIFF
--- a/config/ratchets/host-agent-import-baseline.json
+++ b/config/ratchets/host-agent-import-baseline.json
@@ -14,6 +14,7 @@
       "@agent/index/platformAgentDirectories",
       "@agent/modelHandlers/support/contextUtilization",
       "@agent/runtime/AgentRuntimeHost",
+      "@agent/runtime/agentShutdown",
       "@agent/runtime/detachSubagentsOnStop",
       "@agent/runtime/executeAgent",
       "@agent/runtime/executionRegistry",

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -3,6 +3,7 @@ import * as nodePath from 'node:path';
 
 // Local imports
 import { createPlatformAgentDirectories } from '@agent/index/platformAgentDirectories';
+import { registerAgentShutdownHandlers } from '@agent/runtime/agentShutdown';
 import {
   getServerSideKeyService,
   initializeServerSideKeyAccess,
@@ -314,6 +315,15 @@ export async function initCliPlatform(
     // injections and the direct Lean language services (errors surface via the
     // Tools dashboard if `lake` isn't on PATH).
     initNodeAgentRuntime(lifecycle);
+
+    // Kill agent-spawned OS children before the process dies, exactly as the
+    // extension and desktop hosts do. Background `bash` runs are spawned
+    // `detached` (their own process group, see execUtils) so they survive
+    // `texra` exiting and can never deliver their follow-up result — without
+    // this drain they are orphaned. Registered before the usage-log flush
+    // below so the kills (all synchronous) land first, matching the other
+    // hosts' ordering.
+    registerAgentShutdownHandlers(lifecycle);
 
     // Attribute agent-authored commits to the TeXRA identity by default;
     // configurable via `.texra/config.json` `texra.git.markCommits`.

--- a/src/agent/runtime/agentShutdown.ts
+++ b/src/agent/runtime/agentShutdown.ts
@@ -8,8 +8,8 @@ import { killAllSessionBackgroundProcesses } from './SessionHandle';
 
 /**
  * Stops agent-spawned child processes and CLI-backed agent sessions before
- * host teardown. Every long-lived host (VS Code extension, Electron desktop)
- * registers these so agent work never outlives the host.
+ * host teardown. Every host (VS Code extension, Electron desktop, terminal
+ * CLI) registers these so agent work never outlives the host.
  */
 export function registerAgentShutdownHandlers(lifecycle: LifecycleHost): void {
   lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>

--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -560,11 +560,12 @@ export function startChildRunLoop<TTurn>(
       : undefined;
   } catch (error) {
     // Preserve the setup error while unwinding every resource acquired so far.
+    const cleanupErrors: unknown[] = [];
     const cleanup = (operation: () => void): void => {
       try {
         operation();
-      } catch {
-        // Setup is already failing; continue the remaining cleanup.
+      } catch (cleanupError) {
+        cleanupErrors.push(cleanupError);
       }
     };
     cleanup(() => sessionStage?.end(RUN_OUTCOME.FAILED));
@@ -575,6 +576,12 @@ export function startChildRunLoop<TTurn>(
     });
     cleanup(() => stopWatchingLease?.());
     cleanup(releaseSessionOwnershipOnce);
+    if (cleanupErrors.length > 0) {
+      throw new AggregateError(
+        [error, ...cleanupErrors],
+        `Child run ${executionId} setup failed and rollback was incomplete`,
+      );
+    }
     throw error;
   }
 

--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -10,7 +10,7 @@
 // Host-agnostic, VS Code-free.
 
 import { synchronizeAgentResultOutcome, type ResultMeta } from '@agent/storage';
-import type { AgentTrace } from '@agent/trace';
+import type { AgentTrace, StageHandle } from '@agent/trace';
 import { createChannelTrace } from '@agent/trace';
 import {
   markOwnedExecutionLeaseUndurable,
@@ -518,16 +518,17 @@ export function startChildRunLoop<TTurn>(
   runWithOwnedExecutionLease(executionId, () => undefined);
 
   const runSession = currentSession();
-  strategy.onLoopStart?.(runSession);
+  let sessionOwnershipReleased = false;
+  const releaseSessionOwnershipOnce = (): void => {
+    if (sessionOwnershipReleased) return;
+    sessionOwnershipReleased = true;
+    strategy.releaseSessionOwnership?.();
+  };
+
   const loop = new ChildRunInterruptible(runSession, childStreamId);
-  const stopWatchingLease = onOwnedExecutionLeaseLost(executionId, () => {
-    logger.error('Execution lease was lost; interrupting the former owner', {
-      data: { executionId, childStreamId },
-    });
-    loop.interrupt();
-  });
-  const queue = runSession.followUps.acquire(childStreamId);
-  loop.setQueue(queue);
+  let stopWatchingLease: (() => void) | undefined;
+  let queue!: FollowUpQueue;
+  let queueAcquired = false;
   let attachedHandle: AgentExecutionHandle | undefined;
   let detachLoopInterrupt: (() => void) | undefined;
   const attachLoopInterrupt = (): void => {
@@ -537,19 +538,45 @@ export function startChildRunLoop<TTurn>(
     attachedHandle = handle;
     detachLoopInterrupt = handle.attachInterruptHandler(loop);
   };
-  attachLoopInterrupt();
-  const unregisterChildRunLoop =
-    runSession.executions.registerChildRunLoop(childStreamId);
+  let unregisterChildRunLoop: (() => void) | undefined;
+  let sessionStage: StageHandle | undefined;
 
-  const sessionStage = childStream
-    ? logger.openStage(strategy.stageLabel)
-    : undefined;
-  let sessionOwnershipReleased = false;
-  const releaseSessionOwnershipOnce = (): void => {
-    if (sessionOwnershipReleased) return;
-    sessionOwnershipReleased = true;
-    strategy.releaseSessionOwnership?.();
-  };
+  try {
+    strategy.onLoopStart?.(runSession);
+    stopWatchingLease = onOwnedExecutionLeaseLost(executionId, () => {
+      logger.error('Execution lease was lost; interrupting the former owner', {
+        data: { executionId, childStreamId },
+      });
+      loop.interrupt();
+    });
+    queue = runSession.followUps.acquire(childStreamId);
+    queueAcquired = true;
+    loop.setQueue(queue);
+    attachLoopInterrupt();
+    unregisterChildRunLoop =
+      runSession.executions.registerChildRunLoop(childStreamId);
+    sessionStage = childStream
+      ? logger.openStage(strategy.stageLabel)
+      : undefined;
+  } catch (error) {
+    // Preserve the setup error while unwinding every resource acquired so far.
+    const cleanup = (operation: () => void): void => {
+      try {
+        operation();
+      } catch {
+        // Setup is already failing; continue the remaining cleanup.
+      }
+    };
+    cleanup(() => sessionStage?.end(RUN_OUTCOME.FAILED));
+    cleanup(() => unregisterChildRunLoop?.());
+    cleanup(() => detachLoopInterrupt?.());
+    cleanup(() => {
+      if (queueAcquired) runSession.followUps.release(childStreamId);
+    });
+    cleanup(() => stopWatchingLease?.());
+    cleanup(releaseSessionOwnershipOnce);
+    throw error;
+  }
 
   let latestCostUsd: number | undefined;
   const ports: ChildRunPorts = {
@@ -676,7 +703,7 @@ export function startChildRunLoop<TTurn>(
       }
     } finally {
       detachLoopInterrupt?.();
-      unregisterChildRunLoop();
+      unregisterChildRunLoop?.();
       runSession.followUps.release(childStreamId);
       releaseSessionOwnershipOnce();
       try {
@@ -769,7 +796,7 @@ export function startChildRunLoop<TTurn>(
             data: { executionId, error },
           });
         } finally {
-          stopWatchingLease();
+          stopWatchingLease?.();
         }
       }
     }

--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -128,6 +128,9 @@ export interface ChildRunStrategy<TTurn> {
   /** Log a turn-level error message for a non-throwing failure. */
   onTurnError?(turn: TTurn, logger: AgentTrace): void;
 
+  /** After loop setup, before the initial turn starts. */
+  onLoopStart?(session: SessionHandle): void;
+
   /** After a successful turn: register the session/thread id, etc. */
   onTurnSuccess?(turn: TTurn, session: SessionHandle): void;
 
@@ -515,6 +518,7 @@ export function startChildRunLoop<TTurn>(
   runWithOwnedExecutionLease(executionId, () => undefined);
 
   const runSession = currentSession();
+  strategy.onLoopStart?.(runSession);
   const loop = new ChildRunInterruptible(runSession, childStreamId);
   const stopWatchingLease = onOwnedExecutionLeaseLost(executionId, () => {
     logger.error('Execution lease was lost; interrupting the former owner', {

--- a/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
@@ -22,7 +22,8 @@ import {
   clearStreamStatusForTest,
   seedStreamStatusForTest,
 } from '@test/helpers/streamStatusTestUtils';
-import { createChildStream } from '@tools/childStream';
+import { launchAgentCliSession } from '@tools/agentCliShared';
+import { createChildStream, type ChildStream } from '@tools/childStream';
 
 // Local file imports
 import {
@@ -471,6 +472,64 @@ describe('child stream progress events', () => {
       });
     } finally {
       recorded.detach();
+    }
+  });
+
+  it('finalizes a child stream when agent CLI loop setup fails synchronously', async () => {
+    const active = createRecordingHost();
+    const setupError = new Error('child loop setup failed');
+    const session = defaultSession();
+    const recorded = recordSessionEvents(session.events);
+    let childStream: ChildStream | undefined;
+    let childExecutionId: ExecutionId | undefined;
+    let handle: ReturnType<typeof session.executions.getAgentHandleByStream>;
+
+    try {
+      await expect(
+        launchAgentCliSession({
+          parentStreamId,
+          parentExecutionId: undefined,
+          runtimeHost: active.host,
+          agentName: 'codex',
+          streamPrefix: 'codex',
+          description: 'Fail during synchronous loop setup',
+          config,
+          registerFailedMessage: 'registration failed',
+          startLoop: (context) => {
+            childStream = context.childStream;
+            childExecutionId = context.executionId;
+            handle = session.executions.getAgentHandleByStream(
+              context.childStream.childStreamId,
+            );
+            throw setupError;
+          },
+          summary: 'unreachable',
+          launchedLine: 'unreachable',
+          followUpLine: 'unreachable',
+        }),
+      ).rejects.toBe(setupError);
+
+      expect(childStream).toBeDefined();
+      expect(childExecutionId).toBeDefined();
+      expect(handle).toBeDefined();
+      if (!childStream || !childExecutionId || !handle) {
+        throw new Error('expected the failed child launch to be captured');
+      }
+      expect(session.executions.getHandle(childExecutionId)).toBeUndefined();
+      expect(session.status.get(childStream.childStreamId)).toBe(
+        STREAM_PHASE.FAILED,
+      );
+      await expect(handle.result).resolves.toMatchObject({
+        type: 'result',
+        outcome: 'failed',
+        executionId: childExecutionId,
+        streamId: childStream.childStreamId,
+      });
+    } finally {
+      recorded.detach();
+      if (childStream) {
+        clearStreamStatusForTest(session.status, childStream.childStreamId);
+      }
     }
   });
 

--- a/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
+++ b/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
@@ -315,6 +315,7 @@ describe('childRunLoop E2E fixtures', () => {
     const childStreamId = uniqueStreamId('complete-followup');
     const parentStreamId = 'parent' as StreamTabId;
     const { strategy, callCount, resolveTurn } = createFakeStrategy();
+    const onLoopStart = vi.fn();
     const onTurnSuccess = vi.fn();
     const parentWake = vi.fn();
     const deliveryCompleted = pDefer<{ kind: 'delivered' }>();
@@ -328,9 +329,11 @@ describe('childRunLoop E2E fixtures', () => {
       parentStreamId,
       executionId: 'exec-complete-followup' as ExecutionId,
       agentName: 'fake',
-      strategy: { ...strategy, onTurnSuccess },
+      strategy: { ...strategy, onLoopStart, onTurnSuccess },
     });
 
+    expect(onLoopStart).toHaveBeenCalledOnce();
+    expect(onLoopStart).toHaveBeenCalledWith(session);
     await vi.waitFor(() =>
       expect(isChildRunLoopActive(childStreamId)).toBe(true),
     );

--- a/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
+++ b/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
@@ -285,6 +285,55 @@ describe('childRunLoop E2E fixtures', () => {
     }
   });
 
+  it('reports rollback failures after completing later cleanup actions', () => {
+    const childStreamId = uniqueStreamId('setup-rollback-failure');
+    const parentStreamId = 'parent' as StreamTabId;
+    const executionId = 'exec-setup-rollback-failure' as ExecutionId;
+    const setupError = new Error('loop registration failed');
+    const cleanupError = new Error('queue release failed');
+    const releaseSessionOwnership = vi.fn();
+    const handle = trackChildHandle(executionId, parentStreamId, childStreamId);
+    const registerLoop = vi
+      .spyOn(session.executions, 'registerChildRunLoop')
+      .mockImplementationOnce(() => {
+        throw setupError;
+      });
+    const releaseQueue = vi
+      .spyOn(session.followUps, 'release')
+      .mockImplementationOnce(() => {
+        throw cleanupError;
+      });
+    const { strategy } = createFakeStrategy();
+    let thrown: unknown;
+
+    try {
+      try {
+        startChildRunLoop({
+          childStreamId,
+          parentStreamId,
+          executionId,
+          agentName: 'fake-cli',
+          strategy: { ...strategy, releaseSessionOwnership },
+        });
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(AggregateError);
+      expect((thrown as AggregateError).errors).toEqual([
+        setupError,
+        cleanupError,
+      ]);
+      expect(releaseSessionOwnership).toHaveBeenCalledOnce();
+      expect(mocks.leaseLossListener).toBeUndefined();
+      expect(handle.interrupt()).toBe(false);
+    } finally {
+      registerLoop.mockRestore();
+      releaseQueue.mockRestore();
+      session.followUps.release(childStreamId);
+    }
+  });
+
   it.each([
     {
       name: 'CodexThreads',

--- a/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
+++ b/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
@@ -75,6 +75,11 @@ import {
   type StreamPhase,
   type StreamTabId,
 } from '@shared/schemas';
+import { AgentCliSessionRegistry } from '@tools/agentCliSessionRegistry';
+import {
+  ClaudeAgentSessions,
+  CodexThreads,
+} from '@tools/agentCliSessionStores';
 
 let session: SessionHandle;
 const trackedExecutionIds = new Set<string>();
@@ -220,6 +225,171 @@ describe('childRunLoop E2E fixtures', () => {
     expect(mocks.leaseLossListener).toBeUndefined();
     expect(callCount()).toBe(0);
   });
+
+  it('unwinds provider ownership and loop resources when synchronous setup fails', () => {
+    const childStreamId = uniqueStreamId('setup-failure');
+    const parentStreamId = 'parent' as StreamTabId;
+    const executionId = 'exec-setup-failure' as ExecutionId;
+    const registry = new AgentCliSessionRegistry('test_session_id');
+    const releaseSessionOwnership = vi.fn(() =>
+      registry.releaseByExecutionId(executionId),
+    );
+    const handle = trackChildHandle(executionId, parentStreamId, childStreamId);
+    const interruptHandle = vi.spyOn(handle, 'interrupt');
+    const registerLoop = vi
+      .spyOn(session.executions, 'registerChildRunLoop')
+      .mockImplementationOnce(() => {
+        throw new Error('loop registration failed');
+      });
+    const { strategy } = createFakeStrategy();
+
+    try {
+      expect(() =>
+        startChildRunLoop({
+          childStreamId,
+          parentStreamId,
+          executionId,
+          agentName: 'fake-cli',
+          strategy: {
+            ...strategy,
+            onLoopStart: (runSession) => {
+              registry.trackInFlight({
+                childStreamId,
+                executionId,
+                executions: runSession.executions,
+              });
+            },
+            releaseSessionOwnership,
+          },
+        }),
+      ).toThrow('loop registration failed');
+
+      expect(releaseSessionOwnership).toHaveBeenCalledOnce();
+      expect(isChildRunLoopActive(childStreamId)).toBe(false);
+      expect(mocks.leaseLossListener).toBeUndefined();
+      expect(handle.interrupt()).toBe(false);
+      interruptHandle.mockClear();
+      registry.interruptAll();
+      expect(interruptHandle).not.toHaveBeenCalled();
+      expect(
+        session.followUps.enqueue(
+          childStreamId,
+          { text: 'must stay released' },
+          { createIfMissing: true },
+        ),
+      ).toBe(false);
+    } finally {
+      registerLoop.mockRestore();
+      interruptHandle.mockRestore();
+      registry.releaseByExecutionId(executionId);
+    }
+  });
+
+  it.each([
+    {
+      name: 'CodexThreads',
+      track: (
+        childStreamId: StreamTabId,
+        parentStreamId: StreamTabId,
+        executionId: ExecutionId,
+        runSession: SessionHandle,
+      ) =>
+        CodexThreads.trackInFlight({
+          thread: {} as never,
+          childStreamId,
+          parentStreamId,
+          executionId,
+          executions: runSession.executions,
+        }),
+      interruptAll: () => CodexThreads.interruptAll(),
+      release: (executionId: ExecutionId) =>
+        CodexThreads.releaseByExecutionId(executionId),
+    },
+    {
+      name: 'ClaudeAgentSessions',
+      track: (
+        childStreamId: StreamTabId,
+        parentStreamId: StreamTabId,
+        executionId: ExecutionId,
+        runSession: SessionHandle,
+      ) =>
+        ClaudeAgentSessions.trackInFlight({
+          childStreamId,
+          parentStreamId,
+          executionId,
+          executions: runSession.executions,
+          model: 'claude-sonnet-4-6',
+          permissionMode: 'acceptEdits',
+          effort: 'high',
+        }),
+      interruptAll: () => ClaudeAgentSessions.interruptAll(),
+      release: (executionId: ExecutionId) =>
+        ClaudeAgentSessions.releaseByExecutionId(executionId),
+    },
+  ])(
+    '$name interrupts a real initial-turn loop and releases ownership once',
+    async ({ name, track, interruptAll, release }) => {
+      const childStreamId = uniqueStreamId(`${name}-initial-turn`);
+      const parentStreamId = 'parent' as StreamTabId;
+      const executionId = `exec-${name}-initial-turn` as ExecutionId;
+      const events: string[] = [];
+      const aborted = vi.fn();
+      const releaseSessionOwnership = vi.fn(() => release(executionId));
+      trackChildHandle(executionId, parentStreamId, childStreamId);
+
+      const strategy: ChildRunStrategy<FakeTurn> = {
+        stageLabel: `${name} session`,
+        launch: (_ports, abortController) => {
+          events.push('launch');
+          return new Promise((_resolve, reject) => {
+            const rejectAbort = () => {
+              aborted();
+              const error = new Error('Aborted');
+              error.name = 'AbortError';
+              reject(error);
+            };
+            if (abortController.signal.aborted) rejectAbort();
+            else {
+              abortController.signal.addEventListener('abort', rejectAbort, {
+                once: true,
+              });
+            }
+          });
+        },
+        isTerminal: () => false,
+        formatDelivery: () => 'unexpected delivery',
+        formatError: () => 'unexpected error',
+        onLoopStart: (runSession) => {
+          events.push('registered');
+          track(childStreamId, parentStreamId, executionId, runSession);
+        },
+        releaseSessionOwnership,
+      };
+
+      try {
+        startChildRunLoop({
+          childStreamId,
+          parentStreamId,
+          executionId,
+          agentName: name,
+          strategy,
+        });
+
+        expect(events).toEqual(['registered', 'launch']);
+        expect(isChildRunLoopActive(childStreamId)).toBe(true);
+        interruptAll();
+
+        await vi.waitFor(() => {
+          expect(aborted).toHaveBeenCalledOnce();
+          expect(isChildRunLoopActive(childStreamId)).toBe(false);
+        });
+        expect(releaseSessionOwnership).toHaveBeenCalledOnce();
+        expect(session.executions.getHandle(executionId)).toBeUndefined();
+      } finally {
+        release(executionId);
+      }
+    },
+  );
 
   it('interrupts an in-flight child when its execution lease is lost', async () => {
     const childStreamId = uniqueStreamId('lease-loss');

--- a/src/test-kernel/cli/CliInitPlatform.vitest.mts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.mts
@@ -10,6 +10,10 @@ import { setOutputChannelFactory } from '@logger/logUtils';
 import type { StreamTabId } from '@shared/schemas';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { UsageLogService } from '@telemetry/UsageLogService';
+import {
+  ClaudeAgentSessions,
+  CodexThreads,
+} from '@tools/agentCliSessionStores';
 import { getSetupPlatform } from '@tools/setup/platform';
 
 type SignalSpyEvent = 'SIGINT' | 'SIGTERM';
@@ -82,11 +86,6 @@ const mocks = vi.hoisted(() => ({
   initializeNodeGoalPrompts: vi.fn(),
   initializeNodeRuntimeSkills: vi.fn(),
   initNodeAgentRuntime: vi.fn(),
-  registerAgentShutdownHandlers: vi.fn(
-    (_lifecycle: { onShutdown: unknown }) => {
-      // Wiring assertion only — the drain itself is covered by AgentShutdown.
-    },
-  ),
   initializeServerSideKeyAccess: vi.fn(),
   serverSideKeyService: {
     setUseIncludedModelAccess: vi.fn(),
@@ -106,10 +105,6 @@ vi.mock('@agent/index/platformAgentDirectories', () => ({
 
 vi.mock('@platform/defaults/longRunningModelTransport', () => ({
   installLongRunningModelFetch: mocks.installLongRunningModelFetch,
-}));
-
-vi.mock('@agent/runtime/agentShutdown', () => ({
-  registerAgentShutdownHandlers: mocks.registerAgentShutdownHandlers,
 }));
 
 vi.mock('@auth/serverKeys', () => ({
@@ -292,16 +287,31 @@ describe('CLI platform init', () => {
     // Regression: the CLI was the one host that never registered these, so a
     // background `bash` run (spawned detached, in its own process group) and
     // any live codex / claude_agent session outlived `texra` as orphans.
+    // Asserted through the real `registerAgentShutdownHandlers` and its
+    // observable effect on shutdown, not by mocking the @agent module.
+    const interruptCodex = vi
+      .spyOn(CodexThreads, 'interruptAll')
+      .mockImplementation(() => {});
+    const interruptClaude = vi
+      .spyOn(ClaudeAgentSessions, 'interruptAll')
+      .mockImplementation(() => {});
     mocks.tryPlatform.mockReturnValueOnce(undefined);
     isAuthenticatedSpy.mockResolvedValue(false);
 
-    await initCliPlatform(cliContext({ installSignalHandlers: false }));
+    try {
+      await initCliPlatform(cliContext({ installSignalHandlers: false }));
 
-    // The CLI lifecycle host — the one every exit path drains through
-    // (bin/texra.ts's finally, the signal handlers, the TUI's exitNow).
-    expect(mocks.registerAgentShutdownHandlers).toHaveBeenCalledWith(
-      expect.objectContaining({ onShutdown: expect.any(Function) }),
-    );
+      // Registration alone must not interrupt anything; the drain belongs to
+      // the CLI lifecycle host every exit path runs (bin/texra.ts's finally,
+      // the signal handlers, the TUI's exitNow).
+      expect(interruptCodex).not.toHaveBeenCalled();
+      for (const handler of mocks.shutdownHandlers) await handler();
+      expect(interruptCodex).toHaveBeenCalledOnce();
+      expect(interruptClaude).toHaveBeenCalledOnce();
+    } finally {
+      interruptCodex.mockRestore();
+      interruptClaude.mockRestore();
+    }
   });
 
   it('marks the operator-terminal console sink as trusted', async () => {

--- a/src/test-kernel/cli/CliInitPlatform.vitest.mts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.mts
@@ -82,6 +82,11 @@ const mocks = vi.hoisted(() => ({
   initializeNodeGoalPrompts: vi.fn(),
   initializeNodeRuntimeSkills: vi.fn(),
   initNodeAgentRuntime: vi.fn(),
+  registerAgentShutdownHandlers: vi.fn(
+    (_lifecycle: { onShutdown: unknown }) => {
+      // Wiring assertion only — the drain itself is covered by AgentShutdown.
+    },
+  ),
   initializeServerSideKeyAccess: vi.fn(),
   serverSideKeyService: {
     setUseIncludedModelAccess: vi.fn(),
@@ -101,6 +106,10 @@ vi.mock('@agent/index/platformAgentDirectories', () => ({
 
 vi.mock('@platform/defaults/longRunningModelTransport', () => ({
   installLongRunningModelFetch: mocks.installLongRunningModelFetch,
+}));
+
+vi.mock('@agent/runtime/agentShutdown', () => ({
+  registerAgentShutdownHandlers: mocks.registerAgentShutdownHandlers,
 }));
 
 vi.mock('@auth/serverKeys', () => ({
@@ -277,6 +286,22 @@ describe('CLI platform init', () => {
     expect(vi.mocked(UsageLogService.dispose)).not.toHaveBeenCalled();
     for (const handler of mocks.shutdownHandlers) await handler();
     expect(vi.mocked(UsageLogService.dispose)).toHaveBeenCalled();
+  });
+
+  it('registers the agent shutdown drain on first platform init', async () => {
+    // Regression: the CLI was the one host that never registered these, so a
+    // background `bash` run (spawned detached, in its own process group) and
+    // any live codex / claude_agent session outlived `texra` as orphans.
+    mocks.tryPlatform.mockReturnValueOnce(undefined);
+    isAuthenticatedSpy.mockResolvedValue(false);
+
+    await initCliPlatform(cliContext({ installSignalHandlers: false }));
+
+    // The CLI lifecycle host — the one every exit path drains through
+    // (bin/texra.ts's finally, the signal handlers, the TUI's exitNow).
+    expect(mocks.registerAgentShutdownHandlers).toHaveBeenCalledWith(
+      expect.objectContaining({ onShutdown: expect.any(Function) }),
+    );
   });
 
   it('marks the operator-terminal console sink as trusted', async () => {

--- a/src/test-kernel/tools/AgentCliSessionRegistry.vitest.ts
+++ b/src/test-kernel/tools/AgentCliSessionRegistry.vitest.ts
@@ -194,6 +194,30 @@ describe('AgentCliSessionRegistry', () => {
     }
   });
 
+  it('interrupts an in-flight loop without promoting its reserved resume id', () => {
+    const registry = new AgentCliSessionRegistry('test_session_id');
+    const executionId = 'execution-in-flight' as ExecutionId;
+    const interrupt = vi.fn();
+    const releaseClaim = registry.claim('reserved-session');
+
+    registry.trackInFlight({
+      childStreamId: 'child-in-flight' as StreamTabId,
+      executionId,
+      executions: {
+        getAgentHandleByStream: () => ({ interrupt }),
+      } as any,
+    });
+
+    expect(registry.lookup('reserved-session')).toBeUndefined();
+    registry.interruptAll();
+    expect(interrupt).toHaveBeenCalledOnce();
+
+    registry.releaseByExecutionId(executionId);
+    registry.interruptAll();
+    expect(interrupt).toHaveBeenCalledOnce();
+    releaseClaim?.();
+  });
+
   it('interrupts each child through the execution registry that owns the session', () => {
     const registry = new AgentCliSessionRegistry('test_session_id');
     const ownerA = new ExecutionRegistry();

--- a/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
@@ -26,6 +26,7 @@ const mocks = vi.hoisted(() => ({
   currentSession: vi.fn(),
   query: vi.fn(),
   buildClaudeAgentEnv: vi.fn(),
+  findClaudeBinaryPath: vi.fn(),
   enqueueFollowUp: vi.fn(),
 }));
 
@@ -87,7 +88,7 @@ vi.mock('@tools/claudeAgentConfig', () => ({
 
 vi.mock('@tools/claudeAgentImport', () => ({
   importClaudeAgentSdk: async () => mocks.query,
-  findClaudeBinaryPath: async () => undefined,
+  findClaudeBinaryPath: mocks.findClaudeBinaryPath,
 }));
 
 import { ClaudeAgentTool } from '@tools/claudeAgent';
@@ -114,6 +115,7 @@ describe('claude_agent tool — resume fallback for a torn-down registry', () =>
   function setupCommonMocks(): void {
     mocks.startChildRunLoop.mockReset();
     mocks.buildClaudeAgentEnv.mockReset();
+    mocks.findClaudeBinaryPath.mockReset();
     mocks.requestBashApproval.mockResolvedValue({ accepted: true });
     mocks.getCurrentToolContexts.mockReturnValue({
       runContext: {
@@ -128,6 +130,7 @@ describe('claude_agent tool — resume fallback for a torn-down registry', () =>
     mocks.getExecutionStore.mockReturnValue({ write: async () => {} });
     mocks.ensureRunDir.mockResolvedValue(undefined);
     mocks.buildClaudeAgentEnv.mockResolvedValue({});
+    mocks.findClaudeBinaryPath.mockResolvedValue(undefined);
     mocks.createChildStream.mockReturnValue(
       createFakeAgentCliChildStream(childStreamId),
     );
@@ -135,6 +138,77 @@ describe('claude_agent tool — resume fallback for a torn-down registry', () =>
       followUps: { acquire: () => ({ enqueue: mocks.enqueueFollowUp }) },
     });
   }
+
+  it('resolves the Claude binary before child creation and then tracks startup synchronously', async () => {
+    setupCommonMocks();
+    const binaryPath = pDefer<string | undefined>();
+    const executions = { getAgentHandleByStream: () => undefined } as any;
+    const startupEvents: string[] = [];
+    const originalTrackInFlight =
+      ClaudeAgentSessions.trackInFlight.bind(ClaudeAgentSessions);
+    const trackInFlight = vi
+      .spyOn(ClaudeAgentSessions, 'trackInFlight')
+      .mockImplementation((entry) => {
+        startupEvents.push('tracked');
+        originalTrackInFlight(entry);
+      });
+    mocks.findClaudeBinaryPath.mockReturnValue(binaryPath.promise);
+    mocks.startChildRunLoop.mockImplementation(
+      (params: { strategy: ChildRunStrategy<unknown> }) => {
+        startupEvents.push('startLoop');
+        params.strategy.onLoopStart?.({ executions } as any);
+        startupEvents.push('startLoopReturned');
+      },
+    );
+
+    try {
+      const launch = new ClaudeAgentTool().call({
+        prompt: 'start after binary discovery',
+      });
+      await vi.waitFor(() =>
+        expect(mocks.findClaudeBinaryPath).toHaveBeenCalledOnce(),
+      );
+
+      expect(mocks.registerExecution).not.toHaveBeenCalled();
+      expect(mocks.createChildStream).not.toHaveBeenCalled();
+      expect(mocks.startChildRunLoop).not.toHaveBeenCalled();
+      expect(trackInFlight).not.toHaveBeenCalled();
+
+      binaryPath.resolve('/opt/claude');
+      await expect(launch).resolves.toMatchObject({ status: 'executed' });
+
+      expect(mocks.createChildStream).toHaveBeenCalledOnce();
+      expect(mocks.startChildRunLoop).toHaveBeenCalledOnce();
+      expect(trackInFlight).toHaveBeenCalledOnce();
+      expect(startupEvents).toEqual([
+        'startLoop',
+        'tracked',
+        'startLoopReturned',
+      ]);
+    } finally {
+      const trackedExecutionId = trackInFlight.mock.calls[0]?.[0].executionId;
+      trackInFlight.mockRestore();
+      if (trackedExecutionId) {
+        ClaudeAgentSessions.releaseByExecutionId(trackedExecutionId);
+      }
+    }
+  });
+
+  it('does not create an execution when Claude binary discovery fails', async () => {
+    setupCommonMocks();
+    mocks.findClaudeBinaryPath.mockRejectedValue(
+      new Error('Claude binary lookup failed'),
+    );
+
+    const result = await new ClaudeAgentTool().call({
+      prompt: 'must not create a stale child',
+    });
+
+    expect(result.status).toBe('error');
+    expect(mocks.registerExecution).not.toHaveBeenCalled();
+    expect(mocks.createChildStream).not.toHaveBeenCalled();
+    expect(mocks.startChildRunLoop).not.toHaveBeenCalled();
+  });
 
   it('seeds the fallback launch with the stale session_id so the SDK resumes from disk', async () => {
     setupCommonMocks();

--- a/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
@@ -220,6 +220,30 @@ describe('claude_agent tool — resume fallback for a torn-down registry', () =>
     expect(ClaudeAgentSessions.lookup('stale-session')).toBeUndefined();
   });
 
+  it('exposes an in-flight initial turn to the shared shutdown drain', async () => {
+    setupCommonMocks();
+    const interrupt = vi.fn();
+    let strategy: ChildRunStrategy<unknown> | undefined;
+    mocks.startChildRunLoop.mockImplementation(
+      (params: { strategy: ChildRunStrategy<unknown> }) => {
+        strategy = params.strategy;
+      },
+    );
+
+    await new ClaudeAgentTool().call({
+      prompt: 'start a long initial turn',
+    });
+
+    const executions = {
+      getAgentHandleByStream: () => ({ interrupt }),
+    } as any;
+    strategy?.onLoopStart?.({ executions } as any);
+    ClaudeAgentSessions.interruptAll();
+
+    expect(interrupt).toHaveBeenCalledOnce();
+    strategy?.releaseSessionOwnership?.();
+  });
+
   it('lets a waiting caller own the fallback after the first launch fails', async () => {
     setupCommonMocks();
     const firstEnvStarted = pDefer<void>();

--- a/src/test-kernel/tools/CodexResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/CodexResumeFallback.vitest.ts
@@ -191,6 +191,39 @@ describe('codex tool - atomic resume fallback', () => {
     expect(CodexThreads.lookup('stale-thread')).toBeUndefined();
   });
 
+  it('exposes an in-flight initial turn to the shared shutdown drain', async () => {
+    setupCommonMocks();
+    const interrupt = vi.fn();
+    const thread = { id: undefined, runStreamed: vi.fn() };
+    let strategy: ChildRunStrategy<unknown> | undefined;
+    mocks.importCodexClass.mockResolvedValue(
+      class MockCodex {
+        startThread(): typeof thread {
+          return thread;
+        }
+      },
+    );
+    mocks.startChildRunLoop.mockImplementation(
+      (params: { strategy: ChildRunStrategy<unknown> }) => {
+        strategy = params.strategy;
+      },
+    );
+
+    await new CodexTool().call({
+      prompt: 'start a long initial turn',
+      sandbox_mode: 'workspace-write',
+    });
+
+    const executions = {
+      getAgentHandleByStream: () => ({ interrupt }),
+    } as any;
+    strategy?.onLoopStart?.({ executions } as any);
+    CodexThreads.interruptAll();
+
+    expect(interrupt).toHaveBeenCalledOnce();
+    strategy?.releaseSessionOwnership?.();
+  });
+
   it('lets a waiting caller own the fallback after the first launch fails', async () => {
     setupCommonMocks();
     const firstImportStarted = pDefer<void>();

--- a/src/tools/agentCliSessionRegistry.ts
+++ b/src/tools/agentCliSessionRegistry.ts
@@ -40,6 +40,7 @@ type AgentCliSessionState<T> =
 
 export class AgentCliSessionRegistry<T extends AgentCliSessionEntry> {
   private readonly sessions = new Map<string, AgentCliSessionState<T>>();
+  private readonly inFlight = new Map<ExecutionId, T>();
 
   constructor(
     private readonly persistedSessionKey: string,
@@ -98,6 +99,11 @@ export class AgentCliSessionRegistry<T extends AgentCliSessionEntry> {
       });
   }
 
+  /** Track a launched loop before its SDK session id is safe to publish. */
+  trackInFlight(entry: T): void {
+    this.inFlight.set(entry.executionId, entry);
+  }
+
   lookup(sessionId: string): T | undefined {
     const state = this.sessions.get(sessionId);
     return state?.kind === 'active' ? state.entry : undefined;
@@ -116,8 +122,9 @@ export class AgentCliSessionRegistry<T extends AgentCliSessionEntry> {
     if (state?.kind === 'reserved') state.resolve(undefined);
   }
 
-  /** Release active aliases owned by one child execution without touching claims. */
+  /** Release every alias and in-flight handle owned by one child execution. */
   releaseByExecutionId(executionId: ExecutionId): void {
+    this.inFlight.delete(executionId);
     for (const [sessionId, state] of this.sessions) {
       if (state.kind === 'active' && state.entry.executionId === executionId) {
         this.sessions.delete(sessionId);
@@ -126,10 +133,19 @@ export class AgentCliSessionRegistry<T extends AgentCliSessionEntry> {
   }
 
   interruptAll(): void {
-    for (const state of [...this.sessions.values()]) {
-      if (state.kind === 'reserved') continue;
-      const { childStreamId, executions } = state.entry;
-      executions.getAgentHandleByStream(childStreamId)?.interrupt();
+    const interrupted = new Set<ExecutionId>();
+    const interrupt = (entry: T): void => {
+      if (interrupted.has(entry.executionId)) return;
+      const { childStreamId, executions } = entry;
+      const handle = executions.getAgentHandleByStream(childStreamId);
+      if (!handle) return;
+      interrupted.add(entry.executionId);
+      handle.interrupt();
+    };
+
+    for (const entry of this.inFlight.values()) interrupt(entry);
+    for (const state of this.sessions.values()) {
+      if (state.kind === 'active') interrupt(state.entry);
     }
   }
 }

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -186,7 +186,7 @@ export async function launchAgentCliSession(
   const runWithOwnership = captureOwnedExecutionLease(executionId);
 
   return await runWithOwnership(async () => {
-    let childStream: ChildStream;
+    let childStream: ChildStream | undefined;
     try {
       childStream = createChildStream(executionId, params.parentStreamId, {
         streamPrefix: params.streamPrefix,
@@ -200,7 +200,21 @@ export async function launchAgentCliSession(
       });
       await params.startLoop({ childStream, executionId });
     } catch (error) {
-      throw await releaseOwnedExecutionLeaseAfterFailure(executionId, error);
+      let failure = error;
+      if (childStream) {
+        try {
+          await childStream.finalize({
+            outcome: { kind: 'failed', error },
+            persistence: { kind: 'finalize', flowRecord: 'delete' },
+          });
+        } catch (finalizeError) {
+          failure = new AggregateError(
+            [error, finalizeError],
+            `Agent CLI execution ${executionId} failed and its child stream could not be finalized`,
+          );
+        }
+      }
+      throw await releaseOwnedExecutionLeaseAfterFailure(executionId, failure);
     }
 
     return {

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -620,6 +620,7 @@ async function launchClaudeAgentSession(
     additionalDirectories: resolvedWorkspace.additionalDirectories,
   };
   const env = await config.buildClaudeAgentEnv();
+  const pathToClaudeCodeExecutable = await findClaudeBinaryPath();
   const agentConfig = config.buildClaudeAgentConfig(input.prompt);
   const preview = truncateWithEllipsis(input.prompt, 60);
 
@@ -632,7 +633,7 @@ async function launchClaudeAgentSession(
     description: input.prompt,
     config: agentConfig,
     registerFailedMessage: 'Failed to register Claude Code CLI execution.',
-    startLoop: async ({ childStream, executionId }) =>
+    startLoop: ({ childStream, executionId }) =>
       startClaudeAgentLoop({
         childStream,
         parentStreamId,
@@ -644,7 +645,7 @@ async function launchClaudeAgentSession(
         cwd: workspace.cwd,
         additionalDirectories: workspace.additionalDirectories,
         env,
-        pathToClaudeCodeExecutable: await findClaudeBinaryPath(),
+        pathToClaudeCodeExecutable,
         runtimeHost,
         resumeSessionId: input.session_id ?? undefined,
         releaseFallbackClaim,

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -481,6 +481,19 @@ function startClaudeAgentLoop(params: {
     onTurnError: (turn, log) => {
       if (turn.errorMessage) log.error(turn.errorMessage);
     },
+    onLoopStart: (session) => {
+      ClaudeAgentSessions.trackInFlight({
+        childStreamId,
+        parentStreamId,
+        executionId,
+        executions: session.executions,
+        model: params.model,
+        permissionMode: params.permissionMode,
+        effort: params.effort,
+        cwd: params.cwd,
+        additionalDirectories: params.additionalDirectories,
+      });
+    },
     onTurnSuccess: (turn, session) => {
       if (fallbackSessionId) registerSession(fallbackSessionId, session);
       if (turn.sessionId) registerSession(turn.sessionId, session);

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -457,6 +457,15 @@ function startCodexLoop(params: {
     runTurn,
     isTerminal: () => false,
     getUsage: (turn) => turn.usage,
+    onLoopStart: (session) => {
+      CodexThreads.trackInFlight({
+        thread,
+        childStreamId,
+        parentStreamId,
+        executionId,
+        executions: session.executions,
+      });
+    },
     onTurnSuccess: (_turn, session) => {
       if (fallbackThreadId) registerThread(fallbackThreadId, session);
       if (thread.id) registerThread(thread.id, session);


### PR DESCRIPTION
Fixes #9235

## Problem

The extension and desktop registered `registerAgentShutdownHandlers`, but the CLI did not. Consequently, exiting `texra` could leave detached background `bash` jobs and live Codex or Claude CLI subprocesses running after their owning process had disappeared.

The first implementation exposed a second gap: Codex and Claude sessions were entered in their registries only after the first SDK turn succeeded. Shutdown during that initial turn therefore had no registry entry to interrupt.

## Change

1. Register the shared agent shutdown drain on the CLI lifecycle host, before the existing usage-log flush. This gives all three hosts the same exit behavior.
2. Track a Codex or Claude child loop by execution ID before its initial SDK turn begins. The resume session/thread identifier remains reserved and unpublished until the turn succeeds.
3. Make `AgentCliSessionRegistry.interruptAll()` drain both in-flight and active entries, deduplicated by execution ID, and remove both forms of ownership during normal or failed teardown.
4. Add `ChildRunStrategy.onLoopStart` as the single point at which provider strategies publish that in-flight ownership after core loop setup begins and before the initial turn.
5. Make synchronous child-loop setup transactional. If any setup step throws, unwind the stage, child-loop registration, interrupt attachment, follow-up queue, lease listener, and provider ownership. Continue all rollback operations and report an `AggregateError` if cleanup also fails.
6. If agent-CLI loop startup fails after a child stream has been created, finalize that stream as failed and remove its flow record before releasing the execution lease.
7. Resolve the Claude executable before creating the child execution, so binary discovery cannot leave an untracked execution during shutdown.

These additions close the first-turn race identified in review without exposing an unusable resume identifier or leaving partial loop state behind.

## Shutdown semantics

The CLI already owns a `LifecycleHost`, and every process-exit path drains it. The newly registered handlers are synchronous and best-effort:

- live background shell sessions receive their existing process-group interrupt;
- Codex and Claude execution handles receive their existing interrupt;
- a command that never created an agent session remains a no-op.

This does not alter `detachSubagentsOnStop`. That setting governs stopping an in-process parent run, whereas these handlers run only during host shutdown, when no child process can meaningfully outlive `texra` and later deliver a result.

The resumable-idle exit remains resumable: interrupting an in-flight handle does not publish its reserved resume identifier, and persisted provider identifiers continue to be retained for established sessions.

## Architecture ratchets

The CLI host adds one existing deep import, `@agent/runtime/agentShutdown`, so its R-b count changes from 31 to 32. The union across hosts does not grow: extension and desktop already import the same runtime module. The baseline list remains sorted and duplicate-free.

No host-side `@agent` mock is added. The CLI regression test checks the observable shutdown effect through the real handler registration, so the QA-2 baseline remains unchanged.

## Net elements (R6)

- Added no files and no new top-level exported symbol.
- Added one optional strategy lifecycle method, `ChildRunStrategy.onLoopStart`, invoked from one place and implemented by the two provider strategies that need pre-turn ownership.
- Added one registry operation, `trackInFlight`, and one private execution-ID map. Its two production callers are the Codex and Claude strategies.
- Added transactional rollback within the existing child-loop constructor and failed-launch finalization within the existing agent-CLI launcher.
- Production and ratchet diff: +136 / -34, net +102.
- Test diff: +474 / -3.
- Total: +610 / -37.

The growth is predominantly regression coverage. The production growth is the state and rollback needed to make the shutdown guarantee true during initial turns as well as established sessions.

## Consumer counts (R8)

- `registerAgentShutdownHandlers`: three production host registrations after this change — extension, desktop, and CLI.
- `ChildRunStrategy.onLoopStart`: one core invocation and two production implementations — Codex and Claude.
- `AgentCliSessionRegistry.trackInFlight`: two production callers — Codex and Claude.
- `interruptAll`: existing shared shutdown consumers remain unchanged; its implementation now includes the in-flight population.

Repository-wide searches found no alternate CLI cleanup path and no unhandled provider strategy requiring pre-turn registration.

## Tests

Regression coverage verifies that:

- first CLI initialization registers the shared agent shutdown drain;
- in-flight entries are interruptible without promoting reserved resume identifiers;
- both Codex and Claude initial turns are visible to the shared shutdown drain;
- loop-start registration precedes the first provider turn and ownership is released exactly once;
- synchronous setup failure unwinds every acquired resource;
- cleanup continues after an individual rollback failure and reports all failures;
- a child stream created before loop-start failure is finalized as failed and its flow record is removed;
- Claude binary discovery completes before child creation, and a discovery failure creates no execution.

Focused verification before the final review fix passed 6 files / 62 tests; the exact-head suite adds focused Claude launch-order coverage, together with TypeScript checks, lint, formatting, and diff checks. Exact-head repository CI is the merge gate.

https://claude.ai/code/session_01XZ8Z6rhypTfkVq728XCcCd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes process teardown and child-run lifecycle (interrupt, rollback, session registry); broad regression tests but behavior affects all CLI agent exits and initial Codex/Claude turns.
> 
> **Overview**
> **CLI exit** now registers the same `registerAgentShutdownHandlers` drain as extension and desktop (before usage-log flush), so detached background `bash` and live Codex/Claude CLI work is interrupted when `texra` shuts down instead of being orphaned.
> 
> **Pre-turn shutdown gap:** Codex and Claude register **in-flight** ownership via new `ChildRunStrategy.onLoopStart` → `AgentCliSessionRegistry.trackInFlight` before the first SDK turn succeeds; `interruptAll` hits in-flight and active entries (deduped by execution id) without promoting reserved resume ids. Claude resolves the binary path **before** creating a child execution.
> 
> **Robustness:** `startChildRunLoop` setup is transactional (rollback queue, lease listener, loop registration, ownership on sync failure); `launchAgentCliSession` finalizes a created child stream as failed if loop startup throws.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c75d6e771af41c004d51a162b070db856febcfeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
