### PR TITLE
fix(runtime): bring the resume tool-use path to fresh-launch parity

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -564,45 +564,72 @@ export async function resumeToolUseFromResumeData(
           return await runFlowWithLifecycle(
             ctx,
             async (handle, lifecycle) => {
-              const result = await runToolUseFlow(
-                {
-                  ...ctx,
-                  ...createInterruptCallbacks(),
-                  onRoundFinalized: createUsageRecordingCallback(ctx),
-                  setting,
-                  resume,
-                  tools: options.tools,
-                  drainedFollowUps: options.drainedFollowUps,
-                  takePendingFollowUps: options.takePendingFollowUps,
-                  // A persisted parent marks this execution as a subagent. Without
-                  // this, the rebuilt system prompt would drop subagent-specific
-                  // instructions (e.g. the shared /memories protocol) that the fresh
-                  // run had included.
-                  isSubagent,
-                  onProgress: options.onProgress,
-                  onFollowUpConsumed: wrapOnFollowUpConsumed(
-                    ctx,
-                    options.onFollowUpConsumed,
-                  ),
-                  onFlowRecordDisposition: (disposition) =>
-                    lifecycle.setFlowRecordDisposition(disposition),
-                },
-                undefined,
-                (flowContext) => {
-                  handle.attachToolUseFlow(flowContext);
-                  if (options.isCancellationRequested?.()) {
-                    options.onCancellationAtFlowAttachment?.();
-                    flowContext.interrupt();
-                  }
-                  return () => handle.detachToolUseFlow(flowContext);
-                },
-              );
-              return buildToolUseFlowResult(
-                result,
-                runExecutionId,
-                runStreamId,
-                ctx.attachedMemoryMisses,
-              );
+              try {
+                const result = await runToolUseFlow(
+                  {
+                    ...ctx,
+                    ...createInterruptCallbacks(),
+                    onRoundFinalized: createUsageRecordingCallback(ctx),
+                    setting,
+                    resume,
+                    tools: options.tools,
+                    drainedFollowUps: options.drainedFollowUps,
+                    takePendingFollowUps: options.takePendingFollowUps,
+                    // A persisted parent marks this execution as a subagent. Without
+                    // this, the rebuilt system prompt would drop subagent-specific
+                    // instructions (e.g. the shared /memories protocol) that the fresh
+                    // run had included.
+                    isSubagent,
+                    onProgress: options.onProgress,
+                    onFollowUpConsumed: wrapOnFollowUpConsumed(
+                      ctx,
+                      options.onFollowUpConsumed,
+                    ),
+                    onFlowRecordDisposition: (disposition) =>
+                      lifecycle.setFlowRecordDisposition(disposition),
+                    onModelChanged: (modelHandler) => {
+                      // The tool-use flow already wrote services.config.model
+                      // (=== ctx.config.model, same object), so the live model is
+                      // updated before this fires; only the usage side-effect is
+                      // left to do here. A resumed run reaches `switchModel` the
+                      // same way a fresh one does — through the flow context this
+                      // path attaches to the handle — so it needs the same wiring.
+                      ctx.usageMonitor.setModelInfo({
+                        capabilities: modelHandler.capabilities,
+                        config: modelHandler.config,
+                      });
+                    },
+                  },
+                  undefined,
+                  (flowContext) => {
+                    handle.attachToolUseFlow(flowContext);
+                    if (options.isCancellationRequested?.()) {
+                      options.onCancellationAtFlowAttachment?.();
+                      flowContext.interrupt();
+                    }
+                    return () => handle.detachToolUseFlow(flowContext);
+                  },
+                );
+                return buildToolUseFlowResult(
+                  result,
+                  runExecutionId,
+                  runStreamId,
+                  ctx.attachedMemoryMisses,
+                );
+              } catch (err) {
+                const failedResult = getToolUseFlowErrorResult(err);
+                if (!failedResult) throw err;
+                const result = buildToolUseFlowResult(
+                  failedResult,
+                  runExecutionId,
+                  runStreamId,
+                  ctx.attachedMemoryMisses,
+                );
+                if (isWaitingFlowResult(result)) throw err;
+                throw new AgentFlowError(getSdkErrorMessage(err), result, {
+                  cause: err,
+                });
+              }
             },
             {
               isSubagent,

--- a/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
+++ b/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   invokeModelOrTool: vi.fn(),
   runFlowWithLifecycle: vi.fn(),
   runToolUseFlow: vi.fn(),
+  getToolUseFlowErrorResult: vi.fn(() => undefined as unknown),
   acquireResumedExecutionLease: vi.fn(),
   renewOwnedExecutionLease: vi.fn(),
   runWithExecutionLeaseWriteFence: vi.fn(
@@ -57,7 +58,7 @@ vi.mock('@agent/implementations/flows/reflection/runReflectionFlow', () => ({
 }));
 
 vi.mock('@agent/implementations/flows/tooluse/runToolUseFlow', () => ({
-  getToolUseFlowErrorResult: () => undefined,
+  getToolUseFlowErrorResult: mocks.getToolUseFlowErrorResult,
   runToolUseFlow: mocks.runToolUseFlow,
 }));
 
@@ -66,6 +67,7 @@ import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import type { ITool } from '@agent/core/tools/ToolTypes';
 import type { AgentLaunchContext } from '@agent/runtime/AgentLaunchContext';
 import type { SessionHostInteractions } from '@agent/runtime/HostInteractions';
+import { AgentFlowError } from '@agent/runtime/AgentFlowResult';
 import { resumeToolUseFromResumeData } from '@agent/runtime/executeAgent';
 import { ResumeAdmissionCancelledError } from '@agent/runtime/resumeAdmission';
 import {
@@ -85,6 +87,47 @@ interface InterruptibleFlowInput {
 interface TestFlowContext {
   readonly session: { appendFollowUp(item: unknown): void };
   interrupt(): void;
+}
+
+interface ModelSwitchingFlowInput {
+  onModelChanged?: (
+    modelHandler: {
+      capabilities: Record<string, unknown>;
+      config: Record<string, unknown>;
+    },
+    model: string,
+  ) => void;
+}
+
+/** Minimal launch context for a resumed tool-use run that reaches the flow. */
+function buildResumeContext(
+  executionId: ExecutionId,
+  streamId: StreamTabId,
+  usageMonitor: { setModelInfo: ReturnType<typeof vi.fn> },
+): AgentLaunchContext {
+  return {
+    setting: { agentCategory: AgentCategory.ToolUse },
+    runScope: {
+      executionId,
+      streamId,
+      session: {
+        status: {},
+        transcripts: { ensureLoaded: vi.fn(async () => {}) },
+        flushArtifacts: vi.fn(async () => {}),
+      },
+    },
+    config: { agent: 'test-agent', model: 'test-model' },
+    attachedMemoryMisses: [],
+    usageMonitor: { recordUsage: vi.fn(), ...usageMonitor },
+  } as unknown as AgentLaunchContext;
+}
+
+/** Handle stub for tests that only need the flow to run to completion. */
+function noopFlowHandle(): unknown {
+  return {
+    attachToolUseFlow: vi.fn(),
+    detachToolUseFlow: vi.fn(),
+  };
 }
 
 describe('resumeToolUseFromResumeData cancellation handoff', () => {
@@ -259,5 +302,79 @@ describe('resumeToolUseFromResumeData cancellation handoff', () => {
       'take',
       'detach',
     ]);
+  });
+
+  it('reports a mid-run model switch to the usage monitor', async () => {
+    const executionId = 'e9421-model' as ExecutionId;
+    const streamId = 'stream-9421-model' as StreamTabId;
+    const setModelInfo = vi.fn();
+    mocks.buildAgentLaunchContext.mockResolvedValueOnce(
+      buildResumeContext(executionId, streamId, { setModelInfo }),
+    );
+    mocks.hasPersistedParent.mockResolvedValueOnce(false);
+    mocks.runFlowWithLifecycle.mockImplementationOnce(
+      async (
+        _context: unknown,
+        run: (liveHandle: unknown) => Promise<unknown>,
+      ) => run(noopFlowHandle()),
+    );
+    mocks.runToolUseFlow.mockImplementationOnce(
+      async (input: ModelSwitchingFlowInput) => {
+        input.onModelChanged?.(
+          {
+            capabilities: { supportsVision: true },
+            config: { provider: 'anthropic' },
+          },
+          'next-model',
+        );
+        return { outcome: RUN_OUTCOME.COMPLETED };
+      },
+    );
+
+    await resumeToolUseFromResumeData(
+      createToolUseResumeData({ executionId, streamId }),
+    );
+
+    expect(setModelInfo).toHaveBeenCalledWith({
+      capabilities: { supportsVision: true },
+      config: { provider: 'anthropic' },
+    });
+  });
+
+  it('wraps a failed resumed flow so the partial result reaches the lifecycle', async () => {
+    const executionId = 'e9421-error' as ExecutionId;
+    const streamId = 'stream-9421-error' as StreamTabId;
+    const cause = new Error('provider failed mid-resume');
+    mocks.buildAgentLaunchContext.mockResolvedValueOnce(
+      buildResumeContext(executionId, streamId, { setModelInfo: vi.fn() }),
+    );
+    mocks.hasPersistedParent.mockResolvedValueOnce(true);
+    mocks.runFlowWithLifecycle.mockImplementationOnce(
+      async (
+        _context: unknown,
+        run: (liveHandle: unknown) => Promise<unknown>,
+      ) => run(noopFlowHandle()),
+    );
+    mocks.runToolUseFlow.mockRejectedValueOnce(cause);
+    mocks.getToolUseFlowErrorResult.mockReturnValueOnce({
+      outcome: RUN_OUTCOME.FAILED,
+      lastResponse: 'partial answer',
+      totalCostUsd: 0.25,
+    });
+
+    const error = await resumeToolUseFromResumeData(
+      createToolUseResumeData({ executionId, streamId }),
+    ).catch((err: unknown) => err);
+
+    expect(error).toBeInstanceOf(AgentFlowError);
+    expect((error as AgentFlowError).cause).toBe(cause);
+    expect((error as AgentFlowError).result).toMatchObject({
+      category: 'toolUse',
+      outcome: RUN_OUTCOME.FAILED,
+      lastResponse: 'partial answer',
+      totalCostUsd: 0.25,
+      executionId,
+      streamId,
+    });
   });
 });


### PR DESCRIPTION
Closes #9421

## What was actually wrong

I read both `runToolUseFlow` assembly bodies in `src/agent/runtime/executeAgent.ts` and confirmed both divergences the issue named are real drift, not intentional.

### 1. `onModelChanged` missing on resume

A resumed run registers the same `ToolUseFlowContext` on the execution handle as a fresh one (`handle.attachToolUseFlow(flowContext)` in both bodies), and `flowContext.switchModel` is what the CLI `/model` command calls after resolving the flow through `executions.getToolUseFlowContext(streamId)`. So a model switch is fully reachable on a resumed run.

The flow's `switchModel` writes `services.config.model` and rebuilds the handler itself; the only thing left for the caller is the usage side effect. Without it, `UsageMonitor.modelInfo` stays on the pre-switch model for the rest of the resumed run, which affects:

- `logToBackend` records `config.fullName` and `config.provider` of the old model
- `usesServerSideKeysRoute(config)` decides relay vs api-key from the old model
- `capabilities.supportsPromptCaching` / `supportsReasoning` drive the cache percentage and whether reasoning tokens are reported

### 2. `AgentFlowError` wrapping missing on resume

`runFlowWithLifecycle`'s catch arm builds the subagent delivery result as `getAgentFlowErrorResult(err) ?? buildTerminalFlowResult(...)`. Only the `AgentFlowError` arm carries the flow's partial payload, so a failed resumed subagent turn was delivered to its orchestrator without `lastResponse`, `touchedFiles` or `totalCostUsd` — all of which the fresh path preserves.

The `isWaitingFlowResult(result) -> throw err` guard is carried over unchanged, so a failure that lands on a WAITING outcome still rethrows raw rather than being wrapped into something the lifecycle would finalize as terminal.

Wrapping does not change error handling for anything else: `isDiskFullError` and `normalizeProviderError` both walk the `cause` chain (`findInCauseChain`), and the flow already threw its own wrapper (`ToolUseFlowError`) before this point, so the outer error was never the raw provider error either way.

Nothing here was intentional: neither omission carries a comment, and the two bodies are otherwise the same assembly. This is the same amplification pattern that produced b5c6b47488 / c199ca219a (tool overlays added fresh-path-first, resume patched the same day).

## Verification

- `npm run typecheck` — clean
- `npx vitest run src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts` — 6 passed
- `npx vitest run src/test-kernel/agent/runtime/AgentLaunchActivation.vitest.ts src/test-kernel/agent/runtime/RunAgentOwnership.vitest.ts` — passed, same as on main
- The two new tests were confirmed to fail against the unpatched `executeAgent.ts` (`setModelInfo` never called; the rejection is a plain `Error`, not an `AgentFlowError`) and pass with it.

The duplicated `catch` block this adds to the resume body is removed again by the follow-up that folds the two assemblies (#9417).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent runtime resume and usage reporting paths; behavior change is intentional parity with fresh launches, with targeted tests.
> 
> **Overview**
> Aligns **`resumeToolUseFromResumeData`** with the fresh tool-use launch path so mid-run model switches and flow failures behave the same after a resume.
> 
> **`onModelChanged`** now calls `usageMonitor.setModelInfo` when the user switches models during a resumed run (e.g. `/model`), so usage logging, relay vs API-key routing, and capability-driven reporting stay on the active model instead of the pre-resume one.
> 
> A **`try/catch`** around the resumed `runToolUseFlow` uses `getToolUseFlowErrorResult` and, when partial flow data exists, rethrows **`AgentFlowError`** with that payload—matching fresh runs so subagent lifecycle and orchestrators still get `lastResponse`, cost, and related fields on failure. WAITING outcomes still propagate the original error unchanged.
> 
> Tests cover model-switch wiring and failed-resume wrapping; the flow error helper is mockable in the cancellation suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f95564bef385b71aaabb53751915a7b237cd0653. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->