### PR TITLE
fix(desktop): show missing agent banner

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -88,7 +88,11 @@ import {
   invalidateModelOptionsCache,
 } from '@model/computeModelOptions';
 import { platform } from '@platform/platform';
-import { PROGRESS_VIEW_COMMANDS, COMMON_COMMANDS } from '@shared/ipc';
+import {
+  COMMON_COMMANDS,
+  MAIN_VIEW_COMMANDS,
+  PROGRESS_VIEW_COMMANDS,
+} from '@shared/ipc';
 import {
   AgentCategory,
   SETTINGS_TAB,
@@ -1241,6 +1245,16 @@ export class DesktopProgressBridge {
         void this.options.host.showErrorMessage(message);
         return;
       }
+      case 'showAgentConfigBanner': {
+        const { agentName } =
+          payload as RuntimePresentationEventPayloads['showAgentConfigBanner'];
+        this.postToRenderer({
+          command: MAIN_VIEW_COMMANDS.SHOW_AGENT_CONFIG_BANNER,
+          agentName,
+          customDirSet: true,
+        });
+        return;
+      }
       case 'requestOpenFile': {
         // The extension previews via its LaTeX-Workshop build+view flow
         // (openBuildDisplayIfTex); desktop has no such editor integration,
@@ -1256,8 +1270,11 @@ export class DesktopProgressBridge {
           });
         return;
       }
-      default:
+      default: {
+        const _exhaustive: never = event;
+        void _exhaustive;
         return;
+      }
     }
   }
 

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -39,7 +39,11 @@ import {
   type StreamPhase,
   type StreamTabId,
 } from '@shared/schemas';
-import { COMMON_COMMANDS, PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+import {
+  COMMON_COMMANDS,
+  MAIN_VIEW_COMMANDS,
+  PROGRESS_VIEW_COMMANDS,
+} from '@shared/ipc';
 import { STREAM_TRANSITION_CAUSE } from '@shared/streams/streamStatus';
 import type { ProgressViewInboundHandlerRegistry } from '@shared/schemas/progressView';
 import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
@@ -847,12 +851,20 @@ describe('DesktopProgressBridge', () => {
       actions: ['set-api-key', 'open-configuration-guide'],
       showSuppress: false,
     });
+    bridge.handlePresentationEvent('showAgentConfigBanner', {
+      agentName: 'missing-writer',
+    });
 
     expect(messages).toContainEqual({
       command: DESKTOP_SHELL_COMMANDS.SET_ROUTE,
       route: 'progress',
     });
-    expect(messages).toHaveLength(1);
+    expect(messages).toContainEqual({
+      command: MAIN_VIEW_COMMANDS.SHOW_AGENT_CONFIG_BANNER,
+      agentName: 'missing-writer',
+      customDirSet: true,
+    });
+    expect(messages).toHaveLength(2);
     expect(showErrorMessage).toHaveBeenCalledWith('Root run failed');
     // Folded into the same dialog surface as requestShowError — no second
     // subscribe surface or dialog for instructions.


### PR DESCRIPTION
## Summary

- forward missing-agent configuration banners to the desktop main view
- make desktop presentation-event dispatch exhaustive so future events cannot be silently discarded
- cover the desktop banner message in the presentation routing test

## Design

The runtime event remains host-neutral. Desktop translates it into the existing shared main-view message, so the same banner component and state remain the single presentation surface in both hosts.

## Validation

- `corepack pnpm vitest run src/test-kernel/desktop/DesktopAgentExecution.vitest.mts` (74 tests)
- `corepack pnpm run typecheck`
- `corepack pnpm run lint`
- pre-commit format and guidance-reference checks

Closes #9283

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized desktop presentation routing with a matching test; no auth, data, or execution-path changes beyond showing an existing banner.
> 
> **Overview**
> Fixes desktop not surfacing **missing agent configuration** banners when the runtime emits `showAgentConfigBanner`.
> 
> **Desktop** maps that host-neutral presentation event to the existing shared `MAIN_VIEW_COMMANDS.SHOW_AGENT_CONFIG_BANNER` message (`agentName`, `customDirSet: true`), so the same main-view banner UI as VS Code is used.
> 
> `handlePresentationEvent` now has an **exhaustive** `default` branch (`never`), so any future `RuntimePresentationEvent` must be handled explicitly instead of falling through silently.
> 
> Tests assert the banner IPC is posted alongside progress routing when presentation events are exercised.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67b5e6a3322b989e2bb2b33a4b7239c507227cf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->