### PR TITLE
Refactor: address top tech-debt audit findings in tools, auth, and agent flows

### DIFF
--- a/packages/cli/src/chat/tui/forms/AgentRosterForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AgentRosterForm.tsx
@@ -21,6 +21,7 @@ import {
   type AgentModePreset,
 } from '@shared/schemas/agentPresets';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import { COLOR_ERROR, COLOR_WARNING } from '../ui/colors';
 import { TICK } from '../ui/glyphs';
@@ -147,7 +148,7 @@ export function AgentRosterForm(
         setError(undefined);
       })
       .catch((reason: unknown) => {
-        setError(reason instanceof Error ? reason.message : String(reason));
+        setError(toErrorMessage(reason));
         props.onError?.(reason);
       });
   };
@@ -161,7 +162,7 @@ export function AgentRosterForm(
         refresh();
       })
       .catch((reason: unknown) => {
-        setError(reason instanceof Error ? reason.message : String(reason));
+        setError(toErrorMessage(reason));
         props.onError?.(reason);
       });
   };

--- a/packages/cli/src/runtime/supabaseAuth.ts
+++ b/packages/cli/src/runtime/supabaseAuth.ts
@@ -1,4 +1,5 @@
 // Local imports
+import { invalidateRemoteAgentsAfterSignOut } from '@agent/index';
 import { DEFAULT_OAUTH_PROVIDER, type OAuthProvider } from '@auth/config';
 import {
   refreshRemoteAgentCatalogAfterSignOut,
@@ -217,8 +218,9 @@ export async function signOutCliSupabase(): Promise<void> {
     await serverSideKeyService.setUseIncludedModelAccess(false);
   }
   serverSideKeyService.clearAllCaches({ resetQuotaFlip: true });
-  await refreshRemoteAgentCatalogAfterSignOut((message) =>
-    activeAuthLog?.warn('cli-auth', message),
+  await refreshRemoteAgentCatalogAfterSignOut(
+    invalidateRemoteAgentsAfterSignOut,
+    (message) => activeAuthLog?.warn('cli-auth', message),
   );
 }
 

--- a/packages/cli/src/runtime/supabaseAuth.ts
+++ b/packages/cli/src/runtime/supabaseAuth.ts
@@ -1,6 +1,9 @@
 // Local imports
-import { invalidateRemoteAgentsAfterSignOut } from '@agent/index';
 import { DEFAULT_OAUTH_PROVIDER, type OAuthProvider } from '@auth/config';
+import {
+  refreshRemoteAgentCatalogAfterSignOut,
+  requireOAuthRedirectUrl,
+} from '@auth/authFlowEffects';
 import { createHostAuthCoordinator } from '@auth/SupabaseAuthCoordinator';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import {
@@ -128,18 +131,14 @@ export async function signInCliSupabase(
           ...(queryParams && { queryParams }),
         },
       });
-    if (error || !data.url) {
-      throw new Error(
-        `OAuth initialization failed: ${error?.message || 'missing auth URL'}`,
-      );
-    }
+    const authUrl = requireOAuthRedirectUrl(data, error);
 
     options.signal?.throwIfAborted();
     const sessionPromise = callbackServer.waitForSession(options.signal);
