### PR TITLE
fix: remove orchestration session footer

### DIFF
--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -24,9 +24,7 @@ import '@progressView/frontend';
 import '@progressView/frontend/components/TexraDiffView';
 import type { StreamTabs } from '@progressView/frontend/components/StreamTabs';
 import {
-  handleDeleteAll,
   handleFileAction,
-  handleFilterChange,
   handleFollowupRequestOptions,
   handleFollowUpChange,
   handleFollowUpClear,
@@ -48,7 +46,6 @@ import {
   childStreamsByParent$,
   hasAnyStreams$,
   pendingApprovalIds$,
-  streamFilter$,
   streamStates$,
   streams$,
   tabStreams$,
@@ -332,6 +329,7 @@ conversationView.setAttribute('data-desktop-view', 'progress');
 // Left rail: a fresh <stream-tabs> mount wired to module-level progressState.
 // PRD § 7.D requires mounting <stream-tabs> directly (not inside <progress-app>).
 const railTabs = document.createElement('stream-tabs') as StreamTabs;
+railTabs.presentation = 'orchestration';
 
 const settingsView: HTMLElement = document.createElement('settings-app');
 settingsView.setAttribute('data-desktop-view', 'settings');
@@ -1193,7 +1191,6 @@ function rerenderShell(): void {
   );
   railTabs.streams = tabStreams$.get();
   railTabs.activeStreamId = activeStreamId$.get();
-  railTabs.filter = streamFilter$.get();
   railTabs.streamStates = streamStates$.get();
   railTabs.pendingApprovalStreamIds = pendingApprovalIds$.get();
   railTabs.childStreamsByParent = childStreamsByParent$.get();
@@ -1281,7 +1278,6 @@ function installShellSignalWatcher(): void {
     activeStreamId$.get();
     hasAnyStreams$.get();
     tabStreams$.get();
-    streamFilter$.get();
     streamStates$.get();
     pendingApprovalIds$.get();
     childStreamsByParent$.get();
@@ -1648,11 +1644,6 @@ function wireRailTabs(): void {
     'stream-delete',
     handleStreamDelete as EventListener,
   );
-  railTabs.addEventListener(
-    'filter-change',
-    handleFilterChange as EventListener,
-  );
-  railTabs.addEventListener('delete-all', handleDeleteAll as EventListener);
 }
 
 let conversationWired = false;

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -315,6 +315,8 @@ export class StreamTabs extends LitElement {
 
   @property({ attribute: false }) streams: StreamTabInfo[] = [];
   @property({ type: Boolean, reflect: true }) compact = false;
+  @property({ type: String }) presentation: 'progress' | 'orchestration' =
+    'progress';
   /** Optional rail-header title. Empty (default) renders no header band. */
   @property({ type: String }) heading = '';
   @property({ attribute: false }) activeStreamId: string | null = null;
@@ -474,7 +476,9 @@ export class StreamTabs extends LitElement {
           )}
         </div>
         ${
-          this.compact || (this.streams.length === 0 && this.filter === 'all')
+          this.presentation === 'orchestration' ||
+          this.compact ||
+          (this.streams.length === 0 && this.filter === 'all')
             ? nothing
             : html`<div class="stream-list-footer">
                 <div class="stream-list-controls">

--- a/src/test-kernel/progressView/StreamTabsExpandChevron.vitest.mts
+++ b/src/test-kernel/progressView/StreamTabsExpandChevron.vitest.mts
@@ -79,6 +79,26 @@ describe('stream-tab expand chevron', () => {
     expect(ariaLabel).toContain('unlabeled-stream');
   });
 
+  it('omits the session footer in the orchestration presentation', async () => {
+    const tabs = document.createElement('stream-tabs') as StreamTabs;
+    tabs.presentation = 'orchestration';
+    tabs.streams = [makeStream('session')];
+    document.body.append(tabs);
+    await tabs.updateComplete;
+
+    expect(tabs.shadowRoot?.querySelector('.stream-list-footer')).toBeNull();
+    expect(tabs.shadowRoot?.querySelector('stream-tab')).toBeTruthy();
+  });
+
+  it('retains the session footer in the progress presentation', async () => {
+    const tabs = document.createElement('stream-tabs') as StreamTabs;
+    tabs.streams = [makeStream('session')];
+    document.body.append(tabs);
+    await tabs.updateComplete;
+
+    expect(tabs.shadowRoot?.querySelector('.stream-list-footer')).toBeTruthy();
+  });
+
   it('anchors the general hint to the title, not an ancestor of specific hints', async () => {
     const tabs = document.createElement('stream-tabs') as StreamTabs;
     tabs.streams = [


### PR DESCRIPTION
## Summary

- remove the All, Workflow, and Interactive filters from the desktop orchestration session rail
- remove the clear-all-streams action from that rail
- retain the existing footer in the ordinary progress view
- remove the desktop filter and clear-all event wiring that is no longer reachable

## Verification

- `npm test` (7,802 passed; 4 skipped)
- `npm run typecheck`
- `npm run lint`
- `npm run compile:fast`

Closes #9266

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop-only UI and dead-code removal; progress view behavior unchanged and covered by new tests.
> 
> **Overview**
> The desktop **orchestration** session rail is simplified: it no longer shows the stream list footer (All / Workflow / Interactive filters or **Clear all streams**).
> 
> **`stream-tabs`** gains a `presentation` property (`progress` | `orchestration`). When set to `orchestration`, the footer is omitted; the default **progress** view keeps the existing footer. The desktop shell sets `railTabs.presentation = 'orchestration'` and drops `streamFilter$` binding plus `filter-change` and `delete-all` listeners that only served that rail.
> 
> Vitest covers footer presence for both presentations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d6cad2c3d2d670fcc708945f6a2a5bfa0b5a911. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->