### PR TITLE
test(cli): drop dead initializeServerSideKeyAccess mock

### DIFF
--- a/src/test-kernel/cli/CliInitPlatform.vitest.mts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.mts
@@ -86,7 +86,6 @@ const mocks = vi.hoisted(() => ({
   initializeNodeGoalPrompts: vi.fn(),
   initializeNodeRuntimeSkills: vi.fn(),
   initNodeAgentRuntime: vi.fn(),
-  initializeServerSideKeyAccess: vi.fn(),
   serverSideKeyService: {
     setUseIncludedModelAccess: vi.fn(),
   },
@@ -109,7 +108,6 @@ vi.mock('@platform/defaults/longRunningModelTransport', () => ({
 
 vi.mock('@auth/serverKeys', () => ({
   getServerSideKeyService: () => mocks.serverSideKeyService,
-  initializeServerSideKeyAccess: mocks.initializeServerSideKeyAccess,
 }));
 
 vi.mock('@cli/runtime/supabaseAuth', () => ({


### PR DESCRIPTION
## Summary

#9228 deleted `initializeServerSideKeyAccess` from `src/auth/serverKeys/index.ts` in favor of lazily constructing `ServerSideKeyService`. It left two stale references in this test file's mock scaffolding — a reviewer flagged this on #9228 itself, but the file was never part of that PR's diff, so it went unaddressed.

- `src/test-kernel/cli/CliInitPlatform.vitest.mts:89` — `initializeServerSideKeyAccess: vi.fn()` inside the hoisted `mocks` object.
- `src/test-kernel/cli/CliInitPlatform.vitest.mts:112` — `initializeServerSideKeyAccess: mocks.initializeServerSideKeyAccess` inside the `vi.mock('@auth/serverKeys', ...)` factory.

## Verification that the mock is genuinely dead

- `grep -rn "initializeServerSideKeyAccess"` across `src/` and `packages/` returns **only these two lines** — zero production imports, zero exports from `@auth/serverKeys`, zero assertions anywhere in this test file that reference `mocks.initializeServerSideKeyAccess`.
- Removing both lines is a pure deletion: the full `CliInitPlatform.vitest.mts` suite still passes, 15/15.

## Scope

Exactly these two lines. No other changes to this file or any other.

## Verified

- `npm run typecheck` — clean (root, test-kernel, extension, CLI, trace-viewer, desktop projects).
- `npx vitest run src/test-kernel/cli/CliInitPlatform.vitest.mts` — 15/15 passed.
- `npx eslint src/test-kernel/cli/CliInitPlatform.vitest.mts` — clean.
- `npx prettier --check src/test-kernel/cli/CliInitPlatform.vitest.mts` — clean.

Claude-Session: https://claude.ai/code/session_01XZ8Z6rhypTfkVq728XCcCd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only mock cleanup with no runtime code paths touched.
> 
> **Overview**
> Removes leftover test mock wiring for **`initializeServerSideKeyAccess`** in `CliInitPlatform.vitest.mts`, which no longer exists on `@auth/serverKeys` after lazy `ServerSideKeyService` construction landed elsewhere.
> 
> The hoisted `mocks` object and the `vi.mock('@auth/serverKeys', …)` factory now only expose **`getServerSideKeyService`** (still stubbing `setUseIncludedModelAccess` on the service). No production or test behavior changes beyond aligning mocks with the current module surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 242236b292d0e46097f7b801c99711b5463b5c04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->