### PR TITLE
fix: use one custom-agent delete confirmation

### DIFF
--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.styles.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.styles.ts
@@ -227,26 +227,4 @@ export const agentSelectionPanelStyles: CSSResult = css`
     text-overflow: ellipsis;
     white-space: nowrap;
   }
-
-  .agent-delete-confirm {
-    display: flex;
-    align-items: center;
-    gap: var(--wa-space-xs);
-    padding: var(--wa-space-2xs) var(--wa-space-xs);
-    background: var(--wa-color-danger-fill-quiet);
-    border: var(--border-thin) solid var(--wa-color-danger-on-quiet);
-    border-radius: var(--border-radius);
-    font-size: var(--font-size-sm);
-    color: var(--wa-color-text-normal);
-  }
-
-  .agent-delete-confirm-text {
-    flex: 1;
-  }
-
-  .agent-delete-confirm-actions {
-    display: flex;
-    gap: var(--wa-space-2xs);
-    flex-shrink: 0;
-  }
 `;

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -105,9 +105,6 @@ export class AgentSelectionPanel extends LitElement {
   @state() private groupedSources: Map<AgentSourceType, AgentSelectionItem[]> =
     new Map();
 
-  /** Key of agent pending delete confirmation, or null */
-  @state() private pendingDeleteKey: string | null = null;
-
   /** Flat list in visual display order, for keyboard navigation */
   private displayOrder: AgentSelectionItem[] = [];
 
@@ -139,8 +136,6 @@ export class AgentSelectionPanel extends LitElement {
         this.selectedKey =
           this.displayOrder.length > 0 ? agentKey(this.displayOrder[0]) : null;
       }
-      // Clear stale delete confirmation when agent list changes
-      this.pendingDeleteKey = null;
     }
   }
 
