### PR TITLE
refactor(runtime): collapse status onto one rail — 13 → 10 apply-sites (#9250)

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -1438,7 +1438,6 @@ function transitionChildEventOrderRunning(streamId: StreamTabId): void {
     streamId,
     STREAM_PHASE.RUNNING,
     STREAM_TRANSITION_CAUSE.LIFECYCLE,
-    { events: defaultSession().events },
   );
 }
 
@@ -1446,9 +1445,6 @@ function transitionChildEventOrderTerminal(streamId: StreamTabId): void {
   defaultSession().status.transitionToTerminal(
     streamId,
     STREAM_PHASE.COMPLETED,
-    {
-      events: defaultSession().events,
-    },
   );
 }
 
@@ -1463,7 +1459,6 @@ function attemptChildEventOrderLateResume(streamId: StreamTabId): void {
     streamId,
     STREAM_PHASE.RUNNING,
     STREAM_TRANSITION_CAUSE.RESUME,
-    { events: defaultSession().events },
   );
 }
 
@@ -1941,7 +1936,6 @@ function markHarnessStreamInterrupted(streamId: StreamTabId): void {
     streamId,
     STREAM_PHASE.CANCELLED,
     STREAM_TRANSITION_CAUSE.USER_STOP,
-    { events: defaultSession().events },
   );
 }
 

--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -30,7 +30,6 @@ import type { CliContext } from './cliContext';
 const RUN_PROGRESS_RUN_FACT_TYPES = [
   'conversation.progress',
   'run.config',
-  'status',
   'stage.start',
   'child.activity',
 ] as const satisfies readonly AgentEvent['type'][];
@@ -193,9 +192,6 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
           this.updateHeartbeat();
           this.render(true);
         }
-        return true;
-      case 'status':
-        this.applyStatus(event.streamId, event.phase);
         return true;
       case 'conversation.progress':
         if (this.rootStreamTerminal) return true;

--- a/packages/cli/src/runtime/sessionProgressSubscription.ts
+++ b/packages/cli/src/runtime/sessionProgressSubscription.ts
@@ -5,7 +5,7 @@ import type {
 } from '@agent/runtime/SessionEventHub';
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 import type { CliNdjsonRecord } from '@cli/schemas/cliOutput';
-import type { StreamTabId, UpdateStreamStatusPayload } from '@shared/schemas';
+import type { StreamTabId } from '@shared/schemas';
 import { assertNever } from '@utils/core';
 import { writeNdjsonStdout } from './logSinks';
 import type {
@@ -69,19 +69,6 @@ function projectCliRunFact(
         streamId: event.streamId,
         executionId: event.executionId,
         taskState: agentConfigToTaskState(event.config),
-      },
-    };
-  }
-
-  if (event.type === 'status') {
-    return {
-      event: 'updateStreamStatus',
-      payload: {
-        streamId: event.streamId,
-        status: event.phase,
-        cause: event.cause,
-        ...(event.previousPhase ? { previousStatus: event.previousPhase } : {}),
-        ...(event.substate ? { substate: event.substate } : {}),
       },
     };
   }
@@ -176,16 +163,6 @@ function projectCliRunFact(
   return undefined;
 }
 
-function statusProjectionKey(payload: UpdateStreamStatusPayload): string {
-  return JSON.stringify([
-    payload.streamId,
-    payload.status,
-    payload.previousStatus ?? null,
-    payload.cause ?? null,
-    payload.substate ?? null,
-  ]);
-}
-
 /**
  * Headless CLI compatibility adapter. Public NDJSON output still speaks the
  * frozen progress-event vocabulary inside `kind: "progress"` records, so this
@@ -195,17 +172,7 @@ export function attachCliSessionProgressProjection(
   events: SessionEventHub,
   writeRecord: CliNdjsonProgressRecordWriter = writeNdjsonStdout,
 ): () => void {
-  const lastStatusByStream = new Map<StreamTabId, string>();
-
   function emitProjected(projected: CliProjectedNdjsonProgressEvent): void {
-    if (projected.event === 'updateStreamStatus') {
-      const key = statusProjectionKey(projected.payload);
-      const streamId = projected.payload.streamId;
-      if (lastStatusByStream.get(streamId) === key) return;
-      lastStatusByStream.set(streamId, key);
-    } else if (projected.event === 'removeStream') {
-      lastStatusByStream.delete(projected.payload.streamId);
-    }
     writeRecord({
       kind: 'progress',
       event: projected.event,

--- a/packages/extension/src/commands/agent/followUpCommand.ts
+++ b/packages/extension/src/commands/agent/followUpCommand.ts
@@ -60,9 +60,6 @@ async function lazyDetectWaitingStatus(
       const repaired = defaultSession().status.transitionToWaiting(
         streamId,
         'restart-repair',
-        {
-          events: defaultSession().events,
-        },
       );
       if (repaired) {
         logger.debug(`Lazy detected waiting session for stream: ${streamId}`);

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -449,14 +449,9 @@ async function assembleAgentLaunchContext(
 function acquireStreamOrThrow(
   streamId: StreamTabId,
   streamStatus: StreamStatusMachine,
-  session: SessionHandle,
   taskType: string = 'Task',
 ): void {
-  if (
-    streamStatus.tryAcquire(streamId, {
-      events: session.events,
-    })
-  ) {
+  if (streamStatus.tryAcquire(streamId)) {
     return;
   }
 
@@ -488,7 +483,6 @@ function compensateFailedActivation(args: {
   reservedStreamId?: StreamTabId;
   activatedStreamId?: StreamTabId;
   streamStatus: StreamStatusMachine;
-  session: SessionHandle;
   err: unknown;
   // The run-trace from assembleAgentLaunchContext when it was created before the
   // throw. Reused for the error log so we don't allocate a second one; outer
@@ -500,7 +494,6 @@ function compensateFailedActivation(args: {
     reservedStreamId,
     activatedStreamId,
     streamStatus,
-    session,
     err,
     runTrace,
   } = args;
@@ -521,10 +514,7 @@ function compensateFailedActivation(args: {
       !streamStatus.transitionToTerminal(
         activatedStreamId,
         STREAM_PHASE.FAILED,
-        {
-          trace: runTrace?.trace,
-          ...(runTrace ? {} : { events: session.events }),
-        },
+        runTrace ? { trace: runTrace.trace } : {},
       )
     ) {
       runTrace?.trace.warn('Failed to mark activation failure terminal', {
@@ -538,9 +528,7 @@ function compensateFailedActivation(args: {
   }
 
   if (reservedStreamId) {
-    streamStatus.releaseIfReserved(reservedStreamId, {
-      events: session.events,
-    });
+    streamStatus.releaseIfReserved(reservedStreamId);
   }
 }
 
@@ -566,12 +554,7 @@ export async function buildAgentLaunchContext(
     ? undefined
     : getStreamTabId(config.agent, config.model, { executionId });
   if (reservedStreamId) {
-    acquireStreamOrThrow(
-      reservedStreamId,
-      streamStatus,
-      launchSession,
-      input.taskType,
-    );
+    acquireStreamOrThrow(reservedStreamId, streamStatus, input.taskType);
   }
 
   const resources = new AgentLaunchResources();
@@ -592,7 +575,6 @@ export async function buildAgentLaunchContext(
         reservedStreamId,
         activatedStreamId,
         streamStatus,
-        session: launchSession,
         err,
         runTrace,
       });

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -81,7 +81,14 @@ function isReplayableTerminalResult(event: ResultEvent): boolean {
   );
 }
 
-/** A valid transcript store is required; other owners may be injected. */
+/**
+ * A valid transcript store is required; other owners may be injected.
+ *
+ * `status` is deliberately absent: the machine publishes `updateStreamStatus`
+ * on the hub it is handed at construction, so a separately-injected machine
+ * could be bound to a different hub than `events` and silently drop every
+ * status fact. The session always co-constructs the pair instead.
+ */
 export type SessionHandleInit = Pick<SessionHandle, 'transcripts'> &
   Partial<
     Pick<
