### PR TITLE
fix: unify memory directory traversal

### DIFF
--- a/src/controllers/settingsView/SettingsViewHost.ts
+++ b/src/controllers/settingsView/SettingsViewHost.ts
@@ -11,12 +11,12 @@ import type {
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { MAX_PINNED_MEMORIES } from '@tools/memory/constants';
 import {
+  countPinnedMemories,
   loadMemoryItems,
   loadMemoryPreview,
 } from '@tools/memory/memoryFileSystem';
 import {
   buildFile,
-  countPinnedMemories,
   parseFrontmatter,
   setPinnedMeta,
 } from '@tools/memory/memoryMeta';

--- a/src/test-kernel/settings/MemoryFileSystemConcurrency.vitest.ts
+++ b/src/test-kernel/settings/MemoryFileSystemConcurrency.vitest.ts
@@ -9,7 +9,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 // Local imports
 import { FileType, type FileStat } from '@platform/interfaces';
 import { MEMORY_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
-import { walkMemoryDirectory } from '@tools/memory/memoryFileSystem';
+import {
+  countPinnedMemories,
+  walkMemoryDirectory,
+} from '@tools/memory/memoryFileSystem';
 import { StorageFS } from '@utils/files';
 import { delay } from '@utils/core';
 
@@ -88,12 +91,52 @@ describe('memory filesystem listing', () => {
       readStreamFromText(TEST_FRONTMATTER),
     );
 
-    const items = await walkMemoryDirectory(MEMORY_STORAGE_DIR);
+    const items = [];
+    for await (const item of walkMemoryDirectory(MEMORY_STORAGE_DIR)) {
+      items.push(item);
+    }
 
     expect(items).toHaveLength(FILE_COUNT_PER_DIRECTORY * 2);
     expect(maxActiveMetadataReads).toBeGreaterThan(1);
     expect(maxActiveMetadataReads).toBeLessThanOrEqual(
       MEMORY_LISTING_CONCURRENCY,
     );
+  });
+
+  it('stops metadata reads once the pinned-memory limit is reached', async () => {
+    const cyclePath = path.join(MEMORY_STORAGE_DIR, 'cycle');
+    const files: [string, number][] = [
+      ['cycle', FileType.Directory | FileType.SymbolicLink],
+      ...Array.from({ length: 100 }, (_, index): [string, number] => [
+        `pinned-${index}.md`,
+        FileType.File,
+      ]),
+    ];
+    const pinnedFrontmatter = [
+      '---',
+      'modifiedBy: test-agent',
+      'modifiedAt: 2026-01-01T00:00:00.000Z',
+      'pinned: true',
+      '---',
+      'body',
+    ].join('\n');
+
+    vi.spyOn(StorageFS, 'exists').mockResolvedValue(true);
+    vi.spyOn(StorageFS, 'readDir').mockResolvedValue(files);
+    vi.spyOn(StorageFS, 'stat').mockImplementation(async (target) => {
+      if (target === cyclePath) {
+        throw new Error('The symlink cycle must not be statted');
+      }
+      return {
+        ...testFileStat(),
+        size: Buffer.byteLength(pinnedFrontmatter),
+      };
+    });
+    const readStream = vi
+      .spyOn(StorageFS, 'createReadStream')
+      .mockImplementation(() => readStreamFromText(pinnedFrontmatter));
+
+    await expect(countPinnedMemories(1)).resolves.toBe(1);
+    expect(readStream.mock.calls.length).toBeLessThan(files.length);
   });
 });

