### PR TITLE
Consolidate failed-cycle-outcome construction in flow nodes

### DIFF
--- a/src/agent/core/flows/CycleServices.ts
+++ b/src/agent/core/flows/CycleServices.ts
@@ -16,6 +16,8 @@ import type {
   SdkToolCall,
 } from '@agent/types/ModelHandlerContracts';
 import type { ProviderMessage } from '@agent/types/ProviderMessage';
+import { buildFailedRetryInfo } from '@common/errors';
+import type { RetryErrorInfo } from '@shared/schemas';
 import type { TaskRunFileService } from '@utils/files';
 
 /**
@@ -113,4 +115,17 @@ export interface ToolUseRoundServices<C = unknown> extends CycleRunServices<C> {
   readonly session?: IToolUseSession;
   /** Callback when a queued follow-up is consumed (clears UI display). */
   readonly onFollowUpConsumed?: () => void;
+}
+
+/**
+ * The retry/logging fields every cycle node's `{ outcome: 'failed', ... }`
+ * result carries, regardless of whether that node identifies the failure
+ * with an `error` or a `message` field.
+ */
+export function buildFailedCycleOutcome(error: unknown): {
+  failureLogEmitted: false;
+  userRetryable: boolean;
+  lastError: RetryErrorInfo;
+} {
+  return { failureLogEmitted: false, ...buildFailedRetryInfo(error) };
 }

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
@@ -6,12 +6,14 @@ import {
   createResponseCycleFlow,
   type ResponseCycleShared,
 } from '@agent/core/flows/ResponseCycleFlow';
-import { withModelClient } from '@agent/core/flows/CycleServices';
+import {
+  buildFailedCycleOutcome,
+  withModelClient,
+} from '@agent/core/flows/CycleServices';
 import type {
   AgentRunStateSnapshot,
   ConversationRoundStateSnapshot,
 } from '@agent/core/state/AgentState';
-import { buildFailedRetryInfo } from '@common/errors';
 import type { AgentFileLocation, RetryErrorInfo } from '@shared/schemas';
 import { getDefaultToolRegistry } from '@tools/registry';
 import { ensureError } from '@utils/errors/errorMessage';
