### PR TITLE
refactor(progressView): centralize component icon markup

### DIFF
--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -41,7 +41,7 @@ import {
 } from '@shared/schemas';
 import { designTokens, commonViewStyles } from '@shared/styles';
 import { formatPhaseStageLabel } from '@shared/streams/streamStatusDisplay';
-import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+import { waIcon, type TeXRAIconName } from '@shared/wa/webAwesomeIcons';
 import { ProgressEvents } from '../events';
 
 // Local imports - contexts
@@ -295,11 +295,7 @@ export class BackgroundTasksPanel extends LitElement {
     return html`
       <wa-details class="collapsible-quiet" open>
         <div slot="summary" class="section-label">
-          <wa-icon
-            library=${TEXRA_ICON_LIBRARY}
-            name="comments"
-            aria-hidden="true"
-          ></wa-icon>
+          ${waIcon('comments')}
           <span
             >Inquiries${
               openCount ? html` &middot; ${openCount} open` : nothing
@@ -332,12 +328,7 @@ export class BackgroundTasksPanel extends LitElement {
     return html`
       <div class="task-item">
         <div class="task-header">
-          <wa-icon
-            library=${TEXRA_ICON_LIBRARY}
-            name="circle-question"
-            aria-hidden="true"
-            class="task-icon task-icon--inquiry"
-          ></wa-icon>
+          ${waIcon('circle-question', { className: 'task-icon task-icon--inquiry' })}
           <span id="${idPrefix}-id" class="inquiry-id">${thread.threadId}</span>
           <wa-tooltip for="${idPrefix}-id">${thread.threadId}</wa-tooltip>
           <span id="${idPrefix}-description" class="task-description"
@@ -378,11 +369,7 @@ export class BackgroundTasksPanel extends LitElement {
     return html`
       <wa-details class="collapsible-quiet">
         <div slot="summary" class="section-label">
-          <wa-icon
-            library=${TEXRA_ICON_LIBRARY}
-            name="server-process"
-            aria-hidden="true"
-          ></wa-icon>
+          ${waIcon('server-process')}
           <span
             >Subagents${
               activeCount ? html` &middot; ${activeCount} active` : nothing
@@ -425,16 +412,9 @@ export class BackgroundTasksPanel extends LitElement {
     return html`
       <div class="task-item">
         <div class="task-header">
-          <wa-icon
-            library=${TEXRA_ICON_LIBRARY}
-            name=${icon}
-            aria-hidden="true"
-            class=${classMap({
-              'task-icon': true,
-              'task-icon--process': !isAgentTool(child),
-              'task-icon--subagent': isAgentTool(child),
-            })}
-          ></wa-icon>
+          ${waIcon(icon, {
+            className: `task-icon ${isAgentTool(child) ? 'task-icon--subagent' : 'task-icon--process'}`,
+          })}
           <span
             id="${idPrefix}-name"
             class=${classMap({
@@ -519,7 +499,7 @@ function isAgentTool(child: ActiveChildInfo): boolean {
 }
 
 /** Pick the appropriate wa-icon name for a background task item. */
-function getTaskIcon(child: ActiveChildInfo): string {
+function getTaskIcon(child: ActiveChildInfo): TeXRAIconName {
   if (child.toolName === 'bash') return 'terminal';
   if (isAgentTool(child)) return 'robot';
   // Subagents (delegation, workflow) default to server-process;

--- a/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ExternalInquiryPanel.ts
@@ -40,7 +40,7 @@ import {
 } from '@shared/styles';
 import { CopyButtonController } from '@shared/litControllers/CopyButtonController';
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
-import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import { createFlushableDebounce, tryParseUrl } from '@utils/core';
 import { createBoundedIdSet } from '@utils/core/boundedIdSet';
@@ -299,12 +299,7 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel<'externalInquiry'> {
           slot="summary"
           class="external-inquiry-request__transcript-summary"
         >
-          <wa-icon
-            library=${TEXRA_ICON_LIBRARY}
-            name="history"
-            aria-hidden="true"
-          ></wa-icon>
-          Conversation transcript (${answeredTurns.length})
+          ${waIcon('history')} Conversation transcript (${answeredTurns.length})
         </span>
         <div class="external-inquiry-request__transcript-turns">
           ${repeat(
@@ -378,13 +373,8 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel<'externalInquiry'> {
   private renderSearchHint(): TemplateResult {
     return html`
       <div class="external-inquiry-request__search-hint">
-        <wa-icon
-          library=${TEXRA_ICON_LIBRARY}
-          name="lightbulb"
-          aria-hidden="true"
-        ></wa-icon>
-        Consider enabling <strong>Search</strong> mode in the external tool for
-        this question
+        ${waIcon('lightbulb')} Consider enabling <strong>Search</strong> mode in
+        the external tool for this question
       </div>
     `;
   }
@@ -393,22 +383,13 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel<'externalInquiry'> {
     return html`
       <div class="external-inquiry-request__attach-files">
         <div class="external-inquiry-request__attach-label">
-          <wa-icon
-            library=${TEXRA_ICON_LIBRARY}
-            name="cloud-upload"
-            aria-hidden="true"
-          ></wa-icon>
-          Files to upload to the external model:
+          ${waIcon('cloud-upload')} Files to upload to the external model:
         </div>
         <div class="external-inquiry-request__file-list">
           ${files.map(
             (file) => html`
               <div class="external-inquiry-request__file-item">
-                <wa-icon
-                  library=${TEXRA_ICON_LIBRARY}
-                  name="file"
-                  aria-hidden="true"
-                ></wa-icon>
+                ${waIcon('file')}
                 <span>${file}</span>
               </div>
             `,

--- a/packages/extension/src/progressView/frontend/components/FileList.ts
+++ b/packages/extension/src/progressView/frontend/components/FileList.ts
@@ -24,11 +24,7 @@ import { designTokens, commonViewStyles } from '@shared/styles';
 import { roundIndexedEntries } from '@shared/schemas/roundIndexed';
 import { isKnownUnsupported } from '@shared/utils/dispatcher';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
-import {
-  TEXRA_ICON_LIBRARY,
-  type TeXRAIconName,
-  waIcon,
-} from '@shared/wa/webAwesomeIcons';
+import { type TeXRAIconName, waIcon } from '@shared/wa/webAwesomeIcons';
 import { normalizeFilePath } from '@utils/core';
 import { ELEMENT_IDS } from '../constants';
 import { ProgressEvents } from '../events';
@@ -343,13 +339,7 @@ export class FileList extends LitElement {
                     size="small"
                     @click=${this.runLatexFixer}
                   >
-                    <wa-icon
-                      slot="start"
-                      library=${TEXRA_ICON_LIBRARY}
-                      name="tools"
-                      aria-hidden="true"
-                    ></wa-icon>
-                    Run latexFixer
+                    ${waIcon('tools', { slot: 'start' })} Run latexFixer
                   </wa-button>
                 </div>
               `
@@ -364,11 +354,7 @@ export class FileList extends LitElement {
 
     return html`
       <div class="storage-hint" role="note">
-        <wa-icon
-          library=${TEXRA_ICON_LIBRARY}
-          name="folder-opened"
-          aria-hidden="true"
-        ></wa-icon>
+        ${waIcon('folder-opened')}
         <span class="storage-hint__text">
           Files stay in task-run storage until accepted. Click a file to preview
           it, use Accept to copy it into your workspace, or use the folder
@@ -472,13 +458,7 @@ export class FileList extends LitElement {
       <div class="file-item">
         ${
           failure
-            ? html`<wa-icon
-                  id="${idPrefix}-compile-warning"
-                  library=${TEXRA_ICON_LIBRARY}
-                  name="warning"
-                  class="compile-warning"
-                  aria-label="Compile check failed"
-                ></wa-icon>
+            ? html`${waIcon('warning', { id: `${idPrefix}-compile-warning`, className: 'compile-warning', label: 'Compile check failed' })}
                 <wa-tooltip for="${idPrefix}-compile-warning"
                   >Compile check failed</wa-tooltip
                 >`

--- a/packages/extension/src/progressView/frontend/components/LatexdiffResults.ts
+++ b/packages/extension/src/progressView/frontend/components/LatexdiffResults.ts
@@ -14,7 +14,7 @@ import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 // Local imports - shared styles
 import { designTokens, commonViewStyles } from '@shared/styles';
 import type { DiffResultDisplay, DiffStatus } from '@shared/schemas';
-import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+import { waIcon, type TeXRAIconName } from '@shared/wa/webAwesomeIcons';
 
 // Local imports - progress view events
 import { ProgressEvents } from '../events';
@@ -23,7 +23,7 @@ import { ProgressEvents } from '../events';
 import { buildDetailsSummary } from '../formatters/htmlBuilders';
 
 /** Status wa-icon name lookup for latexdiff entries. */
-const LATEXDIFF_STATUS_ICONS: Record<DiffStatus, string> = {
+const LATEXDIFF_STATUS_ICONS: Record<DiffStatus, TeXRAIconName> = {
   success: 'check',
   error: 'error',
 };
@@ -128,18 +128,8 @@ export class LatexdiffResults extends LitElement {
     const entryId = `latexdiff-entry-${index}`;
     return html`
       <li id=${entryId} class="detail-item" data-run-id=${ifDefined(runId)}>
-        <wa-icon
-          library=${TEXRA_ICON_LIBRARY}
-          name=${icon}
-          aria-hidden="true"
-        ></wa-icon>
-        ${this.renderFileLink(baseFile, baseLabel)}
-        <wa-icon
-          class="arrow"
-          library=${TEXRA_ICON_LIBRARY}
-          name="arrow-right"
-          aria-hidden="true"
-        ></wa-icon>
+        ${waIcon(icon)} ${this.renderFileLink(baseFile, baseLabel)}
+        ${waIcon('arrow-right', { className: 'arrow' })}
         ${this.renderFileLink(revisedFile, revisedLabel)}
         (${this.renderFileLink(diffFile, 'diff')})
         ${message ? html`<wa-tooltip for=${entryId}>${message}</wa-tooltip>` : nothing}

--- a/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -44,7 +44,7 @@ import { getProposalFileGroups } from '@shared/schemas/proposalFields';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 import { renderWorkflowExtractFlagBadges } from '@shared/wa/extractFlagBadges';
-import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { getBasename } from '@utils/core';
 
 // Local imports - base class
@@ -148,11 +148,7 @@ export class ProposalRequestPanel extends BaseApprovalPanel<'proposal'> {
             hasAgentOptions
               ? html`
                   <div class="workflow-proposal__agent-select">
-                    <wa-icon
-                      library=${TEXRA_ICON_LIBRARY}
-                      name="sparkle"
-                      aria-hidden="true"
-                    ></wa-icon>
+                    ${waIcon('sparkle')}
                     <wa-select
                       class="proposal-agent-dropdown"
                       .value=${currentAgent}
@@ -170,11 +166,7 @@ export class ProposalRequestPanel extends BaseApprovalPanel<'proposal'> {
             hasModelOptions
               ? html`
                   <div class="workflow-proposal__model-select">
-                    <wa-icon
-                      library=${TEXRA_ICON_LIBRARY}
-                      name="robot"
-                      aria-hidden="true"
-                    ></wa-icon>
+                    ${waIcon('robot')}
                     <wa-select
                       class="proposal-model-dropdown"
                       .value=${currentModel}

--- a/packages/extension/src/progressView/frontend/components/QueuedFollowUps.ts
+++ b/packages/extension/src/progressView/frontend/components/QueuedFollowUps.ts
@@ -9,7 +9,7 @@ import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 
 // Local imports - shared styles
 import { designTokens, commonViewStyles } from '@shared/styles';
-import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
 // Local imports - progress view constants
@@ -128,12 +128,7 @@ export class QueuedFollowUps extends LitElement {
               const itemId = `queued-follow-up-${index}`;
               return html`
                 <div id=${itemId} class="queued-follow-up-item">
-                  <wa-icon
-                    library=${TEXRA_ICON_LIBRARY}
-                    name="comment"
-                    class="queued-follow-up-icon"
-                    aria-hidden="true"
-                  ></wa-icon>
+                  ${waIcon('comment', { className: 'queued-follow-up-icon' })}
                   <span class="queued-follow-up-text">${display}</span>
                 </div>
                 ${full ? html`<wa-tooltip for=${itemId}>${full}</wa-tooltip>` : nothing}

--- a/packages/extension/src/progressView/frontend/components/RequestPanels.ts
+++ b/packages/extension/src/progressView/frontend/components/RequestPanels.ts
@@ -32,7 +32,7 @@ import {
 } from '@shared/styles';
 
 // Local imports - progress view helpers
-import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+import { waIcon, type TeXRAIconName } from '@shared/wa/webAwesomeIcons';
 import {
   createEmptyPermissionGroups,
   findPanelForPermission,
@@ -61,7 +61,7 @@ import './UserQuestionPanel';
 /** Section configuration for rendering permission groups */
 interface SectionConfig {
   cssClass: string;
-  icon: string;
+  icon: TeXRAIconName;
   title: string;
   renderPanel: (p: PermissionState) => TemplateResult;
 }
@@ -199,11 +199,7 @@ export class RequestPanels extends LitElement {
   ): TemplateResult {
     return html`
       <div class="${config.cssClass}__header">
-        <wa-icon
-          library=${TEXRA_ICON_LIBRARY}
-          name=${config.icon}
-          aria-hidden="true"
-        ></wa-icon>
+        ${waIcon(config.icon)}
         <span>${config.title}</span>
         ${extra}
       </div>
@@ -260,11 +256,7 @@ export class RequestPanels extends LitElement {
           ?disabled=${index === 0}
           @click=${this._eiPrev}
         >
-          <wa-icon
-            library=${TEXRA_ICON_LIBRARY}
-            name="chevron-left"
-            aria-hidden="true"
-          ></wa-icon>
+          ${waIcon('chevron-left')}
         </wa-button>
         <wa-tooltip for="ei-prev-btn">Previous inquiry</wa-tooltip>
         <span class="external-inquiry-requests__counter">
@@ -277,11 +269,7 @@ export class RequestPanels extends LitElement {
           ?disabled=${index === perms.length - 1}
           @click=${this._eiNext}
         >
-          <wa-icon
-            library=${TEXRA_ICON_LIBRARY}
-            name="chevron-right"
-            aria-hidden="true"
-          ></wa-icon>
+          ${waIcon('chevron-right')}
         </wa-button>
         <wa-tooltip for="ei-next-btn">Next inquiry</wa-tooltip>
       </div>

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -38,11 +38,7 @@ import '@awesome.me/webawesome/dist/components/relative-time/relative-time.js';
 import './WorktreeChip';
 import { formatRelativeTime } from '@shared/utils/string';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
-import {
-  TEXRA_ICON_LIBRARY,
-  type TeXRAIconName,
-  waIcon,
-} from '@shared/wa/webAwesomeIcons';
+import { type TeXRAIconName, waIcon } from '@shared/wa/webAwesomeIcons';
 import { renderEmptyState } from '@shared/wa/emptyState';
 import { formatResultCount } from '@utils/text/stringUtils';
 import { layoutStyles } from '../styles/logStyles';
@@ -200,25 +196,13 @@ export class StreamTab extends LitElement {
             <span id="stream-tab-title" class="tab-title"
               >${
                 stream.parentStreamId
-                  ? html`<wa-icon
-                      library=${TEXRA_ICON_LIBRARY}
-                      name="chevron-right"
-                      class="nested-stream-icon"
-                      aria-hidden="true"
-                    ></wa-icon>`
+                  ? html`${waIcon('chevron-right', { className: 'nested-stream-icon' })}`
                   : nothing
               }${stream.label || stream.name}</span
             >
             ${
               this.childCount > 0 && this.compact
-                ? html`<wa-icon
-                    id="stream-tab-compact-children"
-                    library=${TEXRA_ICON_LIBRARY}
-                    name="chevron-right"
-                    class="compact-subagent-hint"
-                    role="img"
-                    aria-label=${childStreamLabel}
-                  ></wa-icon>`
+                ? html`${waIcon('chevron-right', { id: 'stream-tab-compact-children', className: 'compact-subagent-hint', label: childStreamLabel })}`
                 : nothing
             }
           </div>
@@ -260,23 +244,11 @@ export class StreamTab extends LitElement {
                           : ''
                       }</span
                     >
-                    <wa-icon
-                      id="stream-tab-kind"
-                      library=${TEXRA_ICON_LIBRARY}
-                      name=${streamDecorator.icon}
-                      class="stream-kind"
-                      aria-hidden="true"
-                    ></wa-icon>
+                    ${waIcon(streamDecorator.icon, { id: 'stream-tab-kind', className: 'stream-kind' })}
                     ${when(
                       stream.isRemote,
                       () => html`
-                        <wa-icon
-                          id="stream-tab-remote"
-                          library=${TEXRA_ICON_LIBRARY}
-                          name=${AGENT_DECORATORS.properties.remote.icon}
-                          class="remote-agent"
-                          aria-hidden="true"
-                        ></wa-icon>
+                        ${waIcon(AGENT_DECORATORS.properties.remote.icon, { id: 'stream-tab-remote', className: 'remote-agent' })}
                       `,
                     )}
                   </div>

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -33,7 +33,7 @@ import { isInFlightPhase } from '@shared/streams/streamStatus';
 import { parseWorkflowOutputRoundDir } from '@shared/constants/workflowOutput';
 import { ToggleStateStore } from '@shared/state/ToggleStateStore';
 import { scrollToBottom } from '@shared/utils/dom';
-import { TEXRA_ICON_LIBRARY, waIcon } from '@shared/wa/webAwesomeIcons';
+import { waIcon, type TeXRAIconName } from '@shared/wa/webAwesomeIcons';
 import { renderEmptyState } from '@shared/wa/emptyState';
 import { formatDuration } from '@utils/core';
 import { pluralize } from '@utils/text/stringUtils';
@@ -67,7 +67,7 @@ const GROUP_MESSAGE_WINDOW_STEP = 400;
  * (#7993 step 3) — `CANCELLED` now renders distinctly from `COMPLETED`
  * instead of folding into one neutral "stopped" icon.
  */
-function getStatusIcon(status: string): string | null {
+function getStatusIcon(status: string): TeXRAIconName | null {
   switch (status) {
     case STREAM_PHASE.RUNNING:
       return null;
@@ -527,11 +527,7 @@ export class TaskGroupList extends LitElement {
       <span class="group-status-icon">
         ${
           statusIcon
-            ? html`<wa-icon
-                library=${TEXRA_ICON_LIBRARY}
-                name=${statusIcon}
-                aria-hidden="true"
-              ></wa-icon>`
+            ? html`${waIcon(statusIcon)}`
             : html`<wa-spinner></wa-spinner>`
         }
       </span>
@@ -539,12 +535,7 @@ export class TaskGroupList extends LitElement {
       ${this.renderGroupProgress(group, messages)}
       <span class="group-time">
         <span class="group-start-time" data-start=${String(group.startTime)}>
-          <wa-icon
-            library=${TEXRA_ICON_LIBRARY}
-            name="clock"
-            aria-hidden="true"
-          ></wa-icon>
-          ${formattedStartTime}
+          ${waIcon('clock')} ${formattedStartTime}
         </span>
         ${
           durationText

--- a/packages/extension/src/progressView/frontend/components/TodoList.ts
+++ b/packages/extension/src/progressView/frontend/components/TodoList.ts
@@ -22,7 +22,7 @@ import {
   commonViewStyles,
 } from '@shared/styles';
 import { TODO_STATUS, STATUS_ICONS, type TodoItem } from '@shared/schemas';
-import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 import { ELEMENT_IDS } from '../constants';
 
@@ -168,12 +168,7 @@ export class TodoList extends LitElement {
         ${
           isInProgress
             ? html`<wa-spinner class="todo-item__icon"></wa-spinner>`
-            : html`<wa-icon
-                library=${TEXRA_ICON_LIBRARY}
-                name=${icon}
-                class="todo-item__icon"
-                aria-hidden="true"
-              ></wa-icon>`
+            : html`${waIcon(icon, { className: 'todo-item__icon' })}`
         }
         <span class="todo-item__content">${content}</span>
       </div>

--- a/packages/extension/src/progressView/frontend/components/UsagePanel.ts
+++ b/packages/extension/src/progressView/frontend/components/UsagePanel.ts
@@ -14,7 +14,7 @@ import type { TokenUsageStats, UsageRoute } from '@shared/schemas';
 
 // Local imports - shared styles
 import { designTokens } from '@shared/styles';
-import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { clamp, formatCompactTokenCount } from '@utils/core';
 import { formatCostUsd } from '@utils/text/stringUtils';
 
@@ -233,20 +233,10 @@ export class UsagePanel extends LitElement {
     const cacheWrite = this.usage.cacheCreationInputTokens ?? 0;
 
     return html`
-      <wa-icon
-        library=${TEXRA_ICON_LIBRARY}
-        name="pie-chart"
-        aria-hidden="true"
-      ></wa-icon>
+      ${waIcon('pie-chart')}
       <span class="run-summary__label">Total usage:</span>
       <span class="run-summary__value">
-        <wa-icon
-          id="usage-input-icon"
-          library=${TEXRA_ICON_LIBRARY}
-          name="arrow-up"
-          aria-hidden="true"
-        ></wa-icon
-        >${formatCompactTokenCount(inputTokens)}<wa-tooltip
+        ${waIcon('arrow-up', { id: 'usage-input-icon' })}${formatCompactTokenCount(inputTokens)}<wa-tooltip
           for="usage-input-icon"
           >Input tokens</wa-tooltip
         >
@@ -254,13 +244,7 @@ export class UsagePanel extends LitElement {
           cacheRead > 0,
           () =>
             html` ·
-              <wa-icon
-                id="usage-cache-read-icon"
-                library=${TEXRA_ICON_LIBRARY}
-                name="cloud-download"
-                aria-hidden="true"
-              ></wa-icon
-              >${formatCompactTokenCount(cacheRead)}<wa-tooltip
+              ${waIcon('cloud-download', { id: 'usage-cache-read-icon' })}${formatCompactTokenCount(cacheRead)}<wa-tooltip
                 for="usage-cache-read-icon"
                 >Cache read tokens (discounted)</wa-tooltip
               >`,
@@ -269,13 +253,7 @@ export class UsagePanel extends LitElement {
           cacheMiss > 0,
           () =>
             html` ·
-              <wa-icon
-                id="usage-cache-miss-icon"
-                library=${TEXRA_ICON_LIBRARY}
-                name="cloud-upload"
-                aria-hidden="true"
-              ></wa-icon
-              >${formatCompactTokenCount(cacheMiss)}<wa-tooltip
+              ${waIcon('cloud-upload', { id: 'usage-cache-miss-icon' })}${formatCompactTokenCount(cacheMiss)}<wa-tooltip
                 for="usage-cache-miss-icon"
                 >Cache miss tokens (full price)</wa-tooltip
               >`,
@@ -284,25 +262,13 @@ export class UsagePanel extends LitElement {
           cacheWrite > 0,
           () =>
             html` ·
-              <wa-icon
-                id="usage-cache-write-icon"
-                library=${TEXRA_ICON_LIBRARY}
-                name="database"
-                aria-hidden="true"
-              ></wa-icon
-              >${formatCompactTokenCount(cacheWrite)}<wa-tooltip
+              ${waIcon('database', { id: 'usage-cache-write-icon' })}${formatCompactTokenCount(cacheWrite)}<wa-tooltip
                 for="usage-cache-write-icon"
                 >Cache creation tokens (1.25x cost)</wa-tooltip
               >`,
         )}
         ·
-        <wa-icon
-          id="usage-output-icon"
-          library=${TEXRA_ICON_LIBRARY}
-          name="arrow-down"
-          aria-hidden="true"
-        ></wa-icon
-        >${formatCompactTokenCount(outputTokens)}<wa-tooltip
+        ${waIcon('arrow-down', { id: 'usage-output-icon' })}${formatCompactTokenCount(outputTokens)}<wa-tooltip
           for="usage-output-icon"
           >Output tokens</wa-tooltip
         >
@@ -339,11 +305,7 @@ export class UsagePanel extends LitElement {
 
     return html`
       <span id="usage-context-gauge" class="context-gauge">
-        <wa-icon
-          library=${TEXRA_ICON_LIBRARY}
-          name="window"
-          aria-hidden="true"
-        ></wa-icon>
+        ${waIcon('window')}
         <span class="context-gauge__track">
           <wa-progress-bar
             class="context-gauge__bar"

--- a/packages/extension/src/progressView/frontend/components/UserMessage.ts
+++ b/packages/extension/src/progressView/frontend/components/UserMessage.ts
@@ -22,7 +22,7 @@ import { CopyButtonController } from '@shared/litControllers/CopyButtonControlle
 import { designTokens } from '@shared/styles/litStyles';
 import { markdownStyles } from '@shared/styles/markdownStyles';
 import { renderIconActionButton } from '@shared/wa/actionButtons';
-import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 // Local imports - formatter helpers
 import { processMarkdownContent } from '../formatters/markdownRenderer';
@@ -231,12 +231,7 @@ export class UserMessage extends LitElement {
         >
           <div class="user-message-header">
             <span class="user-message-header-left">
-              <wa-icon
-                library=${TEXRA_ICON_LIBRARY}
-                name="comment"
-                class="user-message-icon"
-                aria-hidden="true"
-              ></wa-icon>
+              ${waIcon('comment', { className: 'user-message-icon' })}
               <span id="user-message-timestamp" class="user-message-timestamp"
                 >${timeDisplay}</span
               >

--- a/packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts
+++ b/packages/extension/src/progressView/frontend/components/WorkflowToolUseFollowupSection.ts
@@ -30,7 +30,7 @@ import {
   renderAgentOptions,
   renderModelOptions,
 } from '@shared/utils/selectTemplates';
-import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 import { ProgressEvents } from '../events';
 import type { FollowupOptionsState } from '../store';
@@ -186,13 +186,7 @@ export class WorkflowToolUseFollowupSection extends LitElement {
               ?disabled=${!ready}
               @click=${this.setupFollowup}
             >
-              <wa-icon
-                slot="start"
-                library=${TEXRA_ICON_LIBRARY}
-                name="reply"
-                aria-hidden="true"
-              ></wa-icon>
-              Setup
+              ${waIcon('reply', { slot: 'start' })} Setup
             </wa-button>
             <wa-button
               appearance="filled"
@@ -201,13 +195,7 @@ export class WorkflowToolUseFollowupSection extends LitElement {
               ?disabled=${!ready}
               @click=${this.runFollowup}
             >
-              <wa-icon
-                slot="start"
-                library=${TEXRA_ICON_LIBRARY}
-                name="play"
-                aria-hidden="true"
-              ></wa-icon>
-              Run
+              ${waIcon('play', { slot: 'start' })} Run
             </wa-button>
           </div>
         </div>

--- a/packages/extension/src/progressView/frontend/components/WorktreeChip.ts
+++ b/packages/extension/src/progressView/frontend/components/WorktreeChip.ts
@@ -1,6 +1,5 @@
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { classMap } from 'lit/directives/class-map.js';
 
 import {
   WORKTREE_PR_STATE,
@@ -10,7 +9,7 @@ import {
   type WorktreeCIState,
 } from '@shared/schemas';
 import { designTokens } from '@shared/styles';
-import { TEXRA_ICON_LIBRARY, waIcon } from '@shared/wa/webAwesomeIcons';
+import { waIcon, type TeXRAIconName } from '@shared/wa/webAwesomeIcons';
 
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/badge/badge.js';
@@ -34,7 +33,7 @@ const PR_STATE_VARIANT: Record<
   [WORKTREE_PR_STATE.DRAFT]: 'neutral',
 };
 
-const CI_ICON: Record<WorktreeCIState, string> = {
+const CI_ICON: Record<WorktreeCIState, TeXRAIconName> = {
   [WORKTREE_CI_STATE.PENDING]: 'circle-dot',
   [WORKTREE_CI_STATE.RUNNING]: 'circle-dot',
   [WORKTREE_CI_STATE.SUCCESS]: 'circle-check',
@@ -255,13 +254,7 @@ export class WorktreeChip extends LitElement {
       }
       ${
         pr.ciState
-          ? html`<wa-icon
-                id="worktree-ci-status"
-                library=${TEXRA_ICON_LIBRARY}
-                name=${CI_ICON[ci]}
-                class=${classMap({ 'ci-icon': true, [`ci-${ci}`]: true })}
-                aria-label=${CI_LABEL[ci]}
-              ></wa-icon>
+          ? html`${waIcon(CI_ICON[ci], { id: 'worktree-ci-status', className: `ci-icon ci-${ci}`, label: CI_LABEL[ci] })}
               <wa-tooltip for="worktree-ci-status">${CI_LABEL[ci]}</wa-tooltip>`
           : nothing
       }

--- a/src/shared/schemas/todoDisplay.ts
+++ b/src/shared/schemas/todoDisplay.ts
@@ -1,7 +1,9 @@
+import type { TeXRAIconName } from '@shared/wa/webAwesomeIcons';
+
 import { TODO_STATUS, type TodoStatus } from './todo';
 
 /** wa-icon names for each todo/plan step status (used in webview components). */
-export const STATUS_ICONS: Record<TodoStatus, string> = {
+export const STATUS_ICONS: Record<TodoStatus, TeXRAIconName> = {
   [TODO_STATUS.PENDING]: 'circle-outline',
   [TODO_STATUS.IN_PROGRESS]: 'loading',
   [TODO_STATUS.COMPLETED]: 'pass-filled',

--- a/src/shared/wa/webAwesomeIcons.ts
+++ b/src/shared/wa/webAwesomeIcons.ts
@@ -124,7 +124,7 @@ import { registerIconLibrary } from '@awesome.me/webawesome/dist/components/icon
 import { html, type TemplateResult } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
-export const TEXRA_ICON_LIBRARY = 'texra';
+const TEXRA_ICON_LIBRARY = 'texra';
 
 type FontAwesomePathData = string | string[];
 
@@ -405,6 +405,7 @@ export function registerTeXRAWebAwesomeIcons(): void {
 export type TeXRAIconName = keyof typeof icons | keyof typeof CODICON_ALIASES;
 
 interface WaIconOptions {
+  readonly id?: string;
   // 'start' / 'end' for wa-button; 'icon' for wa-callout / wa-card.
   readonly slot?: 'start' | 'end' | 'icon';
   readonly className?: string;
@@ -422,6 +423,7 @@ export function waIcon(
   options: WaIconOptions = {},
 ): TemplateResult {
   return html`<wa-icon
+    id=${ifDefined(options.id)}
     library=${TEXRA_ICON_LIBRARY}
     name=${name}
     variant=${options.variant ?? 'solid'}


### PR DESCRIPTION
## Summary

- route the remaining progress-view component icons through the shared `waIcon()` renderer
- preserve icon classes, slots, tooltip IDs, labels, conditions, and accessibility semantics
- narrow dynamic icon values to `TeXRAIconName`
- add optional `id` support to `waIcon()` for tooltip-linked icons
- make the icon-library constant private after eliminating its final external consumers

## Issue acceptance gates

Fixes #9232.

- All 14 named component files use `waIcon()`.
- The progress-view frontend has zero remaining hand-written attributed `<wa-icon>` markup.
- External `TEXRA_ICON_LIBRARY` references are zero.
- Dynamic icon maps/fields are narrowed to `TeXRAIconName` where applicable.
- Classes, slots, tooltip bindings, labels, conditions, and decorative-versus-labeled accessibility semantics are preserved.

## Single source of truth

`src/shared/wa/webAwesomeIcons.ts` now exclusively owns the `texra` library name and renders all migrated icons through `waIcon()`. The helper also owns optional tooltip-target IDs alongside its existing class, slot, label, variant, and accessibility options.

## Duplication and abstraction budget

Removed 37 duplicated raw icon templates. No new abstraction was introduced: the established multi-caller `waIcon()` helper gained one optional `id` field required by existing tooltip-linked callers. The helper replaces markup rather than adding another rendering layer.

## Net elements (R6)

- Files: 16 modified, 0 added, 0 deleted.
- Exported symbols: 0 added, 1 removed (`TEXRA_ICON_LIBRARY`).
- Classes/interfaces/enums: 0 added or deleted; one existing private options interface gains `id`.
- Net LoC: **-194** (65 insertions, 259 deletions).

## Consumer counts (R8)

`TEXRA_ICON_LIBRARY` had 14 external consumers before this PR and 0 after; all were rerouted through `waIcon()`. No event/emit/subscriber path changes.

## Host impact

Extension: progress-view rendering only; output and accessibility semantics are preserved.

Desktop: none.

CLI: none.

## Scheduled refactoring

None. This completes the component follow-up from #9223.

## Validation

- Complete progress-view suite: 52 files, 430 tests passed.
- Independent full suite: 782 files, 7,640 tests passed; 1 file / 4 tests skipped.
- Exact-head CI: static checks, both kernel shards, build artifacts, webview smoke, and validation passed.
- Root, test-kernel, and extension TypeScript checks passed locally.
- Repository ESLint passed.
- Prettier check passed for all changed files.
- Dead-code ratchet passed with the baseline unchanged.
- Exact zero-greps for external `TEXRA_ICON_LIBRARY` references and targeted raw icon markup.
- `git diff --check` passed.
- Independent and automated reviews found no code defects.
