### PR TITLE
fix: stop silently zeroing usage deltas that fail schema validation

### DIFF
--- a/src/shared/schemas/streamData.ts
+++ b/src/shared/schemas/streamData.ts
@@ -24,7 +24,6 @@ import {
 import {
   TokenUsageStatsBaseSchema,
   UsageRouteSchema,
-  emptyUsageStats,
   isEmptyUsage,
   type TokenUsageStats,
 } from './usage';
@@ -155,13 +154,13 @@ const TokenUsageStatsParsingBaseSchema = z
     return usageRoute == null ? stats : { ...stats, usageRoute };
   }) as z.ZodType<TokenUsageStats>;
 
-export const TokenUsageStatsParsingSchema =
-  TokenUsageStatsParsingBaseSchema.catch(emptyUsageStats());
-
-// Compile-time assertion: parsing schema output must be assignable to canonical type.
-void (null as unknown as z.infer<
-  typeof TokenUsageStatsParsingSchema
-> satisfies TokenUsageStats);
+/**
+ * Exported so callers that need to validate a single usage delta (e.g.
+ * {@link StreamSnapshotStore.addUsage}) can `safeParse` it themselves and log
+ * loudly on failure, instead of defaulting to zero. Never wrap this in
+ * `.catch()` for persisted/cost data — see `parseUsageData`'s docs and #7464.
+ */
+export { TokenUsageStatsParsingBaseSchema };
 
 export interface ParsedUsageData {
   /** Successfully parsed, non-empty per-run usage. */

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -174,6 +174,35 @@ describe('StreamSnapshotStore', () => {
     );
   });
 
