### PR TITLE
feat(telemetry): add an environment kill switch for usage logging

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -359,6 +359,31 @@ The value must be a JSON boolean. A quoted `"false"` is not a boolean, so TeXRA
 logs a warning and treats the setting as off rather than silently reading it as
 `true`.
 
+You can also opt out from the environment, which needs no config file and works
+in every host:
+
+```bash
+export TEXRA_NO_TELEMETRY=1   # or the cross-tool convention:
+export DO_NOT_TRACK=1
+```
+
+Either variable overrides the setting, so a machine or CI job that exports one
+stays opted out even where `texra.telemetry.enabled` is `true`. The override
+only goes one way — neither variable can turn logging back on — and the
+plan-accounting carve-out above still applies.
+
+Any value counts as "on" except `0`, `false`, `no`, and `off`, which read the
+same as leaving the variable unset. TeXRA reads every `TEXRA_*` on/off variable
+this way.
+
+`texra doctor` reports whether usage logging is currently on, and which of the
+two switches turned it off:
+
+```
+SKIP Usage logging: Off (TEXRA_NO_TELEMETRY is set).
+     Rounds that used included hosted access or a subscription are still recorded, because they meter your plan.
+```
+
 ## Logger Configuration
 
 Control logging behavior:

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -372,8 +372,8 @@ stays opted out even where `texra.telemetry.enabled` is `true`. The override
 only goes one way — neither variable can turn logging back on — and the
 plan-accounting carve-out above still applies.
 
-Any value counts as "on" except `0`, `false`, `no`, and `off`, which read the
-same as leaving the variable unset. TeXRA reads every `TEXRA_*` on/off variable
+Any value counts as "on" except `0`, `false`, `no`, `off`, and the empty
+string, which read the same as leaving the variable unset. TeXRA reads every `TEXRA_*` on/off variable
 this way.
 
 `texra doctor` reports whether usage logging is currently on, and which of the

