### PR TITLE
refactor(runtime): give SessionHandle ownership of its snapshot store

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -60,7 +60,6 @@ import { escapeText } from '@shared/utils/xmlEscape';
 import type { AgentDelegationScope } from '@shared/schemas/agentRoster';
 import { getFirstRunDone } from '@shared/state/onboardingState';
 import { isActivePhase } from '@shared/streams/streamStatus';
-import { StreamSnapshotStore } from '@transcript';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import {
@@ -408,21 +407,10 @@ export async function runChat(
     stdout: process.stdout,
   });
 
-  // Persist per-stream sidecar data (todos, plan, usage, output files) via the
-  // shared, host-agnostic snapshot store so a `texra resume` restores the full
+  // Per-stream sidecar data (todos, plan, usage, output files) is persisted by
+  // the session's own snapshot store, so a `texra resume` restores the full
   // display — the same streamData/{id}/* files the extension/desktop read.
-  const snapshotStore = new StreamSnapshotStore();
   const artifactSession = defaultSession();
-  let detachSnapshotEvents: (() => void) | undefined =
-    snapshotStore.attachSessionEvents(artifactSession.events);
-  let detachSnapshotFlusher: (() => void) | undefined =
-    artifactSession.useArtifactFlusher(() => snapshotStore.flush());
-  const detachSnapshotPersistence = (): void => {
-    detachSnapshotFlusher?.();
-    detachSnapshotFlusher = undefined;
-    detachSnapshotEvents?.();
-    detachSnapshotEvents = undefined;
-  };
 
   const disposers: Array<() => void> = [];
   // Crash safety: if the process dies outside the orderly teardown below
