### PR TITLE
fix(output): correct Windows PDF artifact paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,22 +165,20 @@ jobs:
       - name: Check guidance file references resolve
         run: node scripts/check-guidance-refs.mjs
 
+  # TODO(windows-ci): add windows-latest after #9409 is complete. The latest
+  # full-matrix run in #9503 found 70 failures across CLI, desktop, storage,
+  # tools, and path handling, so Windows cannot yet be a gating runner.
   test:
-    name: kernel tests (${{ matrix.os.label }}, shard ${{ matrix.shard }}/2)
+    name: kernel tests (linux, shard ${{ matrix.shard }}/2)
     needs: changes
     if: needs.changes.outputs.code == 'true' && github.event_name != 'schedule'
-    runs-on: ${{ matrix.os.runner }}
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
       # Run both shards to completion so a red run reports every failure at
       # once instead of hiding the other shard's results.
       fail-fast: false
       matrix:
-        os:
-          - label: linux
-            runner: ubuntu-latest
-          - label: windows
-            runner: windows-latest
         shard: [1, 2]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,32 +165,22 @@ jobs:
       - name: Check guidance file references resolve
         run: node scripts/check-guidance-refs.mjs
 
-  # TODO(windows-ci): add windows-latest to this matrix. TeXRA ships on Windows
-  # and a good deal of the code is platform-specific -- tool discovery under
-  # Program Files, the Perl lookups, path normalization, the CLI's win32
-  # branches -- none of which any runner exercises today. That gap is how a
-  # Ghostscript path list frozen at 9.x and a missing TeX Live Perl directory
-  # both survived.
-  #
-  # Adding it was tried in #9397 and reverted: the suite has ~10 pre-existing
-  # Windows failures across CompiledPdfArtifacts, RunStorageEntryInspection,
-  # ExecutionLease, and FilesUtils. Most are `\` vs `/` in expectations, two are
-  # capability gaps in the fake filesystem (chmod-based permission simulation
-  # and symlink creation), and at least one is a real product bug -- artifact
-  # paths came back with a duplicated run segment (`output\r4\r4\sections\...`).
-  # Those need fixing first, in their own change; a job that cannot pass is
-  # worse than no job.
   test:
-    name: kernel tests (linux, shard ${{ matrix.shard }}/2)
+    name: kernel tests (${{ matrix.os.label }}, shard ${{ matrix.shard }}/2)
     needs: changes
     if: needs.changes.outputs.code == 'true' && github.event_name != 'schedule'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os.runner }}
     timeout-minutes: 20
     strategy:
       # Run both shards to completion so a red run reports every failure at
       # once instead of hiding the other shard's results.
       fail-fast: false
       matrix:
+        os:
+          - label: linux
+            runner: ubuntu-latest
+          - label: windows
+            runner: windows-latest
         shard: [1, 2]
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ All notable changes to this project will be documented in this file.
 
 #### Bug Fixes
 
+- **Compiled PDF artifact paths are correct on Windows** — diff PDFs generated
+  from files in round subdirectories no longer repeat the round directory in
+  their saved path.
 - **Failed agent starts no longer look like successful runs** — when a new
   launch cannot start on a previously completed task, the status update is now
   identified as a rollback rather than a fresh completion.

