### PR TITLE
refactor: consolidate duplicate logic and adopt native/shared helpers

### DIFF
--- a/packages/cli/src/chat/tui/appInteractionPolicy.ts
+++ b/packages/cli/src/chat/tui/appInteractionPolicy.ts
@@ -2,7 +2,7 @@
 
 // Local imports - shared schemas and utilities
 import { AgentCategory, type StreamTabId } from '@shared/schemas';
-import { assertNever } from '@utils/core';
+import { assertNever, groupBy } from '@utils/core';
 
 // Local imports - TUI state
 import {
@@ -247,18 +247,19 @@ export function groupPendingApprovalsByRow(
   summaries: readonly PendingApprovalSummary[],
   rootStreamId: StreamTabId | undefined,
 ): Map<string, PendingApprovalKind[]> {
-  const grouped = new Map<string, PendingApprovalKind[]>();
+  const keyed: { key: string; summary: PendingApprovalSummary }[] = [];
   for (const summary of summaries) {
     const key =
       summary.streamKey === ROOT_APPROVAL_STREAM_KEY
         ? rootStreamId
         : summary.streamKey;
-    if (key === undefined) continue;
-    const kinds = grouped.get(key);
-    if (kinds) kinds.push(summary.kind);
-    else grouped.set(key, [summary.kind]);
+    if (key !== undefined) keyed.push({ key, summary });
   }
-  return grouped;
+  return groupBy(
+    keyed,
+    (entry) => entry.key,
+    (entry) => entry.summary.kind,
+  );
 }
 
 // A workflow-script grandchild `agent()` call is the only interactively

--- a/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
+++ b/packages/cli/src/chat/tui/panes/StaticConversationTranscript.tsx
@@ -14,6 +14,7 @@ import { COLOR_HINT } from '@cli/tui/ui/colors';
 import type { StreamTabId } from '@shared/schemas';
 import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
 import type { ExecutionLabels } from '@shared/tools/executionsDisplay';
+import { groupBy } from '@utils/core';
 import { safeHomedir } from '@utils/system/platformPaths';
 
 import {
@@ -356,7 +357,6 @@ export function appendStaticTranscriptItems({
   const unseenRequests = printRequests.filter(
     (request) => !seen.has(request.id),
   );
-  const requestsByUnseenAnchor = new Map<string, TranscriptPrintRequest[]>();
   const appendItem = (item: StaticTranscriptItem): void => {
     nextItems ??= [...currentItems];
     nextItems.push(item);
@@ -366,15 +366,18 @@ export function appendStaticTranscriptItems({
   // Requests carry the last static entry visible when the user invoked the
   // command. Interleave against that anchor so an owner round trip rebuilds
   // exactly the same chronology as incremental append-only rendering.
+  const anchoredRequests: TranscriptPrintRequest[] = [];
   for (const request of unseenRequests) {
     if (request.afterEntryId === undefined || seen.has(request.afterEntryId)) {
       appendItem({ id: request.id, kind: 'printedTranscript', request });
       continue;
     }
-    const anchored = requestsByUnseenAnchor.get(request.afterEntryId);
-    if (anchored) anchored.push(request);
-    else requestsByUnseenAnchor.set(request.afterEntryId, [request]);
+    anchoredRequests.push(request);
   }
+  const requestsByUnseenAnchor = groupBy(
+    anchoredRequests,
+    (request) => request.afterEntryId,
+  );
   for (const entry of orderedStaticEntries) {
     if (!seen.has(entry.id)) {
       appendItem({ id: entry.id, kind: 'entry', entry });

--- a/packages/cli/src/chat/tui/state/streamViews.ts
+++ b/packages/cli/src/chat/tui/state/streamViews.ts
@@ -5,6 +5,7 @@
 
 // Local imports - shared schemas
 import type { StreamTabId } from '@shared/schemas';
+import { groupBy } from '@utils/core';
 
 // Local imports - CLI state
 import {
@@ -191,23 +192,14 @@ export function groupWorkflowPhaseEntries<
   T extends { readonly workflowPhase?: string },
 >(entries: readonly T[]): readonly T[] {
   const untagged: T[] = [];
-  const groups: T[][] = [];
-  const phaseGroups = new Map<string, T[]>();
+  const tagged: T[] = [];
   for (const entry of entries) {
-    const phase = entry.workflowPhase;
-    if (phase === undefined) {
-      untagged.push(entry);
-      continue;
-    }
-    let group = phaseGroups.get(phase);
-    if (!group) {
-      group = [];
-      phaseGroups.set(phase, group);
-      groups.push(group);
-    }
-    group.push(entry);
+    if (entry.workflowPhase === undefined) untagged.push(entry);
+    else tagged.push(entry);
   }
-  return groups.length > 0 ? [...untagged, ...groups.flat()] : entries;
+  if (tagged.length === 0) return entries;
+  const phaseGroups = groupBy(tagged, (entry) => entry.workflowPhase);
+  return [...untagged, ...[...phaseGroups.values()].flat()];
 }
 
 export function streamTreeEntries(

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -1,5 +1,7 @@
 // Project durable session and run facts into the local TUI state.
 
+import { isDeepStrictEqual } from 'node:util';
+
 import type { AgentEvent } from '@agent/trace';
 import type { AgentConfig } from '@agent/core/definition/AgentConfig';
 import { defaultSession } from '@agent/runtime/SessionHandle';
@@ -74,10 +76,7 @@ function sameStringList(
   left: readonly string[],
   right: readonly string[],
 ): boolean {
-  return (
-    left.length === right.length &&
-    left.every((item, index) => item === right[index])
-  );
+  return isDeepStrictEqual(left, right);
 }
 
 function applyRunConfig(streamId: StreamTabId, config: AgentConfig): void {

--- a/packages/desktop/src/desktopTaskShell.ts
+++ b/packages/desktop/src/desktopTaskShell.ts
@@ -9,7 +9,7 @@
 // and disposed by the renderer; this module only describes what is visible.
 
 import type { TeXRAIconName } from '@shared/wa/iconNames';
-import { getBasename } from '@utils/core';
+import { clamp, getBasename } from '@utils/core';
 
 import type { DesktopRoute } from './desktopShellMessages.js';
 
@@ -409,10 +409,6 @@ export function toggleSummaryBar(
   return { ...state, summaryBarVisible: !state.summaryBarVisible };
 }
 
-function clamp(value: number, minimum: number, maximum: number): number {
-  return Math.min(maximum, Math.max(minimum, Math.round(value)));
-}
-
 export function setBottomPanelHeight(
   state: DesktopTaskShellState,
   height: number,
@@ -420,7 +416,7 @@ export function setBottomPanelHeight(
   return {
     ...state,
     bottomPanelHeight: clamp(
-      height,
+      Math.round(height),
       BOTTOM_PANEL_MIN_HEIGHT,
       BOTTOM_PANEL_MAX_HEIGHT,
     ),
@@ -433,7 +429,11 @@ export function setSidebarWidth(
 ): DesktopTaskShellState {
   return {
     ...state,
-    sidebarWidth: clamp(width, SIDEBAR_MIN_WIDTH, SIDEBAR_MAX_WIDTH),
+    sidebarWidth: clamp(
+      Math.round(width),
+      SIDEBAR_MIN_WIDTH,
+      SIDEBAR_MAX_WIDTH,
+    ),
   };
 }
 
@@ -444,7 +444,7 @@ export function setProjectSectionPosition(
   return {
     ...state,
     projectSectionPosition: clamp(
-      position,
+      Math.round(position),
       PROJECT_SECTION_MIN_POSITION,
       PROJECT_SECTION_MAX_POSITION,
     ),
@@ -457,7 +457,11 @@ export function setWorkbenchWidth(
 ): DesktopTaskShellState {
   return {
     ...state,
-    workbenchWidth: clamp(width, WORKBENCH_MIN_WIDTH, WORKBENCH_MAX_WIDTH),
+    workbenchWidth: clamp(
+      Math.round(width),
+      WORKBENCH_MIN_WIDTH,
+      WORKBENCH_MAX_WIDTH,
+    ),
   };
 }
 

--- a/packages/desktop/src/renderer/desktopCommandPalette.ts
+++ b/packages/desktop/src/renderer/desktopCommandPalette.ts
@@ -14,7 +14,7 @@ import { formatDesktopAccelerator } from '@shared/commands/accelerators';
 import type { DesktopShortcutEntry } from '@shared/commands/shortcutPreferences';
 import type { TeXRAIconName } from '@shared/wa/iconNames';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
-import { isThenable } from '@utils/core';
+import { groupBy, isThenable } from '@utils/core';
 import {
   dispatchDesktopCommand,
   getDesktopCommandMenuEntries,
@@ -436,13 +436,7 @@ function visibleCommandPaletteEntries(
 function groupCommandPaletteEntries(
   entries: readonly CommandPaletteEntry[],
 ): CommandPaletteGroup[] {
-  const grouped = new Map<string, CommandPaletteEntry[]>();
-  for (const entry of entries) {
-    const category = entry.category ?? 'Other';
-    const group = grouped.get(category) ?? [];
-    group.push(entry);
-    grouped.set(category, group);
-  }
+  const grouped = groupBy(entries, (entry) => entry.category ?? 'Other');
   return [...grouped].map(([category, groupEntries]) => ({
     category,
     entries: groupEntries,

--- a/packages/extension/src/commands/latex/figCommands.ts
+++ b/packages/extension/src/commands/latex/figCommands.ts
@@ -11,7 +11,7 @@ import { extractFigurePathsFromLatex } from '@latex/extractFigure';
 import { TikzPictureManager } from '@latex/TikzPictureManager';
 import * as logger from '@logger/logUtils';
 import { pathToLocation } from '@utils/files';
-import { pluralize } from '@utils/text/stringUtils';
+import { pluralize, truncateWithEllipsis } from '@utils/text/stringUtils';
 
 const CHANNEL = 'TestCommands';
 
@@ -74,7 +74,7 @@ export async function handleExtractTikzFigures(): Promise<void> {
         const items = labeledTikzPictures.map(([label, pictures]) => ({
           label: `${label} (${pictures.length} TikZ ${pluralize(pictures.length, 'picture')})`,
           description: `Figure with label: ${label}`,
-          detail: `${pictures[0].slice(0, 100)}...`,
+          detail: truncateWithEllipsis(pictures[0], 100),
         }));
 
         const selected = await vscode.window.showQuickPick(items, {

--- a/packages/extension/src/commands/latex/imageCommands.ts
+++ b/packages/extension/src/commands/latex/imageCommands.ts
@@ -13,6 +13,7 @@ import {
   getBase64EncodedMedia,
   processPdf2Png,
 } from '@utils/media/img';
+import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
 const CHANNEL = 'TestCommands';
 
@@ -67,7 +68,7 @@ export async function handleEncodeImageToBase64(): Promise<string | undefined> {
     const base64String = await getBase64EncodedMedia(selection.relativePath);
     logger.debug(
       CHANNEL,
-      `Truncated base64 string (first 100 chars): ${base64String.slice(0, 100)}...`,
+      `Truncated base64 string (first 100 chars): ${truncateWithEllipsis(base64String, 100)}`,
     );
     return base64String;
   } catch (err) {

--- a/packages/extension/src/frontend/setupTerminalRunner.ts
+++ b/packages/extension/src/frontend/setupTerminalRunner.ts
@@ -21,6 +21,8 @@ import {
   type TerminalRunResult,
 } from '@hosts/uiHosts';
 
+import { raceWithTimeout } from './vscode/raceWithTimeout';
+
 const SHELL_INTEGRATION_WAIT_MS = 2_000;
 const READER_DRAIN_MS = 250;
 
@@ -115,43 +117,6 @@ async function captureExecution(
     output: truncateTerminalOutput(output),
     timedOut: result.timedOut,
   };
-}
-
-type Raced<T> = { timedOut: false; value: T } | { timedOut: true };
-
-/**
- * Race a one-shot event subscription against a timeout. Disposes the
- * subscription and clears the timer in whichever branch wins so we
- * never leak listeners or pending timers.
- */
-function raceWithTimeout<T>(
-  subscribe: (resolve: (value: T) => void) => vscode.Disposable,
-  timeoutMs: number,
-): Promise<Raced<T>> {
-  return new Promise((resolve) => {
-    // Predeclared with `let` so the `settle` closure can read them
-    // even if `subscribe` fires its callback synchronously (would
-    // otherwise hit the TDZ for the original `const` bindings).
-    let settled = false;
-    let timer: ReturnType<typeof setTimeout> | undefined = undefined;
-    let disposable: vscode.Disposable | undefined = undefined;
-    const settle = (result: Raced<T>) => {
-      if (settled) return;
-      settled = true;
-      if (timer !== undefined) clearTimeout(timer);
-      disposable?.dispose();
-      resolve(result);
-    };
-    disposable = subscribe((value) => settle({ timedOut: false, value }));
-    if (settled) {
-      // `subscribe` already resolved synchronously; settle() ran
-      // before `disposable` was assigned, so dispose now and skip
-      // the timer entirely.
-      disposable.dispose();
-      return;
-    }
-    timer = setTimeout(() => settle({ timedOut: true }), timeoutMs);
-  });
 }
 
 /**

--- a/packages/extension/src/frontend/vscode/raceWithTimeout.ts
+++ b/packages/extension/src/frontend/vscode/raceWithTimeout.ts
@@ -1,0 +1,43 @@
+/**
+ * VS Code event/timeout racing helper, shared by call sites that wait on a
+ * one-shot VS Code event with a timeout fallback.
+ */
+
+import * as vscode from 'vscode';
+
+export type Raced<T> = { timedOut: false; value: T } | { timedOut: true };
+
+/**
+ * Race a one-shot event subscription against a timeout. Disposes the
+ * subscription and clears the timer in whichever branch wins so we
+ * never leak listeners or pending timers.
+ */
+export function raceWithTimeout<T>(
+  subscribe: (resolve: (value: T) => void) => vscode.Disposable,
+  timeoutMs: number,
+): Promise<Raced<T>> {
+  return new Promise((resolve) => {
+    // Predeclared with `let` so the `settle` closure can read them
+    // even if `subscribe` fires its callback synchronously (would
+    // otherwise hit the TDZ for the original `const` bindings).
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined = undefined;
+    let disposable: vscode.Disposable | undefined = undefined;
+    const settle = (result: Raced<T>) => {
+      if (settled) return;
+      settled = true;
+      if (timer !== undefined) clearTimeout(timer);
+      disposable?.dispose();
+      resolve(result);
+    };
+    disposable = subscribe((value) => settle({ timedOut: false, value }));
+    if (settled) {
+      // `subscribe` already resolved synchronously; settle() ran
+      // before `disposable` was assigned, so dispose now and skip
+      // the timer entirely.
+      disposable.dispose();
+      return;
+    }
+    timer = setTimeout(() => settle({ timedOut: true }), timeoutMs);
+  });
+}

--- a/packages/extension/src/frontend/vscode/vscodeDiagnostics.ts
+++ b/packages/extension/src/frontend/vscode/vscodeDiagnostics.ts
@@ -9,6 +9,8 @@ import * as vscode from 'vscode';
 
 import * as logger from '@logger/logUtils';
 
+import { raceWithTimeout } from './raceWithTimeout';
+
 const CHANNEL = 'VscodeDiagnostics';
 
 export { DiagnosticSeverity } from 'vscode';
@@ -27,29 +29,18 @@ export async function waitForDiagnosticsChange(
 
   const targetKey = uri.toString().toLowerCase();
 
-  await new Promise<void>((resolve) => {
-    let settled = false;
+  const raced = await raceWithTimeout<void>(
+    (resolve) =>
+      vscode.languages.onDidChangeDiagnostics((event) => {
+        const hasMatch = event.uris.some(
+          (eventUri) => eventUri.toString().toLowerCase() === targetKey,
+        );
+        if (hasMatch) resolve();
+      }),
+    timeoutMs,
+  );
 
-    const disposable = vscode.languages.onDidChangeDiagnostics((event) => {
-      const hasMatch = event.uris.some(
-        (eventUri) => eventUri.toString().toLowerCase() === targetKey,
-      );
-      if (hasMatch) {
-        finish();
-      }
-    });
-
-    const timeoutHandle = setTimeout(() => {
-      logger.debug(CHANNEL, `Timed out waiting for diagnostics: ${uri.fsPath}`);
-      finish();
-    }, timeoutMs);
-
-    function finish(): void {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timeoutHandle);
-      disposable.dispose();
-      resolve();
-    }
-  });
+  if (raced.timedOut) {
+    logger.debug(CHANNEL, `Timed out waiting for diagnostics: ${uri.fsPath}`);
+  }
 }

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -473,11 +473,7 @@ export class TextEditorTool extends defineTool({
         originalContent: fileContent,
         proposedContent: newFileContent,
         sourceTool: 'text_editor:str_replace',
-        afterWrite: ({ appliedContent, baseContent }) => {
-          if (appliedContent !== baseContent) {
-            this.addToHistory(filePath, baseContent);
-          }
-        },
+        afterWrite: this.undoHistoryAfterWrite(filePath),
         present: ({ appliedContent }) => {
           const snippet = appliedContent
             .split('\n')
@@ -536,11 +532,7 @@ export class TextEditorTool extends defineTool({
         originalContent: fileContent,
         proposedContent: newFileContent,
         sourceTool: 'text_editor:insert',
-        afterWrite: ({ appliedContent, baseContent }) => {
-          if (appliedContent !== baseContent) {
-            this.addToHistory(filePath, baseContent);
-          }
-        },
+        afterWrite: this.undoHistoryAfterWrite(filePath),
         present: ({ appliedContent }) => {
           const previewLines = appliedContent.split('\n');
           const insertIndex = insertLine - 1;
@@ -609,6 +601,17 @@ export class TextEditorTool extends defineTool({
    */
   private currentExecutionId(): string {
     return getRunContextExecutionId(tryUseRunContext()) ?? '';
+  }
+
+  /** `afterWrite` callback recording pre-edit content for undo, only when the write actually changed the file. */
+  private undoHistoryAfterWrite(
+    filePath: string,
+  ): (edit: { appliedContent: string; baseContent: string }) => void {
+    return ({ appliedContent, baseContent }) => {
+      if (appliedContent !== baseContent) {
+        this.addToHistory(filePath, baseContent);
+      }
+    };
   }
 
   private addToHistory(filePath: string, content: string): void {

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -2,7 +2,6 @@ import { z } from 'zod';
 
 import type { BashSettlement } from '@agent/runtime/HostInteractions';
 import {
-  currentSession,
   defaultSession,
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
@@ -15,6 +14,7 @@ import { StreamTabIdSchema, type StreamTabId } from '@shared/schemas';
 import { BASH_APPROVAL_CONFIG_KEY } from '@shared/schemas/agentCliSettings';
 import { type ToolResult } from '@shared/schemas/toolResult';
 import { requireInteractions } from '@tools/contextHelpers';
+import { createSessionBypassAccessors } from '@tools/approval/sessionBypassAccessors';
 import { getConfig } from '@utils/config/configUtils';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
@@ -29,24 +29,11 @@ const DEFAULT_BASH_REJECTION_INSTRUCTION =
   'Do not retry this rejected command or another approval-gated shell command for the same check. ' +
   'Continue without running it, use a non-shell method, or explain what approval would be needed.';
 
-export function setBashApprovalSessionBypass(
-  streamId: StreamTabId,
-  enabled: boolean,
-  options?: { silent?: boolean; session?: SessionHandle },
-): void {
-  (options?.session ?? currentSession()).approvals.bash.bypass.setBypass(
-    streamId,
-    enabled,
-    options,
-  );
-}
-
-export function isBashApprovalBypassedForStream(
-  streamId: StreamTabId,
-  session: SessionHandle = currentSession(),
-): boolean {
-  return session.approvals.bash.bypass.isBypassed(streamId);
-}
+const {
+  setSessionBypass: setBashApprovalSessionBypass,
+  isBypassedForStream: isBashApprovalBypassedForStream,
+} = createSessionBypassAccessors((session) => session.approvals.bash.bypass);
+export { setBashApprovalSessionBypass, isBashApprovalBypassedForStream };
 
 export async function requestBashApproval(
   request: BashApprovalRequest,

--- a/src/tools/approval/sessionBypassAccessors.ts
+++ b/src/tools/approval/sessionBypassAccessors.ts
@@ -1,0 +1,38 @@
+import {
+  currentSession,
+  type SessionHandle,
+} from '@agent/runtime/SessionHandle';
+import type { StreamApprovalBypass } from '@agent/runtime/streamApprovalQueue';
+import type { StreamTabId } from '@shared/schemas';
+
+/**
+ * Build the get/set session-bypass accessor pair shared by every approval
+ * kind (bash, tool-edit, …): each kind only differs in which
+ * `StreamApprovalBypass` it reads off `session.approvals`.
+ */
+export function createSessionBypassAccessors(
+  selectBypass: (session: SessionHandle) => StreamApprovalBypass,
+): {
+  setSessionBypass: (
+    streamId: StreamTabId,
+    enabled: boolean,
+    options?: { silent?: boolean; session?: SessionHandle },
+  ) => void;
+  isBypassedForStream: (
+    streamId: StreamTabId,
+    session?: SessionHandle,
+  ) => boolean;
+} {
+  return {
+    setSessionBypass(streamId, enabled, options) {
+      selectBypass(options?.session ?? currentSession()).setBypass(
+        streamId,
+        enabled,
+        options,
+      );
+    },
+    isBypassedForStream(streamId, session = currentSession()) {
+      return selectBypass(session).isBypassed(streamId);
+    },
+  };
+}

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -1,5 +1,4 @@
 import {
-  currentSession,
   defaultSession,
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
@@ -19,6 +18,7 @@ import type { ToolEditApprovalAction } from '@shared/schemas/prompts';
 import type { LineChanges } from '@shared/schemas/lineChanges';
 import { type ToolResult } from '@shared/schemas/toolResult';
 import { recordToolFileRead } from '@tools/fileInteractions';
+import { createSessionBypassAccessors } from '@tools/approval/sessionBypassAccessors';
 import { WorkspaceFS } from '@utils/files';
 import { getConfig } from '@utils/config/configUtils';
 import {
@@ -38,24 +38,13 @@ const TOOL_EDIT_APPROVAL_CONFIG_KEY = 'texra.toolUse.requireEditApproval';
 
 export const REVEAL_TIMEOUT_MS = 1500;
 
-export function setToolEditApprovalSessionBypass(
-  streamId: StreamTabId,
-  enabled: boolean,
-  options?: { silent?: boolean; session?: SessionHandle },
-): void {
-  (options?.session ?? currentSession()).approvals.toolEdit.bypass.setBypass(
-    streamId,
-    enabled,
-    options,
-  );
-}
-
-export function isApprovalBypassedForStream(
-  streamId: StreamTabId,
-  session: SessionHandle = currentSession(),
-): boolean {
-  return session.approvals.toolEdit.bypass.isBypassed(streamId);
-}
+const {
+  setSessionBypass: setToolEditApprovalSessionBypass,
+  isBypassedForStream: isApprovalBypassedForStream,
+} = createSessionBypassAccessors(
+  (session) => session.approvals.toolEdit.bypass,
+);
+export { setToolEditApprovalSessionBypass, isApprovalBypassedForStream };
 
 /**
  * Prepare a tool-edit approval prompt for the host: register the

--- a/src/utils/core/index.ts
+++ b/src/utils/core/index.ts
@@ -75,6 +75,32 @@ export function unique<T>(iterable: Iterable<T>): T[] {
 }
 
 /**
+ * Bucket items into a `Map<K, V[]>` keyed by `keyFn`, preserving each
+ * bucket's first-occurrence insertion order. `valueFn` maps each item to
+ * the value stored in its bucket (defaults to the item itself). Equivalent
+ * to the upcoming `Map.groupBy`, kept as a helper because the repo's `lib`
+ * target (ES2023) doesn't declare it yet.
+ */
+export function groupBy<T, K, V = T>(
+  items: readonly T[],
+  keyFn: (item: T) => K,
+  valueFn?: (item: T) => V,
+): Map<K, V[]> {
+  const groups = new Map<K, V[]>();
+  for (const item of items) {
+    const key = keyFn(item);
+    const value = valueFn ? valueFn(item) : (item as unknown as V);
+    const bucket = groups.get(key);
+    if (bucket) {
+      bucket.push(value);
+    } else {
+      groups.set(key, [value]);
+    }
+  }
+  return groups;
+}
+
+/**
  * Serialize a Map to a plain Record object. Keys are stringified.
  * @example mapToRecord(new Map([['a', 1]])) // { a: 1 }
  */

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -117,6 +117,19 @@ function resultFromExecutionError(err: unknown): ExecResult {
   };
 }
 
+function logExecutionErrorAndBuildResult(
+  err: unknown,
+  options: { quiet?: boolean; channel?: string },
+): ExecResult {
+  if (!options.quiet) {
+    logger.error(
+      options.channel ?? CHANNEL,
+      `Error executing command: ${toErrorMessage(err)}`,
+    );
+  }
+  return resultFromExecutionError(err);
+}
+
 function logCommandStderr(
   channel: string,
   stderr: string | null | undefined,
@@ -411,14 +424,7 @@ export async function executeCommand(
       outputLimitExceeded: maxBufferExceeded,
     });
   } catch (err) {
-    if (!options.quiet) {
-      logger.error(
-        options.channel ?? CHANNEL,
-        `Error executing command: ${toErrorMessage(err)}`,
-      );
-    }
-
-    return resultFromExecutionError(err);
+    return logExecutionErrorAndBuildResult(err, options);
   } finally {
     if (shellTimeoutId !== undefined) clearTimeout(shellTimeoutId);
     if (forceKillTimeoutId !== undefined) clearTimeout(forceKillTimeoutId);
@@ -474,13 +480,6 @@ export function executeCommandSync(
 
     return resultFromProcessOutput(stdout, stderr, exitCode, { timedOut });
   } catch (err) {
-    if (!options.quiet) {
-      logger.error(
-        options.channel ?? CHANNEL,
-        `Error executing command: ${toErrorMessage(err)}`,
-      );
-    }
-
-    return resultFromExecutionError(err);
+    return logExecutionErrorAndBuildResult(err, options);
   }
 }


### PR DESCRIPTION
## Summary

A scheduled sweep of the codebase for consolidation opportunities: duplicate logic across 2+ call sites, and hand-rolled implementations of things a native method or an existing shared helper already covers. Four parallel scans (`src/agent`, `src/tools`/`src/model`/`src/utils`/etc., `packages/extension`, `packages/cli`/`packages/desktop`/`packages/trace-viewer`) turned up eight concrete findings, all applied here. `src/agent/**` came back clean — no findings survived the "real, multi-call-site impact" bar there; that scope is excluded from this PR.

- Add `groupBy()` to `@utils/core` and use it at 5 hand-rolled `Map` bucketing sites, including `groupPendingApprovalsByRow` in `packages/cli/src/chat/tui/appInteractionPolicy.ts` (rebased onto main's own `pendingApprovalsForRows` extraction — see rebase note below), `state/streamViews.ts`, `panes/StaticConversationTranscript.tsx`, and `packages/desktop/src/renderer/desktopCommandPalette.ts`.
- `packages/desktop/src/desktopTaskShell.ts`: drop the local `clamp()` reimplementation, use the shared one from `@utils/core` (already used elsewhere in the same package).
- `packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts`: replace the hand-rolled array-equality check (`sameStringList`) with `node:util`'s `isDeepStrictEqual`, matching the existing pattern in the sibling file `subscribeStreamLog.ts`.
- `packages/extension/src/commands/latex/{figCommands.ts,imageCommands.ts}`: replace manual `.slice(0, 100) + '...'` truncation with the existing grapheme-aware `truncateWithEllipsis()`. **Minor observable change** (flagged by review): the shared helper uses a single-character Unicode ellipsis (`…`) instead of three ASCII dots, and only appends it when the string is actually truncated (the old code appended `...` unconditionally, even to short strings). For `figCommands.ts` it also avoids splitting a multi-byte grapheme mid-truncation. Both are improvements, not regressions, but they are technically observable output changes in a debug log / quick-pick detail string — not pure no-ops.
- Extract `raceWithTimeout()` (event-vs-timeout race with disposal/cleanup bookkeeping) into `packages/extension/src/frontend/vscode/raceWithTimeout.ts`. It previously existed as an unexported local in `setupTerminalRunner.ts` while `vscodeDiagnostics.ts` reimplemented the same settle/cleanup logic from scratch; both now share it. (Two other sites flagged by the scan — `VscodeDiffViewHost.ts` and `SupabaseAuthProvider.ts` — do extra work in their timeout branch that doesn't fit this shape cleanly, so they were left alone rather than forced into it.)
- `src/tools/approval/{bashApproval.ts,toolEditApproval.ts}`: factor the identical session-bypass get/set helper pairs into one parametrized `createSessionBypassAccessors()` in a new `sessionBypassAccessors.ts`. Public export names/signatures are unchanged.
- `src/utils/system/execUtils.ts`: dedupe the identical catch-block error-logging in `executeCommand`/`executeCommandSync` into `logExecutionErrorAndBuildResult()`.
- `src/tools/TextEditorTool.ts`: dedupe the identical undo-history `afterWrite` callback in `strReplace`/`insert` into `undoHistoryAfterWrite()`.

All behavior is preserved except the truncation-formatting nuance called out above (debug-log / quick-pick-detail cosmetics only, not functional).

**Rebase note:** this branch was rebased onto `main` after `main`'s own module-level simplification sweep (#9473) landed and independently touched 5 of the same files — including a parallel extraction of the `pendingApprovalsForRows` grouping (moved to `groupPendingApprovalsByRow` in `appInteractionPolicy.ts`) and a parallel merge of the two array-equality checks in `subscribeRuntimeHost.ts` (into `sameStringList`). Resolved by keeping `main`'s structure and layering this PR's native-method wins on top: `groupPendingApprovalsByRow` now uses `groupBy()` internally, and `sameStringList` now uses `isDeepStrictEqual` internally. That same `main` commit also fixed the pre-existing `@google/genai` type error that was failing `static checks` on this PR before the rebase.

## Issue acceptance gates

Not issue-driven — a proactive consolidation sweep. No specific issue/gates to satisfy.

## Single source of truth

- Map-bucketing: `groupBy()` in `src/utils/core/index.ts`.
- VS Code event/timeout race: `raceWithTimeout()` in `packages/extension/src/frontend/vscode/raceWithTimeout.ts`.
- Approval session-bypass get/set: `createSessionBypassAccessors()` in `src/tools/approval/sessionBypassAccessors.ts`.
- Command-execution error logging: `logExecutionErrorAndBuildResult()` in `src/utils/system/execUtils.ts`.
- Undo-history bookkeeping for text-editor writes: `TextEditorTool.undoHistoryAfterWrite()`.
- Approval-row grouping: `groupPendingApprovalsByRow()` in `packages/cli/src/chat/tui/appInteractionPolicy.ts`.
- Array-equality check for run-config files / queued follow-ups: `sameStringList()` in `subscribeRuntimeHost.ts`.

## Duplication and abstraction budget

Removed: 5 hand-rolled group-by accumulators, 1 duplicated (2-copy) event/timeout race helper, 2 identical approval-bypass accessor pairs, 1 duplicated catch-block, 1 duplicated `afterWrite` callback, 2 manual truncations, 1 duplicated `clamp()`, 2 hand-rolled array-equality checks (now 1 shared helper, native-backed). Each new helper (`groupBy`, `raceWithTimeout`, `createSessionBypassAccessors`, `logExecutionErrorAndBuildResult`, `undoHistoryAfterWrite`) has 2+ real call sites in this same PR and owns exactly one invariant (bucket-by-key order, dispose-on-settle race semantics, bypass read/write, error-log-then-build-result, write-then-record-undo-baseline). No pass-through wrappers added.

## Net elements (R6)

17 files changed, +211/-176 (net +35 lines, but two of those files are new small single-purpose modules; the touched call sites shrank overall). New exported symbols: `groupBy`, `raceWithTimeout`, `Raced`, `createSessionBypassAccessors` — each with 2+ consumers added in this PR. `setBashApprovalSessionBypass`, `isBashApprovalBypassedForStream`, `setToolEditApprovalSessionBypass`, `isApprovalBypassedForStream` keep their exported names/signatures, now backed by the shared factory instead of duplicated bodies.

## Consumer counts (R8)

n/a — no emit path or export was deleted or re-routed; the four approval-bypass export names are preserved with identical signatures.

## Host impact

Extension: `raceWithTimeout` consolidation (terminal runner + diagnostics wait); truncation fix in fig/image commands.

Desktop: `groupBy`/`clamp` consolidation in the command palette and task-shell reducer.

CLI: `groupBy` consolidation across App.tsx/appInteractionPolicy.ts/streamViews/StaticConversationTranscript; `isDeepStrictEqual` in subscribeRuntimeHost.

## Scheduled refactoring

None — `VscodeDiffViewHost.ts`'s reveal-with-retry and `SupabaseAuthProvider.ts`'s cancellation-token-aware wait were deliberately left out of the `raceWithTimeout` consolidation (different timeout-branch behavior); no follow-up filed since they're not a clean fit for the current helper shape.

## Validation

- `npx tsc --noEmit` (root) and every workspace package's typecheck (`cli`, `desktop`, `trace-viewer`, `texra`/extension): clean, zero errors, after rebasing onto `main` (the pre-existing `@google/genai` type error that predated this PR is now fixed upstream).
- `npm test`: 799 test files / 7981 tests passed (1 file / 9 tests skipped, pre-existing).
- `npm run lint`: clean.
- `npm run check:dead-code-ratchet`: no new unused files/exports/types (17 findings, same as baseline).
- `prettier --check`: clean.
- Automated `deepseekproT` review: passes, all eight consolidations verified semantically equivalent; the truncation nuance above is the one finding, now reflected here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FEDFapqtrMxiYoiQmuS4mM)_
