### PR TITLE
Remove undocumented src/skills barrel, import symbols directly

### DIFF
--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -87,7 +87,8 @@ import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { migrateLegacyGlobalBashApprovalOverride } from '@shared/settingsView/handlers/approvalHandlers';
 import { backfillFirstRunDone } from '@shared/state/onboardingState';
-import { defaultSkillSources, setRuntimeSkillSources } from '@skills/index';
+import { defaultSkillSources } from '@skills/skillSources';
+import { setRuntimeSkillSources } from '@skills/runtimeSkills';
 import { UsageLogService } from '@telemetry/UsageLogService';
 import {
   SharedPRPollingSource,

--- a/src/platform/defaults/nodeHost.ts
+++ b/src/platform/defaults/nodeHost.ts
@@ -21,7 +21,10 @@ import { registerAgentFeatures } from '@agent/features';
 import { initializeGoalPrompts } from '@agent/goal/promptLoader';
 import { PathAgentDirectoryBundleSource } from '@agent/index/AgentDirectorySync';
 import { bootstrapPlatformAgentDirectories } from '@agent/index/platformAgentDirectories';
-import { defaultSkillSources, type SkillSourceOptions } from '@skills/skillSources';
+import {
+  defaultSkillSources,
+  type SkillSourceOptions,
+} from '@skills/skillSources';
 import { setRuntimeSkillSources } from '@skills/runtimeSkills';
 import { registerDirectLeanLanguageServices } from '@tools/lean/direct/directLspAdapter';
 

--- a/src/platform/defaults/nodeHost.ts
+++ b/src/platform/defaults/nodeHost.ts
@@ -21,8 +21,8 @@ import { registerAgentFeatures } from '@agent/features';
 import { initializeGoalPrompts } from '@agent/goal/promptLoader';
 import { PathAgentDirectoryBundleSource } from '@agent/index/AgentDirectorySync';
 import { bootstrapPlatformAgentDirectories } from '@agent/index/platformAgentDirectories';
-import { defaultSkillSources, setRuntimeSkillSources } from '@skills/index';
-import type { SkillSourceOptions } from '@skills/index';
+import { defaultSkillSources, type SkillSourceOptions } from '@skills/skillSources';
+import { setRuntimeSkillSources } from '@skills/runtimeSkills';
 import { registerDirectLeanLanguageServices } from '@tools/lean/direct/directLspAdapter';
 
 // Local file imports

--- a/src/skills/index.ts
+++ b/src/skills/index.ts
@@ -1,5 +1,0 @@
-export * from './SkillSchema';
-export * from './frontmatter';
-export * from './loadSkills';
-export * from './runtimeSkills';
-export * from './skillSources';


### PR DESCRIPTION
## Summary

Scheduled structural-debt audit of the codebase for confusing or overlapped responsibilities (VS Code coupling, event-bus/trace duplication, cross-package logic duplication, and barrel/factory boundaries). Three of the four areas audited were clean or only had minor, already-documented tradeoffs. The one verified, actionable finding: `src/skills/index.ts` was an undocumented barrel re-exporting all 5 skills submodules, with no comment marking it as an intentional public surface — violating the "no convenience barrels" rule in `CLAUDE.md`. Its two consumers (`extension.ts`, `nodeHost.ts`) pulled `defaultSkillSources`/`setRuntimeSkillSources` through the barrel, while every other caller (CLI runtime, test-kernel) already imported the identical symbols directly from `@skills/skillSources` / `@skills/runtimeSkills` — two import paths for the same symbols with no rule for which to use.

This PR repoints the two barrel consumers at the direct submodules and deletes the barrel, so every skills symbol has exactly one canonical import path, matching how the rest of the `@skills/*` surface is already consumed elsewhere in the repo.

## Issue acceptance gates

- Undocumented barrel removed: `src/skills/index.ts` deleted.
- All former barrel consumers repointed to the submodule that defines the symbol they use.
- No remaining references to `@skills/index` anywhere in the repo (verified by grep).

## Single source of truth

`@skills/skillSources` now owns `defaultSkillSources`/`SkillSourceOptions`; `@skills/runtimeSkills` owns `setRuntimeSkillSources`. No module re-exports either on their behalf.

## Duplication and abstraction budget

Removed a redundant import surface (the barrel) rather than adding one. No new abstraction introduced.

## Net elements (R6)

3 files changed, 4 insertions(+), 8 deletions(-). 1 file deleted (`src/skills/index.ts`, a pure re-export barrel with no logic). No exported symbols, classes, or interfaces added or removed — only their import path changed.

## Consumer counts (R8)

`@skills/index` had exactly 3 import sites across 2 files (`packages/extension/src/extension.ts:90`, `src/platform/defaults/nodeHost.ts:24-25`) — grepped and confirmed via `grep -rn "@skills/index"` before deletion. All 3 repointed; grep after the change confirms zero remaining references.

## Host impact

Extension: `extension.ts` now imports `defaultSkillSources` from `@skills/skillSources` and `setRuntimeSkillSources` from `@skills/runtimeSkills` directly.

Desktop: no change (does not use the skills barrel).

CLI: no change (already imported the submodules directly; this PR just brings the other two hosts in line).

## Scheduled refactoring

None. Also noted during the audit but out of scope for this PR (lower severity, no functional impact): a stale doc comment in `packages/extension/src/schemas/texraSettings.ts` claims parity with `CliSettingsSchema`/`DesktopSettingsSchema` symbols that don't exist anywhere in the repo — worth a follow-up doc fix but not a responsibility overlap.

## Validation

- `npx tsc --noEmit` — clean (one pre-existing, unrelated error in `modelHandlerGoogleInteractions.ts` confirmed present on `main` before this change, via `git stash`).
- `npx eslint` on both edited files — clean.
- `npx vitest run` on all skills-related suites (`src/test-kernel/skills`, `src/test-kernel/cli/CliSkills.vitest.mts`, `src/test-kernel/agent/utils/userVars.vitest.ts`) — 29 passed, 1 skipped.
- `npm run check:dead-code-ratchet` — no new unused files/exports (17 current vs 17 baselined).

---
_Generated by [Claude Code](https://claude.ai/code/session_012ALifb9JyBY46Tn3K4XMUt)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-path-only refactor with no logic or API changes; low risk of runtime impact.
> 
> **Overview**
> Removes the undocumented `src/skills/index.ts` barrel and makes **`@skills/skillSources`** and **`@skills/runtimeSkills`** the only import paths for skill wiring.
> 
> **Extension** (`extension.ts`) and **Node host** (`nodeHost.ts`) now import `defaultSkillSources` / `SkillSourceOptions` from `@skills/skillSources` and `setRuntimeSkillSources` from `@skills/runtimeSkills`, matching CLI and test-kernel callers. No behavior change—only import paths and deletion of the re-export surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a7fef8a7dce76ea638b81af5104be314388941e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->