### PR TITLE
fix(workflow): unify progress status labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ All notable changes to this project will be documented in this file.
   `@texra-ai/agent`, load agents from a chosen directory, stream run events,
   and await the final result.
 
+#### Bug Fixes
+
+- **Consistent workflow progress** — workflow rounds and task states now use
+  the same numbering and wording in the terminal, desktop, and VS Code.
+
 ## [0.39.9] - 2026-07-26
 
 ### Shared (all surfaces)

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -159,11 +159,11 @@ const SCENARIOS = [
       'Compile check failed',
       'paper.log',
     ],
-    expectPatterns: [/r0.*completed/, /r1.*completed/],
+    expectPatterns: [/r1\/2.*Finished/, /r2\/2.*Finished/],
     ordered: [
-      { before: 'r0', after: 'Generated files' },
+      { before: 'r1/2 Finished', after: 'Generated files' },
       { before: 'Generated files', after: 'Compile check failed' },
-      { before: 'Compile check failed', after: 'r1 (2/2) completed' },
+      { before: 'Compile check failed', after: 'r2/2 Finished' },
     ],
   },
   {

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -153,7 +153,7 @@ const SCENARIOS = [
     bootExpect: 'Tab children',
     keys: ['\t', DOWN, '\r'],
     expect: [
-      'repositoryAudit completed',
+      'repositoryAudit Finished',
       'Generated files',
       'paper.tex',
       'Compile check failed',

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -182,7 +182,7 @@ const SCENARIOS = [
       'Running: Proofread paper B',
       'live-workflow-validation running',
       'Proofread (1/1)',
-      'correct running',
+      'correct Running',
       '2 subagents',
     ],
   },
@@ -2413,10 +2413,10 @@ const SCENARIOS = [
         unexpect: ['Tab children', '1 sub', 'orderChecker'],
       },
       {
-        expect: ['Tab children', '1 sub', 'orderChecker running'],
+        expect: ['Tab children', '1 sub', 'orderChecker Running'],
       },
       {
-        expect: ['1 sub', 'orderChecker running'],
+        expect: ['1 sub', 'orderChecker Running'],
       },
     ],
     expect: ['orderChecker', '1 sub', 'Tab children'],
@@ -2440,13 +2440,13 @@ const SCENARIOS = [
       },
       {
         expect: ['Tab children', 'orderChecker'],
-        unexpect: ['orderChecker running'],
+        unexpect: ['orderChecker Running'],
       },
       {
-        expect: ['orderChecker running'],
+        expect: ['orderChecker Running'],
       },
       {
-        expect: ['orderChecker running'],
+        expect: ['orderChecker Running'],
       },
     ],
     expect: ['orderChecker', '1 sub', 'Tab children'],
@@ -2483,7 +2483,7 @@ const SCENARIOS = [
         unexpect: ['1 sub', 'orderChecker'],
       },
       {
-        expect: ['1 sub', 'orderChecker running'],
+        expect: ['1 sub', 'orderChecker Running'],
       },
     ],
     expect: ['orderChecker', '1 sub', 'Tab children'],
@@ -2522,7 +2522,7 @@ const SCENARIOS = [
         unexpect: ['1 sub', 'orderChecker'],
       },
       {
-        expect: ['1 sub', 'orderChecker running'],
+        expect: ['1 sub', 'orderChecker Running'],
       },
     ],
     expect: ['orderChecker', '1 sub', 'Tab children'],