@@ -89,7 +96,6 @@ export type SessionHandleInit = Pick<SessionHandle, 'transcripts'> &
       | 'executions'
       | 'subscriptions'
       | 'events'
-      | 'status'
       | 'followUps'
       | 'snapshots'
       | 'flushers'
@@ -142,7 +148,7 @@ export class SessionHandle {
     // Forced dependency order, every cross-reference explicit — never let a
     // member fall back to a neighboring module singleton (silent-state-split).
     const events = init.events ?? new SessionEventHub();
-    const status = init.status ?? new StreamStatusMachine(events);
+    const status = new StreamStatusMachine(events);
     const transcripts = init.transcripts;
     const followUps = init.followUps ?? new ToolUseFollowUpQueue();
     const approvals = createSessionApprovals();

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -141,8 +141,8 @@ export class SessionHandle {
     }
     // Forced dependency order, every cross-reference explicit — never let a
     // member fall back to a neighboring module singleton (silent-state-split).
-    const status = init.status ?? new StreamStatusMachine();
     const events = init.events ?? new SessionEventHub();
+    const status = init.status ?? new StreamStatusMachine(events);
     const transcripts = init.transcripts;
     const followUps = init.followUps ?? new ToolUseFollowUpQueue();
     const approvals = createSessionApprovals();

--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -25,7 +25,6 @@ export interface StreamStatusChange {
 }
 
 export interface StreamStatusEmitOptions {
-  events?: SessionEventHub;
   trace?: AgentTrace;
   substate?: StreamSubstate;
 }
@@ -56,6 +55,14 @@ export class StreamStatusMachine {
   private readonly statusListeners = new Set<
     (change: StreamStatusChange) => void
   >();
+
+  /**
+   * @param events Session hub this machine publishes `updateStreamStatus`
+   *   facts on. The session constructs both and hands the hub over once, so a
+   *   transition reaches every projector on the session-fact rail no matter
+   *   which caller triggered it — callers pass only their own trace.
+   */
+  constructor(private readonly events?: SessionEventHub) {}
 
   get(stream: StreamTabId): StreamPhase | undefined {
     return this.stateFor(stream)?.phase;
@@ -309,15 +316,13 @@ export class StreamStatusMachine {
     options.trace?.emit(event);
 
     const change = projectStatusEvent(event);
-    if (!options.trace && options.events) {
-      options.events.emit({
-        scope: 'session',
-        event: {
-          type: 'updateStreamStatus',
-          payload: change,
-        },
-      });
-    }
+    this.events?.emit({
+      scope: 'session',
+      event: {
+        type: 'updateStreamStatus',
+        payload: change,
+      },
+    });
     for (const listener of this.statusListeners) {
       listener(change);
     }

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -131,8 +131,8 @@ export class ExecutionRegistry {
   >();
 
   constructor({
-    streamStatus = new StreamStatusMachine(),
     events = new SessionEventHub(),
+    streamStatus = new StreamStatusMachine(events),
     publishResult,
   }: {
     readonly streamStatus?: StreamStatusMachine;
@@ -966,14 +966,13 @@ export class ExecutionRegistry {
   private streamStatusEmitOptions(
     handle?: AgentExecutionHandle,
   ): StreamStatusEmitOptions {
-    if (handle?.trace) return { trace: handle.trace };
-    return this.events ? { events: this.events } : {};
+    return handle?.trace ? { trace: handle.trace } : {};
   }
 
   /**
-   * Mark a stream CANCELLED from a user stop. Routes the status emission through
-   * the handle's trace when one is available and falls back to the registry's
-   * SessionEventHub otherwise (see {@link streamStatusEmitOptions}).
+   * Mark a stream CANCELLED from a user stop. Passes the handle's trace when
+   * one is available; the session-fact rail is published by the status machine
+   * itself, so no caller has to route it (see {@link streamStatusEmitOptions}).
    */
   private cancelStreamStatus(
     streamId: StreamTabId,

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -87,7 +87,6 @@ export async function resumeQueuedToolUseFromResumeData(
 
   followUpsQueue.acquire(streamId);
   streamStatus.transition(streamId, STREAM_PHASE.RUNNING, 'resume', {
-    events: session.events,
     substate: STREAM_SUBSTATE.RESUMING,
   });
 
@@ -198,9 +197,7 @@ export async function resumeQueuedToolUseFromResumeData(
         followUpsRestored ||
         streamStatus.getSubstate(streamId) === STREAM_SUBSTATE.RESUMING)
     ) {
-      streamStatus.transitionToWaiting(streamId, 'wait', {
-        events: session.events,
-      });
+      streamStatus.transitionToWaiting(streamId, 'wait');
     }
   }
 

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -363,6 +363,11 @@ export type AgentEvent =
  * Event types consumed by both progress-view and headless CLI projections.
  * This host subscription vocabulary is intentionally broader than
  * `RunFactEvent`: it also includes transient runtime events that hosts project.
+ *
+ * `status` is deliberately absent. `StreamStatusMachine` publishes every
+ * transition as an `updateStreamStatus` session fact, so projectors read
+ * status from that one rail; the `status` trace event survives only for
+ * `TexraTranscriptRecorder`, which subscribes to the run trace directly.
  */
 export const RUN_FACT_EVENT_TYPES = Object.freeze([
   'conversation.progress',
@@ -375,7 +380,6 @@ export const RUN_FACT_EVENT_TYPES = Object.freeze([
   'run.start',
   'run.config',
   'usage',
-  'status',
   'stage.start',
   'child.activity',
 ] as const satisfies readonly AgentEvent['type'][]);

--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -121,13 +121,6 @@ export class ProgressFactApplier {
     },
     'run.config': (_streamId, event) =>
       this.handleSetTaskState(event.streamId, event.config.agentCategory),
-    status: (_streamId, event) =>
-      this.setStreamStatus(
-        event.streamId,
-        event.phase,
-        event.previousPhase,
-        event.substate,
-      ),
     updateTodos: (_streamId, event) => this.handleUpdateTodos(event),
     updatePlan: (_streamId, event) => this.handleUpdatePlan(event),
     addOutputFiles: (_streamId, event) => this.handleAddOutputFiles(event),

--- a/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
@@ -13,7 +13,6 @@ import { describe, it, afterEach } from 'vitest';
 
 // Local imports
 import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import {
   AgentExecutionHandle,
@@ -438,9 +437,7 @@ describe('ToolUseFollowUp', () => {
 
     const result = { status: 'queued' as const, reason: 'waiting' as const };
 
-    const routedSession = createTestSession({
-      status: new StreamStatusMachine(),
-    });
+    const routedSession = createTestSession();
     seedStreamStatusForTest(
       routedSession.status,
       parentStreamId,

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -922,8 +922,8 @@ describe('executionRegistry', () => {
 
   it('owns visible stream stop policy for root and children', () => {
     const explicit = createRecordingHost();
-    const streamStatus = new StreamStatusMachine();
     const events = new SessionEventHub();
+    const streamStatus = new StreamStatusMachine(events);
     const recorded = recordSessionEvents(events, { scope: 'session' });
     const registry = new ExecutionRegistry({
       streamStatus,
@@ -1018,8 +1018,8 @@ describe('executionRegistry', () => {
 
   it('detaches descendants when killing with detached subagents', () => {
     const explicit = createRecordingHost();
-    const streamStatus = new StreamStatusMachine();
     const events = new SessionEventHub();
+    const streamStatus = new StreamStatusMachine(events);
     const recorded = recordSessionEvents(events, { scope: 'session' });
     const registry = new ExecutionRegistry({
       streamStatus,
@@ -1079,8 +1079,8 @@ describe('executionRegistry', () => {
 
   it('detaches children when stopping a stream with detached subagents', () => {
     const explicit = createRecordingHost();
-    const streamStatus = new StreamStatusMachine();
     const events = new SessionEventHub();
+    const streamStatus = new StreamStatusMachine(events);
     const recorded = recordSessionEvents(events, { scope: 'session' });
     const registry = new ExecutionRegistry({
       streamStatus,
@@ -1231,8 +1231,8 @@ describe('executionRegistry', () => {
   });
 
   it('cancels an ownerless stream', () => {
-    const streamStatus = new StreamStatusMachine();
     const events = new SessionEventHub();
+    const streamStatus = new StreamStatusMachine(events);
     const recorded = recordSessionEvents(events, { scope: 'session' });
     const registry = new ExecutionRegistry({ streamStatus, events });
     const streamId = 'ownerless-stop-policy-test' as StreamTabId;
@@ -1378,8 +1378,8 @@ describe('executionRegistry', () => {
 
   it('detaches children of an ownerless stream and cancels it', () => {
     const explicit = createRecordingHost();
-    const streamStatus = new StreamStatusMachine();
     const events = new SessionEventHub();
+    const streamStatus = new StreamStatusMachine(events);
     const recorded = recordSessionEvents(events, { scope: 'session' });
     const registry = new ExecutionRegistry({ streamStatus, events });
     const parentStreamId = 'parent-ownerless-detach-test' as StreamTabId;

--- a/src/test-kernel/agent/runtime/StreamStatusService.vitest.ts
+++ b/src/test-kernel/agent/runtime/StreamStatusService.vitest.ts
@@ -32,15 +32,13 @@ import {
 /** Fresh registry + recording host, keyed to a per-test stream id. */
 function setupMachine(streamId: string): {
   machine: StreamStatusMachine;
-  events: SessionEventHub;
   published: ReturnType<typeof recordSessionEvents>;
   streamId: StreamTabId;
 } {
   const events = new SessionEventHub();
   const published = recordSessionEvents(events, { scope: 'session' });
   return {
-    machine: new StreamStatusMachine(),
-    events,
+    machine: new StreamStatusMachine(events),
     published,
     streamId: streamId as StreamTabId,
   };
@@ -64,17 +62,15 @@ describe('StreamStatusMachine', () => {
   });
 
   it('keeps listeners per instance', () => {
-    const first = new StreamStatusMachine();
-    const second = new StreamStatusMachine();
     const events = new SessionEventHub();
+    const first = new StreamStatusMachine(events);
+    const second = new StreamStatusMachine(events);
     const published = recordSessionEvents(events, { scope: 'session' });
     const streamId = 'stream-status-listener-test' as StreamTabId;
     const changes: string[] = [];
 
     first.onDidChange((change) => changes.push(change.streamId));
-    second.transition(streamId, STREAM_PHASE.WAITING, 'restart-repair', {
-      events,
-    });
+    second.transition(streamId, STREAM_PHASE.WAITING, 'restart-repair');
 
     expect(changes).toEqual([]);
     expect(
@@ -126,17 +122,13 @@ describe('StreamStatusMachine', () => {
   });
 
   it('repairs terminal streams to waiting through resume then wait', () => {
-    const { machine, events, published, streamId } = setupMachine(
+    const { machine, published, streamId } = setupMachine(
       'stream-status-terminal-waiting-repair',
     );
 
     seedStreamStatusForTest(machine, streamId, STREAM_PHASE.CANCELLED);
 
-    expect(
-      machine.transitionToWaiting(streamId, 'restart-repair', {
-        events,
-      }),
-    ).toBe(true);
+    expect(machine.transitionToWaiting(streamId, 'restart-repair')).toBe(true);
 
     expect(machine.get(streamId)).toBe(STREAM_PHASE.WAITING);
     expect(sessionFactPayloads(published.events, 'updateStreamStatus')).toEqual(
@@ -158,17 +150,15 @@ describe('StreamStatusMachine', () => {
   });
 
   it('terminalizes waiting streams through resume then lifecycle', () => {
-    const { machine, events, published, streamId } = setupMachine(
+    const { machine, published, streamId } = setupMachine(
       'stream-status-waiting-terminal-repair',
     );
 
     seedStreamStatusForTest(machine, streamId, STREAM_PHASE.WAITING);
 
-    expect(
-      machine.transitionToTerminal(streamId, STREAM_PHASE.FAILED, {
-        events,
-      }),
-    ).toBe(true);
+    expect(machine.transitionToTerminal(streamId, STREAM_PHASE.FAILED)).toBe(
+      true,
+    );
 
     expect(machine.get(streamId)).toBe(STREAM_PHASE.FAILED);
     expect(sessionFactPayloads(published.events, 'updateStreamStatus')).toEqual(
@@ -190,15 +180,13 @@ describe('StreamStatusMachine', () => {
   });
 
   it('terminalizes visible streams that were not started yet', () => {
-    const { machine, events, published, streamId } = setupMachine(
+    const { machine, published, streamId } = setupMachine(
       'stream-status-undefined-terminal-repair',
     );
 
-    expect(
-      machine.transitionToTerminal(streamId, STREAM_PHASE.FAILED, {
-        events,
-      }),
-    ).toBe(true);
+    expect(machine.transitionToTerminal(streamId, STREAM_PHASE.FAILED)).toBe(
+      true,
+    );
 
     expect(machine.get(streamId)).toBe(STREAM_PHASE.FAILED);
     expect(sessionFactPayloads(published.events, 'updateStreamStatus')).toEqual(
@@ -219,17 +207,15 @@ describe('StreamStatusMachine', () => {
   });
 
   it('accepts already-matching terminal outcomes without warning callers', () => {
-    const { machine, events, published, streamId } = setupMachine(
+    const { machine, published, streamId } = setupMachine(
       'stream-status-matching-terminal',
     );
 
     seedStreamStatusForTest(machine, streamId, STREAM_PHASE.CANCELLED);
 
-    expect(
-      machine.transitionToTerminal(streamId, STREAM_PHASE.CANCELLED, {
-        events,
-      }),
-    ).toBe(true);
+    expect(machine.transitionToTerminal(streamId, STREAM_PHASE.CANCELLED)).toBe(
+      true,
+    );
 
     expect(machine.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
     expect(sessionFactPayloads(published.events, 'updateStreamStatus')).toEqual(
@@ -238,17 +224,15 @@ describe('StreamStatusMachine', () => {
   });
 
   it('clears a transient running substate through the table-checked resume transition', () => {
-    const { machine, events, published, streamId } = setupMachine(
+    const { machine, published, streamId } = setupMachine(
       'stream-status-clear-running-substate',
     );
 
     seedStreamStatusForTest(machine, streamId, STREAM_STATUS.RESUMING);
 
-    expect(
-      machine.transition(streamId, STREAM_PHASE.RUNNING, 'resume', {
-        events,
-      }),
-    ).toBe(true);
+    expect(machine.transition(streamId, STREAM_PHASE.RUNNING, 'resume')).toBe(
+      true,
+    );
 
     expect(machine.get(streamId)).toBe(STREAM_PHASE.RUNNING);
     expect(machine.getSubstate(streamId)).toBeUndefined();
@@ -265,17 +249,15 @@ describe('StreamStatusMachine', () => {
   });
 
   it('skips the write and publish for a no-op RUNNING resume with no substate to clear', () => {
-    const { machine, events, published, streamId } = setupMachine(
+    const { machine, published, streamId } = setupMachine(
       'stream-status-noop-running-resume',
     );
 
     seedStreamStatusForTest(machine, streamId, STREAM_PHASE.RUNNING);
 
-    expect(
-      machine.transition(streamId, STREAM_PHASE.RUNNING, 'resume', {
-        events,
-      }),
-    ).toBe(true);
+    expect(machine.transition(streamId, STREAM_PHASE.RUNNING, 'resume')).toBe(
+      true,
+    );
 
     expect(machine.get(streamId)).toBe(STREAM_PHASE.RUNNING);
     expect(machine.getSubstate(streamId)).toBeUndefined();
@@ -308,12 +290,12 @@ describe('StreamStatusMachine', () => {
   });
 
   it('publishes rollback when a visible reservation is released', () => {
-    const { machine, events, published, streamId } = setupMachine(
+    const { machine, published, streamId } = setupMachine(
       'stream-status-reservation-rollback',
     );
 
-    expect(machine.tryAcquire(streamId, { events })).toBe(true);
-    machine.releaseIfReserved(streamId, { events });
+    expect(machine.tryAcquire(streamId)).toBe(true);
+    machine.releaseIfReserved(streamId);
 
     expect(machine.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
     expect(sessionFactPayloads(published.events, 'updateStreamStatus')).toEqual(
@@ -335,21 +317,21 @@ describe('StreamStatusMachine', () => {
   });
 
   it('overlays reservations on stale terminal phases and restores them on rollback', () => {
-    const { machine, events, published, streamId } = setupMachine(
+    const { machine, published, streamId } = setupMachine(
       'stream-status-reservation-overlay',
     );
 
     seedStreamStatusForTest(machine, streamId, STREAM_PHASE.COMPLETED);
 
-    expect(machine.tryAcquire(streamId, { events })).toBe(true);
+    expect(machine.tryAcquire(streamId)).toBe(true);
     expect(machine.get(streamId)).toBe(STREAM_PHASE.RUNNING);
     expect(
       machine.transition(streamId, STREAM_PHASE.RUNNING, 'lifecycle'),
     ).toBe(true);
 
     seedStreamStatusForTest(machine, streamId, STREAM_PHASE.COMPLETED);
-    expect(machine.tryAcquire(streamId, { events })).toBe(true);
-    machine.releaseIfReserved(streamId, { events });
+    expect(machine.tryAcquire(streamId)).toBe(true);
+    machine.releaseIfReserved(streamId);
 
     expect(machine.get(streamId)).toBe(STREAM_PHASE.COMPLETED);
     expect(
@@ -363,8 +345,8 @@ describe('StreamStatusMachine', () => {
   });
 
   it('emits status trace events when a trace owns publication', () => {
-    const machine = new StreamStatusMachine();
     const events = new SessionEventHub();
+    const machine = new StreamStatusMachine(events);
     const published = recordSessionEvents(events, { scope: 'run' });
     const trace = new TraceEmitter();
     const streamId = 'stream-status-projection-test' as StreamTabId;
@@ -399,6 +381,53 @@ describe('StreamStatusMachine', () => {
         status: STREAM_PHASE.RUNNING,
         cause: 'lifecycle',
       },
+    ]);
+  });
+
+  // One rail: the session fact is published by the machine itself, so a
+  // trace-owned transition (run start, terminal, manual-retry wait, restart
+  // repair) reaches every projector without the caller passing a hub. Before
+  // this became unconditional, those transitions were visible only as
+  // run-scope `status` trace events, which is why each projector carried its
+  // own duplicate trace arm.
+  it('publishes the session fact even when a trace owns publication', () => {
+    const { machine, published, streamId } = setupMachine(
+      'stream-status-single-rail',
+    );
+    const trace = new TraceEmitter();
+
+    seedStreamStatusForTest(machine, streamId, STREAM_PHASE.WAITING);
+
+    expect(
+      machine.transition(streamId, STREAM_PHASE.RUNNING, 'resume', {
+        trace,
+        substate: STREAM_SUBSTATE.RESUMING,
+      }),
+    ).toBe(true);
+
+    const payloads = sessionFactPayloads(
+      published.events,
+      'updateStreamStatus',
+    );
+
+    // Field-for-field identical to the hand-built projection the CLI NDJSON
+    // trace arm used to emit, so public `updateStreamStatus` records keep the
+    // same content on the surviving rail.
+    expect(payloads).toEqual([
+      {
+        streamId,
+        status: STREAM_PHASE.RUNNING,
+        previousStatus: STREAM_PHASE.WAITING,
+        cause: 'resume',
+        substate: STREAM_SUBSTATE.RESUMING,
+      },
+    ]);
+    expect(Object.keys(payloads[0] ?? {}).toSorted()).toEqual([
+      'cause',
+      'previousStatus',
+      'status',
+      'streamId',
+      'substate',
     ]);
   });
 });

--- a/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
+++ b/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
@@ -331,26 +331,6 @@ const resumingStatusPayload: RunStatusProjectionPayload = {
   substate: STREAM_SUBSTATE.RESUMING,
 };
 
-function emitRunStatus(
-  events: SessionEventHub,
-  payload: RunStatusProjectionPayload,
-): void {
-  events.emit({
-    scope: 'run',
-    streamId,
-    event: {
-      type: 'status',
-      streamId: payload.streamId,
-      phase: payload.status,
-      cause: payload.cause,
-      ...(payload.previousStatus
-        ? { previousPhase: payload.previousStatus }
-        : {}),
-      ...(payload.substate ? { substate: payload.substate } : {}),
-    },
-  });
-}
-
 function emitSessionStatus(
   events: SessionEventHub,
   payload: UpdateStreamStatusPayload,
@@ -447,6 +427,26 @@ describe('attachCliSessionProgressProjection', () => {
     const detach = attachCliSessionProgressProjection(events, writeRecord);
 
     try {
+      emitSessionStatus(events, resumingStatusPayload);
+
+      expect(writeRecord).toHaveBeenCalledTimes(1);
+      expect(writeRecord).toHaveBeenCalledWith(
+        progressRecord('updateStreamStatus', resumingStatusPayload),
+      );
+    } finally {
+      detach();
+    }
+  });
+
+  it('ignores run-scope status trace events', () => {
+    const events = new SessionEventHub();
+    const writeRecord = recordWriter();
+    const detach = attachCliSessionProgressProjection(events, writeRecord);
+
+    try {
+      // `status` is no longer a projected run fact: `StreamStatusMachine` owns
+      // the single `updateStreamStatus` rail, so a stray run-scope status event
+      // must never reach the public NDJSON stream.
       events.emit({
         scope: 'run',
         streamId,
@@ -460,39 +460,13 @@ describe('attachCliSessionProgressProjection', () => {
         },
       });
 
-      expect(writeRecord).toHaveBeenCalledWith(
-        progressRecord('updateStreamStatus', {
-          streamId,
-          status: STREAM_PHASE.RUNNING,
-          previousStatus: STREAM_PHASE.WAITING,
-          cause: STREAM_TRANSITION_CAUSE.RESUME,
-          substate: STREAM_SUBSTATE.RESUMING,
-        }),
-      );
+      expect(writeRecord).not.toHaveBeenCalled();
     } finally {
       detach();
     }
   });
 
-  it('emits one NDJSON stream-status record for duplicate run-then-session status facts', () => {
-    const events = new SessionEventHub();
-    const writeRecord = recordWriter();
-    const detach = attachCliSessionProgressProjection(events, writeRecord);
-
-    try {
-      emitRunStatus(events, resumingStatusPayload);
-      emitSessionStatus(events, resumingStatusPayload);
-
-      expect(writeRecord).toHaveBeenCalledTimes(1);
-      expect(writeRecord).toHaveBeenCalledWith(
-        progressRecord('updateStreamStatus', resumingStatusPayload),
-      );
-    } finally {
-      detach();
-    }
-  });
-
-  it('keeps same-phase stream-status records when substate changes', () => {
+  it('writes one record per published status fact without renderer dedup', () => {
     const events = new SessionEventHub();
     const writeRecord = recordWriter();
     const detach = attachCliSessionProgressProjection(events, writeRecord);
@@ -502,7 +476,7 @@ describe('attachCliSessionProgressProjection', () => {
     };
 
     try {
-      emitRunStatus(events, resumingStatusPayload);
+      emitSessionStatus(events, resumingStatusPayload);
       emitSessionStatus(events, startingPayload);
 
       expect(writeRecord).toHaveBeenCalledTimes(2);
@@ -513,38 +487,6 @@ describe('attachCliSessionProgressProjection', () => {
       expect(writeRecord).toHaveBeenNthCalledWith(
         2,
         progressRecord('updateStreamStatus', startingPayload),
-      );
-    } finally {
-      detach();
-    }
-  });
-
-  it('forgets the last status when a stream is removed', () => {
-    const events = new SessionEventHub();
-    const writeRecord = recordWriter();
-    const detach = attachCliSessionProgressProjection(events, writeRecord);
-
-    try {
-      emitSessionStatus(events, resumingStatusPayload);
-      emitSessionStatus(events, resumingStatusPayload);
-      events.emit({
-        scope: 'session',
-        event: { type: 'removeStream', payload: { streamId } },
-      });
-      emitSessionStatus(events, resumingStatusPayload);
-
-      expect(writeRecord).toHaveBeenCalledTimes(3);
-      expect(writeRecord).toHaveBeenNthCalledWith(
-        1,
-        progressRecord('updateStreamStatus', resumingStatusPayload),
-      );
-      expect(writeRecord).toHaveBeenNthCalledWith(
-        2,
-        progressRecord('removeStream', { streamId }),
-      );
-      expect(writeRecord).toHaveBeenNthCalledWith(
-        3,
-        progressRecord('updateStreamStatus', resumingStatusPayload),
       );
     } finally {
       detach();

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -260,15 +260,19 @@ function handleStreamStatus(
   streamId: string,
   status: StreamPhase,
 ): void {
+  // Status reaches the renderer on the session-fact rail only: `StreamStatusMachine`
+  // publishes every transition as `updateStreamStatus`, and the renderer no longer
+  // reads run-scope `status` trace events.
   renderer?.handleSessionEvent({
-    scope: 'run',
-    streamId: streamId as StreamTabId,
+    scope: 'session',
     event: {
-      type: 'status',
-      streamId: streamId as StreamTabId,
-      phase: status,
-      previousPhase: STREAM_PHASE.RUNNING,
-      cause: STREAM_TRANSITION_CAUSE.LIFECYCLE,
+      type: 'updateStreamStatus',
+      payload: {
+        streamId: streamId as StreamTabId,
+        status,
+        previousStatus: STREAM_PHASE.RUNNING,
+        cause: STREAM_TRANSITION_CAUSE.LIFECYCLE,
+      },
     },
   });
 }
@@ -594,17 +598,7 @@ describe('CLI run progress renderer', () => {
         ],
       },
     });
-    renderer?.handleSessionEvent({
-      scope: 'run',
-      streamId,
-      event: {
-        type: 'status',
-        streamId,
-        phase: STREAM_PHASE.COMPLETED,
-        previousPhase: STREAM_PHASE.RUNNING,
-        cause: STREAM_TRANSITION_CAUSE.LIFECYCLE,
-      },
-    });
+    handleStreamStatus(renderer, streamId, STREAM_PHASE.COMPLETED);
 
     expect(output.text).toBe(
       'polish paper.tex · 0s\n' +

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -675,11 +675,15 @@ function emitStatusFact(
     previousStatus?: StreamPhase;
   },
 ): void {
-  emitRunEvent(bridge, payload.streamId, {
-    type: 'status',
+  // Status reaches the bridge on the session-fact rail only: `StreamStatusMachine`
+  // publishes every transition as `updateStreamStatus`, and no projector reads
+  // run-scope `status` trace events any more.
+  emitSessionFact(bridge, 'updateStreamStatus', {
     streamId: payload.streamId,
-    phase: payload.status,
-    previousPhase: payload.previousStatus,
+    status: payload.status,
+    ...(payload.previousStatus
+      ? { previousStatus: payload.previousStatus }
+      : {}),
     cause: STREAM_TRANSITION_CAUSE.LIFECYCLE,
   });
 }
@@ -4180,9 +4184,7 @@ describe('DesktopProgressBridge', () => {
         // A bare process-session transition (no live trace) still reaches the
         // reopened presentation as a session fact.
         expect(
-          owner.processSession.status.transitionToWaiting(streamId, 'wait', {
-            events: owner.processSession.events,
-          }),
+          owner.processSession.status.transitionToWaiting(streamId, 'wait'),
         ).toBe(true);
         expect(bridgeB.session.status.get(streamId)).toBe(STREAM_PHASE.WAITING);
         expect(facts).toContainEqual(
@@ -4239,7 +4241,6 @@ describe('DesktopProgressBridge', () => {
           owner.bridgeA.session.status.transitionToTerminal(
             childStreamId,
             STREAM_PHASE.COMPLETED,
-            { events: owner.processSession.events },
           ),
         ).toBe(true);
         expect(bridgeB.session.status.get(childStreamId)).toBe(

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -2170,8 +2170,9 @@ describe('ProgressBackend', () => {
     // block-bodied handler that discarded the promise would hand
     // `withEventErrorHandling` `undefined`, leaving this untouched — and a
     // post-await rejection would then escape logging as an unhandled rejection.
-    // Both `setStreamStatus` callers (the run-fact `status` path and the
-    // session-fact `updateStreamStatus` path) are covered.
+    // `setStreamStatus` now has exactly one caller — the session-fact
+    // `updateStreamStatus` path — since `StreamStatusMachine` publishes every
+    // transition on that rail and the run-fact `status` arm is gone.
     let adopted = 0;
     const tracking: PromiseLike<void> = {
       then(onFulfilled, onRejected) {
@@ -2184,12 +2185,6 @@ describe('ProgressBackend', () => {
     );
 
     try {
-      backend.factApplier.handleRunFact(stream, {
-        type: 'status',
-        streamId: stream,
-        phase: STREAM_PHASE.RUNNING,
-        cause: STREAM_TRANSITION_CAUSE.LIFECYCLE,
-      });
       backend.factApplier.handleSessionFact({
         type: 'updateStreamStatus',
         payload: { streamId: stream, status: STREAM_PHASE.RUNNING },
@@ -2198,7 +2193,7 @@ describe('ProgressBackend', () => {
       // Thenable adoption runs on a microtask; flush before asserting.
       await new Promise((resolve) => setImmediate(resolve));
 
-      expect(adopted).toBe(2);
+      expect(adopted).toBe(1);
     } finally {
       backend.dispose();
     }

--- a/src/tools/delegation/nativeSubagentStrategy.ts
+++ b/src/tools/delegation/nativeSubagentStrategy.ts
@@ -220,10 +220,7 @@ export function createNativeSubagentStrategy(
           streamId,
           STREAM_PHASE.RUNNING,
           STREAM_TRANSITION_CAUSE.RESUME,
-          {
-            events: params.parentSession.events,
-            substate: STREAM_SUBSTATE.RESUMING,
-          },
+          { substate: STREAM_SUBSTATE.RESUMING },
         );
         return await resumeToolUseFromResumeData(resume, params.runtimeHost, {
           session: params.parentSession,


### PR DESCRIPTION
## Summary

Collapses the status fan-out onto **one rail**: `StreamStatusMachine` now
receives the session hub at construction and publishes every transition as an
`updateStreamStatus` session fact, so all four projectors read status from that
single rail. The three projector trace-`status` arms and the renderer dedup map
are deleted.

Closes #9250

## ⚠️ One issue claim is FALSE at `b5751dbe90` — read before reviewing

The issue says deleting the `!options.trace &&` guard makes the session-fact
emission unconditional. **It does not.** `publishStatus` reads
`options.events`, and **no production call site ever passed `trace` and
`events` together** — `ExecutionRegistry.streamStatusEmitOptions` returns one
or the other, `AgentLaunchContext` used `...(runTrace ? {} : { events })`, and
every other site passed exactly one. So on main:

* Deleting the guard alone is a **no-op** — `options.events` is always
  `undefined` when a trace is present.
* Deleting the projector arms alone **silences status** for every trace-owned
  transition: run start (`AgentRunLifecycle.transitionRunStart`), terminal
  (`finalizeRunTerminal`), manual-retry WAITING/RESUME/CANCEL (`RetryState`),
  restart repair, and `ProgressFactApplier.markAllRunningTasksAsCancelled`.

Verified by running the machine directly: `machine.transition(streamId,
RUNNING, 'lifecycle', { trace })` produced **1 run-scope `status` event and 0
session facts**. A test asserting exactly this shape existed on main and was
even named *"emits status trace events when a trace owns publication"* — the
guard encoded a deliberate "trace owns publication" design, not a vestige.

**The fix that actually works** is single-owner by deletion: the session
constructs the hub and the machine together, so the machine hands the fact to
the hub itself and `StreamStatusEmitOptions.events` disappears. That matches
the existing `new ExecutionRegistry({ streamStatus, events })` wiring three
lines away in the same constructor, and it removes parameter accretion instead
of adding it. Seven call-site `events:` properties are deleted; nothing is
plumbed anywhere.

## Net elements (R6)

| element | before | after |
| --- | --- | --- |
| `!options.trace &&` guard | 1 | 0 |
| `StreamStatusEmitOptions.events` field | 1 | 0 |
| call-site `events:` properties | 7 | 0 |
| projector trace-`status` arms | 3 | 0 |
| `statusProjectionKey` function | 1 | 0 |
| `lastStatusByStream` map + dedup branch | 1 | 0 |
| `'status'` in `RUN_FACT_EVENT_TYPES` | 1 | 0 |
| dead `session` params in `AgentLaunchContext` | 2 | 0 |
| `StreamStatusMachine` constructor | 0 | 1 |
| `SessionHandleInit.status` injection seam | 1 | 0 |

Production diff: **+41 / −104** (net **−63** production LoC). Tests:
**+134 / −176** (net **−42**). Whole branch: 19 files, +175 / −280, net
**−105**. (The review commit deleting the `SessionHandleInit.status` seam
adds a 6-line invariant comment; the pre-review production figure was −69.)

## Consumer counts (R8)

Re-routed rail: run-scope trace `'status'` → session fact `updateStreamStatus`. Enumerated on `origin/main` (`b5751dbe90`):

| rail | apply-sites before | after |
| --- | --- | --- |
| trace `status` | **4** — `src/transcript/TexraTranscriptRecorder.ts:389`, `packages/cli/src/runtime/sessionProgressSubscription.ts:76`, `packages/cli/src/runtime/runProgressRenderer.ts:197`, `src/controllers/progressView/backend/events/ProgressFactApplier.ts:124` | **1** — `TexraTranscriptRecorder.ts:389` only |
| session fact `updateStreamStatus` | **4** | **4** (unchanged — the surviving rail) |
| `StreamStatusMachine.onDidChange` | **5** | **5** (unchanged, in-process consumers) |

The three deleted trace arms each have a session-fact counterpart carrying the identical payload (`projectStatusEvent` produces the same field set the hand-built CLI projection did), so no consumer loses status. `'status'` is removed from `RUN_FACT_EVENT_TYPES` with an in-file comment explaining why it must not return; the `assertNever` exhaustiveness arm at `subscribeRuntimeHost.ts:377` is untouched.

The follow-up commit on this branch deletes `SessionHandleInit.status` — **1** consumer, a test that injected a hub-less machine and then seeded through `session.status` anyway (redundant). Removing the seam makes "the machine and the hub are co-constructed" a type-level guarantee rather than a convention, closing the injection gap raised in review.

## Apply-site count: 13 → 10

| rail | before | after |
| --- | --- | --- |
| trace `status` | 4 | **1** — `TexraTranscriptRecorder.ts:389` only |
| session fact `updateStreamStatus` | 4 | 4 — `ProgressFactApplier.ts:248`, `sessionProgressSubscription.ts:47`, `runProgressRenderer.ts:162`, `subscribeRuntimeHost.ts:371` |
| `onDidChange` | 5 | 5 — `executionRegistry.ts:150`, `statusBarSessionEvents.ts:24`, `desktopWindowTitle.ts:76`, `runChatTui.tsx:891`, `subscribeStreamStatus.ts:15` |
| **total** | **13** | **10** |

**≤5 is unreachable by deletion; 10 is the floor.** What remains is one
persistence consumer, four host projectors that each apply status to a
different UI model, and five in-process `onDidChange` listeners — one of them
inside the runtime itself. None is a duplicate of another. The north-star's
aspirational ≤5 target should be restated as **10**.

## NDJSON parity evidence

`projectStatusEvent`'s output is field-for-field identical to the hand-built
projection deleted from `sessionProgressSubscription.ts:76-87`:

| | field set |
| --- | --- |
| deleted hand-built projection | `streamId`, `status`, `cause`, `previousStatus?`, `substate?` |
| `projectStatusEvent` (surviving) | `streamId`, `status`, `previousStatus?`, `cause`, `substate?` |

Pinned by a new test in `StreamStatusService.vitest.ts` that asserts both the
values and the exact key set:

```
expect(Object.keys(payloads[0] ?? {}).toSorted()).toEqual([
  'cause', 'previousStatus', 'status', 'streamId', 'substate',
]);
```

**Record count per transition is 1**, both before and after — the dedup map was
never reachable in production, because the two rails were mutually exclusive
*and* `StreamStatusMachine.transition` already drops a same-phase/same-substate
repeat before it reaches `publishStatus`. `CliSessionProgressSubscription`
covers this directly: one record per published fact, and a stray run-scope
`status` event now writes nothing.

One honest caveat: the two projections emitted keys in **different order**
(`previousStatus` before vs. after `cause`), and NDJSON is
`JSON.stringify(record)`. Because trace-owned and hub-owned transitions both
occur inside a single run today, main already emits **both** key orders in one
NDJSON stream. After this change every status record uses one stable order.
Content is unchanged; byte order becomes *more* consistent, not less.

## `TexraTranscriptRecorder` is untouched

`src/transcript/TexraTranscriptRecorder.ts` **does not appear in this diff**
(`git diff --name-only` confirms). Its trace `status` arm remains the
load-bearing persistence consumer #9127 made it — closing the transcript
boundary and settling open tool rows on WAITING/terminal — per ruling
`9fd44cd689` (#9209), which explicitly withdrew "delete the trace arm".
`subscribeRuntimeHost.ts:371`'s `assertNever` exhaustiveness arm is untouched
for the same reason (silent-degradation rule).

`'status'` is removed from `RUN_FACT_EVENT_TYPES` because no projector reads it
any more; the recorder is unaffected because it subscribes to the run trace
directly (`trace.subscribe`), not through the hub. A comment on the constant
records why it must not come back.

## Acceptance criteria

```
$ ! grep -q '!options.trace' src/agent/runtime/StreamStatusService.ts     # PASS

$ grep -rn "case 'status'\|event.type === 'status'" src packages \
    --include='*.ts' --include='*.tsx' --include='*.mts' \
    | grep -v test-kernel | grep -v 'packages/cli/scripts/' \
    | grep -v "handleSlashCommand"
src/transcript/TexraTranscriptRecorder.ts:389:        case 'status': {   # exactly 1, and it is the recorder

$ ! grep -qE "statusProjectionKey|lastStatusByStream" \
    packages/cli/src/runtime/sessionProgressSubscription.ts             # PASS
```

## Verification

| command | result |
| --- | --- |
| `npm run typecheck` | pass (all 6 projects) |
| `npm run lint` | pass |
| `npx vitest run src/test-kernel/architecture/` | pass |
| `npx vitest run src/test-kernel/agent/runtime/ src/test-kernel/cli/ src/test-kernel/progressView/ src/test-kernel/desktop/` | pass |
| `npm test` (full) | 7644 passed; 3 pre-existing failures |
| `npm run check:dead-code-ratchet` | `18 current vs 18 baselined` — **no baseline bump** |

The 3 remaining failures (`ToolUseRowPatch` styled-tail, `SubagentListDisplay`
×2) are ANSI-colour/width assertions that **fail identically on clean
`origin/main`** — verified by re-running both files at `b5751dbe90`. Unrelated
to status.

## Tests updated deliberately

Every test below pinned the *dual-rail* behaviour this PR removes; each was
moved to the surviving rail rather than weakened.

* `CliSessionProgressSubscription` — deleted `emitRunStatus`; *"emits one
  NDJSON record for duplicate run-then-session status facts"* is gone (it
  asserted the dedup map). Replaced with *"ignores run-scope status trace
  events"* (a stray run event must write nothing) and *"writes one record per
  published status fact without renderer dedup"*. *"forgets the last status
  when a stream is removed"* is deleted outright — it tested only the removed
  cache's eviction.
* `RunProgressRenderer` / `DesktopAgentExecution` — the `handleStreamStatus` /
  `emitStatusFact` helpers now emit the session fact. Same assertions, same
  expected output.
* `ProgressBackend` — *"propagates async fact-handler promises"* covered both
  `setStreamStatus` callers; there is now one, so it dispatches once and
  expects `adopted === 1`.
* `StreamStatusService` / `ExecutionRegistry` — machines constructed with the
  hub; `{ events }` arguments dropped. **New**: *"publishes the session fact
  even when a trace owns publication"* — the regression guard for the bug the
  issue's literal plan would have shipped.

## Atomicity

One commit. There is no safe intermediate state: the guard/ownership change and
the three arm deletions must land together or status is either double-applied
or silenced. This is the #7398 failure shape from fewer-elements §6.

No persisted format changes.

https://claude.ai/code/session_01XZ8Z6rhypTfkVq728XCcCd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core session/status fan-out used by CLI, extension, and progress UI; wrong wiring could drop or duplicate status, though tests explicitly guard trace-owned transitions still publishing session facts.
> 
> **Overview**
> **Collapses stream status onto one rail:** `StreamStatusMachine` is constructed with the session `SessionEventHub` and always emits `updateStreamStatus` session facts on transition (including when a trace also emits run-scope `status`). Callers no longer pass `{ events: session.events }`; `StreamStatusEmitOptions.events` is removed.
> 
> **Session wiring:** `SessionHandle` always co-builds hub + status machine (injection of a separate `status` is disallowed) so status cannot be bound to a different hub than `events`. `ExecutionRegistry` passes `new StreamStatusMachine(events)` when defaults apply.
> 
> **Projectors:** CLI NDJSON projection, `RunProgressRenderer`, and progress-view `ProgressFactApplier` stop consuming run-fact `status`; they read `updateStreamStatus` only. `'status'` is removed from `RUN_FACT_EVENT_TYPES`. NDJSON dedup (`statusProjectionKey` / `lastStatusByStream`) is deleted.
> 
> **Call sites:** Launch, resume, follow-up, delegation, harness, and tests drop redundant `events` options; compensation paths pass trace-only emit options where needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 917f7c7e9f5bd2fee7d33942ccefbe939db84b1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
