### PR TITLE
test(cli): reuse shared Ink test harness fakes in onboarding test

### DIFF
--- a/src/test-kernel/cli/OnboardingFlow.vitest.mts
+++ b/src/test-kernel/cli/OnboardingFlow.vitest.mts
@@ -1,9 +1,9 @@
 import { Console } from 'node:console';
-import { EventEmitter } from 'node:events';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { waitForCondition } from '@test/support/asyncTestUtils';
+import { FakeStdin, FakeStdout } from '@test/support/inkTestHarness.mts';
 
 const mocks = vi.hoisted(() => ({
   updateCliModelAccess: vi.fn(),
@@ -37,60 +37,6 @@ vi.mock('@platform/platform', () => ({
     },
   }),
 }));
-
-class FakeOutput extends EventEmitter {
-  readonly isTTY = true;
-  readonly columns = 100;
-  readonly rows = 30;
-  readonly fd = 1;
-  readonly destroyed = false;
-  output = '';
-
-  write(chunk: string | Uint8Array, ...args: unknown[]): boolean {
-    this.output += Buffer.isBuffer(chunk)
-      ? chunk.toString('utf8')
-      : String(chunk);
-    const callback = args.findLast(
-      (arg): arg is () => void => typeof arg === 'function',
-    );
-    callback?.();
-    return true;
-  }
-
-  getColorDepth(): number {
-    return 24;
-  }
-}
-
-class FakeInput extends EventEmitter {
-  readonly isTTY = true;
-  readonly fd = 0;
-  private readonly chunks: string[] = [];
-
-  write(chunk: string): void {
-    this.chunks.push(chunk);
-    this.emit('readable');
-  }
-
-  read(): string | null {
-    return this.chunks.shift() ?? null;
-  }
-
-  ref(): void {}
-  unref(): void {}
-  pause(): this {
-    return this;
-  }
-  resume(): this {
-    return this;
-  }
-  setEncoding(): this {
-    return this;
-  }
-  setRawMode(): this {
-    return this;
-  }
-}
 
 const ONBOARDING_WAIT_OPTIONS = Object.freeze({
   timeoutMs: 15_000,
@@ -145,9 +91,9 @@ describe('provider-key onboarding flow', () => {
       value: Console,
       configurable: true,
     });
-    const stdin = new FakeInput();
-    const stdout = new FakeOutput();
-    const stderr = new FakeOutput();
+    const stdin = new FakeStdin();
+    const stdout = new FakeStdout(100, 30);
+    const stderr = new FakeStdout(100, 30);
     Object.defineProperties(process, {
       stdin: { value: stdin, configurable: true },
       stdout: { value: stdout, configurable: true },

--- a/src/test-kernel/support/inkTestHarness.mts
+++ b/src/test-kernel/support/inkTestHarness.mts
@@ -141,6 +141,8 @@ export class FakeStdin extends EventEmitter {
 
   ref(): void {}
   unref(): void {}
+  // Unlike real tty.ReadStream, these return void rather than `this` — a
+  // chained call (e.g. `stdin.setRawMode(true).resume()`) will throw here.
   pause(): void {}
   resume(): void {}
   setEncoding(): void {}


### PR DESCRIPTION
## Summary

A scheduled structural-debt audit (21 agents across 12 seams: agent orchestration, model handlers, persistence/output, tools, shared contracts/controllers, platform/utils, and the extension/CLI/desktop hosts) found the codebase's module boundaries and ownership to be well-defined — every seam was independently assessed as healthy, with cases that looked like duplication on a first grep (per-provider model handler subclasses, the 3x webview schema/controller split, desktop's settings controllers, `agents.ts` x3, hostBridge x3, etc.) turning out to be justified separation once traced against call sites and doc comments. No dual systems, SSOT conflicts, or unclear-ownership issues were found in production code.

The one concrete, adversarially-verified finding was a small test-fixture duplication: `OnboardingFlow.vitest.mts` hand-rolled its own `FakeOutput`/`FakeInput` EventEmitter-based TTY doubles instead of reusing the already-exported `FakeStdout`/`FakeStdin` in `test-kernel/support/inkTestHarness.mts`, which 8 other CLI suites already use against this same Ink render path. This PR removes that duplication.

Traced why the local doubles' extra surface (Buffer-to-string handling, write callbacks, `fd`/`destroyed`, chainable `this`-returning methods) is unexercised here: `runCliOnboarding(false)` runs with color disabled, so stdout is wrapped by `sgrStrippingWriteStream`, which already normalizes `Buffer`/`Uint8Array` to a string before the injected stream ever sees it; and `writeTextStdout`/`writeTextStderr` — the only real code that reads `.destroyed` or invokes a write callback — are fully `vi.mock`'ed out in this test file.

## Issue acceptance gates

Scheduled task: "Analyze the codebase to identify areas with confusing or overlapped responsibilities... for the most significant issue, draft a pull request." Gate satisfied: the audit is complete (documented in the session transcript), and this PR implements the single candidate that survived adversarial net-gain verification with high confidence. No module-level responsibility-overlap issue rose to significance — see Summary.

## Single source of truth

`test-kernel/support/inkTestHarness.mts`'s `FakeStdout`/`FakeStdin` are now the sole TTY test doubles for Ink-driven CLI tests; `OnboardingFlow.vitest.mts` no longer owns a competing pair.

## Duplication and abstraction budget

Removed: a duplicate `FakeOutput` (23 lines) and `FakeInput` (29 lines) class pair, plus the now-unused `EventEmitter` import. No new abstraction was added — this is a pure reuse of an existing, already-proven shared fixture; no pass-through layer introduced.

## Net elements (R6)

1 file changed: 4 insertions(+), 58 deletions(-). 2 classes deleted, 0 added. Net LoC: -54.

## Consumer counts (R8)

n/a — this is a test-only fixture swap, not an emit-path or export re-route. (For reference: `grep -rn "FakeOutput|FakeInput" src packages` confirmed zero consumers outside the changed file before deletion.)

## Host impact

Extension: none.

Desktop: none.

CLI: test-only change to `packages/cli`'s onboarding test suite; no production code touched.

## Scheduled refactoring

None — the audit found no other significant candidates worth a follow-up issue. Two smaller, lower-confidence test-dedup candidates (a `FakeRoundNode` fixture shared by 2 suites; a `globalState` mock shared by 2 onboarding suites) were considered and declined: one is marginal value for a new `support/` file at only 2 callers, and the other's proposed implementation would not survive Vitest's `vi.hoisted()` semantics as designed. Not pursued in this PR.

## Validation

- `npx vitest run src/test-kernel/cli/OnboardingFlow.vitest.mts` — 1 passed
- `npm run typecheck` — clean across all packages (root, test-kernel, cli, desktop, trace-viewer)
- `npx eslint src/test-kernel/cli/OnboardingFlow.vitest.mts` — clean
- `npm run check:dead-code-ratchet` — no new findings vs baseline

---
_Generated by [Claude Code](https://claude.ai/code/session_019xuzw6f2DWZ1ADZvvBCDiD)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only fixture consolidation with no production or runtime behavior changes.
> 
> **Overview**
> **Onboarding CLI tests** now use the shared **`FakeStdin` / `FakeStdout`** from `inkTestHarness.mts` instead of local `FakeInput` / `FakeOutput` doubles, dropping ~54 lines of duplicate fixture code and the unused `EventEmitter` import in `OnboardingFlow.vitest.mts`.
> 
> **`inkTestHarness.mts`** documents that **`FakeStdin`**’s `pause` / `resume` / `setEncoding` / `setRawMode` return `void` (not chainable like a real TTY), so chained calls would throw in tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4225159c0f54415329c87d008af7b6513c2cae45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->