### PR TITLE
refactor: quality-lens sweep across fallbacks, wasted work, and ownership

### DIFF
--- a/packages/cli/src/chat/tui/App.tsx
+++ b/packages/cli/src/chat/tui/App.tsx
@@ -189,12 +189,18 @@ export function App(props: AppProps): React.JSX.Element {
     activeStreamId,
     pending,
   });
-  const childListTarget = resolveChildListTarget({
-    activeStreamId,
-    childStreamEntries,
-    parentStream,
-    streams,
-  });
+  // Walks the child-stream tree, so keep it at data-change frequency rather
+  // than recomputing on every keystroke and elapsed-second render.
+  const childListTarget = useMemo(
+    () =>
+      resolveChildListTarget({
+        activeStreamId,
+        childStreamEntries,
+        parentStream,
+        streams,
+      }),
+    [activeStreamId, childStreamEntries, parentStream, streams],
+  );
 
   const stdin = useStdin();
   const foregroundOpen =

--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -1,6 +1,6 @@
 import { Box, Text, useWindowSize } from 'ink';
 import { Badge } from '@inkjs/ui';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { resolveCliModelAccessRoute } from '@cli/runtime/modelAccessRoute';
 import { COLOR_ERROR } from '@cli/tui/ui/colors';
@@ -162,6 +162,18 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     : undefined;
   const now = useLiveNowMs(runStartedAt !== undefined, runStartedAt);
 
+  // Rebuilds the retained + active child rows, so keep it off the 1 Hz
+  // elapsed-time re-render path.
+  const displayStreamId = target.displayStreamId;
+  const subagentCount = useMemo(
+    () =>
+      displayStreamId === undefined
+        ? 0
+        : visibleSubagentRows(displayStreamId, childStreamEntries, streams)
+            .length,
+    [childStreamEntries, displayStreamId, streams],
+  );
+
   const display = buildStatusBarDisplay({
     status: statusSlice?.status,
     substate: statusSlice?.substate,
@@ -175,14 +187,7 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     queuedFollowUpMessages: statusSlice?.queuedFollowUpMessages ?? [],
     usage: statusSlice?.usage,
     roundStage: statusSlice?.roundStage,
-    subagents:
-      target.displayStreamId !== undefined
-        ? visibleSubagentRows(
-            target.displayStreamId,
-            childStreamEntries,
-            streams,
-          ).length
-        : 0,
+    subagents: subagentCount,
     approvalDepth: approvals.depth,
     approvalKind: approvals.kind,
     model: accessTarget.model,

--- a/packages/cli/src/chat/tui/panes/transcriptEntries.ts
+++ b/packages/cli/src/chat/tui/panes/transcriptEntries.ts
@@ -77,13 +77,7 @@ export function isRenderableTranscriptEntry(entry: ConversationEntry): boolean {
   }
 }
 
-function nextRenderableTranscriptEntry(
-  entries: readonly ConversationEntry[],
-  index: number,
-): ConversationEntry | undefined {
-  return entries.slice(index + 1).find(isRenderableTranscriptEntry);
-}
-
+/** Callers gate on {@link isRenderableTranscriptEntry} before asking. */
 function userPromptAwaitsLiveContinuation(
   entries: readonly ConversationEntry[],
   index: number,
@@ -93,12 +87,14 @@ function userPromptAwaitsLiveContinuation(
   if (
     entry?.role !== 'user' ||
     isInquiryContinuationText(entry.text) ||
-    !isRenderableTranscriptEntry(entry) ||
     !isActivePhase(status)
   ) {
     return false;
   }
-  return nextRenderableTranscriptEntry(entries, index) === undefined;
+  return !entries.some(
+    (later, laterIndex) =>
+      laterIndex > index && isRenderableTranscriptEntry(later),
+  );
 }
 
 /** Whether an entry belongs in append-only terminal scrollback now. */
@@ -154,14 +150,15 @@ export function orderedStaticTranscriptEntries(
   entries: readonly ConversationEntry[],
   status: StreamPhase | undefined,
 ): readonly ConversationEntry[] {
-  const candidates = entries
-    .map((entry, index) => ({ entry, index }))
-    .filter(({ index }) => isStaticTranscriptEntryAt(entries, index, status))
-    .map(({ entry, index }) => ({
-      entry,
-      index,
-      key: transcriptOrderKey(entry, index),
-    }));
+  const candidates: Array<{
+    entry: ConversationEntry;
+    index: number;
+    key: readonly [number, number];
+  }> = [];
+  for (const [index, entry] of entries.entries()) {
+    if (!isStaticTranscriptEntryAt(entries, index, status)) continue;
+    candidates.push({ entry, index, key: transcriptOrderKey(entry, index) });
+  }
 
   const alreadyOrdered = candidates.every(
     (candidate, i) =>

--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -128,6 +128,7 @@ import {
   chatTuiCanStartRootRun,
   chatTuiCanStopVisibleRun,
   chatTuiIsResumableIdleOnExit,
+  chatTuiRunPending,
   clearTuiSessionRunState,
   markChatTuiRunCompleted,
   markChatTuiRunPending,
@@ -496,7 +497,7 @@ export async function runChat(
     chatTuiCanInterruptActiveRun(session);
   const canStopActiveRun = (): boolean =>
     chatTuiCanStopVisibleRun({
-      runPending: Boolean(session.runPromise && !session.runCompleted),
+      runPending: chatTuiRunPending(session),
       streamId: session.streamId,
       status: rootStreamStatus(),
     });
@@ -532,7 +533,7 @@ export async function runChat(
     const activeStatus = activeStreamId
       ? streamsSignal.get().get(activeStreamId)?.status
       : undefined;
-    const isRunPending = Boolean(session.runPromise && !session.runCompleted);
+    const isRunPending = chatTuiRunPending(session);
 
     if (
       (isRunPending && activeStatus !== STREAM_PHASE.WAITING) ||

--- a/packages/cli/src/chat/tui/sessionExitController.ts
+++ b/packages/cli/src/chat/tui/sessionExitController.ts
@@ -44,7 +44,11 @@ import {
   collectResumeUsage,
   formatResumeHint,
 } from './state/resumeHint';
-import { chatTuiSigintAction, type TuiSession } from './state/sessionRunState';
+import {
+  chatTuiRunPending,
+  chatTuiSigintAction,
+  type TuiSession,
+} from './state/sessionRunState';
 import type PQueue from 'p-queue';
 import type { Instance as InkInstance } from 'ink';
 
@@ -331,7 +335,7 @@ export function createSessionExitController(
     // chatTuiIsResumableIdleOnExit for the live-flow check that distinguishes
     // this state from a resume slot that is still rehydrating.
     const resumableIdle = ctx.isResumableIdle();
-    if (session.runPromise && !session.runCompleted && !resumableIdle) {
+    if (chatTuiRunPending(session) && !resumableIdle) {
       session.stopRequested = true;
       ctx.interruptActive();
       // Only await a run we actually interrupted/finished. A resumableIdle run

--- a/packages/cli/src/chat/tui/state/sessionRunState.ts
+++ b/packages/cli/src/chat/tui/state/sessionRunState.ts
@@ -132,10 +132,18 @@ export function chatTuiCanStopVisibleRun(facts: ChatTuiRunStopFacts): boolean {
   );
 }
 
+/** Whether the session still holds an unfinished root-run claim. Sole
+ *  derivation of that fact: the availability predicate, the published
+ *  `rootRunPending` signal, and every caller-side "a run is in flight" check
+ *  read it here instead of re-deriving `runPromise && !runCompleted`. */
+export function chatTuiRunPending(session: PendingTuiRunSessionState): boolean {
+  return Boolean(session.runPromise) && !session.runCompleted;
+}
+
 export function chatTuiCanStartRootRun(
   session: PendingTuiRunSessionState,
 ): boolean {
-  return !session.runPromise || session.runCompleted;
+  return !chatTuiRunPending(session);
 }
 
 /**
@@ -147,9 +155,9 @@ export function chatTuiCanStartRootRun(
 export function publishChatTuiRunState(
   session: PublishedTuiRunSessionState,
 ): void {
-  const canStart = chatTuiCanStartRootRun(session);
-  rootRunStartAvailable.set(canStart);
-  rootRunPending.set(!canStart);
+  const runPending = chatTuiRunPending(session);
+  rootRunStartAvailable.set(!runPending);
+  rootRunPending.set(runPending);
   rootRunStreamId.set(session.streamId);
 }
 

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -584,15 +584,15 @@ async function switchRetryToPersonalCredentials(
   decision: ApprovalDecision,
   request: TuiRetryRequest,
   options: {
-    isCurrent?: () => boolean;
+    isCurrent: () => boolean;
     prepareRetry?: HostRetryInteractionOptions['prepareRetry'];
-    preparationSignal?: AbortSignal;
+    preparationSignal: AbortSignal;
     commitQueue: PQueue;
   },
 ): Promise<void> {
-  const isCurrent = () => options.isCurrent?.() ?? true;
+  const isCurrent = options.isCurrent;
   if (!isCurrent()) return;
-  const signal = options.preparationSignal ?? new AbortController().signal;
+  const signal = options.preparationSignal;
 
   const requestedProvider = request.errorDetails?.provider;
   if (!requestedProvider || !isApiProvider(requestedProvider)) {

--- a/packages/cli/src/commands/_helpers/dispatch.ts
+++ b/packages/cli/src/commands/_helpers/dispatch.ts
@@ -18,6 +18,7 @@ import {
   typoSuggestionThreshold,
 } from '@utils/text/editDistance';
 import {
+  documentsNegatedBooleanForm,
   GLOBAL_ARGS,
   GLOBAL_BOOL_FLAGS,
   GLOBAL_VALUE_FLAGS,
@@ -98,16 +99,11 @@ function collectLeadingGlobalFlags(
  * is hit first.
  */
 function firstPositionalIndex(rawArgs: readonly string[]): number | undefined {
-  for (let i = 0; i < rawArgs.length;) {
-    const arg = rawArgs[i];
-    if (arg === undefined || arg === '--') return undefined;
-    if (!arg.startsWith('-')) return i;
-
-    const tokenCount = knownGlobalFlagTokenCount(rawArgs, i);
-    if (tokenCount === undefined) return undefined;
-    i += tokenCount;
-  }
-  return undefined;
+  const { restIndex, stoppedOnUnknownFlag } =
+    collectLeadingGlobalFlags(rawArgs);
+  if (stoppedOnUnknownFlag) return undefined;
+  const token = rawArgs[restIndex];
+  return token === undefined || token === '--' ? undefined : restIndex;
 }
 
 // ---------------------------------------------------------------------------
@@ -472,14 +468,7 @@ function addFlagSpec(specs: CommandFlagSpecs, name: string, def: ArgDef): void {
     }
   }
 
-  // Accept the negated `--no-<name>` form for booleans that document one:
-  // those defaulting to `true` (passed via the negative) and opt-in toggles
-  // that advertise a `negativeDescription` (e.g. `--no-websocket`). Otherwise
-  // `texra run --no-websocket` is rejected as an unknown flag.
-  if (
-    def.type === 'boolean' &&
-    (def.default === true || 'negativeDescription' in def)
-  ) {
+  if (documentsNegatedBooleanForm(def)) {
     addLongFlag(specs, `no-${name}`, { takesValue: false });
   }
 }
@@ -551,18 +540,9 @@ function validateShortFlag(
 }
 
 function helpTargetRawArgs(rawArgs: readonly string[]): readonly string[] {
-  for (let i = 0; i < rawArgs.length;) {
-    const token = rawArgs[i];
-    if (token === undefined || token === '--') break;
-    if (token.startsWith('-')) {
-      const tokenCount = knownGlobalFlagTokenCount(rawArgs, i);
-      if (tokenCount === undefined) break;
-      i += tokenCount;
-      continue;
-    }
-    return token === 'help' ? rawArgs.slice(i + 1) : rawArgs;
-  }
-  return rawArgs;
+  const index = firstPositionalIndex(rawArgs);
+  if (index === undefined || rawArgs[index] !== 'help') return rawArgs;
+  return rawArgs.slice(index + 1);
 }
 
 export async function detectUnknownCliFlag(

--- a/packages/cli/src/commands/_helpers/globalArgs.ts
+++ b/packages/cli/src/commands/_helpers/globalArgs.ts
@@ -192,23 +192,29 @@ export const GLOBAL_VALUE_FLAGS = new Set<string>(
   ),
 );
 
+/**
+ * Whether a boolean arg documents a negated `--no-<name>` spelling: those
+ * defaulting to `true` (passed via the negative, like `--no-color`) and opt-in
+ * toggles that advertise a `negativeDescription` (like `--no-websocket`, which
+ * has no default). citty rewrites any `--no-<name>` to `<name>: false`; both
+ * leading-flag reordering and unknown-flag detection register the spelling so
+ * `texra --no-color agents list` and `texra --no-websocket run polish` parse.
+ */
+export function documentsNegatedBooleanForm(def: {
+  readonly type?: string;
+  readonly default?: boolean | number | string;
+}): boolean {
+  return (
+    def.type === 'boolean' &&
+    (def.default === true || 'negativeDescription' in def)
+  );
+}
+
 export const GLOBAL_BOOL_FLAGS = new Set<string>(
   Object.entries(AGENT_RUN_GLOBAL_ARGS).flatMap(([name, def]) => {
     if (def.type !== 'boolean') return [];
     const flags = flagSpellings(name, def);
-    // Register the negated `--no-<name>` spelling so leading-flag reordering and
-    // unknown-command detection recognize it (e.g. `texra --no-color agents
-    // list`, `texra --no-websocket run polish`). citty rewrites any
-    // `--no-<name>` to `<name>: false`; we register the spelling for booleans
-    // that document a negated form — those defaulting to `true` (passed via the
-    // negative, like `--no-color`) and opt-in toggles that advertise a
-    // `negativeDescription` (like `--no-websocket`, which has no default).
-    if (
-      ('default' in def && def.default === true) ||
-      'negativeDescription' in def
-    ) {
-      flags.push(`--no-${name}`);
-    }
+    if (documentsNegatedBooleanForm(def)) flags.push(`--no-${name}`);
     return flags;
   }),
 );

--- a/packages/cli/src/commands/history.ts
+++ b/packages/cli/src/commands/history.ts
@@ -48,7 +48,7 @@ export function parseHistoryListLimit(
 
 async function runHistoryList(
   context: CliContext,
-  options: { limit?: number } = {},
+  options: { limit?: number },
 ): Promise<number> {
   await initLocalCliPlatform(context);
   const entries = await listCliHistoryEntries();
@@ -72,7 +72,7 @@ async function runHistoryList(
 async function runHistoryShow(
   context: CliContext,
   id: ExecutionId,
-  options: { full?: boolean } = {},
+  options: { full?: boolean },
 ): Promise<number> {
   await initLocalCliPlatform(context);
   const details = await readCliHistoryDetails(id, {
@@ -113,7 +113,7 @@ export async function runHistoryExport(
   context: CliContext,
   id: ExecutionId,
   format: 'html' | 'md',
-  options: { assetsDir?: string } = {},
+  options: { assetsDir?: string },
 ): Promise<number> {
   await initLocalCliPlatform(context);
 

--- a/packages/cli/src/commands/installGithubAction.ts
+++ b/packages/cli/src/commands/installGithubAction.ts
@@ -169,17 +169,19 @@ async function runInstallGithubAction(
     return CliExitCode.Usage;
   }
 
-  const baseRef = branchExists ? null : resolveBaseRef(root, base);
-  if (!branchExists && !baseRef) {
-    writeTextStderr(
-      `Could not resolve base branch "${base}". Fetch it or pass --base <branch>.`,
-    );
-    return CliExitCode.Usage;
+  let checkout: ReturnType<typeof git>;
+  if (branchExists) {
+    checkout = git(root, 'checkout', branch);
+  } else {
+    const baseRef = resolveBaseRef(root, base);
+    if (!baseRef) {
+      writeTextStderr(
+        `Could not resolve base branch "${base}". Fetch it or pass --base <branch>.`,
+      );
+      return CliExitCode.Usage;
+    }
+    checkout = git(root, 'checkout', '-b', branch, baseRef);
   }
-
-  const checkout = branchExists
-    ? git(root, 'checkout', branch)
-    : git(root, 'checkout', '-b', branch, baseRef ?? base);
   if (!checkout.success) {
     writeTextStderr(
       `Failed to check out branch "${branch}": ${checkout.stderr ?? ''}`,
@@ -282,7 +284,7 @@ async function runInstallGithubAction(
   // `gh pr create --web` (it prefills the title/body) and fall back to opening
   // the compare URL directly when gh is unavailable or cannot open the page.
   const prPageUrl = compareUrl(slug, base, branch);
-  let opened = false;
+  let opened: boolean;
   if (ghAvailable(root)) {
     const pr = gh(
       root,

--- a/packages/cli/src/commands/models.ts
+++ b/packages/cli/src/commands/models.ts
@@ -56,7 +56,7 @@ async function loadModelAccessList(
 
 async function listModels(
   context: CliContext,
-  options: CliModelListOptions = {},
+  options: CliModelListOptions,
 ): Promise<number> {
   const result = await loadModelAccessList(context, options);
   if ('error' in result) {
@@ -68,14 +68,12 @@ async function listModels(
   if (context.outputFormat === 'text' && listedModels.length === 0) {
     writeTextStderr(formatNoListableModelsMessage(result.apiMode, options));
   }
+  const records = listedModels.map(({ model }) => cliModelRecord(model));
   emitCliResult(
     context,
     {
-      json: listedModels.map(({ model }) => cliModelRecord(model)),
-      ndjson: listedModels.map(({ model }) => ({
-        kind: 'model',
-        model: cliModelRecord(model),
-      })),
+      json: records,
+      ndjson: records.map((model) => ({ kind: 'model', model })),
       text: listedModels
         .map(({ model, status }) => `${model.value}\t${model.label}\t${status}`)
         .join('\n'),
@@ -111,9 +109,10 @@ async function showModel(context: CliContext, id: string): Promise<number> {
     return CliExitCode.Usage;
   }
 
+  const record = cliModelRecord(entry.model);
   emitCliResult(context, {
-    json: cliModelRecord(entry.model),
-    ndjson: { kind: 'model', model: cliModelRecord(entry.model) },
+    json: record,
+    ndjson: { kind: 'model', model: record },
     text: formatCliModelDetails(entry, result.apiMode),
   });
   return CliExitCode.Success;

--- a/packages/cli/src/runtime/approvalAdapter.ts
+++ b/packages/cli/src/runtime/approvalAdapter.ts
@@ -3,14 +3,11 @@
 // stable surface for command modules, the TUI, and tests.
 
 import type {
-  BashSettlement,
   HostAgentProposalRequest,
   HostApprovalBypassStateUpdate,
   HostInteractions,
   HostRetryRequest,
   HostUserQuestionRequest,
-  PlanApprovalResult,
-  ProposalResult,
   RetryResult,
   UserQuestionSettlement,
 } from '@agent/runtime/HostInteractions';
@@ -127,19 +124,11 @@ async function decideApprovalEvent<K extends CliDecisionApprovalEvent>(
   return decision;
 }
 
-function toBashResult(decision: ApprovalDecision): BashSettlement {
-  return decision.accepted
-    ? { action: 'approve' }
-    : { action: 'reject', feedback: decision.userMessage };
-}
-
-function toPlanResult(decision: ApprovalDecision): PlanApprovalResult {
-  return decision.accepted
-    ? { action: 'approve' }
-    : { action: 'reject', feedback: decision.userMessage };
-}
-
-function toProposalResult(decision: ApprovalDecision): ProposalResult {
+/** Approve/reject settlement shared by the bash, plan, and proposal ports —
+ *  none of them offers the extra actions their result unions allow. */
+function toApprovalSettlement(
+  decision: ApprovalDecision,
+): { action: 'approve' } | { action: 'reject'; feedback?: string } {
   return decision.accepted
     ? { action: 'approve' }
     : { action: 'reject', feedback: decision.userMessage };
@@ -227,7 +216,7 @@ export function createHeadlessCliHostInteractions(
         context,
         hooks,
       );
-      return toBashResult(decision);
+      return toApprovalSettlement(decision);
     },
     async requestPlanApproval(request) {
       const decision = await decideApprovalEvent(
@@ -236,7 +225,7 @@ export function createHeadlessCliHostInteractions(
         context,
         hooks,
       );
-      return toPlanResult(decision);
+      return toApprovalSettlement(decision);
     },
     async requestAgentProposal(request: HostAgentProposalRequest) {
       const decision = await decideApprovalEvent(
@@ -245,7 +234,7 @@ export function createHeadlessCliHostInteractions(
         context,
         hooks,
       );
-      return toProposalResult(decision);
+      return toApprovalSettlement(decision);
     },
     async requestRetry(request: HostRetryRequest) {
       const payload: RetryPermission = {

--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -49,7 +49,7 @@ interface RenderState {
 }
 
 export interface RunProgressRenderer {
-  handleSessionEvent(event: SessionEvent): boolean;
+  handleSessionEvent(event: SessionEvent): void;
   clear(): void;
   preserve(): void;
 }
@@ -86,9 +86,8 @@ export function attachRunProgressRenderer(
 ): () => void {
   if (!renderer) return () => undefined;
 
-  const handleEvent = (event: SessionEvent): void => {
+  const handleEvent = (event: SessionEvent): void =>
     renderer.handleSessionEvent(event);
-  };
   const detachSessionFacts = events.subscribe(handleEvent, {
     scope: 'session',
   });
@@ -118,8 +117,12 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
   private liveLine = false;
   private rootStreamId: StreamTabId | undefined;
   private rootStreamStatus: StreamPhase | undefined;
-  private rootStreamTerminal = false;
   private heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+
+  /** Derived from the one status field, never mirrored into a second flag. */
+  private get rootStreamTerminal(): boolean {
+    return isTerminalOutcomePhase(this.rootStreamStatus);
+  }
 
   constructor(init: RunProgressRendererInit) {
     this.write = init.write ?? writeRawStderr;
@@ -132,11 +135,12 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
     this.startedAt = this.nowMs();
   }
 
-  handleSessionEvent(event: SessionEvent): boolean {
+  handleSessionEvent(event: SessionEvent): void {
     if (event.scope === 'session') {
-      return this.handleSessionFact(event.event);
+      this.handleSessionFact(event.event);
+      return;
     }
-    return this.handleRunFact(event.streamId, event.event);
+    this.handleRunFact(event.streamId, event.event);
   }
 
   clear(): void {
@@ -155,12 +159,12 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
     }
   }
 
-  private handleSessionFact(event: SessionFact): boolean {
+  private handleSessionFact(event: SessionFact): void {
     switch (event.type) {
       case 'updateStreamStatus': {
         const { status, streamId } = event.payload;
         this.applyStatus(streamId, status);
-        return true;
+        return;
       }
       case 'updateStreamDescription':
         if (!this.rootStreamTerminal) {
@@ -169,7 +173,7 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
             event.payload.description,
           );
         }
-        return true;
+        return;
       case 'goalStateChanged':
       case 'inquiryThreadUpdated':
       case 'clearMissingOutputs':
@@ -178,28 +182,28 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
       case 'setActiveStream':
       case 'setParentStream':
       case 'removeStream':
-        return false;
+        return;
     }
-    return assertNever(event, 'Unhandled run-progress renderer session fact');
+    assertNever(event, 'Unhandled run-progress renderer session fact');
   }
 
-  private handleRunFact(streamId: StreamTabId, event: AgentEvent): boolean {
+  private handleRunFact(streamId: StreamTabId, event: AgentEvent): void {
     switch (event.type) {
       case 'run.config':
         if (this.applyRunConfig(event.streamId, event.config)) {
           this.updateHeartbeat();
           this.render(true);
         }
-        return true;
+        return;
       case 'conversation.progress':
-        if (this.rootStreamTerminal) return true;
+        if (this.rootStreamTerminal) return;
         if (this.applyConversationProgress(streamId, event.progress)) {
           this.updateHeartbeat();
           this.render();
         }
-        return true;
+        return;
       case 'stage.start':
-        if (this.rootStreamTerminal || event.kind !== 'round') return true;
+        if (this.rootStreamTerminal || event.kind !== 'round') return;
         if (
           this.applyRoundStage(streamId, {
             index: event.index ?? 0,
@@ -211,15 +215,15 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
           this.updateHeartbeat();
           this.render();
         }
-        return true;
+        return;
       case 'child.activity':
-        if (this.rootStreamTerminal) return true;
+        if (this.rootStreamTerminal) return;
         this.applyActiveSubagents(event.parentStreamId, event.items);
         this.updateHeartbeat();
         this.render(true);
-        return true;
+        return;
       default:
-        return false;
+        return;
     }
   }
 
@@ -278,7 +282,6 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
 
     this.rootStreamStatus = status;
     this.state.phase = formatRunProgressStatus(status);
-    this.rootStreamTerminal = isTerminalOutcomePhase(status);
     if (this.rootStreamTerminal) {
       this.state.activeSubagents = undefined;
     }

--- a/packages/cli/src/runtime/updateChecker.ts
+++ b/packages/cli/src/runtime/updateChecker.ts
@@ -103,11 +103,11 @@ export function isPackageManagerInstall(
   return segments.includes('node_modules') || segments.includes('cellar');
 }
 
-export function buildUpdateCommand(
-  method: InstallMethod,
-  pkg: string = CLI_PACKAGE_NAME,
-): { command: string; args: readonly string[] } {
-  const target = `${pkg}@latest`;
+export function buildUpdateCommand(method: InstallMethod): {
+  command: string;
+  args: readonly string[];
+} {
+  const target = `${CLI_PACKAGE_NAME}@latest`;
   switch (method) {
     case 'pnpm':
       return { command: 'pnpm', args: ['add', '-g', target] };

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -281,13 +281,9 @@ export class DesktopProgressBridge {
     });
     this.state = this.backend.state;
     this.streamLogs = this.state.streamLogs;
-    const detachCompletedResult = this.session.onResult((event) => {
+    this.detachCompletedResult = this.session.onResult((event) => {
       if (event.outcome === 'completed') this.options.host.onRunCompleted();
     });
-    this.detachCompletedResult = () => {
-      detachCompletedResult();
-      this.detachCompletedResult = () => undefined;
-    };
     this.initialization = this.initializeCanonicalState(presentationHost);
   }
 

--- a/packages/desktop/src/main/desktopAgentResume.ts
+++ b/packages/desktop/src/main/desktopAgentResume.ts
@@ -102,7 +102,7 @@ async function resolveDesktopResumeState(
 function resumeDesktopStream(
   streamId: StreamTabId,
   context: DesktopResumeContext,
-  recovery?: RecoveryContinuation,
+  recovery: RecoveryContinuation,
 ): Promise<boolean> {
   if (!context.session.transcripts.has(streamId)) return Promise.resolve(false);
   const terminalResult = trackTerminalResultPresentation(

--- a/packages/desktop/src/main/desktopExecutionIpc.ts
+++ b/packages/desktop/src/main/desktopExecutionIpc.ts
@@ -1,6 +1,8 @@
 import { MAIN_VIEW_COMMANDS } from '@shared/ipc';
-import type { MainViewExecuteMessage } from '@shared/schemas/mainView/executeMessage';
-import { MainViewInboundMessageSchema } from '@shared/schemas/mainView';
+import {
+  MainViewExecuteInboundMessageSchema,
+  type MainViewExecuteMessage,
+} from '@shared/schemas/mainView/executeMessage';
 import {
   createCommandHandler,
   createDesktopErrorReporter,
@@ -20,21 +22,15 @@ export function createDesktopExecutionIpc(
   return createCommandHandler(
     {
       [MAIN_VIEW_COMMANDS.EXECUTE]: (message) => {
-        // Validate at the IPC boundary against the shared inbound schema
-        // (the same schema desktopShellIpc/desktopProgressIpc/desktopSettingsIpc
-        // parse against) instead of blindly casting untrusted renderer input.
-        const parsed = MainViewInboundMessageSchema.safeParse(message);
-        if (
-          !parsed.success ||
-          parsed.data.command !== MAIN_VIEW_COMMANDS.EXECUTE
-        ) {
+        // Validate at the IPC boundary against the shared schema for this
+        // command — the EXECUTE member of the main-view inbound union the
+        // other desktop IPC handlers parse against — instead of blindly
+        // casting untrusted renderer input.
+        const parsed = MainViewExecuteInboundMessageSchema.safeParse(message);
+        if (!parsed.success) {
           reportAsyncError(
             new Error(
-              `Ignoring malformed ${MAIN_VIEW_COMMANDS.EXECUTE} message: ${
-                parsed.success
-                  ? `unexpected command ${String(parsed.data.command)}`
-                  : parsed.error.message
-              }`,
+              `Ignoring malformed ${MAIN_VIEW_COMMANDS.EXECUTE} message: ${parsed.error.message}`,
             ),
           );
           return;

--- a/packages/desktop/src/main/desktopGitHost.ts
+++ b/packages/desktop/src/main/desktopGitHost.ts
@@ -13,7 +13,6 @@
  * extension.
  */
 
-import { clamp } from '@utils/core';
 import {
   COMMIT_LABEL_FORMAT,
   splitCommitLines,
@@ -29,11 +28,9 @@ import {
 /**
  * Maximum number of commits the renderer will display in the launcher banner.
  * Mirrors the extension's `texra.git.numberOfCommitsToShow` default (20). The
- * desktop currently has no per-user override; if/when one is wired the cap
- * stays here as a defence-in-depth bound.
+ * desktop has no per-user override.
  */
-const DEFAULT_COMMIT_LIMIT = 20;
-const MAX_COMMIT_LIMIT = 1000;
+const COMMIT_LIMIT = 20;
 
 /**
  * Hard upper bound on git output bytes (8 MiB). 20 commits with subjects
@@ -67,11 +64,6 @@ export interface CreateDesktopGitHostOptions {
    * picks up workspace switches without needing to be re-instantiated.
    */
   getWorkspacePath: () => string | undefined;
-  /**
-   * Hard cap on the number of commits returned. Defaults to 20 to match
-   * `texra.git.numberOfCommitsToShow`.
-   */
-  commitLimit?: number;
   /** Hook for surfacing unexpected errors (logging, telemetry). */
   onError?: (error: unknown) => void;
 }
@@ -88,8 +80,6 @@ export interface CreateDesktopGitHostOptions {
 export function createDesktopGitHost(
   options: CreateDesktopGitHostOptions,
 ): DesktopGitHost {
-  const limit = clampCommitLimit(options.commitLimit ?? DEFAULT_COMMIT_LIMIT);
-
   async function readGit(
     workspace: string,
     args: readonly string[],
@@ -137,7 +127,7 @@ export function createDesktopGitHost(
         '--no-pager',
         'log',
         '-n',
-        String(limit),
+        String(COMMIT_LIMIT),
         `--pretty=format:${COMMIT_LABEL_FORMAT}`,
       ]);
       // rev-parse already passed, so a failed log is still a git repo. The
@@ -227,11 +217,4 @@ function parseDivergence(output: string | undefined): [number, number] {
 function parseGitCount(value: string): number {
   const parsed = Number.parseInt(value, 10);
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
-}
-
-function clampCommitLimit(value: number): number {
-  if (!Number.isFinite(value)) return DEFAULT_COMMIT_LIMIT;
-  const rounded = Math.floor(value);
-  if (rounded <= 0) return DEFAULT_COMMIT_LIMIT;
-  return clamp(rounded, 1, MAX_COMMIT_LIMIT);
 }

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -115,8 +115,6 @@ import { registerCommands } from './commands';
 
 let statusBarItem: vscode.StatusBarItem | undefined;
 let apiKeyStatusBarItem: vscode.StatusBarItem | undefined;
-let disposeStatusListener: (() => void) | undefined;
-let progressViewProviderInstance: ProgressViewProvider | undefined;
 // Re-instantiated on every activate(): runShutdown() trips an internal
 // idempotency flag, so a stale module-level instance would silently swallow
 // handlers registered by a second activate() in the same process.
@@ -299,7 +297,7 @@ export async function activate(context: vscode.ExtensionContext) {
   lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () => killActiveRecording());
   lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () => UsageLogService.dispose());
   lifecycle.onShutdown(SHUTDOWN_PHASE.BEFORE, () =>
-    progressViewProviderInstance?.flushState(),
+    ProgressViewProvider.getInstance()?.flushState(),
   );
   lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () => clearStoreCache());
   lifecycle.onShutdown(SHUTDOWN_PHASE.ON, () =>
@@ -513,7 +511,6 @@ export async function activate(context: vscode.ExtensionContext) {
   }
 
   const progressViewProvider = new ProgressViewProvider(context);
-  progressViewProviderInstance = progressViewProvider;
   await progressViewProvider.initialize();
 
   logger.info('extension', 'TeXRA extension activated');
@@ -712,7 +709,7 @@ export async function activate(context: vscode.ExtensionContext) {
     }
   };
 
-  disposeStatusListener = subscribeStatusBarSessionEvents({
+  const disposeStatusListener = subscribeStatusBarSessionEvents({
     session: statusBarSession,
     tracker: statusBarUsageTracker,
     onStatusChanged: () => {

--- a/packages/extension/src/frontend/ui/diffView.ts
+++ b/packages/extension/src/frontend/ui/diffView.ts
@@ -11,14 +11,9 @@ interface DiffInfo {
   title: string;
 }
 
-let disposables: vscode.Disposable[] = [];
+let refreshListener: vscode.Disposable | undefined;
 let diffInfo: DiffInfo | undefined;
 let lastRefresh = 0;
-
-function clearDisposables(): void {
-  disposables.forEach((d) => d.dispose());
-  disposables = [];
-}
 
 function refreshDiff(): void {
   if (!diffInfo) {
@@ -44,14 +39,15 @@ export function registerDiffRefresh(
   right: vscode.Uri,
   title: string,
 ): void {
-  clearDisposables();
+  refreshListener?.dispose();
   diffInfo = { left, right, title };
-  disposables.push(vscode.window.onDidChangeTextEditorViewColumn(refreshDiff));
+  refreshListener = vscode.window.onDidChangeTextEditorViewColumn(refreshDiff);
   logger.debug(CHANNEL, 'Registered diff refresh listeners');
 }
 
 export function disposeDiffRefresh(): void {
-  clearDisposables();
+  refreshListener?.dispose();
+  refreshListener = undefined;
   diffInfo = undefined;
   logger.debug(CHANNEL, 'Disposed diff refresh listeners');
 }

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -890,21 +890,17 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       return false;
     }
 
+    // Whichever of `onRun` and the command's own settlement lands first wins:
+    // a promise ignores every resolve after the first.
     return new Promise<boolean>((resolve) => {
-      let settled = false;
-      const settle = (started: boolean): void => {
-        if (settled) return;
-        settled = true;
-        resolve(started);
-      };
       void this.runViewCommand<boolean>('texra.execute', [
         {
           ...validation.request,
-          onRun: () => settle(true),
+          onRun: () => resolve(true),
         },
       ]).then(
-        (completed) => settle(completed === true),
-        () => settle(false),
+        (completed) => resolve(completed === true),
+        () => resolve(false),
       );
     });
   }

--- a/packages/extension/src/progressView/frontend/components/TerminalOutput.ts
+++ b/packages/extension/src/progressView/frontend/components/TerminalOutput.ts
@@ -285,16 +285,10 @@ export class TerminalOutput extends LitElement {
   ): Promise<void> {
     if (!text) return;
 
+    // Whichever lands first wins; a promise ignores every later resolve.
     await new Promise<void>((resolve) => {
-      let resolved = false;
-      const complete = (): void => {
-        if (resolved) return;
-        resolved = true;
-        resolve();
-      };
-
-      terminal.write(text, complete);
-      setTimeout(complete, 100);
+      terminal.write(text, () => resolve());
+      setTimeout(() => resolve(), 100);
     });
   }
 

--- a/packages/extension/src/progressView/frontend/slices/logSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/logSlice.ts
@@ -15,6 +15,10 @@ import { upsertTaskGroupFromStreamLog } from '@shared/streams/taskGroupProjectio
 import { appState } from '../progressState';
 import type { StreamLogs, StreamState } from '../store';
 
+/** Built once: `applyEntry` runs per delta entry in the streaming path. */
+const OptionalContextStateData =
+  ContextStateDataSchema.optional().catch(undefined);
+
 function toLogMessage(entry: StreamLogEntry): LogMessageData {
   return {
     id: entry.id,
@@ -53,9 +57,7 @@ function applyEntry(
   );
 
   if (entry.messageType === MESSAGE_TYPES.CONTEXT_STATE) {
-    const contextState = ContextStateDataSchema.optional()
-      .catch(undefined)
-      .parse(entry.data);
+    const contextState = OptionalContextStateData.parse(entry.data);
     if (contextState) {
       streamState.contextState = contextState;
       stateChanged = true;

--- a/packages/extension/src/progressView/frontend/slices/runTrackingSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/runTrackingSlice.ts
@@ -15,7 +15,6 @@ import {
   type ProgressViewOutboundHandlerRegistry,
 } from '@shared/schemas';
 
-import { isToolUseState, isWorkflowState } from '../store';
 import { setStreamStateForId } from '../progressState';
 import { updateWorkflowState, updateRounds } from '../stateUtils';
 
@@ -61,14 +60,13 @@ export const runTrackingHandlers = {
 
   [PROGRESS_VIEW_COMMANDS.UPDATE_RUN_USAGE]: (data) => {
     const { stream, runId, usage } = data;
-    setStreamStateForId(stream, (prev) => {
-      if (isToolUseState(prev) || isWorkflowState(prev)) {
-        return create(prev, (draft) => {
-          draft.runUsage[runId] = usage;
-          draft.sessionUsage = sumUsageStats(Object.values(draft.runUsage));
-        });
-      }
-      return prev;
-    });
+    // Both stream kinds carry runUsage/sessionUsage (BaseStreamStateSchema),
+    // so no kind narrowing is needed here.
+    setStreamStateForId(stream, (prev) =>
+      create(prev, (draft) => {
+        draft.runUsage[runId] = usage;
+        draft.sessionUsage = sumUsageStats(Object.values(draft.runUsage));
+      }),
+    );
   },
 } satisfies Partial<ProgressViewOutboundHandlerRegistry>;

--- a/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryItemElement.ts
@@ -367,24 +367,17 @@ export class HistoryItemElement extends LitElement {
       ? 'warning'
       : 'brand';
 
-    const extraDetails: TemplateResult[] = [];
-    const pushSection = (
-      label: string | TemplateResult,
-      entries: Array<[string, HistoryConfigValue]>,
-    ): void => {
-      // renderConfigSection filters empty entries and returns null when none remain.
-      const section = this.renderConfigSection(label, entries);
-      if (section) extraDetails.push(section);
-    };
-
-    for (const section of presentation.sections) {
-      pushSection(
-        section.icon
-          ? html`${waIcon(section.icon)} ${section.label}`
-          : section.label,
-        section.entries,
-      );
-    }
+    // renderConfigSection filters empty entries and returns null when none remain.
+    const extraDetails = presentation.sections
+      .map((section) =>
+        this.renderConfigSection(
+          section.icon
+            ? html`${waIcon(section.icon)} ${section.label}`
+            : section.label,
+          section.entries,
+        ),
+      )
+      .filter((section) => section !== null);
 
     const metaParts: Array<string | TemplateResult> = [
       presentation.timestamp,

--- a/packages/extension/src/webview/frontend/mainViewActions.ts
+++ b/packages/extension/src/webview/frontend/mainViewActions.ts
@@ -137,9 +137,11 @@ export function announce(message: string): void {
  * Validates that a selection exists in options.
  * Returns current value if found, otherwise falls back to first available option.
  */
-export function validateSelection<
-  T extends { value: string; disabled?: boolean },
->(options: T[], currentValue: string, preferEnabled = false): string {
+function validateSelection<T extends { value: string; disabled?: boolean }>(
+  options: T[],
+  currentValue: string,
+  preferEnabled: boolean,
+): string {
   const current = options.find((opt) => opt.value === currentValue);
   if (current && (!preferEnabled || !current.disabled)) {
     return currentValue;
@@ -202,16 +204,14 @@ export function updateCheckboxValue(id: string, checked: boolean): void {
 }
 
 export function removeFile(listId: keyof MultiFiles, file: string): void {
-  const files = (multiFiles$.get()[listId] ?? []).filter(
-    (f: string) => f !== file,
-  );
+  const files = multiFiles$.get()[listId].filter((f) => f !== file);
   updateMultiFiles(listId, files);
 }
 
 export function selectMultipleFiles(listId: keyof MultiFiles): void {
   // Hint the OS dialog with the head of the multi-list (the "primary"
   // file post-collapse) so it opens at the right folder.
-  const currentFile = (multiFiles$.get()[listId] ?? [])[0];
+  const currentFile = multiFiles$.get()[listId][0];
   postMessage(MAIN_VIEW_COMMANDS.SELECT_MULTIPLE_FILES, {
     fileType: MULTI_FILE_LIST_BY_KEY[listId].fileType,
     currentFile,

--- a/packages/extension/src/webview/frontend/sessionDefaults.ts
+++ b/packages/extension/src/webview/frontend/sessionDefaults.ts
@@ -2,7 +2,7 @@
 import type { CheckboxValues } from '@shared/schemas';
 import type { SessionType } from './constants';
 
-export interface SessionDefaults {
+interface SessionDefaults {
   fileInputEnabled: boolean;
   resetFiles: boolean;
   checkboxOverrides?: Partial<CheckboxValues>;

--- a/packages/extension/src/webview/frontend/slices/documentSlice.ts
+++ b/packages/extension/src/webview/frontend/slices/documentSlice.ts
@@ -152,8 +152,7 @@ export const documentHandlers = {
     // file to the multi-list head so it becomes the "primary" file.
     if (isDocumentFileType(fileType)) {
       const listId = MULTI_FILE_LISTS[fileType].key;
-      const mf = multiFiles$.get();
-      const existing = mf[listId] ?? [];
+      const existing = multiFiles$.get()[listId];
       const next = [filePath, ...existing.filter((f) => f !== filePath)];
       updateMultiFiles(listId, next);
       return;
@@ -197,8 +196,7 @@ export const documentHandlers = {
 
     const mf = multiFiles$.get();
     const filesToAdd = message.files ?? [];
-    const existing = mf[listId] ?? [];
-    const merged = unique([...existing, ...filesToAdd]);
+    const merged = unique([...mf[listId], ...filesToAdd]);
     multiFiles$.set({ ...mf, [listId]: merged });
     saveState();
   },

--- a/packages/extension/src/webview/managers/FileManager.ts
+++ b/packages/extension/src/webview/managers/FileManager.ts
@@ -44,10 +44,6 @@ type MessageFor<C extends MainViewInboundMessage['command']> = Extract<
   { command: C }
 >;
 
-type EditedFileSelectionMessage = MessageFor<
-  typeof MAIN_VIEW_COMMANDS.SELECT_EDITED_FILE
->;
-
 type EditedFileSelectedMessage = MessageFor<
   typeof MAIN_VIEW_COMMANDS.EDITED_FILE_SELECTED
 >;
@@ -104,9 +100,7 @@ const UPDATE_TO_SET_COMMAND = {
 export class FileManager extends BaseWebviewManager {
   protected readonly channel = CHANNEL;
 
-  async handleEditedFileSelection(
-    _message?: EditedFileSelectionMessage,
-  ): Promise<void> {
+  async handleEditedFileSelection(): Promise<void> {
     const editedFile = await vscode.commands.executeCommand<string>(
       FILE_SELECTION_COMMAND_IDS.selectEditedFile,
     );

--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -139,7 +139,7 @@ export interface ExtractedModelResponse {
   normalizedUsage: NormalizedUsage | undefined;
 }
 
-export type ExtractModelResponseOptions = {
+type ExtractModelResponseOptions = {
   /**
    * Ask the handler to normalize nullish provider usage. A handler may still
    * return undefined when its provider exposes no usage data.

--- a/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
+++ b/src/agent/core/flows/toolUseRound/ToolUseDispatchNode.ts
@@ -159,8 +159,7 @@ export class ToolUseDispatchNode<C> extends Node<
    * are never auto-retried (default maxRetries, exec never throws), and
    * cancellation runs through the batch abort controller, not `this.signal`.
    */
-  async _exec(items: unknown[]): Promise<unknown[]> {
-    const calls = Array.isArray(items) ? (items as SdkToolCall[]) : [];
+  async _exec(calls: SdkToolCall[]): Promise<(ToolExecutionResult | null)[]> {
     if (calls.length === 0) return [];
 
     const results: (ToolExecutionResult | null)[] = new Array<null>(
@@ -653,15 +652,12 @@ export class ToolUseDispatchNode<C> extends Node<
       }
     }
 
-    const extracted = allResults.map((er) => er.extracted);
-    const calls = allResults.map((er) => er.call);
-
     // For handlers that carry provider-side reasoning across multiple parallel
     // calls, batch all tool calls into a single message to preserve thought
     // signatures / reasoning_content.
     const { modelHandler } = this.services;
     const shouldBatch =
-      calls.length > 1 &&
+      allResults.length > 1 &&
       modelHandler.requiresBatchedParallelToolResults &&
       modelHandler.createBatchedToolUseFollowUpMessages !== undefined;
 
@@ -671,10 +667,10 @@ export class ToolUseDispatchNode<C> extends Node<
     if (shouldBatch && modelHandler.createBatchedToolUseFollowUpMessages) {
       const followUpMsgs =
         await modelHandler.createBatchedToolUseFollowUpMessages(
-          calls.map((call, index) => ({
-            call,
-            result: extracted[index].sanitizedResult,
-            attachments: extracted[index].attachments,
+          allResults.map((execResult) => ({
+            call: execResult.call,
+            result: execResult.extracted.sanitizedResult,
+            attachments: execResult.extracted.attachments,
           })),
           workspace,
           assistantText || undefined,
@@ -682,7 +678,7 @@ export class ToolUseDispatchNode<C> extends Node<
       shared.messages.push(...followUpMsgs);
     } else {
       for (const [index, execResult] of allResults.entries()) {
-        const { sanitizedResult, attachments } = extracted[index];
+        const { sanitizedResult, attachments } = execResult.extracted;
         const followUpMsgs = await modelHandler.createToolUseFollowUpMessages(
           this.services.client,
           execResult.call,

--- a/src/agent/export/chatExport/formatSpec.ts
+++ b/src/agent/export/chatExport/formatSpec.ts
@@ -27,13 +27,12 @@ export interface FormatSpec {
 }
 
 /** Metadata fields rendered in the document header. */
-export const HEADER_FIELDS: Array<{ key: keyof DocumentMeta; label: string }> =
-  [
-    { key: 'date', label: 'Date' },
-    { key: 'agent', label: 'Agent' },
-    { key: 'model', label: 'Model' },
-    { key: 'description', label: 'Summary' },
-  ];
+export const HEADER_FIELDS = [
+  { key: 'date', label: 'Date' },
+  { key: 'agent', label: 'Agent' },
+  { key: 'model', label: 'Model' },
+  { key: 'description', label: 'Summary' },
+] as const satisfies readonly { key: keyof DocumentMeta; label: string }[];
 
 function collectFiles(config: ExportConfig): Array<[string, string]> {
   const files: Array<[string, string]> = [];

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
@@ -10,11 +10,6 @@ import { hasDelegationTool } from '@shared/constants/delegationTools';
 import type { ToolUseServices } from '../ToolUseServices';
 import type { ToolUseRunShared, CyclePrepResult } from './types';
 
-interface PrepareExecResult {
-  kind: 'success';
-  result: CyclePrepResult;
-}
-
 /**
  * Session-init node: runs **once per tool-use session** to build the initial
  * message array or restore from a persisted snapshot.
@@ -27,7 +22,7 @@ export class ToolUsePrepareNode<C> extends Node<
   ToolUseRunShared,
   ToolUseServices<C>
 > {
-  async exec(_prepRes: void): Promise<PrepareExecResult> {
+  async exec(_prepRes: void): Promise<CyclePrepResult> {
     const {
       userVarChannels,
       logger,
@@ -71,24 +66,21 @@ export class ToolUsePrepareNode<C> extends Node<
         rebuiltPrompts.instructionSuffix,
       );
       return {
-        kind: 'success',
-        result: {
-          messages: resumeShared.messages,
-          runState: resumeShared.stateSlices.runStateSnapshot,
-          workspaceState: AgentWorkspaceState.fromSnapshot(
-            resumeShared.stateSlices.workspaceSnapshot,
-          ),
-          userChannels: {
-            input: Object.freeze({
-              ...resumeShared.stateSlices.userChannels.input,
-            }),
-            transient: {
-              ...resumeShared.stateSlices.userChannels.transient,
-            },
+        messages: resumeShared.messages,
+        runState: resumeShared.stateSlices.runStateSnapshot,
+        workspaceState: AgentWorkspaceState.fromSnapshot(
+          resumeShared.stateSlices.workspaceSnapshot,
+        ),
+        userChannels: {
+          input: Object.freeze({
+            ...resumeShared.stateSlices.userChannels.input,
+          }),
+          transient: {
+            ...resumeShared.stateSlices.userChannels.transient,
           },
-          shouldSkipCycle: true,
-          systemPrompt: systemMessage,
         },
+        shouldSkipCycle: true,
+        systemPrompt: systemMessage,
       };
     }
 
@@ -135,22 +127,19 @@ export class ToolUsePrepareNode<C> extends Node<
     }
 
     return {
-      kind: 'success',
-      result: {
-        messages,
-        runState,
-        workspaceState,
-        userChannels: userVarChannels,
-        shouldSkipCycle: false,
-        systemPrompt: systemMessage,
-      },
+      messages,
+      runState,
+      workspaceState,
+      userChannels: userVarChannels,
+      shouldSkipCycle: false,
+      systemPrompt: systemMessage,
     };
   }
 
   async post(
     shared: ToolUseRunShared,
     _prepRes: void,
-    execRes: PrepareExecResult,
+    execRes: CyclePrepResult,
   ): Promise<string | undefined> {
     const {
       messages,
@@ -159,7 +148,7 @@ export class ToolUsePrepareNode<C> extends Node<
       userChannels,
       shouldSkipCycle,
       systemPrompt,
-    } = execRes.result;
+    } = execRes;
     shared.messages = [...messages];
     shared.shouldSkipCycle = shouldSkipCycle;
     shared.systemPrompt = systemPrompt;

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -11,18 +11,15 @@ import type { FollowUpQueueBatchItem } from '@agent/followUp/FollowUpQueue';
 import { STREAM_PHASE } from '@shared/schemas';
 import { GoalStore, setGoalSessionBashAutoApproval } from '@tools/goal';
 
-import { findLastAssistantText, extractTouchedFiles } from './types';
+import { findLastAssistantText } from './types';
 import type { ToolUseServices } from '../ToolUseServices';
 import type { ToolUseRunShared, WaitExecResult } from './types';
 
 interface WaitPrepResult {
+  /** Latest assistant text, read only by the root-mode `onIdle` notification. */
   lastResponse: string | undefined;
-  touchedFiles: string[];
   /** True when entering after a failed/cancelled cycle. */
   afterError: boolean;
-  /** Run cost accumulated so far — carried on the WAITING turn facts so the
-   *  child-run loop can settle cost even for a suspended-then-abandoned turn. */
-  totalCostUsd?: number;
 }
 
 export class ToolUseWaitNode<C> extends Node<
@@ -34,22 +31,18 @@ export class ToolUseWaitNode<C> extends Node<
   }
 
   async prep(shared: ToolUseRunShared): Promise<WaitPrepResult> {
-    const { modelHandler, isSubagent, onIdle } = this.services;
+    const { modelHandler, onIdle } = this.services;
 
-    // Subagent mode needs these turn facts for every delivery (the loop's
-    // one delivery site). Root mode only needs `lastResponse`, and only when
-    // `onIdle` is wired (a host projecting the transcript before it blocks).
-    const wantsLastResponse = isSubagent === true || onIdle !== undefined;
+    // Only a wired `onIdle` reads the response text (a host projecting the
+    // transcript before the flow blocks). A suspended subagent turn's facts
+    // are read off the flow result by the child-run loop, not from here.
     return {
       afterError: !!(shared.lastError || shared.userCancelledRetry),
-      touchedFiles: isSubagent ? extractTouchedFiles(shared.stateSlices) : [],
-      lastResponse: wantsLastResponse
+      lastResponse: onIdle
         ? findLastAssistantText(shared.messages, (m) =>
             modelHandler.extractAssistantText(m),
           )
         : undefined,
-      totalCostUsd:
-        shared.stateSlices?.runStateSnapshot.usageAccumulator.totals.totalCost,
     };
   }
 
@@ -111,10 +104,9 @@ export class ToolUseWaitNode<C> extends Node<
     }
 
     // With no externally consumed batch, subagent mode always exits WAITING
-    // here, carrying this cycle's turn facts
-    // (lastResponse/touchedFiles/totalCostUsd). The child-run loop formats and
-    // delivers after suspension, then owns the next queue wait. This keeps
-    // every ordinary suspension symmetric and leaves one delivery site.
+    // here. The child-run loop formats and delivers this cycle's turn facts
+    // after suspension, then owns the next queue wait. This keeps every
+    // ordinary suspension symmetric and leaves one delivery site.
     if (isSubagent === true) {
       ownerSession.status.transitionToWaiting(streamId, 'wait', {
         trace: this.services.logger,

--- a/src/agent/index/AgentDirectoryService.ts
+++ b/src/agent/index/AgentDirectoryService.ts
@@ -47,16 +47,10 @@ export interface AgentDirectoryServiceOptions {
   absoluteDirectories: AbsoluteDirectoryAccess;
   issueReporter: AgentDirectoryIssueReporter;
   logger: AgentDirectoryServiceLogger;
-  defaultCustomDirectoryName?: string;
 }
 
 export class AgentDirectoryService {
-  private readonly defaultCustomDirectoryName: string;
-
-  constructor(private readonly options: AgentDirectoryServiceOptions) {
-    this.defaultCustomDirectoryName =
-      options.defaultCustomDirectoryName ?? CUSTOM_AGENTS_STORAGE_DIR;
-  }
+  constructor(private readonly options: AgentDirectoryServiceOptions) {}
 
   async builtIn(): Promise<string> {
     return this.ensureBuiltInDir(BUILTIN_WORKFLOW_AGENTS_DIR);
@@ -116,7 +110,7 @@ export class AgentDirectoryService {
 
   private async ensureDefaultCustomDir(): Promise<string> {
     try {
-      await this.options.storage.ensureDir(this.defaultCustomDirectoryName);
+      await this.options.storage.ensureDir(CUSTOM_AGENTS_STORAGE_DIR);
     } catch (error) {
       this.options.logger.error(
         'Failed to create default custom agents directory',
@@ -128,7 +122,7 @@ export class AgentDirectoryService {
     }
 
     const defaultPath = this.options.storage.fullPath(
-      this.defaultCustomDirectoryName,
+      CUSTOM_AGENTS_STORAGE_DIR,
     );
     this.options.logger.debug(
       `Using default custom agents directory: ${defaultPath}`,

--- a/src/agent/index/AgentDirectorySync.ts
+++ b/src/agent/index/AgentDirectorySync.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 
 import { isFileNotFoundError } from '@common/errors/errorPredicates';
 import { platform } from '@platform/platform';
+import { KeyedMutex } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 import { GlobalStorageFS } from '@utils/files/storageFS';
 
@@ -107,32 +108,15 @@ export class GlobalStorageAgentDirectoryStorage implements AgentDirectoryStorage
 }
 
 export class BundledAgentDirectorySync {
-  private static readonly reconcileByStorageRoot = new Map<
-    string,
-    Promise<boolean>
-  >();
+  private static readonly reconcileByStorageRoot = new KeyedMutex<string>();
 
   constructor(private readonly options: BundledAgentDirectorySyncOptions) {}
 
-  async reconcile(currentVersion: string | undefined): Promise<boolean> {
-    const storageRoot = this.options.storage.fullPath('');
-    const previous =
-      BundledAgentDirectorySync.reconcileByStorageRoot.get(storageRoot) ??
-      Promise.resolve(true);
-    const current = previous
-      .catch(() => true)
-      .then(() => this.reconcileUnlocked(currentVersion));
-    const tracked = current.finally(() => {
-      if (
-        BundledAgentDirectorySync.reconcileByStorageRoot.get(storageRoot) ===
-        tracked
-      ) {
-        BundledAgentDirectorySync.reconcileByStorageRoot.delete(storageRoot);
-      }
-    });
-    tracked.catch(() => undefined);
-    BundledAgentDirectorySync.reconcileByStorageRoot.set(storageRoot, tracked);
-    return current;
+  reconcile(currentVersion: string | undefined): Promise<boolean> {
+    return BundledAgentDirectorySync.reconcileByStorageRoot.runExclusive(
+      this.options.storage.fullPath(''),
+      () => this.reconcileUnlocked(currentVersion),
+    );
   }
 
   private async reconcileUnlocked(

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -54,7 +54,6 @@ import type {
 } from '@shared/schemas/toolResult';
 import { joinNonEmpty } from '@utils/text/stringUtils';
 import { getAnthropicDynamicFiltering } from '@utils/config/providerConfig';
-import { getConfig } from '@utils/config/configUtils';
 
 // Local file imports
 import {
@@ -64,7 +63,6 @@ import {
 } from './anthropicUsage';
 import {
   getAnthropicMaxPdfPages,
-  DEFAULT_COMPACTION_THRESHOLD_PERCENT,
   estimateTokensFromText,
 } from '../contextManagementConstants';
 import { AnthropicStreamHandler } from '../support/AnthropicStreamHandler';
@@ -773,10 +771,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
 
     // Set up context management before token counting so estimates use matching options.
-    const compactionThresholdPercent = getConfig<number>(
-      'texra.model.compactionThresholdPercent',
-      DEFAULT_COMPACTION_THRESHOLD_PERCENT,
-    );
+    const compactionThresholdPercent = this.getCompactionThresholdPercent();
     const pendingCompactionRequestId = this.getPendingCompactionRequestId();
     const compactionConsumed = setupContextManagement(
       {

--- a/src/agent/modelHandlers/google/googleHandlerShared.ts
+++ b/src/agent/modelHandlers/google/googleHandlerShared.ts
@@ -126,8 +126,8 @@ export async function uploadGoogleMediaEntries<T>(
   const failures: string[] = [];
 
   for (const entry of entries) {
-    const fileName = entry.file_name ?? 'unnamed-file';
-    const mimeType = entry.media_type ?? DEFAULT_ATTACHMENT_MIME_TYPE;
+    const fileName = entry.file_name;
+    const mimeType = entry.media_type;
     const inlinePayload = isNonEmptyString(entry.data) ? entry.data : null;
 
     if (inlinePayload) {

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -211,10 +211,8 @@ export class ModelHandlerOpenAI<
         // summarization system prompt. Apply provider-specific normalization
         // (e.g. DeepSeek's convertContentToString, mergeConsecutiveRoles) so
         // the compaction call doesn't get rejected.
-        const normalizedConversation = this.prepareNormalizedMessages(
-          conversationMessages,
-          this.getMessageNormalizationOptions(),
-        );
+        const normalizedConversation =
+          this.prepareNormalizedMessages(conversationMessages);
 
         const summaryParams = this.buildCompactionSummaryParams(
           normalizedConversation,
@@ -667,10 +665,7 @@ export class ModelHandlerOpenAI<
     const updatedMessages = didCompact ? compactedMessages : undefined;
 
     // Apply message normalization if subclass specifies options
-    const messages = this.prepareNormalizedMessages(
-      messagesToUse,
-      this.getMessageNormalizationOptions(),
-    );
+    const messages = this.prepareNormalizedMessages(messagesToUse);
 
     // Phase 1: BUILD - Construct provider-specific request parameters
     const useStreaming = this.getStreamingConfig();
@@ -719,16 +714,14 @@ export class ModelHandlerOpenAI<
   }
 
   /**
-   * Normalizes messages and logs diagnostics about any changes.
+   * Normalizes messages under {@link getMessageNormalizationOptions} and logs
+   * diagnostics about any changes.
    * @param messages Original message array passed to the handler.
-   * @param options Normalization options passed to the OpenAI utilities.
-   * @param providerLabel Label used to identify the provider in logs.
    */
-  protected prepareNormalizedMessages<T extends ChatCompletionMessageParam>(
+  private prepareNormalizedMessages<T extends ChatCompletionMessageParam>(
     messages: T[],
-    options?: NormalizeOpenAIMessageContentOptions,
-    providerLabel: string = this.config.provider,
   ): T[] {
+    const options = this.getMessageNormalizationOptions();
     const normalizedMessages = options
       ? normalizeOpenAIMessageContent(messages, options)
       : messages;
@@ -738,7 +731,7 @@ export class ModelHandlerOpenAI<
         data: {
           beforeCount: messages.length,
           afterCount: normalizedMessages.length,
-          providerLabel,
+          providerLabel: this.config.provider,
         },
       });
     }

--- a/src/agent/node/persistedFlow.ts
+++ b/src/agent/node/persistedFlow.ts
@@ -293,9 +293,9 @@ export class PersistedFlow<
     while (step.hasMore) {
       step = await this.stepWithResult();
     }
-    return (step.action ??
-      this.cachedRecord?.cursor?.lastAction ??
-      this.cachedRecord?.nodes.at(-1)?.action) as Action | undefined;
+    // The loop only exits on a suspension (which always carries an action) or
+    // on the terminal step, which already resolves the record's last action.
+    return step.action;
   }
 
   /**

--- a/src/agent/runtime/AgentLaunchContext.ts
+++ b/src/agent/runtime/AgentLaunchContext.ts
@@ -236,7 +236,7 @@ async function assembleAgentLaunchContext(
   input: AgentLaunchInput,
   executionId: ExecutionId,
   interactions: SessionHostInteractions,
-  reservedStreamId: StreamTabId | undefined,
+  streamId: StreamTabId,
   resources: AgentLaunchResources,
 ): Promise<AgentLaunchContext> {
   const fullConfig = input.config;
@@ -304,11 +304,6 @@ async function assembleAgentLaunchContext(
           session.responseTextProcessing,
         ),
   );
-
-  const streamId =
-    input.streamTabIdOverride ??
-    reservedStreamId ??
-    getStreamTabId(config.agent, fullConfig.model, { executionId });
 
   const transcriptWriter = await session.transcripts.loadAndAcquireWriter(
     streamId,
@@ -556,9 +551,12 @@ export async function buildAgentLaunchContext(
   if (!input.streamTabIdOverride && (!config.agent || !config.model)) {
     throw new AgentError('Missing required fields: model and/or agent');
   }
-  const reservedStreamId = input.streamTabIdOverride
-    ? undefined
-    : getStreamTabId(config.agent, config.model, { executionId });
+  // One derivation of this run's stream id: an override is used as-is, and
+  // otherwise the derived id is both the reservation and the run's identity.
+  const streamId =
+    input.streamTabIdOverride ??
+    getStreamTabId(config.agent, config.model, { executionId });
+  const reservedStreamId = input.streamTabIdOverride ? undefined : streamId;
   if (reservedStreamId) {
     acquireStreamOrThrow(reservedStreamId, streamStatus);
   }
@@ -569,7 +567,7 @@ export async function buildAgentLaunchContext(
       { ...input, session: launchSession },
       executionId,
       interactions,
-      reservedStreamId,
+      streamId,
       resources,
     );
     resources.transfer();

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -75,7 +75,6 @@ export interface LiveToolUseFlowContext {
 export class AgentExecutionHandle implements ExecutionHandle {
   readonly startedAt = Date.now();
   private _parentStreamId: StreamTabId;
-  private _deliveryTargetStreamId: StreamTabId | undefined;
   private interruptHandler?: ExecutionInterruptHandler;
   private toolUseFlowContext?: LiveToolUseFlowContext;
   private acceptsPendingInterrupt = false;
@@ -119,8 +118,6 @@ export class AgentExecutionHandle implements ExecutionHandle {
     readonly trace?: AgentTrace,
   ) {
     this._parentStreamId = parentStreamId;
-    this._deliveryTargetStreamId =
-      parentStreamId === childStreamId ? undefined : parentStreamId;
   }
 
   /** Settle {@link result} with the terminal outcome (idempotent). */
@@ -149,11 +146,17 @@ export class AgentExecutionHandle implements ExecutionHandle {
   }
 
   get isChildExecution(): boolean {
-    return this._deliveryTargetStreamId !== undefined;
+    return this._parentStreamId !== this.childStreamId;
   }
 
+  /**
+   * The parent this run's results route to, or `undefined` once the run is its
+   * own parent (a root run, or a subagent promoted by {@link detach}). Derived
+   * from `_parentStreamId` rather than mirrored into a second field, so detach
+   * has one write and the two views can never disagree.
+   */
   get deliveryTargetStreamId(): StreamTabId | undefined {
-    return this._deliveryTargetStreamId;
+    return this.isChildExecution ? this._parentStreamId : undefined;
   }
 
   /** Whether lifecycle startup must preserve an already-cancelled status. */
@@ -163,7 +166,6 @@ export class AgentExecutionHandle implements ExecutionHandle {
 
   /** Promote this subagent to a top-level execution (detach from parent). */
   detach(): void {
-    this._deliveryTargetStreamId = undefined;
     this._parentStreamId = this.childStreamId;
   }
 

--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -226,13 +226,17 @@ export class StreamStatusMachine {
   }
 
   entries(): IterableIterator<[StreamTabId, StreamPhase]> {
-    return this.getAll().entries();
+    const phases = new Map<StreamTabId, StreamPhase>();
+    for (const [stream, state] of this.getAllStreamStates()) {
+      phases.set(stream, state.phase);
+    }
+    return phases.entries();
   }
 
   /**
    * Combined per-stream phase + substate, merging in in-flight reservations
-   * exactly once. `getAll()` and `getAllSubstates()` are thin projections of
-   * this so the two views can never diverge on which streams they cover.
+   * exactly once. `entries()` is a thin phase-only projection of this, so the
+   * two views can never diverge on which streams they cover.
    */
   getAllStreamStates(): Map<StreamTabId, StreamPhaseState> {
     const values = new Map<StreamTabId, StreamPhaseState>();
@@ -244,24 +248,6 @@ export class StreamStatusMachine {
         phase: STREAM_PHASE.RUNNING,
         substate: STREAM_SUBSTATE.STARTING,
       });
-    }
-    return values;
-  }
-
-  getAll(): Map<StreamTabId, StreamPhase> {
-    const values = new Map<StreamTabId, StreamPhase>();
-    for (const [stream, state] of this.getAllStreamStates()) {
-      values.set(stream, state.phase);
-    }
-    return values;
-  }
-
-  getAllSubstates(): Map<StreamTabId, StreamSubstate> {
-    const values = new Map<StreamTabId, StreamSubstate>();
-    for (const [stream, state] of this.getAllStreamStates()) {
-      if (state.substate) {
-        values.set(stream, state.substate);
-      }
     }
     return values;
   }

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -140,8 +140,7 @@ export async function resumeQueuedToolUseFromResumeData(
       tools: options.tools,
       approvalPromptsUnavailable: options.approvalPromptsUnavailable,
       runtimeUnavailableTools: options.runtimeUnavailableTools,
-      parentStreamId:
-        options.parentStreamId ?? resume.parentStreamId ?? undefined,
+      parentStreamId: options.parentStreamId ?? resume.parentStreamId,
       workflowPhase: options.workflowPhase,
       onFollowUpConsumed: () => {
         followUps = [];

--- a/src/agent/runtime/runAgent.ts
+++ b/src/agent/runtime/runAgent.ts
@@ -9,7 +9,7 @@ import {
 } from '@agent/storage/executionLease';
 
 import type { ValidatedExecutionRequest } from '@agent/core/state/executionRequests';
-import { EXECUTION_STATUS, type ExecutionId } from '@shared/schemas';
+import { EXECUTION_STATUS } from '@shared/schemas';
 import { generateExecutionId } from '@utils/core';
 import { applyHelperModelPreference } from './helperModelPreference';
 import { executeAgent, type ExecuteAgentOptions } from './executeAgent';
@@ -83,8 +83,7 @@ export async function runAgent(
     ...executeAgentOptions
   } = options;
 
-  const executionId =
-    request.executionId ?? (generateExecutionId() as ExecutionId);
+  const executionId = request.executionId ?? generateExecutionId();
   const shouldRegister =
     registerExecutionOption ?? request.executionId === undefined;
   const runSession = executeAgentOptions.session ?? defaultSession();
@@ -106,9 +105,10 @@ export async function runAgent(
       config.agentCategory,
     );
   } else {
-    const lease = canAcquireResumeLease
-      ? await acquireResumedExecutionLease(executionId, canAcquireResumeLease)
-      : await acquireResumedExecutionLease(executionId);
+    const lease = await acquireResumedExecutionLease(
+      executionId,
+      canAcquireResumeLease,
+    );
     if (lease === 'cancelled') {
       throw new ResumeAdmissionCancelledError(executionId);
     }

--- a/src/agent/runtime/sessionDescription.ts
+++ b/src/agent/runtime/sessionDescription.ts
@@ -102,7 +102,7 @@ export async function generateSessionDescription(
     const agentEntry = getAgent(config.agent, AgentCategory.ToolUse);
     const agentDescription = agentEntry?.description;
 
-    const helperResult = await createHelperModelKit();
+    const helperResult = await createHelperModelKit(session);
     if (!helperResult.kit) {
       warnWithoutRejecting(helperResult.reason);
       return;

--- a/src/common/errors/sdkError/errorInspection.ts
+++ b/src/common/errors/sdkError/errorInspection.ts
@@ -8,10 +8,13 @@ import { pickStatus } from './sdkErrorKinds';
  *  body itself, then its nested `.error` (some SDKs preserve the full
  *  `{ error: {...} }` envelope, others unwrap it before it reaches us).
  *  Shared by every relay/ChatGPT-subscription/credit-depletion body detector,
- *  each of which must check both forms. Returns `[]` for a non-object body. */
-export function errorBodyCandidates(rawErrorBody: unknown): unknown[] {
+ *  each of which must check both forms. Only object candidates are returned,
+ *  so detectors read fields directly instead of re-guarding each element. */
+export function errorBodyCandidates(
+  rawErrorBody: unknown,
+): Record<string, unknown>[] {
   if (!isObject(rawErrorBody)) return [];
-  return [rawErrorBody, (rawErrorBody as { error?: unknown }).error];
+  return [rawErrorBody, rawErrorBody.error].filter(isObject);
 }
 
 /** Pick a non-blank string field off an error-body object. Shared by the

--- a/src/common/errors/sdkError/relayDetection.ts
+++ b/src/common/errors/sdkError/relayDetection.ts
@@ -1,5 +1,5 @@
 import { StatusCodes } from 'http-status-codes';
-import { isObject, isString } from '@utils/core';
+import { isString } from '@utils/core';
 
 import {
   errorBodyCandidates,
@@ -39,10 +39,10 @@ export function inferStatusCodeFromBody(
   rawErrorBody: unknown,
 ): number | undefined {
   // Nested-first, per the docstring above (reversed from errorBodyCandidates'
-  // direct-first default).
-  const candidates = [...errorBodyCandidates(rawErrorBody)].reverse();
+  // direct-first default). `errorBodyCandidates` returns a fresh array, so the
+  // in-place reverse touches nothing the caller holds.
+  const candidates = errorBodyCandidates(rawErrorBody).reverse();
   for (const candidate of candidates) {
-    if (!isObject(candidate)) continue;
     for (const field of ['type', 'code'] as const) {
       const value = candidate[field];
       if (!isString(value)) continue;
@@ -55,13 +55,13 @@ export function inferStatusCodeFromBody(
 
 export function isRelayError(rawErrorBody: unknown): boolean {
   return errorBodyCandidates(rawErrorBody).some(
-    (candidate) => isObject(candidate) && '_relay' in candidate,
+    (candidate) => '_relay' in candidate,
   );
 }
 
 function hasRelayBooleanFlag(rawErrorBody: unknown, field: string): boolean {
   return errorBodyCandidates(rawErrorBody).some(
-    (candidate) => isObject(candidate) && candidate[field] === true,
+    (candidate) => candidate[field] === true,
   );
 }
 

--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -294,9 +294,7 @@ export class ProgressFactApplier {
   }
 
   public handleInquiryThreadUpdated(thread: InquiryThreadUpdatedEvent): void {
-    if (this.webviewUpdater.isAvailable()) {
-      this.webviewUpdater.updateInquiryThread(thread);
-    }
+    this.webviewUpdater.updateInquiryThread(thread);
   }
 
   public handleUpdateStreamDescription({
@@ -304,9 +302,7 @@ export class ProgressFactApplier {
     description,
   }: UpdateStreamDescriptionPayload): void {
     this.state.setStreamDescription(streamId, description);
-    if (this.webviewUpdater.isAvailable()) {
-      this.webviewUpdater.updateStreamDescription(streamId, description);
-    }
+    this.webviewUpdater.updateStreamDescription(streamId, description);
   }
 
   public handleSetParentStream({
@@ -314,12 +310,10 @@ export class ProgressFactApplier {
     parentStreamId,
   }: SetParentStreamPayload): void {
     this.state.setStreamParent(childStreamId, parentStreamId);
-    if (this.webviewUpdater.isAvailable()) {
-      this.webviewUpdater.updateParentStream(
-        childStreamId,
-        parentStreamId ?? undefined,
-      );
-    }
+    this.webviewUpdater.updateParentStream(
+      childStreamId,
+      parentStreamId ?? undefined,
+    );
   }
 
   public handleAddOutputFiles({ streamId }: AddOutputFilesPayload): void {
@@ -385,9 +379,7 @@ export class ProgressFactApplier {
   }
 
   public handleUpdatePlan({ streamId, plan }: UpdatePlanPayload): void {
-    if (this.webviewUpdater.isAvailable()) {
-      this.webviewUpdater.updatePlan(streamId, plan);
-    }
+    this.webviewUpdater.updatePlan(streamId, plan);
   }
 
   public handleUpdateQueuedFollowUps({
@@ -573,12 +565,9 @@ export class ProgressFactApplier {
       roundStage,
     }));
 
-    if (
-      this.webviewUpdater.isAvailable() &&
-      this.state.activeStream === streamId
-    ) {
-      this.webviewUpdater.updateRoundStage(streamId, roundStage);
-    }
+    this.sendIfActive(streamId, () =>
+      this.webviewUpdater.updateRoundStage(streamId, roundStage),
+    );
   }
 
   /**

--- a/src/controllers/progressView/backend/state/ProgressViewState.ts
+++ b/src/controllers/progressView/backend/state/ProgressViewState.ts
@@ -21,7 +21,6 @@ import {
   LOG_LEVELS,
   MESSAGE_TYPES,
   STREAM_LOG_ENTRY_TYPES,
-  type RunOutcome,
   type ActiveChildInfo,
   type AgentCategoryFilter,
   type ConversationProgress,
@@ -468,24 +467,6 @@ export class ProgressViewState {
           : child,
       ),
     };
-  }
-
-  getAllStreamStates(): ReadonlyMap<StreamTabId, StreamExecutionState> {
-    return this._streamStates;
-  }
-
-  async endRunningTaskGroups(
-    now: number = Date.now(),
-    streamIds?: readonly StreamTabId[],
-    status?: RunOutcome,
-  ): Promise<StreamTabId[]> {
-    const affectedFromLogs = streamIds
-      ? await this.streamLogs.endRunningGroupsForStreams(streamIds, now, status)
-      : await this.streamLogs.endRunningGroups(now, [], status);
-    if (affectedFromLogs.length > 0) {
-      await this.streamLogs.save();
-    }
-    return affectedFromLogs;
   }
 
   // -- Lifecycle --------------------------------------------------------------

--- a/src/housekeeping/utils.ts
+++ b/src/housekeeping/utils.ts
@@ -39,7 +39,7 @@ function getFilePatterns(
   base: string,
   model: string,
   agent: string,
-  numRounds: number = 3,
+  numRounds: number,
 ): string[] {
   const patterns: string[] = [];
   const legacyModel = normalizeLegacyModel(model);

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -29,8 +29,6 @@ const LaTeXdiffResultSchema = z.object({
 });
 export type LaTeXdiffResult = z.infer<typeof LaTeXdiffResultSchema>;
 
-const CHANNEL = 'LaTeXCommands';
-
 function hasDocumentEnvironment(content: string): boolean {
   return (
     content.includes('\\begin{document}') && content.includes('\\end{document}')
@@ -41,7 +39,7 @@ export class LaTeXdiffService {
   private readonly fileProcessor: DiffFileProcessor;
   private readonly commandExecutor: DiffCommandExecutor;
 
-  constructor(private readonly channel: string = CHANNEL) {
+  constructor(private readonly channel: string) {
     this.fileProcessor = new DiffFileProcessor();
     // Pass a thunk so DiffCommandExecutor reads the current workspace value
     // each time it runs a diff. Module-scope instances (in latexdiffCommands.ts

--- a/src/latex/latexdiff/outputDiscovery.ts
+++ b/src/latex/latexdiff/outputDiscovery.ts
@@ -261,7 +261,7 @@ export async function discoverLatestExecutionOutputs(query: {
         query.inputFile,
         candidate.agentConfig.inputFiles.slice(1),
       );
-      if (scanned && Object.keys(scanned).length > 0) {
+      if (scanned) {
         return { executionId: candidate.id, rounds: scanned };
       }
     }

--- a/src/latex/texTools.ts
+++ b/src/latex/texTools.ts
@@ -46,7 +46,7 @@ async function readCompileLogTail(
 
 export function buildKpathseaSearchPath(
   prependPaths: readonly string[],
-  existingValue: string | undefined = undefined,
+  existingValue: string | undefined,
   delimiter: string = path.delimiter,
 ): string | undefined {
   const prefix = prependPaths

--- a/src/model/runModelDecision.ts
+++ b/src/model/runModelDecision.ts
@@ -32,7 +32,9 @@ export interface RunModelDecision {
   readonly model: string;
   readonly reason: RunModelDecisionReason;
   readonly unavailable?: true;
-  readonly fallbackFrom?: NormalizedRunModelCandidate & {
+  readonly fallbackFrom?: {
+    readonly model: string;
+    readonly reason: RunModelDecisionReason;
     readonly mode: RunModelFallbackMode;
   };
 }
@@ -76,7 +78,7 @@ export function decideRunModel(
     return {
       model: fallback.model,
       reason: fallback.reason,
-      fallbackFrom: { ...candidate, mode },
+      fallbackFrom: { model: candidate.model, reason: candidate.reason, mode },
     };
   }
 

--- a/src/shared/schemas/mainView/state.ts
+++ b/src/shared/schemas/mainView/state.ts
@@ -405,10 +405,7 @@ export type LaunchTargetChangeDetail = z.infer<
   typeof LaunchTargetChangeDetailSchema
 >;
 
-const TeamChangeDetailSchema = z.object({
-  value: z.string(),
-});
-export type TeamChangeDetail = z.infer<typeof TeamChangeDetailSchema>;
+export type TeamChangeDetail = StringValueDetail;
 
 const ActionDetailSchema = z.object({
   action: z.string(),

--- a/src/shared/sessionTitle.ts
+++ b/src/shared/sessionTitle.ts
@@ -9,7 +9,7 @@ const ACTIVITY_LABEL: Record<SessionTitleState, string | undefined> = {
 /** Format the product title shared by native windows and terminal tabs. */
 export function formatSessionTitle(
   project: string | undefined,
-  state: SessionTitleState = 'idle',
+  state: SessionTitleState,
 ): string {
   return ['TeXRA', ACTIVITY_LABEL[state], project]
     .filter((segment): segment is string => Boolean(segment))

--- a/src/shared/streams/taskGroupProjection.ts
+++ b/src/shared/streams/taskGroupProjection.ts
@@ -26,13 +26,13 @@ import {
  */
 function taskGroupEndStatus(
   value: TaskGroupStatus | EndGroupStatus | undefined,
-  fallback: TaskGroupStatus,
 ): TaskGroupStatus {
   const native = TaskGroupStatusSchema.safeParse(value);
   if (native.success) return native.data;
-  if (value === END_GROUP_STATUS.STOPPED) return STREAM_PHASE.COMPLETED;
   if (value === END_GROUP_STATUS.ERROR) return STREAM_PHASE.FAILED;
-  return fallback;
+  // Legacy `stopped`, an unrecognized value, and an absent one all read as a
+  // group that ended without a recorded failure.
+  return STREAM_PHASE.COMPLETED;
 }
 
 /**
@@ -115,7 +115,7 @@ export function upsertTaskGroupFromStreamLog(
     return true;
   }
 
-  const status = taskGroupEndStatus(payload.status, STREAM_PHASE.COMPLETED);
+  const status = taskGroupEndStatus(payload.status);
   const endTime = payload.endTime;
 
   if (groupIndex === -1) {

--- a/src/telemetry/UsageLogService.ts
+++ b/src/telemetry/UsageLogService.ts
@@ -150,7 +150,9 @@ class UsageLogServiceImpl {
   private retryBatch: UsageLogBatch | null = null;
   private flushTimer: NodeJS.Timeout | null = null;
   private activeFlush: Promise<UsageLogFlushOutcome> | null = null;
-  private config: UsageLogConfig = DEFAULT_CONFIG;
+  // Copied, never aliased: `dispose()` writes `config.enabled`, so a
+  // dispose-before-initialize would otherwise flip DEFAULT_CONFIG for good.
+  private config: UsageLogConfig = { ...DEFAULT_CONFIG };
   private extensionVersion: string | undefined;
   private editorType: string | undefined;
 

--- a/src/test-kernel/agent/AgentDirectorySync.vitest.ts
+++ b/src/test-kernel/agent/AgentDirectorySync.vitest.ts
@@ -25,9 +25,9 @@ import type { BundledAgentDirectoryName } from '@agent/index/BundledAgentDirecto
 function pendingReconcileCount(): number {
   return (
     BundledAgentDirectorySync as unknown as {
-      reconcileByStorageRoot: Map<string, Promise<boolean>>;
+      reconcileByStorageRoot: { mutexes: Map<string, unknown> };
     }
-  ).reconcileByStorageRoot.size;
+  ).reconcileByStorageRoot.mutexes.size;
 }
 
 class FsAgentDirectoryStorage implements AgentDirectoryStorage {

--- a/src/test-kernel/agent/followUp/ToolUsePrepareNodeTranscriptLog.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUsePrepareNodeTranscriptLog.vitest.ts
@@ -125,15 +125,15 @@ describe('ToolUsePrepareNode resume (prompt-cache preservation)', () => {
 
     const result = await node.exec(undefined);
 
-    expect(result.result.systemPrompt).toBe(
+    expect(result.systemPrompt).toBe(
       `${rebuiltPrompts.systemPrompt}\n${rebuiltPrompts.instructionSuffix}`,
     );
-    expect(result.result.messages).toBe(resumeShared.messages);
-    expect(result.result.messages[0]).toEqual({
+    expect(result.messages).toBe(resumeShared.messages);
+    expect(result.messages[0]).toEqual({
       role: 'system',
       content: [{ type: 'text', text: 'stale system' }],
     });
-    expect(result.result.shouldSkipCycle).toBe(true);
+    expect(result.shouldSkipCycle).toBe(true);
     // initializeMessages is the fresh-session path; resume must not call it.
     expect(services.modelHandler.initializeMessages).not.toHaveBeenCalled();
   });

--- a/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
@@ -103,7 +103,7 @@ function createWaitNodeServices(
 }
 
 function waitPrep(afterError = false) {
-  return { afterError, lastResponse: undefined, touchedFiles: [] };
+  return { afterError, lastResponse: undefined };
 }
 
 /**
@@ -147,11 +147,10 @@ describe('ToolUseWaitNode', () => {
     const node = new ToolUseWaitNode().setServices(services);
 
     const prep = await node.prep(shared);
-    // No in-flow delivery site anymore — the wait node only carries the turn
-    // facts on `prep`; the child-run loop formats and delivers after
-    // suspension (see childRunLoop.ts).
+    // No in-flow delivery site anymore — the child-run loop reads the turn
+    // facts off the flow result and delivers after suspension (see
+    // childRunLoop.ts), so the node itself carries none.
     expect(prep.lastResponse).toBeUndefined();
-    expect(prep.touchedFiles).toEqual([]);
 
     const transition = await withTestRunContext(
       interactions,

--- a/src/test-kernel/agent/followUp/ToolUseWaitNodeFollowUpTranscriptLog.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNodeFollowUpTranscriptLog.vitest.ts
@@ -41,7 +41,6 @@ function buildServices(
 // satisfies it (checked at each node.post() call site below).
 const PREP_RES = {
   lastResponse: undefined,
-  touchedFiles: [] as string[],
   afterError: false,
 };
 

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerAnthropic.vitest.ts
@@ -1171,6 +1171,24 @@ describe('ModelHandlerAnthropic model capabilities', () => {
   });
 });
 
+/**
+ * A logged, non-streaming handler pinned to a compaction-capable model with
+ * the compaction threshold at 0, the setup every forced-compaction test needs.
+ */
+function createForcedCompactionHandler(
+  agentCategory: AgentCategory = AgentCategory.Workflow,
+): ModelHandlerAnthropic {
+  const handler = createAnthropicHandler({
+    supportsTokenCounting: false,
+    supportsReasoning: false,
+  });
+  handler.config.fullName = 'claude-opus-4-6';
+  handler.setAgentCategory(agentCategory);
+  stubHandlerForTest(handler);
+  stubCompactionThresholdPercent(0);
+  return handler;
+}
+
 describe('ModelHandlerAnthropic forced compaction', () => {
   it('round-trips forced compaction state into the next workflow invocation', async () => {
     const handler = createAnthropicHandler({
@@ -1332,21 +1350,12 @@ describe('ModelHandlerAnthropic forced compaction', () => {
   });
 
   it('uses the Anthropic minimum trigger for manual compaction requests', async () => {
-    const handler = createAnthropicHandler({
-      supportsTokenCounting: false,
-      supportsReasoning: false,
-    });
-    handler.config.fullName = 'claude-opus-4-6';
-    handler.setAgentCategory(AgentCategory.ToolUse);
+    const handler = createForcedCompactionHandler(AgentCategory.ToolUse);
     handler.requestCompaction();
-
-    stubHandlerForTest(handler);
 
     const messages = helloMessages();
     const { client, messageOptions } =
       createCapturingAnthropicClient('claude-opus-4-6');
-
-    stubCompactionThresholdPercent(0);
 
     await handler.createResponse({ client, messages, temperature: 0 });
 
@@ -1368,15 +1377,8 @@ describe('ModelHandlerAnthropic forced compaction', () => {
   });
 
   it('preserves forced compaction across a transient request retry', async () => {
-    const handler = createAnthropicHandler({
-      supportsTokenCounting: false,
-      supportsReasoning: false,
-    });
-    handler.config.fullName = 'claude-opus-4-6';
-    handler.setAgentCategory(AgentCategory.Workflow);
+    const handler = createForcedCompactionHandler();
     handler.requestCompaction();
-    stubHandlerForTest(handler);
-    stubCompactionThresholdPercent(0);
 
     const messageOptions: any[] = [];
     const create = vi.fn(async (options: any) => {
@@ -1409,14 +1411,7 @@ describe('ModelHandlerAnthropic forced compaction', () => {
   });
 
   it('preserves a newer compaction request when an older request succeeds', async () => {
-    const handler = createAnthropicHandler({
-      supportsTokenCounting: false,
-      supportsReasoning: false,
-    });
-    handler.config.fullName = 'claude-opus-4-6';
-    handler.setAgentCategory(AgentCategory.Workflow);
-    stubHandlerForTest(handler);
-    stubCompactionThresholdPercent(0);
+    const handler = createForcedCompactionHandler();
 
     const messageOptions: any[] = [];
     let resolveFirstResponse: ((response: any) => void) | undefined;
@@ -1458,14 +1453,7 @@ describe('ModelHandlerAnthropic forced compaction', () => {
   });
 
   it('does not leak an abandoned forced compaction into a later call', async () => {
-    const handler = createAnthropicHandler({
-      supportsTokenCounting: false,
-      supportsReasoning: false,
-    });
-    handler.config.fullName = 'claude-opus-4-6';
-    handler.setAgentCategory(AgentCategory.Workflow);
-    stubHandlerForTest(handler);
-    stubCompactionThresholdPercent(0);
+    const handler = createForcedCompactionHandler();
 
     const abandonedRequestId = handler.requestCompaction();
     handler.clearCompactionRequest(abandonedRequestId);
@@ -1482,14 +1470,7 @@ describe('ModelHandlerAnthropic forced compaction', () => {
   });
 
   it('does not let an older recovery clear a newer compaction request', async () => {
-    const handler = createAnthropicHandler({
-      supportsTokenCounting: false,
-      supportsReasoning: false,
-    });
-    handler.config.fullName = 'claude-opus-4-6';
-    handler.setAgentCategory(AgentCategory.Workflow);
-    stubHandlerForTest(handler);
-    stubCompactionThresholdPercent(0);
+    const handler = createForcedCompactionHandler();
 
     const abandonedRequestId = handler.requestCompaction();
     handler.requestCompaction();

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
@@ -208,6 +208,36 @@ function withSdkOptions<T extends { responses: object }>(client: T) {
   });
 }
 
+/**
+ * A client whose pre-flight token count answers `inputTokensPerCall` (keyed by
+ * the 1-based call index) and whose `responses.create` records every request,
+ * answering each with a sequentially numbered completed response.
+ */
+function createPreflightCountingClient(
+  inputTokensPerCall: (call: number) => number,
+) {
+  const requests: any[] = [];
+  const tokenCounts: number[] = [];
+  const client = withSdkOptions({
+    responses: {
+      inputTokens: {
+        count: async () => {
+          const inputTokens = inputTokensPerCall(tokenCounts.length + 1);
+          tokenCounts.push(inputTokens);
+          return { input_tokens: inputTokens };
+        },
+      },
+      create: async (params: any) => {
+        requests.push(params);
+        return createResponse(`resp-${requests.length}`, {
+          input_tokens: 100000,
+        });
+      },
+    },
+  });
+  return { client, requests, tokenCounts };
+}
+
 function createBackgroundAbortHandler(): ModelHandlerOpenAIResponse {
   const handler = new ModelHandlerOpenAIResponse(
     buildTestModelConfig({
@@ -1117,27 +1147,12 @@ describe('ModelHandlerOpenAIResponse.createResponse', () => {
     const compactCalls = stubCompactionToLastMessage(handler, {
       tokensAfter: 1000,
     });
-    const requests: any[] = [];
-    let tokenCountCalls = 0;
-    const client = withSdkOptions({
-      responses: {
-        inputTokens: {
-          count: async () => {
-            tokenCountCalls += 1;
-            // Turn 2's live count lands between the 75% threshold (150k) and
-            // the 200k window: the stale cumulative from turn 1 (100k) would
-            // never have triggered, but the live count must.
-            return { input_tokens: tokenCountCalls === 2 ? 180000 : 1000 };
-          },
-        },
-        create: async (params: any) => {
-          requests.push(params);
-          return createResponse(`resp-${requests.length}`, {
-            input_tokens: 100000,
-          });
-        },
-      },
-    });
+    // Turn 2's live count lands between the 75% threshold (150k) and the 200k
+    // window: the stale cumulative from turn 1 (100k) would never have
+    // triggered, but the live count must.
+    const { client, requests, tokenCounts } = createPreflightCountingClient(
+      (call) => (call === 2 ? 180000 : 1000),
+    );
 
     await handler.createResponse({
       client: client as any,
@@ -1155,7 +1170,7 @@ describe('ModelHandlerOpenAIResponse.createResponse', () => {
     assert.equal(result.response.id, 'resp-2');
     assert.equal(requests.length, 2);
     assert.equal(compactCalls.length, 1);
-    assert.equal(tokenCountCalls, 3);
+    assert.equal(tokenCounts.length, 3);
     assert.deepEqual(requests[1].input, secondTurn.slice(-1));
   });
 
@@ -1165,27 +1180,12 @@ describe('ModelHandlerOpenAIResponse.createResponse', () => {
       contextWindow: 200000,
     });
     const compactCalls = stubCompactionToLastMessage(handler);
-    const requests: any[] = [];
-    let tokenCountCalls = 0;
-    const client = withSdkOptions({
-      responses: {
-        inputTokens: {
-          count: async () => {
-            tokenCountCalls += 1;
-            // Turn 2's pre-flight count overflows the 200k window (the count
-            // includes server-side chained history); the internal retry after
-            // dropping the chain and compacting fits again.
-            return { input_tokens: tokenCountCalls === 2 ? 300000 : 1000 };
-          },
-        },
-        create: async (params: any) => {
-          requests.push(params);
-          return createResponse(`resp-${requests.length}`, {
-            input_tokens: 100000,
-          });
-        },
-      },
-    });
+    // Turn 2's pre-flight count overflows the 200k window (the count includes
+    // server-side chained history); the internal retry after dropping the
+    // chain and compacting fits again.
+    const { client, requests, tokenCounts } = createPreflightCountingClient(
+      (call) => (call === 2 ? 300000 : 1000),
+    );
 
     await handler.createResponse({
       client: client as any,
@@ -1207,7 +1207,7 @@ describe('ModelHandlerOpenAIResponse.createResponse', () => {
     assert.equal(requests.length, 2);
     assert.equal(requests[1].previous_response_id, undefined);
     assert.equal(compactCalls.length, 1);
-    assert.equal(tokenCountCalls, 3);
+    assert.equal(tokenCounts.length, 3);
     assert.deepEqual(requests[1].input, secondTurn.slice(-1));
   });
 
@@ -1223,24 +1223,9 @@ describe('ModelHandlerOpenAIResponse.createResponse', () => {
     const compactCalls = stubCompactionToLastMessage(handler, {
       tokensAfter: 1000,
     });
-    const requests: any[] = [];
-    let tokenCountCalls = 0;
-    const client = withSdkOptions({
-      responses: {
-        inputTokens: {
-          count: async () => {
-            tokenCountCalls += 1;
-            return { input_tokens: tokenCountCalls === 2 ? 300000 : 1000 };
-          },
-        },
-        create: async (params: any) => {
-          requests.push(params);
-          return createResponse(`resp-${requests.length}`, {
-            input_tokens: 100000,
-          });
-        },
-      },
-    });
+    const { client, requests } = createPreflightCountingClient((call) =>
+      call === 2 ? 300000 : 1000,
+    );
 
     await handler.createResponse({
       client: client as any,

--- a/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ToolConversion.vitest.ts
@@ -43,6 +43,17 @@ type ToolDescriptionCase = {
   readonly nestedFields?: readonly DescriptionPath[];
 };
 
+/** A plain JSON-schema function tool, the baseline shape every provider gets. */
+const READ_FILE_DEF: ToolDefinition = {
+  name: 'read_file',
+  description: 'Read a file',
+  parameters: {
+    type: 'object',
+    properties: { path: { type: 'string' } },
+    required: ['path'],
+  },
+};
+
 function propertySchema(
   schema: JsonSchemaWithProperties | undefined,
   field: string,
@@ -544,15 +555,7 @@ describe('toOpenAIResponseTools', () => {
 
   it('filters out function tools when supportsFunctionCalling is false', () => {
     const defs: ToolDefinition[] = [
-      {
-        name: 'read_file',
-        description: 'Read a file',
-        parameters: {
-          type: 'object',
-          properties: { path: { type: 'string' } },
-          required: ['path'],
-        },
-      },
+      READ_FILE_DEF,
       {
         name: 'write_file',
         description: 'Write a file',
@@ -582,17 +585,7 @@ describe('toGoogleTools', () => {
   it.each([
     {
       label: 'converts function declarations to single tool object',
-      defs: [
-        {
-          name: 'read_file',
-          description: 'Read a file',
-          parameters: {
-            type: 'object',
-            properties: { path: { type: 'string' } },
-            required: ['path'],
-          },
-        },
-      ],
+      defs: [READ_FILE_DEF],
       names: ['read_file'],
     },
     {
@@ -605,15 +598,7 @@ describe('toGoogleTools', () => {
       label: 'converts all tools to function declarations',
       defs: [
         { name: 'web_search', description: 'Search the web' },
-        {
-          name: 'read_file',
-          description: 'Read a file',
-          parameters: {
-            type: 'object',
-            properties: { path: { type: 'string' } },
-            required: ['path'],
-          },
-        },
+        READ_FILE_DEF,
         {
           name: 'write_file',
           description: 'Write a file',

--- a/src/test-kernel/agent/runtime/RunAgentOwnership.vitest.ts
+++ b/src/test-kernel/agent/runtime/RunAgentOwnership.vitest.ts
@@ -91,6 +91,7 @@ describe('runAgent execution ownership', () => {
     expect(mocks.registerExecution).not.toHaveBeenCalled();
     expect(mocks.acquireResumedExecutionLease).toHaveBeenCalledWith(
       EXECUTION_ID,
+      undefined,
     );
     expect(mocks.completeOwnedExecutionLease).toHaveBeenCalledWith(
       EXECUTION_ID,

--- a/src/test-kernel/agent/runtime/StreamStatusService.vitest.ts
+++ b/src/test-kernel/agent/runtime/StreamStatusService.vitest.ts
@@ -106,9 +106,10 @@ describe('StreamStatusMachine', () => {
     expect(machine.tryAcquire(streamId)).toBe(true);
     expect(machine.get(streamId)).toBe(STREAM_PHASE.RUNNING);
     expect(machine.getSubstate(streamId)).toBe(STREAM_SUBSTATE.STARTING);
-    expect(machine.getAllSubstates().get(streamId)).toBe(
-      STREAM_SUBSTATE.STARTING,
-    );
+    expect(machine.getAllStreamStates().get(streamId)).toEqual({
+      phase: STREAM_PHASE.RUNNING,
+      substate: STREAM_SUBSTATE.STARTING,
+    });
     expect(machine.tryAcquire(streamId)).toBe(false);
 
     machine.releaseIfReserved(streamId);

--- a/src/test-kernel/cli/ChildListInteraction.vitest.mts
+++ b/src/test-kernel/cli/ChildListInteraction.vitest.mts
@@ -1,3 +1,5 @@
+import { setTimeout as sleep } from 'node:timers/promises';
+
 import { describe, expect, it, vi } from 'vitest';
 
 import { SubagentList } from '@cli/chat/tui/panes/SubagentList';
@@ -238,7 +240,7 @@ describe('CLI child list interaction', () => {
     try {
       await waitFor(() => stdin.listenerCount('readable') > 0);
       for (const input of ['v', 'k', 's', 'r', '\r']) stdin.write(input);
-      await new Promise((resolve) => setTimeout(resolve, 30));
+      await sleep(30);
 
       for (const callback of Object.values(callbacks)) {
         expect(callback).not.toHaveBeenCalled();
@@ -297,7 +299,7 @@ describe('CLI child list interaction', () => {
       await waitFor(() => stdin.listenerCount('readable') > 0);
       stdin.write('[A');
       // No state change to await for a no-op; give the event loop a turn.
-      await new Promise((resolve) => setTimeout(resolve, 30));
+      await sleep(30);
 
       expect(onCancel).not.toHaveBeenCalled();
       expect(onSelectionChange).not.toHaveBeenCalled();

--- a/src/test-kernel/cli/CliSupabaseAuth.vitest.mts
+++ b/src/test-kernel/cli/CliSupabaseAuth.vitest.mts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 
 import { GlobalStateKey } from '@shared/state/stateKeys';
 
@@ -106,6 +106,39 @@ async function loadSupabaseAuth() {
   return import('@cli/runtime/supabaseAuth');
 }
 
+/** The device authorization every device-code path replays. */
+const DEVICE_AUTHORIZATION = Object.freeze({
+  device_code: 'device-code',
+  expires_in: 600,
+  interval: 5,
+  user_code: 'ABCD-EFGH',
+  verification_uri: 'https://auth.example/device',
+});
+
+interface FakeCallbackServer {
+  readonly close: Mock<() => Promise<void>>;
+  readonly redirectTo: string;
+  readonly waitForSession: Mock<(signal?: AbortSignal) => Promise<unknown>>;
+}
+
+/** Arm the browser sign-in transport and hand back its loopback server. */
+function stubBrowserSignIn(
+  waitForSession: (signal?: AbortSignal) => Promise<unknown>,
+): FakeCallbackServer {
+  const callbackServer: FakeCallbackServer = {
+    close: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    redirectTo: 'http://127.0.0.1:0/callback',
+    waitForSession:
+      vi.fn<(signal?: AbortSignal) => Promise<unknown>>(waitForSession),
+  };
+  mocks.startLoopbackCallbackServer.mockResolvedValue(callbackServer);
+  mocks.signInWithOAuth.mockResolvedValue({
+    data: { url: 'https://auth.example/login' },
+    error: null,
+  });
+  return callbackServer;
+}
+
 describe('CLI Supabase auth', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -148,16 +181,7 @@ describe('CLI Supabase auth', () => {
 
   it('clears OpenRouter routing after browser sign-in enables included access', async () => {
     const session = { access_token: 'token' };
-    const callbackServer = {
-      close: vi.fn().mockResolvedValue(undefined),
-      redirectTo: 'http://127.0.0.1:0/callback',
-      waitForSession: vi.fn().mockResolvedValue(session),
-    };
-    mocks.startLoopbackCallbackServer.mockResolvedValue(callbackServer);
-    mocks.signInWithOAuth.mockResolvedValue({
-      data: { url: 'https://auth.example/login' },
-      error: null,
-    });
+    stubBrowserSignIn(async () => session);
     const { signInCliSupabase } = await loadSupabaseAuth();
 
     await expect(signInCliSupabase({ openBrowser: false })).resolves.toBe(
@@ -172,13 +196,7 @@ describe('CLI Supabase auth', () => {
 
   it('clears OpenRouter routing after device-code sign-in enables included access', async () => {
     const session = { access_token: 'device-token' };
-    mocks.requestDeviceAuthorization.mockResolvedValue({
-      device_code: 'device-code',
-      expires_in: 600,
-      interval: 5,
-      user_code: 'ABCD-EFGH',
-      verification_uri: 'https://auth.example/device',
-    });
+    mocks.requestDeviceAuthorization.mockResolvedValue(DEVICE_AUTHORIZATION);
     mocks.pollForDeviceSession.mockResolvedValue(session);
     const { signInCliSupabaseDeviceCode } = await loadSupabaseAuth();
 
@@ -192,13 +210,7 @@ describe('CLI Supabase auth', () => {
 
   it('does not store a device session when cancellation follows polling', async () => {
     const controller = new AbortController();
-    mocks.requestDeviceAuthorization.mockResolvedValue({
-      device_code: 'device-code',
-      expires_in: 600,
-      interval: 5,
-      user_code: 'ABCD-EFGH',
-      verification_uri: 'https://auth.example/device',
-    });
+    mocks.requestDeviceAuthorization.mockResolvedValue(DEVICE_AUTHORIZATION);
     mocks.pollForDeviceSession.mockImplementation(async () => {
       controller.abort();
       return { access_token: 'device-token' };
@@ -215,24 +227,8 @@ describe('CLI Supabase auth', () => {
   it('forwards interactive cancellation to both TeXRA transports', async () => {
     const controller = new AbortController();
     const session = { access_token: 'token' };
-    const callbackServer = {
-      close: vi.fn().mockResolvedValue(undefined),
-      redirectTo: 'http://127.0.0.1:0/callback',
-      waitForSession: vi.fn().mockResolvedValue(session),
-    };
-    const authorization = {
-      device_code: 'device-code',
-      expires_in: 600,
-      interval: 5,
-      user_code: 'ABCD-EFGH',
-      verification_uri: 'https://auth.example/device',
-    };
-    mocks.startLoopbackCallbackServer.mockResolvedValue(callbackServer);
-    mocks.signInWithOAuth.mockResolvedValue({
-      data: { url: 'https://auth.example/login' },
-      error: null,
-    });
-    mocks.requestDeviceAuthorization.mockResolvedValue(authorization);
+    const callbackServer = stubBrowserSignIn(async () => session);
+    mocks.requestDeviceAuthorization.mockResolvedValue(DEVICE_AUTHORIZATION);
     mocks.pollForDeviceSession.mockResolvedValue(session);
     const { signInCliSupabase, signInCliSupabaseDeviceCode } =
       await loadSupabaseAuth();
@@ -249,30 +245,22 @@ describe('CLI Supabase auth', () => {
     expect(mocks.requestDeviceAuthorization).toHaveBeenCalledWith({
       signal: controller.signal,
     });
-    expect(mocks.pollForDeviceSession).toHaveBeenCalledWith(authorization, {
-      signal: controller.signal,
-    });
+    expect(mocks.pollForDeviceSession).toHaveBeenCalledWith(
+      DEVICE_AUTHORIZATION,
+      { signal: controller.signal },
+    );
   });
 
   it('settles browser sign-in cancellation while its launcher remains pending', async () => {
     const controller = new AbortController();
-    const callbackServer = {
-      close: vi.fn().mockResolvedValue(undefined),
-      redirectTo: 'http://127.0.0.1:0/callback',
-      waitForSession: vi.fn(
-        (signal: AbortSignal | undefined) =>
-          new Promise((_resolve, reject) => {
-            signal?.addEventListener('abort', () => reject(signal.reason), {
-              once: true,
-            });
-          }),
-      ),
-    };
-    mocks.startLoopbackCallbackServer.mockResolvedValue(callbackServer);
-    mocks.signInWithOAuth.mockResolvedValue({
-      data: { url: 'https://auth.example/login' },
-      error: null,
-    });
+    const callbackServer = stubBrowserSignIn(
+      (signal) =>
+        new Promise((_resolve, reject) => {
+          signal?.addEventListener('abort', () => reject(signal.reason), {
+            once: true,
+          });
+        }),
+    );
     mocks.openBrowser.mockReturnValue(new Promise(() => {}));
     const { signInCliSupabase } = await loadSupabaseAuth();
     const completion = signInCliSupabase({ signal: controller.signal });
@@ -292,16 +280,7 @@ describe('CLI Supabase auth', () => {
   it('keeps a completed callback successful if the browser launcher later fails', async () => {
     let failBrowserLaunch!: (error: Error) => void;
     const session = { access_token: 'token' };
-    const callbackServer = {
-      close: vi.fn().mockResolvedValue(undefined),
-      redirectTo: 'http://127.0.0.1:0/callback',
-      waitForSession: vi.fn().mockResolvedValue(session),
-    };
-    mocks.startLoopbackCallbackServer.mockResolvedValue(callbackServer);
-    mocks.signInWithOAuth.mockResolvedValue({
-      data: { url: 'https://auth.example/login' },
-      error: null,
-    });
+    const callbackServer = stubBrowserSignIn(async () => session);
     mocks.openBrowser.mockReturnValue(
       new Promise((_resolve, reject) => {
         failBrowserLaunch = reject;

--- a/src/test-kernel/cli/MultiAgentPresets.vitest.mts
+++ b/src/test-kernel/cli/MultiAgentPresets.vitest.mts
@@ -21,6 +21,7 @@ import {
   cliMultiAgentPresetTeamLaunchBlockReason,
   planCliMultiAgentPresets,
   planCliMultiAgentPresetRun,
+  type CliMultiAgentPresetRunPlan,
 } from '@cli/runtime/multiAgentPresets';
 
 function agent(
@@ -58,6 +59,24 @@ function toolUseTeam(preset: TeamPreset, root: string): AgentEntry[] {
   return preset.toolUseAgents.map((name) =>
     agent(name, AgentCategory.ToolUse, name === root ? ['delegate_agent'] : []),
   );
+}
+
+// The lean-project team with two of its seven members and no delegating root.
+function partialLeanProjectPlan(): CliMultiAgentPresetRunPlan {
+  return planRun(findPreset('lean-project'), {
+    toolUseAgents: [
+      agent('lean', AgentCategory.ToolUse),
+      agent('latexFixer', AgentCategory.ToolUse),
+    ],
+  });
+}
+
+// The physicist team reduced to its delegating root plus one member.
+function degradedPhysicistToolUse(): AgentEntry[] {
+  return [
+    agent('orchestrator', AgentCategory.ToolUse, ['delegate_agent']),
+    agent('review', AgentCategory.ToolUse),
+  ];
 }
 
 describe('CLI multi-agent presets', () => {
@@ -116,13 +135,7 @@ describe('CLI multi-agent presets', () => {
   });
 
   it('lists missing preset members as unavailable when no team can launch', () => {
-    const preset = findPreset('lean-project');
-    const plan = planRun(preset, {
-      toolUseAgents: [
-        agent('lean', AgentCategory.ToolUse),
-        agent('latexFixer', AgentCategory.ToolUse),
-      ],
-    });
+    const plan = partialLeanProjectPlan();
 
     const output = formatCliMultiAgentPresetList([plan]);
 
@@ -137,13 +150,7 @@ describe('CLI multi-agent presets', () => {
   });
 
   it('omits the login recovery hint after a remote agent load was attempted', () => {
-    const preset = findPreset('lean-project');
-    const plan = planRun(preset, {
-      toolUseAgents: [
-        agent('lean', AgentCategory.ToolUse),
-        agent('latexFixer', AgentCategory.ToolUse),
-      ],
-    });
+    const plan = partialLeanProjectPlan();
 
     const output = formatCliMultiAgentPresetList([plan], {
       includeLoginHint: false,
@@ -154,13 +161,7 @@ describe('CLI multi-agent presets', () => {
   });
 
   it('marks missing team roots as unavailable', () => {
-    const preset = findPreset('lean-project');
-    const plan = planRun(preset, {
-      toolUseAgents: [
-        agent('lean', AgentCategory.ToolUse),
-        agent('latexFixer', AgentCategory.ToolUse),
-      ],
-    });
+    const plan = partialLeanProjectPlan();
 
     expect(plan.rootAgent).toBeUndefined();
     expect(cliMultiAgentPresetAvailability(plan).status).toBe('unavailable');
@@ -171,12 +172,8 @@ describe('CLI multi-agent presets', () => {
   });
 
   it('keeps degraded presets launchable when they still have delegation', () => {
-    const preset = findPreset('physicist');
-    const plan = planRun(preset, {
-      toolUseAgents: [
-        agent('orchestrator', AgentCategory.ToolUse, ['delegate_agent']),
-        agent('review', AgentCategory.ToolUse),
-      ],
+    const plan = planRun(findPreset('physicist'), {
+      toolUseAgents: degradedPhysicistToolUse(),
     });
 
     expect(cliMultiAgentPresetAvailability(plan).status).toBe('degraded');
@@ -184,13 +181,9 @@ describe('CLI multi-agent presets', () => {
   });
 
   it('formats compact launcher summaries from planned availability', () => {
-    const preset = findPreset('physicist');
-    const plan = planRun(preset, {
+    const plan = planRun(findPreset('physicist'), {
       workflowAgents: [agent('correct', AgentCategory.Workflow)],
-      toolUseAgents: [
-        agent('orchestrator', AgentCategory.ToolUse, ['delegate_agent']),
-        agent('review', AgentCategory.ToolUse),
-      ],
+      toolUseAgents: degradedPhysicistToolUse(),
     });
 
     expect(formatCliMultiAgentPresetLauncherSummary(plan)).toBe(
@@ -203,12 +196,8 @@ describe('CLI multi-agent presets', () => {
   });
 
   it('formats run warnings from planned missing team members', () => {
-    const preset = findPreset('physicist');
-    const plan = planRun(preset, {
-      toolUseAgents: [
-        agent('orchestrator', AgentCategory.ToolUse, ['delegate_agent']),
-        agent('review', AgentCategory.ToolUse),
-      ],
+    const plan = planRun(findPreset('physicist'), {
+      toolUseAgents: degradedPhysicistToolUse(),
     });
 
     expect(formatCliMultiAgentPresetRunWarnings(plan)).toEqual([
@@ -361,13 +350,7 @@ describe('CLI multi-agent presets', () => {
 
   it('serializes planned availability for machine-readable list output', () => {
     const preset = findPreset('lean-project');
-    const plan = planRun(preset, {
-      toolUseAgents: [
-        agent('lean', AgentCategory.ToolUse),
-        agent('latexFixer', AgentCategory.ToolUse),
-      ],
-    });
-    const record = cliMultiAgentPresetListRecord(plan);
+    const record = cliMultiAgentPresetListRecord(partialLeanProjectPlan());
 
     expect(record.id).toBe('lean-project');
     expect(record.toolUseAgents).toEqual(preset.toolUseAgents);

--- a/src/test-kernel/cli/Orchestration.vitest.mts
+++ b/src/test-kernel/cli/Orchestration.vitest.mts
@@ -145,6 +145,23 @@ const ORCHESTRATION_TEST_HEADER_LINES = [
   'Start a session or configure model access.',
 ] as const;
 
+type LauncherLayoutInput = Parameters<typeof orchestrationLauncherLayout>[0];
+
+/** Lay out the seven-item launcher under the test header, so each case only
+ *  states the row budget and the status/footer text it is about. */
+function launcherLayout(
+  overrides: Partial<LauncherLayoutInput> & { readonly rows: number },
+): ReturnType<typeof orchestrationLauncherLayout> {
+  return orchestrationLauncherLayout({
+    columns: 80,
+    itemCount: 7,
+    headerLines: ORCHESTRATION_TEST_HEADER_LINES,
+    statusLines: [],
+    footerHints: [],
+    ...overrides,
+  });
+}
+
 describe('CLI orchestration items', () => {
   it('returns from model selection to the agent or team picker that opened it', () => {
     const action = { kind: 'chat' as const, agent: 'assistant' };
@@ -189,12 +206,8 @@ describe('CLI orchestration items', () => {
   });
 
   it('keeps compact launcher orientation before advisory footer text', () => {
-    const layout = orchestrationLauncherLayout({
+    const layout = launcherLayout({
       rows: 10,
-      columns: 80,
-      itemCount: 7,
-      headerLines: ORCHESTRATION_TEST_HEADER_LINES,
-      statusLines: [],
       footerHints: [
         'Team setup: run `texra multi-agent show <team-id>` using the team id shown in each row.',
         'Researcher Access sign-in may unlock more remote team agents.',
@@ -215,14 +228,7 @@ describe('CLI orchestration items', () => {
       'Team setup: run `texra multi-agent show <team-id>` using the team id shown in each row.',
     ];
 
-    const layout = orchestrationLauncherLayout({
-      rows: 13,
-      columns: 80,
-      itemCount: 7,
-      headerLines: ORCHESTRATION_TEST_HEADER_LINES,
-      statusLines,
-      footerHints,
-    });
+    const layout = launcherLayout({ rows: 13, statusLines, footerHints });
 
     expect(layout).toEqual({
       statusLines,
@@ -233,14 +239,7 @@ describe('CLI orchestration items', () => {
   });
 
   it('budgets wrapped launcher header rows before growing the list', () => {
-    const layout = orchestrationLauncherLayout({
-      rows: 12,
-      columns: 30,
-      itemCount: 7,
-      headerLines: ORCHESTRATION_TEST_HEADER_LINES,
-      statusLines: [],
-      footerHints: [],
-    });
+    const layout = launcherLayout({ rows: 12, columns: 30 });
 
     expect(layout).toEqual({
       statusLines: [],
@@ -257,14 +256,7 @@ describe('CLI orchestration items', () => {
       'actions: `texra login` unlocks included models',
     ];
 
-    const layout = orchestrationLauncherLayout({
-      rows: 14,
-      columns: 80,
-      itemCount: 7,
-      headerLines: ORCHESTRATION_TEST_HEADER_LINES,
-      statusLines,
-      footerHints: [],
-    });
+    const layout = launcherLayout({ rows: 14, statusLines });
 
     expect(layout).toEqual({
       statusLines: statusLines.slice(0, 2),
@@ -280,14 +272,7 @@ describe('CLI orchestration items', () => {
       'auth: signed in as researcher@example.com · tier: Ultra · included usage this month: 25% used, 75% remaining',
     ];
 
-    const layout = orchestrationLauncherLayout({
-      rows: 14,
-      columns: 80,
-      itemCount: 7,
-      headerLines: ORCHESTRATION_TEST_HEADER_LINES,
-      statusLines,
-      footerHints: [],
-    });
+    const layout = launcherLayout({ rows: 14, statusLines });
 
     expect(layout).toEqual({
       statusLines: [
@@ -307,14 +292,7 @@ describe('CLI orchestration items', () => {
     ];
     const footerHints = ['Team settings are available from the launcher.'];
 
-    const layout = orchestrationLauncherLayout({
-      rows: 16,
-      columns: 80,
-      itemCount: 7,
-      headerLines: ORCHESTRATION_TEST_HEADER_LINES,
-      statusLines,
-      footerHints,
-    });
+    const layout = launcherLayout({ rows: 16, statusLines, footerHints });
 
     expect(layout.statusLines).toEqual([
       'api: included TeXRA access',
@@ -330,14 +308,7 @@ describe('CLI orchestration items', () => {
       'auth: signed in as researcher@example.com · tier: Ultra · included usage this month: 25% used, 75% remaining',
     ];
 
-    const layout = orchestrationLauncherLayout({
-      rows: 16,
-      columns: 40,
-      itemCount: 7,
-      headerLines: ORCHESTRATION_TEST_HEADER_LINES,
-      statusLines,
-      footerHints: [],
-    });
+    const layout = launcherLayout({ rows: 16, columns: 40, statusLines });
 
     expect(layout.statusLines).toEqual([
       'api: personal API keys',
@@ -347,14 +318,7 @@ describe('CLI orchestration items', () => {
   });
 
   it('keeps visible choices instead of overflow-only output on tiny row budgets', () => {
-    const layout = orchestrationLauncherLayout({
-      rows: 7,
-      columns: 80,
-      itemCount: 7,
-      headerLines: ORCHESTRATION_TEST_HEADER_LINES,
-      statusLines: [],
-      footerHints: [],
-    });
+    const layout = launcherLayout({ rows: 7 });
 
     expect(layout).toEqual({
       statusLines: [],

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -176,6 +176,15 @@ function handleRunConfig(
   renderer?.handleSessionEvent(runConfigEvent(overrides));
 }
 
+/** Input-less root run the heartbeat and live-line cases below all start from. */
+function handleOrchestratorRootRun(renderer: TestRunProgressRenderer): void {
+  handleRunConfig(renderer, {
+    streamId: 'root-stream',
+    agent: 'orchestrator',
+    inputFiles: [],
+  });
+}
+
 function handleRoundStage(
   renderer: TestRunProgressRenderer,
   streamId: string,
@@ -333,6 +342,13 @@ async function captureStreamWrites(
   }
 
   return output;
+}
+
+function ndjsonRecords(output: string): Record<string, unknown>[] {
+  return output
+    .trim()
+    .split('\n')
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
 }
 
 function decodeStreamChunk(
@@ -525,11 +541,7 @@ describe('CLI run progress renderer', () => {
     const timers = fakeTimers();
     const renderer = ansiRenderer(output, { nowMs: () => now, ...timers });
 
-    handleRunConfig(renderer, {
-      streamId: 'root-stream',
-      agent: 'orchestrator',
-      inputFiles: [],
-    });
+    handleOrchestratorRootRun(renderer);
     now = 950;
     handleActiveSubagents(renderer, 'root-stream', [subagentChild()]);
 
@@ -555,11 +567,7 @@ describe('CLI run progress renderer', () => {
     const timers = fakeTimers();
     const renderer = ansiRenderer(output, timers);
 
-    handleRunConfig(renderer, {
-      streamId: 'root-stream',
-      agent: 'orchestrator',
-      inputFiles: [],
-    });
+    handleOrchestratorRootRun(renderer);
     handleActiveSubagents(renderer, 'root-stream', [subagentChild()]);
 
     renderer?.preserve();
@@ -611,11 +619,7 @@ describe('CLI run progress renderer', () => {
       nowMs: () => now,
     });
 
-    handleRunConfig(renderer, {
-      streamId: 'root-stream',
-      agent: 'orchestrator',
-      inputFiles: [],
-    });
+    handleOrchestratorRootRun(renderer);
     handleActiveSubagents(renderer, 'root-stream', [subagentChild()]);
     now = 11000;
     handleStreamStatus(renderer, 'root-stream', STREAM_PHASE.COMPLETED);
@@ -645,11 +649,7 @@ describe('CLI run progress renderer', () => {
     const output = outputBuffer();
     const renderer = plainRenderer(output, { minIntervalMs: 0 });
 
-    handleRunConfig(renderer, {
-      streamId: 'root-stream',
-      agent: 'orchestrator',
-      inputFiles: [],
-    });
+    handleOrchestratorRootRun(renderer);
     handleStreamStatus(renderer, 'root-stream', STREAM_PHASE.CANCELLED);
 
     expect(output.text).toBe(
@@ -661,11 +661,7 @@ describe('CLI run progress renderer', () => {
     const output = outputBuffer();
     const renderer = plainRenderer(output, { minIntervalMs: 0 });
 
-    handleRunConfig(renderer, {
-      streamId: 'root-stream',
-      agent: 'orchestrator',
-      inputFiles: [],
-    });
+    handleOrchestratorRootRun(renderer);
     handleStreamStatus(renderer, 'root-stream', STREAM_PHASE.FAILED);
     // Post-terminal activity must not un-freeze the renderer (STREAM_PHASE.FAILED
     // must be recognized as a terminal outcome phase, same as COMPLETED/CANCELLED).
@@ -898,10 +894,7 @@ describe('CLI run progress renderer', () => {
       detach();
     });
 
-    const records = output
-      .trim()
-      .split('\n')
-      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    const records = ndjsonRecords(output);
 
     expect(records).toEqual([
       expect.objectContaining({
@@ -948,10 +941,7 @@ describe('CLI run progress renderer', () => {
       await host.close();
     });
 
-    const records = output
-      .trim()
-      .split('\n')
-      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    const records = ndjsonRecords(output);
 
     expect(records).toEqual([
       expect.objectContaining({
@@ -990,10 +980,7 @@ describe('CLI run progress renderer', () => {
       await host.close();
     });
 
-    const records = output
-      .trim()
-      .split('\n')
-      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    const records = ndjsonRecords(output);
 
     const expectedRecords = Object.values(
       RUNTIME_PRESENTATION_NDJSON_CASES,

--- a/src/test-kernel/cli/SlashRegistry.vitest.mts
+++ b/src/test-kernel/cli/SlashRegistry.vitest.mts
@@ -92,6 +92,17 @@ describe('slashRegistry', () => {
     return command;
   }
 
+  /** Open a registered slash command's form and render its adapter node. */
+  function openSlashForm<TProps>(name: string): {
+    readonly props?: TProps;
+    readonly isClosed: () => boolean;
+  } {
+    expect(openRegisteredCliSlashForm(requireSlashCommand(name), '')).toBe(
+      true,
+    );
+    return renderOpenForm<TProps>();
+  }
+
   function renderOpenForm<TProps>(): {
     readonly props?: TProps;
     readonly isClosed: () => boolean;
@@ -194,12 +205,9 @@ describe('slashRegistry', () => {
   it('chains selectable agent picks into the API-mode-aware model picker', async () => {
     resetCliState(INCLUDED_CHAT_SESSION);
     registerBuiltinSlashCommands();
-    const agent = requireSlashCommand('agent');
-    expect(openRegisteredCliSlashForm(agent, '')).toBe(true);
-
-    const agentNode = renderOpenForm<{
+    const agentNode = openSlashForm<{
       onSelect?: (value: string) => void;
-    }>();
+    }>('agent');
     agentNode.props?.onSelect?.('review');
     await settleFormSelection();
 
@@ -221,12 +229,9 @@ describe('slashRegistry', () => {
     registerBuiltinSlashCommands({
       canSelectModel: () => false,
     });
-    const agent = requireSlashCommand('agent');
-    expect(openRegisteredCliSlashForm(agent, '')).toBe(true);
-
-    const agentNode = renderOpenForm<{
+    const agentNode = openSlashForm<{
       onSelect?: (value: string) => void;
-    }>();
+    }>('agent');
     agentNode.props?.onSelect?.('review');
     await settleFormSelection();
 
@@ -241,12 +246,9 @@ describe('slashRegistry', () => {
       canSelectAgent: () => false,
       canSelectModel: () => true,
     });
-    const agent = requireSlashCommand('agent');
-    expect(openRegisteredCliSlashForm(agent, '')).toBe(true);
-
-    const agentNode = renderOpenForm<{
+    const agentNode = openSlashForm<{
       selectable?: boolean;
-    }>();
+    }>('agent');
 
     expect(agentNode.props).toMatchObject({ selectable: false });
     expect(activeForm.get()?.commandName).toBe('agent');
@@ -258,13 +260,10 @@ describe('slashRegistry', () => {
       canSelectAgent: () => false,
       canSelectModel: () => true,
     });
-    const model = requireSlashCommand('model');
-    expect(openRegisteredCliSlashForm(model, '')).toBe(true);
-
-    const modelNode = renderOpenForm<{
+    const modelNode = openSlashForm<{
       onSelect?: (value: string) => void;
       selectable?: boolean;
-    }>();
+    }>('model');
     modelNode.props?.onSelect?.('gpt55');
 
     expect(modelNode.props).toMatchObject({ selectable: true });
@@ -294,12 +293,9 @@ describe('slashRegistry', () => {
           ? 'different conversation format; start new chat'
           : undefined,
     });
-    const model = requireSlashCommand('model');
-    expect(openRegisteredCliSlashForm(model, '')).toBe(true);
-
-    const modelNode = renderOpenForm<{
+    const modelNode = openSlashForm<{
       getModelSwitchDisabledReason?: (model: string) => string | undefined;
-    }>();
+    }>('model');
 
     expect(modelNode.props?.getModelSwitchDisabledReason?.('sonnet46T')).toBe(
       'different conversation format; start new chat',
@@ -314,12 +310,9 @@ describe('slashRegistry', () => {
     registerBuiltinSlashCommands({
       onModelSelect: () => selection.promise,
     });
-    const model = requireSlashCommand('model');
-    expect(openRegisteredCliSlashForm(model, '')).toBe(true);
-
-    const modelNode = renderOpenForm<{
+    const modelNode = openSlashForm<{
       onSelect?: (value: string) => void;
-    }>();
+    }>('model');
     modelNode.props?.onSelect?.('gpt55');
     await settleFormSelection();
 
@@ -379,12 +372,9 @@ describe('slashRegistry', () => {
         errors.push(toErrorMessage(error));
       },
     });
-    const model = requireSlashCommand('model');
-    expect(openRegisteredCliSlashForm(model, '')).toBe(true);
-
-    const modelNode = renderOpenForm<{
+    const modelNode = openSlashForm<{
       onSelect?: (value: string) => void;
-    }>();
+    }>('model');
     modelNode.props?.onSelect?.('gpt55');
     await settleFormSelection();
 
@@ -403,12 +393,9 @@ describe('slashRegistry', () => {
         errors.push(toErrorMessage(error));
       },
     });
-    const api = requireSlashCommand('api');
-    expect(openRegisteredCliSlashForm(api, '')).toBe(true);
-
-    const apiNode = renderOpenForm<{
+    const apiNode = openSlashForm<{
       onSelect?: (value: CliModelAccessSelection) => void;
-    }>();
+    }>('api');
     apiNode.props?.onSelect?.(cliApiFallbackSelection('personal'));
     await settleFormSelection();
 
@@ -422,12 +409,9 @@ describe('slashRegistry', () => {
     registerBuiltinSlashCommands({
       onModelAccessSelect: () => selection.promise,
     });
-    const api = requireSlashCommand('api');
-    expect(openRegisteredCliSlashForm(api, '')).toBe(true);
-
-    const apiNode = renderOpenForm<{
+    const apiNode = openSlashForm<{
       onSelect?: (value: CliModelAccessSelection) => void;
-    }>();
+    }>('api');
     apiNode.props?.onSelect?.(cliApiFallbackSelection('personal'));
     await settleFormSelection();
 
@@ -506,12 +490,10 @@ describe('slashRegistry', () => {
         });
       },
     });
-    const login = requireSlashCommand('login');
 
-    expect(openRegisteredCliSlashForm(login, '')).toBe(true);
-    const loginNode = renderOpenForm<{
+    const loginNode = openSlashForm<{
       onSelect?: (value: string) => void;
-    }>();
+    }>('login');
     loginNode.props?.onSelect?.('chatgpt');
     await settleFormSelection();
 
@@ -534,12 +516,10 @@ describe('slashRegistry', () => {
         output.writeProgress(instruction, { copyable: true });
       },
     });
-    const login = requireSlashCommand('login');
 
-    expect(openRegisteredCliSlashForm(login, '')).toBe(true);
-    const loginNode = renderOpenForm<{
+    const loginNode = openSlashForm<{
       onSelect?: (value: string) => void;
-    }>();
+    }>('login');
     loginNode.props?.onSelect?.('chatgpt');
     await waitFor(() => formProgress.get()?.status === 'succeeded');
     expect(formProgress.get()?.archiveCopyable).toBeTypeOf('function');
@@ -590,12 +570,10 @@ describe('slashRegistry', () => {
         return selection.promise;
       },
     });
-    const login = requireSlashCommand('login');
 
-    expect(openRegisteredCliSlashForm(login, '')).toBe(true);
-    const loginNode = renderOpenForm<{
+    const loginNode = openSlashForm<{
       onSelect?: (value: string) => void;
-    }>();
+    }>('login');
     loginNode.props?.onSelect?.('chatgpt');
     formProgress.get()?.cancel();
 
@@ -621,12 +599,10 @@ describe('slashRegistry', () => {
         errors.push(toErrorMessage(error));
       },
     });
-    const login = requireSlashCommand('login');
 
-    expect(openRegisteredCliSlashForm(login, '')).toBe(true);
-    const loginNode = renderOpenForm<{
+    const loginNode = openSlashForm<{
       onSelect?: (value: string) => void;
-    }>();
+    }>('login');
     loginNode.props?.onSelect?.('chatgpt');
     await settleFormSelection();
 
@@ -650,12 +626,10 @@ describe('slashRegistry', () => {
         outcomes.push('action settled');
       },
     });
-    const api = requireSlashCommand('api');
 
-    expect(openRegisteredCliSlashForm(api, '')).toBe(true);
-    const apiNode = renderOpenForm<{
+    const apiNode = openSlashForm<{
       onSelect?: (value: CliModelAccessSelection) => void;
-    }>();
+    }>('api');
     apiNode.props?.onSelect?.(cliApiFallbackSelection('personal'));
     resetCliState(INCLUDED_CHAT_SESSION);
     selection.resolve();
@@ -678,12 +652,10 @@ describe('slashRegistry', () => {
     registerBuiltinSlashCommands({
       onLogoutSelect: () => completion,
     });
-    const logout = requireSlashCommand('logout');
 
-    expect(openRegisteredCliSlashForm(logout, '')).toBe(true);
-    const logoutNode = renderOpenForm<{
+    const logoutNode = openSlashForm<{
       onSelect?: (value: 'all') => void;
-    }>();
+    }>('logout');
     logoutNode.props?.onSelect?.('all');
     formProgress.get()?.cancel();
 

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -70,11 +70,11 @@ function workflowAgentSlice(
     todos: [],
     plan: null,
     bypass: { bash: false, toolEdit: false, superYolo: false },
+    outputFilesByRound: {},
+    missingOutputsByRound: {},
+    compileFailuresByRound: {},
+    taskGroups: [],
     ...overrides,
-    outputFilesByRound: overrides.outputFilesByRound ?? {},
-    missingOutputsByRound: overrides.missingOutputsByRound ?? {},
-    compileFailuresByRound: overrides.compileFailuresByRound ?? {},
-    taskGroups: overrides.taskGroups ?? [],
   };
 }
 

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
@@ -132,20 +132,13 @@ function tui(presentationHost = host()): {
       }),
   };
   const detachInteractions = defaultSession().useHostInteractions(interactions);
-  let disposed = false;
-  const dispose = () => {
-    if (disposed) return;
-    disposed = true;
-    detachInteractions();
-    interactions.dispose?.();
-  };
-  onTestFinished(dispose);
+  onTestFinished(detachInteractions);
   return {
     presentationHost,
     cliContext,
     interactions,
     prepareRetry,
-    dispose,
+    dispose: detachInteractions,
   };
 }
 
@@ -154,17 +147,29 @@ function relayRetry(params: {
   provider?: string;
   message?: string;
 }): RetryPermission {
+  const message = params.message ?? 'Relay monthly limit reached.';
   return {
     streamId: params.streamId,
     operation: 'model request',
-    errorMessage: params.message ?? 'Relay monthly limit reached.',
+    errorMessage: message,
     errorDetails: {
-      message: params.message ?? 'Relay monthly limit reached.',
+      message,
       exhaustionReason: 'relay-limit',
       isRelayError: true,
       ...(params.provider ? { provider: params.provider } : {}),
     },
   } as RetryPermission;
+}
+
+/** Relay retry on the shared `same-stream` route the route-replacement cases
+ *  below queue two requests against. */
+function requestSameStreamRetry(
+  interactions: HostInteractions,
+  message: string,
+): ReturnType<NonNullable<HostInteractions['requestRetry']>> {
+  return interactions.requestRetry?.(
+    relayRetry({ streamId: 'same-stream', provider: 'openai', message }),
+  );
 }
 
 function chatGptSubscriptionRetry(streamId: string): RetryPermission {
@@ -1121,20 +1126,8 @@ describe('TUI retry approvals', () => {
       .mockResolvedValueOnce(false);
 
     const { interactions } = tui();
-    void interactions.requestRetry?.(
-      relayRetry({
-        streamId: 'same-stream',
-        provider: 'openai',
-        message: 'first retry',
-      }),
-    );
-    void interactions.requestRetry?.(
-      relayRetry({
-        streamId: 'same-stream',
-        provider: 'openai',
-        message: 'second retry',
-      }),
-    );
+    void requestSameStreamRetry(interactions, 'first retry');
+    void requestSameStreamRetry(interactions, 'second retry');
 
     await waitForApproval('retry', { errorMessage: 'second retry' });
 
@@ -1151,22 +1144,10 @@ describe('TUI retry approvals', () => {
       .mockResolvedValueOnce(true);
 
     const { interactions } = tui();
-    void interactions.requestRetry?.(
-      relayRetry({
-        streamId: 'same-stream',
-        provider: 'openai',
-        message: 'first retry',
-      }),
-    );
+    void requestSameStreamRetry(interactions, 'first retry');
     await waitForApproval('retry', { errorMessage: 'first retry' });
 
-    const second = interactions.requestRetry?.(
-      relayRetry({
-        streamId: 'same-stream',
-        provider: 'openai',
-        message: 'second retry',
-      }),
-    );
+    const second = requestSameStreamRetry(interactions, 'second retry');
 
     await vi.waitFor(() => {
       expect(currentApproval.get()).toBeUndefined();
@@ -1181,22 +1162,10 @@ describe('TUI retry approvals', () => {
     mocks.hasUsableApiKey.mockResolvedValue(false);
 
     const { interactions } = tui();
-    void interactions.requestRetry?.(
-      relayRetry({
-        streamId: 'same-stream',
-        provider: 'openai',
-        message: 'first retry',
-      }),
-    );
+    void requestSameStreamRetry(interactions, 'first retry');
     await waitForApproval('retry', { errorMessage: 'first retry' });
 
-    void interactions.requestRetry?.(
-      relayRetry({
-        streamId: 'same-stream',
-        provider: 'openai',
-        message: 'second retry',
-      }),
-    );
+    void requestSameStreamRetry(interactions, 'second retry');
 
     await waitForApproval('retry', { errorMessage: 'second retry' });
   });
@@ -1214,24 +1183,12 @@ describe('TUI retry approvals', () => {
       });
 
     const { interactions, prepareRetry } = tui();
-    void interactions.requestRetry?.(
-      relayRetry({
-        streamId: 'same-stream',
-        provider: 'openai',
-        message: 'first retry',
-      }),
-    );
+    void requestSameStreamRetry(interactions, 'first retry');
     await vi.waitFor(() => {
       expect(mocks.setCliApiMode).toHaveBeenCalledTimes(1);
     });
 
-    const second = interactions.requestRetry?.(
-      relayRetry({
-        streamId: 'same-stream',
-        provider: 'openai',
-        message: 'second retry',
-      }),
-    );
+    const second = requestSameStreamRetry(interactions, 'second retry');
     await Promise.resolve();
     await vi.waitFor(() =>
       expect(mocks.setCliApiMode).toHaveBeenCalledTimes(2),

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -138,6 +138,14 @@ function entryTexts(streamId: StreamTabId): string[] {
   return streamEntries(streamId).map((entry) => entry.text);
 }
 
+/** Run trace bound to the default session's transcript store, which the
+ *  `CLI transcript state` suite clears before every test. */
+function runTrace(
+  streamId: StreamTabId,
+): ReturnType<typeof createRunTrace>['trace'] {
+  return createRunTrace(streamId, defaultSession().transcripts).trace;
+}
+
 /** Run `body` with a TUI run-fact subscription attached to a fresh hub. */
 function withRunFacts(
   body: (hub: SessionEventHub) => void,
@@ -1432,7 +1440,7 @@ describe('CLI transcript state', () => {
   });
 
   it('renders typed loaded images once and excludes ordinary file lists', () => {
-    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    const logger = runTrace(root);
     logger.domain({
       key: 'filesLoaded',
       data: {
@@ -1503,7 +1511,7 @@ describe('CLI transcript state', () => {
   });
 
   it('summarizes subagent protocol continuations in the visible transcript', () => {
-    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    const logger = runTrace(root);
     logger.info('Please solve the problem.', {
       messageType: MESSAGE_TYPES.USER_MESSAGE,
     });
@@ -1522,7 +1530,7 @@ describe('CLI transcript state', () => {
   });
 
   it('summarizes embedded subagent progress blocks in assistant transcript text', () => {
-    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    const logger = runTrace(root);
     logger.info(
       [
         'Waiting for the child.',
@@ -1548,7 +1556,7 @@ describe('CLI transcript state', () => {
   });
 
   it('normalizes common HTML before assistant text reaches the live transcript', () => {
-    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    const logger = runTrace(root);
     logger.info(
       '<h3>Verification Report</h3>The proof is <b>fully verified</b>.',
       { messageType: MESSAGE_TYPES.MODEL_RESPONSE },
@@ -1566,7 +1574,7 @@ describe('CLI transcript state', () => {
   });
 
   it('bounds long subagent result responses in the visible transcript', () => {
-    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    const logger = runTrace(root);
     const response = Array.from(
       { length: 20 },
       (_, index) => `proof line ${index + 1}`,
@@ -1597,7 +1605,7 @@ describe('CLI transcript state', () => {
   });
 
   it('mirrors error log entries into the transcript', () => {
-    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    const logger = runTrace(root);
     logger.error('Model request failed', {
       messageType: MESSAGE_TYPES.ERROR,
     });
@@ -1614,7 +1622,7 @@ describe('CLI transcript state', () => {
   });
 
   it('shows the canonical safe reason below a model-request failure', () => {
-    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    const logger = runTrace(root);
     logger.error('Model request failed (no retry available)', {
       messageType: MESSAGE_TYPES.ERROR,
       data: {
@@ -1645,7 +1653,7 @@ describe('CLI transcript state', () => {
   });
 
   it('keeps the error summary when structured error data is malformed', () => {
-    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    const logger = runTrace(root);
     logger.error('Model request failed', {
       messageType: MESSAGE_TYPES.ERROR,
       data: {
@@ -1662,7 +1670,7 @@ describe('CLI transcript state', () => {
   });
 
   it('removes terminal control sequences from model-error reasons', () => {
-    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    const logger = runTrace(root);
     logger.error('Model request failed', {
       messageType: MESSAGE_TYPES.ERROR,
       data: {
@@ -1682,7 +1690,7 @@ describe('CLI transcript state', () => {
   });
 
   it('redacts credentials embedded in the canonical provider message', () => {
-    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    const logger = runTrace(root);
     const secret = 'sk-provider-redaction-example-1234567890abcdef';
     const ansiSplitSecret = `${secret.slice(0, 12)}\u001b[31m${secret.slice(12)}\u001b[0m`;
     logger.error(`Model request failed with Bearer ${ansiSplitSecret}`, {
@@ -1703,7 +1711,7 @@ describe('CLI transcript state', () => {
   });
 
   it('collapses and bounds long multiline model-error reasons', () => {
-    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    const logger = runTrace(root);
     logger.error('Model request failed', {
       messageType: MESSAGE_TYPES.ERROR,
       data: {
@@ -1722,7 +1730,7 @@ describe('CLI transcript state', () => {
   });
 
   it('adds the personal-API hint once from structured relay-limit data', () => {
-    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    const logger = runTrace(root);
     logger.error('Model request failed', {
       messageType: MESSAGE_TYPES.ERROR,
       data: {
@@ -1742,7 +1750,7 @@ describe('CLI transcript state', () => {
   });
 
   it('keeps actual tool failures on the tool-row renderer', () => {
-    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    const logger = runTrace(root);
     logger.error('Actual tool failed', {
       messageType: MESSAGE_TYPES.TOOL_USE,
       data: {
@@ -1771,7 +1779,7 @@ describe('CLI transcript state', () => {
   });
 
   it('tracks hidden thinking activity without rendering thinking text', () => {
-    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    const logger = runTrace(root);
     const thinking = logger.openStream(MESSAGE_TYPES.THINKING);
 
     // Opening the stream alone marks the phase — hidden reasoning (e.g.
@@ -1814,7 +1822,7 @@ describe('CLI transcript state', () => {
       ...slice,
       category: AgentCategory.Workflow,
     }));
-    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    const logger = runTrace(root);
     const thinking = logger.openStream(MESSAGE_TYPES.THINKING);
     thinking.append('private workflow reasoning');
     logger.info('raw workflow model response', {
@@ -1890,7 +1898,7 @@ describe('CLI transcript state', () => {
       ...slice,
       category: AgentCategory.Workflow,
     }));
-    const logger = createRunTrace(child1, defaultSession().transcripts).trace;
+    const logger = runTrace(child1);
     const secret = 'sk-workflow-summary-1234567890abcdef';
     const ansiSplitSecret = `${secret.slice(0, 12)}\u001b[31m${secret.slice(12)}\u001b[0m`;
     logger.info('workflow prompt', {
@@ -1989,7 +1997,7 @@ describe('CLI transcript state', () => {
       ...slice,
       category: AgentCategory.Workflow,
     }));
-    const logger = createRunTrace(child1, defaultSession().transcripts).trace;
+    const logger = runTrace(child1);
     logger.info('raw dormant workflow prose', {
       messageType: MESSAGE_TYPES.MODEL_RESPONSE,
     });
@@ -2046,7 +2054,7 @@ describe('CLI transcript state', () => {
   });
 
   it('tracks context compaction activity without adding transcript rows', () => {
-    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    const logger = runTrace(root);
 
     logCompactionActivity(logger, 'started');
     syncStreamLog(root);
@@ -2064,7 +2072,7 @@ describe('CLI transcript state', () => {
   });
 
   it('clears an unmatched compaction start when later live activity arrives', () => {
-    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    const logger = runTrace(root);
 
     logCompactionActivity(logger, 'started');
     syncStreamLog(root);
@@ -2079,7 +2087,7 @@ describe('CLI transcript state', () => {
   });
 
   it('does not project empty assistant responses into transcript rows', () => {
-    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    const logger = runTrace(root);
     logger.info('', { messageType: MESSAGE_TYPES.MODEL_RESPONSE });
 
     syncStreamLog(root);
@@ -2100,7 +2108,7 @@ describe('CLI transcript state', () => {
   });
 
   it('trims leading blank assistant rows at turn start', () => {
-    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    const logger = runTrace(root);
     logger.info('Why?', { messageType: MESSAGE_TYPES.USER_MESSAGE });
     logger.info('\n\n  The answer starts here.', {
       messageType: MESSAGE_TYPES.MODEL_RESPONSE,
@@ -2122,7 +2130,7 @@ describe('CLI transcript state', () => {
   // `splitTranscriptEntries` once status flipped to WAITING and silently
   // disappear from the transcript.
   it('preserves the finalized flag through a post-finalize sync tick', () => {
-    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    const logger = runTrace(root);
     logger.info('streaming assistant chunk', {
       messageType: MESSAGE_TYPES.MODEL_RESPONSE,
     });
@@ -2154,7 +2162,7 @@ describe('CLI transcript state', () => {
   // the recorder-level upsert-vs-append unit coverage); these tests confirm
   // the CLI's own state ends up with exactly one entry, never a synthetic one.
   it('reconciles a streamed response to the authoritative post-replacement text', () => {
-    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    const logger = runTrace(root);
     const output = logger.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
     // Raw provider text, as it would arrive before replacement rules run.
     output.append('Done ✓');
@@ -2174,7 +2182,7 @@ describe('CLI transcript state', () => {
   });
 
   it('appends the final response when the round produced no live stream', () => {
-    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    const logger = runTrace(root);
     logger.responseFinalized('The answer is 2.');
 
     syncStreamLog(root);
@@ -2190,7 +2198,7 @@ describe('CLI transcript state', () => {
 
   it('keeps only a summary for an unfocused dormant transcript', () => {
     activeStreamId.set(root);
-    const logger = createRunTrace(child1, defaultSession().transcripts).trace;
+    const logger = runTrace(child1);
     logger.info('Check the second lemma.', {
       messageType: MESSAGE_TYPES.USER_MESSAGE,
     });
@@ -2213,7 +2221,7 @@ describe('CLI transcript state', () => {
 
   it('restores an exact dormant transcript when it is requested', () => {
     activeStreamId.set(root);
-    const logger = createRunTrace(child1, defaultSession().transcripts).trace;
+    const logger = runTrace(child1);
     logger.info('Check the second lemma.', {
       messageType: MESSAGE_TYPES.USER_MESSAGE,
     });
@@ -2237,7 +2245,7 @@ describe('CLI transcript state', () => {
   });
 
   it('does not let an earlier round leak its stream id into a later round', () => {
-    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    const logger = runTrace(root);
     const round0 = logger.openStage('r0', { kind: 'round', index: 0 });
     const output = logger.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
     output.append('Let me check that.');
@@ -2261,7 +2269,7 @@ describe('CLI transcript state', () => {
   });
 
   it('projects a turn boundary from the store alone, with zero synthetic entries', () => {
-    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    const logger = runTrace(root);
     logger.info('What is 1 + 1?', {
       messageType: MESSAGE_TYPES.USER_MESSAGE,
     });
@@ -2383,7 +2391,7 @@ describe('CLI transcript state', () => {
   });
 
   it('flushes pending model-response chunks before transcript sync', () => {
-    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    const logger = runTrace(root);
     const stream = logger.openStream(MESSAGE_TYPES.MODEL_RESPONSE);
     stream.append('A short final answer.');
 
@@ -2396,7 +2404,7 @@ describe('CLI transcript state', () => {
   });
 
   it('finalizes a delayed first model-response sync after the stream is idle', () => {
-    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    const logger = runTrace(root);
     logger.info('A delayed final answer.', {
       messageType: MESSAGE_TYPES.MODEL_RESPONSE,
     });
@@ -2420,7 +2428,7 @@ describe('CLI transcript state', () => {
   });
 
   it('keeps repeated local slash-command responses after stream-log syncs', () => {
-    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    const logger = runTrace(root);
     logger.info('prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
     syncStreamLog(root);
     activeStreamId.set(root);
@@ -2580,7 +2588,7 @@ describe('CLI transcript state', () => {
   });
 
   it('preserves the finalized response across later log syncs', () => {
-    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    const logger = runTrace(root);
     logger.info('1+1', { messageType: MESSAGE_TYPES.USER_MESSAGE });
     syncStreamLog(root);
     logger.responseFinalized('The answer is 2.');
@@ -2597,7 +2605,7 @@ describe('CLI transcript state', () => {
   });
 
   it('orders multiple finalized responses relative to the turns around them', () => {
-    const logger = createRunTrace(root, defaultSession().transcripts).trace;
+    const logger = runTrace(root);
     logger.info('first prompt', { messageType: MESSAGE_TYPES.USER_MESSAGE });
     syncStreamLog(root);
     logger.responseFinalized('first answer');

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -762,7 +762,6 @@ describe('DesktopProgressBridge', () => {
     vi.doUnmock('@agent/storage/detectWaitingStreams');
     vi.doUnmock('@common/storage/KVStore');
     vi.doUnmock('@controllers/mainView/MainViewExecutionController');
-    vi.doUnmock('@agent/runtime/restartRepair');
     vi.doUnmock('vscode');
     vi.restoreAllMocks();
   });

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -105,10 +105,6 @@ class MemoryConfigStore {
   }
 }
 
-async function loadDesktopSettingsIpc(): Promise<DesktopSettingsIpcModule> {
-  return loadSourceModule('@desktop/main/desktopSettingsIpc');
-}
-
 let createDesktopSettingsIpc!: DesktopSettingsIpcModule['createDesktopSettingsIpc'];
 
 function createSettingsFixture(overrides: SettingsFixtureOverrides = {}) {
@@ -173,7 +169,9 @@ function flushAsyncWork(): Promise<void> {
 
 describe('desktop settings IPC', () => {
   beforeAll(async () => {
-    ({ createDesktopSettingsIpc } = await loadDesktopSettingsIpc());
+    ({ createDesktopSettingsIpc } = await loadSourceModule(
+      '@desktop/main/desktopSettingsIpc',
+    ));
   });
 
   afterEach(() => {

--- a/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
@@ -164,6 +164,18 @@ function nonceFor(oauthClient: ReturnType<typeof createOAuthClient>): string {
   return new URLSearchParams(callback?.query).get('app_nonce') ?? '';
 }
 
+/** Routes the callback carrying the nonce the latest sign-in attempt minted. */
+function routeMatchingCallback(
+  router: DesktopProtocolCallbackRouter,
+  oauthClient: ReturnType<typeof createOAuthClient>,
+  tokens: { accessToken: string; refreshToken: string } = {
+    accessToken: 'access-token',
+    refreshToken: 'refresh-token',
+  },
+): void {
+  router.routeUrl(authCallbackUrl({ ...tokens, nonce: nonceFor(oauthClient) }));
+}
+
 function installAuthenticatedSupabaseProvider() {
   const ensureFreshToken = vi.fn(async () => 'fresh-access-token');
   const getSessionTokens = vi.fn(async () => ({
@@ -280,13 +292,7 @@ describe('desktop Supabase auth', () => {
     });
 
     await auth.signIn();
-    router.routeUrl(
-      authCallbackUrl({
-        accessToken: 'access-token',
-        refreshToken: 'refresh-token',
-        nonce: nonceFor(oauthClient),
-      }),
-    );
+    routeMatchingCallback(router, oauthClient);
 
     await vi.waitFor(() => {
       expect(coordinator.storeSession).toHaveBeenCalledWith(
@@ -328,13 +334,7 @@ describe('desktop Supabase auth', () => {
     );
     expect(completed).toBe(false);
 
-    router.routeUrl(
-      authCallbackUrl({
-        accessToken: 'access-token',
-        refreshToken: 'refresh-token',
-        nonce: nonceFor(oauthClient),
-      }),
-    );
+    routeMatchingCallback(router, oauthClient);
 
     await expect(completion).resolves.toBe(true);
     expect(coordinator.storeSession).toHaveBeenCalledOnce();
@@ -421,13 +421,7 @@ describe('desktop Supabase auth', () => {
       expect(oauthClient.auth.signInWithOAuth).toHaveBeenCalled(),
     );
 
-    router.routeUrl(
-      authCallbackUrl({
-        accessToken: 'access-token',
-        refreshToken: 'refresh-token',
-        nonce: nonceFor(oauthClient),
-      }),
-    );
+    routeMatchingCallback(router, oauthClient);
 
     await expect(completion).resolves.toBe(false);
     await vi.waitFor(() =>
@@ -530,13 +524,7 @@ describe('desktop Supabase auth', () => {
     await auth.signIn();
     auth.dispose();
     const persistedCallbackState = createDesktopAuthCallbackState(stateStore);
-    router.routeUrl(
-      authCallbackUrl({
-        accessToken: 'access-token',
-        refreshToken: 'refresh-token',
-        nonce: nonceFor(oauthClient),
-      }),
-    );
+    routeMatchingCallback(router, oauthClient);
 
     createTestAuth({
       router,
@@ -667,13 +655,7 @@ describe('desktop Supabase auth', () => {
 
     await auth.signIn();
     await auth.signOut();
-    router.routeUrl(
-      authCallbackUrl({
-        accessToken: 'access-token',
-        refreshToken: 'refresh-token',
-        nonce: nonceFor(oauthClient),
-      }),
-    );
+    routeMatchingCallback(router, oauthClient);
 
     await Promise.resolve();
 
@@ -697,13 +679,10 @@ describe('desktop Supabase auth', () => {
     });
 
     await auth.signIn();
-    router.routeUrl(
-      authCallbackUrl({
-        accessToken: 'first',
-        refreshToken: 'first',
-        nonce: nonceFor(oauthClient),
-      }),
-    );
+    routeMatchingCallback(router, oauthClient, {
+      accessToken: 'first',
+      refreshToken: 'first',
+    });
     router.routeUrl(
       authCallbackUrl({ accessToken: 'second', refreshToken: 'second' }),
     );
@@ -735,13 +714,7 @@ describe('desktop Supabase auth', () => {
     });
 
     await auth.signIn();
-    router.routeUrl(
-      authCallbackUrl({
-        accessToken: 'access-token',
-        refreshToken: 'refresh-token',
-        nonce: nonceFor(oauthClient),
-      }),
-    );
+    routeMatchingCallback(router, oauthClient);
     await vi.waitFor(() => {
       expect(coordinator.createSessionFromCallback).toHaveBeenCalledOnce();
     });
@@ -775,13 +748,10 @@ describe('desktop Supabase auth', () => {
     });
 
     await auth.signIn();
-    router.routeUrl(
-      authCallbackUrl({
-        accessToken: 'stale-access-token',
-        refreshToken: 'stale-refresh-token',
-        nonce: nonceFor(oauthClient),
-      }),
-    );
+    routeMatchingCallback(router, oauthClient, {
+      accessToken: 'stale-access-token',
+      refreshToken: 'stale-refresh-token',
+    });
     await vi.waitFor(() => {
       expect(coordinator.storeSession).toHaveBeenCalledOnce();
     });
@@ -818,13 +788,10 @@ describe('desktop Supabase auth', () => {
     });
 
     await auth.signIn();
-    router.routeUrl(
-      authCallbackUrl({
-        accessToken: 'stale-access-token',
-        refreshToken: 'stale-refresh-token',
-        nonce: nonceFor(oauthClient),
-      }),
-    );
+    routeMatchingCallback(router, oauthClient, {
+      accessToken: 'stale-access-token',
+      refreshToken: 'stale-refresh-token',
+    });
     await vi.waitFor(() => {
       expect(coordinator.storeSession).toHaveBeenCalledOnce();
     });
@@ -840,13 +807,10 @@ describe('desktop Supabase auth', () => {
     expect(callbackState.hasPendingSignIn()).toBe(true);
     expect(onSessionChanged).not.toHaveBeenCalled();
 
-    router.routeUrl(
-      authCallbackUrl({
-        accessToken: 'new-access-token',
-        refreshToken: 'new-refresh-token',
-        nonce: nonceFor(oauthClient),
-      }),
-    );
+    routeMatchingCallback(router, oauthClient, {
+      accessToken: 'new-access-token',
+      refreshToken: 'new-refresh-token',
+    });
     await vi.waitFor(() => {
       expect(coordinator.storeSession).toHaveBeenCalledTimes(2);
       expect(onSessionChanged).toHaveBeenCalledOnce();
@@ -877,13 +841,10 @@ describe('desktop Supabase auth', () => {
       });
 
       await auth.signIn();
-      router.routeUrl(
-        authCallbackUrl({
-          accessToken: 'stale-access-token',
-          refreshToken: 'stale-refresh-token',
-          nonce: nonceFor(oauthClient),
-        }),
-      );
+      routeMatchingCallback(router, oauthClient, {
+        accessToken: 'stale-access-token',
+        refreshToken: 'stale-refresh-token',
+      });
       await vi.waitFor(() => {
         expect(onSessionChanged).toHaveBeenCalledOnce();
       });
@@ -921,13 +882,7 @@ describe('desktop Supabase auth', () => {
       });
 
       await auth.signIn();
-      router.routeUrl(
-        authCallbackUrl({
-          accessToken: 'access-token',
-          refreshToken: 'refresh-token',
-          nonce: nonceFor(oauthClient),
-        }),
-      );
+      routeMatchingCallback(router, oauthClient);
       await vi.waitFor(() => {
         expect(coordinator.createSessionFromCallback).toHaveBeenCalledOnce();
       });
@@ -961,13 +916,10 @@ describe('desktop Supabase auth', () => {
     await expect(first).resolves.toBe(false);
     await new Promise((resolve) => setTimeout(resolve, 20));
 
-    router.routeUrl(
-      authCallbackUrl({
-        accessToken: 'new-access-token',
-        refreshToken: 'new-refresh-token',
-        nonce: nonceFor(oauthClient),
-      }),
-    );
+    routeMatchingCallback(router, oauthClient, {
+      accessToken: 'new-access-token',
+      refreshToken: 'new-refresh-token',
+    });
 
     await expect(second).resolves.toBe(true);
     expect(coordinator.storeSession).toHaveBeenCalledOnce();
@@ -991,13 +943,7 @@ describe('desktop Supabase auth', () => {
     });
 
     await auth.signIn();
-    router.routeUrl(
-      authCallbackUrl({
-        accessToken: 'access-token',
-        refreshToken: 'refresh-token',
-        nonce: nonceFor(oauthClient),
-      }),
-    );
+    routeMatchingCallback(router, oauthClient);
 
     await vi.waitFor(() => {
       expect(showErrorMessage).toHaveBeenCalledWith(

--- a/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
+++ b/src/test-kernel/desktop/DesktopToolEditApproval.vitest.mts
@@ -79,14 +79,6 @@ function recordSessionEvents(session: SessionHandle): SessionEvent[] {
   return events;
 }
 
-function useControllerApproval(controller: {
-  requestApproval(
-    request: ToolEditApprovalRequest,
-  ): Promise<ToolEditApprovalResult>;
-}): void {
-  activeToolEditApproval = (request) => controller.requestApproval(request);
-}
-
 function createRecordingRuntimeHost(): RecordingRuntimeHost {
   const shownToolEditPermissions: ToolEditPermission[] = [];
   const resolvedToolEditPermissions: Array<{ requestId: string }> = [];
@@ -233,6 +225,38 @@ async function loadApprovalModules(workspacePath = '/workspace') {
   };
 }
 
+/**
+ * Standard approval wiring: a fresh temp root, recording interactions, an
+ * isolated session, and a controller registered as the active approval handler.
+ */
+async function createApprovalFixture(
+  options: {
+    ui?: ApprovalControllerOptions['ui'];
+    workspacePath?: string;
+  } = {},
+): Promise<
+  Awaited<ReturnType<typeof loadApprovalModules>> & {
+    controller: ApprovalController;
+    interactions: RecordingRuntimeHost;
+    session: SessionHandle;
+    tempRoot: string;
+  }
+> {
+  const tempRoot = await createTempRoot();
+  const modules = await loadApprovalModules(options.workspacePath);
+  const interactions = createRecordingRuntimeHost();
+  const session = createTestSession();
+  const controller = createApprovalController(modules.desktopModule, {
+    interactions,
+    ...controllerHostCallbacks(interactions),
+    session,
+    ui: options.ui ?? createStubDesktopAgentExecutionHost(),
+    tempRoot,
+  });
+  activeToolEditApproval = (request) => controller.requestApproval(request);
+  return { ...modules, controller, interactions, session, tempRoot };
+}
+
 describe('desktop tool edit approval', () => {
   afterEach(async () => {
     activeToolEditApproval = undefined;
@@ -347,26 +371,17 @@ describe('desktop tool edit approval', () => {
   approvalTest(
     'routes proposed-file previews through desktop temp files before rejection',
     async () => {
-      const tempRoot = await createTempRoot();
-      const { requestToolEditApproval, desktopModule } =
-        await loadApprovalModules();
-      const interactions = createRecordingRuntimeHost();
-      const emitSpy = vi.spyOn(interactions, 'emit');
-      const session = createTestSession();
-      const sessionEvents = recordSessionEvents(session);
       const opened: string[] = [];
-      const controller = createApprovalController(desktopModule, {
-        interactions,
-        ...controllerHostCallbacks(interactions),
-        session,
-        tempRoot,
-        ui: createStubDesktopAgentExecutionHost({
-          openPath: async (filePath) => {
-            opened.push(filePath);
-          },
-        }),
-      });
-      useControllerApproval(controller);
+      const { requestToolEditApproval, controller, interactions, session } =
+        await createApprovalFixture({
+          ui: createStubDesktopAgentExecutionHost({
+            openPath: async (filePath) => {
+              opened.push(filePath);
+            },
+          }),
+        });
+      const emitSpy = vi.spyOn(interactions, 'emit');
+      const sessionEvents = recordSessionEvents(session);
       const { shownToolEditPermissions: shown } = interactions;
 
       const resultPromise = requestToolEditApproval({
@@ -422,10 +437,6 @@ describe('desktop tool edit approval', () => {
   approvalTest(
     'routes diff actions through the required desktop diff host',
     async () => {
-      const tempRoot = await createTempRoot();
-      const { requestToolEditApproval, desktopModule } =
-        await loadApprovalModules();
-      const interactions = createRecordingRuntimeHost();
       const openPath = vi.fn(async (_filePath: string) => {});
       const openDiff = vi.fn(
         async (
@@ -435,14 +446,10 @@ describe('desktop tool edit approval', () => {
           _options?: DiffOptions,
         ): Promise<DiffSession> => ({ original, proposed, title }),
       );
-      const controller = createApprovalController(desktopModule, {
-        interactions,
-        ...controllerHostCallbacks(interactions),
-        session: createTestSession(),
-        tempRoot,
-        ui: createStubDesktopAgentExecutionHost({ openPath, openDiff }),
-      });
-      useControllerApproval(controller);
+      const { requestToolEditApproval, controller, interactions } =
+        await createApprovalFixture({
+          ui: createStubDesktopAgentExecutionHost({ openPath, openDiff }),
+        });
       const { shownToolEditPermissions: shown } = interactions;
 
       const resultPromise = requestToolEditApproval({
@@ -478,23 +485,15 @@ describe('desktop tool edit approval', () => {
   approvalTest(
     'applies user edits made in the proposed preview file',
     async () => {
-      const tempRoot = await createTempRoot();
-      const { requestToolEditApproval, desktopModule } =
-        await loadApprovalModules();
-      const interactions = createRecordingRuntimeHost();
       const opened: string[] = [];
-      const controller = createApprovalController(desktopModule, {
-        interactions,
-        ...controllerHostCallbacks(interactions),
-        session: createTestSession(),
-        tempRoot,
-        ui: createStubDesktopAgentExecutionHost({
-          openPath: async (filePath) => {
-            opened.push(filePath);
-          },
-        }),
-      });
-      useControllerApproval(controller);
+      const { requestToolEditApproval, controller, interactions } =
+        await createApprovalFixture({
+          ui: createStubDesktopAgentExecutionHost({
+            openPath: async (filePath) => {
+              opened.push(filePath);
+            },
+          }),
+        });
       const { shownToolEditPermissions: shown } = interactions;
 
       const resultPromise = requestToolEditApproval({
@@ -540,19 +539,11 @@ describe('desktop tool edit approval', () => {
         return { ...actual, runLatexdiff };
       });
 
-      const tempRoot = await createTempRoot();
-      const { requestToolEditApproval, desktopModule } =
-        await loadApprovalModules();
-      const interactions = createRecordingRuntimeHost();
       const openBuildDisplay = vi.fn(async () => {});
-      const controller = createApprovalController(desktopModule, {
-        interactions,
-        ...controllerHostCallbacks(interactions),
-        session: createTestSession(),
-        tempRoot,
-        ui: createStubDesktopAgentExecutionHost({ openBuildDisplay }),
-      });
-      useControllerApproval(controller);
+      const { requestToolEditApproval, controller, interactions } =
+        await createApprovalFixture({
+          ui: createStubDesktopAgentExecutionHost({ openBuildDisplay }),
+        });
       const { shownToolEditPermissions: shown } = interactions;
 
       const resultPromise = requestToolEditApproval({
@@ -594,30 +585,23 @@ describe('desktop tool edit approval', () => {
     'uses the injected desktop build display callback for LaTeX preview',
     async () => {
       const workspaceRoot = await createTempRoot('texra-workspace-');
-      const tempRoot = await createTempRoot();
-      const { requestToolEditApproval, desktopModule } =
-        await loadApprovalModules(workspaceRoot);
-      const interactions = createRecordingRuntimeHost();
       const displayed: Array<{
         absolutePath: string;
         options?: { preserveFocus?: boolean };
       }> = [];
       const messages: string[] = [];
-      const controller = createApprovalController(desktopModule, {
-        interactions,
-        ...controllerHostCallbacks(interactions),
-        session: createTestSession(),
-        tempRoot,
-        ui: createStubDesktopAgentExecutionHost({
-          openBuildDisplay: async (location, options) => {
-            displayed.push({ absolutePath: location.absolutePath, options });
-          },
-          showErrorMessage: (message) => {
-            messages.push(message);
-          },
-        }),
-      });
-      useControllerApproval(controller);
+      const { requestToolEditApproval, controller, interactions } =
+        await createApprovalFixture({
+          workspacePath: workspaceRoot,
+          ui: createStubDesktopAgentExecutionHost({
+            openBuildDisplay: async (location, options) => {
+              displayed.push({ absolutePath: location.absolutePath, options });
+            },
+            showErrorMessage: (message) => {
+              messages.push(message);
+            },
+          }),
+        });
       const { shownToolEditPermissions: shown } = interactions;
 
       const resultPromise = requestToolEditApproval({
@@ -658,18 +642,8 @@ describe('desktop tool edit approval', () => {
   approvalTest(
     'does not present a stream approval cancelled during initialization',
     async () => {
-      const tempRoot = await createTempRoot();
-      const { requestToolEditApproval, desktopModule } =
-        await loadApprovalModules();
-      const interactions = createRecordingRuntimeHost();
-      const controller = createApprovalController(desktopModule, {
-        interactions,
-        ...controllerHostCallbacks(interactions),
-        session: createTestSession(),
-        ui: createStubDesktopAgentExecutionHost(),
-        tempRoot,
-      });
-      useControllerApproval(controller);
+      const { requestToolEditApproval, controller, interactions, tempRoot } =
+        await createApprovalFixture();
 
       const resultPromise = requestToolEditApproval({
         path: '/workspace/cancel-during-init.tex',
@@ -697,18 +671,8 @@ describe('desktop tool edit approval', () => {
   approvalTest(
     'does not present an approval when disposed during initialization',
     async () => {
-      const tempRoot = await createTempRoot();
-      const { requestToolEditApproval, desktopModule } =
-        await loadApprovalModules();
-      const interactions = createRecordingRuntimeHost();
-      const controller = createApprovalController(desktopModule, {
-        interactions,
-        ...controllerHostCallbacks(interactions),
-        session: createTestSession(),
-        ui: createStubDesktopAgentExecutionHost(),
-        tempRoot,
-      });
-      useControllerApproval(controller);
+      const { requestToolEditApproval, controller, interactions, tempRoot } =
+        await createApprovalFixture();
 
       const resultPromise = requestToolEditApproval({
         path: '/workspace/dispose-during-init.tex',
@@ -732,18 +696,8 @@ describe('desktop tool edit approval', () => {
   approvalTest(
     'cancels only tool-edit approvals selected for the owning stream',
     async () => {
-      const tempRoot = await createTempRoot();
-      const { requestToolEditApproval, desktopModule } =
-        await loadApprovalModules();
-      const interactions = createRecordingRuntimeHost();
-      const controller = createApprovalController(desktopModule, {
-        interactions,
-        ...controllerHostCallbacks(interactions),
-        session: createTestSession(),
-        ui: createStubDesktopAgentExecutionHost(),
-        tempRoot,
-      });
-      useControllerApproval(controller);
+      const { requestToolEditApproval, controller, interactions, tempRoot } =
+        await createApprovalFixture();
       const { shownToolEditPermissions: shown } = interactions;
       const { resolvedToolEditPermissions: resolved } = interactions;
 
@@ -800,19 +754,13 @@ describe('desktop tool edit approval', () => {
   approvalTest(
     'cleans pending entries and temp files when stream cleanup rejects a request',
     async () => {
-      const tempRoot = await createTempRoot();
-      const { cleanupApprovalsForStream, desktopModule } =
-        await loadApprovalModules();
-      const interactions = createRecordingRuntimeHost();
-      const session = createTestSession();
-      const controller = createApprovalController(desktopModule, {
+      const {
+        cleanupApprovalsForStream,
+        controller,
         interactions,
-        ...controllerHostCallbacks(interactions),
         session,
-        ui: createStubDesktopAgentExecutionHost(),
         tempRoot,
-      });
-      useControllerApproval(controller);
+      } = await createApprovalFixture();
       session.useHostInteractions({
         requestToolEditApproval: (request) =>
           controller.requestApproval(request),

--- a/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
+++ b/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
@@ -256,10 +256,8 @@ describe('desktop main-view IPC', () => {
   afterEach(() => {
     vi.doUnmock('electron');
     vi.doUnmock('@agent/index');
-    vi.doUnmock('@agent/index/agentRegistry');
     vi.doUnmock('@auth/SupabaseClient');
     vi.doUnmock('@model/computeModelOptions');
-    vi.doUnmock('@model/modelOptionsBasic');
   });
 
   it('pushes theme and debug state over the fixed host bridge channel', async () => {

--- a/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
+++ b/src/test-kernel/progressView/ExtensionHostInteractions.vitest.mts
@@ -5,7 +5,6 @@ import * as vscode from 'vscode';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { SessionEvent } from '@agent/runtime/SessionEventHub';
 import type { HostApprovalBypassStateUpdate } from '@agent/runtime/HostInteractions';
-import type { ApprovalRequestHandlerSet } from '@controllers/progressView/backend/progressBackendUiConfig';
 import { createExtensionHostInteractions } from '@progressView/extensionHostInteractions';
 import type { StreamTabId } from '@shared/schemas';
 import { createTestSession as createIsolatedTestSession } from '@test/support/sessionTestUtils';
@@ -60,19 +59,26 @@ function firstShowRequestId(show: ReturnType<typeof vi.fn>): string {
   return requestId;
 }
 
+/**
+ * One handler set per interactions instance: `getApprovalHandlers` must return
+ * the same set on every call, because `cancel()` reaches all seven kinds and
+ * has to find the requests `show()` recorded.
+ */
 function createInteractions(options: {
   presentationSink?: ReturnType<typeof createRuntimeHost>;
-  handlers?: ApprovalRequestHandlerSet;
   setApprovalBypassState?: (update: HostApprovalBypassStateUpdate) => void;
   session: SessionHandle;
 }) {
-  return createExtensionHostInteractions({
-    interactions: options.presentationSink ?? createRuntimeHost(),
-    session: options.session,
-    getApprovalHandlers: () =>
-      options.handlers ?? createRecordingApprovalHandlers(),
-    setApprovalBypassState: options.setApprovalBypassState ?? vi.fn(),
-  });
+  const handlers = createRecordingApprovalHandlers();
+  return {
+    handlers,
+    interactions: createExtensionHostInteractions({
+      interactions: options.presentationSink ?? createRuntimeHost(),
+      session: options.session,
+      getApprovalHandlers: () => handlers,
+      setApprovalBypassState: options.setApprovalBypassState ?? vi.fn(),
+    }),
+  };
 }
 
 function recordSessionEvents(session: SessionHandle): SessionEvent[] {
@@ -87,7 +93,7 @@ describe('createExtensionHostInteractions', () => {
   it('forwards emit to the caller-supplied runtime host (#9251)', () => {
     const presentationSink = createRuntimeHost();
     const session = createTestSession();
-    const interactions = createInteractions({ presentationSink, session });
+    const { interactions } = createInteractions({ presentationSink, session });
 
     interactions.emit?.('requestShowError', { message: 'boom' });
 
@@ -98,7 +104,7 @@ describe('createExtensionHostInteractions', () => {
 
   it('forwards approval bypass state through the host port', () => {
     const setApprovalBypassState = vi.fn();
-    const interactions = createInteractions({
+    const { interactions } = createInteractions({
       session: createTestSession(),
       setApprovalBypassState,
     });
@@ -115,7 +121,7 @@ describe('createExtensionHostInteractions', () => {
 
   it('provides diagnostics and notification capabilities', async () => {
     const session = createTestSession();
-    const interactions = createInteractions({ session });
+    const { interactions } = createInteractions({ session });
     const showInformationMessage = vi
       .spyOn(vscode.window, 'showInformationMessage')
       .mockResolvedValue(undefined);
@@ -158,7 +164,7 @@ describe('createExtensionHostInteractions', () => {
 
   it('runs the selected unavailable-tool notification action', async () => {
     const session = createTestSession();
-    const interactions = createInteractions({ session });
+    const { interactions } = createInteractions({ session });
     const showInformationMessage = vi
       .spyOn(vscode.window, 'showInformationMessage')
       .mockResolvedValue('Open Lean Setup' as never);
@@ -187,9 +193,8 @@ describe('createExtensionHostInteractions', () => {
   });
 
   it('approves already-pending delegated work only in the selected stream', async () => {
-    const handlers = createRecordingApprovalHandlers();
     const session = createTestSession();
-    const interactions = createInteractions({ handlers, session });
+    const { handlers, interactions } = createInteractions({ session });
 
     const initiatingProposal = interactions.requestAgentProposal?.({
       proposalId: 'proposal-current',
@@ -265,12 +270,10 @@ describe('createExtensionHostInteractions', () => {
 
   it('shows and resolves plan approvals through existing handlers', async () => {
     const presentationSink = createRuntimeHost();
-    const handlers = createRecordingApprovalHandlers();
     const session = createTestSession();
     const sessionEvents = recordSessionEvents(session);
-    const interactions = createInteractions({
+    const { handlers, interactions } = createInteractions({
       presentationSink,
-      handlers,
       session,
     });
 
@@ -326,13 +329,11 @@ describe('createExtensionHostInteractions', () => {
   });
 
   it('rejects a request when its show transport fails synchronously', async () => {
-    const handlers = createRecordingApprovalHandlers();
+    const { handlers, interactions } = createInteractions({
+      session: createTestSession(),
+    });
     handlers.transport.planApproval.show.mockImplementationOnce(() => {
       throw new Error('Progress view transport unavailable.');
-    });
-    const interactions = createInteractions({
-      handlers,
-      session: createTestSession(),
     });
 
     const resultPromise = interactions.requestPlanApproval?.({
@@ -355,10 +356,9 @@ describe('createExtensionHostInteractions', () => {
   });
 
   it('surfaces retry requests without stealing active-stream focus (#8246)', () => {
-    const handlers = createRecordingApprovalHandlers();
     const session = createTestSession();
     const sessionEvents = recordSessionEvents(session);
-    const interactions = createInteractions({ handlers, session });
+    const { handlers, interactions } = createInteractions({ session });
 
     void interactions.requestRetry?.({
       requestId: 'retry:subagent',
@@ -391,9 +391,7 @@ describe('createExtensionHostInteractions', () => {
   });
 
   it('does not let an old retry action resolve its replacement', async () => {
-    const handlers = createRecordingApprovalHandlers();
-    const interactions = createInteractions({
-      handlers,
+    const { interactions } = createInteractions({
       session: createTestSession(),
     });
     const first = interactions.requestRetry?.({
@@ -435,10 +433,8 @@ describe('createExtensionHostInteractions', () => {
 
   it('cancels pending retry requests for a removed stream', async () => {
     const presentationSink = createRuntimeHost();
-    const handlers = createRecordingApprovalHandlers();
-    const interactions = createInteractions({
+    const { handlers, interactions } = createInteractions({
       presentationSink,
-      handlers,
       session: createTestSession(),
     });
 
@@ -456,7 +452,7 @@ describe('createExtensionHostInteractions', () => {
 
   it('routes tool-edit cancellation through the native approval owner', () => {
     const session = createTestSession();
-    const interactions = createInteractions({ session });
+    const { interactions } = createInteractions({ session });
     const selector = {
       kind: 'toolEdit' as const,
       streamId: 'stream-a' as StreamTabId,
@@ -472,9 +468,7 @@ describe('createExtensionHostInteractions', () => {
   });
 
   it('forwards a cancellation cause as bash reject feedback', async () => {
-    const handlers = createRecordingApprovalHandlers();
-    const interactions = createInteractions({
-      handlers,
+    const { handlers, interactions } = createInteractions({
       session: createTestSession(),
     });
 
@@ -496,9 +490,7 @@ describe('createExtensionHostInteractions', () => {
   });
 
   it('rejects a resolution whose kind does not match the pending request', async () => {
-    const handlers = createRecordingApprovalHandlers();
-    const interactions = createInteractions({
-      handlers,
+    const { handlers, interactions } = createInteractions({
       session: createTestSession(),
     });
 
@@ -523,9 +515,7 @@ describe('createExtensionHostInteractions', () => {
   });
 
   it('a retry-kind cancel clears only the retry, leaving the plan approval pending', async () => {
-    const handlers = createRecordingApprovalHandlers();
-    const interactions = createInteractions({
-      handlers,
+    const { handlers, interactions } = createInteractions({
       session: createTestSession(),
     });
 
@@ -563,10 +553,8 @@ describe('createExtensionHostInteractions', () => {
 
   it('shows external inquiries without waiting for a user decision', async () => {
     const presentationSink = createRuntimeHost();
-    const handlers = createRecordingApprovalHandlers();
-    const interactions = createInteractions({
+    const { handlers, interactions } = createInteractions({
       presentationSink,
-      handlers,
       session: createTestSession(),
     });
 
@@ -596,9 +584,7 @@ describe('createExtensionHostInteractions', () => {
   });
 
   it('cancels streamless user questions during unscoped cleanup', async () => {
-    const handlers = createRecordingApprovalHandlers();
-    const interactions = createInteractions({
-      handlers,
+    const { handlers, interactions } = createInteractions({
       session: createTestSession(),
     });
 
@@ -638,9 +624,7 @@ describe('createExtensionHostInteractions', () => {
   });
 
   it('settles submitted user questions with their answers', async () => {
-    const handlers = createRecordingApprovalHandlers();
-    const interactions = createInteractions({
-      handlers,
+    const { handlers, interactions } = createInteractions({
       session: createTestSession(),
     });
 
@@ -677,7 +661,7 @@ describe('createExtensionHostInteractions', () => {
     const nativeResult = { accepted: true };
     mocks.nativeRequestApproval.mockResolvedValue(nativeResult);
     const session = createTestSession();
-    const interactions = createInteractions({ session });
+    const { interactions } = createInteractions({ session });
     const request = {
       path: 'paper.tex',
       originalContent: 'A',

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -9,7 +9,7 @@ import '@test/support/defaultSessionTestSetup';
 import * as path from 'node:path';
 
 // Third-party imports
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@tools/goal', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@tools/goal')>();
@@ -75,6 +75,23 @@ import {
 } from '@transcript/streamDataPaths';
 import { StorageFS } from '@utils/files';
 
+/**
+ * Everything a test creates that needs releasing. One owner tears them down in
+ * reverse creation order, so no test carries its own `finally` teardown.
+ */
+const testDisposables: { dispose(): void }[] = [];
+
+afterEach(() => {
+  for (const disposable of testDisposables.splice(0).reverse()) {
+    disposable.dispose();
+  }
+});
+
+function track<T extends { dispose(): void }>(disposable: T): T {
+  testDisposables.push(disposable);
+  return disposable;
+}
+
 function createApprovalOptions() {
   return {
     canSend: () => true,
@@ -100,6 +117,14 @@ function createLifecycleOptions(
   };
 }
 
+/** A live-store session with restart repair deferred, as the hosts open it. */
+async function createLiveStoreSession(): Promise<SessionHandle> {
+  return new SessionHandle({
+    transcripts: await StreamLogStore.open(),
+    restartRepair: 'deferred',
+  });
+}
+
 function toolUseTaskState(agent: string, model: string): TaskState {
   return {
     agentConfig: {
@@ -115,16 +140,18 @@ function createRecordingBackend(): {
   messages: ProgressViewOutboundMessage[];
 } {
   const messages: ProgressViewOutboundMessage[] = [];
-  const backend = new ProgressBackend({
-    storage: new FakeStateStore(),
-    sendMessage: (message) => {
-      messages.push(message);
-      return true;
-    },
-    hasTarget: () => true,
-    approvals: createApprovalOptions(),
-    lifecycle: createLifecycleOptions(),
-  });
+  const backend = track(
+    new ProgressBackend({
+      storage: new FakeStateStore(),
+      sendMessage: (message) => {
+        messages.push(message);
+        return true;
+      },
+      hasTarget: () => true,
+      approvals: createApprovalOptions(),
+      lifecycle: createLifecycleOptions(),
+    }),
+  );
   return { backend, messages };
 }
 
@@ -138,17 +165,20 @@ function createIsolatedRecordingBackend(
   lifecycle: ProgressBackendOptions['lifecycle'];
 } {
   const messages: ProgressViewOutboundMessage[] = [];
-  const backend = new ProgressBackend({
-    storage: new FakeStateStore(),
-    session,
-    sendMessage: (message) => {
-      messages.push(message);
-      return true;
-    },
-    hasTarget: () => true,
-    approvals: createApprovalOptions(),
-    lifecycle,
-  });
+  track(session);
+  const backend = track(
+    new ProgressBackend({
+      storage: new FakeStateStore(),
+      session,
+      sendMessage: (message) => {
+        messages.push(message);
+        return true;
+      },
+      hasTarget: () => true,
+      approvals: createApprovalOptions(),
+      lifecycle,
+    }),
+  );
   return { backend, lifecycle, messages, session };
 }
 
@@ -245,11 +275,7 @@ function emitStreamDescription(
 async function expectDeletionBeforeStorageRootReplacement(
   deletionKind: 'one-stream' | 'all-streams',
 ): Promise<void> {
-  const transcripts = await StreamLogStore.open();
-  const session = new SessionHandle({
-    transcripts,
-    restartRepair: 'deferred',
-  });
+  const session = await createLiveStoreSession();
   const { backend } = createIsolatedRecordingBackend(session);
   const stream = `${deletionKind}-before-root-move` as StreamTabId;
   const operations: string[] = [];
@@ -299,8 +325,6 @@ async function expectDeletionBeforeStorageRootReplacement(
     expect(operations).toEqual(['delete:start', 'delete:end', 'reload']);
   } finally {
     finishDeletion?.();
-    backend.dispose();
-    session.dispose();
   }
 }
 
@@ -367,8 +391,6 @@ async function expectDeletionReleasesEarlierRootReplacement(
     expect(operations).toEqual(['reload:start', 'stop', 'reload:end']);
   } finally {
     releaseReload?.();
-    backend.dispose();
-    session.dispose();
   }
 }
 
@@ -416,45 +438,30 @@ async function expectRetentionNoticeDoesNotBlockStorageRootReplacement(
     await workspaceMove;
   } finally {
     finishNotice?.();
-    backend.dispose();
-    session.dispose();
   }
 }
 
 describe('ProgressBackend', () => {
   it('loads an unfiltered presentation without reloading its live transcript', async () => {
-    const transcripts = await StreamLogStore.open();
-    const session = new SessionHandle({
-      transcripts,
-      restartRepair: 'deferred',
-    });
+    const session = await createLiveStoreSession();
     const waitUntilReady = vi.spyOn(session, 'waitUntilReady');
-    const reload = vi.spyOn(transcripts, 'reload');
+    const reload = vi.spyOn(session.transcripts, 'reload');
     const { backend } = createIsolatedRecordingBackend(session);
     backend.state.agentCategoryFilter = AgentCategory.Workflow;
 
-    try {
-      await backend.load();
+    await backend.load();
 
-      expect(waitUntilReady).toHaveBeenCalledOnce();
-      expect(reload).not.toHaveBeenCalled();
-      expect(backend.state.agentCategoryFilter).toBe('all');
-    } finally {
-      backend.dispose();
-      session.dispose();
-    }
+    expect(waitUntilReady).toHaveBeenCalledOnce();
+    expect(reload).not.toHaveBeenCalled();
+    expect(backend.state.agentCategoryFilter).toBe('all');
   });
 
   it('uses the session-owned replacement boundary after a workspace move', async () => {
-    const transcripts = await StreamLogStore.open();
-    const session = new SessionHandle({
-      transcripts,
-      restartRepair: 'deferred',
-    });
+    const session = await createLiveStoreSession();
     const reloadAfterStorageRootChange = vi
       .spyOn(session, 'reloadAfterStorageRootChange')
       .mockResolvedValue(true);
-    const transcriptReload = vi.spyOn(transcripts, 'reload');
+    const transcriptReload = vi.spyOn(session.transcripts, 'reload');
     const { backend } = createIsolatedRecordingBackend(session);
     const resetPresentation = vi.spyOn(
       backend.state,
@@ -463,26 +470,17 @@ describe('ProgressBackend', () => {
     const clearBridge = vi.spyOn(backend.webviewBridge, 'clearAll');
     backend.state.agentCategoryFilter = AgentCategory.Workflow;
 
-    try {
-      await backend.reloadAfterStorageRootChange();
+    await backend.reloadAfterStorageRootChange();
 
-      expect(reloadAfterStorageRootChange).toHaveBeenCalledOnce();
-      expect(resetPresentation).toHaveBeenCalledOnce();
-      expect(clearBridge).toHaveBeenCalledOnce();
-      expect(transcriptReload).not.toHaveBeenCalled();
-      expect(backend.state.agentCategoryFilter).toBe('all');
-    } finally {
-      backend.dispose();
-      session.dispose();
-    }
+    expect(reloadAfterStorageRootChange).toHaveBeenCalledOnce();
+    expect(resetPresentation).toHaveBeenCalledOnce();
+    expect(clearBridge).toHaveBeenCalledOnce();
+    expect(transcriptReload).not.toHaveBeenCalled();
+    expect(backend.state.agentCategoryFilter).toBe('all');
   });
 
   it('keeps presentation caches when the effective storage root is unchanged', async () => {
-    const transcripts = await StreamLogStore.open();
-    const session = new SessionHandle({
-      transcripts,
-      restartRepair: 'deferred',
-    });
+    const session = await createLiveStoreSession();
     vi.spyOn(session, 'reloadAfterStorageRootChange').mockResolvedValue(false);
     const { backend } = createIsolatedRecordingBackend(session);
     const resetPresentation = vi.spyOn(
@@ -492,24 +490,15 @@ describe('ProgressBackend', () => {
     const clearBridge = vi.spyOn(backend.webviewBridge, 'clearAll');
     const loadPresentation = vi.spyOn(backend.state, 'load');
 
-    try {
-      await backend.reloadAfterStorageRootChange();
+    await backend.reloadAfterStorageRootChange();
 
-      expect(resetPresentation).not.toHaveBeenCalled();
-      expect(clearBridge).not.toHaveBeenCalled();
-      expect(loadPresentation).not.toHaveBeenCalled();
-    } finally {
-      backend.dispose();
-      session.dispose();
-    }
+    expect(resetPresentation).not.toHaveBeenCalled();
+    expect(clearBridge).not.toHaveBeenCalled();
+    expect(loadPresentation).not.toHaveBeenCalled();
   });
 
   it('reconciles presentation caches after a partial session reload', async () => {
-    const transcripts = await StreamLogStore.open();
-    const session = new SessionHandle({
-      transcripts,
-      restartRepair: 'deferred',
-    });
+    const session = await createLiveStoreSession();
     const reloadError = new Error('snapshot hydration failed');
     vi.spyOn(session, 'reloadAfterStorageRootChange').mockRejectedValue(
       reloadError,
@@ -524,26 +513,17 @@ describe('ProgressBackend', () => {
       .spyOn(backend.state, 'load')
       .mockResolvedValue();
 
-    try {
-      await expect(backend.reloadAfterStorageRootChange()).rejects.toBe(
-        reloadError,
-      );
+    await expect(backend.reloadAfterStorageRootChange()).rejects.toBe(
+      reloadError,
+    );
 
-      expect(resetPresentation).toHaveBeenCalledOnce();
-      expect(clearBridge).toHaveBeenCalledOnce();
-      expect(loadPresentation).toHaveBeenCalledOnce();
-    } finally {
-      backend.dispose();
-      session.dispose();
-    }
+    expect(resetPresentation).toHaveBeenCalledOnce();
+    expect(clearBridge).toHaveBeenCalledOnce();
+    expect(loadPresentation).toHaveBeenCalledOnce();
   });
 
   it('retries presentation loading after the storage root already moved', async () => {
-    const transcripts = await StreamLogStore.open();
-    const session = new SessionHandle({
-      transcripts,
-      restartRepair: 'deferred',
-    });
+    const session = await createLiveStoreSession();
     vi.spyOn(session, 'reloadAfterStorageRootChange')
       .mockResolvedValueOnce(true)
       .mockResolvedValue(false);
@@ -554,27 +534,18 @@ describe('ProgressBackend', () => {
       .mockRejectedValueOnce(presentationError)
       .mockResolvedValue();
 
-    try {
-      await expect(backend.reloadAfterStorageRootChange()).rejects.toBe(
-        presentationError,
-      );
-      await expect(
-        backend.reloadAfterStorageRootChange(),
-      ).resolves.toBeUndefined();
+    await expect(backend.reloadAfterStorageRootChange()).rejects.toBe(
+      presentationError,
+    );
+    await expect(
+      backend.reloadAfterStorageRootChange(),
+    ).resolves.toBeUndefined();
 
-      expect(loadPresentation).toHaveBeenCalledTimes(2);
-    } finally {
-      backend.dispose();
-      session.dispose();
-    }
+    expect(loadPresentation).toHaveBeenCalledTimes(2);
   });
 
   it('serializes complete presentation reloads across rapid workspace moves', async () => {
-    const transcripts = await StreamLogStore.open();
-    const session = new SessionHandle({
-      transcripts,
-      restartRepair: 'deferred',
-    });
+    const session = await createLiveStoreSession();
     let finishFirstReload: ((replaced: boolean) => void) | undefined;
     const firstReload = new Promise<boolean>((resolve) => {
       finishFirstReload = resolve;
@@ -585,29 +556,20 @@ describe('ProgressBackend', () => {
       .mockResolvedValue(true);
     const { backend } = createIsolatedRecordingBackend(session);
 
-    try {
-      const first = backend.reloadAfterStorageRootChange();
-      const second = backend.reloadAfterStorageRootChange();
-      await Promise.resolve();
+    const first = backend.reloadAfterStorageRootChange();
+    const second = backend.reloadAfterStorageRootChange();
+    await Promise.resolve();
 
-      expect(reloadAfterStorageRootChange).toHaveBeenCalledOnce();
-      finishFirstReload?.(true);
-      await first;
-      await second;
+    expect(reloadAfterStorageRootChange).toHaveBeenCalledOnce();
+    finishFirstReload?.(true);
+    await first;
+    await second;
 
-      expect(reloadAfterStorageRootChange).toHaveBeenCalledTimes(2);
-    } finally {
-      backend.dispose();
-      session.dispose();
-    }
+    expect(reloadAfterStorageRootChange).toHaveBeenCalledTimes(2);
   });
 
   it('finishes the initial presentation load before a workspace move', async () => {
-    const transcripts = await StreamLogStore.open();
-    const session = new SessionHandle({
-      transcripts,
-      restartRepair: 'deferred',
-    });
+    const session = await createLiveStoreSession();
     vi.spyOn(session, 'waitUntilReady').mockResolvedValue();
     const reloadAfterStorageRootChange = vi
       .spyOn(session, 'reloadAfterStorageRootChange')
@@ -621,24 +583,19 @@ describe('ProgressBackend', () => {
       .mockReturnValueOnce(initialLoadBlocked)
       .mockResolvedValue();
 
-    try {
-      const initialLoad = backend.load();
-      await vi.waitFor(() => {
-        expect(backend.state.load).toHaveBeenCalledOnce();
-      });
-      const workspaceMove = backend.reloadAfterStorageRootChange();
-      await Promise.resolve();
+    const initialLoad = backend.load();
+    await vi.waitFor(() => {
+      expect(backend.state.load).toHaveBeenCalledOnce();
+    });
+    const workspaceMove = backend.reloadAfterStorageRootChange();
+    await Promise.resolve();
 
-      expect(reloadAfterStorageRootChange).not.toHaveBeenCalled();
-      finishInitialLoad?.();
-      await initialLoad;
-      await workspaceMove;
+    expect(reloadAfterStorageRootChange).not.toHaveBeenCalled();
+    finishInitialLoad?.();
+    await initialLoad;
+    await workspaceMove;
 
-      expect(reloadAfterStorageRootChange).toHaveBeenCalledOnce();
-    } finally {
-      backend.dispose();
-      session.dispose();
-    }
+    expect(reloadAfterStorageRootChange).toHaveBeenCalledOnce();
   });
 
   it('finishes a one-stream deletion before replacing the storage root', async () => {
@@ -698,123 +655,97 @@ describe('ProgressBackend', () => {
         bypassActive: true,
       },
     ]);
-
-    backend.dispose();
   });
 
   it('constructs the shared progress backend service graph', () => {
     const { backend } = createRecordingBackend();
 
     expect(backend.approvalHandlers).toBeDefined();
-
-    backend.dispose();
   });
 
   it('handles session facts through its local subscription', () => {
     const target = createIsolatedRecordingBackend();
     const { backend, session } = target;
-    const subscription = backend.setupEventListeners();
+    track(backend.setupEventListeners());
     const streamId = 'desktop-local-stream' as StreamTabId;
 
-    try {
-      emitActiveStream(target, {
-        streamId,
-        agentCategory: AgentCategory.Workflow,
-      });
+    emitActiveStream(target, {
+      streamId,
+      agentCategory: AgentCategory.Workflow,
+    });
 
-      expect(backend.state.activeStream).toBe(streamId);
-      expect(backend.state.streamLogs.has(streamId)).toBe(true);
-    } finally {
-      subscription.dispose();
-      backend.dispose();
-      session.dispose();
-    }
+    expect(backend.state.activeStream).toBe(streamId);
+    expect(backend.state.streamLogs.has(streamId)).toBe(true);
   });
 
   it('attaches snapshot events before run-fact projection', () => {
     const target = createIsolatedRecordingBackend();
-    const { backend, session } = target;
-    const subscription = backend.setupEventListeners();
+    const { backend } = target;
+    track(backend.setupEventListeners());
     const streamId = 'snapshot-before-projection' as StreamTabId;
 
-    try {
-      emitRunConfig(
-        target,
-        streamId,
-        'c40001' as ExecutionId,
-        toolUseTaskState('search', 'deepseekproT'),
-      );
+    emitRunConfig(
+      target,
+      streamId,
+      'c40001' as ExecutionId,
+      toolUseTaskState('search', 'deepseekproT'),
+    );
 
-      expect(backend.state.getStreamMetadata(streamId).run).toMatchObject({
-        kind: 'agent',
-        agent: 'search',
-        model: 'deepseekproT',
-      });
-    } finally {
-      subscription.dispose();
-      backend.dispose();
-      session.dispose();
-    }
+    expect(backend.state.getStreamMetadata(streamId).run).toMatchObject({
+      kind: 'agent',
+      agent: 'search',
+      model: 'deepseekproT',
+    });
   });
 
   it('applies active-stream facts before host navigation callbacks', () => {
-    const session = createTestSession();
+    const session = track(createTestSession());
     const streamId = 'fact-before-route' as StreamTabId;
     const onSetActiveStream = vi.fn(() => {
       throw new Error('closed renderer');
     });
-    const backend = new ProgressBackend({
-      storage: new FakeStateStore(),
-      session,
-      sendMessage: vi.fn(() => true),
-      hasTarget: () => true,
-      approvals: createApprovalOptions(),
-      lifecycle: createLifecycleOptions(),
-      onSetActiveStream,
-    });
-    const subscription = backend.setupEventListeners();
+    const backend = track(
+      new ProgressBackend({
+        storage: new FakeStateStore(),
+        session,
+        sendMessage: vi.fn(() => true),
+        hasTarget: () => true,
+        approvals: createApprovalOptions(),
+        lifecycle: createLifecycleOptions(),
+        onSetActiveStream,
+      }),
+    );
+    track(backend.setupEventListeners());
 
-    try {
-      emitActiveStream(
-        { session },
-        { streamId, agentCategory: AgentCategory.Workflow },
-      );
+    emitActiveStream(
+      { session },
+      { streamId, agentCategory: AgentCategory.Workflow },
+    );
 
-      expect(backend.state.activeStream).toBe(streamId);
-      expect(backend.state.streamLogs.has(streamId)).toBe(true);
-      expect(onSetActiveStream).toHaveBeenCalledOnce();
-    } finally {
-      subscription.dispose();
-      backend.dispose();
-      session.dispose();
-    }
+    expect(backend.state.activeStream).toBe(streamId);
+    expect(backend.state.streamLogs.has(streamId)).toBe(true);
+    expect(onSetActiveStream).toHaveBeenCalledOnce();
   });
 
   it('clears an empty active-stream selection through the shared fact path', async () => {
     const target = createIsolatedRecordingBackend();
-    const { backend, messages, session } = target;
-    const subscription = backend.setupEventListeners();
+    const { backend, messages } = target;
+    track(backend.setupEventListeners());
 
-    try {
-      backend.state.activeStream = 'previous-stream';
-      emitActiveStream(target, { streamId: null });
+    backend.state.activeStream = 'previous-stream';
+    emitActiveStream(target, { streamId: null });
 
-      await vi.waitFor(() => expect(backend.state.activeStream).toBe(''));
-      expect(messages).toContainEqual({
-        command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
-        activeStream: '',
-      });
-    } finally {
-      subscription.dispose();
-      backend.dispose();
-      session.dispose();
-    }
+    await vi.waitFor(() => expect(backend.state.activeStream).toBe(''));
+    expect(messages).toContainEqual({
+      command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+      activeStream: '',
+    });
   });
 
   it('projects goal-state changes through the shared fact path', async () => {
     const target = createIsolatedRecordingBackend();
     const { backend, messages, session } = target;
-    const subscription = backend.setupEventListeners();
+    track(backend.setupEventListeners());
     const stream = 'goal-projection' as StreamTabId;
 
     try {
@@ -835,9 +766,6 @@ describe('ProgressBackend', () => {
       );
     } finally {
       await GoalStore.forget(stream);
-      subscription.dispose();
-      backend.dispose();
-      session.dispose();
     }
   });
 
@@ -849,7 +777,7 @@ describe('ProgressBackend', () => {
         cleanupDeletedStream: (stream) => deletedStreams.push(stream),
       }),
     );
-    const subscription = backend.setupEventListeners();
+    track(backend.setupEventListeners());
     const streamId = 'desktop-child-stream' as StreamTabId;
 
     try {
@@ -865,66 +793,45 @@ describe('ProgressBackend', () => {
       expect(backend.state.streamLogs.has(streamId)).toBe(false);
       expect(backend.state.getStreamState(streamId)).toBeUndefined();
     } finally {
-      subscription.dispose();
       await backend.state.clearAll();
-      backend.dispose();
-      session.dispose();
     }
   });
 
   it('handles removeStream session facts before backend load', async () => {
     const { backend, session } = createIsolatedRecordingBackend();
     const clearStream = vi.spyOn(backend.state, 'clearStream');
-    const subscription = backend.setupEventListeners();
+    track(backend.setupEventListeners());
     const streamId = 'preload-child-stream' as StreamTabId;
 
-    try {
-      session.events.emit({
-        scope: 'session',
-        event: { type: 'removeStream', payload: { streamId } },
-      });
+    session.events.emit({
+      scope: 'session',
+      event: { type: 'removeStream', payload: { streamId } },
+    });
 
-      await vi.waitFor(() =>
-        expect(clearStream).toHaveBeenCalledWith(streamId),
-      );
-    } finally {
-      subscription.dispose();
-      backend.dispose();
-      session.dispose();
-    }
+    await vi.waitFor(() => expect(clearStream).toHaveBeenCalledWith(streamId));
   });
 
   it('refuses reserved stream identifiers before durable cleanup', async () => {
-    const { backend, session } = createIsolatedRecordingBackend();
+    const { backend } = createIsolatedRecordingBackend();
     const clearStream = vi.spyOn(backend.state, 'clearStream');
 
-    try {
-      await backend.deleteStream('' as StreamTabId);
-      await backend.deleteStream('.' as StreamTabId);
-      await backend.deleteStream('..' as StreamTabId);
+    await backend.deleteStream('' as StreamTabId);
+    await backend.deleteStream('.' as StreamTabId);
+    await backend.deleteStream('..' as StreamTabId);
 
-      expect(clearStream).not.toHaveBeenCalled();
-    } finally {
-      backend.dispose();
-      session.dispose();
-    }
+    expect(clearStream).not.toHaveBeenCalled();
   });
 
   it('clears retry UI when stopping without deleting', async () => {
-    const { backend, lifecycle, session } = createIsolatedRecordingBackend();
+    const { backend, lifecycle } = createIsolatedRecordingBackend();
     const stream = 'standalone-stop' as StreamTabId;
 
-    try {
-      await backend.stopStream(stream);
+    await backend.stopStream(stream);
 
-      expect(lifecycle.stopStream).toHaveBeenCalledWith(stream, {
-        clearRetryRequest: true,
-      });
-      expect(lifecycle.cleanupDeletedStream).not.toHaveBeenCalled();
-    } finally {
-      backend.dispose();
-      session.dispose();
-    }
+    expect(lifecycle.stopStream).toHaveBeenCalledWith(stream, {
+      clearRetryRequest: true,
+    });
+    expect(lifecycle.cleanupDeletedStream).not.toHaveBeenCalled();
   });
 
   it('waits for a terminal child lease after its handle is untracked', async () => {
@@ -956,39 +863,31 @@ describe('ProgressBackend', () => {
       expect(backend.state.streamLogs.has(stream)).toBe(false);
     } finally {
       releaseLease();
-      backend.dispose();
-      session.dispose();
     }
   });
 
   it('deletes an active stream and activates the next visible stream', async () => {
-    const { backend, lifecycle, messages, session } =
-      createIsolatedRecordingBackend();
+    const { backend, lifecycle, messages } = createIsolatedRecordingBackend();
     const first = 'first-visible' as StreamTabId;
     const second = 'second-visible' as StreamTabId;
 
-    try {
-      backend.state.streamLogs.ensureStream(first);
-      backend.state.streamLogs.ensureStream(second);
-      backend.state.activeStream = second;
+    backend.state.streamLogs.ensureStream(first);
+    backend.state.streamLogs.ensureStream(second);
+    backend.state.activeStream = second;
 
-      await backend.deleteStream(second);
+    await backend.deleteStream(second);
 
-      expect(lifecycle.cleanupDeletedStream).toHaveBeenCalledWith(second);
-      expect(lifecycle.activateStream).toHaveBeenCalledWith(first);
-      expect(messages).toContainEqual({
-        command: PROGRESS_VIEW_COMMANDS.DELETE_STREAM,
-        stream: second,
-      });
-    } finally {
-      backend.dispose();
-      session.dispose();
-    }
+    expect(lifecycle.cleanupDeletedStream).toHaveBeenCalledWith(second);
+    expect(lifecycle.activateStream).toHaveBeenCalledWith(first);
+    expect(messages).toContainEqual({
+      command: PROGRESS_VIEW_COMMANDS.DELETE_STREAM,
+      stream: second,
+    });
   });
 
   it('skips hidden fallbacks after deleting the active stream', async () => {
     const target = createIsolatedRecordingBackend();
-    const { backend, lifecycle, session } = target;
+    const { backend, lifecycle } = target;
     const active = 'active-workflow' as StreamTabId;
     const hidden = 'hidden-tool-use' as StreamTabId;
     const visible = 'visible-workflow' as StreamTabId;
@@ -997,69 +896,59 @@ describe('ProgressBackend', () => {
       'requestEviction',
     );
 
-    try {
-      // The unfiltered durable fallback selects the last stream (`hidden`),
-      // then the progress filter replaces it with `visible`.
-      for (const stream of [active, visible, hidden]) {
-        backend.state.streamLogs.ensureStream(stream);
-      }
-      backend.state.updateStreamMetadata(active, {
-        agentCategory: AgentCategory.Workflow,
-      });
-      backend.state.updateStreamMetadata(hidden, {
-        agentCategory: AgentCategory.ToolUse,
-      });
-      backend.state.updateStreamMetadata(visible, {
-        agentCategory: AgentCategory.Workflow,
-      });
-      backend.state.agentCategoryFilter = AgentCategory.Workflow;
-      backend.state.activeStream = active;
-
-      await backend.deleteStream(active);
-
-      expect(backend.state.activeStream).toBe(visible);
-      expect(lifecycle.activateStream).toHaveBeenCalledWith(visible);
-      expect(requestEviction).toHaveBeenCalledWith(hidden);
-    } finally {
-      backend.dispose();
-      session.dispose();
+    // The unfiltered durable fallback selects the last stream (`hidden`),
+    // then the progress filter replaces it with `visible`.
+    for (const stream of [active, visible, hidden]) {
+      backend.state.streamLogs.ensureStream(stream);
     }
+    backend.state.updateStreamMetadata(active, {
+      agentCategory: AgentCategory.Workflow,
+    });
+    backend.state.updateStreamMetadata(hidden, {
+      agentCategory: AgentCategory.ToolUse,
+    });
+    backend.state.updateStreamMetadata(visible, {
+      agentCategory: AgentCategory.Workflow,
+    });
+    backend.state.agentCategoryFilter = AgentCategory.Workflow;
+    backend.state.activeStream = active;
+
+    await backend.deleteStream(active);
+
+    expect(backend.state.activeStream).toBe(visible);
+    expect(lifecycle.activateStream).toHaveBeenCalledWith(visible);
+    expect(requestEviction).toHaveBeenCalledWith(hidden);
   });
 
   it('clears selection when deleting the last visible stream', async () => {
     const target = createIsolatedRecordingBackend();
-    const { backend, lifecycle, session } = target;
+    const { backend, lifecycle } = target;
     const active = 'active-workflow' as StreamTabId;
     const hidden = 'hidden-tool-use' as StreamTabId;
 
-    try {
-      backend.state.streamLogs.ensureStream(active);
-      backend.state.streamLogs.ensureStream(hidden);
-      backend.state.updateStreamMetadata(active, {
-        agentCategory: AgentCategory.Workflow,
-      });
-      backend.state.updateStreamMetadata(hidden, {
-        agentCategory: AgentCategory.ToolUse,
-      });
-      backend.state.agentCategoryFilter = AgentCategory.Workflow;
-      backend.state.activeStream = active;
+    backend.state.streamLogs.ensureStream(active);
+    backend.state.streamLogs.ensureStream(hidden);
+    backend.state.updateStreamMetadata(active, {
+      agentCategory: AgentCategory.Workflow,
+    });
+    backend.state.updateStreamMetadata(hidden, {
+      agentCategory: AgentCategory.ToolUse,
+    });
+    backend.state.agentCategoryFilter = AgentCategory.Workflow;
+    backend.state.activeStream = active;
 
-      await backend.deleteStream(active);
+    await backend.deleteStream(active);
 
-      expect(backend.state.activeStream).toBe('');
-      expect(lifecycle.activateStream).not.toHaveBeenCalled();
-      expect(
-        lifecycle.refreshRenderedStreamsAfterDeletion,
-      ).toHaveBeenCalledOnce();
-    } finally {
-      backend.dispose();
-      session.dispose();
-    }
+    expect(backend.state.activeStream).toBe('');
+    expect(lifecycle.activateStream).not.toHaveBeenCalled();
+    expect(
+      lifecycle.refreshRenderedStreamsAfterDeletion,
+    ).toHaveBeenCalledOnce();
   });
 
   it('preserves a stream switch during active-stream deletion', async () => {
     const target = createIsolatedRecordingBackend();
-    const { backend, lifecycle, session } = target;
+    const { backend, lifecycle } = target;
     const active = 'active-stream' as StreamTabId;
     const fallback = 'fallback-stream' as StreamTabId;
     const selected = 'selected-during-delete' as StreamTabId;
@@ -1075,28 +964,22 @@ describe('ProgressBackend', () => {
       },
     );
 
-    try {
-      for (const stream of [active, fallback, selected]) {
-        backend.state.streamLogs.ensureStream(stream);
-      }
-      backend.state.activeStream = active;
-
-      const deletion = backend.deleteStream(active);
-      backend.state.activeStream = selected;
-      releaseClear();
-      await deletion;
-
-      expect(backend.state.activeStream).toBe(selected);
-      expect(lifecycle.activateStream).toHaveBeenCalledWith(selected);
-    } finally {
-      backend.dispose();
-      session.dispose();
+    for (const stream of [active, fallback, selected]) {
+      backend.state.streamLogs.ensureStream(stream);
     }
+    backend.state.activeStream = active;
+
+    const deletion = backend.deleteStream(active);
+    backend.state.activeStream = selected;
+    releaseClear();
+    await deletion;
+
+    expect(backend.state.activeStream).toBe(selected);
+    expect(lifecycle.activateStream).toHaveBeenCalledWith(selected);
   });
 
   it('cleans every stream and emits one bulk deletion', async () => {
-    const { backend, lifecycle, messages, session } =
-      createIsolatedRecordingBackend();
+    const { backend, lifecycle, messages } = createIsolatedRecordingBackend();
     const first = 'bulk-first' as StreamTabId;
     const second = 'bulk-second' as StreamTabId;
     backend.state.streamLogs.ensureStream(first);
@@ -1106,25 +989,20 @@ describe('ProgressBackend', () => {
       failed: new Set(),
     });
 
-    try {
-      await backend.deleteAllStreams();
+    await backend.deleteAllStreams();
 
-      expect(lifecycle.cleanupDeletedStream).toHaveBeenCalledWith(first);
-      expect(lifecycle.cleanupDeletedStream).toHaveBeenCalledWith(second);
-      expect(lifecycle.cleanupDeletedStreams).toHaveBeenCalledWith({
-        allDeleted: true,
-      });
-      expect(messages).toContainEqual({
-        command: PROGRESS_VIEW_COMMANDS.DELETE_ALL,
-      });
-      expect(lifecycle.rebuildRenderedStreams).toHaveBeenCalledWith({
-        syncActiveStream: false,
-      });
-      expect(lifecycle.notifyDeletionRetained).not.toHaveBeenCalled();
-    } finally {
-      backend.dispose();
-      session.dispose();
-    }
+    expect(lifecycle.cleanupDeletedStream).toHaveBeenCalledWith(first);
+    expect(lifecycle.cleanupDeletedStream).toHaveBeenCalledWith(second);
+    expect(lifecycle.cleanupDeletedStreams).toHaveBeenCalledWith({
+      allDeleted: true,
+    });
+    expect(messages).toContainEqual({
+      command: PROGRESS_VIEW_COMMANDS.DELETE_ALL,
+    });
+    expect(lifecycle.rebuildRenderedStreams).toHaveBeenCalledWith({
+      syncActiveStream: false,
+    });
+    expect(lifecycle.notifyDeletionRetained).not.toHaveBeenCalled();
   });
 
   it('stops locally owned streams before bulk cleanup', async () => {
@@ -1154,17 +1032,12 @@ describe('ProgressBackend', () => {
       failed: new Set(),
     });
 
-    try {
-      await backend.deleteAllStreams();
+    await backend.deleteAllStreams();
 
-      expect(lifecycle.stopStream).toHaveBeenCalledWith(first);
-      expect(lifecycle.stopStream).toHaveBeenCalledWith(second);
-      expect(waitForRelease).toHaveBeenCalledWith(first);
-      expect(waitForRelease).toHaveBeenCalledWith(second);
-    } finally {
-      backend.dispose();
-      session.dispose();
-    }
+    expect(lifecycle.stopStream).toHaveBeenCalledWith(first);
+    expect(lifecycle.stopStream).toHaveBeenCalledWith(second);
+    expect(waitForRelease).toHaveBeenCalledWith(first);
+    expect(waitForRelease).toHaveBeenCalledWith(second);
   });
 
   it('aborts bulk cleanup when stopping an owned stream fails', async () => {
@@ -1192,23 +1065,17 @@ describe('ProgressBackend', () => {
     );
     const clearAll = vi.spyOn(backend.state, 'clearAll');
 
-    try {
-      await expect(backend.deleteAllStreams()).rejects.toBe(stopError);
+    await expect(backend.deleteAllStreams()).rejects.toBe(stopError);
 
-      expect(lifecycle.stopStream).toHaveBeenCalledWith(stream);
-      expect(waitForRelease).not.toHaveBeenCalled();
-      expect(clearAll).not.toHaveBeenCalled();
-      expect(lifecycle.cleanupDeletedStream).not.toHaveBeenCalled();
-      expect(lifecycle.cleanupDeletedStreams).not.toHaveBeenCalled();
-    } finally {
-      backend.dispose();
-      session.dispose();
-    }
+    expect(lifecycle.stopStream).toHaveBeenCalledWith(stream);
+    expect(waitForRelease).not.toHaveBeenCalled();
+    expect(clearAll).not.toHaveBeenCalled();
+    expect(lifecycle.cleanupDeletedStream).not.toHaveBeenCalled();
+    expect(lifecycle.cleanupDeletedStreams).not.toHaveBeenCalled();
   });
 
   it('retains protected streams during bulk cleanup', async () => {
-    const { backend, lifecycle, messages, session } =
-      createIsolatedRecordingBackend();
+    const { backend, lifecycle, messages } = createIsolatedRecordingBackend();
     const deleted = 'bulk-deleted' as StreamTabId;
     const retained = 'bulk-retained' as StreamTabId;
     backend.state.streamLogs.ensureStream(deleted);
@@ -1218,70 +1085,64 @@ describe('ProgressBackend', () => {
       failed: new Set(),
     });
 
-    try {
-      await backend.deleteAllStreams();
+    await backend.deleteAllStreams();
 
-      expect(lifecycle.cleanupDeletedStream).toHaveBeenCalledWith(deleted);
-      expect(lifecycle.cleanupDeletedStream).not.toHaveBeenCalledWith(retained);
-      expect(lifecycle.cleanupDeletedStreams).toHaveBeenCalledWith({
-        allDeleted: false,
-      });
-      expect(messages).toContainEqual({
-        command: PROGRESS_VIEW_COMMANDS.DELETE_STREAM,
-        stream: deleted,
-      });
-      expect(messages).not.toContainEqual({
-        command: PROGRESS_VIEW_COMMANDS.DELETE_ALL,
-      });
-      expect(lifecycle.rebuildRenderedStreams).toHaveBeenCalledWith({
-        syncActiveStream: true,
-      });
-      expect(lifecycle.notifyDeletionRetained).toHaveBeenCalledWith(1, 0);
-    } finally {
-      backend.dispose();
-      session.dispose();
-    }
+    expect(lifecycle.cleanupDeletedStream).toHaveBeenCalledWith(deleted);
+    expect(lifecycle.cleanupDeletedStream).not.toHaveBeenCalledWith(retained);
+    expect(lifecycle.cleanupDeletedStreams).toHaveBeenCalledWith({
+      allDeleted: false,
+    });
+    expect(messages).toContainEqual({
+      command: PROGRESS_VIEW_COMMANDS.DELETE_STREAM,
+      stream: deleted,
+    });
+    expect(messages).not.toContainEqual({
+      command: PROGRESS_VIEW_COMMANDS.DELETE_ALL,
+    });
+    expect(lifecycle.rebuildRenderedStreams).toHaveBeenCalledWith({
+      syncActiveStream: true,
+    });
+    expect(lifecycle.notifyDeletionRetained).toHaveBeenCalledWith(1, 0);
   });
 
   it('retains rendered state when durable stream cleanup fails', async () => {
-    const session = createTestSession();
+    const session = track(createTestSession());
     const lifecycle = createLifecycleOptions();
-    const backend = new ProgressBackend({
-      storage: new FakeStateStore(),
-      session,
-      sendMessage: vi.fn(),
-      hasTarget: () => true,
-      approvals: createApprovalOptions(),
-      lifecycle,
-    });
+    const backend = track(
+      new ProgressBackend({
+        storage: new FakeStateStore(),
+        session,
+        sendMessage: vi.fn(),
+        hasTarget: () => true,
+        approvals: createApprovalOptions(),
+        lifecycle,
+      }),
+    );
     const stream = 'retained-stream' as StreamTabId;
     backend.state.streamLogs.ensureStream(stream);
     vi.spyOn(backend.state, 'clearStream').mockResolvedValueOnce('failed');
 
-    try {
-      await backend.deleteStream(stream);
+    await backend.deleteStream(stream);
 
-      expect(lifecycle.cleanupDeletedStream).not.toHaveBeenCalled();
-      expect(lifecycle.rebuildRenderedStreams).toHaveBeenCalledWith({
-        syncActiveStream: true,
-      });
-      expect(lifecycle.notifyDeletionRetained).toHaveBeenCalledWith(0, 1);
-    } finally {
-      backend.dispose();
-      session.dispose();
-    }
+    expect(lifecycle.cleanupDeletedStream).not.toHaveBeenCalled();
+    expect(lifecycle.rebuildRenderedStreams).toHaveBeenCalledWith({
+      syncActiveStream: true,
+    });
+    expect(lifecycle.notifyDeletionRetained).toHaveBeenCalledWith(0, 1);
   });
 
   it('uses the injected target predicate before sending messages', () => {
     const sent = vi.fn(() => true);
     let hasTarget = false;
-    const backend = new ProgressBackend({
-      storage: new FakeStateStore(),
-      sendMessage: sent,
-      hasTarget: () => hasTarget,
-      approvals: createApprovalOptions(),
-      lifecycle: createLifecycleOptions(),
-    });
+    const backend = track(
+      new ProgressBackend({
+        storage: new FakeStateStore(),
+        sendMessage: sent,
+        hasTarget: () => hasTarget,
+        approvals: createApprovalOptions(),
+        lifecycle: createLifecycleOptions(),
+      }),
+    );
 
     backend.webviewUpdater.updateStreams([], '', 'all');
     expect(sent).not.toHaveBeenCalled();
@@ -1295,8 +1156,6 @@ describe('ProgressBackend', () => {
       agentFilter: 'all',
       streamStates: undefined,
     });
-
-    backend.dispose();
   });
 
   it('contains updater transport failures', async () => {
@@ -1307,13 +1166,15 @@ describe('ProgressBackend', () => {
       })
       .mockRejectedValueOnce(new Error('closed transport'));
 
-    const backend = new ProgressBackend({
-      storage: new FakeStateStore(),
-      sendMessage: sent,
-      hasTarget: () => true,
-      approvals: createApprovalOptions(),
-      lifecycle: createLifecycleOptions(),
-    });
+    const backend = track(
+      new ProgressBackend({
+        storage: new FakeStateStore(),
+        sendMessage: sent,
+        hasTarget: () => true,
+        approvals: createApprovalOptions(),
+        lifecycle: createLifecycleOptions(),
+      }),
+    );
 
     expect(() =>
       backend.webviewUpdater.updateStreams([], '', 'all'),
@@ -1322,8 +1183,6 @@ describe('ProgressBackend', () => {
     await Promise.resolve();
 
     expect(sent).toHaveBeenCalledTimes(2);
-
-    backend.dispose();
   });
 
   it('sends the full metadata set once for full-view sync', () => {
@@ -1358,263 +1217,232 @@ describe('ProgressBackend', () => {
     } else {
       throw new Error('Expected full stream metadata sync');
     }
-
-    backend.dispose();
   });
 
   it('keeps a filtered interaction stream reachable without switching', async () => {
     const target = createIsolatedRecordingBackend();
     const { backend, messages } = target;
-    const subscription = backend.setupEventListeners();
+    track(backend.setupEventListeners());
 
-    try {
-      emitActiveStream(target, {
-        streamId: 'root',
-        agentCategory: AgentCategory.Workflow,
-      });
-      await vi.waitFor(() => expect(backend.state.activeStream).toBe('root'));
-      backend.state.agentCategoryFilter = AgentCategory.Workflow;
-      messages.length = 0;
+    emitActiveStream(target, {
+      streamId: 'root',
+      agentCategory: AgentCategory.Workflow,
+    });
+    await vi.waitFor(() => expect(backend.state.activeStream).toBe('root'));
+    backend.state.agentCategoryFilter = AgentCategory.Workflow;
+    messages.length = 0;
 
-      emitActiveStream(target, {
-        streamId: 'hidden-approval',
-        agentCategory: AgentCategory.ToolUse,
-        suppressViewSwitch: true,
-        ensureVisible: true,
-      });
+    emitActiveStream(target, {
+      streamId: 'hidden-approval',
+      agentCategory: AgentCategory.ToolUse,
+      suppressViewSwitch: true,
+      ensureVisible: true,
+    });
 
-      await vi.waitFor(() =>
-        expect(backend.state.agentCategoryFilter).toBe('all'),
-      );
-      expect(backend.state.activeStream).toBe('root');
-      expect(messages).toContainEqual(
-        expect.objectContaining({
-          command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
-          activeStream: 'root',
-          agentFilter: 'all',
-          streams: expect.arrayContaining([
-            expect.objectContaining({ name: 'hidden-approval' }),
-          ]),
-        }),
-      );
-    } finally {
-      subscription.dispose();
-      backend.dispose();
-    }
+    await vi.waitFor(() =>
+      expect(backend.state.agentCategoryFilter).toBe('all'),
+    );
+    expect(backend.state.activeStream).toBe('root');
+    expect(messages).toContainEqual(
+      expect.objectContaining({
+        command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+        activeStream: 'root',
+        agentFilter: 'all',
+        streams: expect.arrayContaining([
+          expect.objectContaining({ name: 'hidden-approval' }),
+        ]),
+      }),
+    );
   });
 
   it('projects a workflow-script phase onto a non-active run stream', async () => {
     const target = createIsolatedRecordingBackend();
     const { backend, messages } = target;
-    const subscription = backend.setupEventListeners();
+    track(backend.setupEventListeners());
     const run = 'workflow-run' as StreamTabId;
 
-    try {
-      emitActiveStream(target, {
-        streamId: 'root',
-        agentCategory: AgentCategory.ToolUse,
-      });
-      await vi.waitFor(() => expect(backend.state.activeStream).toBe('root'));
-      emitActiveStream(target, {
-        streamId: run,
-        agentCategory: AgentCategory.Workflow,
-        suppressViewSwitch: true,
-      });
-      await vi.waitFor(() =>
-        expect(backend.state.getStreamState(run)).toBeDefined(),
-      );
-      messages.length = 0;
+    emitActiveStream(target, {
+      streamId: 'root',
+      agentCategory: AgentCategory.ToolUse,
+    });
+    await vi.waitFor(() => expect(backend.state.activeStream).toBe('root'));
+    emitActiveStream(target, {
+      streamId: run,
+      agentCategory: AgentCategory.Workflow,
+      suppressViewSwitch: true,
+    });
+    await vi.waitFor(() =>
+      expect(backend.state.getStreamState(run)).toBeDefined(),
+    );
+    messages.length = 0;
 
-      emitRunEvent(target, run, {
-        type: 'stage.start',
-        id: 'phase-2',
-        label: 'Reduce',
-        kind: 'phase',
-        index: 1,
-        total: 3,
-      });
+    emitRunEvent(target, run, {
+      type: 'stage.start',
+      id: 'phase-2',
+      label: 'Reduce',
+      kind: 'phase',
+      index: 1,
+      total: 3,
+    });
 
-      // The parent's viewport reads this row, so the push must reach a stream
-      // that is not the active one.
-      expect(backend.state.activeStream).toBe('root');
-      await vi.waitFor(() =>
-        expect(backend.state.getStreamState(run)).toMatchObject({
-          phaseStage: { label: 'Reduce', index: 1, total: 3 },
-        }),
-      );
-      const patch = messages.find(
-        (message) =>
-          message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA &&
-          message.streamInfo.name === run,
-      );
-      if (patch?.command !== PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA) {
-        throw new Error('Expected a metadata patch for the run stream');
-      }
-      expect(patch.streamState).toMatchObject({
+    // The parent's viewport reads this row, so the push must reach a stream
+    // that is not the active one.
+    expect(backend.state.activeStream).toBe('root');
+    await vi.waitFor(() =>
+      expect(backend.state.getStreamState(run)).toMatchObject({
         phaseStage: { label: 'Reduce', index: 1, total: 3 },
-        roundStage: null,
-      });
-    } finally {
-      subscription.dispose();
-      backend.dispose();
-      target.session.dispose();
+      }),
+    );
+    const patch = messages.find(
+      (message) =>
+        message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA &&
+        message.streamInfo.name === run,
+    );
+    if (patch?.command !== PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA) {
+      throw new Error('Expected a metadata patch for the run stream');
     }
+    expect(patch.streamState).toMatchObject({
+      phaseStage: { label: 'Reduce', index: 1, total: 3 },
+      roundStage: null,
+    });
   });
 
   it('patches one stream for subagent registration and run-start metadata', async () => {
     const target = createIsolatedRecordingBackend();
-    const { backend, messages, session } = target;
-    const subscription = backend.setupEventListeners();
+    const { backend, messages } = target;
+    track(backend.setupEventListeners());
 
-    try {
-      for (let i = 0; i < 20; i += 1) {
-        backend.state.streamLogs.ensureStream(`history-${i}`);
-      }
+    for (let i = 0; i < 20; i += 1) {
+      backend.state.streamLogs.ensureStream(`history-${i}`);
+    }
 
-      emitActiveStream(target, {
-        streamId: 'root',
-        agentCategory: AgentCategory.Workflow,
-      });
-      await vi.waitFor(() =>
-        expect(
-          messages.some(
-            (message) =>
-              message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA,
-          ),
-        ).toBe(true),
-      );
-      messages.length = 0;
-
-      emitActiveStream(target, {
-        streamId: 'child',
-        agentCategory: AgentCategory.ToolUse,
-        suppressViewSwitch: true,
-      });
-      await vi.waitFor(() =>
-        expect(
-          messages.find(
-            (message) =>
-              message.command ===
-                PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA &&
-              message.streamInfo.name === 'child',
-          ),
-        ).toBeDefined(),
-      );
+    emitActiveStream(target, {
+      streamId: 'root',
+      agentCategory: AgentCategory.Workflow,
+    });
+    await vi.waitFor(() =>
       expect(
         messages.some(
           (message) =>
-            message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+            message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA,
         ),
-      ).toBe(false);
-      messages.length = 0;
+      ).toBe(true),
+    );
+    messages.length = 0;
 
-      emitRunConfig(
-        target,
-        'child' as StreamTabId,
-        'c41111' as ExecutionId,
-        toolUseTaskState('search', 'deepseekproT'),
-      );
-
-      await vi.waitFor(() =>
-        expect(
-          messages.find(
-            (message) =>
-              message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA,
-          ),
-        ).toMatchObject({
-          streamInfo: {
-            name: 'child',
-            label: 'search',
-            agent: 'search',
-            model: 'deepseekproT',
-            executionId: 'c41111',
-          },
-        }),
-      );
+    emitActiveStream(target, {
+      streamId: 'child',
+      agentCategory: AgentCategory.ToolUse,
+      suppressViewSwitch: true,
+    });
+    await vi.waitFor(() =>
       expect(
-        messages.some(
+        messages.find(
           (message) =>
-            message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+            message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA &&
+            message.streamInfo.name === 'child',
         ),
-      ).toBe(false);
-
-      const patch = messages.find(
-        (message) =>
-          message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA,
-      );
-      messages.length = 0;
-
-      backend.webviewUpdater.sendStreamMetadata(
-        backend.state,
-        backend.factApplier.getAllStreamStates(),
-      );
-      const fullSync = messages.find(
+      ).toBeDefined(),
+    );
+    expect(
+      messages.some(
         (message) => message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
-      );
+      ),
+    ).toBe(false);
+    messages.length = 0;
 
-      if (
-        patch?.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA &&
-        fullSync?.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS
-      ) {
-        expect(
-          fullSync.streams.find((stream) => stream.name === 'child'),
-        ).toEqual(patch.streamInfo);
-        expect(fullSync.streamStates?.child).toEqual(patch.streamState);
-      } else {
-        throw new Error('Expected patch and full sync messages');
-      }
-    } finally {
-      subscription.dispose();
-      backend.dispose();
-      session.dispose();
+    emitRunConfig(
+      target,
+      'child' as StreamTabId,
+      'c41111' as ExecutionId,
+      toolUseTaskState('search', 'deepseekproT'),
+    );
+
+    await vi.waitFor(() =>
+      expect(
+        messages.find(
+          (message) =>
+            message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA,
+        ),
+      ).toMatchObject({
+        streamInfo: {
+          name: 'child',
+          label: 'search',
+          agent: 'search',
+          model: 'deepseekproT',
+          executionId: 'c41111',
+        },
+      }),
+    );
+    expect(
+      messages.some(
+        (message) => message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+      ),
+    ).toBe(false);
+
+    const patch = messages.find(
+      (message) =>
+        message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA,
+    );
+    messages.length = 0;
+
+    backend.webviewUpdater.sendStreamMetadata(
+      backend.state,
+      backend.factApplier.getAllStreamStates(),
+    );
+    const fullSync = messages.find(
+      (message) => message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+    );
+
+    if (
+      patch?.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA &&
+      fullSync?.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS
+    ) {
+      expect(
+        fullSync.streams.find((stream) => stream.name === 'child'),
+      ).toEqual(patch.streamInfo);
+      expect(fullSync.streamStates?.child).toEqual(patch.streamState);
+    } else {
+      throw new Error('Expected patch and full sync messages');
     }
   });
 
   it('scopes direct session events to each backend session', async () => {
     const first = createIsolatedRecordingBackend();
     const second = createIsolatedRecordingBackend();
-    const firstSubscription = first.backend.setupEventListeners();
-    const secondSubscription = second.backend.setupEventListeners();
+    track(first.backend.setupEventListeners());
+    track(second.backend.setupEventListeners());
     const firstStream = 'session:first' as StreamTabId;
     const secondStream = 'session:second' as StreamTabId;
 
-    try {
-      emitActiveStream(first, {
-        streamId: firstStream,
-        agentCategory: AgentCategory.Workflow,
-      });
+    emitActiveStream(first, {
+      streamId: firstStream,
+      agentCategory: AgentCategory.Workflow,
+    });
 
-      await vi.waitFor(() =>
-        expect(first.backend.state.activeStream).toBe(firstStream),
-      );
-      expect(second.backend.state.activeStream).not.toBe(firstStream);
-      expect(JSON.stringify(second.messages)).not.toContain(firstStream);
+    await vi.waitFor(() =>
+      expect(first.backend.state.activeStream).toBe(firstStream),
+    );
+    expect(second.backend.state.activeStream).not.toBe(firstStream);
+    expect(JSON.stringify(second.messages)).not.toContain(firstStream);
 
-      emitActiveStream(second, {
-        streamId: secondStream,
-        agentCategory: AgentCategory.ToolUse,
-      });
+    emitActiveStream(second, {
+      streamId: secondStream,
+      agentCategory: AgentCategory.ToolUse,
+    });
 
-      await vi.waitFor(() =>
-        expect(second.backend.state.activeStream).toBe(secondStream),
-      );
-      expect(first.backend.state.activeStream).toBe(firstStream);
-      expect(JSON.stringify(first.messages)).not.toContain(secondStream);
-    } finally {
-      firstSubscription.dispose();
-      secondSubscription.dispose();
-      first.backend.dispose();
-      second.backend.dispose();
-      first.session.dispose();
-      second.session.dispose();
-    }
+    await vi.waitFor(() =>
+      expect(second.backend.state.activeStream).toBe(secondStream),
+    );
+    expect(first.backend.state.activeStream).toBe(firstStream);
+    expect(JSON.stringify(first.messages)).not.toContain(secondStream);
   });
 
   it('isolates same-stream run facts across simultaneous backend sessions', async () => {
     const first = createIsolatedRecordingBackend();
     const second = createIsolatedRecordingBackend();
-    const firstSubscription = first.backend.setupEventListeners();
-    const secondSubscription = second.backend.setupEventListeners();
+    track(first.backend.setupEventListeners());
+    track(second.backend.setupEventListeners());
     const streamId = 'window:shared-stream-id' as StreamTabId;
     const firstTodo: TodoItem = {
       content: 'from first window',
@@ -1638,198 +1466,170 @@ describe('ProgressBackend', () => {
       diff: null,
     };
 
-    try {
-      await first.backend.state.snapshots.load([]);
-      await second.backend.state.snapshots.load([]);
+    await first.backend.state.snapshots.load([]);
+    await second.backend.state.snapshots.load([]);
 
-      emitRunEvent(first, streamId, {
-        type: 'updateTodos',
-        streamId,
-        todos: [firstTodo],
-      });
-      emitRunEvent(first, streamId, {
-        type: 'addOutputFiles',
-        streamId,
-        filesByRound: { 1: [firstOutput] },
-      });
+    emitRunEvent(first, streamId, {
+      type: 'updateTodos',
+      streamId,
+      todos: [firstTodo],
+    });
+    emitRunEvent(first, streamId, {
+      type: 'addOutputFiles',
+      streamId,
+      filesByRound: { 1: [firstOutput] },
+    });
 
-      expect(first.backend.state.snapshots.getWorkPlan(streamId).todos).toEqual(
-        [firstTodo],
-      );
-      expect(first.backend.state.snapshots.getOutputFiles(streamId)).toEqual({
-        1: [firstOutput],
-      });
-      expect(
-        second.backend.state.snapshots.getWorkPlan(streamId).todos,
-      ).toEqual([]);
-      expect(second.backend.state.snapshots.getOutputFiles(streamId)).toEqual(
-        {},
-      );
-      expect(JSON.stringify(second.messages)).not.toContain(
-        'from first window',
-      );
-      expect(JSON.stringify(second.messages)).not.toContain('first.pdf');
+    expect(first.backend.state.snapshots.getWorkPlan(streamId).todos).toEqual([
+      firstTodo,
+    ]);
+    expect(first.backend.state.snapshots.getOutputFiles(streamId)).toEqual({
+      1: [firstOutput],
+    });
+    expect(second.backend.state.snapshots.getWorkPlan(streamId).todos).toEqual(
+      [],
+    );
+    expect(second.backend.state.snapshots.getOutputFiles(streamId)).toEqual({});
+    expect(JSON.stringify(second.messages)).not.toContain('from first window');
+    expect(JSON.stringify(second.messages)).not.toContain('first.pdf');
 
-      emitRunEvent(second, streamId, {
-        type: 'updateTodos',
-        streamId,
-        todos: [secondTodo],
-      });
+    emitRunEvent(second, streamId, {
+      type: 'updateTodos',
+      streamId,
+      todos: [secondTodo],
+    });
 
-      expect(first.backend.state.snapshots.getWorkPlan(streamId).todos).toEqual(
-        [firstTodo],
-      );
-      expect(
-        second.backend.state.snapshots.getWorkPlan(streamId).todos,
-      ).toEqual([secondTodo]);
-      expect(JSON.stringify(first.messages)).not.toContain(
-        'from second window',
-      );
-    } finally {
-      firstSubscription.dispose();
-      secondSubscription.dispose();
-      first.backend.dispose();
-      second.backend.dispose();
-      first.session.dispose();
-      second.session.dispose();
-    }
+    expect(first.backend.state.snapshots.getWorkPlan(streamId).todos).toEqual([
+      firstTodo,
+    ]);
+    expect(second.backend.state.snapshots.getWorkPlan(streamId).todos).toEqual([
+      secondTodo,
+    ]);
+    expect(JSON.stringify(first.messages)).not.toContain('from second window');
   });
 
   it('isolates simultaneous window sessions across view state, status, snapshots, and transcripts', async () => {
     const first = createIsolatedRecordingBackend();
     const second = createIsolatedRecordingBackend();
-    const firstSubscription = first.backend.setupEventListeners();
-    const secondSubscription = second.backend.setupEventListeners();
+    track(first.backend.setupEventListeners());
+    track(second.backend.setupEventListeners());
     const firstStream = 'window:first' as StreamTabId;
     const secondStream = 'window:second' as StreamTabId;
     const firstExecution = 'f41111' as ExecutionId;
     const secondExecution = 'f42222' as ExecutionId;
 
-    try {
-      await first.backend.state.snapshots.load([]);
-      await second.backend.state.snapshots.load([]);
+    await first.backend.state.snapshots.load([]);
+    await second.backend.state.snapshots.load([]);
 
-      emitActiveStream(first, {
-        streamId: firstStream,
-        agentCategory: AgentCategory.ToolUse,
-      });
-      emitActiveStream(second, {
-        streamId: secondStream,
-        agentCategory: AgentCategory.Workflow,
-      });
+    emitActiveStream(first, {
+      streamId: firstStream,
+      agentCategory: AgentCategory.ToolUse,
+    });
+    emitActiveStream(second, {
+      streamId: secondStream,
+      agentCategory: AgentCategory.Workflow,
+    });
 
-      emitRunConfig(
-        first,
-        firstStream,
-        firstExecution,
-        toolUseTaskState('search', 'deepseekproT'),
-      );
-      emitRunConfig(
-        second,
-        secondStream,
-        secondExecution,
-        toolUseTaskState('revise', 'gpt-4o'),
-      );
-      first.session.status.transition(
-        firstStream,
-        STREAM_PHASE.RUNNING,
-        'lifecycle',
-      );
-      second.session.status.transition(
-        secondStream,
-        STREAM_PHASE.RUNNING,
-        'lifecycle',
-      );
-      second.session.status.transitionToWaiting(secondStream, 'wait');
-      emitStreamDescription(first, {
-        streamId: firstStream,
-        description: 'first window run',
-      });
-      emitStreamDescription(second, {
-        streamId: secondStream,
-        description: 'second window run',
-      });
-      first.backend.state.streamLogs.append(firstStream, {
-        id: 'first-window-log',
-        type: STREAM_LOG_ENTRY_TYPES.LOG,
-        level: LOG_LEVELS.INFO,
-        timestamp: 1_700_000_000_001,
-        messageType: MESSAGE_TYPES.DEFAULT,
-        text: 'first transcript entry',
-      });
-      second.backend.state.streamLogs.append(secondStream, {
-        id: 'second-window-log',
-        type: STREAM_LOG_ENTRY_TYPES.LOG,
-        level: LOG_LEVELS.INFO,
-        timestamp: 1_700_000_000_002,
-        messageType: MESSAGE_TYPES.DEFAULT,
-        text: 'second transcript entry',
-      });
+    emitRunConfig(
+      first,
+      firstStream,
+      firstExecution,
+      toolUseTaskState('search', 'deepseekproT'),
+    );
+    emitRunConfig(
+      second,
+      secondStream,
+      secondExecution,
+      toolUseTaskState('revise', 'gpt-4o'),
+    );
+    first.session.status.transition(
+      firstStream,
+      STREAM_PHASE.RUNNING,
+      'lifecycle',
+    );
+    second.session.status.transition(
+      secondStream,
+      STREAM_PHASE.RUNNING,
+      'lifecycle',
+    );
+    second.session.status.transitionToWaiting(secondStream, 'wait');
+    emitStreamDescription(first, {
+      streamId: firstStream,
+      description: 'first window run',
+    });
+    emitStreamDescription(second, {
+      streamId: secondStream,
+      description: 'second window run',
+    });
+    first.backend.state.streamLogs.append(firstStream, {
+      id: 'first-window-log',
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: LOG_LEVELS.INFO,
+      timestamp: 1_700_000_000_001,
+      messageType: MESSAGE_TYPES.DEFAULT,
+      text: 'first transcript entry',
+    });
+    second.backend.state.streamLogs.append(secondStream, {
+      id: 'second-window-log',
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: LOG_LEVELS.INFO,
+      timestamp: 1_700_000_000_002,
+      messageType: MESSAGE_TYPES.DEFAULT,
+      text: 'second transcript entry',
+    });
 
-      await vi.waitFor(() =>
-        expect(first.backend.state.activeStream).toBe(firstStream),
-      );
-      await vi.waitFor(() =>
-        expect(second.backend.state.activeStream).toBe(secondStream),
-      );
+    await vi.waitFor(() =>
+      expect(first.backend.state.activeStream).toBe(firstStream),
+    );
+    await vi.waitFor(() =>
+      expect(second.backend.state.activeStream).toBe(secondStream),
+    );
 
-      expect(first.backend.state.streamStatus.get(firstStream)).toBe(
-        STREAM_PHASE.RUNNING,
-      );
-      expect(
-        first.backend.state.streamStatus.get(secondStream),
-      ).toBeUndefined();
-      expect(second.backend.state.streamStatus.get(secondStream)).toBe(
-        STREAM_PHASE.WAITING,
-      );
-      expect(
-        second.backend.state.streamStatus.get(firstStream),
-      ).toBeUndefined();
+    expect(first.backend.state.streamStatus.get(firstStream)).toBe(
+      STREAM_PHASE.RUNNING,
+    );
+    expect(first.backend.state.streamStatus.get(secondStream)).toBeUndefined();
+    expect(second.backend.state.streamStatus.get(secondStream)).toBe(
+      STREAM_PHASE.WAITING,
+    );
+    expect(second.backend.state.streamStatus.get(firstStream)).toBeUndefined();
 
-      expect(first.backend.state.snapshots.getExecutionId(firstStream)).toBe(
-        firstExecution,
-      );
-      expect(
-        first.backend.state.snapshots.getExecutionId(secondStream),
-      ).toBeUndefined();
-      expect(second.backend.state.snapshots.getExecutionId(secondStream)).toBe(
-        secondExecution,
-      );
-      expect(
-        second.backend.state.snapshots.getExecutionId(firstStream),
-      ).toBeUndefined();
-      expect(first.backend.state.snapshots.getDescription(firstStream)).toBe(
-        'first window run',
-      );
-      expect(
-        first.backend.state.snapshots.getDescription(secondStream),
-      ).toBeUndefined();
-      expect(second.backend.state.snapshots.getDescription(secondStream)).toBe(
-        'second window run',
-      );
-      expect(
-        second.backend.state.snapshots.getDescription(firstStream),
-      ).toBeUndefined();
+    expect(first.backend.state.snapshots.getExecutionId(firstStream)).toBe(
+      firstExecution,
+    );
+    expect(
+      first.backend.state.snapshots.getExecutionId(secondStream),
+    ).toBeUndefined();
+    expect(second.backend.state.snapshots.getExecutionId(secondStream)).toBe(
+      secondExecution,
+    );
+    expect(
+      second.backend.state.snapshots.getExecutionId(firstStream),
+    ).toBeUndefined();
+    expect(first.backend.state.snapshots.getDescription(firstStream)).toBe(
+      'first window run',
+    );
+    expect(
+      first.backend.state.snapshots.getDescription(secondStream),
+    ).toBeUndefined();
+    expect(second.backend.state.snapshots.getDescription(secondStream)).toBe(
+      'second window run',
+    );
+    expect(
+      second.backend.state.snapshots.getDescription(firstStream),
+    ).toBeUndefined();
 
-      expect(first.backend.state.streamLogs.get(firstStream)?.size).toBe(1);
-      expect(first.backend.state.streamLogs.get(secondStream)).toBeUndefined();
-      expect(second.backend.state.streamLogs.get(secondStream)?.size).toBe(1);
-      expect(second.backend.state.streamLogs.get(firstStream)).toBeUndefined();
-      expect(JSON.stringify(first.messages)).not.toContain(secondStream);
-      expect(JSON.stringify(second.messages)).not.toContain(firstStream);
-    } finally {
-      firstSubscription.dispose();
-      secondSubscription.dispose();
-      first.backend.dispose();
-      second.backend.dispose();
-      first.session.dispose();
-      second.session.dispose();
-    }
+    expect(first.backend.state.streamLogs.get(firstStream)?.size).toBe(1);
+    expect(first.backend.state.streamLogs.get(secondStream)).toBeUndefined();
+    expect(second.backend.state.streamLogs.get(secondStream)?.size).toBe(1);
+    expect(second.backend.state.streamLogs.get(firstStream)).toBeUndefined();
+    expect(JSON.stringify(first.messages)).not.toContain(secondStream);
+    expect(JSON.stringify(second.messages)).not.toContain(firstStream);
   });
 
   it('applies session run facts through the fact-native handler', async () => {
     const { backend, session } = createIsolatedRecordingBackend();
-    const subscription = backend.setupEventListeners();
+    track(backend.setupEventListeners());
     const handleRunFact = vi.spyOn(backend.factApplier, 'handleRunFact');
     const updateFiles = vi.spyOn(backend.webviewUpdater, 'updateFiles');
     const updateMissingOutputs = vi.spyOn(
@@ -1992,16 +1792,13 @@ describe('ProgressBackend', () => {
         ]),
       );
     } finally {
-      subscription.dispose();
       await backend.state.clearAll();
-      backend.dispose();
-      session.dispose();
     }
   });
 
   it('drops malformed updateTodos/updatePlan run facts instead of forwarding them unchecked (#7562)', async () => {
     const { backend, session } = createIsolatedRecordingBackend();
-    const subscription = backend.setupEventListeners();
+    track(backend.setupEventListeners());
     const updateTodos = vi.spyOn(backend.webviewUpdater, 'updateTodos');
     const updatePlan = vi.spyOn(backend.webviewUpdater, 'updatePlan');
     const streamId = 'session:malformed-todos-plan' as StreamTabId;
@@ -2032,16 +1829,13 @@ describe('ProgressBackend', () => {
       expect(updateTodos).not.toHaveBeenCalled();
       expect(updatePlan).not.toHaveBeenCalled();
     } finally {
-      subscription.dispose();
       await backend.state.clearAll();
-      backend.dispose();
-      session.dispose();
     }
   });
 
   it('no-ops session output-file run facts after dispose', async () => {
     const { backend, session } = createIsolatedRecordingBackend();
-    const subscription = backend.setupEventListeners();
+    track(backend.setupEventListeners());
     const handleRunFact = vi.spyOn(backend.factApplier, 'handleRunFact');
     const updateFiles = vi.spyOn(backend.webviewUpdater, 'updateFiles');
     const streamId = 'session:output-files-after-dispose' as StreamTabId;
@@ -2088,16 +1882,13 @@ describe('ProgressBackend', () => {
         1: [outputFile],
       });
     } finally {
-      subscription.dispose();
       await backend.state.clearAll();
-      backend.dispose();
-      session.dispose();
     }
   });
 
   it('handles session facts directly', async () => {
     const target = createIsolatedRecordingBackend();
-    const subscription = target.backend.setupEventListeners();
+    track(target.backend.setupEventListeners());
     const parentStreamId = 'session:parent' as StreamTabId;
     const childStreamId = 'session:child' as StreamTabId;
     const executionId = 'exec:direct-session' as ExecutionId;
@@ -2216,119 +2007,103 @@ describe('ProgressBackend', () => {
         ),
       ).toBe(true);
     } finally {
-      subscription.dispose();
       await target.backend.state.clearAll();
-      target.backend.dispose();
-      target.session.dispose();
     }
   });
 
   it('does not switch category filters for unknown-category status streams', async () => {
     const { backend, messages } = createRecordingBackend();
 
-    try {
-      backend.state.streamLogs.ensureStream('tool-stream');
-      backend.state.updateStreamMetadata('tool-stream', {
-        agentCategory: AgentCategory.ToolUse,
-      });
-      backend.state.getOrCreateStreamState(
-        'tool-stream',
-        AgentCategory.ToolUse,
-      );
-      backend.state.activeStream = 'tool-stream';
-      backend.state.agentCategoryFilter = 'toolUse';
+    backend.state.streamLogs.ensureStream('tool-stream');
+    backend.state.updateStreamMetadata('tool-stream', {
+      agentCategory: AgentCategory.ToolUse,
+    });
+    backend.state.getOrCreateStreamState('tool-stream', AgentCategory.ToolUse);
+    backend.state.activeStream = 'tool-stream';
+    backend.state.agentCategoryFilter = 'toolUse';
 
-      await backend.factApplier.setStreamStatus(
-        'unknown-stream',
-        STREAM_PHASE.RUNNING,
-      );
+    await backend.factApplier.setStreamStatus(
+      'unknown-stream',
+      STREAM_PHASE.RUNNING,
+    );
 
-      const patch = messages.find(
-        (message) =>
-          message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA &&
-          message.streamInfo.name === 'unknown-stream',
-      );
-      expect(backend.state.agentCategoryFilter).toBe('toolUse');
-      expect(backend.state.activeStream).toBe('tool-stream');
-      expect(patch).toMatchObject({
-        agentFilter: 'toolUse',
-        activeStream: undefined,
-        streamInfo: {
-          name: 'unknown-stream',
-          agentCategory: AgentCategory.Workflow,
-        },
-      });
-    } finally {
-      backend.dispose();
-    }
+    const patch = messages.find(
+      (message) =>
+        message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA &&
+        message.streamInfo.name === 'unknown-stream',
+    );
+    expect(backend.state.agentCategoryFilter).toBe('toolUse');
+    expect(backend.state.activeStream).toBe('tool-stream');
+    expect(patch).toMatchObject({
+      agentFilter: 'toolUse',
+      activeStream: undefined,
+      streamInfo: {
+        name: 'unknown-stream',
+        agentCategory: AgentCategory.Workflow,
+      },
+    });
   });
 
   it('clears retained finished children when an existing stream re-enters running', async () => {
     const { backend, messages } = createRecordingBackend();
     const stream = 'tool-stream' as StreamTabId;
 
-    try {
-      await backend.state.snapshots.load([]);
-      backend.state.streamLogs.ensureStream(stream);
-      // Simulate persistence receiving run.config before progress state sees
-      // the RUNNING transition. The transition boundary must refresh the
-      // durable category before replacing stale execution state.
-      backend.state.snapshots.setTaskState(
-        stream,
-        toolUseTaskState('search', 'deepseekproT'),
-        'abc123' as ExecutionId,
-      );
-      backend.state.getOrCreateStreamState(stream, AgentCategory.Workflow);
-      backend.state.updateStreamState(stream, (prev) => ({
-        ...prev,
-        conversationProgress: { toolCallCount: 7 },
-        roundStage: { index: 2 },
-        subagents: [
-          {
-            kind: 'subagent',
-            childStreamId: 'child-stream',
-            executionId: 'finished-child',
-            agentName: 'reviewer',
-            finishedAt: 1,
-          },
-        ],
-      }));
+    await backend.state.snapshots.load([]);
+    backend.state.streamLogs.ensureStream(stream);
+    // Simulate persistence receiving run.config before progress state sees
+    // the RUNNING transition. The transition boundary must refresh the
+    // durable category before replacing stale execution state.
+    backend.state.snapshots.setTaskState(
+      stream,
+      toolUseTaskState('search', 'deepseekproT'),
+      'abc123' as ExecutionId,
+    );
+    backend.state.getOrCreateStreamState(stream, AgentCategory.Workflow);
+    backend.state.updateStreamState(stream, (prev) => ({
+      ...prev,
+      conversationProgress: { toolCallCount: 7 },
+      roundStage: { index: 2 },
+      subagents: [
+        {
+          kind: 'subagent',
+          childStreamId: 'child-stream',
+          executionId: 'finished-child',
+          agentName: 'reviewer',
+          finishedAt: 1,
+        },
+      ],
+    }));
 
-      await backend.factApplier.setStreamStatus(
-        stream,
-        STREAM_PHASE.RUNNING,
-        STREAM_PHASE.COMPLETED,
-      );
+    await backend.factApplier.setStreamStatus(
+      stream,
+      STREAM_PHASE.RUNNING,
+      STREAM_PHASE.COMPLETED,
+    );
 
-      expect(
-        messages.some(
-          (message) =>
-            message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_STATUS,
-        ),
-      ).toBe(false);
-
-      const patch = messages.find(
+    expect(
+      messages.some(
         (message) =>
-          message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA &&
-          message.streamInfo.name === stream,
-      );
-      if (patch?.command !== PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA) {
-        throw new Error('Expected existing stream metadata patch');
-      }
+          message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_STATUS,
+      ),
+    ).toBe(false);
 
-      expect(patch.streamState).toMatchObject({
-        kind: AgentCategory.ToolUse,
-        status: STREAM_PHASE.RUNNING,
-        conversationProgress: { toolCallCount: 0 },
-        roundStage: null,
-        subagents: [],
-      });
-      expect(
-        JSON.parse(JSON.stringify(patch)).streamState.roundStage,
-      ).toBeNull();
-    } finally {
-      backend.dispose();
+    const patch = messages.find(
+      (message) =>
+        message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA &&
+        message.streamInfo.name === stream,
+    );
+    if (patch?.command !== PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA) {
+      throw new Error('Expected existing stream metadata patch');
     }
+
+    expect(patch.streamState).toMatchObject({
+      kind: AgentCategory.ToolUse,
+      status: STREAM_PHASE.RUNNING,
+      conversationProgress: { toolCallCount: 0 },
+      roundStage: null,
+      subagents: [],
+    });
+    expect(JSON.parse(JSON.stringify(patch)).streamState.roundStage).toBeNull();
   });
 
   it('keeps resident background entries during an in-flight status update', async () => {
@@ -2336,30 +2111,26 @@ describe('ProgressBackend', () => {
     const stream = 'background-stream' as StreamTabId;
     const releaseSpy = vi.spyOn(backend.state.streamLogs, 'requestEviction');
 
-    try {
-      backend.state.streamLogs.ensureStream(stream);
-      backend.state.updateStreamMetadata(stream, {
-        agentCategory: AgentCategory.ToolUse,
-      });
-      backend.state.getOrCreateStreamState(stream, AgentCategory.ToolUse);
+    backend.state.streamLogs.ensureStream(stream);
+    backend.state.updateStreamMetadata(stream, {
+      agentCategory: AgentCategory.ToolUse,
+    });
+    backend.state.getOrCreateStreamState(stream, AgentCategory.ToolUse);
 
-      await backend.factApplier.setStreamStatus(
-        stream,
-        STREAM_PHASE.RUNNING,
-        STREAM_PHASE.RUNNING,
-      );
+    await backend.factApplier.setStreamStatus(
+      stream,
+      STREAM_PHASE.RUNNING,
+      STREAM_PHASE.RUNNING,
+    );
 
-      expect(releaseSpy).not.toHaveBeenCalled();
-      expect(backend.state.streamLogs.get(stream)).toBeDefined();
-    } finally {
-      backend.dispose();
-    }
+    expect(releaseSpy).not.toHaveBeenCalled();
+    expect(backend.state.streamLogs.get(stream)).toBeDefined();
   });
 
   it('drops buffered conversation progress when an existing stream re-enters running', async () => {
     vi.useFakeTimers();
     const { backend, messages } = createRecordingBackend();
-    const subscription = backend.setupEventListeners();
+    track(backend.setupEventListeners());
     const stream = 'tool-stream' as StreamTabId;
 
     try {
@@ -2410,8 +2181,6 @@ describe('ProgressBackend', () => {
         ),
       ).toBe(false);
     } finally {
-      subscription.dispose();
-      backend.dispose();
       vi.useRealTimers();
     }
   });
@@ -2440,83 +2209,72 @@ describe('ProgressBackend', () => {
       tracking as Promise<void>,
     );
 
-    try {
-      backend.factApplier.handleSessionFact({
-        type: 'updateStreamStatus',
-        payload: { streamId: stream, status: STREAM_PHASE.RUNNING },
-      });
+    backend.factApplier.handleSessionFact({
+      type: 'updateStreamStatus',
+      payload: { streamId: stream, status: STREAM_PHASE.RUNNING },
+    });
 
-      // Thenable adoption runs on a microtask; flush before asserting.
-      await new Promise((resolve) => setImmediate(resolve));
+    // Thenable adoption runs on a microtask; flush before asserting.
+    await new Promise((resolve) => setImmediate(resolve));
 
-      expect(adopted).toBe(1);
-    } finally {
-      backend.dispose();
-    }
+    expect(adopted).toBe(1);
   });
 
   it('revalidates and syncs the active stream when status registration changes the filter', async () => {
     const { backend, messages } = createRecordingBackend();
 
-    try {
-      backend.state.streamLogs.ensureStream('tool-stream');
-      backend.state.updateStreamMetadata('tool-stream', {
-        agentCategory: AgentCategory.ToolUse,
-      });
-      backend.state.getOrCreateStreamState(
-        'tool-stream',
-        AgentCategory.ToolUse,
-      );
-      backend.state.activeStream = 'tool-stream';
-      backend.state.agentCategoryFilter = 'toolUse';
-      backend.state.streamLogs.ensureStream('workflow-existing');
-      backend.state.updateStreamMetadata('workflow-existing', {
-        agentCategory: AgentCategory.Workflow,
-      });
-      backend.state.getOrCreateStreamState(
-        'workflow-existing',
-        AgentCategory.Workflow,
-      );
-      backend.state.updateStreamMetadata('workflow-stream', {
-        agentCategory: AgentCategory.Workflow,
-      });
-      vi.spyOn(backend.state, 'pickValidActiveStream').mockReturnValue(
-        'workflow-existing',
-      );
+    backend.state.streamLogs.ensureStream('tool-stream');
+    backend.state.updateStreamMetadata('tool-stream', {
+      agentCategory: AgentCategory.ToolUse,
+    });
+    backend.state.getOrCreateStreamState('tool-stream', AgentCategory.ToolUse);
+    backend.state.activeStream = 'tool-stream';
+    backend.state.agentCategoryFilter = 'toolUse';
+    backend.state.streamLogs.ensureStream('workflow-existing');
+    backend.state.updateStreamMetadata('workflow-existing', {
+      agentCategory: AgentCategory.Workflow,
+    });
+    backend.state.getOrCreateStreamState(
+      'workflow-existing',
+      AgentCategory.Workflow,
+    );
+    backend.state.updateStreamMetadata('workflow-stream', {
+      agentCategory: AgentCategory.Workflow,
+    });
+    vi.spyOn(backend.state, 'pickValidActiveStream').mockReturnValue(
+      'workflow-existing',
+    );
 
-      await backend.factApplier.setStreamStatus(
-        'workflow-stream',
-        STREAM_PHASE.RUNNING,
-      );
+    await backend.factApplier.setStreamStatus(
+      'workflow-stream',
+      STREAM_PHASE.RUNNING,
+    );
 
-      const patch = messages.find(
+    const patch = messages.find(
+      (message) =>
+        message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA &&
+        message.streamInfo.name === 'workflow-stream',
+    );
+    expect(backend.state.agentCategoryFilter).toBe('workflow');
+    expect(backend.state.activeStream).toBe('workflow-existing');
+    expect(patch).toMatchObject({
+      agentFilter: 'workflow',
+      activeStream: 'workflow-existing',
+      streamInfo: {
+        name: 'workflow-stream',
+        agentCategory: AgentCategory.Workflow,
+      },
+    });
+    expect(
+      messages.find(
         (message) =>
-          message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA &&
-          message.streamInfo.name === 'workflow-stream',
-      );
-      expect(backend.state.agentCategoryFilter).toBe('workflow');
-      expect(backend.state.activeStream).toBe('workflow-existing');
-      expect(patch).toMatchObject({
-        agentFilter: 'workflow',
-        activeStream: 'workflow-existing',
-        streamInfo: {
-          name: 'workflow-stream',
-          agentCategory: AgentCategory.Workflow,
-        },
-      });
-      expect(
-        messages.find(
-          (message) =>
-            message.command === PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT,
-        ),
-      ).toMatchObject({
-        stream: 'workflow-existing',
-        action: 'render',
-        kind: AgentCategory.Workflow,
-      });
-    } finally {
-      backend.dispose();
-    }
+          message.command === PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT,
+      ),
+    ).toMatchObject({
+      stream: 'workflow-existing',
+      action: 'render',
+      kind: AgentCategory.Workflow,
+    });
   });
 
   it('keeps task-state metadata canonical across filtering, rendering, and sync content', () => {
@@ -2524,73 +2282,69 @@ describe('ProgressBackend', () => {
     const stream = 'search@deepseek#de5711c' as StreamTabId;
     const executionId = 'de5711c' as ExecutionId;
 
-    try {
-      backend.state.streamLogs.ensureStream(stream);
-      // Provisional patches only ever carry agentCategory/isRemote in
-      // production (see ProgressFactApplier.handleSetActiveStream). Identity
-      // comes from the immutable descriptor; input/model details come from
-      // RunConfig and are assembled atomically by applySnapshotMetadata.
-      backend.state.updateStreamMetadata(stream, {
-        agentCategory: AgentCategory.Workflow,
-        isRemote: true,
-        creationTimestamp: 123,
-      });
-      backend.state.snapshots.setTaskState(
-        stream,
-        toolUseTaskState('search', 'deepseekproT'),
-        executionId,
-      );
-      backend.state.refreshStreamMetadataFromSnapshot(stream);
-      // A late provisional event cannot replace task-state authority.
-      backend.state.updateStreamMetadata(stream, {
-        agentCategory: AgentCategory.Workflow,
-      });
+    backend.state.streamLogs.ensureStream(stream);
+    // Provisional patches only ever carry agentCategory/isRemote in
+    // production (see ProgressFactApplier.handleSetActiveStream). Identity
+    // comes from the immutable descriptor; input/model details come from
+    // RunConfig and are assembled atomically by applySnapshotMetadata.
+    backend.state.updateStreamMetadata(stream, {
+      agentCategory: AgentCategory.Workflow,
+      isRemote: true,
+      creationTimestamp: 123,
+    });
+    backend.state.snapshots.setTaskState(
+      stream,
+      toolUseTaskState('search', 'deepseekproT'),
+      executionId,
+    );
+    backend.state.refreshStreamMetadataFromSnapshot(stream);
+    // A late provisional event cannot replace task-state authority.
+    backend.state.updateStreamMetadata(stream, {
+      agentCategory: AgentCategory.Workflow,
+    });
 
-      expect(backend.state.getStreamMetadata(stream)).toMatchObject({
-        agentCategory: AgentCategory.ToolUse,
-        isRemote: true,
-        creationTimestamp: 123,
-        executionId,
-        run: expect.objectContaining({
-          kind: 'agent',
-          agent: 'search',
-          model: 'deepseekproT',
-        }),
-      });
-
-      const toolUseInfos = buildStreamInfos(backend.state, 'toolUse');
-      expect(toolUseInfos.map((info) => info.name)).toContain(stream);
-      expect(toolUseInfos.find((info) => info.name === stream)).toMatchObject({
+    expect(backend.state.getStreamMetadata(stream)).toMatchObject({
+      agentCategory: AgentCategory.ToolUse,
+      isRemote: true,
+      creationTimestamp: 123,
+      executionId,
+      run: expect.objectContaining({
+        kind: 'agent',
         agent: 'search',
-        agentCategory: AgentCategory.ToolUse,
         model: 'deepseekproT',
-        isRemote: true,
-        creationTimestamp: 123,
-        executionId,
-      });
+      }),
+    });
 
-      const workflowInfos = buildStreamInfos(backend.state, 'workflow');
-      expect(workflowInfos.map((info) => info.name)).not.toContain(stream);
+    const toolUseInfos = buildStreamInfos(backend.state, 'toolUse');
+    expect(toolUseInfos.map((info) => info.name)).toContain(stream);
+    expect(toolUseInfos.find((info) => info.name === stream)).toMatchObject({
+      agent: 'search',
+      agentCategory: AgentCategory.ToolUse,
+      model: 'deepseekproT',
+      isRemote: true,
+      creationTimestamp: 123,
+      executionId,
+    });
 
-      backend.factApplier.syncStreamContent(stream);
-      const sync = messages.find(
-        (message) =>
-          message.command === PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT,
-      );
-      expect(sync).toMatchObject({
-        stream,
-        action: 'render',
-        kind: AgentCategory.ToolUse,
-      });
-    } finally {
-      backend.dispose();
-    }
+    const workflowInfos = buildStreamInfos(backend.state, 'workflow');
+    expect(workflowInfos.map((info) => info.name)).not.toContain(stream);
+
+    backend.factApplier.syncStreamContent(stream);
+    const sync = messages.find(
+      (message) =>
+        message.command === PROGRESS_VIEW_COMMANDS.SYNC_STREAM_CONTENT,
+    );
+    expect(sync).toMatchObject({
+      stream,
+      action: 'render',
+      kind: AgentCategory.ToolUse,
+    });
   });
 
   it('models a workflow-script container from the extension event subscription', async () => {
     const target = createIsolatedRecordingBackend();
-    const { backend, session } = target;
-    const subscription = backend.setupEventListeners();
+    const { backend } = target;
+    track(backend.setupEventListeners());
     const stream = 'workflow-script#f10a11' as StreamTabId;
     const executionId = 'f10a11' as ExecutionId;
     const descriptor = buildRunDescriptor({
@@ -2601,87 +2355,72 @@ describe('ProgressBackend', () => {
       kind: 'workflowScript',
     });
 
-    try {
-      backend.state.streamLogs.ensureStream(stream);
-      emitRunEvent(target, stream, { type: 'run.start', descriptor });
-      emitRunConfig(
-        target,
-        stream,
-        executionId,
-        agentConfigToTaskState(
-          AgentConfigSchema.parse({
-            agent: 'generic',
-            model: 'gpt-5.6-sol',
-            agentCategory: AgentCategory.Workflow,
-            instruction:
-              "Workflow script 'repo-cleanup-readonly-pilot-2026-07-24'",
-          }),
-        ),
-      );
-
-      await vi.waitFor(() =>
-        expect(backend.state.getStreamMetadata(stream).run).toEqual({
-          kind: 'workflowScript',
-          workflowName: 'repo-cleanup-readonly-pilot-2026-07-24',
+    backend.state.streamLogs.ensureStream(stream);
+    emitRunEvent(target, stream, { type: 'run.start', descriptor });
+    emitRunConfig(
+      target,
+      stream,
+      executionId,
+      agentConfigToTaskState(
+        AgentConfigSchema.parse({
+          agent: 'generic',
+          model: 'gpt-5.6-sol',
+          agentCategory: AgentCategory.Workflow,
           instruction:
             "Workflow script 'repo-cleanup-readonly-pilot-2026-07-24'",
         }),
-      );
-      const workflowInfos = buildStreamInfos(backend.state, 'workflow');
-      expect(workflowInfos).toContainEqual(
-        expect.objectContaining({
-          name: stream,
-          label: 'repo-cleanup-readonly-pilot-2026-07-24',
-          kind: 'workflowScript',
-          workflowName: 'repo-cleanup-readonly-pilot-2026-07-24',
-          agentCategory: AgentCategory.Workflow,
-        }),
-      );
-      const workflowScript = workflowInfos.find((info) => info.name === stream);
-      expect(workflowScript).not.toHaveProperty('agent');
-      expect(workflowScript).not.toHaveProperty('model');
-    } finally {
-      subscription.dispose();
-      backend.dispose();
-      session.dispose();
-    }
+      ),
+    );
+
+    await vi.waitFor(() =>
+      expect(backend.state.getStreamMetadata(stream).run).toEqual({
+        kind: 'workflowScript',
+        workflowName: 'repo-cleanup-readonly-pilot-2026-07-24',
+        instruction: "Workflow script 'repo-cleanup-readonly-pilot-2026-07-24'",
+      }),
+    );
+    const workflowInfos = buildStreamInfos(backend.state, 'workflow');
+    expect(workflowInfos).toContainEqual(
+      expect.objectContaining({
+        name: stream,
+        label: 'repo-cleanup-readonly-pilot-2026-07-24',
+        kind: 'workflowScript',
+        workflowName: 'repo-cleanup-readonly-pilot-2026-07-24',
+        agentCategory: AgentCategory.Workflow,
+      }),
+    );
+    const workflowScript = workflowInfos.find((info) => info.name === stream);
+    expect(workflowScript).not.toHaveProperty('agent');
+    expect(workflowScript).not.toHaveProperty('model');
   });
 
   it('promotes the transcript first timestamp into canonical metadata', () => {
     const { backend } = createRecordingBackend();
     const stream = 'timestamp-stream' as StreamTabId;
 
-    try {
-      backend.state.streamLogs.ensureStream(stream);
-      backend.state.updateStreamMetadata(stream, { creationTimestamp: 500 });
-      expect(backend.state.getStreamMetadata(stream).creationTimestamp).toBe(
-        500,
-      );
+    backend.state.streamLogs.ensureStream(stream);
+    backend.state.updateStreamMetadata(stream, { creationTimestamp: 500 });
+    expect(backend.state.getStreamMetadata(stream).creationTimestamp).toBe(500);
 
-      backend.state.streamLogs.append(stream, {
-        id: 'first-entry',
-        type: STREAM_LOG_ENTRY_TYPES.LOG,
-        level: LOG_LEVELS.INFO,
-        timestamp: 100,
-        messageType: MESSAGE_TYPES.DEFAULT,
-        text: 'first transcript entry',
-      });
+    backend.state.streamLogs.append(stream, {
+      id: 'first-entry',
+      type: STREAM_LOG_ENTRY_TYPES.LOG,
+      level: LOG_LEVELS.INFO,
+      timestamp: 100,
+      messageType: MESSAGE_TYPES.DEFAULT,
+      text: 'first transcript entry',
+    });
 
-      expect(backend.state.getStreamMetadata(stream).creationTimestamp).toBe(
-        100,
-      );
-      expect(
-        buildStreamInfos(backend.state, 'all').find(
-          (streamInfo) => streamInfo.name === stream,
-        ),
-      ).toMatchObject({ name: stream, creationTimestamp: 100 });
-    } finally {
-      backend.dispose();
-    }
+    expect(backend.state.getStreamMetadata(stream).creationTimestamp).toBe(100);
+    expect(
+      buildStreamInfos(backend.state, 'all').find(
+        (streamInfo) => streamInfo.name === stream,
+      ),
+    ).toMatchObject({ name: stream, creationTimestamp: 100 });
   });
 
   it('deletes the execution directory named by stream metadata when a stream is cleared', async () => {
-    const { backend, session } = createIsolatedRecordingBackend();
+    const { backend } = createIsolatedRecordingBackend();
     const stream = 'tool@deepseek#a6966a' as StreamTabId;
     const executionId = 'a6966a' as ExecutionId;
 
@@ -2708,13 +2447,11 @@ describe('ProgressBackend', () => {
     } finally {
       await GoalStore.forget(stream);
       await backend.state.clearAll();
-      backend.dispose();
-      session.dispose();
     }
   });
 
   it('retains stream state and execution config when adjacent cleanup fails', async () => {
-    const { backend, session } = createIsolatedRecordingBackend();
+    const { backend } = createIsolatedRecordingBackend();
     const stream = 'tool@deepseek#a6966f' as StreamTabId;
     const executionId = 'a6966f' as ExecutionId;
     const snapshotDeleteSpy = vi
@@ -2742,13 +2479,11 @@ describe('ProgressBackend', () => {
     } finally {
       snapshotDeleteSpy.mockRestore();
       await backend.state.clearAll();
-      backend.dispose();
-      session.dispose();
     }
   });
 
   it('commits stream deletion when only final execution cleanup fails', async () => {
-    const { backend, session } = createIsolatedRecordingBackend();
+    const { backend } = createIsolatedRecordingBackend();
     const stream = 'tool@deepseek#a6966e' as StreamTabId;
     const executionId = 'a6966e' as ExecutionId;
     const deleteExecutionSpy = vi
@@ -2777,13 +2512,11 @@ describe('ProgressBackend', () => {
       deleteExecutionSpy.mockRestore();
       await getExecutionStore(executionId).clear();
       await backend.state.clearAll();
-      backend.dispose();
-      session.dispose();
     }
   });
 
   it('does not retain a stream after the transcript commit point', async () => {
-    const { backend, session } = createIsolatedRecordingBackend();
+    const { backend } = createIsolatedRecordingBackend();
     const stream = 'tool@deepseek#a69660' as StreamTabId;
     const executionId = 'a69660' as ExecutionId;
     const forgetSpy = vi
@@ -2808,13 +2541,11 @@ describe('ProgressBackend', () => {
     } finally {
       forgetSpy.mockRestore();
       await backend.state.clearAll();
-      backend.dispose();
-      session.dispose();
     }
   });
 
   it('retains execution sidecars and goals for an externally active run', async () => {
-    const { backend, session } = createIsolatedRecordingBackend();
+    const { backend } = createIsolatedRecordingBackend();
     const stream = 'tool@deepseek#a6966b' as StreamTabId;
     const executionId = 'a6966b' as ExecutionId;
 
@@ -2843,13 +2574,11 @@ describe('ProgressBackend', () => {
       await GoalStore.forget(stream);
       await getExecutionStore(executionId).clear();
       await backend.state.clearAll();
-      backend.dispose();
-      session.dispose();
     }
   });
 
   it('derives an active execution from the stream id when snapshot mapping is absent', async () => {
-    const { backend, session } = createIsolatedRecordingBackend();
+    const { backend } = createIsolatedRecordingBackend();
     const stream = 'tool@deepseek#a6966c' as StreamTabId;
     const executionId = 'a6966c' as ExecutionId;
 
@@ -2874,13 +2603,11 @@ describe('ProgressBackend', () => {
       await GoalStore.forget(stream);
       await getExecutionStore(executionId).clear();
       await backend.state.clearAll();
-      backend.dispose();
-      session.dispose();
     }
   });
 
   it('retains a log-only stream during bulk cleanup when its execution is active', async () => {
-    const { backend, session } = createIsolatedRecordingBackend();
+    const { backend } = createIsolatedRecordingBackend();
     const stream = 'tool@deepseek#a6966d' as StreamTabId;
     const executionId = 'a6966d' as ExecutionId;
 
@@ -2906,13 +2633,11 @@ describe('ProgressBackend', () => {
       await GoalStore.forget(stream);
       await getExecutionStore(executionId).clear();
       await backend.state.clearAll();
-      backend.dispose();
-      session.dispose();
     }
   });
 
   it('serializes bulk cleanup behind an existing staged deletion', async () => {
-    const { backend, session } = createIsolatedRecordingBackend();
+    const { backend } = createIsolatedRecordingBackend();
     const stream = 'tool@deepseek#a6966e' as StreamTabId;
     const executionId = 'a6966e' as ExecutionId;
     let stagedDeletion:
@@ -2946,8 +2671,6 @@ describe('ProgressBackend', () => {
       await stagedDeletion?.rollback();
       await getExecutionStore(executionId).clear();
       await backend.state.clearAll();
-      backend.dispose();
-      session.dispose();
     }
   });
 
@@ -2958,7 +2681,7 @@ describe('ProgressBackend', () => {
     const failedExecution = 'fa11ed6966' as ExecutionId;
     const incompleteExecution = 'faded6966' as ExecutionId;
     const deletedExecution = 'de1e7ed6966' as ExecutionId;
-    const { backend, session } = createIsolatedRecordingBackend();
+    const { backend } = createIsolatedRecordingBackend();
     backend.state.streamLogs.ensureStream(failedStream);
     backend.state.streamLogs.ensureStream(incompleteStream);
     backend.state.streamLogs.ensureStream(deletedStream);
@@ -3003,15 +2726,13 @@ describe('ProgressBackend', () => {
     } finally {
       deleteExecutionSpy.mockRestore();
       await backend.state.clearAll();
-      backend.dispose();
-      session.dispose();
     }
   });
 
   it('does not retain bulk-deleted streams after the transcript commit point', async () => {
     const stream = 'tool@deepseek#b69660' as StreamTabId;
     const executionId = 'b69660' as ExecutionId;
-    const { backend, session } = createIsolatedRecordingBackend();
+    const { backend } = createIsolatedRecordingBackend();
     backend.state.streamLogs.ensureStream(stream);
     backend.state.snapshots.setTaskState(
       stream,
@@ -3035,8 +2756,6 @@ describe('ProgressBackend', () => {
     } finally {
       forgetManySpy.mockRestore();
       await backend.state.clearAll();
-      backend.dispose();
-      session.dispose();
     }
   });
 
@@ -3044,7 +2763,7 @@ describe('ProgressBackend', () => {
     const failedStream = 'restored-override-stream' as StreamTabId;
     const deletedStream = 'workflow@deepseek#f00baa6966' as StreamTabId;
     const executionId = 'f00baa6966' as ExecutionId;
-    const { backend, session } = createIsolatedRecordingBackend();
+    const { backend } = createIsolatedRecordingBackend();
     backend.state.streamLogs.ensureStream(failedStream);
     backend.state.streamLogs.ensureStream(deletedStream);
     backend.state.snapshots.setTaskState(
@@ -3093,14 +2812,12 @@ describe('ProgressBackend', () => {
     } finally {
       deleteTranscriptSpy.mockRestore();
       await backend.state.clearAll();
-      backend.dispose();
-      session.dispose();
     }
   });
 
   it('forgets goal entries when clearing never-registered streams', async () => {
     const stream = 'tool@deepseek#missing' as StreamTabId;
-    const { backend, session } = createIsolatedRecordingBackend();
+    const { backend } = createIsolatedRecordingBackend();
 
     try {
       await GoalStore.start(stream, 'forget this unregistered goal');
@@ -3111,8 +2828,6 @@ describe('ProgressBackend', () => {
     } finally {
       await GoalStore.forget(stream);
       await backend.state.clearAll();
-      backend.dispose();
-      session.dispose();
     }
   });
 
@@ -3121,7 +2836,7 @@ describe('ProgressBackend', () => {
     await StorageFS.ensureDir(STREAM_DATA_DIR);
     await StorageFS.write(sentinel, '{}');
 
-    const { backend, session } = createIsolatedRecordingBackend();
+    const { backend } = createIsolatedRecordingBackend();
     try {
       await backend.state.clearStream('' as StreamTabId);
       await backend.state.clearStream('.' as StreamTabId);
@@ -3130,14 +2845,12 @@ describe('ProgressBackend', () => {
       expect(await StorageFS.exists(sentinel)).toBe(true);
     } finally {
       await backend.state.clearAll();
-      backend.dispose();
-      session.dispose();
     }
   });
 
   it('forgets goal entries when clearing all streams', async () => {
     const stream = 'tool@deepseek#b6966b' as StreamTabId;
-    const { backend, session } = createIsolatedRecordingBackend();
+    const { backend } = createIsolatedRecordingBackend();
 
     try {
       backend.state.streamLogs.ensureStream(stream);
@@ -3149,8 +2862,6 @@ describe('ProgressBackend', () => {
     } finally {
       await GoalStore.forget(stream);
       await backend.state.clearAll();
-      backend.dispose();
-      session.dispose();
     }
   });
 
@@ -3159,7 +2870,7 @@ describe('ProgressBackend', () => {
     const orphanExecution = 'b6966b' as ExecutionId;
     const historyExecution = 'c6966c' as ExecutionId;
 
-    const { backend, session } = await createPersistentRecordingBackend();
+    const { backend } = await createPersistentRecordingBackend();
     try {
       const seed = new StreamSnapshotStore();
       await seed.load([orphanStream]);
@@ -3195,8 +2906,6 @@ describe('ProgressBackend', () => {
       await GoalStore.forget(orphanStream);
       await getExecutionStore(historyExecution).clear();
       await backend.state.clearAll();
-      backend.dispose();
-      session.dispose();
     }
   });
 
@@ -3215,7 +2924,7 @@ describe('ProgressBackend', () => {
     await GoalStore.start(stream, 'finish this interrupted deletion');
     await seed.stageDeleteStream(stream);
 
-    const { backend, session } = await createPersistentRecordingBackend();
+    const { backend } = await createPersistentRecordingBackend();
     try {
       expect(await StorageFS.exists(streamDataDir(stream))).toBe(false);
       expect(await seed.listStagedDeletions()).toContain(stream);
@@ -3230,8 +2939,6 @@ describe('ProgressBackend', () => {
     } finally {
       await GoalStore.forget(stream);
       await backend.state.clearAll();
-      backend.dispose();
-      session.dispose();
     }
   });
 
@@ -3276,8 +2983,6 @@ describe('ProgressBackend', () => {
       deleteSpy.mockRestore();
       await GoalStore.forget(stream);
       await backend.state.clearAll();
-      backend.dispose();
-      session.dispose();
     }
   });
 
@@ -3302,7 +3007,7 @@ describe('ProgressBackend', () => {
     await writeExecutionConfig(sweptExecution);
     await seed.flush();
 
-    const { backend, session } = await createPersistentRecordingBackend();
+    const { backend } = await createPersistentRecordingBackend();
     const originalStageDeleteStream =
       backend.state.snapshots.stageDeleteStream.bind(backend.state.snapshots);
     const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
@@ -3337,8 +3042,6 @@ describe('ProgressBackend', () => {
       await getExecutionStore(failingExecution).clear();
       await getExecutionStore(sweptExecution).clear();
       await backend.state.clearAll();
-      backend.dispose();
-      session.dispose();
     }
   });
 
@@ -3363,7 +3066,7 @@ describe('ProgressBackend', () => {
     await writeExecutionConfig(sweptExecution);
     await seed.flush();
 
-    const { backend, session } = await createPersistentRecordingBackend();
+    const { backend } = await createPersistentRecordingBackend();
     const stores = executionDeleter(backend);
     const originalDeleteExecution = stores.deleteExecution.bind(stores);
     const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
@@ -3398,8 +3101,6 @@ describe('ProgressBackend', () => {
       await getExecutionStore(failingExecution).clear();
       await getExecutionStore(sweptExecution).clear();
       await backend.state.clearAll();
-      backend.dispose();
-      session.dispose();
     }
   });
 
@@ -3418,6 +3119,8 @@ describe('ProgressBackend', () => {
       await writeExecutionConfig(executionId);
       await first.backend.state.flush();
     } finally {
+      // The second backend reopens the same durable store, so the first one
+      // has to be released here rather than at shared teardown.
       first.backend.dispose();
       first.session.dispose();
     }
@@ -3434,8 +3137,6 @@ describe('ProgressBackend', () => {
       expect(await StorageFS.exists(`executions/${executionId}`)).toBe(true);
     } finally {
       await second.backend.state.clearAll();
-      second.backend.dispose();
-      second.session.dispose();
     }
   });
 
@@ -3466,7 +3167,7 @@ describe('ProgressBackend', () => {
     it('hydrates the initial user message from legacyInstructions.json', async () => {
       const stream = 'polish@gpt#legacy01' as StreamTabId;
       const legacyText = 'Polish the introduction section for clarity.';
-      const { backend, session } = await createPersistentRecordingBackend();
+      const { backend } = await createPersistentRecordingBackend();
 
       try {
         await seedPersistedLogWithoutUserMessage(backend, stream);
@@ -3494,15 +3195,13 @@ describe('ProgressBackend', () => {
         ).toBe(true);
       } finally {
         await backend.state.clearAll();
-        backend.dispose();
-        session.dispose();
       }
     });
 
     it('falls back to the older runInstructions.json key (never migrated on disk)', async () => {
       const stream = 'polish@gpt#legacy02' as StreamTabId;
       const legacyText = 'Rewrite the abstract to lead with the contribution.';
-      const { backend, session } = await createPersistentRecordingBackend();
+      const { backend } = await createPersistentRecordingBackend();
 
       try {
         await seedPersistedLogWithoutUserMessage(backend, stream);
@@ -3535,15 +3234,13 @@ describe('ProgressBackend', () => {
         ).toBe(true);
       } finally {
         await backend.state.clearAll();
-        backend.dispose();
-        session.dispose();
       }
     });
 
     it('does not duplicate the backfilled message on a second load()', async () => {
       const stream = 'polish@gpt#legacy03' as StreamTabId;
       const legacyText = 'Tighten the related-work section.';
-      const { backend, session } = await createPersistentRecordingBackend();
+      const { backend } = await createPersistentRecordingBackend();
 
       try {
         await seedPersistedLogWithoutUserMessage(backend, stream);
@@ -3569,8 +3266,6 @@ describe('ProgressBackend', () => {
         expect(matches).toHaveLength(1);
       } finally {
         await backend.state.clearAll();
-        backend.dispose();
-        session.dispose();
       }
     });
   });
@@ -3601,176 +3296,156 @@ describe('retained finished children', () => {
 
   it('keeps a vanished child as a row stamped with finishedAt', () => {
     const { backend } = createRecordingBackend();
-    try {
-      seedParent(backend);
+    seedParent(backend);
 
-      backend.factApplier.updateChildRoster(PARENT, [
-        subagent('a'),
-        subagent('b'),
-      ]);
-      backend.factApplier.updateChildRoster(PARENT, [subagent('a')]);
+    backend.factApplier.updateChildRoster(PARENT, [
+      subagent('a'),
+      subagent('b'),
+    ]);
+    backend.factApplier.updateChildRoster(PARENT, [subagent('a')]);
 
-      const roster = backend.state.getStreamState(PARENT)?.subagents ?? [];
-      expect(roster).toHaveLength(2);
-      expect(roster.find((c) => c.executionId === 'a')?.finishedAt).toBe(
-        undefined,
-      );
-      expect(
-        roster.find((c) => c.executionId === 'b')?.finishedAt,
-      ).toBeGreaterThan(0);
-    } finally {
-      backend.dispose();
-    }
+    const roster = backend.state.getStreamState(PARENT)?.subagents ?? [];
+    expect(roster).toHaveLength(2);
+    expect(roster.find((c) => c.executionId === 'a')?.finishedAt).toBe(
+      undefined,
+    );
+    expect(
+      roster.find((c) => c.executionId === 'b')?.finishedAt,
+    ).toBeGreaterThan(0);
   });
 
   it('promotes a retained child back to one live row when it reappears', () => {
     const { backend } = createRecordingBackend();
-    try {
-      seedParent(backend);
-      const child = subagent('resumed');
+    seedParent(backend);
+    const child = subagent('resumed');
 
-      backend.factApplier.updateChildRoster(PARENT, [child]);
-      let roster = backend.state.getStreamState(PARENT)?.subagents ?? [];
-      expect(roster).toHaveLength(1);
-      expect(roster[0]?.finishedAt).toBeUndefined();
+    backend.factApplier.updateChildRoster(PARENT, [child]);
+    let roster = backend.state.getStreamState(PARENT)?.subagents ?? [];
+    expect(roster).toHaveLength(1);
+    expect(roster[0]?.finishedAt).toBeUndefined();
 
-      backend.factApplier.updateChildRoster(PARENT, []);
-      roster = backend.state.getStreamState(PARENT)?.subagents ?? [];
-      expect(roster).toHaveLength(1);
-      expect(roster[0]?.finishedAt).toBeGreaterThan(0);
+    backend.factApplier.updateChildRoster(PARENT, []);
+    roster = backend.state.getStreamState(PARENT)?.subagents ?? [];
+    expect(roster).toHaveLength(1);
+    expect(roster[0]?.finishedAt).toBeGreaterThan(0);
 
-      backend.factApplier.updateChildRoster(PARENT, [child]);
-      roster = backend.state.getStreamState(PARENT)?.subagents ?? [];
-      expect(roster).toHaveLength(1);
-      expect(roster[0]?.finishedAt).toBeUndefined();
+    backend.factApplier.updateChildRoster(PARENT, [child]);
+    roster = backend.state.getStreamState(PARENT)?.subagents ?? [];
+    expect(roster).toHaveLength(1);
+    expect(roster[0]?.finishedAt).toBeUndefined();
 
-      backend.factApplier.updateChildRoster(PARENT, []);
-      roster = backend.state.getStreamState(PARENT)?.subagents ?? [];
-      expect(roster).toHaveLength(1);
-      expect(roster[0]?.finishedAt).toBeGreaterThan(0);
-      expect(new Set(roster.map((entry) => entry.executionId)).size).toBe(1);
-    } finally {
-      backend.dispose();
-    }
+    backend.factApplier.updateChildRoster(PARENT, []);
+    roster = backend.state.getStreamState(PARENT)?.subagents ?? [];
+    expect(roster).toHaveLength(1);
+    expect(roster[0]?.finishedAt).toBeGreaterThan(0);
+    expect(new Set(roster.map((entry) => entry.executionId)).size).toBe(1);
   });
 
   it('never marks anything finished from a first roster', () => {
     const { backend } = createRecordingBackend();
-    try {
-      seedParent(backend);
+    seedParent(backend);
 
-      backend.factApplier.updateChildRoster(PARENT, [subagent('a')]);
+    backend.factApplier.updateChildRoster(PARENT, [subagent('a')]);
 
-      const roster = backend.state.getStreamState(PARENT)?.subagents ?? [];
-      expect(roster.map((c) => c.executionId)).toEqual(['a']);
-      expect(roster[0]?.finishedAt).toBeUndefined();
-    } finally {
-      backend.dispose();
-    }
+    const roster = backend.state.getStreamState(PARENT)?.subagents ?? [];
+    expect(roster.map((c) => c.executionId)).toEqual(['a']);
+    expect(roster[0]?.finishedAt).toBeUndefined();
   });
 
   it('shows a terminal status that lands after the roster drop', async () => {
     const { backend, messages } = createRecordingBackend();
-    try {
-      seedParent(backend);
-      const child = subagent('late');
-      const childStreamId = 'late-stream' as StreamTabId;
-      backend.state.snapshots.setParentStream(childStreamId, PARENT);
+    seedParent(backend);
+    const child = subagent('late');
+    const childStreamId = 'late-stream' as StreamTabId;
+    backend.state.snapshots.setParentStream(childStreamId, PARENT);
 
-      // Roster drop first — the child is still `running` at this point.
-      backend.factApplier.updateChildRoster(PARENT, [child]);
-      backend.factApplier.updateChildRoster(PARENT, []);
-      messages.length = 0;
+    // Roster drop first — the child is still `running` at this point.
+    backend.factApplier.updateChildRoster(PARENT, [child]);
+    backend.factApplier.updateChildRoster(PARENT, []);
+    messages.length = 0;
 
-      // Terminal status arrives afterwards.
-      backend.state.streamStatus.transitionToTerminal(
-        childStreamId,
-        STREAM_PHASE.COMPLETED,
-      );
-      await backend.factApplier.setStreamStatus(
-        childStreamId,
-        STREAM_PHASE.COMPLETED,
-      );
+    // Terminal status arrives afterwards.
+    backend.state.streamStatus.transitionToTerminal(
+      childStreamId,
+      STREAM_PHASE.COMPLETED,
+    );
+    await backend.factApplier.setStreamStatus(
+      childStreamId,
+      STREAM_PHASE.COMPLETED,
+    );
 
-      const badges = messages.filter(
-        (message) =>
-          message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_BADGES,
-      );
-      expect(badges.at(-1)).toMatchObject({
-        stream: PARENT,
-        subagents: [
-          expect.objectContaining({
-            executionId: 'late',
-            status: STREAM_PHASE.COMPLETED,
-          }),
-        ],
-      });
-    } finally {
-      backend.dispose();
-    }
+    const badges = messages.filter(
+      (message) =>
+        message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_BADGES,
+    );
+    expect(badges.at(-1)).toMatchObject({
+      stream: PARENT,
+      subagents: [
+        expect.objectContaining({
+          executionId: 'late',
+          status: STREAM_PHASE.COMPLETED,
+        }),
+      ],
+    });
   });
 
   it('keeps the resolved terminal status on a later structural sync', async () => {
     const { backend, messages } = createRecordingBackend();
-    try {
-      seedParent(backend);
-      const childStreamId = 'doomed-stream' as StreamTabId;
-      backend.state.snapshots.setParentStream(childStreamId, PARENT);
+    seedParent(backend);
+    const childStreamId = 'doomed-stream' as StreamTabId;
+    backend.state.snapshots.setParentStream(childStreamId, PARENT);
 
-      // Roster drop first, so the retained row is stamped `running` forever.
-      backend.factApplier.updateChildRoster(PARENT, [
-        subagent('doomed', { childStreamId }),
-      ]);
-      backend.factApplier.updateChildRoster(PARENT, []);
-      // Transition only the authoritative status machine. Deliberately avoid
-      // `setStreamStatus`, which also caches the terminal status into the
-      // retained row and would let this test pass without the projection.
-      backend.state.streamStatus.transitionToTerminal(
-        childStreamId,
-        STREAM_PHASE.FAILED,
-      );
-      expect(backend.state.getStreamState(PARENT)?.subagents?.[0]?.status).toBe(
-        STREAM_PHASE.RUNNING,
-      );
-      expect(backend.state.streamStatus.get(childStreamId)).toBe(
-        STREAM_PHASE.FAILED,
-      );
-      messages.length = 0;
+    // Roster drop first, so the retained row is stamped `running` forever.
+    backend.factApplier.updateChildRoster(PARENT, [
+      subagent('doomed', { childStreamId }),
+    ]);
+    backend.factApplier.updateChildRoster(PARENT, []);
+    // Transition only the authoritative status machine. Deliberately avoid
+    // `setStreamStatus`, which also caches the terminal status into the
+    // retained row and would let this test pass without the projection.
+    backend.state.streamStatus.transitionToTerminal(
+      childStreamId,
+      STREAM_PHASE.FAILED,
+    );
+    expect(backend.state.getStreamState(PARENT)?.subagents?.[0]?.status).toBe(
+      STREAM_PHASE.RUNNING,
+    );
+    expect(backend.state.streamStatus.get(childStreamId)).toBe(
+      STREAM_PHASE.FAILED,
+    );
+    messages.length = 0;
 
-      // A structural rebuild (view reopen, theme change, filter switch) is the
-      // frontend's other writer of `subagents`; it must overlay the stale row
-      // with the authoritative status-machine outcome.
-      backend.webviewUpdater.sendStreamMetadata(
-        backend.state,
-        backend.factApplier.getAllStreamStates(),
-      );
-      backend.webviewUpdater.updateStreamMetadata(
-        backend.state,
-        PARENT,
-        backend.factApplier.getAllStreamStates(),
-      );
+    // A structural rebuild (view reopen, theme change, filter switch) is the
+    // frontend's other writer of `subagents`; it must overlay the stale row
+    // with the authoritative status-machine outcome.
+    backend.webviewUpdater.sendStreamMetadata(
+      backend.state,
+      backend.factApplier.getAllStreamStates(),
+    );
+    backend.webviewUpdater.updateStreamMetadata(
+      backend.state,
+      PARENT,
+      backend.factApplier.getAllStreamStates(),
+    );
 
-      const rosters = messages.flatMap((message) => {
-        if (message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS) {
-          return [message.streamStates?.[PARENT]?.subagents ?? []];
-        }
-        if (message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA) {
-          return [message.streamState.subagents];
-        }
-        return [];
-      });
-
-      expect(rosters).toHaveLength(2);
-      for (const roster of rosters) {
-        expect(roster).toEqual([
-          expect.objectContaining({
-            executionId: 'doomed',
-            status: STREAM_PHASE.FAILED,
-          }),
-        ]);
+    const rosters = messages.flatMap((message) => {
+      if (message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS) {
+        return [message.streamStates?.[PARENT]?.subagents ?? []];
       }
-    } finally {
-      backend.dispose();
+      if (message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_METADATA) {
+        return [message.streamState.subagents];
+      }
+      return [];
+    });
+
+    expect(rosters).toHaveLength(2);
+    for (const roster of rosters) {
+      expect(roster).toEqual([
+        expect.objectContaining({
+          executionId: 'doomed',
+          status: STREAM_PHASE.FAILED,
+        }),
+      ]);
     }
   });
 
@@ -3779,54 +3454,46 @@ describe('retained finished children', () => {
     // Mirrors RETAINED_FINISHED_CHILDREN_CAP in ProgressFactApplier.
     const cap = 200;
     const overflow = 5;
-    try {
-      seedParent(backend);
-      const live = subagent('live');
+    seedParent(backend);
+    const live = subagent('live');
 
-      for (let i = 0; i < cap + overflow; i += 1) {
-        vi.spyOn(Date, 'now').mockReturnValue(1_000 + i);
-        backend.factApplier.updateChildRoster(PARENT, [
-          live,
-          subagent(`child-${i}`),
-        ]);
-        backend.factApplier.updateChildRoster(PARENT, [live]);
-      }
-      vi.restoreAllMocks();
-
-      const roster = backend.state.getStreamState(PARENT)?.subagents ?? [];
-      const retained = roster.filter((c) => c.finishedAt !== undefined);
-      expect(roster.filter((c) => c.finishedAt === undefined)).toEqual([live]);
-      expect(retained).toHaveLength(cap);
-      // The five oldest are evicted; the newest survives.
-      const ids = retained.map((c) => c.executionId);
-      expect(ids).not.toContain('child-0');
-      expect(ids).not.toContain(`child-${overflow - 1}`);
-      expect(retained[0]?.executionId).toBe(`child-${overflow}`);
-      expect(retained.at(-1)?.executionId).toBe(`child-${cap + overflow - 1}`);
-    } finally {
-      backend.dispose();
+    for (let i = 0; i < cap + overflow; i += 1) {
+      vi.spyOn(Date, 'now').mockReturnValue(1_000 + i);
+      backend.factApplier.updateChildRoster(PARENT, [
+        live,
+        subagent(`child-${i}`),
+      ]);
+      backend.factApplier.updateChildRoster(PARENT, [live]);
     }
+    vi.restoreAllMocks();
+
+    const roster = backend.state.getStreamState(PARENT)?.subagents ?? [];
+    const retained = roster.filter((c) => c.finishedAt !== undefined);
+    expect(roster.filter((c) => c.finishedAt === undefined)).toEqual([live]);
+    expect(retained).toHaveLength(cap);
+    // The five oldest are evicted; the newest survives.
+    const ids = retained.map((c) => c.executionId);
+    expect(ids).not.toContain('child-0');
+    expect(ids).not.toContain(`child-${overflow - 1}`);
+    expect(retained[0]?.executionId).toBe(`child-${overflow}`);
+    expect(retained.at(-1)?.executionId).toBe(`child-${cap + overflow - 1}`);
   });
 
   it('clears retained rows when the stream re-enters running', async () => {
     const { backend } = createRecordingBackend();
-    try {
-      seedParent(backend);
-      const live = subagent('live');
+    seedParent(backend);
+    const live = subagent('live');
 
-      backend.factApplier.updateChildRoster(PARENT, [live, subagent('done')]);
-      backend.factApplier.updateChildRoster(PARENT, [live]);
-      expect(backend.state.getStreamState(PARENT)?.subagents).toHaveLength(2);
+    backend.factApplier.updateChildRoster(PARENT, [live, subagent('done')]);
+    backend.factApplier.updateChildRoster(PARENT, [live]);
+    expect(backend.state.getStreamState(PARENT)?.subagents).toHaveLength(2);
 
-      await backend.factApplier.setStreamStatus(
-        PARENT,
-        STREAM_PHASE.RUNNING,
-        STREAM_PHASE.COMPLETED,
-      );
+    await backend.factApplier.setStreamStatus(
+      PARENT,
+      STREAM_PHASE.RUNNING,
+      STREAM_PHASE.COMPLETED,
+    );
 
-      expect(backend.state.getStreamState(PARENT)?.subagents).toEqual([live]);
-    } finally {
-      backend.dispose();
-    }
+    expect(backend.state.getStreamState(PARENT)?.subagents).toEqual([live]);
   });
 });

--- a/src/test-kernel/progressView/ProgressBackendAppSignals.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendAppSignals.vitest.ts
@@ -1,7 +1,7 @@
 // Test composition imports
 import '@test/support/defaultSessionTestSetup';
 
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { ProgressBackend } from '@controllers/progressView/backend/ProgressBackend';
 import type {
@@ -52,27 +52,43 @@ class MemoryAppSignals implements AppSignalsLike {
   }
 }
 
+/** Everything a test attaches, released in reverse order by one owner. */
+const testDisposables: { dispose(): void }[] = [];
+
+afterEach(() => {
+  for (const disposable of testDisposables.splice(0).reverse()) {
+    disposable.dispose();
+  }
+});
+
+function track<T extends { dispose(): void }>(disposable: T): T {
+  testDisposables.push(disposable);
+  return disposable;
+}
+
 function createBackend(): ProgressBackend {
-  return new ProgressBackend({
-    storage: new FakeStateStore(),
-    sendMessage: () => true,
-    hasTarget: () => true,
-    approvals: {
-      canSend: () => true,
-      overrides: {
-        retry: { show: vi.fn(), dismiss: vi.fn() },
-        agentProposal: { show: vi.fn(), dismiss: vi.fn() },
+  return track(
+    new ProgressBackend({
+      storage: new FakeStateStore(),
+      sendMessage: () => true,
+      hasTarget: () => true,
+      approvals: {
+        canSend: () => true,
+        overrides: {
+          retry: { show: vi.fn(), dismiss: vi.fn() },
+          agentProposal: { show: vi.fn(), dismiss: vi.fn() },
+        },
       },
-    },
-    lifecycle: {
-      stopStream: vi.fn(),
-      cleanupDeletedStream: vi.fn(),
-      cleanupDeletedStreams: vi.fn(),
-      rebuildRenderedStreams: vi.fn(),
-      activateStream: vi.fn(),
-      notifyDeletionRetained: vi.fn(),
-    },
-  });
+      lifecycle: {
+        stopStream: vi.fn(),
+        cleanupDeletedStream: vi.fn(),
+        cleanupDeletedStreams: vi.fn(),
+        rebuildRenderedStreams: vi.fn(),
+        activateStream: vi.fn(),
+        notifyDeletionRetained: vi.fn(),
+      },
+    }),
+  );
 }
 
 function setStatus(
@@ -98,56 +114,38 @@ describe('attachProgressBackendAppSignals', () => {
   it('marks running progress tasks cancelled on extension deactivation', () => {
     const backend = createBackend();
     const signals = new MemoryAppSignals();
-    const backendSubscription = backend.setupEventListeners();
-    const appSignalSubscription = attachProgressBackendAppSignals(
-      backend,
-      signals,
-    );
+    track(backend.setupEventListeners());
+    track(attachProgressBackendAppSignals(backend, signals));
     const running = 'appsignals:running' as StreamTabId;
     const complete = 'appsignals:complete' as StreamTabId;
 
-    try {
-      setStatus(backend, running, STREAM_PHASE.RUNNING);
-      setStatus(backend, complete, STREAM_PHASE.COMPLETED);
+    setStatus(backend, running, STREAM_PHASE.RUNNING);
+    setStatus(backend, complete, STREAM_PHASE.COMPLETED);
 
-      signals.emit('extensionDeactivating', undefined);
+    signals.emit('extensionDeactivating', undefined);
 
-      expect(backend.state.streamStatus.get(running)).toBe(
-        STREAM_PHASE.CANCELLED,
-      );
-      expect(backend.state.streamStatus.get(complete)).toBe(
-        STREAM_PHASE.COMPLETED,
-      );
-    } finally {
-      appSignalSubscription.dispose();
-      backendSubscription.dispose();
-      backend.dispose();
-    }
+    expect(backend.state.streamStatus.get(running)).toBe(
+      STREAM_PHASE.CANCELLED,
+    );
+    expect(backend.state.streamStatus.get(complete)).toBe(
+      STREAM_PHASE.COMPLETED,
+    );
   });
 
   it('detaches the app-signal listener cleanly', () => {
     const backend = createBackend();
     const signals = new MemoryAppSignals();
-    const backendSubscription = backend.setupEventListeners();
-    const appSignalSubscription = attachProgressBackendAppSignals(
-      backend,
-      signals,
+    track(backend.setupEventListeners());
+    const appSignalSubscription = track(
+      attachProgressBackendAppSignals(backend, signals),
     );
     const running = 'appsignals:disposed' as StreamTabId;
 
-    try {
-      setStatus(backend, running, STREAM_PHASE.RUNNING);
-      appSignalSubscription.dispose();
+    setStatus(backend, running, STREAM_PHASE.RUNNING);
+    appSignalSubscription.dispose();
 
-      signals.emit('extensionDeactivating', undefined);
+    signals.emit('extensionDeactivating', undefined);
 
-      expect(backend.state.streamStatus.get(running)).toBe(
-        STREAM_PHASE.RUNNING,
-      );
-    } finally {
-      appSignalSubscription.dispose();
-      backendSubscription.dispose();
-      backend.dispose();
-    }
+    expect(backend.state.streamStatus.get(running)).toBe(STREAM_PHASE.RUNNING);
   });
 });

--- a/src/test-kernel/progressView/TexraDiffView.vitest.mts
+++ b/src/test-kernel/progressView/TexraDiffView.vitest.mts
@@ -52,7 +52,7 @@ class MockWorker {
   terminate = vi.fn();
 }
 
-function installDom(): JSDOM {
+function installDom(): void {
   const dom = new JSDOM('<!doctype html><body class="vscode-dark"></body>', {
     url: 'http://localhost',
   });
@@ -68,7 +68,6 @@ function installDom(): JSDOM {
   globalThis.ResizeObserver =
     MockResizeObserver as unknown as typeof ResizeObserver;
   globalThis.self = dom.window as unknown as Window & typeof globalThis;
-  return dom;
 }
 
 function restoreDom(): void {

--- a/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
+++ b/src/test-kernel/progressView/ToolUseFormatter.vitest.mts
@@ -40,6 +40,18 @@ beforeAll(async () => {
   ({ render } = await import('lit'));
 });
 
+/** The shared shell of an INFO-level tool-use log entry. */
+function toolUseMessage(id: string, data: unknown): LogMessageData {
+  return {
+    id,
+    text: '',
+    level: LOG_LEVELS.INFO,
+    timestamp: 1,
+    messageType: 'toolUse',
+    data,
+  };
+}
+
 describe('tool-use formatter', () => {
   it('renders workflow-script delegation details without proposal or journal data', () => {
     const script = `export const meta = {
@@ -53,35 +65,28 @@ const papers = await parallel(
   ),
 );
 return { papers, question: args.question };`;
-    const message: LogMessageData = {
-      id: 'workflow-script',
-      text: '',
-      level: LOG_LEVELS.INFO,
-      timestamp: 1,
-      messageType: 'toolUse',
-      data: {
-        toolName: 'delegate_workflow_script',
-        input: {
-          agent: 'research',
-          script,
-          args: {
-            paperIds: ['2401.00001', '2401.00002'],
-            question: 'Which assumptions differ?',
-          },
-          files: {
-            inputFiles: ['paper.tex'],
-            contextFiles: ['references.bib'],
-            mediaFiles: ['figure.pdf'],
-          },
+    const message = toolUseMessage('workflow-script', {
+      toolName: 'delegate_workflow_script',
+      input: {
+        agent: 'research',
+        script,
+        args: {
+          paperIds: ['2401.00001', '2401.00002'],
+          question: 'Which assumptions differ?',
         },
-        output: {
-          status: 'executed',
-          summary:
-            "Completed workflow script 'Literature synthesis' (2 agent calls)",
-          output: JSON.stringify({ compared: 2 }),
+        files: {
+          inputFiles: ['paper.tex'],
+          contextFiles: ['references.bib'],
+          mediaFiles: ['figure.pdf'],
         },
       },
-    };
+      output: {
+        status: 'executed',
+        summary:
+          "Completed workflow script 'Literature synthesis' (2 agent calls)",
+        output: JSON.stringify({ compared: 2 }),
+      },
+    });
 
     const container = document.createElement('div');
     render(formatToolUseTemplate(message, { defaultOpen: true }), container);
@@ -119,21 +124,14 @@ return { papers, question: args.question };`;
   });
 
   it('shows explicit null workflow-script arguments as JSON', () => {
-    const message: LogMessageData = {
-      id: 'workflow-script-null-args',
-      text: '',
-      level: LOG_LEVELS.INFO,
-      timestamp: 1,
-      messageType: 'toolUse',
-      data: {
-        toolName: 'delegate_workflow_script',
-        input: {
-          agent: 'research',
-          script: 'export const meta = { name: "One call" };\nreturn null;',
-          args: null,
-        },
+    const message = toolUseMessage('workflow-script-null-args', {
+      toolName: 'delegate_workflow_script',
+      input: {
+        agent: 'research',
+        script: 'export const meta = { name: "One call" };\nreturn null;',
+        args: null,
       },
-    };
+    });
 
     const container = document.createElement('div');
     render(formatToolUseTemplate(message), container);
@@ -186,18 +184,11 @@ return { papers, question: args.question };`;
   });
 
   it('renders write_file cards even when compact logs omit content', () => {
-    const message: LogMessageData = {
-      id: 'write-file-compact',
-      text: '',
-      level: LOG_LEVELS.INFO,
-      timestamp: 1,
-      messageType: 'toolUse',
-      data: {
-        toolName: 'write_file',
-        input: { path: 'src/main.ts' },
-        output: 'Wrote src/main.ts',
-      },
-    };
+    const message = toolUseMessage('write-file-compact', {
+      toolName: 'write_file',
+      input: { path: 'src/main.ts' },
+      output: 'Wrote src/main.ts',
+    });
 
     const container = document.createElement('div');
     render(formatLogEntry(message), container);
@@ -213,17 +204,10 @@ return { papers, question: args.question };`;
       action: 'wait',
       timeout: 3600,
     };
-    const message: LogMessageData = {
-      id: 'executions-timeout',
-      text: '',
-      level: LOG_LEVELS.INFO,
-      timestamp: 1,
-      messageType: 'toolUse',
-      data: {
-        toolName: 'executions',
-        input,
-      },
-    };
+    const message = toolUseMessage('executions-timeout', {
+      toolName: 'executions',
+      input,
+    });
 
     expect(getToolTimeoutMs('executions', input)).toBe(1_800_000);
     expect(getToolTimeoutMs('executions', { ...input, timeout: 30 })).toBe(
@@ -238,21 +222,14 @@ return { papers, question: args.question };`;
   });
 
   it('labels executions targets when the display model knows the subagents', () => {
-    const message: LogMessageData = {
-      id: 'executions-subagents',
-      text: '',
-      level: LOG_LEVELS.INFO,
-      timestamp: 1,
-      messageType: 'toolUse',
-      data: {
-        toolName: 'executions',
-        input: {
-          action: 'wait',
-          path: '/executions',
-          ids: ['sub-1', 'sub-2'],
-        },
+    const message = toolUseMessage('executions-subagents', {
+      toolName: 'executions',
+      input: {
+        action: 'wait',
+        path: '/executions',
+        ids: ['sub-1', 'sub-2'],
       },
-    };
+    });
 
     const container = document.createElement('div');
     render(
@@ -271,19 +248,12 @@ return { papers, question: args.question };`;
   });
 
   it('keeps the resource path when labeling an executions target', () => {
-    const message: LogMessageData = {
-      id: 'executions-subagent-resource',
-      text: '',
-      level: LOG_LEVELS.INFO,
-      timestamp: 1,
-      messageType: 'toolUse',
-      data: {
-        toolName: 'executions',
-        input: {
-          path: '/executions/sub-1/workspace-files/review.md',
-        },
+    const message = toolUseMessage('executions-subagent-resource', {
+      toolName: 'executions',
+      input: {
+        path: '/executions/sub-1/workspace-files/review.md',
       },
-    };
+    });
 
     const container = document.createElement('div');
     render(
@@ -299,20 +269,13 @@ return { papers, question: args.question };`;
   });
 
   it('keeps the existing executions title for a background process', () => {
-    const message: LogMessageData = {
-      id: 'executions-process',
-      text: '',
-      level: LOG_LEVELS.INFO,
-      timestamp: 1,
-      messageType: 'toolUse',
-      data: {
-        toolName: 'executions',
-        input: {
-          action: 'view',
-          path: '/executions/process-1',
-        },
+    const message = toolUseMessage('executions-process', {
+      toolName: 'executions',
+      input: {
+        action: 'view',
+        path: '/executions/process-1',
       },
-    };
+    });
 
     const container = document.createElement('div');
     render(
@@ -397,18 +360,11 @@ const SUMMARY_CONTROL_CASES = [
 
 describe('wa-details summary controls: activation does not toggle the panel', () => {
   it('clicking the proposal-restore-link ("Setup") button does not toggle the panel, and the click still bubbles to an outer delegated handler', async () => {
-    const message: LogMessageData = {
-      id: 'proposal-1',
-      text: '',
-      level: LOG_LEVELS.INFO,
-      timestamp: 1,
-      messageType: 'toolUse',
-      data: {
-        toolName: 'propose_agent',
-        input: { agent: 'assistant', instruction: 'do the thing' },
-        output: 'proposed',
-      },
-    };
+    const message = toolUseMessage('proposal-1', {
+      toolName: 'propose_agent',
+      input: { agent: 'assistant', instruction: 'do the thing' },
+      output: 'proposed',
+    });
 
     const container = document.createElement('div');
     document.body.appendChild(container);

--- a/src/test-kernel/progressView/WebviewBridge.vitest.ts
+++ b/src/test-kernel/progressView/WebviewBridge.vitest.ts
@@ -41,19 +41,30 @@ function deferredBoolean(): {
 }
 
 describe('WebviewBridge', () => {
+  const bridges: WebviewBridge[] = [];
+
   beforeEach(() => {
     vi.useFakeTimers();
   });
 
   afterEach(() => {
+    for (const bridge of bridges.splice(0)) bridge.dispose();
     vi.useRealTimers();
   });
+
+  /** Registers a bridge for the shared teardown above. */
+  function track(bridge: WebviewBridge): WebviewBridge {
+    bridges.push(bridge);
+    return bridge;
+  }
 
   it('flushes active stream log deltas', async () => {
     const store = StreamLogStore.ephemeral('test');
     const activeStream = 'active' as StreamTabId;
     const sendMessage = vi.fn(() => true);
-    const bridge = new WebviewBridge(store, sendMessage, () => activeStream);
+    const bridge = track(
+      new WebviewBridge(store, sendMessage, () => activeStream),
+    );
 
     bridge.syncStream(activeStream);
     store.append(activeStream, logEntry('active-1', 'active log', 100));
@@ -71,15 +82,15 @@ describe('WebviewBridge', () => {
       updates: [],
       textDeltas: [],
     });
-
-    bridge.dispose();
   });
 
   it('pushes restart-repair group settlements through log deltas', async () => {
     const store = StreamLogStore.ephemeral('test');
     const activeStream = 'active-repair' as StreamTabId;
     const sendMessage = vi.fn(() => true);
-    const bridge = new WebviewBridge(store, sendMessage, () => activeStream);
+    const bridge = track(
+      new WebviewBridge(store, sendMessage, () => activeStream),
+    );
 
     store.append(activeStream, {
       id: 'running-group',
@@ -112,15 +123,15 @@ describe('WebviewBridge', () => {
       ],
       textDeltas: [],
     });
-
-    bridge.dispose();
   });
 
   it('does not queue inactive stream flushes that race with tab switches', async () => {
     const store = StreamLogStore.ephemeral('test');
     let activeStream = 'active' as StreamTabId;
     const sendMessage = vi.fn(() => true);
-    const bridge = new WebviewBridge(store, sendMessage, () => activeStream);
+    const bridge = track(
+      new WebviewBridge(store, sendMessage, () => activeStream),
+    );
 
     store.append(
       'inactive' as StreamTabId,
@@ -130,15 +141,15 @@ describe('WebviewBridge', () => {
     await vi.advanceTimersByTimeAsync(20);
 
     expect(sendMessage).not.toHaveBeenCalled();
-
-    bridge.dispose();
   });
 
   it('syncs inactive stream history explicitly on tab switch', async () => {
     const store = StreamLogStore.ephemeral('test');
     let activeStream = 'active' as StreamTabId;
     const sendMessage = vi.fn(() => true);
-    const bridge = new WebviewBridge(store, sendMessage, () => activeStream);
+    const bridge = track(
+      new WebviewBridge(store, sendMessage, () => activeStream),
+    );
 
     store.append(
       'inactive' as StreamTabId,
@@ -161,15 +172,15 @@ describe('WebviewBridge', () => {
       updates: [],
       textDeltas: [],
     });
-
-    bridge.dispose();
   });
 
   it('replays full streamed text when a webview syncs mid-stream', async () => {
     const store = StreamLogStore.ephemeral('test');
     const activeStream = 'active' as StreamTabId;
     const sendMessage = vi.fn(() => true);
-    const bridge = new WebviewBridge(store, sendMessage, () => activeStream);
+    const bridge = track(
+      new WebviewBridge(store, sendMessage, () => activeStream),
+    );
 
     store.append(activeStream, logEntry('active-1', '', 100));
     store.appendText(activeStream, 'active-1', 'hello ');
@@ -190,8 +201,6 @@ describe('WebviewBridge', () => {
       updates: [],
       textDeltas: [],
     });
-
-    bridge.dispose();
   });
 
   it('keeps the cursor and dirty updates when no target accepts a log delta', async () => {
@@ -202,7 +211,9 @@ describe('WebviewBridge', () => {
       .mockReturnValueOnce(true)
       .mockReturnValueOnce(false)
       .mockReturnValueOnce(true);
-    const bridge = new WebviewBridge(store, sendMessage, () => activeStream);
+    const bridge = track(
+      new WebviewBridge(store, sendMessage, () => activeStream),
+    );
 
     bridge.syncStream(activeStream);
     store.append(activeStream, logEntry('active-1', 'active log', 100));
@@ -235,8 +246,6 @@ describe('WebviewBridge', () => {
       ],
       textDeltas: [],
     });
-
-    bridge.dispose();
   });
 
   it('serializes async flushes and preserves updates made during delivery', async () => {
@@ -247,7 +256,9 @@ describe('WebviewBridge', () => {
       .fn()
       .mockReturnValueOnce(firstDelivery.promise)
       .mockResolvedValue(true);
-    const bridge = new WebviewBridge(store, sendMessage, () => activeStream);
+    const bridge = track(
+      new WebviewBridge(store, sendMessage, () => activeStream),
+    );
 
     bridge.syncStream(activeStream);
     store.append(activeStream, logEntry('active-1', 'active log', 100));
@@ -276,8 +287,6 @@ describe('WebviewBridge', () => {
       ],
       textDeltas: [],
     });
-
-    bridge.dispose();
   });
 
   it('does not resend streamed text already covered by an in-flight full entry', async () => {
@@ -288,7 +297,9 @@ describe('WebviewBridge', () => {
       .fn()
       .mockReturnValueOnce(firstDelivery.promise)
       .mockResolvedValue(true);
-    const bridge = new WebviewBridge(store, sendMessage, () => activeStream);
+    const bridge = track(
+      new WebviewBridge(store, sendMessage, () => activeStream),
+    );
 
     bridge.syncStream(activeStream);
     store.append(activeStream, logEntry('active-1', '', 100));
@@ -324,8 +335,6 @@ describe('WebviewBridge', () => {
       updates: [],
       textDeltas: [{ id: 'active-1', appendText: ' world' }],
     });
-
-    bridge.dispose();
   });
 
   it('ships streamed text as O(L) append deltas instead of full updates', async () => {
@@ -336,7 +345,9 @@ describe('WebviewBridge', () => {
       deliveredBytes += JSON.stringify(message).length;
       return true;
     });
-    const bridge = new WebviewBridge(store, sendMessage, () => activeStream);
+    const bridge = track(
+      new WebviewBridge(store, sendMessage, () => activeStream),
+    );
     const chunk = 'x'.repeat(1024);
 
     bridge.syncStream(activeStream);
@@ -361,7 +372,5 @@ describe('WebviewBridge', () => {
 
     expect(streamedFrames).toHaveLength(40);
     expect(deliveredBytes).toBeLessThan(90_000);
-
-    bridge.dispose();
   });
 });

--- a/src/test-kernel/transcript/StreamLog.vitest.ts
+++ b/src/test-kernel/transcript/StreamLog.vitest.ts
@@ -63,14 +63,9 @@ describe('StreamLog', () => {
     });
     expect(log.hasRunningGroup).toBe(false);
 
-    expect(log.getDirtyUpdates().map((entry) => entry.id)).toEqual([
-      'run',
-      'message-2500',
-    ]);
-    expect(log.drainDirtyUpdates().map((entry) => entry.id)).toEqual([
-      'run',
-      'message-2500',
-    ]);
+    const dirty = log.getDirtyUpdates();
+    expect(dirty.map((entry) => entry.id)).toEqual(['run', 'message-2500']);
+    log.ackDirtyUpdates(dirty);
     expect(log.getDirtyUpdates()).toEqual([]);
   });
 
@@ -86,7 +81,7 @@ describe('StreamLog', () => {
     });
 
     expect(log.update('message', { text: 'unchanged' })).toBeUndefined();
-    expect(log.drainDirtyUpdates()).toEqual([]);
+    expect(log.getDirtyUpdates()).toEqual([]);
   });
 
   it('assigns one durable settlement order when rows become printable', () => {

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -494,11 +494,14 @@ Use action: "subscribe" on /executions/{id} to receive future status and termina
     const timer = setTimeout(() => ac.abort(), timeout * 1000);
     // Abort early if a follow-up is sent to this stream (user wants to break the wait).
     const cleanupFollowUp = listenForFollowUp(ac);
-    const waitPromise = register(ac.signal);
-    if (settled()) ac.abort();
-    await waitPromise;
-    clearTimeout(timer);
-    cleanupFollowUp();
+    try {
+      const waitPromise = register(ac.signal);
+      if (settled()) ac.abort();
+      await waitPromise;
+    } finally {
+      clearTimeout(timer);
+      cleanupFollowUp();
+    }
   }
 
   private async listExecutions(
@@ -950,7 +953,7 @@ Use action: "subscribe" on /executions/{id} to receive future status and termina
     out.push(
       `Showing lines ${first}-${last} of ${lines.length}${hint}.`,
       '',
-      applyViewRange(lines.join('\n'), [first, last]),
+      lines.slice(first - 1, last).join('\n'),
       '',
       footer,
     );

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -222,7 +222,7 @@ export class ReadFileTool extends defineTool({
 }
 
 /** Guard against very large EML files exhausting memory during parsing. */
-const MAX_EML_BYTES = 15 * 1024 * 1024; // 15 MiB — matches DEFAULT_ATTACHMENT_MAX_BYTES
+const MAX_EML_BYTES = 15 * 1024 * 1024; // 15 MiB — matches ATTACHMENT_MAX_BYTES
 
 const IMAGE_EXTENSIONS = new Set([
   '.png',

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -294,15 +294,13 @@ export class TextEditorTool extends defineTool({
     }
 
     // Check if the path is a directory (only view command can be used on directories)
-    try {
-      const stats = await AbsoluteFS.stat(WorkspaceFS.fullPath(filePath));
-      if (isDirectory(stats.type) && command !== 'view') {
-        throw new ToolError(
-          `The path ${displayPath} is a directory and only the 'view' command can be used on directories`,
-        );
-      }
-    } catch (error) {
-      rethrowWithContext(error, `Error validating path`);
+    const stats = await AbsoluteFS.stat(WorkspaceFS.fullPath(filePath)).catch(
+      (error: unknown) => rethrowWithContext(error, 'Error validating path'),
+    );
+    if (isDirectory(stats.type) && command !== 'view') {
+      throw new ToolError(
+        `The path ${displayPath} is a directory and only the 'view' command can be used on directories`,
+      );
     }
   }
 

--- a/src/tools/attachments.ts
+++ b/src/tools/attachments.ts
@@ -17,12 +17,6 @@ export interface BuildFileAttachmentOptions {
   description?: string;
   /** Override detected MIME type */
   mimeType?: string;
-  /** Include base64 data in the attachment */
-  includeBase64?: boolean;
-  /** Maximum allowed file size in bytes */
-  maxBytes?: number;
-  /** Optional root directory override (e.g. a git worktree) */
-  root?: string;
   /**
    * Pre-resolved path. When provided, skips the internal resolveAndFormat()
    * call — use this to avoid double-resolution when the caller already
@@ -31,7 +25,7 @@ export interface BuildFileAttachmentOptions {
   resolved?: WorkspacePathResolution;
 }
 
-const DEFAULT_ATTACHMENT_MAX_BYTES = 15 * 1024 * 1024; // 15 MiB
+const ATTACHMENT_MAX_BYTES = 15 * 1024 * 1024; // 15 MiB
 
 export interface BuildBytesAttachmentOptions {
   /** Display path surfaced to the model. */
@@ -81,9 +75,6 @@ export async function buildFileAttachment({
   filePath,
   description,
   mimeType,
-  includeBase64 = false,
-  maxBytes = DEFAULT_ATTACHMENT_MAX_BYTES,
-  root,
   resolved,
 }: BuildFileAttachmentOptions): Promise<ToolFileAttachment> {
   if (!isNonEmptyString(filePath)) {
@@ -92,7 +83,7 @@ export async function buildFileAttachment({
 
   const { path, display } = resolved
     ? { path: resolved, display: toPosixPath(resolved.relative) }
-    : resolveAndFormat(filePath, root);
+    : resolveAndFormat(filePath);
   const exists = await WorkspaceFS.exists(path.fsPath);
   if (!exists) {
     throw new ToolError(`Attachment not found: ${display}`);
@@ -103,8 +94,8 @@ export async function buildFileAttachment({
     `Failed to inspect attachment ${display}`,
   );
 
-  if (stats.size > maxBytes) {
-    const limitMb = (maxBytes / (1024 * 1024)).toFixed(1);
+  if (stats.size > ATTACHMENT_MAX_BYTES) {
+    const limitMb = (ATTACHMENT_MAX_BYTES / (1024 * 1024)).toFixed(1);
     throw new ToolError(
       `Attachment ${display} exceeds maximum size of ${limitMb} MiB.`,
     );
@@ -124,9 +115,7 @@ export async function buildFileAttachment({
     bytes: buffer,
     description,
   });
-  const base64Data =
-    includeBase64 && attachment.bytes ? buffer.toString('base64') : undefined;
   buffer.fill(0);
 
-  return base64Data ? { ...attachment, base64Data } : attachment;
+  return attachment;
 }

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -447,7 +447,7 @@ export class BashTool extends defineTool({
     );
     let loggedChars = 0;
     let logCapReached = false;
-    // Capture the run's session inside the tool's ALS; finalizeBackground below
+    // Capture the run's session inside the tool's ALS; deliverAndFinalize below
     // unregisters after the process ends, possibly outside the ALS.
     const runSession = currentSession();
     const session = new BashBackgroundSession();
@@ -499,13 +499,6 @@ export class BashTool extends defineTool({
       ),
     );
 
-    const finalizeBackground = (
-      options?: Parameters<typeof childStream.finalize>[0],
-    ): Promise<void> => {
-      detachInterruptHandler();
-      return childStream.finalize(options);
-    };
-
     const logBackgroundFailure = (action: string, err: unknown): void => {
       logger.error(`Failed to ${action} background bash result`, {
         data: err,
@@ -541,11 +534,12 @@ export class BashTool extends defineTool({
 
     const deliverAndFinalize = async (
       text: string,
-      finalizeOptions: Parameters<typeof finalizeBackground>[0],
+      finalizeOptions: Parameters<typeof childStream.finalize>[0],
     ): Promise<void> => {
       // The child is terminal before the continuation is submitted, so a
       // synchronously claimed parent recovery can never observe it as running.
-      await finalizeBackground(finalizeOptions);
+      detachInterruptHandler();
+      await childStream.finalize(finalizeOptions);
       try {
         const delivery = await deliverChildRunFollowUp({
           targetStreamId: parentStreamId,

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -14,12 +14,7 @@ import {
 } from '@agent/runtime/SessionHandle';
 import { classifyAgentError } from '@common/errors';
 import { RUN_OUTCOME, STREAM_PHASE, buildRunDescriptor } from '@shared/schemas';
-import type {
-  ExecutionId,
-  RunKind,
-  StreamTabId,
-  StorageKey,
-} from '@shared/schemas';
+import type { ExecutionId, RunKind, StreamTabId } from '@shared/schemas';
 import { deriveRunOutcome } from '@shared/streams/streamStatus';
 import { createRunTrace } from '@transcript';
 import type { TranscriptWriter } from '@transcript/StreamLogStore';

--- a/src/tools/delegationModelAvailability.ts
+++ b/src/tools/delegationModelAvailability.ts
@@ -6,6 +6,9 @@ import { unique } from '@utils/core';
 
 const AVAILABLE_MODELS_LINE = /^Available models:.*$/m;
 
+const NO_DELEGATION_MODELS_MESSAGE =
+  'No models are currently available for delegation in the active API mode. Switch API mode or configure a provider API key before delegating.';
+
 export function availableModelNamesFromOptions(
   models: readonly ModelOptionData[],
 ): string[] {
@@ -40,9 +43,7 @@ export function selectDelegationModelFromAvailableNames(input: {
     input.availableModels.map((model) => model.trim()).filter(Boolean),
   );
   if (availableModels.length === 0) {
-    throw new Error(
-      'No models are currently available for delegation in the active API mode. Switch API mode or configure a provider API key before delegating.',
-    );
+    throw new Error(NO_DELEGATION_MODELS_MESSAGE);
   }
 
   const decision = decideRunModel(
@@ -58,9 +59,7 @@ export function selectDelegationModelFromAvailableNames(input: {
     (model) => availableModels.includes(model),
   );
   if (!decision) {
-    throw new Error(
-      'No models are currently available for delegation in the active API mode. Switch API mode or configure a provider API key before delegating.',
-    );
+    throw new Error(NO_DELEGATION_MODELS_MESSAGE);
   }
   if (decision.unavailable) {
     const requestedModel = normalizeModelName(input.requestedModel);

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -307,7 +307,7 @@ export class PRPollingSource extends PollingSourceBase<
   }
 
   protected async pollOne(
-    _key: string,
+    key: string,
     state: SubscriptionState,
   ): Promise<void> {
     const { pr } = state;
@@ -328,7 +328,7 @@ export class PRPollingSource extends PollingSourceBase<
       const parsed = this.validateOrSkip(
         prRes,
         GhPullRequestSchema,
-        `Skipping PR poll for ${prKeyToString(pr)}: malformed pull-request payload`,
+        `Skipping PR poll for ${key}: malformed pull-request payload`,
       );
       if (!parsed) return;
       const prData = parsed.data;
@@ -345,7 +345,7 @@ export class PRPollingSource extends PollingSourceBase<
         newState === 'closed'
       ) {
         this.emit(state, formatPRClosed(state.slug, pr.pullNumber, newMerged));
-        this.detach(prKeyToString(pr));
+        this.detach(key);
         return;
       }
       state.state = newState;
@@ -410,13 +410,12 @@ export class PRPollingSource extends PollingSourceBase<
       // transition above is the primary path, but this covers any edge
       // (future refactors, unexpected state) where we could otherwise
       // return early every tick without ever cleaning up.
-      const prKey = prKeyToString(pr);
-      if (this.has(prKey)) {
+      if (this.has(key)) {
         this.emit(
           state,
           formatPRClosed(state.slug, pr.pullNumber, state.merged),
         );
-        this.detach(prKey);
+        this.detach(key);
       }
       state.initialized = true;
       return;

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -466,7 +466,7 @@ export function formatPostCompactionContext(
 
   const lines: string[] = ['<post-compaction-context>', `<note>${note}</note>`];
 
-  if (subagents.length > 0) {
+  if (hasChildren) {
     lines.push(`<active-subagents count="${subagents.length}">`);
     for (const sa of subagents) {
       const statusAttr = sa.status ? ` status="${escapeAttr(sa.status)}"` : '';

--- a/src/transcript/StreamLog.ts
+++ b/src/transcript/StreamLog.ts
@@ -86,14 +86,18 @@ export class StreamLog {
       return entry.seqNo === seqNo ? entry : { ...entry, seqNo };
     });
     this.seqCounter = this.entries.length;
-    this.settlementSeqCounter = Math.max(
-      this.entries.length,
-      ...this.entries.map((entry) => entry.settlementSeqNo ?? 0),
-    );
+    // The settlement head is never below the entry count; one pass over the
+    // entries raises it to the highest order already allocated on disk while
+    // building the id index and the running-state counters.
+    this.settlementSeqCounter = this.entries.length;
 
     for (const [i, entry] of this.entries.entries()) {
       this.indexById.set(entry.id, i);
       this.countEntry(entry, 1);
+      const settlementSeqNo = entry.settlementSeqNo ?? 0;
+      if (settlementSeqNo > this.settlementSeqCounter) {
+        this.settlementSeqCounter = settlementSeqNo;
+      }
     }
   }
 
@@ -291,14 +295,6 @@ export class StreamLog {
     }
     deltas.sort((a, b) => a.seqNo - b.seqNo);
     return deltas.map(({ delta }) => delta);
-  }
-
-  drainDirtyUpdates(
-    maxSeqInclusive: number = this.seqCounter,
-  ): StreamLogEntry[] {
-    const updates = this.getDirtyUpdates(maxSeqInclusive);
-    this.ackDirtyUpdates(updates);
-    return updates;
   }
 
   clearDirtyUpdates(maxSeqInclusive: number = this.seqCounter): void {

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -432,8 +432,11 @@ export class StreamLogStore {
       // queue the intent so it runs once the load completes. Otherwise the
       // rapid in-flight → stale flip would finish the load into memory
       // with no subsequent eviction trigger.
-      if (state?.writer !== undefined || state?.pendingLoad !== undefined) {
-        this.ensureStreamState(streamId).pendingRelease = true;
+      if (
+        state &&
+        (state.writer !== undefined || state.pendingLoad !== undefined)
+      ) {
+        state.pendingRelease = true;
       }
       return;
     }

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -1610,15 +1610,6 @@ export class StreamSnapshotStore {
     return map;
   }
 
-  /** Stream IDs that still have execution sidecar state. */
-  getTaskStateStreams(): Set<StreamTabId> {
-    const streams = new Set<StreamTabId>();
-    for (const [stream, record] of this.records) {
-      if (record.runConfig !== undefined) streams.add(stream);
-    }
-    return streams;
-  }
-
   /**
    * Workflow stream IDs whose taskState's agentConfig matches `match`. Used by
    * command-palette pack/clean to clear missing-output markers across every tab

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -166,11 +166,9 @@ export function attachTranscriptRecorder(
         data: { status: state.ended ? 'completed' : 'running' },
         verbose: isDebugModeEnabled(),
       } satisfies StreamLogAppendInput;
-      const appended = state.ended
-        ? writer.appendSettled(entry)
-        : writer.append(entry);
-      state.created = !!appended;
-      if (!state.created) state.enabled = false;
+      if (state.ended) writer.appendSettled(entry);
+      else writer.append(entry);
+      state.created = true;
       return;
     }
 

--- a/src/transcript/traceAssembler.ts
+++ b/src/transcript/traceAssembler.ts
@@ -46,16 +46,20 @@ export async function assembleTrace(
   const fallbackStreamId = getStreamTabId(config.agent, config.model, {
     executionId,
   });
+  // One call-scoped snapshot store serves both the resolver's sidecar scan and
+  // the snapshot read, so the two share its per-stream KV handles.
+  const snapshotStore = new StreamSnapshotStore();
   const streamId =
     (
       await resolvePersistedStreamIdForExecution(executionId, {
+        snapshotStore,
         streamLogStore,
       })
     )?.streamId ?? fallbackStreamId;
 
   const [, snapshot] = await Promise.all([
     streamLogStore.ensureLoaded(streamId),
-    new StreamSnapshotStore().read(streamId),
+    snapshotStore.read(streamId),
   ]);
   const log = streamLogStore.get(streamId);
   if (!log) return { status: 'streamLogs_missing' };

--- a/src/utils/media/img.ts
+++ b/src/utils/media/img.ts
@@ -205,24 +205,18 @@ export async function countPdfPages(pdfPath: string): Promise<number> {
   }
 }
 
-/** Convert a single page of a PDF to a base64 encoded PNG image. */
+/**
+ * Convert a single page of an already-resolved PDF to a base64 encoded PNG.
+ * The caller owns resolving the path and verifying the image tool once per
+ * conversion, so neither is re-probed per page.
+ */
 async function singlePagePdf2Png(
-  pdfPath: string,
+  absolutePath: string,
   pageNum: number,
   quality: number,
   maxSize: [number, number],
 ): Promise<string> {
   try {
-    // Check for GraphicsMagick/ImageMagick installation
-    if (!(await detectImageTool())) {
-      throw new Error('GraphicsMagick/ImageMagick is not installed.');
-    }
-
-    const absolutePath = await resolveFile(pdfPath);
-    if (!absolutePath) {
-      throw new Error(`PDF file not found: ${pdfPath}`);
-    }
-
     ensureTempDir();
 
     const tempFilePattern = `temp_${Date.now()}`;
@@ -252,7 +246,7 @@ async function singlePagePdf2Png(
     const imageBuffer = AbsoluteFS.readBytesSync(result.path);
     logger.debug(
       CHANNEL,
-      `Successfully converted page ${pageNum} of ${pdfPath} to PNG`,
+      `Successfully converted page ${pageNum} of ${absolutePath} to PNG`,
     );
     return imageBuffer.toString('base64');
   } finally {
@@ -260,33 +254,8 @@ async function singlePagePdf2Png(
   }
 }
 
-/** Convert multiple pages of a PDF to base64 encoded PNG images. */
-async function multiPagePdf2Png(
-  pdfPath: string,
-  pageCount: number,
-  quality: number,
-  maxSize: [number, number],
-  maxPages: number = 100,
-): Promise<string[]> {
-  const pagesToConvert = Math.min(pageCount, maxPages);
-
-  const base64Images: string[] = [];
-  for (let pageNum = 1; pageNum <= pagesToConvert; pageNum++) {
-    const base64Image = await singlePagePdf2Png(
-      pdfPath,
-      pageNum,
-      quality,
-      maxSize,
-    );
-    base64Images.push(base64Image);
-  }
-
-  logger.debug(
-    CHANNEL,
-    `Successfully converted ${base64Images.length} pages from ${pdfPath}`,
-  );
-  return base64Images;
-}
+/** Pages converted when the caller does not cap the count. */
+const DEFAULT_PDF_MAX_PAGES = 100;
 
 /** Process a PDF file and return base64 encoded PNG image(s). Returns null on error. */
 export async function processPdf2Png(
@@ -307,16 +276,31 @@ export async function processPdf2Png(
       return null;
     }
 
-    if (pageCount === 1) {
-      return await singlePagePdf2Png(pdfPath, 1, quality, maxSize);
+    if (!(await detectImageTool())) {
+      throw new Error('GraphicsMagick/ImageMagick is not installed.');
     }
-    return await multiPagePdf2Png(
-      pdfPath,
+
+    if (pageCount === 1) {
+      return await singlePagePdf2Png(absolutePath, 1, quality, maxSize);
+    }
+
+    // `??` on purpose: a null maxPages (e.g. from a .nullish() tool field)
+    // means "no limit requested" and gets the default cap, same as undefined.
+    const pagesToConvert = Math.min(
       pageCount,
-      quality,
-      maxSize,
-      maxPages,
+      maxPages ?? DEFAULT_PDF_MAX_PAGES,
     );
+    const base64Images: string[] = [];
+    for (let pageNum = 1; pageNum <= pagesToConvert; pageNum++) {
+      base64Images.push(
+        await singlePagePdf2Png(absolutePath, pageNum, quality, maxSize),
+      );
+    }
+    logger.debug(
+      CHANNEL,
+      `Successfully converted ${base64Images.length} pages from ${pdfPath}`,
+    );
+    return base64Images;
   } catch (err) {
     logger.error(CHANNEL, `Error processing PDF input: ${toErrorMessage(err)}`);
     return null;

--- a/src/utils/prompt/index.ts
+++ b/src/utils/prompt/index.ts
@@ -111,6 +111,11 @@ async function resolveValue(value: unknown): Promise<unknown> {
   return Object.fromEntries(entries);
 }
 
+// One environment for every prompt render, as in polishModel.ts: configuring
+// nunjucks builds a filesystem loader, and renderString compiles its template
+// per call regardless, so a per-call environment was pure setup cost.
+const promptEnv = nunjucks.configure({ autoescape: false });
+
 /**
  * Render a prompt string using nunjucks templating
  * @param prompt The prompt template string
@@ -122,6 +127,8 @@ export async function renderPrompt(
   variables: Record<string, unknown>,
 ): Promise<string> {
   const resolvedVariables = await resolveValue(variables);
-  const env = nunjucks.configure({ autoescape: false });
-  return env.renderString(prompt, resolvedVariables as Record<string, unknown>);
+  return promptEnv.renderString(
+    prompt,
+    resolvedVariables as Record<string, unknown>,
+  );
 }

--- a/src/utils/system/toolUtils.ts
+++ b/src/utils/system/toolUtils.ts
@@ -329,11 +329,14 @@ export async function checkToolInstalled(
 
     return isInstalled;
   } catch (err) {
+    // The user-facing message is always the tool's own install guidance, so
+    // log the underlying cause instead of dropping it.
+    logger.warn(
+      CHANNEL,
+      `Tool check for '${toolName ?? 'custom config'}' failed: ${toErrorMessage(err)}`,
+    );
     if (showError) {
-      const errorMessage =
-        config.errorMessage ||
-        `Failed to check tool installation: ${toErrorMessage(err)}`;
-      await reportMissingTool(errorMessage);
+      await reportMissingTool(config.errorMessage);
     }
     return false;
   }
@@ -456,33 +459,26 @@ export const SYSTEM_PACKAGE_MANAGERS = ['brew', 'apt', 'scoop'] as const;
 
 export type SystemPackageManager = (typeof SYSTEM_PACKAGE_MANAGERS)[number];
 
-let cachedPackageManager: SystemPackageManager | undefined;
+// Platform-aware probe order: check the platform's native PM first so that
+// cross-platform installs (e.g. Linuxbrew on Linux) don't shadow the PM that
+// DEPENDENCY_INSTALL_COMMANDS actually uses for that platform.
+const PREFERRED_PACKAGE_MANAGER: Readonly<
+  Partial<Record<NodeJS.Platform, SystemPackageManager>>
+> = Object.freeze({ darwin: 'brew', linux: 'apt', win32: 'scoop' });
 
 /**
  * Detect the first available package manager on the system.
- * Returns 'brew', 'apt', 'scoop', or null if none found.
+ * Returns 'brew', 'apt', 'scoop', or null if none found. Each answer comes
+ * from {@link hasPackageManager}, which owns the probe cache.
  */
 export function detectPackageManager(): SystemPackageManager | null {
-  if (cachedPackageManager !== undefined) return cachedPackageManager;
-
-  // Platform-aware order: check the platform's native PM first so that
-  // cross-platform installs (e.g. Linuxbrew on Linux) don't shadow the
-  // PM that DEPENDENCY_INSTALL_COMMANDS actually uses for that platform.
-  const preferred: Partial<Record<NodeJS.Platform, SystemPackageManager>> = {
-    darwin: 'brew',
-    linux: 'apt',
-    win32: 'scoop',
-  };
-  const first = preferred[process.platform];
+  const first = PREFERRED_PACKAGE_MANAGER[process.platform];
   const managers = first
     ? [first, ...SYSTEM_PACKAGE_MANAGERS.filter((name) => name !== first)]
     : SYSTEM_PACKAGE_MANAGERS;
 
   for (const name of managers) {
-    if (hasPackageManager(name)) {
-      cachedPackageManager = name;
-      return name;
-    }
+    if (hasPackageManager(name)) return name;
   }
 
   logger.debug(CHANNEL, 'No package manager detected');

--- a/src/utils/text/xmlConversion.ts
+++ b/src/utils/text/xmlConversion.ts
@@ -101,53 +101,41 @@ function convertHtmlToMarkdown(html: string): string {
 }
 
 /**
- * Reference type patterns for Pandoc normalization.
- * Each entry maps reference type to the LaTeX command.
+ * Pandoc reference rewrites, compiled once at module load.
+ *
+ * Pandoc emits references in three shapes, each carrying the same
+ * `{reference-type="..." reference="label"}` suffix:
+ * - `[\[label\]](#anchor){...}`: markdown link with escaped brackets
+ * - `[label](#anchor){...}`: plain markdown link
+ * - `[label]{...}`: bare
+ * All three become the canonical `\ref{label}` / `\eqref{label}` /
+ * `\cref{label}`.
  */
-const REFERENCE_PATTERNS: Array<{ type: string; command: string }> = [
-  { type: 'ref', command: 'ref' },
-  { type: 'eqref', command: 'eqref' },
-  { type: '[Cc]ref', command: 'cref' },
-];
+const PANDOC_REFERENCE_REWRITES: ReadonlyArray<readonly [RegExp, string]> = (
+  [
+    { type: 'ref', command: 'ref' },
+    { type: 'eqref', command: 'eqref' },
+    { type: '[Cc]ref', command: 'cref' },
+  ] as const
+).flatMap(({ type, command }) => {
+  const suffix = `\\{reference-type="${type}"\\s+reference="([^"]+)"\\}`;
+  const replacement = `\\${command}{$2}`;
+  return [
+    [
+      new RegExp(`\\[\\\\?\\[([^\\]]+)\\\\?\\]\\]\\(#[^)]*\\)${suffix}`, 'g'),
+      replacement,
+    ],
+    [new RegExp(`\\[([^\\[\\]]+)\\]\\(#[^)]*\\)${suffix}`, 'g'), replacement],
+    [new RegExp(`\\[([^\\]]+)\\]${suffix}`, 'g'), replacement],
+  ] as const;
+});
 
-/**
- * Normalize Pandoc reference syntax to canonical LaTeX format.
- * Pandoc outputs references in formats like:
- * - [label]{reference-type="ref" reference="label"}
- * - [\[label\]](#anchor){reference-type="ref" reference="label"}
- * These are converted to standard \ref{label}, \cref{label}, \eqref{label}
- */
+/** Normalize Pandoc reference syntax to canonical LaTeX commands. */
 function normalizePandocReferences(text: string): string {
-  for (const { type, command } of REFERENCE_PATTERNS) {
-    // Handle markdown-link format: [\[label\]](#anchor){reference-type="ref" reference="label"}
-    text = text.replaceAll(
-      new RegExp(
-        `\\[\\\\?\\[([^\\]]+)\\\\?\\]\\]\\(#[^)]*\\)\\{reference-type="${type}"\\s+reference="([^"]+)"\\}`,
-        'g',
-      ),
-      `\\${command}{$2}`,
-    );
-
-    // Handle plain markdown-link format: [label](#anchor){reference-type="ref" reference="label"}
-    text = text.replaceAll(
-      new RegExp(
-        `\\[([^\\[\\]]+)\\]\\(#[^)]*\\)\\{reference-type="${type}"\\s+reference="([^"]+)"\\}`,
-        'g',
-      ),
-      `\\${command}{$2}`,
-    );
-
-    // Handle simple Pandoc format: [label]{reference-type="ref" reference="label"}
-    text = text.replaceAll(
-      new RegExp(
-        `\\[([^\\]]+)\\]\\{reference-type="${type}"\\s+reference="([^"]+)"\\}`,
-        'g',
-      ),
-      `\\${command}{$2}`,
-    );
-  }
-
-  return text;
+  return PANDOC_REFERENCE_REWRITES.reduce(
+    (result, [pattern, replacement]) => result.replaceAll(pattern, replacement),
+    text,
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

Fifth pass in the simplification campaign, and the first partitioned by quality lens rather than by geography. 22 area agents (production dirs paired with their test dirs) applied four lenses: lifecycle ownership and minimal synchronization, excessive fallbacks, duplicated and excessive operations (perf/memory), and interface leakage. Behavior-preserving throughout: provably-dead fallback links were deleted, redundant recomputation removed, return types narrowed to what callers actually read, and listener detaches moved to their owners. Anything whose fix would change a live fallback or a wire contract was reported, not made (167 deferred items, tracked below).

## Issue acceptance gates

No issue; scheduled campaign round. Side deliverable: the lifecycle ownership map (211 facts, 21 with demonstrated race risk) that will drive the single-owner runtime redesign.

## Single source of truth

Changes move derivations to their existing owners rather than creating new ones: repeated fallback values now live at their source; re-parses of boundary-validated data were deleted in favor of the validating boundary; render-frequency computation moved to data-change frequency where provably identical.

## Duplication and abstraction budget

No abstraction added; no middle layers; no single-caller extractions. The diff is deletion-shaped: dead fallback links, immutability-theater copies on data nobody else holds, defensive re-checks the type system already guarantees.

## Net elements (R6)

| | |
| --- | --- |
| Files changed | 108 (all modified, 0 added, 0 deleted) |
| Net LoC | **-914** (2,243 insertions, 3,157 deletions) |
| Exported symbols | -1 (6 added, 7 removed) |

## Consumer counts (R8)

No emit path or subscribe surface deleted or re-routed. The 7 removed exports each grep to zero remaining consumers; the dead-code ratchet confirms (17 findings vs 17 baselined, baseline untouched).

## Host impact

Extension / Desktop / CLI: no behavior change on any host. One reviewer finding (low) was a `??`-vs-default-parameter equivalence on `multiPagePdf2Png.maxPages`, unreachable today; resolved by documenting the deliberate `??` semantics at the site.

## Scheduled refactoring

- The **lifecycle ownership map**: 211 facts catalogued with writers, sync mechanism, and a single-owner sketch each; 21 carry demonstrated race risk (e.g. the run-terminal-outcome fact has four writer arms coordinated by `claimTerminalFinalize`, and the WAITING-teardown fact is belt-and-suspenders across two untrusted sources by its own comment's admission). This is the input to a deliberate redesign, not something to sweep.
- 167 deferred items (live-fallback changes, wire-contract narrowing) recorded in the campaign workspace.
- The consistency-implementation round (approved plan, P1-P8) starts from this base.

## Validation

| check | result |
| --- | --- |
| `npm run typecheck` | pass (1 fix: restored the Lit weak-type `hostConnected` stub an agent deleted — same trap as round 1) |
| `npm test` | 793 files, 8,008 tests, 0 failures, no fixes needed |
| `npm run lint` / `npm run format` / `npx prettier --check .` | pass, no changes |
| dead-code ratchet | 17 vs 17 baselined |
| architecture ratchets | 10 files, 68 tests, pass |

Adversarial review across 14 areas, primed for live-fallback deletion, stale-read introduction, and race uncovering, returned **one low finding**, addressed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qs4Vgf3VxahEjs5maQF5Ds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent launch, stream status, session exit, and TUI run-state signals across many files; changes are intended to be behavior-preserving but regressions could affect Ctrl-C hints, resume/exit, or CLI flag parsing.
> 
> **Overview**
> Large **deletion-shaped** refactor (~900 net lines removed) that consolidates repeated logic, drops provably-dead paths, and moves hot-path work off per-keystroke / per-second renders.
> 
> **CLI & TUI:** Introduces **`chatTuiRunPending`** as the single definition of an in-flight root run (replacing scattered `runPromise && !runCompleted`). **`useMemo`** guards child-list and status-bar subagent counts from 1 Hz elapsed-time ticks. Transcript ordering uses a single forward pass instead of map/filter chains; **`documentsNegatedBooleanForm`** centralizes `--no-*` flag registration and **`firstPositionalIndex`** reuses leading-global-flag parsing. Command handlers lose default empty `options` objects; approval retry options are required where always supplied.
> 
> **Agent runtime:** Stream id is derived once at launch; **`ExecutionHandle.deliveryTargetStreamId`** is computed from parent vs child instead of a mirrored field. **`StreamStatusService`** drops duplicate `getAll` / `getAllSubstates` in favor of **`getAllStreamStates`**. Tool-use prepare/wait nodes return **`CyclePrepResult`** directly (no `{ kind: 'success', result }` wrapper); subagent wait prep no longer builds unused turn facts. **`KeyedMutex`** serializes bundled agent directory reconcile; **`toApprovalSettlement`** unifies bash/plan/proposal settlements.
> 
> **Hosts & IPC:** Desktop EXECUTE validates with a command-specific schema; progress fact appliers stop double **`isAvailable`** checks. Extension/webview slices rely on typed non-optional multi-file lists; run progress renderer drops boolean “handled” returns and derives terminal phase from status.
> 
> **Tests:** Helpers and fixtures deduplicated (forced compaction handler, preflight counting client, browser sign-in stubs, launcher layout wrapper).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 031de10d48a9ab2fcb22ebdce58aca8384822e4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->