### PR TITLE
refactor(agent): sever the @tools/registry cycle at the remote-agent client

### DIFF
--- a/src/agent/index/remoteAgentMeta.ts
+++ b/src/agent/index/remoteAgentMeta.ts
@@ -45,9 +45,8 @@ function getPersistedRemoteAgentMeta(): RemoteAgentMetaCache {
 
 export async function loadRemoteAgents(): Promise<AgentEntry[]> {
   try {
-    const { RemoteAgentLoader } =
-      await import('@agent/remote/RemoteAgentLoader');
-    const remotes = await RemoteAgentLoader.listRemoteAgents();
+    const { listRemoteAgents } = await import('@agent/remote/remoteAgentList');
+    const remotes = await listRemoteAgents();
     const metaCache = getPersistedRemoteAgentMeta();
 
     return remotes.map((remote) => {

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -18,8 +18,8 @@ import { resolveToolDefinitions, type RawToolConfig } from '@tools/registry';
 import { ensureError } from '@utils/errors/errorMessage';
 
 import { fetchRemoteAgentConfigYaml } from './remoteAgentConfigClient';
-import type { RemoteAgentConfig } from './types';
 import { CHANNEL } from './remoteAgentList';
+import type { RemoteAgentConfig } from './types';
 
 /** Load a remote agent configuration by name. */
 export async function loadRemoteAgent(

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -1,6 +1,9 @@
-import ky, { HTTPError } from 'ky';
-import { z } from 'zod';
-
+/**
+ * Config-loading half of the remote-agent client. Resolving a remote agent's
+ * YAML tool list needs `@tools/registry`, which imports every registered tool;
+ * keep this module out of any path reachable from `src/tools/`. The listing
+ * half — which the agent index does reach — lives in `./remoteAgentList`.
+ */
 import {
   type AgentSettingInput,
   AgentPromptSchema,
@@ -8,235 +11,52 @@ import {
   AgentDefinitionSchema,
 } from '@agent/core/definition/AgentDataclass';
 import { extractToolNames, updateAgentMeta } from '@agent/index/agentRegistry';
-import { SUPABASE_CONFIG } from '@auth/config';
 import { SupabaseClient } from '@auth/SupabaseClient';
-import { parseJsonWith } from '@common/parsing/safeParseJson';
 import { parseYamlWith } from '@common/parsing/safeParseYaml';
 import * as logger from '@logger/logUtils';
 import { resolveToolDefinitions, type RawToolConfig } from '@tools/registry';
-import { filterNotNull, filterNotNullish } from '@utils/core';
-import { ensureError, toErrorMessage } from '@utils/errors/errorMessage';
+import { ensureError } from '@utils/errors/errorMessage';
 
-import { errorDataToString } from './errorData';
-import {
-  RemoteAgentListItemSchema,
-  type RemoteAgentListItem,
-  type RemoteAgentConfig,
-} from './types';
 import { fetchRemoteAgentConfigYaml } from './remoteAgentConfigClient';
+import type { RemoteAgentConfig } from './types';
 
 const CHANNEL = 'RemoteAgentLoader';
 
-const FETCH_TIMEOUT_MS = 30_000;
-
-const REMOTE_AGENT_LIST_COLUMNS =
-  'id, name, description, visibility, tools, agent_category';
-const LEGACY_REMOTE_AGENT_LIST_COLUMNS =
-  'id, name, description, visibility, agent_category';
-
-interface RemoteAgentListRow {
-  id: string;
-  name: string;
-  description?: string | null;
-  visibility?: string[] | null;
-  tools?: string[] | null;
-  agent_category?: string | null;
-}
-
-const RemoteAgentListQueryErrorSchema = z.object({
-  code: z.string().nullish(),
-  message: z.string().nullish(),
-  details: z.string().nullish(),
-  hint: z.string().nullish(),
-});
-type RemoteAgentListQueryError = z.infer<
-  typeof RemoteAgentListQueryErrorSchema
->;
-
-type RemoteAgentListQueryResult = {
-  data: RemoteAgentListRow[] | null;
-  error: RemoteAgentListQueryError | null;
-};
-
-/**
- * True only for the pre-migration database shape where `remote_agents.tools`
- * does not exist yet. Other query errors should surface directly.
- */
-export function isMissingRemoteAgentToolsColumnError(
-  error: RemoteAgentListQueryError | null | undefined,
-): boolean {
-  if (!error) return false;
-
-  const text = [error.message, error.details, error.hint]
-    .filter(filterNotNullish)
-    .join(' ')
-    .toLowerCase();
-  const schemaError =
-    error.code === 'PGRST204' ||
-    error.code === '42703' ||
-    text.includes('schema cache') ||
-    text.includes('column');
-
-  return schemaError && /\btools\b/.test(text);
-}
-
-/** Parse DB row to RemoteAgentListItem, returning null on validation failure. */
-function parseListItemRow(row: RemoteAgentListRow): RemoteAgentListItem | null {
-  const result = RemoteAgentListItemSchema.safeParse({
-    id: row.id,
-    name: row.name,
-    description: row.description,
-    visibility: row.visibility,
-    tools: row.tools,
-    agentCategory: row.agent_category,
-  });
-
-  if (!result.success) {
-    logger.warn(
-      CHANNEL,
-      `Invalid metadata for agent "${row.name}": ${z.prettifyError(result.error)}`,
+/** Load a remote agent configuration by name. */
+export async function loadRemoteAgent(
+  agentName: string,
+): Promise<RemoteAgentConfig> {
+  if (!(await SupabaseClient.isAuthenticated())) {
+    throw new Error(
+      'Remote agents require authentication. Sign in using the "TeXRA: Sign In" command.',
     );
-    return null;
   }
 
-  return result.data;
-}
-
-/** Loader for remote agents stored in Supabase. */
-export class RemoteAgentLoader {
-  /** Load a remote agent configuration by name. */
-  static async loadRemoteAgent(agentName: string): Promise<RemoteAgentConfig> {
-    if (!(await SupabaseClient.isAuthenticated())) {
-      throw new Error(
-        'Remote agents require authentication. Sign in using the "TeXRA: Sign In" command.',
-      );
-    }
-
-    logger.info(CHANNEL, `Loading remote agent: ${agentName}`);
-
-    try {
-      const config = await fetchAgentConfig(agentName);
-
-      const registryId = `remote:${agentName}`;
-      updateAgentMeta(registryId, {
-        description: config.description,
-        tools: config.tools,
-        defaultOutputFiles: config.defaultOutputFiles,
-      });
-
-      logger.info(CHANNEL, `Successfully loaded remote agent: ${agentName}`);
-
-      return {
-        settings: config.settings,
-        prompts: config.prompts,
-      };
-    } catch (error) {
-      const lastError = ensureError(error);
-      logger.error(
-        CHANNEL,
-        `Failed to load remote agent "${agentName}": ${lastError.message}`,
-      );
-      throw lastError;
-    }
-  }
-
-  /** List all available remote agents for the current user. */
-  static async listRemoteAgents(): Promise<RemoteAgentListItem[]> {
-    try {
-      const token = await SupabaseClient.getAccessToken();
-      if (!token) return [];
-
-      const { data, error } = await queryRemoteAgentListRows(token);
-
-      if (error) {
-        logger.debug(CHANNEL, `Failed to list remote agents: ${error.message}`);
-        return [];
-      }
-
-      return (data ?? []).map(parseListItemRow).filter(filterNotNull);
-    } catch (error) {
-      logger.debug(
-        CHANNEL,
-        `Error listing remote agents: ${toErrorMessage(error)}`,
-      );
-      return [];
-    }
-  }
-}
-
-async function queryRemoteAgentListRows(
-  accessToken: string,
-): Promise<RemoteAgentListQueryResult> {
-  const current = await fetchRemoteAgentListRows(
-    accessToken,
-    REMOTE_AGENT_LIST_COLUMNS,
-  );
-
-  if (!current.error || !isMissingRemoteAgentToolsColumnError(current.error)) {
-    return current;
-  }
-
-  logger.debug(
-    CHANNEL,
-    `Remote agent tools column unavailable; using legacy list query: ${current.error.message}`,
-  );
-
-  return fetchRemoteAgentListRows(
-    accessToken,
-    LEGACY_REMOTE_AGENT_LIST_COLUMNS,
-  );
-}
-
-async function fetchRemoteAgentListRows(
-  accessToken: string,
-  columns: string,
-): Promise<RemoteAgentListQueryResult> {
-  const url = new URL('/rest/v1/remote_agents', SUPABASE_CONFIG.url);
-  url.searchParams.set('select', columns);
-  url.searchParams.set('order', 'name.asc');
+  logger.info(CHANNEL, `Loading remote agent: ${agentName}`);
 
   try {
-    // retry: 0 preserves the old fetch's fail-fast contract — listRemoteAgents
-    // is awaited by registry/settings refreshes and treats failure as an empty
-    // list, so ky's default GET retries (which honor Retry-After on 429/503)
-    // would block the UI rather than surfacing immediately. AbortSignal.timeout
-    // (vs ky's header-only `timeout`) also guards the .json() body read.
-    const data = await ky
-      .get(url, {
-        headers: {
-          apikey: SUPABASE_CONFIG.publicKey,
-          Authorization: `Bearer ${accessToken}`,
-          Accept: 'application/json',
-        },
-        retry: 0,
-        timeout: false,
-        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-      })
-      .json<RemoteAgentListRow[]>();
-    return { data, error: null };
-  } catch (error) {
-    if (!(error instanceof HTTPError)) throw error;
+    const config = await fetchAgentConfig(agentName);
 
-    // ky v2 auto-consumes the response body into error.data;
-    // error.response body methods are not usable after that.
-    const rawBody = errorDataToString(error.data);
-    const parsedError = rawBody
-      ? parseJsonWith(rawBody, RemoteAgentListQueryErrorSchema).unwrapOr({
-          message: rawBody,
-        })
-      : {};
-    const fallbackMessage =
-      `${error.response.status} ${error.response.statusText}`.trim();
+    const registryId = `remote:${agentName}`;
+    updateAgentMeta(registryId, {
+      description: config.description,
+      tools: config.tools,
+      defaultOutputFiles: config.defaultOutputFiles,
+    });
+
+    logger.info(CHANNEL, `Successfully loaded remote agent: ${agentName}`);
+
     return {
-      data: null,
-      error: {
-        ...parsedError,
-        message:
-          parsedError.message ||
-          fallbackMessage ||
-          'remote list request failed',
-      },
+      settings: config.settings,
+      prompts: config.prompts,
     };
+  } catch (error) {
+    const lastError = ensureError(error);
+    logger.error(
+      CHANNEL,
+      `Failed to load remote agent "${agentName}": ${lastError.message}`,
+    );
+    throw lastError;
   }
 }
 

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -19,8 +19,7 @@ import { ensureError } from '@utils/errors/errorMessage';
 
 import { fetchRemoteAgentConfigYaml } from './remoteAgentConfigClient';
 import type { RemoteAgentConfig } from './types';
-
-const CHANNEL = 'RemoteAgentLoader';
+import { CHANNEL } from './remoteAgentList';
 
 /** Load a remote agent configuration by name. */
 export async function loadRemoteAgent(

--- a/src/agent/remote/remoteAgentList.ts
+++ b/src/agent/remote/remoteAgentList.ts
@@ -24,7 +24,7 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 import { errorDataToString } from './errorData';
 import { RemoteAgentListItemSchema, type RemoteAgentListItem } from './types';
 
-const CHANNEL = 'RemoteAgentLoader';
+export const CHANNEL = 'RemoteAgentLoader';
 
 const FETCH_TIMEOUT_MS = 30_000;
 

--- a/src/agent/remote/remoteAgentList.ts
+++ b/src/agent/remote/remoteAgentList.ts
@@ -1,0 +1,201 @@
+/**
+ * Listing half of the remote-agent client: metadata rows only, no YAML parsing
+ * and no tool resolution.
+ *
+ * Split out of `RemoteAgentLoader.ts` on purpose. The agent index reaches this
+ * module (`@agent/index/agentRegistry` -> `remoteAgentMeta`), and the agent
+ * index is reachable from tool modules such as `@tools/bash`. Keeping
+ * `@tools/registry` — which imports every tool, including the LaTeX, Lean,
+ * arxiv and Zotero ones — out of this file is what stops a generic tool's
+ * module closure from dragging the whole domain-tool set behind it. Config
+ * loading (which genuinely needs `resolveToolDefinitions`) stays in
+ * `RemoteAgentLoader.ts`, which nothing under `src/tools/` reaches.
+ */
+import ky, { HTTPError } from 'ky';
+import { z } from 'zod';
+
+import { SUPABASE_CONFIG } from '@auth/config';
+import { SupabaseClient } from '@auth/SupabaseClient';
+import { parseJsonWith } from '@common/parsing/safeParseJson';
+import * as logger from '@logger/logUtils';
+import { filterNotNull, filterNotNullish } from '@utils/core';
+import { toErrorMessage } from '@utils/errors/errorMessage';
+
+import { errorDataToString } from './errorData';
+import { RemoteAgentListItemSchema, type RemoteAgentListItem } from './types';
+
+const CHANNEL = 'RemoteAgentLoader';
+
+const FETCH_TIMEOUT_MS = 30_000;
+
+const REMOTE_AGENT_LIST_COLUMNS =
+  'id, name, description, visibility, tools, agent_category';
+const LEGACY_REMOTE_AGENT_LIST_COLUMNS =
+  'id, name, description, visibility, agent_category';
+
+interface RemoteAgentListRow {
+  id: string;
+  name: string;
+  description?: string | null;
+  visibility?: string[] | null;
+  tools?: string[] | null;
+  agent_category?: string | null;
+}
+
+const RemoteAgentListQueryErrorSchema = z.object({
+  code: z.string().nullish(),
+  message: z.string().nullish(),
+  details: z.string().nullish(),
+  hint: z.string().nullish(),
+});
+type RemoteAgentListQueryError = z.infer<
+  typeof RemoteAgentListQueryErrorSchema
+>;
+
+type RemoteAgentListQueryResult = {
+  data: RemoteAgentListRow[] | null;
+  error: RemoteAgentListQueryError | null;
+};
+
+/**
+ * True only for the pre-migration database shape where `remote_agents.tools`
+ * does not exist yet. Other query errors should surface directly.
+ */
+export function isMissingRemoteAgentToolsColumnError(
+  error: RemoteAgentListQueryError | null | undefined,
+): boolean {
+  if (!error) return false;
+
+  const text = [error.message, error.details, error.hint]
+    .filter(filterNotNullish)
+    .join(' ')
+    .toLowerCase();
+  const schemaError =
+    error.code === 'PGRST204' ||
+    error.code === '42703' ||
+    text.includes('schema cache') ||
+    text.includes('column');
+
+  return schemaError && /\btools\b/.test(text);
+}
+
+/** Parse DB row to RemoteAgentListItem, returning null on validation failure. */
+function parseListItemRow(row: RemoteAgentListRow): RemoteAgentListItem | null {
+  const result = RemoteAgentListItemSchema.safeParse({
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    visibility: row.visibility,
+    tools: row.tools,
+    agentCategory: row.agent_category,
+  });
+
+  if (!result.success) {
+    logger.warn(
+      CHANNEL,
+      `Invalid metadata for agent "${row.name}": ${z.prettifyError(result.error)}`,
+    );
+    return null;
+  }
+
+  return result.data;
+}
+
+/** List all available remote agents for the current user. */
+export async function listRemoteAgents(): Promise<RemoteAgentListItem[]> {
+  try {
+    const token = await SupabaseClient.getAccessToken();
+    if (!token) return [];
+
+    const { data, error } = await queryRemoteAgentListRows(token);
+
+    if (error) {
+      logger.debug(CHANNEL, `Failed to list remote agents: ${error.message}`);
+      return [];
+    }
+
+    return (data ?? []).map(parseListItemRow).filter(filterNotNull);
+  } catch (error) {
+    logger.debug(
+      CHANNEL,
+      `Error listing remote agents: ${toErrorMessage(error)}`,
+    );
+    return [];
+  }
+}
+
+async function queryRemoteAgentListRows(
+  accessToken: string,
+): Promise<RemoteAgentListQueryResult> {
+  const current = await fetchRemoteAgentListRows(
+    accessToken,
+    REMOTE_AGENT_LIST_COLUMNS,
+  );
+
+  if (!current.error || !isMissingRemoteAgentToolsColumnError(current.error)) {
+    return current;
+  }
+
+  logger.debug(
+    CHANNEL,
+    `Remote agent tools column unavailable; using legacy list query: ${current.error.message}`,
+  );
+
+  return fetchRemoteAgentListRows(
+    accessToken,
+    LEGACY_REMOTE_AGENT_LIST_COLUMNS,
+  );
+}
+
+async function fetchRemoteAgentListRows(
+  accessToken: string,
+  columns: string,
+): Promise<RemoteAgentListQueryResult> {
+  const url = new URL('/rest/v1/remote_agents', SUPABASE_CONFIG.url);
+  url.searchParams.set('select', columns);
+  url.searchParams.set('order', 'name.asc');
+
+  try {
+    // retry: 0 preserves the old fetch's fail-fast contract — listRemoteAgents
+    // is awaited by registry/settings refreshes and treats failure as an empty
+    // list, so ky's default GET retries (which honor Retry-After on 429/503)
+    // would block the UI rather than surfacing immediately. AbortSignal.timeout
+    // (vs ky's header-only `timeout`) also guards the .json() body read.
+    const data = await ky
+      .get(url, {
+        headers: {
+          apikey: SUPABASE_CONFIG.publicKey,
+          Authorization: `Bearer ${accessToken}`,
+          Accept: 'application/json',
+        },
+        retry: 0,
+        timeout: false,
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      })
+      .json<RemoteAgentListRow[]>();
+    return { data, error: null };
+  } catch (error) {
+    if (!(error instanceof HTTPError)) throw error;
+
+    // ky v2 auto-consumes the response body into error.data;
+    // error.response body methods are not usable after that.
+    const rawBody = errorDataToString(error.data);
+    const parsedError = rawBody
+      ? parseJsonWith(rawBody, RemoteAgentListQueryErrorSchema).unwrapOr({
+          message: rawBody,
+        })
+      : {};
+    const fallbackMessage =
+      `${error.response.status} ${error.response.statusText}`.trim();
+    return {
+      data: null,
+      error: {
+        ...parsedError,
+        message:
+          parsedError.message ||
+          fallbackMessage ||
+          'remote list request failed',
+      },
+    };
+  }
+}

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -16,7 +16,7 @@ import {
   type AgentPromptInput,
 } from '@agent/core/definition/AgentDataclass';
 import { mergeInheritedAgentObject } from '@agent/core/definition/agentDefinitionInheritance';
-import { RemoteAgentLoader } from '@agent/remote/RemoteAgentLoader';
+import { loadRemoteAgent } from '@agent/remote/RemoteAgentLoader';
 import { parseYamlWith, safeParseYaml } from '@common/parsing/safeParseYaml';
 import * as logger from '@logger/logUtils';
 import { agentKey } from '@shared/schemas/agent';
@@ -117,9 +117,7 @@ export async function loadAgentSettingAndPrompts(
 
   // Handle remote agents
   if (entry.source === 'remote') {
-    const remoteConfig = await RemoteAgentLoader.loadRemoteAgent(
-      resolution.resolvedName,
-    );
+    const remoteConfig = await loadRemoteAgent(resolution.resolvedName);
 
     // Remote agents are already fully processed (tools resolved, validated)
     return [remoteConfig.settings, remoteConfig.prompts];

--- a/src/test-kernel/agent/AgentRegistryAlias.vitest.mts
+++ b/src/test-kernel/agent/AgentRegistryAlias.vitest.mts
@@ -42,10 +42,8 @@ const listRemoteAgents = vi.hoisted(() =>
   ]),
 );
 
-vi.mock('@agent/remote/RemoteAgentLoader', () => ({
-  RemoteAgentLoader: {
-    listRemoteAgents,
-  },
+vi.mock('@agent/remote/remoteAgentList', () => ({
+  listRemoteAgents,
 }));
 
 const REPO_ROOT = resolve(

--- a/src/test-kernel/agent/remote/RemoteAgentLoaderSchemaFallback.vitest.ts
+++ b/src/test-kernel/agent/remote/RemoteAgentLoaderSchemaFallback.vitest.ts
@@ -1,9 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { loadRemoteAgent } from '@agent/remote/RemoteAgentLoader';
 import {
   isMissingRemoteAgentToolsColumnError,
-  RemoteAgentLoader,
-} from '@agent/remote/RemoteAgentLoader';
+  listRemoteAgents,
+} from '@agent/remote/remoteAgentList';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { SUPABASE_CONFIG } from '@auth/config';
 
@@ -101,7 +102,7 @@ describe('remote agent schema compatibility', () => {
       },
     );
 
-    const agents = await RemoteAgentLoader.listRemoteAgents();
+    const agents = await listRemoteAgents();
 
     expect(agents).toHaveLength(1);
     expect(agents[0]?.name).toBe('legacy-agent');
@@ -136,7 +137,7 @@ describe('remote agent schema compatibility', () => {
       },
     );
 
-    const agents = await RemoteAgentLoader.listRemoteAgents();
+    const agents = await listRemoteAgents();
 
     expect(agents).toHaveLength(1);
     expect(agents[0]?.name).toBe('nullable-error-agent');
@@ -169,7 +170,7 @@ describe('remote agent schema compatibility', () => {
       error: null,
     });
 
-    const agents = await RemoteAgentLoader.listRemoteAgents();
+    const agents = await listRemoteAgents();
 
     expect(agents.map((agent) => agent.name)).toEqual(['review']);
   });
@@ -183,7 +184,7 @@ describe('remote agent schema compatibility', () => {
       },
     });
 
-    const agents = await RemoteAgentLoader.listRemoteAgents();
+    const agents = await listRemoteAgents();
 
     expect(agents).toEqual([]);
     expect(selectedColumns).toEqual([
@@ -217,8 +218,8 @@ describe('remote agent config parsing', () => {
       }),
     );
 
-    await expect(
-      RemoteAgentLoader.loadRemoteAgent('broken-agent'),
-    ).rejects.toThrow('Failed to parse YAML for remote agent "broken-agent"');
+    await expect(loadRemoteAgent('broken-agent')).rejects.toThrow(
+      'Failed to parse YAML for remote agent "broken-agent"',
+    );
   });
 });

--- a/src/test-kernel/architecture/toolRegistryCycle.vitest.ts
+++ b/src/test-kernel/architecture/toolRegistryCycle.vitest.ts
@@ -1,0 +1,123 @@
+// Node imports
+import { readFileSync } from 'node:fs';
+
+// Third-party imports
+import { build } from 'esbuild';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { REPO_ROOT, sourceFilesUnder, toRepoPath } from '../support/repoScan';
+
+/**
+ * Architecture guard: `@tools/registry` imports every registered tool, so any
+ * module that reaches it drags the LaTeX, Lean, arxiv and Zotero tool set — and
+ * their `src/latex/` dependencies — into its own module closure.
+ *
+ * A tool module reaching the registry is a cycle, not a dependency: the
+ * registry already imports the tool. That cycle used to run
+ * `bash -> @agent/storage -> @agent/index/agentRegistry -> remoteAgentMeta ->
+ * RemoteAgentLoader -> @tools/registry`, and it put an identical 630-file
+ * closure on 19 of the 50 `defineTool()` modules. Splitting the remote-agent
+ * client's listing half (`@agent/remote/remoteAgentList`, registry-free) from
+ * its config-loading half (`RemoteAgentLoader`, which genuinely resolves tool
+ * names) severed it.
+ *
+ * Measurement matches the closure census in the issue: an esbuild bundle per
+ * `defineTool()` module with dependencies external, counting non-`node_modules`
+ * inputs. Dynamic `import()` targets count — an npm consumer still installs
+ * them — so a lazy import does not satisfy this guard.
+ */
+
+const TOOL_REGISTRY = 'src/tools/registry.ts';
+
+/**
+ * Tools whose closure may still contain the registry: both launch a subagent
+ * in-band, and resolving that subagent's YAML tool list genuinely needs the
+ * whole tool table (`inBandSubagentExecution -> executeAgent -> agentLoad ->
+ * @tools/registry`). That is a real dependency, not a cycle artifact — but it
+ * is also the only reason these two still ship the domain tools, so shrink this
+ * list rather than growing it.
+ */
+const AGENT_LAUNCHING_TOOLS = [
+  'src/tools/DelegationTools.ts',
+  'src/tools/delegation/WorkflowScriptTool.ts',
+] as const;
+
+/** Domain subsystems no generic tool should have to install. */
+const DOMAIN_PREFIXES = [
+  'src/latex/',
+  'src/tools/arxiv/',
+  'src/tools/lean/',
+  'src/tools/zotero/',
+] as const;
+
+function defineToolModules(): string[] {
+  return sourceFilesUnder(`${REPO_ROOT}/src/tools`, { repoRelative: true })
+    .filter((file) =>
+      readFileSync(`${REPO_ROOT}/${file}`, 'utf8').includes('defineTool('),
+    )
+    .sort();
+}
+
+async function valueClosure(entry: string): Promise<string[]> {
+  const result = await build({
+    absWorkingDir: REPO_ROOT,
+    entryPoints: [entry],
+    bundle: true,
+    write: false,
+    metafile: true,
+    platform: 'node',
+    format: 'esm',
+    packages: 'external',
+    tsconfig: 'tsconfig.json',
+    logLevel: 'silent',
+  });
+  return Object.keys(result.metafile.inputs)
+    .map(toRepoPath)
+    .filter((file) => !file.includes('node_modules'));
+}
+
+describe('tool module closures', () => {
+  const closures = new Map<string, string[]>();
+
+  beforeAll(async () => {
+    const entries = defineToolModules();
+    const resolved = await Promise.all(entries.map(valueClosure));
+    entries.forEach((entry, index) => closures.set(entry, resolved[index]!));
+  }, 120_000);
+
+  it('enumerates every defineTool() module', () => {
+    expect(closures.size).toBeGreaterThan(40);
+    expect([...closures.keys()]).toContain('src/tools/bash.ts');
+  });
+
+  it('keeps @tools/registry out of tool module closures', () => {
+    const offenders = [...closures.entries()]
+      .filter(
+        ([entry, files]) =>
+          !(AGENT_LAUNCHING_TOOLS as readonly string[]).includes(entry) &&
+          files.includes(TOOL_REGISTRY),
+      )
+      .map(([entry]) => entry);
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('keeps the agent-launching allowlist free of stale entries', () => {
+    const stale = AGENT_LAUNCHING_TOOLS.filter(
+      (entry) => !closures.get(entry)?.includes(TOOL_REGISTRY),
+    );
+
+    expect(stale).toEqual([]);
+  });
+
+  it('leaves no LaTeX, Lean, arxiv or Zotero file in bash’s closure', () => {
+    const files = closures.get('src/tools/bash.ts') ?? [];
+
+    expect(files).not.toEqual([]);
+    expect(
+      files.filter((file) =>
+        DOMAIN_PREFIXES.some((prefix) => file.startsWith(prefix)),
+      ),
+    ).toEqual([]);
+  });
+});

--- a/src/test-kernel/architecture/toolRegistryCycle.vitest.ts
+++ b/src/test-kernel/architecture/toolRegistryCycle.vitest.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 
 // Third-party imports
 import { build } from 'esbuild';
+import PQueue from 'p-queue';
 import { beforeAll, describe, expect, it } from 'vitest';
 
 import { REPO_ROOT, sourceFilesUnder, toRepoPath } from '../support/repoScan';
@@ -80,9 +81,14 @@ describe('tool module closures', () => {
   const closures = new Map<string, string[]>();
 
   beforeAll(async () => {
-    const entries = defineToolModules();
-    const resolved = await Promise.all(entries.map(valueClosure));
-    entries.forEach((entry, index) => closures.set(entry, resolved[index]!));
+    // Bounded concurrency: 50 unthrottled esbuild bundles saturate the box and
+    // push the neighbouring architecture ratchets past their own timeouts.
+    const queue = new PQueue({ concurrency: 4 });
+    await queue.addAll(
+      defineToolModules().map((entry) => async () => {
+        closures.set(entry, await valueClosure(entry));
+      }),
+    );
   }, 120_000);
 
   it('enumerates every defineTool() module', () => {
@@ -97,7 +103,8 @@ describe('tool module closures', () => {
           !(AGENT_LAUNCHING_TOOLS as readonly string[]).includes(entry) &&
           files.includes(TOOL_REGISTRY),
       )
-      .map(([entry]) => entry);
+      .map(([entry]) => entry)
+      .sort();
 
     expect(offenders).toEqual([]);
   });


### PR DESCRIPTION
Severs the `@tools/registry` cycle. `bash`'s module closure goes from **630 files / 34 domain files** to **217 / 0**; 17 of the 19 collapsed modules are severed the same way.

## What the cycle actually was

The issue's cycle table is correct about the endpoints but not about the path. Its hop 3 (`AgentRunLifecycle -> AgentLaunchContext`) is `import type`, and the issue says so — but the table's *value* path via `childStream` does not close either. Mapped at `1604f85376` with an esbuild metafile BFS, every one of the 19 modules reaches the registry through **one** gateway:

```
bash.ts -> @agent/storage -> executionLifecycle.ts -> @agent/index/agentRegistry.ts
        -> remoteAgentMeta.ts -> RemoteAgentLoader.ts -> @tools/registry -> ArxivDownloadTool -> @latex/arxivProcessor
```

The other four registry importers (`agentLoad`, `agentToolResolution`, `runToolUseFlow`, `ResponseCycleNode`) are reachable from a tool module **only after passing through `registry.ts` itself**, so they are consequences of the gateway, not separate gateways.

## Two corrections to the issue's prescribed mechanism

**1. A lazy `await import()` cannot satisfy this issue's own acceptance criterion.** `remoteAgentMeta.ts:48` was *already* a lazy dynamic import of `RemoteAgentLoader`, and the edge was still in the closure — esbuild's metafile records it as `kind: "dynamic-import"`:

```json
{ "path": "src/agent/remote/RemoteAgentLoader.ts", "kind": "dynamic-import",
  "original": "@agent/remote/RemoteAgentLoader" }
```

That is the right answer, not a measurement artifact: an npm consumer installs a dynamically imported module too. The issue anticipates this in its Gates section ("lazy imports hide the edge rather than delete it"); this PR takes the deletion branch and adds no new lazy imports.

**2. AC #2 and #3 are not reachable by severing this cycle** — see "What was deliberately not changed".

## The sever: one import-graph split, no new indirection

`RemoteAgentLoader.ts` held two unrelated halves:

| half | needs | consumer |
|---|---|---|
| `listRemoteAgents()` | metadata rows only | `remoteAgentMeta` (reachable from every tool) |
| `loadRemoteAgent()` | `resolveToolDefinitions` → `@tools/registry` | `agentLoad` (reachable only via the registry) |

The agent index only ever wanted the first, but imported the module carrying both. The listing half moves verbatim to **`@agent/remote/remoteAgentList`** — no `@tools/registry` import, and no `@agent/index` import either (`extractToolNames`/`updateAgentMeta` were both used by the config half). `RemoteAgentLoader` keeps config loading; nothing under `src/tools/` reaches it now. The static-only class collapses into the two plain functions it always was.

No port, no facade, no registration plane, no async boundary introduced — `remoteAgentMeta`'s import stays lazy exactly as it was, only repointed.

## Closure evidence

Measured with the issue's recipe: `esbuild` per `defineTool()` module, `bundle: true, write: false, metafile: true, packages: 'external', tsconfig: 'tsconfig.json'`, counting non-`node_modules` inputs. Before = `1604f85376`, after = this branch.

```
                                     before        after
src/tools/bash.ts                630 (dom 34)  217 (dom 0)
src/tools/EditTool.ts            630 (dom 34)  195 (dom 0)
src/tools/WriteTool.ts           630 (dom 34)  202 (dom 0)
src/tools/TextEditorTool.ts      630 (dom 34)  203 (dom 0)
src/tools/plan/PlanTool.ts       630 (dom 34)  191 (dom 0)
src/tools/memory/MemoryTool.ts   630 (dom 34)  200 (dom 0)
src/tools/DiagnosticsTool.ts     630 (dom 34)  188 (dom 0)
src/tools/ExecutionsTool.ts      630 (dom 34)  217 (dom 0)
src/tools/codex.ts               630 (dom 34)  226 (dom 0)
src/tools/claudeAgent.ts         630 (dom 34)  225 (dom 0)
…                                                (17 of 19 total)
src/tools/AcceptRunFilesTool.ts  630 (dom 34)  199 (dom 2)   ← its own @latex/acceptedFileTarget
src/tools/DelegationTools.ts     630 (dom 34)  631 (dom 34)  ← unchanged, see below
src/tools/delegation/
  WorkflowScriptTool.ts          630 (dom 34)  631 (dom 34)  ← unchanged, see below
```

`bash.ts` by subsystem:

```
before  src/agent=228 src/tools=160 src/shared=80 src/utils=48 src/common=24
        src/auth=20  src/latex=20  src/model=15 src/transcript=12 src/replacement=7
        src/platform=6 src/skills=5 src/logger=2 src/telemetry=2 src/eventBus=1

after   src/shared=74 src/agent=65 src/utils=27 src/common=18 src/transcript=12
        src/tools=10 src/auth=4 src/platform=3 src/model=2 src/logger=2
```

Gone from every generic tool: all 20 `src/latex/`, 6 `src/tools/lean/`, 6 arxiv, 5 Zotero, 16 of 20 `src/auth/`, all of `src/skills/`, `src/telemetry/`, `src/replacement/`, `src/eventBus/`, and `src/tools/externalToolDefs.ts` (the issue's second seam — it leaves generic closures as a consequence, untouched).

## Net element accounting

`+381 / −234` lines across 7 files, of which ~200 are the verbatim move. Net production delta: **+1 file, −1 class, +2 exported functions, −1 exported class**. `check:dead-code-ratchet`: 17 findings vs 17 baselined, no baseline bumped. No `config/ratchets/*.json` touched; `git diff --stat src/platform/` is empty.

## What was deliberately not changed

**`DelegationTools` and `WorkflowScriptTool` keep the full registry (631 files, 34 domain).** They reach it by a different and *honest* route: `proposalFlow -> subagentExecution -> inBandSubagentExecution -> @agent/runtime/executeAgent -> agentLoad -> @tools/registry`. Launching a subagent in-band means resolving that subagent's YAML tool list, which genuinely needs the whole tool table. That is a dependency, not a cycle, and no import-graph split can remove it. They also retain LaTeX through `runReflectionFlow -> TeXCountNode / LatexDiffManager / LatexMediaManager` — the agent runtime's own LaTeX coupling, a separate blocker. They are allowlisted in the test with that reasoning.

**AC #2 ("< 200 files") and AC #3 ("0 modules over 200") are not deliverable by severing this cycle, and I did not chase them.** After severing, `bash` is 217 with **zero** domain files: the residue is `src/shared=74` (wire schemas) plus `src/agent=65` (the run/session spine `childStream` genuinely needs). Cutting the *next* edge up the chain (`executionLifecycle -> @agent/index/agentRegistry`) was measured and only reaches 202 — still over, and it is a real usage (`getAgent`/`isAgentRegistryReady`). The <200 target is a statement about the runtime spine, i.e. the `runtimeHost` deletion in §4 of the proposal, not about B1. Reporting this rather than ratcheting it, per the "no new ratchet baselines" constraint.

**No `.js` extensions added to dynamic import specifiers** — that is #9333's business, and the one dynamic import here keeps the surrounding extension-less style.

## Test

`src/test-kernel/architecture/toolRegistryCycle.vitest.ts` — 4 tests, ~5 s, uses the issue's own measurement (esbuild metafile per `defineTool()` module, bounded to concurrency 4 with `p-queue` so it does not starve the neighbouring ratchets). Absolute assertions, **no baseline file**, so it is a guard rather than a ratchet:

1. every `defineTool()` module is enumerated (50 found);
2. no tool module's closure contains `src/tools/registry.ts`, except the two allowlisted agent-launchers;
3. the allowlist has no stale entries (it must shrink, not rot);
4. `bash`'s closure contains no `src/latex/`, `src/tools/lean/`, `src/tools/arxiv/`, `src/tools/zotero/` file.

Verified non-vacuous: restoring the old edge fails tests 2 and 4 with exactly the 17 offenders and 20 LaTeX files.

## Verification

- `npm run typecheck` — exit 0
- `npm run compile:fast` — clean
- `npm run lint` (eslint on changed files) and `prettier --check` — both clean
- `npm run check:dead-code-ratchet` — OK, no new findings
- `npx vitest run src/test-kernel/architecture/` — 11 files / 69 tests pass
- `npx vitest run src/test-kernel/agent/ src/test-kernel/agent/remote/ src/test-kernel/tools/` — every failure reproduces on a detached clean `origin/main` baseline (`WorkflowScriptSandboxBundle`, `DefaultSessionLifecycle`, `TextConnectionHelperModel`, `ClaudeAgentConfig`, `PRPollingSource*`, `SubagentExecutionChildStreamId`, `LeanTools` parallel budget — all 10 s contention timeouts). `subsystemEdgeRatchet` times out at 10 s **on clean `origin/main` without this branch's test file present** (10 files / 65 tests); it takes 9.1 s in isolation, so it is pre-existing borderline, not a regression.

Behavior parity: `registry.ts` is untouched, `resolveToolDefinitions` is untouched, and the moved code is verbatim — tool resolution order, registry contents and the model-facing tool list are unchanged.

Closes #9327

https://claude.ai/code/session_01XZ8Z6rhypTfkVq728XCcCd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactor is mostly a module split with behavior preserved, but it touches agent registry loading paths used by every tool module; the new architecture test should catch regressions of the cycle.
> 
> **Overview**
> **Breaks the import cycle** that pulled `@tools/registry` (and LaTeX/Lean/arxiv/Zotero tools) into generic tool modules via `remoteAgentMeta` → `RemoteAgentLoader`.
> 
> Remote-agent **listing** moves to new `@agent/remote/remoteAgentList` (`listRemoteAgents`, legacy `tools` column fallback unchanged). **YAML config loading** stays in `RemoteAgentLoader` as exported `loadRemoteAgent` and still uses `resolveToolDefinitions`. `remoteAgentMeta`’s dynamic import is repointed to the list module; `agentLoad` calls `loadRemoteAgent` instead of the removed `RemoteAgentLoader` class API.
> 
> Adds `toolRegistryCycle.vitest.ts` to assert most `defineTool()` closures exclude `src/tools/registry.ts` and that `bash` has no domain-tool paths, with an allowlist for delegation tools that genuinely launch subagents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e48829dca2af0721223ceff8058666318b58b4c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->