### PR TITLE
fix(runtime): preserve consistent terminal metadata

### DIFF
--- a/src/agent/runtime/restartRepair.ts
+++ b/src/agent/runtime/restartRepair.ts
@@ -134,8 +134,9 @@ function repairCandidates(
 }
 
 type ExecutionSettlement =
-  | { readonly settled: false }
-  | { readonly settled: true; readonly outcome: RunOutcome };
+  | { readonly kind: 'unsettled' }
+  | { readonly kind: 'unmappable-terminal' }
+  | { readonly kind: 'settled'; readonly outcome: RunOutcome };
 
 /**
  * Revalidate terminal metadata while holding the execution lease.
@@ -150,18 +151,21 @@ async function readExecutionSettlement(
 ): Promise<ExecutionSettlement> {
   const meta = await getExecutionStore(executionId).readMetaStrict();
   if (!meta || (meta.terminalStatus == null && meta.outcome == null)) {
-    return { settled: false };
+    return { kind: 'unsettled' };
+  }
+  if (meta.outcome == null) {
+    return { kind: 'unmappable-terminal' };
   }
   if (meta.outcome !== RUN_OUTCOME.CANCELLED) {
     return {
-      settled: true,
-      outcome: meta.outcome ?? RUN_OUTCOME.FAILED,
+      kind: 'settled',
+      outcome: meta.outcome,
     };
   }
   const resumability = await deriveResumability(executionId);
   return resumability.resumable
-    ? { settled: false }
-    : { settled: true, outcome: RUN_OUTCOME.CANCELLED };
+    ? { kind: 'unsettled' }
+    : { kind: 'settled', outcome: RUN_OUTCOME.CANCELLED };
 }
 
 function synchronizeSettledPhase(
@@ -334,7 +338,10 @@ export async function repairRestartedStreams(
           if (options.signal?.aborted) {
             return { kind: 'cancelled' as const };
           }
-          if (settlement.settled) {
+          if (settlement.kind === 'unmappable-terminal') {
+            return { kind: 'protected-terminal' as const };
+          }
+          if (settlement.kind === 'settled') {
             synchronizeSettledPhase(
               options.streamStatus,
               streamId,
@@ -381,6 +388,12 @@ export async function repairRestartedStreams(
         continue;
       }
       if (repaired.value.kind === 'cancelled') break;
+      if (repaired.value.kind === 'protected-terminal') {
+        options.logger?.debug(
+          `Skipped restart repair for execution ${executionId} with an unknown legacy terminal status`,
+        );
+        continue;
+      }
       if (repaired.value.kind === 'settled') {
         options.logger?.debug(
           `Skipped restart repair for terminal execution ${executionId}`,

--- a/src/shared/schemas/stream.ts
+++ b/src/shared/schemas/stream.ts
@@ -93,7 +93,21 @@ const ExecutionMetaBaseSchema = z.object({
   streamId: StreamTabIdSchema.optional(),
 });
 
-export const ExecutionMetaSchema = ExecutionMetaBaseSchema.transform(
+const ConsistentExecutionMetaSchema = ExecutionMetaBaseSchema.superRefine(
+  (meta, ctx) => {
+    if (meta.terminalStatus == null || meta.outcome == null) return;
+    const projectedOutcome = executionStatusToRunOutcome(meta.terminalStatus);
+    if (projectedOutcome == null || projectedOutcome === meta.outcome) return;
+
+    ctx.addIssue({
+      code: 'custom',
+      path: ['outcome'],
+      message: `outcome ${meta.outcome} contradicts terminalStatus ${meta.terminalStatus}`,
+    });
+  },
+);
+
+export const ExecutionMetaSchema = ConsistentExecutionMetaSchema.transform(
   (meta): z.infer<typeof ExecutionMetaBaseSchema> => {
     const outcome =
       meta.outcome ?? executionStatusToRunOutcome(meta.terminalStatus);

--- a/src/test-kernel/agent/runtime/RestartRepair.vitest.ts
+++ b/src/test-kernel/agent/runtime/RestartRepair.vitest.ts
@@ -200,7 +200,7 @@ describe('repairRestartedStreams', () => {
     }
   });
 
-  it('closes an unknown legacy terminal state conservatively as failed', async () => {
+  it('protects an unknown legacy terminal state from restart repair', async () => {
     const streamId = 'stream-legacy-terminal' as StreamTabId;
     const executionId = 'execution-legacy-terminal' as ExecutionId;
     const store = getExecutionStore(executionId);
@@ -223,16 +223,14 @@ describe('repairRestartedStreams', () => {
         runWithInactiveExecutionLease: performInactiveLease,
       });
 
-      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.FAILED);
-      expect(closeRunningGroups).toHaveBeenCalledWith(
-        [streamId],
-        RUN_OUTCOME.FAILED,
-        expect.any(Number),
-      );
+      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.RUNNING);
+      expect(closeRunningGroups).not.toHaveBeenCalled();
       expect(result.failedStreams).toEqual([]);
-      await expect(store.readMeta()).resolves.toMatchObject({
+      const persistedMeta = await store.readMeta();
+      expect(persistedMeta).toMatchObject({
         terminalStatus: 'legacy-terminal',
       });
+      expect(persistedMeta?.outcome).toBeUndefined();
       expect(finalizeExecution).not.toHaveBeenCalled();
     } finally {
       await store.clear();

--- a/src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts
@@ -116,6 +116,18 @@ describe('ExecutionKVStore meta read shims', () => {
     },
   );
 
+  it('rejects contradictory terminal status and outcome metadata', async () => {
+    const id = 'contradictory-terminal-meta' as ExecutionId;
+
+    await expect(
+      getExecutionStore(id).writeMeta({
+        timestamp: '2026-07-04T00:00:00.000Z',
+        terminalStatus: EXECUTION_STATUS.COMPLETED,
+        outcome: RUN_OUTCOME.FAILED,
+      }),
+    ).rejects.toThrow('outcome failed contradicts terminalStatus completed');
+  });
+
   it('writes the current schema version for execution meta', async () => {
     const id = 'versioned-meta' as ExecutionId;
 


### PR DESCRIPTION
## Summary

- reject execution metadata whose known terminal status contradicts its canonical outcome
- distinguish unsettled executions from terminal legacy records that cannot be mapped to a canonical outcome
- preserve unknown legacy terminal records during restart repair instead of rewriting them as failed

## Design

Execution metadata remains backward compatible: a known legacy status still supplies a missing canonical outcome, and an unknown legacy status may coexist with an explicit canonical outcome. The schema now rejects only pairs whose meanings are both known and contradictory.

Restart repair models settlement as a three-case discriminated union: unsettled, settled with a canonical outcome, or an unmappable legacy terminal record. This makes the preservation policy explicit and prevents the latter case from entering the ordinary failure-repair path.

## Verification

- `npm run format`
- `npm run compile:fast`
- `npm run typecheck`
- `npm run lint`
- `npm test` (8,121 passed; 4 skipped)

Closes #9439

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes restart-repair behavior for legacy terminal metadata and tightens meta writes at the persistence boundary; impact is localized but affects recovery after restarts.
> 
> **Overview**
> **Execution metadata** now rejects writes where a known `terminalStatus` and explicit `outcome` disagree; legacy status can still fill a missing outcome, and unknown legacy statuses remain valid when not contradicted.
> 
> **Restart repair** treats settlement as unsettled, settled (canonical outcome), or **unmappable-terminal** (terminal metadata with no canonical outcome). Unknown legacy terminal records are **skipped** instead of being closed as failed—stream phase and persisted meta stay unchanged.
> 
> Tests cover schema rejection, protected legacy repair behavior, and the updated settlement paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ceb1684d162986070368342bd8f21d926fd33e2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->