### PR TITLE
feat(cli): explain the first-run setup-agent handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.39.10] - 2026-07-29
 
 ### Shared (all surfaces)
 
@@ -26,6 +26,54 @@ All notable changes to this project will be documented in this file.
 - **Concise workflow results** — completed workflow scripts now render one
   shared summary of phases, tasks, generated files, cost, duration, and rerun
   instructions instead of repeating the full run log.
+- **Interrupted runs no longer look stuck** — runs cut off by a crash or
+  force-quit are marked as interrupted when the session reopens, instead of
+  appearing to run forever.
+- **Accurate usage totals** — a malformed usage update can no longer silently
+  reset a run's accumulated token and cost totals to zero.
+
+### CLI
+
+#### New Features
+
+- **First-run handoff explained** — after the initial credential setup, the
+  chat session explains that the setup assistant is guiding the first run and
+  that `/agent` switches to another agent anytime, using the same wording as
+  the setup card in VS Code and the desktop app.
+
+#### Bug Fixes
+
+- **Leftover runs are cleaned up** — opening a CLI session removes runs left
+  behind by earlier interrupted sessions, matching the VS Code and desktop
+  behavior.
+
+### Extension (VS Code) and Desktop
+
+#### New Features
+
+- **Tidier progress view** — stream tabs are denser and the follow-up input is
+  larger, with the unused tab filter and clear-input controls removed; the
+  multi-agent settings now show a single combined Teams block.
+
+#### Bug Fixes
+
+- **Clearer account status** — an expired sign-in no longer shows as
+  "Connected"; the Account settings tab now shows a "Session expired" warning
+  with a sign-in prompt and surfaces server spending-check failures.
+
+### Desktop
+
+#### Bug Fixes
+
+- **Every session appears in the sidebar** — sessions no longer disappear from
+  the desktop sidebar because of a category filter saved in the progress view.
+- **Missing agents are flagged** — the desktop app now shows a banner when a
+  task references an agent that is not configured.
+- **Unsaved edits are protected** — the desktop app asks for confirmation
+  before closing the window or switching workspaces with unsaved file changes,
+  and canceling the close no longer loses those changes.
+- **Reloading the window no longer leaks sessions** — terminal and browser
+  sessions are cleaned up across reloads instead of being left behind.
 
 ## [0.39.9] - 2026-07-26
 

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -25,7 +25,10 @@ import { setCliAgentResumeHandler } from '@cli/runtime/agentResume';
 import { type CliContext, readCliVersion } from '@cli/runtime/cliContext';
 import { type CliToolUseResumeResolution } from '@cli/runtime/sessionResume';
 import { effectiveCliApiMode } from '@cli/runtime/apiAccessMode';
