### PR TITLE
refactor: extract shared persistTerminalExecution helper

### DIFF
--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -25,6 +25,7 @@ import {
   STREAM_PHASE,
   buildRunDescriptor,
   toRetryErrorInfo,
+  type ExecutionId,
   type RunOutcome,
   type StreamTabId,
 } from '@shared/schemas';
@@ -121,6 +122,79 @@ export interface FinalizeRunTerminalResult {
   readonly terminalStatusPersisted: boolean;
 }
 
+export interface PersistTerminalExecutionParams {
+  readonly executionId: ExecutionId;
+  /** Included in warn-log `data` only when the caller has one to report. */
+  readonly agentName?: string;
+  readonly outcome: RunOutcome;
+  readonly flowRecord: FinalizeExecutionInput['flowRecord'];
+  /** Caller's own channel trace, so warn logs keep their originating channel. */
+  readonly logger: AgentTrace;
+  /** Message text differs per call site and is asserted verbatim by existing tests. */
+  readonly failedMessage: string;
+  readonly rejectedMessage: string;
+}
+
+export interface PersistTerminalExecutionResult {
+  readonly terminalStatusPersisted: boolean;
+}
+
+/**
+ * Shared `finalizeExecution` try/catch used by both terminal-persistence
+ * sites: `finalizeRunTerminal`'s finalize arm below and
+ * `ExecutionRegistry.finishWaitingTermination`'s waiting-stop arm. Both sides
+ * previously duplicated this exactly: call `finalizeExecution`, mark the
+ * owned lease undurable and warn on either a `'failed'` result or a rejected
+ * promise, and hand back whether the terminal status reached disk. The
+ * caller keeps everything this helper does not own: the registry keeps its
+ * `synchronizeAgentResultOutcome` follow-up and root-lease release in its own
+ * `finally`; this function never throws, so a caller-side `catch` is
+ * unnecessary and would be dead code.
+ */
+export async function persistTerminalExecution(
+  params: PersistTerminalExecutionParams,
+): Promise<PersistTerminalExecutionResult> {
+  const {
+    executionId,
+    agentName,
+    outcome,
+    flowRecord,
+    logger: callerLogger,
+    failedMessage,
+    rejectedMessage,
+  } = params;
+  try {
+    const finalization = await finalizeExecution({
+      executionId,
+      terminalStatus: projectRunOutcome(outcome).executionStatus,
+      flowRecord,
+    });
+    if (finalization.status === 'failed') {
+      markOwnedExecutionLeaseUndurable(executionId);
+      callerLogger.warn(failedMessage, {
+        data: {
+          ...(agentName ? { agentIdentifier: agentName } : {}),
+          executionId,
+          stage: finalization.stage,
+          terminalStatusPersisted: finalization.terminalStatusPersisted,
+          error: finalization.error,
+        },
+      });
+    }
+    return { terminalStatusPersisted: finalization.terminalStatusPersisted };
+  } catch (error) {
+    markOwnedExecutionLeaseUndurable(executionId);
+    callerLogger.warn(rejectedMessage, {
+      data: {
+        ...(agentName ? { agentIdentifier: agentName } : {}),
+        executionId,
+        error,
+      },
+    });
+    return { terminalStatusPersisted: false };
+  }
+}
+
 /**
  * The single owner of terminal run choreography, shared by the run lifecycle
  * arms below, the agent-CLI session loop, and child stream tabs
@@ -149,35 +223,16 @@ export async function finalizeRunTerminal(
   handle.clearWaitingCleanup();
   let terminalStatusPersisted = false;
   if (params.persistence.kind === 'finalize') {
-    try {
-      const finalization = await finalizeExecution({
-        executionId: handle.executionId,
-        terminalStatus: projectRunOutcome(outcome).executionStatus,
-        flowRecord: params.persistence.flowRecord,
-      });
-      if (finalization.status === 'failed') {
-        markOwnedExecutionLeaseUndurable(handle.executionId);
-        logger.warn('Failed to finalize durable execution state', {
-          data: {
-            agentIdentifier: handle.agentName,
-            executionId: handle.executionId,
-            stage: finalization.stage,
-            terminalStatusPersisted: finalization.terminalStatusPersisted,
-            error: finalization.error,
-          },
-        });
-      }
-      terminalStatusPersisted = finalization.terminalStatusPersisted;
-    } catch (error) {
-      markOwnedExecutionLeaseUndurable(handle.executionId);
-      logger.warn('Execution finalizer rejected unexpectedly', {
-        data: {
-          agentIdentifier: handle.agentName,
-          executionId: handle.executionId,
-          error,
-        },
-      });
-    }
+    const persisted = await persistTerminalExecution({
+      executionId: handle.executionId,
+      agentName: handle.agentName,
+      outcome,
+      flowRecord: params.persistence.flowRecord,
+      logger,
+      failedMessage: 'Failed to finalize durable execution state',
+      rejectedMessage: 'Execution finalizer rejected unexpectedly',
+    });
+    terminalStatusPersisted = persisted.terminalStatusPersisted;
   }
   if (params.stage) {
     try {

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -1,4 +1,4 @@
-import { finalizeExecution, type FinalizeExecutionInput } from '@agent/storage';
+import type { FinalizeExecutionInput } from '@agent/storage';
 import {
   logSdkError,
   type AgentTrace,
@@ -7,7 +7,6 @@ import {
 } from '@agent/trace';
 import { createChannelTrace } from '@agent/trace';
 import {
-  markOwnedExecutionLeaseUndurable,
   onOwnedExecutionLeaseLost,
   captureOwnedExecutionLeaseIfPresent,
 } from '@agent/storage/executionLease';
@@ -25,7 +24,6 @@ import {
   STREAM_PHASE,
   buildRunDescriptor,
   toRetryErrorInfo,
-  type ExecutionId,
   type RunOutcome,
   type StreamTabId,
 } from '@shared/schemas';
@@ -35,7 +33,6 @@ import {
 } from '@shared/state/onboardingState';
 import { agentName as baseAgentName } from '@shared/schemas/agent';
 import { SETUP_AGENT_NAME } from '@shared/constants/agents';
-import { projectRunOutcome } from '@shared/streams/streamStatus';
 
 import { AgentExecutionHandle, type AgentRunHandle } from './ExecutionHandle';
 import { persistTerminalExecution } from './persistTerminalExecution';

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -38,6 +38,7 @@ import { SETUP_AGENT_NAME } from '@shared/constants/agents';
 import { projectRunOutcome } from '@shared/streams/streamStatus';
 
 import { AgentExecutionHandle, type AgentRunHandle } from './ExecutionHandle';
+import { persistTerminalExecution } from './persistTerminalExecution';
 import {
   getAgentFlowErrorResult,
   buildTerminalFlowResult,
@@ -120,79 +121,6 @@ export interface FinalizeRunTerminalParams {
 export interface FinalizeRunTerminalResult {
   readonly event: ResultEvent;
   readonly terminalStatusPersisted: boolean;
-}
-
-export interface PersistTerminalExecutionParams {
-  readonly executionId: ExecutionId;
-  /** Included in warn-log `data` only when the caller has one to report. */
-  readonly agentName?: string;
-  readonly outcome: RunOutcome;
-  readonly flowRecord: FinalizeExecutionInput['flowRecord'];
-  /** Caller's own channel trace, so warn logs keep their originating channel. */
-  readonly logger: AgentTrace;
-  /** Message text differs per call site and is asserted verbatim by existing tests. */
-  readonly failedMessage: string;
-  readonly rejectedMessage: string;
-}
-
-export interface PersistTerminalExecutionResult {
-  readonly terminalStatusPersisted: boolean;
-}
-
-/**
- * Shared `finalizeExecution` try/catch used by both terminal-persistence
- * sites: `finalizeRunTerminal`'s finalize arm below and
- * `ExecutionRegistry.finishWaitingTermination`'s waiting-stop arm. Both sides
- * previously duplicated this exactly: call `finalizeExecution`, mark the
- * owned lease undurable and warn on either a `'failed'` result or a rejected
- * promise, and hand back whether the terminal status reached disk. The
- * caller keeps everything this helper does not own: the registry keeps its
- * `synchronizeAgentResultOutcome` follow-up and root-lease release in its own
- * `finally`; this function never throws, so a caller-side `catch` is
- * unnecessary and would be dead code.
- */
-export async function persistTerminalExecution(
-  params: PersistTerminalExecutionParams,
-): Promise<PersistTerminalExecutionResult> {
-  const {
-    executionId,
-    agentName,
-    outcome,
-    flowRecord,
-    logger: callerLogger,
-    failedMessage,
-    rejectedMessage,
-  } = params;
-  try {
-    const finalization = await finalizeExecution({
-      executionId,
-      terminalStatus: projectRunOutcome(outcome).executionStatus,
-      flowRecord,
-    });
-    if (finalization.status === 'failed') {
-      markOwnedExecutionLeaseUndurable(executionId);
-      callerLogger.warn(failedMessage, {
-        data: {
-          ...(agentName ? { agentIdentifier: agentName } : {}),
-          executionId,
-          stage: finalization.stage,
-          terminalStatusPersisted: finalization.terminalStatusPersisted,
-          error: finalization.error,
-        },
-      });
-    }
-    return { terminalStatusPersisted: finalization.terminalStatusPersisted };
-  } catch (error) {
-    markOwnedExecutionLeaseUndurable(executionId);
-    callerLogger.warn(rejectedMessage, {
-      data: {
-        ...(agentName ? { agentIdentifier: agentName } : {}),
-        executionId,
-        error,
-      },
-    });
-    return { terminalStatusPersisted: false };
-  }
 }
 
 /**

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -12,7 +12,7 @@ import {
   ExecutionLeaseLostError,
   markOwnedExecutionLeaseUndurable,
 } from '@agent/storage/executionLease';
-import { persistTerminalExecution } from '@agent/runtime/AgentRunLifecycle';
+import { persistTerminalExecution } from '@agent/runtime/persistTerminalExecution';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { SessionApprovals } from '@agent/runtime/streamApprovalQueue';
 import {

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -5,16 +5,14 @@
  * notification, and subagent lineage tracking in a single module.
  */
 
