### PR TITLE
feat(auth-bridge): auto-open the editor deep link, keep the button fallback

### DIFF
--- a/supabase/functions/auth-bridge/index.ts
+++ b/supabase/functions/auth-bridge/index.ts
@@ -5,8 +5,9 @@
  * straight to a raw vscode:// deep link. GoTrue server-redirects into a custom
  * scheme are silently dropped by some browsers (Firefox on Linux), which fails
  * the flow with bad_oauth_state. Redirecting to this https bridge lands the
- * user on a real page that offers a real-click "Open in <editor>" button which
- * hands the result back to the editor's deep link.
+ * user on a real page that auto-opens the editor's deep link (client-side
+ * navigation, which browsers honor where they drop the server redirect) and
+ * keeps a real-click "Open in <editor>" button as the fallback.
  *
  * PKCE flow: the only thing GoTrue puts on this page is a one-time ?code= in the
  * query string (or ?error= on failure). No access/refresh token ever reaches
@@ -333,6 +334,23 @@ function bridgePageHtml(ext: string, id: string): string {
         failed();
       }
     });
+
+    if (!oauthError) {
+      // Auto-open the editor; the button stays as the fallback because
+      // browsers may block or prompt on custom-scheme navigation (and some
+      // strip it entirely without a user gesture).
+      lede.textContent =
+        'Opening ' + (DISPLAY[EXT] || 'your editor') +
+        '… If nothing happens, click the button below.';
+      setTimeout(function () {
+        try {
+          window.location.href = deepLink;
+        } catch (navErr) {
+          // Navigation refused (sandboxed/blocked scheme); the manual
+          // button and copyable link above remain the path forward.
+        }
+      }, 200);
+    }
   }
 </script>`);
 }

--- a/supabase/functions/auth-bridge/index.ts
+++ b/supabase/functions/auth-bridge/index.ts
@@ -292,6 +292,8 @@ function bridgePageHtml(ext: string, id: string): string {
 
     var oauthError = getParam('error');
     var errorDescription = getParam('error_description');
+    var hasCode = getParam('code');
+    var hasToken = getParam('access_token');
 
     openLink.textContent = 'Open in ' + (DISPLAY[EXT] || 'your editor');
 
@@ -335,7 +337,7 @@ function bridgePageHtml(ext: string, id: string): string {
       }
     });
 
-    if (!oauthError && (getParam('code') || getParam('access_token'))) {
+    if (!oauthError && (hasCode || hasToken)) {
       // Auto-open the editor only when a usable OAuth payload is present
       // (a code or access_token, not arbitrary query params). A refresh or
       // direct visit after the history scrub has none — stay manual there.

--- a/supabase/functions/auth-bridge/index.ts
+++ b/supabase/functions/auth-bridge/index.ts
@@ -335,8 +335,10 @@ function bridgePageHtml(ext: string, id: string): string {
       }
     });
 
-    if (!oauthError) {
-      // Auto-open the editor; the button stays as the fallback because
+    if (!oauthError && tail) {
+      // Auto-open the editor only when there is a callback payload to hand
+      // back (a refresh or direct visit after the history scrub has none —
+      // stay manual there). The button stays as the fallback because
       // browsers may block or prompt on custom-scheme navigation (and some
       // strip it entirely without a user gesture).
       lede.textContent =

--- a/supabase/functions/auth-bridge/index.ts
+++ b/supabase/functions/auth-bridge/index.ts
@@ -335,12 +335,13 @@ function bridgePageHtml(ext: string, id: string): string {
       }
     });
 
-    if (!oauthError && tail) {
-      // Auto-open the editor only when there is a callback payload to hand
-      // back (a refresh or direct visit after the history scrub has none —
-      // stay manual there). The button stays as the fallback because
-      // browsers may block or prompt on custom-scheme navigation (and some
-      // strip it entirely without a user gesture).
+    if (!oauthError && (getParam('code') || getParam('access_token'))) {
+      // Auto-open the editor only when a usable OAuth payload is present
+      // (a code or access_token, not arbitrary query params). A refresh or
+      // direct visit after the history scrub has none — stay manual there.
+      // The button stays as the fallback because browsers may block or
+      // prompt on custom-scheme navigation (and some strip it entirely
+      // without a user gesture).
       lede.textContent =
         'Opening ' + (DISPLAY[EXT] || 'your editor') +
         '… If nothing happens, click the button below.';


### PR DESCRIPTION
The OAuth bridge page (shown after browser sign-in, with the "Open in Cursor/VS Code" button) now jumps to the editor deep link automatically on a successful callback, while keeping the button, copy-link, and Command Palette instructions as the fallback.

- Auto-navigation is client-side JS after a 200ms paint delay, so browsers that silently drop GoTrue's *server* redirect into custom schemes (the original reason this bridge exists, e.g. Firefox on Linux) still honor it; browsers that prompt on custom-scheme navigation show their "Open app?" dialog with the manual path still visible behind it.
- Error callbacks (?error=) stay manual: the human-readable message renders and nothing navigates away from it.
- The one-time ?code= history scrub is unchanged and runs before navigation.

Note: the function must be redeployed with --no-verify-jwt to take effect (deploy is manual, decoupled from merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX-only change to client-side navigation on an already-validated bridge page; OAuth validation, allowlists, and one-time code scrubbing are unchanged.
> 
> **Overview**
> After a **successful** OAuth callback on the auth-bridge page, the bridge now **auto-navigates** to the editor deep link via client-side `window.location.href` (after a **200ms** delay), instead of relying only on the user clicking **Open in editor**.
> 
> The lede copy switches to an “Opening …” message with a prompt to use the button if nothing happens. **Error** callbacks (`?error=`) and visits **without** `code` or `access_token` (e.g. refresh after history scrub) stay **manual-only**—no auto-navigation.
> 
> Top-of-file comments are updated to describe auto-open plus the existing button, copy-link, and Command Palette fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13c8f6f9421cdde2658b25b8fbd0e7f70b7d3bf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->