### PR TITLE
fix: preserve workflow summary actions

### DIFF
--- a/packages/extension/src/progressView/frontend/components/UserMessage.ts
+++ b/packages/extension/src/progressView/frontend/components/UserMessage.ts
@@ -285,7 +285,8 @@ export class UserMessage extends LitElement {
               label: copyState.ariaLabel,
               tooltip: copyState.title,
               className: `user-message-copy ${copyState.copied ? copyState.successClass : ''}`,
-              onClick: () => this.copyController.copy(displayText),
+              onClick: () =>
+                this.copyController.copy(workflowSummary || displayText),
             })}
             ${
               hasRawMessage

--- a/src/shared/schemas/workflowScriptDelivery.ts
+++ b/src/shared/schemas/workflowScriptDelivery.ts
@@ -17,6 +17,8 @@ export const WorkflowScriptDeliverySummarySchema = z.strictObject({
   durationMs: z.int().nonnegative(),
   files: z.array(WorkflowScriptDeliveryFileSchema),
   scriptPath: z.string(),
+  // Older persisted deliveries predate structured failure causes.
+  errorCause: z.string().nullable().prefault(null),
 });
 
 export type WorkflowScriptDeliverySummary = z.infer<

--- a/src/shared/subagentFollowup.ts
+++ b/src/shared/subagentFollowup.ts
@@ -175,7 +175,11 @@ function progressDetail(xml: string): string {
 }
 
 function resultResponsePreview(response: string): string {
-  const decoded = decodeXmlEntities(response).trim();
+  return decodedResultResponsePreview(decodeXmlEntities(response));
+}
+
+function decodedResultResponsePreview(response: string): string {
+  const decoded = response.trim();
   if (decoded === '') return '';
 
   const lines = decoded.split('\n');
@@ -227,23 +231,13 @@ export function workflowScriptDeliverySummary(xml: string): string | undefined {
   });
   return [
     `${marker} ${summary.name} ${status} · ${facts.join(' · ')}`,
+    ...(summary.outcome === 'failed' && summary.errorCause
+      ? [decodedResultResponsePreview(summary.errorCause)]
+      : []),
     ...fileLines,
     `  script: ${summary.scriptPath}`,
     `  rerun: edit the script, then call delegate_workflow_script with scriptPath`,
   ].join('\n');
-}
-
-/** Retain the cause while excluding the duplicated run log and rerun footer. */
-function workflowScriptErrorCause(xml: string): string | undefined {
-  const message = innerTag(xml, 'message');
-  if (!message) return undefined;
-  let cause = decodeXmlEntities(message);
-  for (const marker of ['\n\n=== Run log', '\n\nScript file:']) {
-    const markerIndex = cause.indexOf(marker);
-    if (markerIndex >= 0) cause = cause.slice(0, markerIndex);
-  }
-  const trimmed = cause.trim();
-  return trimmed ? resultResponsePreview(trimmed) : undefined;
 }
 
 /**
@@ -287,10 +281,7 @@ export function summarizeSubagentFollowup(text: unknown): string {
   if (tag.endsWith('-error')) {
     if (tag === DELIVERY_TAG.workflowScriptError) {
       const summary = workflowScriptDeliverySummary(trimmed);
-      if (summary) {
-        const cause = workflowScriptErrorCause(trimmed);
-        return cause ? `${summary}\n${cause}` : summary;
-      }
+      if (summary) return summary;
     }
     const agent = attr(trimmed, 'agent') ?? tag.slice(0, -'-error'.length);
     const wall = innerTag(trimmed, 'wall-time');

--- a/src/shared/subagentFollowup.ts
+++ b/src/shared/subagentFollowup.ts
@@ -233,6 +233,19 @@ export function workflowScriptDeliverySummary(xml: string): string | undefined {
   ].join('\n');
 }
 
+/** Retain the cause while excluding the duplicated run log and rerun footer. */
+function workflowScriptErrorCause(xml: string): string | undefined {
+  const message = innerTag(xml, 'message');
+  if (!message) return undefined;
+  let cause = decodeXmlEntities(message);
+  for (const marker of ['\n\n=== Run log', '\n\nScript file:']) {
+    const markerIndex = cause.indexOf(marker);
+    if (markerIndex >= 0) cause = cause.slice(0, markerIndex);
+  }
+  const trimmed = cause.trim();
+  return trimmed ? resultResponsePreview(trimmed) : undefined;
+}
+
 /**
  * Collapse a subagent follow-up XML block into a one-line (or, for results,
  * status + response) human-readable summary. Returns `text` unchanged when it
@@ -274,7 +287,10 @@ export function summarizeSubagentFollowup(text: unknown): string {
   if (tag.endsWith('-error')) {
     if (tag === DELIVERY_TAG.workflowScriptError) {
       const summary = workflowScriptDeliverySummary(trimmed);
-      if (summary) return summary;
+      if (summary) {
+        const cause = workflowScriptErrorCause(trimmed);
+        return cause ? `${summary}\n${cause}` : summary;
+      }
     }
     const agent = attr(trimmed, 'agent') ?? tag.slice(0, -'-error'.length);
     const wall = innerTag(trimmed, 'wall-time');

--- a/src/test-kernel/cli/SubagentFollowup.vitest.mts
+++ b/src/test-kernel/cli/SubagentFollowup.vitest.mts
@@ -266,6 +266,37 @@ describe('summarizeSubagentFollowup', () => {
     );
   });
 
+  it('keeps the workflow failure cause but omits its duplicate run log', () => {
+    const summary = JSON.stringify({
+      name: 'proofread-pipeline',
+      outcome: 'failed',
+      phaseCount: 2,
+      taskDone: 1,
+      taskTotal: 4,
+      costUsd: 0.03,
+      durationMs: 5_000,
+      files: [],
+      scriptPath: '.texra/workflow-scripts/proofread-pipeline.mjs',
+    }).replaceAll('"', '&quot;');
+    const xml = [
+      '<workflow-script-error id="abc">',
+      `<workflow-summary>${summary}</workflow-summary>`,
+      '<message>Model request failed: quota exhausted',
+      '',
+      '=== Run log ===',
+      'Finished: earlier task',
+      '',
+      'Script file: .texra/workflow-scripts/proofread-pipeline.mjs</message>',
+      '</workflow-script-error>',
+    ].join('\n');
+
+    const rendered = summarizeSubagentFollowup(xml);
+    expect(rendered).toContain('✗ proofread-pipeline failed');
+    expect(rendered).toContain('Model request failed: quota exhausted');
+    expect(rendered).not.toContain('=== Run log ===');
+    expect(rendered).not.toContain('Finished: earlier task');
+  });
+
   it('decodes only XML entities in a single pass', () => {
     expect(decodeXmlEntities('&quot;&apos;&lt;&gt;&amp;')).toBe('"\'<>&');
     expect(decodeXmlEntities('&amp;lt;')).toBe('&lt;');

--- a/src/test-kernel/cli/SubagentFollowup.vitest.mts
+++ b/src/test-kernel/cli/SubagentFollowup.vitest.mts
@@ -277,6 +277,7 @@ describe('summarizeSubagentFollowup', () => {
       durationMs: 5_000,
       files: [],
       scriptPath: '.texra/workflow-scripts/proofread-pipeline.mjs',
+      errorCause: 'Model request failed: quota exhausted',
     }).replaceAll('"', '&quot;');
     const xml = [
       '<workflow-script-error id="abc">',
@@ -295,6 +296,37 @@ describe('summarizeSubagentFollowup', () => {
     expect(rendered).toContain('Model request failed: quota exhausted');
     expect(rendered).not.toContain('=== Run log ===');
     expect(rendered).not.toContain('Finished: earlier task');
+  });
+
+  it('preserves structured failure text without parsing generated suffixes', () => {
+    const summary = JSON.stringify({
+      name: 'proofread-pipeline',
+      outcome: 'failed',
+      phaseCount: 0,
+      taskDone: 0,
+      taskTotal: 0,
+      costUsd: 0,
+      durationMs: 100,
+      files: [],
+      scriptPath: '.texra/workflow-scripts/proofread-pipeline.mjs',
+      errorCause:
+        'Literal &amp;lt;tag&amp;gt;\n\n=== Run log belongs to the error\nScript file: user note',
+    }).replaceAll('"', '&quot;');
+    const xml = [
+      '<workflow-script-error id="abc">',
+      `<workflow-summary>${summary}</workflow-summary>`,
+      '<message>=== Run log ===',
+      'generated entry',
+      '',
+      'Script file: .texra/workflow-scripts/proofread-pipeline.mjs</message>',
+      '</workflow-script-error>',
+    ].join('\n');
+
+    const rendered = summarizeSubagentFollowup(xml);
+    expect(rendered).toContain('Literal &lt;tag&gt;');
+    expect(rendered).toContain('=== Run log belongs to the error');
+    expect(rendered).toContain('Script file: user note');
+    expect(rendered).not.toContain('generated entry');
   });
 
   it('decodes only XML entities in a single pass', () => {

--- a/src/test-kernel/progressView/UserMessageStructuredDelivery.vitest.mts
+++ b/src/test-kernel/progressView/UserMessageStructuredDelivery.vitest.mts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import type { UserMessage } from '@progressView/frontend/components/UserMessage';
@@ -83,6 +83,18 @@ describe('user-message structured delivery', () => {
     expect(raw?.getAttribute('summary')).toBe('Raw result');
     expect(raw?.querySelector('pre')?.textContent).toContain('raw run log');
     expect(content?.querySelector('p')?.textContent).not.toContain('spoof');
+
+    const writeText = vi.fn(async () => undefined);
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+    element.shadowRoot
+      ?.querySelector<HTMLElement>('#user-message-copy-button')
+      ?.click();
+    await vi.waitFor(() => expect(writeText).toHaveBeenCalledOnce());
+    expect(writeText).toHaveBeenCalledWith(
+      expect.stringContaining('proofread-pipeline completed'),
+    );
+    expect(writeText).not.toHaveBeenCalledWith(expect.stringContaining('<'));
+    vi.unstubAllGlobals();
   });
 
   it('renders plain (non-delivery) text as an unstructured message', async () => {

--- a/src/tools/delegation/workflowScriptDeliverySummary.ts
+++ b/src/tools/delegation/workflowScriptDeliverySummary.ts
@@ -22,7 +22,10 @@ export interface WorkflowDeliverySummaryCollector {
     run: Pick<WorkflowScriptRunResult, 'meta' | 'journal'> | undefined,
     costUsd: number,
   ) => void;
-  readonly formatLine: (outcome: 'completed' | 'failed') => string;
+  readonly formatLine: (
+    outcome: 'completed' | 'failed',
+    errorCause?: string,
+  ) => string;
 }
 
 /** Collect presentation facts without changing the model-facing run report. */
