### PR TITLE
fix(agent-runtime): make interrupt delivery level-triggered (#9435 stage 1)

### DIFF
--- a/src/agent/runtime/InterruptManager.ts
+++ b/src/agent/runtime/InterruptManager.ts
@@ -21,11 +21,15 @@ export function createInterruptCallbacks(): InterruptCallbacks {
 
   return {
     checkInterruption: () => isInterrupted,
+    // Nodes null the slot in their `finally`, so an interrupt can land while
+    // it is empty. Delivery is therefore level-triggered on both edges: the
+    // latch aborts whatever registers next, and `onInterrupt` stays callable
+    // so a second press still reaches a controller registered after the first.
     setAbortController: (controller) => {
       abortController = controller;
+      if (isInterrupted) controller?.abort();
     },
     onInterrupt: () => {
-      if (isInterrupted) return;
       isInterrupted = true;
       abortController?.abort();
     },

--- a/src/test-kernel/agent/runtime/InterruptManager.vitest.ts
+++ b/src/test-kernel/agent/runtime/InterruptManager.vitest.ts
@@ -1,0 +1,62 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports
+import { createInterruptCallbacks } from '@agent/runtime/InterruptManager';
+
+describe('createInterruptCallbacks', () => {
+  it('aborts the controller registered while the run is live', () => {
+    const callbacks = createInterruptCallbacks();
+    const controller = new AbortController();
+
+    callbacks.setAbortController(controller);
+    callbacks.onInterrupt?.();
+
+    expect(controller.signal.aborted).toBe(true);
+    expect(callbacks.checkInterruption()).toBe(true);
+  });
+
+  it('aborts the next controller when the interrupt landed on an empty slot', () => {
+    const callbacks = createInterruptCallbacks();
+
+    // Nodes null the slot in their `finally`, so the interrupt can arrive
+    // between one node releasing it and the next registering.
+    callbacks.setAbortController(null);
+    callbacks.onInterrupt?.();
+
+    const controller = new AbortController();
+    callbacks.setAbortController(controller);
+
+    expect(controller.signal.aborted).toBe(true);
+  });
+
+  it('still reaches a controller registered after a second interrupt', () => {
+    const callbacks = createInterruptCallbacks();
+
+    const first = new AbortController();
+    callbacks.setAbortController(first);
+    callbacks.onInterrupt?.();
+    callbacks.setAbortController(null);
+
+    const second = new AbortController();
+    callbacks.onInterrupt?.();
+    callbacks.setAbortController(second);
+
+    expect(first.signal.aborted).toBe(true);
+    expect(second.signal.aborted).toBe(true);
+  });
+
+  it('aborts a controller registered after the latch without a further interrupt', () => {
+    const callbacks = createInterruptCallbacks();
+    callbacks.onInterrupt?.();
+
+    const first = new AbortController();
+    callbacks.setAbortController(first);
+    callbacks.setAbortController(null);
+    const second = new AbortController();
+    callbacks.setAbortController(second);
+
+    expect(first.signal.aborted).toBe(true);
+    expect(second.signal.aborted).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #9435 (stage 1 only).

## The bug

`createInterruptCallbacks()` (`src/agent/runtime/InterruptManager.ts`) delivered
cancellation as a single edge into a single mutable `AbortController` slot:

```ts
setAbortController: (controller) => {
  abortController = controller;
},
onInterrupt: () => {
  if (isInterrupted) return;
  isInterrupted = true;
  abortController?.abort();
},
```

Nodes register a controller and null the slot in their `finally`
(`RetryState._exec`, `RetryState.withAbortController`,
`ToolUseDispatchNode._exec`, `ToolUseDispatchNode.execCall`). An interrupt that
arrives while the slot is empty aborts nothing, and the `if (isInterrupted)
return` guard consumes the abort edge permanently, so a second Stop press cannot
reach the controller that registers afterwards either. Meanwhile
`registry.terminate` sees `handle.interrupt()` return true and runs
`cancelStreamStatus`, so the UI shows CANCELLED while a fully billed model turn
keeps streaming.

## The change

Six lines in `InterruptManager.ts`. Delivery becomes level-triggered on both
edges: `setAbortController` aborts the incoming controller when the latch is
already set, and `onInterrupt` drops the early exit so it stays callable.

Repeat `onInterrupt` calls are idempotent — aborting an already-aborted
controller is a no-op, and the callback holds no other state. The queue-policy
and `interactions.cancel` work in `flowContext.interrupt()` and
`executeAgent`'s handler was already unconditional, so removing the guard does
not newly re-run anything.

## Why aborting on register is safe

I read all four registration sites first. Each creates a fresh controller for
work that must not proceed after an interrupt, so there is no legitimate
re-registration that an immediate abort would break:

- `RetryState._exec:289` — fresh controller per attempt, owns the model
  invocation. Its `abort` listener sets `_userCancelled`, which is the correct
  classification for a run interrupt.
- `RetryState.withAbortController:194` — owns a controller only when
  `this.signal` is unset; it guards `operation(signal)`, the provider request.
- `ToolUseDispatchNode._exec:178` — batch controller. The dispatch loop already
  breaks on `batchController.signal.aborted`, so an immediate abort stops the
  batch before any call starts.
- `ToolUseDispatchNode.execCall:462` — the standalone (no `batchSignal`) branch,
  which owns exactly one tool call. The chained branch does not register, and it
  already handles a pre-aborted `batchSignal` the same way.

`setAbortController(null)` is unaffected: aborting `null` is a no-op.

## Verification

- New `src/test-kernel/agent/runtime/InterruptManager.vitest.ts`, 4 cases. Three
  of the four fail on the pre-change file (confirmed by stashing the source
  change and re-running); the fourth is the live-controller baseline that passed
  before and still passes. They pin: an interrupt raised while no controller is
  registered still aborts the next one registered, and a second interrupt still
  reaches a controller registered after the first.
- `npm run typecheck` — exit 0.
- `npx vitest run` on the cancellation-adjacent suites: `RetryState`,
  `ToolUseDispatchParallel`, `ToolUseDispatchInterruption`,
  `ResumeToolUseCancellation`, `ResponseCycleCancellation`, `ExecutionRegistry`,
  plus the new file. 116 tests, all passing.

## Deliberately out of scope

- Stage 2 (`RunScope.signal` as the SSOT, deleting `InterruptManager` and the
  `setAbortController` port) and stage 3 (the `pendingInterrupt` attach window).
  Those are the high-risk half of the issue and want their own PRs.
- `terminateWaitingHandle` and anything guarded by `claimTerminalFinalize`, per
  the issue's own out-of-scope note.
- `_userCancelled`, which has a second source in `retryPrompt` and cannot
  collapse into the interrupt latch.
- The issue's suggested end-to-end test (fire the interrupt between
  `ResponsePrepNode.prep` and the model call, assert `createResponse` never
  issues). The unit-level pins above cover the mechanism this PR changes; the
  end-to-end version belongs with stage 2, where the signal reaches
  `RetryableInvocationNode` structurally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent cancellation wiring used by model retries and tool dispatch; behavior change is narrow but affects whether in-flight provider/tool work actually stops when users interrupt.
> 
> **Overview**
> Fixes a race where **Stop** could show the run as cancelled while model/tool work kept going: nodes clear the shared `AbortController` slot in `finally`, so an interrupt between nodes aborted nothing, and the old `onInterrupt` early-return dropped later presses.
> 
> **`createInterruptCallbacks()`** now treats interruption as a **level-triggered latch**: `onInterrupt` always sets the latch and aborts the current controller (no one-shot guard), and **`setAbortController`** immediately aborts any newly registered controller if the latch is already set.
> 
> Adds **`InterruptManager.vitest.ts`** with four cases covering live abort, empty-slot timing, repeated interrupts, and latch-on-register without a second interrupt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 298ed97a47bc968c58f09b71ee81b03752687f74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->