### PR TITLE
fix: consolidate execution flags into single const array

### DIFF
--- a/src/tools/core/define.ts
+++ b/src/tools/core/define.ts
@@ -18,6 +18,17 @@ export function toToolParameters(schema: ZodType): Record<string, unknown> {
   >;
 }
 
+const EXECUTION_FLAGS = [
+  'parallelSafe',
+  'requiresApproval',
+  'slow',
+  'deferLogUntilApproval',
+  'streamsOutput',
+] as const;
+
+type ExecutionFlag = (typeof EXECUTION_FLAGS)[number];
+type DefineToolFlags = { [K in ExecutionFlag]?: boolean };
+
 /**
  * Define a tool with type-safe schema and either a static or dynamic description.
  *
@@ -25,22 +36,14 @@ export function toToolParameters(schema: ZodType): Record<string, unknown> {
  * asynchronously (e.g., agent registry) - the function is called lazily when
  * the tool definition is accessed.
  */
-export function defineTool<T>(def: {
-  name: string;
-  /** Static description string or function for lazy evaluation */
-  description: string | (() => string);
-  schema: ZodType<T, T>;
-  /**
-   * Declare the tool side-effect-free and approval-free, allowing parallel
-   * calls in one model response to execute concurrently (see ITool).
-   */
-  parallelSafe?: boolean;
-  /** Execution behavior consumed by tool resolution and dispatch. */
-  requiresApproval?: boolean;
-  slow?: boolean;
-  deferLogUntilApproval?: boolean;
-  streamsOutput?: boolean;
-}) {
+export function defineTool<T>(
+  def: {
+    name: string;
+    /** Static description string or function for lazy evaluation */
+    description: string | (() => string);
+    schema: ZodType<T, T>;
+  } & DefineToolFlags,
+) {
   const getDescription = (): string =>
     typeof def.description === 'function' ? def.description() : def.description;
 


### PR DESCRIPTION
Extract the five execution flags (parallelSafe, requiresApproval, slow, deferLogUntilApproval, streamsOutput) into a const EXECUTION_FLAGS array and derive the DefineToolFlags type from it. This keeps a single source of truth for flag names instead of repeating them in the parameter type declaration.

## Summary

<!-- Explain the change for a reader who has not seen the issue discussion. -->

## Issue acceptance gates

<!-- List the issue(s) this PR addresses and the exact acceptance gates satisfied. If a gate remains incomplete, say so. -->

## Single source of truth

<!-- Name the module, schema, context object, or coordinator that now owns the relevant fact or decision. -->

## Duplication and abstraction budget

<!-- State what duplication was removed or avoided. If a new abstraction was added, state the invariant or host-boundary decision it owns. Do not add pass-through layers. -->

## Net elements (R6)

<!-- Constructs added vs deleted: files (diffstat), exported symbols (`^[+-]export` over the diff), classes/interfaces/enums, net LoC. Required for refactor/simplify/consolidate/dedupe/extract PRs. -->

## Consumer counts (R8)

<!-- Deleting or re-routing an emit path or export? State the grepped subscriber count per affected key. Otherwise: "n/a" + reason. -->

## Host impact

Extension:

Desktop:

CLI:

## Scheduled refactoring

<!-- Link any follow-up issue, or state "None" if no follow-up is needed. -->

## Validation

<!-- List the checks run. If a check was intentionally not run, say why. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only refactor in `defineTool` with no behavior change to tool dispatch or flag semantics.
> 
> **Overview**
> **Refactors `defineTool`’s optional execution flags** so their names live in one `EXECUTION_FLAGS` const tuple instead of being listed again on the parameter type.
> 
> `defineTool` now takes `DefineToolFlags` (optional booleans keyed by those five names) intersected with the existing `name`, `description`, and `schema` fields. Runtime behavior and how flags are copied onto `GeneratedTool` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2682161ec206238a80d1e824278f18789d54f1bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->