@@ -435,7 +423,7 @@ export async function runChat(
   const terminalTitleUpdates = installTerminalTitleUpdates(context.cwd);
   disposers.push(terminalTitleUpdates.dispose);
   disposers.push(subscribeStreamLog());
-  disposers.push(subscribeStreamArtifacts(snapshotStore));
+  disposers.push(subscribeStreamArtifacts(artifactSession.snapshots));
   disposers.push(subscribeStreamStatus());
 
   const session: TuiSession = {
@@ -512,7 +500,7 @@ export async function runChat(
     getSessionContext: currentSessionContext,
     disposers,
     followUpQueue,
-    snapshotStore,
+    snapshotStore: artifactSession.snapshots,
   });
   disposers.push(
     setCliAgentResumeHandler({
@@ -873,7 +861,6 @@ export async function runChat(
     followUpQueue,
     getApprovalPolicy,
     flushArtifacts: () => artifactSession.flushArtifacts(),
-    detachSnapshotPersistence,
     repaintAfterTerminalResume: () =>
       viewportController.repaintAfterTerminalResume(),
     suspendTerminalTitle: terminalTitleUpdates.suspend,

--- a/packages/cli/src/chat/tui/sessionExitController.ts
+++ b/packages/cli/src/chat/tui/sessionExitController.ts
@@ -78,8 +78,6 @@ interface SessionExitControllerContext {
   readonly getApprovalPolicy: () => CliApprovalPolicy;
   /** Materialize buffered trace chunks + drain debounced StreamLog writes. */
   readonly flushArtifacts: () => Promise<void>;
-  /** Detach the snapshot-persistence event/flusher wiring. */
-  readonly detachSnapshotPersistence: () => void;
   /** Repaint the TUI from a known origin after a `fg`/SIGCONT resume. */
   readonly repaintAfterTerminalResume: () => void;
   /** Replace a live attention title with the idle project title while stopped. */
@@ -160,13 +158,7 @@ export function createSessionExitController(
   // writes so the tail of the session isn't lost (SAVE_DEBOUNCE_MS window).
   // Persistent flushes have bounded retries; an explicitly ephemeral session
   // has no disk work to drain.
-  const drainPersistence = async (): Promise<void> => {
-    try {
-      await ctx.flushArtifacts();
-    } finally {
-      ctx.detachSnapshotPersistence();
-    }
-  };
+  const drainPersistence = (): Promise<void> => ctx.flushArtifacts();
   // These TUI exit paths call process.exit() directly, so bin/texra.ts's
   // `finally` (which runs platform shutdown) never fires. Run the same
   // shutdown sequence the (suppressed) platform SIGINT/SIGTERM handlers

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -14,7 +14,6 @@ import { AgentError } from '@common/errors';
 import { tryPlatform } from '@platform/platform';
 import { SHUTDOWN_PHASE } from '@platform/interfaces';
 import { EXECUTION_STATUS, RUN_OUTCOME } from '@shared/schemas';
-import { StreamSnapshotStore } from '@transcript';
 import { generateExecutionId } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -181,13 +180,6 @@ export async function executeCliRequest(
   // This executes before runtime-host construction and before runAgent.
   const { session } = await initializeHeadlessTranscriptSession();
   const runtimeHost = createCliRuntimeHost(runContext);
-  const snapshotStore = new StreamSnapshotStore();
-  const detachSnapshotEvents = snapshotStore.attachSessionEvents(
-    session.events,
-  );
-  const detachSnapshotFlusher = session.useArtifactFlusher(() =>
-    snapshotStore.flush(),
-  );
   const detachRunProgressRenderer = runtimeHost.attachRunProgressRenderer(
     session.events,
   );
@@ -304,8 +296,6 @@ export async function executeCliRequest(
       await finalizeShutdownStatus();
       await session.flushArtifacts();
     } finally {
-      detachSnapshotFlusher();
-      detachSnapshotEvents();
       await runtimeHost.close();
     }
   }

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -77,7 +77,6 @@ import {
 } from '@shared/copy/executionHistory';
 import type { MainViewExecuteMessage } from '@shared/schemas/mainView/executeMessage';
 import { cleanupUnscopedApprovals } from '@tools/approval';
-import type { StreamSnapshotStore } from '@transcript';
 import { getConfig } from '@utils/config/configUtils';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -108,7 +107,6 @@ export interface DesktopAgentExecutionOptions {
   postToRenderer(message: unknown): boolean | void;
   host: DesktopAgentExecutionHost;
   session: SessionHandle;
-  progressSnapshotStore: StreamSnapshotStore;
   sessionStores: SessionStores;
   /** Aborts construction and detaches presentation when its window closes. */
   presentationSignal?: AbortSignal;
@@ -119,7 +117,6 @@ export interface DesktopProgressBridgeOptions {
   sessionStores: SessionStores;
   logger?: AgentTrace;
   host: DesktopAgentExecutionHost;
-  progressSnapshotStore: StreamSnapshotStore;
   wakeQueuedFollowUpStream?: typeof wakeQueuedFollowUpStream;
 }
 
@@ -209,7 +206,6 @@ export class DesktopProgressBridge {
       session: this.session,
       stateOwnership: 'session',
       storage: platform().workspaceState,
-      snapshots: options.progressSnapshotStore,
       stores: options.sessionStores,
       sendMessage: (message) => {
         return this.postToRenderer(message) !== false;
@@ -1286,7 +1282,6 @@ export async function createDesktopAgentExecution(
     session: options.session,
     sessionStores: options.sessionStores,
     host: options.host,
-    progressSnapshotStore: options.progressSnapshotStore,
   });
   const disposeAbortedPresentation = (): void => progress.dispose();
   options.presentationSignal?.addEventListener(

--- a/packages/desktop/src/main/desktopAgentResume.ts
+++ b/packages/desktop/src/main/desktopAgentResume.ts
@@ -12,7 +12,6 @@ import { trackTerminalResultPresentation } from '@agent/runtime/terminalResultTo
 
 // Shared imports
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
-import type { StreamSnapshotStore } from '@transcript';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 // Local imports
@@ -30,7 +29,6 @@ interface DesktopResumeState {
 
 interface DesktopResumeContext {
   readonly session: SessionHandle;
-  readonly snapshots: StreamSnapshotStore;
   readonly logger: AgentTrace;
   readonly isCancellationRequested: () => boolean;
 }
@@ -40,10 +38,7 @@ export class DesktopProcessResumeOwner {
   private context: DesktopResumeContext | undefined;
 
   /** Attach the canonical process session after platform initialization. */
-  attach(options: {
-    session: SessionHandle;
-    snapshots: StreamSnapshotStore;
-  }): () => void {
+  attach(options: { session: SessionHandle }): () => void {
     let cancelled = false;
     const context: DesktopResumeContext = {
       ...options,
@@ -72,10 +67,11 @@ async function resolveDesktopResumeState(
   streamId: StreamTabId,
   context: DesktopResumeContext,
 ): Promise<DesktopResumeState | undefined> {
-  let runState = context.snapshots.getRunConfig(streamId);
-  let executionId = context.snapshots.getExecutionId(streamId);
+  let runState = context.session.snapshots.getRunConfig(streamId);
+  let executionId = context.session.snapshots.getExecutionId(streamId);
   if (runState && executionId) {
-    const parentStreamId = context.snapshots.getParentStreamId(streamId);
+    const parentStreamId =
+      context.session.snapshots.getParentStreamId(streamId);
     return {
       runState,
       executionId,
@@ -84,7 +80,7 @@ async function resolveDesktopResumeState(
   }
 
   try {
-    await context.snapshots.preload([streamId]);
+    await context.session.snapshots.preload([streamId]);
   } catch (error) {
     context.logger.warn(
       `Failed to read persisted resume data for ${streamId}`,
@@ -92,11 +88,12 @@ async function resolveDesktopResumeState(
     );
     return undefined;
   }
-  runState = context.snapshots.getRunConfig(streamId);
-  executionId = executionId ?? context.snapshots.getExecutionId(streamId);
+  runState = context.session.snapshots.getRunConfig(streamId);
+  executionId =
+    executionId ?? context.session.snapshots.getExecutionId(streamId);
   if (!runState || !context.session.transcripts.has(streamId)) return undefined;
 
-  const parentStreamId = context.snapshots.getParentStreamId(streamId);
+  const parentStreamId = context.session.snapshots.getParentStreamId(streamId);
   return {
     runState,
     ...(executionId && { executionId }),

--- a/packages/desktop/src/main/desktopProcessStores.ts
+++ b/packages/desktop/src/main/desktopProcessStores.ts
@@ -13,9 +13,6 @@ import { STREAM_TRANSITION_CAUSE } from '@shared/streams/streamStatus';
 import { releaseStreamResources } from '@tools/approval';
 import { GoalStore } from '@tools/goal';
 
-// Transcript imports
-import type { StreamSnapshotStore } from '@transcript';
-
 // Local imports
 import { prepareDesktopLegacyStreamImport } from './desktopLegacyStreamImporter.js';
 import { toLogData } from './desktopLogUtils.js';
@@ -27,16 +24,16 @@ import { toLogData } from './desktopLogUtils.js';
  * stores. The same canonical initialization runs when no legacy file exists.
  *
  * Legacy identities must be claimed in the transcript index before orphaned
- * sidecars are swept. The returned callback detaches the snapshot projection
- * during process shutdown.
+ * sidecars are swept. The returned callback detaches this module's own
+ * stream-removal subscription and deletion-ordered flusher during process
+ * shutdown; the session owns the snapshot store's projection and flush.
  */
 export async function initializeDesktopProcessStores(options: {
   session: SessionHandle;
-  snapshots: StreamSnapshotStore;
   legacyStreamFilePath?: string;
 }) {
-  const { session, snapshots } = options;
-  const { transcripts } = session;
+  const { session } = options;
+  const { transcripts, snapshots } = session;
   const logger = createChannelTrace('DesktopLegacyStreamImporter');
   let legacyImport:
     Awaited<ReturnType<typeof prepareDesktopLegacyStreamImport>> | undefined;
@@ -106,7 +103,6 @@ export async function initializeDesktopProcessStores(options: {
     }
   }
 
-  const detachSnapshotEvents = snapshots.attachSessionEvents(session.events);
   const detachStreamRemoval = session.events.subscribe(
     (sessionEvent) => {
       if (
@@ -135,7 +131,6 @@ export async function initializeDesktopProcessStores(options: {
     stores,
     dispose() {
       detachStreamRemoval();
-      detachSnapshotEvents();
       detachArtifactFlusher();
     },
   };

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -50,7 +50,7 @@ import {
 } from '@shared/schemas/agent';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { backfillFirstRunDone } from '@shared/state/onboardingState';
-import { StreamLogStore, type StreamSnapshotStore } from '@transcript';
+import { StreamLogStore } from '@transcript';
 import { DEBOUNCE_OPTIONS_MS } from '@utils/config';
 import { debounce } from '@utils/core';
 import { BinaryResolver } from '@utils/system/binaryResolver';
@@ -320,7 +320,6 @@ function createWindow(options: {
   authCallbackState: DesktopAuthCallbackState;
   initializeCrashReporting: () => Promise<void>;
   processSession: SessionHandle;
-  progressSnapshotStore: StreamSnapshotStore;
   sessionStores: SessionStores;
   /**
    * Captured in `initializeElectronPlatform` BEFORE the bundled-agent sync
@@ -667,7 +666,6 @@ function createWindow(options: {
     postToRenderer: postToRendererIfAlive,
     host: agentExecutionHost,
     session: options.processSession,
-    progressSnapshotStore: options.progressSnapshotStore,
     sessionStores: options.sessionStores,
   };
   let agentExecution: DesktopProgressBridge | undefined;
@@ -1265,7 +1263,6 @@ if (protocolLifecycle.shouldContinue) {
       try {
         const processStores = await initializeDesktopProcessStores({
           session: processSession,
-          snapshots: platformInit.progressSnapshotStore,
           legacyStreamFilePath: protocolLifecycle.ownsSingleInstanceLock
             ? join(app.getPath('userData'), 'streams.json')
             : undefined,
@@ -1274,7 +1271,6 @@ if (protocolLifecycle.shouldContinue) {
         disposeProcessStores = () => processStores.dispose();
         disposeAgentResumeHandler = processResumeOwner.attach({
           session: processSession,
-          snapshots: platformInit.progressSnapshotStore,
         });
         // before-quit semantics: hold every quit event until shutdown handlers
         // have finished draining (a second Cmd+Q while we're mid-drain must NOT
@@ -1336,7 +1332,6 @@ if (protocolLifecycle.shouldContinue) {
             authCallbackState,
             initializeCrashReporting,
             processSession,
-            progressSnapshotStore: platformInit.progressSnapshotStore,
             sessionStores,
             hasPriorInstall: platformInit.hasPriorInstall,
             resourcesPath: platformInit.resourcesPath,

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -27,7 +27,6 @@ import { WorkspaceStorageProvider } from '@platform/defaults/workspaceStorage';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { configKeyVariants } from '@shared/config/configKeys';
 import { seedDisabledToolDefaults } from '@tools/toolAvailability';
-import { StreamSnapshotStore } from '@transcript';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 // Local file imports
@@ -47,7 +46,6 @@ import { showSecretStorageWarningDialog } from './secretStorageWarningDialog.js'
 export interface ElectronPlatformInitResult {
   workspacePath: string | undefined;
   lifecycle: LifecycleHost;
-  progressSnapshotStore: StreamSnapshotStore;
   /**
    * Desktop's memory/history/executions data root (`~/.texra` in
    * production, see `resolveDesktopDataRoot()`). Threaded out so crash
@@ -308,10 +306,6 @@ export async function initializeElectronPlatform(
 
   const resourcesPath = resolveResourcesPath(mainDirname);
 
-  // The Electron composition root attaches this process-owned snapshot store
-  // to its SessionHandle and flushes it with the other session artifacts.
-  const snapshotStore = new StreamSnapshotStore();
-
   // Register the shared Node-host agent runtime: memory + goal tool injections
   // and the direct Lean language services (lake env lean --server).
   initNodeAgentRuntime(lifecycle);
@@ -331,7 +325,6 @@ export async function initializeElectronPlatform(
   return {
     workspacePath,
     lifecycle,
-    progressSnapshotStore: snapshotStore,
     dataRoot,
     hasPriorInstall,
     resourcesPath,

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -34,6 +34,7 @@ import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManage
 import type { StreamTabId } from '@shared/schemas';
 import type { RunTraceFlushEntry } from '@transcript/runTrace';
 import type { StreamLogStore } from '@transcript/StreamLogStore';
+import { StreamSnapshotStore } from '@transcript/StreamSnapshotStore';
 import { getRunContextSession, tryUseRunContext } from './RunContext';
 import { ExecutionRegistry } from './executionRegistry';
 import { ExecutionSubscriptionBinder } from './ExecutionSubscriptionBinder';
@@ -90,6 +91,7 @@ export type SessionHandleInit = Pick<SessionHandle, 'transcripts'> &
       | 'events'
       | 'status'
       | 'followUps'
+      | 'snapshots'
       | 'flushers'
       | 'interactions'
       | 'modelRetries'
@@ -110,6 +112,9 @@ export class SessionHandle {
   readonly transcripts: StreamLogStore;
   /** Session-owned follow-up queue owner. */
   readonly followUps: ToolUseFollowUpQueue;
+  /** Session-owned per-stream sidecar store for runs launched in this session. */
+  readonly snapshots: StreamSnapshotStore;
+  private readonly detachSnapshotEvents: () => void;
   /** This session's execution-keyed trace flushers. */
   readonly flushers: Map<string, RunTraceFlushEntry>;
   private readonly artifactFlushers = new Set<() => Promise<void>>();
@@ -164,6 +169,11 @@ export class SessionHandle {
     this.status = status;
     this.transcripts = transcripts;
     this.followUps = followUps;
+    // The sidecar store is a session artifact exactly like `transcripts`: the
+    // session projects its own run events into it and flushes it below, so no
+    // host has to construct, attach, and flush one of its own.
+    this.snapshots = init.snapshots ?? new StreamSnapshotStore();
+    this.detachSnapshotEvents = this.snapshots.attachSessionEvents(events);
     this.interactions = init.interactions ?? new SessionHostInteractions();
     this.approvals = approvals;
     this.modelRetries = init.modelRetries ?? new ModelRetryGate();
@@ -263,7 +273,11 @@ export class SessionHandle {
   }
 
   private async flushArtifactsOnce(): Promise<void> {
-    const writers = [() => this.transcripts.flush(), ...this.artifactFlushers];
+    const writers = [
+      () => this.transcripts.flush(),
+      () => this.snapshots.flush(),
+      ...this.artifactFlushers,
+    ];
     const results = await Promise.allSettled(
       writers.map((flush) => Promise.resolve().then(flush)),
     );
@@ -408,6 +422,7 @@ export class SessionHandle {
     this.approvals.clearAll();
     this.modelRetries.dispose();
     this.interactions.dispose();
+    this.detachSnapshotEvents();
     this.artifactFlushers.clear();
     this.resultListeners.clear();
     this.missedTerminalResults.clear();

--- a/src/controllers/progressView/backend/ProgressBackend.ts
+++ b/src/controllers/progressView/backend/ProgressBackend.ts
@@ -34,7 +34,6 @@ import type {
 } from '@shared/schemas';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import { isInFlightPhase } from '@shared/streams/streamStatus';
-import type { StreamSnapshotStore } from '@transcript';
 import { canUseStreamDataDir } from '@transcript/streamDataPaths';
 import type { SessionStores } from './state/SessionStores';
 
@@ -62,7 +61,6 @@ interface ProgressBackendLifecycleOptions {
 
 export interface ProgressBackendOptions {
   storage: StateStore;
-  snapshots?: StreamSnapshotStore;
   stores?: SessionStores;
   sendMessage: ProgressViewMessageSender;
   hasTarget(): boolean;
@@ -73,9 +71,9 @@ export interface ProgressBackendOptions {
   /** Session that owns this backend's coordination state (defaults to the process session). */
   session?: SessionHandle;
   /**
-   * `session` when the caller has already attached this snapshot store to the
-   * session event hub, already registered an artifact flusher for it, and
-   * already loaded/swept it at process start. See the #6981 retirement ledger.
+   * `session` when the caller has already loaded and swept the session's
+   * stores at process start. A process-owned session has opened the canonical
+   * live store, so a replacement presentation must not reload or sweep it.
    */
   stateOwnership?: 'backend' | 'session';
   /**
@@ -107,8 +105,6 @@ export class ProgressBackend {
   private readonly onSetActiveStream?: (
     payload: SetActiveStreamPayload,
   ) => void;
-  private readonly detachSnapshotEvents: () => void;
-  private readonly detachArtifactFlusher: () => void;
   private readonly stateOwnership: 'backend' | 'session';
   private disposed = false;
 
@@ -125,18 +121,9 @@ export class ProgressBackend {
     };
     this.state = new ProgressViewState(
       options.storage,
-      options.snapshots,
       this.session,
       options.stores,
     );
-    this.detachSnapshotEvents =
-      this.stateOwnership === 'session'
-        ? () => undefined
-        : this.state.snapshots.attachSessionEvents(this.session.events);
-    this.detachArtifactFlusher =
-      this.stateOwnership === 'session'
-        ? () => undefined
-        : this.session.useArtifactFlusher(() => this.state.snapshots.flush());
     this.webviewUpdater = new WebviewUpdater(
       this.postMessage,
       options.hasTarget,
@@ -353,8 +340,6 @@ export class ProgressBackend {
 
   dispose(): void {
     this.disposed = true;
-    this.detachSnapshotEvents();
-    this.detachArtifactFlusher();
     this.webviewBridge.dispose();
   }
 }

--- a/src/controllers/progressView/backend/state/ProgressViewState.ts
+++ b/src/controllers/progressView/backend/state/ProgressViewState.ts
@@ -33,7 +33,7 @@ import {
 import { isProcessAgent } from '@shared/streams/agentKind';
 import { isActivePhase } from '@shared/streams/streamStatus';
 import { GoalStore } from '@tools/goal';
-import { StreamSnapshotStore, type StreamLogStore } from '@transcript';
+import type { StreamLogStore, StreamSnapshotStore } from '@transcript';
 import { clamp } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import {
@@ -169,7 +169,6 @@ export class ProgressViewState {
 
   constructor(
     storage: StateStore,
-    snapshots = new StreamSnapshotStore(),
     session: SessionHandle = defaultSession(),
     stores?: SessionStores,
   ) {
@@ -183,7 +182,7 @@ export class ProgressViewState {
     );
     this.streamLogs = session.transcripts;
     this.followUps = session.followUps;
-    this.snapshots = snapshots;
+    this.snapshots = session.snapshots;
     this.stores =
       stores ??
       new SessionStores({

--- a/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
@@ -233,6 +233,7 @@ describe('SessionHandle', () => {
       expect(fresh.status).not.toBe(defaultSession().status);
       expect(fresh.events).not.toBe(defaultSession().events);
       expect(fresh.transcripts).not.toBe(defaultSession().transcripts);
+      expect(fresh.snapshots).not.toBe(defaultSession().snapshots);
       expect(fresh.followUps).not.toBe(defaultSession().followUps);
       expect(fresh.approvals).not.toBe(defaultSession().approvals);
       expect(fresh.modelRetries).not.toBe(defaultSession().modelRetries);

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -607,21 +607,19 @@ describe('executeCliRequest', () => {
   it('closes the runtime host when sidecar flush fails', async () => {
     vi.resetModules();
     const flushError = new Error('flush failed');
-    vi.doMock('@transcript', async (importOriginal) => {
-      const actual = await importOriginal<typeof import('@transcript')>();
-      return {
-        ...actual,
-        StreamSnapshotStore: class {
-          attachSessionEvents = vi.fn(() => vi.fn());
+    // The session owns the sidecar store, so the stub has to replace the
+    // module `SessionHandle` imports (not the `@transcript` barrel).
+    vi.doMock('@transcript/StreamSnapshotStore', () => ({
+      StreamSnapshotStore: class {
+        attachSessionEvents = vi.fn(() => vi.fn());
 
-          handleProgressEvent = vi.fn();
+        handleProgressEvent = vi.fn();
 
-          flush = vi.fn(async () => {
-            throw flushError;
-          });
-        },
-      };
-    });
+        flush = vi.fn(async () => {
+          throw flushError;
+        });
+      },
+    }));
 
     try {
       await installFreshDefaultSession();
@@ -634,7 +632,7 @@ describe('executeCliRequest', () => {
 
       expect(mocks.close).toHaveBeenCalledTimes(1);
     } finally {
-      vi.doUnmock('@transcript');
+      vi.doUnmock('@transcript/StreamSnapshotStore');
       vi.resetModules();
       await installFreshDefaultSession();
     }

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -265,7 +265,10 @@ const SEARCH_TOOL_USE_AGENT_CONFIG = AgentConfigSchema.parse({
 async function loadBridgeModule(options: CreateBridgeOptions = {}): Promise<{
   bridgeModule: DesktopAgentExecutionModule;
   openTranscripts(): Promise<StreamLogStore>;
-  createSession(transcripts: StreamLogStore): SessionHandle;
+  createSession(
+    transcripts: StreamLogStore,
+    snapshots: ProgressSnapshotStore,
+  ): SessionHandle;
   createProgressSnapshotStore(): ProgressSnapshotStore;
   processResumeOwner: import('@desktop/main/desktopAgentResume').DesktopProcessResumeOwner;
   progressSnapshotStore: ProgressSnapshotStore;
@@ -445,7 +448,8 @@ async function loadBridgeModule(options: CreateBridgeOptions = {}): Promise<{
   });
   return {
     bridgeModule,
-    createSession: (transcripts) => new SessionHandle({ transcripts }),
+    createSession: (transcripts, snapshots) =>
+      new SessionHandle({ transcripts, snapshots }),
     createProgressSnapshotStore,
     openTranscripts: () => StreamLogStore.open(),
     processResumeOwner,
@@ -475,7 +479,7 @@ async function createBridge(
     await options.configureProgressSnapshotStore(progressSnapshotStore);
     await progressSnapshotStore.flush();
   }
-  const session = createSession(transcripts);
+  const session = createSession(transcripts, progressSnapshotStore);
   const { attachTerminalResultToast } =
     await import('@agent/runtime/terminalResultToast');
   const detachTerminalResultToast = attachTerminalResultToast(
@@ -499,13 +503,7 @@ async function createBridge(
       releaseStreamResources(stream, session);
     },
   });
-  const disposeResumeHandler = processResumeOwner.attach({
-    session,
-    snapshots: progressSnapshotStore,
-  });
-  const detachSnapshotEvents = progressSnapshotStore.attachSessionEvents(
-    session.events,
-  );
+  const disposeResumeHandler = processResumeOwner.attach({ session });
   await options.configureSession?.(session);
   const bridge = new bridgeModule.DesktopProgressBridge(
     (message) => {
@@ -518,7 +516,6 @@ async function createBridge(
       logger: options.loggerErrorSpy
         ? { ...noopTrace, error: options.loggerErrorSpy }
         : undefined,
-      progressSnapshotStore,
       host: createStubDesktopAgentExecutionHost({
         ...(options.showErrorMessage
           ? { showErrorMessage: options.showErrorMessage }
@@ -538,7 +535,6 @@ async function createBridge(
       bridge.dispose();
       disposeResumeHandler();
       detachTerminalResultToast();
-      detachSnapshotEvents();
       session.dispose();
     },
   });
@@ -2807,7 +2803,8 @@ describe('DesktopProgressBridge', () => {
       const transcripts = await openTranscripts();
       transcripts.ensureStream(streamId);
       await transcripts.flush();
-      const processSession = createSession(transcripts);
+      const progressSnapshotStore = createProgressSnapshotStore();
+      const processSession = createSession(transcripts, progressSnapshotStore);
       const { attachTerminalResultToast } =
         await import('@agent/runtime/terminalResultToast');
       const detachTerminalResultToast = attachTerminalResultToast(
@@ -2817,15 +2814,12 @@ describe('DesktopProgressBridge', () => {
       );
       const { initializeDesktopProcessStores } =
         await import('@desktop/main/desktopProcessStores');
-      const progressSnapshotStore = createProgressSnapshotStore();
       const processStores = await initializeDesktopProcessStores({
         session: processSession,
-        snapshots: progressSnapshotStore,
       });
       const { stores: sessionStores } = processStores;
       const disposeResumeHandler = processResumeOwner.attach({
         session: processSession,
-        snapshots: progressSnapshotStore,
       });
       const taskState = workflowTaskState();
       progressSnapshotStore.setTaskState(
@@ -2850,7 +2844,6 @@ describe('DesktopProgressBridge', () => {
         {
           session: processSession,
           sessionStores,
-          progressSnapshotStore,
           ...(wakeQueuedFollowUpStream ? { wakeQueuedFollowUpStream } : {}),
           host: createStubDesktopAgentExecutionHost({
             openDiff: async (original, proposed, title) => {
@@ -2924,7 +2917,6 @@ describe('DesktopProgressBridge', () => {
           {
             session: processSession,
             sessionStores,
-            progressSnapshotStore,
             host: createStubDesktopAgentExecutionHost({
               showErrorMessage: async (message) => {
                 errorsB.push(message);

--- a/src/test-kernel/desktop/DesktopAgentExecutionFactory.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecutionFactory.vitest.mts
@@ -249,13 +249,15 @@ async function createExecution(options: {
   const { initializeDesktopProcessStores } =
     await import('@desktop/main/desktopProcessStores');
   const transcripts = await StreamLogStore.open();
-  const session = new SessionHandle({ transcripts });
-  options.inspectSession?.(session);
   const progressSnapshotStore = new StreamSnapshotStore();
   await options.prepareSnapshotStore?.(progressSnapshotStore);
+  const session = new SessionHandle({
+    transcripts,
+    snapshots: progressSnapshotStore,
+  });
+  options.inspectSession?.(session);
   const processStores = await initializeDesktopProcessStores({
     session,
-    snapshots: progressSnapshotStore,
     ...(options.legacyStreamFilePath
       ? { legacyStreamFilePath: options.legacyStreamFilePath }
       : {}),
@@ -265,7 +267,6 @@ async function createExecution(options: {
     execution = await createDesktopAgentExecution({
       postToRenderer: options.postToRenderer ?? vi.fn(),
       session,
-      progressSnapshotStore,
       sessionStores: processStores.stores,
       presentationSignal: options.presentationSignal,
       host: createStubDesktopAgentExecutionHost({

--- a/src/test-kernel/desktop/DesktopAgentResume.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentResume.vitest.mts
@@ -82,10 +82,10 @@ function createResumeHarness(): {
   session: SessionHandle;
   dispose(): void;
 } {
-  const session = createTestSession();
+  const session = createTestSession({ snapshots: createSnapshots() });
   session.transcripts.ensureStream(stream);
   const owner = new DesktopProcessResumeOwner();
-  const detach = owner.attach({ session, snapshots: createSnapshots() });
+  const detach = owner.attach({ session });
   const detachTerminalResultToast = attachTerminalResultToast(
     session,
     session.interactions,

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -144,7 +144,6 @@ function createIsolatedRecordingBackend(
   const messages: ProgressViewOutboundMessage[] = [];
   const backend = new ProgressBackend({
     storage: new FakeStateStore(),
-    snapshots: new StreamSnapshotStore(),
     session,
     sendMessage: (message) => {
       messages.push(message);
@@ -315,7 +314,6 @@ describe('ProgressBackend', () => {
     });
     const backend = new ProgressBackend({
       storage: new FakeStateStore(),
-      snapshots: new StreamSnapshotStore(),
       session,
       sendMessage: vi.fn(() => true),
       hasTarget: () => true,
@@ -534,7 +532,6 @@ describe('ProgressBackend', () => {
     const lifecycle = createLifecycleOptions();
     const backend = new ProgressBackend({
       storage: new FakeStateStore(),
-      snapshots: new StreamSnapshotStore(),
       session,
       sendMessage: (message) => {
         messages.push(message);
@@ -828,7 +825,6 @@ describe('ProgressBackend', () => {
     const lifecycle = createLifecycleOptions();
     const backend = new ProgressBackend({
       storage: new FakeStateStore(),
-      snapshots: new StreamSnapshotStore(),
       session,
       sendMessage: vi.fn(),
       hasTarget: () => true,
@@ -1812,7 +1808,14 @@ describe('ProgressBackend', () => {
       expect(handleRunFact).not.toHaveBeenCalled();
       expect(handleInteractionEvent).not.toHaveBeenCalled();
       expect(updateFiles).not.toHaveBeenCalled();
-      expect(backend.state.snapshots.getOutputFiles(streamId)).toEqual({});
+      // The presentation no-ops, but the sidecar store is session-owned, so it
+      // keeps recording: disposing one window/webview must not stop the runtime
+      // persisting an in-flight run's outputs. The desktop already behaved this
+      // way (its `stateOwnership: 'session'` backend never detached the store);
+      // the extension now matches it.
+      expect(backend.state.snapshots.getOutputFiles(streamId)).toEqual({
+        1: [outputFile],
+      });
     } finally {
       subscription.dispose();
       await backend.state.clearAll();


### PR DESCRIPTION
## What

`SessionHandle` already owned the sibling store — `transcripts: StreamLogStore` is a **required** member, flushed in the session's artifact-writer list. `snapshots` was the only sibling still left to the hosts, so every host independently constructed the runtime's own `StreamSnapshotStore`, attached it to the session event hub, and registered an artifact flusher for it. Four hand-wired construct/attach/flush rituals, arbitrated by a `stateOwnership` flag whose job at some call sites was literally "somebody else already did the runtime's job".

`snapshots` now sits beside `transcripts`: constructed in `SessionHandle`'s existing composition block, attached to the session's own event hub there (detached in `teardownOwners`), and flushed in the existing writer list.

## Net elements (R6)

**Added — 2 interface members, nothing else.** No new file, class, port, wrapper, or vocabulary.

| | |
|---|---|
| `SessionHandle.snapshots` | new public member |
| `SessionHandleInit.snapshots` | new optional init member (consumer: the desktop/progress test harnesses that seed a pre-populated store) |

Plus one private `detachSnapshotEvents` field, symmetric with the other owners torn down in `teardownOwners()`.

**Deleted:**

| Site | Removed |
|---|---|
| `ProgressBackend` | `snapshots?` option; both `stateOwnership`-gated registrations (`attachSessionEvents`, `useArtifactFlusher`); their two private fields; their two `dispose()` calls |
| `ProgressViewState` | `snapshots` ctor param + its `new StreamSnapshotStore()` default (field now reads `session.snapshots`, matching `streamLogs` / `followUps` / `streamStatus`) |
| `packages/cli/.../runExecution.ts` | construct + attach + flusher block; 2 teardown detaches |
| `packages/cli/.../runChatTui.tsx` | construct + attach + flusher block; the `detachSnapshotPersistence` closure, its `SessionExitControllerContext` member, and its call in `drainPersistence` |
| `packages/desktop/.../platform/index.ts` | `new StreamSnapshotStore()` + `ElectronPlatformInitResult.progressSnapshotStore` |
| `packages/desktop/.../index.ts` | `createWindow` option + 3 pass-through sites |
| `packages/desktop/.../desktopAgentExecution.ts` | `progressSnapshotStore` on both option interfaces + 2 pass-throughs |
| `packages/desktop/.../desktopProcessStores.ts` | `snapshots` parameter; its own `attachSessionEvents` call + dispose |
| `packages/desktop/.../desktopAgentResume.ts` | `snapshots` on `DesktopResumeContext` and `attach()` |

Store construct/attach/flush ritual sites in hosts: **4 → 0**.
Ordered post-init registrations: **−2** (`attachSessionEvents` in ProgressBackend and desktopProcessStores; the flusher registrations fold into the session writer list).
Ctor/option members carrying the store across the four hosts: **7 → 2** (the two new interface members).

**LoC:** production `−63` (`+42 / −105` across 11 files); with tests, `−62` (`+80 / −142` across 17 files).

## Consumer counts (R8)

- Host-side snapshot construct/attach/generic-flush rituals: **4 before, 0 after**.
- Production `SessionHandle.snapshots` owners: **one per process session**; the two `new SessionHandle(...)` sites use the default, while tests may inject through `SessionHandleInit.snapshots`.
- Detached call-scoped disk readers: **5 and unchanged**; they are readers, not competing live owners.
- Desktop deletion-ordered snapshot flusher: **1 and unchanged**; it preserves ordering that the generic session flusher does not encode.
- Searches for `progressSnapshotStore` and `detachSnapshotPersistence` found no remaining production consumers after their carrier paths were deleted.

## Three carve-outs — deliberate non-goals

1. **`stateOwnership` survives.** Only the *construction* arbitration goes away. Its remaining uses gate `streamLogs.reload()` / `sweepOrphanedStreams()` / `snapshots.load()` in `ProgressViewState.load()`, which encode a real process-vs-presentation rule: a process-owned session has already opened the canonical live store, and reloading it for a replacement presentation races live appends. Its doc comment is updated to describe only what it still means.
2. **Desktop's flusher keeps its own wiring.** `flushSnapshotsAfterStartedDeletions` is `enqueueDeletion(() => snapshots.flush())` — a *deletion-queue-ordered* flush, not the generic one. It stays registered via `useArtifactFlusher` in `desktopProcessStores`. The desktop therefore runs both it and the session's bare `snapshots.flush()`; verified safe — `flush()` skips `'staging'` deletion states and `runRollbackRecovery` dedupes concurrent recovery behind a `rollback-recovering` state, and the two run under `Promise.allSettled` with no shared lock, so no deadlock and no resurrection of staged-deleted sidecars.
3. **The five detached disk readers are untouched and are NOT retired by this PR.** `completedRunArchive.ts` (×2), `traceAssembler.ts`, `executionStreamResolver.ts`, `outputDiscovery.ts` each construct their own `StreamSnapshotStore` as a call-scoped reader. The class is dual-*purpose*, not dual-*owned*.

## Headless one-shot behavior — checked, no change

`texra run` / `--print` is unaffected. `executeCliRequest` is the only headless run entry point (`initializeHeadlessTranscriptSession` has exactly one caller), and it **already** constructed, attached, and flushed a `StreamSnapshotStore` unconditionally on every run — sidecar persistence was never opt-in there. Session-owned persistence keeps the same coverage.

More generally, no new disk footprint anywhere: `StreamSnapshotStore`'s constructor does no I/O, writes are driven only by run events, and `flush()` on a store that never saw an event is a no-op. Production has exactly two `new SessionHandle(...)` sites (the desktop process session and `initializeDefaultSession`), so this is one store per host process, as before.

## One deliberate behavior change (test updated, not silenced)

`ProgressBackend.vitest.ts > no-ops session output-file run facts after dispose` asserted that after `backend.dispose()` the store stopped recording. That held only because the backend owned the detach in `'backend'` mode. With session ownership, disposing a presentation no longer stops durable persistence — which is **what the desktop already did** (`stateOwnership: 'session'` never registered a detach, so closing a window never stopped sidecar writes for a run still in flight). The extension now matches. The test's presentation-level assertions (`handleRunFact` / `handleInteractionEvent` / `updateFiles` not called) are unchanged and still pass; the store assertion is inverted with a comment recording the ruling.

## Verification

```
npm run typecheck                  # clean (all 6 projects)
npm run lint                       # clean
npm run check:dead-code-ratchet    # 18 current vs 18 baselined — OK, no new unused exports
npx vitest run src/test-kernel/agent/runtime src/test-kernel/progressView \
  src/test-kernel/desktop src/test-kernel/transcript \
  src/test-kernel/cli/RunExecution.vitest.mts \
  src/test-kernel/cli/TranscriptSessionPolicy.vitest.mts \
  src/test-kernel/cli/RunChatSignalOwnership.vitest.mts \
  src/test-kernel/tools/ExecutionsToolWorkspaceFiles.vitest.ts \
  src/test-kernel/latex/OutputDiscovery.vitest.mts \
  src/test-kernel/schemas/StreamDataRoundMaps.vitest.ts
npx vitest run src/test-kernel/progressView/ProgressBackend.vitest.ts \
  src/test-kernel/desktop/DesktopAgentExecution.vitest.mts   # 152/152 pass in isolation
```

Suite selection came from grepping every file referencing `StreamSnapshotStore`, `stateOwnership`, `ProgressViewState`, `progressSnapshotStore`, or `detachSnapshotPersistence`.

The broad run has residual failures on this dev box, **all** of them `Test timed out in 10000ms` / `Hook timed out` under heavy concurrent load — zero assertion failures attributable to this change. Confirmed environmental: the same suites were run on a clean `origin/main` checkout (detached HEAD, same box) and failed *more* (5 files / 6 tests) than on this branch (3 files / 4 tests). `DefaultSessionLifecycle.vitest.ts`'s `warn called 2 times` is collateral of its own sibling test timing out into a shared hoisted mock, and reproduces identically on unmodified `origin/main`.

https://claude.ai/code/session_01XZ8Z6rhypTfkVq728XCcCd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared session lifecycle and durable resume/sidecar persistence across CLI, desktop, and progress view; behavior change on presentation dispose is intentional but affects when sidecars update during in-flight runs.
> 
> **Overview**
> **`SessionHandle` now owns per-stream sidecar persistence** (`todos`, plan, usage, output files) via a new `snapshots` member, created and wired to the session event hub in the handle constructor, included in `flushArtifacts()`, and detached on teardown.
> 
> **Hosts stop duplicating that wiring.** CLI chat and headless `executeCliRequest` drop standalone `StreamSnapshotStore` construction, event attachment, artifact flushers, and TUI `detachSnapshotPersistence`. Desktop drops the platform-level store and `progressSnapshotStore` threading through windows, execution, resume, and process-store init; resume and progress state read `session.snapshots` instead.
> 
> **`ProgressBackend` / `ProgressViewState`** no longer take an optional `snapshots` argument or register snapshot listeners/flushers on dispose— they use `session.snapshots` like other session-owned stores.
> 
> **Behavior alignment:** disposing a progress presentation no longer stops the session snapshot store from recording run facts (extension matches desktop’s prior `stateOwnership: 'session'` semantics); tests updated accordingly. Desktop keeps its deletion-ordered `flushSnapshotsAfterStartedDeletions` flusher alongside the session’s generic snapshot flush.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ed6ae362865f5c69f8aa4ac0e1b75aa7184731c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
