### PR TITLE
fix: show all orchestration sessions

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -355,6 +355,11 @@ export class DesktopProgressBridge {
     await this.backend.load();
     if (this.disposed) return;
 
+    // Orchestration rail shows all sessions regardless of category — clear any
+    // persisted filter from a previous session so every top-level stream is
+    // visible in the rail and selectable without a stale-filter mismatch.
+    this.state.agentCategoryFilter = 'all';
+
     this.toolEditApprovals = createDesktopToolEditApprovalController({
       runtimeHost: presentationHost,
       session: this.session,

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -48,7 +48,7 @@ import {
   pendingApprovalIds$,
   streamStates$,
   streams$,
-  tabStreams$,
+  topLevelStreams$,
 } from '@progressView/frontend/progressState';
 import { COMMON_COMMANDS, PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import '@settingsView/frontend';
@@ -1189,7 +1189,7 @@ function rerenderShell(): void {
     activeWorkbenchTab(shellState, 'right')?.kind === 'logs' ||
       activeWorkbenchTab(shellState, 'bottom')?.kind === 'logs',
   );
-  railTabs.streams = tabStreams$.get();
+  railTabs.streams = topLevelStreams$.get();
   railTabs.activeStreamId = activeStreamId$.get();
   railTabs.streamStates = streamStates$.get();
   railTabs.pendingApprovalStreamIds = pendingApprovalIds$.get();
@@ -1277,7 +1277,7 @@ function installShellSignalWatcher(): void {
   const shellDeps = new Signal.Computed(() => {
     activeStreamId$.get();
     hasAnyStreams$.get();
-    tabStreams$.get();
+    topLevelStreams$.get();
     streamStates$.get();
     pendingApprovalIds$.get();
     childStreamsByParent$.get();

--- a/packages/extension/src/progressView/frontend/progressState.ts
+++ b/packages/extension/src/progressView/frontend/progressState.ts
@@ -113,9 +113,14 @@ export const streams$ = new Signal.Computed(() => [
   ...streamById$.get().values(),
 ]);
 
+/** Top-level streams, independent of the progress view's category filter. */
+export const topLevelStreams$ = new Signal.Computed(() =>
+  streams$.get().filter((stream) => !stream.parentStreamId),
+);
+
 /** Top-level streams for the tab list (child streams excluded). */
 export const tabStreams$ = new Signal.Computed(() => {
-  const topLevel = streams$.get().filter((stream) => !stream.parentStreamId);
+  const topLevel = topLevelStreams$.get();
   const filter = streamFilter$.get();
   if (filter === 'all') return topLevel;
   return topLevel.filter((stream) => stream.agentCategory === filter);

--- a/src/test-kernel/progressView/StreamMetaState.vitest.ts
+++ b/src/test-kernel/progressView/StreamMetaState.vitest.ts
@@ -10,6 +10,8 @@ import {
   phaseStages$,
   resetProgressState,
   setStreamStateForId,
+  tabStreams$,
+  topLevelStreams$,
 } from '@progressView/frontend/progressState';
 import {
   createInitialState,
@@ -59,6 +61,39 @@ function registerWorkflowStream(
 describe('stream meta frontend state', () => {
   beforeEach(() => {
     resetProgressState();
+  });
+
+  it('keeps the unfiltered top-level stream list independent of the progress filter', () => {
+    const workflowId = 'workflow' as StreamTabId;
+    const toolUseId = 'tool-use' as StreamTabId;
+    const childId = 'child' as StreamTabId;
+    const state = createInitialState();
+    state.streamFilter = 'workflow';
+    registerWorkflowStream(state, workflowId);
+    state.streamById.set(toolUseId, {
+      kind: 'agent',
+      name: toolUseId,
+      label: 'tool-use',
+      agentCategory: AgentCategory.ToolUse,
+      creationTimestamp: 2,
+    });
+    state.streamById.set(childId, {
+      kind: 'agent',
+      name: childId,
+      label: 'child',
+      agentCategory: AgentCategory.ToolUse,
+      creationTimestamp: 3,
+      parentStreamId: workflowId,
+    });
+    seedState(state);
+
+    expect(tabStreams$.get().map((stream) => stream.name)).toEqual([
+      workflowId,
+    ]);
+    expect(topLevelStreams$.get().map((stream) => stream.name)).toEqual([
+      workflowId,
+      toolUseId,
+    ]);
   });
 
   it('patches one stream metadata record without replacing siblings', () => {


### PR DESCRIPTION
Fixes the orchestration view to show all persisted sessions instead of filtering them, ensuring users can see every session regardless of filter state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, desktop-focused UI/state wiring with a targeted test; no auth or data-path changes.
> 
> **Overview**
> The desktop **orchestration rail** was driven by `tabStreams$`, which applies the progress view’s **agent category filter**, so persisted sessions could disappear from the sidebar while still existing in state.
> 
> This change introduces **`topLevelStreams$`** (all top-level streams, no category filter) and wires the desktop shell rail to that signal instead of `tabStreams$`. **`tabStreams$`** still applies the filter for the in-progress tab list (e.g. VS Code `ProgressApp`).
> 
> On desktop startup, **`agentCategoryFilter` is reset to `'all'`** after backend load so a saved filter from a prior session does not hide rail entries or block selection.
> 
> A test asserts that with `streamFilter = 'workflow'`, `tabStreams$` stays filtered while `topLevelStreams$` lists every top-level stream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79bb00642dec4b2d1b8e8ad72a744be583106e61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->