### PR TITLE
fix: show all orchestration sessions

### DIFF
--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -48,7 +48,7 @@ import {
   pendingApprovalIds$,
   streamStates$,
   streams$,
-  tabStreams$,
+  topLevelStreams$,
 } from '@progressView/frontend/progressState';
 import { COMMON_COMMANDS, PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import '@settingsView/frontend';
@@ -1189,7 +1189,7 @@ function rerenderShell(): void {
     activeWorkbenchTab(shellState, 'right')?.kind === 'logs' ||
       activeWorkbenchTab(shellState, 'bottom')?.kind === 'logs',
   );
-  railTabs.streams = tabStreams$.get();
+  railTabs.streams = topLevelStreams$.get();
   railTabs.activeStreamId = activeStreamId$.get();
   railTabs.streamStates = streamStates$.get();
   railTabs.pendingApprovalStreamIds = pendingApprovalIds$.get();
@@ -1277,7 +1277,7 @@ function installShellSignalWatcher(): void {
   const shellDeps = new Signal.Computed(() => {
     activeStreamId$.get();
     hasAnyStreams$.get();
-    tabStreams$.get();
+    topLevelStreams$.get();
     streamStates$.get();
     pendingApprovalIds$.get();
     childStreamsByParent$.get();

--- a/packages/extension/src/progressView/frontend/progressState.ts
+++ b/packages/extension/src/progressView/frontend/progressState.ts
@@ -113,9 +113,14 @@ export const streams$ = new Signal.Computed(() => [
   ...streamById$.get().values(),
 ]);
 
+/** Top-level streams, independent of the progress view's category filter. */
+export const topLevelStreams$ = new Signal.Computed(() =>
+  streams$.get().filter((stream) => !stream.parentStreamId),
+);
+
 /** Top-level streams for the tab list (child streams excluded). */
 export const tabStreams$ = new Signal.Computed(() => {
-  const topLevel = streams$.get().filter((stream) => !stream.parentStreamId);
+  const topLevel = topLevelStreams$.get();
   const filter = streamFilter$.get();
   if (filter === 'all') return topLevel;
   return topLevel.filter((stream) => stream.agentCategory === filter);

--- a/src/test-kernel/progressView/StreamMetaState.vitest.ts
+++ b/src/test-kernel/progressView/StreamMetaState.vitest.ts
@@ -10,6 +10,8 @@ import {
   phaseStages$,
   resetProgressState,
   setStreamStateForId,
+  tabStreams$,
+  topLevelStreams$,
 } from '@progressView/frontend/progressState';
 import {
   createInitialState,
@@ -59,6 +61,39 @@ function registerWorkflowStream(
 describe('stream meta frontend state', () => {
   beforeEach(() => {
     resetProgressState();
+  });
+
+  it('keeps the unfiltered top-level stream list independent of the progress filter', () => {
+    const workflowId = 'workflow' as StreamTabId;
+    const toolUseId = 'tool-use' as StreamTabId;
+    const childId = 'child' as StreamTabId;
+    const state = createInitialState();
+    state.streamFilter = 'workflow';
+    registerWorkflowStream(state, workflowId);
+    state.streamById.set(toolUseId, {
+      kind: 'agent',
+      name: toolUseId,
+      label: 'tool-use',
+      agentCategory: AgentCategory.ToolUse,
+      creationTimestamp: 2,
+    });
+    state.streamById.set(childId, {
+      kind: 'agent',
+      name: childId,
+      label: 'child',
+      agentCategory: AgentCategory.ToolUse,
+      creationTimestamp: 3,
+      parentStreamId: workflowId,
+    });
+    seedState(state);
+
+    expect(tabStreams$.get().map((stream) => stream.name)).toEqual([
+      workflowId,
+    ]);
+    expect(topLevelStreams$.get().map((stream) => stream.name)).toEqual([
+      workflowId,
+      toolUseId,
+    ]);
   });
 
   it('patches one stream metadata record without replacing siblings', () => {


### PR DESCRIPTION
## Summary

- make the desktop orchestration rail independent of the progress view's saved category filter
- show every top-level orchestration session after the footer controls are removed
- retain category filtering in the ordinary progress view
- add regression coverage for a saved Workflow filter with Workflow, Interactive, and child sessions present

## Verification

- `npm test` (7,803 passed; 4 skipped)
- `npm run typecheck`
- `npm run lint`
- `npm run compile:fast`

Follow-up to #9299 and #9266.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small derived-state split and desktop rail data source change; VS Code progress tabs still use tabStreams$ with filtering unchanged.
> 
> **Overview**
> The desktop **orchestration rail** now lists every **top-level** session instead of reusing the progress view’s **category filter** (`tabStreams$`).
> 
> A new **`topLevelStreams$`** signal holds parent-less streams only; **`tabStreams$`** still applies `streamFilter$` for the ordinary progress / VS Code session list. The renderer wires the sidebar `<stream-tabs>` (orchestration presentation) to **`topLevelStreams$`** in both shell rerenders and the signal watcher.
> 
> Regression coverage asserts that with a saved Workflow filter, **`tabStreams$`** stays filtered while **`topLevelStreams$`** still includes Workflow and Interactive top-level sessions (children excluded).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb08e6cd1637c2125fe784e700e59d3fbca98d59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->