### PR TITLE
docs: open-source readiness audit, backend decoupling plan, directory survey

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,9 @@ aliases until a future SDK surface is enforced with a build and import-boundary 
 - `packages/extension/src/common/` holds extension-only helpers (state managers, webview base classes):
   - `packages/extension/src/common/state/` - State managers including `pendingStateManager`
   - `packages/extension/src/common/webview/` - Base classes (`BaseViewContentProvider`, `BaseViewMessageHandler`), webview HTML builder (`buildWebviewHtml`), command constants
-- `src/utils/` is reserved for utilities used by both the extension host and webviews. If a helper is specific to one side, place it under `frontend/` or `common/` instead of `utils/`.
+- `src/utils/` holds host-agnostic utilities. A subset of it must additionally stay **browser-safe**, because the webview frontends import it: as of this writing exactly five modules are reachable from `webview/frontend/`, `progressView/frontend/` and `settingsView/frontend/` — `@utils/core`, `@utils/core/boundedIdSet`, `@utils/errors/errorMessage`, `@utils/files/pastedImageName`, `@utils/text/stringUtils`. Those five, and anything they import, must not reach for Node built-ins. The remaining ~50 files are host-side only.
+
+  Do not read this as "everything in `utils/` is shared with the webviews" — it is not, and an earlier version of this line said so incorrectly. What it does mean: if a helper is specific to one side, prefer `frontend/` or `common/`, and if you add an import to one of the five browser-reachable modules, check that it stays browser-safe.
   - `utils/core/` - Async, type-guard, math, comparator, URL, and path-basics primitives (`debounce`, `delay`, `filterNotNull`, `clamp`, `byName`, `tryParseUrl`, `normalizeFilePath`, `getBasename`, `getFileStem`); re-exports string primitives from `utils/text/stringUtils` for browser-safe barrel access
     - `utils/core/boundedIdSet.ts` - `createBoundedIdSet` (LRU-capped `Set<Id>` for "seen id" guards)
     - `utils/core/idHash.ts` - Node-only deterministic execution-ID derivation
@@ -122,6 +124,7 @@ aliases until a future SDK surface is enforced with a build and import-boundary 
   - `utils/system/` - Shell command execution (`execUtils`)
   - `utils/text/` - Text, string, and XML processing utilities — the single home for generic string helpers (validation, truncation, duration/token/percent formatting)
   - `utils/prompt/` - Prompt builder utilities
+
 - `packages/extension/src/commands/` - VS Code commands grouped by domain
 - `packages/extension/src/settingsView/` - Unified settings webview combining Memory, History, Models, Agents, Multi-Agent, Tools, AI Agents, Git, LaTeX, and Goal tabs
 - `packages/extension/src/progressView/` - Task tracking board webview
@@ -136,7 +139,12 @@ aliases until a future SDK surface is enforced with a build and import-boundary 
 - **Start simple**: Choose the most direct solution that solves the problem. A new abstraction earns its place only when it clearly reduces complexity.
 - **Use native constructs**: Rely on JavaScript/TypeScript built-ins (objects, Maps, Sets, arrays), VS Code APIs, and JSON for state. These are well-understood and require no extra code.
 - **Trust your inputs**: When data flows from code you control, pass it through directly. Transform or validate only at true system boundaries (user input, external APIs).
-- **One error path**: Surface errors once through the shared error utilities in `@common/errors`. Let exceptions propagate naturally to that single handler.
+- **One error path**: Surface errors once, and let exceptions propagate naturally to that single handler rather than being caught and re-reported at every level. Two modules serve different halves of this and both are correct:
+  - `@common/errors` — classification and surfacing: `classifyAgentError`, the SDK-error inspection under `sdkError/`, `errorPredicates`, `errorFormatUtils`. Reach for this when the _kind_ of failure changes what happens next.
+  - `@utils/errors/errorMessage` — the three `unknown`-narrowing primitives `toErrorMessage`, `ensureError`, `extractErrorMessage`. This is the most-imported leaf module in the repo (~199 sites) and is browser-safe, which `@common/errors` is not required to be.
+
+  An earlier version of this line named `@common/errors` as the only error path, which is why the distinction is spelled out here.
+
 - **Evolve incrementally**: Improve existing structures in small steps. Rewrite only when there's a documented, concrete benefit.
 
 ### Zod v4 Schema Patterns

--- a/docs/proposals/2026-07-29-open-source-readiness.md
+++ b/docs/proposals/2026-07-29-open-source-readiness.md
@@ -1,5 +1,12 @@
 # Open-source readiness audit
 
+> **Superseded in part by [`2026-08-01-open-source-readiness-audit.md`](./2026-08-01-open-source-readiness-audit.md).**
+> That audit disproves three conclusions below: that no history rewrite is
+> required (confidential third-party peer-review correspondence is reachable
+> from ~153 of 208 tags under `agents/prl/`), that there is no vendored
+> third-party source, and the telemetry-opt-out status. The licensing and
+> product sections here remain current.
+
 _Audited at `0.40.0` (`f7c3958`), 2026-07-29: full history (17,585 commits),
 working tree, CI, dependency graph, build/test/lint health._
 

