### PR TITLE
refactor(ui): dedupe spin keyframe, use Ink border for session divider

### DIFF
--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -143,11 +143,16 @@ function SessionHeaderBlock({
 
   return (
     <Box flexDirection="column">
-      <Box>
-        <Text aria-hidden color={COLOR_HINT}>
-          {'─'.repeat(columns)}
-        </Text>
-      </Box>
+      <Box
+        aria-hidden
+        width={columns}
+        borderStyle="single"
+        borderTop
+        borderBottom={false}
+        borderLeft={false}
+        borderRight={false}
+        borderColor={COLOR_HINT}
+      />
       <Box flexDirection="column" paddingX={1}>
         <Box gap={2}>
           <Text bold color={COLOR_HINT}>

--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -62,6 +62,22 @@ wa-button[hidden] {
   outline-offset: calc(-1 * var(--focus-ring-offset));
 }
 
+/* Mirrors @shared/styles/litStyles.ts's animationStyles: same keyframe name so
+   a caller can override just the duration, as taskShell.css's
+   .task-environment-refresh does. */
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.spin {
+  animation: spin 2s linear infinite;
+}
+
 wa-button.btn-primary::part(base),
 wa-button.btn-secondary::part(base) {
   min-height: var(--height-button);

--- a/packages/desktop/src/renderer/taskShell.css
+++ b/packages/desktop/src/renderer/taskShell.css
@@ -578,13 +578,7 @@ body[data-desktop-platform='darwin'] .task-sidebar-brand {
 }
 
 .task-environment-refresh[disabled] wa-icon {
-  animation: environment-spin 0.9s linear infinite;
-}
-
-@keyframes environment-spin {
-  to {
-    transform: rotate(360deg);
-  }
+  animation: spin 0.9s linear infinite;
 }
 
 .task-environment-section {


### PR DESCRIPTION
## Summary

Follow-up from a scheduled UI-consistency audit that swept icons, inline styles, modal/dropdown primitives, CSS duplication, and Ink-native opportunities across the extension webviews, desktop renderer, and CLI TUI. Nearly everything audited was already consolidated (the Codicon→canonical-icon migration, Web Awesome dialogs/dropdowns, shared clipboard/debounce/markdown/timestamp helpers). This PR fixes the two small, low-severity findings the audit did surface:

1. **Desktop**: `.task-environment-refresh[disabled] wa-icon` animated with a private `@keyframes environment-spin`, duplicating the shape of the canonical `spin` keyframe already defined in `src/shared/styles/litStyles.ts`'s `animationStyles` (used throughout the extension's Lit shadow-DOM components).
2. **CLI**: the session-header divider in `StaticConversationTranscript.tsx` built its horizontal rule by rendering `'─'.repeat(columns)` into a `<Text>`, instead of using Ink's native single-sided `Box` border.

## Issue acceptance gates

No linked issue — self-initiated cleanup from the audit's findings. Acceptance: both duplications are removed and behavior is visually unchanged (same glyph, same color, same durations).

## Single source of truth

- `src/shared/styles/litStyles.ts`'s `@keyframes spin` is now the one keyframe shape; `packages/desktop/src/renderer/styles.css` mirrors it into light DOM (following the file's existing "canonical controls" mirror convention) so `taskShell.css` can reuse the name and just override `animation-duration` for its faster 0.9s spin.
- Ink's `Box` `borderTop`/`borderColor` props are now the one way this file draws a horizontal rule, replacing manual character repetition.

## Duplication and abstraction budget

Removed one duplicated `@keyframes` block; no new abstraction added — the mirrored keyframe reuses the existing "light-DOM mirror" pattern already documented at the top of `styles.css`.

## Net elements (R6)

3 files changed, 0 added/deleted/renamed. +27/-12 lines. No exported symbols changed.

## Consumer counts (R8)

n/a — no emit path or export changed; purely internal CSS/JSX within the same two files.

## Host impact

Extension: none (unaffected).

Desktop: `.task-environment-refresh` spin animation now resolves through the shared `spin` keyframe mirrored into `styles.css`; visual behavior (0.9s linear spin) is unchanged.

CLI: session header divider now renders via Ink's native `Box` border instead of a manually repeated character string; visual output (a `COLOR_HINT`-colored horizontal rule, `columns` wide, `aria-hidden`) is unchanged.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — clean across all 6 projects (root, test-kernel, extension, cli, trace-viewer, desktop)
- `npx eslint packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx` — clean
- `npx prettier --check` on all 3 changed files — clean
- `npx vitest run` on `src/test-kernel/cli/{StaticBandResize,ConversationPane,WorkflowScriptStreamTranscript}.vitest.mts` — 68/68 passed
- `npx vitest run` on `src/test-kernel/desktop/DesktopControlSystem.vitest.mts` (reads `taskShell.css` structurally) — 14/14 passed
- `npm run check:dead-code-ratchet` — 17 current vs 17 baselined, no new unused exports

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERGytXwJsSr9A8Q5wcgEAk)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS and Ink layout; no APIs, auth, or data paths touched.
> 
> **Overview**
> Small UI-consistency cleanup with **no intended visual change** in desktop or CLI.
> 
> **Desktop:** Removes the private `environment-spin` keyframe from `taskShell.css` and drives the environment refresh icon with the shared `spin` animation name. Adds a light-DOM mirror of the canonical `spin` keyframe (and a default `.spin` utility) in `styles.css`, matching the existing `litStyles` pattern so callers can override duration only—`task-environment-refresh` still uses **0.9s** linear spin.
> 
> **CLI:** Replaces the session header horizontal rule built from repeated `─` characters in `StaticConversationTranscript` with an Ink `Box` **top border** (`COLOR_HINT`, full transcript width, `aria-hidden`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59b123bb88a8442f4d8d7b73874ff45712e832ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->