### PR TITLE
fix: release transcripts loaded for recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Long-running sessions use less memory after recovering interrupted runs** —
+  transcript history loaded only to repair stale run state is released again
+  after the repair is saved, instead of remaining in memory for the rest of
+  the session.
 - **Install in Terminal now offers a command your machine can run** — the Codex
   and Claude Code cards offer the Homebrew command where Homebrew is present
   and Claude Code's Windows installer on Windows, instead of a global npm

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -1315,6 +1315,13 @@ describe('DesktopProgressBridge', () => {
       new Map([[waitingStream, executionId]]),
     );
     expect(bridgeStatus(second).get(waitingStream)).toBe(STREAM_PHASE.WAITING);
+    expect(second.streamLogs.get(waitingStream)).toBeUndefined();
+    expect(second.streamLogs.get(orphanedStream)).toBeUndefined();
+
+    await Promise.all([
+      second.streamLogs.ensureLoaded(waitingStream),
+      second.streamLogs.ensureLoaded(orphanedStream),
+    ]);
     expect(
       second.streamLogs.get(waitingStream)?.getRange(0).at(-1),
     ).toMatchObject({

--- a/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
+++ b/src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts
@@ -47,6 +47,13 @@ function storageFile(dir: string, key: string): string {
   return path.join(dir, `${encodeURIComponent(key)}.json`);
 }
 
+function writtenLog(
+  writes: ReadonlyMap<string, unknown>,
+  streamId: string,
+): StreamLogEntry[] {
+  return writes.get(storageFile(STREAM_LOGS_DIR, streamId)) as StreamLogEntry[];
+}
+
 function streamKeyFromFile(target: string): string {
   return decodeURIComponent(path.basename(target).replace(/\.json$/, ''));
 }
@@ -891,10 +898,11 @@ describe('StreamLogStore load', () => {
 
     const affected = await store.endRunningGroups(300);
     await store.flush();
-    const entry = store.get('alpha')?.getRange(0).at(0);
+    expect(store.get('alpha')).toBeUndefined();
+    expect(storage.fullLogReads()).toBe(1);
+    const entry = writtenLog(storage.writes, 'alpha').at(0);
 
     expect(affected).toEqual(['alpha']);
-    expect(storage.fullLogReads()).toBe(1);
     expect(entry?.type).toBe(STREAM_LOG_ENTRY_TYPES.GROUP_END);
     // endRunningGroups() defaults to RUN_OUTCOME.FAILED (#7993 step 2) — the
     // orphan sweep's caller-classified default, not the folded 'error'
@@ -972,9 +980,9 @@ describe('StreamLogStore load', () => {
 
     expect(affected).toEqual(['alpha']);
     expect(storage.fullLogReads()).toBe(1);
-    expect(store.get('alpha')?.getRange(0).at(0)?.type).toBe(
-      STREAM_LOG_ENTRY_TYPES.GROUP_END,
-    );
+    expect(store.get('alpha')).toBeUndefined();
+    const entry = writtenLog(storage.writes, 'alpha').at(0);
+    expect(entry?.type).toBe(STREAM_LOG_ENTRY_TYPES.GROUP_END);
     expect(store.get('beta')).toBeUndefined();
     expect(
       storage.writes.get(storageFile(STREAM_LOG_SUMMARIES_DIR, 'alpha')),
@@ -987,6 +995,32 @@ describe('StreamLogStore load', () => {
     expect(
       storage.writes.get(storageFile(STREAM_LOG_SUMMARIES_DIR, 'beta')),
     ).toBeUndefined();
+  });
+
+  it('keeps already-resident streams after repairing their running groups', async () => {
+    const storage = mockStorage({
+      logs: {
+        alpha: [runningGroupEntry('alpha', 1, 100)],
+      },
+      summaries: {
+        alpha: {
+          firstTimestamp: 100,
+          lastTimestamp: 100,
+          hasRunningGroup: true,
+        },
+      },
+    });
+    const store = await StreamLogStore.open();
+    await store.ensureLoaded('alpha');
+
+    const affected = await store.endRunningGroupsForStreams(['alpha'], 300);
+    await store.flush();
+
+    expect(affected).toEqual(['alpha']);
+    expect(storage.fullLogReads()).toBe(1);
+    expect(store.get('alpha')?.getRange(0).at(0)?.type).toBe(
+      STREAM_LOG_ENTRY_TYPES.GROUP_END,
+    );
   });
 
   it('finalizes an orphaned streaming-text entry even when its group already closed (#7276)', async () => {
@@ -1013,10 +1047,11 @@ describe('StreamLogStore load', () => {
 
     const affected = await store.endRunningGroupsForStreams(['gamma'], 300);
     await store.flush();
-    const entry = store.get('gamma')?.getRange(0).at(0);
+    expect(store.get('gamma')).toBeUndefined();
+    expect(storage.fullLogReads()).toBe(1);
+    const entry = writtenLog(storage.writes, 'gamma').at(0);
 
     expect(affected).toEqual(['gamma']);
-    expect(storage.fullLogReads()).toBe(1);
     expect(entry?.data).toEqual({ status: 'completed' });
     expect(
       storage.writes.get(storageFile(STREAM_LOG_SUMMARIES_DIR, 'gamma')),
@@ -1048,7 +1083,8 @@ describe('StreamLogStore load', () => {
 
     const affected = await store.endRunningGroupsForStreams(['workflow'], 300);
     await store.flush();
-    const entries = store.get('workflow')?.getRange(0) ?? [];
+    expect(store.get('workflow')).toBeUndefined();
+    const entries = writtenLog(storage.writes, 'workflow');
 
     expect(affected).toEqual(['workflow']);
     expect(entries.at(0)).toMatchObject({
@@ -1106,11 +1142,13 @@ describe('StreamLogStore load', () => {
     await store.flush();
 
     expect(affected).toEqual(['alpha']);
-    expect(store.get('alpha')?.getRange(0).at(0)?.data).toEqual({
+    expect(store.get('alpha')).toBeUndefined();
+    expect(storage.fullLogReads()).toBe(1);
+    const entry = writtenLog(storage.writes, 'alpha').at(0);
+    expect(entry?.data).toEqual({
       status: RUN_OUTCOME.CANCELLED,
       endTime: 300,
     });
-    expect(storage.fullLogReads()).toBe(1);
   });
 
   // §8.3 boundary normalization: the ONE app-side read boundary for legacy
@@ -1205,9 +1243,10 @@ describe('StreamLogStore load', () => {
     expect(affected).toEqual(['beta']);
     expect(storage.fullLogReads()).toBe(1);
     expect(store.get('alpha')).toBeUndefined();
-    expect(store.get('beta')?.getRange(0).at(0)?.type).toBe(
-      STREAM_LOG_ENTRY_TYPES.GROUP_END,
-    );
+
+    expect(store.get('beta')).toBeUndefined();
+    const entry = writtenLog(storage.writes, 'beta').at(0);
+    expect(entry?.type).toBe(STREAM_LOG_ENTRY_TYPES.GROUP_END);
   });
 
   it('bounds stale running group rehydrates', async () => {

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -816,7 +816,13 @@ export class StreamLogStore {
     status: RunOutcome = RUN_OUTCOME.FAILED,
   ): Promise<StreamTabId[]> {
     this.assertWritableStore('finalize running transcript groups');
-    const streamsToLoad = new Set(streamIds);
+    const streamsToLoad = new Set<StreamTabId>();
+    for (const streamId of streamIds) {
+      const state = this.streams.get(streamId);
+      if (state?.log === undefined || state.loadFailed === true) {
+        streamsToLoad.add(streamId);
+      }
+    }
     for (const [streamId, summary] of this.summaries) {
       if (
         hasSomethingRunning(summary) &&
@@ -836,6 +842,11 @@ export class StreamLogStore {
     const affected = this.endRunningEntriesInLoadedLogs(now, undefined, status);
     if (affected.length > 0) {
       void this.save();
+    }
+    // Recovery borrowed these logs only to repair stale entries. Return them
+    // to cold storage; requestEviction waits for any repair write to finish.
+    for (const streamId of streamsToLoad) {
+      this.requestEviction(streamId);
     }
 
     return affected;
@@ -867,6 +878,11 @@ export class StreamLogStore {
     );
     if (affected.length > 0) {
       void this.save();
+    }
+    // Preserve logs that were resident before this call; only release the
+    // cold logs loaded specifically for recovery.
+    for (const streamId of streamsToLoad) {
+      this.requestEviction(streamId);
     }
 
     return affected;


### PR DESCRIPTION
## Summary

Release transcript logs that were loaded solely to repair interrupted runs once their repaired state has been queued for durable storage. Logs that were already resident before recovery remain resident.

This prevents restart repair from retaining every parsed transcript it inspected for the remainder of a long-running process. It addresses the memory-amplification path without increasing the Node heap or adding a periodic cleanup mechanism.

## Issue acceptance gates

No linked issue.

- Cold transcript logs loaded for restart repair are evicted after repair.
- Dirty repaired logs remain resident until their write completes.
- Logs resident before recovery are not evicted.
- Repaired logs can be loaded again from durable storage with their terminal state intact.

## Single source of truth

`StreamLogStore` continues to own transcript residency, durability, and eviction. Recovery returns borrowed logs directly to that owner through the existing `requestEviction` lifecycle.

## Duplication and abstraction budget

No production abstraction or pass-through layer was added. The change uses the existing eviction mechanism at the storage boundary. A small test-only helper removes repeated inspection of recorded transcript writes.

## Net elements (R6)

- Files: 4 modified, 0 added, 0 deleted.
- Exported symbols: 0 added, 0 removed.
- Classes/interfaces/enums: 0 added, 0 removed.
- Lines: +80 / -14, net +66, principally regression coverage.

## Consumer counts (R8)

n/a — no event path or exported symbol is deleted or rerouted.

## Host impact

Extension: Restart recovery releases cold transcript history after saving repairs.

Desktop: Restart recovery has the same reduced resident-memory footprint; the integration test verifies durable reload after eviction.

CLI: Long-running sessions no longer retain cold transcript histories loaded during interrupted-run cleanup.

## Scheduled refactoring

None. Incremental projection of an active TUI transcript is a separate algorithmic concern and is intentionally outside this focused fix.

## Validation

- `npm run format` — passed through the commit hook.
- `npm run compile:fast` — passed.
- `npm run typecheck` — passed.
- `npm run lint` — passed.
- `npx vitest run src/test-kernel/transcript/StreamLogStoreLoad.vitest.ts` — 47 passed.
- Focused transcript and desktop restart-recovery run — 48 passed, 73 skipped.
- Pre-push checks — passed.
- `npm test` — attempted; the parallel run exceeded fixed timeouts in several unrelated CLI, desktop packaging, Lean-tool, and layout tests and was stopped after it ceased making progress. The recovery-related desktop failure from that run was an obsolete residency assertion; after updating it to verify eviction and durable reload, the test passes in isolation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transcript residency during session restart repair across CLI, desktop, and extension; behavior is covered by unit and integration tests, but incorrect eviction could affect UI reload of repaired streams.
> 
> **Overview**
> **Restart repair no longer keeps every inspected transcript in RAM for the rest of the session.** When `endRunningGroups` / `endRunningGroupsForStreams` load cold stream logs to close stale running groups, they now call `requestEviction` on those borrowed logs after the repair is queued for save. Streams that were already resident before the call are unchanged.
> 
> Load planning is tightened so explicit stream IDs are only pulled from disk when the log is not already loaded (or prior load failed); orphan sweeps still load any summary-marked running stream that is not resident.
> 
> Tests assert eviction for cold-loaded repairs, a new case that already-loaded streams stay in memory, desktop restart recovery reloads terminal state from disk after eviction, and the changelog documents lower memory use on long-running sessions after interrupted-run recovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc9f5ae07afde1dc46a7ec929dfc495f104a3931. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->