--- a/docs/proposals/2026-08-01-backend-decoupling-plan.md
+++ b/docs/proposals/2026-08-01-backend-decoupling-plan.md
@@ -1,0 +1,935 @@
+# Backend decoupling plan: finishing the seam that already exists
+
+**Status:** proposal. Supersedes nothing; complements
+`docs/proposals/2026-07-29-open-source-readiness.md`, which covers licensing,
+repo identity, and publication decisions this plan assumes are settled.
+
+**Goal.** Decouple the Supabase backend and the LLM relay from the UI and core
+so that (a) the hosted implementation can live in a private repo, (b) the
+open-source client works standalone on the user's own API keys with no dead
+UI, and (c) a different backend can be installed.
+
+**Method.** The repo already has the idiom and one finished instance of it.
+`src/model/includedModelAccess.ts:28-63` is a typed capability port with a loud
+null object (`BYOK_ONLY`, `:71-91`, which _throws_ at `getRelayBaseUrl` rather
+than fabricating a URL) installed once per process from
+`src/controllers/modelAccess/installTexraModelAccess.ts` next to
+`initPlatform()`. `packages/agent/src/index.ts:225,244` already ships as an
+embedder that never installs it and passes `loadAgents({ includeRemote: false })`.
+This plan adds **two more ports of the same shape**, **one lint block copied
+from an existing recipe**, and **no new machinery**. Every proposed layer that
+turned out to be a pass-through was cut; those cuts are named in §9.
+
+---
+
+## 1. The cut
+
+```mermaid
+graph TB
+  subgraph PUB["PUBLIC repo — texra (open source)"]
+    direction TB
+    CORE["core zones<br/>src/agent · src/model · src/tools · src/shared<br/>src/telemetry · src/common · src/controllers · src/latex"]
+    P1["<b>IncludedModelAccess</b><br/>src/model/includedModelAccess.ts<br/><i>BYOK_ONLY</i>"]
+    P2["<b>RemoteAgentSource</b><br/>src/agent/index/agentSource.ts<br/><i>NO_REMOTE_AGENTS</i>"]
+    P3["<b>AccountPlane</b><br/>src/shared/schemas/account.ts (schema)<br/>src/controllers/account/ (runtime)<br/><i>NO_ACCOUNT</i>"]
+    WIRE["Zod wire contracts<br/>src/shared/schemas/{relayErrorEnvelope,usageLog,spendingStatus}.ts"]
+    HOSTS["hosts — extension · desktop · cli<br/>UI gated on hasIncludedModelAccess()"]
+    INST["src/controllers/texra/installTexraBackend.ts<br/><i>the only file allowed to name the backend</i>"]
+    CORE --> P1 & P2 & P3
+    P1 & P2 & P3 -.-> WIRE
+    HOSTS --> INST
+  end
+  subgraph PRIV["PRIVATE repo — texra-hosted (@texra/hosted)"]
+    ADAPT["adapters: installTexraModelAccess · installTexraRemoteAgents<br/>installTexraAccount · host auth surfaces"]
+    AUTH["src/auth/{SupabaseClient,config,serverKeys,relayToken,SupabaseSession,…}"]
+    EDGE["supabase/functions/** · migrations · seed"]
+    PROMPT["deploy pipeline + storage sync"]
+    ADAPT --> AUTH --> EDGE
+  end
+  INST -.->|"optional dependency<br/>absent ⇒ BYOK, said out loud"| ADAPT
+  WIRE -.->|"imported by both runtimes"| EDGE
+```
+
+|                    | Public (`texra`)                                                                                                                                                                            | Private (`texra-hosted`)                                                                                                  | Interface between                                                                |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| **Model routing**  | `IncludedModelAccess` port + `BYOK_ONLY`; `ModelHandler.resolveClientCredential` (`src/agent/modelHandlers/ModelHandler.ts:494-565`); `ProxyConfig` union (`ProxyConfigResolver.ts:89-173`) | `installTexraModelAccess.ts` incl. `capIncludedReasoningEffort` (tier pricing policy, `:30-48`); `src/auth/serverKeys/**` | 12-member interface + `hasIncludedModelAccess()` + `setUseIncludedModelAccess()` |
+| **Agent catalog**  | `RemoteAgentSource` port; registry fan-out (`src/agent/index/agentRegistry.ts:206`); the 21 prompt YAMLs in `prompts/agents/remote/`                                                        | PostgREST query, `remote_agents` table + column list, `PGRST204`/`42703` sniffing, `get-agent-config` client              | 3-member interface + `RemoteAgentCatalogEntrySchema`                             |
+| **Account / plan** | `AccountPlane` port; `ProfileMessageBuilder` assembly; settings + CLI render models                                                                                                         | `SupabaseClient`, GoTrue session, tier/quota policy, `log-usage` POST, host OAuth flows                                   | 5-member interface + `AccountSnapshotSchema`                                     |
+| **Errors**         | `relayDetection.ts` parses a published Zod envelope; `isRelayError` on the trace wire                                                                                                       | relay `jsonError` builds its body from the same schema                                                                    | `RelayErrorEnvelopeSchema` (versioned)                                           |
+| **Abuse controls** | —                                                                                                                                                                                           | `_shared/emailPolicy.ts`, `relay/requestGate.ts`, `relay/enforcement.ts`, RLS migrations                                  | none — never client-visible                                                      |
+| **Enforcement**    | one `no-restricted-imports` + one `no-restricted-syntax` block in `eslint.config.mjs`                                                                                                       | private CI runs the public suite                                                                                          | lint fails on any new backend import in core                                     |
+
+**Read the boundary as one sentence:** core zones may _ask_ whether included
+access, a hosted catalog, or an account exists; only `src/controllers/texra/`
+may _answer_, and that directory is the unit that moves private.
+
+### Today's violations — the entire size of the problem
+
+`grep "from '@auth/" src/` minus `src/test-kernel/` and `src/auth/` yields
+**11 production files** (`@auth/codex` and `@auth/constants` excluded — see §2):
+
+| File                                                                    | Imports                                    | Fixed by                                               |
+| ----------------------------------------------------------------------- | ------------------------------------------ | ------------------------------------------------------ |
+| `src/agent/remote/remoteAgentConfigClient.ts:4`                         | `SUPABASE_CONFIG`                          | Port B (file moves)                                    |
+| `src/agent/remote/remoteAgentList.ts:17,18`                             | `SUPABASE_CONFIG`, `SupabaseClient`        | Port B (file moves)                                    |
+| `src/agent/remote/RemoteAgentLoader.ts:16`                              | `SupabaseClient`                           | Port B (file deleted)                                  |
+| `src/telemetry/UsageLogService.ts:6,7`                                  | `SupabaseClient`, `SUPABASE_CUSTOM_DOMAIN` | Port C                                                 |
+| `src/tools/setup/platform.ts:15,17`                                     | `relayToken`, `SupabaseClient`             | Port C                                                 |
+| `src/controllers/settingsView/ProfileMessageBuilder.ts:21,22,23`        | all three                                  | Port C                                                 |
+| `src/controllers/mainView/teamCatalogPorts.ts:3`                        | `SupabaseClient`                           | Port B                                                 |
+| `src/controllers/onboarding/setupLaunch.ts:1`                           | `serverKeys`                               | **Step 0 — deletion, no port**                         |
+| `src/controllers/settingsView/SettingsModelSelectionController.ts:8`    | `FREE_TIER`, `MAX_TIER`                    | **Step 0 — deletion, no port**                         |
+| `src/controllers/settingsView/SettingsRemoteAgentPromptController.ts:2` | `ULTRA_TIER`                               | Port B (controller deleted)                            |
+| `src/controllers/modelAccess/installTexraModelAccess.ts:13-16`          | all                                        | sanctioned adapter — moves to `src/controllers/texra/` |
+
+Plus **14 non-test importers** of `getServerSideKeyService()` across all three
+hosts and `src/controllers/`, which route around the one port that already
+exists. Member tally across those call sites:
+`setUseIncludedModelAccess` ×7, `getUseIncludedModelAccess` ×6,
+`clearAllCaches` ×6, `getUserTier` ×3, `canUseServerSideKeys` ×2, and one each
+of `getSpendingStatus`, `getRelayBaseUrl`, `isRelayQuotaExceeded`,
+`wasQuotaAutoSwitched`, `isProviderOnServer`, `shouldUseServerSideKeysSync`,
+`canUseModelSync`.
+
+---
+
+## 2. Why here and not elsewhere — the seams NOT cut
+
+Some coupling stays. Naming it is part of the design.
+
+| Left coupled                                                                                                                                            | Why                                                                                                                                                                                                                                                                                                   | Evidence                                                                         |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| **`@auth/codex/**` and `@auth/constants`** stay importable everywhere                                                                                   | Codex/ChatGPT is a _third-party_ subscription, not TeXRA's backend; it already reaches storage only through `platform().secrets`. `AUTH_COMMANDS` are VS Code command IDs, not endpoints.                                                                                                             | `src/tools/setup/InvokeCommandTool.ts:5`, `src/agent/runtime/ModelFactory.ts:15` |
+| **`isRelayError` stays on the durable trace format**                                                                                                    | It is a field of `ProviderErrorObjectSchema` (`src/shared/schemas/errors.ts:123`) republished on the trace bus (`src/agent/trace/events.ts:281`). Renaming it to `viaProxy` is a persisted-data migration, not a refactor. Under BYOK it is never `true`, so the branches are unreachable, not wrong. |                                                                                  |
+| **`AGENT_SOURCE.REMOTE = 'remote'`** keeps its value                                                                                                    | It is a wire-contract enum member (`src/shared/schemas/agent.ts:22`) consumed by settings IPC, proposals, and the roster, and is persisted in registry keys. Its _meaning_ changes from "Supabase" to "the installed catalog source"; the string does not.                                            |                                                                                  |
+| **`AgentModePreset.texraHostedAgents`** keeps its field name                                                                                            | Persisted in user team presets (`src/shared/schemas/agentPresets.ts:56`). Renaming needs a `z.union()` legacy transform at the entry point — worth doing, but not in the boundary PR series.                                                                                                          |                                                                                  |
+| **The four hosted-vocabulary `ModelAvailabilityKind`s** (`'included-access'`, `'not-included'`, `'included-login-required'`, `'relay-quota-exhausted'`) | `computeModelOptions.ts:102-165` already normalizes them once into a client-owned view model that renderers consume verbatim, and `BYOK_ONLY` collapses all four. This is the seam working.                                                                                                           |                                                                                  |
+| **`RetryState`'s relay-401-refresh control flow** (`src/agent/core/flows/RetryState.ts:196-215`)                                                        | It goes _through_ the port (`getAccessToken(true)`), so it is backend-agnostic already. Generalizing it to `onAuthFailure()` is defensible but is retry-engine surgery unrelated to the cut.                                                                                                          |                                                                                  |
+| **`UsageMonitor`'s awaited flush** (`src/agent/utils/UsageMonitor.ts:296-310`)                                                                          | The `await` on relay rounds exists because the relay enforces its monthly cap from the DB aggregate; the comment says so. `usedRelay = usage.usageRoute === 'relay'` is permanently `false` with no relay installed, so leaving it untouched is both correct and free. **Do not "simplify" this.**    |                                                                                  |
+| **`packages/cli/src/runtime/relayUsage.ts`** (hand-built PostgREST keyset queries over `usage_logs`)                                                    | It is one CLI command in a host zone. It moves wholesale with the private package rather than getting a port nothing else would use.                                                                                                                                                                  | `:195-215`                                                                       |
+| **`supabase/functions/_shared/emailPolicy.ts`** never gets a public contract                                                                            | A 36-domain disposable-mailbox blocklist annotated "observed farming the Researcher Access Program", a privacy-relay blocklist, and `MIN_GITHUB_ACCOUNT_AGE_DAYS = 30`. This is enforcement logic whose value depends on non-publication. It is never client-visible and must not be.                 | `emailPolicy.ts:3-46`                                                            |
+
+### The placement constraint no proposal noticed
+
+`src/test-kernel/architecture/subsystemEdgeRatchet.vitest.ts` fails on any **new
+directed subsystem pair** against `config/ratchets/architecture-edges-baseline.json`.
+The baseline has **no `tools → controllers` and no `telemetry → controllers`
+edge**. It does have `tools → shared`, `telemetry → shared`, `agent → shared`,
+`model → shared`, and `controllers → shared`.
+
+Since `AccountPlane` is consumed by `src/tools/setup/platform.ts`,
+`src/telemetry/UsageLogService.ts`, and `src/controllers/settingsView/`, it
+**must** live in `src/shared/`. Placing it under `src/controllers/account/`
+would create two new edges and fail the ratchet — and would invert layering
+besides. This settles a question the source designs disagreed on.
+
+Conversely, the cut **removes** `agent → auth`, `tools → auth`, and
+`telemetry → auth` (all currently `value` edges in the baseline). Removing edges
+never fails the ratchet; regenerate the baseline in the same PR so the win is
+recorded.
+
+---
+
+## 3. The contract
+
+### Port A — `IncludedModelAccess` (existing, `src/model/includedModelAccess.ts`)
+
+Twelve members unchanged (`:30-63`). Two additions, both paid for by deletion:
+
+```ts
+export interface IncludedModelAccess {
+  /* …existing 12 members… */
+
+  /**
+   * Persist the user's included-vs-personal preference. The provider owns the
+   * write because flipping it must also invalidate entitlement caches and
+   * notify subscribers; a caller touching globalState cannot do that.
+   */
+  setUseIncludedModelAccess(enabled: boolean): Promise<void>;
+}
+
+/**
+ * Whether an included-access provider is installed at all — distinct from every
+ * interface member, which answer "may this user route through it *now*". UI asks
+ * this to decide whether an account surface should exist.
+ */
+export function hasIncludedModelAccess(): boolean; // `installed !== null`
+```
+
+`BYOK_ONLY.setUseIncludedModelAccess` **throws** with
+`INCLUDED_MODEL_ACCESS_REMEDY` (`:97`), matching `getRelayBaseUrl`'s posture
+(`:80-87`) — unreachable behind `hasIncludedModelAccess()`, and a silent no-op
+write is exactly the silent degradation CLAUDE.md bans.
+
+_Justification for `setUseIncludedModelAccess`:_ seven host call sites bind it
+to the singleton (`packages/cli/src/runtime/initPlatform.ts:405,407`,
+`packages/cli/src/runtime/apiAccessMode.ts:57`,
+`packages/desktop/src/main/index.ts:757-758`,
+`packages/desktop/src/main/desktopAgentExecution.ts:478-479`,
+`packages/extension/src/progressView/ProgressViewMessageHandler.ts:603-604`,
+`packages/extension/src/settingsView/SettingsViewMessageHandler.ts:182-183`),
+and `src/controllers/` _already declares it as an injected dependency_
+(`ProgressApiKeyRetryController.ts:44`, `SettingsProfileController.ts:69`).
+The controllers treat it as a port member today; only the hosts don't.
+
+**Deliberately NOT added** (each was in a source design; each is cut):
+
+- `canUseServerSideKeysForModel` — `src/auth/serverKeys/ServerSideKeyService.ts:376-380`
+  defines it as `(await canUseServerSideKeys()) && canUseModelSync(m)`, both
+  already on the port. The bypass at `setupLaunch.ts:49-50` is fixed by
+  composing, not widening.
+- `getSpendingStatus` — spend is an account fact. It lives on Port C, which the
+  CLI status bar can read instead of reaching `getServerSideKeyService()` from
+  inside an Ink render component (`packages/cli/src/chat/tui/panes/StatusBar.tsx:168-176`).
+- `clearAllCaches` — a session-lifecycle event. Port C's `onChange` owns it.
+
+### Port B — `RemoteAgentSource` (new, `src/agent/index/agentSource.ts`)
+
+Sibling of `agentRegistry.ts` and `remoteAgentMeta.ts`, the only modules that
+reach the catalog today. Zone: `src/agent/` (VS Code-free, backend-free).
+
+```ts
+import { z } from 'zod';
+
+/** One catalog row in client vocabulary. No DB column names, no row id. */
+export const RemoteAgentCatalogEntrySchema = z.object({
+  name: AgentNameSchema,
+  description: z.string().nullish(),
+  visibility: z.array(z.string()).nullish(),
+  tools: z.array(z.string()).nullish(),
+  category: z.enum(AgentCategory).nullish(),
+});
+export type RemoteAgentCatalogEntry = z.infer<
+  typeof RemoteAgentCatalogEntrySchema
+>;
+
+export interface RemoteAgentSource {
+  /** Can this source serve definitions right now? Drives team preflight and UI. */
+  isAvailable(): Promise<boolean>;
+  /** Catalog rows. `[]` is a valid answer; failure is the source's to log at warn. */
+  list(): Promise<readonly RemoteAgentCatalogEntry[]>;
+  /** Raw agent YAML for one name. Throws `RemoteAgentUnavailableError`; the host phrases it. */
+  loadDefinitionYaml(agentName: string): Promise<string>;
+  /** Drop cached rows — called on sign-out. */
+  invalidate(): void;
+}
+
+const NO_REMOTE_AGENTS: RemoteAgentSource = {/* false, [], throws, no-op */};
+
+export function setRemoteAgentSource(source: RemoteAgentSource | null): void;
+export function remoteAgentSource(): RemoteAgentSource; // → NO_REMOTE_AGENTS
+export function resetRemoteAgentSourceForTests(): void;
+```
+
+The schema is today's `RemoteAgentListItemSchema` (`src/agent/remote/types.ts:17-29`)
+minus two DB-isms: `id` (a PostgREST primary key that
+`src/agent/index/remoteAgentMeta.ts:52-66` never reads) and the `agentCategory`
+column name. `.nullish()` per CLAUDE.md.
+
+_Why `isAvailable()` is not `list().length > 0`:_
+`SupabaseClient.canAccessRemoteAgentCatalog()` deliberately excludes the CI
+relay token while `isAuthenticated()` includes it
+(`src/auth/SupabaseClient.ts:358-365`), and
+`src/common/teams/TeamAvailabilityPreflight.ts:44-107` needs "could this source
+serve, if asked" _before_ it has a list. Three members is the floor.
+
+**Five verified consumers:** `agentRegistry.ts:206` (`list`), `agentRegistry.ts:552-563`
+(`invalidate`), `agentLoad.ts:133-138` (`loadDefinitionYaml`),
+`teamCatalogPorts.ts:27` (`isAvailable`), and the setup adapter's
+`remoteAgentCatalogAvailable` (`src/tools/setup/platform.ts:134`).
+
+### Port C — `AccountPlane` (split across two files)
+
+**Corrected placement.** An earlier draft put the schema, the port interface and
+the mutable module-level accessor in one file at `src/shared/account.ts`,
+justified by the edge ratchet. That was the wrong reason for the wrong shape:
+the ratchet records the edges the tree has today, not the architecture it should
+have, and letting it site a service locator inside the browser-reachable
+contract zone is exactly the tail wagging the dog. `signIn`, `signOut`,
+`submitUsage`, `onChange` and a module-level setter are runtime orchestration,
+not a wire contract.
+
+| File                                      | Zone               | Contents                                                                                                                          |
+| ----------------------------------------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| `src/shared/schemas/account.ts`           | `src/shared/`      | `AccountSnapshotSchema`, `AccountSnapshot`, `SIGNED_OUT_ACCOUNT`, `UsageSubmitResult` — data only, browser-safe, no mutable state |
+| `src/controllers/account/accountPlane.ts` | `src/controllers/` | The `AccountPlane` interface, `installAccountPlane()`, `getAccountPlane()`, `hasAccountPlane()`                                   |
+
+The schema half follows `src/shared/schemas/spendingStatus.ts:8-52`. The runtime
+half sits in `src/controllers/`, which is the documented home for host-neutral
+orchestration and already carries a `controllers → auth` edge.
+
+**This creates two new subsystem edges** — `tools → controllers` and
+`telemetry → controllers` — which `subsystemEdgeRatchet.vitest.ts` fails on as
+new directed pairs. Regenerate `architecture-edges-baseline.json` in the same
+commit and state the intent in the PR body. Adding a deliberate edge to a
+baseline is the normal use of that ratchet; contorting the design to avoid one
+is not. Note the same commit _removes_ `agent → auth`, `tools → auth` and
+`telemetry → auth`, so the net direction is still toward fewer backend edges.
+
+```ts
+export const AccountSnapshotSchema = z.object({
+  authenticated: z.boolean(),
+  email: z.string().nullable(),
+  /** Operator's plan name, opaque to core. Rendered, never branched on. */
+  planName: z.string().nullable(),
+  sessionProblem: z.enum(['expired', 'unavailable']).nullable(),
+  // NOTE: apiAccessMode and quotaAutoSwitched deliberately absent. They are
+  // routing facts owned by Port A (getUseIncludedModelAccess() /
+  // wasQuotaAutoSwitched()). Restating them here created two owners with no
+  // declared derivation direction — model routing read A while the profile UI
+  // read C, so the two could disagree and nothing said which won. The
+  // presentation boundary composes A and C once, where the view model is built.
+  spendingStatus: SpendingStatusSchema.nullable(),
+  spendingStatusError: SpendingStatusErrorSchema.nullable(),
+});
+export type AccountSnapshot = z.infer<typeof AccountSnapshotSchema>;
+export const SIGNED_OUT_ACCOUNT: AccountSnapshot; // frozen
+
+export type UsageSubmitResult =
+  | { readonly kind: 'accepted' }
+  | { readonly kind: 'retryable'; readonly reason: string }
+  | { readonly kind: 'rejected'; readonly reason: string }
+  /** No sink installed: the caller must stop queueing, loudly and once. */
+  | { readonly kind: 'no-sink' };
+
+export interface AccountPlane {
+  /** `refresh: true` primes entitlement caches before reading. */
+  snapshot(options?: { readonly refresh?: boolean }): Promise<AccountSnapshot>;
+  /** Plan accounting, not telemetry — see below. */
+  submitUsage(batch: UsageLogBatch): Promise<UsageSubmitResult>;
+  /** Run the operator's sign-in. The host supplies UI; the protocol is the impl's. */
+  signIn(options?: { readonly providerHint?: string }): Promise<boolean>;
+  signOut(): Promise<void>;
+  /** Fires after a session change, once the impl has finished its own invalidation. */
+  onChange(listener: () => void): () => void;
+}
+
+const NO_ACCOUNT: AccountPlane; // SIGNED_OUT_ACCOUNT, {kind:'no-sink'},
+// signIn → false, signOut → no-op, onChange → noop disposer
+export function setAccountPlane(plane: AccountPlane | null): void;
+export function accountPlane(): AccountPlane; // → NO_ACCOUNT
+export function resetAccountPlaneForTests(): void;
+```
+
+**The port pays for itself by _shrinking_ the wire contract, not mirroring it.**
+`UpdateProfileMessageSchema` (`src/shared/schemas/profileViewMessages.ts:104-123`)
+gains nothing and **drops three fields that have producer sites and zero
+consumers** — verified by grep across `packages/*/src` and `src/`:
+
+| Dropped field     | Producer                           | Consumers |
+| ----------------- | ---------------------------------- | --------- |
+| `tierConstants`   | `ProfileMessageBuilder.ts:53,56`   | **none**  |
+| `accessExpiresAt` | `ProfileMessageBuilder.ts:120,147` | **none**  |
+| `remoteAgents`    | `ProfileMessageBuilder.ts:132,145` | **none**  |
+
+The remaining fields (`authenticated`, `user`, `tier`, `sessionProblem`,
+`spendingStatus`, `spendingStatusError`) are re-derived from one
+`AccountSnapshot` rather than eight separate `SupabaseClient` /
+`getServerSideKeyService()` reads. `apiAccessMode` and `quotaAutoSwitched` come
+from Port A at the same assembly point — one owner each, composed once. `ProfileMessageBuilder`
+keeps real work on top: provider-key statuses, streaming defaults, and host
+assembly.
+
+_Why `signIn`/`signOut`/`onChange` are on the same port and not a fourth:_
+they are the same plane — who you are, what your plan allows, what your plan is
+billed for. Splitting them yields two ports with two and three members
+installed from the same file at the same moment.
+
+_Why `submitUsage` is here and not on a telemetry port:_
+`src/telemetry/UsageLogService.ts:70-86` states that relay/subscription records
+are **plan accounting**, sent regardless of the `texra.telemetry.enabled`
+opt-out, because the relay reads the aggregate to enforce the spend cap. It is
+an account operation that happens to live in a telemetry module.
+`UsageLogService` keeps every piece of client-owned policy it has today —
+batching, queue cap, opt-out, `PLAN_ACCOUNTING_ROUTES` (`:82-86`), the
+re-read-after-await discipline. Only the URL and the bearer token leave.
+
+### Wire contract — `RelayErrorEnvelopeSchema` (new, `src/shared/schemas/relayErrorEnvelope.ts`)
+
+This is the one contract an alternative backend must satisfy byte-for-byte, and
+today it exists only as five hand-rolled string literals in
+`src/common/errors/sdkError/relayDetection.ts:55-99`.
+
+**Critical correction.** `_relay` is **a version string, not a boolean**:
+`supabase/functions/relay/index.ts:127` declares
+`const RELAY_VERSION = '1.10.0'`, stamped into every error body at `:234` and
+into `/providers` at `:305`. The client discards it —
+`relayDetection.ts:55-59` only checks `'_relay' in candidate`. A schema
+declaring `_relay: z.literal(true)` would silently fail to parse **every** relay
+error, losing quota, concurrency, and `retryAfterSeconds` handling.
+
+```ts
+/**
+ * The error body an included-access relay returns instead of the provider's.
+ * Any implementation of IncludedModelAccess that fronts provider APIs MUST emit
+ * this shape, or the client silently loses quota and rate-limit handling.
+ */
+export const RelayErrorBodySchema = z.looseObject({
+  /** Relay contract version, e.g. '1.10.0'. See RELAY_CONTRACT_VERSION. */
+  _relay: z.string().min(1),
+  type: z.literal('relay_error'),
+  message: z.string(),
+  limitReached: z.boolean().nullish(),
+  requestLimitReached: z.boolean().nullish(),
+  reason: z.enum(['concurrency', 'rate']).nullish(),
+  retryAfterSeconds: z.number().nonnegative().nullish(),
+});
+
+export const RELAY_CONTRACT_MAJOR = 1;
+
+/** null when the body is not a relay body. Throws a named "client too old for
+ *  this relay" error on a major-version mismatch, rather than misclassifying. */
+export function parseRelayErrorBody(raw: unknown): RelayErrorBody | null;
+```
+
+`relayDetection.ts:55-99`'s five sniffers collapse to one `safeParse` over
+`errorBodyCandidates`. `isRelayMonthlyLimitMessage` (`:112-118`, a literal match
+on `'monthly spending limit reached'`) and its CLI string fallback
+(`packages/cli/src/runtime/approval/approvalPolicy.ts:86-95`) are deleted.
+On the private side, `jsonError` (`relay/index.ts:225-245`) builds its body
+through the same schema so a client-visible field cannot be emitted without
+existing in the contract.
+
+### Zone ownership
+
+| File                                                                  | Zone              | Owner after the cut                                                                                           |
+| --------------------------------------------------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------- |
+| `src/model/includedModelAccess.ts`                                    | `src/model`       | public                                                                                                        |
+| `src/agent/index/agentSource.ts`                                      | `src/agent`       | public (new)                                                                                                  |
+| `src/shared/schemas/account.ts`                                       | `src/shared`      | public (new) — schema only                                                                                    |
+| `src/controllers/account/accountPlane.ts`                             | `src/controllers` | public (new) — port + accessor; adds `tools → controllers` and `telemetry → controllers` to the edge baseline |
+| `src/shared/schemas/relayErrorEnvelope.ts`                            | `src/shared`      | public (new)                                                                                                  |
+| `src/shared/schemas/usageLog.ts`                                      | `src/shared`      | public (moved from `src/telemetry/UsageLogTypes.ts`)                                                          |
+| `src/shared/schemas/spendingStatus.ts`                                | `src/shared`      | public (unchanged)                                                                                            |
+| `src/controllers/texra/installTexraModelAccess.ts`                    | adapter           | **private**                                                                                                   |
+| `src/controllers/texra/installTexraRemoteAgents.ts` + `remoteAgents/` | adapter           | **private** (moved from `src/agent/remote/`)                                                                  |
+| `src/controllers/texra/installTexraAccount.ts`                        | adapter           | **private**                                                                                                   |
+| `src/controllers/texra/installTexraBackend.ts`                        | adapter           | **public** — the guarded import site                                                                          |
+
+---
+
+## 4. Two implementations
+
+| Port member                              | Hosted (`@texra/hosted`)                                                                                  | BYOK (nothing installed)                                  | UI under BYOK                                                                                                                                                 |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `hasIncludedModelAccess()`               | `true`                                                                                                    | `false`                                                   | Gates **model-routing** surfaces only — the included/personal radio, `included-*` model states. Account and catalog surfaces gate on their own port; see §6.2 |
+| `getUseIncludedModelAccess()`            | user preference in globalState                                                                            | `false`                                                   | model picker shows `missing-key` / `provider-key`, never `included-*`                                                                                         |
+| `canUseServerSideKeys()`                 | `ServerSideKeyService.canUseServerSideKeys()` (`:238-375`): tier + tier-config + expiry + quota auto-flip | `false`                                                   | —                                                                                                                                                             |
+| `getRelayBaseUrl(p)`                     | `${base}/functions/v1/relay/${p}${suffix}` from `RELAY_PATH_SUFFIXES` (`ServerSideKeyService.ts:46-54`)   | **throws** (unreachable behind the gates)                 | —                                                                                                                                                             |
+| `getAccessToken()`                       | CI relay token, else GoTrue session (`SupabaseClient.ts:200-221`)                                         | `null`                                                    | —                                                                                                                                                             |
+| `setUseIncludedModelAccess(b)`           | persists + clears caches + emits `includedModelAccessChanged`                                             | **throws** (unreachable)                                  | included/personal radio not rendered                                                                                                                          |
+| `capReasoningEffort()`                   | `capIncludedReasoningEffort` (`installTexraModelAccess.ts:30-48`), Max⇒HIGH / free⇒MEDIUM                 | identity                                                  | full effort available on the user's own key                                                                                                                   |
+| `RemoteAgentSource.isAvailable()`        | `SupabaseClient.canAccessRemoteAgentCatalog()`                                                            | `false`                                                   | team preflight takes its existing `'unavailable'` branch                                                                                                      |
+| `RemoteAgentSource.list()`               | PostgREST `remote_agents` query                                                                           | `[]`                                                      | agent list = local YAML only; no empty "remote" category (gated, §6)                                                                                          |
+| `RemoteAgentSource.loadDefinitionYaml()` | `get-agent-config` POST                                                                                   | **throws** (unreachable — no entry has `source:'remote'`) | —                                                                                                                                                             |
+| `AccountPlane.snapshot()`                | `ProfileMessageBuilder.ts:45-127` logic, moved                                                            | `SIGNED_OUT_ACCOUNT`                                      | profile message carries `authenticated: false`, null spend                                                                                                    |
+| `AccountPlane.submitUsage()`             | bearer + ky POST to `functions/v1/log-usage`                                                              | `{ kind: 'no-sink' }`                                     | `UsageLogService` logs once at `info` and stops its queue and timer                                                                                           |
+| `AccountPlane.signIn()`                  | VS Code `AuthenticationProvider` / Electron loopback / CLI device code                                    | `false`                                                   | no sign-in affordance exists to call it                                                                                                                       |
+
+**BYOK model-call path, already proven.** `resolveClientCredential`
+(`ModelHandler.ts:494-565`) computes `canRouteThroughRelay` from
+`getUseIncludedModelAccess()`, gets `false`, and falls through to
+`fetchApiKeyOrThrow` → `platform().secrets`. `resolveBaseUrl` never reaches
+`case 'serverSideKeys'` (`ProxyConfigResolver.ts:162-168`), so the deliberate
+throw stays unreachable. `src/model/apiProviders.ts` imports nothing but
+`PlatformSecrets`. `packages/agent/src/index.ts` ships this way today.
+
+**BYOK usage path.** `UsageMonitor.logToBackend` computes
+`usedRelay = usage.usageRoute === 'relay'` (`:277`), permanently `false`, so the
+awaited forced flush at `:301` never executes. `UsageMonitor` is not touched.
+
+**BYOK setup-agent path.** `getSetupAuthStatus` returns
+`{ authenticated: false, remoteAgentCatalogAvailable: false }` — the shape its
+callers already handle. Side benefit: the user's account email and plan stop
+being fed to the setup LLM as tool output (`src/tools/setup/platform.ts:122-150`
+→ `ProbeEnvironmentTool.ts:58`, `VerifySetupTool.ts:76`).
+
+---
+
+## 5. Enforcement
+
+Written against `eslint.config.mjs` as it exists. `AUTH_RESTRICTED_IMPORT_PATTERNS`
+(`:117-125`) applied at `:567-580` is the exact recipe; this copies it.
+
+**Add next to `AUTH_RESTRICTED_IMPORT_PATTERNS` (~line 117):**
+
+```js
+// Modules that speak to a specific hosted backend. Core zones ask the installed
+// ports (includedModelAccess / remoteAgentSource / accountPlane) instead; the
+// bindings live in src/controllers/texra/. `@auth/codex` and `@auth/constants`
+// are deliberately absent: Codex is a third-party subscription, and
+// AUTH_COMMANDS are VS Code command IDs, not endpoints.
+// ONE list. Both the static rule and the dynamic-import selector are derived
+// from it, so the two cannot drift — an earlier draft of this plan added
+// `@texra/hosted` to the static group only, leaving
+// `await import('@texra/hosted')` legal in every backend-free zone. That is
+// precisely the failure this boundary exists to prevent, so the list is the
+// single source of truth and neither consumer restates it.
+const BACKEND_MODULES = [
+  '@supabase/supabase-js',
+  '@auth/SupabaseClient',
+  '@auth/SupabaseSession',
+  '@auth/SupabaseAuthCoordinator',
+  '@auth/supabaseSessionTypes',
+  '@auth/TokenProvider',
+  '@auth/config',
+  '@auth/relayToken',
+  '@auth/serverKeys',
+  // The extracted hosted package. Without it the whole boundary is defeated
+  // the moment step 10 lands.
+  '@texra/hosted',
+];
+
+const BACKEND_BOUNDARY_MESSAGE =
+  'Backend-free zones must not import a hosted backend. Ask the installed ' +
+  'port instead (includedModelAccess / remoteAgentSource / accountPlane); ' +
+  'bindings belong in src/controllers/texra/.';
+
+const BACKEND_RESTRICTED_IMPORT_GROUP = {
+  // Each entry plus its subpaths.
+  group: BACKEND_MODULES.flatMap((m) => [m, `${m}/**`]),
+  message: BACKEND_BOUNDARY_MESSAGE,
+};
+
+const BACKEND_RESTRICTED_IMPORT_PATTERNS = [
+  BACKEND_RESTRICTED_IMPORT_GROUP,
+  ...HOST_LAYER_RESTRICTED_IMPORT_PATTERNS,
+];
+
+// `no-restricted-imports` cannot see `await import(...)`. One builtin selector
+// closes that hole without a custom rule, built from the SAME array. (The
+// single dynamic backend import in core, src/agent/index/remoteAgentMeta.ts:47,
+// is deleted in step 2; this stops it coming back.)
+const escapeForRegex = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const NO_DYNAMIC_BACKEND_IMPORT = {
+  selector: `ImportExpression[source.value=/^(${BACKEND_MODULES.map(
+    escapeForRegex,
+  ).join('|')})(\\/|$)/]`,
+  message: BACKEND_BOUNDARY_MESSAGE,
+};
+```
+
+**Add this block _before_ the `src/agent/core/**` block at `:552`** (flat config:
+a later block replaces the same rule wholesale, so ordering matters):
+
+```js
+// Backend-free zones. Core may ask whether included access, a hosted catalog,
+// or an account exists; only src/controllers/texra/ may answer.
+{
+  files: [
+    'src/agent/**/*.{ts,tsx,mts,cts}',
+    'src/model/**/*.{ts,tsx,mts,cts}',
+    'src/tools/**/*.{ts,tsx,mts,cts}',
+    'src/shared/**/*.{ts,tsx,mts,cts}',
+    'src/telemetry/**/*.{ts,tsx,mts,cts}',
+    'src/common/**/*.{ts,tsx,mts,cts}',
+    'src/controllers/**/*.{ts,tsx,mts,cts}',
+    'src/latex/**/*.{ts,tsx,mts,cts}',
+    'src/replacement/**/*.{ts,tsx,mts,cts}',
+    'src/eventBus/**/*.{ts,tsx,mts,cts}',
+    'src/hosts/**/*.{ts,tsx,mts,cts}',
+    'packages/agent/src/**/*.{ts,tsx,mts,cts}',
+  ],
+  ignores: ['src/controllers/texra/**', 'src/test-kernel/**'],
+  rules: {
+    'no-restricted-imports': [
+      'error',
+      {
+        paths: HOST_LAYER_RESTRICTED_IMPORT_PATHS,
+        patterns: BACKEND_RESTRICTED_IMPORT_PATTERNS,
+      },
+    ],
+    'no-restricted-syntax': ['error', NO_DYNAMIC_BACKEND_IMPORT],
+  },
+},
+```
+
+**And spread the group into the agent-core patterns** (`:110-116`), because that
+later block would otherwise override the backend ban for `src/agent/core/**`:
+
+```js
+const AGENT_CORE_RESTRICTED_IMPORT_PATTERNS = [
+  { group: ['@agent/modelHandlers', '@agent/modelHandlers/**'], message: '…' },
+  BACKEND_RESTRICTED_IMPORT_GROUP, // ← add
+  ...HOST_LAYER_RESTRICTED_IMPORT_PATTERNS,
+];
+```
+
+**Do not delete the `@supabase/supabase-js` dependency in this step.** An
+earlier draft of this plan said to drop it from `package.json:117` and
+`packages/agent/package.json:59` here. That is wrong and would break the build.
+The dependency is declared in exactly three manifests — root `package.json:117`,
+`packages/agent/package.json:59`, `packages/extension/package.json:1724` — and
+**neither `packages/desktop` nor `packages/cli` declares it at all**. The hosted
+implementation under root `src/auth/` (`SupabaseClient.ts`, `SupabaseSession.ts`)
+still imports it until step 10, and an import originating in root `src/` does not
+resolve through the extension's sibling `node_modules`. Deleting the root
+declaration in a separately-landed step-4 commit therefore fails the desktop and
+CLI builds.
+
+The dependency moves with the implementation, in step 10, or not at all. Until
+then the lint block is what enforces the boundary: a _declared_ dependency that
+no backend-free zone is permitted to import is the correct intermediate state,
+not a cosmetic one.
+
+**Second gate, free:** regenerate
+`config/ratchets/architecture-edges-baseline.json` after step 4 so
+`agent → auth`, `tools → auth`, and `telemetry → auth` are gone. Any
+reintroduction then fails `subsystemEdgeRatchet.vitest.ts` as a new edge.
+
+**Third gate, free:** every new export lands with a consumer in the same PR;
+`npm run check:dead-code-ratchet` enforces it against
+`config/ratchets/knip-baseline.json`.
+
+---
+
+## 6. UI decoupling
+
+Two rules: **no UI surface consumes a backend response shape**, and **no UI
+surface exists that a BYOK build cannot act on**.
+
+### 6.1 Response shapes → view models
+
+| Surface                                                              | Today                                                                                     | After                                                                                                                                                                    |
+| -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `settingsView/frontend/components/profile/RelayQuotaMeter.ts:99-135` | `@property status` **is** the `/tier-config` `SpendingStatus` object                      | binds to `AccountSnapshot.spendingStatus`, a client-owned field of a client-owned snapshot; `spendingQuotaState()` (`spendingStatus.ts:32-52`) still supplies the policy |
+| `settingsView/frontend/tabs/AccountTab.ts:59-69`                     | 8 props, 7 of them hosted concepts                                                        | one `account: AccountSnapshot \| null` prop                                                                                                                              |
+| `packages/cli/src/chat/tui/panes/StatusBar.tsx:168-176`              | Ink render component calls `getServerSideKeyService().getSpendingStatus()` on an interval | reads `accountPlane().snapshot()`; the component stops importing auth                                                                                                    |
+| `progressView/.../messageFormatters.ts:80-92,105-153`                | renders `rawErrorBody` verbatim as `<pre>` JSON and a `banner-details--relay-error` class | `rawErrorBody` stays in the opt-in details block only; `isRelayError` becomes a neutral "routed through included access" label                                           |
+| `packages/cli/src/runtime/apiStatus.ts:200`                          | interpolates the raw thrown error into a status line                                      | maps `UsageSubmitResult`/snapshot state to fixed copy, matching the good branch already at `:190-193`                                                                    |
+| `packages/extension/src/commands/auth/authCommands.ts:75-81`         | shows `SupabaseClient.getInitError()` raw in a toast                                      | mapped message, matching the good branch at `:53-61`                                                                                                                     |
+
+Desktop needs no separate work: `packages/desktop/src/renderer/main.ts:53-54`
+imports `@settingsView/frontend` and `@webview/frontend` wholesale, so one fix
+covers both hosts.
+
+### 6.2 Dead affordances → gated per facet, not on one proxy
+
+**Correction.** An earlier draft of this section gated every account surface on
+`hasIncludedModelAccess()`. That makes one facet the source of truth for a
+different facet. The three ports install independently, so a backend that offers
+accounts but not included model access — or a partially installed one — would
+have its entire account UI hidden while being perfectly functional. Model
+routing is not evidence about account capability.
+
+Each port therefore answers for its own surfaces:
+
+| Surface                                                                                | Gate                                |
+| -------------------------------------------------------------------------------------- | ----------------------------------- |
+| Included/personal radio, `included-*` model states, quota copy                         | `hasIncludedModelAccess()` (Port A) |
+| Account tab, LoginBanner, `/login` `/auth` `/api`, onboarding sign-in choice, sign-out | `hasAccountPlane()` (Port C)        |
+| Remote-agent category, hosted prompt list                                              | `hasRemoteAgentSource()` (Port B)   |
+
+Each is `installed !== null` for its own port — the same one-line shape Port A
+already uses, so this costs three predicates rather than one, not new machinery.
+
+The alternative the maintainer raised — one atomic capability bundle installed
+as a unit, with all three gates derived from it — is simpler to reason about and
+worth taking **if** the three ports will always be installed together. Decide
+this before step 1, because it determines whether `installTexraBackend.ts`
+installs three things or one. Recommendation: keep them separate. A self-hosted
+or third-party backend implementing accounts without a relay is the exact case
+this whole exercise is meant to make possible, and an atomic bundle forecloses
+it.
+
+Whichever is chosen, the gate must be a canonical fact about the facet being
+gated. Do not gate on `authenticated`. `ModelsTab.ts:120-128,163-167` is the only surface that
+gates correctly today, and even it keys on the wrong predicate — under BYOK
+`authenticated` is permanently `false`, which reads as "signed out" rather than
+"no such thing here".
+
+| Surface                                                                                                                                                                                                           | Mechanism needed                                                                                                                                                                                                                                                              |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Account tab — a literal member of `SETTINGS_TAB_ORDER` (`src/shared/schemas/settingsView/data.ts:75-88`) and of `SETTINGS_TAB_GROUPS` (`:128-137`)                                                                | **new**: a capability predicate on tab entries, filtered once where the nav is built. The array is `as const` and doubles as the `SettingsTabName` union, so filter at build time, don't edit the tuple                                                                       |
+| `webview/frontend/components/LoginBanner.ts:87-111` "Researcher Access Program" — shown whenever `!authStatus.authenticated` (`MainViewStartupController.ts:82-88`), i.e. to every BYOK user forever              | existing visibility flag; add **`hasAccountPlane()`** (Port C, not Port A — sign-in is an account fact, not a relay fact) and sequence after step 3                                                                                                                           |
+| `ONBOARDING_CHOICE_SIGN_IN` (`src/shared/copy/onboarding.ts:22-26`) rendered by `OnboardingWelcomeCard.ts:309-323`, `setupAssistantCommand.ts:95-99`, and `packages/cli/src/onboarding/runOnboarding.tsx:596,663` | make the choice list capability-derived; `onboardingFunnel.ts:30-38` is already credential-agnostic                                                                                                                                                                           |
+| CLI `/login` `/logout` `/auth` `/api` (`registerBuiltins.tsx:551-601`) and `LOGIN_FORM_ITEMS` (`LoginForm.tsx:15-35`)                                                                                             | predicate at registration; `LOGIN_FORM_ITEMS` becomes derived, not a frozen literal                                                                                                                                                                                           |
+| `texra auth` subcommand tree (`packages/cli/src/commands/auth.ts`) and `texra setup-token` (`commands/relayTokens.ts`)                                                                                            | omit from the command tree. The NDJSON kinds `'auth-status'`, `'relay-usage'`, `'relay-token'`, `'relay-token-info'`, `'relay-token-revoked'` (`src/schemas/cliOutput.ts:44-51`) stay in the union — removing them breaks a published contract; they are simply never emitted |
+| VS Code walkthrough step (`packages/extension/package.json:1141-1149,1167`)                                                                                                                                       | **manifest JSON — cannot be runtime-gated.** Rewrite the copy so it does not promise Researcher Access or claim the orchestrator requires it                                                                                                                                  |
+| `texra.telemetry.enabled` (`packages/extension/package.json:745-750`, default `true`, description entirely about sending data to TeXRA)                                                                           | default `false` in the public build, description rewritten; the hosted build contributes the plan-accounting note                                                                                                                                                             |
+| `src/shared/copy/promoNotice.ts:15-49` — sponsor promo plus `github.com/sponsors/texra-ai` (`:41`) and `buymeacoffee.com/texra.ai` (`:44`)                                                                        | **delete from `src/shared/`.** Not a port problem: a fork must not ship upstream's funding links. Consumers: `LoginBanner.ts:7`, `ApiAccessSection.ts:19,73-94`                                                                                                               |
+| `packages/desktop/src/main/desktopNavigationPolicy.ts:17-21` — allowlists `texra.ai` for OAuth                                                                                                                    | the allowlist entry becomes a value the installed `AccountPlane` contributes, or a self-hosted backend's redirect is silently blocked                                                                                                                                         |
+
+---
+
+## 7. Migration
+
+Ten steps in three phases. "Parallel" means it can land concurrently with other
+steps in the same phase.
+
+### Phase 1 — the core cut (no user-visible change)
+
+| #     | Change                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | Files                                     | Proof                                                                                                                                                          | Parallel                 |
+| ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| **0** | **Two deletions, no port.** (a) `setupLaunch.ts:49-58`: replace `getServerSideKeyService()` with `includedModelAccess()`; `canUseServerSideKeysForModel(m)` → `(await canUseServerSideKeys()) && canUseModelSync(m)`, verbatim what `ServerSideKeyService.ts:376-380` does. (b) `SettingsModelSelectionController.ts:239-254`: delete the `MAX_TIER→'high' / FREE_TIER→'medium'` switch, call `capReasoningEffort` — removing the second of two independent encodings of one pricing policy (the other is `installTexraModelAccess.ts:30-48`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | 2 edits, both smaller                     | `npm run lint && npm test`; two `@auth/*` imports gone                                                                                                         | ✅ ships alone, first    |
+| **1** | **Widen Port A.** Add `setUseIncludedModelAccess` + `hasIncludedModelAccess()`; implement in `installTexraModelAccess.ts`. Rewrite the 7 host `setUseIncludedModelAccess` bindings and the `getUseIncludedModelAccess` / `getSpendingStatus` reads at `StatusBar.tsx:168-176`, `apiAccessMode.ts`, `secretManager.ts:55-62` (which also gains a missing `await` — today `keyChecks.some(Boolean) \|\| getServerSideKeyService().canUseServerSideKeys()` makes `anyApiKeyExists()` unconditionally true). **Land `hasIncludedModelAccess()`'s consumers in this PR** or the dead-export ratchet correctly fails it — use the LoginBanner and CLI `/login` gates from step 7                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | ~14 edits                                 | `getServerSideKeyService` importers drop from 14 to ≤4; ratchet green                                                                                          | after 0                  |
+| **2** | **Port B.** New `src/agent/index/agentSource.ts`. `git mv src/agent/remote/ src/controllers/texra/remoteAgents/`; add `installTexraRemoteAgents.ts` and fold the `tier !== ULTRA_TIER` prompt gate (`SettingsRemoteAgentPromptController.ts:24`) into its `loadDefinitionYaml`. Rewire `remoteAgentMeta.ts:46-74` (**deleting the `await import('@agent/remote/remoteAgentList')` at `:47`** — the one dynamic backend import in core), `agentLoad.ts:133-138`, `teamCatalogPorts.ts:27`, `agentRegistry.ts:206,552-563`, and both hosts' view-remote-prompt handlers (`settingsView/handlers/agentHandlers.ts:17`, `desktop/desktopAgentSettingsController.ts:5`). **Delete `SettingsRemoteAgentPromptController`** rather than shrink it to a pass-through. **Do not merge the remote branch with the adjacent inline branch at `agentLoad.ts:110-130`** — inline applies `toToolUseSettings` and an `agentCategory` default the remote path does not; merging is a silent behavior change and belongs in its own PR with its own test                                                                                                                              | 1 new, 5 moved, 1 deleted, 6 edits        | `RemoteAgentLoaderSchemaFallback.vitest.ts` extended first; `toolRegistryCycle.vitest.ts` now asserts `agentRegistry` reaches no backend module                | after 1                  |
+| **3** | **Port C.** Move `src/telemetry/UsageLogTypes.ts` → `src/shared/schemas/usageLog.ts` (pure move; it is a wire contract). New `src/shared/schemas/account.ts` (schema only) **and** `src/controllers/account/accountPlane.ts` (port + installer + accessor) — see §3; do **not** create a single `src/shared/account.ts`, which is the placement §3 rejects. Regenerate `architecture-edges-baseline.json` in this step for the two new `→ controllers` edges. New `installTexraAccount.ts` carrying `ProfileMessageBuilder.ts:45-127` **including its conditional-priming comment at `:107-113`** — priming only when included access is on, because `canUseServerSideKeys()` otherwise blanks the spend snapshot. Replace the three bare `catch {}` (`:94-98`, `:124-127`, `:132-135`) with `logger.warn` + a surfaced `sessionProblem: 'unavailable'`; today a backend outage renders as "free plan, no usage". Drop `tierConstants` / `accessExpiresAt` / `remoteAgents` from `UpdateProfileMessageSchema`. Rewire `ProfileMessageBuilder`, `src/tools/setup/platform.ts:122-150`, `UsageLogService` (`{kind:'no-sink'}` ⇒ log once at `info`, stop queue + timer) | 2 new, 1 moved, 1 adapter, ~6 edits       | webview + CLI render from `AccountSnapshot`; `UsageMonitor` untouched                                                                                          | after 1; parallel with 2 |
+| **4** | **Pin the boundary.** `src/controllers/texra/installTexraBackend.ts` calls the three installers; replace the one `installTexraModelAccess()` line at `extension.ts:252`, `desktop/platform/index.ts:300`, `cli/initPlatform.ts:295`. Add the lint blocks from §5. **Do not touch the `@supabase/supabase-js` declarations** — root `src/auth/` still imports the package until step 10, and neither `packages/desktop` nor `packages/cli` declares it, so removing the root entry here fails both host builds (see the note under §5). Regenerate `architecture-edges-baseline.json`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | 1 new, 3 one-liners, 1 config, 1 baseline | `npm run lint` fails on a planted `import { SupabaseClient } from '@auth/SupabaseClient'` in `src/agent/` **and** on a planted `await import(...)` of the same | after 2 and 3            |
+| **5** | **Relay error envelope.** New `src/shared/schemas/relayErrorEnvelope.ts` with `_relay: z.string()`. Rewrite `relayDetection.ts:55-99` as one `safeParse`; delete `isRelayMonthlyLimitMessage` (`:112-118`) and the CLI string fallback (`approvalPolicy.ts:86-95`). Add the major-mismatch error. Point `relay/index.ts:225-245`'s `jsonError` at the same schema                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | ~5 edits + 1 edge function                | a golden fixture captured from `remote.texra.ai` parses; a `_relay: '2.0.0'` fixture raises the named mismatch error                                           | ✅ independent of 1-4    |
+
+### Phase 2 — the product cut (this is what makes BYOK a product)
+
+| #     | Change                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | Files                              | Proof                                                                                                                                                                      | Parallel                                 |
+| ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| **6** | **Package the hosted prompts.** The 21 YAMLs in `prompts/agents/remote/` (16 top-level + 5 under `Lean4/`) are in HEAD and `prompts/README.md:7-9,27-28` declares them the public source of truth that production storage may not own. They are _not_ in the VSIX. Copy or build-step them into `packages/extension/resources/tool_use_agents/` and `resources/agents/` so `orchestrator`, `generic`, `devise`, `apply`, `criticize`, `simplifier`, `progressCheck`, `search` and the Lean line resolve locally; keep `scripts/sync-remote-agents.mjs` pointed at `prompts/` as the SSOT. Hosted catalog entries then _override by name_, never _supply exclusively_ | packaging config + resource wiring | the default `STARTER` team (`agentPresets.ts:108`, needs `orchestrator`) applies cleanly with nothing installed — no "Sign in to TeXRA" modal (`agentHandlers.ts:430-445`) | ✅ independent of all code steps         |
+| **7** | **Gate the affordances** per §6.2: settings-tab predicate, LoginBanner, onboarding choice list, CLI command registration, walkthrough copy, telemetry default, delete `promoNotice.ts`                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | ~15 UI files + manifest            | boot all three hosts without `installTexraBackend()`: zero sign-in CTAs, zero upgrade prompts, zero dead commands                                                          | after 1 (needs `hasIncludedModelAccess`) |
+| **8** | **Make the guarded install real.** `installTexraBackend.ts` becomes one `await import('@texra/hosted')` guarded on `ERR_MODULE_NOT_FOUND`, logging at `info` ("no hosted services package in this build — running bring-your-own-key") and rethrowing anything else. **Resolve the bundler question first** (§9, R2): all three hosts are esbuild/Vite-bundled, so an absent optional package must be marked external or the guarded import is a build-time failure, not a runtime one                                                                                                                                                                               | 1 file + 3 build configs           | public CI installs with `--no-optional`, builds all three hosts, boots each                                                                                                | after 4 and 7                            |
+
+### Phase 3 — the repo cut
+
+| #      | Change                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | Files                                | Proof                                                                | Parallel |
+| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ | -------------------------------------------------------------------- | -------- |
+| **9**  | **Thin the host auth surfaces.** `packages/extension/src/frontend/auth/SupabaseAuthProvider.ts` keeps the VS Code `AuthenticationProvider` shell and delegates to `accountPlane().signIn/signOut/onChange`; `desktopSupabaseAuth.ts` keeps its loopback window; `packages/cli/src/runtime/supabaseAuth.ts` keeps its terminal prompts. The protocol (GoTrue, PKCE, device code, token refresh) and the five `clearAllCaches({resetQuotaFlip:true})` sequences move behind `onChange`. **Re-read `src/auth/authFlowEffects.ts` first** — it documents why the three were deliberately not unified. Highest regression risk in the plan; lowest test coverage | 3 host modules + 3 CLI runtime files | manual sign-in/sign-out on each host, twice each                     | after 8  |
+| **10** | **Extract `texra-hosted`.** `git filter-repo` `supabase/**`, `src/auth/{SupabaseClient,config,SupabaseSession,SupabaseAuthCoordinator,supabaseSessionTypes,TokenProvider,relayToken}.ts`, `src/auth/serverKeys/**`, `src/controllers/texra/**` (except `installTexraBackend.ts`), `packages/cli/src/runtime/{relayUsage,relayTokensClient,supabaseAuthDeviceCode}.ts`, and the 6 cross-importing test files (§8)                                                                                                                                                                                                                                            | repo surgery                         | public `npm test` green; public build boots BYOK; private CI deploys | after 9  |
+
+---
+
+## 8. Repo split
+
+### Decision: `supabase/` moves private. Recommended.
+
+`supabase/README.md:1-17` already states the intent and the completion criteria
+("the canonical TeXRA Cloud source **until** a maintainer selects and creates a
+private infrastructure repository", with a five-point move protocol). The
+argument for keeping it public rests on "no secrets", which is true —
+every credential is `Deno.env.get(...)` — but tests the wrong thing.
+`supabase/functions/_shared/emailPolicy.ts:3-46` is a live anti-abuse gate: a
+36-domain disposable-mailbox blocklist annotated "observed farming the
+Researcher Access Program", a separate privacy-relay blocklist, and
+`MIN_GITHUB_ACCOUNT_AGE_DAYS = 30`. Publishing it hands an attacker the exact
+list to route around and the exact threshold to wait out.
+`relay/requestGate.ts` and `relay/enforcement.ts` compound it. Nothing about
+the tier ladder or the publishable key being already-compiled-into-the-bundle
+applies to enforcement heuristics.
+
+**The honest cost, measured:** 36 of 81 commits touching `supabase/` also touch
+`src/` or `packages/` (~44%). Backend work becomes cross-repo PR pairs for that
+fraction. That is a real, recurring tax, accepted for the abuse-control reason
+above.
+
+### What moves
+
+| To `texra-hosted` (private)                                                                                                                                                     | Why                                                                                                                                               |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `supabase/functions/**`, migrations, `config.toml`                                                                                                                              | enforcement logic + deploy plane                                                                                                                  |
+| `src/auth/{SupabaseClient,config,SupabaseSession,SupabaseAuthCoordinator,supabaseSessionTypes,TokenProvider,relayToken}.ts`, `src/auth/serverKeys/**`                           | `config.ts:119-147` carries `UserTierSchema`, tier constants, `RELAY_TIER_SPENDING_LIMITS` — plan pricing with no public consumer after steps 0-3 |
+| `src/controllers/texra/**` except `installTexraBackend.ts`                                                                                                                      | the adapters                                                                                                                                      |
+| `packages/cli/src/runtime/{relayUsage,relayTokensClient,supabaseAuthDeviceCode}.ts`                                                                                             | PostgREST `usage_logs` queries, relay-token minting, device-code client                                                                           |
+| `src/test-kernel/supabase/**` (4 files), `src/test-kernel/auth/EmailPolicy.vitest.ts`, and the `relayCiToken` path assertion in `src/test-kernel/cli/RelayTokens.vitest.mts:81` | they cross-import Deno source (`../../../supabase/functions/…`)                                                                                   |
+
+**The test list above is the Deno-cross-importing suites only, and it is not
+sufficient.** Measured against HEAD, **36 suites** reference the modules this
+step deletes (`@auth/SupabaseClient`, `@auth/SupabaseSession`,
+`@auth/SupabaseAuthCoordinator`, `@auth/TokenProvider`, `@auth/relayToken`,
+`@auth/serverKeys`). Extracting the implementations without addressing them
+leaves 36 suites importing files that no longer exist, so the promised green
+`npm test` on the public repo is not achievable as step 10 is currently written.
+
+They split into two groups, and the distinction decides the work:
+
+- **Direct implementation suites** — `auth/SupabaseClient.vitest.ts`,
+  `auth/SupabaseSessionLifecycle.vitest.ts`, `auth/ServerSideKeyService.vitest.ts`,
+  `auth/ServerSideKeyServiceSingleton.vitest.ts`, `auth/SupabaseAuthProvider.vitest.ts`,
+  `auth/TierService.vitest.ts`, `agent/remote/RemoteAgentLoaderSchemaFallback.vitest.ts`.
+  These test the hosted implementation itself and **move private with it**.
+- **Consumer suites that reach for the Supabase module only to mock it** — the
+  bulk of the remaining ~29, across `agent/modelHandlers/`, `cli/`, `desktop/`,
+  `controllers/`, `telemetry/`, `settings/`. These are the real signal: a
+  consumer test that must mock `@auth/SupabaseClient` is proof its subject is
+  still coupled to the backend rather than to a port.
+
+That reframes the sequencing. **Steps 1-3 are not complete until these suites
+mock the installed port instead of the Supabase module.** Treat the count of
+consumer suites still naming an `@auth/Supabase*` specifier as the readiness
+metric for step 10: when it reaches zero, extraction is mechanical; while it is
+29, step 10 is blocked regardless of how the implementation files move. Add the
+check to CI as a ratchet so the number cannot climb back.
+
+| Stays public                                                                                | Why                                                                                                                                       |
+| ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `prompts/agents/remote/` (21 YAMLs)                                                         | `prompts/README.md:7-9` declares them the public home; production storage may copy but not own them. Step 6 packages them into the client |
+| `src/auth/codex/**`, `src/auth/core/**`                                                     | third-party subscription plane                                                                                                            |
+| The three port files + `src/shared/schemas/{relayErrorEnvelope,usageLog,spendingStatus}.ts` | the contract                                                                                                                              |
+| `docs/supabase/remote-agents.config.json`, `scripts/sync-remote-agents.mjs`                 | catalog placement metadata; the sync target moves, the source does not                                                                    |
+
+### Mechanics
+
+**History extraction.** `git filter-repo --path supabase --path src/auth/... `
+onto a fresh `texra-hosted`, then a _second_ `filter-repo --invert-paths` pass
+on the public repo. Both must precede the first public push — after
+publication, a rewrite invalidates every clone and cannot recall what was
+served. Also rotate the legacy Supabase anon JWT visible in history before the
+publishable-key rename.
+
+**Contract ownership — and the module-identity problem underneath it.**
+
+The **public** repo owns `src/shared/schemas/relayErrorEnvelope.ts`,
+`usageLog.ts`, `spendingStatus.ts`, and the three port files. `@texra/hosted`
+depends on the public repo, never the reverse.
+
+That is necessary but not sufficient, and an earlier draft glossed the gap: a
+private package cannot _register itself_ against a public singleton unless both
+sides resolve to the **same module instance** at runtime. Pinning a repo SHA in
+private CI gives you the same source text, not the same instance. If the host
+bundles `@agent/*` from source via path aliases while `@texra/hosted` imports a
+built copy, `installAccountPlane()` writes into one module object and
+`getAccountPlane()` reads another — the port reads as "not installed" and the
+whole product silently degrades to BYOK.
+
+**`packages/agent` is most of the answer and is further along than the plan
+assumed.** `@texra-ai/agent` already: declares a three-entry `exports` map
+(`.`, `./schemas`, `./node`), ships `files: ["dist", "LICENSE.txt"]` with
+`publishConfig.access: "public"`, re-exports selected `@agent/*`, `@tools/*` and
+`@shared/schemas` symbols through `src/index.ts` and `src/schemas.ts`, and
+carries a real build pipeline including
+`scripts/rewrite-declaration-aliases.mjs` — the precise machinery an importable
+contract package needs to emit alias-free `.d.ts`. It has zero in-repo consumers
+and its publish job is disabled behind `if: ${{ false && ... }}`
+(`release.yml:158`), so reviving it is a decision about intent, not a build from
+scratch. Adding the port modules and contract schemas to its `exports` map is
+the natural step.
+
+**But do not solve identity with a shared singleton at all.** The cheaper answer
+is already the plan's own idiom: the private package exports **factories**, and
+the public composition root installs them.
+
+```ts
+// @texra/hosted exports functions, registers nothing.
+export function createTexraAccountPlane(deps): AccountPlane;
+
+// The public host wires it — the only place that names the backend.
+installAccountPlane(createTexraAccountPlane(deps)); // src/controllers/texra/
+```
+
+The registry lives in exactly one place (the public repo), is written by exactly
+one caller (the host's composition root), and the private package never reaches
+into public module state. Duplicate instances then cannot cause a silent
+mis-registration, because there is only ever one writer. `@texra/hosted` needs
+the public package only as a **`peerDependency`** for its types.
+
+**Open for the maintainer:** whether `@texra-ai/agent` becomes that public
+package, or a second narrower one is minted for the contract alone. Reviving it
+contradicts nothing in `CLAUDE.md:37` — "there is no `@texra/core` package"
+stays literally true — but it does mean the SDK surface and the backend contract
+share a release cadence. Resolve this before step 10; it does not block steps
+0-9, all of which are single-repo. This inverts today's situation, where `src/auth/config.ts:110-113`
+admits in a comment that "the relay edge function cannot import this
+client-side module" and parity is enforced by a Vitest file.
+
+**Versioning.** `RELAY_CONTRACT_MAJOR` in the public schema; the relay already
+stamps `_relay: '1.10.0'` on every error body and `/providers` response
+(`relay/index.ts:127,234,305`), so the transport for a version handshake is
+deployed and free. Additive fields (`.nullish()`) are a minor bump old clients
+ignore. A breaking change is a major bump served at a version-prefixed relay
+path — `ProxyConfigResolver.resolveBaseUrl`'s `case 'serverSideKeys'`
+(`:162-168`) is the one client-side place that path is chosen.
+`parseRelayErrorBody` raises a named "this client is too old for this relay"
+error on major mismatch instead of misclassifying.
+
+**Drift prevention.** `@texra/hosted` pins a public-repo SHA; its CI runs the
+public test suite plus the relay suites. A `contract` label on public PRs
+touching `src/shared/schemas/relay*` or the three port files triggers a
+private-repo CI run. Being honest: until an SDK surface exists (CLAUDE.md:
+"There is no `@texra/core` package"), drift is caught **one repo away from
+where it is introduced**. That is the single largest recurring cost of the
+split and it does not go away by wishing.
+
+**Public CI against a contract it cannot deploy.** Three jobs, none needing
+deploy credentials:
+
+1. `npm run test:contract` — Vitest replaying golden fixtures in
+   `config/fixtures/relay/*.json` through `RelayErrorBodySchema` and
+   `TierModelConfigSchema`. Committed, so a credential-less fork gets full
+   coverage.
+2. A **scheduled** (not per-PR) job regenerating those fixtures against
+   `remote.texra.ai` with a CI relay token. Drift between the deployed relay and
+   the checked-in contract fails nightly, never a contributor's PR.
+3. `npm run build && npm test` with `--no-optional`, booting all three hosts —
+   otherwise "the open-source client works standalone" becomes an untested
+   claim, which is the same failure mode the anti-silent-degradation rule
+   exists to prevent.
+
+**What the private repo does _not_ need:** a copy of the parity tests'
+`llm-zoo` version handshake. `RelaySharedConfigParity.vitest.ts:97-161` reads
+`pnpm-lock.yaml`, installed `node_modules/llm-zoo/package.json`, and
+`supabase/functions/relay/deno.json` **in one process**; it is not portable
+across repos in any direction. After the split both sides of that comparison
+live in `texra-hosted`, so the test becomes intra-repo — strictly better than
+today's cross-tree import. The two tier-constant parity assertions
+(`:51-67`) become structurally unnecessary once `config.ts` and `models.ts`
+are in the same repo.
+
+---
+
+## 9. Risks and open questions
+
+### Decisions needed before step 1
+
+| #      | Decision                                                                      | Options                                                                                                                                                                                                                                                                                 | Recommendation                                                                                                                                                                                                                                        |
+| ------ | ----------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **D1** | Does `supabase/` move private?                                                | (a) private — protects `emailPolicy.ts` / `requestGate.ts` / `enforcement.ts`, costs ~44% of backend commits becoming PR pairs; (b) public — zero split cost, publishes the abuse-control design                                                                                        | **(a)**, per `supabase/README.md:1-17` and the enforcement-logic argument in §8                                                                                                                                                                       |
+| **D2** | Do the 21 hosted prompts ship in the client?                                  | (a) ship — `prompts/README.md:7-9` already declares them public SSOT, and 5 of 6 built-in teams need them (`agentPresets.ts:108,134,168,205,236`); (b) keep hosted-only and rewrite the presets so hosted agents are purely additive                                                    | **(a)**. They are already public; (b) means the default `STARTER` team is broken in the OSS build for the sake of gating prompts anyone can read                                                                                                      |
+| **D3** | Where does `AccountPlane` live?                                               | one file in `src/shared/` vs split schema/runtime                                                                                                                                                                                                                                       | **Split**: `AccountSnapshotSchema` → `src/shared/schemas/account.ts`, runtime port + accessor → `src/controllers/account/`. Accept the two new ratchet edges and regenerate the baseline; the ratchet records current edges, not architectural intent |
+| **D4** | Does `installTexraBackend.ts` survive review?                                 | (a) keep — 3 callers, real logic (guarded import, typed fallback), and it _replaces_ an existing call rather than adding a layer; (b) delete — each composition root does its own guarded import, ~15 duplicated lines across 3 packages, and the lint `ignores:` glob loses its anchor | **(a)**, but it is the one file in this plan that adds rather than removes. If rejected, nothing else changes                                                                                                                                         |
+| **D5** | Is `src/controllers/modelAccess/` → `src/controllers/texra/` worth the churn? | 3 host imports + the lint glob                                                                                                                                                                                                                                                          | **Optional.** Only justification: a lint exemption should name what it exempts. If declined, keep `modelAccess/` and substitute the glob                                                                                                              |
+| **D6** | Public telemetry default                                                      | `texra.telemetry.enabled` currently defaults `true` with a description about sending data to TeXRA (`packages/extension/package.json:745-750`)                                                                                                                                          | **Default `false`** in the public build. In a repo people will read carefully this is a privacy problem regardless of the port                                                                                                                        |
+
+### Risks
+
+| Risk                                                                                                                                                                                                                                                                                                  | Where    | Mitigation                                                                                                                                                                                                                                                                                                              |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **R1 — `agentLoad`'s remote branch changes behavior.** `agentLoad.ts:133-138` today trusts `RemoteAgentLoader` to have already resolved tools, and skips the `inherits` pipeline entirely                                                                                                             | step 2   | Reproduce `RemoteAgentLoader.ts:47-76` line for line at the new call site. Extend `RemoteAgentLoaderSchemaFallback.vitest.ts` **before** the move. Explicitly do not merge with the inline branch                                                                                                                       |
+| **R2 — the guarded optional import may not survive bundling.** All three hosts are esbuild/Vite-bundled; a bare `await import('@texra/hosted')` of an absent package is a _build-time_ resolution failure unless marked external, and marking it external means it is not bundled when present either | step 8   | Resolve before step 8, not during. Prototype both host builds with and without the package. Fallback: ship two build configs rather than one conditional import                                                                                                                                                         |
+| **R3 — the BYOK build rots silently.** Nobody at TeXRA runs it daily                                                                                                                                                                                                                                  | ongoing  | CI job 3 in §8 is not optional. If it is skipped, goal (b) is an untested claim                                                                                                                                                                                                                                         |
+| **R4 — `Port C` reads as a pass-through.** `AccountSnapshot` overlaps `UpdateProfileMessage`                                                                                                                                                                                                          | step 3   | It shrinks the message by three verified-dead fields and serves three consumers in three zones (`src/controllers/`, `src/tools/`, `packages/cli/`). If `ProfileMessageBuilder` is later folded into the adapter, the port collapses to one consumer — accept that outcome and inline it rather than defending the layer |
+| **R5 — step 9 has the worst coverage in the repo.** Three host auth modules, deliberately not unified (`src/auth/authFlowEffects.ts:1-9`)                                                                                                                                                             | step 9   | Manual sign-in/sign-out on each host, twice. Do not bundle with step 10                                                                                                                                                                                                                                                 |
+| **R6 — plan-accounting semantics.** `log-usage` is on the model-call critical path; a replacement backend must accept an awaited flush per relay round or its cap semantics change                                                                                                                    | contract | Documented in `UsageMonitor.ts:296-300` and now in the port docstring. Not solvable, only disclosable                                                                                                                                                                                                                   |
+| **R7 — `_relay` mis-parse.** A schema declaring `_relay: z.literal(true)` silently fails to parse every relay error, losing quota and rate handling                                                                                                                                                   | step 5   | The schema in §3 declares `z.string()`, matching `relay/index.ts:127,234`. A golden fixture captured from production is the test                                                                                                                                                                                        |
+
+### Open questions
+
+- **Who is the `AccountPlane` for in a third-party build?** A self-hosted
+  backend must still speak GoTrue for sessions (`SupabaseSession.ts` semantics
+  leak through `signIn`'s contract) and must reproduce the per-provider path
+  suffixes in `ServerSideKeyService.ts:46-54`. This plan makes that
+  _documented and type-checked_ rather than reverse-engineerable — full
+  transport pluggability (swappable auth protocol, swappable cap mechanism) is
+  a second project.
+- **`AGENT_SOURCE.REMOTE` in the OSS build.** Step 2 leaves the enum member
+  with zero entries. Step 7's settings gating must hide the empty category or
+  the agent list shows a phantom "remote" group.
+- **Trademark and branding.** `installTexraBackend` and `src/controllers/texra/`
+  name the vendor in the public tree. Fine as an install site; check it against
+  whatever the licensing decision in
+  `docs/proposals/2026-07-29-open-source-readiness.md` §1.4 lands on.
+
+### Layers cut from this plan
+
+Named because "no hollow abstraction" is a rule, not a preference:
+
+- **A fourth "usage" port** — folded into `AccountPlane.submitUsage`.
+  `UsageLogService.flush()` is its only caller; a standalone port would be a
+  single-caller extraction.
+- **`AccountSession` as a separate port** — `signIn`/`signOut`/`onChange` fold
+  into `AccountPlane`. Two ports installed from the same file at the same moment
+  with two and three members is a split for symmetry's sake.
+- **`canUseServerSideKeysForModel` on Port A** — deleted, not added.
+  `ServerSideKeyService.ts:376-380` proves it composes from two existing
+  members.
+- **`SettingsRemoteAgentPromptController`** — after step 2 it would be ~15 lines
+  of call-the-port-and-map-an-error. Deleted, its two host callers
+  (`agentHandlers.ts:58`, `desktopAgentSettingsController.ts:116`) call the port
+  directly.
+- **A `src/ports/` or `src/backend/` directory** — ports live next to their
+  consumers, as `includedModelAccess.ts` lives in `src/model/`. A ports folder
+  would be the hollow layer.
+- **A generalized custom ESLint rule** — the existing
+  `no-vscode-import-in-free-zones` (`eslint.config.mjs:255-318`) could be
+  parameterized, but `no-restricted-imports` + one `no-restricted-syntax`
+  selector covers the same five syntactic forms with zero new machinery.
+- **A `Platform` port for the backend** — `src/platform/platform.ts:29-35`
+  documents that logging deliberately did _not_ become a port; the backend is
+  orthogonal to host identity (all three hosts install the same one), and
+  adding it would force every fake in `FakePlatform.ts` to carry it.

--- a/docs/proposals/2026-08-01-directory-organization.md
+++ b/docs/proposals/2026-08-01-directory-organization.md
@@ -1,0 +1,710 @@
+# Directory organization before open-sourcing
+
+Status: partially executed, across separate pull requests.
+
+Items **4, 5, 6, 7** and **11** are implemented on `split/relocations`, and item
+**10**'s real defect (trace-viewer's undeclared dependencies) together with the
+`@types/*`, `@logger` and `@telemetry` alias deletions from §2 are on
+`split/alias-dependency-fixes`. This document carries no code changes itself.
+
+Item 10's `tsconfig` change was **not** done: trace-viewer genuinely consumes
+`@progressView/*`, `@shared/*`, `@transcript` and `@utils/core`, so dropping its
+`extends` needs a third derive target in `scripts/sync-tsconfig-paths.mjs`
+rather than the one-line edit this document assumed. What shipped instead is a
+validation gate over `tsconfig.build.json`, since that map is a deliberate
+subset and deriving it would be wrong.
+
+Executing item 7 confirmed a defect in its own blast-radius estimate: moving
+`texFormatter.ts` into `src/latex/formatter/` also breaks the file's own
+`./formatter/latexindentpt` and `./formatter/texfmt` imports, which this
+document did not budget for. Item 5's estimate was also wrong in a way that
+broke the build once — its importers span `.mts`, not only `.ts`. Rows 8 and 9,
+the §6 test-kernel checklist, and item 12 have since been corrected for the same
+class of omission, several of them found in review rather than by execution.
+
+Treat the remaining blast-radius cells as reviewed but not proven. The only ones
+proven are the ones that ran, and every one of those was under-counted on first
+estimate. Everything else here remains a proposal.
+
+Scope: directory and file placement across `src/`, `packages/`, `docs/`, and the
+auxiliary root trees. Licensing, community-health files, and content accuracy are
+tracked separately in `docs/proposals/2026-07-29-open-source-readiness.md` and
+`docs/proposals/2026-08-01-open-source-readiness-audit.md` and are referenced, not
+re-derived, here.
+
+---
+
+## 1. The shape of the problem
+
+The first thing a stranger runs is `ls src/`, and the largest thing they see is
+`test-kernel/` — 848 tracked files, 220,483 LOC, 57% of everything under `src/` by
+line count, sitting as a peer of `agent/`, `tools/`, and `shared/`, with a name that
+describes neither tests nor a kernel (`src/test-kernel/support/` is 24 files; the
+"kernel" is 3% of what carries the name). The second thing they hit is that none of
+the 19 remaining subsystems has a README: `git ls-files src | grep -i readme` returns
+exactly 4 files, all under `src/agent/`, and root `README.md` contains zero
+occurrences of `src/`. The layout knowledge exists — `AGENTS.md` lines 86-124 are
+substantive and specific — but it lives in agent-instruction files a drive-by reader
+will not open, and three of its statements are measurably false against the tree
+(`src/utils/` "reserved for utilities used by both the extension host and webviews"
+is true for 5 of 55 files; `src/utils/text/` as "the single home for generic string
+helpers" is contradicted by `src/utils/strings/`; `@common/errors` as the one error
+path is contradicted by `@utils/errors/errorMessage`, the most-imported leaf module
+in the repo at ~199 sites).
+
+What is _not_ wrong is most of the tree. Directory naming is uniform camelCase with
+zero kebab or snake outliers across 154 distinct segments. Import discipline is
+outstanding: 8,439 alias imports against 840 relative ones, zero at depth 4+,
+enforced by a custom auto-fixable `local/prefer-alias-for-deep-relative-imports`
+rule. Path aliases are code-generated from one source (`tsconfig.json` →
+`scripts/sync-tsconfig-paths.mjs`, CI-gated). `src/agent/core/`,
+`src/agent/modelHandlers/`, `src/platform/`, `src/controllers/`, and
+`packages/cli/src/` are genuinely well-decomposed. There is no dead-file
+accumulation: across `src/utils/` + `src/common/` + `src/shared/` (248 files), not
+one has zero production importers.
+
+So the problem is not structure. It is **legibility and honesty of the written
+rules**, plus a handful of specific traps: files sitting beside a directory of the
+same name (`src/tools/DelegationTools.ts` next to `src/tools/delegation/`,
+`src/latex/latexdiff.ts` next to `src/latex/latexdiff/`), `@common/*` resolving into
+two different packages, 12 unfiled cross-process contract files at
+`packages/desktop/src/` root, a `packages/trace-viewer` that declares none of its
+real dependencies, and `docs/proposals/` where 21 of 73 files are one rolling daily
+status report. The right response is roughly 8 small moves, ~6 paragraph edits, and
+one large-but-cheap rename — not a restructuring.
+
+---
+
+## 2. Do this
+
+Ordered by value per unit of churn. Every blast-radius cell names the specific file
+that breaks if you skip it.
+
+| #   | Change                                                                                                                                                                                                                                                                                                                                                                                          | Why                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | Blast radius (files that must change)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | Effort |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| 1   | **Add `src/README.md`** — table of the 19 subsystems with one line each, the browser-reachable vs node-side axis, a pointer to `eslint.config.mjs:61-73` for the VS Code-free zone list (**point, do not transcribe** — duplicated lists drift), and links to the 4 existing agent READMEs                                                                                                      | 19 top-level dirs named `common`, `utils`, `shared`, `hosts`, `housekeeping`, `replacement`, `skills` with no index. Every other item here gets ~80% cheaper once this exists                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | **Zero.** New file. Verified no impact on any tsconfig, `eslint.config.mjs`, all 5 `config/ratchets/*.json`, `vitest.config.mjs` (include glob is `src/test-kernel/**` only), `.vscodeignore`, `electron-builder.yml`. Deliberately _outside_ `docs/`, so `docs/scripts/check-root-docs.mjs` and `docs/.vitepress/publicDocs.js` do not apply — it cannot freeze the texra.ai deploy                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | 1-2 h  |
+| 2   | **Delete the `@types/*` alias** from `tsconfig.json:44`, `tsconfig.build.json:38`, `packages/extension/tsconfig.json:41`, `packages/desktop/tsconfig.paths.json:36`; run `npm run sync:tsconfig-paths`                                                                                                                                                                                          | `@types/` is the reserved DefinitelyTyped npm scope and has **0 usages** across 9,279 internal specifiers. Worse than clutter: `scripts/aliasUtils.mjs` `loadAliases()` filters only values ending `.d.ts`, so `"@types/*": ["src/types/*"]` is injected as a **live esbuild and Vite alias in every host build** — a bare `@types/...` specifier from any bundled dependency resolves into `src/types/`                                                                                                                                                                                                                                                                                 | 4 line deletions, 0 source files. `src/types/ambient.d.ts` **stays** — it resolves via the `include` glob and the `"turndown-plugin-gfm"` mapping at `tsconfig.json:48`, not the alias. `src/test-kernel/scripts/AliasMapGeneration.vitest.ts` uses its own fixture and passes unchanged                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | 15 min |
+| 3   | **Delete the dead bare aliases `"@logger"` and `"@telemetry"`** — `tsconfig.json:25,27`, `tsconfig.build.json:21,23`, `packages/extension/tsconfig.json:23,25`, `packages/desktop/tsconfig.paths.json:17,19`                                                                                                                                                                                    | Neither `src/logger/` nor `src/telemetry/` has an `index.ts`; `tsconfig.build.json` points at `src/logger/index.ts`, a file that does not exist. Both bare forms measure **0 usages**; all 165+ real imports are deep. They falsely imply a barrel exists, inviting the convenience barrel CLAUDE.md forbids                                                                                                                                                                                                                                                                                                                                                                             | 8 line deletions, 0 source files. **Do not extend to `@transcript`/`@model`/`@housekeeping`** — 50/22/7 live bare uses and real `index.ts` files. Keep the entries in `subsystemEdgeRatchet.vitest.ts` `SUBSYSTEM_ALIASES` (defensive, free)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | 15 min |
+| 4   | **`git mv src/utils/strings/appendTail.ts src/utils/text/appendTail.ts`**, delete `src/utils/strings/`                                                                                                                                                                                                                                                                                          | `AGENTS.md:115` states `utils/text/` is "the single home for generic string helpers". `utils/strings/` holds exactly one file and is never mentioned in AGENTS.md's directory list, so it is invisible to anyone following the docs — a contributor goes to `text/`, finds no `appendTail`, and writes a duplicate                                                                                                                                                                                                                                                                                                                                                                       | **3 import statements**: `src/tools/bash.ts:52`, `src/agent/modelHandlers/utils/toolAttachmentUtils.ts:10`, `src/test-kernel/utils/AppendTail.vitest.ts:4` (+ a comment line naming the alias). All 5 ratchets verified to contain zero `appendTail` / `src/utils/strings` occurrences. `@utils/*` is a wildcard — no alias edit                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | 15 min |
+| 5   | **`git mv src/test-kernel/helpers/streamStatusTestUtils.ts src/test-kernel/support/`**, delete `helpers/`                                                                                                                                                                                                                                                                                       | `AGENTS.md:564,566` names `src/test-kernel/support/` twice as _the_ promotion target for shared fixtures. `helpers/` holds one file with 16 importers spanning agent/runtime, agent/followUp, cli, desktop, tools — unambiguously shared infrastructure in the wrong home. This _enforces an existing documented rule_ rather than inventing a preference                                                                                                                                                                                                                                                                                                                                | **16 import statements**, all the identical specifier `@test/helpers/streamStatusTestUtils` → `@test/support/…`. One `sed`. `vitest.config.mjs` references `support/setupFakePlatform.ts` and `support/vscode-mock.ts` by exact filename, so adding a file to `support/` touches nothing. `knip-baseline.json` references only `support/setupFakePlatform.ts`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | 20 min |
+| 6   | **Rename `src/shared/mainView/executeMessage.ts` → `executionFormState.ts`** (it defines `MainViewExecutionFormState`, not a message)                                                                                                                                                                                                                                                           | Two files named `executeMessage.ts` twelve characters apart, one importing the other (`src/shared/mainView/executeMessage.ts:1` imports `MainViewExecuteMessage` from `../schemas/mainView/executeMessage`). Copy-paste hazard and autocomplete trap                                                                                                                                                                                                                                                                                                                                                                                                                                     | **2 import statements**: `packages/extension/src/webview/frontend/mainViewActions.ts:24`, `src/test-kernel/shared/MainViewExecuteMessage.vitest.ts:7`. Zero ratchet/alias/eslint/packaging impact                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | 15 min |
+| 7   | **`git mv src/latex/texFormatter.ts src/latex/formatter/`**                                                                                                                                                                                                                                                                                                                                     | Same beside-its-own-folder trap as `src/tools/delegation`, at the cheapest possible instance. `src/latex/` has 19 loose root files against 2 subdirectories; this is the one with no resolution collision                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | **2 import statements.** `@latex/*` is a wildcard; `src/test-kernel/architecture/toolRegistryCycle.vitest.ts:49` lists `'src/latex/'` as a _prefix_, so intra-subsystem moves survive. **Do not also move `latexdiff.ts`** — see §5, decision D                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | 15 min |
+| 8   | **Move the 10 delegation files at `src/tools/` root into the existing `src/tools/delegation/`** — `DelegationTools.ts`, `subagentResults.ts`, `subagentDiffs.ts`, `childStream.ts`, `childRunDelivery.ts`, `deliveryEnvelope.ts`, `delegationAgentAvailability.ts`, `delegationModelAvailability.ts`, `delegationWorktreeAvailability.ts`, `delegationDescriptionBlock.ts` (~1,915 lines)       | This is an _active mis-navigation_, not untidiness: a reader looking for delegation code opens `src/tools/delegation/` (13 files) and never sees `DelegationTools.ts` one level up. Nothing in the tree tells them which is authoritative — there is no `src/tools/README.md` and CLAUDE.md is silent on `src/tools/` internals                                                                                                                                                                                                                                                                                                                                                          | ~41 importer files. **`src/test-kernel/architecture/toolRegistryCycle.vitest.ts:42` hardcodes the literal string `'src/tools/DelegationTools.ts'`** in its `AGENT_LAUNCHING_TOOLS` allowlist — the test fails until that literal is updated, and it must be in the same commit. Verified unaffected: `architecture-edges-baseline.json` (keyed on first segment under `src/`), `knip-baseline.json` (0 `src/tools/` entries), all 4 tsconfigs (`@tools/*` wildcard), `eslint.config.mjs:64` (bare `'src/tools'` zone string), `.vscodeignore`, `electron-builder.yml`, `scripts/aliases.mjs` (derives from tsconfig). **Also rewrite the moved file's own imports**: `DelegationTools.ts:50,58,59,61` reference `./delegation/proposalFlow`, `./delegation/inputFields` (twice) and `./delegation/workflowFileValidation`, which resolve to a nonexistent `delegation/delegation/` from the new location. **And rewrite the runtime-reachability metadata**: `src/shared/schemas/stateSettings.ts:192` names `src/tools/DelegationTools.ts` inside `GIT_WORKTREE_RUNTIME_REACHABILITY`, and `stateSettings.vitest.ts:181-190` resolves every declared segment and asserts it exists — so `npm test` fails on the stale path even with all imports and the architecture allowlist updated                                                                       | 2-3 h  |
+| 9   | **Create `packages/desktop/src/shared/` and move all 12 loose root files into it** — `desktopCommandSurface`, `desktopDiffMessages`, `desktopLogMessages`, `desktopOnboardingMessages`, `desktopPdfMessages`, `desktopPromptMessages`, `desktopProtocol`, `desktopShellMessages`, `desktopTaskShell`, `desktopWorkspaceMessages`, `hostBridgeChannels`, `workspacePath`. **Keep the filenames** | These 12 are the main↔preload↔renderer contract — verified by import tracing (`desktopShellMessages` pulled from both `main/` and `renderer/`; `hostBridgeChannels` from `main/` and `preload/`). Today `packages/desktop/src/` reads as "three process dirs and a pile", when the pile is the most architecturally important layer. A contributor adding an IPC message guesses `main/`, which quietly breaks the renderer's ability to import it                                                                                                                                                                                                                                       | ~48 import specifiers across 31 files. **Hazard: mixed module resolution.** The same modules are imported both with and without `.js` (`'../desktopShellMessages.js'` ×6 and `'../desktopShellMessages'` ×2; `@desktop/workspacePath.js` at `main/platform/index.ts:12` and `paths.ts:10` vs `@desktop/workspacePath` at `src/test-kernel/desktop/desktopWorkspacePath.vitest.ts:11`). `main/` and `preload/` resolve NodeNext (extension required); `renderer/` and test-kernel resolve bundler. **A find-replace that normalizes extensions breaks the main/preload build.** Unaffected: `@desktop/*` whole-src alias, `knip.json:26-36` entries, `electron-builder.yml` (ships `dist/` only), all eslint globs. **Also rewrite three test path literals**: `src/test-kernel/desktop/DesktopControlSystem.vitest.mts` `read()`s `packages/desktop/src/desktopOnboardingMessages.ts` (`:135`), `desktopCommandSurface.ts` (`:235`) and `desktopWorkspaceMessages.ts` (`:276`) by literal path; each targets a nonexistent file after the move. **Correction: `config/ratchets/knip-baseline.json` IS affected** — it keys an accepted unused-export finding by the literal path `packages/desktop/src/desktopCommandSurface.ts`, so the move reads as a new finding and fails `check:dead-code-ratchet` unless the baseline is regenerated in the same commit | 2-3 h  |
+| 10  | **Fix `packages/trace-viewer`'s declarations**: add `zod` to `dependencies`; stop extending `../desktop/tsconfig.paths.json` at `packages/trace-viewer/tsconfig.json:2`; add a `packages/trace-viewer` workspace block to `knip.json`                                                                                                                                                           | The only genuine _correctness_ defect in this survey. `ls packages/trace-viewer/node_modules` returns exactly typescript, vite, vite-plugin-singlefile — **`zod` is absent**, yet `src/traceDataSchema.ts:7` imports it and resolves only by walking up to root `node_modules`. Under pnpm's isolated layout that is an accident, not a design: the package cannot build standalone and a root zod major bump silently changes what it compiles against. And its type resolution is a downstream side effect of a _code-generated_ file (`scripts/sync-tsconfig-paths.mjs` target #2) owned by an unrelated package. Its 10 files are outside `npm run check:dead-code-ratchet` entirely | `packages/trace-viewer/package.json`, `packages/trace-viewer/tsconfig.json:2`, `knip.json` (**expect new findings against `config/ratchets/knip-baseline.json` — regenerate**), `pnpm-lock.yaml`. Giving it its own tsconfig means `scripts/aliasUtils.mjs` needs a third derive target (or an explicit extends from a shared root config) plus a `sync-tsconfig-paths.mjs` target so it cannot drift. `packages/extension/package.json:1769` already declares `"@texra/trace-viewer": "workspace:*"` — keep consistent. **Defer the `outDir` change** (see §3)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | 2-3 h  |
+| 11  | **Move the 21 `YYYY-MM-DD-agent-sdk-readiness-checkpoint.md` files from `docs/proposals/` to `docs/dev/audits/`**, and add `docs/proposals/README.md` mirroring `docs/prds/README.md`                                                                                                                                                                                                           | 29% of `docs/proposals/` is one rolling daily status report (2026-06-25 → 2026-08-01). A stranger sees 73 undifferentiated files, 21 near-identically named, and concludes the project churns without converging. `docs/dev/audits` is already a `TIMESTAMPED_DIRS` member (`docs/scripts/check-root-docs.mjs:26`) so the date prefixes stay valid, and it is an `ARCHIVAL_DIRS` carve-out in `scripts/check-guidance-refs.mjs:32` so stale paths inside them are already exempt                                                                                                                                                                                                         | 21 `git mv` of markdown + ~25 intra-series links. **Both source and destination are already in `docs/.vitepress/publicDocs.js` `srcExclude`**, so the publish allowlist and the deploy are untouched. `check-root-docs.mjs:104` `markdownFilesUnder` recurses (verified `:95-101`), so subdirectories are already handled. Zero source, zero ratchet, zero build config                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | 1-2 h  |
+| 12  | **Fold the two doc singletons**: `docs/pocketflow/state_architecture.md` → `docs/architecture/pocketflow-state.md` (also fixes the only snake_case filename among 206 tracked docs markdown files); `docs/skills/skill-authoring.md` → `docs/dev/`                                                                                                                                              | Both directories hold exactly one file and CLAUDE.md links into them, so they are load-bearing but read as abandoned                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | **5 citations, not 2.** `CLAUDE.md:136` and `AGENTS.md:407` are gated by `scripts/check-guidance-refs.mjs` — a move without them **fails the commit**. `docs/README.md:23`, `docs/prds/cli-tui-ink/2026-05-14-30-reference.md:85` and `docs/prds/2026-05-14-skills.md:25` (which calls it the authoritative authoring conventions) are _ungated and will rot silently_ — `check-guidance-refs.mjs` does not scan `docs/prds/`; `docs/README.md` in particular is the first file a stranger opens. Drop the now-empty `'pocketflow/**'` and `'skills/**'` entries from `publicDocs.js` `srcExclude`. **Caveat**: `state_architecture.md:35-40` documents `runState.toSnapshot()` / `AgentRunState.fromSnapshot()` against a codebase with no `AgentRunState` class (per `2026-08-01-open-source-readiness-audit.md`). Fix or delete the content _before_ promoting it into `architecture/`, or the rename makes a wrong doc more trusted                                                                                                                                                                                                                                                                                                                                                                                                                        | 1 h    |
+| 13  | **`git mv packages/extension/src/MainViewProvider.ts packages/extension/src/webview/`** — the directory name stays                                                                                                                                                                                                                                                                              | `progressView/` and `settingsView/` each hold their `*ViewProvider.ts` _and_ their `*ViewMessageHandler.ts`; the main view alone has its provider orphaned at the package src root (only 3 `.ts` files live there) while its handler sits in `webview/`. This fixes the actual asymmetry                                                                                                                                                                                                                                                                                                                                                                                                 | ~1-2 import statements. **Explicitly does NOT rename the directory** — see §5, decision E, and §3                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | 20 min |
+| 14  | **Add `packages/agent/README.md`** stating it is the intended SDK surface, pre-release and unpublished — **or** set `"private": true` and delete the dead publish job at `.github/workflows/release.yml:153-201`                                                                                                                                                                                | `packages/agent/src/` is 3 files / 510 lines with zero in-repo consumers, and its status is readable only from `if: ${{ false && … }}` at `release.yml:158`. A stranger reverse-engineers a disabled CI job to learn whether a package is real                                                                                                                                                                                                                                                                                                                                                                                                                                           | README path: 1 new file. Delete path: `knip.json:17-24` workspace block, `eslint.config.mjs:70,398`, `config/ratchets/knip-baseline.json`, root `package.json:28`. **Do not** rewrite `CLAUDE.md:37` — "There is no `@texra/core` package" is true as written and stays true                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | 30 min |
+| 15  | **Extend `scripts/check-guidance-refs.mjs:64-73` `PATH_PREFIXES` with `'skills/'` and `'prompts/'`**                                                                                                                                                                                                                                                                                            | Both trees are cited from CLAUDE.md/AGENTS.md and both are currently **unguarded** — the gate's `PATH_PREFIXES` lists `src/`, `packages/`, `docs/`, `config/`, `patches/`, `scripts/`, `supabase/`, `.github/`, `.claude/` and neither of these. `skills/` is a shipped product surface with two hardcoded packaging consumers                                                                                                                                                                                                                                                                                                                                                           | 2 lines. **Verify first** that no existing guidance prose cites an already-moved `skills/` or `prompts/` path, or the gate fails on its first run                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | 15 min |
+
+**Total for items 1-7 and 13-15: under a day, ~25 import statements.** Items 8-12
+are the bulk of the work and are independent of each other.
+
+---
+
+## 3. Don't do this
+
+Each of these was proposed and refuted. Recorded so nobody re-litigates them.
+
+| Rejected                                                                                                                                    | Why not                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Split `src/agent/runtime/` (52 files, flat) into subdirectories**                                                                         | `src/agent/runtime/README.md` already contains a seven-row module map and a section literally titled **"Why this stays flat"** that makes and rejects this exact proposal, naming the condition to revisit ("if a future refactor touches a whole group's call sites anyway"). Cost is worse than the README estimates: **306 importer files and 664 distinct `@agent/runtime/*` specifiers**, plus 48 occurrences in `config/ratchets/host-agent-import-baseline.json` and 18 in `host-agent-mock-baseline.json`                                                                                                                                                                                                                     |
+| **Move `src/tools/` external-agent (13 files) and filesystem (10 files) clusters into new subdirectories**                                  | These are the expensive two-thirds of the `src/tools/` proposal (~100 importer files) for materially less benefit than the delegation cluster. Neither sits beside a same-named directory, so neither causes the mis-navigation that justifies item 8. Revisit only if a refactor touches those call sites anyway                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| **Move all tools to `<domain>/<Name>Tool.ts` and fix `registry.ts`'s five import shapes**                                                   | After moving the 5 obvious candidates, `registry.ts` still imports in **four** shapes — 9 root-level `*Tool.ts`, 15 barrel-less domain dirs, 4 barrel imports all remain. Half-executing a consistency fix leaves the same confusion plus churned blame on `codex.ts` and `claudeAgent.ts`, two of the largest files in the subsystem. Also: the "primary export is the Tool class" premise is **false** for 3 of the 5 (`grep.ts` also exports `buildArguments`; `codex.ts` and `claudeAgent.ts` export `runStreamedTurn`). And it would require regenerating 8 entries in `config/ratchets/shared-schemas-deep-import-baseline.json`, which the original proposal missed. **Adopt the written rule (§4); drop the move**            |
+| **Move `src/utils/errors/errorMessage.ts` to `@common/errors` or `@shared/`**                                                               | **199 import statements across ~200 files** — the most-imported leaf module in the repo — to empty one directory. Its current placement is _forced_ by `eslint.config.mjs:584-603`, which bars extension frontends from importing `@common` at runtime. Document the constraint (§4); leave the file                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| **Merge `src/utils/` into `src/common/`, or vice versa**                                                                                    | ~50 of 55 `src/utils/` files and 28 of 28 `src/common/` files are the same zone (node-side, host-agnostic, zero `vscode` imports). The `errors/`/`files/` name collisions between them are real but cause no reader harm — the alias prefix disambiguates at every call site. Fix the rule, not the tree                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| **Regroup `src/shared/{wa,styles,litControllers,markdown,highlighting,monaco}/` under `src/shared/ui/`**                                    | **235 import statements**, plus **9 hardcoded literal source paths** in `src/test-kernel/settings/SettingsStyleContracts.vitest.mts:35,38,39,59,69,85,91` and `src/test-kernel/desktop/DesktopControlSystem.vitest.mts:42-43` that break silently. A README sentence makes the same boundary visible for free                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| **Move `src/shared/settingsView/handlers/` to `src/controllers/settingsView/`**                                                             | Refuted by an existing guard: `src/test-kernel/shared/SharedSettingsViewBoundary.vitest.ts:12` asserts nothing under `src/shared/settingsView` imports `@controllers/`, `@agent/`, `@model/`, `@tools/`, or `@auth/`. The placement is deliberate and enforced — these handlers live in `shared/` precisely because they must stay dependency-light, a strictly tighter constraint than `src/controllers/`, whose baseline out-edges include every subsystem the guard forbids. Moving them deletes the guard (and costs 31 statements across 21 files)                                                                                                                                                                               |
+| **Fold the singleton subsystems `logger/`, `telemetry/`, `eventBus/`, `hosts/`, `replacement/`, `skills/`, `housekeeping/`, `transcript/`** | Every top-level `src/` directory is a **node** in `config/ratchets/architecture-edges-baseline.json` (96 edges, 18 nodes). Folding one rewrites the edge set and forces a baseline regeneration no reviewer can eyeball. `logger` is the extreme case: 12 in-edges, second-most-depended-on node in the graph — merging it into `utils` permanently erases the ratchet's ability to see who logs. All eight are coherently named and none is stale                                                                                                                                                                                                                                                                                    |
+| **Move `src/types/ambient.d.ts`** (delete the alias only)                                                                                   | Referenced from **nine** places across four independently-resolving build graphs: `packages/desktop/tsconfig.{main,renderer,preload}.json`, `packages/trace-viewer/tsconfig.json:20`, `packages/extension/tsconfig.json:64`, `tsconfig.test-kernel.json:12`, `tsconfig.build.json:44`, plus the `turndown-plugin-gfm` special-case in three configs. Ambient declarations that fail to load degrade to `any` silently, and a single root `npm run typecheck` does not exercise the desktop preload or trace-viewer graphs                                                                                                                                                                                                             |
+| **Rename `src/agent/index/` to `src/agent/catalog/`**                                                                                       | The confusion is real (`@agent/index` reads as "the agent barrel", which the repo bans), but: **90 occurrences across 75 files** (43 barrel + 32 deep imports like `@agent/index/agentRegistry` ×19), **three ratchets** carrying the literal string (`host-agent-import-baseline.json` 9, `host-agent-mock-baseline.json` 11, `shared-schemas-deep-import-baseline.json` 9), and ~20 ungated doc citations under `docs/prds/` and `docs/supabase/`. A one-line AGENTS.md entry (§4) captures most of the value for free. Rename _only_ if bundled into a pre-flip cleanup where blame churn is already being paid                                                                                                                    |
+| **Rename `packages/extension/src/webview/` → `mainView/`**                                                                                  | Six hardcoded string sites, **two of which fail silently and ship**: `packages/extension/.vscodeignore:52` is `!src/webview/*.html`, the negation that re-includes the main view's HTML in the VSIX (skip it and the marketplace build has no main view); `scripts/verify-vsix-contents.mjs:184` asserts `extension/dist/webview/bundle.js`. Plus `packages/extension/vite.config.ts:7,41,44-45` (the string derives the **dist folder name**), `packages/extension/package.json:1813-1815` (three shell loops spelling `for v in progressView settingsView webview`), `MainViewProvider.ts:84,88,307`, `scripts/clean-extension-dist.mjs`, `common/webview/resourceRoots.ts:11-12`, `eslint.config.mjs:71,586`. Take item 13 instead |
+| **Rename `packages/cli/src/chat/tui/` or `packages/cli/src/tui/`**                                                                          | The claimed "mechanical find-replace over relative paths" is false — **zero** files under `chat/tui/` use a relative path to the primitives; all 133 occurrences across 57 files are the alias form `@cli/tui/…`. And `packages/cli/scripts/reactCompilerPlugin.mjs:20-26` hardcodes `TUI_PATH_SEGMENTS`, with a comment at `:5-9` warning that these components "silently lose compiler memoization on relocation". No call site is ambiguous today                                                                                                                                                                                                                                                                                  |
+| **Move the 23 package-specific files out of root `scripts/`**                                                                               | `knip.json:7` makes `scripts/**/*.mjs` an **entry of the root workspace**; neither `packages/extension` (`src/**/*.{ts,tsx}`) nor `packages/desktop` includes `scripts/`. The move silently drops 23 scripts out of `npm run check:dead-code-ratchet`. Also `packages/extension/.vscodeignore` has no `scripts/**` or blanket `*.mjs` rule, so a new `packages/extension/scripts/` ships into the VSIX by default. The filenames already carry ownership (`verify-desktop-package.mjs`, `copy-extension-skills.mjs`)                                                                                                                                                                                                                  |
+| **Move `packages/extension/resources/` to the repo root**                                                                                   | It is already the staging **destination** for root-level shared assets: `scripts/copy-extension-skills.mjs:11-21` copies root `skills/` _into_ it, gitignored per `packages/extension/.gitignore:9-11`. Inverting the flow for a sibling subtree creates two opposite conventions in one directory. It also breaks zero-build dev access — `packages/extension/src/extension.ts:199,288` and 3 other sites read resources straight out of the tree via `context.extensionPath`, which in F5 dev _is_ `packages/extension/`                                                                                                                                                                                                            |
+| **Rename `packages/extension/src/frontend/`** (the misleading extension-host tree)                                                          | Already documented deliberately: `AGENTS.md:94-101` gives it a seven-entry subdirectory map and a usage rule; `CLAUDE.md:64-68` disambiguates it explicitly. And the proposal defeats itself — the word `frontend` appears in **203 import specifiers across 86 files**, so leaving the alias leaves the confusion verbatim in every import line. Keep the three-column mapping table idea (§4)                                                                                                                                                                                                                                                                                                                                       |
+| **Move `docs/` into the pnpm workspace**                                                                                                    | The isolation is deliberate and documented: `docs/scripts/check-root-docs.mjs:11-12` says it is "intentionally dependency-free … so it runs without installing the docs sub-project", repeated at `docs/.vitepress/publicDocs.js:5-7`. Folding it in pushes vitepress + mermaid into every contributor's install. One sentence in `docs/README.md` fixes the real defect                                                                                                                                                                                                                                                                                                                                                              |
+| **Restructure `docs/` into `public/` + `internal/`**                                                                                        | Moving `docs/dev/` makes `scripts/check-guidance-refs.mjs:27` `GUIDANCE_DIRS` point at a nonexistent path — **the gate stops scanning and starts passing silently**, same for `ARCHIVAL_DIRS:32`. ~190 citations would need rewriting, of which only ~6 are inside any gate's scan set. The safety property this is meant to buy already exists: `check-root-docs.mjs:62-92` hard-fails any root entry classified in neither the allowlist nor `srcExclude`                                                                                                                                                                                                                                                                           |
+| **Split `docs/proposals/` into `active/` / `shipped/` / `archive/`**                                                                        | Requires a human judgment call on 73 historical documents and rewrites ~78 ungated citations — 18 of them are source comments in `src/` and `packages/` (`src/agent/trace/index.ts`, `src/shared/schemas/*.ts`, `packages/cli/src/chat/tui/state/*.ts`, `packages/extension/src/progressView/frontend/components/messageIndex.ts`) covered by no gate at all. Item 11 delivers nearly all the reader benefit                                                                                                                                                                                                                                                                                                                          |
+| **Subdivide `docs/.vitepress/components/` (104 flat `.vue` files)**                                                                         | ~147 import rewrites (88 markdown + 59 inter-component) plus 23 registrations in `theme/index.js`, every one a **silent runtime break** — Vue SFC imports in markdown are not type-checked and there is no docs typecheck step. The files already self-organize by suffix (`*Hero.vue`, `Mockup*.vue`, `*Card.vue`). No stranger reads the marketing site's Vue internals                                                                                                                                                                                                                                                                                                                                                             |
+| **Reorganize `docs/supabase/` or promote its SQL into `supabase/migrations/`**                                                              | `docs/README.md` states an explicit conditioned hold ("remains here until an approved private destination has been created, copied, hash-verified, access-checked, and tested"). And four of the 13 files are factually wrong per `2026-08-01-open-source-readiness-audit.md` §4.5 — promoting stale SQL into the location a Supabase CLI user trusts is actively harmful. The one real item (`remote-agents.config.json` is a runtime input under `docs/`) is a two-line change to `scripts/sync-remote-agents.mjs:23-24`                                                                                                                                                                                                            |
+| **Rename `@texra/desktop` and `@texra/trace-viewer` to `@texra-ai/*`**                                                                      | `"private": true` is already the machine-readable, npm-native signal for "never published" and it is already correct on both. The rename touches ~14 references across 8 files including a real dependency edge at `packages/extension/package.json:1769`. Document the rule instead (§5, decision A)                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| **Split `src/test-kernel/cli/` (147 flat files) to mirror `packages/cli/src/`**                                                             | Suites are leaves — nothing imports them, `vitest.config.mjs:26`'s `**` glob is depth-agnostic, and nobody navigates to a test by walking the tree. Cost: `config/ratchets/host-agent-mock-baseline.json` pins 40 exact paths under `src/test-kernel/{cli,desktop}` and `hostAgentMockRatchet.vitest.ts:48-50` resolves those directories by literal name; `agentRuntimeProgressEventsBoundary.vitest.ts:36-39` pins 3 more. A second ~200-file relocation immediately after item 18 invalidates every open branch twice                                                                                                                                                                                                              |
+| **Move `packages/desktop/tests/e2e/` or delete its screenshot baselines**                                                                   | `packages/desktop/tests/e2e/README.md` already states the suite is "**not** wired into the default `npm test` flow" and documents the manual `TEXRA_UPDATE_E2E_SCREENSHOTS=1` baseline workflow, explaining the PNGs are committed "so reviewers have a fixed reference". The layout is idiomatic Playwright. Baseline staleness is a test-maintenance question, not a directory one                                                                                                                                                                                                                                                                                                                                                  |
+| **Delete the four `src/tools/*/index.ts` barrels**                                                                                          | The consumer counts behind this were wrong: `src/tools/inquiry/index.ts` has 3 consumers, not 6 — the other four resolve to `src/shared/schemas/inquiry.ts`, an unrelated module, and those four files appeared in the proposed edit list. `src/tools/setup/index.ts` and `src/tools/approval/index.ts` already carry the docstring the rule requires. Adding a docstring to `lean/`, `latex/`, and `userQuestion/` satisfies AGENTS.md's "documented public surface" carve-out for 3 lines                                                                                                                                                                                                                                           |
+| **Delete `docs/proposals/2026-07-17-workflow-script-async-execution.md.local-before-pull`** as a merge artifact                             | It is not one. Lines 3-7 read: "**Historical snapshot (not authoritative).** This file preserves the local-before-pull state of the proposal. Refer to the [canonical proposal](…) for the current, authoritative version." Deleting it is free, but it is a deliberate, self-labeling, cross-linked archive — a judgment call for the maintainer, not a defect                                                                                                                                                                                                                                                                                                                                                                       |
+| **Move `TERMS_OF_SERVICE.md` into `docs/`**                                                                                                 | `docs/scripts/check-root-docs.mjs:78-81` hard-fails any root `.md` in neither `publicRootDocs` nor `srcExclude`, and `docs/package.json:5` `sync-legal` (`cp ../TERMS_OF_SERVICE.md terms.md`) becomes a same-directory self-copy                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| **Change `packages/trace-viewer`'s `outDir`** away from `../extension/resources/traceViewer` (yet)                                          | Touches `vite.config.ts:16-19`, `vite.standalone.config.ts:27`, `packages/extension/.gitignore:16-21`, `.vscodeignore:34-49`, `packages/cli/scripts/copy-resources.mjs:33`, `electron-builder.yml:44`, `scripts/verify-desktop-package.mjs:631`, `src/transcript/standaloneTraceHtml.ts:35`, `src/controllers/settingsView/ChatExportController.ts:177` — **plus a new extension copy step that does not exist today**. Do the declaration fixes (item 10); defer this                                                                                                                                                                                                                                                                |
+| **Write `CONTRIBUTING.md` / `CODE_OF_CONDUCT.md` now**                                                                                      | Already decided: `2026-08-01-open-source-readiness-audit.md` §6 lists these under "explicitly not worth doing" and `2026-07-29-open-source-readiness.md:178-181` explains the reasoning — soliciting contributions under all-rights-reserved with no CLA creates IP ambiguity. They are held behind the license decision, not overlooked. Same for `.github/ISSUE_TEMPLATE/`: `README.md:142` routes issues to `github.com/texra-ai/texra-issues` deliberately                                                                                                                                                                                                                                                                        |
+| **Create `packages/README.md`**                                                                                                             | It would duplicate `AGENTS.md:85-92` while falling **outside** `scripts/check-guidance-refs.mjs` (`:26-27` = CLAUDE.md, AGENTS.md, `.claude/skills`, `docs/dev`), the gate built precisely because guidance prose rots. Two indexes, one guarded and one not, is worse than one guarded index — and the rot rate is not hypothetical: a proposed test-kernel map in this very survey listed a `settingsView/` directory that does not exist (the real one is `settings/`). **Extend AGENTS.md:85-92 instead**                                                                                                                                                                                                                         |
+
+---
+
+## 4. Document instead of moving
+
+This is where most of the value is. All of these are placement questions whose real
+fix is prose in a **gated** file — `CLAUDE.md`, `AGENTS.md`, `.claude/skills/**`, or
+`docs/dev/**`, the four locations `scripts/check-guidance-refs.mjs:26-27` scans.
+Everything else rots unwatched.
+
+### 4.1 Correct the `src/utils/` rule — it is false for ~50 of 55 files
+
+Replace `AGENTS.md:106` and the corresponding `CLAUDE.md` "Layout" bullet.
+
+> `src/utils/` holds host-agnostic, `vscode`-free helpers reached by agnostic core.
+> Only a small browser-safe subset is additionally importable by webviews — today
+> `@utils/core`, `@utils/core/boundedIdSet`, `@utils/text/stringUtils`,
+> `@utils/errors/errorMessage`, and `@utils/files/pastedImageName`. Everything else
+> (`utils/system/`, `utils/files/`, `utils/git/`, `utils/config/`) is node-side; 22
+> of 55 files import `node:` builtins outright.
+
+Evidence: measured across all 161 browser-side source files in
+`packages/extension/src/{webview,progressView,settingsView}/frontend`,
+`packages/desktop/src/renderer`, and `packages/trace-viewer/src`, exactly 5 distinct
+`@utils/*` module paths are reachable. Zero files under `src/utils/` import `vscode`
+— which also means **`CLAUDE.md`'s VS Code-allowed-zone list is wrong in the other
+direction**: it names `src/utils/config/`, whose 5 files contain no `vscode` import.
+Fix both.
+
+### 4.2 State the `utils/` vs `common/` vs `shared/` axis
+
+Add to `src/README.md` and `AGENTS.md:102-106`:
+
+> The axis is reachability, not host. `src/shared/` is everything reachable from a
+> **browser** context (93 of 165 files are). `src/utils/` and `src/common/` are both
+> node-side and host-agnostic; the line between them is genericity —
+> `src/utils/` holds domain-free primitives (strings, paths, fs wrappers, exec, git);
+> `src/common/` holds TeXRA-domain host-neutral logic (error taxonomy, team roster,
+> storage layout). `errors/` and `files/` exist under both by design; the alias
+> prefix disambiguates at every call site.
+
+Note the existing `AGENTS.md:102` phrase "backend-only helpers" for `src/common/` is
+slightly wrong — `src/shared/subagentFollowup.ts:20` imports
+`@common/parsing/safeParseJson`, so reach into the browser-adjacent tree is nonzero.
+
+### 4.3 Correct the `src/shared/` description
+
+`CLAUDE.md` calls it "wire contracts and UI-shared message types". Actual contents
+include 26 files importing `lit` (11 in `wa/`, 10 in `styles/`, 3 in
+`litControllers/`, plus `utils/dom.ts` and `BaseWebviewApp.ts`), a markdown-it+KaTeX
+pipeline (`markdown/`, 5), and a Monaco shim. Replace with:
+
+> `src/shared/` is everything reachable from a browser context — wire contracts
+> (`schemas/` 62, `ipc.ts`, `hostBridgeTypes.ts`, `streams/`, `commands/`, `state/`)
+> **plus the shared webview UI kit** (`wa/` 16, `utils/` 12, `styles/` 11,
+> `copy/` 6, `markdown/` 5, `litControllers/` 4, `highlighting/` 3, `monaco/` 1).
+> The "no `@agent/*` imports here" rule follows from the contracts half.
+
+This also makes the no-`@agent` rule read as a consequence rather than an arbitrary
+constraint.
+
+### 4.4 Document the error-helper split — the single highest-frequency placement decision
+
+`AGENTS.md:131` says "Surface errors once through the shared error utilities in
+`@common/errors`". But `@utils/errors/errorMessage` has ~199 importers, more than
+double `@common/errors`' ~95. Add under `### Directory organization`:
+
+> `@common/errors/` is the backend-only error surface — SDK error classification,
+> provider formatting, agent error classes. `@utils/errors/errorMessage` is the
+> browser-safe error-to-string primitive and lives outside `@common/` deliberately:
+> `eslint.config.mjs:584-603` bars **extension frontends** from importing `@common`
+> or `@tools` runtime values (type imports are allowed). Note that rule covers
+> `packages/extension/src/{webview,progressView,settingsView}/frontend/**` only —
+> it does **not** cover `packages/desktop/src/renderer/**` or
+> `packages/trace-viewer/src/**`, where the same invariant is convention, not lint.
+> **The test: if a webview needs it, it cannot live in `@common/`.**
+
+Write the scope caveat exactly. A confidently-wrong claim here is worse than none —
+`check-guidance-refs.mjs` verifies only that cited _paths_ exist, never that the
+surrounding claim is true (it says so at `:14-16`).
+
+### 4.5 Write down the filename rule that already governs 90% of the tree
+
+Add under `AGENTS.md`'s `### Naming conventions` (lines 79-84), which currently
+covers only const-object casing and `UPPER_SNAKE_CASE`:
+
+> Filenames are camelCase. PascalCase only when the module's identity is **one
+> primary exported symbol** — a class, a Lit/Ink component, or a single dominant
+> type — in which case the filename matches that symbol exactly. Directories are
+> lowercase or camelCase, never kebab or snake; packages are the exception
+> (`trace-viewer`).
+
+Measured: 1,143 camelCase / 386 PascalCase / **0 kebab / 0 snake** across
+non-test source files. Of 211 PascalCase files under `src/` (excluding test-kernel),
+64 export no class — all type-identity modules (`IModelHandler.ts`,
+`ConversationBlockTypes.ts`, `AgentFinalResult.ts`), which the "primary exported
+symbol" wording covers. **Rename nothing**: 64 renames break git blame for zero
+reader benefit, and the rule as worded makes 211 of 211 compliant by definition.
+
+Skip the optional `unicorn/filename-case` lint. Configured to allow both camelCase
+and PascalCase (the only configuration that passes today) it would happily accept a
+new PascalCase file exporting a plain function — the exact deviation the rule
+prevents — while locking out kebab and snake, which nothing uses.
+
+### 4.6 Write down the `src/tools/` placement rule
+
+There is no `src/tools/README.md` and CLAUDE.md is silent on the subsystem's
+internals, yet `registry.ts:12-70` teaches five import shapes at once. New tools are
+the most likely first contribution from an outside contributor. Add to
+`AGENTS.md`'s `### Directory organization`:
+
+> New tools go in a domain subdirectory as `<Name>Tool.ts`, imported directly by
+> `src/tools/registry.ts`. Do not add a barrel; the 8 existing ones
+> (`approval`, `github`, `goal`, `inquiry`, `latex`, `lean`, `setup`,
+> `userQuestion`) predate the rule and each must carry a docstring declaring its
+> surface. Files at the `src/tools/` root are legacy placement, not a second
+> sanctioned option.
+
+### 4.7 Name `src/agent/index/` for what it is
+
+One line, in `src/README.md` and `AGENTS.md`:
+
+> `src/agent/index/` is the **agent catalog** — registry, agent directories, YAML
+> scanning, remote agent metadata. The directory name predates the barrel
+> convention and is not a barrel; `@agent/index` is a subsystem path, not
+> `@agent`'s public surface.
+
+### 4.8 Add the three-column host-layer mapping to `AGENTS.md:85-92`
+
+The same internal layer is named three different things across hosts, and this is
+genuinely non-obvious:
+
+| Concern                   | extension                                                                  | desktop                                       | cli                                                                           |
+| ------------------------- | -------------------------------------------------------------------------- | --------------------------------------------- | ----------------------------------------------------------------------------- |
+| Host-side service helpers | `packages/extension/src/frontend/` (7 subdirs, mapped at AGENTS.md:94-101) | `packages/desktop/src/main/`                  | `packages/cli/src/runtime/`                                                   |
+| Cross-process contracts   | root `src/shared/`                                                         | `packages/desktop/src/shared/` (after item 9) | root `src/shared/`                                                            |
+| UI                        | `src/{webview,progressView,settingsView}/frontend/`                        | `packages/desktop/src/renderer/`              | `packages/cli/src/chat/tui/` (app) + `packages/cli/src/tui/` (Ink primitives) |
+
+Also state the workspace index here (five packages, name, published-to) rather than
+in a new `packages/README.md` — see §3.
+
+### 4.9 Add a `docs/README.md` sentence on the docs sub-project's isolation
+
+> `docs/` is deliberately **not** a pnpm workspace member. It carries its own
+> `package-lock.json` and installs with `cd docs && npm ci` so the VitePress site
+> builds without the monorepo toolchain, and so the commit-time gates
+> (`docs/scripts/check-root-docs.mjs`, `docs/.vitepress/publicDocs.js`) stay
+> dependency-free.
+
+Optionally add `docs:dev` / `docs:build` passthroughs to root `package.json` (49
+scripts today, none for docs).
+
+### 4.10 Three new READMEs that replace physical merges
+
+| File                                     | Content                                                                                                                                                                                                                                                                                                                                                                                               | Replaces                                                                                                                                                                                                                                                                                                                                                     |
+| ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `packages/extension/resources/README.md` | `agents/` = reflection-flow YAML; `tool_use_agents/` = tooluse-flow YAML; both packaged into the VSIX                                                                                                                                                                                                                                                                                                 | Merging the four agent-YAML trees. Note `prompts/README.md:7-20` already enumerates all four homes — what is missing is only the **flow** mapping, which is one sentence there and one in CLAUDE.md's Agent system paragraph (which today names only `resources/agents/`, 5 of 57+ agent YAML, and never mentions `tool_use_agents/`)                        |
+| `skills/README.md`                       | The uniform package shape (`SKILL.md` + `references/*.md` + `agents/openai.yaml`, all 14 identical), **both packaging consumers by path** — `scripts/copy-extension-skills.mjs:12-21` and `packages/desktop/electron-builder.yml:48-49` — and a pointer to the authoring rules                                                                                                                        | Moving `skills/`, which those two hardcoded manifest paths make load-bearing at the root                                                                                                                                                                                                                                                                     |
+| `config/README.md`                       | These are **generated, checked-in** baselines with two consumer families (4 Vitest architecture tests and `scripts/check-dead-code-ratchet.mjs`), plus how to regenerate each — especially `architecture-edges-baseline.json`, whose 96 pinned edges make every top-level `src/` rename expensive. Nothing currently says this at the file's own location; a contributor discovers it from a red test | Moving `config/ratchets/` into `src/test-kernel/`, which would hide it from `check-dead-code-ratchet.mjs`. Also record: **do not** move root tool configs into `config/` — `eslint.config.mjs`, `tsconfig.json`, `.prettierrc`, `.pre-commit-config.yaml`, `pnpm-workspace.yaml`, `package.json` are all root-discovered by convention or editor integration |
+
+### 4.11 Add the test-placement mapping to `AGENTS.md` (currently one line, at `:124`)
+
+> All Vitest suites live under `src/test-kernel/`; **zero** are colocated (verified
+> across `src/**` and `packages/*/src/**`). The directory is the source subsystem,
+> with two aliases that cannot be derived: `packages/extension/src/settingsView/` →
+> `test-kernel/settings/`, and `packages/<pkg>/src/` → `test-kernel/<pkg>/`. Suites
+> mirror the source tree only where a subsystem has earned subdirectories; flat is
+> fine. Shared fakes are promoted to `src/test-kernel/support/` (fixture rule of
+> three, one fake per port).
+
+Do **not** write a `.ts` vs `.mts` rule until it is verified. The plausible rule
+("`.mts` when the suite transitively imports an ESM-only dependency") is refuted by
+`src/test-kernel/cli/`, which holds 4 `.ts` files among 143 `.mts`. Derive the real
+constraint from `tsconfig.test-kernel.json` first, or document only the part that is
+observably true (PascalCase-after-subject).
+
+### 4.12 A lint rule worth adding
+
+When items 10 or the `@traceViewer/*` alias land, add `'@traceViewer/**'` to
+`eslint.config.mjs:90-105` `HOST_LAYER_RESTRICTED_IMPORT_PATTERNS`, beside the
+existing `'@cli/**'` and `'@desktop/**'` at `:102-103`. Without it, root `src/`
+production code gains a lint-legal import path into a host UI package — the exact
+boundary that rule block exists to hold. This is the one alias addition with a real
+failure mode.
+
+Also consider hardening `docs/scripts/check-root-docs.mjs`: extend `TIMESTAMPED_DIRS`
+(`:26`) or add a plain kebab-case filename check to cover `architecture/`, `design/`,
+and `reference/`, which today have no naming gate at all — which is how
+`docs/prds/2025-12-25-POCKETFLOW_ISSUES_PROGRESS.md` and
+`docs/prds/2026-01-03-LOGGING_STREAMING_ARCHITECTURE.md`, the only two
+SCREAMING_SNAKE files under `prds/`, got in.
+
+---
+
+## 5. The naming decisions
+
+One-way doors. Once the repo is public and people import from it, each of these is
+expensive to revisit.
+
+### A. Package scopes — **keep all three, document the rule**
+
+| Package dir             | npm name                       | Published to                              |
+| ----------------------- | ------------------------------ | ----------------------------------------- |
+| `packages/extension`    | `texra` (publisher `texra-ai`) | VS Code Marketplace as `texra-ai.texra`   |
+| `packages/cli`          | `@texra-ai/cli`                | npm (`release.yml:144`)                   |
+| `packages/agent`        | `@texra-ai/agent`              | npm — **job disabled**, `release.yml:158` |
+| `packages/desktop`      | `@texra/desktop`               | never (`private: true`)                   |
+| `packages/trace-viewer` | `@texra/trace-viewer`          | never (`private: true`)                   |
+
+**Recommendation:** state the rule in `AGENTS.md:85-92` — `@texra-ai/*` = published
+to npm; `@texra/*` = workspace-internal, never published; bare `texra` = VS Code
+Marketplace identity, which cannot be scoped. Do not rename. `"private": true` is
+already the machine-readable signal a stranger checks before any prose convention,
+and it is already correct on both `@texra/*` packages. **Open question for the
+maintainer:** is the `@texra` npm scope actually owned? `release.yml` only ever
+publishes `@texra-ai/*`. If it is not owned, squatting an unowned scope in two
+manifests is worth a one-line comment even if the names stay.
+
+### B. `@common/*` resolving into two packages — **rename, but not urgently**
+
+`tsconfig.json` declares `@common/state` and `@common/webview` →
+`packages/extension/src/common/*` while `@common/*` → `src/common/*`. So
+`import … from '@common/webview'` and `import … from '@common/errors'` in the same
+file resolve into different packages, one VS Code-coupled and one in a VS Code-free
+zone. The repo has already paid for this twice in documentation
+(`CLAUDE.md`'s defensive "`src/common/webview/` does not exist" line;
+`src/shared/state/stateKeys.ts:10,12`) and once in ratchet complexity
+(`subsystemEdgeRatchet.vitest.ts:43-56` invents two pseudo-subsystems,
+`common-state-extension` and `common-webview-extension`, with a 5-line comment).
+
+**Recommendation:** rename to `@extCommon/state` and `@extCommon/webview`, reserving
+`@common/*` for `src/common/*`. This is the one item in the survey that genuinely
+misleads a stranger — `@common/state` reads as core code and is not. But it is not
+free:
+
+- **52 import statements** (33 `@common/state` + 19 `@common/webview`).
+- **4 alias configs**: `tsconfig.json`, `tsconfig.build.json`,
+  `packages/extension/tsconfig.json`, `packages/desktop/tsconfig.paths.json`.
+- **4 `eslint.config.mjs` sites**: `:78`, `:83` (per-alias messages in
+  `HOST_LAYER_RESTRICTED_IMPORT_PATHS`) and `:99-100`
+  (`HOST_LAYER_RESTRICTED_IMPORT_PATTERNS`).
+- **2 packaging scripts**: `scripts/verify-desktop-package.mjs:482` and
+  `scripts/verify-desktop-build-artifacts.mjs:109` both emit
+  `@common/state/stateKeys` in invariant error text.
+- Docstrings at `src/shared/state/PersistedState.ts:17` and
+  `src/shared/state/stateKeys.ts:10,12`.
+
+**Critical:** the `SUBSYSTEM_ALIASES` carve-out in `subsystemEdgeRatchet.vitest.ts:47-51`
+must be **renamed, not deleted**. It is not a workaround for the naming collision —
+it is a deliberate guard so a future `src/`-side import of a VS Code-coupled module
+produces a new-edge ratchet failure instead of being absorbed into the `common`
+baseline. Its own comment says so. Deleting it silently removes the guard. Same for
+the `CLAUDE.md` line, which stays useful as a pointer. `scripts/aliases.mjs`
+auto-derives build aliases from tsconfig, so no Vite or esbuild edit is needed.
+
+### C. `src/test-kernel/` — **`test-kernel/` at the root, not `tests/`**
+
+Three options: leave it, `git mv src/test-kernel tests`, or `git mv src/test-kernel
+test-kernel` (a pure `src/` prefix strip).
+
+**Recommendation: the prefix strip.** The `tests/` rename additionally churns
+`typecheck:test-kernel` (`package.json:25,27`), `tsconfig.test-kernel.json`,
+`eslint.config.mjs:423`, and 135 doc mentions across 48 `.md` files, for no
+structural gain. The prefix strip is mechanically the smallest diff that fixes the
+actual defect: `ls src/` stops being dominated by non-source, and casual LOC counts
+of `src/` stop reporting roughly double the real production size. See §6 for
+sequencing — this is a pre-flip-only move.
+
+### D. `src/latex/latexdiff.ts` — **rename, don't stutter**
+
+`@latex/latexdiff` currently resolves to `src/latex/latexdiff.ts`. Move it into
+`src/latex/latexdiff/` and the specifier becomes unresolvable (there is no
+`index.ts` there, and adding one runs into the no-convenience-barrels rule), forcing
+all 6 importers to `@latex/latexdiff/latexdiff` — a stutter that reads worse than
+what it replaced.
+
+**Recommendation:** if this is done at all, rename on move
+(`latexdiff/orchestrator.ts`; note `latexdiff/service.ts` already exists). Otherwise
+leave it and do only `texFormatter.ts` (item 7).
+
+### E. `packages/extension/src/webview/` — **keep the directory name**
+
+Renaming it to `mainView/` would make all three views spell alike and align with
+root `src/shared/schemas/mainView/`. It would also touch 8 hardcoded string sites,
+two of which fail silently and ship a broken VSIX (`.vscodeignore:52`,
+`verify-vsix-contents.mjs:184`), and the string derives the **dist folder name**
+(`vite.config.ts:44-45`), so the rename cascades out of `src/`. **Recommendation:**
+move only `MainViewProvider.ts` into it (item 13) and note the naming asymmetry in
+`AGENTS.md`.
+
+### F. `packages/desktop/src/*` filenames — **keep the `desktop` prefix**
+
+Ten of the 12 files moving in item 9 carry a redundant `desktop` prefix inside
+`packages/desktop/`. Dropping it reads better
+(`desktop/src/shared/shellMessages.ts`) but doubles the diff, destroys
+`git log --follow` continuity on 10 files at the exact moment strangers start
+reading history, and creates `packages/desktop/src/shared/` filenames that collide
+conceptually with root `src/shared/` reached via `@shared/*` **in the same files**.
+**Recommendation:** move the directory, keep the names.
+
+### G. `@types/*` — **delete** (item 2). `@traceViewer/*` — **add**, with the eslint pattern from §4.12.
+
+---
+
+## 6. Sequence
+
+The distinguishing property: **moves that break `git blame` and invalidate open
+branches are cheapest while the repo is private and has no forks.** Anything on the
+pre-flip list should be paid for now or deferred indefinitely.
+
+### Before the open-source flip
+
+**Wave 0 — blockers owned elsewhere.** Resolve root `LICENSE` (8 bytes, content
+`LICENSE\n`) and the contradictory `docs/package.json:22` `"license": "MIT"` against
+three packages declaring proprietary. Tracked in
+`2026-07-29-open-source-readiness.md:37-52,403-404` and
+`2026-08-01-open-source-readiness-audit.md:22-23,57`. Nothing in this document
+depends on it, but it gates the public push.
+
+**Wave 1 — free and parallelizable.** Items 1, 2, 3, 14, 15 plus every §4 doc edit.
+Zero blast radius, no ordering constraints, no atomicity requirements. Land item 1
+(`src/README.md`) first so the rest has a place to point.
+
+**Wave 2 — small atomic moves, parallelizable across items but each internally
+atomic.** Items 4, 5, 6, 7, 13. Each is one `git mv` plus 2-16 specifier rewrites.
+Item 5 should be sequenced _with_ item 18 if both are done, so its 16 lines change
+once.
+
+**Wave 3 — the blame-breaking moves. Pre-flip or never.**
+
+| Item                                               | Must be a single atomic commit because                                                                                                                        |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 8 (`src/tools/delegation`)                         | The move and the `toolRegistryCycle.vitest.ts:42` literal cannot be split — the test is red in between                                                        |
+| 9 (`packages/desktop/src/shared/`)                 | 48 specifiers across 31 files with two module-resolution regimes; a partial state does not typecheck                                                          |
+| 18 = §5.C (`src/test-kernel` → root `test-kernel`) | 848 renames + 9 config files + 3 ratchet path rewrites; see below                                                                                             |
+| §5.B (`@extCommon/*`) if adopted                   | 52 specifiers + 4 tsconfigs + 4 eslint sites + 2 scripts + the ratchet `SUBSYSTEM_ALIASES` rename must land together or the ratchet guard silently disappears |
+
+**The test-kernel move (§5.C), in full.** Config edits (9 files): `vitest.config.mjs`
+lines 18/21/26/28; `tsconfig.json:58` (alias) and `:77` (exclude — delete);
+`tsconfig.build.json:45` (exclude — delete, **only in this commit**; under
+`rootDir: "."` it is what stops `.d.ts` emit walking the whole repo, so deleting it
+speculatively makes `@texra-ai/agent`'s declaration build emit for 848 test files);
+`tsconfig.test-kernel.json` include globs; `knip.json:7`; `eslint.config.mjs:50`
+and `:540`; `packages/desktop/tsconfig.paths.json:50` **regenerated** via
+`scripts/sync-tsconfig-paths.mjs` (CI gates it at `ci.yml:139-140`).
+
+Ratchet path rewrites: `host-agent-mock-baseline.json` (40 entries),
+`knip-baseline.json` (2), `shared-schemas-deep-import-baseline.json` (1).
+`architecture-edges-baseline.json` and `host-agent-import-baseline.json` need
+**zero** — verified: the baseline has 0 test-kernel refs and
+`subsystemEdgeRatchet.vitest.ts:72` returns null for `subsystem === 'test-kernel'`.
+This is the load-bearing fact that makes a top-level `src/` move affordable here and
+nowhere else in the repo.
+
+**Rewriting those 40 baseline entries is not sufficient — the scan roots are also
+hardcoded in test code.** `hostAgentMockRatchet.vitest.ts:48-51` builds
+`HOST_DIRS` by resolving the literal paths `src/test-kernel/cli` and
+`src/test-kernel/desktop` against the repo root. After the move `sourceFilesUnder`
+finds no files, and because the assertions only require the current count to be
+**≤** baseline, zero sites trivially satisfies them: the suite stays green while
+silently guarding nothing. This is the same failure shape as the
+`excludeTestKernel` trap below, and it must be in the atomic commit. Both
+`HOST_DIRS` entries need rewriting alongside the baseline.
+
+Depth-anchored code — **22 files resolve paths at runtime with `../../..`**, and one
+is shared infrastructure: `src/test-kernel/support/repoScan.ts:10-13` sets
+`REPO_ROOT = resolve(<support dir>, '../../..')`, used by 5 architecture ratchets.
+Under a root-level `test-kernel/support/` that resolves _above_ the repo root. Also
+`desktopTestPaths.mts:7`, `cli/CliSkills.vitest.mts:52`,
+`tools/setup/ApplyTeamTool.vitest.mts:33`,
+`commands/AgentCreatorTemplateSchema.vitest.ts:17`.
+
+Test assertions that hardcode their own location: `src/test-kernel/scripts/AliasMapGeneration.vitest.ts:32` hard-asserts
+`'@test/*': ['src/test-kernel/*']`, and
+`src/test-kernel/desktop/ElectronCompositionRoot.vitest.mts:219-222` lists its own
+path in `exemptConsumers`. After the move the consumer scan reports the new path,
+the exemption stops matching, and the suite flags **itself** as an unauthorized
+`initializeDesktopProcessStores` consumer.
+
+**Do not blanket-delete `excludeTestKernel` call sites.** Six of eight are safely
+deletable (`progressEventHandlerRetirement.vitest.ts:35`,
+`sharedSchemasDeepImportRatchet.vitest.ts:560`,
+`sessionFactAmbientHelperRetirement.vitest.ts:28`,
+`dependencyDirection.vitest.ts:113` and its four siblings). Two are not:
+`src/test-kernel/architecture/agentRuntimeProgressEventsBoundary.vitest.ts:41-62`
+computes both `PRODUCTION_FILES = scanFiles(true)` and
+`ALL_SOURCE_FILES = scanFiles(false)`, and the `false` branch **deliberately** scans
+test-kernel — its allowlist at `:36-39` pins three `src/test-kernel/cli/*.vitest.mts`
+files as permitted importers of the NDJSON vocabulary. Move the tests to a root
+directory not in `SCAN_ROOTS` and delete the option, and the ratchet **stays green
+while losing its coverage**. Correct execution: **add** the new root to
+`SCAN_ROOTS` and re-express the partition by root.
+
+Verified unaffected by the move: CI (`ci.yml:206` is
+`pnpm run test --shard=…` with no path; the changes filter at `:60` is
+`grep -vE '^docs/|\.md$'`), and all four packaging paths — `.vscodeignore`'s
+`src/**` at `:15` is package-relative and never reaches root `src/`;
+`electron-builder.yml` `files:` is `dist` + `package.json` + node-pty;
+`packages/cli/package.json` and `packages/agent/package.json` ship `files: ["dist", …]`.
+No esbuild or Vite entry config references test-kernel. **Say this in the commit
+message so no reviewer re-derives it.**
+
+Doc rot: 135 test-kernel mentions across 48 `.md` files, of which only ~9 are
+gate-enforced (AGENTS.md ×4, `.claude/skills/code-review/references/review-checklist.md`
+×3, `docs/dev/verification.md` ×1); ~117 in `docs/proposals`, `docs/prds`, and
+`docs/architecture` are uncovered. Plus **6 production source files** carrying
+`src/test-kernel/...` doc comments that no gate sees (the scanner is `.md`-only):
+`src/platform/defaults/fsEntryTypeBits.ts:4`, `src/auth/config.ts:115,134`,
+`packages/desktop/src/renderer/desktopCommandPalette.ts:67`,
+`packages/extension/src/webview/frontend/persistence.ts:12`,
+`scripts/aliasUtils.mjs:47`, `scripts/check-dead-code-ratchet.mjs:12`.
+
+Before committing any Wave 3 item: do it in a scratch worktree and run
+`npm run typecheck && npm test && npm run lint && npm run check:tsconfig-paths &&
+npm run check:guidance-refs && node docs/scripts/check-root-docs.mjs`.
+
+### After the flip
+
+Items 10 (trace-viewer declarations), 11 and 12 (docs), plus any per-package README
+work. None breaks blame in source, none invalidates a code branch, and the docs
+moves conflict only with docs branches. Item 10's `knip-baseline.json` regeneration
+is easier to review once nothing else is moving.
+
+### Deliberately never
+
+Everything in §3.
+
+---
+
+## 7. Left alone deliberately
+
+So nobody "fixes" these later.
+
+1. **Directory naming.** 154 distinct segments under `src/` and `packages/*/src/`:
+   132 lowercase single-word, 19 camelCase, 1 kebab (`trace-viewer`, a package
+   name), 0 PascalCase, 0 snake_case. The two underscore-prefixed dirs
+   (`packages/cli/src/chat/tui/forms/_shared/`,
+   `packages/cli/src/commands/_helpers/`) are a deliberate "not a domain folder"
+   marker. State it as the rule; change nothing.
+
+2. **The alias system and its generation.** 8,439 alias imports vs 840 relative,
+   0 at depth 4+, enforced by the custom auto-fixable
+   `local/prefer-alias-for-deep-relative-imports`. `tsconfig.json` is the single
+   hand-edited source; `scripts/sync-tsconfig-paths.mjs` code-generates the
+   extension and desktop maps with a `--check` CI diff gate;
+   `scripts/aliases.mjs` derives the bundler map for all four Vite configs and
+   vitest. The 44/39-key delta between root and extension is intentional
+   derivation (`EXTENSION_EXCLUDED_ALIASES`), not drift. This is the single reason
+   every move above is affordable.
+
+3. **`config/ratchets/architecture-edges-baseline.json`.** 96 directed edges over
+   18 nodes with a `semantics` field explaining the type-only/value distinction.
+   It is the machine-checked layering document most repos never write, and it is an
+   asset for an open-source reader. Every proposal above is scoped to preserve it
+   rather than force a regeneration.
+
+4. **`src/agent/core/` and `src/agent/modelHandlers/`.** Clean decomposition with
+   READMEs (`definition/ flows/ state/ tools/ usage/`;
+   `anthropic/ google/ openai/ openrouter/ vscodelm/ support/ utils/`). Any future
+   reorg of `src/tools/` should copy this shape.
+
+5. **`src/platform/` and `src/controllers/`.** Interfaces at the root with 14
+   implementations under `defaults/` — a legible port/adapter split.
+   `src/controllers/` mirrors host views 1:1 with **zero** loose files at the
+   subsystem root.
+
+6. **`src/shared/schemas/index.ts`** and the other compliant barrels. It is an
+   explicitly documented public surface enforced by
+   `shared-schemas-deep-import-baseline.json` +
+   `sharedSchemasDeepImportRatchet.vitest.ts`, which classifies every deep import
+   as `forced` or `gratuitous`. `src/common/errors/index.ts` and
+   `src/utils/files/index.ts` carry hand-written "these are NOT re-exported"
+   notes — the no-convenience-barrels rule being enforced by hand. Total barrel
+   count is 38 across 2,417 files (1.6%).
+
+7. **The one-Vitest-root convention.** Zero colocated tests anywhere in `src/**`
+   or `packages/*/src/**` — verified by glob, and rarer than it sounds. Do not
+   "fix" test-kernel by scattering 848 suites next to their sources.
+   `src/test-kernel/architecture/` (10 ratchets, each named for what it pins) and
+   `src/test-kernel/support/` (a composition root registered at
+   `eslint.config.mjs:50` alongside `extension.ts` and `initPlatform.ts`) move as
+   units.
+
+8. **`packages/cli/src/`** — the best-organized host tree in the repo
+   (`commands/` one file per subcommand with `_helpers/`, `runtime/`, `schemas/`,
+   `onboarding/`, `bin/`). **`packages/desktop/src/{main,preload,renderer}`** —
+   correctly mirrors Electron's own process vocabulary even though it does not
+   match the other two hosts. **`packages/extension/resources/` internal shape** —
+   the categories are clean; only its 12 loose siblings at `packages/desktop/src/`
+   root were the problem.
+
+9. **`.github/`** — 12 workflows with prompts factored into `.github/prompts/`
+   (7 files, consumed by 6 workflows) rather than inlined in YAML, and tool
+   allowlists in `.github/automation/allowed-tools.json` keyed by workflow role.
+   This is a model other repos should copy.
+
+10. **The docs date-prefix gate.** `docs/scripts/check-root-docs.mjs` mandates
+    `YYYY-MM-DD-` in `prds`/`proposals`/`dev/audits`, rejects double-dated names,
+    and catches audit/prd/proposal-marked files anywhere lacking a prefix.
+    Compliance is 100%. **`docs/.vitepress/publicDocs.js`** is a genuine single
+    source of truth, deliberately dependency-free (`:5-8`) and _consumed_ rather
+    than duplicated by the gate — preserve that property. The second allowlist in
+    `.github/workflows/docs-deploy.yml:46-49` is stated defense-in-depth, not
+    accidental duplication.
+
+11. **`docs/prds/`** — a README index, 76/76 files with `created`/`updated`
+    frontmatter, and a `cli-tui-ink/` sub-package with its own README and an
+    `NN-`-ordered `mockups/` subdirectory. That subdirectory is the template
+    `docs/proposals/` should follow. **`docs/guide/`** — flat, kebab-case, 33
+    files; correct granularity for a user guide, do not subdivide.
+
+12. **`skills/` package shape** (all 14 exactly `SKILL.md` + `references/<one>.md`
+    - `agents/openai.yaml`), **`patches/`** (2 files, `<pkg>@<version>.patch`,
+      wired through `pnpm-workspace.yaml` `patchedDependencies`),
+      **`config/ratchets/` naming** (`<subject>-baseline.json`), and the split
+      between `.claude/` (repo-development skills) and `skills/` (product skills).
+
+13. **No cross-package duplication.** An exhaustive md5 sweep over every tracked
+    file in `packages/` and `src/` found exactly **one** byte-identical pair, and
+    it is a logo (`packages/desktop/build/icon.png` ==
+    `packages/extension/resources/logo-512x512.png`). Two hypotheses tested and
+    rejected: `packages/cli/src/runtime/updateChecker.ts` (456 lines) vs
+    `packages/desktop/src/main/desktopUpdateChecker.ts` (152) share their core via
+    `@shared/state/stateKeys` and `@utils/system/envFlags`; the ~40 same-basename
+    pairs (`agents.ts`, `history.ts`, `memory.ts`, `doctor.ts`, `tools.ts`,
+    `skills.ts`) are the CLI's deliberate thin-command / implementation split.
+
+14. **`src/tools/wolfram/test/check.wl`** is _not_ a runtime asset — it is an ad-hoc
+    physics scratchpad (spinor eigenstates, Pauli matrices, `Print` statements) with
+    no code path constructing its path. Do not rename it to `resources/`; that
+    replaces one misleading name with another. `git rm` it or leave it.
+
+---
+
+## Coverage gaps
+
+Stated honestly so nobody assumes more rigor than exists.
+
+- **Nothing was executed.** No `npm run typecheck`, no vitest run, no ratchet run,
+  no scratch `git mv`. Every "this does not change the edge set" claim is derived
+  from _reading_ `subsystemEdgeRatchet.vitest.ts`'s first-path-segment keying logic,
+  not from running it. Every blast radius is a grep count. The most likely place a
+  count is off is the ~22 depth-anchored relative escapes in `src/test-kernel/`.
+- **`src/agent/` was surveyed two levels deep.**
+  `src/agent/implementations/flows/` (20), `src/agent/storage/` (13), and
+  `src/agent/output/` (18) were counted but not read file-by-file. Finer-grained
+  issues may exist inside them.
+- **`docs/` findings were deliberately narrowed** to specific non-obvious calls per
+  the brief. The internal _content_ of the 148 prds/proposals was not read beyond
+  filenames, frontmatter presence, and `supersed*` greps — so claims about which
+  proposals are semantically superseded are limited to what those show.
+- **Test quality and coverage were not assessed** — no judgment on whether 807
+  suites over 165,855 LOC of production code is the right ratio, whether suites
+  duplicate each other, or whether any are skipped. Note `packages/agent` (10 files)
+  has no identifiable test directory and `packages/trace-viewer` (10 files) has one
+  test file; whether that is correct for thin re-export packages is unexamined.
+- **`supabase/`** (73 tracked files) was out of scope except where `docs/supabase/`
+  bears on it.
+- **`.vitepress/config.js` sidebar/nav structure** and the contents of
+  `docs/public/` assets were not examined.
+- **Whether the `@texra` npm scope is owned** could not be determined from the
+  repo — `release.yml` only ever publishes `@texra-ai/*`, which is suggestive but
+  not proof. Ask before acting on §5.A's rename branch (which is recommended
+  against anyway).
+- **One false lead recorded so nobody re-investigates:** an early grep suggested 14
+  external citations of `docs/reference/`. All 14 were inside gitignored
+  `packages/desktop/dist/` build output (Supabase SDK doc URLs). The true count of
+  citations from tracked non-docs files is **zero**. Similarly,
+  `docs/.vitepress/dist/` is 9.1 MB on disk but gitignored with 0 tracked files —
+  not a clone-size problem.

--- a/docs/proposals/2026-08-01-open-source-readiness-audit.md
+++ b/docs/proposals/2026-08-01-open-source-readiness-audit.md
@@ -1,0 +1,713 @@
+# TeXRA Open-Source Readiness Plan
+
+> **Supersedes parts of [`2026-07-29-open-source-readiness.md`](./2026-07-29-open-source-readiness.md)**
+> — specifically its history-rewrite, vendored-source, and telemetry
+> conclusions. Its licensing and product sections stand.
+
+Synthesis of eleven parallel audits plus an adversarial verification pass, against
+`10ffd138365eab7fc0a03be40d2b33337a794267`. Every claim below carries a file path; refuted
+claims are collected in §6 so they do not get re-litigated.
+
+---
+
+## 1. Verdict
+
+**No — not as-is, and not with this git history.** Two things make a visibility flip today
+actively harmful rather than merely premature: `git show v0.15.10:agents/prl/example_rebuttal_package.txt`
+publishes an anonymous APS referee's verbatim confidential report plus a named PRL editor and an
+internal manuscript ID belonging to a third party, reachable from 154 of 208 release tags; and
+three separate pieces of MIT-licensed third-party code (`src/agent/node/index.ts`,
+`packages/extension/resources/agents/write/beamerthemeconfposter.sty`,
+`@fortawesome/free-solid-svg-icons`) ship in the Marketplace VSIX and the signed desktop
+installers with their copyright notices stripped or absent — a live violation that publication
+merely makes greppable.
+
+**The single biggest decision, before anything else: choose the license _and_ the repo boundary
+together.** `LICENSE` is 8 bytes containing the word `LICENSE` (`wc -c LICENSE` → 8), while
+`packages/{extension,cli,agent}/LICENSE.txt:1-3` say "All rights reserved" and
+`docs/package.json:22` says `"license": "MIT"`. Nothing else can be sequenced until that is
+settled, because it gates the SXKDZ consent email, the NOTICE file, the CONTRIBUTING copy, and
+whether `supabase/` ships at all. The good news: this repo is in unusually good shape
+underneath — 8,170 tests pass on a cold clone, `typecheck`/`lint`/`format:check` are clean,
+history contains **zero** leaked credentials across a full 219,097-object scan, and the
+dependency graph has no GPL/AGPL/SSPL/BUSL anywhere. The blockers are five discrete pieces of
+work, not a rewrite.
+
+---
+
+## 2. Blockers
+
+Ordered by real-world consequence. All five must close before the visibility flip.
+
+### B1 — Confidential third-party peer-review correspondence in published git history
+
+|                                      |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Evidence**                         | `git show v0.15.10:agents/prl/example_rebuttal_package.txt` (21,931 B): `Dear Dr.~Garisto,` (PRL Managing Editor), `my manuscript (LK15932/Deng)` (internal APS ID), and three `\begin{referee}{A}` blocks reproducing an anonymous referee's report **verbatim and in full** ("The manuscript by Deng examines Bell state inequalities… At this stage, the manuscript does not yet meet this goal."), signed `Dong-Ling Deng`. Second, independent correspondence: `git show 7a02f5cd1:agents/prl/reply_to_editor.tex:9` → `Dear Dr.~Samindranath Mitra`. Sanitized twin at `agents/prl/template_reply_to_editor.tex` (`Dear Dr.~{EDITOR_NAME}`) proves the `example_*` file is the real filled-in instance, not a fixture. |
+| **Reach**                            | `git tag --contains 88b08e626` → **154 of 208 tags**; `git branch -r --contains` → 33 branches. `origin/backend` (tip `e648bf58e`, 2024-11-11) carries `agents/prl/example_rebuttal_letter.txt` independently, so a tag-only purge misses it.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| **Why blocker**                      | APS referee reports and editorial correspondence are confidential by the terms under which referees and editors participate. The referee, the two editors, and the corresponding author (a third party the maintainer is not a co-author of) never consented. This is not hygiene.                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| **Why the existing audit missed it** | `docs/proposals/2026-07-29-open-source-readiness.md:345` states "no rotation or history rewrite is required" and `:347` scopes its clean bill to "The working tree". The recorded scan matched credential _formats_, not prose. `docs/proposals/2026-07-24-open-source-release.md:205-206` sets the correct gate ("a secret and personal-data scan passes on both the release tree and the history being published") — it has provably not run.                                                                                                                                                                                                                                                                              |
+| **Fix**                              | One `git filter-repo --invert-paths` pass over a **fresh `git clone --mirror`** (this checkout is shallow — `.git/shallow` exists), removing `--path-glob 'agents/*'` at minimum. Delete or rewrite `origin/backend` in the same pass. Verify `git rev-list --objects --all \| grep -E 'example_rebuttal\|reply_to_(editor\|referees)'` returns empty, then `git push --mirror --force`. **Ref deletion is not an acceptable fallback** — GitHub keeps unreachable objects fetchable by SHA at `/commit/<sha>` indefinitely.                                                                                                                                                                                                 |
+| **Cost of delay**                    | Zero-cost today: GitHub API for this repo returns `"private":true, "forks_count":0, "stargazers_count":0` — nothing external can break. After the flip, a rewrite strands every SHA anyone has linked and forces a hard reset on every cloner. **The window closes at the flip.**                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| **Effort**                           | Hours (one maintenance window). Free riders in the same pass: `coauthor-python/prototypes/`, `Notebooks/` (4 verbatim Anthropic Cookbook notebooks, 10 blobs, largest object in the pack at 4,458,316 B), `*.vsix` (141 blobs).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+
+### B2 — `src/agent/node/index.ts` is an unattributed derivative of MIT-licensed PocketFlow-Typescript, already shipping
+
+|                        |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Evidence**           | Diffed against `The-Pocket/PocketFlow-Typescript` `src/index.ts` (MIT, © 2025 Victor Duarte and Zachary Huang). Verbatim carryover at `src/agent/node/index.ts:62` (`Node won't run successors. Use Flow.`), `:75`, `:85`, `:95-100` (`clone()` incl. the `clonedNode` local), `:233-241` (`_orchestrate` line-for-line, only `setParams(p)` → `setServices(...)`), `:249` (`throw new Error("Flow can't exec.")`), and an identical export list at `:252`. Independently corroborating: `:8` hardcodes `const CHANNEL = 'PocketFlow'`. |
+| **Attribution status** | Zero SPDX hits across 2,140 non-dist `.ts`/`.tsx` files. No `NOTICE`/`THIRD-PARTY-*` file exists anywhere. `docs/guide/acknowledgments.md` credits Prompt Poet (line 37) but never PocketFlow. `AGENTS.md:403-404` acknowledges descent in prose — which does not satisfy MIT's notice-retention clause.                                                                                                                                                                                                                                |
+| **Why blocker**        | MIT requires the copyright and permission notice "be included in all copies or substantial portions". TeXRA distributes this file **today** in the Marketplace VSIX and the signed desktop installers with no notice. It is an ongoing violation against a named third party, and the exact string `Flow can't exec.` is a one-line search.                                                                                                                                                                                             |
+| **Fix**                | Add upstream MIT text + "Copyright (c) 2025 Victor Duarte and Zachary Huang" to a `NOTICE` / `THIRD-PARTY-LICENSES` file; add a provenance header to `src/agent/node/index.ts`. **Ensure it ships**: `scripts/verify-extension-package-invariants.mjs:42` currently lists only `'LICENSE.txt'` in `REQUIRED_PACKAGED_PATHS`, and `packages/desktop/electron-builder.yml:29-41` ships no legal file at all. Also correct `docs/proposals/2026-07-29-open-source-readiness.md:355` ("No vendored third-party source.").                   |
+| **Not required**       | `CLAUDE.md:138` needs **no** correction — it is scoped to API surface (ruling out upstream's `BatchNode`/`params` channel), not provenance. MIT is compatible with any license you choose; this costs a notice, not a relicense.                                                                                                                                                                                                                                                                                                        |
+| **Effort**             | Hours.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+
+### B3 — A stripped-attribution MIT beamer theme ships inside the "All rights reserved" VSIX
+
+|                 |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Evidence**    | `packages/extension/resources/agents/write/beamerthemeconfposter.sty:1-11` is `anishathalye/gemini`'s `beamerthemegemini.sty:4-13` byte-for-byte **with the two attribution lines `% Gemini theme` / `% https://github.com/anishathalye/gemini` deleted**. Downstream matches: `\newcommand{\samelineand}{\qquad}`, `\heading`, the `headline title/author/institute` font set, the three itemize `\vrule width 0.5ex height 0.5ex` templates. `beamercolorthemempi.sty` is gemini's companion colortheme renamed — it sets gemini-only keys `headline rule` (:32), `block separator` (:40), `block alerted separator` (:45). gemini is MIT (© Anish Athalye). |
+| **Ships today** | Referenced by `template_poster.tex:4-5` (`\usetheme{confposter}` / `\usecolortheme{mpi}`) and `paper2poster.yaml`; not excluded by `packages/extension/.vscodeignore`. No credit in `docs/guide/acknowledgments.md`. Git provenance is unrecoverable — `git log --diff-filter=A` on the directory returns a single unrelated 2026 commit.                                                                                                                                                                                                                                                                                                                      |
+| **Why blocker** | This is worse than B2: the attribution comment was present upstream and is absent locally, and the file sits inside a package whose `LICENSE.txt:1-3` reads "TeXRA is proprietary software. All rights reserved." A LaTeX-literate audience notices this on day one.                                                                                                                                                                                                                                                                                                                                                                                           |
+| **Fix**         | Restore the upstream header + gemini's MIT text in both `.sty` files, add an `acknowledgments.md` entry, and fold into the same NOTICE file as B2. Do the same provenance check on `template_poster.tex` and `template_slide.tex` (unaudited).                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| **Effort**      | Hours.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+
+### B4 — `claude.yml` persists `BOT_PAT` into `.git/config`, then runs an agent with `Bash(node *)` over attacker-authored issue text
+
+**This is the only finding whose risk is _created_ by flipping to public.**
+
+|                                |                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Evidence**                   | `.github/workflows/claude.yml:55-59` — `actions/checkout@v6` with `token: ${{ env.GH_TOKEN }}` (= `secrets.BOT_PAT \|\| secrets.GITHUB_TOKEN`, `:21`) and **no** `persist-credentials: false`. Verified against `actions/checkout@v6`'s own `action.yml`: `persist-credentials` still `default: true`. The PAT lands in `.git/config` in the agent's cwd. Job holds `contents: write, pull-requests: write, issues: write, id-token: write` (`:47-52`).               |
+| **Tool surface**               | `.github/automation/allowed-tools.json`, key `claude-interactive` (selected at `claude.yml:85`) includes `Read` (opens `.git/config`) and `Bash(node *)` — i.e. `node -e '<arbitrary>'`, unrestricted RCE with network egress. Longstanding, not a typo: same entry in the pre-extraction action at `344d2c82b~1:.github/actions/claude-code-with-provider/action.yml:296`.                                                                                           |
+| **Gate asymmetry**             | `claude.yml:35` correctly gates the `issues` event on `github.event.issue.author_association`; `claude.yml:32` gates `issue_comment` **only** on `github.event.comment.author_association`. Post-publication an outsider's issue _body_ becomes agent-visible instructions the moment any MEMBER/COLLABORATOR replies `@claude`. The body demonstrably reaches the job: `claude.yml:130-132` forwards `comment-body`, `issue-body`, `issue-title`.                    |
+| **Not mitigated by**           | The `.trusted-actions` second checkout (`claude.yml:61-66`) only pins the _prompt_ (`:89`) and _tool preset_ (`:86`) to base-ref history. It sanitizes nothing about the untrusted issue body.                                                                                                                                                                                                                                                                        |
+| **Repo already knows the fix** | `.github/workflows/texra-code-review.yml:94` and `:104` both set `persist-credentials: false`, with `:110-111` explaining why.                                                                                                                                                                                                                                                                                                                                        |
+| **Fix**                        | (1) `persist-credentials: false` at `claude.yml:57-59` — the agent reaches GitHub via `mcp__github__*`, not git creds. (2) Extend the `claude.yml:32-33` `if:` to also require `github.event.issue.author_association` / `pull_request.author_association` in the trusted set. (3) Drop `Bash(node *)` from `claude-interactive` in favour of the specific `Bash(npm run *)` entries already listed beside it. (4) Confirm `BOT_PAT` is fine-grained and repo-scoped. |
+| **Effort**                     | Hours (the checkout flag is one line).                                                                                                                                                                                                                                                                                                                                                                                                                                |
+
+### B5 — An outside contributor holds copyright in a substantial merged commit, with no CLA or DCO
+
+|                                                  |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Evidence**                                     | `f7528670de9162d4e534aafa2d5135c47e865368`, `SXKDZ <Mr.SXKDZ@Gmail.com>`, "feat(desktop): modernize the Electron workspace UI (#9216)" — `packages/desktop/src/desktopTaskShell.ts` +491, `desktopWorkspaceMessages.ts` +263, `main/desktopBrowserViews.ts` +238, `main/desktopAgentExecution.ts` +648, `scripts/dev.mjs` +187, plus `electron-builder.yml` and `.github/workflows/ci.yml`. Not de minimis.                                                                                       |
+| **No inbound grant**                             | Full listing of `.github/`: `FUNDING.yml`, `PULL_REQUEST_TEMPLATE.md`, `automation/`, `dependabot.yml`, `labels.yml`, `prompts/`, `workflows/`. No CODEOWNERS, no CLA, no DCO. No `CONTRIBUTING.md` anywhere in the tree. GitHub ToS D.6 pins the inbound grant to the outbound notice in the repo at merge time — which was `packages/*/LICENSE.txt:1-3` "All rights reserved", an end-user grant, **not** a sublicensable grant to the repo owner. D.6 does not supply relicensing rights here. |
+| **Why I rate this blocker (verifier said high)** | Publishing `packages/desktop` under a new OSS license distributes SXKDZ's copyrighted work under terms he has never granted. That is the same class of exposure as B2/B3 — a license violation against a named third party — not merely an incomplete release. It is also **the only item on this list that becomes strictly harder after the flip**, since publication multiplies the number of holders.                                                                                         |
+| **Fix**                                          | A one-line email agreement from `Mr.SXKDZ@Gmail.com` consenting to relicense `f7528670` under the chosen license. Then adopt DCO (`Signed-off-by`, low friction) or CLA (required if you want to preserve the `TERMS_OF_SERVICE.md:62`/`:156` assignment-on-incorporation option) and enforce it in CI from day one. Add `.github/CODEOWNERS` in the same change.                                                                                                                                 |
+| **Not a concern**                                | `LionSR` (5 commits) is the maintainer's own account and every commit is a `"version"`-line bump across 4-5 `package.json` files — uncopyrightable. 361 commits authored as `Claude <noreply@anthropic.com>` raise an authorship-of-record question worth one sentence in the governance doc, nothing more.                                                                                                                                                                                       |
+| **Effort**                                       | Days (waiting on a human reply — **start this today**, it is the long pole).                                                                                                                                                                                                                                                                                                                                                                                                                      |
+
+---
+
+## 3. The open-core decision
+
+Everything else hangs off this. Two sub-decisions that must be made together: **what license**, and
+**does `supabase/` ship**.
+
+### 3.1 What is actually coupled
+
+| Surface                                     | Status                                                  | Evidence                                                                                                                                                                                                                        |
+| ------------------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `supabase/functions/relay/`                 | Contains a **broken** enforcement control (see below)   | `relay/index.ts:510` → `enforcement.ts:88` → `migrations/20260609212200_drop_usage_base_view.sql:14-25`                                                                                                                         |
+| `supabase/functions/_shared/emailPolicy.ts` | Anti-abuse logic whose value depends on non-publication | `:3` `MIN_GITHUB_ACCOUNT_AGE_DAYS = 30`, `:6-35` disposable set, `:39-44` privacy-relay set. Already decided private at `docs/proposals/2026-08-01-backend-decoupling-plan.md:111`, `:614-619`, `:711` (D1)                     |
+| `supabase/migrations/`                      | **Cannot rebuild the schema it references**             | `rg '^CREATE TABLE' supabase/migrations/*.sql` → 6 tables. `profiles`, `remote_agents`, `agent_whitelist` never created, yet `20260517100300_rls_initplan_wrap_auth_uid.sql:7-31` `ALTER POLICY` on all three                   |
+| `docs/supabase/` (13 files)                 | Unclassified; contains a live ops runbook               | `AUTH_OPERATIONS.md:5,23-27,55` (June 2026 OAuth outage, `before-user-created` hook URL). `supabase/README.md:25-29` bans runbooks from a public repo — but that rule only guards `supabase/`, so these slipped past            |
+| `prompts/agents/remote/*.yaml` (21 files)   | Gated behind Ultra in-product, but in the tree          | `src/controllers/settingsView/SettingsRemoteAgentPromptController.ts:24-28` vs. full `systemPrompt:` bodies in `simplifier.yaml:19+`, `elevate.yaml` (40 KB); `scripts/sync-remote-agents.mjs:242` calls them "Source of truth" |
+| Cross-tree test imports                     | 6 vitest files import Deno source by relative path      | Already enumerated verbatim at `docs/proposals/2026-08-01-backend-decoupling-plan.md:635`, with the replacement CI (golden fixtures) specified at `:655-671`                                                                    |
+
+**The load-bearing new fact:** the relay's monthly spend cap is computed **entirely from rows the
+client wrote**. `relay/index.ts:510` → `enforcement.ts:88` → an RPC that is bare
+`SELECT COALESCE(SUM(r.cost),0) FROM public.usage_logs r WHERE r.used_relay = TRUE …`
+(`20260609212200_drop_usage_base_view.sql:14-25`). Both summed columns arrive verbatim from the
+client (`log-usage/usageValidation.ts:26,33` → `log-usage/index.ts:138,142`), and the relay
+itself writes no usage row anywhere in its 857 lines — it forwards the response unmodified
+(`index.ts:803-838`). A caller holding a relay JWT or a 365-day CI token
+(`relay-tokens/index.ts:37-38`) who simply never POSTs `log-usage` keeps their aggregate at $0
+forever, so `TIER_SPENDING_LIMITS` (`relay/models.ts:239-243`, $10/$50/$300) never fires.
+Remaining controls are per-request only: 20 req/min + 4 concurrent for free
+(`models.ts:249-253`), 2 MiB body, 8192 output tokens (`requestLimits.ts:15-16`). Blast radius is
+bounded — `relay/index.ts:500` rejects openai/anthropic/google below Ultra _before_ the spend
+check — so the exposure is the cheap-provider set (deepseek/moonshot/minimax/glm/xai). Still five
+to six figures a month per abusing account. **`docs/proposals/2026-07-29-open-source-readiness.md:110-111`
+("Enforcement is server-side and does not depend on secrecy") is wrong for this specific control.**
+
+### 3.2 The three options
+
+| Option                                                                                                                                                    | What it means                                                                                                   | Trade-offs                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **A. Publish everything**                                                                                                                                 | `supabase/`, `docs/supabase/`, `prompts/agents/remote/` all public under one license                            | ✅ Cleanest story, no boundary to maintain, no CI split work. ❌ Publishes `emailPolicy.ts`'s exact blocklist and 30-day threshold; publishes the broken spend cap as a copy-pasteable recipe; publishes `AUTH_OPERATIONS.md`'s failure-mode map; makes `SettingsRemoteAgentPromptController.ts:24-28` absurd (the extension refuses to show a user a file they can `cat` from their clone). Requires fixing the auth-github audience bypass and the spend cap **first**.                                                                                                                                                                                        |
+| **B. Split `supabase/` (+ `docs/supabase/`) into a private repo**                                                                                         | Public repo = the three hosts + core; private repo = edge functions, migrations, ops docs, `src/auth/config.ts` | ✅ Already designed and costed by the maintainer at `docs/proposals/2026-08-01-backend-decoupling-plan.md` (D1 at `:711` recommends exactly this; `:633-671` specifies the moves and the golden-fixture CI replacement). ✅ Removes the honest-signal problem: you stop publishing enforcement you know is advisory. ❌ Requires deleting the `ci.yml:123-128` Deno step and porting 6 vitest files (both already enumerated at `:635`). ❌ You must still fix the spend cap and auth-github — privacy is not a fix.                                                                                                                                             |
+| **C. Publish everything under a license that matches the business model** (e.g. BSL/PolyForm with a converting date, or AGPL with a commercial exception) | Source-available rather than OSI-open                                                                           | ✅ Lets `supabase/` stay in-tree without inviting a competing relay. ❌ Requires **fresh consent from SXKDZ specifically for that license** (B5), which is a harder ask than MIT/Apache. ❌ Contradicts `docs/guide/open-source.md:242` ("All of these projects are MIT-licensed") on a page linked from the footer of every texra.ai page (`docs/.vitepress/config.js:184`). ❌ Kills the academic-adoption story — a BSL tool is one a university legal office will bounce. ❌ Provenance debt (B2/B3) is _worse_ under a restrictive license, since you would be sublicensing stripped MIT code under terms MIT does not permit you to impose without notice. |
+
+### 3.3 Recommendation
+
+**Option B, with Apache-2.0 on the public repo.**
+
+- **B over A** because the maintainer already reached this conclusion with better information
+  than this audit has (`2026-08-01-backend-decoupling-plan.md:711`, D1: "private — protects
+  `emailPolicy.ts` / `requestGate.ts` / `enforcement.ts`"), and because the relay spend cap being
+  advisory means publishing `enforcement.ts` today would publish a control the maintainer believes
+  works and does not. Fix the control on your own schedule in a private repo; do not put "here is
+  how our billing cap fails" on the front page of a launch.
+- **B over C** because C's cost lands squarely on B5 — you would be asking a contributor to
+  consent to a source-available license, which is materially harder than consenting to a standard
+  one, and you would be doing it under time pressure.
+- **Apache-2.0 over MIT** for two concrete reasons here: it has an explicit patent grant (relevant
+  for an academic tool that may attract institutional adoption), and its §4(b)/§4(d) notice
+  machinery gives you a natural home for the B2/B3/Font-Awesome attributions you now have to ship
+  anyway. Both are compatible with the inbound MIT you are consuming. If simplicity wins, MIT is
+  fine — but pick one and fix all nine declaration sites in a single commit (see §4.1).
+- **`prompts/agents/remote/` stays public** and the Ultra gate at
+  `SettingsRemoteAgentPromptController.ts:24-28` gets deleted. `2026-08-01-backend-decoupling-plan.md:713`
+  (D2) already leans this way; shipping a paywall on a file that is in the user's own clone is the
+  kind of contradiction people screenshot. Note the files are in 5,377 commits of history, so
+  "move them private later" is not available without another rewrite.
+- **Split `TERMS_OF_SERVICE.md`.** `:29-30` forbid modification and redistribution and `:62`
+  asserts proprietary ownership. Scope those to the hosted Service (relay, accounts, quotas) and
+  explicitly carve out the repo's code as governed by the new license, or users sit under two
+  contradictory grants simultaneously.
+
+---
+
+## 4. High priority — fix before launch
+
+### 4.1 License declarations (one commit, once the decision lands)
+
+Nine sites, no two of which agree today. `docs/proposals/2026-07-29-open-source-readiness.md:43-53`
+has six of them accurately; the two it misses are:
+
+- **`docs/package.json:22` `"license": "MIT"`** — the only declaration in the tree that _grants_
+  rather than reserves, on a package with no `"private": true`. Scope-limiter worth recording:
+  `docs/` is outside the workspace (`pnpm-workspace.yaml` globs `packages/*` only), is never
+  published to npm, and GitHub's license detection reads the repo-root `LICENSE` — so this is a
+  contradiction in a tracked file, not an effective grant. Still fix it; the licensing sweep will
+  otherwise complete around it.
+- **Copyright-line disagreement**: `README.md:148` "© TeXRA Team 2025–2026" vs.
+  `docs/.vitepress/config.js:185` "Copyright © 2024-2026 TeXRA Team", for a holder that
+  `TERMS_OF_SERVICE.md:13` defines as "not a corporate entity". A third string exists upstream:
+  `texra-ai/texra-scientific-skills`'s LICENSE says "Copyright (c) 2026 texra-ai".
+
+Also set `license` on `packages/desktop/package.json` and `packages/trace-viewer/package.json`
+(neither has one; both ship inside the installer despite `private: true`).
+
+### 4.2 Backend security defects (fix regardless of where `supabase/` lives)
+
+| Item                                                                                         | Evidence                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | Severity |
+| -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| **`auth-github /exchange` accepts any GitHub access token with no OAuth-app audience check** | `supabase/functions/auth-github/index.ts:110-183` — `validateGitHubToken` calls `api.github.com/user` (`:129`) and `/user/emails` (`:161`) and reads neither `X-OAuth-Client-Id` nor `X-OAuth-Scopes`. Repo-wide grep for those headers across `supabase/`, `src/`, `packages/` → **zero hits**. Route `:189-201` accepts only `{github_token}`; success reaches `mintGoTrueSession` at `:357` and returns a refreshable session at `:370`. Sign-up policy checks (`checkEmailDomain` `:295`, `checkGitHubAccountAge` `:304`) sit only in the **new-user** branch — for an existing TeXRA user a bare third-party token walks from `:214` to `:357` with no gate at all. No nonce, no PKCE, no per-route rate limit. Explicitly in scope per `SECURITY.md:32-33`.                                                                              | High     |
+| **Relay spend cap is client-attested** (see §3.1)                                            | `relay/index.ts:510`, `enforcement.ts:88`, `20260609212200_drop_usage_base_view.sql:14-25`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | High     |
+| **LLM picks its own privilege level for spawned agent CLIs**                                 | `src/tools/codex.ts:121` puts `sandbox_mode` (incl. `'danger-full-access'`, `agentCliSettings.ts:23-27`) in the **model-facing** schema; `codex.ts:552-555` only fills a default when the model _omitted_ it, then passes it through at `:513`→`:521`. Same shape at `claudeAgent.ts:116-118` / `:555-556` / `:243-245` (`bypassPermissions` → `allowDangerouslySkipPermissions = true`). The only gate is `bashApproval.ts:83-88`, which returns `{action:'approve'}` unconditionally when the stream is bypassed — and the bypass is **stream-scoped, not command-scoped** (`bashApproval.ts:42-43` via `sessionBypassAccessors.ts`), so a "don't ask again" on a benign `latexmk` silently pre-approves a later `danger-full-access` launch in the same stream. Squarely `SECURITY.md:31-37` ("Prompt injection that escalates privilege"). | High     |
+
+For the third: the escalation is **not** invisible (`codex.ts:558` and `claudeAgent.ts:562`
+interpolate the mode into the approval label) and **not** undocumented
+(`docs/guide/agent-integrations.md:64` states the override exists). The defect is the missing
+_ceiling_: treat `getCodexSandboxMode()` / `getClaudeAgentPermissionMode()` as a maximum and
+reject or loudly downgrade anything above it — or remove the fields from the model-facing schemas
+entirely, since the model has no basis for choosing them.
+
+### 4.3 Contributor-breaking build failures
+
+- **Windows cannot build the extension or the docs at all.** `packages/extension/package.json:1813`
+  `"vite:webviews": "… && for v in progressView settingsView webview; do VITE_WEBVIEW=$v vite build; done"`,
+  `:1814`, `:1815` (`concurrently "VITE_WEBVIEW=… vite build --watch"`), `:1804`
+  (`[ "$SKIP_VSCE_PREPUBLISH" = "1" ] || …`), `:1820` (`mkdir -p …`); `docs/package.json:6-7`
+  (`cp ../TERMS_OF_SERVICE.md terms.md`). All POSIX-only; pnpm spawns through `cmd.exe` on
+  Windows. No `.npmrc`, no `pnpm.scriptShell`, no `.devcontainer/`, and zero occurrences of
+  `windows|wsl|cmd.exe|powershell` in `README.md`, `AGENTS.md`, `CLAUDE.md`, or `docs/dev/*.md`.
+  The F5 path is affected: `.vscode/launch.json:16` → `.vscode/tasks.json:7` (`isDefault: true`)
+  → `watch:fast` → `vite:webviews:watch`. Root `package.json` scripts are Node-based and portable,
+  so the breakage is localized. **Fix**: move the loops/copies into `scripts/*.mjs` Node helpers,
+  or state Windows-unsupported-for-dev + recommend WSL in one line. Silent `cmd.exe` syntax errors
+  are the worst of both. _(The maintainer's §4.6 covers Windows **test** failures and never
+  notices the build is unrunnable there.)_
+- **Every Windows checkout fails `format:check` and is blocked by pre-commit.** `.gitattributes`
+  is one line — `.github/workflows/*.lock.yml linguist-generated=true merge=ours` — and
+  `ls .github/workflows` shows 13 plain `.yml` files, so the rule is dead. `.prettierrc` has no
+  `endOfLine`; no `.editorconfig` exists; `git ls-files --eol` → `3101 i/lf`. Gates:
+  `.github/workflows/ci.yml:110` and `.pre-commit-config.yaml:4-8`. **Fix**: add
+  `* text=auto eol=lf`, drop the dead rule. _(The "unmergeable 3,100-file diff" is refuted —
+  git's clean filter re-normalizes under `core.autocrlf=true`. The damage is red CI plus a
+  pre-commit hook that refuses every commit until the contributor discovers `core.autocrlf=false`.)_
+
+### 4.4 Repo identity — the sweep that will report complete while still broken
+
+`docs/proposals/2026-07-29-open-source-readiness.md:132-150` (§3.1) enumerates manifests, README,
+guide docs, `config.js`, and `.github/labels.yml`. It was built from a ripgrep sweep, and
+**ripgrep skips dotfiles by default** — so `.github/**` (9 hits) and `.claude/**` are absent from
+its list. Re-run with `rg --hidden`. Uncovered instances:
+
+| Site                                                                                                                                 | What breaks                                                                                                                                                                                                                                                                                                                                                                                                |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `.claude/skills/tech-debt-tournament/SKILL.md:14`, `:21`, `:25`                                                                      | Ships "Ledger issue: **LionSR/TeXRA#8974**" and `query: "repo:LionSR/TeXRA is:issue label:tech-debt"` — a user-invocable skill that searches a repo outsiders cannot read. Either parameterise from runtime context (as `.github/prompts/repository-quality-improver-prompt.md` already does) or move it out of the published tree; it is maintainer process, unlike `code-review`/`texra-cli`/`releasing` |
+| `.claude/skills/code-review/references/review-checklist.md:125,128,139`                                                              | Makes "a dated #6981 row" a **merge blocker** and cites "the #7210 pattern" — normative gates pointing at issues an outsider cannot open, in the skill `CLAUDE.md` tells every contributor to load                                                                                                                                                                                                         |
+| `src/test-kernel/agent/followUp/ToolUseDispatchInterruption.vitest.ts:149`, `src/test-kernel/tools/GitHubPrTypes.vitest.ts:24,40,62` | `LionSR/TeXRA` fixtures                                                                                                                                                                                                                                                                                                                                                                                    |
+| `docs/supabase/REMOTE_AGENTS_IMPLEMENTATION.md:184`, `MIGRATION_UNIFY_MULTIPLE.md:48`, `SUPABASE_SETUP.md:196,729-730`               | Stale `LionSR` publisher identity, contradicted by `packages/extension/package.json:6` `"publisher": "texra-ai"` and `src/auth/config.ts:241`                                                                                                                                                                                                                                                              |
+
+### 4.5 Stale docs that publish for the first time on flip day
+
+`docs/supabase/` is excluded from texra.ai (`docs/.vitepress/publicDocs.js:45` — `'supabase/**'`
+in `srcExclude`) and is **not counted** by the readiness audit: `:120-122` states "145 files
+across `docs/prds/` (77), `docs/proposals/` (68), …" and 77 + 68 = 145 exactly, so the four
+trailing directories contribute nothing and `docs/supabase/` (13), `docs/pocketflow/` (1),
+`docs/skills/` (1) are never named. Fifteen unlisted files publish by default. Concretely wrong:
+
+- `REMOTE_AGENTS_IMPLEMENTATION.md:103-107` tells self-hosters to set three VS Code settings
+  (`TeXRA: Auth › Supabase Url`, `Auth › Supabase Anon Key`, `Remote Agents › Edge Function Url`).
+  All 52 keys across the 18 `contributes.configuration` sections in
+  `packages/extension/package.json` were enumerated; filtered on `/auth|relay|url|supabase|remote/i`
+  → **zero matches**. All three settings are fiction.
+- `RELAY_SETUP.md:9-11` states $3/M tier boundaries; `supabase/functions/relay/models.ts:130-131`
+  says 1.5 / 9.
+- `MIGRATION_PREMIUM_TO_RESEARCHER.sql:21` `CHECK (tier IN ('free','researcher'))` vs.
+  `src/auth/config.ts:119` `z.enum(['free','Max','Ultra'])`.
+- `AUTH_OPERATIONS.md` is an incident runbook — the exact artifact `supabase/README.md:25-29`
+  forbids in a public repo. The rule only guards `supabase/`, so it slipped past.
+
+**Fix**: delete or rewrite these four files; move `AUTH_OPERATIONS.md` and the operational SQL to
+the private repo. Note `scripts/sync-remote-agents.mjs:21,242` writes
+`docs/supabase/SYNC_REMOTE_AGENTS.sql`, so it moves with them or gets repointed.
+
+_(Do **not** add env-var backend-override plumbing on the strength of these docs — see §6.)_
+
+### 4.6 The `docs/proposals` split will break CI, and the readiness audit does not say so
+
+`scripts/check-guidance-refs.mjs:26-27` (`GUIDANCE_FILES = ['CLAUDE.md','AGENTS.md']`,
+`GUIDANCE_DIRS = ['.claude/skills','docs/dev']`) plus `:61-73` (`PATH_PREFIXES` includes `'docs/'`)
+fails any unresolvable cited path, and it runs as the **deliberately ungated** `guidance-refs` job
+(`.github/workflows/ci.yml:142-166`). Load-bearing citations that break on a split:
+
+- `CLAUDE.md:90`, `.claude/skills/code-review/SKILL.md:20`, `review-checklist.md:134` →
+  `docs/proposals/2026-06-10-error-pipeline-and-ownership.md`
+- `review-checklist.md:123` → `docs/proposals/2026-07-07-fewer-elements.md` (source of the R1/R5–R8
+  rules the PR template enforces)
+- `review-checklist.md:113` → `docs/proposals/2026-07-03-tech-debt-audit.md`
+- `.claude/skills/texra-cli/SKILL.md:115` → `docs/proposals/2026-07-03-ink-practices-from-claude-code.md`
+- `CLAUDE.md:136`, `AGENTS.md:407` → `docs/pocketflow/state_architecture.md`
+
+**Fix**: inline the load-bearing content into `AGENTS.md` / the review checklist first, so the
+rules stand alone; then let the proposals become non-normative history. Run
+`scripts/check-guidance-refs.mjs` as the acceptance test for whichever split you choose.
+
+---
+
+## 5. Medium / post-launch
+
+### Legal & attribution (one file closes most of it)
+
+Generate `THIRD-PARTY-LICENSES.txt` at build time (`pnpm licenses list --json` or
+`license-checker-rseidelsohn`) and add it to `REQUIRED_PACKAGED_PATHS` in
+`scripts/verify-extension-package-invariants.mjs:41-58` and to `files`/`extraResources` in
+`packages/desktop/electron-builder.yml:29-51`. Bundlers are not a mitigation:
+`packages/extension/esbuild.config.mjs:42` sets `minify: production`,
+`packages/extension/vite.config.ts:34` sets `minify: 'esbuild'`, neither sets `legalComments`, and
+the built 9,762,585-byte `dist/extension.js` contains **12** `@license`/`Copyright (c)`
+occurrences total. Fold in:
+
+- **B2 (PocketFlow)** and **B3 (gemini)**.
+- **Font Awesome Free**, `(CC-BY-4.0 AND MIT)` per
+  `node_modules/.pnpm/@fortawesome+free-solid-svg-icons@7.3.1/…/package.json:31`. CC BY 4.0
+  attribution is mandatory and is **not** satisfied by your own LICENSE. The artwork is re-emitted,
+  not linked: `src/shared/wa/webAwesomeIcons.ts` imports 125 icons (`:2-126`), `iconSvg()`
+  (`:143-151`) rebuilds `<path d="…"/>` from `svgPathData`, `:310` wraps it as a `data:` URI and
+  `:313-322` registers it for both the TeXRA and WA `default` libraries — so it renders in all four
+  hosts. Upstream ships a `LICENSE.txt` that reaches no TeXRA artifact.
+  `docs/proposals/2026-07-29-open-source-readiness.md:351-355` classifies the tail as "remainder
+  permissive" and never names CC-BY-4.0. An in-app credit in settings/about is the cleaner fix.
+- **`patches/openai@6.46.0.patch`** — Apache-2.0 NOTICE propagation. (The §4(b) "modified files"
+  concern is largely satisfied already: a version-named patch file in `patches/` is a more legible
+  change record than a header comment. `patches/ink@7.1.0.patch` is MIT, same treatment.)
+- **`skills/`** — `ls -a skills/` returns exactly the 14 directories that
+  `docs/guide/open-source.md:145-153,171-177` enumerate as the contents of
+  `texra-ai/texra-scientific-skills` and `texra-ai/texra-lean-skills`, with **no** LICENSE, README,
+  or provenance file at any level. The public counterparts are MIT
+  (`raw.githubusercontent.com/texra-ai/texra-scientific-skills/main/LICENSE` → "Copyright (c) 2026
+  texra-ai"), so identical content is offered under two different licenses simultaneously — and
+  it is redistributed under this repo's terms via `scripts/copy-extension-skills.mjs:11,17` →
+  `verify-extension-package-invariants.mjs:53` and `electron-builder.yml:48-51`. Put a LICENSE in
+  `skills/` and record which copy is canonical.
+
+Verified-clean and worth preserving: **no GPL/LGPL/AGPL/SSPL/BUSL/Commons Clause** anywhere in the
+735-package graph; only file-level MPL-2.0 (lightningcss, dompurify dual MPL/Apache), used
+unmodified. Add a CI job that fails on a disallowed license class so this stays true.
+
+### CI / release
+
+| Item                                                                                             | Evidence                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | Note                                                                                                                                                                                                                                                                                                                                                                                           |
+| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **npm provenance is disabled with a comment that expires on the flip**                           | `.github/workflows/release.yml:143-151` — "this repo is private, so … provenance generation must be disabled or npm rejects the publish with a 422" + `NPM_CONFIG_PROVENANCE: 'false'`. Duplicate at `:196-200` in the `publish-agent` job, itself dead-gated at `:157` (`if: ${{ false && … }}`). `id-token: write` is already present (`:161-163`) and `npm@^11.5.1` is already installed (`:138-139`).                                                                                                                                    | **Ordering matters**: `packages/cli/package.json:10` `repository.url` is `git+https://github.com/texra-ai/texra-issues.git`, not the build repo. Fix repository fields in §4.4 **first**, then delete the env block — otherwise you trade a 422 for a repository-mismatch failure. Failure mode is silent: the publish keeps succeeding, unattested, forever.                                  |
+| **The docs boundary gate never runs for a mixed code+docs PR**                                   | `docs/scripts/check-root-docs.mjs:1-9` calls itself a CI gate. Its only CI path is `npm run docs:build` (`docs/package.json:11` → `:9`) at `ci.yml:401`, inside `docs-check` (`ci.yml:363`) whose condition at `:370` is `needs.changes.outputs.code != 'true'`; `ci.yml:59-60` sets `code=true` for any changed file outside `docs/` that is not `*.md`. Post-merge backstop is `docs-deploy.yml:42-44`, so the stray doc merges and the next push to main fails Deploy Docs against the dist-root allowlist (`:59-90`), freezing texra.ai. | Fix: add `node docs/scripts/check-root-docs.mjs` to the already-ungated `guidance-refs` job (`ci.yml:142-166`), and correct the script header. One line.                                                                                                                                                                                                                                       |
+| **8 of 9 edge functions, incl. the entire auth surface, sit outside every gate**                 | `ci.yml:122-128` is the repo's only Deno step, `working-directory: supabase/functions/relay`. `find supabase -name 'deno.json*'` → 8 configs, 7 unchecked; `_shared/` (9 modules incl. `auth.ts`, `crypto.ts`, `goTrueSession.ts`, `relayCiToken.ts`) has no `deno.json` at all. Three committed test files never execute: `auth-device/approvalRequest_test.ts`, `before-user-created/webhookVerification_test.ts`, `log-usage/usageValidation_test.ts`.                                                                                    | Only relevant if `supabase/` stays public. If it moves private, this becomes the private repo's problem — but it is still a real hole on the surface `SECURITY.md:32,39` puts in scope.                                                                                                                                                                                                        |
+| **PR CI never builds desktop bundles or the CLI production bundle**                              | `ci.yml:206-282` runs only `validate:tui`, `pnpm --filter texra build:fast`, `check:vsix-contents`; `runtime-validation` is `if: github.event_name != 'pull_request'` (`:322-323`); `desktop-package.yml:2-3` is `workflow_dispatch:` only. `validate:tui` builds a _separate_ 50-line entry (`packages/cli/scripts/build-harness.mjs`) — `packages/cli/scripts/build-bundle.mjs` (100 lines) is never exercised on a PR, and neither is `check:architecture`.                                                                               | `ci.yml:261-263` intentionally excludes desktop _packaging_; `desktop:build` (esbuild + Vite) is a different, cheap thing not covered by that rationale.                                                                                                                                                                                                                                       |
+| **`check:remote-agents` is a drift gate nothing invokes**                                        | `package.json:58`. Every sibling has a caller (`check:dead-code-ratchet` → `ci.yml:131`, `check:tsconfig-paths` → `:140`, `check:vsix-contents` → `:264` and `release.yml:77`, the five desktop ones → `desktop-package.yml`). This is the only unwired one.                                                                                                                                                                                                                                                                                 | One line next to `ci.yml:140`.                                                                                                                                                                                                                                                                                                                                                                 |
+| **Both AI review workflows silently no-op on fork PRs and report green**                         | `claude-code-review.yml:102-107` writes `skip=true` + a `reason` output; every later step is gated on `skip != 'true'` (`:110,116,124,132,156,175`) **including the failure gate at `:172-182`**, so the job reports success having done nothing. `rg 'provider-token.outputs'` confirms `reason` is written once and read **zero** times. Contrast `texra-code-review.yml:63`, which emits `::notice::`.                                                                                                                                    | This is the automation equivalent of `catch {}` — the defect class `CLAUDE.md` names. Post a comment or mark the check neutral.                                                                                                                                                                                                                                                                |
+| **`.trusted-actions` protects the prompt but the prompt reads PR-controlled guidance**           | `claude-code-review.yml:109-113` checks out the PR (no `ref:`) while `:115-121` puts only the base ref in `.trusted-actions`; the trusted prompt `.github/prompts/claude-code-review-prompt.md:5-7` then says "Read `.claude/skills/code-review/SKILL.md`", "Consult `CLAUDE.md` and `AGENTS.md`" — all resolving into the untrusted checkout.                                                                                                                                                                                               | Bounded: fork PRs skip entirely (no secrets). Applies to same-repo branches, and widens when the repo moves to `texra-ai` and `MEMBER` covers more people. `docs/dev/verification.md:53-61` is **correctly** scoped and needs no correction. Fix: sparse-checkout the guidance into `.trusted-actions` too, or skip automated review when the diff touches `.claude/`/`CLAUDE.md`/`AGENTS.md`. |
+| **Signing secrets are job-scoped, so `pnpm install` sees them**                                  | `desktop-package.yml:37-46` (CSC_LINK, CSC_KEY_PASSWORD, APPLE_*) at job scope with `pnpm install --frozen-lockfile` at `:65`; Windows equivalent `:190-197`/`:216`. Consumed only at `:103` / `:234`. The workflow's own `unset` at `:91-102` shows the narrowing is understood — it just happens too late.                                                                                                                                                                                                                                 | Mitigated by `workflow_dispatch:`-only triggering (`:3-25`) and pnpm's deny-by-default `allowBuilds:` (`pnpm-workspace.yaml:12-21`, 9 named packages). Move the `env:` blocks down one level; add `permissions:` to the three installer jobs (`:32`, `:128`, `:185`).                                                                                                                          |
+| **Dependabot covers only the root workspace**                                                    | `.github/dependabot.yml:3-4` — one entry, `npm` / `/`. No `github-actions` ecosystem, so even the one SHA-pinned action (`texra-code-review.yml:112`) never gets bumped. `docs/` is outside the workspace (`pnpm-workspace.yaml:1-2`) yet `docs/package-lock.json` (139 KB, `vitepress ^2.0.0-alpha.15`) builds and force-pushes the public site (`docs-deploy.yml:40,120-122`) with zero monitoring.                                                                                                                                        | Add `github-actions` + a second `npm` entry at `/docs` (needs `--legacy-peer-deps` handling per `docs-deploy.yml:37-39`). Deno has no Dependabot ecosystem — not a gap.                                                                                                                                                                                                                        |
+| **SHA-pin the one action that holds publish credentials**                                        | `release.yml:88` and `:96` — `HaaLeo/publish-vscode-extension@v2` receiving `VSCE_PAT` and `OVSX_PAT` in the same job. This is the only genuinely third-party action holding high-value secrets.                                                                                                                                                                                                                                                                                                                                             | Unchanged by repo visibility. Pin both to SHAs in the style of `texra-code-review.yml:112`.                                                                                                                                                                                                                                                                                                    |
+| **Version-bump PRs are opened with `GITHUB_TOKEN`, so they trigger no CI**                       | `version-bump.yml:57-59`, while `:49`/`:52-54` rewrite every manifest and regenerate `pnpm-lock.yaml`. `ci.yml:403-462` (`validate-status`) is clearly designed as the required check.                                                                                                                                                                                                                                                                                                                                                       | Decide before enabling required status checks, not after. `claude.yml:133` already passes `BOT_PAT` to a sibling auto-PR action.                                                                                                                                                                                                                                                               |
+| **No `permissions:` at all in `ci.yml`; three installer jobs in `desktop-package.yml` likewise** | `rg '^\s*permissions:' .github/workflows/` hits 11 files; `ci.yml` (461 lines, 9 jobs) has none, and `desktop-package.yml`'s only block is `:275`.                                                                                                                                                                                                                                                                                                                                                                                           | Blast radius only — fork runs are read-only regardless. Add `contents: read` + set the repo default to read-only.                                                                                                                                                                                                                                                                              |
+| **No workflow guards on `github.repository ==`**                                                 | `docs-deploy.yml:3-8` fires on push to main; `:106` writes `CNAME texra.ai`; `:113-121` force-pushes gh-pages. Same gap in `label-sync.yml`, `version-bump.yml`.                                                                                                                                                                                                                                                                                                                                                                             | Nearly unreachable — GitHub disables _all_ workflows in forks until the owner opts in (platform behavior, not in-repo). Two-line fix, low priority.                                                                                                                                                                                                                                            |
+
+### Code hygiene
+
+- **2,168 lines of desktop Playwright specs are outside typecheck, lint, `npm test`, and every
+  workflow — and are already rotting.** Exclusions: `vitest.config.mjs:26`; all four
+  `packages/desktop/tsconfig*.json` `include` only `src/` + `vite.config.ts`; root
+  `package.json:9` lints `packages/desktop/src` only; the sole Playwright reference in CI is
+  `desktop-package.yml:154` (`install-deps chromium`, feeding the packaging smoke at `:163-165`).
+  Compiling them proves the rot has landed: `packages/desktop/tests/e2e/menuLifetime.spec.ts:49`
+  → `TS2367` — `item.role === 'appmenu'` compares against a literal Electron's union does not
+  contain, so that lookup is statically dead. Baselines are never diffed:
+  `screenshots.spec.ts:21-27` returns `testInfo.outputPath()` unless
+  `TEXRA_UPDATE_E2E_SCREENSHOTS === '1'`, and `rg 'toHaveScreenshot|toMatchSnapshot'
+packages/desktop/tests/` → zero. `knip.json:36` lists `tests/**` as an entry but `project` is
+  `src/**`, so knip does not parse them either.
+- **`packages/agent` is a never-shipped SDK advertised in the release pipeline.**
+  `release.yml:153-158`: `publish-agent`, comment "NOT PUBLISHED YET: @texra-ai/agent has no npm
+  package or trusted publisher configured", `if: ${{ false && … }}` — and 60 lines of dead steps
+  through `:201`. The package is 510 source lines (`src/index.ts` 301, `node.ts` 160,
+  `schemas.ts` 49) against **70** runtime dependencies, `private` unset,
+  `publishConfig.access: 'public'`, version-bumped every release, `registry.npmjs.org` → 404, no
+  README. And `ls docs/proposals/*agent-sdk*checkpoint*` → **21** files; with the deltas,
+  north-star, foundation-gap and audits, agent-SDK docs are **29 of the 72 files in
+  `docs/proposals/`**. Pick: ship it, mark `"private": true` and delete the dead job, or add a
+  README saying it is pre-release.
+- **ESLint disables the two rules everyone looks for, under "REVISIT LATER".**
+  `eslint.config.mjs:501-502` (`no-explicit-any: 'off'`), `:504-510`, `:525-526`
+  (`no-unused-vars: 'off'`). Measured debt is tiny — exactly 20 `any` occurrences in non-test
+  production source across 17 files, zero `eslint-disable` escapes. The config understates the
+  codebase's real discipline and will be the first quotable line in a skeptical thread. Turn both
+  on (`varsIgnorePattern: '^_'`), fix ~40 sites, delete the comments.
+- **`supabase/migrations/` cannot build the schema it references.** `rg '^CREATE TABLE'
+supabase/migrations/*.sql` → 6 tables; `profiles`, `remote_agents`, `agent_whitelist` never
+  created, yet `20260517100300_rls_initplan_wrap_auth_uid.sql:7-31` `ALTER POLICY` five policies
+  across all three, and `20260602120000_lock_down_profiles_privileged_columns.sql` revokes/grants
+  on `profiles`. The **auditability** cost is the real one: `profiles.tier` is what the relay
+  trusts (`relay/index.ts:494`), gating both `:500-507` and `:510`, and the RLS UPDATE policy that
+  stops a user self-promoting is precisely what is missing — while `20260602120000`'s header
+  documents that exactly that bug once shipped. (The "contributors can't `supabase db reset`"
+  argument is weak: `supabase/README.md:1-6` says this tree is the canonical cloud source pending a
+  private infra repo, not a self-hostable backend.)
+- **Applied one-off production DDL lives in `docs/` outside the migrations directory.**
+  `docs/supabase/MIGRATION_FLEXIBLE_USER_GROUPS.sql:17` (`ALTER TABLE profiles ADD COLUMN … permissions TEXT[]`),
+  `:23` (`DROP CONSTRAINT profiles_tier_check`), plus `ADD_*.sql` and
+  `MIGRATION_PREMIUM_TO_RESEARCHER.sql`, documented as copy-paste-into-the-SQL-Editor
+  (`ADD_LEAN_AGENTS.sql:1-11`). Contrast `SYNC_REMOTE_AGENTS.sql:1-3`, which is generated and
+  script-owned (`package.json:57`).
+- **`axios@1.17.0`** (single resolved version, sole path `arxiv-client@0.0.9`) carries
+  GHSA-mwf2-3pr3-8698, vulnerable `>=1.13.0 <1.18.0`. `pnpm audit --prod` → "2 low | 11 moderate |
+  1 high". Not exploitable here (public arXiv metadata), but landing with a clean audit removes
+  scanner drive-bys before they start — consistent with `SECURITY.md:52`. Fix: pnpm `overrides`
+  pin to `^1.18.0` (Dependabot cannot reach a transitive pinned by an unmaintained direct dep).
+
+### Product surface
+
+- **Nothing states what is free vs. paid.** `src/auth/config.ts:118` defines
+  `['free','Max','Ultra']` with `:131-135` `{free:10, Max:50, Ultra:300}` dollar constants, and
+  exactly **one** user-facing string in the entire codebase names a plan:
+  `src/controllers/settingsView/SettingsRemoteAgentPromptController.ts:27` "Viewing remote agent
+  prompts requires an Ultra plan." No docs page mentions Ultra or Max; `TERMS_OF_SERVICE.md` has
+  no fees section; there is no payment processor anywhere in the tree.
+  `src/controllers/modelAccess/installTexraModelAccess.ts:25-27` even contains a truncated
+  sentence — "cost far more per request than the tier prices in," — dangling at pricing that does
+  not exist. One paragraph fixes this; it is not a pricing-page project. _(The "undisclosed
+  monetization" reading is refuted — see §6 — the dollar figures are TeXRA's own per-tier relay
+  cost ceilings, consistent with `docs/guide/remote-agents.md:126` "We do not charge".)_
+- **`docs/guide/open-source.md` is footer-linked from every texra.ai page**
+  (`docs/.vitepress/config.js:184`, nav at `:174`) and its premise at `:3` — "We've open-sourced
+  **key components of our infrastructure**" — becomes false on flip day; the page never lists
+  TeXRA. Rewrite it as part of the flip changeset, leading with the repo and its license. It is
+  also the natural home for the B2/B3/Font-Awesome credits.
+- **No `CITATION.cff`**, on a tool whose audience is academics and whose
+  `docs/guide/acknowledgments.md:7` promises "we will provide a preferred citation format" and
+  points at `github.com/texra-ai/texra-issues` (no code). The material to cite is already on the
+  same page at `:22` (ICML 2026, arXiv:2506.06214). The flip turns on GitHub's "Cite this
+  repository" widget; it will be dark.
+- **npm namespace is squattable.** `registry.npmjs.org/-/org/texra/package` → `{"error":"Scope not
+found"}`; `registry.npmjs.org/texra` → 404 — while `packages/extension/package.json` declares
+  `"name": "texra"` with `"private": false` and **no `files` allowlist**. Register `texra` and
+  `@texra` defensively **before** publishing the repo, and set `"private": true` on
+  `packages/extension` (it ships as a VSIX via `vsce`, never via npm).
+- **14/14 shipped skills say "Use when Codex needs to…"** in front-matter (`skills/*/SKILL.md:3`),
+  copied verbatim into the extension by `scripts/copy-extension-skills.mjs:20-21` and wired into
+  `contributes.chatSkills` at `packages/extension/package.json:1623` — whose host is Copilot Chat.
+  One `sed`, done upstream in the MIT satellite repos so the next re-vendor does not undo it.
+- **`docs/guide/remote-agents.md:25`** offers "GitHub, Google, or GitLab"; `src/auth/config.ts:92`
+  is `['github','google']`. README gets it right; the guide does not.
+- **`TERMS_OF_SERVICE.md:74` calls usage logs "anonymized"** when every row carries `user_id`
+  (`log-usage/index.ts:129`) and the admin view re-identifies directly
+  (`20260609212200_drop_usage_base_view.sql:30-47` joins `profiles.email`). That is _pseudonymous_,
+  and the distinction is legally operative under GDPR. The four-field list is also incomplete
+  (`log-usage/index.ts:133-146` adds agent_name, stream_id, extension_version, editor_type, …),
+  and §9 never states the opt-out's plan-accounting carve-out
+  (`src/telemetry/UsageLogService.ts:82-95`). `docs/guide/configuration.md:340-347` states all of
+  this correctly — align the legal doc to the guide, not the reverse.
+- **`TERMS_OF_SERVICE.md:38`** says "API keys are stored locally using VS Code's built-in Secret
+  Storage" — false for the CLI (`packages/cli/src/runtime/cliSecrets.ts:49-51,83`, plaintext JSON
+  at `~/.texra/secrets.json`) and the desktop app (`electronSecrets.ts:121-126`, Electron
+  safeStorage). _(The storage design itself is fine: `cliSecrets.ts:15` sets `0o600` and
+  `jsonStore.ts:54-56,213-220` chmods the containing directory to `0o700` — same posture as `gh`,
+  `aws-cli`, `npm`.)_
+- **Marketplace Q&A is on by default.** `packages/extension/package.json` declares no `qna` key,
+  so the storefront opens a third inbox next to `README.md:143`'s `texra-issues` and the source
+  repo's newly-enabled Issues tab. Set it deliberately. `sponsor` is optional polish
+  (`README.md:43-44` already carries the links).
+- **A BYOK user who never signed in still contacts `remote.texra.ai` on first model call.**
+  `ModelHandler.ts:501-506` → `ServerSideKeyService.ts:139-141` (preference defaults `true`
+  whenever a globalState store exists) → `:302-310` (anonymous `getConfig(undefined)`) →
+  `src/auth/config.ts:86` `RELAY_TIER_CONFIG_URL`. No credential or prompt content leaves; it is an
+  unauthenticated GET on the dispatch path. But the opt-out is UI-only, unlike the two existing
+  env kill switches (`src/telemetry/UsageLogService.ts:62-65`,
+  `src/utils/system/semverUpdateCheck.ts:29`, both via `src/utils/system/envFlags.ts`). Add
+  `TEXRA_NO_INCLUDED_ACCESS` using the same helper and document the full set of hosts TeXRA
+  contacts. One call to an existing helper; the launch-thread cost of not having it is real.
+
+### Repo presentation
+
+- **254 remote branches**, 152 of them `origin/claude/*`, oldest `origin/backend` at 2024-11-11.
+  35 are already merged into `origin/main`, 32 have no commit since 2026-06-01 — that is a
+  zero-risk delete list covering a quarter of them. `origin/backend` must go regardless (see B1);
+  keep `origin/gh-pages` (live deploy target).
+- **Ten author identities on one email.** `git shortlog -sne --all` → `divergence_lu@icloud.com`
+  under `Ray` (6,921), `Sirui Lu` (2,566), `Sirui@MPQ` (2,437), `Sirui@mba` (1,149), `Sirui Lu
+(laptop)` (169), `Sirui Lu (MPQ office)` (152), three `(aider)` variants, `Squirrel` (2). No
+  `.mailmap`. A root `.mailmap` collapses the contributors graph retroactively with no rewrite —
+  but note it does **not** remove the address from commit objects; that is a `filter-repo` decision
+  for the B1 window if you want it.
+- **`docs/prds/cli-tui-ink/mockups/`** (11 mockups + README) ends each file with open questions
+  answered by pasted chat replies: `2026-05-14-08-tool-variants.md:118` "User: ok, do as you
+  recommend. don't overcrowd the TUI"; `2026-05-14-05-transcript-search.md:66` "User: this can
+  wait."; `2026-05-14-01-streaming.md:49-52` where four either/or questions each end with a bare
+  "User: yes" / "User: maybe both?" — so the record does not say what was chosen. No secrets, no
+  PII; this is tone plus doc-usability, and a reason to lean toward the "split to a private repo"
+  arm §2.3 already offers.
+- **Two undated, current-tense design docs describe code that no longer exists.**
+  `docs/pocketflow/state_architecture.md:35-40` shows `runState.toSnapshot()` /
+  `AgentRunState.fromSnapshot(...)` — there is no `AgentRunState` class at all (`rg 'AgentRunState'
+src/` yields only `AgentRunStateSnapshotSchema`/`AgentRunStateSnapshot` at
+  `src/agent/core/state/AgentState.ts:22-29`; the methods live in `AgentWorkspaceState.ts:426,459`).
+  Both `CLAUDE.md:136` and `AGENTS.md:407` route contributors there.
+  `docs/design/subagent-output-design.md:5` asserts "`executeAgent()` returns `void`" against
+  `src/agent/runtime/executeAgent.ts:409-430` (`Promise<AgentRuntimeFlowResult>`, two overloads),
+  and its call graph at `:9`/`:246` names `executeAgentWithLogging`, a symbol whose only occurrence
+  in the repo is that doc. Neither file is inside `scripts/check-guidance-refs.mjs`'s
+  `GUIDANCE_DIRS` (`:26-27`) — add `docs/architecture`, `docs/design`, `docs/pocketflow`.
+- **`docs/dev/verification.md:19-21`** tells contributors that `npm run typecheck` has pre-existing
+  `@openrouter/sdk/models` errors to ignore. It does not: that resolution is aliased in all three
+  tsconfigs (`tsconfig.json:50-56`, `packages/extension/tsconfig.json:49-55`,
+  `packages/desktop/tsconfig.paths.json`) and `typecheck:workspace` runs clean. Delete the two
+  comment lines — this is the one file whose job is to teach verification, and it trains people to
+  shrug off type errors.
+- **`docs/dev/texra-cli-checkout.md:4-6`** says "the repository is not open source" and `:30` cites
+  a `"Local CLI (texra-local)"` section of `CLAUDE.md` that does not exist (`rg -ni
+'texra-local|local cli' CLAUDE.md` → zero).
+- **`.vscode/settings.json:15`** commits `"texra.ui.showLoginBanner": false` — the only
+  unjustified entry in an otherwise build-only, fully-commented file. Sharper:
+  `grep -c 'showLoginBanner' packages/extension/package.json` → **0**, so the key is undeclared in
+  `contributes.configuration` even though `src/controllers/mainView/MainViewStartupController.ts:82-87`
+  reads it and `:104-107` uses it. Every contributor sees an "Unknown Configuration Setting"
+  warning on an uncommented line that suppresses the sign-in banner — the exact onboarding surface
+  they need to test. Introduced in `03db4189d` as a testing leftover. Delete the line.
+- **`docs/guide/configuration.md:147`** ships `C:\\Users\\thinking\\scoop\\...` where the same file
+  uses `C:\\Users\\Username\\` at `:436` and `/Users/username/` at `:444`. Published live
+  (`docs/.vitepress/publicDocs.js:29`). One word.
+- **`docs/reference/`** is two files: `relay-tier-config.md` and an orphaned `index.md` whose `:3`
+  is site-voiced ("For step-by-step guides, see the [Guide](/guide/) section") and whose every link
+  redirects back into `/guide/`, in a directory `publicDocs.js:41` excludes from the site and
+  `config.js` never references. Delete `index.md`.
+- **`QITBench`** appears in exactly two files repo-wide (`docs/supabase/SYNC_REMOTE_AGENTS.sql:33,48`
+  and `docs/supabase/remote-agents.config.json:18,21`) as an undocumented `visibility` tier
+  alongside `whitelist`/`researcher`/`public`. `2026-08-01-backend-decoupling-plan.md:642` places
+  `remote-agents.config.json` in the "Stays public" table, so this is a decided publication —
+  decide whether to document the tier or rename it to a generic key.
+- **Prerequisites nobody documented**: Deno 2.8.3 (`ci.yml:94-97`, `:123-128`) with zero install
+  guidance anywhere (checked `README.md`, `AGENTS.md`, `CLAUDE.md`, `docs/dev/`, `docs/guide/`,
+  `supabase/README.md`, `supabase/writing_edge_functions.md`); Linux desktop e2e needs
+  `playwright install-deps` + `xvfb-run` (`desktop-package.yml:154,163-165`) which
+  `docs/dev/verification.md`'s bare `pnpm exec playwright test` does not mention; and `electron` is
+  **absent** from `pnpm-workspace.yaml`'s `allowBuilds:` list, so its postinstall never runs and the
+  ~100 MB binary downloads lazily on first `require('electron')` (reproduced: `node
+scripts/check-desktop-electron-binary.mjs` prints "Downloading Electron binary…" on a fully
+  installed tree). Also: root `package.json` has **no `engines`** while corepack-provisioned
+  pnpm 11.5.2 requires `node >=22.13` and `README.md:22,122` +
+  `packages/{cli,agent}/package.json` all say `>=22.9.0`. No `.nvmrc`/`.tool-versions`.
+- **The PR template demands undefined rule IDs.** `.github/PULL_REQUEST_TEMPLATE.md:17-19` (`## Net
+elements (R6)`) and `:21-23` (`## Consumer counts (R8)`). `rg '\bR6\b|\bR8\b' AGENTS.md CLAUDE.md
+README.md` → two lines, `AGENTS.md:577-578`, which merely restate that the template requires
+  them. The template's inline HTML comments _are_ operative instructions (a contributor can fill
+  both correctly without the checklist — see §6), so this is one link, not a rewrite. `README.md`
+  contains no pointer to `AGENTS.md`, contributing, or pre-commit (verified by grep).
+
+---
+
+## 6. Explicitly not worth doing
+
+Things a generic audit — or one of the eleven auditors — would tell you to do, that this repo
+should skip. Each was checked and refuted.
+
+| Recommendation                                                                                             | Why skip                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **"SHA-pin all `LionSR/agent-ci-actions@v1` call sites; it's a third-party supply-chain root"**            | `git remote -v` → `origin … /git/LionSR/TeXRA`. **`LionSR` is the account that owns this repository.** Six of the eight cited `uses:` are first-party — same trust boundary as the repo itself. One auditor independently confirmed the action repo is **public** (3 stars, created 2026-06-04). Moving it to `texra-ai` + SHA-pinning is reasonable tidiness, not a supply-chain finding.                                                                                                                                                                                                                                                       |
+| **"Fork PRs will fail on `LionSR/agent-ci-actions`, breaking day-one contributors"**                       | Every call site is unreachable for outsiders: `claude-code-review.yml:135` is behind the provider-token skip (`:85-107`, documented at `:53-55`); `issue-tracker.yml:138` has the identical gate at `:55-77`; `claude.yml:79/:122` require `author_association` in OWNER/MEMBER/COLLABORATOR (`:28-34`); `issue-tree.yml` and `repository-quality-improver.yml` are schedule-only, which GitHub disables in forks.                                                                                                                                                                                                                               |
+| **"Rewrite ~980 bare `#NNNN` refs in docs / 442 in source, they'll mislink"**                              | GitHub autolinks `#N` in **issue/PR/commit bodies and markdown rendering**, not in source-blob views — a `// see #3781` in a `.ts` file renders as plain text. The docs are already excluded from texra.ai (`publicDocs.js:35-40`). Also, `rg -nP '#\d{3,5}' CLAUDE.md AGENTS.md` → **zero**; the cited strings live in `docs/proposals/`. Keep only the one sharp instance: `.claude/skills/code-review/references/review-checklist.md:125,128,139`, where `#6981`/`#7210` are normative _merge gates_ in a skill `CLAUDE.md` tells contributors to load.                                                                                       |
+| **"Add `TEXRA_SUPABASE_URL` env-var override plumbing so people can self-host against their own backend"** | A client hardcoding its own vendor endpoint is normal; the publishable key at `src/auth/config.ts:35` is public by design and says so. "A different backend can be installed" is already the designed goal of `docs/proposals/2026-08-01-backend-decoupling-plan.md:9-11`, with a port. The real task is **delete or rewrite four stale files** (§4.5), not build plumbing for docs that were wrong.                                                                                                                                                                                                                                             |
+| **"Withhold the Codex/Copilot proposals — they admit riding provider ToS violations"**                     | The Copilot route ships **no code** (`rg 'api.githubcopilot.com'` outside `docs/` → 0 hits), so that PRD documents a decision _not_ to ship on ToS grounds — diligence, not willfulness. The Codex admission is duplicated in shipping source at `src/auth/codex/codexConstants.ts:5-8` with the client id at `:19`, so removing the docs removes nothing, and the client id + endpoint are already public in Zed's and OpenCode's repos. What survives is one line: exempt these files from `2026-07-29-open-source-readiness.md:127-129`'s blanket "no business-sensitive material" clearance.                                                 |
+| **"Falling back to the user's own API key when a model is out-of-tier"**                                   | `ModelHandler.ts:538-543` throws deliberately. Silently spending a user's personal OpenAI key when they believe they are on included access is exactly the quiet substitution `CLAUDE.md`'s "Silent degradation is a defect" rule forbids. The current error names both remedies, and `:551-554` shows the ordering was reasoned about.                                                                                                                                                                                                                                                                                                          |
+| **"Add SPDX headers to 2,140 source files + a CI check that manifests match LICENSE"**                     | Optional under every license in play, and absent in most major OSS projects that ship one root LICENSE. The only concrete drift (`docs/package.json`) is already captured in §4.1.                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| **"Add `.env.local`, `*.pem`, `*.key` to `.gitignore`"**                                                   | `find . -name '.env*' -not -path '*/node_modules/*'` → **nothing** in the tree. The one documented path (`packages/extension/src/extension.ts:180-182` reads literal `.env`) is covered by `.gitignore:4`, which has no leading slash and therefore matches at any depth (verified with `git check-ignore -v` on `packages/cli/.env`, `supabase/.env`, `docs/.env`). The real control — push protection — is already launch step 5 (`2026-07-29-open-source-readiness.md:154-158`, `:410`).                                                                                                                                                      |
+| **"Add a GitHub-token pattern to log redaction"**                                                          | `src/test-kernel/desktop/DesktopLogRedaction.vitest.mts:11,22` already asserts `ghp_…` is redacted, via `BEARER_PATTERN` (`src/logger/redaction.ts:10`, applied `:106`). The hypothesized leak path does not exist: `grep -rn 'x-access-token\|@github.com\|extraheader'` over `src/` and `packages/*/src` → zero. The token is stored in VS Code SecretStorage (`githubSubscriptionHandlers.ts:56`), not in loggable config.                                                                                                                                                                                                                    |
+| **"CLI secrets should use a keyring; plaintext `~/.texra/secrets.json` is a defect"**                      | `cliSecrets.ts:15` sets `0o600` and `jsonStore.ts:54-56,213-220` chmods the parent to `0o700` (with a follow-up chmod that fixes a pre-existing loose directory). Same posture as `gh`, `aws-cli`, `npm`, `kubectl`. The real defect is the false sentence at `TERMS_OF_SERVICE.md:38` (§5).                                                                                                                                                                                                                                                                                                                                                     |
+| **"Publish conversation-storage warnings — runs are written unencrypted"**                                 | Run storage sits under `~/.texra`, which is `0700` for anyone who has ever run `texra auth`; on the VS Code host it is inside the editor's globalStorage. `docs/guide/memory.md:95` already discloses the analogous case.                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| **"Add a safe-harbor clause / narrow SECURITY.md's testing invitation"**                                   | `SECURITY.md` has an explicit `## Out of scope` section covering scanner output, missing headers, already-compromised machines, and bad agent output; the 5-day line is hedged in the same sentence; no bounty is offered and no active testing is authorized.                                                                                                                                                                                                                                                                                                                                                                                   |
+| **"Split CHANGELOG.md; reorganize `docs/`; write a CONTRIBUTING.md"**                                      | `CHANGELOG.md` is clean (3,047 lines, zero `#NNNN`, sync wired at `docs/package.json:7`). The CONTRIBUTING absence is tracked at `2026-07-29-open-source-readiness.md:178-181` and deliberately **held** until the license lands (`:27-30`: soliciting contributions under all-rights-reserved with no CLA/DCO creates IP ambiguity) — that reasoning is correct; unblock it in §7 Phase 3, don't treat it as a finding. Same for `CODE_OF_CONDUCT.md`. `.github/ISSUE_TEMPLATE/`'s absence is a routing decision (`README.md:143` sends issues to `texra-ai/texra-issues`), not an oversight.                                                   |
+| **"Fix the 87 error-swallowing catch blocks / the dead-code baseline"**                                    | Already measured and budgeted: `.claude/skills/code-review/references/review-checklist.md` §15 records a 2026-07 audit of 880 catch sites (~87% legitimate) with an M1–M6 taxonomy and a named end-state. The knip baseline is 17 entries, 7 of which are false positives (`frontend/lean/VscodeIntegration.ts`, namespace-imported at `packages/extension/src/extension.ts:57,531`). Two are genuinely dead. Not a release concern.                                                                                                                                                                                                             |
+| **"Reconsider excluding Windows from the gating test matrix"**                                             | `2026-07-29-open-source-readiness.md` §4.6 is a full page on exactly this, with the failure inventory, the reason for reverting, and a `TODO(windows-ci)` marker in `ci.yml` refreshed on 2026-08-01 (`e0ce8532d`). The maintainer decided this within the last 72 hours.                                                                                                                                                                                                                                                                                                                                                                        |
+| **"`coauthor-for-vs-code/` in history is an absorbed third-party project"**                                | `git log --format='%an <%ae>' -- 'coauthor-for-vs-code/*'` → 549 commits, **all** `divergence_lu@icloud.com`. It is this project's own predecessor (`e0eeb39d1 refactor: rename project from CoAuthor to TexRA`). No third-party license to carry forward.                                                                                                                                                                                                                                                                                                                                                                                       |
+| **"`coauthor-python/prototypes/xml_extraction/*.tex` exposes an unpublished manuscript"**                  | Published: Molpeceres, Lu, Cirac & Kraus, arXiv:2503.24330 / Phys. Rev. Research **7**, 033162 (2025), 21+19 pages. The `tum.de` address and affiliations are on the public paper; the appendices the finding called "unpublished supplementary derivations" are in the published version; the maintainer is a co-author. A courtesy item that rides free on B1's purge, nothing more.                                                                                                                                                                                                                                                           |
+| **"Strip `Claude-Session:` trailers from 881 commits"**                                                    | The string appears in **zero** tracked files (`grep -rn 'Claude-Session' CLAUDE.md AGENTS.md .claude/ .github/` → nothing) — it is injected by the agent harness, so the prescribed fix has no target. The IDs are not credentials. And AI authorship is already visible from the author field regardless (3,980 commits as `Claude <noreply@anthropic.com>`).                                                                                                                                                                                                                                                                                   |
+| **"Sanitize the `6b9e775a6` scrub commit's contents from history"**                                        | Two of its three items are non-sensitive: the "machine path" is `/Users/me/Local/AI-Projects/coauthor/...` (`me` was already the placeholder), and `jntubmcgbhwtcktubelv` is published in DNS — `getent hosts remote.texra.ai` returns `jntubmcgbhwtcktubelv.supabase.co` as the CNAME, resolving to the same Cloudflare pair, so redacting a markdown line conceals nothing. The residue is one personal gmail, dwarfed by ~13,300 commits authored from `divergence_lu@icloud.com`. Update `2026-07-29-open-source-readiness.md:334-347` to say its clean bill covers the working tree and credential formats only — that is the whole action. |
+| **"Add a `publicGuidePages` allowlist so nothing internal lands in `docs/guide/`"**                        | `docs/scripts/check-root-docs.mjs:111-113` already runs `markdownFilesUnder(docsDir)` **recursively** over the whole tree and rejects any `audit                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | prd | proposal`-shaped basename without a date prefix, anywhere. Publishing everything under `guide/` is the documented design (`publicDocs.js:27-29`). |
+| **"Bump `docs-deploy.yml`'s action majors"**                                                               | `@v4` vs `@v6` elsewhere, with no advisory and no failure mode named. The `git push -f "https://x-access-token:${GITHUB_TOKEN}@…"` at `:120-122` is the standard documented pattern, uses `env:` rather than an inline `${{ }}` expansion (`:109-110` — already the safe form), and the token is job-scoped and auto-masked.                                                                                                                                                                                                                                                                                                                     |
+| **"`.gitattributes`'s dead `*.lock.yml` rule is a credibility cost"**                                      | Both attributes are inert against a non-matching path. Fix it while adding `* text=auto eol=lf` (§4.3), but there is no separate finding here.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| **"The Overleaf UI screenshot is a trademark risk"**                                                       | `docs/public/images/overleaf-git.png` is a 610×294 crop of Overleaf's Sync menu, used to illustrate the step documented at `docs/guide/working-with-overleaf.md:80`. Ordinary nominative use; already live on texra.ai.                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| **"`README.md` is the Marketplace/npm body — decide the split first"**                                     | True and intentional, and documented three times by the maintainer: `packages/extension/.gitignore:1-7`, `packages/cli/scripts/copy-docs.mjs:3-5`, `packages/cli/.gitignore:1`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| **"The ProtonMail sign-up blocklist is a PR risk"**                                                        | The block already ships with an exception path in both the runtime message (`supabase/functions/_shared/emailPolicy.ts:72-77` — "…contact contact@texra.ai for an exception") and the public ToS (`TERMS_OF_SERVICE.md:40,42`), and `emailPolicy.ts:42` says the category is kept separate specifically so it can move to soft-review. The deliberate decision was already made. What remains is one code comment (`:41`, "Privacy-relay providers disproportionately used for free-tier abuse") that characterizes a provider's users and will be quoted out of context — reword it, that's all. _(Moot entirely under Option B.)_              |
+| **"The free-tier 2 MiB body cap is defeatable via server-side conversation state"**                        | Unreachable. `relay/index.ts:548` applies the cap only to free tier; `relay/index.ts:500` + `models.ts:123-124` reject openai/anthropic/google (the only providers with `/responses` / `/interactions` state endpoints) below Ultra, 48 lines earlier. The users with the cap have no route; the users with the route have no cap.                                                                                                                                                                                                                                                                                                               |
+| **"Move the six `supabase/`-importing vitest files before splitting"**                                     | Already enumerated verbatim, including the exact line number `RelayTokens.vitest.mts:81`, at `2026-08-01-backend-decoupling-plan.md:635`, with the replacement CI at `:655-671`. The one residual — the `ci.yml:123-128` Deno step — is a 6-line deletion that fails loudly.                                                                                                                                                                                                                                                                                                                                                                     |
+
+---
+
+## 7. Suggested sequence
+
+Effort is maintainer-hours unless noted. **‖** marks work that parallelizes.
+
+### Phase 0 — Decide (blocks everything). ~half a day of thinking, no code.
+
+1. **Pick the license.** Recommendation: Apache-2.0. — 1h
+2. **Pick the boundary.** Recommendation: `supabase/` + `docs/supabase/` → private repo (§3.3);
+   `prompts/agents/remote/` stays public and the Ultra gate at
+   `SettingsRemoteAgentPromptController.ts:24-28` is deleted. — 1h
+3. **Commit to the history rewrite** (B1). There is no viable alternative — ref deletion leaves
+   objects fetchable by SHA. — 15m
+
+### Phase 1 — Long-pole and irreversible. Start day 1.
+
+4. **Email SXKDZ** (`Mr.SXKDZ@Gmail.com`) for relicensing consent on `f7528670` (B5). _This is the
+   only item gated on someone else's response — send it before anything else._ — 30m + wait
+5. **History rewrite** on a fresh `git clone --mirror` (B1). Purge `agents/*`, delete
+   `origin/backend`; free riders `coauthor-python/prototypes/`, `Notebooks/`, `*.vsix`. Verify with
+   `git rev-list --objects --all | grep -E 'example_rebuttal|reply_to_(editor|referees)'` → empty.
+   Delete the 35 merged + 32 stale branches in the same window. — 4-6h
+6. ‖ **Attribution pass** (B2, B3): NOTICE/THIRD-PARTY-LICENSES with PocketFlow + gemini + Font
+   Awesome + patched-openai entries; provenance headers in `src/agent/node/index.ts` and both
+   `.sty` files; add the file to `verify-extension-package-invariants.mjs:42` and
+   `electron-builder.yml`. — 4h
+7. ‖ **CI hardening** (B4): `persist-credentials: false` at `claude.yml:57`; extend the `:32-33`
+   gate; drop `Bash(node *)`; verify `BOT_PAT` scope. — 2h
+
+### Phase 2 — Pre-flip cleanup. All parallelizable.
+
+8. ‖ **License declarations** — all nine sites in one commit (§4.1). — 1h
+9. ‖ **Repo identity sweep with `rg --hidden`** (§4.4), including `.claude/skills/` and
+   `.github/workflows/`; fix `packages/{cli,extension,agent,desktop}` `repository.url` (prerequisite
+   for provenance). — 3h
+10. ‖ **Delete/rewrite stale `docs/supabase/`** (§4.5); move `AUTH_OPERATIONS.md` + operational SQL
+    private; repoint `scripts/sync-remote-agents.mjs`. — 2h
+11. ‖ **Inline the load-bearing proposal content** into `AGENTS.md` / review-checklist, then run
+    `scripts/check-guidance-refs.mjs` as the split's acceptance test (§4.6). — 4h
+12. ‖ **Windows unblock**: Node-ify the five extension scripts + two docs copies, add
+    `* text=auto eol=lf`, add root `engines: {node: ">=22.13"}` + `.nvmrc` (§4.3). — 4h
+13. ‖ **Register `texra` and `@texra` on npm**; set `"private": true` on `packages/extension`. — 30m
+14. ‖ **Backend security fixes** (§4.2) — `auth-github` audience check, relay self-metering, agent-CLI
+    privilege ceiling. Under Option B the first two land in the private repo and do not gate the
+    flip; the third does, since `src/tools/` is public. — 2-3 days
+15. ‖ **Small stuff**: delete `.vscode/settings.json:15`; fix `docs/guide/configuration.md:147`,
+    `docs/guide/remote-agents.md:25`, `docs/dev/verification.md:19-21`,
+    `docs/dev/texra-cli-checkout.md:4-6,30`; delete `docs/reference/index.md`; `sed` the 14
+    `SKILL.md` descriptions; add `.mailmap`; wire `check:remote-agents` into `ci.yml:140`; add the
+    boundary check to the `guidance-refs` job; pnpm-override `axios@^1.18.0`. — 3h total
+
+### Phase 3 — Flip day.
+
+16. **Rewrite `docs/guide/open-source.md`** in the same changeset as the flip (§5). — 2h
+17. **Add `CITATION.cff`** + repoint `docs/guide/acknowledgments.md:7`. — 30m
+18. **Write `CONTRIBUTING.md` + `CODEOWNERS` + DCO/CLA enforcement** — unblocked now that the
+    license exists. Lead with "builds don't type check" per
+    `2026-07-29-open-source-readiness.md:178-181`, expand R6/R8 with a link. — 3h
+19. **Flip visibility.** Immediately: enable secret scanning + push protection (already launch step
+    5 at `:410`); set the default workflow token to read-only; set `qna` on the Marketplace
+    manifest. — 1h
+20. **Delete `NPM_CONFIG_PROVENANCE: 'false'`** (both occurrences) — _only after step 9_ — and
+    verify the provenance badge on the next `cli-v*` release. — 30m
+
+### Phase 4 — Post-launch.
+
+21. Automate `THIRD-PARTY-LICENSES.txt` at build time + a disallowed-license CI gate. — 1d
+22. Deno matrix over all 8 `deno.json` directories + a `_shared/deno.json`; add `desktop:build` and
+    `cli bundle` to the PR `build` job. — 1d
+23. Wire desktop e2e into CI under `xvfb-run` (or delete the never-diffed baseline PNGs and say so);
+    fix `menuLifetime.spec.ts:49`. — 1d
+24. Resolve `packages/agent`: ship, `private: true`, or README. Collapse the 21 agent-SDK checkpoint
+    proposals. — 1d
+25. Re-enable `no-explicit-any` + `no-unused-vars` (~40 sites). — 4h
+26. Baseline migration for `profiles`/`remote_agents`/`agent_whitelist`; fold the hand-run
+    `docs/supabase/*.sql` into `supabase/migrations/` or archive them. — 2d
+27. `TERMS_OF_SERVICE.md` §9 alignment (`:74`, `:38`) + the Service/code carve-out. — 2h
+
+---
+
+## 8. Coverage and gaps
+
+**What was actually executed** (Linux, Node 22.22.2): a cold `pnpm install --frozen-lockfile`
+(44.9 s), `npm run typecheck`, `npm run lint`, `npm run format:check`, `npm test`
+(806 files / 8,170 tests, 598.9 s, **zero failures**, no network or credentials needed),
+`pnpm --filter texra build:fast` (produced a 172-file VSIX), `pnpm run desktop:build`,
+`pnpm --filter @texra-ai/cli run bundle`, `docs npm ci && npm run docs:build`, five cheap CI gates,
+`check:dead-code-ratchet`, and `pnpm audit --prod` — all green, `git status` clean throughout. A
+full-history blob scan streamed all 219,097 objects / 78,672 blobs (86.4 MiB pack) through
+credential regexes twice, plus all 8.1 MB of commit messages: **zero real credentials, zero PEM
+keys, no `.env`/`.pem`/`.key`/DB dump ever committed**. Dependency licensing was resolved by
+fetching all 735 packages from `registry.npmjs.org`, not guessed.
+
+**Not checked, and needing a human:**
+
+- **Legal review.** The TOS/license split (§3.3), the Apache-vs-MIT choice, whether the B5 consent
+  email is sufficient in your jurisdiction, and — flagged but unresolvable from inside the repo —
+  whether any MPQ employment or institutional IP agreement constrains the relicensing. Trademark
+  registration status for "TeXRA" and the logo was not investigated; patent exposure was not
+  assessed.
+- **Dependency license precision.** The registry sweep resolved each package's `latest` dist-tag,
+  **not** the exact version pinned in `pnpm-lock.yaml` — a historical license change on a pinned
+  older version would not show up. Transitive **Deno/JSR** imports under `supabase/functions/**` are
+  a separate graph and were not covered at all.
+- **Visual inspection.** Four PNGs were opened and read as images
+  (`walkthroughs/media/{texra-progressboard,file-selection,api-key-setup}.png`,
+  `docs/public/images/overleaf-git.png`) plus three desktop e2e screenshots — all clean, synthetic
+  content, PNG metadata dumped. **Not opened**: `vscode-compare.png`,
+  `agent-model-selection.png`, `auto-extract-options.png`, and the four PDFs under
+  `docs/public/examples/`. Their source `.tex` is synthetic, but a human should look.
+- **Windows and macOS.** Every Windows claim in §4.3 is derived from reading the scripts plus
+  documented `cmd.exe` / `core.autocrlf` defaults — nothing was executed on Windows. Deno is not
+  installed here, so the three orphaned edge-function test suites were never run; whether they
+  still **pass** is unknown, and that is the more interesting question than whether CI runs them.
+  `pnpm --filter @texra/desktop test:e2e` was not run (needs a display).
+- **GitHub-side state.** Not visible from a clone and all of it becomes public or semi-public on
+  flip: **issue and PR bodies and comments**, wiki, Discussions, Actions run logs, repository
+  secrets/variables, branch protection, the current default workflow-token permission, and whether
+  "send secrets to fork PRs" is off. `BOT_PAT` and `DESKTOP_RELEASES_TOKEN` scopes are **inferred
+  from usage, not verified** — B4's severity depends on `BOT_PAT` being multi-repo, which should be
+  confirmed. Issue/PR comment history in particular deserves its own pass before the flip, since it
+  is the one large corpus this audit could not read.
+- **Live rendered surfaces.** No claim about what texra.ai, the Marketplace listing, the npm page,
+  `github.com/sponsors/texra-ai`, or the homebrew tap currently render was verified — everything is
+  grounded in repo contents.
+- **Not attempted**: any live exploitation of `remote.texra.ai`; RLS policy _correctness_ across the
+  30+ migrations (the missing `CREATE TABLE`s make this impossible from the repo anyway); prompt
+  provenance for the 21 hosted-agent YAMLs in `prompts/agents/remote/` (only `.github/prompts/` was
+  read, and it is clean); the trace-viewer package; the extension's webview message-handler surface;
+  and whether `contact@texra.ai` is monitored or GitHub private vulnerability reporting is enabled.
+- **Method caveat.** The working checkout is **shallow** (`.git/shallow`, graft at `64de7c367`).
+  `git merge-base --is-ancestor` and `git log main -- <old-path>` return misleading results for
+  pre-2026-05 commits. B1's reachability was established through `git tag --contains` and
+  `git ls-tree -r v0.15.10` instead, which is sound — but any future verification must be done on a
+  full mirror clone, not this one.

