### PR TITLE
fix(runtime): preserve restart repair after rollback

### DIFF
--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -326,7 +326,14 @@ export class SessionHandle {
     generation: number,
   ): Promise<boolean> {
     if (generation !== this.storageGeneration) return false;
-    await Promise.all([this.transcripts.flush(), this.snapshots.flush()]);
+    try {
+      await Promise.all([this.transcripts.flush(), this.snapshots.flush()]);
+    } catch (flushError) {
+      return this.restoreRestartRepairAfterReplacementFailure(
+        generation,
+        flushError,
+      );
+    }
     if (
       generation !== this.storageGeneration ||
       this.restartRepairAbort.signal.aborted
@@ -334,7 +341,10 @@ export class SessionHandle {
       return false;
     }
     const storage = platform().storage;
-    if (storage.commitWorkspaceStorageChange?.() === false) return false;
+    if (storage.commitWorkspaceStorageChange?.() === false) {
+      await this.runRestartRepair(generation);
+      return false;
+    }
     const previousStatus = this.status.getAllStreamStates();
     try {
       await this.transcripts.reload();
@@ -390,8 +400,26 @@ export class SessionHandle {
           'Workspace storage replacement and rollback both failed',
         );
       }
-      throw replacementError;
+      return this.restoreRestartRepairAfterReplacementFailure(
+        generation,
+        replacementError,
+      );
     }
+  }
+
+  private async restoreRestartRepairAfterReplacementFailure(
+    generation: number,
+    replacementError: unknown,
+  ): Promise<never> {
+    try {
+      await this.runRestartRepair(generation);
+    } catch (repairError) {
+      throw new AggregateError(
+        [replacementError, repairError],
+        'Workspace storage replacement failed and restored restart repair also failed',
+      );
+    }
+    throw replacementError;
   }
 
   private async runRestartRepair(generation: number): Promise<void> {

--- a/src/test-kernel/agent/runtime/SessionRestartRepair.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionRestartRepair.vitest.ts
@@ -598,6 +598,94 @@ describe('SessionHandle restart repair', () => {
     }
   });
 
+  it('restores delayed lease repair after a root replacement rolls back', async () => {
+    vi.useFakeTimers({
+      now: new Date('2026-07-28T12:00:00.000Z'),
+    });
+    const rollbackExecutionId = '9355abcd' as ExecutionId;
+    const rollbackStreamId = `crashed#${rollbackExecutionId}` as StreamTabId;
+    const storage = platform().storage;
+    let activeRoot = 'old';
+    Object.assign(storage, {
+      hasPendingWorkspaceStorageChange: () => true,
+      commitWorkspaceStorageChange: () => {
+        activeRoot = 'new';
+        return true;
+      },
+      rollbackWorkspaceStorageChange: () => {
+        activeRoot = 'old';
+        return true;
+      },
+    });
+    const transcripts = await StreamLogStore.open();
+    transcripts.append(rollbackStreamId, {
+      id: 'rollback-running-group',
+      type: STREAM_LOG_ENTRY_TYPES.GROUP_START,
+      level: LOG_LEVELS.INFO,
+      timestamp: Date.now(),
+      data: { status: STREAM_PHASE.RUNNING },
+    });
+    await transcripts.flush();
+    const executionStore = getExecutionStore(rollbackExecutionId);
+    await executionStore.writeMeta({
+      timestamp: new Date().toISOString(),
+    });
+    await executionStore.write(flowKey(rollbackExecutionId), {
+      invalid: true,
+    });
+    await StorageFS.ensureDir('executionLeases');
+    await StorageFS.writeAtomic(
+      `executionLeases/${rollbackExecutionId}.json`,
+      JSON.stringify({
+        version: 1,
+        executionId: rollbackExecutionId,
+        ownerToken: '00000000-0000-4000-8000-000000000002',
+        acquiredAt: Date.now(),
+        heartbeatAt: Date.now(),
+      }),
+    );
+
+    const session = new SessionHandle({
+      transcripts,
+      restartRepair: 'deferred',
+    });
+
+    try {
+      await session.waitUntilReady();
+      expect(session.status.get(rollbackStreamId)).toBe(STREAM_PHASE.RUNNING);
+
+      const replacementError = new Error('new snapshot root is unreadable');
+      vi.spyOn(transcripts, 'reload').mockResolvedValue();
+      vi.spyOn(session.snapshots, 'load')
+        .mockRejectedValueOnce(replacementError)
+        .mockResolvedValue();
+
+      await expect(session.reloadAfterStorageRootChange()).rejects.toBe(
+        replacementError,
+      );
+      expect(activeRoot).toBe('old');
+      expect(session.status.get(rollbackStreamId)).toBe(STREAM_PHASE.RUNNING);
+
+      await vi.advanceTimersByTimeAsync(EXECUTION_LEASE_STALE_MS + 1);
+      await vi.waitFor(() => {
+        expect(session.status.get(rollbackStreamId)).toBe(STREAM_PHASE.FAILED);
+      });
+
+      await expect(executionStore.readMeta()).resolves.toMatchObject({
+        terminalStatus: EXECUTION_STATUS.ERROR,
+      });
+      expect(
+        transcripts.get(rollbackStreamId)?.getRange(0).at(-1),
+      ).toMatchObject({
+        type: STREAM_LOG_ENTRY_TYPES.GROUP_END,
+        data: { status: RUN_OUTCOME.FAILED },
+      });
+    } finally {
+      session.dispose();
+      vi.useRealTimers();
+    }
+  });
+
   it('skips replacement when the workspace storage root is unchanged', async () => {
     const transcripts = await StreamLogStore.open();
     const session = new SessionHandle({


### PR DESCRIPTION
## Summary

- recompute delayed restart repair when a workspace-storage replacement leaves the previous root active
- cover old-store flush failure, a declined root commit, and successful rollback after a new-root load failure
- preserve the successful replacement path, where repair is computed from the new root and supersedes the previous schedule

## Motivation

A deferred restart repair is cancelled before workspace storage is replaced. If the replacement then fails and rolls back, the session restores its stores and stream status but previously did not restore that delayed repair. A fresh foreign execution lease could consequently become stale without the running stream being repaired until the application restarted.

## Validation

- `npm run format`
- `npm run compile:safe`
- `npm run lint`
- `npm test` (7,906 passed; 4 skipped)
- `npm run check:dead-code-ratchet`
- regression test with a fresh foreign lease, a forced storage-root rollback, and repair after the lease becomes stale

Closes #9355

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session persistence and restart-repair scheduling around workspace root changes; behavior is narrow but safety-critical for crashed-run recovery after failed storage migrations.
> 
> **Overview**
> **Fixes a gap where deferred restart repair was cancelled at the start of a workspace storage root swap but not re-established when the swap aborted and the session stayed on the old root.**
> 
> `replaceStoresAfterStorageRootChange` now runs `runRestartRepair` after **pre-commit flush failures**, when **`commitWorkspaceStorageChange` declines** the new root, and after a **successful rollback** following a new-root load failure—via a shared `restoreRestartRepairAfterReplacementFailure` path that still surfaces the original replacement error (and wraps repair failures in `AggregateError`).
> 
> A regression test simulates a forced rollback with a fresh foreign execution lease and asserts the stream is failed once the lease goes stale, without requiring an app restart.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a14ea0d7cca98df7776569f76eada66aedb378c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->