### PR TITLE
refactor(settings): share agent file actions

### DIFF
--- a/packages/desktop/src/main/desktopAgentSettingsController.ts
+++ b/packages/desktop/src/main/desktopAgentSettingsController.ts
@@ -19,6 +19,7 @@ import type { TeamAvailabilityChoice } from '@common/teams/TeamAvailabilityPrefl
 import { loadTeamOptions } from '@common/teams/TeamPlan';
 import { applyTeamRosterWithPreflight } from '@common/teams/TeamRosterApplication';
 import { createTeamCatalogPorts } from '@controllers/mainView/teamCatalogPorts';
+import { createSettingsAgentActions } from '@controllers/settingsView/SettingsAgentActions';
 import { SettingsAgentFileController } from '@controllers/settingsView/SettingsAgentFileController';
 import { SettingsRemoteAgentPromptController } from '@controllers/settingsView/SettingsRemoteAgentPromptController';
 import { createSettingsAgentControllers } from '@controllers/settingsView/SettingsAgentControllerFactory';
@@ -135,6 +136,7 @@ export class DefaultDesktopAgentSettingsController implements DesktopAgentSettin
   private readonly remoteCatalog: DefaultDesktopAgentSettingsControllerOptions['remoteCatalog'];
   private readonly notifications: DefaultDesktopAgentSettingsControllerOptions['notifications'];
   private readonly resourcesPath: string;
+  private readonly agentActions;
   /** Path planners for custom-agent copy/delete/template writes. */
   private readonly fileController = new SettingsAgentFileController();
   private readonly remotePromptController =
@@ -174,15 +176,54 @@ export class DefaultDesktopAgentSettingsController implements DesktopAgentSettin
     this.catalogController = controllers.catalog;
     this.directoryController = controllers.directory;
     this.visibilityController = controllers.visibility;
+    this.agentActions = createSettingsAgentActions({
+      directoryController: this.directoryController,
+      findAgent: (source, name) => getAgent(agentKey(source, name)),
+      getCustomAgentDirectory: directory.getCustomAgentDirectory,
+      getSourceDirectory: directory.getSourceDirectory,
+      openDocument: directory.openPath,
+      revealFile: directory.revealPath,
+      confirmAction: (message, confirmLabel) =>
+        prompts.confirm({
+          title:
+            confirmLabel === 'Delete'
+              ? 'Delete custom agent?'
+              : 'Overwrite custom copy?',
+          message,
+        }),
+      showInfoMessage: notifications.showInfoMessage,
+      showErrorMessage: notifications.showErrorMessage,
+      formatOpenAgentYamlError: (reason, name) =>
+        reason === 'missingAgent'
+          ? `Agent not found: ${name}`
+          : `No configuration file found for agent: ${name}`,
+      refreshAfterMutation: () => this.refreshAfterAgentMutation(),
+      run: async (command, failureMessage, action) => {
+        if (
+          command === SETTINGS_VIEW_COMMANDS.OPEN_AGENT_YAML ||
+          command === SETTINGS_VIEW_COMMANDS.REVEAL_AGENT_FILE
+        ) {
+          await action();
+          return;
+        }
+        try {
+          await action();
+        } catch (error) {
+          await notifications.showErrorMessage(
+            `${failureMessage}: ${toErrorMessage(error)}`,
+          );
+        }
+      },
+    });
     this.handlers = {
       setAgentEnabled: (message) => this.updateAgentEnabled(message),
       setAllAgentsEnabled: (message) => this.updateAllAgentsEnabled(message),
-      openAgentYaml: (message) => this.openAgentYaml(message),
+      openAgentYaml: this.agentActions.openAgentYaml,
       openAgentFolder: () => this.openAgentFolder(),
       createAgent: (message) => this.createAgent(message),
-      customizeAgent: (message) => this.customizeAgent(message),
-      deleteCustomAgent: (message) => this.deleteCustomAgent(message),
-      revealAgentFile: (message) => this.revealAgentFile(message),
+      customizeAgent: this.agentActions.customizeAgent,
+      deleteCustomAgent: this.agentActions.deleteCustomAgent,
+      revealAgentFile: this.agentActions.revealAgentFile,
       viewRemoteAgentPrompt: (message) => this.viewRemoteAgentPrompt(message),
       setCustomAgentDir: () => this.setCustomAgentDir(),
       resetCustomAgentDir: () => this.resetCustomAgentDir(),
@@ -321,24 +362,6 @@ export class DefaultDesktopAgentSettingsController implements DesktopAgentSettin
     ]);
   }
 
-  private async openAgentYaml(
-    message: AgentMessage<typeof SETTINGS_VIEW_COMMANDS.OPEN_AGENT_YAML>,
-  ): Promise<void> {
-    const result = this.directoryController.planOpenAgentYaml({
-      source: message.agentSource,
-      name: message.agentName,
-    });
-    if (!result.ok) {
-      await this.notifications.showErrorMessage(
-        result.reason === 'missingAgent'
-          ? `Agent not found: ${message.agentName}`
-          : `No configuration file found for agent: ${message.agentName}`,
-      );
-      return;
-    }
-    await this.directory.openPath(result.path);
-  }
-
   private async openAgentFolder(): Promise<void> {
     const result = await this.directoryController.planOpenAgentFolder('custom');
     if (!result.ok) {
@@ -424,103 +447,6 @@ export class DefaultDesktopAgentSettingsController implements DesktopAgentSettin
     }
   }
 
