### PR TITLE
fix: unify approval bypass notifications

### DIFF
--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -149,11 +149,6 @@ export function createTuiHostInteractions(
         request.streamId
       ) {
         setToolEditApprovalSessionBypass(request.streamId, true, host);
-        setTuiApprovalBypassState({
-          streamId: request.streamId,
-          kind: 'toolEdit',
-          bypassActive: true,
-        });
       }
       return decision.accepted
         ? { accepted: true, appliedContent: request.proposedContent }
@@ -184,7 +179,10 @@ export function createTuiHostInteractions(
     openExternalInquiry(request) {
       return openExternalInquiryInteraction(request, context);
     },
-    setApprovalBypassState: setTuiApprovalBypassState,
+    setApprovalBypassState(update) {
+      setTuiApprovalBypassState(update);
+      host.emitApprovalBypassState(update);
+    },
     cancel(selector: HostInteractionCancelSelector = {}) {
       // Retry routes live outside the modal queue (the pre-queue auto-switch
       // lookup), so a retry-kind or unfiltered cancel must settle them too —
@@ -390,11 +388,6 @@ async function requestBashInteraction(
   const decision = await decideWithPolicy(context, 'bash', payload);
   if (decision.accepted && decision.bypass === 'bash' && request.streamId) {
     setBashApprovalSessionBypass(request.streamId, true, host);
-    setTuiApprovalBypassState({
-      streamId: request.streamId,
-      kind: 'bash',
-      bypassActive: true,
-    });
   }
   return {
     accepted: decision.accepted,
@@ -425,13 +418,6 @@ async function requestProposalInteraction(
     request.streamId
   ) {
     setDelegatedWorkApprovalBypasses(request.streamId, true, host);
-    for (const kind of ['superYolo', 'toolEdit', 'bash'] as const) {
-      setTuiApprovalBypassState({
-        streamId: request.streamId,
-        kind,
-        bypassActive: true,
-      });
-    }
     approveQueuedDelegatedWorkForStream(request.streamId);
   }
   const feedback = feedbackOnReject(decision);

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -4,6 +4,7 @@
 
 import type {
   HostAgentProposalRequest,
+  HostApprovalBypassStateUpdate,
   HostBashApprovalResult,
   HostInteractions,
   HostRetryRequest,
@@ -66,6 +67,12 @@ export {
   formatRetryRequestMessage,
   formatToolEditApprovalSummary,
 } from './approval/approvalSummaries';
+
+interface HeadlessCliHostInteractionHooks extends CliApprovalPromptHooks {
+  readonly setApprovalBypassState?: (
+    update: HostApprovalBypassStateUpdate,
+  ) => void;
+}
 
 function toToolEditResult(
   decision: ApprovalDecision,
@@ -197,9 +204,10 @@ async function askHeadlessUserQuestion(
 
 export function createHeadlessCliHostInteractions(
   context: CliContext,
-  hooks: CliApprovalPromptHooks = {},
+  hooks: HeadlessCliHostInteractionHooks = {},
 ): HostInteractions {
   return {
+    setApprovalBypassState: hooks.setApprovalBypassState,
     requestToolEditApproval(request) {
       return decideToolEdit(request, context, hooks);
     },

--- a/packages/cli/src/runtime/runExecution.ts
+++ b/packages/cli/src/runtime/runExecution.ts
@@ -186,6 +186,8 @@ export async function executeCliRequest(
   const detachHostInteractions = session.useHostInteractions(
     createHeadlessCliHostInteractions(runContext, {
       beforePrompt: () => runtimeHost.prepareInteractivePrompt?.(),
+      setApprovalBypassState: (update) =>
+        runtimeHost.emitApprovalBypassState(update),
     }),
   );
   // Present terminal-error toasts from the run's `result` event through the same

--- a/packages/cli/src/runtime/runtimeHost.ts
+++ b/packages/cli/src/runtime/runtimeHost.ts
@@ -9,6 +9,10 @@ import {
   type RuntimePresentationEvent,
   type RuntimePresentationEventPayloads,
 } from '@agent/runtime/runtimePresentationEvents';
+import type {
+  ApprovalBypassKind,
+  HostApprovalBypassStateUpdate,
+} from '@agent/runtime/HostInteractions';
 import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import type { CliNdjsonRecord } from '@cli/schemas/cliOutput';
 import { INSTRUCTION_ACTION, type InstructionAction } from '@shared/schemas';
@@ -31,8 +35,15 @@ import type { CliContext } from './cliContext';
 export type CliRuntimeHost = AgentRuntimeHost & {
   attachRunProgressRenderer(events: SessionEventHub): () => void;
   prepareInteractivePrompt?: () => void;
+  emitApprovalBypassState(update: HostApprovalBypassStateUpdate): void;
   close(): Promise<void>;
 };
+
+const ApprovalBypassNdjsonEvent = {
+  bash: 'updateBashApprovalBypassState',
+  toolEdit: 'updateToolEditApprovalBypassState',
+  superYolo: 'updateSuperYoloBypassState',
+} as const satisfies Record<ApprovalBypassKind, string>;
 
 /**
  * Human-readable phrasing for {@link InstructionAction} tokens printed to
@@ -102,6 +113,16 @@ export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
   return {
     attachRunProgressRenderer: attachProgressRenderer,
     prepareInteractivePrompt,
+    emitApprovalBypassState({ streamId, kind, bypassActive }) {
+      if (closed || context.outputFormat !== 'ndjson') return;
+      const record: CliNdjsonRecord = {
+        kind: 'progress',
+        event: ApprovalBypassNdjsonEvent[kind],
+        ts: new Date().toISOString(),
+        payload: { streamId, bypassActive },
+      };
+      writeNdjsonStdout(record);
+    },
     emit<K extends AgentRuntimeEvent>(
       event: K,
       payload: AgentRuntimeEventPayloads[K],

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -301,6 +301,7 @@ export class DesktopProgressBridge {
       session: this.session,
       getApprovalHandlers: () => this.backend.approvalHandlers,
       getToolEditApprovals: () => this.toolEditApprovals!,
+      setApprovalBypassState: this.backend.setApprovalBypassState,
       showInfoMessage: (message) => this.options.host.showInfoMessage(message),
     });
     this.fileActions = new DesktopProgressFileActions(this.options.host, {

--- a/packages/desktop/src/main/desktopHostInteractions.ts
+++ b/packages/desktop/src/main/desktopHostInteractions.ts
@@ -9,6 +9,7 @@ import {
   type BashSettlement,
   type HostBashApprovalRequest,
   type HostBashApprovalResult,
+  type HostApprovalBypassStateUpdate,
   type HostInteractionCancelSelector,
   type HostInteractionOptions,
   type HostInteractions,
@@ -43,6 +44,7 @@ export interface DesktopHostInteractionsOptions {
   session: SessionHandle;
   getApprovalHandlers(): ApprovalRequestHandlerSet;
   getToolEditApprovals(): DesktopToolEditApprovalController;
+  setApprovalBypassState(update: HostApprovalBypassStateUpdate): void;
   showInfoMessage(message: string): Promise<void> | void;
 }
 
@@ -86,6 +88,10 @@ class DesktopHostInteractionsImpl implements DesktopHostInteractions {
 
   showInfoMessage(message: string): Promise<void> | void {
     return this.options.showInfoMessage(message);
+  }
+
+  setApprovalBypassState(update: HostApprovalBypassStateUpdate): void {
+    this.options.setApprovalBypassState(update);
   }
 
   requestToolEditApproval(

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -165,6 +165,7 @@ export class ProgressViewProvider extends BaseWebviewProvider {
       runtimeHost: createAgentPresentationHost(this),
       session: defaultSession(),
       getApprovalHandlers: () => this.backend.approvalHandlers,
+      setApprovalBypassState: this.backend.setApprovalBypassState,
     });
     this.messageHandler = new ProgressViewMessageHandler(
       this,

--- a/packages/extension/src/progressView/extensionHostInteractions.ts
+++ b/packages/extension/src/progressView/extensionHostInteractions.ts
@@ -11,6 +11,7 @@ import {
   type BashSettlement,
   type HostBashApprovalRequest,
   type HostBashApprovalResult,
+  type HostApprovalBypassStateUpdate,
   type HostInteractionCancelSelector,
   type HostInteractionOptions,
   type HostInteractions,
@@ -50,6 +51,7 @@ export interface ExtensionHostInteractionsOptions {
   runtimeHost: AgentRuntimeHost;
   session: SessionHandle;
   getApprovalHandlers(): ApprovalRequestHandlerSet;
+  setApprovalBypassState(update: HostApprovalBypassStateUpdate): void;
 }
 
 export interface ExtensionHostInteractions extends HostInteractions {
@@ -212,6 +214,7 @@ export function createExtensionHostInteractions(
     submitUserQuestionDecision,
     dismissExternalInquiry: (requestId) =>
       handlers().externalInquiry.dismiss(requestId),
+    setApprovalBypassState: options.setApprovalBypassState,
     requestToolEditApproval(
       request: ToolEditApprovalRequest,
       interactionOptions?: HostInteractionOptions,

--- a/packages/extension/src/progressView/frontend/slices/permissionSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/permissionSlice.ts
@@ -91,10 +91,16 @@ export const permissionHandlers = {
   [PROGRESS_VIEW_COMMANDS.UPDATE_BYPASS]: (data) => {
     updateToolUseState(data.stream, (prev) =>
       create(prev, (draft) => {
-        if (data.type === 'toolEdit') {
-          draft.toolEditBypass = data.bypassActive;
-        } else {
-          draft.superYoloBypass = data.bypassActive;
+        switch (data.type) {
+          case 'bash':
+            draft.bashBypass = data.bypassActive;
+            break;
+          case 'toolEdit':
+            draft.toolEditBypass = data.bypassActive;
+            break;
+          case 'superYolo':
+            draft.superYoloBypass = data.bypassActive;
+            break;
         }
       }),
     );

--- a/packages/extension/src/progressView/frontend/slices/syncSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/syncSlice.ts
@@ -56,6 +56,7 @@ export const syncHandlers = {
         todos: workPlan.todos,
         plan: workPlan.plan,
         queuedFollowUps: workPlan.queuedFollowUps,
+        bashBypass: controls.bashBypass,
         toolEditBypass: controls.toolEditBypass,
         superYoloBypass: controls.superYoloBypass,
         goalActive: goal.active,

--- a/packages/trace-viewer/src/replayTrace.ts
+++ b/packages/trace-viewer/src/replayTrace.ts
@@ -217,6 +217,7 @@ export function replayTrace(trace: TraceDocument): void {
             queuedFollowUps: [],
           },
           controls: {
+            bashBypass: false,
             toolEditBypass: false,
             superYoloBypass: false,
             goal: { active: false },

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -151,7 +151,8 @@ export class SessionHandle {
     const status = new StreamStatusMachine(events);
     const transcripts = init.transcripts;
     const followUps = init.followUps ?? new ToolUseFollowUpQueue();
-    const approvals = createSessionApprovals();
+    const interactions = init.interactions ?? new SessionHostInteractions();
+    const approvals = createSessionApprovals(interactions);
     const executions =
       init.executions ??
       new ExecutionRegistry({ streamStatus: status, events });
@@ -180,7 +181,7 @@ export class SessionHandle {
     // host has to construct, attach, and flush one of its own.
     this.snapshots = init.snapshots ?? new StreamSnapshotStore();
     this.detachSnapshotEvents = this.snapshots.attachSessionEvents(events);
-    this.interactions = init.interactions ?? new SessionHostInteractions();
+    this.interactions = interactions;
     this.approvals = approvals;
     this.modelRetries = init.modelRetries ?? new ModelRetryGate();
     this.workflowControls =

--- a/src/agent/runtime/runtimeInteractionEvents.ts
+++ b/src/agent/runtime/runtimeInteractionEvents.ts
@@ -1,4 +1,4 @@
-import type { StreamTabId, ToolEditPermission } from '@shared/schemas';
+import type { ToolEditPermission } from '@shared/schemas';
 
 /**
  * Host interaction and approval UI requests emitted by runtime/tool code.
@@ -10,16 +10,4 @@ import type { StreamTabId, ToolEditPermission } from '@shared/schemas';
 export interface RuntimeInteractionEventPayloads {
   showToolEditPermission: ToolEditPermission;
   resolveToolEditPermission: { requestId: string };
-  updateToolEditApprovalBypassState: {
-    streamId: StreamTabId;
-    bypassActive: boolean;
-  };
-  updateBashApprovalBypassState: {
-    streamId: StreamTabId;
-    bypassActive: boolean;
-  };
-  updateSuperYoloBypassState: {
-    streamId: StreamTabId;
-    bypassActive: boolean;
-  };
 }

--- a/src/agent/runtime/streamApprovalQueue.ts
+++ b/src/agent/runtime/streamApprovalQueue.ts
@@ -14,13 +14,11 @@ import PQueue from 'p-queue';
 
 import type { StreamTabId } from '@shared/schemas';
 
+import {
+  type ApprovalBypassKind,
+  SessionHostInteractions,
+} from './HostInteractions';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
-
-/** Progress events that announce per-stream approval-bypass changes. */
-type ApprovalBypassEvent =
-  | 'updateToolEditApprovalBypassState'
-  | 'updateBashApprovalBypassState'
-  | 'updateSuperYoloBypassState';
 
 /** The three independently-tracked bypass kinds `SessionApprovals` owns. */
 type BypassAncestryKind = 'toolEdit' | 'bash' | 'proposal';
@@ -32,7 +30,7 @@ const ALL_BYPASS_ANCESTRY_KINDS: readonly BypassAncestryKind[] = [
 ];
 
 /**
- * Per-stream bypass state bound to the progress event that announces it.
+ * Per-stream bypass state bound to the host interaction that announces it.
  *
  * Single implementation behind the tool-edit, bash, and proposal (super-YOLO)
  * bypass values, so set/clear semantics and UI notification stay uniform
@@ -47,8 +45,8 @@ const ALL_BYPASS_ANCESTRY_KINDS: readonly BypassAncestryKind[] = [
 export interface StreamApprovalBypass {
   isBypassed(streamId: StreamTabId): boolean;
   /**
-   * Set bypass for a stream. Emits the bound progress event when a
-   * `runtimeHost` is provided (unless `silent`); omit the host for
+   * Set bypass for a stream. Notifies the active host interaction when a
+   * `runtimeHost` is provided (unless `silent`); omit the runtime host for
    * pre-activation setup where no UI exists yet.
    */
   setBypass(
@@ -62,7 +60,8 @@ export interface StreamApprovalBypass {
 }
 
 function createStreamApprovalBypass(
-  event: ApprovalBypassEvent,
+  kind: ApprovalBypassKind,
+  interactions: Pick<SessionHostInteractions, 'setApprovalBypassState'>,
   resolveParent: (streamId: StreamTabId) => StreamTabId | undefined,
   resolveDescendants: (streamId: StreamTabId) => readonly StreamTabId[],
 ): StreamApprovalBypass {
@@ -93,12 +92,17 @@ function createStreamApprovalBypass(
     );
     byStream.set(streamId, enabled);
     if (runtimeHost && !options?.silent) {
-      runtimeHost.emit(event, { streamId, bypassActive: enabled });
+      interactions.setApprovalBypassState({
+        streamId,
+        kind,
+        bypassActive: enabled,
+      });
       for (const descendant of descendants) {
         const bypassActive = resolve(descendant);
         if (previousDescendantStates.get(descendant) !== bypassActive) {
-          runtimeHost.emit(event, {
+          interactions.setApprovalBypassState({
             streamId: descendant,
+            kind,
             bypassActive,
           });
         }
@@ -127,7 +131,8 @@ interface StreamApprovalController {
 }
 
 interface StreamApprovalControllerOptions {
-  bypassEvent: ApprovalBypassEvent;
+  kind: ApprovalBypassKind;
+  interactions: Pick<SessionHostInteractions, 'setApprovalBypassState'>;
   resolveParent: (streamId: StreamTabId) => StreamTabId | undefined;
   resolveDescendants: (streamId: StreamTabId) => readonly StreamTabId[];
 }
@@ -139,7 +144,8 @@ function createStreamApprovalController(
 
   return {
     bypass: createStreamApprovalBypass(
-      options.bypassEvent,
+      options.kind,
+      options.interactions,
       options.resolveParent,
       options.resolveDescendants,
     ),
@@ -223,7 +229,12 @@ export interface SessionApprovals {
   clearAll(): void;
 }
 
-export function createSessionApprovals(): SessionApprovals {
+export function createSessionApprovals(
+  interactions: Pick<
+    SessionHostInteractions,
+    'setApprovalBypassState'
+  > = new SessionHostInteractions(),
+): SessionApprovals {
   // One ancestry graph per bypass kind — deliberately NOT shared — so that
   // e.g. linking `bash` ancestry for a delegated subagent can never let it
   // also inherit `toolEdit` or `proposal` bypass from the same parent.
@@ -256,17 +267,20 @@ export function createSessionApprovals(): SessionApprovals {
     };
 
   const toolEdit = createStreamApprovalController({
-    bypassEvent: 'updateToolEditApprovalBypassState',
+    kind: 'toolEdit',
+    interactions,
     resolveParent: resolveParentFor('toolEdit'),
     resolveDescendants: resolveDescendantsFor('toolEdit'),
   });
   const bash = createStreamApprovalController({
-    bypassEvent: 'updateBashApprovalBypassState',
+    kind: 'bash',
+    interactions,
     resolveParent: resolveParentFor('bash'),
     resolveDescendants: resolveDescendantsFor('bash'),
   });
   const proposal = createStreamApprovalBypass(
-    'updateSuperYoloBypassState',
+    'superYolo',
+    interactions,
     resolveParentFor('proposal'),
     resolveDescendantsFor('proposal'),
   );

--- a/src/controllers/progressView/ProgressViewCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewCommandHandlers.ts
@@ -171,7 +171,6 @@ export function createProgressViewCommandHandlers(
       session,
     });
     setBashApprovalSessionBypass(stream, enabled, runtimeHost, {
-      silent: true,
       session,
     });
     await showInfo?.(

--- a/src/controllers/progressView/backend/ProgressBackend.ts
+++ b/src/controllers/progressView/backend/ProgressBackend.ts
@@ -1,4 +1,5 @@
 import { RUN_FACT_EVENT_TYPES } from '@agent/trace';
+import type { HostApprovalBypassStateUpdate } from '@agent/runtime/HostInteractions';
 import {
   defaultSession,
   type SessionHandle,
@@ -99,6 +100,9 @@ export class ProgressBackend {
   readonly factApplier: ProgressFactApplier;
   readonly interactionHandler: ProgressInteractionHandler;
   readonly approvalHandlers: ApprovalRequestHandlerSet;
+  readonly setApprovalBypassState: (
+    update: HostApprovalBypassStateUpdate,
+  ) => void;
   private readonly session: SessionHandle;
   private readonly lifecycle: ProgressBackendLifecycleOptions;
   private readonly postMessage: (message: ProgressViewOutboundMessage) => void;
@@ -153,6 +157,7 @@ export class ProgressBackend {
       options.getStreamControls,
     );
     this.interactionHandler = new ProgressInteractionHandler(ui.callbacks);
+    this.setApprovalBypassState = ui.setApprovalBypassState;
     this.onSetActiveStream = options.onSetActiveStream;
   }
 

--- a/src/controllers/progressView/backend/WebviewUpdater.ts
+++ b/src/controllers/progressView/backend/WebviewUpdater.ts
@@ -178,7 +178,7 @@ export class WebviewUpdater {
 
   updateBypassState(
     stream: StreamTabId,
-    type: 'toolEdit' | 'superYolo',
+    type: 'bash' | 'toolEdit' | 'superYolo',
     bypassActive: boolean,
   ): void {
     this.sendMessage({

--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -62,6 +62,7 @@ export type ProgressEventSubscription = {
 };
 
 interface ProgressStreamBypassControls {
+  bashBypass: boolean;
   toolEditBypass: boolean;
   superYoloBypass: boolean;
 }
@@ -87,6 +88,7 @@ type RunFactHandlers = {
 
 function getDefaultProgressStreamControls(): ProgressStreamControls {
   return {
+    bashBypass: false,
     toolEditBypass: false,
     superYoloBypass: false,
     goalActive: false,
@@ -740,6 +742,7 @@ export class ProgressFactApplier {
         queuedFollowUps: this.state.followUps.getAll(stream),
       },
       controls: {
+        bashBypass: controls.bashBypass,
         toolEditBypass: controls.toolEditBypass,
         superYoloBypass: controls.superYoloBypass,
         goal: controls.goalActive

--- a/src/controllers/progressView/backend/events/ProgressInteractionHandler.ts
+++ b/src/controllers/progressView/backend/events/ProgressInteractionHandler.ts
@@ -4,27 +4,19 @@ import { withEventErrorHandling } from './errorHandling';
 
 /**
  * UI callbacks for the interaction events that still enter the progress view:
- * tool-edit show/resolve and the two approval-bypass state pushes. Durable
- * run and stream facts are handled by `ProgressFactApplier`.
+ * tool-edit show/resolve callbacks. Durable run and stream facts are handled
+ * by `ProgressFactApplier`; approval-bypass state uses `HostInteractions`.
  */
 export interface UICallbacks {
   showToolEditPermission: (
     payload: RuntimeInteractionEventPayloads['showToolEditPermission'],
   ) => void;
   resolveToolEditPermission: (requestId: string) => void;
-  updateToolEditApprovalBypassState: (
-    streamId: string,
-    bypassActive: boolean,
-  ) => void;
-  updateSuperYoloBypassState: (streamId: string, bypassActive: boolean) => void;
 }
 
 export type ProgressBackendInteractionPayloads = Pick<
   RuntimeInteractionEventPayloads,
-  | 'showToolEditPermission'
-  | 'resolveToolEditPermission'
-  | 'updateToolEditApprovalBypassState'
-  | 'updateSuperYoloBypassState'
+  'showToolEditPermission' | 'resolveToolEditPermission'
 >;
 
 export type ProgressBackendInteractionEvent =
@@ -33,8 +25,6 @@ export type ProgressBackendInteractionEvent =
 const PROGRESS_BACKEND_INTERACTION_EVENTS = [
   'showToolEditPermission',
   'resolveToolEditPermission',
-  'updateToolEditApprovalBypassState',
-  'updateSuperYoloBypassState',
 ] as const satisfies readonly ProgressBackendInteractionEvent[];
 
 const ProgressBackendInteractionEventSet: ReadonlySet<string> = new Set(
@@ -83,24 +73,6 @@ export class ProgressInteractionHandler {
         context: 'failed to resolve approval prompt',
         handle: (payload) =>
           this.uiCallbacks.resolveToolEditPermission(payload.requestId),
-      },
-      updateToolEditApprovalBypassState: {
-        module: 'ProgressInteractionHandler',
-        context: 'failed to update approval bypass state',
-        handle: (payload) =>
-          this.uiCallbacks.updateToolEditApprovalBypassState(
-            payload.streamId,
-            payload.bypassActive,
-          ),
-      },
-      updateSuperYoloBypassState: {
-        module: 'ProgressInteractionHandler',
-        context: 'failed to update super yolo bypass state',
-        handle: (payload) =>
-          this.uiCallbacks.updateSuperYoloBypassState(
-            payload.streamId,
-            payload.bypassActive,
-          ),
       },
     };
   }

--- a/src/controllers/progressView/backend/progressBackendUiConfig.ts
+++ b/src/controllers/progressView/backend/progressBackendUiConfig.ts
@@ -1,6 +1,7 @@
 import type { AgentTrace } from '@agent/trace';
 import {
   type HostBashApprovalResult,
+  type HostApprovalBypassStateUpdate,
   matchesCancelSelector,
   type HostInteractionCancelSelector,
   type HostUserQuestionResult,
@@ -266,12 +267,13 @@ export async function replayApprovalRequestHandlers(
 
 interface ProgressBackendUiConfig {
   callbacks: UICallbacks;
+  setApprovalBypassState(update: HostApprovalBypassStateUpdate): void;
   hasPendingPermissions(streamId: string): boolean;
 }
 
 interface ProgressBackendUiConfigParams {
   handlers: ApprovalRequestHandlerSet;
-  /** Transport for the bypass-state pushes (handlers own their own transport). */
+  /** Transport for approval-bypass state (handlers own their own transport). */
   webviewUpdater: WebviewUpdater;
   /** Gate shared with the handlers; also guards the bypass-state pushes. */
   canSend: () => boolean;
@@ -295,16 +297,11 @@ export function createProgressBackendUiConfig(
     callbacks: {
       showToolEditPermission: (p) => handlers.toolEdit.show(p),
       resolveToolEditPermission: (id) => handlers.toolEdit.dismiss(id),
-      updateToolEditApprovalBypassState: (streamId, bypassActive) => {
-        if (canSend()) {
-          webviewUpdater.updateBypassState(streamId, 'toolEdit', bypassActive);
-        }
-      },
-      updateSuperYoloBypassState: (streamId, bypassActive) => {
-        if (canSend()) {
-          webviewUpdater.updateBypassState(streamId, 'superYolo', bypassActive);
-        }
-      },
+    },
+    setApprovalBypassState: ({ streamId, kind, bypassActive }) => {
+      if (canSend()) {
+        webviewUpdater.updateBypassState(streamId, kind, bypassActive);
+      }
     },
     hasPendingPermissions: (streamId) =>
       APPROVAL_REQUEST_HANDLER_KEYS.some((key) =>

--- a/src/controllers/progressView/progressStreamControls.ts
+++ b/src/controllers/progressView/progressStreamControls.ts
@@ -3,6 +3,7 @@ import type { ProgressStreamControls } from '@controllers/progressView/backend/e
 import type { StreamTabId } from '@shared/schemas';
 import {
   isApprovalBypassedForStream,
+  isBashApprovalBypassedForStream,
   proposalApprovals,
 } from '@tools/approval';
 import { GoalStore } from '@tools/goal';
@@ -13,6 +14,7 @@ export function getProgressStreamControls(
 ): ProgressStreamControls {
   const goal = GoalStore.getForStream(streamId);
   const bypasses = {
+    bashBypass: isBashApprovalBypassedForStream(streamId, session),
     toolEditBypass: isApprovalBypassedForStream(streamId, session),
     superYoloBypass: proposalApprovals(session).isBypassed(streamId),
   };

--- a/src/shared/schemas/progressView/outbound.ts
+++ b/src/shared/schemas/progressView/outbound.ts
@@ -236,7 +236,7 @@ const UpdatePermissionMessageSchema = z.discriminatedUnion('action', [
     id: z.string(),
   }),
 ]);
-const BypassTypeSchema = z.enum(['toolEdit', 'superYolo']);
+const BypassTypeSchema = z.enum(['bash', 'toolEdit', 'superYolo']);
 
 const UpdateBypassMessageSchema = StreamScopedBaseSchema.extend({
   command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_BYPASS),
@@ -321,6 +321,7 @@ const ToolUseStreamContentMessageSchema = z.strictObject({
     queuedFollowUps: z.array(z.string()),
   }),
   controls: z.strictObject({
+    bashBypass: z.boolean(),
     toolEditBypass: z.boolean(),
     superYoloBypass: z.boolean(),
     goal: GoalStateSchema,

--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -194,6 +194,7 @@ const ToolUseStreamStateSchema = BaseStreamStateSchema.extend({
   todos: z.array(TodoItemSchema).prefault([]),
   plan: PlanSchema.nullable().prefault(null),
   queuedFollowUps: z.array(z.string()).prefault([]),
+  bashBypass: z.boolean().optional(),
   toolEditBypass: z.boolean().optional(),
   superYoloBypass: z.boolean().optional(),
   goalActive: z.boolean().optional(),

--- a/src/test-kernel/agent/followUp/ChildStreamYoloInheritance.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamYoloInheritance.vitest.ts
@@ -118,7 +118,8 @@ describe('child subagent stream approval inheritance', () => {
   });
 
   it('announces inherited edit-bypass changes for visible descendants', () => {
-    const { events, host } = createRecordingHost();
+    const { events, host, interactions } = createRecordingHost();
+    const detach = currentSession().useHostInteractions(interactions);
     const parent = 'stream:visible-parent' as StreamTabId;
     const child = 'stream:visible-child' as StreamTabId;
     const grandchild = 'stream:visible-grandchild' as StreamTabId;
@@ -129,27 +130,41 @@ describe('child subagent stream approval inheritance', () => {
     configureDelegatedChildApprovals(pinnedChild, parent);
     setToolEditApprovalSessionBypass(pinnedChild, true, host, { silent: true });
 
-    setToolEditApprovalSessionBypass(parent, false, host);
+    try {
+      setToolEditApprovalSessionBypass(parent, false, host);
 
-    expect(
-      events.filter(
-        ({ event }) => event === 'updateToolEditApprovalBypassState',
-      ),
-    ).toEqual([
-      {
-        event: 'updateToolEditApprovalBypassState',
-        payload: { streamId: parent, bypassActive: false },
-      },
-      {
-        event: 'updateToolEditApprovalBypassState',
-        payload: { streamId: child, bypassActive: false },
-      },
-      {
-        event: 'updateToolEditApprovalBypassState',
-        payload: { streamId: grandchild, bypassActive: false },
-      },
-    ]);
-    expect(isApprovalBypassedForStream(pinnedChild)).toBe(true);
+      expect(
+        events.filter(({ event }) => event === 'setApprovalBypassState'),
+      ).toEqual([
+        {
+          event: 'setApprovalBypassState',
+          payload: {
+            streamId: parent,
+            kind: 'toolEdit',
+            bypassActive: false,
+          },
+        },
+        {
+          event: 'setApprovalBypassState',
+          payload: {
+            streamId: child,
+            kind: 'toolEdit',
+            bypassActive: false,
+          },
+        },
+        {
+          event: 'setApprovalBypassState',
+          payload: {
+            streamId: grandchild,
+            kind: 'toolEdit',
+            bypassActive: false,
+          },
+        },
+      ]);
+      expect(isApprovalBypassedForStream(pinnedChild)).toBe(true);
+    } finally {
+      detach();
+    }
   });
 
   it('lets a conversation round inherit bypass from the previous round via the session-level ancestry link', () => {

--- a/src/test-kernel/agent/followUp/HumanPromptProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/HumanPromptProgressEvents.vitest.ts
@@ -217,29 +217,39 @@ describe('human prompt progress events', () => {
   it('publishes tool-edit bypass changes through the explicit runtime host', () => {
     const explicit = createRecordingHost();
     const streamId = 'stream:tool-edit-bypass' as StreamTabId;
+    const detach = defaultSession().useHostInteractions(explicit.interactions);
 
-    setToolEditApprovalSessionBypass(streamId, true, explicit.host);
+    try {
+      setToolEditApprovalSessionBypass(streamId, true, explicit.host);
 
-    expect(explicit.events).toEqual([
-      {
-        event: 'updateToolEditApprovalBypassState',
-        payload: { streamId, bypassActive: true },
-      },
-    ]);
+      expect(explicit.events).toEqual([
+        {
+          event: 'setApprovalBypassState',
+          payload: { streamId, kind: 'toolEdit', bypassActive: true },
+        },
+      ]);
+    } finally {
+      detach();
+    }
   });
 
   it('publishes bash bypass changes through the explicit runtime host', () => {
     const explicit = createRecordingHost();
     const streamId = 'stream:bash-bypass' as StreamTabId;
+    const detach = defaultSession().useHostInteractions(explicit.interactions);
 
-    setBashApprovalSessionBypass(streamId, true, explicit.host);
+    try {
+      setBashApprovalSessionBypass(streamId, true, explicit.host);
 
-    expect(explicit.events).toEqual([
-      {
-        event: 'updateBashApprovalBypassState',
-        payload: { streamId, bypassActive: true },
-      },
-    ]);
+      expect(explicit.events).toEqual([
+        {
+          event: 'setApprovalBypassState',
+          payload: { streamId, kind: 'bash', bypassActive: true },
+        },
+      ]);
+    } finally {
+      detach();
+    }
   });
 
   it('keeps bash and edit session bypasses independent', async () => {
@@ -323,14 +333,19 @@ describe('human prompt progress events', () => {
   it('publishes proposal bypass changes through the explicit runtime host', () => {
     const explicit = createRecordingHost();
     const streamId = 'stream:proposal-bypass' as StreamTabId;
+    const detach = defaultSession().useHostInteractions(explicit.interactions);
 
-    proposalApprovals().setBypass(streamId, true, explicit.host);
+    try {
+      proposalApprovals().setBypass(streamId, true, explicit.host);
 
-    expect(explicit.events).toEqual([
-      {
-        event: 'updateSuperYoloBypassState',
-        payload: { streamId, bypassActive: true },
-      },
-    ]);
+      expect(explicit.events).toEqual([
+        {
+          event: 'setApprovalBypassState',
+          payload: { streamId, kind: 'superYolo', bypassActive: true },
+        },
+      ]);
+    } finally {
+      detach();
+    }
   });
 });

--- a/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
@@ -423,6 +423,11 @@ describe('ToolUseWaitNode', () => {
       lastError: { message: 'cycle failed', userRetryable: false },
     });
     const runtimeHost = { emit: vi.fn() };
+    const setApprovalBypassState = vi.fn();
+    const session = sessionWithInteractions({
+      setApprovalBypassState,
+      cancel: vi.fn(),
+    });
     const logger = new TraceEmitter();
     const hub = new SessionEventHub();
     const recorded = recordSessionEvents(hub, { scope: 'run' });
@@ -449,7 +454,7 @@ describe('ToolUseWaitNode', () => {
             lastResponse: undefined,
             touchedFiles: [],
           }),
-        { stopAfterCycle: true },
+        { session, stopAfterCycle: true },
       );
 
       const goal = GoalStore.getForStream(streamId);
@@ -461,14 +466,16 @@ describe('ToolUseWaitNode', () => {
           streamId,
         }),
       );
-      expect(runtimeHost.emit).toHaveBeenCalledWith(
-        'updateBashApprovalBypassState',
-        { streamId, bypassActive: false },
-      );
-      expect(runtimeHost.emit).not.toHaveBeenCalledWith(
-        'updateToolEditApprovalBypassState',
-        { streamId, bypassActive: false },
-      );
+      expect(setApprovalBypassState).toHaveBeenCalledWith({
+        streamId,
+        kind: 'bash',
+        bypassActive: false,
+      });
+      expect(setApprovalBypassState).not.toHaveBeenCalledWith({
+        streamId,
+        kind: 'toolEdit',
+        bypassActive: false,
+      });
     } finally {
       recorded.detach();
       detachTrace();

--- a/src/test-kernel/agent/progressTestUtils.ts
+++ b/src/test-kernel/agent/progressTestUtils.ts
@@ -218,6 +218,8 @@ export function createRecordingHost(): {
     },
   };
   const interactions: HostInteractions = {
+    setApprovalBypassState: (update) =>
+      events.push({ event: 'setApprovalBypassState', payload: update }),
     requestBashApproval: (request) => {
       const requestId = `bash-${pendingBashes.size + 1}`;
       const streamId = request.streamId ?? '';
@@ -370,7 +372,7 @@ export function sessionWithInteractions(
   if (interactions) owner.use(interactions);
   return {
     interactions: owner,
-    approvals: createSessionApprovals(),
+    approvals: createSessionApprovals(owner),
     modelRetries: new ModelRetryGate(),
     status,
     transcripts: { ensureLoaded: async () => {} },

--- a/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionInteractions.vitest.ts
@@ -116,6 +116,7 @@ function createPortSession(): {
   session: SessionHandle;
   uiEvents: UiEvent[];
   emitted: string[];
+  setApprovalBypassState: ReturnType<typeof vi.fn>;
   interactions: DesktopHostInteractions;
 } {
   const uiEvents: UiEvent[] = [];
@@ -125,9 +126,11 @@ function createPortSession(): {
   };
   const handlers = createHandlerSet(uiEvents);
   const session = createTestSession();
+  const setApprovalBypassState = vi.fn();
   const interactions = createDesktopHostInteractions({
     runtimeHost,
     session,
+    setApprovalBypassState,
     showInfoMessage: vi.fn(),
     getApprovalHandlers: () => handlers,
     getToolEditApprovals: () => ({
@@ -141,7 +144,13 @@ function createPortSession(): {
     }),
   });
   session.useHostInteractions(interactions);
-  return { session, uiEvents, emitted, interactions };
+  return {
+    session,
+    uiEvents,
+    emitted,
+    setApprovalBypassState,
+    interactions,
+  };
 }
 
 function createControllablePlanAdapter(
@@ -219,6 +228,19 @@ const criticism = {
 };
 
 describe('session.interactions immediate capabilities', () => {
+  it('forwards approval bypass state through the desktop port', () => {
+    const { interactions, setApprovalBypassState } = createPortSession();
+    const update = {
+      streamId,
+      kind: 'toolEdit',
+      bypassActive: true,
+    } as const;
+
+    interactions.setApprovalBypassState?.(update);
+
+    expect(setApprovalBypassState).toHaveBeenCalledWith(update);
+  });
+
   it('delegates immediate capabilities to the active adapter', async () => {
     const session = createTestSession();
     const diagnostics = [diagnostic];

--- a/src/test-kernel/cli/RunExecution.vitest.mts
+++ b/src/test-kernel/cli/RunExecution.vitest.mts
@@ -144,6 +144,7 @@ function stubRunExecutionDeps(): void {
   });
   mocks.createCliRuntimeHost.mockReturnValue({
     emit: mocks.emit,
+    emitApprovalBypassState: vi.fn(),
     attachRunProgressRenderer: vi.fn(() => mocks.detachRunProgressRenderer),
     prepareInteractivePrompt: mocks.prepareInteractivePrompt,
     close: mocks.close,
@@ -308,15 +309,32 @@ describe('executeCliRequest', () => {
 
     expect(mocks.createHeadlessCliHostInteractions).toHaveBeenCalledWith(
       context,
-      expect.objectContaining({ beforePrompt: expect.any(Function) }),
+      expect.objectContaining({
+        beforePrompt: expect.any(Function),
+        setApprovalBypassState: expect.any(Function),
+      }),
     );
 
     const hooks = mocks.createHeadlessCliHostInteractions.mock
       .calls[0]?.[1] as {
       beforePrompt?: () => void;
+      setApprovalBypassState?: (update: {
+        streamId: string;
+        kind: 'bash';
+        bypassActive: boolean;
+      }) => void;
     };
     hooks.beforePrompt?.();
     expect(mocks.prepareInteractivePrompt).toHaveBeenCalledTimes(1);
+    const update = {
+      streamId: 'stream:bypass',
+      kind: 'bash',
+      bypassActive: true,
+    } as const;
+    hooks.setApprovalBypassState?.(update);
+    expect(
+      mocks.createCliRuntimeHost.mock.results[0]?.value.emitApprovalBypassState,
+    ).toHaveBeenCalledWith(update);
   });
 
   it('restores CLI host interactions before closing the runtime host', async () => {

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -1185,6 +1185,55 @@ describe('CLI run progress renderer', () => {
     ]);
   });
 
+  it('preserves approval bypass records in ndjson mode', async () => {
+    const output = await captureStreamWrites(process.stdout, async () => {
+      const host = createCliRuntimeHost(
+        context({ mode: 'headless', outputFormat: 'ndjson' }),
+      );
+
+      host.emitApprovalBypassState({
+        streamId: 'stream-1',
+        kind: 'bash',
+        bypassActive: true,
+      });
+      host.emitApprovalBypassState({
+        streamId: 'stream-1',
+        kind: 'toolEdit',
+        bypassActive: false,
+      });
+      host.emitApprovalBypassState({
+        streamId: 'stream-1',
+        kind: 'superYolo',
+        bypassActive: true,
+      });
+
+      await host.close();
+    });
+
+    const records = output
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+
+    expect(records).toEqual([
+      expect.objectContaining({
+        kind: 'progress',
+        event: 'updateBashApprovalBypassState',
+        payload: { streamId: 'stream-1', bypassActive: true },
+      }),
+      expect.objectContaining({
+        kind: 'progress',
+        event: 'updateToolEditApprovalBypassState',
+        payload: { streamId: 'stream-1', bypassActive: false },
+      }),
+      expect.objectContaining({
+        kind: 'progress',
+        event: 'updateSuperYoloBypassState',
+        payload: { streamId: 'stream-1', bypassActive: true },
+      }),
+    ]);
+  });
+
   it('applies an explicit ndjson policy to every runtime presentation request', async () => {
     const output = await captureStreamWrites(process.stdout, async () => {
       const host = createCliRuntimeHost(

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
@@ -109,6 +109,7 @@ function context(): CliContext {
 function host(): CliRuntimeHost {
   return {
     emit: vi.fn(),
+    emitApprovalBypassState: vi.fn(),
     close: vi.fn(async () => undefined),
   } as unknown as CliRuntimeHost;
 }
@@ -283,13 +284,11 @@ describe('TUI retry approvals', () => {
       userMessage: undefined,
     });
     expect(streams.get().get('bash-bypass-stream')?.bypass.bash).toBe(true);
-    expect(runtimeHost.emit).toHaveBeenCalledWith(
-      'updateBashApprovalBypassState',
-      {
-        streamId: 'bash-bypass-stream',
-        bypassActive: true,
-      },
-    );
+    expect(runtimeHost.emitApprovalBypassState).toHaveBeenCalledWith({
+      streamId: 'bash-bypass-stream',
+      kind: 'bash',
+      bypassActive: true,
+    });
   });
 
   it('updates TUI bash bypass state when goal auto-approval is enabled and cleared', async () => {
@@ -300,13 +299,11 @@ describe('TUI retry approvals', () => {
       runtimeHost,
     );
     expect(streams.get().get('goal-bypass-stream')?.bypass.bash).toBe(true);
-    expect(runtimeHost.emit).toHaveBeenCalledWith(
-      'updateBashApprovalBypassState',
-      {
-        streamId: 'goal-bypass-stream',
-        bypassActive: true,
-      },
-    );
+    expect(runtimeHost.emitApprovalBypassState).toHaveBeenCalledWith({
+      streamId: 'goal-bypass-stream',
+      kind: 'bash',
+      bypassActive: true,
+    });
 
     await setGoalSessionBashAutoApproval(
       'goal-bypass-stream',
@@ -314,13 +311,11 @@ describe('TUI retry approvals', () => {
       runtimeHost,
     );
     expect(streams.get().get('goal-bypass-stream')?.bypass.bash).toBe(false);
-    expect(runtimeHost.emit).toHaveBeenCalledWith(
-      'updateBashApprovalBypassState',
-      {
-        streamId: 'goal-bypass-stream',
-        bypassActive: false,
-      },
-    );
+    expect(runtimeHost.emitApprovalBypassState).toHaveBeenCalledWith({
+      streamId: 'goal-bypass-stream',
+      kind: 'bash',
+      bypassActive: false,
+    });
   });
 
   it('updates TUI edit bypass state at the approval decision site', async () => {
@@ -346,13 +341,11 @@ describe('TUI retry approvals', () => {
       appliedContent: 'new',
     });
     expect(streams.get().get('edit-bypass-stream')?.bypass.toolEdit).toBe(true);
-    expect(runtimeHost.emit).toHaveBeenCalledWith(
-      'updateToolEditApprovalBypassState',
-      {
-        streamId: 'edit-bypass-stream',
-        bypassActive: true,
-      },
-    );
+    expect(runtimeHost.emitApprovalBypassState).toHaveBeenCalledWith({
+      streamId: 'edit-bypass-stream',
+      kind: 'toolEdit',
+      bypassActive: true,
+    });
   });
 
   it('enables the complete delegated-task approval mode at the proposal decision site', async () => {
@@ -391,14 +384,21 @@ describe('TUI retry approvals', () => {
     expect(isBashApprovalBypassedForStream('proposal-bypass-stream')).toBe(
       true,
     );
-    expect(runtimeHost.emit).toHaveBeenCalledWith(
-      'updateSuperYoloBypassState',
-      { streamId: 'proposal-bypass-stream', bypassActive: true },
-    );
-    expect(runtimeHost.emit).toHaveBeenCalledWith(
-      'updateToolEditApprovalBypassState',
-      { streamId: 'proposal-bypass-stream', bypassActive: true },
-    );
+    expect(runtimeHost.emitApprovalBypassState).toHaveBeenCalledWith({
+      streamId: 'proposal-bypass-stream',
+      kind: 'superYolo',
+      bypassActive: true,
+    });
+    expect(runtimeHost.emitApprovalBypassState).toHaveBeenCalledWith({
+      streamId: 'proposal-bypass-stream',
+      kind: 'toolEdit',
+      bypassActive: true,
+    });
+    expect(runtimeHost.emitApprovalBypassState).toHaveBeenCalledWith({
+      streamId: 'proposal-bypass-stream',
+      kind: 'bash',
+      bypassActive: true,
+    });
   });
 
   it('approves delegated work already queued in the same stream', async () => {

--- a/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
@@ -377,10 +377,18 @@ describe('createProgressViewCommandHandlers - bypass toggles', () => {
 
   it('keeps tool-edit and bash bypass symmetric behind the edit shield', async () => {
     const stream = 'stream:edit-bypass';
-    const { events, host } = createRecordingRuntimeHost();
+    const { host } = createRecordingRuntimeHost();
+    const session = createTestSession();
+    const setApprovalBypassState = vi.fn();
+    session.useHostInteractions({
+      setApprovalBypassState,
+      cancel: vi.fn(),
+    });
     const showInfo = vi.fn();
     const handlers = createProgressViewCommandHandlers(
-      createActions({ bypass: { runtimeHost: host, showInfo } }),
+      createActions({
+        bypass: { runtimeHost: host, session, showInfo },
+      }),
     );
 
     expectDispatched(
@@ -392,14 +400,13 @@ describe('createProgressViewCommandHandlers - bypass toggles', () => {
     );
     await Promise.resolve();
 
-    expect(isApprovalBypassedForStream(stream)).toBe(true);
-    expect(isBashApprovalBypassedForStream(stream)).toBe(true);
-    expect(events).toEqual([
-      {
-        event: 'updateToolEditApprovalBypassState',
-        payload: { streamId: stream, bypassActive: true },
-      },
-    ]);
+    expect(isApprovalBypassedForStream(stream, session)).toBe(true);
+    expect(isBashApprovalBypassedForStream(stream, session)).toBe(true);
+    expect(setApprovalBypassState).toHaveBeenCalledWith({
+      streamId: stream,
+      kind: 'toolEdit',
+      bypassActive: true,
+    });
     expect(showInfo).toHaveBeenCalledWith(
       'File edits and shell commands will be auto-approved for this run.',
     );
@@ -413,12 +420,14 @@ describe('createProgressViewCommandHandlers - bypass toggles', () => {
     );
     await Promise.resolve();
 
-    expect(isApprovalBypassedForStream(stream)).toBe(false);
-    expect(isBashApprovalBypassedForStream(stream)).toBe(false);
-    expect(events.at(-1)).toEqual({
-      event: 'updateToolEditApprovalBypassState',
-      payload: { streamId: stream, bypassActive: false },
+    expect(isApprovalBypassedForStream(stream, session)).toBe(false);
+    expect(isBashApprovalBypassedForStream(stream, session)).toBe(false);
+    expect(setApprovalBypassState).toHaveBeenCalledWith({
+      streamId: stream,
+      kind: 'toolEdit',
+      bypassActive: false,
     });
+    session.dispose();
   });
 
   it('forces edit and bash bypass on without inverting a decoupled stream', async () => {
@@ -451,10 +460,16 @@ describe('createProgressViewCommandHandlers - bypass toggles', () => {
 
   it('makes delegated task bypass enable edit and bash bypasses', async () => {
     const stream = 'stream:proposal-bypass';
-    const { events, host } = createRecordingRuntimeHost();
+    const { host } = createRecordingRuntimeHost();
+    const session = createTestSession();
+    const setApprovalBypassState = vi.fn();
+    session.useHostInteractions({
+      setApprovalBypassState,
+      cancel: vi.fn(),
+    });
     const showInfo = vi.fn();
     const actions = createActions({
-      bypass: { runtimeHost: host, showInfo },
+      bypass: { runtimeHost: host, session, showInfo },
     });
     const handlers = createProgressViewCommandHandlers(actions);
 
@@ -467,19 +482,16 @@ describe('createProgressViewCommandHandlers - bypass toggles', () => {
     );
     await Promise.resolve();
 
-    expect(proposalApprovals().isBypassed(stream)).toBe(true);
-    expect(isApprovalBypassedForStream(stream)).toBe(true);
-    expect(isBashApprovalBypassedForStream(stream)).toBe(true);
-    expect(events).toEqual([
-      {
-        event: 'updateSuperYoloBypassState',
-        payload: { streamId: stream, bypassActive: true },
-      },
-      {
-        event: 'updateToolEditApprovalBypassState',
-        payload: { streamId: stream, bypassActive: true },
-      },
-    ]);
+    expect(proposalApprovals(session).isBypassed(stream)).toBe(true);
+    expect(isApprovalBypassedForStream(stream, session)).toBe(true);
+    expect(isBashApprovalBypassedForStream(stream, session)).toBe(true);
+    expect(setApprovalBypassState.mock.calls.map(([update]) => update)).toEqual(
+      [
+        { streamId: stream, kind: 'superYolo', bypassActive: true },
+        { streamId: stream, kind: 'toolEdit', bypassActive: true },
+        { streamId: stream, kind: 'bash', bypassActive: true },
+      ],
+    );
     expect(showInfo).toHaveBeenCalledWith(
       'Agent tasks, file edits, and shell commands will be auto-approved for this run.',
     );
@@ -493,9 +505,9 @@ describe('createProgressViewCommandHandlers - bypass toggles', () => {
       handlers,
     );
     await Promise.resolve();
-    expect(proposalApprovals().isBypassed(stream)).toBe(true);
-    expect(isApprovalBypassedForStream(stream)).toBe(true);
-    expect(isBashApprovalBypassedForStream(stream)).toBe(true);
+    expect(proposalApprovals(session).isBypassed(stream)).toBe(true);
+    expect(isApprovalBypassedForStream(stream, session)).toBe(true);
+    expect(isBashApprovalBypassedForStream(stream, session)).toBe(true);
     expect(actions.approval.approvePendingDelegatedWork).toHaveBeenCalledWith(
       stream,
       'proposal-current',
@@ -510,22 +522,20 @@ describe('createProgressViewCommandHandlers - bypass toggles', () => {
     );
     await Promise.resolve();
 
-    expect(proposalApprovals().isBypassed(stream)).toBe(false);
-    expect(isApprovalBypassedForStream(stream)).toBe(false);
-    expect(isBashApprovalBypassedForStream(stream)).toBe(false);
-    expect(events.slice(-2)).toEqual([
-      {
-        event: 'updateSuperYoloBypassState',
-        payload: { streamId: stream, bypassActive: false },
-      },
-      {
-        event: 'updateToolEditApprovalBypassState',
-        payload: { streamId: stream, bypassActive: false },
-      },
+    expect(proposalApprovals(session).isBypassed(stream)).toBe(false);
+    expect(isApprovalBypassedForStream(stream, session)).toBe(false);
+    expect(isBashApprovalBypassedForStream(stream, session)).toBe(false);
+    expect(
+      setApprovalBypassState.mock.calls.slice(-3).map(([update]) => update),
+    ).toEqual([
+      { streamId: stream, kind: 'superYolo', bypassActive: false },
+      { streamId: stream, kind: 'toolEdit', bypassActive: false },
+      { streamId: stream, kind: 'bash', bypassActive: false },
     ]);
     expect(showInfo).toHaveBeenLastCalledWith(
       'Agent tasks, file edits, and shell commands will require approval for this run.',
     );
+    session.dispose();
   });
 });
 

--- a/src/test-kernel/progressView/AgentPresentationHostReplayGate.vitest.mts
+++ b/src/test-kernel/progressView/AgentPresentationHostReplayGate.vitest.mts
@@ -164,8 +164,6 @@ describe('extension presentation-event emit port (#9251 replay gate)', () => {
     const uiCallbacks: UICallbacks = {
       showToolEditPermission: (p) => toolEdit.show(p),
       resolveToolEditPermission: (id) => toolEdit.dismiss(id),
-      updateToolEditApprovalBypassState: () => {},
-      updateSuperYoloBypassState: () => {},
     };
     const interactionHandler = new ProgressInteractionHandler(uiCallbacks);
     const detachSink = setExtensionInteractionEventSink((event, payload) =>
@@ -178,6 +176,7 @@ describe('extension presentation-event emit port (#9251 replay gate)', () => {
       runtimeHost: presentationHost,
       session,
       getApprovalHandlers: () => createApprovalHandlers(toolEdit),
+      setApprovalBypassState: vi.fn(),
     });
     const detachInteractions = session.useHostInteractions(interactions);
 
@@ -244,6 +243,7 @@ describe('extension presentation-event emit port (#9251 replay gate)', () => {
         runtimeHost: presentationHost,
         session,
         getApprovalHandlers: () => createApprovalHandlers(),
+        setApprovalBypassState: vi.fn(),
       });
       const detach = session.useHostInteractions(interactions);
       try {

--- a/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
+++ b/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { SessionEvent } from '@agent/runtime/SessionEventHub';
 import type {
+  HostApprovalBypassStateUpdate,
   HostBashApprovalResult,
   HostUserQuestionResult,
   PlanApprovalResult,
@@ -167,12 +168,14 @@ function firstShowRequestId(show: ReturnType<typeof vi.fn>): string {
 function createInteractions(options: {
   runtimeHost?: ReturnType<typeof createRuntimeHost>;
   handlers?: ApprovalRequestHandlerSet;
+  setApprovalBypassState?: (update: HostApprovalBypassStateUpdate) => void;
   session: SessionHandle;
 }) {
   return createExtensionHostInteractions({
     runtimeHost: options.runtimeHost ?? createRuntimeHost(),
     session: options.session,
     getApprovalHandlers: () => options.handlers ?? createHandlers(),
+    setApprovalBypassState: options.setApprovalBypassState ?? vi.fn(),
   });
 }
 
@@ -195,6 +198,23 @@ describe('createExtensionHostInteractions', () => {
     expect(runtimeHost.emit).toHaveBeenCalledWith('requestShowError', {
       message: 'boom',
     });
+  });
+
+  it('forwards approval bypass state through the host port', () => {
+    const setApprovalBypassState = vi.fn();
+    const interactions = createInteractions({
+      session: createTestSession(),
+      setApprovalBypassState,
+    });
+    const update = {
+      streamId: 'stream:bypass',
+      kind: 'bash',
+      bypassActive: true,
+    } as const;
+
+    interactions.setApprovalBypassState?.(update);
+
+    expect(setApprovalBypassState).toHaveBeenCalledWith(update);
   });
 
   it('provides diagnostics and notification capabilities', async () => {

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -244,6 +244,41 @@ function emitRunFact<K extends RunFactEventName>(
 }
 
 describe('ProgressBackend', () => {
+  it('projects every approval bypass kind through one backend port', () => {
+    const { backend, messages } = createRecordingBackend();
+
+    for (const kind of ['bash', 'toolEdit', 'superYolo'] as const) {
+      backend.setApprovalBypassState({
+        streamId: 'stream:bypass',
+        kind,
+        bypassActive: true,
+      });
+    }
+
+    expect(messages).toEqual([
+      {
+        command: PROGRESS_VIEW_COMMANDS.UPDATE_BYPASS,
+        stream: 'stream:bypass',
+        type: 'bash',
+        bypassActive: true,
+      },
+      {
+        command: PROGRESS_VIEW_COMMANDS.UPDATE_BYPASS,
+        stream: 'stream:bypass',
+        type: 'toolEdit',
+        bypassActive: true,
+      },
+      {
+        command: PROGRESS_VIEW_COMMANDS.UPDATE_BYPASS,
+        stream: 'stream:bypass',
+        type: 'superYolo',
+        bypassActive: true,
+      },
+    ]);
+
+    backend.dispose();
+  });
+
   it('constructs the shared progress backend service graph', () => {
     const backend = new ProgressBackend({
       storage: new FakeStateStore(),
@@ -1488,9 +1523,8 @@ describe('ProgressBackend', () => {
     // A run that kept executing headless after a desktop window closed still
     // holds the host-channel emit closure that routes to handleInteractionEvent.
     expect(() =>
-      backend.handleInteractionEvent('updateToolEditApprovalBypassState', {
-        streamId,
-        bypassActive: true,
+      backend.handleInteractionEvent('resolveToolEditPermission', {
+        requestId: 'edit-after-close',
       }),
     ).not.toThrow();
 

--- a/src/test-kernel/progressView/ProgressViewMessageDispatcher.vitest.ts
+++ b/src/test-kernel/progressView/ProgressViewMessageDispatcher.vitest.ts
@@ -97,6 +97,7 @@ describe('SyncStreamContentMessageSchema', () => {
     runUsage: {},
     workPlan: { todos: [], plan: null, queuedFollowUps: [] },
     controls: {
+      bashBypass: false,
       toolEditBypass: false,
       superYoloBypass: false,
       goal: { active: false },

--- a/src/test-kernel/progressView/StreamContentSync.vitest.ts
+++ b/src/test-kernel/progressView/StreamContentSync.vitest.ts
@@ -276,6 +276,7 @@ describe('progress view stream-content projection', () => {
       (streamId) => {
         expect(streamId).toBe(controlledStream);
         return {
+          bashBypass: true,
           toolEditBypass: true,
           superYoloBypass: true,
           goalActive: true,

--- a/src/tools/approval/proposalApproval.ts
+++ b/src/tools/approval/proposalApproval.ts
@@ -44,5 +44,5 @@ export function setDelegatedWorkApprovalBypasses(
   // ancestry-resolved inheritance from the parent — super-YOLO granted here
   // must survive the parent later re-gating its own edits.
   toolEdit.bypass.setBypass(streamId, enabled, runtimeHost);
-  bash.bypass.setBypass(streamId, enabled, runtimeHost, { silent: true });
+  bash.bypass.setBypass(streamId, enabled, runtimeHost);
 }

--- a/src/tools/goal/goalAutoApproval.ts
+++ b/src/tools/goal/goalAutoApproval.ts
@@ -1,5 +1,4 @@
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { currentSession } from '@agent/runtime/SessionHandle';
 import type { StreamTabId } from '@shared/schemas/identifiers';
 
 /**
@@ -30,9 +29,4 @@ export async function setGoalSessionBashAutoApproval(
   const { setBashApprovalSessionBypass } =
     await import('@tools/approval/bashApproval');
   setBashApprovalSessionBypass(streamId, enabled, runtimeHost);
-  currentSession().interactions.setApprovalBypassState({
-    streamId,
-    kind: 'bash',
-    bypassActive: enabled,
-  });
 }


### PR DESCRIPTION
Closes #9248

## Summary

- routes bash, tool-edit, and delegated-work bypass changes through `HostInteractions.setApprovalBypassState`
- implements the surviving port for extension, desktop, interactive CLI, and headless CLI hosts
- preserves the three public CLI NDJSON event names and their exact payload shape
- synchronizes bash bypass state with the progress view and trace viewer alongside the existing bypass kinds

## Verification

- `npm run format`
- `npm run typecheck`
- `npm run lint -- --quiet`
- `npm run compile:fast`
- focused approval, host-port, backend, and CLI suites: 264 tests passed
- full suite: 7,653 tests passed; two pre-existing CLI signal-ownership tests timed out under full-suite contention and both passed immediately in isolation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches approval/session bypass plumbing across CLI, desktop, extension, and progress-view sync; behavior changes include bash bypass now being announced like other kinds (no silent coupling), which could affect UI timing but is covered by broad test updates.
> 
> **Overview**
> Approval bypass changes (**bash**, **tool-edit**, **super-YOLO**) no longer go out as separate `runtimeHost.emit` progress events. **`SessionApprovals`** / **`streamApprovalQueue`** call **`session.interactions.setApprovalBypassState`**, which each host implements (extension/desktop **`ProgressBackend`**, interactive TUI local state + **`emitApprovalBypassState`**, headless CLI NDJSON).
> 
> **Progress view** bypass is centralized on **`createProgressBackendUiConfig.setApprovalBypassState`** → **`UPDATE_BYPASS`**; **`ProgressInteractionHandler`** no longer handles the old bypass interaction events. **Bash bypass** is now a real control (`bashBypass` on sync/schema, permission slice switch, **`getProgressStreamControls`**); coupled tool-edit/bash toggles no longer use **`silent`** bash updates, so bash UI stays in sync.
> 
> **CLI NDJSON** keeps the three legacy event names and payloads via **`CliRuntimeHost.emitApprovalBypassState`**. Duplicate TUI **`setTuiApprovalBypassState`** calls at individual approval sites were removed in favor of the unified **`setApprovalBypassState`** hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4279d9004a8864c1c0c6d2139067b1c6efe6ad93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->