### PR TITLE
docs: add open-source readiness audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,25 +165,32 @@ jobs:
       - name: Check guidance file references resolve
         run: node scripts/check-guidance-refs.mjs
 
-  # Windows is in the matrix because TeXRA ships there and a good deal of the
-  # code is platform-specific -- tool discovery under Program Files, the
-  # Strawberry/tlperl Perl lookups, path normalization, the CLI's win32
-  # branches. None of that was exercised by CI while every job ran on Linux,
-  # which is how a Ghostscript path list frozen at 9.x and a missing TeX Live
-  # Perl directory both survived. Windows runners bill at 2x, so the shard count
-  # is unchanged rather than widened.
+  # TODO(windows-ci): add windows-latest to this matrix. TeXRA ships on Windows
+  # and a good deal of the code is platform-specific -- tool discovery under
+  # Program Files, the Perl lookups, path normalization, the CLI's win32
+  # branches -- none of which any runner exercises today. That gap is how a
+  # Ghostscript path list frozen at 9.x and a missing TeX Live Perl directory
+  # both survived.
+  #
+  # Adding it was tried in #9397 and reverted: the suite has ~10 pre-existing
+  # Windows failures across CompiledPdfArtifacts, RunStorageEntryInspection,
+  # ExecutionLease, and FilesUtils. Most are `\` vs `/` in expectations, two are
+  # capability gaps in the fake filesystem (chmod-based permission simulation
+  # and symlink creation), and at least one is a real product bug -- artifact
+  # paths came back with a duplicated run segment (`output\r4\r4\sections\...`).
+  # Those need fixing first, in their own change; a job that cannot pass is
+  # worse than no job.
   test:
-    name: kernel tests (${{ matrix.os }}, shard ${{ matrix.shard }}/2)
+    name: kernel tests (linux, shard ${{ matrix.shard }}/2)
     needs: changes
     if: needs.changes.outputs.code == 'true' && github.event_name != 'schedule'
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
-      # Run every leg to completion so a red run reports all failures at once
-      # instead of hiding the other shards' results.
+      # Run both shards to completion so a red run reports every failure at
+      # once instead of hiding the other shard's results.
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
         shard: [1, 2]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,17 +165,25 @@ jobs:
       - name: Check guidance file references resolve
         run: node scripts/check-guidance-refs.mjs
 
+  # Windows is in the matrix because TeXRA ships there and a good deal of the
+  # code is platform-specific -- tool discovery under Program Files, the
+  # Strawberry/tlperl Perl lookups, path normalization, the CLI's win32
+  # branches. None of that was exercised by CI while every job ran on Linux,
+  # which is how a Ghostscript path list frozen at 9.x and a missing TeX Live
+  # Perl directory both survived. Windows runners bill at 2x, so the shard count
+  # is unchanged rather than widened.
   test:
-    name: kernel tests (linux, shard ${{ matrix.shard }}/2)
+    name: kernel tests (${{ matrix.os }}, shard ${{ matrix.shard }}/2)
     needs: changes
     if: needs.changes.outputs.code == 'true' && github.event_name != 'schedule'
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
-      # Run both shards to completion so a red run reports every failure at
-      # once instead of hiding the other shard's results.
+      # Run every leg to completion so a red run reports all failures at once
+      # instead of hiding the other shards' results.
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
         shard: [1, 2]
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,11 @@ packages/desktop/extension/
 references/openrouter-skills/
 
 .pnpm-store/
-# CI checks out a private trusted-actions repo here at runtime; never commit it.
+# The bot workflows (claude.yml, claude-code-review.yml, issue-tracker.yml)
+# check this repo out a second time here at the PR's *base* ref, so the
+# automation prompts and tool allowlists they run with come from trusted
+# committed history rather than the PR branch under review. Runtime-only;
+# never commit it.
 .trusted-actions/
 
 # Generated TypeScript compiler output

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,66 +2,61 @@
 
 ## Supported versions
 
-TeXRA ships from a single release line across all three surfaces (VS Code
-extension, desktop app, and `@texra-ai/cli`). Only the **latest released
-version** receives security fixes. Please upgrade before reporting — see the
+TeXRA ships from a single release line across all three surfaces: the VS Code
+extension, the desktop app, and `@texra-ai/cli`. Only the latest released
+version gets security fixes. Please upgrade before reporting — see the
 [changelog](./CHANGELOG.md) for what is current.
 
 ## Reporting a vulnerability
 
-**Do not open a public issue for a security problem.**
+Do not open a public issue for a security problem.
 
-Email **contact@texra.ai** with `SECURITY` in the subject line. Please include:
+Email **contact@texra.ai** with `SECURITY` in the subject line, and include:
 
