### PR TITLE
refactor: remove unreachable user text placement

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -138,8 +138,6 @@ const DEFAULT_CONTINUE_LIMIT = 10;
 const DEFAULT_INPUT_TOKEN_LIMIT = 1500000;
 const DEFAULT_OUTPUT_TOKEN_LIMIT_FACTOR = 2.5;
 
-type UserTextPlacement = 'last-user' | 'continuation';
-
 interface AssistantTextAppendOptions {
   /**
    * True when the current trailing user/system message may be the synthetic
@@ -1246,16 +1244,8 @@ export abstract class ModelHandler<
     endTag: string,
   ): ExtractResponseResult;
 
-  /**
-   * Append provider-shaped user text. `last-user` is for pseudo-prefill
-   * instructions that should join the current request; `continuation` is for the
-   * synthetic "cut off" prompt added between model calls.
-   */
-  protected abstract appendUserText(
-    messages: M[],
-    text: string,
-    placement: UserTextPlacement,
-  ): void;
+  /** Append a provider-shaped continuation prompt as a fresh message. */
+  protected abstract appendUserText(messages: M[], text: string): void;
 
   /**
    * Append text to the existing assistant/model turn when the provider message
@@ -1294,7 +1284,7 @@ export abstract class ModelHandler<
     this.logger.debug('Adding continuation message to conversation', {
       data: { continuationMessage: continuationPrompt },
     });
-    this.appendUserText(messages, continuationPrompt, 'continuation');
+    this.appendUserText(messages, continuationPrompt);
   }
 
   /**

--- a/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/anthropic/modelHandlerAnthropic.ts
@@ -1221,17 +1221,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     };
   }
 
-  protected appendUserText(
-    messages: MessageParam[],
-    text: string,
-    placement: 'last-user' | 'continuation',
-  ): void {
-    const lastMessage = placement === 'last-user' ? messages.at(-1) : undefined;
-    if (lastMessage && Array.isArray(lastMessage.content)) {
-      lastMessage.content.push(textBlock(text));
-      return;
-    }
-
+  protected appendUserText(messages: MessageParam[], text: string): void {
     messages.push({ role: 'user', content: [textBlock(text)] });
   }
 

--- a/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleGenAI.ts
@@ -622,17 +622,7 @@ export class ModelHandlerGoogleGenAI extends GoogleModelHandlerBase<
     );
   }
 
-  protected appendUserText(
-    messages: Content[],
-    text: string,
-    placement: 'last-user' | 'continuation',
-  ): void {
-    const lastMessage = messages.at(-1);
-    if (placement === 'last-user' && lastMessage?.role === 'user') {
-      (lastMessage.parts ??= []).push(createPartFromText(text));
-      return;
-    }
-
+  protected appendUserText(messages: Content[], text: string): void {
     messages.push(createUserContent(createPartFromText(text)));
   }
 

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -891,17 +891,7 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
   // Stop / continue (PORT — keyed on Interaction status, not FinishReason)
   // ===========================================================================
 
-  protected appendUserText(
-    messages: Step[],
-    text: string,
-    placement: 'last-user' | 'continuation',
-  ): void {
-    const last = messages.at(-1);
-    if (placement === 'last-user' && last?.type === 'user_input') {
-      (last.content ??= []).push(this.textMedia(text));
-      return;
-    }
-
+  protected appendUserText(messages: Step[], text: string): void {
     messages.push({
       type: 'user_input',
       content: [this.textMedia(text)],

--- a/src/agent/modelHandlers/modelHandlerValidation.ts
+++ b/src/agent/modelHandlers/modelHandlerValidation.ts
@@ -217,7 +217,6 @@ export class ModelHandlerValidation extends ModelHandler<
   protected appendUserText(
     messages: ChatCompletionMessageParam[],
     text: string,
-    _placement: 'last-user' | 'continuation',
   ): void {
     messages.push({ role: 'user', content: text });
   }

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAI.ts
@@ -936,12 +936,10 @@ export class ModelHandlerOpenAI<
   protected appendUserText(
     messages: ChatCompletionMessageParam[],
     text: string,
-    placement: 'last-user' | 'continuation',
   ): void {
     appendUserTextToChatMessages(
       messages,
       text,
-      placement,
       this.capabilities.supportsIntermDevMsgs,
     );
   }

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -2477,30 +2477,11 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     return usageRoute == null ? usage : { ...usage, usageRoute };
   }
 
-  protected appendUserText(
-    messages: ResponseInputItem[],
-    text: string,
-    placement: 'last-user' | 'continuation',
-  ): void {
-    if (placement === 'continuation') {
-      const role = this.capabilities.supportsIntermDevMsgs ? 'system' : 'user';
-      messages.push({
-        type: 'message',
-        role,
-        content: [createInputText(text)],
-      });
-      return;
-    }
-
-    const lastMessage = messages.at(-1);
-    if (lastMessage) {
-      this.appendInputText(lastMessage, text);
-      return;
-    }
-
+  protected appendUserText(messages: ResponseInputItem[], text: string): void {
+    const role = this.capabilities.supportsIntermDevMsgs ? 'system' : 'user';
     messages.push({
       type: 'message',
-      role: 'user',
+      role,
       content: [createInputText(text)],
     });
   }

--- a/src/agent/modelHandlers/openai/openAIMessageUtils.ts
+++ b/src/agent/modelHandlers/openai/openAIMessageUtils.ts
@@ -395,34 +395,14 @@ export function extractChatAssistantText<T extends MessageLike>(
 }
 
 /**
- * Appends `text` to the conversation as a user turn: for a continuation
- * prompt, a fresh message (routed to "system" when the model requires
- * intermediate messages in that role); otherwise merged into the trailing
- * message's content.
+ * Appends a fresh continuation prompt, routed to "system" when the model
+ * requires intermediate messages in that role.
  */
 export function appendUserTextToChatMessages<T extends MessageLike>(
   messages: T[],
   text: string,
-  placement: 'last-user' | 'continuation',
   supportsIntermDevMsgs: boolean,
 ): void {
-  if (placement === 'continuation') {
-    const role = supportsIntermDevMsgs ? 'system' : 'user';
-    messages.push({ role, content: [{ type: 'text', text }] } as T);
-    return;
-  }
-
-  const lastMessage = messages.at(-1);
-  if (lastMessage && Array.isArray(lastMessage.content)) {
-    lastMessage.content.push({ type: 'text', text });
-    return;
-  }
-  if (lastMessage && typeof lastMessage.content === 'string') {
-    lastMessage.content = [
-      { type: 'text', text: lastMessage.content },
-      { type: 'text', text },
-    ];
-    return;
-  }
-  messages.push({ role: 'user', content: [{ type: 'text', text }] } as T);
+  const role = supportsIntermDevMsgs ? 'system' : 'user';
+  messages.push({ role, content: [{ type: 'text', text }] } as T);
 }

--- a/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/openrouter/modelHandlerOpenRouterNative.ts
@@ -697,15 +697,10 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
   // Stop / continue logic
   // ---------------------------------------------------------------------------
 
-  protected appendUserText(
-    messages: ChatMessages[],
-    text: string,
-    placement: 'last-user' | 'continuation',
-  ): void {
+  protected appendUserText(messages: ChatMessages[], text: string): void {
     appendUserTextToChatMessages(
       messages,
       text,
-      placement,
       this.capabilities.supportsIntermDevMsgs,
     );
   }

--- a/src/agent/modelHandlers/vscodelm/modelHandlerVscodeLm.ts
+++ b/src/agent/modelHandlers/vscodelm/modelHandlerVscodeLm.ts
@@ -338,13 +338,7 @@ export class ModelHandlerVscodeLm extends ModelHandler<
   protected appendUserText(
     messages: LanguageModelMessage[],
     text: string,
-    placement: 'last-user' | 'continuation',
   ): void {
-    const last = messages.at(-1);
-    if (placement === 'last-user' && last?.role === 'user') {
-      messages[messages.length - 1] = appendText(last, text);
-      return;
-    }
     messages.push({ role: 'user', content: [textPart(text)] });
   }
 

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerContinuationContract.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerContinuationContract.vitest.ts
@@ -19,6 +19,8 @@ import { ModelHandlerGoogleInteractions } from '@agent/modelHandlers/google/mode
 import { ModelHandlerOpenAI } from '@agent/modelHandlers/openai/modelHandlerOpenAI';
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/openai/modelHandlerOpenAIResponse';
 import { ModelHandlerOpenRouterNative } from '@agent/modelHandlers/openrouter/modelHandlerOpenRouterNative';
+import { ModelHandlerVscodeLm } from '@agent/modelHandlers/vscodelm/modelHandlerVscodeLm';
+import type { LanguageModelMessage } from '@platform/languageModel';
 import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 
 // Third-party imports
@@ -79,6 +81,12 @@ function textFromGoogleContent(message: Content): string {
 function textFromInteractionStep(step: Interactions.Step): string {
   if (!('content' in step) || !Array.isArray(step.content)) return '';
   return step.content.map((part) => ('text' in part ? part.text : '')).join('');
+}
+
+function textFromVscodeLmMessage(message: LanguageModelMessage): string {
+  return message.content
+    .map((part) => (part.kind === 'text' ? part.text : ''))
+    .join('');
 }
 
 function assertSingleAssistantTurn(messages: readonly unknown[]): void {
@@ -245,6 +253,39 @@ const cases: ContinuationCase[] = [
       );
     },
   },
+  {
+    name: 'VS Code LM',
+    run: () => {
+      const handler = new ModelHandlerVscodeLm(
+        buildTestModelConfig({
+          provider: ModelProvider.COPILOT,
+          capabilities: CONTINUATION_CAPABILITIES,
+        }),
+      );
+      handler.setLogger({ ...noopTrace });
+      const messages: LanguageModelMessage[] = [
+        handler.createAssistantMessage('partial'),
+      ];
+      const workspaceState = createWorkspaceState();
+
+      handler.addContinueMessage(messages, workspaceState, agentSetting);
+      assert.equal(messages.length, 2);
+      assert.equal(messages.at(-1)?.role, 'user');
+      assert.match(
+        textFromVscodeLmMessage(messages.at(-1)!),
+        /continue responding exactly from where you left/i,
+      );
+
+      handler.updateMessageContent(messages, '', ' resumed', workspaceState);
+
+      assertSingleAssistantTurn(messages);
+      assert.equal(messages.at(-1)?.role, 'assistant');
+      assert.equal(
+        textFromVscodeLmMessage(messages.at(-1)!),
+        'partial\n\n resumed',
+      );
+    },
+  },
 ];
 
 describe('model handler continuation contract', () => {
@@ -253,6 +294,142 @@ describe('model handler continuation contract', () => {
       testCase.run();
     });
   }
+
+  it('preserves OpenAI-family system continuation messages after resumed output', () => {
+    const capabilities = {
+      ...CONTINUATION_CAPABILITIES,
+      supportsIntermDevMsgs: true,
+    };
+
+    const chatHandler = new ModelHandlerOpenAI(
+      buildTestModelConfig({
+        provider: ModelProvider.OPENAI,
+        capabilities,
+      }),
+    );
+    chatHandler.setLogger({ ...noopTrace });
+    const chatMessages: ChatCompletionMessageParam[] = [
+      chatHandler.createAssistantMessage('partial'),
+    ];
+    const chatWorkspaceState = createWorkspaceState();
+    chatHandler.addContinueMessage(
+      chatMessages,
+      chatWorkspaceState,
+      agentSetting,
+    );
+    const chatContinuation = chatMessages.at(-1)!;
+    assert.equal(chatMessages.length, 2);
+    const chatContinuationText = textFromOpenAiContent(
+      chatContinuation.content,
+    );
+    assert.match(
+      chatContinuationText,
+      /continue responding exactly from where you left/i,
+    );
+    assert.deepEqual(chatContinuation, {
+      role: 'system',
+      content: [{ type: 'text', text: chatContinuationText }],
+    });
+    chatHandler.updateMessageContent(
+      chatMessages,
+      '',
+      ' resumed',
+      chatWorkspaceState,
+    );
+    assert.equal(chatMessages.length, 2);
+    assert.equal(
+      textFromOpenAiContent(chatMessages[0]?.content),
+      'partial resumed',
+    );
+    assert.equal(chatMessages.at(-1), chatContinuation);
+
+    const responseHandler = new ModelHandlerOpenAIResponse(
+      buildTestModelConfig({
+        provider: ModelProvider.OPENAI,
+        capabilities,
+      }),
+    );
+    responseHandler.setLogger({ ...noopTrace });
+    const responseMessages: ResponseInputItem[] = [
+      responseHandler.createAssistantMessage('partial'),
+    ];
+    const responseWorkspaceState = createWorkspaceState();
+    responseHandler.addContinueMessage(
+      responseMessages,
+      responseWorkspaceState,
+      agentSetting,
+    );
+    const responseContinuation = responseMessages.at(-1)!;
+    assert.equal(responseMessages.length, 2);
+    const responseContinuationText =
+      textFromResponseContent(responseContinuation);
+    assert.match(
+      responseContinuationText,
+      /continue responding exactly from where you left/i,
+    );
+    assert.deepEqual(responseContinuation, {
+      type: 'message',
+      role: 'system',
+      content: [{ type: 'input_text', text: responseContinuationText }],
+    });
+    responseHandler.updateMessageContent(
+      responseMessages,
+      '',
+      ' resumed',
+      responseWorkspaceState,
+    );
+    assert.equal(responseMessages.length, 2);
+    assert.equal(
+      textFromResponseContent(responseMessages[0]!),
+      'partial resumed',
+    );
+    assert.equal(responseMessages.at(-1), responseContinuation);
+
+    const openRouterHandler = new ModelHandlerOpenRouterNative(
+      buildTestModelConfig({
+        provider: ModelProvider.OPENAI,
+        capabilities,
+        openrouterFullName: 'openai/test-model',
+      }),
+    );
+    openRouterHandler.setLogger({ ...noopTrace });
+    const openRouterMessages: ChatMessages[] = [
+      openRouterHandler.createAssistantMessage('partial'),
+    ];
+    const openRouterWorkspaceState = createWorkspaceState();
+    openRouterHandler.addContinueMessage(
+      openRouterMessages,
+      openRouterWorkspaceState,
+      agentSetting,
+    );
+    const openRouterContinuation = openRouterMessages.at(-1)!;
+    assert.equal(openRouterMessages.length, 2);
+    const openRouterContinuationText = textFromOpenAiContent(
+      openRouterContinuation.content as ChatCompletionMessageParam['content'],
+    );
+    assert.match(
+      openRouterContinuationText,
+      /continue responding exactly from where you left/i,
+    );
+    assert.deepEqual(openRouterContinuation, {
+      role: 'system',
+      content: [{ type: 'text', text: openRouterContinuationText }],
+    });
+    openRouterHandler.updateMessageContent(
+      openRouterMessages,
+      '',
+      ' resumed',
+      openRouterWorkspaceState,
+    );
+    assert.equal(openRouterMessages.length, 2);
+    assert.equal(
+      textFromOpenAiContent(
+        openRouterMessages[0]?.content as ChatCompletionMessageParam['content'],
+      ),
+      'partial resumed',
+    );
+    assert.equal(openRouterMessages.at(-1), openRouterContinuation);
+  });
 
   it('keeps Google GenAI continuation prompts separate from trailing user turns', () => {
     const handler = new ModelHandlerGoogleGenAI(


### PR DESCRIPTION
## Summary

Remove the unreachable `UserTextPlacement` union and its placement parameter from the model-handler continuation path. Every live caller already selected `continuation`; provider implementations now express that single behavior directly and dead `last-user` merge branches are gone.

## Issue acceptance gates

Closes #9458.

- Removes `UserTextPlacement` and the placement parameter from the base contract, sole caller, all provider overrides, and the shared OpenAI-family helper.
- Removes every `last-user` branch and residual reference.
- Preserves each provider's live continuation role and content shape.
- Extends lifecycle coverage to VS Code LM and exact OpenAI-family system continuation payloads.

## Single source of truth

`ModelHandler.addContinueMessage` is the sole producer of provider-shaped continuation prompts and `appendUserText` now represents only that behavior.

## Duplication and abstraction budget

Deletes an unreachable mode and its repeated parameter plumbing across eight handler implementations. Adds no production abstraction.

## Net elements (R6)

- Files: 11 modified, 0 added, 0 deleted.
- Types: deletes the private `UserTextPlacement` union; no exports/classes/interfaces/enums added.
- LoC: +191 / -107, net +84, driven by explicit cross-provider lifecycle regression coverage; production code is net negative.

## Consumer counts (R8)

The placement argument had one producer (`ModelHandler.addContinueMessage`) and eight provider implementations plus one shared helper. Repository-wide search finds no residual `last-user` or placement references in the model-handler path.

## Host impact

Extension: No behavior change.

Desktop: No behavior change.

CLI: No behavior change.

## Scheduled refactoring

None.

## Validation

- Focused model-handler suite: 198 tests passed across 8 files.
- Continuation contract: 11 tests passed.
- Source TypeScript check: passed.
- Test-kernel TypeScript check: passed.
- Agent package build/declaration validation: passed (681 declarations, 70 external packages).
- ESLint on all changed files: passed.
- Prettier and `git diff --check`: passed.
- Independent adversarial review: no remaining actionable findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with no intended runtime change; risk is limited to continuation message shaping across providers, now covered by expanded contract tests.
> 
> **Overview**
> Removes the unused **`UserTextPlacement`** mode (`last-user` vs `continuation`) from the model-handler continuation path. **`appendUserText`** now has a single job: add the synthetic “response got cut off” prompt as a **new** message, matching what **`addContinueMessage`** was already the only caller to do.
> 
> Provider overrides drop merge-into-last-user branches and always push a fresh turn (Anthropic/Google/VS Code LM as user; OpenAI-family via **`appendUserTextToChatMessages`** as **system** when intermediate dev messages are supported, otherwise user). **OpenAI Responses** stops appending continuation text onto the trailing message and uses the same system/user routing as chat.
> 
> **`ModelHandlerContinuationContract`** gains VS Code LM coverage and asserts OpenAI/OpenRouter/OpenAI Responses keep **system**-role continuation messages after resumed output is merged into the prior assistant turn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1369d85046879a7b0562c24073bcc219f36685e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->