-    options.onAuthUrl?.(data.url);
+    options.onAuthUrl?.(authUrl);
     if (options.openBrowser ?? true) {
       const browserLaunch = openBrowser(
-        data.url,
+        authUrl,
         options.log,
         options.manualBrowserHint ?? 'texra login --no-browser',
       );
@@ -218,12 +217,9 @@ export async function signOutCliSupabase(): Promise<void> {
     await serverSideKeyService.setUseIncludedModelAccess(false);
   }
   serverSideKeyService.clearAllCaches({ resetQuotaFlip: true });
-  await invalidateRemoteAgentsAfterSignOut().catch((error: unknown) => {
-    activeAuthLog?.warn(
-      'cli-auth',
-      `Local agent catalog refresh failed after sign-out: ${String(error)}`,
-    );
-  });
+  await refreshRemoteAgentCatalogAfterSignOut((message) =>
+    activeAuthLog?.warn('cli-auth', message),
+  );
 }
 
 /**

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -896,7 +896,7 @@ export class DesktopProgressBridge {
         await this.applyFollowUpPolishResult(result);
       },
       onPolishError: async (stream, error) => {
-        const message = error instanceof Error ? error.message : `${error}`;
+        const message = toErrorMessage(error);
         this.postToRenderer({
           command: PROGRESS_VIEW_COMMANDS.UPDATE_FOLLOW_UP_TEXT,
           stream,

--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -3,6 +3,7 @@ import { randomBytes } from 'node:crypto';
 import PQueue from 'p-queue';
 import { z } from 'zod';
 
+import { invalidateRemoteAgentsAfterSignOut } from '@agent/index';
 import {
   DEFAULT_OAUTH_PROVIDER,
   getAuthCallbackUri,
@@ -392,8 +393,9 @@ export function createDesktopSupabaseAuth(
       });
       SupabaseClient.setTokenExpiry(null);
       clearDesktopServerSideKeyCaches(log);
-      await refreshRemoteAgentCatalogAfterSignOut((message) =>
-        log.warn(message),
+      await refreshRemoteAgentCatalogAfterSignOut(
+        invalidateRemoteAgentsAfterSignOut,
+        (message) => log.warn(message),
       );
       await host.onSessionChanged();
     },

--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -3,12 +3,15 @@ import { randomBytes } from 'node:crypto';
 import PQueue from 'p-queue';
 import { z } from 'zod';
 
-import { invalidateRemoteAgentsAfterSignOut } from '@agent/index';
 import {
   DEFAULT_OAUTH_PROVIDER,
   getAuthCallbackUri,
   type OAuthProvider,
 } from '@auth/config';
+import {
+  refreshRemoteAgentCatalogAfterSignOut,
+  requireOAuthRedirectUrl,
+} from '@auth/authFlowEffects';
 import { createHostAuthCoordinator } from '@auth/SupabaseAuthCoordinator';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import {
@@ -339,14 +342,10 @@ export function createDesktopSupabaseAuth(
         provider,
         options: { redirectTo },
       });
-      if (error || !data.url) {
-        throw new Error(
-          `OAuth initialization failed: ${error?.message || 'missing auth URL'}`,
-        );
-      }
+      const authUrl = requireOAuthRedirectUrl(data, error);
       if (!ownsAttempt(generation, nonce)) return;
 
-      await host.openExternalUrl(data.url);
+      await host.openExternalUrl(authUrl);
       await host.showInfoMessage(
         'Complete sign-in in your browser. TeXRA updates automatically when it finishes.',
       );
@@ -393,11 +392,9 @@ export function createDesktopSupabaseAuth(
       });
       SupabaseClient.setTokenExpiry(null);
       clearDesktopServerSideKeyCaches(log);
-      await invalidateRemoteAgentsAfterSignOut().catch((error: unknown) => {
-        log.warn(
-          `Local agent catalog refresh failed after sign-out: ${toErrorMessage(error)}`,
-        );
-      });
+      await refreshRemoteAgentCatalogAfterSignOut((message) =>
+        log.warn(message),
+      );
       await host.onSessionChanged();
     },
 

--- a/packages/extension/src/commands/system/textEditorCommands.ts
+++ b/packages/extension/src/commands/system/textEditorCommands.ts
@@ -70,14 +70,14 @@ export async function handleTestTextEditor(): Promise<void> {
       `Created TextEditorTool instance with command: ${command}`,
     );
 
-    // Type assertion is safe because showQuickPick options match EditorCommand values
-    const input: TextEditorInput = {
-      command: command as EditorCommand,
-      path: filePath,
-    };
+    // Each branch builds its own fully-formed discriminated-union variant
+    // rather than mutating a shared object, since TextEditorInput no longer
+    // admits partial cross-command assignment.
+    let input: TextEditorInput;
 
-    switch (command) {
-      case 'view':
+    switch (command as EditorCommand) {
+      case 'view': {
+        let view_range: [number, number] | undefined;
         const useRange = await vscode.window.showQuickPick(['Yes', 'No'], {
           placeHolder: 'Specify a line range?',
         });
@@ -95,15 +95,17 @@ export async function handleTestTextEditor(): Promise<void> {
           );
 
           if (startLine && endLine) {
-            input.view_range = [
+            view_range = [
               Number.parseInt(startLine, 10),
               Number.parseInt(endLine, 10),
             ];
           }
         }
+        input = { command: 'view', path: filePath, view_range };
         break;
+      }
 
-      case 'str_replace':
+      case 'str_replace': {
         const oldStr = await vscode.window.showInputBox({
           prompt: 'Enter text to replace',
         });
@@ -117,11 +119,16 @@ export async function handleTestTextEditor(): Promise<void> {
           prompt: 'Enter replacement text',
         });
 
-        input.old_str = oldStr;
-        input.new_str = newStr ?? '';
+        input = {
+          command: 'str_replace',
+          path: filePath,
+          old_str: oldStr,
+          new_str: newStr ?? '',
+        };
         break;
+      }
 
-      case 'insert':
+      case 'insert': {
         const insertLine = await promptLineNumber(
           'Enter line number to insert at',
           'Please enter a valid line number (0 or greater)',
@@ -141,11 +148,16 @@ export async function handleTestTextEditor(): Promise<void> {
           return;
         }
 
-        input.insert_line = Number.parseInt(insertLine, 10);
-        input.new_str = textToInsert;
+        input = {
+          command: 'insert',
+          path: filePath,
+          insert_line: Number.parseInt(insertLine, 10),
+          new_str: textToInsert,
+        };
         break;
+      }
 
-      case 'create':
+      case 'create': {
         const newFilePath = await vscode.window.showInputBox({
           prompt: 'Enter path for new file (relative to workspace)',
           value: 'new_file.txt',
@@ -164,12 +176,16 @@ export async function handleTestTextEditor(): Promise<void> {
           return;
         }
 
-        input.path = newFilePath;
-        input.file_text = fileContent;
+        input = {
+          command: 'create',
+          path: newFilePath,
+          file_text: fileContent,
+        };
         break;
+      }
 
       case 'undo_edit':
-        // No additional input needed
+        input = { command: 'undo_edit', path: filePath };
         break;
 
       default:

--- a/packages/extension/src/frontend/auth/SupabaseAuthProvider.ts
+++ b/packages/extension/src/frontend/auth/SupabaseAuthProvider.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { invalidateRemoteAgentsAfterSignOut } from '@agent/index';
+import { refreshRemoteAgentCatalogAfterSignOut } from '@auth/authFlowEffects';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import {
   AUTH_BRIDGE_URL,
@@ -545,12 +545,9 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
   private async afterLocalSessionCleared(sessionId: string): Promise<void> {
     getServerSideKeyService().clearAllCaches({ resetQuotaFlip: true });
     invalidateModelOptionsCache();
-    await invalidateRemoteAgentsAfterSignOut().catch((error: unknown) => {
-      logger.warn(
-        'SupabaseAuthProvider',
-        `Local agent catalog refresh failed after sign-out: ${toErrorMessage(error)}`,
-      );
-    });
+    await refreshRemoteAgentCatalogAfterSignOut((message) =>
+      logger.warn('SupabaseAuthProvider', message),
+    );
     this._onDidChangeSessions.fire({
       added: [],
       removed: [

--- a/packages/extension/src/frontend/auth/SupabaseAuthProvider.ts
+++ b/packages/extension/src/frontend/auth/SupabaseAuthProvider.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { invalidateRemoteAgentsAfterSignOut } from '@agent/index';
 import { refreshRemoteAgentCatalogAfterSignOut } from '@auth/authFlowEffects';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import {
@@ -545,8 +546,9 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
   private async afterLocalSessionCleared(sessionId: string): Promise<void> {
     getServerSideKeyService().clearAllCaches({ resetQuotaFlip: true });
     invalidateModelOptionsCache();
-    await refreshRemoteAgentCatalogAfterSignOut((message) =>
-      logger.warn('SupabaseAuthProvider', message),
+    await refreshRemoteAgentCatalogAfterSignOut(
+      invalidateRemoteAgentsAfterSignOut,
+      (message) => logger.warn('SupabaseAuthProvider', message),
     );
     this._onDidChangeSessions.fire({
       added: [],

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -195,7 +195,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         await this.applyFollowUpPolishResult(result);
       },
       onPolishError: (stream, error) => {
-        const errorMsg = error instanceof Error ? error.message : `${error}`;
+        const errorMsg = toErrorMessage(error);
         this.postToActiveView({
           command: PROGRESS_VIEW_COMMANDS.UPDATE_FOLLOW_UP_TEXT,
           stream,

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
@@ -47,8 +47,6 @@ import {
 } from '@shared/schemas/proposalFields';
 import { WorkflowScriptFilesSchema } from '@shared/schemas/workflowScriptFiles';
 import type { ExecutionsToolInput } from '@tools/ExecutionsTool';
-import type { EditInput } from '@tools/EditTool';
-import type { TextEditorInput } from '@tools/TextEditorTool';
 import type { ReadInput } from '@tools/ReadTool';
 import type { WriteInput } from '@tools/WriteTool';
 import type {
@@ -89,10 +87,13 @@ function buildFileGroupsSection(
   );
 }
 
+/** Common shape of the edit_file and str_replace_editor tool inputs, for display purposes only. */
+type EditDiffLikeInput = { old_str?: unknown; new_str?: unknown };
+
 function buildEditDiffInputSections(ctx: ToolSectionContext): TemplateResult[] {
   const { input, filePath, parsedOutput } = ctx;
   if (!isObject(input)) return [];
-  const editInput = input as EditInput | TextEditorInput;
+  const editInput = input as EditDiffLikeInput;
   if (
     typeof editInput.old_str !== 'string' ||
     typeof editInput.new_str !== 'string'
@@ -158,8 +159,7 @@ function buildMemorySections(ctx: ToolSectionContext): TemplateResult[] {
   const { input } = ctx;
   if (!isObject(input)) return [];
   const memInput = input as MemoryToolInput;
-  const command = memInput.command;
-  const memPath = memInput.path ?? '';
+  const memPath = memInput.command === 'rename' ? '' : (memInput.path ?? '');
   const sections: TemplateResult[] = [];
 
   if (memPath) {
@@ -169,7 +169,7 @@ function buildMemorySections(ctx: ToolSectionContext): TemplateResult[] {
   }
 
   if (
-    command === 'str_replace' &&
+    memInput.command === 'str_replace' &&
     memInput.old_str != null &&
     memInput.new_str != null
   ) {
@@ -179,7 +179,7 @@ function buildMemorySections(ctx: ToolSectionContext): TemplateResult[] {
         buildEditDiffSection(memInput.old_str, memInput.new_str),
       ),
     );
-  } else if (command === 'create' && memInput.file_text != null) {
+  } else if (memInput.command === 'create' && memInput.file_text != null) {
     const contentLanguage = memPath
       ? getLanguageFromPath(memPath)
       : 'plaintext';
@@ -188,7 +188,7 @@ function buildMemorySections(ctx: ToolSectionContext): TemplateResult[] {
         language: contentLanguage,
       }),
     );
-  } else if (command === 'insert') {
+  } else if (memInput.command === 'insert') {
     const insertText = memInput.insert_text ?? memInput.new_str;
     if (insertText != null) {
       const lineLabel =
@@ -204,7 +204,7 @@ function buildMemorySections(ctx: ToolSectionContext): TemplateResult[] {
         }),
       );
     }
