### PR TITLE
fix(storage): serialize deletions with root changes

### DIFF
--- a/src/controllers/progressView/backend/ProgressBackend.ts
+++ b/src/controllers/progressView/backend/ProgressBackend.ts
@@ -172,23 +172,23 @@ export class ProgressBackend {
     );
   }
 
-  deleteStream(stream: StreamTabId): Promise<void> {
-    return this.enqueueStorageOperation(() => this.deleteStreamNow(stream));
+  async deleteStream(stream: StreamTabId): Promise<void> {
+    const wasActive = this.state.activeStream === stream;
+    const retained = await this.enqueuePreparedStorageOperation(
+      () => this.prepareStreamDeletion(stream),
+      () => this.deleteStreamNow(stream, wasActive),
+    );
+    if (retained) await this.notifyDeletionRetained(retained);
   }
 
-  private async deleteStreamNow(stream: StreamTabId): Promise<void> {
+  private async prepareStreamDeletion(stream: StreamTabId): Promise<void> {
     if (!canUseStreamDataDir(stream)) return;
 
     const hasStream =
       this.state.streamLogs.has(stream) ||
       Boolean(this.state.snapshots.getTaskState(stream));
-    if (!hasStream) {
-      const deletion = await this.state.clearStream(stream);
-      if (deletion !== 'deleted') await this.notifyDeletionRetained(deletion);
-      return;
-    }
+    if (!hasStream) return;
 
-    const wasActive = this.state.activeStream === stream;
     const ownedLocally =
       this.session.executions.getAgentHandleByStream(stream) !== undefined;
     if (ownedLocally && isInFlightPhase(this.session.status.get(stream))) {
@@ -199,12 +199,26 @@ export class ProgressBackend {
     // execution lease. Auto-close can land in that interval, so the handle is
     // not a reliable indication that local durable writes have finished.
     await this.state.waitForOwnedExecutionRelease(stream);
+  }
+
+  private async deleteStreamNow(
+    stream: StreamTabId,
+    wasActive: boolean,
+  ): Promise<'active' | 'failed' | undefined> {
+    if (!canUseStreamDataDir(stream)) return undefined;
+
+    const hasStream =
+      this.state.streamLogs.has(stream) ||
+      Boolean(this.state.snapshots.getTaskState(stream));
+    if (!hasStream) {
+      const deletion = await this.state.clearStream(stream);
+      return deletion === 'deleted' ? undefined : deletion;
+    }
 
     const deletion = await this.state.clearStream(stream);
     if (deletion !== 'deleted') {
       this.lifecycle.rebuildRenderedStreams({ syncActiveStream: true });
-      await this.notifyDeletionRetained(deletion);
-      return;
+      return deletion;
     }
 
     this.lifecycle.cleanupDeletedStream(stream);
@@ -243,13 +257,23 @@ export class ProgressBackend {
     } else {
       this.lifecycle.refreshRenderedStreamsAfterDeletion?.();
     }
+    return undefined;
   }
 
-  deleteAllStreams(): Promise<void> {
-    return this.enqueueStorageOperation(() => this.deleteAllStreamsNow());
+  async deleteAllStreams(): Promise<void> {
+    const retained = await this.enqueuePreparedStorageOperation(
+      () => this.prepareAllStreamDeletions(),
+      () => this.deleteAllStreamsNow(),
+    );
+    if (retained) {
+      await this.lifecycle.notifyDeletionRetained(
+        retained.activeCount,
+        retained.failedCount,
+      );
+    }
   }
 
-  private async deleteAllStreamsNow(): Promise<void> {
+  private async prepareAllStreamDeletions(): Promise<void> {
     const streamIds = this.state.streamLogs.keys();
     const locallyOwnedStreams = streamIds.filter(
       (stream) =>
@@ -267,7 +291,12 @@ export class ProgressBackend {
         this.state.waitForOwnedExecutionRelease(stream),
       ),
     );
+  }
 
+  private async deleteAllStreamsNow(): Promise<
+    { activeCount: number; failedCount: number } | undefined
+  > {
+    const streamIds = this.state.streamLogs.keys();
     const retained = await this.state.clearAll();
     const retainedStreams = new Set([...retained.active, ...retained.failed]);
     const deleted = streamIds.filter((stream) => !retainedStreams.has(stream));
@@ -288,12 +317,12 @@ export class ProgressBackend {
       }
     }
     this.lifecycle.rebuildRenderedStreams({ syncActiveStream: !allDeleted });
-    if (!allDeleted) {
-      await this.lifecycle.notifyDeletionRetained(
-        retained.active.size,
-        retained.failed.size,
-      );
-    }
+    return allDeleted
+      ? undefined
+      : {
+          activeCount: retained.active.size,
+          failedCount: retained.failed.size,
+        };
   }
 
   load(): Promise<void> {
@@ -347,10 +376,35 @@ export class ProgressBackend {
    * Serialize operations whose filesystem work must observe one workspace
    * root from beginning to end.
    */
-  private enqueueStorageOperation(work: () => Promise<void>): Promise<void> {
-    // `add` widens to `void | undefined` for abort/timeout options; neither is
-    // used, so every enqueued operation runs and resolves with `void`.
-    return this.storageOperationQueue.add(work) as Promise<void>;
+  private enqueueStorageOperation<T>(work: () => Promise<T>): Promise<T> {
+    // `add` widens to `T | void` for abort/timeout options; neither is used,
+    // so every enqueued operation runs and resolves with its result.
+    return this.storageOperationQueue.add(work) as Promise<T>;
+  }
+
+  /**
+   * Reserve queue order before stopping executions, but perform that
+   * preparation outside the queue. An earlier root replacement may be waiting
+   * for the same execution leases and must be able to observe their release.
+   */
+  private enqueuePreparedStorageOperation<T>(
+    prepare: () => Promise<void>,
+    work: () => Promise<T>,
+  ): Promise<T> {
+    let publishPreparation!: (value: PromiseLike<void>) => void;
+    const preparation = new Promise<void>((resolve) => {
+      publishPreparation = resolve;
+    });
+    const operation = this.enqueueStorageOperation(async () => {
+      await preparation;
+      return work();
+    });
+    const pendingPreparation = prepare();
+    // If an earlier queue entry is still running, attach a rejection handler
+    // until this operation reaches the same promise.
+    void preparation.catch(() => undefined);
+    publishPreparation(pendingPreparation);
+    return operation;
   }
 
   setupEventListeners(): ProgressEventSubscription {

--- a/src/controllers/progressView/backend/ProgressBackend.ts
+++ b/src/controllers/progressView/backend/ProgressBackend.ts
@@ -105,7 +105,7 @@ export class ProgressBackend {
     payload: SetActiveStreamPayload,
   ) => void;
   private readonly stateOwnership: 'backend' | 'session';
-  private readonly storageRootQueue = new PQueue({ concurrency: 1 });
+  private readonly storageOperationQueue = new PQueue({ concurrency: 1 });
   private presentationReloadPending = false;
   private disposed = false;
 
@@ -172,7 +172,11 @@ export class ProgressBackend {
     );
   }
 
-  async deleteStream(stream: StreamTabId): Promise<void> {
+  deleteStream(stream: StreamTabId): Promise<void> {
+    return this.enqueueStorageOperation(() => this.deleteStreamNow(stream));
+  }
+
+  private async deleteStreamNow(stream: StreamTabId): Promise<void> {
     if (!canUseStreamDataDir(stream)) return;
 
     const hasStream =
@@ -241,7 +245,11 @@ export class ProgressBackend {
     }
   }
 
-  async deleteAllStreams(): Promise<void> {
+  deleteAllStreams(): Promise<void> {
+    return this.enqueueStorageOperation(() => this.deleteAllStreamsNow());
+  }
+
+  private async deleteAllStreamsNow(): Promise<void> {
     const streamIds = this.state.streamLogs.keys();
     const locallyOwnedStreams = streamIds.filter(
       (stream) =>
@@ -289,7 +297,7 @@ export class ProgressBackend {
   }
 
   load(): Promise<void> {
-    return this.enqueueStorageRootWork(async () => {
+    return this.enqueueStorageOperation(async () => {
       await this.session.waitUntilReady();
       await this.loadPresentationState();
     });
@@ -325,7 +333,7 @@ export class ProgressBackend {
       }
       if (sessionReloadError) throw sessionReloadError;
     };
-    return this.enqueueStorageRootWork(reload);
+    return this.enqueueStorageOperation(reload);
   }
 
   private async loadPresentationState(): Promise<void> {
@@ -335,10 +343,14 @@ export class ProgressBackend {
     this.state.agentCategoryFilter = 'all';
   }
 
-  private enqueueStorageRootWork(work: () => Promise<void>): Promise<void> {
+  /**
+   * Serialize operations whose filesystem work must observe one workspace
+   * root from beginning to end.
+   */
+  private enqueueStorageOperation(work: () => Promise<void>): Promise<void> {
     // `add` widens to `void | undefined` for abort/timeout options; neither is
     // used, so every enqueued operation runs and resolves with `void`.
-    return this.storageRootQueue.add(work) as Promise<void>;
+    return this.storageOperationQueue.add(work) as Promise<void>;
   }
 
   setupEventListeners(): ProgressEventSubscription {

--- a/src/controllers/progressView/backend/ProgressBackend.ts
+++ b/src/controllers/progressView/backend/ProgressBackend.ts
@@ -409,7 +409,7 @@ export class ProgressBackend {
       await preparation;
       return work();
     });
-    const pendingPreparation = prepare();
+    const pendingPreparation = Promise.resolve().then(prepare);
     // If an earlier queue entry is still running, attach a rejection handler
     // until this operation reaches the same promise.
     void preparation.catch(() => undefined);

--- a/src/controllers/progressView/backend/ProgressBackend.ts
+++ b/src/controllers/progressView/backend/ProgressBackend.ts
@@ -106,6 +106,7 @@ export class ProgressBackend {
   ) => void;
   private readonly stateOwnership: 'backend' | 'session';
   private readonly storageOperationQueue = new PQueue({ concurrency: 1 });
+  private storageGeneration = 0;
   private presentationReloadPending = false;
   private disposed = false;
 
@@ -174,9 +175,13 @@ export class ProgressBackend {
 
   async deleteStream(stream: StreamTabId): Promise<void> {
     const wasActive = this.state.activeStream === stream;
+    const storageGeneration = this.storageGeneration;
     const retained = await this.enqueuePreparedStorageOperation(
       () => this.prepareStreamDeletion(stream),
-      () => this.deleteStreamNow(stream, wasActive),
+      () =>
+        storageGeneration === this.storageGeneration
+          ? this.deleteStreamNow(stream, wasActive)
+          : Promise.resolve(undefined),
     );
     if (retained) await this.notifyDeletionRetained(retained);
   }
@@ -261,9 +266,13 @@ export class ProgressBackend {
   }
 
   async deleteAllStreams(): Promise<void> {
+    const storageGeneration = this.storageGeneration;
     const retained = await this.enqueuePreparedStorageOperation(
       () => this.prepareAllStreamDeletions(),
-      () => this.deleteAllStreamsNow(),
+      () =>
+        storageGeneration === this.storageGeneration
+          ? this.deleteAllStreamsNow()
+          : Promise.resolve(undefined),
     );
     if (retained) {
       await this.lifecycle.notifyDeletionRetained(
@@ -343,6 +352,7 @@ export class ProgressBackend {
         sessionReloadError = error;
       }
       if (sessionReloadError || storageRootReplaced) {
+        this.storageGeneration += 1;
         this.presentationReloadPending = true;
       }
       if (!this.presentationReloadPending) return;

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -305,6 +305,128 @@ async function expectDeletionBeforeStorageRootReplacement(
   }
 }
 
+async function expectDeletionCanReleaseRootReplacement(
+  deletionKind: 'one-stream' | 'all-streams',
+): Promise<void> {
+  const session = createTestSession();
+  const stream = `${deletionKind}-releases-root-move` as StreamTabId;
+  const operations: string[] = [];
+  let releaseReload: (() => void) | undefined;
+  const reloadBlocked = new Promise<void>((resolve) => {
+    releaseReload = resolve;
+  });
+  const reloadAfterStorageRootChange = vi
+    .spyOn(session, 'reloadAfterStorageRootChange')
+    .mockImplementation(async () => {
+      operations.push('reload:start');
+      await reloadBlocked;
+      operations.push('reload:end');
+      return false;
+    });
+  const lifecycle = createLifecycleOptions({
+    stopStream: vi.fn(() => {
+      operations.push('stop');
+      releaseReload?.();
+    }),
+  });
+  const { backend } = createIsolatedRecordingBackend(session, lifecycle);
+  backend.state.streamLogs.ensureStream(stream);
+  session.status.transition(
+    stream,
+    STREAM_PHASE.RUNNING,
+    STREAM_TRANSITION_CAUSE.LIFECYCLE,
+  );
+  vi.spyOn(session.executions, 'getAgentHandleByStream').mockReturnValue(
+    {} as never,
+  );
+  vi.spyOn(backend.state, 'waitForOwnedExecutionRelease').mockResolvedValue();
+  if (deletionKind === 'one-stream') {
+    vi.spyOn(backend.state, 'clearStream').mockImplementation(async () => {
+      operations.push('delete');
+      return 'deleted';
+    });
+  } else {
+    vi.spyOn(backend.state, 'clearAll').mockImplementation(async () => {
+      operations.push('delete');
+      return { active: new Set(), failed: new Set() };
+    });
+  }
+
+  try {
+    const workspaceMove = backend.reloadAfterStorageRootChange();
+    await vi.waitFor(() =>
+      expect(reloadAfterStorageRootChange).toHaveBeenCalledOnce(),
+    );
+    const deletion =
+      deletionKind === 'one-stream'
+        ? backend.deleteStream(stream)
+        : backend.deleteAllStreams();
+
+    await deletion;
+    await workspaceMove;
+
+    expect(operations).toEqual([
+      'reload:start',
+      'stop',
+      'reload:end',
+      'delete',
+    ]);
+  } finally {
+    releaseReload?.();
+    backend.dispose();
+    session.dispose();
+  }
+}
+
+async function expectRetentionNoticeDoesNotBlockStorageRootReplacement(
+  deletionKind: 'one-stream' | 'all-streams',
+): Promise<void> {
+  let finishNotice: (() => void) | undefined;
+  const noticeBlocked = new Promise<void>((resolve) => {
+    finishNotice = resolve;
+  });
+  const lifecycle = createLifecycleOptions({
+    notifyDeletionRetained: vi.fn(() => noticeBlocked),
+  });
+  const session = createTestSession();
+  const reloadAfterStorageRootChange = vi
+    .spyOn(session, 'reloadAfterStorageRootChange')
+    .mockResolvedValue(false);
+  const { backend } = createIsolatedRecordingBackend(session, lifecycle);
+  const stream = `${deletionKind}-retained-before-root-move` as StreamTabId;
+  backend.state.streamLogs.ensureStream(stream);
+  if (deletionKind === 'one-stream') {
+    vi.spyOn(backend.state, 'clearStream').mockResolvedValue('active');
+  } else {
+    vi.spyOn(backend.state, 'clearAll').mockResolvedValue({
+      active: new Set([stream]),
+      failed: new Set(),
+    });
+  }
+
+  try {
+    const deletion =
+      deletionKind === 'one-stream'
+        ? backend.deleteStream(stream)
+        : backend.deleteAllStreams();
+    await vi.waitFor(() =>
+      expect(lifecycle.notifyDeletionRetained).toHaveBeenCalled(),
+    );
+    const workspaceMove = backend.reloadAfterStorageRootChange();
+
+    await vi.waitFor(() =>
+      expect(reloadAfterStorageRootChange).toHaveBeenCalledOnce(),
+    );
+    finishNotice?.();
+    await deletion;
+    await workspaceMove;
+  } finally {
+    finishNotice?.();
+    backend.dispose();
+    session.dispose();
+  }
+}
+
 describe('ProgressBackend', () => {
   it('loads an unfiltered presentation without reloading its live transcript', async () => {
     const transcripts = await StreamLogStore.open();
@@ -531,6 +653,24 @@ describe('ProgressBackend', () => {
 
   it('finishes an all-stream deletion before replacing the storage root', async () => {
     await expectDeletionBeforeStorageRootReplacement('all-streams');
+  });
+
+  it('lets one-stream deletion release a root replacement ahead of it', async () => {
+    await expectDeletionCanReleaseRootReplacement('one-stream');
+  });
+
+  it('lets all-stream deletion release a root replacement ahead of it', async () => {
+    await expectDeletionCanReleaseRootReplacement('all-streams');
+  });
+
+  it('does not retain the storage queue for a one-stream notice', async () => {
+    await expectRetentionNoticeDoesNotBlockStorageRootReplacement('one-stream');
+  });
+
+  it('does not retain the storage queue for an all-stream notice', async () => {
+    await expectRetentionNoticeDoesNotBlockStorageRootReplacement(
+      'all-streams',
+    );
   });
 
   it('projects every approval bypass kind through one backend port', () => {

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -305,7 +305,7 @@ async function expectDeletionBeforeStorageRootReplacement(
   }
 }
 
-async function expectDeletionCanReleaseRootReplacement(
+async function expectDeletionReleasesEarlierRootReplacement(
   deletionKind: 'one-stream' | 'all-streams',
 ): Promise<void> {
   const session = createTestSession();
@@ -321,7 +321,7 @@ async function expectDeletionCanReleaseRootReplacement(
       operations.push('reload:start');
       await reloadBlocked;
       operations.push('reload:end');
-      return false;
+      return true;
     });
   const lifecycle = createLifecycleOptions({
     stopStream: vi.fn(() => {
@@ -365,12 +365,7 @@ async function expectDeletionCanReleaseRootReplacement(
     await deletion;
     await workspaceMove;
 
-    expect(operations).toEqual([
-      'reload:start',
-      'stop',
-      'reload:end',
-      'delete',
-    ]);
+    expect(operations).toEqual(['reload:start', 'stop', 'reload:end']);
   } finally {
     releaseReload?.();
     backend.dispose();
@@ -655,12 +650,12 @@ describe('ProgressBackend', () => {
     await expectDeletionBeforeStorageRootReplacement('all-streams');
   });
 
-  it('lets one-stream deletion release a root replacement ahead of it', async () => {
-    await expectDeletionCanReleaseRootReplacement('one-stream');
+  it('releases an earlier root replacement without deleting from its new root', async () => {
+    await expectDeletionReleasesEarlierRootReplacement('one-stream');
   });
 
-  it('lets all-stream deletion release a root replacement ahead of it', async () => {
-    await expectDeletionCanReleaseRootReplacement('all-streams');
+  it('releases an earlier root replacement without clearing its new root', async () => {
+    await expectDeletionReleasesEarlierRootReplacement('all-streams');
   });
 
   it('does not retain the storage queue for a one-stream notice', async () => {

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -243,6 +243,68 @@ function emitRunFact<K extends RunFactEventName>(
   });
 }
 
+async function expectDeletionBeforeStorageRootReplacement(
+  deletionKind: 'one-stream' | 'all-streams',
+): Promise<void> {
+  const transcripts = await StreamLogStore.open();
+  const session = new SessionHandle({
+    transcripts,
+    restartRepair: 'deferred',
+  });
+  const { backend } = createIsolatedRecordingBackend(session);
+  const stream = `${deletionKind}-before-root-move` as StreamTabId;
+  const operations: string[] = [];
+  let finishDeletion: (() => void) | undefined;
+  const deletionBlocked = new Promise<void>((resolve) => {
+    finishDeletion = resolve;
+  });
+  if (deletionKind === 'one-stream') {
+    vi.spyOn(backend.state, 'clearStream').mockImplementation(async () => {
+      operations.push('delete:start');
+      await deletionBlocked;
+      operations.push('delete:end');
+      return 'deleted';
+    });
+  } else {
+    vi.spyOn(backend.state, 'clearAll').mockImplementation(async () => {
+      operations.push('delete:start');
+      await deletionBlocked;
+      operations.push('delete:end');
+      return { active: new Set(), failed: new Set() };
+    });
+  }
+  const reloadAfterStorageRootChange = vi
+    .spyOn(session, 'reloadAfterStorageRootChange')
+    .mockImplementation(async () => {
+      operations.push('reload');
+      return true;
+    });
+  backend.state.streamLogs.ensureStream(stream);
+
+  try {
+    const deletion =
+      deletionKind === 'one-stream'
+        ? backend.deleteStream(stream)
+        : backend.deleteAllStreams();
+    await vi.waitFor(() => {
+      expect(operations).toEqual(['delete:start']);
+    });
+    const workspaceMove = backend.reloadAfterStorageRootChange();
+    await Promise.resolve();
+
+    expect(reloadAfterStorageRootChange).not.toHaveBeenCalled();
+    finishDeletion?.();
+    await deletion;
+    await workspaceMove;
+
+    expect(operations).toEqual(['delete:start', 'delete:end', 'reload']);
+  } finally {
+    finishDeletion?.();
+    backend.dispose();
+    session.dispose();
+  }
+}
+
 describe('ProgressBackend', () => {
   it('loads an unfiltered presentation without reloading its live transcript', async () => {
     const transcripts = await StreamLogStore.open();
@@ -461,6 +523,14 @@ describe('ProgressBackend', () => {
       backend.dispose();
       session.dispose();
     }
+  });
+
+  it('finishes a one-stream deletion before replacing the storage root', async () => {
+    await expectDeletionBeforeStorageRootReplacement('one-stream');
+  });
+
+  it('finishes an all-stream deletion before replacing the storage root', async () => {
+    await expectDeletionBeforeStorageRootReplacement('all-streams');
   });
 
   it('projects every approval bypass kind through one backend port', () => {


### PR DESCRIPTION
## Summary

- serialize one-stream deletion, all-stream deletion, presentation loading, and workspace-root replacement through one backend queue
- keep each deletion on a single storage root from its first lifecycle step through durable and presentation cleanup
- cover both single-stream and bulk-deletion races against a queued workspace move

## Validation

- `npm run format`
- `npm run lint`
- `npm run compile:safe`
- `npm test` — 793 files passed; 7,901 tests passed
- `npm run check:dead-code-ratchet`
- focused progress-backend suite — 82 tests passed
- pre-commit and pre-push hooks

Closes #9354

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches durable stream deletion and workspace storage-root replacement ordering; mistakes could corrupt or leak session data, though behavior is heavily regression-tested.
> 
> **Overview**
> **ProgressBackend** now routes stream deletion, bulk deletion, presentation load, and workspace-root reload through one serialized storage queue, with a **storage generation** counter so in-flight deletes skip durable cleanup if the root already moved.
> 
> Single- and all-stream deletes split into **prepare** (stop runs, wait for execution leases) running **outside** the queue, and **delete now** (clear streams, UI cleanup) running **inside** it. That ordering lets a queued workspace reload proceed while a delete is still stopping work, and prevents a delete started before a move from wiping data under the new root. Deletion-retention UI callbacks run after the queued phase so they no longer block root replacement.
> 
> Vitest coverage adds race scenarios for delete-vs-`reloadAfterStorageRootChange` for one stream, all streams, and retained-delete notices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64a1f29a1358dd529ab8673bf680354937fdcd70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->