### PR TITLE
Type ActiveChildInfo.status as StreamPhase

### DIFF
--- a/docs/proposals/2026-07-30-agent-sdk-readiness-checkpoint.md
+++ b/docs/proposals/2026-07-30-agent-sdk-readiness-checkpoint.md
@@ -120,11 +120,11 @@ pass; none are applied here.
 - **[TRACKED] Model-handler base → collaborator extractions (standing §9.3).**
   Re-verified. **Honesty correction to the "2068-LOC god class" framing:** the
   file is 2025 LOC at HEAD, but **~39% (~785 lines) is comment/blank** — chiefly
-  the `#7101`-triage doc blocks that record *why* each capability getter stays
-  overridable. The *logical* class is ~1200 lines. The clearest genuine
+  the `#7101`-triage doc blocks that record _why_ each capability getter stays
+  overridable. The _logical_ class is ~1200 lines. The clearest genuine
   extraction remains the **credential/route cluster** (`ModelHandler.ts:208-702`:
   a `WeakMap` + two route fields + ~13 methods operating only on those fields and
-  `this.config`) into a `ClientCredentialRouter` collaborator the handler *holds*.
+  `this.config`) into a `ClientCredentialRouter` collaborator the handler _holds_.
   Caveat that keeps it off the mechanical-lift list: the credential state is
   threaded into the `createResponse` template (`:1130-1136`, `getBaseUrl` reads
   the active route at `:687`), so the collaborator must expose an active-route
@@ -177,7 +177,7 @@ pass; none are applied here.
   (1) the `MODEL_HANDLER_COMPATIBILITY_KEYS` enum
   (`modelHandlerCompatibilityKey.ts:3-19`); (2) the `PROVIDER_HANDLER_ROUTES`
   record's `compatibilityKey` fields + lazy `load` loaders
-  (`ModelFactory.ts:73-147`), which also encode routing *precedence* at `:328`;
+  (`ModelFactory.ts:73-147`), which also encode routing _precedence_ at `:328`;
   and (3) the `switch (compatibilityKey)` at `ModelFactory.ts:595-663`, which
   special-cases `ModelHandlerOpenAIResponse` / `ModelHandlerGoogleInteractions` /
   `ModelHandlerOpenRouterNative` / `ModelHandlerValidation` outside the record and
@@ -190,7 +190,7 @@ pass; none are applied here.
   "run the async Codex/Kimi/vscodelm-availability overrides, then
   `new (await ROUTES_BY_KEY[key].load())(…)`". Payoff is moderate (the switch is
   ~70 lines) — SDK-surface tidiness, not urgent. Distinct from §New-5, which is
-  about the two *entrypoints*; this is about the *dispatch table* behind them.
+  about the two _entrypoints_; this is about the _dispatch table_ behind them.
   Sibling note under standing §9.3: this is the same "the handler surface is wide
   because the runtime asks a lot of it" theme as the port width — the SDK lever is
   narrowing the demand, not the derived surfaces.
@@ -200,7 +200,7 @@ pass; none are applied here.
   `AgentEvent` on the run trace (`:316`); (2) an `updateStreamStatus` `SessionFact`
   on the session hub (`:319-325`); (3) the direct `statusListeners` callback set
   (`:326-328`). Because the `attachRunTrace` bridge re-broadcasts every run
-  `AgentEvent` onto the hub, the `status` event *also* reaches the hub — where the
+  `AgentEvent` onto the hub, the `status` event _also_ reaches the hub — where the
   progress projectors filter it out (`status` is deliberately excluded from
   `RUN_FACT_EVENT_TYPES`) — while the semantically identical `updateStreamStatus`
   fact is separately published. So one transition has four representations. It
@@ -214,7 +214,7 @@ pass; none are applied here.
   highest-value dedup in the observability surface, and `conversation.progress`
   (already single-rail via a session projector, `helpers.ts:200-215`) is the
   pattern to follow.
-- **[NEW → RETRACTED] §New-10 — `polishModel.ts` is *not* a naked single-caller
+- **[NEW → RETRACTED] §New-10 — `polishModel.ts` is _not_ a naked single-caller
   extraction; do not merge it. (Corrected 2026-07-30 by a live-authorized census
   — see "Follow-up" below.)** The `-07-29` framing and the runtime deep-dive both
   read this as "`renderPolishPrompt` has one consumer (`textEnhancement`), so
