### PR TITLE
refactor: compiler-enforce invariants in ad-hoc grab-bag data structures

### DIFF
--- a/packages/cli/src/chat/tui/panes/StatusBar.tsx
+++ b/packages/cli/src/chat/tui/panes/StatusBar.tsx
@@ -204,7 +204,7 @@ export function StatusBar(props: StatusBarProps): React.JSX.Element {
     compactingActive: statusSlice?.compactingActive ?? false,
     queuedFollowUpMessages: statusSlice?.queuedFollowUpMessages ?? [],
     usage: statusSlice?.usage,
-    roundStage: statusSlice?.roundStage,
+    stage: statusSlice?.stage,
     subagents: subagentCount,
     approvalDepth: approvals.depth,
     approvalKind: approvals.kind,

--- a/packages/cli/src/chat/tui/panes/SubagentList.tsx
+++ b/packages/cli/src/chat/tui/panes/SubagentList.tsx
@@ -49,6 +49,7 @@ import {
   pendingApprovalRowSuffix,
 } from './SubagentListDisplay';
 import type { PendingApprovalKind } from '../state/approvalQueue';
+import type { StreamStage } from '../state/cliState';
 import type { StreamView } from '../state/streamViews';
 
 function HiddenRowSummary({
@@ -116,6 +117,14 @@ function PhaseHeader({
   );
 }
 
+// A workflow-script run advances through phases, a tool-use run through
+// rounds; one slot carries whichever this stream has.
+function formatStageLabel(stage: StreamStage | undefined): string | undefined {
+  if (stage === undefined) return undefined;
+  if (stage.kind === 'round') return formatRoundStageLabel(stage);
+  return formatPhaseStageLabel(stage);
+}
+
 function SessionRow({
   active,
   focused,
@@ -153,11 +162,7 @@ function SessionRow({
   // this truncate-end text sheds inline elapsed (narrow mode only), the round,
   // and last the pending-approval kind. The metadata column never shrinks.
   const approvalSuffix = pendingApprovalRowSuffix(pendingKinds);
-  // A workflow-script run advances through phases, a tool-use run through
-  // rounds; one slot carries whichever this stream has.
-  const stageLabel =
-    formatPhaseStageLabel(session.slice?.phaseStage) ??
-    formatRoundStageLabel(session.slice?.roundStage);
+  const stageLabel = formatStageLabel(session.slice?.stage);
   // The resolved model is per-agent identity (a workflow run's grandchildren
   // can each resolve a different model); the list-root row is the conversation
   // itself, whose model already rides the status bar. A background bash stream

--- a/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
+++ b/packages/cli/src/chat/tui/panes/statusBarDisplay.ts
@@ -19,7 +19,6 @@ import { resolveProviderCapabilities } from '@model/providerCapabilities';
 import {
   spendingQuotaRemainingPercent,
   spendingQuotaState,
-  type RoundStage,
   type SpendingStatus,
   type StreamPhase,
   type StreamSubstate,
@@ -27,7 +26,10 @@ import {
   type TokenUsageStats,
 } from '@shared/schemas';
 import { isActivePhase } from '@shared/streams/streamStatus';
-import { formatRoundStageLabel } from '@shared/streams/streamStatusDisplay';
+import {
+  formatPhaseStageLabel,
+  formatRoundStageLabel,
+} from '@shared/streams/streamStatusDisplay';
 import {
   filterNotNullish,
   formatCompactDuration,
@@ -45,6 +47,7 @@ import { formatResumeCommand } from '../state/resumeHint';
 import {
   type BypassState,
   type StreamSlice,
+  type StreamStage,
   type TransientNotice,
 } from '../state/cliState';
 import {
@@ -91,7 +94,7 @@ export interface StatusBarDisplayInput {
   readonly compactingActive?: boolean;
   readonly queuedFollowUpMessages: readonly string[];
   readonly usage: TokenUsageStats | undefined;
-  readonly roundStage: RoundStage | undefined;
+  readonly stage: StreamStage | undefined;
   /** Retained and active direct subagents owned by the displayed stream. */
   readonly subagents: number;
   readonly approvalDepth: number;
@@ -263,25 +266,42 @@ function formatUsage(
   };
 }
 
-function roundSegment(
-  roundStage: RoundStage | undefined,
+// A workflow-script run advances through phases, a tool-use run through
+// rounds; one status-bar slot carries whichever this stream has (mirrors the
+// SubagentList row's `stageLabel`).
+function stageSegment(
+  stage: StreamStage | undefined,
 ): StatusBarSegment | undefined {
-  return roundStage !== undefined
-    ? {
-        text: formatRoundStageLabel(roundStage),
-        // Keep round visibility on narrow terminals: degrade to the bare
-        // current-round label instead of dropping the planned total's context.
-        compactText: formatRoundStageLabel({ index: roundStage.index }),
-        color: 'dim',
-        compactPriority: STATUS_BAR_COMPACT_PRIORITY.round,
-      }
-    : undefined;
+  if (stage === undefined) return undefined;
+  if (stage.kind === 'round') {
+    return {
+      text: formatRoundStageLabel(stage),
+      // Keep round visibility on narrow terminals: degrade to the bare
+      // current-round label instead of dropping the planned total's context.
+      compactText: formatRoundStageLabel({ index: stage.index }),
+      color: 'dim',
+      compactPriority: STATUS_BAR_COMPACT_PRIORITY.stage,
+    };
+  }
+  const text = formatPhaseStageLabel(stage);
+  if (text === undefined) return undefined;
+  return {
+    text,
+    // Keep phase visibility on narrow terminals: degrade to the bare
+    // current-phase label instead of dropping the planned total's context.
+    compactText: formatPhaseStageLabel({
+      label: stage.label,
+      ...(stage.index !== undefined ? { index: stage.index } : {}),
+    }),
+    color: 'dim',
+    compactPriority: STATUS_BAR_COMPACT_PRIORITY.stage,
+  };
 }
 
 // Lower values are removed first when the left status group exceeds the row.
 const STATUS_BAR_COMPACT_PRIORITY = {
   activeSubagent: 20,
-  round: 30,
+  stage: 30,
   usage: 40,
   queuedFollowUp: 50,
   approvalPolicy: 55,
@@ -962,7 +982,7 @@ export function buildStatusBarDisplay(
       accessModeSegment(input.modelAccess),
       relayQuotaSegment(input.relayQuota, input.modelAccess),
       approvalPolicySegment(input.approvalPolicy),
-      roundSegment(input.roundStage),
+      stageSegment(input.stage),
       formatUsage(input.usage, input.model),
       queuedFollowUpsCountSegment(input.queuedFollowUpMessages),
       subagentsSegment(input.subagents),

--- a/packages/cli/src/chat/tui/state/cliState.ts
+++ b/packages/cli/src/chat/tui/state/cliState.ts
@@ -13,10 +13,8 @@ import {
   type MessageType,
   type NormalizedToolUse,
   type OutputFileInfo,
-  type PhaseStage,
   type Plan,
   type RoundIndexed,
-  type RoundStage,
   type StreamPhase,
   type StreamSubstate,
   type StreamTabId,
@@ -153,6 +151,33 @@ interface StreamFileMetadata {
   readonly output: readonly string[];
 }
 
+/**
+ * Current run/round/phase progress for one stream. A tool-use run advances
+ * through numbered rounds; a workflow-script run advances through named
+ * phases instead — never both — so this is one discriminated field rather
+ * than two independently-optional ones (`roundStage` / `phaseStage`) that
+ * every reader had to fall back between.
+ */
+export type StreamStage =
+  | {
+      readonly kind: 'round';
+      /** Zero-based round/turn index. */
+      readonly index: number;
+      /** Planned total, when known. Workflow runs set this; tool-use turns
+       *  may not. */
+      readonly total?: number;
+    }
+  | {
+      readonly kind: 'phase';
+      /** Phase title, free-form text from the workflow script. */
+      readonly label: string;
+      /** Zero-based position in the declared phase list. Absent for a phase
+       *  the script opened dynamically, which has no declared position. */
+      readonly index?: number;
+      /** Number of declared phases, when known. */
+      readonly total?: number;
+    };
+
 export interface StreamSlice {
   readonly streamId: StreamTabId;
   /** Model identity captured from setTaskState for this specific stream. */
@@ -200,10 +225,12 @@ export interface StreamSlice {
   /** True while the runtime is summarizing prior conversation context. */
   readonly compactingActive: boolean;
   readonly conversation: ConversationProgress | undefined;
-  readonly roundStage?: RoundStage | undefined;
-  /** Current workflow-script phase. Fills the same row slot as `roundStage`
-   *  — a run advances through phases or rounds, never both. */
-  readonly phaseStage?: PhaseStage | undefined;
+  /** Round/turn progress (tool-use runs) or workflow-script phase progress
+   *  (workflow runs) — a run advances through phases or rounds, never both,
+   *  so one discriminated slot fills the same row/segment either renderer
+   *  reads, instead of two independently-optional fields every consumer had
+   *  to fall back between. */
+  readonly stage?: StreamStage | undefined;
   readonly entries: readonly ConversationEntry[];
   readonly queuedFollowUpMessages: readonly string[];
   readonly todos: readonly TodoItem[];
@@ -259,8 +286,7 @@ function emptySlice(streamId: StreamTabId): StreamSlice {
     usage: undefined,
     cumulativeUsage: undefined,
     conversation: undefined,
-    roundStage: undefined,
-    phaseStage: undefined,
+    stage: undefined,
     entries: [],
     queuedFollowUpMessages: [],
     todos: [],

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -10,9 +10,7 @@ import {
   type ClearMissingOutputsPayload,
   type SetActiveStreamPayload,
   type StreamTabId,
-  type UpdatePhaseStagePayload,
   type UpdateQueuedFollowUpsPayload,
-  type UpdateRoundStagePayload,
   type UpdateStreamUsagePayload,
 } from '@shared/schemas';
 import type { StreamSnapshotStore } from '@transcript';
@@ -25,6 +23,7 @@ import {
   recordMissingOutputsReset,
   removeStream,
   registerCliStateResetHook,
+  type StreamStage,
 } from './cliState';
 import {
   applySubagentRoster,
@@ -108,35 +107,10 @@ function applyRunConfig(streamId: StreamTabId, config: AgentConfig): void {
   });
 }
 
-function applyRoundStage(payload: UpdateRoundStagePayload): void {
-  patchStream(payload.streamId, (s) => {
-    if (
-      s.roundStage?.index === payload.roundStage.index &&
-      s.roundStage?.total === payload.roundStage.total
-    ) {
-      return s;
-    }
-    return {
-      ...s,
-      roundStage: payload.roundStage,
-    };
-  });
-}
-
-function applyPhaseStage(payload: UpdatePhaseStagePayload): void {
-  patchStream(payload.streamId, (s) => {
-    if (
-      s.phaseStage?.label === payload.phaseStage.label &&
-      s.phaseStage?.index === payload.phaseStage.index &&
-      s.phaseStage?.total === payload.phaseStage.total
-    ) {
-      return s;
-    }
-    return {
-      ...s,
-      phaseStage: payload.phaseStage,
-    };
-  });
+function applyStage(streamId: StreamTabId, stage: StreamStage): void {
+  patchStream(streamId, (s) =>
+    isDeepStrictEqual(s.stage, stage) ? s : { ...s, stage },
+  );
 }
 
 type MissingOutputTargetResolver = Pick<
@@ -230,27 +204,23 @@ function applyDirectTuiRunEvent(
       return;
     case 'stage.start':
       if (event.kind === 'phase') {
-        applyPhaseStage({
-          streamId: fallbackStreamId,
-          phaseStage: {
-            label: event.label,
-            ...(event.index !== undefined ? { index: event.index } : {}),
-            ...(event.total !== undefined && event.total > 0
-              ? { total: event.total }
-              : {}),
-          },
+        applyStage(fallbackStreamId, {
+          kind: 'phase',
+          label: event.label,
+          ...(event.index !== undefined ? { index: event.index } : {}),
+          ...(event.total !== undefined && event.total > 0
+            ? { total: event.total }
+            : {}),
         });
         return;
       }
       if (event.kind !== 'round') return;
-      applyRoundStage({
-        streamId: fallbackStreamId,
-        roundStage: {
-          index: event.index ?? 0,
-          ...(event.total !== undefined && event.total > 0
-            ? { total: event.total }
-            : {}),
-        },
+      applyStage(fallbackStreamId, {
+        kind: 'round',
+        index: event.index ?? 0,
+        ...(event.total !== undefined && event.total > 0
+          ? { total: event.total }
+          : {}),
       });
       return;
     case 'child.activity':

--- a/packages/cli/src/runtime/cliPresentationHost.ts
+++ b/packages/cli/src/runtime/cliPresentationHost.ts
@@ -1,7 +1,9 @@
 // Local imports - runtime
-import type {
-  RuntimePresentationEvent,
-  RuntimePresentationEventPayloads,
+import {
+  dispatchPresentationEvent,
+  type PresentationEventHandlers,
+  type RuntimePresentationEvent,
+  type RuntimePresentationEventPayloads,
 } from '@agent/runtime/runtimePresentationEvents';
 import type {
   ApprovalBypassKind,
@@ -10,7 +12,6 @@ import type {
 import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import type { CliNdjsonRecord } from '@cli/schemas/cliOutput';
 import { INSTRUCTION_ACTION, type InstructionAction } from '@shared/schemas';
-import { assertNever } from '@utils/core';
 
 // Local imports - CLI runtime
 import {
@@ -59,35 +60,45 @@ const INSTRUCTION_ACTION_HINT: Partial<Record<InstructionAction, string>> = {
   [INSTRUCTION_ACTION.OPEN_MODELS_DOC]: 'see the model documentation',
 } satisfies Record<InstructionAction, string>;
 
-function writeRuntimePresentationNdjson(
+/**
+ * Builds the NDJSON-mode handler map. None of these events have an NDJSON
+ * wire representation of their own today, so `requestOpenFile`,
+ * `showAgentConfigBanner`, and `requestEnsureProgressView` are deliberate
+ * no-ops here (unlike the text-mode handlers below, which still surface a
+ * debug log for the events they don't render). Building this per `logger`
+ * keeps the handlers closed over the specific `Logger` instance in play at
+ * call time (an ndjson sink is created lazily via `ensureLogger()`).
+ */
+function createRuntimePresentationNdjsonHandlers(
   logger: Logger,
-  event: RuntimePresentationEvent,
-  payload: RuntimePresentationEventPayloads[RuntimePresentationEvent],
-): void {
-  switch (event) {
-    case 'requestShowError': {
-      const errorPayload =
-        payload as RuntimePresentationEventPayloads['requestShowError'];
-      logger.error(errorPayload.message);
-      return;
-    }
-    case 'requestShowInstruction': {
-      const instructionPayload =
-        payload as RuntimePresentationEventPayloads['requestShowInstruction'];
-      logger.info(instructionPayload.message, {
-        key: instructionPayload.key,
-        actions: instructionPayload.actions,
-        showSuppress: instructionPayload.showSuppress,
+): PresentationEventHandlers<RuntimePresentationEventPayloads> {
+  return {
+    requestShowError: (payload) => {
+      logger.error(payload.message);
+    },
+    requestShowInstruction: (payload) => {
+      logger.info(payload.message, {
+        key: payload.key,
+        actions: payload.actions,
+        showSuppress: payload.showSuppress,
       });
-      return;
-    }
-    case 'requestOpenFile':
-    case 'showAgentConfigBanner':
-    case 'requestEnsureProgressView':
-      return;
-    default:
-      assertNever(event, 'Unhandled CLI NDJSON presentation event');
-  }
+    },
+    requestOpenFile: () => undefined,
+    showAgentConfigBanner: () => undefined,
+    requestEnsureProgressView: () => undefined,
+  };
+}
+
+function writeRuntimePresentationNdjson<K extends RuntimePresentationEvent>(
+  logger: Logger,
+  event: K,
+  payload: RuntimePresentationEventPayloads[K],
+): void {
+  dispatchPresentationEvent(
+    createRuntimePresentationNdjsonHandlers(logger),
+    event,
+    payload,
+  );
 }
 
 export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
@@ -101,6 +112,44 @@ export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
     logger = createCliLogger(sink);
     return logger;
   }
+
+  const logDebugEvent = (event: RuntimePresentationEvent): void => {
+    if (context.quietLogs) return;
+    ensureLogger().debug(`Runtime event: ${String(event)}`);
+  };
+
+  /**
+   * Text-mode (non-NDJSON) handler map. `requestOpenFile`,
+   * `showAgentConfigBanner`, and `requestEnsureProgressView` have no
+   * dedicated text-mode presentation today, so each falls back to the same
+   * quiet debug log the pre-refactor `else` branch produced for "everything
+   * else" — reproduced per-key here rather than as a catch-all, so a future
+   * `RuntimePresentationEventPayloads` addition is a compile error to decide
+   * on rather than a silent fall-through.
+   */
+  const textModeHandlers: PresentationEventHandlers<RuntimePresentationEventPayloads> =
+    {
+      requestShowError: (payload) => {
+        runProgress?.preserve();
+        ensureLogger().error(payload.message);
+      },
+      requestShowInstruction: (payload) => {
+        // Not gated by quietLogs (below): unlike the debug fallback, this is
+        // an actionable instruction (e.g. missing API key), not routine
+        // progress noise.
+        runProgress?.preserve();
+        const hint = payload.actions?.length
+          ? ` (${payload.actions
+              .map((action) => INSTRUCTION_ACTION_HINT[action] ?? action)
+              .join(', ')})`
+          : '';
+        ensureLogger().info(`${payload.message}${hint}`);
+      },
+      requestOpenFile: () => logDebugEvent('requestOpenFile'),
+      showAgentConfigBanner: () => logDebugEvent('showAgentConfigBanner'),
+      requestEnsureProgressView: () =>
+        logDebugEvent('requestEnsureProgressView'),
+    };
 
   return {
     attachRunProgressRenderer: (events) =>
@@ -123,42 +172,11 @@ export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
       if (closed) return;
 
       if (context.outputFormat === 'ndjson') {
-        writeRuntimePresentationNdjson(
-          ensureLogger(),
-          event,
-          payload as RuntimePresentationEventPayloads[RuntimePresentationEvent],
-        );
+        writeRuntimePresentationNdjson(ensureLogger(), event, payload);
         return;
       }
 
-      if (event === 'requestShowError') {
-        runProgress?.preserve();
-        ensureLogger().error(
-          (payload as RuntimePresentationEventPayloads['requestShowError'])
-            .message,
-        );
-        return;
-      }
-
-      if (event === 'requestShowInstruction') {
-        // Not gated by quietLogs (below): unlike the debug fallback, this is
-        // an actionable instruction (e.g. missing API key), not routine
-        // progress noise.
-        runProgress?.preserve();
-        const instructionPayload =
-          payload as RuntimePresentationEventPayloads['requestShowInstruction'];
-        const hint = instructionPayload.actions?.length
-          ? ` (${instructionPayload.actions
-              .map((action) => INSTRUCTION_ACTION_HINT[action] ?? action)
-              .join(', ')})`
-          : '';
-        ensureLogger().info(`${instructionPayload.message}${hint}`);
-        return;
-      }
-
-      if (context.quietLogs) return;
-
-      ensureLogger().debug(`Runtime event: ${String(event)}`);
+      dispatchPresentationEvent(textModeHandlers, event, payload);
     },
     async close() {
       closed = true;

--- a/packages/cli/src/runtime/cliPresentationHost.ts
+++ b/packages/cli/src/runtime/cliPresentationHost.ts
@@ -89,21 +89,11 @@ function createRuntimePresentationNdjsonHandlers(
   };
 }
 
-function writeRuntimePresentationNdjson<K extends RuntimePresentationEvent>(
-  logger: Logger,
-  event: K,
-  payload: RuntimePresentationEventPayloads[K],
-): void {
-  dispatchPresentationEvent(
-    createRuntimePresentationNdjsonHandlers(logger),
-    event,
-    payload,
-  );
-}
-
 export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
   let sink: LogSink | undefined;
   let logger: Logger | undefined;
+  let ndjsonHandlers:
+    PresentationEventHandlers<RuntimePresentationEventPayloads> | undefined;
   let closed = false;
   const runProgress = createRunProgressRenderer(context);
   function ensureLogger(): Logger {
@@ -172,7 +162,9 @@ export function createCliRuntimeHost(context: CliContext): CliRuntimeHost {
       if (closed) return;
 
       if (context.outputFormat === 'ndjson') {
-        writeRuntimePresentationNdjson(ensureLogger(), event, payload);
+        ndjsonHandlers ??=
+          createRuntimePresentationNdjsonHandlers(ensureLogger());
+        dispatchPresentationEvent(ndjsonHandlers, event, payload);
         return;
       }
 

--- a/packages/cli/src/runtime/workflowPlainProjection.ts
+++ b/packages/cli/src/runtime/workflowPlainProjection.ts
@@ -28,16 +28,6 @@ export interface WorkflowPlainProjectionOptions {
   readonly beforeWrite?: () => void;
 }
 
-/** Read `key`'s value from `map`, creating and storing it via `create` on a
- *  miss. Kept local: the only insert-or-create nested map in this file. */
-function getOrCreate<K, V>(map: Map<K, V>, key: K, create: () => V): V {
-  const existing = map.get(key);
-  if (existing !== undefined) return existing;
-  const created = create();
-  map.set(key, created);
-  return created;
-}
-
 function completionLine(outcome: RunOutcome, agentName: string): string {
   const label = (() => {
     switch (outcome) {
@@ -122,12 +112,11 @@ function createWorkflowStreamProjection(
             event.stageId !== undefined &&
             !openedPhases.has(event.stageId)
           ) {
-            const pending = getOrCreate(
-              pendingCalls,
-              event.stageId,
-              () => new Map<string, WorkflowCallProgress>(),
-            );
+            const pending =
+              pendingCalls.get(event.stageId) ??
+              new Map<string, WorkflowCallProgress>();
             pending.set(event.logId, event.task);
+            pendingCalls.set(event.stageId, pending);
           } else {
             writeCall(event.logId, event.task);
           }

--- a/packages/cli/src/runtime/workflowPlainProjection.ts
+++ b/packages/cli/src/runtime/workflowPlainProjection.ts
@@ -28,6 +28,16 @@ export interface WorkflowPlainProjectionOptions {
   readonly beforeWrite?: () => void;
 }
 
+/** Read `key`'s value from `map`, creating and storing it via `create` on a
+ *  miss. Kept local: the only insert-or-create nested map in this file. */
+function getOrCreate<K, V>(map: Map<K, V>, key: K, create: () => V): V {
+  const existing = map.get(key);
+  if (existing !== undefined) return existing;
+  const created = create();
+  map.set(key, created);
+  return created;
+}
+
 function completionLine(outcome: RunOutcome, agentName: string): string {
   const label = (() => {
     switch (outcome) {
@@ -112,11 +122,12 @@ function createWorkflowStreamProjection(
             event.stageId !== undefined &&
             !openedPhases.has(event.stageId)
           ) {
-            const pending =
-              pendingCalls.get(event.stageId) ??
-              new Map<string, WorkflowCallProgress>();
+            const pending = getOrCreate(
+              pendingCalls,
+              event.stageId,
+              () => new Map<string, WorkflowCallProgress>(),
+            );
             pending.set(event.logId, event.task);
-            pendingCalls.set(event.stageId, pending);
           } else {
             writeCall(event.logId, event.task);
           }

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -20,9 +20,11 @@ import {
   presentFollowUpResult,
   submitFollowUp,
 } from '@agent/followUp/ToolUseFollowUp';
-import type {
-  RuntimePresentationEvent,
-  RuntimePresentationEventPayloads,
+import {
+  dispatchPresentationEvent,
+  type PresentationEventHandlers,
+  type RuntimePresentationEvent,
+  type RuntimePresentationEventPayloads,
 } from '@agent/runtime/runtimePresentationEvents';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { prepareMainViewExecutionLaunch } from '@controllers/mainView/backend/MainViewExecutionLaunchController';
@@ -199,6 +201,13 @@ export class DesktopProgressBridge {
   private toolEditApprovals: ToolEditApprovalController | undefined;
   private hostInteractions!: ProgressHostInteractions;
   private fileActions!: DesktopProgressFileActions;
+  /**
+   * One handler per `RuntimePresentationEvent`, dispatched via
+   * `dispatchPresentationEvent` from `handlePresentationEvent` below. Built
+   * once in the constructor (rather than per-call) since every handler body
+   * only closes over `this`, which is stable for the bridge's lifetime.
+   */
+  private readonly presentationEventHandlers: PresentationEventHandlers<RuntimePresentationEventPayloads>;
   private readonly initialization: Promise<void>;
   private disposed = false;
   private presentationReady = false;
@@ -218,6 +227,46 @@ export class DesktopProgressBridge {
       polishText: (text, fileContext) =>
         polishTextWithAI(text, fileContext, options.session),
     });
+    this.presentationEventHandlers = {
+      // The desktop task shell keeps the conversation canvas permanently on
+      // screen, so there is no separate progress surface to reveal.
+      requestEnsureProgressView: () => undefined,
+      requestShowError: ({ message }) => {
+        void this.options.host.showErrorMessage(message);
+      },
+      requestShowInstruction: (instruction) => {
+        // An instruction is actionable guidance, not a failure, so it uses
+        // the info dialog. The desktop dialog carries no buttons, so the
+        // action tokens the extension renders as buttons become trailing
+        // hint text and `showSuppress` has no affordance to attach to.
+        const hint = instruction.actions?.length
+          ? ` (${instruction.actions
+              .map((action) => INSTRUCTION_ACTION_HINT[action] ?? action)
+              .join(', ')})`
+          : '';
+        void this.options.host.showInfoMessage(`${instruction.message}${hint}`);
+      },
+      showAgentConfigBanner: ({ agentName }) => {
+        this.postToRenderer({
+          command: MAIN_VIEW_COMMANDS.SHOW_AGENT_CONFIG_BANNER,
+          agentName,
+          customDirSet: true,
+        });
+      },
+      requestOpenFile: (data: RequestOpenFilePayload) => {
+        // The extension previews via its LaTeX-Workshop build+view flow
+        // (openBuildDisplayIfTex); desktop has no such editor integration, so
+        // open the resolved path through the same preview-with-fallback host
+        // `openWorkflowOutput` already uses (see runExecution above).
+        this.options.host
+          .openPath(data.location.absolutePath)
+          .catch((error) => {
+            this.logger.warn('Failed to open requested file on desktop', {
+              data: toLogData(error),
+            });
+          });
+      },
+    };
     const presentationHost: Pick<SessionHostInteractions, 'emit'> = {
       emit: (event, payload) => this.handlePresentationEvent(event, payload),
     };
@@ -1075,63 +1124,7 @@ export class DesktopProgressBridge {
   ): void {
     if (this.disposed) return;
 
-    switch (event) {
-      // The desktop task shell keeps the conversation canvas permanently on
-      // screen, so there is no separate progress surface to reveal.
-      case 'requestEnsureProgressView':
-        return;
-      case 'requestShowError': {
-        const { message } =
-          payload as RuntimePresentationEventPayloads['requestShowError'];
-        void this.options.host.showErrorMessage(message);
-        return;
-      }
-      case 'requestShowInstruction': {
-        const instruction =
-          payload as RuntimePresentationEventPayloads['requestShowInstruction'];
-        // An instruction is actionable guidance, not a failure, so it uses the
-        // info dialog. The desktop dialog carries no buttons, so the action
-        // tokens the extension renders as buttons become trailing hint text
-        // and `showSuppress` has no affordance to attach to.
-        const hint = instruction.actions?.length
-          ? ` (${instruction.actions
-              .map((action) => INSTRUCTION_ACTION_HINT[action] ?? action)
-              .join(', ')})`
-          : '';
-        void this.options.host.showInfoMessage(`${instruction.message}${hint}`);
-        return;
-      }
-      case 'showAgentConfigBanner': {
-        const { agentName } =
-          payload as RuntimePresentationEventPayloads['showAgentConfigBanner'];
-        this.postToRenderer({
-          command: MAIN_VIEW_COMMANDS.SHOW_AGENT_CONFIG_BANNER,
-          agentName,
-          customDirSet: true,
-        });
-        return;
-      }
-      case 'requestOpenFile': {
-        // The extension previews via its LaTeX-Workshop build+view flow
-        // (openBuildDisplayIfTex); desktop has no such editor integration,
-        // so open the resolved path through the same preview-with-fallback
-        // host `openWorkflowOutput` already uses (see runExecution above).
-        const data = payload as RequestOpenFilePayload;
-        this.options.host
-          .openPath(data.location.absolutePath)
-          .catch((error) => {
-            this.logger.warn('Failed to open requested file on desktop', {
-              data: toLogData(error),
-            });
-          });
-        return;
-      }
-      default: {
-        const _exhaustive: never = event;
-        void _exhaustive;
-        return;
-      }
-    }
+    dispatchPresentationEvent(this.presentationEventHandlers, event, payload);
   }
 
   private updateStreamMetadata(): StreamTabId | '' {

--- a/packages/extension/src/frontend/events/agentEventListeners.ts
+++ b/packages/extension/src/frontend/events/agentEventListeners.ts
@@ -10,9 +10,11 @@
 import * as vscode from 'vscode';
 
 import type { SessionHostInteractions } from '@agent/runtime/HostInteractions';
-import type {
-  RuntimePresentationEvent,
-  RuntimePresentationEventPayloads,
+import {
+  dispatchPresentationEvent,
+  type PresentationEventHandlers,
+  type RuntimePresentationEvent,
+  type RuntimePresentationEventPayloads,
 } from '@agent/runtime/runtimePresentationEvents';
 import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 import { getMainWebview } from '@frontend/system/commandUtils';
@@ -138,56 +140,43 @@ async function handleRequestEnsureProgressView(
 }
 
 /**
- * Build the presentation host the extension's `HostInteractions` adapter
- * forwards `emit` calls to (`createExtensionHostInteractions`'s `interactions`
- * option, wired in `ProgressViewProvider`'s constructor).
- *
- * The five presentation events below are the extension's own dispatch,
- * replacing a previous per-host presentation-event bus and its static router
- * (a duplicate replay mechanism — see #9251).
+ * Builds the extension's presentation-event handler map. Every
+ * `RuntimePresentationEvent` key is required by
+ * `PresentationEventHandlers<RuntimePresentationEventPayloads>` — omitting
+ * one here is a compile error rather than a silently dropped event (CLAUDE.md,
+ * silent degradation), replacing the previous `switch`'s `never`-typed
+ * `default` guard. The five presentation events handled here are the
+ * extension's own dispatch, replacing a previous per-host presentation-event
+ * bus and its static router (a duplicate replay mechanism — see #9251).
  * `SessionHostInteractions` (the runtime) owns replaying an event emitted
  * before this host attaches, via `AgentRuntimeEmitOptions.replayWhenAttached`.
  */
+function createPresentationEventHandlers(
+  progressViewProvider: ProgressViewProvider,
+): PresentationEventHandlers<RuntimePresentationEventPayloads> {
+  return {
+    requestOpenFile: handleRequestOpenFile,
+    requestShowInstruction: handleRequestShowInstruction,
+    showAgentConfigBanner: (payload) => {
+      void handleShowAgentConfigBanner(payload);
+    },
+    requestShowError: handleRequestShowError,
+    requestEnsureProgressView: (payload) => {
+      void handleRequestEnsureProgressView(payload, progressViewProvider);
+    },
+  };
+}
+
 export function createAgentPresentationHost(
   progressViewProvider: ProgressViewProvider,
 ): Pick<SessionHostInteractions, 'emit'> {
+  const handlers = createPresentationEventHandlers(progressViewProvider);
   return {
     emit<K extends RuntimePresentationEvent>(
       event: K,
       payload: RuntimePresentationEventPayloads[K],
     ): void {
-      switch (event) {
-        case 'requestOpenFile':
-          handleRequestOpenFile(payload as RequestOpenFilePayload);
-          return;
-        case 'requestShowInstruction':
-          handleRequestShowInstruction(
-            payload as RequestShowInstructionPayload,
-          );
-          return;
-        case 'showAgentConfigBanner':
-          void handleShowAgentConfigBanner(
-            payload as ShowAgentConfigBannerPayload,
-          );
-          return;
-        case 'requestShowError':
-          handleRequestShowError(payload as RequestShowErrorPayload);
-          return;
-        case 'requestEnsureProgressView':
-          void handleRequestEnsureProgressView(
-            payload as RequestEnsureProgressViewPayload,
-            progressViewProvider,
-          );
-          return;
-        default: {
-          // Exhaustiveness guard: a new RuntimePresentationEvent must take an
-          // explicit stance here rather than being silently dropped by this
-          // host (CLAUDE.md, silent degradation).
-          const _exhaustive: never = event;
-          void _exhaustive;
-          return;
-        }
-      }
+      dispatchPresentationEvent(handlers, event, payload);
     },
   };
 }

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters/toolSections.ts
@@ -49,15 +49,16 @@ import {
   type ProposalFileGroup,
 } from '@shared/schemas/proposalFields';
 import { WorkflowScriptFilesSchema } from '@shared/schemas/workflowScriptFiles';
-import type { ExecutionsToolInput } from '@tools/ExecutionsTool';
+// Type-only: this is a browser frontend (see eslint `no-restricted-imports`
+// for packages/extension/src/{webview,progressView,settingsView}/frontend),
+// so runtime values (including each tool's Zod input schema) cannot be
+// imported from `@tools/**` here — only their inferred types, which are
+// erased at build time. Each builder below therefore validates the input
+// shape itself with `isObject`/`typeof` guards rather than a schema parse;
+// `ReadInput`/`WriteInput` are used purely for their (erased) type shape,
+// the rest are documented in each builder's own comment.
 import type { ReadInput } from '@tools/ReadTool';
 import type { WriteInput } from '@tools/WriteTool';
-import type {
-  DelegateAgentInput,
-  WorkflowAgentInput,
-} from '@tools/DelegationTools';
-import type { AcceptRunFilesInput } from '@tools/AcceptRunFilesTool';
-import type { MemoryToolInput } from '@tools/memory/MemoryTool';
 import { isObject } from '@utils/core';
 
 import { codexToolRenderers } from '../codexToolTemplates';
@@ -90,7 +91,20 @@ function buildFileGroupsSection(
   );
 }
 
-/** Common shape of the edit_file and str_replace_editor tool inputs, for display purposes only. */
+/**
+ * Common shape of the edit_file and str_replace_editor tool inputs, for
+ * display purposes only.
+ *
+ * No single canonical schema validates this shape: this dispatch entry
+ * ('edit' display kind) covers three different tool names — edit_file
+ * (`EditInputSchema`), str_replace_editor (`TextEditorInputSchema`, a
+ * discriminated union where only the `str_replace` branch has
+ * old_str/new_str), and str_replace_based_edit_tool, which is Anthropic's
+ * native tool-use alias and is not a registered TeXRA tool with its own
+ * schema at all. Rather than fabricate a schema spanning all three, this
+ * keeps the type-only cast but narrows with explicit runtime `typeof` checks
+ * below before any field is used.
+ */
 type EditDiffLikeInput = { old_str?: unknown; new_str?: unknown };
 
 function buildEditDiffInputSections(ctx: ToolSectionContext): TemplateResult[] {
@@ -124,16 +138,24 @@ function buildEditDiffInputSections(ctx: ToolSectionContext): TemplateResult[] {
   return sections;
 }
 
+/** Narrows `input.range` to `ReadInput['range']`'s display-relevant fields. */
+function readRangeOf(input: unknown): ReadInput['range'] {
+  if (!isObject(input) || !isObject(input.range)) return undefined;
+  const { start, end } = input.range;
+  if (typeof start !== 'number') return undefined;
+  return { start, end: typeof end === 'number' ? end : undefined };
+}
+
 function buildFileLinkSections(ctx: ToolSectionContext): TemplateResult[] {
   const { input, filePath } = ctx;
   if (!filePath) return [];
-  const readInput = isObject(input) ? (input as ReadInput) : undefined;
+  const range = readRangeOf(input);
   return [
     buildToolUseSection(
       'File:',
       buildFileLinkWithLines(filePath, {
-        startLine: readInput?.range?.start,
-        endLine: readInput?.range?.end ?? undefined,
+        startLine: range?.start,
+        endLine: range?.end ?? undefined,
       }),
     ),
   ];
@@ -142,14 +164,20 @@ function buildFileLinkSections(ctx: ToolSectionContext): TemplateResult[] {
 function buildFileContentSections(ctx: ToolSectionContext): TemplateResult[] {
   const { toolName, input, filePath } = ctx;
   if (!filePath) return [];
-  const writeInput = isObject(input) ? (input as WriteInput) : undefined;
+  // WriteInput's only display-relevant field; validated directly rather than
+  // via `WriteInputSchema` (a runtime import from `@tools/WriteTool`, which a
+  // browser frontend may not use — see the import-block comment above).
+  const content: WriteInput['content'] | undefined =
+    isObject(input) && typeof input.content === 'string'
+      ? input.content
+      : undefined;
   const contentLanguage = getLanguageFromPath(filePath);
   const sections = [
     buildToolUseSection('File:', buildFileLinkWithLines(filePath)),
   ];
-  if (typeof writeInput?.content === 'string') {
+  if (content !== undefined) {
     sections.push(
-      buildToolSection('', writeInput.content, {
+      buildToolSection('', content, {
         toolName,
         language: contentLanguage,
       }),
@@ -158,11 +186,20 @@ function buildFileContentSections(ctx: ToolSectionContext): TemplateResult[] {
   return sections;
 }
 
+/**
+ * `MemoryToolInput` is a `z.discriminatedUnion` on the host-only
+ * `MemoryToolInputSchema` (`@tools/memory/MemoryTool`), which this browser
+ * frontend cannot import as a runtime value (see the import-block comment
+ * above). Rather than re-implement the full 8-branch union as a parallel
+ * schema, each field this section actually displays is read directly with
+ * its own `typeof` guard.
+ */
 function buildMemorySections(ctx: ToolSectionContext): TemplateResult[] {
   const { input } = ctx;
-  if (!isObject(input)) return [];
-  const memInput = input as MemoryToolInput;
-  const memPath = memInput.command === 'rename' ? '' : (memInput.path ?? '');
+  if (!isObject(input) || typeof input.command !== 'string') return [];
+  const command = input.command;
+  const path = typeof input.path === 'string' ? input.path : undefined;
+  const memPath = command === 'rename' ? '' : (path ?? '');
   const sections: TemplateResult[] = [];
 
   if (memPath) {
@@ -171,45 +208,47 @@ function buildMemorySections(ctx: ToolSectionContext): TemplateResult[] {
     );
   }
 
-  if (
-    memInput.command === 'str_replace' &&
-    memInput.old_str != null &&
-    memInput.new_str != null
-  ) {
+  const oldStr = typeof input.old_str === 'string' ? input.old_str : undefined;
+  const newStr = typeof input.new_str === 'string' ? input.new_str : undefined;
+  const fileText =
+    typeof input.file_text === 'string' ? input.file_text : undefined;
+  const insertText =
+    typeof input.insert_text === 'string' ? input.insert_text : undefined;
+  const insertLine =
+    typeof input.insert_line === 'number' ? input.insert_line : undefined;
+  const oldPath =
+    typeof input.old_path === 'string' ? input.old_path : undefined;
+  const newPath =
+    typeof input.new_path === 'string' ? input.new_path : undefined;
+
+  if (command === 'str_replace' && oldStr != null && newStr != null) {
     sections.push(
-      buildToolUseSection(
-        '',
-        buildEditDiffSection(memInput.old_str, memInput.new_str),
-      ),
+      buildToolUseSection('', buildEditDiffSection(oldStr, newStr)),
     );
-  } else if (memInput.command === 'create' && memInput.file_text != null) {
+  } else if (command === 'create' && fileText != null) {
     const contentLanguage = memPath
       ? getLanguageFromPath(memPath)
       : 'plaintext';
     sections.push(
-      buildToolSection('', memInput.file_text, {
+      buildToolSection('', fileText, {
         language: contentLanguage,
       }),
     );
-  } else if (memInput.command === 'insert') {
-    const insertText = memInput.insert_text ?? memInput.new_str;
-    if (insertText != null) {
+  } else if (command === 'insert') {
+    const text = insertText ?? newStr;
+    if (text != null) {
       const lineLabel =
-        memInput.insert_line != null
-          ? `Insert at line ${memInput.insert_line}:`
-          : 'Insert:';
+        insertLine != null ? `Insert at line ${insertLine}:` : 'Insert:';
       const contentLanguage = memPath
         ? getLanguageFromPath(memPath)
         : 'plaintext';
       sections.push(
-        buildToolSection(lineLabel, insertText, {
+        buildToolSection(lineLabel, text, {
           language: contentLanguage,
         }),
       );
     }
-  } else if (memInput.command === 'rename') {
-    const oldPath = memInput.old_path;
-    const newPath = memInput.new_path;
+  } else if (command === 'rename') {
     if (oldPath != null && newPath != null) {
       sections.push(
         buildToolUseSection('Rename:', wrapInPre(`${oldPath} → ${newPath}`)),
@@ -219,12 +258,18 @@ function buildMemorySections(ctx: ToolSectionContext): TemplateResult[] {
   return sections;
 }
 
+/**
+ * `ExecutionsToolInput` derives from the host-only `ExecutionsToolInputSchema`
+ * (`@tools/ExecutionsTool`), unavailable as a runtime import here (see the
+ * import-block comment above); fields are read with individual guards
+ * instead.
+ */
 function buildExecutionsSections(ctx: ToolSectionContext): TemplateResult[] {
   const { input } = ctx;
   if (!isObject(input)) return [];
-  const execInput = input as ExecutionsToolInput;
-  const execPath = execInput.path ?? '';
-  const action = execInput.action ?? EXECUTIONS_DEFAULT_ACTION;
+  const execPath = typeof input.path === 'string' ? input.path : '';
+  const action: string =
+    typeof input.action === 'string' ? input.action : EXECUTIONS_DEFAULT_ACTION;
   const sections: TemplateResult[] = [];
 
   if (execPath) {
@@ -234,7 +279,7 @@ function buildExecutionsSections(ctx: ToolSectionContext): TemplateResult[] {
   }
 
   if (action === 'wait') {
-    const timeout = getExecutionsWaitTimeoutSeconds(execInput.timeout);
+    const timeout = getExecutionsWaitTimeoutSeconds(input.timeout);
     sections.push(
       buildToolUseSection('Action:', wrapInPre(`wait (timeout: ${timeout}s)`)),
     );
@@ -242,8 +287,13 @@ function buildExecutionsSections(ctx: ToolSectionContext): TemplateResult[] {
     sections.push(buildToolUseSection('Action:', wrapInPre('kill')));
   }
 
-  if (execInput.view_range) {
-    const [start, end] = execInput.view_range;
+  const viewRange = input.view_range;
+  if (
+    Array.isArray(viewRange) &&
+    typeof viewRange[0] === 'number' &&
+    typeof viewRange[1] === 'number'
+  ) {
+    const [start, end] = viewRange;
     sections.push(
       buildToolUseSection('Range:', wrapInPre(`lines ${start}–${end}`)),
     );
@@ -251,21 +301,40 @@ function buildExecutionsSections(ctx: ToolSectionContext): TemplateResult[] {
   return sections;
 }
 
+/** One `AcceptRunFilesInput.files` entry, narrowed for display purposes only. */
+function acceptRunFileEntryOf(raw: unknown): {
+  path: string;
+  original?: string;
+} {
+  if (!isObject(raw)) return { path: '' };
+  return {
+    path: typeof raw.path === 'string' ? raw.path : '',
+    original: typeof raw.original === 'string' ? raw.original : undefined,
+  };
+}
+
+/**
+ * `AcceptRunFilesInput` derives from the host-only
+ * `AcceptRunFilesInputSchema` (`@tools/AcceptRunFilesTool`), unavailable as a
+ * runtime import here (see the import-block comment above); fields are read
+ * with individual guards instead.
+ */
 function buildAcceptRunFilesSections(
   ctx: ToolSectionContext,
 ): TemplateResult[] {
   const { input, parsedOutput } = ctx;
   if (!isObject(input)) return [];
-  const acceptInput = input as AcceptRunFilesInput;
   const sections: TemplateResult[] = [];
 
-  if (acceptInput.execution_id) {
+  const executionId =
+    typeof input.execution_id === 'string' ? input.execution_id : undefined;
+  if (executionId) {
     // prettier-ignore
-    sections.push(buildToolUseSection('Execution:', html`<code class="execution-id">${acceptInput.execution_id}</code>`));
+    sections.push(buildToolUseSection('Execution:', html`<code class="execution-id">${executionId}</code>`));
   }
 
-  const files = acceptInput.files;
-  if (Array.isArray(files) && files.length > 0) {
+  const files = Array.isArray(input.files) ? input.files : undefined;
+  if (files && files.length > 0) {
     const edits = getOutputEdits<{
       path?: string;
       lineChanges?: { added: number; removed: number };
@@ -275,7 +344,8 @@ function buildAcceptRunFilesSections(
     );
 
     // prettier-ignore
-    const fileItems = html`${files.map((f) => {
+    const fileItems = html`${files.map((raw) => {
+      const f = acceptRunFileEntryOf(raw);
       const dest = f.original ?? f.path ?? '';
       const source = f.path ?? '';
       const isMapped = dest && source && dest !== source;
@@ -292,23 +362,35 @@ function buildAcceptRunFilesSections(
   return sections;
 }
 
+/** Filters an unknown value down to a `string[]`, dropping non-string entries. */
+function toStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value.filter((v): v is string => typeof v === 'string');
+}
+
+/**
+ * `DelegateAgentInput`/`WorkflowAgentInput` derive from host-only schemas
+ * (`@tools/DelegationTools`, `@tools/delegation/inputFields`), unavailable as
+ * runtime imports here (see the import-block comment above) — and even a
+ * type-shape union of the two wouldn't cover every legacy alias in
+ * `DELEGATION_TOOLS` (`resume_agent`, `propose_agent`, `propose_workflow`
+ * predate these schemas). Each displayed field is read with its own guard
+ * instead, tolerating both current and legacy delegation payloads alike.
+ */
 function buildDelegationSections(ctx: ToolSectionContext): TemplateResult[] {
   const { input } = ctx;
   if (!isObject(input)) return [];
-  const delegateInput = input as DelegateAgentInput | WorkflowAgentInput;
   const sections: TemplateResult[] = [];
 
   const execId =
-    'execution_id' in delegateInput
-      ? (delegateInput as DelegateAgentInput).execution_id
-      : undefined;
+    typeof input.execution_id === 'string' ? input.execution_id : undefined;
   if (execId) {
     // prettier-ignore
     sections.push(buildToolUseSection('Resume:', html`<code class="execution-id">${execId}</code>`));
   }
 
-  const agent = delegateInput.agent;
-  const model = delegateInput.model;
+  const agent = typeof input.agent === 'string' ? input.agent : undefined;
+  const model = typeof input.model === 'string' ? input.model : undefined;
   if (agent || model) {
     const agentPart = agent ?? 'unknown';
     const modelPart = model
@@ -318,22 +400,27 @@ function buildDelegationSections(ctx: ToolSectionContext): TemplateResult[] {
     sections.push(buildToolUseSection('Agent:', html`<code class="execution-id">${agentPart}</code>${modelPart}`));
   }
 
-  const instruction = delegateInput.instruction;
+  const instruction =
+    typeof input.instruction === 'string' ? input.instruction : undefined;
   if (instruction) {
     sections.push(buildToolUseSection('Instruction:', wrapInPre(instruction)));
   }
 
   const extractFlags: string[] = [];
-  if ('extractFigures' in delegateInput && delegateInput.extractFigures)
-    extractFlags.push('Extract Figures');
-  if ('extractTikz' in delegateInput && delegateInput.extractTikz)
-    extractFlags.push('Extract TikZ');
+  if (input.extractFigures) extractFlags.push('Extract Figures');
+  if (input.extractTikz) extractFlags.push('Extract TikZ');
   if (extractFlags.length > 0) {
     // prettier-ignore
     sections.push(buildToolUseSection('Extraction:', html`${extractFlags.map((f) => buildStatusBadge('image', f))}`));
   }
 
-  const fileGroups = getProposalFileGroups(delegateInput);
+  const fileGroups = getProposalFileGroups({
+    inputFiles: toStringArray(input.inputFiles),
+    contextFiles: toStringArray(input.contextFiles),
+    mediaFiles: toStringArray(input.mediaFiles),
+    outputFiles: toStringArray(input.outputFiles),
+    memories: toStringArray(input.memories),
+  });
   const filesSection = buildFileGroupsSection(fileGroups);
   if (filesSection !== undefined) sections.push(filesSection);
   return sections;

--- a/packages/extension/src/progressView/frontend/progressState.ts
+++ b/packages/extension/src/progressView/frontend/progressState.ts
@@ -32,6 +32,7 @@ import { setsEqual } from './utils';
 import { clearFollowUpInputTransientStateStore } from './followUpInputState';
 import {
   createInitialState,
+  ensureStreamState,
   EMPTY_STREAM_LOGS,
   isToolUseState,
   type StreamState,
@@ -390,6 +391,10 @@ export function setStreamStateForId(
   if (updated === current) return;
   appState.set(
     create(state, (draft) => {
+      // Backfills streamLogs/followupOptionsByStream alongside streamStates
+      // when this is the first handler to observe the stream (see
+      // `ensureStreamState`'s doc comment for the owned key list).
+      ensureStreamState(draft, streamId, current.kind);
       draft.streamStates.set(streamId, updated);
     }),
   );

--- a/packages/extension/src/progressView/frontend/slices/logSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/logSlice.ts
@@ -116,6 +116,7 @@ export const logHandlers = {
         // Backfills streamLogs (and followupOptionsByStream) if this is the
         // first handler to observe the stream — see `ensureStreamState`.
         ensureStreamState(draft, streamId, streamState.kind);
+        // Non-null: ensureStreamState above guarantees this entry exists.
         const streamLogs: StreamLogs = draft.streamLogs.get(streamId)!;
 
         let logChanged = false;

--- a/packages/extension/src/progressView/frontend/slices/logSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/logSlice.ts
@@ -13,7 +13,7 @@ import {
 import { upsertTaskGroupFromStreamLog } from '@shared/streams/taskGroupProjection';
 
 import { appState } from '../progressState';
-import type { StreamLogs, StreamState } from '../store';
+import { ensureStreamState, type StreamLogs, type StreamState } from '../store';
 
 /** Built once: `applyEntry` runs per delta entry in the streaming path. */
 const OptionalContextStateData =
@@ -113,15 +113,10 @@ export const logHandlers = {
         const streamState = draft.streamStates.get(streamId);
         if (!streamState) return;
 
-        const existingStreamLogs = draft.streamLogs.get(streamId);
-        const streamLogs: StreamLogs = existingStreamLogs ?? {
-          logs: [],
-          logIndex: new Map<string, number>(),
-          taskGroupIndex: new Map<string, number>(),
-          updatedMessageIndices: [],
-          updatedMessageBaseGeneration: 0,
-          generation: 0,
-        };
+        // Backfills streamLogs (and followupOptionsByStream) if this is the
+        // first handler to observe the stream — see `ensureStreamState`.
+        ensureStreamState(draft, streamId, streamState.kind);
+        const streamLogs: StreamLogs = draft.streamLogs.get(streamId)!;
 
         let logChanged = false;
         let stateChanged = false;

--- a/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
+++ b/packages/extension/src/progressView/frontend/slices/streamLifecycleSlice.ts
@@ -9,7 +9,6 @@ import { create } from 'mutative';
 
 import { PROGRESS_VIEW_COMMANDS } from '@shared/ipc';
 import {
-  createStreamState,
   type ProgressViewOutboundHandlerRegistry,
   type StreamMetadata,
   type StreamTabId,
@@ -18,6 +17,7 @@ import {
 
 import {
   deleteStreamState,
+  ensureStreamState,
   firstStreamId,
   type ProgressState,
   type StreamState,
@@ -59,13 +59,18 @@ function updateStreamInfo(
   // Explicit description on StreamTabInfo wins over the pending buffer.
   const mergedStates = new Map<string, StreamState>();
   const newStreamById = new Map<string, StreamTabInfo>();
+  // Streams with no backend metadata and no prior state yet: routed through
+  // `ensureStreamState` below so their default streamStates entry and its
+  // streamLogs/followupOptionsByStream companions are created together,
+  // instead of synthesizing a bare streamStates default here.
+  const streamsNeedingDefaultState: StreamTabInfo[] = [];
   for (const stream of streams) {
     const existing = state.streamStates.get(stream.name);
     const metadata = backendMetadata?.[stream.name];
     if (metadata) {
       mergedStates.set(stream.name, mergeBackendOwnedState(existing, metadata));
     } else if (!existing) {
-      mergedStates.set(stream.name, createStreamState(stream.agentCategory));
+      streamsNeedingDefaultState.push(stream);
     }
     // Always drain the pending buffer so stale entries don't linger once the
     // stream registers, even if the payload already carries a description.
@@ -97,6 +102,10 @@ function updateStreamInfo(
 
     for (const [name, merged] of mergedStates) {
       draft.streamStates.set(name, merged);
+    }
+
+    for (const stream of streamsNeedingDefaultState) {
+      ensureStreamState(draft, stream.name, stream.agentCategory);
     }
 
     draft.streamById = newStreamById;

--- a/packages/extension/src/progressView/frontend/store.ts
+++ b/packages/extension/src/progressView/frontend/store.ts
@@ -1,5 +1,7 @@
 // Shared imports
 import {
+  createStreamState,
+  type AgentCategory,
   type AgentCategoryFilter,
   type ContextStateData,
   type LogMessageData,
@@ -51,14 +53,26 @@ export interface StreamLogs {
   generation: number;
 }
 
-export const EMPTY_STREAM_LOGS: StreamLogs = {
-  logs: [],
-  logIndex: new Map(),
-  taskGroupIndex: new Map(),
-  updatedMessageIndices: [],
-  updatedMessageBaseGeneration: 0,
-  generation: 0,
-};
+/** Fresh, unshared `StreamLogs` value for a stream with no log entries yet. */
+function createEmptyStreamLogs(): StreamLogs {
+  return {
+    logs: [],
+    logIndex: new Map(),
+    taskGroupIndex: new Map(),
+    updatedMessageIndices: [],
+    updatedMessageBaseGeneration: 0,
+    generation: 0,
+  };
+}
+
+/**
+ * Stable empty fallback for read paths (e.g. `activeStreamLogs$`) that need a
+ * value before any log has arrived for a stream. Never mutated in place —
+ * writers always replace the map entry with a fresh object (see
+ * `ensureStreamState` and `logSlice.ts`), so sharing this single reference
+ * across reads is safe.
+ */
+export const EMPTY_STREAM_LOGS: StreamLogs = createEmptyStreamLogs();
 
 export interface ProgressState {
   activeStreamId: StreamTabId | null;
@@ -91,6 +105,42 @@ export function deleteStreamState(
   draft.streamStates.delete(streamId);
   draft.streamLogs.delete(streamId);
   draft.followupOptionsByStream.delete(streamId);
+}
+
+/**
+ * Create default entries — for whichever of the same key list
+ * `deleteStreamState` owns (`streamStates`, `streamLogs`,
+ * `followupOptionsByStream`) a stream doesn't have one in yet. Single owner
+ * of that initialization logic, mirroring `deleteStreamState`, so a stream
+ * can't end up registered in some of these maps but not others depending on
+ * which handler happened to observe it first. Already-present entries are
+ * left untouched.
+ *
+ * Does not touch `streamById`, for the same reason `deleteStreamState`
+ * doesn't: every call site that introduces a brand-new stream already holds
+ * its full `StreamTabInfo` and writes it through its own logic (e.g. the
+ * newest-first sorted upsert in `streamMetaSlice.ts`) — there is no
+ * meaningful placeholder to synthesize here.
+ *
+ * Returns the stream's (possibly just-created) `StreamState`.
+ */
+export function ensureStreamState(
+  draft: Draft<ProgressState>,
+  streamId: StreamTabId,
+  agentCategory: AgentCategory,
+): StreamState {
+  let state = draft.streamStates.get(streamId);
+  if (!state) {
+    state = createStreamState(agentCategory);
+    draft.streamStates.set(streamId, state);
+  }
+  if (!draft.streamLogs.has(streamId)) {
+    draft.streamLogs.set(streamId, createEmptyStreamLogs());
+  }
+  if (!draft.followupOptionsByStream.has(streamId)) {
+    draft.followupOptionsByStream.set(streamId, {});
+  }
+  return state;
 }
 
 /** Return the first stream ID from a streamById Map, or null if empty. */

--- a/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
+++ b/src/agent/modelHandlers/google/modelHandlerGoogleInteractions.ts
@@ -218,20 +218,28 @@ function isBackgroundUnsupportedError(error: unknown): boolean {
   );
 }
 
-/** Mutable accumulator for a single in-flight step during streaming. */
-interface PendingStep {
-  type: Step['type'] | string;
+/**
+ * Raw accumulator for a single in-flight step during streaming.
+ *
+ * This buffers delta fragments ONLY — it carries no discriminant `type` tag.
+ * Earlier versions mutated a `.type` field as different SSE delta kinds
+ * arrived (`'model_output'` / `'thought'` / `'function_call'`), which made the
+ * final kind depend on mutation order rather than on the data actually
+ * accumulated. `finalizeSteps` now derives the kind once, from which of these
+ * fields are populated (see the precedence comment there).
+ */
+interface PendingStepBuffer {
   /** model_output text accumulator */
-  text: string;
+  text?: string;
   /** thought summary accumulator */
-  thought: string;
+  thought?: string;
   /** thought signature, captured from ThoughtSignatureDelta */
   signature?: string;
-  /** function_call fields */
+  /** function_call id/name, seeded from a function_call step.start event */
   callId?: string;
   callName?: string;
   /** concatenated arguments_delta fragments, parsed at step.stop */
-  argsBuffer: string;
+  argsBuffer?: string;
   /** parsed arguments after step.stop */
   args?: Record<string, unknown>;
 }
@@ -1643,7 +1651,7 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
     let streamsFinalized = false;
 
     try {
-      const pending = new Map<number, PendingStep>();
+      const pending = new Map<number, PendingStepBuffer>();
       let completedInteraction: GoogleGenAIInteraction | undefined;
       let runningUsage: Usage | undefined;
       let interactionId: string | undefined;
@@ -1670,8 +1678,12 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
           }
 
           case 'step.stop': {
+            // argsBuffer only ever accumulates via `arguments_delta`, which is
+            // exclusive to function_call steps — its presence is itself the
+            // "this is a function call" signal, so no separate kind check is
+            // needed here.
             const slot = pending.get(event.index);
-            if (slot && slot.type === 'function_call' && slot.argsBuffer) {
+            if (slot?.argsBuffer) {
               slot.args = parseToolInputAsObject(
                 slot.argsBuffer,
                 slot.callId ?? 'unknown',
@@ -1751,20 +1763,20 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
     }
   }
 
-  private seedPendingStep(step?: Step): PendingStep {
-    return {
-      type: step?.type ?? 'model_output',
-      text: '',
-      thought: '',
-      argsBuffer: '',
-      ...(step?.type === 'function_call'
-        ? { callId: step.id, callName: step.name }
-        : {}),
-    };
+  /**
+   * Seed a fresh accumulator for a `step.start` event. The only up-front data
+   * worth capturing is a function_call step's id/name (arguments stream in
+   * later via `arguments_delta`, handled by {@link applyDelta}); every other
+   * step kind starts empty and is categorized later in {@link finalizeSteps}.
+   */
+  private seedPendingStep(step?: Step): PendingStepBuffer {
+    return step?.type === 'function_call'
+      ? { callId: step.id, callName: step.name }
+      : {};
   }
 
   private applyDelta(
-    slot: PendingStep,
+    slot: PendingStepBuffer,
     delta: Interactions.StepDelta['delta'],
     output: ReturnType<ModelHandlerGoogleInteractions['createOutputStream']>,
     thinking: ReturnType<
@@ -1774,32 +1786,30 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
   ): void {
     switch (delta.type) {
       case 'text':
-        slot.type = 'model_output';
         if (delta.text) {
-          slot.text += delta.text;
+          slot.text = (slot.text ?? '') + delta.text;
           output.append(delta.text);
           onOutputText(delta.text);
         }
         break;
       case 'thought_summary': {
-        slot.type = 'thought';
         const text =
           delta.content && isTextContent(delta.content)
             ? delta.content.text
             : '';
         if (text) {
-          slot.thought += text;
+          slot.thought = (slot.thought ?? '') + text;
           thinking.append(text);
         }
         break;
       }
       case 'thought_signature':
-        slot.type = 'thought';
         if (delta.signature) slot.signature = delta.signature;
         break;
       case 'arguments_delta':
-        slot.type = 'function_call';
-        if (delta.arguments) slot.argsBuffer += delta.arguments;
+        if (delta.arguments) {
+          slot.argsBuffer = (slot.argsBuffer ?? '') + delta.arguments;
+        }
         break;
       default:
         // Media / built-in tool deltas are ignored in v0 (no media-out, no
@@ -1809,14 +1819,24 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
   }
 
   /** Turn the per-index accumulators into a verbatim model-generated Step[]. */
-  private finalizeSteps(pending: Map<number, PendingStep>): Step[] {
+  private finalizeSteps(pending: Map<number, PendingStepBuffer>): Step[] {
     const ordered = [...pending.entries()].toSorted((a, b) => a[0] - b[0]);
     const steps: Step[] = [];
     for (const [, slot] of ordered) {
-      if (slot.type === 'thought') {
+      // Derive the step's kind ONCE from which raw fields actually
+      // accumulated data, instead of the old approach of mutating a `.type`
+      // tag as each delta arrived. Precedence — thought, then function_call,
+      // then model_output text — mirrors the branch order the mutation-based
+      // version checked in, and is safe because the Interactions SSE
+      // contract never mixes delta families within one step index: a thought
+      // step only ever receives thought_summary/thought_signature deltas, a
+      // function_call step only arguments_delta (plus its id/name seeded at
+      // step.start), and a model_output step only text — so at most one of
+      // these signal groups is ever populated for a given index.
+      if (slot.signature || slot.thought) {
         const step = this.thoughtStep(slot.signature, slot.thought);
         if (step) steps.push(step);
-      } else if (slot.type === 'function_call') {
+      } else if (slot.callId || slot.callName || slot.argsBuffer || slot.args) {
         steps.push({
           type: 'function_call',
           id: slot.callId ?? generateShortId(),
@@ -1824,7 +1844,7 @@ export class ModelHandlerGoogleInteractions extends GoogleModelHandlerBase<
           arguments:
             slot.args ??
             parseToolInputAsObject(
-              slot.argsBuffer,
+              slot.argsBuffer ?? '',
               slot.callId ?? 'unknown',
               this.logger,
             ),

--- a/src/agent/runtime/AgentFlowResult.ts
+++ b/src/agent/runtime/AgentFlowResult.ts
@@ -58,10 +58,10 @@ export type AgentFlowResult = z.infer<typeof AgentFlowResultSchema>;
 const WaitingToolUseFlowResultSchema = AgentFlowMetaSchema.extend({
   category: z.literal('toolUse'),
   outcome: z.literal(STREAM_PHASE.WAITING),
-  lastResponse: z.string().optional(),
-  /** Workspace-relative paths of files edited by tool calls during this session. */
-  touchedFiles: z.array(z.string()).optional(),
-});
+}).extend(
+  ToolUseFlowResultSchema.pick({ lastResponse: true, touchedFiles: true })
+    .shape,
+);
 
 export type WaitingToolUseFlowResult = z.infer<
   typeof WaitingToolUseFlowResultSchema

--- a/src/agent/runtime/runtimePresentationEvents.ts
+++ b/src/agent/runtime/runtimePresentationEvents.ts
@@ -27,3 +27,44 @@ export interface AgentRuntimeEmitOptions {
   /** Retain a presentation event until a temporarily detached UI returns. */
   readonly replayWhenAttached?: boolean;
 }
+
+/**
+ * One handler per {@link RuntimePresentationEventPayloads} key, each typed to
+ * that event's own payload. Building a value of this type as an object
+ * literal (rather than a `switch (event) { case ... }`) is what lets
+ * TypeScript correlate the map's value type to a specific key through the
+ * object's own indexed-access type, instead of through a hand-written
+ * `payload as Payloads['x']` cast repeated on every branch.
+ */
+export type PresentationEventHandlers<
+  Payloads = RuntimePresentationEventPayloads,
+> = {
+  [K in keyof Payloads]: (payload: Payloads[K]) => void;
+};
+
+/**
+ * Dispatches a `(event, payload)` pair — as received from a
+ * `SessionHostInteractions.emit`-style call — to the matching entry of a
+ * {@link PresentationEventHandlers} map.
+ *
+ * Every host that reacts to `RuntimePresentationEvent`s (CLI, desktop, VS
+ * Code extension) used to hand-write its own
+ * `switch (event) { case 'x': (payload as Payloads['x'])... }` dispatcher,
+ * re-asserting the event/payload correlation with a cast on every branch.
+ * Calling this instead — with `handlers` built as a
+ * `PresentationEventHandlers` object literal — needs no cast: `K` narrows
+ * `handlers[event]` to `(payload: Payloads[K]) => void` and `payload` is
+ * already `Payloads[K]`, so the call typechecks structurally. This mirrors
+ * the `HandlerRegistry`/`createDispatcher` idiom the progressView/
+ * settingsView message dispatchers already use
+ * (`src/shared/utils/dispatcher.ts`), minus the schema-parsing step those
+ * need for a raw `unknown` wire message — this dispatcher's `(event,
+ * payload)` pair is already typed at the call site.
+ */
+export function dispatchPresentationEvent<Payloads, K extends keyof Payloads>(
+  handlers: PresentationEventHandlers<Payloads>,
+  event: K,
+  payload: Payloads[K],
+): void {
+  handlers[event](payload);
+}

--- a/src/controllers/progressView/backend/state/ProgressViewState.ts
+++ b/src/controllers/progressView/backend/state/ProgressViewState.ts
@@ -281,10 +281,38 @@ export class ProgressViewState {
     return state;
   }
 
-  private applySnapshotMetadata(
+  /**
+   * The single writer for {@link ProgressStreamMetadata}: every mutation site
+   * below builds a `Partial<ProgressStreamMetadata>` patch and routes it
+   * through here rather than assigning fields by hand. A field the patch
+   * doesn't mention is preserved verbatim from `current` — callers that want
+   * to clear a field (e.g. detaching a parent) do so by including that key
+   * in the patch with an explicit `undefined`, same as before this was
+   * centralized.
+   */
+  private applyMetadataPatch(
+    current: ProgressStreamMetadata,
+    patch: Partial<ProgressStreamMetadata>,
+  ): ProgressStreamMetadata {
+    return { ...current, ...patch };
+  }
+
+  /**
+   * Build the snapshot-owned slice of a metadata patch: `agentCategory` and
+   * `run` are only ever set together, atomically, from one `RunConfig` (see
+   * the {@link ProgressStreamRunDetails} doc) and are therefore omitted from
+   * the patch entirely when no config has resolved yet, rather than being
+   * patched to `undefined` — that is what lets `run`'s three-owner union
+   * stay all-or-nothing instead of drifting field-by-field. `executionId`,
+   * `parentStreamId`, and `description` fall back to the current value when
+   * the snapshot store doesn't have one yet, so a patch built before that
+   * data loads can never clear a field the snapshot hasn't caught up to.
+   */
+  private buildSnapshotMetadataPatch(
     stream: StreamTabId,
-    metadata: ProgressStreamMetadata,
-  ): void {
+    current: ProgressStreamMetadata,
+  ): Partial<ProgressStreamMetadata> {
+    const patch: Partial<ProgressStreamMetadata> = {};
     const config = this.snapshots.getRunConfig(stream);
     if (config) {
       const descriptor = this.snapshots.getRunDescriptor(stream);
@@ -292,24 +320,24 @@ export class ProgressViewState {
       const runKind =
         descriptor?.kind ??
         (isProcessAgent(config.agent) ? 'process' : 'agent');
-      metadata.agentCategory = descriptor?.category ?? config.agentCategory;
+      patch.agentCategory = descriptor?.category ?? config.agentCategory;
       const workingDirectory = config.workingDirectory ?? undefined;
       if (runKind === 'workflowScript') {
-        metadata.run = {
+        patch.run = {
           kind: 'workflowScript',
           workflowName: identityName,
           instruction: config.instruction,
           workingDirectory,
         };
       } else if (runKind === 'process') {
-        metadata.run = {
+        patch.run = {
           kind: 'process',
           agent: identityName,
           instruction: config.instruction,
           workingDirectory,
         };
       } else {
-        metadata.run = {
+        patch.run = {
           kind: 'agent',
           agent: identityName,
           inputFile: config.inputFiles?.at(0),
@@ -320,12 +348,24 @@ export class ProgressViewState {
       }
     }
 
-    metadata.executionId =
-      this.snapshots.getExecutionId(stream) ?? metadata.executionId;
-    metadata.parentStreamId =
-      this.snapshots.getParentStreamId(stream) ?? metadata.parentStreamId;
-    metadata.description =
-      this.snapshots.getDescription(stream) ?? metadata.description;
+    patch.executionId =
+      this.snapshots.getExecutionId(stream) ?? current.executionId;
+    patch.parentStreamId =
+      this.snapshots.getParentStreamId(stream) ?? current.parentStreamId;
+    patch.description =
+      this.snapshots.getDescription(stream) ?? current.description;
+
+    return patch;
+  }
+
+  private applySnapshotMetadata(
+    stream: StreamTabId,
+    current: ProgressStreamMetadata,
+  ): ProgressStreamMetadata {
+    return this.applyMetadataPatch(
+      current,
+      this.buildSnapshotMetadataPatch(stream, current),
+    );
   }
 
   /**
@@ -339,14 +379,17 @@ export class ProgressViewState {
   ): void {
     const state = this.getOrCreateSession(stream, patch.creationTimestamp);
     const creationTimestamp = state.metadata.creationTimestamp;
-    state.metadata = { ...state.metadata, ...patch, creationTimestamp };
-    this.applySnapshotMetadata(stream, state.metadata);
+    const merged = this.applyMetadataPatch(state.metadata, {
+      ...patch,
+      creationTimestamp,
+    });
+    state.metadata = this.applySnapshotMetadata(stream, merged);
   }
 
   /** Re-apply newly loaded snapshot authority without changing live-only data. */
   refreshStreamMetadataFromSnapshot(stream: StreamTabId): void {
-    const metadata = this.getOrCreateSession(stream).metadata;
-    this.applySnapshotMetadata(stream, metadata);
+    const state = this.getOrCreateSession(stream);
+    state.metadata = this.applySnapshotMetadata(stream, state.metadata);
   }
 
   /**
@@ -355,10 +398,10 @@ export class ProgressViewState {
    */
   resetStreamMetadataForRun(stream: StreamTabId): void {
     const state = this.getOrCreateSession(stream);
-    state.metadata = {
+    const reset: ProgressStreamMetadata = {
       creationTimestamp: state.metadata.creationTimestamp,
     };
-    this.applySnapshotMetadata(stream, state.metadata);
+    state.metadata = this.applySnapshotMetadata(stream, reset);
   }
 
   /**
@@ -379,12 +422,15 @@ export class ProgressViewState {
     stream: StreamTabId,
     parent: StreamTabId | null | undefined,
   ): void {
-    const metadata = this.getOrCreateSession(stream).metadata;
-    metadata.parentStreamId = parent ?? undefined;
+    const state = this.getOrCreateSession(stream);
+    state.metadata = this.applyMetadataPatch(state.metadata, {
+      parentStreamId: parent ?? undefined,
+    });
   }
 
   setStreamDescription(stream: StreamTabId, description: string): void {
-    this.getOrCreateSession(stream).metadata.description = description;
+    const state = this.getOrCreateSession(stream);
+    state.metadata = this.applyMetadataPatch(state.metadata, { description });
   }
 
   // todos/plan are owned + persisted by StreamSnapshotStore (workPlan.json).

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -172,7 +172,10 @@ const AVAILABILITY_STATUS_FIELDS = {
     available: false,
     requiresKey: false,
   },
-} satisfies Record<ModelAvailabilityKind, Omit<ModelAvailabilityStatus, 'kind'>>;
+} satisfies Record<
+  ModelAvailabilityKind,
+  Omit<ModelAvailabilityStatus, 'kind'>
+>;
 
 /** Resolve a full availability status from its kind. */
 function availabilityStatus(
@@ -187,7 +190,9 @@ function availabilityStatus(
  * one table (or have its `available` flip) without the other noticing.
  */
 type UnavailableAvailabilityKind = {
-  [K in ModelAvailabilityKind]: (typeof AVAILABILITY_STATUS_FIELDS)[K]['available'] extends true
+  [
+    K in ModelAvailabilityKind
+  ]: (typeof AVAILABILITY_STATUS_FIELDS)[K]['available'] extends true
     ? never
     : K;
 }[ModelAvailabilityKind];

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -98,11 +98,14 @@ interface ModelAvailabilityStatus {
 /**
  * Per-kind status fields. `kind` is intentionally omitted here: the record key
  * is the single source of truth and `availabilityStatus()` reattaches it.
+ *
+ * Declared with `satisfies` rather than a `Record<...>` type annotation so
+ * each entry's `available` literal (`true`/`false`) survives into
+ * {@link UnavailableAvailabilityKind} below — an annotation would widen it to
+ * `boolean` and break that derivation — while `satisfies` still rejects a
+ * missing or misshapen kind exactly like the annotation did.
  */
-const AVAILABILITY_STATUS_FIELDS: Record<
-  ModelAvailabilityKind,
-  Omit<ModelAvailabilityStatus, 'kind'>
-> = {
+const AVAILABILITY_STATUS_FIELDS = {
   'openrouter-key': {
     label: 'OpenRouter key',
     available: true,
@@ -169,7 +172,7 @@ const AVAILABILITY_STATUS_FIELDS: Record<
     available: false,
     requiresKey: false,
   },
-};
+} satisfies Record<ModelAvailabilityKind, Omit<ModelAvailabilityStatus, 'kind'>>;
 
 /** Resolve a full availability status from its kind. */
 function availabilityStatus(
@@ -177,6 +180,72 @@ function availabilityStatus(
 ): ModelAvailabilityStatus {
   return { kind, ...AVAILABILITY_STATUS_FIELDS[kind] };
 }
+
+/**
+ * Every kind whose {@link AVAILABILITY_STATUS_FIELDS} entry is
+ * `available: false` — derived, not hand-listed, so a kind can't be added to
+ * one table (or have its `available` flip) without the other noticing.
+ */
+type UnavailableAvailabilityKind = {
+  [K in ModelAvailabilityKind]: (typeof AVAILABILITY_STATUS_FIELDS)[K]['available'] extends true
+    ? never
+    : K;
+}[ModelAvailabilityKind];
+
+/** Everything an unavailable-reason builder needs to reconstruct the exact
+ *  wording `getModelUnavailableReason` used to hand-roll per branch. */
+interface UnavailableReasonContext {
+  readonly model: string;
+  readonly config: ModelConfig;
+  readonly ctx: ModelAvailabilityContext;
+}
+
+/**
+ * Per-kind unavailable-reason prose, compiler-checked the same way
+ * {@link AVAILABILITY_STATUS_FIELDS} is: omitting a kind here — including a
+ * newly added `ModelAvailabilityKind` whose status is `available: false` —
+ * is a type error instead of a silent fall-through to a generic message.
+ */
+const UNAVAILABLE_REASON_BUILDERS: Record<
+  UnavailableAvailabilityKind,
+  (reasonCtx: UnavailableReasonContext) => string
+> = {
+  retired: ({ model }) =>
+    `Model "${model}" is retired and no longer available from its provider. Choose an active model.`,
+  'provider-unavailable': ({ model }) =>
+    `Model "${model}" requires a provider request mode that OpenRouter does not support. Disable OpenRouter and use the provider API directly.`,
+  'missing-key': ({ model, config, ctx }) => {
+    if (shouldRouteModelThroughOpenRouter(config, ctx.useOpenRouter)) {
+      return `Model "${model}" requires an OpenRouter API key.`;
+    }
+    const directProvider = resolveDirectModelApiKeyProvider(config);
+    const modelSource = resolveModelSource(config) ?? config.provider;
+    const providerName = PROVIDER_DISPLAY_NAMES[modelSource] ?? modelSource;
+    if (!directProvider) {
+      return `Model "${model}" is provided by ${providerName}, which does not use provider API keys. Use a host that supports ${providerName} models or choose another model.`;
+    }
+    const nextStep = allowsModelRelay(config)
+      ? 'Provide it, or enable included access.'
+      : 'Provide it to continue.';
+    return `Model "${model}" requires your ${providerName} API key. ${nextStep}`;
+  },
+  'not-included': ({ model }) =>
+    `Model "${model}" is not available with your current subscription tier. Upgrade your plan or switch to a different model.`,
+  'included-login-required': ({ model }) =>
+    `Model "${model}" is served by included TeXRA model access, which needs an account. Sign in, or provide a provider API key and switch to personal API keys.`,
+  'relay-quota-exhausted': ({ model }) =>
+    `Model "${model}" is unavailable because your monthly TeXRA relay quota is exhausted. Switch to personal API keys or wait for the next quota period.`,
+  'copilot-consent-required': ({ model }) =>
+    `Model "${model}" needs your consent before TeXRA can use it through Copilot in VS Code.`,
+  'copilot-unavailable': ({ model }) =>
+    `Model "${model}" is currently unavailable through Copilot in VS Code.`,
+  // Unreachable from `getModelUnavailableReason` today (it returns its own
+  // "not recognized" message before a config resolves far enough to compute
+  // availability at all), but the table must still cover it: `unknown-model`
+  // is `available: false`, so leaving it out would defeat the whole point of
+  // this table being compiler-checked.
+  'unknown-model': ({ model }) => `Model "${model}" is not recognized.`,
+};
 
 /**
  * Ship the resolved verdict on the option row. Every option leaves this
@@ -475,50 +544,12 @@ export async function getModelUnavailableReason(
   const availability = await resolveModelAvailability(model, config, ctx);
   if (availability.available) return null;
 
-  if (availability.kind === 'retired') {
-    return `Model "${model}" is retired and no longer available from its provider. Choose an active model.`;
-  }
-
-  if (isOpenRouterRoutingUnsupported(config, ctx.useOpenRouter)) {
-    return `Model "${model}" requires a provider request mode that OpenRouter does not support. Disable OpenRouter and use the provider API directly.`;
-  }
-
-  if (shouldRouteModelThroughOpenRouter(config, ctx.useOpenRouter)) {
-    return `Model "${model}" requires an OpenRouter API key.`;
-  }
-
-  if (availability.kind === 'not-included') {
-    // User has server access but model isn't available on their tier
-    return `Model "${model}" is not available with your current subscription tier. Upgrade your plan or switch to a different model.`;
-  }
-
-  if (availability.kind === 'included-login-required') {
-    return `Model "${model}" is served by included TeXRA model access, which needs an account. Sign in, or provide a provider API key and switch to personal API keys.`;
-  }
-
-  if (availability.kind === 'relay-quota-exhausted') {
-    return `Model "${model}" is unavailable because your monthly TeXRA relay quota is exhausted. Switch to personal API keys or wait for the next quota period.`;
-  }
-
-  if (availability.kind === 'copilot-consent-required') {
-    return `Model "${model}" needs your consent before TeXRA can use it through Copilot in VS Code.`;
-  }
-
-  if (availability.kind === 'copilot-unavailable') {
-    return `Model "${model}" is currently unavailable through Copilot in VS Code.`;
-  }
-
-  // Personal key mode or unauthenticated — missing key or keyless provider.
-  const directProvider = resolveDirectModelApiKeyProvider(config);
-  const modelSource = resolveModelSource(config) ?? config.provider;
-  const providerName = PROVIDER_DISPLAY_NAMES[modelSource] ?? modelSource;
-  if (!directProvider) {
-    return `Model "${model}" is provided by ${providerName}, which does not use provider API keys. Use a host that supports ${providerName} models or choose another model.`;
-  }
-  const nextStep = allowsModelRelay(config)
-    ? 'Provide it, or enable included access.'
-    : 'Provide it to continue.';
-  return `Model "${model}" requires your ${providerName} API key. ${nextStep}`;
+  // `availability.kind` is guaranteed `available: false` here, so it's a
+  // valid `UnavailableAvailabilityKind` and every case is covered by
+  // `UNAVAILABLE_REASON_BUILDERS` — the compiler, not this call site, is what
+  // enforces that a newly added unavailable kind gets a reason.
+  const kind = availability.kind as UnavailableAvailabilityKind;
+  return UNAVAILABLE_REASON_BUILDERS[kind]({ model, config, ctx });
 }
 
 /** Build typed model option data for a single model. */

--- a/src/test-kernel/cli/StatusBar.vitest.mts
+++ b/src/test-kernel/cli/StatusBar.vitest.mts
@@ -70,7 +70,7 @@ function statusInput(
     bypass: NO_BYPASS,
     queuedFollowUpMessages: [],
     usage: undefined,
-    roundStage: undefined,
+    stage: undefined,
     subagents: 0,
     approvalDepth: 0,
     model: 'deepseekT',
@@ -465,7 +465,7 @@ describe('CLI StatusBar display model', () => {
           'Also mention the finite monoid argument.',
         ],
         usage: { inputTokens: 80_000, outputTokens: 25_000, cost: 0 },
-        roundStage: { index: 1 },
+        stage: { kind: 'round', index: 1 },
         subagents: 2,
         approvalDepth: 3,
         childNavigationAvailable: true,
@@ -496,7 +496,7 @@ describe('CLI StatusBar display model', () => {
     const display = buildStatusBarDisplay(
       statusInput({
         status: STREAM_PHASE.RUNNING,
-        roundStage: { index: 1, total: 3 },
+        stage: { kind: 'round', index: 1, total: 3 },
       }),
     );
 

--- a/src/test-kernel/cli/SubagentListDisplay.vitest.mts
+++ b/src/test-kernel/cli/SubagentListDisplay.vitest.mts
@@ -65,7 +65,7 @@ function workflowAgentSlice(
     usage: undefined,
     cumulativeUsage: undefined,
     conversation: undefined,
-    roundStage: undefined,
+    stage: undefined,
     entries: [],
     queuedFollowUpMessages: [],
     todos: [],
@@ -700,7 +700,7 @@ describe('CLI child list display model', () => {
               active: false,
               slice: workflowAgentSlice('run', {
                 status: STREAM_PHASE.RUNNING,
-                phaseStage: { label: 'Reduce', index: 1, total: 3 },
+                stage: { kind: 'phase', label: 'Reduce', index: 1, total: 3 },
               }),
             },
             {
@@ -709,7 +709,7 @@ describe('CLI child list display model', () => {
               active: false,
               slice: workflowAgentSlice('reflect', {
                 status: STREAM_PHASE.RUNNING,
-                roundStage: { index: 1, total: 3 },
+                stage: { kind: 'round', index: 1, total: 3 },
               }),
             },
           ],
@@ -1016,32 +1016,6 @@ describe('CLI child list display model', () => {
     expect(wideOutput.indexOf('writer-attempt')).toBeLessThan(
       wideOutput.indexOf('Reduce (2/2)'),
     );
-  });
-
-  it('never shows both a phase and a round on one row', async () => {
-    const run = 'run' as StreamTabId;
-    const output = await renderSubagentList(
-      {
-        maxRows: 3,
-        sessions: [
-          {
-            id: run,
-            label: 'workflow-script',
-            active: false,
-            slice: workflowAgentSlice('run', {
-              status: STREAM_PHASE.RUNNING,
-              phaseStage: { label: 'Reduce', index: 1, total: 3 },
-              roundStage: { index: 0, total: 9 },
-            }),
-          },
-        ],
-      },
-      100,
-      { until: (frame) => frame.includes('workflow-script') },
-    );
-
-    expect(output).toContain('Reduce 2/3');
-    expect(output).not.toContain('r1/9');
   });
 
   // The right-aligned metadata column is the one row element `SubagentList`

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -328,12 +328,12 @@ describe('cliState Phase 4 fields', () => {
         },
       });
 
-      expect(streams.get().get(child1)?.phaseStage).toEqual({
+      expect(streams.get().get(child1)?.stage).toEqual({
+        kind: 'phase',
         label: 'Reduce',
         index: 1,
         total: 3,
       });
-      expect(streams.get().get(child1)?.roundStage).toBeUndefined();
 
       hub.emit({
         scope: 'run',
@@ -348,11 +348,11 @@ describe('cliState Phase 4 fields', () => {
         },
       });
 
-      expect(streams.get().get(root)?.roundStage).toEqual({
+      expect(streams.get().get(root)?.stage).toEqual({
+        kind: 'round',
         index: 1,
         total: 4,
       });
-      expect(streams.get().get(root)?.phaseStage).toBeUndefined();
     });
   });
 
@@ -369,7 +369,8 @@ describe('cliState Phase 4 fields', () => {
         },
       });
 
-      expect(streams.get().get(child1)?.phaseStage).toEqual({
+      expect(streams.get().get(child1)?.stage).toEqual({
+        kind: 'phase',
         label: 'Cleanup',
       });
     });
@@ -2763,14 +2764,15 @@ describe('subscribeRuntimeHost run facts', () => {
         },
       });
 
-      expect(streams.get().get(root)?.roundStage).toEqual({
+      expect(streams.get().get(root)?.stage).toEqual({
+        kind: 'round',
         index: 1,
         total: 3,
       });
     });
   });
 
-  it('ignores direct non-round stage.start events without host emission', () => {
+  it('applies direct non-round stage.start events to the phase slot, not the round slot', () => {
     withRunFacts((hub) => {
       hub.emit({
         scope: 'run',
@@ -2784,7 +2786,11 @@ describe('subscribeRuntimeHost run facts', () => {
         },
       });
 
-      expect(streams.get().get(root)?.roundStage).toBeUndefined();
+      expect(streams.get().get(root)?.stage).toEqual({
+        kind: 'phase',
+        label: 'Compile phase',
+        index: 0,
+      });
     });
   });
 

--- a/src/tools/claudeAgentShared.ts
+++ b/src/tools/claudeAgentShared.ts
@@ -1,5 +1,6 @@
 // Shared constants and helpers for the Claude Code CLI tool.
 
+import { warn } from '@logger/logUtils';
 import type {
   ClaudeAgentEffort,
   TokenUsageStats,
@@ -8,6 +9,8 @@ import type {
 import { truncateSummary } from '@utils/text/stringUtils';
 
 import type { EffortLevel } from '@anthropic-ai/claude-agent-sdk';
+
+const LOG_CHANNEL = 'claudeAgent';
 
 /**
  * Compile-time guard: `ClaudeAgentEffort` in `@shared` (the single source of
@@ -92,6 +95,36 @@ export function buildClaudeUsageStats(usage: ClaudeTurnUsage): TokenUsageStats {
   };
 }
 
+/** Narrow an SDK-sourced value to a plain record, the way every built-in
+ *  tool's `input` arrives per the tool-use protocol (a no-argument call still
+ *  sends `{}`, never a bare primitive or `null`). Shared so the guard is
+ *  written once and `buildClaudeToolUseLog` and `describeToolInput` can't
+ *  drift apart on what counts as "object-shaped". */
+function isToolRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object';
+}
+
+/**
+ * Narrow a `tool_use` block's `input` to a record for storage on
+ * `ToolUseLog`. A non-object payload here means the SDK sent something
+ * outside the tool-use contract (every call — including no-argument ones —
+ * carries a JSON object), so it's worth a loud warning rather than a cast
+ * that silently misrepresents the value as a record.
+ */
+function toToolInputRecord(
+  toolName: string,
+  input: unknown,
+): Record<string, unknown> | undefined {
+  if (input === undefined) return undefined;
+  if (isToolRecord(input)) return input;
+  warn(
+    LOG_CHANNEL,
+    `Claude tool "${toolName}" sent a non-object input; expected a JSON object per the tool-use protocol.`,
+    { data: { input } },
+  );
+  return undefined;
+}
+
 /**
  * Build a tool-use log entry for a Claude `tool_use` content block.
  * Mirrors the rendering of Codex's command/file-change events while retaining
@@ -109,10 +142,12 @@ export function buildClaudeToolUseLog(params: {
   return {
     toolName: `claude:${params.toolName}`,
     summary: truncateSummary(summarySource, SUMMARY_MAX_LENGTH),
-    input: params.input as Record<string, unknown>,
-    ...(params.output !== undefined && {
-      output: params.output as Record<string, unknown>,
-    }),
+    input: toToolInputRecord(params.toolName, params.input),
+    // Unlike `input`, a tool_result's `output` is routinely a plain string
+    // (or other non-object value) — that's a normal outcome, not a
+    // protocol violation, so it's stored as-is (matching `ToolUseLog.output`'s
+    // `unknown` type) with no record cast and no warning.
+    ...(params.output !== undefined && { output: params.output }),
     ...(params.isError &&
       params.errorMessage && {
         error: params.errorMessage,
@@ -127,8 +162,8 @@ export function buildClaudeToolUseLog(params: {
  * to the tool name when the input shape isn't recognized.
  */
 function describeToolInput(toolName: string, input: unknown): string {
-  if (input == null || typeof input !== 'object') return toolName;
-  const record = input as Record<string, unknown>;
+  if (!isToolRecord(input)) return toolName;
+  const record = input;
 
   switch (toolName) {
     case 'Bash':


### PR DESCRIPTION
## Summary

Follow-up to a data-structure complexity audit of the codebase. This PR fixes the highest-value findings (2 High, 8 Medium severity) by replacing designs that relied on a comment or call-site discipline to stay correct with designs the compiler enforces:

- **CLI TUI** (`cliState.ts`, `subscribeRuntimeHost.ts`, `SubagentList.tsx`, `statusBarDisplay.ts`, `StatusBar.tsx`): `StreamSlice.roundStage`/`phaseStage` were two independently-optional fields documented as "never both set." Collapsed into one discriminated `stage: {kind:'round',...} | {kind:'phase',...}` union — the invariant is now structural, not a comment two readers had to know about.
- **Presentation event dispatch** (`runtimePresentationEvents.ts` + `cliPresentationHost.ts`, `desktopAgentExecution.ts`, `agentEventListeners.ts`): three hosts each hand-wrote a `switch(event){case 'x': payload as Payloads['x']}` dispatcher. Added one shared `dispatchPresentationEvent` helper (mirroring the existing `HandlerRegistry` idiom in `src/shared/utils/dispatcher.ts`) so each host supplies a handler-object literal with zero casts. The CLI NDJSON handler map is built once and cached alongside the lazily-constructed logger, rather than reallocated per event.
- **Extension progressView** (`toolSections.ts`, `store.ts` + 3 slice files): 7 tool-input builders did `isObject(input) ? (input as SomeToolInput) : undefined` with no shape validation. Replaced with real field-level checks (schema-based `safeParse` was tried first but reverted — it would have imported Node-only runtime values from `@tools/*` into a browser-bundled webview, an existing architectural boundary). Also centralized per-stream Map creation (`ensureStreamState`) to match the existing centralized deletion (`deleteStreamState`).
- **Google model handler** (`modelHandlerGoogleInteractions.ts`): a step accumulator's `type` discriminant was reassigned repeatedly as SSE deltas arrived, with a silent fallback if nothing ever tagged it. Now buffers raw deltas untagged and derives the step kind once in `finalizeSteps`, from whichever fields are non-empty. (Reviewed and confirmed behavior-preserving: the `model_output`/`slot.text` fallback branch predates this diff.)
- **`AgentFlowResult.ts`**: `WaitingToolUseFlowResultSchema` redeclared two fields verbatim instead of `.pick()`-composing them from `ToolUseFlowResultSchema`.
- **`computeModelOptions.ts`**: the unavailable-reason message was generated by a hand-written `if`/`else` chain not tied to the compiler-checked `ModelAvailabilityKind` table, so a new kind could silently fall through to a generic message. Folded into a second table (`UNAVAILABLE_REASON_BUILDERS`) keyed the same way, so a missing case is now a type error.
- **`claudeAgentShared.ts`**: `buildClaudeToolUseLog` cast SDK-sourced `input` to `Record<string, unknown>` with no runtime check. Added a guard that logs at `warn` (not silently) on a genuine non-object shape.
- **`ProgressViewState.ts`**: `ProgressStreamMetadata` was mutated in place from four independent call sites with no single writer. Routed all mutation through one `applyMetadataPatch` reducer, preserving every documented ordering hazard.

A local `getOrCreate` helper was briefly added to `workflowPlainProjection.ts` for a 3-level nested-map buffer, then inlined back at its one call site per review feedback (single-caller extractions are banned in this repo regardless of export visibility) — that file has no net diff against `main`.

## Issue acceptance gates

No tracked issue; this addresses a standalone audit's High/Medium findings directly. Each finding above is fixed in full — no partial gates.

## Single source of truth

- `StreamStage` (in `cliState.ts`) is now the sole owner of a stream's round/phase progress fact.
- `dispatchPresentationEvent` (in `runtimePresentationEvents.ts`) is the sole event↔payload correlation point for all three hosts.
- `AVAILABILITY_STATUS_FIELDS` + `UNAVAILABLE_REASON_BUILDERS` in `computeModelOptions.ts` are both keyed by `ModelAvailabilityKind`, so the compiler ties them together.
- `applyMetadataPatch` in `ProgressViewState.ts` is the sole writer of `ProgressStreamMetadata`.

## Duplication and abstraction budget

Removed: two near-duplicate stage-patch functions (`applyRoundStage`/`applyPhaseStage` → one `applyStage`); three independent switch-with-casts dispatchers → one shared helper with three call sites; four independent metadata-mutation call sites → one reducer; one duplicated schema-field declaration → `.pick()`. Added: one new shared helper (`dispatchPresentationEvent`), justified by its three genuine call sites (cli/desktop/extension) per this repo's "factories need multiple callers" rule. No new abstraction was kept where it had only one caller — `workflowPlainProjection.ts`'s `getOrCreate` was inlined back per review.

## Net elements (R6)

22 files changed, 797 insertions(+), 479 deletions(-), 0 files added. 6 net `export` line changes (renamed/consolidated fields and functions, no new public surface beyond the one justified shared helper). No new classes/interfaces beyond the `StreamStage` discriminated union and `PresentationEventHandlers` mapped type, both replacing what they consolidate.

## Consumer counts (R8)

n/a — no emit path or export was deleted/re-routed; `roundStage`/`phaseStage` reads were grepped across `packages/cli` and every call site was updated in place (see per-file changes above).

## Host impact

Extension: `agentEventListeners.ts` dispatch refactor, `toolSections.ts` cast-to-validation refactor, `store.ts`/slice centralized stream-map creation.

Desktop: `desktopAgentExecution.ts` presentation-event dispatch refactor (behavior-preserving).

CLI: `StreamSlice.stage` discriminated union across TUI state/render/display; `cliPresentationHost.ts` dispatch refactor with a cached NDJSON handler map.

## Scheduled refactoring

None — the remaining Low-severity audit findings (e.g. `ProviderMessage`'s necessarily-untagged SDK union, minor generic-narrowing casts) were assessed as either intentional/necessary complexity or too low-value to warrant a follow-up.

## Validation

- `npm run lint` — clean, whole repo.
- `npm run typecheck` — clean, whole repo (workspace, test-kernel, agent, extension, cli, trace-viewer, desktop).
- `npm test` — 802 files / 8124 tests passed, 1 file / 9 tests skipped (pre-existing skips), 0 failures.
- `npm run check:dead-code-ratchet` — 17 findings, matches baseline exactly.
- `npx prettier --check` on all touched files — clean.
- Fixed 3 `src/test-kernel/cli/*.vitest.mts` files that referenced the old `roundStage`/`phaseStage` fields directly (outside the refactor agents' scoped directories, caught by the full typecheck) — updated to the new `stage` shape and removed one test whose premise (both fields set simultaneously) is now structurally impossible to construct.
- Addressed review feedback across multiple passes: cached the NDJSON handler map instead of reallocating per event; inlined the single-caller `getOrCreate` helper back to its call site; documented a non-null assertion's safety invariant inline.
