### PR TITLE
fix(desktop): clean resources on renderer reload

### DIFF
--- a/packages/desktop/src/main/desktopPtyHost.ts
+++ b/packages/desktop/src/main/desktopPtyHost.ts
@@ -69,7 +69,8 @@ export interface DesktopPtyHost {
   /**
    * Starts a session. Rejects when the native module is unavailable, so the
    * caller can report "terminal unavailable" rather than hanging on a
-   * terminal that will never produce output.
+   * terminal that will never produce output. Returns `undefined` when resource
+   * disposal invalidates the request while the native module is loading.
    */
   create(input: {
     id: string;

--- a/packages/desktop/src/main/desktopPtyHost.ts
+++ b/packages/desktop/src/main/desktopPtyHost.ts
@@ -61,8 +61,8 @@ export interface DesktopPtyHostOptions {
   /** Reports process exit so the UI can mark the session finished. */
   onExit(sessionId: string, exitCode: number): void;
   onError?(error: unknown): void;
-  /** Overrides native process creation for a controlled host environment. */
-  spawnPty?: NodePtyModule['spawn'];
+  /** Overrides native-module loading for a controlled host environment. */
+  loadPty?: () => Promise<NodePtyModule>;
 }
 
 export interface DesktopPtyHost {
@@ -76,7 +76,7 @@ export interface DesktopPtyHost {
     cols: number;
     rows: number;
     cwd?: string;
-  }): Promise<PtySessionHandle>;
+  }): Promise<PtySessionHandle | undefined>;
   get(id: string): PtySessionHandle | undefined;
   disposeAll(): void;
 }
