### PR TITLE
refactor: unify second-tier progress handlers across hosts

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -880,14 +880,14 @@ export class DesktopProgressBridge {
         showInfo: async (message) => {
           await this.options.host.showInfoMessage(message);
         },
-        showError: async (message) => {
-          await this.options.host.showErrorMessage(message);
-        },
       },
       session: this.session,
       getTaskState: (stream) => this.state.snapshots.getTaskState(stream),
       restoreTaskState: async (taskState) => {
-        return this.restoreTaskState(taskState);
+        const restored = this.restoreTaskState(taskState);
+        if (!restored) {
+          await this.options.host.showErrorMessage('Failed to restore state');
+        }
       },
       applyFollowUpPlan: async (plan) => {
         await this.applyFollowUpPlan(plan);

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -896,8 +896,7 @@ export class DesktopProgressBridge {
         await this.applyFollowUpPolishResult(result);
       },
       onPolishError: (stream, error) => {
-        const message =
-          error instanceof Error ? error.message : `${error}`;
+        const message = error instanceof Error ? error.message : `${error}`;
         this.postToRenderer({
           command: PROGRESS_VIEW_COMMANDS.UPDATE_FOLLOW_UP_TEXT,
           stream,

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -17,7 +17,6 @@ import type { SessionHostInteractions } from '@agent/runtime/HostInteractions';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { polishTextWithAI } from '@agent/runtime/textEnhancement';
 import {
-  notifyFollowUpSent,
   presentFollowUpResult,
   submitFollowUp,
 } from '@agent/followUp/ToolUseFollowUp';
@@ -53,6 +52,10 @@ import {
   type WorkflowFileOperationRequest,
 } from '@controllers/progressView/ProgressWorkflowActionsController';
 import { ProgressViewHost } from '@controllers/progressView/ProgressViewHost';
+import {
+  createProgressViewSecondTierHandlers,
+  type ProgressViewSecondTierActions,
+} from '@controllers/progressView/ProgressViewCommandHandlers';
 import { buildMainViewState } from '@controllers/mainView/MainViewStateRestoreController';
 import {
   runCleanMultiple,
@@ -64,7 +67,6 @@ import {
 import {
   API_PROVIDERS,
   hasUsableApiKey,
-  isApiProvider,
   lookupApiKey,
 } from '@model/apiProviders';
 import {
@@ -541,26 +543,6 @@ export class DesktopProgressBridge {
     }
   }
 
-  private async processToolUseFollowUp(
-    data: {
-      stream: StreamTabId;
-      agent: string;
-      model: string;
-      initialQuestion?: string;
-    },
-    executeImmediately: boolean,
-  ): Promise<void> {
-    await this.applyFollowUpPlan(
-      await this.followUpController.planToolUseFollowUpForStream({
-        streamId: data.stream,
-        agent: data.agent,
-        model: data.model,
-        initialQuestion: data.initialQuestion,
-        executeImmediately,
-      }),
-    );
-  }
-
   /**
    * Carry out a plan from `ProgressFollowUpController`, the desktop counterpart
    * of the extension's `applyFollowUpPlan`. As documented on the plan type, the
@@ -889,8 +871,86 @@ export class DesktopProgressBridge {
   }
 
   private createProgressViewInboundHandlers(): DesktopProgressInboundHandlerRegistry {
+    const secondTierActions: ProgressViewSecondTierActions = {
+      workflowActions: this.workflowActions,
+      apiKeyRetry: this.apiKeyRetryController,
+      followUp: this.followUpController,
+      followUpPolish: this.followUpPolishController,
+      host: {
+        showInfo: async (message) => {
+          await this.options.host.showInfoMessage(message);
+        },
+        showError: async (message) => {
+          await this.options.host.showErrorMessage(message);
+        },
+      },
+      session: this.session,
+      getTaskState: (stream) => this.state.snapshots.getTaskState(stream),
+      restoreTaskState: async (taskState) => {
+        return this.restoreTaskState(taskState);
+      },
+      applyFollowUpPlan: async (plan) => {
+        await this.applyFollowUpPlan(plan);
+      },
+      applyPolishResult: async (result) => {
+        await this.applyFollowUpPolishResult(result);
+      },
+      onPolishError: (stream, error) => {
+        const message =
+          error instanceof Error ? error.message : `${error}`;
+        this.postToRenderer({
+          command: PROGRESS_VIEW_COMMANDS.UPDATE_FOLLOW_UP_TEXT,
+          stream,
+          kind: 'polishError',
+          text: null,
+          error: message,
+        });
+        this.logger.error(`Error polishing follow-up: ${message}`, {
+          data: toLogData(error),
+        });
+        void this.options.host.showErrorMessage(
+          `Error polishing follow-up: ${message}`,
+        );
+      },
+      loadFollowUpOptions: async () => {
+        const [agentOptions, modelOptionsData] = await Promise.all([
+          computeAgentOptionsData(),
+          computeModelOptionsData(undefined, undefined, {
+            agentCategory: AgentCategory.ToolUse,
+          }),
+        ]);
+        return {
+          toolUseAgentsData: agentOptions.toolUse,
+          modelOptionsData,
+        };
+      },
+      postToRenderer: (message) => {
+        this.postToRenderer(message);
+      },
+      restoreProposalConfig: async (proposal) => {
+        await this.agentProposalController.restoreProposalConfig(proposal);
+      },
+      retry: {
+        submit: (stream, requestId, feedback) =>
+          this.hostInteractions.submitRetryDecision(stream, requestId, {
+            action: 'retry',
+            ...(feedback ? { feedback } : {}),
+          }),
+        cancel: (stream, requestId) =>
+          this.hostInteractions.submitRetryDecision(stream, requestId, {
+            action: 'cancel',
+          }),
+      },
+    };
+
     return {
+      // First-tier shared progress command groups
       ...this.progressHost.commandHandlers,
+
+      // Second-tier shared progress command groups
+      ...createProgressViewSecondTierHandlers(secondTierActions),
+
+      // Host-specific handlers below
       // Getting-started actions from the progress empty-state. openWalkthrough
       // has a desktop equivalent; the remaining four actions are VS Code-only.
       [PROGRESS_VIEW_COMMANDS.GETTING_STARTED_ACTION]: async (data) => {
@@ -908,159 +968,8 @@ export class DesktopProgressBridge {
           `"${labels[data.action]}" requires the VS Code extension.`,
         );
       },
-      // Trivially wireable with existing desktop infrastructure.
-      showInformationMessage: (data) => {
-        void this.options.host.showInfoMessage(data.text);
-      },
-      restoreProposalConfig: async (data) => {
-        await this.agentProposalController.restoreProposalConfig(data.proposal);
-      },
-      // Mirrors the extension's PROGRESS_VIEW_COMMANDS.RESTORE_STATE handler
-      // (`texra.restoreState`): look up the stream's persisted task state and
-      // route the renderer to the main view with it. Surfaces a failure the
-      // same way the extension's `texra.restoreState` command does when
-      // `buildMainViewState` throws on malformed/incompatible persisted data.
-      restoreState: async (data) => {
-        const taskState = this.state.snapshots.getTaskState(data.stream);
-        if (!taskState) return;
-        const restored = this.restoreTaskState(taskState);
-        if (!restored) {
-          await this.options.host.showErrorMessage('Failed to restore state');
-        }
-      },
-      // Mirrors the extension's `texra.compactResponse` command
-      // (`commands/agent/agentCommands.ts`): the decision is made by the
-      // host-agnostic execution registry; only the three user-facing messages
-      // are host-specific.
-      compactResponse: async (data) => {
-        const result = this.session.executions.requestManualCompaction(
-          data.stream,
-        );
-        switch (result.kind) {
-          case 'no_active_tool_use':
-            await this.options.host.showInfoMessage(
-              'No active tool-use session found for this stream.',
-            );
-            return;
-          case 'unsupported':
-            await this.options.host.showInfoMessage(
-              'Manual context compaction is not yet available for this model. Stay tuned!',
-            );
-            return;
-          case 'requested':
-            notifyFollowUpSent(result.streamId, result.session);
-            await this.options.host.showInfoMessage(
-              'Context compaction requested. The agent will process it on the next model call.',
-            );
-            return;
-        }
-      },
-      // diff/pack/clean all resolve their run configuration from the shared
-      // snapshot store through the host-neutral
-      // `ProgressWorkflowActionsController`, exactly as the extension's
-      // ProgressViewMessageHandler does.
-      diffStream: (data) => this.workflowActions.diffStream(data.stream),
-      packStream: (data) =>
-        this.workflowActions.runFileOperation(data.stream, 'pack'),
-      cleanStream: (data) =>
-        this.workflowActions.runFileOperation(data.stream, 'clean'),
-      // Mirrors the extension's handleRetryStreamRequest /
-      // handleCancelRetryRequest: settle the pending retry card on the shared
-      // approval handler.
-      retryStreamRequest: async (data) => {
-        const resolved = this.hostInteractions.submitRetryDecision(
-          data.stream,
-          data.requestId,
-          { action: 'retry', feedback: data.feedback },
-        );
-        if (!resolved) {
-          await this.options.host.showInfoMessage(
-            'No retryable request is available for this stream yet.',
-          );
-        }
-      },
-      cancelRetryRequest: (data) => {
-        this.hostInteractions.submitRetryDecision(data.stream, data.requestId, {
-          action: 'cancel',
-        });
-      },
-      // Mirrors the extension's handleUseOwnApiKey. The credential and routing
-      // rules live in the host-neutral controller; the desktop differs only in
-      // how it asks for a missing key — it opens the Models tab, which is this
-      // host's key-entry surface, rather than a modal input box.
-      useOwnApiKey: async (data) => {
-        const provider =
-          data.provider !== undefined && isApiProvider(data.provider)
-            ? data.provider
-            : undefined;
-        const result = await this.apiKeyRetryController.useOwnApiKey({
-          stream: data.stream,
-          requestId: data.requestId,
-          provider,
-          exhaustionReason: data.exhaustionReason,
-          viaRelay: data.viaRelay,
-        });
-        if (result.proceeded && !result.retried) {
-          await this.options.host.showInfoMessage(
-            'Switched to your own API key. No pending retry to resume — run the agent again when ready.',
-          );
-        }
-      },
-      // Mirrors the extension's handlePolishFollowUp. The desktop has no
-      // progress-notification affordance, so the run is unannounced; every
-      // outcome still reaches the renderer through the same
-      // UPDATE_FOLLOW_UP_TEXT message the controller builds.
-      polishFollowUp: async (data) => {
-        const taskState = this.state.snapshots.getTaskState(data.stream);
-        if (!taskState) return;
-        try {
-          const result = await this.followUpPolishController.polishFollowUp({
-            stream: data.stream,
-            text: data.text,
-            taskState,
-          });
-          await this.applyFollowUpPolishResult(result);
-        } catch (error) {
-          const message = toErrorMessage(error);
-          this.postToRenderer({
-            command: PROGRESS_VIEW_COMMANDS.UPDATE_FOLLOW_UP_TEXT,
-            stream: data.stream,
-            kind: 'polishError',
-            text: null,
-            error: message,
-          });
-          this.logger.error(`Error polishing follow-up: ${message}`, {
-            data: toLogData(error),
-          });
-          await this.options.host.showErrorMessage(
-            `Error polishing follow-up: ${message}`,
-          );
-        }
-      },
-      // `setupFollowup` stages the follow-up in the launcher for review;
-      // `runFollowup` starts it immediately. Both go through the same planner,
-      // exactly as the extension's `processToolUseFollowup(data, immediate)`.
-      setupFollowup: (data) => this.processToolUseFollowUp(data, false),
-      runFollowup: (data) => this.processToolUseFollowUp(data, true),
-      getFollowupOptions: async (data) => {
-        const [agentOptions, modelOptionsData] = await Promise.all([
-          computeAgentOptionsData(),
-          computeModelOptionsData(undefined, undefined, {
-            agentCategory: AgentCategory.ToolUse,
-          }),
-        ]);
-        this.postToRenderer({
-          command: PROGRESS_VIEW_COMMANDS.SET_FOLLOWUP_OPTIONS,
-          stream: data.stream,
-          toolUseAgentsData: agentOptions.toolUse,
-          modelOptionsData,
-        });
-      },
-      // Voice dictation for the follow-up box. The recording and transcription
-      // core (`@tools/media/audio`: sox + a transcription model) is
-      // host-agnostic; the extension wraps it in a webview-bound
-      // `RecordingManager`, so the desktop drives the same two calls and posts
-      // the same UPDATE_RECORDING / UPDATE_FOLLOW_UP_TEXT messages.
+      // Recording: the desktop calls standalone functions and posts status
+      // manually; the extension wraps it in a webview-bound RecordingManager.
       startRecording: async () => {
         try {
           const result = await startRecording();
@@ -1076,8 +985,6 @@ export class DesktopProgressBridge {
       stopRecording: async () => {
         try {
           const transcription = stopRecordingAndTranscribe();
-          // Acknowledge before awaiting so the mic button leaves its recording
-          // state while transcription is still running, as in the extension.
           this.postRecordingStatus({ status: 'stopped' });
           const result = await transcription;
           if (result.success) {
@@ -1094,20 +1001,10 @@ export class DesktopProgressBridge {
           this.postRecordingStatus({ status: 'stopped' });
         }
       },
-      runCompileFixer: async (data) => {
-        await this.applyFollowUpPlan(
-          await this.followUpController.planCompileFixerForStream(data.stream),
-        );
-      },
-      // The extension routes these through `texra.showMemory` /
-      // `texra.auth.viewProfile`, both of which open the settings view (the
-      // former on its Memory tab). The desktop's settings surface is an overlay
-      // reached by the same route + tab messages `desktopShellIpc` posts.
+      // Settings navigation
       openMemoryView: () => {
         this.routeToSettings(SETTINGS_TAB.MEMORY);
       },
-      // Profile is the settings header rather than a tab, so — as in the
-      // extension's `viewProfile()` — opening the view is the whole action.
       openProfile: () => {
         this.routeToSettings();
       },

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -895,7 +895,7 @@ export class DesktopProgressBridge {
       applyPolishResult: async (result) => {
         await this.applyFollowUpPolishResult(result);
       },
-      onPolishError: (stream, error) => {
+      onPolishError: async (stream, error) => {
         const message = error instanceof Error ? error.message : `${error}`;
         this.postToRenderer({
           command: PROGRESS_VIEW_COMMANDS.UPDATE_FOLLOW_UP_TEXT,
@@ -907,7 +907,7 @@ export class DesktopProgressBridge {
         this.logger.error(`Error polishing follow-up: ${message}`, {
           data: toLogData(error),
         });
-        void this.options.host.showErrorMessage(
+        await this.options.host.showErrorMessage(
           `Error polishing follow-up: ${message}`,
         );
       },

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -933,7 +933,7 @@ export class DesktopProgressBridge {
         submit: (stream, requestId, feedback) =>
           this.hostInteractions.submitRetryDecision(stream, requestId, {
             action: 'retry',
-            ...(feedback ? { feedback } : {}),
+            feedback,
           }),
         cancel: (stream, requestId) =>
           this.hostInteractions.submitRetryDecision(stream, requestId, {

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -21,6 +21,10 @@ import {
 } from '@controllers/progressView/ProgressFollowUpController';
 import { ProgressWorkflowActionsController } from '@controllers/progressView/ProgressWorkflowActionsController';
 import { ProgressViewHost } from '@controllers/progressView/ProgressViewHost';
+import {
+  createProgressViewSecondTierHandlers,
+  type ProgressViewSecondTierActions,
+} from '@controllers/progressView/ProgressViewCommandHandlers';
 import { SecretManager } from '@frontend/secretManager';
 import { loadOptions } from '@frontend/agents/optionsLoader';
 import { handleProgressViewToolEditApprovalAction } from '@frontend/approval/nativeToolEditApproval';
@@ -168,6 +172,88 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       };
     };
 
+    const secondTierActions: ProgressViewSecondTierActions = {
+      workflowActions: this.workflowActionsController,
+      apiKeyRetry: this.apiKeyRetryController,
+      followUp: this.followUpController,
+      followUpPolish: this.followUpPolishController,
+      host: {
+        showInfo: async (message) => {
+          await this.host.info(message);
+        },
+        showError: async (message) => {
+          await this.host.error(message);
+        },
+      },
+      session: defaultSession(),
+      getTaskState: (stream) =>
+        this.provider.state.snapshots.getTaskState(stream),
+      restoreTaskState: async (taskState) => {
+        return (
+          (await this.runViewCommand<boolean>('texra.restoreState', [
+            taskState,
+          ])) === true
+        );
+      },
+      applyFollowUpPlan: async (plan) => {
+        await this.applyFollowUpPlan(plan);
+      },
+      applyPolishResult: async (result) => {
+        await this.applyFollowUpPolishResult(result);
+      },
+      onPolishError: (stream, error) => {
+        const errorMsg =
+          error instanceof Error ? error.message : `${error}`;
+        this.postToActiveView({
+          command: PROGRESS_VIEW_COMMANDS.UPDATE_FOLLOW_UP_TEXT,
+          stream,
+          kind: 'polishError',
+          text: null,
+          error: errorMsg,
+        });
+        void this.host.error(`Error polishing follow-up: ${errorMsg}`);
+        this.logger.error(this.channel, `Error polishing follow-up: ${errorMsg}`, {
+          data: error instanceof Error ? error : undefined,
+        });
+      },
+      loadFollowUpOptions: async () => {
+        const { agentOptions, modelOptions } = await loadOptions();
+        return {
+          toolUseAgentsData: agentOptions.toolUse,
+          modelOptionsData: modelOptions,
+        };
+      },
+      postToRenderer: (message) => {
+        this.postToActiveView(message);
+      },
+      restoreProposalConfig: async (proposal) => {
+        const restored =
+          await this.agentProposalController.restoreProposalConfig(proposal);
+        if (!restored) return;
+        this.logger.info(
+          this.channel,
+          'Restored proposal config to main view',
+          {
+            data: {
+              agent: proposal.agent,
+              agentCategory: proposal.agentCategory,
+            },
+          },
+        );
+      },
+      retry: {
+        submit: (stream, requestId, feedback) =>
+          this.interactions.submitRetryDecision(stream, requestId, {
+            action: 'retry',
+            ...(feedback ? { feedback } : {}),
+          }),
+        cancel: (stream, requestId) =>
+          this.interactions.submitRetryDecision(stream, requestId, {
+            action: 'cancel',
+          }),
+      },
+    };
+
     return {
       // Common handlers - passthrough to webview
       [PROGRESS_VIEW_COMMANDS.WEBVIEW_READY]: async () => {
@@ -183,36 +269,25 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       [PROGRESS_VIEW_COMMANDS.POP_OUT]: () => this.provider.popOutToEditor(),
       [PROGRESS_VIEW_COMMANDS.POP_BACK]: () => this.provider.popBackToSidebar(),
 
-      // Shared progress command groups
+      // First-tier shared progress command groups
       ...this.progressHost.commandHandlers,
-      [PROGRESS_VIEW_COMMANDS.COMPACT_RESPONSE]: async (data) => {
-        await this.runViewCommand('texra.compactResponse', [data.stream]);
-      },
 
-      // Actions
-      [PROGRESS_VIEW_COMMANDS.DIFF_STREAM]: (data) =>
-        this.workflowActionsController.diffStream(data.stream),
-      [PROGRESS_VIEW_COMMANDS.PACK_STREAM]: (data) =>
-        this.workflowActionsController.runFileOperation(data.stream, 'pack'),
-      [PROGRESS_VIEW_COMMANDS.CLEAN_STREAM]: (data) =>
-        this.workflowActionsController.runFileOperation(data.stream, 'clean'),
-      [PROGRESS_VIEW_COMMANDS.RETRY_STREAM_REQUEST]: (data) =>
-        this.handleRetryStreamRequest(data),
-      [PROGRESS_VIEW_COMMANDS.CANCEL_RETRY_REQUEST]: (data) => {
-        this.handleCancelRetryRequest(data);
-      },
+      // Second-tier shared progress command groups
+      ...createProgressViewSecondTierHandlers(secondTierActions),
+
+      // Override USE_OWN_API_KEY: the shared factory handles the generic case;
+      // the extension adds VS Code-specific Copilot-subscription fallback
+      // (`startCopilotFallbackRun`) before delegating to the shared controller.
       [PROGRESS_VIEW_COMMANDS.USE_OWN_API_KEY]: (data) =>
         this.handleUseOwnApiKey(data),
-      [PROGRESS_VIEW_COMMANDS.RESTORE_STATE]: async (data) => {
-        const taskState = this.provider.state.snapshots.getTaskState(
-          data.stream,
-        );
-        if (taskState) {
-          await this.runViewCommand('texra.restoreState', [taskState]);
-        }
-      },
+      // Override POLISH_FOLLOW_UP: the shared factory does the core
+      // controller call and result dispatch; the extension adds a VS Code
+      // progress notification (`vscode.window.withProgress`) around it.
       [PROGRESS_VIEW_COMMANDS.POLISH_FOLLOW_UP]: (data) =>
         this.handlePolishFollowUp(data),
+
+      // Recording (host-specific: extension wraps in a webview-bound
+      // RecordingManager that posts status internally)
       [PROGRESS_VIEW_COMMANDS.START_RECORDING]: async () => {
         const view = this.getActiveView();
         if (view) await this.recordingManager.start(view);
@@ -221,42 +296,12 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         const view = this.getActiveView();
         if (view) await this.recordingManager.stop(view);
       },
-      [PROGRESS_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE]: async (data) => {
-        await this.host.info(data.text);
-      },
-      [PROGRESS_VIEW_COMMANDS.RESTORE_PROPOSAL_CONFIG]: async (data) => {
-        const restored =
-          await this.agentProposalController.restoreProposalConfig(
-            data.proposal,
-          );
-        if (restored) {
-          this.logger.info(
-            this.channel,
-            'Restored proposal config to main view',
-            {
-              data: {
-                agent: data.proposal.agent,
-                agentCategory: data.proposal.agentCategory,
-              },
-            },
-          );
-        }
-      },
+
       // Profile & Memory - direct command execution
       [PROGRESS_VIEW_COMMANDS.OPEN_PROFILE]: runCommand(
         'texra.auth.viewProfile',
       ),
       [PROGRESS_VIEW_COMMANDS.OPEN_MEMORY_VIEW]: runCommand('texra.showMemory'),
-
-      // Followup task
-      [PROGRESS_VIEW_COMMANDS.GET_FOLLOWUP_OPTIONS]: (data) =>
-        this.handleGetFollowupOptions(data.stream),
-      [PROGRESS_VIEW_COMMANDS.SETUP_FOLLOWUP]: (data) =>
-        this.processToolUseFollowup(data, false),
-      [PROGRESS_VIEW_COMMANDS.RUN_FOLLOWUP]: (data) =>
-        this.processToolUseFollowup(data, true),
-      [PROGRESS_VIEW_COMMANDS.RUN_COMPILE_FIXER]: (data) =>
-        this.handleRunCompileFixer(data.stream),
 
       [PROGRESS_VIEW_COMMANDS.GETTING_STARTED_ACTION]: (data) =>
         this.runGettingStartedAction(data.action),
@@ -611,32 +656,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   // Action handlers
   // ============================================================
 
-  private async handleRetryStreamRequest(
-    data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.RETRY_STREAM_REQUEST>,
-  ): Promise<void> {
-    const resolved = this.interactions.submitRetryDecision(
-      data.stream,
-      data.requestId,
-      {
-        action: 'retry',
-        feedback: data.feedback,
-      },
-    );
-    if (!resolved) {
-      await this.host.info(
-        'No retryable request is available for this stream yet.',
-      );
-    }
-  }
-
-  private handleCancelRetryRequest(
-    data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.CANCEL_RETRY_REQUEST>,
-  ): void {
-    this.interactions.submitRetryDecision(data.stream, data.requestId, {
-      action: 'cancel',
-    });
-  }
-
   private handleBashApprovalAction(
     data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION>,
   ): void {
@@ -926,39 +945,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         () => settle(false),
       );
     });
-  }
-
-  private async handleGetFollowupOptions(streamId: StreamTabId): Promise<void> {
-    const { agentOptions, modelOptions } = await loadOptions();
-    this.postToActiveView({
-      command: PROGRESS_VIEW_COMMANDS.SET_FOLLOWUP_OPTIONS,
-      stream: streamId,
-      toolUseAgentsData: agentOptions.toolUse,
-      modelOptionsData: modelOptions,
-    });
-  }
-
-  private async processToolUseFollowup(
-    data:
-      | MessageFor<typeof PROGRESS_VIEW_COMMANDS.SETUP_FOLLOWUP>
-      | MessageFor<typeof PROGRESS_VIEW_COMMANDS.RUN_FOLLOWUP>,
-    executeImmediately: boolean,
-  ): Promise<void> {
-    await this.applyFollowUpPlan(
-      await this.followUpController.planToolUseFollowUpForStream({
-        streamId: data.stream,
-        agent: data.agent,
-        model: data.model,
-        initialQuestion: data.initialQuestion,
-        executeImmediately,
-      }),
-    );
-  }
-
-  private async handleRunCompileFixer(streamId: StreamTabId): Promise<void> {
-    await this.applyFollowUpPlan(
-      await this.followUpController.planCompileFixerForStream(streamId),
-    );
   }
 
   private async applyFollowUpPlan(plan: ProgressFollowUpPlan): Promise<void> {

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -241,7 +241,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         submit: (stream, requestId, feedback) =>
           this.interactions.submitRetryDecision(stream, requestId, {
             action: 'retry',
-            ...(feedback ? { feedback } : {}),
+            feedback,
           }),
         cancel: (stream, requestId) =>
           this.interactions.submitRetryDecision(stream, requestId, {

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -202,8 +202,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         await this.applyFollowUpPolishResult(result);
       },
       onPolishError: (stream, error) => {
-        const errorMsg =
-          error instanceof Error ? error.message : `${error}`;
+        const errorMsg = error instanceof Error ? error.message : `${error}`;
         this.postToActiveView({
           command: PROGRESS_VIEW_COMMANDS.UPDATE_FOLLOW_UP_TEXT,
           stream,
@@ -212,9 +211,13 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           error: errorMsg,
         });
         void this.host.error(`Error polishing follow-up: ${errorMsg}`);
-        this.logger.error(this.channel, `Error polishing follow-up: ${errorMsg}`, {
-          data: error instanceof Error ? error : undefined,
-        });
+        this.logger.error(
+          this.channel,
+          `Error polishing follow-up: ${errorMsg}`,
+          {
+            data: error instanceof Error ? error : undefined,
+          },
+        );
       },
       loadFollowUpOptions: async () => {
         const { agentOptions, modelOptions } = await loadOptions();

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -181,19 +181,12 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         showInfo: async (message) => {
           await this.host.info(message);
         },
-        showError: async (message) => {
-          await this.host.error(message);
-        },
       },
       session: defaultSession(),
       getTaskState: (stream) =>
         this.provider.state.snapshots.getTaskState(stream),
       restoreTaskState: async (taskState) => {
-        return (
-          (await this.runViewCommand<boolean>('texra.restoreState', [
-            taskState,
-          ])) === true
-        );
+        await this.runViewCommand('texra.restoreState', [taskState]);
       },
       applyFollowUpPlan: async (plan) => {
         await this.applyFollowUpPlan(plan);

--- a/src/controllers/progressView/ProgressViewCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewCommandHandlers.ts
@@ -460,7 +460,7 @@ export function createProgressViewSecondTierHandlers(
           );
           return;
         case 'requested':
-          notifyFollowUpSent(result.streamId, deps.session);
+          notifyFollowUpSent(result.streamId, result.session);
           await deps.host.showInfo(
             'Context compaction requested. The agent will process it on the next model call.',
           );

--- a/src/controllers/progressView/ProgressViewCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewCommandHandlers.ts
@@ -324,7 +324,6 @@ export interface ProgressViewSecondTierActions {
   /** Host-level user messaging. */
   readonly host: {
     readonly showInfo: (message: string) => Promise<void> | void;
-    readonly showError: (message: string) => Promise<void> | void;
   };
   /** Session handle (for manual compaction). */
   readonly session: SessionHandle;
@@ -334,9 +333,10 @@ export interface ProgressViewSecondTierActions {
    * Restore task state from a completed run into the main view (the extension
    * routes through `texra.restoreState`; the desktop calls
    * `buildMainViewState` / `prepareMainViewExecutionLaunch` directly).
-   * Returns true when the state was restored and the main view received it.
+   * The host owns any failure reporting because the extension command and
+   * desktop state builder have different error paths.
    */
-  readonly restoreTaskState: (taskState: TaskState) => Promise<boolean>;
+  readonly restoreTaskState: (taskState: TaskState) => Promise<void>;
   /** Resolve a follow-up plan (plan kinds map to host-specific execution). */
   readonly applyFollowUpPlan: (plan: ProgressFollowUpPlan) => Promise<void>;
   /** Render a polish result (update renderer + show host messages). */
@@ -440,10 +440,7 @@ export function createProgressViewSecondTierHandlers(
     [CMD.RESTORE_STATE]: async (data) => {
       const taskState = deps.getTaskState(data.stream);
       if (!taskState) return;
-      const restored = await deps.restoreTaskState(taskState);
-      if (!restored) {
-        await deps.host.showError('Failed to restore state');
-      }
+      await deps.restoreTaskState(taskState);
     },
 
     // ── Manual compaction ──

--- a/src/controllers/progressView/ProgressViewCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewCommandHandlers.ts
@@ -1,10 +1,15 @@
 // Local imports
+import type { TaskState } from '@agent/core/state/TaskState';
+import { notifyFollowUpSent } from '@agent/followUp/ToolUseFollowUp';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
-import type { AgentCategoryFilter, StreamTabId } from '@shared/schemas';
+import { isApiProvider } from '@model/apiProviders';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
+import type { AgentOptionData, ModelOptionData } from '@shared/schemas';
+import type { AgentCategoryFilter, StreamTabId } from '@shared/schemas';
 import type {
   ProgressViewInboundHandlerRegistry,
   ProgressViewInboundMessage,
+  ProgressViewOutboundMessage,
 } from '@shared/schemas/progressView';
 import {
   isApprovalBypassedForStream,
@@ -19,6 +24,16 @@ import {
 } from '@tools/inquiry';
 import { persistOpenTurnDraft } from '@tools/inquiry/externalInquiryStorage';
 import { savePastedImageBase64 } from '@utils/files/pastedImageUtils';
+import type { ProgressWorkflowActionsController } from './ProgressWorkflowActionsController';
+import type { ProgressApiKeyRetryController } from './ProgressApiKeyRetryController';
+import type {
+  ProgressFollowUpController,
+  ProgressFollowUpPlan,
+} from './ProgressFollowUpController';
+import type {
+  ProgressFollowUpPolishController,
+  ProgressFollowUpPolishResult,
+} from './ProgressFollowUpPolishController';
 
 type ProgressViewMessage<C extends ProgressViewInboundMessage['command']> =
   Extract<ProgressViewInboundMessage, { command: C }>;
@@ -291,6 +306,239 @@ export function createProgressViewCommandHandlers(
       externalInquiry.dismiss(data.threadId);
       await continueExternalInquiryAction(transition, externalInquiry);
     },
+  } satisfies Partial<ProgressViewInboundHandlerRegistry>;
+}
+
+// ── Second-tier handler deps ──────────────────────────────────────────────
+
+export interface ProgressViewSecondTierActions {
+  /** Shared controllers (host-neutral; created once per host with injected deps). */
+  readonly workflowActions: ProgressWorkflowActionsController;
+  readonly apiKeyRetry: ProgressApiKeyRetryController;
+  readonly followUp: ProgressFollowUpController;
+  readonly followUpPolish: ProgressFollowUpPolishController;
+  /** Host-level user messaging. */
+  readonly host: {
+    readonly showInfo: (message: string) => Promise<void> | void;
+    readonly showError: (message: string) => Promise<void> | void;
+  };
+  /** Session handle (for manual compaction). */
+  readonly session: SessionHandle;
+  /** Look up a stream's task state from persisted snapshots. */
+  readonly getTaskState: (stream: StreamTabId) => TaskState | undefined;
+  /**
+   * Restore task state from a completed run into the main view (the extension
+   * routes through `texra.restoreState`; the desktop calls
+   * `buildMainViewState` / `prepareMainViewExecutionLaunch` directly).
+   * Returns true when the state was restored and the main view received it.
+   */
+  readonly restoreTaskState: (taskState: TaskState) => Promise<boolean>;
+  /** Resolve a follow-up plan (plan kinds map to host-specific execution). */
+  readonly applyFollowUpPlan: (plan: ProgressFollowUpPlan) => Promise<void>;
+  /** Render a polish result (update renderer + show host messages). */
+  readonly applyPolishResult: (
+    result: ProgressFollowUpPolishResult,
+  ) => Promise<void>;
+  /** Handle a polish controller exception (post error to renderer + log + host message). */
+  readonly onPolishError: (
+    stream: StreamTabId,
+    error: unknown,
+  ) => void | Promise<void>;
+  /** Load follow-up option catalogs (host-specific loading paths). */
+  readonly loadFollowUpOptions: () => Promise<{
+    toolUseAgentsData?: readonly AgentOptionData[];
+    modelOptionsData?: readonly ModelOptionData[];
+  }>;
+  /** Post a message to the renderer. */
+  readonly postToRenderer: (message: ProgressViewOutboundMessage) => void;
+  /** Restore an agent proposal config into the main view (delegates to agentProposalController). */
+  readonly restoreProposalConfig: (
+    proposal: import('@shared/schemas').AgentProposal,
+  ) => Promise<void>;
+  /** Retry request settlement. */
+  readonly retry: {
+    readonly submit: (
+      stream: StreamTabId,
+      requestId: string,
+      feedback?: string,
+    ) => boolean;
+    readonly cancel: (stream: StreamTabId, requestId: string) => void;
+  };
+}
+
+/**
+ * Shared second-tier progress-view command handlers used by both extension and
+ * desktop.
+ *
+ * These handlers wrap shared controllers ({@link ProgressWorkflowActionsController},
+ * {@link ProgressApiKeyRetryController}, {@link ProgressFollowUpController},
+ * {@link ProgressFollowUpPolishController}) plus host-injected callbacks for
+ * messaging, retry settlement, state restoration, plan/polish result
+ * application, follow-up option loading, recording, and proposal restore.
+ *
+ * Hosts create the controllers and callbacks once, call this factory, and
+ * spread the result into their handler registry alongside
+ * {@link createProgressViewCommandHandlers} and host-specific commands.
+ */
+export function createProgressViewSecondTierHandlers(
+  deps: ProgressViewSecondTierActions,
+) {
+  const CMD = PROGRESS_VIEW_COMMANDS;
+
+  return {
+    // ── Workflow toolbar (diff / pack / clean) ──
+    [CMD.DIFF_STREAM]: (data) =>
+      deps.workflowActions.diffStream(data.stream),
+    [CMD.PACK_STREAM]: (data) =>
+      deps.workflowActions.runFileOperation(data.stream, 'pack'),
+    [CMD.CLEAN_STREAM]: (data) =>
+      deps.workflowActions.runFileOperation(data.stream, 'clean'),
+
+    // ── Retry ──
+    [CMD.RETRY_STREAM_REQUEST]: async (data) => {
+      const resolved = deps.retry.submit(
+        data.stream,
+        data.requestId,
+        data.feedback,
+      );
+      if (!resolved) {
+        await deps.host.showInfo(
+          'No retryable request is available for this stream yet.',
+        );
+      }
+    },
+    [CMD.CANCEL_RETRY_REQUEST]: (data) => {
+      deps.retry.cancel(data.stream, data.requestId);
+    },
+
+    // ── API key retry ──
+    [CMD.USE_OWN_API_KEY]: async (data) => {
+      // Provider validation: the IPC payload strings / user input must match a
+      // known api provider; silently narrow unknown values so the controller
+      // skips its provider-specific key-lookup branch.
+      const providerArg =
+        data.provider !== undefined && isApiProvider(data.provider)
+          ? data.provider
+          : undefined;
+
+      const result = await deps.apiKeyRetry.useOwnApiKey({
+        stream: data.stream,
+        requestId: data.requestId,
+        provider: providerArg,
+        exhaustionReason: data.exhaustionReason,
+        viaRelay: data.viaRelay,
+      });
+      if (result.proceeded && !result.retried) {
+        await deps.host.showInfo(
+          'Switched to your own API key. No pending retry to resume — run the agent again when ready.',
+        );
+      }
+    },
+
+    // ── State restore ──
+    [CMD.RESTORE_STATE]: async (data) => {
+      const taskState = deps.getTaskState(data.stream);
+      if (!taskState) return;
+      const restored = await deps.restoreTaskState(taskState);
+      if (!restored) {
+        await deps.host.showError('Failed to restore state');
+      }
+    },
+
+    // ── Manual compaction ──
+    [CMD.COMPACT_RESPONSE]: async (data) => {
+      const result = deps.session.executions.requestManualCompaction(
+        data.stream,
+      );
+      switch (result.kind) {
+        case 'no_active_tool_use':
+          await deps.host.showInfo(
+            'No active tool-use session found for this stream.',
+          );
+          return;
+        case 'unsupported':
+          await deps.host.showInfo(
+            'Manual context compaction is not yet available for this model. Stay tuned!',
+          );
+          return;
+        case 'requested':
+          notifyFollowUpSent(result.streamId, deps.session);
+          await deps.host.showInfo(
+            'Context compaction requested. The agent will process it on the next model call.',
+          );
+          return;
+      }
+    },
+
+    // ── Show info ──
+    [CMD.SHOW_INFORMATION_MESSAGE]: (data) => {
+      void deps.host.showInfo(data.text);
+    },
+
+    // ── Proposal config restore ──
+    [CMD.RESTORE_PROPOSAL_CONFIG]: async (data) => {
+      await deps.restoreProposalConfig(data.proposal);
+    },
+
+    // ── Follow-up polish ──
+    [CMD.POLISH_FOLLOW_UP]: async (data) => {
+      const taskState = deps.getTaskState(data.stream);
+      if (!taskState) return;
+      try {
+        const result = await deps.followUpPolish.polishFollowUp({
+          stream: data.stream,
+          text: data.text,
+          taskState,
+        });
+        await deps.applyPolishResult(result);
+      } catch (error) {
+        deps.onPolishError(data.stream, error);
+      }
+    },
+
+    // ── Follow-up tasks ──
+    [CMD.SETUP_FOLLOWUP]: async (data) => {
+      await deps.applyFollowUpPlan(
+        await deps.followUp.planToolUseFollowUpForStream({
+          streamId: data.stream,
+          agent: data.agent,
+          model: data.model,
+          initialQuestion: data.initialQuestion,
+          executeImmediately: false,
+        }),
+      );
+    },
+    [CMD.RUN_FOLLOWUP]: async (data) => {
+      await deps.applyFollowUpPlan(
+        await deps.followUp.planToolUseFollowUpForStream({
+          streamId: data.stream,
+          agent: data.agent,
+          model: data.model,
+          initialQuestion: data.initialQuestion,
+          executeImmediately: true,
+        }),
+      );
+    },
+    [CMD.GET_FOLLOWUP_OPTIONS]: async (data) => {
+      const { toolUseAgentsData, modelOptionsData } =
+        await deps.loadFollowUpOptions();
+      deps.postToRenderer({
+        command: CMD.SET_FOLLOWUP_OPTIONS,
+        stream: data.stream,
+        ...(toolUseAgentsData && { toolUseAgentsData }),
+        ...(modelOptionsData && { modelOptionsData }),
+      } as ProgressViewOutboundMessage);
+    },
+    [CMD.RUN_COMPILE_FIXER]: async (data) => {
+      await deps.applyFollowUpPlan(
+        await deps.followUp.planCompileFixerForStream(data.stream),
+      );
+    },
+
+    // Voice recording (START_RECORDING / STOP_RECORDING) is host-specific:
+    // the extension wraps it in a webview-bound RecordingManager that posts
+    // status messages internally; the desktop calls standalone recording
+    // functions and posts status manually. Each host keeps its own pair.
   } satisfies Partial<ProgressViewInboundHandlerRegistry>;
 }
 

--- a/src/controllers/progressView/ProgressViewCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewCommandHandlers.ts
@@ -4,7 +4,11 @@ import { notifyFollowUpSent } from '@agent/followUp/ToolUseFollowUp';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { isApiProvider } from '@model/apiProviders';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
-import type { AgentOptionData, ModelOptionData } from '@shared/schemas';
+import type {
+  AgentOptionData,
+  AgentProposal,
+  ModelOptionData,
+} from '@shared/schemas';
 import type { AgentCategoryFilter, StreamTabId } from '@shared/schemas';
 import type {
   ProgressViewInboundHandlerRegistry,
@@ -352,9 +356,7 @@ export interface ProgressViewSecondTierActions {
   /** Post a message to the renderer. */
   readonly postToRenderer: (message: ProgressViewOutboundMessage) => void;
   /** Restore an agent proposal config into the main view (delegates to agentProposalController). */
-  readonly restoreProposalConfig: (
-    proposal: import('@shared/schemas').AgentProposal,
-  ) => Promise<void>;
+  readonly restoreProposalConfig: (proposal: AgentProposal) => Promise<void>;
   /** Retry request settlement. */
   readonly retry: {
     readonly submit: (
@@ -387,8 +389,7 @@ export function createProgressViewSecondTierHandlers(
 
   return {
     // ── Workflow toolbar (diff / pack / clean) ──
-    [CMD.DIFF_STREAM]: (data) =>
-      deps.workflowActions.diffStream(data.stream),
+    [CMD.DIFF_STREAM]: (data) => deps.workflowActions.diffStream(data.stream),
     [CMD.PACK_STREAM]: (data) =>
       deps.workflowActions.runFileOperation(data.stream, 'pack'),
     [CMD.CLEAN_STREAM]: (data) =>
@@ -471,8 +472,8 @@ export function createProgressViewSecondTierHandlers(
     },
 
     // ── Show info ──
-    [CMD.SHOW_INFORMATION_MESSAGE]: (data) => {
-      void deps.host.showInfo(data.text);
+    [CMD.SHOW_INFORMATION_MESSAGE]: async (data) => {
+      await deps.host.showInfo(data.text);
     },
 
     // ── Proposal config restore ──
@@ -492,7 +493,7 @@ export function createProgressViewSecondTierHandlers(
         });
         await deps.applyPolishResult(result);
       } catch (error) {
-        deps.onPolishError(data.stream, error);
+        await deps.onPolishError(data.stream, error);
       }
     },
 

--- a/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
@@ -36,8 +36,12 @@ const externalInquiryMocks = vi.hoisted(() => ({
   continueExternalInquiryAction: vi.fn(),
   persistExternalInquiryAction: vi.fn(),
 }));
+const followUpMocks = vi.hoisted(() => ({
+  notifyFollowUpSent: vi.fn(),
+}));
 
 vi.mock('@tools/inquiry', () => externalInquiryMocks);
+vi.mock('@agent/followUp/ToolUseFollowUp', () => followUpMocks);
 vi.mock('@utils/files/pastedImageUtils', () => ({
   savePastedImageBase64: vi.fn(),
 }));
@@ -919,6 +923,32 @@ describe('createProgressViewSecondTierHandlers', () => {
       }),
     ).rejects.toBe(failure);
     expect(actions.restoreTaskState).toHaveBeenCalledWith(taskState);
+  });
+
+  it('notifies compaction through the execution owner session', async () => {
+    const ownerSession = {};
+    const actions = createSecondTierActions({
+      session: {
+        executions: {
+          requestManualCompaction: vi.fn().mockReturnValue({
+            kind: 'requested',
+            streamId: 'stream-1',
+            session: ownerSession,
+          }),
+        },
+      } as unknown as ProgressViewSecondTierActions['session'],
+    });
+    const handlers = createProgressViewSecondTierHandlers(actions);
+
+    await assertSupported(handlers[PROGRESS_VIEW_COMMANDS.COMPACT_RESPONSE])({
+      command: PROGRESS_VIEW_COMMANDS.COMPACT_RESPONSE,
+      stream: 'stream-1',
+    });
+
+    expect(followUpMocks.notifyFollowUpSent).toHaveBeenCalledWith(
+      'stream-1',
+      ownerSession,
+    );
   });
 
   it('awaits polish error reporting', async () => {

--- a/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
@@ -10,7 +10,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SessionHostInteractions } from '@agent/runtime/HostInteractions';
 import {
   createProgressViewCommandHandlers as createSharedProgressViewCommandHandlers,
+  createProgressViewSecondTierHandlers,
   type ProgressViewCommandActions,
+  type ProgressViewSecondTierActions,
 } from '@controllers/progressView/ProgressViewCommandHandlers';
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import {
@@ -107,6 +109,51 @@ function createActions(
     },
     ...overrides,
   };
+}
+
+function createSecondTierActions(
+  overrides: Partial<ProgressViewSecondTierActions> = {},
+): ProgressViewSecondTierActions {
+  return {
+    workflowActions: {
+      diffStream: vi.fn(),
+      runFileOperation: vi.fn(),
+    },
+    apiKeyRetry: {
+      useOwnApiKey: vi
+        .fn()
+        .mockResolvedValue({ proceeded: false, retried: false }),
+    },
+    followUp: {
+      planToolUseFollowUpForStream: vi.fn(),
+      planCompileFixerForStream: vi.fn(),
+    },
+    followUpPolish: {
+      polishFollowUp: vi.fn(),
+    },
+    host: {
+      showInfo: vi.fn(),
+      showError: vi.fn(),
+    },
+    session: {
+      executions: {
+        requestManualCompaction: vi.fn(),
+      },
+    },
+    getTaskState: vi.fn(),
+    restoreTaskState: vi.fn(),
+    applyFollowUpPlan: vi.fn(),
+    applyPolishResult: vi.fn(),
+    onPolishError: vi.fn(),
+    loadFollowUpOptions: vi.fn().mockResolvedValue({}),
+    postToRenderer: vi.fn(),
+    restoreProposalConfig: vi.fn(),
+    retry: {
+      submit: vi.fn(),
+      cancel: vi.fn(),
+    },
+    ...overrides,
+  } as unknown as ProgressViewSecondTierActions;
 }
 
 function createRecordingInteractions(): {
@@ -786,6 +833,102 @@ describe('external inquiry action schema', () => {
       ).toHaveBeenCalledWith(transition, actions.externalInquiry);
     },
   );
+});
+
+describe('createProgressViewSecondTierHandlers', () => {
+  it('defines the complete shared second-tier command set', () => {
+    const handlers = createProgressViewSecondTierHandlers(
+      createSecondTierActions(),
+    );
+
+    expect(Object.keys(handlers).toSorted()).toEqual(
+      [
+        PROGRESS_VIEW_COMMANDS.DIFF_STREAM,
+        PROGRESS_VIEW_COMMANDS.PACK_STREAM,
+        PROGRESS_VIEW_COMMANDS.CLEAN_STREAM,
+        PROGRESS_VIEW_COMMANDS.RETRY_STREAM_REQUEST,
+        PROGRESS_VIEW_COMMANDS.CANCEL_RETRY_REQUEST,
+        PROGRESS_VIEW_COMMANDS.USE_OWN_API_KEY,
+        PROGRESS_VIEW_COMMANDS.RESTORE_STATE,
+        PROGRESS_VIEW_COMMANDS.COMPACT_RESPONSE,
+        PROGRESS_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE,
+        PROGRESS_VIEW_COMMANDS.RESTORE_PROPOSAL_CONFIG,
+        PROGRESS_VIEW_COMMANDS.POLISH_FOLLOW_UP,
+        PROGRESS_VIEW_COMMANDS.SETUP_FOLLOWUP,
+        PROGRESS_VIEW_COMMANDS.RUN_FOLLOWUP,
+        PROGRESS_VIEW_COMMANDS.GET_FOLLOWUP_OPTIONS,
+        PROGRESS_VIEW_COMMANDS.RUN_COMPILE_FIXER,
+      ].toSorted(),
+    );
+  });
+
+  it('awaits host information messages', async () => {
+    const failure = new Error('message host failed');
+    const actions = createSecondTierActions({
+      host: {
+        showInfo: vi.fn().mockRejectedValue(failure),
+        showError: vi.fn(),
+      },
+    });
+    const handlers = createProgressViewSecondTierHandlers(actions);
+
+    await expect(
+      assertSupported(
+        handlers[PROGRESS_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE],
+      )({
+        command: PROGRESS_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE,
+        text: 'Ready',
+      }),
+    ).rejects.toBe(failure);
+  });
+
+  it('reports an unavailable retry through the host', async () => {
+    const actions = createSecondTierActions();
+    const handlers = createProgressViewSecondTierHandlers(actions);
+
+    await assertSupported(
+      handlers[PROGRESS_VIEW_COMMANDS.RETRY_STREAM_REQUEST],
+    )({
+      command: PROGRESS_VIEW_COMMANDS.RETRY_STREAM_REQUEST,
+      stream: 'stream-1',
+      requestId: 'request-1',
+      feedback: 'Try once more',
+    });
+
+    expect(actions.retry.submit).toHaveBeenCalledWith(
+      'stream-1',
+      'request-1',
+      'Try once more',
+    );
+    expect(actions.host.showInfo).toHaveBeenCalledWith(
+      'No retryable request is available for this stream yet.',
+    );
+  });
+
+  it('awaits polish error reporting', async () => {
+    const polishFailure = new Error('polish failed');
+    const reportingFailure = new Error('reporting failed');
+    const actions = createSecondTierActions({
+      getTaskState: vi.fn().mockReturnValue({}),
+      followUpPolish: {
+        polishFollowUp: vi.fn().mockRejectedValue(polishFailure),
+      } as unknown as ProgressViewSecondTierActions['followUpPolish'],
+      onPolishError: vi.fn().mockRejectedValue(reportingFailure),
+    });
+    const handlers = createProgressViewSecondTierHandlers(actions);
+
+    await expect(
+      assertSupported(handlers[PROGRESS_VIEW_COMMANDS.POLISH_FOLLOW_UP])({
+        command: PROGRESS_VIEW_COMMANDS.POLISH_FOLLOW_UP,
+        stream: 'stream-1',
+        text: 'Improve this',
+      }),
+    ).rejects.toBe(reportingFailure);
+    expect(actions.onPolishError).toHaveBeenCalledWith(
+      'stream-1',
+      polishFailure,
+    );
+  });
 });
 
 describe('user question action schema', () => {

--- a/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
+++ b/src/test-kernel/controllers/ProgressViewCommandHandlers.vitest.ts
@@ -133,7 +133,6 @@ function createSecondTierActions(
     },
     host: {
       showInfo: vi.fn(),
-      showError: vi.fn(),
     },
     session: {
       executions: {
@@ -867,7 +866,6 @@ describe('createProgressViewSecondTierHandlers', () => {
     const actions = createSecondTierActions({
       host: {
         showInfo: vi.fn().mockRejectedValue(failure),
-        showError: vi.fn(),
       },
     });
     const handlers = createProgressViewSecondTierHandlers(actions);
@@ -903,6 +901,24 @@ describe('createProgressViewSecondTierHandlers', () => {
     expect(actions.host.showInfo).toHaveBeenCalledWith(
       'No retryable request is available for this stream yet.',
     );
+  });
+
+  it('leaves restore failure reporting to the host callback', async () => {
+    const failure = new Error('restore failed');
+    const taskState = {};
+    const actions = createSecondTierActions({
+      getTaskState: vi.fn().mockReturnValue(taskState),
+      restoreTaskState: vi.fn().mockRejectedValue(failure),
+    });
+    const handlers = createProgressViewSecondTierHandlers(actions);
+
+    await expect(
+      assertSupported(handlers[PROGRESS_VIEW_COMMANDS.RESTORE_STATE])({
+        command: PROGRESS_VIEW_COMMANDS.RESTORE_STATE,
+        stream: 'stream-1',
+      }),
+    ).rejects.toBe(failure);
+    expect(actions.restoreTaskState).toHaveBeenCalledWith(taskState);
   });
 
   it('awaits polish error reporting', async () => {


### PR DESCRIPTION
## Summary

The extension and desktop progress views previously implemented the same second-tier command dispatch independently. This change gives those 15 commands one host-neutral owner while retaining host-specific effects behind explicit callbacks.

The shared factory covers workflow toolbar actions, retry settlement, API-key retry, state restoration, manual compaction, information messages, proposal restoration, follow-up polishing and planning, option loading, and compile-fixer launch. Recording remains host-specific because the extension and desktop use materially different recording lifecycles.

Closes #9386.

## Issue acceptance gates

- The duplicated extension and desktop command bodies are replaced by one shared factory.
- Host-specific UI, state, and execution effects remain injected by each host.
- The shared factory has direct tests for its exact command boundary and asynchronous error behavior.
- Extension and desktop behavior remains covered by their existing integration suites.

## Single source of truth

`createProgressViewSecondTierHandlers` in `ProgressViewCommandHandlers.ts` is now the sole dispatcher for the 15 commands listed above. The extension and desktop construct the same controller set and provide only the operations that necessarily differ between hosts, such as renderer posting, state restoration, and user messages.

This keeps protocol-to-controller routing in one place without moving VS Code or Electron dependencies into host-neutral code. Restore failure reporting belongs to each host callback: the extension command already owns its error path, while desktop reports failures from its local state builder.

## Duplication and abstraction budget

The change removes two parallel command maps and adds one shared factory with a single dependency interface. The factory owns substantive dispatch behavior rather than merely forwarding to another wrapper layer. No new class, lifecycle, registry, or pass-through factory is introduced.

Voice recording is deliberately excluded because its two host implementations do not have the same contract. First-tier progress handlers and genuinely host-specific commands remain in their existing owners.

## Net elements (R6)

Diffstat: 4 files changed, 615 insertions, 302 deletions. Most inserted lines are the consolidated factory and 189 lines of focused tests; the two host command maps become substantially smaller.

Exported surface: one factory and one dependency interface are added. No existing export is removed.

## Consumer counts (R8)

The new factory has exactly two production consumers:

- the VS Code extension `ProgressViewMessageHandler`;
- the Electron `DesktopProgressBridge`.

All 15 shared command keys are asserted in a direct factory test. Existing inbound message schemas and outbound renderer messages are unchanged. No subscriber, command constant, or public IPC type is removed.

## Host impact

- Extension: command results continue through VS Code-specific state restoration, messages, proposal handling, and follow-up launch callbacks.
- Desktop: command results continue through Electron-specific renderer posting, state construction, and execution-launch callbacks.
- CLI: unaffected.

## Scheduled refactoring

None. Recording remains host-specific by design, and no further common layer is needed for this issue.

## Validation

- `npm run format` — clean through the pre-commit hook.
- `npm run typecheck` — clean across all packages.
- `npm run lint` — clean across the repository.
- `npm run compile:fast` — passed.
- Relevant suites — 3 files, 143 tests passed.
- Full `npm test` — 798 files passed and 7,958 tests passed; one unrelated QuickJS memory-limit timing assertion took 3.171 seconds against a 3-second threshold while four repository-wide checks ran concurrently. The same test passed in isolation in 217 ms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent execution paths (retry, API keys, follow-ups, compaction) on both hosts; behavior should be equivalent but regressions would affect live runs, not just UI.
> 
> **Overview**
> **Consolidates 15 duplicated progress-view IPC commands** (workflow diff/pack/clean, retry, API-key retry, restore state, compaction, follow-ups, polish, etc.) into **`createProgressViewSecondTierHandlers`** in `ProgressViewCommandHandlers.ts`, alongside a **`ProgressViewSecondTierActions`** callback surface for host-specific effects.
> 
> The **VS Code** `ProgressViewMessageHandler` and **desktop** `DesktopProgressBridge` now build that dependency bag from their existing controllers and spread the factory next to first-tier `progressHost.commandHandlers`. **Recording stays per-host**; the extension still **overrides** `USE_OWN_API_KEY` (Copilot fallback) and `POLISH_FOLLOW_UP` (progress UI).
> 
> Adds **vitest coverage** for the factory’s command set and async/error paths (retry unavailable, restore failures, compaction notify, polish errors).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1839d6ef286d165c8195504ec9859f144f6b996f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

