### PR TITLE
fix(ci): fail when Claude review does not run

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -168,3 +168,15 @@ jobs:
                 body: '⏳ Claude quota exhausted or rate limit reached. Add the `re-review` label to retry the review.\n\n(If this persists, please check the [Claude Code action logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}))'
               });
             }
+
+      - name: Fail when Claude review did not complete
+        if: |
+          steps.claude-switch.outputs.skip != 'true' &&
+          steps.provider-token.outputs.skip != 'true' &&
+          steps.trusted-provider-wrapper.outputs.available == 'true' &&
+          steps.claude-review.outcome != 'success'
+        env:
+          CLAUDE_REVIEW_OUTCOME: ${{ steps.claude-review.outcome }}
+        run: |
+          echo "::error::Claude code review did not complete (outcome: $CLAUDE_REVIEW_OUTCOME)."
+          exit 1


### PR DESCRIPTION
## Summary

Make Claude code-review checks report an honest failure when the review action does not complete. The review action remains recoverable long enough to post the existing quota/rate-limit comment, then a final step fails the matrix job instead of allowing a misleading green check.

## Issue acceptance gates

Closes #9462.

- A failed or cancelled Claude review action no longer produces a successful provider check.
- The existing PR comment and `re-review` retry instructions still run first.
- Disabled reviews, unconfigured provider credentials, and fork PRs continue to skip without false failures.
- Each configured provider reports its own outcome independently.

## Single source of truth

`steps.claude-review.outcome` is the sole fact used by both the explanatory comment and final check conclusion.

## Duplication and abstraction budget

No new abstraction. The final gate deliberately repeats the existing provider-enabled condition so comment and failure behavior have identical scope.

## Net elements (R6)

- Files: 1 modified.
- Exports/classes/interfaces/enums: none.
- LoC: +12 / -0.

## Consumer counts (R8)

n/a — no export or event route changed.

## Host impact

Extension: None.

Desktop: None.

CLI: None.

## Scheduled refactoring

None.

## Validation

- `actionlint .github/workflows/claude-code-review.yml` — passed.
- YAML parse and semantic assertions for `continue-on-error`, failure condition, and `exit 1` — passed.
- Prettier and `git diff --check` — passed.
- Independent GitHub Actions semantics review — no actionable findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change with no application, auth, or data-path impact; behavior is narrowly scoped to non-success review outcomes when the review actually ran.
> 
> **Overview**
> Closes the gap where a **failed or cancelled** Claude code review could still show a **green** check because `Run Claude Code Review` uses `continue-on-error: true`.
> 
> A new step **Fail when Claude review did not complete** runs after the existing quota/rate-limit PR comment. It uses the **same `if` guards** as that comment (review enabled, token present, trusted wrapper available) and fails the matrix job when `steps.claude-review.outcome` is not `success`, with an `::error::` annotation including the outcome. Skipped paths (disabled review, missing credentials, etc.) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbe7f1a9beef94078890c6f7c4988a3ead835417. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->