### PR TITLE
Replace hand-rolled promise-chain serialization with p-queue

### DIFF
--- a/packages/cli/src/runtime/approval/approvalPolicy.ts
+++ b/packages/cli/src/runtime/approval/approvalPolicy.ts
@@ -1,3 +1,5 @@
+import PQueue from 'p-queue';
+
 import type { HostUserQuestionResult } from '@agent/runtime/HostInteractions';
 import { isRelayMonthlyLimitMessage } from '@common/errors/sdkErrorUtils';
 import {
@@ -51,7 +53,7 @@ export interface CliApprovalPromptHooks {
 }
 
 const deniedApprovalContexts = new WeakSet<CliContext>();
-const cliPromptQueues = new WeakMap<CliContext, Promise<unknown>>();
+const cliPromptQueues = new WeakMap<CliContext, PQueue>();
 
 function denyMessage(policy: CliContext['approvalPolicy']): string {
   return policy === 'ask'
@@ -105,13 +107,12 @@ function enqueueCliPrompt<T>(
   context: CliContext,
   prompt: () => Promise<T>,
 ): Promise<T> {
-  const previous = cliPromptQueues.get(context) ?? Promise.resolve();
-  const next = previous.catch(() => undefined).then(prompt);
-  cliPromptQueues.set(
-    context,
-    next.catch(() => undefined),
-  );
-  return next;
+  let queue = cliPromptQueues.get(context);
+  if (!queue) {
+    queue = new PQueue({ concurrency: 1 });
+    cliPromptQueues.set(context, queue);
+  }
+  return queue.add(prompt);
 }
 
 async function askCliApprovalQuestion(

--- a/packages/cli/src/runtime/cliSecrets.ts
+++ b/packages/cli/src/runtime/cliSecrets.ts
@@ -1,6 +1,8 @@
 // Node imports
 import path from 'node:path';
 
+import PQueue from 'p-queue';
+
 // Local imports
 import type { PlatformSecrets } from '@platform/secrets';
 import { JsonStore } from '@platform/defaults/jsonStore';
@@ -24,13 +26,13 @@ const SECRETS_FILE_MODE = 0o600;
  *
  * Each operation opens its own `JsonStore` rather than caching one for the
  * lifetime of this instance, so reads (`get`/`getStored`/`listStoredKeys`)
- * always observe the current on-disk file. Mutations are linked at call time
- * through {@link mutationQueue}, before the asynchronous open, so same-key
- * writes preserve caller order. `JsonStore` handles cross-instance and
- * cross-process exclusion while flushing.
+ * always observe the current on-disk file. Mutations are serialized at call
+ * time through {@link mutationQueue}, before the asynchronous open, so
+ * same-key writes preserve caller order. `JsonStore` handles cross-instance
+ * and cross-process exclusion while flushing.
  */
 export class CliSecrets implements PlatformSecrets {
-  private mutationQueue: Promise<void> = Promise.resolve();
+  private readonly mutationQueue = new PQueue({ concurrency: 1 });
 
   constructor(private readonly filePath = cliSecretsPath()) {}
 
@@ -62,12 +64,10 @@ export class CliSecrets implements PlatformSecrets {
   }
 
   private mutate(op: (store: JsonStore) => Promise<void>): Promise<void> {
-    const mutation = this.mutationQueue.then(async () => {
+    return this.mutationQueue.add(async () => {
       const store = await this.openStore();
       await op(store);
     });
-    this.mutationQueue = mutation.catch(() => {});
-    return mutation;
   }
 
   private openStore(): Promise<JsonStore> {


### PR DESCRIPTION
## Summary

A scheduled audit for ad-hoc/reinvented-wheel code found that this codebase already adopts `p-retry`, `p-queue`, `lru-cache`, `nanoid`, `structuredClone`, `isDeepStrictEqual`, `perfect-debounce`, and `pretty-ms` consistently. The two clear, safe candidates it turned up were both instances of the `chain = chain.then(...)` promise-chain-serialization idiom that `AGENTS.md` already names and bans, in favor of `p-queue` — this PR replaces those with `PQueue`, matching how the same CLI package already solves the identical problem elsewhere (`streamApprovalQueue.ts`, `chatSessionController.followUpQueue`).

- `packages/cli/src/runtime/approval/approvalPolicy.ts`: `cliPromptQueues` was a `WeakMap<CliContext, Promise<unknown>>` manually re-chained on every prompt. Now a `WeakMap<CliContext, PQueue>` with `concurrency: 1`, created lazily per context.
- `packages/cli/src/runtime/cliSecrets.ts`: `CliSecrets.mutationQueue` was a `Promise<void>` field re-chained the same way for every secrets-file mutation. Now a `PQueue` instance, added to via `.add()`.

Both replacements preserve the original serialization semantics: one job in flight at a time, and one job's failure doesn't block the next.

### Not touched (investigated and deliberately skipped)

- `src/transcript/StreamSnapshotStore.ts`'s `seedChain` — a superficially similar `Promise`-chain field, but it's load-bearing for a version/eviction/staged-deletion correctness protocol (explicit `#7892`/`#7464`/`#8226` bug references in the comments), not a plain serialization queue. Swapping it for a generic `PQueue` would risk breaking that contract without a much larger, dedicated redesign.
- `packages/cli/src/runtime/runProgressRenderer.ts`'s `formatElapsed` — looked like a duplicate of the `pretty-ms`-backed `formatCompactDuration`, but its own comment explains a deliberate behavior difference (never rolls over to hour granularity, unlike `formatCompactDuration`) that `pretty-ms`'s options can't reproduce. Not a genuine duplicate.
- `src/agent/runtime/ModelRetryGate.ts`'s hand-rolled backoff coordinator — documented, justified exception (`p-retry` can't coordinate shared backoff across concurrent callers on the same provider route).
- Ad-hoc type-guards for provider error bodies (`src/common/errors/sdkError/`) and the Supabase `auth-device` retry loop — debatable/weak candidates, not clear-cut violations.

## Issue acceptance gates

No linked issue — this follows up on a scheduled ad-hoc-implementation audit. Gate: replace the two spots that reinvent an already-adopted pattern (`p-queue`) without behavior change.

## Single source of truth

`PQueue` (already a repo dependency, already used for this exact purpose in `runChatTui.tsx` and `subscribeApprovals.ts`) is now the single serialization primitive in both files, replacing the ad-hoc `Promise`-chain field each one maintained independently.

## Duplication and abstraction budget

Removed: two independent reimplementations of promise-chain serialization. No new abstraction added — both call sites use `PQueue` directly, same as its existing callers in this package.

## Net elements (R6)

2 files changed, 17 insertions(+), 16 deletions(-). No exported symbols added or removed, no new classes/interfaces.

## Consumer counts (R8)

n/a — no emit path or export was removed or re-routed; both changes are internal to their respective modules.

## Host impact

Extension: none.

Desktop: none.

CLI: `approvalPolicy.ts` (approval-prompt serialization) and `cliSecrets.ts` (secrets-file write serialization) behave identically from the caller's perspective — same ordering guarantees, same per-call promise semantics.

## Scheduled refactoring

None.

## Validation

- `npm run typecheck` — passes.
- `npm run lint` — passes (full repo).
- `npx vitest run src/test-kernel/cli` — 149 test files, 2006 passed / 4 skipped (pre-existing skips, unrelated to this change).

---
_Generated by [Claude Code](https://claude.ai/code/session_012KcbtxxWaXM8ab659WCyfM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor only; same concurrency-1 ordering guarantees for prompts and secrets writes, with no API or export changes.
> 
> **Overview**
> Replaces the banned `chain = chain.then(...)` serialization pattern with **`PQueue` (`concurrency: 1`)** in two CLI runtime modules, aligning them with existing callers such as the TUI follow-up and approval queues.
> 
> In **`approvalPolicy.ts`**, per-`CliContext` CLI approval/user prompts are queued via a lazily created `WeakMap<CliContext, PQueue>` instead of manually re-chaining a `Promise` on every enqueue. In **`cliSecrets.ts`**, secrets-file **`mutate`** operations use a `PQueue` instance instead of a `Promise<void>` mutation chain.
> 
> **Ordering and caller-facing behavior are unchanged**: one async job at a time, with a failed job not blocking subsequent work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0d6fe497f1b1fc5efd5c5a39513de69c692da15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->