### PR TITLE
feat: summarize workflow deliveries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ All notable changes to this project will be documented in this file.
   non-interactive runs now print phase, task, and completion progress; workflow
   task cards open their child runs directly without a duplicate background-task
   panel.
+- **Concise workflow results** — completed workflow scripts now render one
+  shared summary of phases, tasks, generated files, cost, duration, and rerun
+  instructions instead of repeating the full run log.
 
 ## [0.39.9] - 2026-07-26
 

--- a/packages/extension/src/progressView/frontend/components/UserMessage.ts
+++ b/packages/extension/src/progressView/frontend/components/UserMessage.ts
@@ -13,10 +13,14 @@ import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 // Side-effect imports - register WA icon component
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
+import '@awesome.me/webawesome/dist/components/details/details.js';
 
 // Local imports - shared styles
 import { compactIconActionButtonStyles } from '@shared/styles';
-import { decodeXmlEntities } from '@shared/subagentFollowup';
+import {
+  decodeXmlEntities,
+  workflowScriptDeliverySummary,
+} from '@shared/subagentFollowup';
 import { DELIVERY_TAGS, type DeliveryTagName } from '@shared/deliveryTags';
 import { CopyButtonController } from '@shared/litControllers/CopyButtonController';
 import { designTokens } from '@shared/styles/litStyles';
@@ -136,6 +140,19 @@ export class UserMessage extends LitElement {
         white-space: normal;
       }
 
