### PR TITLE
fix(schemas): give commonViewMessages a working barrel path

### DIFF
--- a/src/shared/schemas/index.ts
+++ b/src/shared/schemas/index.ts
@@ -44,7 +44,7 @@ export * from './mainView';
 export * from './progressView';
 
 // Layer 6: Other view message schemas
-export * as commonViewMessages from './commonViewMessages';
+export * from './commonViewMessages';
 // Memory/History/Profile view-message schemas have a single public home in
 // settingsViewMessages (the canonical settings entry point), which re-exports
 // the symbols consumers need. They are not re-exported directly here, so each


### PR DESCRIPTION
## What

`src/shared/schemas/index.ts` published `commonViewMessages` as a namespace
object:

```ts
export * as commonViewMessages from './commonViewMessages';
```

Replaced with a flat re-export, matching every other family in the file:

```ts
export * from './commonViewMessages';
```

## Why (per #9257 maintainer ruling)

The maintainer ruled `@shared/schemas` a published surface, then ruled on
this specific defect in the issue comments: the namespace form publishes an
object nobody imports, so this family had **no working barrel path at all**
— all its consumers were forced deep. That also makes the comment at
`index.ts:49-52` ("each family is published through exactly one barrel
path") false for this family. Under a published-surface ruling this is a
defect, not a preference.

## Zero-consumer evidence

```
$ grep -rn "commonViewMessages\." src packages
src/shared/schemas/progressView/outbound.ts:359:// ... comment only, not code
```

No code anywhere imports the namespace object via `commonViewMessages.X`.
Meanwhile 9 production sites deep-import `@shared/schemas/commonViewMessages`
directly (`BaseWebviewApp.ts`, `packages/extension/.../persistence.ts`,
`.../MainApp.ts`, `.../TexraDiffView.ts`, `packages/desktop/.../main.ts`,
`.../diffOverlay.ts`, `.../desktopViewStateIpc.ts`,
`.../desktopShellIpc.ts`, `src/shared/wa/hostTheme.ts`), plus a test-kernel
consumer.

## Collision check (verified, not assumed)

`commonViewMessages.ts` exports exactly 10 symbols: `ThemeSchema`, `Theme`,
`DESKTOP_THEME_KIND`, `DesktopThemeKind`, `SetThemeMessageSchema`,
`WebviewReadyMessageSchema`, `SwitchViewTarget`, `SwitchViewMessageSchema`,
`CommonViewMessageSchema`, `StateRestoreMessage`.

Grepped `src/shared/schemas/**` for each name as an `export const|type|...`
declaration outside `commonViewMessages.ts` — zero hits. The only other
files that reference these names (`settingsView/inbound.ts`,
`mainView/inbound.ts`, `progressView/outbound.ts`,
`progressView/inbound.ts`) `import` them from `../commonViewMessages` for
internal use inside discriminated unions — they don't re-export them, so
there's no shadow through the `mainView`/`progressView`/`settingsViewMessages`
barrels either.

**Symbol delta: +10 symbols on the barrel, 0 collisions.**

## Explicitly out of scope (per issue ruling)

- Not migrating the ~9 deep importers to the new barrel path — opportunistic
  follow-up, not a churn PR here.
- Not touching the four other zero-consumer `export *` lines
  (`agentRoster`, `agentCliSettings`, `fileFields`, `spendingStatus`) — ruled
  to stay published since their symbols are deep-imported by `packages/*`.
- Not converting any `export *` to a named list (priced at +359 LoC,
  rejected).

## Ratchet baseline

#9260 (the `@shared/schemas` deep-import ratchet) is still **open, not
merged**, as of this PR — confirmed via `gh pr view 9260`. So there is no
forced/gratuitous baseline file on `main` yet for this change to move
`commonViewMessages` between buckets, and no baseline regeneration was
needed here. If #9260 lands first, that ratchet will need to be
regenerated with its own tooling as the maintainer's ruling describes.

## Verification

- `npm run typecheck` — clean across all workspace packages (core + cli +
  extension + desktop + trace-viewer).
- `npm run lint` — clean.
- `npx vitest run src/test-kernel/architecture/` — 9 files / 58 tests
  passed.
- `npm run check:dead-code-ratchet` — 18 current vs 18 baselined, no new
  findings. Adding the 10 symbols did not surface new unused-export
  findings (they're already consumed via the existing deep imports).

Closes #9257

Claude-Session: https://claude.ai/code/session_01XZ8Z6rhypTfkVq728XCcCd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line barrel export change with verified no symbol collisions; runtime behavior unchanged since consumers still use existing deep import paths.
> 
> **Overview**
> **Fixes the `@shared/schemas` barrel for `commonViewMessages`.** The index previously used `export * as commonViewMessages`, which only exposed a namespace object and left no working top-level barrel path for that family’s symbols—unlike the other view-message barrels in the same file.
> 
> The change switches to `export * from './commonViewMessages'`, publishing the family’s ~10 symbols (`Theme`, `CommonViewMessageSchema`, `StateRestoreMessage`, etc.) directly on `@shared/schemas`. **No importer migrations** in this PR; existing deep imports to `@shared/schemas/commonViewMessages` stay as-is.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21f39547186a1561f2f494b1a104df17b7c63722. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->