### PR TITLE
fix(schemas): surface malformed persisted metadata

### DIFF
--- a/src/shared/schemas/agentPresets.ts
+++ b/src/shared/schemas/agentPresets.ts
@@ -59,15 +59,25 @@ export const AgentModePresetSchema = z.object({
 export type AgentModePreset = z.infer<typeof AgentModePresetSchema>;
 
 export function parseAgentModePresets(raw: unknown): AgentModePreset[] {
-  return z
-    .array(z.unknown())
-    .catch([])
-    .parse(raw)
-    .flatMap((rawPreset) => {
-      const result = AgentModePresetSchema.safeParse(rawPreset);
-      if (!result.success) return [];
-      return [result.data];
-    });
+  const parsedRecords = z.array(z.unknown()).prefault([]).safeParse(raw);
+  if (!parsedRecords.success) {
+    console.warn(
+      `[agentPresets] Custom agent teams are not an array; ignoring them for ` +
+        `this read: ${parsedRecords.error.message}`,
+    );
+    return [];
+  }
+
+  return parsedRecords.data.flatMap((rawPreset, index) => {
+    const result = AgentModePresetSchema.safeParse(rawPreset);
+    if (result.success) return [result.data];
+
+    console.warn(
+      `[agentPresets] Ignoring malformed custom agent team at index ${index}: ` +
+        result.error.message,
+    );
+    return [];
+  });
 }
 
 /**

--- a/src/shared/schemas/streamData.ts
+++ b/src/shared/schemas/streamData.ts
@@ -137,8 +137,8 @@ const numericUsageParsingShape = Object.fromEntries(
 const TokenUsageStatsParsingBaseSchema = z
   .object({
     ...numericUsageParsingShape,
-    viaChatGptSubscription: z.boolean().catch(false).prefault(false),
-    usageRoute: UsageRouteSchema.optional().catch(undefined),
+    viaChatGptSubscription: z.boolean().prefault(false),
+    usageRoute: UsageRouteSchema.optional(),
     // The numeric fields are derived from `TokenUsageStatsBaseSchema.shape` above;
     // TypeScript cannot recover the required keys through `Object.fromEntries`.
   })

--- a/src/test-kernel/schemas/StreamDataUsage.vitest.ts
+++ b/src/test-kernel/schemas/StreamDataUsage.vitest.ts
@@ -120,6 +120,26 @@ describe('stream data usage parsing', () => {
     expect(usage.get('run')).not.toHaveProperty('viaChatGptSubscription');
   });
 
+  it.each([
+    ['subscription marker', { viaChatGptSubscription: 'yes' }],
+    ['usage route', { usageRoute: 'unknown-route' }],
+  ])('preserves a run with a malformed %s', (_field, malformedField) => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const rawRun = {
+      inputTokens: 10,
+      outputTokens: 2,
+      cost: 0.1,
+      ...malformedField,
+    };
+
+    const { usage, unparsedRuns } = parseUsageData({ run: rawRun });
+
+    expect(usage.has('run')).toBe(false);
+    expect(unparsedRuns.get('run')).toEqual(rawRun);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
   it('preserves an unparseable run entry instead of silently zeroing it', () => {
     // Regression test for #7464: a run entry that isn't an object at all
     // (e.g. corrupted to a bare string) must not be replaced by zeroed

--- a/src/test-kernel/shared/AgentPresetHostedMetadata.vitest.ts
+++ b/src/test-kernel/shared/AgentPresetHostedMetadata.vitest.ts
@@ -43,6 +43,32 @@ describe('parseAgentModePresets icon degradation', () => {
     toolUseAgents: ['assistant'],
   });
 
+  it('treats an absent custom-preset value as an empty list', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(parseAgentModePresets(undefined)).toEqual([]);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('warns when the custom-preset value is malformed', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(parseAgentModePresets('not-an-array')).toEqual([]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('not an array'));
+  });
+
+  it('warns about a malformed record without dropping valid siblings', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const presets = parseAgentModePresets([
+      customPreset('rocket'),
+      { id: 'incomplete' },
+    ]);
+
+    expect(presets.map((preset) => preset.id)).toEqual(['custom-1']);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('index 1'));
+  });
+
   it('keeps a preset whose icon is unknown, degrading to bookmark loudly', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 


### PR DESCRIPTION
## Summary

- reject malformed present subscription markers and usage routes so per-run usage preservation can retain the original record
- keep absent custom-team state as an empty list while warning on malformed present top-level state
- warn for malformed custom-team records without hiding valid sibling records

## Design

Persisted usage data already has a boundary that logs invalid run entries and returns their raw values for lossless rewriting. Removing the two field-level catches lets malformed accounting metadata reach that boundary instead of being converted into ordinary defaults.

Custom-team parsing remains resilient because several UI and launch callers consume it synchronously. The parser now uses `prefault([])` only for a genuinely absent value, reports malformed present data, and continues parsing valid sibling records. The raw records remain owned by the settings state, so parsing does not rewrite or delete malformed entries.

## Verification

- `npm run format`
- `npm run compile:fast`
- `npm run typecheck`
- `npm run lint`
- `npm test` (8,126 passed; 4 skipped)

Closes #9395

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how corrupted usage and settings metadata is interpreted at read time; callers that assumed silent defaults may see more `unparsedRuns` and console warnings, but valid data paths are unchanged.
> 
> **Overview**
> Tightens parsing of **persisted sidecar metadata** so bad on-disk values are visible and losslessly round-tripped instead of normalized away.
> 
> For **per-run usage** (`TokenUsageStatsParsingBaseSchema`), removes field-level `.catch()` on `viaChatGptSubscription` and `usageRoute`. Wrong types or invalid routes no longer become `false` / `undefined`; the run fails `safeParse` and lands in `unparsedRuns` like other unparseable usage entries (#7464 behavior).
> 
> For **custom agent teams** (`parseAgentModePresets`), uses `prefault([])` only when the value is absent, **warns** when the stored value is not an array, and **warns per bad record** while still returning valid sibling presets. Malformed teams are skipped for this read but are not rewritten by the parser itself.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 016e2bca0bcf8e87759a1efb74ef590cceb41eed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->