@@ -2543,8 +2543,8 @@ const SCENARIOS = [
     checkpoints: [
       { unexpect: ['Tab children', '1 sub', 'orderChecker'] },
       { unexpect: ['Tab children', '1 sub', 'orderChecker'] },
-      { expect: ['1 sub', 'orderChecker running'] },
-      { expect: ['1 sub', 'orderChecker running'] },
+      { expect: ['1 sub', 'orderChecker Running'] },
+      { expect: ['1 sub', 'orderChecker Running'] },
       {
         // Promoted to top-level: no longer active under root. The historical
         // relationship still contributes to the retained subagent count, but
@@ -2587,12 +2587,12 @@ const SCENARIOS = [
         unexpect: ['1 sub', 'orderChecker'],
       },
       {
-        expect: ['1 sub', 'orderChecker running'],
+        expect: ['1 sub', 'orderChecker Running'],
       },
       {
         // A late, stale roster from the child's former parent must not erase
         // active membership under the new (root) parent.
-        expect: ['1 sub', 'orderChecker running'],
+        expect: ['1 sub', 'orderChecker Running'],
       },
     ],
     // Prove the TUI is still interactive by focusing the reattached child.
@@ -2639,16 +2639,16 @@ const SCENARIOS = [
     checkpoints: [
       { unexpect: ['Tab children', '1 sub', 'orderChecker'] },
       { unexpect: ['Tab children', '1 sub', 'orderChecker'] },
-      { expect: ['1 sub', 'orderChecker running'] },
-      { expect: ['1 sub', 'orderChecker running'] },
+      { expect: ['1 sub', 'orderChecker Running'] },
+      { expect: ['1 sub', 'orderChecker Running'] },
       {
         // Untrack (roster omission) arrives before the terminal status: the
         // retained/historical row survives, but active membership does not.
-        expect: ['orderChecker running', '1 sub'],
+        expect: ['orderChecker Running', '1 sub'],
       },
       {
-        expect: ['orderChecker completed', '1 sub'],
-        unexpect: ['orderChecker running'],
+        expect: ['orderChecker Finished', '1 sub'],
+        unexpect: ['orderChecker Running'],
       },
       {
         // Removal scrubs every trace, including the retained/historical row.
@@ -2692,13 +2692,13 @@ const SCENARIOS = [
     },
     bootExpect: 'Tab children',
     expect: [
-      'strategy running',
-      'leanSolver waiting for you',
-      'reviewer error',
+      'strategy Running',
+      'leanSolver Waiting for follow-up',
+      'reviewer Failed',
       '3 sub',
       'Tab children',
     ],
-    unexpect: ['reviewer running'],
+    unexpect: ['reviewer Running'],
   },
   {
     name: 'subagents-with-todos-compact',
@@ -2772,7 +2772,7 @@ const SCENARIOS = [
     keys: ['\t', DOWN, DOWN, DOWN, '\r'],
     expect: [
       'strategy is checking the harness-child-strategy details',
-      '✓ ● strategy running',
+      '✓ ● strategy Running',
     ],
     unexpect: [
       'agent: chat · model: harness-model',
@@ -2795,7 +2795,7 @@ const SCENARIOS = [
     keys: ['\t', DOWN, DOWN],
     resizes: [{ cols: 44, rows: 7 }],
     expect: ['leanSolver w', '+3 sessions'],
-    maxOccurrences: [{ text: 'leanSolver waiting for you', max: 1 }],
+    maxOccurrences: [{ text: 'leanSolver Waiting for follow-up', max: 1 }],
   },
   {
     name: 'subagent-list-remembers-selection',
@@ -2808,7 +2808,7 @@ const SCENARIOS = [
     },
     bootExpect: 'Tab children',
     keys: ['\t', DOWN, DOWN, DOWN, ESC, '\t'],
-    expect: ['›   ● strategy running', 'Tab input', 'Esc input'],
+    expect: ['›   ● strategy Running', 'Tab input', 'Esc input'],
     unexpect: ['signal read during notification phase', 'ERROR'],
   },
   {
@@ -2869,7 +2869,7 @@ const SCENARIOS = [
     expect: [
       'strategy detail line 15',
       'strategy detail line 18',
-      '✓ ● strategy running',
+      '✓ ● strategy Running',
     ],
     unexpect: [
       'strategy detail line 01',
@@ -2893,7 +2893,7 @@ const SCENARIOS = [
     },
     bootExpect: 'Tab children',
     keys: ['\t', DOWN, DOWN, DOWN, '\r'],
-    expect: ['1 subagent', 'localChecker running'],
+    expect: ['1 subagent', 'localChecker Running'],
     unexpect: [
       'leanSolver',
       'reviewer',
@@ -2961,7 +2961,7 @@ const SCENARIOS = [
     bootExpect: 'Tab children',
     keys: ['\t', DOWN, DOWN, DOWN, 'v'],
     expect: [
-      '›   ● strategy running',
+      '›   ● strategy Running',
       'Session selection active.',
       'v full output',
       'Esc input',
@@ -3032,7 +3032,7 @@ const SCENARIOS = [
     bootExpect: 'Tab children',
     keys: ['\t', DOWN, DOWN, DOWN, 'k'],
     expect: [
-      '›   ● strategy stopped',
+      '›   ● strategy Cancelled',
       'Enter focus',
       'v full output',
       'Tab input',
@@ -3054,7 +3054,7 @@ const SCENARIOS = [
     keys: ['\t', DOWN, DOWN, DOWN, 'k', '\r'],
     frame: 'viewport',
     expect: [
-      '› ✓ ● strategy stopped',
+      '› ✓ ● strategy Cancelled',
       '◆ stopped',
       'root active',
       STOPPED_SUBAGENT_INPUT_MESSAGE_START,
@@ -3074,14 +3074,14 @@ const SCENARIOS = [
     keys: ['\t', DOWN, DOWN, DOWN, 'k', '\r', '\t', UP, '\r'],
     frame: 'viewport',
     expect: [
-      '✓ ● leanSolver waiting for you',
+      '✓ ● leanSolver Waiting for follow-up',
       '◆ waiting for you',
       'root active',
     ],
     unexpect: [
       'Harness interrupt requested.',
       STOPPED_SUBAGENT_INPUT_MESSAGE_START,
-      '› ✓ ● strategy stopped',
+      '› ✓ ● strategy Cancelled',
     ],
   },
   {
@@ -3105,7 +3105,7 @@ const SCENARIOS = [
     ],
     frame: 'viewport',
     expect: [
-      '› ✓ ● strategy stopped',
+      '› ✓ ● strategy Cancelled',
       '◆ stopped',
       'root active',
       STOPPED_SUBAGENT_INPUT_MESSAGE_START,
@@ -3204,9 +3204,9 @@ const SCENARIOS = [
     expect: [
       'Harness focused interrupt requested for harness-stream-1.',
       '› ✓ ● main stopped',
-      'strategy running',
-      'leanSolver waiting for you',
-      'reviewer running',
+      'strategy Running',
+      'leanSolver Waiting for follow-up',
+      'reviewer Running',
       '3 sub',
       'Session selection active.',
     ],
@@ -3232,9 +3232,9 @@ const SCENARIOS = [
     ],
     frame: 'viewport',
     expect: [
-      'strategy stopped',
-      'leanSolver waiting for you',
-      'reviewer running',
+      'strategy Cancelled',
+      'leanSolver Waiting for follow-up',
+      'reviewer Running',
       '3 subagents',
       'Session selection active.',
     ],
@@ -3252,9 +3252,9 @@ const SCENARIOS = [
     keys: ['\t', DOWN, DOWN, DOWN, '\r', { input: ESC, delayMs: 700 }],
     frame: 'viewport',
     expect: [
-      'strategy stopped',
-      '› ✓ ● reviewer running',
-      'leanSolver waiting for you',
+      'strategy Cancelled',
+      '› ✓ ● reviewer Running',
+      'leanSolver Waiting for follow-up',
       'Ctrl-C stop root',
     ],
     unexpect: ['Harness interrupt requested.', '› ✓ ● main stopped'],
@@ -3270,7 +3270,7 @@ const SCENARIOS = [
     bootExpect: 'Run command?',
     keys: [{ input: ESC, delayMs: 700 }],
     frame: 'viewport',
-    expect: ['› ✓ ● main running', 'strategy running', '3 sub'],
+    expect: ['› ✓ ● main running', 'strategy Running', '3 sub'],
     unexpect: [
       'Run command?',
       'Harness focused interrupt requested',
@@ -3287,7 +3287,7 @@ const SCENARIOS = [
     bootExpect: 'Tab children',
     keys: [{ input: ESC, delayMs: 80 }, '2'],
     frame: 'viewport',
-    expect: ['› ✓ ● leanSolver waiting for you', 'root active'],
+    expect: ['› ✓ ● leanSolver Waiting for follow-up', 'root active'],
     unexpect: [
       'Harness focused interrupt requested',
       'Harness interrupt requested.',

--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -3055,7 +3055,7 @@ const SCENARIOS = [
     frame: 'viewport',
     expect: [
       '› ✓ ● strategy Cancelled',
-      '◆ stopped',
+      '◆ Cancelled',
       'root active',
       STOPPED_SUBAGENT_INPUT_MESSAGE_START,
       'Ctrl-C stop root',
@@ -3075,7 +3075,7 @@ const SCENARIOS = [
     frame: 'viewport',
     expect: [
       '✓ ● leanSolver Waiting for follow-up',
-      '◆ waiting for you',
+      '◆ Waiting for follow-up',
       'root active',
     ],
     unexpect: [
@@ -3106,7 +3106,7 @@ const SCENARIOS = [
     frame: 'viewport',
     expect: [
       '› ✓ ● strategy Cancelled',
-      '◆ stopped',
+      '◆ Cancelled',
       'root active',
       STOPPED_SUBAGENT_INPUT_MESSAGE_START,
     ],

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -7,6 +7,7 @@ import { useMemo } from 'react';
 // Local imports - shared stream state
 import {
   AgentCategory,
+  WORKFLOW_TASK_STATUS_LABEL,
   type StreamTabId,
   type WorkflowCallProgress,
 } from '@shared/schemas';
@@ -19,6 +20,7 @@ import {
   formatPhaseStageLabel,
   formatRoundStageLabel,
   formatStreamStatusLabel,
+  streamStatusDisplayKey,
 } from '@shared/streams/streamStatusDisplay';
 import { formatResultCount } from '@utils/text/stringUtils';
 
@@ -132,11 +134,23 @@ function SessionRow({
   readonly session: StreamView;
 }): React.JSX.Element {
   const status = session.slice?.status;
-  const statusLabel = formatStreamStatusLabel(status, {
-    style: 'cli',
-    isChildStream: session.parentId !== undefined,
-    ...(session.slice?.substate ? { substate: session.slice.substate } : {}),
-  });
+  const substate = session.slice?.substate;
+  const statusKey = streamStatusDisplayKey(status, substate);
+  const childStatusLabel =
+    session.parentId !== undefined &&
+    statusKey !== undefined &&
+    Object.hasOwn(WORKFLOW_TASK_STATUS_LABEL, statusKey)
+      ? WORKFLOW_TASK_STATUS_LABEL[
+          statusKey as keyof typeof WORKFLOW_TASK_STATUS_LABEL
+        ]
+      : undefined;
+  const statusLabel =
+    childStatusLabel ??
+    formatStreamStatusLabel(status, {
+      style: 'cli',
+      isChildStream: session.parentId !== undefined,
+      ...(substate ? { substate } : {}),
+    });
   const elapsed = childElapsed(
     {
       status,

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -7,7 +7,6 @@ import { useMemo } from 'react';
 // Local imports - shared stream state
 import {
   AgentCategory,
-  WORKFLOW_TASK_STATUS_LABEL,
   type StreamTabId,
   type WorkflowCallProgress,
 } from '@shared/schemas';
@@ -19,13 +18,12 @@ import {
 import {
   formatPhaseStageLabel,
   formatRoundStageLabel,
-  formatStreamStatusLabel,
-  streamStatusDisplayKey,
 } from '@shared/streams/streamStatusDisplay';
 import { formatResultCount } from '@utils/text/stringUtils';
 
 // Local imports - TUI rendering
 import { truncateSummaryToWidth } from '../render/terminalText';
+import { formatCliStatusLabel } from '../sessionStatus';
 
 // Local imports - TUI state and controls
 import { childElapsed } from '../state/childControls';
@@ -135,22 +133,11 @@ function SessionRow({
 }): React.JSX.Element {
   const status = session.slice?.status;
   const substate = session.slice?.substate;
-  const statusKey = streamStatusDisplayKey(status, substate);
-  const childStatusLabel =
-    session.parentId !== undefined &&
-    statusKey !== undefined &&
-    Object.hasOwn(WORKFLOW_TASK_STATUS_LABEL, statusKey)
-      ? WORKFLOW_TASK_STATUS_LABEL[
-          statusKey as keyof typeof WORKFLOW_TASK_STATUS_LABEL
-        ]
-      : undefined;
-  const statusLabel =
-    childStatusLabel ??
-    formatStreamStatusLabel(status, {
-      style: 'cli',
-      isChildStream: session.parentId !== undefined,
-      ...(substate ? { substate } : {}),
-    });
+  const statusLabel = formatCliStatusLabel(
+    status,
+    substate,
+    session.parentId !== undefined,
+  );
   const elapsed = childElapsed(
     {
       status,

--- a/packages/cli/src/chat/tui/panes/WorkflowRunDetails.tsx
+++ b/packages/cli/src/chat/tui/panes/WorkflowRunDetails.tsx
@@ -8,11 +8,12 @@ import { Box, Text } from 'ink';
 
 import {
   STREAM_PHASE,
+  WORKFLOW_TASK_STATUS_LABEL,
   roundIndexedEntries,
   type TaskGroup,
   type TaskGroupStatus,
 } from '@shared/schemas';
-import { formatStreamStatusLabel } from '@shared/streams/streamStatusDisplay';
+import { formatRoundStageLabel } from '@shared/streams/streamStatusDisplay';
 import { formatDuration } from '@utils/text/stringUtils';
 
 import { safeTerminalText } from '../render/terminalText';
@@ -83,16 +84,10 @@ function taskGroupLine(group: TaskGroup, label: string): WorkflowRunDetailLine {
       : '';
   return {
     key: `group:${group.id}`,
-    text: `${appearance.marker} ${safeTerminalText(label)} ${formatStreamStatusLabel(group.status, { style: 'cli' })}${duration}`,
+    text: `${appearance.marker} ${safeTerminalText(label)} ${WORKFLOW_TASK_STATUS_LABEL[group.status]}${duration}`,
     tone: appearance.tone,
     role: 'lifecycle',
   };
-}
-
-function roundLabel(round: number, total: number | undefined): string {
-  return total === undefined
-    ? `r${round}`
-    : `r${round} (${round + 1}/${total})`;
 }
 
 function lifecyclePriority(
@@ -163,11 +158,16 @@ function workflowRunDetailGroups(
     const planned = group === undefined && round < plannedTotal;
     const lines: WorkflowRunDetailLine[] = [];
     if (group) {
-      lines.push(taskGroupLine(group, roundLabel(round, group.total)));
+      lines.push(
+        taskGroupLine(
+          group,
+          formatRoundStageLabel({ index: round, total: group.total }),
+        ),
+      );
     } else {
       const label = planned
-        ? `${roundLabel(round, plannedTotal)} planned`
-        : `${roundLabel(round, undefined)} results`;
+        ? `${formatRoundStageLabel({ index: round, total: plannedTotal })} ${WORKFLOW_TASK_STATUS_LABEL.planned}`
+        : `${formatRoundStageLabel({ index: round })} results`;
       lines.push({
         key: `round:${round}`,
         text: `${TODO_PENDING} ${label}`,
@@ -206,7 +206,7 @@ function workflowRunDetailGroups(
     ).entries()) {
       lines.push({
         key: `missing:${round}:${path}:${index}`,
-        text: `  ${WARNING} r${round} · Missing expected output: ${safeTerminalText(path)}`,
+        text: `  ${WARNING} ${formatRoundStageLabel({ index: round })} · Missing expected output: ${safeTerminalText(path)}`,
         tone: 'warning',
         role: 'alert',
       });
@@ -216,7 +216,7 @@ function workflowRunDetailGroups(
     ).entries()) {
       lines.push({
         key: `compile:${round}:${failure.log.absolutePath}:${index}`,
-        text: `  ${CROSS} r${round} · Compile check failed: ${safeTerminalText(failure.displayName)} · ${safeTerminalText(failure.logRelativePath)}`,
+        text: `  ${CROSS} ${formatRoundStageLabel({ index: round })} · Compile check failed: ${safeTerminalText(failure.displayName)} · ${safeTerminalText(failure.logRelativePath)}`,
         tone: 'error',
         role: 'alert',
       });

--- a/packages/cli/src/chat/tui/sessionStatus.ts
+++ b/packages/cli/src/chat/tui/sessionStatus.ts
@@ -4,6 +4,8 @@ import {
 } from '@cli/runtime/modelAccessRoute';
 import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
 import {
+  STREAM_PHASE,
+  STREAM_STATUS,
   WORKFLOW_TASK_STATUS_LABEL,
   type StreamSubstate,
 } from '@shared/schemas';
@@ -50,6 +52,9 @@ export function formatCliStatusLabel(
   substate?: StreamSubstate,
   isChildStream?: boolean,
 ): string {
+  if (isChildStream && status === STREAM_STATUS.STOPPED) {
+    return WORKFLOW_TASK_STATUS_LABEL[STREAM_PHASE.CANCELLED];
+  }
   const statusKey = streamStatusDisplayKey(status, substate);
   if (isChildStream && statusKey === undefined) return '';
   if (

--- a/packages/cli/src/chat/tui/sessionStatus.ts
+++ b/packages/cli/src/chat/tui/sessionStatus.ts
@@ -51,6 +51,7 @@ export function formatCliStatusLabel(
   isChildStream?: boolean,
 ): string {
   const statusKey = streamStatusDisplayKey(status, substate);
+  if (isChildStream && statusKey === undefined) return '';
   if (
     isChildStream &&
     statusKey !== undefined &&

--- a/packages/cli/src/chat/tui/sessionStatus.ts
+++ b/packages/cli/src/chat/tui/sessionStatus.ts
@@ -3,9 +3,15 @@ import {
   type CliModelAccessRoute,
 } from '@cli/runtime/modelAccessRoute';
 import type { CliApprovalPolicy } from '@cli/schemas/cliSettings';
-import type { StreamSubstate } from '@shared/schemas';
+import {
+  WORKFLOW_TASK_STATUS_LABEL,
+  type StreamSubstate,
+} from '@shared/schemas';
 import { summarizeFollowupMessage } from '@shared/subagentFollowup';
-import { formatStreamStatusLabel } from '@shared/streams/streamStatusDisplay';
+import {
+  formatStreamStatusLabel,
+  streamStatusDisplayKey,
+} from '@shared/streams/streamStatusDisplay';
 import { truncateSummary } from '@utils/text/stringUtils';
 
 import { formatResumeCommand } from './state/resumeHint';
@@ -44,6 +50,16 @@ export function formatCliStatusLabel(
   substate?: StreamSubstate,
   isChildStream?: boolean,
 ): string {
+  const statusKey = streamStatusDisplayKey(status, substate);
+  if (
+    isChildStream &&
+    statusKey !== undefined &&
+    Object.hasOwn(WORKFLOW_TASK_STATUS_LABEL, statusKey)
+  ) {
+    return WORKFLOW_TASK_STATUS_LABEL[
+      statusKey as keyof typeof WORKFLOW_TASK_STATUS_LABEL
+    ];
+  }
   return formatStreamStatusLabel(status, {
     style: 'cli',
     missingLabel: '—',

--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -36,6 +36,7 @@ import '@awesome.me/webawesome/dist/components/badge/badge.js';
 import {
   DEFAULT_STREAM_METADATA_STATUS,
   STREAM_PHASE,
+  WORKFLOW_TASK_STATUS_LABEL,
   type ActiveChildInfo,
   type InquiryThreadUpdatedEvent,
 } from '@shared/schemas';
@@ -532,16 +533,31 @@ function taskStatusBadge(child: ActiveChildInfo): {
   if (child.finishedAt === undefined || subagentStatusStillInFlight) {
     return child.status === STREAM_PHASE.WAITING ||
       child.status === DEFAULT_STREAM_METADATA_STATUS
-      ? { text: 'waiting', variant: 'neutral' }
-      : { text: 'running', variant: 'warning' };
+      ? {
+          text: WORKFLOW_TASK_STATUS_LABEL.waiting,
+          variant: 'neutral',
+        }
+      : {
+          text: WORKFLOW_TASK_STATUS_LABEL.running,
+          variant: 'warning',
+        };
   }
   switch (child.status) {
     case STREAM_PHASE.FAILED:
-      return { text: STREAM_PHASE.FAILED, variant: 'danger' };
+      return {
+        text: WORKFLOW_TASK_STATUS_LABEL.failed,
+        variant: 'danger',
+      };
     case STREAM_PHASE.CANCELLED:
-      return { text: STREAM_PHASE.CANCELLED, variant: 'neutral' };
+      return {
+        text: WORKFLOW_TASK_STATUS_LABEL.cancelled,
+        variant: 'neutral',
+      };
     default:
-      return { text: STREAM_PHASE.COMPLETED, variant: 'success' };
+      return {
+        text: WORKFLOW_TASK_STATUS_LABEL.completed,
+        variant: 'success',
+      };
   }
 }
 

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -23,11 +23,10 @@ import { designTokens } from '@shared/styles';
 import { workflowPhaseCallProgress } from '@shared/copy/workflowCall';
 import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
 
-// Side-effect imports - register WA icon and spinner components
+// Side-effect imports - register Web Awesome components
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/details/details.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import '@awesome.me/webawesome/dist/components/spinner/spinner.js';
 
 import { isInFlightPhase } from '@shared/streams/streamStatus';
 import { parseWorkflowOutputRoundDir } from '@shared/constants/workflowOutput';
@@ -63,15 +62,15 @@ const DEFAULT_GROUP_MESSAGE_WINDOW = 400;
 const GROUP_MESSAGE_WINDOW_STEP = 400;
 
 /**
- * Maps group status to a wa-icon name; null indicates an animated spinner.
+ * Maps group status to a steady wa-icon name.
  * `TaskGroup.status` is the native `StreamPhase`/`RunOutcome` vocabulary
  * (#7993 step 3) — `CANCELLED` now renders distinctly from `COMPLETED`
  * instead of folding into one neutral "stopped" icon.
  */
-function getStatusIcon(status: string): TeXRAIconName | null {
+function getStatusIcon(status: string): TeXRAIconName {
   switch (status) {
     case STREAM_PHASE.RUNNING:
-      return null;
+      return 'circle';
     case STREAM_PHASE.FAILED:
       return 'circle-exclamation';
     case STREAM_PHASE.COMPLETED:
@@ -525,13 +524,7 @@ export class TaskGroupList extends LitElement {
         ? ` (${group.index + 1}/${group.total})`
         : '';
     return html`
-      <span class="group-status-icon">
-        ${
-          statusIcon
-            ? html`${waIcon(statusIcon)}`
-            : html`<wa-spinner></wa-spinner>`
-        }
-      </span>
+      <span class="group-status-icon"> ${waIcon(statusIcon)} </span>
       <span class="group-title">${group.name}${positionText}</span>
       ${this.renderGroupProgress(group, messages)}
       <span class="group-time">

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -29,6 +29,7 @@ import '@awesome.me/webawesome/dist/components/details/details.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
 import { isInFlightPhase } from '@shared/streams/streamStatus';
+import { formatRoundStageLabel } from '@shared/streams/streamStatusDisplay';
 import { parseWorkflowOutputRoundDir } from '@shared/constants/workflowOutput';
 import { ToggleStateStore } from '@shared/state/ToggleStateStore';
 import { scrollToBottom } from '@shared/utils/dom';
@@ -523,9 +524,16 @@ export class TaskGroupList extends LitElement {
       group.index !== undefined && group.total !== undefined
         ? ` (${group.index + 1}/${group.total})`
         : '';
+    const title =
+      group.kind === 'round' && group.index !== undefined
+        ? formatRoundStageLabel({
+            index: group.index,
+            total: group.total,
+          })
+        : `${group.name}${positionText}`;
     return html`
       <span class="group-status-icon"> ${waIcon(statusIcon)} </span>
-      <span class="group-title">${group.name}${positionText}</span>
+      <span class="group-title">${title}</span>
       ${this.renderGroupProgress(group, messages)}
       <span class="group-time">
         <span class="group-start-time" data-start=${String(group.startTime)}>

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -29,7 +29,10 @@ import '@awesome.me/webawesome/dist/components/details/details.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 
 import { isInFlightPhase } from '@shared/streams/streamStatus';
-import { formatRoundStageLabel } from '@shared/streams/streamStatusDisplay';
+import {
+  formatRoundStageLabel,
+  formatStreamStatusLabel,
+} from '@shared/streams/streamStatusDisplay';
 import { parseWorkflowOutputRoundDir } from '@shared/constants/workflowOutput';
 import { ToggleStateStore } from '@shared/state/ToggleStateStore';
 import { scrollToBottom } from '@shared/utils/dom';
@@ -532,7 +535,13 @@ export class TaskGroupList extends LitElement {
           })
         : `${group.name}${positionText}`;
     return html`
-      <span class="group-status-icon"> ${waIcon(statusIcon)} </span>
+      <span class="group-status-icon">
+        ${waIcon(statusIcon, {
+          label: formatStreamStatusLabel(group.status, {
+            style: 'progressHeader',
+          }),
+        })}
+      </span>
       <span class="group-title">${title}</span>
       ${this.renderGroupProgress(group, messages)}
       <span class="group-time">

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/workflowCallFormatter.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/workflowCallFormatter.ts
@@ -3,7 +3,7 @@ import { html, nothing, type TemplateResult } from 'lit';
 
 // Local imports - shared contracts
 import {
-  WORKFLOW_CALL_STATUS_LABEL,
+  WORKFLOW_TASK_STATUS_LABEL,
   WorkflowCallProgressSchema,
   type LogMessageData,
   type WorkflowCallProgress,
@@ -17,12 +17,10 @@ import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { assertNever } from '@utils/core';
 
 function statusIcon(call: WorkflowCallProgress): TemplateResult {
-  if (call.status === 'running') {
-    return html`<wa-spinner aria-label="Running"></wa-spinner>`;
-  }
   const icon: TeXRAIconName = (() => {
     switch (call.status) {
       case 'planned':
+      case 'running':
         return 'circle';
       case 'completed':
       case 'cached':
@@ -74,7 +72,7 @@ export function formatWorkflowCallTemplate(
         }
       </span>
       <span class="workflow-task-status"
-        >${WORKFLOW_CALL_STATUS_LABEL[call.status]}</span
+        >${WORKFLOW_TASK_STATUS_LABEL[call.status]}</span
       >
     </div>
   `;

--- a/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
+++ b/packages/extension/src/progressView/frontend/styles/logEntryStyles.ts
@@ -99,7 +99,7 @@ export const logEntryStyles = css`
     margin-top: 0.1em;
   }
 
-  .workflow-task-icon :is(wa-icon, wa-spinner) {
+  .workflow-task-icon wa-icon {
     font-size: 1em;
   }
 

--- a/src/shared/copy/workflowCall.ts
+++ b/src/shared/copy/workflowCall.ts
@@ -1,6 +1,6 @@
 import {
   isTerminalWorkflowCallProgress,
-  WORKFLOW_CALL_STATUS_LABEL,
+  WORKFLOW_TASK_STATUS_LABEL,
   type WorkflowCallProgress,
 } from '@shared/schemas';
 import { formatCompactDuration, formatCostUsd } from '@utils/text/stringUtils';
@@ -96,5 +96,5 @@ export function formatWorkflowCallLine(call: WorkflowCallProgress): string {
   const suffix = metadata.length > 0 ? ` · ${metadata.join(' · ')}` : '';
   const detail = workflowCallDetail(call);
   const explanation = detail ? ` — ${detail.text}` : '';
-  return `${WORKFLOW_CALL_STATUS_LABEL[call.status]}: ${call.label}${suffix}${explanation}`;
+  return `${WORKFLOW_TASK_STATUS_LABEL[call.status]}: ${call.label}${suffix}${explanation}`;
 }

--- a/src/shared/schemas/workflowCallProgress.ts
+++ b/src/shared/schemas/workflowCallProgress.ts
@@ -87,11 +87,16 @@ export function isTerminalWorkflowCallProgress(
   }
 }
 
-export const WORKFLOW_CALL_STATUS_LABEL = {
+export const WORKFLOW_TASK_STATUS_LABEL = {
   planned: 'Planned',
   running: 'Running',
+  waiting: 'Waiting for follow-up',
   completed: 'Finished',
   cached: 'Saved result',
   skipped: 'Skipped',
+  cancelled: 'Cancelled',
   failed: 'Failed',
-} as const satisfies Record<WorkflowCallProgress['status'], string>;
+} as const satisfies Record<
+  WorkflowCallProgress['status'] | 'waiting' | 'cancelled',
+  string
+>;

--- a/src/test-kernel/cli/SessionStatus.vitest.mts
+++ b/src/test-kernel/cli/SessionStatus.vitest.mts
@@ -288,6 +288,7 @@ describe('CLI session status formatter', () => {
   it('uses the footer label for an idle waiting stream', () => {
     expect(formatCliStatusLabel(STREAM_PHASE.WAITING)).toBe('idle');
     expect(formatCliStatusLabel(undefined, undefined, true)).toBe('');
+    expect(formatCliStatusLabel('stopped', undefined, true)).toBe('Cancelled');
     expect(
       formatCliSessionStatus({
         agent: 'research',

--- a/src/test-kernel/cli/SessionStatus.vitest.mts
+++ b/src/test-kernel/cli/SessionStatus.vitest.mts
@@ -287,6 +287,7 @@ describe('CLI session status formatter', () => {
 
   it('uses the footer label for an idle waiting stream', () => {
     expect(formatCliStatusLabel(STREAM_PHASE.WAITING)).toBe('idle');
+    expect(formatCliStatusLabel(undefined, undefined, true)).toBe('');
     expect(
       formatCliSessionStatus({
         agent: 'research',

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -822,10 +822,24 @@ describe('CLI StatusBar display model', () => {
       }),
     );
     expect(childDisplay.left.map(statusBarSegmentText)).toContain(
-      'waiting for you',
+      'Waiting for follow-up',
     );
     expect(childDisplay.left.map(statusBarSegmentText)).not.toContain('idle');
   });
+
+  it.each([
+    [STREAM_PHASE.FAILED, 'Failed'],
+    [STREAM_PHASE.CANCELLED, 'Cancelled'],
+  ] as const)(
+    'uses the canonical %s label for a focused child',
+    (status, label) => {
+      const display = buildStatusBarDisplay(
+        statusInput({ status, isChildStream: true }),
+      );
+
+      expect(display.left.map(statusBarSegmentText)).toContain(label);
+    },
+  );
 
   it('derives isChildStream for statusBarStreamTarget from whichever stream is actually displayed', () => {
     const root = 'root';

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -579,9 +579,9 @@ describe('CLI child list display model', () => {
 
     expect(sessions.find(({ id }) => id === bash)?.toolName).toBe('bash');
     expect(sessions.find(({ id }) => id === agent)?.toolName).toBeUndefined();
-    expect(output.match(/bash running/g)).toHaveLength(2);
+    expect(output.match(/bash Running/g)).toHaveLength(2);
     expect(output).not.toContain('gemini35f');
-    expect(output).toContain('bash running · gpt56');
+    expect(output).toContain('bash Running · gpt56');
     expect(output).toContain('5 tool calls');
     expect(output).toContain('↓40k');
   });
@@ -615,6 +615,48 @@ describe('CLI child list display model', () => {
     expect(output).toContain('devise completed');
     expect(output).not.toContain('in:2');
     expect(output).not.toContain('ctx:1');
+  });
+
+  it('uses canonical task status labels for child rows', async () => {
+    const { ink, React } = await loadInk();
+    const root = 'root' as StreamTabId;
+    const output = await renderOutputAtTerminalSize(
+      ink,
+      React.createElement(SubagentList, {
+        maxRows: 5,
+        sessions: [
+          {
+            id: 'done' as StreamTabId,
+            label: 'reviewer',
+            parentId: root,
+            slice: workflowAgentSlice('done', {
+              status: STREAM_PHASE.COMPLETED,
+            }),
+          },
+          {
+            id: 'failed' as StreamTabId,
+            label: 'critic',
+            parentId: root,
+            slice: workflowAgentSlice('failed', {
+              status: STREAM_PHASE.FAILED,
+            }),
+          },
+          {
+            id: 'waiting' as StreamTabId,
+            label: 'editor',
+            parentId: root,
+            slice: workflowAgentSlice('waiting', {
+              status: STREAM_PHASE.WAITING,
+            }),
+          },
+        ],
+      }),
+      100,
+    );
+
+    expect(output).toContain('reviewer Finished');
+    expect(output).toContain('critic Failed');
+    expect(output).toContain('editor Waiting for follow-up');
   });
 
   it.each([120, 80, 64, 56])(
@@ -737,23 +779,23 @@ describe('CLI child list display model', () => {
 
     expect(output).toContain('◆ Map');
     expect(output).toContain('◆ Reduce');
-    expect(output).toContain('loose-agent running');
+    expect(output).toContain('loose-agent Running');
     // The phase-less row sits above every header, so no header can be read as
     // owning it.
-    expect(output.indexOf('loose-agent running')).toBeLessThan(
+    expect(output.indexOf('loose-agent Running')).toBeLessThan(
       output.indexOf('◆'),
     );
     // One header per phase, and each group's rows still follow its own header.
     expect(output.split('◆ Map')).toHaveLength(2);
     expect(output.split('◆ Reduce')).toHaveLength(2);
     expect(output.indexOf('◆ Map')).toBeLessThan(
-      output.indexOf('map-agent running'),
+      output.indexOf('map-agent Running'),
     );
-    expect(output.indexOf('map-agent running')).toBeLessThan(
+    expect(output.indexOf('map-agent Running')).toBeLessThan(
       output.indexOf('◆ Reduce'),
     );
     expect(output.indexOf('◆ Reduce')).toBeLessThan(
-      output.indexOf('reduce-agent running'),
+      output.indexOf('reduce-agent Running'),
     );
   });
 
@@ -1039,7 +1081,7 @@ describe('CLI child list display model', () => {
         { until: (frame) => frame.includes('writer') },
       );
 
-      expect(output).toContain('writer running');
+      expect(output).toContain('writer Running');
       expect(output.includes('5 tool calls · ↓40k')).toBe(metadataColumn);
     },
   );

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -649,6 +649,11 @@ describe('CLI child list display model', () => {
               status: STREAM_PHASE.WAITING,
             }),
           },
+          {
+            id: 'attached' as StreamTabId,
+            label: 'attached',
+            parentId: root,
+          },
         ],
       }),
       100,
@@ -657,6 +662,8 @@ describe('CLI child list display model', () => {
     expect(output).toContain('reviewer Finished');
     expect(output).toContain('critic Failed');
     expect(output).toContain('editor Waiting for follow-up');
+    expect(output).toContain('attached');
+    expect(output).not.toContain('attached —');
   });
 
   it.each([120, 80, 64, 56])(

--- a/src/test-kernel/cli/WorkflowRunDetails.vitest.mts
+++ b/src/test-kernel/cli/WorkflowRunDetails.vitest.mts
@@ -89,13 +89,13 @@ describe('workflowRunDetailLines', () => {
     });
 
     expect(lines.map((line) => line.text)).toEqual([
-      '✓ Repository audit completed · 9s',
-      '✓ r0 (1/2) completed · 7s',
+      '✓ Repository audit Finished · 9s',
+      '✓ r1/2 Finished · 7s',
       '  Generated files',
       '    › output/paper.tex (+12 -3)',
-      '  ⚠ r0 · Missing expected output: appendix.tex',
-      '  ✗ r0 · Compile check failed: paper.pdf · paper.log',
-      '□ r1 (2/2) planned',
+      '  ⚠ r1 · Missing expected output: appendix.tex',
+      '  ✗ r1 · Compile check failed: paper.pdf · paper.log',
+      '□ r2/2 Planned',
     ]);
     expect(lines.map((line) => line.tone)).toEqual([
       'success',
@@ -127,8 +127,8 @@ describe('workflowRunDetailLines', () => {
     });
 
     expect(lines.map((line) => line.text)).toEqual([
-      '● r3 running',
-      '  ⚠ r3 · Missing expected output: bad.tex',
+      '● r4 Running',
+      '  ⚠ r4 · Missing expected output: bad.tex',
     ]);
   });
 
@@ -170,7 +170,7 @@ describe('workflowRunDetailLines', () => {
     );
 
     expect(line?.text).toBe(
-      '  ✗ r0 · Compile check failed: paper.pdf · paper.log',
+      '  ✗ r1 · Compile check failed: paper.pdf · paper.log',
     );
     expect(line?.role).toBe('alert');
   });
@@ -197,9 +197,7 @@ describe('workflowRunDetailLines', () => {
       compileFailuresByRound: {},
     });
 
-    expect(lines.map((line) => line.text)).toEqual([
-      '✓ Round 3 completed · 1s',
-    ]);
+    expect(lines.map((line) => line.text)).toEqual(['✓ Round 3 Finished · 1s']);
   });
 
   it('budgets detail rows together with the live transcript viewport', async () => {
@@ -242,11 +240,11 @@ describe('workflowRunDetailLines', () => {
     const rows = output.split('\n');
 
     expect(rows).toHaveLength(4);
-    expect(output).toContain('r0 (1/4) running');
-    expect(output).toContain('r1 (2/4) planned');
-    expect(output).toContain('r2 (3/4) planned');
+    expect(output).toContain('r1/4 Running');
+    expect(output).toContain('r2/4 Planned');
+    expect(output).toContain('r3/4 Planned');
     expect(output).toContain('live workflow log');
-    expect(output).not.toContain('r3 (4/4) planned');
+    expect(output).not.toContain('r4/4 Planned');
   });
 
   it('keeps warning context ahead of generated files and future plans', () => {
@@ -302,9 +300,9 @@ describe('workflowRunDetailLines', () => {
     );
 
     expect(lines.map((line) => line.text)).toEqual([
-      '✓ r0 (1/2) completed · 1s',
-      '  ✗ r0 · Compile check failed: paper.pdf · paper.log',
-      '□ r1 (2/2) planned',
+      '✓ r1/2 Finished · 1s',
+      '  ✗ r1 · Compile check failed: paper.pdf · paper.log',
+      '□ r2/2 Planned',
     ]);
   });
 });

--- a/src/test-kernel/progressView/BackgroundTasksPanel.vitest.mts
+++ b/src/test-kernel/progressView/BackgroundTasksPanel.vitest.mts
@@ -100,7 +100,7 @@ describe('background-tasks-panel', () => {
     const badges = [...shadow.querySelectorAll('wa-badge.task-status')].map(
       (node) => node.textContent,
     );
-    expect(badges).toEqual(['running', 'completed']);
+    expect(badges).toEqual(['Running', 'Finished']);
     expect(shadow.textContent).not.toContain('completed</em>');
     expect(shadow.textContent).not.toMatch(/All \d+ subagents completed/);
 
@@ -176,7 +176,7 @@ describe('background-tasks-panel', () => {
     await element.updateComplete;
 
     const badge = element.shadowRoot?.querySelector('wa-badge.task-status');
-    expect(badge?.textContent).toBe('running');
+    expect(badge?.textContent).toBe('Running');
     expect(badge?.getAttribute('variant')).toBe('warning');
 
     element.remove();

--- a/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
+++ b/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
@@ -381,6 +381,32 @@ describe('task-group-list orphan re-rooting', () => {
 // STOPPED default, and a cancelled group no longer renders identically to a
 // completed one.
 describe('task-group-list status icon (#7993 step 3)', () => {
+  it('formats round group titles with the shared one-based label', async () => {
+    const parent: TaskGroup = {
+      id: 'run',
+      name: 'Run: reflection',
+      startTime: 1,
+      status: STREAM_PHASE.RUNNING,
+    };
+    const round: TaskGroup = {
+      id: 'round-0',
+      name: 'r0',
+      kind: 'round',
+      index: 0,
+      total: 3,
+      startTime: 2,
+      status: STREAM_PHASE.RUNNING,
+      parentGroupId: 'run',
+    };
+
+    const list = await renderList([parent, round], []);
+    const title = list.shadowRoot
+      ?.querySelector(`#${GROUP_DOM_IDS.HEADER_PREFIX}round-0 .group-title`)
+      ?.textContent?.trim();
+
+    expect(title).toBe('r1/3');
+  });
+
   it('renders a distinct icon for completed, cancelled, and failed groups', async () => {
     const parent: TaskGroup = {
       id: 'run',

--- a/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
+++ b/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
@@ -403,8 +403,12 @@ describe('task-group-list status icon (#7993 step 3)', () => {
     const title = list.shadowRoot
       ?.querySelector(`#${GROUP_DOM_IDS.HEADER_PREFIX}round-0 .group-title`)
       ?.textContent?.trim();
+    const statusLabel = list.shadowRoot
+      ?.querySelector(`#${GROUP_DOM_IDS.HEADER_PREFIX}round-0 wa-icon`)
+      ?.getAttribute('label');
 
     expect(title).toBe('r1/3');
+    expect(statusLabel).toBe('Running');
   });
 
   it('renders a distinct icon for completed, cancelled, and failed groups', async () => {

--- a/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
+++ b/src/test-kernel/progressView/TaskGroupListIndex.vitest.ts
@@ -659,11 +659,26 @@ describe('task-group-list workflow-script phase rendering (#8722)', () => {
     expect(header?.querySelector('.group-progress')?.textContent?.trim()).toBe(
       '1/2',
     );
+    expect(header?.querySelector('wa-spinner')).toBeNull();
+    expect(header?.querySelector('wa-icon')?.getAttribute('name')).toBe(
+      'circle',
+    );
     // The enclosing header is the card's one home for its phase.
     const content = list.shadowRoot?.querySelector(
       `#${GROUP_DOM_IDS.CONTENT_PREFIX}phase-map`,
     );
     expect(content?.querySelector('.workflow-task-phase')).toBeNull();
     expect(content?.querySelector('.workflow-task-details')).toBeNull();
+    expect(content?.querySelector('wa-spinner')).toBeNull();
+    expect(
+      content
+        ?.querySelector('[data-log-id="task-b"] wa-icon')
+        ?.getAttribute('name'),
+    ).toBe('circle');
+    expect(
+      content
+        ?.querySelector('[data-log-id="task-b"] .workflow-task-status')
+        ?.textContent?.trim(),
+    ).toBe('Running');
   });
 });


### PR DESCRIPTION
## Summary

- show workflow rounds with the shared one-based `rN/total` notation in the terminal
- use one canonical task-status vocabulary for terminal details, extension rows, task cards, and plain-text projections
- replace animated workflow task and group markers with steady status icons

## Design

Workflow state wording previously leaked into several renderers: some displayed raw stream values while others translated the same state independently. `WORKFLOW_TASK_STATUS_LABEL` now owns that wording, while each host remains responsible only for its presentation. The terminal also delegates round notation to the existing shared formatter instead of maintaining a second numbering rule.

## Validation

- `npm run format`
- `npm run compile:fast`
- `npm run lint`
- `npm run typecheck`
- `npm test` (795 files passed, 1 skipped; 7,919 tests passed, 4 skipped)

Closes #9322

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display and copy alignment only; behavior is covered by extensive CLI and progress-view test updates with no auth, data, or execution-path changes.
> 
> **Overview**
> **Unifies workflow and subagent progress wording** across the CLI, VS Code progress view, and shared plain-text helpers so rounds, task states, and child-session labels read the same everywhere.
> 
> The shared **`WORKFLOW_TASK_STATUS_LABEL`** map (renamed from `WORKFLOW_CALL_STATUS_LABEL`) now drives status text for workflow calls, task groups, background-task badges, and CLI child rows—including **Waiting for follow-up**, **Finished**, **Cancelled**, and **Failed** instead of mixed raw phases or lowercase strings. The CLI routes child streams through **`formatCliStatusLabel`**, maps stopped children to **Cancelled**, and uses the shared **`formatRoundStageLabel`** for workflow run details (`r1/2` one-based) and round-qualified alerts.
> 
> The extension **drops animated `wa-spinner` markers** for in-flight workflow tasks and group headers in favor of steady **`wa-icon`** labels tied to the same status vocabulary; round group titles use the shared round formatter instead of ad hoc `(i/n)` on the group name.
> 
> TUI harness expectations and kernel tests are updated to match the new copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4216967fa516eba34ae09f248a392d55786beb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->