### PR TITLE
feat(runtime): support per-run tool overlays

### DIFF
--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -46,8 +46,8 @@ import {
 import { deriveRunOutcome } from '@shared/streams/streamStatus';
 import { getDefaultToolRegistry } from '@tools/registry';
 import {
+  buildOverlayToolRegistry,
   buildTerminalTool,
-  buildTerminalToolRegistry,
 } from '@tools/structuredOutput';
 import { TaskRunFileService } from '@utils/files';
 
@@ -242,7 +242,7 @@ export async function runToolUseFlow<C = unknown>(
     appendOverlayTool(terminalTool);
   }
   const registry = overlayTools.length
-    ? buildTerminalToolRegistry(baseRegistry, overlayTools)
+    ? buildOverlayToolRegistry(baseRegistry, overlayTools)
     : baseRegistry;
 
   const kv = getExecutionStore(executionId);

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -25,7 +25,7 @@ import {
   AgentCategory,
   type AgentToolUseSetting,
 } from '@agent/core/definition/AgentDataclass';
-import type { IToolRegistry } from '@agent/core/tools/ToolTypes';
+import type { ITool, IToolRegistry } from '@agent/core/tools/ToolTypes';
 import type { BaseFlowContextInit } from '@agent/core/flows/BaseFlowServices';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
@@ -102,6 +102,8 @@ export interface RunToolUseFlowInput<
   ) => void;
   /** Runtime feature registry for auto-injected tools. */
   toolInjections?: ToolInjectionRegistry;
+  /** Caller-supplied tools available only to this run. */
+  tools?: readonly ITool[];
   /** Reports whether terminal finalization should retain the resume record. */
   onFlowRecordDisposition?: (disposition: 'preserve' | 'delete') => void;
 }
@@ -200,6 +202,25 @@ export async function runToolUseFlow<C = unknown>(
     runtimeUnavailableTools: runContext.runtimeUnavailableTools,
     toolInjections: input.toolInjections,
   });
+  const overlayTools: ITool[] = [];
+  const overlayNames = new Set<string>();
+  const appendOverlayTool = (tool: ITool): void => {
+    const { name } = tool.definition;
+    if (overlayNames.has(name) || baseRegistry.has(name)) {
+      logger.warn(`Run-scoped tool "${name}" shadows an existing tool.`);
+    }
+    overlayNames.add(name);
+    const definitionIndex = resolvedTools.findIndex(
+      (definition) => definition.name === name,
+    );
+    if (definitionIndex === -1) {
+      resolvedTools.push(tool.definition);
+    } else {
+      resolvedTools[definitionIndex] = tool.definition;
+    }
+    overlayTools.push(tool);
+  };
+  for (const tool of input.tools ?? []) appendOverlayTool(tool);
 
   // Unforced structured-output floor: when the config declares an output
   // schema, append a synthetic `submit_output` terminal tool to the
