### PR TITLE
docs(auth): explain credential refresh boundary

### DIFF
--- a/src/auth/authFlowEffects.ts
+++ b/src/auth/authFlowEffects.ts
@@ -7,13 +7,15 @@
  * not a missing shared coordinator. The extension invalidates its long-lived
  * model cache before publishing a session event. Desktop routes the same
  * transition through its settings-IPC refresh chain because that chain also
- * republishes model, profile, and agent-catalog state; its onboarding refresh
- * is a separate call made by the same desktop session-change handler. Ordinary
- * CLI login and logout commands exit without consuming model options. The
- * long-lived CLI paths own their additional state transitions: onboarding
- * applies the selected access mode, while the chat TUI updates its session API
- * mode and refreshes credential-dependent views. Collapsing these effects
- * would either omit host refresh work or repeat it.
+ * republishes model and profile state. Agent-catalog publication normally
+ * follows there, except that team sign-in deliberately defers it to the team
+ * resolver; onboarding is refreshed separately by the desktop session-change
+ * handler. Ordinary CLI login and logout commands exit without consuming
+ * model options. Persistent CLI callers own their subsequent transition before
+ * reading credential-dependent state: onboarding applies its selected access
+ * mode, the orchestration launcher invalidates its model list, and the chat TUI
+ * updates its session API mode and views. Collapsing these effects would either
+ * omit host refresh work or repeat it.
  */
 
 import { toErrorMessage } from '@utils/errors/errorMessage';

--- a/src/auth/authFlowEffects.ts
+++ b/src/auth/authFlowEffects.ts
@@ -14,8 +14,10 @@
  * model options. Persistent CLI callers own their subsequent transition before
  * reading credential-dependent state: onboarding applies its selected access
  * mode, the orchestration launcher invalidates its model list, and the chat TUI
- * updates its session API mode and views. Collapsing these effects would either
- * omit host refresh work or repeat it.
+ * updates its session API mode and views. Within that persistent CLI session,
+ * setup-agent team sign-in immediately refreshes and rereads the remote agent
+ * catalog before applying the selected team. Collapsing these effects would
+ * either omit host refresh work or repeat it.
  */
 
 import { toErrorMessage } from '@utils/errors/errorMessage';

--- a/src/auth/authFlowEffects.ts
+++ b/src/auth/authFlowEffects.ts
@@ -7,11 +7,13 @@
  * not a missing shared coordinator. The extension invalidates its long-lived
  * model cache before publishing a session event. Desktop routes the same
  * transition through its settings-IPC refresh chain because that chain also
- * republishes model, profile, onboarding, and agent-catalog state. Ordinary
- * CLI login and logout commands exit without consuming model options; the
- * long-lived onboarding path invalidates them when it applies the selected
- * access mode. Collapsing these effects would either omit host refresh work or
- * repeat it.
+ * republishes model, profile, and agent-catalog state; its onboarding refresh
+ * is a separate call made by the same desktop session-change handler. Ordinary
+ * CLI login and logout commands exit without consuming model options. The
+ * long-lived CLI paths own their additional state transitions: onboarding
+ * applies the selected access mode, while the chat TUI updates its session API
+ * mode and refreshes credential-dependent views. Collapsing these effects
+ * would either omit host refresh work or repeat it.
  */
 
 import { toErrorMessage } from '@utils/errors/errorMessage';

--- a/src/auth/authFlowEffects.ts
+++ b/src/auth/authFlowEffects.ts
@@ -3,9 +3,15 @@
  * (`packages/extension/src/frontend/auth/SupabaseAuthProvider.ts`,
  * `packages/desktop/src/main/desktopSupabaseAuth.ts`,
  * `packages/cli/src/runtime/supabaseAuth.ts`). Deliberately narrow: the
- * broader post-auth cache-invalidation sequence differs by host (desktop
- * routes it through its settings-IPC refresh chain, which does more than a
- * bare cache clear) and is not safe to collapse into one call.
+ * broader post-auth cache-invalidation sequence is a permanent host boundary,
+ * not a missing shared coordinator. The extension invalidates its long-lived
+ * model cache before publishing a session event. Desktop routes the same
+ * transition through its settings-IPC refresh chain because that chain also
+ * republishes model, profile, onboarding, and agent-catalog state. Ordinary
+ * CLI login and logout commands exit without consuming model options; the
+ * long-lived onboarding path invalidates them when it applies the selected
+ * access mode. Collapsing these effects would either omit host refresh work or
+ * repeat it.
  */
 
 import { toErrorMessage } from '@utils/errors/errorMessage';


### PR DESCRIPTION
## Summary

Documents why post-credential-change invalidation remains a host boundary rather than a shared coordinator.

- the extension invalidates its long-lived model cache before publishing its session event
- desktop refreshes model, profile, onboarding, and agent-catalog surfaces through settings IPC
- ordinary CLI login/logout exits before model options are consumed, while CLI onboarding invalidates them through its access-mode transition

This resolves the design question without adding a shallow wrapper or duplicating desktop refresh work.

## Validation

- Prettier check
- ESLint on `src/auth/authFlowEffects.ts`
- `git diff --check`

Closes #9485

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only update with no runtime or API changes.
> 
> **Overview**
> **Documentation-only change** in `src/auth/authFlowEffects.ts`: the file header comment is rewritten to state explicitly that post-auth cache invalidation is an intentional **host boundary**, not a gap to unify.
> 
> The new text spells out how each surface handles credential transitions—the extension clears its model cache before session events, desktop goes through settings IPC (models, profile, onboarding, agent catalog with team-sign-in deferrals), and CLI behavior for one-shot login/logout vs persistent sessions (onboarding, launcher, TUI, setup-agent team sign-in)—and why folding these into one helper would **skip or duplicate** host-specific refresh work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dece61ed7b6f8c0dcee7e99f83e477740475b260. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->