### PR TITLE
ci(release): fix typecheck OOM and gate unpublished agent package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Type check
+        # tsc on this workspace exceeds Node's default heap on the CI runner
+        # (v0.39.10 release OOMed with exit 134); mirror the lint script's bump.
+        env:
+          NODE_OPTIONS: '--max-old-space-size=6144'
         run: pnpm run typecheck
 
       # Fail the release before building/publishing if the code-generated
@@ -148,7 +152,10 @@ jobs:
 
   publish-agent:
     name: Publish agent package to npm (Trusted Publishing)
-    if: ${{ !github.event.release.prerelease && startsWith(github.event.release.tag_name, 'cli-v') }}
+    # NOT PUBLISHED YET: @texra-ai/agent has no npm package or trusted
+    # publisher configured, so this job 404s on every cli-v* release. To
+    # re-enable, drop the `false &&` once the package is ready to ship.
+    if: ${{ false && !github.event.release.prerelease && startsWith(github.event.release.tag_name, 'cli-v') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:


### PR DESCRIPTION
## Summary

Two release-workflow fixes surfaced by the 0.39.10 release:

1. **publish-extension typecheck OOM**: the `Type check` step runs `pnpm run typecheck` with Node's default heap; tsc on this workspace now exceeds it on the ubuntu runner (v0.39.10 publish failed twice with exit 134 / mark-compact OOM). Bump `NODE_OPTIONS` to 6144 MB, mirroring the repo's lint script.
2. **publish-agent 404 on every CLI release**: `@texra-ai/agent` is not published yet (no npm package, no trusted publisher configured), so the job fails every `cli-v*` release with npm E404. Gate it off with `false &&` keeping the original condition in place; re-enable by dropping the `false &&` when the package ships.

## Issue acceptance gates

No tracking issue — release-blocker triage. Gates: (1) release typecheck step gets the same heap headroom as lint; (2) releases go green without publishing the agent package; (3) re-enabling the agent publish stays a one-token change.

## Single source of truth

`.github/workflows/release.yml` — the only publish path (protocol forbids local vsce/npm publish).

## Duplication and abstraction budget

None — in-place edits to the existing steps.

## Net elements (R6)

Not a refactor. 1 file, +8/−1, no new symbols.

## Consumer counts (R8)

n/a — CI-only change; the gated job's tag/version assertions remain intact for re-enablement.

## Host impact

Extension: unblocks Marketplace + Open VSX publish.

Desktop: none.

CLI: npm publish of `@texra-ai/cli` unchanged; agent package no longer attempted.

## Scheduled refactoring

Re-enable `publish-agent` when `@texra-ai/agent` is ready to publish (trusted publisher on npmjs.com).

## Validation

- YAML inspected; no type/lint surface (workflow-only change). The v0.39.10 re-cut will exercise it end to end.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow edits with no runtime or auth changes; agent publish is intentionally skipped until the package exists on npm.
> 
> **Overview**
> Unblocks extension releases that were failing during CI **typecheck** by setting `NODE_OPTIONS: '--max-old-space-size=6144'` on that step—the same heap limit already used by the root **lint** script—after v0.39.10 hit Node OOM (exit 134) on the default heap.
> 
> Stops **CLI releases** from failing on a missing npm package by hard-disabling the `publish-agent` job with `false &&` in its `if` condition while keeping the original `cli-v*` guard in place for a one-line re-enable when `@texra-ai/agent` is ready to ship.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 071a99e5b9d0ef33e2bbf7d5a0118ce67a052d05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->