### PR TITLE
fix(runtime): own detached child-run rejections

### DIFF
--- a/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
@@ -102,6 +102,10 @@ const parentStreamId = 'stream:parent' as StreamTabId;
 const childStreamId = 'stream:claude-child' as StreamTabId;
 const executionId = 'parent-exec' as ExecutionId;
 
+function completedChildRunLoop(): { completion: Promise<void> } {
+  return { completion: Promise.resolve() };
+}
+
 async function* streamMessages(messages: unknown[]): AsyncGenerator<unknown> {
   for (const message of messages) {
     yield message;
@@ -118,6 +122,7 @@ describe('claude_agent tool — resume fallback for a torn-down registry', () =>
 
   function setupCommonMocks(): void {
     mocks.startChildRunLoop.mockReset();
+    mocks.startChildRunLoop.mockReturnValue(completedChildRunLoop());
     mocks.buildClaudeAgentEnv.mockReset();
     mocks.findClaudeBinaryPath.mockReset();
     mocks.requestBashApproval.mockResolvedValue({ accepted: true });
@@ -162,6 +167,7 @@ describe('claude_agent tool — resume fallback for a torn-down registry', () =>
         startupEvents.push('startLoop');
         params.strategy.onLoopStart?.({ executions } as any);
         startupEvents.push('startLoopReturned');
+        return completedChildRunLoop();
       },
     );
 
@@ -214,6 +220,29 @@ describe('claude_agent tool — resume fallback for a torn-down registry', () =>
     expect(mocks.startChildRunLoop).not.toHaveBeenCalled();
   });
 
+  it('logs a detached run-loop rejection through the child trace', async () => {
+    setupCommonMocks();
+    const childStream = createFakeAgentCliChildStream(childStreamId);
+    const error = vi
+      .spyOn(childStream.logger, 'error')
+      .mockImplementation(() => {});
+    const lateFailure = new Error('late Claude finalization failed');
+    mocks.createChildStream.mockReturnValue(childStream);
+    mocks.startChildRunLoop.mockReturnValue({
+      completion: Promise.reject(lateFailure),
+    });
+
+    await expect(
+      new ClaudeAgentTool().call({ prompt: 'launch Claude' }),
+    ).resolves.toMatchObject({ status: 'executed' });
+    await vi.waitFor(() => {
+      expect(error).toHaveBeenCalledWith(
+        'Claude Agent run loop failed after launch',
+        { data: lateFailure },
+      );
+    });
+  });
+
   it('seeds the fallback launch with the stale session_id so the SDK resumes from disk', async () => {
     setupCommonMocks();
     mocks.query.mockReturnValue(
@@ -260,6 +289,7 @@ describe('claude_agent tool — resume fallback for a torn-down registry', () =>
     mocks.startChildRunLoop.mockImplementation(
       (params: { strategy: ChildRunStrategy<unknown> }) => {
         strategy = params.strategy;
+        return completedChildRunLoop();
       },
     );
 
@@ -307,6 +337,7 @@ describe('claude_agent tool — resume fallback for a torn-down registry', () =>
     mocks.startChildRunLoop.mockImplementation(
       (params: { strategy: ChildRunStrategy<unknown> }) => {
         strategy = params.strategy;
+        return completedChildRunLoop();
       },
     );
 
@@ -338,6 +369,7 @@ describe('claude_agent tool — resume fallback for a torn-down registry', () =>
     mocks.startChildRunLoop.mockImplementation(
       (params: { strategy: ChildRunStrategy<unknown> }) => {
         strategy = params.strategy;
+        return completedChildRunLoop();
       },
     );
 

--- a/src/test-kernel/tools/CodexResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/CodexResumeFallback.vitest.ts
@@ -97,6 +97,10 @@ const parentStreamId = 'stream:parent' as StreamTabId;
 const childStreamId = 'stream:codex-child' as StreamTabId;
 const executionId = 'parent-exec' as ExecutionId;
 
+function completedChildRunLoop(): { completion: Promise<void> } {
+  return { completion: Promise.resolve() };
+}
+
 describe('codex tool - atomic resume fallback', () => {
   afterEach(() => {
     vi.clearAllMocks();
@@ -106,6 +110,7 @@ describe('codex tool - atomic resume fallback', () => {
 
   function setupCommonMocks(): void {
     mocks.startChildRunLoop.mockReset();
+    mocks.startChildRunLoop.mockReturnValue(completedChildRunLoop());
     mocks.importCodexClass.mockReset();
     mocks.findCodexBinaryPath.mockReset();
     mocks.requestBashApproval.mockResolvedValue({ accepted: true });
@@ -130,6 +135,41 @@ describe('codex tool - atomic resume fallback', () => {
     });
   }
 
+  it('logs a detached run-loop rejection through the child trace', async () => {
+    setupCommonMocks();
+    const childStream = createFakeAgentCliChildStream(childStreamId);
+    const error = vi
+      .spyOn(childStream.logger, 'error')
+      .mockImplementation(() => {});
+    const lateFailure = new Error('late Codex finalization failed');
+    mocks.createChildStream.mockReturnValue(childStream);
+    mocks.startChildRunLoop.mockReturnValue({
+      completion: Promise.reject(lateFailure),
+    });
+    mocks.importCodexClass.mockResolvedValue(
+      class MockCodex {
+        startThread(): {
+          id: undefined;
+          runStreamed: ReturnType<typeof vi.fn>;
+        } {
+          return { id: undefined, runStreamed: vi.fn() };
+        }
+      },
+    );
+
+    await expect(
+      new CodexTool().call({
+        prompt: 'launch Codex',
+        sandbox_mode: 'workspace-write',
+      }),
+    ).resolves.toMatchObject({ status: 'executed' });
+    await vi.waitFor(() => {
+      expect(error).toHaveBeenCalledWith('Codex run loop failed after launch', {
+        data: lateFailure,
+      });
+    });
+  });
+
   it('launches one fallback loop when concurrent calls use the same stale thread_id', async () => {
     setupCommonMocks();
     const sdkImportStarted = pDefer<void>();
@@ -148,6 +188,7 @@ describe('codex tool - atomic resume fallback', () => {
     mocks.startChildRunLoop.mockImplementation(
       (params: { strategy: ChildRunStrategy<unknown> }) => {
         strategy = params.strategy;
+        return completedChildRunLoop();
       },
     );
 
@@ -212,6 +253,7 @@ describe('codex tool - atomic resume fallback', () => {
     mocks.startChildRunLoop.mockImplementation(
       (params: { strategy: ChildRunStrategy<unknown> }) => {
         strategy = params.strategy;
+        return completedChildRunLoop();
       },
     );
 
@@ -251,6 +293,7 @@ describe('codex tool - atomic resume fallback', () => {
     mocks.startChildRunLoop.mockImplementation(
       (params: { strategy: ChildRunStrategy<unknown> }) => {
         strategy = params.strategy;
+        return completedChildRunLoop();
       },
     );
 

--- a/src/test-kernel/tools/SubagentExecutionChildStreamId.vitest.ts
+++ b/src/test-kernel/tools/SubagentExecutionChildStreamId.vitest.ts
@@ -17,10 +17,15 @@ const mocks = vi.hoisted(() => ({
   registerExecution: vi.fn(),
   tryUseRunContext: vi.fn(),
   getCurrentToolCallContext: vi.fn(),
+  childLoopError: vi.fn(),
 }));
 
 vi.mock('@agent/runtime/childRunLoop', () => ({
   startChildRunLoop: mocks.startChildRunLoop,
+}));
+
+vi.mock('@agent/trace', () => ({
+  createChannelTrace: () => ({ error: mocks.childLoopError }),
 }));
 
 vi.mock('@agent/storage', () => ({
@@ -60,6 +65,9 @@ describe('executeSubagent childStreamId derivation', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.startChildRunLoop.mockReturnValue({
+      completion: Promise.resolve(),
+    });
     mocks.registerExecution.mockResolvedValue(undefined);
     mocks.tryUseRunContext.mockReturnValue({
       executionId: 'parent-exec',
@@ -142,5 +150,30 @@ describe('executeSubagent childStreamId derivation', () => {
         executionId: loopParams.executionId as never,
       }),
     );
+  });
+
+  it('logs a detached run-loop rejection through the runtime trace', async () => {
+    const lateFailure = new Error('late subagent finalization failed');
+    mocks.startChildRunLoop.mockReturnValue({
+      completion: Promise.reject(lateFailure),
+    });
+
+    await expect(
+      executeSubagent(
+        {
+          agent: 'proof-checker',
+          model: 'gpt5',
+          agentCategory: 'toolUse',
+        } as never,
+        'proof-checker',
+        orchestratorStreamId,
+      ),
+    ).resolves.toMatchObject({ status: 'executed' });
+    await vi.waitFor(() => {
+      expect(mocks.childLoopError).toHaveBeenCalledWith(
+        "Subagent 'proof-checker' run loop failed after launch",
+        { data: lateFailure },
+      );
+    });
   });
 });

--- a/src/tools/claudeAgent.ts
+++ b/src/tools/claudeAgent.ts
@@ -517,13 +517,18 @@ function startClaudeAgentLoop(params: {
     },
   };
 
-  startChildRunLoop({
+  const { completion } = startChildRunLoop({
     childStream,
     childStreamId,
     parentStreamId,
     executionId,
     agentName: CLAUDE_AGENT_NAME,
     strategy,
+  });
+  void completion.catch((error: unknown) => {
+    childStream.logger.error(`Claude Agent run loop failed after launch`, {
+      data: error,
+    });
   });
 }
 

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -485,13 +485,18 @@ function startCodexLoop(params: {
     },
   };
 
-  startChildRunLoop({
+  const { completion } = startChildRunLoop({
     childStream,
     childStreamId,
     parentStreamId,
     executionId,
     agentName: 'codex',
     strategy,
+  });
+  void completion.catch((error: unknown) => {
+    childStream.logger.error(`Codex run loop failed after launch`, {
+      data: error,
+    });
   });
 }
 

--- a/src/tools/delegation/subagentExecution.ts
+++ b/src/tools/delegation/subagentExecution.ts
@@ -9,6 +9,7 @@
 
 // Local imports
 import { registerExecution } from '@agent/storage';
+import { createChannelTrace } from '@agent/trace';
 import {
   captureOwnedExecutionLease,
   releaseOwnedExecutionLeaseAfterFailure,
@@ -185,13 +186,19 @@ export async function executeSubagent(
     try {
       const { createNativeSubagentStrategy } =
         await import('./nativeSubagentStrategy');
-      startChildRunLoop({
+      const { completion } = startChildRunLoop({
         childStreamId,
         parentStreamId: orchestratorStreamId,
         executionId,
         agentName,
         strategy: createNativeSubagentStrategy(strategyParams),
         recordCost,
+      });
+      void completion.catch((error: unknown) => {
+        createChannelTrace('childRunLoop').error(
+          `Subagent '${agentName}' run loop failed after launch`,
+          { data: error },
+        );
       });
     } catch (error) {
       throw await releaseOwnedExecutionLeaseAfterFailure(executionId, error);


### PR DESCRIPTION
## Summary

- attach a rejection owner to each detached Claude, Codex, and native-subagent child run
- log late run-loop or finalization failures through the child or runtime trace
- preserve the existing single user-facing result path rather than delivering a second error
- update run-loop test doubles to satisfy the handle contract and cover each late-rejection path

## Validation

- `npm run format`
- `npm run lint`
- `npm run compile:safe`
- `npm test` — 793 files passed; 7,899 tests passed
- `npm run check:dead-code-ratchet`
- focused child-launch suite — 4 files passed; 39 tests passed
- pre-commit and pre-push hooks

Closes #9325

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change with detached promise handling; no change to launch semantics or user-visible delivery paths beyond logging.
> 
> **Overview**
> Detached **child run loops** can fail after the tool has already returned `executed`. This PR **attaches a handler** to `startChildRunLoop`'s `completion` promise for Claude Agent, Codex, and native subagent launches so those late rejections are **logged** (child stream logger for CLI agents, `childRunLoop` channel trace for subagents) instead of becoming unhandled rejections.
> 
> The **user-facing path is unchanged**: the initial tool result still reflects successful launch; failures after launch do not produce a second error delivery.
> 
> Tests now return a `{ completion }` handle from `startChildRunLoop` mocks and add coverage that a rejected `completion` still yields `executed` while the expected error log fires.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 531cf5c437a20a5bf27c933f8ca59732cf40a7bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->