-  } else if (command === 'rename') {
+  } else if (memInput.command === 'rename') {
     const oldPath = memInput.old_path;
     const newPath = memInput.new_path;
     if (oldPath != null && newPath != null) {

--- a/src/agent/implementations/flows/flowLastError.ts
+++ b/src/agent/implementations/flows/flowLastError.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared by the two flow entry points (`runReflectionFlow`, `runToolUseFlow`):
+ * both re-throw their persisted `shared.lastError` as a real `Error` so
+ * `runFlowWithLifecycle` logs it and shows the user notification, attaching
+ * the full structured provider error so downstream formatters can surface
+ * statusCode, provider, etc. without sniffing the message string. The two
+ * callers construct different `Error` subclasses (ToolUseFlowError carries a
+ * partial result payload the outer catch reads back out), so only the
+ * attach-and-throw tail is shared here.
+ */
+
+import { attachProviderError } from '@common/errors/sdkErrorUtils';
+import { toProviderErrorFromRetry, type RetryErrorInfo } from '@shared/schemas';
+
+export function throwFlowLastError(
+  err: Error,
+  lastError: RetryErrorInfo,
+): never {
+  attachProviderError(err, toProviderErrorFromRetry(lastError));
+  throw err;
+}

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -20,11 +20,9 @@ import {
   PersistedFlowStateError,
   readPersistedFlowRecord,
 } from '@agent/node/persistedFlow';
-import { attachProviderError } from '@common/errors/sdkErrorUtils';
 import { LatexMediaManager } from '@latex/LatexMediaManager';
 import {
   RUN_OUTCOME,
-  toProviderErrorFromRetry,
   type AgentFileLocation,
   type RoundOutput,
   type RunOutcome,
@@ -50,6 +48,7 @@ import {
   type ReflectionFlowShared,
 } from './ReflectionFlowState';
 import { RoundPersistedFlow } from './RoundPersistedFlow';
+import { throwFlowLastError } from '../flowLastError';
 import type {
   ReflectionServices,
   WorkflowOutputPolicy,
@@ -331,12 +330,7 @@ export async function runReflectionFlow<C = unknown>(
       outcome = RUN_OUTCOME.FAILED;
       // Re-throw so runFlowWithLifecycle logs the error and shows
       // the user notification. State was already projected per-step.
-      // Attach the full structured provider error so downstream error
-      // formatters can surface statusCode, provider, etc. without
-      // sniffing the message string.
-      const err = new Error(shared.lastError.message);
-      attachProviderError(err, toProviderErrorFromRetry(shared.lastError));
-      throw err;
+      throwFlowLastError(new Error(shared.lastError.message), shared.lastError);
     }
     outcome = flowOutcome;
   } catch (error) {

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -31,18 +31,12 @@ import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
 import { resolveAgentTools } from '@agent/runtime/agentToolResolution';
 import type { ToolInjectionRegistry } from '@agent/runtime/toolInjection';
-import { attachProviderError } from '@common/errors/sdkErrorUtils';
 import {
   getRuntimeModelConfig,
   resolveRuntimeModelConfig,
 } from '@model/runtimeModelRegistry';
 import type { SubagentProgressUpdate } from '@shared/schemas';
-import {
-  RUN_OUTCOME,
-  STREAM_PHASE,
-  toProviderErrorFromRetry,
-  type RunOutcome,
-} from '@shared/schemas';
+import { RUN_OUTCOME, STREAM_PHASE, type RunOutcome } from '@shared/schemas';
 import { deriveRunOutcome } from '@shared/streams/streamStatus';
 import { getDefaultToolRegistry } from '@tools/registry';
 import {
@@ -68,6 +62,7 @@ import {
   setToolUseSharedModel,
 } from './modelSwitchState';
 import { ToolUseSessionLifecycle } from './ToolUseSessionLifecycle';
+import { throwFlowLastError } from '../flowLastError';
 import type { ToolUseServices } from './ToolUseServices';
 
 export interface RunToolUseFlowInput<
@@ -613,17 +608,13 @@ export async function runToolUseFlow<C = unknown>(
     if (shared.lastError) {
       // Re-throw so runFlowWithLifecycle logs the error and shows
       // the user notification, while preserving terminal run accounting.
-      // Attach the full structured provider error so downstream error
-      // formatters can surface statusCode, provider, etc. without
-      // sniffing the message string.
       const err = new ToolUseFlowError(shared.lastError.message, {
         outcome,
         lastResponse,
         touchedFiles,
         totalCostUsd,
       });
-      attachProviderError(err, toProviderErrorFromRetry(shared.lastError));
-      throw err;
+      throwFlowLastError(err, shared.lastError);
     }
   } finally {
     activePersistedFlow = undefined;

--- a/src/agent/index/inlineAgents.ts
+++ b/src/agent/index/inlineAgents.ts
@@ -25,6 +25,7 @@ import {
   AgentWorkflowSettingSchema,
   type AgentDefinition,
 } from '@agent/core/definition/AgentDataclass';
+import { toErrorMessage } from '@utils/errors/errorMessage';
 import { extractToolNames } from './agentYamlScanner';
 import type { AgentEntry } from './agentEntry';
 
@@ -149,10 +150,9 @@ function normalizeInlineAgent(definition: unknown): InlineAgent {
   try {
     AgentPromptSchema.parse(parsed.prompts);
   } catch (error) {
-    throw new Error(
-      `Inline agent "${parsed.name}": ${error instanceof Error ? error.message : String(error)}`,
-      { cause: error },
-    );
+    throw new Error(`Inline agent "${parsed.name}": ${toErrorMessage(error)}`, {
+      cause: error,
+    });
   }
 
   return {

--- a/src/auth/authFlowEffects.ts
+++ b/src/auth/authFlowEffects.ts
@@ -1,0 +1,46 @@
+/**
+ * Small effects shared by the three hosts' OAuth sign-in/sign-out flows
+ * (`packages/extension/src/frontend/auth/SupabaseAuthProvider.ts`,
+ * `packages/desktop/src/main/desktopSupabaseAuth.ts`,
+ * `packages/cli/src/runtime/supabaseAuth.ts`). Deliberately narrow: the
+ * broader post-auth cache-invalidation sequence differs by host (desktop
+ * routes it through its settings-IPC refresh chain, which does more than a
+ * bare cache clear) and is not safe to collapse into one call.
+ */
+
+import { invalidateRemoteAgentsAfterSignOut } from '@agent/index';
+import { toErrorMessage } from '@utils/errors/errorMessage';
+
+/**
+ * Validate a Supabase `signInWithOAuth` result, returning the redirect URL
+ * or throwing the "OAuth initialization failed" message the desktop and CLI
+ * hosts already surface verbatim on failure. The extension host keeps its
+ * own variant (a user-facing notification with a "Try again." suffix), so
+ * it isn't routed through this helper.
+ */
+export function requireOAuthRedirectUrl(
+  data: { url?: string | null },
+  error: { message: string } | null,
+): string {
+  if (error || !data.url) {
+    throw new Error(
+      `OAuth initialization failed: ${error?.message || 'missing auth URL'}`,
+    );
+  }
+  return data.url;
+}
+
+/**
+ * Best-effort remote-agent-catalog refresh after sign-out. Failures are
+ * logged through the caller's `warn`, never thrown — a stale local catalog
+ * must not block sign-out from completing.
+ */
+export async function refreshRemoteAgentCatalogAfterSignOut(
+  warn: (message: string) => void,
+): Promise<void> {
+  await invalidateRemoteAgentsAfterSignOut().catch((error: unknown) => {
+    warn(
+      `Local agent catalog refresh failed after sign-out: ${toErrorMessage(error)}`,
+    );
+  });
+}

--- a/src/auth/authFlowEffects.ts
+++ b/src/auth/authFlowEffects.ts
@@ -8,7 +8,6 @@
  * bare cache clear) and is not safe to collapse into one call.
  */
 
-import { invalidateRemoteAgentsAfterSignOut } from '@agent/index';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 /**
@@ -33,12 +32,16 @@ export function requireOAuthRedirectUrl(
 /**
  * Best-effort remote-agent-catalog refresh after sign-out. Failures are
  * logged through the caller's `warn`, never thrown — a stale local catalog
- * must not block sign-out from completing.
+ * must not block sign-out from completing. Takes the invalidation call as a
+ * parameter (rather than importing `invalidateRemoteAgentsAfterSignOut`
+ * directly from `@agent/index`) so `src/auth/` doesn't take on a dependency
+ * on the `agent` subsystem — the reverse edge is the only one baselined.
  */
 export async function refreshRemoteAgentCatalogAfterSignOut(
+  invalidateCatalog: () => Promise<void>,
   warn: (message: string) => void,
 ): Promise<void> {
-  await invalidateRemoteAgentsAfterSignOut().catch((error: unknown) => {
+  await invalidateCatalog().catch((error: unknown) => {
     warn(
       `Local agent catalog refresh failed after sign-out: ${toErrorMessage(error)}`,
     );

--- a/src/shared/schemas/toolResult.ts
+++ b/src/shared/schemas/toolResult.ts
@@ -195,8 +195,15 @@ export const ToolResultSchema = z.discriminatedUnion('status', [
 export type ToolResult = z.infer<typeof ToolResultSchema>;
 
 export class ToolError extends Error {
-  constructor(message: string, options?: { cause?: unknown }) {
+  /** Brief human-facing summary carried through to the ToolResult, when set. */
+  readonly summary?: string;
+
+  constructor(
+    message: string,
+    options?: { cause?: unknown; summary?: string },
+  ) {
     super(message, options);
     this.name = 'ToolError';
+    this.summary = options?.summary;
   }
 }

--- a/src/test-kernel/cli/CliSupabaseAuth.vitest.mts
+++ b/src/test-kernel/cli/CliSupabaseAuth.vitest.mts
@@ -344,7 +344,7 @@ describe('CLI Supabase auth', () => {
     expect(mocks.authCoordinator.clearSession).toHaveBeenCalledOnce();
     expect(warn).toHaveBeenCalledWith(
       'cli-auth',
-      'Local agent catalog refresh failed after sign-out: Error: local rebuild failed',
+      'Local agent catalog refresh failed after sign-out: local rebuild failed',
     );
   });
 });

--- a/src/test-kernel/tools/MemoryTool.vitest.ts
+++ b/src/test-kernel/tools/MemoryTool.vitest.ts
@@ -86,9 +86,10 @@ describe('MemoryTool view with an omitted path', () => {
       command: 'create',
       file_text: 'body',
     });
+    expect(create.status).toBe('error');
     expect(create).toMatchObject({
       status: 'error',
-      error: 'Parameter `path` is required for command: create',
+      error: expect.stringContaining('path'),
     });
   });
 });

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -671,26 +671,21 @@ Use action: "subscribe" on /executions/{id} to receive future status and termina
     const callerStreamId = getRunContextStreamId(ctx);
 
     if (getRunContextExecutionId(ctx) === executionId) {
-      return {
-        status: 'error',
-        error: `Cannot kill your own execution (${executionId}).`,
-      };
+      throw new ToolError(`Cannot kill your own execution (${executionId}).`);
     }
 
     const target = currentSession().executions.getHandle(executionId);
     if (!target) {
-      return {
-        status: 'error',
-        error: `Execution ${executionId} not found or already completed.`,
-      };
+      throw new ToolError(
+        `Execution ${executionId} not found or already completed.`,
+      );
     }
 
     // Scope: can only kill your own children. Deny if no context.
     if (!callerStreamId || target.parentStreamId !== callerStreamId) {
-      return {
-        status: 'error',
-        error: `Cannot kill execution ${executionId}: not a child of this session.`,
-      };
+      throw new ToolError(
+        `Cannot kill execution ${executionId}: not a child of this session.`,
+      );
     }
 
     // Only block subagent kills when the toggle is disabled; process kills are always allowed.
@@ -701,11 +696,9 @@ Use action: "subscribe" on /executions/{id} to receive future status and termina
         true,
       )
     ) {
-      return {
-        status: 'error',
-        error:
-          'Killing subagents is disabled. Enable it in Settings > Multi-Agent.',
-      };
+      throw new ToolError(
+        'Killing subagents is disabled. Enable it in Settings > Multi-Agent.',
+      );
     }
 
     const success = currentSession().executions.kill(executionId, {
@@ -717,10 +710,7 @@ Use action: "subscribe" on /executions/{id} to receive future status and termina
         output: `Execution ${executionId} terminated.`,
       };
     }
-    return {
-      status: 'error',
-      error: `Execution ${executionId} could not be terminated.`,
-    };
+    throw new ToolError(`Execution ${executionId} could not be terminated.`);
   }
 
   private handleSubscribe(executionId: ExecutionId): ToolResult {

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -130,8 +130,16 @@ class ExecutionFileHistory {
   }
 }
 
+// Branches use looseObject (not strictObject): after flattenTopLevelUnion()
+// merges every branch's properties into one JSON schema for OpenAI/Gemini/
+// Anthropic tool-calling, some OpenAI-compatible providers (DeepSeek, Kimi,
+// ...) fill every advertised property — including ones only relevant to a
+// different command — with null rather than omitting them. A strictObject
+// branch rejects that as an unrecognized key regardless of nullability;
+// looseObject tolerates the cross-branch leakage while still enforcing each
+// branch's own required fields. See AGENTS.md "Tool input schemas".
 const TextEditorInputSchema = z.discriminatedUnion('command', [
-  z.strictObject({
+  z.looseObject({
     command: z.literal('view'),
     path: z.string(),
     view_range: z
@@ -140,24 +148,24 @@ const TextEditorInputSchema = z.discriminatedUnion('command', [
       .nullish()
       .describe('1-indexed. Use -1 for EOF.'),
   }),
-  z.strictObject({
+  z.looseObject({
     command: z.literal('create'),
     path: z.string(),
     file_text: z.string(),
   }),
-  z.strictObject({
+  z.looseObject({
     command: z.literal('str_replace'),
     path: z.string(),
     old_str: z.string(),
     new_str: z.string().nullish(),
   }),
-  z.strictObject({
+  z.looseObject({
     command: z.literal('insert'),
     path: z.string(),
     insert_line: z.number().describe('1-indexed.'),
     new_str: z.string(),
   }),
-  z.strictObject({
+  z.looseObject({
     command: z.literal('undo_edit'),
     path: z.string(),
   }),

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -35,7 +35,6 @@ import {
   resolveAndFormat,
   currentToolRoot,
 } from './pathResolution';
-import { requireField } from './utils';
 
 // Constants
 const CHANNEL = 'TextEditorTool';
@@ -131,19 +130,38 @@ class ExecutionFileHistory {
   }
 }
 
-const TextEditorInputSchema = z.strictObject({
-  command: z.enum(['view', 'create', 'str_replace', 'insert', 'undo_edit']),
-  path: z.string(),
-  file_text: z.string().nullish(),
-  view_range: z
-    .array(z.number())
-    .length(2)
-    .nullish()
-    .describe('1-indexed. Use -1 for EOF.'),
-  old_str: z.string().nullish(),
-  new_str: z.string().nullish(),
-  insert_line: z.number().nullish().describe('1-indexed.'),
-});
+const TextEditorInputSchema = z.discriminatedUnion('command', [
+  z.strictObject({
+    command: z.literal('view'),
+    path: z.string(),
+    view_range: z
+      .array(z.number())
+      .length(2)
+      .nullish()
+      .describe('1-indexed. Use -1 for EOF.'),
+  }),
+  z.strictObject({
+    command: z.literal('create'),
+    path: z.string(),
+    file_text: z.string(),
+  }),
+  z.strictObject({
+    command: z.literal('str_replace'),
+    path: z.string(),
+    old_str: z.string(),
+    new_str: z.string().nullish(),
+  }),
+  z.strictObject({
+    command: z.literal('insert'),
+    path: z.string(),
+    insert_line: z.number().describe('1-indexed.'),
+    new_str: z.string(),
+  }),
+  z.strictObject({
+    command: z.literal('undo_edit'),
+    path: z.string(),
+  }),
+]);
 
 /** Derived from TextEditorInputSchema - single source of truth */
 export type TextEditorInput = z.infer<typeof TextEditorInputSchema>;
@@ -206,31 +224,31 @@ export class TextEditorTool extends defineTool({
     switch (command) {
       case 'view':
         return this.view(filePath, displayPath, input.view_range ?? undefined);
-      case 'create': {
-        const fileText = requireField(input.file_text, 'file_text', command);
+      case 'create':
         logger.info(CHANNEL, `create: ${displayPath}`);
-        return this.create(filePath, displayPath, fileText);
-      }
-      case 'str_replace': {
-        const oldStr = requireField(input.old_str, 'old_str', command);
-        logger.info(CHANNEL, `str_replace: ${oldStr} -> ${input.new_str}`);
+        return this.create(filePath, displayPath, input.file_text);
+      case 'str_replace':
+        logger.info(
+          CHANNEL,
+          `str_replace: ${input.old_str} -> ${input.new_str}`,
+        );
         return this.strReplace(
           filePath,
           displayPath,
-          oldStr,
+          input.old_str,
           input.new_str ?? '',
         );
-      }
-      case 'insert': {
-        const insertLine = requireField(
-          input.insert_line,
-          'insert_line',
-          command,
+      case 'insert':
+        logger.info(
+          CHANNEL,
+          `insert: ${input.insert_line} -> ${input.new_str}`,
         );
-        const newStr = requireField(input.new_str, 'new_str', command);
-        logger.info(CHANNEL, `insert: ${insertLine} -> ${newStr}`);
-        return this.insert(filePath, displayPath, insertLine, newStr);
-      }
+        return this.insert(
+          filePath,
+          displayPath,
+          input.insert_line,
+          input.new_str,
+        );
       case 'undo_edit':
         // Claude 4 models don't support undo_edit command
         if (this.apiType === 'text_editor_20250429') {

--- a/src/tools/core/base.ts
+++ b/src/tools/core/base.ts
@@ -59,27 +59,10 @@ export abstract class BaseTool<T> implements ITool {
    */
   async call(rawInput: unknown): Promise<ToolResult> {
     try {
-      // Strip null-valued keys from object inputs before validation. Providers
-      // that null-fill every known field across discriminated-union variants
-      // (OpenAI-compatible APIs) will otherwise trip z.strictObject rejections
-      // for keys that belong to other variants. Null ↔ undefined are equivalent
-      // under the repo's .nullish() convention.
-      const input =
-        rawInput !== null &&
-        typeof rawInput === 'object' &&
-        !Array.isArray(rawInput)
-          ? (() => {
-              const sanitized = { ...(rawInput as Record<string, unknown>) };
-              for (const key of Object.keys(sanitized)) {
-                if (sanitized[key] === null) delete sanitized[key];
-              }
-              return sanitized;
-            })()
-          : rawInput;
-      const validated = this.validate(input);
-      const parsed = validated instanceof Promise ? await validated : validated;
+      const validated = this.validate(rawInput);
+      const input = validated instanceof Promise ? await validated : validated;
       // await is required here - without it, rejections bypass the catch block
-      return await this.execute(parsed);
+      return await this.execute(input);
     } catch (err) {
       if (err instanceof ZodError) {
         return {

--- a/src/tools/core/base.ts
+++ b/src/tools/core/base.ts
@@ -59,10 +59,27 @@ export abstract class BaseTool<T> implements ITool {
    */
   async call(rawInput: unknown): Promise<ToolResult> {
     try {
-      const validated = this.validate(rawInput);
-      const input = validated instanceof Promise ? await validated : validated;
+      // Strip null-valued keys from object inputs before validation. Providers
+      // that null-fill every known field across discriminated-union variants
+      // (OpenAI-compatible APIs) will otherwise trip z.strictObject rejections
+      // for keys that belong to other variants. Null ↔ undefined are equivalent
+      // under the repo's .nullish() convention.
+      const input =
+        rawInput !== null &&
+        typeof rawInput === 'object' &&
+        !Array.isArray(rawInput)
+          ? (() => {
+              const sanitized = { ...(rawInput as Record<string, unknown>) };
+              for (const key of Object.keys(sanitized)) {
+                if (sanitized[key] === null) delete sanitized[key];
+              }
+              return sanitized;
+            })()
+          : rawInput;
+      const validated = this.validate(input);
+      const parsed = validated instanceof Promise ? await validated : validated;
       // await is required here - without it, rejections bypass the catch block
-      return await this.execute(input);
+      return await this.execute(parsed);
     } catch (err) {
       if (err instanceof ZodError) {
         return {

--- a/src/tools/core/base.ts
+++ b/src/tools/core/base.ts
@@ -7,6 +7,7 @@ import type { ToolDefinition } from '@model/ToolDefinition';
 import {
   DIAGNOSTIC_TYPE_VALIDATION_ERROR,
   formatZodIssuesForDiagnostics,
+  ToolError,
   type ToolResult,
 } from '@shared/schemas/toolResult';
 import { toErrorMessage } from '@utils/errors/errorMessage';
@@ -77,9 +78,11 @@ export abstract class BaseTool<T> implements ITool {
       const message = toErrorMessage(err).trim();
       // Only include error name - stack traces waste tokens and aren't actionable by models
       const diagnostics = err instanceof Error ? { name: err.name } : undefined;
+      const summary = err instanceof ToolError ? err.summary : undefined;
       return {
         status: 'error',
         error: message || 'Tool execution failed.',
+        ...(summary !== undefined ? { summary } : {}),
         ...(diagnostics !== undefined ? { diagnostics } : {}),
       };
     }

--- a/src/tools/lean/LspTools.ts
+++ b/src/tools/lean/LspTools.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import type { ToolResult } from '@shared/schemas/toolResult';
+import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { defineTool } from '@tools/core/define';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { formatResultCount } from '@utils/text/stringUtils';
@@ -165,11 +165,10 @@ Tips:
         diagnostics: { ...baseDiagnostics, details: diagnostics },
       };
     } catch (error) {
-      return {
-        status: 'error',
-        summary: 'Failed to get diagnostics',
-        error: `Error: ${toErrorMessage(error)}\n\nIn VS Code: install the Lean 4 extension (leanprover.lean4). In CLI/desktop: install elan so that \`lake\` is on PATH, and make sure the file is inside a Lake project (lakefile.lean / lakefile.toml).`,
-      };
+      throw new ToolError(
+        `Error: ${toErrorMessage(error)}\n\nIn VS Code: install the Lean 4 extension (leanprover.lean4). In CLI/desktop: install elan so that \`lake\` is on PATH, and make sure the file is inside a Lake project (lakefile.lean / lakefile.toml).`,
+        { cause: error, summary: 'Failed to get diagnostics' },
+      );
     }
   }
 }
@@ -207,11 +206,10 @@ Requires: Lean 4 VS Code extension installed and active.`,
         output: `Executed "${command}" on ${file}`,
       };
     } catch (error) {
-      return {
-        status: 'error',
+      throw new ToolError(`Error: ${toErrorMessage(error)}`, {
+        cause: error,
         summary: 'Command failed',
-        error: `Error: ${toErrorMessage(error)}`,
-      };
+      });
     }
   }
 }
@@ -260,11 +258,13 @@ In VS Code, these commands use the Lean 4 extension. CLI and desktop provide the
         output: `Executed "${command}" successfully`,
       };
     } catch (error) {
-      return {
-        status: 'error',
-        summary: 'Command failed',
-        error: `Error executing "${command}": ${toErrorMessage(error)}`,
-      };
+      throw new ToolError(
+        `Error executing "${command}": ${toErrorMessage(error)}`,
+        {
+          cause: error,
+          summary: 'Command failed',
+        },
+      );
     }
   }
 }
@@ -304,11 +304,10 @@ Requires: Lean 4 VS Code extension installed and active.`,
           return this.executeHover(file, line0, col0, location);
       }
     } catch (error) {
-      return {
-        status: 'error',
+      throw new ToolError(`Error: ${toErrorMessage(error)}`, {
+        cause: error,
         summary: `Failed to get ${type}`,
-        error: `Error: ${toErrorMessage(error)}`,
-      };
+      });
     }
   }
 

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -52,8 +52,16 @@ import {
 
 const MEMORY_PATH_DESCRIPTION = `Path under ${MEMORY_DISPLAY_ROOT} (e.g. ${MEMORY_DISPLAY_ROOT}/notes.md).`;
 
+// Branches use looseObject (not strictObject): after flattenTopLevelUnion()
+// merges every branch's properties into one JSON schema for OpenAI/Gemini/
+// Anthropic tool-calling, some OpenAI-compatible providers (DeepSeek, Kimi,
+// ...) fill every advertised property — including ones only relevant to a
+// different command — with null rather than omitting them. A strictObject
+// branch rejects that as an unrecognized key regardless of nullability;
+// looseObject tolerates the cross-branch leakage while still enforcing each
+// branch's own required fields. See AGENTS.md "Tool input schemas".
 const MemoryToolInputSchema = z.discriminatedUnion('command', [
-  z.strictObject({
+  z.looseObject({
     command: z.literal('view'),
     path: z
       .string()
@@ -80,44 +88,46 @@ const MemoryToolInputSchema = z.discriminatedUnion('command', [
         'Max entries to return from directory listing. Default: 100, max: 200.',
       ),
   }),
-  z.strictObject({
+  z.looseObject({
     command: z.literal('create'),
     path: z.string().describe(MEMORY_PATH_DESCRIPTION),
     file_text: z.string(),
   }),
-  z.strictObject({
+  z.looseObject({
     command: z.literal('str_replace'),
     path: z.string().describe(MEMORY_PATH_DESCRIPTION),
     old_str: z.string(),
     new_str: z.string(),
   }),
-  z.strictObject({
-    command: z.literal('insert'),
-    path: z.string().describe(MEMORY_PATH_DESCRIPTION),
-    insert_line: z.int().min(0),
-    insert_text: z
-      .string()
-      .nullish()
-      .describe('Text to insert. Aliased by `new_str` if omitted.'),
-    new_str: z.string().nullish(),
-  }).refine((data) => data.insert_text != null || data.new_str != null, {
-    message: 'insert_text is required for command="insert".',
-    path: ['insert_text'],
-  }),
-  z.strictObject({
+  z
+    .looseObject({
+      command: z.literal('insert'),
+      path: z.string().describe(MEMORY_PATH_DESCRIPTION),
+      insert_line: z.int().min(0),
+      insert_text: z
+        .string()
+        .nullish()
+        .describe('Text to insert. Aliased by `new_str` if omitted.'),
+      new_str: z.string().nullish(),
+    })
+    .refine((data) => data.insert_text != null || data.new_str != null, {
+      message: 'insert_text is required for command="insert".',
+      path: ['insert_text'],
+    }),
+  z.looseObject({
     command: z.literal('delete'),
     path: z.string().describe(MEMORY_PATH_DESCRIPTION),
   }),
-  z.strictObject({
+  z.looseObject({
     command: z.literal('rename'),
     old_path: z.string().describe(MEMORY_PATH_DESCRIPTION),
     new_path: z.string().describe(MEMORY_PATH_DESCRIPTION),
   }),
-  z.strictObject({
+  z.looseObject({
     command: z.literal('pin'),
     path: z.string().describe(MEMORY_PATH_DESCRIPTION),
   }),
-  z.strictObject({
+  z.looseObject({
     command: z.literal('unpin'),
     path: z.string().describe(MEMORY_PATH_DESCRIPTION),
   }),
@@ -180,13 +190,10 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
           input.new_str,
         );
       case 'insert': {
-        // Zod .refine() guarantees at least one is non-null; `new_str` is the
-        // canonical field for TextEditorTool parity, `insert_text` is an alias.
-        return this.insert(
-          locate(input.path),
-          input.insert_line,
-          input.insert_text ?? input.new_str!,
-        );
+        // Schema-enforced: the branch's .refine() rejects insert_text and
+        // new_str both being absent before execute() is ever reached.
+        const insertText = (input.insert_text ?? input.new_str)!;
+        return this.insert(locate(input.path), input.insert_line, insertText);
       }
       case 'delete':
         return this.delete(locate(input.path));
@@ -294,10 +301,10 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
         limit,
       );
 
-      const header = `Contents of ${inputPath} (showing ${start}–${end} of ${total}, up to 2 levels deep):`;
+      const header = `Contents of ${inputPath} (showing ${start}\u2013${end} of ${total}, up to 2 levels deep):`;
       return {
         status: 'executed',
-        summary: `Listed directory: ${inputPath} (${start}–${end} of ${total})`,
+        summary: `Listed directory: ${inputPath} (${start}\u2013${end} of ${total})`,
         output: `${header}\nSIZE\tMODIFIED\tBY\tPATH\n${page.join('\n')}${formatPaginationHint(end, total)}`,
       };
     }

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -32,7 +32,6 @@ import {
   paginateToolListing,
   ViewRangeSchema,
 } from '../formatting';
-import { requireField } from '../utils';
 import {
   MAX_VIEW_LINES,
   MAX_PINNED_MEMORIES,
@@ -51,51 +50,75 @@ import {
   type MemoryFileMeta,
 } from './memoryMeta';
 
-const MemoryToolInputSchema = z.strictObject({
-  command: z.enum([
-    'view',
-    'create',
-    'str_replace',
-    'insert',
-    'delete',
-    'rename',
-    'pin',
-    'unpin',
-  ]),
-  path: z
-    .string()
-    .nullish()
-    .describe(
-      `Path under ${MEMORY_DISPLAY_ROOT} (e.g. ${MEMORY_DISPLAY_ROOT}/notes.md). Required for every command except \`view\` (which defaults to the ${MEMORY_DISPLAY_ROOT} root directory listing when omitted) and \`rename\` (which uses \`old_path\`/\`new_path\` instead).`,
-    ),
-  file_text: z.string().nullish(),
-  view_range: ViewRangeSchema.nullish(),
-  old_str: z.string().nullish(),
-  new_str: z.string().nullish(),
-  insert_line: z.int().min(0).nullish(),
-  insert_text: z.string().nullish(),
-  old_path: z.string().nullish(),
-  new_path: z.string().nullish(),
+const MEMORY_PATH_DESCRIPTION = `Path under ${MEMORY_DISPLAY_ROOT} (e.g. ${MEMORY_DISPLAY_ROOT}/notes.md).`;
 
-  /** Zero-based offset for paginating directory listings (command="view" on a directory). */
-  offset: z
-    .int()
-    .min(0)
-    .nullish()
-    .describe(
-      'Zero-based offset into the directory listing. Use with limit for pagination. Default: 0.',
-    ),
-
-  /** Maximum entries to return from a directory listing (command="view" on a directory). */
-  limit: z
-    .int()
-    .min(1)
-    .max(200)
-    .nullish()
-    .describe(
-      'Max entries to return from directory listing. Default: 100, max: 200.',
-    ),
-});
+const MemoryToolInputSchema = z.discriminatedUnion('command', [
+  z.strictObject({
+    command: z.literal('view'),
+    path: z
+      .string()
+      .nullish()
+      .describe(
+        `${MEMORY_PATH_DESCRIPTION} Defaults to the ${MEMORY_DISPLAY_ROOT} root directory listing when omitted.`,
+      ),
+    view_range: ViewRangeSchema.nullish(),
+    /** Zero-based offset for paginating directory listings (path points to a directory). */
+    offset: z
+      .int()
+      .min(0)
+      .nullish()
+      .describe(
+        'Zero-based offset into the directory listing. Use with limit for pagination. Default: 0.',
+      ),
+    /** Maximum entries to return from a directory listing (path points to a directory). */
+    limit: z
+      .int()
+      .min(1)
+      .max(200)
+      .nullish()
+      .describe(
+        'Max entries to return from directory listing. Default: 100, max: 200.',
+      ),
+  }),
+  z.strictObject({
+    command: z.literal('create'),
+    path: z.string().describe(MEMORY_PATH_DESCRIPTION),
+    file_text: z.string(),
+  }),
+  z.strictObject({
+    command: z.literal('str_replace'),
+    path: z.string().describe(MEMORY_PATH_DESCRIPTION),
+    old_str: z.string(),
+    new_str: z.string(),
+  }),
+  z.strictObject({
+    command: z.literal('insert'),
+    path: z.string().describe(MEMORY_PATH_DESCRIPTION),
+    insert_line: z.int().min(0),
+    insert_text: z
+      .string()
+      .nullish()
+      .describe('Text to insert. Aliased by `new_str` if omitted.'),
+    new_str: z.string().nullish(),
+  }),
+  z.strictObject({
+    command: z.literal('delete'),
+    path: z.string().describe(MEMORY_PATH_DESCRIPTION),
+  }),
+  z.strictObject({
+    command: z.literal('rename'),
+    old_path: z.string().describe(MEMORY_PATH_DESCRIPTION),
+    new_path: z.string().describe(MEMORY_PATH_DESCRIPTION),
+  }),
+  z.strictObject({
+    command: z.literal('pin'),
+    path: z.string().describe(MEMORY_PATH_DESCRIPTION),
+  }),
+  z.strictObject({
+    command: z.literal('unpin'),
+    path: z.string().describe(MEMORY_PATH_DESCRIPTION),
+  }),
+]);
 
 /** Derived from MemoryToolInputSchema - single source of truth */
 export type MemoryToolInput = z.infer<typeof MemoryToolInputSchema>;
@@ -129,13 +152,8 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
     // Normalize a raw display path into a `{ display, storage }` pair at the
     // dispatch boundary so ops never need to call `resolveMemoryPath`
     // themselves. Throws ToolError if the path is outside `/memories`.
-    const locate = (
-      raw: string | undefined | null,
-      field: string,
-    ): MemoryLocation => {
-      const storage = this.resolveMemoryPath(
-        requireField(raw, field, input.command),
-      );
+    const locate = (raw: string): MemoryLocation => {
+      const storage = this.resolveMemoryPath(raw);
       return { display: toDisplayPath(storage), storage };
     };
 
@@ -145,45 +163,34 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
         // /memories instead of erroring - the model's first call in a
         // fresh session is reliably a bare `view` with no path.
         return this.view(
-          locate(input.path ?? MEMORY_DISPLAY_ROOT, 'path'),
+          locate(input.path ?? MEMORY_DISPLAY_ROOT),
           input.view_range ?? undefined,
           input.offset ?? 0,
           input.limit ?? 100,
         );
       case 'create':
-        return this.create(
-          locate(input.path, 'path'),
-          requireField(input.file_text, 'file_text', input.command),
-        );
+        return this.create(locate(input.path), input.file_text);
       case 'str_replace':
         return this.strReplace(
-          locate(input.path, 'path'),
-          requireField(input.old_str, 'old_str', input.command),
-          requireField(input.new_str, 'new_str', input.command),
+          locate(input.path),
+          input.old_str,
+          input.new_str,
         );
-      case 'insert':
-        return this.insert(
-          locate(input.path, 'path'),
-          requireField(input.insert_line, 'insert_line', input.command),
-          requireField(
-            input.insert_text ?? input.new_str,
-            'insert_text',
-            input.command,
-          ),
-        );
+      case 'insert': {
+        const insertText = input.insert_text ?? input.new_str;
+        if (insertText == null) {
+          throw new ToolError('insert_text is required for command="insert".');
+        }
+        return this.insert(locate(input.path), input.insert_line, insertText);
+      }
       case 'delete':
-        return this.delete(locate(input.path, 'path'));
+        return this.delete(locate(input.path));
       case 'rename':
-        return this.rename(
-          locate(input.old_path, 'old_path'),
-          locate(input.new_path, 'new_path'),
-        );
+        return this.rename(locate(input.old_path), locate(input.new_path));
       case 'pin':
-        return this.pin(locate(input.path, 'path'));
+        return this.pin(locate(input.path));
       case 'unpin':
-        return this.unpin(locate(input.path, 'path'));
-      default:
-        throw new ToolError(`Unrecognized command: ${input.command}`);
+        return this.unpin(locate(input.path));
     }
   }
 

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -52,16 +52,8 @@ import {
 
 const MEMORY_PATH_DESCRIPTION = `Path under ${MEMORY_DISPLAY_ROOT} (e.g. ${MEMORY_DISPLAY_ROOT}/notes.md).`;
 
-// Branches use looseObject (not strictObject): after flattenTopLevelUnion()
-// merges every branch's properties into one JSON schema for OpenAI/Gemini/
-// Anthropic tool-calling, some OpenAI-compatible providers (DeepSeek, Kimi,
-// ...) fill every advertised property — including ones only relevant to a
-// different command — with null rather than omitting them. A strictObject
-// branch rejects that as an unrecognized key regardless of nullability;
-// looseObject tolerates the cross-branch leakage while still enforcing each
-// branch's own required fields. See AGENTS.md "Tool input schemas".
 const MemoryToolInputSchema = z.discriminatedUnion('command', [
-  z.looseObject({
+  z.strictObject({
     command: z.literal('view'),
     path: z
       .string()
@@ -88,46 +80,44 @@ const MemoryToolInputSchema = z.discriminatedUnion('command', [
         'Max entries to return from directory listing. Default: 100, max: 200.',
       ),
   }),
-  z.looseObject({
+  z.strictObject({
     command: z.literal('create'),
     path: z.string().describe(MEMORY_PATH_DESCRIPTION),
     file_text: z.string(),
   }),
-  z.looseObject({
+  z.strictObject({
     command: z.literal('str_replace'),
     path: z.string().describe(MEMORY_PATH_DESCRIPTION),
     old_str: z.string(),
     new_str: z.string(),
   }),
-  z
-    .looseObject({
-      command: z.literal('insert'),
-      path: z.string().describe(MEMORY_PATH_DESCRIPTION),
-      insert_line: z.int().min(0),
-      insert_text: z
-        .string()
-        .nullish()
-        .describe('Text to insert. Aliased by `new_str` if omitted.'),
-      new_str: z.string().nullish(),
-    })
-    .refine((data) => data.insert_text != null || data.new_str != null, {
-      message: 'insert_text is required for command="insert".',
-      path: ['insert_text'],
-    }),
-  z.looseObject({
+  z.strictObject({
+    command: z.literal('insert'),
+    path: z.string().describe(MEMORY_PATH_DESCRIPTION),
+    insert_line: z.int().min(0),
+    insert_text: z
+      .string()
+      .nullish()
+      .describe('Text to insert. Aliased by `new_str` if omitted.'),
+    new_str: z.string().nullish(),
+  }).refine((data) => data.insert_text != null || data.new_str != null, {
+    message: 'insert_text is required for command="insert".',
+    path: ['insert_text'],
+  }),
+  z.strictObject({
     command: z.literal('delete'),
     path: z.string().describe(MEMORY_PATH_DESCRIPTION),
   }),
-  z.looseObject({
+  z.strictObject({
     command: z.literal('rename'),
     old_path: z.string().describe(MEMORY_PATH_DESCRIPTION),
     new_path: z.string().describe(MEMORY_PATH_DESCRIPTION),
   }),
-  z.looseObject({
+  z.strictObject({
     command: z.literal('pin'),
     path: z.string().describe(MEMORY_PATH_DESCRIPTION),
   }),
-  z.looseObject({
+  z.strictObject({
     command: z.literal('unpin'),
     path: z.string().describe(MEMORY_PATH_DESCRIPTION),
   }),
@@ -190,10 +180,13 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
           input.new_str,
         );
       case 'insert': {
-        // Schema-enforced: the branch's .refine() rejects insert_text and
-        // new_str both being absent before execute() is ever reached.
-        const insertText = (input.insert_text ?? input.new_str)!;
-        return this.insert(locate(input.path), input.insert_line, insertText);
+        // Zod .refine() guarantees at least one is non-null; `new_str` is the
+        // canonical field for TextEditorTool parity, `insert_text` is an alias.
+        return this.insert(
+          locate(input.path),
+          input.insert_line,
+          input.insert_text ?? input.new_str!,
+        );
       }
       case 'delete':
         return this.delete(locate(input.path));
@@ -301,10 +294,10 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
         limit,
       );
 
-      const header = `Contents of ${inputPath} (showing ${start}\u2013${end} of ${total}, up to 2 levels deep):`;
+      const header = `Contents of ${inputPath} (showing ${start}–${end} of ${total}, up to 2 levels deep):`;
       return {
         status: 'executed',
-        summary: `Listed directory: ${inputPath} (${start}\u2013${end} of ${total})`,
+        summary: `Listed directory: ${inputPath} (${start}–${end} of ${total})`,
         output: `${header}\nSIZE\tMODIFIED\tBY\tPATH\n${page.join('\n')}${formatPaginationHint(end, total)}`,
       };
     }

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -52,8 +52,16 @@ import {
 
 const MEMORY_PATH_DESCRIPTION = `Path under ${MEMORY_DISPLAY_ROOT} (e.g. ${MEMORY_DISPLAY_ROOT}/notes.md).`;
 
+// Branches use looseObject (not strictObject): after flattenTopLevelUnion()
+// merges every branch's properties into one JSON schema for OpenAI/Gemini/
+// Anthropic tool-calling, some OpenAI-compatible providers (DeepSeek, Kimi,
+// ...) fill every advertised property — including ones only relevant to a
+// different command — with null rather than omitting them. A strictObject
+// branch rejects that as an unrecognized key regardless of nullability;
+// looseObject tolerates the cross-branch leakage while still enforcing each
+// branch's own required fields. See AGENTS.md "Tool input schemas".
 const MemoryToolInputSchema = z.discriminatedUnion('command', [
-  z.strictObject({
+  z.looseObject({
     command: z.literal('view'),
     path: z
       .string()
@@ -80,41 +88,46 @@ const MemoryToolInputSchema = z.discriminatedUnion('command', [
         'Max entries to return from directory listing. Default: 100, max: 200.',
       ),
   }),
-  z.strictObject({
+  z.looseObject({
     command: z.literal('create'),
     path: z.string().describe(MEMORY_PATH_DESCRIPTION),
     file_text: z.string(),
   }),
-  z.strictObject({
+  z.looseObject({
     command: z.literal('str_replace'),
     path: z.string().describe(MEMORY_PATH_DESCRIPTION),
     old_str: z.string(),
     new_str: z.string(),
   }),
-  z.strictObject({
-    command: z.literal('insert'),
-    path: z.string().describe(MEMORY_PATH_DESCRIPTION),
-    insert_line: z.int().min(0),
-    insert_text: z
-      .string()
-      .nullish()
-      .describe('Text to insert. Aliased by `new_str` if omitted.'),
-    new_str: z.string().nullish(),
-  }),
-  z.strictObject({
+  z
+    .looseObject({
+      command: z.literal('insert'),
+      path: z.string().describe(MEMORY_PATH_DESCRIPTION),
+      insert_line: z.int().min(0),
+      insert_text: z
+        .string()
+        .nullish()
+        .describe('Text to insert. Aliased by `new_str` if omitted.'),
+      new_str: z.string().nullish(),
+    })
+    .refine((data) => data.insert_text != null || data.new_str != null, {
+      message: 'insert_text is required for command="insert".',
+      path: ['insert_text'],
+    }),
+  z.looseObject({
     command: z.literal('delete'),
     path: z.string().describe(MEMORY_PATH_DESCRIPTION),
   }),
-  z.strictObject({
+  z.looseObject({
     command: z.literal('rename'),
     old_path: z.string().describe(MEMORY_PATH_DESCRIPTION),
     new_path: z.string().describe(MEMORY_PATH_DESCRIPTION),
   }),
-  z.strictObject({
+  z.looseObject({
     command: z.literal('pin'),
     path: z.string().describe(MEMORY_PATH_DESCRIPTION),
   }),
-  z.strictObject({
+  z.looseObject({
     command: z.literal('unpin'),
     path: z.string().describe(MEMORY_PATH_DESCRIPTION),
   }),
@@ -177,10 +190,9 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
           input.new_str,
         );
       case 'insert': {
-        const insertText = input.insert_text ?? input.new_str;
-        if (insertText == null) {
-          throw new ToolError('insert_text is required for command="insert".');
-        }
+        // Schema-enforced: the branch's .refine() rejects insert_text and
+        // new_str both being absent before execute() is ever reached.
+        const insertText = (input.insert_text ?? input.new_str)!;
         return this.insert(locate(input.path), input.insert_line, insertText);
       }
       case 'delete':

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -33,23 +33,6 @@ export function requireNonEmptyString(
 }
 
 /**
- * Validate that a field is not null/undefined for a given command.
- * Centralizes the common pattern of validating required parameters in tool execute methods.
- */
-export function requireField<T>(
-  value: T | null | undefined,
-  fieldName: string,
-  command: string,
-): T {
-  if (value == null) {
-    throw new ToolError(
-      `Parameter \`${fieldName}\` is required for command: ${command}`,
-    );
-  }
-  return value;
-}
-
-/**
  * Wrap an async API call and convert any error to a ToolError.
  * Simplifies the common try-catch-rethrow-as-ToolError pattern.
  * ToolErrors from nested calls pass through unwrapped so the original


### PR DESCRIPTION
## Summary

Follow-up to a scheduled tech-debt audit that identified five refactoring targets across the codebase. This PR implements the contained, low-risk items in full; the two largest/riskiest items are deliberately deferred (see below) after investigation showed they'd require either unsafe cross-subsystem coupling or a much larger, higher-risk restructuring than fits a single cleanup pass.

Changes:
1. **Tools** — `MemoryTool` and `TextEditorTool` converted from flat all-`.nullish()` schemas + runtime `requireField()` checks to `z.discriminatedUnion('command', [...])`, matching the pattern `PlanTool` already uses. Required fields are now enforced by Zod at validation time; the schema no longer advertises every field as valid for every command.
2. **Tools** — `ToolError` gained an optional `summary`, carried through by `BaseTool.call`, so a tool can `throw` once instead of hand-building `{status:'error', summary, error}` in a wrapping try/catch. Applied to `LspTools`' four try/catch blocks and `ExecutionsTool.handleKill`'s four early-return sites. Left `ZoteroAddTool`/`LoogleTool` alone — those build genuinely structured per-item results for partial-failure aggregation across a batch, not the boilerplate pattern this cleans up. Also replaced ~5 hand-inlined `err instanceof Error ? err.message : String(err)` sites with the existing `toErrorMessage()` helper.
3. **Auth** — extracted the two genuinely-identical pieces of the three hosts' (extension/desktop/CLI) OAuth sign-in/sign-out flows into `src/auth/authFlowEffects.ts`: the `signInWithOAuth` `error || !data.url` guard (desktop + CLI; extension keeps its own user-facing variant), and the best-effort `invalidateRemoteAgentsAfterSignOut().catch(warn)` block (all three hosts).
4. **Agent flows** — extracted the two-line "attach structured provider error, then throw" tail shared by `runReflectionFlow` and `runToolUseFlow` into `throwFlowLastError()`.

## Issue acceptance gates

Not tied to a filed issue — this is the direct output of a scheduled tech-debt-audit routine's findings (5 ranked targets), acted on in the same session. Gate: implement the contained/low-risk findings fully and verifiably; explicitly flag findings investigated and found unsafe or not worth the risk, rather than silently dropping them.

## Single source of truth

- `BaseTool.call` (`src/tools/core/base.ts`) is now the single place a thrown `ToolError` becomes a `ToolResult`, including its optional `summary`.
- `src/auth/authFlowEffects.ts` is the single source for the OAuth-init-check message and the post-sign-out catalog-refresh-and-warn sequence.
- `throwFlowLastError` (`src/agent/implementations/flows/flowLastError.ts`) is the single place a flow's persisted `lastError` becomes a thrown, provider-error-tagged `Error`.

## Duplication and abstraction budget

Removed: the `requireField` runtime-validation helper (now dead, deleted); ~9 hand-rolled try/catch-to-ToolResult blocks; 3 near-identical OAuth-init-check blocks (2 collapsed; the 3rd, extension's, correctly kept separate — it carries a distinct user-facing "Try again." message); 3 near-identical sign-out catalog-refresh-and-warn blocks; 2 near-identical attach-provider-error-and-throw tails.

No new pass-through layers. Every new export (`throwFlowLastError`, `requireOAuthRedirectUrl`, `refreshRemoteAgentCatalogAfterSignOut`) has ≥2 real callers and owns a specific invariant (respectively: "attach structured provider error before throwing a flow's terminal error", "the OAuth-init-check contract two hosts already agree on verbatim", "best-effort catalog refresh must never block sign-out").

**Investigated and deliberately not changed**, with reasoning inline in the relevant commits:
- The audit's claimed "byte-identical" persisted-flow-record bootstrap between `runReflectionFlow` and `runToolUseFlow` isn't byte-identical on inspection — reflection is a plain resume-or-fresh branch, tool-use is a three-way branch with its own migration/deep-equality handling. A shared wrapper would have to recreate that branching as parameters, which isn't simplification.
- The audit's claimed "3-way compat-key fallback duplicated at 4 sites" also doesn't hold up: only 2 of the 4 sites actually have the third fallback; the other 2 are a 2-way fallback with no equivalent. A wrapper thin enough to cover both shapes would just rename the existing `inferAndLogPersistedModelHandlerCompatibilityKey()` call.
- `interactions.cancel({streamId, cause: 'Run ended.'})` "teardown duplication" is a single-line call to a shared method from its two natural call sites, not duplication.
- The larger round/turn-loop unification (`RoundPersistedFlow` vs. the tool-use `do/while`) and the `ResponseCycleNode`/`ToolUseCycleNode` wrapper-node consolidation are real but substantially larger, higher-risk restructurings of live execution-critical code — deferred as separate, dedicated, test-guarded work rather than folded into this pass.
- The audit-proposed three-host settings/config consolidation (~900–1,300 lines) and the `modelHandlers` `createResponseImpl` untangle + 3-way compaction-cache unification (paid-API code paths) were scoped out entirely: both are large enough and touch enough live/paid-API/three-host surface that a single unsupervised pass couldn't verify them to the bar this repo holds without dedicated, incremental, test-guarded follow-up sessions.
- A full logger-idiom migration (109 files) was scoped out as too large/low-value-density for this pass despite being mechanically safe; left as a good candidate for a dedicated follow-up.

One correction made mid-PR: the first `authFlowEffects.ts` draft imported `invalidateRemoteAgentsAfterSignOut` directly from `@agent/index`, which the repo's `subsystemEdgeRatchet` test caught as a new `auth->agent` edge (only the reverse `agent->auth` is baselined — `auth` is meant to stay a lower-level subsystem). Fixed by taking the invalidation call as an injected parameter instead.

## Net elements (R6)

22 files changed, +333/−257 (net +76 lines, despite removing real duplication — the discriminated-union schemas are inherently more verbose than the flat schema + runtime checks they replace, and that verbosity is the point: it makes required-per-command fields visible in the type instead of only enforced at runtime).

Exported symbols: −1 (`requireField`, now dead and deleted) / +3 (`throwFlowLastError`, `requireOAuthRedirectUrl`, `refreshRemoteAgentCatalogAfterSignOut`) — net +2, each replacing 2–4 duplicated call sites.

## Consumer counts (R8)

n/a — no emit path or widely-subscribed export was deleted or re-routed. `requireField` had exactly 2 callers, both removed in this PR (grepped and confirmed zero remaining references before deletion).

## Host impact

**Extension:** `SupabaseAuthProvider.ts` sign-out now calls the shared `refreshRemoteAgentCatalogAfterSignOut`; its OAuth sign-in error message is unchanged (kept host-specific). `MemoryTool`/`TextEditorTool` input shape changes affect the progress-view tool-call renderer and the "test text editor" debug command (both updated).

**Desktop:** `desktopSupabaseAuth.ts` sign-in/sign-out now use the two shared auth helpers. `desktopAgentExecution.ts` gets a one-line error-message-formatting cleanup.

**CLI:** `supabaseAuth.ts` sign-in/sign-out now use the two shared auth helpers; the sign-out warning message loses a redundant "Error: " prefix (now matches extension/desktop's format) — one test updated to match. `AgentRosterForm.tsx` gets a one-line error-message-formatting cleanup.

## Scheduled refactoring

None filed. The deferred items are called out above (in "Duplication and abstraction budget") for a maintainer to decide whether to file as follow-up issues.

## Validation

- `tsc --noEmit` — root project, and each of extension/CLI/desktop's full typecheck scripts (all their sub-tsconfigs) — clean, run after every change group.
- `npm run lint` — full repo (`src`, all four `packages/*/src`) — clean.
- `npx prettier --check` — clean on every changed file.
- `node scripts/check-dead-code-ratchet.mjs` — 17/17 baseline, no new dead exports (confirms `requireField`'s deletion didn't orphan anything and nothing new went unused).
- Full `npx vitest run` (7,957 tests) — clean except 2 pre-existing environmental failures, confirmed by reproducing both identically on the unmodified tree in this sandbox: a GC-timing-threshold assertion in `WorkflowScriptEngine.vitest.ts`, and a process-group-abort test in `SystemUtils.vitest.ts` that depends on signal delivery this sandboxed container doesn't support. Neither touches any file changed in this PR.
- `subsystemEdgeRatchet.vitest.ts` (architecture-boundary ratchet) — initially caught the `auth->agent` edge described above; fixed and re-verified green.
- Targeted re-runs after each change group: `src/test-kernel/tools/` (93 files, 696 tests), auth suites (6 files, 67 tests), `src/test-kernel/agent/` (198 files, 2000 tests) — all green.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01B2EAJYV5eoiEP5gqG8MNmj

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2EAJYV5eoiEP5gqG8MNmj)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tool input schema changes affect live agent tool-calling and validation paths; auth/sign-out and flow error propagation are shared across CLI, desktop, and extension but behavior is intended to stay equivalent.
> 
> **Overview**
> **Tech-debt pass** that centralizes repeated patterns and tightens tool input validation without changing product behavior.
> 
> **Tools:** `MemoryTool` and `TextEditorTool` now use **`z.discriminatedUnion('command', …)`** with per-command `looseObject` branches (to tolerate providers that send null for unrelated fields). Runtime **`requireField`** checks are removed; the VS Code text-editor test command builds fully typed union variants per branch. **`ToolError`** gains an optional **`summary`**, propagated by **`BaseTool.call`** so tools can **`throw`** instead of hand-building error results (`ExecutionsTool.handleKill`, Lean **`LspTools`**). Progress-view formatters use a local **`EditDiffLikeInput`** and narrow on **`memInput.command`** instead of importing edit-tool types.
> 
> **Auth:** New **`src/auth/authFlowEffects.ts`** — **`requireOAuthRedirectUrl`** (CLI + desktop OAuth init) and **`refreshRemoteAgentCatalogAfterSignOut`** (all three hosts; invalidation injected to avoid **`auth→agent`** edge). Several sites switch to **`toErrorMessage`**.
> 
> **Agent flows:** Shared **`throwFlowLastError`** replaces duplicate attach-provider-error-and-throw logic in reflection and tool-use flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f57b0d91162e07dd1f24a6db50c8a2d6e079c16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->