### PR TITLE
refactor: make response text processing host supplied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file.
 - **Embeddable agent package** — Node applications can install
   `@texra-ai/agent`, load agents from a chosen directory, stream run events,
   and await the final result.
+- **Predictable embedded model output** — the agent package now returns
+  provider text unchanged and joins continued responses deterministically,
+  while TeXRA applications retain their LaTeX-aware processing.
 
 #### Bug Fixes
 

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -27,6 +27,7 @@ import {
   initializeDefaultSession,
 } from '@agent/runtime/SessionHandle';
 import { SupabaseClient } from '@auth/SupabaseClient';
+import { texraResponseTextProcessing } from '@latex/texraResponseTextProcessing';
 import { platform, tryPlatform } from '@platform/platform';
 import { MEMORY_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 import {
@@ -438,7 +439,10 @@ if (HARNESS_MEMORY_FILES.length > 0) {
     utimesSync(filePath, mtime, mtime);
   });
 }
-initializeDefaultSession({ transcripts: await StreamLogStore.open() });
+initializeDefaultSession({
+  transcripts: await StreamLogStore.open(),
+  responseTextProcessing: texraResponseTextProcessing,
+});
 const harnessFollowUpLease = defaultSession().followUps.claimLive(
   STREAM_ID,
   'flow',

--- a/packages/cli/src/runtime/transcriptSession.ts
+++ b/packages/cli/src/runtime/transcriptSession.ts
@@ -4,6 +4,7 @@ import {
   tryDefaultSession,
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
+import { texraResponseTextProcessing } from '@latex/texraResponseTextProcessing';
 import { GoalStore } from '@tools/goal';
 import { StreamLogStore } from '@transcript';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -43,7 +44,10 @@ async function initializePersistentSession(
   transcripts: StreamLogStore,
 ): Promise<CliTranscriptSession> {
   const result = await persistentSession(
-    initializeDefaultSession({ transcripts }),
+    initializeDefaultSession({
+      transcripts,
+      responseTextProcessing: texraResponseTextProcessing,
+    }),
   );
   const stores = new SessionStores({
     streamLogs: result.session.transcripts,
@@ -103,6 +107,7 @@ export async function initializeInteractiveTranscriptSession(
     const warning = formatEphemeralWarning(reason);
     const session = initializeDefaultSession({
       transcripts: StreamLogStore.ephemeral(reason),
+      responseTextProcessing: texraResponseTextProcessing,
     });
     await session.waitUntilReady();
     policy.showPersistentWarning(warning);

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -15,6 +15,7 @@ import { detachSubagentsOnStop } from '@agent/runtime/detachSubagentsOnStop';
 import { trackTerminalResultPresentation } from '@agent/runtime/terminalResultToast';
 import type { SessionHostInteractions } from '@agent/runtime/HostInteractions';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
+import { polishTextWithAI } from '@agent/runtime/textEnhancement';
 import {
   notifyFollowUpSent,
   presentFollowUpResult,
@@ -166,8 +167,7 @@ export class DesktopProgressBridge {
   /** Plans tool-use follow-up runs and compile-fix runs for a finished stream. */
   private followUpController!: ProgressFollowUpController;
   /** Rewrites follow-up text with the helper model ("Polish" in the follow-up box). */
-  private readonly followUpPolishController =
-    new ProgressFollowUpPolishController();
+  private readonly followUpPolishController: ProgressFollowUpPolishController;
   /** Switches a credit/limit-exhausted run onto the user's own API key. */
   private apiKeyRetryController!: ProgressApiKeyRetryController;
   /**
@@ -197,6 +197,10 @@ export class DesktopProgressBridge {
     private readonly options: DesktopProgressBridgeOptions,
   ) {
     this.logger = options.logger ?? createChannelTrace('DesktopProgressBridge');
+    this.followUpPolishController = new ProgressFollowUpPolishController({
+      polishText: (text, fileContext) =>
+        polishTextWithAI(text, fileContext, options.session),
+    });
     const presentationHost: Pick<SessionHostInteractions, 'emit'> = {
       emit: (event, payload) => this.handlePresentationEvent(event, payload),
     };

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -37,6 +37,7 @@ import { LatexConfigPersistenceController } from '@controllers/settingsView/Late
 import { LatexToolingController } from '@controllers/settingsView/LatexToolingController';
 import { prepareMainViewExecutionRequest } from '@controllers/mainView/MainViewExecutionController';
 import type { TerminalRunResult } from '@hosts/uiHosts';
+import { texraResponseTextProcessing } from '@latex/texraResponseTextProcessing';
 import { hasUsableSetupCredential } from '@model/setupCredentialAccess';
 import { platform } from '@platform/platform';
 import { SHUTDOWN_PHASE } from '@platform/interfaces';
@@ -1295,6 +1296,7 @@ if (protocolLifecycle.shouldContinue) {
       const processSession = new SessionHandle({
         transcripts,
         restartRepair: 'deferred',
+        responseTextProcessing: texraResponseTextProcessing,
       });
       const detachTerminalResultToast = attachTerminalResultToast(
         processSession,

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -67,6 +67,7 @@ import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 import { migrateLegacyVscodeStorage } from '@frontend/vscode/sharedStorageRoot';
 import { VscodeSecrets } from '@frontend/vscode/vscodeSecrets';
 import { VscodeConfigProvider } from '@frontend/vscode/vscodeConfig';
+import { texraResponseTextProcessing } from '@latex/texraResponseTextProcessing';
 import * as logger from '@logger/logUtils';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { refreshModelListStateIfNeeded } from '@model/modelListRefresh';
@@ -272,6 +273,7 @@ export async function activate(context: vscode.ExtensionContext) {
   );
   const runtimeSession = initializeDefaultSession({
     transcripts: await StreamLogStore.open(),
+    responseTextProcessing: texraResponseTextProcessing,
   });
   await runtimeSession.waitUntilReady();
   registerAgentFeatures();

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -22,7 +22,6 @@ import {
 import type { ProviderUsage } from '@agent/core/usage/ResponseUsage';
 import { K_SLICE } from '@agent/core/constants';
 import { useLaunchRunContext } from '@agent/runtime/RunContext';
-import { bestConnectionMethod } from '@agent/runtime/textConnection';
 import type { ToolDefinition } from '@model';
 import { MESSAGE_TYPES, AgentFileLocationSchema } from '@shared/schemas';
 import { OUTPUT_END_TAG } from '@shared/schemas/output';
@@ -319,16 +318,16 @@ class ResponseProcessNode<C> extends BaseNode<
         return { kind: 'success', value: { ...common, hasResponse: false } };
       }
 
-      // Text cleanup (replacementEngine.applyAll) is applied once inside each
-      // handler's extractResponse, so newResponse is already cleaned here.
+      // A host-supplied processor is applied once inside each handler's
+      // extractResponse, so newResponse is already in its final form here.
       // Re-applying would run non-idempotent custom replacements twice.
       const processedResponse = newResponse;
 
-      const connector = await bestConnectionMethod(
-        prepRes.lastResponse.slice(-K_SLICE),
-        processedResponse.slice(0, K_SLICE),
-      );
-      const bestConnector = connector.connector;
+      const bestConnector =
+        await this.services.runScope.session.responseTextProcessing.connectResponseText(
+          prepRes.lastResponse.slice(-K_SLICE),
+          processedResponse.slice(0, K_SLICE),
+        );
       const updatedAccumulatedOutput =
         prepRes.accumulatedOutput + bestConnector + processedResponse;
 

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -316,6 +316,7 @@ export async function runToolUseFlow<C = unknown>(
     const nextHandler = (await createModelHandler(
       nextConfig,
       setting.agentCategory,
+      services.runScope.session.responseTextProcessing.postProcessResponse,
     )) as ToolUseServices<C>['modelHandler'];
     if (!modelHandlersShareConversationFormat(previousHandler, nextHandler)) {
       nextHandler.dispose();

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -316,7 +316,7 @@ export async function runToolUseFlow<C = unknown>(
     const nextHandler = (await createModelHandler(
       nextConfig,
       setting.agentCategory,
-      services.runScope.session.responseTextProcessing.postProcessResponse,
+      services.runScope.session.responseTextProcessing,
     )) as ToolUseServices<C>['modelHandler'];
     if (!modelHandlersShareConversationFormat(previousHandler, nextHandler)) {
       nextHandler.dispose();

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -52,8 +52,8 @@ import type {
   TokenValidationResult,
 } from '@agent/types/ModelHandlerContracts';
 import {
-  preserveResponseText,
-  type ResponseTextPostProcessor,
+  createNeutralResponseTextProcessing,
+  type ResponseTextProcessing,
 } from '@agent/runtime/responseTextProcessing';
 import { hasConfigurableReasoningEffort } from '@agent/modelHandlers/support/reasoningEffort';
 import type {
@@ -233,7 +233,8 @@ export abstract class ModelHandler<
     MediaAttachmentKind[]
   >();
   private createdMediaEntriesForAttachmentLog: MediaEntry[] = [];
-  protected readonly postProcessResponse: ResponseTextPostProcessor;
+  protected readonly normalizeResponseText: ResponseTextProcessing['normalizeResponseText'];
+  protected readonly postProcessResponse: ResponseTextProcessing['postProcessResponse'];
 
   /**
    * Whether the handler supports processing attachments in tool results.
@@ -278,10 +279,11 @@ export abstract class ModelHandler<
 
   constructor(
     config: ResolvedModelConfig,
-    postProcessResponse: ResponseTextPostProcessor = preserveResponseText,
+    responseTextProcessing: ResponseTextProcessing = createNeutralResponseTextProcessing(),
   ) {
     this.config = { ...config };
-    this.postProcessResponse = postProcessResponse;
+    this.normalizeResponseText = responseTextProcessing.normalizeResponseText;
+    this.postProcessResponse = responseTextProcessing.postProcessResponse;
     this.capabilities = structuredClone(config.capabilities);
     this.continueLimit = DEFAULT_CONTINUE_LIMIT;
     this.inputTokenLimit = DEFAULT_INPUT_TOKEN_LIMIT;

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -51,6 +51,10 @@ import type {
   TokenCountOptions,
   TokenValidationResult,
 } from '@agent/types/ModelHandlerContracts';
+import {
+  preserveResponseText,
+  type ResponseTextPostProcessor,
+} from '@agent/runtime/responseTextProcessing';
 import { hasConfigurableReasoningEffort } from '@agent/modelHandlers/support/reasoningEffort';
 import type {
   ServerToolExtractionResult,
@@ -229,6 +233,7 @@ export abstract class ModelHandler<
     MediaAttachmentKind[]
   >();
   private createdMediaEntriesForAttachmentLog: MediaEntry[] = [];
+  protected readonly postProcessResponse: ResponseTextPostProcessor;
 
   /**
    * Whether the handler supports processing attachments in tool results.
@@ -271,8 +276,12 @@ export abstract class ModelHandler<
     return false;
   }
 
-  constructor(config: ResolvedModelConfig) {
+  constructor(
+    config: ResolvedModelConfig,
+    postProcessResponse: ResponseTextPostProcessor = preserveResponseText,
+  ) {
     this.config = { ...config };
+    this.postProcessResponse = postProcessResponse;
     this.capabilities = structuredClone(config.capabilities);
     this.continueLimit = DEFAULT_CONTINUE_LIMIT;
     this.inputTokenLimit = DEFAULT_INPUT_TOKEN_LIMIT;
@@ -1537,6 +1546,7 @@ export abstract class ModelHandler<
       outputLocation,
       workspaceState,
       this.logger,
+      this.postProcessResponse,
     );
 
     messages.push(this.createAssistantMessageForPrefillText(fileContent));

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -43,7 +43,6 @@ import {
   takeTail,
   PARTIAL_TEXT_TAIL_MAX,
 } from '@common/errors/sdkErrorUtils';
-import replacementEngine from '@replacement/engine';
 import type {
   FileLocation,
   MediaAttachmentKind,
@@ -1221,7 +1220,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       stopReason === ANTHROPIC_STOP.STOP_SEQUENCE,
     );
 
-    newResponse = replacementEngine.applyAll(newResponse);
+    newResponse = this.postProcessResponse(newResponse);
 
     return {
       text: newResponse,

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -1210,7 +1210,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     const stopReason = responseObject.stop_reason;
     let newResponse = responseObject.content
       .filter(isBetaTextBlock)
-      .map((block) => block.text.trim())
+      .map((block) => this.normalizeResponseText(block.text))
       .join('');
 
     // Add end tag if needed

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -712,7 +712,9 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     // The getter may use cached values that don't reflect mutations we made
     // to the candidates array during streaming (lines 536-550, 577-584).
     // Filter out thought parts and concatenate text from remaining parts.
-    const rawResponseText = extractNonThinkingText(parts, true);
+    const rawResponseText = this.normalizeResponseText(
+      extractNonThinkingText(parts),
+    );
 
     // For TOOL CALL ONLY RESPONSE this happens sometimes, we don't want to log it
     let responseText = this.postProcessResponse(rawResponseText);

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -727,7 +727,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     if (
       stopReason === FinishReason.STOP &&
       endTag &&
-      !responseText.endsWith(endTag)
+      !responseText.trimEnd().endsWith(endTag)
     ) {
       this.logger.debug(
         `Model stopped naturally but didn't include end tag. Appending ${endTag}.`,

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -36,7 +36,6 @@ import {
   takeTail,
   PARTIAL_TEXT_TAIL_MAX,
 } from '@common/errors/sdkErrorUtils';
-import replacementEngine from '@replacement/engine';
 import type { FileLocation, MediaAttachmentKind } from '@shared/schemas';
 import type {
   ToolFileAttachment,
@@ -716,7 +715,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     const rawResponseText = extractNonThinkingText(parts, true);
 
     // For TOOL CALL ONLY RESPONSE this happens sometimes, we don't want to log it
-    let responseText = replacementEngine.applyAll(rawResponseText);
+    let responseText = this.postProcessResponse(rawResponseText);
 
     const usage = responseObject.usageMetadata;
     const stopReason: FinishReason =

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -37,7 +37,6 @@ import {
   PARTIAL_TEXT_TAIL_MAX,
 } from '@common/errors/sdkErrorUtils';
 import type { ToolDefinition } from '@model';
-import replacementEngine from '@replacement/engine';
 import type { FileLocation, MediaAttachmentKind } from '@shared/schemas';
 import type {
   ToolFileAttachment,
@@ -953,7 +952,7 @@ export class ModelHandlerGoogleInteractions extends ModelHandler<
       .map((s) => joinTextContent(s.content ?? []))
       .join('');
 
-    let responseText = replacementEngine.applyAll(rawText);
+    let responseText = this.postProcessResponse(rawText);
     const usage = responseObject.usage;
     // Map the Interactions terminal *status* to the canonical Google chat
     // FinishReason the shared stop/continue logic understands (mirrors the

--- a/src/agent/modelHandlers/modelHandlerValidation.ts
+++ b/src/agent/modelHandlers/modelHandlerValidation.ts
@@ -14,7 +14,7 @@ import type {
   ExtractResponseResult,
   SdkToolCall,
 } from '@agent/types/ModelHandlerContracts';
-import type { ResponseTextPostProcessor } from '@agent/runtime/responseTextProcessing';
+import type { ResponseTextProcessing } from '@agent/runtime/responseTextProcessing';
 import type { ProviderStopReason } from '@agent/types/StopReasonTypes';
 import type { FileLocation, MediaAttachmentKind } from '@shared/schemas';
 import type {
@@ -134,9 +134,9 @@ export class ModelHandlerValidation extends ModelHandler<
 > {
   constructor(
     config: ModelConfig,
-    postProcessResponse?: ResponseTextPostProcessor,
+    responseTextProcessing?: ResponseTextProcessing,
   ) {
-    super(config, postProcessResponse);
+    super(config, responseTextProcessing);
     this.capabilities.supportsVision = false;
     this.capabilities.supportsFunctionCalling = true;
     this.capabilities.supportsAssistantPrefill = false;

--- a/src/agent/modelHandlers/modelHandlerValidation.ts
+++ b/src/agent/modelHandlers/modelHandlerValidation.ts
@@ -14,8 +14,8 @@ import type {
   ExtractResponseResult,
   SdkToolCall,
 } from '@agent/types/ModelHandlerContracts';
+import type { ResponseTextPostProcessor } from '@agent/runtime/responseTextProcessing';
 import type { ProviderStopReason } from '@agent/types/StopReasonTypes';
-import replacementEngine from '@replacement/engine';
 import type { FileLocation, MediaAttachmentKind } from '@shared/schemas';
 import type {
   ToolFileAttachment,
@@ -132,8 +132,11 @@ export class ModelHandlerValidation extends ModelHandler<
   unknown,
   ValidationResponse
 > {
-  constructor(config: ModelConfig) {
-    super(config);
+  constructor(
+    config: ModelConfig,
+    postProcessResponse?: ResponseTextPostProcessor,
+  ) {
+    super(config, postProcessResponse);
     this.capabilities.supportsVision = false;
     this.capabilities.supportsFunctionCalling = true;
     this.capabilities.supportsAssistantPrefill = false;
@@ -211,12 +214,8 @@ export class ModelHandlerValidation extends ModelHandler<
   }
 
   extractResponse(responseObject: ValidationResponse): ExtractResponseResult {
-    // Apply text cleanup here like every other handler's extractResponse. The
-    // response cycle relies on this single per-handler pass (it no longer
-    // re-applies cleanup itself), so a handler that returned raw text would
-    // silently skip cleanup on the reflection path.
     return {
-      text: replacementEngine.applyAll(responseObject.text),
+      text: this.postProcessResponse(responseObject.text),
       usage: responseObject.usage,
       stopReason: responseObject.stopReason,
     };

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -908,7 +908,7 @@ export class ModelHandlerOpenAI<
       this.logger.warn(
         'Using direct response format (streaming style) as fallback',
       );
-      let newResponse = classified.content.trim();
+      let newResponse = this.normalizeResponseText(classified.content);
       const { stopReason, usage } = classified;
 
       // Only restore the end tag when it was configured as an API-level
@@ -933,7 +933,7 @@ export class ModelHandlerOpenAI<
     this.logger.debug(`Stop reason: ${stopReason}`);
     let newResponse = '';
     if (choice.message.content) {
-      newResponse = choice.message.content.trim();
+      newResponse = this.normalizeResponseText(choice.message.content);
     } else if (
       stopReason === OPENAI_CHAT_FINISH.TOOL_CALLS ||
       stopReason === OPENAI_CHAT_FINISH.FUNCTION_CALL ||

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -33,7 +33,6 @@ import {
   PARTIAL_TEXT_TAIL_MAX,
 } from '@common/errors/sdkErrorUtils';
 import type { ToolDefinition } from '@model';
-import replacementEngine from '@replacement/engine';
 import type { FileLocation, MediaAttachmentKind } from '@shared/schemas';
 import type {
   ToolFileAttachment,
@@ -923,7 +922,7 @@ export class ModelHandlerOpenAI<
         stopReason === OPENAI_CHAT_FINISH.STOP &&
           this.configuresEndTagStopSequence,
       );
-      newResponse = replacementEngine.applyAll(newResponse);
+      newResponse = this.postProcessResponse(newResponse);
 
       return { text: newResponse, usage, stopReason };
     }
@@ -962,7 +961,7 @@ export class ModelHandlerOpenAI<
       stopReason === OPENAI_CHAT_FINISH.STOP &&
         this.configuresEndTagStopSequence,
     );
-    newResponse = replacementEngine.applyAll(newResponse);
+    newResponse = this.postProcessResponse(newResponse);
 
     return { text: newResponse, usage: responseObject.usage, stopReason };
   }

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -47,7 +47,6 @@ import type {
   OpenAIResponseProviderCapabilities,
   ProviderCapabilityProfile,
 } from '@model/providerCapabilities';
-import replacementEngine from '@replacement/engine';
 import type { FileLocation, MediaAttachmentKind } from '@shared/schemas';
 import { DEFAULT_CORE_SETTINGS } from '@shared/schemas/coreSettings';
 import type {
@@ -2459,7 +2458,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     // stripped it. Forging the tag here would be pure speculation that could
     // mask genuinely incomplete output as done; the extraction layer already
     // tolerates a missing end tag.
-    newResponse = replacementEngine.applyAll(newResponse);
+    newResponse = this.postProcessResponse(newResponse);
 
     return { text: newResponse, usage, stopReason };
   }

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -2440,11 +2440,14 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         },
       );
     }
-    let newResponse = responseObject.output_text?.trim() ?? '';
-    if (!newResponse && Array.isArray(responseObject.output)) {
+    const providerOutputText = responseObject.output_text ?? '';
+    let newResponse = this.normalizeResponseText(providerOutputText);
+    if (!providerOutputText.trim() && Array.isArray(responseObject.output)) {
       // Mutates responseObject.output_text from output message parts.
       addOutputText(responseObject);
-      newResponse = responseObject.output_text?.trim() ?? '';
+      newResponse = this.normalizeResponseText(
+        responseObject.output_text ?? '',
+      );
     }
 
     const stopReason =

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -529,13 +529,14 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     let newResponse = '';
     const msg = choice.message;
     if (typeof msg.content === 'string') {
-      newResponse = msg.content.trim();
+      newResponse = this.normalizeResponseText(msg.content);
     } else if (Array.isArray(msg.content)) {
-      newResponse = (msg.content as ChatContentItems[])
-        .filter((p): p is { type: 'text'; text: string } => p.type === 'text')
-        .map((p) => p.text)
-        .join('')
-        .trim();
+      newResponse = this.normalizeResponseText(
+        (msg.content as ChatContentItems[])
+          .filter((p): p is { type: 'text'; text: string } => p.type === 'text')
+          .map((p) => p.text)
+          .join(''),
+      );
     } else if (
       stopReason === OPENAI_CHAT_FINISH.TOOL_CALLS ||
       (msg.toolCalls && msg.toolCalls.length > 0)

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -22,7 +22,6 @@ import {
   takeTail,
   PARTIAL_TEXT_TAIL_MAX,
 } from '@common/errors/sdkErrorUtils';
-import replacementEngine from '@replacement/engine';
 import type { FileLocation, MediaAttachmentKind } from '@shared/schemas';
 import type {
   ToolFileAttachment,
@@ -551,7 +550,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
       endTag,
       stopReason === OPENAI_CHAT_FINISH.STOP,
     );
-    newResponse = replacementEngine.applyAll(newResponse);
+    newResponse = this.postProcessResponse(newResponse);
 
     return {
       text: newResponse,

--- a/src/agent/modelHandlers/utils/fileContentUtils.ts
+++ b/src/agent/modelHandlers/utils/fileContentUtils.ts
@@ -6,7 +6,7 @@
 // Local imports
 import { type AgentTrace } from '@agent/trace';
 import type { AgentWorkspaceState } from '@agent/core/state/AgentWorkspaceState';
-import replacementEngine from '@replacement/engine';
+import type { ResponseTextPostProcessor } from '@agent/runtime/responseTextProcessing';
 import type { FileLocation } from '@shared/schemas';
 import { FlexibleFS } from '@utils/files';
 import { extractScratchpad } from '@utils/text/xmlUtils';
@@ -45,10 +45,11 @@ export async function prepareExistingOutputContent(
   outputLocation: FileLocation,
   workspaceState: AgentWorkspaceState,
   logger: AgentTrace,
+  postProcessResponse: ResponseTextPostProcessor,
 ): Promise<PreparedFileContent> {
   // Read and clean the file content
   let content = await FlexibleFS.read(outputLocation);
-  content = replacementEngine.applyAll(content);
+  content = postProcessResponse(content);
 
   // Extract any existing scratchpad content and log it
   const scratchpad = await extractScratchpad(content, 'scratchpad');

--- a/src/agent/modelHandlers/vscodelm/modelHandlerVscodeLm.ts
+++ b/src/agent/modelHandlers/vscodelm/modelHandlerVscodeLm.ts
@@ -8,7 +8,7 @@ import type {
   TokenCountOptions,
   VscodeLmToolCall,
 } from '@agent/types/ModelHandlerContracts';
-import type { ResponseTextPostProcessor } from '@agent/runtime/responseTextProcessing';
+import type { ResponseTextProcessing } from '@agent/runtime/responseTextProcessing';
 import { OPENAI_CHAT_FINISH } from '@agent/types/StopReasonTypes';
 import type { MediaEntry } from '@agent/utils/mediaTypes';
 import type { SdkErrorKind } from '@common/errors/sdkErrorUtils';
@@ -189,9 +189,9 @@ export class ModelHandlerVscodeLm extends ModelHandler<
 > {
   constructor(
     config: ModelConfig,
-    postProcessResponse?: ResponseTextPostProcessor,
+    responseTextProcessing?: ResponseTextProcessing,
   ) {
-    super(config, postProcessResponse);
+    super(config, responseTextProcessing);
     this.capabilities.supportsNativeAudio = false;
     this.capabilities.supportsNativePdf = false;
     this.capabilities.supportsAssistantPrefill = false;
@@ -332,7 +332,7 @@ export class ModelHandlerVscodeLm extends ModelHandler<
 
   extractResponse(response: VscodeLmResponse): ExtractResponseResult {
     return {
-      text: this.postProcessResponse(response.text.trim()),
+      text: this.postProcessResponse(this.normalizeResponseText(response.text)),
       usage: response.usage,
       stopReason: response.stopReason,
     };

--- a/src/agent/modelHandlers/vscodelm/modelHandlerVscodeLm.ts
+++ b/src/agent/modelHandlers/vscodelm/modelHandlerVscodeLm.ts
@@ -8,6 +8,7 @@ import type {
   TokenCountOptions,
   VscodeLmToolCall,
 } from '@agent/types/ModelHandlerContracts';
+import type { ResponseTextPostProcessor } from '@agent/runtime/responseTextProcessing';
 import { OPENAI_CHAT_FINISH } from '@agent/types/StopReasonTypes';
 import type { MediaEntry } from '@agent/utils/mediaTypes';
 import type { SdkErrorKind } from '@common/errors/sdkErrorUtils';
@@ -29,7 +30,6 @@ import {
   type LanguageModelToolCallPart,
   type LanguageModelToolResultPart,
 } from '@platform/languageModel';
-import replacementEngine from '@replacement/engine';
 import type { FileLocation, MediaAttachmentKind } from '@shared/schemas';
 import type {
   ToolFileAttachment,
@@ -187,8 +187,11 @@ export class ModelHandlerVscodeLm extends ModelHandler<
   VscodeLmResponse,
   LanguageModelDataPart
 > {
-  constructor(config: ModelConfig) {
-    super(config);
+  constructor(
+    config: ModelConfig,
+    postProcessResponse?: ResponseTextPostProcessor,
+  ) {
+    super(config, postProcessResponse);
     this.capabilities.supportsNativeAudio = false;
     this.capabilities.supportsNativePdf = false;
     this.capabilities.supportsAssistantPrefill = false;
@@ -329,7 +332,7 @@ export class ModelHandlerVscodeLm extends ModelHandler<
 
   extractResponse(response: VscodeLmResponse): ExtractResponseResult {
     return {
-      text: replacementEngine.applyAll(response.text.trim()),
+      text: this.postProcessResponse(response.text.trim()),
       usage: response.usage,
       stopReason: response.stopReason,
     };

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -284,6 +284,9 @@ async function assembleAgentLaunchContext(
     agentCategory: setting.agentCategory,
   };
 
+  // A delegated launch runs inside the parent run's context and therefore
+  // inherits its session policy; a root launch resolves the process default.
+  const session = input.session ?? currentSession();
   const modelHandlerCompatibilityKey =
     input.modelHandlerCompatibilityKey ??
     (await inferLaunchModelHandlerCompatibilityKey(executionId, config.model));
@@ -293,8 +296,13 @@ async function assembleAgentLaunchContext(
           modelConfig,
           modelHandlerCompatibilityKey,
           setting.agentCategory,
+          session.responseTextProcessing.postProcessResponse,
         )
-      : await createModelHandler(modelConfig, setting.agentCategory),
+      : await createModelHandler(
+          modelConfig,
+          setting.agentCategory,
+          session.responseTextProcessing.postProcessResponse,
+        ),
   );
 
   const streamId =
@@ -302,11 +310,6 @@ async function assembleAgentLaunchContext(
     reservedStreamId ??
     getStreamTabId(config.agent, fullConfig.model, { executionId });
 
-  // `currentSession()` (not `defaultSession()`): a delegated launch runs inside
-  // the parent run's ALS, so it inherits the parent's session; a root launch
-  // runs outside any ALS, so it resolves to the process default. Either way the
-  // child is tracked in the same session as its launcher.
-  const session = input.session ?? currentSession();
   const transcriptWriter = await session.transcripts.loadAndAcquireWriter(
     streamId,
     executionId,

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -296,12 +296,12 @@ async function assembleAgentLaunchContext(
           modelConfig,
           modelHandlerCompatibilityKey,
           setting.agentCategory,
-          session.responseTextProcessing.postProcessResponse,
+          session.responseTextProcessing,
         )
       : await createModelHandler(
           modelConfig,
           setting.agentCategory,
-          session.responseTextProcessing.postProcessResponse,
+          session.responseTextProcessing,
         ),
   );
 

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -7,7 +7,7 @@ import {
   internalValidationModelHandlerEnvName,
   shouldUseInternalValidationModelHandler,
 } from '@agent/runtime/internalValidationOverride';
-import type { ResponseTextPostProcessor } from '@agent/runtime/responseTextProcessing';
+import type { ResponseTextProcessing } from '@agent/runtime/responseTextProcessing';
 import {
   CodexAuthError,
   formatCodexAuthUnavailableMessage,
@@ -49,7 +49,7 @@ const CHANNEL = 'ModelFactory';
 
 type ModelHandlerConstructor = new (
   config: ModelConfig,
-  postProcessResponse?: ResponseTextPostProcessor,
+  responseTextProcessing?: ResponseTextProcessing,
 ) => ModelHandler<ProviderMessage>;
 
 type ProviderHandlerLoader = () => Promise<ModelHandlerConstructor>;
@@ -427,7 +427,7 @@ function withCompatibilityRoutingMode(
 export async function createModelHandler(
   originalConfig: ModelConfig,
   agentCategory?: AgentCategory,
-  postProcessResponse?: ResponseTextPostProcessor,
+  responseTextProcessing?: ResponseTextProcessing,
 ): Promise<ModelHandler> {
   const config = withShortModelName(originalConfig);
   const useOpenRouter = getUseOpenRouter();
@@ -445,7 +445,7 @@ export async function createModelHandler(
     compatibilityKey,
     useOpenRouter,
     { allowCodexSubscriptionOverride: true, agentCategory },
-    postProcessResponse,
+    responseTextProcessing,
   );
 }
 
@@ -458,7 +458,7 @@ export async function createModelHandlerForCompatibilityKey(
   originalConfig: ModelConfig,
   compatibilityKey: ModelHandlerCompatibilityKey,
   agentCategory?: AgentCategory,
-  postProcessResponse?: ResponseTextPostProcessor,
+  responseTextProcessing?: ResponseTextProcessing,
 ): Promise<ModelHandler> {
   const routedConfig = withCompatibilityRoutingMode(
     withShortModelName(originalConfig),
@@ -474,7 +474,7 @@ export async function createModelHandlerForCompatibilityKey(
         compatibilityKey === 'ModelHandlerOpenAIResponse',
       agentCategory,
     },
-    postProcessResponse,
+    responseTextProcessing,
   );
 }
 
@@ -486,7 +486,7 @@ async function createModelHandlerForResolvedCompatibilityKey(
     allowCodexSubscriptionOverride: boolean;
     agentCategory: AgentCategory | undefined;
   },
-  postProcessResponse?: ResponseTextPostProcessor,
+  responseTextProcessing?: ResponseTextProcessing,
 ): Promise<ModelHandler> {
   if (
     compatibilityKey !== 'ModelHandlerValidation' &&
@@ -528,7 +528,7 @@ async function createModelHandlerForResolvedCompatibilityKey(
       const { ModelHandlerCodex } =
         await import('@agent/modelHandlers/openai/modelHandlerCodex');
       return finalizeModelHandler(
-        new ModelHandlerCodex(config, postProcessResponse),
+        new ModelHandlerCodex(config, responseTextProcessing),
         'ModelHandlerOpenAIResponse',
       );
     }
@@ -604,7 +604,7 @@ async function createModelHandlerForResolvedCompatibilityKey(
       const { ModelHandlerValidation } =
         await import('@agent/modelHandlers/modelHandlerValidation');
       return withModelHandlerCompatibilityKey(
-        new ModelHandlerValidation(config, postProcessResponse),
+        new ModelHandlerValidation(config, responseTextProcessing),
         'ModelHandlerValidation',
       );
     }
@@ -614,7 +614,7 @@ async function createModelHandlerForResolvedCompatibilityKey(
       const { ModelHandlerOpenAIResponse } =
         await import('@agent/modelHandlers/openai/modelHandlerOpenAIResponse');
       return finalizeModelHandler(
-        new ModelHandlerOpenAIResponse(config, postProcessResponse),
+        new ModelHandlerOpenAIResponse(config, responseTextProcessing),
         'ModelHandlerOpenAIResponse',
       );
     }
@@ -624,7 +624,7 @@ async function createModelHandlerForResolvedCompatibilityKey(
       const { ModelHandlerGoogleInteractions } =
         await import('@agent/modelHandlers/google/modelHandlerGoogleInteractions');
       return finalizeModelHandler(
-        new ModelHandlerGoogleInteractions(config, postProcessResponse),
+        new ModelHandlerGoogleInteractions(config, responseTextProcessing),
         'ModelHandlerGoogleInteractions',
       );
     }
@@ -640,7 +640,7 @@ async function createModelHandlerForResolvedCompatibilityKey(
       return finalizeModelHandler(
         new ModelHandlerOpenRouterNative(
           { ...config, openrouterFullName },
-          postProcessResponse,
+          responseTextProcessing,
         ),
         'ModelHandlerOpenRouterNative',
       );
@@ -656,7 +656,7 @@ async function createModelHandlerForResolvedCompatibilityKey(
       const HandlerClass = await route.load();
       logger.debug(CHANNEL, `Using Handler: ${HandlerClass.name}`);
       return finalizeModelHandler(
-        new HandlerClass(config, postProcessResponse),
+        new HandlerClass(config, responseTextProcessing),
         route.compatibilityKey,
       );
     }

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -7,6 +7,7 @@ import {
   internalValidationModelHandlerEnvName,
   shouldUseInternalValidationModelHandler,
 } from '@agent/runtime/internalValidationOverride';
+import type { ResponseTextPostProcessor } from '@agent/runtime/responseTextProcessing';
 import {
   CodexAuthError,
   formatCodexAuthUnavailableMessage,
@@ -48,6 +49,7 @@ const CHANNEL = 'ModelFactory';
 
 type ModelHandlerConstructor = new (
   config: ModelConfig,
+  postProcessResponse?: ResponseTextPostProcessor,
 ) => ModelHandler<ProviderMessage>;
 
 type ProviderHandlerLoader = () => Promise<ModelHandlerConstructor>;
@@ -425,6 +427,7 @@ function withCompatibilityRoutingMode(
 export async function createModelHandler(
   originalConfig: ModelConfig,
   agentCategory?: AgentCategory,
+  postProcessResponse?: ResponseTextPostProcessor,
 ): Promise<ModelHandler> {
   const config = withShortModelName(originalConfig);
   const useOpenRouter = getUseOpenRouter();
@@ -442,6 +445,7 @@ export async function createModelHandler(
     compatibilityKey,
     useOpenRouter,
     { allowCodexSubscriptionOverride: true, agentCategory },
+    postProcessResponse,
   );
 }
 
@@ -454,6 +458,7 @@ export async function createModelHandlerForCompatibilityKey(
   originalConfig: ModelConfig,
   compatibilityKey: ModelHandlerCompatibilityKey,
   agentCategory?: AgentCategory,
+  postProcessResponse?: ResponseTextPostProcessor,
 ): Promise<ModelHandler> {
   const routedConfig = withCompatibilityRoutingMode(
     withShortModelName(originalConfig),
@@ -469,6 +474,7 @@ export async function createModelHandlerForCompatibilityKey(
         compatibilityKey === 'ModelHandlerOpenAIResponse',
       agentCategory,
     },
+    postProcessResponse,
   );
 }
 
@@ -480,6 +486,7 @@ async function createModelHandlerForResolvedCompatibilityKey(
     allowCodexSubscriptionOverride: boolean;
     agentCategory: AgentCategory | undefined;
   },
+  postProcessResponse?: ResponseTextPostProcessor,
 ): Promise<ModelHandler> {
   if (
     compatibilityKey !== 'ModelHandlerValidation' &&
@@ -521,7 +528,7 @@ async function createModelHandlerForResolvedCompatibilityKey(
       const { ModelHandlerCodex } =
         await import('@agent/modelHandlers/openai/modelHandlerCodex');
       return finalizeModelHandler(
-        new ModelHandlerCodex(config),
+        new ModelHandlerCodex(config, postProcessResponse),
         'ModelHandlerOpenAIResponse',
       );
     }
@@ -597,7 +604,7 @@ async function createModelHandlerForResolvedCompatibilityKey(
       const { ModelHandlerValidation } =
         await import('@agent/modelHandlers/modelHandlerValidation');
       return withModelHandlerCompatibilityKey(
-        new ModelHandlerValidation(config),
+        new ModelHandlerValidation(config, postProcessResponse),
         'ModelHandlerValidation',
       );
     }
@@ -607,7 +614,7 @@ async function createModelHandlerForResolvedCompatibilityKey(
       const { ModelHandlerOpenAIResponse } =
         await import('@agent/modelHandlers/openai/modelHandlerOpenAIResponse');
       return finalizeModelHandler(
-        new ModelHandlerOpenAIResponse(config),
+        new ModelHandlerOpenAIResponse(config, postProcessResponse),
         'ModelHandlerOpenAIResponse',
       );
     }
@@ -617,7 +624,7 @@ async function createModelHandlerForResolvedCompatibilityKey(
       const { ModelHandlerGoogleInteractions } =
         await import('@agent/modelHandlers/google/modelHandlerGoogleInteractions');
       return finalizeModelHandler(
-        new ModelHandlerGoogleInteractions(config),
+        new ModelHandlerGoogleInteractions(config, postProcessResponse),
         'ModelHandlerGoogleInteractions',
       );
     }
@@ -631,7 +638,10 @@ async function createModelHandlerForResolvedCompatibilityKey(
       const { ModelHandlerOpenRouterNative } =
         await import('@agent/modelHandlers/openrouter/modelHandlerOpenRouterNative');
       return finalizeModelHandler(
-        new ModelHandlerOpenRouterNative({ ...config, openrouterFullName }),
+        new ModelHandlerOpenRouterNative(
+          { ...config, openrouterFullName },
+          postProcessResponse,
+        ),
         'ModelHandlerOpenRouterNative',
       );
     }
@@ -646,7 +656,7 @@ async function createModelHandlerForResolvedCompatibilityKey(
       const HandlerClass = await route.load();
       logger.debug(CHANNEL, `Using Handler: ${HandlerClass.name}`);
       return finalizeModelHandler(
-        new HandlerClass(config),
+        new HandlerClass(config, postProcessResponse),
         route.compatibilityKey,
       );
     }

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -64,6 +64,10 @@ import {
   repairRestartedStreams,
   RestartRepairRetryScheduler,
 } from './restartRepair';
+import {
+  createNeutralResponseTextProcessing,
+  type ResponseTextProcessing,
+} from './responseTextProcessing';
 
 const logger = createChannelTrace('sessionHandle');
 
@@ -119,6 +123,7 @@ export type SessionHandleInit = Pick<SessionHandle, 'transcripts'> & {
       | 'flushers'
       | 'interactions'
       | 'modelRetries'
+      | 'responseTextProcessing'
       | 'workflowControls'
     >
   >;
@@ -150,6 +155,8 @@ export class SessionHandle {
   readonly approvals: SessionApprovals;
   /** Coordinates recovery probes for model routes shared by parallel runs. */
   readonly modelRetries: ModelRetryGate;
+  /** Host policy for provider-output cleanup and continuation joining. */
+  readonly responseTextProcessing: ResponseTextProcessing;
   /**
    * Session-owned bridge from a workflow-script grandchild's execution id to
    * its run's engine skip/retry control. Populated by the workflow-script
@@ -207,6 +214,8 @@ export class SessionHandle {
     this.interactions = interactions;
     this.approvals = approvals;
     this.modelRetries = init.modelRetries ?? new ModelRetryGate();
+    this.responseTextProcessing =
+      init.responseTextProcessing ?? createNeutralResponseTextProcessing();
     this.workflowControls =
       init.workflowControls ?? new WorkflowControlRegistry();
     // Every session owns exactly one trace-flusher map. There is no

--- a/src/agent/runtime/helperModel.ts
+++ b/src/agent/runtime/helperModel.ts
@@ -9,7 +9,10 @@
 import type { ModelHandler } from '@agent/modelHandlers/ModelHandler';
 import { auxiliaryRetry } from '@agent/modelHandlers/support/auxiliaryRetry';
 import { createModelHandler } from '@agent/runtime/ModelFactory';
-import { currentSession } from '@agent/runtime/SessionHandle';
+import {
+  currentSession,
+  type SessionHandle,
+} from '@agent/runtime/SessionHandle';
 import { getModelUnavailableReason } from '@model/computeModelOptions';
 import { resolveRuntimeModelConfig } from '@model/runtimeModelRegistry';
 
@@ -28,7 +31,9 @@ export type HelperModelResult =
   { kit: HelperModelKit } | { kit: undefined; reason: string };
 
 /** Resolve the configured helper model, create a non-streaming handler, and obtain a client. */
-export async function createHelperModelKit(): Promise<HelperModelResult> {
+export async function createHelperModelKit(
+  session: SessionHandle = currentSession(),
+): Promise<HelperModelResult> {
   const modelName = getHelperModelName();
 
   const reason = await getModelUnavailableReason(modelName);
@@ -47,7 +52,7 @@ export async function createHelperModelKit(): Promise<HelperModelResult> {
   const handler = await createModelHandler(
     modelConfig,
     undefined,
-    currentSession().responseTextProcessing.postProcessResponse,
+    session.responseTextProcessing,
   );
   handler.setOutputStreaming(false);
   handler.setProgressViewEnabled(false);

--- a/src/agent/runtime/helperModel.ts
+++ b/src/agent/runtime/helperModel.ts
@@ -9,6 +9,7 @@
 import type { ModelHandler } from '@agent/modelHandlers/ModelHandler';
 import { auxiliaryRetry } from '@agent/modelHandlers/support/auxiliaryRetry';
 import { createModelHandler } from '@agent/runtime/ModelFactory';
+import { currentSession } from '@agent/runtime/SessionHandle';
 import { getModelUnavailableReason } from '@model/computeModelOptions';
 import { resolveRuntimeModelConfig } from '@model/runtimeModelRegistry';
 
@@ -43,7 +44,11 @@ export async function createHelperModelKit(): Promise<HelperModelResult> {
     };
   }
 
-  const handler = await createModelHandler(modelConfig);
+  const handler = await createModelHandler(
+    modelConfig,
+    undefined,
+    currentSession().responseTextProcessing.postProcessResponse,
+  );
   handler.setOutputStreaming(false);
   handler.setProgressViewEnabled(false);
 

--- a/src/agent/runtime/responseTextProcessing.ts
+++ b/src/agent/runtime/responseTextProcessing.ts
@@ -19,7 +19,7 @@ export interface ResponseTextProcessing {
 }
 
 /** Preserve provider text when no host-specific post-processor is supplied. */
-export function preserveResponseText(text: string): string {
+function preserveResponseText(text: string): string {
   return text;
 }
 

--- a/src/agent/runtime/responseTextProcessing.ts
+++ b/src/agent/runtime/responseTextProcessing.ts
@@ -1,0 +1,40 @@
+/** Optional host policy for text returned by a provider. */
+export type ResponseTextPostProcessor = (text: string) => string;
+
+/**
+ * Host policy for provider-output cleanup and joining continued responses.
+ *
+ * The package defaults are deliberately neutral and deterministic: provider
+ * text is returned unchanged, and adjacent non-whitespace text is separated
+ * by one space. TeXRA hosts may inject their LaTeX-specific behavior.
+ */
+export interface ResponseTextProcessing {
+  readonly postProcessResponse: ResponseTextPostProcessor;
+  readonly connectResponseText: (
+    previous: string,
+    next: string,
+  ) => Promise<string>;
+}
+
+/** Preserve provider text when no host-specific post-processor is supplied. */
+export function preserveResponseText(text: string): string {
+  return text;
+}
+
+async function connectResponseText(
+  previous: string,
+  next: string,
+): Promise<string> {
+  if (!previous || !next || /\s$/.test(previous) || /^\s/.test(next)) {
+    return '';
+  }
+  return ' ';
+}
+
+/** Create neutral package defaults when a host supplies no text policy. */
+export function createNeutralResponseTextProcessing(): ResponseTextProcessing {
+  return {
+    postProcessResponse: preserveResponseText,
+    connectResponseText,
+  };
+}

--- a/src/agent/runtime/responseTextProcessing.ts
+++ b/src/agent/runtime/responseTextProcessing.ts
@@ -9,6 +9,8 @@ export type ResponseTextPostProcessor = (text: string) => string;
  * by one space. TeXRA hosts may inject their LaTeX-specific behavior.
  */
 export interface ResponseTextProcessing {
+  /** Normalize provider text only when the host explicitly requests it. */
+  readonly normalizeResponseText: ResponseTextPostProcessor;
   readonly postProcessResponse: ResponseTextPostProcessor;
   readonly connectResponseText: (
     previous: string,
@@ -34,6 +36,7 @@ async function connectResponseText(
 /** Create neutral package defaults when a host supplies no text policy. */
 export function createNeutralResponseTextProcessing(): ResponseTextProcessing {
   return {
+    normalizeResponseText: preserveResponseText,
     postProcessResponse: preserveResponseText,
     connectResponseText,
   };

--- a/src/agent/runtime/textEnhancement.ts
+++ b/src/agent/runtime/textEnhancement.ts
@@ -5,6 +5,7 @@ import { isNonEmptyString } from '@utils/core';
 import { extractTextFromTag } from '@utils/text/xmlUtils';
 import { renderPolishPrompt } from './polishModel';
 import { createHelperModelKit, runHelperModelCompletion } from './helperModel';
+import type { SessionHandle } from './SessionHandle';
 
 const CHANNEL = 'TextEnhancement';
 
@@ -48,12 +49,13 @@ function formatFileContext(ctx: FileContext): string {
 export async function polishTextWithAI(
   text: string,
   fileContext?: FileContext,
+  session?: SessionHandle,
 ): Promise<{ success: boolean; text: string; error?: string }> {
   try {
     const fileContextString = fileContext ? formatFileContext(fileContext) : '';
     const prompt = await renderPolishPrompt(fileContextString, text);
 
-    const helperResult = await createHelperModelKit();
+    const helperResult = await createHelperModelKit(session);
     if (!helperResult.kit) {
       throw new Error(helperResult.reason);
     }

--- a/src/latex/texraResponseTextProcessing.ts
+++ b/src/latex/texraResponseTextProcessing.ts
@@ -2,12 +2,13 @@ import type { ResponseTextProcessing } from '@agent/runtime/responseTextProcessi
 import replacementEngine from '@replacement/engine';
 
 /** TeXRA's LaTeX-aware provider-output policy, injected by application hosts. */
-export const texraResponseTextProcessing: ResponseTextProcessing = {
-  normalizeResponseText: (text) => text.trim(),
-  postProcessResponse: (text) => replacementEngine.applyAll(text),
-  connectResponseText: async (previous, next) => {
-    const { bestConnectionMethod } =
-      await import('@agent/runtime/textConnection');
-    return (await bestConnectionMethod(previous, next)).connector;
-  },
-};
+export const texraResponseTextProcessing: ResponseTextProcessing =
+  Object.freeze<ResponseTextProcessing>({
+    normalizeResponseText: (text) => text.trim(),
+    postProcessResponse: (text) => replacementEngine.applyAll(text),
+    connectResponseText: async (previous, next) => {
+      const { bestConnectionMethod } =
+        await import('@agent/runtime/textConnection');
+      return (await bestConnectionMethod(previous, next)).connector;
+    },
+  });

--- a/src/latex/texraResponseTextProcessing.ts
+++ b/src/latex/texraResponseTextProcessing.ts
@@ -1,0 +1,12 @@
+import type { ResponseTextProcessing } from '@agent/runtime/responseTextProcessing';
+import replacementEngine from '@replacement/engine';
+
+/** TeXRA's LaTeX-aware provider-output policy, injected by application hosts. */
+export const texraResponseTextProcessing: ResponseTextProcessing = {
+  postProcessResponse: (text) => replacementEngine.applyAll(text),
+  connectResponseText: async (previous, next) => {
+    const { bestConnectionMethod } =
+      await import('@agent/runtime/textConnection');
+    return (await bestConnectionMethod(previous, next)).connector;
+  },
+};

--- a/src/latex/texraResponseTextProcessing.ts
+++ b/src/latex/texraResponseTextProcessing.ts
@@ -3,6 +3,7 @@ import replacementEngine from '@replacement/engine';
 
 /** TeXRA's LaTeX-aware provider-output policy, injected by application hosts. */
 export const texraResponseTextProcessing: ResponseTextProcessing = {
+  normalizeResponseText: (text) => text.trim(),
   postProcessResponse: (text) => replacementEngine.applyAll(text),
   connectResponseText: async (previous, next) => {
     const { bestConnectionMethod } =

--- a/src/test-kernel/agent/ResponseCycleContinuation.vitest.ts
+++ b/src/test-kernel/agent/ResponseCycleContinuation.vitest.ts
@@ -203,6 +203,54 @@ describe('response cycle continuation phases', () => {
     expect(action).toBe(FlowTransition.COMPLETE);
   });
 
+  it('uses the owning session policy to join continued responses', async () => {
+    const connectResponseText = vi.fn(async () => '\n');
+    const workspace = AgentWorkspaceState.create();
+    workspace.assembly.accumulatedOutput = 'left';
+    workspace.assembly.lastResponse = 'left';
+    const shared = createShared({ responseObject: {} });
+    const services = {
+      runScope: {
+        session: {
+          responseTextProcessing: { connectResponseText },
+        },
+      },
+      round: { responseTimeMs: 0 },
+      workspace,
+      logger: {
+        openStage: () => ({ run: (run: () => unknown) => run() }),
+        debug: vi.fn(),
+        info: vi.fn(),
+      },
+      modelHandler: {
+        processThinkingBlock: vi.fn(() => null),
+        getStreamingConfig: vi.fn(() => false),
+        extractResponse: vi.fn(() => ({
+          text: 'right',
+          usage: {},
+          stopReason: ANTHROPIC_STOP.END_TURN,
+        })),
+        normalizeUsage: vi.fn(() => undefined),
+      },
+    } as unknown as ResponseCycleServices<unknown>;
+    const node = getProcessNode().setServices(services);
+
+    const prepResult = await node.prep(shared);
+    const execResult = await node.exec(prepResult);
+
+    expect(connectResponseText).toHaveBeenCalledExactlyOnceWith(
+      'left',
+      'right',
+    );
+    expect(execResult).toMatchObject({
+      kind: 'success',
+      value: {
+        bestConnector: '\n',
+        updatedAccumulatedOutput: 'left\nright',
+      },
+    });
+  });
+
   it('forces compaction for an Anthropic overflow with empty assistant text', async () => {
     const shared = createShared({
       stopReason: ANTHROPIC_STOP.MODEL_CONTEXT_WINDOW_EXCEEDED,

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerGoogleGenAI.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerGoogleGenAI.vitest.ts
@@ -627,6 +627,26 @@ describe('ModelHandlerGoogleGenAI streaming failure diagnostics', () => {
   });
 });
 
+describe('ModelHandlerGoogleGenAI response extraction', () => {
+  it('preserves trailing whitespace without duplicating an existing end tag', () => {
+    const handler = createGoogleGenAIHandler();
+    const response = new GenerateContentResponse();
+    response.candidates = [
+      {
+        content: {
+          role: 'model',
+          parts: [createPartFromText('answer</documents>\n')],
+        },
+        finishReason: FinishReason.STOP,
+      } as any,
+    ];
+
+    expect(handler.extractResponse(response, '</documents>').text).toBe(
+      'answer</documents>\n',
+    );
+  });
+});
+
 describe('ModelHandlerGoogleGenAI.shouldContinue', () => {
   const handler = createGoogleGenAIHandler();
 

--- a/src/test-kernel/agent/modelHandlers/ResponseTextProcessing.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ResponseTextProcessing.vitest.ts
@@ -1,0 +1,60 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+import { MODEL_CONFIGS } from 'llm-zoo';
+
+// Local imports
+import { ModelHandlerValidation } from '@agent/modelHandlers/modelHandlerValidation';
+import { createNeutralResponseTextProcessing } from '@agent/runtime/responseTextProcessing';
+import { texraResponseTextProcessing } from '@latex/texraResponseTextProcessing';
+
+const RAW_PROVIDER_TEXT = '$\\mathrm{Tr}$ remains provider text.';
+const RESPONSE = {
+  text: RAW_PROVIDER_TEXT,
+  usage: {
+    completion_tokens: 0,
+    prompt_tokens: 0,
+    total_tokens: 0,
+  },
+  stopReason: 'stop' as const,
+};
+
+describe('response text processing', () => {
+  it('returns provider output unchanged when no processor is supplied', () => {
+    const handler = new ModelHandlerValidation(MODEL_CONFIGS.gpt54);
+
+    expect(handler.extractResponse(RESPONSE).text).toBe(RAW_PROVIDER_TEXT);
+  });
+
+  it('applies an explicitly supplied processor exactly once', () => {
+    const postProcessResponse = vi.fn((text: string) => `[${text}]`);
+    const handler = new ModelHandlerValidation(
+      MODEL_CONFIGS.gpt54,
+      postProcessResponse,
+    );
+
+    expect(handler.extractResponse(RESPONSE).text).toBe(
+      `[${RAW_PROVIDER_TEXT}]`,
+    );
+    expect(postProcessResponse).toHaveBeenCalledExactlyOnceWith(
+      RAW_PROVIDER_TEXT,
+    );
+  });
+
+  it('joins continuation text deterministically without a helper model', async () => {
+    const processing = createNeutralResponseTextProcessing();
+
+    await expect(processing.connectResponseText('left', 'right')).resolves.toBe(
+      ' ',
+    );
+    await expect(
+      processing.connectResponseText('left ', 'right'),
+    ).resolves.toBe('');
+    await expect(processing.connectResponseText('', 'right')).resolves.toBe('');
+  });
+
+  it('keeps TeXRA replacement behavior in the application adapter', () => {
+    expect(
+      texraResponseTextProcessing.postProcessResponse(RAW_PROVIDER_TEXT),
+    ).toBe('$\\Tr$ remains provider text.');
+  });
+});

--- a/src/test-kernel/agent/modelHandlers/ResponseTextProcessing.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ResponseTextProcessing.vitest.ts
@@ -1,11 +1,14 @@
 // Third-party imports
 import { describe, expect, it, vi } from 'vitest';
-import { MODEL_CONFIGS } from 'llm-zoo';
+import { MODEL_CONFIGS, ModelProvider } from 'llm-zoo';
 
 // Local imports
+import { noopTrace } from '@agent/trace';
 import { ModelHandlerValidation } from '@agent/modelHandlers/modelHandlerValidation';
+import { ModelHandlerOpenAI } from '@agent/modelHandlers/openai/modelHandlerOpenAI';
 import { createNeutralResponseTextProcessing } from '@agent/runtime/responseTextProcessing';
 import { texraResponseTextProcessing } from '@latex/texraResponseTextProcessing';
+import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 
 const RAW_PROVIDER_TEXT = '$\\mathrm{Tr}$ remains provider text.';
 const RESPONSE = {
@@ -27,10 +30,11 @@ describe('response text processing', () => {
 
   it('applies an explicitly supplied processor exactly once', () => {
     const postProcessResponse = vi.fn((text: string) => `[${text}]`);
-    const handler = new ModelHandlerValidation(
-      MODEL_CONFIGS.gpt54,
+    const handler = new ModelHandlerValidation(MODEL_CONFIGS.gpt54, {
+      normalizeResponseText: (text) => text,
       postProcessResponse,
-    );
+      connectResponseText: async () => ' ',
+    });
 
     expect(handler.extractResponse(RESPONSE).text).toBe(
       `[${RAW_PROVIDER_TEXT}]`,
@@ -38,6 +42,30 @@ describe('response text processing', () => {
     expect(postProcessResponse).toHaveBeenCalledExactlyOnceWith(
       RAW_PROVIDER_TEXT,
     );
+  });
+
+  it('preserves OpenAI Chat Completions whitespace by default', () => {
+    const handler = new ModelHandlerOpenAI(
+      buildTestModelConfig({
+        provider: ModelProvider.OPENAI,
+        capabilities: { supportsReasoning: true, supportsVision: false },
+      }),
+    );
+    handler.setLogger({ ...noopTrace });
+
+    const result = handler.extractResponse(
+      {
+        choices: [
+          {
+            message: { content: '  indented text\n' },
+            finish_reason: 'stop',
+          },
+        ],
+      },
+      '',
+    );
+
+    expect(result.text).toBe('  indented text\n');
   });
 
   it('joins continuation text deterministically without a helper model', async () => {
@@ -53,8 +81,11 @@ describe('response text processing', () => {
   });
 
   it('keeps TeXRA replacement behavior in the application adapter', () => {
-    expect(
-      texraResponseTextProcessing.postProcessResponse(RAW_PROVIDER_TEXT),
-    ).toBe('$\\Tr$ remains provider text.');
+    const normalized = texraResponseTextProcessing.normalizeResponseText(
+      ` ${RAW_PROVIDER_TEXT}\n`,
+    );
+    expect(texraResponseTextProcessing.postProcessResponse(normalized)).toBe(
+      '$\\Tr$ remains provider text.',
+    );
   });
 });

--- a/src/test-kernel/agent/modelHandlers/ResponseTextProcessing.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ResponseTextProcessing.vitest.ts
@@ -81,6 +81,8 @@ describe('response text processing', () => {
   });
 
   it('keeps TeXRA replacement behavior in the application adapter', () => {
+    expect(Object.isFrozen(texraResponseTextProcessing)).toBe(true);
+
     const normalized = texraResponseTextProcessing.normalizeResponseText(
       ` ${RAW_PROVIDER_TEXT}\n`,
     );

--- a/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
@@ -138,11 +138,13 @@ describe('AgentLaunchContext', () => {
       toolUseAgentKeys: ['builtInToolUse:orchestrator'],
     };
     const postProcessResponse = vi.fn((text: string) => text);
+    const responseTextProcessing = {
+      normalizeResponseText: (text: string) => text,
+      postProcessResponse,
+      connectResponseText: async () => ' ',
+    };
     const session = createTestSession({
-      responseTextProcessing: {
-        postProcessResponse,
-        connectResponseText: async () => ' ',
-      },
+      responseTextProcessing,
     });
     const detachEvents = session.events.subscribe(() => undefined);
     const detachStatus = session.status.onDidChange(({ status }) => {
@@ -193,7 +195,7 @@ describe('AgentLaunchContext', () => {
         delegationAgentScope,
       });
       expect(mocks.createHandler.mock.calls.at(-1)?.at(3)).toBe(
-        postProcessResponse,
+        responseTextProcessing,
       );
       expect(endStage).toHaveBeenCalledExactlyOnceWith(RUN_OUTCOME.FAILED);
       expect(handler.dispose).toHaveBeenCalledOnce();

--- a/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
@@ -137,7 +137,13 @@ describe('AgentLaunchContext', () => {
       workflowAgentKeys: ['builtInWorkflow:correct'],
       toolUseAgentKeys: ['builtInToolUse:orchestrator'],
     };
-    const session = createTestSession();
+    const postProcessResponse = vi.fn((text: string) => text);
+    const session = createTestSession({
+      responseTextProcessing: {
+        postProcessResponse,
+        connectResponseText: async () => ' ',
+      },
+    });
     const detachEvents = session.events.subscribe(() => undefined);
     const detachStatus = session.status.onDidChange(({ status }) => {
       if (status === STREAM_PHASE.FAILED) order.push('terminal');
@@ -186,6 +192,9 @@ describe('AgentLaunchContext', () => {
       expect(mocks.buildVars.mock.calls.at(-1)?.at(6)).toEqual({
         delegationAgentScope,
       });
+      expect(mocks.createHandler.mock.calls.at(-1)?.at(3)).toBe(
+        postProcessResponse,
+      );
       expect(endStage).toHaveBeenCalledExactlyOnceWith(RUN_OUTCOME.FAILED);
       expect(handler.dispose).toHaveBeenCalledOnce();
       expect(session.status.get('late-assembly-stream')).toBe(

--- a/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionHandle.vitest.ts
@@ -236,6 +236,9 @@ describe('SessionHandle', () => {
       expect(fresh.followUps).not.toBe(defaultSession().followUps);
       expect(fresh.approvals).not.toBe(defaultSession().approvals);
       expect(fresh.modelRetries).not.toBe(defaultSession().modelRetries);
+      expect(fresh.responseTextProcessing).not.toBe(
+        defaultSession().responseTextProcessing,
+      );
       expect(fresh.workflowControls).not.toBe(
         defaultSession().workflowControls,
       );

--- a/src/test-kernel/agent/runtime/TextEnhancementSession.vitest.ts
+++ b/src/test-kernel/agent/runtime/TextEnhancementSession.vitest.ts
@@ -1,0 +1,40 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports
+import type { SessionHandle } from '@agent/runtime/SessionHandle';
+import { polishTextWithAI } from '@agent/runtime/textEnhancement';
+
+const mocks = vi.hoisted(() => ({
+  createHelperModelKit: vi.fn(),
+  renderPolishPrompt: vi.fn(async () => 'polish prompt'),
+  runHelperModelCompletion: vi.fn(),
+}));
+
+vi.mock('@agent/runtime/helperModel', () => ({
+  createHelperModelKit: mocks.createHelperModelKit,
+  runHelperModelCompletion: mocks.runHelperModelCompletion,
+}));
+
+vi.mock('@agent/runtime/polishModel', () => ({
+  renderPolishPrompt: mocks.renderPolishPrompt,
+}));
+
+describe('text enhancement session ownership', () => {
+  it('passes an explicit host session to helper-model creation', async () => {
+    const session = {} as SessionHandle;
+    const kit = { handler: {}, client: {}, modelName: 'helper' };
+    mocks.createHelperModelKit.mockResolvedValue({ kit });
+    mocks.runHelperModelCompletion.mockResolvedValue(
+      '<corrected_text>polished</corrected_text>',
+    );
+
+    await expect(
+      polishTextWithAI('draft', undefined, session),
+    ).resolves.toEqual({
+      success: true,
+      text: 'polished',
+    });
+    expect(mocks.createHelperModelKit).toHaveBeenCalledExactlyOnceWith(session);
+  });
+});

--- a/src/test-kernel/cli/RunChatSignalOwnership.vitest.mts
+++ b/src/test-kernel/cli/RunChatSignalOwnership.vitest.mts
@@ -70,6 +70,7 @@ vi.doMock(cliRequire.resolve('ink'), () => ({
 
 vi.mock('@latex/texraResponseTextProcessing', () => ({
   texraResponseTextProcessing: {
+    normalizeResponseText: (text: string) => text,
     postProcessResponse: (text: string) => text,
     connectResponseText: async () => ' ',
   },

--- a/src/test-kernel/cli/RunChatSignalOwnership.vitest.mts
+++ b/src/test-kernel/cli/RunChatSignalOwnership.vitest.mts
@@ -68,6 +68,13 @@ vi.doMock(cliRequire.resolve('ink'), () => ({
   useWindowSize: vi.fn(),
 }));
 
+vi.mock('@latex/texraResponseTextProcessing', () => ({
+  texraResponseTextProcessing: {
+    postProcessResponse: (text: string) => text,
+    connectResponseText: async () => ' ',
+  },
+}));
+
 vi.mock('@cli/runtime/initPlatform', () => ({
   handOffCliShutdownSignalHandlers: mocks.handOffCliShutdownSignalHandlers,
   initCliPlatform: mocks.initCliPlatform,
@@ -449,7 +456,7 @@ describe('runChat signal ownership wiring', () => {
       kill.mockRestore();
       exit.mockRestore();
     }
-  });
+  }, 20_000);
 
   it('constructs the exact initial run configuration for a resumed team', async () => {
     const exitTui = deferred();
@@ -537,5 +544,5 @@ describe('runChat signal ownership wiring', () => {
       loadAgentsSpy.mockRestore();
       getVisibleAgentsSpy.mockRestore();
     }
-  });
+  }, 20_000);
 });


### PR DESCRIPTION
## Summary

Make provider-response processing an explicit session policy rather than an implicit property of every model handler. The embeddable agent package now preserves provider text, including its leading and trailing whitespace, and joins continuation text deterministically by default. The VS Code, desktop, and CLI applications inject TeXRA's existing normalization, LaTeX replacement, and helper-model joining behavior at their composition roots.

This also propagates the owning session's policy to delegated launches, helper-model handlers, and handlers created by in-session model switching. Desktop follow-up polishing passes its process session explicitly because that host intentionally has no default-session singleton.

Closes #9334.

## Issue acceptance gates

- A model handler constructed without a policy returns provider output unmodified, including surrounding whitespace.
- The neutral continuation policy is deterministic and does not call a helper model.
- TeXRA's extension, desktop, CLI, and CLI harness inject the existing LaTeX-aware behavior.
- Every production handler-construction path either inherits its owning session policy or deliberately uses the neutral default.
- The existing replacement behavior remains covered, and the full replacement and repository test suites pass.

## Single source of truth

`src/agent/runtime/responseTextProcessing.ts` owns the neutral `ResponseTextProcessing` contract and defaults. Each `SessionHandle` owns one policy instance, so root runs, delegated runs, helper calls, continuations, and model switches agree on the same decision.

`src/latex/texraResponseTextProcessing.ts` is the single TeXRA application policy. It preserves the current response normalization and replacement engine, and loads the helper-model connector only when a continuation requires it.

## Duplication and abstraction budget

Nine model-handler-area imports of the replacement engine were removed. All handlers now use the base handler's normalization and post-processing members, and continuation joining uses the owning session policy.

The two added policy modules own genuine boundary decisions: neutral package behavior and TeXRA application behavior. No pass-through wrapper or second factory layer was added.

## Net elements (R6)

- Files: 4 added, 0 deleted; 32 files changed.
- Exported symbols: 4 added, 0 removed.
- Types: 1 interface and 1 type alias added; 0 classes or enums added or removed.
- Lines: 421 added, 72 deleted; net +349.

## Consumer counts (R8)

n/a — this change does not delete or reroute an event emission path, command, or exported API consumer. It reroutes internal response-text processing through a session-owned policy.

## Host impact

Extension: injects the TeXRA response-text policy when creating the default runtime session; user-visible behavior is unchanged.

Desktop: injects the same policy into the process session and explicitly passes that session to follow-up polishing; user-visible behavior is unchanged.

CLI: injects the same policy into persistent, ephemeral, and harness sessions; user-visible behavior is unchanged.

The embeddable `@texra-ai/agent` package now returns provider text unchanged and uses deterministic continuation joining unless a host supplies another policy.

## Scheduled refactoring

None for this bounded provider-response decision. Other replacement-engine uses in output and editing tools are outside the `extractResponse` and response-cycle paths ruled by #9334.

## Validation

- `npm run format`
- `npm run lint`
- `npm run compile:safe`
- `npm test` — 799 files passed, 1 skipped; 7,953 tests passed, 4 skipped
- Focused response-processing, continuation, helper-model, text-enhancement session, model-switch, session, launch-context, CLI startup, desktop bridge, provider-handler, and architecture suites
- Published package artifact validation — 679 declarations and 70 external packages
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all provider `extractResponse` paths and continuation assembly; incorrect host wiring could change LaTeX output or whitespace, though TeXRA hosts are explicitly updated and new tests cover neutral vs TeXRA behavior.
> 
> **Overview**
> **Response text processing is now a `SessionHandle` policy** instead of every model handler calling the replacement engine and trimming directly. Handlers use injected `normalizeResponseText` / `postProcessResponse`; the response cycle joins continuations via `session.responseTextProcessing.connectResponseText` rather than always calling the helper-model connector.
> 
> **Neutral defaults** live in `responseTextProcessing.ts`: provider text is preserved (including whitespace), and multi-chunk continuations get a deterministic single-space join with no helper model. **TeXRA apps** (CLI, desktop, extension, harness) pass `texraResponseTextProcessing` at session init—trim, `replacementEngine.applyAll`, and the existing `bestConnectionMethod` for joins—so user-visible LaTeX behavior stays the same.
> 
> The policy is threaded through **model handler construction** (`ModelFactory`, launches, mid-run model switches, helper-model kits) and **desktop follow-up polish** now passes the process session into `polishTextWithAI` so helper runs inherit the same policy. Google GenAI end-tag detection uses `trimEnd()` so trailing whitespace after an end tag is not double-appended.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5bb659ba3c2b662413316ca35812c9969ba69c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


