### PR TITLE
refactor(tools): factor prerequisites-check wiring in externalToolDefs

### DIFF
--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -218,6 +218,37 @@ async function probeSdkBinaryAvailable(
   }
 }
 
+/**
+ * Wire a prerequisites-style availability entry. `probe` runs once and its
+ * result is cached by the availability layer, then handed back to every
+ * callback as `probeResult`. `resolve` turns that (possibly absent) cached
+ * value into a typed prerequisites object which `check`/`statusLabel`/
+ * `detailCheck` receive directly — so each entry declares the
+ * `resolve(probeResult)` step once instead of repeating it in all three
+ * callbacks, and those callbacks stay pure functions of the resolved value.
+ */
+function prerequisitesChecks<T>(config: {
+  probe: () => Promise<T>;
+  resolve: (probeResult: unknown) => T | Promise<T>;
+  check: (prereqs: T) => boolean;
+  statusLabel?: (prereqs: T) => string | undefined;
+  detailCheck?: (prereqs: T) => string | undefined;
+}): Pick<ExternalToolDef, 'probe' | 'check' | 'statusLabel' | 'detailCheck'> {
+  const { probe, resolve, check, statusLabel, detailCheck } = config;
+  return {
+    probe,
+    check: async (probeResult) => check(await resolve(probeResult)),
+    ...(statusLabel && {
+      statusLabel: async (probeResult) =>
+        statusLabel(await resolve(probeResult)),
+    }),
+    ...(detailCheck && {
+      detailCheck: async (probeResult) =>
+        detailCheck(await resolve(probeResult)),
+    }),
+  };
+}
+
 // ============================================================
 // Definitions
 // ============================================================
@@ -336,47 +367,43 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     configNotes:
       'VS Code build: requires the leanprover.lean4 extension. ' +
       'CLI / desktop builds: requires `lake` on PATH; each Lake project root gets its own language server, surfaced below.',
