### PR TITLE
refactor(agent): move RoundPersistedFlow out of the generic node engine

### DIFF
--- a/src/agent/implementations/flows/reflection/RoundPersistedFlow.ts
+++ b/src/agent/implementations/flows/reflection/RoundPersistedFlow.ts
@@ -1,5 +1,7 @@
 /**
- * RoundPersistedFlow - Flow-level round management with persistence.
+ * RoundPersistedFlow - the reflection flow's round loop, over a PersistedFlow.
+ * Rounds — including the bounded compile-repair round — are reflection-product
+ * policy, so this lives here and not in the generic `@agent/node` engine.
  *
  * Extends PersistedFlow to centrally manage round transitions:
  * - Round counter increment (single source of truth)
@@ -16,8 +18,10 @@
  * ```
  */
 
+import { BaseNode } from '@agent/node';
 import type { ExecutionKVStore } from '@agent/storage';
 import type { StageHandle } from '@agent/trace';
+import { PersistedFlow } from '@agent/node/persistedFlow';
 import {
   RUN_OUTCOME,
   type RetryErrorInfo,
@@ -25,8 +29,6 @@ import {
 } from '@shared/schemas';
 import { deriveRunOutcome } from '@shared/streams/streamStatus';
 
-import { BaseNode } from './index';
-import { PersistedFlow } from './persistedFlow';
 import type { z } from 'zod';
 
 // ============================================================================

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -21,7 +21,6 @@ import {
   PersistedFlowStateError,
   readPersistedFlowRecord,
 } from '@agent/node/persistedFlow';
-import { RoundPersistedFlow } from '@agent/node/roundPersistedFlow';
 import { attachProviderError } from '@common/errors/sdkErrorUtils';
 import { LatexMediaManager } from '@latex/LatexMediaManager';
 import {
@@ -51,6 +50,7 @@ import {
   ReflectionFlowStateCanonicalSchema,
   type ReflectionFlowShared,
 } from './ReflectionFlowState';
+import { RoundPersistedFlow } from './RoundPersistedFlow';
 import type {
   ReflectionServices,
   WorkflowOutputPolicy,

--- a/src/agent/node/persistedFlow.ts
+++ b/src/agent/node/persistedFlow.ts
@@ -167,11 +167,9 @@ export function stampFlowRecordSchemaVersion<T extends FlowRecord>(flow: T): T {
  * Result from a step execution.
  * Used by stepWithResult() for subclasses that need action and shared state.
  */
-export interface StepResult<S> {
+interface StepResult<S> {
   /** Whether there are more nodes to execute */
   hasMore: boolean;
-  /** Whether this step persisted a non-terminal wait at the current node. */
-  waiting?: boolean;
   /** The action returned by the node (for routing) */
   action: string | undefined;
   /** The shared state after node execution (mutated in-place) */
@@ -358,7 +356,6 @@ export class PersistedFlow<
 
     return {
       hasMore: !waiting,
-      ...(waiting ? { waiting } : {}),
       action,
       shared,
     };
@@ -380,8 +377,8 @@ export class PersistedFlow<
 
   /**
    * Reset the node history so the next stepWithResult() starts from the
-   * beginning of the flow graph. Used by RoundPersistedFlow to loop rounds
-   * without embedding loop edges in the graph itself.
+   * beginning of the flow graph. Used by round-looping subclasses to restart
+   * the graph without embedding loop edges in it.
    */
   protected async resetNodeHistory(shared: S): Promise<void> {
     await this.commitShared(shared, (flow) => {

--- a/src/test-kernel/agent/RoundPersistedFlowCompileRepair.vitest.ts
+++ b/src/test-kernel/agent/RoundPersistedFlowCompileRepair.vitest.ts
@@ -7,7 +7,7 @@ import { BaseNode } from '@agent/node';
 import {
   RoundPersistedFlow,
   type RoundAwareState,
-} from '@agent/node/roundPersistedFlow';
+} from '@agent/implementations/flows/reflection/RoundPersistedFlow';
 import type { ExecutionKVStore } from '@agent/storage/ExecutionKVStore';
 import {
   RUN_OUTCOME,

--- a/src/test-kernel/progressView/RepairRoundBadge.vitest.ts
+++ b/src/test-kernel/progressView/RepairRoundBadge.vitest.ts
@@ -7,7 +7,7 @@ import { BaseNode } from '@agent/node';
 import {
   RoundPersistedFlow,
   type RoundAwareState,
-} from '@agent/node/roundPersistedFlow';
+} from '@agent/implementations/flows/reflection/RoundPersistedFlow';
 import { computeRoundStageTotal } from '@agent/implementations/flows/reflection/runReflectionFlow';
 import type { ExecutionKVStore } from '@agent/storage/ExecutionKVStore';
 import type { RoundStage } from '@shared/schemas';


### PR DESCRIPTION
## What

Two changes that make `src/agent/node/` honestly generic.

1. **Move** `src/agent/node/roundPersistedFlow.ts` →
   `src/agent/implementations/flows/reflection/RoundPersistedFlow.ts`.
2. **Delete** `StepResult.waiting` and **un-export** `StepResult` in
   `src/agent/node/persistedFlow.ts`.

## Why the move is a layering change, not a rename

`src/agent/node/` is the host-agnostic flow engine — `BaseNode`/`Node`/`Flow`,
the persisted record, the replay cursor. It is the module a future SDK surface
would expose, and CLAUDE.md already treats it as core-facing.

`roundPersistedFlow.ts` was filed there but is not framework. It is
reflection-product policy wearing a base-class:

- a **round counter** (`currentRound` / `totalRounds` / `continueRounds`),
- **round stage** open/close against `StageHandle` (`@agent/trace`),
- **workspace reset** between rounds,
- and `grantExtraRound` — the **bounded compile-repair round** added for #7077,
  which is a LaTeX concern living inside a would-be-SDK engine module.

It also reaches sideways for `RUN_OUTCOME` / `deriveRunOutcome` from
`@shared/schemas` + `@shared/streams/streamStatus` to compute a `RunOutcome`,
which nothing else in `src/agent/node/` does.

It has **exactly one instantiator** — `runReflectionFlow.ts:262` — so the
"generic base class" framing was never load-bearing. Moving it beside that
caller is what removes product policy from the engine directory; that is the
argument, not tidiness. (fewer-elements R4: this is not a churn-only rename —
the file changes owner, and the engine directory's contract changes with it.)

`src/agent/node/` goes from **1015 → 756** lines, all of it generic
node/flow/persist machinery.

### Direction check (the part that could have been wrong)

`RoundPersistedFlow extends PersistedFlow`, so the move had to not invert the
dependency. It does not:

- **Before**: `implementations/flows/reflection/runReflectionFlow.ts` →
  `@agent/node/roundPersistedFlow` (`implementations → node`, downward).
- **After**: `implementations/flows/reflection/RoundPersistedFlow.ts` →
  `@agent/node` + `@agent/node/persistedFlow` (`implementations → node`,
  still downward).

No `node → implementations` edge is created. `src/agent/node/index.ts` and
`persistedFlow.ts` import nothing from `implementations/`, so there is no
cycle either. `persistedFlow.ts`'s one doc-comment reference to the class by
name (`resetNodeHistory`) is genericised to "round-looping subclasses" so the
engine no longer names a product class even in prose.

**Architecture ratchets: no new edge, no baseline bumped.**
`subsystemEdgeRatchet` works at top-level `src/<subsystem>` granularity — both
the old and new homes are `agent`, so the edge set is byte-identical.
`config/ratchets/architecture-edges-baseline.json` is untouched.
`dependencyDirection.vitest.ts` regulates `vscode` imports, `shared → agent`,
core → host aliases, and `agent/core → modelHandlers` — none of which this
move touches.

## Grep evidence for the two deletions

**`StepResult.waiting` — zero readers.** Declared at `persistedFlow.ts:172-174`,
written at `:361`, never read.

```
$ grep -rn "\.waiting\b" --include="*.ts" --include="*.tsx" . \
    --exclude-dir=node_modules --exclude-dir=.git \
  | grep -vE "waitingStreams|waitingTermination|waitingCleanup"
(no matches)
```

The excluded names are unrelated identifiers (`ExecutionHandle.waitingCleanups`,
`waitingTerminationStarted`, desktop `result.waitingStreams`) that a bare
`.waiting` prefix grep picks up. The local `const waiting` at `:341` is still
live — it drives `next` and `hasMore`; only the object property is gone.

**`StepResult` — zero importers.** Its only two mentions repo-wide are its own
declaration and the return type of `stepWithResult()` in the same file:

```
$ grep -rn "StepResult" --include="*.ts" --include="*.tsx" --include="*.mjs" \
    --include="*.md" --include="*.json" . --exclude-dir=node_modules --exclude-dir=.git
./src/agent/node/persistedFlow.ts:170:export interface StepResult<S> {
./src/agent/node/persistedFlow.ts:313:  protected async stepWithResult(): Promise<StepResult<S>> {
(plus two unrelated `FunctionResultStepResult` hits in a Google-API doc)
```

`RoundPersistedFlow` consumes it by inference off `this.stepWithResult()`, which
does not need the type exported. No tsconfig sets `declaration`, so nothing
depends on it being nameable from outside.

## Net elements (R6)

| | |
|---|---|
| Files added | 0 (1 rename, detected at 95% similarity) |
| Files deleted | 0 |
| Exports added | 0 |
| Exports removed | 1 (`StepResult`) |
| Interface fields removed | 1 (`StepResult.waiting`) |
| **Net lines** | **+11 / −12 = −1** |

The −1 is honest and small on purpose: the three deleted lines
(`waiting?: boolean` + its doc line + the spread at the return site) are offset
by a 2-line header note on the moved file recording *why* it lives in
`reflection/` — so the next sweep doesn't move it back. The value here is
placement, not size.

## Consumer counts (R8)

Both removed exports have zero subscribers, per the grep evidence above:

- `StepResult` — 0 importers repo-wide (only its own declaration and the
  `stepWithResult()` return type in the same file).
- `StepResult.waiting` — 0 readers repo-wide (written once at
  `persistedFlow.ts:361`, never read anywhere).

No emit path or event-channel key is affected by this PR.

## Adjacent changes deliberately NOT made

A sibling study evaluated and rejected each of these; I did not attempt them:

- **Not replacing/rewriting the engine.** The replay cursor is load-bearing on
  all 4 resume entry points and pinned by 4 tests; a plain-function replacement
  measured +16..+24 production LoC plus ~2,000 test LoC rewritten. Standing trap
  per `docs/proposals/2026-07-09-state-of-the-architecture.md:741`.
- **Not collapsing `PersistedFlow` and `RoundPersistedFlow`.** They are not
  siblings — the latter extends the former — and merging would push
  reflection-only callbacks (`grantExtraRound`, `resetForNextRound`,
  `createRoundStage`) into the shared base, i.e. the exact leak this PR removes.
- **Not deleting `replayLegacyNodePath`.** Live v1 persisted-record shim, gated
  by a compatibility window.
- **Not deleting `flowName` / `createdAt` / `params` from the record.** Required
  by the read schema; removing them is a persisted-format change for −8 LoC.
- **Not touching `docs/pocketflow/`.** A sibling PR owns that.
- **Not collapsing the inner flows to plain loops.**
- **Not un-exporting `RoundCallbacks`** (used only within its own file). It is
  not currently a knip finding and touching it is unrelated to the layering
  argument; left for whoever next has a reason to open that file.
- **Not rewriting the historical docs** that cite the old `node/roundPersistedFlow.ts`
  path (dated proposals / PRDs / audits under `docs/`). They are point-in-time
  records, and `node scripts/check-guidance-refs.mjs` passes — no *guidance* file
  references the moved path.

## Verification

All run locally on this branch.

| Command | Result |
|---|---|
| `npm run typecheck` | pass (all 6 projects: root, test-kernel, extension, cli, trace-viewer, desktop) |
| `npx vitest run src/test-kernel/architecture/` | **9 files, 58 tests passed** — identical to the pre-change baseline run |
| `npx vitest run` over the 15 suites touching `RoundPersistedFlow` / `PersistedFlow` / `StepResult` / `runReflectionFlow` / `@agent/node` | **15 files, 212 tests passed** |
| `npm test` (full suite, run alone) | 778 files / 7634 tests passed; **4 files / 6 tests failed, all pre-existing** — see below |
| `npm run check:dead-code-ratchet` | `18 current vs 18 baselined` — `Dead-code ratchet OK: no new unused files/exports/types found.` |
| `npx eslint` + `npx prettier --check` on all 5 changed files | clean |
| `node scripts/check-guidance-refs.mjs` | `Guidance references OK — checked 11 file(s)` |

The 15 suites in the third row (not just the two that name `RoundPersistedFlow`):
`AgentWorkspaceWorkPlanState`, `ModelHandlerCompatibilityInference`,
`XmlOutputManager`, `PersistedFlow`, `PocketFlowNode`, `ReflectionFlowStateRecovery`,
`RegisterExecutionWorkspaceDirectory`, `RoundPersistedFlowCompileRepair`,
`ResumeToolUseCancellation`, `SessionResumeRetrieval`, `storage/Resumability`,
`cli/HistoryStatus`, `progressView/RepairRoundBadge`, `ExecutionsToolResumability`,
`ExecutionsToolWorkspaceFiles`.

### The 6 full-suite failures are pre-existing, not from this PR

```
FAIL src/test-kernel/agent/WorkflowScriptSandboxBundle.vitest.ts > instantiates embedded QuickJS from the 'extension' bundle shape
FAIL src/test-kernel/agent/WorkflowScriptSandboxBundle.vitest.ts > instantiates embedded QuickJS from the 'CLI and desktop' bundle shape
FAIL src/test-kernel/cli/ConfigForm.vitest.mts > keeps a successfully saved key configured when its refresh fails
FAIL src/test-kernel/cli/SubagentListDisplay.vitest.mts > keeps 'live tool activity' visible below one-row long-file metadata at narrow widths
FAIL src/test-kernel/cli/SubagentListDisplay.vitest.mts > keeps 'failed tool activity' visible below one-row long-file metadata at narrow widths
FAIL src/test-kernel/cli/ToolUseRowPatch.vitest.mts > renders a styled tail when a tool exceeds its bounded viewport
```

Re-running those four files at this branch's merge base
(`97543989b5`, detached, no local changes) reproduces **the same six failures,
same test names**: `Test Files 4 failed (4) / Tests 6 failed | 63 passed (69)`.
They are embedded-QuickJS bundle and Ink TUI layout assertions; none of them
imports `PersistedFlow`, `RoundPersistedFlow`, `StepResult`, or
`runReflectionFlow`.

(An earlier full-suite run also flagged `tools/lean/LeanTools` —
`expected 823 to be less than 600` — which disappeared once I stopped running
three vitest processes at once. That one was CPU contention on my machine, not
a code failure.)

### One brief in the task description that was inaccurate

The brief predicted `src/agent/node/` would go "~758 → ~502" lines. The real
counts are **1015 → 756** — the estimate omitted `index.ts` (252 lines). The
delta removed from the directory (256 lines) is right; the totals were not.
Everything else in the brief checked out at `origin/main` verbatim: the ~256 LoC
file, the `@shared/schemas` + `StageHandle` imports, `extends PersistedFlow` at
`:105`, the single production consumer at `runReflectionFlow.ts:262`,
`StepResult.waiting` at `:172-174` set at `:361`, and zero readers for both.

https://claude.ai/code/session_01XZ8Z6rhypTfkVq728XCcCd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layering/import-path refactor with no new behavior; the only production consumer already lived in reflection, and removed APIs had no external readers.
> 
> **Overview**
> **Moves reflection round-loop policy out of `@agent/node`.** `RoundPersistedFlow` now lives beside `runReflectionFlow` under `implementations/flows/reflection/`, with imports updated from `@agent/node/roundPersistedFlow` to the local module (including compile-repair and progress-badge tests).
> 
> **Trims the generic persisted-flow engine surface.** In `persistedFlow.ts`, `StepResult` is no longer exported, the unused `waiting` field is removed from step results (waiting still drives `hasMore` internally), and `resetNodeHistory` docs refer to “round-looping subclasses” instead of naming `RoundPersistedFlow`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88bb08e8470451fd701fe91be62e0e6cbbec8d29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
