### PR TITLE
refactor(runtime): persist stream identity at registration

### DIFF
--- a/src/agent/runtime/runAgent.ts
+++ b/src/agent/runtime/runAgent.ts
@@ -14,6 +14,7 @@ import { EXECUTION_STATUS } from '@shared/schemas';
 import { generateExecutionId } from '@utils/core';
 import { applyHelperModelPreference } from './helperModelPreference';
 import { executeAgent, type ExecuteAgentOptions } from './executeAgent';
+import { getStreamTabId } from './streamTab';
 import { defaultSession } from './SessionHandle';
 import { flushOwnedExecutionArtifacts } from './executionOwnership';
 import { ResumeAdmissionCancelledError } from './resumeAdmission';
@@ -98,13 +99,10 @@ export async function runAgent(
     : request.config;
 
   if (shouldRegister) {
-    await registerExecution(
-      executionId,
-      config,
-      config.agent,
-      undefined,
-      config.agentCategory,
-    );
+    await registerExecution(executionId, config, config.agent, {
+      streamId: getStreamTabId(config.agent, config.model, { executionId }),
+      category: config.agentCategory,
+    });
   } else {
     const lease = await acquireResumedExecutionLease(
       executionId,

--- a/src/agent/storage/executionLifecycle.ts
+++ b/src/agent/storage/executionLifecycle.ts
@@ -107,9 +107,13 @@ export async function registerExecution(
   executionId: ExecutionId,
   config: AgentConfig,
   agentName: string,
-  parentExecutionId?: ExecutionId,
-  category?: string,
+  options: {
+    readonly streamId: StreamTabId;
+    readonly parentExecutionId?: ExecutionId;
+    readonly category?: string;
+  },
 ): Promise<void> {
+  const { streamId, parentExecutionId, category } = options;
   await acquireFreshExecutionLease(executionId);
   const runWithOwnership = captureOwnedExecutionLease(executionId);
   await runWithOwnership(async () => {
@@ -118,6 +122,7 @@ export async function registerExecution(
       const store = getExecutionStore(executionId);
       const meta = {
         timestamp,
+        streamId,
         parentExecutionId,
         ...(category ? { category } : {}),
       };
@@ -328,22 +333,5 @@ export async function writeSessionDescription(
     executionId,
     { description },
     'session description',
-  );
-}
-
-/**
- * Cache the resolved transcript stream for an execution, once
- * `resolvePersistedStreamIdForExecution` (`executionStreamResolver.ts`) has
- * actually decided it via its meta-scan, so later resolutions for the same
- * executionId can skip straight to this field instead of re-scanning.
- */
-export async function writeExecutionStreamId(
-  executionId: ExecutionId,
-  streamId: StreamTabId,
-): Promise<void> {
-  await persistSupplementaryMetaFieldsBestEffort(
-    executionId,
-    { streamId },
-    'execution stream id',
   );
 }

--- a/src/agent/storage/executionLifecycle.ts
+++ b/src/agent/storage/executionLifecycle.ts
@@ -335,3 +335,15 @@ export async function writeSessionDescription(
     'session description',
   );
 }
+
+/** Persist a confirmed stream identity for a pre-streamId execution record. */
+export async function writeLegacyExecutionStreamId(
+  executionId: ExecutionId,
+  streamId: StreamTabId,
+): Promise<void> {
+  await persistSupplementaryMetaFieldsBestEffort(
+    executionId,
+    { streamId },
+    'legacy execution stream id',
+  );
+}

--- a/src/shared/schemas/stream.ts
+++ b/src/shared/schemas/stream.ts
@@ -86,9 +86,8 @@ const ExecutionMetaBaseSchema = z.object({
   /** AI-generated summary of what the session aimed to accomplish. */
   description: z.string().optional(),
   /**
-   * The transcript stream this execution's data lives under, once resolved.
-   * Decide-once-carry-as-data cache for the execution stream resolver: absent
-   * on executions whose stream wasn't resolved yet (or predate this field).
+   * The transcript stream this execution's data lives under. Current runs
+   * write it at registration; it may be absent on historical executions.
    */
   streamId: StreamTabIdSchema.optional(),
 });

--- a/src/test-kernel/agent/RegisterExecutionWorkspaceDirectory.vitest.ts
+++ b/src/test-kernel/agent/RegisterExecutionWorkspaceDirectory.vitest.ts
@@ -7,6 +7,7 @@ import {
   EXECUTION_STATUS,
   RUN_OUTCOME,
   type ExecutionId,
+  type StreamTabId,
 } from '@shared/schemas';
 
 const mocks = vi.hoisted(() => ({
@@ -84,17 +85,20 @@ describe('execution lifecycle', () => {
 
   it('pins the active workspace path when a config has no working directory', async () => {
     const executionId = 'abc123' as ExecutionId;
-    await registerExecution(
-      executionId,
-      baseConfig,
-      'chat',
-      undefined,
-      'toolUse',
-    );
+    await registerExecution(executionId, baseConfig, 'chat', {
+      streamId: 'chat@deepseekT#abc123' as StreamTabId,
+      category: 'toolUse',
+    });
 
     expect(mocks.writeConfig).toHaveBeenCalledWith({
       ...baseConfig,
       workingDirectory: '/workspace/root',
+    });
+    expect(mocks.writeMeta).toHaveBeenCalledWith({
+      timestamp: expect.any(String),
+      streamId: 'chat@deepseekT#abc123',
+      parentExecutionId: undefined,
+      category: 'toolUse',
     });
     await finalizeExecution({
       executionId,
@@ -108,7 +112,9 @@ describe('execution lifecycle', () => {
     mocks.writeConfig.mockRejectedValueOnce(new Error('config write failed'));
 
     await expect(
-      registerExecution(executionId, baseConfig, 'chat'),
+      registerExecution(executionId, baseConfig, 'chat', {
+        streamId: 'chat@deepseekT#abc124' as StreamTabId,
+      }),
     ).rejects.toThrow('config write failed');
 
     await expect(inspectExecutionLease(executionId)).resolves.toEqual({
@@ -123,7 +129,9 @@ describe('execution lifecycle', () => {
     });
 
     await expect(
-      registerExecution(executionId, baseConfig, 'chat'),
+      registerExecution(executionId, baseConfig, 'chat', {
+        streamId: 'chat@deepseekT#abc125' as StreamTabId,
+      }),
     ).rejects.toThrow('store construction failed');
     await expect(inspectExecutionLease(executionId)).resolves.toEqual({
       status: 'missing',

--- a/src/test-kernel/cli/HistoryStatus.vitest.ts
+++ b/src/test-kernel/cli/HistoryStatus.vitest.ts
@@ -20,7 +20,11 @@ import {
   resolveCliHistoryStatus,
   userStartedCliHistoryEntries,
 } from '@cli/runtime/history';
-import { EXECUTION_STATUS, type ExecutionId } from '@shared/schemas';
+import {
+  EXECUTION_STATUS,
+  type ExecutionId,
+  type StreamTabId,
+} from '@shared/schemas';
 import { setupPlatform } from '@test/support/setupPlatform';
 
 const TOOL_USE_CONFIG: AgentConfig = AgentConfigSchema.parse({
@@ -136,7 +140,9 @@ describe('CLI history status formatting', () => {
 
   it('does not mark invalid flow records as resumable', async () => {
     const id = 'abc123' as ExecutionId;
-    await registerExecution(id, TOOL_USE_CONFIG, 'orchestrator', undefined);
+    await registerExecution(id, TOOL_USE_CONFIG, 'orchestrator', {
+      streamId: `orchestrator@deepseekT#${id}` as StreamTabId,
+    });
     await releaseOwnedExecutionLease(id);
     await getExecutionStore(id).write(flowKey(id), {
       flowName: 'test',
@@ -159,7 +165,9 @@ describe('CLI history status formatting', () => {
 
   it('does not mark non-tool-use flow records as CLI-resumable', async () => {
     const id = 'workflow-with-flow' as ExecutionId;
-    await registerExecution(id, WORKFLOW_CONFIG, 'correct', undefined);
+    await registerExecution(id, WORKFLOW_CONFIG, 'correct', {
+      streamId: `correct@deepseekT#${id}` as StreamTabId,
+    });
     await releaseOwnedExecutionLease(id);
     await getExecutionStore(id).write(flowKey(id), {
       flowName: 'test',

--- a/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/ClaudeAgentResumeFallback.vitest.ts
@@ -71,6 +71,8 @@ vi.mock('@utils/files/taskRunStorage', () => ({
 
 vi.mock('@tools/childStream', () => ({
   createChildStream: mocks.createChildStream,
+  getChildStreamId: (executionId: string, prefix: string) =>
+    `${prefix}#${executionId}`,
 }));
 
 vi.mock('@agent/runtime/childRunLoop', () => ({

--- a/src/test-kernel/tools/CodexResumeFallback.vitest.ts
+++ b/src/test-kernel/tools/CodexResumeFallback.vitest.ts
@@ -66,6 +66,8 @@ vi.mock('@utils/files/taskRunStorage', () => ({
 
 vi.mock('@tools/childStream', () => ({
   createChildStream: mocks.createChildStream,
+  getChildStreamId: (executionId: string, prefix: string) =>
+    `${prefix}#${executionId}`,
 }));
 
 vi.mock('@agent/runtime/childRunLoop', () => ({

--- a/src/test-kernel/tools/DelegationHeadless.vitest.mts
+++ b/src/test-kernel/tools/DelegationHeadless.vitest.mts
@@ -448,7 +448,10 @@ describe('headless delegation', () => {
       result.executionId,
       expect.objectContaining({ agent: 'review' }),
       'review',
-      STABLE_PARENT_EXECUTION_ID,
+      expect.objectContaining({
+        parentExecutionId: STABLE_PARENT_EXECUTION_ID,
+        streamId: expect.stringContaining(`#${result.executionId}`),
+      }),
     );
     expect(mocks.writeResultMeta).toHaveBeenCalledWith({
       producer: 'subagent',
@@ -748,7 +751,10 @@ describe('headless delegation', () => {
       completed.executionId,
       expect.anything(),
       'review',
-      STABLE_PARENT_EXECUTION_ID,
+      expect.objectContaining({
+        parentExecutionId: STABLE_PARENT_EXECUTION_ID,
+        streamId: expect.stringContaining(`#${completed.executionId}`),
+      }),
     );
   });
 

--- a/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
+++ b/src/test-kernel/tools/ExecutionsToolOutput.vitest.ts
@@ -243,8 +243,10 @@ describe('ExecutionsTool /executions/{id}/output', () => {
         agentCategory: AgentCategory.ToolUse,
       }),
       'bash',
-      undefined,
-      'process',
+      {
+        streamId: `bash@tool#${executionId}` as StreamTabId,
+        category: 'process',
+      },
     );
     const streamId = `bash@tool#${executionId}` as StreamTabId;
     const transcripts = defaultSession().transcripts;
@@ -365,8 +367,10 @@ describe('ExecutionsTool /executions/{id}/output', () => {
         agentCategory: AgentCategory.ToolUse,
       }),
       'bash',
-      undefined,
-      'process',
+      {
+        streamId: `bash@tool#${executionId}` as StreamTabId,
+        category: 'process',
+      },
     );
 
     const result = await readOutput(executionId);
@@ -388,6 +392,7 @@ describe('ExecutionsTool /executions/{id}/output', () => {
         agentCategory: AgentCategory.ToolUse,
       }),
       'chat',
+      { streamId: `chat@model#${executionId}` as StreamTabId },
     );
 
     const result = await readOutput(executionId);

--- a/src/test-kernel/tools/SubagentExecutionChildStreamId.vitest.ts
+++ b/src/test-kernel/tools/SubagentExecutionChildStreamId.vitest.ts
@@ -135,7 +135,10 @@ describe('executeSubagent childStreamId derivation', () => {
       loopParams.executionId,
       expect.any(Object),
       agentName,
-      'parent-exec',
+      expect.objectContaining({
+        parentExecutionId: 'parent-exec',
+        streamId: loopParams.childStreamId,
+      }),
     );
     const expectedChildStreamId = getStreamTabId(
       configPayload.agent,

--- a/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
+++ b/src/test-kernel/tools/WorkflowScriptTool.vitest.ts
@@ -61,6 +61,8 @@ vi.mock('@agent/runtime/childRunLoop', () => ({
 
 vi.mock('@tools/childStream', () => ({
   createRehydratedChildStream: mocks.createChildStream,
+  getChildStreamId: (executionId: string, prefix: string) =>
+    `${prefix}#${executionId}`,
 }));
 
 vi.mock('@tools/approval', () => ({
@@ -326,7 +328,10 @@ describe('WorkflowScriptTool', () => {
         agentSource: 'builtInWorkflow',
       }),
       'tool-test',
-      executionId,
+      {
+        streamId: `workflow-script#${runExecutionId}`,
+        parentExecutionId: executionId,
+      },
     );
     expect(mocks.createChildStream).toHaveBeenCalledWith(
       runExecutionId,
@@ -421,7 +426,10 @@ describe('WorkflowScriptTool', () => {
       runExecutionIdFor('edited-tool-test'),
       expect.anything(),
       'edited-tool-test',
-      executionId,
+      {
+        streamId: `workflow-script#${runExecutionIdFor('edited-tool-test')}`,
+        parentExecutionId: executionId,
+      },
     );
   });
 
@@ -602,7 +610,10 @@ describe('WorkflowScriptTool', () => {
       runExecutionIdFor('tool-test'),
       expect.objectContaining({ model: 'served-model' }),
       'tool-test',
-      executionId,
+      {
+        streamId: `workflow-script#${runExecutionIdFor('tool-test')}`,
+        parentExecutionId: executionId,
+      },
     );
   });
 
@@ -642,7 +653,10 @@ describe('WorkflowScriptTool', () => {
         mediaFiles: ['figure.pdf'],
       }),
       'tool-test',
-      executionId,
+      {
+        streamId: `workflow-script#${runExecutionIdFor('tool-test')}`,
+        parentExecutionId: executionId,
+      },
     );
   });
 
@@ -700,7 +714,10 @@ describe('WorkflowScriptTool', () => {
         mediaFiles: ['figure.pdf'],
       }),
       'resume',
-      executionId,
+      {
+        streamId: `workflow-script#${runExecutionIdFor('resume')}`,
+        parentExecutionId: executionId,
+      },
     );
   });
 

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -361,6 +361,47 @@ describe('completedRunArchive facade', () => {
     expect(result.conversation!.length).toBeGreaterThan(0);
   });
 
+  it('falls through to a content-bearing historical sibling stream', async () => {
+    const executionId = '0777aa0777aa' as ExecutionId;
+    const emptyStream = 'aChild@tool#0777aa0777aa' as StreamTabId;
+    const fullStream = 'zOrchestrator@deepseekproT#0777aa0777aa' as StreamTabId;
+
+    const snapshots = new StreamSnapshotStore();
+    snapshots.setTaskState(emptyStream, taskState('bash'), executionId);
+    snapshots.setTaskState(fullStream, taskState('orchestrator'), executionId);
+    await snapshots.flush();
+
+    const logs = await StreamLogStore.open();
+    logs.ensureStream(emptyStream);
+    logs.append(
+      emptyStream,
+      logRow(MESSAGE_TYPES.PROGRESS_STATUS, { text: 'Working...' }),
+    );
+    logs.ensureStream(fullStream);
+    logs.append(
+      fullStream,
+      logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'Real question' }),
+    );
+    logs.append(
+      fullStream,
+      logRow(MESSAGE_TYPES.MODEL_RESPONSE, { text: 'Real answer' }),
+    );
+    await logs.flush();
+
+    const result = await readCompletedRunConversation(executionId);
+    expect(result).toEqual({
+      source: 'streamLog',
+      streamId: fullStream,
+      conversation: [
+        { role: 'user', content: 'Real question' },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Real answer' }],
+        },
+      ],
+    });
+  });
+
   it('falls back to legacy when the transcript holds no conversation-shaped rows', async () => {
     const executionId = 'eee555eee555' as ExecutionId;
     const streamId = 'orchestrator@deepseekproT#eee555eee555' as StreamTabId;

--- a/src/test-kernel/transcript/completedRunArchive.vitest.ts
+++ b/src/test-kernel/transcript/completedRunArchive.vitest.ts
@@ -361,47 +361,6 @@ describe('completedRunArchive facade', () => {
     expect(result.conversation!.length).toBeGreaterThan(0);
   });
 
-  it('falls through to the content-bearing sibling when the resolver picks an empty log (non-empty rule)', async () => {
-    const executionId = '0777aa0777aa' as ExecutionId;
-    // Both streams are meta-matched and log-backed; the alphabetically
-    // first-scanned one holds only non-conversation rows, so the resolver's
-    // log-rank pick (#7433 criteria) reconstructs empty. No legacy file
-    // exists — the facade must fall through to the sibling that actually
-    // holds the transcript.
-    const emptyStream = 'aChild@tool#0777aa0777aa' as StreamTabId;
-    const fullStream = 'zOrchestrator@deepseekproT#0777aa0777aa' as StreamTabId;
-
-    const snapshots = new StreamSnapshotStore();
-    snapshots.setTaskState(emptyStream, taskState('bash'), executionId);
-    snapshots.setTaskState(fullStream, taskState('orchestrator'), executionId);
-    await snapshots.flush();
-
-    const logs = await StreamLogStore.open();
-    logs.ensureStream(emptyStream);
-    logs.append(
-      emptyStream,
-      logRow(MESSAGE_TYPES.PROGRESS_STATUS, { text: 'Working...' }),
-    );
-    logs.ensureStream(fullStream);
-    logs.append(
-      fullStream,
-      logRow(MESSAGE_TYPES.USER_MESSAGE, { text: 'Real question' }),
-    );
-    logs.append(
-      fullStream,
-      logRow(MESSAGE_TYPES.MODEL_RESPONSE, { text: 'Real answer' }),
-    );
-    await logs.flush();
-
-    const result = await readCompletedRunConversation(executionId);
-    expect(result.source).toBe('streamLog');
-    expect(result.streamId).toBe(fullStream);
-    expect(result.conversation).toEqual([
-      { role: 'user', content: 'Real question' },
-      { role: 'assistant', content: [{ type: 'text', text: 'Real answer' }] },
-    ]);
-  });
-
   it('falls back to legacy when the transcript holds no conversation-shaped rows', async () => {
     const executionId = 'eee555eee555' as ExecutionId;
     const streamId = 'orchestrator@deepseekproT#eee555eee555' as StreamTabId;

--- a/src/test-kernel/transcript/executionStreamResolver.vitest.ts
+++ b/src/test-kernel/transcript/executionStreamResolver.vitest.ts
@@ -8,14 +8,7 @@ import {
 import { getExecutionStore } from '@agent/storage/ExecutionKVStore';
 import { registerExecution } from '@agent/storage/executionLifecycle';
 import { releaseOwnedExecutionLease } from '@agent/storage/executionLease';
-import {
-  LOG_LEVELS,
-  MESSAGE_TYPES,
-  STREAM_LOG_ENTRY_TYPES,
-  type ExecutionId,
-  type StreamTabId,
-  type TodoItem,
-} from '@shared/schemas';
+import { type ExecutionId, type StreamTabId } from '@shared/schemas';
 import { AgentCategory } from '@shared/schemas/agent';
 import {
   cleanupTempDirs,
@@ -24,7 +17,6 @@ import {
 import { setupPlatform } from '@test/support/setupPlatform';
 import {
   resolvePersistedStreamIdForExecution,
-  StreamLogStore,
   StreamSnapshotStore,
 } from '@transcript';
 
@@ -37,33 +29,11 @@ const MINIMAL_CONFIG: AgentConfig = AgentConfigSchema.parse({
 
 const tempDirs: string[] = [];
 
-/** Appends a single stream-log entry so a candidate stream is log-backed. */
-async function appendLogEntry(
-  logStore: StreamLogStore,
-  streamId: StreamTabId,
-): Promise<void> {
-  logStore.append(streamId, {
-    id: 'entry-1',
-    type: STREAM_LOG_ENTRY_TYPES.LOG,
-    level: LOG_LEVELS.INFO,
-    timestamp: 100,
-    messageType: MESSAGE_TYPES.DEFAULT,
-    text: 'child stream output',
-  });
-  await logStore.flush();
-}
-
 function taskState(agent: string, model = 'deepseekproT'): TaskState {
   return TaskStateSchema.parse({
     agentConfig: { agent, model, agentCategory: AgentCategory.ToolUse },
   });
 }
-
-const TODO: TodoItem = {
-  content: 'Fix the bug',
-  status: 'pending',
-  activeForm: 'Fixing the bug',
-};
 
 describe('resolvePersistedStreamIdForExecution', () => {
   setupPlatform(() => createTempDirPlatform('texra-resolver-', tempDirs));
@@ -87,117 +57,6 @@ describe('resolvePersistedStreamIdForExecution', () => {
 
     expect(resolved).toEqual({ streamId, source: 'streamDataMeta' });
   });
-
-  it(
-    'prefers the meta-matched candidate with a real workPlan.json over a bare ' +
-      'meta-only match sharing the same executionId (#7298)',
-    async () => {
-      const executionId = 'abc222' as ExecutionId;
-      // A parent orchestrator tab and a child bash-tool stream both record the
-      // same executionId in their sidecar meta.json, but only the child ever
-      // durably persisted todos — mirrors the resolver picking the parent (no
-      // streamLogs/workPlan) and callers like the completed-run todo reader
-      // silently reading nothing.
-      // Named so the no-data candidate sorts alphabetically FIRST in the
-      // persisted-stream directory listing — this is what makes the test
-      // actually exercise the "first meta match wins" bug rather than
-      // accidentally passing because the real-data stream happened to be
-      // read first.
-      const parentStream = 'aOrchestrator@deepseekproT#abc222' as StreamTabId;
-      const childStream = 'zBashTool@tool#abc222' as StreamTabId;
-
-      const store = new StreamSnapshotStore();
-      store.setTaskState(parentStream, taskState('orchestrator'), executionId);
-      store.setTaskState(childStream, taskState('bash'), executionId);
-      store.setTodos(childStream, [TODO]);
-      await store.flush();
-
-      const resolved = await resolvePersistedStreamIdForExecution(executionId, {
-        snapshotStore: new StreamSnapshotStore(),
-      });
-
-      expect(resolved).toEqual({
-        streamId: childStream,
-        source: 'streamDataMeta',
-      });
-    },
-  );
-
-  it(
-    'prefers the meta-matched candidate with real streamLogs over a bare ' +
-      'meta-only match, using an already-loaded StreamLogStore (#7298)',
-    async () => {
-      const executionId = 'abc333' as ExecutionId;
-      // Same alphabetical-ordering reasoning as the workPlan test above.
-      const parentStream = 'aOrchestrator@deepseekproT#abc333' as StreamTabId;
-      const childStream = 'zBashTool@tool#abc333' as StreamTabId;
-
-      const snapshotWriter = new StreamSnapshotStore();
-      snapshotWriter.setTaskState(
-        parentStream,
-        taskState('orchestrator'),
-        executionId,
-      );
-      snapshotWriter.setTaskState(childStream, taskState('bash'), executionId);
-      await snapshotWriter.flush();
-
-      const logStore = await StreamLogStore.open();
-      await appendLogEntry(logStore, childStream);
-
-      const resolved = await resolvePersistedStreamIdForExecution(executionId, {
-        snapshotStore: new StreamSnapshotStore(),
-        streamLogStore: logStore,
-      });
-
-      expect(resolved).toEqual({
-        streamId: childStream,
-        source: 'streamDataMeta',
-      });
-    },
-  );
-
-  it(
-    'prefers a log-backed meta match over an earlier-ordered workPlan-only ' +
-      'match sharing the same executionId (#7403)',
-    async () => {
-      const executionId = 'abc444' as ExecutionId;
-      // Named so the workPlan-only candidate sorts alphabetically FIRST in
-      // the persisted-stream directory listing, mirroring the reported bug:
-      // an earlier-ordered candidate has only workPlan.json (no stream log)
-      // while a later-ordered candidate has the real streamLogs entry. The
-      // resolver must still pick the log-backed one regardless of order.
-      const workPlanOnlyStream =
-        'aOrchestrator@deepseekproT#abc444' as StreamTabId;
-      const logBackedStream = 'zBashTool@tool#abc444' as StreamTabId;
-
-      const snapshotWriter = new StreamSnapshotStore();
-      snapshotWriter.setTaskState(
-        workPlanOnlyStream,
-        taskState('orchestrator'),
-        executionId,
-      );
-      snapshotWriter.setTaskState(
-        logBackedStream,
-        taskState('bash'),
-        executionId,
-      );
-      snapshotWriter.setTodos(workPlanOnlyStream, [TODO]);
-      await snapshotWriter.flush();
-
-      const logStore = await StreamLogStore.open();
-      await appendLogEntry(logStore, logBackedStream);
-
-      const resolved = await resolvePersistedStreamIdForExecution(executionId, {
-        snapshotStore: new StreamSnapshotStore(),
-        streamLogStore: logStore,
-      });
-
-      expect(resolved).toEqual({
-        streamId: logBackedStream,
-        source: 'streamDataMeta',
-      });
-    },
-  );
 
   it(
     'bounds the concurrent meta-file reads instead of fanning out over every ' +
@@ -240,99 +99,63 @@ describe('resolvePersistedStreamIdForExecution', () => {
     },
   );
 
-  it('returns a cached executionMeta streamId without scanning any persisted stream (#7469)', async () => {
+  it('returns the birth-written execution stream without scanning sidecars', async () => {
     const executionId = 'abc555' as ExecutionId;
-    const cachedStreamId = 'orchestrator@deepseekproT#abc555' as StreamTabId;
-    await registerExecution(executionId, MINIMAL_CONFIG, 'orchestrator');
-    await releaseOwnedExecutionLease(executionId);
-    await getExecutionStore(executionId).writeMeta({
-      timestamp: new Date().toISOString(),
-      streamId: cachedStreamId,
+    const streamId = 'orchestrator@deepseekproT#abc555' as StreamTabId;
+    await registerExecution(executionId, MINIMAL_CONFIG, 'orchestrator', {
+      streamId,
     });
+    await releaseOwnedExecutionLease(executionId);
 
-    // No persisted stream exists at all — if the cache weren't consulted
-    // first, the scan would find nothing and this would resolve to null.
     const resolved = await resolvePersistedStreamIdForExecution(executionId, {
       snapshotStore: new StreamSnapshotStore(),
     });
 
     expect(resolved).toEqual({
-      streamId: cachedStreamId,
+      streamId,
       source: 'executionMeta',
     });
+    await expect(
+      getExecutionStore(executionId).readMeta(),
+    ).resolves.toMatchObject({ streamId });
   });
 
-  it('caches a streamDataMeta resolution onto the execution meta for a later cheap lookup (#7469)', async () => {
+  it('retains a sidecar scan fallback for execution records predating streamId', async () => {
     const executionId = 'abc666' as ExecutionId;
     const streamId = 'orchestrator@deepseekproT#abc666' as StreamTabId;
-    await registerExecution(executionId, MINIMAL_CONFIG, 'orchestrator');
-    await releaseOwnedExecutionLease(executionId);
+    await getExecutionStore(executionId).writeMeta({
+      timestamp: new Date().toISOString(),
+    });
 
     const store = new StreamSnapshotStore();
     store.setTaskState(streamId, taskState('orchestrator'), executionId);
     await store.flush();
 
-    const first = await resolvePersistedStreamIdForExecution(executionId, {
+    const resolved = await resolvePersistedStreamIdForExecution(executionId, {
       snapshotStore: new StreamSnapshotStore(),
     });
-    expect(first).toEqual({ streamId, source: 'streamDataMeta' });
-
-    // Wait for the resolver's write-through to land on the execution meta.
-    await vi.waitFor(async () => {
-      const meta = await getExecutionStore(executionId).readMeta();
-      expect(meta?.streamId).toBe(streamId);
-    });
-
-    const second = await resolvePersistedStreamIdForExecution(executionId, {
-      snapshotStore: new StreamSnapshotStore(),
-    });
-    expect(second).toEqual({ streamId, source: 'executionMeta' });
+    expect(resolved).toEqual({ streamId, source: 'streamDataMeta' });
   });
 
-  it(
-    'does not cache a multi-candidate resolution, so a later call with a ' +
-      'loaded streamLogStore can still pick the log-backed candidate (#7469)',
-    async () => {
-      const executionId = 'abc777' as ExecutionId;
-      const parentStream = 'aOrchestrator@deepseekproT#abc777' as StreamTabId;
-      const childStream = 'zBashTool@tool#abc777' as StreamTabId;
-      await registerExecution(executionId, MINIMAL_CONFIG, 'orchestrator');
-      await releaseOwnedExecutionLease(executionId);
+  it('uses enumeration order for ambiguous pre-streamId sidecars', async () => {
+    const executionId = 'abc777' as ExecutionId;
+    const firstStream = 'aOrchestrator@deepseekproT#abc777' as StreamTabId;
+    const secondStream = 'zBashTool@tool#abc777' as StreamTabId;
+    const snapshotWriter = new StreamSnapshotStore();
+    snapshotWriter.setTaskState(
+      firstStream,
+      taskState('orchestrator'),
+      executionId,
+    );
+    snapshotWriter.setTaskState(secondStream, taskState('bash'), executionId);
+    await snapshotWriter.flush();
 
-      const snapshotWriter = new StreamSnapshotStore();
-      snapshotWriter.setTaskState(
-        parentStream,
-        taskState('orchestrator'),
-        executionId,
-      );
-      snapshotWriter.setTaskState(childStream, taskState('bash'), executionId);
-      await snapshotWriter.flush();
-
-      const logStore = await StreamLogStore.open();
-      await appendLogEntry(logStore, childStream);
-
-      // First call has no streamLogStore, so pickBestMetaMatch can't see the
-      // child's log and falls back to the first candidate (the parent).
-      const uninformed = await resolvePersistedStreamIdForExecution(
-        executionId,
-        { snapshotStore: new StreamSnapshotStore() },
-      );
-      expect(uninformed).toEqual({
-        streamId: parentStream,
-        source: 'streamDataMeta',
-      });
-
-      // If that resolution had been cached, this second call -- which DOES
-      // have the log store -- would incorrectly return the cached parent
-      // instead of correctly picking the log-backed child.
-      const informed = await resolvePersistedStreamIdForExecution(executionId, {
-        snapshotStore: new StreamSnapshotStore(),
-        streamLogStore: logStore,
-      });
-      expect(informed).toEqual({
-        streamId: childStream,
-        source: 'streamDataMeta',
-      });
-    },
-  );
+    const resolved = await resolvePersistedStreamIdForExecution(executionId, {
+      snapshotStore: new StreamSnapshotStore(),
+    });
+    expect(resolved).toEqual({
+      streamId: firstStream,
+      source: 'streamDataMeta',
+    });
+  });
 });

--- a/src/test-kernel/transcript/executionStreamResolver.vitest.ts
+++ b/src/test-kernel/transcript/executionStreamResolver.vitest.ts
@@ -8,7 +8,14 @@ import {
 import { getExecutionStore } from '@agent/storage/ExecutionKVStore';
 import { registerExecution } from '@agent/storage/executionLifecycle';
 import { releaseOwnedExecutionLease } from '@agent/storage/executionLease';
-import { type ExecutionId, type StreamTabId } from '@shared/schemas';
+import {
+  LOG_LEVELS,
+  MESSAGE_TYPES,
+  STREAM_LOG_ENTRY_TYPES,
+  type ExecutionId,
+  type StreamTabId,
+  type TodoItem,
+} from '@shared/schemas';
 import { AgentCategory } from '@shared/schemas/agent';
 import {
   cleanupTempDirs,
@@ -17,6 +24,7 @@ import {
 import { setupPlatform } from '@test/support/setupPlatform';
 import {
   resolvePersistedStreamIdForExecution,
+  StreamLogStore,
   StreamSnapshotStore,
 } from '@transcript';
 
@@ -29,11 +37,32 @@ const MINIMAL_CONFIG: AgentConfig = AgentConfigSchema.parse({
 
 const tempDirs: string[] = [];
 
+async function appendLogEntry(
+  logStore: StreamLogStore,
+  streamId: StreamTabId,
+): Promise<void> {
+  logStore.append(streamId, {
+    id: 'entry-1',
+    type: STREAM_LOG_ENTRY_TYPES.LOG,
+    level: LOG_LEVELS.INFO,
+    timestamp: 100,
+    messageType: MESSAGE_TYPES.DEFAULT,
+    text: 'child stream output',
+  });
+  await logStore.flush();
+}
+
 function taskState(agent: string, model = 'deepseekproT'): TaskState {
   return TaskStateSchema.parse({
     agentConfig: { agent, model, agentCategory: AgentCategory.ToolUse },
   });
 }
+
+const TODO: TodoItem = {
+  content: 'Fix the bug',
+  status: 'pending',
+  activeForm: 'Fixing the bug',
+};
 
 describe('resolvePersistedStreamIdForExecution', () => {
   setupPlatform(() => createTempDirPlatform('texra-resolver-', tempDirs));
@@ -135,9 +164,12 @@ describe('resolvePersistedStreamIdForExecution', () => {
       snapshotStore: new StreamSnapshotStore(),
     });
     expect(resolved).toEqual({ streamId, source: 'streamDataMeta' });
+    await expect(
+      getExecutionStore(executionId).readMeta(),
+    ).resolves.toMatchObject({ streamId });
   });
 
-  it('uses enumeration order for ambiguous pre-streamId sidecars', async () => {
+  it('prefers a work-plan-bearing historical stream over a bare match', async () => {
     const executionId = 'abc777' as ExecutionId;
     const firstStream = 'aOrchestrator@deepseekproT#abc777' as StreamTabId;
     const secondStream = 'zBashTool@tool#abc777' as StreamTabId;
@@ -148,14 +180,47 @@ describe('resolvePersistedStreamIdForExecution', () => {
       executionId,
     );
     snapshotWriter.setTaskState(secondStream, taskState('bash'), executionId);
+    snapshotWriter.setTodos(secondStream, [TODO]);
     await snapshotWriter.flush();
 
     const resolved = await resolvePersistedStreamIdForExecution(executionId, {
       snapshotStore: new StreamSnapshotStore(),
     });
     expect(resolved).toEqual({
-      streamId: firstStream,
+      streamId: secondStream,
       source: 'streamDataMeta',
+      fallbackStreamIds: [firstStream],
     });
+  });
+
+  it('prefers a log-backed historical stream over a work-plan-only match', async () => {
+    const executionId = 'abc888' as ExecutionId;
+    const workPlanStream = 'aOrchestrator@deepseekproT#abc888' as StreamTabId;
+    const logStream = 'zBashTool@tool#abc888' as StreamTabId;
+    const snapshotWriter = new StreamSnapshotStore();
+    snapshotWriter.setTaskState(
+      workPlanStream,
+      taskState('orchestrator'),
+      executionId,
+    );
+    snapshotWriter.setTaskState(logStream, taskState('bash'), executionId);
+    snapshotWriter.setTodos(workPlanStream, [TODO]);
+    await snapshotWriter.flush();
+
+    const logStore = await StreamLogStore.open();
+    await appendLogEntry(logStore, logStream);
+
+    const resolved = await resolvePersistedStreamIdForExecution(executionId, {
+      snapshotStore: new StreamSnapshotStore(),
+      streamLogStore: logStore,
+    });
+    expect(resolved).toEqual({
+      streamId: logStream,
+      source: 'streamDataMeta',
+      fallbackStreamIds: [workPlanStream],
+    });
+    expect(
+      (await getExecutionStore(executionId).readMeta())?.streamId,
+    ).toBeUndefined();
   });
 });

--- a/src/tools/agentCliShared.ts
+++ b/src/tools/agentCliShared.ts
@@ -27,7 +27,11 @@ import {
 import { generateExecutionId } from '@utils/core';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
-import { createChildStream, type ChildStream } from './childStream';
+import {
+  createChildStream,
+  getChildStreamId,
+  type ChildStream,
+} from './childStream';
 
 /**
  * Publish a turn's token usage to the progress UI for an agent-CLI child stream.
@@ -173,14 +177,13 @@ export async function launchAgentCliSession(
   params: AgentCliLaunchParams,
 ): Promise<ToolResult> {
   const executionId = generateExecutionId();
+  const childStreamId = getChildStreamId(executionId, params.streamPrefix);
 
   try {
-    await registerExecution(
-      executionId,
-      params.config,
-      params.agentName,
-      params.parentExecutionId,
-    );
+    await registerExecution(executionId, params.config, params.agentName, {
+      streamId: childStreamId,
+      parentExecutionId: params.parentExecutionId,
+    });
   } catch {
     throw new ToolError(params.registerFailedMessage);
   }

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -68,6 +68,7 @@ const BACKGROUND_OUTPUT_TAIL_CHARS = 12_000;
  * recover it from the follow-up.
  */
 const BACKGROUND_OUTPUT_HEAD_CHARS = 1_000;
+const BASH_CHILD_STREAM_PREFIX = 'bash@tool';
 const FOREGROUND_OUTPUT_HEAD_CHARS = TOOL_RESULT_TRUNCATION_HEAD_CHARS;
 const FOREGROUND_OUTPUT_TAIL_CHARS = TOOL_RESULT_TRUNCATION_TAIL_CHARS;
 const SHELL_BACKGROUNDING_PATTERN =
@@ -411,7 +412,7 @@ export class BashTool extends defineTool({
     });
 
     await registerExecution(executionId, syntheticConfig, 'bash', {
-      streamId: getChildStreamId(executionId, 'bash@tool'),
+      streamId: getChildStreamId(executionId, BASH_CHILD_STREAM_PREFIX),
       parentExecutionId,
       category: 'process',
     });
@@ -421,7 +422,7 @@ export class BashTool extends defineTool({
     try {
       runWithOwnership(() => {
         childStream = createChildStream(executionId, parentStreamId, {
-          streamPrefix: 'bash@tool',
+          streamPrefix: BASH_CHILD_STREAM_PREFIX,
           streamCategory: AgentCategory.ToolUse,
           runKind: 'process',
           agentName: 'bash',

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -53,7 +53,7 @@ import { appendHead, appendTail } from '@utils/strings/appendTail';
 
 // Local file imports
 import { defineTool } from './core/define';
-import { createChildStream } from './childStream';
+import { createChildStream, getChildStreamId } from './childStream';
 import { parseWorkingDirectory } from './pathResolution';
 
 const BACKGROUND_OUTPUT_TAIL_CHARS = 12_000;
@@ -410,13 +410,11 @@ export class BashTool extends defineTool({
       agentCategory: AgentCategory.ToolUse,
     });
 
-    await registerExecution(
-      executionId,
-      syntheticConfig,
-      'bash',
+    await registerExecution(executionId, syntheticConfig, 'bash', {
+      streamId: getChildStreamId(executionId, 'bash@tool'),
       parentExecutionId,
-      'process',
-    );
+      category: 'process',
+    });
     const runWithOwnership = captureOwnedExecutionLease(executionId);
 
     let childStream!: ReturnType<typeof createChildStream>;

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -245,7 +245,7 @@ export async function createRehydratedChildStream(
   options: CreateChildStreamOptions,
 ): Promise<ChildStream> {
   const session = currentSession();
-  const childStreamId = `${options.streamPrefix}#${executionId}` as StreamTabId;
+  const childStreamId = getChildStreamId(executionId, options.streamPrefix);
   const writer = await session.transcripts.loadAndAcquireWriter(
     childStreamId,
     executionId,

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -79,13 +79,21 @@ export interface ChildStream {
   finalize: (options?: FinalizeChildStreamOptions) => Promise<void>;
 }
 
+/** Derive the durable stream identity shared by registration and creation. */
+export function getChildStreamId(
+  executionId: ExecutionId,
+  streamPrefix: string,
+): StreamTabId {
+  return `${streamPrefix}#${executionId}` as StreamTabId;
+}
+
 /** Create a child stream tab and execution handle for a background child task. */
 export function createChildStream(
   executionId: ExecutionId,
   parentStreamId: StreamTabId,
   options: CreateChildStreamOptions,
 ): ChildStream {
-  const childStreamId = `${options.streamPrefix}#${executionId}` as StreamTabId;
+  const childStreamId = getChildStreamId(executionId, options.streamPrefix);
 
   // Capture the run's session at creation (inside the parent run's ALS); the
   // status-update and finalize closures below fire later, possibly outside it.

--- a/src/tools/delegation/WorkflowScriptTool.ts
+++ b/src/tools/delegation/WorkflowScriptTool.ts
@@ -28,7 +28,10 @@ import { WorkflowScriptFilesSchema } from '@shared/schemas/workflowScriptFiles';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { DELEGATE_WORKFLOW_SCRIPT_TOOL_NAME } from '@shared/constants/delegationTools';
 import { configureDelegatedChildApprovals } from '@tools/approval';
-import { createRehydratedChildStream } from '@tools/childStream';
+import {
+  createRehydratedChildStream,
+  getChildStreamId,
+} from '@tools/childStream';
 import {
   assertWritable,
   resolveWorkspaceRelativePath,
@@ -355,12 +358,10 @@ Durability: the journal is keyed by meta.name within this session. If the run ti
     );
 
     try {
-      await registerExecution(
-        runExecutionId,
-        runConfig,
-        meta.name,
-        runScope.executionId,
-      );
+      await registerExecution(runExecutionId, runConfig, meta.name, {
+        streamId: getChildStreamId(runExecutionId, STREAM_PREFIX),
+        parentExecutionId: runScope.executionId,
+      });
     } catch (error) {
       // A relaunch whose prior run is still in flight shares this deterministic
       // id: the fresh-lease acquisition fails closed rather than starting a

--- a/src/tools/delegation/inBandSubagentExecution.ts
+++ b/src/tools/delegation/inBandSubagentExecution.ts
@@ -30,6 +30,7 @@ import {
 } from '@agent/core/definition/AgentConfig';
 import type { AgentFinalResult } from '@agent/runtime/AgentFinalResult';
 import type { AgentFlowResult } from '@agent/runtime/AgentFlowResult';
+import { getStreamTabId } from '@agent/runtime/streamTab';
 import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import { releaseExecutionLeaseAfterArtifacts } from '@agent/runtime/executionOwnership';
 import * as logger from '@logger/logUtils';
@@ -438,12 +439,10 @@ async function executeInBand(
   const workingDirectory = config.workingDirectory ?? undefined;
 
   try {
-    await registerExecution(
-      executionId,
-      config,
-      options.agentName,
-      options.parentExecutionId,
-    );
+    await registerExecution(executionId, config, options.agentName, {
+      streamId: getStreamTabId(config.agent, config.model, { executionId }),
+      parentExecutionId: options.parentExecutionId,
+    });
   } catch (cause) {
     if (mode === 'required-result') {
       throw new SubagentDurabilityError(

--- a/src/tools/delegation/subagentExecution.ts
+++ b/src/tools/delegation/subagentExecution.ts
@@ -154,21 +154,24 @@ export async function executeSubagent(
   const executionId = generateExecutionId();
   const startedAt = Date.now();
   const config = AgentConfigSchema.parse(childConfigPayload);
-  await registerExecution(executionId, config, agentName, parentExecutionId);
+  // Must match the id `buildAgentLaunchContext` actually reserves for this
+  // executionId (see AgentLaunchContext.ts's `reservedStreamId`), or the
+  // loop acquires the wrong follow-up queue/interrupt slot. That reservation
+  // uses the canonical config's agent/model — not the `agentName` parameter,
+  // which callers may resolve differently
+  // (e.g. an approved agent override's display name vs. its registry name).
+  // Derive from the exact same fields, not a parallel formula.
+  const childStreamId = getStreamTabId(config.agent, config.model, {
+    executionId,
+  });
+  await registerExecution(executionId, config, agentName, {
+    streamId: childStreamId,
+    parentExecutionId,
+  });
   const runWithOwnership = captureOwnedExecutionLease(executionId);
 
   return await runWithOwnership(async () => {
     const isToolUse = config.agentCategory === AgentCategory.ToolUse;
-    // Must match the id `buildAgentLaunchContext` actually reserves for this
-    // executionId (see AgentLaunchContext.ts's `reservedStreamId`), or the
-    // loop acquires the wrong follow-up queue/interrupt slot. That reservation
-    // uses the canonical config's agent/model — not the `agentName` parameter,
-    // which callers may resolve differently
-    // (e.g. an approved agent override's display name vs. its registry name).
-    // Derive from the exact same fields, not a parallel formula.
-    const childStreamId = getStreamTabId(config.agent, config.model, {
-      executionId,
-    });
     const strategyParams = {
       config,
       agentCategoryExplicit: childConfigPayload.agentCategory !== undefined,

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -27,11 +27,7 @@ import {
 } from '@shared/schemas';
 import { assertNever } from '@utils/core';
 
-import {
-  findExecutionSuffixMatches,
-  resolvePersistedStreamIdForExecution,
-  scanPersistedStreamsForExecution,
-} from './executionStreamResolver';
+import { resolvePersistedStreamIdForExecution } from './executionStreamResolver';
 import { STREAM_DATA_KEYS, streamDataDir } from './streamDataPaths';
 import { StreamLogStore, STREAM_LOGS_DIR } from './StreamLogStore';
 import { StreamSnapshotStore } from './StreamSnapshotStore';
@@ -346,47 +342,11 @@ async function conversationFromStream(
 }
 
 /**
- * Sibling sidecar streams for the same execution, tried only when the
- * resolver's pick reconstructs empty (cold path). #7433's resolver ranking
- * (log-backed > workPlan-only > bare, scan order within a rank) stays the
- * primary criteria — this layers the has-content preference on top without
- * teaching the generic resolver (also used by the todos reader and the
- * trace assembler) what "conversation content" means. Only log-backed
- * siblings can yield content, so the rest are skipped.
- */
-async function siblingConversationStreams(
-  executionId: ExecutionId,
-  primary: StreamTabId,
-  snapshotStore: StreamSnapshotStore,
-  streamLogStore: StreamLogStore,
-): Promise<StreamTabId[]> {
-  const { persistedStreams, metaMatched } =
-    await scanPersistedStreamsForExecution(executionId, snapshotStore);
-  const suffixMatched = findExecutionSuffixMatches(
-    [...persistedStreams, ...streamLogStore.keys()],
-    executionId,
-  );
-
-  const seen = new Set<StreamTabId>([primary]);
-  const siblings: StreamTabId[] = [];
-  for (const streamId of [...metaMatched, ...suffixMatched]) {
-    if (seen.has(streamId) || !streamLogStore.has(streamId)) continue;
-    seen.add(streamId);
-    siblings.push(streamId);
-  }
-  return siblings;
-}
-
-/**
- * Sidecar arm of the non-empty rule: the resolver's pick first, then —
- * only if it reconstructs empty — every other log-backed sibling stream
- * sharing this executionId, in the same deterministic enumeration order the
- * resolver scans. Returns `null` when no candidate yields content.
+ * Sidecar arm of the non-empty rule. Returns `null` when the registered
+ * stream has no conversation content.
  */
 async function readSidecarConversation(
-  executionId: ExecutionId,
   primary: StreamTabId,
-  snapshotStore: StreamSnapshotStore,
   streamLogStore: StreamLogStore,
 ): Promise<CompletedRunConversationReadResult | null> {
   const primaryConversation = await conversationFromStream(
@@ -399,17 +359,6 @@ async function readSidecarConversation(
       source: 'streamLog',
       streamId: primary,
     };
-  }
-  for (const streamId of await siblingConversationStreams(
-    executionId,
-    primary,
-    snapshotStore,
-    streamLogStore,
-  )) {
-    const conversation = await conversationFromStream(streamLogStore, streamId);
-    if (conversation.length > 0) {
-      return { conversation, source: 'streamLog', streamId };
-    }
   }
   return null;
 }
@@ -451,12 +400,7 @@ export async function readCompletedRunConversation(
   const trySidecar =
     async (): Promise<CompletedRunConversationReadResult | null> =>
       resolved
-        ? readSidecarConversation(
-            executionId,
-            resolved.streamId,
-            snapshotStore,
-            streamLogStore,
-          )
+        ? readSidecarConversation(resolved.streamId, streamLogStore)
         : null;
 
   // Freshness decides order only. The resolver pick's streamLogs mtime

--- a/src/transcript/completedRunArchive.ts
+++ b/src/transcript/completedRunArchive.ts
@@ -27,7 +27,11 @@ import {
 } from '@shared/schemas';
 import { assertNever } from '@utils/core';
 
-import { resolvePersistedStreamIdForExecution } from './executionStreamResolver';
+import {
+  findPersistedStreamFallbacksForExecution,
+  resolvePersistedStreamIdForExecution,
+  type PersistedStreamIdResolution,
+} from './executionStreamResolver';
 import { STREAM_DATA_KEYS, streamDataDir } from './streamDataPaths';
 import { StreamLogStore, STREAM_LOGS_DIR } from './StreamLogStore';
 import { StreamSnapshotStore } from './StreamSnapshotStore';
@@ -342,23 +346,40 @@ async function conversationFromStream(
 }
 
 /**
- * Sidecar arm of the non-empty rule. Returns `null` when the registered
- * stream has no conversation content.
+ * Sidecar arm of the non-empty rule. Current executions normally need only
+ * their registered primary. If it reconstructs empty, historical candidates
+ * are tried in deterministic order before the legacy projection.
  */
 async function readSidecarConversation(
-  primary: StreamTabId,
+  executionId: ExecutionId,
+  resolved: PersistedStreamIdResolution,
+  snapshotStore: StreamSnapshotStore,
   streamLogStore: StreamLogStore,
 ): Promise<CompletedRunConversationReadResult | null> {
   const primaryConversation = await conversationFromStream(
     streamLogStore,
-    primary,
+    resolved.streamId,
   );
   if (primaryConversation.length > 0) {
     return {
       conversation: primaryConversation,
       source: 'streamLog',
-      streamId: primary,
+      streamId: resolved.streamId,
     };
+  }
+
+  const fallbackStreamIds =
+    resolved.fallbackStreamIds ??
+    (await findPersistedStreamFallbacksForExecution(
+      executionId,
+      resolved.streamId,
+      { snapshotStore, streamLogStore },
+    ));
+  for (const streamId of fallbackStreamIds) {
+    const conversation = await conversationFromStream(streamLogStore, streamId);
+    if (conversation.length > 0) {
+      return { conversation, source: 'streamLog', streamId };
+    }
   }
   return null;
 }
@@ -400,7 +421,12 @@ export async function readCompletedRunConversation(
   const trySidecar =
     async (): Promise<CompletedRunConversationReadResult | null> =>
       resolved
-        ? readSidecarConversation(resolved.streamId, streamLogStore)
+        ? readSidecarConversation(
+            executionId,
+            resolved,
+            snapshotStore,
+            streamLogStore,
+          )
         : null;
 
   // Freshness decides order only. The resolver pick's streamLogs mtime

--- a/src/transcript/executionStreamResolver.ts
+++ b/src/transcript/executionStreamResolver.ts
@@ -1,6 +1,7 @@
 import pMap from 'p-map';
 
 import { getExecutionStore } from '@agent/storage/ExecutionKVStore';
+import { writeLegacyExecutionStreamId } from '@agent/storage/executionLifecycle';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 
 import { StreamSnapshotStore } from './StreamSnapshotStore';
@@ -12,11 +13,13 @@ type PersistedStreamIdResolutionSource =
 export interface PersistedStreamIdResolution {
   readonly streamId: StreamTabId;
   readonly source: PersistedStreamIdResolutionSource;
+  /** Other persisted candidates to try when a historical primary is empty. */
+  readonly fallbackStreamIds?: readonly StreamTabId[];
 }
 
 export interface PersistedStreamIdResolverOptions {
   readonly snapshotStore?: StreamSnapshotStore;
-  readonly streamLogStore?: Pick<StreamLogStore, 'keys'>;
+  readonly streamLogStore?: Pick<StreamLogStore, 'keys' | 'has'>;
 }
 
 /**
@@ -70,13 +73,74 @@ function findExecutionSuffixMatches(
   return streams.filter((id) => id.endsWith(suffix));
 }
 
+/** Choose the data-bearing primary for an ambiguous historical record. */
+async function pickBestLegacyMetaMatch(
+  candidates: readonly StreamTabId[],
+  snapshotStore: StreamSnapshotStore,
+  streamLogStore: Pick<StreamLogStore, 'has'> | undefined,
+): Promise<StreamTabId> {
+  if (candidates.length === 1) return candidates[0];
+
+  const withData = await pMap(
+    candidates,
+    async (streamId) => {
+      const hasLog = streamLogStore?.has(streamId) ?? false;
+      return {
+        streamId,
+        hasLog,
+        hasWorkPlan:
+          hasLog || (await snapshotStore.hasPersistedWorkPlan(streamId)),
+      };
+    },
+    { concurrency: META_SCAN_CONCURRENCY },
+  );
+  return (
+    withData.find((entry) => entry.hasLog)?.streamId ??
+    withData.find((entry) => entry.hasWorkPlan)?.streamId ??
+    candidates[0]
+  );
+}
+
+function orderedFallbacks(
+  primary: StreamTabId,
+  candidates: readonly StreamTabId[],
+): StreamTabId[] {
+  const seen = new Set<StreamTabId>([primary]);
+  return candidates.filter((streamId) => {
+    if (seen.has(streamId)) return false;
+    seen.add(streamId);
+    return true;
+  });
+}
+
+/**
+ * Find alternative persisted streams for the rare case where a historical
+ * primary reconstructs no conversation. Current executions do not need this
+ * scan unless their registered stream is unexpectedly empty.
+ */
+export async function findPersistedStreamFallbacksForExecution(
+  executionId: ExecutionId,
+  primary: StreamTabId,
+  options: PersistedStreamIdResolverOptions = {},
+): Promise<StreamTabId[]> {
+  const snapshotStore = options.snapshotStore ?? new StreamSnapshotStore();
+  const { persistedStreams, metaMatched } =
+    await scanPersistedStreamsForExecution(executionId, snapshotStore);
+  const suffixMatched = findExecutionSuffixMatches(
+    [...persistedStreams, ...(options.streamLogStore?.keys() ?? [])],
+    executionId,
+  );
+  return orderedFallbacks(primary, [...metaMatched, ...suffixMatched]);
+}
+
 /**
  * Resolve an execution id to the stream id used by transcript sidecars.
  *
  * New executions carry this mapping in their own metadata from registration.
- * The sidecar scan and suffix checks are compatibility fallbacks for records
- * created before that field existed. Enumeration order settles ambiguous old
- * records; current records never enter that branch.
+ * The ranked sidecar scan and suffix checks are compatibility fallbacks for
+ * records created before that field existed; current records never enter that
+ * branch. A unique confirmed legacy match is written through once so later
+ * reads use the same constant-time metadata path as current executions.
  *
  * `null` means no persisted stream carries this execution. Callers that have
  * a derivable stream id own that substitution.
@@ -96,22 +160,54 @@ export async function resolvePersistedStreamIdForExecution(
     await scanPersistedStreamsForExecution(executionId, snapshotStore);
 
   if (metaMatched.length > 0) {
-    return { streamId: metaMatched[0], source: 'streamDataMeta' };
+    const streamId = await pickBestLegacyMetaMatch(
+      metaMatched,
+      snapshotStore,
+      options.streamLogStore,
+    );
+    if (metaMatched.length === 1) {
+      await writeLegacyExecutionStreamId(executionId, streamId);
+    }
+    const suffixMatched = findExecutionSuffixMatches(
+      [...persistedStreams, ...(options.streamLogStore?.keys() ?? [])],
+      executionId,
+    );
+    const fallbackStreamIds = orderedFallbacks(streamId, [
+      ...metaMatched,
+      ...suffixMatched,
+    ]);
+    return {
+      streamId,
+      source: 'streamDataMeta',
+      ...(fallbackStreamIds.length > 0 ? { fallbackStreamIds } : {}),
+    };
   }
 
-  const matchedSidecar = findExecutionSuffixMatches(
+  const matchedSidecars = findExecutionSuffixMatches(
     persistedStreams,
     executionId,
-  )[0];
+  );
+  const matchedSidecar = matchedSidecars[0];
   if (matchedSidecar) {
-    return { streamId: matchedSidecar, source: 'streamDataSuffix' };
+    const fallbackStreamIds = orderedFallbacks(matchedSidecar, matchedSidecars);
+    return {
+      streamId: matchedSidecar,
+      source: 'streamDataSuffix',
+      ...(fallbackStreamIds.length > 0 ? { fallbackStreamIds } : {}),
+    };
   }
 
-  const matchedLog = options.streamLogStore
-    ? findExecutionSuffixMatches(options.streamLogStore.keys(), executionId)[0]
-    : undefined;
+  const matchedLogs = options.streamLogStore
+    ? findExecutionSuffixMatches(options.streamLogStore.keys(), executionId)
+    : [];
+  const matchedLog = matchedLogs[0];
   if (matchedLog) {
-    return { streamId: matchedLog, source: 'streamLogsSuffix' };
+    const fallbackStreamIds = orderedFallbacks(matchedLog, matchedLogs);
+    return {
+      streamId: matchedLog,
+      source: 'streamLogsSuffix',
+      ...(fallbackStreamIds.length > 0 ? { fallbackStreamIds } : {}),
+    };
   }
 
   return null;

--- a/src/transcript/executionStreamResolver.ts
+++ b/src/transcript/executionStreamResolver.ts
@@ -1,7 +1,6 @@
 import pMap from 'p-map';
 
 import { getExecutionStore } from '@agent/storage/ExecutionKVStore';
-import { writeExecutionStreamId } from '@agent/storage/executionLifecycle';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 
 import { StreamSnapshotStore } from './StreamSnapshotStore';
@@ -17,7 +16,7 @@ export interface PersistedStreamIdResolution {
 
 export interface PersistedStreamIdResolverOptions {
   readonly snapshotStore?: StreamSnapshotStore;
-  readonly streamLogStore?: Pick<StreamLogStore, 'keys' | 'has'>;
+  readonly streamLogStore?: Pick<StreamLogStore, 'keys'>;
 }
 
 /**
@@ -29,7 +28,7 @@ export interface PersistedStreamIdResolverOptions {
  */
 const META_SCAN_CONCURRENCY = 8;
 
-export interface ExecutionStreamScan {
+interface ExecutionStreamScan {
   /** Every stream with sidecars under `streamData/`, in enumeration order. */
   readonly persistedStreams: StreamTabId[];
   /** Persisted streams whose sidecar `meta.json` claims this execution. */
@@ -37,13 +36,11 @@ export interface ExecutionStreamScan {
 }
 
 /**
- * The one meta scan over persisted sidecars for an execution: list every
- * `streamData/` stream once, read each one's `meta.json` executionId, and
- * report which of them claim `executionId`. Shared by this resolver and the
- * completed-run conversation reader's sibling search so both enumerate in the
- * same order under the same bounded fan-out.
+ * Compatibility scan for executions registered before their stream identity
+ * was stored directly: list every `streamData/` stream once, read each one's
+ * `meta.json` executionId, and report which of them claim `executionId`.
  */
-export async function scanPersistedStreamsForExecution(
+async function scanPersistedStreamsForExecution(
   executionId: ExecutionId,
   snapshotStore: StreamSnapshotStore,
 ): Promise<ExecutionStreamScan> {
@@ -74,68 +71,12 @@ export function findExecutionSuffixMatches(
 }
 
 /**
- * Disambiguate multiple persisted streams whose sidecar `meta.json` all
- * reference the same `executionId` (e.g. a parent orchestrator tab and a
- * `bash@tool#executionId` child stream). Ranks candidates by data kind: a
- * real `streamLogs` entry always outranks a `workPlan.json`-only match,
- * which in turn outranks a bare metadata match (scan order only breaks ties
- * within the same rank), so a log-backed candidate is never shadowed by an
- * earlier-ordered workPlan-only one.
- *
- * Data presence is checked cheaply: an already-loaded `StreamLogStore.has()`
- * lookup is O(1) in-memory, and `hasPersistedWorkPlan()` is a single stat, so
- * this never re-reads the full per-stream sidecar set.
- */
-async function pickBestMetaMatch(
-  candidates: readonly StreamTabId[],
-  snapshotStore: StreamSnapshotStore,
-  streamLogStore: Pick<StreamLogStore, 'keys' | 'has'> | undefined,
-): Promise<StreamTabId> {
-  if (candidates.length === 1) return candidates[0];
-
-  const withData = await pMap(
-    candidates,
-    async (streamId) => {
-      const hasLog = streamLogStore?.has(streamId) ?? false;
-      return {
-        streamId,
-        hasLog,
-        // hasWorkPlan is irrelevant once hasLog is true (log rank always
-        // wins below) — skip the disk stat in that case, since this runs on
-        // the hot path #7299 already had to bound for fd pressure.
-        hasWorkPlan:
-          hasLog || (await snapshotStore.hasPersistedWorkPlan(streamId)),
-      };
-    },
-    { concurrency: META_SCAN_CONCURRENCY },
-  );
-  return (
-    withData.find((entry) => entry.hasLog)?.streamId ??
-    withData.find((entry) => entry.hasWorkPlan)?.streamId ??
-    candidates[0]
-  );
-}
-
-/**
  * Resolve an execution id to the stream id used by transcript sidecars.
  *
- * The sidecar metadata is canonical. The suffix checks preserve compatibility
- * with older records and child-stream prefixes that cannot be derived from the
- * top-level agent/model pair.
- *
- * Decide-once-carry-as-data (#7469): when a `streamDataMeta` resolution below
- * finds exactly one meta-matched candidate (no disambiguation needed), it's
- * cached onto the execution's own metadata (`writeExecutionStreamId`) before a
- * later call for the same executionId can skip straight to a single cheap
- * read instead of re-scanning every persisted stream. A multi-candidate
- * resolution is deliberately NOT cached: `pickBestMetaMatch`'s ranking
- * depends on which `streamLogStore`/workPlan data happens to be available to
- * *this* call, so an earlier call without a loaded `streamLogStore` could
- * settle on a worse (non-log-backed) candidate than a later call that does
- * have one — caching that would permanently shadow the better answer. The
- * suffix sources further below are heuristic guesses for when no stream's
- * meta.json actually claims this executionId at all, and caching a guess as
- * if it were a confirmed match could pin a wrong answer too.
+ * New executions carry this mapping in their own metadata from registration.
+ * The sidecar scan and suffix checks are compatibility fallbacks for records
+ * created before that field existed. Enumeration order settles ambiguous old
+ * records; current records never enter that branch.
  *
  * `null` means no persisted stream carries this execution. Callers that have
  * a derivable stream id own that substitution.
@@ -144,10 +85,10 @@ export async function resolvePersistedStreamIdForExecution(
   executionId: ExecutionId,
   options: PersistedStreamIdResolverOptions = {},
 ): Promise<PersistedStreamIdResolution | null> {
-  const cachedStreamId = (await getExecutionStore(executionId).readMeta())
+  const registeredStreamId = (await getExecutionStore(executionId).readMeta())
     ?.streamId;
-  if (cachedStreamId) {
-    return { streamId: cachedStreamId, source: 'executionMeta' };
+  if (registeredStreamId) {
+    return { streamId: registeredStreamId, source: 'executionMeta' };
   }
 
   const snapshotStore = options.snapshotStore ?? new StreamSnapshotStore();
@@ -155,15 +96,7 @@ export async function resolvePersistedStreamIdForExecution(
     await scanPersistedStreamsForExecution(executionId, snapshotStore);
 
   if (metaMatched.length > 0) {
-    const streamId = await pickBestMetaMatch(
-      metaMatched,
-      snapshotStore,
-      options.streamLogStore,
-    );
-    if (metaMatched.length === 1) {
-      await writeExecutionStreamId(executionId, streamId);
-    }
-    return { streamId, source: 'streamDataMeta' };
+    return { streamId: metaMatched[0], source: 'streamDataMeta' };
   }
 
   const matchedSidecar = findExecutionSuffixMatches(

--- a/src/transcript/executionStreamResolver.ts
+++ b/src/transcript/executionStreamResolver.ts
@@ -62,7 +62,7 @@ async function scanPersistedStreamsForExecution(
 }
 
 /** Streams whose id carries the `#executionId` suffix, in the given order. */
-export function findExecutionSuffixMatches(
+function findExecutionSuffixMatches(
   streams: readonly StreamTabId[],
   executionId: ExecutionId,
 ): StreamTabId[] {


### PR DESCRIPTION
## Summary

Persist the execution-to-stream mapping when an execution is registered. This makes durable execution metadata authoritative for current runs, so their history, trace, and archive reads do not scan sidecar directories.

Historical executions without `meta.streamId` retain the bounded, data-aware sidecar fallback. Unique confirmed historical matches are written through once, and conversation reads retain sibling fall-through when the selected historical stream has no conversation rows.

## Issue acceptance gates

- Closes #9425.
- Every production `registerExecution` caller supplies the stream identity used by that execution.
- `registerExecution` writes `meta.streamId` in the initial metadata write.
- The resolver reads execution metadata first and retains compatibility ranking and suffix checks only for old records.
- Unique historical matches retain one-time write-through, while ambiguous matches remain uncached.
- Historical sibling fall-through remains available without duplicating sidecar-enumeration logic in the archive reader.

## Single source of truth

`registerExecution` in `src/agent/storage/executionLifecycle.ts` owns the durable execution-to-stream mapping for current runs. `executionStreamResolver.ts` owns historical candidate discovery and ranking. `getChildStreamId` in `src/tools/childStream.ts` owns the prefixed child-stream formula shared by registration and both child-stream creation paths.

## Duplication and abstraction budget

The completed-run archive no longer implements an independent sidecar scan; it consumes ordered historical fallbacks from the resolver. One small child-stream helper was added because registration and both creation paths must derive exactly the same identifier. Review established that historical ranking, sibling fall-through, and unique-match write-through are necessary compatibility behavior, so they remain explicitly confined to historical or empty-primary paths.

## Net elements (R6)

- Files: 0 added, 0 deleted, 21 modified.
- Exported symbols: 3 added, 4 removed or made private; net -1.
- Named routines: `getChildStreamId`, the legacy write-through, and resolver-owned historical fallback enumeration are added; the general post-hoc writer and archive-owned sibling scanner are removed. The ranking routine remains private and is explicitly historical.
- Net LoC: 329 additions, 381 deletions; net -52.

## Consumer counts (R8)

`writeExecutionStreamId` had one resolver caller and is replaced by a legacy-only writer with the same single caller. `scanPersistedStreamsForExecution` had two consumers; its archive consumer is removed and the scan is now private to the resolver. `findExecutionSuffixMatches` is also private. The resolver exposes one ordered-fallback operation consumed only by the completed-run archive. No event emit path or subscriber key changes.

## Host impact

Extension: Top-level and child executions persist their stream identity at registration; no user-interface change.

Desktop: Uses the same host-neutral registration and resolution paths; no host-specific change.

CLI: Child agent sessions persist the prefixed child stream selected at launch; command behavior is unchanged.

## Scheduled refactoring

None. The compatibility scan remains intentionally for historical execution records.

## Validation

- `npm run format`
- `npm run compile:fast`
- `npm run lint`
- `npm run typecheck`
- `npm test` — 815 files passed, 1 skipped; 8,237 tests passed, 4 skipped.
