### PR TITLE
fix: retain file action tooltips

### DIFF
--- a/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
+++ b/packages/extension/src/webview/frontend/components/FileSelectGroup.ts
@@ -6,6 +6,7 @@ import { repeat } from 'lit/directives/repeat.js';
 
 import '@awesome.me/webawesome/dist/components/dropdown/dropdown.js';
 import '@awesome.me/webawesome/dist/components/dropdown-item/dropdown-item.js';
+import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 
 import { designTokens } from '@shared/styles';
 import type {


### PR DESCRIPTION
Follow-up to #9268.

The main label tooltip and helper descriptions remain removed. This restores the Web Awesome tooltip registration required by the two remaining file-action tooltips in `FileSelectGroup`, avoiding reliance on a transitive component import.

## Verification

- `npm run lint -- --quiet`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dependency import in a webview UI component with no logic or data-handling changes.
> 
> **Overview**
> **Restores the Web Awesome `tooltip` side-effect import** in `FileSelectGroup` so `<wa-tooltip>` elements used on the config dropdown triggers and per-row remove buttons register correctly after tooltip cleanup in #9268.
> 
> This is an explicit local import rather than depending on another module to pull in the tooltip package transitively; broader label/helper tooltips stay removed as in that change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 738900ee1cc902971eb384f50fe13a063c125d2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->