### PR TITLE
fix(agent-runtime): preserve follow-ups and retry outcomes

### DIFF
--- a/src/agent/core/flows/CycleServices.ts
+++ b/src/agent/core/flows/CycleServices.ts
@@ -133,5 +133,6 @@ export interface FailedCycleFields {
 }
 
 export function buildFailedCycleOutcome(error: unknown): FailedCycleFields {
-  return { failureLogEmitted: false, ...buildFailedRetryInfo(error) };
+  const { lastError } = buildFailedRetryInfo(error);
+  return { failureLogEmitted: false, lastError };
 }

--- a/src/agent/core/flows/CycleServices.ts
+++ b/src/agent/core/flows/CycleServices.ts
@@ -125,13 +125,13 @@ export interface ToolUseRoundServices<C = unknown> extends CycleRunServices<C> {
 
 /**
  * The retry/logging fields every cycle node's `{ outcome: 'failed', ... }`
- * result carries, regardless of whether that node identifies the failure
- * with an `error` or a `message` field.
+ * result carries, alongside any node-specific failure context.
  */
-export function buildFailedCycleOutcome(error: unknown): {
-  failureLogEmitted: false;
-  userRetryable: boolean;
-  lastError: RetryErrorInfo;
-} {
+export interface FailedCycleFields {
+  readonly failureLogEmitted: boolean;
+  readonly lastError: RetryErrorInfo;
+}
+
+export function buildFailedCycleOutcome(error: unknown): FailedCycleFields {
   return { failureLogEmitted: false, ...buildFailedRetryInfo(error) };
 }

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
@@ -8,13 +8,14 @@ import {
 } from '@agent/core/flows/ResponseCycleFlow';
 import {
   buildFailedCycleOutcome,
+  type FailedCycleFields,
   withModelClient,
 } from '@agent/core/flows/CycleServices';
 import type {
   AgentRunStateSnapshot,
   ConversationRoundStateSnapshot,
 } from '@agent/core/state/AgentState';
-import type { AgentFileLocation, RetryErrorInfo } from '@shared/schemas';
+import type { AgentFileLocation } from '@shared/schemas';
 import { getDefaultToolRegistry } from '@tools/registry';
 import { ensureError } from '@utils/errors/errorMessage';
 
@@ -35,13 +36,7 @@ interface CyclePrepInput {
 type CycleOutcome =
   | { outcome: 'completed'; endTurn: boolean }
   | { outcome: 'cancelled' }
-  | {
-      outcome: 'failed';
-      error: Error;
-      userRetryable: boolean;
-      lastError?: RetryErrorInfo;
-      failureLogEmitted: boolean;
-    };
+  | ({ outcome: 'failed'; error: Error } & FailedCycleFields);
 
 export class ResponseCycleNode<C = unknown> extends Node<
   ReflectionFlowShared,
@@ -122,7 +117,6 @@ export class ResponseCycleNode<C = unknown> extends Node<
         return {
           outcome: 'failed',
           error: new Error(cycleShared.lastError.message),
-          userRetryable: cycleShared.lastError.userRetryable,
           lastError: cycleShared.lastError,
           failureLogEmitted: cycleShared.failureLogEmitted ?? false,
         };
@@ -177,10 +171,7 @@ export class ResponseCycleNode<C = unknown> extends Node<
       if (!execRes.failureLogEmitted) {
         logger.error(`Response cycle failed: ${execRes.error.message}`);
       }
-      shared.lastError = execRes.lastError ?? {
-        message: execRes.error.message,
-        userRetryable: execRes.userRetryable,
-      };
+      shared.lastError = execRes.lastError;
       shared.continueRounds = false;
       shared.endTurn = false;
       return FlowTransition.FINALIZE;

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -10,15 +10,11 @@ import {
 } from '@agent/core/flows/ToolUseRoundFlow';
 import {
   buildFailedCycleOutcome,
+  type FailedCycleFields,
   withModelClient,
 } from '@agent/core/flows/CycleServices';
 import type { ProviderMessage } from '@agent/types/ProviderMessage';
-import {
-  MESSAGE_TYPES,
-  RUN_OUTCOME,
-  type RetryErrorInfo,
-  type RunOutcome,
-} from '@shared/schemas';
+import { MESSAGE_TYPES, RUN_OUTCOME, type RunOutcome } from '@shared/schemas';
 import { deriveRunOutcome } from '@shared/streams/streamStatus';
 
 import {
@@ -32,13 +28,7 @@ type ToolUseCycleOutcome =
   | { outcome: 'completed'; messages: ProviderMessage[] }
   | { outcome: 'skipped' }
   | { outcome: 'cancelled' }
-  | {
-      outcome: 'failed';
-      message: string;
-      userRetryable: boolean;
-      lastError?: RetryErrorInfo;
-      failureLogEmitted: boolean;
-    };
+  | ({ outcome: 'failed' } & FailedCycleFields);
 
 export class ToolUseCycleNode<C> extends Node<
   ToolUseRunShared,
@@ -162,8 +152,6 @@ export class ToolUseCycleNode<C> extends Node<
       if (lastError) {
         return {
           outcome: 'failed',
-          message: lastError.message,
-          userRetryable: lastError.userRetryable,
           lastError,
           failureLogEmitted: roundShared.failureLogEmitted ?? false,
         };
@@ -189,11 +177,7 @@ export class ToolUseCycleNode<C> extends Node<
     _prepRes: CyclePrepResult,
     error: Error,
   ): Promise<ToolUseCycleOutcome> {
-    return {
-      outcome: 'failed',
-      message: error.message,
-      ...buildFailedCycleOutcome(error),
-    };
+    return { outcome: 'failed', ...buildFailedCycleOutcome(error) };
   }
 
   async post(
@@ -240,15 +224,12 @@ export class ToolUseCycleNode<C> extends Node<
       case 'skipped':
         break;
       case 'failed':
-        shared.lastError = execRes.lastError ?? {
-          message: execRes.message,
-          userRetryable: execRes.userRetryable,
-        };
+        shared.lastError = execRes.lastError;
         if (!execRes.failureLogEmitted) {
           // Outer cycle failures have not passed through RetryState's
           // structured error logger. Surface them before WaitNode resets
           // lastError on a follow-up.
-          this.services.logger.error(execRes.message, {
+          this.services.logger.error(execRes.lastError.message, {
             messageType: MESSAGE_TYPES.ERROR,
           });
         }

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -78,12 +78,7 @@ export class ToolUseWaitNode<C> extends Node<
     // The goalPaused event makes the pause user-visible: a silent stop
     // mid-objective reads as a hang.
     if (prepRes.afterError && !hasDrainedFollowUps) {
-      const goal = GoalStore.getForStream(streamId);
-      if (goal?.status === 'active') {
-        await GoalStore.setStatus(streamId, 'paused');
-        await setGoalSessionBashAutoApproval(streamId, false);
-        emitRunFact(this.services.logger, 'goalPaused', { streamId });
-      }
+      await this.pauseActiveGoal(streamId);
     } else if (!isSubagent) {
       // Root-only notification: fires every cycle (not just a genuine
       // block) so a host can project each round's response as it happens —
@@ -180,13 +175,6 @@ export class ToolUseWaitNode<C> extends Node<
       return FlowTransition.COMPLETE;
     }
 
-    // A user follow-up is ready for the next cycle. Clear any prior
-    // error/cancellation state so runToolUseFlow does not treat a recovered
-    // error as terminal. Root flows arrive here from their session queue;
-    // resumed subagents arrive here through the one-shot handoff above.
-    shared.lastError = undefined;
-    shared.userCancelledRetry = undefined;
-
     await session.transcripts.ensureLoaded(streamId);
     session.status.transition(streamId, STREAM_PHASE.RUNNING, 'resume', {
       trace: logger,
@@ -202,13 +190,38 @@ export class ToolUseWaitNode<C> extends Node<
       }
     }
 
-    await applyFollowUpBatch(
-      shared,
-      execRes.followUps,
-      execRes.synthetic,
-      this.services,
-    );
+    try {
+      await applyFollowUpBatch(
+        shared,
+        execRes.followUps,
+        execRes.synthetic,
+        this.services,
+      );
+    } catch (error) {
+      if (prepRes.afterError) {
+        await this.pauseActiveGoal(streamId);
+      }
+      throw error;
+    }
+
+    // A user follow-up reached the transcript and is ready for the next
+    // cycle. Clear any prior error/cancellation state so runToolUseFlow does
+    // not treat a recovered error as terminal. If applying the follow-up
+    // failed above, preserve that state for the resumable failure path.
+    shared.lastError = undefined;
+    shared.userCancelledRetry = undefined;
 
     return FlowTransition.CONTINUE;
+  }
+
+  private async pauseActiveGoal(streamId: string): Promise<void> {
+    const goal = GoalStore.getForStream(streamId);
+    if (goal?.status !== 'active') {
+      return;
+    }
+
+    await GoalStore.setStatus(streamId, 'paused');
+    await setGoalSessionBashAutoApproval(streamId, false);
+    emitRunFact(this.services.logger, 'goalPaused', { streamId });
   }
 }

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -50,6 +50,7 @@ export class ToolUseWaitNode<C> extends Node<
     const { checkInterruption, session, isSubagent } = this.services;
     const { runScope, stopAfterCycle } = useLaunchRunContext();
     const { streamId, session: ownerSession } = runScope;
+    const hasDrainedFollowUps = Boolean(this.drainedFollowUps?.length);
 
     if (checkInterruption()) {
       return { kind: 'stop' };
@@ -65,17 +66,18 @@ export class ToolUseWaitNode<C> extends Node<
     // Stopping here would drop that user input on the floor — and skip the
     // `post` clear of `lastError`/`userCancelledRetry` that consuming it
     // performs, which is what makes the error recovered rather than terminal.
-    if (prepRes.afterError && isSubagent && !this.drainedFollowUps?.length) {
+    if (prepRes.afterError && isSubagent && !hasDrainedFollowUps) {
       return { kind: 'stop' };
     }
 
-    // A failed/cancelled cycle ends the autonomous leg. Pause any active
-    // goal so it surfaces as resumable — the in-cycle retry layer already
-    // absorbed transient errors before we reach here — instead of leaving the
-    // record `active` while the loop is actually stalled on a blocking wait.
+    // A failed/cancelled cycle with no recovery input ends the autonomous
+    // leg. Pause any active goal so it surfaces as resumable — the in-cycle
+    // retry layer already absorbed transient errors before we reach here —
+    // instead of leaving the record `active` while the loop is actually
+    // stalled. A drained batch continues immediately and keeps the goal live.
     // The goalPaused event makes the pause user-visible: a silent stop
     // mid-objective reads as a hang.
-    if (prepRes.afterError) {
+    if (prepRes.afterError && !hasDrainedFollowUps) {
       const goal = GoalStore.getForStream(streamId);
       if (goal?.status === 'active') {
         await GoalStore.setStatus(streamId, 'paused');

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -59,7 +59,13 @@ export class ToolUseWaitNode<C> extends Node<
     // it must not see a failure as a successful completion.
     // In subagent mode, stop immediately: the orchestrator was never
     // notified, so waiting for a follow-up would hang forever.
-    if (prepRes.afterError && isSubagent) {
+    //
+    // A batch the child-run loop already drained is the exception: it is
+    // in hand, so there is nothing to wait for and no hang to avoid.
+    // Stopping here would drop that user input on the floor — and skip the
+    // `post` clear of `lastError`/`userCancelledRetry` that consuming it
+    // performs, which is what makes the error recovered rather than terminal.
+    if (prepRes.afterError && isSubagent && !this.drainedFollowUps?.length) {
       return { kind: 'stop' };
     }
 

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -608,7 +608,7 @@ export async function runToolUseFlow<C = unknown>(
         // run ended: the wait node clears it when a follow-up recovers.
         cancelled,
       });
-      if (outcome === RUN_OUTCOME.CANCELLED && cancelled) {
+      if (outcome === RUN_OUTCOME.CANCELLED) {
         await activePersistedFlow?.prepareForFollowUp(shared);
       }
     }

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -596,6 +596,8 @@ export async function runToolUseFlow<C = unknown>(
     if (finalAction === FlowTransition.WAITING) {
       outcome = STREAM_PHASE.WAITING;
     } else {
+      const cancelled =
+        input.checkInterruption() || Boolean(shared.userCancelledRetry);
       outcome = deriveRunOutcome({
         failed: Boolean(shared.lastError),
         // A retry the user declined ends the run without leaving a
@@ -604,12 +606,11 @@ export async function runToolUseFlow<C = unknown>(
         // preserved its record as resumable — a success that is also
         // resumable. `userCancelledRetry` survives only when it is why the
         // run ended: the wait node clears it when a follow-up recovers.
-        cancelled:
-          input.checkInterruption() || Boolean(shared.userCancelledRetry),
+        cancelled,
       });
-    }
-    if (outcome === RUN_OUTCOME.CANCELLED && input.checkInterruption()) {
-      await activePersistedFlow?.prepareForFollowUp(shared);
+      if (outcome === RUN_OUTCOME.CANCELLED && cancelled) {
+        await activePersistedFlow?.prepareForFollowUp(shared);
+      }
     }
     if (shared.lastError) {
       // Re-throw so runFlowWithLifecycle logs the error and shows

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -598,7 +598,14 @@ export async function runToolUseFlow<C = unknown>(
     } else {
       outcome = deriveRunOutcome({
         failed: Boolean(shared.lastError),
-        cancelled: input.checkInterruption(),
+        // A retry the user declined ends the run without leaving a
+        // `lastError` behind. Counting only `checkInterruption()` here
+        // reported that run as COMPLETED while the `finally` below still
+        // preserved its record as resumable — a success that is also
+        // resumable. `userCancelledRetry` survives only when it is why the
+        // run ended: the wait node clears it when a follow-up recovers.
+        cancelled:
+          input.checkInterruption() || Boolean(shared.userCancelledRetry),
       });
     }
     if (outcome === RUN_OUTCOME.CANCELLED && input.checkInterruption()) {

--- a/src/test-kernel/agent/CycleServices.vitest.ts
+++ b/src/test-kernel/agent/CycleServices.vitest.ts
@@ -1,0 +1,16 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports
+import { buildFailedCycleOutcome } from '@agent/core/flows/CycleServices';
+
+describe('cycle failure outcomes', () => {
+  it('keeps the normalized error as the single failure description', () => {
+    const outcome = buildFailedCycleOutcome(new Error('cycle failed'));
+
+    expect(outcome).toEqual({
+      failureLogEmitted: false,
+      lastError: expect.objectContaining({ message: 'cycle failed' }),
+    });
+  });
+});

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -23,6 +23,7 @@ import {
   flowKey,
   type FlowRecord,
 } from '@agent/node/persistedFlow';
+import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import {
   retrieveSessionResumeData,
   type ToolUseResumeData,
@@ -795,6 +796,35 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
       cursor: { nextNodeId: 'start' },
       shared: { shouldSkipCycle: true },
     });
+  });
+
+  it('resets the resumable cursor after the user declines a retry', async () => {
+    const executionId = 'abc-declined-retry' as ExecutionId;
+    const streamId = 'chat@gpt54#abc-declined-retry' as StreamTabId;
+    const shared = {
+      messages: [],
+      shouldSkipCycle: false,
+      stateSlices: defaultStateSlices(),
+      userCancelledRetry: true,
+    };
+    await writeFlowRecord(executionId, shared, {
+      cursor: { nextNodeId: null, lastAction: FlowTransition.COMPLETE },
+    });
+    const runSpy = vi
+      .spyOn(PersistedFlow.prototype, 'run')
+      .mockResolvedValueOnce(FlowTransition.COMPLETE);
+
+    try {
+      const result = await runPersistedFlow(executionId, streamId, undefined);
+
+      expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
+      expect(await readFlowRecord(executionId)).toMatchObject({
+        cursor: { nextNodeId: 'start' },
+        shared: { shouldSkipCycle: true, userCancelledRetry: true },
+      });
+    } finally {
+      runSpy.mockRestore();
+    }
   });
 
   it('preserves an established flow when provider cancellation rejects the run', async () => {

--- a/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseProgressEvents.vitest.ts
@@ -206,8 +206,10 @@ describe('tool-use progress events', () => {
 
     const transition = await node.post(shared as ToolUseRunShared, prepRes, {
       outcome: 'failed',
-      message: 'Model claude-opus-4-7 not found',
-      userRetryable: false,
+      lastError: {
+        message: 'Model claude-opus-4-7 not found',
+        userRetryable: false,
+      },
       failureLogEmitted: false,
     });
 
@@ -235,8 +237,6 @@ describe('tool-use progress events', () => {
     };
     await node.post(shared as ToolUseRunShared, prepRes, {
       outcome: 'failed',
-      message: lastError.message,
-      userRetryable: lastError.userRetryable,
       lastError,
       failureLogEmitted: true,
     });

--- a/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
@@ -923,14 +923,25 @@ describe('ToolUseWaitNode', () => {
 
   // Regression: #9443. The subagent after-error stop fired before the drained
   // batch was consumed, dropping user input the child-run loop had already
-  // taken off the queue — and skipping `post`'s error clear with it.
-  it('consumes a drained batch after an error instead of dropping it', async () => {
+  // taken off the queue — and skipping `post`'s error clear with it. Since
+  // consuming the batch continues immediately, an active goal must not be
+  // paused or lose its unattended bash approval first.
+  it('recovers an errored goal from a drained batch without pausing it', async () => {
+    const streamId = 'wait-node-error-drained-goal' as StreamTabId;
+    await installPlatform();
+    await GoalStore.start(streamId, 'finish the autonomous proof');
+
     const shared: ToolUseRunShared = toolUseRunShared();
     shared.lastError = {
       message: 'stale failure from the previous cycle',
       userRetryable: false,
     };
     const interactions = { emit: vi.fn() };
+    const setApprovalBypassState = vi.fn();
+    const ownerSession = sessionWithInteractions({
+      setApprovalBypassState,
+      cancel: vi.fn(),
+    });
     const batch = [{ text: 'try the other lemma', origin: 'user' as const }];
     const services = createWaitNodeServices({
       isSubagent: true,
@@ -945,26 +956,34 @@ describe('ToolUseWaitNode', () => {
     });
     const node = new ToolUseWaitNode(batch).setServices(services);
 
-    const prep = await node.prep(shared);
-    expect(prep.afterError).toBe(true);
+    try {
+      const prep = await node.prep(shared);
+      expect(prep.afterError).toBe(true);
 
-    const { exec, transition } = await withTestRunContext(
-      interactions,
-      'test-stream',
-      async () => {
-        const exec = await node.exec(prep);
-        return { exec, transition: await node.post(shared, prep, exec) };
-      },
-    );
+      const { exec, transition } = await withTestRunContext(
+        interactions,
+        streamId,
+        async () => {
+          const exec = await node.exec(prep);
+          return { exec, transition: await node.post(shared, prep, exec) };
+        },
+        { session: ownerSession },
+      );
 
-    expect(exec).toEqual({
-      kind: 'continue',
-      followUps: batch,
-      synthetic: false,
-    });
-    expect(transition).toBe(FlowTransition.CONTINUE);
-    // Consuming the batch recovers the error rather than stranding it.
-    expect(shared.lastError).toBeUndefined();
+      expect(exec).toEqual({
+        kind: 'continue',
+        followUps: batch,
+        synthetic: false,
+      });
+      expect(transition).toBe(FlowTransition.CONTINUE);
+      // Consuming the batch recovers the error rather than stranding it.
+      expect(shared.lastError).toBeUndefined();
+      expect(GoalStore.getForStream(streamId)?.status).toBe('active');
+      expect(setApprovalBypassState).not.toHaveBeenCalled();
+    } finally {
+      await GoalStore.forget(streamId);
+      cleanupApprovalsForStream(streamId);
+    }
   });
 
   // Companion to the above: with no drained batch in hand, the after-error

--- a/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
@@ -920,6 +920,75 @@ describe('ToolUseWaitNode', () => {
       'please revise the theorem',
     );
   });
+
+  // Regression: #9443. The subagent after-error stop fired before the drained
+  // batch was consumed, dropping user input the child-run loop had already
+  // taken off the queue — and skipping `post`'s error clear with it.
+  it('consumes a drained batch after an error instead of dropping it', async () => {
+    const shared: ToolUseRunShared = toolUseRunShared();
+    shared.lastError = {
+      message: 'stale failure from the previous cycle',
+      userRetryable: false,
+    };
+    const interactions = { emit: vi.fn() };
+    const batch = [{ text: 'try the other lemma', origin: 'user' as const }];
+    const services = createWaitNodeServices({
+      isSubagent: true,
+      modelHandler: {
+        createUserFollowUpMessages: vi.fn(
+          async (
+            _messages: ProviderMessage[],
+            text: string,
+          ): Promise<ProviderMessage[]> => [{ role: 'user', content: text }],
+        ),
+      },
+    });
+    const node = new ToolUseWaitNode(batch).setServices(services);
+
+    const prep = await node.prep(shared);
+    expect(prep.afterError).toBe(true);
+
+    const { exec, transition } = await withTestRunContext(
+      interactions,
+      'test-stream',
+      async () => {
+        const exec = await node.exec(prep);
+        return { exec, transition: await node.post(shared, prep, exec) };
+      },
+    );
+
+    expect(exec).toEqual({
+      kind: 'continue',
+      followUps: batch,
+      synthetic: false,
+    });
+    expect(transition).toBe(FlowTransition.CONTINUE);
+    // Consuming the batch recovers the error rather than stranding it.
+    expect(shared.lastError).toBeUndefined();
+  });
+
+  // Companion to the above: with no drained batch in hand, the after-error
+  // stop must still fire, or a subagent would wait for a follow-up its
+  // orchestrator was never told to send.
+  it('still stops a subagent after an error when no batch was drained', async () => {
+    const shared: ToolUseRunShared = toolUseRunShared();
+    shared.lastError = { message: 'boom', userRetryable: false };
+    const interactions = { emit: vi.fn() };
+    const waitForFollowUp = vi.fn();
+    const services = createWaitNodeServices({
+      isSubagent: true,
+      session: { waitForFollowUp },
+    });
+    const node = new ToolUseWaitNode().setServices(services);
+
+    const prep = await node.prep(shared);
+    const exec = await withTestRunContext(interactions, 'test-stream', () =>
+      node.exec(prep),
+    );
+
+    expect(exec).toEqual({ kind: 'stop' });
+    expect(waitForFollowUp).not.toHaveBeenCalled();
+  });
 });
 
 describe('extractTouchedFiles', () => {

--- a/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
@@ -945,6 +945,7 @@ describe('ToolUseWaitNode', () => {
     const batch = [{ text: 'try the other lemma', origin: 'user' as const }];
     const services = createWaitNodeServices({
       isSubagent: true,
+      runScope: testRunScope(streamId),
       modelHandler: {
         createUserFollowUpMessages: vi.fn(
           async (

--- a/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
+++ b/src/test-kernel/agent/followUp/ToolUseWaitNode.vitest.ts
@@ -986,6 +986,69 @@ describe('ToolUseWaitNode', () => {
     }
   });
 
+  it('pauses an errored goal when a drained recovery batch cannot be applied', async () => {
+    const streamId = 'wait-node-error-recovery-failed' as StreamTabId;
+    await installPlatform();
+    await GoalStore.start(streamId, 'finish the autonomous proof');
+
+    const shared: ToolUseRunShared = toolUseRunShared();
+    shared.lastError = {
+      message: 'stale failure from the previous cycle',
+      userRetryable: false,
+    };
+    const interactions = { emit: vi.fn() };
+    const setApprovalBypassState = vi.fn();
+    const ownerSession = sessionWithInteractions({
+      setApprovalBypassState,
+      cancel: vi.fn(),
+    });
+    const applicationError = new Error('follow-up media is unreadable');
+    const batch = [{ text: 'use this diagram', origin: 'user' as const }];
+    const services = createWaitNodeServices({
+      isSubagent: true,
+      runScope: testRunScope(streamId),
+      modelHandler: {
+        createUserFollowUpMessages: vi.fn(async () => {
+          throw applicationError;
+        }),
+      },
+    });
+    const node = new ToolUseWaitNode(batch).setServices(services);
+
+    try {
+      const prep = await node.prep(shared);
+      const exec = await withTestRunContext(
+        interactions,
+        streamId,
+        () => node.exec(prep),
+        { session: ownerSession },
+      );
+
+      await expect(
+        withTestRunContext(
+          interactions,
+          streamId,
+          () => node.post(shared, prep, exec),
+          { session: ownerSession },
+        ),
+      ).rejects.toBe(applicationError);
+
+      expect(shared.lastError).toEqual({
+        message: 'stale failure from the previous cycle',
+        userRetryable: false,
+      });
+      expect(GoalStore.getForStream(streamId)?.status).toBe('paused');
+      expect(setApprovalBypassState).toHaveBeenCalledWith({
+        streamId,
+        kind: 'bash',
+        bypassActive: false,
+      });
+    } finally {
+      await GoalStore.forget(streamId);
+      cleanupApprovalsForStream(streamId);
+    }
+  });
+
   // Companion to the above: with no drained batch in hand, the after-error
   // stop must still fire, or a subagent would wait for a follow-up its
   // orchestrator was never told to send.


### PR DESCRIPTION
## Summary

- preserve a drained subagent follow-up batch after an error while keeping a successfully recovered goal active; pause the goal and disable unattended shell approval if the recovery input itself cannot be applied
- report a declined user retry as a cancelled run and reset its persisted cursor for later follow-up recovery
- make failed cycle results carry one required, canonical error description and remove post-processing fallbacks that reconstructed missing data

## Reasoning

For #9443, the wait node drained queued follow-ups and then discarded them because a stale cycle error unconditionally selected the stop transition. The stop condition now applies only when the drain produced no follow-up batch. A ready recovery batch also bypasses goal pausing because the flow is continuing rather than stalling. Focused tests cover the preserved active-goal path, failed recovery-input pausing, and the original no-batch stop path. Failed cycle results use a shared required field set, so progress and retry consumers cannot receive an underspecified failure result.

For #9442, the originally suspected double read of the interruption state is not the failing path. The contradiction occurs when a user declines a retry: the flow records `userCancelledRetry` but its final result considered only the interruption flag. Final result derivation now treats either condition as cancellation and uses that same fact to reset the persisted cursor, preventing both a completed/resumable contradiction and a retained terminal cursor that cannot consume a later follow-up.

## Validation

- `npm run typecheck`
- `npm run format`
- `npm run compile:fast`
- `npm run lint`
- `npm test` (8,120 passed, 4 skipped)
- focused persisted-cursor, active-goal recovery, and fallback-normalization regressions
- dead-code ratchet unchanged at 17

Closes #9442.
Closes #9443.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tool-use wait/resume, persisted cursor reset, and run outcome derivation—user-visible recovery paths—but behavior is covered by focused regressions and scope is limited to agent flow nodes.
> 
> **Overview**
> Fixes **subagent recovery after a failed cycle** when the child-run loop has already drained a follow-up batch: `ToolUseWaitNode` no longer stops (or pauses the goal) in that case, applies the batch before clearing error state, and pauses the goal only if applying recovery input fails.
> 
> Treats a **declined user retry** (`userCancelledRetry`) as cancellation in `runToolUseFlow`, resets the persisted cursor via `prepareForFollowUp`, and avoids reporting COMPLETED while the record stays resumable.
> 
> Introduces shared **`FailedCycleFields`** (`failureLogEmitted` + required `lastError`) for reflection and tool-use cycle nodes, removing duplicate `message`/`userRetryable` fields and post-path fallbacks that rebuilt missing errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef91ef9a4e16ec7e2cb402ef80db6af5e9ff896b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->