### PR TITLE
refactor(update): share host update-check state machine

### DIFF
--- a/packages/cli/src/runtime/updateChecker.ts
+++ b/packages/cli/src/runtime/updateChecker.ts
@@ -9,13 +9,14 @@ import type { StateStore } from '@platform/interfaces';
 import { JsonStore } from '@platform/defaults/jsonStore';
 import { createNodeStorageProvider } from '@platform/defaults/nodeStorage';
 import { GlobalStateKey } from '@shared/state/stateKeys';
-import {
-  DAILY_UPDATE_CHECK_INTERVAL_MS,
-  isNewerSemverVersion,
-  UPDATE_CHECK_SKIP_ENV,
-} from '@utils/system/semverUpdateCheck';
+import { UPDATE_CHECK_SKIP_ENV } from '@utils/system/semverUpdateCheck';
 import { executeCommand } from '@utils/system/execUtils';
 import { isEnvFlagEnabled } from '@utils/system/envFlags';
+import {
+  fetchJsonStringField,
+  runDailyUpdateCheck,
+  type UpdateCheckFetchResult,
+} from '@utils/system/updateCheck';
 
 import {
   readCliAmbientState,
@@ -39,11 +40,6 @@ const CLI_HOMEBREW_FORMULA = 'texra';
 const DEFAULT_REGISTRY = 'https://registry.npmjs.org';
 const DEFAULT_TIMEOUT_MS = 2500;
 const HOMEBREW_COMMAND_TIMEOUT_MS = 10000;
-/**
- * Check for a new release at most once per day, matching the desktop update
- * checker's cadence (see `desktopUpdateChecker.ts`).
- */
-const CHECK_INTERVAL_MS = DAILY_UPDATE_CHECK_INTERVAL_MS;
 
 /** Package manager the running binary was installed with. */
 export type InstallMethod = 'npm' | 'pnpm' | 'yarn' | 'bun' | 'brew';
@@ -141,18 +137,13 @@ export async function fetchLatestCliVersion(options?: {
   fetchImpl?: typeof fetch;
 }): Promise<string | undefined> {
   const registry = options?.registry ?? DEFAULT_REGISTRY;
-  const fetchImpl = options?.fetchImpl ?? fetch;
-  try {
-    const response = await fetchImpl(`${registry}/${CLI_PACKAGE_NAME}/latest`, {
-      signal: AbortSignal.timeout(options?.timeoutMs ?? DEFAULT_TIMEOUT_MS),
-      headers: { accept: 'application/json' },
-    });
-    if (!response.ok) return undefined;
-    const body = (await response.json()) as { version?: unknown };
-    return typeof body.version === 'string' ? body.version : undefined;
-  } catch {
-    return undefined;
-  }
+  return fetchJsonStringField({
+    url: `${registry}/${CLI_PACKAGE_NAME}/latest`,
+    field: 'version',
+    timeoutMs: options?.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    headers: { accept: 'application/json' },
+    fetchImpl: options?.fetchImpl,
+  });
 }
 
 type CommandRunner = (
@@ -208,19 +199,13 @@ function parseHomebrewFormulaVersion(
   return entry?.versions?.stable ?? undefined;
 }
 
-/** Result of one fetch attempt against the package source. */
-export interface CliUpdateFetchResult {
-  /** Latest published version, when one could be read (possibly stale). */
-  version: string | undefined;
-  /**
-   * True when the version reflects a live consultation of the source — an npm
-   * registry response, or `brew info` after a successful tap refresh. False
-   * when only stale local metadata was readable (failed `brew update`): still
-   * usable for a prompt, but the attempt must retry next launch instead of
-   * being stamped for a full throttle window.
-   */
-  refreshed: boolean;
-}
+/**
+ * Result of one fetch attempt against the package source. For Homebrew,
+ * `refreshed: false` means a failed tap refresh yielded only stale local
+ * metadata: the version may still be offered, but the daily check is not
+ * stamped as complete.
+ */
+export type CliUpdateFetchResult = UpdateCheckFetchResult;
 
 /**
  * Attempt to refresh Homebrew tap metadata and fetch the latest formula
@@ -312,17 +297,13 @@ export interface CheckCliUpdateAvailableOptions {
 
 /**
  * At most once per day (persisted in global state), fetch the latest
- * published version and report it when newer than `currentVersion`. Mirrors
- * the desktop update checker's throttle (see `checkForDesktopUpdate` in
- * `desktopUpdateChecker.ts`), but this is the single owner of the daily
- * stamp: it is written in exactly one place, only once every outcome of the
- * attempt is known — the source was genuinely consulted (`refreshed`, not a
- * stale brew cache behind a failed tap refresh) and, when an update was
- * available, `notify` resolved (the user actually saw it). Any other outcome
- * (offline, registry hiccup, failed tap refresh, killed prompt) leaves the
- * stamp unwritten so the next launch retries instead of being suppressed for
- * a full day. The stamp write itself is best-effort: a failed write never
- * rejects the completed attempt (it only means an early re-check).
+ * published version and report it when newer than `currentVersion`. The shared
+ * daily-check state machine writes the stamp only after the source was
+ * genuinely consulted (`refreshed`, not a stale brew cache behind a failed tap
+ * refresh) and, when an update was available, `notify` resolved. Any other
+ * outcome (offline, registry hiccup, failed tap refresh, killed prompt) leaves
+ * the stamp unwritten so the next launch retries. CLI stamp persistence is
+ * best-effort: a failed write means an early re-check, not a failed update.
  */
 export async function checkCliUpdateAvailable({
   currentVersion,
@@ -331,34 +312,17 @@ export async function checkCliUpdateAvailable({
   notify,
   now = Date.now,
 }: CheckCliUpdateAvailableOptions): Promise<string | undefined> {
-  const lastCheckedAt = globalState.get<number>(
-    GlobalStateKey.CLI_UPDATE_CHECK_LAST_CHECKED_AT,
-    0,
-  );
-  const nowMs = now();
-  if (nowMs - lastCheckedAt < CHECK_INTERVAL_MS) return undefined;
-
-  const { version, refreshed } = await fetchLatest();
-  const latest =
-    version !== undefined && isNewerSemverVersion(version, currentVersion)
-      ? version
-      : undefined;
-  if (latest !== undefined) await notify(latest);
-  if (version !== undefined && refreshed) {
-    try {
-      await globalState.update(
-        GlobalStateKey.CLI_UPDATE_CHECK_LAST_CHECKED_AT,
-        nowMs,
-      );
-    } catch {
-      // Best-effort: the stamp write can fail even when `JsonStore.open`
-      // succeeded (readable-but-unwritable global storage). By this point the
-      // whole attempt — including the notify prompt — has completed, so a
-      // failed stamp must not reject and cancel an update the user already
-      // accepted; worst case the next launch re-checks a day early.
-    }
-  }
-  return latest;
+  return runDailyUpdateCheck({
+    currentVersion,
+    state: globalState,
+    lastCheckedAtKey: GlobalStateKey.CLI_UPDATE_CHECK_LAST_CHECKED_AT,
+    fetchLatest,
+    notify,
+    now,
+    // A readable-but-unwritable global state file must not cancel an update
+    // the user already accepted; the next launch merely checks again early.
+    stampFailure: 'ignore',
+  });
 }
 
 let notified = false;

--- a/packages/desktop/src/main/desktopUpdateChecker.ts
+++ b/packages/desktop/src/main/desktopUpdateChecker.ts
@@ -51,7 +51,7 @@ async function fetchLatestDesktopRelease(options?: {
     },
     fetchImpl: options?.fetchImpl,
   });
-  return tag === undefined ? undefined : { version: tag.replace(/^v/, '') };
+  return tag ? { version: tag.replace(/^v/, '') } : undefined;
 }
 
 export interface CheckForDesktopUpdateOptions {

--- a/packages/desktop/src/main/desktopUpdateChecker.ts
+++ b/packages/desktop/src/main/desktopUpdateChecker.ts
@@ -1,11 +1,11 @@
 import type { StateStore } from '@platform/interfaces';
 import { GlobalStateKey } from '@shared/state/stateKeys';
-import {
-  DAILY_UPDATE_CHECK_INTERVAL_MS,
-  isNewerSemverVersion,
-  UPDATE_CHECK_SKIP_ENV,
-} from '@utils/system/semverUpdateCheck';
+import { UPDATE_CHECK_SKIP_ENV } from '@utils/system/semverUpdateCheck';
 import { isEnvFlagEnabled } from '@utils/system/envFlags';
+import {
+  fetchJsonStringField,
+  runDailyUpdateCheck,
+} from '@utils/system/updateCheck';
 
 /**
  * Lightweight desktop update check (issue #7682, decision: arm b).
@@ -30,8 +30,6 @@ export const DESKTOP_RELEASES_PAGE_URL =
 /** Stable identifier for GitHub API request logging/diagnostics. */
 const GITHUB_USER_AGENT = 'TeXRA-Desktop';
 const FETCH_TIMEOUT_MS = 5000;
-/** Poll at most once per day so a normal multi-launch day makes one request. */
-const CHECK_INTERVAL_MS = DAILY_UPDATE_CHECK_INTERVAL_MS;
 
 interface DesktopLatestRelease {
   /** Release version with any leading `v` stripped, e.g. `0.40.0`. */
@@ -43,23 +41,17 @@ async function fetchLatestDesktopRelease(options?: {
   timeoutMs?: number;
   fetchImpl?: typeof fetch;
 }): Promise<DesktopLatestRelease | undefined> {
-  const fetchImpl = options?.fetchImpl ?? fetch;
-  try {
-    const response = await fetchImpl(RELEASES_API_URL, {
-      signal: AbortSignal.timeout(options?.timeoutMs ?? FETCH_TIMEOUT_MS),
-      headers: {
-        accept: 'application/vnd.github+json',
-        'user-agent': GITHUB_USER_AGENT,
-      },
-    });
-    if (!response.ok) return undefined;
-    const body = (await response.json()) as { tag_name?: unknown };
-    const tag = typeof body.tag_name === 'string' ? body.tag_name : undefined;
-    if (!tag) return undefined;
-    return { version: tag.replace(/^v/, '') };
-  } catch {
-    return undefined;
-  }
+  const tag = await fetchJsonStringField({
+    url: RELEASES_API_URL,
+    field: 'tag_name',
+    timeoutMs: options?.timeoutMs ?? FETCH_TIMEOUT_MS,
+    headers: {
+      accept: 'application/vnd.github+json',
+      'user-agent': GITHUB_USER_AGENT,
+    },
+    fetchImpl: options?.fetchImpl,
+  });
+  return tag === undefined ? undefined : { version: tag.replace(/^v/, '') };
 }
 
 export interface CheckForDesktopUpdateOptions {
@@ -118,35 +110,17 @@ async function runDesktopUpdateCheck({
   if (!isPackaged) return;
   if (isEnvFlagEnabled(UPDATE_CHECK_SKIP_ENV, env)) return;
 
-  const lastCheckedAt = globalState.get<number>(
-    GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT,
-    0,
-  );
-  const nowMs = now();
-  if (nowMs - lastCheckedAt < CHECK_INTERVAL_MS) return;
-
-  const release = await fetchRelease();
-  if (!release) return;
-
-  // Notify at most once per release version; a matching-or-older release just
-  // refreshes the throttle stamp below.
-  if (
-    isNewerSemverVersion(release.version, currentVersion) &&
-    globalState.get<string>(
+  await runDailyUpdateCheck({
+    currentVersion,
+    state: globalState,
+    lastCheckedAtKey: GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT,
+    lastNotifiedVersionKey:
       GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_NOTIFIED_VERSION,
-    ) !== release.version
-  ) {
-    await notify(release);
-    await globalState.update(
-      GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_NOTIFIED_VERSION,
-      release.version,
-    );
-  }
-
-  // Stamp the daily throttle only after a successful fetch and any required
-  // notification, so a failed check retries on the next launch.
-  await globalState.update(
-    GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT,
-    nowMs,
-  );
+    fetchLatest: async () => {
+      const release = await fetchRelease();
+      return { version: release?.version, refreshed: release !== undefined };
+    },
+    notify: (version) => notify({ version }),
+    now,
+  });
 }

--- a/src/test-kernel/desktop/DesktopUpdateChecker.vitest.mts
+++ b/src/test-kernel/desktop/DesktopUpdateChecker.vitest.mts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { CheckForDesktopUpdateOptions } from '@desktop/main/desktopUpdateChecker';
 import { GlobalStateKey } from '@shared/state/stateKeys';
@@ -13,6 +13,10 @@ type DesktopLatestRelease = Parameters<
 >[0];
 
 describe('desktop update checker', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it('exposes a known-constant releases page URL (never opens API-provided URLs)', async () => {
     const { DESKTOP_RELEASES_PAGE_URL } = await loadSourceModule(
       '@desktop/main/desktopUpdateChecker',
@@ -218,6 +222,28 @@ describe('desktop update checker', () => {
       expect(
         globalState.get(GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT),
       ).toBe(nowMs + 1000);
+    });
+
+    it('treats an empty release tag as a failed fetch', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => ({
+          ok: true,
+          json: async () => ({ tag_name: '' }),
+        })) as unknown as typeof fetch,
+      );
+
+      await checkForDesktopUpdate({
+        currentVersion: '0.39.3',
+        globalState,
+        isPackaged: true,
+        env: {},
+        notify: () => {},
+      });
+
+      expect(
+        globalState.get(GlobalStateKey.DESKTOP_UPDATE_CHECK_LAST_CHECKED_AT),
+      ).toBeUndefined();
     });
 
     it('does not persist the throttle stamp when notification fails', async () => {

--- a/src/test-kernel/utils/system/SemverUpdateCheck.vitest.ts
+++ b/src/test-kernel/utils/system/SemverUpdateCheck.vitest.ts
@@ -2,7 +2,10 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { FakeStateStore } from '@test/support/FakePlatform';
 import { isNewerSemverVersion } from '@utils/system/semverUpdateCheck';
-import { runDailyUpdateCheck } from '@utils/system/updateCheck';
+import {
+  fetchJsonStringField,
+  runDailyUpdateCheck,
+} from '@utils/system/updateCheck';
 
 describe('isNewerSemverVersion', () => {
   it('compares numerically across all components', () => {
@@ -107,5 +110,41 @@ describe('runDailyUpdateCheck', () => {
     await expect(runDailyUpdateCheck(options)).rejects.toThrow(
       'read-only state',
     );
+  });
+
+  it('ignores a synchronous throttle stamp failure when requested', async () => {
+    const state = new FakeStateStore();
+    vi.spyOn(state, 'update').mockImplementation(() => {
+      throw new Error('read-only state');
+    });
+
+    await expect(
+      runDailyUpdateCheck({
+        currentVersion: '1.0.0',
+        state,
+        lastCheckedAtKey,
+        fetchLatest: async () => ({ version: '1.0.0', refreshed: true }),
+        notify: () => {},
+        now: () => nowMs,
+        stampFailure: 'ignore',
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('fetchJsonStringField', () => {
+  it('rejects an empty string field', async () => {
+    const fetchImpl = vi.fn(async () =>
+      Response.json({ version: '' }),
+    ) as unknown as typeof fetch;
+
+    await expect(
+      fetchJsonStringField({
+        url: 'https://example.test/latest',
+        field: 'version',
+        timeoutMs: 1000,
+        fetchImpl,
+      }),
+    ).resolves.toBeUndefined();
   });
 });

--- a/src/test-kernel/utils/system/SemverUpdateCheck.vitest.ts
+++ b/src/test-kernel/utils/system/SemverUpdateCheck.vitest.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
+import { FakeStateStore } from '@test/support/FakePlatform';
 import { isNewerSemverVersion } from '@utils/system/semverUpdateCheck';
+import { runDailyUpdateCheck } from '@utils/system/updateCheck';
 
 describe('isNewerSemverVersion', () => {
   it('compares numerically across all components', () => {
@@ -22,5 +24,88 @@ describe('isNewerSemverVersion', () => {
     expect(isNewerSemverVersion('latest', '1.0.0')).toBe(false);
     expect(isNewerSemverVersion('not-a-version', '0.39.3')).toBe(false);
     expect(isNewerSemverVersion('0.40.0', 'not-a-version')).toBe(false);
+  });
+});
+
+describe('runDailyUpdateCheck', () => {
+  const nowMs = Date.UTC(2026, 0, 1);
+  const lastCheckedAtKey = 'update.lastCheckedAt';
+  const lastNotifiedVersionKey = 'update.lastNotifiedVersion';
+
+  it('notifies before stamping a successful live check', async () => {
+    const state = new FakeStateStore();
+    let stampDuringNotify: number | undefined;
+
+    const latest = await runDailyUpdateCheck({
+      currentVersion: '1.0.0',
+      state,
+      lastCheckedAtKey,
+      fetchLatest: async () => ({ version: '1.1.0', refreshed: true }),
+      notify: () => {
+        stampDuringNotify = state.get(lastCheckedAtKey);
+      },
+      now: () => nowMs,
+    });
+
+    expect(latest).toBe('1.1.0');
+    expect(stampDuringNotify).toBeUndefined();
+    expect(state.get(lastCheckedAtKey)).toBe(nowMs);
+  });
+
+  it('does not repeat a release notification but still stamps a live refresh', async () => {
+    const state = new FakeStateStore({
+      [lastNotifiedVersionKey]: '1.1.0',
+    });
+    const notify = vi.fn();
+
+    await runDailyUpdateCheck({
+      currentVersion: '1.0.0',
+      state,
+      lastCheckedAtKey,
+      lastNotifiedVersionKey,
+      fetchLatest: async () => ({ version: '1.1.0', refreshed: true }),
+      notify,
+      now: () => nowMs,
+    });
+
+    expect(notify).not.toHaveBeenCalled();
+    expect(state.get(lastCheckedAtKey)).toBe(nowMs);
+  });
+
+  it('can offer stale source metadata without stamping the check', async () => {
+    const state = new FakeStateStore();
+    const notify = vi.fn();
+
+    await runDailyUpdateCheck({
+      currentVersion: '1.0.0',
+      state,
+      lastCheckedAtKey,
+      fetchLatest: async () => ({ version: '1.1.0', refreshed: false }),
+      notify,
+      now: () => nowMs,
+    });
+
+    expect(notify).toHaveBeenCalledWith('1.1.0');
+    expect(state.get(lastCheckedAtKey)).toBeUndefined();
+  });
+
+  it('applies the host policy when the throttle stamp cannot be persisted', async () => {
+    const state = new FakeStateStore();
+    vi.spyOn(state, 'update').mockRejectedValue(new Error('read-only state'));
+    const options = {
+      currentVersion: '1.0.0',
+      state,
+      lastCheckedAtKey,
+      fetchLatest: async () => ({ version: '1.0.0', refreshed: true }),
+      notify: () => {},
+      now: () => nowMs,
+    };
+
+    await expect(
+      runDailyUpdateCheck({ ...options, stampFailure: 'ignore' }),
+    ).resolves.toBeUndefined();
+    await expect(runDailyUpdateCheck(options)).rejects.toThrow(
+      'read-only state',
+    );
   });
 });

--- a/src/utils/system/updateCheck.ts
+++ b/src/utils/system/updateCheck.ts
@@ -68,11 +68,15 @@ export async function runDailyUpdateCheck({
   }
 
   if (refreshed) {
-    const stamp = state.update(lastCheckedAtKey, nowMs);
     if (stampFailure === 'ignore') {
-      await Promise.resolve(stamp).catch(() => undefined);
+      try {
+        await state.update(lastCheckedAtKey, nowMs);
+      } catch {
+        // CLI throttle persistence is best-effort; a read-only state store
+        // must not invalidate an update result that was already accepted.
+      }
     } else {
-      await stamp;
+      await state.update(lastCheckedAtKey, nowMs);
     }
   }
 
@@ -109,7 +113,7 @@ export async function fetchJsonStringField({
     const body: unknown = await response.json();
     if (typeof body !== 'object' || body === null) return undefined;
     const value = (body as Record<string, unknown>)[field];
-    return typeof value === 'string' ? value : undefined;
+    return typeof value === 'string' && value !== '' ? value : undefined;
   } catch {
     // AbortError (timeout), TypeError (network), and SyntaxError (invalid JSON)
     // all make this best-effort update source unavailable for the current run.

--- a/src/utils/system/updateCheck.ts
+++ b/src/utils/system/updateCheck.ts
@@ -1,0 +1,116 @@
+import type { StateStore } from '@platform/interfaces';
+
+import {
+  DAILY_UPDATE_CHECK_INTERVAL_MS,
+  isNewerSemverVersion,
+} from './semverUpdateCheck';
+
+/** Result of consulting an update source. */
+export interface UpdateCheckFetchResult {
+  /** Published version, when the source supplied one. */
+  version: string | undefined;
+  /** Whether the result came from a successful live refresh. */
+  refreshed: boolean;
+}
+
+export interface DailyUpdateCheckOptions {
+  currentVersion: string;
+  state: StateStore;
+  lastCheckedAtKey: string;
+  /** Persisted version used by hosts that notify only once per release. */
+  lastNotifiedVersionKey?: string;
+  fetchLatest: () => Promise<UpdateCheckFetchResult>;
+  notify: (latest: string) => PromiseLike<void> | void;
+  now?: () => number;
+  /** Whether failure to persist the throttle stamp rejects the check. */
+  stampFailure?: 'throw' | 'ignore';
+}
+
+/**
+ * Run one daily-throttled update check.
+ *
+ * The throttle stamp is written only after a live source consultation and any
+ * required notification. Thus network failures, stale local metadata, and
+ * failed notifications all retry on the next launch. Hosts may additionally
+ * persist the last notified version when a release should be announced only
+ * once, independently of the daily fetch cadence.
+ */
+export async function runDailyUpdateCheck({
+  currentVersion,
+  state,
+  lastCheckedAtKey,
+  lastNotifiedVersionKey,
+  fetchLatest,
+  notify,
+  now = Date.now,
+  stampFailure = 'throw',
+}: DailyUpdateCheckOptions): Promise<string | undefined> {
+  const lastCheckedAt = state.get<number>(lastCheckedAtKey, 0);
+  const nowMs = now();
+  if (nowMs - lastCheckedAt < DAILY_UPDATE_CHECK_INTERVAL_MS) return undefined;
+
+  const { version, refreshed } = await fetchLatest();
+  if (version === undefined) return undefined;
+
+  const latest = isNewerSemverVersion(version, currentVersion)
+    ? version
+    : undefined;
+  const alreadyNotified =
+    latest !== undefined &&
+    lastNotifiedVersionKey !== undefined &&
+    state.get<string>(lastNotifiedVersionKey) === latest;
+
+  if (latest !== undefined && !alreadyNotified) {
+    await notify(latest);
+    if (lastNotifiedVersionKey !== undefined) {
+      await state.update(lastNotifiedVersionKey, latest);
+    }
+  }
+
+  if (refreshed) {
+    const stamp = state.update(lastCheckedAtKey, nowMs);
+    if (stampFailure === 'ignore') {
+      await Promise.resolve(stamp).catch(() => undefined);
+    } else {
+      await stamp;
+    }
+  }
+
+  return latest;
+}
+
+export interface FetchJsonStringFieldOptions {
+  url: string;
+  field: string;
+  timeoutMs: number;
+  headers?: HeadersInit;
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Fetch one string field from a JSON response. Update checks are best-effort:
+ * non-success responses, malformed payloads, timeouts, and network failures
+ * all yield `undefined`.
+ */
+export async function fetchJsonStringField({
+  url,
+  field,
+  timeoutMs,
+  headers,
+  fetchImpl = fetch,
+}: FetchJsonStringFieldOptions): Promise<string | undefined> {
+  try {
+    const response = await fetchImpl(url, {
+      signal: AbortSignal.timeout(timeoutMs),
+      headers,
+    });
+    if (!response.ok) return undefined;
+
+    const body: unknown = await response.json();
+    if (typeof body !== 'object' || body === null) return undefined;
+    const value = (body as Record<string, unknown>)[field];
+    return typeof value === 'string' ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/utils/system/updateCheck.ts
+++ b/src/utils/system/updateCheck.ts
@@ -13,7 +13,7 @@ export interface UpdateCheckFetchResult {
   refreshed: boolean;
 }
 
-export interface DailyUpdateCheckOptions {
+interface DailyUpdateCheckOptions {
   currentVersion: string;
   state: StateStore;
   lastCheckedAtKey: string;
@@ -79,7 +79,7 @@ export async function runDailyUpdateCheck({
   return latest;
 }
 
-export interface FetchJsonStringFieldOptions {
+interface FetchJsonStringFieldOptions {
   url: string;
   field: string;
   timeoutMs: number;

--- a/src/utils/system/updateCheck.ts
+++ b/src/utils/system/updateCheck.ts
@@ -111,6 +111,8 @@ export async function fetchJsonStringField({
     const value = (body as Record<string, unknown>)[field];
     return typeof value === 'string' ? value : undefined;
   } catch {
+    // AbortError (timeout), TypeError (network), and SyntaxError (invalid JSON)
+    // all make this best-effort update source unavailable for the current run.
     return undefined;
   }
 }


### PR DESCRIPTION
## Summary

- Centralize daily throttling, semantic-version comparison, notification ordering, and successful-check stamping in one host-neutral update-check module.
- Share timeout-bounded, failure-tolerant JSON version fetching between the CLI registry and desktop release sources.
- Retain host-specific behavior: CLI installation prompts and best-effort stamp writes, desktop one-notification-per-version state and in-flight window ownership.

## Issue acceptance gates

- #9515: one shared state-machine core accepts host-specific state keys and notification callbacks.
- #9515: one shared HTTP helper owns timeout, response, payload, and failure handling for string version fields.
- #9515: host-specific IPC, notification, interactive update, and concurrency behavior remains at each host boundary.
- Empty desktop release tags remain failed fetches and therefore do not suppress retries.
- Empty npm registry version fields are now likewise treated as failed refreshes; they are invalid semantic versions and no longer stamp the daily throttle.

## Single source of truth

`src/utils/system/updateCheck.ts` now owns the daily update-check lifecycle and resilient JSON-field fetch. `semverUpdateCheck.ts` remains the owner of semantic-version comparison, cadence, and the common opt-out environment variable.

## Duplication and abstraction budget

The CLI and desktop previously encoded the same throttle, fetch, comparison, notify, and stamp ordering independently. The new module has two production consumers and owns the cross-host invariant. It is not a pass-through: it hides retry eligibility, notification suppression, persistence ordering, and stamp-failure policy. Host adapters retain only genuine host differences.

## Net elements (R6)

- Files: 5 changed; 1 production file added; no files deleted.
- Exported symbols: 3 shared exports added (`UpdateCheckFetchResult`, `runDailyUpdateCheck`, `fetchJsonStringField`); the existing `CliUpdateFetchResult` export remains as a type alias.
- Types/functions: net +2 interfaces and +2 functions; no classes or enums added.
- LoC: +340/-130, net +210 overall. Production code is +188/-128, net +60; direct and regression tests account for the remaining net +150.
- Justification: the small production increase replaces two independent state machines and two independent HTTP failure handlers with one two-consumer owner. The test increase directly covers the shared policy branches and the empty-tag regression identified in review.

## Consumer counts (R8)

- `runDailyUpdateCheck`: 2 production consumers (CLI and desktop).
- `fetchJsonStringField`: 2 production consumers (CLI and desktop).
- `UpdateCheckFetchResult`: 1 production type consumer through the public CLI result alias.
- No emit path, subscriber key, or existing export was deleted or rerouted.

## Host impact

Extension: None.

Desktop: Uses the shared lifecycle and JSON fetch while retaining packaging checks, environment opt-out, in-flight coalescing, latest-window notification ownership, and per-release suppression.

CLI: Uses the shared lifecycle and JSON fetch while retaining TTY/source-install gates, npm/Homebrew source selection, interactive installation, and best-effort throttle persistence.

## Scheduled refactoring

None. The duplicate implementations are removed in this PR; no dual-system transition remains.

## Validation

- `npm run format`
- `npm run compile:fast`
- `npm run lint`
- `npm run typecheck`
- `npm test` (806 files passed, 1 skipped; 8176 tests passed, 4 skipped)
- Latest focused review-fix suite: 20 tests passed.
- `npm run typecheck:test-kernel`

Closes #9515

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches startup update-check paths for CLI and desktop; behavior is intended to be equivalent but ordering and empty-tag handling are subtle enough to warrant careful review.
> 
> **Overview**
> Introduces **`src/utils/system/updateCheck.ts`** as the shared owner of daily-throttled update checks and timeout-bounded JSON version fetches, replacing parallel logic in the CLI and desktop checkers.
> 
> **`runDailyUpdateCheck`** centralizes the 24h throttle, semver comparison, notify-before-stamp ordering, optional once-per-release notification (`lastNotifiedVersionKey`), and the `refreshed` gate so stale sources (e.g. failed Homebrew tap refresh) do not suppress retries. **`fetchJsonStringField`** unifies npm registry and GitHub release fetches and now treats **empty string fields as no version** (e.g. empty `tag_name`).
> 
> CLI **`checkCliUpdateAvailable`** delegates to the shared helper with **`stampFailure: 'ignore'`** so read-only global state cannot undo an accepted update. Desktop **`checkForDesktopUpdate`** delegates while keeping packaging/env gates and in-flight coalescing at the host boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44b97feaedb4458edcd023052a11b75d1c7f6402. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