--- a/scripts/check-guidance-refs.mjs
+++ b/scripts/check-guidance-refs.mjs
@@ -23,7 +23,7 @@ import { fileURLToPath } from 'node:url';
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
 
 // Files whose prose is read as instructions by an agent or contributor.
-const GUIDANCE_FILES = ['CLAUDE.md', 'AGENTS.md'];
+const GUIDANCE_FILES = ['CLAUDE.md', 'AGENTS.md', 'src/README.md'];
 const GUIDANCE_DIRS = ['.claude/skills', 'docs/dev'];
 
 // Dated point-in-time records, not standing instructions. They describe the
@@ -71,6 +71,12 @@ const PATH_PREFIXES = [
   'supabase/',
   '.github/',
   '.claude/',
+  // Both are cited from CLAUDE.md/AGENTS.md and both are shipped surfaces:
+  // skills/ is packaged into the client, prompts/agents/remote/ is the declared
+  // public home for the hosted agent YAMLs. Without these prefixes a stale
+  // citation to either tree rots silently.
+  'skills/',
+  'prompts/',
 ];
 
 // Generated or installed at build time, so absent in a clean checkout.

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,96 @@
+# `src/` — host-agnostic core
+
+Everything here is shared by all three hosts: the VS Code extension
+(`packages/extension`), the Electron desktop app (`packages/desktop`), and the
+terminal CLI (`packages/cli`). Host-specific wiring lives in those packages, not
+here.
+
+There is no `@texra/core` package. Hosts reach this code through the path
+aliases declared in `tsconfig.json` (`@agent/*`, `@platform/*`, `@shared/*`, …).
+Use the alias, not a long relative chain.
+
+## Subsystems
+
+| Directory           | What it is                                                                                                                                                                                               |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/agent/`        | The agent domain model, PocketFlow flows, and provider abstraction. Largest subsystem; has its own READMEs — start with [`agent/core/README.md`](agent/core/README.md)                                   |
+| `src/tools/`        | Tool implementations the agent can call (bash, file edits, delegation, search, setup)                                                                                                                    |
+| `src/shared/`       | Two things: wire contracts and message types (Zod schemas), **and** the shared browser UI kit (`wa/`, `styles/`, `litControllers/`, `markdown/`). Browser-reachable throughout                           |
+| `src/controllers/`  | Host-neutral orchestration — the layer hosts call into instead of driving `agent/` directly                                                                                                              |
+| `src/utils/`        | Host-agnostic helpers. Five modules are additionally browser-safe (see below)                                                                                                                            |
+| `src/latex/`        | LaTeX compilation, diffing, formatting, and log parsing                                                                                                                                                  |
+| `src/common/`       | Cross-cutting helpers that are not wire contracts — notably `common/errors/` error classification                                                                                                        |
+| `src/auth/`         | Sign-in, session, and credential handling. **Core zones import this directly today** — `tools/setup/platform.ts`, `agent/remote/`, `telemetry/` all do. Decoupling it behind ports is proposed, not done |
+| `src/platform/`     | The `Platform` port interfaces (config, state, log, fs, workspace, storage, secrets) that hosts implement                                                                                                |
+| `src/model/`        | Model catalog, selection, and capability resolution                                                                                                                                                      |
+| `src/transcript/`   | Trace and transcript document schemas plus stream logging                                                                                                                                                |
+| `src/replacement/`  | Text-replacement utilities used by editing tools                                                                                                                                                         |
+| `src/skills/`       | Skill schema and loading                                                                                                                                                                                 |
+| `src/housekeeping/` | Workspace cleanup routines                                                                                                                                                                               |
+| `src/telemetry/`    | Usage-log reporting                                                                                                                                                                                      |
+| `src/logger/`       | Channel-keyed logging primitives                                                                                                                                                                         |
+| `src/eventBus/`     | `AppSignals` **only** — process-scoped app-lifecycle signals (auth, subscriptions, tool availability). Not run or session progress                                                                       |
+| `src/hosts/`        | UI host descriptors shared across the three hosts                                                                                                                                                        |
+| `src/types/`        | Ambient module declarations for untyped third-party packages                                                                                                                                             |
+| `src/test-kernel/`  | The test suite. 848 files, ~57% of `src/` by line count — it dominates a directory listing but ships in nothing                                                                                          |
+
+## Two axes that decide where code goes
+
+**Does it import `vscode`?** Some directories here are enforced VS Code-free:
+importing `vscode` inside one is a lint error, not a convention. The canonical
+list is `VSCODE_FREE_ZONE_DIRS` in `eslint.config.mjs:60` — read it there rather
+than trusting a copy, including this one. Code in those zones reaches host
+services through `platform()` from `@platform/platform`; when it needs a
+capability the port does not expose, add a typed port rather than an import.
+
+**Does it run in a webview?** The webview frontends bundle for the browser, so
+anything they import must avoid Node built-ins. Exactly five `utils` modules are
+reachable from them today — `@utils/core`, `@utils/core/boundedIdSet`,
+`@utils/errors/errorMessage`, `@utils/files/pastedImageName`,
+`@utils/text/stringUtils`. Adding an import to any of those five, or to their
+transitive dependencies, can break a webview build in a way `tsc` will not catch.
+
+## Picking between the general-sounding names
+
+`shared/`, `common/`, and `utils/` are the three placements newcomers get wrong.
+
+- **`shared/`** — two things, both browser-reachable. First, types and schemas
+  that cross a process or wire boundary (extension host ↔ webview, main ↔
+  renderer, client ↔ backend): if both sides must agree on the shape, it goes
+  here. Second, the **shared browser UI kit** — `shared/wa/` (Web Awesome icon
+  and component helpers), `shared/styles/`, `shared/litControllers/`,
+  `shared/markdown/`, `BaseWebviewApp.ts`. That is runtime UI code, not a
+  contract: 26 modules under `shared/` import `lit`. Reusable webview UI belongs
+  here, not in a host package.
+- **`common/`** — cross-cutting logic with domain meaning that is not a wire
+  contract. Error classification is the clearest example.
+- **`utils/`** — leaf helpers with no domain knowledge. If it could plausibly be
+  an npm package, it belongs here.
+
+When two fit, prefer the one with the tighter constraints. Note that "tighter"
+varies within `shared/` itself: `shared/settingsView/handlers/` is guarded by
+`SharedSettingsViewBoundary.vitest.ts` against importing `@controllers/`,
+`@agent/`, `@model/`, `@tools/` or `@auth/`, while `shared/wa/` deliberately
+depends on Lit. Check for an existing boundary test near your target directory
+before assuming either extreme.
+
+**Where this document is not authoritative.** [`AGENTS.md`](../AGENTS.md) is the
+canonical statement of conventions; this file is an orientation map for `src/`
+and defers to it wherever the two overlap. Facts that live in code — the
+VS Code-free zone list, the lint rules, the ratchet baselines — are canonical in
+code, and this file points at them rather than restating them.
+
+## Conventions worth knowing before your first change
+
+- **Builds do not type check.** esbuild and Vite strip types without checking
+  them. Run `npm run typecheck`, or use the `:safe` script variants.
+- **No convenience barrels.** An `index.ts` exists only for a documented public
+  surface. Import the file that defines the symbol.
+- **Schemas are the source of truth.** Define the Zod schema, derive the type
+  with `z.infer`. Tool input schemas use `.nullish()`, not `.optional()`.
+- **Silent degradation is a defect.** A fallback that hides a failure must log
+  loudly or not exist.
+
+Full conventions and the reasoning behind each: [`AGENTS.md`](../AGENTS.md).
+Orientation for agents and a map of the wiring points that fail silently:
+[`CLAUDE.md`](../CLAUDE.md).


### PR DESCRIPTION
**Split as requested.** This PR is now documents only — 7 files. All code moved to three independently reviewable PRs:

| PR | Contents |
|---|---|
| #9535 | Workflow hardening — `claude.yml`, `allowed-tools.json` |
| #9536 | Package/alias fixes — trace-viewer deps, three dead aliases, build-map gate |
| #9537 | The five relocations plus every importer, test-literal and doc-link rewrite |

Each verifies standalone (`npm run typecheck` clean across all seven projects on each branch, plus the relevant gates).

## What's left here

- **`2026-08-01-open-source-readiness-audit.md`** — eleven parallel audits with adversarial verification; 90 findings survived, 33 refuted and recorded so they aren't re-proposed. Supersession headers now scope the three conclusions it disproves in `2026-07-29-open-source-readiness.md`.
- **`2026-08-01-backend-decoupling-plan.md`** — revised substantially in review (see below).
- **`2026-08-01-directory-organization.md`** — the tree is structurally sound; the problem is legibility and written rules that no longer match it.
- **`AGENTS.md`**, **`src/README.md`**, **`check-guidance-refs.mjs`** — two AGENTS.md rules that were measurably false against the tree, plus a `src/` index (there was none; the only four READMEs are under `src/agent/`).

## Backend plan changes from review

Per-facet availability gates instead of one proxy fact · Port A owning `apiAccessMode`/`quotaAutoSwitched` rather than Port C duplicating them · `AccountPlane` split into a shared schema and a controllers-side runtime registry, rather than letting the edge ratchet site a service locator in the browser-reachable zone · one `BACKEND_MODULES` array deriving both lint rules · the `@supabase/supabase-js` removal moved out of step 4 · step 10 rescoped against the **36** suites that actually import the modules it deletes.

The contract-ownership section now addresses module identity head-on and recommends factory exports over a shared singleton — a private package registering into a public singleton needs the same module *instance*, which SHA-pinned CI does not provide.

## Still open — and this PR should not merge until they're resolved

Your four substantive objections stand, and I have not tried to paper over them:

1. **The audit reproduces confidential correspondence and a working relay-accounting weakness.** I still don't know what "closing" these means beyond scheduling the history rewrite and fixing the client-attested spend cap server-side, both outside this PR. Tell me the shape you want and I'll do it.
2. **No importable public contract for `@texra/hosted`.** Documented now, with `packages/agent` assessed as the candidate — but the package decision is yours.
3. **`AccountPlane.signIn()` returning a boolean across three distinct host session protocols.** Not yet addressed.
4. **The dependency-license verdict is broader than the pinned npm and Deno/JSR versions actually examined.** Not yet narrowed.

Items 3 and 4 are straightforward once you confirm the direction; 1 and 2 are decisions rather than edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3sUAZ2ygoZ58tBPerPjS6