### PR TITLE
fix(desktop): preserve unsaved editor changes

### DIFF
--- a/packages/desktop/src/desktopWorkspaceMessages.ts
+++ b/packages/desktop/src/desktopWorkspaceMessages.ts
@@ -17,6 +17,7 @@ export const DESKTOP_WORKSPACE_COMMANDS = {
   WRITE_FILE: 'desktop:workspace:writeFile',
   FILE_WRITTEN: 'desktop:workspace:fileWritten',
   FILE_ERROR: 'desktop:workspace:fileError',
+  EDITOR_DIRTY_STATE: 'desktop:workspace:editorDirtyState',
   // Terminal
   TERMINAL_START: 'desktop:terminal:start',
   TERMINAL_INPUT: 'desktop:terminal:input',
@@ -80,6 +81,11 @@ const DesktopWriteFileMessageSchema = z.object({
   command: z.literal(DESKTOP_WORKSPACE_COMMANDS.WRITE_FILE),
   path: z.string(),
   contents: z.string(),
+});
+
+const DesktopEditorDirtyStateMessageSchema = z.object({
+  command: z.literal(DESKTOP_WORKSPACE_COMMANDS.EDITOR_DIRTY_STATE),
+  dirty: z.boolean(),
 });
 
 export const DesktopFileWrittenMessageSchema = z.object({
@@ -246,6 +252,7 @@ export const DesktopWorkspaceInboundMessageSchema = z.discriminatedUnion(
     DesktopListFilesMessageSchema,
     DesktopReadFileMessageSchema,
     DesktopWriteFileMessageSchema,
+    DesktopEditorDirtyStateMessageSchema,
     DesktopTerminalStartMessageSchema,
     DesktopTerminalInputMessageSchema,
     DesktopTerminalResizeMessageSchema,

--- a/packages/desktop/src/main/desktopWorkspaceIpc.ts
+++ b/packages/desktop/src/main/desktopWorkspaceIpc.ts
@@ -114,10 +114,21 @@ async function resolveWorkspaceWritePath(inputPath: string): Promise<string> {
     if (!isFileNotFoundError(error)) throw error;
   }
 
-  const [canonicalRoot, canonicalParent] = await Promise.all([
-    platform().fs.realPath(root),
-    platform().fs.realPath(dirname(located.absolutePath)),
-  ]);
+  let canonicalRoot: string;
+  let canonicalParent: string;
+  try {
+    [canonicalRoot, canonicalParent] = await Promise.all([
+      platform().fs.realPath(root),
+      platform().fs.realPath(dirname(located.absolutePath)),
+    ]);
+  } catch (error) {
+    if (isFileNotFoundError(error)) {
+      throw new Error(
+        'The file cannot be recreated because its parent folder no longer exists.',
+      );
+    }
+    throw error;
+  }
   const canonicalTarget = join(canonicalParent, basename(located.absolutePath));
   if (!isPathWithin(canonicalRoot, canonicalTarget)) {
     throw new Error('Only files inside the workspace folder can be opened.');

--- a/packages/desktop/src/main/desktopWorkspaceIpc.ts
+++ b/packages/desktop/src/main/desktopWorkspaceIpc.ts
@@ -8,9 +8,10 @@
 // otherwise read or overwrite anything the user can reach.
 
 // Node imports
-import { join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 
 // Local imports - file listing
+import { isFileNotFoundError } from '@common/errors';
 import {
   loadFileListSettings,
   passesFileFilters,
@@ -45,6 +46,7 @@ import type { DesktopBrowserViews } from './desktopBrowserViews.js';
 export interface DesktopWorkspaceIpcOptions {
   ptyHost: DesktopPtyHost;
   browserViews: DesktopBrowserViews;
+  onEditorDirtyChange?(dirty: boolean): void;
   /**
    * Translates renderer-reported CSS pixel bounds into window coordinates.
    * A WebContentsView is positioned in device-independent window space, which
@@ -75,6 +77,48 @@ async function resolveWorkspacePath(inputPath: string): Promise<string> {
     platform().fs.realPath(root),
     platform().fs.realPath(located.absolutePath),
   ]);
+  if (!isPathWithin(canonicalRoot, canonicalTarget)) {
+    throw new Error('Only files inside the workspace folder can be opened.');
+  }
+  return canonicalTarget;
+}
+
+/**
+ * Resolves a write target without requiring the file itself to still exist.
+ * The canonical parent remains mandatory, so recreating an externally deleted
+ * file cannot bypass the workspace or symlink boundary.
+ */
+async function resolveWorkspaceWritePath(inputPath: string): Promise<string> {
+  try {
+    return await resolveWorkspacePath(inputPath);
+  } catch (error) {
+    if (!isFileNotFoundError(error)) throw error;
+  }
+
+  const located = WorkspaceFS.locatePath(inputPath);
+  if (located.kind !== 'workspace') {
+    throw new Error('Only files inside the workspace folder can be opened.');
+  }
+  const root = WorkspaceFS.getPath();
+  if (!root) {
+    throw new Error('Workspace path is not available.');
+  }
+
+  // A dangling symlink also makes realPath fail with ENOENT. It must remain
+  // rejected: writing through it could create a target outside the workspace.
+  try {
+    if (await platform().fs.isSymlink(located.absolutePath)) {
+      throw new Error('Symbolic links cannot be recreated by the editor.');
+    }
+  } catch (error) {
+    if (!isFileNotFoundError(error)) throw error;
+  }
+
+  const [canonicalRoot, canonicalParent] = await Promise.all([
+    platform().fs.realPath(root),
+    platform().fs.realPath(dirname(located.absolutePath)),
+  ]);
+  const canonicalTarget = join(canonicalParent, basename(located.absolutePath));
   if (!isPathWithin(canonicalRoot, canonicalTarget)) {
     throw new Error('Only files inside the workspace folder can be opened.');
   }
@@ -184,7 +228,7 @@ export function createDesktopWorkspaceIpc(
 
   async function writeFile(path: string, contents: string): Promise<void> {
     try {
-      await WorkspaceFS.write(await resolveWorkspacePath(path), contents);
+      await WorkspaceFS.write(await resolveWorkspaceWritePath(path), contents);
       renderer.postToRenderer({
         command: DESKTOP_WORKSPACE_COMMANDS.FILE_WRITTEN,
         path,
@@ -229,6 +273,9 @@ export function createDesktopWorkspaceIpc(
       const data = parsed.data;
 
       switch (data.command) {
+        case DESKTOP_WORKSPACE_COMMANDS.EDITOR_DIRTY_STATE:
+          options.onEditorDirtyChange?.(data.dirty);
+          return true;
         case DESKTOP_WORKSPACE_COMMANDS.LIST_FILES:
           void listFiles(data.directory);
           return true;

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -472,6 +472,25 @@ function createWindow(options: {
     signInForRemoteAgentCatalog,
   );
   const folderPickerDefaultPath = options.workspacePath ?? app.getPath('home');
+  let editorHasUnsavedChanges = false;
+  const confirmDiscardUnsavedEditorChanges = (): boolean => {
+    if (!editorHasUnsavedChanges) return true;
+    const response = dialog.showMessageBoxSync(window, {
+      type: 'warning',
+      buttons: ['Keep Editing', 'Discard Changes'],
+      defaultId: 0,
+      cancelId: 0,
+      title: 'Unsaved Changes',
+      message: 'This workspace has unsaved editor changes.',
+      detail: 'Discard the changes and continue?',
+    });
+    if (response !== 1) return false;
+    editorHasUnsavedChanges = false;
+    return true;
+  };
+  window.webContents.on('will-prevent-unload', (event) => {
+    if (confirmDiscardUnsavedEditorChanges()) event.preventDefault();
+  });
   const openLogsFolder = async () =>
     previewHost.openPath(getDesktopLogDirectory());
   const openWorkspaceFolder = async () => {
@@ -482,6 +501,7 @@ function createWindow(options: {
     });
     const selectedPath = result.canceled ? undefined : result.filePaths[0];
     if (!selectedPath) return;
+    if (!confirmDiscardUnsavedEditorChanges()) return;
 
     await platform().globalState.update(
       DESKTOP_WORKSPACE_PATH_STATE_KEY,
@@ -1113,6 +1133,9 @@ function createWindow(options: {
         };
       },
       getEnvironmentSummary: () => gitHost.getEnvironmentSummary(),
+      onEditorDirtyChange: (dirty) => {
+        editorHasUnsavedChanges = dirty;
+      },
       onAsyncError: reportAsyncError,
     },
   );

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -143,6 +143,8 @@ const moduleDirname = fileURLToPath(new URL('.', import.meta.url));
 const desktopMainDir = findDesktopMainDir(moduleDirname);
 let mainWindow: BrowserWindow | null = null;
 let reopenMainWindow: (() => void) | undefined;
+let workspaceRelaunchInProgress = false;
+let continueQuitAfterWindowClose: (() => void) | undefined;
 
 // Playwright relaunch tests need a deterministic Electron profile so
 // app-scoped stores survive across child processes. Normal desktop launches
@@ -473,8 +475,11 @@ function createWindow(options: {
   );
   const folderPickerDefaultPath = options.workspacePath ?? app.getPath('home');
   let editorHasUnsavedChanges = false;
-  const confirmDiscardUnsavedEditorChanges = (): boolean => {
-    if (!editorHasUnsavedChanges) return true;
+  let allowNextPreventedUnload = false;
+  let pendingWorkspaceRelaunch:
+    { selectedPath: string; args: string[] } | undefined;
+  const confirmDiscardUnsavedEditorChanges = (force = false): boolean => {
+    if (!force && !editorHasUnsavedChanges) return true;
     const response = dialog.showMessageBoxSync(window, {
       type: 'warning',
       buttons: ['Keep Editing', 'Discard Changes'],
@@ -489,7 +494,21 @@ function createWindow(options: {
     return true;
   };
   window.webContents.on('will-prevent-unload', (event) => {
-    if (confirmDiscardUnsavedEditorChanges()) event.preventDefault();
+    if (allowNextPreventedUnload) {
+      allowNextPreventedUnload = false;
+      event.preventDefault();
+      return;
+    }
+    // The event itself is authoritative: it is emitted only after the
+    // renderer observes a dirty Monaco buffer and refuses the unload. The
+    // mirrored IPC flag may still be in flight.
+    if (confirmDiscardUnsavedEditorChanges(true)) {
+      event.preventDefault();
+      return;
+    }
+    pendingWorkspaceRelaunch = undefined;
+    workspaceRelaunchInProgress = false;
+    continueQuitAfterWindowClose = undefined;
   });
   const openLogsFolder = async () =>
     previewHost.openPath(getDesktopLogDirectory());
@@ -501,31 +520,18 @@ function createWindow(options: {
     });
     const selectedPath = result.canceled ? undefined : result.filePaths[0];
     if (!selectedPath) return;
+    const hadUnsavedChanges = editorHasUnsavedChanges;
     if (!confirmDiscardUnsavedEditorChanges()) return;
-
-    await platform().globalState.update(
-      DESKTOP_WORKSPACE_PATH_STATE_KEY,
+    allowNextPreventedUnload = hadUnsavedChanges;
+    pendingWorkspaceRelaunch = {
       selectedPath,
-    );
-    const relaunchArgs = withWorkspacePathArg(
-      process.argv.slice(1),
-      selectedPath,
-    );
-    // The development supervisor owns Vite and the Electron child. Let it
-    // replace the child so the new process keeps a live renderer URL; calling
-    // app.relaunch() directly orphaned the replacement and made the
-    // supervisor tear Vite down as soon as the original process exited.
-    if (
-      process.env.TEXRA_DESKTOP_DEV_SUPERVISED === '1' &&
-      typeof process.send === 'function'
-    ) {
-      process.send(relaunchArgs);
-    } else {
-      app.relaunch({ args: relaunchArgs });
-    }
-    // `app.exit()` bypasses before-quit; use the lifecycle-aware path so the
-    // process session drains before Electron starts the replacement process.
-    app.quit();
+      args: withWorkspacePathArg(process.argv.slice(1), selectedPath),
+    };
+    workspaceRelaunchInProgress = true;
+    // Closing first lets the renderer's authoritative beforeunload check veto
+    // the switch. The replacement is scheduled only from the closed handler,
+    // after unsaved changes can no longer cancel it.
+    window.close();
   };
   attachRendererConsoleLog(window.webContents);
   const agentExecutionHost: DesktopAgentExecutionHost = {
@@ -1178,6 +1184,10 @@ function createWindow(options: {
     Menu.buildFromTemplate(buildDesktopMenuTemplate(shellActions)),
   );
   window.once('closed', () => {
+    const workspaceRelaunch = pendingWorkspaceRelaunch;
+    pendingWorkspaceRelaunch = undefined;
+    const continueQuit = continueQuitAfterWindowClose;
+    continueQuitAfterWindowClose = undefined;
     windowClosed = true;
     disposeWindowTitle();
     presentationAbort.abort();
@@ -1205,6 +1215,33 @@ function createWindow(options: {
     // down — neither is reachable once the window is gone.
     ptyHost.disposeAll();
     browserViews.disposeAll();
+    if (workspaceRelaunch) {
+      void (async () => {
+        try {
+          await platform().globalState.update(
+            DESKTOP_WORKSPACE_PATH_STATE_KEY,
+            workspaceRelaunch.selectedPath,
+          );
+        } catch (error) {
+          reportAsyncError(error);
+        }
+        // The development supervisor owns Vite and the Electron child. Let it
+        // replace the child so the new process keeps a live renderer URL.
+        if (
+          process.env.TEXRA_DESKTOP_DEV_SUPERVISED === '1' &&
+          typeof process.send === 'function'
+        ) {
+          process.send(workspaceRelaunch.args);
+        } else {
+          app.relaunch({ args: workspaceRelaunch.args });
+        }
+        // Use the lifecycle-aware path so the process session drains before
+        // Electron starts the replacement process.
+        app.quit();
+      })();
+    } else {
+      continueQuit?.();
+    }
   });
   let windowPresented = false;
   const presentWindow = (): void => {
@@ -1287,15 +1324,20 @@ if (protocolLifecycle.shouldContinue) {
         disposeAgentResumeHandler = processResumeOwner.attach({
           session: processSession,
         });
-        // before-quit semantics: hold every quit event until shutdown handlers
-        // have finished draining (a second Cmd+Q while we're mid-drain must NOT
-        // be allowed to terminate the process). Only after runShutdown resolves
-        // do we let Electron's own quit sequence proceed — and we mark
-        // shutdownStarted to avoid re-entering the runShutdown chain.
+        // Ask the renderer to close before draining process services. A dirty
+        // editor can veto that close and remain fully operational. Once the
+        // window really closes, its handler calls app.quit() again and this
+        // listener proceeds with the ordinary shutdown chain.
         let shutdownStarted = false;
         let quitting = false;
         app.on('before-quit', (event) => {
           if (quitting) return;
+          if (mainWindow && !mainWindow.isDestroyed()) {
+            event.preventDefault();
+            continueQuitAfterWindowClose = () => app.quit();
+            mainWindow.close();
+            return;
+          }
           event.preventDefault();
           if (shutdownStarted) return;
           shutdownStarted = true;
@@ -1368,5 +1410,6 @@ if (protocolLifecycle.shouldContinue) {
 }
 
 app.on('window-all-closed', () => {
+  if (workspaceRelaunchInProgress) return;
   if (process.platform !== 'darwin') app.quit();
 });

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -8,7 +8,7 @@ import {
 
 const rendererWindow = globalThis as typeof globalThis & {
   addEventListener?: (
-    type: 'beforeunload',
+    type: 'unload',
     listener: () => void,
     options?: { once?: boolean },
   ) => void;
@@ -28,7 +28,7 @@ installElectronHostBridge({
       listener(message);
     ipcRenderer.on(channel, handler);
     rendererWindow.addEventListener?.(
-      'beforeunload',
+      'unload',
       () => ipcRenderer.off(channel, handler),
       { once: true },
     );

--- a/packages/desktop/src/renderer/editorPane.ts
+++ b/packages/desktop/src/renderer/editorPane.ts
@@ -71,6 +71,7 @@ export interface EditorPane {
   setTheme(theme: DesktopThemeKind): void;
   /** Re-lays-out Monaco after its container resizes or becomes visible. */
   layout(): void;
+  hasUnsavedChanges(): boolean;
   save(): Promise<void>;
   dispose(): void;
 }
@@ -472,6 +473,7 @@ export function createEditorPane(callbacks: EditorPaneCallbacks): EditorPane {
       editor?.layout();
     },
 
+    hasUnsavedChanges: () => dirtyPaths.size > 0,
     save,
 
     dispose() {

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -355,6 +355,9 @@ const editorPane = createEditorPane({
     updateShell(
       setWorkbenchTabDirty(shellState, `workbench:editor:${path}`, dirty),
     );
+    postMessage(DESKTOP_WORKSPACE_COMMANDS.EDITOR_DIRTY_STATE, {
+      dirty: editorPane.hasUnsavedChanges(),
+    });
   },
   onError: (error) => console.error('TeXRA editor pane', error),
 });
@@ -1721,8 +1724,14 @@ if (!bootstrapFailed) {
   document.body.dataset.desktopReady = 'true';
 }
 
+window.addEventListener('beforeunload', (event) => {
+  if (!editorPane.hasUnsavedChanges()) return;
+  event.preventDefault();
+  event.returnValue = '';
+});
+
 window.addEventListener(
-  'beforeunload',
+  'unload',
   () => {
     surfaceResizeObserver?.disconnect();
     disposeShortcutHints?.();

--- a/src/test-kernel/desktop/DesktopControlSystem.vitest.mts
+++ b/src/test-kernel/desktop/DesktopControlSystem.vitest.mts
@@ -237,6 +237,7 @@ describe('desktop control system', () => {
       'packages/desktop/src/desktopCommandSurface.ts',
     );
     const electronMain = read('packages/desktop/src/main/index.ts');
+    const preload = read('packages/desktop/src/preload/index.ts');
     const editorPane = read('packages/desktop/src/renderer/editorPane.ts');
     const renderer = read('packages/desktop/src/renderer/main.ts');
 
@@ -253,7 +254,16 @@ describe('desktop control system', () => {
     expect(renderer).toContain('DESKTOP_WORKSPACE_COMMANDS.EDITOR_DIRTY_STATE');
     expect(editorPane).toContain('model.getVersionId() !== savedVersion');
     expect(electronMain).toContain("on('will-prevent-unload'");
-    expect(electronMain).toContain('confirmDiscardUnsavedEditorChanges()');
+    expect(electronMain).toContain('confirmDiscardUnsavedEditorChanges(true)');
+    expect(electronMain).toContain('allowNextPreventedUnload');
+    expect(electronMain).toMatch(
+      /workspaceRelaunchInProgress = true;[\s\S]*?window\.close\(\);[\s\S]*?window\.once\('closed',[\s\S]*?app\.relaunch/u,
+    );
+    expect(electronMain).toMatch(
+      /app\.on\('before-quit',[\s\S]*?mainWindow\.close\(\);[\s\S]*?lifecycle\.runShutdown\(\)/u,
+    );
+    expect(preload).toContain("'unload',");
+    expect(preload).not.toContain("'beforeunload'");
   });
 
   it('executes immediate follow-up plans after restoring their launcher state', () => {

--- a/src/test-kernel/desktop/DesktopControlSystem.vitest.mts
+++ b/src/test-kernel/desktop/DesktopControlSystem.vitest.mts
@@ -236,6 +236,7 @@ describe('desktop control system', () => {
     const commandSurface = read(
       'packages/desktop/src/desktopCommandSurface.ts',
     );
+    const electronMain = read('packages/desktop/src/main/index.ts');
     const editorPane = read('packages/desktop/src/renderer/editorPane.ts');
     const renderer = read('packages/desktop/src/renderer/main.ts');
 
@@ -248,7 +249,11 @@ describe('desktop control system', () => {
     expect(commandSurface).toContain("SAVE_FILE: 'texra.desktop.saveFile'");
     expect(commandSurface).toContain("accelerator: 'CommandOrControl+S'");
     expect(renderer).toContain('void editorPane.save()');
+    expect(renderer).toContain('editorPane.hasUnsavedChanges()');
+    expect(renderer).toContain('DESKTOP_WORKSPACE_COMMANDS.EDITOR_DIRTY_STATE');
     expect(editorPane).toContain('model.getVersionId() !== savedVersion');
+    expect(electronMain).toContain("on('will-prevent-unload'");
+    expect(electronMain).toContain('confirmDiscardUnsavedEditorChanges()');
   });
 
   it('executes immediate follow-up plans after restoring their launcher state', () => {

--- a/src/test-kernel/desktop/DesktopWorkspaceIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopWorkspaceIpc.vitest.mts
@@ -1,5 +1,6 @@
 // Node imports
 import {
+  existsSync,
   mkdtempSync,
   mkdirSync,
   readFileSync,
@@ -27,6 +28,7 @@ import { createFakePlatform } from '@test/support/FakePlatform';
 let fixtureRoot = '';
 let workspacePath = '';
 let externalPath = '';
+let missingExternalPath = '';
 
 function createPtyHost(): DesktopPtyHost {
   return {
@@ -57,6 +59,7 @@ describe('desktop workspace IPC', () => {
     fixtureRoot = mkdtempSync(join(tmpdir(), 'texra-workspace-ipc-'));
     workspacePath = join(fixtureRoot, 'workspace');
     externalPath = join(fixtureRoot, 'external.txt');
+    missingExternalPath = join(fixtureRoot, 'missing-external.txt');
     mkdirSync(workspacePath);
     mkdirSync(join(workspacePath, 'src', 'deep'), { recursive: true });
     mkdirSync(join(workspacePath, 'node_modules'));
@@ -69,6 +72,10 @@ describe('desktop workspace IPC', () => {
     );
     writeFileSync(externalPath, 'outside', 'utf8');
     symlinkSync(externalPath, join(workspacePath, 'linked.tex'));
+    symlinkSync(
+      missingExternalPath,
+      join(workspacePath, 'dangling-linked.tex'),
+    );
     const [{ initPlatform }, { nodeFilesystem }] = await Promise.all([
       import('@platform/platform'),
       import('@platform/defaults/nodeFilesystem'),
@@ -169,8 +176,13 @@ describe('desktop workspace IPC', () => {
       path: 'linked.tex',
       contents: 'overwritten',
     });
+    ipc.handleMessage({
+      command: DESKTOP_WORKSPACE_COMMANDS.WRITE_FILE,
+      path: 'dangling-linked.tex',
+      contents: 'created outside',
+    });
 
-    await vi.waitFor(() => expect(onAsyncError).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(onAsyncError).toHaveBeenCalledTimes(3));
     expect(postToRenderer).not.toHaveBeenCalledWith(
       expect.objectContaining({
         command: DESKTOP_WORKSPACE_COMMANDS.FILE_READ,
@@ -184,6 +196,57 @@ describe('desktop workspace IPC', () => {
       }),
     );
     expect(readFileSync(externalPath, 'utf8')).toBe('outside');
+    expect(existsSync(missingExternalPath)).toBe(false);
+  });
+
+  it('recreates a workspace file deleted after the editor loaded it', async () => {
+    const postToRenderer = vi.fn();
+    const ipc = createDesktopWorkspaceIpc(
+      { postToRenderer },
+      {
+        ptyHost: createPtyHost(),
+        browserViews: createBrowserViews(),
+        toWindowBounds: (bounds) => bounds,
+      },
+    );
+    rmSync(join(workspacePath, 'paper.tex'));
+
+    ipc.handleMessage({
+      command: DESKTOP_WORKSPACE_COMMANDS.WRITE_FILE,
+      path: 'paper.tex',
+      contents: 'recovered buffer',
+    });
+
+    await vi.waitFor(() =>
+      expect(postToRenderer).toHaveBeenCalledWith({
+        command: DESKTOP_WORKSPACE_COMMANDS.FILE_WRITTEN,
+        path: 'paper.tex',
+      }),
+    );
+    expect(readFileSync(join(workspacePath, 'paper.tex'), 'utf8')).toBe(
+      'recovered buffer',
+    );
+  });
+
+  it('reports renderer editor dirty state to the window lifecycle', () => {
+    const onEditorDirtyChange = vi.fn();
+    const ipc = createDesktopWorkspaceIpc(
+      { postToRenderer: vi.fn() },
+      {
+        ptyHost: createPtyHost(),
+        browserViews: createBrowserViews(),
+        toWindowBounds: (bounds) => bounds,
+        onEditorDirtyChange,
+      },
+    );
+
+    expect(
+      ipc.handleMessage({
+        command: DESKTOP_WORKSPACE_COMMANDS.EDITOR_DIRTY_STATE,
+        dirty: true,
+      }),
+    ).toBe(true);
+    expect(onEditorDirtyChange).toHaveBeenCalledWith(true);
   });
 
   it('posts environment state and clears loading state after host failures', async () => {

--- a/src/test-kernel/desktop/DesktopWorkspaceIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopWorkspaceIpc.vitest.mts
@@ -228,6 +228,34 @@ describe('desktop workspace IPC', () => {
     );
   });
 
+  it('reports a clear error when the deleted file parent is also gone', async () => {
+    const postToRenderer = vi.fn();
+    const ipc = createDesktopWorkspaceIpc(
+      { postToRenderer },
+      {
+        ptyHost: createPtyHost(),
+        browserViews: createBrowserViews(),
+        toWindowBounds: (bounds) => bounds,
+      },
+    );
+    rmSync(join(workspacePath, 'src'), { recursive: true });
+
+    ipc.handleMessage({
+      command: DESKTOP_WORKSPACE_COMMANDS.WRITE_FILE,
+      path: 'src/index.ts',
+      contents: 'unrecoverable buffer',
+    });
+
+    await vi.waitFor(() =>
+      expect(postToRenderer).toHaveBeenCalledWith({
+        command: DESKTOP_WORKSPACE_COMMANDS.FILE_ERROR,
+        path: 'src/index.ts',
+        message:
+          'The file cannot be recreated because its parent folder no longer exists.',
+      }),
+    );
+  });
+
   it('reports renderer editor dirty state to the window lifecycle', () => {
     const onEditorDirtyChange = vi.fn();
     const ipc = createDesktopWorkspaceIpc(


### PR DESCRIPTION
## Summary

- report aggregate editor dirty state from the sandboxed renderer to the main process
- ask for explicit confirmation before closing the desktop window or replacing its workspace when editor buffers are unsaved
- defer renderer disposal until an unload actually occurs, so canceling a close leaves Monaco and its models intact
- allow Save to recreate a workspace file deleted externally while retaining the canonical workspace and symlink boundary

Closes #9277.

## Existing coverage from #9216

PR #9216 already added the Save command, Command/Ctrl+S binding, and Monaco model-version guard. This PR completes the unresolved parts of #9277: close/workspace-switch preservation and external-deletion recovery.

## Design

Dirty state originates in `EditorPane` and is sent through the existing desktop workspace IPC boundary. The main process owns the one native confirmation function used by both ordinary unload prevention and workspace replacement. A canceled close no longer runs renderer cleanup; actual unload performs cleanup once.

For a deleted file, the write resolver accepts a missing final path only after canonicalizing its existing parent inside the canonical workspace root. A dangling symlink remains rejected, since writing through it could create an external target.

## Regression evidence

Before the change:

- the renderer disposed the editor unconditionally in `beforeunload`, even when unloading should be canceled
- workspace replacement scheduled relaunch without any dirty-buffer decision
- saving an externally deleted file failed while resolving the missing target with `realPath`

The added tests verify dirty-state IPC, recovery of a deleted workspace file, and rejection of a dangling symlink to a missing external target. The desktop control-system assertion pins the unload and confirmation wiring.

## Validation

- `npm run format`
- `npm run compile:fast`
- `npm run typecheck`
- `npm run lint`
- `npm run check:dead-code-ratchet` — 17 current / 17 baselined
- `npx vitest run src/test-kernel/architecture/` — 10 files, 65 cases passed
- focused desktop tests — 3 files, 27 cases passed
- `npm test` — 7,796 passed, 4 skipped; 7,800 total

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches window lifecycle, quit/relaunch, and filesystem write resolution (security-sensitive path canonicalization); behavior is well covered by new IPC and control-system tests but regressions could affect data loss or workspace switching.
> 
> **Overview**
> **Protects unsaved Monaco buffers** when quitting, closing the window, or switching workspace folders. The renderer blocks unload via `beforeunload` when any tab is dirty, reports aggregate dirty state over new `EDITOR_DIRTY_STATE` IPC, and only tears down the editor on **`unload`** (preload IPC cleanup moved the same way) so a canceled close leaves models intact. The main process mirrors dirty state, shows a native discard confirmation on `will-prevent-unload`, and defers workspace relaunch until after `window.close()` succeeds—persisting the new path and `app.relaunch` from the `closed` handler. **`before-quit`** now closes the main window first so a dirty editor can cancel quit; shutdown runs on the follow-up quit after the window is gone.
> 
> **Save after external deletion:** writes use `resolveWorkspaceWritePath`, which can recreate a missing file when its parent still canonicalizes inside the workspace, while still rejecting symlink escapes (including dangling links) and surfacing a clear error if the parent folder is gone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb200d2af57997e88e31047d345102f65337fdd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->