### PR TITLE
refactor: unify team launch preparation

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -30,15 +30,8 @@ import {
   loadFileListSettings,
   type ListableFileType,
 } from '@common/files/fileListingRules';
-import {
-  formatPartialTeamLaunchMessage,
-  formatTeamLaunchBlockedMessage,
-  formatTeamUnavailableMessage,
-  formatUnknownTeamMessage,
-  resolveTeamLaunch,
-  TEAM_SELECTION_REQUIRED_MESSAGE,
-} from '@common/teams/TeamPlan';
 import { listWorkspaceFiles } from '@common/files/workspaceFileListing';
+import { prepareMainViewExecutionLaunch } from '@controllers/mainView/MainViewExecutionLaunchController';
 import { replayApprovalRequestHandlers } from '@controllers/progressView/backend/progressBackendUiConfig';
 import { buildStreamInfo } from '@controllers/progressView/backend/streamInfoUtils';
 import { ProgressBackend } from '@controllers/progressView/backend/ProgressBackend';
@@ -60,11 +53,6 @@ import {
 } from '@controllers/progressView/ProgressWorkflowActionsController';
 import { ProgressViewHost } from '@controllers/progressView/ProgressViewHost';
 import { buildMainViewState } from '@controllers/mainView/MainViewStateRestoreController';
