### PR TITLE
fix(runtime): preserve owner isolation during handoff

### DIFF
--- a/packages/cli/src/chat/tui/state/approvalQueue.ts
+++ b/packages/cli/src/chat/tui/state/approvalQueue.ts
@@ -453,11 +453,18 @@ export function clearApprovalsForOwner(owner: object): number {
   });
 }
 
-export function clearRetryApprovalsForStream(streamId: string): void {
-  clearApprovalsWhere(
-    (payload) =>
-      payload.kind === 'retry' && payload.payload.streamId === streamId,
+/** Replace a retry only within the host attachment that owns it. */
+export function clearRetryApprovalsForStream(
+  streamId: string,
+  owner: object,
+): void {
+  settleItems(
+    (item) =>
+      item.owner === owner &&
+      item.payload.kind === 'retry' &&
+      item.payload.payload.streamId === streamId,
     INTERRUPT,
+    { cancelled: true },
   );
 }
 

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -312,11 +312,13 @@ async function requestProposalInteraction(
 
 /**
  * The queue entry is this retry's liveness: reserving it replaces whatever
- * retry the stream had (its pre-modal lookup, its modal, or the credential
- * switch it had already started), and holding it until `release` means a later
- * cancel reaches the commit as well. Nothing here re-checks whether the
- * request is still current — a settled entry ignores `present` and `settle`,
- * and its abort signal stops the work in flight.
+ * retry the same host owned for the stream (its pre-modal lookup, its modal, or
+ * the credential switch it had already started), and holding it until
+ * `release` means a later cancel reaches the commit as well. Another host may
+ * temporarily overlap during attachment handoff, so its reservation remains
+ * isolated. Nothing here re-checks whether the request is still current — a
+ * settled entry ignores `present` and `settle`, and its abort signal stops the
+ * work in flight.
  */
 async function requestRetryInteraction(
   request: HostRetryRequest,
@@ -324,7 +326,7 @@ async function requestRetryInteraction(
   attachment: { readonly owner: object; readonly commitQueue: PQueue },
   options: HostRetryInteractionOptions | undefined,
 ): Promise<RetryResult> {
-  clearRetryApprovalsForStream(request.streamId);
+  clearRetryApprovalsForStream(request.streamId, attachment.owner);
   const reservation = reserveApproval(
     { kind: 'retry', payload: request },
     { onPresent: announceApproval, owner: attachment.owner },

--- a/packages/extension/src/frontend/agents/AgentDirectoryManager.ts
+++ b/packages/extension/src/frontend/agents/AgentDirectoryManager.ts
@@ -188,6 +188,9 @@ class AgentDirectoryManager {
       }
 
       const directories = await this.getAllLocal();
+      if (this.watcherSubscriptions.size === 0) {
+        return;
+      }
       const cached = this.watcherDirectories;
       this.watcherDirectories = directories;
       if (cached && this.sameDirectories(cached, directories)) {

--- a/packages/extension/src/frontend/agents/AgentDirectoryManager.ts
+++ b/packages/extension/src/frontend/agents/AgentDirectoryManager.ts
@@ -198,6 +198,9 @@ class AgentDirectoryManager {
       }
 
       await this.buildAgentWatchers(directories);
+      if (this.watcherSubscriptions.size === 0) {
+        this.disposeAgentWatchers();
+      }
     });
   }
 

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
@@ -1308,6 +1308,45 @@ describe('TUI retry approvals', () => {
     await waitForApproval('retry', { errorMessage: 'second retry' });
   });
 
+  it('does not replace a retry owned by another host on the same stream', async () => {
+    mocks.hasUsableApiKey.mockResolvedValue(false);
+
+    const older = tui();
+    const newer = tui();
+    const olderResult = older.interactions.requestRetry?.(
+      relayRetry({
+        streamId: 'shared-stream',
+        provider: 'openai',
+        message: 'older host retry',
+      }),
+    );
+    await waitForApproval('retry', { errorMessage: 'older host retry' });
+
+    const newerResult = newer.interactions.requestRetry?.(
+      relayRetry({
+        streamId: 'shared-stream',
+        provider: 'openai',
+        message: 'newer host retry',
+      }),
+    );
+    await vi.waitFor(() => {
+      expect(pendingApprovalSummaries.get()).toHaveLength(2);
+    });
+    expect(currentApproval.get()?.payload).toMatchObject({
+      kind: 'retry',
+      payload: { errorMessage: 'older host retry' },
+    });
+
+    older.dispose();
+    await expect(olderResult).resolves.toEqual({ action: 'cancel' });
+    await waitForApproval('retry', { errorMessage: 'newer host retry' });
+    decideRetry({ accepted: true });
+    await expect(newerResult).resolves.toEqual({
+      action: 'retry',
+      feedback: undefined,
+    });
+  });
+
   it('detaches one host without settling the live host retry', async () => {
     mocks.hasUsableApiKey.mockResolvedValue(false);
 

--- a/src/test-kernel/frontend/agents/AgentDirectoryWatchers.vitest.ts
+++ b/src/test-kernel/frontend/agents/AgentDirectoryWatchers.vitest.ts
@@ -213,7 +213,7 @@ describe('agent directory watcher rebuilds', () => {
 
     expect(refreshSettled).toBe(true);
     await refreshed;
-    expect(mocks.watchedDirectories).toEqual(['/agents/builtin']);
+    expect(mocks.watchedDirectories).toEqual([]);
   });
 
   it('rebuilds for a subdirectory created after the running rebuild listed its parent', async () => {

--- a/src/test-kernel/frontend/agents/AgentDirectoryWatchers.vitest.ts
+++ b/src/test-kernel/frontend/agents/AgentDirectoryWatchers.vitest.ts
@@ -11,6 +11,7 @@ const EXTERNAL_SECOND = '/external/second';
 
 const mocks = vi.hoisted(() => ({
   getAllLocal: vi.fn<() => Promise<unknown[]>>(),
+  liveWatcherDirectories: new Set<string>(),
   watchedDirectories: [] as string[],
   /** Directory listings keyed by fsPath, standing in for the disk. */
   tree: new Map<string, [string, number][]>(),
@@ -47,6 +48,7 @@ vi.mock('vscode', () => ({
     },
     createFileSystemWatcher: (pattern: { base: { fsPath: string } }) => {
       mocks.watchedDirectories.push(pattern.base.fsPath);
+      mocks.liveWatcherDirectories.add(pattern.base.fsPath);
       return {
         onDidCreate: (handler: (uri: { fsPath: string }) => void) => {
           mocks.createHandlers.set(pattern.base.fsPath, handler);
@@ -54,7 +56,9 @@ vi.mock('vscode', () => ({
         },
         onDidChange: () => ({ dispose: () => {} }),
         onDidDelete: () => ({ dispose: () => {} }),
-        dispose: () => {},
+        dispose: () => {
+          mocks.liveWatcherDirectories.delete(pattern.base.fsPath);
+        },
       };
     },
   },
@@ -138,6 +142,7 @@ describe('agent directory watcher rebuilds', () => {
   beforeEach(() => {
     subscription?.dispose();
     subscription = undefined;
+    mocks.liveWatcherDirectories.clear();
     mocks.watchedDirectories.length = 0;
     mocks.tree.clear();
     mocks.heldReads.clear();
@@ -214,6 +219,30 @@ describe('agent directory watcher rebuilds', () => {
     expect(refreshSettled).toBe(true);
     await refreshed;
     expect(mocks.watchedDirectories).toEqual([]);
+  });
+
+  it('disposes watchers built after the last subscription is removed', async () => {
+    const scan = pDefer<void>();
+    mocks.getAllLocal.mockResolvedValue([
+      { directory: EXTERNAL_FIRST, source: 'custom' },
+    ]);
+    mocks.tree.set(EXTERNAL_FIRST, []);
+    mocks.heldReads.set(EXTERNAL_FIRST, scan);
+
+    subscription = agentDirectories.watchAgentDirectories({
+      onEvent: () => {},
+    });
+    await vi.waitFor(() => {
+      expect(mocks.heldReads.has(EXTERNAL_FIRST)).toBe(false);
+    });
+
+    subscription.dispose();
+    subscription = undefined;
+    scan.resolve();
+    await settle();
+
+    expect(mocks.watchedDirectories).toEqual([EXTERNAL_FIRST]);
+    expect(mocks.liveWatcherDirectories.size).toBe(0);
   });
 
   it('rebuilds for a subdirectory created after the running rebuild listed its parent', async () => {


### PR DESCRIPTION
## Summary

Addresses two exact-head review findings that arrived as #9507 was being merged.

- rechecks watcher subscriptions after the asynchronous directory scan, preventing watcher handles from being rebuilt after the last subscriber has disposed
- scopes same-stream retry replacement to the owning host attachment, so an overlapping replacement host cannot cancel a retry still committing under the detaching host
- corrects the watcher interleaving expectation and adds a same-stream, two-owner retry regression test

## Validation

- focused watcher and retry suites: 45 tests pass
- extension typecheck
- CLI typecheck
- test-kernel typecheck
- ESLint on changed files
- Prettier and `git diff --check`

Follow-up to #9507.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes approval-queue behavior during host handoff and extension file-watcher lifecycle; risk is mitigated by focused regression tests but affects overlapping TUI hosts and async subscription teardown.
> 
> **Overview**
> Fixes two handoff races from the prior runtime work: **TUI retry approvals** and **agent directory watchers**.
> 
> **Retry approvals:** `clearRetryApprovalsForStream` now requires the **host attachment `owner`**, so starting a retry on a replacement host no longer cancels an older host’s retry on the same `streamId` during overlap. `requestRetryInteraction` passes `attachment.owner`; comments note per-host isolation while attachments overlap.
> 
> **Agent directory watchers:** `ensureAgentWatchers` re-checks `watcherSubscriptions` after the async `getAllLocal()` and again after `buildAgentWatchers`; if the last subscriber disposed mid-rebuild, it **disposes watchers** instead of leaving handles live.
> 
> Tests add a same-stream two-host retry regression, a “dispose watchers built after unsubscribe” case, and fix the interleaving expectation when refresh settles with no subscribers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92ad11105b75b0461f48a0356bdeec9ab1d4a24e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Closes #9512
Closes #9513