### PR TITLE
refactor(cli,desktop): dedupe UI-audit findings across TUI and webview

### DIFF
--- a/packages/cli/src/chat/tui/forms/_shared/selectWindow.ts
+++ b/packages/cli/src/chat/tui/forms/_shared/selectWindow.ts
@@ -3,6 +3,8 @@
 // fixed number of chrome rows (border, title, description, key hints). The only
 // per-form difference is that chrome-row count, so the policy lives here once.
 
+import { isCompactRows } from '@cli/chat/tui/ui/theme';
+
 export interface SelectWindowSize {
   readonly maxVisibleItems: number | undefined;
   readonly showOverflow: boolean;
@@ -11,7 +13,7 @@ export interface SelectWindowSize {
 export const COMPACT_FORM_MAX_ROWS = 9;
 
 export function isCompactFormRows(availableRows: number | undefined): boolean {
-  return availableRows !== undefined && availableRows <= COMPACT_FORM_MAX_ROWS;
+  return isCompactRows(availableRows, COMPACT_FORM_MAX_ROWS);
 }
 
 /**

--- a/packages/cli/src/chat/tui/modals/PlanApproval.tsx
+++ b/packages/cli/src/chat/tui/modals/PlanApproval.tsx
@@ -12,6 +12,7 @@ import { COLOR_INFO } from '../ui/colors';
 import {
   clampModalWidth,
   CONFIRM_CARD_HORIZONTAL_DECORATION,
+  isCompactRows,
 } from '../ui/theme';
 import { confirmCardCompactChromeRows } from './ConfirmCardState';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
@@ -48,7 +49,7 @@ export function isCompactPlanApprovalRows(
   return (
     availableRows !== undefined &&
     availableRows > 0 &&
-    availableRows <= compactMaxRows
+    isCompactRows(availableRows, compactMaxRows)
   );
 }
 

--- a/packages/cli/src/chat/tui/modals/UserQuestion.tsx
+++ b/packages/cli/src/chat/tui/modals/UserQuestion.tsx
@@ -14,27 +14,23 @@ import {
   USER_QUESTION_SKIPPED_FEEDBACK,
   userQuestionDecision,
 } from './UserQuestionState';
-import { COLOR_HINT, COLOR_SUCCESS } from '../ui/colors';
+import { COLOR_SUCCESS } from '../ui/colors';
 import {
   clampModalWidth,
   CONFIRM_CARD_HORIZONTAL_DECORATION,
+  isCompactRows,
 } from '../ui/theme';
 import { BaseTextInput } from '../input/BaseTextInput';
-import { isEscapeInput, isPlainReturnInput } from '../input/inputKeys';
+import { isEscapeInput } from '../input/inputKeys';
 import {
   previousRowsText,
   selectVisibleInlineOverflowText,
 } from '../render/overflowText';
 import { wrapAnsiToWidth } from '../render/ansiWrap';
 import { clipToWidth, textDisplayWidth } from '../render/terminalText';
-import {
-  nextWrappingHighlightIndex,
-  Select,
-  visibleSelectRange,
-} from '../ui/Select';
+import { Select } from '../ui/Select';
 import { KeyHints, type KeyHint } from '../ui/KeyHints';
 import { BorderedPanel } from '../ui/BorderedPanel';
-import { POINTER, TICK } from '../ui/glyphs';
 import type { ApprovalDecision } from '../state/approvalQueue';
 
 export interface UserQuestionProps {
@@ -106,10 +102,7 @@ function userQuestionChoiceHints({
 export function isCompactUserQuestionRows(
   availableRows: number | undefined,
 ): boolean {
-  return (
-    availableRows !== undefined &&
-    availableRows <= COMPACT_USER_QUESTION_MAX_ROWS
-  );
+  return isCompactRows(availableRows, COMPACT_USER_QUESTION_MAX_ROWS);
 }
 
 export function userQuestionChoiceRowsBudget({
@@ -330,73 +323,13 @@ interface MultiSelectQuestionProps {
 function MultiSelectQuestion(
   props: MultiSelectQuestionProps,
 ): React.JSX.Element {
-  const [highlight, setHighlight] = useState(0);
   const [selected, setSelected] = useState<readonly string[]>([]);
   const options = props.question.options;
   const maxVisibleOptions = userQuestionChoiceRowsBudget({
     availableRows: props.availableRows,
     optionCount: options.length,
   });
-  const visibleRange = visibleSelectRange({
-    itemCount: options.length,
-    highlight,
-    maxVisibleItems: maxVisibleOptions,
-  });
-  const visibleOptions = options.slice(visibleRange.start, visibleRange.end);
-  const inlineOverflowText = selectVisibleInlineOverflowText({
-    hiddenAfter: options.length - visibleRange.end,
-    hiddenBefore: visibleRange.start,
-    showOverflow: false,
-    visibleItemCount: visibleOptions.length,
-  });
-
-  useInput((input, key) => {
-    // Esc cancels; Ctrl+C is owned by the App's unified handler (exits the app).
-    if (isEscapeInput(input, key)) {
-      props.onCancel();
-      return;
-    }
-    if (key.upArrow) {
-      setHighlight((h) =>
-        nextWrappingHighlightIndex({
-          direction: -1,
-          highlight: h,
-          itemCount: options.length,
-        }),
-      );
-      return;
-    }
-    if (key.downArrow) {
-      setHighlight((h) =>
-        nextWrappingHighlightIndex({
-          direction: 1,
-          highlight: h,
-          itemCount: options.length,
-        }),
-      );
-      return;
-    }
-    if (input === ' ') {
-      const option = options[highlight];
-      if (option) {
-        setSelected((s) => toggleUserQuestionSelection(s, option.label));
-      }
-      return;
-    }
-    if (isPlainReturnInput(input, key)) {
-      props.onSubmit([...selected]);
-      return;
-    }
-    const digit = Number(input);
-    if (Number.isInteger(digit) && digit >= 1 && digit <= options.length) {
-      const index = digit - 1;
-      const option = options[index];
-      setHighlight(index);
-      if (option) {
-        setSelected((s) => toggleUserQuestionSelection(s, option.label));
-      }
-    }
-  });
+  const selectedValues = useMemo(() => new Set(selected), [selected]);
 
   return (
     <QuestionShell
@@ -415,42 +348,21 @@ function MultiSelectQuestion(
         { key: 'Esc', action: 'skip' },
       ]}
     >
-      {visibleOptions.map((option, offset) => {
-        const optionIndex = visibleRange.start + offset;
-        const focused = optionIndex === highlight;
-        const checked = selected.includes(option.label);
-        const showInlineOverflow = focused && inlineOverflowText;
-        return (
-          <Box key={option.label} minWidth={0}>
-            <Box flexShrink={0}>
-              <Text color={focused ? COLOR_HINT : undefined}>
-                {focused ? POINTER : ' '} {checked ? TICK : ' '}{' '}
-                {optionIndex + 1}.{' '}
-              </Text>
-            </Box>
-            <Box flexShrink={0} maxWidth={24}>
-              <Text
-                color={focused ? COLOR_HINT : undefined}
-                wrap="truncate-end"
-              >
-                {option.label}
-              </Text>
-            </Box>
-            {showInlineOverflow ? (
-              <Box flexShrink={0}>
-                <Text dimColor>{` — ${inlineOverflowText}`}</Text>
-              </Box>
-            ) : null}
-            {option.description && !showInlineOverflow ? (
-              <Box minWidth={0} flexShrink={1}>
-                <Text dimColor wrap="truncate-end">
-                  {` — ${option.description}`}
-                </Text>
-              </Box>
-            ) : null}
-          </Box>
-        );
-      })}
+      <Select
+        mode="multi"
+        items={options.map((option) => ({
+          value: option.label,
+          label: option.label,
+          description: option.description ?? undefined,
+        }))}
+        maxVisibleItems={maxVisibleOptions}
+        selectedValues={selectedValues}
+        onToggle={(label) =>
+          setSelected((s) => toggleUserQuestionSelection(s, label))
+        }
+        onSelect={() => props.onSubmit([...selected])}
+        onCancel={props.onCancel}
+      />
     </QuestionShell>
   );
 }

--- a/packages/cli/src/chat/tui/panes/InputBar.tsx
+++ b/packages/cli/src/chat/tui/panes/InputBar.tsx
@@ -39,6 +39,7 @@ import {
 } from '../commands/slashRegistry';
 import {
   reverseSearchOpen as reverseSearchOpenSignal,
+  setTransientNotice,
   slashPaletteOpen,
 } from '../state/cliState';
 import { useSignal } from '../state/useSignal';
@@ -123,7 +124,6 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
   const keyboardActive = props.keyboardActive ?? true;
   const [value, setValueState] = useState('');
   const reverseSearchOpen = useSignal(reverseSearchOpenSignal);
-  const [attachNotice, setAttachNotice] = useState<string | null>(null);
   const draftValueRef = useRef(value);
   // ↑/↓ history browsing (shell-style). `index` walks the persisted entries,
   // `savedDraft` restores whatever was typed before browsing began, and
@@ -226,7 +226,7 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
         const result = await attachClipboardImage();
         if (!attempt.isCurrent()) return null;
         if (!result.ok) {
-          setAttachNotice(result.reason);
+          setTransientNotice(result.reason);
           return null;
         }
         return attachmentsRef.current.addPastedImage({
@@ -236,20 +236,13 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
         });
       } catch (error) {
         if (attempt.isCurrent()) {
-          setAttachNotice(`Image paste failed: ${toErrorMessage(error)}`);
+          setTransientNotice(`Image paste failed: ${toErrorMessage(error)}`);
         }
         return null;
       }
     },
     [],
   );
-
-  // Clear the transient paste notice a few seconds after it appears.
-  useEffect(() => {
-    if (attachNotice === null) return;
-    const timer = setTimeout(() => setAttachNotice(null), 4000);
-    return () => clearTimeout(timer);
-  }, [attachNotice]);
 
   // Listen for Ctrl-R *outside* the text input — Ink emits the keystroke
   // to every `useInput` consumer, and BaseTextInput drops unhandled ctrl
@@ -424,7 +417,6 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
           onCancel={() => reverseSearchOpenSignal.set(false)}
         />
       ) : null}
-      {attachNotice ? <Text dimColor>{attachNotice}</Text> : null}
       <Box
         borderStyle="round"
         borderColor={COLOR_BORDER}
@@ -461,7 +453,7 @@ export function InputBar(props: InputBarProps): React.JSX.Element {
             transformPaste={transformPaste}
             onImagePaste={onImagePaste}
             onImagePasteError={(error) =>
-              setAttachNotice(`Image paste failed: ${toErrorMessage(error)}`)
+              setTransientNotice(`Image paste failed: ${toErrorMessage(error)}`)
             }
             onInputChunkSubmit={handleInputChunkSubmit}
             onSubmit={showPalette ? () => undefined : handleSubmit}

--- a/packages/cli/src/chat/tui/panes/QueuedFollowUpsPanel.tsx
+++ b/packages/cli/src/chat/tui/panes/QueuedFollowUpsPanel.tsx
@@ -1,8 +1,10 @@
 import { Box, Text } from 'ink';
 
 import { summarizeFollowupMessage } from '@shared/subagentFollowup';
+import { pluralize } from '@utils/text/stringUtils';
 
 import { COLOR_WARNING } from '../ui/colors';
+import { hiddenRowsText } from '../render/overflowText';
 import {
   textDisplayWidth,
   truncateSummaryToWidth,
@@ -74,7 +76,10 @@ export function queuedFollowUpPanelDisplay({
     rows.push({
       kind: 'overflow',
       text: truncateSummaryToWidth(
-        `… +${hiddenCount} more queued`,
+        hiddenRowsText(
+          hiddenCount,
+          pluralize(hiddenCount, 'queued follow-up', 'queued follow-ups'),
+        ),
         contentWidth,
       ),
     });

--- a/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
+++ b/packages/cli/src/chat/tui/panes/TodosPlanPanel.tsx
@@ -10,12 +10,13 @@ import {
   type TodoItem,
   type TodoStatus,
 } from '@shared/schemas';
-import { formatResultCount } from '@utils/text/stringUtils';
+import { pluralize } from '@utils/text/stringUtils';
 
 import {
   activeStreamId as activeStreamIdSignal,
   streams as streamsSignal,
 } from '../state/cliState';
+import { hiddenRowsText } from '../render/overflowText';
 import { useSignal } from '../state/useSignal';
 import { COLOR_HINT, COLOR_SUCCESS } from '../ui/colors';
 import { TODO_ACTIVE, TODO_DONE, TODO_PENDING } from '../ui/glyphs';
@@ -211,10 +212,12 @@ export function TodosPlanPanel(
         ))}
         {hiddenCount > 0 && rows.length < rowBudget ? (
           <Box height={1} minWidth={0} overflowY="hidden">
-            <Text
-              dimColor
-              wrap="truncate-end"
-            >{`… +${formatResultCount(hiddenCount, 'more todo/plan item')}`}</Text>
+            <Text dimColor wrap="truncate-end">
+              {hiddenRowsText(
+                hiddenCount,
+                pluralize(hiddenCount, 'todo/plan item', 'todo/plan items'),
+              )}
+            </Text>
           </Box>
         ) : null}
       </Box>

--- a/packages/cli/src/chat/tui/ui/Select.tsx
+++ b/packages/cli/src/chat/tui/ui/Select.tsx
@@ -56,11 +56,12 @@ export interface SelectProps<T> {
   readonly wrap?: boolean;
   /** Called when `wrap` is false and a move would cross the top/bottom edge. */
   readonly onBoundaryEscape?: (direction: -1 | 1) => void;
-  /** Defaults to `'single'`: Space and hotkeys select-and-close via `onSelect`.
-   *  In `'multi'`, Space and hotkeys instead toggle membership via `onToggle`
-   *  (caller owns the selected set and reads it back in its own `onSelect`,
-   *  which Enter still calls once to submit); the tick glyph reflects
-   *  `selectedValues` instead of `activeValue`. */
+  /** Defaults to `'single'`: hotkeys (1-9, then a-z) select-and-close via
+   *  `onSelect`; Enter does the same on the highlighted row; Space is
+   *  unhandled. In `'multi'`, Space and hotkeys instead toggle membership via
+   *  `onToggle` (caller owns the selected set and reads it back in its own
+   *  `onSelect`, which Enter still calls once to submit); the tick glyph
+   *  reflects `selectedValues` instead of `activeValue`. */
   readonly mode?: 'single' | 'multi';
   /** Required in `'multi'` mode: the set of currently-toggled-on values. */
   readonly selectedValues?: ReadonlySet<T>;

--- a/packages/cli/src/chat/tui/ui/Select.tsx
+++ b/packages/cli/src/chat/tui/ui/Select.tsx
@@ -56,6 +56,16 @@ export interface SelectProps<T> {
   readonly wrap?: boolean;
   /** Called when `wrap` is false and a move would cross the top/bottom edge. */
   readonly onBoundaryEscape?: (direction: -1 | 1) => void;
+  /** Defaults to `'single'`: Space and hotkeys select-and-close via `onSelect`.
+   *  In `'multi'`, Space and hotkeys instead toggle membership via `onToggle`
+   *  (caller owns the selected set and reads it back in its own `onSelect`,
+   *  which Enter still calls once to submit); the tick glyph reflects
+   *  `selectedValues` instead of `activeValue`. */
+  readonly mode?: 'single' | 'multi';
+  /** Required in `'multi'` mode: the set of currently-toggled-on values. */
+  readonly selectedValues?: ReadonlySet<T>;
+  /** Required in `'multi'` mode: called with the row's value on Space/hotkey. */
+  readonly onToggle?: (value: T) => void;
   readonly renderItem?: (
     item: SelectItem<T>,
     state: {
@@ -346,6 +356,11 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
         cancelAndDrop();
         return;
       }
+      if (props.mode === 'multi' && input === ' ') {
+        const choice = props.items[highlightRef.current];
+        if (choice && !choice.disabled) props.onToggle?.(choice.value);
+        return;
+      }
       if (isPlainReturnInput(input, key)) {
         const choice = props.items[highlightRef.current];
         if (choice && !choice.disabled) props.onSelect(choice.value);
@@ -356,9 +371,10 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
         cancelAndDrop();
         return;
       }
-      // Single-key jumps (1-9, then a-z) for direct selection. Ignore Ctrl
-      // chords: Ctrl+C exits the app through App's unified handler, and other
-      // Ctrl+<letter> chords were never meant as row hotkeys.
+      // Single-key jumps (1-9, then a-z) for direct selection (or, in multi
+      // mode, direct toggle). Ignore Ctrl chords: Ctrl+C exits the app through
+      // App's unified handler, and other Ctrl+<letter> chords were never
+      // meant as row hotkeys.
       if (!key.ctrl && props.hotkeys !== false) {
         const idx = selectIndexForHotkeyInput(input);
         if (idx != null && idx < props.items.length) {
@@ -366,7 +382,11 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
           if (choice && !choice.disabled) {
             highlightRef.current = idx;
             props.onHighlightChange?.(choice.value);
-            props.onSelect(choice.value);
+            if (props.mode === 'multi') {
+              props.onToggle?.(choice.value);
+            } else {
+              props.onSelect(choice.value);
+            }
           }
         }
       }
@@ -382,7 +402,10 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
       {visibleItems.map((item, offset) => {
         const i = visibleRange.start + offset;
         const focused = props.highlightedValue !== null && i === highlight;
-        const active = item.value === props.activeValue;
+        const active =
+          props.mode === 'multi'
+            ? (props.selectedValues?.has(item.value) ?? false)
+            : item.value === props.activeValue;
         const pointer = focused ? POINTER : ' ';
         const tick = active ? TICK : ' ';
         const hotkey = selectHotkeyForIndex(i);

--- a/packages/cli/src/chat/tui/ui/Select.tsx
+++ b/packages/cli/src/chat/tui/ui/Select.tsx
@@ -383,6 +383,10 @@ export function Select<T>(props: SelectProps<T>): React.JSX.Element {
             highlightRef.current = idx;
             props.onHighlightChange?.(choice.value);
             if (props.mode === 'multi') {
+              // Unlike single-select's onSelect, onToggle doesn't end this
+              // list's lifetime — it keeps rendering, so the visible pointer
+              // and scroll window must actually follow the hotkey press.
+              setHighlight(idx);
               props.onToggle?.(choice.value);
             } else {
               props.onSelect(choice.value);

--- a/packages/cli/src/chat/tui/ui/theme.ts
+++ b/packages/cli/src/chat/tui/ui/theme.ts
@@ -17,6 +17,20 @@ export function clampModalWidth(
   return Math.max(min, width);
 }
 
+/**
+ * Shared "below N rows, switch to compact chrome" predicate. Each modal/form
+ * still owns its own threshold constant (chrome differs per widget) and
+ * usually its own named wrapper (e.g. `isCompactPlanApprovalRows`) for
+ * call-site readability and any widget-specific threshold adjustment — this
+ * just names the one comparison every one of those wrappers makes.
+ */
+export function isCompactRows(
+  availableRows: number | undefined,
+  threshold: number,
+): boolean {
+  return availableRows !== undefined && availableRows <= threshold;
+}
+
 /** Columns consumed by the edit diff panel's side padding/gutter. */
 export const EDIT_DIFF_PADDING = 6;
 

--- a/packages/desktop/src/renderer/reviewPane.css
+++ b/packages/desktop/src/renderer/reviewPane.css
@@ -177,8 +177,14 @@
   gap: var(--wa-space-xs);
 }
 
-.desktop-review-empty wa-icon {
+.desktop-review-empty .empty-state-icon {
   font-size: var(--icon-size-l);
+}
+
+.desktop-review-empty .empty-state-title {
+  margin: 0;
+  font-size: inherit;
+  font-weight: var(--wa-font-weight-bold, bold);
 }
 
 .desktop-review-no-results {

--- a/packages/desktop/src/renderer/reviewPane.ts
+++ b/packages/desktop/src/renderer/reviewPane.ts
@@ -5,6 +5,7 @@ import '@progressView/frontend/components/TexraDiffView';
 import { html, nothing, render, type TemplateResult } from 'lit';
 
 import { DESKTOP_THEME_KIND, type DesktopThemeKind } from '@shared/schemas';
+import { renderEmptyState } from '@shared/wa/emptyState';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 import { buildEditorTree, type EditorTreeNode } from './editorTree';
@@ -145,12 +146,12 @@ export function createReviewPane(): ReviewPaneController {
             ${
               selected
                 ? diffView
-                : html`
-                    <div class="desktop-review-empty">
-                      ${waIcon('plus-minus')}
-                      <strong>No changes to review</strong>
-                    </div>
-                  `
+                : renderEmptyState({
+                    icon: 'plus-minus',
+                    title: 'No changes to review',
+                    headingTag: 'h3',
+                    className: 'desktop-review-empty',
+                  })
             }
           </main>
           <aside class="desktop-review-sidebar" aria-label="Changed files">

--- a/src/test-kernel/cli/QueuedFollowUpsPanel.vitest.mts
+++ b/src/test-kernel/cli/QueuedFollowUpsPanel.vitest.mts
@@ -85,7 +85,7 @@ describe('CLI queued follow-up panel display model', () => {
 
     expect(display.rows.map((row) => row.text)).toEqual([
       '1. first',
-      '… +2 more queued',
+      '... 2 queued follow-ups hidden',
     ]);
     expect(display.hiddenCount).toBe(2);
   });
@@ -97,7 +97,9 @@ describe('CLI queued follow-up panel display model', () => {
       width: 80,
     });
 
-    expect(display.rows.map((row) => row.text)).toEqual(['… +2 more queued']);
+    expect(display.rows.map((row) => row.text)).toEqual([
+      '... 2 queued follow-ups hidden',
+    ]);
     expect(display.hiddenCount).toBe(2);
   });
 


### PR DESCRIPTION
## Summary

Follow-up to a scheduled UI-consistency audit that surveyed the CLI Ink TUI and the Lit/Font-Awesome webview/desktop frontends for ad-hoc UI implementations and duplicated logic. This PR fixes the findings that are genuine, mechanically-verifiable duplications; the rest were investigated and left alone with reasons below (they turned out to be intentional or would require forcing an abstraction that doesn't actually fit).

## Issue acceptance gates

No tracked issue — this is a direct follow-up to the audit's own findings, delivered as a single PR per the request. Gates satisfied: every fix removes the duplication the audit named while preserving existing external behavior for all pre-existing callers (verified by full test suite + typecheck, see Validation).

## Single source of truth

- Paste/attach status text in the CLI now has one owner: `setTransientNotice`/`transientNotice` in `state/cliState.ts` (previously `InputBar` also had its own local `attachNotice` state + timer).
- The "N hidden" overflow marker text now has one owner: `hiddenRowsText` in `render/overflowText.ts` (previously `QueuedFollowUpsPanel` and `TodosPlanPanel` each hand-wrote their own phrasing).
- Multi-select list navigation now has one owner: `ui/Select.tsx`, extended with an optional `mode="multi"` (previously `MultiSelectQuestion` hand-rolled its own arrow-key/hotkey `useInput` loop alongside `SingleSelectQuestion`, which already used `Select`).
- The "below N rows → compact chrome" comparison now has one owner: `isCompactRows(rows, threshold)` in `ui/theme.ts` (previously three modules each repeated the same `rows <= threshold` check under a different name).
- Desktop's "No changes to review" state now goes through the same `renderEmptyState()` helper the extension's webviews already use, instead of hand-rolled markup.

## Duplication and abstraction budget

Removed: a second paste-notice timer, two divergent "N hidden" phrasings, a ~70-line duplicate list-navigation loop, and three copies of one comparison. Added: one new optional mode on `Select` (additive, default-`'single'` behavior byte-for-byte unchanged for every existing caller) and one small `isCompactRows` helper with a doc comment stating the invariant it owns (the single "rows ≤ threshold" comparison; callers keep their own threshold constants and any widget-specific adjustment, e.g. `isCompactPlanApprovalRows`'s goal-notice row bump). No new pass-through layers.

Left alone on purpose (forcing a fix here would either not be a real fix or would need visual verification this environment can't provide):
- `FileSelectGroup`'s compact inline "No files selected." placeholder — a different, correctly-scaled pattern from the hero `renderEmptyState()` (single-line list placeholder vs. full-page/section empty state); routing it through the hero component would be an oversized regression, not a fix.
- `.desktop-review-empty`/`.desktop-review-no-results` CSS — already a shared base rule plus two variants, not a duplicate.
- The `@keyframes spin`/`.spin` mirror between `litStyles.ts` (Lit `css`) and desktop's plain `styles.css` — already commented as an intentional mirror; unifying it needs a cross-bundler build change (Lit CSSResult vs. a plain CSS file loaded by Vite) that isn't worth the risk for ~10 lines.
- The static-icon-plus-CSS-animation loading indicator in desktop's `main.ts` vs. the animated `<wa-spinner>` convention elsewhere — on inspection this deliberately reuses the shared `.spin` CSS instead of pulling in the spinner component; not a defect.
- Unifying `confirmCardContentRowsBudget` / `userQuestionChoiceRowsBudget` / `computeSelectWindowSize` — surface-similar ("reserve chrome rows, clamp for a short terminal") but each has genuinely different arithmetic (title-wrapping vs. none, binary compact flag vs. threshold-crossing, overflow-marker row spending vs. none). Forcing a shared function here is exactly the single-caller-pretending-to-be-general pattern this repo's own abstraction-discipline rule bans.

## Net elements (R6)

Diffstat: 11 files changed, 109 insertions(+), 143 deletions(-), net **-34 LoC**.
Exported-symbol diff (`^[+-]export` over the diff): **+1** (`isCompactRows`), 0 removed. No new classes/interfaces/enums.

## Consumer counts (R8)

No emit path or export was deleted or re-routed to a different owner in a way that changes subscriber wiring:
- `Select`'s new props are additive and optional; all ~8 existing `<Select>` call sites (forms + `SingleSelectQuestion`) are unaffected — grepped and confirmed none pass `mode`, so all fall through to the untouched `'single'` branch.
- `isCompactPlanApprovalRows` / `isCompactUserQuestionRows` / `isCompactFormRows` keep their exported names and signatures; only their internal implementation now delegates to `isCompactRows`. Existing test imports of these three (`PlanApproval.vitest.mts`, `UserQuestion.vitest.mts`, `ModelListForm.vitest.mts`) needed no changes and still pass.
- n/a otherwise — no export was removed.

## Host impact

Extension: no functional change (only the shared `Select`/`overflowText`/`theme` modules it doesn't consume were touched elsewhere in the CLI package; the webview frontend itself is untouched).

Desktop: `reviewPane.ts`'s empty "no changes" state now renders through the shared `renderEmptyState()` helper with matching CSS added to `reviewPane.css`; visually equivalent (icon + bold title, centered), verified via the existing `DesktopReviewPane.vitest.mts` (asserts the text content) since this sandbox has no display to screenshot the Electron renderer.

CLI: paste-failure notices now surface in the status bar (directly below the input box, same immediate vicinity as before) instead of a line inside the input bar itself; multi-select questions now use the same list widget as single-select questions, gaining its `a`-`z` hotkey range past 9 options as a side effect.

## Scheduled refactoring

None — the two deferred items above (cross-bundler spin-keyframe sharing, and any future generalization of the row-budget helpers if a fourth widget ever needs genuinely identical math) aren't tracked as follow-ups since neither is a known defect today.

## Validation

- `npm run typecheck` — clean (all packages).
- `npm run lint` — clean (whole repo).
- `npm run check:dead-code-ratchet` — clean, 17 findings vs. 17 baseline (no new unused exports).
- `npx vitest run src/test-kernel/cli` — 149 files / 2006 tests passed.
- `npx vitest run src/test-kernel/desktop src/test-kernel/progressView src/test-kernel/shared` — 137 files / 1206 tests passed.
- Full `npm test` — 797 of 799 files passed; the 2 failures (`WorkflowScriptEngine` QuickJS memory-exhaustion timing, `SystemUtils` process-group abort) are pre-existing, timing/sandbox-sensitive, unrelated to any file in this diff, and reproduce identically in isolation on an unmodified checkout in this container.
- No interactive TUI/Electron rendering test exists in this repo for these components (confirmed: no `ink-testing-library` dependency, no rendered-modal test anywhere in `test-kernel/cli`) — verification for the `Select` multi-select behavior relied on careful manual trace of the new branches plus the full logic-level test suite above, consistent with this repo's existing testing depth for the TUI layer.

---

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_012S6hpxBqXo5FTSFBCpoYgF

---
_Generated by [Claude Code](https://claude.ai/code/session_012S6hpxBqXo5FTSFBCpoYgF)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly refactors and additive Select props; user-visible shifts are minor (notice placement, overflow copy, multi-select hotkeys past nine options).
> 
> **Overview**
> Follow-up to a UI-consistency audit: this PR removes duplicated TUI/desktop patterns without changing the overall feature set.
> 
> **CLI TUI:** Paste/attach failures now call shared **`setTransientNotice`** instead of **`InputBar`**’s local notice state and timer (notices show via the global transient notice path, e.g. status bar). **`hiddenRowsText`** replaces hand-written overflow strings in **`QueuedFollowUpsPanel`** and **`TodosPlanPanel`** (wording shifts to forms like `... 2 queued follow-ups hidden`). **`isCompactRows`** in **`theme.ts`** centralizes the `availableRows <= threshold` check used by form/modal compact helpers. **`Select`** gains optional **`mode="multi"`** (Space/hotkeys toggle, Enter submits); **`MultiSelectQuestion`** drops its custom **`useInput`** loop and renders **`Select`** instead—existing single-select callers stay on default **`single`** behavior.
> 
> **Desktop:** The review pane’s “No changes to review” empty state uses shared **`renderEmptyState()`** with matching CSS hooks instead of inline markup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bfa68fb354d9bd39a02b9734c1e6991376f5171. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
