### PR TITLE
fix: confirm extension custom agent deletion

### DIFF
--- a/packages/extension/src/settingsView/handlers/agentHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/agentHandlers.ts
@@ -355,6 +355,14 @@ export class AgentHandlers {
         return;
       }
 
+      const deleteChoice = 'Delete';
+      const confirmed = await vscode.window.showWarningMessage(
+        `Delete "${data.agentName}"? This cannot be undone.`,
+        { modal: true },
+        deleteChoice,
+      );
+      if (confirmed !== deleteChoice) return;
+
       await AbsoluteFS.delete(result.plan.path, { recursive: false });
 
       void vscode.window.showInformationMessage(


### PR DESCRIPTION
## Summary

- require confirmation before the extension deletes a custom agent
- match the desktop confirmation message and cancellation behavior

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm run compile:fast`
- `npx vitest run src/test-kernel/controllers/SettingsAgentFileController.vitest.ts`
- `npx prettier --check packages/extension/src/settingsView/handlers/agentHandlers.ts`

Closes #9420

🤖 Generated with [Claude Code](https://claude.com/claude-code)