### PR TITLE
refactor: fold the fresh and resume tool-use assemblies in executeAgent

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -20,10 +20,8 @@ import {
 import type { ITool } from '@agent/core/tools/ToolTypes';
 import { hasPersistedParent } from '@agent/storage/executionLifecycle';
 import {
-  abandonOwnedExecutionLease,
   acquireResumedExecutionLease,
   captureOwnedExecutionLease,
-  completeOwnedExecutionLease,
   releaseOwnedExecutionLeaseAfterFailure,
 } from '@agent/storage/executionLease';
 import { AgentError, getSdkErrorMessage } from '@common/errors';
@@ -47,6 +45,7 @@ import {
 import {
   runFlowWithLifecycle,
   type FlowLifecycleControl,
+  type RunFlowLifecycleOptions,
 } from './AgentRunLifecycle';
 import {
   AgentFlowError,
@@ -58,7 +57,7 @@ import {
 } from './AgentFlowResult';
 import { createInterruptCallbacks } from './InterruptManager';
 import { generateSessionDescription } from './sessionDescription';
-import { flushOwnedExecutionArtifacts } from './executionOwnership';
+import { releaseExecutionLeaseAfterArtifacts } from './executionOwnership';
 import { ResumeAdmissionCancelledError } from './resumeAdmission';
 import type { SessionHandle } from './SessionHandle';
 import type { AgentExecutionHandle, AgentRunHandle } from './ExecutionHandle';
@@ -116,49 +115,75 @@ function wrapOnFollowUpConsumed(
 }
 
 /**
- * Run the tool-use flow for a single agent execution.
+ * The wiring the two tool-use entry points genuinely do not share. Everything
+ * outside this union is assembled once in {@link launchToolUseRun}, so a field
+ * added for one entry point cannot go missing on the other.
+ */
+type ToolUseLaunchVariant =
+  | {
+      readonly kind: 'fresh';
+      /** Root-run-only; resume has no caller-supplied equivalent. */
+      readonly onIdle?: (lastResponse: string | undefined) => void;
+    }
+  | {
+      readonly kind: 'resume';
+      readonly resume: ToolUseResumeData;
+      readonly drainedFollowUps?: readonly FollowUpQueueBatchItem[];
+      readonly takePendingFollowUps?: () => readonly FollowUpQueueBatchItem[];
+      /** Queried once the resumed flow is attached and interruptible. */
+      readonly isCancellationRequested?: () => boolean;
+      readonly onCancellationAtFlowAttachment?: () => void;
+    };
+
+/**
+ * Run the tool-use flow for a single agent execution, fresh or resumed.
  *
  * Owns all tool-use-specific wiring: progress counters, follow-up queuing,
  * model-change side effects, and error wrapping into `AgentFlowError`.
- * The caller (`executeAgent`) owns lifecycle and stream-status; this function
- * owns only what is specific to the ToolUse category.
+ * The callers (`executeAgent`, `resumeToolUseFromResumeData`) own lifecycle and
+ * stream-status; this function owns only what is specific to the ToolUse
+ * category.
  */
-async function runToolUseAgent(
+async function launchToolUseRun(
   ctx: AgentLaunchContext,
   handle: AgentExecutionHandle,
   lifecycle: FlowLifecycleControl,
-  setting: AgentToolUseSetting,
-  options: Pick<
-    ExecuteAgentOptions,
-    'isSubagent' | 'onFollowUpConsumed' | 'onProgress' | 'onIdle' | 'tools'
-  >,
+  shared: SubagentRunOptions & {
+    readonly setting: AgentToolUseSetting;
+    /**
+     * Fresh launches take this from the caller; resume derives it from
+     * persisted lineage, because the rebuilt system prompt would otherwise drop
+     * subagent-specific instructions (e.g. the shared /memories protocol) that
+     * the fresh run had included.
+     */
+    readonly isSubagent?: boolean;
+  },
+  variant: ToolUseLaunchVariant,
 ): Promise<AgentRuntimeFlowResult> {
   const { streamId: runStreamId, executionId: runExecutionId } = ctx.runScope;
-  const onRoundFinalized = createUsageRecordingCallback(ctx);
   try {
     const result = await runToolUseFlow(
       {
         ...ctx,
         ...createInterruptCallbacks(),
-        onRoundFinalized,
-        setting,
-        isSubagent: options.isSubagent,
-        onIdle: options.onIdle,
+        onRoundFinalized: createUsageRecordingCallback(ctx),
+        setting: shared.setting,
+        isSubagent: shared.isSubagent,
+        tools: shared.tools,
         onProgress: (update) => {
           if (update.kind === 'overview') {
             logConversationProgress(ctx.logger, {
               toolCallCount: update.toolCallCount,
             });
           }
-          options.onProgress?.(update);
+          shared.onProgress?.(update);
         },
         onFollowUpConsumed: wrapOnFollowUpConsumed(
           ctx,
-          options.onFollowUpConsumed,
+          shared.onFollowUpConsumed,
         ),
         onFlowRecordDisposition: (disposition) =>
           lifecycle.setFlowRecordDisposition(disposition),
-        tools: options.tools,
         onModelChanged: (modelHandler) => {
           // The tool-use flow already wrote services.config.model
           // (=== ctx.config.model, same object), so the live model is updated
@@ -168,10 +193,21 @@ async function runToolUseAgent(
             config: modelHandler.config,
           });
         },
+        ...(variant.kind === 'fresh'
+          ? { onIdle: variant.onIdle }
+          : {
+              resume: variant.resume,
+              drainedFollowUps: variant.drainedFollowUps,
+              takePendingFollowUps: variant.takePendingFollowUps,
+            }),
       },
       undefined,
       (flowContext) => {
         handle.attachToolUseFlow(flowContext);
+        if (variant.kind === 'resume' && variant.isCancellationRequested?.()) {
+          variant.onCancellationAtFlowAttachment?.();
+          flowContext.interrupt();
+        }
         return () => handle.detachToolUseFlow(flowContext);
       },
     );
@@ -193,6 +229,24 @@ async function runToolUseAgent(
     if (isWaitingFlowResult(result)) throw err;
     throw new AgentFlowError(getSdkErrorMessage(err), result, { cause: err });
   }
+}
+
+/**
+ * The lifecycle options every entry point that drives one run passes.
+ * `isSubagent` stays a separate argument because resume derives it from
+ * persisted lineage rather than from the caller's options.
+ */
+function buildLifecycleOptions(
+  options: SubagentRunOptions,
+  isSubagent: boolean | undefined,
+): RunFlowLifecycleOptions {
+  return {
+    isSubagent,
+    parentStreamId: options.parentStreamId,
+    workflowPhase: options.workflowPhase,
+    onError: options.onRunError,
+    onRun: options.onRun,
+  };
 }
 
 /**
@@ -437,17 +491,17 @@ export async function executeAgent(
             });
 
             if (setting.agentCategory === AgentCategory.ToolUse) {
-              return runToolUseAgent(ctx, handle, lifecycle, setting, options);
+              return launchToolUseRun(
+                ctx,
+                handle,
+                lifecycle,
+                { ...options, setting, isSubagent },
+                { kind: 'fresh', onIdle: options.onIdle },
+              );
             }
             return runReflectionAgent(ctx, handle, setting);
           },
-          {
-            isSubagent,
-            parentStreamId: options.parentStreamId,
-            workflowPhase: options.workflowPhase,
-            onError: options.onRunError,
-            onRun: options.onRun,
-          },
+          buildLifecycleOptions(options, isSubagent),
         );
         if (
           isWaitingFlowResult(result) &&
@@ -541,14 +595,13 @@ export async function resumeToolUseFromResumeData(
       runtimeUnavailableTools: options.runtimeUnavailableTools,
     };
     const { setting } = ctx;
-    const {
-      streamId: runStreamId,
-      executionId: runExecutionId,
-      session: runSession,
-    } = ctx.runScope;
+    const { streamId: runStreamId, session: runSession } = ctx.runScope;
 
+    // Only the run itself is guarded here. The release below is deliberately
+    // outside: a release that fails must not be retried by the catch arm.
+    let result: AgentRuntimeFlowResult;
     try {
-      const result = await withExecutionRunContext(
+      result = await withExecutionRunContext(
         ctx,
         runContextOptions,
         async () => {
@@ -563,101 +616,46 @@ export async function resumeToolUseFromResumeData(
 
           return await runFlowWithLifecycle(
             ctx,
-            async (handle, lifecycle) => {
-              try {
-                const result = await runToolUseFlow(
-                  {
-                    ...ctx,
-                    ...createInterruptCallbacks(),
-                    onRoundFinalized: createUsageRecordingCallback(ctx),
-                    setting,
-                    resume,
-                    tools: options.tools,
-                    drainedFollowUps: options.drainedFollowUps,
-                    takePendingFollowUps: options.takePendingFollowUps,
-                    // A persisted parent marks this execution as a subagent. Without
-                    // this, the rebuilt system prompt would drop subagent-specific
-                    // instructions (e.g. the shared /memories protocol) that the fresh
-                    // run had included.
-                    isSubagent,
-                    onProgress: options.onProgress,
-                    onFollowUpConsumed: wrapOnFollowUpConsumed(
-                      ctx,
-                      options.onFollowUpConsumed,
-                    ),
-                    onFlowRecordDisposition: (disposition) =>
-                      lifecycle.setFlowRecordDisposition(disposition),
-                    onModelChanged: (modelHandler) => {
-                      // The tool-use flow already wrote services.config.model
-                      // (=== ctx.config.model, same object), so the live model is
-                      // updated before this fires; only the usage side-effect is
-                      // left to do here. A resumed run reaches `switchModel` the
-                      // same way a fresh one does — through the flow context this
-                      // path attaches to the handle — so it needs the same wiring.
-                      ctx.usageMonitor.setModelInfo({
-                        capabilities: modelHandler.capabilities,
-                        config: modelHandler.config,
-                      });
-                    },
-                  },
-                  undefined,
-                  (flowContext) => {
-                    handle.attachToolUseFlow(flowContext);
-                    if (options.isCancellationRequested?.()) {
-                      options.onCancellationAtFlowAttachment?.();
-                      flowContext.interrupt();
-                    }
-                    return () => handle.detachToolUseFlow(flowContext);
-                  },
-                );
-                return buildToolUseFlowResult(
-                  result,
-                  runExecutionId,
-                  runStreamId,
-                  ctx.attachedMemoryMisses,
-                );
-              } catch (err) {
-                const failedResult = getToolUseFlowErrorResult(err);
-                if (!failedResult) throw err;
-                const result = buildToolUseFlowResult(
-                  failedResult,
-                  runExecutionId,
-                  runStreamId,
-                  ctx.attachedMemoryMisses,
-                );
-                if (isWaitingFlowResult(result)) throw err;
-                throw new AgentFlowError(getSdkErrorMessage(err), result, {
-                  cause: err,
-                });
-              }
-            },
-            {
-              isSubagent,
-              parentStreamId: options.parentStreamId,
-              workflowPhase: options.workflowPhase,
-              onError: options.onRunError,
-              onRun: options.onRun,
-            },
+            async (handle, lifecycle) =>
+              launchToolUseRun(
+                ctx,
+                handle,
+                lifecycle,
+                { ...options, setting, isSubagent },
+                {
+                  kind: 'resume',
+                  resume,
+                  drainedFollowUps: options.drainedFollowUps,
+                  takePendingFollowUps: options.takePendingFollowUps,
+                  isCancellationRequested: options.isCancellationRequested,
+                  onCancellationAtFlowAttachment:
+                    options.onCancellationAtFlowAttachment,
+                },
+              ),
+            buildLifecycleOptions(options, isSubagent),
           );
         },
       );
-      if (!isWaitingFlowResult(result)) {
-        await flushOwnedExecutionArtifacts(runSession, resume.executionId);
-        await completeOwnedExecutionLease(resume.executionId);
-      }
-      return result;
     } catch (error) {
+      // The run's own failure is the one the caller must see; a release failure
+      // on top of it is additional information, not a replacement.
       try {
-        await flushOwnedExecutionArtifacts(runSession, resume.executionId);
-      } catch (artifactError) {
-        abandonOwnedExecutionLease(resume.executionId);
+        await releaseExecutionLeaseAfterArtifacts(
+          runSession,
+          resume.executionId,
+        );
+      } catch (releaseError) {
         throw new AggregateError(
-          [error, artifactError],
+          [error, releaseError],
           `Execution ${resume.executionId} failed and its final artifacts could not be persisted`,
         );
       }
-      await completeOwnedExecutionLease(resume.executionId);
       throw error;
     }
+    // A WAITING result keeps the lease: the next resume owns this execution.
+    if (!isWaitingFlowResult(result)) {
+      await releaseExecutionLeaseAfterArtifacts(runSession, resume.executionId);
+    }
+    return result;
   });
 }


### PR DESCRIPTION
Closes #9417

Stacked on #9465 (`fix/9421-resume-tooluse-parity`). Base it on `main` once that merges. Doing #9421 first matters: it brought the resume path to parity so this fold is not parameterizing a bug.

## What the fold does

`launchToolUseRun(ctx, handle, lifecycle, shared, variant)` now owns the single `runToolUseFlow` assembly, and `buildLifecycleOptions` owns the `runFlowWithLifecycle` options bag that both entry points passed identically.

`shared` is `SubagentRunOptions & { setting, isSubagent }` and both call sites pass `{ ...options, setting, isSubagent }`. Spreading the whole options object rather than picking three fields is deliberate: a new `SubagentRunOptions` field then reaches both paths by construction, which is the failure mode this issue is about. `isSubagent` is a separate field because resume derives it from persisted lineage (`hasPersistedParent`) rather than from the caller.

`variant` stays explicit, because it is the enumeration of what the two paths genuinely do not share.

## Adjudicating each divergence

**Parameters** (per-path by nature, kept on `ToolUseLaunchVariant`):

| Divergence | Why it is a parameter |
| --- | --- |
| `onIdle` | Root-run-only; `ResumeToolUseFromResumeDataOptions` has no such option to forward |
| `resume`, `drainedFollowUps`, `takePendingFollowUps` | Only a resume has a persisted cursor and an external turn owner |
| `isCancellationRequested`, `onCancellationAtFlowAttachment` | The one-shot handoff window exists only on resume; the check stays inside the shared `onSetup` |

**Reviewed behavior changes:**

1. **Resume now emits `conversation.progress`.** The fresh path wrapped `onProgress` to call `logConversationProgress`; resume forwarded the callback raw. `ProgressFactApplier.handleRunningTransition` calls `resetPerRunChildState`, which clears `conversationProgress.toolCallCount` to 0 on every RUNNING transition — including a resume. Since nothing on the resume path re-emitted the fact, a resumed run displayed zero tool calls for its entire life. The counter is restored from the persisted workspace snapshot (`AgentWorkspaceState.fromSnapshot` reads `parsed.toolCallCount`), so the emitted value continues rather than restarting, and it is the same number the resume path already forwarded to `options.onProgress`.

2. **The resume epilogue adopts `releaseExecutionLeaseAfterArtifacts`.** It is the helper the other release sites already use (`bash.ts`, `inBandSubagentExecution.ts`, `SessionHandle.ts`, `childRunLoop.ts`); no new helper was invented. The success-path release moved out of the `try`, which is what drops the double-flush quirk: previously a success-arm flush failure fell into the catch arm, flushed a second time, and then called `completeOwnedExecutionLease` anyway. Now a failed flush abandons the lease — the durable record is retained and expires at the stale horizon instead of being explicitly released while artifacts did not land. The failure arm keeps its `AggregateError` wrapper so the run's own error is never replaced by a cleanup error. A WAITING result still keeps the lease for the next resume.

`runAgent`'s epilogue is untouched, and `flushOwnedExecutionArtifacts` stays exported for it.

## Net elements (R6)

Module-scope declarations in `src/agent/runtime/executeAgent.ts`: 14 → 16.

- Removed: `runToolUseAgent`
- Added: `launchToolUseRun`, `buildLifecycleOptions`, `ToolUseLaunchVariant`

Net **+2 declarations**, all module-private; no new exports, so the dead-code ratchet has nothing to absorb. Import bindings: -3 (`abandonOwnedExecutionLease`, `completeOwnedExecutionLease`, `flushOwnedExecutionArtifacts`), +2 (`releaseExecutionLeaseAfterArtifacts`, `RunFlowLifecycleOptions`).

**The issue's estimate was wrong on size.** It predicted roughly -38 net LoC and 1 element cut. Actual: 117 insertions / 119 deletions, and the file goes 663 → 661 lines. The duplicated assembly really was ~40 lines, but the discriminated union plus the two call sites cost about the same. The win here is structural (one assembly, one lifecycle bag, no second place to forget a field), not LoC, and it is worth reporting honestly rather than dressing up.

## Consumer counts (R8)

- `launchToolUseRun` — 2 callers (`executeAgent`, `resumeToolUseFromResumeData`)
- `buildLifecycleOptions` — 2 callers (same two)
- `ToolUseLaunchVariant` — 2 construction sites
- `releaseExecutionLeaseAfterArtifacts` — 4 existing production call sites, now 6
- `flushOwnedExecutionArtifacts` — still consumed by `runAgent.ts` and by `releaseExecutionLeaseAfterArtifacts`, so the export stays live

No single-caller extraction.

## Verification

- `npx tsc --noEmit` and `npx tsc --noEmit -p tsconfig.test-kernel.json` — clean
- `npx eslint src/agent/runtime/executeAgent.ts` — clean
- `npm run check:dead-code-ratchet` — 17 current vs 17 baselined, no new findings
- `npx vitest run` over `ResumeToolUseCancellation`, `AgentLaunchActivation`, `resumeQueuedToolUse`, `RunAgentOwnership`, `NativeSubagentStrategy`, `RunScopedToolOverlay`, `AgentRunLifecycle`, `ChildRunLoop` — 86 passed. `RunScopedToolOverlay` is the regression suite from the original tool-overlay incident; `ResumeToolUseCancellation` covers the attachment-time cancellation handoff that the shared `onSetup` now carries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent execution entry points and execution-lease/artifact teardown on resume; fixes are localized but affect durability and progress UI for resumed runs.
> 
> **Overview**
> **Unifies** fresh (`executeAgent`) and resume (`resumeToolUseFromResumeData`) tool-use wiring behind **`launchToolUseRun`**, with path-specific fields on a **`ToolUseLaunchVariant`** (`fresh` vs `resume`) and shared **`SubagentRunOptions`** spread so new options reach both paths. **`buildLifecycleOptions`** centralizes the **`runFlowWithLifecycle`** options both entry points used.
> 
> **Resume behavior fixes:** the shared **`onProgress`** wrapper now calls **`logConversationProgress`** on overview updates (resume previously forwarded progress raw, so UI tool-call counts could stay at zero after RUNNING). The resume epilogue switches from manual flush/complete to **`releaseExecutionLeaseAfterArtifacts`**, moving terminal release outside the run **`try`** so a failed artifact flush is not retried and abandons the lease instead of completing after a failed flush; **`WAITING`** still keeps the lease.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31a151396ef2097c745a828a9462fc3c3263bdef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->