### PR TITLE
fix(cli): hide inactive agent picker hints

### DIFF
--- a/packages/cli/src/chat/tui/forms/AgentListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AgentListForm.tsx
@@ -253,7 +253,10 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
         </Box>
       ) : null}
       <Box marginTop={1}>
-        <PickerKeyHints selectable={props.selectable} hasItems />
+        <PickerKeyHints
+          selectable={props.selectable}
+          hasItems={items.length > 0}
+        />
       </Box>
     </FormFrame>
   );

--- a/packages/cli/src/chat/tui/forms/AgentListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/AgentListForm.tsx
@@ -152,6 +152,8 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
       const options = await computeAgentOptionsData();
       return { toolUse: options.toolUse, workflow: options.workflow };
     },
+    isEmpty: (groups) => groups.toolUse.length === 0,
+    closeEmptyOnEnter: true,
     items: (groups) =>
       groups.toolUse.map((agent) => ({
         value: agent.value,
@@ -196,7 +198,7 @@ export function AgentListForm(props: AgentListFormProps): React.JSX.Element {
     </Text>
   ) : null;
 
-  if (isCompactFormRows(props.availableRows)) {
+  if (isCompactFormRows(props.availableRows) && items.length > 0) {
     return (
       <FormFrame title="/agent" showCloseHint={false}>
         {currentAgentHintRow}

--- a/packages/cli/src/chat/tui/forms/ModelListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/ModelListForm.tsx
@@ -3,7 +3,7 @@
 // message it chooses the root model; once a tool-use chat is waiting, it can
 // switch the live conversation to a compatible model for future turns.
 
-import { Box, Text, useInput } from 'ink';
+import { Box, Text } from 'ink';
 
 import {
   emptyModelListMessageForCliMode,
@@ -28,7 +28,6 @@ import {
   PickerKeyHints,
 } from './_shared/FormFrame';
 import { useAsyncPickerForm } from './_shared/ListForm';
-import { isPlainReturnInput } from '../input/inputKeys';
 
 const TUI_MODEL_EMPTY_RECOVERY = {
   includedModeAction: 'switch with /api included',
@@ -72,12 +71,7 @@ export function modelListDescription({
 function EmptyModelListState(props: {
   readonly models: readonly CliModelAccess[];
   readonly apiMode: ApiAccessMode;
-  readonly onClose: () => void;
 }): React.JSX.Element {
-  useInput((input, key) => {
-    if (isPlainReturnInput(input, key)) props.onClose();
-  });
-
   return (
     <Text>
       {emptyModelListMessageForCliMode(
@@ -99,6 +93,7 @@ export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
         agentCategory: props.agentCategory,
       }),
     isEmpty: (models) => !models.some((model) => model.available),
+    closeEmptyOnEnter: true,
     items: (models) =>
       modelSelectItemsForCliMode(
         models,
@@ -149,11 +144,7 @@ export function ModelListForm(props: ModelListFormProps): React.JSX.Element {
     >
       <Text dimColor>{description}</Text>
       {items.length === 0 ? (
-        <EmptyModelListState
-          models={models}
-          apiMode={props.apiMode}
-          onClose={props.onClose}
-        />
+        <EmptyModelListState models={models} apiMode={props.apiMode} />
       ) : (
         <Box flexDirection="column">
           <Select

--- a/packages/cli/src/chat/tui/forms/_shared/ListForm.tsx
+++ b/packages/cli/src/chat/tui/forms/_shared/ListForm.tsx
@@ -217,6 +217,7 @@ export function useAsyncPickerForm<TData, TValue>(args: {
   readonly showTransientCloseHint?: boolean;
   readonly load: () => Promise<TData>;
   readonly isEmpty?: (data: TData) => boolean;
+  readonly closeEmptyOnEnter?: boolean;
   readonly items: (data: TData) => ReadonlyArray<SelectItem<TValue>>;
   /** `false` renders a read-only list where selecting closes the form. */
   readonly selectable?: boolean;
@@ -231,6 +232,7 @@ export function useAsyncPickerForm<TData, TValue>(args: {
       load: args.load,
       onClose: args.onClose,
       isEmpty: args.isEmpty,
+      closeEmptyOnEnter: args.closeEmptyOnEnter,
     });
   const selectable = args.selectable !== false;
   const items = data === undefined ? [] : args.items(data);

--- a/packages/cli/src/chat/tui/forms/_shared/useAsyncListForm.ts
+++ b/packages/cli/src/chat/tui/forms/_shared/useAsyncListForm.ts
@@ -41,18 +41,24 @@ export interface UseAsyncListFormOptions<T> {
    * actionable can omit this.
    */
   readonly isEmpty?: (data: T) => boolean;
+  /** Also close an empty picker on Enter when its footer advertises that key. */
+  readonly closeEmptyOnEnter?: boolean;
 }
 
 export function shouldCloseAsyncListFormOnInput(args: {
   readonly input: string;
-  readonly key: Pick<ReturnKeyInput, 'escape'>;
+  readonly key: Pick<ReturnKeyInput, 'escape' | 'return'>;
   readonly loading: boolean;
   readonly error: string | undefined;
   readonly empty: boolean;
+  readonly closeEmptyOnEnter?: boolean;
 }): boolean {
   return (
-    (args.loading || args.error !== undefined || args.empty) &&
-    isEscapeInput(args.input, args.key)
+    ((args.loading || args.error !== undefined || args.empty) &&
+      isEscapeInput(args.input, args.key)) ||
+    (args.empty &&
+      args.closeEmptyOnEnter === true &&
+      isPlainReturnInput(args.input, args.key))
   );
 }
 
@@ -106,6 +112,7 @@ export function useAsyncListForm<T>(
         loading,
         error,
         empty,
+        closeEmptyOnEnter: options.closeEmptyOnEnter,
       })
     ) {
       options.onClose();

--- a/src/test-kernel/cli/ModelListForm.vitest.mts
+++ b/src/test-kernel/cli/ModelListForm.vitest.mts
@@ -79,6 +79,28 @@ describe('CLI async list form close input', () => {
       }),
     ).toBe(false);
   });
+
+  it('closes an empty picker on Enter only when its footer advertises it', () => {
+    expect(
+      shouldCloseAsyncListFormOnInput({
+        input: '\r',
+        key: { return: true },
+        loading: false,
+        error: undefined,
+        empty: true,
+        closeEmptyOnEnter: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldCloseAsyncListFormOnInput({
+        input: '\r',
+        key: { return: true },
+        loading: false,
+        error: undefined,
+        empty: true,
+      }),
+    ).toBe(false);
+  });
 });
 
 describe('CLI async list form buffered input', () => {


### PR DESCRIPTION
## Summary

Fixes #9476.

The `/agent` picker now derives its key-hint state from the rendered agent list. When no agents are available, it advertises only the close actions instead of navigation and selection shortcuts that cannot do anything.

This matches the existing `/model` picker behavior and keeps `PickerKeyHints` as the single owner of picker footer vocabulary.

## Validation

- `npm run format`
- `npm run compile:fast`
- `npm run lint`
- `npm test` — 801 files passed, 1 skipped; 8,113 tests passed, 4 skipped
- `corepack pnpm --filter @texra-ai/cli run typecheck`
- `corepack pnpm run check:dead-code-ratchet`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TUI-only picker input and footer behavior; no auth, data, or API surface changes.
> 
> **Overview**
> When `/agent` or `/model` has **no selectable rows**, footers now show only **Enter/Esc to close** instead of navigate/select shortcuts, by driving `PickerKeyHints` with `hasItems={items.length > 0}`. **`/agent`** also skips the compact single-row layout when the tool-use list is empty.
> 
> Empty pickers can **close on Enter** in line with that footer: `useAsyncListForm` / `useAsyncPickerForm` gain optional **`closeEmptyOnEnter`**, wired for both forms via **`isEmpty`**. **`ModelListForm`** drops a local `useInput` on the empty state in favor of the shared hook; tests cover Enter-close only when `closeEmptyOnEnter` is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ae00aeefafbf86081073c1faa96f609f05914f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->