### PR TITLE
Reduce data-structure duplication flagged by design audit

### DIFF
--- a/packages/extension/src/schemas/texraSettings.ts
+++ b/packages/extension/src/schemas/texraSettings.ts
@@ -58,23 +58,6 @@ export const TEXRA_SETTING_KEYS = TEXRA_SETTING_PATHS.map(
 );
 const TEXRA_SETTING_KEY_SET = new Set<TexraSettingKey>(TEXRA_SETTING_KEYS);
 
-interface TexraPackageConfigurationProperty {
-  type?: string;
-  items?: unknown;
-  additionalProperties?: unknown;
-  default?: unknown;
-  enum?: unknown[];
-  minimum?: number;
-  maximum?: number;
-  [key: string]: unknown;
-}
-
-export interface TexraPackageConfigurationSection {
-  title?: string;
-  properties?: Record<string, TexraPackageConfigurationProperty>;
-  [key: string]: unknown;
-}
-
 type JsonSchemaObject = {
   type?: string;
   properties?: Record<string, JsonSchemaObject>;
@@ -88,17 +71,51 @@ type JsonSchemaObject = {
   enumDescriptions?: unknown[];
 };
 
-const GENERATED_PACKAGE_SCHEMA_FIELDS = [
-  'type',
-  'items',
-  'additionalProperties',
-  'default',
-  'enum',
-  'minimum',
-  'maximum',
-  'description',
-  'enumDescriptions',
-] as const;
+/**
+ * A single package.json configuration property: every {@link JsonSchemaObject}
+ * field except `properties` (which only appears on schema container nodes,
+ * not on a leaf setting's package.json entry), plus an index signature so an
+ * `existing` untyped package.json property can be spread in as a starting
+ * point. Derived from `JsonSchemaObject` instead of hand-duplicated so a
+ * field added there can't silently go missing here.
+ */
+type TexraPackageConfigurationProperty = Omit<
+  JsonSchemaObject,
+  'properties'
+> & {
+  [key: string]: unknown;
+};
+
+export interface TexraPackageConfigurationSection {
+  title?: string;
+  properties?: Record<string, TexraPackageConfigurationProperty>;
+  [key: string]: unknown;
+}
+
+type GeneratedSchemaField = Exclude<keyof JsonSchemaObject, 'properties'>;
+
+/**
+ * Every field this module regenerates from the Zod-derived JSON schema, as a
+ * `Record` rather than a hand-typed array literal: adding a field to
+ * {@link JsonSchemaObject} makes this object fail to type-check until the new
+ * field is listed here, so the two can't drift out of sync silently.
+ */
+const GENERATED_PACKAGE_SCHEMA_FIELD_FLAGS: Record<GeneratedSchemaField, true> =
+  {
+    type: true,
+    items: true,
+    additionalProperties: true,
+    default: true,
+    enum: true,
+    minimum: true,
+    maximum: true,
+    description: true,
+    enumDescriptions: true,
+  };
+
+const GENERATED_PACKAGE_SCHEMA_FIELDS = Object.keys(
+  GENERATED_PACKAGE_SCHEMA_FIELD_FLAGS,
+) as GeneratedSchemaField[];
 
 let texraSettingsJsonSchema: JsonSchemaObject | undefined;
 let parsedDefaultTexraSettings: TexraSettings | undefined;

--- a/src/agent/modelHandlers/openai/modelHandlerCodex.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerCodex.ts
@@ -87,6 +87,13 @@ export function isGenerationRequest(url: string): boolean {
  *  otherwise. */
 export const CODEX_DEFAULT_INSTRUCTIONS = 'You are a helpful assistant.';
 
+/** Shape of one `input` array entry that {@link rewriteCodexRequestBody}
+ *  reads. Named once here instead of an inline cast per field read. */
+interface CodexInputItem {
+  role?: unknown;
+  content?: unknown;
+}
+
 /**
  * Rewrite a parsed Responses request body for the (unofficial) Codex backend.
  * Pure: returns a new top-level object and never mutates `body`, so the
@@ -142,14 +149,10 @@ export function rewriteCodexRequestBody(
   if (Array.isArray(rewritten.input)) {
     const kept: unknown[] = [];
     for (const item of rewritten.input) {
-      const role =
-        item && typeof item === 'object'
-          ? (item as { role?: unknown }).role
-          : undefined;
-      if (role === 'system' || role === 'developer') {
-        const text = partsToText(
-          (item as { content?: unknown }).content,
-        ).trim();
+      const record: CodexInputItem | undefined =
+        item && typeof item === 'object' ? (item as CodexInputItem) : undefined;
+      if (record?.role === 'system' || record?.role === 'developer') {
+        const text = partsToText(record.content).trim();
         if (
           text &&
           !instructions.some((instruction) => instruction.includes(text))

--- a/src/agent/modelHandlers/openai/modelHandlerMiniMax.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerMiniMax.ts
@@ -56,7 +56,9 @@ export class ModelHandlerMiniMax extends ReasoningModelHandlerOpenAI {
     );
 
     if (this.capabilities.supportsReasoning) {
-      (params as Record<string, unknown>).reasoning_split = true;
+      // MiniMax-only field, not part of the OpenAI SDK's typed request params.
+      (params as typeof params & { reasoning_split: boolean }).reasoning_split =
+        true;
     }
 
     return params;

--- a/src/common/errors/sdkError/chatgptSubscriptionDetection.ts
+++ b/src/common/errors/sdkError/chatgptSubscriptionDetection.ts
@@ -1,9 +1,12 @@
 import prettyMilliseconds from 'pretty-ms';
 
-import { isObject } from '@utils/core';
 import { capitalize } from '@utils/text/stringUtils';
 
-import { pickNumberField, pickStringField } from './errorInspection';
+import {
+  errorBodyCandidates,
+  pickNumberField,
+  pickStringField,
+} from './errorInspection';
 
 /**
  * Detection + formatting for the ChatGPT-subscription (Codex backend) usage
@@ -34,9 +37,7 @@ export interface ChatGptSubscriptionLimit {
 export function parseChatGptSubscriptionLimit(
   rawErrorBody: unknown,
 ): ChatGptSubscriptionLimit | null {
-  if (!isObject(rawErrorBody)) return null;
-  const candidates = [rawErrorBody, rawErrorBody.error];
-  for (const candidate of candidates) {
+  for (const candidate of errorBodyCandidates(rawErrorBody)) {
     if (pickStringField(candidate, 'type') !== 'usage_limit_reached') continue;
     return {
       planType: pickStringField(candidate, 'plan_type'),

--- a/src/common/errors/sdkError/errorInspection.ts
+++ b/src/common/errors/sdkError/errorInspection.ts
@@ -4,6 +4,16 @@ import { isObject, isString } from '@utils/core';
 
 import { pickStatus } from './sdkErrorKinds';
 
+/** Direct-or-enveloped candidate objects for a raw provider error body: the
+ *  body itself, then its nested `.error` (some SDKs preserve the full
+ *  `{ error: {...} }` envelope, others unwrap it before it reaches us).
+ *  Shared by every relay/ChatGPT-subscription/credit-depletion body detector,
+ *  each of which must check both forms. Returns `[]` for a non-object body. */
+export function errorBodyCandidates(rawErrorBody: unknown): unknown[] {
+  if (!isObject(rawErrorBody)) return [];
+  return [rawErrorBody, (rawErrorBody as { error?: unknown }).error];
+}
+
 /** Pick a non-blank string field off an error-body object. Shared by the
  *  relay/ChatGPT-subscription/credit-depletion body detectors, which all read
  *  loosely-typed provider JSON. */
@@ -46,12 +56,25 @@ export function getErrorClassNames(err: unknown): string[] {
   return [...classNames];
 }
 
-type StatusCarrier = {
-  status?: number;
-  statusCode?: number;
-  code?: number;
-  response?: { status?: number };
-  error?: { status?: number };
+/** Field aliases across thrown SDK/provider error shapes — the only fields
+ *  `detectStatusCode`/`detectStatusText`/`detectRequestId`/`detectRawErrorBody`
+ *  read. Kept in one type so a new alias lands in a single place instead of
+ *  redeclared per detector. Nested carriers (`response`, `error`) are left
+ *  as loose records since each detector reads a different field off them. */
+type SdkErrorLike = {
+  status?: unknown;
+  statusCode?: unknown;
+  code?: unknown;
+  statusText?: unknown;
+  request_id?: unknown;
+  requestId?: unknown;
+  requestID?: unknown;
+  message?: unknown;
+  headers?: HeaderBag;
+  response?: Record<string, unknown>;
+  error?: Record<string, unknown>;
+  body?: unknown;
+  data?: unknown;
 };
 
 /** Canonical HTTP status extractor for thrown SDK/provider errors. The only
@@ -62,7 +85,7 @@ export function detectStatusCode(err: unknown): number | undefined {
     return undefined;
   }
 
-  const candidate = err as StatusCarrier;
+  const candidate = err as SdkErrorLike;
   return (
     pickStatus(candidate.status) ??
     pickStatus(candidate.statusCode) ??
@@ -77,16 +100,12 @@ export function detectStatusText(
   statusCode?: number,
 ): string | undefined {
   if (isObject(err)) {
-    const candidate = err as {
-      statusText?: string;
-      response?: { statusText?: string };
-      error?: { statusText?: string };
-    };
+    const candidate = err as SdkErrorLike;
     const explicit =
       candidate.statusText ??
       candidate.response?.statusText ??
       candidate.error?.statusText;
-    if (explicit) return explicit;
+    if (isString(explicit) && explicit) return explicit;
   }
   return statusCode ? safeGetReasonPhrase(statusCode) : undefined;
 }
@@ -175,12 +194,7 @@ function detectProviderFromText(text: string): string | undefined {
 export function detectRequestId(err: unknown): string | undefined {
   if (!isObject(err)) return undefined;
 
-  const candidate = err as {
-    request_id?: string;
-    requestId?: string;
-    requestID?: string;
-    headers?: HeaderBag;
-  };
+  const candidate = err as SdkErrorLike;
 
   const relayRequestId = getHeaderValue(
     candidate.headers,
@@ -207,13 +221,7 @@ export function detectRawErrorBody(err: unknown): unknown {
     return undefined;
   }
 
-  const candidate = err as {
-    error?: unknown;
-    body?: unknown;
-    data?: unknown;
-    response?: { data?: unknown };
-    message?: string;
-  };
+  const candidate = err as SdkErrorLike;
 
   const directBody =
     candidate.error ??
@@ -225,7 +233,7 @@ export function detectRawErrorBody(err: unknown): unknown {
   }
 
   // Google GenAI SDK may embed JSON in the error message
-  if (candidate.message && candidate.message.startsWith('{')) {
+  if (isString(candidate.message) && candidate.message.startsWith('{')) {
     return safeParseJson(candidate.message).unwrapOr(undefined);
   }
 

--- a/src/common/errors/sdkError/relayDetection.ts
+++ b/src/common/errors/sdkError/relayDetection.ts
@@ -1,7 +1,7 @@
 import { StatusCodes } from 'http-status-codes';
 import { isObject, isString } from '@utils/core';
 
-import { pickStringField } from './errorInspection';
+import { errorBodyCandidates, pickStringField } from './errorInspection';
 
 /**
  * Maps provider error type/code strings to their corresponding HTTP status
@@ -34,11 +34,9 @@ const ERROR_TYPE_OR_CODE_TO_STATUS: Record<string, number> = {
 export function inferStatusCodeFromBody(
   rawErrorBody: unknown,
 ): number | undefined {
-  if (!isObject(rawErrorBody)) {
-    return undefined;
-  }
-  const body = rawErrorBody as { error?: unknown };
-  const candidates = [body.error, rawErrorBody];
+  // Nested-first, per the docstring above (reversed from errorBodyCandidates'
+  // direct-first default).
+  const candidates = [...errorBodyCandidates(rawErrorBody)].reverse();
   for (const candidate of candidates) {
     if (!isObject(candidate)) continue;
     for (const field of ['type', 'code'] as const) {
@@ -52,26 +50,14 @@ export function inferStatusCodeFromBody(
 }
 
 export function isRelayError(rawErrorBody: unknown): boolean {
-  if (!isObject(rawErrorBody)) {
-    return false;
-  }
-  // Direct check (OpenAI/Anthropic SDKs extract the error object)
-  if ('_relay' in rawErrorBody) {
-    return true;
-  }
-  // Nested check (Google GenAI may preserve full response body)
-  const nested = (rawErrorBody as { error?: unknown }).error;
-  return isObject(nested) && '_relay' in nested;
+  return errorBodyCandidates(rawErrorBody).some(
+    (candidate) => isObject(candidate) && '_relay' in candidate,
+  );
 }
 
 function hasRelayBooleanFlag(rawErrorBody: unknown, field: string): boolean {
-  if (!isObject(rawErrorBody)) return false;
-  if ((rawErrorBody as Record<string, unknown>)[field] === true) {
-    return true;
-  }
-  const nested = (rawErrorBody as { error?: unknown }).error;
-  return (
-    isObject(nested) && (nested as Record<string, unknown>)[field] === true
+  return errorBodyCandidates(rawErrorBody).some(
+    (candidate) => isObject(candidate) && candidate[field] === true,
   );
 }
 
@@ -91,12 +77,7 @@ export function isRelayRequestLimitBody(rawErrorBody: unknown): boolean {
 export function getRelayRequestLimitReason(
   rawErrorBody: unknown,
 ): 'concurrency' | 'rate' | undefined {
-  if (!isObject(rawErrorBody)) return undefined;
-  const candidates = [
-    rawErrorBody,
-    (rawErrorBody as { error?: unknown }).error,
-  ];
-  for (const candidate of candidates) {
+  for (const candidate of errorBodyCandidates(rawErrorBody)) {
     if (!isObject(candidate)) continue;
     const reason = candidate.reason;
     if (reason === 'concurrency' || reason === 'rate') return reason;
@@ -108,12 +89,7 @@ export function getRelayRequestLimitReason(
 export function getRelayRequestLimitRetryAfterMs(
   rawErrorBody: unknown,
 ): number | undefined {
-  if (!isObject(rawErrorBody)) return undefined;
-  const candidates = [
-    rawErrorBody,
-    (rawErrorBody as { error?: unknown }).error,
-  ];
-  for (const candidate of candidates) {
+  for (const candidate of errorBodyCandidates(rawErrorBody)) {
     if (!isObject(candidate)) continue;
     const seconds = candidate.retryAfterSeconds;
     if (
@@ -129,13 +105,7 @@ export function getRelayRequestLimitRetryAfterMs(
 
 /** True only when a provider body explicitly identifies a model-scoped limit. */
 export function isModelScopedRateLimitBody(rawErrorBody: unknown): boolean {
-  if (!isObject(rawErrorBody)) return false;
-  const candidates = [
-    rawErrorBody,
-    (rawErrorBody as { error?: unknown }).error,
-  ];
-  return candidates.some((candidate) => {
-    if (!isObject(candidate)) return false;
+  return errorBodyCandidates(rawErrorBody).some((candidate) => {
     const scope =
       pickStringField(candidate, 'scope') ??
       pickStringField(candidate, 'rate_limit_scope') ??
@@ -157,13 +127,7 @@ export function isRelayMonthlyLimitMessage(
  *  part of the signal; OpenAI may report `insufficient_quota` directly.
  *  Covers both the direct format and the enveloped format. */
 export function isUpstreamCreditDepletedBody(rawErrorBody: unknown): boolean {
-  if (!isObject(rawErrorBody)) return false;
-  const candidates = [
-    rawErrorBody,
-    (rawErrorBody as { error?: unknown }).error,
-  ];
-  return candidates.some((c) => {
-    if (!isObject(c)) return false;
+  return errorBodyCandidates(rawErrorBody).some((c) => {
     const type = pickStringField(c, 'type');
     const code = pickStringField(c, 'code');
     const message = pickStringField(c, 'message')?.toLowerCase();

--- a/src/tools/zotero/ZoteroAddTool.ts
+++ b/src/tools/zotero/ZoteroAddTool.ts
@@ -223,14 +223,38 @@ const CROSSREF_TYPE_MAP: Record<string, string> = {
   other: 'document',
 };
 
+/** A Zotero Connector `saveItems` creator entry: a parsed given/family name,
+ *  or a single opaque name for organizations and unparsed CSL literals. */
+type ZoteroCreator =
+  | { firstName: string; lastName: string; creatorType: 'author' }
+  | { name: string; creatorType: 'author' };
+
+/**
+ * Canonical shape of a Zotero Connector `saveItems` item. Both `resolveDOI`
+ * (Crossref-derived) and `toZoteroItem` (manual metadata) build this same
+ * shape from different sources — sharing the type keeps a field renamed in
+ * one path from silently drifting out of sync with the other.
+ */
+interface ZoteroConnectorItem {
+  itemType: string;
+  title?: string;
+  DOI?: string;
+  url?: string;
+  creators?: ZoteroCreator[];
+  date?: string;
+  abstractNote?: string;
+  publicationTitle?: string;
+  volume?: string;
+  issue?: string;
+  pages?: string;
+}
+
 /**
  * Resolve a DOI to full metadata via the Crossref API.
  * Uses the shared CrossrefClient and rate limiter from @tools/citation.
  * Returns a Zotero-format item object, or null if resolution fails.
  */
-async function resolveDOI(
-  doi: string,
-): Promise<Record<string, unknown> | null> {
+async function resolveDOI(doi: string): Promise<ZoteroConnectorItem | null> {
   try {
     await waitForRateLimit('crossref', CROSSREF_CONSTANTS.RATE_LIMIT_DELAY_MS);
 
@@ -244,19 +268,19 @@ async function resolveDOI(
 
     const work: Work = response.content.message;
 
-    const creators = work.author?.length
+    const creators: ZoteroCreator[] | undefined = work.author?.length
       ? work.author.map((a: CslCreator) => {
           if (a.given && a.family) {
             return {
               firstName: a.given,
               lastName: a.family,
-              creatorType: 'author',
+              creatorType: 'author' as const,
             };
           }
           // name = Crossref org author, literal = CSL unparsed name
           return {
             name: a.name || a.literal || a.family || 'Unknown',
-            creatorType: 'author',
+            creatorType: 'author' as const,
           };
         })
       : undefined;
@@ -272,20 +296,20 @@ async function resolveDOI(
     const containerTitle =
       rawContainer != null ? String(rawContainer) : undefined;
 
-    return {
+    const item: ZoteroConnectorItem = {
       itemType: CROSSREF_TYPE_MAP[work.type || ''] || 'journalArticle',
-      ...(work.title?.[0] && { title: work.title[0] }),
       DOI: doi,
-      ...(creators?.length && { creators }),
-
-      ...(year != null && { date: String(year) }),
-      ...(containerTitle && { publicationTitle: containerTitle }),
-      ...(work.volume && { volume: String(work.volume) }),
-      ...(work.issue && { issue: String(work.issue) }),
-      ...(work.page && { pages: String(work.page) }),
-      ...(work.abstract && { abstractNote: work.abstract }),
-      ...(work.resource?.primary?.URL && { url: work.resource.primary.URL }),
     };
+    if (work.title?.[0]) item.title = work.title[0];
+    if (creators?.length) item.creators = creators;
+    if (year != null) item.date = String(year);
+    if (containerTitle) item.publicationTitle = containerTitle;
+    if (work.volume) item.volume = String(work.volume);
+    if (work.issue) item.issue = String(work.issue);
+    if (work.page) item.pages = String(work.page);
+    if (work.abstract) item.abstractNote = work.abstract;
+    if (work.resource?.primary?.URL) item.url = work.resource.primary.URL;
+    return item;
   } catch {
     return null;
   }
@@ -294,33 +318,36 @@ async function resolveDOI(
 /**
  * Convert our item schema to Zotero Connector format.
  */
-function toZoteroItem(item: z.infer<typeof ZoteroItemSchema>): object {
+function toZoteroItem(
+  item: z.infer<typeof ZoteroItemSchema>,
+): ZoteroConnectorItem {
   // Parse authors into Zotero creator format
-  const creators = item.authors?.length
+  const creators: ZoteroCreator[] | undefined = item.authors?.length
     ? item.authors.map((name) => {
         const parts = name.trim().split(/\s+/);
         if (parts.length === 1) {
-          return { name: parts[0], creatorType: 'author' };
+          return { name: parts[0], creatorType: 'author' as const };
         }
-        const lastName = parts.pop();
+        const lastName = parts.pop() as string;
         const firstName = parts.join(' ');
-        return { firstName, lastName, creatorType: 'author' };
+        return { firstName, lastName, creatorType: 'author' as const };
       })
     : undefined;
 
-  return {
+  const result: ZoteroConnectorItem = {
     itemType: item.itemType || 'journalArticle',
-    ...(item.title && { title: item.title }),
-    ...(item.doi && { DOI: item.doi }),
-    ...(item.url && { url: item.url }),
-    ...(creators && { creators }),
-    ...(item.year && { date: item.year }),
-    ...(item.abstract && { abstractNote: item.abstract }),
-    ...(item.publicationTitle && { publicationTitle: item.publicationTitle }),
-    ...(item.volume && { volume: item.volume }),
-    ...(item.issue && { issue: item.issue }),
-    ...(item.pages && { pages: item.pages }),
   };
+  if (item.title) result.title = item.title;
+  if (item.doi) result.DOI = item.doi;
+  if (item.url) result.url = item.url;
+  if (creators) result.creators = creators;
+  if (item.year) result.date = item.year;
+  if (item.abstract) result.abstractNote = item.abstract;
+  if (item.publicationTitle) result.publicationTitle = item.publicationTitle;
+  if (item.volume) result.volume = item.volume;
+  if (item.issue) result.issue = item.issue;
+  if (item.pages) result.pages = item.pages;
+  return result;
 }
 
 export class ZoteroAddTool extends defineTool({


### PR DESCRIPTION
## Summary

A scheduled data-structure design audit of this repo turned up 5 real instances of duplicated/hand-synced shapes and untyped casts (1 High, 2 Medium, 2 Low). This PR fixes all 5, each by naming a shared type or factoring a repeated helper — no behavior changes.

- **Zotero (High)** — `src/tools/zotero/ZoteroAddTool.ts`: `resolveDOI` (Crossref-derived) and `toZoteroItem` (manual metadata) each hand-built the same conceptual Zotero Connector item payload with no shared type, so a field rename in one path could silently drift from the other. Both now build a shared `ZoteroConnectorItem` type.
- **SDK errors (Medium)** — `src/common/errors/sdkError/{relayDetection,chatgptSubscriptionDetection,errorInspection}.ts`: the "direct-or-`.error`-enveloped" candidate-list pattern was reimplemented 7 times. Factored into one `errorBodyCandidates()` helper. Also collapsed 4 ad hoc inline candidate interfaces in `errorInspection.ts` (`StatusCarrier` + 3 anonymous types) into one `SdkErrorLike` type — as a side effect, `detectStatusText`/`detectRawErrorBody` now validate string fields with `isString()` instead of trusting an unsafe cast.
- **texraSettings (Medium)** — `packages/extension/src/schemas/texraSettings.ts`: two near-duplicate JSON-schema-property interfaces plus a third, separately hand-typed field-name array (`GENERATED_PACKAGE_SCHEMA_FIELDS`) bridging them, with no compiler check keeping the three in sync. `TexraPackageConfigurationProperty` is now derived from `JsonSchemaObject` via `Omit`, and the field list is generated from a `Record<GeneratedSchemaField, true>` — adding a field to one now fails to compile until the other is updated.
- **modelHandlerMiniMax (Low)** — replaced a blanket `Record<string, unknown>` cast (open to any string key) with a narrow `typeof params & { reasoning_split: boolean }` intersection for the one vendor-specific field being set.
- **modelHandlerCodex (Low)** — named the repeated `input` item shape once (`CodexInputItem`) instead of two separate inline `as {role?: unknown}` / `as {content?: unknown}` casts per loop iteration.

## Issue acceptance gates

No tracked issue — filed and fixed in the same session, driven by the scheduled data-structure audit's findings (1 High, 2 Medium, 2 Low; all addressed here).

## Single source of truth

- `ZoteroConnectorItem` (ZoteroAddTool.ts) — canonical Zotero Connector `saveItems` payload shape.
- `errorBodyCandidates()` (errorInspection.ts) — canonical direct-or-enveloped error-body candidate list.
- `SdkErrorLike` (errorInspection.ts) — canonical field-alias shape for thrown SDK/provider errors.
- `JsonSchemaObject` (texraSettings.ts) — canonical JSON-schema node shape; `TexraPackageConfigurationProperty` and `GeneratedSchemaField` now derive from it instead of being hand-duplicated.

## Duplication and abstraction budget

Removed: the Zotero item shape duplicated across 2 functions; the error-body candidate-list pattern duplicated across 7 call sites; 4 ad hoc overlapping SDK-error field-alias interfaces collapsed to 1; the JSON-schema-property shape duplicated across 2 interfaces plus a manually-kept field array. Added: 2 small local types (`ZoteroConnectorItem`/`ZoteroCreator`, `CodexInputItem`) and 1 shared helper (`errorBodyCandidates`) — each owns exactly the shape/invariant named above, no pass-through wrappers.

## Net elements (R6)

7 files changed, +176/-152 lines (net -24 unique-diff lines, or +7 counting the reformatted texraSettings.ts churn as net-neutral). One new exported symbol: `errorBodyCandidates` (2 external consumers: `relayDetection.ts`, `chatgptSubscriptionDetection.ts`). No new classes; 2 new small interfaces/types added (`ZoteroConnectorItem`+`ZoteroCreator`, `CodexInputItem`), 1 renamed from `interface` to derived `type` (`TexraPackageConfigurationProperty`), 3 ad hoc inline candidate types removed in favor of 1 shared `SdkErrorLike`.

## Consumer counts (R8)

No emit path or export was deleted or re-routed. `errorBodyCandidates` is newly exported with 2 immediate consumers, both updated in this PR.

## Host impact

Extension: `texraSettings.ts` change is extension-package-local; package.json configuration generation behavior is unchanged (verified by re-running typecheck + the settings-configuration test suite).

Desktop: none — no desktop-specific code touched.

CLI: none — no CLI-specific code touched.

## Scheduled refactoring

None — this was itself the scheduled-audit follow-up; no further work identified.

## Validation

- `npm run typecheck` — clean across the full workspace (core, test-kernel, extension, cli, trace-viewer, desktop).
- `npm run lint` — clean.
- `npx vitest run` (full suite) — 7946 passed, 2 pre-existing failures unrelated to this diff (`WorkflowScriptEngine.vitest.ts` QuickJS memory-timing test, `SystemUtils.vitest.ts` process-group-abort test — both reproduce on an isolated re-run and touch files this PR never modifies).
- Targeted re-runs of tests covering every touched module: `CodexRequestRewrite.vitest.ts`, `CodexEncryptedReasoning.vitest.ts`, `ChatGptSubscriptionDetection.vitest.ts`, `SdkErrorUtils.vitest.mts`, `RelayRequestLimits.vitest.ts`, `RelayModelAccess.vitest.ts`, `RelayReasoningCaps.vitest.ts`, `settingsConfiguration.vitest.ts`, `ModelFactoryRouting.vitest.ts` — all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_016r7BtTuPF9wCTx6R5ZHNsb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactoring-only typing and deduplication across error parsing, Zotero payloads, settings schema generation, and model handlers; behavior is intended unchanged aside from stricter string checks on some SDK error fields.
> 
> **Overview**
> Addresses a design-audit pass by **introducing shared types and one helper** so hand-synced shapes cannot drift, with **no intended runtime behavior changes**.
> 
> **SDK error handling** adds `errorBodyCandidates()` and routes relay, ChatGPT subscription, and related detectors through it instead of repeating direct vs `{ error: ... }` candidate lists. `SdkErrorLike` replaces several overlapping inline error-object types in `errorInspection.ts`; status text and raw-body extraction now use `isString()` on message fields.
> 
> **Zotero** defines `ZoteroConnectorItem` / `ZoteroCreator` so Crossref `resolveDOI` and manual `toZoteroItem` build the same connector payload shape.
> 
> **Extension settings** derives `TexraPackageConfigurationProperty` from `JsonSchemaObject` and drives `GENERATED_PACKAGE_SCHEMA_FIELDS` from a typed `Record` so new JSON-schema fields must be updated in one place to compile.
> 
> **Model handlers** use `CodexInputItem` in Codex request rewriting and a narrow `reasoning_split` intersection on MiniMax params instead of broad `Record<string, unknown>` casts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50e7deb0390e69e5506ce6a82778070bef056808. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->