### PR TITLE
fix(runtime): preserve flow errors during teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,8 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
-- **Agent failures retain their partial result when cleanup also fails** — the
-  original provider or flow error is now reported with any partial response and
-  touched files, while cleanup failures are recorded separately.
+- **Agent failures retain their partial result** — the original error is now
+  reported together with any partial response and affected files.
 - **Long-running sessions use less memory after recovering interrupted runs** —
   transcript history loaded only to repair stale run state is released again
   after the repair is saved, instead of remaining in memory for the rest of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Agent failures retain their partial result when cleanup also fails** — the
+  original provider or flow error is now reported with any partial response and
+  touched files, while cleanup failures are recorded separately.
 - **Long-running sessions use less memory after recovering interrupted runs** —
   transcript history loaded only to repair stale run state is released again
   after the repair is saved, instead of remaining in memory for the rest of

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -2,6 +2,7 @@
 import { isDeepStrictEqual } from 'node:util';
 
 // Local imports
+import { logSdkError } from '@agent/trace';
 import { getExecutionStore } from '@agent/storage';
 import {
   activeModelHandlerCompatibilityKey,
@@ -400,6 +401,20 @@ export async function runToolUseFlow<C = unknown>(
   let preserveResumeRecord = false;
   let persistenceRecoveryPending = false;
   let flowRunStarted = false;
+  let primaryFailure: { readonly error: unknown } | undefined;
+  let earlyResult: RunToolUseFlowResult | undefined;
+  const startupInterruption = Symbol('startup interruption');
+  const teardownFailures: Array<{
+    readonly operation: string;
+    readonly error: unknown;
+  }> = [];
+  const attemptTeardown = (operation: string, action: () => void): void => {
+    try {
+      action();
+    } catch (error) {
+      teardownFailures.push({ operation, error });
+    }
+  };
   const compatibilityKey = activeModelHandlerCompatibilityKey(
     services.modelHandler,
   );
@@ -418,7 +433,8 @@ export async function runToolUseFlow<C = unknown>(
     // it before touching the persisted resume record.
     if (input.checkInterruption()) {
       preserveResumeRecord = input.resume !== undefined;
-      return { outcome };
+      earlyResult = { outcome };
+      throw startupInterruption;
     }
 
     persistenceRecoveryPending = true;
@@ -428,7 +444,8 @@ export async function runToolUseFlow<C = unknown>(
     if (input.checkInterruption()) {
       persistenceRecoveryPending = false;
       preserveResumeRecord = input.resume !== undefined;
-      return { outcome };
+      earlyResult = { outcome };
+      throw startupInterruption;
     }
     // Past both startup cancellation guards: any later interrupt() is a
     // genuine mid-run cancellation, so go back to the normal destructive
@@ -623,9 +640,11 @@ export async function runToolUseFlow<C = unknown>(
       });
       throwFlowLastError(err, shared.lastError);
     }
+  } catch (error) {
+    if (error !== startupInterruption) primaryFailure = { error };
   } finally {
     activePersistedFlow = undefined;
-    teardownSetup?.();
+    attemptTeardown('detaching the live flow', () => teardownSetup?.());
     teardownSetup = undefined;
     let preservationReason: string | undefined;
     if (preserveResumeRecord) {
@@ -647,7 +666,11 @@ export async function runToolUseFlow<C = unknown>(
       preserveFlowRecord && !persistenceRecoveryPending;
 
     if (preservationReason) logger.debug(preservationReason);
-    input.onFlowRecordDisposition?.(preserveFlowRecord ? 'preserve' : 'delete');
+    attemptTeardown('reporting flow-record disposition', () =>
+      input.onFlowRecordDisposition?.(
+        preserveFlowRecord ? 'preserve' : 'delete',
+      ),
+    );
     // AgentRunLifecycle applies this policy with terminal metadata through one
     // storage finalization after the flow reports its outcome.
 
@@ -655,16 +678,48 @@ export async function runToolUseFlow<C = unknown>(
     // explicitly recoverable. Every other exit is terminal. The lifecycle's
     // generation-scoped release is a no-op for an inner native-child turn,
     // whose child loop retains the sole consumer lease across turns.
-    sessionLifecycle.release(
-      preserveFollowUpQueue || runSession.executions.hasActiveChildren(streamId)
-        ? 'recoverable'
-        : 'terminal',
+    attemptTeardown('releasing the follow-up queue', () =>
+      sessionLifecycle.release(
+        preserveFollowUpQueue ||
+          runSession.executions.hasActiveChildren(streamId)
+          ? 'recoverable'
+          : 'terminal',
+      ),
     );
-    runSession.interactions.cancel({ streamId, cause: 'Run ended.' });
+    attemptTeardown('cancelling host interactions', () =>
+      runSession.interactions.cancel({ streamId, cause: 'Run ended.' }),
+    );
     for (const handler of switchedHandlers) {
-      handler.dispose();
+      attemptTeardown('disposing a switched model handler', () =>
+        handler.dispose(),
+      );
     }
   }
+
+  if (primaryFailure) {
+    for (const failure of teardownFailures) {
+      logSdkError(
+        logger,
+        `Tool-use teardown failed while ${failure.operation}`,
+        failure.error,
+      );
+    }
+    throw primaryFailure.error;
+  }
+
+  const [firstTeardownFailure, ...additionalTeardownFailures] =
+    teardownFailures;
+  for (const failure of additionalTeardownFailures) {
+    logSdkError(
+      logger,
+      `Tool-use teardown failed while ${failure.operation}`,
+      failure.error,
+    );
+  }
+  if (firstTeardownFailure) {
+    throw firstTeardownFailure.error;
+  }
+  if (earlyResult) return earlyResult;
 
   if (
     outputSchema !== undefined &&

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -403,7 +403,7 @@ export async function runToolUseFlow<C = unknown>(
   let flowRunStarted = false;
   let primaryFailure: { readonly error: unknown } | undefined;
   let earlyResult: RunToolUseFlowResult | undefined;
-  const startupInterruption = Symbol('startup interruption');
+  const startupInterruption = new Error('Tool-use startup interrupted.');
   const teardownFailures: Array<{
     readonly operation: string;
     readonly error: unknown;
@@ -640,6 +640,15 @@ export async function runToolUseFlow<C = unknown>(
       });
       throwFlowLastError(err, shared.lastError);
     }
+    if (
+      outputSchema !== undefined &&
+      outcome === RUN_OUTCOME.COMPLETED &&
+      shared.structured === undefined
+    ) {
+      throw new Error(
+        'Structured-output run completed without calling submit_output.',
+      );
+    }
   } catch (error) {
     if (error !== startupInterruption) primaryFailure = { error };
   } finally {
@@ -720,16 +729,6 @@ export async function runToolUseFlow<C = unknown>(
     throw firstTeardownFailure.error;
   }
   if (earlyResult) return earlyResult;
-
-  if (
-    outputSchema !== undefined &&
-    outcome === RUN_OUTCOME.COMPLETED &&
-    shared.structured === undefined
-  ) {
-    throw new Error(
-      'Structured-output run completed without calling submit_output.',
-    );
-  }
 
   return {
     outcome,

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -677,6 +677,51 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
     }
   });
 
+  it('preserves a missing structured-output failure when teardown also fails', async () => {
+    const executionId =
+      'abc-flow-structured-output-and-teardown-failure' as ExecutionId;
+    const streamId =
+      'chat@gpt54#abc-flow-structured-output-and-teardown-failure' as StreamTabId;
+    const snapshot = {
+      ...buildToolUseResumeData(executionId, streamId),
+      agentConfig: AgentConfigSchema.parse({
+        ...CONFIG,
+        outputSchema: {
+          type: 'object',
+          properties: { answer: { type: 'string' } },
+          required: ['answer'],
+        },
+      }),
+    };
+    const session = createTestSession();
+    const teardownFailure = new Error('flow detachment failed');
+    const runSpy = vi
+      .spyOn(PersistedFlow.prototype, 'run')
+      .mockResolvedValueOnce(FlowTransition.COMPLETE);
+    const sharedSpy = vi
+      .spyOn(PersistedFlow.prototype, 'getShared')
+      .mockResolvedValue(snapshot.shared);
+
+    try {
+      await expect(
+        runPersistedFlow(
+          executionId,
+          streamId,
+          snapshot,
+          () => () => {
+            throw teardownFailure;
+          },
+          session,
+        ),
+      ).rejects.toThrow(
+        'Structured-output run completed without calling submit_output.',
+      );
+    } finally {
+      runSpy.mockRestore();
+      sharedSpy.mockRestore();
+    }
+  });
+
   it.each([
     {
       name: 'invalid shared state',

--- a/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
+++ b/src/test-kernel/agent/SessionResumeRetrieval.vitest.ts
@@ -34,6 +34,7 @@ import { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { ModelHandlerCompatibilityKey } from '@agent/runtime/modelHandlerCompatibilityKey';
 import { ToolInjectionRegistry } from '@agent/runtime/toolInjection';
 import {
+  getToolUseFlowErrorResult,
   runToolUseFlow,
   type RunToolUseFlowResult,
   type RunToolUseFlowInput,
@@ -584,6 +585,95 @@ describe('runToolUseFlow consumes the resume boundary instead of re-parsing', ()
         deleteSpy.mockRestore();
         session.followUps.terminalize(streamId);
       }
+    }
+  });
+
+  it('preserves the structured flow error when teardown also fails', async () => {
+    const executionId = 'abc-flow-primary-and-teardown-failure' as ExecutionId;
+    const streamId =
+      'chat@gpt54#abc-flow-primary-and-teardown-failure' as StreamTabId;
+    const snapshot = buildToolUseResumeData(executionId, streamId);
+    const session = createTestSession();
+    const teardownFailure = new Error('flow detachment failed');
+    const failedShared = {
+      ...snapshot.shared,
+      lastError: {
+        message: 'provider failed after partial output',
+        userRetryable: true,
+      },
+      lastResponse: 'partial assistant response',
+    };
+    const runSpy = vi
+      .spyOn(PersistedFlow.prototype, 'run')
+      .mockResolvedValueOnce(FlowTransition.COMPLETE);
+    const sharedSpy = vi
+      .spyOn(PersistedFlow.prototype, 'getShared')
+      .mockResolvedValue(failedShared);
+    const releaseSpy = vi.spyOn(session.followUps, 'release');
+    const errorLogSpy = vi
+      .spyOn(noopTrace, 'error')
+      .mockImplementation(() => {});
+
+    try {
+      let caught: unknown;
+      try {
+        await runPersistedFlow(
+          executionId,
+          streamId,
+          snapshot,
+          () => () => {
+            throw teardownFailure;
+          },
+          session,
+        );
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(caught).not.toBe(teardownFailure);
+      expect(getToolUseFlowErrorResult(caught)).toMatchObject({
+        outcome: RUN_OUTCOME.FAILED,
+        lastResponse: 'partial assistant response',
+      });
+      expect(releaseSpy).toHaveBeenCalled();
+      expect(errorLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('detaching the live flow'),
+        expect.any(Object),
+      );
+    } finally {
+      runSpy.mockRestore();
+      sharedSpy.mockRestore();
+      releaseSpy.mockRestore();
+      errorLogSpy.mockRestore();
+    }
+  });
+
+  it('surfaces the first teardown failure after an otherwise successful exit', async () => {
+    const executionId = 'abc-flow-teardown-failure' as ExecutionId;
+    const streamId = 'chat@gpt54#abc-flow-teardown-failure' as StreamTabId;
+    const snapshot = buildToolUseResumeData(executionId, streamId);
+    const session = createTestSession();
+    const teardownFailure = new Error('flow detachment failed');
+    const releaseSpy = vi.spyOn(session.followUps, 'release');
+
+    try {
+      await expect(
+        runPersistedFlow(
+          executionId,
+          streamId,
+          snapshot,
+          (context) => {
+            context.interrupt();
+            return () => {
+              throw teardownFailure;
+            };
+          },
+          session,
+        ),
+      ).rejects.toBe(teardownFailure);
+      expect(releaseSpy).toHaveBeenCalled();
+    } finally {
+      releaseSpy.mockRestore();
     }
   });
 


### PR DESCRIPTION
## Summary

Preserve the structured tool-use failure and its partial result when one or more teardown operations also fail. Teardown remains best-effort: every registered cleanup is attempted, secondary cleanup failures are logged, and the first cleanup failure is surfaced only when the flow itself succeeded.

Startup cancellation retains its previous early-result behavior while passing through the same teardown policy.

## Issue acceptance gates

Closes #9441.

- A flow failure remains the primary error when teardown also fails.
- Partial response and touched-file metadata remain available through ToolUseFlowError.
- All teardown operations are attempted independently.
- A teardown failure is still observable when no primary flow failure exists.
- Regression tests cover both precedence branches.

## Single source of truth

runToolUseFlow owns the final ordering between the flow result and teardown failures. The final decision is made once, after all teardown attempts have completed.

## Duplication and abstraction budget

A local attemptTeardown helper owns the repeated catch-and-collect operation. No exported abstraction or pass-through layer was added.

## Net elements (R6)

- Files: 3 modified, 0 added, 0 deleted.
- Exported symbols: no change.
- Classes, interfaces, and enums: no change.
- Net lines: +208/-17. Most added lines are three regression tests.

## Consumer counts (R8)

n/a: no event path or export was deleted or rerouted.

## Host impact

Extension: Reports the original agent failure and preserves its partial result if cleanup also fails.

Desktop: Same shared runtime behavior.

CLI: Same shared runtime behavior.

## Scheduled refactoring

None.

## Validation

- npm run format
- npm run compile:fast
- npm run typecheck
- npm run lint
- npm test: 8,129 passed, 4 skipped
- Focused SessionResumeRetrieval suite: 35 passed
- Isolated DesktopAgentExecution suite: 73 passed after one load-sensitive full-suite timeout; the subsequent complete suite passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core agent run exit ordering in `runToolUseFlow`, affecting error reporting and cleanup across CLI, desktop, and extension; behavior is well-tested but touches a critical runtime path.
> 
> **Overview**
> **Agent failures now keep partial results** when cleanup also fails — hosts still get the original provider/agent error plus `lastResponse` and touched files via `ToolUseFlowError`, instead of a teardown error masking the real failure.
> 
> **`runToolUseFlow` teardown is best-effort and ordered.** Cleanup steps (detach live flow, disposition callback, follow-up release, interaction cancel, switched handler dispose) run through a local `attemptTeardown` helper that collects errors without aborting the rest. After `finally`, the **primary flow error wins** if the run already failed; extra teardown failures are logged with `logSdkError`. If the run succeeded, the **first teardown failure is thrown** so cleanup bugs stay observable.
> 
> Startup cancellation still returns the early cancelled outcome but now goes through the same `finally` teardown path (via a dedicated interruption sentinel). Structured-output validation (`submit_output` missing on a completed run) is evaluated in the main try path so it is not lost when teardown throws.
> 
> Regression tests cover primary-vs-teardown precedence and the structured-output + teardown case; the changelog notes the user-visible fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73e1444c36916c500d69dc5d7c4469c7ca9f6a14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