@@ -150,7 +145,6 @@ export class AgentSelectionPanel extends LitElement {
 
   private selectAgent(agent: AgentSelectionItem): void {
     this.selectedKey = agentKey(agent);
-    this.pendingDeleteKey = null;
   }
 
   private handleListKeydown(event: KeyboardEvent): void {
@@ -206,21 +200,9 @@ export class AgentSelectionPanel extends LitElement {
   }
 
   private handleDeleteCustomAgent(agent: AgentSelectionItem): void {
-    const key = agentKey(agent);
-    if (this.pendingDeleteKey === key) {
-      // Confirmed — request the delete
-      this.pendingDeleteKey = null;
-      postMessage(SETTINGS_VIEW_COMMANDS.DELETE_CUSTOM_AGENT, {
-        agentName: agent.name,
-      });
-    } else {
-      // First click — show confirmation
-      this.pendingDeleteKey = key;
-    }
-  }
-
-  private cancelDelete(): void {
-    this.pendingDeleteKey = null;
+    postMessage(SETTINGS_VIEW_COMMANDS.DELETE_CUSTOM_AGENT, {
+      agentName: agent.name,
+    });
   }
 
   private handleViewRemotePrompt(agent: AgentSelectionItem): void {
@@ -460,8 +442,6 @@ export class AgentSelectionPanel extends LitElement {
     const { tone, badge } = SOURCE_META[agent.source];
     const builtIn = tone === 'builtin';
     const isCustom = agent.source === AGENT_SOURCE.CUSTOM;
-    const showDeleteConfirm =
-      isCustom && this.pendingDeleteKey === agentKey(agent);
 
     return html`
       <div class="agent-detail-pane">
@@ -530,36 +510,6 @@ export class AgentSelectionPanel extends LitElement {
         <div class="agent-detail-actions">
           ${this.renderDetailActions(agent)}
         </div>
-
-        ${
-          showDeleteConfirm
-            ? html`
-                <div class="agent-delete-confirm">
-                  <span class="agent-delete-confirm-text">
-                    Delete custom agent "${agent.name}"? This cannot be undone.
-                  </span>
-                  <div class="agent-delete-confirm-actions">
-                    ${renderLabeledActionButton({
-                      icon: 'trash',
-                      text: 'Delete',
-                      label: 'Confirm delete custom agent',
-                      className: 'agent-action-btn',
-                      kind: 'danger',
-                      onClick: () => this.handleDeleteCustomAgent(agent),
-                    })}
-                    ${renderLabeledActionButton({
-                      icon: 'xmark',
-                      text: 'Cancel',
-                      label: 'Cancel delete custom agent',
-                      className: 'agent-action-btn',
-                      kind: 'ghost',
-                      onClick: () => this.cancelDelete(),
-                    })}
-                  </div>
-                </div>
-              `
-            : nothing
-        }
       </div>
     `;
   }

--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -441,7 +441,6 @@ export class AgentSelectionPanel extends LitElement {
 
     const { tone, badge } = SOURCE_META[agent.source];
     const builtIn = tone === 'builtin';
-    const isCustom = agent.source === AGENT_SOURCE.CUSTOM;
 
     return html`
       <div class="agent-detail-pane">

--- a/packages/extension/src/settingsView/handlers/agentHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/agentHandlers.ts
@@ -60,6 +60,7 @@ export class AgentHandlers {
       fetchPromptConfig: fetchRemoteAgentConfigYaml,
     });
   private readonly visibilityController: SettingsAgentVisibilityController;
+  private readonly activeCustomAgentDeletions = new Set<string>();
 
   constructor(
     private readonly ctx: SettingsHandlerContext,
@@ -317,50 +318,57 @@ export class AgentHandlers {
   async handleDeleteCustomAgent(
     data: SettingsMessageFor<typeof SETTINGS_VIEW_CMD.DELETE_CUSTOM_AGENT>,
   ): Promise<void> {
-    await withHandlerErrorHandling(
-      this.ctx,
-      'Failed to delete custom agent',
-      async () => {
-        const key = createKey('custom', data.agentName);
-        const entry = getAgent(key);
-        if (!entry?.path) {
-          await showLoggedMessage(
-            this.ctx.channel,
-            `Custom agent not found: ${data.agentName}`,
+    if (this.activeCustomAgentDeletions.has(data.agentName)) return;
+    this.activeCustomAgentDeletions.add(data.agentName);
+
+    try {
+      await withHandlerErrorHandling(
+        this.ctx,
+        'Failed to delete custom agent',
+        async () => {
+          const key = createKey('custom', data.agentName);
+          const entry = getAgent(key);
+          if (!entry?.path) {
+            await showLoggedMessage(
+              this.ctx.channel,
+              `Custom agent not found: ${data.agentName}`,
+            );
+            return;
+          }
+
+          const customDir = await agentDirectories.custom();
+          const result = this.fileController.planDeleteCustomAgent({
+            entry,
+            customDir,
+          });
+          if (!result.ok) {
+            await showLoggedMessage(
+              this.ctx.channel,
+              `Refusing to delete: file is not inside the custom agents directory.`,
+            );
+            return;
+          }
+
+          const deleteChoice = 'Delete';
+          const confirmed = await vscode.window.showWarningMessage(
+            `Delete "${data.agentName}"? This cannot be undone.`,
+            { modal: true },
+            deleteChoice,
           );
-          return;
-        }
+          if (confirmed !== deleteChoice) return;
 
-        const customDir = await agentDirectories.custom();
-        const result = this.fileController.planDeleteCustomAgent({
-          entry,
-          customDir,
-        });
-        if (!result.ok) {
-          await showLoggedMessage(
-            this.ctx.channel,
-            `Refusing to delete: file is not inside the custom agents directory.`,
+          await AbsoluteFS.delete(result.plan.path, { recursive: false });
+
+          void vscode.window.showInformationMessage(
+            `Deleted custom agent: ${data.agentName}`,
           );
-          return;
-        }
 
-        const deleteChoice = 'Delete';
-        const confirmed = await vscode.window.showWarningMessage(
-          `Delete "${data.agentName}"? This cannot be undone.`,
-          { modal: true },
-          deleteChoice,
-        );
-        if (confirmed !== deleteChoice) return;
-
-        await AbsoluteFS.delete(result.plan.path, { recursive: false });
-
-        void vscode.window.showInformationMessage(
-          `Deleted custom agent: ${data.agentName}`,
-        );
-
-        await this.refreshAfterAgentMutation();
-      },
-    );
+          await this.refreshAfterAgentMutation();
+        },
+      );
+    } finally {
+      this.activeCustomAgentDeletions.delete(data.agentName);
+    }
   }
 
   // ── Custom agent directory handlers ──

--- a/src/test-kernel/settings/AgentHandlersDelete.vitest.ts
+++ b/src/test-kernel/settings/AgentHandlersDelete.vitest.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  createKey: vi.fn(() => 'custom:my-agent'),
+  deleteFile: vi.fn(async () => undefined),
+  getAgent: vi.fn(() => ({ path: '/custom/my-agent.yaml' })),
+  planDeleteCustomAgent: vi.fn(() => ({
+    ok: true as const,
+    plan: { path: '/custom/my-agent.yaml' },
+  })),
+  refreshAfterAgentMutation: vi.fn(async () => undefined),
+  showInformationMessage: vi.fn(),
+  showWarningMessage: vi.fn(),
+}));
+
+vi.mock('vscode', () => ({
+  commands: { executeCommand: vi.fn() },
+  window: {
+    showInformationMessage: mocks.showInformationMessage,
+    showWarningMessage: mocks.showWarningMessage,
+  },
+  workspace: { openTextDocument: vi.fn() },
+  Uri: { file: (path: string) => ({ fsPath: path }) },
+}));
+
+vi.mock('@agent/index', () => ({
+  createKey: mocks.createKey,
+  getAgent: mocks.getAgent,
+  loadAgents: vi.fn(),
+  refresh: vi.fn(),
+}));
+vi.mock('@agent/remote/remoteAgentConfigClient', () => ({
+  fetchRemoteAgentConfigYaml: vi.fn(),
+}));
+vi.mock('@auth/SupabaseClient', () => ({
+  SupabaseClient: { getAccessToken: vi.fn(), getUserTier: vi.fn() },
+}));
+vi.mock('@common/state', () => ({ globalSM: {}, workspaceSM: {} }));
+vi.mock('@common/teams/TeamRosterApplication', () => ({
+  applyTeamRosterWithPreflight: vi.fn(),
+}));
+vi.mock('@controllers/settingsView/SettingsAgentControllerFactory', () => ({
+  createSettingsAgentControllers: () => ({
+    catalog: {},
+    directory: {},
+    visibility: {},
+  }),
+}));
+vi.mock('@controllers/settingsView/SettingsAgentFileController', () => ({
+  SettingsAgentFileController: class {
+    planDeleteCustomAgent = mocks.planDeleteCustomAgent;
+  },
+}));
+vi.mock(
+  '@controllers/settingsView/SettingsRemoteAgentPromptController',
+  () => ({
+    SettingsRemoteAgentPromptController: class {},
+  }),
+);
+vi.mock('@frontend/agents/agentTemplateBundle', () => ({
+  renderAgentTemplateFromBundle: vi.fn(),
+}));
+vi.mock('@frontend/auth/agentCatalogRefreshScope', () => ({
+  withAgentCatalogAuthRefreshDeferred: vi.fn(),
+}));
+vi.mock('@frontend/agents/AgentDirectoryManager', () => ({
+  agentDirectories: {
+    custom: vi.fn(async () => '/custom'),
+    getDirectory: vi.fn(),
+  },
+}));
+vi.mock('@frontend/ui/errorHandlingUtils', () => ({
+  showLoggedErrorMessage: vi.fn(),
+  showLoggedMessage: vi.fn(),
+}));
+vi.mock('@shared/settingsView/handlers/agentSelectionHandlers', () => ({
+  buildAgentModePresetsMessage: vi.fn(),
+  buildAgentSelectionMessage: vi.fn(),
+  buildCustomAgentDirMessage: vi.fn(),
+}));
+vi.mock('@utils/files', () => ({
+  AbsoluteFS: { delete: mocks.deleteFile },
+}));
+
+import { AgentHandlers } from '@settingsView/handlers/agentHandlers';
+
+function createHandlers(): AgentHandlers {
+  return new AgentHandlers(
+    {
+      channel: 'test',
+      extensionContext: {},
+      logger: { debug: vi.fn(), error: vi.fn(), warn: vi.fn() },
+      withActiveWebview: vi.fn(),
+    } as never,
+    mocks.refreshAfterAgentMutation,
+  );
+}
+
+describe('AgentHandlers custom-agent deletion', () => {
+  it('coalesces repeated requests while the host confirmation is pending', async () => {
+    let resolveConfirmation!: (choice: string | undefined) => void;
+    const pendingConfirmation = new Promise<string | undefined>((resolve) => {
+      resolveConfirmation = resolve;
+    });
+    mocks.showWarningMessage.mockReturnValueOnce(pendingConfirmation);
+    const handlers = createHandlers();
+    const request = {
+      command: 'deleteCustomAgent',
+      agentName: 'my-agent',
+    } as const;
+
+    const first = handlers.handleDeleteCustomAgent(request);
+    await vi.waitFor(() =>
+      expect(mocks.showWarningMessage).toHaveBeenCalledTimes(1),
+    );
+
+    await handlers.handleDeleteCustomAgent(request);
+    expect(mocks.showWarningMessage).toHaveBeenCalledTimes(1);
+
+    resolveConfirmation(undefined);
+    await first;
+
+    mocks.showWarningMessage.mockResolvedValueOnce(undefined);
+    await handlers.handleDeleteCustomAgent(request);
+    expect(mocks.showWarningMessage).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/test-kernel/settings/AgentSelectionPanelToggle.vitest.ts
+++ b/src/test-kernel/settings/AgentSelectionPanelToggle.vitest.ts
@@ -19,6 +19,7 @@ import {
 type AgentSelectionPanelElement = HTMLElement & {
   agents: AgentSelectionItem[];
   category: 'workflow' | 'toolUse';
+  unsupportedCommands: ReadonlySet<string> | null;
   updateComplete: Promise<boolean>;
 };
 
@@ -30,14 +31,25 @@ const workflowAgent: AgentSelectionItem = {
   enabled: true,
 };
 
-function renderAgentSelectionPanel(): Promise<AgentSelectionPanelElement> {
+const customAgent: AgentSelectionItem = {
+  name: 'my-agent',
+  category: 'workflow',
+  source: AGENT_SOURCE.CUSTOM,
+  hasPath: true,
+  enabled: true,
+};
+
+function renderAgentSelectionPanel(
+  agents: AgentSelectionItem[] = [workflowAgent],
+): Promise<AgentSelectionPanelElement> {
   return mountComponent<AgentSelectionPanelElement>('agent-selection-panel', {
-    agents: [workflowAgent],
+    agents,
     category: 'workflow',
+    unsupportedCommands: new Set(),
   });
 }
 
-describe('AgentSelectionPanel enabled toggle', () => {
+describe('AgentSelectionPanel', () => {
   useLitComponentTestDom(
     () =>
       import('@settingsView/frontend/components/profile/AgentSelectionPanel'),
@@ -91,5 +103,23 @@ describe('AgentSelectionPanel enabled toggle', () => {
     // The toggle's click handler stops propagation, so the row's own
     // click-to-select handler must not also fire.
     expect(rowClicked).toBe(false);
+  });
+
+  it('requests custom-agent deletion on the first click without an inline confirmation', async () => {
+    const panel = await renderAgentSelectionPanel([customAgent]);
+    const deleteButton = panel.shadowRoot!.querySelector(
+      '[aria-label="Delete custom agent"]',
+    ) as HTMLElement;
+
+    expect(deleteButton).not.toBeNull();
+    expect(panel.shadowRoot!.querySelector('.agent-delete-confirm')).toBeNull();
+
+    deleteButton.click();
+    await panel.updateComplete;
+
+    expect(mocks.postMessage.mock.calls).toEqual([
+      [SETTINGS_VIEW_COMMANDS.DELETE_CUSTOM_AGENT, { agentName: 'my-agent' }],
+    ]);
+    expect(panel.shadowRoot!.querySelector('.agent-delete-confirm')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Remove the settings webview's inline two-click custom-agent deletion confirmation. Clicking Delete now sends the delete request immediately; the extension host's existing modal remains the single confirmation surface.

## Issue acceptance gates

Closes #9461.

- Removes `pendingDeleteKey`, the inline confirm/cancel rendering, and its dead CSS.
- Preserves the unsupported-command guard around the Delete control.
- Adds regression tests proving the first click sends exactly one delete command without rendering an inline confirmation, and repeated requests are coalesced while the host modal is pending.

## Single source of truth

`packages/extension/src/settingsView/handlers/agentHandlers.ts` remains the sole owner of delete confirmation, path validation, and per-agent single-flight suppression before deletion.

## Duplication and abstraction budget

Deletes the duplicate webview confirmation state and UI. Adds no abstraction or pass-through layer.

## Net elements (R6)

- Files: 4 modified, 1 added, 0 deleted.
- Exports/classes/interfaces/enums: no net change.
- LoC: +211 / -119, net +92 (including focused host-handler test scaffolding).

## Consumer counts (R8)

n/a — no export or event key was deleted or rerouted; the existing `DELETE_CUSTOM_AGENT` message is now sent on the first click.

## Host impact

Extension: Custom-agent deletion uses one host modal instead of inline confirmation plus modal.

Desktop: None; desktop already uses its single host confirmation.

CLI: None.

## Scheduled refactoring

None.

## Validation

- Focused delete-flow tests — 4 passed across 2 files.
- Extension TypeScript check — passed.
- ESLint on the three changed files — passed.
- Prettier check on the three changed files — passed.
- `git diff --check origin/main...HEAD` — passed.
- Independent code review — no actionable findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX and confirmation-surface consolidation only; deletion still goes through the same host modal and path validation before file delete.
> 
> **Overview**
> Custom-agent **Delete** in the settings agent panel now sends `DELETE_CUSTOM_AGENT` on the **first click**, instead of a two-step inline confirm/cancel in the detail pane.
> 
> The webview drops `pendingDeleteKey`, the inline confirmation markup, and the related CSS. **Confirmation and path checks stay on the extension host** via the existing modal `showWarningMessage` flow in `handleDeleteCustomAgent`.
> 
> The handler adds an **`activeCustomAgentDeletions` guard** so repeated delete requests for the same agent while that modal is open do not stack multiple dialogs.
> 
> Tests cover one-shot delete from the panel (no inline UI) and coalescing duplicate handler calls until the modal resolves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24b99fd82653c136c1d297581e53e476d1b10e52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