-  /** Copy a bundled agent into the custom directory so it can be edited. */
-  private async customizeAgent(
-    data: AgentMessage<typeof SETTINGS_VIEW_COMMANDS.CUSTOMIZE_AGENT>,
-  ): Promise<void> {
-    const entry = getAgent(agentKey(data.agentSource, data.agentName));
-    if (!entry?.path) {
-      await this.notifications.showErrorMessage(
-        `Agent not found or has no file: ${data.agentName}`,
-      );
-      return;
-    }
-
-    try {
-      const [customDir, sourceDir] = await Promise.all([
-        this.directory.getCustomAgentDirectory(),
-        this.directory.getSourceDirectory(data.agentSource),
-      ]);
-
-      const result = this.fileController.planCustomizeAgent({
-        entry: { path: entry.path },
-        customDir,
-        ...(sourceDir && { sourceDir }),
-      });
-      if (!result.ok) {
-        await this.notifications.showErrorMessage(
-          'Refusing to copy: target path escapes the custom agents directory.',
-        );
-        return;
-      }
-
-      const { targetPath } = result.plan;
-      await AbsoluteFS.ensureDir(path.dirname(targetPath));
-
-      // Never clobber an existing custom copy, which may hold user edits.
-      if (await AbsoluteFS.exists(targetPath)) {
-        const confirmed = await this.prompts.confirm({
-          title: 'Overwrite custom copy?',
-          message: `A custom copy already exists: ${path.basename(targetPath)}`,
-        });
-        if (!confirmed) return;
-      }
-
-      await AbsoluteFS.copy(entry.path, targetPath, { overwrite: true });
-      await this.directory.openPath(targetPath);
-      await this.notifications.showInfoMessage(
-        `Created custom copy: ${path.basename(targetPath)}`,
-      );
-      await this.refreshAfterAgentMutation();
-    } catch (error) {
-      await this.notifications.showErrorMessage(
-        `Failed to create custom agent copy: ${toErrorMessage(error)}`,
-      );
-    }
-  }
-
-  private async deleteCustomAgent(
-    data: AgentMessage<typeof SETTINGS_VIEW_COMMANDS.DELETE_CUSTOM_AGENT>,
-  ): Promise<void> {
-    const entry = getAgent(agentKey('custom', data.agentName));
-    if (!entry?.path) {
-      await this.notifications.showErrorMessage(
-        `Custom agent not found: ${data.agentName}`,
-      );
-      return;
-    }
-
-    try {
-      const customDir = await this.directory.getCustomAgentDirectory();
-      const result = this.fileController.planDeleteCustomAgent({
-        entry: { path: entry.path },
-        customDir,
-      });
-      if (!result.ok) {
-        await this.notifications.showErrorMessage(
-          'Refusing to delete: file is not inside the custom agents directory.',
-        );
-        return;
-      }
-
-      const confirmed = await this.prompts.confirm({
-        title: 'Delete custom agent?',
-        message: `Delete "${data.agentName}"? This cannot be undone.`,
-      });
-      if (!confirmed) return;
-
-      await AbsoluteFS.delete(result.plan.path, { recursive: false });
-      await this.notifications.showInfoMessage(
-        `Deleted custom agent: ${data.agentName}`,
-      );
-      await this.refreshAfterAgentMutation();
-    } catch (error) {
-      await this.notifications.showErrorMessage(
-        `Failed to delete custom agent: ${toErrorMessage(error)}`,
-      );
-    }
-  }
-
   /**
    * Show a hosted agent's prompt YAML. The extension opens an untitled editor;
    * the desktop has no editor surface, so the config is written to a temporary
@@ -549,22 +475,6 @@ export class DefaultDesktopAgentSettingsController implements DesktopAgentSettin
         `Failed to view remote agent prompt: ${toErrorMessage(error)}`,
       );
     }
-  }
-
-  private async revealAgentFile(
-    message: AgentMessage<typeof SETTINGS_VIEW_COMMANDS.REVEAL_AGENT_FILE>,
-  ): Promise<void> {
-    const result = this.directoryController.planRevealAgentFile({
-      source: message.agentSource,
-      name: message.agentName,
-    });
-    if (!result.ok) {
-      await this.notifications.showErrorMessage(
-        `Agent not found or has no file: ${message.agentName}`,
-      );
-      return;
-    }
-    await this.directory.revealPath(result.path);
   }
 
   private async applyAgentModePreset(

--- a/packages/desktop/src/main/desktopAgentSettingsController.ts
+++ b/packages/desktop/src/main/desktopAgentSettingsController.ts
@@ -19,7 +19,7 @@ import type { TeamAvailabilityChoice } from '@common/teams/TeamAvailabilityPrefl
 import { loadTeamOptions } from '@common/teams/TeamPlan';
 import { applyTeamRosterWithPreflight } from '@common/teams/TeamRosterApplication';
 import { createTeamCatalogPorts } from '@controllers/mainView/teamCatalogPorts';
-import { createSettingsAgentActions } from '@controllers/settingsView/SettingsAgentActions';
+import { createSettingsAgentActions } from '@controllers/settingsView/backend/SettingsAgentActions';
 import { SettingsAgentFileController } from '@controllers/settingsView/SettingsAgentFileController';
 import { SettingsRemoteAgentPromptController } from '@controllers/settingsView/SettingsRemoteAgentPromptController';
 import { createSettingsAgentControllers } from '@controllers/settingsView/SettingsAgentControllerFactory';

--- a/packages/extension/src/settingsView/handlers/agentHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/agentHandlers.ts
@@ -15,6 +15,7 @@ import { SupabaseClient } from '@auth/SupabaseClient';
 import { workspaceSM, globalSM } from '@common/state';
 import { applyTeamRosterWithPreflight } from '@common/teams/TeamRosterApplication';
 import { createSettingsAgentControllers } from '@controllers/settingsView/SettingsAgentControllerFactory';
+import { createSettingsAgentActions } from '@controllers/settingsView/SettingsAgentActions';
 import { SettingsRemoteAgentPromptController } from '@controllers/settingsView/SettingsRemoteAgentPromptController';
 import { SettingsAgentFileController } from '@controllers/settingsView/SettingsAgentFileController';
 import type { SettingsAgentVisibilityController } from '@controllers/settingsView/SettingsAgentVisibilityController';
@@ -57,6 +58,7 @@ export class AgentHandlers {
       fetchPromptConfig: fetchRemoteAgentConfigYaml,
     });
   private readonly visibilityController: SettingsAgentVisibilityController;
+  private readonly agentActions;
   private readonly activeCustomAgentDeletions = new Set<string>();
 
   constructor(
@@ -75,6 +77,37 @@ export class AgentHandlers {
     this.catalogController = controllers.catalog;
     this.directoryController = controllers.directory;
     this.visibilityController = controllers.visibility;
+    this.agentActions = createSettingsAgentActions({
+      directoryController: this.directoryController,
+      findAgent: (source, name) => getAgent(agentKey(source, name)),
+      getCustomAgentDirectory: () => agentDirectories.custom(),
+      getSourceDirectory: (source) => agentDirectories.getDirectory(source),
+      openDocument: async (filePath) => {
+        const doc = await vscode.workspace.openTextDocument(filePath);
+        await vscode.window.showTextDocument(doc, { preview: false });
+      },
+      revealFile: async (filePath) => {
+        await vscode.commands.executeCommand(
+          'revealFileInOS',
+          vscode.Uri.file(filePath),
+        );
+      },
+      confirmAction: (message, confirmLabel) =>
+        confirmModal(message, confirmLabel),
+      showInfoMessage: async (message) => {
+        void vscode.window.showInformationMessage(message);
+      },
+      showErrorMessage: async (message) => {
+        await showLoggedMessage(this.ctx.channel, message);
+      },
+      formatOpenAgentYamlError: (reason, name) =>
+        reason === 'missingAgent'
+          ? `Agent "${name}" could not be found. It may have been removed or renamed. Check the Agents tab in Settings to see available agents.`
+          : `No configuration file found for agent "${name}". The agent definition may be incomplete — try re-creating it from the Agents tab.`,
+      refreshAfterMutation: () => this.refreshAfterAgentMutation(),
+      run: (_command, failureMessage, action) =>
+        withHandlerErrorHandling(this.ctx, failureMessage, action),
+    });
   }
 
   // ── Agent selection data ──
@@ -93,34 +126,7 @@ export class AgentHandlers {
   async handleOpenAgentYaml(
     data: SettingsMessageFor<typeof SETTINGS_VIEW_CMD.OPEN_AGENT_YAML>,
   ): Promise<void> {
-    await withHandlerErrorHandling(
-      this.ctx,
-      'Failed to open agent YAML file',
-      async () => {
-        const result = this.directoryController.planOpenAgentYaml({
-          source: data.agentSource,
-          name: data.agentName,
-        });
-        if (!result.ok && result.reason === 'missingAgent') {
-          await showLoggedMessage(
-            this.ctx.channel,
-            `Agent "${data.agentName}" could not be found. It may have been removed or renamed. Check the Agents tab in Settings to see available agents.`,
-          );
-          return;
-        }
-
-        if (!result.ok) {
-          await showLoggedMessage(
-            this.ctx.channel,
-            `No configuration file found for agent "${data.agentName}". The agent definition may be incomplete — try re-creating it from the Agents tab.`,
-          );
-          return;
-        }
-
-        const doc = await vscode.workspace.openTextDocument(result.path);
-        await vscode.window.showTextDocument(doc, { preview: false });
-      },
-    );
+    await this.agentActions.openAgentYaml(data);
   }
 
   async handleSetAgentEnabled(
@@ -186,27 +192,7 @@ export class AgentHandlers {
   async handleRevealAgentFile(
     data: SettingsMessageFor<typeof SETTINGS_VIEW_CMD.REVEAL_AGENT_FILE>,
   ): Promise<void> {
-    await withHandlerErrorHandling(
-      this.ctx,
-      'Failed to reveal agent file',
-      async () => {
-        const result = this.directoryController.planRevealAgentFile({
-          source: data.agentSource,
-          name: data.agentName,
-        });
-        if (!result.ok) {
-          await showLoggedMessage(
-            this.ctx.channel,
-            `Agent not found or has no file: ${data.agentName}`,
-          );
-          return;
-        }
-        await vscode.commands.executeCommand(
-          'revealFileInOS',
-          vscode.Uri.file(result.path),
-        );
-      },
-    );
+    await this.agentActions.revealAgentFile(data);
   }
 
   async handleViewRemoteAgentPrompt(
@@ -251,63 +237,7 @@ export class AgentHandlers {
   async handleCustomizeAgent(
     data: SettingsMessageFor<typeof SETTINGS_VIEW_CMD.CUSTOMIZE_AGENT>,
   ): Promise<void> {
-    await withHandlerErrorHandling(
-      this.ctx,
-      'Failed to create custom agent copy',
-      async () => {
-        const key = agentKey(data.agentSource, data.agentName);
-        const entry = getAgent(key);
-        if (!entry?.path) {
-          await showLoggedMessage(
-            this.ctx.channel,
-            `Agent not found or has no file: ${data.agentName}`,
-          );
-          return;
-        }
-
-        const customDir = await agentDirectories.custom();
-        const sourceDir = await agentDirectories.getDirectory(data.agentSource);
-
-        const result = this.fileController.planCustomizeAgent({
-          entry,
-          customDir,
-          sourceDir,
-        });
-        if (!result.ok) {
-          await showLoggedMessage(
-            this.ctx.channel,
-            `Refusing to copy: target path escapes the custom agents directory.`,
-          );
-          return;
-        }
-
-        const { targetPath } = result.plan;
-
-        await AbsoluteFS.ensureDir(path.dirname(targetPath));
-
-        // Avoid overwriting an existing custom copy with user edits
-        if (await AbsoluteFS.exists(targetPath)) {
-          const confirmed = await confirmModal(
-            `A custom copy already exists: ${path.basename(targetPath)}`,
-            'Overwrite',
-          );
-          if (!confirmed) return;
-        }
-
-        await AbsoluteFS.copy(entry.path, targetPath, { overwrite: true });
-
-        const doc = await vscode.workspace.openTextDocument(
-          vscode.Uri.file(targetPath),
-        );
-        await vscode.window.showTextDocument(doc, { preview: false });
-
-        void vscode.window.showInformationMessage(
-          `Created custom copy: ${path.basename(targetPath)}`,
-        );
-
-        await this.refreshAfterAgentMutation();
-      },
-    );
+    await this.agentActions.customizeAgent(data);
   }
 
   async handleDeleteCustomAgent(
@@ -317,48 +247,7 @@ export class AgentHandlers {
     this.activeCustomAgentDeletions.add(data.agentName);
 
     try {
-      await withHandlerErrorHandling(
-        this.ctx,
-        'Failed to delete custom agent',
-        async () => {
-          const key = agentKey('custom', data.agentName);
-          const entry = getAgent(key);
-          if (!entry?.path) {
-            await showLoggedMessage(
-              this.ctx.channel,
-              `Custom agent not found: ${data.agentName}`,
-            );
-            return;
-          }
-
-          const customDir = await agentDirectories.custom();
-          const result = this.fileController.planDeleteCustomAgent({
-            entry,
-            customDir,
-          });
-          if (!result.ok) {
-            await showLoggedMessage(
-              this.ctx.channel,
-              `Refusing to delete: file is not inside the custom agents directory.`,
-            );
-            return;
-          }
-
-          const confirmed = await confirmModal(
-            `Delete "${data.agentName}"? This cannot be undone.`,
-            'Delete',
-          );
-          if (!confirmed) return;
-
-          await AbsoluteFS.delete(result.plan.path, { recursive: false });
-
-          void vscode.window.showInformationMessage(
-            `Deleted custom agent: ${data.agentName}`,
-          );
-
-          await this.refreshAfterAgentMutation();
-        },
-      );
+      await this.agentActions.deleteCustomAgent(data);
     } finally {
       this.activeCustomAgentDeletions.delete(data.agentName);
     }

--- a/packages/extension/src/settingsView/handlers/agentHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/agentHandlers.ts
@@ -15,7 +15,7 @@ import { SupabaseClient } from '@auth/SupabaseClient';
 import { workspaceSM, globalSM } from '@common/state';
 import { applyTeamRosterWithPreflight } from '@common/teams/TeamRosterApplication';
 import { createSettingsAgentControllers } from '@controllers/settingsView/SettingsAgentControllerFactory';
-import { createSettingsAgentActions } from '@controllers/settingsView/SettingsAgentActions';
+import { createSettingsAgentActions } from '@controllers/settingsView/backend/SettingsAgentActions';
 import { SettingsRemoteAgentPromptController } from '@controllers/settingsView/SettingsRemoteAgentPromptController';
 import { SettingsAgentFileController } from '@controllers/settingsView/SettingsAgentFileController';
 import type { SettingsAgentVisibilityController } from '@controllers/settingsView/SettingsAgentVisibilityController';

--- a/src/controllers/settingsView/SettingsAgentActions.ts
+++ b/src/controllers/settingsView/SettingsAgentActions.ts
@@ -1,0 +1,203 @@
+// Standard library imports
+import * as path from 'node:path';
+
+// Local imports - controllers
+import type { SettingsAgentDirectoryController } from '@controllers/settingsView/SettingsAgentDirectoryController';
+// Local imports - shared
+import { SETTINGS_VIEW_COMMANDS } from '@shared/ipc';
+import type { AgentSource, SettingsMessageFor } from '@shared/schemas';
+// Local imports - utilities
+import { AbsoluteFS } from '@utils/files';
+import { isStrictlyWithin } from '@utils/core/pathCore';
+
+interface AgentFileHandlers {
+  openAgentYaml(
+    message: SettingsMessageFor<typeof SETTINGS_VIEW_COMMANDS.OPEN_AGENT_YAML>,
+  ): Promise<void>;
+  customizeAgent(
+    message: SettingsMessageFor<typeof SETTINGS_VIEW_COMMANDS.CUSTOMIZE_AGENT>,
+  ): Promise<void>;
+  deleteCustomAgent(
+    message: SettingsMessageFor<
+      typeof SETTINGS_VIEW_COMMANDS.DELETE_CUSTOM_AGENT
+    >,
+  ): Promise<void>;
+  revealAgentFile(
+    message: SettingsMessageFor<
+      typeof SETTINGS_VIEW_COMMANDS.REVEAL_AGENT_FILE
+    >,
+  ): Promise<void>;
+}
+
+type AgentFileCommand = keyof AgentFileHandlers;
+
+interface SettingsAgentActionsOptions {
+  readonly directoryController: Pick<
+    SettingsAgentDirectoryController,
+    'planOpenAgentYaml' | 'planRevealAgentFile'
+  >;
+  readonly findAgent: (
+    source: AgentSource,
+    name: string,
+  ) => { path?: string } | undefined;
+  readonly getCustomAgentDirectory: () => Promise<string>;
+  readonly getSourceDirectory: (
+    source: AgentSource,
+  ) => Promise<string | undefined>;
+  readonly openDocument: (filePath: string) => Promise<void>;
+  readonly revealFile: (filePath: string) => Promise<void>;
+  readonly confirmAction: (
+    message: string,
+    confirmLabel: string,
+  ) => Promise<boolean>;
+  readonly showInfoMessage: (message: string) => Promise<void>;
+  readonly showErrorMessage: (message: string) => Promise<void>;
+  readonly formatOpenAgentYamlError: (
+    reason: 'missingAgent' | 'missingPath',
+    agentName: string,
+  ) => string;
+  readonly refreshAfterMutation: () => Promise<void>;
+  readonly run: (
+    command: AgentFileCommand,
+    failureMessage: string,
+    action: () => Promise<void>,
+  ) => Promise<void>;
+}
+
+/**
+ * Build the settings handlers whose file-system decisions are identical in
+ * every graphical host. Host-specific presentation and catalog refresh policy
+ * remain explicit dependencies.
+ */
+export function createSettingsAgentActions(
+  options: SettingsAgentActionsOptions,
+): AgentFileHandlers {
+  const run = (
+    command: AgentFileCommand,
+    action: () => Promise<void>,
+  ): Promise<void> => options.run(command, FAILURE_MESSAGES[command], action);
+
+  return {
+    openAgentYaml: (message) =>
+      run(message.command, async () => {
+        const result = options.directoryController.planOpenAgentYaml({
+          source: message.agentSource,
+          name: message.agentName,
+        });
+        if (!result.ok) {
+          await options.showErrorMessage(
+            options.formatOpenAgentYamlError(result.reason, message.agentName),
+          );
+          return;
+        }
+        await options.openDocument(result.path);
+      }),
+
+    revealAgentFile: (message) =>
+      run(message.command, async () => {
+        const result = options.directoryController.planRevealAgentFile({
+          source: message.agentSource,
+          name: message.agentName,
+        });
+        if (!result.ok) {
+          await options.showErrorMessage(
+            `Agent not found or has no file: ${message.agentName}`,
+          );
+          return;
+        }
+        await options.revealFile(result.path);
+      }),
+
+    customizeAgent: (message) =>
+      run(message.command, async () => {
+        const entryPath = options.findAgent(
+          message.agentSource,
+          message.agentName,
+        )?.path;
+        if (!entryPath) {
+          await options.showErrorMessage(
+            `Agent not found or has no file: ${message.agentName}`,
+          );
+          return;
+        }
+
+        const [customDir, sourceDir] = await Promise.all([
+          options.getCustomAgentDirectory(),
+          options.getSourceDirectory(message.agentSource),
+        ]);
+        const relativePath = sourceDir
+          ? path.relative(sourceDir, entryPath)
+          : path.basename(entryPath);
+        const targetPath = path.join(customDir, relativePath);
+        if (!isInside(customDir, targetPath)) {
+          await options.showErrorMessage(
+            'Refusing to copy: target path escapes the custom agents directory.',
+          );
+          return;
+        }
+
+        await AbsoluteFS.ensureDir(path.dirname(targetPath));
+        if (
+          (await AbsoluteFS.exists(targetPath)) &&
+          !(await options.confirmAction(
+            `A custom copy already exists: ${path.basename(targetPath)}`,
+            'Overwrite',
+          ))
+        ) {
+          return;
+        }
+
+        await AbsoluteFS.copy(entryPath, targetPath, { overwrite: true });
+        await options.openDocument(targetPath);
+        await options.showInfoMessage(
+          `Created custom copy: ${path.basename(targetPath)}`,
+        );
+        await options.refreshAfterMutation();
+      }),
+
+    deleteCustomAgent: (message) =>
+      run(message.command, async () => {
+        const entryPath = options.findAgent('custom', message.agentName)?.path;
+        if (!entryPath) {
+          await options.showErrorMessage(
+            `Custom agent not found: ${message.agentName}`,
+          );
+          return;
+        }
+
+        const customDir = await options.getCustomAgentDirectory();
+        if (!isInside(customDir, entryPath)) {
+          await options.showErrorMessage(
+            'Refusing to delete: file is not inside the custom agents directory.',
+          );
+          return;
+        }
+
+        if (
+          !(await options.confirmAction(
+            `Delete "${message.agentName}"? This cannot be undone.`,
+            'Delete',
+          ))
+        ) {
+          return;
+        }
+
+        await AbsoluteFS.delete(entryPath, { recursive: false });
+        await options.showInfoMessage(
+          `Deleted custom agent: ${message.agentName}`,
+        );
+        await options.refreshAfterMutation();
+      }),
+  };
+}
+
+const FAILURE_MESSAGES: Readonly<Record<AgentFileCommand, string>> = {
+  openAgentYaml: 'Failed to open agent YAML file',
+  customizeAgent: 'Failed to create custom agent copy',
+  deleteCustomAgent: 'Failed to delete custom agent',
+  revealAgentFile: 'Failed to reveal agent file',
+};
+
+function isInside(parentDir: string, candidatePath: string): boolean {
+  return isStrictlyWithin(path.resolve(parentDir), path.resolve(candidatePath));
+}

