### PR TITLE
refactor(progressView): replace hand-rolled flush timer with shared FlushableDebounce

### DIFF
--- a/src/controllers/progressView/backend/WebviewBridge.ts
+++ b/src/controllers/progressView/backend/WebviewBridge.ts
@@ -6,6 +6,7 @@ import type {
   StreamLogTextDelta,
   StreamTabId,
 } from '@shared/schemas';
+import { createFlushableDebounce, type FlushableDebounce } from '@utils/core';
 
 const CHANNEL = 'WebviewBridge';
 
@@ -40,7 +41,7 @@ interface StreamEntry {
 }
 
 export class WebviewBridge {
-  private flushTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly flushDebounce: FlushableDebounce;
   /** Registered streams: presence means cursor is seeded; `dirty` means pending flush. */
   private readonly streams = new Map<StreamTabId, StreamEntry>();
   private readonly unsubscribe: () => void;
@@ -52,6 +53,10 @@ export class WebviewBridge {
     private readonly sendMessage: ProgressViewMessageSender,
     private readonly getActiveStream: () => StreamTabId | null,
   ) {
+    this.flushDebounce = createFlushableDebounce(
+      () => void this.runFlush(),
+      FRAME_INTERVAL_MS,
+    );
     this.unsubscribe = this.store.onChange((streamId) => {
       if (streamId !== this.getActiveStream()) return;
       // A stream is mirrored to the webview only after `syncStream` seeds its
@@ -71,10 +76,7 @@ export class WebviewBridge {
 
   dispose(): void {
     this.unsubscribe();
-    if (this.flushTimer) {
-      clearTimeout(this.flushTimer);
-      this.flushTimer = null;
-    }
+    this.flushDebounce.cancel();
     this.streams.clear();
   }
 
@@ -97,11 +99,7 @@ export class WebviewBridge {
       this.flushRequested = true;
       return;
     }
-    if (this.flushTimer) return;
-    this.flushTimer = setTimeout(() => {
-      this.flushTimer = null;
-      void this.runFlush();
-    }, FRAME_INTERVAL_MS);
+    if (!this.flushDebounce.pending) this.flushDebounce.schedule();
   }
 
   private async runFlush(): Promise<void> {


### PR DESCRIPTION
## Summary

Follow-up to a scheduled reinvented-wheel audit of the codebase. `WebviewBridge`
(`src/controllers/progressView/backend/WebviewBridge.ts`) hand-rolled a
`setTimeout`/`clearTimeout` throttle guard (`flushTimer` + `scheduleFlush()`)
to batch webview flushes into one per animation-frame-ish window. The
codebase already has a shared `createFlushableDebounce` helper
(`src/utils/core`, built on `perfect-debounce`) for exactly this "start once,
coalesce further calls until it fires" shape, already used the same way in
`subscribeStreamLog.ts`, `agentReviewCommitWatcher.ts`, and
`packages/extension/src/webview/frontend/persistence.ts`. This PR converges
`WebviewBridge` onto that shared helper instead of keeping its own timer
bookkeeping.

Two other candidates from the audit were investigated and **not** changed,
with rationale below.

## Issue acceptance gates

No tracked issue — this is direct follow-through on a scheduled audit's
findings. Gate: replace a hand-rolled timer/throttle pattern with the
project's existing shared primitive, with no behavior change, verified by
the existing test suite.

## Single source of truth

`FlushableDebounce` (`src/utils/core/index.ts`) is now the single owner of
"start a timer once, ignore further calls until it fires, support a
synchronous flush" scheduling logic for `WebviewBridge`, same as it already
is for `subscribeStreamLog.ts`, `agentReviewCommitWatcher.ts`, and
`persistence.ts`. `WebviewBridge` no longer owns its own `setTimeout` handle.

## Duplication and abstraction budget

Removed a fourth hand-rolled reimplementation of a pattern the repo already
has a shared, tested helper for. No new abstraction was added —
`createFlushableDebounce` already existed and is unchanged; this PR only
adds a new call site.

## Net elements (R6)

1 file changed, 8 insertions(+), 10 deletions(-). No new exported symbols
(diff has no `^[+-]export` lines). No new classes/interfaces/enums — the
existing `FlushableDebounce` interface is imported as a type, not
redefined.

## Consumer counts (R8)

n/a — no emit path, export, or public API was removed or re-routed. Both
`private` fields (`flushTimer` → `flushDebounce`) and one `private` method
body (`scheduleFlush`) changed; both have zero external consumers by
construction (`private`).

## Host impact

Extension: `WebviewBridge` backs the extension's progress webview
(`ProgressBackend.ts`, `ProgressFactApplier.ts` are its only consumers) —
flush-batching timing (16ms window) is unchanged, only the timer mechanism
changed.

Desktop: not applicable — `src/controllers/` is host-agnostic core, not
imported by the desktop-specific packages directly for this feature.

CLI: not applicable — the CLI's own stream-sync path
(`packages/cli/src/chat/tui/state/subscribeStreamLog.ts`) already uses
`createFlushableDebounce`; this PR doesn't touch it.

## Scheduled refactoring

None needed for this change. Two other audit candidates were evaluated and
intentionally left as-is (see below) rather than deferred — they don't need
follow-up, they need to stay as they are:

- **`src/telemetry/UsageLogService.ts`** — its `flush()` hand-rolls a
  promise-based single-flight/drain loop (`activeFlush`) instead of using
  `p-queue`, which on the surface looks like the exact "hand-rolled promise
  chain" pattern CLAUDE.md tells you to avoid. I implemented the mechanical
  swap to `p-queue` and ran it against the existing test suite
  (`UsageLogService.vitest.ts`) — it **deterministically fails 3 of 10
  tests** (batches that should resolve `accepted` resolve `pending`
  instead). The reason: `flush()` isn't a simple "one task per call" queue
  consumer — it does batch coalescing, retry-first FIFO ordering between a
  dedicated `retryBatch` slot and the live queue, and cross-batch outcome
  aggregation (PENDING/REJECTED/ACCEPTED) across dynamically-arriving
  entries within a single caller's drain session. `p-queue` has no way to
  let a late caller "join" an in-flight task without enqueuing a redundant
  one, which races with the loop's own re-check and can spuriously return
  `PENDING` instead of the real batch outcome. This is closer to
  `ModelRetryGate.ts` (bespoke coordination logic the audit explicitly
  excluded) than to the simple one-task-per-call `PQueue({concurrency: 1})`
  pattern used in `jsonStore.ts` / `executionLease.ts` / `SessionStores.ts`
  / `agentRegistry.ts`. Reverted; left unchanged.
- **`src/agent/modelHandlers/google/googleMessageHelpers.ts`**
  (`validateGoogleMessageHistory`) — manual loop-based invariant checking
  (role enum, alternation, non-empty parts) over an already-typed
  `Content[]` array. Wrapping this in a Zod `.superRefine()` schema
  wouldn't reduce line count or add a real type-safety win (the input is
  already typed, not an untrusted deserialization boundary) — it would just
  reformat the same imperative checks inside a Zod ceremony, which
  CLAUDE.md's abstraction-discipline guidance argues against. Left
  unchanged.

## Validation

- `npx vitest run src/test-kernel/progressView/WebviewBridge.vitest.ts src/test-kernel/progressView/StreamContentSync.vitest.ts` — 14/14 passed, run 5× to rule out timing flakiness from the debounce-timer swap.
- `npm run typecheck` — clean across the whole workspace (core, extension, cli, trace-viewer, desktop).
- `npx eslint src/controllers/progressView/backend/WebviewBridge.ts` — clean.
- `npm run check:dead-code-ratchet` — no new unused exports/files.
- `npx vitest run` (full suite) — 787/790 files, 7793/7804 tests passed. The 2 failures (`WorkflowScriptEngine.vitest.ts` timing threshold, `SystemUtils.vitest.ts` process-group-abort) are pre-existing environment/timing flakiness in this sandbox (a wall-clock assertion and a process-signal test), unrelated to this change — neither test touches `WebviewBridge`, `progressView`, or telemetry.
- The `UsageLogService.ts` p-queue attempt was implemented and tested (see above), found to regress behavior, and reverted — not shipped.


---
_Generated by [Claude Code](https://claude.ai/code/session_0198sfPTRZa8D3MXQaeLAd6P)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal scheduling refactor only; flush interval and coalescing semantics stay the same, covered by existing progress view tests.
> 
> **Overview**
> **WebviewBridge** no longer keeps its own `flushTimer` / `setTimeout` bookkeeping for batching progress log flushes to the webview. It now uses the shared **`createFlushableDebounce`** helper (16ms window, unchanged) from `@utils/core`, matching other call sites like stream log subscription and persistence.
> 
> `scheduleFlush` coalesces via **`flushDebounce.pending`** instead of checking a local timer handle; **`dispose`** calls **`flushDebounce.cancel()`** instead of **`clearTimeout`**. Flush single-flight and re-schedule logic in **`runFlush`** is untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24b89a241489a9b16e6ae2f576cbe8a005f97d4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->