--- a/docs/guide/texra-cli.md
+++ b/docs/guide/texra-cli.md
@@ -414,5 +414,5 @@ Two switches are environment-only:
 | `TEXRA_NO_TELEMETRY` / `DO_NOT_TRACK` | Turn off usage logging for rounds billed to your own API key ([Usage Logging](./configuration#usage-logging)) |
 | `TEXRA_NO_UPDATE_CHECK`               | Skip the daily check for a newer `texra` release                                                              |
 
-Both take `1`, `true`, or any other value; `0`, `false`, `no`, `off`, and unset
-mean "leave it on".
+Both take `1`, `true`, or any other value; `0`, `false`, `no`, `off`, empty,
+and unset mean "leave it on".

--- a/docs/guide/texra-cli.md
+++ b/docs/guide/texra-cli.md
@@ -406,3 +406,13 @@ included hosted access. `--api-mode included` keeps the default hosted behavior
 when the account is signed in. The accepted aliases match the TUI `/api`
 command: for example, `direct`, `api`, and `byok` select personal API keys,
 while `included` selects hosted access.
+
+Two switches are environment-only:
+
+| Variable                              | Effect                                                                                                        |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `TEXRA_NO_TELEMETRY` / `DO_NOT_TRACK` | Turn off usage logging for rounds billed to your own API key ([Usage Logging](./configuration#usage-logging)) |
+| `TEXRA_NO_UPDATE_CHECK`               | Skip the daily check for a newer `texra` release                                                              |
+
+Both take `1`, `true`, or any other value; `0`, `false`, `no`, `off`, and unset
+mean "leave it on".

--- a/docs/proposals/2026-07-29-open-source-readiness.md
+++ b/docs/proposals/2026-07-29-open-source-readiness.md
@@ -215,8 +215,20 @@ in `config/ratchets/architecture-edges-baseline.json`. Host config is reached
 through the `platform()` port; `src/tools/goal/goalFeatureFlag.ts` uses the same
 edge for its feature flag.
 
-User documentation is in `docs/guide/configuration.md` under "Usage Logging",
-including that disabling it also stops hosted spend accounting.
+Rounds that ran through the relay or a subscription are exempt from the opt-out:
+the relay enforces the monthly spend cap from the aggregate those records
+populate, so suppressing them would let hosted calls run against a stale total.
+What the opt-out governs is `api-key` rounds, which cost TeXRA nothing.
+
+`TEXRA_NO_TELEMETRY=1` and the cross-tool `DO_NOT_TRACK=1` do the same thing
+from the environment, overriding the setting in one direction only — neither can
+turn logging back on. Both go through `isEnvFlagEnabled`
+(`src/utils/system/envFlags.ts`), which is now also how `TEXRA_NO_UPDATE_CHECK`
+and `TEXRA_DISABLE_KEYCHAIN` are read, so `=0` means off everywhere instead of
+only in the hosts that happened to test for it.
+
+User documentation is in `docs/guide/configuration.md` under "Usage Logging"
+and in `docs/guide/texra-cli.md` under the environment-only switches.
 
 ### 4.3 `npm test` was not green on a clean checkout
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -35,6 +35,9 @@ async function runDoctor(context: CliContext): Promise<number> {
             modelAccessList: async () => {
               throw initError;
             },
+            usageLoggingOptOut: () => {
+              throw initError;
+            },
           },
     ),
   );

--- a/packages/cli/src/runtime/doctor.ts
+++ b/packages/cli/src/runtime/doctor.ts
@@ -13,6 +13,11 @@ import {
 } from '@latex/latexToolchain';
 import { workspaceTexraConfigPath } from '@platform/defaults/nodeStorage';
 import {
+  TELEMETRY_ENABLED_KEY,
+  usageLoggingOptOut,
+  type UsageLoggingOptOut,
+} from '@telemetry/UsageLogService';
+import {
   TEXRA_CLI_SUPPORTED_NODE_RANGE,
   TEXRA_CLI_SUPPORTED_NODE_RANGE_DISPLAY,
 } from '@tools/externalToolDefs';
@@ -65,6 +70,7 @@ interface DoctorDependencies {
   readonly latexToolchain?: () => Promise<LatexToolchainProbe>;
   readonly pathStat?: (filePath: string) => Promise<DirectoryStat>;
   readonly pathAccess?: (filePath: string, mode?: number) => Promise<void>;
+  readonly usageLoggingOptOut?: () => UsageLoggingOptOut;
 }
 
 type ResolvedDoctorDependencies = Required<DoctorDependencies>;
@@ -324,6 +330,52 @@ async function checkConfig(context: CliContext): Promise<DoctorCheck> {
   }
 }
 
+/**
+ * What TeXRA reports about the user's own usage, and how to stop it.
+ *
+ * `doctor` is where a user goes to see what the CLI is doing, and usage logging
+ * is the one thing it does that leaves the machine without being asked for. The
+ * wording states the two facts that decide whether someone cares: what is in a
+ * record, and what stays on after opting out.
+ */
+function checkTelemetry(deps: ResolvedDoctorDependencies): DoctorCheck {
+  let optOut: UsageLoggingOptOut;
+  try {
+    optOut = deps.usageLoggingOptOut();
+  } catch (error) {
+    return failFromError(
+      'telemetry',
+      'Usage logging',
+      'Could not read the usage-logging setting.',
+      error,
+    );
+  }
+
+  if (optOut?.source === 'environment') {
+    return skip(
+      'telemetry',
+      'Usage logging',
+      `Off (${optOut.envVar} is set).`,
+      'Rounds that used included hosted access or a subscription are still recorded, because they meter your plan.',
+    );
+  }
+  if (optOut?.source === 'setting') {
+    return skip(
+      'telemetry',
+      'Usage logging',
+      `Off (${TELEMETRY_ENABLED_KEY}).`,
+      'Rounds that used included hosted access or a subscription are still recorded, because they meter your plan.',
+    );
+  }
+  return check(
+    'telemetry',
+    'Usage logging',
+    'pass',
+    'On: model, token counts, and cost per round, sent while signed in. No prompt or document text.',
+    `Turn it off with TEXRA_NO_TELEMETRY=1, or "${TELEMETRY_ENABLED_KEY}": false in .texra/config.json.`,
+  );
+}
+
 export async function buildDoctorReport(
   context: CliContext,
   deps: DoctorDependencies = {},
@@ -335,6 +387,7 @@ export async function buildDoctorReport(
     latexToolchain: deps.latexToolchain ?? probeLatexToolchain,
     pathStat: deps.pathStat ?? stat,
     pathAccess: deps.pathAccess ?? access,
+    usageLoggingOptOut: deps.usageLoggingOptOut ?? usageLoggingOptOut,
   };
   const checks: DoctorCheck[] = [
     checkNode(resolved.nodeVersion),
@@ -349,6 +402,7 @@ export async function buildDoctorReport(
     await checkModels(resolved),
     ...(await checkLatex(resolved)),
     await checkConfig(context),
+    checkTelemetry(resolved),
   ];
   return {
     ok: !checks.some((check) => check.status === 'fail'),

--- a/packages/cli/src/runtime/updateChecker.ts
+++ b/packages/cli/src/runtime/updateChecker.ts
@@ -15,9 +15,9 @@ import {
   UPDATE_CHECK_SKIP_ENV,
 } from '@utils/system/semverUpdateCheck';
 import { executeCommand } from '@utils/system/execUtils';
+import { isEnvFlagEnabled } from '@utils/system/envFlags';
 
 import {
-  cliEnvValue,
   readCliAmbientState,
   readCliEntrypointPath,
   resolveCliCwd,
@@ -378,7 +378,7 @@ export async function notifyCliUpdate(context: CliContext): Promise<void> {
   notified = true;
 
   const ambient = readCliAmbientState();
-  if (cliEnvValue(UPDATE_CHECK_SKIP_ENV)) return;
+  if (isEnvFlagEnabled(UPDATE_CHECK_SKIP_ENV)) return;
   if (ambient.isCi) return;
   // Require all three standard streams to be a TTY. stdout matters even though
   // the prompt uses stdin/stderr: a half-redirected invocation like

--- a/packages/desktop/src/main/desktopUpdateChecker.ts
+++ b/packages/desktop/src/main/desktopUpdateChecker.ts
@@ -5,6 +5,7 @@ import {
   isNewerSemverVersion,
   UPDATE_CHECK_SKIP_ENV,
 } from '@utils/system/semverUpdateCheck';
+import { isEnvFlagEnabled } from '@utils/system/envFlags';
 
 /**
  * Lightweight desktop update check (issue #7682, decision: arm b).
@@ -115,7 +116,7 @@ async function runDesktopUpdateCheck({
   env = process.env,
 }: CheckForDesktopUpdateOptions): Promise<void> {
   if (!isPackaged) return;
-  if (env[UPDATE_CHECK_SKIP_ENV]) return;
+  if (isEnvFlagEnabled(UPDATE_CHECK_SKIP_ENV, env)) return;
 
   const lastCheckedAt = globalState.get<number>(
     GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT,

--- a/packages/desktop/src/main/platform/electronSecrets.ts
+++ b/packages/desktop/src/main/platform/electronSecrets.ts
@@ -4,6 +4,7 @@ import type { PlatformSecrets } from '@platform/secrets';
 import type { JsonStore } from '@platform/defaults/jsonStore';
 import { assertNever } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
+import { isEnvFlagEnabled } from '@utils/system/envFlags';
 
 type StoredSecret = { encrypted: true; value: string };
 type SecretStorageMode = 'encrypted' | 'basic_text' | 'unavailable';
@@ -28,10 +29,7 @@ const SAFE_STORAGE_UNAVAILABLE_MESSAGE =
  * API keys still work via the existing override in `ElectronSecrets.get()`.
  */
 function isKeychainDisabled(): boolean {
-  return (
-    process.env.TEXRA_DISABLE_KEYCHAIN === '1' ||
-    process.env.TEXRA_DISABLE_KEYCHAIN === 'true'
-  );
+  return isEnvFlagEnabled('TEXRA_DISABLE_KEYCHAIN');
 }
 
 let warnedAboutKeychainDisabled = false;

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -811,7 +811,7 @@
           "texra.telemetry.enabled": {
             "type": "boolean",
             "default": true,
-            "description": "Send a usage record for each model round to TeXRA: model and provider, agent name and category, token counts, cost, response time, route, stream id, and the TeXRA version and host. Never prompt text, document content, or file names. Records are sent only while signed in. Turning this off stops reporting for rounds billed to your own API key; rounds that went through the relay or a subscription are still recorded, because they meter your hosted usage against your plan.",
+            "description": "Send a usage record for each model round to TeXRA: model and provider, agent name and category, token counts, cost, response time, route, stream id, and the TeXRA version and host. Never prompt text, document content, or file names. Records are sent only while signed in. Turning this off stops reporting for rounds billed to your own API key; rounds that went through the relay or a subscription are still recorded, because they meter your hosted usage against your plan. Setting TEXRA_NO_TELEMETRY=1 or DO_NOT_TRACK=1 in the environment turns it off regardless of this setting.",
             "scope": "application"
           }
         }

--- a/src/shared/schemas/coreSettings.ts
+++ b/src/shared/schemas/coreSettings.ts
@@ -627,7 +627,7 @@ export const CoreSettingsShape = {
     .strictObject({
       enabled: boolField(
         DEFAULT_CORE_SETTINGS.telemetry.enabled,
-        'Send a usage record for each model round to TeXRA: model and provider, agent name and category, token counts, cost, response time, route, stream id, and the TeXRA version and host. Never prompt text, document content, or file names. Records are sent only while signed in. Turning this off stops reporting for rounds billed to your own API key; rounds that went through the relay or a subscription are still recorded, because they meter your hosted usage against your plan.',
+        'Send a usage record for each model round to TeXRA: model and provider, agent name and category, token counts, cost, response time, route, stream id, and the TeXRA version and host. Never prompt text, document content, or file names. Records are sent only while signed in. Turning this off stops reporting for rounds billed to your own API key; rounds that went through the relay or a subscription are still recorded, because they meter your hosted usage against your plan. Setting TEXRA_NO_TELEMETRY=1 or DO_NOT_TRACK=1 in the environment turns it off regardless of this setting.',
       ),
     })
     .prefault(DEFAULT_CORE_SETTINGS.telemetry),

--- a/src/telemetry/UsageLogService.ts
+++ b/src/telemetry/UsageLogService.ts
@@ -10,6 +10,7 @@ import { platform } from '@platform/platform';
 import type { UsageRoute } from '@shared/schemas';
 import { DEFAULT_CORE_SETTINGS } from '@shared/schemas/coreSettings';
 import { toErrorMessage } from '@utils/errors/errorMessage';
+import { isEnvFlagEnabled } from '@utils/system/envFlags';
 
 import { UsageLogResponseSchema } from './UsageLogTypes';
 import type {
@@ -50,6 +51,24 @@ const DEFAULT_CONFIG: UsageLogConfig = {
 export const TELEMETRY_ENABLED_KEY = 'texra.telemetry.enabled';
 
 /**
+ * Environment variables that switch usage logging off without editing config.
+ *
+ * `TEXRA_NO_TELEMETRY` is ours; `DO_NOT_TRACK` is the cross-tool console
+ * convention, honoured so a user who exports it once opts out of every tool
+ * that respects it. Either one overrides {@link TELEMETRY_ENABLED_KEY} — an
+ * environment that says "do not send" wins over a stored `true`, never the
+ * reverse, so neither can be used to force logging back on.
+ */
+const TELEMETRY_OPT_OUT_ENV_VARS = [
+  'TEXRA_NO_TELEMETRY',
+  'DO_NOT_TRACK',
+] as const;
+
+function isTelemetryDisabledByEnv(): boolean {
+  return TELEMETRY_OPT_OUT_ENV_VARS.some((name) => isEnvFlagEnabled(name));
+}
+
+/**
  * Routes whose records meter what the user consumed against their plan.
  *
  * The relay reads a database aggregate populated by `log-usage` to enforce the
@@ -86,6 +105,10 @@ function isPlanAccounting(
  * test) can hold the service off regardless of user settings.
  */
 function isTelemetryEnabledBySetting(): boolean {
+  // Checked before the config read so the kill switch also holds on a host that
+  // has not initialized its platform yet.
+  if (isTelemetryDisabledByEnv()) return false;
+
   const raw = platform().config.get<unknown>(
     TELEMETRY_ENABLED_KEY,
     DEFAULT_CORE_SETTINGS.telemetry.enabled,
@@ -101,6 +124,25 @@ function isTelemetryEnabledBySetting(): boolean {
     `Ignoring non-boolean ${TELEMETRY_ENABLED_KEY} (got ${typeof raw}); treating optional usage logging as disabled`,
   );
   return false;
+}
+
+/** Why optional usage logging is off, or `null` when it is on. */
+export type UsageLoggingOptOut =
+  | { readonly source: 'environment'; readonly envVar: string }
+  | { readonly source: 'setting' }
+  | null;
+
+/**
+ * The opt-out as a user-facing fact, for surfaces that report what TeXRA is
+ * doing (`texra doctor`). Derived from the same gate the send path uses, so a
+ * report of "off" cannot drift from the behaviour.
+ */
+export function usageLoggingOptOut(): UsageLoggingOptOut {
+  const envVar = TELEMETRY_OPT_OUT_ENV_VARS.find((name) =>
+    isEnvFlagEnabled(name),
+  );
+  if (envVar) return { source: 'environment', envVar };
+  return isTelemetryEnabledBySetting() ? null : { source: 'setting' };
 }
 
 class UsageLogServiceImpl {
@@ -121,6 +163,13 @@ class UsageLogServiceImpl {
     this.extensionVersion = extensionVersion;
     this.editorType = editorType;
     this.startFlushTimer();
+
+    if (isTelemetryDisabledByEnv()) {
+      logger.info(
+        CHANNEL,
+        `Optional usage logging is disabled by the environment (${TELEMETRY_OPT_OUT_ENV_VARS.join(' / ')}); only plan-accounting rounds are reported`,
+      );
+    }
 
     logger.debug(
       CHANNEL,

--- a/src/test-kernel/telemetry/UsageLogService.vitest.ts
+++ b/src/test-kernel/telemetry/UsageLogService.vitest.ts
@@ -82,6 +82,7 @@ describe('UsageLogService', () => {
   afterEach(async () => {
     await UsageLogService.dispose();
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
 
@@ -465,6 +466,74 @@ describe('UsageLogService', () => {
       await expect(flush).resolves.toBe(USAGE_LOG_FLUSH_OUTCOME.ACCEPTED);
       expect(fetchMock).not.toHaveBeenCalled();
       expect(batches).toEqual([]);
+    });
+
+    // The environment kill switch is what a user has when editing settings is
+    // awkward: a CI job, a shared machine, or a one-off `TEXRA_NO_TELEMETRY=1
+    // texra run`. It overrides a stored `true` and cannot re-enable logging.
+    it.each([
+      ['TEXRA_NO_TELEMETRY', '1'],
+      ['TEXRA_NO_TELEMETRY', 'true'],
+      ['DO_NOT_TRACK', '1'],
+    ])('sends nothing while %s=%s is set', async (name, value) => {
+      vi.spyOn(SupabaseClient, 'getRelayAccessToken').mockResolvedValue(
+        'token',
+      );
+      await platform().config.update(TELEMETRY_ENABLED_KEY, true);
+      vi.stubEnv(name, value);
+
+      const batches: unknown[] = [];
+      const fetchMock = stubFetch(batches);
+
+      UsageLogService.log(usageEntry('optional'));
+      await expect(UsageLogService.flush()).resolves.toBe(
+        USAGE_LOG_FLUSH_OUTCOME.ACCEPTED,
+      );
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(batches).toEqual([]);
+    });
+
+    it.each([['0'], ['false'], ['']])(
+      'ignores TEXRA_NO_TELEMETRY=%p',
+      async (value) => {
+        vi.spyOn(SupabaseClient, 'getRelayAccessToken').mockResolvedValue(
+          'token',
+        );
+        await platform().config.update(TELEMETRY_ENABLED_KEY, true);
+        vi.stubEnv('TEXRA_NO_TELEMETRY', value);
+
+        const batches: unknown[] = [];
+        const fetchMock = stubFetch(batches);
+
+        UsageLogService.log(usageEntry('optional'));
+        await expect(UsageLogService.flush()).resolves.toBe(
+          USAGE_LOG_FLUSH_OUTCOME.ACCEPTED,
+        );
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(batches.map(batchModels)).toEqual([['optional']]);
+      },
+    );
+
+    // Same carve-out as the setting: the spend cap is enforced from these
+    // records, so the environment switch must not suppress them either.
+    it('still sends relay usage while TEXRA_NO_TELEMETRY is set', async () => {
+      vi.spyOn(SupabaseClient, 'getRelayAccessToken').mockResolvedValue(
+        'token',
+      );
+      vi.stubEnv('TEXRA_NO_TELEMETRY', '1');
+
+      const batches: unknown[] = [];
+      const fetchMock = stubFetch(batches);
+
+      UsageLogService.log({ ...usageEntry('hosted'), usageRoute: 'relay' });
+      await expect(UsageLogService.flush()).resolves.toBe(
+        USAGE_LOG_FLUSH_OUTCOME.ACCEPTED,
+      );
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(batches.map(batchModels)).toEqual([['hosted']]);
     });
 
     // JsonConfigProvider returns raw JSON from a hand-edited .texra/config.json,

--- a/src/test-kernel/utils/system/EnvFlags.vitest.ts
+++ b/src/test-kernel/utils/system/EnvFlags.vitest.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { isEnvFlagEnabled } from '@utils/system/envFlags';
+
+describe('isEnvFlagEnabled', () => {
+  it('reads any set value other than an off spelling as on', () => {
+    expect(isEnvFlagEnabled('FLAG', { FLAG: '1' })).toBe(true);
+    expect(isEnvFlagEnabled('FLAG', { FLAG: 'true' })).toBe(true);
+    expect(isEnvFlagEnabled('FLAG', { FLAG: 'yes' })).toBe(true);
+    expect(isEnvFlagEnabled('FLAG', { FLAG: ' TRUE ' })).toBe(true);
+  });
+
+  // The whole point of a shared helper: `=0` used to mean "on" wherever the
+  // caller tested `env[NAME]` for truthiness.
+  it('reads the off spellings and an unset variable as off', () => {
+    expect(isEnvFlagEnabled('FLAG', { FLAG: '0' })).toBe(false);
+    expect(isEnvFlagEnabled('FLAG', { FLAG: 'false' })).toBe(false);
+    expect(isEnvFlagEnabled('FLAG', { FLAG: 'No' })).toBe(false);
+    expect(isEnvFlagEnabled('FLAG', { FLAG: 'off' })).toBe(false);
+    expect(isEnvFlagEnabled('FLAG', { FLAG: '  ' })).toBe(false);
+    expect(isEnvFlagEnabled('FLAG', {})).toBe(false);
+  });
+});

--- a/src/utils/system/envFlags.ts
+++ b/src/utils/system/envFlags.ts
@@ -1,0 +1,26 @@
+/**
+ * How TeXRA reads a boolean environment variable, in one place.
+ *
+ * Every host had grown its own spelling of this check — `env[NAME]` truthiness
+ * in the update checkers, `=== '1' || === 'true'` in the desktop secrets shim —
+ * so `TEXRA_NO_UPDATE_CHECK=0` disabled update checks in one host and
+ * `TEXRA_DISABLE_KEYCHAIN=yes` did nothing in another. A user who writes `=0`
+ * means off in both.
+ */
+const ENV_FLAG_OFF_VALUES = new Set(['', '0', 'false', 'no', 'off']);
+
+/**
+ * Whether `name` is set to something that means "on".
+ *
+ * Unset, empty, and the explicit off spellings (`0`, `false`, `no`, `off`,
+ * case-insensitive) are false; any other value is true, so `=1`, `=true`, and a
+ * bare `=yes` all work.
+ */
+export function isEnvFlagEnabled(
+  name: string,
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  const value = env[name];
+  if (value == null) return false;
+  return !ENV_FLAG_OFF_VALUES.has(value.trim().toLowerCase());
+}

--- a/src/utils/system/semverUpdateCheck.ts
+++ b/src/utils/system/semverUpdateCheck.ts
@@ -22,5 +22,8 @@ export function isNewerSemverVersion(latest: string, current: string): boolean {
 /** Poll for updates at most once per day. */
 export const DAILY_UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
-/** Env var that disables both the CLI's and desktop's update checks. */
+/**
+ * Env var that disables both the CLI's and desktop's update checks. Read with
+ * `isEnvFlagEnabled` (see `envFlags.ts`), so `=0` / `=false` leave the check on.
+ */
 export const UPDATE_CHECK_SKIP_ENV = 'TEXRA_NO_UPDATE_CHECK';


### PR DESCRIPTION
## Why

Usage logging already had an opt-out, `texra.telemetry.enabled`, but it was only
reachable by editing VS Code settings or `.texra/config.json`. For an
open-source audience that is the wrong shape: the expected move is to export a
variable once and be done, with no config file and no GUI.

## What

**An environment kill switch.** `TEXRA_NO_TELEMETRY=1`, or the cross-tool
`DO_NOT_TRACK=1`, turns off optional usage logging in all three hosts. It
overrides the setting in one direction only, so neither variable can turn
logging back on. The plan-accounting carve-out is unchanged: relay and
subscription rounds still report, because the relay enforces the monthly spend
cap from the aggregate those records populate.

Two names because they serve different users: `TEXRA_NO_TELEMETRY` is the
discoverable one and matches the `TEXRA_NO_UPDATE_CHECK` we already ship;
`DO_NOT_TRACK` is for someone who exports it once in a shell profile and expects
every tool that honours the convention to comply. One gate, two names, not two
code paths.

**One convention for boolean env vars** (`src/utils/system/envFlags.ts`). The
repo had grown three:

| Variable                 | Before                                    | After              |
| ------------------------ | ----------------------------------------- | ------------------ |
| `TEXRA_NO_UPDATE_CHECK`  | `=0` **disabled** update checks (truthy)  | `=0` means off     |
| `TEXRA_DISABLE_KEYCHAIN` | `=yes` did nothing (only `1` \| `true`)   | `=yes` means on    |
| `TEXRA_NO_TELEMETRY`     | did not exist                             | same rules         |

`0`, `false`, `no`, `off`, and unset all mean off now. The strict `=== '1'`
gates on the internal validation harness are deliberately untouched: those are
security-shaped, not user-facing toggles.

**`texra doctor` reports the state.** It is where users go to see what the CLI
is doing, and usage logging is the one thing it does that leaves the machine
without being asked. The status derives from the same gate the send path uses,
so the report cannot drift from the behaviour.

```
PASS Usage logging: On: model, token counts, and cost per round, sent while signed in. No prompt or document text.
     Turn it off with TEXRA_NO_TELEMETRY=1, or "texra.telemetry.enabled": false in .texra/config.json.

SKIP Usage logging: Off (TEXRA_NO_TELEMETRY is set).
     Rounds that used included hosted access or a subscription are still recorded, because they meter your plan.
```

Also corrects a stale claim in `docs/proposals/2026-07-29-open-source-readiness.md`
that opting out stops hosted spend accounting. It does not, and the doctor hint
now says so.

## Verified

- `npm run typecheck` exit 0 (all six projects).
- `npx vitest run` on the two touched suites: 31 passed. New coverage for the
  env override, the off spellings, and the plan-accounting exemption under the
  env switch.
- `npx eslint` and `npx prettier --check` clean on every touched file.
- `npm run check:package-contributes` in sync; `npm run check:dead-code-ratchet`
  OK (it flagged one export with no consumer, which I made internal rather than
  baselining).
- Ran the built binary in all four states — on, off by `TEXRA_NO_TELEMETRY`, off
  by `DO_NOT_TRACK`, off by `texra.telemetry.enabled` in a workspace config —
  and confirmed the doctor line and `=0` fallthrough by hand.

## Note

An empty `docs/marketing/` directory (left behind by #9114, containing only a
`.DS_Store`) was failing the `docs-root-boundary` pre-commit hook on this
machine and blocking any commit. Removed locally; it was untracked, so it is not
in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qs4Vgf3VxahEjs5maQF5Ds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Privacy and UX changes with tests; relay/subscription usage reporting is explicitly preserved. Minor behavior change: `TEXRA_NO_UPDATE_CHECK=0` no longer disables update checks.
> 
> **Overview**
> Adds **environment-only opt-out** for optional usage logging via `TEXRA_NO_TELEMETRY` or `DO_NOT_TRACK`, overriding `texra.telemetry.enabled` when set but never forcing logging back on. Relay and subscription rounds still upload for plan metering.
> 
> Introduces shared **`isEnvFlagEnabled`** in `src/utils/system/envFlags.ts` and wires it into usage logging, CLI/desktop update checks (`TEXRA_NO_UPDATE_CHECK`), and desktop keychain bypass (`TEXRA_DISABLE_KEYCHAIN`) so `0`/`false`/`no`/`off` mean off consistently.
> 
> **`texra doctor`** gains a Usage logging check driven by `usageLoggingOptOut()`, matching the send path. Docs and setting descriptions document env switches and correct the hosted spend-accounting carve-out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a065c34c81d93da8bb9d6d2997301c497b6b418. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->