@@ -145,12 +147,8 @@ export class ResponseCycleNode<C = unknown> extends Node<
     } catch (error) {
       recordRound(prepRes.run, prepRes.round);
       await this.services.onRoundFinalized(prepRes.run);
-      return {
-        outcome: 'failed',
-        error: ensureError(error),
-        failureLogEmitted: false,
-        ...buildFailedRetryInfo(error),
-      };
+      const err = ensureError(error);
+      return { outcome: 'failed', error: err, ...buildFailedCycleOutcome(err) };
     } finally {
       if (cycleShared.contextWindowRecoveryRequestId !== undefined) {
         modelHandler.clearCompactionRequest(
@@ -164,12 +162,7 @@ export class ResponseCycleNode<C = unknown> extends Node<
     _prepRes: CyclePrepInput,
     error: Error,
   ): Promise<CycleOutcome> {
-    return {
-      outcome: 'failed',
-      error,
-      failureLogEmitted: false,
-      ...buildFailedRetryInfo(error),
-    };
+    return { outcome: 'failed', error, ...buildFailedCycleOutcome(error) };
   }
 
   async post(

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -8,9 +8,11 @@ import {
   createToolUseRoundFlow,
   type ToolUseRoundShared,
 } from '@agent/core/flows/ToolUseRoundFlow';
-import { withModelClient } from '@agent/core/flows/CycleServices';
+import {
+  buildFailedCycleOutcome,
+  withModelClient,
+} from '@agent/core/flows/CycleServices';
 import type { ProviderMessage } from '@agent/types/ProviderMessage';
-import { buildFailedRetryInfo } from '@common/errors';
 import {
   MESSAGE_TYPES,
   RUN_OUTCOME,
@@ -190,8 +192,7 @@ export class ToolUseCycleNode<C> extends Node<
     return {
       outcome: 'failed',
       message: error.message,
-      failureLogEmitted: false,
-      ...buildFailedRetryInfo(error),
+      ...buildFailedCycleOutcome(error),
     };
   }
 


### PR DESCRIPTION
## Summary

Scheduled scan for consolidation opportunities (duplicate logic, custom code that should use native/stdlib methods). Two independent passes covered: sleep/clone/dedup/debounce/retry/chunk/deep-equal/pick-omit/promise-chaining patterns across the whole tree, and cross-module duplication in `modelHandlers/`, the `reflection`/`tooluse` flows, `tools/`, the three host packages, and Zod schemas.

**Result: the codebase is already well-consolidated.** `p-retry`, `p-queue`, `structuredClone`, and `perfect-debounce` are each centralized behind one shared wrapper; SDK-error tagging, usage normalization, tool-schema conversion, auxiliary retry, background polling, media-attachment handling, path resolution, and file-edit application already live in single shared modules. No hand-rolled promise chains, manual array-dedup, or `JSON.parse(JSON.stringify(...))` cloning were found in production code.

Two genuine findings surfaced; this PR fixes the safe one and documents the other for a follow-up that needs browser verification.

### Fixed: `execFallback`/catch-block boilerplate duplicated across the two cycle-flow nodes

`ResponseCycleNode.ts` and `ToolUseCycleNode.ts` each built their `{ outcome: 'failed', ... }` result independently in two places (a `catch` block and `execFallback`), all four spreading `buildFailedRetryInfo(error)` with a hand-written `failureLogEmitted: false`. Extracted `buildFailedCycleOutcome()` into `CycleServices.ts` so the retry/logging fields can't drift between the `error`-field (Reflection) and `message`-field (ToolUse) variants as more outcome fields get added later.

### Flagged, not fixed: copy-button timed-reset logic duplicated in two mechanisms

`src/shared/utils/clipboard.ts:copyWithFeedback()` (imperative, DOM-attribute-based timer, used by `LogList.ts` via event delegation over dynamically rendered buttons) and `src/shared/litControllers/CopyButtonController.ts` (Lit `ReactiveController`, used by single-owned buttons in `UserMessage.ts`/`ExternalInquiryPanel.ts`) both reimplement the same "flip to success state → timeout → revert, cancel on re-trigger" state machine. This is already tracked as `CTRL-1` in `docs/prds/2026-01-27-prd-ui-regression-audit.md` (P2, "Document that patterns must not be mixed on same element, or consolidate to single mechanism"). Not touched here: `LogList.ts`'s event-delegation pattern (one handler over N dynamically rendered buttons) doesn't fit `CopyButtonController`'s one-controller-per-host-component model, so a real merge needs a design decision plus live webview verification that this automated run can't do — left as-is rather than risk an untested behavior change in the copy UX.

## Issue acceptance gates

No linked issue — this is a scheduled tech-debt scan. Acceptance gate self-imposed: identify duplication, fix what's safe and testable, flag what needs human/browser judgment.

## Single source of truth

`buildFailedCycleOutcome()` in `src/agent/core/flows/CycleServices.ts` now owns the failed-cycle retry/logging field shape for both cycle-flow nodes.

## Duplication and abstraction budget

Removed: 2 duplicated 4-6 line blocks (one per node) building the same `{ failureLogEmitted, userRetryable, lastError }` triple. No new pass-through layer — `buildFailedCycleOutcome` sits next to the existing `withModelClient` helper in the same file both nodes already import from.

## Net elements (R6)

3 files changed, +27/-18 lines. +1 exported function (`buildFailedCycleOutcome`), 0 new classes/interfaces. Net: -9 lines across the two call sites' duplicated boilerplate, +1 shared function.

## Consumer counts (R8)

No emit path or export was deleted or re-routed — `buildFailedRetryInfo` itself is untouched and still exported/used elsewhere. n/a.

## Host impact

Extension: none (core-only change).

Desktop: none (core-only change).

CLI: none (core-only change).

## Scheduled refactoring

Follow-up: decide whether to consolidate the copy-button timed-reset duplication (`clipboard.ts` vs `CopyButtonController.ts`, tracked as CTRL-1 in the UI regression-audit PRD) or formally document that the two mechanisms must not be mixed on the same element. Needs a live browser check in the webview, not just typecheck/unit tests.

## Validation

- `npm run typecheck` — passes (core, extension, cli, desktop, trace-viewer).
- `npx eslint` on the 3 changed files — clean (one import-order issue auto-fixed).
- `npx vitest run src/test-kernel/agent` — 1999 passed, 1 pre-existing unrelated failure (`WorkflowScriptEngine.vitest.ts` QuickJS memory-exhaustion timing assertion, not touched by this change), all tests covering `ResponseCycleNode`/`ToolUseCycleNode` pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_013z5SvUtkEnoswrePskLdT1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical deduplication with no behavior change; only how failed outcomes are assembled in agent cycle nodes.
> 
> **Overview**
> Adds **`buildFailedCycleOutcome()`** in `CycleServices.ts` as the single place that sets `failureLogEmitted: false` plus the retry fields from `buildFailedRetryInfo()`.
> 
> **`ResponseCycleNode`** and **`ToolUseCycleNode`** now spread that helper in their `catch` / `execFallback` paths instead of repeating the same triple inline. Reflection failures still attach an `error`; tool-use failures still use `message`—only the shared retry/logging slice is centralized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a78e2325b593b1f49cc832fd6b62057dec2f6b78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->