### PR TITLE
refactor: share pending interaction kind with agent SDK

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -14,6 +14,7 @@ import { SessionHandle as RuntimeSessionHandle } from '@agent/runtime/SessionHan
 import { runAgent as runValidatedAgent } from '@agent/runtime/runAgent';
 import { initPlatform, tryPlatform, type Platform } from '@platform/platform';
 import { initNodeAgentRuntime } from '@platform/defaults/nodeHost';
+import type { ProgressPermissionKind as PendingInteractionKind } from '@shared/schemas';
 import {
   ClaudeAgentSessions,
   CodexThreads,
@@ -25,6 +26,7 @@ export type { ITool, IToolRegistry } from '@agent/core/tools/ToolTypes';
 export { MapToolRegistry } from '@agent/core/tools/ToolTypes';
 export { defineTool } from '@tools/core/define';
 export type { DefinedToolClass } from '@tools/core/define';
+export type { ProgressPermissionKind as PendingInteractionKind } from '@shared/schemas';
 export type {
   AgentFlowResult,
   ToolUseFlowResult,
@@ -34,14 +36,7 @@ export type {
 /** Select pending host interactions to cancel. */
 export interface HostInteractionCancelSelector {
   readonly streamId?: string | null;
-  readonly kind?:
-    | 'toolEdit'
-    | 'bash'
-    | 'planApproval'
-    | 'proposal'
-    | 'retry'
-    | 'userQuestion'
-    | 'externalInquiry';
+  readonly kind?: PendingInteractionKind;
   readonly cause?: string;
 }
 

--- a/src/agent/runtime/HostInteractions.ts
+++ b/src/agent/runtime/HostInteractions.ts
@@ -7,7 +7,7 @@ import type {
 import type {
   AgentProposal,
   Plan,
-  ProgressPermissionKind,
+  ProgressPermissionKind as PendingInteractionKind,
   ProviderErrorPartial,
   StreamTabId,
   UserQuestionAnswers,
@@ -21,6 +21,8 @@ import type {
   RuntimePresentationEvent,
   RuntimePresentationEventPayloads,
 } from './runtimePresentationEvents';
+
+export type { ProgressPermissionKind as PendingInteractionKind } from '@shared/schemas';
 
 const logger = createChannelTrace('SessionHostInteractions');
 
@@ -161,8 +163,6 @@ export type UserQuestionSettlement =
       readonly feedback?: string;
       readonly answers?: never;
     };
-
-export type PendingInteractionKind = ProgressPermissionKind;
 
 export type SettledInteractionKind = keyof HostInteractionResultByKind;
 

--- a/src/test-kernel/agent/AgentPackage.vitest.ts
+++ b/src/test-kernel/agent/AgentPackage.vitest.ts
@@ -87,7 +87,11 @@ vi.mock('@transcript/StreamLogStore', () => ({
 }));
 
 // Local imports - package API under test
-import { runAgent } from '../../../packages/agent/src/index';
+import {
+  runAgent,
+  type HostInteractionCancelSelector,
+  type PendingInteractionKind,
+} from '../../../packages/agent/src/index';
 import { nodePlatform } from '../../../packages/agent/src/node';
 
 const PLATFORM = { lifecycle: {} } as unknown as Platform;
@@ -116,6 +120,13 @@ describe('agent package run lifecycle', () => {
         return RESULT;
       },
     );
+  });
+
+  it('exports the canonical pending interaction kind for cancellation selectors', () => {
+    const kind: PendingInteractionKind = 'planApproval';
+    const selector: HostInteractionCancelSelector = { kind };
+
+    expect(selector.kind).toBe(kind);
   });
 
   it('initializes standard runtime features once for concurrent first runs', async () => {


### PR DESCRIPTION
## Summary

Make the agent SDK's pending-interaction kind use the same canonical permission vocabulary as the runtime instead of hand-copying seven string literals. Current main already introduced provider-independent `ProgressPermissionKind`; this PR re-exports it under the compatibility name `PendingInteractionKind` at both runtime and SDK boundaries.

## Issue acceptance gates

Closes #9471.

- Removes the copied SDK literal union.
- Keeps `PendingInteractionKind` source-compatible from `HostInteractions.ts`.
- Adds a public SDK `PendingInteractionKind` type export and uses it in `HostInteractionCancelSelector.kind`.
- Passes the package provider-leak/declaration validation gate.

## Single source of truth

`ProgressPermissionKind` in `src/shared/schemas/progressView/outbound.ts`, derived from the canonical `PERMISSION_KIND` schema vocabulary, now owns the member set.

## Duplication and abstraction budget

Deletes one seven-member copied union and one redundant runtime alias declaration. Adds no wrapper or new module; both compatibility names re-export the existing provider-free canonical type.

## Net elements (R6)

- Files: 3 modified, 0 added, 0 deleted.
- Exports: adds the package-level `PendingInteractionKind` type export; preserves the runtime export.
- LoC: +18 / -12, net +6 (including focused public-surface coverage).

## Consumer counts (R8)

- Runtime `PendingInteractionKind`: existing compatibility export and internal consumers preserved.
- SDK copied union: one consumer, `HostInteractionCancelSelector.kind`, now uses the canonical type.

## Host impact

Extension: Type-only; no behavior change.

Desktop: Type-only; no behavior change.

CLI: Type-only; no behavior change.

## Scheduled refactoring

None.

## Validation

- Agent package build/provider-leak validation: 684 declarations and 70 external packages passed.
- Agent package API tests: 12 passed.
- Source and test-kernel TypeScript checks: passed.
- ESLint, Prettier, and `git diff --check`: passed.
- Independent type-surface review: no actionable findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only refactor with no runtime behavior changes; member set stays tied to the existing schema vocabulary.
> 
> **Overview**
> **Unifies pending-interaction / permission kind typing** so the agent SDK and runtime both use `ProgressPermissionKind` from `@shared/schemas`, re-exported as `PendingInteractionKind` for backward compatibility.
> 
> The agent package **drops the hand-maintained seven-literal union** on `HostInteractionCancelSelector.kind` and **adds a public `PendingInteractionKind` type export**. Runtime `HostInteractions.ts` **stops declaring a local alias** and instead imports and re-exports the same canonical type. A package API test asserts the exported type works with cancellation selectors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95f68b7da6e874230f23376a6453ee1f3dd8f865. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->