-import {
-  finalizeExecution,
-  synchronizeAgentResultOutcome,
-} from '@agent/storage';
+import { synchronizeAgentResultOutcome } from '@agent/storage';
 import { createChannelTrace, type ResultEvent } from '@agent/trace';
 import {
   completeOwnedExecutionLease,
   ExecutionLeaseLostError,
   markOwnedExecutionLeaseUndurable,
 } from '@agent/storage/executionLease';
+import { persistTerminalExecution } from '@agent/runtime/AgentRunLifecycle';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { SessionApprovals } from '@agent/runtime/streamApprovalQueue';
 import {
@@ -34,7 +32,6 @@ import {
   isActivePhase,
   isInFlightPhase,
   isTerminalOutcomePhase,
-  projectRunOutcome,
 } from '@shared/streams/streamStatus';
 import { formatDuration } from '@utils/core';
 import {
@@ -956,34 +953,20 @@ export class ExecutionRegistry {
       // after durable terminal metadata exists. A turn that does continue will
       // replace it with its own result.
       try {
-        const result = await finalizeExecution({
+        const result = await persistTerminalExecution({
           executionId: handle.executionId,
-          terminalStatus: projectRunOutcome(RUN_OUTCOME.CANCELLED)
-            .executionStatus,
+          outcome: RUN_OUTCOME.CANCELLED,
           flowRecord: 'delete',
+          logger,
+          failedMessage: 'Failed to finalize stopped waiting execution',
+          rejectedMessage: 'Waiting-execution finalizer rejected unexpectedly',
         });
-        if (result.status === 'failed') {
-          markOwnedExecutionLeaseUndurable(handle.executionId);
-          logger.warn('Failed to finalize stopped waiting execution', {
-            data: {
-              executionId: handle.executionId,
-              stage: result.stage,
-              terminalStatusPersisted: result.terminalStatusPersisted,
-              error: result.error,
-            },
-          });
-        }
         if (result.terminalStatusPersisted) {
           await synchronizeAgentResultOutcome(
             handle.executionId,
             RUN_OUTCOME.CANCELLED,
           );
         }
-      } catch (error) {
-        markOwnedExecutionLeaseUndurable(handle.executionId);
-        logger.warn('Waiting-execution finalizer rejected unexpectedly', {
-          data: { executionId: handle.executionId, error },
-        });
       } finally {
         if (!handle.isChildExecution) {
           try {

--- a/src/agent/runtime/persistTerminalExecution.ts
+++ b/src/agent/runtime/persistTerminalExecution.ts
@@ -1,0 +1,88 @@
+/**
+ * Shared terminal-persistence tail for the two run-finalization arms.
+ *
+ * Lives in its own module rather than beside either caller: `AgentRunLifecycle`
+ * already imports `ExecutionRegistry`, so hosting this value here keeps the
+ * registry from importing back into the lifecycle module and closing the graph.
+ */
+
+import { finalizeExecution, type FinalizeExecutionInput } from '@agent/storage';
+import type { AgentTrace } from '@agent/trace';
+import { markOwnedExecutionLeaseUndurable } from '@agent/storage/executionLease';
+import type { ExecutionId, RunOutcome } from '@shared/schemas';
+import { projectRunOutcome } from '@shared/streams/streamStatus';
+
+export interface PersistTerminalExecutionParams {
+  readonly executionId: ExecutionId;
+  /** Included in warn-log `data` only when the caller has one to report. */
+  readonly agentName?: string;
+  readonly outcome: RunOutcome;
+  readonly flowRecord: FinalizeExecutionInput['flowRecord'];
+  /** Caller's own channel trace, so warn logs keep their originating channel. */
+  readonly logger: AgentTrace;
+  /** Message text differs per call site and is asserted verbatim by existing tests. */
+  readonly failedMessage: string;
+  readonly rejectedMessage: string;
+}
+
+export interface PersistTerminalExecutionResult {
+  readonly terminalStatusPersisted: boolean;
+}
+
+/**
+ * Shared `finalizeExecution` try/catch used by both terminal-persistence
+ * sites: `AgentRunLifecycle.finalizeRunTerminal`'s finalize arm and
+ * `ExecutionRegistry.finishWaitingTermination`'s waiting-stop arm. Both sides
+ * previously duplicated this exactly: call `finalizeExecution`, mark the
+ * owned lease undurable and warn on either a `'failed'` result or a rejected
+ * promise, and hand back whether the terminal status reached disk. The
+ * caller keeps everything this helper does not own: the registry keeps its
+ * `synchronizeAgentResultOutcome` follow-up and root-lease release in its own
+ * `finally`; this function never throws, so a caller-side `catch` is
+ * unnecessary and would be dead code.
+ */
+export async function persistTerminalExecution(
+  params: PersistTerminalExecutionParams,
+): Promise<PersistTerminalExecutionResult> {
+  const {
+    executionId,
+    agentName,
+    outcome,
+    flowRecord,
+    logger: callerLogger,
+    failedMessage,
+    rejectedMessage,
+  } = params;
+  const agentData =
+    agentName !== undefined ? { agentIdentifier: agentName } : {};
+  try {
+    const finalization = await finalizeExecution({
+      executionId,
+      terminalStatus: projectRunOutcome(outcome).executionStatus,
+      flowRecord,
+    });
+    if (finalization.status === 'failed') {
+      markOwnedExecutionLeaseUndurable(executionId);
+      callerLogger.warn(failedMessage, {
+        data: {
+          ...agentData,
+          executionId,
+          stage: finalization.stage,
+          terminalStatusPersisted: finalization.terminalStatusPersisted,
+          error: finalization.error,
+        },
+      });
+    }
+    return { terminalStatusPersisted: finalization.terminalStatusPersisted };
+  } catch (error) {
+    markOwnedExecutionLeaseUndurable(executionId);
+    callerLogger.warn(rejectedMessage, {
+      data: {
+        ...agentData,
+        executionId,
+        error,
+      },
+    });
+    return { terminalStatusPersisted: false };
+  }
+}


### PR DESCRIPTION
## Summary

Closes #9418.

`finishWaitingTermination` (`executionRegistry.ts`) and `finalizeRunTerminal`
(`AgentRunLifecycle.ts`) each ran the identical `finalizeExecution` try/catch:
call `finalizeExecution`, mark the owned lease undurable and warn on either a
`'failed'` result or a rejected promise, and hand back whether the terminal
status reached disk. Extracted that block into a single
`persistTerminalExecution` helper in `AgentRunLifecycle.ts` with exactly two
callers.

The two call sites differ in two ways that existing tests assert verbatim:
the warn-log message text, and whether the log `data` includes an
`agentIdentifier` field. So the helper takes `failedMessage` /
`rejectedMessage` and the caller's own channel-trace `logger` as parameters
instead of hardcoding either — this keeps the log channel origin and text
unchanged rather than silently rerouting both call sites' warnings through
`AgentRunLifecycle`'s `agentRunLifecycle` channel.

Scope kept deliberately narrow per the issue: the registry keeps its
publish-before-persist ordering, `untrackIfCurrent`,
`synchronizeAgentResultOutcome` follow-up, and root-lease release in its own
`finally` around the helper call — none of that moved into the helper. The
`claimTerminalFinalize` two-arm terminal split was not touched.

## Net elements (R6)

- +1 export: `persistTerminalExecution` (plus its two small param/result
  interfaces) in `AgentRunLifecycle.ts`.
- -1 duplicated `finalizeExecution` try/catch block (was inlined at both call
  sites, ~24 and ~30 lines respectively).
- Net: one shared implementation instead of two near-identical ones; the two
  call sites shrank from a 20-30 line inline block each to a single call.

## Consumer counts (R8)

- `persistTerminalExecution`: 2 callers — `finalizeRunTerminal` in
  `AgentRunLifecycle.ts` (same file) and
  `ExecutionRegistry.finishWaitingTermination` in `executionRegistry.ts`.
  Both callers ship in this PR.

## Verification

- `npm run typecheck` — full chain (root tsc, test-kernel tsc, agent build,
  cli/trace-viewer/desktop typecheck) passes clean, no new errors.
- `npx vitest run src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts` —
  62/62 pass, unmodified (including the exact-message warn-log assertions
  this refactor had to preserve).
- `npx eslint src/agent/runtime/AgentRunLifecycle.ts src/agent/runtime/executionRegistry.ts` — clean.
- `npm run check:dead-code-ratchet` — 17 findings, unchanged vs baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with behavior preserved via parameterized log messages and caller-owned follow-up; touches durable execution finalization but does not change control flow at either call site.
> 
> **Overview**
> Duplicates the same **`finalizeExecution`** tail—project outcome to terminal status, mark the owned lease undurable and warn on failure or rejection, return whether the terminal status persisted—into **`persistTerminalExecution`** in a dedicated module so **`ExecutionRegistry`** can use it without importing **`AgentRunLifecycle`** (circular dependency).
> 
> **`finalizeRunTerminal`** and **`finishWaitingTermination`** now call the helper instead of inlined try/catch blocks. Call sites still pass their own trace **`logger`**, warn message strings, and optional **`agentName`** for log **`data`**, so existing test assertions on log channel and text stay unchanged. Registry-only behavior (**`synchronizeAgentResultOutcome`**, root lease release, publish/untrack ordering) remains at the call sites; the helper never throws.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 251a11f735ba3eaeff410157ed252df294ca2ba0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->