--- a/src/test-kernel/tools/MemoryTool.vitest.ts
+++ b/src/test-kernel/tools/MemoryTool.vitest.ts
@@ -1,3 +1,8 @@
+// Node imports
+import { Buffer } from 'node:buffer';
+import * as path from 'node:path';
+import { Readable } from 'node:stream';
+
 // Third-party imports
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -15,6 +20,15 @@ const TEST_FRONTMATTER = [
   'modifiedAt: 2026-01-01T00:00:00.000Z',
   '---',
   'note body',
+].join('\n');
+const PINNED_FRONTMATTER = [
+  '---',
+  'modifiedBy: pin-agent',
+  'modifiedAt: 2026-01-01T00:00:00.000Z',
+  'executionId: run-7',
+  'pinned: true',
+  '---',
+  'pinned body',
 ].join('\n');
 
 function dirStat(): FileStat {
@@ -37,6 +51,7 @@ function fileStat(size: number): FileStat {
 
 describe('MemoryTool view with an omitted path', () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -68,6 +83,12 @@ describe('MemoryTool view with an omitted path', () => {
       target === MEMORY_STORAGE_DIR ? [['notes.md', FileType.File]] : [],
     );
     vi.spyOn(StorageFS, 'read').mockResolvedValue(TEST_FRONTMATTER);
+    vi.spyOn(StorageFS, 'createReadStream').mockImplementation(
+      () =>
+        Readable.from([Buffer.from(TEST_FRONTMATTER)]) as unknown as ReturnType<
+          typeof StorageFS.createReadStream
+        >,
+    );
 
     const omitted = await new MemoryTool().call({ command: 'view' });
     const explicitRoot = await new MemoryTool().call({
@@ -91,5 +112,103 @@ describe('MemoryTool view with an omitted path', () => {
       status: 'error',
       error: expect.stringContaining('path'),
     });
+  });
+
+  it('preserves the model-facing directory listing bytes and depth limit', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-02T00:00:00.000Z'));
+
+    const alphaPath = path.join(MEMORY_STORAGE_DIR, 'alpha');
+    const betaPath = path.join(alphaPath, 'beta');
+    const pinnedPath = path.join(alphaPath, 'pinned.md');
+    const rootFilePath = path.join(MEMORY_STORAGE_DIR, 'root.md');
+
+    vi.spyOn(StorageFS, 'exists').mockResolvedValue(true);
+    vi.spyOn(StorageFS, 'readDir').mockImplementation(async (target) => {
+      if (target === MEMORY_STORAGE_DIR) {
+        return [
+          ['alpha', FileType.Directory],
+          ['root.md', FileType.File],
+        ];
+      }
+      if (target === alphaPath) {
+        return [
+          ['pinned.md', FileType.File],
+          ['beta', FileType.Directory],
+        ];
+      }
+      if (target === betaPath) {
+        throw new Error('The depth-2 directory must not be traversed');
+      }
+      throw new Error(`Unexpected readDir target: ${target}`);
+    });
+    vi.spyOn(StorageFS, 'stat').mockImplementation(async (target) => {
+      if (target === pinnedPath) {
+        return fileStat(Buffer.byteLength(PINNED_FRONTMATTER));
+      }
+      if (target === rootFilePath) {
+        return fileStat(Buffer.byteLength(TEST_FRONTMATTER));
+      }
+      return dirStat();
+    });
+    vi.spyOn(StorageFS, 'createReadStream').mockImplementation(
+      (target) =>
+        Readable.from([
+          Buffer.from(
+            target === pinnedPath ? PINNED_FRONTMATTER : TEST_FRONTMATTER,
+          ),
+        ]) as unknown as ReturnType<typeof StorageFS.createReadStream>,
+    );
+
+    const result = await new MemoryTool().call({
+      command: 'view',
+      path: MEMORY_DISPLAY_ROOT,
+    });
+
+    expect(result).toEqual({
+      status: 'executed',
+      summary: 'Listed directory: /memories (1–5 of 5)',
+      output: [
+        'Contents of /memories (showing 1–5 of 5, up to 2 levels deep):',
+        'SIZE\tMODIFIED\tBY\tPATH',
+        '0 B\tyesterday\t-\t/memories',
+        '0 B\tyesterday\t-\t/memories/alpha',
+        `${Buffer.byteLength(PINNED_FRONTMATTER)} B\tyesterday\tpin-agent (run-7)\t/memories/alpha/pinned.md [pinned]`,
+        '0 B\tyesterday\t-\t/memories/alpha/beta',
+        `${Buffer.byteLength(TEST_FRONTMATTER)} B\tyesterday\ttest-agent\t/memories/root.md`,
+      ].join('\n'),
+    });
+  });
+
+  it('skips a symlink cycle when listing memory directories', async () => {
+    const cyclePath = path.join(MEMORY_STORAGE_DIR, 'cycle');
+
+    vi.spyOn(StorageFS, 'exists').mockResolvedValue(true);
+    vi.spyOn(StorageFS, 'readDir').mockImplementation(async (target) => {
+      if (target === MEMORY_STORAGE_DIR) {
+        return [['cycle', FileType.Directory | FileType.SymbolicLink]];
+      }
+      if (target === cyclePath) {
+        throw new Error('The symlink cycle must not be traversed');
+      }
+      throw new Error(`Unexpected readDir target: ${target}`);
+    });
+    vi.spyOn(StorageFS, 'stat').mockImplementation(async (target) => {
+      if (target === cyclePath) {
+        throw new Error('The symlink cycle must not be statted');
+      }
+      return dirStat();
+    });
+
+    const result = await new MemoryTool().call({
+      command: 'view',
+      path: MEMORY_DISPLAY_ROOT,
+    });
+
+    expect(result).toMatchObject({
+      status: 'executed',
+      summary: 'Listed directory: /memories (1–1 of 1)',
+    });
+    expect(result.output).not.toContain('cycle');
   });
 });

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -10,11 +10,14 @@ import {
   getRunContextExecutionId,
   tryUseRunContext,
 } from '@agent/runtime/RunContext';
-import { debug } from '@logger/logUtils';
 import { MEMORY_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 import { formatBytes, formatRelativeTime } from '@shared/utils/string';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { replaceLiteralMatches } from '@tools/fileEditFlow';
+import {
+  countPinnedMemories,
+  walkMemoryDirectory,
+} from '@tools/memory/memoryFileSystem';
 import { StorageFS } from '@utils/files';
 import { isDirectory } from '@utils/files/fsEntryType';
 import { splitContentLines } from '@utils/text/stringUtils';
@@ -37,7 +40,6 @@ import {
   MAX_PINNED_MEMORIES,
   DIRECTORY_LISTING_DEPTH,
   MEMORY_DISPLAY_ROOT,
-  shouldSkipEntry,
 } from './constants';
 import { displayToStoragePath, toDisplayPath } from './memoryUtils';
 import {
@@ -46,7 +48,6 @@ import {
   createMeta,
   formatAttribution,
   setPinnedMeta,
-  countPinnedMemories,
   type MemoryFileMeta,
 } from './memoryMeta';
 
@@ -145,6 +146,7 @@ type ListingEntry = {
   size: number;
   mtime: number;
   isDir: boolean;
+  meta?: MemoryFileMeta | null;
 };
 
 /**
@@ -546,57 +548,28 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
       isDir: true,
     });
 
-    await this.walkDirectory(resolvedPath, 0, entries);
-
-    return Promise.all(
-      entries.map(async (entry) => {
-        let display = toDisplayPath(entry.path);
-        const age = formatRelativeTime(entry.mtime);
-        let by = '-';
-        if (!entry.isDir) {
-          try {
-            const { meta } = await this.readMemoryFile(entry.path);
-            if (meta) {
-              by = formatAttribution(meta);
-              if (meta.pinned) display += ' [pinned]';
-            }
-          } catch (error) {
-            // Unreadable file — skip attribution (benign: listing still works)
-            debug(
-              'memory',
-              `Skipping attribution for unreadable memory file ${entry.path}`,
-              { data: error },
-            );
-          }
-        }
-        return `${formatBytes(entry.size)}\t${age}\t${by}\t${display}`;
-      }),
-    );
-  }
-
-  private async walkDirectory(
-    currentPath: string,
-    depth: number,
-    entries: ListingEntry[],
-  ): Promise<void> {
-    if (depth >= DIRECTORY_LISTING_DEPTH) return;
-
-    const children = await StorageFS.readDir(currentPath);
-    for (const [name, type] of children) {
-      if (shouldSkipEntry(name)) continue;
-      const childPath = path.join(currentPath, name);
-      const stats = await StorageFS.stat(childPath);
-      const isDir = isDirectory(type);
+    for await (const entry of walkMemoryDirectory(resolvedPath, '', {
+      maxDepth: DIRECTORY_LISTING_DEPTH,
+      includeDirs: true,
+    })) {
       entries.push({
-        path: childPath,
-        size: stats.size,
-        mtime: stats.mtime,
-        isDir,
+        path: entry.storagePath,
+        size: entry.size,
+        mtime: entry.mtime,
+        isDir: entry.isDir,
+        meta: entry.meta,
       });
-
-      if (isDir) {
-        await this.walkDirectory(childPath, depth + 1, entries);
-      }
     }
+
+    return entries.map((entry) => {
+      let display = toDisplayPath(entry.path);
+      const age = formatRelativeTime(entry.mtime);
+      let by = '-';
+      if (!entry.isDir && entry.meta) {
+        by = formatAttribution(entry.meta);
+        if (entry.meta.pinned) display += ' [pinned]';
+      }
+      return `${formatBytes(entry.size)}\t${age}\t${by}\t${display}`;
+    });
   }
 }

--- a/src/tools/memory/memoryFileSystem.ts
+++ b/src/tools/memory/memoryFileSystem.ts
@@ -61,7 +61,7 @@ function createWalkTaskRunner(concurrency: number): WalkTaskRunner {
   const waiters: Array<() => void> = [];
 
   return async <T>(task: () => Promise<T>): Promise<T> => {
-    if (activeTasks >= concurrency) {
+    while (activeTasks >= concurrency) {
       await new Promise<void>((resolve) => {
         waiters.push(resolve);
       });

--- a/src/tools/memory/memoryFileSystem.ts
+++ b/src/tools/memory/memoryFileSystem.ts
@@ -7,8 +7,9 @@
 
 import * as path from 'node:path';
 
-import pMap from 'p-map';
+import { pMapIterable, pMapSkip } from 'p-map';
 
+import { debug } from '@logger/logUtils';
 import { MEMORY_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
 import type { MemoryPreview, MemoryViewItem } from '@shared/schemas';
 import {
@@ -17,7 +18,11 @@ import {
   shouldSkipEntry,
 } from '@tools/memory/constants';
 import { relativeToDisplayPath } from '@tools/memory/memoryUtils';
-import { parseFrontmatter, formatAttribution } from '@tools/memory/memoryMeta';
+import {
+  parseFrontmatter,
+  formatAttribution,
+  type MemoryFileMeta,
+} from '@tools/memory/memoryMeta';
 import { StorageFS } from '@utils/files';
 import { isDirectory, isSymlink } from '@utils/files/fsEntryType';
 import {
@@ -29,9 +34,47 @@ const FRONTMATTER_SCAN_BYTES = 16 * 1024;
 const PREVIEW_SCAN_BYTES = 64 * 1024;
 const MEMORY_LISTING_CONCURRENCY = 8;
 
-interface DirectoryToWalk {
+/** Options controlling how far and how much {@link walkMemoryDirectory} descends. */
+export interface MemoryWalkOptions {
+  /** Number of levels below the walk root to include. Unlimited when omitted. */
+  maxDepth?: number;
+  /** Include directory entries themselves in the yielded results. */
+  includeDirs?: boolean;
+}
+
+/** One filesystem entry discovered while walking the memory tree. */
+export interface MemoryWalkEntry {
+  /** Path relative to the walk root (matches the `relativeRoot` passed in). */
+  relativePath: string;
   storagePath: string;
-  relativeRoot: string;
+  size: number;
+  mtime: number;
+  isDir: boolean;
+  /** Frontmatter metadata for files; always null for directories. */
+  meta: MemoryFileMeta | null;
+}
+
+type WalkTaskRunner = <T>(task: () => Promise<T>) => Promise<T>;
+
+function createWalkTaskRunner(concurrency: number): WalkTaskRunner {
+  let activeTasks = 0;
+  const waiters: Array<() => void> = [];
+
+  return async <T>(task: () => Promise<T>): Promise<T> => {
+    if (activeTasks >= concurrency) {
+      await new Promise<void>((resolve) => {
+        waiters.push(resolve);
+      });
+    }
+
+    activeTasks++;
+    try {
+      return await task();
+    } finally {
+      activeTasks--;
+      waiters.shift()?.();
+    }
+  };
 }
 
 async function readStoragePrefix(
@@ -89,12 +132,23 @@ function buildPreview(
 }
 
 async function readMemoryMeta(storagePath: string, stats: { size: number }) {
-  const { text: raw } = await readStoragePrefix(
-    storagePath,
-    FRONTMATTER_SCAN_BYTES,
-    stats,
-  );
-  return parseFrontmatter(raw).meta;
+  try {
+    const { text: raw } = await readStoragePrefix(
+      storagePath,
+      FRONTMATTER_SCAN_BYTES,
+      stats,
+    );
+    return parseFrontmatter(raw).meta;
+  } catch (error) {
+    // Unreadable file (race deletion, permission error) — skip attribution
+    // rather than failing the whole walk; the entry itself still lists.
+    debug(
+      'memory',
+      `Skipping attribution for unreadable memory file ${storagePath}`,
+      { data: error },
+    );
+    return null;
+  }
 }
 
 export async function loadMemoryPreview(
@@ -111,81 +165,100 @@ export async function loadMemoryPreview(
   };
 }
 
-/**
- * Walks the memory directory and collects all memory items.
- * @param storagePath - Current directory path to walk
- * @param relativeRoot - Path relative to MEMORY_STORAGE_DIR for display
- * @returns Array of memory items found in the directory
- */
-export async function walkMemoryDirectory(
+async function* walkDir(
   storagePath: string,
-  relativeRoot = '',
-): Promise<MemoryViewItem[]> {
-  const items: MemoryViewItem[] = [];
-  const pendingDirectories: DirectoryToWalk[] = [{ storagePath, relativeRoot }];
+  relativeRoot: string,
+  depth: number,
+  options: MemoryWalkOptions,
+  runTask: WalkTaskRunner,
+): AsyncGenerator<MemoryWalkEntry> {
+  const entries = await StorageFS.readDir(storagePath);
 
-  for (let index = 0; index < pendingDirectories.length; index++) {
-    const directory = pendingDirectories[index];
-    const entries = await StorageFS.readDir(directory.storagePath);
+  const results = pMapIterable(
+    entries,
+    async ([name, type]): Promise<MemoryWalkEntry | typeof pMapSkip> => {
+      if (shouldSkipEntry(name)) {
+        return pMapSkip;
+      }
 
-    const results = await pMap(
-      entries,
-      async ([name, type]): Promise<{
-        item?: MemoryViewItem;
-        directory?: DirectoryToWalk;
-      } | null> => {
-        if (shouldSkipEntry(name)) {
-          return null;
-        }
+      // Skip symlinks to avoid cycles; we have no realpath/visited guard.
+      if (isSymlink(type)) {
+        return pMapSkip;
+      }
 
-        // Skip symlinks to avoid cycles; we have no realpath/visited guard.
-        if (isSymlink(type)) {
-          return null;
-        }
-
-        const nextRelative = directory.relativeRoot
-          ? path.join(directory.relativeRoot, name)
+      return runTask(async () => {
+        const nextRelative = relativeRoot
+          ? path.join(relativeRoot, name)
           : name;
-        const nextStoragePath = path.join(MEMORY_STORAGE_DIR, nextRelative);
+        const nextStoragePath = path.join(storagePath, name);
+        const stats = await StorageFS.stat(nextStoragePath);
 
         if (isDirectory(type)) {
           return {
-            directory: {
-              storagePath: nextStoragePath,
-              relativeRoot: nextRelative,
-            },
+            relativePath: nextRelative,
+            storagePath: nextStoragePath,
+            size: stats.size,
+            mtime: stats.mtime,
+            isDir: true,
+            meta: null,
           };
         }
 
-        const stats = await StorageFS.stat(nextStoragePath);
         const meta = await readMemoryMeta(nextStoragePath, stats);
-        const displayPath = relativeToDisplayPath(nextRelative);
-
         return {
-          item: {
-            displayPath,
-            storagePath: nextStoragePath,
-            size: stats.size,
-            mtime: new Date(stats.mtime).toISOString(),
-            modifiedBy: meta ? formatAttribution(meta) : undefined,
-            pinned: meta?.pinned,
-          },
+          relativePath: nextRelative,
+          storagePath: nextStoragePath,
+          size: stats.size,
+          mtime: stats.mtime,
+          isDir: false,
+          meta,
         };
-      },
-      { concurrency: MEMORY_LISTING_CONCURRENCY },
-    );
+      });
+    },
+    { concurrency: MEMORY_LISTING_CONCURRENCY },
+  );
 
-    for (const result of results) {
-      if (result?.directory) {
-        pendingDirectories.push(result.directory);
+  for await (const entry of results) {
+    if (entry.isDir) {
+      if (options.includeDirs) {
+        yield entry;
       }
-      if (result?.item) {
-        items.push(result.item);
+      if (options.maxDepth === undefined || depth + 1 < options.maxDepth) {
+        yield* walkDir(
+          entry.storagePath,
+          entry.relativePath,
+          depth + 1,
+          options,
+          runTask,
+        );
       }
+    } else {
+      yield entry;
     }
   }
+}
 
-  return items;
+/**
+ * Walks the memory directory tree in depth-first order, skipping dotfiles,
+ * `node_modules`, and symlinks (no realpath/visited guard, so a symlink is
+ * never followed rather than risking a cycle).
+ * @param storagePath - Directory to start walking from
+ * @param relativeRoot - Path prefix used to build each entry's relativePath
+ * @param options - `maxDepth` (levels below the root; unlimited if omitted)
+ *   and `includeDirs` (whether directory entries themselves are yielded)
+ */
+export function walkMemoryDirectory(
+  storagePath: string,
+  relativeRoot = '',
+  options: MemoryWalkOptions = {},
+): AsyncGenerator<MemoryWalkEntry> {
+  return walkDir(
+    storagePath,
+    relativeRoot,
+    0,
+    options,
+    createWalkTaskRunner(MEMORY_LISTING_CONCURRENCY),
+  );
 }
 
 /**
@@ -198,9 +271,37 @@ export async function loadMemoryItems(): Promise<MemoryViewItem[]> {
     return [];
   }
 
-  const items = await walkMemoryDirectory(MEMORY_STORAGE_DIR);
+  const items: MemoryViewItem[] = [];
+  for await (const entry of walkMemoryDirectory(MEMORY_STORAGE_DIR)) {
+    items.push({
+      displayPath: relativeToDisplayPath(entry.relativePath),
+      storagePath: entry.storagePath,
+      size: entry.size,
+      mtime: new Date(entry.mtime).toISOString(),
+      modifiedBy: entry.meta ? formatAttribution(entry.meta) : undefined,
+      pinned: entry.meta?.pinned,
+    });
+  }
   return items.toSorted(
     (a, b) =>
       (b.pinned ? 1 : 0) - (a.pinned ? 1 : 0) || b.mtime.localeCompare(a.mtime),
   );
+}
+
+/**
+ * Count pinned memory files under MEMORY_STORAGE_DIR.
+ * Short-circuits once `limit` is reached to avoid unnecessary reads.
+ * Returns 0 if the storage root does not exist.
+ */
+export async function countPinnedMemories(limit?: number): Promise<number> {
+  const exists = await StorageFS.exists(MEMORY_STORAGE_DIR);
+  if (!exists) return 0;
+
+  const cap = limit ?? Infinity;
+  let count = 0;
+  for await (const entry of walkMemoryDirectory(MEMORY_STORAGE_DIR)) {
+    if (entry.meta?.pinned) count++;
+    if (count >= cap) break;
+  }
+  return count;
 }

--- a/src/tools/memory/memoryMeta.ts
+++ b/src/tools/memory/memoryMeta.ts
@@ -6,17 +6,10 @@
  * no locking, no orphan cleanup — delete/rename just works.
  */
 
-import * as path from 'node:path';
-
 import * as yaml from 'yaml';
 import { z } from 'zod';
 
 import { parseYamlWith } from '@common/parsing/safeParseYaml';
-import { MEMORY_STORAGE_DIR } from '@platform/defaults/workspaceStorage';
-import { StorageFS } from '@utils/files';
-import { isDirectory } from '@utils/files/fsEntryType';
-
-import { shouldSkipEntry } from './constants';
 
 /**
  * Attribution metadata schema. Source of truth for the {@link MemoryFileMeta}
@@ -144,38 +137,6 @@ export function setPinnedMeta(
     ...base,
     pinned: pinned ? true : undefined,
   };
-}
-
-/**
- * Count pinned memory files under MEMORY_STORAGE_DIR.
- * Short-circuits once `limit` is reached to avoid unnecessary reads.
- * Returns 0 if the storage root does not exist.
- */
-export async function countPinnedMemories(limit?: number): Promise<number> {
-  const exists = await StorageFS.exists(MEMORY_STORAGE_DIR);
-  if (!exists) return 0;
-  return countPinnedInDir(MEMORY_STORAGE_DIR, limit ?? Infinity);
-}
-
-async function countPinnedInDir(
-  dirPath: string,
-  limit: number,
-): Promise<number> {
-  let count = 0;
-  const children = await StorageFS.readDir(dirPath);
-  for (const [name, type] of children) {
-    if (shouldSkipEntry(name)) continue;
-    const childPath = path.join(dirPath, name);
-    if (isDirectory(type)) {
-      count += await countPinnedInDir(childPath, limit - count);
-    } else {
-      const raw = await StorageFS.read(childPath);
-      const { meta } = parseFrontmatter(raw);
-      if (meta?.pinned) count++;
-    }
-    if (count >= limit) break;
-  }
-  return count;
 }
 
 // ── Display ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- use the symlink-safe memory walker for settings, tool listings, and pinned-memory counting
- preserve the model-facing directory listing format and depth limit
- stop pinned-memory counting at the configured cap
- cover symlink cycles and the exact listing output

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm run compile:fast`
- `npx vitest run src/test-kernel/tools/MemoryTool.vitest.ts src/test-kernel/settings/MemoryFileSystemConcurrency.vitest.ts`

Closes #9428

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Shared filesystem traversal affects pin limits and all memory listings; behavior changes (prefix reads, symlink skip) are intentional but touch multiple user-facing paths.
> 
> **Overview**
> **Unifies memory tree walking** so settings UI, `MemoryTool` directory listings, and pinned-memory limits all use the same `walkMemoryDirectory` async generator in `memoryFileSystem`, instead of separate recursive walkers (including the old full-file-read pin counter in `memoryMeta`).
> 
> The shared walker **skips symlinks**, supports **`maxDepth` / `includeDirs`**, reads **frontmatter via bounded prefix streams** with **concurrency limits**, and **tolerates unreadable files** without failing the whole listing. **`countPinnedMemories`** moves here and **stops scanning once the limit is reached**.
> 
> **`MemoryTool`** drops its private directory walk and builds model-facing listings from walker metadata (preserving depth limit, attribution, and `[pinned]` tags). **Imports** in settings wiring switch to the filesystem module. **Tests** cover concurrency, early pin-count exit, exact listing output, depth bounds, and symlink cycles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 982eb21e98a1c709ec3593e5219b7319eadbf5e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->