### PR TITLE
fix: support voice transcription uploads

### DIFF
--- a/src/platform/defaults/longRunningModelTransport.ts
+++ b/src/platform/defaults/longRunningModelTransport.ts
@@ -1,6 +1,7 @@
 // Third-party imports
 import {
   fetch as undiciFetch,
+  FormData as UndiciFormData,
   getGlobalDispatcher,
   type Dispatcher,
   type RequestInfo as UndiciRequestInfo,
@@ -11,6 +12,7 @@ const MODEL_STREAM_INACTIVITY_TIMEOUT_MS = 30 * 60 * 1000;
 const MODEL_RESPONSE_HEADERS_TIMEOUT_MS = 10 * 60 * 1000;
 const ROUTING_FETCH_MARKER = Symbol('texra.longRunningModelFetchRouter');
 type RoutingFetch = typeof fetch & { [ROUTING_FETCH_MARKER]?: true };
+type UploadCompatibleFetch = typeof fetch & { Response: typeof Response };
 
 function isGoogleClassicStreamingRequest(input: RequestInfo | URL): boolean {
   let url: string;
@@ -37,6 +39,23 @@ async function normalizeModelRequest(
   init?: RequestInit,
 ): Promise<[UndiciRequestInfo, UndiciRequestInit]> {
   if (!(input instanceof Request)) {
+    if (init?.body instanceof FormData) {
+      const body = new UndiciFormData();
+      for (const [name, value] of init.body.entries()) {
+        if (typeof value === 'string') {
+          body.append(name, value);
+        } else {
+          body.append(name, value, value.name);
+        }
+      }
+      return [
+        input as UndiciRequestInfo,
+        {
+          ...init,
+          body,
+        } as UndiciRequestInit,
+      ];
+    }
     return [input as UndiciRequestInfo, init as UndiciRequestInit];
   }
 
@@ -87,15 +106,24 @@ export function composeLongRunningModelDispatcher(): Dispatcher {
  * package-undici fetch rejects native `Request` instances (OpenRouter's
  * HTTPClient passes one), so it is rebuilt from interoperable primitives.
  */
-export const longRunningModelFetch: typeof fetch = async (input, init) => {
-  const [requestInput, requestInit] = await normalizeModelRequest(input, init);
-  // Undici implements the Web Fetch response contract at runtime, but its
-  // package-local types are not assignable to the DOM library's Response.
-  return undiciFetch(requestInput, {
-    ...requestInit,
-    dispatcher: composeLongRunningModelDispatcher(),
-  }) as unknown as Promise<Response>;
-};
+export const longRunningModelFetch: UploadCompatibleFetch = Object.assign(
+  async (input: RequestInfo | URL, init?: RequestInit) => {
+    const [requestInput, requestInit] = await normalizeModelRequest(
+      input,
+      init,
+    );
+    // Undici implements the Web Fetch response contract at runtime, but its
+    // package-local types are not assignable to the DOM library's Response.
+    return undiciFetch(requestInput, {
+      ...requestInit,
+      dispatcher: composeLongRunningModelDispatcher(),
+    }) as unknown as Promise<Response>;
+  },
+  {
+    // OpenAI checks this constructor before creating multipart uploads.
+    Response,
+  },
+);
 
 /**
  * Route Google classic streaming generation through the model transport.

--- a/src/platform/defaults/longRunningModelTransport.ts
+++ b/src/platform/defaults/longRunningModelTransport.ts
@@ -40,6 +40,8 @@ async function normalizeModelRequest(
 ): Promise<[UndiciRequestInfo, UndiciRequestInit]> {
   if (!(input instanceof Request)) {
     if (init?.body instanceof FormData) {
+      // OpenAI builds multipart bodies with the host-global FormData, while
+      // package Undici recognizes only its own FormData implementation.
       const body = new UndiciFormData();
       for (const [name, value] of init.body.entries()) {
         if (typeof value === 'string') {
@@ -104,26 +106,28 @@ export function composeLongRunningModelDispatcher(): Dispatcher {
  * where native fetch would couple our dispatcher to whatever undici the host
  * Node embeds. That same choice is why {@link normalizeModelRequest} exists —
  * package-undici fetch rejects native `Request` instances (OpenRouter's
- * HTTPClient passes one), so it is rebuilt from interoperable primitives.
+ * HTTPClient passes one) and does not serialize host-global `FormData`
+ * instances (OpenAI's audio client passes one), so both are translated at
+ * this boundary.
  */
-export const longRunningModelFetch: UploadCompatibleFetch = Object.assign(
-  async (input: RequestInfo | URL, init?: RequestInit) => {
-    const [requestInput, requestInit] = await normalizeModelRequest(
-      input,
-      init,
-    );
-    // Undici implements the Web Fetch response contract at runtime, but its
-    // package-local types are not assignable to the DOM library's Response.
-    return undiciFetch(requestInput, {
-      ...requestInit,
-      dispatcher: composeLongRunningModelDispatcher(),
-    }) as unknown as Promise<Response>;
-  },
-  {
-    // OpenAI checks this constructor before creating multipart uploads.
-    Response,
-  },
-);
+const longRunningModelFetchImpl: typeof fetch = async (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => {
+  const [requestInput, requestInit] = await normalizeModelRequest(input, init);
+  // Undici implements the Web Fetch response contract at runtime, but its
+  // package-local types are not assignable to the DOM library's Response.
+  return undiciFetch(requestInput, {
+    ...requestInit,
+    dispatcher: composeLongRunningModelDispatcher(),
+  }) as unknown as Promise<Response>;
+};
+// OpenAI checks this constructor before creating multipart uploads.
+Object.defineProperty(longRunningModelFetchImpl, 'Response', {
+  value: Response,
+});
+export const longRunningModelFetch =
+  longRunningModelFetchImpl as UploadCompatibleFetch;
 
 /**
  * Route Google classic streaming generation through the model transport.

--- a/src/test-kernel/agent/modelHandlers/LongRunningModelFetch.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/LongRunningModelFetch.vitest.ts
@@ -1,5 +1,7 @@
 // Third-party imports
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import OpenAI from 'openai';
+import { FormData as UndiciFormData, type Dispatcher } from 'undici';
 
 const transportMocks = vi.hoisted(() => ({
   undiciFetch: vi.fn(),
@@ -20,9 +22,6 @@ import {
   installLongRunningModelFetch,
   longRunningModelFetch,
 } from '@platform/defaults/longRunningModelTransport';
-
-// Type imports
-import type { Dispatcher } from 'undici';
 
 const nativeFetch = globalThis.fetch;
 
@@ -81,6 +80,30 @@ describe('long-running model transport', () => {
       }),
       expect.anything(),
     );
+  });
+
+  it('translates OpenAI multipart uploads for package Undici', async () => {
+    transportMocks.getGlobalDispatcher.mockReturnValue({
+      compose: vi.fn().mockReturnValue({}),
+    } as unknown as Dispatcher);
+    transportMocks.undiciFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ text: 'transcribed text' }), {
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    const client = new OpenAI({
+      apiKey: 'test-key',
+      fetch: longRunningModelFetch,
+    });
+
+    const result = await client.audio.transcriptions.create({
+      file: new File(['audio'], 'recording.wav', { type: 'audio/wav' }),
+      model: 'gpt-4o-transcribe',
+    });
+
+    expect(result.text).toBe('transcribed text');
+    const [, init] = transportMocks.undiciFetch.mock.calls[0] ?? [];
+    expect(init?.body).toBeInstanceOf(UndiciFormData);
   });
 
   it('routes classic streamGenerateContent through the timeout-aware transport', async () => {


### PR DESCRIPTION
## Summary

- convert the global `FormData` produced by the OpenAI client into package-Undici `FormData` at the model transport boundary
- expose the compatible response constructor expected by the OpenAI upload capability check
- exercise the actual audio-transcription multipart path in a regression test

## Cause

The timeout-aware model transport uses package Undici, while the OpenAI client constructs multipart bodies with the host global `FormData`. Package Undici serializes that foreign object as plain text, and the OpenAI client detects the incompatibility before sending the recording.

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm run compile:fast`
- focused multipart regression: 6 tests passed
- `npm test` (782 files passed, 1 skipped; 7,652 tests passed, 4 skipped)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized boundary fix in the model fetch adapter with a focused regression test; no auth or data-model changes.
> 
> **Overview**
> Fixes **voice transcription** (and other OpenAI multipart uploads) when traffic goes through the timeout-aware **package-Undici** model fetch.
> 
> `normalizeModelRequest` now copies host-global **`FormData`** into Undici’s **`FormData`** (strings and file blobs with filenames) before `undiciFetch`, because Undici only serializes its own multipart type. **`longRunningModelFetch`** also exposes the host **`Response`** constructor so the OpenAI SDK’s upload capability check passes.
> 
> A regression test drives **`client.audio.transcriptions.create`** through **`longRunningModelFetch`** and asserts the outbound body is Undici **`FormData`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c792b7e615b1655db7063de6a48805211d05b447. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->