### PR TITLE
docs: recover lost fixes to agent-sdk-foundation-gap.md

### DIFF
--- a/docs/proposals/2026-07-26-agent-sdk-foundation-gap.md
+++ b/docs/proposals/2026-07-26-agent-sdk-foundation-gap.md
@@ -374,22 +374,6 @@ consumers, one of them inside the runtime itself. **Restate the acceptance targe
 and `executeCommand.ts` (45 LoC, 0 detaches), learns everything needed to write a frontend,
 and opening `runExecution.ts` teaches nothing extra — because nothing extra is left in it.
 
-## 8. What not to do
-
-Carried from north-star §5 and re-confirmed by these studies: no `@texra/core` barrel before
-the fence enforces; no `runSession()` facade; no repo-wide `StreamTabId` rename; no
-dependency-cruiser; no definitions-as-options API; no trace↔bus merge. Added by this study:
-
-- **Do not collapse to a single rail Codex-style.** Its purity is a subprocess artifact, and
-  it costs silently auto-denied approvals. Keep a blocking-decision callback rail.
-- **Do not unify the two shaping pipelines.** Extension and desktop already share one
-  renderer; Ink genuinely diverges.
-- **Do not treat export count as the target.** 236 exports did not stop the reference SDK
-  from being embeddable in four lines.
-- **Do not make `SessionHandle` the public surface without argument.** Anthropic built,
-  shipped, and then _removed_ `unstable_v2_createSession` / `SDKSession` in 0.3.142,
-  reverting to the single iterator. That experiment has already been run.
-
 ## 7.1 The interaction-surface design (tournament result, design of record)
 
 Produced by a judge-panel tournament: four independent designs (minimal-surface,
@@ -523,6 +507,22 @@ measuring the second will be disappointed. §9 remains untouched by this design.
   `commonViewMessages`, which publishes a namespace **nobody imports**, leaving that family with
   no working barrel path and all 10 consumers forced deep.
 
+## 8. What not to do
+
+Carried from north-star §5 and re-confirmed by these studies: no `@texra/core` barrel before
+the fence enforces; no `runSession()` facade; no repo-wide `StreamTabId` rename; no
+dependency-cruiser; no definitions-as-options API; no trace↔bus merge. Added by this study:
+
+- **Do not collapse to a single rail Codex-style.** Its purity is a subprocess artifact, and
+  it costs silently auto-denied approvals. Keep a blocking-decision callback rail.
+- **Do not unify the two shaping pipelines.** Extension and desktop already share one
+  renderer; Ink genuinely diverges.
+- **Do not treat export count as the target.** 236 exports did not stop the reference SDK
+  from being embeddable in four lines.
+- **Do not make `SessionHandle` the public surface without argument.** Anthropic built,
+  shipped, and then _removed_ `unstable_v2_createSession` / `SDKSession` in 0.3.142,
+  reverting to the single iterator. That experiment has already been run.
+
 ## 8.1 Where the mass is — and why there is no four-figure production win
 
 Measured at HEAD (tracked files, tests and fixtures excluded, `wc -l`):
@@ -541,7 +541,10 @@ Production mass by bucket: provider + product domain 63,246 (21.6%) · renderers
 
 **Duplication is not the lever.** A normalized-line clone census (K=6, ≥25-line blocks, 0
 pair-level false positives on inspection) finds lines participating in any cross-file clone =
-**2,823 / 294,420 = 0.96% of production**. The complete list of clusters above threshold is
+**2,823 / 294,420 = 0.96% of production**. (The census denominator counts total lines by a
+different methodology than the `wc -l` production count above — the two don't reconcile
+exactly, but the gap is immaterial to the 0.96% conclusion.) The complete list of clusters
+above threshold is
 ten pairs totalling 449 lines; the largest is **80** lines (`modelHandlerGoogleGenAI` ↔
 `modelHandlerGoogleInteractions`, two distinct Google APIs — justified). **There is no
 ≥1,000-LoC copy-paste cluster in this repository.** The "duplication" the studies report is
@@ -569,7 +572,7 @@ product risk** — and it buys no architecture, which should be said plainly whe
 | `@shared` names                                  |               586 |                     573 imported / 990 exported |
 
 Exact and re-confirmed: CLI `tui/state` 5,764; `restartRepair.ts` 415; `SessionStores.ts` 549;
-`@controllers/` consumers 0/44/44/0; 11 ALS reads of which 8 are `runScope`-only; 4
+`@controllers/` consumers 1/44/44/0; 11 ALS reads of which 8 are `runScope`-only; 4
 `StreamSnapshotStore` write-owners.
 
 ### Withdrawn as net-positive


### PR DESCRIPTION
## What happened

Commit `6b2891420e` on the now-merged branch `docs/agent-sdk-foundation-gap` contained three review-feedback fixes to `docs/proposals/2026-07-26-agent-sdk-foundation-gap.md`. It is **not an ancestor of `main`** (`git merge-base --is-ancestor 6b2891420e origin/main` fails) — PR #9243 merged an earlier state of the branch and this work was dropped.

The doc has changed since (`94ec483f73` and `66ec0e2dab` added unrelated status-rail corrections), so this recovers the **content**, not the commit: I read `git show 6b2891420e`, then re-applied the same three intents on top of current `main` rather than cherry-picking (which would have conflicted/clobbered the newer text).

## The three recovered intents

1. **Section ordering.** `§7.1`/`§7.2` now sit directly after `§7`, and `§8` after `§7.2`, so heading numbers are monotonic (previous order was `7 → 8 → 7.1 → 7.2 → 8.1 → 9`). Content moved only — no heading renumbered, retitled, or edited.
2. **`@controllers/` count mirror.** The §8.1 "Exact and re-confirmed" recap said `0/44/44/0`; fixed to `1/44/44/0` to match the correct count already in §3.3 (one CLI consumer, `packages/cli/src/onboarding/runOnboarding.tsx` importing `planOnboardingFunnelTransition`).
3. **Clone-census denominator note.** Added a one-sentence parenthetical noting the census denominator (294,420) uses a different line-counting methodology than the production LoC figure (292,864) above it, so the two don't need to reconcile exactly and the ~1,556-line gap doesn't move the 0.96% conclusion.

This is a recovery of already-reviewed work, not new analysis.

## Verification

- Confirmed all three issues were still present on `origin/main` before editing (none had been separately fixed by a later commit).
- Grepped for `§7.1`/`§7.2`/`§8`/`§8.1` cross-references after the move — none exist elsewhere in the doc, so nothing broke.
- Gates: `npx prettier --check`, `node docs/scripts/check-root-docs.mjs`, `node scripts/check-guidance-refs.mjs` — all pass.
- Docs-only change, no `src/`/`packages/` touched.

https://claude.ai/code/session_01XZ8Z6rhypTfkVq728XCcCd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to a proposal file; no runtime or API behavior changes.
> 
> **Overview**
> Recovers review feedback that was dropped when an earlier branch merged without commit `6b2891420e` — **content only**, no new analysis.
> 
> **Section order:** Moves **§8 What not to do** to sit after **§7.2** (and after **§7.1**), so the doc reads **§7 → §7.1 → §7.2 → §8 → §8.1** instead of jumping from §7 to §8 before the §7.x subsections. Text is unchanged; blocks were relocated only.
> 
> **§8.1 recap:** Updates the “Exact and re-confirmed” `@controllers/` consumer tally from **`0/44/44/0`** to **`1/44/44/0`**, matching **§3.3** (one CLI import of `planOnboardingFunnelTransition`).
> 
> **Clone census:** Adds a short note that the **0.96%** figure uses a **294,420**-line census denominator with different counting than the **292,864** `wc -l` production total above, so the ~1.5k gap does not affect the conclusion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eedb5386c1f351e467432a00371904762abe6d5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->