### PR TITLE
refactor(schemas): un-export two dead schema-paired types

### DIFF
--- a/packages/extension/src/progressView/frontend/slices/syncSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/syncSlice.ts
@@ -44,8 +44,8 @@ export const syncHandlers = {
       }));
     } else {
       const { workPlan, controls } = data;
-      // `controls.goal` is already GoalState (the wire schema imports
-      // GoalStateSchema directly from `@shared/schemas/goal`) — no need to
+      // `controls.goal` already matches GoalStateSchema (the wire schema
+      // imports it directly from `@shared/schemas/goal`) — no need to
       // round-trip it through deriveGoalState.
       const goal = controls.goal;
       updateToolUseState(data.stream, (prev) => ({

--- a/src/shared/schemas/goal.ts
+++ b/src/shared/schemas/goal.ts
@@ -51,7 +51,7 @@ export const GoalStateSchema = z.discriminatedUnion('active', [
     objective: z.string(),
   }),
 ]);
-export type GoalState = z.infer<typeof GoalStateSchema>;
+type GoalState = z.infer<typeof GoalStateSchema>;
 
 /**
  * Single source of truth for the "status/objective are only meaningful while

--- a/src/shared/schemas/output.ts
+++ b/src/shared/schemas/output.ts
@@ -121,7 +121,7 @@ export const CompileFailureSummarySchema = z.object({
   logPath: z.string(),
   logAbsolutePath: z.string(),
 });
-export type CompileFailureSummary = z.infer<typeof CompileFailureSummarySchema>;
+type CompileFailureSummary = z.infer<typeof CompileFailureSummarySchema>;
 
 export const CompileResultSchema = z.discriminatedUnion('status', [
   z.strictObject({


### PR DESCRIPTION
## Summary

The maintainer has ruled that `@shared/schemas` (`src/shared/schemas/index.ts`)
**is a published surface and stays**. A follow-up audit asked whether everything
on that surface is necessary. This PR removes only the parts that are *provably*
unnecessary and require **zero consumer changes**. A separate decision covers
the rest.

Two exported types are referenced **only inside their own defining file**. The
`export` keyword is dropped; the declaration stays.

| symbol | file | paired `…Schema` still exported? |
|---|---|---|
| `CompileFailureSummary` | `src/shared/schemas/output.ts:124` | ✅ `CompileFailureSummarySchema` (`output.ts:117`) |
| `GoalState` | `src/shared/schemas/goal.ts:54` | ✅ `GoalStateSchema` (`goal.ts:46`) |

**Surviving-schema note.** Both are `z.infer<typeof XSchema>` aliases whose
paired schema remains exported, so `z.infer<typeof CompileFailureSummarySchema>`
and `z.infer<typeof GoalStateSchema>` remain available to any future consumer.
Nothing leaves the surface that cannot be recovered by name.

Both types do appear in the signature of an exported function
(`roundOutputsToCompileFailureSummaries` returns `CompileFailureSummary[]`;
`deriveGoalState` returns `GoalState`). TypeScript emits those signatures fine
against a non-exported alias, and the `z.infer` escape hatch above covers a
consumer who wants to name the type.

## Issue acceptance gates

No tracked issue. This is a hand-audited follow-up to a broader "un-export dead
schema-paired types" task; the two symbols here are the subset of that task's
original 9-item list that satisfy the task's own safety rule (paired schema
stays exported). The other 7 items were evaluated and dropped — see "Items from
the original scope that were dropped" below.

## Single source of truth

`src/shared/schemas/index.ts` remains the one published `@shared/schemas`
surface and the sole owner of what's re-exported from it. This PR doesn't add
or move an owner — it narrows two type re-exports on that existing surface.

## Duplication and abstraction budget

No duplication removed or added; no new abstraction introduced. This is a
subtractive change (two `export` keywords removed) with no replacement layer.

## Net elements (R6)

- Files changed: 3 (`src/shared/schemas/output.ts`, `src/shared/schemas/goal.ts`,
  `packages/extension/src/progressView/frontend/slices/syncSlice.ts`)
- Exported symbols: **−2** (`GoalState`, `CompileFailureSummary` lose `export`;
  declarations and paired `…Schema` exports are untouched)
- Classes/interfaces/enums added or removed: 0
- Net LoC: **−0** on the schema files (keyword removal only) + a 1-line comment
  reflow in `syncSlice.ts`. Surface reduction is 516 → 514 published symbols,
  not a line-count change.

## Consumer counts (R8)

Un-exporting `GoalState` and `CompileFailureSummary`. Whole-word search across
the entire repo, including gitignored files, excluding only `node_modules`,
`.git`, build output and source maps:

```
rg -n --no-ignore --glob '!node_modules' --glob '!.git' -w \
  'CompileFailureSummary|GoalState' . | grep -v '/dist/\|/out/\|\.map:'
```

```
src/shared/schemas/goal.ts:54:export type GoalState = z.infer<typeof GoalStateSchema>;
src/shared/schemas/goal.ts:68:}): GoalState {
src/shared/schemas/output.ts:124:export type CompileFailureSummary = z.infer<typeof CompileFailureSummarySchema>;
src/shared/schemas/output.ts:206:): CompileFailureSummary[] {
packages/extension/src/progressView/frontend/slices/syncSlice.ts:47:      // `controls.goal` is already GoalState (the wire schema imports
```

Consumer count: **0** for both symbols. `-w` (whole word) is what makes this
sound: it matches the **imported name** in an import clause and *not* the
schema name, since `FileLineage` does not match inside `FileLineageSchema`
(`S` is a word character). It also catches every aliasing vector that defeats
a naive grep — `import { X as Y }`, `import * as N` + `N.X`, and
`export type { X }` all still contain `X` as a whole word.

`syncSlice.ts:47` was flagged as a possible real consumer of `GoalState`.
**Verified: comment only.** The code beneath it is an unannotated
`const goal = controls.goal;` with no type reference. The comment now points
at the surviving `GoalStateSchema` instead of the un-exported alias.

## Host impact

Extension: comment-only change in `syncSlice.ts` (progressView frontend); no
behavior change.

Desktop: none — no desktop-specific code touches either symbol.

CLI: none — no CLI-specific code touches either symbol.

## Deliberately out of scope

Not touched, per the maintainer's separate decision:

- `export * as commonViewMessages from './commonViewMessages';` (`index.ts:47`)
- `export * from './agentRoster';` (`index.ts:4`)
- `export * from './agentCliSettings';` (`index.ts:5`)
- `export * from './fileFields';` (`index.ts:6`)
- `export * from './spendingStatus';` (`index.ts:15`)

## Items from the original scope that were dropped

The task listed 8 types plus 1 barrel line. **7 of the 9 were skipped**, each for
a verified reason — see the review comment below for the full evidence. Summary:

- **`mainViewMessages` barrel line — already landed.** Commit `5bc57898d9`
  (today) already deleted `export * as mainViewMessages from './mainView';` for
  exactly this reason. No such line exists on `origin/main`.
- **6 types have no exported paired schema**, so un-exporting them would remove
  a name from the surface with no `z.infer` replacement — which the task's own
  rule forbids (*"do NOT un-export a type whose paired schema is absent"*).
  They are all genuinely zero-importer, so they remain available for a maintainer
  ruling: `FileLineage`, `ParsedUsageData`, `PersistedRoundIndexed`,
  `StatusCounts`, `StreamStatusTrait`, `WorkflowTaskTerminalProgress`.

## Scheduled refactoring

None filed. The 6 types with no paired schema (listed above) remain candidates
for a maintainer to un-export later if the missing `z.infer` fallback is judged
acceptable; no issue tracks this since it's a deliberate deferral, not a defect.

## Validation

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run check:dead-code-ratchet` — 18 current vs 18 baselined, no new
  findings. Baseline NOT bumped (`unusedTypes` was and remains 0: knip treats
  the schemas barrel as an entry point, so barrel-re-exported symbols never
  registered as unused — which is why this audit had to be done by hand).
- `npx vitest run src/test-kernel/{schemas,progressView,shared}/ …` — 85 files,
  739 tests passed

https://claude.ai/code/session_01XZ8Z6rhypTfkVq728XCcCd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No runtime or consumer import changes; only removes two unused exported type aliases from the schemas barrel.
> 
> **Overview**
> Shrinks the published `@shared/schemas` surface by making **`GoalState`** and **`CompileFailureSummary`** module-private. Their paired Zod schemas (`GoalStateSchema`, `CompileFailureSummarySchema`) stay exported, so callers can still name the shapes via `z.infer<typeof …>`.
> 
> In **`syncSlice.ts`**, a comment is updated to refer to **`GoalStateSchema`** instead of the removed public **`GoalState`** alias; runtime behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e3755759d8bc9a36e989049cd695c4e9a8ba3e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
