### PR TITLE
refactor(runtime): delete the 5 producerless show* arms from RuntimeInteractionEventPayloads

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -30,7 +30,6 @@ import {
   type ProposalResult,
   type RetryResult,
 } from '@agent/runtime/HostInteractions';
-import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
 import { isPreferCodexSubscription } from '@auth/codex';
 import { getCliApiMode, setCliApiMode } from '@cli/runtime/apiAccessMode';
 import {
@@ -51,7 +50,14 @@ import {
   isApiProvider,
 } from '@model/apiProviders';
 import { platform } from '@platform/platform';
-import { isUpstreamCreditDepletedError } from '@shared/schemas';
+import {
+  isUpstreamCreditDepletedError,
+  type AgentProposalPermission,
+  type BashPermission,
+  type ExternalInquiryPermission,
+  type PlanApprovalPermission,
+  type RetryPermission,
+} from '@shared/schemas';
 import {
   setBashApprovalSessionBypass,
   setDelegatedWorkApprovalBypasses,
@@ -316,7 +322,7 @@ async function decideWithPolicy<
     kind === 'retry'
       ? immediateDecisionForApproval(
           'showRetryRequest',
-          payload as RuntimeInteractionEventPayloads['showRetryRequest'],
+          payload as RetryPermission,
           context,
         )
       : immediateDecision(context);
@@ -374,7 +380,7 @@ async function requestBashInteraction(
   host: CliRuntimeHost,
   requestId: string,
 ): Promise<HostBashApprovalResult> {
-  const payload: RuntimeInteractionEventPayloads['showBashPermission'] = {
+  const payload: BashPermission = {
     requestId,
     command: request.command,
     ...(request.cwd ? { cwd: request.cwd } : {}),
@@ -397,7 +403,7 @@ async function requestBashInteraction(
 }
 
 async function requestPlanInteraction(
-  request: RuntimeInteractionEventPayloads['showPlanApproval'],
+  request: PlanApprovalPermission,
   context: CliContext,
 ): Promise<PlanApprovalResult> {
   const decision = await decideWithPolicy(context, 'plan', request);
@@ -408,7 +414,7 @@ async function requestPlanInteraction(
 }
 
 async function requestProposalInteraction(
-  request: RuntimeInteractionEventPayloads['showAgentProposal'],
+  request: AgentProposalPermission,
   context: CliContext,
   host: CliRuntimeHost,
 ): Promise<ProposalResult> {
@@ -558,7 +564,7 @@ async function requestUserQuestionInteraction(
 }
 
 async function openExternalInquiryInteraction(
-  payload: RuntimeInteractionEventPayloads['showExternalInquiry'],
+  payload: ExternalInquiryPermission,
   context: CliContext,
 ): Promise<{ threadId: string }> {
   handleExternalInquiry(payload, context);
@@ -740,7 +746,7 @@ async function switchRetryToPersonalCredentials(
 }
 
 function handleExternalInquiry(
-  payload: RuntimeInteractionEventPayloads['showExternalInquiry'],
+  payload: ExternalInquiryPermission,
   context: CliContext,
 ): void {
   const threadId = payload.threadId;

--- a/packages/cli/src/runtime/approval/approvalPolicy.ts
+++ b/packages/cli/src/runtime/approval/approvalPolicy.ts
@@ -1,10 +1,13 @@
 import type { HostUserQuestionResult } from '@agent/runtime/HostInteractions';
-import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
 import { isRelayMonthlyLimitMessage } from '@common/errors/sdkErrorUtils';
 import {
   isChatGptSubscriptionLimitError,
   isCredentialExhausted,
+  type AgentProposalPermission,
+  type BashPermission,
   type ExhaustionReason,
+  type PlanApprovalPermission,
+  type RetryPermission,
   type ApprovalDecision as SharedApprovalDecision,
 } from '@shared/schemas';
 
@@ -16,12 +19,20 @@ import { askCliQuestion } from '../logSinks';
  * or by prompting, as opposed to the human-input requests (user questions,
  * external inquiry) that always need a person. Both the headless adapter and
  * the TUI discriminate on this set.
+ *
+ * CLI-owned, not a runtime event vocabulary: nothing emits these names over
+ * `AgentRuntimeHost`. They are the discriminator for the CLI's own approval
+ * prompts, and the payloads are the plain `@shared/schemas` permission shapes
+ * the live `HostInteractions` requests already carry.
  */
-export type CliDecisionApprovalEvent =
-  | 'showBashPermission'
-  | 'showPlanApproval'
-  | 'showAgentProposal'
-  | 'showRetryRequest';
+export interface CliDecisionApprovalPayloads {
+  showBashPermission: BashPermission;
+  showPlanApproval: PlanApprovalPermission;
+  showAgentProposal: AgentProposalPermission;
+  showRetryRequest: RetryPermission;
+}
+
+export type CliDecisionApprovalEvent = keyof CliDecisionApprovalPayloads;
 
 // The headless adapter only ever sets accepted + userMessage, but reusing the
 // host-neutral shape (which also carries optional userQuestionAnswers) keeps a
@@ -59,14 +70,12 @@ export function hasCliApprovalDenied(context: CliContext): boolean {
 /** Whether the failed retry was a ChatGPT-subscription (Codex) usage limit, so
  *  the switch turns off the subscription preference rather than relay access. */
 export function isCliChatGptSubscriptionRetry(
-  payload: RuntimeInteractionEventPayloads['showRetryRequest'],
+  payload: RetryPermission,
 ): boolean {
   return isChatGptSubscriptionLimitError(payload.errorDetails);
 }
 
-export function isCliApiSwitchableRetry(
-  payload: RuntimeInteractionEventPayloads['showRetryRequest'],
-): boolean {
+export function isCliApiSwitchableRetry(payload: RetryPermission): boolean {
   const details = payload.errorDetails;
   if (!details) return false;
   if (isChatGptSubscriptionLimitError(details)) return true;
@@ -180,12 +189,10 @@ export function immediateDecision(
  *  and auto-approval modes should not burn the retry budget. */
 function isUnretryableRetryRequest(
   event: CliDecisionApprovalEvent,
-  payload: RuntimeInteractionEventPayloads[CliDecisionApprovalEvent],
+  payload: CliDecisionApprovalPayloads[CliDecisionApprovalEvent],
 ): boolean {
   if (event !== 'showRetryRequest') return false;
-  const details = (
-    payload as RuntimeInteractionEventPayloads['showRetryRequest']
-  ).errorDetails;
+  const details = (payload as RetryPermission).errorDetails;
   if (!details) return false;
   if (isCredentialExhausted(details)) return true;
   if (details.statusCode === 401 || details.statusCode === 403) return true;
@@ -194,7 +201,7 @@ function isUnretryableRetryRequest(
 
 export function immediateDecisionForApproval(
   event: CliDecisionApprovalEvent,
-  payload: RuntimeInteractionEventPayloads[CliDecisionApprovalEvent],
+  payload: CliDecisionApprovalPayloads[CliDecisionApprovalEvent],
   context: CliContext,
 ): ApprovalDecision | undefined {
   if (isUnretryableRetryRequest(event, payload)) {

--- a/packages/cli/src/runtime/approval/approvalSummaries.ts
+++ b/packages/cli/src/runtime/approval/approvalSummaries.ts
@@ -1,11 +1,11 @@
 import { structuredPatch } from 'diff';
 
 import type { HostUserQuestionRequest } from '@agent/runtime/HostInteractions';
-import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
 import {
   agentProposalCategoryLabel,
   getProposalFileGroups,
   type AgentProposalPermission,
+  type RetryPermission,
 } from '@shared/schemas';
 import type { ToolEditApprovalRequest } from '@tools/approval/toolEditApproval';
 
@@ -139,9 +139,7 @@ export function formatAgentProposalApprovalSummary(
   ].join('\n');
 }
 
-export function formatRetryRequestMessage(
-  payload: RuntimeInteractionEventPayloads['showRetryRequest'],
-): string {
+export function formatRetryRequestMessage(payload: RetryPermission): string {
   const message = `Retry requested (${payload.operation}): ${payload.errorMessage ?? 'unknown error'}`;
   if (isCliChatGptSubscriptionRetry(payload)) {
     return [message, CLI_CHATGPT_SUBSCRIPTION_RETRY_HINT].join('\n');

--- a/packages/cli/src/runtime/approval/eventDispatch.ts
+++ b/packages/cli/src/runtime/approval/eventDispatch.ts
@@ -1,32 +1,36 @@
-import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
+import type {
+  AgentProposalPermission,
+  BashPermission,
+  PlanApprovalPermission,
+  RetryPermission,
+} from '@shared/schemas';
 
-import { type CliDecisionApprovalEvent } from './approvalPolicy';
+import {
+  type CliDecisionApprovalEvent,
+  type CliDecisionApprovalPayloads,
+} from './approvalPolicy';
 import { formatAgentProposalApprovalSummary } from './approvalSummaries';
 
 export function summarizeApprovalEvent<K extends CliDecisionApprovalEvent>(
   event: K,
-  payload: RuntimeInteractionEventPayloads[K],
+  payload: CliDecisionApprovalPayloads[K],
 ): string {
   switch (event) {
     case 'showBashPermission': {
-      const data =
-        payload as RuntimeInteractionEventPayloads['showBashPermission'];
+      const data = payload as BashPermission;
       const cwd = data.cwd ? `Directory: ${data.cwd}\n` : '';
       return `Command requested:\n${cwd}${data.command}`;
     }
     case 'showPlanApproval': {
-      const data =
-        payload as RuntimeInteractionEventPayloads['showPlanApproval'];
+      const data = payload as PlanApprovalPermission;
       return `Plan approval requested:\n${JSON.stringify(data.plan, null, 2)}`;
     }
     case 'showAgentProposal': {
-      const data =
-        payload as RuntimeInteractionEventPayloads['showAgentProposal'];
+      const data = payload as AgentProposalPermission;
       return formatAgentProposalApprovalSummary(data);
     }
     case 'showRetryRequest': {
-      const data =
-        payload as RuntimeInteractionEventPayloads['showRetryRequest'];
+      const data = payload as RetryPermission;
       return `Retry requested for ${data.operation}: ${data.errorMessage ?? 'unknown error'}`;
     }
     default: {

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -13,8 +13,11 @@ import type {
   ProposalResult,
   RetryResult,
 } from '@agent/runtime/HostInteractions';
-import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
-import type { UserQuestionAnswers } from '@shared/schemas';
+import type {
+  BashPermission,
+  RetryPermission,
+  UserQuestionAnswers,
+} from '@shared/schemas';
 
 import { handleExternalInquiryAction } from '@tools/inquiry/ExternalInquiryTool';
 import {
@@ -29,6 +32,7 @@ import {
   type ApprovalDecision,
   type CliApprovalPromptHooks,
   type CliDecisionApprovalEvent,
+  type CliDecisionApprovalPayloads,
   askApproval,
   askUserQuestionDenial,
   approvalPromptAllowed,
@@ -90,7 +94,7 @@ async function decideToolEdit(
 
 async function decideApprovalEvent<K extends CliDecisionApprovalEvent>(
   event: K,
-  payload: RuntimeInteractionEventPayloads[K],
+  payload: CliDecisionApprovalPayloads[K],
   context: CliContext,
   hooks: CliApprovalPromptHooks,
   options: { writeRejectionToStderr?: boolean } = {},
@@ -98,7 +102,7 @@ async function decideApprovalEvent<K extends CliDecisionApprovalEvent>(
   const immediate = immediateDecisionForApproval(event, payload, context);
 
   if (event === 'showRetryRequest') {
-    const data = payload as RuntimeInteractionEventPayloads['showRetryRequest'];
+    const data = payload as RetryPermission;
     if (!immediate) hooks.beforePrompt?.();
     writeTextStderr(formatRetryRequestMessage(data));
   }
@@ -200,7 +204,7 @@ export function createHeadlessCliHostInteractions(
       return decideToolEdit(request, context, hooks);
     },
     async requestBashApproval(request) {
-      const payload: RuntimeInteractionEventPayloads['showBashPermission'] = {
+      const payload: BashPermission = {
         requestId: 'headless-bash',
         command: request.command,
         ...(request.cwd ? { cwd: request.cwd } : {}),
@@ -234,7 +238,7 @@ export function createHeadlessCliHostInteractions(
       return toProposalResult(decision);
     },
     async requestRetry(request: HostRetryRequest) {
-      const payload: RuntimeInteractionEventPayloads['showRetryRequest'] = {
+      const payload: RetryPermission = {
         requestId: request.requestId,
         streamId: request.streamId,
         operation: request.operation,

--- a/src/agent/runtime/runtimeInteractionEvents.ts
+++ b/src/agent/runtime/runtimeInteractionEvents.ts
@@ -1,12 +1,4 @@
-import type {
-  AgentProposalPermission,
-  BashPermission,
-  ExternalInquiryPermission,
-  PlanApprovalPermission,
-  RetryPermission,
-  StreamTabId,
-  ToolEditPermission,
-} from '@shared/schemas';
+import type { StreamTabId, ToolEditPermission } from '@shared/schemas';
 
 /**
  * Host interaction and approval UI requests emitted by runtime/tool code.
@@ -16,7 +8,6 @@ import type {
  * interaction-owned rather than part of the frozen progress fact map.
  */
 export interface RuntimeInteractionEventPayloads {
-  showRetryRequest: RetryPermission;
   showToolEditPermission: ToolEditPermission;
   resolveToolEditPermission: { requestId: string };
   updateToolEditApprovalBypassState: {
@@ -31,8 +22,4 @@ export interface RuntimeInteractionEventPayloads {
     streamId: StreamTabId;
     bypassActive: boolean;
   };
-  showBashPermission: BashPermission;
-  showAgentProposal: AgentProposalPermission;
-  showPlanApproval: PlanApprovalPermission;
-  showExternalInquiry: ExternalInquiryPermission;
 }

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.mts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.mts
@@ -56,19 +56,17 @@ function useCliHostInteractions(
   );
 }
 
-const credentialExhaustedRetry: RetryPermission =
-  {
-    requestId: 'relay-limit-retry',
-    streamId:
-      'test-stream' as RetryPermission['streamId'],
-    operation: 'Model request',
-    errorMessage: 'HTTP 429 Too Many Requests',
-    errorDetails: {
-      exhaustionReason: 'relay-limit',
-      isRelayError: true,
-      statusCode: 429,
-    },
-  };
+const credentialExhaustedRetry: RetryPermission = {
+  requestId: 'relay-limit-retry',
+  streamId: 'test-stream' as RetryPermission['streamId'],
+  operation: 'Model request',
+  errorMessage: 'HTTP 429 Too Many Requests',
+  errorDetails: {
+    exhaustionReason: 'relay-limit',
+    isRelayError: true,
+    statusCode: 429,
+  },
+};
 
 beforeEach(async () => {
   const { initPlatform: init } = await import('@platform/platform');

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.mts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.mts
@@ -10,7 +10,6 @@ vi.mock('@tools/inquiry/ExternalInquiryTool', () => ({
   handleExternalInquiryAction: handleExternalInquiryActionMock,
 }));
 
-import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import type { HostRetryRequest } from '@agent/runtime/HostInteractions';
 import {
@@ -30,6 +29,8 @@ import type { CliApprovalPromptHooks } from '@cli/runtime/approval/approvalPolic
 import {
   AgentCategory,
   DEFAULT_TOOL_CONFIG,
+  type AgentProposalPermission,
+  type RetryPermission,
   type StreamTabId,
 } from '@shared/schemas';
 import { createTestCliContext } from '@test/cli/fixtures/cliContext';
@@ -55,11 +56,11 @@ function useCliHostInteractions(
   );
 }
 
-const credentialExhaustedRetry: RuntimeInteractionEventPayloads['showRetryRequest'] =
+const credentialExhaustedRetry: RetryPermission =
   {
     requestId: 'relay-limit-retry',
     streamId:
-      'test-stream' as RuntimeInteractionEventPayloads['showRetryRequest']['streamId'],
+      'test-stream' as RetryPermission['streamId'],
     operation: 'Model request',
     errorMessage: 'HTTP 429 Too Many Requests',
     errorDetails: {
@@ -148,7 +149,7 @@ describe('human input approval policy', () => {
 });
 
 describe('approval prompt hooks', () => {
-  const proposal: RuntimeInteractionEventPayloads['showAgentProposal'] = {
+  const proposal: AgentProposalPermission = {
     proposalId: 'proposal-1',
     streamId: 'root@deepseekT#abc',
     agent: 'review',
@@ -528,7 +529,7 @@ describe('formatRetryRequestMessage', () => {
   });
 
   it('recognizes relay monthly-limit text when the relay body is absent', () => {
-    const retry: RuntimeInteractionEventPayloads['showRetryRequest'] = {
+    const retry: RetryPermission = {
       ...credentialExhaustedRetry,
       errorMessage:
         'HTTP 429 Too Many Requests – 429 Monthly spending limit reached ($300).',

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
@@ -167,9 +167,7 @@ function relayRetry(params: {
   } as RetryPermission;
 }
 
-function chatGptSubscriptionRetry(
-  streamId: string,
-): RetryPermission {
+function chatGptSubscriptionRetry(streamId: string): RetryPermission {
   return {
     streamId,
     operation: 'model request',

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
@@ -69,7 +69,6 @@ import type {
   HostRetryInteractionOptions,
 } from '@agent/runtime/HostInteractions';
 import { defaultSession } from '@agent/runtime/SessionHandle';
-import type { RuntimeInteractionEventPayloads } from '@agent/runtime/runtimeInteractionEvents';
 import {
   clearApprovals,
   currentApproval,
@@ -87,7 +86,7 @@ import { createTuiHostInteractions } from '@cli/chat/tui/state/subscribeApproval
 import type { CliContext } from '@cli/runtime/cliContext';
 import type { CliRuntimeHost } from '@cli/runtime/runtimeHost';
 import type { ApiProvider } from '@model/apiProviders';
-import { AgentCategory } from '@shared/schemas';
+import { AgentCategory, type RetryPermission } from '@shared/schemas';
 import { createTestCliContext } from '@test/cli/fixtures/cliContext';
 import { setGoalSessionBashAutoApproval } from '@tools/goal';
 import {
@@ -154,7 +153,7 @@ function relayRetry(params: {
   streamId: string;
   provider?: string;
   message?: string;
-}): RuntimeInteractionEventPayloads['showRetryRequest'] {
+}): RetryPermission {
   return {
     streamId: params.streamId,
     operation: 'model request',
@@ -165,12 +164,12 @@ function relayRetry(params: {
       isRelayError: true,
       ...(params.provider ? { provider: params.provider } : {}),
     },
-  } as RuntimeInteractionEventPayloads['showRetryRequest'];
+  } as RetryPermission;
 }
 
 function chatGptSubscriptionRetry(
   streamId: string,
-): RuntimeInteractionEventPayloads['showRetryRequest'] {
+): RetryPermission {
   return {
     streamId,
     operation: 'model request',
@@ -180,7 +179,7 @@ function chatGptSubscriptionRetry(
       exhaustionReason: 'chatgpt-subscription',
       provider: 'openai',
     },
-  } as RuntimeInteractionEventPayloads['showRetryRequest'];
+  } as RetryPermission;
 }
 
 function decideRetry(decision: ApprovalDecision): void {
@@ -610,7 +609,7 @@ describe('TUI retry approvals', () => {
         isRelayError: false,
         provider: 'openai',
       },
-    } as RuntimeInteractionEventPayloads['showRetryRequest']);
+    } as RetryPermission);
 
     await vi.waitFor(() => {
       expect(mocks.setCliApiMode).toHaveBeenCalledWith('personal');


### PR DESCRIPTION
## What

`RuntimeInteractionEventPayloads` declared 10 arms. Five — `showRetryRequest`, `showBashPermission`, `showPlanApproval`, `showAgentProposal`, `showExternalInquiry` — had **zero `.emit(` producers repo-wide**. Production routes all five through their live, response-bearing `HostInteractions` twins (`requestRetry`, `requestBashApproval`, `requestPlanApproval`, `requestAgentProposal`, `openExternalInquiry`). The runtime was advertising a host surface it never wrote to.

The names survived only as CLI-local type aliases whose payloads are already plain `@shared/schemas` permission shapes, so those sites now name the schema type directly.

Closes #9247

## NDJSON byte-parity gate (the blocking check)

`packages/cli/src/runtime/runtimeHost.ts:121-128` is a **catch-all**: in `--output-format ndjson`, every non-presentation `AgentRuntimeEvent` is serialized verbatim as `{kind:'progress', event, ts, payload}`. So these arms are not literally consumer-less — the CLI would serialize them if anything emitted them. Two independent proofs that no NDJSON record can change:

**1. Producer census — nothing can reach `emit()` with these names.** Every production `.emit(` call site on `AgentRuntimeHost` was enumerated. String-literal emits are only: `requestShowError`, `requestShowInstruction`, `requestOpenFile`, `showAgentConfigBanner`, `requestEnsureProgressView` (all presentation, diverted before the catch-all by `writeRuntimePresentationNdjson`), plus `showToolEditPermission` (`src/tools/approval/toolEditApproval.ts:103`) and `resolveToolEditPermission` (extension + desktop tool-edit approval). The three dynamic/forwarding sites are all closed:

- `src/agent/runtime/streamApprovalQueue.ts:96,100` — the `event` variable is typed `ApprovalBypassEvent`, a 3-literal union of the `update*BypassState` arms only.
- `packages/desktop/src/main/desktopHostInteractions.ts:84` and `src/agent/runtime/HostInteractions.ts:390-400` — generic pass-throughs; they forward only what a producer above hands them.
- `packages/extension/src/frontend/agentRuntime/extensionAgentRuntimeHost.ts` — narrows through `isProgressBackendInteractionEvent`, whose registry already lists only the 4 surviving non-presentation arms.

So the only `kind:'progress'` records producible today are `showToolEditPermission`, `resolveToolEditPermission`, and the three `update*BypassState` arms. None of the five deleted names can ever have appeared on the stream.

**2. Empirical: the built CLI bundle is byte-identical.** The change is entirely type-erased — no executable statement is added or removed. Built `packages/cli/dist/bin/texra.js` on `origin/main` (`b5751dbe90`) and on this branch:

```
198499262bb143b0249941bd98d6eb604e3c2165e3629d03be77fcf3df091c4b  origin/main
198499262bb143b0249941bd98d6eb604e3c2165e3629d03be77fcf3df091c4b  this branch
```

Identical SHA-256 over 11,493,207 bytes. The shipped CLI JavaScript is unchanged, so NDJSON record names, ordering, and payloads are unchanged by construction. No published JSON surface is removed or renamed.

## Net elements (R6)

| | constructs | LoC |
|---|---|---|
| `src/agent/runtime/runtimeInteractionEvents.ts` | interface arms **10 → 5**; type imports **7 → 2** | **+1 / −14 = −13** |
| `packages/cli` (5 prod files) | `CliDecisionApprovalPayloads` **+1 interface (4 members)**; `CliDecisionApprovalEvent` becomes derived (`keyof`) instead of a hand-written 4-literal union | +63 / −44 = **+19** |
| `src/test-kernel` (2 files) | none | +12 / −12 = **0** |
| **Total** | **net −4 declared arms** (5 runtime arms deleted, 4 re-homed CLI-side, `showExternalInquiry` gone entirely) | **+76 / −70 = +6** |

The point is not LoC. Every remaining arm in `runtimeInteractionEvents.ts` now has a producer, so the file stops advertising a runtime surface that does not exist. The new `CliDecisionApprovalPayloads` has two consumers in this PR (`approvalAdapter.ts`, `eventDispatch.ts`).

### Where this diverges from the issue's plan (issue claim that was incomplete)

The issue listed 17 CLI sites as "mechanical substitution to the `@shared/schemas` name" and said `CliDecisionApprovalEvent` "does not need `RuntimeInteractionEventPayloads` and keeps its current spelling." **The literal spelling is preserved, but the union could not stay as-is.** Three sites index the runtime map *generically* by that union and are not a mechanical name swap — the issue's file list omits all three:

- `packages/cli/src/runtime/approvalAdapter.ts:93` — `payload: RuntimeInteractionEventPayloads[K]`, `K extends CliDecisionApprovalEvent`
- `packages/cli/src/runtime/approval/eventDispatch.ts:8` — same generic form
- `packages/cli/src/runtime/approval/approvalPolicy.ts:183,197` — `RuntimeInteractionEventPayloads[CliDecisionApprovalEvent]`

Since the CLI sourced its *payload types* from the deleted runtime arms, it now owns them: `CliDecisionApprovalPayloads` maps the same 4 literals to the same `@shared/schemas` types, and `CliDecisionApprovalEvent = keyof CliDecisionApprovalPayloads`. Type correlation at call sites is preserved exactly; no behavior or string literal changes.

Also not in the issue's file list: two test-kernel files type-index the deleted arms and would fail `tsc -p tsconfig.test-kernel.json`. Updated deliberately, type-spelling only — `RuntimeInteractionEventPayloads['showRetryRequest']` → `RetryPermission`, `['showAgentProposal']` → `AgentProposalPermission`. No assertion, fixture value, or expectation was changed; nothing was relaxed to make a test pass.

## Consumer counts (R8)

Grepped on `origin/main` (`b5751dbe90`) before deletion — `emit(\s*'<key>'` for producers, `case '<key>'` for subscribers:

| deleted arm | `.emit(` producers | `case '…'` subscribers |
| --- | --- | --- |
| `showRetryRequest` | **0** | 1 — `packages/cli/src/runtime/approval/eventDispatch.ts:27` |
| `showBashPermission` | **0** | 1 — `eventDispatch.ts:11` |
| `showPlanApproval` | **0** | 1 — `eventDispatch.ts:17` |
| `showAgentProposal` | **0** | 1 — `eventDispatch.ts:22` |
| `showExternalInquiry` | **0** | **0** |

No arm had a producer, so **no emit path is severed** — the producer census above enumerates every `.emit(` site on `AgentRuntimeHost` and none can name these five. The four surviving subscribers are all one CLI-owned decision switch; they keep the identical string literals and now index `CliDecisionApprovalPayloads` instead of the runtime map, so the dispatch is unchanged. `showExternalInquiry` had neither a producer nor a subscriber and is deleted outright.

## Verification

Issue acceptance criteria 1–3 (run verbatim):

- **AC1** five arms gone from the runtime declaration — PASS (0 matches)
- **AC2** exactly five arms remain — PASS (`count=5`)
- **AC3** no production file outside `packages/cli` names any of the five — PASS (0 matches)

Commands and results:

| command | result |
|---|---|
| `npm run typecheck` | **PASS** — all 6 projects (root, test-kernel, extension, cli, trace-viewer, desktop) |
| `npx vitest run src/test-kernel/architecture/` | **PASS** — 9 files, 58 tests |
| `npx vitest run` (full suite) | 7645/7655 passed; **4 files fail identically on `origin/main`** (see below) |
| targeted: `ApprovalAdapter` + `TuiApprovalRetry` + `CliNdjsonRecordContract` + `HumanPromptProgressEvents` + `PlanToolWorkPlanState` + `Wolfram` + `PermissionDedup` + `DesktopToolEditApproval` + `NativeToolEditApproval` | **PASS** — 9 files, 133 tests |
| `npm run lint` | **PASS** — clean |
| `npm run check:dead-code-ratchet` | **PASS** — `18 current vs 18 baselined`, "no new unused files/exports/types found" |

**No ratchet baseline was modified.** `config/ratchets/knip-baseline.json` is untouched.

The targeted suite covers every test referencing the five deleted names or `runtimeInteractionEvents`, including the tool-edit consumers of the arms that stay.

### Full-suite failures are pre-existing on `origin/main`

Four files fail. Each was run in isolation on this branch and on detached `origin/main` (`b5751dbe90`) — **byte-identical outcome on both: `4 failed | 1 passed`, `6 failed | 67 passed`**:

- `src/test-kernel/agent/WorkflowScriptSandboxBundle.vitest.ts`
- `src/test-kernel/cli/ConfigForm.vitest.mts`
- `src/test-kernel/cli/SubagentListDisplay.vitest.mts`
- `src/test-kernel/cli/ToolUseRowPatch.vitest.mts`

None import or exercise the approval/interaction surface this PR touches. Not introduced here, and not fixed here (out of scope).

`src/test-kernel/agent/runtime/DefaultSessionLifecycle.vitest.ts` also failed once, in a full-suite run that overlapped with a concurrent lint job. It passes cleanly on this branch and on `origin/main` when run without contention (4/4). Recorded as a contention-sensitive flake, not a regression — its subject (`SessionHandle` default-session fallback warning) was changed by recent unrelated main commits (`f1bb427a9c`, `dadf51e87d`, `81c3e9bb99`, `8ed6ae3628`).


https://claude.ai/code/session_01XZ8Z6rhypTfkVq728XCcCd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only refactor with no executable changes; runtime NDJSON and approval flows are unchanged, only the declared event surface and CLI type sources move.
> 
> **Overview**
> **Trims `RuntimeInteractionEventPayloads`** by removing five `show*` arms (`showRetryRequest`, `showBashPermission`, `showPlanApproval`, `showAgentProposal`, `showExternalInquiry`) that had no runtime emitters; production already handles those flows through `HostInteractions` request methods. The map now only lists events that can actually be emitted (tool-edit and bypass-state updates).
> 
> **Moves CLI approval typing off the runtime map.** The CLI adds `CliDecisionApprovalPayloads` (four `show*` keys → `BashPermission`, `PlanApprovalPermission`, `AgentProposalPermission`, `RetryPermission` from `@shared/schemas`) and uses those types in the headless adapter, TUI `subscribeApprovals`, policy/summary/dispatch helpers, and tests instead of `RuntimeInteractionEventPayloads[...]`. `showExternalInquiry` is typed only as `ExternalInquiryPermission` where needed.
> 
> This is a **type-only** refactor: approval behavior and event string literals used internally by the CLI are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5911790a614dbea64721859afd5de602ce43aaff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
