### PR TITLE
Delete legacy stream-status trait table and predicates (#7993 step 4)

### DIFF
--- a/docs/proposals/2026-07-03-session-scoped-runtime-architecture.md
+++ b/docs/proposals/2026-07-03-session-scoped-runtime-architecture.md
@@ -1369,3 +1369,56 @@ not have to rediscover them): CLI TUI's `src/test-kernel/cli/
 TuiStateAndFocus.vitest.mts` (references `STREAM_STATUS` per §8.1's census);
 the extension's `TaskGroupListIndex.vitest.ts`, which builds `TaskGroup`
 fixtures directly from `STREAM_STATUS` literals.
+
+### 8.6 Step 4 execution record (2026-07-29): what was deleted, and what is permanent
+
+§8.4 step 3 (the parent issue's goal item 4) named one deletion list. On
+execution the list split cleanly in three, and only the first part is a
+deletion — recorded here so a future sweep does not re-open the other two as
+outstanding debt.
+
+**Deleted — provably dead, no released-data dependency.**
+
+- `STREAM_STATUS_TRAITS` and everything derived from it:
+  `streamStatusesWithTrait`, `StreamStatusTrait`,
+  `LIVE_ELAPSED_STREAM_STATUSES` (`src/shared/schemas/stream.ts`). Membership
+  questions are answered exclusively by the `StreamPhase` predicates
+  (`isActivePhase`/`isInFlightPhase`/`isTerminalOutcomePhase`,
+  `@shared/streams/streamStatus`) after steps 2-3. The last non-test consumer
+  was `packages/cli/scripts/tui-harness.tsx`, migrated in the same change:
+  the harness now seeds child rosters with `STREAM_PHASE` values, which is
+  what production has written since #8317, so the harness is a faithful
+  mirror again rather than the repo's last legacy-vocabulary producer.
+- `groupEndStatusForOutcome` (`@shared/streams/streamStatus`) — the
+  `'ok' | 'error'` intermediate hop. Its only caller was
+  `legacyEndGroupStatusForOutcome` in the same file; the fold is now stated
+  once, there.
+- The trait-table pin in `RunOutcomeAlgebra.vitest.ts`, replaced by an
+  exhaustive pin of the three `StreamPhase` predicates over
+  `StreamPhaseSchema.options` — the membership fact keeps its coverage, on
+  the canonical vocabulary.
+
+**Permanent, not debt.** `STREAM_STATUS`/`StreamStatusSchema`/`StreamStatus`
+and `END_GROUP_STATUS`/`EndGroupStatusSchema` stay, as §8.3 already ruled,
+because two read boundaries never age out:
+
+1. `StreamLogStore.parsePersistedEntries`'s group-status normalization —
+   released transcripts are never rewritten.
+2. The standalone trace-viewer's file import (`replayTrace.ts`'s
+   `StreamLifecycleStatusSchema` parse and `StreamSnapshot.status`, plus
+   `GroupLogPayloadSchema`'s legacy `EndGroupStatus` union member, which
+   serves the raw `trace.entries` this boundary forwards into `logSlice.ts`)
+   — a static exported `trace.json` stays legacy-shaped forever.
+
+Their doc comments now say this in the enum's own definition, so the next
+reader does not have to reconstruct it from the ledger.
+
+**Still dated, deliberately not touched.** The remaining legacy _reads_ are
+released-data compatibility with live removal triggers in the #6981 ledger,
+not dead code: the frozen CLI headless JSON `endGroupStatus` projection
+(`packages/cli/src/runtime/terminalStatus.ts`, v0.41 / 2026-08-04 whichever
+is later — the only remaining caller of `legacyEndGroupStatusForOutcome`),
+`streamStatusDisplay.ts`'s legacy display arm and
+`sessionStatus.ts`'s legacy child-`stopped` label, and the `terminalStatus`
+and `meta.json.taskState` tier-3 shims. These are what keep #7993's last
+checkbox open; nothing above unblocks them.

--- a/packages/cli/scripts/tui-harness.tsx
+++ b/packages/cli/scripts/tui-harness.tsx
@@ -32,13 +32,10 @@ import { platform, tryPlatform } from '@platform/platform';
 import { MEMORY_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 import {
   AgentCategory,
-  LIVE_ELAPSED_STREAM_STATUSES,
   LOG_LEVELS,
   MESSAGE_TYPES,
   STREAM_PHASE,
-  STREAM_STATUS,
   STREAM_LOG_ENTRY_TYPES,
-  streamStatusToPhase,
   TODO_STATUS,
   TOOL_USE_STATUS,
   type ActiveChildInfo,
@@ -53,6 +50,7 @@ import {
 } from '@shared/schemas';
 import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
 import {
+  isActivePhase,
   isInFlightPhase,
   STREAM_TRANSITION_CAUSE,
 } from '@shared/streams/streamStatus';
@@ -1732,7 +1730,7 @@ if (SHOW_CHILDREN) {
     executionId: 'harness-nested-local-checker',
     agentName: 'localChecker',
     childStreamId: 'harness-nested-local-checker-stream',
-    status: STREAM_STATUS.RUNNING,
+    status: STREAM_PHASE.RUNNING,
     startedAt: nestedStartedAt,
   };
   const childStreams = [
@@ -1741,7 +1739,7 @@ if (SHOW_CHILDREN) {
       executionId: 'harness-child-strategy',
       agentName: 'strategy',
       childStreamId: 'harness-child-strategy-stream',
-      status: STREAM_STATUS.RUNNING,
+      status: STREAM_PHASE.RUNNING,
       startedAt,
     },
     {
@@ -1749,7 +1747,7 @@ if (SHOW_CHILDREN) {
       executionId: 'harness-child-lean',
       agentName: 'leanSolver',
       childStreamId: 'harness-child-lean-stream',
-      status: STREAM_STATUS.WAITING,
+      status: STREAM_PHASE.WAITING,
       elapsed: '2m 3s',
     },
     {
@@ -1757,21 +1755,21 @@ if (SHOW_CHILDREN) {
       executionId: 'harness-child-review',
       agentName: 'reviewer',
       childStreamId: 'harness-child-review-stream',
-      status: STREAM_STATUS.RUNNING,
+      status: STREAM_PHASE.RUNNING,
       startedAt: startedAt + 12_000,
     },
   ].map((child) =>
     child.agentName === FAILED_CHILD_AGENT
       ? {
           ...child,
-          status: STREAM_STATUS.ERROR,
+          status: STREAM_PHASE.FAILED,
           startedAt: undefined,
           elapsed: null,
         }
       : child,
   );
   const activeSubagents = childStreams.filter(
-    (child) => child.status !== STREAM_STATUS.ERROR,
+    (child) => child.status !== STREAM_PHASE.FAILED,
   );
   // Seed through the real transition functions rather than poking StreamSlice
   // fields directly: register the complete roster first (so the errored
@@ -1794,11 +1792,11 @@ if (SHOW_CHILDREN) {
     if (addNestedChildren) applySubagentRoster(streamId, [nestedStrategyChild]);
     patchStream(streamId, (slice) => ({
       ...slice,
-      status: streamStatusToPhase(child.status),
+      status: child.status,
       description: `${child.agentName} sub-workflow`,
       entries: makeChildEntries(child.agentName, child.executionId),
       runStartedAt:
-        child.status === STREAM_STATUS.RUNNING ? child.startedAt : undefined,
+        child.status === STREAM_PHASE.RUNNING ? child.startedAt : undefined,
       // One child carries usage so scenarios pin the row metadata column's
       // generated-token figure (`↓40k`).
       cumulativeUsage:
@@ -2087,9 +2085,7 @@ function appendHarnessChildSubmitAck(
   text: string,
   streamId: StreamTabId,
 ): void {
-  const status = streams.get().get(streamId)?.status;
-  const isLive =
-    status !== undefined && LIVE_ELAPSED_STREAM_STATUSES.has(status);
+  const isLive = isActivePhase(streams.get().get(streamId)?.status);
   appendHarnessTranscript('assistant', text, streamId, { finalized: !isLive });
 }
 

--- a/src/shared/schemas/stream.ts
+++ b/src/shared/schemas/stream.ts
@@ -3,6 +3,32 @@ import { z } from 'zod';
 import { AgentCategorySchema } from './agent';
 import { ExecutionIdSchema, StreamTabIdSchema } from './identifiers';
 
+/**
+ * The retired 7-value live-status vocabulary. **Read-only residue** — no
+ * production code decides anything from it any more (#7993 steps 2-3 moved
+ * every live producer and host reader to `StreamPhase` + `StreamSubstate`).
+ * It survives for exactly three reasons, all of them parse-side:
+ *
+ * 1. `StreamLogStore.parsePersistedEntries` normalizes pre-cutover on-disk
+ *    `GROUP_START`/`GROUP_END` `data.status` rows (§8.3's first permanent
+ *    boundary — released transcripts are never rewritten, so this parse
+ *    never ages out).
+ * 2. The standalone trace-viewer's file import (`replayTrace.ts`) parses
+ *    externally-authored `trace.json` exports through
+ *    `StreamLifecycleStatusSchema` and `StreamSnapshot.status` (§8.3's
+ *    second permanent boundary — a static exported file stays legacy-shaped
+ *    forever).
+ * 3. Display tolerance for those two inputs
+ *    (`@shared/streams/streamStatusDisplay`), plus the frozen CLI headless
+ *    JSON `endGroupStatus` projection whose own removal is dated in the
+ *    #6981 ledger (v0.41 / 2026-08-04, whichever is later).
+ *
+ * The trait table that used to hang off this enum is gone: membership
+ * questions are answered by the `StreamPhase` predicates in
+ * `@shared/streams/streamStatus` (`isActivePhase`, `isInFlightPhase`,
+ * `isTerminalOutcomePhase`). Do not add a new reader here — add a
+ * `StreamPhase` one.
+ */
 export const STREAM_STATUS = {
   RUNNING: 'running',
   ERROR: 'error',
@@ -15,98 +41,6 @@ export const STREAM_STATUS = {
 
 export const StreamStatusSchema = z.enum(STREAM_STATUS);
 export type StreamStatus = z.infer<typeof StreamStatusSchema>;
-
-/**
- * Declarative trait table for the live stream state machine — the single
- * source of truth for every status-membership question. Predicates and sets
- * (here and in `@shared/streams/streamStatus`) are derived from this table;
- * never declare a new status list by hand.
- *
- * Traits:
- * - `active`      — a model/tool cycle is executing right now.
- * - `inFlight`    — a cycle may still append to the stream; the stream must
- *                   not be evicted or acquired by a new run.
- * - `liveElapsed` — elapsed-time displays keep advancing.
- * - `terminal`    — the current execution cycle has ended; resumption needs
- *                   an explicit user action.
- *
- * The table makes the two deliberate oddballs visible:
- * - WAITING is `terminal` AND `inFlight`: the cycle ended (status bar shows
- *   idle) but a follow-up appends to the same log, so the stream is not
- *   acquirable.
- * - INITIALIZING is neither `active` nor `terminal`: a brief pre-start state
- *   that ticks elapsed time and blocks acquisition, but runs no model calls.
- */
-const STREAM_STATUS_TRAITS = {
-  [STREAM_STATUS.RUNNING]: {
-    active: true,
-    inFlight: true,
-    liveElapsed: true,
-    terminal: false,
-  },
-  [STREAM_STATUS.RESUMING]: {
-    active: true,
-    inFlight: true,
-    liveElapsed: true,
-    terminal: false,
-  },
-  [STREAM_STATUS.INITIALIZING]: {
-    active: false,
-    inFlight: true,
-    liveElapsed: true,
-    terminal: false,
-  },
-  [STREAM_STATUS.WAITING]: {
-    active: false,
-    inFlight: true,
-    liveElapsed: false,
-    terminal: true,
-  },
-  [STREAM_STATUS.STOPPED]: {
-    active: false,
-    inFlight: false,
-    liveElapsed: false,
-    terminal: true,
-  },
-  [STREAM_STATUS.ERROR]: {
-    active: false,
-    inFlight: false,
-    liveElapsed: false,
-    terminal: true,
-  },
-  [STREAM_STATUS.READY]: {
-    active: false,
-    inFlight: false,
-    liveElapsed: false,
-    terminal: true,
-  },
-} as const satisfies Record<
-  StreamStatus,
-  {
-    active: boolean;
-    inFlight: boolean;
-    liveElapsed: boolean;
-    terminal: boolean;
-  }
->;
-
-export type StreamStatusTrait =
-  keyof (typeof STREAM_STATUS_TRAITS)[StreamStatus];
-
-/** Derive the set of statuses carrying a trait — the only list constructor. */
-export function streamStatusesWithTrait(
-  trait: StreamStatusTrait,
-): ReadonlySet<StreamStatus> {
-  return new Set(
-    StreamStatusSchema.options.filter(
-      (status) => STREAM_STATUS_TRAITS[status][trait],
-    ),
-  );
-}
-
-/** Statuses whose elapsed display should keep advancing while active. */
-export const LIVE_ELAPSED_STREAM_STATUSES: ReadonlySet<string> =
-  streamStatusesWithTrait('liveElapsed');
 
 export const EXECUTION_STATUS = {
   COMPLETED: 'completed',

--- a/src/shared/streams/streamStatus.ts
+++ b/src/shared/streams/streamStatus.ts
@@ -79,14 +79,22 @@ export function runOutcomeToExecutionStatus(
   return projectRunOutcome(outcome).executionStatus;
 }
 
-export function groupEndStatusForOutcome(outcome: RunOutcome): 'ok' | 'error' {
-  return outcome === RUN_OUTCOME.FAILED ? 'error' : 'ok';
-}
-
+/**
+ * The frozen 2-value `EndGroupStatus` fold, kept for the one external
+ * contract that still publishes it: the CLI headless JSON's deprecated
+ * `endGroupStatus` field (`packages/cli/src/runtime/terminalStatus.ts`),
+ * whose removal is dated in the #6981 ledger (v0.41 / 2026-08-04, whichever
+ * is later). No transcript writer calls this any more — every `GROUP_END`
+ * producer emits the literal `RunOutcome` (#8087 / §8.2).
+ *
+ * `cancelled` folds to `'stopped'` alongside `completed` because that is what
+ * the frozen field has always published; the distinction lives on `outcome`,
+ * which is what consumers were told to migrate to.
+ */
 export function legacyEndGroupStatusForOutcome(
   outcome: RunOutcome,
 ): 'error' | 'stopped' {
-  return groupEndStatusForOutcome(outcome) === 'error' ? 'error' : 'stopped';
+  return outcome === RUN_OUTCOME.FAILED ? 'error' : 'stopped';
 }
 
 // ============================================================================

--- a/src/test-kernel/shared/RunOutcomeAlgebra.vitest.ts
+++ b/src/test-kernel/shared/RunOutcomeAlgebra.vitest.ts
@@ -4,12 +4,9 @@ import { describe, expect, it } from 'vitest';
 // Local imports
 import {
   EXECUTION_STATUS,
-  LIVE_ELAPSED_STREAM_STATUSES,
   RUN_OUTCOME,
   STREAM_PHASE,
-  STREAM_STATUS,
   StreamPhaseSchema,
-  streamStatusesWithTrait,
   type RunOutcome,
   type StreamPhase,
 } from '@shared/schemas';
@@ -17,7 +14,9 @@ import {
   canAcquireStreamReservation,
   canTransitionStreamPhase,
   deriveRunOutcome,
-  groupEndStatusForOutcome,
+  isActivePhase,
+  isInFlightPhase,
+  isTerminalOutcomePhase,
   legacyEndGroupStatusForOutcome,
   projectRunOutcome,
   RUN_OUTCOME_PROJECTION,
@@ -62,15 +61,14 @@ describe('run outcome algebra', () => {
   // sweep to write the literal RunOutcome), nor from logSlice.ts's read side
   // (#7993 step 3 retypes TaskGroup.status to the native StreamPhase/
   // RunOutcome vocabulary, so that reader no longer needs to fold a
-  // canonical value down to a legacy bucket). It survives as a Tier-4-only
-  // read-side derive helper for the frozen CLI headless JSON's
-  // `endGroupStatus` projection (packages/cli/src/runtime/terminalStatus.ts)
-  // — the algebra itself is unchanged, so it still needs to stay correct.
-  it('derives folded legacy group-end projections from one helper', () => {
-    expect(groupEndStatusForOutcome(RUN_OUTCOME.COMPLETED)).toBe('ok');
-    expect(groupEndStatusForOutcome(RUN_OUTCOME.CANCELLED)).toBe('ok');
-    expect(groupEndStatusForOutcome(RUN_OUTCOME.FAILED)).toBe('error');
-
+  // canonical value down to a legacy bucket). Its single remaining caller is
+  // the frozen CLI headless JSON's `endGroupStatus` projection
+  // (packages/cli/src/runtime/terminalStatus.ts), whose own removal is dated
+  // in the #6981 ledger — the fold itself is unchanged, so it still needs to
+  // stay correct until then. The intermediate `groupEndStatusForOutcome`
+  // ('ok' | 'error') hop was deleted with the rest of the legacy vocabulary
+  // production surface (#7993 step 4): it had no caller but this one.
+  it('folds each outcome into the frozen 2-value legacy projection', () => {
     expect(legacyEndGroupStatusForOutcome(RUN_OUTCOME.COMPLETED)).toBe(
       'stopped',
     );
@@ -181,33 +179,66 @@ describe('stream phase transition table', () => {
   });
 });
 
-describe('stream status trait table', () => {
-  it('derives the historical membership sets from traits', () => {
-    expect(streamStatusesWithTrait('active')).toEqual(
-      new Set([STREAM_STATUS.RUNNING, STREAM_STATUS.RESUMING]),
+// The membership sets these three predicates answer used to be derived from
+// the legacy 7-value STREAM_STATUS_TRAITS table, deleted with the rest of the
+// legacy vocabulary's production surface (#7993 step 4). They are now the only
+// enumeration of "which phases are active / in flight / terminal", so pin them
+// exhaustively over the phase vocabulary rather than by example.
+describe('stream phase membership predicates', () => {
+  const membership: Record<
+    StreamPhase,
+    { active: boolean; inFlight: boolean; terminalOutcome: boolean }
+  > = {
+    [STREAM_PHASE.RUNNING]: {
+      active: true,
+      inFlight: true,
+      terminalOutcome: false,
+    },
+    // WAITING is the deliberate oddball the old trait table also made
+    // visible: the cycle ended, but a follow-up appends to the same stream,
+    // so it is not acquirable and not a terminal outcome either.
+    [STREAM_PHASE.WAITING]: {
+      active: false,
+      inFlight: true,
+      terminalOutcome: false,
+    },
+    [STREAM_PHASE.COMPLETED]: {
+      active: false,
+      inFlight: false,
+      terminalOutcome: true,
+    },
+    [STREAM_PHASE.CANCELLED]: {
+      active: false,
+      inFlight: false,
+      terminalOutcome: true,
+    },
+    [STREAM_PHASE.FAILED]: {
+      active: false,
+      inFlight: false,
+      terminalOutcome: true,
+    },
+  };
+
+  it('classifies every phase, and treats absence as no-run-yet', () => {
+    for (const phase of StreamPhaseSchema.options) {
+      expect(isActivePhase(phase)).toBe(membership[phase].active);
+      expect(isInFlightPhase(phase)).toBe(membership[phase].inFlight);
+      expect(isTerminalOutcomePhase(phase)).toBe(
+        membership[phase].terminalOutcome,
+      );
+    }
+
+    expect(isActivePhase(undefined)).toBe(false);
+    expect(isInFlightPhase(undefined)).toBe(false);
+    expect(isTerminalOutcomePhase(undefined)).toBe(false);
+  });
+
+  it('makes every terminal outcome phase a RunOutcome', () => {
+    const terminalPhases = StreamPhaseSchema.options.filter(
+      isTerminalOutcomePhase,
     );
-    expect(streamStatusesWithTrait('inFlight')).toEqual(
-      new Set([
-        STREAM_STATUS.RUNNING,
-        STREAM_STATUS.RESUMING,
-        STREAM_STATUS.INITIALIZING,
-        STREAM_STATUS.WAITING,
-      ]),
-    );
-    expect(LIVE_ELAPSED_STREAM_STATUSES).toEqual(
-      new Set([
-        STREAM_STATUS.RUNNING,
-        STREAM_STATUS.RESUMING,
-        STREAM_STATUS.INITIALIZING,
-      ]),
-    );
-    expect(streamStatusesWithTrait('terminal')).toEqual(
-      new Set([
-        STREAM_STATUS.WAITING,
-        STREAM_STATUS.STOPPED,
-        STREAM_STATUS.ERROR,
-        STREAM_STATUS.READY,
-      ]),
+    expect(new Set<string>(terminalPhases)).toEqual(
+      new Set<string>(Object.values(RUN_OUTCOME)),
     );
   });
 });


### PR DESCRIPTION
## Summary

Completes #7993 step 4 by removing the legacy `STREAM_STATUS_TRAITS` table and all derived predicates (`streamStatusesWithTrait`, `LIVE_ELAPSED_STREAM_STATUSES`, `groupEndStatusForOutcome`) that became dead code after steps 2–3 migrated all production readers to the canonical `StreamPhase` vocabulary.

The three `StreamPhase` predicates (`isActivePhase`, `isInFlightPhase`, `isTerminalOutcomePhase`) now own all membership questions. The frozen `STREAM_STATUS` enum itself remains permanent for two read-only parse boundaries (persisted log normalization and trace-viewer file import) documented in the enum's own comment.

## Issue acceptance gates

#7993 step 4 (delete legacy vocabulary production surface):
- ✅ Remove `STREAM_STATUS_TRAITS` and derived helpers
- ✅ Migrate last non-test consumer (`tui-harness.tsx`) to `STREAM_PHASE`
- ✅ Replace trait-table test pin with exhaustive `StreamPhase` predicate coverage
- ✅ Document permanent read boundaries in enum comments

## Single source of truth

`StreamPhase` predicates (`@shared/streams/streamStatus`) now own all membership facts. The legacy `STREAM_STATUS` enum is read-only residue for two permanent parse boundaries (log normalization and trace-viewer import), documented in its own definition.

## Duplication and abstraction budget

Removed one level of indirection: `groupEndStatusForOutcome` (the `'ok' | 'error'` intermediate hop) was deleted; `legacyEndGroupStatusForOutcome` now states the fold directly. This was the only caller of the intermediate function.

## Net elements (R6)

**Deleted exports:**
- `STREAM_STATUS_TRAITS` (const)
- `streamStatusesWithTrait` (function)
- `StreamStatusTrait` (type)
- `LIVE_ELAPSED_STREAM_STATUSES` (const)
- `groupEndStatusForOutcome` (function)

**Modified:**
- `legacyEndGroupStatusForOutcome`: inlined the fold; added doc comment explaining permanent CLI contract
- `tui-harness.tsx`: replaced `STREAM_STATUS` literals with `STREAM_PHASE`, removed `LIVE_ELAPSED_STREAM_STATUSES` check in favor of `isActivePhase()`

**Files changed:** 5 (stream.ts, streamStatus.ts, tui-harness.tsx, RunOutcomeAlgebra.vitest.ts, proposal doc)

**Net LoC:** ~120 deleted (trait table + test pin + doc comments for permanent boundaries)

## Consumer counts (R8)

- `STREAM_STATUS_TRAITS`: 1 caller (test pin) — deleted
- `streamStatusesWithTrait`: 2 callers (test pin + `LIVE_ELAPSED_STREAM_STATUSES` definition) — deleted
- `LIVE_ELAPSED_STREAM_STATUSES`: 1 caller (`tui-harness.tsx`) — migrated to `isActivePhase()`
- `groupEndStatusForOutcome`: 1 caller (`legacyEndGroupStatusForOutcome`) — inlined

## Host impact

**Extension:** None (no direct consumer of deleted symbols)

**Desktop:** None (no direct consumer of deleted symbols)

**CLI:** `tui-harness.tsx` (test harness) now seeds child rosters with `STREAM_PHASE` values instead of `STREAM_STATUS`, making the harness a faithful mirror of production again rather than the repo's last legacy-vocabulary producer.

## Scheduled refactoring

None. The remaining legacy reads are released-data compatibility with removal triggers in #6981 (v0.41 / 2026-08-04): frozen CLI headless JSON `endGroupStatus` projection, `streamStatusDisplay.ts` legacy display arm, and `sessionStatus.ts` legacy child-`stopped` label. These are what keep #7993's last checkbox open; nothing in this PR unblocks them.

## Validation

-

https://claude.ai/code/session_01QF8CDYnP9BMud46o3wmdUG

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly dead-code removal and test/harness alignment; runtime behavior should be unchanged aside from harness fixtures matching production vocabulary.
> 
> **Overview**
> Completes **#7993 step 4** by deleting the legacy **`STREAM_STATUS_TRAITS`** surface and derived helpers (`streamStatusesWithTrait`, `LIVE_ELAPSED_STREAM_STATUSES`, `StreamStatusTrait`) from `stream.ts`. Live membership checks now go only through **`isActivePhase` / `isInFlightPhase` / `isTerminalOutcomePhase`** in `@shared/streams/streamStatus`.
> 
> **`groupEndStatusForOutcome`** is removed; **`legacyEndGroupStatusForOutcome`** inlines the failed-vs-stopped fold for the dated CLI headless **`endGroupStatus`** projection. **`STREAM_STATUS`** stays with expanded comments as **read-only residue** for persisted log normalization and trace-viewer import.
> 
> **`tui-harness.tsx`** (last non-test legacy producer) seeds child rosters with **`STREAM_PHASE`** and uses **`isActivePhase`** instead of **`LIVE_ELAPSED_STREAM_STATUSES`**. **`RunOutcomeAlgebra.vitest.ts`** replaces the trait-table pin with exhaustive **`StreamPhase`** predicate coverage. The session-scoped runtime proposal doc adds **§8.6** recording what was deleted vs what remains intentionally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05fdea8c9e5afc2df6af9b8065e9c71efc805307. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->