### PR TITLE
refactor(agent): declare runScope on AgentCore

### DIFF
--- a/src/agent/core/flows/BaseFlowServices.ts
+++ b/src/agent/core/flows/BaseFlowServices.ts
@@ -9,6 +9,7 @@ import type {
 } from '@agent/core/definition/AgentDataclass';
 import type { UserVariableChannels } from '@agent/core/definition/AgentCycleOptions';
 import type { AgentRunStateSnapshot } from '@agent/core/state/AgentState';
+import type { RunScope } from '@agent/runtime/RunScope';
 
 /** Callback invoked when a round/cycle completes for usage tracking. */
 export type RoundFinalizedCallback = (
@@ -16,6 +17,8 @@ export type RoundFinalizedCallback = (
 ) => void | Promise<void>;
 
 export interface AgentCore<C = unknown> {
+  /** Run identity and owning session; the same frozen object the ambient `RunContext` carries. */
+  readonly runScope: RunScope;
   modelHandler: IModelHandler<ProviderMessage, unknown, SdkToolCall, C>;
   config: AgentConfig;
   setting: AgentSetting;

--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -6,7 +6,6 @@ import { logContextStateSnapshot } from '@agent/trace';
 import { isRemoteAgent } from '@agent/index/agentRegistry';
 import type { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import type { AgentCore } from '@agent/core/flows/BaseFlowServices';
-import { useLaunchRunContext } from '@agent/runtime/RunContext';
 import {
   ProviderMessageArraySchema,
   type ProviderMessage,
@@ -103,11 +102,10 @@ export type CycleDebugFileOptions = {
 export async function saveCycleDebug(
   object: unknown,
   objectType: 'messages' | 'response',
-  services: Pick<AgentCore, 'logger' | 'config'>,
+  services: Pick<AgentCore, 'logger' | 'config' | 'runScope'>,
   fileOptions: CycleDebugFileOptions,
 ): Promise<void> {
-  const { runScope } = useLaunchRunContext();
-  const { executionId } = runScope;
+  const { executionId } = services.runScope;
   await maybeSaveDebugObject({
     object,
     objectType,
@@ -122,10 +120,9 @@ export async function saveCycleDebug(
 }
 
 export function defaultPostCompactionContext(
-  services: Pick<WorkspaceScopedCore, 'workspace'>,
+  services: Pick<WorkspaceScopedCore, 'workspace' | 'runScope'>,
 ): string | null {
-  const { runScope } = useLaunchRunContext();
-  const { session, streamId } = runScope;
+  const { session, streamId } = services.runScope;
   return formatPostCompactionContext(
     session.executions.getActiveChildren(streamId),
     services.workspace.workPlan.toSnapshot(),

--- a/src/agent/core/flows/ModelInvocationNode.ts
+++ b/src/agent/core/flows/ModelInvocationNode.ts
@@ -15,7 +15,6 @@ import type {
   ModelCredentialRoute,
   ModelCredentialSelection,
 } from '@agent/types/ModelHandlerContracts';
-import { useLaunchRunContext } from '@agent/runtime/RunContext';
 import {
   classifyModelRateLimitFailure,
   classifyRelayRequestLimitFailure,
@@ -66,15 +65,16 @@ export interface ModelInvocationConfig<TShared, TServices> {
 /**
  * Only the services this node and its `RetryableInvocationNode` base class
  * actually read: the model handler, logger, setting (temperature/tools),
- * config (for `saveCycleDebug`'s log context), the retry machinery's abort
- * controller setter, plus the live model client. Picking
+ * config (for `saveCycleDebug`'s log context), the run scope (retry gate and
+ * debug-log identity), the retry machinery's abort controller setter, plus the
+ * live model client. Picking
  * from `AgentCore`/`BaseFlowContextInit` instead of requiring the literal
  * type keeps every existing caller, which passes the full services bag,
  * satisfying this narrower shape structurally.
  */
 type InvocationServices = Pick<
   AgentCore,
-  'modelHandler' | 'logger' | 'setting' | 'config'
+  'modelHandler' | 'logger' | 'setting' | 'config' | 'runScope'
 > &
   Pick<BaseFlowContextInit, 'setAbortController'> & {
     readonly client: unknown;
@@ -132,7 +132,7 @@ export class ModelInvocationNode<
       const modelRetryRoute = services.modelHandler.getModelRetryRouteKey(
         services.client,
       );
-      const gate = useLaunchRunContext().runScope.session.modelRetries;
+      const gate = services.runScope.session.modelRetries;
       const usesRelay = services.clientCredentialRoute === 'relay';
       const invoke = async () => {
         const start = Date.now();

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -3,7 +3,7 @@
 import { Node } from '@agent/node';
 import { logErrorData, logProgressStatus, type AgentTrace } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
-import { useLaunchRunContext } from '@agent/runtime/RunContext';
+import type { RunScope } from '@agent/runtime/RunScope';
 import type {
   ModelCredentialRoute,
   ModelCredentialSelection,
@@ -60,6 +60,7 @@ export type InvocationResult<TSuccess> =
 interface RetryableNodeServices {
   config: Pick<AgentConfig, 'model'>;
   logger: AgentTrace;
+  readonly runScope: RunScope;
   setAbortController: (ac: AbortController | null) => void;
   refreshClient?: (
     selection?: ModelCredentialSelection,
@@ -327,8 +328,7 @@ export abstract class RetryableInvocationNode<
   protected async handleManualRetryPrompt(
     error: Error,
   ): Promise<ManualRetryPromptResult> {
-    const { logger } = this.services;
-    const { runScope } = useLaunchRunContext();
+    const { logger, runScope } = this.services;
     const { session, streamId } = runScope;
     const streamStatus = session.status;
     const operationName = this.getOperationName();

--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -1,5 +1,4 @@
 import { Node } from '@agent/node';
-import { useLaunchRunContext } from '@agent/runtime/RunContext';
 import { emitRunFact } from '@agent/runtime/runFactEvents';
 import type { RoundFileMapping } from '@agent/output/types';
 import type { CompiledPdfArtifact } from '@agent/output/compiledPdfArtifacts';
@@ -60,9 +59,9 @@ export class OutputNode<C = unknown> extends Node<
   ReflectionServices<C>
 > {
   private outputDependencies(): OutputDependencies {
-    const { runScope } = useLaunchRunContext();
+    const { baseFiles, config, fileService, logger, setting, runScope } =
+      this.services;
     const { runtimeHost, streamId } = runScope;
-    const { baseFiles, config, fileService, logger, setting } = this.services;
 
     return {
       baseFiles,

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -10,7 +10,6 @@ import {
 import { XmlOutputManager } from '@agent/output/XmlOutputManager';
 import { LatexDiffManager } from '@agent/output/LatexDiffManager';
 import type { BaseFlowContextInit } from '@agent/core/flows/BaseFlowServices';
-import { useLaunchRunContext } from '@agent/runtime/RunContext';
 import { activeModelHandlerCompatibilityKey } from '@agent/runtime/ModelFactory';
 import { inferAndLogPersistedModelHandlerCompatibilityKey } from '@agent/runtime/modelHandlerCompatibilityInference';
 import { getOutputFileName } from '@agent/utils/outputFileUtils';
@@ -101,8 +100,8 @@ export async function runReflectionFlow<C = unknown>(
     userVarChannels,
     checkInterruption,
     onRoundFinalized,
+    runScope,
   } = input;
-  const { runScope } = useLaunchRunContext();
   const { runtimeHost, streamId, executionId, session: runSession } = runScope;
   // Capture the run's scope at setup; the interrupt closure below fires from
   // the host thread outside the ALS.

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -2,7 +2,6 @@ import PQueue from 'p-queue';
 
 import { Node } from '@agent/node';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
-import { useLaunchRunContext } from '@agent/runtime/RunContext';
 import { emitRunFact } from '@agent/runtime/runFactEvents';
 import { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
 import {
@@ -63,8 +62,7 @@ export class ToolUseCycleNode<C> extends Node<
   }
 
   async exec(prepRes: CyclePrepResult): Promise<ToolUseCycleOutcome> {
-    const { modelHandler } = this.services;
-    const { runScope } = useLaunchRunContext();
+    const { modelHandler, runScope } = this.services;
     const { streamId } = runScope;
 
     if (prepRes.shouldSkipCycle) {

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -172,8 +172,7 @@ export class ToolUseWaitNode<C> extends Node<
     prepRes: WaitPrepResult,
     execRes: WaitExecResult,
   ): Promise<string | undefined> {
-    const { onFollowUpConsumed, logger } = this.services;
-    const { runScope } = useLaunchRunContext();
+    const { onFollowUpConsumed, logger, runScope } = this.services;
     const { streamId, session } = runScope;
 
     if (execRes.kind === 'waiting') {

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -55,7 +55,7 @@ import {
   withRunContext,
   type CreateLaunchRunContextOptions,
 } from './RunContext';
-import { createRunScope, type RunScope } from './RunScope';
+import { createRunScope } from './RunScope';
 import {
   countMediaFilesNeedingVision,
   formatMediaNeedsVisionWarning,
@@ -70,7 +70,6 @@ import type { AgentRuntimeHost } from './AgentRuntimeHost';
 const logger = createChannelTrace('AgentLaunchContext');
 
 export interface AgentLaunchContext extends AgentCore {
-  readonly runScope: RunScope;
   usageMonitor: UsageMonitor;
   storageKey: StorageKey;
   parentStage: StageHandle;

--- a/src/agent/runtime/RunContext.ts
+++ b/src/agent/runtime/RunContext.ts
@@ -235,8 +235,11 @@ export function getRunContextSession(
  * Flow nodes only ever execute inside `withExecutionRunContext` (in
  * `AgentLaunchContext.ts`), which always projects a `launch` context — the
  * `bare` variant of `createRunContext` is exclusively for manually
- * constructed test/one-shot tool contexts. Use this instead of re-deriving
- * these fields on the flow-service bag.
+ * constructed test/one-shot tool contexts.
+ *
+ * Code holding a flow-service bag reads `services.runScope` directly (the same
+ * frozen object, declared on `AgentCore`); this accessor is the fallback for
+ * code that holds no bag, chiefly the `src/tools/` layer.
  */
 export function useLaunchRunContext(): LaunchRunContext {
   const context = useRunContext();

--- a/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
+++ b/src/test-kernel/agent/ReflectionFlowStateRecovery.vitest.ts
@@ -74,22 +74,24 @@ async function runPersistedReflectionFlow(
   streamId: StreamTabId,
 ): Promise<Awaited<ReturnType<typeof runReflectionFlow>>> {
   const session = createTestSession();
+  const runScope = createRunScope({
+    runtimeHost: noopAgentRuntimeHost,
+    streamId,
+    executionId,
+    agentName: CONFIG.agent,
+    session,
+  });
   const context = createRunContext({
     modelSource: 'live',
     getModel: () => CONFIG.model,
-    runScope: createRunScope({
-      runtimeHost: noopAgentRuntimeHost,
-      streamId,
-      executionId,
-      agentName: CONFIG.agent,
-      session,
-    }),
+    runScope,
   });
 
   try {
     return await withRunContext(context, () =>
       runReflectionFlow({
         config: CONFIG,
+        runScope,
         setting: SETTING,
         prompt: PROMPT,
         logger: noopTrace,

--- a/src/test-kernel/agent/ResponseCycleTools.vitest.mts
+++ b/src/test-kernel/agent/ResponseCycleTools.vitest.mts
@@ -5,7 +5,7 @@ import { responseCycleToolsForModel } from '@agent/core/flows/ResponseCycleFlow'
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
 import { createRunScope } from '@agent/runtime/RunScope';
 import { getDefaultToolRegistry } from '@tools/registry';
-import { withTestRunContext } from './progressTestUtils';
+import { testRunScope, withTestRunContext } from './progressTestUtils';
 
 function toolNames(tools: readonly { name: string }[] | undefined): string[] {
   return tools?.map((tool) => tool.name) ?? [];
@@ -125,6 +125,7 @@ describe('response cycle tool visibility', () => {
         isBackgroundModeActive: () => false,
         setOutputStreaming: vi.fn(),
       },
+      runScope: testRunScope('response-cycle-invocation'),
       runtimeHost: { emit: vi.fn() },
       setAbortController: vi.fn(),
       setting: {

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -153,16 +153,17 @@ async function runPersistedFlow(
     input: Object.freeze({ MODEL: config.model }),
     transient: {},
   };
+  const runScope = createRunScope({
+    runtimeHost: noopAgentRuntimeHost,
+    streamId,
+    executionId,
+    agentName: config.agent,
+    session,
+  });
   const context = createRunContext({
     modelSource: 'live',
     getModel: () => config.model,
-    runScope: createRunScope({
-      runtimeHost: noopAgentRuntimeHost,
-      streamId,
-      executionId,
-      agentName: config.agent,
-      session,
-    }),
+    runScope,
   });
   let interrupted = false;
 
@@ -171,6 +172,7 @@ async function runPersistedFlow(
       runToolUseFlow(
         {
           config,
+          runScope,
           setting: TOOL_USE_SETTING,
           prompt: TOOL_USE_PROMPT,
           logger: noopTrace,

--- a/src/test-kernel/agent/core/FinalToolSynthesis.vitest.ts
+++ b/src/test-kernel/agent/core/FinalToolSynthesis.vitest.ts
@@ -11,7 +11,7 @@ import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { CreateResponseOptions } from '@agent/types/ModelHandlerContracts';
 import type { ProviderMessage } from '@agent/types/ProviderMessage';
 import { createRunTrace, StreamLogStore } from '@transcript';
-import { withTestRunContext } from '../progressTestUtils';
+import { testRunScope, withTestRunContext } from '../progressTestUtils';
 
 function buildRound(supportsForcedToolChoice: boolean) {
   const requests: CreateResponseOptions[] = [];
@@ -58,6 +58,7 @@ function buildRound(supportsForcedToolChoice: boolean) {
     checkInterruption: () => false,
     client: {},
     config: { agent: 'test-agent', model: 'test-model' },
+    runScope: testRunScope('final-tool-synthesis'),
     fileService: {
       createLocation: (filePath: string) => ({ absolutePath: filePath }),
     },

--- a/src/test-kernel/agent/followUp/ToolUseDispatchInterruption.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseDispatchInterruption.vitest.ts
@@ -15,7 +15,7 @@ import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { createRunTrace, StreamLogStore } from '@transcript';
 
 // Local file imports
-import { withTestRunContext } from '../progressTestUtils';
+import { testRunScope, withTestRunContext } from '../progressTestUtils';
 
 /**
  * Regression test for https://github.com/LionSR/TeXRA/issues/7163.
@@ -79,6 +79,7 @@ describe('ToolUseDispatchNode interruption', () => {
     }));
 
     const services = {
+      runScope: testRunScope('test-stream'),
       checkInterruption,
       client: {},
       config: { agent: 'test-agent', model: 'test-model' },
@@ -255,6 +256,7 @@ describe('ToolUseDispatchNode interruption', () => {
     }));
 
     const services = {
+      runScope: testRunScope('test-stream'),
       checkInterruption,
       client: {},
       config: { agent: 'test-agent', model: 'test-model' },

--- a/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
@@ -59,6 +59,7 @@ import {
   createRecordingHost,
   recordSessionEvents,
   runEventsOfType,
+  testRunScope,
   withTestRunContext,
 } from '../progressTestUtils';
 
@@ -98,6 +99,7 @@ describe('tool-use progress events', () => {
     const streamId = 'stream:single-shot-final-tool' as StreamTabId;
     const node = new ToolUseCycleNode().setServices({
       streamId,
+      runScope: testRunScope(streamId, { runtimeHost: host }),
       runtimeHost: host,
       logger,
       modelHandler: {
@@ -127,6 +129,7 @@ describe('tool-use progress events', () => {
     const streamId = 'stream:headless-final-tool' as StreamTabId;
     const node = new ToolUseCycleNode().setServices({
       streamId,
+      runScope: testRunScope(streamId, { runtimeHost: host }),
       runtimeHost: host,
       logger,
       modelHandler: {
@@ -166,6 +169,7 @@ describe('tool-use progress events', () => {
 
     const node = new ToolUseCycleNode().setServices({
       streamId,
+      runScope: testRunScope(streamId, { runtimeHost: host }),
       runtimeHost: host,
       logger,
       modelHandler: { getClient: vi.fn() },
@@ -310,6 +314,7 @@ describe('tool-use round outcome persistence (#8023)', () => {
       );
       const node = new ToolUseCycleNode().setServices({
         streamId,
+        runScope: testRunScope(streamId, { runtimeHost: host }),
         runtimeHost: host,
         logger,
         modelHandler: { getClient: vi.fn() },

--- a/src/test-kernel/agent/followUp/ToolUseRoundFollowUpMedia.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseRoundFollowUpMedia.vitest.ts
@@ -15,7 +15,7 @@ import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { createRunTrace, StreamLogStore } from '@transcript';
 
 // Local file imports
-import { withTestRunContext } from '../progressTestUtils';
+import { testRunScope, withTestRunContext } from '../progressTestUtils';
 
 /**
  * Fields identical across every `ToolUseRoundServices` fixture below --
@@ -24,6 +24,7 @@ import { withTestRunContext } from '../progressTestUtils';
  */
 function baseRoundServices(traceLabel: string) {
   return {
+    runScope: testRunScope('test-stream'),
     checkInterruption: () => false,
     client: {},
     config: { agent: 'test-agent', model: 'test-model' },

--- a/src/test-kernel/agent/followUp/ToolUseRoundPrepNodeFollowUpTranscriptLog.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseRoundPrepNodeFollowUpTranscriptLog.vitest.ts
@@ -5,12 +5,13 @@ import { describe, expect, it, vi } from 'vitest';
 import { ToolUseRoundPrepNode } from '@agent/core/flows/toolUseRound/ToolUseRoundPrepNode';
 import type { ToolUseRoundServices } from '@agent/core/flows/CycleServices';
 import type { ToolUseRoundShared } from '@agent/core/flows/toolUseRound/roundShared';
-import { withTestRunContext } from '../progressTestUtils';
+import { testRunScope, withTestRunContext } from '../progressTestUtils';
 
 function buildServices(
   overrides: Partial<ToolUseRoundServices<unknown>> = {},
 ): ToolUseRoundServices<unknown> {
   return {
+    runScope: testRunScope('test-stream'),
     checkInterruption: () => false,
     config: { model: 'deepseekT', agent: 'chat' } as never,
     logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },

--- a/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
@@ -40,6 +40,7 @@ import {
   recordSessionEvents,
   runEventsOfType,
   sessionWithInteractions,
+  testRunScope,
   toolUseRunShared,
   withTestRunContext,
 } from '../progressTestUtils';
@@ -54,7 +55,11 @@ type WaitNodeModelHandlerOverrides = Omit<
 type WaitNodeServiceOverrides = Partial<
   Pick<
     ToolUseServices,
-    'checkInterruption' | 'isSubagent' | 'onFollowUpConsumed' | 'onIdle'
+    | 'checkInterruption'
+    | 'isSubagent'
+    | 'onFollowUpConsumed'
+    | 'onIdle'
+    | 'runScope'
   >
 > & {
   fileService?: Partial<ToolUseServices['fileService']>;
@@ -69,6 +74,7 @@ function createWaitNodeServices(
   const { fileService, modelHandler, session, ...topLevel } = overrides;
   const { capabilities, ...modelHandlerOverrides } = modelHandler ?? {};
   return {
+    runScope: testRunScope('test-stream'),
     checkInterruption: () => false,
     fileService: {
       createLocation: (filePath: string) => ({ absolutePath: filePath }),
@@ -714,6 +720,7 @@ describe('ToolUseWaitNode', () => {
     const createUserFollowUpMessages = vi.fn(async () => []);
     const runtimeHost = { emit: vi.fn() };
     const services = createWaitNodeServices({
+      runScope: testRunScope(streamId, { session: ownerSession }),
       modelHandler: {
         createUserFollowUpMessages,
       },

--- a/src/test-kernel/agent/followUp/ToolUseWaitNodeFollowUpTranscriptLog.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNodeFollowUpTranscriptLog.vitest.ts
@@ -9,12 +9,17 @@ import type {
   WaitExecResult,
 } from '@agent/implementations/flows/tooluse/nodes/types';
 import type { ToolUseServices } from '@agent/implementations/flows/tooluse/ToolUseServices';
-import { toolUseRunShared, withTestRunContext } from '../progressTestUtils';
+import {
+  testRunScope,
+  toolUseRunShared,
+  withTestRunContext,
+} from '../progressTestUtils';
 
 function buildServices(
   overrides: Partial<ToolUseServices<unknown>> = {},
 ): ToolUseServices<unknown> {
   return {
+    runScope: testRunScope('test-stream'),
     logger: Object.assign(new TraceEmitter(), {
       debug: vi.fn(),
       info: vi.fn(),

--- a/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
@@ -29,6 +29,7 @@ import {
   createRecordingHost,
   recordSessionEvents,
   runEventsOfType,
+  testRunScope,
   withTestRunContext,
 } from '../progressTestUtils';
 
@@ -117,6 +118,7 @@ function createOutputNode(
 ): OutputNode {
   return new OutputNode().setServices({
     streamId,
+    runScope: testRunScope(streamId, { runtimeHost: host }),
     logger,
     outputState,
     runtimeHost: host,

--- a/src/test-kernel/agent/progressTestUtils.ts
+++ b/src/test-kernel/agent/progressTestUtils.ts
@@ -1,7 +1,10 @@
 // Local imports
 import type { AgentEvent } from '@agent/trace';
 import type { ToolUseRunShared } from '@agent/implementations/flows/tooluse/nodes/types';
-import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import {
+  noopAgentRuntimeHost,
+  type AgentRuntimeHost,
+} from '@agent/runtime/AgentRuntimeHost';
 import {
   matchesCancelSelector,
   SessionHostInteractions,
@@ -18,7 +21,7 @@ import {
   type UserQuestionSettlement,
 } from '@agent/runtime/HostInteractions';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
-import { createRunScope } from '@agent/runtime/RunScope';
+import { createRunScope, type RunScope } from '@agent/runtime/RunScope';
 import { ModelRetryGate } from '@agent/runtime/ModelRetryGate';
 import type {
   SessionEvent,
@@ -375,12 +378,37 @@ export function sessionWithInteractions(
 }
 
 /**
+ * The `RunScope` a flow-services fixture must carry, since nodes read run
+ * identity from `services.runScope`. Same shape {@link withTestRunContext}
+ * installs ambiently — pass one `session` to both so they agree.
+ */
+export function testRunScope(
+  streamId: string,
+  options: {
+    session?: SessionHandle;
+    runtimeHost?: AgentRuntimeHost;
+  } = {},
+): RunScope {
+  const runtimeHost = options.runtimeHost ?? noopAgentRuntimeHost;
+  return createRunScope({
+    runtimeHost,
+    streamId: streamId as StreamTabId,
+    executionId: 'deadbeef' as ExecutionId,
+    agentName: 'test-agent',
+    session:
+      options.session ??
+      sessionWithInteractions(interactionsByHost.get(runtimeHost)),
+  });
+}
+
+/**
  * Run `fn` inside a launch `RunContext` carrying `runtimeHost`/`streamId`.
  *
- * Flow nodes read these from the ambient `RunContext` rather than the
- * services bag (DI cleanup Step 2) — production always runs them inside
- * `withExecutionRunContext`, which always projects a `launch` context. Tests
- * that call a node's `exec`/`post` directly need the same scope.
+ * Most flow nodes now read run identity from `services.runScope`; the reads
+ * still on the ambient context need the launch scope installed — production
+ * always runs them inside `withExecutionRunContext`, which always projects a
+ * `launch` context. Tests calling a node's `exec`/`post` directly need the
+ * same scope. Pass `session` so it matches the one on the services bag.
  */
 export function withTestRunContext<T>(
   runtimeHost: AgentRuntimeHost,
@@ -393,19 +421,10 @@ export function withTestRunContext<T>(
     stopAfterCycle?: boolean;
   } = {},
 ): Promise<T> {
-  const {
-    session = sessionWithInteractions(interactionsByHost.get(runtimeHost)),
-    ...contextOptions
-  } = options;
+  const { session, ...contextOptions } = options;
   return withRunContext(
     createRunContext({
-      runScope: createRunScope({
-        runtimeHost,
-        streamId: streamId as StreamTabId,
-        executionId: 'deadbeef' as ExecutionId,
-        agentName: 'test-agent',
-        session,
-      }),
+      runScope: testRunScope(streamId, { runtimeHost, session }),
       modelSource: 'live',
       getModel: () => undefined,
       ...contextOptions,

--- a/src/test-kernel/agent/runtime/RetryState.vitest.ts
+++ b/src/test-kernel/agent/runtime/RetryState.vitest.ts
@@ -32,7 +32,7 @@ import type {
   RetryResult,
 } from '@agent/runtime/HostInteractions';
 import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
-import { createRunScope } from '@agent/runtime/RunScope';
+import { createRunScope, type RunScope } from '@agent/runtime/RunScope';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import {
@@ -68,10 +68,12 @@ import { createTestSession } from '@test/support/sessionTestUtils';
 import {
   createRecordingHost,
   sessionWithInteractions,
+  testRunScope,
 } from '../progressTestUtils';
 
 interface TestRetryServices {
   config: { model: string };
+  runScope: RunScope;
   streamId: StreamTabId;
   runtimeHost: AgentRuntimeHost;
   logger: AgentTrace;
@@ -132,15 +134,21 @@ function createRetryNode(
   streamId: StreamTabId,
   refreshClient?: (selection?: unknown, signal?: AbortSignal) => Promise<void>,
   clientCredentialRoute?: ModelCredentialRoute,
+  // The node reads its session from `services.runScope`, so a test driving a
+  // real session's host interactions must hand that same session in here.
+  sessionOverride?: SessionHandle,
 ): RetryNodeKit {
-  const streamStatus = new StreamStatusMachine();
   const requestRetry = vi.fn<RetryNodeKit['requestRetry']>();
-  const session = sessionWithInteractions(
-    { requestRetry, cancel: () => {} },
-    streamStatus,
-  );
+  const session =
+    sessionOverride ??
+    sessionWithInteractions(
+      { requestRetry, cancel: () => {} },
+      new StreamStatusMachine(),
+    );
+  const streamStatus = session.status;
   const node = new ExposedRetryNode().setServices({
     config: { model: 'copilot:sonnet46' },
+    runScope: testRunScope(streamId, { session }),
     streamId,
     runtimeHost: noopAgentRuntimeHost,
     logger: noopTrace,
@@ -264,6 +272,7 @@ async function captureModelRetry(
     logger: noopTrace,
     setting: { temperature: 0 },
     config: { model: 'openai:test' },
+    runScope: testRunScope(streamId, { session }),
     setAbortController: vi.fn(),
     client,
     clientCredentialRoute: credentialRoute,
@@ -444,6 +453,7 @@ describe('RetryState', () => {
     try {
       const node = new StatuslessServerErrorNode().setServices({
         config: { model: 'openai:test' },
+        runScope: testRunScope('retry-delay' as StreamTabId),
         streamId: 'retry-delay' as StreamTabId,
         runtimeHost: noopAgentRuntimeHost,
         logger: noopTrace,
@@ -489,6 +499,7 @@ describe('RetryState', () => {
       };
       const node = new InterruptibleBackoffNode().setServices({
         config: { model: 'openai:test' },
+        runScope: testRunScope('retry-interrupt' as StreamTabId),
         streamId: 'retry-interrupt' as StreamTabId,
         runtimeHost: noopAgentRuntimeHost,
         logger: noopTrace,
@@ -1050,7 +1061,7 @@ describe('RetryState', () => {
     const session = createTestSession();
     const recording = createRecordingHost();
     session.useHostInteractions(recording.interactions);
-    const { node } = createRetryNode(streamId);
+    const { node } = createRetryNode(streamId, undefined, undefined, session);
     const streamStatus = session.status;
 
     try {

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -63,6 +63,7 @@ import * as execUtils from '@utils/system/execUtils';
 import {
   createRecordingHost,
   recordSessionEvents,
+  testRunScope,
   withTestRunContext,
 } from '../agent/progressTestUtils';
 
@@ -165,6 +166,7 @@ function roundServices(opts: {
   setAbortController?: (controller: AbortController | null) => void;
 }): ToolUseRoundServices<OpenAI> {
   return {
+    runScope: testRunScope(opts.streamId),
     modelHandler: new BashMockHandler(testModelConfig),
     config: testModelConfig as any,
     setting: {
@@ -262,8 +264,11 @@ describe('BashTool', () => {
     // Create and run the flow directly
     const flow = createToolUseRoundFlow();
     flow.setServices(options);
-    await withTestRunContext(noopAgentRuntimeHost, 'bash-tool', () =>
-      flow.run(shared),
+    await withTestRunContext(
+      noopAgentRuntimeHost,
+      'bash-tool',
+      () => flow.run(shared),
+      { session: options.runScope.session },
     );
 
     const toolOutputMessage = messages.find(
@@ -520,27 +525,31 @@ describe('BashTool', () => {
 
       const node = new ToolUseDispatchNode<OpenAI>();
       node.setServices(options);
-      await withTestRunContext(noopAgentRuntimeHost, 'tool-status-log', () =>
-        node.post(
-          shared,
-          [call],
-          [
-            {
-              call,
-              result: {},
-              parsedInput: {},
-              extracted: {
-                attachments: [],
-                sanitizedResult: { status: 'executed' },
-              },
-              editedFiles: [],
-              logRef: {
-                logId: undefined,
-                groupId: runTrace.trace.activeStageId(),
-              },
-            } as any,
-          ],
-        ),
+      await withTestRunContext(
+        noopAgentRuntimeHost,
+        'tool-status-log',
+        () =>
+          node.post(
+            shared,
+            [call],
+            [
+              {
+                call,
+                result: {},
+                parsedInput: {},
+                extracted: {
+                  attachments: [],
+                  sanitizedResult: { status: 'executed' },
+                },
+                editedFiles: [],
+                logRef: {
+                  logId: undefined,
+                  groupId: runTrace.trace.activeStageId(),
+                },
+              } as any,
+            ],
+          ),
+        { session: options.runScope.session },
       );
 
       const completedEvent = events.findLast(
@@ -1003,6 +1012,7 @@ describe('BashTool', () => {
         noopAgentRuntimeHost,
         'bash-tool',
         () => node.exec(call),
+        { session: options.runScope.session },
       );
 
       assert.equal(result, null);


### PR DESCRIPTION
Declares `runScope: RunScope` on `AgentCore` so flow nodes read
`this.services.runScope` instead of `useLaunchRunContext()`.

Closes #9255 — implements the ruling on that issue, including the
same-PR doc-comment fix it required.

## The load-bearing fact, verified at runtime

The issue's premise is that `runScope` is *already* an own property of the
object the flows spread, absent only from the declared type. I verified this
on the real production path before touching anything, with temporary probes
(all reverted; not in this diff):

1. **Launch context** — probing the object `buildAgentLaunchContext` actually
   returns, driven through the real `executeAgent` path:
   `hop1Own=true hop1Def=true`, and the value is `frozen=true`. Spreading it
   four times in a row preserved it every time
   (`hop2Own/hop3Own/hop4Own=true`) with `sameRef=true` — same object
   identity, no copy.
2. **Flow services bag** — probe at `runToolUseFlow`'s `const services`, again
   on the real `executeAgent` path: `[TOOLUSE-SERVICES] own=true sameRef=true`.
3. **Node `this.services`** — probe in `BaseNode.setServices`, reached through
   the production chain: `ToolUsePersistedFlow ownRunScope=true defined=true`,
   `ToolUsePrepareNode ownRunScope=true defined=true`.
4. **`withModelClient`** (the 4th spread, `ToolUseCycleNode` /
   `ResponseCycleNode`) — direct unit probe: own property preserved,
   `toBe(runScope)` by reference.

Both `withExecutionRunContext` call sites in `executeAgent` (`:397`, `:557`)
pass the same `ctx` whose `runScope` is spread into the flow input, so the
ambient scope and the bag are the identical frozen object on every production
path. The conversion is behaviour-identical, not merely equivalent.

## Ambient reads: 11 → 3

Converted (8):

| site | reads |
| --- | --- |
| `core/flows/ModelInvocationNode.ts` | `services.runScope.session.modelRetries` |
| `core/flows/CommonCycleTypes.ts` (`saveCycleDebug`) | `services.runScope.executionId` |
| `core/flows/CommonCycleTypes.ts` (`defaultPostCompactionContext`) | `services.runScope.{session,streamId}` |
| `core/flows/RetryState.ts` | `this.services.runScope` |
| `implementations/flows/tooluse/nodes/ToolUseCycleNode.ts` | `this.services.runScope` |
| `implementations/flows/tooluse/nodes/ToolUseWaitNode.ts` (`post`) | `this.services.runScope` |
| `implementations/flows/reflection/nodes/OutputNode.ts` | `this.services.runScope` |
| `implementations/flows/reflection/runReflectionFlow.ts` | `input.runScope` |

Left on the ALS (3), exactly the ones the ruling named — they also need
`runtimeUnavailableTools` / `approvalPromptsUnavailable` / `stopAfterCycle`,
which are per-run *launch* facts, not scope identity:
`core/flows/ResponseCycleFlow.ts:226`,
`tooluse/nodes/ToolUseWaitNode.ts:61` (`exec`),
`tooluse/runToolUseFlow.ts:184`.

## Net-element accounting

| | before | after |
| --- | --- | --- |
| ambient `useLaunchRunContext()` in flow primitives | 11 | **3** |
| production call-site signature changes | — | **0** |
| new exports / types / ports / wrappers (production) | — | **0** |
| new abstractions | — | **0** |
| `config/ratchets/*.json` bumps | — | **0** |

One field declaration moved: `readonly runScope: RunScope` is deleted from
`AgentLaunchContext` and declared on `AgentCore`, which it already extends.
Two structural minimum types that flow nodes are generic over —
`RetryState.RetryableNodeServices` and `ModelInvocationNode.InvocationServices`
— gained the same field so the nodes can read it; neither is exported.
`saveCycleDebug` / `defaultPostCompactionContext` widened their existing
`Pick<…>` by one key; every caller already passes the full bag, so no call
site changed.

**Production LoC: +26 / −29 = net −3.** Below the −10/−15 estimate on the
issue, which did not count the field declaration, the two `import type`
lines, or the mandated doc-comment rewrite (+3 by itself). The read-site
conversion alone is ≈ −11.

## Core → runtime edge delta

`src/agent/core/` modules with a **value** import of
`@agent/runtime/RunContext`: **4 → 1** — exactly the reduction the issue
predicted. Only `ResponseCycleFlow.ts` remains, for its residual ALS read.

Two **type-only** edges to `@agent/runtime/RunScope` appear
(`BaseFlowServices.ts`, and `RetryState.ts` where it *replaces* a value edge
to `RunContext`). Both are `import type`, erased at build.

Counting the whole flow-primitive surface (`core/` + `implementations/flows/`),
modules holding a value edge to `@agent/runtime/RunContext`: **9 → 3**.

`npx vitest run src/test-kernel/architecture/` passes unchanged (9 files, 58
tests) — the subsystem-edge ratchet is subsystem-granular, so an intra-`agent`
edge does not touch `architecture-edges-baseline.json`. No baseline was
edited.

## The doc comment

`RunContext.useLaunchRunContext`'s *"Use this instead of re-deriving these
fields on the flow-service bag"* rested on a false premise — nothing was
re-derived; it is the same frozen object by reference. Replaced with what is
true: code holding a services bag reads `services.runScope`, and this accessor
is the fallback for code that holds no bag — chiefly `src/tools/`
(58 accessor call sites across 24 files), which this change does not touch.

`withTestRunContext`'s doc comment in `progressTestUtils.ts` asserted the same
now-false thing and is corrected alongside it.

## A claim on the issue that turned out FALSE

> Migration cost outside `src/agent/core/`: **~2 test lines**, 0 production
> call sites.

The **0 production call sites** half is exactly right — `npm run typecheck`
went green across all six projects with no production edit beyond the
declaration move.

The **~2 test lines** half is wrong by more than an order of magnitude: **14
test files** needed changes (+137 / −68). Test fixtures build services bags
with `as unknown as ToolUseRoundServices` and friends, which bypasses the
type entirely — so they keep compiling but throw
`Cannot destructure property 'streamId' of 'runScope' as it is undefined`
the moment a node reads `services.runScope`. Typecheck surfaced only 4 of
them; the other 10 appeared only under a full `npm test`. Worth recording,
because the same casting pattern will hide the cost of any future field added
to `AgentCore`.

The churn is mostly mechanical. `progressTestUtils.testRunScope(streamId, {
session, runtimeHost })` was added — same shape `withTestRunContext` already
installed ambiently, which now delegates to it — so fixtures and the ambient
scope cannot drift apart. It has 12 callers in this PR.

Two fixtures needed a real fix rather than a field: `RetryState`'s
"resolves manual retries through the session host interactions" and
`ToolUseWaitNode`'s "updates the run session status while waiting and
resuming" were passing a *different* `SessionHandle` to the ambient scope than
the node's services carried. That was invisible while the node read the ALS;
it is now threaded explicitly.

## Verification

All run in this worktree.

| command | result |
| --- | --- |
| `npm run typecheck` | pass (root, test-kernel, extension, cli, trace-viewer, desktop) |
| `npx vitest run src/test-kernel/architecture/` | **9 files / 58 tests passed** |
| `npm test` (full, 783 files) | **766 passed, 16 failed / 7628 tests passed, 20 failed** |
| `npm run lint` | clean |
| `npm run check:dead-code-ratchet` | `18 current vs 18 baselined` — OK |
| `npx prettier --check` (24 changed files) | clean |

Suites specifically covering the change, all green:
`src/test-kernel/agent/followUp/`, `src/test-kernel/agent/core/`,
`src/test-kernel/agent/output/`, `ResponseCycleTools`,
`agent/runtime/RetryState`, `tools/BashTool`, `SessionResumeRetrieval`,
`ReflectionFlowStateRecovery` — 34 files / 288 tests + 96 tests.

**Zero regressions.** All 16 full-run failures were baselined by checking out
detached `origin/main` and re-running the same 15 files:

- **Pre-existing on main, reproduced there**: `WorkflowScriptSandboxBundle`,
  `cli/ConfigForm`, `cli/SubagentListDisplay`, `cli/ToolUseRowPatch`, and
  `cli/RunChatSignalOwnership` (fails identically on `origin/main` alone:
  `Test timed out in 10000ms` + `The default session has already been
  initialized.` — this one is *not* on the documented known-failure list, so
  flagging it).
- **Load-induced timeouts under the 783-file run**: the remaining 10
  (`desktop/*`, `cli/TranscriptSessionPolicy`, `cli/StaticBandResize`,
  `cli/CliSupabaseAuth`, `tools/ClaudeAgentConfig`, `tools/lean/LeanTools`,
  `agent/runtime/DefaultSessionLifecycle`) all pass in isolation on this
  branch and all fail at ~10-16 s (the default test timeout) in the full run.

None of the 16 is in the agent flow primitives.

https://claude.ai/code/session_01XZ8Z6rhypTfkVq728XCcCd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with no production API changes; behavior stays the same frozen `runScope` object, with broader test fixture updates to avoid undefined `runScope` at runtime.
> 
> **Overview**
> **Flow nodes now read run identity from `services.runScope` instead of ambient `useLaunchRunContext()`**, by declaring `readonly runScope: RunScope` on `AgentCore` (moved off `AgentLaunchContext`, which already extended it).
> 
> Eight call sites in core flows and tool-use/reflection nodes now use `this.services.runScope` for `streamId`, `session`, `executionId`, model retry gates, and debug logging. **`useLaunchRunContext()` remains only where launch-only ALS fields are needed** (`stopAfterCycle`, `approvalPromptsUnavailable`, `runtimeUnavailableTools`)—e.g. `ResponseCycleFlow`, `ToolUseWaitNode.exec`, `runToolUseFlow`.
> 
> `RetryableNodeServices` / `ModelInvocationNode.InvocationServices` and helpers like `saveCycleDebug` / `defaultPostCompactionContext` widen their `Pick<>` types to include `runScope`. Docs on `useLaunchRunContext` and `withTestRunContext` are corrected: the services bag and ALS share the same frozen `runScope` by reference.
> 
> Tests gain **`testRunScope()`** so fixtures match ambient launch context; several flows pass `runScope` explicitly and align `session` on the bag with `withTestRunContext`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b114d5bcaeccbd21ac8b611ef9dc7b6929cc5bfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->