### PR TITLE
refactor(runtime): give demonstrated-race lifecycle facts a single owner

### DIFF
--- a/packages/cli/src/chat/tui/state/approvalQueue.ts
+++ b/packages/cli/src/chat/tui/state/approvalQueue.ts
@@ -5,6 +5,13 @@
 // the next entry. `clearApprovals` resolves every caller promise directly, so
 // a session interrupt cannot leave a hidden scheduler task or queue slot
 // blocked.
+//
+// The queue is also the only owner of "this request is still live".
+// `reserveApproval` takes a slot before the request can be shown (a retry has
+// to read the keychain first) and keeps it after the decision while its owner
+// commits, so one clear or cancel settles the pre-modal lookup, the modal, and
+// the committing work through the same structure — there is no second registry
+// to sweep and no staleness re-check at the call sites.
 
 import { signal, type Signal } from '@lit-labs/signals';
 
@@ -74,7 +81,16 @@ export interface ApprovalQueueStatus {
 }
 
 export interface EnqueueApprovalOptions {
-  readonly onPresent?: () => void;
+  /** Called with the payload as presented, once, when the entry becomes the
+   *  foreground modal. */
+  readonly onPresent?: (payload: ApprovalPayload) => void;
+}
+
+interface ReserveApprovalOptions extends EnqueueApprovalOptions {
+  /** The host attachment this reservation belongs to. Hosts overlap while a
+   *  previous run's detached children finish, so a detaching host must settle
+   *  its own reservations without touching the live host's. */
+  readonly owner?: object;
 }
 
 /** Derived from the wire contract, so the queue's payload kinds and every
@@ -109,12 +125,28 @@ export const pendingApprovalSummaries = PENDING_SUMMARIES as Signal.State<
   readonly PendingApprovalSummary[]
 >;
 
-const clearListeners = new Set<() => void>();
+/**
+ * `preparing` holds a slot for a request that cannot be shown yet: invisible
+ * to the modal, the depth, and the summaries, but settleable and cancellable.
+ * `pending` is a live request waiting for its turn at the modal. `committing`
+ * is a decided reservation whose owner is still acting on the answer, so a
+ * later cancel can still reach that work.
+ */
+type ApprovalQueuePhase = 'preparing' | 'pending' | 'committing';
 
 interface ApprovalQueueItem {
-  readonly payload: ApprovalPayload;
+  /** Mutable so a reservation can publish the finished request when it
+   *  presents; every other entry keeps the payload it was queued with. */
+  payload: ApprovalPayload;
   readonly resolve: (decision: ApprovalDecision) => void;
-  readonly onPresent?: () => void;
+  readonly onPresent?: (payload: ApprovalPayload) => void;
+  /** Reservations only. Aborted when the entry is cleared or replaced — never
+   *  by its own decision — so preparation and commit work stops at its next
+   *  await. */
+  readonly preparation?: AbortController;
+  /** Reservations only. The host attachment that took the slot. */
+  readonly owner?: object;
+  phase: ApprovalQueuePhase;
   /** Set once the item has been foregrounded, so re-presentations after a
    *  queue reorder cannot re-fire focus/notification side effects. */
   presented?: boolean;
@@ -122,38 +154,30 @@ interface ApprovalQueueItem {
 
 const pendingItems: ApprovalQueueItem[] = [];
 
-/** Split `items` into [matching, non-matching], each order-preserving. */
-function partitionItems(
-  items: readonly ApprovalQueueItem[],
-  predicate: (item: ApprovalQueueItem) => boolean,
-): [ApprovalQueueItem[], ApprovalQueueItem[]] {
-  const matching: ApprovalQueueItem[] = [];
-  const rest: ApprovalQueueItem[] = [];
-  for (const item of items) {
-    (predicate(item) ? matching : rest).push(item);
-  }
-  return [matching, rest];
-}
-
 const INTERRUPT: ApprovalDecision = {
   accepted: false,
   userMessage: 'Session interrupted.',
 };
 
+/** The entry the modal shows: the first one waiting for a user decision. */
+function foregroundItem(): ApprovalQueueItem | undefined {
+  return pendingItems.find((item) => item.phase === 'pending');
+}
+
 function presentForeground(): void {
-  const item = pendingItems[0];
+  const item = foregroundItem();
   if (!item || CURRENT.get()) return;
 
   if (!item.presented) {
     item.presented = true;
     try {
-      item.onPresent?.();
+      item.onPresent?.(item.payload);
     } catch {
       // Presentation hooks update surrounding TUI state only; approval
       // resolution must remain available even if focus activation fails.
     }
   }
-  if (pendingItems[0] !== item) return;
+  if (foregroundItem() !== item) return;
 
   CURRENT.set({
     payload: item.payload,
@@ -164,32 +188,61 @@ function presentForeground(): void {
 }
 
 /**
- * Atomically remove and settle every matching item. The queue is partitioned
- * before any promise resolves or survivor is presented, so a bulk cancellation
- * cannot briefly foreground another item that the same operation removes.
+ * Apply one queue mutation and re-project the foreground from the result.
+ * `settle` runs at the single point where the queue is already consistent and
+ * the next modal has not been presented yet, so a bulk cancellation cannot
+ * briefly foreground an item that the same operation removes.
+ */
+function updateQueue(mutate: () => void, settle?: () => void): void {
+  const previousForeground = foregroundItem();
+  mutate();
+  const foregroundChanged = previousForeground !== foregroundItem();
+  if (foregroundChanged) CURRENT.set(undefined);
+  syncApprovalStatus();
+  settle?.();
+  if (foregroundChanged) presentForeground();
+}
+
+/**
+ * Settle every matching entry with `decision`. A cancelled settlement drops
+ * each entry and aborts any reservation among them; an answered one keeps a
+ * reservation's slot (as `committing`) until its owner releases it, so a
+ * cancel arriving after the decision still reaches the work that decision
+ * started.
  */
 function settleItems(
   predicate: (item: ApprovalQueueItem) => boolean,
   decision: ApprovalDecision,
+  options: { readonly cancelled?: boolean } = {},
 ): number {
-  const previousForeground = pendingItems[0];
-  const [removed, retained] = partitionItems(pendingItems, predicate);
-  if (removed.length === 0) return 0;
+  const matched = pendingItems.filter(predicate);
+  if (matched.length === 0) return 0;
+  const dropped = new Set(
+    options.cancelled === true
+      ? matched
+      : matched.filter((item) => !item.preparation),
+  );
 
-  pendingItems.splice(0, pendingItems.length, ...retained);
-  const foregroundChanged = previousForeground !== pendingItems[0];
-  if (foregroundChanged) CURRENT.set(undefined);
-  syncApprovalStatus();
-  for (const item of removed) item.resolve(decision);
-  if (foregroundChanged) presentForeground();
-  return removed.length;
-}
-
-export function onApprovalsCleared(listener: () => void): () => void {
-  clearListeners.add(listener);
-  return () => {
-    clearListeners.delete(listener);
-  };
+  updateQueue(
+    () => {
+      if (dropped.size > 0) {
+        const retained = pendingItems.filter((item) => !dropped.has(item));
+        pendingItems.splice(0, pendingItems.length, ...retained);
+      }
+      for (const item of matched) {
+        if (!dropped.has(item)) item.phase = 'committing';
+      }
+    },
+    () => {
+      for (const item of matched) {
+        if (options.cancelled === true) {
+          item.preparation?.abort(new Error('Approval request was cancelled.'));
+        }
+        item.resolve(decision);
+      }
+    },
+  );
+  return matched.length;
 }
 
 function statusKindForPayload(
@@ -224,10 +277,6 @@ function approvalQueueStatusKind(
   return sawQuestion ? 'question' : 'approval';
 }
 
-function* pendingApprovalPayloads(): Iterable<ApprovalPayload> {
-  for (const item of pendingItems) yield item.payload;
-}
-
 export function approvalPayloadStreamId(
   payload: ApprovalPayload,
 ): StreamTabId | undefined {
@@ -246,16 +295,18 @@ export function approvalPayloadStreamId(
 }
 
 function syncApprovalStatus(): void {
-  const depth = pendingItems.length;
+  // Only `pending` entries are requests the user can act on: a reservation is
+  // not a prompt before it presents, and no longer one once it is decided.
+  const waiting = pendingItems.filter((item) => item.phase === 'pending');
   STATUS.set({
-    depth,
+    depth: waiting.length,
     kind:
-      depth === 0
+      waiting.length === 0
         ? 'approval'
-        : approvalQueueStatusKind(pendingApprovalPayloads()),
+        : approvalQueueStatusKind(waiting.map((item) => item.payload)),
   });
   PENDING_SUMMARIES.set(
-    pendingItems.map((item) => ({
+    waiting.map((item) => ({
       streamKey:
         approvalPayloadStreamId(item.payload) ?? ROOT_APPROVAL_STREAM_KEY,
       kind: item.payload.kind,
@@ -284,21 +335,17 @@ export function promoteApprovalsForStream(
       (options.includeSessionWide === true && itemStreamId === undefined)
     );
   };
-  const [promoted, rest] = partitionItems(pendingItems, matches);
+  const promoted = pendingItems.filter(matches);
   if (promoted.length === 0) return;
-  const next = [...promoted, ...rest];
+  const next = [...promoted, ...pendingItems.filter((item) => !matches(item))];
   // Already a contiguous prefix (a head-only check would miss matching items
   // still parked behind other streams) — nothing to reorder.
   if (next.every((item, index) => item === pendingItems[index])) return;
-  const headChanged = pendingItems[0] !== next[0];
-  pendingItems.splice(0, pendingItems.length, ...next);
-  // Only re-project when the head actually moved; the current projection's
-  // decide closure settles by item identity, so it stays valid either way.
-  if (headChanged) {
-    CURRENT.set(undefined);
-    presentForeground();
-  }
-  syncApprovalStatus();
+  // The current projection's decide closure settles by item identity, so it
+  // stays valid when the foreground entry keeps its place.
+  updateQueue(() => {
+    pendingItems.splice(0, pendingItems.length, ...next);
+  });
 }
 
 export function enqueueApproval(
@@ -306,31 +353,104 @@ export function enqueueApproval(
   options: EnqueueApprovalOptions = {},
 ): Promise<ApprovalDecision> {
   return new Promise<ApprovalDecision>((resolve) => {
-    const wasEmpty = pendingItems.length === 0;
-    pendingItems.push({ payload, resolve, onPresent: options.onPresent });
+    pendingItems.push({
+      payload,
+      resolve,
+      onPresent: options.onPresent,
+      phase: 'pending',
+    });
     syncApprovalStatus();
-    if (wasEmpty) presentForeground();
+    presentForeground();
   });
 }
 
 /**
- * Hard-cancel every pending resolver and clear the foreground projection.
+ * A queue entry held from before its request can be shown until its owner has
+ * finished acting on the decision. Every operation is a no-op once the queue
+ * has settled the entry from the other direction, which is what makes a
+ * staleness check at the call site unnecessary.
+ */
+interface ApprovalReservation {
+  /** Resolves once the queue answers this entry: its own modal decision, an
+   *  auto-decision passed to {@link settle}, a replacement, or a clear. */
+  readonly decided: Promise<ApprovalDecision>;
+  /** Aborts when the entry is cleared or replaced, never on its own decision,
+   *  so work running for the entry stops at its next await. */
+  readonly signal: AbortSignal;
+  /** Publish the finished payload and join the visible queue. */
+  readonly present: (payload: ApprovalPayload) => void;
+  /** Answer the entry without showing a modal. */
+  readonly settle: (decision: ApprovalDecision) => void;
+  /** Hand the slot back once the decision has been acted on. */
+  readonly release: () => void;
+}
+
+/**
+ * Take a queue slot for a request that is not ready to show yet.
+ */
+export function reserveApproval(
+  payload: ApprovalPayload,
+  options: ReserveApprovalOptions = {},
+): ApprovalReservation {
+  const preparation = new AbortController();
+  let decide!: (decision: ApprovalDecision) => void;
+  const decided = new Promise<ApprovalDecision>((resolve) => {
+    decide = resolve;
+  });
+  const item: ApprovalQueueItem = {
+    payload,
+    resolve: decide,
+    onPresent: options.onPresent,
+    preparation,
+    owner: options.owner,
+    phase: 'preparing',
+  };
+  pendingItems.push(item);
+
+  return {
+    decided,
+    signal: preparation.signal,
+    present: (presented) => {
+      if (item.phase !== 'preparing' || !pendingItems.includes(item)) return;
+      updateQueue(() => {
+        item.payload = presented;
+        item.phase = 'pending';
+        // Enter the visible queue at its tail: the reservation held liveness,
+        // not a place in line, so a request that only became showable now
+        // cannot displace a modal the user is already answering.
+        pendingItems.splice(pendingItems.indexOf(item), 1);
+        pendingItems.push(item);
+      });
+    },
+    settle: (decision) => {
+      settleItems((candidate) => candidate === item, decision);
+    },
+    release: () => {
+      if (!pendingItems.includes(item)) return;
+      updateQueue(() => {
+        pendingItems.splice(pendingItems.indexOf(item), 1);
+      });
+    },
+  };
+}
+
+/**
+ * Hard-cancel every entry and clear the foreground projection.
  */
 export function clearApprovals(): void {
-  CURRENT.set(undefined);
-  for (const listener of clearListeners) {
-    try {
-      listener();
-    } catch {
-      // Clear hooks invalidate surrounding async state only; approval
-      // interruption must continue even if a hook fails.
-    }
-  }
-  const items = pendingItems.splice(0);
-  syncApprovalStatus();
-  for (const item of items) {
-    item.resolve(INTERRUPT);
-  }
+  settleItems(() => true, INTERRUPT, { cancelled: true });
+}
+
+/**
+ * Settle the reservations `owner` took, leaving every other entry alone. A host
+ * detaches when the last execution it owns finishes, which can be after a newer
+ * host has taken over the session, so this must not reach the newer host's
+ * requests.
+ */
+export function clearApprovalsForOwner(owner: object): number {
+  return settleItems((item) => item.owner === owner, INTERRUPT, {
+    cancelled: true,
+  });
 }
 
 export function clearRetryApprovalsForStream(streamId: string): void {
@@ -359,5 +479,7 @@ export function clearApprovalsWhere(
   predicate: (payload: ApprovalPayload) => boolean,
   decision: ApprovalDecision = INTERRUPT,
 ): number {
-  return settleItems((item) => predicate(item.payload), decision);
+  return settleItems((item) => predicate(item.payload), decision, {
+    cancelled: true,
+  });
 }

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -44,6 +44,7 @@ import { denyExternalInquiryIfNoHumanInput } from '@cli/runtime/approval/humanIn
 import type { CliContext } from '@cli/runtime/cliContext';
 import type { CliRuntimeHost } from '@cli/runtime/cliPresentationHost';
 import { missingApiKeyRetryMessage } from '@cli/tui/ui/retryCopy';
+import { warn as logWarning } from '@logger/logUtils';
 import {
   apiKeyExistsUncached,
   hasUsableApiKey,
@@ -58,7 +59,6 @@ import {
   type ExternalInquiryPermission,
   type PlanApprovalPermission,
 } from '@shared/schemas';
-import { APPROVAL_REPLACED_CAUSE } from '@shared/copy/interactionCancellation';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import {
   setDelegatedWorkApprovalBypasses,
@@ -78,10 +78,11 @@ import {
   type ApprovalBypassKind,
   approveQueuedDelegatedWorkForStream,
   approvalPayloadStreamId,
+  clearApprovalsForOwner,
   clearApprovalsWhere,
   clearRetryApprovalsForStream,
   enqueueApproval,
-  onApprovalsCleared,
+  reserveApproval,
   type ApprovalDecision,
   type ApprovalPayload,
   type TuiRetryRequest,
@@ -128,14 +129,12 @@ export function createTuiHostInteractions(
   host: CliRuntimeHost,
   context: CliContext,
 ): HostInteractions {
-  const retryRoutes = new Map<string, ActiveRetryRoute>();
   // The two persisted access fields commit as one choice within this TUI
   // lifetime. Keeping the queue session-owned prevents stale work leaking
   // across disposed hosts or tests.
   const retryCredentialCommitQueue = new PQueue({ concurrency: 1 });
-  const disposeApprovalClearListener = onApprovalsCleared(() => {
-    invalidateRetryRoutes(retryRoutes, { cancel: true });
-  });
+  // Identity of this attachment in the shared approval queue.
+  const interactionOwner = {};
 
   return {
     emit: (event, payload) => host.emit(event, payload),
@@ -170,8 +169,7 @@ export function createTuiHostInteractions(
       return requestRetryInteraction(
         request,
         context,
-        retryRoutes,
-        retryCredentialCommitQueue,
+        { owner: interactionOwner, commitQueue: retryCredentialCommitQueue },
         options,
       );
     },
@@ -187,18 +185,6 @@ export function createTuiHostInteractions(
       host.emitApprovalBypassState(update);
     },
     cancel(selector: HostInteractionCancelSelector = {}) {
-      // Retry routes live outside the modal queue (the pre-queue auto-switch
-      // lookup), so a retry-kind or unfiltered cancel must settle them too —
-      // this is what the coordinator layer's clearAll did before the fold.
-      if (selector.kind === undefined || selector.kind === 'retry') {
-        if (typeof selector.streamId === 'string') {
-          cancelRetryRoute(retryRoutes, selector.streamId);
-        } else if (selector.streamId === undefined) {
-          invalidateRetryRoutes(retryRoutes, { cancel: true });
-        }
-        // streamId === null: retry requests always carry a concrete stream id,
-        // so the unscoped sweep has no retry routes to settle.
-      }
       clearApprovalsWhere((payload) =>
         matchesCancelSelector(
           { kind: payload.kind, streamId: approvalPayloadStreamId(payload) },
@@ -207,21 +193,13 @@ export function createTuiHostInteractions(
       );
     },
     dispose() {
-      invalidateRetryRoutes(retryRoutes, { cancel: true });
-      disposeApprovalClearListener();
+      // Retries are the only requests that carry work bound to this host (the
+      // key lookup and the credential commit queue above), so detaching must
+      // settle them. Other queued approvals stay decidable at the modal, and a
+      // newer host's retries belong to that host's reservations, not these.
+      clearApprovalsForOwner(interactionOwner);
     },
   };
-}
-
-/**
- * Retry auto-switches need an async key lookup before the modal appears.
- * Track the latest route per stream so a stale lookup cannot switch API mode
- * or trigger an older retry after a newer retry request replaced it.
- */
-interface ActiveRetryRoute {
-  readonly routeId: symbol;
-  readonly preparationController: AbortController;
-  readonly settle?: (result: RetryResult) => void;
 }
 
 function runRetryTask<T>(
@@ -264,54 +242,8 @@ function prepareRetryClient(
   return runRetryTask(() => prepare(selection, signal), signal);
 }
 
-function isActiveRetryRoute(
-  retryRoutes: Map<string, ActiveRetryRoute>,
-  streamId: string,
-  routeId: symbol,
-): boolean {
-  return retryRoutes.get(streamId)?.routeId === routeId;
-}
-
-function cancelRetryRoute(
-  retryRoutes: Map<string, ActiveRetryRoute>,
-  streamId: string,
-): void {
-  settleRetryRoute(retryRoutes, streamId, { action: 'cancel' });
-}
-
-function settleRetryRoute(
-  retryRoutes: Map<string, ActiveRetryRoute>,
-  streamId: string,
-  result: RetryResult,
-): void {
-  const route = retryRoutes.get(streamId);
-  if (!route) return;
-  retryRoutes.delete(streamId);
-  route.preparationController.abort(new Error('Retry request was replaced.'));
-  route.settle?.(result);
-}
-
-function invalidateRetryRoutes(
-  retryRoutes: Map<string, ActiveRetryRoute>,
-  options: { cancel: boolean },
-): void {
-  const streamIds = [...retryRoutes.keys()];
-  for (const streamId of streamIds) {
-    if (options.cancel) {
-      cancelRetryRoute(retryRoutes, streamId);
-    } else {
-      retryRoutes.delete(streamId);
-    }
-  }
-}
-
-interface RouteWithPolicyOptions<P> {
-  beforeQueue?: (payload: P) => Promise<ApprovalDecision | undefined>;
-  isCurrent?: () => boolean;
-}
-
-// Retry carries its own policy lookup (`showRetryRequest`) and route
-// bookkeeping, so it enters through `decideAfterImmediatePolicy` directly.
+// Retry carries its own policy lookup (`showRetryRequest`) and owns a queue
+// reservation, so it does not enter through this path.
 async function decideWithPolicy<
   K extends 'bash' | 'planApproval' | 'proposal',
   P,
@@ -319,40 +251,12 @@ async function decideWithPolicy<
   const policy = immediateDecision(context);
   if (policy) return policy;
 
-  return decideAfterImmediatePolicy(context, kind, payload);
-}
-
-async function decideAfterImmediatePolicy<
-  K extends 'bash' | 'planApproval' | 'proposal' | 'retry',
-  P,
->(
-  context: CliContext,
-  kind: K,
-  payload: P,
-  options: RouteWithPolicyOptions<P> = {},
-): Promise<ApprovalDecision> {
-  let autoDecision: ApprovalDecision | undefined;
-  if (options.beforeQueue) {
-    try {
-      autoDecision = await options.beforeQueue(payload);
-    } catch {
-      autoDecision = undefined;
-    }
-    if (options.isCurrent && !options.isCurrent()) {
-      return { accepted: false, userMessage: APPROVAL_REPLACED_CAUSE };
-    }
-    if (autoDecision) return autoDecision;
-  }
-
   try {
     const queuePayload = { kind, payload } as Extract<
       ApprovalPayload,
       { kind: K }
     >;
     const decision = await enqueueTuiApproval(queuePayload);
-    if (options.isCurrent && !options.isCurrent()) {
-      return { accepted: false, userMessage: APPROVAL_REPLACED_CAUSE };
-    }
     markIfRejected(context, decision);
     return decision;
   } catch {
@@ -406,110 +310,133 @@ async function requestProposalInteraction(
   return toApprovalSettlement(decision);
 }
 
+/**
+ * The queue entry is this retry's liveness: reserving it replaces whatever
+ * retry the stream had (its pre-modal lookup, its modal, or the credential
+ * switch it had already started), and holding it until `release` means a later
+ * cancel reaches the commit as well. Nothing here re-checks whether the
+ * request is still current — a settled entry ignores `present` and `settle`,
+ * and its abort signal stops the work in flight.
+ */
 async function requestRetryInteraction(
   request: HostRetryRequest,
   context: CliContext,
-  retryRoutes: Map<string, ActiveRetryRoute>,
-  retryCredentialCommitQueue: PQueue,
+  attachment: { readonly owner: object; readonly commitQueue: PQueue },
   options: HostRetryInteractionOptions | undefined,
 ): Promise<RetryResult> {
-  cancelRetryRoute(retryRoutes, request.streamId);
-  const routeId = Symbol(request.streamId);
-  const preparationController = new AbortController();
   clearRetryApprovalsForStream(request.streamId);
+  const reservation = reserveApproval(
+    { kind: 'retry', payload: request },
+    { onPresent: announceApproval, owner: attachment.owner },
+  );
+  // Written before any path that can produce a credential-changing decision:
+  // only the modal and the auto-switch produce one, and both run after this.
+  let promptRequest: TuiRetryRequest = request;
 
-  return await new Promise<RetryResult>((resolve) => {
-    retryRoutes.set(request.streamId, {
-      routeId,
-      preparationController,
-      settle: resolve,
-    });
-    const isCurrent = () =>
-      isActiveRetryRoute(retryRoutes, request.streamId, routeId);
-    const finish = () => {
-      if (isCurrent()) retryRoutes.delete(request.streamId);
-    };
-
+  const immediate = immediateDecisionForApproval(
+    'showRetryRequest',
+    request,
+    context,
+  );
+  if (immediate) {
+    reservation.settle(immediate);
+  } else {
     void (async () => {
-      const immediate: ApprovalDecision | undefined =
-        immediateDecisionForApproval('showRetryRequest', request, context);
-      let promptRequest: TuiRetryRequest = request;
-      if (!immediate && isCliApiSwitchableRetry(request)) {
-        const requestedProvider = request.errorDetails?.provider;
-        const provider =
-          requestedProvider && isApiProvider(requestedProvider)
-            ? requestedProvider
-            : undefined;
-        let personalApiKeyAvailable = false;
-        let missingPersonalApiKeyMessage = missingApiKeyRetryMessage(provider);
-        if (provider) {
-          try {
-            personalApiKeyAvailable = await hasUsableApiKey(
-              platform().secrets,
-              provider,
-            );
-          } catch {
-            // A keychain failure must not permit an automatic credential switch.
-            missingPersonalApiKeyMessage = missingApiKeyRetryMessage(
-              provider,
-              'unavailable',
-            );
+      let autoSwitch: ApprovalDecision | undefined;
+      try {
+        if (isCliApiSwitchableRetry(request)) {
+          const requestedProvider = request.errorDetails?.provider;
+          const provider =
+            requestedProvider && isApiProvider(requestedProvider)
+              ? requestedProvider
+              : undefined;
+          let personalApiKeyAvailable = false;
+          let missingPersonalApiKeyMessage =
+            missingApiKeyRetryMessage(provider);
+          if (provider) {
+            try {
+              personalApiKeyAvailable = await hasUsableApiKey(
+                platform().secrets,
+                provider,
+              );
+            } catch {
+              // A keychain failure must not permit an automatic credential
+              // switch.
+              missingPersonalApiKeyMessage = missingApiKeyRetryMessage(
+                provider,
+                'unavailable',
+              );
+            }
           }
+          promptRequest = {
+            ...request,
+            personalApiKeyAvailable,
+            missingPersonalApiKeyMessage,
+          };
         }
-        promptRequest = {
-          ...request,
-          personalApiKeyAvailable,
-          missingPersonalApiKeyMessage,
-        };
+        autoSwitch = await maybeAutoSwitchRetry(promptRequest);
+      } catch (error) {
+        // Preparation only decides whether the modal can be skipped, so a
+        // failed lookup falls through to the modal instead of denying a retry
+        // the user never saw.
+        logWarning(
+          'cli.tui',
+          `The retry request could not be prepared: ${toErrorMessage(error)}`,
+        );
       }
-      if (!isCurrent()) return;
-      const decision =
-        immediate ??
-        (await decideAfterImmediatePolicy(context, 'retry', promptRequest, {
-          beforeQueue: maybeAutoSwitchRetry,
-          isCurrent,
-        }));
-      if (!isCurrent()) return;
-      if (
-        decision.accepted &&
-        (decision.apiMode || decision.disableChatGptSubscription)
-      ) {
-        clearRetryApprovalsForStream(request.streamId);
-      }
-      if (!decision.accepted) {
-        resolve({ action: 'cancel' });
-        finish();
+      if (autoSwitch) {
+        reservation.settle(autoSwitch);
         return;
       }
       try {
-        const changesCredentialRoute =
-          decision.apiMode !== undefined ||
-          decision.disableChatGptSubscription === true;
-        if (changesCredentialRoute) {
-          await switchRetryToPersonalCredentials(decision, promptRequest, {
-            isCurrent,
-            prepareRetry: options?.prepareRetry,
-            preparationSignal: preparationController.signal,
-            commitQueue: retryCredentialCommitQueue,
-          });
-        } else if (options?.prepareRetry) {
-          await prepareRetryClient(
-            options.prepareRetry,
-            'configured',
-            preparationController.signal,
-          );
-        }
-        if (!isCurrent()) return;
-        resolve({ action: 'retry', feedback: decision.userMessage });
+        reservation.present({ kind: 'retry', payload: promptRequest });
       } catch (error) {
-        if (isCurrent()) {
-          resolve({ action: 'deny', reason: toErrorMessage(error) });
-        }
-      } finally {
-        finish();
+        logWarning(
+          'cli.tui',
+          `The retry request could not be shown: ${toErrorMessage(error)}`,
+        );
+        reservation.settle({
+          accepted: false,
+          userMessage: toErrorMessage(error),
+        });
       }
     })();
-  });
+  }
+
+  const decision = await reservation.decided;
+  try {
+    if (!decision.accepted) {
+      // A cleared or replaced entry was never denied by a user, so it must not
+      // mark the run as approval-denied.
+      if (!reservation.signal.aborted) markApprovalDenied(context);
+      return { action: 'cancel' };
+    }
+    if (
+      decision.apiMode !== undefined ||
+      decision.disableChatGptSubscription === true
+    ) {
+      await switchRetryToPersonalCredentials(decision, promptRequest, {
+        prepareRetry: options?.prepareRetry,
+        preparationSignal: reservation.signal,
+        commitQueue: attachment.commitQueue,
+      });
+    } else if (options?.prepareRetry) {
+      await prepareRetryClient(
+        options.prepareRetry,
+        'configured',
+        reservation.signal,
+      );
+    }
+    // A cancel landing while the last preparation step was already resolving
+    // has no await left to reject, so the entry's own state decides.
+    if (reservation.signal.aborted) return { action: 'cancel' };
+    return { action: 'retry', feedback: decision.userMessage };
+  } catch (error) {
+    if (reservation.signal.aborted) return { action: 'cancel' };
+    return { action: 'deny', reason: toErrorMessage(error) };
+  } finally {
+    reservation.release();
+  }
 }
 
 async function requestUserQuestionInteraction(
@@ -532,21 +459,22 @@ async function requestUserQuestionInteraction(
 export function enqueueTuiApproval(
   payload: ApprovalPayload,
 ): Promise<ApprovalDecision> {
-  return enqueueApproval(payload, {
-    onPresent: () => {
-      const streamId = approvalPayloadStreamId(payload);
-      if (streamId) {
-        defaultSession().events.emit({
-          scope: 'session',
-          event: {
-            type: 'setActiveStream',
-            payload: { streamId },
-          },
-        });
-      }
-      notify({ kind: 'approvalNeeded' });
-    },
-  });
+  return enqueueApproval(payload, { onPresent: announceApproval });
+}
+
+/** Focus the asking stream and ring the terminal when a modal appears. */
+function announceApproval(payload: ApprovalPayload): void {
+  const streamId = approvalPayloadStreamId(payload);
+  if (streamId) {
+    defaultSession().events.emit({
+      scope: 'session',
+      event: {
+        type: 'setActiveStream',
+        payload: { streamId },
+      },
+    });
+  }
+  notify({ kind: 'approvalNeeded' });
 }
 
 function markIfRejected(context: CliContext, decision: ApprovalDecision): void {
@@ -579,14 +507,11 @@ async function switchRetryToPersonalCredentials(
   decision: ApprovalDecision,
   request: TuiRetryRequest,
   options: {
-    isCurrent: () => boolean;
     prepareRetry?: HostRetryInteractionOptions['prepareRetry'];
     preparationSignal: AbortSignal;
     commitQueue: PQueue;
   },
 ): Promise<void> {
-  const isCurrent = options.isCurrent;
-  if (!isCurrent()) return;
   const signal = options.preparationSignal;
 
   const requestedProvider = request.errorDetails?.provider;
@@ -595,146 +520,151 @@ async function switchRetryToPersonalCredentials(
       'The failed API provider could not be identified, so TeXRA did not change access settings.',
     );
   }
-  const missingKeyMessage =
-    request.missingPersonalApiKeyMessage ??
-    missingApiKeyRetryMessage(requestedProvider);
-  const validateCurrentKey = async (): Promise<void> => {
-    const keyExists = await runRetryTask(
-      () => apiKeyExistsUncached(platform().secrets, requestedProvider),
-      signal,
+  const keyExists = await runRetryTask(
+    () => apiKeyExistsUncached(platform().secrets, requestedProvider),
+    signal,
+  );
+  if (!keyExists) {
+    throw new Error(
+      request.missingPersonalApiKeyMessage ??
+        missingApiKeyRetryMessage(requestedProvider),
     );
-    if (!isCurrent()) throw new Error('Retry request was replaced.');
-    if (!keyExists) throw new Error(missingKeyMessage);
-    // The presentation check is deliberately cached. Drop that cache only
-    // after the uncached commit check so getClient() must read the current key.
-    invalidateApiKeyCache();
-  };
-
-  await validateCurrentKey();
+  }
+  // The presentation check is deliberately cached. Drop that cache only after
+  // the uncached commit check so getClient() must read the current key.
+  invalidateApiKeyCache();
 
   if (!options.prepareRetry) {
     throw new Error('The model client cannot be refreshed for this retry.');
   }
   await prepareRetryClient(options.prepareRetry, 'personal', signal);
-  if (!isCurrent()) throw new Error('Retry request was replaced.');
 
-  await options.commitQueue.add(async () => {
-    if (!isCurrent()) throw new Error('Retry request was replaced.');
-    const previousApiMode = getCliApiMode();
-    const previousOpenRouter = cliOpenRouterEnabled();
-    const previousSubscriptionPreference = isPreferCodexSubscription();
-    let apiModeWriteStarted = false;
-    let subscriptionWriteStarted = false;
-    try {
-      if (decision.apiMode) {
-        const apiMode = decision.apiMode;
-        apiModeWriteStarted = true;
-        await runRetryTask(() => setCliApiMode(apiMode), signal);
-        if (!isCurrent()) throw new Error('Retry request was replaced.');
-      }
-      if (decision.disableChatGptSubscription) {
-        subscriptionWriteStarted = true;
-        const update = await runRetryTask(
-          () => setCliCodexSubscription(false),
-          signal,
-        );
-        if (update.effective) {
-          throw new Error(
-            'ChatGPT subscription remains enabled by a more specific setting.',
-          );
-        }
-        if (!isCurrent()) throw new Error('Retry request was replaced.');
-      }
-      if (decision.apiMode) patchSessionMeta({ apiMode: decision.apiMode });
-      return;
-    } catch (error) {
-      const rollbackFailures: Error[] = [];
-      if (subscriptionWriteStarted && !isPreferCodexSubscription()) {
+  // Wrapped so a cancel settles this retry immediately instead of waiting for
+  // an unrelated stream's commit or rollback to drain first. The task still
+  // runs, and stops at the check below.
+  await runRetryTask(
+    () =>
+      options.commitQueue.add(async () => {
+        // The task can wait behind another stream's rollback, so the queue may
+        // have cancelled this retry since it was scheduled.
+        signal.throwIfAborted();
+        const previousApiMode = getCliApiMode();
+        const previousOpenRouter = cliOpenRouterEnabled();
+        const previousSubscriptionPreference = isPreferCodexSubscription();
+        let apiModeWriteStarted = false;
+        let subscriptionWriteStarted = false;
         try {
-          const update = await setCliCodexSubscription(
-            previousSubscriptionPreference,
-          );
-          if (update.effective !== previousSubscriptionPreference) {
-            throw new Error(
-              `ChatGPT subscription preference remained ${String(update.effective)}.`,
+          if (decision.apiMode) {
+            const apiMode = decision.apiMode;
+            apiModeWriteStarted = true;
+            await runRetryTask(() => setCliApiMode(apiMode), signal);
+            signal.throwIfAborted();
+          }
+          if (decision.disableChatGptSubscription) {
+            subscriptionWriteStarted = true;
+            const update = await runRetryTask(
+              () => setCliCodexSubscription(false),
+              signal,
+            );
+            if (update.effective) {
+              throw new Error(
+                'ChatGPT subscription remains enabled by a more specific setting.',
+              );
+            }
+            signal.throwIfAborted();
+          }
+          if (decision.apiMode) patchSessionMeta({ apiMode: decision.apiMode });
+          return;
+        } catch (error) {
+          const rollbackFailures: Error[] = [];
+          if (subscriptionWriteStarted && !isPreferCodexSubscription()) {
+            try {
+              const update = await setCliCodexSubscription(
+                previousSubscriptionPreference,
+              );
+              if (update.effective !== previousSubscriptionPreference) {
+                throw new Error(
+                  `ChatGPT subscription preference remained ${String(update.effective)}.`,
+                );
+              }
+            } catch (rollbackError) {
+              const persistenceContext =
+                isPreferCodexSubscription() === previousSubscriptionPreference
+                  ? 'The previous ChatGPT subscription preference appears restored in memory, but persistence could not be confirmed'
+                  : 'Could not restore the ChatGPT subscription preference';
+              rollbackFailures.push(
+                new Error(
+                  `${persistenceContext}: ${toErrorMessage(rollbackError)}`,
+                  {
+                    cause: rollbackError,
+                  },
+                ),
+              );
+            }
+          }
+          if (apiModeWriteStarted && getCliApiMode() === decision.apiMode) {
+            try {
+              await setCliApiMode(previousApiMode);
+              if (getCliApiMode() !== previousApiMode) {
+                throw new Error(`API mode remained ${getCliApiMode()}.`);
+              }
+            } catch (rollbackError) {
+              const persistenceContext =
+                getCliApiMode() === previousApiMode
+                  ? 'The previous API mode appears restored in memory, but persistence could not be confirmed'
+                  : 'Could not restore API mode';
+              rollbackFailures.push(
+                new Error(
+                  `${persistenceContext}: ${toErrorMessage(rollbackError)}`,
+                  {
+                    cause: rollbackError,
+                  },
+                ),
+              );
+            }
+          }
+          // After the mode, because restoring included access clears the OpenRouter
+          // toggle: a switch the user never got would otherwise leave their routing
+          // preference silently off.
+          if (
+            apiModeWriteStarted &&
+            previousOpenRouter &&
+            !cliOpenRouterEnabled()
+          ) {
+            try {
+              await platform().globalState.update(
+                GlobalStateKey.USE_OPENROUTER,
+                true,
+              );
+              if (!cliOpenRouterEnabled()) {
+                throw new Error('OpenRouter routing remained disabled.');
+              }
+            } catch (rollbackError) {
+              const persistenceContext = cliOpenRouterEnabled()
+                ? 'The previous OpenRouter routing preference appears restored in memory, but persistence could not be confirmed'
+                : 'Could not restore OpenRouter routing';
+              rollbackFailures.push(
+                new Error(
+                  `${persistenceContext}: ${toErrorMessage(rollbackError)}`,
+                  {
+                    cause: rollbackError,
+                  },
+                ),
+              );
+            }
+          }
+          if (rollbackFailures.length > 0) {
+            throw new AggregateError(
+              [error, ...rollbackFailures],
+              `${toErrorMessage(error)} Previous access settings could not be fully restored: ${rollbackFailures.map(toErrorMessage).join(' ')}`,
+              { cause: error },
             );
           }
-        } catch (rollbackError) {
-          const persistenceContext =
-            isPreferCodexSubscription() === previousSubscriptionPreference
-              ? 'The previous ChatGPT subscription preference appears restored in memory, but persistence could not be confirmed'
-              : 'Could not restore the ChatGPT subscription preference';
-          rollbackFailures.push(
-            new Error(
-              `${persistenceContext}: ${toErrorMessage(rollbackError)}`,
-              {
-                cause: rollbackError,
-              },
-            ),
-          );
+          throw error;
         }
-      }
-      if (apiModeWriteStarted && getCliApiMode() === decision.apiMode) {
-        try {
-          await setCliApiMode(previousApiMode);
-          if (getCliApiMode() !== previousApiMode) {
-            throw new Error(`API mode remained ${getCliApiMode()}.`);
-          }
-        } catch (rollbackError) {
-          const persistenceContext =
-            getCliApiMode() === previousApiMode
-              ? 'The previous API mode appears restored in memory, but persistence could not be confirmed'
-              : 'Could not restore API mode';
-          rollbackFailures.push(
-            new Error(
-              `${persistenceContext}: ${toErrorMessage(rollbackError)}`,
-              {
-                cause: rollbackError,
-              },
-            ),
-          );
-        }
-      }
-      // After the mode, because restoring included access clears the OpenRouter
-      // toggle: a switch the user never got would otherwise leave their routing
-      // preference silently off.
-      if (
-        apiModeWriteStarted &&
-        previousOpenRouter &&
-        !cliOpenRouterEnabled()
-      ) {
-        try {
-          await platform().globalState.update(
-            GlobalStateKey.USE_OPENROUTER,
-            true,
-          );
-          if (!cliOpenRouterEnabled()) {
-            throw new Error('OpenRouter routing remained disabled.');
-          }
-        } catch (rollbackError) {
-          const persistenceContext = cliOpenRouterEnabled()
-            ? 'The previous OpenRouter routing preference appears restored in memory, but persistence could not be confirmed'
-            : 'Could not restore OpenRouter routing';
-          rollbackFailures.push(
-            new Error(
-              `${persistenceContext}: ${toErrorMessage(rollbackError)}`,
-              {
-                cause: rollbackError,
-              },
-            ),
-          );
-        }
-      }
-      if (rollbackFailures.length > 0) {
-        throw new AggregateError(
-          [error, ...rollbackFailures],
-          `${toErrorMessage(error)} Previous access settings could not be fully restored: ${rollbackFailures.map(toErrorMessage).join(' ')}`,
-          { cause: error },
-        );
-      }
-      throw error;
-    }
-  });
+      }),
+    signal,
+  );
 }
 
 function handleExternalInquiry(

--- a/packages/desktop/src/desktopWorkspaceMessages.ts
+++ b/packages/desktop/src/desktopWorkspaceMessages.ts
@@ -17,7 +17,6 @@ export const DESKTOP_WORKSPACE_COMMANDS = {
   WRITE_FILE: 'desktop:workspace:writeFile',
   FILE_WRITTEN: 'desktop:workspace:fileWritten',
   FILE_ERROR: 'desktop:workspace:fileError',
-  EDITOR_DIRTY_STATE: 'desktop:workspace:editorDirtyState',
   // Terminal
   TERMINAL_START: 'desktop:terminal:start',
   TERMINAL_INPUT: 'desktop:terminal:input',
@@ -81,11 +80,6 @@ const DesktopWriteFileMessageSchema = z.object({
   command: z.literal(DESKTOP_WORKSPACE_COMMANDS.WRITE_FILE),
   path: z.string(),
   contents: z.string(),
-});
-
-const DesktopEditorDirtyStateMessageSchema = z.object({
-  command: z.literal(DESKTOP_WORKSPACE_COMMANDS.EDITOR_DIRTY_STATE),
-  dirty: z.boolean(),
 });
 
 export const DesktopFileWrittenMessageSchema = z.object({
@@ -252,7 +246,6 @@ export const DesktopWorkspaceInboundMessageSchema = z.discriminatedUnion(
     DesktopListFilesMessageSchema,
     DesktopReadFileMessageSchema,
     DesktopWriteFileMessageSchema,
-    DesktopEditorDirtyStateMessageSchema,
     DesktopTerminalStartMessageSchema,
     DesktopTerminalInputMessageSchema,
     DesktopTerminalResizeMessageSchema,

--- a/packages/desktop/src/main/desktopWorkspaceIpc.ts
+++ b/packages/desktop/src/main/desktopWorkspaceIpc.ts
@@ -46,7 +46,6 @@ import type { DesktopBrowserViews } from './desktopBrowserViews.js';
 export interface DesktopWorkspaceIpcOptions {
   ptyHost: DesktopPtyHost;
   browserViews: DesktopBrowserViews;
-  onEditorDirtyChange?(dirty: boolean): void;
   /**
    * Translates renderer-reported CSS pixel bounds into window coordinates.
    * A WebContentsView is positioned in device-independent window space, which
@@ -302,9 +301,6 @@ export function createDesktopWorkspaceIpc(
       const data = parsed.data;
 
       switch (data.command) {
-        case DESKTOP_WORKSPACE_COMMANDS.EDITOR_DIRTY_STATE:
-          options.onEditorDirtyChange?.(data.dirty);
-          return true;
         case DESKTOP_WORKSPACE_COMMANDS.LIST_FILES:
           void listFiles(data.directory);
           return true;

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -507,12 +507,13 @@ function createWindow(options: {
     signInForRemoteAgentCatalog,
   );
   const folderPickerDefaultPath = options.workspacePath ?? app.getPath('home');
-  let editorHasUnsavedChanges = false;
-  let allowNextPreventedUnload = false;
   let pendingWorkspaceRelaunch:
     { selectedPath: string; args: string[] } | undefined;
-  const confirmDiscardUnsavedEditorChanges = (force = false): boolean => {
-    if (!force && !editorHasUnsavedChanges) return true;
+  // The renderer owns editor dirtiness. This event is the main process's only
+  // reading of it: Chromium emits it after the renderer's beforeunload handler
+  // observes a dirty Monaco buffer and refuses the unload, so every close path
+  // (quit, workspace switch, window close) asks here and nowhere else.
+  window.webContents.on('will-prevent-unload', (event) => {
     const response = dialog.showMessageBoxSync(window, {
       type: 'warning',
       buttons: ['Keep Editing', 'Discard Changes'],
@@ -522,20 +523,7 @@ function createWindow(options: {
       message: 'This workspace has unsaved editor changes.',
       detail: 'Discard the changes and continue?',
     });
-    if (response !== 1) return false;
-    editorHasUnsavedChanges = false;
-    return true;
-  };
-  window.webContents.on('will-prevent-unload', (event) => {
-    if (allowNextPreventedUnload) {
-      allowNextPreventedUnload = false;
-      event.preventDefault();
-      return;
-    }
-    // The event itself is authoritative: it is emitted only after the
-    // renderer observes a dirty Monaco buffer and refuses the unload. The
-    // mirrored IPC flag may still be in flight.
-    if (confirmDiscardUnsavedEditorChanges(true)) {
+    if (response === 1) {
       event.preventDefault();
       return;
     }
@@ -553,17 +541,16 @@ function createWindow(options: {
     });
     const selectedPath = result.canceled ? undefined : result.filePaths[0];
     if (!selectedPath) return;
-    const hadUnsavedChanges = editorHasUnsavedChanges;
-    if (!confirmDiscardUnsavedEditorChanges()) return;
-    allowNextPreventedUnload = hadUnsavedChanges;
     pendingWorkspaceRelaunch = {
       selectedPath,
       args: withWorkspacePathArg(process.argv.slice(1), selectedPath),
     };
     workspaceRelaunchInProgress = true;
-    // Closing first lets the renderer's authoritative beforeunload check veto
-    // the switch. The replacement is scheduled only from the closed handler,
-    // after unsaved changes can no longer cancel it.
+    // Attempt the close unconditionally: the renderer decides whether there is
+    // anything to discard, and the will-prevent-unload handler above clears the
+    // pending relaunch when the user keeps editing. The replacement is
+    // scheduled only from the closed handler, after unsaved changes can no
+    // longer cancel it.
     window.close();
   };
   attachRendererConsoleLog(window.webContents);
@@ -1108,9 +1095,6 @@ function createWindow(options: {
         };
       },
       getEnvironmentSummary: () => gitHost.getEnvironmentSummary(),
-      onEditorDirtyChange: (dirty) => {
-        editorHasUnsavedChanges = dirty;
-      },
       onAsyncError: reportAsyncError,
     },
   );

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -360,9 +360,6 @@ const editorPane = createEditorPane({
     updateShell(
       setWorkbenchTabDirty(shellState, `workbench:editor:${path}`, dirty),
     );
-    postMessage(DESKTOP_WORKSPACE_COMMANDS.EDITOR_DIRTY_STATE, {
-      dirty: editorPane.hasUnsavedChanges(),
-    });
   },
   onError: (error) => console.error('TeXRA editor pane', error),
 });
@@ -1655,6 +1652,8 @@ if (!bootstrapFailed) {
   document.body.dataset.desktopReady = 'true';
 }
 
+// Sole owner of "the workspace has unsaved editor changes": the main process
+// keeps no copy and learns of it only when this veto raises will-prevent-unload.
 window.addEventListener('beforeunload', (event) => {
   if (!editorPane.hasUnsavedChanges()) return;
   event.preventDefault();

--- a/packages/extension/src/MainViewProvider.ts
+++ b/packages/extension/src/MainViewProvider.ts
@@ -9,9 +9,11 @@ import { consumePendingState } from '@common/state';
 import {
   BaseWebviewProvider,
   BundledViewContentProvider,
+  getActiveSidebarView,
   getCombinedLocalResourceRoots,
   SIDEBAR_VIEWS,
   setActiveSidebarView,
+  type SidebarView,
 } from '@common/webview';
 import { EXTENSION_CATEGORIES, getFilterExtensions } from '@common/files';
 import {
@@ -42,8 +44,6 @@ import { DEBOUNCE_OPTIONS_MS } from '@utils/config/constants';
 import { MainViewMessageHandler } from './webview/MainViewMessageHandler';
 import type { ProgressViewProvider } from './progressView/ProgressViewProvider';
 
-export type SidebarMode = 'main' | 'progress';
-
 export class MainViewProvider
   extends BaseWebviewProvider
   implements vscode.WebviewViewProvider
@@ -56,7 +56,6 @@ export class MainViewProvider
 
   private static commandsRegistered = false;
 
-  private _activeMode: SidebarMode = 'main';
   private _messageDisposable?: vscode.Disposable;
   private _progressViewProvider?: ProgressViewProvider;
 
@@ -150,7 +149,9 @@ export class MainViewProvider
 
   /** Returns the sidebar webview, but only when in main mode. */
   private getMainModeView(): vscode.WebviewView | undefined {
-    return this._activeMode === 'main' ? this.getWebviewView() : undefined;
+    return getActiveSidebarView() === SIDEBAR_VIEWS.MAIN
+      ? this.getWebviewView()
+      : undefined;
   }
 
   /**
@@ -329,11 +330,10 @@ export class MainViewProvider
   protected override cleanupView(): void {
     this._messageDisposable?.dispose();
     this._messageDisposable = undefined;
-    if (this._activeMode === 'progress') {
+    if (getActiveSidebarView() === SIDEBAR_VIEWS.PROGRESS) {
       this._progressViewProvider?.resetSidebarReady();
-      void setActiveSidebarView(SIDEBAR_VIEWS.MAIN);
     }
-    this._activeMode = 'main';
+    setActiveSidebarView(SIDEBAR_VIEWS.MAIN);
     super.cleanupView();
   }
 
@@ -366,10 +366,6 @@ export class MainViewProvider
     this._progressViewProvider = pvp;
   }
 
-  public getActiveMode(): SidebarMode {
-    return this._activeMode;
-  }
-
   public getWebviewView(): vscode.WebviewView | undefined {
     return this._view as vscode.WebviewView | undefined;
   }
@@ -377,27 +373,20 @@ export class MainViewProvider
   /**
    * Switch the single sidebar view between 'main' (launcher) and 'progress' content.
    * Swaps HTML and message listener so both bundles share one VS Code view slot.
+   * Claiming the surface and swapping its content happen in one tick, so a
+   * concurrent switch cannot land between them.
    */
-  public async switchMode(mode: SidebarMode): Promise<void> {
+  public switchMode(mode: SidebarView): void {
     const webviewView = this.getWebviewView();
-    if (!webviewView || mode === this._activeMode) return;
+    if (!webviewView || mode === getActiveSidebarView()) return;
 
     // Guard provider availability before mutating any state.
-    if (mode === 'progress' && !this._progressViewProvider) return;
+    if (mode === SIDEBAR_VIEWS.PROGRESS && !this._progressViewProvider) return;
 
-    this._activeMode = mode;
-    await setActiveSidebarView(
-      mode === 'progress' ? SIDEBAR_VIEWS.PROGRESS : SIDEBAR_VIEWS.MAIN,
-    );
-
-    // A concurrent switchMode call may have changed _activeMode while we awaited.
-    // Bail out so the newer call's HTML/listener wins.
-    if (this._activeMode !== mode) return;
-
+    setActiveSidebarView(mode);
     this._messageDisposable?.dispose();
-    this._messageDisposable = undefined;
 
-    if (mode === 'progress') {
+    if (mode === SIDEBAR_VIEWS.PROGRESS) {
       const pvp = this._progressViewProvider!;
       webviewView.webview.html = pvp
         .getContentProvider()
@@ -417,7 +406,7 @@ export class MainViewProvider
   }
 
   public async showInSidebar(): Promise<void> {
-    await this.switchMode('main');
+    this.switchMode(SIDEBAR_VIEWS.MAIN);
     await vscode.commands.executeCommand('texra.mainView.focus');
   }
 }

--- a/packages/extension/src/common/webview/index.ts
+++ b/packages/extension/src/common/webview/index.ts
@@ -6,6 +6,7 @@ export {
   SIDEBAR_VIEWS,
   getActiveSidebarView,
   setActiveSidebarView,
+  type SidebarView,
 } from './viewState';
 export {
   getSharedLocalResourceRoots,

--- a/packages/extension/src/common/webview/viewState.ts
+++ b/packages/extension/src/common/webview/viewState.ts
@@ -1,6 +1,10 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
+// Local imports
+import * as logger from '@logger/logUtils';
+
+const CHANNEL = 'extension';
 const TEXRA_ACTIVE_VIEW_CONTEXT_KEY = 'texra.activeView';
 
 export const SIDEBAR_VIEWS = {
@@ -16,11 +20,21 @@ export function getActiveSidebarView(): SidebarView {
   return activeSidebarView;
 }
 
-export async function setActiveSidebarView(view: SidebarView): Promise<void> {
+/**
+ * Sole writer of "which surface the sidebar shows". The `texra.activeView`
+ * context key is a projection of this value, pushed without awaiting so a
+ * caller commits its content swap in the same tick it claims the surface.
+ * That leaves no window for a second switch to interleave.
+ */
+export function setActiveSidebarView(view: SidebarView): void {
   activeSidebarView = view;
-  await vscode.commands.executeCommand(
-    'setContext',
-    TEXRA_ACTIVE_VIEW_CONTEXT_KEY,
-    view,
-  );
+  void vscode.commands
+    .executeCommand('setContext', TEXRA_ACTIVE_VIEW_CONTEXT_KEY, view)
+    .then(undefined, (error: unknown) => {
+      logger.error(
+        CHANNEL,
+        `Failed to publish the ${TEXRA_ACTIVE_VIEW_CONTEXT_KEY} context key`,
+        { data: error },
+      );
+    });
 }

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -180,7 +180,7 @@ export async function activate(context: vscode.ExtensionContext) {
   dotenv.config({
     path: path.join(workspaceRoot, '.env'),
   });
-  await setActiveSidebarView(SIDEBAR_VIEWS.MAIN);
+  setActiveSidebarView(SIDEBAR_VIEWS.MAIN);
   const gitRepoRoot = await resolveGitCommonRoot(workspaceRoot);
 
   agentDirectories.initialize(context);
@@ -520,6 +520,12 @@ export async function activate(context: vscode.ExtensionContext) {
   // fully wrapped in try/catch.)
   setTimeout(() => void configureLatexSettings(), 0);
   const mainViewProvider = registerCommands(context);
+  // Wire the two sidebar surfaces to each other before anything can invoke a
+  // placement command: `texra.showProgressView` is registered above and is
+  // also the status bar item's command, and a progress view without its main
+  // view provider would claim the sidebar placement without swapping content.
+  progressViewProvider.setMainViewProvider(mainViewProvider);
+  mainViewProvider.setProgressViewProvider(progressViewProvider);
   registerFileDecorations(context);
 
   setLeanLanguageServices(leanVscodeIntegration);
@@ -735,12 +741,6 @@ export async function activate(context: vscode.ExtensionContext) {
       });
     }),
   );
-
-  progressViewProvider.setSidebarWebviewGetter(
-    () => mainViewProvider.getWebviewView()?.webview,
-  );
-  progressViewProvider.setMainViewProvider(mainViewProvider);
-  mainViewProvider.setProgressViewProvider(progressViewProvider);
 
   // Gating commandPalette / keybindings / menus / views on `texra.activated`
   // keeps them hidden until every command handler is registered. This must run

--- a/packages/extension/src/frontend/agents/AgentDirectoryManager.ts
+++ b/packages/extension/src/frontend/agents/AgentDirectoryManager.ts
@@ -5,7 +5,7 @@ import * as path from 'node:path';
 // Third-party imports
 import * as vscode from 'vscode';
 import { minimatch } from 'minimatch';
-import pDefer from 'p-defer';
+import PQueue from 'p-queue';
 
 // Local imports
 import type {
@@ -49,8 +49,7 @@ class AgentDirectoryManager {
   private watcherSubscriptions = new Set<AgentDirectoryWatcherSubscription>();
   private externalWatcherDirectoryPaths = new Set<string>();
   private watcherDirectories: AgentDirectoryEntry[] | null = null;
-  private watcherSetupPromise: Promise<void> | null = null;
-  private watcherRebuildRequested = false;
+  private readonly watcherRebuilds = new PQueue({ concurrency: 1 });
 
   initialize(context: vscode.ExtensionContext): void {
     this.context = context;
@@ -168,37 +167,35 @@ class AgentDirectoryManager {
     );
   }
 
+  /**
+   * The rebuild queue is the only writer of the watcher set and of the cached
+   * directory list. One rebuild runs at a time and at most one waits behind
+   * it: a request arriving while a rebuild runs is answered by the waiting
+   * one, which reads the directory list after the running rebuild has settled.
+   * Disposal never discards queued rebuilds, so every caller awaiting one
+   * settles; a rebuild that starts with no subscriptions left has nothing to
+   * watch and returns.
+   */
   private async ensureAgentWatchers(): Promise<void> {
-    if (this.watcherSetupPromise) {
-      await this.watcherSetupPromise;
-      if (this.watcherRebuildRequested) {
-        await this.ensureAgentWatchers();
-      }
+    if (this.watcherRebuilds.size > 0) {
+      await this.watcherRebuilds.onIdle();
       return;
     }
 
-    const setupDeferred = pDefer<void>();
-    this.watcherSetupPromise = setupDeferred.promise;
-    this.watcherRebuildRequested = false;
+    await this.watcherRebuilds.add(async () => {
+      if (this.watcherSubscriptions.size === 0) {
+        return;
+      }
 
-    try {
       const directories = await this.getAllLocal();
-      if (
-        this.watcherDirectories &&
-        this.sameDirectories(this.watcherDirectories, directories)
-      ) {
+      const cached = this.watcherDirectories;
+      this.watcherDirectories = directories;
+      if (cached && this.sameDirectories(cached, directories)) {
         return;
       }
 
       await this.buildAgentWatchers(directories);
-    } finally {
-      setupDeferred.resolve();
-      this.watcherSetupPromise = null;
-    }
-
-    if (this.watcherRebuildRequested) {
-      await this.ensureAgentWatchers();
-    }
+    });
   }
 
   private async buildAgentWatchers(
@@ -211,7 +208,6 @@ class AgentDirectoryManager {
     this.watcherDisposables.forEach((watcher) => watcher.dispose());
     this.watcherDisposables = [];
     this.externalWatcherDirectoryPaths.clear();
-    this.watcherDirectories = directories;
 
     const watchedDirectories: string[] = [];
     const skippedDirectories: string[] = [];
@@ -359,9 +355,14 @@ class AgentDirectoryManager {
     }
   }
 
+  /**
+   * Clearing the cached list is what forces the next queued rebuild to do real
+   * work. The only write that can overwrite the cleared list is the running
+   * rebuild's own commit, which happens before that rebuild scans directory
+   * trees, so a request lost that way is one whose change the scan still sees.
+   */
   private requestAgentWatcherRebuild(): void {
     this.watcherDirectories = null;
-    this.watcherRebuildRequested = true;
     this.scheduleAgentWatcherSetup();
   }
 
@@ -456,8 +457,6 @@ class AgentDirectoryManager {
     this.watcherDisposables = [];
     this.externalWatcherDirectoryPaths.clear();
     this.watcherDirectories = null;
-    this.watcherSetupPromise = null;
-    this.watcherRebuildRequested = false;
   }
 }
 

--- a/packages/extension/src/progressView/ProgressViewProvider.ts
+++ b/packages/extension/src/progressView/ProgressViewProvider.ts
@@ -9,9 +9,9 @@ import { attachTerminalResultToast } from '@agent/runtime/terminalResultToast';
 import {
   BaseWebviewProvider,
   BundledViewContentProvider,
+  getActiveSidebarView,
   getSharedLocalResourceRoots,
   SIDEBAR_VIEWS,
-  setActiveSidebarView,
 } from '@common/webview';
 import { workspaceSM } from '@common/state';
 import { ToolEditApprovalController } from '@controllers/approval/ToolEditApprovalController';
@@ -75,7 +75,6 @@ export class ProgressViewProvider extends BaseWebviewProvider {
   private _panelJustDisposed = false;
   private readonly logger: AgentTrace;
 
-  private _sidebarWebviewGetter?: () => vscode.Webview | undefined;
   private _mainViewProvider?: MainViewProvider;
   private readonly detachHostInteractions: () => void;
 
@@ -226,12 +225,6 @@ export class ProgressViewProvider extends BaseWebviewProvider {
 
   // --- Wiring from extension.ts ---
 
-  public setSidebarWebviewGetter(
-    getter: () => vscode.Webview | undefined,
-  ): void {
-    this._sidebarWebviewGetter = getter;
-  }
-
   public setMainViewProvider(mvp: MainViewProvider): void {
     this._mainViewProvider = mvp;
   }
@@ -369,10 +362,10 @@ export class ProgressViewProvider extends BaseWebviewProvider {
     if (this._activePlacement === 'editor') {
       return this._panelView?.visible === true;
     }
-    // Sidebar mode: visible only when MainViewProvider is in progress mode
+    // Sidebar mode: visible only while the sidebar shows progress content
     return (
-      this._mainViewProvider?.getActiveMode() === 'progress' &&
-      this._mainViewProvider.getWebviewView()?.visible === true
+      getActiveSidebarView() === SIDEBAR_VIEWS.PROGRESS &&
+      this._mainViewProvider?.getWebviewView()?.visible === true
     );
   }
 
@@ -443,16 +436,12 @@ export class ProgressViewProvider extends BaseWebviewProvider {
     this._panelJustDisposed = false;
     this._activePlacement = 'sidebar';
 
-    if (this._mainViewProvider) {
-      // Focus first to ensure VS Code resolves the webview before switching content.
-      // Without this, switchMode no-ops on first use (view not yet created).
-      if (!options?.inPlace) {
-        await vscode.commands.executeCommand('texra.mainView.focus');
-      }
-      await this._mainViewProvider.switchMode('progress');
-    } else {
-      await setActiveSidebarView(SIDEBAR_VIEWS.PROGRESS);
+    // Focus first to ensure VS Code resolves the webview before switching content.
+    // Without this, switchMode no-ops on first use (view not yet created).
+    if (!options?.inPlace) {
+      await vscode.commands.executeCommand('texra.mainView.focus');
     }
+    this._mainViewProvider?.switchMode(SIDEBAR_VIEWS.PROGRESS);
 
     if (this.isActivePlacementReady()) {
       this.syncFullView();
@@ -486,7 +475,7 @@ export class ProgressViewProvider extends BaseWebviewProvider {
     if (this._panelView) {
       const placementChanged = this._activePlacement !== 'editor';
       this._activePlacement = 'editor';
-      await this.restoreSidebarToLauncher();
+      this._mainViewProvider?.switchMode(SIDEBAR_VIEWS.MAIN);
       this.revealEditorPanel();
       this.syncFullView();
       if (placementChanged) await this.replayPendingPrompts();
@@ -523,7 +512,7 @@ export class ProgressViewProvider extends BaseWebviewProvider {
     );
 
     this._activePlacement = 'editor';
-    await this.restoreSidebarToLauncher();
+    this._mainViewProvider?.switchMode(SIDEBAR_VIEWS.MAIN);
   }
 
   public async popBackToSidebar(): Promise<void> {
@@ -535,14 +524,6 @@ export class ProgressViewProvider extends BaseWebviewProvider {
     this.disposePanelResources(true);
     this.backend.dispose();
     super.dispose();
-  }
-
-  private async restoreSidebarToLauncher(): Promise<void> {
-    if (this._mainViewProvider) {
-      await this._mainViewProvider.switchMode('main');
-    } else {
-      await setActiveSidebarView(SIDEBAR_VIEWS.MAIN);
-    }
   }
 
   private isActivePlacementReady(): boolean {
@@ -557,9 +538,8 @@ export class ProgressViewProvider extends BaseWebviewProvider {
     }
     // Only return the sidebar webview when it's actually showing progress content.
     // Otherwise progress messages would be routed to the launcher webview.
-    if (this._mainViewProvider?.getActiveMode() !== 'progress')
-      return undefined;
-    return this._sidebarWebviewGetter?.();
+    if (getActiveSidebarView() !== SIDEBAR_VIEWS.PROGRESS) return undefined;
+    return this._mainViewProvider?.getWebviewView()?.webview;
   }
 
   private async sendToActiveProgressWebview(

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -543,14 +543,17 @@ export async function runFlowWithLifecycle(
     // Persist the terminal fact before any supplementary UX state. In
     // particular, a completed tool-use flow must not remain resumable while an
     // onboarding write is pending.
-    await finalizeTerminal({ outcome: result.outcome });
+    const finalized = await finalizeTerminal({ outcome: result.outcome });
+    // The phase decides the verdict here exactly as in the catch arm: a stop
+    // that won on the stream must not let the caller observe COMPLETED.
+    const resolvedOutcome = finalized?.event.outcome ?? result.outcome;
 
     // Onboarding funnel (PRD: agent-native onboarding): State 1 ends when any
     // real run completes. The setup conversation itself doesn't count, but the
     // demo it delegates does (subagent runs land here too). Best-effort: a
     // state write failure must never affect the run.
     if (
-      result.outcome === RUN_OUTCOME.COMPLETED &&
+      resolvedOutcome === RUN_OUTCOME.COMPLETED &&
       baseAgentName(agentIdentifier) !== SETUP_AGENT_NAME
     ) {
       try {
@@ -563,8 +566,8 @@ export async function runFlowWithLifecycle(
       }
     }
 
-    logger.debug(`Task completed with outcome: ${result.outcome}`);
-    return result;
+    logger.debug(`Task completed with outcome: ${resolvedOutcome}`);
+    return withResolvedOutcome(result, resolvedOutcome);
   } catch (err) {
     const kind = classifyAgentError(err);
     const outcome = AGENT_ERROR_OUTCOME[kind];

--- a/src/agent/runtime/AgentRunLifecycle.ts
+++ b/src/agent/runtime/AgentRunLifecycle.ts
@@ -27,6 +27,7 @@ import {
   type RunOutcome,
   type StreamTabId,
 } from '@shared/schemas';
+import { isTerminalOutcomePhase } from '@shared/streams/streamStatus';
 import {
   getFirstRunDone,
   setFirstRunDone,
@@ -70,6 +71,17 @@ export interface RunFlowLifecycleOptions {
 
 type FlowRecordDisposition = FinalizeExecutionInput['flowRecord'];
 
+/**
+ * Flow-record retention: a fixed disposition, or the caller's policy keyed on
+ * the terminal outcome {@link finalizeRunTerminal} resolves. Keying it on the
+ * caller's own report instead would derive the record's fate from a different
+ * owner than the outcome it is persisted beside — a genuinely failed run kept
+ * resumable, or a cancelled one stripped of the record every other cancel path
+ * preserves.
+ */
+type FlowRecordRetention =
+  FlowRecordDisposition | ((outcome: RunOutcome) => FlowRecordDisposition);
+
 /** Private control channel through which a flow reports its retention policy. */
 export interface FlowLifecycleControl {
   setFlowRecordDisposition(disposition: FlowRecordDisposition): void;
@@ -79,7 +91,7 @@ export type RunTerminalPersistence =
   | { readonly kind: 'skip' }
   | {
       readonly kind: 'finalize';
-      readonly flowRecord: FinalizeExecutionInput['flowRecord'];
+      readonly flowRecord: FlowRecordRetention;
     };
 
 export interface FinalizeRunTerminalParams {
@@ -89,9 +101,16 @@ export interface FinalizeRunTerminalParams {
   readonly executions: Pick<ExecutionRegistry, 'untrack'>;
   /** Status machine owning this run's stream phase; terminalized last. */
   readonly streamStatus: StreamStatusMachine;
-  /** The run's canonical terminal fact; every write below is a projection of it. */
+  /**
+   * The exiting run's own report. The stream phase owns the terminal fact, so
+   * this stands only while that phase is still non-terminal — see
+   * {@link finalizeRunTerminal}.
+   */
   readonly outcome: RunOutcome;
-  /** Classified error facts carried on the terminal `result` event. */
+  /**
+   * Classified error facts carried on the terminal `result` event, dropped
+   * when the stream phase resolves a different outcome than `outcome`.
+   */
   readonly error?: ResultEvent['error'];
   /** Run usage totals riding the terminal `result` event, when known. */
   readonly usage?: ResultEvent['usage'];
@@ -110,9 +129,11 @@ export interface FinalizeRunTerminalParams {
   /**
    * Delivery hook (subagent onError) run after the result settles and before
    * untrack, so the parent still sees this child as active while the
-   * delivery routes. Guarded: a throwing hook cannot abort finalization.
+   * delivery routes. Receives the resolved outcome so the payload the parent
+   * gets reports the same terminal fact as the persisted history and the
+   * `result` event. Guarded: a throwing hook cannot abort finalization.
    */
-  readonly deliver?: () => void | Promise<void>;
+  readonly deliver?: (outcome: RunOutcome) => void | Promise<void>;
 }
 
 export interface FinalizeRunTerminalResult {
@@ -123,36 +144,44 @@ export interface FinalizeRunTerminalResult {
 /**
  * The single owner of terminal run choreography, shared by the run lifecycle
  * arms below, the agent-CLI session loop, and child stream tabs
- * (`finalizeChildStream`): waiting-cleanup clear, outcome projection to
- * persisted history, transcript stage end, the terminal `result` event
- * (emit + settle), the delivery hook, then registry untrack + terminal stream
- * phase — in that order. Exactly-once per handle: the claim below flips
- * synchronously in the same tick as the check, so a second call (e.g. the
- * lifecycle catch arm after the success arm already finalized, a concurrent
- * finalize racing across this function's await points, or a finalize after a
- * `terminateWaitingHandle` already settled the handle) no-ops structurally.
+ * (`finalizeChildStream`): outcome projection to persisted history, transcript
+ * stage end, the terminal `result` event (emit + settle), the delivery hook,
+ * then registry untrack + terminal stream phase — in that order. Exactly-once
+ * per handle: the claim below flips synchronously in the same tick as the
+ * check, so a second call (e.g. the lifecycle catch arm after the success arm
+ * already finalized, or a concurrent finalize racing across this function's
+ * await points) no-ops structurally. A stop of a suspended run claims the same
+ * gate (`AgentExecutionHandle.beginSuspendedTermination`), so a kill landing
+ * mid-finalize cannot publish a second, contradictory outcome either.
  */
 export async function finalizeRunTerminal(
   params: FinalizeRunTerminalParams,
 ): Promise<FinalizeRunTerminalResult | undefined> {
-  const { handle, outcome } = params;
+  const { handle } = params;
   if (!handle.claimTerminalFinalize()) return undefined;
-  // This run is terminating, not suspending: drop any waiting-cleanup
-  // registered on this handle before teardown detaches the interrupt handler —
-  // otherwise ExecutionRegistry.terminate() could mistake this handle for a
-  // suspended one in the window between interrupt-handler detach and untrack.
-  // Defensive: this function's own WAITING branch never reaches
-  // finalizeRunTerminal on the same call (it returns early), so there is no
-  // live registration to clear in the common case — this guards a future
-  // caller that registers one outside that branch.
-  handle.clearWaitingCleanup();
+  // The stream phase is the single owner of a run's terminal outcome, so
+  // `params.outcome` is the exiting run's report rather than the verdict. A
+  // stop that already landed CANCELLED outranks a child whose process then
+  // exits non-zero; a turn that already published FAILED outranks a stop that
+  // arrived after it. Resolving once here is what lets every projection below
+  // (persisted history, stage end, result event, terminal phase) read one
+  // value, so no caller has to cross-check the phase for itself.
+  const observedPhase = params.streamStatus.get(handle.childStreamId);
+  const outcome = isTerminalOutcomePhase(observedPhase)
+    ? observedPhase
+    : params.outcome;
+  // Error facts the run classified for an outcome that did not happen are not
+  // facts about this run.
+  const error = outcome === params.outcome ? params.error : undefined;
   let terminalStatusPersisted = false;
   if (params.persistence.kind === 'finalize') {
+    const { flowRecord } = params.persistence;
     const persisted = await persistTerminalExecution({
       executionId: handle.executionId,
       agentName: handle.agentName,
       outcome,
-      flowRecord: params.persistence.flowRecord,
+      flowRecord:
+        typeof flowRecord === 'function' ? flowRecord(outcome) : flowRecord,
       logger,
       failedMessage: 'Failed to finalize durable execution state',
       rejectedMessage: 'Execution finalizer rejected unexpectedly',
@@ -181,14 +210,14 @@ export async function finalizeRunTerminal(
     agentName: handle.agentName,
     category: handle.category,
     isSubagent: params.isSubagent,
-    ...(params.error ? { error: params.error } : {}),
+    ...(error ? { error } : {}),
     ...(params.usage ? { usage: params.usage } : {}),
   };
   params.trace?.emit(event);
   handle.settleResult(event);
   if (params.deliver) {
     try {
-      await params.deliver();
+      await params.deliver(outcome);
     } catch (deliveryError) {
       logger.warn('Terminal delivery hook failed', {
         data: { agentIdentifier: handle.agentName, error: deliveryError },
@@ -200,6 +229,10 @@ export async function finalizeRunTerminal(
   // escape past an already-settled result.
   try {
     params.executions.untrack(handle.executionId);
+    // Refused only when the phase turned terminal after the resolution above,
+    // i.e. a stop that landed across this function's own awaits. The phase
+    // keeps its own value; the divergence from the published result is real
+    // and must stay loud.
     if (
       !params.streamStatus.transitionToTerminal(handle.childStreamId, outcome, {
         trace: handle.trace,
@@ -239,6 +272,70 @@ function transitionRunStart(ctx: AgentLaunchContext): void {
     return;
   }
   logger.warn('Failed to transition run to RUNNING', {
+    data: {
+      agentIdentifier: ctx.config.agent,
+      streamId,
+    },
+  });
+}
+
+/**
+ * The run's own flow result, relabelled with the outcome finalization resolved.
+ *
+ * A flow reports the exit it saw; the stream phase decides the run's terminal
+ * fact. Everything the parent receives — the delivered payload and the returned
+ * result — has to carry that same verdict, or an orchestrator formats a failure
+ * for a run whose durable record says cancelled.
+ */
+function withResolvedOutcome(
+  result: AgentFlowResult,
+  outcome: RunOutcome,
+): AgentFlowResult {
+  if (result.outcome === outcome) return result;
+  return { ...result, outcome };
+}
+
+/**
+ * Claim the stream for a run a stop reached before it could start.
+ *
+ * The stop's own USER_STOP transition is refused while the stream still carries
+ * a previous run's terminal phase (`canTransitionStreamPhase` requires an
+ * in-flight `from`), and this run skips the RUNNING claim so the stop it is
+ * carrying survives. Without this write the stream would keep the earlier run's
+ * COMPLETED/FAILED, and `finalizeRunTerminal` — which reads the phase as the
+ * owner of the terminal outcome — would publish and persist that stale verdict
+ * for an execution that never ran a turn. Resuming first mirrors the explicit
+ * RUNNING choreography `transitionToTerminal` uses to leave WAITING.
+ *
+ * A phase that already reads CANCELLED needs no write — whether this run's own
+ * stop wrote it or a previous run left it, it is the outcome this run is headed
+ * for — and rewriting it would publish a RUNNING blip for a run that never ran.
+ * A non-terminal phase needs none either: the run's own report stands while the
+ * phase carries nothing to inherit.
+ */
+function transitionStopBeforeRunStart(ctx: AgentLaunchContext): void {
+  const { streamId, session } = ctx.runScope;
+  const streamStatus = session.status;
+  const phase = streamStatus.get(streamId);
+  if (phase === STREAM_PHASE.CANCELLED || !isTerminalOutcomePhase(phase)) {
+    return;
+  }
+  const options = { trace: ctx.logger };
+  const recorded =
+    streamStatus.transition(
+      streamId,
+      STREAM_PHASE.RUNNING,
+      'resume',
+      options,
+    ) &&
+    streamStatus.transition(
+      streamId,
+      STREAM_PHASE.CANCELLED,
+      'user-stop',
+      options,
+    );
+  if (recorded) return;
+  logger.warn('Failed to record a stop that landed before run start', {
     data: {
       agentIdentifier: ctx.config.agent,
       streamId,
@@ -345,7 +442,7 @@ export async function runFlowWithLifecycle(
   const finalizeTerminal = (arm: {
     outcome: RunOutcome;
     error?: ResultEvent['error'];
-    deliver?: () => void | Promise<void>;
+    deliver?: (outcome: RunOutcome) => void | Promise<void>;
   }): Promise<FinalizeRunTerminalResult | undefined> =>
     finalizeRunTerminal({
       handle,
@@ -360,10 +457,13 @@ export async function runFlowWithLifecycle(
         : {
             kind: 'finalize',
             // Tool-use flows report the exact recovery decision through the
-            // private lifecycle control. Other flows retain the historical policy.
+            // private lifecycle control. Other flows retain the historical
+            // policy, read against the outcome finalization resolves rather
+            // than this arm's report.
             flowRecord:
               flowRecordDisposition ??
-              (arm.outcome === RUN_OUTCOME.COMPLETED ? 'delete' : 'preserve'),
+              ((resolved) =>
+                resolved === RUN_OUTCOME.COMPLETED ? 'delete' : 'preserve'),
           },
       ...arm,
     });
@@ -372,10 +472,16 @@ export async function runFlowWithLifecycle(
     // backends can create the initial StreamExecutionState with the real
     // category when the transition-owned run-start side effects fire.
     emitRunStart(ctx);
-    // The lifecycle owns every stream-status transition: RUNNING here,
+    // The lifecycle owns every stream-status transition: the start claim here,
     // terminal states in the success/error arms below. Runners must not
-    // set stream status themselves.
-    if (!handle.hasPendingInterrupt) transitionRunStart(ctx);
+    // set stream status themselves. Either branch leaves the stream carrying
+    // this run's own phase, which is what makes the terminal phase a verdict
+    // about this run rather than whatever the last one left behind.
+    if (handle.hasPendingInterrupt) {
+      transitionStopBeforeRunStart(ctx);
+    } else {
+      transitionRunStart(ctx);
+    }
     let result: AgentRuntimeFlowResult;
     try {
       result = await runner(handle, lifecycleControl);
@@ -387,12 +493,12 @@ export async function runFlowWithLifecycle(
       logger.debug(`Task suspended with outcome: ${result.outcome}`);
       // The handle stays tracked (correct for resume) but the live tool-use
       // session and its interrupt handler are already gone by the time
-      // this returns (runToolUseFlow's finally). Register a fallback so a
-      // stop/kill during the suspended window still tears this down instead
-      // of ExecutionRegistry.terminate() finding no interrupt target and
-      // no-oping — see AgentRunLifecycle/ExecutionRegistry issue #7287.
+      // this returns (runToolUseFlow's finally). Parking the handle is the
+      // one place this run is recorded as suspended, and carries the teardown
+      // a stop/kill runs instead of the absent interrupt target — see
+      // AgentRunLifecycle/ExecutionRegistry issue #7287.
       const parentStageId = ctx.parentStage.id;
-      handle.registerWaitingCleanup(async () => {
+      handle.suspend(async () => {
         session.followUps.terminalize(streamId);
         if (handle.executionLeaseLost) return;
         // Close this turn's "Run: ..." transcript group so a killed suspended
@@ -519,22 +625,30 @@ export async function runFlowWithLifecycle(
     // Terminal-error toasts are not emitted here: hosts present them from the
     // `result` event via `session.onResult` + `terminalResultToast` (the
     // single decision point), keeping the run-lifecycle out of host UI.
-    await finalizeTerminal({
+    const finalized = await finalizeTerminal({
       outcome,
       error,
       deliver:
         subagentResult && options?.onError
-          ? () => options.onError?.(err, subagentResult)
+          ? (resolved) =>
+              options.onError?.(
+                err,
+                withResolvedOutcome(subagentResult, resolved),
+              )
           : undefined,
     });
+    // The finalizer resolved this run's terminal fact; the exits below report
+    // the same one it published. It returns nothing only when the success arm
+    // already finalized, and then this arm's report is all this exit knows.
+    const resolvedOutcome = finalized?.event.outcome ?? outcome;
 
     if (subagentResult) {
-      return subagentResult;
+      return withResolvedOutcome(subagentResult, resolvedOutcome);
     }
     if (kind === 'abort') {
       return buildTerminalFlowResult(
         category,
-        outcome,
+        resolvedOutcome,
         executionId,
         streamId,
         ctx.attachedMemoryMisses,

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -45,6 +45,17 @@ export interface ExecutionInterruptHandler {
   readonly ownsBackgroundProcess?: boolean;
 }
 
+/**
+ * A run parked at WAITING, and whether a stop has already claimed its teardown.
+ *
+ * Presence is the authoritative suspension fact: only the WAITING branch of
+ * `runFlowWithLifecycle` parks a handle, so no reader has to cross-check the
+ * stream phase to learn whether a run is really suspended.
+ */
+type RunSuspension =
+  | { readonly state: 'parked'; readonly teardown: () => void | Promise<void> }
+  | { readonly state: 'terminating'; readonly completion: Promise<void> };
+
 export interface LiveToolUseFlowContext {
   readonly ownerSession?: SessionHandle;
   readonly session: {
@@ -79,9 +90,7 @@ export class AgentExecutionHandle implements ExecutionHandle {
   private toolUseFlowContext?: LiveToolUseFlowContext;
   private acceptsPendingInterrupt = false;
   private pendingInterrupt = false;
-  private waitingCleanups?: Set<() => void | Promise<void>>;
-  private waitingCleanupCompletion: Promise<void> = Promise.resolve();
-  private _waitingTerminationStarted = false;
+  private suspension?: RunSuspension;
   private _executionLeaseLost = false;
   private executionLeaseScope?: OwnedExecutionLeaseScope;
 
@@ -131,9 +140,9 @@ export class AgentExecutionHandle implements ExecutionHandle {
    * Returns true for exactly one caller — the flag flips synchronously in the
    * same tick as the check, so two `finalizeRunTerminal` calls racing across
    * await points (e.g. a lifecycle arm vs a concurrent finalize of the same
-   * handle) cannot both win. Also refuses when a terminal result already
-   * settled outside the finalizer (`terminateWaitingHandle` settles directly),
-   * so a late finalize cannot publish a second, contradictory result.
+   * handle) cannot both win. A stop of a suspended run claims through the same
+   * gate ({@link beginSuspendedTermination}), so the run lifecycle and the
+   * registry cannot both publish a terminal outcome for one run.
    */
   claimTerminalFinalize(): boolean {
     if (this._finalizeClaimed || this._settled) return false;
@@ -270,56 +279,44 @@ export class AgentExecutionHandle implements ExecutionHandle {
   }
 
   /**
-   * Register a teardown callback for when this handle is torn down while
-   * suspended at WAITING — the live tool-use session and interrupt
-   * context is already gone by then (`runToolUseFlow`'s `finally` detaches
-   * it unconditionally on return, while the handle itself stays tracked so a
-   * later resume can find it). `ExecutionRegistry.terminate()`
-   * runs these instead of the (now absent) live interrupt when a stop/kill
-   * targets a suspended subagent that has no loop-level interrupt handler
-   * covering the gap (see `childRunLoop.ts`'s own whole-lifetime
-   * handler, which is the primary path for a loop-driven child).
+   * Park this handle at WAITING, carrying the teardown a stop must run.
+   *
+   * The live tool-use session and interrupt context are already gone by the
+   * time a run suspends (`runToolUseFlow`'s `finally` detaches them on return)
+   * while the handle stays tracked so a later resume can find it, so
+   * `ExecutionRegistry.terminate()` reaches a suspended run through
+   * {@link beginSuspendedTermination} instead of a live interrupt (#7287).
    */
-  registerWaitingCleanup(cleanup: () => void | Promise<void>): void {
-    (this.waitingCleanups ??= new Set()).add(cleanup);
+  suspend(teardown: () => void | Promise<void>): void {
+    this.suspension = { state: 'parked', teardown };
+  }
+
+  /** True once a stop claimed this suspended run and its teardown began. */
+  get suspendedTerminationStarted(): boolean {
+    return this.suspension?.state === 'terminating';
   }
 
   /**
-   * Drop every registered waiting-cleanup without running it. The run
-   * lifecycle calls this on every non-WAITING terminal path: a flow that
-   * continues past the wait (queued follow-up, root mode only) or errors out
-   * must not leave a stale cleanup that `ExecutionRegistry.terminate()` could
-   * mistake for a suspended handle during normal teardown.
+   * Claim the terminal outcome of a run parked at WAITING and start its
+   * teardown, returning the teardown's completion. Returns undefined when this
+   * handle never parked, when a stop already claimed it, or when a
+   * `finalizeRunTerminal` already claimed the run's terminal outcome. The whole
+   * transition is synchronous, so a stop and a concurrent finalize of the same
+   * handle cannot both proceed.
    */
-  clearWaitingCleanup(): void {
-    this.waitingCleanups = undefined;
-  }
-
-  /**
-   * Run and clear every registered waiting-cleanup callback.
-   * Returns whether any callback was registered (and thus ran).
-   */
-  runWaitingCleanup(): boolean {
-    const cleanups = this.waitingCleanups;
-    if (!cleanups || cleanups.size === 0) return false;
-    this._waitingTerminationStarted = true;
-    this.waitingCleanups = undefined;
-    this.waitingCleanupCompletion = Promise.all(
-      [...cleanups].map(async (cleanup) => cleanup()),
-    ).then(() => undefined);
+  beginSuspendedTermination(): Promise<void> | undefined {
+    if (this.suspension?.state !== 'parked') return undefined;
+    if (!this.claimTerminalFinalize()) return undefined;
+    const { teardown } = this.suspension;
+    const completion = (async (): Promise<void> => {
+      await teardown();
+    })();
     // The registry normally awaits this before terminal persistence. Retain a
     // rejection handler for the lease-loss branch, which intentionally skips
     // durable finalization but must not create an unhandled rejection.
-    void this.waitingCleanupCompletion.catch(() => undefined);
-    return true;
-  }
-
-  get waitingTerminationStarted(): boolean {
-    return this._waitingTerminationStarted;
-  }
-
-  waitForWaitingCleanup(): Promise<void> {
-    return this.waitingCleanupCompletion;
+    void completion.catch(() => undefined);
+    this.suspension = { state: 'terminating', completion };
+    return completion;
   }
 }
 
@@ -334,7 +331,6 @@ export type AgentRunHandle = Pick<
   | 'trace'
   | 'result'
   | 'deliveryTargetStreamId'
-  | 'registerWaitingCleanup'
   | 'interrupt'
 >;
 

--- a/src/agent/runtime/childRunLoop.ts
+++ b/src/agent/runtime/childRunLoop.ts
@@ -9,7 +9,7 @@
 //
 // Host-agnostic, VS Code-free.
 
-import { synchronizeAgentResultOutcome, type ResultMeta } from '@agent/storage';
+import type { ResultMeta } from '@agent/storage';
 import type { AgentTrace, StageHandle } from '@agent/trace';
 import { createChannelTrace } from '@agent/trace';
 import {
@@ -741,11 +741,16 @@ export function startChildRunLoop<TTurn>(
         if (childStream) {
           // Agent-CLI: ChildStream.finalize owns this handle for the loop's
           // whole lifetime (one handle, tracked once by createChildStream).
+          // A failed turn is reported with its cause even when a stop
+          // followed it: the stream phase arbitrates, so a stop that landed
+          // CANCELLED still outranks this report, while a failure that
+          // already terminalized the phase keeps its diagnosis instead of
+          // publishing FAILED with no error facts at all.
           let loopOutcome: ChildStreamOutcome;
-          if (loop.isInterrupted()) {
+          if (sawTurnFailure) {
+            loopOutcome = { kind: 'failed', error: lastTurnErr };
+          } else if (loop.isInterrupted()) {
             loopOutcome = { kind: 'cancelled' };
-          } else if (sawTurnFailure) {
-            loopOutcome = { kind: 'failed' };
           } else {
             loopOutcome = { kind: 'completed' };
           }
@@ -778,7 +783,7 @@ export function startChildRunLoop<TTurn>(
               failed: sawTurnFailure && !loop.isInterrupted(),
               cancelled: loop.isInterrupted(),
             });
-            const finalized = await finalizeRunTerminal({
+            await finalizeRunTerminal({
               handle,
               executions: runSession.executions,
               streamStatus: runSession.status,
@@ -793,16 +798,13 @@ export function startChildRunLoop<TTurn>(
               isSubagent: true,
               persistence: {
                 kind: 'finalize',
-                flowRecord:
-                  outcome === RUN_OUTCOME.CANCELLED ? 'preserve' : 'delete',
+                // Keyed on the outcome the finalizer resolves, not this loop's
+                // report: only a genuinely interrupted run leaves state worth
+                // resuming, and the phase is what decides which run that is.
+                flowRecord: (resolved) =>
+                  resolved === RUN_OUTCOME.CANCELLED ? 'preserve' : 'delete',
               },
             });
-            // No turn result follows an interruption between turns. Only this
-            // path may relabel the latest interim envelope; ordinary terminal
-            // turns persist their own result after runFlowWithLifecycle returns.
-            if (finalized?.terminalStatusPersisted && loop.isInterrupted()) {
-              await synchronizeAgentResultOutcome(executionId, outcome);
-            }
           }
         }
         // Wake the parent only now — after this child's own finalize above —

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -18,7 +18,10 @@ import {
   type AgentWorkflowSetting,
 } from '@agent/core/definition/AgentDataclass';
 import type { ITool } from '@agent/core/tools/ToolTypes';
-import { hasPersistedParent } from '@agent/storage/executionLifecycle';
+import {
+  clearTerminalExecutionState,
+  hasPersistedParent,
+} from '@agent/storage/executionLifecycle';
 import {
   acquireResumedExecutionLease,
   captureOwnedExecutionLease,
@@ -570,6 +573,10 @@ export async function resumeToolUseFromResumeData(
     let isSubagent: boolean;
     let ctx: AgentLaunchContext;
     try {
+      // This execution is running again, so the terminal facts its previous
+      // run left behind stop describing it here, before any turn of the
+      // resumed run can write a result envelope for readers to project onto.
+      await clearTerminalExecutionState(resume.executionId);
       isSubagent = await hasPersistedParent(resume.executionId);
       ctx = await buildAgentLaunchContext({
         config: resume.agentConfig,

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -5,7 +5,6 @@
  * notification, and subagent lineage tracking in a single module.
  */
 
-import { synchronizeAgentResultOutcome } from '@agent/storage';
 import { createChannelTrace, type ResultEvent } from '@agent/trace';
 import {
   completeOwnedExecutionLease,
@@ -225,10 +224,10 @@ export class ExecutionRegistry {
     if (
       previous instanceof AgentExecutionHandle &&
       handle instanceof AgentExecutionHandle &&
-      previous.waitingTerminationStarted
+      previous.suspendedTerminationStarted
     ) {
       // A resumed lifecycle can replace its suspended predecessor while the
-      // predecessor's asynchronous waiting cleanup is still in progress. The
+      // predecessor's asynchronous teardown is still in progress. The
       // stop already claimed that execution, so carry it across the ownership
       // handoff instead of allowing the successor to revive the run.
       handle.interrupt();
@@ -770,7 +769,7 @@ export class ExecutionRegistry {
       // No live interrupt context: a native subagent suspended at WAITING has
       // already had its tool-use session disposed and interrupt handler detached
       // (runToolUseFlow's finally), while the handle stays tracked for resume
-      // (runFlowWithLifecycle). Run its registered waiting-cleanup instead of
+      // (runFlowWithLifecycle). Run the teardown it parked with instead of
       // silently no-oping the kill.
       return this.terminateWaitingHandle(handle);
     }
@@ -779,39 +778,22 @@ export class ExecutionRegistry {
   }
 
   /**
-   * Tear down an `AgentExecutionHandle` suspended at WAITING (or transitioning
-   * out of it via a resume that hasn't yet installed its own live context)
-   * with no live interrupt context. Returns false (no-op) when the handle
-   * never registered a waiting-cleanup — i.e. it isn't actually suspended,
-   * just momentarily between its own interrupt-handler detach and untrack during
-   * normal teardown — or when `streamStatus` shows neither state (see below).
+   * Tear down an `AgentExecutionHandle` parked at WAITING with no live
+   * interrupt context, returning whether this stop claimed the run.
    *
-   * A registered waiting-cleanup alone does not prove the run is genuinely
-   * suspended: `runFlowWithLifecycle`'s own WAITING branch is the only
-   * registrant today (native subagent turns are loop-driven — see
-   * `childRunLoop.ts` — with delivery choreography owned entirely by the
-   * loop's single site, so there is no more per-strategy speculative
-   * registration on every delivered turn). `runFlowWithLifecycle` clears
-   * this registration (`handle.clearWaitingCleanup()`) on both of its
-   * non-WAITING terminal arms, so in practice a stale cleanup is gone well
-   * before this method could ever see it — but this method does not rely on
-   * every non-waiting exit remembering to call that: `streamStatus` only
-   * reaches `WAITING` on the genuine suspend path (`ToolUseWaitNode` only
-   * transitions to WAITING when it is actually suspending — unconditionally
-   * for a subagent cycle, or after the queue is confirmed empty for a root
-   * cycle), so checking it here is an independent, authoritative
-   * confirmation that this handle is really parked, not mid-flight — belt
-   * and suspenders against a future non-waiting exit that forgets the clear
-   * (see #7324 review discussion).
-   *
-   * `resumeQueuedToolUseFromResumeData` flips `streamStatus` to RUNNING with a
-   * RESUMING substate *before* the resumed run installs its own interrupt
-   * context, so a stop landing in that window would otherwise find this same
-   * still-WAITING-suspended handle but a non-WAITING phase, and get wrongly
-   * no-opped by the check above. `getToolUseFollowUpTarget` already treats
-   * RESUMING the same as WAITING for the analogous follow-up-admission
-   * decision — mirrored here so a stop during that window still tears the
-   * stalled resume down instead of silently ignoring it.
+   * The handle's own suspension is the single authority on both questions this
+   * path used to cross-check: `runFlowWithLifecycle`'s WAITING branch is what
+   * parks a handle, and `beginSuspendedTermination` claims the run's terminal
+   * outcome and starts the teardown in one synchronous step. So a handle that
+   * never parked (one merely between its own interrupt-handler detach and
+   * untrack during normal teardown) and a run whose terminal outcome
+   * `finalizeRunTerminal` already claimed both leave this a no-op, with no
+   * `streamStatus` re-read: a stop can neither abandon a live run nor publish
+   * a second outcome. That also covers the window
+   * `resumeQueuedToolUseFromResumeData` opens by flipping the stream to
+   * RUNNING/RESUMING before the resumed run installs its own context — the
+   * suspended handle it replaces is still parked, so a stop landing there
+   * still tears the stalled resume down.
    *
    * This path bypasses `runFlowWithLifecycle`'s own terminal handling (the
    * flow never resumes to produce one), so it publishes the terminal
@@ -832,14 +814,8 @@ export class ExecutionRegistry {
    * though the turn's own trace is already gone.
    */
   private terminateWaitingHandle(handle: AgentExecutionHandle): boolean {
-    const status = this.streamStatus.get(handle.childStreamId);
-    const resuming =
-      this.streamStatus.getSubstate(handle.childStreamId) ===
-      STREAM_SUBSTATE.RESUMING;
-    if (status !== STREAM_PHASE.WAITING && !resuming) {
-      return false;
-    }
-    if (!handle.runWaitingCleanup()) return false;
+    const teardown = handle.beginSuspendedTermination();
+    if (!teardown) return false;
     const cancelledResult: ResultEvent = {
       type: 'result',
       outcome: RUN_OUTCOME.CANCELLED,
@@ -849,7 +825,7 @@ export class ExecutionRegistry {
       category: handle.category,
       isSubagent: handle.isChildExecution,
     };
-    void this.finishWaitingTermination(handle, cancelledResult).catch(
+    void this.finishWaitingTermination(handle, teardown, cancelledResult).catch(
       async (error: unknown) => {
         const recoveryFailures = [error];
         if (!(error instanceof ExecutionLeaseLostError)) {
@@ -898,11 +874,12 @@ export class ExecutionRegistry {
 
   private async finishWaitingTermination(
     handle: AgentExecutionHandle,
+    teardown: Promise<void>,
     cancelledResult: ResultEvent,
   ): Promise<void> {
     return await handle.runWithExecutionLease(async () => {
       try {
-        await handle.waitForWaitingCleanup();
+        await teardown;
       } catch (error) {
         // Transcript closure and terminal execution metadata are independent
         // durable facts. Preserve the failed artifact fence, but still give the
@@ -943,13 +920,8 @@ export class ExecutionRegistry {
         untrackMode: 'unconditional',
       });
 
-      // No later result write is guaranteed here, including during RESUMING:
-      // the resume can fail before installing its own handle, while this method
-      // has already untracked the suspended one. Align the interim envelope only
-      // after durable terminal metadata exists. A turn that does continue will
-      // replace it with its own result.
       try {
-        const result = await persistTerminalExecution({
+        await persistTerminalExecution({
           executionId: handle.executionId,
           outcome: RUN_OUTCOME.CANCELLED,
           flowRecord: 'delete',
@@ -957,12 +929,6 @@ export class ExecutionRegistry {
           failedMessage: 'Failed to finalize stopped waiting execution',
           rejectedMessage: 'Waiting-execution finalizer rejected unexpectedly',
         });
-        if (result.terminalStatusPersisted) {
-          await synchronizeAgentResultOutcome(
-            handle.executionId,
-            RUN_OUTCOME.CANCELLED,
-          );
-        }
       } finally {
         if (!handle.isChildExecution) {
           try {

--- a/src/agent/runtime/persistTerminalExecution.ts
+++ b/src/agent/runtime/persistTerminalExecution.ts
@@ -37,9 +37,8 @@ export interface PersistTerminalExecutionResult {
  * owned lease undurable and warn on either a `'failed'` result or a rejected
  * promise, and hand back whether the terminal status reached disk. The
  * caller keeps everything this helper does not own: the registry keeps its
- * `synchronizeAgentResultOutcome` follow-up and root-lease release in its own
- * `finally`; this function never throws, so a caller-side `catch` is
- * unnecessary and would be dead code.
+ * root-lease release in its own `finally`; this function never throws, so a
+ * caller-side `catch` is unnecessary and would be dead code.
  */
 export async function persistTerminalExecution(
   params: PersistTerminalExecutionParams,

--- a/src/agent/runtime/restartRepair.ts
+++ b/src/agent/runtime/restartRepair.ts
@@ -1,6 +1,5 @@
 import {
   finalizeExecution as defaultFinalizeExecution,
-  synchronizeAgentResultOutcome as defaultSynchronizeResultOutcome,
   type FinalizeExecutionInput,
   type FinalizeExecutionResult,
 } from '@agent/storage/executionLifecycle';
@@ -49,11 +48,6 @@ export interface RestartRepairOptions {
   finalizeExecution?: (
     input: FinalizeExecutionInput,
   ) => Promise<FinalizeExecutionResult>;
-  /** Align the latest persisted envelope after terminal metadata is durable. */
-  synchronizeResultOutcome?: (
-    executionId: ExecutionId,
-    outcome: RunOutcome,
-  ) => Promise<void>;
   /** Serialize liveness validation and repair mutations with acquisition. */
   runWithInactiveExecutionLease?: <T>(
     executionId: ExecutionId,
@@ -242,10 +236,6 @@ async function writeFailedTerminalStatuses(
   finalizeExecution: (
     input: FinalizeExecutionInput,
   ) => Promise<FinalizeExecutionResult>,
-  synchronizeResultOutcome: (
-    executionId: ExecutionId,
-    outcome: RunOutcome,
-  ) => Promise<void>,
   logger: RestartRepairLogger | undefined,
 ): Promise<ExecutionId[]> {
   const status = projectRunOutcome(RUN_OUTCOME.FAILED).executionStatus;
@@ -264,10 +254,6 @@ async function writeFailedTerminalStatuses(
   );
 
   const updated: ExecutionId[] = [];
-  const synchronizationWrites: Array<{
-    streamId: StreamTabId;
-    executionId: ExecutionId;
-  }> = [];
   for (const [index, result] of results.entries()) {
     const { streamId, executionId } = writes[index];
     if (result.status === 'fulfilled') {
@@ -285,7 +271,6 @@ async function writeFailedTerminalStatuses(
       }
       if (finalization.terminalStatusPersisted) {
         updated.push(executionId);
-        synchronizationWrites.push({ streamId, executionId });
       }
       continue;
     }
@@ -294,18 +279,6 @@ async function writeFailedTerminalStatuses(
     });
   }
 
-  const synchronizationResults = await Promise.allSettled(
-    synchronizationWrites.map(({ executionId }) =>
-      synchronizeResultOutcome(executionId, RUN_OUTCOME.FAILED),
-    ),
-  );
-  for (const [index, result] of synchronizationResults.entries()) {
-    if (result.status === 'fulfilled') continue;
-    const { streamId, executionId } = synchronizationWrites[index];
-    logger?.warn('Failed to align restart-repair result outcome', {
-      data: { streamId, executionId, error: result.reason },
-    });
-  }
   return updated;
 }
 
@@ -505,7 +478,6 @@ async function repairRestartedStream(
       ? new Map<StreamTabId, ExecutionId>([[streamId, executionId]])
       : options.executionIds,
     options.finalizeExecution ?? defaultFinalizeExecution,
-    options.synchronizeResultOutcome ?? defaultSynchronizeResultOutcome,
     options.logger,
   );
   return {

--- a/src/agent/runtime/resumeQueuedToolUse.ts
+++ b/src/agent/runtime/resumeQueuedToolUse.ts
@@ -84,7 +84,7 @@ export async function resumeQueuedToolUseFromResumeData(
   const existingHandle = session.executions.getHandle(resume.executionId);
   if (
     existingHandle instanceof AgentExecutionHandle &&
-    existingHandle.waitingTerminationStarted
+    existingHandle.suspendedTerminationStarted
   ) {
     return false;
   }

--- a/src/agent/runtime/runAgent.ts
+++ b/src/agent/runtime/runAgent.ts
@@ -1,4 +1,5 @@
 import { finalizeExecution, registerExecution } from '@agent/storage';
+import { clearTerminalExecutionState } from '@agent/storage/executionLifecycle';
 import {
   abandonOwnedExecutionLease,
   acquireResumedExecutionLease,
@@ -124,6 +125,12 @@ export async function runAgent(
     const callerOnRun = executeAgentOptions.onRun;
     try {
       try {
+        // A resumed execution is no longer described by the terminal facts its
+        // previous run persisted; drop them before this run writes anything a
+        // reader would project them onto.
+        if (!shouldRegister) {
+          await clearTerminalExecutionState(executionId);
+        }
         const result = await executeAgent(config, executionId, {
           ...executeAgentOptions,
           onRun: async (handle) => {

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -29,6 +29,7 @@ import { byString, filterNotNull, normalizeFilePath } from '@utils/core';
 import { toErrorMessage } from '@utils/errors/errorMessage';
 
 import {
+  applyExecutionOutcome,
   parsePersistedResultMeta,
   ResultMetaSchema,
   type ResultMeta,
@@ -292,21 +293,26 @@ class StorageFSKVStore extends KVStore implements ExecutionKVStore {
   }
 
   async readResultMeta(): Promise<ResultMeta | null> {
-    const raw = await this.read(KEYS.RESULT_META);
+    const [raw, meta] = await Promise.all([
+      this.read(KEYS.RESULT_META),
+      this.readMeta(),
+    ]);
     if (raw == null) return null;
 
     const canonical = ResultMetaSchema.safeParse(raw);
-    if (canonical.success) return canonical.data;
+    if (canonical.success) {
+      return applyExecutionOutcome(canonical.data, meta?.outcome);
+    }
 
-    const [meta, config] = await Promise.all([
-      this.readMeta(),
-      this.readConfig(),
-    ]);
+    const config = await this.readConfig();
     try {
-      return parsePersistedResultMeta(raw, {
-        category: config?.agentCategory,
-        outcome: meta?.outcome,
-      });
+      return applyExecutionOutcome(
+        parsePersistedResultMeta(raw, {
+          category: config?.agentCategory,
+          outcome: meta?.outcome,
+        }),
+        meta?.outcome,
+      );
     } catch (error) {
       logger.warn(
         CHANNEL,

--- a/src/agent/storage/executionLifecycle.ts
+++ b/src/agent/storage/executionLifecycle.ts
@@ -20,7 +20,6 @@ import {
   type ExecutionId,
   type ExecutionMeta,
   type ExecutionStatus,
-  type RunOutcome,
   type StreamTabId,
 } from '@shared/schemas';
 import { WorkspaceFS } from '@utils/files';
@@ -31,7 +30,6 @@ import {
   captureOwnedExecutionLease,
   releaseOwnedExecutionLease,
 } from './executionLease';
-import { ResultMetaSchema } from './resultMeta';
 
 const CHANNEL = 'ExecutionLifecycle';
 
@@ -212,42 +210,28 @@ async function persistSupplementaryMetaFieldsBestEffort(
 }
 
 /**
- * Align an existing agent result after a suspended run terminates between
- * turns. Call this only when no later turn-owned result write can replace the
- * record. The durable execution outcome is checked first, so a failed status
- * write cannot relabel the result on its own.
+ * Drop the previous run's terminal facts as a persisted execution is admitted
+ * for resumption. `meta.outcome` owns "how did this run end" and every reader
+ * projects it onto the turn-owned result envelope (`applyExecutionOutcome`), so
+ * an execution that resumes while still carrying its interrupted predecessor's
+ * outcome relabels every turn the resumed run writes until its next terminal
+ * finalize. Both fields go together: `ExecutionMetaSchema` re-derives `outcome`
+ * from a surviving `terminalStatus`.
+ *
+ * Metadata that is absent or unreadable is left alone: `readResultMeta` reads
+ * the same metadata, so there is no outcome to project either way, and the
+ * store already warns about metadata it could not parse.
  */
-export async function synchronizeAgentResultOutcome(
+export async function clearTerminalExecutionState(
   executionId: ExecutionId,
-  outcome: RunOutcome,
 ): Promise<void> {
-  try {
-    const store = getExecutionStore(executionId);
-    const meta = await store.readMeta();
-    if (meta?.outcome !== outcome) return;
-
-    const resultMeta = await store.readResultMeta();
-    if (
-      !resultMeta ||
-      resultMeta.producer === 'backgroundBash' ||
-      resultMeta.result.outcome === outcome
-    ) {
-      return;
-    }
-    const updatedResultMeta = ResultMetaSchema.parse({
-      ...resultMeta,
-      result: { ...resultMeta.result, outcome },
-    });
-    await store.writeResultMeta(updatedResultMeta);
-  } catch (err) {
-    // Terminal cleanup stays non-throwing, but this leaves the public result
-    // stale and must remain visible to operators.
-    logger.warn(
-      CHANNEL,
-      `Failed to synchronize result outcome for ${executionId}: ${toErrorMessage(err)}`,
-      { data: err },
-    );
-  }
+  const meta = await getExecutionStore(executionId).readMeta();
+  if (!meta) return;
+  if (meta.terminalStatus === undefined && meta.outcome === undefined) return;
+  await enqueueMetaUpdate(executionId, () => ({
+    terminalStatus: undefined,
+    outcome: undefined,
+  }));
 }
 
 /**

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -30,7 +30,6 @@ export {
 export {
   finalizeExecution,
   registerExecution,
-  synchronizeAgentResultOutcome,
   type FinalizeExecutionInput,
   type FinalizeExecutionResult,
   writeSessionDescription,

--- a/src/agent/storage/resultMeta.ts
+++ b/src/agent/storage/resultMeta.ts
@@ -54,6 +54,34 @@ export const ResultMetaSchema = z.discriminatedUnion('producer', [
 
 export type ResultMeta = z.infer<typeof ResultMetaSchema>;
 
+/**
+ * Project the execution's durable terminal outcome onto a persisted result
+ * record. `meta.outcome` is the only writer of "how did this run end": the
+ * result record is an interim envelope rewritten by every turn, and a run can
+ * end after its last turn wrote one (interrupted between turns, stopped while
+ * suspended, failed by restart repair). A durable `completed` is never
+ * projected: it only ever agrees with the envelope, whose producer may already
+ * have downgraded a nominally completed flow that reported an application-level
+ * error (`buildSubagentFailureResultMeta`).
+ */
+export function applyExecutionOutcome(
+  record: ResultMeta,
+  executionOutcome: RunOutcome | undefined,
+): ResultMeta {
+  if (
+    record.producer === 'backgroundBash' ||
+    executionOutcome === undefined ||
+    executionOutcome === RUN_OUTCOME.COMPLETED ||
+    record.result.outcome === executionOutcome
+  ) {
+    return record;
+  }
+  return ResultMetaSchema.parse({
+    ...record,
+    result: { ...record.result, outcome: executionOutcome },
+  });
+}
+
 /** Remove persistence-only producer context from the public result value. */
 export function unwrapResultMeta(
   meta: ResultMeta,

--- a/src/controllers/progressView/backend/WebviewUpdater.ts
+++ b/src/controllers/progressView/backend/WebviewUpdater.ts
@@ -423,13 +423,6 @@ export class WebviewUpdater {
   ): StreamMetadata {
     const current = state.getStreamState(streamInfo.name);
     const streamState = streamStates?.get(streamInfo.name);
-    // The roster goes through `projectChildRosters` here too, not just on the
-    // badge path: this structural rebuild is the frontend's other writer of
-    // `subagents` (`mergeBackendOwnedState` overlays every
-    // backend-owned field), so shipping the raw roster would let a later
-    // UPDATE_STREAMS overwrite a resolved terminal status with the stale value
-    // stamped at roster-drop time.
-    const rosters = current ? state.projectChildRosters(current) : undefined;
     return buildStreamMetadata({
       kind: streamInfo.agentCategory,
       status: streamState?.phase,
@@ -438,7 +431,7 @@ export class WebviewUpdater {
       conversationProgress: current?.conversationProgress,
       roundStage: current?.roundStage,
       phaseStage: current?.phaseStage,
-      subagents: rosters?.subagents,
+      subagents: current?.subagents,
     });
   }
 }

--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -11,7 +11,6 @@ import { WebviewBridge } from '@controllers/progressView/backend/WebviewBridge';
 import {
   ProgressViewState,
   type ActiveStreamId,
-  type StreamBadgeSnapshot,
   type StreamExecutionState,
 } from '@controllers/progressView/backend/state/ProgressViewState';
 import { buildStreamInfos } from '@controllers/progressView/backend/streamInfoUtils';
@@ -611,19 +610,33 @@ export class ProgressFactApplier {
    * so hosts can list it. A retained row is only ever created from an entry
    * that was already in OUR roster and is absent from `next`, so a first
    * roster can never mark anything finished.
+   *
+   * `next` decides roster membership and identity only. A row we already track
+   * keeps the phase `recordChildPhase` wrote, so the status-machine fact stays
+   * the sole writer of `status` and a roster stamped before a later transition
+   * cannot regress a resolved row. A row entering the roster (first sighting,
+   * or a retained child going live again) has no recorded phase to keep, so it
+   * takes the one stamped at emission.
    */
   public updateChildRoster(
     parentStreamId: StreamTabId,
     next: StreamExecutionState['subagents'],
   ): void {
-    let nextBadges: StreamBadgeSnapshot | null = null;
-
     this.state.updateStreamState(parentStreamId, (prev) => {
       const previous = prev.subagents;
-      const vanishedIds = diffActiveChildren(
-        previous.filter((child) => child.finishedAt === undefined),
-        next,
+      const liveBefore = previous.filter(
+        (child) => child.finishedAt === undefined,
       );
+      const recordedPhases = new Map(
+        liveBefore.map((child) => [child.executionId, child.status]),
+      );
+      const live = next.map((child) => {
+        const recorded = recordedPhases.get(child.executionId);
+        return recorded === undefined || recorded === child.status
+          ? child
+          : { ...child, status: recorded };
+      });
+      const vanishedIds = diffActiveChildren(liveBefore, next);
       const finishedAt = Date.now();
       const nextIds = new Set(next.map((child) => child.executionId));
       // Previously-retained rows first (already in ascending `finishedAt`
@@ -639,17 +652,18 @@ export class ProgressFactApplier {
           .filter((child) => vanishedIds.has(child.executionId))
           .map((child) => ({ ...child, finishedAt })),
       ].slice(-RETAINED_FINISHED_CHILDREN_CAP);
-      const updatedState = { ...prev, subagents: [...next, ...retained] };
-      nextBadges = this.state.projectChildRosters(updatedState);
-      return updatedState;
+      return { ...prev, subagents: [...live, ...retained] };
     });
 
+    const updated = this.state.getStreamState(parentStreamId);
     if (
       this.webviewUpdater.isAvailable() &&
       parentStreamId === this.state.activeStream &&
-      nextBadges
+      updated
     ) {
-      this.webviewUpdater.updateStreamBadges(parentStreamId, nextBadges);
+      this.webviewUpdater.updateStreamBadges(parentStreamId, {
+        subagents: updated.subagents,
+      });
     }
   }
 
@@ -751,7 +765,7 @@ export class ProgressFactApplier {
       conversationProgress: state.conversationProgress,
       roundStage: state.roundStage ?? null,
       phaseStage: state.phaseStage ?? null,
-      badges: this.state.projectChildRosters(state),
+      badges: { subagents: state.subagents },
       parentStreamId: this.state.snapshots.getParentStreamId(stream) ?? null,
     };
   }
@@ -764,6 +778,11 @@ export class ProgressFactApplier {
     _previousStatus?: StreamPhase,
     substate?: StreamSubstate,
   ): Promise<void> {
+    // Land the status-machine phase in the parent rosters before this handler
+    // can suspend, so rows are written in fact order and a slow active-phase
+    // rehydrate can never overwrite a later phase.
+    const rosterParents = this.state.recordChildPhase(streamId, status);
+
     // Active phases keep the full log resident for runtime writes. Inactive,
     // unfocused streams release heavy entries and rehydrate on demand.
     const requiresPersistentRehydrate =
@@ -784,46 +803,16 @@ export class ProgressFactApplier {
       ? this.handleRunningTransition(streamId)
       : undefined;
 
-    // Keep the roster's fallback status current before the status-machine
-    // entry can be cleared by child cleanup. Projection still overlays from
-    // the machine while it exists; this cached value preserves the terminal
-    // outcome for later structural syncs after cleanup.
-    const parentStreamId = this.state.snapshots.getParentStreamId(streamId);
-    let parentState = parentStreamId
-      ? this.state.getStreamState(parentStreamId)
-      : undefined;
-    if (
-      parentStreamId &&
-      parentState?.subagents.some(
-        (child) =>
-          child.kind === 'subagent' && child.childStreamId === streamId,
-      )
-    ) {
-      parentState = {
-        ...parentState,
-        subagents: parentState.subagents.map((child) =>
-          child.kind === 'subagent' && child.childStreamId === streamId
-            ? { ...child, status }
-            : child,
-        ),
-      };
-      const updatedParentState = parentState;
-      this.state.updateStreamState(parentStreamId, () => updatedParentState);
-    }
-
     if (!this.webviewUpdater.isAvailable()) return;
 
-    // A child's roster drop can land BEFORE its terminal status. Re-push the
-    // active parent's badges from the canonical projection when it catches up.
-    if (
-      parentStreamId &&
-      parentStreamId === this.state.activeStream &&
-      parentState
-    ) {
-      this.webviewUpdater.updateStreamBadges(
-        parentStreamId,
-        this.state.projectChildRosters(parentState),
-      );
+    // Push the rows just written whenever the parent holding them is on screen.
+    for (const parent of rosterParents) {
+      if (parent !== this.state.activeStream) continue;
+      const parentState = this.state.getStreamState(parent);
+      if (!parentState) continue;
+      this.webviewUpdater.updateStreamBadges(parent, {
+        subagents: parentState.subagents,
+      });
     }
 
     const isNewStream = !this.state.streamLogs.has(streamId);

--- a/src/controllers/progressView/backend/state/ProgressViewState.ts
+++ b/src/controllers/progressView/backend/state/ProgressViewState.ts
@@ -27,6 +27,7 @@ import {
   type ExecutionId,
   type PhaseStage,
   type RoundStage,
+  type StreamPhase,
   type StreamTabId,
 } from '@shared/schemas';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
@@ -451,27 +452,39 @@ export class ProgressViewState {
   }
 
   /**
-   * Project a stream's child roster for the wire. `streamStatus` — not the
-   * roster row — owns a subagent's phase: a child's roster drop can arrive
-   * BEFORE its terminal status (the cancel path untracks the handle, then
-   * transitions the stream), so the status stamped into a retained row at drop
-   * time can read `running` forever. Resolve it here, at the one boundary every
-   * roster-carrying payload passes through — badges, the tab-switch content
-   * sync, and the structural `UPDATE_STREAMS` / `UPDATE_STREAM_METADATA`
-   * rebuild alike — so no send path can ship the stale stamped value.
+   * Carry a child stream's phase into every roster row that tracks it, and
+   * return the parents whose rosters changed. `streamStatus` owns a subagent's
+   * phase and this is the single write that lands it in a roster, so every send
+   * path ships stored data. Rows are keyed by their own `childStreamId` rather
+   * than by the parent-link snapshot: a child's roster drop can arrive BEFORE
+   * its terminal phase (the cancel path untracks the handle, then transitions
+   * the stream), and a detached child loses the parent link entirely while its
+   * retained row lives on under the former parent.
    */
-  projectChildRosters(state: StreamExecutionState): StreamBadgeSnapshot {
-    return {
-      subagents: state.subagents.map((child) =>
-        child.kind === 'subagent'
-          ? {
-              ...child,
-              status:
-                this.streamStatus.get(child.childStreamId) ?? child.status,
-            }
-          : child,
-      ),
-    };
+  recordChildPhase(
+    childStreamId: StreamTabId,
+    phase: StreamPhase,
+  ): StreamTabId[] {
+    const changedParents: StreamTabId[] = [];
+    for (const [parent, state] of this._streamStates) {
+      const tracksChild = state.subagents.some(
+        (child) =>
+          child.kind === 'subagent' &&
+          child.childStreamId === childStreamId &&
+          child.status !== phase,
+      );
+      if (!tracksChild) continue;
+      this._streamStates.set(parent, {
+        ...state,
+        subagents: state.subagents.map((child) =>
+          child.kind === 'subagent' && child.childStreamId === childStreamId
+            ? { ...child, status: phase }
+            : child,
+        ),
+      });
+      changedParents.push(parent);
+    }
+    return changedParents;
   }
 
   // -- Lifecycle --------------------------------------------------------------

--- a/src/test-kernel/agent/RegisterExecutionWorkspaceDirectory.vitest.ts
+++ b/src/test-kernel/agent/RegisterExecutionWorkspaceDirectory.vitest.ts
@@ -3,7 +3,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
 import { flowKey } from '@agent/node/persistedFlow';
-import * as logger from '@logger/logUtils';
 import {
   EXECUTION_STATUS,
   RUN_OUTCOME,
@@ -27,7 +26,6 @@ vi.mock('@agent/storage/ExecutionKVStore', () => ({
 import {
   finalizeExecution,
   registerExecution,
-  synchronizeAgentResultOutcome,
   writeTerminalStatus,
 } from '@agent/storage/executionLifecycle';
 import { inspectExecutionLease } from '@agent/storage/executionLease';
@@ -156,40 +154,6 @@ describe('execution lifecycle', () => {
     expect(mocks.writeResultMeta).not.toHaveBeenCalled();
   });
 
-  it('aligns an interim result after a suspended run terminates between turns', async () => {
-    const executionId = 'suspended-terminal-result' as ExecutionId;
-    mocks.readMeta.mockResolvedValue(
-      executionMeta({
-        terminalStatus: EXECUTION_STATUS.INTERRUPTED,
-        outcome: RUN_OUTCOME.CANCELLED,
-      }),
-    );
-    mocks.readResultMeta.mockResolvedValue(
-      resultMeta(RUN_OUTCOME.COMPLETED, 'Interim result.'),
-    );
-
-    await synchronizeAgentResultOutcome(executionId, RUN_OUTCOME.CANCELLED);
-
-    expect(mocks.writeResultMeta).toHaveBeenCalledWith(
-      resultMeta(RUN_OUTCOME.CANCELLED, 'Interim result.'),
-    );
-  });
-
-  it('does not change the result outcome when execution metadata is missing', async () => {
-    mocks.readResultMeta.mockResolvedValue(
-      resultMeta('completed', 'Finished.'),
-    );
-
-    await synchronizeAgentResultOutcome(
-      'missing-terminal-meta' as ExecutionId,
-      RUN_OUTCOME.CANCELLED,
-    );
-
-    expect(mocks.writeMeta).not.toHaveBeenCalled();
-    expect(mocks.readResultMeta).not.toHaveBeenCalled();
-    expect(mocks.writeResultMeta).not.toHaveBeenCalled();
-  });
-
   it('rejects when terminal metadata cannot be written', async () => {
     mocks.readMeta.mockResolvedValue(
       executionMeta({
@@ -312,32 +276,5 @@ describe('execution lifecycle', () => {
       }),
     );
     expect(mocks.delete).toHaveBeenCalledWith(flowKey(executionId));
-  });
-
-  it('warns when the persisted result outcome cannot be reconciled', async () => {
-    const executionId = 'result-sync-failed' as ExecutionId;
-    const error = new Error('result disk full');
-    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
-    mocks.readMeta.mockResolvedValue(
-      executionMeta({ outcome: RUN_OUTCOME.CANCELLED }),
-    );
-    mocks.readResultMeta.mockResolvedValue(
-      resultMeta('completed', 'Interim result.'),
-    );
-    mocks.writeResultMeta.mockRejectedValueOnce(error);
-
-    try {
-      await synchronizeAgentResultOutcome(executionId, RUN_OUTCOME.CANCELLED);
-
-      expect(warnSpy).toHaveBeenCalledWith(
-        'ExecutionLifecycle',
-        expect.stringContaining(
-          `Failed to synchronize result outcome for ${executionId}`,
-        ),
-        { data: error },
-      );
-    } finally {
-      warnSpy.mockRestore();
-    }
   });
 });

--- a/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/followUp/ChildStreamProgressEvents.vitest.ts
@@ -569,7 +569,11 @@ describe('child stream progress events', () => {
     });
   });
 
-  it('preserves explicit user stops during child loop status changes', async () => {
+  // The child reports its own exit and nothing else: every mid-loop report
+  // below is refused by the status machine because a stop already cancelled
+  // the stream, and `finalizeRunTerminal` resolves the run's terminal outcome
+  // from that phase rather than from the failure the child reports.
+  it('settles a stopped child loop as cancelled from the stream phase', async () => {
     const recorded = recordSessionEvents(defaultSession().events);
 
     const childStream = startCodexChild(

--- a/src/test-kernel/agent/runtime/AgentLaunchActivation.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentLaunchActivation.vitest.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   acquireResumedExecutionLease: vi.fn(),
   buildVars: vi.fn(),
+  clearTerminalExecutionState: vi.fn(),
   completeOwnedExecutionLease: vi.fn(),
   createHandler: vi.fn(),
   createTrace: vi.fn(),
@@ -30,6 +31,7 @@ vi.mock('@transcript', async (importActual) => ({
 }));
 vi.mock('@agent/utils/userVars', () => ({ buildUserVars: mocks.buildVars }));
 vi.mock('@agent/storage/executionLifecycle', () => ({
+  clearTerminalExecutionState: mocks.clearTerminalExecutionState,
   hasPersistedParent: mocks.hasPersistedParent,
 }));
 vi.mock('@agent/storage/executionLease', () => ({
@@ -130,6 +132,7 @@ describe('native agent launch activation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.acquireResumedExecutionLease.mockResolvedValue('existing');
+    mocks.clearTerminalExecutionState.mockResolvedValue(undefined);
     mocks.releaseOwnedExecutionLeaseAfterFailure.mockImplementation(
       async (_executionId: ExecutionId, error: unknown) => error,
     );

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -706,7 +706,9 @@ describe('runFlowWithLifecycle', () => {
         return toolUseResult(executionId, streamId, RUN_OUTCOME.COMPLETED);
       });
 
-      expect(result.outcome).toBe(RUN_OUTCOME.COMPLETED);
+      // The caller receives the same verdict persistence carries: the stop
+      // won on the stream, so the flow's COMPLETED report is relabeled.
+      expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
       expect(storageMocks.finalizeExecution).toHaveBeenCalledExactlyOnceWith(
         expect.objectContaining({
           terminalStatus: EXECUTION_STATUS.INTERRUPTED,

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -12,9 +12,13 @@ import {
   inspectExecutionLease,
   releaseOwnedExecutionLease,
 } from '@agent/storage/executionLease';
-import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
+import {
+  StreamStatusMachine,
+  type StreamStatusChange,
+} from '@agent/runtime/StreamStatusService';
 import {
   AgentExecutionHandle,
+  type AgentRunHandle,
   type LiveToolUseFlowContext,
 } from '@agent/runtime/ExecutionHandle';
 import { defaultSession } from '@agent/runtime/SessionHandle';
@@ -71,7 +75,6 @@ const storageMocks = vi.hoisted(() => ({
       flowRecord: input.flowRecord === 'delete' ? 'deleted' : 'preserved',
     }),
   ),
-  synchronizeAgentResultOutcome: vi.fn().mockResolvedValue(undefined),
 }));
 
 const channelTraceMocks = vi.hoisted(() => ({
@@ -80,7 +83,6 @@ const channelTraceMocks = vi.hoisted(() => ({
 
 vi.mock('@agent/storage', () => ({
   finalizeExecution: storageMocks.finalizeExecution,
-  synchronizeAgentResultOutcome: storageMocks.synchronizeAgentResultOutcome,
 }));
 
 vi.mock('@agent/trace', async (importOriginal) => {
@@ -148,21 +150,12 @@ function waitingResult(
 /**
  * Returns the suspended handle for a run that reported WAITING.
  *
- * `terminateWaitingHandle` requires the stream to have genuinely reached
- * WAITING (belt-and-suspenders confirmation the handle is really parked, not
- * mid-flight; see #7324 review discussion). The fake runners below return the
- * WAITING outcome directly without driving the real `transitionToWaiting()`,
- * so the phase is seeded explicitly here.
+ * The fake runners below return the WAITING outcome without driving the real
+ * `transitionToWaiting()`, so the stream phase never reaches WAITING here —
+ * which is the point: the handle's own suspension is what makes a stop tear
+ * the run down, so no phase seeding is needed to reach that path.
  */
-function takeWaitingHandle(
-  executionId: ExecutionId,
-  streamId: StreamTabId,
-): AgentExecutionHandle {
-  seedStreamStatusForTest(
-    defaultSession().status,
-    streamId,
-    STREAM_STATUS.WAITING,
-  );
+function takeWaitingHandle(executionId: ExecutionId): AgentExecutionHandle {
   const handle = defaultSession().executions.getHandle(executionId);
   expect(handle).toBeInstanceOf(AgentExecutionHandle);
   if (!(handle instanceof AgentExecutionHandle)) {
@@ -488,33 +481,46 @@ describe('runFlowWithLifecycle', () => {
     }
   });
 
-  it('clears a pre-registered waiting-cleanup when the run completes without suspending', async () => {
+  it('does not let a stop abandon a run that completes without suspending', async () => {
+    // The window a stop could once fall into: the run has returned, its live
+    // interrupt context is detached, and its own finalize is parked at the
+    // persist await with the handle still tracked. Only the WAITING branch
+    // parks a handle, so there is no suspension for the stop to find and
+    // nothing the exit has to remember to clear.
     const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
-      'lifecycle-stale-waiting-cleanup',
+      'lifecycle-completed-not-suspended',
     );
-    const staleCleanup = vi.fn();
-    let captured: AgentExecutionHandle | undefined;
+    storageMocks.finalizeExecution.mockClear();
+    let releasePersist: (() => void) | undefined;
+    storageMocks.finalizeExecution.mockImplementationOnce(
+      async () =>
+        new Promise((resolve) => {
+          releasePersist = () =>
+            resolve({
+              status: 'durable',
+              terminalStatusPersisted: true,
+              flowRecord: 'deleted',
+            });
+        }),
+    );
 
     try {
-      // Simulate a waiting-cleanup registered on this handle by some
-      // caller, then the run completing normally without ever suspending.
-      const result = await runFlowWithLifecycle(
+      const running = runFlowWithLifecycle(
         ctx,
         async () => toolUseResult(executionId, streamId, RUN_OUTCOME.COMPLETED),
-        {
-          isSubagent: true,
-          onRun: (handle) => {
-            captured = handle as AgentExecutionHandle;
-            handle.registerWaitingCleanup(staleCleanup);
-          },
-        },
+        { isSubagent: true },
       );
+      await vi.waitFor(() => expect(releasePersist).toBeDefined());
 
+      expect(defaultSession().executions.kill(executionId)).toBe(false);
+
+      releasePersist?.();
+      const result = await running;
       expect(result.outcome).toBe(RUN_OUTCOME.COMPLETED);
-      // The stale registration must be gone: nothing ran it, and a
-      // terminate() racing into the teardown window must not find it.
-      expect(staleCleanup).not.toHaveBeenCalled();
-      expect(captured?.runWaitingCleanup()).toBe(false);
+      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.COMPLETED);
+      expect(
+        defaultSession().executions.getHandle(executionId),
+      ).toBeUndefined();
     } finally {
       defaultSession().executions.untrack(executionId);
       clearStreamStatusForTest(streamStatus, streamId);
@@ -603,6 +609,149 @@ describe('runFlowWithLifecycle', () => {
     expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
   });
 
+  // The stream is reused across runs, so a run that never claims it inherits
+  // whatever the last one left. A stop landing in the track()-to-start window
+  // is refused by the phase table while that leftover is terminal, so without
+  // the start-time claim this run would adopt the previous run's COMPLETED as
+  // its own verdict and drop its abort facts.
+  it('does not adopt a previous run terminal phase when a stop lands before start', async () => {
+    const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
+      'lifecycle-stale-phase-early-stop',
+    );
+    storageMocks.finalizeExecution.mockClear();
+    let terminalResult: AgentRunHandle['result'] | undefined;
+
+    try {
+      seedStreamStatusForTest(streamStatus, streamId, STREAM_PHASE.COMPLETED);
+
+      const result = await runFlowWithLifecycle(
+        ctx,
+        async (handle) => {
+          expect(handle.hasPendingInterrupt).toBe(true);
+          throw new DOMException('Request aborted', 'AbortError');
+        },
+        {
+          onRun: (handle) => {
+            terminalResult = handle.result;
+            expect(defaultSession().executions.kill(executionId)).toBe(true);
+          },
+        },
+      );
+
+      expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
+      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
+      expect(storageMocks.finalizeExecution).toHaveBeenCalledWith(
+        expect.objectContaining({
+          terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+          flowRecord: 'preserve',
+        }),
+      );
+      await expect(terminalResult).resolves.toMatchObject({
+        outcome: RUN_OUTCOME.CANCELLED,
+        error: { kind: 'abort' },
+      });
+    } finally {
+      clearStreamStatusForTest(streamStatus, streamId);
+    }
+  });
+
+  // The claim above is a repair for an inherited phase, not a second start: a
+  // stop that already reads CANCELLED on the stream is this run's outcome too,
+  // so a run that never ran must not publish a RUNNING blip on the way out.
+  it('publishes no RUNNING blip when the stop that beat run start already cancelled the stream', async () => {
+    const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
+      'lifecycle-early-stop-no-blip',
+    );
+    const changes: StreamStatusChange[] = [];
+    const detachStatus = streamStatus.onDidChange((change) => {
+      if (change.streamId === streamId) changes.push(change);
+    });
+
+    try {
+      const result = await runFlowWithLifecycle(
+        ctx,
+        async () => {
+          throw new DOMException('Request aborted', 'AbortError');
+        },
+        {
+          onRun: () => {
+            expect(defaultSession().executions.kill(executionId)).toBe(true);
+          },
+        },
+      );
+
+      expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
+      expect(changes.map((change) => change.status)).toEqual([
+        STREAM_PHASE.CANCELLED,
+      ]);
+    } finally {
+      detachStatus();
+      clearStreamStatusForTest(streamStatus, streamId);
+    }
+  });
+
+  // Outcome and flow-record disposition are one decision: a run the phase says
+  // was interrupted keeps the record that makes it resumable, even when its own
+  // report reached completion first.
+  it('keeps the flow record of a stopped run whose report says completed', async () => {
+    const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
+      'lifecycle-stop-during-completion',
+    );
+    storageMocks.finalizeExecution.mockClear();
+
+    try {
+      const result = await runFlowWithLifecycle(ctx, async () => {
+        expect(defaultSession().executions.kill(executionId)).toBe(true);
+        expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
+        return toolUseResult(executionId, streamId, RUN_OUTCOME.COMPLETED);
+      });
+
+      expect(result.outcome).toBe(RUN_OUTCOME.COMPLETED);
+      expect(storageMocks.finalizeExecution).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+          flowRecord: 'preserve',
+        }),
+      );
+      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
+    } finally {
+      clearStreamStatusForTest(streamStatus, streamId);
+    }
+  });
+
+  // The parent's delivery is a projection of the same terminal fact as the
+  // persisted history, so a stopped child never arrives formatted as a failure.
+  it('delivers a stopped subagent as cancelled when its flow reports a failure', async () => {
+    const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
+      'lifecycle-subagent-stop-then-failure',
+    );
+    const onError = vi.fn();
+    storageMocks.finalizeExecution.mockClear();
+
+    try {
+      const result = await runFlowWithLifecycle(
+        ctx,
+        async () => {
+          expect(defaultSession().executions.kill(executionId)).toBe(true);
+          throw new Error('child exited with code 143');
+        },
+        { isSubagent: true, onError },
+      );
+
+      expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
+      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
+      expect(storageMocks.finalizeExecution).toHaveBeenCalledWith(
+        expect.objectContaining({
+          terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+        }),
+      );
+      expect(onError).toHaveBeenCalledOnce();
+      expect(onError.mock.calls[0][1]).toEqual(result);
+    } finally {
+      clearStreamStatusForTest(streamStatus, streamId);
+    }
+  });
+
   it('lets a stop/kill tear down a subagent suspended at WAITING (issue #7287)', async () => {
     const { executionId, streamId, ctx } = lifecycleFixture(
       'lifecycle-subagent-waiting-kill',
@@ -632,7 +781,7 @@ describe('runFlowWithLifecycle', () => {
       // as its trace channel.
       const traceEmit = vi.spyOn(noopTrace, 'emit');
 
-      const waitingHandle = takeWaitingHandle(executionId, streamId);
+      const waitingHandle = takeWaitingHandle(executionId);
 
       // runToolUseFlow's finally detaches this stream's interrupt handler but
       // (post #7286) preserves the follow-up queue for WAITING — it does not
@@ -641,7 +790,7 @@ describe('runFlowWithLifecycle', () => {
       // see runToolUseFlow.ts). Before the fix, `executions.kill()`
       // found no interrupt target for a suspended handle and silently
       // no-opped, leaving the handle stuck registered forever. It must now
-      // fall back to the waiting-cleanup registered above and actually tear
+      // fall back to the teardown the WAITING branch parked and actually tear
       // the execution down.
       expect(defaultSession().executions.kill(executionId)).toBe(true);
       await waitingHandle.result;
@@ -730,7 +879,7 @@ describe('runFlowWithLifecycle', () => {
         { isSubagent: true },
       );
       expect(result.outcome).toBe(STREAM_PHASE.WAITING);
-      const waitingHandle = takeWaitingHandle(executionId, streamId);
+      const waitingHandle = takeWaitingHandle(executionId);
 
       expect(defaultSession().executions.kill(executionId)).toBe(true);
       await writerLoadStarted;
@@ -1051,6 +1200,111 @@ describe('finalizeRunTerminal', () => {
           },
         },
       );
+    } finally {
+      clearStreamStatusForTest(streamStatus, streamId);
+    }
+  });
+
+  // The stream phase is the single owner of a run's terminal outcome. A
+  // stop/kill transitions the phase behind the run's back, and the run it
+  // killed then reports its own non-zero exit as a failure — so the phase, not
+  // the report, has to decide, and no caller may cross-check it for itself.
+  it('resolves the terminal outcome from an already-cancelled stream phase', async () => {
+    const executionId = 'exec-finalize-stopped';
+    const streamId = 'stream-finalize-stopped' as StreamTabId;
+    const streamStatus = new StreamStatusMachine();
+    const handle = new AgentExecutionHandle(
+      executionId,
+      streamId,
+      streamId,
+      'test-agent',
+      'toolUse',
+      noopTrace,
+    );
+    const untrack = vi.fn();
+    const stage = { end: vi.fn() };
+    storageMocks.finalizeExecution.mockClear();
+    channelTraceMocks.warn.mockClear();
+
+    try {
+      seedStreamStatusForTest(streamStatus, streamId, STREAM_PHASE.CANCELLED);
+
+      const finalized = await finalizeRunTerminal({
+        handle,
+        executions: { untrack },
+        streamStatus,
+        outcome: RUN_OUTCOME.FAILED,
+        error: { kind: 'unexpected', message: 'exited with code 143' },
+        isSubagent: false,
+        stage,
+        trace: noopTrace,
+        persistence: { kind: 'finalize', flowRecord: 'delete' },
+      });
+
+      expect(finalized?.event).toMatchObject({
+        type: 'result',
+        outcome: RUN_OUTCOME.CANCELLED,
+        executionId,
+        streamId,
+      });
+      // Error facts classified for a failure that the phase says never
+      // happened must not ride the cancelled result.
+      expect(finalized?.event.error).toBeUndefined();
+      await expect(handle.result).resolves.toBe(finalized?.event);
+      expect(stage.end).toHaveBeenCalledExactlyOnceWith(RUN_OUTCOME.CANCELLED);
+      expect(storageMocks.finalizeExecution).toHaveBeenCalledWith(
+        expect.objectContaining({
+          terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+        }),
+      );
+      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
+      // The resolution is what keeps the terminal transition from being
+      // refused, so nothing is left to warn about.
+      expect(channelTraceMocks.warn).not.toHaveBeenCalled();
+    } finally {
+      clearStreamStatusForTest(streamStatus, streamId);
+    }
+  });
+
+  // The same ownership rule in the other direction: a phase that already
+  // published FAILED is a terminal fact a later stop cannot rewrite, so a
+  // caller reporting `cancelled` does not get to relabel it.
+  it('keeps an already-failed stream phase over a later cancelled report', async () => {
+    const executionId = 'exec-finalize-failed-then-stopped';
+    const streamId = 'stream-finalize-failed-then-stopped' as StreamTabId;
+    const streamStatus = new StreamStatusMachine();
+    const handle = new AgentExecutionHandle(
+      executionId,
+      streamId,
+      streamId,
+      'test-agent',
+      'toolUse',
+      noopTrace,
+    );
+    const untrack = vi.fn();
+    channelTraceMocks.warn.mockClear();
+
+    try {
+      seedStreamStatusForTest(streamStatus, streamId, STREAM_PHASE.FAILED);
+
+      const finalized = await finalizeRunTerminal({
+        handle,
+        executions: { untrack },
+        streamStatus,
+        outcome: RUN_OUTCOME.CANCELLED,
+        isSubagent: false,
+        trace: noopTrace,
+        persistence: { kind: 'skip' },
+      });
+
+      expect(finalized?.event).toMatchObject({
+        type: 'result',
+        outcome: RUN_OUTCOME.FAILED,
+        executionId,
+        streamId,
+      });
+      expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.FAILED);
+      expect(channelTraceMocks.warn).not.toHaveBeenCalled();
     } finally {
       clearStreamStatusForTest(streamStatus, streamId);
     }

--- a/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
+++ b/src/test-kernel/agent/runtime/ChildRunLoop.vitest.ts
@@ -14,7 +14,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   finalizeExecution: vi.fn(),
-  synchronizeAgentResultOutcome: vi.fn(),
   persistChildRunReport: vi.fn(),
   persistChildRunResultMeta: vi.fn(),
   deliverChildRunFollowUp: vi.fn(),
@@ -27,7 +26,6 @@ const mocks = vi.hoisted(() => ({
 vi.mock('@agent/storage', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@agent/storage')>()),
   finalizeExecution: mocks.finalizeExecution,
-  synchronizeAgentResultOutcome: mocks.synchronizeAgentResultOutcome,
 }));
 
 vi.mock('@agent/storage/executionLease', async (importOriginal) => ({
@@ -70,13 +68,17 @@ import {
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
 import { AgentExecutionHandle } from '@agent/runtime/ExecutionHandle';
+import type { AgentConfig } from '@agent/core/definition/AgentConfig';
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import {
+  EXECUTION_STATUS,
   STREAM_PHASE,
   type ExecutionId,
   type StreamPhase,
   type StreamTabId,
 } from '@shared/schemas';
 import { AgentCliSessionRegistry } from '@tools/agentCliSessionRegistry';
+import { createChildStream } from '@tools/childStream';
 import {
   ClaudeAgentSessions,
   CodexThreads,
@@ -85,6 +87,12 @@ import { createWorkflowAttemptCostTracker } from '@tools/delegation/workflowScri
 
 let session: SessionHandle;
 const trackedExecutionIds = new Set<string>();
+
+const childStreamConfig = {
+  agentCategory: AgentCategory.ToolUse,
+  model: 'test-model',
+  agent: 'fake-cli',
+} as unknown as AgentConfig;
 
 function uniqueStreamId(label: string): StreamTabId {
   return `${label}-${Math.random().toString(36).slice(2)}` as StreamTabId;
@@ -224,7 +232,6 @@ beforeEach(() => {
     terminalStatusPersisted: true,
     flowRecord: 'deleted',
   });
-  mocks.synchronizeAgentResultOutcome.mockResolvedValue(undefined);
   mocks.persistChildRunReport.mockImplementation(async (_id, msg: string) => {
     return { kind: 'persisted' as const, msg };
   });
@@ -651,7 +658,7 @@ describe('childRunLoop E2E fixtures', () => {
     expect(mocks.deliverChildRunFollowUp).toHaveBeenCalledTimes(1);
   });
 
-  it('stop between turns settles without result sync when terminal metadata fails', async () => {
+  it('stop between turns settles the ghost handle when terminal metadata fails', async () => {
     // Regression: for a native strategy (no ChildStream — each turn owns its
     // own AgentExecutionHandle via runFlowWithLifecycle, not the loop), a
     // stop landing BETWEEN turns interrupts the loop through the run handle
@@ -710,7 +717,14 @@ describe('childRunLoop E2E fixtures', () => {
     // Untracked: no longer resumable — a later delegate_agent(execution_id=…)
     // would correctly report "not found" instead of finding a ghost handle.
     expect(session.executions.getHandle(executionId)).toBeUndefined();
-    expect(mocks.synchronizeAgentResultOutcome).not.toHaveBeenCalled();
+    // The loop routes the cancellation through the durable outcome's only
+    // writer; the interim result envelope is left exactly as its turn wrote
+    // it, and reads project the durable outcome onto it.
+    expect(mocks.finalizeExecution).toHaveBeenCalledWith({
+      executionId,
+      terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+      flowRecord: 'preserve',
+    });
   });
 
   it('reattaches the loop interrupt handler immediately when a turn settles, before delivery (Copilot review: no interrupt gap during delivery)', async () => {
@@ -900,6 +914,56 @@ describe('childRunLoop E2E fixtures', () => {
       }),
     });
     expect(session.executions.getHandle(executionId)).toBeUndefined();
+  });
+
+  it('keeps the failing turn diagnosis when an interrupt lands after the failure', async () => {
+    const executionId = 'fa11ed01' as ExecutionId;
+    const parentStreamId = 'parent' as StreamTabId;
+    const childStream = createChildStream(executionId, parentStreamId, {
+      streamPrefix: 'codex',
+      streamCategory: AgentCategory.ToolUse,
+      runKind: 'agent',
+      agentName: 'fake-cli',
+      description: 'Fail a turn, then take an interrupt',
+      config: childStreamConfig,
+    });
+    trackedExecutionIds.add(executionId);
+    const childStreamId = childStream.childStreamId;
+    const handle = session.executions.getAgentHandleByStream(childStreamId);
+    const { strategy, rejectTurn } = createFakeStrategy();
+    // Fires between the turn failure landing FAILED on the stream phase and
+    // the loop's finalize, so the loop reports an interrupted run for a stream
+    // whose phase already carries the failure.
+    const interruptAfterFailure = vi.fn(() => {
+      mocks.leaseLossListener?.();
+    });
+
+    startChildRunLoop({
+      childStream,
+      childStreamId,
+      parentStreamId,
+      executionId,
+      agentName: 'fake-cli',
+      strategy,
+      recordCost: interruptAfterFailure,
+    });
+
+    await waitForLiveOwner(childStreamId);
+    await rejectTurn(1, new Error('turn blew up'));
+    await waitForLoopEnd(childStreamId);
+
+    expect(interruptAfterFailure).toHaveBeenCalledOnce();
+    expect(session.status.get(childStreamId)).toBe(STREAM_PHASE.FAILED);
+    await expect(handle?.result).resolves.toMatchObject({
+      outcome: 'failed',
+      executionId,
+      error: expect.objectContaining({
+        message: expect.stringContaining('turn blew up'),
+      }),
+    });
+    expect(mocks.finalizeExecution).toHaveBeenCalledWith(
+      expect.objectContaining({ terminalStatus: EXECUTION_STATUS.ERROR }),
+    );
   });
 
   it('recordCost commits exactly once with the greatest observed value', async () => {

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -13,6 +13,7 @@ import {
   AgentExecutionHandle,
   type LiveToolUseFlowContext,
 } from '@agent/runtime/ExecutionHandle';
+import { finalizeRunTerminal } from '@agent/runtime/AgentRunLifecycle';
 import { ExecutionRegistry } from '@agent/runtime/executionRegistry';
 import {
   SessionEventHub,
@@ -43,7 +44,6 @@ import {
 
 const storageMocks = vi.hoisted(() => ({
   finalizeExecution: vi.fn(),
-  synchronizeAgentResultOutcome: vi.fn(),
 }));
 
 const channelTraceMocks = vi.hoisted(() => ({
@@ -53,13 +53,9 @@ const channelTraceMocks = vi.hoisted(() => ({
 vi.mock('@agent/storage', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@agent/storage')>();
   storageMocks.finalizeExecution.mockImplementation(actual.finalizeExecution);
-  storageMocks.synchronizeAgentResultOutcome.mockImplementation(
-    actual.synchronizeAgentResultOutcome,
-  );
   return {
     ...actual,
     finalizeExecution: storageMocks.finalizeExecution,
-    synchronizeAgentResultOutcome: storageMocks.synchronizeAgentResultOutcome,
   };
 });
 
@@ -132,7 +128,7 @@ describe('executionRegistry', () => {
     }
   });
 
-  it('retains an in-progress waiting cleanup after registrations are cleared', async () => {
+  it('lets exactly one stop claim a suspended run and reports its teardown', async () => {
     const handle = createHandle(
       'exec-waiting-cleanup-completion',
       'stream-waiting-cleanup-completion' as StreamTabId,
@@ -142,12 +138,16 @@ describe('executionRegistry', () => {
     const cleanupFinished = new Promise<void>((resolve) => {
       finishCleanup = resolve;
     });
-    handle.registerWaitingCleanup(() => cleanupFinished);
+    handle.suspend(() => cleanupFinished);
 
-    expect(handle.runWaitingCleanup()).toBe(true);
-    handle.clearWaitingCleanup();
+    const teardown = handle.beginSuspendedTermination();
+    expect(teardown).toBeDefined();
+    expect(handle.suspendedTerminationStarted).toBe(true);
+    // A second stop of the same suspended run finds the claim taken, so it
+    // cannot start a second teardown or publish a second terminal outcome.
+    expect(handle.beginSuspendedTermination()).toBeUndefined();
     let observedCompletion = false;
-    const observation = handle.waitForWaitingCleanup().then(() => {
+    const observation = teardown?.then(() => {
       observedCompletion = true;
     });
     await Promise.resolve();
@@ -168,7 +168,7 @@ describe('executionRegistry', () => {
 
     try {
       registry.track(handle);
-      handle.registerWaitingCleanup(() => {});
+      handle.suspend(() => {});
       handle.markExecutionLeaseLost();
       seedStreamStatusForTest(streamStatus, streamId, STREAM_STATUS.WAITING);
 
@@ -313,7 +313,7 @@ describe('executionRegistry', () => {
     }
   });
 
-  it('falls back to a registered waiting-cleanup when a suspended handle has no live interrupt (issue #7287)', async () => {
+  it('falls back to the parked teardown when a suspended handle has no live interrupt (issue #7287)', async () => {
     // Regression: a native subagent suspended at WAITING has already had its
     // live interrupt context detached (runToolUseFlow's finally), while the
     // handle stays tracked for resume. Before the fix, terminate() found no
@@ -329,10 +329,10 @@ describe('executionRegistry', () => {
     try {
       const handle = createHandle(executionId, parentStreamId, childStreamId);
       registry.track(handle);
-      handle.registerWaitingCleanup(cleanup);
+      handle.suspend(cleanup);
       // No handle interrupt target: mirrors a suspended subagent whose live
-      // tool-use session has already been disposed.
-      // Genuinely suspended: only `transitionToWaiting` reaches this status.
+      // tool-use session has already been disposed. The stream phase follows
+      // the same suspension, as it does in production.
       seedStreamStatusForTest(
         streamStatus,
         childStreamId,
@@ -385,7 +385,7 @@ describe('executionRegistry', () => {
         leaseScope,
       });
       registry.track(handle);
-      handle.registerWaitingCleanup(() => {});
+      handle.suspend(() => {});
       // Genuinely suspended: only `transitionToWaiting` reaches this status.
       seedStreamStatusForTest(
         streamStatus,
@@ -445,7 +445,7 @@ describe('executionRegistry', () => {
         childStreamId,
       );
       registry.track(handle);
-      handle.registerWaitingCleanup(async () => {
+      handle.suspend(async () => {
         await cleanupGate;
         order.push('cleanup');
       });
@@ -493,7 +493,7 @@ describe('executionRegistry', () => {
         childStreamId,
       );
       registry.track(previous);
-      previous.registerWaitingCleanup(() => cleanupGate);
+      previous.suspend(() => cleanupGate);
       seedStreamStatusForTest(
         streamStatus,
         childStreamId,
@@ -542,7 +542,7 @@ describe('executionRegistry', () => {
         leaseScope: lostScope,
       });
       registry.track(previous);
-      previous.registerWaitingCleanup(() => undefined);
+      previous.suspend(() => undefined);
       seedStreamStatusForTest(streamStatus, streamId, STREAM_STATUS.WAITING);
 
       expect(registry.kill(executionId)).toBe(true);
@@ -577,7 +577,7 @@ describe('executionRegistry', () => {
         childStreamId,
       );
       registry.track(handle);
-      handle.registerWaitingCleanup(() => {});
+      handle.suspend(() => {});
       seedStreamStatusForTest(
         streamStatus,
         childStreamId,
@@ -610,13 +610,12 @@ describe('executionRegistry', () => {
       terminalStatusPersisted: false,
       error: durabilityError,
     });
-    storageMocks.synchronizeAgentResultOutcome.mockClear();
     channelTraceMocks.warn.mockClear();
 
     try {
       const handle = createHandle(executionId, parentStreamId, childStreamId);
       registry.track(handle);
-      handle.registerWaitingCleanup(() => {});
+      handle.suspend(() => {});
       seedStreamStatusForTest(
         streamStatus,
         childStreamId,
@@ -645,7 +644,6 @@ describe('executionRegistry', () => {
           },
         );
       });
-      expect(storageMocks.synchronizeAgentResultOutcome).not.toHaveBeenCalled();
     } finally {
       registry.dispose();
     }
@@ -663,13 +661,12 @@ describe('executionRegistry', () => {
       terminalStatusPersisted: true,
       flowRecord: 'deleted',
     });
-    storageMocks.synchronizeAgentResultOutcome.mockResolvedValueOnce(undefined);
     channelTraceMocks.warn.mockClear();
 
     try {
       const handle = createHandle(executionId, parentStreamId, childStreamId);
       registry.track(handle);
-      handle.registerWaitingCleanup(() => Promise.reject(cleanupError));
+      handle.suspend(() => Promise.reject(cleanupError));
       seedStreamStatusForTest(
         streamStatus,
         childStreamId,
@@ -695,7 +692,7 @@ describe('executionRegistry', () => {
     }
   });
 
-  it('synchronizes a waiting stop when only flow-record deletion fails', async () => {
+  it('persists a waiting stop when only flow-record deletion fails', async () => {
     const streamStatus = new StreamStatusMachine();
     const registry = new ExecutionRegistry({ streamStatus });
     const executionId = 'exec-waiting-kill-flow-delete-failure' as ExecutionId;
@@ -710,14 +707,12 @@ describe('executionRegistry', () => {
       terminalStatusPersisted: true,
       error: cleanupError,
     });
-    storageMocks.synchronizeAgentResultOutcome.mockResolvedValueOnce(undefined);
-    storageMocks.synchronizeAgentResultOutcome.mockClear();
     channelTraceMocks.warn.mockClear();
 
     try {
       const handle = createHandle(executionId, parentStreamId, childStreamId);
       registry.track(handle);
-      handle.registerWaitingCleanup(() => {});
+      handle.suspend(() => {});
       seedStreamStatusForTest(
         streamStatus,
         childStreamId,
@@ -727,9 +722,12 @@ describe('executionRegistry', () => {
       expect(registry.kill(executionId)).toBe(true);
 
       await vi.waitFor(() => {
-        expect(
-          storageMocks.synchronizeAgentResultOutcome,
-        ).toHaveBeenCalledExactlyOnceWith(executionId, RUN_OUTCOME.CANCELLED);
+        expect(storageMocks.finalizeExecution).toHaveBeenCalledWith({
+          executionId,
+          terminalStatus: projectRunOutcome(RUN_OUTCOME.CANCELLED)
+            .executionStatus,
+          flowRecord: 'delete',
+        });
       });
       expect(channelTraceMocks.warn).toHaveBeenCalledExactlyOnceWith(
         'Failed to finalize stopped waiting execution',
@@ -747,12 +745,11 @@ describe('executionRegistry', () => {
     }
   });
 
-  it('reports a failed kill for a tracked handle with neither an interrupt nor a waiting-cleanup', () => {
-    // Guards the fallback above: a handle that never registered a
-    // waiting-cleanup (i.e. was never confirmed suspended at WAITING) must
-    // still no-op exactly like before the fix — otherwise the fallback could
-    // spuriously tear down a handle mid-completion, in the narrow window
-    // between its own interrupt unregister and its own untrack.
+  it('reports a failed kill for a tracked handle with neither an interrupt nor a suspension', () => {
+    // Guards the fallback above: a handle that never parked must still no-op
+    // exactly like before the fix — otherwise the fallback could spuriously
+    // tear down a handle mid-completion, in the narrow window between its own
+    // interrupt unregister and its own untrack.
     const streamStatus = new StreamStatusMachine();
     const registry = new ExecutionRegistry({ streamStatus });
     const executionId = 'exec-no-cleanup-kill-test';
@@ -772,38 +769,101 @@ describe('executionRegistry', () => {
     }
   });
 
-  it('does not abandon a handle with a stale waiting-cleanup when the stream never actually reached WAITING (review: waiting cleanup on non-suspend paths)', () => {
-    // A registered waiting-cleanup alone does not prove genuine suspension —
-    // if a registrant ever registers one without the flow actually
-    // transitioning to WAITING (streamStatus stays whatever it was), and a
-    // kill lands in the narrow window between that turn's interrupt-
-    // unregister and its handle's normal untrack, terminate() must not
-    // mistake the stale registered cleanup for a genuine suspension and
-    // incorrectly abandon/cancel a run that is still executing or has
-    // already completed. `runFlowWithLifecycle` is the only registrant today
-    // (see AgentRunLifecycle.ts) and only registers after `streamStatus` has
-    // already reached WAITING, so this guard is defensive against any future
-    // registrant that doesn't hold that invariant.
+  it('leaves a never-suspended handle alone even while its stream reads WAITING', () => {
+    // The handle owns the suspension fact; the stream phase is only a
+    // projection of it. A stop landing in the narrow window between a live
+    // turn's interrupt-handler detach and its own untrack must not abandon a
+    // run that never parked, no matter what phase the stream currently shows.
     const streamStatus = new StreamStatusMachine();
     const registry = new ExecutionRegistry({ streamStatus });
-    const executionId = 'exec-non-suspend-stale-cleanup-test';
+    const executionId = 'exec-never-suspended-phase-only-test';
     const parentStreamId =
-      'parent-non-suspend-stale-cleanup-test' as StreamTabId;
-    const childStreamId = 'child-non-suspend-stale-cleanup-test' as StreamTabId;
-    const cleanup = vi.fn();
+      'parent-never-suspended-phase-only-test' as StreamTabId;
+    const childStreamId =
+      'child-never-suspended-phase-only-test' as StreamTabId;
 
     try {
       const handle = createHandle(executionId, parentStreamId, childStreamId);
       registry.track(handle);
-      // A cleanup gets registered directly here, simulating any registrant
-      // that registers one without the flow actually suspending — streamStatus
-      // was never transitioned to WAITING (no `transitionToWaiting` call).
-      handle.registerWaitingCleanup(cleanup);
+      seedStreamStatusForTest(
+        streamStatus,
+        childStreamId,
+        STREAM_STATUS.WAITING,
+      );
 
       expect(registry.kill(executionId)).toBe(false);
 
-      expect(cleanup).not.toHaveBeenCalled();
       expect(registry.getHandle(executionId)).toBe(handle);
+      expect(streamStatus.get(childStreamId)).toBe(STREAM_STATUS.WAITING);
+    } finally {
+      registry.dispose();
+    }
+  });
+
+  it('refuses a waiting stop once a terminal finalize has claimed the run', async () => {
+    // Both terminal writers claim the same gate, so a kill landing while
+    // `finalizeRunTerminal` is parked at its persist await cannot run the
+    // suspended teardown, publish a second `result`, or persist a second
+    // terminal status over the finalizer's outcome.
+    const streamStatus = new StreamStatusMachine();
+    const registry = new ExecutionRegistry({ streamStatus });
+    const executionId = 'exec-waiting-stop-after-claim' as ExecutionId;
+    const childStreamId = 'child-waiting-stop-after-claim' as StreamTabId;
+    const teardown = vi.fn();
+    storageMocks.finalizeExecution.mockClear();
+    let releasePersist: (() => void) | undefined;
+    storageMocks.finalizeExecution.mockImplementationOnce(
+      async () =>
+        new Promise((resolve) => {
+          releasePersist = () =>
+            resolve({
+              status: 'durable',
+              terminalStatusPersisted: true,
+              flowRecord: 'deleted',
+            });
+        }),
+    );
+
+    try {
+      const handle = createHandle(
+        executionId,
+        'parent-waiting-stop-after-claim' as StreamTabId,
+        childStreamId,
+      );
+      registry.track(handle);
+      handle.suspend(teardown);
+      seedStreamStatusForTest(
+        streamStatus,
+        childStreamId,
+        STREAM_STATUS.WAITING,
+      );
+
+      const finalized = finalizeRunTerminal({
+        handle,
+        executions: registry,
+        streamStatus,
+        outcome: RUN_OUTCOME.COMPLETED,
+        isSubagent: true,
+        persistence: { kind: 'finalize', flowRecord: 'delete' },
+      });
+      await vi.waitFor(() => expect(releasePersist).toBeDefined());
+
+      expect(registry.kill(executionId)).toBe(false);
+
+      releasePersist?.();
+      await finalized;
+      expect(teardown).not.toHaveBeenCalled();
+      await expect(handle.result).resolves.toMatchObject({
+        outcome: RUN_OUTCOME.COMPLETED,
+      });
+      expect(storageMocks.finalizeExecution).toHaveBeenCalledExactlyOnceWith({
+        executionId,
+        terminalStatus: projectRunOutcome(RUN_OUTCOME.COMPLETED)
+          .executionStatus,
+        flowRecord: 'delete',
+      });
+      expect(registry.getHandle(executionId)).toBeUndefined();
+      expect(streamStatus.get(childStreamId)).toBe(STREAM_PHASE.COMPLETED);
     } finally {
       registry.dispose();
     }
@@ -812,11 +872,9 @@ describe('executionRegistry', () => {
   it('tears down and aligns a suspended handle killed during RESUMING', async () => {
     // Regression: `resumeQueuedToolUseFromResumeData` flips `streamStatus` to
     // RUNNING with a RESUMING substate *before* the resumed run installs its
-    // own interrupt context. A kill landing in that window would otherwise
-    // find this same still-suspended handle (its waiting-cleanup from the
-    // earlier genuine WAITING suspension is still registered) but a
-    // non-WAITING phase, and get wrongly no-opped by the WAITING-only guard
-    // above — silently ignoring a stop the user actually issued.
+    // own interrupt context. The handle it is resuming is still parked from
+    // the earlier genuine WAITING suspension, so a kill landing in that window
+    // tears it down off that fact alone — no phase or substate is consulted.
     const streamStatus = new StreamStatusMachine();
     const registry = new ExecutionRegistry({ streamStatus });
     const executionId = 'exec-resuming-window-kill-test' as ExecutionId;
@@ -844,7 +902,7 @@ describe('executionRegistry', () => {
       });
       const handle = createHandle(executionId, parentStreamId, childStreamId);
       registry.track(handle);
-      handle.registerWaitingCleanup(cleanup);
+      handle.suspend(cleanup);
       // Mirrors resumeQueuedToolUseFromResumeData's status flip that runs ahead of
       // the resumed run's own context — RUNNING phase, RESUMING substate.
       seedStreamStatusForTest(

--- a/src/test-kernel/agent/runtime/RestartRepair.vitest.ts
+++ b/src/test-kernel/agent/runtime/RestartRepair.vitest.ts
@@ -403,7 +403,6 @@ describe('repairRestartedStreams', () => {
     seedRunning(streamStatus, streamId);
     const closeRunningGroups = closeGroupsOn(RUN_OUTCOME.FAILED);
     const finalizeExecution = createDurableFinalizer();
-    const synchronizeResultOutcome = vi.fn(async () => undefined);
 
     const result = await repairRestartedStreams({
       streamStatus,
@@ -411,7 +410,6 @@ describe('repairRestartedStreams', () => {
       executionIds: new Map([[streamId, executionId]]),
       closeRunningGroups,
       finalizeExecution,
-      synchronizeResultOutcome,
       now: 456,
     });
 
@@ -433,10 +431,6 @@ describe('repairRestartedStreams', () => {
       terminalStatus: EXECUTION_STATUS.ERROR,
       flowRecord: 'delete',
     });
-    expect(synchronizeResultOutcome).toHaveBeenCalledWith(
-      executionId,
-      RUN_OUTCOME.FAILED,
-    );
   });
 
   it('does not write failed terminal meta before failed groups close', async () => {
@@ -476,7 +470,6 @@ describe('repairRestartedStreams', () => {
       return streamIds;
     });
     const finalizeExecution = createDurableFinalizer();
-    const synchronizeResultOutcome = vi.fn(async () => undefined);
 
     const result = await repairRestartedStreams({
       streamStatus,
@@ -488,7 +481,6 @@ describe('repairRestartedStreams', () => {
       repairStreams: [firstStream, secondStream],
       closeRunningGroups,
       finalizeExecution,
-      synchronizeResultOutcome,
       signal: abort.signal,
       runWithInactiveExecutionLease: performInactiveLease,
     });
@@ -499,10 +491,6 @@ describe('repairRestartedStreams', () => {
       terminalStatus: EXECUTION_STATUS.ERROR,
       flowRecord: 'delete',
     });
-    expect(synchronizeResultOutcome).toHaveBeenCalledWith(
-      firstExecution,
-      RUN_OUTCOME.FAILED,
-    );
     expect(result.failedStreams).toEqual([firstStream]);
     expect(streamStatus.get(secondStream)).toBe(STREAM_PHASE.RUNNING);
     expect(finalizeExecution).toHaveBeenCalledOnce();
@@ -593,7 +581,7 @@ describe('repairRestartedStreams', () => {
     expect(finalizeExecution).not.toHaveBeenCalled();
   });
 
-  it('does not report or synchronize terminal status when metadata persistence fails', async () => {
+  it('does not report terminal status when metadata persistence fails', async () => {
     const streamId = 'stream-metadata-failure' as StreamTabId;
     const executionId = 'execution-metadata-failure' as ExecutionId;
     const streamStatus = new StreamStatusMachine();
@@ -605,7 +593,6 @@ describe('repairRestartedStreams', () => {
       terminalStatusPersisted: false as const,
       error: durabilityError,
     }));
-    const synchronizeResultOutcome = vi.fn(async () => undefined);
     const logger = { debug: vi.fn(), warn: vi.fn() };
 
     const result = await repairRestartedStreams({
@@ -614,13 +601,11 @@ describe('repairRestartedStreams', () => {
       executionIds: new Map([[streamId, executionId]]),
       closeRunningGroups: async (streamIds) => [...streamIds],
       finalizeExecution,
-      synchronizeResultOutcome,
       logger,
     });
 
     expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.FAILED);
     expect(result.terminalStatusUpdated).toEqual([]);
-    expect(synchronizeResultOutcome).not.toHaveBeenCalled();
     expect(logger.warn).toHaveBeenCalledExactlyOnceWith(
       'Failed to finalize restart-repair execution',
       {
@@ -635,7 +620,7 @@ describe('repairRestartedStreams', () => {
     );
   });
 
-  it('reports flow cleanup failure but synchronizes durable terminal metadata', async () => {
+  it('reports flow cleanup failure but keeps durable terminal metadata', async () => {
     const streamId = 'stream-flow-delete-failure' as StreamTabId;
     const executionId = 'execution-flow-delete-failure' as ExecutionId;
     const streamStatus = new StreamStatusMachine();
@@ -647,7 +632,6 @@ describe('repairRestartedStreams', () => {
       terminalStatusPersisted: true as const,
       error: cleanupError,
     }));
-    const synchronizeResultOutcome = vi.fn(async () => undefined);
     const logger = { debug: vi.fn(), warn: vi.fn() };
 
     const result = await repairRestartedStreams({
@@ -656,15 +640,10 @@ describe('repairRestartedStreams', () => {
       executionIds: new Map([[streamId, executionId]]),
       closeRunningGroups: async (streamIds) => [...streamIds],
       finalizeExecution,
-      synchronizeResultOutcome,
       logger,
     });
 
     expect(result.terminalStatusUpdated).toEqual([executionId]);
-    expect(synchronizeResultOutcome).toHaveBeenCalledExactlyOnceWith(
-      executionId,
-      RUN_OUTCOME.FAILED,
-    );
     expect(logger.warn).toHaveBeenCalledExactlyOnceWith(
       'Failed to finalize restart-repair execution',
       {
@@ -697,7 +676,7 @@ describe('repairRestartedStreams', () => {
     expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.FAILED);
   });
 
-  it('writes failed execution metadata through the default lifecycle hook', async () => {
+  it('writes failed execution metadata that supersedes an interim result', async () => {
     const streamId = 'stream-real-meta' as StreamTabId;
     const executionId = 'execution-real-meta' as ExecutionId;
     const store = getExecutionStore(executionId);

--- a/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
+++ b/src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   abandonOwnedExecutionLease: vi.fn(),
   buildAgentLaunchContext: vi.fn(),
+  clearTerminalExecutionState: vi.fn(),
   hasPersistedParent: vi.fn(),
   invokeModelOrTool: vi.fn(),
   runFlowWithLifecycle: vi.fn(),
@@ -50,6 +51,7 @@ vi.mock('@agent/runtime/AgentRunLifecycle', () => ({
 }));
 
 vi.mock('@agent/storage/executionLifecycle', () => ({
+  clearTerminalExecutionState: mocks.clearTerminalExecutionState,
   hasPersistedParent: mocks.hasPersistedParent,
 }));
 
@@ -134,10 +136,67 @@ describe('resumeToolUseFromResumeData cancellation handoff', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.acquireResumedExecutionLease.mockResolvedValue('existing');
+    mocks.clearTerminalExecutionState.mockResolvedValue(undefined);
     mocks.releaseOwnedExecutionLeaseAfterFailure.mockImplementation(
       async (_executionId: ExecutionId, error: unknown) => error,
     );
     mocks.completeOwnedExecutionLease.mockResolvedValue(undefined);
+  });
+
+  // The predecessor run's terminal outcome is projected onto every result
+  // envelope read back (`applyExecutionOutcome`), so it has to be gone before
+  // the resumed run can write a turn of its own.
+  it('clears the previous run terminal facts before the resumed run starts', async () => {
+    const executionId = 'e9503-boundary' as ExecutionId;
+    const streamId = 'stream-9503-boundary' as StreamTabId;
+    const order: string[] = [];
+    mocks.clearTerminalExecutionState.mockImplementationOnce(async () => {
+      order.push('clear');
+    });
+    mocks.buildAgentLaunchContext.mockImplementationOnce(async () => {
+      order.push('launch');
+      return buildResumeContext(executionId, streamId, {
+        setModelInfo: vi.fn(),
+      });
+    });
+    mocks.hasPersistedParent.mockResolvedValueOnce(true);
+    mocks.runFlowWithLifecycle.mockImplementationOnce(
+      async (
+        _context: unknown,
+        run: (liveHandle: unknown) => Promise<unknown>,
+      ) => run(noopFlowHandle()),
+    );
+    mocks.runToolUseFlow.mockImplementationOnce(async () => {
+      order.push('flow');
+      return { outcome: RUN_OUTCOME.COMPLETED };
+    });
+
+    await resumeToolUseFromResumeData(
+      createToolUseResumeData({ executionId, streamId }),
+    );
+
+    expect(mocks.clearTerminalExecutionState).toHaveBeenCalledWith(executionId);
+    expect(order).toEqual(['clear', 'launch', 'flow']);
+  });
+
+  it('releases the resumed lease when the terminal-fact clear fails', async () => {
+    const storageError = new Error('meta write failed');
+    const snapshot = createToolUseResumeData({
+      executionId: 'e9503-boundary-failure' as ExecutionId,
+      streamId: 'stream-9503-boundary-failure' as StreamTabId,
+    });
+    mocks.clearTerminalExecutionState.mockRejectedValueOnce(storageError);
+
+    await expect(resumeToolUseFromResumeData(snapshot)).rejects.toBe(
+      storageError,
+    );
+
+    expect(mocks.hasPersistedParent).not.toHaveBeenCalled();
+    expect(mocks.buildAgentLaunchContext).not.toHaveBeenCalled();
+    expect(mocks.releaseOwnedExecutionLeaseAfterFailure).toHaveBeenCalledWith(
+      snapshot.executionId,
+      storageError,
+    );
   });
 
   it('resolves execution lineage before activating the resume stream', async () => {

--- a/src/test-kernel/agent/runtime/RunAgentOwnership.vitest.ts
+++ b/src/test-kernel/agent/runtime/RunAgentOwnership.vitest.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   abandonOwnedExecutionLease: vi.fn(),
   renewOwnedExecutionLease: vi.fn(),
   acquireResumedExecutionLease: vi.fn(),
+  clearTerminalExecutionState: vi.fn(),
   executeAgent: vi.fn(),
   finalizeExecution: vi.fn(),
   markOwnedExecutionLeaseUndurable: vi.fn(),
@@ -31,6 +32,10 @@ vi.mock('@agent/storage/executionLease', () => ({
   ) => operation(),
 }));
 
+vi.mock('@agent/storage/executionLifecycle', () => ({
+  clearTerminalExecutionState: mocks.clearTerminalExecutionState,
+}));
+
 vi.mock('@agent/runtime/executeAgent', () => ({
   executeAgent: mocks.executeAgent,
 }));
@@ -53,6 +58,7 @@ describe('runAgent execution ownership', () => {
     vi.clearAllMocks();
     mocks.registerExecution.mockResolvedValue(undefined);
     mocks.acquireResumedExecutionLease.mockResolvedValue('acquired');
+    mocks.clearTerminalExecutionState.mockResolvedValue(undefined);
     mocks.completeOwnedExecutionLease.mockResolvedValue(undefined);
     mocks.renewOwnedExecutionLease.mockResolvedValue(undefined);
     flushArtifacts.mockResolvedValue(undefined);
@@ -96,6 +102,44 @@ describe('runAgent execution ownership', () => {
     expect(mocks.completeOwnedExecutionLease).toHaveBeenCalledWith(
       EXECUTION_ID,
     );
+  });
+
+  // A workflow resume reuses the execution record, so the previous run's
+  // terminal outcome is still on disk and would be projected onto every result
+  // envelope this run writes (`applyExecutionOutcome`) until it finalizes.
+  it('clears the previous run terminal facts before a resumed run executes', async () => {
+    const order: string[] = [];
+    mocks.clearTerminalExecutionState.mockImplementationOnce(async () => {
+      order.push('clear');
+    });
+    mocks.executeAgent.mockImplementationOnce(async () => {
+      order.push('execute');
+      return {
+        category: 'toolUse',
+        executionId: EXECUTION_ID,
+        streamId: EXECUTION_ID,
+        outcome: 'COMPLETED',
+      };
+    });
+
+    await runAgent(
+      { config: CONFIG, executionId: EXECUTION_ID },
+      { session: SESSION },
+    );
+
+    expect(mocks.clearTerminalExecutionState).toHaveBeenCalledWith(
+      EXECUTION_ID,
+    );
+    expect(order).toEqual(['clear', 'execute']);
+  });
+
+  it('leaves a freshly registered run without a terminal-fact clear', async () => {
+    await runAgent(
+      { config: CONFIG, executionId: EXECUTION_ID },
+      { session: SESSION, registerExecution: true },
+    );
+
+    expect(mocks.clearTerminalExecutionState).not.toHaveBeenCalled();
   });
 
   it('abandons a resume whose canonical admission is withdrawn under the lease lock', async () => {

--- a/src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts
+++ b/src/test-kernel/agent/storage/ExecutionKVStore.vitest.ts
@@ -13,7 +13,9 @@ import {
   EXECUTION_META_SCHEMA_VERSION,
   getExecutionStore,
   isReservedKvKeyName,
+  type ResultMeta,
 } from '@agent/storage';
+import { clearTerminalExecutionState } from '@agent/storage/executionLifecycle';
 import * as logger from '@logger/logUtils';
 import {
   EXECUTION_STATUS,
@@ -228,10 +230,6 @@ describe('ExecutionKVStore meta read shims', () => {
         touchedFiles: ['notes.md'],
       },
     };
-    await getExecutionStore(id).write('meta', {
-      timestamp: '2026-07-04T00:00:00.000Z',
-      outcome: RUN_OUTCOME.FAILED,
-    });
     await getExecutionStore(id).write('config', {
       agent: 'writer',
       model: 'gpt5',
@@ -315,6 +313,145 @@ describe('ExecutionKVStore meta read shims', () => {
         cost: 0,
       },
     });
+  });
+
+  // `meta.outcome` is the only writer of "how did this run end". These pin the
+  // case a repair pass used to fix up with a second write after the fact: a run
+  // that ends after its last turn wrote an interim envelope (interrupted
+  // between turns, stopped while suspended, failed by restart repair) now reads
+  // back through the owning fact instead.
+  it('supersedes an interim result outcome with the durable cancelled outcome', async () => {
+    const id = 'terminal-outcome-supersedes-interim' as ExecutionId;
+    const interim = {
+      producer: 'subagent',
+      agentName: 'reviewer',
+      wallTimeMs: 20,
+      result: {
+        category: 'toolUse',
+        outcome: RUN_OUTCOME.COMPLETED,
+        response: 'Interim result.',
+        files: [],
+        cost: 0.1,
+      },
+    };
+    await getExecutionStore(id).write('result-meta', interim);
+    await getExecutionStore(id).write('meta', {
+      timestamp: '2026-07-04T00:00:00.000Z',
+      terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+      outcome: RUN_OUTCOME.CANCELLED,
+    });
+
+    await expect(getExecutionStore(id).readResultMeta()).resolves.toEqual({
+      ...interim,
+      result: { ...interim.result, outcome: RUN_OUTCOME.CANCELLED },
+    });
+    // Read-time projection only: the turn-owned record is never rewritten, so
+    // a later turn's own write still lands on an untouched envelope.
+    await expect(getExecutionStore(id).read('result-meta')).resolves.toEqual(
+      interim,
+    );
+  });
+
+  it('keeps a producer failure signal when the execution completed', async () => {
+    const id = 'terminal-outcome-keeps-failure' as ExecutionId;
+    await getExecutionStore(id).write('result-meta', {
+      producer: 'subagent',
+      agentName: 'reviewer',
+      wallTimeMs: 20,
+      result: {
+        category: 'toolUse',
+        outcome: RUN_OUTCOME.FAILED,
+        response: 'The subagent reported an error.',
+        files: [],
+        cost: 0.1,
+      },
+    });
+    await getExecutionStore(id).write('meta', {
+      timestamp: '2026-07-04T00:00:00.000Z',
+      terminalStatus: EXECUTION_STATUS.COMPLETED,
+      outcome: RUN_OUTCOME.COMPLETED,
+    });
+
+    await expect(getExecutionStore(id).readResultMeta()).resolves.toMatchObject(
+      { result: { outcome: RUN_OUTCOME.FAILED } },
+    );
+  });
+
+  it('keeps the record outcome while the execution has no terminal outcome', async () => {
+    const id = 'terminal-outcome-absent' as ExecutionId;
+    await getExecutionStore(id).write('result-meta', {
+      producer: 'subagent',
+      agentName: 'reviewer',
+      wallTimeMs: 20,
+      result: {
+        category: 'toolUse',
+        outcome: RUN_OUTCOME.COMPLETED,
+        response: 'Waiting for the next turn.',
+        files: [],
+        cost: 0.1,
+      },
+    });
+    await getExecutionStore(id).write('meta', {
+      timestamp: '2026-07-04T00:00:00.000Z',
+    });
+
+    await expect(getExecutionStore(id).readResultMeta()).resolves.toMatchObject(
+      { result: { outcome: RUN_OUTCOME.COMPLETED } },
+    );
+  });
+
+  // The resume boundary is what keeps the projection honest: a stopped run
+  // with a preserved flow record is resumable (`deriveResumability`), and the
+  // resumed turns write their own envelopes. Without the boundary clear, the
+  // interrupted predecessor's outcome would relabel every one of them.
+  it('serves the resumed turn outcome once the resume boundary clears the terminal facts', async () => {
+    const id = 'terminal-outcome-resume-boundary' as ExecutionId;
+    const interim = {
+      producer: 'subagent',
+      agentName: 'reviewer',
+      wallTimeMs: 20,
+      result: {
+        category: 'toolUse',
+        outcome: RUN_OUTCOME.COMPLETED,
+        response: 'Interim result before the stop.',
+        files: [],
+        cost: 0.1,
+      },
+    } satisfies ResultMeta;
+    await getExecutionStore(id).write('result-meta', interim);
+    await getExecutionStore(id).write('meta', {
+      timestamp: '2026-07-04T00:00:00.000Z',
+      terminalStatus: EXECUTION_STATUS.INTERRUPTED,
+      outcome: RUN_OUTCOME.CANCELLED,
+    });
+    await expect(getExecutionStore(id).readResultMeta()).resolves.toMatchObject(
+      { result: { outcome: RUN_OUTCOME.CANCELLED } },
+    );
+
+    await clearTerminalExecutionState(id);
+    await getExecutionStore(id).writeResultMeta({
+      ...interim,
+      result: {
+        ...interim.result,
+        response: 'Interim result from the resumed turn.',
+      },
+    });
+
+    await expect(getExecutionStore(id).readResultMeta()).resolves.toMatchObject(
+      { result: { outcome: RUN_OUTCOME.COMPLETED } },
+    );
+    await expect(getExecutionStore(id).readMeta()).resolves.toEqual({
+      schemaVersion: EXECUTION_META_SCHEMA_VERSION,
+      timestamp: '2026-07-04T00:00:00.000Z',
+    });
+  });
+
+  it('leaves an execution with no persisted metadata untouched at the resume boundary', async () => {
+    const id = 'terminal-outcome-resume-no-meta' as ExecutionId;
+
+    await expect(clearTerminalExecutionState(id)).resolves.toBeUndefined();
+
+    await expect(getExecutionStore(id).readMeta()).resolves.toBeNull();
   });
 
   it('infers category for legacy subagent result metadata with no category tag (workflow fields)', async () => {

--- a/src/test-kernel/cli/TerminalCleanup.vitest.mts
+++ b/src/test-kernel/cli/TerminalCleanup.vitest.mts
@@ -3,10 +3,7 @@ import { writeSync } from 'node:fs';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { terminalCapabilities } from '@cli/chat/tui/state/terminalCapabilities';
-import {
-  approvalQueueStatus,
-  clearApprovals,
-} from '@cli/chat/tui/state/approvalQueue';
+import { approvalQueueStatus } from '@cli/chat/tui/state/approvalQueue';
 import {
   resetCliState,
   rootRunPending,
@@ -38,7 +35,9 @@ const NO_TERMINAL_CAPABILITIES = {
 };
 
 afterEach(() => {
-  clearApprovals();
+  // These cases drive the title from the projected approval status directly,
+  // without queueing an approval, so reset what they wrote.
+  approvalQueueStatus.set({ depth: 0, kind: 'approval' });
   resetCliState();
   vi.restoreAllMocks();
   // `writeSync` is a vi.fn() created inside the vi.mock() factory above, not

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
@@ -20,11 +20,27 @@ const mocks = vi.hoisted(() => ({
   preferSubscription: true,
   notify: vi.fn(),
   openRouter: false,
+  retryCopyFailure: undefined as Error | undefined,
   secrets: {},
   setCliApiMode: vi.fn(),
   setCliCodexSubscription: vi.fn(),
   updateGlobalState: vi.fn(),
 }));
+
+// Injection point for a pre-modal preparation failure: the retry copy is read
+// while the request is still being assembled, before the modal can be shown.
+vi.mock('@cli/tui/ui/retryCopy', async (importActual) => {
+  const actual = await importActual<typeof import('@cli/tui/ui/retryCopy')>();
+  return {
+    ...actual,
+    missingApiKeyRetryMessage: (
+      ...args: Parameters<typeof actual.missingApiKeyRetryMessage>
+    ): string => {
+      if (mocks.retryCopyFailure) throw mocks.retryCopyFailure;
+      return actual.missingApiKeyRetryMessage(...args);
+    },
+  };
+});
 
 vi.mock('@model/codex/codexPreference', () => ({
   isPreferCodexSubscription: () => mocks.preferSubscription,
@@ -78,6 +94,7 @@ import type {
 } from '@agent/runtime/HostInteractions';
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import {
+  approvalQueueStatus,
   clearApprovals,
   currentApproval,
   enqueueApproval,
@@ -93,6 +110,7 @@ import {
 import { createTuiHostInteractions } from '@cli/chat/tui/state/subscribeApprovals';
 import type { CliContext } from '@cli/runtime/cliContext';
 import type { CliRuntimeHost } from '@cli/runtime/cliPresentationHost';
+import { hasCliApprovalDenied } from '@cli/runtime/approvalAdapter';
 import type { ApiProvider } from '@model/apiProviders';
 import { AgentCategory, type RetryPermission } from '@shared/schemas';
 import { GlobalStateKey } from '@shared/state/stateKeys';
@@ -174,8 +192,8 @@ function relayRetry(params: {
   } as RetryPermission;
 }
 
-/** Relay retry on the shared `same-stream` route the route-replacement cases
- *  below queue two requests against. */
+/** Relay retry on the shared `same-stream` stream the replacement cases below
+ *  queue two requests against. */
 function requestSameStreamRetry(
   interactions: HostInteractions,
   message: string,
@@ -273,6 +291,7 @@ afterEach(() => {
   clearApprovals();
   cleanupAllApprovals();
   resetCliState();
+  mocks.retryCopyFailure = undefined;
   mocks.apiKeyExistsUncached.mockReset();
   mocks.hasUsableApiKey.mockReset();
   mocks.invalidateApiKeyCache.mockReset();
@@ -1071,6 +1090,72 @@ describe('TUI retry approvals', () => {
     expect(mocks.setCliCodexSubscription).not.toHaveBeenCalled();
   });
 
+  it('holds a preparing retry out of the queue, then joins behind the open modal', async () => {
+    let resolveLookup: ((value: boolean) => void) | undefined;
+    mocks.hasUsableApiKey.mockImplementation(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveLookup = resolve;
+        }),
+    );
+
+    const { interactions } = tui();
+    const retry = interactions.requestRetry?.(
+      relayRetry({ streamId: 'preparing-stream', provider: 'openai' }),
+    );
+    const bash = interactions.requestBashApproval?.({
+      command: 'echo ok',
+      streamId: 'bash-stream',
+    });
+
+    await waitForApproval('bash', { streamId: 'bash-stream' });
+    // The retry owns a queue slot from the moment it is requested, but it is
+    // not a request the user can act on until its key lookup finishes.
+    expect(approvalQueueStatus.get().depth).toBe(1);
+    expect(pendingApprovalSummaries.get()).toEqual([
+      { streamKey: 'bash-stream', kind: 'bash' },
+    ]);
+
+    resolveLookup?.(false);
+    await vi.waitFor(() => {
+      expect(pendingApprovalSummaries.get()).toEqual([
+        { streamKey: 'bash-stream', kind: 'bash' },
+        { streamKey: 'preparing-stream', kind: 'retry' },
+      ]);
+    });
+    // It joined behind the modal the user is already answering.
+    expect(currentApproval.get()?.payload).toMatchObject({ kind: 'bash' });
+
+    currentApproval.get()?.decide({ accepted: true });
+    await expect(bash).resolves.toEqual({ action: 'approve' });
+    await waitForApproval('retry', { streamId: 'preparing-stream' });
+    decideRetry({ accepted: false });
+    await expect(retry).resolves.toEqual({ action: 'cancel' });
+  });
+
+  it('records an approval denial for a refused retry but not for a cleared one', async () => {
+    mocks.hasUsableApiKey.mockResolvedValue(false);
+
+    const { cliContext, interactions } = tui();
+    const cleared = interactions.requestRetry?.(
+      relayRetry({ streamId: 'cleared-retry', provider: 'openai' }),
+    );
+    await waitForApproval('retry', { streamId: 'cleared-retry' });
+    clearApprovals();
+
+    await expect(cleared).resolves.toEqual({ action: 'cancel' });
+    expect(hasCliApprovalDenied(cliContext)).toBe(false);
+
+    const refused = interactions.requestRetry?.(
+      relayRetry({ streamId: 'refused-retry', provider: 'openai' }),
+    );
+    await waitForApproval('retry', { streamId: 'refused-retry' });
+    decideRetry({ accepted: false });
+
+    await expect(refused).resolves.toEqual({ action: 'cancel' });
+    expect(hasCliApprovalDenied(cliContext)).toBe(true);
+  });
+
   it('cancels ordinary retry preparation after approval', async () => {
     const ordinaryPrepare = vi.fn(
       async (_selection, _signal?: AbortSignal) =>
@@ -1091,6 +1176,10 @@ describe('TUI retry approvals', () => {
     await waitForApproval('retry', { streamId: 'cancelled-ordinary' });
     decideRetry({ accepted: true });
     await vi.waitFor(() => expect(ordinaryPrepare).toHaveBeenCalledOnce());
+    // The decided retry no longer reads as a request waiting on the user,
+    // but the queue still owns it, so the cancel below reaches its
+    // preparation.
+    expect(approvalQueueStatus.get()).toEqual({ depth: 0, kind: 'approval' });
     interactions.cancel({
       streamId: 'cancelled-ordinary',
       kind: 'retry',
@@ -1217,6 +1306,133 @@ describe('TUI retry approvals', () => {
     void requestSameStreamRetry(interactions, 'second retry');
 
     await waitForApproval('retry', { errorMessage: 'second retry' });
+  });
+
+  it('detaches one host without settling the live host retry', async () => {
+    mocks.hasUsableApiKey.mockResolvedValue(false);
+
+    const older = tui();
+    const newer = tui();
+    const detached = older.interactions.requestRetry?.(
+      relayRetry({ streamId: 'detached-host', provider: 'openai' }),
+    );
+    const live = newer.interactions.requestRetry?.(
+      relayRetry({ streamId: 'live-host', provider: 'openai' }),
+    );
+    await vi.waitFor(() => {
+      expect(pendingApprovalSummaries.get()).toEqual([
+        { streamKey: 'detached-host', kind: 'retry' },
+        { streamKey: 'live-host', kind: 'retry' },
+      ]);
+    });
+
+    // The older host releases once the last execution it owned finishes, which
+    // is after the newer host has taken over the session.
+    older.dispose();
+
+    await expect(detached).resolves.toEqual({ action: 'cancel' });
+    expect(pendingApprovalSummaries.get()).toEqual([
+      { streamKey: 'live-host', kind: 'retry' },
+    ]);
+    await waitForApproval('retry', { streamId: 'live-host' });
+    decideRetry({ accepted: true });
+    await expect(live).resolves.toEqual({
+      action: 'retry',
+      feedback: undefined,
+    });
+  });
+
+  it('cancels a retry aborted while its preparation was resolving', async () => {
+    const preparation = pDefer<void>();
+    const prepareRetry = vi.fn(() => preparation.promise);
+
+    const { interactions } = tui();
+    const result = interactions.requestRetry?.(
+      {
+        requestId: 'abort-at-resolution',
+        streamId: 'abort-at-resolution',
+        operation: 'model request',
+        errorMessage: 'Temporary connection error.',
+      },
+      { prepareRetry },
+    );
+    await waitForApproval('retry', { streamId: 'abort-at-resolution' });
+    decideRetry({ accepted: true });
+    await vi.waitFor(() => expect(prepareRetry).toHaveBeenCalledOnce());
+
+    // Registered after the abort-aware wrapper, so the interrupt lands once
+    // that wrapper has resolved and dropped its abort listener, and before the
+    // retry's own continuation runs: no await is left to observe the abort.
+    void preparation.promise.then(() => {
+      clearApprovals();
+    });
+    preparation.resolve();
+
+    await expect(result).resolves.toEqual({ action: 'cancel' });
+  });
+
+  it('shows the retry modal when pre-modal preparation fails', async () => {
+    mocks.retryCopyFailure = new Error('retry copy unavailable');
+
+    const { cliContext, interactions, prepareRetry } = tui();
+    const result = interactions.requestRetry?.(
+      relayRetry({ streamId: 'preparation-failure', provider: 'openai' }),
+    );
+
+    await waitForApproval('retry', { streamId: 'preparation-failure' });
+    expect(hasCliApprovalDenied(cliContext)).toBe(false);
+    decideRetry({ accepted: true });
+
+    await expect(result).resolves.toEqual({
+      action: 'retry',
+      feedback: undefined,
+    });
+    expect(prepareRetry).toHaveBeenCalledWith('configured', expect.anything());
+    expect(hasCliApprovalDenied(cliContext)).toBe(false);
+  });
+
+  it('cancels a retry parked behind another commit without waiting for it', async () => {
+    mocks.hasUsableApiKey.mockResolvedValue(true);
+    const blockingWrite = pDefer<undefined>();
+    mocks.setCliApiMode.mockImplementationOnce(async (mode) => {
+      mocks.apiMode = mode;
+      await blockingWrite.promise;
+    });
+    const queuedPreparation = pDefer<void>();
+    const queuedPrepare = vi.fn(() => queuedPreparation.promise);
+
+    const { interactions } = tui();
+    const blocking = interactions.requestRetry?.(
+      relayRetry({ streamId: 'blocking-commit', provider: 'openai' }),
+    );
+    await vi.waitFor(() => expect(mocks.setCliApiMode).toHaveBeenCalledOnce());
+
+    const queued = interactions.requestRetry?.(
+      relayRetry({ streamId: 'queued-commit', provider: 'openai' }),
+      { prepareRetry: queuedPrepare },
+    );
+    await vi.waitFor(() => expect(queuedPrepare).toHaveBeenCalledOnce());
+    queuedPreparation.resolve();
+    // One tick for the abort-aware wrapper around the preparation, one for the
+    // retry's continuation, which parks the commit behind the blocked one.
+    await queuedPreparation.promise;
+    await Promise.resolve();
+    await Promise.resolve();
+
+    interactions.cancel({
+      streamId: 'queued-commit',
+      kind: 'retry',
+      cause: 'Cancelled in test.',
+    });
+    await expect(queued).resolves.toEqual({ action: 'cancel' });
+    expect(mocks.setCliApiMode).toHaveBeenCalledOnce();
+
+    blockingWrite.resolve(undefined);
+    await expect(blocking).resolves.toEqual({
+      action: 'retry',
+      feedback: undefined,
+    });
+    expect(mocks.setCliApiMode).toHaveBeenCalledOnce();
   });
 
   it('serializes a newer switch behind stale-switch rollback', async () => {

--- a/src/test-kernel/cli/TuiHostInteractionsCancelForStream.vitest.mts
+++ b/src/test-kernel/cli/TuiHostInteractionsCancelForStream.vitest.mts
@@ -201,12 +201,12 @@ describe('createTuiHostInteractions', () => {
     }
   });
 
-  it('an unfiltered cancel settles active retry routes (pre-fold cleanupAllRequests parity)', async () => {
+  it('an unfiltered cancel settles a live retry (pre-fold cleanupAllRequests parity)', async () => {
     const interactions = createTuiHostInteractions(host(), context());
     try {
-      // requestRetry registers a route in the retry-route registry before the
-      // modal decision settles; cancel({}) must settle the route (resolving
-      // the pending retry with 'cancel'), not just clear the modal queue.
+      // requestRetry holds a queue reservation from before the modal appears
+      // until its decision has been acted on; cancel({}) must settle that
+      // entry, resolving the pending retry with 'cancel'.
       const retryResult = interactions.requestRetry?.({
         requestId: 'retry:first',
         streamId: 'stream-a',
@@ -220,8 +220,8 @@ describe('createTuiHostInteractions', () => {
       await expect(retryResult).resolves.toEqual({ action: 'cancel' });
       expect(currentApproval.get()).toBeUndefined();
 
-      // The route registry entry is gone: a stale decision on the old route
-      // cannot resurrect the retry (a fresh request gets a fresh route).
+      // The settled entry is gone from the queue: a stale decision cannot
+      // resurrect it, and a fresh request reserves a fresh entry.
       const second = interactions.requestRetry?.({
         requestId: 'retry:second',
         streamId: 'stream-a',

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -1097,7 +1097,10 @@ describe('CLI TUI row allocation', () => {
     });
   });
 
-  it('uses child slice status as a fallback for focused child follow-ups', () => {
+  // The roster row carries no status of its own: `reconstruct` resolves every
+  // child row's status from the stream status map, so a roster snapshot that
+  // still says RUNNING cannot keep a stopped child accepting follow-ups.
+  it('routes focused child follow-ups from the stream status, not the roster row', () => {
     patchStream(root, (s) => ({ ...s, status: STREAM_PHASE.WAITING }));
     applySubagentRoster(root, [
       {

--- a/src/test-kernel/desktop/DesktopControlSystem.vitest.mts
+++ b/src/test-kernel/desktop/DesktopControlSystem.vitest.mts
@@ -249,11 +249,7 @@ describe('desktop control system', () => {
     expect(commandSurface).toContain("accelerator: 'CommandOrControl+S'");
     expect(renderer).toContain('void editorPane.save()');
     expect(renderer).toContain('editorPane.hasUnsavedChanges()');
-    expect(renderer).toContain('DESKTOP_WORKSPACE_COMMANDS.EDITOR_DIRTY_STATE');
     expect(editorPane).toContain('model.getVersionId() !== savedVersion');
-    expect(electronMain).toContain("on('will-prevent-unload'");
-    expect(electronMain).toContain('confirmDiscardUnsavedEditorChanges(true)');
-    expect(electronMain).toContain('allowNextPreventedUnload');
     expect(electronMain).toMatch(
       /webContents\.on\('did-navigate',[\s\S]*?initialRendererNavigationComplete[\s\S]*?workspaceIpc\.disposeRendererResources\(\)/u,
     );
@@ -265,6 +261,47 @@ describe('desktop control system', () => {
     );
     expect(preload).toContain("'unload',");
     expect(preload).not.toContain("'beforeunload'");
+  });
+
+  it('asks about unsaved editor changes from the renderer veto alone', () => {
+    // The main process used to mirror the renderer's dirty flag over IPC and
+    // pre-arm the next prevented unload from that copy. A stale mirror either
+    // prompted about changes that were already saved or left the pre-arm set,
+    // so the next genuinely dirty close discarded the buffers without asking.
+    const electronMain = read('packages/desktop/src/main/index.ts');
+    const renderer = read('packages/desktop/src/renderer/main.ts');
+    const workspaceIpc = read(
+      'packages/desktop/src/main/desktopWorkspaceIpc.ts',
+    );
+    const messages = read('packages/desktop/src/desktopWorkspaceMessages.ts');
+
+    // The renderer's veto is the only gate on dirtiness.
+    expect(renderer).toMatch(
+      /addEventListener\('beforeunload',[\s\S]*?editorPane\.hasUnsavedChanges\(\)[\s\S]*?event\.preventDefault\(\)/u,
+    );
+    // One reader, one prompt: the discard dialog exists only inside the
+    // will-prevent-unload handler that veto raises.
+    expect(electronMain).toMatch(
+      /webContents\.on\('will-prevent-unload',[\s\S]*?showMessageBoxSync[\s\S]*?'Discard Changes'[\s\S]*?event\.preventDefault\(\)/u,
+    );
+    expect(
+      electronMain.match(/Discard the changes and continue\?/gu),
+    ).toHaveLength(1);
+    // Keeping the changes cancels whichever close raised the prompt.
+    expect(electronMain).toMatch(
+      /will-prevent-unload'[\s\S]*?pendingWorkspaceRelaunch = undefined;[\s\S]*?workspaceRelaunchInProgress = false;[\s\S]*?continueQuitAfterWindowClose = undefined;/u,
+    );
+    // The folder switch closes unconditionally instead of reading a copy.
+    expect(electronMain).toMatch(
+      /const openWorkspaceFolder[\s\S]*?pendingWorkspaceRelaunch = \{[\s\S]*?window\.close\(\);/u,
+    );
+    expect(electronMain).not.toContain('editorHasUnsavedChanges');
+    expect(electronMain).not.toContain('allowNextPreventedUnload');
+    // No mirror on the wire, in the router, or in the renderer.
+    for (const source of [messages, workspaceIpc, renderer, electronMain]) {
+      expect(source).not.toContain('EDITOR_DIRTY_STATE');
+    }
+    expect(workspaceIpc).not.toContain('onEditorDirtyChange');
   });
 
   it('executes immediate follow-up plans after restoring their launcher state', () => {

--- a/src/test-kernel/desktop/DesktopWorkspaceIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopWorkspaceIpc.vitest.mts
@@ -242,17 +242,19 @@ describe('desktop workspace IPC', () => {
     );
   });
 
-  it('reports renderer editor dirty state to the window lifecycle', () => {
-    const onEditorDirtyChange = vi.fn();
-    const ipc = createIpc(vi.fn(), { onEditorDirtyChange });
+  it('accepts no editor dirty-state mirror from the renderer', () => {
+    // Editor dirtiness lives in the renderer's Monaco buffers. The main
+    // process used to keep a mirrored copy here and decide the discard prompt
+    // from it, which went stale while the message was in flight; the prompt is
+    // now driven only by the renderer's beforeunload veto.
+    const ipc = createIpc(vi.fn());
 
     expect(
       ipc.handleMessage({
-        command: DESKTOP_WORKSPACE_COMMANDS.EDITOR_DIRTY_STATE,
+        command: 'desktop:workspace:editorDirtyState',
         dirty: true,
       }),
-    ).toBe(true);
-    expect(onEditorDirtyChange).toHaveBeenCalledWith(true);
+    ).toBe(false);
   });
 
   it('disposes terminal and browser resources at a renderer boundary', () => {

--- a/src/test-kernel/frontend/agents/AgentDirectoryWatchers.vitest.ts
+++ b/src/test-kernel/frontend/agents/AgentDirectoryWatchers.vitest.ts
@@ -1,0 +1,263 @@
+// Third-party imports
+import pDefer from 'p-defer';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Type imports
+import type { AgentDirectoryEntry } from '@agent/index';
+import type * as vscode from 'vscode';
+
+const EXTERNAL_FIRST = '/external/first';
+const EXTERNAL_SECOND = '/external/second';
+
+const mocks = vi.hoisted(() => ({
+  getAllLocal: vi.fn<() => Promise<unknown[]>>(),
+  watchedDirectories: [] as string[],
+  /** Directory listings keyed by fsPath, standing in for the disk. */
+  tree: new Map<string, [string, number][]>(),
+  /** Reads parked until the test releases them, keyed by fsPath. */
+  heldReads: new Map<string, { promise: Promise<void> }>(),
+  createHandlers: new Map<string, (uri: { fsPath: string }) => void>(),
+}));
+
+vi.mock('vscode', () => ({
+  Uri: {
+    file: (fsPath: string) => ({ fsPath }),
+    joinPath: (base: { fsPath: string }, ...segments: string[]) => ({
+      fsPath: [base.fsPath, ...segments].join('/'),
+    }),
+  },
+  workspace: {
+    getWorkspaceFolder: (uri: { fsPath: string }) =>
+      uri.fsPath.startsWith('/external')
+        ? undefined
+        : { uri: { fsPath: '/workspace' } },
+    fs: {
+      readDirectory: async (uri: { fsPath: string }) => {
+        const entries = [...(mocks.tree.get(uri.fsPath) ?? [])];
+        const held = mocks.heldReads.get(uri.fsPath);
+        if (held) {
+          mocks.heldReads.delete(uri.fsPath);
+          await held.promise;
+        }
+        return entries;
+      },
+      stat: async (uri: { fsPath: string }) => ({
+        type: mocks.tree.has(uri.fsPath) ? 2 : 1,
+      }),
+    },
+    createFileSystemWatcher: (pattern: { base: { fsPath: string } }) => {
+      mocks.watchedDirectories.push(pattern.base.fsPath);
+      return {
+        onDidCreate: (handler: (uri: { fsPath: string }) => void) => {
+          mocks.createHandlers.set(pattern.base.fsPath, handler);
+          return { dispose: () => {} };
+        },
+        onDidChange: () => ({ dispose: () => {} }),
+        onDidDelete: () => ({ dispose: () => {} }),
+        dispose: () => {},
+      };
+    },
+  },
+  RelativePattern: class {
+    constructor(
+      public readonly base: unknown,
+      public readonly pattern: string,
+    ) {}
+  },
+  FileType: { Unknown: 0, File: 1, Directory: 2, SymbolicLink: 64 },
+}));
+
+vi.mock('node:fs/promises', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  realpath: async (fsPath: string) => fsPath,
+}));
+
+vi.mock('@agent/index/platformAgentDirectories', () => ({
+  createPlatformAgentDirectories: () => ({
+    builtIn: async () => '/agents/builtin',
+    builtInToolUse: async () => '/agents/toolUse',
+    custom: async () => '/agents/custom',
+    getDirectory: async () => undefined,
+    getAllLocal: mocks.getAllLocal,
+  }),
+}));
+
+vi.mock('@common/state', () => ({
+  GlobalStateKey: { CUSTOM_AGENT_DIR: 'customAgentDir' },
+  globalSM: { get: () => '', update: async () => {} },
+}));
+
+vi.mock('@frontend/ui/errorHandlingUtils', () => ({
+  showLoggedMessageWithDocs: vi.fn(),
+}));
+
+vi.mock('@frontend/ui/dialogs', () => ({
+  selectFolder: vi.fn(),
+}));
+
+vi.mock('@logger/logUtils', () => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+const { agentDirectories } =
+  await import('@frontend/agents/AgentDirectoryManager');
+
+function directoryList(...directories: string[]): AgentDirectoryEntry[] {
+  return directories.map((directory) => ({
+    directory,
+    source: 'builtIn' as AgentDirectoryEntry['source'],
+  }));
+}
+
+function externalCustomDirectories(): AgentDirectoryEntry[] {
+  return [EXTERNAL_FIRST, EXTERNAL_SECOND].map((directory) => ({
+    directory,
+    source: 'custom' as AgentDirectoryEntry['source'],
+  }));
+}
+
+function fireCreate(watchedDirectory: string, createdPath: string): void {
+  const handler = mocks.createHandlers.get(watchedDirectory);
+  if (!handler) {
+    throw new Error(`No create handler registered for ${watchedDirectory}`);
+  }
+  handler({ fsPath: createdPath });
+}
+
+/** Lets every queued rebuild run to completion. */
+async function settle(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('agent directory watcher rebuilds', () => {
+  let subscription: vscode.Disposable | undefined;
+
+  beforeEach(() => {
+    subscription?.dispose();
+    subscription = undefined;
+    mocks.watchedDirectories.length = 0;
+    mocks.tree.clear();
+    mocks.heldReads.clear();
+    mocks.createHandlers.clear();
+    mocks.getAllLocal.mockReset();
+    agentDirectories.initialize({} as vscode.ExtensionContext);
+  });
+
+  it('builds the watcher set once for subscriptions racing the same directory read', async () => {
+    const firstRead = pDefer<AgentDirectoryEntry[]>();
+    mocks.getAllLocal
+      .mockReturnValueOnce(firstRead.promise)
+      .mockResolvedValue(directoryList('/agents/builtin'));
+
+    subscription = agentDirectories.watchAgentDirectories({
+      onEvent: () => {},
+    });
+    const second = agentDirectories.watchAgentDirectories({
+      onEvent: () => {},
+    });
+
+    firstRead.resolve(directoryList('/agents/builtin'));
+    await settle();
+    second.dispose();
+
+    expect(mocks.watchedDirectories).toEqual(['/agents/builtin']);
+  });
+
+  it('rebuilds for a directory change raised while a rebuild is already running', async () => {
+    const firstRead = pDefer<AgentDirectoryEntry[]>();
+    mocks.getAllLocal
+      .mockReturnValueOnce(firstRead.promise)
+      .mockResolvedValue(directoryList('/agents/custom'));
+
+    subscription = agentDirectories.watchAgentDirectories({
+      onEvent: () => {},
+    });
+
+    // The settings view changes the custom agent directory while the first
+    // read is still in flight: the change must not be dropped.
+    const refreshed = agentDirectories.refreshAfterDirChange();
+    firstRead.resolve(directoryList('/agents/builtin'));
+    await refreshed;
+    await settle();
+
+    expect(mocks.watchedDirectories).toEqual([
+      '/agents/builtin',
+      '/agents/custom',
+    ]);
+  });
+
+  it('settles a queued rebuild when the last subscription is disposed first', async () => {
+    const firstRead = pDefer<AgentDirectoryEntry[]>();
+    mocks.getAllLocal
+      .mockReturnValueOnce(firstRead.promise)
+      .mockResolvedValue(directoryList('/agents/custom'));
+
+    subscription = agentDirectories.watchAgentDirectories({
+      onEvent: () => {},
+    });
+
+    // The settings view awaits a rebuild that is still queued behind the
+    // in-flight one when the sidebar drops its last subscription.
+    let refreshSettled = false;
+    const refreshed = agentDirectories.refreshAfterDirChange().then(() => {
+      refreshSettled = true;
+    });
+
+    subscription.dispose();
+    subscription = undefined;
+    firstRead.resolve(directoryList('/agents/builtin'));
+    await settle();
+
+    expect(refreshSettled).toBe(true);
+    await refreshed;
+    expect(mocks.watchedDirectories).toEqual(['/agents/builtin']);
+  });
+
+  it('rebuilds for a subdirectory created after the running rebuild listed its parent', async () => {
+    mocks.getAllLocal.mockImplementation(async () =>
+      externalCustomDirectories(),
+    );
+    mocks.tree.set(EXTERNAL_FIRST, []);
+    mocks.tree.set(EXTERNAL_SECOND, []);
+
+    subscription = agentDirectories.watchAgentDirectories({
+      onEvent: () => {},
+    });
+    await settle();
+
+    expect(mocks.watchedDirectories).toEqual([EXTERNAL_FIRST, EXTERNAL_SECOND]);
+
+    // Park the rebuild that `one` triggers on the scan of the second
+    // directory, leaving the watchers it just created for the first directory
+    // live while it runs.
+    const secondScan = pDefer<void>();
+    mocks.heldReads.set(EXTERNAL_SECOND, secondScan);
+    mocks.tree.set(EXTERNAL_FIRST, [['one', 2]]);
+    mocks.tree.set(`${EXTERNAL_FIRST}/one`, []);
+    fireCreate(EXTERNAL_FIRST, `${EXTERNAL_FIRST}/one`);
+    await settle();
+
+    // `two` lands after that rebuild listed the first directory, so only a
+    // later rebuild can pick it up.
+    mocks.tree.set(EXTERNAL_FIRST, [
+      ['one', 2],
+      ['two', 2],
+    ]);
+    mocks.tree.set(`${EXTERNAL_FIRST}/two`, []);
+    fireCreate(EXTERNAL_FIRST, `${EXTERNAL_FIRST}/two`);
+    await settle();
+
+    secondScan.resolve();
+    await settle();
+
+    expect(mocks.watchedDirectories.slice(-4)).toEqual([
+      EXTERNAL_FIRST,
+      `${EXTERNAL_FIRST}/one`,
+      `${EXTERNAL_FIRST}/two`,
+      EXTERNAL_SECOND,
+    ]);
+  });
+});

--- a/src/test-kernel/progressView/ProgressBackend.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackend.vitest.ts
@@ -29,6 +29,7 @@ import {
   type DeleteExecutionResult,
 } from '@agent/storage';
 import { AgentConfigSchema } from '@agent/core/definition/AgentConfig';
+import { AgentExecutionHandle } from '@agent/runtime/ExecutionHandle';
 import { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { TaskState } from '@agent/core/state/TaskState';
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
@@ -3343,27 +3344,25 @@ describe('retained finished children', () => {
   });
 
   it('keeps the resolved terminal status on a later structural sync', async () => {
-    const { backend, messages } = createRecordingBackend();
+    const { backend, messages } = createIsolatedRecordingBackend();
+    track(backend.setupEventListeners());
     seedParent(backend);
     const childStreamId = 'doomed-stream' as StreamTabId;
     backend.state.snapshots.setParentStream(childStreamId, PARENT);
 
-    // Roster drop first, so the retained row is stamped `running` forever.
+    // Roster drop first, so the retained row is stamped `running`.
     backend.factApplier.updateChildRoster(PARENT, [
       subagent('doomed', { childStreamId }),
     ]);
     backend.factApplier.updateChildRoster(PARENT, []);
-    // Transition only the authoritative status machine. Deliberately avoid
-    // `setStreamStatus`, which also caches the terminal status into the
-    // retained row and would let this test pass without the projection.
+    // Transition the status machine and nothing else: its fact is the single
+    // owner of a roster row's phase, so the retained row must be written by
+    // this call alone, with no read-time repair on the send paths.
     backend.state.streamStatus.transitionToTerminal(
       childStreamId,
       STREAM_PHASE.FAILED,
     );
     expect(backend.state.getStreamState(PARENT)?.subagents?.[0]?.status).toBe(
-      STREAM_PHASE.RUNNING,
-    );
-    expect(backend.state.streamStatus.get(childStreamId)).toBe(
       STREAM_PHASE.FAILED,
     );
     messages.length = 0;
@@ -3400,6 +3399,158 @@ describe('retained finished children', () => {
         }),
       ]);
     }
+  });
+
+  it('keeps a recorded terminal phase when a stale roster still says running', async () => {
+    const { backend, messages } = createRecordingBackend();
+    seedParent(backend);
+    const childStreamId = 'stale-stream' as StreamTabId;
+    const live = subagent('stale', { childStreamId });
+
+    backend.factApplier.updateChildRoster(PARENT, [live]);
+    await backend.factApplier.setStreamStatus(
+      childStreamId,
+      STREAM_PHASE.FAILED,
+    );
+    messages.length = 0;
+
+    // A roster snapshot stamped before the transition, delivered after it: the
+    // child is still tracked, so it arrives as a live row carrying `running`.
+    backend.factApplier.updateChildRoster(PARENT, [live]);
+
+    const roster = backend.state.getStreamState(PARENT)?.subagents ?? [];
+    expect(roster).toEqual([
+      expect.objectContaining({
+        executionId: 'stale',
+        status: STREAM_PHASE.FAILED,
+      }),
+    ]);
+    expect(roster[0]?.finishedAt).toBeUndefined();
+    // No further status fact arrives for a terminal child, so the badge push
+    // driven by the stale roster is the last word on the wire.
+    expect(
+      messages.findLast(
+        (message) =>
+          message.command === PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_BADGES,
+      ),
+    ).toMatchObject({
+      stream: PARENT,
+      subagents: [
+        expect.objectContaining({
+          executionId: 'stale',
+          status: STREAM_PHASE.FAILED,
+        }),
+      ],
+    });
+  });
+
+  it('takes the emitted phase when a retained child goes live again', () => {
+    const { backend } = createRecordingBackend();
+    seedParent(backend);
+    const childStreamId = 'requeued-stream' as StreamTabId;
+
+    backend.factApplier.updateChildRoster(PARENT, [
+      subagent('requeued', { childStreamId, status: STREAM_PHASE.WAITING }),
+    ]);
+    backend.factApplier.updateChildRoster(PARENT, []);
+    backend.factApplier.updateChildRoster(PARENT, [
+      subagent('requeued', { childStreamId, status: STREAM_PHASE.RUNNING }),
+    ]);
+
+    const roster = backend.state.getStreamState(PARENT)?.subagents ?? [];
+    expect(roster).toEqual([
+      expect.objectContaining({
+        executionId: 'requeued',
+        status: STREAM_PHASE.RUNNING,
+      }),
+    ]);
+    expect(roster[0]?.finishedAt).toBeUndefined();
+  });
+
+  it('keeps a resolved live row when an older roster stamp arrives after it', async () => {
+    // The reverse of the roster-drop ordering: the child is still tracked when
+    // its terminal phase lands, and a roster stamped before that transition is
+    // applied afterwards. With the send-time projection gone, an older stamp
+    // that reached the row would freeze this badge at `running` forever.
+    const { backend, session } = createIsolatedRecordingBackend();
+    track(backend.setupEventListeners());
+    seedParent(backend);
+    const executionId = 'c0ffee01' as ExecutionId;
+    const childStreamId = 'restamped-stream' as StreamTabId;
+    const handle = new AgentExecutionHandle(
+      executionId,
+      PARENT,
+      childStreamId,
+      'agent-restamped',
+      AgentCategory.ToolUse,
+    );
+    session.executions.trackAgentExecution(handle, {
+      status: STREAM_PHASE.RUNNING,
+    });
+    const rosterStampedWhileRunning =
+      session.executions.getActiveChildren(PARENT);
+    backend.factApplier.updateChildRoster(PARENT, rosterStampedWhileRunning);
+    expect(backend.state.getStreamState(PARENT)?.subagents?.[0]?.status).toBe(
+      STREAM_PHASE.RUNNING,
+    );
+
+    session.status.transitionToTerminal(childStreamId, STREAM_PHASE.FAILED);
+    expect(backend.state.getStreamState(PARENT)?.subagents?.[0]?.status).toBe(
+      STREAM_PHASE.FAILED,
+    );
+
+    backend.factApplier.updateChildRoster(PARENT, rosterStampedWhileRunning);
+    expect(backend.state.getStreamState(PARENT)?.subagents).toEqual([
+      expect.objectContaining({
+        executionId,
+        status: STREAM_PHASE.FAILED,
+      }),
+    ]);
+
+    // A roster the emitter stamps now carries the resolved phase too, so the
+    // row is written from the same owner on both paths.
+    backend.factApplier.updateChildRoster(
+      PARENT,
+      session.executions.getActiveChildren(PARENT),
+    );
+    expect(backend.state.getStreamState(PARENT)?.subagents).toEqual([
+      expect.objectContaining({
+        executionId,
+        status: STREAM_PHASE.FAILED,
+      }),
+    ]);
+    session.executions.untrack(executionId);
+  });
+
+  it('writes the terminal status of a child detached from its parent', async () => {
+    const { backend } = createRecordingBackend();
+    seedParent(backend);
+    const childStreamId = 'detached-stream' as StreamTabId;
+
+    backend.factApplier.updateChildRoster(PARENT, [
+      subagent('detached', { childStreamId }),
+    ]);
+    // Detaching promotes a running subagent to top-level: the parent link goes
+    // away and the roster drops the row, but the child keeps running and
+    // finishes later. The row is found by its own childStreamId, so the phase
+    // still lands.
+    backend.factApplier.handleSetParentStream({
+      childStreamId,
+      parentStreamId: null,
+    });
+    backend.factApplier.updateChildRoster(PARENT, []);
+
+    await backend.factApplier.setStreamStatus(
+      childStreamId,
+      STREAM_PHASE.COMPLETED,
+    );
+
+    expect(backend.state.getStreamState(PARENT)?.subagents).toEqual([
+      expect.objectContaining({
+        executionId: 'detached',
+        status: STREAM_PHASE.COMPLETED,
+      }),
+    ]);
   });
 
   it('caps retained rows, evicting the oldest and keeping every live one', () => {

--- a/src/test-kernel/tools/BashTool.vitest.ts
+++ b/src/test-kernel/tools/BashTool.vitest.ts
@@ -42,6 +42,7 @@ import { MAX_TOOL_RESULT_TEXT_LENGTH } from '@agent/modelHandlers/contextManagem
 import { formatToolResultAsText } from '@agent/modelHandlers/utils/toolAttachmentUtils';
 import {
   EXECUTION_STATUS,
+  STREAM_PHASE,
   STREAM_STATUS,
   type StreamTabId,
 } from '@shared/schemas';
@@ -814,6 +815,56 @@ describe('BashTool', () => {
       );
     });
     recorded.detach();
+    defaultSession().followUps.terminalize(parentStreamId);
+  });
+
+  it('persists a killed background command as interrupted, not failed', async () => {
+    let resolveCommand: ((result: ExecResult) => void) | undefined;
+    vi.spyOn(execUtils, 'executeCommand').mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveCommand = resolve;
+        }),
+    );
+    await installPlatform({
+      workspacePath: '/workspace',
+      config: { 'texra.toolUse.requireBashApproval': false },
+    });
+    const parentStreamId = 'bash-killed-background' as StreamTabId;
+    const recorded = recordSessionEvents(defaultSession().events);
+
+    const launchResult = await launchBackgroundBash(parentStreamId);
+    const launchOutput = String(launchResult.output ?? '');
+    const executionId = /Execution ID: (\S+)/.exec(launchOutput)?.[1];
+    const childStreamId = /Stream tab: (\S+)/.exec(launchOutput)?.[1] as
+      StreamTabId | undefined;
+    assert.ok(executionId, launchOutput);
+    assert.ok(childStreamId, launchOutput);
+
+    // The user stop lands CANCELLED on the stream phase; only afterwards does
+    // the killed process report its non-zero exit.
+    assert.equal(defaultSession().executions.kill(executionId), true);
+    assert.equal(
+      defaultSession().status.get(childStreamId),
+      STREAM_PHASE.CANCELLED,
+    );
+    resolveCommand?.({
+      success: false,
+      stdout: '',
+      stderr: 'Terminated\n',
+      timedOut: false,
+      exitCode: 143,
+    });
+
+    const store = getExecutionStore(executionId);
+    await vi.waitFor(async () => {
+      assert.equal(
+        (await store.readMeta())?.terminalStatus,
+        EXECUTION_STATUS.INTERRUPTED,
+      );
+    });
+    recorded.detach();
+    clearStreamStatusForTest(defaultSession().status, childStreamId);
     defaultSession().followUps.terminalize(parentStreamId);
   });
 

--- a/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
+++ b/src/test-kernel/tools/NativeSubagentStrategy.vitest.ts
@@ -28,7 +28,6 @@ const mocks = vi.hoisted(() => ({
   readConfig: vi.fn(),
   resumeToolUseFromResumeData: vi.fn(),
   retrieveSessionResumeData: vi.fn(),
-  synchronizeAgentResultOutcome: vi.fn(),
 }));
 
 vi.mock('@agent/runtime/executeAgent', () => ({
@@ -39,7 +38,6 @@ vi.mock('@agent/runtime/executeAgent', () => ({
 vi.mock('@agent/storage', () => ({
   finalizeExecution: mocks.finalizeExecution,
   getExecutionStore: vi.fn(() => ({ readConfig: mocks.readConfig })),
-  synchronizeAgentResultOutcome: mocks.synchronizeAgentResultOutcome,
 }));
 
 vi.mock('@agent/storage/executionLease', async (importOriginal) => ({
@@ -127,7 +125,6 @@ describe('NativeSubagentStrategy', () => {
       terminalStatusPersisted: true,
       flowRecord: 'deleted',
     });
-    mocks.synchronizeAgentResultOutcome.mockResolvedValue(undefined);
   });
 
   afterEach(() => {

--- a/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
+++ b/src/test-kernel/transcript/StreamSnapshotStore.vitest.ts
@@ -937,6 +937,227 @@ describe('StreamSnapshotStore', () => {
     });
   });
 
+  it('keeps a same-execution model switch that arrives during async hydration', async () => {
+    await installPlatform();
+    const executionId = 'abc123' as ExecutionId;
+    const persisted = toolUseTaskState('search', 'deepseekproT');
+    const switched = toolUseTaskState('search', 'kimi26T');
+    await writeStreamFile(STREAM, 'meta.json', {
+      schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
+      executionId,
+    });
+    await StorageFS.ensureDir(resolveRunStoragePath(executionId));
+    await getExecutionStore(executionId).writeConfig(persisted.agentConfig);
+
+    const store = new StreamSnapshotStore();
+    // A model switch rewrites the execution config and re-emits `run.config`
+    // for the SAME execution, so the identity check cannot tell the two apart:
+    // the live event wins because the seed only fills what it did not receive.
+    const wasModelSwitchInjected = injectDuringExecutionConfigHydration(
+      executionId,
+      () => store.setTaskState(STREAM, switched, executionId),
+    );
+
+    await store.load([STREAM]);
+
+    expect(wasModelSwitchInjected).toHaveBeenCalledOnce();
+    expect(store.getRunConfig(STREAM)?.model).toBe('kimi26T');
+    expect(store.getExecutionId(STREAM)).toBe(executionId);
+  });
+
+  it('does not re-derive the run.start descriptor when a seed re-reads disk meta', async () => {
+    await installPlatform();
+    const executionId = 'abc123' as ExecutionId;
+    const taskState = toolUseTaskState('worker-agent');
+    const workflowDescriptor = buildRunDescriptor({
+      streamId: STREAM,
+      executionId,
+      agent: 'workflow-script',
+      category: AgentCategory.Workflow,
+      kind: 'workflowScript',
+    });
+    await StorageFS.ensureDir(resolveRunStoragePath(executionId));
+    await getExecutionStore(executionId).writeConfig(taskState.agentConfig);
+
+    const store = new StreamSnapshotStore();
+    store.setRunDescriptor(workflowDescriptor);
+    store.setTaskState(STREAM, taskState, executionId);
+    await store.flush();
+
+    // Disk meta drops back to the pre-descriptor shape for the same execution.
+    // Re-seeding may read it, but may not synthesize a competing identity from
+    // the execution config over the one run.start emitted.
+    await writeStreamFile(STREAM, 'meta.json', {
+      schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
+      executionId,
+    });
+    await store.load([STREAM]);
+
+    expect(store.getRunDescriptor(STREAM)).toEqual(workflowDescriptor);
+    expect(store.getExecutionId(STREAM)).toBe(executionId);
+  });
+
+  it('adopts run identity from disk when meta names a different execution', async () => {
+    await installPlatform();
+    const liveExecutionId = 'abc123' as ExecutionId;
+    const foreignExecutionId = 'def456' as ExecutionId;
+    const foreignTaskState = toolUseTaskState('foreign-search');
+
+    const store = new StreamSnapshotStore();
+    store.setTaskState(
+      STREAM,
+      toolUseTaskState('live-search'),
+      liveExecutionId,
+    );
+    await store.flush();
+
+    await StorageFS.ensureDir(resolveRunStoragePath(foreignExecutionId));
+    await getExecutionStore(foreignExecutionId).writeConfig(
+      foreignTaskState.agentConfig,
+    );
+    await writeStreamFile(STREAM, 'meta.json', {
+      schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
+      executionId: foreignExecutionId,
+    });
+    await store.load([STREAM]);
+
+    expect(store.getExecutionId(STREAM)).toBe(foreignExecutionId);
+    expect(store.getTaskState(STREAM)).toEqual(foreignTaskState);
+    expect(store.getRunDescriptor(STREAM)).toMatchObject({
+      executionId: foreignExecutionId,
+      agent: 'foreign-search',
+    });
+  });
+
+  it('refreshes the run config from disk when another host switched the model', async () => {
+    await installPlatform();
+    const executionId = 'abc123' as ExecutionId;
+    await writeStreamFile(STREAM, 'meta.json', {
+      schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
+      executionId,
+    });
+    await StorageFS.ensureDir(resolveRunStoragePath(executionId));
+    await getExecutionStore(executionId).writeConfig(
+      toolUseTaskState('search', 'deepseekproT').agentConfig,
+    );
+
+    const store = new StreamSnapshotStore();
+    await store.load([STREAM]);
+    expect(store.getRunConfig(STREAM)?.model).toBe('deepseekproT');
+
+    // The model switch runs in another host: it rewrites the execution config
+    // for the SAME execution and this store never sees the `run.config` event.
+    await getExecutionStore(executionId).writeConfig(
+      toolUseTaskState('search', 'kimi26T').agentConfig,
+    );
+    await store.load([STREAM]);
+
+    expect(store.getRunConfig(STREAM)?.model).toBe('kimi26T');
+    expect(store.getExecutionId(STREAM)).toBe(executionId);
+  });
+
+  it('replaces a legacy run config once meta names a real execution', async () => {
+    await installPlatform();
+    const legacyTaskState = toolUseTaskState('legacy-search');
+    await writeStreamFile(STREAM, 'meta.json', {
+      schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
+      taskState: legacyTaskState,
+    });
+
+    const store = new StreamSnapshotStore();
+    await store.load([STREAM]);
+    expect(store.getTaskState(STREAM)).toEqual(legacyTaskState);
+    expect(store.getRunDescriptor(STREAM)).toBeUndefined();
+
+    // A legacy config carries no descriptor, so the handoff cannot be detected
+    // from the descriptor half alone: the pair still has to move together.
+    const executionId = 'def456' as ExecutionId;
+    const handoffTaskState = toolUseTaskState('handoff-search');
+    await StorageFS.ensureDir(resolveRunStoragePath(executionId));
+    await getExecutionStore(executionId).writeConfig(
+      handoffTaskState.agentConfig,
+    );
+    await writeStreamFile(STREAM, 'meta.json', {
+      schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
+      executionId,
+    });
+    await store.load([STREAM]);
+
+    expect(store.getTaskState(STREAM)).toEqual(handoffTaskState);
+    expect(store.getRunDescriptor(STREAM)).toMatchObject({
+      executionId,
+      agent: 'handoff-search',
+    });
+  });
+
+  it('drops run identity when disk meta no longer names an execution', async () => {
+    await installPlatform();
+    const executionId = 'abc123' as ExecutionId;
+    await writeStreamFile(STREAM, 'meta.json', {
+      schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
+      executionId,
+    });
+    await StorageFS.ensureDir(resolveRunStoragePath(executionId));
+    await getExecutionStore(executionId).writeConfig(
+      toolUseTaskState().agentConfig,
+    );
+
+    const store = new StreamSnapshotStore();
+    await store.load([STREAM]);
+    expect(store.getRunDescriptor(STREAM)).toMatchObject({ executionId });
+
+    await writeStreamFile(STREAM, 'meta.json', {
+      schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
+      description: 'Detached tab',
+    });
+    await store.load([STREAM]);
+
+    expect(store.getRunDescriptor(STREAM)).toBeUndefined();
+    expect(store.getRunConfig(STREAM)).toBeUndefined();
+    expect(store.getExecutionId(STREAM)).toBeUndefined();
+    expect(store.getDescription(STREAM)).toBe('Detached tab');
+  });
+
+  it('does not attach the seeded run config to a run.start that lands during hydration', async () => {
+    await installPlatform();
+    const oldExecutionId = 'abc123' as ExecutionId;
+    const newExecutionId = 'def456' as ExecutionId;
+    const oldTaskState = toolUseTaskState('old-search');
+    await writeStreamFile(STREAM, 'meta.json', {
+      schemaVersion: RUN_DESCRIPTOR_SCHEMA_VERSION,
+      executionId: oldExecutionId,
+    });
+    await StorageFS.ensureDir(resolveRunStoragePath(oldExecutionId));
+    await getExecutionStore(oldExecutionId).writeConfig(
+      oldTaskState.agentConfig,
+    );
+
+    const store = new StreamSnapshotStore();
+    await store.load([STREAM]);
+    expect(store.getTaskState(STREAM)).toEqual(oldTaskState);
+
+    const newDescriptor = buildRunDescriptor({
+      streamId: STREAM,
+      executionId: newExecutionId,
+      agent: 'workflow-script',
+      category: AgentCategory.Workflow,
+      kind: 'workflowScript',
+    });
+    // `run.start` for the next execution lands while the seed is still reading
+    // the previous one's config, which belongs to neither the new identity nor
+    // this stream any more.
+    const wasRunStartInjected = injectDuringExecutionConfigHydration(
+      oldExecutionId,
+      () => store.setRunDescriptor(newDescriptor),
+    );
+    await store.load([STREAM]);
+
+    expect(wasRunStartInjected).toHaveBeenCalledOnce();
+    expect(store.getRunDescriptor(STREAM)).toEqual(newDescriptor);
+    expect(store.getRunConfig(STREAM)).toBeUndefined();
+    expect(store.getTaskState(STREAM)).toBeUndefined();
+  });
+
   it('persists a late reset and round patch that arrive during async hydration', async () => {
     await installPlatform();
     const dir = streamDataDir(STREAM);

--- a/src/test-kernel/webview/SidebarSurfaceOwnership.vitest.ts
+++ b/src/test-kernel/webview/SidebarSurfaceOwnership.vitest.ts
@@ -1,0 +1,175 @@
+// Third-party imports
+import pDefer from 'p-defer';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Type imports
+import type { ProgressViewProvider } from '@progressView/ProgressViewProvider';
+import type * as vscode from 'vscode';
+
+const MAIN_HTML = '<main-view />';
+const PROGRESS_HTML = '<progress-view />';
+
+const mocks = vi.hoisted(() => ({
+  executeCommand: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+}));
+
+vi.mock('vscode', () => ({
+  commands: {
+    executeCommand: mocks.executeCommand,
+    getCommands: async () => ['texra.getWebviewView'],
+  },
+  window: { showInformationMessage: vi.fn() },
+  workspace: {
+    createFileSystemWatcher: () => ({
+      onDidCreate: () => ({ dispose: () => {} }),
+      onDidChange: () => ({ dispose: () => {} }),
+      onDidDelete: () => ({ dispose: () => {} }),
+      dispose: () => {},
+    }),
+    onDidChangeWorkspaceFolders: () => ({ dispose: () => {} }),
+  },
+  Uri: { file: (fsPath: string) => ({ fsPath }) },
+}));
+
+vi.mock('@common/webview', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  BundledViewContentProvider: class {
+    getHtmlContent(): string {
+      return MAIN_HTML;
+    }
+  },
+  getCombinedLocalResourceRoots: () => [],
+}));
+
+vi.mock('@webview/MainViewMessageHandler', () => ({
+  MainViewMessageHandler: class {
+    handleMessage = vi.fn();
+    clearActiveView = vi.fn();
+  },
+}));
+
+vi.mock('@agent/index', () => ({
+  refresh: vi.fn(),
+  computeAgentOptionsData: vi.fn(),
+  getAgent: vi.fn(),
+}));
+vi.mock('@agent/core/definition/AgentDataclass', () => ({
+  AgentCategory: { ToolUse: 'toolUse' },
+}));
+vi.mock('@commands/setup/setupAssistantCommand', () => ({
+  hasAnyUsableSetupCredential: vi.fn(async () => false),
+}));
+vi.mock('@common/state', () => ({ consumePendingState: () => undefined }));
+vi.mock('@common/files', () => ({
+  EXTENSION_CATEGORIES: [],
+  getFilterExtensions: () => [],
+}));
+vi.mock('@eventBus/AppSignals', () => ({
+  appSignals: { on: () => () => {} },
+}));
+vi.mock('@frontend/agents/AgentDirectoryManager', () => ({
+  agentDirectories: { watchAgentDirectories: () => ({ dispose: () => {} }) },
+}));
+vi.mock('@frontend/auth/agentCatalogRefreshScope', () => ({
+  isAgentCatalogAuthRefreshDeferred: () => false,
+  runAfterAgentCatalogAuthRefresh: vi.fn(),
+}));
+vi.mock('@frontend/events/onTexraAuthSessionsChanged', () => ({
+  onTexraAuthSessionsChanged: vi.fn(),
+}));
+vi.mock('@frontend/agents/optionsLoader', () => ({
+  loadMainViewModelOptions: vi.fn(),
+}));
+vi.mock('@frontend/agents/teamOptionsLoader', () => ({
+  loadMainViewTeamOptions: vi.fn(),
+}));
+vi.mock('@utils/config/configUtils', () => ({ watchConfig: vi.fn() }));
+
+const { SIDEBAR_VIEWS, getActiveSidebarView, setActiveSidebarView } =
+  await import('@common/webview');
+const { MainViewProvider } =
+  await import('../../../packages/extension/src/MainViewProvider');
+
+function createWebviewView() {
+  return {
+    webview: {
+      options: {},
+      html: '',
+      postMessage: vi.fn(),
+      onDidReceiveMessage: vi.fn(() => ({ dispose: vi.fn() })),
+    },
+    visible: true,
+    onDidDispose: vi.fn(() => ({ dispose: vi.fn() })),
+  };
+}
+
+function createProgressViewProvider() {
+  return {
+    getContentProvider: () => ({ getHtmlContent: () => PROGRESS_HTML }),
+    handleSidebarMessage: vi.fn(),
+    resetSidebarReady: vi.fn(),
+  };
+}
+
+async function settle(): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    await Promise.resolve();
+  }
+}
+
+describe('sidebar surface ownership', () => {
+  let provider: InstanceType<typeof MainViewProvider>;
+  let view: ReturnType<typeof createWebviewView>;
+  let progressViewProvider: ReturnType<typeof createProgressViewProvider>;
+
+  beforeEach(() => {
+    mocks.executeCommand.mockReset();
+    mocks.executeCommand.mockResolvedValue(undefined);
+    setActiveSidebarView(SIDEBAR_VIEWS.MAIN);
+    provider = new MainViewProvider({
+      subscriptions: [],
+      globalState: { get: () => undefined, update: async () => {} },
+    } as unknown as vscode.ExtensionContext);
+    progressViewProvider = createProgressViewProvider();
+    provider.setProgressViewProvider(
+      progressViewProvider as unknown as ProgressViewProvider,
+    );
+    view = createWebviewView();
+    provider.resolveWebviewView(view as unknown as vscode.WebviewView);
+  });
+
+  it('swaps the sidebar content in the tick that claims the surface', () => {
+    // The context key push never settles: the swap must not wait on it.
+    mocks.executeCommand.mockReturnValue(new Promise(() => {}));
+
+    provider.switchMode(SIDEBAR_VIEWS.PROGRESS);
+
+    expect(getActiveSidebarView()).toBe(SIDEBAR_VIEWS.PROGRESS);
+    expect(view.webview.html).toBe(PROGRESS_HTML);
+  });
+
+  it('leaves the newest switch owning the surface when switches overlap', async () => {
+    const contextKeyPush = pDefer<undefined>();
+    mocks.executeCommand.mockReturnValue(contextKeyPush.promise);
+
+    provider.switchMode(SIDEBAR_VIEWS.PROGRESS);
+    provider.switchMode(SIDEBAR_VIEWS.MAIN);
+    contextKeyPush.resolve(undefined);
+    await settle();
+
+    expect(getActiveSidebarView()).toBe(SIDEBAR_VIEWS.MAIN);
+    expect(view.webview.html).toBe(MAIN_HTML);
+    expect(progressViewProvider.resetSidebarReady).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the surface to the launcher when the view is torn down', () => {
+    provider.switchMode(SIDEBAR_VIEWS.PROGRESS);
+
+    provider.resolveWebviewView(
+      createWebviewView() as unknown as vscode.WebviewView,
+    );
+
+    expect(getActiveSidebarView()).toBe(SIDEBAR_VIEWS.MAIN);
+    expect(progressViewProvider.resetSidebarReady).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -2,11 +2,7 @@
 import { z } from 'zod';
 
 // Local imports
-import {
-  finalizeExecution,
-  getExecutionStore,
-  registerExecution,
-} from '@agent/storage';
+import { getExecutionStore, registerExecution } from '@agent/storage';
 import {
   captureOwnedExecutionLease,
   markOwnedExecutionLeaseUndurable,
@@ -21,6 +17,7 @@ import {
   getCurrentToolContexts,
   type ToolCallContext,
 } from '@agent/followUp/ToolFileInteractionContext';
+import type { RunTerminalPersistence } from '@agent/runtime/AgentRunLifecycle';
 import type { ExecutionInterruptHandler } from '@agent/runtime/ExecutionHandle';
 import {
   getRunContextExecutionId,
@@ -38,10 +35,6 @@ import {
 } from '@shared/toolUse';
 import { type StreamTabId, type ExecutionId } from '@shared/schemas';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
-import {
-  deriveRunOutcome,
-  projectRunOutcome,
-} from '@shared/streams/streamStatus';
 import { deliverChildRunFollowUp } from '@tools/childRunDelivery';
 import { requireRunStream } from '@tools/contextHelpers';
 import {
@@ -82,6 +75,18 @@ const SHELL_BACKGROUNDING_PATTERN =
 const SHELL_BACKGROUNDING_MESSAGE =
   'This command uses shell-level backgrounding (`nohup ... &`) inside a foreground bash tool call. ' +
   'Do not emulate background execution inside the shell; call the bash tool again with `run_in_background: true` and the command without `nohup` or a trailing `&`.';
+
+/**
+ * A background command's durable terminal state is written by the shared
+ * finalizer, from the outcome the stream phase resolved. Deriving it here from
+ * the process exit alone would record ERROR for a command the user killed:
+ * the kill lands CANCELLED on the phase and only then does the process exit
+ * non-zero. There is no flow to resume, so the record is always dropped.
+ */
+const BACKGROUND_TERMINAL_PERSISTENCE: RunTerminalPersistence = {
+  kind: 'finalize',
+  flowRecord: 'delete',
+};
 
 interface BoundedOutputCapture {
   append(chunk: string): void;
@@ -509,22 +514,7 @@ export class BashTool extends defineTool({
       logBackgroundFailure(action, err);
     };
 
-    const finalizeAndReport = async (
-      success: boolean,
-      msg: string,
-    ): Promise<void> => {
-      try {
-        const finalization = await finalizeExecution({
-          executionId,
-          terminalStatus: projectRunOutcome(
-            deriveRunOutcome({ failed: !success, cancelled: false }),
-          ).executionStatus,
-          flowRecord: 'delete',
-        });
-        if (finalization.status === 'failed') throw finalization.error;
-      } catch (err: unknown) {
-        logDurabilityFailure('finalize execution', err);
-      }
+    const persistReport = async (msg: string): Promise<void> => {
       try {
         await getExecutionStore(executionId).writeReport(msg);
       } catch (err: unknown) {
@@ -595,11 +585,12 @@ export class BashTool extends defineTool({
           } catch (err: unknown) {
             logDurabilityFailure('persist result metadata', err);
           }
-          await finalizeAndReport(result.success, msg);
+          await persistReport(msg);
 
           await deliverAndFinalize(msg, {
             wallTimeMs,
             outcome: error ? { kind: 'failed', error } : { kind: 'completed' },
+            persistence: BACKGROUND_TERMINAL_PERSISTENCE,
             autoClose: true,
           });
           return;
@@ -607,10 +598,11 @@ export class BashTool extends defineTool({
 
         const { error } = outcome;
         const msg = formatBashError(executionId, command, error);
-        await finalizeAndReport(false, msg);
+        await persistReport(msg);
 
         await deliverAndFinalize(msg, {
           outcome: { kind: 'failed', error },
+          persistence: BACKGROUND_TERMINAL_PERSISTENCE,
           autoClose: true,
         });
       } catch (err: unknown) {

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -13,7 +13,7 @@ import {
   type SessionHandle,
 } from '@agent/runtime/SessionHandle';
 import { classifyAgentError } from '@common/errors';
-import { RUN_OUTCOME, STREAM_PHASE, buildRunDescriptor } from '@shared/schemas';
+import { STREAM_PHASE, buildRunDescriptor } from '@shared/schemas';
 import type { ExecutionId, RunKind, StreamTabId } from '@shared/schemas';
 import { deriveRunOutcome } from '@shared/streams/streamStatus';
 import { createRunTrace } from '@transcript';
@@ -36,11 +36,9 @@ interface CreateChildStreamOptions {
 }
 
 /**
- * How the child stream's own caller believes its run ended. `finalize` still
- * cross-checks the execution registry for an already-CANCELLED status (an
- * explicit stop/kill can land between the caller deciding this and the call
- * landing here), so `cancelled` always wins regardless of what the registry
- * later confirms.
+ * What the child observed about its own exit. It is a report, not a verdict:
+ * the stream phase owns the terminal outcome, so an explicit stop/kill that
+ * already landed CANCELLED outranks the non-zero exit it caused.
  */
 export type ChildStreamOutcome =
   | { kind: 'completed' }
@@ -176,8 +174,9 @@ export function createChildStream(
     return {
       childStreamId,
       logger: runTrace.trace,
-      // Mid-run status updates are intentionally best-effort. Explicit stops and
-      // stale handles are ignored by the registry; finalize owns terminal status.
+      // Reports, not writes: the status machine's transition table decides
+      // which of these lands, so a stale handle or a stream a stop already
+      // cancelled simply keeps the phase it has.
       waitForInput: () => {
         session.executions.updateAgentExecutionStatus(
           handle,
@@ -263,10 +262,10 @@ interface FinalizeChildStreamArgs {
 }
 
 /**
- * Finalize a child stream tab: presentation logging plus the child-specific
- * outcome derivation, then the shared terminal finalizer (settle, untrack,
- * terminal stream phase) and the autoClose emit. Child streams never traverse
- * the run lifecycle, so this is their only settle point.
+ * Finalize a child stream tab: presentation logging plus the child's report of
+ * its own exit, then the shared terminal finalizer (settle, untrack, terminal
+ * stream phase) and the autoClose emit. Child streams never traverse the run
+ * lifecycle, so this is their only settle point.
  */
 async function finalizeChildStream(
   args: FinalizeChildStreamArgs,
@@ -296,25 +295,17 @@ async function finalizeChildStream(
     });
   }
 
-  // The terminal outcome the child finishes with — the single derivation for
-  // everything the shared finalizer projects. Explicit user stops win: the
-  // registry may already show CANCELLED (stop/kill transitioned it) for a
-  // child whose own exit reported a failure (e.g. a killed bash process exits
-  // non-zero), and long-lived child loops finalize after an interrupt. Clean
-  // exits project to `completed` so the tab clears.
-  const stopped =
-    outcomeOption.kind === 'cancelled' ||
-    session.executions.getStatus(handle).status === STREAM_PHASE.CANCELLED;
+  // What the child saw, projected into the shared vocabulary. The stream phase
+  // decides which of this and an already-landed stop is the run's terminal
+  // fact; that resolution lives in `finalizeRunTerminal`.
   const outcome = deriveRunOutcome({
-    failed: !stopped && outcomeOption.kind === 'failed',
-    cancelled: stopped,
+    failed: outcomeOption.kind === 'failed',
+    cancelled: outcomeOption.kind === 'cancelled',
   });
   const error =
-    outcome === RUN_OUTCOME.FAILED
+    outcomeOption.kind === 'failed'
       ? {
-          kind: classifyAgentError(
-            outcomeOption.kind === 'failed' ? outcomeOption.error : undefined,
-          ),
+          kind: classifyAgentError(outcomeOption.error),
           message: errorMessage ?? 'Child stream failed',
         }
       : undefined;

--- a/src/transcript/StreamSnapshotStore.ts
+++ b/src/transcript/StreamSnapshotStore.ts
@@ -281,9 +281,17 @@ interface StreamRecord {
   usageUnparsed: Map<string, unknown>;
   workPlan: WorkPlanSnapshot;
   meta: StreamTabMeta | undefined;
-  /** Immutable run descriptor parsed/emitted once per execution stream. */
+  /**
+   * Run identity: the descriptor and config of the ONE execution `meta` names,
+   * always for the same execution (a `run.start` for a new one drops the
+   * previous run's config with it). The descriptor is immutable per execution,
+   * so the live `run.start` owns it and a seed never re-derives a competing one
+   * for that execution. The config is mutable and persisted — a model switch
+   * rewrites `executions/{id}/config.json` and re-emits `run.config` — so
+   * `config.json` owns it and a seed re-reads it, yielding only to a live event
+   * that landed after the seed read disk.
+   */
   runDescriptor: RunDescriptor | undefined;
-  /** Current run config, hydrated from executions/{id}/config.json. */
   runConfig: AgentConfig | undefined;
 
   // -- Lazy seeding: a stream's existing disk data is read into memory BEFORE
@@ -1483,11 +1491,16 @@ export class StreamSnapshotStore {
     const config = taskState.agentConfig;
     const record = this.getOrCreateRecord(stream);
     record.runConfig = config;
-    const descriptor =
-      record.runDescriptor ??
-      (executionId
-        ? descriptorFromConfig(stream, executionId, config)
-        : undefined);
+    // Synthesize an identity only for a run that never emitted `run.start`
+    // (legacy meta, hosts driving the store by hand). A descriptor left over
+    // from a PREVIOUS execution is not this run's identity, so it is replaced
+    // rather than kept: the descriptor always describes the execution the
+    // stream's meta names, which is what lets the seed path tell a live pair
+    // apart from one disk has moved past.
+    let descriptor = record.runDescriptor;
+    if (executionId && descriptor?.executionId !== executionId) {
+      descriptor = descriptorFromConfig(stream, executionId, config);
+    }
     if (descriptor) record.runDescriptor = descriptor;
     this.queueMetaPatch(stream, {
       ...(executionId ? { executionId } : {}),
@@ -1503,6 +1516,14 @@ export class StreamSnapshotStore {
   setRunDescriptor(descriptor: RunDescriptor): void {
     const stream = descriptor.streamId;
     const record = this.getOrCreateRecord(stream);
+    // The config of the run this stream just left is not this run's config;
+    // `run.config` follows `run.start` with the new one. A config carrying no
+    // identity yet is this run's until something says otherwise, so only a
+    // KNOWN previous execution drops it.
+    const previous = record.runDescriptor;
+    if (previous && previous.executionId !== descriptor.executionId) {
+      record.runConfig = undefined;
+    }
     record.runDescriptor = descriptor;
     this.queueMetaPatch(stream, {
       executionId: descriptor.executionId,
@@ -1983,10 +2004,6 @@ export class StreamSnapshotStore {
     const version = this.streamVersion(stream);
     const record = this.getOrCreateRecord(stream);
     const metaOverlay = record.metaOverlay ? record.meta : undefined;
-    const runConfigOverlay =
-      metaOverlay !== undefined ? record.runConfig : undefined;
-    const runDescriptorOverlay =
-      metaOverlay !== undefined ? record.runDescriptor : undefined;
     const usageOverlayToReplay = new Map(record.overlays.usage);
     // Seeded with `data.legacyKeys` unconditionally (unlike the overlay
     // additions below, which are gated on that overlay actually being
@@ -2003,51 +2020,54 @@ export class StreamSnapshotStore {
     record.usage = new Map([...data.usage].filter(([, v]) => !isEmptyUsage(v)));
     record.usageUnparsed = new Map(data.usageUnparsed);
     record.workPlan = data.workPlan;
-    record.runDescriptor = undefined;
-    record.runConfig = undefined;
 
-    let meta = metaOverlay
+    const meta = metaOverlay
       ? { ...(data.meta ?? {}), ...metaOverlay }
       : data.meta;
-    let hydrated: HydratedRunState = {};
-    if (meta) {
-      record.meta = meta;
-      hydrated = await this.hydrateRunStateFromMeta(stream, meta);
-      if (this.streamVersion(stream) !== version) return;
-    } else {
-      record.meta = undefined;
-    }
-
-    // `record` rides across the hydration await above: records are mutated
-    // in place, never replaced, so re-reading its overlay fields here picks
-    // up any concurrent eager mutation that landed while hydration was in
-    // flight (the exact race #8014 fixed). Never re-resolve the record via
-    // `getOrCreateRecord` here — if the stream was evicted during the await,
-    // that would resurrect a record for a deleted stream and defeat
-    // `writeMergedSidecars`' eviction check (#8226); an orphaned `record` is
-    // mutated harmlessly and never written.
-    const latestMetaOverlay = record.metaOverlay ? record.meta : undefined;
-    if (latestMetaOverlay) {
-      meta = { ...(data.meta ?? {}), ...latestMetaOverlay };
-      record.meta = meta;
-    }
-    const latestRunConfigOverlay =
-      latestMetaOverlay !== undefined ? record.runConfig : undefined;
-    const latestRunDescriptorOverlay =
-      latestMetaOverlay !== undefined ? record.runDescriptor : undefined;
-    const runConfig =
-      latestRunConfigOverlay ?? runConfigOverlay ?? hydrated.config;
-    const executionId = executionIdFromMeta(meta);
-    const runDescriptor =
-      latestRunDescriptorOverlay ??
-      runDescriptorOverlay ??
-      hydrated.descriptor ??
-      (runConfig && executionId
-        ? descriptorFromConfig(stream, executionId, runConfig)
-        : undefined);
-    if (runConfig) record.runConfig = runConfig;
-    if (runDescriptor) record.runDescriptor = runDescriptor;
+    record.meta = meta;
     record.metaOverlay = false;
+
+    // Disk meta names which execution the stream is on, so a memory pair for a
+    // DIFFERENT execution (or for any execution once meta names none) is a
+    // handoff another writer completed: both halves go, and hydration installs
+    // a coherent pair instead of one half of each run. For the execution meta
+    // does name, the two halves have different owners. The descriptor is
+    // immutable, so the live `run.start` outranks anything hydration can
+    // synthesize from config. The config is mutable and persisted, so this seed
+    // re-reads it — another host can switch the model without this store seeing
+    // `run.config`, and `load()` promises a refresh — and yields only to a live
+    // config newer than the snapshot: one still pending at seed start, or one
+    // that lands during the hydration below. A config an EARLIER seed left in
+    // memory is not newer, and is what goes stale.
+    //
+    // `record` rides across the hydration await: records are mutated in place,
+    // never replaced. Never re-resolve it via `getOrCreateRecord` here — if the
+    // stream was evicted during the await, that would resurrect a record for a
+    // deleted stream and defeat `writeMergedSidecars`' eviction check (#8226);
+    // an orphaned `record` is mutated harmlessly and never written.
+    const executionId = executionIdFromMeta(meta);
+    if (!meta || record.runDescriptor?.executionId !== executionId) {
+      record.runDescriptor = undefined;
+      record.runConfig = undefined;
+    }
+    if (meta) {
+      const pendingLiveWrite = metaOverlay !== undefined;
+      const configBeforeHydration = record.runConfig;
+      const hydrated = await this.hydrateRunStateFromMeta(stream, meta);
+      if (this.streamVersion(stream) !== version) return;
+      // Re-checked after the await: a `run.start` for another execution can
+      // land during it, and this seed's pair belongs to the run it read.
+      const liveDescriptor = record.runDescriptor;
+      if (!liveDescriptor || liveDescriptor.executionId === executionId) {
+        record.runDescriptor ??= hydrated.descriptor;
+        const liveRunConfig =
+          record.runConfig !== undefined &&
+          (pendingLiveWrite || record.runConfig !== configBeforeHydration);
+        if (!liveRunConfig) {
+          record.runConfig = hydrated.config ?? record.runConfig;
+        }
+      }
+    }
 
     const { overlays } = record;
     if (overlays.outputFiles) {


### PR DESCRIPTION
## Summary

Implements the single-owner sketches for the lifecycle ownership map's **demonstrated races** (the map itself shipped with #9486: 211 multi-writer facts, 21 with demonstrated race risk). The goal state, applied fact by fact: one owner writes, everyone else reads, and the compensations that kept multiple writers honest — defensive re-reads, repair functions, mirror fields, belt-and-suspenders cross-checks — are deleted in the same change, each replaced by a test pinning the interleaving it guarded.

18 races were in scope (3 skipped as deliberate two-writers or blocked): **9 fully single-owner'd, 2 partial, 7 produced design reports** for the true redesigns.

## Issue acceptance gates

No issue; campaign round on the #9486 map. The 7 report-only designs feed the runtime gold-standard PRD work.

## Single source of truth

- **WAITING suspension** is one handle-owned fact (`suspension: parked | terminating`); the registry's stop path consults no stream phase or substate. Deleted: the two-source cross-check and its 30-line justifying comment, `clearWaitingCleanup`, the multi-registrant cleanup set, the `_waitingTerminationStarted` mirror.
- **Terminal finalization** claims through one gate (`claimTerminalFinalize`) on every arm including the waiting-stop path, making double persist/untrack/phase writes impossible by construction.
- **Terminal outcome** resolves from the stream phase, with the lifecycle claiming the stream on both start branches so the phase is always this run's verdict; flow-record retention became a policy over the *resolved* outcome; the delivered subagent payload is relabeled to match.
- **`meta.outcome`** clears at both resume boundaries, so the read-time projection (which replaced the deleted `synchronizeAgentResultOutcome` repair function) can never relabel a live resumed run.
- Plus the tools/transcript/progress/CLI/extension single-owner fixes from the same map (bash child terminal phase, snapshot seed authority, roster status write-through, retry-route liveness, watcher rebuild queue).

## Duplication and abstraction budget

Mechanism count strictly decreases: every change deletes more coordination than it adds (a state enum or a policy function replaces two booleans plus discipline). No middle layers.

## Net elements (R6)

| | |
| --- | --- |
| Files changed | 53 |
| Net LoC | +1,739 (2,958 insertions, 1,219 deletions) — the insertions are dominated by race tests: every deleted guard's interleaving is now pinned |
| Exported symbols | +1 (5 added, 4 removed) |

## Consumer counts (R8)

`synchronizeAgentResultOutcome` deleted (grep-zero consumers after callers moved to the read-time projection + resume-boundary clear); `registerWaitingCleanup` removed from the SDK-facing `AgentRunHandle` (zero repo callers). Dead-code ratchet 17 vs 17.

## Host impact

Extension / Desktop / CLI: no intended user-visible change. One deliberate edge-behavior change: `kill()` on a suspended handle returns `false` when a terminal finalize already claimed the run (previously it raced a second persist/untrack/phase write).

## Adversarial review and the fix pass

The race-focused review (categories: guard-deleted-case-uncovered, second-writer-survives, ordering-change) produced **32 findings — 3 high, 11 medium**. A verify-then-fix pass resolved all of them: **24 confirmed and fixed, 8 refuted with evidence, zero guards restored** — every real finding was closed by completing the design (threading the missing cause, resolving outcome before disposition, clearing meta.outcome at resume, claiming the stream at start), not by re-adding compensations.

The three worth reading:
1. **A stop landing between `track()` and run-start** could leave the previous run's terminal phase on a reused stream, and phase-wins resolution would publish COMPLETED for a killed run. Fixed by the start-time stream claim; two tests pin the window including the no-RUNNING-blip property.
2. **Flow-record disposition vs resolved outcome**: a run whose flow reported COMPLETED while a stop landed CANCELLED persisted `interrupted` yet **deleted** the flow record resumability needs. Retention is now a policy over the resolved outcome.
3. **Read-time outcome projection on resumed runs**: nothing cleared `meta.outcome` on resume, so a resumed-after-cancel child kept being served CANCELLED. Cleared at both resume boundaries, inside the lease-failure scopes.

## Sequencing note

Main moved 34 commits mid-round (#9494–#9503, including sibling runtime fixes). The branch was rebased before the fix pass ran, so every finding was verified against current main — several refutations cite exactly those newer commits.

## Validation

| check | result |
| --- | --- |
| `npm run typecheck` | pass |
| `env -u FORCE_COLOR npm test` | 805 files, 8,170 tests, 0 failures |
| lint / prettier | pass |
| dead-code + architecture ratchets | pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qs4Vgf3VxahEjs5maQF5Ds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches terminal outcome arbitration, suspended-run teardown, credential commit on CLI retries, and execution persistence on resume—core run lifecycle and auth-adjacent CLI paths where race bugs have high blast radius.
> 
> **Overview**
> This PR **collapses multi-writer “demonstrated races” into one owner per fact** and removes the compensations (re-reads, mirror fields, repair sweeps) that previously kept writers from disagreeing. Behavior is meant to stay the same except where noted below.
> 
> **Agent runtime** is the bulk of the change. **WAITING suspension** lives on the handle (`suspend` / `beginSuspendedTermination`) instead of a separate waiting-cleanup registry plus stream-phase cross-checks. **Terminal finalization** goes through one `claimTerminalFinalize` gate; **`finalizeRunTerminal` resolves outcome from the stream phase** (with start-time stream claims so a reused stream does not inherit the last run’s verdict). Flow-record retention and delivered subagent payloads follow that **resolved** outcome. **`synchronizeAgentResultOutcome` is removed** in favor of **`applyExecutionOutcome` on read** and **`clearTerminalExecutionState` at resume** so stale `meta.outcome` cannot relabel a live run. Progress view **child roster status** is written via `recordChildPhase` instead of late projection in `projectChildRosters`.
> 
> **CLI TUI** folds retry pre-modal work into the approval queue: **`reserveApproval`** with `preparing` / `pending` / `committing` phases and **`clearApprovalsForOwner`** replace the per-stream retry route map and `onApprovalsCleared` listener.
> 
> **Desktop** drops main-process editor dirty IPC; unsaved changes are enforced only via renderer **`beforeunload`** and **`will-prevent-unload`**.
> 
> **VS Code extension**: sidebar mode is **`setActiveSidebarView` synchronous** (no await on context publish); progress/main providers wire earlier; **agent directory watcher rebuilds** use a single **`PQueue`** instead of promise + rebuild-requested flag.
> 
> **Intended edge change:** `kill()` on a suspended handle can return **false** when terminal finalize already claimed the run (avoids double persist/phase writes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b444dc30918949f0750f79e0181d2e78d5be94f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->