### PR TITLE
test: consolidate 3 ad hoc multi-scope ConfigProvider fakes into one

### DIFF
--- a/src/test-kernel/auth/CodexPreference.vitest.ts
+++ b/src/test-kernel/auth/CodexPreference.vitest.ts
@@ -8,64 +8,8 @@ import {
   setPreferCodexSubscription,
 } from '@model/codex/codexPreference';
 import { platform } from '@platform/platform';
-import type {
-  ConfigInspection,
-  ConfigProvider,
-  ConfigTarget,
-  Disposable,
-} from '@platform/interfaces';
 import { installPlatform } from '@test/support/setupPlatform';
-
-// The shared `FakeConfigProvider` records one target per key, so it cannot hold
-// a folder override and a global value for the same key at once — the exact
-// state this suite needs.
-class FolderOverrideConfigProvider implements ConfigProvider {
-  private readonly globalValues = new Map<string, unknown>();
-  private readonly workspaceValues = new Map<string, unknown>();
-  private readonly folderValues = new Map<string, unknown>();
-
-  constructor(folderValue: boolean) {
-    this.folderValues.set(CODEX_PREFER_SUBSCRIPTION_KEY, folderValue);
-  }
-
-  get<T>(key: string, defaultValue?: T): T {
-    return (this.folderValues.get(key) ??
-      this.workspaceValues.get(key) ??
-      this.globalValues.get(key) ??
-      defaultValue) as T;
-  }
-
-  async update<T>(
-    key: string,
-    value: T,
-    target: ConfigTarget = 'workspace',
-  ): Promise<void> {
-    const values =
-      target === 'global' ? this.globalValues : this.workspaceValues;
-    values.set(key, value);
-  }
-
-  inspect<T = unknown>(key: string): ConfigInspection<T> | undefined {
-    return {
-      globalValue: this.globalValues.get(key) as T | undefined,
-      workspaceValue: this.workspaceValues.get(key) as T | undefined,
-      workspaceFolderValue: this.folderValues.get(key) as T | undefined,
-      effectiveValue: this.get<T>(key),
-    };
-  }
-
-  isExplicitlySet(key: string): boolean {
-    return (
-      this.globalValues.has(key) ||
-      this.workspaceValues.has(key) ||
-      this.folderValues.has(key)
-    );
-  }
-
-  watch(): Disposable {
-    return { dispose: () => {} };
-  }
-}
+import { FakeScopedConfigProvider } from '@test/support/FakePlatform';
 
 describe('Codex subscription preference', () => {
   it('writes workspace preference when workspace config already controls it', async () => {
@@ -86,7 +30,8 @@ describe('Codex subscription preference', () => {
   });
 
   it('does not treat folder overrides as writable workspace config', async () => {
-    const config = new FolderOverrideConfigProvider(false);
+    const config = new FakeScopedConfigProvider();
+    config.seedWorkspaceFolder(CODEX_PREFER_SUBSCRIPTION_KEY, false);
     await installPlatform({}, { config });
 
     const update = await setPreferCodexSubscription(true);

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -11,7 +11,10 @@ import type { StreamTabId } from '@shared/schemas';
 import { AGENT_SKILLS_CONFIG_KEY } from '@shared/schemas/agentSkills';
 import { GlobalStateKey, WorkspaceStateKey } from '@shared/state/stateKeys';
 import { DEFAULT_GIT_MARK_COMMITS } from '@shared/schemas/stateSettings';
-import { FakeStateStore } from '@test/support/FakePlatform';
+import {
+  FakeScopedConfigProvider,
+  FakeStateStore,
+} from '@test/support/FakePlatform';
 import { setupPlatform } from '@test/support/setupPlatform';
 import { createDeferred } from '@test/support/asyncTestUtils';
 import { GoalStore } from '@tools/goal';
@@ -67,55 +70,13 @@ type CapturedSettingsFixtureOverrides = Omit<
   'postToRenderer'
 >;
 
-class MemoryConfigStore {
-  readonly values = new Map<string, unknown>();
-  // Only recorded when a call site passes an explicit target -- do not
-  // default this, or a call site that forgets to pass `target` would still
-  // read back as 'workspace' and mask the exact scope-mismatch regression
-  // this store exists to catch (see issue #7085).
-  readonly updateTargets = new Map<string, 'global' | 'workspace'>();
-
-  get<T>(key: string, defaultValue?: T): T {
-    return (this.values.has(key) ? this.values.get(key) : defaultValue) as T;
-  }
-
-  async update<T>(
-    key: string,
-    value: T,
-    target?: 'global' | 'workspace',
-  ): Promise<void> {
-    if (target === undefined) {
-      this.updateTargets.delete(key);
-    } else {
-      this.updateTargets.set(key, target);
-    }
-    if (value === undefined) {
-      this.values.delete(key);
-    } else {
-      this.values.set(key, value);
-    }
-  }
-
-  inspect<T = unknown>(key: string): { effectiveValue?: T } | undefined {
-    return { effectiveValue: this.get<T>(key) };
-  }
-
-  isExplicitlySet(key: string): boolean {
-    return this.values.has(key);
-  }
-
-  watch(): { dispose(): void } {
-    return { dispose: () => undefined };
-  }
-}
-
 let createDesktopSettingsIpc!: DesktopSettingsIpcModule['createDesktopSettingsIpc'];
 
 function createSettingsFixture(overrides: SettingsFixtureOverrides = {}) {
   const {
     globalState = new FakeStateStore(),
     workspaceState = new FakeStateStore(),
-    config = new MemoryConfigStore(),
+    config = new FakeScopedConfigProvider(),
     ui,
     ...settingsOverrides
   } = overrides;
@@ -705,8 +666,8 @@ describe('desktop settings IPC', () => {
     const workspaceState = new FakeStateStore({
       [WorkspaceStateKey.CODEX_SANDBOX_MODE]: 'danger-full-access',
     });
-    const config = new MemoryConfigStore();
-    config.values.set('texra.toolUse.requireBashApproval', false);
+    const config = new FakeScopedConfigProvider();
+    config.seedWorkspace('texra.toolUse.requireBashApproval', false);
     const agentSettingsController = createStubDesktopAgentSettingsController();
     const postAgentStartupData = vi.fn(async () => undefined);
     agentSettingsController.postStartupData = postAgentStartupData;
@@ -778,7 +739,7 @@ describe('desktop settings IPC', () => {
   });
 
   it('writes the bash-approval toggle to the workspace config scope, not global', async () => {
-    const config = new MemoryConfigStore();
+    const config = new FakeScopedConfigProvider();
 
     const { settings, posted } = createCapturedSettingsFixture({
       config,
@@ -793,10 +754,10 @@ describe('desktop settings IPC', () => {
     ).toBe(true);
     await flushAsyncWork();
 
-    expect(config.values.get('texra.toolUse.requireBashApproval')).toBe(false);
+    expect(config.get('texra.toolUse.requireBashApproval')).toBe(false);
     // Security-adjacent scope pin: a per-workspace approval bypass must never
     // be written to the global config target (see issue #7085).
-    expect(config.updateTargets.get('texra.toolUse.requireBashApproval')).toBe(
+    expect(config.lastTargetFor('texra.toolUse.requireBashApproval')).toBe(
       'workspace',
     );
     expect(
@@ -812,7 +773,7 @@ describe('desktop settings IPC', () => {
   });
 
   it('writes the agent-skills toggle and returns the shared setting message', async () => {
-    const config = new MemoryConfigStore();
+    const config = new FakeScopedConfigProvider();
 
     const { settings, posted } = createCapturedSettingsFixture({
       config,
@@ -827,8 +788,8 @@ describe('desktop settings IPC', () => {
     ).toBe(true);
     await flushAsyncWork();
 
-    expect(config.values.get(AGENT_SKILLS_CONFIG_KEY)).toBe(false);
-    expect(config.updateTargets.get(AGENT_SKILLS_CONFIG_KEY)).toBe('workspace');
+    expect(config.get(AGENT_SKILLS_CONFIG_KEY)).toBe(false);
+    expect(config.lastTargetFor(AGENT_SKILLS_CONFIG_KEY)).toBe('workspace');
     expect(
       posted.find(
         (message) =>
@@ -854,7 +815,7 @@ describe('desktop settings IPC', () => {
 
     const { settings, posted } = createCapturedSettingsFixture({
       ...state,
-      config: new MemoryConfigStore(),
+      config: new FakeScopedConfigProvider(),
       credentialSettingsController,
       ui: { onError: () => undefined },
     });

--- a/src/test-kernel/settings/BashApprovalGlobalMigration.vitest.ts
+++ b/src/test-kernel/settings/BashApprovalGlobalMigration.vitest.ts
@@ -2,11 +2,6 @@
 import { describe, expect, it } from 'vitest';
 
 // Local imports
-import type {
-  ConfigInspection,
-  ConfigProvider,
-  ConfigTarget,
-} from '@platform/interfaces';
 import { MemoryStateStore } from '@platform/defaults/memoryState';
 import { BASH_APPROVAL_CONFIG_KEY } from '@shared/schemas/agentCliSettings';
 import {
@@ -14,110 +9,13 @@ import {
   migrateLegacyGlobalBashApprovalOverride,
 } from '@shared/settingsView/handlers/approvalHandlers';
 import { WorkspaceStateKey } from '@shared/state/stateKeys';
-
-/**
- * Minimal in-memory `ConfigProvider` with real workspace -> global fallback
- * semantics, mirroring `VscodeConfigProvider`/`JsonConfigProvider`. Needed
- * here (rather than the no-op `RecordingConfigProvider` used by
- * `BashApprovalConfigTarget.vitest.ts`) because the migration reads
- * `inspect()` to distinguish "no override anywhere" from "explicit
- * workspace override" from "legacy global override only".
- */
-class FakeConfigProvider implements ConfigProvider {
-  private readonly workspaceValues = new Map<string, unknown>();
-  private readonly workspaceFolderValues = new Map<string, unknown>();
-  private readonly globalValues = new Map<string, unknown>();
-  readonly updateCalls: Array<{
-    key: string;
-    value: unknown;
-    target: ConfigTarget;
-  }> = [];
-
-  /**
-   * When set, `update()` calls targeting this scope throw instead of
-   * applying -- simulates a persistence failure (e.g. VS Code rejecting the
-   * write) so tests can assert on partial-migration recovery behavior.
-   */
-  failUpdatesForTarget?: ConfigTarget;
-
-  get<T>(key: string, defaultValue?: T): T {
-    // Mirrors VS Code's own resolution order: resource (folder) scope wins
-    // over workspace scope, which wins over global scope.
-    if (this.workspaceFolderValues.has(key))
-      return this.workspaceFolderValues.get(key) as T;
-    if (this.workspaceValues.has(key))
-      return this.workspaceValues.get(key) as T;
-    if (this.globalValues.has(key)) return this.globalValues.get(key) as T;
-    return defaultValue as T;
-  }
-
-  async update<T>(
-    key: string,
-    value: T,
-    target: ConfigTarget = 'workspace',
-  ): Promise<void> {
-    if (target === this.failUpdatesForTarget) {
-      throw new Error(`simulated ${target}-scope update failure for ${key}`);
-    }
-    this.updateCalls.push({ key, value, target });
-    const store =
-      target === 'global' ? this.globalValues : this.workspaceValues;
-    if (value === undefined) {
-      store.delete(key);
-    } else {
-      store.set(key, value);
-    }
-  }
-
-  inspect<T = unknown>(key: string): ConfigInspection<T> | undefined {
-    return {
-      globalValue: this.globalValues.has(key)
-        ? (this.globalValues.get(key) as T)
-        : undefined,
-      workspaceValue: this.workspaceValues.has(key)
-        ? (this.workspaceValues.get(key) as T)
-        : undefined,
-      workspaceFolderValue: this.workspaceFolderValues.has(key)
-        ? (this.workspaceFolderValues.get(key) as T)
-        : undefined,
-      effectiveValue: this.get<T>(key),
-    };
-  }
-
-  isExplicitlySet(key: string): boolean {
-    return (
-      this.workspaceValues.has(key) ||
-      this.workspaceFolderValues.has(key) ||
-      this.globalValues.has(key)
-    );
-  }
-
-  watch(): { dispose(): void } {
-    return { dispose: () => undefined };
-  }
-
-  /** Seeds a legacy global value directly, without going through `update()`. */
-  seedGlobal(key: string, value: unknown): void {
-    this.globalValues.set(key, value);
-  }
-
-  /**
-   * Seeds a resource-scoped `workspaceFolderValue` directly. Real writes
-   * to `'workspace'` target (`ConfigTarget` has no folder-scope option) land
-   * in `workspaceValue`, but `texra.toolUse.requireBashApproval` is declared
-   * `resource`-scoped, so post-#7148 UI writes commonly resolve as
-   * `workspaceFolderValue` instead -- this seeds that shape directly.
-   */
-  seedWorkspaceFolder(key: string, value: unknown): void {
-    this.workspaceFolderValues.set(key, value);
-  }
-}
+import { FakeScopedConfigProvider } from '@test/support/FakePlatform';
 
 describe('migrateLegacyGlobalBashApprovalOverride', () => {
   it('migrates a pre-existing legacy global override to workspace scope and clears it globally', async () => {
     // Simulates a user who disabled bash approval before #7148, when the
     // extension still wrote it to the global scope (issue #7085 / #7169).
-    const config = new FakeConfigProvider();
+    const config = new FakeScopedConfigProvider();
     config.seedGlobal(BASH_APPROVAL_CONFIG_KEY, false);
     const workspaceState = new MemoryStateStore();
 
@@ -148,7 +46,7 @@ describe('migrateLegacyGlobalBashApprovalOverride', () => {
   });
 
   it('is a no-op when no legacy global override exists', async () => {
-    const config = new FakeConfigProvider();
+    const config = new FakeScopedConfigProvider();
     const workspaceState = new MemoryStateStore();
 
     await migrateLegacyGlobalBashApprovalOverride({ workspaceState, config });
@@ -168,7 +66,7 @@ describe('migrateLegacyGlobalBashApprovalOverride', () => {
   });
 
   it('never re-runs once the per-workspace marker is already set', async () => {
-    const config = new FakeConfigProvider();
+    const config = new FakeScopedConfigProvider();
     config.seedGlobal(BASH_APPROVAL_CONFIG_KEY, false);
     const workspaceState = new MemoryStateStore();
     await workspaceState.update(
@@ -185,7 +83,7 @@ describe('migrateLegacyGlobalBashApprovalOverride', () => {
   });
 
   it("does not overwrite a workspace's own explicit override, but still clears the stale global value", async () => {
-    const config = new FakeConfigProvider();
+    const config = new FakeScopedConfigProvider();
     config.seedGlobal(BASH_APPROVAL_CONFIG_KEY, false);
     // This workspace already has its own explicit value -- e.g. set via the
     // post-#7148 settings UI in an earlier session.
@@ -205,7 +103,7 @@ describe('migrateLegacyGlobalBashApprovalOverride', () => {
     // than `workspaceValue` -- the migration must treat that the same as an
     // explicit workspace override, not just copy the stale global `false`
     // over the top of it (issue #7169 bugbot follow-up).
-    const config = new FakeConfigProvider();
+    const config = new FakeScopedConfigProvider();
     config.seedGlobal(BASH_APPROVAL_CONFIG_KEY, false);
     config.seedWorkspaceFolder(BASH_APPROVAL_CONFIG_KEY, true);
     const workspaceState = new MemoryStateStore();
@@ -240,7 +138,7 @@ describe('migrateLegacyGlobalBashApprovalOverride', () => {
     // global `false` is left to silently keep bypassing approval in every
     // other, not-yet-migrated workspace with no way to ever retry the clear
     // (issue #7169 bugbot + claude-review follow-up).
-    const config = new FakeConfigProvider();
+    const config = new FakeScopedConfigProvider();
     config.seedGlobal(BASH_APPROVAL_CONFIG_KEY, false);
     config.failUpdatesForTarget = 'global';
     const workspaceState = new MemoryStateStore();

--- a/src/test-kernel/support/FakePlatform.ts
+++ b/src/test-kernel/support/FakePlatform.ts
@@ -182,6 +182,126 @@ export class FakeConfigProvider implements ConfigProvider {
   }
 }
 
+/**
+ * `ConfigProvider` fake with real folder -> workspace -> global fallback,
+ * mirroring `VscodeConfigProvider`/`JsonConfigProvider`'s resolution order.
+ * Unlike `FakeConfigProvider` above (which records one target per key and
+ * so cannot hold a folder override and a global value for the same key at
+ * once), this tracks the three scopes independently.
+ *
+ * `update()`'s `target` is intentionally never defaulted: a call site that
+ * omits it is recorded as `undefined`, not silently coerced to
+ * `'workspace'`, so tests can catch scope-mismatch regressions (issue
+ * #7085) that a defaulted target would mask.
+ */
+export class FakeScopedConfigProvider implements ConfigProvider {
+  private readonly globalValues = new Map<string, unknown>();
+
+  private readonly workspaceValues = new Map<string, unknown>();
+
+  private readonly workspaceFolderValues = new Map<string, unknown>();
+
+  private readonly lastTargets = new Map<string, ConfigTarget>();
+
+  readonly updateCalls: Array<{
+    key: string;
+    value: unknown;
+    target: ConfigTarget | undefined;
+  }> = [];
+
+  /**
+   * When set, `update()` calls targeting this scope throw instead of
+   * applying -- simulates a persistence failure (e.g. VS Code rejecting the
+   * write) so tests can assert on partial-migration recovery behavior.
+   */
+  failUpdatesForTarget?: ConfigTarget;
+
+  get<T>(key: string, defaultValue?: T): T {
+    if (this.workspaceFolderValues.has(key))
+      return this.workspaceFolderValues.get(key) as T;
+    if (this.workspaceValues.has(key))
+      return this.workspaceValues.get(key) as T;
+    if (this.globalValues.has(key)) return this.globalValues.get(key) as T;
+    return defaultValue as T;
+  }
+
+  async update<T>(
+    key: string,
+    value: T,
+    target?: ConfigTarget,
+  ): Promise<void> {
+    if (target !== undefined && target === this.failUpdatesForTarget) {
+      throw new Error(`simulated ${target}-scope update failure for ${key}`);
+    }
+    this.updateCalls.push({ key, value, target });
+    if (target === undefined) {
+      this.lastTargets.delete(key);
+    } else {
+      this.lastTargets.set(key, target);
+    }
+    const store =
+      target === 'global' ? this.globalValues : this.workspaceValues;
+    if (value === undefined) {
+      store.delete(key);
+    } else {
+      store.set(key, value);
+    }
+  }
+
+  /** The most recent explicit `target` passed to `update()` for `key`, or `undefined` if none was given. */
+  lastTargetFor(key: string): ConfigTarget | undefined {
+    return this.lastTargets.get(key);
+  }
+
+  inspect<T = unknown>(key: string): ConfigInspection<T> | undefined {
+    return {
+      globalValue: this.globalValues.has(key)
+        ? (this.globalValues.get(key) as T)
+        : undefined,
+      workspaceValue: this.workspaceValues.has(key)
+        ? (this.workspaceValues.get(key) as T)
+        : undefined,
+      workspaceFolderValue: this.workspaceFolderValues.has(key)
+        ? (this.workspaceFolderValues.get(key) as T)
+        : undefined,
+      effectiveValue: this.get<T>(key),
+    };
+  }
+
+  isExplicitlySet(key: string): boolean {
+    return (
+      this.globalValues.has(key) ||
+      this.workspaceValues.has(key) ||
+      this.workspaceFolderValues.has(key)
+    );
+  }
+
+  watch(): Disposable {
+    return { dispose: () => {} };
+  }
+
+  /** Seeds a legacy global value directly, without going through `update()`. */
+  seedGlobal(key: string, value: unknown): void {
+    this.globalValues.set(key, value);
+  }
+
+  /** Seeds a workspace value directly, without going through `update()`. */
+  seedWorkspace(key: string, value: unknown): void {
+    this.workspaceValues.set(key, value);
+  }
+
+  /**
+   * Seeds a resource-scoped `workspaceFolderValue` directly. Real writes to
+   * the `'workspace'` target (`ConfigTarget` has no folder-scope option)
+   * land in `workspaceValue`, but some settings are declared
+   * `resource`-scoped, so UI writes to them commonly resolve as
+   * `workspaceFolderValue` instead -- this seeds that shape directly.
+   */
+  seedWorkspaceFolder(key: string, value: unknown): void {
+    this.workspaceFolderValues.set(key, value);
+  }
+}
+
 export class FakeStateStore implements StateStore {
   private readonly values = new Map<string, unknown>();
 

--- a/src/test-kernel/support/FakePlatform.ts
+++ b/src/test-kernel/support/FakePlatform.ts
@@ -225,11 +225,7 @@ export class FakeScopedConfigProvider implements ConfigProvider {
     return defaultValue as T;
   }
 
-  async update<T>(
-    key: string,
-    value: T,
-    target?: ConfigTarget,
-  ): Promise<void> {
+  async update<T>(key: string, value: T, target?: ConfigTarget): Promise<void> {
     if (target !== undefined && target === this.failUpdatesForTarget) {
       throw new Error(`simulated ${target}-scope update failure for ${key}`);
     }


### PR DESCRIPTION
## Summary

A scheduled structural-debt audit ([debt-audit workflow](https://code.claude.com/docs/en/claude-code-on-the-web), 19 agents, ~43 min) scanned the codebase for overlapping/confusing responsibilities. It surfaced real criterion-2 dual-system debt: three test files each independently hand-rolled a folder → workspace → global-scoped `ConfigProvider` test fake, working around a gap in the canonical `FakeConfigProvider` (`src/test-kernel/support/FakePlatform.ts`), which records only one scope per key and so can't represent "a key holds both a global value and a workspace/folder override" — a state these three suites specifically need to test.

This PR adds one canonical multi-scope fake, `FakeScopedConfigProvider`, to `FakePlatform.ts`, and deletes the three local reimplementations:

- `FakeConfigProvider` in `src/test-kernel/settings/BashApprovalGlobalMigration.vitest.ts` (89 lines)
- `FolderOverrideConfigProvider` in `src/test-kernel/auth/CodexPreference.vitest.ts` (47 lines)
- `MemoryConfigStore` in `src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts` (41 lines)

All three classes were test-file-local with zero consumers outside their own file — no production code touched.

## Issue acceptance gates

No tracked issue; this is a repo-wide structural-debt scan (scheduled routine), not a response to a filed bug. Acceptance gate is self-imposed: identify genuine duplicate-logic/overlap debt and consolidate the most significant instance, with all affected suites still green.

## Single source of truth

`FakeScopedConfigProvider` (`src/test-kernel/support/FakePlatform.ts`) is now the one fake that owns folder > workspace > global fallback resolution for tests that need multi-scope `ConfigProvider` behavior — mirroring the real `VscodeConfigProvider`/`JsonConfigProvider` resolution order the three ad hoc fakes were each separately reimplementing.

## Duplication and abstraction budget

Removed: 177 lines of duplicated folder/workspace/global scope-resolution logic spread across three files. No new abstraction layer was introduced — `FakeScopedConfigProvider` is an additive sibling export next to the existing single-scope `FakeConfigProvider` (kept as-is; it has ~10 other consumers unrelated to this multi-scope need), not a wrapper around it.

One behavioral nuance preserved deliberately: `MemoryConfigStore`'s `update()` never defaulted its `target` parameter, specifically to catch scope-mismatch regressions (issue #7085) that a defaulted `'workspace'` would mask. `FakeScopedConfigProvider.update()` keeps that contract — `target?: ConfigTarget` stays `undefined`-preserving — and exposes it via a new `lastTargetFor(key)` query method, alongside the ordered `updateCalls` history the other two fakes needed.

## Net elements (R6)

- Classes: 4 → 1 (net **-3**): deletes `FakeConfigProvider` (local), `FolderOverrideConfigProvider`, `MemoryConfigStore`; adds one exported `FakeScopedConfigProvider`.
- Exported symbols: net **+1** (`FakeScopedConfigProvider` is now exported for reuse; the three deleted classes were unexported/file-local).
- Files: no new files; 1 file grows (`FakePlatform.ts` +120 lines), 3 files shrink.
- Net LoC: **-76** across the 4 files (144 insertions / 220 deletions).

## Consumer counts (R8)

Not an emit-path or event-key change. Grep-verified consumer counts of the deleted classes before removal:
- `FakeConfigProvider` (BashApprovalGlobalMigration-local): 6 construction sites, all within the same file.
- `FolderOverrideConfigProvider`: 1 construction site, file-local.
- `MemoryConfigStore`: 5 construction sites (incl. one default-parameter value) + 2 `.updateTargets.get()` read sites, all file-local.

No consumer existed outside the three defining files (`grep -rln` confirmed), so this is a pure in-place substitution with no external call-site risk.

## Host impact

Extension: none (test-only change).

Desktop: none (test-only change; `DesktopSettingsIpc.vitest.mts` covers desktop IPC but no desktop production code changed).

CLI: none.

## Scheduled refactoring

None — this consolidation is complete in this PR.

## Validation

- `npm run typecheck` — full workspace (core, test-kernel, agent, extension, cli, trace-viewer, desktop) — clean.
- `npx eslint` on all 4 changed files — clean.
- `npx vitest run` on the 3 directly affected spec files — 3 files / 31 tests passed.
- `npx vitest run src/test-kernel/settings src/test-kernel/auth src/test-kernel/desktop` (full surrounding directories) — 105 files / 844 tests passed.
- `npm run check:dead-code-ratchet` — no new unused files/exports/types vs. baseline.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jr9GB742QEyV2nUV653gBW)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with no production or runtime behavior changes; existing assertions are preserved via the shared fake.
> 
> **Overview**
> Introduces **`FakeScopedConfigProvider`** in `FakePlatform.ts` as the shared test double for folder → workspace → global config resolution (matching real providers), and removes three file-local copies (`FolderOverrideConfigProvider`, `MemoryConfigStore`, and the migration-local `FakeConfigProvider`).
> 
> The three affected suites (**Codex preference**, **bash-approval global migration**, **desktop settings IPC**) now construct this fake and use **`seedGlobal` / `seedWorkspace` / `seedWorkspaceFolder`** plus **`lastTargetFor`** and **`updateCalls`** instead of bespoke maps and helpers.
> 
> **`update()`** still does not default **`target`** to `'workspace'`, so tests can still catch scope-mismatch regressions (e.g. issue #7085). Production code is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bec70d7fdb1a1465cc813d496a603fc8a887a6a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->