### PR TITLE
fix(delegation): prevent completed-child delivery replay storms

### DIFF
--- a/config/ratchets/host-agent-import-baseline.json
+++ b/config/ratchets/host-agent-import-baseline.json
@@ -10,6 +10,7 @@
       "@agent/export/loadChatExportInput",
       "@agent/export/schemas",
       "@agent/followUp/ToolUseFollowUp",
+      "@agent/followUp/ToolUseFollowUpQueueManager",
       "@agent/index",
       "@agent/index/platformAgentDirectories",
       "@agent/modelHandlers/support/contextUtilization",

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -439,7 +439,12 @@ if (HARNESS_MEMORY_FILES.length > 0) {
   });
 }
 initializeDefaultSession({ transcripts: await StreamLogStore.open() });
-const harnessFollowUpQueue = defaultSession().followUps.acquire(STREAM_ID);
+const harnessFollowUpLease = defaultSession().followUps.claimLive(
+  STREAM_ID,
+  'flow',
+)!;
+const harnessFollowUpQueue =
+  defaultSession().followUps.queue(harnessFollowUpLease);
 for (const followUp of QUEUED_FOLLOW_UPS) {
   harnessFollowUpQueue.enqueue({ text: followUp });
 }
@@ -2266,7 +2271,7 @@ function appendHarnessStatus(): void {
 function resetHarnessForClear(): void {
   const meta = sessionMeta.get();
   clearApprovals();
-  defaultSession().followUps.drain(STREAM_ID);
+  harnessFollowUpQueue.drain();
   void GoalStore.forget(STREAM_ID);
   const store = defaultSession().transcripts;
   for (const streamId of streams.get().keys()) {

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -8,6 +8,7 @@
 import PQueue from 'p-queue';
 
 import { getExecutionStore } from '@agent/storage';
+import type { FollowUpRecoveryLease } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import {
   AgentConfigSchema,
   type AgentConfig,
@@ -36,6 +37,7 @@ import {
 } from '@cli/runtime/sessionResume';
 import { runOutcomeExitCode } from '@cli/runtime/terminalStatus';
 import { CLI_UNAVAILABLE_TOOLS } from '@cli/runtime/unavailableTools';
+import type { RecoveryContinuation } from '@platform/interfaces';
 import {
   RUN_OUTCOME,
   STREAM_PHASE,
@@ -101,8 +103,9 @@ interface SupersededInterruptedRecovery {
 }
 
 interface AutoResumeOptions {
+  readonly recovery?: RecoveryContinuation;
   readonly extraFollowUps?: readonly InterruptedFollowUp[];
-  readonly onFollowUpQueueReady?: () => void;
+  readonly onFollowUpQueueReady?: (recovery: FollowUpRecoveryLease) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -152,7 +155,10 @@ export interface ChatSessionController {
    * Attempt to resume a queued follow-up target from the CLI platform port.
    * Returns true only when this controller accepts the target resume.
    */
-  tryResumeStream(streamId: StreamTabId): Promise<boolean>;
+  tryResumeStream(
+    streamId: StreamTabId,
+    recovery?: RecoveryContinuation,
+  ): Promise<boolean>;
 
   /** Whether a new root run can be started right now. */
   canStartRootRun(): boolean;
@@ -233,19 +239,17 @@ export function createChatSessionController(
     return streamId ? { streamId, followUps } : undefined;
   };
 
-  const enqueueRecoveryFollowUps = (
+  const restoreRecoveryFollowUps = (
     recovery: SupersededInterruptedRecovery | undefined,
-    streamId: StreamTabId,
+    lease: FollowUpRecoveryLease,
   ): void => {
-    for (const followUp of recovery?.followUps ?? []) {
-      defaultSession().followUps.enqueue(streamId, followUp, { force: true });
-    }
+    defaultSession().followUps.restore(lease, recovery?.followUps ?? []);
     if (recovery?.followUps.length) {
       defaultSession().events.emit({
         scope: 'session',
         event: {
           type: 'updateQueuedFollowUps',
-          payload: { streamId },
+          payload: { streamId: lease.streamId },
         },
       });
     }
@@ -574,8 +578,12 @@ export function createChatSessionController(
 
   const tryResumeStream = (
     streamId: StreamTabId,
-    options: AutoResumeOptions = {},
+    recoveryOrOptions: RecoveryContinuation | AutoResumeOptions = {},
   ): Promise<boolean> => {
+    const options: AutoResumeOptions =
+      'kind' in recoveryOrOptions
+        ? { recovery: recoveryOrOptions }
+        : recoveryOrOptions;
     let resolveRun: (resumed: boolean) => void = () => {};
     let rejectRun: (error: unknown) => void = () => {};
     const runPromise = new Promise<boolean>((resolve, reject) => {
@@ -631,48 +639,58 @@ export function createChatSessionController(
         let resumedOutcome: Parameters<typeof runOutcomeExitCode>[0] =
           RUN_OUTCOME.COMPLETED;
         const resumed = await setCliHelperModel(currentModel).then(() =>
-          resolveAndResumeStream(streamId, {
-            runtimeHost,
-            streamStatus: defaultSession().status,
-            isCancellationRequested: () => session.stopRequested,
-            resolveResumeState: async () => ({
-              runState: config,
-              executionId,
-              parentStreamId,
-            }),
-            resumeToolUse: (resume) =>
-              resumeQueuedToolUseFromResumeData(streamId, resume, runtimeHost, {
-                session: defaultSession(),
-                approvalPromptsUnavailable: approvalsUnavailable,
-                runtimeUnavailableTools: CLI_UNAVAILABLE_TOOLS,
-                extraFollowUps: options.extraFollowUps,
-                onFollowUpQueueReady: () => {
-                  if (options.onFollowUpQueueReady) {
-                    options.onFollowUpQueueReady();
-                  } else {
-                    const recovery = supersedeInterruptedRecovery();
-                    enqueueRecoveryFollowUps(recovery, streamId);
-                  }
-                },
-                isCancellationRequested: () => session.stopRequested,
-                onResult: (result) => {
-                  resumedOutcome = result.outcome;
-                },
-                onError: reportRunFailure,
+          resolveAndResumeStream(
+            streamId,
+            {
+              runtimeHost,
+              streamStatus: defaultSession().status,
+              isCancellationRequested: () => session.stopRequested,
+              resolveResumeState: async () => ({
+                runState: config,
+                executionId,
+                parentStreamId,
               }),
-            executeWorkflow: async () => {
-              throw new Error(
-                'CLI chat cannot auto-resume workflow streams from follow-up wake.',
-              );
+              resumeToolUse: (resume, claimedRecovery) =>
+                resumeQueuedToolUseFromResumeData(
+                  streamId,
+                  resume,
+                  runtimeHost,
+                  {
+                    session: defaultSession(),
+                    recovery: claimedRecovery,
+                    approvalPromptsUnavailable: approvalsUnavailable,
+                    runtimeUnavailableTools: CLI_UNAVAILABLE_TOOLS,
+                    extraFollowUps: options.extraFollowUps,
+                    onFollowUpQueueReady: (lease) => {
+                      if (options.onFollowUpQueueReady) {
+                        options.onFollowUpQueueReady(lease);
+                      } else {
+                        const recovery = supersedeInterruptedRecovery();
+                        restoreRecoveryFollowUps(recovery, lease);
+                      }
+                    },
+                    isCancellationRequested: () => session.stopRequested,
+                    onResult: (result) => {
+                      resumedOutcome = result.outcome;
+                    },
+                    onError: reportRunFailure,
+                  },
+                ),
+              executeWorkflow: async () => {
+                throw new Error(
+                  'CLI chat cannot auto-resume workflow streams from follow-up wake.',
+                );
+              },
+              reportNoResumableSession: () => {
+                appendLocalAssistantTranscript(
+                  'Message queued. Auto-resume found no resumable session state; resume the session manually or start a new agent task.',
+                  streamId,
+                );
+              },
+              reportFailure: (_failedStream, error) => reportRunFailure(error),
             },
-            reportNoResumableSession: () => {
-              appendLocalAssistantTranscript(
-                'Message queued. Auto-resume found no resumable session state; resume the session manually or start a new agent task.',
-                streamId,
-              );
-            },
-            reportFailure: (_failedStream, error) => reportRunFailure(error),
-          }),
+            options.recovery,
+          ),
         );
 
         if (resumed) {

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -503,7 +503,8 @@ export async function runChat(
   });
   disposers.push(
     setCliAgentResumeHandler({
-      tryResumeStream: (streamId) => chatController.tryResumeStream(streamId),
+      tryResumeStream: (streamId, recovery) =>
+        chatController.tryResumeStream(streamId, recovery),
     }),
   );
 

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -18,9 +18,8 @@ import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { detachSubagentsOnStop } from '@agent/runtime/detachSubagentsOnStop';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import {
-  presentFollowUpWakeResult,
-  sendFollowUp,
-  wakeQueuedFollowUpStream,
+  presentFollowUpResult,
+  submitFollowUp,
 } from '@agent/followUp/ToolUseFollowUp';
 import { setCliAgentResumeHandler } from '@cli/runtime/agentResume';
 import { type CliContext, readCliVersion } from '@cli/runtime/cliContext';
@@ -739,25 +738,17 @@ export async function runChat(
           followUpTarget = session.streamId;
         }
         if (!followUpTarget || session.stopRequested) return;
-        const result = await sendFollowUp(
-          followUpTarget,
-          prepared.instruction,
+        const result = await submitFollowUp(followUpTarget, {
+          text: prepared.instruction,
           mediaFiles,
-          prepared.displayInstruction,
-        );
+          displayText: prepared.displayInstruction,
+        });
         if (result.status === 'sent') {
           emitQueuedFollowUpsChanged(followUpTarget);
           delivered = true;
         } else if (result.status === 'queued') {
           emitQueuedFollowUpsChanged(followUpTarget);
-          if (
-            defaultSession().executions.isChildRunLoopActive(followUpTarget)
-          ) {
-            delivered = true;
-            return;
-          }
-          const wake = await wakeQueuedFollowUpStream(followUpTarget, result);
-          const presentation = presentFollowUpWakeResult(wake);
+          const presentation = presentFollowUpResult(result);
           if (presentation.severity !== 'none') {
             if (presentation.refreshQueuedFollowUps) {
               emitQueuedFollowUpsChanged(followUpTarget);
@@ -767,10 +758,9 @@ export async function runChat(
               followUpTarget,
             );
           }
-          delivered =
-            wake.kind !== 'dropped' && wake.kind !== 'queued_resume_failed';
+          delivered = result.continuation !== 'resume_failed';
         }
-        if (result.status === 'no_session') {
+        if (result.status === 'no_session' || result.status === 'dropped') {
           // Child stream ids are keys in parentStream; the root session id is not.
           if (followUpTarget === session.streamId) {
             session.stopRequested = true;

--- a/packages/cli/src/runtime/agentResume.ts
+++ b/packages/cli/src/runtime/agentResume.ts
@@ -1,9 +1,11 @@
-// Local imports
-import { isResumeInFlight } from '@agent/runtime/resolveAndResumeStream';
+import type { RecoveryContinuation } from '@platform/interfaces';
 import type { StreamTabId } from '@shared/schemas';
 
 export interface CliAgentResumeHandler {
-  tryResumeStream(streamId: StreamTabId): Promise<boolean>;
+  tryResumeStream(
+    streamId: StreamTabId,
+    recovery?: RecoveryContinuation,
+  ): Promise<boolean>;
 }
 
 let activeHandler: CliAgentResumeHandler | undefined;
@@ -13,18 +15,13 @@ export function setCliAgentResumeHandler(
 ): () => void {
   activeHandler = handler;
   return () => {
-    if (activeHandler === handler) {
-      activeHandler = undefined;
-    }
+    if (activeHandler === handler) activeHandler = undefined;
   };
 }
 
 export async function tryResumeCliStream(
   streamId: StreamTabId,
+  recovery?: RecoveryContinuation,
 ): Promise<boolean> {
-  return activeHandler?.tryResumeStream(streamId) ?? false;
-}
-
-export function isCliResumeInFlight(streamId: StreamTabId): boolean {
-  return activeHandler != null && isResumeInFlight(streamId);
+  return activeHandler?.tryResumeStream(streamId, recovery) ?? false;
 }

--- a/packages/cli/src/runtime/initPlatform.ts
+++ b/packages/cli/src/runtime/initPlatform.ts
@@ -34,7 +34,7 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 
 // Local file imports
 import { applyCliGitAuthorConfig } from './gitAuthor';
-import { isCliResumeInFlight, tryResumeCliStream } from './agentResume';
+import { tryResumeCliStream } from './agentResume';
 import { getCliSecrets } from './cliSecrets';
 import { isTexraCliEntrypointPath, readCliEntrypointPath } from './cliContext';
 import { flushNdjsonStdout, writeTextStderr } from './logSinks';
@@ -285,7 +285,6 @@ export async function initCliPlatform(
         lifecycle,
         agentResume: {
           tryResumeStream: tryResumeCliStream,
-          isResumeInFlight: isCliResumeInFlight,
         },
         agentDirectories,
         getWorkspacePath: () => cliWorkspaceCwd,

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -1414,7 +1414,7 @@ export class DesktopProgressBridge {
     };
   }
 
-  private async sendFollowUp(
+  private sendFollowUp(
     streamId: StreamTabId,
     text: string,
     mediaFiles?: readonly string[],
@@ -1423,31 +1423,45 @@ export class DesktopProgressBridge {
     // handle is tracked in `this.session`, but this IPC path runs outside the
     // run ALS, so the module default (currentSession ⇒ defaultSession) would
     // look in the wrong registry and report `no_session` for a live run.
-    const result = await submitFollowUp(
+    // Admission and the recovery claim happen synchronously inside
+    // submitFollowUp. Presentation remains detached because recovery may run a
+    // complete agent turn; closing a desktop window must not await that turn.
+    void submitFollowUp(
       streamId,
       { text, mediaFiles },
       { session: this.session },
-    );
-    if (result.status === 'sent' || result.status === 'queued') {
-      this.session.events.emit({
-        scope: 'session',
-        event: {
-          type: 'updateQueuedFollowUps',
-          payload: { streamId },
-        },
-      });
-      const presentation = presentFollowUpResult(result);
-      if (presentation.severity !== 'none') {
-        await this.session.interactions.showInfoMessage(presentation.message, {
-          replayWhenAttached: true,
-        });
-      }
-      return;
-    }
+    )
+      .then(async (result) => {
+        if (result.status === 'sent' || result.status === 'queued') {
+          this.session.events.emit({
+            scope: 'session',
+            event: {
+              type: 'updateQueuedFollowUps',
+              payload: { streamId },
+            },
+          });
+          const presentation = presentFollowUpResult(result);
+          if (presentation.severity !== 'none') {
+            await this.session.interactions.showInfoMessage(
+              presentation.message,
+              {
+                replayWhenAttached: true,
+              },
+            );
+          }
+          return;
+        }
 
-    await this.options.host.showInfoMessage(
-      'No active session. Start a new agent task to continue.',
-    );
+        await this.options.host.showInfoMessage(
+          'No active session. Start a new agent task to continue.',
+        );
+      })
+      .catch((error: unknown) => {
+        this.logger.warn(`Failed to submit follow-up for stream ${streamId}`, {
+          data: toLogData(error),
+        });
+      });
+    return Promise.resolve();
   }
 
   openFileCompile(filePath: string): Promise<void> {

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -17,9 +17,8 @@ import { trackTerminalResultPresentation } from '@agent/runtime/terminalResultTo
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import {
   notifyFollowUpSent,
-  presentFollowUpWakeResult,
-  sendFollowUp,
-  wakeQueuedFollowUpStream,
+  presentFollowUpResult,
+  submitFollowUp,
 } from '@agent/followUp/ToolUseFollowUp';
 import type {
   RuntimePresentationEvent,
@@ -160,42 +159,6 @@ export interface DesktopProgressBridgeOptions {
   sessionStores: SessionStores;
   logger?: AgentTrace;
   host: DesktopAgentExecutionHost;
-  wakeQueuedFollowUpStream?: typeof wakeQueuedFollowUpStream;
-}
-
-async function wakeDesktopFollowUp(
-  streamId: StreamTabId,
-  result: Extract<
-    Awaited<ReturnType<typeof sendFollowUp>>,
-    { status: 'sent' | 'queued' }
-  >,
-  session: SessionHandle,
-  wakeFollowUpStream: typeof wakeQueuedFollowUpStream = wakeQueuedFollowUpStream,
-): Promise<void> {
-  // This continuation deliberately accepts only the process SessionHandle.
-  // It may outlive a window, so it must not capture a bridge or BrowserWindow
-  // presentation. Its important failure notice explicitly survives a detached
-  // interval and is delivered once when the next presentation attaches.
-  const wake = await wakeFollowUpStream(
-    streamId,
-    result,
-    platform().agentResume,
-    session,
-  );
-  const presentation = presentFollowUpWakeResult(wake);
-  if (presentation.severity === 'none') return;
-  if (presentation.refreshQueuedFollowUps) {
-    session.events.emit({
-      scope: 'session',
-      event: {
-        type: 'updateQueuedFollowUps',
-        payload: { streamId },
-      },
-    });
-  }
-  await session.interactions.showInfoMessage(presentation.message, {
-    replayWhenAttached: true,
-  });
 }
 
 export class DesktopProgressBridge {
@@ -1460,12 +1423,10 @@ export class DesktopProgressBridge {
     // handle is tracked in `this.session`, but this IPC path runs outside the
     // run ALS, so the module default (currentSession ⇒ defaultSession) would
     // look in the wrong registry and report `no_session` for a live run.
-    const result = await sendFollowUp(
+    const result = await submitFollowUp(
       streamId,
-      text,
-      mediaFiles,
-      undefined,
-      this.session,
+      { text, mediaFiles },
+      { session: this.session },
     );
     if (result.status === 'sent' || result.status === 'queued') {
       this.session.events.emit({
@@ -1475,17 +1436,12 @@ export class DesktopProgressBridge {
           payload: { streamId },
         },
       });
-      const logger = this.logger;
-      void wakeDesktopFollowUp(
-        streamId,
-        result,
-        this.session,
-        this.options.wakeQueuedFollowUpStream,
-      ).catch((error: unknown) => {
-        logger.warn(`Failed to wake follow-up stream ${streamId}`, {
-          data: toLogData(error),
+      const presentation = presentFollowUpResult(result);
+      if (presentation.severity !== 'none') {
+        await this.session.interactions.showInfoMessage(presentation.message, {
+          replayWhenAttached: true,
         });
-      });
+      }
       return;
     }
 

--- a/packages/desktop/src/main/desktopAgentResume.ts
+++ b/packages/desktop/src/main/desktopAgentResume.ts
@@ -3,14 +3,12 @@ import type { AgentTrace } from '@agent/trace';
 import { createChannelTrace } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
-import {
-  isResumeInFlight,
-  resolveAndResumeStream,
-} from '@agent/runtime/resolveAndResumeStream';
+import { resolveAndResumeStream } from '@agent/runtime/resolveAndResumeStream';
 import { resumeQueuedToolUseFromResumeData } from '@agent/runtime/resumeQueuedToolUse';
 import { trackTerminalResultPresentation } from '@agent/runtime/terminalResultToast';
 
 // Shared imports
+import type { RecoveryContinuation } from '@platform/interfaces';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -52,14 +50,21 @@ export class DesktopProcessResumeOwner {
     };
   }
 
-  tryResumeStream(streamId: StreamTabId): Promise<boolean> {
-    return this.context
-      ? resumeDesktopStream(streamId, this.context)
-      : Promise.resolve(false);
-  }
-
-  isResumeInFlight(streamId: StreamTabId): boolean {
-    return this.context ? isResumeInFlight(streamId) : false;
+  tryResumeStream(
+    streamId: StreamTabId,
+    recovery?: RecoveryContinuation,
+  ): Promise<boolean> {
+    const context = this.context;
+    if (!context) return Promise.resolve(false);
+    const claimedRecovery = recovery
+      ? context.session.followUps.useRecovery(recovery)
+      : context.session.followUps.claimRecovery(streamId, true);
+    if (!claimedRecovery) return Promise.resolve(false);
+    return resumeDesktopStream(streamId, context, claimedRecovery).finally(
+      () => {
+        context.session.followUps.release(claimedRecovery, 'recoverable');
+      },
+    );
   }
 }
 
@@ -104,6 +109,7 @@ async function resolveDesktopResumeState(
 function resumeDesktopStream(
   streamId: StreamTabId,
   context: DesktopResumeContext,
+  recovery?: RecoveryContinuation,
 ): Promise<boolean> {
   if (!context.session.transcripts.has(streamId)) return Promise.resolve(false);
   const terminalResult = trackTerminalResultPresentation(
@@ -135,65 +141,70 @@ function resumeDesktopStream(
     );
   };
   const runtimeHost = context.session.interactions;
-  return resolveAndResumeStream(streamId, {
-    runtimeHost,
-    streamStatus: context.session.status,
-    resolveResumeState: async (id) => {
-      const resumeState = await resolveDesktopResumeState(id, context);
-      if (isResumeInvalidated()) return undefined;
-      if (!resumeState) {
-        await context.session.interactions.showInfoMessage(
-          'No persisted run state was found for this stream. Start a new run instead.',
+  return resolveAndResumeStream(
+    streamId,
+    {
+      runtimeHost,
+      streamStatus: context.session.status,
+      resolveResumeState: async (id) => {
+        const resumeState = await resolveDesktopResumeState(id, context);
+        if (isResumeInvalidated()) return undefined;
+        if (!resumeState) {
+          await context.session.interactions.showInfoMessage(
+            'No persisted run state was found for this stream. Start a new run instead.',
+            { replayWhenAttached: true },
+          );
+          return undefined;
+        }
+        if (!resumeState.executionId) {
+          await context.session.interactions.showInfoMessage(
+            'This stream has no persisted execution id. Start a new run instead.',
+            { replayWhenAttached: true },
+          );
+          return undefined;
+        }
+        return {
+          runState: resumeState.runState,
+          executionId: resumeState.executionId,
+          ...(resumeState.parentStreamId !== undefined && {
+            parentStreamId: resumeState.parentStreamId,
+          }),
+        };
+      },
+      resumeToolUse: (snapshot, claimedRecovery) =>
+        resumeQueuedToolUseFromResumeData(
+          snapshot.streamId,
+          snapshot,
+          runtimeHost,
+          {
+            session: context.session,
+            recovery: claimedRecovery,
+            runtimeUnavailableTools: DESKTOP_UNAVAILABLE_TOOLS,
+            canAcquireResumeLease,
+            isCancellationRequested: isResumeInvalidated,
+            onError: (error) => reportUnhandledFailure(streamId, error),
+          },
+        ),
+      executeWorkflow: (config, executionId, modelHandlerCompatibilityKey) =>
+        launchDesktopAgent(
+          { config, executionId },
+          {
+            session: context.session,
+            canAcquireResumeLease,
+          },
+          {
+            modelHandlerCompatibilityKey,
+            suppressErrorNotification: true,
+          },
+        ),
+      reportNoResumableSession: () =>
+        context.session.interactions.showInfoMessage(
+          'This run has no resumable session state. Start a new run instead.',
           { replayWhenAttached: true },
-        );
-        return undefined;
-      }
-      if (!resumeState.executionId) {
-        await context.session.interactions.showInfoMessage(
-          'This stream has no persisted execution id. Start a new run instead.',
-          { replayWhenAttached: true },
-        );
-        return undefined;
-      }
-      return {
-        runState: resumeState.runState,
-        executionId: resumeState.executionId,
-        ...(resumeState.parentStreamId !== undefined && {
-          parentStreamId: resumeState.parentStreamId,
-        }),
-      };
+        ),
+      reportFailure: reportUnhandledFailure,
+      isCancellationRequested: isResumeInvalidated,
     },
-    resumeToolUse: (snapshot) =>
-      resumeQueuedToolUseFromResumeData(
-        snapshot.streamId,
-        snapshot,
-        runtimeHost,
-        {
-          session: context.session,
-          runtimeUnavailableTools: DESKTOP_UNAVAILABLE_TOOLS,
-          canAcquireResumeLease,
-          isCancellationRequested: isResumeInvalidated,
-          onError: (error) => reportUnhandledFailure(streamId, error),
-        },
-      ),
-    executeWorkflow: (config, executionId, modelHandlerCompatibilityKey) =>
-      launchDesktopAgent(
-        { config, executionId },
-        {
-          session: context.session,
-          canAcquireResumeLease,
-        },
-        {
-          modelHandlerCompatibilityKey,
-          suppressErrorNotification: true,
-        },
-      ),
-    reportNoResumableSession: () =>
-      context.session.interactions.showInfoMessage(
-        'This run has no resumable session state. Start a new run instead.',
-        { replayWhenAttached: true },
-      ),
-    reportFailure: reportUnhandledFailure,
-    isCancellationRequested: isResumeInvalidated,
-  }).finally(terminalResult.dispose);
+    recovery,
+  ).finally(terminalResult.dispose);
 }

--- a/packages/extension/src/commands/agent/followUpCommand.ts
+++ b/packages/extension/src/commands/agent/followUpCommand.ts
@@ -5,10 +5,9 @@ import * as vscode from 'vscode';
 import { deriveResumability } from '@agent/storage';
 import { createChannelTrace } from '@agent/trace';
 import {
-  presentFollowUpWakeResult,
-  sendFollowUp,
-  wakeQueuedFollowUpStream,
-  type SendFollowUpResult,
+  presentFollowUpResult,
+  submitFollowUp,
+  type SubmitFollowUpResult,
 } from '@agent/followUp/ToolUseFollowUp';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { registerCommands } from '@commands/_shared/registerCommands';
@@ -73,7 +72,7 @@ async function lazyDetectWaitingStatus(
 }
 
 async function handleFollowUpResult(
-  result: SendFollowUpResult,
+  result: SubmitFollowUpResult,
   streamId: StreamTabId,
 ): Promise<void> {
   switch (result.status) {
@@ -83,9 +82,7 @@ async function handleFollowUpResult(
     case 'queued':
       emitQueuedFollowUpsChanged(streamId);
       {
-        const presentation = presentFollowUpWakeResult(
-          await wakeQueuedFollowUpStream(streamId, result),
-        );
+        const presentation = presentFollowUpResult(result);
         if (presentation.severity === 'warning') {
           if (presentation.refreshQueuedFollowUps) {
             emitQueuedFollowUpsChanged(streamId);
@@ -100,6 +97,7 @@ async function handleFollowUpResult(
       }
       break;
     case 'no_session':
+    case 'dropped':
       await vscode.window.showWarningMessage(
         'No active session. Start a new agent task to continue.',
       );
@@ -120,7 +118,10 @@ export function registerFollowUpCommand(context: vscode.ExtensionContext) {
 
         await lazyDetectWaitingStatus(streamId);
 
-        const result = await sendFollowUp(streamId, text, mediaFiles);
+        const result = await submitFollowUp(streamId, {
+          text,
+          mediaFiles,
+        });
         await handleFollowUpResult(result, streamId);
       },
     },

--- a/packages/extension/src/commands/agent/resumeCommand.ts
+++ b/packages/extension/src/commands/agent/resumeCommand.ts
@@ -10,6 +10,7 @@ import {
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import { registerCommands } from '@commands/_shared/registerCommands';
 import { logErrorMessage } from '@frontend/ui/errorHandlingUtils';
+import type { RecoveryContinuation } from '@platform/interfaces';
 import { getToolUsePersistenceEnabled } from '@utils/config/constants';
 
 interface ResumeAgentResult {
@@ -47,6 +48,7 @@ async function showResumeError(error: unknown): Promise<void> {
  */
 export function resumeExtensionToolUseFromResumeData(
   resume: ToolUseResumeData,
+  recovery?: RecoveryContinuation,
   followUp?: string,
 ): Promise<boolean> {
   if (!getToolUsePersistenceEnabled()) {
@@ -57,6 +59,7 @@ export function resumeExtensionToolUseFromResumeData(
     resume,
     defaultSession().interactions,
     {
+      recovery,
       ...(followUp !== undefined && {
         extraFollowUps: [{ text: followUp, origin: 'user' as const }],
       }),
@@ -101,6 +104,7 @@ export function registerResumeAgentCommand(
 
         const success = await resumeExtensionToolUseFromResumeData(
           resume,
+          undefined,
           payload?.followUp,
         );
         return { success };

--- a/packages/extension/src/commands/agent/resumeFromResumeData.ts
+++ b/packages/extension/src/commands/agent/resumeFromResumeData.ts
@@ -11,11 +11,9 @@
  * extension supplies only how it resolves persisted state and launches a run.
  */
 import { createChannelTrace } from '@agent/trace';
-import {
-  isResumeInFlight,
-  resolveAndResumeStream,
-} from '@agent/runtime/resolveAndResumeStream';
+import { resolveAndResumeStream } from '@agent/runtime/resolveAndResumeStream';
 import { defaultSession } from '@agent/runtime/SessionHandle';
+import type { RecoveryContinuation } from '@platform/interfaces';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 import type { StreamTabId } from '@shared/schemas';
 
@@ -24,45 +22,59 @@ import { resumeExtensionToolUseFromResumeData } from './resumeCommand';
 
 const logger = createChannelTrace('resumeFromResumeData');
 
-export { isResumeInFlight };
-
 export function tryResumeFromResumeData(
   streamId: StreamTabId,
+  recovery?: RecoveryContinuation,
 ): Promise<boolean> {
-  return resolveAndResumeStream(streamId, {
-    runtimeHost: defaultSession().interactions,
-    // The extension runs on the default session for this host-path caller
-    // (outside any run ALS), so its status plane is the same one every other
-    // unmigrated default-session caller reads through `defaultSession()`.
-    streamStatus: defaultSession().status,
-    resolveResumeState: async (id) => {
-      const progressState = ProgressViewProvider.getInstance()?.state;
-      if (!progressState) {
-        logger.warn(`No ProgressViewProvider found for stream: ${id}`);
-        return undefined;
-      }
-      const executionId = progressState.snapshots.getExecutionId(id);
-      const taskState = progressState.snapshots.getTaskState(id);
-      if (!executionId) {
-        logger.warn(`No execution ID found for stream: ${id}`);
-        return undefined;
-      }
-      if (!taskState) {
-        logger.warn(`No task state found for stream: ${id}`);
-        return undefined;
-      }
-      const parentStreamId = progressState.snapshots.getParentStreamId(id);
-      return {
-        runState: taskState,
-        executionId,
-        ...(parentStreamId !== undefined && { parentStreamId }),
-      };
+  const session = defaultSession();
+  const claimedRecovery = recovery
+    ? session.followUps.useRecovery(recovery)
+    : session.followUps.claimRecovery(streamId, true);
+  if (!claimedRecovery) return Promise.resolve(false);
+  return resolveAndResumeStream(
+    streamId,
+    {
+      runtimeHost: session.interactions,
+      // The extension runs on the default session for this host-path caller
+      // (outside any run ALS), so its status plane is the same one every other
+      // unmigrated default-session caller reads through `defaultSession()`.
+      streamStatus: session.status,
+      resolveResumeState: async (id) => {
+        const progressState = ProgressViewProvider.getInstance()?.state;
+        if (!progressState) {
+          logger.warn(`No ProgressViewProvider found for stream: ${id}`);
+          return undefined;
+        }
+        const executionId = progressState.snapshots.getExecutionId(id);
+        const taskState = progressState.snapshots.getTaskState(id);
+        if (!executionId) {
+          logger.warn(`No execution ID found for stream: ${id}`);
+          return undefined;
+        }
+        if (!taskState) {
+          logger.warn(`No task state found for stream: ${id}`);
+          return undefined;
+        }
+        const parentStreamId = progressState.snapshots.getParentStreamId(id);
+        return {
+          runState: taskState,
+          executionId,
+          ...(parentStreamId !== undefined && { parentStreamId }),
+        };
+      },
+      resumeToolUse: resumeExtensionToolUseFromResumeData,
+      executeWorkflow: (config, executionId, modelHandlerCompatibilityKey) =>
+        runExecuteCommand({
+          config,
+          executionId,
+          modelHandlerCompatibilityKey,
+        }),
+      reportFailure: (id, error) => {
+        logger.error(`Failed to resume stream: ${id}`, { data: error });
+      },
     },
-    resumeToolUse: resumeExtensionToolUseFromResumeData,
-    executeWorkflow: (config, executionId, modelHandlerCompatibilityKey) =>
-      runExecuteCommand({ config, executionId, modelHandlerCompatibilityKey }),
-    reportFailure: (id, error) => {
-      logger.error(`Failed to resume stream: ${id}`, { data: error });
-    },
+    claimedRecovery,
+  ).finally(() => {
+    session.followUps.release(claimedRecovery, 'recoverable');
   });
 }

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -29,10 +29,7 @@ import { SupabaseClient } from '@auth/SupabaseClient';
 import { hasAnyUsableSetupCredential } from '@commands/setup/setupAssistantCommand';
 import { openGettingStarted } from '@commands/system/walkthroughCommands';
 import { createSampleProjectWithoutWorkspace } from '@commands/system/sampleProjectCommands';
-import {
-  isResumeInFlight,
-  tryResumeFromResumeData,
-} from '@commands/agent/resumeFromResumeData';
+import { tryResumeFromResumeData } from '@commands/agent/resumeFromResumeData';
 import { globalSM, initializeStateManagers, workspaceSM } from '@common/state';
 import { SIDEBAR_VIEWS, setActiveSidebarView } from '@common/webview';
 import { appSignals } from '@eventBus/AppSignals';
@@ -241,8 +238,8 @@ export async function activate(context: vscode.ExtensionContext) {
     lifecycle,
     agentDirectories,
     agentResume: {
-      tryResumeStream: (streamId) => tryResumeFromResumeData(streamId),
-      isResumeInFlight: (streamId) => isResumeInFlight(streamId),
+      tryResumeStream: (streamId, recovery) =>
+        tryResumeFromResumeData(streamId, recovery),
     },
     toolAvailability: {
       ...NO_TOOL_AVAILABILITY_HOST,

--- a/src/agent/followUp/FollowUpQueue.ts
+++ b/src/agent/followUp/FollowUpQueue.ts
@@ -52,12 +52,12 @@ export class FollowUpQueue {
   private deferred: DeferredPromise<FollowUpQueueItem | null> | null = null;
 
   enqueue(value: FollowUpQueueInput): void {
-    this.enqueueItem({
-      text: value.text,
-      displayText: value.displayText,
-      origin: value.origin ?? 'user',
-      mediaFiles: value.mediaFiles,
-    });
+    this.enqueueItem(this.toItem(value));
+  }
+
+  /** Restore a drained visible batch ahead of input that raced its consumer. */
+  restore(values: readonly FollowUpQueueInput[]): void {
+    this.queued.unshift(...values.map((value) => this.toItem(value)));
   }
 
   enqueueSynthetic(value: string): void {
@@ -72,6 +72,15 @@ export class FollowUpQueue {
     } else {
       this.queued.push(value);
     }
+  }
+
+  private toItem(value: FollowUpQueueInput): FollowUpQueueItem {
+    return {
+      text: value.text,
+      displayText: value.displayText,
+      origin: value.origin ?? 'user',
+      mediaFiles: value.mediaFiles,
+    };
   }
 
   isEmpty(): boolean {
@@ -99,6 +108,9 @@ export class FollowUpQueue {
     }
     if (checkInterruption()) {
       return Promise.resolve(null);
+    }
+    if (this.deferred) {
+      throw new Error('Follow-up queue already has a waiting consumer.');
     }
     const d = pDefer<FollowUpQueueItem | null>();
     this.deferred = d;

--- a/src/agent/followUp/ToolUseFollowUp.ts
+++ b/src/agent/followUp/ToolUseFollowUp.ts
@@ -122,7 +122,7 @@ export async function submitFollowUp(
       item,
       'live_owner',
     );
-    if (submission.kind === 'live') {
+    if (submission.kind === 'live' || submission.kind === 'queued') {
       return {
         status: 'queued',
         reason: 'waiting',
@@ -147,9 +147,15 @@ export async function submitFollowUp(
     item,
     options.mode === 'live_notification' ? 'live_owner' : 'recoverable',
   );
-  if (submission.kind === 'unavailable' || submission.kind === 'not_owned') {
-    return { status: 'dropped' };
+  if (submission.kind === 'unavailable') return { status: 'dropped' };
+  if (submission.kind === 'queued') {
+    return {
+      status: 'queued',
+      reason: target.reason,
+      continuation: 'live',
+    };
   }
+  if (submission.kind === 'not_owned') return { status: 'dropped' };
   if (submission.kind === 'live' || submission.kind === 'recovering') {
     return {
       status: 'queued',

--- a/src/agent/followUp/ToolUseFollowUp.ts
+++ b/src/agent/followUp/ToolUseFollowUp.ts
@@ -1,15 +1,4 @@
-/**
- * Tool-use follow-up message coordination.
- *
- * Routes follow-up messages to the appropriate session based on state:
- * - Active session: direct append
- * - Resuming session: queue for later
- * - No session: return status (caller handles UI)
- *
- * This module is VS Code-agnostic. Callers are responsible for
- * showing appropriate UI notifications based on the returned result.
- */
-
+/** Tool-use follow-up routing and continuation ownership. */
 import { createChannelTrace } from '@agent/trace';
 import { type ToolUseFollowUpQueueReason } from '@agent/runtime/executionRegistry';
 import {
@@ -22,30 +11,21 @@ import {
   tryUseRunContext,
 } from '@agent/runtime/RunContext';
 import { platform } from '@platform/platform';
+import type { AgentResumePort } from '@platform/interfaces';
 import type { StreamTabId } from '@shared/schemas';
 import type { FollowUpQueueInput } from './FollowUpQueue';
 
-/**
- * Result of sending a follow-up message to a tool-use session.
- */
-export type SendFollowUpResult =
+export type SubmitFollowUpResult =
   | { status: 'sent' }
   | {
       status: 'queued';
       reason: ToolUseFollowUpQueueReason;
+      continuation: 'live' | 'recovering' | 'resumed' | 'resume_failed';
     }
-  | { status: 'no_session'; streamStatus: string | undefined };
+  | { status: 'no_session'; streamStatus: string | undefined }
+  | { status: 'dropped' };
 
-export type FollowUpWakeResult =
-  | { kind: 'not_required' }
-  | { kind: 'queued_without_wake' }
-  | { kind: 'resumed' }
-  | { kind: 'resume_in_flight' }
-  | { kind: 'active_or_resuming' }
-  | { kind: 'queued_resume_failed' }
-  | { kind: 'dropped' };
-
-export type FollowUpWakePresentation =
+export type FollowUpPresentation =
   | { severity: 'none' }
   | {
       severity: 'info' | 'warning';
@@ -53,115 +33,33 @@ export type FollowUpWakePresentation =
       refreshQueuedFollowUps: boolean;
     };
 
-export interface FollowUpResumePort {
-  tryResumeStream(streamId: StreamTabId): Promise<boolean>;
-  isResumeInFlight?(streamId: StreamTabId): boolean;
+export interface SubmitFollowUpOptions {
+  readonly session?: SessionHandle;
+  readonly resumePort?: Pick<AgentResumePort, 'tryResumeStream'>;
+  /** Notifications never revive a persisted cursor; continuations do. */
+  readonly mode?: 'continuation' | 'live_notification';
 }
 
-/** In-flight resume attempts per stream — see {@link wakeQueuedFollowUpStream}. */
-const wakeAttempts = new Map<StreamTabId, Promise<boolean>>();
-
-/**
- * After a queued delivery, wake a stream whose cycle has exited (WAITING
- * snapshot or disposed-with-children) via the host resume port so the queued
- * item is consumed instead of sitting until the user pokes the stream. When
- * the wake fails and the stream is gone for good (`children_running` on a
- * non-in-flight stream), re-release the force-reopened queue so late
- * deliveries don't leak into the next run on that stream.
- *
- * Returns a declarative outcome so hosts can map queue/wake policy to their
- * own user-facing messages without reconstructing the release rules.
- */
-export async function wakeQueuedFollowUpStream(
-  streamId: StreamTabId,
-  result: SendFollowUpResult,
-  resumePort?: FollowUpResumePort,
-  session?: SessionHandle,
-): Promise<FollowUpWakeResult> {
-  if (
-    result.status !== 'queued' ||
-    (result.reason !== 'waiting' && result.reason !== 'children_running')
-  ) {
-    return result.status === 'queued'
-      ? { kind: 'queued_without_wake' }
-      : { kind: 'not_required' };
+export function presentFollowUpResult(
+  result: SubmitFollowUpResult,
+): FollowUpPresentation {
+  if (result.status === 'dropped') {
+    return {
+      severity: 'warning',
+      message:
+        'Message dropped because no session was available to receive it. Start a new agent task to continue.',
+      refreshQueuedFollowUps: true,
+    };
   }
-  // Serialize wakes per stream: hosts report an already-in-flight resume as
-  // `false`, indistinguishable from "unresumable", and may not have set
-  // RESUMING yet — so a concurrent wake must await the first attempt's
-  // outcome instead of re-poking the port and releasing the queue the
-  // in-flight resume is about to drain.
-  let attempt = wakeAttempts.get(streamId);
-  const port = resumePort ?? platform().agentResume;
-  if (!attempt) {
-    attempt = port.tryResumeStream(streamId).finally(() => {
-      wakeAttempts.delete(streamId);
-    });
-    wakeAttempts.set(streamId, attempt);
+  if (result.status === 'queued' && result.continuation === 'resume_failed') {
+    return {
+      severity: 'info',
+      message:
+        'Message queued. Auto-resume failed; start a new agent task to continue.',
+      refreshQueuedFollowUps: false,
+    };
   }
-  const resumed = await attempt;
-  if (resumed) {
-    return { kind: 'resumed' };
-  }
-  if (port.isResumeInFlight?.(streamId) === true) {
-    return { kind: 'resume_in_flight' };
-  }
-  const ownerSession = session ?? currentSession();
-  if (ownerSession.status.isActiveOrResuming(streamId)) {
-    return { kind: 'active_or_resuming' };
-  }
-  if (result.reason !== 'children_running') {
-    return { kind: 'queued_resume_failed' };
-  }
-  ownerSession.followUps.release(streamId);
-  return { kind: 'dropped' };
-}
-
-/**
- * Shared host-facing presentation for wake outcomes. It intentionally maps
- * only queue/wake policy to UI text; provider/model follow-up construction
- * stays with the caller that owns that context.
- */
-export function presentFollowUpWakeResult(
-  result: FollowUpWakeResult,
-): FollowUpWakePresentation {
-  switch (result.kind) {
-    case 'dropped':
-      return {
-        severity: 'warning',
-        message:
-          'Message dropped because no session was available to receive it. Start a new agent task to continue.',
-        refreshQueuedFollowUps: true,
-      };
-    case 'queued_resume_failed':
-      return {
-        severity: 'info',
-        message:
-          'Message queued. Auto-resume failed; start a new agent task to continue.',
-        refreshQueuedFollowUps: false,
-      };
-    case 'not_required':
-    case 'queued_without_wake':
-    case 'resumed':
-    case 'resume_in_flight':
-    case 'active_or_resuming':
-      return { severity: 'none' };
-  }
-}
-
-/**
- * Compatibility view for tool paths that only need to know whether the queued
- * item survived. UI callers should prefer {@link wakeQueuedFollowUpStream}.
- */
-export async function wakeOrReleaseQueuedStream(
-  streamId: StreamTabId,
-  result: SendFollowUpResult,
-  session?: SessionHandle,
-): Promise<boolean> {
-  return (
-    (await wakeQueuedFollowUpStream(streamId, result, undefined, session))
-      .kind !== 'dropped'
-  );
+  return { severity: 'none' };
 }
 
 const logger = createChannelTrace('ToolUseFollowUp');
@@ -201,74 +99,75 @@ function followUpSentSession(session?: SessionHandle): SessionHandle {
 }
 
 /**
- * Send a follow-up message to a tool-use session.
- *
- * Routes based on session state:
- * 1. Active agent: direct append → { status: 'sent' }
- * 2. Resuming/Waiting session: queue for later → { status: 'queued' }
- * 3. No session found → { status: 'no_session' }
- *
- * Items queued for WAITING sessions are picked up when user resumes.
- *
- * `session` defaults to {@link currentSession} so in-run callers (binder send,
- * bash, delegation, CLI session loop, inquiry continuation) resolve the active
- * run's session via the ALS and stay byte-identical. HOST-PATH callers that
- * run OUTSIDE any run ALS (e.g. the desktop progress-view IPC handler, whose
- * runs are tracked in an explicit process session, not the module default) MUST pass
- * their owning session, or the run's handle is looked up in the wrong registry
- * and a live follow-up is dropped as `no_session`.
+ * Submit visible input or an automatic notification through the stream's sole
+ * continuation boundary. Routing, enqueue, live-owner detection, and persisted
+ * recovery dispatch are one operation; callers never perform a separate wake.
+ * The resume port is invoked before this function's first await, allowing its
+ * synchronous recovery claim to serialize concurrent submissions.
  */
-export function sendFollowUp(
+export async function submitFollowUp(
   streamId: StreamTabId,
-  followUp: FollowUpQueueInput,
-): Promise<SendFollowUpResult>;
-export function sendFollowUp(
-  streamId: StreamTabId,
-  followUp: FollowUpQueueInput,
-  mediaFiles: undefined,
-  displayText: undefined,
-  session?: SessionHandle,
-): Promise<SendFollowUpResult>;
-export function sendFollowUp(
-  streamId: StreamTabId,
-  followUp: string,
-  mediaFiles?: readonly string[],
-  displayText?: string,
-  session?: SessionHandle,
-): Promise<SendFollowUpResult>;
-export async function sendFollowUp(
-  streamId: StreamTabId,
-  followUp: string | FollowUpQueueInput,
-  mediaFiles?: readonly string[],
-  displayText?: string,
-  session?: SessionHandle,
-): Promise<SendFollowUpResult> {
-  const ownerSession = session ?? currentSession();
+  followUp: FollowUpQueueInput | string,
+  options: SubmitFollowUpOptions = {},
+): Promise<SubmitFollowUpResult> {
+  const ownerSession = options.session ?? currentSession();
   const target = ownerSession.executions.getToolUseFollowUpTarget(streamId);
-  const item =
-    typeof followUp === 'string'
-      ? { text: followUp, mediaFiles, displayText }
-      : followUp;
+  const item = typeof followUp === 'string' ? { text: followUp } : followUp;
 
   if (target.kind === 'active') {
+    // A child loop remains the owner during active inner turns, so input joins
+    // its ordered queue rather than creating a second turn driver.
+    const submission = ownerSession.followUps.submit(
+      streamId,
+      item,
+      'live_owner',
+    );
+    if (submission.kind === 'live') {
+      return {
+        status: 'queued',
+        reason: 'waiting',
+        continuation: 'live',
+      };
+    }
+    if (submission.kind !== 'not_owned') return { status: 'dropped' };
     target.context.session.appendFollowUp(item);
     notifyFollowUpSent(streamId, ownerSession);
     return { status: 'sent' };
   }
 
-  if (target.kind === 'queue') {
-    // children_running reopens a queue sealed by session disposal; callers
-    // must auto-resume the parent or release again to avoid stale delivery.
-    ownerSession.followUps.enqueue(streamId, item, {
-      createIfMissing: true,
-      force: target.reason === 'children_running',
-    });
-    return { status: 'queued', reason: target.reason };
+  if (target.kind === 'no_session') {
+    logger.warn(
+      `No active session for follow-up on stream ${streamId}. Status: ${target.streamStatus}`,
+    );
+    return { status: 'no_session', streamStatus: target.streamStatus };
   }
 
-  // No active/waiting session found - caller should handle UI notification
-  logger.warn(
-    `No active session for follow-up on stream ${streamId}. Status: ${target.streamStatus}`,
+  const submission = ownerSession.followUps.submit(
+    streamId,
+    item,
+    options.mode === 'live_notification' ? 'live_owner' : 'recoverable',
   );
-  return { status: 'no_session', streamStatus: target.streamStatus };
+  if (submission.kind === 'unavailable' || submission.kind === 'not_owned') {
+    return { status: 'dropped' };
+  }
+  if (submission.kind === 'live' || submission.kind === 'recovering') {
+    return {
+      status: 'queued',
+      reason: target.reason,
+      continuation: submission.kind,
+    };
+  }
+
+  const recovery = submission.lease;
+  const resume = (options.resumePort ?? platform().agentResume).tryResumeStream(
+    streamId,
+    recovery,
+  );
+  const resumed = await resume;
+  if (!resumed) ownerSession.followUps.release(recovery, 'recoverable');
+  return {
+    status: 'queued',
+    reason: target.reason,
+    continuation: resumed ? 'resumed' : 'resume_failed',
+  };
 }

--- a/src/agent/followUp/ToolUseFollowUp.ts
+++ b/src/agent/followUp/ToolUseFollowUp.ts
@@ -36,8 +36,11 @@ export type FollowUpPresentation =
 export interface SubmitFollowUpOptions {
   readonly session?: SessionHandle;
   readonly resumePort?: Pick<AgentResumePort, 'tryResumeStream'>;
-  /** Notifications never revive a persisted cursor; continuations do. */
-  readonly mode?: 'continuation' | 'live_notification';
+  /**
+   * Notifications never revive a persisted cursor. Child delivery may revive
+   * only a recoverable queue retained while that child was active.
+   */
+  readonly mode?: 'continuation' | 'live_notification' | 'child_delivery';
 }
 
 export function presentFollowUpResult(
@@ -122,6 +125,17 @@ export async function submitFollowUp(
       item,
       'live_owner',
     );
+    if (submission.kind === 'live_flow') {
+      if (options.mode === 'live_notification') {
+        return {
+          status: 'queued',
+          reason: 'waiting',
+          continuation: 'live',
+        };
+      }
+      notifyFollowUpSent(streamId, ownerSession);
+      return { status: 'sent' };
+    }
     if (submission.kind === 'live' || submission.kind === 'queued') {
       return {
         status: 'queued',
@@ -135,32 +149,39 @@ export async function submitFollowUp(
     return { status: 'sent' };
   }
 
-  if (target.kind === 'no_session') {
+  if (target.kind === 'no_session' && options.mode !== 'child_delivery') {
     logger.warn(
       `No active session for follow-up on stream ${streamId}. Status: ${target.streamStatus}`,
     );
     return { status: 'no_session', streamStatus: target.streamStatus };
   }
 
-  const submission = ownerSession.followUps.submit(
-    streamId,
-    item,
-    options.mode === 'live_notification' ? 'live_owner' : 'recoverable',
-  );
+  let admission: 'live_owner' | 'recoverable' | 'existing_recoverable' =
+    'recoverable';
+  if (options.mode === 'live_notification') {
+    admission = 'live_owner';
+  } else if (target.kind === 'no_session') {
+    admission = 'existing_recoverable';
+  }
+  const submission = ownerSession.followUps.submit(streamId, item, admission);
   if (submission.kind === 'unavailable') return { status: 'dropped' };
   if (submission.kind === 'queued') {
     return {
       status: 'queued',
-      reason: target.reason,
+      reason: target.kind === 'queue' ? target.reason : 'children_running',
       continuation: 'live',
     };
   }
   if (submission.kind === 'not_owned') return { status: 'dropped' };
-  if (submission.kind === 'live' || submission.kind === 'recovering') {
+  if (
+    submission.kind === 'live' ||
+    submission.kind === 'live_flow' ||
+    submission.kind === 'recovering'
+  ) {
     return {
       status: 'queued',
-      reason: target.reason,
-      continuation: submission.kind,
+      reason: target.kind === 'queue' ? target.reason : 'children_running',
+      continuation: submission.kind === 'live_flow' ? 'live' : submission.kind,
     };
   }
 
@@ -173,7 +194,7 @@ export async function submitFollowUp(
   if (!resumed) ownerSession.followUps.release(recovery, 'recoverable');
   return {
     status: 'queued',
-    reason: target.reason,
+    reason: target.kind === 'queue' ? target.reason : 'children_running',
     continuation: resumed ? 'resumed' : 'resume_failed',
   };
 }

--- a/src/agent/followUp/ToolUseFollowUpQueueManager.ts
+++ b/src/agent/followUp/ToolUseFollowUpQueueManager.ts
@@ -224,7 +224,15 @@ export class ToolUseFollowUpQueue {
     entry?.queue.dispose();
     this.entries.delete(streamId);
     this.terminal.set(streamId, true);
-    for (const observer of this.releaseObservers) observer(streamId);
+    for (const observer of this.releaseObservers) {
+      try {
+        observer(streamId);
+      } catch (err) {
+        logger.warn(`Release observer threw for stream ${streamId}`, {
+          data: err,
+        });
+      }
+    }
     return true;
   }
 

--- a/src/agent/followUp/ToolUseFollowUpQueueManager.ts
+++ b/src/agent/followUp/ToolUseFollowUpQueueManager.ts
@@ -45,6 +45,7 @@ export type FollowUpSubmission =
   | { readonly kind: 'not_owned' }
   | { readonly kind: 'queued' }
   | { readonly kind: 'live' }
+  | { readonly kind: 'live_flow' }
   | { readonly kind: 'recovering' }
   | { readonly kind: 'recovery'; readonly lease: FollowUpRecoveryLease };
 
@@ -107,33 +108,35 @@ export class ToolUseFollowUpQueue {
   }
 
   /**
-   * Submit through the queue's ownership boundary. `live_owner` joins a child
-   * loop that already owns the stream, or enqueues without claiming when the
-   * entry exists but has no child owner (so live_notification callers can post
-   * progress updates to a WAITING parent queue). `recoverable` admits persisted
-   * WAITING and children-running cursors and synchronously claims their
-   * recovery generation before returning.
+   * Submit through the queue's ownership boundary. `live_owner` joins a live
+   * flow or child consumer, or enqueues without claiming when the entry has no
+   * live owner (so live notifications can reach a WAITING parent queue).
+   * `recoverable` admits a registry-approved persisted cursor and creates its
+   * queue when needed. `existing_recoverable` admits only an already-retained
+   * recoverable queue, which lets a final child result survive child untracking
+   * without reopening an otherwise terminal parent.
    */
   submit(
     streamId: StreamTabId,
     followUp: FollowUpQueueInput,
-    admission: 'live_owner' | 'recoverable',
+    admission: 'live_owner' | 'recoverable' | 'existing_recoverable',
   ): FollowUpSubmission {
     if (this.terminal.has(streamId)) return { kind: 'unavailable' };
 
     let entry = this.entries.get(streamId);
     if (admission === 'live_owner') {
-      if (entry?.owner?.kind !== 'child') {
-        if (!entry) return { kind: 'not_owned' };
-        // Queue exists but has no child owner — enqueue without claiming.
-        // live_notification callers (child progress updates, execution
-        // subscription events) use this to reach WAITING parents whose
-        // queue will be consumed when the stream resumes.
+      if (!entry) return { kind: 'not_owned' };
+      if (!entry.owner) {
+        // Live notifications use this path to reach WAITING parents whose
+        // retained queue will be consumed when the stream resumes.
         entry.queue.enqueue(followUp);
         logger.debug(`Queued follow-up for stream ${streamId}.`);
         return { kind: 'queued' };
       }
     } else {
+      if (!entry && admission === 'existing_recoverable') {
+        return { kind: 'unavailable' };
+      }
       entry ??= this.createEntry(streamId);
       if (!entry.owner) entry.lifecycle = 'recoverable';
     }
@@ -141,9 +144,8 @@ export class ToolUseFollowUpQueue {
     entry.queue.enqueue(followUp);
     logger.debug(`Queued follow-up for stream ${streamId}.`);
     const owner = entry.owner;
-    if (owner?.kind === 'flow' || owner?.kind === 'child') {
-      return { kind: 'live' };
-    }
+    if (owner?.kind === 'flow') return { kind: 'live_flow' };
+    if (owner?.kind === 'child') return { kind: 'live' };
     if (owner?.kind === 'recovery') return { kind: 'recovering' };
 
     const lease = this.claim(entry, streamId, 'recovery');

--- a/src/agent/followUp/ToolUseFollowUpQueueManager.ts
+++ b/src/agent/followUp/ToolUseFollowUpQueueManager.ts
@@ -1,5 +1,6 @@
 import { LRUCache } from 'lru-cache';
 import { createChannelTrace } from '@agent/trace';
+import type { RecoveryContinuation } from '@platform/interfaces';
 import type { StreamTabId } from '@shared/schemas';
 import {
   FollowUpQueue,
@@ -9,31 +10,60 @@ import {
 
 const logger = createChannelTrace('ToolUseFollowUpQueue');
 
+type QueueLifecycle = 'live' | 'recoverable' | 'recovering';
+export type FollowUpConsumerKind = 'flow' | 'child' | 'recovery';
+
+interface QueueEntry {
+  readonly queue: FollowUpQueue;
+  lifecycle: QueueLifecycle;
+  generation: number;
+  owner?: FollowUpConsumerLease;
+}
+
 /**
- * Follow-up queue owner indexed by stream ID.
+ * Exclusive authority to consume one stream's follow-up queue.
  *
- * Every instance is session-owned — the process default lives at
- * `defaultSession().followUps` (#7694); there is no separate static/module
- * singleton to reach it through.
+ * The manager issues at most one lease per entry. Claims and releases are
+ * synchronous, and every lease carries the entry generation it claimed. A
+ * release from an older flow/child therefore cannot clear or terminalize a
+ * successor recovery generation. Only the lease may wait, drain, or dispose;
+ * producers submit through the manager and cannot manufacture a consumer.
+ */
+export interface FollowUpConsumerLease {
+  readonly streamId: StreamTabId;
+  readonly generation: number;
+  readonly kind: FollowUpConsumerKind;
+}
+
+export interface FollowUpRecoveryLease
+  extends FollowUpConsumerLease, RecoveryContinuation {
+  readonly kind: 'recovery';
+}
+
+export type FollowUpSubmission =
+  | { readonly kind: 'unavailable' }
+  | { readonly kind: 'not_owned' }
+  | { readonly kind: 'live' }
+  | { readonly kind: 'recovering' }
+  | { readonly kind: 'recovery'; readonly lease: FollowUpRecoveryLease };
+
+/**
+ * Session-owned continuation boundary indexed by stream ID.
+ *
+ * Lifecycle is explicit: an owned entry is `live` or `recovering`, an unowned
+ * persisted cursor is `recoverable`, and terminal stream ids are retained in a
+ * bounded tombstone cache. Terminal entries cannot be reopened.
  */
 export class ToolUseFollowUpQueue {
-  static readonly RELEASED_CAP = 500;
-  private readonly queues = new Map<StreamTabId, FollowUpQueue>();
-  /** Streams whose queues were explicitly released (orchestrator disposed). */
-  private readonly released = new LRUCache<StreamTabId, true>({
-    max: ToolUseFollowUpQueue.RELEASED_CAP,
+  static readonly TERMINAL_CAP = 500;
+  private readonly entries = new Map<StreamTabId, QueueEntry>();
+  private readonly terminal = new LRUCache<StreamTabId, true>({
+    max: ToolUseFollowUpQueue.TERMINAL_CAP,
   });
-  /** Observers notified whenever a stream's queue is released. */
   private readonly releaseObservers = new Set<
     (streamId: StreamTabId) => void
   >();
 
-  /**
-   * Register a callback fired when any stream's follow-up queue is released.
-   * Returns an unsubscribe function. Used by async event sources (e.g. PR
-   * polling) to tear down stream-scoped subscriptions when the owning stream
-   * goes away.
-   */
   onRelease(observer: (streamId: StreamTabId) => void): () => void {
     this.releaseObservers.add(observer);
     return () => {
@@ -41,85 +71,195 @@ export class ToolUseFollowUpQueue {
     };
   }
 
-  acquire(streamId: StreamTabId): FollowUpQueue {
-    this.released.delete(streamId);
-    const existing = this.queues.get(streamId);
-    if (existing) return existing;
-    const queue = new FollowUpQueue();
-    this.queues.set(streamId, queue);
-    return queue;
+  /** Claim a live flow/child consumer. A competing owner is rejected. */
+  claimLive(
+    streamId: StreamTabId,
+    kind: Exclude<FollowUpConsumerKind, 'recovery'>,
+  ): FollowUpConsumerLease | undefined {
+    if (this.terminal.has(streamId)) return undefined;
+    const entry = this.entries.get(streamId) ?? this.createEntry(streamId);
+    return this.claim(entry, streamId, kind);
   }
 
-  release(streamId: StreamTabId): void {
-    const queue = this.queues.get(streamId);
-    if (queue) {
-      queue.dispose();
-      this.queues.delete(streamId);
+  /** Claim persisted recovery before any asynchronous resume preparation. */
+  claimRecovery(
+    streamId: StreamTabId,
+    createIfMissing = false,
+  ): FollowUpRecoveryLease | undefined {
+    if (this.terminal.has(streamId)) return undefined;
+    const entry =
+      this.entries.get(streamId) ??
+      (createIfMissing ? this.createEntry(streamId) : undefined);
+    if (!entry || entry.lifecycle !== 'recoverable' || entry.owner) {
+      return undefined;
     }
-    this.rememberReleased(streamId);
-    logger.debug(`Released follow-up queue for stream ${streamId}.`);
+    return this.claim(entry, streamId, 'recovery') as FollowUpRecoveryLease;
+  }
+
+  useRecovery(
+    recovery: RecoveryContinuation,
+  ): FollowUpRecoveryLease | undefined {
+    const entry = this.entries.get(recovery.streamId);
+    return entry?.owner === recovery && recovery.kind === 'recovery'
+      ? (entry.owner as FollowUpRecoveryLease)
+      : undefined;
+  }
+
+  /**
+   * Submit through the queue's ownership boundary. `live_owner` only joins a
+   * child loop that already owns the stream; callers may otherwise use their
+   * active flow directly. `recoverable` admits persisted WAITING and
+   * children-running cursors and synchronously claims their recovery
+   * generation before returning.
+   */
+  submit(
+    streamId: StreamTabId,
+    followUp: FollowUpQueueInput,
+    admission: 'live_owner' | 'recoverable',
+  ): FollowUpSubmission {
+    if (this.terminal.has(streamId)) return { kind: 'unavailable' };
+
+    let entry = this.entries.get(streamId);
+    if (admission === 'live_owner') {
+      if (entry?.owner?.kind !== 'child') return { kind: 'not_owned' };
+    } else {
+      entry ??= this.createEntry(streamId);
+      if (!entry.owner) entry.lifecycle = 'recoverable';
+    }
+
+    entry.queue.enqueue(followUp);
+    logger.debug(`Queued follow-up for stream ${streamId}.`);
+    const owner = entry.owner;
+    if (owner?.kind === 'flow' || owner?.kind === 'child') {
+      return { kind: 'live' };
+    }
+    if (owner?.kind === 'recovery') return { kind: 'recovering' };
+
+    const lease = this.claim(entry, streamId, 'recovery');
+    if (!lease) return { kind: 'recovering' };
+    return { kind: 'recovery', lease: lease as FollowUpRecoveryLease };
+  }
+
+  /** Restore a failed recovery batch ahead of submissions that raced it. */
+  restore(
+    lease: FollowUpRecoveryLease,
+    followUps: readonly FollowUpQueueInput[],
+  ): void {
+    this.requireOwner(lease).queue.restore(followUps);
+  }
+
+  /** Read-only lifecycle probe used by diagnostics and teardown assertions. */
+  hasLiveOwner(streamId: StreamTabId): boolean {
+    const owner = this.entries.get(streamId)?.owner;
+    return owner?.kind === 'flow' || owner?.kind === 'child';
+  }
+
+  /** Inner child/recovery flows borrow the queue their outer owner consumes. */
+  externallyOwnedQueue(streamId: StreamTabId): FollowUpQueue | undefined {
+    const entry = this.entries.get(streamId);
+    return entry?.owner?.kind === 'child' || entry?.owner?.kind === 'recovery'
+      ? entry.queue
+      : undefined;
+  }
+
+  queue(lease: FollowUpConsumerLease): FollowUpQueue {
+    return this.requireOwner(lease).queue;
+  }
+
+  drainItems(lease: FollowUpConsumerLease): DrainedFollowUpItem[] {
+    return this.requireOwner(lease).queue.drainItems();
+  }
+
+  /**
+   * Release only the generation represented by `lease`. `recoverable` keeps
+   * queued data for a successor claim; `terminal` disposes it permanently.
+   */
+  release(
+    lease: FollowUpConsumerLease,
+    next: 'recoverable' | 'terminal',
+  ): boolean {
+    const entry = this.entries.get(lease.streamId);
+    if (
+      !entry ||
+      entry.owner !== lease ||
+      entry.generation !== lease.generation
+    ) {
+      return false;
+    }
+    entry.owner = undefined;
+    if (next === 'recoverable') {
+      entry.lifecycle = 'recoverable';
+      return true;
+    }
+    entry.queue.dispose();
+    this.entries.delete(lease.streamId);
+    this.terminal.set(lease.streamId, true);
+    logger.debug(`Terminalized follow-up queue for stream ${lease.streamId}.`);
     for (const observer of this.releaseObservers) {
       try {
-        observer(streamId);
+        observer(lease.streamId);
       } catch (err) {
-        logger.warn(`Release observer threw for stream ${streamId}`, {
+        logger.warn(`Release observer threw for stream ${lease.streamId}`, {
           data: err,
         });
       }
     }
-  }
-
-  /**
-   * Enqueue a follow-up for a stream.
-   *
-   * Auto-creates the queue if it doesn't exist yet (needed for WAITING streams
-   * from prior sessions) only when the caller has already admitted the
-   * follow-up through the registry. Returns false and silently discards if the queue was
-   * explicitly released (orchestrator disposed — late-arriving subagent
-   * results). Pass `{ force: true }` for explicit user actions that should
-   * reopen or create a queue even without `createIfMissing` (caller is
-   * responsible for ensuring a consumer will drain it, or releasing again on
-   * failure).
-   */
-  enqueue(
-    streamId: StreamTabId,
-    followUp: FollowUpQueueInput,
-    options?: { createIfMissing?: boolean; force?: boolean },
-  ): boolean {
-    if (this.released.has(streamId) && !options?.force) {
-      logger.debug(
-        `Queue for stream ${streamId} was released, discarding follow-up.`,
-      );
-      return false;
-    }
-    const queue = this.queues.get(streamId);
-    if (!queue && !options?.createIfMissing && !options?.force) {
-      logger.debug(
-        `No follow-up queue for stream ${streamId}, discarding follow-up.`,
-      );
-      return false;
-    }
-    const target = queue ?? this.acquire(streamId);
-    target.enqueue(followUp);
-    logger.debug(`Queued follow-up for stream ${streamId}.`);
     return true;
   }
 
-  drain(streamId: StreamTabId): string[] {
-    return this.queues.get(streamId)?.drain() ?? [];
+  /** Terminalize a stream; any outstanding lease becomes stale immediately. */
+  terminalize(streamId: StreamTabId): boolean {
+    const entry = this.entries.get(streamId);
+    entry?.queue.dispose();
+    this.entries.delete(streamId);
+    this.terminal.set(streamId, true);
+    for (const observer of this.releaseObservers) observer(streamId);
+    return true;
   }
 
-  /** Drain queued follow-ups with their media file paths (resume replay). */
-  drainItems(streamId: StreamTabId): DrainedFollowUpItem[] {
-    return this.queues.get(streamId)?.drainItems() ?? [];
-  }
-
-  /** Get all queued follow-up messages for a stream without consuming them. */
+  /** Presentation-only snapshot; does not grant consumption rights. */
   getAll(streamId: StreamTabId): string[] {
-    return this.queues.get(streamId)?.getAll() ?? [];
+    return this.entries.get(streamId)?.queue.getAll() ?? [];
   }
 
-  private rememberReleased(streamId: StreamTabId): void {
-    this.released.set(streamId, true);
+  private createEntry(streamId: StreamTabId): QueueEntry {
+    const entry: QueueEntry = {
+      queue: new FollowUpQueue(),
+      lifecycle: 'recoverable',
+      generation: 0,
+    };
+    this.entries.set(streamId, entry);
+    return entry;
+  }
+
+  private claim(
+    entry: QueueEntry,
+    streamId: StreamTabId,
+    kind: FollowUpConsumerKind,
+  ): FollowUpConsumerLease | undefined {
+    if (entry.owner) return undefined;
+    entry.generation += 1;
+    const lease: FollowUpConsumerLease = {
+      streamId,
+      generation: entry.generation,
+      kind,
+    };
+    entry.owner = lease;
+    entry.lifecycle = kind === 'recovery' ? 'recovering' : 'live';
+    return lease;
+  }
+
+  private requireOwner(lease: FollowUpConsumerLease): QueueEntry {
+    const entry = this.entries.get(lease.streamId);
+    if (
+      !entry ||
+      entry.owner !== lease ||
+      entry.generation !== lease.generation
+    ) {
+      throw new Error(
+        `Follow-up consumer lease is stale for stream ${lease.streamId}.`,
+      );
+    }
+    return entry;
   }
 }

--- a/src/agent/followUp/ToolUseFollowUpQueueManager.ts
+++ b/src/agent/followUp/ToolUseFollowUpQueueManager.ts
@@ -43,6 +43,7 @@ export interface FollowUpRecoveryLease
 export type FollowUpSubmission =
   | { readonly kind: 'unavailable' }
   | { readonly kind: 'not_owned' }
+  | { readonly kind: 'queued' }
   | { readonly kind: 'live' }
   | { readonly kind: 'recovering' }
   | { readonly kind: 'recovery'; readonly lease: FollowUpRecoveryLease };
@@ -106,11 +107,12 @@ export class ToolUseFollowUpQueue {
   }
 
   /**
-   * Submit through the queue's ownership boundary. `live_owner` only joins a
-   * child loop that already owns the stream; callers may otherwise use their
-   * active flow directly. `recoverable` admits persisted WAITING and
-   * children-running cursors and synchronously claims their recovery
-   * generation before returning.
+   * Submit through the queue's ownership boundary. `live_owner` joins a child
+   * loop that already owns the stream, or enqueues without claiming when the
+   * entry exists but has no child owner (so live_notification callers can post
+   * progress updates to a WAITING parent queue). `recoverable` admits persisted
+   * WAITING and children-running cursors and synchronously claims their
+   * recovery generation before returning.
    */
   submit(
     streamId: StreamTabId,
@@ -121,7 +123,16 @@ export class ToolUseFollowUpQueue {
 
     let entry = this.entries.get(streamId);
     if (admission === 'live_owner') {
-      if (entry?.owner?.kind !== 'child') return { kind: 'not_owned' };
+      if (entry?.owner?.kind !== 'child') {
+        if (!entry) return { kind: 'not_owned' };
+        // Queue exists but has no child owner — enqueue without claiming.
+        // live_notification callers (child progress updates, execution
+        // subscription events) use this to reach WAITING parents whose
+        // queue will be consumed when the stream resumes.
+        entry.queue.enqueue(followUp);
+        logger.debug(`Queued follow-up for stream ${streamId}.`);
+        return { kind: 'queued' };
+      }
     } else {
       entry ??= this.createEntry(streamId);
       if (!entry.owner) entry.lifecycle = 'recoverable';

--- a/src/agent/implementations/flows/tooluse/ToolUseSessionLifecycle.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseSessionLifecycle.ts
@@ -1,5 +1,9 @@
-import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
+import {
+  ToolUseFollowUpQueue,
+  type FollowUpConsumerLease,
+} from '@agent/followUp/ToolUseFollowUpQueueManager';
 import type {
+  FollowUpQueue,
   FollowUpQueueBatch,
   FollowUpQueueInput,
 } from '@agent/followUp/FollowUpQueue';
@@ -7,13 +11,30 @@ import type { IToolUseSession } from '@agent/core/flows/IToolUseSession';
 import type { StreamTabId } from '@shared/schemas';
 
 export class ToolUseSessionLifecycle implements IToolUseSession {
-  private readonly followUps = this.queue.acquire(this.streamTabId);
+  private readonly followUps: FollowUpQueue;
+  private readonly lease: FollowUpConsumerLease | undefined;
   private syntheticFollowUpPending = false;
 
   constructor(
     private readonly streamTabId: StreamTabId,
     private readonly queue: ToolUseFollowUpQueue,
-  ) {}
+  ) {
+    const lease = queue.claimLive(streamTabId, 'flow');
+    if (lease) {
+      this.lease = lease;
+      this.followUps = queue.queue(lease);
+      return;
+    }
+    // A native child loop owns continuation across all of its turns. Its inner
+    // one-cycle flow uses that queue without becoming a second consumer.
+    const childQueue = queue.externallyOwnedQueue(streamTabId);
+    if (!childQueue) {
+      throw new Error(
+        `Follow-up continuation already has an owner for stream ${streamTabId}.`,
+      );
+    }
+    this.followUps = childQueue;
+  }
 
   appendFollowUp(followUp: FollowUpQueueInput): void {
     this.followUps.enqueue(followUp);
@@ -44,23 +65,12 @@ export class ToolUseSessionLifecycle implements IToolUseSession {
     this.followUps.dispose();
   }
 
-  /**
-   * Same wake-up as `interrupt()` (unblock any in-progress `waitForFollowUp`)
-   * but, unlike it, does not drop already-queued items. For the narrow window
-   * during resume startup after the live flow context is attached but before
-   * the flow is interruptible: an async cancellation must not erase a new
-   * follow-up appended through that context, since the flow's own early-cancel
-   * branch preserves the resume record for a later replay (see
-   * `runToolUseFlow`'s `preserveResumeRecord` finally guard, which also skips
-   * releasing this queue in that case). Every other cancellation path keeps
-   * using `interrupt()`'s destructive clear.
-   */
   interruptPreservingQueue(): void {
     this.syntheticFollowUpPending = false;
     this.followUps.cancelWait();
   }
 
-  dispose(): void {
-    this.queue.release(this.streamTabId);
+  release(next: 'recoverable' | 'terminal'): void {
+    if (this.lease) this.queue.release(this.lease, next);
   }
 }

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -625,16 +625,15 @@ export async function runToolUseFlow<C = unknown>(
     // AgentRunLifecycle applies this policy with terminal metadata through one
     // storage finalization after the flow reports its outcome.
 
-    // Recovery failures preserve the unread record but release the rebuilt
-    // live queue. The resume wrapper owns the drained batch and restores it
-    // after rejection; retaining both copies here would replay it twice.
-    //
-    // WAITING retains its existing stronger property: the live lifecycle
-    // remains attached to the queue so a racing follow-up, a genuine kill,
-    // or the next resume observes the same queue instance.
-    if (!preserveFollowUpQueue) {
-      sessionLifecycle.dispose();
-    }
+    // A suspended cursor and a completed parent with live children remain
+    // explicitly recoverable. Every other exit is terminal. The lifecycle's
+    // generation-scoped release is a no-op for an inner native-child turn,
+    // whose child loop retains the sole consumer lease across turns.
+    sessionLifecycle.release(
+      preserveFollowUpQueue || runSession.executions.hasActiveChildren(streamId)
+        ? 'recoverable'
+        : 'terminal',
+    );
     runSession.interactions.cancel({ streamId, cause: 'Run ended.' });
     for (const handler of switchedHandlers) {
       handler.dispose();

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -425,7 +425,7 @@ export async function runFlowWithLifecycle(
       // no-oping — see AgentRunLifecycle/ExecutionRegistry issue #7287.
       const parentStageId = ctx.parentStage.id;
       handle.registerWaitingCleanup(async () => {
-        session.followUps.release(streamId);
+        session.followUps.terminalize(streamId);
         if (handle.executionLeaseLost) return;
         // Close this turn's "Run: ..." transcript group so a killed suspended
         // subagent doesn't leave it stuck at `running` forever (every other

--- a/src/agent/runtime/ExecutionSubscriptionBinder.ts
+++ b/src/agent/runtime/ExecutionSubscriptionBinder.ts
@@ -14,7 +14,7 @@
 import { createChannelTrace } from '@agent/trace';
 import type { ExecutionHandle } from '@agent/runtime/ExecutionHandle';
 import type { ExecutionRegistry } from '@agent/runtime/executionRegistry';
-import { sendFollowUp } from '@agent/followUp/ToolUseFollowUp';
+import { submitFollowUp } from '@agent/followUp/ToolUseFollowUp';
 import type { StreamTabId } from '@shared/schemas';
 import { DELIVERY_TAG } from '@shared/deliveryTags';
 import { wrapAndSanitizeTag } from '@utils/text/sanitizeTag';
@@ -156,13 +156,10 @@ class ExecutionSubscription implements Disposable {
   }
 
   private send(text: string): void {
-    void sendFollowUp(
-      this.streamId,
-      wrapAndSanitizeTag(TAG, text),
-      undefined,
-      undefined,
-      this.session,
-    )
+    void submitFollowUp(this.streamId, wrapAndSanitizeTag(TAG, text), {
+      session: this.session,
+      mode: 'live_notification',
+    })
       .then((result) => {
         if (result.status === 'sent' || result.status === 'queued') {
           emitQueuedFollowUpsChanged(this.streamId, this.session);

--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -27,8 +27,12 @@ import type {
   AgentExecutionHandle,
   ExecutionInterruptHandler,
 } from '@agent/runtime/ExecutionHandle';
-import type { FollowUpQueue } from '@agent/followUp/FollowUpQueue';
-import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
+import type {
+  FollowUpQueue,
+  FollowUpQueueBatchItem,
+  FollowUpQueueInput,
+} from '@agent/followUp/FollowUpQueue';
+import type { FollowUpConsumerLease } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import { classifyAgentError } from '@common/errors';
 import { isUserAbort } from '@common/errors/sdkErrorUtils';
 import {
@@ -40,11 +44,9 @@ import {
 import { deriveRunOutcome } from '@shared/streams/streamStatus';
 
 import {
-  enqueueChildRunFollowUp,
-  wakeChildRunFollowUp,
+  deliverChildRunFollowUp,
   persistChildRunReport,
   persistChildRunResultMeta,
-  type ChildRunEnqueueResult,
 } from '@tools/childRunDelivery';
 import { formatSubagentProgress } from '@tools/subagentResults';
 import type { ChildStream, ChildStreamOutcome } from '@tools/childStream';
@@ -229,8 +231,8 @@ export interface ChildRunLoopHandle {
  *
  * Does NOT implement the session duck-type (no `session.appendFollowUp`), so
  * flow-only commands such as context compaction ignore it. Follow-ups route
- * through the WAITING state queue path: `sendFollowUp()` → stream is WAITING →
- * `session.followUps.enqueue()`.
+ * through the queue-owned submission path, which joins this loop's live lease
+ * instead of creating a competing continuation.
  *
  * `interrupt()` additionally delegates into a live native turn's flow
  * context, when one is currently attached. `handle.getToolUseFlow()` is the
@@ -383,7 +385,7 @@ async function persistResultMetaBestEffort(
  */
 interface PendingChildDelivery {
   readonly targetStreamId: StreamTabId;
-  readonly enqueueResult: ChildRunEnqueueResult;
+  readonly followUp: FollowUpQueueInput;
 }
 
 /**
@@ -398,7 +400,6 @@ async function deliverTurn<TTurn>(params: {
   strategy: ChildRunStrategy<TTurn>;
   executionId: ExecutionId;
   parentStreamId: StreamTabId;
-  session: SessionHandle;
   logger: AgentTrace;
   turn: TTurn | null;
   err: unknown;
@@ -410,7 +411,6 @@ async function deliverTurn<TTurn>(params: {
     strategy,
     executionId,
     parentStreamId,
-    session,
     logger,
     turn,
     err,
@@ -451,59 +451,42 @@ async function deliverTurn<TTurn>(params: {
     return undefined;
   }
   if (prepareParentDelivery?.() === false) return undefined;
-  const enqueueResult = await enqueueChildRunFollowUp({
+  return {
     targetStreamId,
     followUp: { text: msg, origin: 'subagent_result' },
-    session,
-  });
-  if (enqueueResult.kind === 'no_session') {
-    logger.warn(
-      'Turn result not delivered: parent stream has no active session. The result remains in the execution report.',
-      {
-        data: {
-          executionId,
-          parentStreamId: targetStreamId,
-          streamStatus: enqueueResult.streamStatus ?? 'unknown',
-        },
-      },
-    );
-  }
-  return { targetStreamId, enqueueResult };
+  };
 }
 
 /**
  * Resolve a pending delivery's wake step (no-op when there is nothing to
  * wake, or the enqueue itself found no session — already logged above).
  */
-async function wakePendingDelivery(
+async function submitPendingDelivery(
   pending: PendingChildDelivery | undefined,
   session: SessionHandle,
   executionId: ExecutionId,
   logger: AgentTrace,
 ): Promise<void> {
-  if (!pending || pending.enqueueResult.kind === 'no_session') return;
-  const delivery = await wakeChildRunFollowUp(
-    pending.targetStreamId,
-    pending.enqueueResult,
+  if (!pending) return;
+  const delivery = await deliverChildRunFollowUp({
+    targetStreamId: pending.targetStreamId,
+    followUp: pending.followUp,
     session,
-  );
-  if (delivery.kind === 'dropped') {
+  });
+  if (delivery.kind !== 'delivered') {
     logger.warn(
-      'Turn result dropped: parent stream is gone and could not be resumed. The result remains in the execution report.',
-      { data: { executionId, parentStreamId: pending.targetStreamId } },
+      'Turn result not delivered: parent stream is unavailable. The result remains in the execution report.',
+      {
+        data: {
+          executionId,
+          parentStreamId: pending.targetStreamId,
+          ...(delivery.kind === 'no_session' && {
+            streamStatus: delivery.streamStatus ?? 'unknown',
+          }),
+        },
+      },
     );
   }
-}
-
-/**
- * True when this session owns a live child-run loop for `streamId`. Enqueueing
- * into that loop's `FollowUpQueue` either wakes its pending wait or leaves the
- * item for its next wait boundary, so callers avoid racing a second host-level
- * resume. A genuine restart has no registered loop and still needs the generic
- * wake path.
- */
-export function isChildRunLoopActive(streamId: StreamTabId): boolean {
-  return currentSession().executions.isChildRunLoopActive(streamId);
 }
 
 /**
@@ -544,7 +527,7 @@ export function startChildRunLoop<TTurn>(
   const loop = new ChildRunInterruptible(runSession, childStreamId);
   let stopWatchingLease: (() => void) | undefined;
   let queue!: FollowUpQueue;
-  let queueAcquired = false;
+  let queueLease: FollowUpConsumerLease | undefined;
   let attachedHandle: AgentExecutionHandle | undefined;
   let detachLoopInterrupt: (() => void) | undefined;
   const attachLoopInterrupt = (): void => {
@@ -554,7 +537,6 @@ export function startChildRunLoop<TTurn>(
     attachedHandle = handle;
     detachLoopInterrupt = handle.attachInterruptHandler(loop);
   };
-  let unregisterChildRunLoop: (() => void) | undefined;
   let sessionStage: StageHandle | undefined;
 
   try {
@@ -565,12 +547,15 @@ export function startChildRunLoop<TTurn>(
       });
       loop.interrupt();
     });
-    queue = runSession.followUps.acquire(childStreamId);
-    queueAcquired = true;
+    queueLease = runSession.followUps.claimLive(childStreamId, 'child');
+    if (!queueLease) {
+      throw new Error(
+        `Follow-up continuation already has an owner for child ${childStreamId}.`,
+      );
+    }
+    queue = runSession.followUps.queue(queueLease);
     loop.setQueue(queue);
     attachLoopInterrupt();
-    unregisterChildRunLoop =
-      runSession.executions.registerChildRunLoop(childStreamId);
     sessionStage = childStream
       ? logger.openStage(strategy.stageLabel)
       : undefined;
@@ -585,10 +570,9 @@ export function startChildRunLoop<TTurn>(
       }
     };
     cleanup(() => sessionStage?.end(RUN_OUTCOME.FAILED));
-    cleanup(() => unregisterChildRunLoop?.());
     cleanup(() => detachLoopInterrupt?.());
     cleanup(() => {
-      if (queueAcquired) runSession.followUps.release(childStreamId);
+      if (queueLease) runSession.followUps.release(queueLease, 'terminal');
     });
     cleanup(() => stopWatchingLease?.());
     cleanup(releaseSessionOwnershipOnce);
@@ -610,14 +594,11 @@ export function startChildRunLoop<TTurn>(
         : parentStreamId;
       if (!targetStreamId) return; // Detached — see deliverTurn for the same guard.
       const msg = formatSubagentProgress(executionId, agentName, update);
-      // Enqueue-only — intentional. A live progress notification should
-      // never wake a WAITING/detached parent stream just to deliver an
-      // interim update; only a turn's own delivery (deliverTurn, below)
-      // wakes the parent.
-      void enqueueChildRunFollowUp({
+      void deliverChildRunFollowUp({
         targetStreamId,
         followUp: { text: msg, origin: 'subagent_result' },
         session: runSession,
+        mode: 'live_notification',
       });
     },
     recordCost: (totalCostUsd) => {
@@ -669,7 +650,6 @@ export function startChildRunLoop<TTurn>(
           strategy,
           executionId,
           parentStreamId,
-          session: runSession,
           logger,
           turn,
           err,
@@ -716,7 +696,7 @@ export function startChildRunLoop<TTurn>(
         // the instant this turn settled) — then just drain the next batch. A
         // follow-up already raced into the queue resumes immediately instead
         // of genuinely waiting.
-        await wakePendingDelivery(delivery, runSession, executionId, logger);
+        await submitPendingDelivery(delivery, runSession, executionId, logger);
         childStream?.waitForInput();
         if (loop.isInterrupted()) break;
 
@@ -729,8 +709,7 @@ export function startChildRunLoop<TTurn>(
       }
     } finally {
       detachLoopInterrupt?.();
-      unregisterChildRunLoop?.();
-      runSession.followUps.release(childStreamId);
+      if (queueLease) runSession.followUps.release(queueLease, 'terminal');
       releaseSessionOwnershipOnce();
       try {
         try {
@@ -815,7 +794,7 @@ export function startChildRunLoop<TTurn>(
         // so a resumed parent turn that immediately waits on this execution
         // (e.g. `executions` tool with `action=wait`) always observes it
         // terminal instead of racing its own wake (#8093).
-        await wakePendingDelivery(
+        await submitPendingDelivery(
           pendingDelivery,
           runSession,
           executionId,

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -102,7 +102,6 @@ export type ManualCompactionRequestResult =
  */
 export class ExecutionRegistry {
   private readonly handles = new Map<string, ExecutionHandle>();
-  private readonly activeChildRunLoops = new Set<StreamTabId>();
   private disposed = false;
   private readonly changeCallbacks = new Map<string, Array<() => void>>();
   private readonly disposeStatusListener: () => void;
@@ -191,7 +190,6 @@ export class ExecutionRegistry {
     this.disposeStatusListener();
     const executionIds = [...this.handles.keys()];
     this.handles.clear();
-    this.activeChildRunLoops.clear();
     for (const executionId of executionIds) {
       this.notifyRegistrationListeners(executionId, undefined);
       this.notifyWaiters(executionId);
@@ -199,20 +197,6 @@ export class ExecutionRegistry {
     this.changeCallbacks.clear();
     this.persistentListeners.clear();
     this.registrationListeners.clear();
-  }
-
-  /** Register a live child-run loop and return its lifecycle disposer. */
-  registerChildRunLoop(streamId: StreamTabId): () => void {
-    this.assertActive();
-    this.activeChildRunLoops.add(streamId);
-    return () => {
-      this.activeChildRunLoops.delete(streamId);
-    };
-  }
-
-  /** True while this session owns a live child-run loop for `streamId`. */
-  isChildRunLoopActive(streamId: StreamTabId): boolean {
-    return this.activeChildRunLoops.has(streamId);
   }
 
   /** Register an execution handle. */
@@ -716,7 +700,7 @@ export class ExecutionRegistry {
     return result;
   }
 
-  private hasActiveChildren(parentStreamId: StreamTabId): boolean {
+  hasActiveChildren(parentStreamId: StreamTabId): boolean {
     for (const handle of this.handles.values()) {
       if (isChildExecution(handle, parentStreamId)) return true;
     }

--- a/src/agent/runtime/resolveAndResumeStream.ts
+++ b/src/agent/runtime/resolveAndResumeStream.ts
@@ -10,6 +10,7 @@
  */
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { TaskState } from '@agent/core/state/TaskState';
+import type { RecoveryContinuation } from '@platform/interfaces';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 
 import {
@@ -48,7 +49,10 @@ export interface ResumeStreamPorts {
     streamId: StreamTabId,
   ): Promise<ResolvedResumeState | undefined>;
   /** Resume canonical tool-use state (host injects its failure surface). */
-  resumeToolUse(resume: ToolUseResumeData): Promise<boolean>;
+  resumeToolUse(
+    resume: ToolUseResumeData,
+    recovery?: RecoveryContinuation,
+  ): Promise<boolean>;
   /**
    * Launch a workflow resume run. The extension re-parses the config and opens
    * the final output; the desktop runs it directly and opens its own preview —
@@ -70,18 +74,6 @@ export interface ResumeStreamPorts {
 }
 
 /**
- * Streams whose resume has been accepted and is still preparing. Module-level so
- * a single host-initiated resume is visible to the queued-delivery wake path
- * (`AgentResumePort.isResumeInFlight`) across every entry point and host, and so
- * a concurrent wake cannot launch a duplicate resume.
- */
-const resumeInFlight = new Set<StreamTabId>();
-
-export function isResumeInFlight(streamId: StreamTabId): boolean {
-  return resumeInFlight.has(streamId);
-}
-
-/**
  * Attempt to resume a WAITING / children-running stream from its persisted
  * state. Returns `true` when the resume reached the run lifecycle, `false`
  * otherwise (already active/resuming, nothing to resume, or a handled failure).
@@ -89,19 +81,18 @@ export function isResumeInFlight(streamId: StreamTabId): boolean {
 export async function resolveAndResumeStream(
   streamId: StreamTabId,
   ports: ResumeStreamPorts,
+  recovery?: RecoveryContinuation,
 ): Promise<boolean> {
   const isCancellationRequested = (): boolean =>
     ports.isCancellationRequested?.() === true;
 
   if (
     isCancellationRequested() ||
-    ports.streamStatus.isActiveOrResuming(streamId) ||
-    resumeInFlight.has(streamId)
+    ports.streamStatus.isActiveOrResuming(streamId)
   ) {
     return false;
   }
 
-  resumeInFlight.add(streamId);
   try {
     const resolved = await ports.resolveResumeState(streamId);
     if (isCancellationRequested()) return false;
@@ -131,7 +122,7 @@ export async function resolveAndResumeStream(
 
     if (resume.type === 'toolUse') {
       // The tool-use helper owns the RESUMING flip + follow-up dance.
-      return await ports.resumeToolUse(resume);
+      return await ports.resumeToolUse(resume, recovery);
     }
 
     // Workflow launch owns stream acquisition and status transitions through
@@ -147,7 +138,5 @@ export async function resolveAndResumeStream(
     if (isCancellationRequested()) return false;
     await ports.reportFailure?.(streamId, error);
     return false;
-  } finally {
-    resumeInFlight.delete(streamId);
   }
 }

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -2,7 +2,12 @@ import type {
   FollowUpQueueBatchItem,
   FollowUpQueueInput,
 } from '@agent/followUp/FollowUpQueue';
-import type { AgentRuntimeFlowResult } from '@agent/runtime/AgentFlowResult';
+import type { FollowUpRecoveryLease } from '@agent/followUp/ToolUseFollowUpQueueManager';
+import {
+  isWaitingFlowResult,
+  type AgentRuntimeFlowResult,
+} from '@agent/runtime/AgentFlowResult';
+import type { RecoveryContinuation } from '@platform/interfaces';
 import {
   STREAM_PHASE,
   STREAM_SUBSTATE,
@@ -20,6 +25,8 @@ import type { ToolUseResumeData } from './SessionResumeRetrieval';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 
 export interface ResumeQueuedToolUseOptions extends SubagentRunOptions {
+  /** Recovery ownership synchronously claimed by the submission boundary. */
+  readonly recovery?: RecoveryContinuation;
   /** Recheck canonical admission atomically while acquiring the resumed lease. */
   readonly canAcquireResumeLease?: () => boolean | Promise<boolean>;
   /** Query a caller-owned stop request at the resumed flow attachment boundary. */
@@ -43,7 +50,7 @@ export interface ResumeQueuedToolUseOptions extends SubagentRunOptions {
    * Fires after the shared stream queue is acquired and marked RESUMING, but
    * before its queued items are drained into the rebuilt session.
    */
-  readonly onFollowUpQueueReady?: () => void;
+  readonly onFollowUpQueueReady?: (recovery: FollowUpRecoveryLease) => void;
   /**
    * Host-specific failure surface (log + toast). Invoked after the stream has
    * been returned to WAITING, so a blocking host dialog cannot strand the
@@ -85,24 +92,25 @@ export async function resumeQueuedToolUseFromResumeData(
     return false;
   }
 
-  followUpsQueue.acquire(streamId);
+  const queueLease = options.recovery
+    ? followUpsQueue.useRecovery(options.recovery)
+    : followUpsQueue.claimRecovery(streamId);
+  if (!queueLease) return false;
   streamStatus.transition(streamId, STREAM_PHASE.RUNNING, 'resume', {
     substate: STREAM_SUBSTATE.RESUMING,
   });
 
   const seed = options.extraFollowUps ?? [];
   let followUps: readonly FollowUpQueueInput[] = seed;
-  let followUpBoundaryReached = false;
   let cancelledAtFlowAttachment = false;
   let cancelledBeforeLaunch = false;
   let followUpsRestored = false;
   let resumeError: { error: unknown } | undefined;
+  let runResult: AgentRuntimeFlowResult | undefined;
   const restoreFollowUps = (): void => {
     if (followUpsRestored) return;
     followUpsRestored = true;
-    for (const item of followUps) {
-      followUpsQueue.enqueue(streamId, item, { force: true });
-    }
+    followUpsQueue.restore(queueLease, followUps);
     if (followUps.length > 0) {
       session.events.emit({
         scope: 'session',
@@ -114,8 +122,8 @@ export async function resumeQueuedToolUseFromResumeData(
     }
   };
   try {
-    options.onFollowUpQueueReady?.();
-    followUps = [...seed, ...followUpsQueue.drainItems(streamId)];
+    options.onFollowUpQueueReady?.(queueLease);
+    followUps = [...seed, ...followUpsQueue.drainItems(queueLease)];
     session.events.emit({
       scope: 'session',
       event: {
@@ -158,19 +166,12 @@ export async function resumeQueuedToolUseFromResumeData(
       // this host resume must claim the late batch so input accepted by the
       // live context cannot remain dormant.
       takePendingFollowUps: () => {
-        const isPostParkClaim = followUpBoundaryReached;
-        followUpBoundaryReached = true;
-        if (
-          isPostParkClaim &&
-          session.executions.isChildRunLoopActive(streamId)
-        ) {
-          return [];
-        }
-        const raced = followUpsQueue.drainItems(streamId);
+        const raced = followUpsQueue.drainItems(queueLease);
         followUps = [...followUps, ...raced];
         return raced.map(toFollowUpBatchItem);
       },
     });
+    runResult = result;
     if (followUps.length > 0) restoreFollowUps();
     options.onResult?.(result);
   } catch (error) {
@@ -199,6 +200,12 @@ export async function resumeQueuedToolUseFromResumeData(
     ) {
       streamStatus.transitionToWaiting(streamId, 'wait');
     }
+    followUpsQueue.release(
+      queueLease,
+      !runResult || isWaitingFlowResult(runResult) || followUpsRestored
+        ? 'recoverable'
+        : 'terminal',
+    );
   }
 
   if (cancelledBeforeLaunch) return false;

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -94,7 +94,7 @@ export async function resumeQueuedToolUseFromResumeData(
 
   const queueLease = options.recovery
     ? followUpsQueue.useRecovery(options.recovery)
-    : followUpsQueue.claimRecovery(streamId);
+    : followUpsQueue.claimRecovery(streamId, true);
   if (!queueLease) return false;
   streamStatus.transition(streamId, STREAM_PHASE.RUNNING, 'resume', {
     substate: STREAM_SUBSTATE.RESUMING,

--- a/src/platform/interfaces.ts
+++ b/src/platform/interfaces.ts
@@ -307,6 +307,12 @@ export interface AgentDirectoriesPort {
  * (e.g. the inquiry continuation injector) can trigger auto-resume without
  * importing the host-level command pipeline.
  */
+export interface RecoveryContinuation {
+  readonly streamId: StreamTabId;
+  readonly generation: number;
+  readonly kind: 'recovery';
+}
+
 export interface AgentResumePort {
   /**
    * Attempt to resume a WAITING / children-running stream from its
@@ -317,12 +323,8 @@ export interface AgentResumePort {
    * already active/resuming, etc.) — callers should fall back to leaving
    * the message queued for the next manual resume.
    */
-  tryResumeStream(streamId: StreamTabId): Promise<boolean>;
-
-  /**
-   * Whether the host has already accepted a resume for this stream and is
-   * still preparing it. A queued-delivery wake uses this to avoid releasing a
-   * force-reopened queue while a host-initiated resume is about to drain it.
-   */
-  isResumeInFlight?(streamId: StreamTabId): boolean;
+  tryResumeStream(
+    streamId: StreamTabId,
+    recovery?: RecoveryContinuation,
+  ): Promise<boolean>;
 }

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -623,7 +623,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       } finally {
         readSpy.mockRestore();
         deleteSpy.mockRestore();
-        session.followUps.release(streamId);
+        session.followUps.terminalize(streamId);
       }
     }
   });
@@ -756,7 +756,10 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       expect(readSpy).not.toHaveBeenCalled();
       expect(deleteSpy).not.toHaveBeenCalledWith(flowKey(executionId));
       expect(dispositions).toEqual(['delete']);
-      expect(releaseSpy).toHaveBeenCalledWith(streamId);
+      expect(releaseSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ streamId, kind: 'flow' }),
+        'terminal',
+      );
     } finally {
       readSpy.mockRestore();
       deleteSpy.mockRestore();
@@ -943,7 +946,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       ]);
     } finally {
       readSpy.mockRestore();
-      session.followUps.release(streamId);
+      session.followUps.terminalize(streamId);
     }
   });
 
@@ -998,7 +1001,7 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       ]);
     } finally {
       runSpy.mockRestore();
-      session.followUps.release(streamId);
+      session.followUps.terminalize(streamId);
     }
   });
 

--- a/src/test-kernel/agent/followUp/FollowUpQueue.vitest.ts
+++ b/src/test-kernel/agent/followUp/FollowUpQueue.vitest.ts
@@ -1,279 +1,116 @@
-// Third-party imports
 import { describe, expect, it } from 'vitest';
 
-// Local imports
-import { ToolUseSessionLifecycle } from '@agent/implementations/flows/tooluse/ToolUseSessionLifecycle';
 import { FollowUpQueue } from '@agent/followUp/FollowUpQueue';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import type { StreamTabId } from '@shared/schemas';
 
+const stream = (value: string) => value as StreamTabId;
+
 describe('FollowUpQueue', () => {
-  function createLifecycle(streamId: StreamTabId): ToolUseSessionLifecycle {
-    return new ToolUseSessionLifecycle(streamId, new ToolUseFollowUpQueue());
-  }
-
-  it('batches visible follow-ups for normal user input', async () => {
+  it('keeps visible and synthetic batches separate', async () => {
     const queue = new FollowUpQueue();
+    queue.enqueueSynthetic('compact');
+    queue.enqueue({ text: 'first', mediaFiles: ['/tmp/a.png'] });
+    queue.enqueue({ text: 'second', origin: 'subagent_result' });
 
-    queue.enqueue({ text: 'first' });
-    queue.enqueue({ text: 'second' });
-
+    expect(queue.getAll()).toEqual(['first', 'second']);
     await expect(queue.waitAndDrainAll(() => false)).resolves.toEqual({
-      items: [
-        { text: 'first', origin: 'user' },
-        { text: 'second', origin: 'user' },
-      ],
-      synthetic: false,
-    });
-  });
-
-  it('keeps synthetic follow-ups out of visible queue state', async () => {
-    const queue = new FollowUpQueue();
-
-    queue.enqueueSynthetic('compact now');
-    queue.enqueue({ text: 'user text' });
-
-    expect(queue.getAll()).toEqual(['user text']);
-
-    await expect(queue.waitAndDrainAll(() => false)).resolves.toEqual({
-      items: [{ text: 'compact now', origin: 'synthetic' }],
+      items: [{ text: 'compact', origin: 'synthetic' }],
       synthetic: true,
     });
     await expect(queue.waitAndDrainAll(() => false)).resolves.toEqual({
-      items: [{ text: 'user text', origin: 'user' }],
-      synthetic: false,
-    });
-  });
-
-  it('coalesces a contiguous run of synthetic follow-ups into one batch', async () => {
-    const queue = new FollowUpQueue();
-
-    queue.enqueueSynthetic('maintenance one');
-    queue.enqueueSynthetic('maintenance two');
-    queue.enqueue({ text: 'user text' });
-
-    await expect(queue.waitAndDrainAll(() => false)).resolves.toEqual({
       items: [
-        { text: 'maintenance one', origin: 'synthetic' },
-        { text: 'maintenance two', origin: 'synthetic' },
-      ],
-      synthetic: true,
-    });
-    await expect(queue.waitAndDrainAll(() => false)).resolves.toEqual({
-      items: [{ text: 'user text', origin: 'user' }],
-      synthetic: false,
-    });
-  });
-
-  it('does not merge synthetic batches across a visible item', async () => {
-    const queue = new FollowUpQueue();
-
-    queue.enqueueSynthetic('maintenance one');
-    queue.enqueue({ text: 'user text' });
-    queue.enqueueSynthetic('maintenance two');
-
-    await expect(queue.waitAndDrainAll(() => false)).resolves.toEqual({
-      items: [{ text: 'maintenance one', origin: 'synthetic' }],
-      synthetic: true,
-    });
-    await expect(queue.waitAndDrainAll(() => false)).resolves.toEqual({
-      items: [{ text: 'user text', origin: 'user' }],
-      synthetic: false,
-    });
-    await expect(queue.waitAndDrainAll(() => false)).resolves.toEqual({
-      items: [{ text: 'maintenance two', origin: 'synthetic' }],
-      synthetic: true,
-    });
-  });
-
-  it('carries media file paths on their own visible batch items', async () => {
-    const queue = new FollowUpQueue();
-
-    queue.enqueue({
-      text: 'look at this',
-      mediaFiles: ['/tmp/pasted/a.png'],
-    });
-    queue.enqueue({ text: 'and this', mediaFiles: ['/tmp/pasted/b.png'] });
-
-    await expect(queue.waitAndDrainAll(() => false)).resolves.toEqual({
-      items: [
-        {
-          text: 'look at this',
-          mediaFiles: ['/tmp/pasted/a.png'],
-          origin: 'user',
-        },
-        {
-          text: 'and this',
-          mediaFiles: ['/tmp/pasted/b.png'],
-          origin: 'user',
-        },
+        { text: 'first', mediaFiles: ['/tmp/a.png'], origin: 'user' },
+        { text: 'second', origin: 'subagent_result' },
       ],
       synthetic: false,
     });
   });
 
-  it('keeps injected text separate from display text', async () => {
+  it('rejects a second waiter instead of replacing the first', async () => {
     const queue = new FollowUpQueue();
+    const first = queue.waitForNext(() => false);
 
-    queue.enqueue({
-      text: '<skill_activation>hidden</skill_activation>',
-      displayText: 'fix theorem',
-    });
-
-    expect(queue.getAll()).toEqual(['fix theorem']);
-    await expect(queue.waitAndDrainAll(() => false)).resolves.toEqual({
-      items: [
-        {
-          text: '<skill_activation>hidden</skill_activation>',
-          displayText: 'fix theorem',
-          origin: 'user',
-        },
-      ],
-      synthetic: false,
-    });
-  });
-
-  it('preserves subagent-result origin on queued delivery items', async () => {
-    const queue = new FollowUpQueue();
-
-    queue.enqueue({
-      text: '<subagent-result>done</subagent-result>',
-      origin: 'subagent_result',
-    });
-    queue.enqueue({ text: 'user correction' });
-
-    await expect(queue.waitAndDrainAll(() => false)).resolves.toEqual({
-      items: [
-        {
-          text: '<subagent-result>done</subagent-result>',
-          origin: 'subagent_result',
-        },
-        { text: 'user correction', origin: 'user' },
-      ],
-      synthetic: false,
-    });
-  });
-
-  it('coalesces duplicate synthetic session follow-ups', async () => {
-    const session = createLifecycle('stream:synthetic-coalesce' as StreamTabId);
-
-    try {
-      session.appendSyntheticFollowUp('compact now');
-      session.appendSyntheticFollowUp('compact again');
-
-      await expect(session.waitForFollowUp(() => false)).resolves.toEqual({
-        items: [{ text: 'compact now', origin: 'synthetic' }],
-        synthetic: true,
-      });
-      expect(session.hasQueuedFollowUp()).toBe(false);
-    } finally {
-      session.dispose();
-    }
-  });
-
-  it('allows synthetic session follow-ups after an interrupt clears the queue', async () => {
-    const session = createLifecycle(
-      'stream:synthetic-interrupt' as StreamTabId,
+    expect(() => queue.waitForNext(() => false)).toThrow(
+      'already has a waiting consumer',
     );
+    queue.enqueue({ text: 'accepted once' });
+    await expect(first).resolves.toEqual({
+      text: 'accepted once',
+      origin: 'user',
+    });
+  });
+});
 
-    try {
-      session.appendSyntheticFollowUp('compact before interrupt');
-      session.interrupt();
-      session.appendSyntheticFollowUp('compact after interrupt');
+describe('ToolUseFollowUpQueue ownership', () => {
+  it('allows exactly one live or recovery owner', () => {
+    const queues = new ToolUseFollowUpQueue();
+    const id = stream('stream:exclusive');
+    const child = queues.claimLive(id, 'child');
+    expect(child).toBeDefined();
+    expect(queues.claimLive(id, 'flow')).toBeUndefined();
+    expect(queues.claimRecovery(id)).toBeUndefined();
 
-      await expect(session.waitForFollowUp(() => false)).resolves.toEqual({
-        items: [{ text: 'compact after interrupt', origin: 'synthetic' }],
-        synthetic: true,
-      });
-    } finally {
-      session.dispose();
-    }
+    expect(queues.release(child!, 'recoverable')).toBe(true);
+    const recovery = queues.claimRecovery(id);
+    expect(recovery).toBeDefined();
+    expect(queues.claimLive(id, 'child')).toBeUndefined();
   });
 
-  it('attaches media to a session follow-up', async () => {
-    const session = createLifecycle('stream:media-followup' as StreamTabId);
+  it('does not let a stale lease release a successor generation', () => {
+    const queues = new ToolUseFollowUpQueue();
+    const id = stream('stream:generation');
+    const child = queues.claimLive(id, 'child')!;
+    queues.queue(child).enqueue({ text: 'before handoff' });
+    queues.release(child, 'recoverable');
+    const recovery = queues.claimRecovery(id)!;
+    expect(
+      queues.submit(id, { text: 'during recovery' }, 'recoverable'),
+    ).toEqual({ kind: 'recovering' });
 
-    try {
-      session.appendFollowUp({
-        text: 'describe the figure',
-        mediaFiles: ['/tmp/pasted/fig.png'],
-      });
-
-      await expect(session.waitForFollowUp(() => false)).resolves.toEqual({
-        items: [
-          {
-            text: 'describe the figure',
-            mediaFiles: ['/tmp/pasted/fig.png'],
-            origin: 'user',
-          },
-        ],
-        synthetic: false,
-      });
-    } finally {
-      session.dispose();
-    }
+    expect(queues.release(child, 'terminal')).toBe(false);
+    expect(queues.getAll(id)).toEqual(['before handoff', 'during recovery']);
+    expect(queues.drainItems(recovery).map((item) => item.text)).toEqual([
+      'before handoff',
+      'during recovery',
+    ]);
   });
 
-  it('does not create ghost queues for unknown streams', () => {
-    const queue = new ToolUseFollowUpQueue();
-    const streamId = 'stream:unknown-followup' as StreamTabId;
+  it('keeps sessions isolated for the same stream id', () => {
+    const a = new ToolUseFollowUpQueue();
+    const b = new ToolUseFollowUpQueue();
+    const id = stream('stream:shared-id');
+    const aLease = a.claimLive(id, 'flow')!;
+    const bLease = b.claimLive(id, 'flow')!;
 
-    try {
-      expect(queue.enqueue(streamId, { text: 'late result' })).toBe(false);
-      expect(queue.getAll(streamId)).toEqual([]);
-    } finally {
-      queue.release(streamId);
-    }
+    a.queue(aLease).enqueue({ text: 'a' });
+    b.queue(bLease).enqueue({ text: 'b' });
+
+    expect(a.drainItems(aLease).map((item) => item.text)).toEqual(['a']);
+    expect(b.drainItems(bLease).map((item) => item.text)).toEqual(['b']);
   });
 
-  it('creates queues only for explicitly admitted follow-ups', () => {
-    const queue = new ToolUseFollowUpQueue();
-    const streamId = 'stream:admitted-followup' as StreamTabId;
+  it('never reopens a terminal stream', () => {
+    const queues = new ToolUseFollowUpQueue();
+    const id = stream('stream:terminal');
+    const lease = queues.claimLive(id, 'flow')!;
+    queues.release(lease, 'terminal');
 
-    try {
-      expect(
-        queue.enqueue(
-          streamId,
-          { text: 'admitted result' },
-          { createIfMissing: true },
-        ),
-      ).toBe(true);
-      expect(queue.getAll(streamId)).toEqual(['admitted result']);
-    } finally {
-      queue.release(streamId);
-    }
+    expect(queues.claimLive(id, 'flow')).toBeUndefined();
+    expect(queues.submit(id, { text: 'late' }, 'recoverable')).toEqual({
+      kind: 'unavailable',
+    });
   });
 
-  it('does not forget every released stream when the release cap is exceeded', () => {
-    const queue = new ToolUseFollowUpQueue();
-    const firstStream = 'stream:released-first' as StreamTabId;
-    const retainedStream = 'stream:released-retained' as StreamTabId;
+  it('deletion invalidates a live generation and rejects late input', () => {
+    const queues = new ToolUseFollowUpQueue();
+    const id = stream('stream:deleted');
+    const lease = queues.claimLive(id, 'child')!;
 
-    queue.acquire(firstStream);
-    queue.release(firstStream);
-    queue.acquire(retainedStream);
-    queue.release(retainedStream);
-
-    for (let i = 0; i < ToolUseFollowUpQueue.RELEASED_CAP - 1; i += 1) {
-      queue.release(`stream:released-extra-${i}` as StreamTabId);
-    }
-
-    try {
-      expect(queue.enqueue(firstStream, { text: 'late first' })).toBe(false);
-      expect(queue.getAll(firstStream)).toEqual([]);
-      expect(
-        queue.enqueue(
-          retainedStream,
-          {
-            text: 'late retained',
-          },
-          { createIfMissing: true },
-        ),
-      ).toBe(false);
-      expect(queue.getAll(retainedStream)).toEqual([]);
-    } finally {
-      queue.release(firstStream);
-      queue.release(retainedStream);
-    }
+    expect(queues.terminalize(id)).toBe(true);
+    expect(queues.release(lease, 'recoverable')).toBe(false);
+    expect(queues.submit(id, { text: 'late' }, 'recoverable')).toEqual({
+      kind: 'unavailable',
+    });
   });
 });

--- a/src/test-kernel/agent/followUp/FollowUpQueue.vitest.ts
+++ b/src/test-kernel/agent/followUp/FollowUpQueue.vitest.ts
@@ -76,6 +76,25 @@ describe('ToolUseFollowUpQueue ownership', () => {
     ]);
   });
 
+  it('enqueues live_owner notifications on a recoverable entry without claiming', () => {
+    const queues = new ToolUseFollowUpQueue();
+    const id = stream('stream:live-notify');
+    const child = queues.claimLive(id, 'child')!;
+    queues.release(child, 'recoverable');
+
+    // live_owner admission on a recoverable entry (no child owner) should
+    // enqueue without claiming ownership, returning 'queued'.
+    expect(queues.submit(id, { text: 'progress' }, 'live_owner')).toEqual({
+      kind: 'queued',
+    });
+    expect(queues.getAll(id)).toEqual(['progress']);
+
+    // The entry stays recoverable (no owner) — a subsequent recovery claim
+    // can still acquire it.
+    const recovery = queues.claimRecovery(id);
+    expect(recovery).toBeDefined();
+  });
+
   it('keeps sessions isolated for the same stream id', () => {
     const a = new ToolUseFollowUpQueue();
     const b = new ToolUseFollowUpQueue();

--- a/src/test-kernel/agent/followUp/GitHubSubscriptionProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/GitHubSubscriptionProgressEvents.vitest.ts
@@ -6,12 +6,12 @@ import '@test/support/defaultSessionTestSetup';
 // Third-party imports
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const sendFollowUpMock = vi.hoisted(() =>
+const submitFollowUpMock = vi.hoisted(() =>
   vi.fn(async () => ({ status: 'sent' as const })),
 );
 
 vi.mock('@agent/followUp/ToolUseFollowUp', () => ({
-  sendFollowUp: sendFollowUpMock,
+  submitFollowUp: submitFollowUpMock,
 }));
 
 // Local imports
@@ -129,8 +129,8 @@ class RegistryTestSource {
 
 describe('GitHub subscription app signals and follow-ups', () => {
   beforeEach(() => {
-    sendFollowUpMock.mockReset();
-    sendFollowUpMock.mockResolvedValue({ status: 'sent' as const });
+    submitFollowUpMock.mockReset();
+    submitFollowUpMock.mockResolvedValue({ status: 'sent' as const });
   });
 
   it('publishes binding changes through app signals', () => {
@@ -257,7 +257,7 @@ describe('GitHub subscription app signals and follow-ups', () => {
       keyOf: (input) => input,
       bindingsChangedEvent: 'repoSubscriptionBindingsChanged',
     });
-    sendFollowUpMock.mockClear();
+    submitFollowUpMock.mockClear();
 
     try {
       withRunContext(
@@ -271,12 +271,10 @@ describe('GitHub subscription app signals and follow-ups', () => {
 
       source.emit('owner/repo', 'new github event');
 
-      expect(sendFollowUpMock).toHaveBeenCalledWith(
+      expect(submitFollowUpMock).toHaveBeenCalledWith(
         streamId,
         'new github event',
-        undefined,
-        undefined,
-        session,
+        { session, mode: 'live_notification' },
       );
     } finally {
       session.dispose();
@@ -299,7 +297,7 @@ describe('GitHub subscription app signals and follow-ups', () => {
       bindingsChangedEvent: 'repoSubscriptionBindingsChanged',
     });
     const unhandledRejection = vi.fn();
-    sendFollowUpMock.mockRejectedValueOnce(new Error('delivery failed'));
+    submitFollowUpMock.mockRejectedValueOnce(new Error('delivery failed'));
 
     try {
       process.once('unhandledRejection', unhandledRejection);

--- a/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
@@ -57,6 +57,13 @@ describe('submitFollowUp', () => {
     const session = fakeSession({ kind: 'queue', reason: 'waiting' });
     const tryResumeStream = vi.fn(async () => true);
 
+    // Create a child-owned entry (simulates a running child loop), then
+    // release the lease so the entry exists but has no owner — the exact
+    // state of a WAITING parent queue after a child finishes its turn and
+    // a live_notification (progress update, execution event) arrives.
+    const child = session.followUps.claimLive(streamId, 'child')!;
+    session.followUps.release(child, 'recoverable');
+
     // live_notification on a WAITING queue without child owner should enqueue
     // without claiming recovery or triggering a stream resume.
     const result = await submitFollowUp(streamId, 'child progress', {

--- a/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
@@ -6,6 +6,7 @@ import {
 } from '@agent/followUp/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import type { ToolUseFollowUpTarget } from '@agent/runtime/executionRegistry';
+import type { LiveToolUseFlowContext } from '@agent/runtime/ExecutionHandle';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { StreamTabId } from '@shared/schemas';
 
@@ -23,6 +24,22 @@ function fakeSession(target: ToolUseFollowUpTarget): SessionHandle {
     followUps: new ToolUseFollowUpQueue(),
     events: { emit: vi.fn() },
   } as unknown as SessionHandle;
+}
+
+function activeTarget(
+  appendFollowUp: LiveToolUseFlowContext['session']['appendFollowUp'],
+): ToolUseFollowUpTarget {
+  return {
+    kind: 'active',
+    context: {
+      session: { appendFollowUp },
+      modelHandler: { supportsManualCompaction: true },
+      requestImmediateCompaction: () => {},
+      modelSwitchDisabledReason: () => undefined,
+      switchModel: async () => {},
+      interrupt: () => {},
+    },
+  };
 }
 
 const id = (value: string) => value as StreamTabId;
@@ -50,6 +67,56 @@ describe('submitFollowUp', () => {
     expect(
       session.followUps.drainItems(child).map((item) => item.text),
     ).toEqual(['while waiting', 'between turns', 'during turn']);
+  });
+
+  it('reports input admitted by a live flow as sent', async () => {
+    const streamId = id('stream:live-flow');
+    const appendFollowUp = vi.fn();
+    const session = fakeSession(activeTarget(appendFollowUp));
+    const flow = session.followUps.claimLive(streamId, 'flow')!;
+    const tryResumeStream = vi.fn(async () => true);
+
+    await expect(
+      submitFollowUp(streamId, 'during active turn', {
+        session,
+        resumePort: { tryResumeStream },
+      }),
+    ).resolves.toEqual({ status: 'sent' });
+
+    expect(tryResumeStream).not.toHaveBeenCalled();
+    expect(appendFollowUp).not.toHaveBeenCalled();
+    expect(session.followUps.drainItems(flow)).toMatchObject([
+      { text: 'during active turn' },
+    ]);
+    expect(session.events.emit).toHaveBeenCalledWith({
+      scope: 'session',
+      event: {
+        type: 'followUpSent',
+        payload: { streamId },
+      },
+    });
+  });
+
+  it('does not report an automatic live-flow notification as user input', async () => {
+    const streamId = id('stream:live-flow-notification');
+    const session = fakeSession(activeTarget(vi.fn()));
+    const flow = session.followUps.claimLive(streamId, 'flow')!;
+
+    await expect(
+      submitFollowUp(streamId, 'child progress', {
+        session,
+        mode: 'live_notification',
+      }),
+    ).resolves.toEqual({
+      status: 'queued',
+      reason: 'waiting',
+      continuation: 'live',
+    });
+
+    expect(session.followUps.drainItems(flow)).toMatchObject([
+      { text: 'child progress' },
+    ]);
+    expect(session.events.emit).not.toHaveBeenCalled();
   });
 
   it('enqueues live notifications for a waiting parent without child owner', async () => {
@@ -181,6 +248,58 @@ describe('submitFollowUp', () => {
     });
 
     expect(tryResumeStream).toHaveBeenCalledTimes(1);
+  });
+
+  it('delivers a final child result through the retained queue after child untracking', async () => {
+    const streamId = id('stream:final-child-delivery');
+    const session = fakeSession({
+      kind: 'no_session',
+      streamStatus: 'completed',
+    });
+    const parentFlow = session.followUps.claimLive(streamId, 'flow')!;
+    session.followUps.release(parentFlow, 'recoverable');
+    const tryResumeStream = vi.fn(async () => true);
+
+    await expect(
+      submitFollowUp(
+        streamId,
+        { text: 'final child result', origin: 'subagent_result' },
+        {
+          session,
+          resumePort: { tryResumeStream },
+          mode: 'child_delivery',
+        },
+      ),
+    ).resolves.toEqual({
+      status: 'queued',
+      reason: 'children_running',
+      continuation: 'resumed',
+    });
+
+    expect(tryResumeStream).toHaveBeenCalledTimes(1);
+    expect(session.followUps.getAll(streamId)).toEqual(['final child result']);
+  });
+
+  it('does not let child delivery reopen a terminal parent queue', async () => {
+    const streamId = id('stream:terminal-child-delivery');
+    const session = fakeSession({
+      kind: 'no_session',
+      streamStatus: 'completed',
+    });
+    const tryResumeStream = vi.fn(async () => true);
+
+    await expect(
+      submitFollowUp(
+        streamId,
+        { text: 'late child result', origin: 'subagent_result' },
+        {
+          session,
+          resumePort: { tryResumeStream },
+          mode: 'child_delivery',
+        },
+      ),
+    ).resolves.toEqual({ status: 'dropped' });
+    expect(tryResumeStream).not.toHaveBeenCalled();
   });
 
   it('rejects terminal queues and never invokes recovery', async () => {

--- a/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
@@ -52,6 +52,28 @@ describe('submitFollowUp', () => {
     ).toEqual(['while waiting', 'between turns', 'during turn']);
   });
 
+  it('enqueues live notifications for a waiting parent without child owner', async () => {
+    const streamId = id('stream:waiting-notification');
+    const session = fakeSession({ kind: 'queue', reason: 'waiting' });
+    const tryResumeStream = vi.fn(async () => true);
+
+    // live_notification on a WAITING queue without child owner should enqueue
+    // without claiming recovery or triggering a stream resume.
+    const result = await submitFollowUp(streamId, 'child progress', {
+      session,
+      resumePort: { tryResumeStream },
+      mode: 'live_notification',
+    });
+
+    expect(result).toMatchObject({
+      status: 'queued',
+      reason: 'waiting',
+      continuation: 'live',
+    });
+    expect(tryResumeStream).not.toHaveBeenCalled();
+    expect(session.followUps.getAll(streamId)).toEqual(['child progress']);
+  });
+
   it('claims one recovery synchronously and orders repeated submissions once', async () => {
     const streamId = id('stream:recovery');
     const session = fakeSession({ kind: 'queue', reason: 'waiting' });
@@ -112,6 +134,33 @@ describe('submitFollowUp', () => {
     const childFirst = new ToolUseFollowUpQueue();
     expect(childFirst.claimLive(streamId, 'child')).toBeDefined();
     expect(childFirst.claimRecovery(streamId)).toBeUndefined();
+  });
+
+  it('enqueues live notifications for children-running parent without recovery', async () => {
+    const streamId = id('stream:children-running-notification');
+    const session = fakeSession({
+      kind: 'queue',
+      reason: 'children_running',
+    });
+    // Create a child-owned entry to simulate the parent having active children.
+    const child = session.followUps.claimLive(streamId, 'child')!;
+    // Release the child so the queue stays but loses its owner.
+    session.followUps.release(child, 'recoverable');
+    const tryResumeStream = vi.fn(async () => true);
+
+    const result = await submitFollowUp(streamId, 'child update', {
+      session,
+      resumePort: { tryResumeStream },
+      mode: 'live_notification',
+    });
+
+    expect(result).toMatchObject({
+      status: 'queued',
+      reason: 'children_running',
+      continuation: 'live',
+    });
+    expect(tryResumeStream).not.toHaveBeenCalled();
+    expect(session.followUps.getAll(streamId)).toEqual(['child update']);
   });
 
   it('keeps children-running explicitly recoverable after child untracking', async () => {

--- a/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUp.vitest.ts
@@ -1,472 +1,161 @@
-// Test composition imports
+import { describe, expect, it, vi } from 'vitest';
 
-// Local imports
-import '@test/support/defaultSessionTestSetup';
-
-// Test support imports
-
-// Node imports
-import { strict as assert } from 'node:assert';
-
-// Third-party imports
-import { describe, it, afterEach } from 'vitest';
-
-// Local imports
-import { noopAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { defaultSession } from '@agent/runtime/SessionHandle';
 import {
-  AgentExecutionHandle,
-  type LiveToolUseFlowContext,
-} from '@agent/runtime/ExecutionHandle';
-import {
-  presentFollowUpWakeResult,
-  sendFollowUp,
-  wakeQueuedFollowUpStream,
-  wakeOrReleaseQueuedStream,
+  presentFollowUpResult,
+  submitFollowUp,
 } from '@agent/followUp/ToolUseFollowUp';
-import { ToolUseSessionLifecycle } from '@agent/implementations/flows/tooluse/ToolUseSessionLifecycle';
-import type { FollowUpQueueInput } from '@agent/followUp/FollowUpQueue';
-import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
-import {
-  clearStreamStatusForTest,
-  seedStreamStatusForTest,
-} from '@test/helpers/streamStatusTestUtils';
-import { installPlatform } from '@test/support/setupPlatform';
-import { createFakePlatform } from '@test/support/FakePlatform';
-import { createTestSession } from '@test/support/sessionTestUtils';
+import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
+import type { ToolUseFollowUpTarget } from '@agent/runtime/executionRegistry';
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
+import type { StreamTabId } from '@shared/schemas';
 
-type ResumeHost = NonNullable<
-  NonNullable<Parameters<typeof createFakePlatform>[1]>['agentResume']
->;
-
-function initResumePlatform(agentResume: ResumeHost): Promise<void> {
-  return installPlatform({}, { agentResume });
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
 }
 
-function trackChildHandle(
-  executionId: string,
-  parentStreamId: StreamTabId,
-  childStreamId: StreamTabId,
-): void {
-  const handle = new AgentExecutionHandle(
-    executionId,
-    parentStreamId,
-    childStreamId,
-    'test-subagent',
-    'toolUse',
-    noopAgentRuntimeHost,
-  );
-  defaultSession().executions.track(handle);
+function fakeSession(target: ToolUseFollowUpTarget): SessionHandle {
+  return {
+    executions: { getToolUseFollowUpTarget: () => target },
+    followUps: new ToolUseFollowUpQueue(),
+    events: { emit: vi.fn() },
+  } as unknown as SessionHandle;
 }
 
-describe('ToolUseFollowUp', () => {
-  const streamId = 'stream-follow-up' as StreamTabId;
+const id = (value: string) => value as StreamTabId;
 
-  afterEach(() => {
-    for (const executionId of defaultSession().executions.getActiveIds()) {
-      defaultSession().executions.untrack(executionId);
+describe('submitFollowUp', () => {
+  it('uses the live child owner while waiting, between turns, and during a turn', async () => {
+    const streamId = id('stream:live-child');
+    const session = fakeSession({ kind: 'queue', reason: 'waiting' });
+    const child = session.followUps.claimLive(streamId, 'child')!;
+    const tryResumeStream = vi.fn(async () => true);
+
+    for (const text of ['while waiting', 'between turns', 'during turn']) {
+      await expect(
+        submitFollowUp(streamId, text, {
+          session,
+          resumePort: { tryResumeStream },
+        }),
+      ).resolves.toMatchObject({
+        status: 'queued',
+        continuation: 'live',
+      });
     }
-    defaultSession().followUps.release(streamId);
+
+    expect(tryResumeStream).not.toHaveBeenCalled();
+    expect(
+      session.followUps.drainItems(child).map((item) => item.text),
+    ).toEqual(['while waiting', 'between turns', 'during turn']);
   });
 
-  function trackToolUseFlow(
-    stream: StreamTabId,
-    appendFollowUp: LiveToolUseFlowContext['session']['appendFollowUp'],
-    executionId = `exec-${stream}`,
-  ): string {
-    const handle = new AgentExecutionHandle(
-      executionId,
-      stream,
-      stream,
-      'demo-agent',
-      'toolUse',
-      noopAgentRuntimeHost,
-    );
-    handle.attachToolUseFlow({
-      session: { appendFollowUp },
-      modelHandler: { supportsManualCompaction: true },
-      runtimeHost: noopAgentRuntimeHost,
-      requestImmediateCompaction: () => {},
-      modelSwitchDisabledReason: () => undefined,
-      switchModel: async () => {},
-      interrupt: () => {},
+  it('claims one recovery synchronously and orders repeated submissions once', async () => {
+    const streamId = id('stream:recovery');
+    const session = fakeSession({ kind: 'queue', reason: 'waiting' });
+    const barrier = deferred<boolean>();
+    const claimed: unknown[] = [];
+    const tryResumeStream = vi.fn((_: StreamTabId, recovery: unknown) => {
+      claimed.push(recovery);
+      return barrier.promise;
     });
-    defaultSession().executions.track(handle);
-    return executionId;
-  }
 
-  it('maps wake outcomes to shared host presentation messages', () => {
-    assert.deepEqual(presentFollowUpWakeResult({ kind: 'dropped' }), {
-      severity: 'warning',
-      message:
-        'Message dropped because no session was available to receive it. Start a new agent task to continue.',
-      refreshQueuedFollowUps: true,
+    const first = submitFollowUp(streamId, 'one', {
+      session,
+      resumePort: { tryResumeStream },
     });
-    assert.deepEqual(
-      presentFollowUpWakeResult({ kind: 'queued_resume_failed' }),
-      {
-        severity: 'info',
-        message:
-          'Message queued. Auto-resume failed; start a new agent task to continue.',
-        refreshQueuedFollowUps: false,
-      },
-    );
-    assert.deepEqual(presentFollowUpWakeResult({ kind: 'resumed' }), {
+    const second = submitFollowUp(streamId, 'two', {
+      session,
+      resumePort: { tryResumeStream },
+    });
+    const third = submitFollowUp(streamId, 'three', {
+      session,
+      resumePort: { tryResumeStream },
+    });
+
+    expect(tryResumeStream).toHaveBeenCalledTimes(1);
+    expect(claimed).toHaveLength(1);
+    await expect(second).resolves.toMatchObject({ continuation: 'recovering' });
+    await expect(third).resolves.toMatchObject({ continuation: 'recovering' });
+    expect(session.followUps.getAll(streamId)).toEqual(['one', 'two', 'three']);
+
+    barrier.resolve(true);
+    await expect(first).resolves.toMatchObject({ continuation: 'resumed' });
+  });
+
+  it('starts recovery after the child generation releases', async () => {
+    const streamId = id('stream:child-release');
+    const session = fakeSession({ kind: 'queue', reason: 'waiting' });
+    const child = session.followUps.claimLive(streamId, 'child')!;
+    session.followUps.release(child, 'recoverable');
+    const tryResumeStream = vi.fn(async () => true);
+
+    await expect(
+      submitFollowUp(streamId, 'continue', {
+        session,
+        resumePort: { tryResumeStream },
+      }),
+    ).resolves.toMatchObject({ continuation: 'resumed' });
+    expect(tryResumeStream).toHaveBeenCalledTimes(1);
+  });
+
+  it('makes recovery-vs-child claims exclusive in either order', () => {
+    const streamId = id('stream:claim-race');
+    const recoveryFirst = new ToolUseFollowUpQueue();
+    expect(
+      recoveryFirst.submit(streamId, { text: 'recover' }, 'recoverable').kind,
+    ).toBe('recovery');
+    expect(recoveryFirst.claimLive(streamId, 'child')).toBeUndefined();
+
+    const childFirst = new ToolUseFollowUpQueue();
+    expect(childFirst.claimLive(streamId, 'child')).toBeDefined();
+    expect(childFirst.claimRecovery(streamId)).toBeUndefined();
+  });
+
+  it('keeps children-running explicitly recoverable after child untracking', async () => {
+    const streamId = id('stream:children-running');
+    const session = fakeSession({ kind: 'queue', reason: 'children_running' });
+    const tryResumeStream = vi.fn(async () => true);
+
+    await submitFollowUp(streamId, 'child result', {
+      session,
+      resumePort: { tryResumeStream },
+    });
+
+    expect(tryResumeStream).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects terminal queues and never invokes recovery', async () => {
+    const streamId = id('stream:terminal');
+    const session = fakeSession({ kind: 'queue', reason: 'waiting' });
+    const lease = session.followUps.claimLive(streamId, 'flow')!;
+    session.followUps.release(lease, 'terminal');
+    const tryResumeStream = vi.fn(async () => true);
+
+    await expect(
+      submitFollowUp(streamId, 'late', {
+        session,
+        resumePort: { tryResumeStream },
+      }),
+    ).resolves.toEqual({ status: 'dropped' });
+    expect(tryResumeStream).not.toHaveBeenCalled();
+  });
+
+  it('maps merged host outcomes without ownership checks', () => {
+    expect(presentFollowUpResult({ status: 'sent' })).toEqual({
       severity: 'none',
     });
-  });
-
-  it('sends follow-ups to active flow contexts', async () => {
-    const calls: string[] = [];
-    trackToolUseFlow(streamId, (followUp) => {
-      calls.push(followUp.text);
-    });
-
-    const result = await sendFollowUp(streamId, 'hello');
-
-    assert.equal(calls.length, 1);
-    assert.equal(calls[0], 'hello');
-    assert.deepEqual(result, { status: 'sent' });
-  });
-
-  it('preserves explicit follow-up item origin for active flow contexts', async () => {
-    const calls: FollowUpQueueInput[] = [];
-    trackToolUseFlow(streamId, (followUp) => {
-      calls.push(followUp);
-    });
-
-    const result = await sendFollowUp(streamId, {
-      text: 'subagent result',
-      origin: 'subagent_result',
-    });
-
-    assert.deepEqual(result, { status: 'sent' });
-    assert.deepEqual(calls, [
-      { text: 'subagent result', origin: 'subagent_result' },
-    ]);
-  });
-
-  it('does not drop a follow-up that races into the live queue before a WAITING teardown (issue #7286)', async () => {
-    // Regression: runToolUseFlow's finally called sessionLifecycle.dispose()
-    // unconditionally, even on the WAITING branch. While the tool-use flow
-    // context is still attached (teardownSetup/detach runs earlier in that
-    // same finally, but after a follow-up can land here), a delegate_agent
-    // follow-up can reach the live queue via sendFollowUp's 'active' branch
-    // -- dispose() then released that same queue, silently discarding the
-    // item before the native wake path (which only handles 'queued' results)
-    // ever saw it. Fixed by skipping dispose() when the outcome is WAITING.
-    const waitingStreamId = 'stream-waiting-race-follow-up' as StreamTabId;
-    const sessionLifecycle = new ToolUseSessionLifecycle(
-      waitingStreamId,
-      defaultSession().followUps,
-    );
-    const executionId = trackToolUseFlow(waitingStreamId, (followUp) =>
-      sessionLifecycle.appendFollowUp(followUp),
-    );
-
-    try {
-      // Simulate the race: a delegate_agent follow-up lands in the live
-      // session while the tool-use flow context is still attached.
-      const result = await sendFollowUp(waitingStreamId, 'keep going');
-      assert.deepEqual(result, { status: 'sent' });
-      assert.equal(sessionLifecycle.hasQueuedFollowUp(), true);
-
-      // runToolUseFlow's finally, on the WAITING branch, now skips
-      // sessionLifecycle.dispose() -- the follow-up survives instead of
-      // being dropped when the queue would otherwise have been released.
-      assert.deepEqual(defaultSession().followUps.getAll(waitingStreamId), [
-        'keep going',
-      ]);
-
-      // A subsequent resume constructs a new ToolUseSessionLifecycle for the
-      // same stream; since the queue was never released, acquire() hands
-      // back the same live instance with the raced-in follow-up intact.
-      const resumedSessionLifecycle = new ToolUseSessionLifecycle(
-        waitingStreamId,
-        defaultSession().followUps,
-      );
-      assert.equal(resumedSessionLifecycle.hasQueuedFollowUp(), true);
-    } finally {
-      defaultSession().executions.untrack(executionId);
-      sessionLifecycle.dispose();
-    }
-  });
-
-  it('reports unknown streams as no session', async () => {
-    const missingStreamId = 'missing-follow-up-session' as StreamTabId;
-
-    const result = await sendFollowUp(missingStreamId, 'hello');
-
-    assert.deepEqual(result, {
-      status: 'no_session',
-      streamStatus: undefined,
-    });
-    assert.deepEqual(await wakeQueuedFollowUpStream(missingStreamId, result), {
-      kind: 'not_required',
-    });
-  });
-
-  it('queues follow-ups when children are still running', async () => {
-    const parentStreamId = 'parent-stream-children' as StreamTabId;
-    const childStreamId = 'child-stream-children' as StreamTabId;
-    const executionId = 'exec-children-running';
-
-    trackChildHandle(executionId, parentStreamId, childStreamId);
-
-    try {
-      const result = await sendFollowUp(parentStreamId, 'hello while running');
-
-      assert.deepEqual(result, {
-        status: 'queued',
-        reason: 'children_running',
-      });
-      assert.deepEqual(defaultSession().followUps.getAll(parentStreamId), [
-        'hello while running',
-      ]);
-    } finally {
-      defaultSession().executions.untrack(executionId);
-      defaultSession().followUps.release(parentStreamId);
-    }
-  });
-
-  it('survives prior queue release when children are running', async () => {
-    // Regression: without force:true, enqueue() silently drops messages
-    // on streams previously released by sessionLifecycle.dispose().
-    const parentStreamId = 'parent-stream-released' as StreamTabId;
-    const childStreamId = 'child-stream-released' as StreamTabId;
-    const executionId = 'exec-released';
-
-    trackChildHandle(executionId, parentStreamId, childStreamId);
-    defaultSession().followUps.release(parentStreamId);
-
-    try {
-      const result = await sendFollowUp(parentStreamId, 'after release');
-
-      assert.deepEqual(result, {
-        status: 'queued',
-        reason: 'children_running',
-      });
-      assert.deepEqual(defaultSession().followUps.getAll(parentStreamId), [
-        'after release',
-      ]);
-    } finally {
-      defaultSession().executions.untrack(executionId);
-      defaultSession().followUps.release(parentStreamId);
-    }
-  });
-
-  it('queues subagent result follow-ups through the released parent queue', async () => {
-    const parentStreamId = 'parent-stream-subagent-result' as StreamTabId;
-    const childStreamId = 'child-stream-subagent-result' as StreamTabId;
-    const executionId = 'exec-subagent-result';
-
-    trackChildHandle(executionId, parentStreamId, childStreamId);
-    defaultSession().followUps.release(parentStreamId);
-
-    try {
-      const result = await sendFollowUp(parentStreamId, {
-        text: 'child done',
-        origin: 'subagent_result',
-      });
-
-      assert.deepEqual(result, {
-        status: 'queued',
-        reason: 'children_running',
-      });
-      assert.deepEqual(defaultSession().followUps.drainItems(parentStreamId), [
-        {
-          text: 'child done',
-          origin: 'subagent_result',
-          // Queue items always carry the optional metadata slots explicitly.
-          displayText: undefined,
-          mediaFiles: undefined,
-        },
-      ]);
-    } finally {
-      defaultSession().executions.untrack(executionId);
-      defaultSession().followUps.release(parentStreamId);
-    }
-  });
-
-  it('serializes concurrent wakes so an in-flight resume keeps the queue', async () => {
-    // Regression: hosts report an already-in-flight resume as `false` before
-    // RESUMING is set, so a second concurrent wake used to release the queue
-    // the first resume was about to drain.
-    const parentStreamId = 'parent-stream-wake-race' as StreamTabId;
-    const childStreamId = 'child-stream-wake-race' as StreamTabId;
-    const executionId = 'exec-wake-race';
-
-    let resumeCalls = 0;
-    let resolveResume!: (resumed: boolean) => void;
-    await initResumePlatform({
-      tryResumeStream: () => {
-        resumeCalls++;
-        return new Promise<boolean>((resolve) => {
-          resolveResume = resolve;
-        });
-      },
-    });
-
-    trackChildHandle(executionId, parentStreamId, childStreamId);
-
-    try {
-      const first = await sendFollowUp(parentStreamId, 'result one');
-      const second = await sendFollowUp(parentStreamId, 'result two');
-      assert.deepEqual(first, { status: 'queued', reason: 'children_running' });
-      assert.deepEqual(second, {
-        status: 'queued',
-        reason: 'children_running',
-      });
-
-      const wakes = Promise.all([
-        wakeOrReleaseQueuedStream(parentStreamId, first),
-        wakeOrReleaseQueuedStream(parentStreamId, second),
-      ]);
-      resolveResume(true);
-
-      assert.deepEqual(await wakes, [true, true]);
-      assert.equal(resumeCalls, 1);
-      assert.deepEqual(defaultSession().followUps.getAll(parentStreamId), [
-        'result one',
-        'result two',
-      ]);
-    } finally {
-      defaultSession().executions.untrack(executionId);
-      defaultSession().followUps.release(parentStreamId);
-    }
-  });
-
-  it('releases the reopened queue when the parent cannot be resumed', async () => {
-    const parentStreamId = 'parent-stream-wake-dead' as StreamTabId;
-    const childStreamId = 'child-stream-wake-dead' as StreamTabId;
-    const executionId = 'exec-wake-dead';
-
-    await initResumePlatform({ tryResumeStream: async () => false });
-
-    trackChildHandle(executionId, parentStreamId, childStreamId);
-
-    try {
-      const result = await sendFollowUp(parentStreamId, 'late result');
-      assert.deepEqual(result, {
-        status: 'queued',
-        reason: 'children_running',
-      });
-
-      assert.deepEqual(await wakeQueuedFollowUpStream(parentStreamId, result), {
-        kind: 'dropped',
-      });
-      assert.deepEqual(defaultSession().followUps.getAll(parentStreamId), []);
-    } finally {
-      defaultSession().executions.untrack(executionId);
-      defaultSession().followUps.release(parentStreamId);
-    }
-  });
-
-  it('reports failed waiting-stream wakes without dropping the queue', async () => {
-    const waitingStreamId = 'parent-stream-wake-waiting' as StreamTabId;
-
-    await initResumePlatform({ tryResumeStream: async () => false });
-    seedStreamStatusForTest(
-      defaultSession().status,
-      waitingStreamId,
-      STREAM_STATUS.WAITING,
-    );
-
-    try {
-      const result = await sendFollowUp(
-        waitingStreamId,
-        'queued while waiting',
-      );
-      assert.deepEqual(result, {
+    expect(
+      presentFollowUpResult({
         status: 'queued',
         reason: 'waiting',
-      });
-
-      assert.deepEqual(
-        await wakeQueuedFollowUpStream(waitingStreamId, result),
-        { kind: 'queued_resume_failed' },
-      );
-      assert.deepEqual(defaultSession().followUps.getAll(waitingStreamId), [
-        'queued while waiting',
-      ]);
-    } finally {
-      clearStreamStatusForTest(defaultSession().status, waitingStreamId);
-      defaultSession().followUps.release(waitingStreamId);
-    }
-  });
-
-  it('keeps the reopened queue while the host has a resume in flight', async () => {
-    const parentStreamId = 'parent-stream-wake-in-flight' as StreamTabId;
-    const childStreamId = 'child-stream-wake-in-flight' as StreamTabId;
-    const executionId = 'exec-wake-in-flight';
-
-    await initResumePlatform({
-      tryResumeStream: async () => false,
-      isResumeInFlight: (stream) => stream === parentStreamId,
+        continuation: 'resume_failed',
+      }),
+    ).toMatchObject({ severity: 'info' });
+    expect(presentFollowUpResult({ status: 'dropped' })).toMatchObject({
+      severity: 'warning',
     });
-
-    trackChildHandle(executionId, parentStreamId, childStreamId);
-
-    try {
-      const result = await sendFollowUp(parentStreamId, 'late result');
-      assert.deepEqual(result, {
-        status: 'queued',
-        reason: 'children_running',
-      });
-
-      assert.equal(
-        await wakeOrReleaseQueuedStream(parentStreamId, result),
-        true,
-      );
-      assert.deepEqual(defaultSession().followUps.getAll(parentStreamId), [
-        'late result',
-      ]);
-    } finally {
-      defaultSession().executions.untrack(executionId);
-      defaultSession().followUps.release(parentStreamId);
-    }
-  });
-
-  it('routes the wake decision to an explicitly passed session instead of currentSession()', async () => {
-    // Regression for #7161: an explicit session param must decide
-    // active/resuming (and therefore wake/release) on its own state, not
-    // silently fall back to the process default session.
-    const parentStreamId = 'parent-stream-session-routing' as StreamTabId;
-
-    await initResumePlatform({ tryResumeStream: async () => false });
-
-    const result = { status: 'queued' as const, reason: 'waiting' as const };
-
-    const routedSession = createTestSession();
-    seedStreamStatusForTest(
-      routedSession.status,
-      parentStreamId,
-      STREAM_STATUS.RUNNING,
-    );
-
-    try {
-      // The explicit session marks this stream RUNNING (active), so passing
-      // it must make the wake decision defer to it.
-      assert.deepEqual(
-        await wakeQueuedFollowUpStream(
-          parentStreamId,
-          result,
-          undefined,
-          routedSession,
-        ),
-        { kind: 'active_or_resuming' },
-      );
-
-      // Without an explicit session, the decision falls back to
-      // currentSession() (the process default), whose status machine has no
-      // state for this stream — proving the two sessions are not conflated
-      // and the routed session's state actually drove the result above.
-      assert.deepEqual(await wakeQueuedFollowUpStream(parentStreamId, result), {
-        kind: 'queued_resume_failed',
-      });
-    } finally {
-      clearStreamStatusForTest(routedSession.status, parentStreamId);
-      defaultSession().followUps.release(parentStreamId);
-    }
   });
 });

--- a/src/test-kernel/agent/followUp/ToolUseFollowUpProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseFollowUpProgressEvents.vitest.ts
@@ -22,7 +22,7 @@ import { defaultSession, SessionHandle } from '@agent/runtime/SessionHandle';
 import {
   notifyFollowUpSent,
   onFollowUpSent,
-  sendFollowUp,
+  submitFollowUp,
 } from '@agent/followUp/ToolUseFollowUp';
 import { STREAM_PHASE, STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 import {
@@ -115,13 +115,9 @@ describe('tool-use follow-up progress events', () => {
 
     trackToolUseFlow({ host, appendFollowUp, session });
 
-    const result = await sendFollowUp(
-      streamId,
-      'please continue',
-      undefined,
-      undefined,
+    const result = await submitFollowUp(streamId, 'please continue', {
       session,
-    );
+    });
     detachFacts();
 
     expect(result).toEqual({ status: 'sent' });
@@ -258,9 +254,9 @@ describe('tool-use follow-up progress events', () => {
 
     trackToolUseFlow({ host, appendFollowUp: vi.fn() });
 
-    await sendFollowUp(streamId, 'break wait');
+    await submitFollowUp(streamId, 'break wait');
     unsubscribeFollowUpObservers.pop()?.();
-    await sendFollowUp(streamId, 'after unsubscribe');
+    await submitFollowUp(streamId, 'after unsubscribe');
 
     expect(observed).toEqual([streamId]);
   });
@@ -288,13 +284,9 @@ describe('tool-use follow-up progress events', () => {
         session,
       });
 
-      const result = await sendFollowUp(
-        streamId,
-        'observer ordering',
-        undefined,
-        undefined,
+      const result = await submitFollowUp(streamId, 'observer ordering', {
         session,
-      );
+      });
 
       expect(result).toEqual({ status: 'sent' });
       expect(order).toEqual([
@@ -318,7 +310,7 @@ describe('tool-use follow-up progress events', () => {
     );
     trackToolUseFlow({ host, appendFollowUp });
 
-    const result = await sendFollowUp(streamId, 'late follow-up');
+    const result = await submitFollowUp(streamId, 'late follow-up');
 
     expect(result).toEqual({
       status: 'no_session',
@@ -336,12 +328,10 @@ describe('tool-use follow-up progress events', () => {
     });
 
     try {
-      const result = await sendFollowUp(
+      const result = await submitFollowUp(
         'stream:no-follow-up-session' as StreamTabId,
         'cannot deliver',
-        undefined,
-        undefined,
-        session,
+        { session },
       );
 
       expect(result).toEqual({
@@ -364,7 +354,7 @@ describe('tool-use follow-up progress events', () => {
     );
 
     try {
-      const result = await sendFollowUp(
+      const result = await submitFollowUp(
         resumingStreamId,
         'queued while resuming',
       );
@@ -372,12 +362,13 @@ describe('tool-use follow-up progress events', () => {
       expect(result).toEqual({
         status: 'queued',
         reason: 'resuming',
+        continuation: 'resume_failed',
       });
       expect(defaultSession().followUps.getAll(resumingStreamId)).toEqual([
         'queued while resuming',
       ]);
     } finally {
-      defaultSession().followUps.release(resumingStreamId);
+      defaultSession().followUps.terminalize(resumingStreamId);
     }
   });
 
@@ -402,18 +393,19 @@ describe('tool-use follow-up progress events', () => {
     defaultSession().executions.track(handle);
 
     try {
-      const result = await sendFollowUp(parentStreamId, 'continue child');
+      const result = await submitFollowUp(parentStreamId, 'continue child');
 
       expect(result).toEqual({
         status: 'queued',
         reason: 'children_running',
+        continuation: 'resume_failed',
       });
       expect(defaultSession().followUps.getAll(parentStreamId)).toEqual([
         'continue child',
       ]);
     } finally {
       defaultSession().executions.untrack(executionId);
-      defaultSession().followUps.release(parentStreamId);
+      defaultSession().followUps.terminalize(parentStreamId);
     }
   });
 });

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -707,9 +707,9 @@ describe('runFlowWithLifecycle', () => {
     const { executionId, streamId, ctx } = lifecycleFixture(
       'lifecycle-subagent-waiting-kill',
     );
-    const followUpsRelease = vi.spyOn(
+    const followUpsTerminalize = vi.spyOn(
       ctx.runScope.session.followUps,
-      'release',
+      'terminalize',
     );
     const transcriptsUpdate = vi.spyOn(
       ctx.runScope.session.transcripts,
@@ -731,7 +731,7 @@ describe('runFlowWithLifecycle', () => {
 
       expect(result.outcome).toBe(STREAM_PHASE.WAITING);
       expect(defaultSession().executions.getHandle(executionId)).toBeDefined();
-      expect(followUpsRelease).not.toHaveBeenCalled();
+      expect(followUpsTerminalize).not.toHaveBeenCalled();
       expect(storageMocks.finalizeExecution).not.toHaveBeenCalled();
       // The fixture's ctx.logger is noopTrace, and the run handle carries it
       // as its trace channel.
@@ -783,7 +783,7 @@ describe('runFlowWithLifecycle', () => {
       expect(defaultSession().status.get(streamId)).toBe(
         STREAM_PHASE.CANCELLED,
       );
-      expect(followUpsRelease).toHaveBeenCalledWith(streamId);
+      expect(followUpsTerminalize).toHaveBeenCalledWith(streamId);
       await vi.waitFor(() =>
         expect(storageMocks.finalizeExecution).toHaveBeenCalledWith({
           executionId,

--- a/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
+++ b/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
@@ -17,8 +17,7 @@ const mocks = vi.hoisted(() => ({
   synchronizeAgentResultOutcome: vi.fn(),
   persistChildRunReport: vi.fn(),
   persistChildRunResultMeta: vi.fn(),
-  enqueueChildRunFollowUp: vi.fn(),
-  wakeChildRunFollowUp: vi.fn(),
+  deliverChildRunFollowUp: vi.fn(),
   runWithOwnedExecutionLease: vi.fn(
     (_executionId: ExecutionId, operation: () => unknown) => operation(),
   ),
@@ -54,8 +53,7 @@ vi.mock('@agent/runtime/executionOwnership', () => ({
 vi.mock('@tools/childRunDelivery', () => ({
   persistChildRunReport: mocks.persistChildRunReport,
   persistChildRunResultMeta: mocks.persistChildRunResultMeta,
-  enqueueChildRunFollowUp: mocks.enqueueChildRunFollowUp,
-  wakeChildRunFollowUp: mocks.wakeChildRunFollowUp,
+  deliverChildRunFollowUp: mocks.deliverChildRunFollowUp,
 }));
 
 import {
@@ -64,7 +62,6 @@ import {
 } from '@agent/workflowScript';
 import {
   startChildRunLoop,
-  isChildRunLoopActive,
   type ChildRunPorts,
   type ChildRunStrategy,
 } from '@agent/runtime/childRunLoop';
@@ -194,11 +191,7 @@ beforeEach(() => {
     return { kind: 'persisted' as const, msg };
   });
   mocks.persistChildRunResultMeta.mockResolvedValue({ kind: 'skipped' });
-  mocks.enqueueChildRunFollowUp.mockResolvedValue({
-    kind: 'enqueued',
-    sendResult: { status: 'sent' },
-  });
-  mocks.wakeChildRunFollowUp.mockResolvedValue({ kind: 'delivered' });
+  mocks.deliverChildRunFollowUp.mockResolvedValue({ kind: 'delivered' });
 });
 
 afterEach(() => {
@@ -226,7 +219,7 @@ describe('childRunLoop E2E fixtures', () => {
       }),
     ).toThrow('lease generation lost');
 
-    expect(isChildRunLoopActive(childStreamId)).toBe(false);
+    expect(session.followUps.hasLiveOwner(childStreamId)).toBe(false);
     expect(mocks.leaseLossListener).toBeUndefined();
     expect(callCount()).toBe(0);
   });
@@ -242,7 +235,7 @@ describe('childRunLoop E2E fixtures', () => {
     const handle = trackChildHandle(executionId, parentStreamId, childStreamId);
     const interruptHandle = vi.spyOn(handle, 'interrupt');
     const registerLoop = vi
-      .spyOn(session.executions, 'registerChildRunLoop')
+      .spyOn(session.followUps, 'claimLive')
       .mockImplementationOnce(() => {
         throw new Error('loop registration failed');
       });
@@ -270,72 +263,17 @@ describe('childRunLoop E2E fixtures', () => {
       ).toThrow('loop registration failed');
 
       expect(releaseSessionOwnership).toHaveBeenCalledOnce();
-      expect(isChildRunLoopActive(childStreamId)).toBe(false);
+      expect(session.followUps.hasLiveOwner(childStreamId)).toBe(false);
       expect(mocks.leaseLossListener).toBeUndefined();
       expect(handle.interrupt()).toBe(false);
       interruptHandle.mockClear();
       registry.interruptAll();
       expect(interruptHandle).not.toHaveBeenCalled();
-      expect(
-        session.followUps.enqueue(
-          childStreamId,
-          { text: 'must stay released' },
-          { createIfMissing: true },
-        ),
-      ).toBe(false);
+      expect(session.followUps.getAll(childStreamId)).toEqual([]);
     } finally {
       registerLoop.mockRestore();
       interruptHandle.mockRestore();
       registry.releaseByExecutionId(executionId);
-    }
-  });
-
-  it('reports rollback failures after completing later cleanup actions', () => {
-    const childStreamId = uniqueStreamId('setup-rollback-failure');
-    const parentStreamId = 'parent' as StreamTabId;
-    const executionId = 'exec-setup-rollback-failure' as ExecutionId;
-    const setupError = new Error('loop registration failed');
-    const cleanupError = new Error('queue release failed');
-    const releaseSessionOwnership = vi.fn();
-    const handle = trackChildHandle(executionId, parentStreamId, childStreamId);
-    const registerLoop = vi
-      .spyOn(session.executions, 'registerChildRunLoop')
-      .mockImplementationOnce(() => {
-        throw setupError;
-      });
-    const releaseQueue = vi
-      .spyOn(session.followUps, 'release')
-      .mockImplementationOnce(() => {
-        throw cleanupError;
-      });
-    const { strategy } = createFakeStrategy();
-    let thrown: unknown;
-
-    try {
-      try {
-        startChildRunLoop({
-          childStreamId,
-          parentStreamId,
-          executionId,
-          agentName: 'fake-cli',
-          strategy: { ...strategy, releaseSessionOwnership },
-        });
-      } catch (error) {
-        thrown = error;
-      }
-
-      expect(thrown).toBeInstanceOf(AggregateError);
-      expect((thrown as AggregateError).errors).toEqual([
-        setupError,
-        cleanupError,
-      ]);
-      expect(releaseSessionOwnership).toHaveBeenCalledOnce();
-      expect(mocks.leaseLossListener).toBeUndefined();
-      expect(handle.interrupt()).toBe(false);
-    } finally {
-      registerLoop.mockRestore();
-      releaseQueue.mockRestore();
-      session.followUps.release(childStreamId);
     }
   });
 
@@ -430,12 +368,12 @@ describe('childRunLoop E2E fixtures', () => {
         });
 
         expect(events).toEqual(['registered', 'launch']);
-        expect(isChildRunLoopActive(childStreamId)).toBe(true);
+        expect(session.followUps.hasLiveOwner(childStreamId)).toBe(true);
         interruptAll();
 
         await vi.waitFor(() => {
           expect(aborted).toHaveBeenCalledOnce();
-          expect(isChildRunLoopActive(childStreamId)).toBe(false);
+          expect(session.followUps.hasLiveOwner(childStreamId)).toBe(false);
         });
         expect(releaseSessionOwnership).toHaveBeenCalledOnce();
         expect(session.executions.getHandle(executionId)).toBeUndefined();
@@ -466,9 +404,9 @@ describe('childRunLoop E2E fixtures', () => {
     await rejectTurn(1, abortError);
 
     await vi.waitFor(() =>
-      expect(isChildRunLoopActive(childStreamId)).toBe(false),
+      expect(session.followUps.hasLiveOwner(childStreamId)).toBe(false),
     );
-    expect(mocks.enqueueChildRunFollowUp).not.toHaveBeenCalled();
+    expect(mocks.deliverChildRunFollowUp).not.toHaveBeenCalled();
   });
 
   it('persists without parent delivery in persist-only mode', async () => {
@@ -490,8 +428,8 @@ describe('childRunLoop E2E fixtures', () => {
       executionId,
       'delivered:saved',
     );
-    expect(mocks.enqueueChildRunFollowUp).not.toHaveBeenCalled();
-    expect(mocks.wakeChildRunFollowUp).not.toHaveBeenCalled();
+    expect(mocks.deliverChildRunFollowUp).not.toHaveBeenCalled();
+    expect(mocks.deliverChildRunFollowUp).not.toHaveBeenCalled();
   });
 
   it('releases session ownership before delivering a failed turn', async () => {
@@ -499,9 +437,9 @@ describe('childRunLoop E2E fixtures', () => {
     const parentStreamId = 'parent' as StreamTabId;
     const { strategy, rejectTurn } = createFakeStrategy();
     const releaseSessionOwnership = vi.fn();
-    mocks.enqueueChildRunFollowUp.mockImplementation(async () => {
+    mocks.deliverChildRunFollowUp.mockImplementation(async () => {
       expect(releaseSessionOwnership).toHaveBeenCalledOnce();
-      return { kind: 'enqueued', sendResult: { status: 'sent' } };
+      return { kind: 'delivered' };
     });
 
     startChildRunLoop({
@@ -513,11 +451,11 @@ describe('childRunLoop E2E fixtures', () => {
     });
 
     await vi.waitFor(() =>
-      expect(isChildRunLoopActive(childStreamId)).toBe(true),
+      expect(session.followUps.hasLiveOwner(childStreamId)).toBe(true),
     );
     await rejectTurn(1, new Error('initial turn failed'));
     await vi.waitFor(() =>
-      expect(isChildRunLoopActive(childStreamId)).toBe(false),
+      expect(session.followUps.hasLiveOwner(childStreamId)).toBe(false),
     );
     expect(releaseSessionOwnership).toHaveBeenCalledOnce();
   });
@@ -540,7 +478,7 @@ describe('childRunLoop E2E fixtures', () => {
     // Give the loop's async IIFE a tick to attach its interrupt handler and
     // call launch().
     await vi.waitFor(() =>
-      expect(isChildRunLoopActive(childStreamId)).toBe(true),
+      expect(session.followUps.hasLiveOwner(childStreamId)).toBe(true),
     );
 
     expect(handle.interrupt()).toBe(true);
@@ -551,10 +489,10 @@ describe('childRunLoop E2E fixtures', () => {
     await rejectTurn(1, abortError);
 
     await vi.waitFor(() =>
-      expect(isChildRunLoopActive(childStreamId)).toBe(false),
+      expect(session.followUps.hasLiveOwner(childStreamId)).toBe(false),
     );
-    expect(mocks.enqueueChildRunFollowUp).not.toHaveBeenCalled();
-    expect(mocks.wakeChildRunFollowUp).not.toHaveBeenCalled();
+    expect(mocks.deliverChildRunFollowUp).not.toHaveBeenCalled();
+    expect(mocks.deliverChildRunFollowUp).not.toHaveBeenCalled();
     expect(session.executions.getHandle(executionId)).toBeUndefined();
   });
 
@@ -566,7 +504,7 @@ describe('childRunLoop E2E fixtures', () => {
     const onTurnSuccess = vi.fn();
     const parentWake = vi.fn();
     const deliveryCompleted = pDefer<{ kind: 'delivered' }>();
-    mocks.wakeChildRunFollowUp.mockImplementation(async () => {
+    mocks.deliverChildRunFollowUp.mockImplementation(async () => {
       parentWake();
       return deliveryCompleted.promise;
     });
@@ -582,12 +520,12 @@ describe('childRunLoop E2E fixtures', () => {
     expect(onLoopStart).toHaveBeenCalledOnce();
     expect(onLoopStart).toHaveBeenCalledWith(session);
     await vi.waitFor(() =>
-      expect(isChildRunLoopActive(childStreamId)).toBe(true),
+      expect(session.followUps.hasLiveOwner(childStreamId)).toBe(true),
     );
     await resolveTurn(1, { kind: 'interim', value: 'first' });
 
     await vi.waitFor(() => {
-      expect(mocks.enqueueChildRunFollowUp).toHaveBeenCalledWith(
+      expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledWith(
         expect.objectContaining({
           targetStreamId: parentStreamId,
           followUp: expect.objectContaining({ text: 'delivered:first' }),
@@ -598,7 +536,7 @@ describe('childRunLoop E2E fixtures', () => {
     // N+1. Even input already queued during delivery must not begin another
     // model turn until the parent has received this result.
     await vi.waitFor(() =>
-      expect(mocks.wakeChildRunFollowUp).toHaveBeenCalled(),
+      expect(mocks.deliverChildRunFollowUp).toHaveBeenCalled(),
     );
     expect(onTurnSuccess).toHaveBeenCalledOnce();
     expect(onTurnSuccess.mock.invocationCallOrder[0]).toBeLessThan(
@@ -606,9 +544,13 @@ describe('childRunLoop E2E fixtures', () => {
     );
 
     // Enqueue a follow-up on the same queue the loop is now blocked on.
-    session.followUps
-      .acquire(childStreamId)
-      .enqueue({ text: 'keep going', origin: 'user' });
+    expect(
+      session.followUps.submit(
+        childStreamId,
+        { text: 'keep going', origin: 'user' },
+        'live_owner',
+      ),
+    ).toEqual({ kind: 'live' });
     expect(callCount()).toBe(1);
 
     deliveryCompleted.resolve({ kind: 'delivered' });
@@ -621,14 +563,14 @@ describe('childRunLoop E2E fixtures', () => {
     await resolveTurn(2, { kind: 'terminal', value: 'final' });
 
     await vi.waitFor(() => {
-      expect(mocks.enqueueChildRunFollowUp).toHaveBeenCalledWith(
+      expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledWith(
         expect.objectContaining({
           followUp: expect.objectContaining({ text: 'delivered:final' }),
         }),
       );
     });
     await vi.waitFor(() =>
-      expect(isChildRunLoopActive(childStreamId)).toBe(false),
+      expect(session.followUps.hasLiveOwner(childStreamId)).toBe(false),
     );
   });
 
@@ -648,7 +590,7 @@ describe('childRunLoop E2E fixtures', () => {
     });
 
     await vi.waitFor(() =>
-      expect(isChildRunLoopActive(childStreamId)).toBe(true),
+      expect(session.followUps.hasLiveOwner(childStreamId)).toBe(true),
     );
     // Interrupt the loop, then let the in-flight turn resolve normally
     // (not aborted) — mirrors a turn that was already past its own
@@ -657,15 +599,15 @@ describe('childRunLoop E2E fixtures', () => {
     await resolveTurn(1, { kind: 'terminal', value: 'late' });
 
     await vi.waitFor(() =>
-      expect(isChildRunLoopActive(childStreamId)).toBe(false),
+      expect(session.followUps.hasLiveOwner(childStreamId)).toBe(false),
     );
     expect(mocks.persistChildRunReport).toHaveBeenCalledWith(
       executionId,
       'delivered:late',
     );
     expect(releaseSessionOwnership).toHaveBeenCalledOnce();
-    expect(mocks.enqueueChildRunFollowUp).not.toHaveBeenCalled();
-    expect(mocks.wakeChildRunFollowUp).not.toHaveBeenCalled();
+    expect(mocks.deliverChildRunFollowUp).not.toHaveBeenCalled();
+    expect(mocks.deliverChildRunFollowUp).not.toHaveBeenCalled();
   });
 
   it('kill during WAITING: interrupting the loop while it is blocked between turns ends the run without a hang', async () => {
@@ -684,22 +626,22 @@ describe('childRunLoop E2E fixtures', () => {
     });
 
     await vi.waitFor(() =>
-      expect(isChildRunLoopActive(childStreamId)).toBe(true),
+      expect(session.followUps.hasLiveOwner(childStreamId)).toBe(true),
     );
     await resolveTurn(1, { kind: 'interim', value: 'first' });
 
     await vi.waitFor(() => {
-      expect(mocks.enqueueChildRunFollowUp).toHaveBeenCalled();
+      expect(mocks.deliverChildRunFollowUp).toHaveBeenCalled();
     });
     // The loop is now blocked in queue.waitAndDrainAll; the loop's handler on
     // the run handle is the live stop target.
     expect(handle.interrupt()).toBe(true);
 
     await vi.waitFor(() =>
-      expect(isChildRunLoopActive(childStreamId)).toBe(false),
+      expect(session.followUps.hasLiveOwner(childStreamId)).toBe(false),
     );
     // Only the one interim delivery — the kill did not spawn another turn.
-    expect(mocks.enqueueChildRunFollowUp).toHaveBeenCalledTimes(1);
+    expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledTimes(1);
   });
 
   it('stop between turns settles without result sync when terminal metadata fails', async () => {
@@ -732,7 +674,7 @@ describe('childRunLoop E2E fixtures', () => {
     });
 
     await vi.waitFor(() =>
-      expect(isChildRunLoopActive(childStreamId)).toBe(true),
+      expect(session.followUps.hasLiveOwner(childStreamId)).toBe(true),
     );
 
     // Mirrors what a real native turn's runFlowWithLifecycle does: track a
@@ -747,14 +689,14 @@ describe('childRunLoop E2E fixtures', () => {
 
     await resolveTurn(1, { kind: 'interim', value: 'first' });
     await vi.waitFor(() =>
-      expect(mocks.enqueueChildRunFollowUp).toHaveBeenCalledTimes(1),
+      expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledTimes(1),
     );
 
     // Loop is now between turns. Interrupt it through the run handle.
     expect(handle.interrupt()).toBe(true);
 
     await vi.waitFor(() =>
-      expect(isChildRunLoopActive(childStreamId)).toBe(false),
+      expect(session.followUps.hasLiveOwner(childStreamId)).toBe(false),
     );
 
     // Settled: handle.result resolves instead of hanging forever.
@@ -779,10 +721,10 @@ describe('childRunLoop E2E fixtures', () => {
     const executionId = 'exec-reregister-before-delivery' as ExecutionId;
     const handle = trackChildHandle(executionId, parentStreamId, childStreamId);
     let deliveryGate: DeferredPromise<void> | undefined;
-    mocks.enqueueChildRunFollowUp.mockImplementation(async () => {
+    mocks.deliverChildRunFollowUp.mockImplementation(async () => {
       deliveryGate = pDefer<void>();
       await deliveryGate.promise;
-      return { kind: 'enqueued', sendResult: { status: 'sent' } };
+      return { kind: 'delivered' };
     });
 
     const strategy: ChildRunStrategy<FakeTurn> = {
@@ -805,20 +747,20 @@ describe('childRunLoop E2E fixtures', () => {
     // window the review flagged as unprotected.
     await vi.waitFor(() => expect(deliveryGate).toBeDefined());
 
-    // The loop's own interrupt handler must already be back in place here,
-    // even though delivery has not finished.
-    expect(handle.interrupt()).toBe(true);
+    // Terminal delivery starts only after child finalization and lease release,
+    // so there is no longer a live child continuation to interrupt here.
+    expect(handle.interrupt()).toBe(false);
 
     deliveryGate?.resolve();
     await vi.waitFor(() =>
-      expect(isChildRunLoopActive(childStreamId)).toBe(false),
+      expect(session.followUps.hasLiveOwner(childStreamId)).toBe(false),
     );
   });
 
   it('#8093 regression: a terminal turn finalizes this child before its wake step is even reached, so a resumed parent never self-stalls waiting on it', async () => {
-    // Regression: `wakeChildRunFollowUp` can await the ENTIRE resumed parent
+    // Regression: parent continuation submission can await the ENTIRE resumed
     // turn (`agentResume.tryResumeStream` → … → `resumeToolUseFromResumeData`).
-    // Before #8093, the loop awaited enqueue-and-wake together, inline in the
+    // Before #8093, the loop awaited split enqueue/wake work inline in the
     // turn loop, and only finalized this child (untracking its execution
     // handle) afterward in the outer `finally` — so a resumed parent that
     // immediately calls `executions` with action=wait on this same execution
@@ -834,7 +776,7 @@ describe('childRunLoop E2E fixtures', () => {
 
     let releaseWake: (() => void) | undefined;
     let handleAtWakeTime: unknown;
-    mocks.wakeChildRunFollowUp.mockImplementation(async () => {
+    mocks.deliverChildRunFollowUp.mockImplementation(async () => {
       // Snapshot registry state the instant the wake step is reached — the
       // same moment a resumed parent's own turn would begin running.
       handleAtWakeTime = session.executions.getHandle(executionId);
@@ -866,7 +808,7 @@ describe('childRunLoop E2E fixtures', () => {
 
     releaseWake?.();
     await vi.waitFor(() =>
-      expect(isChildRunLoopActive(childStreamId)).toBe(false),
+      expect(session.followUps.hasLiveOwner(childStreamId)).toBe(false),
     );
   });
 
@@ -884,22 +826,26 @@ describe('childRunLoop E2E fixtures', () => {
     });
 
     await vi.waitFor(() =>
-      expect(isChildRunLoopActive(childStreamId)).toBe(true),
+      expect(session.followUps.hasLiveOwner(childStreamId)).toBe(true),
     );
     await resolveTurn(1, { kind: 'interim', value: 'first' });
     await vi.waitFor(() => {
-      expect(mocks.enqueueChildRunFollowUp).toHaveBeenCalledTimes(1);
+      expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledTimes(1);
     });
 
-    session.followUps
-      .acquire(childStreamId)
-      .enqueue({ text: 'resume please', origin: 'user' });
+    expect(
+      session.followUps.submit(
+        childStreamId,
+        { text: 'resume please', origin: 'user' },
+        'live_owner',
+      ),
+    ).toEqual({ kind: 'live' });
 
     const resumeFailure = new Error('resume storage unreadable');
     await rejectTurn(2, resumeFailure);
 
     await vi.waitFor(() => {
-      expect(mocks.enqueueChildRunFollowUp).toHaveBeenCalledWith(
+      expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledWith(
         expect.objectContaining({
           followUp: expect.objectContaining({ text: 'error:thrown' }),
         }),
@@ -907,7 +853,7 @@ describe('childRunLoop E2E fixtures', () => {
     });
     expect(errors).toContain(resumeFailure);
     await vi.waitFor(() =>
-      expect(isChildRunLoopActive(childStreamId)).toBe(false),
+      expect(session.followUps.hasLiveOwner(childStreamId)).toBe(false),
     );
   });
 
@@ -925,19 +871,19 @@ describe('childRunLoop E2E fixtures', () => {
     });
 
     await vi.waitFor(() =>
-      expect(isChildRunLoopActive(childStreamId)).toBe(true),
+      expect(session.followUps.hasLiveOwner(childStreamId)).toBe(true),
     );
     await resolveTurn(1, { kind: 'error-turn', value: 'oops' });
 
     await vi.waitFor(() => {
-      expect(mocks.enqueueChildRunFollowUp).toHaveBeenCalledWith(
+      expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledWith(
         expect.objectContaining({
           followUp: expect.objectContaining({ text: 'error:oops' }),
         }),
       );
     });
     await vi.waitFor(() =>
-      expect(isChildRunLoopActive(childStreamId)).toBe(false),
+      expect(session.followUps.hasLiveOwner(childStreamId)).toBe(false),
     );
   });
 
@@ -956,7 +902,7 @@ describe('childRunLoop E2E fixtures', () => {
     });
 
     await vi.waitFor(() =>
-      expect(isChildRunLoopActive(childStreamId)).toBe(true),
+      expect(session.followUps.hasLiveOwner(childStreamId)).toBe(true),
     );
 
     const handle = trackChildHandle(
@@ -969,7 +915,7 @@ describe('childRunLoop E2E fixtures', () => {
     await resolveTurn(1, { kind: 'error-turn', value: 'oops' });
 
     await vi.waitFor(() =>
-      expect(isChildRunLoopActive(childStreamId)).toBe(false),
+      expect(session.followUps.hasLiveOwner(childStreamId)).toBe(false),
     );
     await expect(handle.result).resolves.toMatchObject({
       outcome: 'failed',
@@ -1022,16 +968,20 @@ describe('childRunLoop E2E fixtures', () => {
     });
 
     await vi.waitFor(() =>
-      expect(isChildRunLoopActive(childStreamId)).toBe(true),
+      expect(session.followUps.hasLiveOwner(childStreamId)).toBe(true),
     );
     launchResolve?.({ kind: 'interim', value: 'first' });
     await vi.waitFor(() =>
-      expect(mocks.enqueueChildRunFollowUp).toHaveBeenCalledTimes(1),
+      expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledTimes(1),
     );
 
-    session.followUps
-      .acquire(childStreamId)
-      .enqueue({ text: 'go on', origin: 'user' });
+    expect(
+      session.followUps.submit(
+        childStreamId,
+        { text: 'go on', origin: 'user' },
+        'live_owner',
+      ),
+    ).toEqual({ kind: 'live' });
     // Waits for the loop to have actually invoked runTurn (calls increments
     // synchronously inside it) — not for the queue to read empty, which can
     // happen before the loop's own continuation runs (see the "delegate →
@@ -1040,7 +990,7 @@ describe('childRunLoop E2E fixtures', () => {
     runTurnResolve?.({ kind: 'terminal', value: 'final' });
 
     await vi.waitFor(() =>
-      expect(isChildRunLoopActive(childStreamId)).toBe(false),
+      expect(session.followUps.hasLiveOwner(childStreamId)).toBe(false),
     );
     expect(recordCost).toHaveBeenCalledTimes(1);
     expect(recordCost).toHaveBeenCalledWith(0.2);
@@ -1124,7 +1074,7 @@ describe('childRunLoop E2E fixtures', () => {
 
     await expect(completion).resolves.toBeUndefined();
     expect(recordCost).toHaveBeenCalledOnce();
-    expect(mocks.wakeChildRunFollowUp).toHaveBeenCalledOnce();
+    expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledOnce();
   });
 
   it('finalizes and wakes when the parent cost observer rejects', async () => {
@@ -1153,6 +1103,6 @@ describe('childRunLoop E2E fixtures', () => {
 
     await expect(completion).resolves.toBeUndefined();
     await vi.waitFor(() => expect(recordCost).toHaveBeenCalledOnce());
-    expect(mocks.wakeChildRunFollowUp).toHaveBeenCalledOnce();
+    expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledOnce();
   });
 });

--- a/src/test-kernel/agent/runtime/ExecutionSubscriptionBinderSession.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionSubscriptionBinderSession.vitest.ts
@@ -6,14 +6,14 @@ type MockSendFollowUpResult =
   | { status: 'queued'; reason: 'waiting' }
   | { status: 'no_session'; streamStatus: string | undefined };
 
-const sendFollowUpMock = vi.hoisted(() =>
+const submitFollowUpMock = vi.hoisted(() =>
   vi.fn<(...args: unknown[]) => Promise<MockSendFollowUpResult>>(async () => ({
     status: 'sent',
   })),
 );
 
 vi.mock('@agent/followUp/ToolUseFollowUp', () => ({
-  sendFollowUp: sendFollowUpMock,
+  submitFollowUp: submitFollowUpMock,
 }));
 
 // Local imports
@@ -150,8 +150,8 @@ describe('ExecutionSubscriptionBinder lifecycle', () => {
 
 describe('ExecutionSubscriptionBinder session routing', () => {
   beforeEach(() => {
-    sendFollowUpMock.mockReset();
-    sendFollowUpMock.mockResolvedValue({ status: 'sent' as const });
+    submitFollowUpMock.mockReset();
+    submitFollowUpMock.mockResolvedValue({ status: 'sent' as const });
   });
 
   it('passes the owning session to subscription follow-ups', async () => {
@@ -175,12 +175,10 @@ describe('ExecutionSubscriptionBinder session routing', () => {
       registry.untrack(executionId);
       await settleDelivery();
 
-      expect(sendFollowUpMock).toHaveBeenCalledWith(
+      expect(submitFollowUpMock).toHaveBeenCalledWith(
         streamId,
         expect.stringContaining(executionId),
-        undefined,
-        undefined,
-        session,
+        { session, mode: 'live_notification' },
       );
       expect(recorded.events).toEqual([
         {
@@ -220,7 +218,7 @@ describe('ExecutionSubscriptionBinder session routing', () => {
       });
       const executionId = `exec-subscription-${sendResult.status}-event-test`;
       const handle = createSearchHandle(executionId, explicit.host);
-      sendFollowUpMock.mockResolvedValueOnce(sendResult);
+      submitFollowUpMock.mockResolvedValueOnce(sendResult);
 
       try {
         registry.track(handle);
@@ -310,7 +308,7 @@ describe('ExecutionSubscriptionBinder session routing', () => {
     const executionId = 'exec-subscription-rejection-test';
     const handle = createSearchHandle(executionId, explicit.host);
     const unhandledRejection = vi.fn();
-    sendFollowUpMock.mockRejectedValueOnce(new Error('delivery failed'));
+    submitFollowUpMock.mockRejectedValueOnce(new Error('delivery failed'));
 
     try {
       process.once('unhandledRejection', unhandledRejection);

--- a/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
@@ -374,10 +374,5 @@ describe('SessionHandle', () => {
     expect(() =>
       trackAgent(session, host, 'exec:late', 'stream:late' as StreamTabId),
     ).toThrow('Cannot register execution work after session disposal.');
-    expect(() =>
-      session.executions.registerChildRunLoop(
-        'stream:late-child' as StreamTabId,
-      ),
-    ).toThrow('Cannot register execution work after session disposal.');
   });
 });

--- a/src/test-kernel/agent/runtime/SessionScope.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionScope.vitest.ts
@@ -11,7 +11,7 @@ import { describe, expect, it } from 'vitest';
 // Local imports
 import { SessionHandle, defaultSession } from '@agent/runtime/SessionHandle';
 import { AgentExecutionHandle } from '@agent/runtime/ExecutionHandle';
-import { sendFollowUp } from '@agent/followUp/ToolUseFollowUp';
+import { submitFollowUp } from '@agent/followUp/ToolUseFollowUp';
 import { MESSAGE_TYPES, type Plan, type StreamTabId } from '@shared/schemas';
 import { createTestSession } from '@test/support/sessionTestUtils';
 import { cleanupAllApprovals } from '@tools/approval';
@@ -112,12 +112,10 @@ describe('session-owned transcripts and follow-up queues (Stage 3a)', () => {
     const streamId = 'stream:session-followups' as StreamTabId;
 
     try {
-      a.followUps.acquire(streamId);
-      b.followUps.acquire(streamId);
-      a.followUps.enqueue(streamId, { text: 'from a' });
-      b.followUps.enqueue(streamId, { text: 'from b' });
+      a.followUps.submit(streamId, { text: 'from a' }, 'recoverable');
+      b.followUps.submit(streamId, { text: 'from b' }, 'recoverable');
 
-      a.followUps.release(streamId);
+      a.followUps.terminalize(streamId);
 
       expect(a.followUps.getAll(streamId)).toEqual([]);
       expect(b.followUps.getAll(streamId)).toEqual(['from b']);
@@ -190,24 +188,25 @@ describe('sendFollowUp host-path session routing (SDK Step 7d PR 4)', () => {
       // A host-path caller (outside any run ALS, like the desktop IPC handler)
       // that passes its process session sees the live child and queues.
       await expect(
-        sendFollowUp(
-          parentStream,
-          'continue',
-          undefined,
-          undefined,
-          processSession,
-        ),
-      ).resolves.toEqual({ status: 'queued', reason: 'children_running' });
+        submitFollowUp(parentStream, 'continue', {
+          session: processSession,
+          resumePort: { tryResumeStream: async () => false },
+        }),
+      ).resolves.toEqual({
+        status: 'queued',
+        reason: 'children_running',
+        continuation: 'resume_failed',
+      });
 
       // Without the session it falls back to the default session, which does
       // not track this run — this is the dropped-follow-up regression the
       // session parameter prevents on desktop.
-      await expect(sendFollowUp(parentStream, 'continue')).resolves.toEqual({
+      await expect(submitFollowUp(parentStream, 'continue')).resolves.toEqual({
         status: 'no_session',
         streamStatus: undefined,
       });
     } finally {
-      processSession.followUps.release(parentStream);
+      processSession.followUps.terminalize(parentStream);
       processSession.dispose();
     }
   });

--- a/src/test-kernel/agent/runtime/resolveAndResumeStream.vitest.ts
+++ b/src/test-kernel/agent/runtime/resolveAndResumeStream.vitest.ts
@@ -10,7 +10,6 @@ vi.mock('@agent/runtime/SessionResumeRetrieval', () => ({
 }));
 
 import {
-  isResumeInFlight,
   resolveAndResumeStream,
   type ResumeStreamPorts,
 } from '@agent/runtime/resolveAndResumeStream';
@@ -60,7 +59,7 @@ describe('resolveAndResumeStream', () => {
     const ports = basePorts();
 
     await expect(resolveAndResumeStream(STREAM, ports)).resolves.toBe(true);
-    expect(ports.resumeToolUse).toHaveBeenCalledWith(snapshot);
+    expect(ports.resumeToolUse).toHaveBeenCalledWith(snapshot, undefined);
     expect(ports.executeWorkflow).not.toHaveBeenCalled();
   });
 
@@ -87,7 +86,7 @@ describe('resolveAndResumeStream', () => {
       expect.anything(),
       { parentStreamId },
     );
-    expect(ports.resumeToolUse).toHaveBeenCalledWith(snapshot);
+    expect(ports.resumeToolUse).toHaveBeenCalledWith(snapshot, undefined);
   });
 
   it('launches workflow resumes without pre-acquiring the stream', async () => {
@@ -152,7 +151,6 @@ describe('resolveAndResumeStream', () => {
     await expect(resolveAndResumeStream(STREAM, ports)).resolves.toBe(false);
     expect(ports.resolveResumeState).not.toHaveBeenCalled();
     expect(retrieveSessionResumeDataMock).not.toHaveBeenCalled();
-    expect(isResumeInFlight(STREAM)).toBe(false);
   });
 
   it('stops after persisted state resolution when cancellation arrives', async () => {
@@ -172,7 +170,6 @@ describe('resolveAndResumeStream', () => {
     expect(retrieveSessionResumeDataMock).not.toHaveBeenCalled();
     expect(ports.resumeToolUse).not.toHaveBeenCalled();
     expect(ports.executeWorkflow).not.toHaveBeenCalled();
-    expect(isResumeInFlight(STREAM)).toBe(false);
   });
 
   it('stops after resume-data retrieval when cancellation arrives', async () => {
@@ -188,7 +185,6 @@ describe('resolveAndResumeStream', () => {
     await expect(resolveAndResumeStream(STREAM, ports)).resolves.toBe(false);
     expect(ports.resumeToolUse).not.toHaveBeenCalled();
     expect(ports.executeWorkflow).not.toHaveBeenCalled();
-    expect(isResumeInFlight(STREAM)).toBe(false);
   });
 
   it('guards against the injected session machine, not the process default (#7640)', async () => {
@@ -261,11 +257,9 @@ describe('resolveAndResumeStream', () => {
 
     const pending = resolveAndResumeStream(STREAM, ports);
     await reportStarted;
-    expect(isResumeInFlight(STREAM)).toBe(true);
 
     release();
     await expect(pending).resolves.toBe(false);
-    expect(isResumeInFlight(STREAM)).toBe(false);
   });
 
   it('surfaces a retrieval failure without leaking the in-flight slot', async () => {
@@ -275,7 +269,6 @@ describe('resolveAndResumeStream', () => {
 
     await expect(resolveAndResumeStream(STREAM, ports)).resolves.toBe(false);
     expect(ports.reportFailure).toHaveBeenCalledWith(STREAM, error);
-    expect(isResumeInFlight(STREAM)).toBe(false);
   });
 
   it('keeps the in-flight guard until async failure reporting completes', async () => {
@@ -298,11 +291,9 @@ describe('resolveAndResumeStream', () => {
 
     const pending = resolveAndResumeStream(STREAM, ports);
     await reportStarted;
-    expect(isResumeInFlight(STREAM)).toBe(true);
 
     release();
     await expect(pending).resolves.toBe(false);
-    expect(isResumeInFlight(STREAM)).toBe(false);
   });
 
   it('reports in-flight while preparing and clears it once settled', async () => {
@@ -327,10 +318,8 @@ describe('resolveAndResumeStream', () => {
 
     const pending = resolveAndResumeStream(STREAM, ports);
     await reached;
-    expect(isResumeInFlight(STREAM)).toBe(true);
 
     release();
     await expect(pending).resolves.toBe(true);
-    expect(isResumeInFlight(STREAM)).toBe(false);
   });
 });

--- a/src/test-kernel/agent/runtime/resumeQueuedToolUse.vitest.ts
+++ b/src/test-kernel/agent/runtime/resumeQueuedToolUse.vitest.ts
@@ -1,628 +1,123 @@
-// Test composition imports
-import '@test/support/defaultSessionTestSetup';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Test support imports
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { FollowUpQueueInput } from '@agent/followUp/FollowUpQueue';
-import { AgentExecutionHandle } from '@agent/runtime/ExecutionHandle';
-import { ResumeAdmissionCancelledError } from '@agent/runtime/resumeAdmission';
-import { defaultSession } from '@agent/runtime/SessionHandle';
 import { resumeQueuedToolUseFromResumeData } from '@agent/runtime/resumeQueuedToolUse';
-import {
-  RUN_OUTCOME,
-  STREAM_PHASE,
-  STREAM_STATUS,
-  type ExecutionId,
-  type StreamTabId,
-} from '@shared/schemas';
+import type { StreamTabId } from '@shared/schemas';
+import { RUN_OUTCOME } from '@shared/schemas';
 import { createTestSession } from '@test/support/sessionTestUtils';
 import { createToolUseResumeData } from '@test/support/toolUseResumeTestUtils';
 
-const resumeToolUseFromResumeDataMock = vi.hoisted(() =>
-  vi.fn(async (..._args: unknown[]): Promise<unknown> => undefined),
-);
-
+const resumeToolUseFromResumeDataMock = vi.hoisted(() => vi.fn());
 vi.mock('@agent/runtime/executeAgent', () => ({
   resumeToolUseFromResumeData: resumeToolUseFromResumeDataMock,
 }));
 
-import {
-  clearStreamStatusForTest,
-  seedStreamStatusForTest,
-} from '@test/helpers/streamStatusTestUtils';
-import {
-  createRecordingHost,
-  recordSessionEvents,
-  sessionFactPayloads,
-} from '../progressTestUtils';
-
-const STREAM = 'stream:tooluse-resume' as StreamTabId;
+const STREAM = 'stream:resume-ownership' as StreamTabId;
 const runtimeHost = { emit: vi.fn() };
-let recordedSession: ReturnType<typeof recordSessionEvents> | undefined;
+const completed = {
+  category: 'toolUse' as const,
+  outcome: RUN_OUTCOME.COMPLETED,
+  executionId: 'exec:resume',
+  streamId: STREAM,
+  lastResponse: 'done',
+  touchedFiles: [],
+  totalCostUsd: 0,
+};
 
-function snapshot(parentStreamId?: StreamTabId) {
-  return createToolUseResumeData({ streamId: STREAM, parentStreamId });
+function snapshot() {
+  return createToolUseResumeData({ streamId: STREAM });
 }
 
-interface CapturedResumeOptions {
-  parentStreamId?: StreamTabId;
-  isCancellationRequested?: () => boolean;
-  drainedFollowUps?: readonly FollowUpQueueInput[];
-  takePendingFollowUps: () => readonly FollowUpQueueInput[];
-  onFollowUpConsumed?: () => void;
-  onCancellationAtFlowAttachment?: () => void;
+function seedRecoverable(
+  session: ReturnType<typeof createTestSession>,
+  ...texts: string[]
+): void {
+  const flow = session.followUps.claimLive(STREAM, 'flow')!;
+  for (const text of texts) session.followUps.queue(flow).enqueue({ text });
+  session.followUps.release(flow, 'recoverable');
 }
 
-function capturedResumeOptions(): CapturedResumeOptions {
-  const calls = resumeToolUseFromResumeDataMock.mock
-    .calls as unknown as unknown[][];
-  return calls.at(-1)?.[2] as CapturedResumeOptions;
-}
-
-/** Capture the callback that closes the queue gap at flow attachment. */
-function capturedTakePendingFollowUps(): () => readonly FollowUpQueueInput[] {
-  const options = capturedResumeOptions();
-  return options.takePendingFollowUps;
-}
-
-describe('resumeQueuedToolUseFromResumeData', () => {
+describe('resumeQueuedToolUseFromResumeData ownership', () => {
   beforeEach(() => {
     resumeToolUseFromResumeDataMock.mockReset();
     resumeToolUseFromResumeDataMock.mockImplementation(
-      async (...args: unknown[]) => {
-        const options = args[2] as CapturedResumeOptions;
+      async (_resume: unknown, _host: unknown, options: any) => {
         options.onFollowUpConsumed?.();
-        return undefined;
+        return completed;
       },
     );
-    runtimeHost.emit.mockReset();
-    recordedSession = recordSessionEvents(defaultSession().events, {
-      scope: 'session',
-    });
   });
 
-  afterEach(() => {
-    recordedSession?.detach();
-    recordedSession = undefined;
-    defaultSession().followUps.release(STREAM);
-    clearStreamStatusForTest(defaultSession().status, STREAM);
-  });
-
-  it('drains queued follow-ups, hands them to the flow, and notifies the UI', async () => {
-    defaultSession().followUps.enqueue(
-      STREAM,
-      { text: 'queued one' },
-      { force: true },
-    );
-
-    await expect(
-      resumeQueuedToolUseFromResumeData(STREAM, snapshot(), runtimeHost, {
-        onError: vi.fn(),
-      }),
-    ).resolves.toBe(true);
-
-    // The initial batch travels via the direct drainedFollowUps handoff (a
-    // subagent's WAITING cursor never reads the stream queue). The attachment
-    // drain supplies any item that arrived before the live context existed.
-    expect(capturedResumeOptions().drainedFollowUps).toEqual([
-      {
-        text: 'queued one',
-        displayText: undefined,
-        mediaFiles: undefined,
-        origin: 'user',
-      },
-    ]);
-    expect(capturedTakePendingFollowUps()()).toEqual([]);
-    expect(
-      sessionFactPayloads(
-        recordedSession?.events ?? [],
-        'updateQueuedFollowUps',
-      ),
-    ).toContainEqual({ streamId: STREAM });
-  });
-
-  it('does not resume after waiting termination is claimed', async () => {
+  it('claims recovery before draining and preserves ordered raced input', async () => {
     const session = createTestSession();
-    const executionId = 'exec-waiting-termination-claimed' as ExecutionId;
-    const resume = createToolUseResumeData({ executionId, streamId: STREAM });
-    let finishCleanup = (): void => undefined;
-    const cleanupGate = new Promise<void>((resolve) => {
-      finishCleanup = resolve;
-    });
-    const handle = new AgentExecutionHandle(
-      executionId,
-      'parent-waiting-termination-claimed' as StreamTabId,
-      STREAM,
-      'test-agent',
-      'toolUse',
-      createRecordingHost().host,
-    );
+    seedRecoverable(session, 'first');
 
     try {
-      session.executions.track(handle);
-      handle.registerWaitingCleanup(async () => cleanupGate);
-      seedStreamStatusForTest(session.status, STREAM, STREAM_STATUS.WAITING);
-      session.followUps.enqueue(
-        STREAM,
-        { text: 'do not resume' },
-        { force: true },
-      );
-
-      expect(session.executions.kill(executionId)).toBe(true);
-      expect(handle.waitingTerminationStarted).toBe(true);
-      await expect(
-        resumeQueuedToolUseFromResumeData(STREAM, resume, runtimeHost, {
-          session,
-          onError: vi.fn(),
-        }),
-      ).resolves.toBe(false);
-
-      expect(resumeToolUseFromResumeDataMock).not.toHaveBeenCalled();
-      expect(session.followUps.getAll(STREAM)).toEqual(['do not resume']);
-      expect(session.status.get(STREAM)).toBe(STREAM_PHASE.WAITING);
-    } finally {
-      handle.markExecutionLeaseLost();
-      finishCleanup();
-      await handle.result;
-      session.dispose();
-    }
-  });
-
-  it('seeds an explicit follow-up ahead of the queued items', async () => {
-    defaultSession().followUps.enqueue(
-      STREAM,
-      { text: 'queued one' },
-      { force: true },
-    );
-
-    await resumeQueuedToolUseFromResumeData(STREAM, snapshot(), runtimeHost, {
-      extraFollowUps: [{ text: 'typed alongside resume', origin: 'user' }],
-      onError: vi.fn(),
-    });
-
-    expect(
-      capturedResumeOptions().drainedFollowUps?.map((item) => item.text),
-    ).toEqual(['typed alongside resume', 'queued one']);
-  });
-
-  it('keeps ready-boundary and setup-race follow-ups in order', async () => {
-    const onFollowUpQueueReady = vi.fn(() => {
-      defaultSession().followUps.enqueue(STREAM, {
-        text: 'queued at the ready boundary',
-      });
-    });
-    let attachmentFollowUps: readonly FollowUpQueueInput[] = [];
-    resumeToolUseFromResumeDataMock.mockImplementationOnce(
-      async (...args: unknown[]) => {
-        const options = args[2] as ReturnType<typeof capturedResumeOptions>;
-        defaultSession().followUps.enqueue(STREAM, {
-          text: 'queued after the initial drain',
-        });
-        attachmentFollowUps = options.takePendingFollowUps();
-        options.onFollowUpConsumed?.();
-      },
-    );
-
-    await resumeQueuedToolUseFromResumeData(STREAM, snapshot(), runtimeHost, {
-      onFollowUpQueueReady,
-      onError: vi.fn(),
-    });
-
-    expect(onFollowUpQueueReady).toHaveBeenCalledOnce();
-    expect(
-      [
-        ...(capturedResumeOptions().drainedFollowUps ?? []),
-        ...attachmentFollowUps,
-      ].map((item) => item.text),
-    ).toEqual([
-      'queued at the ready boundary',
-      'queued after the initial drain',
-    ]);
-  });
-
-  it('claims a follow-up queued during an orphaned host-resumed subagent turn after it parks', async () => {
-    let postParkFollowUps: readonly FollowUpQueueInput[] = [];
-    resumeToolUseFromResumeDataMock.mockImplementationOnce(
-      async (...args: unknown[]) => {
-        const options = args[2] as ReturnType<typeof capturedResumeOptions>;
-        expect(options.takePendingFollowUps()).toEqual([]);
-
-        defaultSession().followUps.enqueue(STREAM, {
-          text: 'queued during the active turn',
-        });
-        postParkFollowUps = options.takePendingFollowUps();
-        options.onFollowUpConsumed?.();
-        return {
-          category: 'toolUse',
-          outcome: STREAM_PHASE.WAITING,
-          executionId: 'exec-orphan-waiting',
-          streamId: STREAM,
-        };
-      },
-    );
-
-    await expect(
-      resumeQueuedToolUseFromResumeData(STREAM, snapshot(), runtimeHost, {
-        onError: vi.fn(),
-      }),
-    ).resolves.toBe(true);
-
-    expect(postParkFollowUps.map((item) => item.text)).toEqual([
-      'queued during the active turn',
-    ]);
-    expect(defaultSession().followUps.getAll(STREAM)).toEqual([]);
-  });
-
-  it('restores a post-park batch exactly once when cancellation wins before consumption', async () => {
-    resumeToolUseFromResumeDataMock.mockImplementationOnce(
-      async (...args: unknown[]) => {
-        const options = args[2] as ReturnType<typeof capturedResumeOptions>;
-        expect(options.takePendingFollowUps()).toEqual([]);
-
-        defaultSession().followUps.enqueue(STREAM, {
-          text: 'late input before cancellation',
-        });
-        expect(options.takePendingFollowUps().map((item) => item.text)).toEqual(
-          ['late input before cancellation'],
-        );
-        seedStreamStatusForTest(
-          defaultSession().status,
-          STREAM,
-          STREAM_PHASE.CANCELLED,
-        );
-        return {
-          category: 'toolUse',
-          outcome: RUN_OUTCOME.CANCELLED,
-          executionId: 'exec-orphan-cancelled',
-          streamId: STREAM,
-        };
-      },
-    );
-
-    await expect(
-      resumeQueuedToolUseFromResumeData(STREAM, snapshot(), runtimeHost, {
-        onError: vi.fn(),
-      }),
-    ).resolves.toBe(false);
-
-    expect(defaultSession().followUps.getAll(STREAM)).toEqual([
-      'late input before cancellation',
-    ]);
-  });
-
-  it('leaves post-park input to a registered child loop', async () => {
-    const unregisterChildRunLoop =
-      defaultSession().executions.registerChildRunLoop(STREAM);
-    try {
-      resumeToolUseFromResumeDataMock.mockImplementationOnce(
-        async (...args: unknown[]) => {
-          const options = args[2] as ReturnType<typeof capturedResumeOptions>;
-          expect(options.takePendingFollowUps()).toEqual([]);
-
-          defaultSession().followUps.enqueue(STREAM, {
-            text: 'next loop-backed turn',
-          });
-          expect(options.takePendingFollowUps()).toEqual([]);
-          return {
-            category: 'toolUse',
-            outcome: STREAM_PHASE.WAITING,
-            executionId: 'exec-loop-waiting',
-            streamId: STREAM,
-          };
-        },
-      );
-
       await expect(
         resumeQueuedToolUseFromResumeData(STREAM, snapshot(), runtimeHost, {
+          session,
+          onFollowUpQueueReady: () => {
+            expect(
+              session.followUps.submit(
+                STREAM,
+                { text: 'second' },
+                'recoverable',
+              ),
+            ).toEqual({ kind: 'recovering' });
+          },
           onError: vi.fn(),
         }),
       ).resolves.toBe(true);
 
-      expect(defaultSession().followUps.getAll(STREAM)).toEqual([
-        'next loop-backed turn',
+      const options = resumeToolUseFromResumeDataMock.mock.calls[0]?.[2];
+      expect(options.drainedFollowUps.map((item: any) => item.text)).toEqual([
+        'first',
+        'second',
       ]);
     } finally {
-      unregisterChildRunLoop();
+      session.dispose();
     }
   });
 
-  it('passes snapshot parent stream identity to the leaf resume', async () => {
-    const parentStreamId = 'stream:parent' as StreamTabId;
-
-    await resumeQueuedToolUseFromResumeData(
-      STREAM,
-      snapshot(parentStreamId),
-      runtimeHost,
-      { onError: vi.fn() },
-    );
-
-    expect(capturedResumeOptions().parentStreamId).toBe(parentStreamId);
-  });
-
-  it('keeps an explicit queue parent stream ahead of the snapshot parent', async () => {
-    const explicitParent = 'stream:explicit-parent' as StreamTabId;
-    const snapshotParent = 'stream:snapshot-parent' as StreamTabId;
-
-    await resumeQueuedToolUseFromResumeData(
-      STREAM,
-      snapshot(snapshotParent),
-      runtimeHost,
-      {
-        parentStreamId: explicitParent,
-        onError: vi.fn(),
-      },
-    );
-
-    expect(capturedResumeOptions().parentStreamId).toBe(explicitParent);
-  });
-
-  it('restores drained follow-ups when cancellation reaches flow setup', async () => {
-    defaultSession().followUps.enqueue(
-      STREAM,
-      { text: 'queued one' },
-      { force: true },
-    );
-    const isCancellationRequested = vi.fn(() => true);
-    resumeToolUseFromResumeDataMock.mockImplementationOnce(
-      async (...args: unknown[]) => {
-        const options = args[2] as ReturnType<typeof capturedResumeOptions>;
-        expect(options.isCancellationRequested).toBe(isCancellationRequested);
-        defaultSession().followUps.enqueue(
-          STREAM,
-          { text: 'queued during resume' },
-          { force: true },
-        );
-        if (options.isCancellationRequested?.()) {
-          options.onCancellationAtFlowAttachment?.();
-        }
-        options.takePendingFollowUps();
-        seedStreamStatusForTest(
-          defaultSession().status,
-          STREAM,
-          STREAM_PHASE.CANCELLED,
-        );
-      },
-    );
-
-    await expect(
-      resumeQueuedToolUseFromResumeData(STREAM, snapshot(), runtimeHost, {
-        isCancellationRequested,
-        onError: vi.fn(),
-      }),
-    ).resolves.toBe(false);
-
-    expect(defaultSession().followUps.getAll(STREAM)).toEqual([
-      'queued one',
-      'queued during resume',
-    ]);
-    expect(defaultSession().status.get(STREAM)).toBe(STREAM_STATUS.WAITING);
-  });
-
-  it('restores an unconsumed batch when cancellation lands after attachment', async () => {
-    defaultSession().followUps.enqueue(
-      STREAM,
-      { text: 'queued one' },
-      { force: true },
-    );
-    resumeToolUseFromResumeDataMock.mockImplementationOnce(
-      async (...args: unknown[]) => {
-        const options = args[2] as ReturnType<typeof capturedResumeOptions>;
-        options.takePendingFollowUps();
-        seedStreamStatusForTest(
-          defaultSession().status,
-          STREAM,
-          STREAM_PHASE.CANCELLED,
-        );
-        return {
-          category: 'toolUse',
-          outcome: RUN_OUTCOME.CANCELLED,
-          executionId: 'exec-cancelled',
-          streamId: STREAM,
-        };
-      },
-    );
-
-    await expect(
-      resumeQueuedToolUseFromResumeData(STREAM, snapshot(), runtimeHost, {
-        isCancellationRequested: () => false,
-        onError: vi.fn(),
-      }),
-    ).resolves.toBe(false);
-
-    expect(defaultSession().followUps.getAll(STREAM)).toEqual(['queued one']);
-    expect(defaultSession().status.get(STREAM)).toBe(STREAM_STATUS.WAITING);
-  });
-
-  it('restores drained follow-ups once when cancellation result handling throws', async () => {
-    const failure = new Error('result callback failed');
-    const reportFailure = vi.fn();
-    defaultSession().followUps.enqueue(
-      STREAM,
-      { text: 'queued one' },
-      { force: true },
-    );
-    resumeToolUseFromResumeDataMock.mockImplementationOnce(
-      async (...args: unknown[]) => {
-        const options = args[2] as ReturnType<typeof capturedResumeOptions>;
-        options.takePendingFollowUps();
-      },
-    );
-
-    await expect(
-      resumeQueuedToolUseFromResumeData(STREAM, snapshot(), runtimeHost, {
-        isCancellationRequested: () => true,
-        onResult: () => {
-          throw failure;
-        },
-        onError: reportFailure,
-      }),
-    ).resolves.toBe(false);
-
-    expect(defaultSession().followUps.getAll(STREAM)).toEqual(['queued one']);
-    expect(reportFailure).toHaveBeenCalledWith(failure);
-    expect(
-      sessionFactPayloads(
-        recordedSession?.events ?? [],
-        'updateQueuedFollowUps',
-      ),
-    ).toHaveLength(2);
-  });
-
-  it('does not restore a consumed batch when cancellation result handling throws', async () => {
-    const failure = new Error('result callback failed');
-    const reportFailure = vi.fn();
-    let cancellationRequested = false;
-    const isCancellationRequested = vi.fn(() => cancellationRequested);
-    defaultSession().followUps.enqueue(
-      STREAM,
-      { text: 'queued one' },
-      { force: true },
-    );
-    resumeToolUseFromResumeDataMock.mockImplementationOnce(
-      async (...args: unknown[]) => {
-        const options = args[2] as ReturnType<typeof capturedResumeOptions>;
-        options.takePendingFollowUps();
-        options.onFollowUpConsumed?.();
-        cancellationRequested = true;
-        seedStreamStatusForTest(
-          defaultSession().status,
-          STREAM,
-          STREAM_PHASE.CANCELLED,
-        );
-      },
-    );
-
-    await expect(
-      resumeQueuedToolUseFromResumeData(STREAM, snapshot(), runtimeHost, {
-        isCancellationRequested,
-        onResult: () => {
-          throw failure;
-        },
-        onError: reportFailure,
-      }),
-    ).resolves.toBe(false);
-
-    expect(defaultSession().followUps.getAll(STREAM)).toEqual([]);
-    expect(reportFailure).toHaveBeenCalledWith(failure);
-    expect(
-      sessionFactPayloads(
-        recordedSession?.events ?? [],
-        'updateQueuedFollowUps',
-      ),
-    ).toHaveLength(1);
-  });
-
-  it('treats a subagent parking back to WAITING as success without replaying follow-ups', async () => {
-    // Host-path resume of a WAITING subagent (e.g. a follow-up sent to a
-    // child stream from the progress view): the turn completes and the wait
-    // node parks the stream WAITING again. That is success — no failure
-    // surface, and the consumed follow-up must not be re-enqueued.
-    const reportFailure = vi.fn();
-    defaultSession().followUps.enqueue(
-      STREAM,
-      { text: 'queued one' },
-      { force: true },
-    );
-    resumeToolUseFromResumeDataMock.mockImplementationOnce(
-      async (...args: unknown[]) => {
-        const options = args[2] as ReturnType<typeof capturedResumeOptions>;
-        options.takePendingFollowUps();
-        options.onFollowUpConsumed?.();
-        seedStreamStatusForTest(
-          defaultSession().status,
-          STREAM,
-          STREAM_PHASE.WAITING,
-        );
-        return {
-          category: 'toolUse',
-          outcome: STREAM_PHASE.WAITING,
-          executionId: 'exec-waiting',
-          streamId: STREAM,
-        };
-      },
-    );
-
-    await expect(
-      resumeQueuedToolUseFromResumeData(
-        STREAM,
-        snapshot('stream:parent' as StreamTabId),
-        runtimeHost,
-        {
-          extraFollowUps: [{ text: 'talk to the subagent', origin: 'user' }],
-          onError: reportFailure,
-        },
-      ),
-    ).resolves.toBe(true);
-
-    expect(
-      capturedResumeOptions().drainedFollowUps?.map((item) => item.text),
-    ).toEqual(['talk to the subagent', 'queued one']);
-    expect(reportFailure).not.toHaveBeenCalled();
-    expect(defaultSession().followUps.getAll(STREAM)).toEqual([]);
-    expect(defaultSession().status.get(STREAM)).toBe(STREAM_STATUS.WAITING);
-  });
-
-  it('re-enqueues follow-ups, settles to WAITING, and reports on failure', async () => {
-    const failure = new Error('resume blew up');
-    resumeToolUseFromResumeDataMock.mockRejectedValue(failure);
-    const reportFailure = vi.fn();
-    defaultSession().followUps.enqueue(
-      STREAM,
-      { text: 'queued one' },
-      { force: true },
-    );
-
-    await expect(
-      resumeQueuedToolUseFromResumeData(STREAM, snapshot(), runtimeHost, {
-        onError: reportFailure,
-      }),
-    ).resolves.toBe(false);
-
-    expect(defaultSession().followUps.getAll(STREAM)).toEqual(['queued one']);
-    expect(defaultSession().status.get(STREAM)).toBe(STREAM_STATUS.WAITING);
-    expect(reportFailure).toHaveBeenCalledWith(failure);
-    // The re-enqueue replays a queue update beyond the initial drain notification.
-    expect(
-      sessionFactPayloads(
-        recordedSession?.events ?? [],
-        'updateQueuedFollowUps',
-      ),
-    ).toHaveLength(2);
-  });
-
-  it('does not restore deleted-stream state after guarded admission is cancelled', async () => {
+  it('rejects a competing recovery consumer deterministically', async () => {
     const session = createTestSession();
-    session.transcripts.ensureStream(STREAM);
-    session.followUps.enqueue(STREAM, { text: 'queued one' }, { force: true });
-    const reportFailure = vi.fn();
+    seedRecoverable(session, 'once');
+    let unblock!: () => void;
+    const barrier = new Promise<void>((resolve) => {
+      unblock = resolve;
+    });
     resumeToolUseFromResumeDataMock.mockImplementationOnce(async () => {
-      await session.transcripts.delete(STREAM);
-      throw new ResumeAdmissionCancelledError('cancelled' as ExecutionId);
+      await barrier;
+      return completed;
     });
 
     try {
+      const first = resumeQueuedToolUseFromResumeData(
+        STREAM,
+        snapshot(),
+        runtimeHost,
+        { session, onError: vi.fn() },
+      );
+      await vi.waitFor(() =>
+        expect(resumeToolUseFromResumeDataMock).toHaveBeenCalledOnce(),
+      );
       await expect(
         resumeQueuedToolUseFromResumeData(STREAM, snapshot(), runtimeHost, {
           session,
-          canAcquireResumeLease: () => false,
-          onError: reportFailure,
+          onError: vi.fn(),
         }),
       ).resolves.toBe(false);
-
-      expect(session.transcripts.has(STREAM)).toBe(false);
-      expect(session.followUps.getAll(STREAM)).toEqual([]);
-      expect(reportFailure).not.toHaveBeenCalled();
+      unblock();
+      await first;
+      expect(resumeToolUseFromResumeDataMock).toHaveBeenCalledOnce();
     } finally {
-      session.followUps.release(STREAM);
-      session.status.clearStream(STREAM);
       session.dispose();
     }
   });
 
-  it('uses the supplied session status plane for resume markers', async () => {
-    const failure = new Error('session-scoped resume failed');
-    resumeToolUseFromResumeDataMock.mockRejectedValue(failure);
+  it('restores an unconsumed batch after resume failure', async () => {
     const session = createTestSession();
+    seedRecoverable(session, 'keep me');
+    resumeToolUseFromResumeDataMock.mockRejectedValueOnce(new Error('failed'));
 
     try {
       await expect(
@@ -631,57 +126,73 @@ describe('resumeQueuedToolUseFromResumeData', () => {
           onError: vi.fn(),
         }),
       ).resolves.toBe(false);
-
-      expect(session.status.get(STREAM)).toBe(STREAM_STATUS.WAITING);
-      expect(defaultSession().status.get(STREAM)).toBeUndefined();
+      expect(session.followUps.getAll(STREAM)).toEqual(['keep me']);
     } finally {
-      session.status.clearStream(STREAM);
       session.dispose();
     }
   });
 
-  it('preserves failed resume follow-ups in the supplied session queue only', async () => {
-    const failure = new Error('session queue resume failed');
-    resumeToolUseFromResumeDataMock.mockRejectedValue(failure);
+  it('replays a completed-child result that races a failed recovery', async () => {
     const session = createTestSession();
+    seedRecoverable(session, 'original');
+    let rejectResume!: (error: unknown) => void;
+    const barrier = new Promise<never>((_resolve, reject) => {
+      rejectResume = reject;
+    });
+    resumeToolUseFromResumeDataMock.mockReturnValueOnce(barrier);
 
     try {
-      session.followUps.enqueue(
+      const resuming = resumeQueuedToolUseFromResumeData(
         STREAM,
-        { text: 'session queued' },
-        { force: true },
+        snapshot(),
+        runtimeHost,
+        { session, onError: vi.fn() },
+      );
+      await vi.waitFor(() =>
+        expect(resumeToolUseFromResumeDataMock).toHaveBeenCalledOnce(),
       );
 
+      expect(
+        session.followUps.submit(
+          STREAM,
+          { text: 'completed child', origin: 'subagent_result' },
+          'recoverable',
+        ),
+      ).toEqual({ kind: 'recovering' });
+      rejectResume(new Error('resume failed'));
+
+      await expect(resuming).resolves.toBe(false);
+      expect(session.followUps.getAll(STREAM)).toEqual([
+        'original',
+        'completed child',
+      ]);
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it('adopts the exact recovery generation claimed by submission', async () => {
+    const session = createTestSession();
+    const submission = session.followUps.submit(
+      STREAM,
+      { text: 'claimed' },
+      'recoverable',
+    );
+    expect(submission.kind).toBe('recovery');
+    if (submission.kind !== 'recovery') throw new Error('recovery not claimed');
+    const recovery = submission.lease;
+
+    try {
       await expect(
         resumeQueuedToolUseFromResumeData(STREAM, snapshot(), runtimeHost, {
           session,
+          recovery,
           onError: vi.fn(),
         }),
-      ).resolves.toBe(false);
-
-      expect(session.followUps.getAll(STREAM)).toEqual(['session queued']);
-      expect(defaultSession().followUps.getAll(STREAM)).toEqual([]);
+      ).resolves.toBe(true);
+      expect(resumeToolUseFromResumeDataMock).toHaveBeenCalledOnce();
     } finally {
-      session.followUps.release(STREAM);
-      session.status.clearStream(STREAM);
       session.dispose();
     }
-  });
-
-  it('leaves the status alone when the started run has taken it over', async () => {
-    resumeToolUseFromResumeDataMock.mockImplementation(async () => {
-      seedStreamStatusForTest(
-        defaultSession().status,
-        STREAM,
-        STREAM_STATUS.RUNNING,
-      );
-    });
-
-    await expect(
-      resumeQueuedToolUseFromResumeData(STREAM, snapshot(), runtimeHost, {
-        onError: vi.fn(),
-      }),
-    ).resolves.toBe(true);
-    expect(defaultSession().status.get(STREAM)).toBe(STREAM_STATUS.RUNNING);
   });
 });

--- a/src/test-kernel/agent/storage/SessionStores.vitest.ts
+++ b/src/test-kernel/agent/storage/SessionStores.vitest.ts
@@ -57,7 +57,7 @@ describe('SessionStores deletion coordination', () => {
     const session = createTestSession();
     const stream = 'tool@test#abc001' as StreamTabId;
     session.transcripts.ensureStream(stream);
-    session.followUps.acquire(stream);
+    session.followUps.claimLive(stream, 'flow');
     let unblockDeletion!: () => void;
     const deletionBlocked = new Promise<void>((resolve) => {
       unblockDeletion = resolve;

--- a/src/test-kernel/cli/CliInitPlatform.vitest.mts
+++ b/src/test-kernel/cli/CliInitPlatform.vitest.mts
@@ -330,8 +330,10 @@ describe('CLI platform init', () => {
 
     type NodePlatformOptions = {
       readonly agentResume: {
-        tryResumeStream(streamId: StreamTabId): Promise<boolean>;
-        isResumeInFlight(streamId: StreamTabId): boolean;
+        tryResumeStream(
+          streamId: StreamTabId,
+          recovery?: unknown,
+        ): Promise<boolean>;
       };
     };
     const createNodePlatformCalls = mocks.createNodePlatform.mock
@@ -353,10 +355,6 @@ describe('CLI platform init', () => {
       executeWorkflow: vi.fn(async () => {}),
     });
 
-    expect(nodePlatformOptions.agentResume.isResumeInFlight(streamId)).toBe(
-      false,
-    );
-
     const tryResumeStream = vi.fn(async () => true);
     const dispose = setCliAgentResumeHandler({
       tryResumeStream,
@@ -366,10 +364,7 @@ describe('CLI platform init', () => {
       await expect(
         nodePlatformOptions.agentResume.tryResumeStream(streamId),
       ).resolves.toBe(true);
-      expect(tryResumeStream).toHaveBeenCalledWith(streamId);
-      expect(nodePlatformOptions.agentResume.isResumeInFlight(streamId)).toBe(
-        true,
-      );
+      expect(tryResumeStream).toHaveBeenCalledWith(streamId, undefined);
     } finally {
       dispose();
       releaseResumeState();

--- a/src/test-kernel/cli/SessionStatus.vitest.mts
+++ b/src/test-kernel/cli/SessionStatus.vitest.mts
@@ -301,14 +301,14 @@ describe('CLI session status formatter', () => {
 
   it('reads queued follow-ups from the queue manager for status details', () => {
     const queueManager = new ToolUseFollowUpQueue();
-    const queue = queueManager.acquire(STREAM_ID);
-    queueManager.drain(STREAM_ID);
+    const lease = queueManager.claimLive(STREAM_ID, 'flow')!;
+    queueManager.drainItems(lease);
     try {
-      queue.enqueue({ text: 'Fresh queue message' });
+      queueManager.queue(lease).enqueue({ text: 'Fresh queue message' });
 
       expect(queueManager.getAll(STREAM_ID)).toEqual(['Fresh queue message']);
     } finally {
-      queueManager.drain(STREAM_ID);
+      queueManager.drainItems(lease);
     }
   });
 });

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -3305,7 +3305,8 @@ describe('subscribeRuntimeHost run facts', () => {
     const hub = new SessionEventHub();
     const detach = attachTuiRunFactSubscription(hub);
     patchStream(root, (s) => ({ ...s, status: STREAM_PHASE.RUNNING }));
-    const queue = defaultSession().followUps.acquire(root);
+    const lease = defaultSession().followUps.claimLive(root, 'flow')!;
+    const queue = defaultSession().followUps.queue(lease);
 
     try {
       queue.enqueue({ text: 'Keep the proof under one page.' });
@@ -3335,7 +3336,7 @@ describe('subscribeRuntimeHost run facts', () => {
       expect(slice?.queuedFollowUpMessages).toEqual([]);
     } finally {
       detach();
-      defaultSession().followUps.release(root);
+      defaultSession().followUps.terminalize(root);
     }
   });
 

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -126,7 +126,6 @@ vi.mock('@cli/runtime/sessionResume', () => ({
 }));
 
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
-import { wakeQueuedFollowUpStream } from '@agent/followUp/ToolUseFollowUp';
 import { AgentExecutionHandle } from '@agent/runtime/ExecutionHandle';
 import { ExecutionRegistry } from '@agent/runtime/executionRegistry';
 import { SessionHostInteractions } from '@agent/runtime/HostInteractions';
@@ -460,7 +459,7 @@ describe('createChatSessionController', () => {
       useHostInteractions: vi.fn(() => mocks.detachHostInteractions),
       interactions: { cancel: mocks.cancelInteractions },
       events: { emit: mocks.sessionEventEmit },
-      followUps: { enqueue: mocks.followUpEnqueue },
+      followUps: { restore: mocks.followUpEnqueue },
       status: { isActiveOrResuming: mocks.streamIsActiveOrResuming },
       executions: {
         stopAgentStream: mocks.stopAgentStream,
@@ -476,7 +475,11 @@ describe('createChatSessionController', () => {
     mocks.resumeQueuedToolUseFromResumeData.mockImplementation(
       async (...args: unknown[]) => {
         const options = args[3] as ResumeQueuedToolUseOptions;
-        options.onFollowUpQueueReady?.();
+        options.onFollowUpQueueReady?.({
+          streamId: 'stream:test' as StreamTabId,
+          generation: 1,
+          kind: 'recovery',
+        });
         return true;
       },
     );
@@ -692,7 +695,7 @@ describe('createChatSessionController', () => {
         interactions.use(adapter),
       interactions,
       events,
-      followUps: { enqueue: mocks.followUpEnqueue },
+      followUps: { restore: mocks.followUpEnqueue },
       approvals: { registerStreamParent: vi.fn() },
       status,
       executions,
@@ -1263,13 +1266,7 @@ describe('createChatSessionController', () => {
       makeInit({ session, snapshotStore }),
     );
 
-    await expect(
-      wakeQueuedFollowUpStream(
-        'child-stream',
-        { status: 'queued', reason: 'waiting' },
-        ctrl,
-      ),
-    ).resolves.toEqual({ kind: 'queued_resume_failed' });
+    await expect(ctrl.tryResumeStream('child-stream')).resolves.toBe(false);
 
     expect(snapshotStore.preload).not.toHaveBeenCalled();
   });
@@ -1362,9 +1359,8 @@ describe('createChatSessionController', () => {
     await expect(launcherResume).resolves.toBe(true);
     await expect(admission.completion).resolves.toBe(true);
     expect(mocks.followUpEnqueue).toHaveBeenCalledWith(
-      'stream-1',
-      { text: 'Transfer this accepted message.' },
-      { force: true },
+      expect.objectContaining({ kind: 'recovery' }),
+      [{ text: 'Transfer this accepted message.' }],
     );
   });
 
@@ -1433,7 +1429,11 @@ describe('createChatSessionController', () => {
     mocks.resumeQueuedToolUseFromResumeData.mockImplementationOnce(
       async (...args: unknown[]) => {
         const options = args[3] as ResumeQueuedToolUseOptions;
-        options.onFollowUpQueueReady?.();
+        options.onFollowUpQueueReady?.({
+          streamId: 'stream:test' as StreamTabId,
+          generation: 1,
+          kind: 'recovery',
+        });
         return resume.promise;
       },
     );
@@ -1538,6 +1538,7 @@ describe('createChatSessionController', () => {
       expect.objectContaining({
         isCancellationRequested: expect.any(Function),
       }),
+      undefined,
     );
     expect(mocks.projectStreamTranscript).not.toHaveBeenCalledWith('stream-1', {
       finalize: true,

--- a/src/test-kernel/commands/agent/ResumeExtensionToolUseFromResumeData.vitest.ts
+++ b/src/test-kernel/commands/agent/ResumeExtensionToolUseFromResumeData.vitest.ts
@@ -73,6 +73,7 @@ describe('resumeExtensionToolUseFromResumeData', () => {
     await expect(
       resumeExtensionToolUseFromResumeData(
         snapshot(),
+        undefined,
         'typed alongside resume',
       ),
     ).resolves.toBe(true);

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -71,8 +71,6 @@ import {
 } from './desktopAgentExecutionTestHarness.mjs';
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
 
-type WakeQueuedFollowUpStream =
-  typeof import('@agent/followUp/ToolUseFollowUp').wakeQueuedFollowUpStream;
 type DesktopProgressBridgeOptions =
   import('@desktop/main/desktopAgentExecution').DesktopProgressBridgeOptions;
 
@@ -167,15 +165,7 @@ type BridgeWithSession = TestableBridge & {
     };
     status: StreamStatusMachine;
     events: SessionHandle['events'];
-    followUps: {
-      enqueue(
-        streamId: StreamTabId,
-        followUp: { text: string },
-        options?: { force?: boolean },
-      ): boolean;
-      getAll(streamId: StreamTabId): string[];
-      release(streamId: StreamTabId): void;
-    };
+    followUps: SessionHandle['followUps'];
   };
 };
 
@@ -197,6 +187,17 @@ function bridgeFollowUps(
   return (bridge as BridgeWithSession).session.followUps;
 }
 
+function seedBridgeFollowUp(
+  bridge: TestableBridge,
+  streamId: StreamTabId,
+  text: string,
+): void {
+  const followUps = bridgeFollowUps(bridge);
+  const lease = followUps.claimLive(streamId, 'flow')!;
+  followUps.queue(lease).enqueue({ text });
+  followUps.release(lease, 'recoverable');
+}
+
 type CreateBridgeOptions = {
   kvStoreBacking?: Map<string, unknown>;
   kvRead?: (key: string) => Promise<unknown> | unknown;
@@ -215,7 +216,6 @@ type CreateBridgeOptions = {
   configureSession?: (session: SessionHandle) => Promise<void> | void;
   deferReady?: boolean;
   detectWaitingStreams?: ReturnType<typeof vi.fn>;
-  wakeQueuedFollowUpStream?: WakeQueuedFollowUpStream;
   showErrorMessage?: (message: string) => Promise<void> | void;
   showInfoMessage?: (message: string) => Promise<void> | void;
   onRunCompleted?: () => void;
@@ -286,12 +286,10 @@ async function loadBridgeModule(options: CreateBridgeOptions = {}): Promise<{
   const kvStoreBacking = options.kvStoreBacking ?? new Map<string, unknown>();
   let resumeDelegate: AgentResumePort = {
     tryResumeStream: async () => false,
-    isResumeInFlight: () => false,
   };
   const agentResume: AgentResumePort = {
-    tryResumeStream: (streamId) => resumeDelegate.tryResumeStream(streamId),
-    isResumeInFlight: (streamId) =>
-      resumeDelegate.isResumeInFlight?.(streamId) ?? false,
+    tryResumeStream: (streamId, recovery) =>
+      resumeDelegate.tryResumeStream(streamId, recovery),
   };
   const [{ initPlatform }, { createFakePlatform }] = await Promise.all([
     import('@platform/platform'),
@@ -2334,8 +2332,13 @@ describe('DesktopProgressBridge', () => {
           }),
         }),
     );
+    let pendingAtAttachment: readonly { text: string; origin?: string }[] = [];
     const resumeToolUseFromResumeData = vi.fn(async (...args: unknown[]) => {
-      const options = args[2] as { onFollowUpConsumed?: () => void };
+      const options = args[2] as {
+        onFollowUpConsumed?: () => void;
+        takePendingFollowUps(): readonly { text: string; origin?: string }[];
+      };
+      pendingAtAttachment = options.takePendingFollowUps();
       options.onFollowUpConsumed?.();
     });
     const messages: unknown[] = [];
@@ -2356,11 +2359,7 @@ describe('DesktopProgressBridge', () => {
         childStreamId: 'stream-1',
         parentStreamId,
       });
-      bridgeFollowUps(bridge).enqueue(
-        'stream-1',
-        { text: 'queued follow-up' },
-        { force: true },
-      );
+      seedBridgeFollowUp(bridge, 'stream-1' as StreamTabId, 'queued follow-up');
 
       await expect(bridge.tryResumeStream('stream-1')).resolves.toBe(true);
       expect(retrieveSessionResumeData).toHaveBeenCalledWith(
@@ -2386,7 +2385,6 @@ describe('DesktopProgressBridge', () => {
         unknown,
         {
           drainedFollowUps?: readonly { text: string; origin?: string }[];
-          takePendingFollowUps(): readonly { text: string; origin?: string }[];
         },
       ];
       // The drained batch travels via the direct drainedFollowUps handoff (a
@@ -2395,9 +2393,9 @@ describe('DesktopProgressBridge', () => {
       expect(resumeOptions.drainedFollowUps?.map((item) => item.text)).toEqual([
         'queued follow-up',
       ]);
-      expect(resumeOptions.takePendingFollowUps()).toEqual([]);
+      expect(pendingAtAttachment).toEqual([]);
     } finally {
-      bridgeFollowUps(bridge).release('stream-1');
+      bridgeFollowUps(bridge).terminalize('stream-1');
       bridgeStatus(bridge).clearStream('stream-1');
     }
   });
@@ -2425,11 +2423,7 @@ describe('DesktopProgressBridge', () => {
         executionId: 'ec1001' as ExecutionId,
         taskState: { agentConfig: SEARCH_TOOL_USE_AGENT_CONFIG },
       });
-      bridgeFollowUps(bridge).enqueue(
-        'stream-1',
-        { text: 'queued follow-up' },
-        { force: true },
-      );
+      seedBridgeFollowUp(bridge, 'stream-1' as StreamTabId, 'queued follow-up');
 
       await expect(bridge.tryResumeStream('stream-1')).resolves.toBe(false);
       expect(bridgeFollowUps(bridge).getAll('stream-1')).toEqual([
@@ -2437,7 +2431,7 @@ describe('DesktopProgressBridge', () => {
       ]);
       expect(bridgeStatus(bridge).get('stream-1')).toBe(STREAM_STATUS.WAITING);
     } finally {
-      bridgeFollowUps(bridge).release('stream-1');
+      bridgeFollowUps(bridge).terminalize('stream-1');
       bridgeStatus(bridge).clearStream('stream-1');
     }
   });
@@ -2690,7 +2684,6 @@ describe('DesktopProgressBridge', () => {
       category = AgentCategory.Workflow,
       messages = [],
       detectWaitingStreams,
-      wakeQueuedFollowUpStream,
     }: {
       streamId: StreamTabId;
       executionId: ExecutionId;
@@ -2698,7 +2691,6 @@ describe('DesktopProgressBridge', () => {
       category?: AgentCategory;
       messages?: unknown[];
       detectWaitingStreams?: ReturnType<typeof vi.fn>;
-      wakeQueuedFollowUpStream?: WakeQueuedFollowUpStream;
     }) {
       const {
         bridgeModule,
@@ -2757,7 +2749,6 @@ describe('DesktopProgressBridge', () => {
         {
           session: processSession,
           sessionStores,
-          ...(wakeQueuedFollowUpStream ? { wakeQueuedFollowUpStream } : {}),
           host: createStubDesktopAgentExecutionHost({
             openDiff: async (original, proposed, title) => {
               diffPathsA.push({
@@ -3059,65 +3050,6 @@ describe('DesktopProgressBridge', () => {
         await expect(planPromise).resolves.toEqual({ action: 'approve' });
       } finally {
         bridgeB.dispose();
-      }
-    });
-
-    it('replays a follow-up wake notice that completes after window close exactly once', async () => {
-      const streamId = 'process-follow-up-wake' as StreamTabId;
-      const executionId = 'ec00ea' as ExecutionId;
-      let finishWake: (result: { kind: 'dropped' }) => void = () => undefined;
-      const wakeResult = new Promise<{ kind: 'dropped' }>((resolve) => {
-        finishWake = resolve;
-      });
-      const wakeQueuedFollowUpStream = vi.fn(() => wakeResult);
-      const owner = await createProcessOwner({
-        streamId,
-        executionId,
-        agentName: 'search',
-        category: AgentCategory.ToolUse,
-        wakeQueuedFollowUpStream,
-      });
-      expect(
-        owner.processSession.status.transitionToWaiting(streamId, 'wait', {
-          trace: owner.trace as unknown as AgentTrace,
-        }),
-      ).toBe(true);
-      const send = assertSupported(
-        owner.bridgeA.progressViewInboundHandlers[
-          PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP
-        ],
-      );
-
-      await send({
-        command: PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP,
-        stream: streamId,
-        text: 'Continue after the child completes.',
-      });
-      expect(wakeQueuedFollowUpStream).toHaveBeenCalledOnce();
-      owner.close();
-      finishWake({ kind: 'dropped' });
-      await settleProgressEvents();
-      expect(owner.infosA).toEqual([]);
-
-      const { bridgeB, infosB } = await owner.reopen();
-      try {
-        await vi.waitFor(() =>
-          expect(infosB).toEqual([
-            'Message dropped because no session was available to receive it. Start a new agent task to continue.',
-          ]),
-        );
-        await settleProgressEvents();
-        expect(infosB).toHaveLength(1);
-      } finally {
-        bridgeB.dispose();
-      }
-
-      const { bridgeB: bridgeC, infosB: infosC } = await owner.reopen();
-      try {
-        await settleProgressEvents();
-        expect(infosC).toEqual([]);
-      } finally {
-        bridgeC.dispose();
       }
     });
 
@@ -3686,11 +3618,13 @@ describe('DesktopProgressBridge', () => {
         childStreamId,
         STREAM_PHASE.RUNNING,
       );
-      owner.processSession.followUps.enqueue(
+      const followUpLease = owner.processSession.followUps.claimLive(
         childStreamId,
-        { text: 'late follow-up' },
-        { force: true },
-      );
+        'flow',
+      )!;
+      owner.processSession.followUps
+        .queue(followUpLease)
+        .enqueue({ text: 'late follow-up' });
       await owner.processSession.flushArtifacts();
       owner.close();
       const pendingApproval =

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -102,6 +102,11 @@ type TestableBridge = Bridge & {
   syncFullView(): void;
   completeWebviewReady(): Promise<void>;
   tryResumeStream(streamId: StreamTabId): Promise<boolean>;
+  sendFollowUp(
+    streamId: StreamTabId,
+    text: string,
+    mediaFiles?: readonly string[],
+  ): Promise<void>;
   setActiveStream(streamId: StreamTabId): void;
   revealStream(streamId: StreamTabId): Promise<void>;
   deleteStream(streamId: StreamTabId): Promise<void>;
@@ -601,6 +606,36 @@ function shownToolEditRequestId(messages: unknown[]): string | undefined {
   }
   return undefined;
 }
+
+describe('desktop follow-up submission', () => {
+  it('does not hold the IPC request open for the resumed turn', async () => {
+    const streamId = 'desktop-detached-follow-up' as StreamTabId;
+    let finishResumeLookup!: (value: null) => void;
+    const resumeLookup = new Promise<null>((resolve) => {
+      finishResumeLookup = resolve;
+    });
+    const bridge = await createBridge([], {
+      retrieveSessionResumeData: vi.fn(() => resumeLookup),
+      configureSession: (session) => {
+        seedStreamStatusForTest(
+          session.status,
+          streamId,
+          STREAM_STATUS.WAITING,
+        );
+      },
+    });
+
+    await expect(bridge.sendFollowUp(streamId, 'continue')).resolves.toBe(
+      undefined,
+    );
+    expect(bridgeFollowUps(bridge).getAll(streamId)).toEqual(['continue']);
+
+    finishResumeLookup(null);
+    await vi.waitFor(() =>
+      expect(bridgeFollowUps(bridge).getAll(streamId)).toEqual(['continue']),
+    );
+  });
+});
 
 function appendRunningGroup(
   store: StreamLogStore,

--- a/src/test-kernel/desktop/DesktopAgentResume.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentResume.vitest.mts
@@ -229,8 +229,9 @@ describe('desktop process resume owner', () => {
       createToolUseResumeData({ streamId: stream, executionId }),
     );
     const harness = createResumeHarness();
-    harness.session.followUps.acquire(stream);
-    harness.session.followUps.enqueue(stream, { text: 'keep this queued' });
+    const flow = harness.session.followUps.claimLive(stream, 'flow')!;
+    harness.session.followUps.queue(flow).enqueue({ text: 'keep this queued' });
+    harness.session.followUps.release(flow, 'recoverable');
     resumeToolUseFromResumeData.mockImplementation(
       async (_resume, _runtimeHost, options) => {
         await options?.onRun?.({} as never);

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -2042,11 +2042,13 @@ describe('ProgressBackend', () => {
           cause: STREAM_TRANSITION_CAUSE.LIFECYCLE,
         },
       });
-      target.session.followUps.enqueue(
+      const followUpLease = target.session.followUps.claimLive(
         parentStreamId,
-        { text: 'continue with the local calculation' },
-        { force: true },
-      );
+        'flow',
+      )!;
+      target.session.followUps.queue(followUpLease).enqueue({
+        text: 'continue with the local calculation',
+      });
       emitRunFact(target, parentStreamId, 'updateMissingOutputs', {
         streamId: parentStreamId,
         filesByRound: { 0: ['missing-output.tex'] },

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -639,8 +639,8 @@ describe('BashTool', () => {
       },
     );
 
-    const sendFollowUpSpy = vi
-      .spyOn(toolUseFollowUp, 'sendFollowUp')
+    const submitFollowUpSpy = vi
+      .spyOn(toolUseFollowUp, 'submitFollowUp')
       .mockResolvedValue({ status: 'sent' });
 
     const parentStreamId = 'bash-tool-bg-parent' as StreamTabId;
@@ -666,7 +666,7 @@ describe('BashTool', () => {
       // once the (mocked) process settles.
       await vi.waitFor(() => {
         assert.ok(
-          sendFollowUpSpy.mock.calls.length > 0,
+          submitFollowUpSpy.mock.calls.length > 0,
           'Background bash should deliver a follow-up once the run completes',
         );
       });
@@ -677,7 +677,7 @@ describe('BashTool', () => {
     // sendFollowUp is overloaded (string | FollowUpQueueInput); bash.ts always
     // calls the object form, but Parameters<> on an overloaded function type
     // resolves to the last signature, so assert the concrete shape here.
-    const followUpArg = sendFollowUpSpy.mock.calls[0]?.[1] as unknown as
+    const followUpArg = submitFollowUpSpy.mock.calls[0]?.[1] as unknown as
       { text: string } | undefined;
     const deliveredText = followUpArg?.text;
     assert.ok(
@@ -755,7 +755,7 @@ describe('BashTool', () => {
     } finally {
       recorded.detach();
       clearStreamStatusForTest(defaultSession().status, parentStreamId);
-      defaultSession().followUps.release(parentStreamId);
+      defaultSession().followUps.terminalize(parentStreamId);
     }
   });
 
@@ -845,7 +845,7 @@ describe('BashTool', () => {
       releaseResume?.();
       recorded.detach();
       clearStreamStatusForTest(defaultSession().status, parentStreamId);
-      defaultSession().followUps.release(parentStreamId);
+      defaultSession().followUps.terminalize(parentStreamId);
     }
   });
 
@@ -900,7 +900,7 @@ describe('BashTool', () => {
       );
     });
     recorded.detach();
-    defaultSession().followUps.release(parentStreamId);
+    defaultSession().followUps.terminalize(parentStreamId);
   });
 
   it('accepts optional command descriptions without passing them to the shell', async () => {

--- a/src/test-kernel/tools/ChildRunDelivery.vitest.ts
+++ b/src/test-kernel/tools/ChildRunDelivery.vitest.ts
@@ -81,7 +81,7 @@ describe('child run delivery', () => {
     expect(mocks.submitFollowUp).toHaveBeenCalledWith(
       'parent',
       { text: 'done', origin: 'subagent_result' },
-      { session, mode: undefined },
+      { session, mode: 'child_delivery' },
     );
   });
 

--- a/src/test-kernel/tools/ChildRunDelivery.vitest.ts
+++ b/src/test-kernel/tools/ChildRunDelivery.vitest.ts
@@ -1,15 +1,12 @@
-// Third-party imports
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Local imports
 import type { ResultMeta } from '@agent/storage';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 
 const mocks = vi.hoisted(() => ({
   writeResultMeta: vi.fn(),
   writeReport: vi.fn(),
-  sendFollowUp: vi.fn(),
-  wakeOrReleaseQueuedStream: vi.fn(),
+  submitFollowUp: vi.fn(),
 }));
 
 vi.mock('@agent/storage', () => ({
@@ -20,42 +17,19 @@ vi.mock('@agent/storage', () => ({
 }));
 
 vi.mock('@agent/followUp/ToolUseFollowUp', () => ({
-  sendFollowUp: mocks.sendFollowUp,
-  wakeOrReleaseQueuedStream: mocks.wakeOrReleaseQueuedStream,
+  submitFollowUp: mocks.submitFollowUp,
 }));
+
 import {
   deliverChildRunFollowUp,
-  enqueueChildRunFollowUp,
-  wakeChildRunFollowUp,
   persistChildRunReport,
   persistChildRunResultMeta,
 } from '@tools/childRunDelivery';
 
 describe('child run delivery', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+  beforeEach(() => vi.clearAllMocks());
 
-  it('persists reports through the execution store', async () => {
-    mocks.writeReport.mockResolvedValue(undefined);
-
-    await expect(
-      persistChildRunReport('exec-1' as ExecutionId, 'payload'),
-    ).resolves.toEqual({ kind: 'persisted' });
-
-    expect(mocks.writeReport).toHaveBeenCalledWith('payload');
-  });
-
-  it('returns the storage error when report persistence fails', async () => {
-    const err = new Error('disk full');
-    mocks.writeReport.mockRejectedValue(err);
-
-    await expect(
-      persistChildRunReport('exec-1' as ExecutionId, 'payload'),
-    ).resolves.toEqual({ kind: 'failed', err });
-  });
-
-  it('persists result manifests through the execution store', async () => {
+  it('persists reports and result manifests', async () => {
     const resultMeta = {
       producer: 'subagent',
       agentName: 'review',
@@ -68,18 +42,34 @@ describe('child run delivery', () => {
         cost: 0,
       },
     } satisfies ResultMeta;
+    mocks.writeReport.mockResolvedValue(undefined);
     mocks.writeResultMeta.mockResolvedValue(undefined);
 
     await expect(
+      persistChildRunReport('exec-1' as ExecutionId, 'payload'),
+    ).resolves.toEqual({ kind: 'persisted' });
+    await expect(
       persistChildRunResultMeta('exec-1' as ExecutionId, resultMeta),
     ).resolves.toEqual({ kind: 'persisted' });
-
+    expect(mocks.writeReport).toHaveBeenCalledWith('payload');
     expect(mocks.writeResultMeta).toHaveBeenCalledWith(resultMeta);
   });
 
-  it('delivers a follow-up with the explicit owner session', async () => {
-    const session = { tag: 'owner-session' };
-    mocks.sendFollowUp.mockResolvedValue({ status: 'sent' });
+  it('returns persistence failures', async () => {
+    const err = new Error('disk full');
+    mocks.writeReport.mockRejectedValue(err);
+    await expect(
+      persistChildRunReport('exec-1' as ExecutionId, 'payload'),
+    ).resolves.toEqual({ kind: 'failed', err });
+  });
+
+  it('submits delivery and recovery as one operation', async () => {
+    const session = { tag: 'owner' };
+    mocks.submitFollowUp.mockResolvedValue({
+      status: 'queued',
+      reason: 'waiting',
+      continuation: 'resumed',
+    });
 
     await expect(
       deliverChildRunFollowUp({
@@ -88,187 +78,33 @@ describe('child run delivery', () => {
         session: session as never,
       }),
     ).resolves.toEqual({ kind: 'delivered' });
-
-    expect(mocks.sendFollowUp).toHaveBeenCalledWith(
+    expect(mocks.submitFollowUp).toHaveBeenCalledWith(
       'parent',
       { text: 'done', origin: 'subagent_result' },
-      undefined,
-      undefined,
-      session,
-    );
-    expect(mocks.wakeOrReleaseQueuedStream).not.toHaveBeenCalled();
-  });
-
-  it('wakes or releases force-opened parent queues with the same session', async () => {
-    const session = { tag: 'owner-session' };
-    const sendResult = { status: 'queued', reason: 'children_running' };
-    mocks.sendFollowUp.mockResolvedValue(sendResult);
-    mocks.wakeOrReleaseQueuedStream.mockResolvedValue(true);
-
-    await expect(
-      deliverChildRunFollowUp({
-        targetStreamId: 'parent' as StreamTabId,
-        followUp: { text: 'done', origin: 'subagent_result' },
-        session: session as never,
-        wake: true,
-      }),
-    ).resolves.toEqual({ kind: 'delivered' });
-
-    expect(mocks.wakeOrReleaseQueuedStream).toHaveBeenCalledWith(
-      'parent',
-      sendResult,
-      session,
+      { session, mode: undefined },
     );
   });
 
-  it('classifies missing and dropped parent streams', async () => {
-    const session = { tag: 'owner-session' };
-    mocks.sendFollowUp.mockResolvedValueOnce({
+  it('classifies missing and terminal parents', async () => {
+    mocks.submitFollowUp.mockResolvedValueOnce({
       status: 'no_session',
       streamStatus: 'completed',
     });
-
     await expect(
       deliverChildRunFollowUp({
         targetStreamId: 'parent' as StreamTabId,
-        followUp: { text: 'done', origin: 'subagent_result' },
-        session: session as never,
-        wake: true,
+        followUp: { text: 'done' },
+        session: {} as never,
       }),
-    ).resolves.toEqual({
-      kind: 'no_session',
-      streamStatus: 'completed',
-    });
+    ).resolves.toEqual({ kind: 'no_session', streamStatus: 'completed' });
 
-    mocks.sendFollowUp.mockResolvedValueOnce({
-      status: 'queued',
-      reason: 'children_running',
-    });
-    mocks.wakeOrReleaseQueuedStream.mockResolvedValueOnce(false);
-
+    mocks.submitFollowUp.mockResolvedValueOnce({ status: 'dropped' });
     await expect(
       deliverChildRunFollowUp({
         targetStreamId: 'parent' as StreamTabId,
-        followUp: { text: 'done', origin: 'subagent_result' },
-        session: session as never,
-        wake: true,
+        followUp: { text: 'late' },
+        session: {} as never,
       }),
     ).resolves.toEqual({ kind: 'dropped' });
-  });
-
-  // #8093: enqueue and wake are split so a caller can finalize its own child
-  // between them, keeping the (potentially slow) wake off the critical path
-  // that must observe the child as terminal.
-  describe('enqueueChildRunFollowUp / wakeChildRunFollowUp split', () => {
-    it('enqueueChildRunFollowUp only sends — it never calls the wake port', async () => {
-      const session = { tag: 'owner-session' };
-      mocks.sendFollowUp.mockResolvedValue({ status: 'sent' });
-
-      await expect(
-        enqueueChildRunFollowUp({
-          targetStreamId: 'parent' as StreamTabId,
-          followUp: { text: 'done', origin: 'subagent_result' },
-          session: session as never,
-        }),
-      ).resolves.toEqual({
-        kind: 'enqueued',
-        sendResult: { status: 'sent' },
-      });
-      expect(mocks.wakeOrReleaseQueuedStream).not.toHaveBeenCalled();
-    });
-
-    it('enqueueChildRunFollowUp classifies a missing parent session without waking', async () => {
-      const session = { tag: 'owner-session' };
-      mocks.sendFollowUp.mockResolvedValue({
-        status: 'no_session',
-        streamStatus: 'completed',
-      });
-
-      await expect(
-        enqueueChildRunFollowUp({
-          targetStreamId: 'parent' as StreamTabId,
-          followUp: { text: 'done', origin: 'subagent_result' },
-          session: session as never,
-        }),
-      ).resolves.toEqual({ kind: 'no_session', streamStatus: 'completed' });
-      expect(mocks.wakeOrReleaseQueuedStream).not.toHaveBeenCalled();
-    });
-
-    it('wakeChildRunFollowUp resolves a no_session enqueue result without calling the wake port', async () => {
-      const session = { tag: 'owner-session' };
-
-      await expect(
-        wakeChildRunFollowUp(
-          'parent' as StreamTabId,
-          { kind: 'no_session', streamStatus: 'completed' },
-          session as never,
-        ),
-      ).resolves.toEqual({ kind: 'no_session', streamStatus: 'completed' });
-      expect(mocks.wakeOrReleaseQueuedStream).not.toHaveBeenCalled();
-    });
-
-    it('wakeChildRunFollowUp wakes (or releases) using the enqueue result it was handed', async () => {
-      const session = { tag: 'owner-session' };
-      const sendResult = { status: 'queued', reason: 'children_running' };
-      mocks.wakeOrReleaseQueuedStream.mockResolvedValue(true);
-
-      await expect(
-        wakeChildRunFollowUp(
-          'parent' as StreamTabId,
-          { kind: 'enqueued', sendResult: sendResult as never },
-          session as never,
-        ),
-      ).resolves.toEqual({ kind: 'delivered' });
-      expect(mocks.wakeOrReleaseQueuedStream).toHaveBeenCalledWith(
-        'parent',
-        sendResult,
-        session,
-      );
-    });
-
-    it('the enqueue half settles before a slow wake half resolves', async () => {
-      // Regression shape for #8093: a caller must be able to observe the
-      // enqueue's completion (and act on it — e.g. finalize its own child)
-      // strictly before the wake half, which can hang for as long as the
-      // resumed parent's own turn takes.
-      const session = { tag: 'owner-session' };
-      mocks.sendFollowUp.mockResolvedValue({
-        status: 'queued',
-        reason: 'children_running',
-      });
-      let resolveWake: (() => void) | undefined;
-      mocks.wakeOrReleaseQueuedStream.mockImplementation(
-        () =>
-          new Promise<boolean>((resolve) => {
-            resolveWake = () => resolve(true);
-          }),
-      );
-
-      const enqueueResult = await enqueueChildRunFollowUp({
-        targetStreamId: 'parent' as StreamTabId,
-        followUp: { text: 'done', origin: 'subagent_result' },
-        session: session as never,
-      });
-      // Enqueue is fully settled — the wake port has not even been called
-      // yet, proving the caller can act on this result (e.g. finalize)
-      // before ever touching the wake step.
-      expect(mocks.wakeOrReleaseQueuedStream).not.toHaveBeenCalled();
-
-      let woke = false;
-      const wakePromise = wakeChildRunFollowUp(
-        'parent' as StreamTabId,
-        enqueueResult,
-        session as never,
-      ).then((result) => {
-        woke = true;
-        return result;
-      });
-      await Promise.resolve();
-      expect(woke).toBe(false);
-
-      resolveWake?.();
-      await expect(wakePromise).resolves.toEqual({ kind: 'delivered' });
-      expect(woke).toBe(true);
-    });
   });
 });

--- a/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
@@ -27,7 +27,7 @@ const mocks = vi.hoisted(() => ({
   query: vi.fn(),
   buildClaudeAgentEnv: vi.fn(),
   findClaudeBinaryPath: vi.fn(),
-  enqueueFollowUp: vi.fn(),
+  submitFollowUp: vi.fn(async () => ({ status: 'sent' as const })),
 }));
 
 vi.mock('@tools/approval/bashApproval', () => ({
@@ -37,6 +37,10 @@ vi.mock('@tools/approval/bashApproval', () => ({
 
 vi.mock('@agent/followUp/ToolFileInteractionContext', () => ({
   getCurrentToolContexts: mocks.getCurrentToolContexts,
+}));
+
+vi.mock('@agent/followUp/ToolUseFollowUp', () => ({
+  submitFollowUp: mocks.submitFollowUp,
 }));
 
 vi.mock('@agent/runtime/RunContext', () => ({
@@ -135,7 +139,7 @@ describe('claude_agent tool — resume fallback for a torn-down registry', () =>
       createFakeAgentCliChildStream(childStreamId),
     );
     mocks.currentSession.mockReturnValue({
-      followUps: { acquire: () => ({ enqueue: mocks.enqueueFollowUp }) },
+      followUps: { acquire: () => ({ enqueue: vi.fn() }) },
     });
   }
 
@@ -285,10 +289,12 @@ describe('claude_agent tool — resume fallback for a torn-down registry', () =>
     expect(firstResult.status).toBe('executed');
     expect(secondResult.summary).toMatch(/Follow-up queued/);
     expect(mocks.startChildRunLoop).toHaveBeenCalledTimes(1);
-    expect(mocks.enqueueFollowUp).toHaveBeenCalledOnce();
-    expect(mocks.enqueueFollowUp).toHaveBeenCalledWith({
-      text: 'also update the tests',
-    });
+    expect(mocks.submitFollowUp).toHaveBeenCalledOnce();
+    expect(mocks.submitFollowUp).toHaveBeenCalledWith(
+      childStreamId,
+      'also update the tests',
+      expect.objectContaining({ session: expect.anything() }),
+    );
 
     strategy?.releaseSessionOwnership?.();
     expect(ClaudeAgentSessions.lookup('stale-session')).toBeUndefined();

--- a/src/test-kernel/tools/CodexResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/CodexResumeFallback.vitest.ts
@@ -22,7 +22,7 @@ const mocks = vi.hoisted(() => ({
   importCodexClass: vi.fn(),
   findCodexBinaryPath: vi.fn(),
   resumeThread: vi.fn(),
-  enqueueFollowUp: vi.fn(),
+  submitFollowUp: vi.fn(async () => ({ status: 'sent' as const })),
 }));
 
 vi.mock('@tools/approval/bashApproval', () => ({
@@ -32,6 +32,10 @@ vi.mock('@tools/approval/bashApproval', () => ({
 
 vi.mock('@agent/followUp/ToolFileInteractionContext', () => ({
   getCurrentToolContexts: mocks.getCurrentToolContexts,
+}));
+
+vi.mock('@agent/followUp/ToolUseFollowUp', () => ({
+  submitFollowUp: mocks.submitFollowUp,
 }));
 
 vi.mock('@agent/runtime/RunContext', () => ({
@@ -122,7 +126,7 @@ describe('codex tool - atomic resume fallback', () => {
       createFakeAgentCliChildStream(childStreamId),
     );
     mocks.currentSession.mockReturnValue({
-      followUps: { acquire: () => ({ enqueue: mocks.enqueueFollowUp }) },
+      followUps: { acquire: () => ({ enqueue: vi.fn() }) },
     });
   }
 
@@ -182,10 +186,12 @@ describe('codex tool - atomic resume fallback', () => {
     expect(mocks.resumeThread).toHaveBeenCalledOnce();
     expect(mocks.resumeThread).toHaveBeenCalledWith('stale-thread');
     expect(mocks.startChildRunLoop).toHaveBeenCalledTimes(1);
-    expect(mocks.enqueueFollowUp).toHaveBeenCalledOnce();
-    expect(mocks.enqueueFollowUp).toHaveBeenCalledWith({
-      text: 'also update the tests',
-    });
+    expect(mocks.submitFollowUp).toHaveBeenCalledOnce();
+    expect(mocks.submitFollowUp).toHaveBeenCalledWith(
+      childStreamId,
+      'also update the tests',
+      expect.objectContaining({ session: expect.anything() }),
+    );
 
     strategy?.releaseSessionOwnership?.();
     expect(CodexThreads.lookup('stale-thread')).toBeUndefined();

--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -289,8 +289,8 @@ describe('headless delegation', () => {
     for (const executionId of defaultSession().executions.getActiveIds()) {
       defaultSession().executions.untrack(executionId);
     }
-    defaultSession().followUps.release('parent-stream' as StreamTabId);
-    defaultSession().followUps.release('child-stream' as StreamTabId);
+    defaultSession().followUps.terminalize('parent-stream' as StreamTabId);
+    defaultSession().followUps.terminalize('child-stream' as StreamTabId);
   });
 
   it('awaits child delegation during one-shot tool-use runs', async () => {

--- a/src/test-kernel/tools/DelegationTools.vitest.ts
+++ b/src/test-kernel/tools/DelegationTools.vitest.ts
@@ -7,9 +7,7 @@ import { describe, it, afterEach, beforeEach, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   tryUseRunContext: vi.fn(),
   currentSession: vi.fn(),
-  sendFollowUp: vi.fn(),
-  wakeQueuedFollowUpStream: vi.fn(),
-  isChildRunLoopActive: vi.fn(),
+  submitFollowUp: vi.fn(),
   deliverChildRunFollowUp: vi.fn(),
 }));
 
@@ -28,12 +26,7 @@ vi.mock('@agent/runtime/SessionHandle', () => ({
 }));
 
 vi.mock('@agent/followUp/ToolUseFollowUp', () => ({
-  sendFollowUp: mocks.sendFollowUp,
-  wakeQueuedFollowUpStream: mocks.wakeQueuedFollowUpStream,
-}));
-
-vi.mock('@agent/runtime/childRunLoop', () => ({
-  isChildRunLoopActive: mocks.isChildRunLoopActive,
+  submitFollowUp: mocks.submitFollowUp,
 }));
 
 vi.mock('@tools/childRunDelivery', () => ({
@@ -42,7 +35,6 @@ vi.mock('@tools/childRunDelivery', () => ({
 
 // Local imports
 import { AgentExecutionHandle } from '@agent/runtime/ExecutionHandle';
-import type { FollowUpWakeResult } from '@agent/followUp/ToolUseFollowUp';
 import { FileType, type FileStat } from '@platform/interfaces';
 import { AgentCategory, type StreamTabId } from '@shared/schemas';
 import {
@@ -142,24 +134,8 @@ describe('DelegationTools', () => {
   });
 });
 
-// Races the tool call's promise against a short timer so a regression that
-// re-introduces blocking (awaiting the resumed child's full turn) fails fast
-// instead of hanging until the child eventually resolves.
-async function raceAgainstBlockingResume<T>(
-  promise: Promise<T>,
-): Promise<{ settled: true; value: T } | { settled: false }> {
-  const TIMEOUT = Symbol('timeout');
-  const outcome = await Promise.race([
-    promise.then((value) => ({ settled: true as const, value })),
-    new Promise<typeof TIMEOUT>((resolve) =>
-      setTimeout(() => resolve(TIMEOUT), 50),
-    ),
-  ]);
-  return outcome === TIMEOUT ? { settled: false } : outcome;
-}
-
-describe('DelegateAgentTool resume (issue #7289)', () => {
-  const executionId = 'exec-resume-issue-7289';
+describe('DelegateAgentTool resume ownership', () => {
+  const executionId = 'exec-resume-ownership';
   const parentStreamId = 'parent-stream' as StreamTabId;
   const childStreamId = 'child-stream' as StreamTabId;
 
@@ -182,109 +158,40 @@ describe('DelegateAgentTool resume (issue #7289)', () => {
     mocks.currentSession.mockReturnValue({
       executions: { getHandle: () => makeHandle() },
     } as never);
-    mocks.sendFollowUp.mockResolvedValue({
-      status: 'queued',
-      reason: 'waiting',
-    });
     mocks.deliverChildRunFollowUp.mockResolvedValue({ kind: 'delivered' });
   });
 
-  it('does not dispatch a wake when a child-run loop is already listening on the resumed stream', async () => {
-    // The loop is already blocked in queue.waitAndDrainAll on the same
-    // FollowUpQueue instance sendFollowUp just enqueued into — the enqueue
-    // alone resolves it, so a wake here would race a second, competing
-    // resume through the generic host resume port (see childRunLoop.ts's
-    // isChildRunLoopActive doc comment).
-    mocks.isChildRunLoopActive.mockReturnValue(true);
-
-    const tool = new DelegateAgentTool();
-    const outcome = await raceAgainstBlockingResume(
-      tool.call({ execution_id: executionId, instruction: 'Keep going.' }),
-    );
-
-    assert.strictEqual(
-      outcome.settled,
-      true,
-      'delegate_agent resume blocked the parent tool call',
-    );
-    if (outcome.settled) {
-      assert.strictEqual(outcome.value.status, 'executed');
-    }
-    assert.strictEqual(mocks.wakeQueuedFollowUpStream.mock.calls.length, 0);
-  });
-
-  it('returns once the follow-up is queued, without waiting for the host resume port when no loop is listening', async () => {
-    mocks.isChildRunLoopActive.mockReturnValue(false);
-    let resolveWake: ((value: FollowUpWakeResult) => void) | undefined;
-    mocks.wakeQueuedFollowUpStream.mockReturnValue(
-      new Promise<FollowUpWakeResult>((resolve) => {
-        resolveWake = resolve;
-      }),
-    );
-
-    const tool = new DelegateAgentTool();
-    const outcome = await raceAgainstBlockingResume(
-      tool.call({ execution_id: executionId, instruction: 'Keep going.' }),
-    );
-
-    assert.strictEqual(
-      outcome.settled,
-      true,
-      'delegate_agent resume blocked the parent tool call on the host resume port',
-    );
-    if (outcome.settled) {
-      assert.strictEqual(outcome.value.status, 'executed');
-    }
-    assert.strictEqual(mocks.wakeQueuedFollowUpStream.mock.calls.length, 1);
-
-    resolveWake?.({ kind: 'resumed' });
-  });
-
-  it('delivers a terminal error to the parent when the wake resolves as failed (no thrown exception)', async () => {
-    // Regression: the removed NativeSubagentStrategy delivered a terminal
-    // error to the orchestrator on this exact wake failure. Without it, this
-    // tool call returns a normal "queued" success and the parent never
-    // hears back — a silent hang, not a visible error.
-    mocks.isChildRunLoopActive.mockReturnValue(false);
-    mocks.wakeQueuedFollowUpStream.mockResolvedValue({
-      kind: 'queued_resume_failed',
+  it('uses the merged submission result without a caller-local owner check', async () => {
+    mocks.submitFollowUp.mockResolvedValue({
+      status: 'queued',
+      reason: 'waiting',
+      continuation: 'live',
     });
 
-    const tool = new DelegateAgentTool();
-    const result = await tool.call({
+    const result = await new DelegateAgentTool().call({
       execution_id: executionId,
       instruction: 'Keep going.',
     });
-    assert.strictEqual(result.status, 'executed');
 
-    await vi.waitFor(() => {
-      assert.strictEqual(mocks.deliverChildRunFollowUp.mock.calls.length, 1);
-    });
-    const [deliveryArgs] = mocks.deliverChildRunFollowUp.mock.calls;
-    assert.strictEqual(deliveryArgs[0].targetStreamId, parentStreamId);
-    assert.match(deliveryArgs[0].followUp.text, /<subagent-error/);
-    assert.strictEqual(deliveryArgs[0].followUp.origin, 'subagent_result');
-    assert.strictEqual(deliveryArgs[0].wake, true);
+    assert.strictEqual(result.status, 'executed');
+    assert.strictEqual(mocks.submitFollowUp.mock.calls.length, 1);
+    assert.strictEqual(mocks.deliverChildRunFollowUp.mock.calls.length, 0);
   });
 
-  it('delivers a terminal error to the parent when the wake itself throws', async () => {
-    mocks.isChildRunLoopActive.mockReturnValue(false);
-    mocks.wakeQueuedFollowUpStream.mockRejectedValue(
-      new Error('resume storage unreadable'),
-    );
+  it('reports a merged recovery failure to the parent', async () => {
+    mocks.submitFollowUp.mockResolvedValue({
+      status: 'queued',
+      reason: 'waiting',
+      continuation: 'resume_failed',
+    });
 
-    const tool = new DelegateAgentTool();
-    const result = await tool.call({
+    await new DelegateAgentTool().call({
       execution_id: executionId,
       instruction: 'Keep going.',
     });
-    assert.strictEqual(result.status, 'executed');
 
-    await vi.waitFor(() => {
-      assert.strictEqual(mocks.deliverChildRunFollowUp.mock.calls.length, 1);
-    });
-    const [deliveryArgs] = mocks.deliverChildRunFollowUp.mock.calls;
-    assert.strictEqual(deliveryArgs[0].targetStreamId, parentStreamId);
-    assert.match(deliveryArgs[0].followUp.text, /resume storage unreadable/);
+    await vi.waitFor(() =>
+      assert.strictEqual(mocks.deliverChildRunFollowUp.mock.calls.length, 1),
+    );
   });
 });

--- a/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
@@ -67,7 +67,7 @@ async function launchBackgroundRun(
     },
   );
   const followUp = vi
-    .spyOn(toolUseFollowUp, 'sendFollowUp')
+    .spyOn(toolUseFollowUp, 'submitFollowUp')
     .mockResolvedValue({ status: 'sent' });
 
   const { host } = createRecordingHost();

--- a/src/test-kernel/tools/InquiryContinuationSession.vitest.ts
+++ b/src/test-kernel/tools/InquiryContinuationSession.vitest.ts
@@ -3,14 +3,9 @@ import '@test/support/defaultSessionTestSetup';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const sendFollowUpMock = vi.hoisted(() =>
+const submitFollowUpMock = vi.hoisted(() =>
   vi.fn<(...args: unknown[]) => Promise<unknown>>(async () => ({
     status: 'sent' as const,
-  })),
-);
-const wakeQueuedFollowUpStreamMock = vi.hoisted(() =>
-  vi.fn<(...args: unknown[]) => Promise<unknown>>(async () => ({
-    kind: 'not_required' as const,
   })),
 );
 const getThreadSummaryMock = vi.hoisted(() => vi.fn());
@@ -18,8 +13,7 @@ const listOpenThreadsForStreamMock = vi.hoisted(() => vi.fn(async () => []));
 const readExternalInquiryThreadMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@agent/followUp/ToolUseFollowUp', () => ({
-  sendFollowUp: sendFollowUpMock,
-  wakeQueuedFollowUpStream: wakeQueuedFollowUpStreamMock,
+  submitFollowUp: submitFollowUpMock,
 }));
 
 vi.mock('@platform/platform', () => ({
@@ -73,11 +67,7 @@ function answeredManifest(): ExternalInquiryThreadManifest {
 
 describe('external inquiry continuation session routing', () => {
   beforeEach(() => {
-    sendFollowUpMock.mockClear();
-    wakeQueuedFollowUpStreamMock.mockReset();
-    wakeQueuedFollowUpStreamMock.mockResolvedValue({
-      kind: 'not_required' as const,
-    });
+    submitFollowUpMock.mockClear();
     getThreadSummaryMock.mockResolvedValue({
       threadId: THREAD,
       parentStreamId: STREAM,
@@ -100,21 +90,10 @@ describe('external inquiry continuation session routing', () => {
     );
 
     expect(outcome).toBe('sent');
-    expect(sendFollowUpMock).toHaveBeenCalledWith(
+    expect(submitFollowUpMock).toHaveBeenCalledWith(
       STREAM,
       expect.stringContaining('[inquiry] ei_aabbccdd0011 answered.'),
-      undefined,
-      undefined,
-      session,
-    );
-    // The wake/resume/release decision must route to the same session
-    // that owns this continuation (e.g. a desktop window), not fall back
-    // to currentSession() / the platform default.
-    expect(wakeQueuedFollowUpStreamMock).toHaveBeenCalledWith(
-      STREAM,
-      { status: 'sent' },
-      undefined,
-      session,
+      { session },
     );
   });
 
@@ -272,12 +251,10 @@ describe('external inquiry continuation session routing', () => {
 
   it('delegates queued wake decisions to the follow-up owner, threading the session', async () => {
     const session = { tag: 'desktop-session' } as unknown as SessionHandle;
-    sendFollowUpMock.mockResolvedValueOnce({
+    submitFollowUpMock.mockResolvedValueOnce({
       status: 'queued',
       reason: 'waiting',
-    });
-    wakeQueuedFollowUpStreamMock.mockResolvedValueOnce({
-      kind: 'resumed' as const,
+      continuation: 'resumed' as const,
     });
 
     const outcome = await injectContinuationForAnsweredThread(
@@ -287,21 +264,13 @@ describe('external inquiry continuation session routing', () => {
     );
 
     expect(outcome).toBe('resumed');
-    expect(wakeQueuedFollowUpStreamMock).toHaveBeenCalledWith(
-      STREAM,
-      { status: 'queued', reason: 'waiting' },
-      undefined,
-      session,
-    );
   });
 
   it('passes an undefined session through to the wake decision when none was provided', async () => {
-    sendFollowUpMock.mockResolvedValueOnce({
+    submitFollowUpMock.mockResolvedValueOnce({
       status: 'queued',
       reason: 'waiting',
-    });
-    wakeQueuedFollowUpStreamMock.mockResolvedValueOnce({
-      kind: 'resumed' as const,
+      continuation: 'resumed' as const,
     });
 
     const outcome = await injectContinuationForAnsweredThread(
@@ -310,21 +279,11 @@ describe('external inquiry continuation session routing', () => {
     );
 
     expect(outcome).toBe('resumed');
-    expect(wakeQueuedFollowUpStreamMock).toHaveBeenCalledWith(
-      STREAM,
-      { status: 'queued', reason: 'waiting' },
-      undefined,
-      undefined,
-    );
   });
 
   it('archives inquiries when the follow-up owner drops a stale queue', async () => {
-    sendFollowUpMock.mockResolvedValueOnce({
-      status: 'queued',
-      reason: 'children_running',
-    });
-    wakeQueuedFollowUpStreamMock.mockResolvedValueOnce({
-      kind: 'dropped' as const,
+    submitFollowUpMock.mockResolvedValueOnce({
+      status: 'dropped' as const,
     });
 
     const outcome = await injectContinuationForAnsweredThread(

--- a/src/test-kernel/tools/InquiryReadBoundary.vitest.ts
+++ b/src/test-kernel/tools/InquiryReadBoundary.vitest.ts
@@ -3,20 +3,14 @@ import '@test/support/defaultSessionTestSetup';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const sendFollowUpMock = vi.hoisted(() =>
+const submitFollowUpMock = vi.hoisted(() =>
   vi.fn<(...args: unknown[]) => Promise<unknown>>(async () => ({
     status: 'sent' as const,
   })),
 );
-const wakeQueuedFollowUpStreamMock = vi.hoisted(() =>
-  vi.fn<(...args: unknown[]) => Promise<unknown>>(async () => ({
-    kind: 'not_required' as const,
-  })),
-);
 
 vi.mock('@agent/followUp/ToolUseFollowUp', () => ({
-  sendFollowUp: sendFollowUpMock,
-  wakeQueuedFollowUpStream: wakeQueuedFollowUpStreamMock,
+  submitFollowUp: submitFollowUpMock,
 }));
 
 import { ExternalInquiryRequestHandler } from '@controllers/progressView/backend/ExternalInquiryRequestHandler';
@@ -167,8 +161,7 @@ describe('external inquiry read boundary', () => {
   setupPlatform();
 
   beforeEach(() => {
-    sendFollowUpMock.mockClear();
-    wakeQueuedFollowUpStreamMock.mockClear();
+    submitFollowUpMock.mockClear();
   });
 
   it('hydrates legacy answers through inquiry read', async () => {
@@ -193,12 +186,10 @@ describe('external inquiry read boundary', () => {
     const outcome = await injectContinuationForAnsweredThread(THREAD);
 
     expect(outcome).toBe('sent');
-    expect(sendFollowUpMock).toHaveBeenCalledWith(
+    expect(submitFollowUpMock).toHaveBeenCalledWith(
       STREAM,
       expect.stringContaining('Legacy A'),
-      undefined,
-      undefined,
-      undefined,
+      { session: undefined },
     );
   });
 

--- a/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
+++ b/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
@@ -12,10 +12,7 @@ import { setTimeout as sleep } from 'node:timers/promises';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports
-import {
-  isChildRunLoopActive,
-  startChildRunLoop,
-} from '@agent/runtime/childRunLoop';
+import { startChildRunLoop } from '@agent/runtime/childRunLoop';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { AgentFlowError } from '@agent/runtime/AgentFlowResult';
 import { AgentExecutionHandle } from '@agent/runtime/ExecutionHandle';
@@ -27,8 +24,7 @@ import {
 } from '@shared/schemas';
 
 const mocks = vi.hoisted(() => ({
-  enqueueChildRunFollowUp: vi.fn(),
-  wakeChildRunFollowUp: vi.fn(),
+  deliverChildRunFollowUp: vi.fn(),
   executeAgent: vi.fn(),
   finalizeExecution: vi.fn(),
   persistChildRunReport: vi.fn(),
@@ -67,8 +63,7 @@ vi.mock('@agent/runtime/SessionResumeRetrieval', () => ({
 }));
 
 vi.mock('@tools/childRunDelivery', () => ({
-  enqueueChildRunFollowUp: mocks.enqueueChildRunFollowUp,
-  wakeChildRunFollowUp: mocks.wakeChildRunFollowUp,
+  deliverChildRunFollowUp: mocks.deliverChildRunFollowUp,
   persistChildRunReport: mocks.persistChildRunReport,
   persistChildRunResultMeta: mocks.persistChildRunResultMeta,
 }));
@@ -107,11 +102,7 @@ function baseParams(
 describe('NativeSubagentStrategy', () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    mocks.enqueueChildRunFollowUp.mockResolvedValue({
-      kind: 'enqueued',
-      sendResult: { status: 'sent' },
-    });
-    mocks.wakeChildRunFollowUp.mockResolvedValue({ kind: 'delivered' });
+    mocks.deliverChildRunFollowUp.mockResolvedValue({ kind: 'delivered' });
     mocks.persistChildRunReport.mockResolvedValue({ kind: 'persisted' });
     mocks.persistChildRunResultMeta.mockResolvedValue({ kind: 'skipped' });
     mocks.finalizeExecution.mockResolvedValue({
@@ -645,19 +636,25 @@ describe('NativeSubagentStrategy', () => {
         strategy,
       });
       await vi.waitFor(() =>
-        expect(mocks.enqueueChildRunFollowUp).toHaveBeenCalledTimes(1),
+        expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledTimes(1),
       );
 
-      session.followUps.acquire(childStreamId).enqueue({
-        text: 'Also state exactly where finiteness is used.',
-        origin: 'user',
-      });
+      expect(
+        session.followUps.submit(
+          childStreamId,
+          {
+            text: 'Also state exactly where finiteness is used.',
+            origin: 'user',
+          },
+          'live_owner',
+        ),
+      ).toEqual({ kind: 'live' });
 
       await vi.waitFor(() =>
         expect(mocks.resumeToolUseFromResumeData).toHaveBeenCalledTimes(1),
       );
       await vi.waitFor(() =>
-        expect(mocks.enqueueChildRunFollowUp).toHaveBeenCalledTimes(2),
+        expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledTimes(2),
       );
       // Give an accidentally re-enqueued batch enough time to start a second
       // immediate resume. The guarded mock above prevents an actual busy loop.
@@ -679,22 +676,22 @@ describe('NativeSubagentStrategy', () => {
       ]);
       expect(session.followUps.getAll(childStreamId)).toEqual([]);
       expect(session.status.get(childStreamId)).toBe(STREAM_PHASE.WAITING);
-      const resumedDeliveries = mocks.enqueueChildRunFollowUp.mock.calls.filter(
+      const resumedDeliveries = mocks.deliverChildRunFollowUp.mock.calls.filter(
         ([delivery]) => delivery.followUp.text.includes('follow-up response'),
       );
       expect(resumedDeliveries).toHaveLength(1);
     } finally {
       const handleWasTracked =
         session.executions.getHandle(executionId) !== undefined;
-      if (isChildRunLoopActive(childStreamId)) handle.interrupt();
+      if (session.followUps.hasLiveOwner(childStreamId)) handle.interrupt();
       await vi.waitFor(() =>
-        expect(isChildRunLoopActive(childStreamId)).toBe(false),
+        expect(session.followUps.hasLiveOwner(childStreamId)).toBe(false),
       );
       if (handleWasTracked) await handle.result;
       if (session.executions.getHandle(executionId)) {
         session.executions.untrack(executionId);
       }
-      session.followUps.release(childStreamId);
+      session.followUps.terminalize(childStreamId);
       session.status.clearStream(childStreamId);
     }
   });
@@ -785,16 +782,16 @@ describe('NativeSubagentStrategy', () => {
       });
 
       await vi.waitFor(() =>
-        expect(mocks.enqueueChildRunFollowUp).toHaveBeenCalledTimes(1),
+        expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledTimes(1),
       );
       await vi.waitFor(() =>
-        expect(isChildRunLoopActive(childStreamId)).toBe(false),
+        expect(session.followUps.hasLiveOwner(childStreamId)).toBe(false),
       );
 
       expect(mocks.resumeToolUseFromResumeData).not.toHaveBeenCalled();
       expect(mocks.retrieveSessionResumeData).not.toHaveBeenCalled();
     } finally {
-      session.followUps.release(childStreamId);
+      session.followUps.terminalize(childStreamId);
       session.status.clearStream(childStreamId);
     }
   });

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -22,11 +22,7 @@ import {
   tryUseRunContext,
 } from '@agent/runtime/RunContext';
 import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
-import { isChildRunLoopActive } from '@agent/runtime/childRunLoop';
-import {
-  sendFollowUp,
-  wakeQueuedFollowUpStream,
-} from '@agent/followUp/ToolUseFollowUp';
+import { submitFollowUp } from '@agent/followUp/ToolUseFollowUp';
 import * as logger from '@logger/logUtils';
 import {
   AgentCategory,
@@ -90,7 +86,6 @@ async function deliverResumeWakeFailure(
     targetStreamId: handle.parentStreamId,
     followUp: { text: msg, origin: 'subagent_result' },
     session,
-    wake: true,
   });
   if (delivery.kind !== 'delivered') {
     logger.warn(
@@ -317,52 +312,25 @@ Git worktree support: resolved from the active workspace at runtime.`,
     }
 
     const framedInstruction = formatFollowUpInstruction(instruction);
-    const result = await sendFollowUp(handle.childStreamId, framedInstruction);
-
-    // Dispatch the wake without awaiting it: waking a WAITING subagent resumes
-    // its run all the way to the next WAITING/terminal boundary, which can be
-    // an entire child turn. This tool call only hands the follow-up off — the
-    // result (or the wake's own failure) arrives asynchronously via the
-    // follow-up queue, same as the original delegation's async-arrival
-    // contract. Awaiting it here would stall this tool call, and the parent
-    // orchestrator's whole turn with it, for as long as the child keeps
-    // running (see #7289).
-    //
-    // A live child-run loop for this stream is already blocked in
-    // `queue.waitAndDrainAll` on the same `FollowUpQueue` instance
-    // `sendFollowUp` just enqueued into — the enqueue alone resolves that
-    // wait (see `isChildRunLoopActive`), so an additional wake here would
-    // race a second, competing resume through the generic host-level
-    // restart-recovery path against the loop's own in-flight continuation.
-    // Only genuinely wake when no loop is listening — a restarted process,
-    // where the persisted stream is WAITING but nothing in this process is
-    // watching its queue.
-    if (!isChildRunLoopActive(handle.childStreamId)) {
-      // A wake failure (thrown, or a resolved 'queued_resume_failed'/
-      // 'dropped' outcome) means the child will never actually resume and
-      // deliver a result — the orchestrator would otherwise see this tool
-      // call return a normal "queued" success and then silently never hear
-      // back. Deliver a terminal error to the parent on that failure, same
-      // as the deleted NativeSubagentStrategy.wakeQueuedFollowUp used to.
-      wakeQueuedFollowUpStream(handle.childStreamId, result, undefined, session)
-        .then((wakeResult) => {
-          if (
-            wakeResult.kind === 'queued_resume_failed' ||
-            wakeResult.kind === 'dropped'
-          ) {
-            return deliverResumeWakeFailure(
-              handle,
-              session,
-              executionId,
-              new Error(
-                `Resume wake failed (${wakeResult.kind}): the subagent's follow-up could not be delivered to a resumed run.`,
-              ),
-            );
-          }
-        })
-        .catch((err: unknown) =>
-          deliverResumeWakeFailure(handle, session, executionId, err),
-        );
+    const result = await submitFollowUp(
+      handle.childStreamId,
+      framedInstruction,
+      {
+        session,
+      },
+    );
+    if (
+      result.status === 'dropped' ||
+      (result.status === 'queued' && result.continuation === 'resume_failed')
+    ) {
+      void deliverResumeWakeFailure(
+        handle,
+        session,
+        executionId,
+        new Error(
+          'The subagent follow-up could not be delivered to a live or recovered continuation.',
+        ),
+      );
     }
 
     switch (result.status) {
@@ -387,6 +355,10 @@ Git worktree support: resolved from the active workspace at runtime.`,
       case 'no_session':
         throw new Error(
           `No active session for '${handle.agentName}' (stream status: ${result.streamStatus ?? 'unknown'}). The subagent may have stopped or its session expired.`,
+        );
+      case 'dropped':
+        throw new Error(
+          `No continuation owner is available for '${handle.agentName}'.`,
         );
     }
   }

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -12,6 +12,7 @@ import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { currentSession } from '@agent/runtime/SessionHandle';
 import { getCurrentToolContexts } from '@agent/followUp/ToolFileInteractionContext';
+import { submitFollowUp } from '@agent/followUp/ToolUseFollowUp';
 import type { RunContext } from '@agent/runtime/RunContext';
 import type {
   ExecutionId,
@@ -71,7 +72,7 @@ export interface AgentCliResumeLabels {
   queuedLabel: string;
 }
 
-function queueAgentCliFollowUp(
+async function queueAgentCliFollowUp(
   stored: ResumableAgentCliSession,
   params: {
     id: string;
@@ -79,7 +80,7 @@ function queueAgentCliFollowUp(
     callerStreamId: StreamTabId | undefined;
     labels: AgentCliResumeLabels;
   },
-): ToolResult {
+): Promise<ToolResult> {
   const { id, prompt, callerStreamId, labels } = params;
   if (callerStreamId && stored.parentStreamId !== callerStreamId) {
     throw new ToolError(
@@ -87,9 +88,14 @@ function queueAgentCliFollowUp(
     );
   }
 
-  currentSession().followUps.acquire(stored.childStreamId).enqueue({
-    text: prompt,
+  const result = await submitFollowUp(stored.childStreamId, prompt, {
+    session: currentSession(),
   });
+  if (result.status === 'no_session' || result.status === 'dropped') {
+    throw new ToolError(
+      `${labels.notActiveLabel} '${id}' no longer has a resumable continuation.`,
+    );
+  }
 
   const preview = truncateWithEllipsis(prompt, 60);
   return {
@@ -137,7 +143,7 @@ export async function resumeOrLaunchAgentCliSession(
 
     const stored = await store.waitForActive(id);
     if (!stored) continue;
-    return queueAgentCliFollowUp(stored, {
+    return await queueAgentCliFollowUp(stored, {
       id,
       prompt: params.prompt,
       callerStreamId: params.callerStreamId,

--- a/src/tools/approval/index.ts
+++ b/src/tools/approval/index.ts
@@ -88,7 +88,7 @@ export function releaseStreamResources(
   session: SessionHandle = defaultSession(),
 ): void {
   cleanupApprovalsForStream(streamId, session);
-  session.followUps.release(streamId);
+  session.followUps.terminalize(streamId);
 }
 
 /**

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -43,11 +43,7 @@ import {
   deriveRunOutcome,
   projectRunOutcome,
 } from '@shared/streams/streamStatus';
-import {
-  enqueueChildRunFollowUp,
-  wakeChildRunFollowUp,
-  type ChildRunEnqueueResult,
-} from '@tools/childRunDelivery';
+import { deliverChildRunFollowUp } from '@tools/childRunDelivery';
 import { requireRunStream } from '@tools/contextHelpers';
 import {
   formatBashDelivery,
@@ -513,69 +509,28 @@ export class BashTool extends defineTool({
       }
     };
 
-    const enqueueParentFollowUp = async (
-      text: string,
-    ): Promise<ChildRunEnqueueResult | undefined> => {
-      try {
-        return await enqueueChildRunFollowUp({
-          targetStreamId: parentStreamId,
-          followUp: { text, origin: 'subagent_result' },
-          session: runSession,
-        });
-      } catch (err: unknown) {
-        logBackgroundFailure('enqueue', err);
-        return undefined;
-      }
-    };
-
-    // Wake the parent only after this child is finalized (see #8093): waking
-    // a WAITING parent can await its entire resumed turn
-    // (`agentResume.tryResumeStream` → … → `resumeToolUseFromResumeData`), and
-    // that resumed turn may itself wait on this execution — so finalizing
-    // first keeps a self-stall impossible instead of merely unlikely.
-    const wakeParentFollowUp = async (
-      enqueueResult: ChildRunEnqueueResult | undefined,
-    ): Promise<void> => {
-      if (!enqueueResult) return;
-      if (enqueueResult.kind === 'no_session') {
-        logger.debug(
-          'Background bash follow-up dropped: parent stream has no active session.',
-          {
-            data: {
-              parentStreamId,
-              streamStatus: enqueueResult.streamStatus ?? 'unknown',
-            },
-          },
-        );
-        return;
-      }
-      try {
-        const delivery = await wakeChildRunFollowUp(
-          parentStreamId,
-          enqueueResult,
-          runSession,
-        );
-        if (delivery.kind === 'dropped') {
-          logger.warn(
-            'Background bash follow-up dropped: parent stream is gone and could not be resumed.',
-            { data: { parentStreamId } },
-          );
-        }
-      } catch (err: unknown) {
-        logBackgroundFailure('wake', err);
-      }
-    };
-
     const deliverAndFinalize = async (
       text: string,
       finalizeOptions: Parameters<typeof finalizeBackground>[0],
     ): Promise<void> => {
-      // Order matters (see #8093): enqueue the result (fast), finalize this
-      // child so its terminal state is visible in the in-memory execution
-      // registry, then wake the parent — never the other way around.
-      const enqueueResult = await enqueueParentFollowUp(text);
+      // The child is terminal before the continuation is submitted, so a
+      // synchronously claimed parent recovery can never observe it as running.
       await finalizeBackground(finalizeOptions);
-      await wakeParentFollowUp(enqueueResult);
+      try {
+        const delivery = await deliverChildRunFollowUp({
+          targetStreamId: parentStreamId,
+          followUp: { text, origin: 'subagent_result' },
+          session: runSession,
+        });
+        if (delivery.kind !== 'delivered') {
+          logger.warn(
+            'Background bash follow-up dropped: parent stream is unavailable.',
+            { data: { parentStreamId } },
+          );
+        }
+      } catch (err: unknown) {
+        logBackgroundFailure('delivery', err);
+      }
     };
 
     void runWithOwnership(async () => {

--- a/src/tools/childRunDelivery.ts
+++ b/src/tools/childRunDelivery.ts
@@ -47,11 +47,11 @@ export async function deliverChildRunFollowUp(params: {
   readonly targetStreamId: StreamTabId;
   readonly followUp: FollowUpQueueInput;
   readonly session: SessionHandle;
-  readonly mode?: 'continuation' | 'live_notification';
+  readonly mode?: 'continuation' | 'live_notification' | 'child_delivery';
 }): Promise<ChildRunDeliveryResult> {
   const result = await submitFollowUp(params.targetStreamId, params.followUp, {
     session: params.session,
-    mode: params.mode,
+    mode: params.mode ?? 'child_delivery',
   });
   if (result.status === 'no_session') {
     return { kind: 'no_session', streamStatus: result.streamStatus };

--- a/src/tools/childRunDelivery.ts
+++ b/src/tools/childRunDelivery.ts
@@ -1,19 +1,7 @@
-/**
- * Shared mechanics for delivering child-run results to an owning parent stream.
- *
- * Callers own their result format, duplicate-delivery policy, and warning text.
- * This module owns only the common boundary actions: best-effort report writes,
- * follow-up enqueue, and optional wake-or-release of a force-opened queue.
- */
-
-// Local imports
+/** Shared persistence and parent-continuation delivery for child runs. */
 import { getExecutionStore, type ResultMeta } from '@agent/storage';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
-import {
-  sendFollowUp,
-  wakeOrReleaseQueuedStream,
-  type SendFollowUpResult,
-} from '@agent/followUp/ToolUseFollowUp';
+import { submitFollowUp } from '@agent/followUp/ToolUseFollowUp';
 import type { FollowUpQueueInput } from '@agent/followUp/FollowUpQueue';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 
@@ -21,15 +9,6 @@ export type ChildRunDeliveryResult =
   | { kind: 'delivered' }
   | { kind: 'no_session'; streamStatus: string | undefined }
   | { kind: 'dropped' };
-
-/**
- * Outcome of the fast "enqueue" half of delivery — appending to (or queueing
- * on) the parent stream's follow-up queue. Never waits on a resumed parent
- * turn; safe to await before a caller finalizes its own child.
- */
-export type ChildRunEnqueueResult =
-  | { kind: 'enqueued'; sendResult: SendFollowUpResult }
-  | { kind: 'no_session'; streamStatus: string | undefined };
 
 export type ChildRunReportResult =
   { kind: 'persisted' } | { kind: 'failed'; err: unknown };
@@ -55,9 +34,7 @@ export async function persistChildRunResultMeta(
   executionId: ExecutionId,
   resultMeta: ResultMeta | undefined,
 ): Promise<ChildRunResultMetaResult> {
-  if (!resultMeta) {
-    return { kind: 'skipped' };
-  }
+  if (!resultMeta) return { kind: 'skipped' };
   try {
     await getExecutionStore(executionId).writeResultMeta(resultMeta);
     return { kind: 'persisted' };
@@ -66,76 +43,20 @@ export async function persistChildRunResultMeta(
   }
 }
 
-/**
- * Enqueue a child-run result on the parent stream's follow-up queue. Never
- * awaits a resumed parent turn — callers that must finalize their own child
- * before the wake step (see {@link wakeChildRunFollowUp}) call this first.
- */
-export async function enqueueChildRunFollowUp(params: {
-  readonly targetStreamId: StreamTabId;
-  readonly followUp: FollowUpQueueInput;
-  readonly session: SessionHandle;
-}): Promise<ChildRunEnqueueResult> {
-  const result = await sendFollowUp(
-    params.targetStreamId,
-    params.followUp,
-    undefined,
-    undefined,
-    params.session,
-  );
-  return result.status === 'no_session'
-    ? { kind: 'no_session', streamStatus: result.streamStatus }
-    : { kind: 'enqueued', sendResult: result };
-}
-
-/**
- * Wake (or release) the parent stream for a result already enqueued via
- * {@link enqueueChildRunFollowUp}. This is the half that can await an entire
- * resumed parent turn (`agentResume.tryResumeStream` → … →
- * `resumeToolUseFromResumeData`) — call it only after any of this child's own
- * finalization work is done, so a resumed parent that immediately waits on
- * this child's execution never races its own wake.
- */
-export async function wakeChildRunFollowUp(
-  targetStreamId: StreamTabId,
-  enqueueResult: ChildRunEnqueueResult,
-  session: SessionHandle,
-): Promise<ChildRunDeliveryResult> {
-  if (enqueueResult.kind === 'no_session') {
-    return { kind: 'no_session', streamStatus: enqueueResult.streamStatus };
-  }
-  return (await wakeOrReleaseQueuedStream(
-    targetStreamId,
-    enqueueResult.sendResult,
-    session,
-  ))
-    ? { kind: 'delivered' }
-    : { kind: 'dropped' };
-}
-
-/**
- * Enqueue-then-wake in one call, for callers with no finalization step to
- * order the wake after (e.g. a live-progress notification, or a wake-failure
- * error report). Callers that finalize their own child around delivery use
- * {@link enqueueChildRunFollowUp} and {@link wakeChildRunFollowUp} directly,
- * with the finalize sandwiched between them.
- */
 export async function deliverChildRunFollowUp(params: {
   readonly targetStreamId: StreamTabId;
   readonly followUp: FollowUpQueueInput;
   readonly session: SessionHandle;
-  readonly wake?: boolean;
+  readonly mode?: 'continuation' | 'live_notification';
 }): Promise<ChildRunDeliveryResult> {
-  const enqueueResult = await enqueueChildRunFollowUp(params);
-  if (enqueueResult.kind === 'no_session') {
-    return { kind: 'no_session', streamStatus: enqueueResult.streamStatus };
+  const result = await submitFollowUp(params.targetStreamId, params.followUp, {
+    session: params.session,
+    mode: params.mode,
+  });
+  if (result.status === 'no_session') {
+    return { kind: 'no_session', streamStatus: result.streamStatus };
   }
-  if (!params.wake) {
-    return { kind: 'delivered' };
-  }
-  return wakeChildRunFollowUp(
-    params.targetStreamId,
-    enqueueResult,
-    params.session,
-  );
+  return result.status === 'dropped'
+    ? { kind: 'dropped' }
+    : { kind: 'delivered' };
 }

--- a/src/tools/github/StreamSubscriptionRegistry.ts
+++ b/src/tools/github/StreamSubscriptionRegistry.ts
@@ -13,7 +13,7 @@
 
 import type { AgentTrace } from '@agent/trace';
 import { createChannelTrace } from '@agent/trace';
-import { sendFollowUp } from '@agent/followUp/ToolUseFollowUp';
+import { submitFollowUp } from '@agent/followUp/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/followUp/ToolUseFollowUpQueueManager';
 import {
   currentSession,
@@ -110,13 +110,10 @@ export class StreamSubscriptionRegistry<K extends string, Input> {
       session,
     };
     subscription.onEvent = (text: string) => {
-      void sendFollowUp(
-        streamId,
-        text,
-        undefined,
-        undefined,
-        subscription.session,
-      )
+      void submitFollowUp(streamId, text, {
+        session: subscription.session,
+        mode: 'live_notification',
+      })
         .then((result) => {
           if (result.status === 'sent' || result.status === 'queued') {
             subscription.session.events.emit({

--- a/src/tools/inquiry/inquiryContinuation.ts
+++ b/src/tools/inquiry/inquiryContinuation.ts
@@ -14,9 +14,8 @@
 
 import { createChannelTrace } from '@agent/trace';
 import {
-  sendFollowUp,
-  wakeQueuedFollowUpStream,
-  type FollowUpWakeResult,
+  submitFollowUp,
+  type SubmitFollowUpResult,
 } from '@agent/followUp/ToolUseFollowUp';
 import {
   getRunContextSession,
@@ -129,22 +128,14 @@ async function emitInquiryThreadUpdate(
   });
 }
 
-function mapWakeResultToInquiryOutcome(
-  result: FollowUpWakeResult,
+function mapSubmissionToInquiryOutcome(
+  result: SubmitFollowUpResult,
 ): InjectionOutcome {
-  switch (result.kind) {
-    case 'not_required':
-      return 'sent';
-    case 'resumed':
-      return 'resumed';
-    case 'dropped':
-      return 'archived';
-    case 'queued_without_wake':
-    case 'resume_in_flight':
-    case 'active_or_resuming':
-    case 'queued_resume_failed':
-      return 'queued';
+  if (result.status === 'sent') return 'sent';
+  if (result.status === 'dropped' || result.status === 'no_session') {
+    return 'archived';
   }
+  return result.continuation === 'resumed' ? 'resumed' : 'queued';
 }
 
 function mapInjectionOutcomeToResumeOutcome(
@@ -159,13 +150,9 @@ async function deliverContinuation(params: {
   threadId: ExternalInquiryThreadId;
   session?: SessionHandle;
 }): Promise<InjectionOutcome> {
-  const result = await sendFollowUp(
-    params.parentStreamId,
-    params.text,
-    undefined,
-    undefined,
-    params.session,
-  );
+  const result = await submitFollowUp(params.parentStreamId, params.text, {
+    session: params.session,
+  });
 
   if (result.status === 'no_session') {
     logger.warn(
@@ -179,14 +166,7 @@ async function deliverContinuation(params: {
     return 'archived';
   }
 
-  const outcome = mapWakeResultToInquiryOutcome(
-    await wakeQueuedFollowUpStream(
-      params.parentStreamId,
-      result,
-      undefined,
-      params.session,
-    ),
-  );
+  const outcome = mapSubmissionToInquiryOutcome(result);
 
   await emitInquiryThreadUpdate(
     params.threadId,


### PR DESCRIPTION
## Summary

Fixes a severe continuation race in which concurrent follow-ups could start competing resume owners for the same delegated stream and replay terminal child output thousands of times.

- Replaces the split enqueue/wake protocol with one generation-scoped queue lease per stream.
- Routes all user input, child delivery, live notifications, and persisted recovery through `submitFollowUp`.
- Preserves final child and background-Bash results after the child is untracked by admitting them only to an already-retained recoverable parent queue; terminal queues cannot be reopened.
- Preserves the existing `sent` notification for ordinary active-flow input while keeping automatic live notifications session-internal.
- Keeps desktop follow-up IPC non-blocking while a resumed agent turn runs; any delayed presentation is replayed when a window attaches.
- Threads recovery leases through extension, desktop, and CLI resume paths, including direct/manual resume after restart.

## Issue acceptance gates

- Concurrent submissions synchronously claim at most one recovery owner.
- A live child loop remains the sole continuation owner across waiting, between-turn, and active-turn states.
- Repeated follow-ups are ordered once and do not create duplicate host resumes.
- Direct resume creates the missing in-memory queue after restart.
- The last native child or background Bash result reaches a completed parent through its retained recoverable queue after child finalization.
- Finalized parent queues are not revived by stale child output.
- Active-flow user input emits the established `followUpSent` fact; automatic progress notifications do not.
- Desktop IPC returns without waiting for the resumed turn.

## Design

`ToolUseFollowUpQueue` is the single authority for queue ownership. Synchronous, generation-scoped `flow`, `child`, and `recovery` leases replace the former module-level in-flight guards and caller-local ownership tests. `submitFollowUp` is the single admission and continuation boundary.

The last-child ordering repair does not restore the old two-step protocol. Child delivery uses an `existing_recoverable` admission that can consume only the parent queue retained while children were active. It cannot create a queue for a terminal stream.

## Host impact

- **Extension:** follow-ups and direct/manual resumes use the shared recovery lease.
- **Desktop:** follow-up submission remains detached from the duration of a resumed turn, with replayable delayed messages.
- **CLI:** the recovery lease is forwarded through the TUI resume adapter instead of being dropped.

## Scope

The complete PR changes 62 files because the ownership contract is shared by the runtime, three hosts, and their tests. The final review-fix commit changes 7 files and adds focused coverage for active-flow notification semantics, last-child delivery after untracking, terminal non-revival, and desktop IPC detachment.

No compatibility shim, persisted schema, event key, or host-specific ownership path was added.

## Validation

- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run compile:fast`
- `npm test` — 787 files passed; 7,831 tests passed; 1 file and 4 tests skipped
- 159 focused follow-up, child-loop, Bash, resume, and desktop tests passed
- `npm run check:dead-code-ratchet` — 17 current / 17 baseline
- `git diff --check`

Closes #9345