--- a/src/agent/output/compiledPdfArtifacts.ts
+++ b/src/agent/output/compiledPdfArtifacts.ts
@@ -43,12 +43,13 @@ function normalizePdfRelativePath(pdfPath: string): string {
 }
 
 function stripRoundPrefix(relativePath: string, round: number): string {
-  const separatorIndex = relativePath.indexOf('/');
-  if (separatorIndex === -1) return relativePath;
-  const firstSegment = relativePath.slice(0, separatorIndex);
+  const normalizedPath = relativePath.replaceAll('\\', '/');
+  const separatorIndex = normalizedPath.indexOf('/');
+  if (separatorIndex === -1) return normalizedPath;
+  const firstSegment = normalizedPath.slice(0, separatorIndex);
   return parseWorkflowOutputRoundDir(firstSegment) === round
-    ? relativePath.slice(separatorIndex + 1)
-    : relativePath;
+    ? normalizedPath.slice(separatorIndex + 1)
+    : normalizedPath;
 }
 
 function toPdfRelativePath(options: PublishCompiledPdfOptions): string {
@@ -94,12 +95,16 @@ export async function publishCompiledPdfArtifact(
   if (!isFile(stats.type)) return null;
 
   const pdfRelativePath = toPdfRelativePath(options);
-  const roundRelativePath = path.join(
+  const roundRelativePath = path.posix.join(
     'output',
     `r${options.round}`,
     pdfRelativePath,
   );
-  const latestRelativePath = path.join('output', 'latest', pdfRelativePath);
+  const latestRelativePath = path.posix.join(
+    'output',
+    'latest',
+    pdfRelativePath,
+  );
   const roundAbsolutePath = path.join(options.runDirectory, roundRelativePath);
   const latestAbsolutePath = path.join(
     options.runDirectory,

--- a/src/test-kernel/agent/output/CompiledPdfArtifacts.vitest.ts
+++ b/src/test-kernel/agent/output/CompiledPdfArtifacts.vitest.ts
@@ -197,6 +197,31 @@ describe('compiled PDF artifacts', () => {
     );
   });
 
+  it('strips a Windows-style round prefix without duplicating it', async () => {
+    const runDirectory = await makeTempDir();
+    const compiledPdfPath = path.join(runDirectory, 'build', 'main.pdf');
+    await writePdf(compiledPdfPath, 'diff pdf');
+
+    const artifact = await publishCompiledPdfArtifact({
+      runDirectory,
+      executionId: 'windows123',
+      round: 4,
+      displayName: 'main.tex',
+      source: createRunStorageLocation(
+        path.join(runDirectory, 'r4', 'sections', 'main.tex'),
+        'r4\\sections\\main.tex',
+        'windows123',
+      ),
+      compiledPdfPath,
+      pdfStemSuffix: '-diff',
+    });
+
+    expect(artifact?.pdf.relativePath).toBe('output/r4/sections/main-diff.pdf');
+    expect(artifact?.latestPdf.relativePath).toBe(
+      'output/latest/sections/main-diff.pdf',
+    );
+  });
+
   it('keeps distinct diff kinds for the same revised source', async () => {
     const runDirectory = await makeTempDir();
     const buildDir = path.join(runDirectory, 'diff', 'r5', 'build');

--- a/src/test-kernel/utils/files/FilesUtils.vitest.ts
+++ b/src/test-kernel/utils/files/FilesUtils.vitest.ts
@@ -158,7 +158,10 @@ describe('pathUtils Test Suite', () => {
       const relativePath = 'relative/path/file.txt';
       const resolved = WorkspaceFS.toAbsolute(relativePath);
       assert.strictEqual(path.isAbsolute(resolved), true);
-      assert.strictEqual(resolved.endsWith(relativePath), true);
+      assert.strictEqual(
+        resolved.endsWith(path.join('relative', 'path', 'file.txt')),
+        true,
+      );
     });
   });
 });

--- a/src/test-kernel/utils/files/RunStorageEntryInspection.vitest.ts
+++ b/src/test-kernel/utils/files/RunStorageEntryInspection.vitest.ts
@@ -1,5 +1,10 @@
+// Node imports
+import * as path from 'node:path';
+
+// Third-party imports
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+// Local imports
 import { FileType, type FileStat } from '@platform/interfaces';
 import type { ExecutionId } from '@shared/schemas';
 import { setupPlatform } from '@test/support/setupPlatform';
@@ -11,10 +16,24 @@ import {
 } from '@utils/files/taskRunStorage';
 
 const executionId = 'abcdef123456' as ExecutionId;
+const storageRoot = path.resolve(path.sep, 'storage');
+const workspaceRoot = path.resolve(path.sep, 'workspace');
 const originalStat = StorageFS.stat;
 const originalFullPath = StorageFS.fullPath;
 
-setupPlatform({ storagePath: '/storage', workspacePath: '/workspace' });
+setupPlatform({ storagePath: storageRoot, workspacePath: workspaceRoot });
+
+function primaryEntry(...segments: string[]): string {
+  return path.join('executions', executionId, ...segments);
+}
+
+function legacyEntry(...segments: string[]): string {
+  return path.join('taskRuns', executionId, ...segments);
+}
+
+function storagePath(...segments: string[]): string {
+  return path.join(storageRoot, ...segments);
+}
 
 function fileStat(type: number): FileStat {
   return { type, ctime: 0, mtime: 0, size: 1 };
@@ -26,7 +45,7 @@ function missing(target: string): Error {
 
 describe('inspectRunStorageEntry', () => {
   beforeEach(() => {
-    StorageFS.fullPath = (target) => `/storage/${target}`;
+    StorageFS.fullPath = (target) => path.join(storageRoot, target);
   });
 
   afterEach(() => {
@@ -36,13 +55,10 @@ describe('inspectRunStorageEntry', () => {
 
   it('returns a canonical location for a regular primary-layout file', async () => {
     StorageFS.stat = async (target) => {
-      if (target === `executions/${executionId}/r1/draft.tex`) {
+      if (target === primaryEntry('r1', 'draft.tex')) {
         return fileStat(FileType.File);
       }
-      if (
-        target === `executions/${executionId}` ||
-        target === `executions/${executionId}/r1`
-      ) {
+      if (target === primaryEntry() || target === primaryEntry('r1')) {
         return fileStat(FileType.Directory);
       }
       throw missing(target);
@@ -54,7 +70,7 @@ describe('inspectRunStorageEntry', () => {
       kind: 'file',
       location: {
         kind: 'runStorage',
-        absolutePath: `/storage/executions/${executionId}/r1/draft.tex`,
+        absolutePath: storagePath('executions', executionId, 'r1', 'draft.tex'),
         relativePath: 'r1/draft.tex',
         executionId,
       },
@@ -63,10 +79,10 @@ describe('inspectRunStorageEntry', () => {
 
   it('falls back to the legacy layout only when the primary entry is absent', async () => {
     StorageFS.stat = async (target) => {
-      if (target === `taskRuns/${executionId}/result.tex`) {
+      if (target === legacyEntry('result.tex')) {
         return fileStat(FileType.File);
       }
-      if (target === `taskRuns/${executionId}`) {
+      if (target === legacyEntry()) {
         return fileStat(FileType.Directory);
       }
       throw missing(target);
@@ -77,7 +93,7 @@ describe('inspectRunStorageEntry', () => {
     expect(result).toMatchObject({
       kind: 'file',
       location: {
-        absolutePath: `/storage/taskRuns/${executionId}/result.tex`,
+        absolutePath: storagePath('taskRuns', executionId, 'result.tex'),
       },
     });
   });
@@ -115,16 +131,16 @@ describe('inspectRunStorageEntry', () => {
 
   it('rejects a regular file reached through an ancestor symlink', async () => {
     StorageFS.stat = async (target) => {
-      if (target.endsWith('/link/result.tex')) {
+      if (target.endsWith(path.join('link', 'result.tex'))) {
         return fileStat(FileType.File);
       }
-      if (target === `executions/${executionId}`) {
+      if (target === primaryEntry()) {
         return fileStat(FileType.Directory);
       }
-      if (target === `executions/${executionId}/r1`) {
+      if (target === primaryEntry('r1')) {
         return fileStat(FileType.Directory);
       }
-      if (target === `executions/${executionId}/r1/link`) {
+      if (target === primaryEntry('r1', 'link')) {
         return fileStat(FileType.SymbolicLink | FileType.Directory);
       }
       throw missing(target);
@@ -134,7 +150,7 @@ describe('inspectRunStorageEntry', () => {
       inspectRunStorageEntry(executionId, 'r1/link/result.tex'),
     ).resolves.toMatchObject({
       kind: 'symlink',
-      absolutePath: `/storage/executions/${executionId}/r1/link`,
+      absolutePath: storagePath('executions', executionId, 'r1', 'link'),
     });
   });
 
@@ -142,10 +158,10 @@ describe('inspectRunStorageEntry', () => {
     const inspected: string[] = [];
     StorageFS.stat = async (target) => {
       inspected.push(target);
-      if (target === `executions/${executionId}`) {
+      if (target === primaryEntry()) {
         return fileStat(FileType.Directory);
       }
-      if (target === `executions/${executionId}/dangling`) {
+      if (target === primaryEntry('dangling')) {
         return fileStat(FileType.SymbolicLink | FileType.Unknown);
       }
       throw missing(target);
@@ -155,11 +171,9 @@ describe('inspectRunStorageEntry', () => {
       inspectRunStorageEntry(executionId, 'dangling/result.tex'),
     ).resolves.toMatchObject({
       kind: 'symlink',
-      absolutePath: `/storage/executions/${executionId}/dangling`,
+      absolutePath: storagePath('executions', executionId, 'dangling'),
     });
-    expect(inspected).not.toContain(
-      `executions/${executionId}/dangling/result.tex`,
-    );
+    expect(inspected).not.toContain(primaryEntry('dangling', 'result.tex'));
   });
 
   it('does not turn storage permission failures into a missing entry', async () => {
@@ -175,7 +189,7 @@ describe('inspectRunStorageEntry', () => {
   it('recovers execution identity from current and legacy absolute paths', () => {
     expect(
       runStorageLocationFromAnyAbsolutePath(
-        `/storage/executions/${executionId}/r2/result.tex`,
+        storagePath('executions', executionId, 'r2', 'result.tex'),
       ),
     ).toMatchObject({
       kind: 'runStorage',
@@ -184,7 +198,7 @@ describe('inspectRunStorageEntry', () => {
     });
     expect(
       runStorageLocationFromAnyAbsolutePath(
-        `/storage/taskRuns/${executionId}/result.tex`,
+        storagePath('taskRuns', executionId, 'result.tex'),
       ),
     ).toMatchObject({
       kind: 'runStorage',
@@ -192,7 +206,9 @@ describe('inspectRunStorageEntry', () => {
       relativePath: 'result.tex',
     });
     expect(
-      runStorageLocationFromAnyAbsolutePath('/workspace/result.tex'),
+      runStorageLocationFromAnyAbsolutePath(
+        path.join(workspaceRoot, 'result.tex'),
+      ),
     ).toBeUndefined();
   });
 
@@ -201,12 +217,12 @@ describe('inspectRunStorageEntry', () => {
 
     expect(fileService.locateSource('draft.tex')).toEqual({
       kind: 'workspace',
-      absolutePath: '/workspace/draft.tex',
+      absolutePath: path.join(workspaceRoot, 'draft.tex'),
       relativePath: 'draft.tex',
     });
     expect(
       fileService.locateSource(
-        `/storage/executions/${executionId}/r1/draft.tex`,
+        storagePath('executions', executionId, 'r1', 'draft.tex'),
       ),
     ).toMatchObject({
       kind: 'runStorage',
@@ -214,7 +230,9 @@ describe('inspectRunStorageEntry', () => {
       relativePath: 'r1/draft.tex',
     });
     expect(
-      fileService.locateSource(`/storage/taskRuns/${executionId}/legacy.tex`),
+      fileService.locateSource(
+        storagePath('taskRuns', executionId, 'legacy.tex'),
+      ),
     ).toMatchObject({
       kind: 'runStorage',
       executionId,


### PR DESCRIPTION
## Summary

Fix the confirmed Windows PDF artifact-path defect from #9409 and make the two directly implicated path suites portable.

- Normalize run-storage source separators before removing the round prefix.
- Keep published artifact relative paths in canonical POSIX form while using native paths for filesystem access.
- Add a platform-independent regression test for the duplicated-round defect.
- Derive storage and workspace test expectations from node:path instead of host-specific literals.
- Update the Windows-CI TODO with the measured scope from this PR.

## Design

The production repair stays at the compiled-artifact boundary, where a source-relative path is converted into a published PDF path. This keeps one normalization rule and does not alter general file-location construction or filesystem semantics. Absolute paths continue to use the host path implementation; only the stored relative identity is canonicalized.

The two test suites raised during review now construct storage keys, absolute paths, and suffixes through the same host-native path operations used by production.

## Windows CI experiment

This PR temporarily restored both Windows kernel shards to test the premise of #9409. The exact run found 70 failed tests and one failed suite across CLI, desktop, storage, tools, and path handling, substantially more than the ten failures originally recorded. The gating matrix is therefore not included in this PR; #9409 remains open with the run as its new baseline.

## Validation

- npm run format
- npm run compile:fast
- npm run typecheck
- npm run lint
- Four suites originally named in #9409: 70 tests passed locally
- Portable path suites after review: 33 tests passed locally
- Test-kernel typecheck passed after review changes
- Full suite with CI concurrency: 802 files passed, 1 skipped; 8,130 tests passed, 4 skipped
- Windows evidence run: https://github.com/LionSR/TeXRA/actions/runs/30686155180

Addresses the confirmed artifact-path defect in #9409; the broader Windows CI campaign remains open.