### PR TITLE
fix: remove redundant input hints

### DIFF
--- a/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
+++ b/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
@@ -317,8 +317,7 @@ export class FileSelectGroup extends LitElement {
             <span class="file-select-icon" aria-hidden="true">
               ${waIcon(config.icon as TeXRAIconName)}
             </span>
-            <label id="${this.listId}Label">${config.label}</label>
-            <wa-tooltip for="${this.listId}Label">${config.tooltip}</wa-tooltip>
+            <label>${config.label}</label>
             ${
               config.toolConfig === 'tool'
                 ? this.renderToolConfigMenu()
@@ -327,15 +326,6 @@ export class FileSelectGroup extends LitElement {
             ${
               config.toolConfig === 'autoExtract'
                 ? this.renderAutoExtractMenu()
-                : nothing
-            }
-            ${
-              config.description
-                ? html`<span
-                    class="file-select-hint"
-                    title=${config.description}
-                    >${config.description}</span
-                  >`
                 : nothing
             }
           </div>

--- a/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
+++ b/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
@@ -6,7 +6,6 @@ import { repeat } from 'lit/directives/repeat.js';
 
 import '@awesome.me/webawesome/dist/components/dropdown/dropdown.js';
 import '@awesome.me/webawesome/dist/components/dropdown-item/dropdown-item.js';
-import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 
 import { designTokens } from '@shared/styles';
 import type {

--- a/packages/extension/src/webview/frontend/components/InstructionPanel.ts
+++ b/packages/extension/src/webview/frontend/components/InstructionPanel.ts
@@ -517,13 +517,6 @@ export class InstructionPanel extends LitElement {
               className: session.isRecording ? 'recording' : '',
               action: 'record',
             })}
-            ${renderIconActionButton({
-              id: 'eraseInstructionButton',
-              icon: 'clear-all',
-              label: 'Erase instruction',
-              tooltip: 'Erase instruction',
-              action: 'erase',
-            })}
           </div>
         </div>
         ${this.renderSessionHint(session)}

--- a/packages/extension/src/webview/frontend/mainViewActions.ts
+++ b/packages/extension/src/webview/frontend/mainViewActions.ts
@@ -524,10 +524,6 @@ export function runPanelAction(action: ActionDetail['action']): void {
     case 'record':
       toggleRecording();
       break;
-    case 'erase':
-      setInstruction('');
-      saveState();
-      break;
   }
 }
 

--- a/packages/extension/src/webview/frontend/store.ts
+++ b/packages/extension/src/webview/frontend/store.ts
@@ -143,8 +143,6 @@ export const FILE_SELECT_CONFIGS: ReadonlyArray<FileSelectConfig> = [
     addOpenedLabel: 'Add opened files as input',
     emptyListLabel: 'Clear all input files',
     selectListLabel: 'Add input files',
-    tooltip: 'Primary files the agent processes, such as .tex, .txt, or .md',
-    description: 'Read and edited by the agent',
     toolConfig: 'tool',
   },
   {
@@ -154,9 +152,6 @@ export const FILE_SELECT_CONFIGS: ReadonlyArray<FileSelectConfig> = [
     addOpenedLabel: 'Add opened files as context',
     emptyListLabel: 'Clear all context files',
     selectListLabel: 'Add context files',
-    tooltip:
-      "Read-only context the agent sees but won't modify — bibliographies (.bib/.bbl), reference papers, style/macro files (.sty/.cls), or any document the output should match",
-    description: 'Read-only context — not modified',
   },
   {
     type: 'media',
@@ -165,8 +160,6 @@ export const FILE_SELECT_CONFIGS: ReadonlyArray<FileSelectConfig> = [
     addOpenedLabel: 'Add opened files as media',
     emptyListLabel: 'Clear all media files',
     selectListLabel: 'Add media files',
-    tooltip: 'Images, figures, and media assets used by the document',
-    description: 'Images and figures the agent can view',
     toolConfig: 'autoExtract',
   },
 ];

--- a/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
+++ b/packages/extension/src/webview/frontend/styles/fileSelectStyles.ts
@@ -80,16 +80,6 @@ export const fileSelectLayoutStyles = css`
     flex-shrink: 0;
   }
 
-  .file-select-hint {
-    font-size: var(--font-size-xs);
-    color: var(--color-text-secondary);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    flex-shrink: 1;
-    min-width: 0;
-  }
-
   .file-select-actions {
     display: flex;
     flex-direction: row;

--- a/src/shared/schemas/mainView/state.ts
+++ b/src/shared/schemas/mainView/state.ts
@@ -196,8 +196,6 @@ const FileSelectConfigSchema = z.object({
   addOpenedLabel: z.string(),
   emptyListLabel: z.string(),
   selectListLabel: z.string(),
-  tooltip: z.string(),
-  description: z.string().nullish(),
   toolConfig: z.enum(['tool', 'autoExtract']).nullish(),
 });
 export type FileSelectConfig = z.infer<typeof FileSelectConfigSchema>;


### PR DESCRIPTION
## Summary

- remove the hover tooltips and secondary descriptions from the Input, Context, and Media file sections
- remove the instruction eraser button and its now-unreachable action branch
- remove the obsolete schema fields and styles instead of leaving hidden interface data behind

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm run compile:fast`
- `npm test` (782 files passed, 1 skipped; 7,651 tests passed, 4 skipped)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic main-view cleanup with no changes to execution, persistence, or security paths; the only behavioral loss is the instruction clear shortcut.
> 
> **Overview**
> Simplifies the main view by dropping **duplicate explanatory UI** around file lists and the instruction field.
> 
> **Input / Context / Media** headers now show only the section label (and existing config menus). Label **hover tooltips**, inline **description** hints, and the related `tooltip` / `description` fields on `FileSelectConfig` are removed end-to-end, including unused `.file-select-hint` styles.
> 
> The instruction panel **“Erase instruction”** control and the matching **`erase`** branch in `runPanelAction` are removed so clearing text is no longer a one-click action from the toolbar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bba13dc033b5285c0621f541d0acbba8950713e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->