-import { createTeamCatalogPorts } from '@controllers/mainView/teamCatalogPorts';
-import {
-  prepareMainViewExecutionRequest,
-  prepareMainViewTeamExecutionRequest,
-} from '@controllers/mainView/MainViewExecutionController';
 import {
   runCleanMultiple,
   runCleanRunDir,
@@ -1503,63 +1491,11 @@ export class DesktopProgressBridge {
   }
 
   async handleExecute(message: MainViewExecuteMessage): Promise<void> {
-    let preparation;
-    if (message.session?.launchTarget === 'team') {
-      try {
-        const teamId = message.session.teamId;
-        if (!teamId) {
-          await this.options.host.showErrorMessage(
-            TEAM_SELECTION_REQUIRED_MESSAGE,
-          );
-          return;
-        }
-
-        const resolution = await resolveTeamLaunch({
-          teamId,
-          ...createTeamCatalogPorts(),
-          choose: (unavailableNames) =>
-            this.options.host.chooseTeamAvailability(unavailableNames),
-          signIn: () => this.options.host.signInForRemoteAgentCatalog(),
-        });
-
-        if (resolution.status === 'cancelled') return;
-        if (resolution.status === 'unknown-team') {
-          await this.options.host.showErrorMessage(
-            formatUnknownTeamMessage(teamId),
-          );
-          return;
-        }
-        if (resolution.status === 'blocked') {
-          await this.options.host.showErrorMessage(
-            formatTeamLaunchBlockedMessage(teamId, resolution.reason),
-          );
-          return;
-        }
-        if (resolution.status === 'unavailable') {
-          await this.options.host.showErrorMessage(
-            formatTeamUnavailableMessage(teamId, resolution.unavailableNames),
-          );
-          return;
-        }
-
-        if (resolution.partial) {
-          await this.options.host.showInfoMessage(
-            formatPartialTeamLaunchMessage(resolution.missingNames),
-          );
-        }
-        preparation = prepareMainViewTeamExecutionRequest(
-          message,
-          resolution.fields,
-        );
-      } catch (error) {
-        await this.options.host.showErrorMessage(
-          `Team launch failed: ${toErrorMessage(error)}`,
-        );
-        return;
-      }
-    } else {
-      preparation = prepareMainViewExecutionRequest(message);
-    }
+    const preparation = await prepareMainViewExecutionLaunch(
+      message,
+      this.options.host,
+    );
+    if (!preparation) return;
     if (!preparation.valid) {
       await this.options.host.showErrorMessage(preparation.message);
       return;

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -31,7 +31,7 @@ import {
   type ListableFileType,
 } from '@common/files/fileListingRules';
 import { listWorkspaceFiles } from '@common/files/workspaceFileListing';
-import { prepareMainViewExecutionLaunch } from '@controllers/mainView/MainViewExecutionLaunchController';
+import { prepareMainViewExecutionLaunch } from '@controllers/mainView/backend/MainViewExecutionLaunchController';
 import { replayApprovalRequestHandlers } from '@controllers/progressView/backend/progressBackendUiConfig';
 import { buildStreamInfo } from '@controllers/progressView/backend/streamInfoUtils';
 import { ProgressBackend } from '@controllers/progressView/backend/ProgressBackend';
@@ -1491,11 +1491,19 @@ export class DesktopProgressBridge {
   }
 
   async handleExecute(message: MainViewExecuteMessage): Promise<void> {
-    const preparation = await prepareMainViewExecutionLaunch(
+    const launch = await prepareMainViewExecutionLaunch(
       message,
       this.options.host,
     );
-    if (!preparation) return;
+    if (launch.status === 'cancelled') return;
+    if (launch.status === 'error') {
+      await this.options.host.showErrorMessage(launch.message);
+      return;
+    }
+    if (launch.infoMessage) {
+      await this.options.host.showInfoMessage(launch.infoMessage);
+    }
+    const { preparation } = launch;
     if (!preparation.valid) {
       await this.options.host.showErrorMessage(preparation.message);
       return;

--- a/packages/desktop/src/main/desktopAgentExecutionHost.ts
+++ b/packages/desktop/src/main/desktopAgentExecutionHost.ts
@@ -1,9 +1,11 @@
-import type { MainViewExecutionLaunchHost } from '@controllers/mainView/MainViewExecutionLaunchController';
+import type { MainViewExecutionLaunchHost } from '@controllers/mainView/backend/MainViewExecutionLaunchController';
 import type { DiffViewHost } from '@hosts/uiHosts';
 import type { BuildDisplayFn } from '@tools/approval/latexPreview';
 
 /** Required desktop capabilities used throughout an agent execution. */
 export interface DesktopAgentExecutionHost extends MainViewExecutionLaunchHost {
+  showErrorMessage(message: string): Promise<void> | void;
+  showInfoMessage(message: string): Promise<void> | void;
   openPath(filePath: string, line?: number): Promise<void>;
   openBuildDisplay: BuildDisplayFn;
   openDiff: DiffViewHost['openDiff'];

--- a/packages/desktop/src/main/desktopAgentExecutionHost.ts
+++ b/packages/desktop/src/main/desktopAgentExecutionHost.ts
@@ -1,19 +1,13 @@
-import type { TeamAvailabilityChoice } from '@common/teams/TeamAvailabilityPreflight';
+import type { MainViewExecutionLaunchHost } from '@controllers/mainView/MainViewExecutionLaunchController';
 import type { DiffViewHost } from '@hosts/uiHosts';
 import type { BuildDisplayFn } from '@tools/approval/latexPreview';
 
 /** Required desktop capabilities used throughout an agent execution. */
-export interface DesktopAgentExecutionHost {
+export interface DesktopAgentExecutionHost extends MainViewExecutionLaunchHost {
   openPath(filePath: string, line?: number): Promise<void>;
   openBuildDisplay: BuildDisplayFn;
   openDiff: DiffViewHost['openDiff'];
   confirmAcceptFile(message: string): Promise<boolean>;
-  chooseTeamAvailability(
-    unavailableNames: readonly string[],
-  ): Promise<TeamAvailabilityChoice | undefined>;
-  signInForRemoteAgentCatalog(): Promise<boolean>;
-  showErrorMessage(message: string): Promise<void> | void;
-  showInfoMessage(message: string): Promise<void> | void;
   /** Recompute window state derived from a newly completed run. */
   onRunCompleted(): void;
 }

--- a/packages/extension/src/webview/managers/executionHandlers.ts
+++ b/packages/extension/src/webview/managers/executionHandlers.ts
@@ -9,7 +9,7 @@ import {
   TEAM_LAUNCH_CONTINUE_LABEL,
   TEAM_LAUNCH_SIGN_IN_LABEL,
 } from '@common/teams/TeamPlan';
-import { prepareMainViewExecutionLaunch } from '@controllers/mainView/MainViewExecutionLaunchController';
+import { prepareMainViewExecutionLaunch } from '@controllers/mainView/backend/MainViewExecutionLaunchController';
 import { logErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
@@ -66,7 +66,7 @@ export async function handleExecute(
     return;
   }
 
-  const preparation = await prepareMainViewExecutionLaunch(message, {
+  const launch = await prepareMainViewExecutionLaunch(message, {
     chooseTeamAvailability: async (unavailableNames) => {
       const choice = await vscode.window.showWarningMessage(
         formatUnavailableTeamMembersMessage(unavailableNames),
@@ -82,14 +82,16 @@ export async function handleExecute(
       Boolean(
         await vscode.commands.executeCommand<boolean>(AUTH_COMMANDS.SIGN_IN),
       ),
-    showErrorMessage: async (errorMessage) => {
-      await vscode.window.showErrorMessage(errorMessage);
-    },
-    showInfoMessage: async (infoMessage) => {
-      await vscode.window.showInformationMessage(infoMessage);
-    },
   });
-  if (!preparation) return;
+  if (launch.status === 'cancelled') return;
+  if (launch.status === 'error') {
+    await vscode.window.showErrorMessage(launch.message);
+    return;
+  }
+  if (launch.infoMessage) {
+    await vscode.window.showInformationMessage(launch.infoMessage);
+  }
+  const { preparation } = launch;
   if (!preparation.valid) {
     logErrorMessage(
       CHANNEL,

--- a/packages/extension/src/webview/managers/executionHandlers.ts
+++ b/packages/extension/src/webview/managers/executionHandlers.ts
@@ -4,30 +4,18 @@ import * as vscode from 'vscode';
 
 import { AUTH_COMMANDS } from '@auth/constants';
 import {
-  formatPartialTeamLaunchMessage,
-  formatTeamLaunchBlockedMessage,
-  formatTeamUnavailableMessage,
   formatUnavailableTeamMembersMessage,
-  formatUnknownTeamMessage,
-  resolveTeamLaunch,
   TEAM_LAUNCH_CANCEL_LABEL,
   TEAM_LAUNCH_CONTINUE_LABEL,
   TEAM_LAUNCH_SIGN_IN_LABEL,
-  TEAM_SELECTION_REQUIRED_MESSAGE,
 } from '@common/teams/TeamPlan';
-import { createTeamCatalogPorts } from '@controllers/mainView/teamCatalogPorts';
-import {
-  type MainViewExecutionPreparationResult,
-  prepareMainViewExecutionRequest,
-  prepareMainViewTeamExecutionRequest,
-} from '@controllers/mainView/MainViewExecutionController';
+import { prepareMainViewExecutionLaunch } from '@controllers/mainView/MainViewExecutionLaunchController';
 import { logErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
 import type { MainViewExecuteMessage } from '@shared/schemas/mainView/executeMessage';
 import type { FileOperationMessage } from '@shared/schemas/mainView/inbound';
 import { pathToLocation } from '@utils/files';
-import { toErrorMessage } from '@utils/errors/errorMessage';
 
 const CHANNEL = 'ExecutionHandlers';
 
@@ -78,73 +66,30 @@ export async function handleExecute(
     return;
   }
 
-  let preparation: MainViewExecutionPreparationResult;
-  if (message.session?.launchTarget === 'team') {
-    try {
-      const teamId = message.session.teamId;
-      if (!teamId) {
-        vscode.window.showErrorMessage(TEAM_SELECTION_REQUIRED_MESSAGE);
-        return;
-      }
-
-      const resolution = await resolveTeamLaunch({
-        teamId,
-        ...createTeamCatalogPorts(),
-        choose: async (unavailableNames) => {
-          const choice = await vscode.window.showWarningMessage(
-            formatUnavailableTeamMembersMessage(unavailableNames),
-            TEAM_LAUNCH_SIGN_IN_LABEL,
-            TEAM_LAUNCH_CONTINUE_LABEL,
-            TEAM_LAUNCH_CANCEL_LABEL,
-          );
-          if (choice === TEAM_LAUNCH_SIGN_IN_LABEL) return 'sign-in';
-          if (choice === TEAM_LAUNCH_CONTINUE_LABEL) return 'continue';
-          return 'cancel';
-        },
-        signIn: async () =>
-          Boolean(
-            await vscode.commands.executeCommand<boolean>(
-              AUTH_COMMANDS.SIGN_IN,
-            ),
-          ),
-      });
-
-      if (resolution.status === 'cancelled') return;
-      if (resolution.status === 'unknown-team') {
-        vscode.window.showErrorMessage(formatUnknownTeamMessage(teamId));
-        return;
-      }
-      if (resolution.status === 'blocked') {
-        vscode.window.showErrorMessage(
-          formatTeamLaunchBlockedMessage(teamId, resolution.reason),
-        );
-        return;
-      }
-      if (resolution.status === 'unavailable') {
-        vscode.window.showErrorMessage(
-          formatTeamUnavailableMessage(teamId, resolution.unavailableNames),
-        );
-        return;
-      }
-
-      if (resolution.partial) {
-        await vscode.window.showInformationMessage(
-          formatPartialTeamLaunchMessage(resolution.missingNames),
-        );
-      }
-      preparation = prepareMainViewTeamExecutionRequest(
-        message,
-        resolution.fields,
+  const preparation = await prepareMainViewExecutionLaunch(message, {
+    chooseTeamAvailability: async (unavailableNames) => {
+      const choice = await vscode.window.showWarningMessage(
+        formatUnavailableTeamMembersMessage(unavailableNames),
+        TEAM_LAUNCH_SIGN_IN_LABEL,
+        TEAM_LAUNCH_CONTINUE_LABEL,
+        TEAM_LAUNCH_CANCEL_LABEL,
       );
-    } catch (error) {
-      vscode.window.showErrorMessage(
-        `Team launch failed: ${toErrorMessage(error)}`,
-      );
-      return;
-    }
-  } else {
-    preparation = prepareMainViewExecutionRequest(message);
-  }
+      if (choice === TEAM_LAUNCH_SIGN_IN_LABEL) return 'sign-in';
+      if (choice === TEAM_LAUNCH_CONTINUE_LABEL) return 'continue';
+      return 'cancel';
+    },
+    signInForRemoteAgentCatalog: async () =>
+      Boolean(
+        await vscode.commands.executeCommand<boolean>(AUTH_COMMANDS.SIGN_IN),
+      ),
+    showErrorMessage: async (errorMessage) => {
+      await vscode.window.showErrorMessage(errorMessage);
+    },
+    showInfoMessage: async (infoMessage) => {
+      await vscode.window.showInformationMessage(infoMessage);
+    },
+  });
+  if (!preparation) return;
   if (!preparation.valid) {
     logErrorMessage(
       CHANNEL,

--- a/src/controllers/mainView/MainViewExecutionLaunchController.ts
+++ b/src/controllers/mainView/MainViewExecutionLaunchController.ts
@@ -1,0 +1,89 @@
+// Local imports - team launch
+import type { TeamAvailabilityChoice } from '@common/teams/TeamAvailabilityPreflight';
+import {
+  formatPartialTeamLaunchMessage,
+  formatTeamLaunchBlockedMessage,
+  formatTeamUnavailableMessage,
+  formatUnknownTeamMessage,
+  resolveTeamLaunch,
+  TEAM_SELECTION_REQUIRED_MESSAGE,
+} from '@common/teams/TeamPlan';
+
+// Local imports - main-view execution
+import { createTeamCatalogPorts } from '@controllers/mainView/teamCatalogPorts';
+import {
+  type MainViewExecutionPreparationResult,
+  prepareMainViewExecutionRequest,
+  prepareMainViewTeamExecutionRequest,
+} from '@controllers/mainView/MainViewExecutionController';
+
+// Local imports - shared types and errors
+import type { MainViewExecuteMessage } from '@shared/schemas';
+import { toErrorMessage } from '@utils/errors/errorMessage';
+
+/** Host interactions needed by the shared team-launch decision sequence. */
+export interface MainViewExecutionLaunchHost {
+  chooseTeamAvailability(
+    unavailableNames: readonly string[],
+  ): Promise<TeamAvailabilityChoice | undefined>;
+  signInForRemoteAgentCatalog(): Promise<boolean>;
+  showErrorMessage(message: string): Promise<void> | void;
+  showInfoMessage(message: string): Promise<void> | void;
+}
+
+/**
+ * Resolve an ordinary or team launch into one validated execution request.
+ * Host-specific prechecks and invalid-request presentation remain with callers.
+ */
+export async function prepareMainViewExecutionLaunch(
+  message: MainViewExecuteMessage,
+  host: MainViewExecutionLaunchHost,
+): Promise<MainViewExecutionPreparationResult | undefined> {
+  if (message.session?.launchTarget !== 'team') {
+    return prepareMainViewExecutionRequest(message);
+  }
+
+  try {
+    const teamId = message.session.teamId;
+    if (!teamId) {
+      await host.showErrorMessage(TEAM_SELECTION_REQUIRED_MESSAGE);
+      return undefined;
+    }
+
+    const resolution = await resolveTeamLaunch({
+      teamId,
+      ...createTeamCatalogPorts(),
+      choose: (unavailableNames) =>
+        host.chooseTeamAvailability(unavailableNames),
+      signIn: () => host.signInForRemoteAgentCatalog(),
+    });
+
+    switch (resolution.status) {
+      case 'cancelled':
+        return undefined;
+      case 'unknown-team':
+        await host.showErrorMessage(formatUnknownTeamMessage(teamId));
+        return undefined;
+      case 'blocked':
+        await host.showErrorMessage(
+          formatTeamLaunchBlockedMessage(teamId, resolution.reason),
+        );
+        return undefined;
+      case 'unavailable':
+        await host.showErrorMessage(
+          formatTeamUnavailableMessage(teamId, resolution.unavailableNames),
+        );
+        return undefined;
+      case 'ready':
+        if (resolution.partial) {
+          await host.showInfoMessage(
+            formatPartialTeamLaunchMessage(resolution.missingNames),
+          );
+        }
+        return prepareMainViewTeamExecutionRequest(message, resolution.fields);
+    }
+  } catch (error) {
+    await host.showErrorMessage(`Team launch failed: ${toErrorMessage(error)}`);
+    return undefined;
+  }
+}

--- a/src/controllers/mainView/backend/MainViewExecutionLaunchController.ts
+++ b/src/controllers/mainView/backend/MainViewExecutionLaunchController.ts
@@ -19,6 +19,7 @@ import {
 
 // Local imports - shared types and errors
 import type { MainViewExecuteMessage } from '@shared/schemas';
+import { assertNever } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 /** Host interactions needed by the shared team-launch decision sequence. */
@@ -27,27 +28,37 @@ export interface MainViewExecutionLaunchHost {
     unavailableNames: readonly string[],
   ): Promise<TeamAvailabilityChoice | undefined>;
   signInForRemoteAgentCatalog(): Promise<boolean>;
-  showErrorMessage(message: string): Promise<void> | void;
-  showInfoMessage(message: string): Promise<void> | void;
 }
+
+/** Host-neutral result of resolving the launch sequence. */
+export type MainViewExecutionLaunchResult =
+  | {
+      status: 'prepared';
+      preparation: MainViewExecutionPreparationResult;
+      infoMessage?: string;
+    }
+  | { status: 'cancelled' }
+  | { status: 'error'; message: string };
 
 /**
  * Resolve an ordinary or team launch into one validated execution request.
- * Host-specific prechecks and invalid-request presentation remain with callers.
+ * Host-specific prechecks and all user-facing presentation remain with callers.
  */
 export async function prepareMainViewExecutionLaunch(
   message: MainViewExecuteMessage,
   host: MainViewExecutionLaunchHost,
-): Promise<MainViewExecutionPreparationResult | undefined> {
+): Promise<MainViewExecutionLaunchResult> {
   if (message.session?.launchTarget !== 'team') {
-    return prepareMainViewExecutionRequest(message);
+    return {
+      status: 'prepared',
+      preparation: prepareMainViewExecutionRequest(message),
+    };
   }
 
   try {
     const teamId = message.session.teamId;
     if (!teamId) {
-      await host.showErrorMessage(TEAM_SELECTION_REQUIRED_MESSAGE);
-      return undefined;
+      return { status: 'error', message: TEAM_SELECTION_REQUIRED_MESSAGE };
     }
 
     const resolution = await resolveTeamLaunch({
@@ -60,30 +71,50 @@ export async function prepareMainViewExecutionLaunch(
 
     switch (resolution.status) {
       case 'cancelled':
-        return undefined;
+        return { status: 'cancelled' };
       case 'unknown-team':
-        await host.showErrorMessage(formatUnknownTeamMessage(teamId));
-        return undefined;
+        return {
+          status: 'error',
+          message: formatUnknownTeamMessage(teamId),
+        };
       case 'blocked':
-        await host.showErrorMessage(
-          formatTeamLaunchBlockedMessage(teamId, resolution.reason),
-        );
-        return undefined;
+        return {
+          status: 'error',
+          message: formatTeamLaunchBlockedMessage(teamId, resolution.reason),
+        };
       case 'unavailable':
-        await host.showErrorMessage(
-          formatTeamUnavailableMessage(teamId, resolution.unavailableNames),
+        return {
+          status: 'error',
+          message: formatTeamUnavailableMessage(
+            teamId,
+            resolution.unavailableNames,
+          ),
+        };
+      case 'ready': {
+        const preparation = prepareMainViewTeamExecutionRequest(
+          message,
+          resolution.fields,
         );
-        return undefined;
-      case 'ready':
-        if (resolution.partial) {
-          await host.showInfoMessage(
-            formatPartialTeamLaunchMessage(resolution.missingNames),
-          );
-        }
-        return prepareMainViewTeamExecutionRequest(message, resolution.fields);
+        return resolution.partial
+          ? {
+              status: 'prepared',
+              preparation,
+              infoMessage: formatPartialTeamLaunchMessage(
+                resolution.missingNames,
+              ),
+            }
+          : { status: 'prepared', preparation };
+      }
+      default:
+        return assertNever(
+          resolution,
+          'Unhandled main-view team launch resolution',
+        );
     }
   } catch (error) {
-    await host.showErrorMessage(`Team launch failed: ${toErrorMessage(error)}`);
-    return undefined;
+    return {
+      status: 'error',
+      message: `Team launch failed: ${toErrorMessage(error)}`,
+    };
   }
 }

--- a/src/test-kernel/controllers/MainViewExecutionLaunchController.vitest.ts
+++ b/src/test-kernel/controllers/MainViewExecutionLaunchController.vitest.ts
@@ -32,14 +32,12 @@ vi.mock('@controllers/mainView/MainViewExecutionController', () => ({
 }));
 
 const { prepareMainViewExecutionLaunch } =
-  await import('@controllers/mainView/MainViewExecutionLaunchController');
+  await import('@controllers/mainView/backend/MainViewExecutionLaunchController');
 
 function createHost() {
   return {
     chooseTeamAvailability: vi.fn(async () => 'continue' as const),
     signInForRemoteAgentCatalog: vi.fn(async () => true),
-    showErrorMessage: vi.fn(async () => undefined),
-    showInfoMessage: vi.fn(async () => undefined),
   };
 }
 
@@ -61,7 +59,7 @@ describe('main-view execution launch controller', () => {
 
     await expect(
       prepareMainViewExecutionLaunch(message, createHost()),
-    ).resolves.toBe(preparation);
+    ).resolves.toEqual({ status: 'prepared', preparation });
     expect(mocks.resolveTeamLaunch).not.toHaveBeenCalled();
   });
 
@@ -70,10 +68,7 @@ describe('main-view execution launch controller', () => {
 
     await expect(
       prepareMainViewExecutionLaunch(teamMessage(''), host),
-    ).resolves.toBeUndefined();
-    expect(host.showErrorMessage).toHaveBeenCalledExactlyOnceWith(
-      'Select a team',
-    );
+    ).resolves.toEqual({ status: 'error', message: 'Select a team' });
     expect(mocks.resolveTeamLaunch).not.toHaveBeenCalled();
   });
 
@@ -94,15 +89,14 @@ describe('main-view execution launch controller', () => {
       expected: 'Unavailable physicist: critic, writer',
     },
   ])(
-    'presents $resolution.status team failures',
+    'returns $resolution.status team failures',
     async ({ resolution, expected }) => {
       const host = createHost();
       mocks.resolveTeamLaunch.mockResolvedValue(resolution);
 
       await expect(
         prepareMainViewExecutionLaunch(teamMessage(), host),
-      ).resolves.toBeUndefined();
-      expect(host.showErrorMessage).toHaveBeenCalledExactlyOnceWith(expected);
+      ).resolves.toEqual({ status: 'error', message: expected });
       expect(mocks.prepareMainViewTeamExecutionRequest).not.toHaveBeenCalled();
     },
   );
@@ -113,12 +107,10 @@ describe('main-view execution launch controller', () => {
 
     await expect(
       prepareMainViewExecutionLaunch(teamMessage(), host),
-    ).resolves.toBeUndefined();
-    expect(host.showErrorMessage).not.toHaveBeenCalled();
-    expect(host.showInfoMessage).not.toHaveBeenCalled();
+    ).resolves.toEqual({ status: 'cancelled' });
   });
 
-  it('presents partial membership and prepares the resolved team fields', async () => {
+  it('returns partial membership and prepares the resolved team fields', async () => {
     const host = createHost();
     const fields = {
       agent: 'team-root',
@@ -138,12 +130,13 @@ describe('main-view execution launch controller', () => {
     mocks.prepareMainViewTeamExecutionRequest.mockReturnValue(preparation);
     const message = teamMessage();
 
-    await expect(prepareMainViewExecutionLaunch(message, host)).resolves.toBe(
+    await expect(
+      prepareMainViewExecutionLaunch(message, host),
+    ).resolves.toEqual({
+      status: 'prepared',
       preparation,
-    );
-    expect(host.showInfoMessage).toHaveBeenCalledExactlyOnceWith(
-      'Partial: writer',
-    );
+      infoMessage: 'Partial: writer',
+    });
     expect(mocks.prepareMainViewTeamExecutionRequest).toHaveBeenCalledWith(
       message,
       fields,
@@ -169,9 +162,9 @@ describe('main-view execution launch controller', () => {
 
     await expect(
       prepareMainViewExecutionLaunch(teamMessage(), host),
-    ).resolves.toBeUndefined();
-    expect(host.showErrorMessage).toHaveBeenCalledExactlyOnceWith(
-      'Team launch failed: catalog unavailable',
-    );
+    ).resolves.toEqual({
+      status: 'error',
+      message: 'Team launch failed: catalog unavailable',
+    });
   });
 });

--- a/src/test-kernel/controllers/MainViewExecutionLaunchController.vitest.ts
+++ b/src/test-kernel/controllers/MainViewExecutionLaunchController.vitest.ts
@@ -1,0 +1,177 @@
+// Third-party imports
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Local imports
+import type { MainViewExecuteMessage } from '@shared/schemas';
+
+const mocks = vi.hoisted(() => ({
+  createTeamCatalogPorts: vi.fn(() => ({ catalog: true })),
+  prepareMainViewExecutionRequest: vi.fn(),
+  prepareMainViewTeamExecutionRequest: vi.fn(),
+  resolveTeamLaunch: vi.fn(),
+}));
+
+vi.mock('@common/teams/TeamPlan', () => ({
+  formatPartialTeamLaunchMessage: (names: readonly string[]) =>
+    `Partial: ${names.join(', ')}`,
+  formatTeamLaunchBlockedMessage: (teamId: string, reason: string) =>
+    `Blocked ${teamId}: ${reason}`,
+  formatTeamUnavailableMessage: (teamId: string, names: readonly string[]) =>
+    `Unavailable ${teamId}: ${names.join(', ')}`,
+  formatUnknownTeamMessage: (teamId: string) => `Unknown ${teamId}`,
+  resolveTeamLaunch: mocks.resolveTeamLaunch,
+  TEAM_SELECTION_REQUIRED_MESSAGE: 'Select a team',
+}));
+vi.mock('@controllers/mainView/teamCatalogPorts', () => ({
+  createTeamCatalogPorts: mocks.createTeamCatalogPorts,
+}));
+vi.mock('@controllers/mainView/MainViewExecutionController', () => ({
+  prepareMainViewExecutionRequest: mocks.prepareMainViewExecutionRequest,
+  prepareMainViewTeamExecutionRequest:
+    mocks.prepareMainViewTeamExecutionRequest,
+}));
+
+const { prepareMainViewExecutionLaunch } =
+  await import('@controllers/mainView/MainViewExecutionLaunchController');
+
+function createHost() {
+  return {
+    chooseTeamAvailability: vi.fn(async () => 'continue' as const),
+    signInForRemoteAgentCatalog: vi.fn(async () => true),
+    showErrorMessage: vi.fn(async () => undefined),
+    showInfoMessage: vi.fn(async () => undefined),
+  };
+}
+
+function teamMessage(teamId = 'physicist'): MainViewExecuteMessage {
+  return {
+    session: { launchTarget: 'team', teamId },
+  };
+}
+
+describe('main-view execution launch controller', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('prepares ordinary launches without loading the team catalog', async () => {
+    const message: MainViewExecuteMessage = {};
+    const preparation = { valid: false as const, message: 'ordinary' };
+    mocks.prepareMainViewExecutionRequest.mockReturnValue(preparation);
+
+    await expect(
+      prepareMainViewExecutionLaunch(message, createHost()),
+    ).resolves.toBe(preparation);
+    expect(mocks.resolveTeamLaunch).not.toHaveBeenCalled();
+  });
+
+  it('rejects a team launch without a selected team', async () => {
+    const host = createHost();
+
+    await expect(
+      prepareMainViewExecutionLaunch(teamMessage(''), host),
+    ).resolves.toBeUndefined();
+    expect(host.showErrorMessage).toHaveBeenCalledExactlyOnceWith(
+      'Select a team',
+    );
+    expect(mocks.resolveTeamLaunch).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      resolution: { status: 'unknown-team' },
+      expected: 'Unknown physicist',
+    },
+    {
+      resolution: { status: 'blocked', reason: 'no runnable root' },
+      expected: 'Blocked physicist: no runnable root',
+    },
+    {
+      resolution: {
+        status: 'unavailable',
+        unavailableNames: ['critic', 'writer'],
+      },
+      expected: 'Unavailable physicist: critic, writer',
+    },
+  ])(
+    'presents $resolution.status team failures',
+    async ({ resolution, expected }) => {
+      const host = createHost();
+      mocks.resolveTeamLaunch.mockResolvedValue(resolution);
+
+      await expect(
+        prepareMainViewExecutionLaunch(teamMessage(), host),
+      ).resolves.toBeUndefined();
+      expect(host.showErrorMessage).toHaveBeenCalledExactlyOnceWith(expected);
+      expect(mocks.prepareMainViewTeamExecutionRequest).not.toHaveBeenCalled();
+    },
+  );
+
+  it('returns without presenting an error when team launch is cancelled', async () => {
+    const host = createHost();
+    mocks.resolveTeamLaunch.mockResolvedValue({ status: 'cancelled' });
+
+    await expect(
+      prepareMainViewExecutionLaunch(teamMessage(), host),
+    ).resolves.toBeUndefined();
+    expect(host.showErrorMessage).not.toHaveBeenCalled();
+    expect(host.showInfoMessage).not.toHaveBeenCalled();
+  });
+
+  it('presents partial membership and prepares the resolved team fields', async () => {
+    const host = createHost();
+    const fields = {
+      agent: 'team-root',
+      delegationAgentScope: {
+        workflowAgentKeys: ['workflow:critic'],
+        toolUseAgentKeys: ['toolUse:team-root'],
+      },
+      cliMultiAgentPresetId: 'physicist',
+    };
+    const preparation = { valid: false as const, message: 'invalid model' };
+    mocks.resolveTeamLaunch.mockResolvedValue({
+      status: 'ready',
+      fields,
+      partial: true,
+      missingNames: ['writer'],
+    });
+    mocks.prepareMainViewTeamExecutionRequest.mockReturnValue(preparation);
+    const message = teamMessage();
+
+    await expect(prepareMainViewExecutionLaunch(message, host)).resolves.toBe(
+      preparation,
+    );
+    expect(host.showInfoMessage).toHaveBeenCalledExactlyOnceWith(
+      'Partial: writer',
+    );
+    expect(mocks.prepareMainViewTeamExecutionRequest).toHaveBeenCalledWith(
+      message,
+      fields,
+    );
+    expect(mocks.resolveTeamLaunch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 'physicist',
+        catalog: true,
+        choose: expect.any(Function),
+        signIn: expect.any(Function),
+      }),
+    );
+    const launchPorts = mocks.resolveTeamLaunch.mock.calls[0]![0];
+    await expect(launchPorts.choose(['writer'])).resolves.toBe('continue');
+    await expect(launchPorts.signIn()).resolves.toBe(true);
+    expect(host.chooseTeamAvailability).toHaveBeenCalledWith(['writer']);
+    expect(host.signInForRemoteAgentCatalog).toHaveBeenCalledOnce();
+  });
+
+  it('surfaces catalog errors and returns no preparation', async () => {
+    const host = createHost();
+    mocks.resolveTeamLaunch.mockRejectedValue(new Error('catalog unavailable'));
+
+    await expect(
+      prepareMainViewExecutionLaunch(teamMessage(), host),
+    ).resolves.toBeUndefined();
+    expect(host.showErrorMessage).toHaveBeenCalledExactlyOnceWith(
+      'Team launch failed: catalog unavailable',
+    );
+  });
+});

--- a/src/test-kernel/webview/ExecutionHandlers.vitest.ts
+++ b/src/test-kernel/webview/ExecutionHandlers.vitest.ts
@@ -6,6 +6,9 @@ import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
 
 const mocks = vi.hoisted(() => ({
   executeCommand: vi.fn(),
+  prepareMainViewExecutionLaunch: vi.fn(),
+  showErrorMessage: vi.fn(),
+  showInformationMessage: vi.fn(),
   pathToLocation: vi.fn((absolutePath: string) => ({
     kind: 'external' as const,
     absolutePath,
@@ -14,9 +17,10 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('vscode', () => ({
   commands: { executeCommand: mocks.executeCommand },
+  workspace: {},
   window: {
-    showErrorMessage: vi.fn(),
-    showInformationMessage: vi.fn(),
+    showErrorMessage: mocks.showErrorMessage,
+    showInformationMessage: mocks.showInformationMessage,
     showWarningMessage: vi.fn(),
   },
 }));
@@ -43,18 +47,57 @@ vi.mock('@controllers/mainView/MainViewExecutionController', () => ({
   prepareMainViewExecutionRequest: vi.fn(),
   prepareMainViewTeamExecutionRequest: vi.fn(),
 }));
+vi.mock(
+  '@controllers/mainView/backend/MainViewExecutionLaunchController',
+  () => ({
+    prepareMainViewExecutionLaunch: mocks.prepareMainViewExecutionLaunch,
+  }),
+);
 vi.mock('@frontend/ui/errorHandlingUtils', () => ({
   logErrorMessage: vi.fn(),
 }));
 vi.mock('@logger/logUtils', () => ({ info: vi.fn() }));
 vi.mock('@utils/files', () => ({ pathToLocation: mocks.pathToLocation }));
 
-const { handleFileOperation } =
+const { handleExecute, handleFileOperation } =
   await import('@webview/managers/executionHandlers');
 
 describe('MainView execution handlers', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('presents launch errors at the extension boundary', async () => {
+    mocks.prepareMainViewExecutionLaunch.mockResolvedValue({
+      status: 'error',
+      message: 'Team launch failed',
+    });
+
+    await handleExecute({});
+
+    expect(mocks.showErrorMessage).toHaveBeenCalledExactlyOnceWith(
+      'Team launch failed',
+    );
+    expect(mocks.executeCommand).not.toHaveBeenCalled();
+  });
+
+  it('presents launch information before executing the prepared request', async () => {
+    const request = { agentName: 'team-root' };
+    mocks.prepareMainViewExecutionLaunch.mockResolvedValue({
+      status: 'prepared',
+      preparation: { valid: true, request },
+      infoMessage: 'Continuing without writer',
+    });
+
+    await handleExecute({});
+
+    expect(mocks.showInformationMessage).toHaveBeenCalledExactlyOnceWith(
+      'Continuing without writer',
+    );
+    expect(mocks.executeCommand).toHaveBeenCalledExactlyOnceWith(
+      'texra.execute',
+      request,
+    );
   });
 
   it.each([


### PR DESCRIPTION
## Summary

The extension and desktop launch paths now use one host-neutral backend controller for the team-selection, availability, sign-in, partial-team, and error branches. The controller returns a tagged launch result; each host remains responsible for presenting errors and informational notices.

## Issue acceptance gates

Closes #9359.

- One shared launch sequence owns ordinary and team preparation.
- Extension-only workspace and documentation behavior remains in the extension caller.
- Desktop execution still enters through `runExecution`.
- All team resolution branches and host presentation boundaries are covered by tests.

## Single source of truth

`src/controllers/mainView/backend/MainViewExecutionLaunchController.ts` now owns the ordinary-versus-team launch decision and the complete team-resolution state machine.

## Duplication and abstraction budget

The duplicate desktop and extension team-launch branches were removed. The new controller owns the cross-host decision invariant and returns a tagged result; it does not wrap execution or perform host presentation.

## Net elements (R6)

- Files: 6 changed; 2 added and 4 modified.
- Diffstat: 378 insertions, 158 deletions; net +220 lines, including 216 lines of new controller and boundary tests.
- Exported symbols: +3 (`MainViewExecutionLaunchHost`, `MainViewExecutionLaunchResult`, and `prepareMainViewExecutionLaunch`); no exported symbol was removed. The existing `DesktopAgentExecutionHost` export changed only by extending the new port.
- Classes/interfaces/enums: +1 interface, +0 classes, +0 enums. The tagged result adds one exported type alias.

## Consumer counts (R8)

No event or emit path was added, deleted, or rerouted. The new preparation function has 2 production consumers (desktop and extension); the new host port has 1 production type consumer (`DesktopAgentExecutionHost`). The result type is consumed through the function return type and inferred at both call sites.

## Host impact

Extension: uses the shared preparation result while retaining workspace validation, VS Code dialogs, the file-management documentation action, and `texra.execute` dispatch.

Desktop: uses the same preparation result while retaining desktop dialogs and `runExecution` dispatch.

CLI: no behavior change.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run compile:fast`
- focused controller, desktop, extension, and caller-boundary tests: 36 passed
- full Vitest run: 7,945 passed and 4 skipped