### PR TITLE
feat(agent): add an 'inline' AgentSource for definitions supplied as values

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -657,7 +657,10 @@ function createWindow(options: {
             return platform().agentDirectories.builtIn();
           case 'builtInToolUse':
             return platform().agentDirectories.builtInToolUse();
+          // No local directory: remote agents live in Supabase, inline ones
+          // were supplied as values and were never written to disk.
           case 'remote':
+          case 'inline':
             return Promise.resolve(undefined);
         }
       },

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -43,6 +43,7 @@ const SOURCE_DISPLAY_NAMES: Record<string, string> = {
   [AGENT_SOURCE.BUILT_IN_TOOL_USE]: 'Built-in',
   [AGENT_SOURCE.CUSTOM]: 'Custom',
   [AGENT_SOURCE.REMOTE]: 'Remote',
+  [AGENT_SOURCE.INLINE]: 'Inline',
 };
 
 function isBuiltIn(source: string): boolean {

--- a/src/agent/index/AgentDirectoryService.ts
+++ b/src/agent/index/AgentDirectoryService.ts
@@ -89,7 +89,10 @@ export class AgentDirectoryService {
         return this.builtIn();
       case 'builtInToolUse':
         return this.builtInToolUse();
+      // Neither has a local directory: a remote agent lives in Supabase, an
+      // inline one was supplied as a value and was never written to disk.
       case 'remote':
+      case 'inline':
         return undefined;
     }
   }

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -30,6 +30,7 @@ import {
   TOOL_USE_LOOKUP_PRIORITY,
 } from './agentRegistryConstants';
 import { scanDirectory } from './agentYamlScanner';
