### PR TITLE
refactor: simplify code changed since 0.39.9

### DIFF
--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -920,13 +920,6 @@ function makeChildEntries(agent: string, action: string): ConversationEntry[] {
   ];
 }
 
-function isDifferentExecution(
-  child: ActiveChildInfo,
-  executionId: string,
-): boolean {
-  return child.executionId !== executionId;
-}
-
 function harnessMessageEntry(
   id: string,
   text: string,
@@ -1141,7 +1134,8 @@ function applyHarnessApprovalDecision(decision: ApprovalDecision): void {
 function appendHarnessExternalInquiryDecision(
   decision: ApprovalDecision,
 ): void {
-  appendHarnessUserTranscript(
+  appendHarnessTranscript(
+    'user',
     buildContinuationText({
       event: decision.accepted && decision.userMessage ? 'answered' : 'dropped',
       threadId: EXTERNAL_INQUIRY_THREAD_ID,
@@ -2093,10 +2087,6 @@ function appendHarnessChildSubmitAck(
   appendHarnessTranscript('assistant', text, streamId, { finalized: !isLive });
 }
 
-function appendHarnessUserTranscript(text: string): void {
-  appendHarnessTranscript('user', text);
-}
-
 function appendHarnessTranscript(
   role: 'assistant' | 'error' | 'user',
   text: string,
@@ -2127,12 +2117,6 @@ function defaultHarnessTranscriptStreamId(): StreamTabId {
   });
 }
 
-function formatHarnessSlashHelp(): string {
-  return formatSlashCommandHelp(listSlashCommands(), {
-    shortcutModifierLabel: defaultShortcutModifierLabel(),
-  });
-}
-
 function setHarnessApprovalPolicy(policy: CliApprovalPolicy): void {
   harnessApprovalPolicy = policy;
   sessionMeta.set({
@@ -2152,17 +2136,13 @@ function getHarnessModelSwitchDisabledReason(
     : undefined;
 }
 
-function openHarnessApprovalPolicyForm(remainder: string): boolean {
-  return openCliSlashCommandForm('approval', remainder);
-}
-
 function applyHarnessApprovalPolicySelection(
   input: string,
   usage: string,
 ): void {
   const normalized = input.trim().toLowerCase();
   if (!normalized || normalized === 'status') {
-    if (openHarnessApprovalPolicyForm(input)) return;
+    if (openCliSlashCommandForm('approval', input)) return;
   }
 
   const policy = parseCliApprovalPolicy(normalized);
@@ -2195,9 +2175,7 @@ function markHarnessExecutionStopped(executionId: string): void {
   const messageId = `harness-killed-${executionId}-${Date.now()}`;
   applySubagentRoster(
     STREAM_ID,
-    activeSubagentRows.filter((child) =>
-      isDifferentExecution(child, executionId),
-    ),
+    activeSubagentRows.filter((child) => child.executionId !== executionId),
   );
   patchStream(STREAM_ID, (slice) => ({
     ...slice,
@@ -2306,7 +2284,11 @@ function handleHarnessSlashCommand(line: string): boolean {
   const rest = parsed.remainder.trim();
   switch (commandName) {
     case 'help':
-      appendHarnessAssistantTranscript(formatHarnessSlashHelp());
+      appendHarnessAssistantTranscript(
+        formatSlashCommandHelp(listSlashCommands(), {
+          shortcutModifierLabel: defaultShortcutModifierLabel(),
+        }),
+      );
       return true;
     case 'status':
       appendHarnessStatus();

--- a/packages/cli/src/chat/chatSessionController.ts
+++ b/packages/cli/src/chat/chatSessionController.ts
@@ -408,20 +408,18 @@ export function createChatSessionController(
         releaseIfUnused();
       },
     );
+    const deleteOwnedEntries = <K>(map: Map<K, object>): void => {
+      for (const [key, owner] of map) {
+        if (owner === interactionOwner) map.delete(key);
+      }
+    };
     const releaseHost = (): void => {
       if (released) return;
       released = true;
       detachExecutionListener();
       detachChildActivationListener();
-      for (const [executionId, owner] of executionInteractionOwners) {
-        if (owner === interactionOwner) {
-          executionInteractionOwners.delete(executionId);
-        }
-      }
-      for (const [streamId, owner] of streamInteractionOwners) {
-        if (owner === interactionOwner)
-          streamInteractionOwners.delete(streamId);
-      }
+      deleteOwnedEntries(executionInteractionOwners);
+      deleteOwnedEntries(streamInteractionOwners);
       detachResultToastOnce();
       detachHostInteractions();
       if (session.presentationHost === presentationHost) {

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -429,9 +429,8 @@ export function StaticConversationTranscript({
   const sessionMeta = useSignal(sessionMetaSignal);
   const parentStream = useSignal(parentStreamSignal);
   const childStreamEntries = useSignal(childStreamEntriesSignal);
-  const [state, setState] = useState<StaticTranscriptState>(() => ({
-    ownerKey,
-    items: appendStaticTranscriptItems({
+  const buildFreshItems = (): readonly StaticTranscriptItem[] =>
+    appendStaticTranscriptItems({
       currentItems: [],
       streams,
       childStreamEntries,
@@ -442,24 +441,13 @@ export function StaticConversationTranscript({
       printRequests,
       scrollbackStreamId,
       width: normalizedWidth,
-    }),
+    });
+  const [state, setState] = useState<StaticTranscriptState>(() => ({
+    ownerKey,
+    items: buildFreshItems(),
   }));
 
-  const items =
-    state.ownerKey === ownerKey
-      ? state.items
-      : appendStaticTranscriptItems({
-          currentItems: [],
-          streams,
-          childStreamEntries,
-          executionLabels: subagentExecutionLabels,
-          meta: sessionMeta,
-          maxRows,
-          parentStream,
-          printRequests,
-          scrollbackStreamId,
-          width: normalizedWidth,
-        });
+  const items = state.ownerKey === ownerKey ? state.items : buildFreshItems();
 
   useEffect(() => {
     // On a hard reset (e.g. /clear, picker-to-chat handoff) start the

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -367,12 +367,12 @@ export async function runChat(
     initialAgent: agent,
     initialModel: model,
     interruptActive,
-    requestInputExit: () => exitController.requestInputExit(),
+    requestInputExit: exitController.requestInputExit,
     getApprovalPolicy,
     setApprovalPolicy,
     canSelectModel: canSelectCurrentModel,
     resetSession: resetSessionForClear,
-    resumeExecution: (id: ExecutionId) => chatController.resume(id),
+    resumeExecution: chatController.resume,
   });
   const initialPresetId = initialResume
     ? (initialResume.resolution.agentConfig.cliMultiAgentPresetId ?? undefined)
@@ -521,8 +521,7 @@ export async function runChat(
   });
   disposers.push(
     setCliAgentResumeHandler({
-      tryResumeStream: (streamId, recovery) =>
-        chatController.tryResumeStream(streamId, recovery),
+      tryResumeStream: chatController.tryResumeStream,
     }),
   );
 
@@ -593,7 +592,7 @@ export async function runChat(
     onLogoutSelect: (value, output) => logoutFromChat(value, output),
     onMemorySelect: showCliMemoryPreview,
     onSkillSelect: activateSkillForNextMessage,
-    onResumeSelect: (id: ExecutionId) => chatController.resume(id),
+    onResumeSelect: chatController.resume,
     getConfigStores: cliSettingsStores,
     onError: (error) => {
       appendLocalAssistantTranscript(toErrorMessage(error));

--- a/packages/cli/src/chat/tui/sessionStatus.ts
+++ b/packages/cli/src/chat/tui/sessionStatus.ts
@@ -52,19 +52,17 @@ export function formatCliStatusLabel(
   substate?: StreamSubstate,
   isChildStream?: boolean,
 ): string {
-  if (isChildStream && status === STREAM_STATUS.STOPPED) {
-    return WORKFLOW_TASK_STATUS_LABEL[STREAM_PHASE.CANCELLED];
-  }
-  const statusKey = streamStatusDisplayKey(status, substate);
-  if (isChildStream && statusKey === undefined) return '';
-  if (
-    isChildStream &&
-    statusKey !== undefined &&
-    Object.hasOwn(WORKFLOW_TASK_STATUS_LABEL, statusKey)
-  ) {
-    return WORKFLOW_TASK_STATUS_LABEL[
-      statusKey as keyof typeof WORKFLOW_TASK_STATUS_LABEL
-    ];
+  if (isChildStream) {
+    if (status === STREAM_STATUS.STOPPED) {
+      return WORKFLOW_TASK_STATUS_LABEL[STREAM_PHASE.CANCELLED];
+    }
+    const statusKey = streamStatusDisplayKey(status, substate);
+    if (statusKey === undefined) return '';
+    if (Object.hasOwn(WORKFLOW_TASK_STATUS_LABEL, statusKey)) {
+      return WORKFLOW_TASK_STATUS_LABEL[
+        statusKey as keyof typeof WORKFLOW_TASK_STATUS_LABEL
+      ];
+    }
   }
   return formatStreamStatusLabel(status, {
     style: 'cli',

--- a/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamLog.ts
@@ -123,9 +123,7 @@ function safeWorkflowOperationalSummary(text: string): string | undefined {
 function workflowOperationalDescription(
   entries: readonly ConversationEntry[],
 ): string | undefined {
-  for (let index = entries.length - 1; index >= 0; index -= 1) {
-    const entry = entries[index];
-    if (!entry) continue;
+  for (const entry of entries.toReversed()) {
     if (entry.role === 'tool') {
       const description =
         safeWorkflowOperationalSummary(entry.toolUse.headerSummary) ??
@@ -177,17 +175,14 @@ function logEntryStreamIsRunning(entry: StreamLogEntry): boolean {
 function latestLogActivityIsThinking(
   entries: readonly StreamLogEntry[],
 ): boolean {
-  for (let index = entries.length - 1; index >= 0; index -= 1) {
-    const entry = entries[index];
-    if (!entry || !LIVE_ACTIVITY_MESSAGE_TYPES.has(entry.messageType ?? '')) {
-      continue;
-    }
-    return (
-      entry.messageType === MESSAGE_TYPES.THINKING &&
-      logEntryStreamIsRunning(entry)
-    );
-  }
-  return false;
+  const entry = entries.findLast((candidate) =>
+    LIVE_ACTIVITY_MESSAGE_TYPES.has(candidate.messageType ?? ''),
+  );
+  if (!entry) return false;
+  return (
+    entry.messageType === MESSAGE_TYPES.THINKING &&
+    logEntryStreamIsRunning(entry)
+  );
 }
 
 function latestCompactionActivityIsRunning(

--- a/packages/cli/src/chat/tui/state/transcript.ts
+++ b/packages/cli/src/chat/tui/state/transcript.ts
@@ -35,10 +35,6 @@ export function isFinalTranscriptStatus(
 
 let localEntrySeq = 0;
 
-function normalizeTranscriptText(text: string): string {
-  return text.trim();
-}
-
 export function appendLocalAssistantTranscript(
   text: string,
   streamId?: StreamTabId,
@@ -59,7 +55,7 @@ function appendLocalTranscriptEntry(
   text: string,
   explicitStreamId?: StreamTabId,
 ): void {
-  const normalized = normalizeTranscriptText(text);
+  const normalized = text.trim();
   if (!normalized) return;
 
   const streamId = explicitStreamId ?? defaultLocalTranscriptStreamId();

--- a/packages/cli/src/runtime/cliPresentationHost.ts
+++ b/packages/cli/src/runtime/cliPresentationHost.ts
@@ -100,17 +100,10 @@ export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
     return logger;
   }
 
-  function prepareInteractivePrompt(): void {
-    runProgress?.preserve();
-  }
-
-  function attachProgressRenderer(events: SessionEventHub): () => void {
-    return attachRunProgressRenderer(events, runProgress);
-  }
-
   return {
-    attachRunProgressRenderer: attachProgressRenderer,
-    prepareInteractivePrompt,
+    attachRunProgressRenderer: (events) =>
+      attachRunProgressRenderer(events, runProgress),
+    prepareInteractivePrompt: () => runProgress?.preserve(),
     emitApprovalBypassState({ streamId, kind, bypassActive }) {
       if (closed || context.outputFormat !== 'ndjson') return;
       const record: CliNdjsonRecord = {

--- a/packages/desktop/src/desktopTaskShell.ts
+++ b/packages/desktop/src/desktopTaskShell.ts
@@ -236,7 +236,7 @@ export function openWorkbenchTab(
       : state.workbenchTabs;
   const activeWorkbenchTabIds = { ...state.activeWorkbenchTabIds };
   if (request.kind === 'editor' && request.target) {
-    for (const placement of ['right', 'bottom'] as const) {
+    for (const placement of WORKBENCH_PLACEMENTS) {
       if (activeWorkbenchTabIds[placement] === 'workbench:editor') {
         activeWorkbenchTabIds[placement] = undefined;
       }
@@ -486,6 +486,5 @@ export function workspaceInitials(workspacePath: string | undefined): string {
 
 export function workspaceName(workspacePath: string | undefined): string {
   if (!workspacePath) return 'No project open';
-  const normalized = workspacePath.replaceAll('\\', '/').replace(/\/+$/, '');
-  return normalized.split('/').findLast(Boolean) ?? workspacePath;
+  return basename(workspacePath);
 }

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -36,7 +36,6 @@ import {
 import { LatexConfigPersistenceController } from '@controllers/settingsView/LatexConfigPersistenceController';
 import { LatexToolingController } from '@controllers/settingsView/LatexToolingController';
 import { prepareMainViewExecutionRequest } from '@controllers/mainView/MainViewExecutionController';
-import type { TerminalRunResult } from '@hosts/uiHosts';
 import { texraResponseTextProcessing } from '@latex/texraResponseTextProcessing';
 import { hasUsableSetupCredential } from '@model/setupCredentialAccess';
 import { platform } from '@platform/platform';
@@ -304,15 +303,23 @@ function createWindow(options: {
   const ipcRef: {
     current?: ReturnType<typeof installDesktopMainViewIpc>;
   } = {};
+  // `installDesktopHostBridge.postToRenderer` is itself a no-op when
+  // `webContents.isDestroyed()`. Without checking that here too, callers would
+  // falsely report success and skip their external-viewer fallback. Bot
+  // review (#3816) caught it. Shared by the prompt controller, preview host,
+  // agent-execution wiring, and the pty/browser-view workspace IPC below; the
+  // diff host keeps its own narrower check (no `webContents.isDestroyed()`)
+  // per bot review #3815, so it is not folded in.
+  const postToRendererIfAlive = (message: unknown): boolean => {
+    const ipc = ipcRef.current;
+    if (!ipc || window.isDestroyed() || window.webContents.isDestroyed()) {
+      return false;
+    }
+    ipc.postToRenderer(message);
+    return true;
+  };
   const promptController = new DesktopPromptController({
-    postToRenderer: (message) => {
-      const ipc = ipcRef.current;
-      if (!ipc || window.isDestroyed() || window.webContents.isDestroyed()) {
-        return false;
-      }
-      ipc.postToRenderer(message);
-      return true;
-    },
+    postToRenderer: postToRendererIfAlive,
   });
   const settingsIpcRef: {
     current?: ReturnType<typeof createDesktopSettingsIpc>;
@@ -387,20 +394,6 @@ function createWindow(options: {
       },
     }).catch(reportAsyncError);
   }
-  // `installDesktopHostBridge.postToRenderer` is itself a no-op when
-  // `webContents.isDestroyed()`. Without checking that here too, callers would
-  // falsely report success and skip their external-viewer fallback. Bot
-  // review (#3816) caught it. Shared by the preview host and agent-execution
-  // wiring below; the diff host keeps its own narrower check (no
-  // `webContents.isDestroyed()`) per bot review #3815, so it is not folded in.
-  const postToRendererIfAlive = (message: unknown): boolean => {
-    const ipc = ipcRef.current;
-    if (!ipc || window.isDestroyed() || window.webContents.isDestroyed()) {
-      return false;
-    }
-    ipc.postToRenderer(message);
-    return true;
-  };
   /**
    * Fire-and-forget post for controllers that don't act on delivery. The
    * bridge's own `webContents.isDestroyed()` no-op (see above) is the guard
@@ -1091,20 +1084,16 @@ function createWindow(options: {
   // Interactive terminals and embedded browser tabs. Both stream to the
   // renderer through the IPC bridge installed just below, so they post via
   // `ipcRef.current` rather than capturing a bridge that doesn't exist yet.
-  const postWorkspaceMessage = (message: unknown): void => {
-    if (window.isDestroyed() || window.webContents.isDestroyed()) return;
-    ipcRef.current?.postToRenderer(message);
-  };
   const ptyHost = createDesktopPtyHost({
     cwd: options.workspacePath,
     onData: (sessionId, data) =>
-      postWorkspaceMessage({
+      postToRendererIfAlive({
         command: DESKTOP_WORKSPACE_COMMANDS.TERMINAL_DATA,
         sessionId,
         data,
       }),
     onExit: (sessionId, exitCode) =>
-      postWorkspaceMessage({
+      postToRendererIfAlive({
         command: DESKTOP_WORKSPACE_COMMANDS.TERMINAL_EXIT,
         sessionId,
         exitCode,
@@ -1115,14 +1104,14 @@ function createWindow(options: {
     getWindow: () => (window.isDestroyed() ? undefined : window),
     openExternalUrl: (url) => previewHost.openExternal(url),
     onNavigated: (state) =>
-      postWorkspaceMessage({
+      postToRendererIfAlive({
         command: DESKTOP_WORKSPACE_COMMANDS.BROWSER_STATE,
         ...state,
       }),
     onError: reportAsyncError,
   });
   const workspaceIpc = createDesktopWorkspaceIpc(
-    { postToRenderer: postWorkspaceMessage },
+    { postToRenderer: postToRendererIfAlive },
     {
       ptyHost,
       browserViews,

--- a/packages/desktop/src/renderer/desktopShortcutRegistry.ts
+++ b/packages/desktop/src/renderer/desktopShortcutRegistry.ts
@@ -86,8 +86,11 @@ export function createDesktopShortcutRegistry(
   }
 
   function update(id: string, accelerator: string | undefined): void {
-    if (!availableEntries.some((entry) => entry.id === id)) {
-      if (id !== DESKTOP_COMMAND_PALETTE_ID) return;
+    if (
+      !availableEntries.some((entry) => entry.id === id) &&
+      id !== DESKTOP_COMMAND_PALETTE_ID
+    ) {
+      return;
     }
     overrides = {
       ...overrides,

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -27,7 +27,6 @@ import {
   handleFileAction,
   handleFollowupRequestOptions,
   handleFollowUpChange,
-  handleFollowUpClear,
   handleFollowUpFocusComplete,
   handleFollowUpPolish,
   handleFollowUpSend,
@@ -1694,10 +1693,6 @@ function wireConversation(): void {
     handleFollowUpSend as EventListener,
   );
   conversationView.addEventListener('followup-polish', handleFollowUpPolish);
-  conversationView.addEventListener(
-    'followup-clear',
-    handleFollowUpClear as EventListener,
-  );
   // followup-focus-complete: clear the focus/polish/transcribe trigger flags.
   conversationView.addEventListener(
     'followup-focus-complete',

--- a/packages/extension/src/commands/agent/executeCommand.ts
+++ b/packages/extension/src/commands/agent/executeCommand.ts
@@ -6,7 +6,6 @@ import { z, ZodError } from 'zod';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { ModelHandlerCompatibilityKeySchema } from '@agent/runtime/modelHandlerCompatibilityKey';
 import { runAgent } from '@agent/runtime/runAgent';
-import { defaultSession } from '@agent/runtime/SessionHandle';
 import { openFinalOutputIfAvailable } from '@frontend/agents/finalOutputOpener';
 import * as logger from '@logger/logUtils';
 import type { ExecutionId } from '@shared/schemas';

--- a/packages/extension/src/commands/auth/authCommands.ts
+++ b/packages/extension/src/commands/auth/authCommands.ts
@@ -108,6 +108,12 @@ export async function signIn(): Promise<boolean> {
       return false;
     }
 
+    const showAuthServiceUnavailable = () =>
+      showLoggedMessage(
+        CHANNEL,
+        'The authentication service is temporarily unavailable. Your stored session has not been removed; try again later.',
+      );
+
     let storedSessionState = await SupabaseClient.getStoredSessionState();
     if (storedSessionState === 'invalid') {
       const cleared =
@@ -118,10 +124,7 @@ export async function signIn(): Promise<boolean> {
         : await SupabaseClient.getStoredSessionState();
     }
     if (storedSessionState === 'transient') {
-      void showLoggedMessage(
-        CHANNEL,
-        'The authentication service is temporarily unavailable. Your stored session has not been removed; try again later.',
-      );
+      void showAuthServiceUnavailable();
       return false;
     }
 
@@ -131,10 +134,7 @@ export async function signIn(): Promise<boolean> {
         await showSignedInMessage('Already signed in as', false);
         return true;
       }
-      void showLoggedMessage(
-        CHANNEL,
-        'The authentication service is temporarily unavailable. Your stored session has not been removed; try again later.',
-      );
+      void showAuthServiceUnavailable();
       return false;
     }
 

--- a/packages/extension/src/commands/setup/setupAssistantCommand.ts
+++ b/packages/extension/src/commands/setup/setupAssistantCommand.ts
@@ -252,9 +252,7 @@ export async function launchSetupAssistant(): Promise<SetupAssistantLaunchResult
     // fresh load.
     await loadAgents();
 
-    const launch = async () => {
-      await runAgent({ config }, {});
-    };
+    const launch = () => runAgent({ config }, {});
 
     if (resolution.requiresOpenRouter) {
       await withOpenRouterFlagOn(launch);

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -240,8 +240,7 @@ export async function activate(context: vscode.ExtensionContext) {
     lifecycle,
     agentDirectories,
     agentResume: {
-      tryResumeStream: (streamId, recovery) =>
-        tryResumeFromResumeData(streamId, recovery),
+      tryResumeStream: tryResumeFromResumeData,
     },
     toolAvailability: {
       ...NO_TOOL_AVAILABILITY_HOST,

--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -12,7 +12,7 @@ import { BaseWebviewApp } from '@shared/BaseWebviewApp';
 import { postMessage } from '@shared/hostBridge';
 
 // Local imports - shared schemas
-import { type ProgressViewOutboundMessage } from '@shared/schemas';
+import type { ProgressViewOutboundMessage } from '@shared/schemas';
 import { SignalWatcher } from '@shared/signals';
 import { designTokens, viewTabStyles } from '@shared/styles';
 import { registerTeXRAWebAwesomeIcons } from '@shared/wa/webAwesomeIcons';

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -7,8 +7,6 @@ import { classMap } from 'lit/directives/class-map.js';
 import { guard } from 'lit/directives/guard.js';
 import { repeat } from 'lit/directives/repeat.js';
 
-// Local imports - stream state
-
 // Local imports - shared schemas
 import {
   MESSAGE_TYPES,

--- a/packages/extension/src/progressView/frontend/eventHandlers.ts
+++ b/packages/extension/src/progressView/frontend/eventHandlers.ts
@@ -19,7 +19,6 @@ import { clearInquiryDraft } from './components/ExternalInquiryPanel';
 import {
   APPROVE_SESSION_ACTION,
   APPROVE_ALL_DELEGATED_WORK_ACTION,
-  type FollowUpClearDetail,
   type FollowupCommandDetail,
   type FollowUpChangeDetail,
   type FollowUpSendDetail,
@@ -159,18 +158,6 @@ export function handleFollowUpPolish(): void {
     stream: result.streamId,
     text: result.text,
   });
-}
-
-export function handleFollowUpClear(
-  event: CustomEvent<FollowUpClearDetail>,
-): void {
-  const streamId = event.detail.streamId;
-  if (!appState.get().streamStates.has(streamId)) return;
-  updateToolUseState(streamId, (prev) =>
-    create(prev, (draft) => {
-      draft.ui.followUpText = '';
-    }),
-  );
 }
 
 /**

--- a/packages/extension/src/progressView/frontend/events.ts
+++ b/packages/extension/src/progressView/frontend/events.ts
@@ -37,10 +37,6 @@ export interface FollowUpSendDetail {
   readonly images: readonly ExtractedClipboardImage[];
 }
 
-export interface FollowUpClearDetail {
-  readonly streamId: string;
-}
-
 export interface FollowupCommandDetail {
   agent: string;
   model: string;
@@ -193,9 +189,6 @@ export const ProgressEvents = {
 
   followupSend: (detail: FollowUpSendDetail) =>
     createEvent('followup-send', detail),
-
-  followupClear: (detail: FollowUpClearDetail) =>
-    createEvent('followup-clear', detail),
 
   followupPolish: () => createEvent('followup-polish', undefined),
 

--- a/packages/extension/src/progressView/frontend/formatters/index.ts
+++ b/packages/extension/src/progressView/frontend/formatters/index.ts
@@ -69,18 +69,23 @@ function formatRenderError(label: string, errorMsg: string): TemplateResult {
   return html`<div class="log-line log-line--render-error"><span class="render-error-icon">${waIcon('triangle-exclamation')}</span><span class="render-error-text">Failed to render ${label}: ${errorMsg}</span></div>`;
 }
 
-/** Wrap a formatter function with error handling for graceful degradation. */
+/**
+ * Wrap a formatter function with error handling for graceful degradation.
+ * `label` may be a fixed string or a function deriving the label from the
+ * message (e.g. naming the tool in a tool-use error card).
+ */
 function wrapWithErrorHandling(
   fn: (
     m: LogMessageData,
     opts?: FormatOptions & { isRunning?: boolean },
   ) => FormatResult,
-  label: string,
+  label: string | ((message: LogMessageData) => string),
 ): TemplateFormatterFn {
   return (message, options) => {
-    const result = safeFormat(() => fn(message, options), label);
+    const resolvedLabel = typeof label === 'function' ? label(message) : label;
+    const result = safeFormat(() => fn(message, options), resolvedLabel);
     if (!result.ok) {
-      return formatRenderError(label, result.error);
+      return formatRenderError(resolvedLabel, result.error);
     }
     return result.value;
   };
@@ -111,17 +116,7 @@ const TEMPLATE_FORMATTERS: Record<string, TemplateFormatterFn | null> = {
   scratchpad: wrapWithErrorHandling(formatBannerContentTemplate, 'scratchpad'),
 
   // Tool/search/fetch results
-  toolUse: (message, options) => {
-    const label = getToolUseRenderLabel(message);
-    const result = safeFormat(
-      () => formatToolUseTemplate(message, options),
-      label,
-    );
-    if (!result.ok) {
-      return formatRenderError(label, result.error);
-    }
-    return result.value;
-  },
+  toolUse: wrapWithErrorHandling(formatToolUseTemplate, getToolUseRenderLabel),
   webSearch: wrapWithErrorHandling(formatWebSearchTemplate, 'web search'),
   webFetch: wrapWithErrorHandling(formatWebFetchTemplate, 'web fetch'),
 

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/workflowCallFormatter.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/workflowCallFormatter.ts
@@ -54,6 +54,7 @@ export function formatWorkflowCallTemplate(
 ): TemplateResult {
   const call = WorkflowCallProgressSchema.parse(message.data);
   const detail = workflowCallDetail(call);
+  const hasChildStream = call.childStreamId !== undefined;
   const openChildStream = (event: Event): void => {
     if (call.childStreamId === undefined) return;
     event.currentTarget?.dispatchEvent(
@@ -69,14 +70,14 @@ export function formatWorkflowCallTemplate(
   return html`
     <div
       class=${`workflow-task workflow-task--${call.status}${
-        call.childStreamId === undefined ? '' : ' workflow-task--linked'
+        hasChildStream ? ' workflow-task--linked' : ''
       }`}
       data-log-id=${message.id}
       data-group-id=${message.groupId ?? ''}
-      role=${call.childStreamId === undefined ? nothing : 'button'}
-      tabindex=${call.childStreamId === undefined ? nothing : '0'}
-      @click=${call.childStreamId === undefined ? nothing : openChildStream}
-      @keydown=${call.childStreamId === undefined ? nothing : handleKeydown}
+      role=${hasChildStream ? 'button' : nothing}
+      tabindex=${hasChildStream ? '0' : nothing}
+      @click=${hasChildStream ? openChildStream : nothing}
+      @keydown=${hasChildStream ? handleKeydown : nothing}
     >
       <span class="workflow-task-icon">${statusIcon(call)}</span>
       <span class="workflow-task-body">

--- a/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
@@ -114,6 +114,21 @@ function updateStreamInfo(
   });
 }
 
+/**
+ * Resolve the next active stream id for an incoming `activeStream` value:
+ * an explicit empty string means "no selection", a known stream id is kept
+ * as-is, and anything else (unset or no-longer-present) falls back to the
+ * first available stream.
+ */
+function resolveActiveStreamId(
+  activeStream: StreamTabId | '',
+  streamById: Map<StreamTabId, StreamTabInfo>,
+): StreamTabId | null {
+  if (activeStream === '') return null;
+  if (activeStream && streamById.has(activeStream)) return activeStream;
+  return firstStreamId(streamById);
+}
+
 // ============================================================
 // Handlers
 // ============================================================
@@ -138,14 +153,10 @@ export const streamLifecycleHandlers = {
     // when the current filter excludes every stream. Since the backend now
     // emits all streams unfiltered, falling back to firstStreamId would
     // re-pick a filtered-out tab and render hidden-category content.
-    let nextActiveStreamId: StreamTabId | null;
-    if (data.activeStream === '') {
-      nextActiveStreamId = null;
-    } else if (data.activeStream && updated.streamById.has(data.activeStream)) {
-      nextActiveStreamId = data.activeStream;
-    } else {
-      nextActiveStreamId = firstStreamId(updated.streamById);
-    }
+    const nextActiveStreamId = resolveActiveStreamId(
+      data.activeStream,
+      updated.streamById,
+    );
 
     appState.set(
       create(updated, (draft) => {
@@ -156,14 +167,10 @@ export const streamLifecycleHandlers = {
 
   [PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM]: (data) => {
     const prev = appState.get();
-    let nextActiveStreamId: StreamTabId | null;
-    if (data.activeStream === '') {
-      nextActiveStreamId = null;
-    } else if (data.activeStream && prev.streamById.has(data.activeStream)) {
-      nextActiveStreamId = data.activeStream;
-    } else {
-      nextActiveStreamId = firstStreamId(prev.streamById);
-    }
+    const nextActiveStreamId = resolveActiveStreamId(
+      data.activeStream,
+      prev.streamById,
+    );
     if (nextActiveStreamId === prev.activeStreamId) return;
     appState.set(
       create(prev, (draft) => {

--- a/packages/extension/src/settingsView/frontend/tabs/GoalTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/GoalTab.ts
@@ -134,7 +134,7 @@ export class GoalTab extends LitElement {
     ];
     return html`
       <div
-        class=${'goal-row' + (inFlight ? ' is-clickable' : '')}
+        class=${`goal-row${inFlight ? ' is-clickable' : ''}`}
         @click=${inFlight ? () => this.handleReveal(item.streamId) : null}
         @keydown=${
           inFlight

--- a/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -444,9 +444,10 @@ export class ToolsTab extends LitElement {
         })}
         ${this.renderAgentSkillsSettings()} ${this.renderApprovalSettings()}
         ${this.renderDesktopCrashReporting()}
-        ${CATEGORY_ORDER.filter((cat) => groups.has(cat)).map((cat) =>
-          this.renderCategory(cat, groups.get(cat)!),
-        )}
+        ${CATEGORY_ORDER.flatMap((cat) => {
+          const catItems = groups.get(cat);
+          return catItems ? [this.renderCategory(cat, catItems)] : [];
+        })}
       </div>
     `;
   }

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -112,7 +112,7 @@ import {
   scheduleInstructionSave,
 } from './persistence';
 import { mainViewMessageHandlers } from './messageDispatcher';
-import { FILE_SELECT_CONFIGS } from './store';
+import { FILE_SELECT_CONFIGS, FILE_TYPE_TO_KEY } from './store';
 import { mainViewStyles } from './styles';
 
 registerTeXRAWebAwesomeIcons();
@@ -376,12 +376,10 @@ export class MainApp extends MainAppBase {
     const sf = singleFiles$.get();
     const fo = fileOptions$.get();
     const files = multiFiles$.get();
-    const visibleFileCount = visibleFileConfigs.reduce((count, config) => {
-      if (config.type === 'input') return count + files.inputFiles.length;
-      if (config.type === 'context') return count + files.contextFiles.length;
-      if (config.type === 'media') return count + files.mediaFiles.length;
-      return count + files.outputFiles.length;
-    }, 0);
+    const visibleFileCount = visibleFileConfigs.reduce(
+      (count, config) => count + files[FILE_TYPE_TO_KEY[config.type]].length,
+      0,
+    );
 
     const setupCard =
       onboardingState === 'setup'

--- a/packages/extension/src/webview/frontend/slices/catalogSlice.ts
+++ b/packages/extension/src/webview/frontend/slices/catalogSlice.ts
@@ -41,17 +41,16 @@ function validateAgentSelection(
   currentValue: string,
   preferredFallback: readonly string[] = [],
 ): string {
-  if (options.some((opt) => opt.value === currentValue)) {
-    return currentValue;
-  }
-  // Match by name: handles source changes, plain-name defaults, and remote
-  // rows whose value still carries legacy decorated storage names.
-  const name = agentName(currentValue);
-  const byName = options.find((opt) => agentName(opt.value) === name);
-  if (byName) return byName.value;
+  // Exact match, then match by name: handles source changes, plain-name
+  // defaults, and remote rows whose value still carries legacy decorated
+  // storage names.
+  const match = findAgentSelection(options, currentValue);
+  if (match) return match;
   for (const preferred of preferredFallback) {
-    const match = options.find((opt) => agentName(opt.value) === preferred);
-    if (match) return match.value;
+    const fallbackMatch = options.find(
+      (opt) => agentName(opt.value) === preferred,
+    );
+    if (fallbackMatch) return fallbackMatch.value;
   }
   // No match — keep stale value so the UI shows no selection.
   // Execution will error with "unknown agent" if the user proceeds.

--- a/src/agent/followUp/FollowUpQueue.ts
+++ b/src/agent/followUp/FollowUpQueue.ts
@@ -103,8 +103,9 @@ export class FollowUpQueue {
   waitForNext(
     checkInterruption: () => boolean,
   ): Promise<FollowUpQueueItem | null> {
-    if (this.queued.length > 0) {
-      return Promise.resolve(this.queued.shift()!);
+    const next = this.queued.shift();
+    if (next) {
+      return Promise.resolve(next);
     }
     if (checkInterruption()) {
       return Promise.resolve(null);

--- a/src/agent/followUp/ToolUseFollowUp.ts
+++ b/src/agent/followUp/ToolUseFollowUp.ts
@@ -156,6 +156,7 @@ export async function submitFollowUp(
     return { status: 'no_session', streamStatus: target.streamStatus };
   }
 
+  const reason = target.kind === 'queue' ? target.reason : 'children_running';
   let admission: 'live_owner' | 'recoverable' | 'existing_recoverable' =
     'recoverable';
   if (options.mode === 'live_notification') {
@@ -166,11 +167,7 @@ export async function submitFollowUp(
   const submission = ownerSession.followUps.submit(streamId, item, admission);
   if (submission.kind === 'unavailable') return { status: 'dropped' };
   if (submission.kind === 'queued') {
-    return {
-      status: 'queued',
-      reason: target.kind === 'queue' ? target.reason : 'children_running',
-      continuation: 'live',
-    };
+    return { status: 'queued', reason, continuation: 'live' };
   }
   if (submission.kind === 'not_owned') return { status: 'dropped' };
   if (
@@ -180,7 +177,7 @@ export async function submitFollowUp(
   ) {
     return {
       status: 'queued',
-      reason: target.kind === 'queue' ? target.reason : 'children_running',
+      reason,
       continuation: submission.kind === 'live_flow' ? 'live' : submission.kind,
     };
   }
@@ -194,7 +191,7 @@ export async function submitFollowUp(
   if (!resumed) ownerSession.followUps.release(recovery, 'recoverable');
   return {
     status: 'queued',
-    reason: target.kind === 'queue' ? target.reason : 'children_running',
+    reason,
     continuation: resumed ? 'resumed' : 'resume_failed',
   };
 }

--- a/src/agent/followUp/ToolUseFollowUpQueueManager.ts
+++ b/src/agent/followUp/ToolUseFollowUpQueueManager.ts
@@ -208,15 +208,7 @@ export class ToolUseFollowUpQueue {
     this.entries.delete(lease.streamId);
     this.terminal.set(lease.streamId, true);
     logger.debug(`Terminalized follow-up queue for stream ${lease.streamId}.`);
-    for (const observer of this.releaseObservers) {
-      try {
-        observer(lease.streamId);
-      } catch (err) {
-        logger.warn(`Release observer threw for stream ${lease.streamId}`, {
-          data: err,
-        });
-      }
-    }
+    this.notifyReleaseObservers(lease.streamId);
     return true;
   }
 
@@ -226,6 +218,11 @@ export class ToolUseFollowUpQueue {
     entry?.queue.dispose();
     this.entries.delete(streamId);
     this.terminal.set(streamId, true);
+    this.notifyReleaseObservers(streamId);
+    return true;
+  }
+
+  private notifyReleaseObservers(streamId: StreamTabId): void {
     for (const observer of this.releaseObservers) {
       try {
         observer(streamId);
@@ -235,7 +232,6 @@ export class ToolUseFollowUpQueue {
         });
       }
     }
-    return true;
   }
 
   /** Presentation-only snapshot; does not grant consumption rights. */

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -1464,10 +1464,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     const toolUseBlocks = responseObject.content.filter(isBetaToolUseBlock);
 
-    if (toolUseBlocks.length === 0) {
-      return [];
-    }
-
     return toolUseBlocks
       .filter((b) => b.id && b.name)
       .map(

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -836,23 +836,23 @@ export class ModelHandlerGoogleGenAI extends GoogleModelHandlerBase<
     const parts = responseObject?.candidates?.[0]?.content?.parts;
     if (!Array.isArray(parts)) return [];
 
-    const results: GoogleToolCall[] = [];
-    for (const part of parts) {
+    return parts.flatMap((part): GoogleToolCall[] => {
       const call = part.functionCall;
-      if (!call?.name) continue;
-      results.push({
-        provider: 'google',
-        callId: call.id ?? generateShortId(),
-        name: call.name,
-        input: call.args,
-        raw: call,
-        thoughtSignature:
-          typeof part.thoughtSignature === 'string'
-            ? part.thoughtSignature
-            : undefined,
-      });
-    }
-    return results;
+      if (!call?.name) return [];
+      return [
+        {
+          provider: 'google',
+          callId: call.id ?? generateShortId(),
+          name: call.name,
+          input: call.args,
+          raw: call,
+          thoughtSignature:
+            typeof part.thoughtSignature === 'string'
+              ? part.thoughtSignature
+              : undefined,
+        },
+      ];
+    });
   }
 
   /**

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -1011,10 +1011,9 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
 
   extractToolUse(responseObject: GoogleGenAIInteraction): GoogleToolCall[] {
     const steps = responseObject?.steps ?? [];
-    const results: GoogleToolCall[] = [];
-    for (const step of steps) {
-      if (step.type !== 'function_call') continue;
-      results.push({
+    return steps
+      .filter((s): s is FunctionCallStep => s.type === 'function_call')
+      .map((step): GoogleToolCall => ({
         provider: 'google',
         callId: step.id ?? generateShortId(),
         name: step.name,
@@ -1022,9 +1021,7 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
         // GoogleToolCall.raw is a chat `FunctionCall`; reconstruct the shape the
         // downstream code reads (name/args/id) from the Interactions step.
         raw: { id: step.id, name: step.name, args: step.arguments },
-      });
-    }
-    return results;
+      }));
   }
 
   // ===========================================================================

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -1688,11 +1688,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           )
         : await this.compactConversationClientSide(client, messages, signal);
       // compactionResult is set if compaction succeeded
-      compactedThisCall = this.compactionResult !== undefined;
-      if (compactedThisCall) {
+      const { compactionResult } = this;
+      compactedThisCall = compactionResult !== undefined;
+      if (compactionResult) {
         // Note: the chain anchor is already cleared inside compactConversation()
         // immediately after the compact endpoint succeeds (before token counting).
-        compactedMessages = this.compactionResult!.compactedMessages;
+        compactedMessages = compactionResult.compactedMessages;
       }
     }
 

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -312,13 +312,7 @@ export class SessionHandle {
         ) {
           return false;
         }
-        for (const streamId of this.transcripts.getUnfinishedStreamIds()) {
-          this.status.transition(
-            streamId,
-            STREAM_PHASE.RUNNING,
-            STREAM_TRANSITION_CAUSE.LIFECYCLE,
-          );
-        }
+        this.markUnfinishedStreamsRunning();
         await this.runRestartRepair(generation);
         return true;
       };
@@ -360,13 +354,7 @@ export class SessionHandle {
       this.status.clearAll();
       const streamIds = this.transcripts.keys();
       await this.snapshots.load(streamIds);
-      for (const streamId of this.transcripts.getUnfinishedStreamIds()) {
-        this.status.transition(
-          streamId,
-          STREAM_PHASE.RUNNING,
-          STREAM_TRANSITION_CAUSE.LIFECYCLE,
-        );
-      }
+      this.markUnfinishedStreamsRunning();
       await this.runRestartRepair(generation);
       storage.finalizeWorkspaceStorageChange?.();
       return true;
@@ -429,6 +417,17 @@ export class SessionHandle {
       );
     }
     throw replacementError;
+  }
+
+  /** Transition every transcript-unfinished stream to RUNNING ahead of restart repair. */
+  private markUnfinishedStreamsRunning(): void {
+    for (const streamId of this.transcripts.getUnfinishedStreamIds()) {
+      this.status.transition(
+        streamId,
+        STREAM_PHASE.RUNNING,
+        STREAM_TRANSITION_CAUSE.LIFECYCLE,
+      );
+    }
   }
 
   private async runRestartRepair(generation: number): Promise<void> {

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -561,7 +561,7 @@ export async function resumeToolUseFromResumeData(
 
           await runSession.transcripts.ensureLoaded(runStreamId);
 
-          const result = await runFlowWithLifecycle(
+          return await runFlowWithLifecycle(
             ctx,
             async (handle, lifecycle) => {
               const result = await runToolUseFlow(
@@ -612,7 +612,6 @@ export async function resumeToolUseFromResumeData(
               onRun: options.onRun,
             },
           );
-          return result;
         },
       );
       if (!isWaitingFlowResult(result)) {

--- a/src/agent/storage/SessionStores.ts
+++ b/src/agent/storage/SessionStores.ts
@@ -277,12 +277,10 @@ export class SessionStores {
     const streamIds = unique([...snapshotStreams, ...canonicalStreams]);
     const executionIdsByStream = new Map(this.snapshots.getExecutionIdMap());
     for (const stream of snapshotStreams) {
-      const executionId = await this.snapshots.readPersistedExecutionId(stream);
+      const executionId =
+        (await this.snapshots.readPersistedExecutionId(stream)) ??
+        executionIdFromStream(stream);
       if (executionId) executionIdsByStream.set(stream, executionId);
-      else {
-        const derived = executionIdFromStream(stream);
-        if (derived) executionIdsByStream.set(stream, derived);
-      }
     }
     for (const stream of streamIds) {
       if (executionIdsByStream.has(stream)) continue;

--- a/src/controllers/progressView/ProgressViewCommandHandlers.ts
+++ b/src/controllers/progressView/ProgressViewCommandHandlers.ts
@@ -387,6 +387,26 @@ export function createProgressViewSecondTierHandlers(
 ) {
   const CMD = PROGRESS_VIEW_COMMANDS;
 
+  const planFollowUp = async (
+    data: {
+      stream: StreamTabId;
+      agent: string;
+      model: string;
+      initialQuestion?: string;
+    },
+    executeImmediately: boolean,
+  ): Promise<void> => {
+    await deps.applyFollowUpPlan(
+      await deps.followUp.planToolUseFollowUpForStream({
+        streamId: data.stream,
+        agent: data.agent,
+        model: data.model,
+        initialQuestion: data.initialQuestion,
+        executeImmediately,
+      }),
+    );
+  };
+
   return {
     // ── Workflow toolbar (diff / pack / clean) ──
     [CMD.DIFF_STREAM]: (data) => deps.workflowActions.diffStream(data.stream),
@@ -495,28 +515,8 @@ export function createProgressViewSecondTierHandlers(
     },
 
     // ── Follow-up tasks ──
-    [CMD.SETUP_FOLLOWUP]: async (data) => {
-      await deps.applyFollowUpPlan(
-        await deps.followUp.planToolUseFollowUpForStream({
-          streamId: data.stream,
-          agent: data.agent,
-          model: data.model,
-          initialQuestion: data.initialQuestion,
-          executeImmediately: false,
-        }),
-      );
-    },
-    [CMD.RUN_FOLLOWUP]: async (data) => {
-      await deps.applyFollowUpPlan(
-        await deps.followUp.planToolUseFollowUpForStream({
-          streamId: data.stream,
-          agent: data.agent,
-          model: data.model,
-          initialQuestion: data.initialQuestion,
-          executeImmediately: true,
-        }),
-      );
-    },
+    [CMD.SETUP_FOLLOWUP]: (data) => planFollowUp(data, false),
+    [CMD.RUN_FOLLOWUP]: (data) => planFollowUp(data, true),
     [CMD.GET_FOLLOWUP_OPTIONS]: async (data) => {
       const { toolUseAgentsData, modelOptionsData } =
         await deps.loadFollowUpOptions();

--- a/src/controllers/progressView/backend/ProgressBackend.ts
+++ b/src/controllers/progressView/backend/ProgressBackend.ts
@@ -186,13 +186,17 @@ export class ProgressBackend {
     if (retained) await this.notifyDeletionRetained(retained);
   }
 
+  /** Whether local durable state exists for `stream` (log or task snapshot). */
+  private hasDeletableStreamData(stream: StreamTabId): boolean {
+    return (
+      this.state.streamLogs.has(stream) ||
+      Boolean(this.state.snapshots.getTaskState(stream))
+    );
+  }
+
   private async prepareStreamDeletion(stream: StreamTabId): Promise<void> {
     if (!canUseStreamDataDir(stream)) return;
-
-    const hasStream =
-      this.state.streamLogs.has(stream) ||
-      Boolean(this.state.snapshots.getTaskState(stream));
-    if (!hasStream) return;
+    if (!this.hasDeletableStreamData(stream)) return;
 
     const ownedLocally =
       this.session.executions.getAgentHandleByStream(stream) !== undefined;
@@ -212,10 +216,7 @@ export class ProgressBackend {
   ): Promise<'active' | 'failed' | undefined> {
     if (!canUseStreamDataDir(stream)) return undefined;
 
-    const hasStream =
-      this.state.streamLogs.has(stream) ||
-      Boolean(this.state.snapshots.getTaskState(stream));
-    if (!hasStream) {
+    if (!this.hasDeletableStreamData(stream)) {
       const deletion = await this.state.clearStream(stream);
       return deletion === 'deleted' ? undefined : deletion;
     }

--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -108,7 +108,10 @@ export class ProgressFactApplier {
       () => this.flushProgressUpdates(),
       PROGRESS_THROTTLE_MS,
     );
-  private pendingProgressUpdates = new Map<StreamTabId, ConversationProgress>();
+  private readonly pendingProgressUpdates = new Map<
+    StreamTabId,
+    ConversationProgress
+  >();
 
   /**
    * Run-fact dispatch table (see `RUN_FACT_EVENT_TYPES`); keys stay exhaustive.
@@ -177,9 +180,9 @@ export class ProgressFactApplier {
   };
 
   constructor(
-    private state: ProgressViewState,
-    private webviewUpdater: WebviewUpdater,
-    private webviewBridge: WebviewBridge,
+    private readonly state: ProgressViewState,
+    private readonly webviewUpdater: WebviewUpdater,
+    private readonly webviewBridge: WebviewBridge,
     private readonly hasPendingPermissions: (streamId: string) => boolean,
     private readonly deleteStream: (
       stream: StreamTabId,

--- a/src/controllers/progressView/backend/state/ProgressViewState.ts
+++ b/src/controllers/progressView/backend/state/ProgressViewState.ts
@@ -154,11 +154,11 @@ export class ProgressViewState {
   readonly stores: SessionStores;
 
   // -- Preferences ------------------------------------------------------------
-  private _prefs!: PersistedState<ProgressViewPrefs>;
+  private readonly _prefs: PersistedState<ProgressViewPrefs>;
 
   // -- Ephemeral state (session-only, not persisted) --------------------------
-  private _streamStates = new Map<StreamTabId, StreamExecutionState>();
-  private _sessionState = new Map<StreamTabId, StreamSessionState>();
+  private readonly _streamStates = new Map<StreamTabId, StreamExecutionState>();
+  private readonly _sessionState = new Map<StreamTabId, StreamSessionState>();
 
   readonly streamStatus: StreamStatusMachine;
   readonly followUps: ToolUseFollowUpQueue;
@@ -498,7 +498,7 @@ export class ProgressViewState {
       ...this.streamLogs.keys(),
       ...this._sessionState.keys(),
       ...this._streamStates.keys(),
-      ...[...this.streamStatus.entries()].map(([stream]) => stream),
+      ...Array.from(this.streamStatus.entries(), ([stream]) => stream),
     ]);
     const deletion = await this.stores.deleteAll();
     const retainedStreams = new Set([...deletion.active, ...deletion.failed]);

--- a/src/housekeeping/packLatexdiffvc.ts
+++ b/src/housekeeping/packLatexdiffvc.ts
@@ -68,10 +68,8 @@ export async function runPackLatexdiffvc(
   }
 
   if (clean) {
-    for (const files of [mainFiles, tempFiles]) {
-      for (const file of files) {
-        await WorkspaceFS.delete(file);
-      }
+    for (const file of [...mainFiles, ...tempFiles]) {
+      await WorkspaceFS.delete(file);
     }
     logger.info(CHANNEL, 'Cleanup complete.');
     return { status: 'cleaned', inputFile };

--- a/src/latex/latexToolchain.ts
+++ b/src/latex/latexToolchain.ts
@@ -55,15 +55,14 @@ const REQUIRED_TOOLS = new Set<LatexToolName>(['latexmk']);
 /** Probe the LaTeX tools used by both the extension and CLI surfaces. */
 export async function probeLatexToolchain(): Promise<LatexToolchainProbe> {
   const toolNames = Object.keys(TOOL_PURPOSES) as LatexToolName[];
-  const installed = await Promise.all(
-    toolNames.map((tool) => checkToolInstalled(tool, false)),
+  const tools = await Promise.all(
+    toolNames.map(async (name): Promise<LatexToolStatus> => ({
+      name,
+      installed: await checkToolInstalled(name, false),
+      required: REQUIRED_TOOLS.has(name),
+      purpose: TOOL_PURPOSES[name],
+    })),
   );
-  const tools = toolNames.map((name, index): LatexToolStatus => ({
-    name,
-    installed: installed[index] ?? false,
-    required: REQUIRED_TOOLS.has(name),
-    purpose: TOOL_PURPOSES[name],
-  }));
   return {
     tools,
     hasCompiler: tools.some(

--- a/src/shared/commands/shortcutPreferences.ts
+++ b/src/shared/commands/shortcutPreferences.ts
@@ -73,8 +73,7 @@ export function keyboardEventToAccelerator(
 
   const parts: string[] = [];
   if (platform === 'darwin' && event.metaKey) parts.push('Command');
-  if (platform !== 'darwin' && event.ctrlKey) parts.push('Control');
-  if (platform === 'darwin' && event.ctrlKey) parts.push('Control');
+  if (event.ctrlKey) parts.push('Control');
   if (event.altKey) parts.push(platform === 'darwin' ? 'Option' : 'Alt');
   if (event.shiftKey) parts.push('Shift');
   if (platform !== 'darwin' && event.metaKey) parts.push('Super');
@@ -82,24 +81,25 @@ export function keyboardEventToAccelerator(
   return [...parts, key].join('+');
 }
 
+const SUPPORTED_NAMED_KEYS: Record<string, string> = {
+  ArrowDown: 'Down',
+  ArrowLeft: 'Left',
+  ArrowRight: 'Right',
+  ArrowUp: 'Up',
+  Backspace: 'Backspace',
+  Delete: 'Delete',
+  End: 'End',
+  Enter: 'Enter',
+  Escape: 'Escape',
+  Home: 'Home',
+  PageDown: 'PageDown',
+  PageUp: 'PageUp',
+  Tab: 'Tab',
+};
+
 function normalizeKeyboardKey(key: string): string | undefined {
   if (key === ' ') return 'Space';
   if (key.length === 1) return key.toUpperCase();
   if (/^F\d{1,2}$/i.test(key)) return key.toUpperCase();
-  const supported: Record<string, string> = {
-    ArrowDown: 'Down',
-    ArrowLeft: 'Left',
-    ArrowRight: 'Right',
-    ArrowUp: 'Up',
-    Backspace: 'Backspace',
-    Delete: 'Delete',
-    End: 'End',
-    Enter: 'Enter',
-    Escape: 'Escape',
-    Home: 'Home',
-    PageDown: 'PageDown',
-    PageUp: 'PageUp',
-    Tab: 'Tab',
-  };
-  return supported[key];
+  return SUPPORTED_NAMED_KEYS[key];
 }

--- a/src/shared/monaco/monacoLoader.ts
+++ b/src/shared/monaco/monacoLoader.ts
@@ -245,13 +245,11 @@ export function monacoLanguageForPath(filePath: string): string {
     case 'ts':
     case 'mts':
     case 'cts':
-      return 'typescript';
     case 'tsx':
       return 'typescript';
     case 'js':
     case 'mjs':
     case 'cjs':
-      return 'javascript';
     case 'jsx':
       return 'javascript';
     case 'json':

--- a/src/shared/schemas/mainView/state.ts
+++ b/src/shared/schemas/mainView/state.ts
@@ -115,7 +115,7 @@ export type WorkspaceRootOptionData = z.infer<
 export const TeamOptionDataSchema = PickerOptionBaseSchema.extend({
   /** Provenance uses the shared `'built-in' | 'custom'` team vocabulary. */
   source: z.enum(['built-in', 'custom']),
-  /** Web Awesome icon name registered in `src/shared/wa/webAwesomeIcons.ts`. */
+  /** Web Awesome icon name registered in `src/shared/wa/iconNames.ts`. */
   icon: z.string(),
   /** Preset description, surfaced as the option `title`. */
   description: z.string().prefault(''),

--- a/src/shared/subagentFollowup.ts
+++ b/src/shared/subagentFollowup.ts
@@ -174,10 +174,6 @@ function progressDetail(xml: string): string {
   }
 }
 
-function resultResponsePreview(response: string): string {
-  return decodedResultResponsePreview(decodeXmlEntities(response));
-}
-
 function decodedResultResponsePreview(response: string): string {
   const decoded = response.trim();
   if (decoded === '') return '';
@@ -259,30 +255,32 @@ export function summarizeSubagentFollowup(text: unknown): string {
     return `⟳ ${agent} · ${progressDetail(trimmed)}`;
   }
 
+  if (
+    tag === DELIVERY_TAG.workflowScriptResult ||
+    tag === DELIVERY_TAG.workflowScriptError
+  ) {
+    const summary = workflowScriptDeliverySummary(trimmed);
+    if (summary) return summary;
+  }
+
   // Result/error envelopes share one shape across families
   // (formatChildRunDelivery/formatChildRunError): subagent-*, background-*,
   // codex-*, claude-agent-*. Agent-CLI producers (codex.ts, claudeAgent.ts)
   // don't set an `agent` attribute, so fall back to the tag's own family name
   // (e.g. `codex-result` → `codex`) rather than the generic `subagent`.
   if (tag.endsWith('-result')) {
-    if (tag === DELIVERY_TAG.workflowScriptResult) {
-      const summary = workflowScriptDeliverySummary(trimmed);
-      if (summary) return summary;
-    }
     const agent = attr(trimmed, 'agent') ?? tag.slice(0, -'-result'.length);
     const status = attr(trimmed, 'status') ?? 'completed';
     const wall = innerTag(trimmed, 'wall-time');
     const response = innerTag(trimmed, 'response');
     const head = `✓ ${agent} ${status}${wall ? ` · ${wall}` : ''}`;
-    const preview = response ? resultResponsePreview(response) : '';
+    const preview = response
+      ? decodedResultResponsePreview(decodeXmlEntities(response))
+      : '';
     return preview ? `${head}\n${preview}` : head;
   }
 
   if (tag.endsWith('-error')) {
-    if (tag === DELIVERY_TAG.workflowScriptError) {
-      const summary = workflowScriptDeliverySummary(trimmed);
-      if (summary) return summary;
-    }
     const agent = attr(trimmed, 'agent') ?? tag.slice(0, -'-error'.length);
     const wall = innerTag(trimmed, 'wall-time');
     const message = innerTag(trimmed, 'message');

--- a/src/shared/wa/emptyState.ts
+++ b/src/shared/wa/emptyState.ts
@@ -63,7 +63,7 @@ export function renderEmptyState({
   kicker,
   kickerIcon,
 }: EmptyStateOptions): TemplateResult {
-  const tag = HEADING_TAGS[headingTag] ?? HEADING_TAGS.h2;
+  const tag = HEADING_TAGS[headingTag];
   // staticHtml + literal lets the heading element stay parameterizable
   // (semantic outline) while keeping interpolated children type-checked.
   return staticHtml`

--- a/src/shared/wa/iconNames.ts
+++ b/src/shared/wa/iconNames.ts
@@ -143,6 +143,4 @@ export const TEXRA_ICON_CANONICAL_NAMES = [
   'xmark',
 ] as const;
 
-type TeXRACanonicalIconName = (typeof TEXRA_ICON_CANONICAL_NAMES)[number];
-
-export type TeXRAIconName = TeXRACanonicalIconName;
+export type TeXRAIconName = (typeof TEXRA_ICON_CANONICAL_NAMES)[number];

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -142,7 +142,7 @@ export async function resumeOrLaunchAgentCliSession(
 
     const stored = await store.waitForActive(id);
     if (!stored) continue;
-    return await queueAgentCliFollowUp(stored, {
+    return queueAgentCliFollowUp(stored, {
       id,
       prompt: params.prompt,
       callerStreamId: params.callerStreamId,
@@ -189,7 +189,7 @@ export async function launchAgentCliSession(
   }
   const runWithOwnership = captureOwnedExecutionLease(executionId);
 
-  return await runWithOwnership(async () => {
+  return runWithOwnership(async () => {
     let childStream: ChildStream | undefined;
     try {
       childStream = createChildStream(executionId, params.parentStreamId, {

--- a/src/tools/github/StreamSubscriptionRegistry.ts
+++ b/src/tools/github/StreamSubscriptionRegistry.ts
@@ -59,7 +59,7 @@ interface BoundSubscription {
   /**
    * Session captured at bind() time (inside the run's AsyncLocalStorage).
    * onEvent fires later from a detached polling timer where the ALS is empty, so
-   * it must pass this session to sendFollowUp explicitly — otherwise sendFollowUp
+   * it must pass this session to submitFollowUp explicitly — otherwise submitFollowUp
    * falls back to defaultSession() and the follow-up is misrouted/dropped on a
    * non-default session (for example, the desktop process session). Mirrors
    * ExecutionSubscriptionBinder.

--- a/src/tools/userQuestion/UserQuestionTool.ts
+++ b/src/tools/userQuestion/UserQuestionTool.ts
@@ -11,7 +11,6 @@ import { defaultSession } from '@agent/runtime/SessionHandle';
 import {
   UserQuestionAnswersSchema,
   UserQuestionPromptSchema,
-  type UserQuestionAnswers,
 } from '@shared/schemas';
 import type { ToolResult } from '@shared/schemas/toolResult';
 import { requireInteractions } from '@tools/contextHelpers';


### PR DESCRIPTION
Behavior-preserving simplification pass over the release range, run as a fan-out of code-simplifier agents with an adversarial verification layer on top.

## Scope

| | |
|---|---|
| Range | `v0.39.9..main` — 237 commits |
| Primary (reviewed line-by-line, edit-eligible) | **458** changed `.ts`/`.tsx` files, ~148k LOC |
| Surface area (read for context; edited only where a call site required it) | **1,253** 1-hop importers/imports, ~240k LOC |
| Partition | 39 globally-disjoint slices (1,711 paths, 1,711 unique) so concurrent edits could not collide |

## Result

**52 files, +288 / −400 = net −112 lines.** 63 changes applied; **156** candidates considered and deliberately declined.

| Category | n |
|---|---|
| dedup — verbatim duplication → ≥2-caller local | 19 |
| inline single-caller pass-through, delete wrapper | 12 |
| dead code | 11 |
| ES2023 idiom | 6 |
| flatten nesting | 5 |
| type tightening (`readonly`, drop disproven `!`) | 5 |
| verbosity / static-map hoist / stale doc path | 6 |

The 156:63 decline-to-apply ratio is the point. `AGENTS.md` and review-checklist §13 record that 22 prior PRs pitched as "reductions" net-*added* 5,046 lines, so agents were barred from adding files, shared helpers, or single-caller extractions, and required to report real net LOC. Most of the guardrails' value showed up as refusals.

Representative refusals: a BFS queue loop that `push`es mid-iteration left as an index loop; a backwards scan whose callback is not a pure predicate left alone; `SettingsApp.renderActivePanel` **not** converted to an `assertNever` switch because its `default:` is intentional recovery for a stale panel index, so exhaustiveness would turn graceful fallback into a throw.

## One dead chain removed deliberately

`followup-clear` was fully unwired: `ProgressEvents.followupClear` had zero callers, so the surviving `handleFollowUpClear` listener in the desktop renderer was unreachable. `git log -S` confirms #9314 (*"remove clutter"*) intentionally deleted the Clear button, so this is leftover plumbing rather than staged scaffolding. Removed emitter, detail type, handler, and listener registration.

## A regression was caught, by tests

One agent rewrote `ToolUseWaitNode.exec()` to read `runScope` from `this.services` instead of `useLaunchRunContext()`, assuming equivalence. They are different objects with different `streamId`/`session`, so goal lookups silently missed — status stayed `active` instead of `paused`, `exec.kind` returned `stop` instead of `continue`. **It type-checked cleanly and its slice auditor passed it `CLEAN`.** Four tests in `ToolUseWaitNode.vitest.ts` caught it; the hunk was reverted and that file is back to 17/17.

Because the per-slice audit layer demonstrably missed that, a second independent read-only verification pass ran over all 52 final files (8 groups), calibrated on this exact failure mode. It returned no further findings — supporting evidence, not proof; the test suite is the real gate.

I additionally hand-verified the hunks in the classes TypeScript cannot catch:
- Three unwrapped arrow wrappers in `runChatTui.tsx` — both targets are `create*` factories returning object literals of plain closures, so there is no `this` to lose; the eager-vs-deferred property read is safe because the enclosing `slashCommandContext` is itself lazily invoked (its existing comment documents that invariant) and all five call sites are post-setup callbacks.
- `FollowUpQueue.waitForNext` hoisting `.shift()` out of its length guard — `FollowUpQueueItem` is an `interface`, so an element can never be falsy.
- `compactionResult` truthiness vs `!== undefined` — declared `?:`, never `null`, no `await` between read and use.
- `shortcutPreferences` merged `ctrlKey` branches — the two were mutually exclusive on platform, so `parts` is identical; the hoisted lookup map has exactly two references and is never mutated.

## Verification

All four gates green, real exit codes:

| Gate | Result |
|---|---|
| `npm run typecheck` | **0** — root + extension, cli, trace-viewer, desktop projects |
| `npm test` | **0** — 7953 passed, 4 skipped, 799 files |
| `npm run lint` | **0** |
| `npm run check:dead-code-ratchet` | **0** — 17 findings vs 17 baselined |

No exported signature, Zod schema shape, log text, or user-visible string changed. No new files, helpers, or abstractions. No changes to config, tests, docs, or the lockfile. No CHANGELOG entry — `AGENTS.md` excludes refactors with no user-visible effect.

## Follow-up not taken

`StreamTabs.ts:315` gained a `presentation: 'progress' | 'orchestration'` property that is never read and that no caller sets. Left alone: removing it would change a component's public shape, and unlike `followup-clear` I could not establish from history that it is abandoned rather than staged for a sibling PR.

https://claude.ai/code/session_014ZRRFg5idpVcBayZfbwmJW

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with no schema, export, or user-visible string changes; the main functional removal is confirmed-dead followup-clear IPC, and the PR was gated by full typecheck and test suite.
> 
> **Overview**
> Behavior-preserving cleanup that **nets fewer lines** by inlining single-use helpers, deduplicating loops, and removing dead UI plumbing.
> 
> **Dead path removed:** The **`followup-clear`** event chain is deleted end-to-end (`FollowUpClearDetail`, `handleFollowUpClear`, desktop listener, `ProgressEvents.followupClear`) because nothing emitted it after the follow-up Clear control was removed earlier.
> 
> **CLI / TUI:** Harness and chat code drop thin wrappers (e.g. harness user transcript, slash-help formatters) and pass **stable method references** into slash-command context instead of re-wrapping `resume` / `tryResumeStream` / `requestInputExit`. Static transcript state uses a shared **`buildFreshItems`** builder; session controller uses **`deleteOwnedEntries`** when tearing down interaction-owner maps. Child status labeling and stream-log scans use **`toReversed` / `findLast`** instead of manual index loops.
> 
> **Desktop:** **`postToRendererIfAlive`** is hoisted and reused for PTY, browser, workspace IPC, and the prompt controller (same destroy checks as before). Workbench editor placeholder clearing iterates **`WORKBENCH_PLACEMENTS`**; **`workspaceName`** uses **`basename`** instead of manual path splitting.
> 
> **Extension / progress UI:** Log formatters route **tool-use** errors through **`wrapWithErrorHandling`** with a dynamic label; workflow-call cards use a **`hasChildStream`** flag. Active stream resolution is centralized in **`resolveActiveStreamId`** for two progress commands. **`planFollowUp`** dedupes setup vs run follow-up handlers. Auth sign-in reuses **`showAuthServiceUnavailable`** for duplicate transient-unavailable messages.
> 
> **Agent runtime:** Follow-up queue **`waitForNext`** hoists **`shift()`**; follow-up submit factors a shared **`reason`**; queue manager **`notifyReleaseObservers`** runs on terminalize too. **`markUnfinishedStreamsRunning`** consolidates restart-repair status transitions; Google/Anthropic/OpenAI handlers simplify **`extractToolUse`** and compaction reads without changing shapes. Misc. readonly fields, loop flattening, and comment fixes elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8cb76475f2e9a1e6c4be3b5170461c5f16c112e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->