--- a/src/controllers/settingsView/SettingsAgentFileController.ts
+++ b/src/controllers/settingsView/SettingsAgentFileController.ts
@@ -3,39 +3,6 @@ import * as path from 'node:path';
 
 // Local imports - shared
 import type { AgentCategory } from '@shared/schemas/agent';
-import { isStrictlyWithin } from '@utils/core/pathCore';
-
-export interface SettingsAgentFileEntry {
-  path: string;
-}
-
-interface SettingsAgentCustomizePlan {
-  targetPath: string;
-}
-
-export type SettingsAgentCustomizeResult =
-  | {
-      ok: true;
-      plan: SettingsAgentCustomizePlan;
-    }
-  | {
-      ok: false;
-      reason: 'targetEscapesCustomDir';
-    };
-
-interface SettingsAgentDeletePlan {
-  path: string;
-}
-
-export type SettingsAgentDeleteResult =
-  | {
-      ok: true;
-      plan: SettingsAgentDeletePlan;
-    }
-  | {
-      ok: false;
-      reason: 'fileOutsideCustomDir';
-    };
 
 export interface SettingsAgentTemplatePlan {
   fileName: string;
@@ -46,35 +13,6 @@ export interface SettingsAgentTemplatePlan {
 }
 
 export class SettingsAgentFileController {
-  planCustomizeAgent(input: {
-    entry: SettingsAgentFileEntry;
-    customDir: string;
-    sourceDir?: string;
-  }): SettingsAgentCustomizeResult {
-    const targetPath = this.resolveCustomTargetPath({
-      customDir: input.customDir,
-      sourceDir: input.sourceDir,
-      sourcePath: input.entry.path,
-    });
-
-    if (!this.isInside(input.customDir, targetPath)) {
-      return { ok: false, reason: 'targetEscapesCustomDir' };
-    }
-
-    return { ok: true, plan: { targetPath } };
-  }
-
-  planDeleteCustomAgent(input: {
-    entry: SettingsAgentFileEntry;
-    customDir: string;
-  }): SettingsAgentDeleteResult {
-    if (!this.isInside(input.customDir, input.entry.path)) {
-      return { ok: false, reason: 'fileOutsideCustomDir' };
-    }
-
-    return { ok: true, plan: { path: input.entry.path } };
-  }
-
   validateTemplateName(value: string): string | null {
     if (!value) return 'Name cannot be empty';
     if (value.includes('/') || value.includes('\\')) {
@@ -108,23 +46,5 @@ export class SettingsAgentFileController {
       description,
       templateKind: isToolUse ? 'toolUse' : 'workflowSingle',
     };
-  }
-
-  private resolveCustomTargetPath(input: {
-    customDir: string;
-    sourceDir?: string;
-    sourcePath: string;
-  }): string {
-    const relativePath = input.sourceDir
-      ? path.relative(input.sourceDir, input.sourcePath)
-      : path.basename(input.sourcePath);
-    return path.join(input.customDir, relativePath);
-  }
-
-  private isInside(parentDir: string, candidatePath: string): boolean {
-    return isStrictlyWithin(
-      path.resolve(parentDir),
-      path.resolve(candidatePath),
-    );
   }
 }

--- a/src/controllers/settingsView/backend/SettingsAgentActions.ts
+++ b/src/controllers/settingsView/backend/SettingsAgentActions.ts
@@ -66,7 +66,7 @@ interface SettingsAgentActionsOptions {
 
 /**
  * Build the settings handlers whose file-system decisions are identical in
- * every graphical host. Host-specific presentation and catalog refresh policy
+ * every graphical host. Presentation and catalog refresh policy
  * remain explicit dependencies.
  */
 export function createSettingsAgentActions(

--- a/src/test-kernel/controllers/SettingsAgentFileController.vitest.ts
+++ b/src/test-kernel/controllers/SettingsAgentFileController.vitest.ts
@@ -9,86 +9,9 @@ import { describe, it } from 'vitest';
 import { SettingsAgentFileController } from '@controllers/settingsView/SettingsAgentFileController';
 
 const controller = new SettingsAgentFileController();
-const ROOT = path.join(path.sep, 'repo');
-const BUILT_IN_DIR = path.join(ROOT, 'resources', 'agents');
-const CUSTOM_DIR = path.join(ROOT, 'custom-agents');
+const CUSTOM_DIR = path.join(path.sep, 'repo', 'custom-agents');
 
 describe('SettingsAgentFileController', () => {
-  it('plans custom agent copies while preserving source-relative paths', () => {
-    const result = controller.planCustomizeAgent({
-      customDir: CUSTOM_DIR,
-      sourceDir: BUILT_IN_DIR,
-      entry: {
-        path: path.join(BUILT_IN_DIR, 'writing', 'draft.yaml'),
-      },
-    });
-
-    assert.equal(result.ok, true);
-    if (!result.ok) return;
-    assert.equal(
-      result.plan.targetPath,
-      path.join(CUSTOM_DIR, 'writing', 'draft.yaml'),
-    );
-  });
-
-  it('rejects customize targets that would escape the custom directory', () => {
-    const result = controller.planCustomizeAgent({
-      customDir: CUSTOM_DIR,
-      sourceDir: BUILT_IN_DIR,
-      entry: {
-        path: path.join(ROOT, 'other', 'outside.yaml'),
-      },
-    });
-
-    assert.deepEqual(result, { ok: false, reason: 'targetEscapesCustomDir' });
-  });
-
-  it('falls back to the basename when the source directory is unknown', () => {
-    const result = controller.planCustomizeAgent({
-      customDir: CUSTOM_DIR,
-      entry: {
-        path: path.join(ROOT, 'elsewhere', 'agent.yaml'),
-      },
-    });
-
-    assert.equal(result.ok, true);
-    if (!result.ok) return;
-    assert.equal(result.plan.targetPath, path.join(CUSTOM_DIR, 'agent.yaml'));
-  });
-
-  it.each([
-    {
-      label:
-        'accepts child paths when the custom directory is the filesystem root',
-      customDir: path.parse(ROOT).root,
-      entryPath: path.join(ROOT, 'custom-agents', 'agent.yaml'),
-    },
-    {
-      label: 'plans custom agent deletion for a custom directory agent',
-      customDir: CUSTOM_DIR,
-      entryPath: path.join(CUSTOM_DIR, 'agent.yaml'),
-    },
-  ])('$label', ({ customDir, entryPath }) => {
-    assert.deepEqual(
-      controller.planDeleteCustomAgent({
-        customDir,
-        entry: { path: entryPath },
-      }),
-      { ok: true, plan: { path: entryPath } },
-    );
-  });
-
-  it('rejects deletion outside the custom directory', () => {
-    const result = controller.planDeleteCustomAgent({
-      customDir: CUSTOM_DIR,
-      entry: {
-        path: path.join(ROOT, 'resources', 'agent.yaml'),
-      },
-    });
-
-    assert.deepEqual(result, { ok: false, reason: 'fileOutsideCustomDir' });
-  });
-
   it('validates template agent names', () => {
     assert.equal(controller.validateTemplateName(''), 'Name cannot be empty');
     assert.equal(

--- a/src/test-kernel/settings/AgentHandlersDelete.vitest.ts
+++ b/src/test-kernel/settings/AgentHandlersDelete.vitest.ts
@@ -1,13 +1,14 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   deleteFile: vi.fn(async () => undefined),
+  copyFile: vi.fn(async () => undefined),
+  ensureDir: vi.fn(async () => undefined),
+  fileExists: vi.fn(async () => false),
   getAgent: vi.fn(() => ({ path: '/custom/my-agent.yaml' })),
-  planDeleteCustomAgent: vi.fn(() => ({
-    ok: true as const,
-    plan: { path: '/custom/my-agent.yaml' },
-  })),
+  getSourceDirectory: vi.fn(async () => undefined as string | undefined),
   refreshAfterAgentMutation: vi.fn(async () => undefined),
+  showLoggedMessage: vi.fn(async () => ''),
   showInformationMessage: vi.fn(),
   showWarningMessage: vi.fn(),
 }));
@@ -16,6 +17,7 @@ vi.mock('vscode', () => ({
   commands: { executeCommand: vi.fn() },
   window: {
     showInformationMessage: mocks.showInformationMessage,
+    showTextDocument: vi.fn(),
     showWarningMessage: mocks.showWarningMessage,
   },
   workspace: { openTextDocument: vi.fn() },
@@ -45,9 +47,7 @@ vi.mock('@controllers/settingsView/SettingsAgentControllerFactory', () => ({
   }),
 }));
 vi.mock('@controllers/settingsView/SettingsAgentFileController', () => ({
-  SettingsAgentFileController: class {
-    planDeleteCustomAgent = mocks.planDeleteCustomAgent;
-  },
+  SettingsAgentFileController: class {},
 }));
 vi.mock(
   '@controllers/settingsView/SettingsRemoteAgentPromptController',
@@ -64,7 +64,7 @@ vi.mock('@frontend/auth/agentCatalogRefreshScope', () => ({
 vi.mock('@frontend/agents/AgentDirectoryManager', () => ({
   agentDirectories: {
     custom: vi.fn(async () => '/custom'),
-    getDirectory: vi.fn(),
+    getDirectory: mocks.getSourceDirectory,
   },
 }));
 vi.mock('@frontend/ui/dialogs', () => ({
@@ -79,7 +79,7 @@ vi.mock('@frontend/ui/dialogs', () => ({
 }));
 vi.mock('@frontend/ui/errorHandlingUtils', () => ({
   showLoggedErrorMessage: vi.fn(),
-  showLoggedMessage: vi.fn(),
+  showLoggedMessage: mocks.showLoggedMessage,
 }));
 vi.mock('@shared/settingsView/handlers/agentSelectionHandlers', () => ({
   buildAgentModePresetsMessage: vi.fn(),
@@ -87,7 +87,12 @@ vi.mock('@shared/settingsView/handlers/agentSelectionHandlers', () => ({
   buildCustomAgentDirMessage: vi.fn(),
 }));
 vi.mock('@utils/files', () => ({
-  AbsoluteFS: { delete: mocks.deleteFile },
+  AbsoluteFS: {
+    copy: mocks.copyFile,
+    delete: mocks.deleteFile,
+    ensureDir: mocks.ensureDir,
+    exists: mocks.fileExists,
+  },
 }));
 
 import { AgentHandlers } from '@settingsView/handlers/agentHandlers';
@@ -104,7 +109,14 @@ function createHandlers(): AgentHandlers {
   );
 }
 
-describe('AgentHandlers custom-agent deletion', () => {
+describe('AgentHandlers custom-agent file actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getAgent.mockReturnValue({ path: '/custom/my-agent.yaml' });
+    mocks.getSourceDirectory.mockResolvedValue(undefined);
+    mocks.fileExists.mockResolvedValue(false);
+  });
+
   it('coalesces repeated requests while the host confirmation is pending', async () => {
     let resolveConfirmation!: (choice: string | undefined) => void;
     const pendingConfirmation = new Promise<string | undefined>((resolve) => {
@@ -131,5 +143,58 @@ describe('AgentHandlers custom-agent deletion', () => {
     mocks.showWarningMessage.mockResolvedValueOnce(undefined);
     await handlers.handleDeleteCustomAgent(request);
     expect(mocks.showWarningMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects deletion outside the configured custom directory', async () => {
+    mocks.getAgent.mockReturnValueOnce({ path: '/bundled/my-agent.yaml' });
+
+    await createHandlers().handleDeleteCustomAgent({
+      command: 'deleteCustomAgent',
+      agentName: 'my-agent',
+    });
+
+    expect(mocks.showLoggedMessage).toHaveBeenCalledWith(
+      'test',
+      'Refusing to delete: file is not inside the custom agents directory.',
+    );
+    expect(mocks.showWarningMessage).not.toHaveBeenCalled();
+    expect(mocks.deleteFile).not.toHaveBeenCalled();
+  });
+
+  it('preserves the source-relative path when creating a custom copy', async () => {
+    mocks.getAgent.mockReturnValueOnce({
+      path: '/bundled/writing/my-agent.yaml',
+    });
+    mocks.getSourceDirectory.mockResolvedValueOnce('/bundled');
+
+    await createHandlers().handleCustomizeAgent({
+      command: 'customizeAgent',
+      agentSource: 'builtInWorkflow',
+      agentName: 'my-agent',
+    });
+
+    expect(mocks.copyFile).toHaveBeenCalledWith(
+      '/bundled/writing/my-agent.yaml',
+      '/custom/writing/my-agent.yaml',
+      { overwrite: true },
+    );
+    expect(mocks.refreshAfterAgentMutation).toHaveBeenCalledOnce();
+  });
+
+  it('rejects a custom-copy target outside the configured directory', async () => {
+    mocks.getAgent.mockReturnValueOnce({ path: '/outside/my-agent.yaml' });
+    mocks.getSourceDirectory.mockResolvedValueOnce('/bundled');
+
+    await createHandlers().handleCustomizeAgent({
+      command: 'customizeAgent',
+      agentSource: 'builtInWorkflow',
+      agentName: 'my-agent',
+    });
+
+    expect(mocks.showLoggedMessage).toHaveBeenCalledWith(
+      'test',
+      'Refusing to copy: target path escapes the custom agents directory.',
+    );
+    expect(mocks.copyFile).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Consolidate the extension and desktop orchestration for opening, revealing, copying, and deleting agent files. The new shared action owner performs the common path planning, containment checks, confirmations, file mutations, and success/error sequencing, while each host retains its own presentation and refresh policy.

Closes #9415.

## Issue acceptance gates

- A shared agents-actions builder now owns customize, deleteCustom, openYaml, and revealFile orchestration.
- Extension and desktop both use the message-shaped shared handlers introduced before this issue.
- Existing host-specific wording, confirmation presentation, editor/reveal operations, error boundaries, and catalog refresh topology are preserved.
- AI creation, template rendering, remote-prompt viewing, authentication deferral, teams/presets, and directory-refresh behavior remain host-side.
- No shared-handler directory move or CLI import change is included.

## Single source of truth

src/controllers/settingsView/backend/SettingsAgentActions.ts now owns the four common agent-file flows and their path-containment invariants. SettingsAgentFileController retains only template-name validation and template-file planning.

## Duplication and abstraction budget

The two independent plan-check-notify implementations were deleted from the extension and desktop. The new two-consumer builder is not a pass-through: it owns source-relative copy targets, custom-directory containment, overwrite/delete confirmation order, mutation order, and post-mutation notification/refresh sequencing. Host effects are injected explicitly.

## Net elements (R6)

- Files: 1 added, 0 deleted.
- Exported symbols: 1 added, 3 deleted.
- Classes/interfaces/enums: 2 interfaces added, 3 interfaces deleted; no classes or enums added.
- Lines: 363 added, 453 deleted, net -90.

## Consumer counts (R8)

No event emitter or subscriber path changes. The three deleted planner type exports had 0 external type consumers. The two deleted planner methods had exactly 2 production callers, both rerouted to the shared action owner in this PR.

## Host impact

Extension:

- Uses the shared actions through its existing logged-error boundary.
- Retains VS Code editor/reveal operations, detailed missing-file wording, non-blocking success notifications, catalog refresh behavior, and concurrent-delete coalescing.

Desktop:

- Uses the same shared actions through its existing Electron ports.
- Retains desktop confirmation titles, concise missing-file wording, local copy/delete error reporting, and propagation of unexpected open/reveal failures.

CLI:

- No behavior or import changes.

## Scheduled refactoring

None.

## Validation

- npm run format
- npm run compile:fast
- npm run lint
- npm run typecheck
- npm test: 814 files passed, 1 skipped; 8,234 tests passed, 4 skipped
- Post-review focused settings, desktop, and architecture suites: 6 files and 34 tests passed
- npm run check:dead-code-ratchet
- git diff --check