+import { defineInlineAgents, inlineAgentEntries } from './inlineAgents';
 import { loadRemoteAgents, persistRemoteAgentMeta } from './remoteAgentMeta';
 import {
   entriesToOptionData,
@@ -147,6 +148,22 @@ export async function loadAgents(
   return initPromise;
 }
 
+/**
+ * Register agent definitions supplied as values, so an embedder can hand the
+ * runtime an agent without writing a YAML file. Each definition is validated
+ * here (throwing on a malformed one) and published under `inline:<name>` — a
+ * namespace of its own, so an inline agent can never collide with a same-named
+ * `custom` entry, only outrank it in bare-name lookups.
+ *
+ * Safe before or after {@link loadAgents}: entries land in the live cache
+ * immediately and are re-merged by every subsequent load or refresh.
+ */
+export function registerInlineAgents(definitions: readonly unknown[]): void {
+  for (const entry of defineInlineAgents(definitions)) {
+    cache.set(agentKeyOf(entry), entry);
+  }
+}
+
 async function doLoad(
   includeRemote: boolean,
   loadEpoch: number,
@@ -172,8 +189,12 @@ async function doLoad(
       includeRemote ? loadRemoteAgents() : Promise.resolve([]),
     ]);
 
-  // Register all entries
+  // Register all entries. Inline definitions were normalized at registration
+  // and live outside the directory scan, so they are re-merged on every load —
+  // a catalog refresh rebuilds the cache from scratch and would otherwise drop
+  // them.
   const allEntries = [
+    ...inlineAgentEntries(),
     ...customEntries,
     ...builtInEntries,
     ...toolUseEntries,

--- a/src/agent/index/agentRegistryConstants.ts
+++ b/src/agent/index/agentRegistryConstants.ts
@@ -6,8 +6,17 @@ export {
   PREFERRED_TOOL_USE_AGENTS,
 } from '@shared/constants/agents';
 
-/** Source priority for lookups (higher priority first). */
+/**
+ * Source priority for lookups (higher priority first).
+ *
+ * `inline` leads both lists: a definition the embedder handed the runtime as a
+ * value is the most specific statement of intent, so it wins over a same-named
+ * file on disk. It must be listed rather than left out — `deduplicateByName`
+ * compares `indexOf`, and an absent source scores `-1`, which would rank it
+ * first by accident instead of by decision.
+ */
 export const LOOKUP_PRIORITY: AgentSource[] = [
+  'inline',
   'custom',
   'remote',
   'builtInWorkflow',
@@ -16,6 +25,7 @@ export const LOOKUP_PRIORITY: AgentSource[] = [
 
 /** Source priority for tool-use sessions (prefers tool-use agents over workflow). */
 export const TOOL_USE_LOOKUP_PRIORITY: AgentSource[] = [
+  'inline',
   'custom',
   'remote',
   'builtInToolUse',

--- a/src/agent/index/index.ts
+++ b/src/agent/index/index.ts
@@ -28,6 +28,7 @@ export {
   type ResolvedAgent,
   // Core functions
   loadAgents,
+  registerInlineAgents,
   getAgent,
   resolveAgent,
   resolveAgentForLaunch,

--- a/src/agent/index/inlineAgents.ts
+++ b/src/agent/index/inlineAgents.ts
@@ -1,0 +1,130 @@
+/**
+ * Inline agent definitions: agent definitions supplied to the runtime as
+ * values instead of YAML files on disk.
+ *
+ * This is the local twin of the remote catalog. `remoteAgentMeta.ts` fabricates
+ * an {@link AgentEntry} with an empty `path` from a Supabase row and
+ * `agentLoad.ts` skips the filesystem read for `source: 'remote'`; the same two
+ * moves here take a caller-supplied definition object instead of a network
+ * fetch.
+ *
+ * The split matches the one the file path already uses: this module validates a
+ * definition and derives its registry metadata, exactly as `agentYamlScanner`
+ * does for a YAML file, while `agentLoad` resolves tools and applies
+ * `AgentSettingSchema`/`AgentPromptSchema` for both. That keeps tool resolution
+ * on a single code path, and keeps `@tools/registry` — which the registry
+ * deliberately reaches only through a lazy import (see `loadRemoteAgents`) — out
+ * of the eagerly loaded registry graph.
+ */
+
+import {
+  AgentCategory,
+  AgentDefinitionSchema,
+  AgentWorkflowSettingSchema,
+  type AgentDefinition,
+} from '@agent/core/definition/AgentDataclass';
+import { extractToolNames } from './agentYamlScanner';
+import type { AgentEntry } from './agentEntry';
+
+interface InlineAgent {
+  readonly entry: AgentEntry;
+  readonly definition: AgentDefinition;
+}
+
+/**
+ * Registered inline definitions, keyed by agent name — every entry here is an
+ * inline one, so the registry's `source:name` qualification would add nothing.
+ *
+ * Module-level because the agent registry it feeds is itself process-global and
+ * resolution is a synchronous read; hanging definitions off a per-run options
+ * bag would fork the lookup. Registrations outlive `refresh()` — the registry
+ * rebuilds its cache from scratch on every load, so `doLoad` re-merges these
+ * entries rather than letting a catalog refresh silently drop them.
+ */
+const inlineAgents = new Map<string, InlineAgent>();
+
+/**
+ * Validate agent definitions supplied as values and derive their registry
+ * entries, replacing any previous registration of the same name. Returns the
+ * entries so the caller can publish them into the live cache.
+ *
+ * Throws on an invalid definition: an embedder handing over a malformed agent
+ * must find out at the call it made, not at launch.
+ */
+export function defineInlineAgents(
+  definitions: readonly unknown[],
+): AgentEntry[] {
+  return definitions.map((definition) => {
+    const inline = normalizeInlineAgent(definition);
+    inlineAgents.set(inline.entry.name, inline);
+    return inline.entry;
+  });
+}
+
+/** Registry entries for every currently registered inline definition. */
+export function inlineAgentEntries(): AgentEntry[] {
+  return [...inlineAgents.values()].map((inline) => inline.entry);
+}
+
+/**
+ * The validated definition behind a registered inline agent — what the
+ * `agentLoad` source-switch arm parses instead of reading a YAML file.
+ */
+export function inlineAgentDefinition(name: string): AgentDefinition {
+  const inline = inlineAgents.get(name);
+  if (!inline) {
+    throw new Error(
+      `Inline agent "${name}" is not registered. Call registerInlineAgents before launching it.`,
+    );
+  }
+  return inline.definition;
+}
+
+function normalizeInlineAgent(definition: unknown): InlineAgent {
+  const parsed = AgentDefinitionSchema.parse(definition);
+
+  if (parsed.inherits) {
+    // The YAML loader resolves `inherits` against a source's directory scan;
+    // an inline definition has no directory, so honouring it would silently
+    // resolve against a different source's files. Reject instead.
+    throw new Error(
+      `Inline agent "${parsed.name}" declares "inherits: ${parsed.inherits}"; inline definitions must be self-contained.`,
+    );
+  }
+
+  const settings = parsed.settings;
+  const category = settings.agentCategory ?? AgentCategory.Workflow;
+  const tools = extractToolNames(settings.tools);
+  const defaultOutputFiles = settings.defaultOutputFiles;
+
+  return {
+    entry: {
+      name: parsed.name,
+      source: 'inline',
+      path: '',
+      category,
+      description: parsed.description,
+      tools: tools?.length ? tools : undefined,
+      defaultOutputFiles: defaultOutputFiles?.length
+        ? defaultOutputFiles
+        : undefined,
+      rounds:
+        category === AgentCategory.Workflow
+          ? Math.max(
+              // Materializes the schema's own default when unset.
+              AgentWorkflowSettingSchema.shape.rounds.parse(settings.rounds),
+              userRequestCount(parsed),
+            )
+          : undefined,
+      internal: settings.internal === true || undefined,
+    },
+    definition: parsed,
+  };
+}
+
+/** Round floor for a workflow agent, mirroring `agentYamlScanner`'s rule. */
+function userRequestCount(definition: AgentDefinition): number {
+  const userRequest = definition.prompts.userRequest;
+  if (Array.isArray(userRequest)) return userRequest.length;
+  return userRequest ? 1 : 0;
+}

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -16,6 +16,7 @@ import {
   type AgentPromptInput,
 } from '@agent/core/definition/AgentDataclass';
 import { mergeInheritedAgentObject } from '@agent/core/definition/agentDefinitionInheritance';
+import { inlineAgentDefinition } from '@agent/index/inlineAgents';
 import { RemoteAgentLoader } from '@agent/remote/RemoteAgentLoader';
 import { parseYamlWith, safeParseYaml } from '@common/parsing/safeParseYaml';
 import * as logger from '@logger/logUtils';
@@ -114,6 +115,17 @@ export async function loadAgentSettingAndPrompts(
   seen: ReadonlySet<string> = new Set(),
 ): Promise<[AgentSetting, AgentPrompt]> {
   const { entry } = resolution;
+
+  // Handle inline agents: the definition was supplied as a value and validated
+  // at registration, so there is nothing to read from disk. Tools and defaults
+  // still go through the same resolution the YAML path uses below.
+  if (entry.source === 'inline') {
+    const definition = inlineAgentDefinition(resolution.resolvedName);
+    return [
+      AgentSettingSchema.parse(resolveAgentSettingTools(definition.settings)),
+      AgentPromptSchema.parse(definition.prompts),
+    ];
+  }
 
   // Handle remote agents
   if (entry.source === 'remote') {

--- a/src/shared/schemas/agent.ts
+++ b/src/shared/schemas/agent.ts
@@ -20,6 +20,13 @@ export const AGENT_SOURCE = {
   BUILT_IN_WORKFLOW: 'builtInWorkflow',
   BUILT_IN_TOOL_USE: 'builtInToolUse',
   REMOTE: 'remote',
+  /**
+   * Definition supplied as a value rather than read from a YAML file — the
+   * embedding-API counterpart of `remote`, which likewise fabricates a registry
+   * entry with an empty `path` and skips the loader's filesystem read. Entries
+   * come from `registerInlineAgents` (`@agent/index/agentRegistry`).
+   */
+  INLINE: 'inline',
 } as const;
 
 /** Single source of truth for agent source identifiers. */

--- a/src/test-kernel/agent/core/ConfigSchemas.vitest.ts
+++ b/src/test-kernel/agent/core/ConfigSchemas.vitest.ts
@@ -1,6 +1,7 @@
 // Third-party imports
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'vitest';
+import { z } from 'zod';
 
 // Standard library imports
 
@@ -12,6 +13,7 @@ import {
   WorkflowAgentConfigSchema,
 } from '@agent/core/definition/AgentConfig';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { AGENT_SOURCE } from '@shared/schemas';
 import { MainViewPersistedStateSchema } from '@shared/schemas/mainView';
 import { ToolConfigSchema } from '@shared/schemas/toolConfig';
 
@@ -108,5 +110,64 @@ describe('AgentConfigSchema', () => {
     assert.deepStrictEqual(parsed.inputFiles, ['main.tex']);
     assert.deepStrictEqual(parsed.contextFiles, ['refs.bib']);
     assert.deepStrictEqual(parsed.mediaFiles, ['figure.png']);
+  });
+});
+
+/**
+ * `agentSource` is persisted (execution `config.json`, trace documents), so
+ * widening `AGENT_SOURCE` is a persisted-schema change in both directions.
+ */
+describe('AgentConfigSchema agentSource compatibility', () => {
+  it('round-trips every current source, including inline', () => {
+    for (const source of Object.values(AGENT_SOURCE)) {
+      const parsed = AgentConfigSchema.parse({
+        agent: 'scratchpad',
+        agentSource: source,
+      });
+      assert.strictEqual(parsed.agentSource, source);
+    }
+  });
+
+  it('reads records persisted before the field existed', () => {
+    assert.strictEqual(AgentConfigSchema.parse({}).agentSource, undefined);
+    assert.strictEqual(
+      AgentConfigSchema.parse({ agentSource: null }).agentSource,
+      null,
+    );
+  });
+
+  it('rejects an unrecognized source loudly instead of defaulting it', () => {
+    const result = AgentConfigSchema.safeParse({ agentSource: 'notASource' });
+
+    assert.strictEqual(result.success, false);
+    assert.deepStrictEqual(result.error?.issues[0]?.path, ['agentSource']);
+  });
+
+  it('makes an older build reject an inline source rather than drop it', () => {
+    // Forward compatibility is a downgrade scenario: only a widened build can
+    // write `inline`, and an older build validates the same field with the
+    // enum as it stood before. `.nullish()` keeps the field optional, but a
+    // *present* unknown value is a parse error — so the older build fails at
+    // its read boundary rather than silently defaulting the source. Every
+    // persisted read is already written for that: `ExecutionKVStore.readConfig`
+    // goes through `readValidated`, which warns and returns null (the same
+    // "corrupt config" path history views already handle), and
+    // `executionListing`'s backfill logs and skips the entry.
+    const olderBuildSourceSchema = z
+      .enum(['custom', 'builtInWorkflow', 'builtInToolUse', 'remote'])
+      .nullish();
+
+    assert.strictEqual(
+      olderBuildSourceSchema.safeParse('inline').success,
+      false,
+    );
+    assert.strictEqual(
+      olderBuildSourceSchema.safeParse(undefined).success,
+      true,
+    );
+    assert.strictEqual(
+      olderBuildSourceSchema.safeParse('custom').success,
+      true,
+    );
   });
 });

--- a/src/test-kernel/agent/runtime/agentLoad.vitest.ts
+++ b/src/test-kernel/agent/runtime/agentLoad.vitest.ts
@@ -2,16 +2,29 @@
 
 // Standard library imports
 import { strict as assert } from 'node:assert';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import * as path from 'node:path';
-import { describe, it, beforeEach, afterEach, vi } from 'vitest';
+import { beforeAll, describe, it, beforeEach, afterEach, vi } from 'vitest';
 
 // Local imports - agent runtime
-import { resolveAgent, type ResolvedAgent } from '@agent/index';
+import {
+  getAgent,
+  loadAgents,
+  refresh,
+  registerInlineAgents,
+  resolveAgent,
+  resolveAgentForLaunch,
+  type ResolvedAgent,
+} from '@agent/index';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
   loadAgentSettingAndPrompts,
   validateAgentYamlContent,
 } from '@agent/runtime/agentLoad';
+import type { AgentDirectoriesPort } from '@platform/interfaces';
+import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+import { installPlatform } from '@test/support/setupPlatform';
 import { AbsoluteFS } from '@utils/files';
 
 vi.mock('@agent/index', async () => {
@@ -258,5 +271,156 @@ describe('loadAgentSettingAndPrompts', () => {
       // any later test in this describe block.
       resolveAgentMock.mockImplementation(actual.resolveAgent);
     }
+  });
+});
+
+describe('inline agent definitions', () => {
+  const SCRATCHPAD = {
+    name: 'scratchpad',
+    description: 'Registered as a value, never written to disk.',
+    settings: { agentCategory: AgentCategory.ToolUse, tools: ['grep'] },
+    prompts: { systemPrompt: 'You are an inline agent.' },
+  };
+
+  async function useAgentDirectories(dir: string): Promise<void> {
+    const directories: AgentDirectoriesPort = {
+      custom: async () => dir,
+      builtIn: async () => dir,
+      builtInToolUse: async () => dir,
+    };
+    await installPlatform(
+      {},
+      { fs: nodeFilesystem, agentDirectories: directories },
+    );
+  }
+
+  beforeAll(async () => {
+    // Every agent directory points at an empty folder: nothing the registry
+    // returns below can have come from YAML on disk.
+    await useAgentDirectories(
+      await mkdtemp(path.join(tmpdir(), 'texra-empty-agents-')),
+    );
+    registerInlineAgents([SCRATCHPAD]);
+    await loadAgents({ includeRemote: false });
+  });
+
+  it('resolves a registered definition with no YAML behind it', () => {
+    const entry = getAgent('scratchpad');
+    assert.strictEqual(entry?.source, 'inline');
+    assert.strictEqual(entry.path, '');
+    assert.strictEqual(entry.category, AgentCategory.ToolUse);
+    assert.deepStrictEqual(entry.tools, ['grep']);
+    assert.strictEqual(getAgent('inline:scratchpad')?.name, 'scratchpad');
+  });
+
+  it('returns settings and prompts without reading the filesystem', async () => {
+    const resolution = resolveAgentForLaunch(
+      AgentCategory.ToolUse,
+      'scratchpad',
+    );
+    assert.ok(resolution, 'launch resolution should find the inline agent');
+    assert.strictEqual(resolution.definitionPath, '');
+
+    const read = vi.spyOn(AbsoluteFS, 'read');
+    try {
+      const [settings, prompts] = await loadAgentSettingAndPrompts(resolution);
+
+      assert.strictEqual(settings.agentCategory, AgentCategory.ToolUse);
+      assert.strictEqual(
+        prompts.systemPrompt,
+        'You are an inline agent.',
+        'prompts should come back already parsed',
+      );
+      assert.strictEqual(read.mock.calls.length, 0);
+    } finally {
+      read.mockRestore();
+    }
+  });
+
+  it('survives a catalog refresh that rebuilds the cache', async () => {
+    await refresh({ includeRemote: false });
+    assert.strictEqual(getAgent('inline:scratchpad')?.source, 'inline');
+  });
+
+  it('accepts a registration made after the initial load', () => {
+    registerInlineAgents([
+      {
+        name: 'lateComer',
+        settings: { agentCategory: AgentCategory.Workflow, rounds: 3 },
+        prompts: { userRequest: 'Do the thing.' },
+      },
+    ]);
+
+    const entry = getAgent('lateComer');
+    assert.strictEqual(entry?.source, 'inline');
+    assert.strictEqual(entry.rounds, 3);
+  });
+
+  it('rejects a definition that declares inherits', () => {
+    assert.throws(
+      () =>
+        registerInlineAgents([
+          {
+            name: 'derived',
+            inherits: 'scratchpad',
+            settings: { agentCategory: AgentCategory.ToolUse },
+            prompts: {},
+          },
+        ]),
+      (error: unknown) =>
+        error instanceof Error &&
+        error.message.includes('must be self-contained'),
+    );
+  });
+
+  it('rejects a malformed definition at the registration call', () => {
+    assert.throws(() => registerInlineAgents([{ name: '' }]));
+  });
+
+  it('fails loudly when the load path names an unregistered inline agent', async () => {
+    await assert.rejects(
+      () =>
+        loadAgentSettingAndPrompts({
+          entry: {
+            name: 'ghost',
+            source: 'inline',
+            path: '',
+            category: AgentCategory.ToolUse,
+          },
+          definitionPath: '',
+          resolvedName: 'ghost',
+        }),
+      (error: unknown) =>
+        error instanceof Error &&
+        error.message.includes('Inline agent "ghost" is not registered'),
+    );
+  });
+
+  it('keys inline agents apart from a same-named custom agent', async () => {
+    const customDir = await mkdtemp(path.join(tmpdir(), 'texra-custom-'));
+    await writeFile(
+      path.join(customDir, 'scratchpad.yaml'),
+      [
+        'name: scratchpad',
+        'description: On-disk namesake',
+        'settings:',
+        '  agentCategory: toolUse',
+        '  tools: []',
+        'prompts:',
+        '  systemPrompt: On-disk scratchpad.',
+        '',
+      ].join('\n'),
+    );
+    await useAgentDirectories(customDir);
+    await refresh({ includeRemote: false });
+
+    // Distinct keys, so neither registration displaces the other...
+    assert.strictEqual(
+      getAgent('custom:scratchpad')?.path,
+      path.join(customDir, 'scratchpad.yaml'),
+    );
+    assert.strictEqual(getAgent('inline:scratchpad')?.path, '');
+    // ...and the bare name prefers the definition the embedder supplied.
+    assert.strictEqual(getAgent('scratchpad')?.source, 'inline');
   });
 });


### PR DESCRIPTION
Recovered from an agent that completed the work and committed it, then died at an auth error before pushing. Implements #9331 per `docs/proposals/2026-07-27-agent-npm-package-step3.md` §5a.

## What this is

Definitions-as-values for an npm consumer, **without a new API surface**. It reuses the value-injection seam the Supabase remote catalog already ships: `remoteAgentMeta.ts` fabricates an `AgentEntry` with `path: ''`, and `agentLoad.ts` skips the YAML load in a source switch. Inline agents get a third arm in that same switch, returning already-parsed `settings`/`prompts`.

New: `src/agent/index/inlineAgents.ts` (130 lines), one `AGENT_SOURCE` arm, one switch arm in `agentLoad.ts`. **Zero new ports. Zero new schemas** — `AgentDefinitionSchema` is the same parse for both paths.

The trap recorded on the issue was avoided: no definitions bag hangs off `RunAgentOptions`. The registry is process-global and resolution is a sync read; a per-run bag would fork the lookup path.

## Scope

11 files, +417/−4, including tests in `ConfigSchemas.vitest.ts` (+61) and `agentLoad.vitest.ts` (+168).

## Caveat — the read-compat gate

`AgentSource` is persisted (`AgentConfig.agentSource`). The brief made the old-build read-compat question a make-or-break gate: what an *older* build does when it reads a persisted config carrying `'inline'`. The agent died before reporting its verdict, so **I cannot confirm that gate was closed** — the tests it added cover the new path, not the backward-read path.

Reviewer: please confirm the tolerant-read behavior for persisted `agentSource` before merging, or ask for a follow-up commit adding that case. Flagging it rather than letting a green CI imply it was checked.

https://claude.ai/code/session_01XZ8Z6rhypTfkVq728XCcCd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persisted `agentSource` and core registry/launch resolution; behavior is well-tested but downgrade reads of `inline` configs will fail validation on older clients.
> 
> **Overview**
> Introduces **`inline`** as a first-class `AgentSource` so npm/embed consumers can supply agent definitions as in-memory values instead of YAML files, mirroring how **remote** agents skip disk (`path: ''`) and bypass filesystem reads in `agentLoad`.
> 
> **Registration and registry:** New `inlineAgents.ts` validates with `AgentDefinitionSchema`, rejects `inherits`, and keeps definitions in a process-global map. **`registerInlineAgents`** publishes `inline:<name>` entries into the live cache immediately; **`doLoad`/`refresh`** re-merges them so catalog rebuilds do not drop registrations. **`inline`** is first in `LOOKUP_PRIORITY` / `TOOL_USE_LOOKUP_PRIORITY` so bare-name resolution prefers embedder-supplied agents over same-named custom YAML.
> 
> **Loading:** `loadAgentSettingAndPrompts` adds an inline branch that returns parsed settings/prompts (with the same tool resolution as YAML). Directory services and desktop agent-settings wiring treat **`inline`** like **`remote`** (no local folder).
> 
> **UI/schema:** `AGENT_SOURCE.INLINE` is documented and labeled **Inline** in the agent selection panel. Tests cover registry/load behavior, name collisions with custom agents, and **`agentSource`** persistence round-trips—including the expectation that **older builds fail parse** on persisted `inline` rather than silently ignoring it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d308b7102da92048e8fb5d79b324d43a6985ac0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->