@@ -230,7 +230,7 @@ pass; none are applied here.
   separately-tested concern into its consumer. **Net-neutral-to-negative churn —
   leave `polishModel.ts` as its own file.** The broader placement observation (the
   runtime "content helpers" cluster is one-shot content generation that an SDK
-  boundary would lift out of the launch layer) still stands as a *directional*
+  boundary would lift out of the launch layer) still stands as a _directional_
   note, but it is a deliberate relocation, not a file merge.
 - **[NEW] §New-11 — `setLogger` mutable injection could be ambient trace via
   `RunScope`. (M; pairs with §New-4.)** The run trace is pushed into the model
@@ -242,7 +242,7 @@ pass; none are applied here.
   this). The run already executes inside a `withExecutionRunContext`
   `AsyncLocalStorage` scope whose `RunScope` carries `session` but not `trace`.
   Adding the trace to `RunScope` and resolving `this.logger ?? ambientTrace() ??
-  noopTrace` per emit deletes `setLogger`, the `MediaAttachmentProcessor.setLogger`
+noopTrace` per emit deletes `setLogger`, the `MediaAttachmentProcessor.setLogger`
   re-wrap, the constructor placeholder, and the model-switch re-wire — **and**
   fixes the standing gap (audit `-05-29`) where `createHelperModelKit()` handlers
   never get a logger at all. Cost: emit-site reads must be per-call (the handler
@@ -390,7 +390,7 @@ not-yet-clean. The census is the deliverable:
 do" subset empty of clean mechanical wins. This is the strongest available
 confirmation of the standing verdict: the remaining items are design-judgment or
 deliberate-sequencing work, not drive-by simplifications. The genuinely safe next
-steps are the *additive* SDK-surface exposures the subagent-boundaries section names
+steps are the _additive_ SDK-surface exposures the subagent-boundaries section names
 (publish `ChildRunStrategy`; expose the helper-model one-shots as a headless
 sub-task API), which add capability without touching the tested invariants above —
 those are the right candidates for the next attended change.
@@ -405,7 +405,7 @@ those are the right candidates for the next attended change.
   to file:line; the two headline claims (§New-8's triple encoding, §New-9's
   four-way status emission) plus the §New-1 never-parsed schemas and §New-7
   un-optioned redact call were independently re-verified this pass by direct grep
-  at HEAD. The four-way *count* in §New-9 relies on the deep-dive's reading of the
+  at HEAD. The four-way _count_ in §New-9 relies on the deep-dive's reading of the
   `attachRunTrace` bridge's re-broadcast; the three primary emit sites
   (`StreamStatusService.ts:316,319,326`) were verified directly. Re-derive before
   any edit, per the standing rule.

--- a/packages/cli/src/chat/tui/state/childExecutions.ts
+++ b/packages/cli/src/chat/tui/state/childExecutions.ts
@@ -10,10 +10,11 @@
 // transition/selector semantics this module implements.
 
 import { computed, signal, type Signal } from '@lit-labs/signals';
-import type {
-  ActiveChildInfo,
-  StreamTabId,
-  SubagentChildInfo,
+import {
+  STREAM_PHASE,
+  type ActiveChildInfo,
+  type StreamTabId,
+  type SubagentChildInfo,
 } from '@shared/schemas';
 
 import type { StreamSlice } from './cliState';
@@ -193,10 +194,20 @@ export function setParentStream(
 
 /** Field-by-field comparison of the persisted roster summary — avoids a
  *  spurious `changed` on a same-content roster snapshot the runtime resends
- *  as a fresh array/object on every poll. */
+ *  as a fresh array/object on every poll.
+ *
+ *  `elapsed` is compared only when `skipElapsed` is false. While a child is
+ *  live (status undefined or `running`), `childElapsed` derives the display
+ *  from `startedAt` and ignores the cached formatted string, so a
+ *  formatted-time-only delta there is safe to drop — otherwise every roster
+ *  tick would force a `CHILD_STREAMS.set`. Once the child is no longer live,
+ *  the cached `elapsed` string becomes the value of record (terminal display,
+ *  `formatPostCompactionContext`), so a delta there must still count as a
+ *  change or the retained row freezes at a stale, often near-zero, elapsed. */
 function summaryUnchanged(
   a: LiveChildStreamEntry['summary'],
   b: LiveChildStreamEntry['summary'],
+  skipElapsed: boolean,
 ): boolean {
   if (a === b) return true;
   if (!a || !b) return false;
@@ -204,21 +215,26 @@ function summaryUnchanged(
     a.agentName === b.agentName &&
     a.executionId === b.executionId &&
     a.startedAt === b.startedAt &&
+    (skipElapsed || a.elapsed === b.elapsed) &&
     a.toolName === b.toolName &&
     a.workflowPhase === b.workflowPhase
   );
 }
 
-/** Whether applying `nextEntry` over `entry` would be a no-op. */
+/** Whether applying `nextEntry` over `entry` would be a no-op. `childStatus`
+ *  decides whether an `elapsed`-only delta counts (see `summaryUnchanged`). */
 function subagentEntryUnchanged(
   entry: LiveChildStreamEntry | undefined,
   nextEntry: LiveChildStreamEntry,
+  childStatus: ActiveChildInfo['status'],
 ): boolean {
+  const skipElapsed =
+    childStatus === undefined || childStatus === STREAM_PHASE.RUNNING;
   return (
     entry !== undefined &&
     entry.active === nextEntry.active &&
     entry.parent === nextEntry.parent &&
-    summaryUnchanged(entry.summary, nextEntry.summary)
+    summaryUnchanged(entry.summary, nextEntry.summary, skipElapsed)
   );
 }
 
@@ -303,7 +319,7 @@ export function applySubagentRoster(
       active: true,
       parent,
     };
-    if (subagentEntryUnchanged(entry, nextEntry)) continue;
+    if (subagentEntryUnchanged(entry, nextEntry, child.status)) continue;
     out.set(childStreamId, nextEntry);
     changed = true;
   }

--- a/packages/cli/src/chat/tui/state/childExecutions.ts
+++ b/packages/cli/src/chat/tui/state/childExecutions.ts
@@ -204,7 +204,6 @@ function summaryUnchanged(
     a.agentName === b.agentName &&
     a.executionId === b.executionId &&
     a.startedAt === b.startedAt &&
-    a.elapsed === b.elapsed &&
     a.toolName === b.toolName &&
     a.workflowPhase === b.workflowPhase
   );

--- a/packages/cli/src/chat/tui/state/childExecutions.ts
+++ b/packages/cli/src/chat/tui/state/childExecutions.ts
@@ -10,11 +10,10 @@
 // transition/selector semantics this module implements.
 
 import { computed, signal, type Signal } from '@lit-labs/signals';
-import {
-  STREAM_PHASE,
-  type ActiveChildInfo,
-  type StreamTabId,
-  type SubagentChildInfo,
+import type {
+  ActiveChildInfo,
+  StreamTabId,
+  SubagentChildInfo,
 } from '@shared/schemas';
 
 import type { StreamSlice } from './cliState';
@@ -196,18 +195,20 @@ export function setParentStream(
  *  spurious `changed` on a same-content roster snapshot the runtime resends
  *  as a fresh array/object on every poll.
  *
- *  `elapsed` is compared only when `skipElapsed` is false. While a child is
- *  live (status undefined or `running`), `childElapsed` derives the display
- *  from `startedAt` and ignores the cached formatted string, so a
- *  formatted-time-only delta there is safe to drop — otherwise every roster
- *  tick would force a `CHILD_STREAMS.set`. Once the child is no longer live,
- *  the cached `elapsed` string becomes the value of record (terminal display,
- *  `formatPostCompactionContext`), so a delta there must still count as a
- *  change or the retained row freezes at a stale, often near-zero, elapsed. */
+ *  `elapsed` is compared like every other field: `AgentRunLifecycle`
+ *  untracks a finishing child (omitting it from the next roster) *before*
+ *  transitioning its stream to a terminal phase, so a roster tick carrying
+ *  both a terminal `status` and a fresh `elapsed` never happens in practice —
+ *  the last roster snapshot this child appears in is always `running`. If
+ *  `elapsed` were dropped from this comparison while the child is running,
+ *  the cached summary would freeze at whichever tick happened to be the
+ *  first one where the other fields settled (typically the very first
+ *  tick), not the last live value before removal, and that stale, near-zero
+ *  duration is what the retained row and `formatPostCompactionContext` would
+ *  read verbatim. */
 function summaryUnchanged(
   a: LiveChildStreamEntry['summary'],
   b: LiveChildStreamEntry['summary'],
-  skipElapsed: boolean,
 ): boolean {
   if (a === b) return true;
   if (!a || !b) return false;
@@ -215,26 +216,22 @@ function summaryUnchanged(
     a.agentName === b.agentName &&
     a.executionId === b.executionId &&
     a.startedAt === b.startedAt &&
-    (skipElapsed || a.elapsed === b.elapsed) &&
+    a.elapsed === b.elapsed &&
     a.toolName === b.toolName &&
     a.workflowPhase === b.workflowPhase
   );
 }
 
-/** Whether applying `nextEntry` over `entry` would be a no-op. `childStatus`
- *  decides whether an `elapsed`-only delta counts (see `summaryUnchanged`). */
+/** Whether applying `nextEntry` over `entry` would be a no-op. */
 function subagentEntryUnchanged(
   entry: LiveChildStreamEntry | undefined,
   nextEntry: LiveChildStreamEntry,
-  childStatus: ActiveChildInfo['status'],
 ): boolean {
-  const skipElapsed =
-    childStatus === undefined || childStatus === STREAM_PHASE.RUNNING;
   return (
     entry !== undefined &&
     entry.active === nextEntry.active &&
     entry.parent === nextEntry.parent &&
-    summaryUnchanged(entry.summary, nextEntry.summary, skipElapsed)
+    summaryUnchanged(entry.summary, nextEntry.summary)
   );
 }
 
@@ -319,7 +316,7 @@ export function applySubagentRoster(
       active: true,
       parent,
     };
-    if (subagentEntryUnchanged(entry, nextEntry, child.status)) continue;
+    if (subagentEntryUnchanged(entry, nextEntry)) continue;
     out.set(childStreamId, nextEntry);
     changed = true;
   }

--- a/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -34,7 +34,6 @@ import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';
 // Local imports
 import '@awesome.me/webawesome/dist/components/badge/badge.js';
 import {
-  DEFAULT_STREAM_METADATA_STATUS,
   STREAM_PHASE,
   WORKFLOW_TASK_STATUS_LABEL,
   type ActiveChildInfo,
@@ -535,11 +534,9 @@ function taskStatusBadge(child: ActiveChildInfo): {
   const subagentStatusStillInFlight =
     child.kind === 'subagent' &&
     (child.status === STREAM_PHASE.RUNNING ||
-      child.status === STREAM_PHASE.WAITING ||
-      child.status === DEFAULT_STREAM_METADATA_STATUS);
+      child.status === STREAM_PHASE.WAITING);
   if (child.finishedAt === undefined || subagentStatusStillInFlight) {
-    return child.status === STREAM_PHASE.WAITING ||
-      child.status === DEFAULT_STREAM_METADATA_STATUS
+    return child.status === STREAM_PHASE.WAITING
       ? {
           text: WORKFLOW_TASK_STATUS_LABEL.waiting,
           variant: 'neutral',

--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -7,7 +7,10 @@ import { roundIndexedRecord } from './roundIndexed';
 import {
   STREAM_STATUS,
   StreamLifecycleStatusSchema,
+  StreamPhaseSchema,
+  StreamStatusSchema,
   StreamSubstateSchema,
+  streamStatusToPhase,
 } from './stream';
 import { TaskGroupSchema } from './taskGroup';
 import { PlanSchema } from './plan';
@@ -26,8 +29,18 @@ import { RunUsageMapSchema, TokenUsageStatsSchema } from './usage';
 const ActiveChildInfoBaseSchema = z.object({
   executionId: z.string(),
   agentName: z.string(),
-  /** Current execution status (e.g. "running", "waiting"). Defaults to "running". */
-  status: z.string().optional(),
+  /**
+   * Current execution phase. Persisted rosters written before the
+   * `StreamPhase` cutover carry the retired 7-value `StreamStatus` vocabulary
+   * instead; the legacy union member below maps those to their `StreamPhase`
+   * equivalent on read.
+   */
+  status: z
+    .union([
+      StreamPhaseSchema,
+      StreamStatusSchema.transform(streamStatusToPhase),
+    ])
+    .optional(),
   /** Epoch milliseconds when the child execution began. */
   startedAt: z.int().positive().optional(),
   /**

--- a/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
+++ b/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
@@ -104,7 +104,7 @@ const child = {
   executionId: childExecutionId,
   childStreamId,
   agentName: 'review',
-  status: 'running',
+  status: STREAM_PHASE.RUNNING,
 };
 const PROGRESS_PROJECTION_CASES = {
   setActiveStream: {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -3554,29 +3554,30 @@ describe('child-stream ordered transition matrix', () => {
     ]);
   });
 
-  it('5b. elapsed-only roster ticks are dropped while running, captured once terminal', () => {
-    // While the child is live (status undefined or running), an elapsed-only
-    // delta must not force a `CHILD_STREAMS.set` — the display derives
-    // elapsed from `startedAt` instead. But once the roster tick lands after
-    // the child goes terminal, the freshest `elapsed` must be captured, not
-    // frozen at whichever value happened to be cached from an earlier tick
-    // (the roster row is a model-facing consumer via
-    // `formatPostCompactionContext`, and the retained-row display falls back
-    // to the cached string once the child is no longer live).
+  it('5b. a live roster tick with only elapsed changed still updates the retained summary', () => {
+    // AgentRunLifecycle untracks a finishing child (so it drops out of the
+    // next roster) *before* transitioning its stream to a terminal phase, so
+    // production never sends a roster tick that carries both a terminal
+    // status and a fresh elapsed for this child - the last roster snapshot
+    // it ever appears in is always `running`. An elapsed-only delta must
+    // therefore still count as a change while the child is running, or the
+    // cached summary freezes at whichever tick happened to settle first
+    // (typically the very first one) instead of the last live value before
+    // removal - the value the retained row and `formatPostCompactionContext`
+    // read verbatim once the child is gone from the roster.
     patchStream(kid, (s) => ({ ...s, status: STREAM_PHASE.RUNNING }));
     applySubagentRoster(parentP, [rosterRow(STREAM_PHASE.RUNNING, '0s')]);
     setParentStream(kid, parentP);
 
-    // A later live tick changes only `elapsed`; must not overwrite the cache.
     applySubagentRoster(parentP, [rosterRow(STREAM_PHASE.RUNNING, '5s')]);
-    expect(retainedRows(parentP)).toMatchObject([{ elapsed: '0s' }]);
+    applySubagentRoster(parentP, [rosterRow(STREAM_PHASE.RUNNING, '41s')]);
 
-    // The child goes terminal, then one final roster tick reports its true
-    // final elapsed time. This must land in the retained summary.
+    // The child is untracked (dropped from the roster) with its last-known
+    // elapsed already captured; the terminal status lands separately.
+    applySubagentRoster(parentP, []);
     patchStream(kid, (s) => ({ ...s, status: STREAM_PHASE.COMPLETED }));
-    applySubagentRoster(parentP, [rosterRow(STREAM_PHASE.COMPLETED, '42s')]);
 
-    expect(retainedRows(parentP)).toMatchObject([{ elapsed: '42s' }]);
+    expect(retainedRows(parentP)).toMatchObject([{ elapsed: '41s' }]);
   });
 
   it('6. promotion with stale roster: A, S(running), R_P+, E_P+, E0, R_P+', () => {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -3461,13 +3461,14 @@ describe('child-stream ordered transition matrix', () => {
   const parentQ = 'parent-q' as StreamTabId;
   const kid = 'kid' as StreamTabId;
 
-  function rosterRow(status?: StreamPhase) {
+  function rosterRow(status?: StreamPhase, elapsed?: string) {
     return {
       kind: 'subagent' as const,
       executionId: 'kid-exec',
       agentName: 'kid-agent',
       childStreamId: kid,
       status,
+      elapsed,
     };
   }
 
@@ -3551,6 +3552,31 @@ describe('child-stream ordered transition matrix', () => {
     expect(retainedRows(parentP)).toMatchObject([
       { status: STREAM_PHASE.COMPLETED },
     ]);
+  });
+
+  it('5b. elapsed-only roster ticks are dropped while running, captured once terminal', () => {
+    // While the child is live (status undefined or running), an elapsed-only
+    // delta must not force a `CHILD_STREAMS.set` — the display derives
+    // elapsed from `startedAt` instead. But once the roster tick lands after
+    // the child goes terminal, the freshest `elapsed` must be captured, not
+    // frozen at whichever value happened to be cached from an earlier tick
+    // (the roster row is a model-facing consumer via
+    // `formatPostCompactionContext`, and the retained-row display falls back
+    // to the cached string once the child is no longer live).
+    patchStream(kid, (s) => ({ ...s, status: STREAM_PHASE.RUNNING }));
+    applySubagentRoster(parentP, [rosterRow(STREAM_PHASE.RUNNING, '0s')]);
+    setParentStream(kid, parentP);
+
+    // A later live tick changes only `elapsed`; must not overwrite the cache.
+    applySubagentRoster(parentP, [rosterRow(STREAM_PHASE.RUNNING, '5s')]);
+    expect(retainedRows(parentP)).toMatchObject([{ elapsed: '0s' }]);
+
+    // The child goes terminal, then one final roster tick reports its true
+    // final elapsed time. This must land in the retained summary.
+    patchStream(kid, (s) => ({ ...s, status: STREAM_PHASE.COMPLETED }));
+    applySubagentRoster(parentP, [rosterRow(STREAM_PHASE.COMPLETED, '42s')]);
+
+    expect(retainedRows(parentP)).toMatchObject([{ elapsed: '42s' }]);
   });
 
   it('6. promotion with stale roster: A, S(running), R_P+, E_P+, E0, R_P+', () => {

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -93,6 +93,7 @@ import {
   type ExecutionId,
   type Plan,
   type StorageKey,
+  type StreamPhase,
   type StreamTabId,
   type TodoItem,
 } from '@shared/schemas';
@@ -3460,7 +3461,7 @@ describe('child-stream ordered transition matrix', () => {
   const parentQ = 'parent-q' as StreamTabId;
   const kid = 'kid' as StreamTabId;
 
-  function rosterRow(status?: string) {
+  function rosterRow(status?: StreamPhase) {
     return {
       kind: 'subagent' as const,
       executionId: 'kid-exec',
@@ -3645,14 +3646,14 @@ describe('child-stream ordered transition matrix', () => {
   it('10. two-child retention keeps stable order across reordering and shrinking rosters', () => {
     const kidA = 'kid-a' as StreamTabId;
     const kidB = 'kid-b' as StreamTabId;
-    const rowA = (status?: string) => ({
+    const rowA = (status?: StreamPhase) => ({
       kind: 'subagent' as const,
       executionId: 'exec-a',
       agentName: 'a',
       childStreamId: kidA,
       status,
     });
-    const rowB = (status?: string) => ({
+    const rowB = (status?: StreamPhase) => ({
       kind: 'subagent' as const,
       executionId: 'exec-b',
       agentName: 'b',


### PR DESCRIPTION
Closes #9437

## What changed

Two narrow edits from the debt-audit finding, plus one incidental unrelated file caught by the whole-repo `npm run format` pre-commit hook.

1. **`src/shared/schemas/streamState.ts`** — tightened `ActiveChildInfoSchema.status` from `z.string().optional()` to a union of `StreamPhaseSchema` and a legacy `StreamStatusSchema.transform(streamStatusToPhase)` member (both optional). Every producer (`ExecutionRegistry.getStatus`, `ProgressFactApplier.setStreamStatus`) already writes a `StreamPhase` value; the legacy member normalizes persisted rosters written before the `StreamPhase` cutover (the retired 7-value `StreamStatus` vocabulary) into the canonical shape at the parse boundary, reusing the existing `streamStatusToPhase` helper rather than adding a new one.

2. **`packages/extension/src/progressView/frontend/components/BackgroundTasksPanel.ts`** — with `status` now typed as `StreamPhase | undefined`, the two `child.status === DEFAULT_STREAM_METADATA_STATUS` ('ready') comparisons in `taskStatusBadge` became unrepresentable (that string literal is not a member of the type), so they're removed along with the now-dead `DEFAULT_STREAM_METADATA_STATUS` import.

3. **`packages/cli/src/chat/tui/state/childExecutions.ts`** — originally dropped `a.elapsed === b.elapsed` from `summaryUnchanged` as an incidental cleanup, but review (Codex + Cursor Bugbot) caught that this froze the cached summary at whichever roster tick happened to settle first, rather than the last live value: `AgentRunLifecycle` untracks a finishing child (dropping it from the roster) *before* transitioning its stream to a terminal phase, so a roster tick never carries both a terminal status and a fresh `elapsed`. Reverted — `elapsed` stays in the comparison like every other field, matching pre-PR behavior, with an expanded comment documenting why. `formatPostCompactionContext` (`src/tools/subagentResults.ts`) is a model-facing consumer of the cached value, so staleness there would have been model-visible.

4. **Two test fixtures** (`src/test-kernel/cli/TuiStateAndFocus.vitest.mts`, `src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts`) built `ActiveChildInfo`-shaped objects with a bare `string` (or `string`-typed helper param) for `status`; retyped to `StreamPhase` to satisfy the tightened schema. No behavioral change, purely fixture typing.

5. **`docs/proposals/2026-07-30-agent-sdk-readiness-checkpoint.md`** — incidental markdown-emphasis normalization (`*word*` → `_word_`) picked up by the repo's `npm run format` pre-commit hook, which runs `prettier --write .` over the whole tree rather than just staged files. Unrelated to this issue's content; included only because the hook would otherwise loop on this pre-existing drift on every commit attempt.

## Verification

- Read the issue's cited call sites before changing anything: `ExecutionRegistry.collectChildSummary`/`getStatus` (already `StreamPhase`-typed), `ProgressFactApplier.setStreamStatus` (writes `StreamPhase` into the roster cache), `BackgroundTasksPanel.taskStatusBadge`, and `formatPostCompactionContext` in `src/tools/subagentResults.ts` — confirmed the audit's claim that `status`/`elapsed` are a deliberate post-cleanup cache read and a model-facing consumer, not stale producer stamps. Did not touch either field.
- `npx tsc --noEmit` (root) — clean.
- `npx tsc --noEmit` (packages/extension) — clean.
- `npx tsc --noEmit` (packages/cli) — clean.
- `npx tsc --noEmit -p tsconfig.test-kernel.json` — surfaced two now-invalid `string`-typed test fixtures (not mentioned in the issue); fixed both, then reran clean.
- `npm run typecheck` (full chain: root, test-kernel, `@texra-ai/agent` build, extension, cli, trace-viewer, desktop) — clean.
- Targeted vitest: `ChildControls.vitest.mts` (7 passed), `TuiStateAndFocus.vitest.mts` + `CliSessionProgressSubscription.vitest.mts` + `ChildControls.vitest.mts` together (151 passed, including new scenario 5b covering the elapsed invariant above). `BackgroundTasksPanel.vitest.mts` was independently re-verified (not just re-asserted): it passes consistently on this branch, and passes identically with these changes stashed out — not a regression from this PR.

## Left out

Nothing from the issue's scope. The retirement of the `StreamLifecycleStatus`/`DEFAULT_STREAM_METADATA_STATUS` vocabulary itself (the `'ready'` fold spanning `streamMetadata.ts`, `StreamTabs`, `StreamHeader`, `streamTree`, `WorkflowToolUseFollowupSection`, `replayTrace`, and the trace-viewer mirror schema) is explicitly out of scope per the issue — that's a separate migration with wire/persistence compatibility concerns, not a fold-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema/UI typing and CLI cache semantics with targeted tests; no auth, persistence wire format break beyond backward-compatible Zod transforms.
> 
> **Overview**
> **`ActiveChildInfo.status`** is no longer a loose optional string: the schema accepts **`StreamPhase`** and, on read, maps pre-cutover **`StreamStatus`** values through **`streamStatusToPhase`** so persisted rosters stay compatible.
> 
> **Background Tasks** badge logic drops comparisons against the retired **`'ready'`** default metadata status (and the unused import), which are invalid once **`status`** is **`StreamPhase | undefined`**.
> 
> **CLI child roster caching** gets a documented invariant in **`summaryUnchanged`**: **`elapsed`** must participate in equality while a child is still on the roster so elapsed-only poll ticks refresh the cached summary before untrack/removal; **`TuiStateAndFocus`** adds scenario **5b** to lock that behavior. Incidental proposal-doc emphasis formatting from Prettier is unrelated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abd5d33d2b2ccb2dd10be257cf1b6cf3c1212c72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