@@ -170,14 +170,24 @@ export function createDesktopPtyHost(
   options: DesktopPtyHostOptions,
 ): DesktopPtyHost {
   const sessions = new Map<string, PtySessionHandle>();
+  let generation = 0;
 
   return {
     async create({ id, cols, rows, cwd }) {
       const existing = sessions.get(id);
       if (existing) return existing;
 
-      const spawnPty = options.spawnPty ?? (await loadNodePty()).spawn;
-      const child = spawnPty(defaultShell(), [], {
+      const creationGeneration = generation;
+      const pty = await (options.loadPty?.() ?? loadNodePty());
+      // disposeAll marks every request begun by the old renderer as stale,
+      // including requests that had not yet reached the sessions map.
+      if (creationGeneration !== generation) return undefined;
+      // Two starts for the same renderer ID can share the module-load await.
+      // Whichever resumes second adopts the handle installed by the first.
+      const loadedExisting = sessions.get(id);
+      if (loadedExisting) return loadedExisting;
+
+      const child = pty.spawn(defaultShell(), [], {
         name: 'xterm-256color',
         // A pty spawned at 0 columns makes shells emit unusable line wrapping,
         // so clamp to a sane minimum until the renderer reports real bounds.
@@ -224,6 +234,7 @@ export function createDesktopPtyHost(
     get: (id) => sessions.get(id),
 
     disposeAll() {
+      generation += 1;
       // Copy first: dispose() mutates the map through the shared handle.
       for (const handle of [...sessions.values()]) handle.dispose();
       sessions.clear();

--- a/packages/desktop/src/main/desktopPtyHost.ts
+++ b/packages/desktop/src/main/desktopPtyHost.ts
@@ -179,7 +179,13 @@ export function createDesktopPtyHost(
       if (existing) return existing;
 
       const creationGeneration = generation;
-      const pty = await (options.loadPty?.() ?? loadNodePty());
+      let pty: NodePtyModule;
+      try {
+        pty = await (options.loadPty?.() ?? loadNodePty());
+      } catch (error) {
+        if (creationGeneration !== generation) return undefined;
+        throw error;
+      }
       // disposeAll marks every request begun by the old renderer as stale,
       // including requests that had not yet reached the sessions map.
       if (creationGeneration !== generation) return undefined;

--- a/packages/desktop/src/main/desktopPtyHost.ts
+++ b/packages/desktop/src/main/desktopPtyHost.ts
@@ -61,6 +61,8 @@ export interface DesktopPtyHostOptions {
   /** Reports process exit so the UI can mark the session finished. */
   onExit(sessionId: string, exitCode: number): void;
   onError?(error: unknown): void;
+  /** Overrides native process creation for a controlled host environment. */
+  spawnPty?: NodePtyModule['spawn'];
 }
 
 export interface DesktopPtyHost {
@@ -174,8 +176,8 @@ export function createDesktopPtyHost(
       const existing = sessions.get(id);
       if (existing) return existing;
 
-      const pty = await loadNodePty();
-      const child = pty.spawn(defaultShell(), [], {
+      const spawnPty = options.spawnPty ?? (await loadNodePty()).spawn;
+      const child = spawnPty(defaultShell(), [], {
         name: 'xterm-256color',
         // A pty spawned at 0 columns makes shells emit unusable line wrapping,
         // so clamp to a sane minimum until the renderer reports real bounds.
@@ -183,12 +185,6 @@ export function createDesktopPtyHost(
         rows: Math.max(rows, 5),
         cwd: cwd ?? options.cwd ?? process.cwd(),
         env: ptyEnvironment(),
-      });
-
-      child.onData((data) => options.onData(id, data));
-      child.onExit(({ exitCode }) => {
-        sessions.delete(id);
-        options.onExit(id, exitCode);
       });
 
       const handle: PtySessionHandle = {
@@ -204,7 +200,7 @@ export function createDesktopPtyHost(
           }
         },
         dispose: () => {
-          sessions.delete(id);
+          if (sessions.get(id) === handle) sessions.delete(id);
           try {
             child.kill();
           } catch (error) {
@@ -212,6 +208,15 @@ export function createDesktopPtyHost(
           }
         },
       };
+      child.onData((data) => {
+        if (sessions.get(id) !== handle) return;
+        options.onData(id, data);
+      });
+      child.onExit(({ exitCode }) => {
+        if (sessions.get(id) !== handle) return;
+        sessions.delete(id);
+        options.onExit(id, exitCode);
+      });
       sessions.set(id, handle);
       return handle;
     },

--- a/packages/desktop/src/main/desktopWorkspaceIpc.ts
+++ b/packages/desktop/src/main/desktopWorkspaceIpc.ts
@@ -272,6 +272,7 @@ export function createDesktopWorkspaceIpc(
         cols,
         rows,
       });
+      if (!session) return;
       if (initialCommand) {
         session.write(`${initialCommand}\r`);
       }

--- a/packages/desktop/src/main/desktopWorkspaceIpc.ts
+++ b/packages/desktop/src/main/desktopWorkspaceIpc.ts
@@ -57,6 +57,16 @@ export interface DesktopWorkspaceIpcOptions {
   onAsyncError?(error: unknown): void;
 }
 
+export interface DesktopWorkspaceIpc extends DesktopMessageHandler {
+  /**
+   * Releases resources owned by the current renderer document.
+   *
+   * Renderer reload creates a new terminal-id namespace and a new browser-tab
+   * layout, so neither resource may survive across that boundary.
+   */
+  disposeRendererResources(): void;
+}
+
 /**
  * Resolves a renderer-supplied path inside the workspace, or throws.
  *
@@ -139,7 +149,7 @@ async function resolveWorkspaceWritePath(inputPath: string): Promise<string> {
 export function createDesktopWorkspaceIpc(
   renderer: DesktopRenderer,
   options: DesktopWorkspaceIpcOptions,
-): DesktopMessageHandler {
+): DesktopWorkspaceIpc {
   const reportError = (error: unknown) => options.onAsyncError?.(error);
 
   function postFileError(path: string, error: unknown): void {
@@ -278,6 +288,11 @@ export function createDesktopWorkspaceIpc(
   }
 
   return {
+    disposeRendererResources() {
+      options.ptyHost.disposeAll();
+      options.browserViews.disposeAll();
+    },
+
     handleMessage(message: DesktopCommandMessage) {
       const parsed = DesktopWorkspaceInboundMessageSchema.safeParse(message);
       if (!parsed.success) return false;

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1145,6 +1145,17 @@ function createWindow(options: {
       onAsyncError: reportAsyncError,
     },
   );
+  let initialRendererNavigationComplete = false;
+  window.webContents.on('did-navigate', () => {
+    if (!initialRendererNavigationComplete) {
+      initialRendererNavigationComplete = true;
+      return;
+    }
+    // A fresh renderer has its own terminal IDs and browser-tab layout. Tear
+    // down the previous document's main-process resources before those IDs can
+    // be reused or an old WebContentsView can cover the new page.
+    workspaceIpc.disposeRendererResources();
+  });
   const mainViewIpc = installDesktopMainViewIpc(window, {
     workspace: workspaceIpc,
     executeAgent: async (message) => {
@@ -1213,8 +1224,7 @@ function createWindow(options: {
     setupSignInRegistration.dispose();
     // Shells keep running and web contents keep loading unless explicitly torn
     // down — neither is reachable once the window is gone.
-    ptyHost.disposeAll();
-    browserViews.disposeAll();
+    workspaceIpc.disposeRendererResources();
     if (workspaceRelaunch) {
       void (async () => {
         try {

--- a/src/test-kernel/desktop/DesktopControlSystem.vitest.mts
+++ b/src/test-kernel/desktop/DesktopControlSystem.vitest.mts
@@ -257,6 +257,9 @@ describe('desktop control system', () => {
     expect(electronMain).toContain('confirmDiscardUnsavedEditorChanges(true)');
     expect(electronMain).toContain('allowNextPreventedUnload');
     expect(electronMain).toMatch(
+      /webContents\.on\('did-navigate',[\s\S]*?initialRendererNavigationComplete[\s\S]*?workspaceIpc\.disposeRendererResources\(\)/u,
+    );
+    expect(electronMain).toMatch(
       /workspaceRelaunchInProgress = true;[\s\S]*?window\.close\(\);[\s\S]*?window\.once\('closed',[\s\S]*?app\.relaunch/u,
     );
     expect(electronMain).toMatch(

--- a/src/test-kernel/desktop/DesktopPtyHost.vitest.mts
+++ b/src/test-kernel/desktop/DesktopPtyHost.vitest.mts
@@ -127,4 +127,27 @@ describe('desktop pty host', () => {
     expect(spawnPty).toHaveBeenCalledOnce();
     expect(host.get('workbench:terminal:1')).toBe(replacement);
   });
+
+  it('ignores a module-load failure from an invalidated creation', async () => {
+    let failLoading = (_error: Error): void => {};
+    const loadFailure = new Promise<PtyModule>((_resolve, reject) => {
+      failLoading = reject;
+    });
+    const host = createDesktopPtyHost({
+      onData: vi.fn(),
+      onExit: vi.fn(),
+      loadPty: vi.fn<LoadPty>().mockReturnValue(loadFailure),
+    });
+
+    const staleCreation = host.create({
+      id: 'workbench:terminal:1',
+      cols: 80,
+      rows: 24,
+    });
+    host.disposeAll();
+    failLoading(new Error('node-pty unavailable'));
+
+    await expect(staleCreation).resolves.toBeUndefined();
+    expect(host.get('workbench:terminal:1')).toBeUndefined();
+  });
 });

--- a/src/test-kernel/desktop/DesktopPtyHost.vitest.mts
+++ b/src/test-kernel/desktop/DesktopPtyHost.vitest.mts
@@ -1,0 +1,78 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports
+import { createDesktopPtyHost } from '@desktop/main/desktopPtyHost';
+
+interface FakePty {
+  emitData(data: string): void;
+  emitExit(exitCode: number): void;
+  kill: ReturnType<typeof vi.fn>;
+}
+
+function createFakePty(pid: number): FakePty & {
+  onData(listener: (data: string) => void): void;
+  onExit(listener: (event: { exitCode: number }) => void): void;
+  write: ReturnType<typeof vi.fn>;
+  resize: ReturnType<typeof vi.fn>;
+  readonly pid: number;
+} {
+  let dataListener = (_data: string): void => {};
+  let exitListener = (_event: { exitCode: number }): void => {};
+  return {
+    pid,
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+    onData(listener) {
+      dataListener = listener;
+    },
+    onExit(listener) {
+      exitListener = listener;
+    },
+    emitData: (data) => dataListener(data),
+    emitExit: (exitCode) => exitListener({ exitCode }),
+  };
+}
+
+describe('desktop pty host', () => {
+  it('ignores callbacks from a disposed session after its id is reused', async () => {
+    const oldPty = createFakePty(101);
+    const replacementPty = createFakePty(102);
+    const spawnPty = vi
+      .fn()
+      .mockReturnValueOnce(oldPty)
+      .mockReturnValueOnce(replacementPty);
+    const onData = vi.fn();
+    const onExit = vi.fn();
+    const host = createDesktopPtyHost({ onData, onExit, spawnPty });
+
+    const oldSession = await host.create({
+      id: 'workbench:terminal:1',
+      cols: 80,
+      rows: 24,
+    });
+    oldSession.dispose();
+    const replacementSession = await host.create({
+      id: 'workbench:terminal:1',
+      cols: 100,
+      rows: 30,
+    });
+
+    expect(replacementSession).not.toBe(oldSession);
+    expect(spawnPty).toHaveBeenCalledTimes(2);
+    oldPty.emitData('late output');
+    oldPty.emitExit(0);
+
+    expect(host.get('workbench:terminal:1')).toBe(replacementSession);
+    expect(onData).not.toHaveBeenCalled();
+    expect(onExit).not.toHaveBeenCalled();
+
+    replacementPty.emitData('new output');
+    replacementPty.emitExit(7);
+
+    expect(onData).toHaveBeenCalledWith('workbench:terminal:1', 'new output');
+    expect(onExit).toHaveBeenCalledWith('workbench:terminal:1', 7);
+    expect(host.get('workbench:terminal:1')).toBeUndefined();
+  });
+});

--- a/src/test-kernel/desktop/DesktopPtyHost.vitest.mts
+++ b/src/test-kernel/desktop/DesktopPtyHost.vitest.mts
@@ -2,28 +2,29 @@
 import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
-import { createDesktopPtyHost } from '@desktop/main/desktopPtyHost';
+import {
+  createDesktopPtyHost,
+  type DesktopPtyHostOptions,
+} from '@desktop/main/desktopPtyHost';
+
+type LoadPty = NonNullable<DesktopPtyHostOptions['loadPty']>;
+type PtyModule = Awaited<ReturnType<LoadPty>>;
+type SpawnPty = PtyModule['spawn'];
+type PtyProcess = ReturnType<SpawnPty>;
 
 interface FakePty {
   emitData(data: string): void;
   emitExit(exitCode: number): void;
-  kill: ReturnType<typeof vi.fn>;
 }
 
-function createFakePty(pid: number): FakePty & {
-  onData(listener: (data: string) => void): void;
-  onExit(listener: (event: { exitCode: number }) => void): void;
-  write: ReturnType<typeof vi.fn>;
-  resize: ReturnType<typeof vi.fn>;
-  readonly pid: number;
-} {
+function createFakePty(pid: number): FakePty & PtyProcess {
   let dataListener = (_data: string): void => {};
-  let exitListener = (_event: { exitCode: number }): void => {};
+  let exitListener: Parameters<PtyProcess['onExit']>[0] = () => {};
   return {
     pid,
-    write: vi.fn(),
-    resize: vi.fn(),
-    kill: vi.fn(),
+    write: vi.fn<(data: string) => void>(),
+    resize: vi.fn<(cols: number, rows: number) => void>(),
+    kill: vi.fn<(signal?: string) => void>(),
     onData(listener) {
       dataListener = listener;
     },
@@ -35,29 +36,41 @@ function createFakePty(pid: number): FakePty & {
   };
 }
 
+function loadFakePty(spawn: SpawnPty): LoadPty {
+  return async () => ({ spawn });
+}
+
 describe('desktop pty host', () => {
   it('ignores callbacks from a disposed session after its id is reused', async () => {
     const oldPty = createFakePty(101);
     const replacementPty = createFakePty(102);
     const spawnPty = vi
-      .fn()
+      .fn<SpawnPty>()
       .mockReturnValueOnce(oldPty)
       .mockReturnValueOnce(replacementPty);
     const onData = vi.fn();
     const onExit = vi.fn();
-    const host = createDesktopPtyHost({ onData, onExit, spawnPty });
+    const host = createDesktopPtyHost({
+      onData,
+      onExit,
+      loadPty: loadFakePty(spawnPty),
+    });
 
     const oldSession = await host.create({
       id: 'workbench:terminal:1',
       cols: 80,
       rows: 24,
     });
+    if (!oldSession) throw new Error('Expected the old session to start.');
     oldSession.dispose();
     const replacementSession = await host.create({
       id: 'workbench:terminal:1',
       cols: 100,
       rows: 30,
     });
+    if (!replacementSession) {
+      throw new Error('Expected the replacement session to start.');
+    }
 
     expect(replacementSession).not.toBe(oldSession);
     expect(spawnPty).toHaveBeenCalledTimes(2);
@@ -74,5 +87,44 @@ describe('desktop pty host', () => {
     expect(onData).toHaveBeenCalledWith('workbench:terminal:1', 'new output');
     expect(onExit).toHaveBeenCalledWith('workbench:terminal:1', 7);
     expect(host.get('workbench:terminal:1')).toBeUndefined();
+  });
+
+  it('abandons a session creation invalidated while its module loads', async () => {
+    const pty = createFakePty(201);
+    const spawnPty = vi.fn<SpawnPty>(() => pty);
+    let finishLoading = (_module: PtyModule): void => {};
+    const firstLoad = new Promise<PtyModule>((resolve) => {
+      finishLoading = resolve;
+    });
+    const loadPty = vi
+      .fn<LoadPty>()
+      .mockReturnValueOnce(firstLoad)
+      .mockResolvedValue({ spawn: spawnPty });
+    const host = createDesktopPtyHost({
+      onData: vi.fn(),
+      onExit: vi.fn(),
+      loadPty,
+    });
+
+    const staleCreation = host.create({
+      id: 'workbench:terminal:1',
+      cols: 80,
+      rows: 24,
+    });
+    host.disposeAll();
+    finishLoading({ spawn: spawnPty });
+
+    expect(await staleCreation).toBeUndefined();
+    expect(spawnPty).not.toHaveBeenCalled();
+    expect(host.get('workbench:terminal:1')).toBeUndefined();
+
+    const replacement = await host.create({
+      id: 'workbench:terminal:1',
+      cols: 100,
+      rows: 30,
+    });
+    expect(replacement).toBeDefined();
+    expect(spawnPty).toHaveBeenCalledOnce();
+    expect(host.get('workbench:terminal:1')).toBe(replacement);
   });
 });

--- a/src/test-kernel/desktop/DesktopWorkspaceIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopWorkspaceIpc.vitest.mts
@@ -277,6 +277,24 @@ describe('desktop workspace IPC', () => {
     expect(onEditorDirtyChange).toHaveBeenCalledWith(true);
   });
 
+  it('disposes terminal and browser resources at a renderer boundary', () => {
+    const ptyHost = createPtyHost();
+    const browserViews = createBrowserViews();
+    const ipc = createDesktopWorkspaceIpc(
+      { postToRenderer: vi.fn() },
+      {
+        ptyHost,
+        browserViews,
+        toWindowBounds: (bounds) => bounds,
+      },
+    );
+
+    ipc.disposeRendererResources();
+
+    expect(ptyHost.disposeAll).toHaveBeenCalledOnce();
+    expect(browserViews.disposeAll).toHaveBeenCalledOnce();
+  });
+
   it('posts environment state and clears loading state after host failures', async () => {
     const environment: DesktopEnvironmentSummary = {
       isGitRepository: true,


### PR DESCRIPTION
## Summary

- dispose integrated terminal sessions and embedded browser views after a renderer reload
- preserve resources during the initial renderer navigation
- prevent delayed callbacks from a disposed shell from affecting a replacement that reuses its terminal ID
- cancel terminal creation requests, including late load failures, after their renderer is replaced
- use the same workspace-owned cleanup operation when the application window closes
- test the joint resource boundary, window navigation wiring, callback race, and pending-load races

## Design

Desktop workspace IPC already owns both main-process resource families associated with one renderer document. Its disposal operation is therefore the single lifecycle boundary for reload and window close. A successful application-window navigation after the initial load invokes that operation before the new renderer can reuse terminal IDs or inherit a stale overlaid browser view.

Pseudo-terminal callbacks verify handle identity, not only the textual terminal ID. Delayed output or exit from a killed process therefore cannot mutate or notify a replacement process that inherited the same renderer-generated ID. Disposal also advances the host generation, so a terminal request still awaiting the native module is abandoned before either its successful result or failure can enter the new renderer's ID namespace.

## Validation

- `corepack pnpm vitest run src/test-kernel/desktop/DesktopPtyHost.vitest.mts src/test-kernel/desktop/DesktopWorkspaceIpc.vitest.mts src/test-kernel/desktop/DesktopControlSystem.vitest.mts` (25 tests)
- `corepack pnpm run typecheck`
- `corepack pnpm run lint`
- pre-commit format and guidance-reference checks

Closes #9282
