### PR TITLE
refactor(progress): remove unused tab presentation property

### DIFF
--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -337,7 +337,6 @@ conversationView.setAttribute('data-desktop-view', 'progress');
 // Left rail: a fresh <stream-tabs> mount wired to module-level progressState.
 // PRD § 7.D requires mounting <stream-tabs> directly (not inside <progress-app>).
 const railTabs = document.createElement('stream-tabs') as StreamTabs;
-railTabs.presentation = 'orchestration';
 
 const settingsView: HTMLElement = document.createElement('settings-app');
 settingsView.setAttribute('data-desktop-view', 'settings');

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -317,8 +317,6 @@ export class StreamTabs extends LitElement {
 
   @property({ attribute: false }) streams: StreamTabInfo[] = [];
   @property({ type: Boolean, reflect: true }) compact = false;
-  @property({ type: String }) presentation: 'progress' | 'orchestration' =
-    'progress';
   /** Optional rail-header title. Empty (default) renders no header band. */
   @property({ type: String }) heading = '';
   @property({ attribute: false }) activeStreamId: string | null = null;

--- a/src/test-kernel/progressView/StreamTabsExpandChevron.vitest.mts
+++ b/src/test-kernel/progressView/StreamTabsExpandChevron.vitest.mts
@@ -83,17 +83,7 @@ describe('stream-tab expand chevron', () => {
     expect(ariaLabel).toContain('unlabeled-stream');
   });
 
-  it('omits the session footer in the orchestration presentation', async () => {
-    const tabs = await mountTabs({
-      presentation: 'orchestration',
-      streams: [makeStream('session')],
-    });
-
-    expect(tabs.shadowRoot?.querySelector('.stream-list-footer')).toBeNull();
-    expect(tabs.shadowRoot?.querySelector('stream-tab')).toBeTruthy();
-  });
-
-  it('renders no session footer in the progress presentation either', async () => {
+  it('renders no session footer', async () => {
     const tabs = await mountTabs({ streams: [makeStream('session')] });
 
     expect(tabs.shadowRoot?.querySelector('.stream-list-footer')).toBeNull();


### PR DESCRIPTION
## Summary

- remove the unused `StreamTabs.presentation` property
- remove the obsolete desktop assignment to the abandoned orchestration presentation
- retain one presentation-independent regression test for the absent session footer

## Design

The orchestration footer was removed when the orchestration rail was simplified. Since then, the two accepted presentation values have produced identical output. Removing the property restores the component interface to the distinction that the implementation actually supports and eliminates a misleading mode from both the desktop caller and the test suite.

## Verification

- `npm run format`
- `npm run compile:fast`
- `npm run typecheck`
- `npm run lint`
- `npm test` (8,120 passed; 4 skipped)
- focused `StreamTabsExpandChevron` suite (5 passed)

Closes #9401

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Interface cleanup only; no behavior change because both presentation values were already equivalent.
> 
> **Overview**
> Removes the dead **`presentation`** API from **`stream-tabs`**, which previously accepted `'progress' | 'orchestration'` but rendered the same UI after the orchestration rail footer was dropped.
> 
> The desktop shell no longer sets **`railTabs.presentation = 'orchestration'`**. Tests drop the presentation-specific footer cases and keep a single assertion that **`.stream-list-footer`** is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 732ec5167fc6833ffc41daa6dd34560e24c61d7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->