-- what the issue is, and which surface it affects (extension / desktop / CLI /
+- what the issue is, and which surface it affects (extension, desktop, CLI, or
   the hosted relay at `remote.texra.ai`)
-- the version you observed it on
+- the version you saw it on
 - steps to reproduce, or a proof of concept
 - the impact you believe it has
 
-You should get an acknowledgement within **5 business days**. TeXRA is a small
-team, so please allow reasonable time for a fix before disclosing publicly. We
-will tell you when a fix ships and are glad to credit you in the changelog
-unless you would rather stay anonymous.
+You will get an acknowledgement within 5 business days. TeXRA is a small team;
+please allow time for a fix before disclosing publicly. We will tell you when a
+fix ships, and will credit you in the changelog unless you would rather stay
+anonymous.
 
-## What is in scope
-
-The parts of TeXRA that handle credentials and untrusted input are the areas
-worth the most scrutiny:
+## In scope
 
 - **Credential storage and transport** — provider API keys (VS Code
-  SecretStorage, the Electron keychain, and the CLI's credential store), OAuth
-  tokens, and relay access tokens.
-- **The authentication flows** — OAuth callbacks and deep links, the device-code
+  SecretStorage, the Electron keychain, the CLI credential store), OAuth tokens,
+  and relay access tokens.
+- **Authentication flows** — OAuth callbacks and deep links, the device-code
   flow, and the auth bridge.
 - **Agent tool execution** — shell, file-write, and edit tools, including the
-  per-stream approval gate and anything that lets an agent act without it.
+  per-stream approval gate and anything that bypasses it.
 - **Prompt injection that escalates privilege** — content in a user's documents,
-  tool results, or fetched pages that causes an agent to take an action the
-  approval gate was supposed to cover.
-- **The hosted relay** — authentication, tier enforcement, rate and spend
-  limits.
+  tool results, or fetched pages that makes an agent take an action the approval
+  gate should have covered.
+- **The hosted relay** — authentication, tier enforcement, rate and spend limits.
 - **Webview and renderer isolation** — the VS Code webviews and the Electron
   renderer, including navigation policy and any path from rendered content to
   host APIs.
 
-## What is not in scope
+## Out of scope
 
-- Findings that require an already-compromised machine or an attacker who
-  already has the user's provider API keys.
-- The behaviour of third-party model providers themselves. Report those to the
-  provider.
-- An agent producing wrong, low-quality, or unexpected _content_. That is a bug
-  — please file it as one — not a vulnerability.
-- Missing hardening headers or similar findings on the marketing site with no
-  demonstrated impact.
+- Findings that require an already-compromised machine, or an attacker who
+  already holds the user's provider API keys.
+- The behaviour of third-party model providers. Report those to the provider.
+- An agent producing wrong, low-quality, or unexpected content. File that as a
+  bug.
+- Missing hardening headers on the marketing site with no demonstrated impact.
 - Automated scanner output with no accompanying analysis.
 
-## A note on API keys
+## API keys
 
 TeXRA runs agents against model providers using either your own API keys or
-TeXRA's hosted relay. Keys you supply are stored by the host platform's secret
-store and sent only to the provider (or to the relay, when a request is routed
-through it). If you believe a key of yours has been exposed by TeXRA, rotate it
-with your provider first, then report it — rotating immediately limits the
-damage regardless of what we find.
+TeXRA's hosted relay. Keys you supply are held in the host platform's secret
+store and sent only to the provider, or to the relay when a request is routed
+through it.
+
+If you think a key of yours has been exposed by TeXRA, rotate it with your
+provider first, then report it.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -54,9 +54,18 @@ anonymous.
 ## API keys
 
 TeXRA runs agents against model providers using either your own API keys or
-TeXRA's hosted relay. Keys you supply are held in the host platform's secret
-store and sent only to the provider, or to the relay when a request is routed
-through it.
+TeXRA's hosted relay. Where a key lives depends on how you supplied it:
+
+- **Entered through TeXRA** (`TeXRA: Set API Key`, the desktop credential
+  settings, or `texra auth`) — stored in the host's secret store: VS Code
+  SecretStorage, the Electron keychain, or the CLI credential store.
+- **Supplied through the environment** — an exported variable, or a workspace
+  `.env` that the extension loads at activation. These are read straight from
+  the environment at request time and never enter any secret store. A `.env` is
+  plain text in your workspace, so keep it out of version control.
+
+Either way the key is sent only to the provider, or to the relay when a request
+is routed through it.
 
 If you think a key of yours has been exposed by TeXRA, rotate it with your
 provider first, then report it.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,67 @@
+# Security Policy
+
+## Supported versions
+
+TeXRA ships from a single release line across all three surfaces (VS Code
+extension, desktop app, and `@texra-ai/cli`). Only the **latest released
+version** receives security fixes. Please upgrade before reporting — see the
+[changelog](./CHANGELOG.md) for what is current.
+
+## Reporting a vulnerability
+
+**Do not open a public issue for a security problem.**
+
+Email **contact@texra.ai** with `SECURITY` in the subject line. Please include:
+
+- what the issue is, and which surface it affects (extension / desktop / CLI /
+  the hosted relay at `remote.texra.ai`)
+- the version you observed it on
+- steps to reproduce, or a proof of concept
+- the impact you believe it has
+
+You should get an acknowledgement within **5 business days**. TeXRA is a small
+team, so please allow reasonable time for a fix before disclosing publicly. We
+will tell you when a fix ships and are glad to credit you in the changelog
+unless you would rather stay anonymous.
+
+## What is in scope
+
+The parts of TeXRA that handle credentials and untrusted input are the areas
+worth the most scrutiny:
+
+- **Credential storage and transport** — provider API keys (VS Code
+  SecretStorage, the Electron keychain, and the CLI's credential store), OAuth
+  tokens, and relay access tokens.
+- **The authentication flows** — OAuth callbacks and deep links, the device-code
+  flow, and the auth bridge.
+- **Agent tool execution** — shell, file-write, and edit tools, including the
+  per-stream approval gate and anything that lets an agent act without it.
+- **Prompt injection that escalates privilege** — content in a user's documents,
+  tool results, or fetched pages that causes an agent to take an action the
+  approval gate was supposed to cover.
+- **The hosted relay** — authentication, tier enforcement, rate and spend
+  limits.
+- **Webview and renderer isolation** — the VS Code webviews and the Electron
+  renderer, including navigation policy and any path from rendered content to
+  host APIs.
+
+## What is not in scope
+
+- Findings that require an already-compromised machine or an attacker who
+  already has the user's provider API keys.
+- The behaviour of third-party model providers themselves. Report those to the
+  provider.
+- An agent producing wrong, low-quality, or unexpected _content_. That is a bug
+  — please file it as one — not a vulnerability.
+- Missing hardening headers or similar findings on the marketing site with no
+  demonstrated impact.
+- Automated scanner output with no accompanying analysis.
+
+## A note on API keys
+
+TeXRA runs agents against model providers using either your own API keys or
+TeXRA's hosted relay. Keys you supply are stored by the host platform's secret
+store and sent only to the provider (or to the relay, when a request is routed
+through it). If you believe a key of yours has been exposed by TeXRA, rotate it
+with your provider first, then report it — rotating immediately limits the
+damage regardless of what we find.

--- a/config/ratchets/architecture-edges-baseline.json
+++ b/config/ratchets/architecture-edges-baseline.json
@@ -71,6 +71,7 @@
     { "from": "skills", "to": "utils", "kind": "value" },
     { "from": "telemetry", "to": "auth", "kind": "value" },
     { "from": "telemetry", "to": "logger", "kind": "value" },
+    { "from": "telemetry", "to": "platform", "kind": "value" },
     { "from": "telemetry", "to": "shared", "kind": "value" },
     { "from": "telemetry", "to": "utils", "kind": "value" },
     { "from": "tools", "to": "agent", "kind": "value" },

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -305,30 +305,24 @@ Dashboard. Click **Change** in the directory info bar to select a new folder, or
 ## Usage Logging
 
 TeXRA records one usage entry per model round and sends it to TeXRA's backend.
-This is what meters relay and subscription usage against your plan.
+These entries meter relay and subscription usage against your plan.
 
 ```json
 "texra.telemetry.enabled": true
 ```
 
-Each entry contains only:
+Each entry contains the model and provider, the agent name and category, the
+input, output, cached, and reasoning token counts, the computed cost, and the
+response time. It contains no prompt text, document content, file names, or
+anything else from your workspace. Entries are sent only while you are signed
+in; signed out, nothing leaves your machine.
 
-- the model and provider used
-- the agent name and category
-- input, output, cached, and reasoning token counts
-- the computed cost and the response time
+Set `texra.telemetry.enabled` to `false` to send nothing. This takes effect
+immediately, and entries already queued are discarded rather than sent. Because
+these entries are what meters hosted usage, disabling them also stops relay and
+subscription spend accounting — leave it on if you rely on hosted access.
 
-It does **not** contain prompt text, document content, file names, or anything
-from your workspace. Entries are only transmitted while you are signed in — if
-you are signed out, nothing leaves your machine.
-
-Set `texra.telemetry.enabled` to `false` to send nothing. Turning it off takes
-effect immediately: entries already queued are discarded rather than sent. Note
-that because these entries are what meters hosted usage, disabling them also
-stops relay and subscription spend accounting, so leave it on if you rely on
-hosted access.
-
-In VS Code the setting is under **TeXRA → Privacy**; in the CLI and desktop app
+In VS Code the setting is under **TeXRA → Privacy**. In the CLI and desktop app,
 set it in `.texra/config.json`:
 
 ```json

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -305,22 +305,46 @@ Dashboard. Click **Change** in the directory info bar to select a new folder, or
 ## Usage Logging
 
 TeXRA records one usage entry per model round and sends it to TeXRA's backend.
-These entries meter relay and subscription usage against your plan.
 
 ```json
 "texra.telemetry.enabled": true
 ```
 
-Each entry contains the model and provider, the agent name and category, the
-input, output, cached, and reasoning token counts, the computed cost, and the
-response time. It contains no prompt text, document content, file names, or
-anything else from your workspace. Entries are sent only while you are signed
-in; signed out, nothing leaves your machine.
+Each entry contains exactly these fields:
 
-Set `texra.telemetry.enabled` to `false` to send nothing. This takes effect
-immediately, and entries already queued are discarded rather than sent. Because
-these entries are what meters hosted usage, disabling them also stops relay and
-subscription spend accounting — leave it on if you rely on hosted access.
+| Field                            | Value                                                                     |
+| -------------------------------- | ------------------------------------------------------------------------- |
+| `model`, `provider`              | which model answered the round                                            |
+| `agentName`, `agentCategory`     | which agent ran it                                                        |
+| `inputTokens`, `outputTokens`    | token counts, excluding cache hits                                        |
+| `cachedInputTokens`              | prompt-cache hits                                                         |
+| `reasoningTokens`                | reasoning tokens, where the provider reports them                         |
+| `cost`                           | the computed cost in USD                                                  |
+| `responseTimeMs`                 | round-trip time                                                           |
+| `usedRelay`, `usageRoute`        | whether the round went through the relay, a subscription, or your own key |
+| `streamId`                       | an opaque id grouping rounds from one session                             |
+| `timestamp`                      | when the round finished                                                   |
+| `extensionVersion`, `editorType` | the TeXRA version and host (`cli`, `Visual Studio Code`, …)               |
+
+No prompt text, document content, file names, or workspace paths are included.
+
+Entries are transmitted only while you are signed in. Rounds recorded while you
+are signed out stay queued in memory, and are uploaded if you sign in later in
+the same session; they are discarded when TeXRA exits.
+
+### Opting out
+
+Set `texra.telemetry.enabled` to `false`. This takes effect immediately, and
+optional entries already queued are dropped rather than sent.
+
+It does not suppress everything. Rounds that ran through the relay or a
+subscription (`usageRoute` of `relay`, `chatgpt-subscription`, or
+`kimi-code-subscription`) are still sent, because those records are what meters
+your hosted usage against your plan's monthly spend limit — they are billing
+data, not analytics. What the setting turns off is logging for rounds billed to
+your own API key (`usageRoute` of `api-key`), which cost TeXRA nothing.
+
+If you use only your own API keys, opting out stops all usage reporting.
 
 In VS Code the setting is under **TeXRA → Privacy**. In the CLI and desktop app,
 set it in `.texra/config.json`:
@@ -330,6 +354,10 @@ set it in `.texra/config.json`:
   "texra.telemetry.enabled": false
 }
 ```
+
+The value must be a JSON boolean. A quoted `"false"` is not a boolean, so TeXRA
+logs a warning and treats the setting as off rather than silently reading it as
+`true`.
 
 ## Logger Configuration
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -302,6 +302,41 @@ The custom agents directory can be changed from the **Agents** tab in the TeXRA
 Dashboard. Click **Change** in the directory info bar to select a new folder, or
 **Reset** to return to the default location inside global storage.
 
+## Usage Logging
+
+TeXRA records one usage entry per model round and sends it to TeXRA's backend.
+This is what meters relay and subscription usage against your plan.
+
+```json
+"texra.telemetry.enabled": true
+```
+
+Each entry contains only:
+
+- the model and provider used
+- the agent name and category
+- input, output, cached, and reasoning token counts
+- the computed cost and the response time
+
+It does **not** contain prompt text, document content, file names, or anything
+from your workspace. Entries are only transmitted while you are signed in — if
+you are signed out, nothing leaves your machine.
+
+Set `texra.telemetry.enabled` to `false` to send nothing. Turning it off takes
+effect immediately: entries already queued are discarded rather than sent. Note
+that because these entries are what meters hosted usage, disabling them also
+stops relay and subscription spend accounting, so leave it on if you rely on
+hosted access.
+
+In VS Code the setting is under **TeXRA → Privacy**; in the CLI and desktop app
+set it in `.texra/config.json`:
+
+```json
+{
+  "texra.telemetry.enabled": false
+}
+```
+
 ## Logger Configuration
 
 Control logging behavior:

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -173,7 +173,7 @@ pdflatex --version
 ### Perl
 
 ::: info OPTIONAL
-Perl backs the `latexindent` and `latexdiff` LaTeX tools (both are Perl scripts). Install it only if you use auto-formatting or LaTeX diffs — it's pre-installed on macOS/Linux and bundled with TeX Live, but **not** with MiKTeX.
+Perl backs the `latexindent` and `latexdiff` LaTeX tools (both are Perl scripts). You only need it if you use auto-formatting or LaTeX diffs. It ships with macOS and with TeX Live, and is present on most Linux installs — but **not** with MiKTeX, and not on minimal or container Linux images. Check with `perl --version` rather than assuming.
 :::
 
 #### Windows

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -173,13 +173,22 @@ pdflatex --version
 ### Perl
 
 ::: info OPTIONAL
-Perl backs the `latexindent` and `latexdiff` LaTeX tools (both are Perl scripts). Install it only if you use auto-formatting or LaTeX diffs — it's usually already bundled with MiKTeX/TeX Live and pre-installed on macOS/Linux.
+Perl backs the `latexindent` and `latexdiff` LaTeX tools (both are Perl scripts). Install it only if you use auto-formatting or LaTeX diffs — it's pre-installed on macOS/Linux and bundled with TeX Live, but **not** with MiKTeX.
 :::
 
 #### Windows
 
-- Included with MiKTeX or TeX Live
-- Verify installation by running `perl --version` in Command Prompt
+TeX Live for Windows ships its own Perl, so `latexindent` and `latexdiff` work out of the box. **MiKTeX does not bundle Perl** — if you installed MiKTeX (the option recommended above for beginners), install Perl separately:
+
+1. Download [Strawberry Perl](https://strawberryperl.com/)
+2. Run the installer, which adds Perl to your PATH
+3. Restart VS Code, then verify in Command Prompt or PowerShell:
+
+```bash
+perl --version
+```
+
+If you skip this on MiKTeX, TeXRA still compiles documents; only auto-formatting and LaTeX diffs are unavailable. The Setup Wizard flags the missing dependency and points to the same download.
 
 #### macOS
 

--- a/docs/proposals/2026-07-29-open-source-readiness.md
+++ b/docs/proposals/2026-07-29-open-source-readiness.md
@@ -11,6 +11,33 @@ cleanup.
 
 Sections are ordered by whether they block flipping the switch.
 
+## Status
+
+Everything that needed no decision from the maintainers has been done. What is
+left is genuinely waiting on a choice.
+
+| Item                                       | Status                                          |
+| ------------------------------------------ | ----------------------------------------------- |
+| §3.2 `packages/agent` repo metadata        | **Done**                                        |
+| §4.1 `SECURITY.md`                         | **Done**                                        |
+| §4.2 Telemetry opt-out                     | **Done** — `texra.telemetry.enabled`            |
+| §4.3 `npm test` green on a clean checkout  | **Done**                                        |
+| §4.5 Stale `.gitignore` comment            | **Done**                                        |
+| §1 Licensing and legal                     | Blocked — needs a license choice                |
+| §2 What gets published                     | Blocked — needs three product calls             |
+| §3.1 Repo identity                         | Blocked — needs the final repo home             |
+| §3.3 Secret scanning                       | Blocked — repo admin setting, and a timing call |
+| §4.1 `CONTRIBUTING.md` / `CODE_OF_CONDUCT` | Deliberately held — see below                   |
+| §4.4 `minimumReleaseAge`                   | Held — documented tradeoff, maintainer's call   |
+
+`CONTRIBUTING.md` and `CODE_OF_CONDUCT.md` are held on purpose rather than
+overlooked. Soliciting outside contributions while the repo is still "all rights
+reserved" with no CLA or DCO creates exactly the IP ambiguity §1.4 warns about —
+inbound patches with no clear grant, on a codebase whose copyright may later be
+assigned. They should land together with the license decision, not before it.
+`SECURITY.md` is different: a private path for reporting vulnerabilities is
+worth having under any license, and it invites no code.
+
 ---
 
 ## 1. Blockers — licensing and legal
@@ -130,9 +157,11 @@ so you are not running two trackers.
 
 ### 3.2 `packages/agent` has no repo metadata
 
-`@texra-ai/agent` is published to npm (`private: false`) with **no**
-`repository`, `bugs`, or `homepage` field. Fill these in — it's the package
-most likely to be found by someone who has never heard of TeXRA.
+**Done.** `@texra-ai/agent` is published to npm (`private: false`) and had **no**
+`repository`, `bugs`, `homepage`, or `author` field — the package most likely to
+be found by someone who has never heard of TeXRA. It now carries the same four
+fields as the CLI and extension packages, so it moves with them when §3.1 is
+settled.
 
 ### 3.3 GitHub secret scanning is off
 
@@ -147,17 +176,22 @@ protection is the thing that stops the first contributor accident.
 
 ### 4.1 No community files
 
-Missing: `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`,
-`.github/ISSUE_TEMPLATE/`. `.github/PULL_REQUEST_TEMPLATE.md` exists.
+`SECURITY.md` — **done**. It mattered more than usual here: the project handles
+user API keys, OAuth tokens, and a hosted relay, and there was no published way
+to report a vulnerability privately. It names `contact@texra.ai`, scopes what is
+worth reporting (credential storage, the auth flows, tool-execution approval,
+prompt injection that escalates privilege, relay enforcement, webview and
+renderer isolation), and tells reporters to rotate an exposed key first.
 
-`AGENTS.md` (38 KB) is excellent contributor material but is written for
-agents. A human `CONTRIBUTING.md` should point at it and lead with the single
-highest-value fact in this repo: **builds do not type check — run
-`npm run typecheck` or the `:safe` script variants.**
+Still missing: `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `.github/ISSUE_TEMPLATE/`,
+`.github/CODEOWNERS`. `.github/PULL_REQUEST_TEMPLATE.md` exists. The first two
+are held until the license lands (see **Status** above); the issue templates and
+CODEOWNERS depend on §3.1's repo home and on who is on the team.
 
-`SECURITY.md` matters more than usual here: the project handles user API keys,
-OAuth tokens, and a hosted relay. There is currently no published way to report
-a vulnerability privately.
+When `CONTRIBUTING.md` is written: `AGENTS.md` (38 KB) is excellent contributor
+material but is written for agents. The human version should point at it and
+lead with the single highest-value fact in this repo — **builds do not type
+check; run `npm run typecheck` or the `:safe` script variants.**
 
 ### 4.2 Telemetry has no opt-out
 
@@ -169,28 +203,65 @@ agent name and category, input/output/cached/reasoning token counts, cost, and
 response time to `remote.texra.ai/functions/v1/log-usage`.
 
 It only flushes when signed in — `flushQueuedBatch()` returns early without a
-relay access token — but **signed-in BYOK users are logged too**
-(`usedRelay: false` entries), and there is no key in
-`contributes.configuration` to turn it off.
+relay access token — but **signed-in BYOK users were logged too**
+(`usedRelay: false` entries), and there was no key in
+`contributes.configuration` to turn it off. Invisible in a private repo; in a
+public one it is the first thing people grep for.
 
-That is invisible in a private repo. In a public one it is the first thing
-people grep for. Add a setting, honour it in both hosts, and document what is
-collected.
+**Done.** `texra.telemetry.enabled` (default `true`, so no behaviour change) now
+gates it, added to `CoreSettingsShape` so all three hosts pick it up: VS Code
+surfaces it under **TeXRA → Privacy** at `application` scope — deliberately not
+`resource`, so a workspace cannot re-enable logging a user turned off — and the
+CLI and desktop read it from `.texra/config.json` via `JsonConfigProvider`, with
+`KNOWN_TEXRA_KEYS` picking it up automatically from `CORE_SETTING_PATHS`.
+
+The setting is read **live** on each queue and flush rather than snapshotted at
+`initialize()`, so turning it off takes effect immediately instead of at next
+launch, and the flush path discards rounds recorded before the opt-out rather
+than shipping one last batch.
+
+One trap worth remembering, since it is not obvious from the names: the discard
+is gated on the user setting **alone**, never on `config.enabled`. That field is
+the lifecycle gate, and `dispose()` clears it precisely so no new entry is
+queued while shutdown drains the final batch. Keying the discard off it too
+silently dropped the last flush on every CLI exit — and with it the relay spend
+accounting. The existing "waits for successive active batches during disposal"
+test catches this; it is not redundant.
+
+Reading the setting adds a `telemetry -> platform` subsystem edge, which the
+LAY-1 ratchet correctly flagged as new. It is accepted and recorded in
+`config/ratchets/architecture-edges-baseline.json`: reaching host config through
+the `platform()` port is the sanctioned mechanism, and it is the same edge
+`src/tools/goal/goalFeatureFlag.ts` already relies on for its feature flag.
+
+Documented for users in `docs/guide/configuration.md` under "Usage Logging",
+including the fact that disabling it also stops hosted spend accounting.
 
 ### 4.3 `npm test` is not green on a clean checkout
 
-3 failures out of 7,965 (796 of 800 files pass). All environment-sensitive
-rather than real defects:
+**Done.** 3 failures out of 7,965 (796 of 800 files passed). CI on `main` is
+green, so all three were specific to a sandboxed or loaded machine — but a
+first-time contributor still ran `npm test` and saw red.
 
-| Test                                                        | Cause                                                      |
-| ----------------------------------------------------------- | ---------------------------------------------------------- |
-| `src/test-kernel/agent/WorkflowScriptEngine.vitest.ts:1741` | wall-clock assertion `< 3000 ms`; took 9,349 ms under load |
-| `src/test-kernel/desktop/DesktopDevScript.vitest.mts`       | requires an installed Electron binary                      |
-| `src/test-kernel/utils/system/SystemUtils.vitest.ts:224`    | process-group abort race in a container                    |
+| Test                                                        | Cause                                                      | Fix                     |
+| ----------------------------------------------------------- | ---------------------------------------------------------- | ----------------------- |
+| `src/test-kernel/desktop/DesktopDevScript.vitest.mts`       | `require('electron')` downloads the binary on demand       | made hermetic           |
+| `src/test-kernel/agent/WorkflowScriptEngine.vitest.ts:1741` | wall-clock assertion `< 3000 ms`; took 9,349 ms under load | budget widened          |
+| `src/test-kernel/utils/system/SystemUtils.vitest.ts:224`    | 1 s budget for process-group teardown                      | budget widened to ~10 s |
 
-A first-time contributor runs `npm test` and sees red. Gate each on its
-prerequisite (skip when Electron is absent; make the timing assertions
-tolerant or budget-relative).
+The Electron one was the interesting case. Electron 43 dropped its `postinstall`
+script — `require('electron')` now _downloads_ the platform binary the first
+time it is called. So `dev.mjs`'s module-level require turned a unit test into a
+network fetch on a fresh checkout, and a hard failure with no network. Rather
+than skip it, the test now sets `ELECTRON_OVERRIDE_DIST_PATH`, which
+short-circuits that resolution. No coverage is lost: the assertions only check
+the spawn arguments, env, and stdio, never the binary's location. The test is
+now hermetic everywhere instead of quietly depending on the network in CI.
+
+The other two are pure hang guards, not latency measurements — the memory test's
+containment is already proven by its `/memory/` rejection (a failure of the
+memory limit would reject with `/timed out/` instead), so a tight wall-clock
+bound there bought nothing and flaked whenever the suite saturated every core.
 
 ### 4.4 Supply-chain quarantine is disabled repo-wide
 
@@ -203,11 +274,13 @@ packages that actually need it.
 
 ### 4.5 A stale comment invents a private dependency
 
-`.gitignore`: _"CI checks out a private trusted-actions repo here at runtime;
-never commit it."_ It doesn't. The `.trusted-actions` checkout in
-`claude.yml`, `claude-code-review.yml`, and `issue-tracker.yml` has no
-`repository:` field — it is a self-checkout of this repo's own default branch.
-Outside readers will hunt for a private repo that does not exist.
+**Done.** `.gitignore` claimed _"CI checks out a private trusted-actions repo
+here at runtime; never commit it."_ It doesn't. The `.trusted-actions` checkout
+in `claude.yml`, `claude-code-review.yml`, and `issue-tracker.yml` has no
+`repository:` field — it is a second checkout of _this_ repo at the PR's base
+ref, so the automation prompts and tool allowlists come from trusted committed
+history rather than the branch under review. Outside readers would have hunted
+for a private repo that does not exist; the comment now says what it is for.
 
 ---
 
@@ -279,17 +352,20 @@ alias boundary. Nothing to delete — worth tidying the declarations if the
 
 ## Suggested order
 
+What remains, all of it downstream of a decision:
+
 1. Pick the license → rewrite `LICENSE`, the three `LICENSE.txt`, all
    `license` fields, and the README footer. (§1.1, §1.2)
 2. Split the TOS into Service vs. Software; settle the copyright line and
    DCO/CLA. (§1.3, §1.4)
 3. Decide `prompts/agents/remote/`, `supabase/`, and internal `docs/`. (§2)
-4. Settle the repo home; fix every `repository`/`bugs` link; migrate issues. (§3.1, §3.2)
+4. Settle the repo home; fix every `repository`/`bugs` link; migrate issues. (§3.1)
 5. Enable secret scanning + push protection. (§3.3)
-6. Add the telemetry opt-out. (§4.2)
-7. Add `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, issue
-   templates, `CODEOWNERS`. (§4.1)
-8. Make `npm test` green on a clean checkout. (§4.3)
-9. Housekeeping: `minimumReleaseAge`, the stale `.gitignore` comment. (§4.4, §4.5)
+6. Once 1–2 land: `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`. Once 4 lands:
+   issue templates and `CODEOWNERS`. (§4.1)
+7. Revisit `minimumReleaseAge` at whatever profile the project ends up with.
+   (§4.4)
 
-Steps 1–5 gate the flip. 6–9 can land in the same week but do not block it.
+Steps 1–5 gate the flip. Step 1 unblocks the most: it is the only thing 6
+waits on, and the licence text is the last piece of the repo that still says
+the opposite of what you intend.

--- a/docs/proposals/2026-07-29-open-source-readiness.md
+++ b/docs/proposals/2026-07-29-open-source-readiness.md
@@ -9,19 +9,21 @@ licensing and product decisions, not engineering cleanup.
 
 ## Status
 
-| Item                                       | Status                           |
-| ------------------------------------------ | -------------------------------- |
-| §1 Licensing and legal                     | Needs a license choice           |
-| §2 What gets published                     | Needs three product calls        |
-| §3.1 Repo identity                         | Needs the final repo home        |
-| §3.2 `packages/agent` repo metadata        | Done                             |
-| §3.3 Secret scanning                       | Repo admin setting               |
-| §4.1 `SECURITY.md`                         | Done                             |
-| §4.1 `CONTRIBUTING.md` / `CODE_OF_CONDUCT` | Held until the license lands     |
-| §4.2 Telemetry opt-out                     | Done — `texra.telemetry.enabled` |
-| §4.3 `npm test` green on a clean checkout  | Done                             |
-| §4.4 `minimumReleaseAge`                   | Open — documented tradeoff       |
-| §4.5 Stale `.gitignore` comment            | Done                             |
+| Item                                       | Status                            |
+| ------------------------------------------ | --------------------------------- |
+| §1 Licensing and legal                     | Needs a license choice            |
+| §2 What gets published                     | Needs three product calls         |
+| §3.1 Repo identity                         | Needs the final repo home         |
+| §3.2 `packages/agent` repo metadata        | Done                              |
+| §3.3 Secret scanning                       | Repo admin setting                |
+| §4.1 `SECURITY.md`                         | Done                              |
+| §4.1 `CONTRIBUTING.md` / `CODE_OF_CONDUCT` | Held until the license lands      |
+| §4.2 Telemetry opt-out                     | Done — `texra.telemetry.enabled`  |
+| §4.3 `npm test` green on a clean checkout  | Done                              |
+| §4.4 `minimumReleaseAge`                   | Open — documented tradeoff        |
+| §4.5 Stale `.gitignore` comment            | Done                              |
+| §4.6 CI ran only on Linux                  | Done — Windows in the matrix      |
+| §4.7 Windows tool discovery                | Done — Ghostscript, TeX Live Perl |
 
 `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md` are held rather than skipped.
 Soliciting contributions under "all rights reserved" with no CLA or DCO creates
@@ -221,11 +223,11 @@ including that disabling it also stops hosted spend accounting.
 Done. 3 failures out of 7,965 (796 of 800 files passed). CI on `main` was green,
 so all three were specific to a sandboxed or loaded machine.
 
-| Test                                                        | Cause                                                      | Fix                     |
-| ----------------------------------------------------------- | ---------------------------------------------------------- | ----------------------- |
-| `src/test-kernel/desktop/DesktopDevScript.vitest.mts`       | `require('electron')` downloads the binary on demand       | made hermetic           |
-| `src/test-kernel/agent/WorkflowScriptEngine.vitest.ts:1741` | wall-clock assertion `< 3000 ms`; took 9,349 ms under load | budget widened          |
-| `src/test-kernel/utils/system/SystemUtils.vitest.ts:224`    | 1 s budget for process-group teardown                      | budget widened to ~10 s |
+| Test                                                     | Cause                                                      | Fix                                 |
+| -------------------------------------------------------- | ---------------------------------------------------------- | ----------------------------------- |
+| `src/test-kernel/desktop/DesktopDevScript.vitest.mts`    | `require('electron')` downloads the binary on demand       | made hermetic                       |
+| `src/test-kernel/agent/WorkflowScriptEngine.vitest.ts`   | wall-clock assertion `< 3000 ms`; took 9,349 ms under load | assertion removed, per-test timeout |
+| `src/test-kernel/utils/system/SystemUtils.vitest.ts:224` | 1 s budget for process-group teardown                      | ~10 s budget, per-test timeout      |
 
 Electron 43 dropped its `postinstall`; `require('electron')` now downloads the
 platform binary on first call. `dev.mjs` requires it at module load, so the test
@@ -234,10 +236,18 @@ network. It now sets `ELECTRON_OVERRIDE_DIST_PATH`, which short-circuits that
 resolution. The assertions cover spawn arguments, env, and stdio, not the binary
 path, so no coverage is lost.
 
-The other two bounds are hang guards, not latency measurements. The memory
-test's containment is established by its `/memory/` rejection — a failure of the
-memory limit rejects with `/timed out/` instead — so the wall-clock bound only
-needs to catch a wedged process.
+The other two were wall-clock bounds standing in as hang guards. Both needed a
+per-test timeout to have any effect at all, because `vitest.config.mjs` sets
+`testTimeout: 10000` and the widened bounds exceeded it — the runner aborted the
+test before the assertion could run, so the first attempt at this traded an
+assertion failure for a timeout failure.
+
+The memory test then lost its bound entirely. Containment is established by its
+`/memory/` rejection (a failure of the memory limit rejects with `/timed out/`
+instead), and filling the guest heap 1 MB at a time took 78 s during a
+full-suite run on a contended machine — so any bound tight enough to mean
+something is a bound the test trips over. The per-test timeout is the hang
+guard; a redundant assertion measuring machine load is not.
 
 ### 4.4 Supply-chain quarantine is disabled repo-wide
 
@@ -257,6 +267,41 @@ and tool allowlists come from committed history rather than the branch under
 review. The comment now says that.
 
 ---
+
+### 4.6 CI only ever ran on Linux
+
+Done. Every `ci.yml` job was `ubuntu-latest` except the macOS webview smoke, so
+none of the platform-specific code was exercised: tool discovery under
+`Program Files`, the Strawberry/tlperl Perl lookups, path normalization, the
+CLI's `win32` branches. That is how a Ghostscript path list frozen at 9.x and a
+missing TeX Live Perl directory both survived — no test covered them and no
+runner ran them.
+
+`windows-latest` is now in the sharded kernel-test matrix, gating like the Linux
+shards. The shard count is unchanged rather than widened, because Windows
+runners bill at 2x. `timeout-minutes` went 20 → 30 for the slower runner.
+
+Still Linux-only: build, lint, typecheck, and the docs build. Those are
+platform-independent enough not to need duplicating.
+
+### 4.7 Windows tool discovery was frozen to specific versions
+
+Done. Two instances of the same bug, both found by reading the Windows probe
+list rather than by any test:
+
+- **Ghostscript** was six hardcoded `gs9.54`–`gs9.56` directories, so a current
+  10.x install was invisible unless already on `PATH`. Now globbed, with the 9.x
+  preference order preserved.
+- **TeX Live's Perl** (`tlpkg/tlperl/bin`) was not probed at all, so
+  `checkCoreDependencies()` reported Perl missing on a TeX Live box and the
+  Setup Wizard asked for Strawberry Perl the user did not need. `latexindent`
+  and `latexdiff` were unaffected — they resolve to the `.exe` wrappers under
+  `texlive/*/bin/*`, which use tlperl internally.
+
+Neither is covered by a test: `getExtraDirs()` takes no injection and caches at
+module scope, so exercising the win32 branch means faking `process.platform`,
+`globSync`, and the filesystem, and the assertion would restate the glob. §4.6
+is the real mitigation.
 
 ## 5. Verified clean
 

--- a/docs/proposals/2026-07-29-open-source-readiness.md
+++ b/docs/proposals/2026-07-29-open-source-readiness.md
@@ -22,7 +22,7 @@ licensing and product decisions, not engineering cleanup.
 | §4.3 `npm test` green on a clean checkout  | Done                              |
 | §4.4 `minimumReleaseAge`                   | Open — documented tradeoff        |
 | §4.5 Stale `.gitignore` comment            | Done                              |
-| §4.6 CI ran only on Linux                  | Done — Windows in the matrix      |
+| §4.6 CI runs only on Linux                 | Blocked — ~10 Windows failures    |
 | §4.7 Windows tool discovery                | Done — Ghostscript, TeX Live Perl |
 
 `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md` are held rather than skipped.
@@ -268,21 +268,37 @@ review. The comment now says that.
 
 ---
 
-### 4.6 CI only ever ran on Linux
+### 4.6 CI only ever runs on Linux
 
-Done. Every `ci.yml` job was `ubuntu-latest` except the macOS webview smoke, so
-none of the platform-specific code was exercised: tool discovery under
-`Program Files`, the Strawberry/tlperl Perl lookups, path normalization, the
-CLI's `win32` branches. That is how a Ghostscript path list frozen at 9.x and a
-missing TeX Live Perl directory both survived — no test covered them and no
-runner ran them.
+Not done — attempted and reverted, with the findings below.
 
-`windows-latest` is now in the sharded kernel-test matrix, gating like the Linux
-shards. The shard count is unchanged rather than widened, because Windows
-runners bill at 2x. `timeout-minutes` went 20 → 30 for the slower runner.
+Every `ci.yml` job is `ubuntu-latest` except the macOS webview smoke, so none of
+the platform-specific code is exercised: tool discovery under `Program Files`,
+the Perl lookups, path normalization, the CLI's `win32` branches. That is how a
+Ghostscript path list frozen at 9.x and a missing TeX Live Perl directory both
+survived — no test covered them and no runner ran them.
 
-Still Linux-only: build, lint, typecheck, and the docs build. Those are
-platform-independent enough not to need duplicating.
+Adding `windows-latest` to the sharded kernel-test matrix works, and immediately
+surfaced **~10 pre-existing Windows failures** (both Linux shards, static checks,
+build, and the macOS smoke stayed green). In three buckets:
+
+| Bucket                 | Where                                                                            | Nature                                                                                   |
+| ---------------------- | -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| Separator expectations | `CompiledPdfArtifacts.vitest.ts` ×5, `RunStorageEntryInspection.vitest.ts:202`   | `output\r2\paper.pdf` vs `output/r2/paper.pdf`; needs a decision on where to normalize   |
+| Fake-filesystem gaps   | `RunStorageEntryInspection.vitest.ts:77,135,156`, `ExecutionLease.vitest.ts:619` | symlinks report `kind: 'missing'`; chmod-based permission-denied simulation is a no-op   |
+| Real product bug       | `CompiledPdfArtifacts.vitest.ts:194,232,277`                                     | artifact paths carry a **duplicated run segment**: `output\r4\r4\sections\main-diff.pdf` |
+
+The third bucket is the reason this was reverted rather than merged: it is a
+genuine path-joining defect on Windows, not a test artifact, and it wants its own
+change with someone who can iterate against a Windows runner. Landing a gating
+job that cannot pass would have wedged every PR; making it non-gating would have
+been the silent-degradation antipattern.
+
+The matrix change is recorded as a `TODO(windows-ci)` comment above the `test`
+job in `ci.yml`, carrying this inventory so the next attempt starts from it.
+
+Still Linux-only regardless: build, lint, typecheck, and the docs build. Those
+are platform-independent enough not to need duplicating.
 
 ### 4.7 Windows tool discovery was frozen to specific versions
 

--- a/docs/proposals/2026-07-29-open-source-readiness.md
+++ b/docs/proposals/2026-07-29-open-source-readiness.md
@@ -1,0 +1,295 @@
+# Open-source readiness audit
+
+_Audited at `0.40.0` (`f7c3958`), 2026-07-29. Full history (17,585 commits),
+working tree, CI, dependency graph, and build/test/lint health._
+
+**Verdict.** The code is in good shape — typecheck and lint are clean, there
+are no secrets in history, dependency licensing is clean, and there is
+effectively **no dead code to remove**. What stands between here and a public
+repo is almost entirely legal and product-decision work, not engineering
+cleanup.
+
+Sections are ordered by whether they block flipping the switch.
+
+---
+
+## 1. Blockers — licensing and legal
+
+### 1.1 The root `LICENSE` is a placeholder
+
+`LICENSE` is 8 bytes containing the literal word `LICENSE`. It has never been
+a real license file.
+
+### 1.2 Everything currently declares itself proprietary
+
+Five places all say "proprietary, all rights reserved" and must agree on
+whatever license is chosen:
+
+| Where                                                 | Current state                                     |
+| ----------------------------------------------------- | ------------------------------------------------- |
+| `LICENSE`                                             | placeholder                                       |
+| `packages/agent/LICENSE.txt`                          | "TeXRA Proprietary License … All rights reserved" |
+| `packages/cli/LICENSE.txt`                            | same                                              |
+| `packages/extension/LICENSE.txt`                      | same                                              |
+| `license` field in the three published `package.json` | `SEE LICENSE IN LICENSE.txt`                      |
+| `README.md` footer                                    | "© TeXRA Team 2025–2026. All rights reserved."    |
+
+`packages/desktop` and `packages/trace-viewer` have no `license` field at all
+(both are `private: true`, so this is lower priority, but they still ship in
+the desktop installer).
+
+### 1.3 The Terms of Service contradict an OSS license
+
+`TERMS_OF_SERVICE.md` currently forbids exactly what an OSS license grants:
+
+- §29 — "Modify, adapt, or create derivative works of the Service."
+- §54 — "Attempt to reverse-engineer, decompile, or disassemble the Service…"
+- §62 — "TeXRA is proprietary software. All rights, title, and interest in the
+  Service, including its code, design, documentation, and trademarks, are
+  owned by the TeXRA team…"
+
+The TOS needs a clean split between **the Service** (hosted relay, accounts,
+subscriptions — still governed by the TOS) and **the software** (this repo —
+governed by the new license). Otherwise every user is under two contradictory
+grants.
+
+### 1.4 Copyright holder and contributor terms are undecided
+
+§62 also says rights "will be assigned to any successor entity upon
+incorporation." Decide the copyright line _before_ publishing, and decide
+whether inbound contributions need a DCO or a CLA — you want one if there is
+any chance of relicensing or assigning to a future entity. Retrofitting a CLA
+after outside contributions land is painful.
+
+Also missing: `.github/CODEOWNERS`, and the trademark position on the "TeXRA"
+name/logo (the TOS reserves trademarks; an OSS license should not silently
+grant them).
+
+---
+
+## 2. Blockers — decisions about what actually gets published
+
+These are business calls, not defects. Each one is a thing that is private
+today and becomes public the moment the repo flips.
+
+### 2.1 Hosted-specialist system prompts (`prompts/agents/remote/`)
+
+21 YAML files, 408 KB, containing the **full system prompts** for the
+sign-in-gated hosted specialists the README markets as the paid surface —
+`orchestrator`, `logic`, `notation`, `enhance`, `elevate`, `humanize`,
+`devise`, `apply`, `verifyFix`, `progressCheck`, and the whole Lean line.
+
+These are _not_ shipped in the VSIX. They live only here and are synced into
+Supabase by `scripts/sync-remote-agents.mjs`. A public repo publishes them.
+
+**Decide:** ship them (transparency, forkability) or move them to a private
+repo and keep the sync script pointed there.
+
+### 2.2 Server-side abuse controls (`supabase/`)
+
+Publishing `supabase/functions/relay/**` publishes the enforcement design
+verbatim: `requestGate.ts` (per-tier rate and concurrency limits),
+`enforcement.ts` (monthly spend verification), `requestLimits.ts`, and 22 SQL
+migrations including all the RLS policies. `src/auth/config.ts:129-133` also
+hardcodes the tier spend caps ($10 free / $50 Max / $300 Ultra).
+
+This is defensible — enforcement is server-side and doesn't depend on secrecy,
+and the RLS migrations look correctly scoped to `service_role`. But confirm
+deliberately that no control depends on obscurity before publishing, and
+decide whether `supabase/` belongs in the public repo at all.
+
+### 2.3 4.5 MB of internal design docs
+
+145 files across `docs/prds/` (77), `docs/proposals/` (68), `docs/dev/`,
+`docs/architecture/`, `docs/design/`, `docs/reference/`. They are excluded
+from the texra.ai site by `docs/.vitepress/publicDocs.js`, but that only
+governs the _site_ — a public repo publishes the files themselves.
+
+They contain no secrets and no business-sensitive material (checked: the only
+"revenue/margin" hits are CSS `margin`). They're genuinely good contributor
+context. **Decide:** keep as-is, or split to a private repo.
+
+---
+
+## 3. Blockers — repo identity and hardening
+
+### 3.1 The repo has two identities
+
+Code lives in `lionsr/texra` (private); issues live in the separate public
+`texra-ai/texra-issues`. Every published package points at the latter:
+
+- `packages/extension/package.json` — `repository`, `bugs` → `texra-issues`
+- `packages/cli/package.json` — same
+- `packages/desktop/package.json` — same
+- `README.md`, `docs/guide/{quick-start,installation,troubleshooting,acknowledgments,index}.md`,
+  `docs/index.md`, `docs/.vitepress/config.js` — all link to `texra-issues`
+- `.github/labels.yml:1` — "Source of truth for issue/PR labels on lionsr/texra"
+
+Decide the final home, update all of the above, and plan the issue migration
+so you are not running two trackers.
+
+### 3.2 `packages/agent` has no repo metadata
+
+`@texra-ai/agent` is published to npm (`private: false`) with **no**
+`repository`, `bugs`, or `homepage` field. Fill these in — it's the package
+most likely to be found by someone who has never heard of TeXRA.
+
+### 3.3 GitHub secret scanning is off
+
+Confirmed: the secret-scanning API returns _"Repository does not have GitHub
+Advanced Security enabled."_ Turn on **secret scanning and push protection**
+before flipping to public — both are free on public repositories, and push
+protection is the thing that stops the first contributor accident.
+
+---
+
+## 4. Should do before launch
+
+### 4.1 No community files
+
+Missing: `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`,
+`.github/ISSUE_TEMPLATE/`. `.github/PULL_REQUEST_TEMPLATE.md` exists.
+
+`AGENTS.md` (38 KB) is excellent contributor material but is written for
+agents. A human `CONTRIBUTING.md` should point at it and lead with the single
+highest-value fact in this repo: **builds do not type check — run
+`npm run typecheck` or the `:safe` script variants.**
+
+`SECURITY.md` matters more than usual here: the project handles user API keys,
+OAuth tokens, and a hosted relay. There is currently no published way to report
+a vulnerability privately.
+
+### 4.2 Telemetry has no opt-out
+
+`src/telemetry/UsageLogService.ts` defaults to `enabled: true` and is
+initialized unconditionally from both hosts
+(`packages/extension/src/extension.ts:490`,
+`packages/cli/src/runtime/initPlatform.ts:337`). It sends model, provider,
+agent name and category, input/output/cached/reasoning token counts, cost, and
+response time to `remote.texra.ai/functions/v1/log-usage`.
+
+It only flushes when signed in — `flushQueuedBatch()` returns early without a
+relay access token — but **signed-in BYOK users are logged too**
+(`usedRelay: false` entries), and there is no key in
+`contributes.configuration` to turn it off.
+
+That is invisible in a private repo. In a public one it is the first thing
+people grep for. Add a setting, honour it in both hosts, and document what is
+collected.
+
+### 4.3 `npm test` is not green on a clean checkout
+
+3 failures out of 7,965 (796 of 800 files pass). All environment-sensitive
+rather than real defects:
+
+| Test                                                        | Cause                                                      |
+| ----------------------------------------------------------- | ---------------------------------------------------------- |
+| `src/test-kernel/agent/WorkflowScriptEngine.vitest.ts:1741` | wall-clock assertion `< 3000 ms`; took 9,349 ms under load |
+| `src/test-kernel/desktop/DesktopDevScript.vitest.mts`       | requires an installed Electron binary                      |
+| `src/test-kernel/utils/system/SystemUtils.vitest.ts:224`    | process-group abort race in a container                    |
+
+A first-time contributor runs `npm test` and sees red. Gate each on its
+prerequisite (skip when Electron is absent; make the timing assertions
+tolerant or budget-relative).
+
+### 4.4 Supply-chain quarantine is disabled repo-wide
+
+`pnpm-workspace.yaml` sets `minimumReleaseAge: 0`, turning off pnpm 11's
+24-hour quarantine, while `.github/dependabot.yml` opens grouped dependency PRs
+daily. The comment explains the tradeoff (same-day `llm-zoo` bumps for new
+models), which was reasonable while private. A public, higher-profile repo
+raises the value of that window — consider scoping the override to the
+packages that actually need it.
+
+### 4.5 A stale comment invents a private dependency
+
+`.gitignore`: _"CI checks out a private trusted-actions repo here at runtime;
+never commit it."_ It doesn't. The `.trusted-actions` checkout in
+`claude.yml`, `claude-code-review.yml`, and `issue-tracker.yml` has no
+`repository:` field — it is a self-checkout of this repo's own default branch.
+Outside readers will hunt for a private repo that does not exist.
+
+---
+
+## 5. Verified clean — do not re-audit
+
+Recorded so this work isn't repeated.
+
+**Secrets.** Scanned all ~74,000 blobs in the full 17,585-commit history for
+OpenAI, Anthropic, GitHub (PAT/OAuth/App), AWS, Google, Slack, GitLab, npm,
+Supabase, and HuggingFace key formats plus PEM private keys: **zero hits.**
+
+The single JWT in history is a Supabase **anon** key (project ref
+`jntubmcgbhwtcktubelv`, `role: anon`) that used to sit in `src/auth/config.ts`
+and has since been replaced by `sb_publishable_…`. Anon and publishable keys
+are public by design and already ship in every VSIX. **No rotation or history
+rewrite is required.** No `service_role` key appears anywhere.
+
+Working tree is also clean: no credentials, no gitignored-but-tracked files, no
+real user data, no local author paths, no `.npmrc` with a private registry.
+
+**Dependency licensing.** 3,162 resolved packages: 2,349 MIT, 239 Apache-2.0,
+194 ISC, 114 BSD-3, 90 BSD-2, 50 0BSD, 41 BlueOak, remainder permissive.
+**Zero GPL / AGPL / SSPL / BUSL / Commons Clause.** The only weak copyleft is
+MPL-2.0 (`lightningcss`, and `dompurify` which is dual MPL/Apache) — file-level
+and fine for unmodified use. No vendored third-party source anywhere.
+
+**CI is already fork-safe.** `claude.yml`, `claude-code-review.yml`, and
+`issue-tracker.yml` all gate on
+`author_association ∈ {OWNER, MEMBER, COLLABORATOR}` plus a `vars.*_ENABLED`
+kill switch, so a drive-by `@claude` comment from a stranger cannot trigger a
+run with write permissions. The one `pull_request_target` workflow
+(`auto-label.yml`) never checks out PR code and passes the untrusted PR title
+through `env:` rather than inline `${{ }}` interpolation — the correct pattern.
+
+**Code health.** `npm run typecheck` clean across all six projects.
+`npm run lint` clean. Git history is 76 MB with no large binaries (biggest blob
+is a 4.25 MB vision notebook).
+
+**Dead code: nothing to remove.** knip reports 2 unused files and 15 unused
+exports; every one is an indirection false positive, and all are already in
+`config/ratchets/knip-baseline.json`:
+
+- `src/test-kernel/support/setupFakePlatform.ts` — it _is_ vitest's
+  `setupFiles` entry (`vitest.config.mjs:28`); knip doesn't parse that field.
+- `packages/trace-viewer/vite.standalone.config.ts` — invoked by that
+  package's own `build` script.
+- The 7 `packages/extension/src/frontend/lean/VscodeIntegration.ts` exports —
+  reached through namespace injection,
+  `setLeanLanguageServices(leanVscodeIntegration)` at
+  `packages/extension/src/extension.ts:531`.
+- The rest are desktop test hooks and warning constants.
+
+Three scripts that look orphaned (`scripts/deploy-relay.mjs`,
+`scripts/esm-cjs-globals-banner.mjs`,
+`scripts/prune-desktop-codex-payload.mjs`) are all referenced — from
+`docs/supabase/RELAY_SETUP.md`, the cli/desktop esbuild configs, and
+`electron-builder.yml`'s `afterPack` respectively.
+
+**One real gap, but not dead code.** `knip.json` sets
+`"ignoreDependencies": [".*"]`, so unused dependencies are ungated. Lifting it
+surfaces 113 "unused" deps, but they are workspace-hoisting artifacts, not
+dead: `dotenv`, `fs-extra`, `mark.js`, and `minimatch` are declared in the root
+`package.json` yet imported only from `packages/extension`, and nearly all of
+`packages/agent`'s list is re-exported core that knip can't trace across the
+alias boundary. Nothing to delete — worth tidying the declarations if the
+`@texra/core` package ever lands.
+
+---
+
+## Suggested order
+
+1. Pick the license → rewrite `LICENSE`, the three `LICENSE.txt`, all
+   `license` fields, and the README footer. (§1.1, §1.2)
+2. Split the TOS into Service vs. Software; settle the copyright line and
+   DCO/CLA. (§1.3, §1.4)
+3. Decide `prompts/agents/remote/`, `supabase/`, and internal `docs/`. (§2)
+4. Settle the repo home; fix every `repository`/`bugs` link; migrate issues. (§3.1, §3.2)
+5. Enable secret scanning + push protection. (§3.3)
+6. Add the telemetry opt-out. (§4.2)
+7. Add `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, issue
+   templates, `CODEOWNERS`. (§4.1)
+8. Make `npm test` green on a clean checkout. (§4.3)
+9. Housekeeping: `minimumReleaseAge`, the stale `.gitignore` comment. (§4.4, §4.5)
+
+Steps 1–5 gate the flip. 6–9 can land in the same week but do not block it.

--- a/docs/proposals/2026-07-29-open-source-readiness.md
+++ b/docs/proposals/2026-07-29-open-source-readiness.md
@@ -1,56 +1,44 @@
 # Open-source readiness audit
 
-_Audited at `0.40.0` (`f7c3958`), 2026-07-29. Full history (17,585 commits),
-working tree, CI, dependency graph, and build/test/lint health._
+_Audited at `0.40.0` (`f7c3958`), 2026-07-29: full history (17,585 commits),
+working tree, CI, dependency graph, build/test/lint health._
 
-**Verdict.** The code is in good shape — typecheck and lint are clean, there
-are no secrets in history, dependency licensing is clean, and there is
-effectively **no dead code to remove**. What stands between here and a public
-repo is almost entirely legal and product-decision work, not engineering
-cleanup.
-
-Sections are ordered by whether they block flipping the switch.
+Typecheck and lint are clean, there are no secrets in history, dependency
+licensing is clean, and there is no dead code to remove. What remains is
+licensing and product decisions, not engineering cleanup.
 
 ## Status
 
-Everything that needed no decision from the maintainers has been done. What is
-left is genuinely waiting on a choice.
+| Item                                       | Status                           |
+| ------------------------------------------ | -------------------------------- |
+| §1 Licensing and legal                     | Needs a license choice           |
+| §2 What gets published                     | Needs three product calls        |
+| §3.1 Repo identity                         | Needs the final repo home        |
+| §3.2 `packages/agent` repo metadata        | Done                             |
+| §3.3 Secret scanning                       | Repo admin setting               |
+| §4.1 `SECURITY.md`                         | Done                             |
+| §4.1 `CONTRIBUTING.md` / `CODE_OF_CONDUCT` | Held until the license lands     |
+| §4.2 Telemetry opt-out                     | Done — `texra.telemetry.enabled` |
+| §4.3 `npm test` green on a clean checkout  | Done                             |
+| §4.4 `minimumReleaseAge`                   | Open — documented tradeoff       |
+| §4.5 Stale `.gitignore` comment            | Done                             |
 
-| Item                                       | Status                                          |
-| ------------------------------------------ | ----------------------------------------------- |
-| §3.2 `packages/agent` repo metadata        | **Done**                                        |
-| §4.1 `SECURITY.md`                         | **Done**                                        |
-| §4.2 Telemetry opt-out                     | **Done** — `texra.telemetry.enabled`            |
-| §4.3 `npm test` green on a clean checkout  | **Done**                                        |
-| §4.5 Stale `.gitignore` comment            | **Done**                                        |
-| §1 Licensing and legal                     | Blocked — needs a license choice                |
-| §2 What gets published                     | Blocked — needs three product calls             |
-| §3.1 Repo identity                         | Blocked — needs the final repo home             |
-| §3.3 Secret scanning                       | Blocked — repo admin setting, and a timing call |
-| §4.1 `CONTRIBUTING.md` / `CODE_OF_CONDUCT` | Deliberately held — see below                   |
-| §4.4 `minimumReleaseAge`                   | Held — documented tradeoff, maintainer's call   |
-
-`CONTRIBUTING.md` and `CODE_OF_CONDUCT.md` are held on purpose rather than
-overlooked. Soliciting outside contributions while the repo is still "all rights
-reserved" with no CLA or DCO creates exactly the IP ambiguity §1.4 warns about —
-inbound patches with no clear grant, on a codebase whose copyright may later be
-assigned. They should land together with the license decision, not before it.
-`SECURITY.md` is different: a private path for reporting vulnerabilities is
-worth having under any license, and it invites no code.
+`CONTRIBUTING.md` and `CODE_OF_CONDUCT.md` are held rather than skipped.
+Soliciting contributions under "all rights reserved" with no CLA or DCO creates
+the IP ambiguity described in §1.4. `SECURITY.md` is not held: a private
+reporting path is useful under any license and invites no code.
 
 ---
 
-## 1. Blockers — licensing and legal
+## 1. Licensing and legal
 
 ### 1.1 The root `LICENSE` is a placeholder
 
-`LICENSE` is 8 bytes containing the literal word `LICENSE`. It has never been
-a real license file.
+`LICENSE` is 8 bytes containing the literal word `LICENSE`.
 
-### 1.2 Everything currently declares itself proprietary
+### 1.2 Everything declares itself proprietary
 
-Five places all say "proprietary, all rights reserved" and must agree on
-whatever license is chosen:
+Six places must agree on whatever license is chosen:
 
 | Where                                                 | Current state                                     |
 | ----------------------------------------------------- | ------------------------------------------------- |
@@ -61,13 +49,12 @@ whatever license is chosen:
 | `license` field in the three published `package.json` | `SEE LICENSE IN LICENSE.txt`                      |
 | `README.md` footer                                    | "© TeXRA Team 2025–2026. All rights reserved."    |
 
-`packages/desktop` and `packages/trace-viewer` have no `license` field at all
-(both are `private: true`, so this is lower priority, but they still ship in
-the desktop installer).
+`packages/desktop` and `packages/trace-viewer` have no `license` field. Both are
+`private: true`, but they ship in the desktop installer.
 
 ### 1.3 The Terms of Service contradict an OSS license
 
-`TERMS_OF_SERVICE.md` currently forbids exactly what an OSS license grants:
+`TERMS_OF_SERVICE.md` forbids what an OSS license grants:
 
 - §29 — "Modify, adapt, or create derivative works of the Service."
 - §54 — "Attempt to reverse-engineer, decompile, or disassemble the Service…"
@@ -75,70 +62,70 @@ the desktop installer).
   Service, including its code, design, documentation, and trademarks, are
   owned by the TeXRA team…"
 
-The TOS needs a clean split between **the Service** (hosted relay, accounts,
-subscriptions — still governed by the TOS) and **the software** (this repo —
-governed by the new license). Otherwise every user is under two contradictory
+The TOS needs a split between the Service (hosted relay, accounts,
+subscriptions — still governed by the TOS) and the software (this repo —
+governed by the new license). Otherwise users are under two contradictory
 grants.
 
 ### 1.4 Copyright holder and contributor terms are undecided
 
-§62 also says rights "will be assigned to any successor entity upon
-incorporation." Decide the copyright line _before_ publishing, and decide
-whether inbound contributions need a DCO or a CLA — you want one if there is
-any chance of relicensing or assigning to a future entity. Retrofitting a CLA
-after outside contributions land is painful.
+§62 says rights "will be assigned to any successor entity upon incorporation."
+Settle the copyright line before publishing, and decide whether inbound
+contributions need a DCO or a CLA. A CLA is hard to retrofit once outside
+contributions have landed, and relicensing or assigning to a future entity
+needs one.
 
-Also missing: `.github/CODEOWNERS`, and the trademark position on the "TeXRA"
-name/logo (the TOS reserves trademarks; an OSS license should not silently
-grant them).
+Also open: `.github/CODEOWNERS`, and the trademark position on the TeXRA
+name and logo. The TOS reserves trademarks; an OSS license should not grant
+them implicitly.
 
 ---
 
-## 2. Blockers — decisions about what actually gets published
+## 2. What gets published
 
-These are business calls, not defects. Each one is a thing that is private
-today and becomes public the moment the repo flips.
+Business calls, not defects. Each is private today and becomes public when the
+repo flips.
 
 ### 2.1 Hosted-specialist system prompts (`prompts/agents/remote/`)
 
-21 YAML files, 408 KB, containing the **full system prompts** for the
-sign-in-gated hosted specialists the README markets as the paid surface —
-`orchestrator`, `logic`, `notation`, `enhance`, `elevate`, `humanize`,
-`devise`, `apply`, `verifyFix`, `progressCheck`, and the whole Lean line.
+21 YAML files, 408 KB, holding the system prompts for the sign-in-gated hosted
+specialists the README markets as the paid surface: `orchestrator`, `logic`,
+`notation`, `enhance`, `elevate`, `humanize`, `devise`, `apply`, `verifyFix`,
+`progressCheck`, and the Lean line.
 
-These are _not_ shipped in the VSIX. They live only here and are synced into
-Supabase by `scripts/sync-remote-agents.mjs`. A public repo publishes them.
+They are not shipped in the VSIX. They exist only here and are synced into
+Supabase by `scripts/sync-remote-agents.mjs`.
 
-**Decide:** ship them (transparency, forkability) or move them to a private
-repo and keep the sync script pointed there.
+Decide: publish them, or move them to a private repo and repoint the sync
+script.
 
 ### 2.2 Server-side abuse controls (`supabase/`)
 
-Publishing `supabase/functions/relay/**` publishes the enforcement design
-verbatim: `requestGate.ts` (per-tier rate and concurrency limits),
-`enforcement.ts` (monthly spend verification), `requestLimits.ts`, and 22 SQL
-migrations including all the RLS policies. `src/auth/config.ts:129-133` also
-hardcodes the tier spend caps ($10 free / $50 Max / $300 Ultra).
+Publishing `supabase/functions/relay/**` publishes the enforcement design:
+`requestGate.ts` (per-tier rate and concurrency limits), `enforcement.ts`
+(monthly spend verification), `requestLimits.ts`, and 22 SQL migrations
+including the RLS policies. `src/auth/config.ts:129-133` hardcodes the tier
+spend caps ($10 free / $50 Max / $300 Ultra).
 
-This is defensible — enforcement is server-side and doesn't depend on secrecy,
-and the RLS migrations look correctly scoped to `service_role`. But confirm
-deliberately that no control depends on obscurity before publishing, and
-decide whether `supabase/` belongs in the public repo at all.
+Enforcement is server-side and does not depend on secrecy, and the RLS
+migrations are scoped to `service_role`. Before publishing, confirm no control
+depends on obscurity, and decide whether `supabase/` belongs in the public repo
+at all.
 
 ### 2.3 4.5 MB of internal design docs
 
 145 files across `docs/prds/` (77), `docs/proposals/` (68), `docs/dev/`,
-`docs/architecture/`, `docs/design/`, `docs/reference/`. They are excluded
-from the texra.ai site by `docs/.vitepress/publicDocs.js`, but that only
-governs the _site_ — a public repo publishes the files themselves.
+`docs/architecture/`, `docs/design/`, `docs/reference/`. `publicDocs.js`
+excludes them from the texra.ai site, but that governs the site only — a public
+repo publishes the files.
 
-They contain no secrets and no business-sensitive material (checked: the only
-"revenue/margin" hits are CSS `margin`). They're genuinely good contributor
-context. **Decide:** keep as-is, or split to a private repo.
+They contain no secrets and no business-sensitive material; the only
+"revenue/margin" hits are CSS `margin`. Decide: keep, or split to a private
+repo.
 
 ---
 
-## 3. Blockers — repo identity and hardening
+## 3. Repo identity and hardening
 
 ### 3.1 The repo has two identities
 
@@ -152,50 +139,48 @@ Code lives in `lionsr/texra` (private); issues live in the separate public
   `docs/index.md`, `docs/.vitepress/config.js` — all link to `texra-issues`
 - `.github/labels.yml:1` — "Source of truth for issue/PR labels on lionsr/texra"
 
-Decide the final home, update all of the above, and plan the issue migration
-so you are not running two trackers.
+Settle the final home, update all of the above, and plan the issue migration so
+there is only one tracker.
 
 ### 3.2 `packages/agent` has no repo metadata
 
-**Done.** `@texra-ai/agent` is published to npm (`private: false`) and had **no**
-`repository`, `bugs`, `homepage`, or `author` field — the package most likely to
-be found by someone who has never heard of TeXRA. It now carries the same four
-fields as the CLI and extension packages, so it moves with them when §3.1 is
+Done. `@texra-ai/agent` is published to npm (`private: false`) and had no
+`repository`, `bugs`, `homepage`, or `author` field. It now carries the same
+four as the CLI and extension packages, so it moves with them when §3.1 is
 settled.
 
 ### 3.3 GitHub secret scanning is off
 
-Confirmed: the secret-scanning API returns _"Repository does not have GitHub
-Advanced Security enabled."_ Turn on **secret scanning and push protection**
-before flipping to public — both are free on public repositories, and push
-protection is the thing that stops the first contributor accident.
+The secret-scanning API returns "Repository does not have GitHub Advanced
+Security enabled." Turn on secret scanning and push protection before flipping
+to public. Both are free on public repositories, and push protection is what
+stops the first contributor accident.
 
 ---
 
 ## 4. Should do before launch
 
-### 4.1 No community files
+### 4.1 Community files
 
-`SECURITY.md` — **done**. It mattered more than usual here: the project handles
-user API keys, OAuth tokens, and a hosted relay, and there was no published way
-to report a vulnerability privately. It names `contact@texra.ai`, scopes what is
-worth reporting (credential storage, the auth flows, tool-execution approval,
-prompt injection that escalates privilege, relay enforcement, webview and
-renderer isolation), and tells reporters to rotate an exposed key first.
+`SECURITY.md` — done. The project handles user API keys, OAuth tokens, and a
+hosted relay, and had no published way to report a vulnerability privately. It
+names `contact@texra.ai` and scopes what is worth reporting: credential
+storage, the auth flows, tool-execution approval, prompt injection that
+escalates privilege, relay enforcement, and webview/renderer isolation.
 
-Still missing: `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `.github/ISSUE_TEMPLATE/`,
-`.github/CODEOWNERS`. `.github/PULL_REQUEST_TEMPLATE.md` exists. The first two
-are held until the license lands (see **Status** above); the issue templates and
-CODEOWNERS depend on §3.1's repo home and on who is on the team.
+Still missing: `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`,
+`.github/ISSUE_TEMPLATE/`, `.github/CODEOWNERS`.
+`.github/PULL_REQUEST_TEMPLATE.md` exists. The first two wait on the license;
+the issue templates and CODEOWNERS wait on §3.1 and on team membership.
 
-When `CONTRIBUTING.md` is written: `AGENTS.md` (38 KB) is excellent contributor
-material but is written for agents. The human version should point at it and
-lead with the single highest-value fact in this repo — **builds do not type
-check; run `npm run typecheck` or the `:safe` script variants.**
+For `CONTRIBUTING.md`: `AGENTS.md` (38 KB) is good contributor material but is
+written for agents. The human version should point at it and lead with the fact
+that builds do not type check — `npm run typecheck`, or the `:safe` script
+variants.
 
-### 4.2 Telemetry has no opt-out
+### 4.2 Telemetry had no opt-out
 
-`src/telemetry/UsageLogService.ts` defaults to `enabled: true` and is
+`src/telemetry/UsageLogService.ts` defaulted to `enabled: true` and was
 initialized unconditionally from both hosts
 (`packages/extension/src/extension.ts:490`,
 `packages/cli/src/runtime/initPlatform.ts:337`). It sends model, provider,
@@ -203,45 +188,38 @@ agent name and category, input/output/cached/reasoning token counts, cost, and
 response time to `remote.texra.ai/functions/v1/log-usage`.
 
 It only flushes when signed in — `flushQueuedBatch()` returns early without a
-relay access token — but **signed-in BYOK users were logged too**
-(`usedRelay: false` entries), and there was no key in
-`contributes.configuration` to turn it off. Invisible in a private repo; in a
-public one it is the first thing people grep for.
+relay access token — but signed-in BYOK users were logged too (`usedRelay:
+false` entries), and no key in `contributes.configuration` turned it off.
 
-**Done.** `texra.telemetry.enabled` (default `true`, so no behaviour change) now
-gates it, added to `CoreSettingsShape` so all three hosts pick it up: VS Code
-surfaces it under **TeXRA → Privacy** at `application` scope — deliberately not
-`resource`, so a workspace cannot re-enable logging a user turned off — and the
-CLI and desktop read it from `.texra/config.json` via `JsonConfigProvider`, with
-`KNOWN_TEXRA_KEYS` picking it up automatically from `CORE_SETTING_PATHS`.
+Done. `texra.telemetry.enabled` (default `true`, so no behaviour change) gates
+it. It lives in `CoreSettingsShape`, so all three hosts pick it up. VS Code
+shows it under TeXRA → Privacy at `application` scope, not `resource`, so a
+workspace cannot re-enable logging a user turned off. The CLI and desktop read
+it from `.texra/config.json` through `JsonConfigProvider`, and
+`KNOWN_TEXRA_KEYS` derives it from `CORE_SETTING_PATHS`.
 
-The setting is read **live** on each queue and flush rather than snapshotted at
-`initialize()`, so turning it off takes effect immediately instead of at next
-launch, and the flush path discards rounds recorded before the opt-out rather
-than shipping one last batch.
+The setting is read on each queue and flush rather than snapshotted at
+`initialize()`, so turning it off applies immediately and the flush path
+discards rounds recorded before the opt-out instead of sending a final batch.
 
-One trap worth remembering, since it is not obvious from the names: the discard
-is gated on the user setting **alone**, never on `config.enabled`. That field is
-the lifecycle gate, and `dispose()` clears it precisely so no new entry is
-queued while shutdown drains the final batch. Keying the discard off it too
-silently dropped the last flush on every CLI exit — and with it the relay spend
-accounting. The existing "waits for successive active batches during disposal"
-test catches this; it is not redundant.
+The discard is gated on the user setting alone, not on `config.enabled`.
+`config.enabled` is the lifecycle gate: `dispose()` clears it so no new entry is
+queued while shutdown drains the last batch. Gating the discard on it as well
+drops that flush on every CLI exit, and the relay spend accounting with it. The
+"waits for successive active batches during disposal" test covers this.
 
-Reading the setting adds a `telemetry -> platform` subsystem edge, which the
-LAY-1 ratchet correctly flagged as new. It is accepted and recorded in
-`config/ratchets/architecture-edges-baseline.json`: reaching host config through
-the `platform()` port is the sanctioned mechanism, and it is the same edge
-`src/tools/goal/goalFeatureFlag.ts` already relies on for its feature flag.
+Reading the setting adds a `telemetry -> platform` subsystem edge, now recorded
+in `config/ratchets/architecture-edges-baseline.json`. Host config is reached
+through the `platform()` port; `src/tools/goal/goalFeatureFlag.ts` uses the same
+edge for its feature flag.
 
-Documented for users in `docs/guide/configuration.md` under "Usage Logging",
-including the fact that disabling it also stops hosted spend accounting.
+User documentation is in `docs/guide/configuration.md` under "Usage Logging",
+including that disabling it also stops hosted spend accounting.
 
-### 4.3 `npm test` is not green on a clean checkout
+### 4.3 `npm test` was not green on a clean checkout
 
-**Done.** 3 failures out of 7,965 (796 of 800 files passed). CI on `main` is
-green, so all three were specific to a sandboxed or loaded machine — but a
-first-time contributor still ran `npm test` and saw red.
+Done. 3 failures out of 7,965 (796 of 800 files passed). CI on `main` was green,
+so all three were specific to a sandboxed or loaded machine.
 
 | Test                                                        | Cause                                                      | Fix                     |
 | ----------------------------------------------------------- | ---------------------------------------------------------- | ----------------------- |
@@ -249,123 +227,116 @@ first-time contributor still ran `npm test` and saw red.
 | `src/test-kernel/agent/WorkflowScriptEngine.vitest.ts:1741` | wall-clock assertion `< 3000 ms`; took 9,349 ms under load | budget widened          |
 | `src/test-kernel/utils/system/SystemUtils.vitest.ts:224`    | 1 s budget for process-group teardown                      | budget widened to ~10 s |
 
-The Electron one was the interesting case. Electron 43 dropped its `postinstall`
-script — `require('electron')` now _downloads_ the platform binary the first
-time it is called. So `dev.mjs`'s module-level require turned a unit test into a
-network fetch on a fresh checkout, and a hard failure with no network. Rather
-than skip it, the test now sets `ELECTRON_OVERRIDE_DIST_PATH`, which
-short-circuits that resolution. No coverage is lost: the assertions only check
-the spawn arguments, env, and stdio, never the binary's location. The test is
-now hermetic everywhere instead of quietly depending on the network in CI.
+Electron 43 dropped its `postinstall`; `require('electron')` now downloads the
+platform binary on first call. `dev.mjs` requires it at module load, so the test
+performed a network fetch on a fresh checkout and failed outright without
+network. It now sets `ELECTRON_OVERRIDE_DIST_PATH`, which short-circuits that
+resolution. The assertions cover spawn arguments, env, and stdio, not the binary
+path, so no coverage is lost.
 
-The other two are pure hang guards, not latency measurements — the memory test's
-containment is already proven by its `/memory/` rejection (a failure of the
-memory limit would reject with `/timed out/` instead), so a tight wall-clock
-bound there bought nothing and flaked whenever the suite saturated every core.
+The other two bounds are hang guards, not latency measurements. The memory
+test's containment is established by its `/memory/` rejection — a failure of the
+memory limit rejects with `/timed out/` instead — so the wall-clock bound only
+needs to catch a wedged process.
 
 ### 4.4 Supply-chain quarantine is disabled repo-wide
 
-`pnpm-workspace.yaml` sets `minimumReleaseAge: 0`, turning off pnpm 11's
-24-hour quarantine, while `.github/dependabot.yml` opens grouped dependency PRs
-daily. The comment explains the tradeoff (same-day `llm-zoo` bumps for new
-models), which was reasonable while private. A public, higher-profile repo
-raises the value of that window — consider scoping the override to the
-packages that actually need it.
+`pnpm-workspace.yaml` sets `minimumReleaseAge: 0`, turning off pnpm 11's 24-hour
+quarantine, while `.github/dependabot.yml` opens grouped dependency PRs daily.
+The comment explains the tradeoff: same-day `llm-zoo` bumps for new models. A
+higher-profile public repo raises the value of that window. Consider scoping the
+override to the packages that need it.
 
 ### 4.5 A stale comment invents a private dependency
 
-**Done.** `.gitignore` claimed _"CI checks out a private trusted-actions repo
-here at runtime; never commit it."_ It doesn't. The `.trusted-actions` checkout
-in `claude.yml`, `claude-code-review.yml`, and `issue-tracker.yml` has no
-`repository:` field — it is a second checkout of _this_ repo at the PR's base
-ref, so the automation prompts and tool allowlists come from trusted committed
-history rather than the branch under review. Outside readers would have hunted
-for a private repo that does not exist; the comment now says what it is for.
+Done. `.gitignore` claimed "CI checks out a private trusted-actions repo here at
+runtime; never commit it." The `.trusted-actions` checkout in `claude.yml`,
+`claude-code-review.yml`, and `issue-tracker.yml` has no `repository:` field —
+it is a second checkout of this repo at the PR's base ref, so automation prompts
+and tool allowlists come from committed history rather than the branch under
+review. The comment now says that.
 
 ---
 
-## 5. Verified clean — do not re-audit
+## 5. Verified clean
 
-Recorded so this work isn't repeated.
+Recorded so this is not repeated.
 
 **Secrets.** Scanned all ~74,000 blobs in the full 17,585-commit history for
 OpenAI, Anthropic, GitHub (PAT/OAuth/App), AWS, Google, Slack, GitLab, npm,
-Supabase, and HuggingFace key formats plus PEM private keys: **zero hits.**
+Supabase, and HuggingFace key formats plus PEM private keys: zero hits.
 
-The single JWT in history is a Supabase **anon** key (project ref
-`jntubmcgbhwtcktubelv`, `role: anon`) that used to sit in `src/auth/config.ts`
-and has since been replaced by `sb_publishable_…`. Anon and publishable keys
-are public by design and already ship in every VSIX. **No rotation or history
-rewrite is required.** No `service_role` key appears anywhere.
+The one JWT in history is a Supabase anon key (project ref
+`jntubmcgbhwtcktubelv`, `role: anon`) that sat in `src/auth/config.ts` and has
+since been replaced by `sb_publishable_…`. Anon and publishable keys are public
+by design and already ship in every VSIX, so no rotation or history rewrite is
+required. No `service_role` key appears anywhere.
 
-Working tree is also clean: no credentials, no gitignored-but-tracked files, no
-real user data, no local author paths, no `.npmrc` with a private registry.
+The working tree is clean too: no credentials, no gitignored-but-tracked files,
+no real user data, no local author paths, no `.npmrc` with a private registry.
 
 **Dependency licensing.** 3,162 resolved packages: 2,349 MIT, 239 Apache-2.0,
-194 ISC, 114 BSD-3, 90 BSD-2, 50 0BSD, 41 BlueOak, remainder permissive.
-**Zero GPL / AGPL / SSPL / BUSL / Commons Clause.** The only weak copyleft is
-MPL-2.0 (`lightningcss`, and `dompurify` which is dual MPL/Apache) — file-level
-and fine for unmodified use. No vendored third-party source anywhere.
+194 ISC, 114 BSD-3, 90 BSD-2, 50 0BSD, 41 BlueOak, remainder permissive. Zero
+GPL, AGPL, SSPL, BUSL, or Commons Clause. The only weak copyleft is MPL-2.0
+(`lightningcss`, and `dompurify` which is dual MPL/Apache), which is file-level
+and fine for unmodified use. No vendored third-party source.
 
-**CI is already fork-safe.** `claude.yml`, `claude-code-review.yml`, and
-`issue-tracker.yml` all gate on
+**CI is fork-safe.** `claude.yml`, `claude-code-review.yml`, and
+`issue-tracker.yml` gate on
 `author_association ∈ {OWNER, MEMBER, COLLABORATOR}` plus a `vars.*_ENABLED`
-kill switch, so a drive-by `@claude` comment from a stranger cannot trigger a
-run with write permissions. The one `pull_request_target` workflow
-(`auto-label.yml`) never checks out PR code and passes the untrusted PR title
-through `env:` rather than inline `${{ }}` interpolation — the correct pattern.
+kill switch, so a drive-by `@claude` comment cannot trigger a run with write
+permissions. The one `pull_request_target` workflow (`auto-label.yml`) never
+checks out PR code and passes the untrusted PR title through `env:` rather than
+inline `${{ }}` interpolation.
 
-**Code health.** `npm run typecheck` clean across all six projects.
-`npm run lint` clean. Git history is 76 MB with no large binaries (biggest blob
-is a 4.25 MB vision notebook).
+**Code health.** `npm run typecheck` clean across all six projects, `npm run
+lint` clean. Git history is 76 MB with no large binaries; the biggest blob is a
+4.25 MB vision notebook.
 
 **Dead code: nothing to remove.** knip reports 2 unused files and 15 unused
-exports; every one is an indirection false positive, and all are already in
+exports. Each is an indirection false positive, and all are in
 `config/ratchets/knip-baseline.json`:
 
-- `src/test-kernel/support/setupFakePlatform.ts` — it _is_ vitest's
-  `setupFiles` entry (`vitest.config.mjs:28`); knip doesn't parse that field.
-- `packages/trace-viewer/vite.standalone.config.ts` — invoked by that
-  package's own `build` script.
-- The 7 `packages/extension/src/frontend/lean/VscodeIntegration.ts` exports —
-  reached through namespace injection,
+- `src/test-kernel/support/setupFakePlatform.ts` is vitest's `setupFiles` entry
+  (`vitest.config.mjs:28`), a field knip does not parse.
+- `packages/trace-viewer/vite.standalone.config.ts` is invoked by that package's
+  `build` script.
+- The 7 `packages/extension/src/frontend/lean/VscodeIntegration.ts` exports are
+  reached through namespace injection —
   `setLeanLanguageServices(leanVscodeIntegration)` at
   `packages/extension/src/extension.ts:531`.
 - The rest are desktop test hooks and warning constants.
 
-Three scripts that look orphaned (`scripts/deploy-relay.mjs`,
-`scripts/esm-cjs-globals-banner.mjs`,
-`scripts/prune-desktop-codex-payload.mjs`) are all referenced — from
-`docs/supabase/RELAY_SETUP.md`, the cli/desktop esbuild configs, and
-`electron-builder.yml`'s `afterPack` respectively.
+Three scripts that look orphaned — `scripts/deploy-relay.mjs`,
+`scripts/esm-cjs-globals-banner.mjs`, `scripts/prune-desktop-codex-payload.mjs` —
+are referenced from `docs/supabase/RELAY_SETUP.md`, the cli/desktop esbuild
+configs, and `electron-builder.yml`'s `afterPack` respectively.
 
-**One real gap, but not dead code.** `knip.json` sets
+**Dependency declarations, not dead code.** `knip.json` sets
 `"ignoreDependencies": [".*"]`, so unused dependencies are ungated. Lifting it
-surfaces 113 "unused" deps, but they are workspace-hoisting artifacts, not
-dead: `dotenv`, `fs-extra`, `mark.js`, and `minimatch` are declared in the root
-`package.json` yet imported only from `packages/extension`, and nearly all of
-`packages/agent`'s list is re-exported core that knip can't trace across the
-alias boundary. Nothing to delete — worth tidying the declarations if the
-`@texra/core` package ever lands.
+surfaces 113 "unused" deps, but they are workspace-hoisting artifacts:
+`dotenv`, `fs-extra`, `mark.js`, and `minimatch` are declared in the root
+`package.json` but imported only from `packages/extension`, and most of
+`packages/agent`'s list is re-exported core that knip cannot trace across the
+alias boundary. Nothing to delete; worth tidying if a `@texra/core` package ever
+lands.
 
 ---
 
-## Suggested order
+## Order
 
-What remains, all of it downstream of a decision:
+Everything below is downstream of a decision.
 
-1. Pick the license → rewrite `LICENSE`, the three `LICENSE.txt`, all
-   `license` fields, and the README footer. (§1.1, §1.2)
-2. Split the TOS into Service vs. Software; settle the copyright line and
+1. Pick the license; rewrite `LICENSE`, the three `LICENSE.txt`, all `license`
+   fields, and the README footer. (§1.1, §1.2)
+2. Split the TOS into Service and Software; settle the copyright line and
    DCO/CLA. (§1.3, §1.4)
 3. Decide `prompts/agents/remote/`, `supabase/`, and internal `docs/`. (§2)
-4. Settle the repo home; fix every `repository`/`bugs` link; migrate issues. (§3.1)
-5. Enable secret scanning + push protection. (§3.3)
-6. Once 1–2 land: `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`. Once 4 lands:
-   issue templates and `CODEOWNERS`. (§4.1)
-7. Revisit `minimumReleaseAge` at whatever profile the project ends up with.
-   (§4.4)
+4. Settle the repo home; fix every `repository`/`bugs` link; migrate issues.
+   (§3.1)
+5. Enable secret scanning and push protection. (§3.3)
+6. After 1–2: `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`. After 4: issue
+   templates and `CODEOWNERS`. (§4.1)
+7. Revisit `minimumReleaseAge`. (§4.4)
 
-Steps 1–5 gate the flip. Step 1 unblocks the most: it is the only thing 6
-waits on, and the licence text is the last piece of the repo that still says
-the opposite of what you intend.
+Steps 1–5 gate the flip. Step 1 also unblocks step 6.

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -3,6 +3,15 @@
   "version": "0.40.0",
   "description": "Embeddable TeXRA agent runtime",
   "license": "SEE LICENSE IN LICENSE.txt",
+  "author": "TeXRA.ai",
+  "homepage": "https://texra.ai",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/texra-ai/texra-issues.git"
+  },
+  "bugs": {
+    "url": "https://github.com/texra-ai/texra-issues/issues"
+  },
   "type": "module",
   "engines": {
     "node": ">=22.9.0"

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -806,6 +806,17 @@
         }
       },
       {
+        "title": "Privacy",
+        "properties": {
+          "texra.telemetry.enabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "Send usage records for each model round to TeXRA. Each record contains the model and provider, the agent name and category, token counts, the computed cost, and the response time — never prompt text, document content, or file names. Records are only transmitted while signed in, and they are what meters relay and subscription usage against your plan, so turning this off also stops that accounting. Set to false to send nothing.",
+            "scope": "application"
+          }
+        }
+      },
+      {
         "title": "Logger",
         "properties": {
           "texra.logger.debugMode": {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -811,7 +811,7 @@
           "texra.telemetry.enabled": {
             "type": "boolean",
             "default": true,
-            "description": "Send usage records for each model round to TeXRA. Each record contains the model and provider, the agent name and category, token counts, the computed cost, and the response time — never prompt text, document content, or file names. Records are only transmitted while signed in, and they are what meters relay and subscription usage against your plan, so turning this off also stops that accounting. Set to false to send nothing.",
+            "description": "Send a usage record for each model round to TeXRA: model and provider, agent name and category, token counts, cost, and response time. Never prompt text, document content, or file names. Records are sent only while signed in, and they meter relay and subscription usage against your plan, so turning this off also stops that accounting.",
             "scope": "application"
           }
         }

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -811,7 +811,7 @@
           "texra.telemetry.enabled": {
             "type": "boolean",
             "default": true,
-            "description": "Send a usage record for each model round to TeXRA: model and provider, agent name and category, token counts, cost, and response time. Never prompt text, document content, or file names. Records are sent only while signed in, and they meter relay and subscription usage against your plan, so turning this off also stops that accounting.",
+            "description": "Send a usage record for each model round to TeXRA: model and provider, agent name and category, token counts, cost, response time, route, stream id, and the TeXRA version and host. Never prompt text, document content, or file names. Records are sent only while signed in. Turning this off stops reporting for rounds billed to your own API key; rounds that went through the relay or a subscription are still recorded, because they meter your hosted usage against your plan.",
             "scope": "application"
           }
         }

--- a/src/shared/schemas/coreSettings.ts
+++ b/src/shared/schemas/coreSettings.ts
@@ -627,7 +627,7 @@ export const CoreSettingsShape = {
     .strictObject({
       enabled: boolField(
         DEFAULT_CORE_SETTINGS.telemetry.enabled,
-        'Send a usage record for each model round to TeXRA: model and provider, agent name and category, token counts, cost, and response time. Never prompt text, document content, or file names. Records are sent only while signed in, and they meter relay and subscription usage against your plan, so turning this off also stops that accounting.',
+        'Send a usage record for each model round to TeXRA: model and provider, agent name and category, token counts, cost, response time, route, stream id, and the TeXRA version and host. Never prompt text, document content, or file names. Records are sent only while signed in. Turning this off stops reporting for rounds billed to your own API key; rounds that went through the relay or a subscription are still recorded, because they meter your hosted usage against your plan.',
       ),
     })
     .prefault(DEFAULT_CORE_SETTINGS.telemetry),

--- a/src/shared/schemas/coreSettings.ts
+++ b/src/shared/schemas/coreSettings.ts
@@ -627,7 +627,7 @@ export const CoreSettingsShape = {
     .strictObject({
       enabled: boolField(
         DEFAULT_CORE_SETTINGS.telemetry.enabled,
-        'Send usage records for each model round to TeXRA. Each record contains the model and provider, the agent name and category, token counts, the computed cost, and the response time — never prompt text, document content, or file names. Records are only transmitted while signed in, and they are what meters relay and subscription usage against your plan, so turning this off also stops that accounting. Set to false to send nothing.',
+        'Send a usage record for each model round to TeXRA: model and provider, agent name and category, token counts, cost, and response time. Never prompt text, document content, or file names. Records are sent only while signed in, and they meter relay and subscription usage against your plan, so turning this off also stops that accounting.',
       ),
     })
     .prefault(DEFAULT_CORE_SETTINGS.telemetry),

--- a/src/shared/schemas/coreSettings.ts
+++ b/src/shared/schemas/coreSettings.ts
@@ -258,6 +258,9 @@ export const DEFAULT_CORE_SETTINGS = {
   logger: {
     debugMode: false,
   },
+  telemetry: {
+    enabled: true,
+  },
   debug: {
     saveDebugObjects: false,
     saveInputPrompt: false,
@@ -620,6 +623,14 @@ export const CoreSettingsShape = {
       ),
     })
     .prefault(DEFAULT_CORE_SETTINGS.logger),
+  telemetry: z
+    .strictObject({
+      enabled: boolField(
+        DEFAULT_CORE_SETTINGS.telemetry.enabled,
+        'Send usage records for each model round to TeXRA. Each record contains the model and provider, the agent name and category, token counts, the computed cost, and the response time — never prompt text, document content, or file names. Records are only transmitted while signed in, and they are what meters relay and subscription usage against your plan, so turning this off also stops that accounting. Set to false to send nothing.',
+      ),
+    })
+    .prefault(DEFAULT_CORE_SETTINGS.telemetry),
   debug: z
     .strictObject({
       saveDebugObjects: boolField(
@@ -764,6 +775,7 @@ export const CORE_SETTING_PATHS = [
   'agentReview.model',
   'audio.soxPath',
   'logger.debugMode',
+  'telemetry.enabled',
   'debug.saveDebugObjects',
   'debug.saveInputPrompt',
   'skills.enabled',

--- a/src/telemetry/UsageLogService.ts
+++ b/src/telemetry/UsageLogService.ts
@@ -7,6 +7,7 @@ import { SupabaseClient } from '@auth/SupabaseClient';
 import { SUPABASE_CUSTOM_DOMAIN } from '@auth/config';
 import * as logger from '@logger/logUtils';
 import { platform } from '@platform/platform';
+import type { UsageRoute } from '@shared/schemas';
 import { DEFAULT_CORE_SETTINGS } from '@shared/schemas/coreSettings';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
@@ -49,20 +50,57 @@ const DEFAULT_CONFIG: UsageLogConfig = {
 export const TELEMETRY_ENABLED_KEY = 'texra.telemetry.enabled';
 
 /**
+ * Routes whose records meter what the user consumed against their plan.
+ *
+ * The relay reads a database aggregate populated by `log-usage` to enforce the
+ * monthly spend cap, and the subscription routes are accounted the same way. A
+ * record on one of these routes is therefore not telemetry — dropping it lets
+ * hosted calls continue against a stale total, past the cap. They are sent
+ * regardless of {@link TELEMETRY_ENABLED_KEY}; the opt-out governs the
+ * `api-key` (bring-your-own-key) rounds, which cost TeXRA nothing and exist
+ * only as analytics.
+ */
+const PLAN_ACCOUNTING_ROUTES = new Set<UsageRoute>([
+  'relay',
+  'chatgpt-subscription',
+  'kimi-code-subscription',
+]);
+
+function isPlanAccounting(
+  entry: Pick<UsageLogEntry, 'usedRelay' | 'usageRoute'>,
+): boolean {
+  return (
+    entry.usedRelay === true ||
+    (entry.usageRoute != null && PLAN_ACCOUNTING_ROUTES.has(entry.usageRoute))
+  );
+}
+
+/**
  * The user's usage-logging opt-out, read live rather than snapshotted at
  * {@link UsageLogServiceImpl.initialize}.
  *
- * Reading it on each queue and flush is what makes turning the setting off take
+ * Reading it on each queue and send is what makes turning the setting off take
  * effect immediately instead of at the next launch — and lets the flush path
- * discard rounds recorded before the opt-out rather than shipping one last
+ * drop optional rounds recorded before the opt-out rather than shipping one last
  * batch. `config.enabled` remains a separate, independent gate so a host (or a
  * test) can hold the service off regardless of user settings.
  */
 function isTelemetryEnabledBySetting(): boolean {
-  return platform().config.get<boolean>(
+  const raw = platform().config.get<unknown>(
     TELEMETRY_ENABLED_KEY,
     DEFAULT_CORE_SETTINGS.telemetry.enabled,
   );
+  if (typeof raw === 'boolean') return raw;
+  // `.texra/config.json` is hand-edited and JsonConfigProvider hands back raw
+  // JSON, so a mistyped `"false"` would arrive as a truthy string and quietly
+  // re-enable the very thing the user tried to switch off. Treat any non-boolean
+  // as opted out and say so. Failing closed is safe here precisely because plan
+  // accounting does not go through this gate.
+  logger.warn(
+    CHANNEL,
+    `Ignoring non-boolean ${TELEMETRY_ENABLED_KEY} (got ${typeof raw}); treating optional usage logging as disabled`,
+  );
+  return false;
 }
 
 class UsageLogServiceImpl {
@@ -93,7 +131,8 @@ class UsageLogServiceImpl {
   log(
     entry: Omit<UsageLogEntry, 'timestamp' | 'extensionVersion' | 'editorType'>,
   ): void {
-    if (!this.config.enabled || !isTelemetryEnabledBySetting()) return;
+    if (!this.config.enabled) return;
+    if (!isPlanAccounting(entry) && !isTelemetryEnabledBySetting()) return;
 
     if (this.queue.length >= MAX_QUEUE_SIZE) {
       logger.warn(CHANNEL, 'Queue full, dropping oldest entry');
@@ -146,28 +185,6 @@ class UsageLogServiceImpl {
   }
 
   private async flushQueuedBatch(): Promise<UsageLogFlushOutcome> {
-    // Opting out mid-session must discard what is already queued, not merely
-    // stop new entries — otherwise the timer would still ship the rounds
-    // recorded before the user turned logging off.
-    //
-    // Gated on the user setting ALONE, deliberately. `config.enabled` is the
-    // lifecycle gate, and dispose() clears it precisely so no new entry is
-    // queued while shutdown drains the last batch — treating that as an opt-out
-    // here would discard the final flush on every CLI exit, taking relay spend
-    // accounting with it.
-    if (!isTelemetryEnabledBySetting()) {
-      const discarded = this.queue.length + (this.retryBatch ? 1 : 0);
-      this.queue = [];
-      this.retryBatch = null;
-      if (discarded > 0) {
-        logger.debug(
-          CHANNEL,
-          'Usage logging is disabled; discarded queued entries without sending',
-        );
-      }
-      return USAGE_LOG_FLUSH_OUTCOME.PENDING;
-    }
-
     let batch: UsageLogBatch | null = null;
     try {
       const token = await SupabaseClient.getRelayAccessToken();
@@ -188,6 +205,28 @@ class UsageLogServiceImpl {
           entries,
           batchId: randomUUID(),
         };
+      }
+
+      // Re-read the setting here rather than on entry: the token lookup above is
+      // an await, so a user who opts out while it is in flight would otherwise
+      // have this continuation ship the batch anyway. Applied after the batch is
+      // taken so it also drops optional rounds queued before the opt-out instead
+      // of leaving the timer to send them.
+      if (!isTelemetryEnabledBySetting()) {
+        const kept = batch.entries.filter(isPlanAccounting);
+        const dropped = batch.entries.length - kept.length;
+        if (dropped > 0) {
+          logger.debug(
+            CHANNEL,
+            `Usage logging is disabled; dropped ${dropped} optional ${dropped === 1 ? 'entry' : 'entries'} without sending`,
+          );
+        }
+        if (kept.length === 0) {
+          // ACCEPTED, not PENDING: these entries are gone for good, and PENDING
+          // means "kept for a later retry" to every caller that inspects it.
+          return USAGE_LOG_FLUSH_OUTCOME.ACCEPTED;
+        }
+        batch = { ...batch, entries: kept };
       }
 
       logger.debug(

--- a/src/telemetry/UsageLogService.ts
+++ b/src/telemetry/UsageLogService.ts
@@ -6,6 +6,8 @@ import pTimeout from 'p-timeout';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { SUPABASE_CUSTOM_DOMAIN } from '@auth/config';
 import * as logger from '@logger/logUtils';
+import { platform } from '@platform/platform';
+import { DEFAULT_CORE_SETTINGS } from '@shared/schemas/coreSettings';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { UsageLogResponseSchema } from './UsageLogTypes';
@@ -43,6 +45,26 @@ const DEFAULT_CONFIG: UsageLogConfig = {
   enabled: true,
 };
 
+/** Config key backing the usage-logging opt-out. */
+export const TELEMETRY_ENABLED_KEY = 'texra.telemetry.enabled';
+
+/**
+ * The user's usage-logging opt-out, read live rather than snapshotted at
+ * {@link UsageLogServiceImpl.initialize}.
+ *
+ * Reading it on each queue and flush is what makes turning the setting off take
+ * effect immediately instead of at the next launch — and lets the flush path
+ * discard rounds recorded before the opt-out rather than shipping one last
+ * batch. `config.enabled` remains a separate, independent gate so a host (or a
+ * test) can hold the service off regardless of user settings.
+ */
+function isTelemetryEnabledBySetting(): boolean {
+  return platform().config.get<boolean>(
+    TELEMETRY_ENABLED_KEY,
+    DEFAULT_CORE_SETTINGS.telemetry.enabled,
+  );
+}
+
 class UsageLogServiceImpl {
   private queue: UsageLogEntry[] = [];
   private retryBatch: UsageLogBatch | null = null;
@@ -71,7 +93,7 @@ class UsageLogServiceImpl {
   log(
     entry: Omit<UsageLogEntry, 'timestamp' | 'extensionVersion' | 'editorType'>,
   ): void {
-    if (!this.config.enabled) return;
+    if (!this.config.enabled || !isTelemetryEnabledBySetting()) return;
 
     if (this.queue.length >= MAX_QUEUE_SIZE) {
       logger.warn(CHANNEL, 'Queue full, dropping oldest entry');
@@ -124,6 +146,28 @@ class UsageLogServiceImpl {
   }
 
   private async flushQueuedBatch(): Promise<UsageLogFlushOutcome> {
+    // Opting out mid-session must discard what is already queued, not merely
+    // stop new entries — otherwise the timer would still ship the rounds
+    // recorded before the user turned logging off.
+    //
+    // Gated on the user setting ALONE, deliberately. `config.enabled` is the
+    // lifecycle gate, and dispose() clears it precisely so no new entry is
+    // queued while shutdown drains the last batch — treating that as an opt-out
+    // here would discard the final flush on every CLI exit, taking relay spend
+    // accounting with it.
+    if (!isTelemetryEnabledBySetting()) {
+      const discarded = this.queue.length + (this.retryBatch ? 1 : 0);
+      this.queue = [];
+      this.retryBatch = null;
+      if (discarded > 0) {
+        logger.debug(
+          CHANNEL,
+          'Usage logging is disabled; discarded queued entries without sending',
+        );
+      }
+      return USAGE_LOG_FLUSH_OUTCOME.PENDING;
+    }
+
     let batch: UsageLogBatch | null = null;
     try {
       const token = await SupabaseClient.getRelayAccessToken();

--- a/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
@@ -1738,7 +1738,12 @@ while (true) values.push(new Uint8Array(1024 * 1024))`,
         timeoutMs: 2_000,
       }),
     ).rejects.toThrow(/memory/i);
-    expect(Date.now() - startedAt).toBeLessThan(3_000);
+    // Containment is proven by the /memory/ rejection above: had the runtime's
+    // memory limit not tripped, the 2s engine timeout would have rejected with
+    // /timed out/ instead. This bound only guards against the allocation loop
+    // wedging the host indefinitely, so it is deliberately loose — a tight
+    // budget here just flakes when the suite saturates every core.
+    expect(Date.now() - startedAt).toBeLessThan(30_000);
   });
 
   it('aborts in-flight agents when the call cap trips', async () => {

--- a/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
+++ b/src/test-kernel/agent/WorkflowScriptEngine.vitest.ts
@@ -1727,8 +1727,17 @@ return await parallel([
     expect(sawAbort).toBe(true);
   });
 
+  // Containment is proven by the /memory/ rejection alone: had the runtime's
+  // memory limit not tripped, the 2s engine timeout would have rejected with
+  // /timed out/ instead.
+  //
+  // There is deliberately no wall-clock assertion. One used to guard against the
+  // allocation loop wedging the host, but filling the guest heap 1 MB at a time
+  // took 78s during a full-suite run on a contended machine, so any bound tight
+  // enough to mean something is a bound this test trips over. The per-test
+  // timeout below is the hang guard, and it needs to be explicit because it
+  // exceeds the suite-wide `testTimeout: 10000` in vitest.config.mjs.
   it('contains guest memory exhaustion inside the QuickJS runtime', async () => {
-    const startedAt = Date.now();
     await expect(
       runWorkflowScript({
         script: `${META}
@@ -1738,13 +1747,7 @@ while (true) values.push(new Uint8Array(1024 * 1024))`,
         timeoutMs: 2_000,
       }),
     ).rejects.toThrow(/memory/i);
-    // Containment is proven by the /memory/ rejection above: had the runtime's
-    // memory limit not tripped, the 2s engine timeout would have rejected with
-    // /timed out/ instead. This bound only guards against the allocation loop
-    // wedging the host indefinitely, so it is deliberately loose — a tight
-    // budget here just flakes when the suite saturates every core.
-    expect(Date.now() - startedAt).toBeLessThan(30_000);
-  });
+  }, 150_000);
 
   it('aborts in-flight agents when the call cap trips', async () => {
     let sawAbort = false;

--- a/src/test-kernel/desktop/DesktopDevScript.vitest.mts
+++ b/src/test-kernel/desktop/DesktopDevScript.vitest.mts
@@ -29,6 +29,7 @@ class FakeChild extends EventEmitter {
 
 const originalArgv = [...process.argv];
 const originalNpmExecPath = process.env.npm_execpath;
+const originalElectronDistPath = process.env.ELECTRON_OVERRIDE_DIST_PATH;
 const originalSigintListeners = new Set(process.listeners('SIGINT'));
 const originalSigtermListeners = new Set(process.listeners('SIGTERM'));
 
@@ -38,6 +39,11 @@ afterEach(() => {
     delete process.env.npm_execpath;
   } else {
     process.env.npm_execpath = originalNpmExecPath;
+  }
+  if (originalElectronDistPath == null) {
+    delete process.env.ELECTRON_OVERRIDE_DIST_PATH;
+  } else {
+    process.env.ELECTRON_OVERRIDE_DIST_PATH = originalElectronDistPath;
   }
   for (const listener of process.listeners('SIGINT')) {
     if (!originalSigintListeners.has(listener)) {
@@ -119,6 +125,13 @@ describe('desktop development launcher', () => {
       setTimeout: vi.fn(async () => {}),
     }));
     vi.stubGlobal('fetch', fetch);
+    // dev.mjs resolves the Electron binary at module load (`require('electron')`),
+    // and electron's index.js *downloads* the platform binary on demand when it
+    // is missing. That turned this unit test into a network fetch on a fresh
+    // checkout — and a hard failure with no network. The override short-circuits
+    // that resolution to a fixed path; the assertions below only check the spawn
+    // arguments, env, and stdio, never the binary's location.
+    process.env.ELECTRON_OVERRIDE_DIST_PATH = '/test/electron-dist';
     process.env.npm_execpath = '/test/pnpm.cjs';
     process.argv = [
       process.execPath,

--- a/src/test-kernel/telemetry/UsageLogService.vitest.ts
+++ b/src/test-kernel/telemetry/UsageLogService.vitest.ts
@@ -361,8 +361,10 @@ describe('UsageLogService', () => {
       UsageLogService.log(usageEntry('before-opt-out'));
       await platform().config.update(TELEMETRY_ENABLED_KEY, false);
 
+      // ACCEPTED, not PENDING: the entry is gone, and PENDING means "kept for a
+      // later retry" everywhere else in this service.
       await expect(UsageLogService.flush()).resolves.toBe(
-        USAGE_LOG_FLUSH_OUTCOME.PENDING,
+        USAGE_LOG_FLUSH_OUTCOME.ACCEPTED,
       );
 
       expect(fetchMock).not.toHaveBeenCalled();
@@ -391,5 +393,99 @@ describe('UsageLogService', () => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(batches.map(batchModels)).toEqual([['sent']]);
     });
+
+    // The relay enforces the monthly spend cap from the aggregate that these
+    // records populate, so an opt-out that suppressed them would let hosted
+    // calls run on against a stale total. Only `api-key` rounds are optional.
+    it.each([
+      ['relay', 'relay'],
+      ['chatgpt-subscription', 'chatgpt-subscription'],
+      ['kimi-code-subscription', 'kimi-code-subscription'],
+    ] as const)(
+      'still sends %s usage while the setting is off',
+      async (_label, usageRoute) => {
+        vi.spyOn(SupabaseClient, 'getRelayAccessToken').mockResolvedValue(
+          'token',
+        );
+        await platform().config.update(TELEMETRY_ENABLED_KEY, false);
+
+        const batches: unknown[] = [];
+        const fetchMock = stubFetch(batches);
+
+        UsageLogService.log({ ...usageEntry('hosted'), usageRoute });
+        await expect(UsageLogService.flush()).resolves.toBe(
+          USAGE_LOG_FLUSH_OUTCOME.ACCEPTED,
+        );
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(batches.map(batchModels)).toEqual([['hosted']]);
+      },
+    );
+
+    it('drops optional entries from a batch but keeps the accounted ones', async () => {
+      vi.spyOn(SupabaseClient, 'getRelayAccessToken').mockResolvedValue(
+        'token',
+      );
+
+      const batches: unknown[] = [];
+      const fetchMock = stubFetch(batches);
+
+      UsageLogService.log({ ...usageEntry('byok'), usageRoute: 'api-key' });
+      UsageLogService.log({ ...usageEntry('hosted'), usageRoute: 'relay' });
+      await platform().config.update(TELEMETRY_ENABLED_KEY, false);
+
+      await expect(UsageLogService.flush()).resolves.toBe(
+        USAGE_LOG_FLUSH_OUTCOME.ACCEPTED,
+      );
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(batches.map(batchModels)).toEqual([['hosted']]);
+    });
+
+    // getRelayAccessToken() is awaited before the batch is sent, so an opt-out
+    // that lands during that await must still take effect.
+    it('honours an opt-out that lands while the token lookup is in flight', async () => {
+      const { promise: tokenReleased, resolve: releaseToken } = deferred();
+      vi.spyOn(SupabaseClient, 'getRelayAccessToken').mockImplementation(
+        async () => {
+          await tokenReleased;
+          return 'token';
+        },
+      );
+
+      const batches: unknown[] = [];
+      const fetchMock = stubFetch(batches);
+
+      UsageLogService.log(usageEntry('optional'));
+      const flush = UsageLogService.flush();
+
+      await platform().config.update(TELEMETRY_ENABLED_KEY, false);
+      releaseToken();
+
+      await expect(flush).resolves.toBe(USAGE_LOG_FLUSH_OUTCOME.ACCEPTED);
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(batches).toEqual([]);
+    });
+
+    // JsonConfigProvider returns raw JSON from a hand-edited .texra/config.json,
+    // so a mistyped string must not read as truthy and re-enable logging.
+    it.each([['false'], ['0'], [0], [null]])(
+      'treats the non-boolean value %p as opted out',
+      async (value) => {
+        vi.spyOn(SupabaseClient, 'getRelayAccessToken').mockResolvedValue(
+          'token',
+        );
+        await platform().config.update(TELEMETRY_ENABLED_KEY, value);
+
+        const batches: unknown[] = [];
+        const fetchMock = stubFetch(batches);
+
+        UsageLogService.log(usageEntry('optional'));
+        await UsageLogService.flush();
+
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(batches).toEqual([]);
+      },
+    );
   });
 });

--- a/src/test-kernel/telemetry/UsageLogService.vitest.ts
+++ b/src/test-kernel/telemetry/UsageLogService.vitest.ts
@@ -11,10 +11,13 @@ import {
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import * as logger from '@logger/logUtils';
+import { platform } from '@platform/platform';
 import {
+  TELEMETRY_ENABLED_KEY,
   USAGE_LOG_FLUSH_OUTCOME,
   UsageLogService,
 } from '@telemetry/UsageLogService';
+import { setupPlatform } from '@test/support/setupPlatform';
 
 function usageEntry(model: string) {
   return {
@@ -318,5 +321,75 @@ describe('UsageLogService', () => {
     ]);
     expect(batchId(batches[1])).toBe(batchId(batches[0]));
     expect(batchId(batches[2])).not.toBe(batchId(batches[0]));
+  });
+
+  describe('texra.telemetry.enabled opt-out', () => {
+    // These tests write to the config provider. Without a per-test platform the
+    // mutation outlives the test — the file-scoped fake from setupFakePlatform
+    // is shared — and a stray `enabled: false` silently disables logging for
+    // every suite that runs afterwards.
+    setupPlatform();
+
+    it('sends nothing while the setting is off', async () => {
+      vi.spyOn(SupabaseClient, 'getRelayAccessToken').mockResolvedValue(
+        'token',
+      );
+      await platform().config.update(TELEMETRY_ENABLED_KEY, false);
+
+      const batches: unknown[] = [];
+      const fetchMock = stubFetch(batches);
+
+      UsageLogService.log(usageEntry('first'));
+      await expect(UsageLogService.flush()).resolves.toBe(
+        USAGE_LOG_FLUSH_OUTCOME.ACCEPTED,
+      );
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(batches).toEqual([]);
+    });
+
+    // The setting is read live, so turning it off has to drop rounds already
+    // queued under the old value rather than letting the next flush ship them.
+    it('discards entries queued before the setting was turned off', async () => {
+      vi.spyOn(SupabaseClient, 'getRelayAccessToken').mockResolvedValue(
+        'token',
+      );
+
+      const batches: unknown[] = [];
+      const fetchMock = stubFetch(batches);
+
+      UsageLogService.log(usageEntry('before-opt-out'));
+      await platform().config.update(TELEMETRY_ENABLED_KEY, false);
+
+      await expect(UsageLogService.flush()).resolves.toBe(
+        USAGE_LOG_FLUSH_OUTCOME.PENDING,
+      );
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(batches).toEqual([]);
+    });
+
+    it('resumes sending once the setting is turned back on', async () => {
+      vi.spyOn(SupabaseClient, 'getRelayAccessToken').mockResolvedValue(
+        'token',
+      );
+      await platform().config.update(TELEMETRY_ENABLED_KEY, false);
+
+      const batches: unknown[] = [];
+      const fetchMock = stubFetch(batches);
+
+      UsageLogService.log(usageEntry('dropped'));
+      await UsageLogService.flush();
+      expect(fetchMock).not.toHaveBeenCalled();
+
+      await platform().config.update(TELEMETRY_ENABLED_KEY, true);
+      UsageLogService.log(usageEntry('sent'));
+      await expect(UsageLogService.flush()).resolves.toBe(
+        USAGE_LOG_FLUSH_OUTCOME.ACCEPTED,
+      );
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(batches.map(batchModels)).toEqual([['sent']]);
+    });
   });
 });

--- a/src/test-kernel/utils/system/SystemUtils.vitest.ts
+++ b/src/test-kernel/utils/system/SystemUtils.vitest.ts
@@ -34,8 +34,13 @@ async function waitForFile(filePath: string): Promise<void> {
   throw new Error(`Timed out waiting for ${filePath}`);
 }
 
+// Signal delivery to a whole process group, and the kernel reaping the members,
+// is not instant — and gets markedly slower when the suite is saturating every
+// core. The budget is generous (~10s) because it exists to catch a genuinely
+// leaked child, not to measure teardown latency; a tight one only produces
+// flakes on loaded machines.
 async function waitForProcessExit(pid: number): Promise<void> {
-  for (let attempt = 0; attempt < 50; attempt += 1) {
+  for (let attempt = 0; attempt < 500; attempt += 1) {
     try {
       process.kill(pid, 0);
     } catch {

--- a/src/test-kernel/utils/system/SystemUtils.vitest.ts
+++ b/src/test-kernel/utils/system/SystemUtils.vitest.ts
@@ -39,6 +39,12 @@ async function waitForFile(filePath: string): Promise<void> {
 // core. The budget is generous (~10s) because it exists to catch a genuinely
 // leaked child, not to measure teardown latency; a tight one only produces
 // flakes on loaded machines.
+//
+// It exceeds the suite-wide `testTimeout: 10000` in vitest.config.mjs, so every
+// test calling this must pass PROCESS_EXIT_TEST_TIMEOUT_MS. Without it the
+// runner aborts the test mid-poll and the extra budget buys nothing.
+const PROCESS_EXIT_TEST_TIMEOUT_MS = 30_000;
+
 async function waitForProcessExit(pid: number): Promise<void> {
   for (let attempt = 0; attempt < 500; attempt += 1) {
     try {
@@ -202,67 +208,75 @@ describe('executeCommand', () => {
     assert.match(result.stderr ?? '', /maxBuffer exceeded/i);
   });
 
-  it('aborts shell command process groups including children', async () => {
-    if (process.platform === 'win32') return;
+  it(
+    'aborts shell command process groups including children',
+    async () => {
+      if (process.platform === 'win32') return;
 
-    const dir = mkdtempSync(join(tmpdir(), 'texra-exec-abort-'));
-    tempDirs.push(dir);
-    const pidFile = join(dir, 'sleep.pid');
-    const controller = new AbortController();
-    const promise = executeCommand('sleep 60 & echo $! > "$PID_FILE"; wait', {
-      cwd: dir,
-      env: { PID_FILE: pidFile },
-      signal: controller.signal,
-      timeout: 60_000,
-    });
-
-    await waitForFile(pidFile);
-    const childPid = Number.parseInt(readFileSync(pidFile, 'utf8'), 10);
-    assert.ok(Number.isInteger(childPid) && childPid > 0);
-
-    controller.abort();
-    const result = await promise;
-
-    assert.equal(result.success, false);
-    assert.equal(result.timedOut, false);
-    assert.equal(result.stderr, 'Command aborted by user');
-    await waitForProcessExit(childPid);
-  });
-
-  it('aborts array-form commands via execa native cancelSignal', async () => {
-    if (process.platform === 'win32') return;
-
-    const controller = new AbortController();
-    let childPid: number | undefined;
-    const promise = executeCommand(
-      [process.execPath, '-e', 'setTimeout(() => {}, 60000)'],
-      {
+      const dir = mkdtempSync(join(tmpdir(), 'texra-exec-abort-'));
+      tempDirs.push(dir);
+      const pidFile = join(dir, 'sleep.pid');
+      const controller = new AbortController();
+      const promise = executeCommand('sleep 60 & echo $! > "$PID_FILE"; wait', {
+        cwd: dir,
+        env: { PID_FILE: pidFile },
         signal: controller.signal,
         timeout: 60_000,
-        onPid: (pid) => {
-          childPid = pid;
+      });
+
+      await waitForFile(pidFile);
+      const childPid = Number.parseInt(readFileSync(pidFile, 'utf8'), 10);
+      assert.ok(Number.isInteger(childPid) && childPid > 0);
+
+      controller.abort();
+      const result = await promise;
+
+      assert.equal(result.success, false);
+      assert.equal(result.timedOut, false);
+      assert.equal(result.stderr, 'Command aborted by user');
+      await waitForProcessExit(childPid);
+    },
+    PROCESS_EXIT_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'aborts array-form commands via execa native cancelSignal',
+    async () => {
+      if (process.platform === 'win32') return;
+
+      const controller = new AbortController();
+      let childPid: number | undefined;
+      const promise = executeCommand(
+        [process.execPath, '-e', 'setTimeout(() => {}, 60000)'],
+        {
+          signal: controller.signal,
+          timeout: 60_000,
+          onPid: (pid) => {
+            childPid = pid;
+          },
         },
-      },
-    );
+      );
 
-    for (
-      let attempt = 0;
-      attempt < 50 && childPid === undefined;
-      attempt += 1
-    ) {
-      await sleep(20);
-    }
-    assert.ok(childPid && childPid > 0);
+      for (
+        let attempt = 0;
+        attempt < 50 && childPid === undefined;
+        attempt += 1
+      ) {
+        await sleep(20);
+      }
+      assert.ok(childPid && childPid > 0);
 
-    controller.abort();
-    const result = await promise;
+      controller.abort();
+      const result = await promise;
 
-    assert.equal(result.success, false);
-    assert.equal(result.timedOut, false);
-    assert.equal(result.exitCode, 130);
-    assert.equal(result.stderr, 'Command aborted by user');
-    await waitForProcessExit(childPid!);
-  });
+      assert.equal(result.success, false);
+      assert.equal(result.timedOut, false);
+      assert.equal(result.exitCode, 130);
+      assert.equal(result.stderr, 'Command aborted by user');
+      await waitForProcessExit(childPid!);
+    },
+    PROCESS_EXIT_TEST_TIMEOUT_MS,
+  );
 
   it('unblocks aborted array-form await when a descendant holds stdio', async () => {
     if (process.platform === 'win32') return;

--- a/src/utils/system/platformPaths.ts
+++ b/src/utils/system/platformPaths.ts
@@ -145,6 +145,31 @@ function getExtraDirs(): string[] {
         }
       }
     }
+
+    // TeX Live for Windows bundles its own Perl (tlperl) instead of putting one
+    // on PATH. latexindent/latexdiff still work there because they resolve to
+    // the .exe wrappers under texlive/*/bin/*, which use tlperl internally --
+    // but a bare `perl` does not exist, so checkCoreDependencies() reported
+    // Perl missing and told TeX Live users to install Strawberry Perl they do
+    // not need. Probed after the entries above so a user-installed Perl still
+    // wins; tlperl is the fallback, and it carries the modules latexindent
+    // needs.
+    const tlperlPatterns = ['C:/texlive/*/tlpkg/tlperl/bin'];
+    if (process.env.USERPROFILE) {
+      tlperlPatterns.push(
+        `${normalizeFilePath(process.env.USERPROFILE)}/texlive/*/tlpkg/tlperl/bin`,
+      );
+    }
+    for (const pattern of tlperlPatterns) {
+      for (const dir of globDescending(pattern)) {
+        if (
+          AbsoluteFS.existsSync(path.join(dir, 'perl.exe')) &&
+          !dirs.includes(dir)
+        ) {
+          dirs.push(dir);
+        }
+      }
+    }
   } else {
     // Linux/Unix paths
     dirs.push(

--- a/src/utils/system/platformPaths.ts
+++ b/src/utils/system/platformPaths.ts
@@ -83,15 +83,19 @@ function getExtraDirs(): string[] {
       'C:\\Program Files\\MiKTeX 2.9\\miktex\\bin',
       'C:\\Program Files (x86)\\MiKTeX\\miktex\\bin',
       'C:\\Program Files (x86)\\MiKTeX 2.9\\miktex\\bin',
-      'C:\\Program Files\\gs\\gs9.56.1\\bin',
-      'C:\\Program Files\\gs\\gs9.55.0\\bin',
-      'C:\\Program Files\\gs\\gs9.54.0\\bin',
-      'C:\\Program Files (x86)\\gs\\gs9.56.1\\bin',
-      'C:\\Program Files (x86)\\gs\\gs9.55.0\\bin',
-      'C:\\Program Files (x86)\\gs\\gs9.54.0\\bin',
       // Strawberry Perl (recommended Perl distribution for Windows)
       'C:\\Strawberry\\perl\\bin',
     );
+
+    // Ghostscript installs under a version-stamped directory. This was six
+    // hardcoded 9.54-9.56 paths, so a current 10.x install was invisible unless
+    // it was already on PATH. Descending sort keeps the previous preference
+    // order among 9.x releases (9.56 before 9.55 before 9.54) and treats 10.x as
+    // a fallback, since "gs9" sorts above "gs1" -- any installed version works,
+    // so the ordering is a preference, not a correctness requirement.
+    for (const programFiles of ['C:/Program Files', 'C:/Program Files (x86)']) {
+      dirs.push(...globDescending(`${programFiles}/gs/*/bin`));
+    }
     const localAppData =
       process.env.LOCALAPPDATA ||
       (process.env.USERPROFILE


### PR DESCRIPTION
Audits the repo at 0.40.0 for what blocks flipping it public: licensing
(placeholder LICENSE, proprietary per-package terms, TOS clauses that
contradict an OSS grant), the publish-scope decisions (hosted-specialist
prompts, supabase/ enforcement, internal design docs), repo identity, and
hardening.

Records the verified-clean results so they are not re-audited: no secrets
across the full 17,585-commit history, no copyleft dependencies, fork-safe
CI automation, clean typecheck/lint, and no dead code (every knip finding
is an indirection false positive already in the ratchet baseline).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PAiHM1qnmVEiRxVnK1tQCR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Telemetry gating affects billing-related flush behavior for relay/subscription routes and must stay correct; usage logging changes touch privacy-sensitive data paths across all hosts.
> 
> **Overview**
> Prepares the repo for a potential public flip while shipping several user-facing and platform fixes.
> 
> **Open-source readiness** adds `docs/proposals/2026-07-29-open-source-readiness.md` (licensing, publish scope, repo identity, CI gaps) and a new **`SECURITY.md`** with private disclosure via `contact@texra.ai`. **`@texra-ai/agent`** gets `repository` / `bugs` / `homepage` / `author` metadata aligned with other published packages. **`.gitignore`** clarifies that `.trusted-actions/` is a second checkout of this repo at the PR base ref, not a private actions repo. **CI** documents a deferred **`TODO(windows-ci)`** after a reverted Windows matrix attempt (~10 pre-existing failures).
> 
> **Privacy / usage logging** introduces **`texra.telemetry.enabled`** (default `true`) in core settings and VS Code **TeXRA → Privacy**. `UsageLogService` reads the setting live on queue and flush so opt-out is immediate and drops already-queued optional entries; **relay and subscription routes still log** for plan spend accounting. Non-boolean config values fail closed with a warning. Docs cover fields sent and opt-out behavior in `configuration.md`; architecture ratchet records **`telemetry → platform`**.
> 
> **Windows tool discovery** replaces hardcoded Ghostscript 9.x paths with globs under Program Files and probes **TeX Live `tlperl`** so dependency checks stop pushing Strawberry Perl on TeX Live installs. **Installation** docs spell out MiKTeX vs TeX Live Perl on Windows.
> 
> **Test reliability** makes the desktop dev script test hermetic via `ELECTRON_OVERRIDE_DIST_PATH`, relaxes flaky wall-clock bounds in workflow memory and process-abort tests with explicit per-test timeouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ace615a72f6d2889086ad961836853b4b777c1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->