+      .workflow-delivery-raw {
+        margin-top: var(--wa-space-xs);
+        font-size: var(--font-size-xs);
+      }
+
+      .workflow-delivery-raw pre {
+        max-height: min(34vh, 360px);
+        margin: var(--wa-space-xs) 0 0;
+        overflow: auto;
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+
       .user-message-timestamp {
         font-size: var(--font-size-xs);
       }
@@ -185,6 +202,7 @@ export class UserMessage extends LitElement {
     isStructuredDelivery: false,
     hasRawMessage: false,
     displayText: '',
+    workflowSummary: '',
     structuredMarkdownHtml: '',
   };
 
@@ -192,6 +210,7 @@ export class UserMessage extends LitElement {
     isStructuredDelivery: boolean;
     hasRawMessage: boolean;
     displayText: string;
+    workflowSummary: string;
     structuredMarkdownHtml: string;
   } {
     if (this.displayCache.text === this.text) {
@@ -204,16 +223,22 @@ export class UserMessage extends LitElement {
     const displayText = hasRawMessage
       ? decodeXmlEntities(this.text)
       : this.text;
+    // Parse presentation metadata before decoding the escaped response body:
+    // model text containing a literal <workflow-summary> must not shadow the
+    // envelope-owned summary element.
+    const workflowSummary = workflowScriptDeliverySummary(this.text) ?? '';
+    const structuredDisplayText = workflowSummary || displayText;
 
     this.displayCache = {
       text: this.text,
       isStructuredDelivery,
       hasRawMessage,
       displayText,
+      workflowSummary,
       // Cached alongside displayText: message text is immutable after
       // creation, so the Markdown parse must not rerun on every render.
       structuredMarkdownHtml: isStructuredDelivery
-        ? processMarkdownContent(displayText)
+        ? processMarkdownContent(structuredDisplayText)
         : '',
     };
     return this.displayCache;
@@ -232,6 +257,7 @@ export class UserMessage extends LitElement {
       isStructuredDelivery,
       hasRawMessage,
       displayText,
+      workflowSummary,
       structuredMarkdownHtml,
     } = this.getDisplayState();
 
@@ -282,6 +308,16 @@ export class UserMessage extends LitElement {
                   data-log-id=${this.logId}
                 >
                   ${unsafeHTML(structuredMarkdownHtml)}
+                  ${
+                    workflowSummary
+                      ? html`<wa-details
+                          class="workflow-delivery-raw"
+                          summary="Raw result"
+                        >
+                          <pre>${displayText}</pre>
+                        </wa-details>`
+                      : nothing
+                  }
                 </div>`
               : html`<div
                   class="user-message-content"

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
@@ -339,7 +339,7 @@ function buildDelegationSections(ctx: ToolSectionContext): TemplateResult[] {
 function buildWorkflowScriptSections(
   ctx: ToolSectionContext,
 ): TemplateResult[] {
-  const { input, parsedOutput } = ctx;
+  const { input } = ctx;
   if (!isObject(input)) {
     return [
       buildToolUseSection(
@@ -378,18 +378,6 @@ function buildWorkflowScriptSections(
     ? buildFileGroupsSection(getProposalFileGroups(files.data))
     : undefined;
   if (filesSection !== undefined) sections.push(filesSection);
-
-  const rawResult = isObject(parsedOutput) ? parsedOutput.output : parsedOutput;
-  const { text: resultText, language: resultLanguage } =
-    stringifyWithLanguage(rawResult);
-  if (resultText) {
-    sections.push(
-      buildToolSection('Result:', resultText, {
-        language: resultLanguage,
-        extraClass: 'tool-output-full',
-      }),
-    );
-  }
 
   return sections;
 }

--- a/src/shared/schemas/index.ts
+++ b/src/shared/schemas/index.ts
@@ -21,6 +21,7 @@ export * from './roundIndexed';
 export * from './output';
 export * from './progressEvents';
 export * from './workflowCallProgress';
+export * from './workflowScriptDelivery';
 
 // Layer 3: Depends on layer 2
 export * from './log';

--- a/src/shared/schemas/workflowScriptDelivery.ts
+++ b/src/shared/schemas/workflowScriptDelivery.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+const WorkflowScriptDeliveryFileSchema = z.strictObject({
+  path: z.string(),
+  added: z.int().nonnegative().nullable(),
+  removed: z.int().nonnegative().nullable(),
+});
+
+/** Compact, host-neutral facts used to present a workflow-script delivery. */
+export const WorkflowScriptDeliverySummarySchema = z.strictObject({
+  name: z.string(),
+  outcome: z.enum(['completed', 'failed']),
+  phaseCount: z.int().nonnegative(),
+  taskDone: z.int().nonnegative(),
+  taskTotal: z.int().nonnegative(),
+  costUsd: z.number().nonnegative(),
+  durationMs: z.int().nonnegative(),
+  files: z.array(WorkflowScriptDeliveryFileSchema),
+  scriptPath: z.string(),
+});
+
+export type WorkflowScriptDeliverySummary = z.infer<
+  typeof WorkflowScriptDeliverySummarySchema
+>;

--- a/src/shared/subagentFollowup.ts
+++ b/src/shared/subagentFollowup.ts
@@ -19,7 +19,12 @@
 import escapeRegExp from 'escape-string-regexp';
 import { safeParseJson } from '@common/parsing/safeParseJson';
 import { DELIVERY_TAG, DELIVERY_TAGS } from '@shared/deliveryTags';
-import { formatResultCount } from '@utils/text/stringUtils';
+import { WorkflowScriptDeliverySummarySchema } from '@shared/schemas';
+import {
+  formatCompactDuration,
+  formatCostUsd,
+  formatResultCount,
+} from '@utils/text/stringUtils';
 
 // Derived from the single owned DELIVERY_TAGS list (@shared/deliveryTags),
 // same derivation pattern UserMessage.ts uses for its structured-delivery
@@ -191,6 +196,44 @@ function resultResponsePreview(response: string): string {
 }
 
 /**
+ * Read the presentation-only facts attached to a workflow delivery. The raw
+ * response remains intact for the invoking model and diagnostic inspection.
+ */
+export function workflowScriptDeliverySummary(xml: string): string | undefined {
+  const rawSummary = innerTag(xml, 'workflow-summary');
+  if (!rawSummary) return undefined;
+  const parsedJson = safeParseJson(decodeXmlEntities(rawSummary));
+  if (parsedJson.isErr()) return undefined;
+  const parsed = WorkflowScriptDeliverySummarySchema.safeParse(
+    parsedJson.value,
+  );
+  if (!parsed.success) return undefined;
+
+  const summary = parsed.data;
+  const marker = summary.outcome === 'completed' ? '✓' : '✗';
+  const status = summary.outcome === 'completed' ? 'completed' : 'failed';
+  const facts = [
+    `${formatResultCount(summary.phaseCount, 'phase')}`,
+    `${summary.taskDone}/${summary.taskTotal} tasks`,
+    formatCostUsd(summary.costUsd),
+    formatCompactDuration(summary.durationMs),
+  ];
+  const fileLines = summary.files.map((file) => {
+    const diffstat =
+      file.added != null && file.removed != null
+        ? ` (+${file.added} -${file.removed})`
+        : '';
+    return `  ${file.path}${diffstat}`;
+  });
+  return [
+    `${marker} ${summary.name} ${status} · ${facts.join(' · ')}`,
+    ...fileLines,
+    `  script: ${summary.scriptPath}`,
+    `  rerun: edit the script, then call delegate_workflow_script with scriptPath`,
+  ].join('\n');
+}
+
+/**
  * Collapse a subagent follow-up XML block into a one-line (or, for results,
  * status + response) human-readable summary. Returns `text` unchanged when it
  * is not a subagent block. Malformed non-string payloads render as a visible
@@ -215,6 +258,10 @@ export function summarizeSubagentFollowup(text: unknown): string {
   // don't set an `agent` attribute, so fall back to the tag's own family name
   // (e.g. `codex-result` → `codex`) rather than the generic `subagent`.
   if (tag.endsWith('-result')) {
+    if (tag === DELIVERY_TAG.workflowScriptResult) {
+      const summary = workflowScriptDeliverySummary(trimmed);
+      if (summary) return summary;
+    }
     const agent = attr(trimmed, 'agent') ?? tag.slice(0, -'-result'.length);
     const status = attr(trimmed, 'status') ?? 'completed';
     const wall = innerTag(trimmed, 'wall-time');
@@ -225,6 +272,10 @@ export function summarizeSubagentFollowup(text: unknown): string {
   }
 
   if (tag.endsWith('-error')) {
+    if (tag === DELIVERY_TAG.workflowScriptError) {
+      const summary = workflowScriptDeliverySummary(trimmed);
+      if (summary) return summary;
+    }
     const agent = attr(trimmed, 'agent') ?? tag.slice(0, -'-error'.length);
     const wall = innerTag(trimmed, 'wall-time');
     const message = innerTag(trimmed, 'message');

--- a/src/test-kernel/cli/SubagentFollowup.vitest.mts
+++ b/src/test-kernel/cli/SubagentFollowup.vitest.mts
@@ -231,6 +231,41 @@ describe('summarizeSubagentFollowup', () => {
     );
   });
 
+  it('renders the typed workflow summary instead of its raw run-log tail', () => {
+    const summary = JSON.stringify({
+      name: 'proofread-pipeline',
+      outcome: 'completed',
+      phaseCount: 2,
+      taskDone: 4,
+      taskTotal: 4,
+      costUsd: 0.19,
+      durationMs: 724_000,
+      files: [
+        { path: 'paper_A.tex', added: 120, removed: 80 },
+        { path: 'notes.txt', added: null, removed: null },
+      ],
+      scriptPath: '.texra/workflow-scripts/proofread-pipeline.mjs',
+    }).replaceAll('"', '&quot;');
+    const xml = [
+      '<workflow-script-result id="abc">',
+      '<response>result',
+      '=== Run log ===',
+      'many duplicate lines</response>',
+      `<workflow-summary>${summary}</workflow-summary>`,
+      '</workflow-script-result>',
+    ].join('\n');
+
+    expect(summarizeSubagentFollowup(xml)).toBe(
+      [
+        '✓ proofread-pipeline completed · 2 phases · 4/4 tasks · $0.190 · 12m 4s',
+        '  paper_A.tex (+120 -80)',
+        '  notes.txt',
+        '  script: .texra/workflow-scripts/proofread-pipeline.mjs',
+        '  rerun: edit the script, then call delegate_workflow_script with scriptPath',
+      ].join('\n'),
+    );
+  });
+
   it('decodes only XML entities in a single pass', () => {
     expect(decodeXmlEntities('&quot;&apos;&lt;&gt;&amp;')).toBe('"\'<>&');
     expect(decodeXmlEntities('&amp;lt;')).toBe('&lt;');

--- a/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
+++ b/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
@@ -97,7 +97,7 @@ return { papers, question: args.question };`;
 
     expect(details?.open).toBe(true);
     expect(container.querySelector('wa-icon[name="list-ul"]')).not.toBeNull();
-    expect(labels).toEqual(['Agent:', 'Script:', 'Args:', 'Files:', 'Result:']);
+    expect(labels).toEqual(['Agent:', 'Script:', 'Args:', 'Files:']);
     expect(container.textContent).toContain('research');
     expect(scriptBlock?.querySelector('code')?.textContent).toBe(script);
     expect(scriptBlock?.textContent).toContain('JavaScript');
@@ -110,7 +110,7 @@ return { papers, question: args.question };`;
     expect(container.textContent).toContain('(Input)');
     expect(container.textContent).toContain('(Context)');
     expect(container.textContent).toContain('(Media)');
-    expect(container.textContent).toContain('"compared":2');
+    expect(container.textContent).not.toContain('"compared":2');
     expect(container.textContent).not.toContain('journal');
     expect(container.querySelector('.proposal-banner-setup')).toBeNull();
   });

--- a/src/test-kernel/progressView/UserMessageStructuredDelivery.vitest.mts
+++ b/src/test-kernel/progressView/UserMessageStructuredDelivery.vitest.mts
@@ -53,6 +53,38 @@ describe('user-message structured delivery', () => {
     });
   }
 
+  it('shows a workflow summary with the raw envelope collapsed', async () => {
+    const summary = JSON.stringify({
+      name: 'proofread-pipeline',
+      outcome: 'completed',
+      phaseCount: 2,
+      taskDone: 4,
+      taskTotal: 4,
+      costUsd: 0.19,
+      durationMs: 724_000,
+      files: [{ path: 'paper.tex', added: 12, removed: 8 }],
+      scriptPath: '.texra/workflow-scripts/proofread-pipeline.mjs',
+    }).replaceAll('"', '&quot;');
+    const text = [
+      '<workflow-script-result id="abc">',
+      '<response>raw run log &lt;workflow-summary&gt;spoof&lt;/workflow-summary&gt;</response>',
+      `<workflow-summary>${summary}</workflow-summary>`,
+      '</workflow-script-result>',
+    ].join('\n');
+
+    const element = await mount(text);
+    const content = element.shadowRoot?.querySelector('.user-message-content');
+    const raw = element.shadowRoot?.querySelector(
+      'wa-details.workflow-delivery-raw',
+    );
+
+    expect(content?.textContent).toContain('proofread-pipeline completed');
+    expect(content?.textContent).toContain('paper.tex (+12 -8)');
+    expect(raw?.getAttribute('summary')).toBe('Raw result');
+    expect(raw?.querySelector('pre')?.textContent).toContain('raw run log');
+    expect(content?.querySelector('p')?.textContent).not.toContain('spoof');
+  });
+
   it('renders plain (non-delivery) text as an unstructured message', async () => {
     const element = await mount('hello world');
 

--- a/src/test-kernel/tools/WorkflowScriptStrategy.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptStrategy.vitest.ts
@@ -29,7 +29,17 @@ return await agent('saved call')`;
 const finalResult: AgentFinalResult = {
   category: 'workflow',
   outcome: 'completed',
-  outputs: [],
+  outputs: [
+    {
+      round: 0,
+      relativePath: 'paper.tex',
+      absolutePath: '/workspace/paper.tex',
+      location: 'workspace',
+      originalPath: '/workspace/paper.tex',
+      added: 12,
+      removed: 8,
+    },
+  ],
   compileFailures: [],
   diffs: [],
   cost: 0.42,
@@ -132,6 +142,13 @@ describe('createWorkflowScriptStrategy', () => {
       'Script file: .texra/workflow-scripts/draft-strategy.mjs',
     );
     expect(delivery).toContain('with scriptPath:');
+    expect(delivery).toContain('<workflow-summary>');
+    expect(delivery).toContain('"outcome":"completed"');
+    expect(delivery).toContain('"taskDone":1');
+    expect(delivery).toContain('"costUsd":0.42');
+    expect(delivery).toContain(
+      '"files":[{"path":"paper.tex","added":12,"removed":8}]',
+    );
   });
 
   it('settles zero for a pure checkpoint replay', async () => {
@@ -279,6 +296,7 @@ throw new Error('script failed after replay')`;
       'Script file: .texra/workflow-scripts/draft-strategy.mjs',
     );
     expect(errText).toContain('with scriptPath:');
+    expect(errText).toContain('"outcome":"failed"');
   });
 
   it('retains live spend when the completed journal result is malformed', async () => {

--- a/src/tools/delegation/workflowScriptDeliverySummary.ts
+++ b/src/tools/delegation/workflowScriptDeliverySummary.ts
@@ -1,0 +1,112 @@
+// Local imports - agent runtime
+import type {
+  WorkflowJournalEntry,
+  WorkflowScriptEvent,
+  WorkflowScriptRunResult,
+} from '@agent/workflowScript';
+import { AgentFinalResultSchema } from '@agent/runtime/AgentFinalResult';
+
+// Local imports - shared delivery schema
+import type { WorkflowScriptDeliverySummary } from '@shared/schemas';
+import { escapeText } from '@shared/utils/xmlEscape';
+
+type WorkflowTaskOutcome = Extract<
+  WorkflowScriptEvent,
+  { type: 'agent:end' }
+>['outcome'];
+
+export interface WorkflowDeliverySummaryCollector {
+  readonly start: () => void;
+  readonly onEvent: (event: WorkflowScriptEvent) => void;
+  readonly settle: (
+    run: Pick<WorkflowScriptRunResult, 'meta' | 'journal'> | undefined,
+    costUsd: number,
+  ) => void;
+  readonly formatLine: (outcome: 'completed' | 'failed') => string;
+}
+
+/** Collect presentation facts without changing the model-facing run report. */
+export function createWorkflowDeliverySummaryCollector(
+  name: string,
+  scriptPath: string,
+): WorkflowDeliverySummaryCollector {
+  const phases = new Set<string>();
+  const tasks = new Map<string, WorkflowTaskOutcome | 'planned' | 'running'>();
+  const files = new Map<
+    string,
+    WorkflowScriptDeliverySummary['files'][number]
+  >();
+  let startedAt = Date.now();
+  let declaredPhaseCount = 0;
+  let declaredTaskCount = 0;
+  let settledCostUsd = 0;
+
+  const collectJournalFiles = (journal: readonly WorkflowJournalEntry[]) => {
+    for (const entry of journal) {
+      const parsed = AgentFinalResultSchema.safeParse(entry.result);
+      if (!parsed.success) continue;
+      if (parsed.data.category === 'workflow') {
+        for (const output of parsed.data.outputs) {
+          files.set(output.relativePath, {
+            path: output.relativePath,
+            added: output.added,
+            removed: output.removed,
+          });
+        }
+      } else {
+        for (const path of parsed.data.files) {
+          files.set(path, { path, added: null, removed: null });
+        }
+      }
+    }
+  };
+
+  return {
+    start: () => {
+      startedAt = Date.now();
+    },
+    onEvent: (event) => {
+      switch (event.type) {
+        case 'plan':
+          declaredTaskCount = event.tasks.length;
+          for (const task of event.tasks) tasks.set(task.id, 'planned');
+          break;
+        case 'phase':
+          phases.add(event.title);
+          break;
+        case 'agent:start':
+          tasks.set(event.progressId, 'running');
+          break;
+        case 'agent:end':
+          tasks.set(event.progressId, event.outcome);
+          break;
+        case 'agent:stream':
+        case 'log':
+          break;
+      }
+    },
+    settle: (run, costUsd) => {
+      settledCostUsd = costUsd;
+      if (!run) return;
+      declaredPhaseCount = run.meta.phases?.length ?? phases.size;
+      declaredTaskCount = run.meta.tasks?.length ?? tasks.size;
+      collectJournalFiles(run.journal);
+    },
+    formatLine: (outcome) => {
+      const summary: WorkflowScriptDeliverySummary = {
+        name,
+        outcome,
+        phaseCount: Math.max(declaredPhaseCount, phases.size),
+        taskDone: [...tasks.values()].filter(
+          (status) => status === 'completed' || status === 'cached',
+        ).length,
+        taskTotal: Math.max(declaredTaskCount, tasks.size),
+        costUsd: settledCostUsd,
+        durationMs: Date.now() - startedAt,
+        files: [...files.values()],
+        scriptPath,
+      };
+      return `<workflow-summary>${escapeText(JSON.stringify(summary))}</workflow-summary>`;
+    },
+  };
+}

--- a/src/tools/delegation/workflowScriptRun.ts
+++ b/src/tools/delegation/workflowScriptRun.ts
@@ -30,6 +30,8 @@ type WorkflowScriptRunWithProgressOptions = Omit<
    * to the invoking model, which otherwise cannot see any of it.
    */
   readonly onActivity?: (line: string) => void;
+  /** Observe the engine events from which this projection is derived. */
+  readonly onEvent?: (event: WorkflowScriptEvent) => void;
 };
 
 interface PhaseStage {
@@ -154,7 +156,7 @@ export async function runPersistedWorkflowScriptWithProgress(
   trace: AgentTrace,
   options: WorkflowScriptRunWithProgressOptions,
 ): Promise<WorkflowScriptRunResult> {
-  const { getCallCostUsd, onActivity, ...runOptions } = options;
+  const { getCallCostUsd, onActivity, onEvent, ...runOptions } = options;
   const parentStageId = trace.activeStageId();
   const phases = new Map<string, PhaseStage>();
   const phaseStageIds = new Map<string, string>();
@@ -286,6 +288,7 @@ export async function runPersistedWorkflowScriptWithProgress(
 
   const project = (event: WorkflowScriptEvent): void => {
     if (closed) return;
+    onEvent?.(event);
     switch (event.type) {
       case 'plan':
         for (const task of event.tasks) {

--- a/src/tools/delegation/workflowScriptStrategy.ts
+++ b/src/tools/delegation/workflowScriptStrategy.ts
@@ -12,7 +12,10 @@
  */
 
 // Local imports
-import { readWorkflowScriptCheckpoint } from '@agent/workflowScript';
+import {
+  parseWorkflowScript,
+  readWorkflowScriptCheckpoint,
+} from '@agent/workflowScript';
 import type {
   WorkflowAgentInvocation,
   WorkflowAgentRunner,
@@ -42,6 +45,7 @@ import {
   runPersistedWorkflowScriptWithProgress,
 } from './workflowScriptRun';
 import { fingerprintWorkflowAgentDependencies } from './workflowScriptAgentRunner';
+import { createWorkflowDeliverySummaryCollector } from './workflowScriptDeliverySummary';
 
 const RUN_LOG_MAX_LINES = 80;
 const RUN_LOG_MAX_LINE_LENGTH = 500;
@@ -140,12 +144,17 @@ export function createWorkflowScriptStrategy(
   params: WorkflowScriptStrategyParams,
 ): ChildRunStrategy<WorkflowScriptRunResult> {
   const runLog = createRunLogCollector();
+  const summary = createWorkflowDeliverySummaryCollector(
+    params.name,
+    params.scriptPath,
+  );
 
   return {
     stageLabel: `Workflow script '${params.name}'`,
     ...(params.deliveryMode && { deliveryMode: params.deliveryMode }),
 
     launch: async (ports, abortController) => {
+      summary.start();
       // Physical-attempt callbacks are the current-invocation boundary: replay
       // and stable recovery emit none, while every model attempt emits one.
       const attemptCost = createWorkflowAttemptCostTracker();
@@ -189,6 +198,7 @@ export function createWorkflowScriptStrategy(
             fingerprintWorkflowAgentDependencies(params.executionId, options),
           getCallCostUsd: (index) => callCostsByIndex.get(index),
           onActivity: runLog.add,
+          onEvent: summary.onEvent,
           onControl: (control) => {
             // Translate an execution-id-keyed host request into an
             // index-keyed engine action; unknown/settled children no-op,
@@ -218,7 +228,17 @@ export function createWorkflowScriptStrategy(
             params.store,
             params.checkpointId,
           );
-          ports.recordCost(attemptCost.total(checkpoint?.journal ?? []));
+          const costUsd = attemptCost.total(checkpoint?.journal ?? []);
+          ports.recordCost(costUsd);
+          summary.settle(
+            checkpoint
+              ? {
+                  meta: parseWorkflowScript(checkpoint.script).meta,
+                  journal: checkpoint.journal,
+                }
+              : undefined,
+            costUsd,
+          );
         } catch {
           // Cost settlement is best-effort on the failure path.
         }
@@ -232,7 +252,9 @@ export function createWorkflowScriptStrategy(
 
       // The final journal supplies only this invocation's missing/lower
       // completed-call fallback; baseline history contributes zero.
-      ports.recordCost(attemptCost.total(run.journal));
+      const costUsd = attemptCost.total(run.journal);
+      ports.recordCost(costUsd);
+      summary.settle(run, costUsd);
       return run;
     },
 
@@ -249,6 +271,7 @@ export function createWorkflowScriptStrategy(
         },
         {
           response: `${formatWorkflowResult(turn.result)}${runLog.format()}\n\n${formatWorkflowScriptReference(params.scriptPath)}`,
+          lines: [summary.formatLine('completed')],
         },
       ),
 
@@ -260,6 +283,7 @@ export function createWorkflowScriptStrategy(
         },
         {
           message: `${toErrorMessage(err)}${runLog.format()}\n\n${formatWorkflowScriptReference(params.scriptPath)}\n\nCompleted agent() calls are journaled under meta.name '${params.name}'; rerunning that file resumes without repeating them.`,
+          lines: [summary.formatLine('failed')],
         },
       ),
   };


### PR DESCRIPTION
## Summary

- attach a typed presentation summary to workflow-script completion and failure deliveries while preserving the complete model-facing result and run-log tail
- render the same concise phase, task, file, cost, duration, script, and rerun summary in terminal and progress surfaces
- keep the raw delivery available behind disclosure/copy controls and remove the duplicate workflow tool-card result section

## Design

The former renderers had to display an opaque delivery envelope, so the same run log appeared in the child stream, parent message, and tool card. A host-neutral summary schema and collector now hide that reconstruction behind one delivery contract. Both renderers consume the same formatter, while the raw response remains the source of truth for the invoking model and diagnostics.

## Validation

- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run compile:fast`
- focused Vitest coverage: 80 passed
- full Vitest suite: 7,931 passed, 4 skipped; the two load-sensitive `RunChatSignalOwnership` tests timed out under full-suite load and passed 2/2 together in isolation

Closes #9323

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-layer changes with schema-validated metadata; model-facing delivery bodies and billing settlement paths stay intact, with focused test coverage.
> 
> **Overview**
> Completed **workflow-script** deliveries now carry a typed `<workflow-summary>` JSON envelope alongside the unchanged full `<response>` and run log, so humans see one compact outcome instead of duplicating the entire trace.
> 
> A **collector** hooks workflow engine events and journal settlement to build phases, task counts, file diffstats, cost, duration, and script/rerun hints; **CLI** `summarizeSubagentFollowup` and the **VS Code** structured user message both render that same formatted summary. The progress view shows the summary in markdown and tucks the raw envelope under a **Raw result** disclosure; the workflow-script tool card no longer repeats the tool **Result** section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f2a3bb78e9125456b5195653614851120ff19a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->