### PR TITLE
docs: correct wrong status-rail prescription in agent-sdk-foundation-gap

### DIFF
--- a/docs/proposals/2026-07-26-agent-sdk-foundation-gap.md
+++ b/docs/proposals/2026-07-26-agent-sdk-foundation-gap.md
@@ -158,7 +158,8 @@ The same fact→view switch exists **four times** (219 LoC of switch, inside 2,0
 over the same 13 `RUN_FACT_EVENT_TYPES` and 10 `SessionFact` arms) — **three of the four
 inside the CLI**. One
 status write site fans to three rails with **13 production apply-sites**, forcing 30 LoC of
-dedup in a renderer. _(Corrected 2026-07-26: the two status rails were mutually exclusive in
+dedup in a renderer. _(Corrected 2026-07-26: the two **projectable** status rails — trace and
+session-fact; `onDidChange` is the third and fires unconditionally — were mutually exclusive in
 production, so this dedup map was never reachable — dead code, not an active CLAUDE.md
 violation; see the acceptance-criteria row 5 correction in §7.)_
 
@@ -356,12 +357,14 @@ consumers, one of them inside the runtime itself. **Restate the acceptance targe
 > used `...(runTrace ? {} : { events })`). So dropping the `!options.trace &&` guard alone is a
 > no-op, and deleting the three projector trace-arms alone **silences status entirely** for every
 > trace-owned transition — run start, terminal, manual-retry WAITING/RESUME/CANCEL, restart
-> repair. The rails being mutually exclusive also means the renderer dedup map §3.3 calls a
+> repair. The rails being mutually exclusive also means the renderer dedup map that §3.3 calls a
 > CLAUDE.md violation was **unreachable dead code**, not an active violation.
 >
 > The route that actually reaches 13 → 10: `StreamStatusMachine` receives the session hub at
-> construction — mirroring `new ExecutionRegistry({ streamStatus, events })` three lines away in
-> the same `SessionHandle` constructor — and publishes the fact itself.
+> construction — mirroring `new ExecutionRegistry({ streamStatus, events })` a few statements
+> later in the same `SessionHandle` constructor — and publishes the fact itself. The
+> independent `SessionHandleInit.status` injection seam goes away with it, so the machine and
+> the hub can no longer be bound to different owners.
 > `StreamStatusEmitOptions.events` and its 7 call-site properties are deleted, along with
 > `'status'` from `RUN_FACT_EVENT_TYPES`. Apply-sites land at 13 → 10 as targeted (trace 4→1,
 > fact 4→4, `onDidChange` 5→5), for **−69** production LoC, with `TexraTranscriptRecorder`
@@ -475,7 +478,8 @@ reaches it. Disjoint consumers; **one rail fixes both.**
 Orthogonal, each needing its own ruling: the reveal-stream fold (7) and the status rail
 13 → 10 (8, atomic). **No persisted format changes in any step.**
 
-> **Corrected 2026-07-26** — step 8 as described above is not atomic-safe: dropping the
+> **Corrected 2026-07-26** — step 8 as prescribed in the §7 acceptance-criteria row-5 note is
+> not atomic-safe: dropping the
 > `!options.trace &&` guard alone is a no-op and deleting the three projector trace-arms alone
 > silences status for every trace-owned transition (run start, terminal, manual-retry
 > WAITING/RESUME/CANCEL, restart repair) — the two do not compose into "one rail." See the

--- a/docs/proposals/2026-07-26-agent-sdk-foundation-gap.md
+++ b/docs/proposals/2026-07-26-agent-sdk-foundation-gap.md
@@ -158,7 +158,9 @@ The same fact→view switch exists **four times** (219 LoC of switch, inside 2,0
 over the same 13 `RUN_FACT_EVENT_TYPES` and 10 `SessionFact` arms) — **three of the four
 inside the CLI**. One
 status write site fans to three rails with **13 production apply-sites**, forcing 30 LoC of
