### PR TITLE
test(trace): restore strict minimal doubles

### DIFF
--- a/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
+++ b/src/test-kernel/agent/output/XmlOutputManager.vitest.ts
@@ -48,12 +48,23 @@ function createXmlManager(
   inputFiles: string[] = ['paper.tex'],
   options: XmlManagerOptions = {},
 ): XmlOutputManager {
+  const logger =
+    options.logger ??
+    spiedTrace(
+      {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        domain: vi.fn(),
+      },
+      { strict: true },
+    );
   return new XmlOutputManager(
     {
       inputFiles,
       outputFiles: options.outputFiles ?? [],
     } as unknown as AgentConfig,
-    options.logger ?? spiedTrace(),
+    logger,
     new TaskRunFileService('xml-output-manager-test'),
   );
 }

--- a/src/test-kernel/agent/output/outputOperations.vitest.ts
+++ b/src/test-kernel/agent/output/outputOperations.vitest.ts
@@ -38,7 +38,7 @@ describe('tryOperation', () => {
       loggedType,
     }) => {
       const warn = vi.fn();
-      const logger = spiedTrace({ warn });
+      const logger = spiedTrace({ warn }, { strict: true });
 
       const result = await tryOperation(
         async () => {

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -372,7 +372,7 @@ describe('executionRegistry', () => {
       'parent-waiting-kill-publish-result-test' as StreamTabId;
     const childStreamId =
       'child-waiting-kill-publish-result-test' as StreamTabId;
-    const trace = spiedTrace({ emit: vi.fn() });
+    const trace = spiedTrace({ emit: vi.fn() }, { strict: true });
     const leaseScopeInvoked = vi.fn();
     const leaseScope: OwnedExecutionLeaseScope = (operation) => {
       leaseScopeInvoked();

--- a/src/test-kernel/support/spiedTrace.ts
+++ b/src/test-kernel/support/spiedTrace.ts
@@ -3,13 +3,23 @@ import { vi } from 'vitest';
 import type { AgentTrace } from '@agent/trace';
 import { noopTrace } from '@agent/trace';
 
+interface SpiedTraceOptions {
+  /** Throw when code reads a trace member not supplied in `overrides`. */
+  readonly strict?: boolean;
+}
+
 /**
  * `noopTrace` with `debug`/`info`/`warn`/`error`/`domain` replaced by
  * `vi.fn()` spies, for tests that assert on trace calls. Pass `overrides`
- * to spy on additional members or stub others.
+ * to spy on additional members or stub others. Strict mode preserves the
+ * narrower contract of a minimal test double: only explicitly supplied
+ * members may be read.
  */
-export function spiedTrace(overrides?: Partial<AgentTrace>): AgentTrace {
-  return {
+export function spiedTrace(
+  overrides?: Partial<AgentTrace>,
+  options?: SpiedTraceOptions,
+): AgentTrace {
+  const trace: AgentTrace = {
     ...noopTrace,
     debug: vi.fn(),
     info: vi.fn(),
@@ -18,4 +28,20 @@ export function spiedTrace(overrides?: Partial<AgentTrace>): AgentTrace {
     domain: vi.fn(),
     ...overrides,
   };
+
+  if (!options?.strict) {
+    return trace;
+  }
+
+  const permittedMembers = new Set(Reflect.ownKeys(overrides ?? {}));
+  return new Proxy(trace, {
+    get(target, property, receiver) {
+      if (typeof property === 'symbol' || permittedMembers.has(property)) {
+        return Reflect.get(target, property, receiver);
+      }
+      throw new Error(
+        `Unexpected AgentTrace.${String(property)} access; add it to the strict test double`,
+      );
+    },
+  });
 }

--- a/src/test-kernel/support/spiedTrace.vitest.ts
+++ b/src/test-kernel/support/spiedTrace.vitest.ts
@@ -1,0 +1,19 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports
+import { spiedTrace } from '@test/support/spiedTrace';
+
+describe('spiedTrace', () => {
+  it('rejects access to trace members omitted from a strict test double', () => {
+    const warn = vi.fn();
+    const trace = spiedTrace({ warn }, { strict: true });
+
+    trace.warn('expected warning');
+
+    expect(warn).toHaveBeenCalledWith('expected warning');
+    expect(() => trace.error('unexpected error')).toThrow(
+      'Unexpected AgentTrace.error access',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add an opt-in strict mode to the shared `spiedTrace` test helper
- make strict doubles throw when production code reads a trace member the test did not explicitly permit
- restore the former minimal-double contracts in the execution registry, output operation, and XML output suites
- add direct regression coverage for the strict-access tripwire

## Reasoning

The shared permissive trace double made every `AgentTrace` member available as a silent no-op. In tests that previously used deliberately minimal stubs, this removed a useful structural assertion: a new logging or event call could pass unnoticed even when the test intended to permit only a small trace surface.

Strict mode retains the convenient shared helper while requiring the caller to name each allowed member. The default remains permissive for suites that need a general-purpose trace. The three affected fixtures now state their exact contracts: `emit` for waiting-execution publication, `warn` for recoverable output failures, and `debug`/`info`/`warn`/`domain` for XML output management.

## Validation

- `npm run format`
- `npm run compile:fast`
- `npm run typecheck`
- `npm run lint`
- `npm test` (8,121 passed, 4 skipped)
- focused strict-trace and affected-suite run (114 passed)
- dead-code ratchet unchanged at 17

Closes #9478.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only helper and fixture changes with no production runtime impact.
> 
> **Overview**
> Adds **opt-in strict mode** to the shared `spiedTrace` helper so tests can enforce a minimal `AgentTrace` surface: when `{ strict: true }`, a `Proxy` throws if production code reads any member not listed in the `overrides` object (default behavior stays permissive via `noopTrace`).
> 
> **Execution registry**, **output operations**, and **XML output manager** fixtures now use strict doubles with explicitly named members (`emit`; `warn`; `debug`/`info`/`warn`/`domain` respectively), restoring the old “only these trace calls are allowed” contracts. A small **`spiedTrace.vitest.ts`** regression test covers the tripwire.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b5826c7b29bacce0da23a72b75bb064a2d6a4a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->