@@ -213,15 +234,16 @@ export async function runToolUseFlow<C = unknown>(
       : undefined;
   let pendingStructuredOutput: ToolUseRunShared['structured'];
   let finalTool: ToolUseServices<C>['finalTool'];
-  let registry = baseRegistry;
   if (outputSchema) {
     const terminalTool = buildTerminalTool(outputSchema, (value) => {
       pendingStructuredOutput = value;
     });
     finalTool = { name: terminalTool.definition.name };
-    resolvedTools.push(terminalTool.definition);
-    registry = buildTerminalToolRegistry(baseRegistry, terminalTool);
+    appendOverlayTool(terminalTool);
   }
+  const registry = overlayTools.length
+    ? buildTerminalToolRegistry(baseRegistry, overlayTools)
+    : baseRegistry;
 
   const kv = getExecutionStore(executionId);
 

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -206,17 +206,22 @@ export async function runToolUseFlow<C = unknown>(
   const overlayNames = new Set<string>();
   const appendOverlayTool = (tool: ITool): void => {
     const { name } = tool.definition;
-    if (overlayNames.has(name) || baseRegistry.has(name)) {
-      logger.warn(`Run-scoped tool "${name}" shadows an existing tool.`);
-    }
-    overlayNames.add(name);
     const definitionIndex = resolvedTools.findIndex(
       (definition) => definition.name === name,
     );
+    if (
+      overlayNames.has(name) ||
+      baseRegistry.has(name) ||
+      definitionIndex !== -1
+    ) {
+      logger.warn(`Run-scoped tool "${name}" shadows an existing tool.`);
+    }
+    overlayNames.add(name);
+    const definition = { ...tool.definition, forceFunctionCall: true };
     if (definitionIndex === -1) {
-      resolvedTools.push(tool.definition);
+      resolvedTools.push(definition);
     } else {
-      resolvedTools[definitionIndex] = tool.definition;
+      resolvedTools[definitionIndex] = definition;
     }
     overlayTools.push(tool);
   };

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -264,7 +264,11 @@ export function toOpenAIResponseTools(
 
   for (const d of defs) {
     // Handle native web search tool (only if model supports it)
-    if (d.name === 'web_search' && supportsNativeWebSearch) {
+    if (
+      d.name === 'web_search' &&
+      supportsNativeWebSearch &&
+      !d.forceFunctionCall
+    ) {
       const webSearchTool: WebSearchTool = { type: 'web_search' };
       tools.push(webSearchTool);
       continue;
@@ -328,7 +332,9 @@ export function toAnthropicTools(
 
   return defs.map<ToolUnion>((d) => {
     // Check for native/server tools
-    const remoteType = ANTHROPIC_TOOL_TYPE_MAP[d.name];
+    const remoteType = d.forceFunctionCall
+      ? undefined
+      : ANTHROPIC_TOOL_TYPE_MAP[d.name];
     if (remoteType) {
       const gated = CONDITIONAL_NATIVE_TOOLS[d.name];
       // If not gated (undefined) or explicitly enabled, use native tool

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -17,6 +17,7 @@ import {
   type AgentToolUseSetting,
   type AgentWorkflowSetting,
 } from '@agent/core/definition/AgentDataclass';
+import type { ITool } from '@agent/core/tools/ToolTypes';
 import { hasPersistedParent } from '@agent/storage/executionLifecycle';
 import {
   abandonOwnedExecutionLease,
@@ -129,7 +130,7 @@ async function runToolUseAgent(
   setting: AgentToolUseSetting,
   options: Pick<
     ExecuteAgentOptions,
-    'isSubagent' | 'onFollowUpConsumed' | 'onProgress' | 'onIdle'
+    'isSubagent' | 'onFollowUpConsumed' | 'onProgress' | 'onIdle' | 'tools'
   >,
 ): Promise<AgentRuntimeFlowResult> {
   const { streamId: runStreamId, executionId: runExecutionId } = ctx.runScope;
@@ -157,6 +158,7 @@ async function runToolUseAgent(
         ),
         onFlowRecordDisposition: (disposition) =>
           lifecycle.setFlowRecordDisposition(disposition),
+        tools: options.tools,
         onModelChanged: (modelHandler) => {
           // The tool-use flow already wrote services.config.model
           // (=== ctx.config.model, same object), so the live model is updated
@@ -313,6 +315,8 @@ export interface SubagentRunOptions {
 
 /** Options for executeAgent. */
 export interface ExecuteAgentOptions extends SubagentRunOptions {
+  /** Run-scoped tools added to tool-use agents without mutating the default registry. */
+  readonly tools?: readonly ITool[];
   /** The caller owns presentation for failures before the run lifecycle. */
   suppressErrorNotification?: boolean;
   /** When true, proposal tools are filtered out to prevent nesting. */

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -280,6 +280,8 @@ function buildFallbackNotification(config: AgentConfig): FallbackNotification {
  * under a different name.
  */
 export interface SubagentRunOptions {
+  /** Run-scoped tools added to tool-use agents without mutating the default registry. */
+  readonly tools?: readonly ITool[];
   /** Parent stream ID for subagent lineage tracking. Defaults to own streamId. */
   parentStreamId?: StreamTabId;
   /** Fires when a tool-use session consumes queued follow-up instructions. */
@@ -315,8 +317,6 @@ export interface SubagentRunOptions {
 
 /** Options for executeAgent. */
 export interface ExecuteAgentOptions extends SubagentRunOptions {
-  /** Run-scoped tools added to tool-use agents without mutating the default registry. */
-  readonly tools?: readonly ITool[];
   /** The caller owns presentation for failures before the run lifecycle. */
   suppressErrorNotification?: boolean;
   /** When true, proposal tools are filtered out to prevent nesting. */
@@ -571,6 +571,7 @@ export async function resumeToolUseFromResumeData(
                   onRoundFinalized: createUsageRecordingCallback(ctx),
                   setting,
                   resume,
+                  tools: options.tools,
                   drainedFollowUps: options.drainedFollowUps,
                   takePendingFollowUps: options.takePendingFollowUps,
                   // A persisted parent marks this execution as a subagent. Without

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -137,6 +137,7 @@ export async function resumeQueuedToolUseFromResumeData(
     // cursor accepts either route; the handoff works for both.
     const result = await resumeToolUseFromResumeData(resume, {
       session: options.session,
+      tools: options.tools,
       approvalPromptsUnavailable: options.approvalPromptsUnavailable,
       runtimeUnavailableTools: options.runtimeUnavailableTools,
       parentStreamId:

--- a/src/agent/runtime/runAgent.ts
+++ b/src/agent/runtime/runAgent.ts
@@ -30,6 +30,7 @@ export interface RunAgentOptions extends Pick<
   | 'stopAfterCycle'
   | 'approvalPromptsUnavailable'
   | 'runtimeUnavailableTools'
+  | 'tools'
   | 'session'
   | 'modelHandlerCompatibilityKey'
   | 'onRun'

--- a/src/model/ToolDefinition.ts
+++ b/src/model/ToolDefinition.ts
@@ -25,6 +25,8 @@ export const ToolDefinitionSchema = z.looseObject({
   parameters: z.record(z.string(), z.unknown()).optional(),
   /** Runtime-only: original Zod schema for SDK-native conversion */
   zodSchema: z.custom<ZodType>().optional(),
+  /** Runtime-only: do not infer a provider-native tool from this definition's name. */
+  forceFunctionCall: z.boolean().optional(),
 });
 
 /** Tool definition type - derived from schema */

--- a/src/test-kernel/agent/RunScopedToolOverlay.vitest.ts
+++ b/src/test-kernel/agent/RunScopedToolOverlay.vitest.ts
@@ -75,7 +75,7 @@ describe('run-scoped tool overlay', () => {
     });
     const warn = vi.fn<typeof noopTrace.warn>();
     const logger = { ...noopTrace, warn };
-    const observedToolNames: string[][] = [];
+    const observedTools: { name: string; forceFunctionCall?: boolean }[][] = [];
     const stopAfterObservation = Object.assign(
       new Error('Tool list observed'),
       {
@@ -95,8 +95,10 @@ describe('run-scoped tool overlay', () => {
       getWireRouteKey: () => 'test',
       getModelRetryRouteKey: () => 'test:model',
       extractAssistantText: () => undefined,
-      createResponse: async (options: { tools?: { name: string }[] }) => {
-        observedToolNames.push(options.tools?.map(({ name }) => name) ?? []);
+      createResponse: async (options: {
+        tools?: { name: string; forceFunctionCall?: boolean }[];
+      }) => {
+        observedTools.push(options.tools ?? []);
         throw stopAfterObservation;
       },
     } as unknown as RunToolUseFlowInput['modelHandler'];
@@ -127,7 +129,14 @@ describe('run-scoped tool overlay', () => {
         ),
       ).rejects.toThrow('Tool list observed');
 
-      expect(observedToolNames).toEqual([['first', 'second', 'submit_output']]);
+      expect(observedTools[0]?.map(({ name }) => name)).toEqual([
+        'first',
+        'second',
+        'submit_output',
+      ]);
+      expect(
+        observedTools[0]?.every(({ forceFunctionCall }) => forceFunctionCall),
+      ).toBe(true);
       expect(warn).toHaveBeenCalledWith(
         'Run-scoped tool "first" shadows an existing tool.',
       );

--- a/src/test-kernel/agent/RunScopedToolOverlay.vitest.ts
+++ b/src/test-kernel/agent/RunScopedToolOverlay.vitest.ts
@@ -1,0 +1,138 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports - agent
+import { noopTrace } from '@agent/trace';
+import {
+  AgentCategory,
+  AgentPromptSchema,
+  AgentToolUseSettingSchema,
+} from '@agent/core/definition/AgentDataclass';
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import { MapToolRegistry, type ITool } from '@agent/core/tools/ToolTypes';
+import {
+  runToolUseFlow,
+  type RunToolUseFlowInput,
+} from '@agent/implementations/flows/tooluse/runToolUseFlow';
+import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
+import { createRunScope } from '@agent/runtime/RunScope';
+
+// Local imports - shared
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
+import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
+
+// Test support imports
+import { setupPlatform } from '@test/support/setupPlatform';
+import { createTestSession } from '@test/support/sessionTestUtils';
+
+const CONFIG: AgentConfig = {
+  inputFiles: [],
+  contextFiles: [],
+  mediaFiles: [],
+  outputFiles: [],
+  editedFile: null,
+  agent: 'chat',
+  model: 'test-model',
+  instruction: 'Use the supplied tools.',
+  agentCategory: AgentCategory.ToolUse,
+  editedFiles: [],
+  toolConfig: DEFAULT_TOOL_CONFIG,
+  memories: [],
+  workingDirectory: process.cwd(),
+  cliOutputFile: null,
+  cliMultiAgentPresetId: null,
+  outputSchema: {
+    type: 'object',
+    properties: { answer: { type: 'string' } },
+    required: ['answer'],
+  },
+};
+
+function tool(name: string): ITool {
+  return {
+    definition: { name, description: name, parameters: {} },
+    call: vi.fn(),
+  };
+}
+
+describe('run-scoped tool overlay', () => {
+  setupPlatform({ workspacePath: process.cwd() });
+
+  it('adds two injected tools and submit_output to the model-facing list', async () => {
+    const executionId = '9329abcd' as ExecutionId;
+    const streamId = `chat#${executionId}` as StreamTabId;
+    const session = createTestSession();
+    const runScope = createRunScope({
+      executionId,
+      streamId,
+      agentName: 'chat',
+      session,
+    });
+    const context = createRunContext({
+      modelSource: 'live',
+      getModel: () => CONFIG.model,
+      runScope,
+    });
+    const warn = vi.fn<typeof noopTrace.warn>();
+    const logger = { ...noopTrace, warn };
+    const observedToolNames: string[][] = [];
+    const stopAfterObservation = Object.assign(
+      new Error('Tool list observed'),
+      {
+        status: 401,
+      },
+    );
+    const modelHandler = {
+      capabilities: { supportsFunctionCalling: true, supportsVision: false },
+      config: { provider: 'test' },
+      supportsForcedToolChoice: false,
+      requiresPerCallSystemPrompt: false,
+      initializeMessages: async () => [{ role: 'user', content: 'test' }],
+      consumeInsertedAttachmentKinds: () => [],
+      getClient: async () => ({}),
+      getCredentialRouteForClient: () => undefined,
+      setOutputStreaming: () => {},
+      getWireRouteKey: () => 'test',
+      getModelRetryRouteKey: () => 'test:model',
+      extractAssistantText: () => undefined,
+      createResponse: async (options: { tools?: { name: string }[] }) => {
+        observedToolNames.push(options.tools?.map(({ name }) => name) ?? []);
+        throw stopAfterObservation;
+      },
+    } as unknown as RunToolUseFlowInput['modelHandler'];
+
+    try {
+      await expect(
+        withRunContext(context, () =>
+          runToolUseFlow(
+            {
+              config: CONFIG,
+              runScope,
+              setting: AgentToolUseSettingSchema.parse({}),
+              prompt: AgentPromptSchema.parse({}),
+              logger,
+              userVarChannels: {
+                input: Object.freeze({ MODEL: CONFIG.model }),
+                transient: {},
+              },
+              modelHandler,
+              checkInterruption: () => false,
+              setAbortController: () => {},
+              onRoundFinalized: () => {},
+              isSubagent: true,
+              tools: [tool('first'), tool('second')],
+            },
+            new MapToolRegistry({ first: tool('first') }),
+          ),
+        ),
+      ).rejects.toThrow('Tool list observed');
+
+      expect(observedToolNames).toEqual([['first', 'second', 'submit_output']]);
+      expect(warn).toHaveBeenCalledWith(
+        'Run-scoped tool "first" shadows an existing tool.',
+      );
+    } finally {
+      session.dispose();
+    }
+  });
+});

--- a/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
@@ -185,6 +185,23 @@ describe('OpenAI tool conversion', () => {
 });
 
 describe('Anthropic tool conversion', () => {
+  it('keeps a shadowing provider-native name as a function tool', () => {
+    const tools = toAnthropicTools([
+      {
+        name: 'bash',
+        description: 'Caller-supplied bash',
+        forceFunctionCall: true,
+      },
+    ]);
+
+    expect(tools[0]).toMatchObject({
+      name: 'bash',
+      description: 'Caller-supplied bash',
+      input_schema: { type: 'object' },
+    });
+    expect(tools[0]).not.toHaveProperty('type');
+  });
+
   it('uses an empty object input schema when parameters are omitted', () => {
     const tools = toAnthropicTools([
       {
@@ -519,6 +536,23 @@ describe('toOpenAIResponseTools', () => {
     const tool = tools[0] as FunctionTool;
     assert.equal(tool.type, 'function');
     assert.equal(tool.name, def.name);
+  });
+
+  it('keeps a shadowing web_search definition as a function tool', () => {
+    const tools = toOpenAIResponseTools(
+      [
+        {
+          name: 'web_search',
+          description: 'Caller-supplied search',
+          forceFunctionCall: true,
+        },
+      ],
+      { supportsNativeWebSearch: true },
+    );
+
+    assert.equal(tools.length, 1);
+    assert.equal(tools[0].type, 'function');
+    assert.equal((tools[0] as FunctionTool).name, 'web_search');
   });
 
   it('filters out function tools when supportsFunctionCalling is false', () => {

--- a/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
+++ b/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
@@ -63,6 +63,7 @@ vi.mock('@agent/implementations/flows/tooluse/runToolUseFlow', () => ({
 
 // Local imports
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import type { ITool } from '@agent/core/tools/ToolTypes';
 import type { AgentLaunchContext } from '@agent/runtime/AgentLaunchContext';
 import type { SessionHostInteractions } from '@agent/runtime/HostInteractions';
 import { resumeToolUseFromResumeData } from '@agent/runtime/executeAgent';
@@ -78,6 +79,7 @@ interface InterruptibleFlowInput {
   checkInterruption(): boolean;
   onInterrupt?: () => void;
   takePendingFollowUps?: () => readonly unknown[];
+  tools?: readonly ITool[];
 }
 
 interface TestFlowContext {
@@ -175,6 +177,12 @@ describe('resumeToolUseFromResumeData cancellation handoff', () => {
       usageMonitor: { recordUsage: vi.fn() },
     } as unknown as AgentLaunchContext;
     const order: string[] = [];
+    const tools = [
+      {
+        definition: { name: 'run_scoped' },
+        call: vi.fn(),
+      },
+    ] as unknown as readonly ITool[];
     let attachedContext: TestFlowContext | undefined;
     const handle = {
       attachToolUseFlow: vi.fn((flowContext: TestFlowContext) => {
@@ -201,6 +209,7 @@ describe('resumeToolUseFromResumeData cancellation handoff', () => {
         _registry: unknown,
         onSetup: (flowContext: TestFlowContext) => void | (() => void),
       ) => {
+        expect(input.tools).toBe(tools);
         const flowContext: TestFlowContext = {
           session: { appendFollowUp: vi.fn() },
           interrupt: () => {
@@ -226,6 +235,7 @@ describe('resumeToolUseFromResumeData cancellation handoff', () => {
     });
 
     const result = await resumeToolUseFromResumeData(snapshot, {
+      tools,
       takePendingFollowUps: () => {
         order.push('take');
         return [];

--- a/src/test-kernel/agent/runtime/resumeQueuedToolUse.vitest.ts
+++ b/src/test-kernel/agent/runtime/resumeQueuedToolUse.vitest.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { ITool } from '@agent/core/tools/ToolTypes';
 import { resumeQueuedToolUseFromResumeData } from '@agent/runtime/resumeQueuedToolUse';
 import type { StreamTabId } from '@shared/schemas';
 import { RUN_OUTCOME } from '@shared/schemas';
@@ -49,11 +50,15 @@ describe('resumeQueuedToolUseFromResumeData ownership', () => {
   it('claims recovery before draining and preserves ordered raced input', async () => {
     const session = createTestSession();
     seedRecoverable(session, 'first');
+    const tools = [
+      { definition: { name: 'run_scoped' }, call: vi.fn() },
+    ] as unknown as readonly ITool[];
 
     try {
       await expect(
         resumeQueuedToolUseFromResumeData(STREAM, snapshot(), {
           session,
+          tools,
           onFollowUpQueueReady: () => {
             expect(
               session.followUps.submit(
@@ -68,6 +73,7 @@ describe('resumeQueuedToolUseFromResumeData ownership', () => {
       ).resolves.toBe(true);
 
       const options = resumeToolUseFromResumeDataMock.mock.calls[0]?.[1];
+      expect(options.tools).toBe(tools);
       expect(options.drainedFollowUps.map((item: any) => item.text)).toEqual([
         'first',
         'second',

--- a/src/test-kernel/tools/structuredOutput.vitest.ts
+++ b/src/test-kernel/tools/structuredOutput.vitest.ts
@@ -7,8 +7,8 @@ import { MapToolRegistry, type ITool } from '@agent/core/tools/ToolTypes';
 
 // Local imports - tools
 import {
+  buildOverlayToolRegistry,
   buildTerminalTool,
-  buildTerminalToolRegistry,
   normalizeStructuredOutputSchema,
 } from '@tools/structuredOutput';
 
@@ -237,7 +237,7 @@ describe('buildTerminalTool', () => {
   });
 });
 
-describe('buildTerminalToolRegistry', () => {
+describe('buildOverlayToolRegistry', () => {
   const schema = z.strictObject({ title: z.string() });
   const tool = (name: string) =>
     ({
@@ -252,7 +252,7 @@ describe('buildTerminalToolRegistry', () => {
     const first = tool('first');
     const second = tool('second');
     const terminalTool = buildTerminalTool(schema, vi.fn());
-    const overlay = buildTerminalToolRegistry(base, [
+    const overlay = buildOverlayToolRegistry(base, [
       first,
       second,
       terminalTool,
@@ -269,8 +269,8 @@ describe('buildTerminalToolRegistry', () => {
   it('isolates concurrent overlays without mutating the shared base', () => {
     const first = tool('first');
     const second = tool('second');
-    const firstRun = buildTerminalToolRegistry(base, [first]);
-    const secondRun = buildTerminalToolRegistry(base, [second]);
+    const firstRun = buildOverlayToolRegistry(base, [first]);
+    const secondRun = buildOverlayToolRegistry(base, [second]);
 
     expect(firstRun.get('first')).toBe(first);
     expect(firstRun.get('second')).toBeUndefined();
@@ -283,7 +283,7 @@ describe('buildTerminalToolRegistry', () => {
   it('lets the last run-scoped tool win a name collision', () => {
     const first = tool('read_file');
     const second = tool('read_file');
-    const overlay = buildTerminalToolRegistry(base, [first, second]);
+    const overlay = buildOverlayToolRegistry(base, [first, second]);
 
     expect(overlay.get('read_file')).toBe(second);
   });

--- a/src/test-kernel/tools/structuredOutput.vitest.ts
+++ b/src/test-kernel/tools/structuredOutput.vitest.ts
@@ -239,29 +239,52 @@ describe('buildTerminalTool', () => {
 
 describe('buildTerminalToolRegistry', () => {
   const schema = z.strictObject({ title: z.string() });
+  const tool = (name: string) =>
+    ({
+      definition: { name, description: name, parameters: {} },
+    }) as ITool;
   const realTool = {
     definition: { name: 'read_file', description: 'read', parameters: {} },
   } as ITool;
   const base = new MapToolRegistry({ read_file: realTool });
 
-  it('overrides submit_output while delegating every other lookup', () => {
+  it('resolves every run-scoped tool while delegating other lookups', () => {
+    const first = tool('first');
+    const second = tool('second');
     const terminalTool = buildTerminalTool(schema, vi.fn());
-    const overlay = buildTerminalToolRegistry(base, terminalTool);
+    const overlay = buildTerminalToolRegistry(base, [
+      first,
+      second,
+      terminalTool,
+    ]);
 
+    expect(overlay.get('first')).toBe(first);
+    expect(overlay.get('second')).toBe(second);
     expect(overlay.get(SUBMIT_OUTPUT_TOOL_NAME)).toBe(terminalTool);
-    expect(overlay.has(SUBMIT_OUTPUT_TOOL_NAME)).toBe(true);
     expect(overlay.get('read_file')).toBe(realTool);
-    expect(overlay.has('read_file')).toBe(true);
     expect(overlay.get('missing')).toBeUndefined();
     expect(overlay.has('missing')).toBe(false);
   });
 
-  it('never mutates the base registry', () => {
-    const terminalTool = buildTerminalTool(schema, vi.fn());
-    buildTerminalToolRegistry(base, terminalTool);
+  it('isolates concurrent overlays without mutating the shared base', () => {
+    const first = tool('first');
+    const second = tool('second');
+    const firstRun = buildTerminalToolRegistry(base, [first]);
+    const secondRun = buildTerminalToolRegistry(base, [second]);
 
-    // The shared default registry must never gain the synthetic tool.
-    expect(base.get(SUBMIT_OUTPUT_TOOL_NAME)).toBeUndefined();
-    expect(base.has(SUBMIT_OUTPUT_TOOL_NAME)).toBe(false);
+    expect(firstRun.get('first')).toBe(first);
+    expect(firstRun.get('second')).toBeUndefined();
+    expect(secondRun.get('second')).toBe(second);
+    expect(secondRun.get('first')).toBeUndefined();
+    expect(base.get('first')).toBeUndefined();
+    expect(base.get('second')).toBeUndefined();
+  });
+
+  it('lets the last run-scoped tool win a name collision', () => {
+    const first = tool('read_file');
+    const second = tool('read_file');
+    const overlay = buildTerminalToolRegistry(base, [first, second]);
+
+    expect(overlay.get('read_file')).toBe(second);
   });
 });

--- a/src/tools/structuredOutput.ts
+++ b/src/tools/structuredOutput.ts
@@ -224,7 +224,7 @@ export function buildTerminalTool(
  * overlay. Concurrent runs can therefore share `base` without seeing one
  * another's injected or structured-output tools.
  */
-export function buildTerminalToolRegistry(
+export function buildOverlayToolRegistry(
   base: IToolRegistry,
   tools: readonly ITool[],
 ): IToolRegistry {

--- a/src/tools/structuredOutput.ts
+++ b/src/tools/structuredOutput.ts
@@ -219,19 +219,20 @@ export function buildTerminalTool(
 }
 
 /**
- * Wrap a base registry so `submit_output` resolves to the run-scoped terminal
- * tool while every other lookup delegates to `base`. The shared default
- * registry is never mutated, so concurrent runs never see one another's
- * terminal tool. Used by the tool-use flow to make the synthetic tool findable
- * by name (`toolRegistry.get('submit_output')`) alongside the real tools.
+ * Overlay run-scoped tools on a base registry without mutating it. Overlay
+ * tools win name collisions, and later entries win collisions within the
+ * overlay. Concurrent runs can therefore share `base` without seeing one
+ * another's injected or structured-output tools.
  */
 export function buildTerminalToolRegistry(
   base: IToolRegistry,
-  terminalTool: ITool,
+  tools: readonly ITool[],
 ): IToolRegistry {
+  const overlay = new Map(
+    tools.map((tool) => [tool.definition.name, tool] as const),
+  );
   return {
-    get: (name) =>
-      name === SUBMIT_OUTPUT_TOOL_NAME ? terminalTool : base.get(name),
-    has: (name) => name === SUBMIT_OUTPUT_TOOL_NAME || base.has(name),
+    get: (name) => overlay.get(name) ?? base.get(name),
+    has: (name) => overlay.has(name) || base.has(name),
   };
 }


### PR DESCRIPTION
## Summary

- add `tools?: readonly ITool[]` to `ExecuteAgentOptions` and `RunAgentOptions`
- compose caller-supplied tools with each tool-use run without mutating the shared default registry
- add injected definitions unconditionally to the model-facing tool list, alongside `submit_output`
- make run-scoped tools win name collisions and emit a warning when they shadow another tool

## Design

This is an intentional API addition. It generalizes the existing per-run `submit_output` overlay from one tool to an arbitrary finite list; it does not add registry mutation, a new service port, or a second tool-resolution mechanism.

Each run constructs an immutable overlay map. Later run-scoped entries win collisions, so the structured-output terminal tool remains authoritative if a caller also supplies `submit_output`. The model-facing definition list uses the same ordering and contains at most one definition for each name.

The production diff is a net addition of 28 lines, below the issue's 60-line ceiling.

## Validation

- `npm run format`
- `npm run compile:safe`
- `npm run lint`
- `npm test` (7,908 passed; 4 skipped)
- `npm run check:dead-code-ratchet`
- flow-level coverage for two injected tools plus `submit_output`, including collision warning
- registry coverage for lookup, collision precedence, base immutability, and concurrent-run isolation

Closes #9329

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the tool-use flow’s registry composition and provider tool conversion, but uses immutable per-run overlays and adds targeted tests across flow, resume, conversion, and registry behavior.
> 
> **Overview**
> Callers can pass **`tools?: readonly ITool[]`** through **`runAgent`**, **`executeAgent`**, and resume paths so tool-use runs get extra implementations for that execution only, without changing the shared default registry.
> 
> **`runToolUseFlow`** merges caller tools and structured-output **`submit_output`** into one per-run overlay via **`buildOverlayToolRegistry`** (replacing the single-tool **`buildTerminalToolRegistry`**). Overlay definitions are added to the model-facing list with **`forceFunctionCall: true`**; name collisions favor the overlay and log a shadowing warning.
> 
> **`ToolDefinition.forceFunctionCall`** skips provider-native shortcuts (e.g. Anthropic **`bash`**, OpenAI **`web_search`**) so run-scoped tools with those names stay ordinary function tools.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c199ca219a93e5f5c3830b7ad6052a4c174582fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->