### PR TITLE
fix(auth): reject malformed user tiers

### DIFF
--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -347,9 +347,10 @@ export class SupabaseClient {
         return defaultTier;
       }
 
-      // A present malformed tier is profile corruption. Let the outer error
-      // path log it before conservatively returning the default tier.
-      return UserTierSchema.parse(data.tier);
+      // SQL NULL denotes a profile without an assigned paid tier. A present
+      // malformed string is profile corruption: let the outer error path log
+      // it before conservatively returning the default tier.
+      return UserTierSchema.parse(data.tier ?? defaultTier);
     } catch (error) {
       logger.error(
         'SupabaseClient',

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -347,7 +347,9 @@ export class SupabaseClient {
         return defaultTier;
       }
 
-      return UserTierSchema.catch('free').parse(data.tier);
+      // A present malformed tier is profile corruption. Let the outer error
+      // path log it before conservatively returning the default tier.
+      return UserTierSchema.parse(data.tier);
     } catch (error) {
       logger.error(
         'SupabaseClient',

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -133,7 +133,9 @@ const RELAY_TIER_SPENDING_LIMITS: Record<UserTier, number> = {
 };
 
 export function getRelaySpendingLimit(tier: string | undefined): number {
-  const parsedTier = UserTierSchema.catch(FREE_TIER).parse(tier);
+  // An absent tier denotes an unauthenticated/free request. A present but
+  // malformed tier is accounting data corruption and must fail validation.
+  const parsedTier = UserTierSchema.prefault(FREE_TIER).parse(tier);
   return RELAY_TIER_SPENDING_LIMITS[parsedTier];
 }
 

--- a/src/auth/relayToken.ts
+++ b/src/auth/relayToken.ts
@@ -49,7 +49,8 @@ export function getConfiguredRelayToken(
 
 const TierConfigUserStatusSchema = z.object({
   userStatus: z
-    .object({ tier: UserTierSchema.catch('free') })
+    // A present malformed tier is a relay contract failure, not a free tier.
+    .object({ tier: UserTierSchema })
     .loose()
     .nullish(),
 });

--- a/src/auth/relayToken.ts
+++ b/src/auth/relayToken.ts
@@ -13,6 +13,7 @@ import { LRUCache } from 'lru-cache';
 import { z } from 'zod';
 
 import {
+  FREE_TIER,
   RELAY_TIER_CONFIG_URL,
   SERVER_SIDE_CACHE_TTL_MS,
   UserTierSchema,
@@ -50,7 +51,9 @@ export function getConfiguredRelayToken(
 const TierConfigUserStatusSchema = z.object({
   userStatus: z
     // A present malformed tier is a relay contract failure, not a free tier.
-    .object({ tier: UserTierSchema })
+    .object({
+      tier: UserTierSchema.nullable().transform((tier) => tier ?? FREE_TIER),
+    })
     .loose()
     .nullish(),
 });

--- a/src/test-kernel/auth/SupabaseClient.vitest.ts
+++ b/src/test-kernel/auth/SupabaseClient.vitest.ts
@@ -51,6 +51,7 @@ describe('SupabaseClient', () => {
   afterEach(() => {
     SupabaseClient.resetForTests();
     resetRelayTokenTierCacheForTests();
+    vi.restoreAllMocks();
   });
 
   it('reads session tokens through the registered token provider', async () => {
@@ -212,6 +213,32 @@ describe('SupabaseClient', () => {
       'SupabaseClient',
       expect.stringContaining('Error getting user tier:'),
     );
+  });
+
+  it('treats a null profile tier as free without reporting corruption', async () => {
+    SupabaseClient.setAuthProvider(
+      createTokenProvider({
+        getSessionTokens: async () => ({
+          accessToken: 'access-token',
+          refreshToken: 'refresh-token',
+        }),
+      }),
+    );
+    vi.spyOn(SupabaseClient, 'getClient').mockReturnValue({
+      auth: { setSession: vi.fn(async () => {}) },
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          single: vi.fn(async () => ({
+            data: { tier: null },
+            error: null,
+          })),
+        })),
+      })),
+    } as never);
+    const error = vi.spyOn(logger, 'error').mockImplementation(() => {});
+
+    await expect(SupabaseClient.getSessionTier()).resolves.toBe('free');
+    expect(error).not.toHaveBeenCalled();
   });
 
   it('waits for token provider readiness', async () => {

--- a/src/test-kernel/auth/SupabaseClient.vitest.ts
+++ b/src/test-kernel/auth/SupabaseClient.vitest.ts
@@ -1,6 +1,6 @@
 // Third-party imports
 import { strict as assert } from 'node:assert';
-import { describe, it, afterEach } from 'vitest';
+import { describe, it, afterEach, expect, vi } from 'vitest';
 
 // Standard library imports
 
@@ -13,6 +13,7 @@ import {
 } from '@auth/relayToken';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import type { AuthTokenProvider } from '@auth/TokenProvider';
+import * as logger from '@logger/logUtils';
 import { createDeferred } from '@test/support/asyncTestUtils';
 
 async function withRelayTokenEnv(
@@ -182,6 +183,35 @@ describe('SupabaseClient', () => {
     SupabaseClient.setAuthProvider(provider);
 
     assert.equal(await SupabaseClient.getSessionTokens(), null);
+  });
+
+  it('logs a malformed profile tier instead of accepting it as free', async () => {
+    SupabaseClient.setAuthProvider(
+      createTokenProvider({
+        getSessionTokens: async () => ({
+          accessToken: 'access-token',
+          refreshToken: 'refresh-token',
+        }),
+      }),
+    );
+    vi.spyOn(SupabaseClient, 'getClient').mockReturnValue({
+      auth: { setSession: vi.fn(async () => {}) },
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          single: vi.fn(async () => ({
+            data: { tier: 'corrupted' },
+            error: null,
+          })),
+        })),
+      })),
+    } as never);
+    const error = vi.spyOn(logger, 'error').mockImplementation(() => {});
+
+    await expect(SupabaseClient.getSessionTier()).resolves.toBe('free');
+    expect(error).toHaveBeenCalledWith(
+      'SupabaseClient',
+      expect.stringContaining('Error getting user tier:'),
+    );
   });
 
   it('waits for token provider readiness', async () => {

--- a/src/test-kernel/cli/RelayTokens.vitest.mts
+++ b/src/test-kernel/cli/RelayTokens.vitest.mts
@@ -136,6 +136,17 @@ describe('TEXRA_RELAY_TOKEN consumption (CI relay tokens)', () => {
     ).toEqual({ state: 'unknown' });
   });
 
+  it('does not turn a malformed relay tier into free access', async () => {
+    const malformed = singleFetch(
+      jsonResponse({ userStatus: { tier: 'corrupted' } }),
+    );
+
+    expect(
+      await fetchRelayTokenStatus(`${TOKEN}5`, malformed.fetchImpl),
+    ).toEqual({ state: 'unknown' });
+    expect(getCachedRelayTokenState(`${TOKEN}5`)).toBeUndefined();
+  });
+
   it('caches a rejection so synchronous credential checks can see it', async () => {
     const { fetchImpl, calls } = singleFetch(jsonResponse({ tiers: {} }));
     expect(await fetchRelayTokenStatus(TOKEN, fetchImpl)).toEqual({

--- a/src/test-kernel/cli/RelayTokens.vitest.mts
+++ b/src/test-kernel/cli/RelayTokens.vitest.mts
@@ -147,6 +147,18 @@ describe('TEXRA_RELAY_TOKEN consumption (CI relay tokens)', () => {
     expect(getCachedRelayTokenState(`${TOKEN}5`)).toBeUndefined();
   });
 
+  it('treats a null relay tier as valid free access', async () => {
+    const { fetchImpl } = singleFetch(
+      jsonResponse({ userStatus: { tier: null } }),
+    );
+
+    expect(await fetchRelayTokenStatus(`${TOKEN}6`, fetchImpl)).toEqual({
+      state: 'valid',
+      tier: 'free',
+    });
+    expect(getCachedRelayTokenState(`${TOKEN}6`)).toBe('valid');
+  });
+
   it('caches a rejection so synchronous credential checks can see it', async () => {
     const { fetchImpl, calls } = singleFetch(jsonResponse({ tiers: {} }));
     expect(await fetchRelayTokenStatus(TOKEN, fetchImpl)).toEqual({

--- a/src/test-kernel/supabase/RelaySharedConfigParity.vitest.ts
+++ b/src/test-kernel/supabase/RelaySharedConfigParity.vitest.ts
@@ -43,6 +43,13 @@ describe('relay shared configuration parity', () => {
     }
   });
 
+  it('defaults only an absent spending tier to free', () => {
+    expect(getRelaySpendingLimit(undefined)).toBe(
+      TIER_SPENDING_LIMITS[FREE_TIER],
+    );
+    expect(() => getRelaySpendingLimit('corrupted')).toThrow();
+  });
+
   it('keeps the workspace llm-zoo range floor in sync with the relay deno.json pin', () => {
     const workspacePackageJson = JSON.parse(
       readFileSync(resolve(REPO_ROOT, 'package.json'), 'utf8'),


### PR DESCRIPTION
Fixes #9326.

## Summary

User tiers determine relay spending limits and included-access eligibility.
Malformed present tier values were previously indistinguishable from a genuine
`free` tier at three authentication and accounting boundaries.

This change:

- keeps `undefined` as the documented free-tier default for local spending-limit
  lookup, while rejecting malformed present strings;
- validates profile database tiers without `.catch()`, allowing the existing
  outer error path to log corruption before conservatively returning the
  default tier;
- treats a malformed tier in the relay tier-config response as an unknown
  server result and does not cache it as valid free-tier access.

The neighboring `.catch()` sites named in the issue remain unchanged: they are
documented compatibility or display-state recovery paths, not authoritative
authentication or accounting data.

## Tests

- Added local spending-limit coverage distinguishing an absent tier from a
  malformed tier.
- Added profile database coverage verifying that a malformed tier is logged.
- Added relay-token coverage verifying that a malformed tier yields `unknown`
  and is not cached.

## Validation

- `npm run format`
- `npm run lint`
- `npm run compile:safe`
- `npm test` — 793 test files and 7,894 tests passed; 1 file and 4 tests skipped
- `npm run check:dead-code-ratchet`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tier validation on relay spending limits and auth/profile boundaries; behavior for corrupt data is stricter but still fails conservatively to free where documented.
> 
> **Overview**
> **Malformed user tier strings are no longer silently treated as `free`** at profile lookup, relay spending limits, and CI relay tier-config validation.
> 
> `getRelaySpendingLimit` now defaults only **missing** tiers to free (`prefault`) and **throws** on present garbage. `getSessionTier` maps SQL `NULL` to free but lets Zod reject corrupt profile values so the existing catch path logs and still returns free conservatively. Relay tier-config parsing maps `null` to free for valid tokens but treats a present invalid tier as probe failure (`unknown`, not cached as valid free).
> 
> Tests cover absent vs malformed spending tiers, profile corruption logging vs null tier, and relay malformed vs null responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6444c200b308123b49ae9a35483974f8feed0b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->