### PR TITLE
fix(cli): sweep orphaned streams on session open

### DIFF
--- a/packages/cli/src/runtime/transcriptSession.ts
+++ b/packages/cli/src/runtime/transcriptSession.ts
@@ -1,3 +1,4 @@
+import { SessionStores } from '@agent/storage';
 import {
   initializeDefaultSession,
   tryDefaultSession,
@@ -37,6 +38,20 @@ async function persistentSession(
   return { session, canResume: true };
 }
 
+async function initializePersistentSession(
+  transcripts: StreamLogStore,
+): Promise<CliTranscriptSession> {
+  const result = await persistentSession(
+    initializeDefaultSession({ transcripts }),
+  );
+  const stores = new SessionStores({
+    streamLogs: result.session.transcripts,
+    snapshots: result.session.snapshots,
+  });
+  await stores.sweepOrphanedStreams(new Set(result.session.transcripts.keys()));
+  return result;
+}
+
 /** Prepare the process session for a noninteractive run before it can start. */
 export async function initializeHeadlessTranscriptSession(
   openPersistentStore: OpenPersistentStore = () => StreamLogStore.open(),
@@ -45,7 +60,7 @@ export async function initializeHeadlessTranscriptSession(
   if (existing) return persistentSession(existing);
 
   const transcripts = await openPersistentStore();
-  return persistentSession(initializeDefaultSession({ transcripts }));
+  return initializePersistentSession(transcripts);
 }
 
 /**
@@ -89,7 +104,7 @@ export async function initializeInteractiveTranscriptSession(
     return { session, canResume: false, warning };
   }
 
-  return persistentSession(initializeDefaultSession({ transcripts }));
+  return initializePersistentSession(transcripts);
 }
 
 function formatEphemeralWarning(reason: string): string {

--- a/packages/cli/src/runtime/transcriptSession.ts
+++ b/packages/cli/src/runtime/transcriptSession.ts
@@ -4,6 +4,7 @@ import {
   tryDefaultSession,
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
+import { GoalStore } from '@tools/goal';
 import { StreamLogStore } from '@transcript';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -47,6 +48,10 @@ async function initializePersistentSession(
   const stores = new SessionStores({
     streamLogs: result.session.transcripts,
     snapshots: result.session.snapshots,
+    goalEntries: {
+      forget: (stream) => GoalStore.forget(stream, result.session),
+      forgetMany: (streams) => GoalStore.forgetMany(streams, result.session),
+    },
   });
   await stores.sweepOrphanedStreams(new Set(result.session.transcripts.keys()));
   return result;

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -5,6 +5,7 @@ import type { AgentTrace } from '@agent/trace';
 
 import { computeAgentOptionsData, getAgent } from '@agent/index';
 import { createChannelTrace } from '@agent/trace';
+import type { SessionStores } from '@agent/storage';
 import {
   validateExecutionRequest,
   type ValidatedExecutionRequest,
@@ -14,7 +15,6 @@ import { detachSubagentsOnStop } from '@agent/runtime/detachSubagentsOnStop';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { trackTerminalResultPresentation } from '@agent/runtime/terminalResultToast';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
-import type { SessionStores } from '@agent/runtime/SessionStores';
 import {
   notifyFollowUpSent,
   presentFollowUpWakeResult,

--- a/packages/desktop/src/main/desktopProcessStores.ts
+++ b/packages/desktop/src/main/desktopProcessStores.ts
@@ -1,9 +1,7 @@
 // Agent imports
 import { createChannelTrace } from '@agent/trace';
+import { SessionStores } from '@agent/storage';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
-
-// Controller imports
-import { SessionStores } from '@agent/runtime/SessionStores';
 
 // Tool imports
 import { releaseStreamResources } from '@tools/approval';

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -13,6 +13,7 @@ import {
   shell,
 } from 'electron';
 
+import type { SessionStores } from '@agent/storage';
 import {
   computeAgentOptionsData,
   getAgent,
@@ -23,7 +24,6 @@ import {
 } from '@agent/index/agentRegistry';
 import { registerAgentShutdownHandlers } from '@agent/runtime/agentShutdown';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
-import type { SessionStores } from '@agent/runtime/SessionStores';
 import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { SupabaseClient } from '@auth/SupabaseClient';

--- a/src/agent/storage/SessionStores.ts
+++ b/src/agent/storage/SessionStores.ts
@@ -48,7 +48,7 @@ export interface DeleteAllStreamsResult {
 export type DeleteStreamResult = 'deleted' | 'active' | 'failed';
 
 /**
- * Owns the durable footprint for a progress stream.
+ * Coordinates the durable footprint for a progress stream.
  *
  * `StreamLogStore` and `StreamSnapshotStore` keep separate on-disk formats;
  * this class owns the lifecycle invariant across those formats plus the

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -49,3 +49,8 @@ export {
   type ResumabilityDecision,
 } from './resumability';
 export { resolveChildRunOutput } from './childRunOutput';
+export {
+  SessionStores,
+  type DeleteAllStreamsResult,
+  type DeleteStreamResult,
+} from './SessionStores';

--- a/src/controllers/progressView/backend/ProgressBackend.ts
+++ b/src/controllers/progressView/backend/ProgressBackend.ts
@@ -1,12 +1,12 @@
 import PQueue from 'p-queue';
 
 import { RUN_FACT_EVENT_TYPES } from '@agent/trace';
+import type { SessionStores } from '@agent/storage';
 import type { HostApprovalBypassStateUpdate } from '@agent/runtime/HostInteractions';
 import {
   defaultSession,
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
-import type { SessionStores } from '@agent/runtime/SessionStores';
 import {
   WebviewBridge,
   type ProgressViewMessageSender,

--- a/src/controllers/progressView/backend/state/ProgressViewState.ts
+++ b/src/controllers/progressView/backend/state/ProgressViewState.ts
@@ -3,6 +3,11 @@ import { z } from 'zod';
 
 import type { AgentTrace } from '@agent/trace';
 import { createChannelTrace } from '@agent/trace';
+import {
+  SessionStores,
+  type DeleteAllStreamsResult,
+  type DeleteStreamResult,
+} from '@agent/storage';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import type { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
@@ -10,11 +15,6 @@ import {
   defaultSession,
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
-import {
-  SessionStores,
-  type DeleteAllStreamsResult,
-  type DeleteStreamResult,
-} from '@agent/runtime/SessionStores';
 import type { StateStore } from '@platform/interfaces';
 import {
   AgentCategoryFilterSchema,

--- a/src/test-kernel/agent/storage/SessionStores.vitest.ts
+++ b/src/test-kernel/agent/storage/SessionStores.vitest.ts
@@ -1,12 +1,11 @@
-// Test setup imports
+// Test composition imports
 import '@test/support/defaultSessionTestSetup';
 
 // Third-party imports
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
-import type { DeleteExecutionOptions } from '@agent/storage';
-import { SessionStores } from '@agent/runtime/SessionStores';
+import { SessionStores, type DeleteExecutionOptions } from '@agent/storage';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { createTestSession } from '@test/support/sessionTestUtils';
 import { releaseStreamResources } from '@tools/approval';

--- a/src/test-kernel/cli/TranscriptSessionPolicy.vitest.mts
+++ b/src/test-kernel/cli/TranscriptSessionPolicy.vitest.mts
@@ -1,6 +1,16 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-afterEach(() => {
+import type { StreamTabId } from '@shared/schemas';
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  const [{ teardownDefaultSession }, { cleanupTempDirs }] = await Promise.all([
+    import('@agent/runtime/SessionHandle'),
+    import('@test/support/tempDirPlatform'),
+  ]);
+  teardownDefaultSession();
+  await cleanupTempDirs(tempDirs);
   vi.doUnmock('@agent/runtime/runAgent');
   vi.doUnmock('@cli/runtime/runtimeHost');
   vi.doUnmock('@cli/runtime/transcriptSession');
@@ -81,5 +91,37 @@ describe('CLI transcript session policy', () => {
         },
       ),
     ).rejects.toBe(failure);
+  });
+
+  it('reclaims an orphaned stream sidecar when a headless session opens', async () => {
+    vi.resetModules();
+    const [
+      { initPlatform },
+      { createTempDirPlatform },
+      { StreamLogStore, StreamSnapshotStore },
+      { initializeHeadlessTranscriptSession },
+    ] = await Promise.all([
+      import('@platform/platform'),
+      import('@test/support/tempDirPlatform'),
+      import('@transcript'),
+      import('@cli/runtime/transcriptSession'),
+    ]);
+    initPlatform(
+      await createTempDirPlatform('texra-cli-orphan-sweep-', tempDirs),
+    );
+    const orphan = 'orphaned-cli-stream' as StreamTabId;
+    const writer = new StreamSnapshotStore();
+    writer.setDescription(orphan, 'orphaned sidecar');
+    await writer.flush();
+    await expect(writer.listPersistedStreams()).resolves.toEqual([orphan]);
+
+    const transcripts = await StreamLogStore.open();
+    const result = await initializeHeadlessTranscriptSession(
+      async () => transcripts,
+    );
+
+    await expect(
+      result.session.snapshots.listPersistedStreams(),
+    ).resolves.toEqual([]);
   });
 });

--- a/src/test-kernel/cli/TranscriptSessionPolicy.vitest.mts
+++ b/src/test-kernel/cli/TranscriptSessionPolicy.vitest.mts
@@ -99,11 +99,15 @@ describe('CLI transcript session policy', () => {
       { initPlatform },
       { createTempDirPlatform },
       { StreamLogStore, StreamSnapshotStore },
+      { initializeDefaultSession, teardownDefaultSession },
+      { GoalStore },
       { initializeHeadlessTranscriptSession },
     ] = await Promise.all([
       import('@platform/platform'),
       import('@test/support/tempDirPlatform'),
       import('@transcript'),
+      import('@agent/runtime/SessionHandle'),
+      import('@tools/goal'),
       import('@cli/runtime/transcriptSession'),
     ]);
     initPlatform(
@@ -115,6 +119,13 @@ describe('CLI transcript session policy', () => {
     await writer.flush();
     await expect(writer.listPersistedStreams()).resolves.toEqual([orphan]);
 
+    initializeDefaultSession({
+      transcripts: StreamLogStore.ephemeral('orphaned goal fixture'),
+    });
+    await GoalStore.start(orphan, 'orphaned goal');
+    expect(GoalStore.getForStream(orphan)).not.toBeNull();
+    teardownDefaultSession();
+
     const transcripts = await StreamLogStore.open();
     const result = await initializeHeadlessTranscriptSession(
       async () => transcripts,
@@ -123,5 +134,6 @@ describe('CLI transcript session policy', () => {
     await expect(
       result.session.snapshots.listPersistedStreams(),
     ).resolves.toEqual([]);
+    expect(GoalStore.getForStream(orphan)).toBeNull();
   });
 });

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -486,7 +486,7 @@ async function createBridge(
     session.interactions,
     { replayWhenAttached: true },
   );
-  const { SessionStores } = await import('@agent/runtime/SessionStores');
+  const { SessionStores } = await import('@agent/storage');
   const { releaseStreamResources } = await import('@tools/approval');
   const { GoalStore: bridgeGoalStore } = await import('@tools/goal');
   const sessionStores = new SessionStores({


### PR DESCRIPTION
## Summary

- sweep orphaned stream sidecars and execution directories after a new persistent CLI session becomes ready
- cover both headless runs and interactive chat through the shared transcript-session initializer
- move `SessionStores` from runtime control into `@agent/storage`, its existing durable-storage boundary, so the CLI adds no new deep agent import
- add a real node-backed regression that persists an ownerless sidecar, opens the CLI session, and observes its removal

Closes #9259. Tracker: #9258.

## Cause

The extension and desktop invoked `SessionStores.sweepOrphanedStreams` during startup, but the CLI had no caller. Persistent CLI sessions therefore loaded their canonical transcript streams while leaving unrelated `streamData/` sidecars and their execution directories on disk indefinitely.

## Design

`SessionStores` coordinates transcript, sidecar, execution, goal, and lease storage and has no runtime-control dependency. Placing it under `src/agent/storage/` makes `@agent/storage` the single host-facing boundary for this ownership rule. The CLI already imports that boundary, so its distinct `@agent/*` deep-import count remains 32 and no architecture baseline changes.

The sweep runs only for a newly opened persistent session, after `SessionHandle.waitUntilReady()` has loaded the live transcript set. Existing in-process sessions are not swept repeatedly, and ephemeral interactive fallback remains unchanged.

The status-repair path is untouched.

## Regression evidence

Before the production change, the added regression failed with:

```text
expected [ 'orphaned-cli-stream' ] to deeply equal []
```

After the change, `TranscriptSessionPolicy.vitest.mts` passes all 4 cases and the persisted orphan list is empty.

## Cold-start measurement

A 100-iteration empty-store measurement after one warm-up produced:

- median: 0.13 ms
- mean: 0.15 ms
- p95: 0.23 ms

The common no-orphan path does not warrant an additional gate.

## Net elements (R6)

- product files: 0 net (one module moved from `agent/runtime` to `agent/storage`)
- test files: 0 net (the path-mirrored suite moved with the product module)
- ratchet baselines: 0 changed
- test cases: +1 regression

## Validation

- `npm run format`
- `npm run compile:fast`
- `npm run typecheck`
- `npm run lint`
- `npm run check:dead-code-ratchet` — 17 current / 17 baselined
- `npx vitest run src/test-kernel/architecture/` — 10 files, 65 cases passed; no baseline bump
- `npx vitest run src/test-kernel/cli/TranscriptSessionPolicy.vitest.mts src/test-kernel/agent/storage/SessionStores.vitest.ts` — 2 files, 7 cases passed
- `npm test` — 7,793 passed, 4 skipped; 7,797 total

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Startup now deletes orphaned on-disk stream sidecars and related execution/goal state; incorrect sweep logic could remove durable data, though it is scoped to streams absent from the loaded transcript index.
> 
> **Overview**
> **Persistent CLI sessions** now run the same orphan cleanup as desktop/extension: after a new persistent session is ready, `initializePersistentSession` builds `SessionStores` (with goal forget hooks) and calls `sweepOrphanedStreams` against the live transcript stream IDs. Headless and interactive paths that open persistence use this helper; reusing an in-process session and ephemeral interactive fallback are unchanged.
> 
> **`SessionStores`** is re-exported from `@agent/storage` instead of `@agent/runtime`; desktop, progress backend, and tests import it from storage only (module relocated under `src/agent/storage/`).
> 
> A **node regression** asserts that a persisted snapshot sidecar with no canonical transcript is removed when `initializeHeadlessTranscriptSession` runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 116dbb747e30055f007979d8d5f1c413a9948588. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->