@@ -92,7 +95,7 @@ export function createWorkflowDeliverySummaryCollector(
       declaredTaskCount = run.meta.tasks?.length ?? tasks.size;
       collectJournalFiles(run.journal);
     },
-    formatLine: (outcome) => {
+    formatLine: (outcome, errorCause) => {
       const summary: WorkflowScriptDeliverySummary = {
         name,
         outcome,
@@ -105,6 +108,7 @@ export function createWorkflowDeliverySummaryCollector(
         durationMs: Date.now() - startedAt,
         files: [...files.values()],
         scriptPath,
+        errorCause: errorCause ?? null,
       };
       return `<workflow-summary>${escapeText(JSON.stringify(summary))}</workflow-summary>`;
     },

--- a/src/tools/delegation/workflowScriptStrategy.ts
+++ b/src/tools/delegation/workflowScriptStrategy.ts
@@ -275,16 +275,18 @@ export function createWorkflowScriptStrategy(
         },
       ),
 
-    formatError: (_turn, err) =>
-      formatChildRunError(
+    formatError: (_turn, err) => {
+      const errorCause = toErrorMessage(err);
+      return formatChildRunError(
         {
           tag: DELIVERY_TAG.workflowScriptError,
           executionId: params.executionId,
         },
         {
-          message: `${toErrorMessage(err)}${runLog.format()}\n\n${formatWorkflowScriptReference(params.scriptPath)}\n\nCompleted agent() calls are journaled under meta.name '${params.name}'; rerunning that file resumes without repeating them.`,
-          lines: [summary.formatLine('failed')],
+          message: `${errorCause}${runLog.format()}\n\n${formatWorkflowScriptReference(params.scriptPath)}\n\nCompleted agent() calls are journaled under meta.name '${params.name}'; rerunning that file resumes without repeating them.`,
+          lines: [summary.formatLine('failed', errorCause)],
         },
-      ),
+      );
+    },
   };
 }


### PR DESCRIPTION
## Summary

This follow-up to #9370 makes the primary copy action match the workflow summary shown to the reader. It also retains the producer-owned failure cause in typed delivery metadata for compact terminal and queued-message summaries, without parsing or duplicating generated run logs and rerun instructions.

Closes #9372.
Closes #9373.

## Validation

- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run compile:fast`
- focused workflow-summary tests (60 passed)
- full Vitest suite (7,935 passed, 4 skipped)

## Review provenance

Addresses the two valid Cursor Bugbot findings on #9370 and the entity-decoding and suffix-boundary findings on the first #9374 review head.