+  it('discards a malformed usage delta LOUDLY instead of silently zeroing accumulated cost', async () => {
+    const warnSpy = vi.spyOn(logUtils, 'warn').mockImplementation(() => {});
+    const writer = new StreamSnapshotStore();
+
+    void writer.addUsage(STREAM, RUN, usage(100, 20, 0.5));
+    // A delta with an uncoercible numeric field must not wipe out the
+    // already-accumulated cost, and must warn rather than fail silently.
+    void writer.addUsage(STREAM, RUN, {
+      ...usage(50, 10, 0.25),
+      inputTokens: 'not-a-number' as unknown as number,
+    });
+
+    await writer.flush();
+
+    const reader = new StreamSnapshotStore();
+    const snap = await reader.read(STREAM);
+    expect(snap.runUsage[RUN]).toMatchObject({
+      inputTokens: 100,
+      outputTokens: 20,
+      cost: 0.5,
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      'StreamSnapshotStore',
+      expect.stringContaining('Discarding malformed usage delta'),
+      expect.anything(),
+    );
+    warnSpy.mockRestore();
+  });
+
   it('persists durable run facts directly from session events and ignores goalPaused', async () => {
     const events = new SessionEventHub();
     const writer = new StreamSnapshotStore();

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -42,7 +42,7 @@ import {
   RoundKeySchema,
   StreamTabIdSchema,
   sumUsageStats,
-  TokenUsageStatsParsingSchema,
+  TokenUsageStatsParsingBaseSchema,
   buildRunDescriptor,
   type CompileFailure,
   type ExecutionId,
@@ -831,7 +831,20 @@ export class StreamSnapshotStore {
     storageKey: StorageKey,
     usage: TokenUsageStats,
   ): UsageUpdateResult {
-    const delta = TokenUsageStatsParsingSchema.parse(usage);
+    const parsed = TokenUsageStatsParsingBaseSchema.safeParse(usage);
+    if (!parsed.success) {
+      logger.warn(
+        CHANNEL,
+        `Discarding malformed usage delta for run ${storageKey} on stream ` +
+          `${stream} instead of silently zeroing accumulated cost.`,
+        {
+          data: parsed.error.issues
+            .map((i) => `${i.path.join('.') || '<root>'}: ${i.message}`)
+            .join('; '),
+        },
+      );
+    }
+    const delta = parsed.success ? parsed.data : emptyUsageStats();
     const version = this.streamVersion(stream);
     const overlayPatch = isEmptyUsage(delta)
       ? undefined


### PR DESCRIPTION
## Summary

A scheduled data-structure review flagged that `StreamSnapshotStore.addUsage()` parsed incoming per-run token-usage deltas through `TokenUsageStatsParsingSchema`, a Zod schema built with `.catch(emptyUsageStats())`. If a delta ever failed validation (e.g. a non-coercible numeric field), it silently collapsed to an all-zero usage object and was merged into the accumulated cost overlay that `writeUsage()` persists to `usageStats.json` — undercounting real cost with no trace of the failure. This is the exact silent-zero billing bug that `parseUsageData()` (same file) was rewritten to fix on the *read* path (see its docstring referencing bug #7464); the live-delta *write* path (`addUsage`) still had it.

`addUsage()` now `safeParse`s the delta and logs a loud warning via `logger.warn` on failure instead of silently defaulting to zero, mirroring `parseUsageData()`'s existing pattern. The catching schema export (`TokenUsageStatsParsingSchema`) is removed since it had exactly one call site and existed only to enable the swallow; the underlying non-catching base schema is now exported directly (`TokenUsageStatsParsingBaseSchema`) for `safeParse` use.

## Issue acceptance gates

No tracked issue — surfaced by a scheduled codebase review for data-structure/parsing anti-patterns. Acceptance gate: usage deltas that fail validation must be discarded loudly (logged) rather than silently zeroing/corrupting persisted cost data, matching the standard already applied to `parseUsageData()`.

## Single source of truth

`TokenUsageStatsParsingBaseSchema` (`src/shared/schemas/streamData.ts`) is now the one exported schema for parsing a single usage object; both `parseUsageData()` (read path) and `StreamSnapshotStore.addUsage()` (write path) use `safeParse` against it and handle failure the same way (log + fall back to `emptyUsageStats()` without persisting the failure as truth).

## Duplication and abstraction budget

Removed the divergent second parsing strategy (`.catch()`-wrapped schema) rather than adding a new abstraction — `addUsage` now reuses the same base schema and failure-handling shape `parseUsageData` already established. No new exports beyond renaming the one that was removed.

## Net elements (R6)

n/a — bug fix, not a refactor/simplify/consolidate/dedupe/extract PR. Net diff: -1 export (`TokenUsageStatsParsingSchema`), +1 export (`TokenUsageStatsParsingBaseSchema`, previously private), +1 test.

## Consumer counts (R8)

`TokenUsageStatsParsingSchema` had exactly 1 consumer (`StreamSnapshotStore.ts`), grepped repo-wide before removal; that consumer is updated in this PR. No other references found outside a docs file (unaffected).

## Host impact

Extension: none — `StreamSnapshotStore` is host-agnostic core, used identically by all hosts.

Desktop: none.

CLI: none.

## Scheduled refactoring

None. Two other Low-severity findings from the same review (`ExternalToolDef`'s flat 19-optional-field bag in `src/tools/externalToolDefs.ts`, and near-duplicate JSON-schema-ish types in `packages/extension/src/schemas/texraSettings.ts`) were deliberately left out of this PR — both are static/build-time config shapes with no correctness bug, and reshaping them carries diff risk disproportionate to the benefit. No follow-up issue filed.

## Validation

- `npx tsc --noEmit` (root) — pass
- `npx tsc --noEmit -p tsconfig.test-kernel.json` — pass
- `pnpm --filter texra typecheck`, `--filter @texra-ai/cli typecheck`, `--filter @texra/trace-viewer run typecheck`, `--filter @texra/desktop typecheck` — all pass
- `npx eslint src/shared/schemas/streamData.ts src/transcript/StreamSnapshotStore.ts` — clean
- `npx vitest run` on `StreamSnapshotStore.vitest.ts` (incl. new regression test), `StreamContentSync.vitest.ts`, `ProgressBackend.vitest.ts`, `executionStreamResolver.vitest.ts`, `completedRunArchive.vitest.ts`, `LegacyDataMigration.vitest.ts`, `ExecutionsToolWorkspaceFiles.vitest.ts` — all pass (190 tests)
- `npm run check:dead-code-ratchet` — no new violations
- Full-repo `npx vitest run` was kicked off but not awaited to completion before pushing; the targeted suites above cover every file touched by this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBWbxNukChvMNjeeUn6P9C)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches token/cost persistence on the live write path, but behavior only changes when validation fails (now warn + skip delta); valid deltas unchanged.
> 
> **Overview**
> Fixes a **write-path billing bug**: `StreamSnapshotStore.addUsage()` used `TokenUsageStatsParsingSchema` with `.catch(emptyUsageStats())`, so a bad delta could merge as all zeros into `usageStats.json` with no trace—the same class of issue `parseUsageData()` already guards on read (#7464).
> 
> **`addUsage`** now **`safeParse`s** via **`TokenUsageStatsParsingBaseSchema`**, **`logger.warn`s** on failure, and treats the delta as **empty** so **already-accumulated** run totals are unchanged. The catching export **`TokenUsageStatsParsingSchema`** is removed; the base schema is **exported** for callers that must handle parse failures explicitly (docs say not to wrap it in `.catch()` for persisted cost). A **regression test** covers a non-coercible `inputTokens` field after a valid delta.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecae764097f24ae3b478314ab22147a20aff869a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->