-    probe: async () => {
-      const extensionAvailable =
-        platform().toolAvailability.isVscodeExtensionInstalled(
-          LEAN4_EXTENSION_ID,
-        );
-      const lakeAvailable = BinaryResolver.findPath('lake') !== null;
-      return { extensionAvailable, lakeAvailable };
-    },
-    check: async (probeResult) => {
-      const { extensionAvailable, lakeAvailable } =
-        resolveLean4Prerequisites(probeResult);
-      return extensionAvailable || lakeAvailable;
-    },
-    statusLabel: async (probeResult) => {
-      const { extensionAvailable, lakeAvailable } =
-        resolveLean4Prerequisites(probeResult);
-      if (!extensionAvailable && !lakeAvailable) return 'Needs setup';
-      const activeCount = listLeanServers().filter(isLeanServerActive).length;
-      return activeCount > 0
-        ? `${formatResultCount(activeCount, 'server')} active`
-        : undefined;
-    },
-    detailCheck: async (probeResult) => {
-      const { extensionAvailable, lakeAvailable } =
-        resolveLean4Prerequisites(probeResult);
-      const lines: string[] = [];
-      if (extensionAvailable) {
-        lines.push('VS Code Lean 4 extension installed.');
-      }
-      if (lakeAvailable) {
-        lines.push('Direct LSP mode available (`lake` on PATH).');
-      }
-      if (!extensionAvailable && !lakeAvailable) {
-        lines.push(
-          'Neither the leanprover.lean4 extension nor a `lake` binary was detected. Install one of them to enable Lean tools.',
-        );
-      }
-      lines.push('');
-      lines.push(summarizeLeanServers());
-      return lines.join('\n');
-    },
+    ...prerequisitesChecks({
+      probe: async () => {
+        const extensionAvailable =
+          platform().toolAvailability.isVscodeExtensionInstalled(
+            LEAN4_EXTENSION_ID,
+          );
+        const lakeAvailable = BinaryResolver.findPath('lake') !== null;
+        return { extensionAvailable, lakeAvailable };
+      },
+      resolve: resolveLean4Prerequisites,
+      check: ({ extensionAvailable, lakeAvailable }) =>
+        extensionAvailable || lakeAvailable,
+      statusLabel: ({ extensionAvailable, lakeAvailable }) => {
+        if (!extensionAvailable && !lakeAvailable) return 'Needs setup';
+        const activeCount = listLeanServers().filter(isLeanServerActive).length;
+        return activeCount > 0
+          ? `${formatResultCount(activeCount, 'server')} active`
+          : undefined;
+      },
+      detailCheck: ({ extensionAvailable, lakeAvailable }) => {
+        const lines: string[] = [];
+        if (extensionAvailable) {
+          lines.push('VS Code Lean 4 extension installed.');
+        }
+        if (lakeAvailable) {
+          lines.push('Direct LSP mode available (`lake` on PATH).');
+        }
+        if (!extensionAvailable && !lakeAvailable) {
+          lines.push(
+            'Neither the leanprover.lean4 extension nor a `lake` binary was detected. Install one of them to enable Lean tools.',
+          );
+        }
+        lines.push('');
+        lines.push(summarizeLeanServers());
+        return lines.join('\n');
+      },
+    }),
   },
   {
     id: 'workflow-script',
@@ -413,34 +440,29 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     toggleable: true,
     installActionCommand: 'texra.showGitSettings',
     installActionLabel: 'Open Git settings',
-    probe: getGitHubPRPrerequisites,
-    check: async (probeResult) => {
-      const { tokenPresent, inGitRepo } =
-        await resolveGitHubPRPrerequisites(probeResult);
-      return tokenPresent && inGitRepo;
-    },
-    statusLabel: async (probeResult) => {
-      const { tokenPresent, inGitRepo } =
-        await resolveGitHubPRPrerequisites(probeResult);
-      if (tokenPresent && inGitRepo) return undefined;
-      if (tokenPresent && !inGitRepo) return 'Needs git repo';
-      if (!tokenPresent && inGitRepo) return 'Needs token';
-      return 'Needs setup';
-    },
-    detailCheck: async (probeResult) => {
-      const { tokenPresent, inGitRepo } =
-        await resolveGitHubPRPrerequisites(probeResult);
-      if (tokenPresent && inGitRepo) {
-        return 'GitHub token detected and workspace is a git repo. Ready to subscribe to PR activity.';
-      }
-      if (!tokenPresent && !inGitRepo) {
-        return 'Open a git-tracked folder, or run git init and add a github.com remote. Then set a token in the Git tab.';
-      }
-      if (!tokenPresent) {
-        return 'This workspace is a git repo. Set a GitHub personal access token in the Git tab to enable PR activity subscriptions.';
-      }
-      return 'GitHub token is set. Open a git-tracked folder, or run git init and add a github.com remote, to use PR activity subscriptions.';
-    },
+    ...prerequisitesChecks({
+      probe: getGitHubPRPrerequisites,
+      resolve: resolveGitHubPRPrerequisites,
+      check: ({ tokenPresent, inGitRepo }) => tokenPresent && inGitRepo,
+      statusLabel: ({ tokenPresent, inGitRepo }) => {
+        if (tokenPresent && inGitRepo) return undefined;
+        if (tokenPresent && !inGitRepo) return 'Needs git repo';
+        if (!tokenPresent && inGitRepo) return 'Needs token';
+        return 'Needs setup';
+      },
+      detailCheck: ({ tokenPresent, inGitRepo }) => {
+        if (tokenPresent && inGitRepo) {
+          return 'GitHub token detected and workspace is a git repo. Ready to subscribe to PR activity.';
+        }
+        if (!tokenPresent && !inGitRepo) {
+          return 'Open a git-tracked folder, or run git init and add a github.com remote. Then set a token in the Git tab.';
+        }
+        if (!tokenPresent) {
+          return 'This workspace is a git repo. Set a GitHub personal access token in the Git tab to enable PR activity subscriptions.';
+        }
+        return 'GitHub token is set. Open a git-tracked folder, or run git init and add a github.com remote, to use PR activity subscriptions.';
+      },
+    }),
   },
 
   {
@@ -481,18 +503,17 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
       'Coming soon. This entry only checks whether the local CLI is visible.',
     comingSoon: true,
     hideFromCli: true,
-    probe: probeTexraCli,
-    check: async (probeResult) => resolveBooleanProbe(probeResult) ?? false,
-    statusLabel: async (probeResult) =>
-      resolveBooleanProbe(probeResult)
-        ? 'Detected; integration coming soon'
-        : undefined,
-    detailCheck: async (probeResult) => {
-      const installed = resolveBooleanProbe(probeResult) ?? false;
-      return installed
-        ? 'TeXRA CLI detected on PATH. This integration is not enabled for agent runs yet.'
-        : 'TeXRA CLI not detected on PATH. This integration is not enabled for agent runs yet.';
-    },
+    ...prerequisitesChecks<boolean | undefined>({
+      probe: probeTexraCli,
+      resolve: resolveBooleanProbe,
+      check: (detected) => detected ?? false,
+      statusLabel: (detected) =>
+        detected ? 'Detected; integration coming soon' : undefined,
+      detailCheck: (detected) =>
+        (detected ?? false)
+          ? 'TeXRA CLI detected on PATH. This integration is not enabled for agent runs yet.'
+          : 'TeXRA CLI not detected on PATH. This integration is not enabled for agent runs yet.',
+    }),
   },
 
   {

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -231,21 +231,15 @@ function prerequisitesChecks<T>(config: {
   probe: () => Promise<T>;
   resolve: (probeResult: unknown) => T | Promise<T>;
   check: (prereqs: T) => boolean;
-  statusLabel?: (prereqs: T) => string | undefined;
-  detailCheck?: (prereqs: T) => string | undefined;
+  statusLabel: (prereqs: T) => string | undefined;
+  detailCheck: (prereqs: T) => string | undefined;
 }): Pick<ExternalToolDef, 'probe' | 'check' | 'statusLabel' | 'detailCheck'> {
   const { probe, resolve, check, statusLabel, detailCheck } = config;
   return {
     probe,
     check: async (probeResult) => check(await resolve(probeResult)),
-    ...(statusLabel && {
-      statusLabel: async (probeResult) =>
-        statusLabel(await resolve(probeResult)),
-    }),
-    ...(detailCheck && {
-      detailCheck: async (probeResult) =>
-        detailCheck(await resolve(probeResult)),
-    }),
+    statusLabel: async (probeResult) => statusLabel(await resolve(probeResult)),
+    detailCheck: async (probeResult) => detailCheck(await resolve(probeResult)),
   };
 }
 


### PR DESCRIPTION
## Summary

Three external-tool availability entries in `src/tools/externalToolDefs.ts` — Lean 4, GitHub activity subscription, and TeXRA CLI — shared the same shape: a `probe` whose cached result is re-`resolve`d inside *every* one of `check`, `statusLabel`, and `detailCheck`. As a result the `resolve(probeResult)` step (plus its destructuring) was hand-written **nine times** across the three entries, and each callback had to remember to run it with the correct argument before it could read the prerequisites.

This PR introduces a small module-private `prerequisitesChecks<T>` helper that declares the `probe → resolve → callback` wiring once and hands each callback the already-resolved, typed prerequisites object. The callbacks become pure functions of that object, so they can no longer drift on *how* the probe result is resolved.

Behavior is unchanged: the helper preserves the exact probe/resolve/callback semantics for all three entries, including the async GitHub resolve (`resolveGitHubPRPrerequisites`) and the boolean CLI probe (`resolveBooleanProbe`).

This came out of a broader tech-debt audit of the repo. On close inspection the codebase is well-factored; the largest *safe, mechanical* duplication was this one. The bigger structural items the audit surfaced — the "mirrors the OpenAI Responses handler" / "Mirrors the extension" parallel stacks in the model handlers and host controllers, and the personal-style replacement data shipped in `src/replacement/maxRules.ts` — are mostly irreducible per-provider/per-host divergence or need a maintainer decision on the abstraction/host-boundary approach, so they are intentionally **not** bundled here (see Scheduled refactoring).

## Issue acceptance gates

No tracking issue — this is a standalone cleanup. Gate: remove the repeated `resolve(probeResult)` boilerplate across the three prerequisites-style entries without changing availability behavior. Satisfied.

## Single source of truth

`prerequisitesChecks<T>` now owns the probe→resolve→callback wiring for prerequisites-style entries. The existing per-tool resolvers (`resolveLean4Prerequisites`, `resolveGitHubPRPrerequisites`, `resolveBooleanProbe`) remain the single source of truth for how each probe result is interpreted; the helper only removes the duplicated call-site plumbing around them.

## Duplication and abstraction budget

Removed: nine repeated `resolve(probeResult)` invocations (three per entry × three entries) and their destructuring, collapsed to one `resolve` reference per entry. The new abstraction has three call sites and captures real logic (awaiting the resolve, then delegating to pure callbacks); it is not a pass-through layer — it changes the callback contract from "receive raw `probeResult`, resolve it yourself" to "receive resolved prerequisites".

## Net elements (R6)

- Files: 1 changed (`src/tools/externalToolDefs.ts`), diffstat `+102 / −81`, **net +21 LoC**. This is a clarity/consistency refactor, not a line-count reduction — the helper adds ~35 lines while the three entries each drop their repeated resolve/destructure lines and gain one indentation level.
- Exported symbols: **0 added, 0 removed** (`^[+-]export` over the diff is empty).
- Classes/interfaces/enums: none added or removed.
- New functions: 1 module-private (`prerequisitesChecks<T>`), 3 call sites.

## Consumer counts (R8)

n/a — no emit path or export was deleted or re-routed. The helper is module-private with 3 in-file callers; no external consumers exist or are affected.

## Host impact

Extension: none — `externalToolDefs` availability behavior is unchanged.

Desktop: none — same.

CLI: none — same (the TeXRA-CLI entry keeps `hideFromCli`/`comingSoon` and identical detection output).

## Scheduled refactoring

None filed yet. Larger items identified by the audit and deferred for maintainer review of approach:
- Unify the parallel "server-state chain + background + compaction" stacks in `modelHandlerOpenAIResponse.ts` / `modelHandlerGoogleInteractions.ts` (self-documented "mirrors" copies; touches hot-path token math).
- Extract shared host-controller wiring behind a `HostPorts` seam (`ProgressViewMessageHandler` vs `desktopAgentExecution`) — architectural, host-boundary decision.
- Move the personal-style data in `src/replacement/maxRules.ts` (~640 LoC) to user config via the existing `NonRegexReplacementCategory` schema.

## Validation

- `npm run typecheck` — full multi-package pass, exit 0.
- `npx eslint src/tools/externalToolDefs.ts` — clean.
- `npx prettier --check src/tools/externalToolDefs.ts` — clean.
- `npx vitest run` on `externalToolDefs.vitest.ts`, `lean/LeanTools.vitest.ts`, `ToolAvailabilitySeeding.vitest.ts` — 22 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PeGjGRdLWYhZCBrsgkjuym

---
_Generated by [Claude Code](https://claude.ai/code/session_01PeGjGRdLWYhZCBrsgkjuym)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor in tool availability metadata only; no new exports and semantics preserved via existing resolvers.
> 
> **Overview**
> Adds a module-private **`prerequisitesChecks<T>`** helper in `externalToolDefs.ts` that runs **`probe` → `resolve` once** and passes typed prerequisites into **`check`**, **`statusLabel`**, and **`detailCheck`**, instead of each callback repeating `await resolve(probeResult)`.
> 
> **Lean 4**, **GitHub activity subscription**, and **TeXRA CLI** availability entries are migrated to spread this helper; existing resolvers (`resolveLean4Prerequisites`, `resolveGitHubPRPrerequisites`, `resolveBooleanProbe`) are unchanged. **Runtime availability behavior and dashboard copy should be the same** — this is wiring deduplication only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b6bff988355b39a7c673e51c352015bd094a9c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->