### PR TITLE
refactor(runtime): delete unreachable interaction timeout results

### DIFF
--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -401,11 +401,7 @@ export abstract class RetryableInvocationNode<
       return { shouldRetry: false, userCancelled: false };
     }
 
-    const message =
-      result.action === 'timeout'
-        ? 'Retry timed out (no response)'
-        : 'Retry cancelled by user';
-    logProgressStatus(logger, message);
+    logProgressStatus(logger, 'Retry cancelled by user');
     streamStatus.transition(streamId, STREAM_PHASE.CANCELLED, 'user-stop', {
       trace: logger,
     });

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -68,8 +68,7 @@ export interface HostRetryInteractionOptions extends HostInteractionOptions {
 export type PlanApprovalResult =
   | { action: 'approve'; feedback?: never }
   | { action: 'approve_and_goal'; feedback?: never }
-  | { action: 'reject'; feedback?: string }
-  | { action: 'timeout'; feedback?: never };
+  | { action: 'reject'; feedback?: string };
 
 export type ProposalResult =
   | {
@@ -89,18 +88,11 @@ export type ProposalResult =
       model?: never;
       agent?: never;
       feedback?: never;
-    }
-  | {
-      action: 'timeout';
-      model?: never;
-      agent?: never;
-      feedback?: never;
     };
 
 export type RetrySettlement =
   | { action: 'retry'; feedback?: string; reason?: never }
-  | { action: 'cancel'; feedback?: never; reason?: never }
-  | { action: 'timeout'; feedback?: never; reason?: never };
+  | { action: 'cancel'; feedback?: never; reason?: never };
 
 export type RetryResult =
   | RetrySettlement
@@ -126,15 +118,6 @@ export interface HostBashApprovalRequest {
 export interface HostBashApprovalResult {
   readonly accepted: boolean;
   readonly userMessage?: string;
-  /**
-   * Set when `accepted: false` came from the host-side interaction timeout
-   * rather than an explicit user rejection — mirrors the distinct
-   * `{ action: 'timeout' }` shape `PlanApprovalResult`/`ProposalResult`/
-   * `RetryResult` already use (see #7327), kept as a flag here since
-   * restructuring this result to a discriminated union isn't worth it for a
-   * single boolean. Consumers must not report a timeout as a user rejection.
-   */
-  readonly timedOut?: boolean;
 }
 
 export type HostAgentProposalRequest = AgentProposal & {
@@ -181,8 +164,7 @@ export interface HostExternalInquiryHandle {
 
 export type BashSettlement =
   | { readonly action: 'approve'; readonly feedback?: never }
-  | { readonly action: 'reject'; readonly feedback?: string }
-  | { readonly action: 'timeout'; readonly feedback?: never };
+  | { readonly action: 'reject'; readonly feedback?: string };
 
 export type UserQuestionSettlement =
   | {
@@ -216,7 +198,6 @@ type CancellationResultFactories = {
 const cancellationResultFactories: CancellationResultFactories = {
   bash: (feedback) => ({
     accepted: false,
-    timedOut: undefined,
     userMessage: feedback?.trim(),
   }),
   plan: (feedback) => ({ action: 'reject', feedback }),

--- a/src/agent/runtime/hostInteractionResultMappers.ts
+++ b/src/agent/runtime/hostInteractionResultMappers.ts
@@ -11,7 +11,6 @@ export function toBashApprovalResult(
 ): HostBashApprovalResult {
   return {
     accepted: decision.action === 'approve',
-    timedOut: decision.action === 'timeout' ? true : undefined,
     // Deliberate alignment choice, not an oversight: `userMessage` exists to
     // explain a rejection back to the agent (see buildBashApprovalRejectedResult),
     // so it's scoped to the reject action alone. The pre-alignment desktop

--- a/src/test-kernel/agent/runtime/HostInteractionSettlements.vitest.ts
+++ b/src/test-kernel/agent/runtime/HostInteractionSettlements.vitest.ts
@@ -3,6 +3,7 @@ import { expect, expectTypeOf, it } from 'vitest';
 
 // Local imports - host interactions
 import {
+  type BashSettlement,
   cancellationResultFor,
   type HostBashApprovalResult,
   type HostUserQuestionResult,
@@ -46,6 +47,21 @@ it('makes contradictory interaction decisions unrepresentable', () => {
   expectTypeOf<
     IsAssignable<{ action: 'cancel'; reason: string }, RetrySettlement>
   >().toEqualTypeOf<false>();
+  expectTypeOf<
+    IsAssignable<{ action: 'timeout' }, PlanApprovalResult>
+  >().toEqualTypeOf<false>();
+  expectTypeOf<
+    IsAssignable<{ action: 'timeout' }, ProposalResult>
+  >().toEqualTypeOf<false>();
+  expectTypeOf<
+    IsAssignable<{ action: 'timeout' }, RetrySettlement>
+  >().toEqualTypeOf<false>();
+  expectTypeOf<
+    IsAssignable<{ action: 'timeout' }, BashSettlement>
+  >().toEqualTypeOf<false>();
+  expectTypeOf<
+    'timedOut' extends keyof HostBashApprovalResult ? true : false
+  >().toEqualTypeOf<false>();
 });
 
 it("returns each interaction kind's exact cancellation result", () => {
@@ -67,7 +83,6 @@ it("returns each interaction kind's exact cancellation result", () => {
 it('normalizes bash cancellation feedback like an explicit rejection', () => {
   expect(cancellationResultFor('bash', '  reason  ')).toEqual({
     accepted: false,
-    timedOut: undefined,
     userMessage: 'reason',
   });
 });

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -1081,28 +1081,25 @@ describe('RetryState', () => {
     }
   });
 
-  it.each(['cancel', 'timeout'] as const)(
-    'stops the stream after manual retry %s',
-    async (action) => {
-      const streamId = `retry-state-${action}` as StreamTabId;
-      const { node, session, streamStatus, requestRetry } =
-        createRetryNode(streamId);
+  it('stops the stream after manual retry cancellation', async () => {
+    const streamId = 'retry-state-cancel' as StreamTabId;
+    const { node, session, streamStatus, requestRetry } =
+      createRetryNode(streamId);
 
-      requestRetry.mockResolvedValueOnce({ action });
+    requestRetry.mockResolvedValueOnce({ action: 'cancel' });
 
-      try {
-        seedStreamStatusForTest(streamStatus, streamId, STREAM_STATUS.RUNNING);
+    try {
+      seedStreamStatusForTest(streamStatus, streamId, STREAM_STATUS.RUNNING);
 
-        await withRetryRunContext(streamId, session, () =>
-          node.promptFor(new Error('temporary provider failure')),
-        );
+      await withRetryRunContext(streamId, session, () =>
+        node.promptFor(new Error('temporary provider failure')),
+      );
 
-        expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
-      } finally {
-        clearStreamStatusForTest(streamStatus, streamId);
-      }
-    },
-  );
+      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
+    } finally {
+      clearStreamStatusForTest(streamStatus, streamId);
+    }
+  });
 
   it('classifies a policy/headless retry denial as failed, not cancelled (#7331)', async () => {
     const streamId = 'retry-state-deny' as StreamTabId;

--- a/src/test-kernel/desktop/DesktopHostInteractions.vitest.mts
+++ b/src/test-kernel/desktop/DesktopHostInteractions.vitest.mts
@@ -416,27 +416,6 @@ describe('createDesktopHostInteractions', () => {
     });
   });
 
-  it('preserves a bash timeout resolution as distinct from rejection', async () => {
-    const handlers = createHandlers();
-    const { interactions } = await createInteractions(handlers);
-
-    const resultPromise = interactions.requestBashApproval({
-      command: 'sleep 10',
-      streamId: 'stream-a' as StreamTabId,
-    });
-    const requestId = firstShowRequestId(handlers.transport.bash.show);
-
-    expect(
-      interactions.submitBashDecision(requestId, { action: 'timeout' }),
-    ).toBe(true);
-
-    await expect(resultPromise).resolves.toEqual({
-      accepted: false,
-      timedOut: true,
-    });
-    expect(handlers.transport.bash.dismiss).toHaveBeenCalledWith(requestId);
-  });
-
   it('preserves typed proposal approval overrides', async () => {
     const handlers = createHandlers();
     const { interactions } = await createInteractions(handlers);

--- a/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
+++ b/src/test-kernel/tools/BashToolErrorFeedback.vitest.ts
@@ -182,10 +182,7 @@ describe('BashTool error feedback', () => {
     expect(executeSpy).toHaveBeenCalledOnce();
   });
 
-  it('reports a real rejection distinctly from an approval timeout', async () => {
-    // Regression coverage for #7444: a host-side approval timeout must not
-    // collapse into the same "User rejected command" shape as an
-    // explicit reject once it reaches the agent.
+  it('reports an explicit approval rejection to the agent', async () => {
     vi.mocked(requestBashApproval).mockResolvedValueOnce({
       accepted: false,
       userMessage: 'No thanks.',
@@ -193,15 +190,5 @@ describe('BashTool error feedback', () => {
     const rejected = await new BashTool().call({ command: 'echo rejected' });
     expect(rejected.status).toBe('error');
     expect(rejected.error).toContain('User rejected command');
-
-    vi.mocked(requestBashApproval).mockResolvedValueOnce({
-      accepted: false,
-      userMessage: 'Approval request timed out.',
-      timedOut: true,
-    });
-    const timedOut = await new BashTool().call({ command: 'echo timeout' });
-    expect(timedOut.status).toBe('error');
-    expect(timedOut.error).not.toContain('User rejected command');
-    expect(timedOut.error).toContain('timed out');
   });
 });

--- a/src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts
+++ b/src/test-kernel/tools/PlanToolWorkPlanState.vitest.ts
@@ -281,24 +281,6 @@ describe('PlanTool — update (plan approval)', () => {
       await GoalStore.forget(streamId);
     }
   });
-
-  it('clears a timed-out plan from displayed work-plan state', async () => {
-    await installPlatform(false);
-    const { decisions, resultPromise, events, workPlanState } = startPlanUpdate(
-      'stream:plan-timeout' as StreamTabId,
-      plan.objective,
-    );
-
-    const approval = findPlanApproval(events);
-    expect(submitPlanDecision(decisions, approval, { action: 'timeout' })).toBe(
-      true,
-    );
-
-    const result = await resultPromise;
-    expect(result.status).toBe('error');
-    expect(workPlanState.plan).toBeNull();
-    expect(workPlanState.planSummary).toBeNull();
-  });
 });
 
 describe('PlanTool — pause/complete (goal lifecycle)', () => {

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -227,11 +227,7 @@ export async function withAgentCliApproval(
 ): Promise<ToolResult> {
   const approval = await requestBashApproval({ command: approvalLabel });
   if (!approval.accepted) {
-    return buildBashApprovalRejectedResult(
-      approvalLabel,
-      approval.userMessage,
-      approval.timedOut,
-    );
+    return buildBashApprovalRejectedResult(approvalLabel, approval.userMessage);
   }
 
   const contexts = getCurrentToolContexts();

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -28,19 +28,12 @@ type BashApprovalRequest = z.infer<typeof BashApprovalRequestSchema>;
 const BashApprovalResultSchema = z.object({
   accepted: z.boolean(),
   userMessage: z.string().optional(),
-  /** Distinguishes a host-side interaction timeout from an explicit reject. */
-  timedOut: z.boolean().optional(),
 });
 type BashApprovalResult = z.infer<typeof BashApprovalResultSchema>;
 
 const DEFAULT_BASH_REJECTION_INSTRUCTION =
   'Do not retry this rejected command or another approval-gated shell command for the same check. ' +
   'Continue without running it, use a non-shell method, or explain what approval would be needed.';
-
-const DEFAULT_BASH_TIMEOUT_INSTRUCTION =
-  'The approval request was not answered in time — this is not an explicit ' +
-  'rejection. You may retry the command later if it is still needed, use a ' +
-  'non-shell method, or continue without it.';
 
 export function setBashApprovalSessionBypass(
   streamId: StreamTabId,
@@ -105,21 +98,14 @@ async function showApprovalPrompt(
 export function buildBashApprovalRejectedResult(
   command: string,
   userMessage?: string,
-  timedOut?: boolean,
 ): ToolResult {
   const preview = truncateWithEllipsis(command, 60);
-  const message = timedOut
-    ? `Command approval timed out: ${preview}`
-    : `User rejected command: ${preview}`;
+  const message = `User rejected command: ${preview}`;
   const feedback = userMessage?.trim();
   return {
     status: 'error',
     summary: message,
     error: message,
-    userInstruction:
-      feedback ||
-      (timedOut
-        ? DEFAULT_BASH_TIMEOUT_INSTRUCTION
-        : DEFAULT_BASH_REJECTION_INSTRUCTION),
+    userInstruction: feedback || DEFAULT_BASH_REJECTION_INSTRUCTION,
   };
 }

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -258,7 +258,6 @@ export class BashTool extends defineTool({
       return buildBashApprovalRejectedResult(
         input.command,
         approval.userMessage,
-        approval.timedOut,
       );
     }
 

--- a/src/tools/delegation/proposalFlow.ts
+++ b/src/tools/delegation/proposalFlow.ts
@@ -121,12 +121,6 @@ function proposalResultToToolResult(
         error: `Delegation to '${agentName}' was rejected.\nYour delegation was: ${echo}${feedbackLine}`,
       };
     }
-    case 'timeout':
-      return {
-        status: 'error',
-        summary: `Delegation to '${agentName}' timed out`,
-        error: `Delegation to '${agentName}' timed out waiting for user approval.\nYour delegation was: ${echo}`,
-      };
     case 'setup':
       return {
         status: 'executed',

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -276,18 +276,8 @@ Best practices:
       return this.startGoalForPlan(plan, streamId);
     }
 
-    // Rejected or timed out — clear the plan from UI
+    // Rejected — clear the plan from UI
     workPlanState.updatePlan(null);
-
-    if (result.action === 'timeout') {
-      logger.warn('Plan approval timed out');
-      return {
-        status: 'error',
-        summary: 'Plan approval timed out',
-        error:
-          'The plan approval request timed out before the user responded. Please try again or proceed without a plan.',
-      };
-    }
 
     const feedback = result.feedback;
     const feedbackNote = feedback

--- a/src/tools/setup/SendToTerminalTool.ts
+++ b/src/tools/setup/SendToTerminalTool.ts
@@ -65,11 +65,7 @@ export class SendToTerminalTool extends defineTool({
 
     const approval = await requestBashApproval({ command });
     if (!approval.accepted) {
-      return buildBashApprovalRejectedResult(
-        command,
-        approval.userMessage,
-        approval.timedOut,
-      );
+      return buildBashApprovalRejectedResult(command, approval.userMessage);
     }
 
     const name = TERMINAL_NAME_PREFIX + input.label.trim();

--- a/src/tools/wolfram/WolframTool.ts
+++ b/src/tools/wolfram/WolframTool.ts
@@ -62,11 +62,7 @@ export class WolframTool extends defineTool({
     const command = wolframApprovalCommand(input.code);
     const approval = await requestBashApproval({ command });
     if (!approval.accepted) {
-      return buildBashApprovalRejectedResult(
-        command,
-        approval.userMessage,
-        approval.timedOut,
-      );
+      return buildBashApprovalRejectedResult(command, approval.userMessage);
     }
 
     getCurrentToolContexts()?.callContext?.hooks?.onExecutionReady?.();


### PR DESCRIPTION
Closes #9237

## Problem

#9227 deleted `HostInteractionOptions.timeoutMs` and the only runtime path that could produce interaction timeouts. Five timeout-shaped result members remained in the public interaction types even though no production host could construct them:

- `PlanApprovalResult.action === 'timeout'`
- `ProposalResult.action === 'timeout'`
- `RetrySettlement.action === 'timeout'`
- `BashSettlement.action === 'timeout'`
- `HostBashApprovalResult.timedOut`

Keeping these branches forced consumers to describe behavior that had become unreachable and made the interaction contract wider than the implementation.

## Change

Delete the five dead result members and their downstream branches:

- plan approval now distinguishes only approve, approve-with-goal, and reject;
- proposal approval now distinguishes approve, reject, and setup;
- retry settlement now distinguishes retry and cancel, with the existing headless `deny` result retained;
- bash approval now distinguishes approve and reject;
- bash rejection formatting no longer accepts or forwards a timeout flag.

The unrelated execution-timeout fields on shell commands, terminal runs, and workflow sandbox results remain intact. This PR removes only host-interaction approval timeouts.

## Net elements (R6)

- Deleted four discriminated-union variants and one interface field.
- Deleted the plan, retry, proposal, and bash mapper timeout branches.
- Deleted the bash timeout instruction constant and the third parameter of `buildBashApprovalRejectedResult`.
- Deleted two timeout-only tests and narrowed two mixed tests to their still-reachable cancellation/rejection cases.
- Added no production type, function, field, branch, or file.
- Production diff: +10 / -77, net -67.
- Test diff: +32 / -72, net -40.
- Total: +42 / -149, net -107.

The test additions are compile-time assertions that all four timeout settlement shapes, and the bash `timedOut` key, remain absent.

## Consumer counts (R8)

- Production timeout producers before this PR: 0; after this PR: 0. The types now match that fact.
- Removed four discriminant consumers: `PlanTool`, `RetryState`, `proposalFlow`, and `toBashApprovalResult`.
- Removed the bash timeout-formatting branch and four `approval.timedOut` forwarding sites.
- `buildBashApprovalRejectedResult` retains its four production callers; all now pass only command and optional user feedback.
- Repository-wide searches leave no interaction `action: 'timeout'`, comparison, switch case, or `approval.timedOut` read. The remaining timeout vocabulary belongs to actual command/process timeouts.

## Verification

- Root TypeScript check: passed.
- Test-kernel TypeScript check: passed.
- ESLint: passed.
- Dead-code ratchet: 18 current / 18 baselined, passed.
- Focused interaction, retry, desktop-host, plan, provider-fallback, and bash-feedback tests: 8 files / 111 tests passed.
- Prettier and `git diff --check`: passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletion-only alignment of types and unreachable branches; no new approval behavior. Residual risk is any external consumer still typing timeout results, which TypeScript should catch.
> 
> **Overview**
> After **`HostInteractionOptions.timeoutMs`** was removed, no host could still emit approval **timeouts**. This PR deletes that dead contract surface and the code that pretended to handle it.
> 
> **Types and runtime:** `PlanApprovalResult`, `ProposalResult`, `RetrySettlement`, and `BashSettlement` no longer include `action: 'timeout'`; **`HostBashApprovalResult.timedOut`** is gone. **`RetryState`** always logs manual retry dismissal as user cancel (no timeout-specific path). **`toBashApprovalResult`** and cancellation helpers no longer set timeout flags.
> 
> **Tools:** **`buildBashApprovalRejectedResult`** only models explicit rejection (no timeout copy or third argument). **`PlanTool`**, **`proposalFlow`**, bash/wolfram/terminal/agent-CLI callers drop timeout branches. **Shell/command execution timeouts** (e.g. `executeCommand`, terminal `timedOut`) are unchanged.
> 
> **Tests:** Timeout-only cases removed; compile-time checks assert timeout shapes stay unrepresentable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdb0df7176b0e069bcec7660603e0859fb94bdc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->