-dedup in a renderer (banned by CLAUDE.md's UI anti-patterns rule).
+dedup in a renderer. _(Corrected 2026-07-26: the two status rails were mutually exclusive in
+production, so this dedup map was never reachable — dead code, not an active CLAUDE.md
+violation; see the acceptance-criteria row 5 correction in §7.)_
 
 ## 4. Intermediate layers, measured — and mostly exonerated
 
@@ -346,6 +348,25 @@ arm in #9127 (it closes the transcript boundary and settles open tool rows on WA
 silent-degradation rule; and the five `onDidChange` listeners are all legitimate in-process
 consumers, one of them inside the runtime itself. **Restate the acceptance target as 10.**
 
+> **Corrected 2026-07-26 — "deleting the three projector trace-arms" is not the mechanism that
+> gets there; see [#9250 comment](https://github.com/LionSR/TeXRA/issues/9250#issuecomment-5084548544)
+> and #9263.** `publishStatus` gates the session-fact emit on `options.events`, and no production
+> call site has ever passed `trace` and `events` together
+> (`ExecutionRegistry.streamStatusEmitOptions` returns one or the other; `AgentLaunchContext`
+> used `...(runTrace ? {} : { events })`). So dropping the `!options.trace &&` guard alone is a
+> no-op, and deleting the three projector trace-arms alone **silences status entirely** for every
+> trace-owned transition — run start, terminal, manual-retry WAITING/RESUME/CANCEL, restart
+> repair. The rails being mutually exclusive also means the renderer dedup map §3.3 calls a
+> CLAUDE.md violation was **unreachable dead code**, not an active violation.
+>
+> The route that actually reaches 13 → 10: `StreamStatusMachine` receives the session hub at
+> construction — mirroring `new ExecutionRegistry({ streamStatus, events })` three lines away in
+> the same `SessionHandle` constructor — and publishes the fact itself.
+> `StreamStatusEmitOptions.events` and its 7 call-site properties are deleted, along with
+> `'status'` from `RUN_FACT_EVENT_TYPES`. Apply-sites land at 13 → 10 as targeted (trace 4→1,
+> fact 4→4, `onDidChange` 5→5), for **−69** production LoC, with `TexraTranscriptRecorder`
+> untouched.
+
 **One-line test for the goal:** a reader opens `desktopAgentLaunch.ts` (44 LoC, 0 detaches)
 and `executeCommand.ts` (45 LoC, 0 detaches), learns everything needed to write a frontend,
 and opening `runExecution.ts` teaches nothing extra — because nothing extra is left in it.
@@ -453,6 +474,14 @@ reaches it. Disjoint consumers; **one rail fixes both.**
 
 Orthogonal, each needing its own ruling: the reveal-stream fold (7) and the status rail
 13 → 10 (8, atomic). **No persisted format changes in any step.**
+
+> **Corrected 2026-07-26** — step 8 as described above is not atomic-safe: dropping the
+> `!options.trace &&` guard alone is a no-op and deleting the three projector trace-arms alone
+> silences status for every trace-owned transition (run start, terminal, manual-retry
+> WAITING/RESUME/CANCEL, restart repair) — the two do not compose into "one rail." See the
+> corrected acceptance-criteria row 5 note (§7) and
+> [#9250 comment](https://github.com/LionSR/TeXRA/issues/9250#issuecomment-5084548544) / #9263
+> for the mechanism that actually ships 13 → 10.
 
 ### Correction to a premise this doc previously carried
 


### PR DESCRIPTION
## Summary

`docs/proposals/2026-07-26-agent-sdk-foundation-gap.md` prescribed a status-rail
change that does not work and would ship a silent regression if followed
literally:

> Deleting the three _projector_ trace-arms per the `9fd44cd689` (#9209) ruling
> takes 13 → **10**

(§7.1's migration list makes the same claim tersely as step 8: "the status rail
13 → 10 (8, atomic)".)

## Why it fails

`publishStatus` gates the session-fact emit on `options.events`, and **no
production call site has ever passed `trace` and `events` together**
(`ExecutionRegistry.streamStatusEmitOptions` returns one or the other;
`AgentLaunchContext` used `...(runTrace ? {} : { events })`). So:

- Dropping the `!options.trace &&` guard alone is a **no-op**.
- Deleting the three projector trace-arms alone **silences status entirely**
  for every trace-owned transition — run start, terminal, manual-retry
  WAITING/RESUME/CANCEL, restart repair.

The doc also mischaracterized the renderer dedup map as an active CLAUDE.md
violation (§3.3); the rails being mutually exclusive means that map was in
fact **unreachable dead code**, never an active violation.

## What this PR does

Docs-only, in-place corrections with visible `> **Corrected 2026-07-26**`
blockquote markers, matching the doc's existing §4 correction style:

- **§3.3** (line ~161) — inline correction of the CLAUDE.md-violation
  mischaracterization.
- **§7, acceptance-criteria row 5 note** (after line ~349) — full correction:
  what's wrong, and the mechanism that actually works.
- **§7.1, migration list step 8** (after line ~476) — short pointer correction
  back to the §7 note.

Describes the real fix, landed in **#9263**: `StreamStatusMachine` receives
the session hub at construction — mirroring `new ExecutionRegistry({
streamStatus, events })` three lines away in the same `SessionHandle`
constructor — and publishes the fact itself. `StreamStatusEmitOptions.events`
and its 7 call-site properties are deleted, along with `'status'` from
`RUN_FACT_EVENT_TYPES`. Apply-sites land at 13 → 10 as targeted (trace 4→1,
fact 4→4, `onDidChange` 5→5), for −69 production LoC, with
`TexraTranscriptRecorder` untouched.

Full finding: https://github.com/LionSR/TeXRA/issues/9250#issuecomment-5084548544
Real fix: #9263

No section renumbering, no restructuring, no `src/`/`packages/` changes.

## Test plan

- [x] `npx prettier --write docs/proposals/2026-07-26-agent-sdk-foundation-gap.md` — no changes needed
- [x] `npx prettier --check docs/proposals/2026-07-26-agent-sdk-foundation-gap.md` — pass
- [x] `node docs/scripts/check-root-docs.mjs` — pass
- [x] `node scripts/check-guidance-refs.mjs` — pass

https://claude.ai/code/session_01XZ8Z6rhypTfkVq728XCcCd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proposal documentation only; no runtime, package, or behavioral changes.
> 
> **Overview**
> **Docs-only fix** to `docs/proposals/2026-07-26-agent-sdk-foundation-gap.md` so the proposal no longer tells implementers to follow a status-rail path that would **silence trace-owned status** (run start, terminal, manual-retry, restart repair).
> 
> The doc had claimed deleting three projector trace-arms (per #9209) would take **13 → 10** apply-sites and treated renderer dedup as an active CLAUDE.md violation. New **`> **Corrected 2026-07-26**`** blockquotes (matching §4) fix that in **§3.3**, the **§7 row-5 acceptance note**, and **§7.1 migration step 8**: `publishStatus` only emits session facts when `options.events` is set, and production never passes `trace` and `events` together (`ExecutionRegistry.streamStatusEmitOptions` returns one or the other), so dropping the `!options.trace &&` guard alone is a no-op and removing trace-arms alone breaks status; the mutually exclusive rails mean the dedup map was **unreachable dead code**.
> 
> The corrected write-up points to the real mechanism (**#9263**): `StreamStatusMachine` gets the session hub at construction and publishes facts itself, removing `StreamStatusEmitOptions.events`, `'status'` from `RUN_FACT_EVENT_TYPES`, and the independent status injection seam—still landing at **13 → 10** apply-sites without touching `TexraTranscriptRecorder`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66ec0e2dabbfa3f1ab2ecca63d8c9995be302788. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->