-import { firstRunSetupAgentOverride } from '@cli/onboarding/setupContinuation';
+import {
+  firstRunSetupAgentOverride,
+  SETUP_AGENT_HANDOFF_NOTICE,
+} from '@cli/onboarding/setupContinuation';
 import { resolveChatDefaults } from '@cli/runtime/chatDefaults';
 import { CliExitCode } from '@cli/runtime/exitCodes';
 import {
@@ -142,6 +145,12 @@ export interface RunChatInit {
   readonly agentOverride?: string;
   /** `--model` override from the CLI; falls through `resolveChatDefaults`. */
   readonly modelOverride?: string;
+  /**
+   * Display-only transcript notice shown at session start (never sent to the
+   * model). Callers that steer the session themselves — the first-run
+   * setup-agent handoff in `orchestrate` — use it to explain that steering.
+   */
+  readonly startupNotice?: string;
   /** Visible team identity when chat was launched from a multi-agent preset. */
   readonly teamName?: string;
   /** Multi-agent preset id when chat was launched from a team preset. */
@@ -392,6 +401,15 @@ export async function runChat(
   }
   if (modelSelection.notice) {
     appendLocalAssistantTranscript(modelSelection.notice);
+  }
+  // First-run handoff explanation: when the setup agent owns this session
+  // (decided here for `texra chat`, passed in by `orchestrate`), say so —
+  // display-only, so the agent waits for the user's first message.
+  const startupNotice =
+    init.startupNotice ??
+    (setupAgentOverride ? SETUP_AGENT_HANDOFF_NOTICE : undefined);
+  if (startupNotice) {
+    appendLocalAssistantTranscript(startupNotice);
   }
 
   const inputHistory = await loadInputHistory();

--- a/packages/cli/src/commands/orchestrate.ts
+++ b/packages/cli/src/commands/orchestrate.ts
@@ -10,7 +10,10 @@ import { readAgentSkillsEnabled } from '@shared/settingsView/handlers/agentSkill
 import { getFirstRunDone } from '@shared/state/onboardingState';
 import { updateConfig } from '@utils/config/configUtils';
 
-import { firstRunSetupAgentOverride } from '../onboarding/setupContinuation';
+import {
+  firstRunSetupAgentOverride,
+  SETUP_AGENT_HANDOFF_NOTICE,
+} from '../onboarding/setupContinuation';
 import { CliExitCode } from '../runtime/exitCodes';
 import { listCliHistoryEntries } from '../runtime/history';
 import { initInteractiveCliPlatform } from '../runtime/initPlatform';
@@ -154,6 +157,7 @@ async function runOrchestration(context: CliContext): Promise<number> {
     const { runChat } = await import('../chat/tui/runChatTui');
     const result = await runChat(context, {
       agentOverride: setupAgentOverride,
+      startupNotice: SETUP_AGENT_HANDOFF_NOTICE,
     });
     return result.exitCode;
   }

--- a/packages/cli/src/onboarding/setupContinuation.ts
+++ b/packages/cli/src/onboarding/setupContinuation.ts
@@ -7,6 +7,7 @@
 // platform global state and pass it in.
 
 import { SETUP_AGENT_NAME } from '@shared/constants/agents';
+import { ONBOARDING_SETUP_HANDOFF } from '@shared/copy/onboarding';
 
 export interface FirstRunSetupContinuationInputs {
   /** The first-run picker just configured a credential in this process. */
@@ -30,3 +31,12 @@ export function firstRunSetupAgentOverride(
   if (inputs.pinnedAgent?.trim()) return undefined;
   return SETUP_AGENT_NAME;
 }
+
+/**
+ * Local transcript notice shown when the setup agent takes over a first-run
+ * session. Display-only (appended via `appendLocalAssistantTranscript`) — it
+ * is never sent to the model, so the agent stays reactive instead of speaking
+ * first on its own. Built from the shared State 1 handoff sentence (same
+ * wording as the extension/desktop setup card) plus the CLI's own hint.
+ */
+export const SETUP_AGENT_HANDOFF_NOTICE = `${ONBOARDING_SETUP_HANDOFF} Tell it what you are working on — or switch to another agent anytime with /agent.`;

--- a/packages/extension/src/webview/frontend/components/OnboardingSetupCard.ts
+++ b/packages/extension/src/webview/frontend/components/OnboardingSetupCard.ts
@@ -5,7 +5,7 @@ import { LitElement, css, html, type TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
 import { designTokens, commonViewStyles } from '@shared/styles';
-import { ONBOARDING_NARRATIVE } from '@shared/copy/onboarding';
+import { ONBOARDING_SETUP_HANDOFF } from '@shared/copy/onboarding';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 import { MainViewEvents } from '../events';
@@ -72,7 +72,7 @@ export class OnboardingSetupCard extends LitElement {
       <wa-callout id="onboardingSetupCard" variant="brand">
         ${waIcon('rocket', { slot: 'icon' })}
         <span class="title">Credential ready</span>
-        <p class="copy">${ONBOARDING_NARRATIVE}</p>
+        <p class="copy">${ONBOARDING_SETUP_HANDOFF}</p>
         <div class="actions">
           <wa-button
             id="onboardingRunSetupButton"

--- a/src/shared/copy/onboarding.ts
+++ b/src/shared/copy/onboarding.ts
@@ -39,3 +39,13 @@ export const ONBOARDING_CHOICE_SKIP_LABEL = 'Skip for now';
  */
 export const ONBOARDING_NARRATIVE =
   'Run setup once: TeXRA checks LaTeX, applies the right agent team, and starts your first polish.';
+
+/**
+ * State 1 handoff sentence: a credential just landed and the setup assistant
+ * owns the next step. The CLI prints it as a transcript notice when the setup
+ * agent takes over the first-run session; the extension/desktop setup card
+ * shows it under the "Credential ready" title. Surface-specific hints (the
+ * CLI's `/agent`, the card's Run-setup button) stay in the surface.
+ */
+export const ONBOARDING_SETUP_HANDOFF =
+  "You're starting with the setup assistant: it checks your environment, applies the right agent team, and helps you run your first task.";


### PR DESCRIPTION
## Summary

After the first-run credential picker configures a credential, the CLI lands the user in a chat owned by the `setup` agent with no shell-level explanation — the only hint was the agent's own greeting, which depends on the model following its opening-move instruction. This PR adds a display-only transcript notice at the handoff (appended via `appendLocalAssistantTranscript`, never sent to the model, so the agent stays reactive instead of speaking first) and unifies the wording across all three surfaces on one shared State 1 sentence, `ONBOARDING_SETUP_HANDOFF`, in `@shared/copy/onboarding`. The extension/desktop setup card now renders that same sentence instead of the walkthrough narrative.

Also includes the 0.39.10 changelog preparation (second commit), covering the release's user-visible changes including this one.

## Issue acceptance gates

No tracking issue — direct user request. Gates satisfied: (1) first-run CLI handoff explained without a proactive model message; (2) wording consistent with the extension/desktop setup card; (3) explicit agent pins and `texra setup` unchanged.

## Single source of truth

`ONBOARDING_SETUP_HANDOFF` in `src/shared/copy/onboarding.ts` owns the State 1 handoff sentence for all surfaces, per that file's documented no-paraphrasing rule. `firstRunSetupAgentOverride` (`packages/cli/src/onboarding/setupContinuation.ts`) remains the single decision point for when the setup agent takes a first-run session.

## Duplication and abstraction budget

Avoided a third paraphrase of the State 1 copy: the CLI notice composes the shared sentence plus its surface-specific `/agent` hint, matching the copy file's rule that surface hints stay in the surface. No new abstraction — one string constant.

## Net elements (R6)

Not a refactor PR. 6 files changed (+95/−5): +2 exported symbols (`ONBOARDING_SETUP_HANDOFF`, `SETUP_AGENT_HANDOFF_NOTICE`), +1 optional `RunChatInit.startupNotice` field, no deletions.

## Consumer counts (R8)

`ONBOARDING_SETUP_HANDOFF`: 2 consumers (`setupContinuation.ts`, `OnboardingSetupCard.ts`). `SETUP_AGENT_HANDOFF_NOTICE`: 2 consumers (`runChatTui.tsx`, `orchestrate.ts`). `ONBOARDING_NARRATIVE` keeps its walkthrough consumer (`welcomeView.ts`). `RunChatInit` callers grepped: orchestrate, setup, chat/resume commands — all compile unchanged since the field is optional.

## Host impact

Extension: setup card copy now uses the shared State 1 sentence (same meaning, consistent wording).

Desktop: same card component — covered by the extension change.

CLI: new display-only transcript notice when the first-run setup agent takes the session (`texra` orchestrate and `texra chat` paths); `RunChatInit.startupNotice` threads the orchestrate handoff through chat startup.

## Scheduled refactoring

None.

## Validation

- `npx prettier` on changed files
- `npm run typecheck` (all five tsconfigs)
- `npm run lint` — no errors
- `npm run compile:fast` — bundle built
- Vitest targeted: OnboardingGate (15), OnboardingFunnel (22), RunChatSignalOwnership/RunChatConfig/SetupCommand/CliRootArgs (125) — all pass
- Full `npm test`: 799 files passed, 7,953 tests passed, 4 skipped

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding copy and display-only CLI transcript UX; no auth, persistence, or model-prompt behavior changes beyond local UI text.
> 
> **Overview**
> **First-run setup handoff** is explained in the CLI without prompting the model: when the setup agent owns a new session, a **display-only** local assistant line is appended to the transcript (never sent to the model), so users see why they landed on setup and can still send the first message themselves.
> 
> **Shared State 1 copy** — `ONBOARDING_SETUP_HANDOFF` in `@shared/copy/onboarding` is the single handoff sentence for CLI and extension/desktop. The VS Code **Credential ready** setup card uses that string instead of the walkthrough `ONBOARDING_NARRATIVE`. The CLI composes it with a surface-specific `/agent` hint via `SETUP_AGENT_HANDOFF_NOTICE`.
> 
> **Wiring** — optional `RunChatInit.startupNotice` lets `orchestrate` pass the notice explicitly; `texra chat` derives the same notice when `firstRunSetupAgentOverride` applies. **CHANGELOG** adds the **0.39.10** release entry (includes this change among broader release notes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1945abb7b8961f7608e30255920d63daa0ac9eef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->