### PR TITLE
refactor(runtime): unify stream status events

### DIFF
--- a/packages/cli/src/chat/tui/runChatTui.tsx
+++ b/packages/cli/src/chat/tui/runChatTui.tsx
@@ -884,10 +884,10 @@ export async function runChat(
   // signals "your turn." Combined with the StatusBar pill, this replaces
   // the legacy reader.prompt() ergonomics.
   disposers.push(
-    defaultSession().status.onDidChange((change) => {
+    defaultSession().events.subscribeStatus((change) => {
       if (
         change.streamId === session.streamId &&
-        change.status === STREAM_PHASE.WAITING &&
+        change.phase === STREAM_PHASE.WAITING &&
         !session.stopRequested
       ) {
         notify({ kind: 'agentFinished' });

--- a/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
+++ b/packages/cli/src/chat/tui/state/subscribeRuntimeHost.ts
@@ -290,7 +290,7 @@ export function attachTuiRunFactSubscription(
           return;
         case 'goalStateChanged':
         case 'inquiryThreadUpdated':
-        case 'updateStreamStatus':
+        case 'status':
           return;
         case 'clearMissingOutputs':
           applyClearMissingOutputs(fact.payload, missingOutputTargets);

--- a/packages/cli/src/chat/tui/state/subscribeStreamStatus.ts
+++ b/packages/cli/src/chat/tui/state/subscribeStreamStatus.ts
@@ -1,5 +1,4 @@
-// Mirror the default session's status machine `onDidChange` into the
-// per-stream status signal.
+// Mirror canonical session status facts into the per-stream status signal.
 
 import { defaultSession } from '@agent/runtime/SessionHandle';
 import {
@@ -17,7 +16,7 @@ import { isFinalTranscriptStatus } from './transcript';
 import { projectStreamTranscript } from './transcriptProjection';
 
 export function subscribeStreamStatus(): () => void {
-  return defaultSession().status.onDidChange((change) => {
+  return defaultSession().events.subscribeStatus((change) => {
     // Patch status BEFORE projection so the transcript projector derives
     // `finalizeDeferred` from the current status. A reused stream still
     // carrying `WAITING` from the previous turn would otherwise finalize
@@ -25,12 +24,12 @@ export function subscribeStreamStatus(): () => void {
     // `<Static>` before it finished streaming.
     const recognized = setStreamStatusInCliState({
       streamId: change.streamId,
-      status: change.status,
+      status: change.phase,
       ...(change.substate ? { substate: change.substate } : {}),
     });
     if (recognized) {
       projectStreamTranscript(change.streamId, {
-        finalize: isFinalTranscriptStatus(change.status),
+        finalize: isFinalTranscriptStatus(change.phase),
       });
     }
 
@@ -40,7 +39,7 @@ export function subscribeStreamStatus(): () => void {
     if (
       (change.cause === STREAM_TRANSITION_CAUSE.LIFECYCLE ||
         change.cause === STREAM_TRANSITION_CAUSE.USER_STOP) &&
-      isTerminalOutcomePhase(change.status) &&
+      isTerminalOutcomePhase(change.phase) &&
       activeStreamId.get() === change.streamId
     ) {
       const ownerStreamId = parentStream.get().get(change.streamId);

--- a/packages/cli/src/runtime/runProgressRenderer.ts
+++ b/packages/cli/src/runtime/runProgressRenderer.ts
@@ -164,9 +164,8 @@ class DefaultRunProgressRenderer implements RunProgressRenderer {
 
   private handleSessionFact(event: SessionFact): void {
     switch (event.type) {
-      case 'updateStreamStatus': {
-        const { status, streamId } = event.payload;
-        this.applyStatus(streamId, status);
+      case 'status': {
+        this.applyStatus(event.streamId, event.phase);
         return;
       }
       case 'updateStreamDescription':

--- a/packages/cli/src/runtime/sessionProgressSubscription.ts
+++ b/packages/cli/src/runtime/sessionProgressSubscription.ts
@@ -50,8 +50,17 @@ function projectCliSessionFact(
       return { event: 'setActiveStream', payload: fact.payload };
     case 'updateStreamDescription':
       return { event: 'updateStreamDescription', payload: fact.payload };
-    case 'updateStreamStatus':
-      return { event: 'updateStreamStatus', payload: fact.payload };
+    case 'status':
+      return {
+        event: 'updateStreamStatus',
+        payload: {
+          streamId: fact.streamId,
+          status: fact.phase,
+          cause: fact.cause,
+          ...(fact.previousPhase ? { previousStatus: fact.previousPhase } : {}),
+          ...(fact.substate ? { substate: fact.substate } : {}),
+        },
+      };
     case 'setParentStream':
       return { event: 'setParentStream', payload: fact.payload };
     case 'removeStream':

--- a/packages/cli/src/runtime/workflowPlainProjection.ts
+++ b/packages/cli/src/runtime/workflowPlainProjection.ts
@@ -188,20 +188,20 @@ export function attachWorkflowPlainProjection(
         projections.delete(event.payload.streamId);
         return;
       }
-      if (event.type !== 'updateStreamStatus') return;
-      const projection = projections.get(event.payload.streamId);
+      if (event.type !== 'status') return;
+      const projection = projections.get(event.streamId);
       if (!projection) return;
-      switch (event.payload.status) {
+      switch (event.phase) {
         case STREAM_PHASE.COMPLETED:
         case STREAM_PHASE.CANCELLED:
         case STREAM_PHASE.FAILED:
-          projection.complete(event.payload.status);
+          projection.complete(event.phase);
           break;
         case STREAM_PHASE.RUNNING:
         case STREAM_PHASE.WAITING:
           break;
         default:
-          assertNever(event.payload.status, 'Unhandled workflow stream status');
+          assertNever(event.phase, 'Unhandled workflow stream status');
       }
     },
     { scope: 'session' },

--- a/packages/desktop/src/main/desktopWindowTitle.ts
+++ b/packages/desktop/src/main/desktopWindowTitle.ts
@@ -16,7 +16,7 @@ type DesktopSessionActivity = SessionTitleState;
 
 type DesktopTitleSession = Pick<
   SessionHandle,
-  'executions' | 'interactions' | 'status'
+  'events' | 'executions' | 'interactions' | 'status'
 >;
 
 type DesktopTitleWindow = Pick<
@@ -73,7 +73,7 @@ export function installDesktopWindowTitle(
   window.webContents.on('page-title-updated', preventRendererTitle);
   const disposeRegistrations =
     session.executions.addRegistrationListener(update);
-  const disposeStatus = session.status.onDidChange(update);
+  const disposeStatus = session.events.subscribeStatus(update);
   const disposePending = session.interactions.onPendingCountChange(update);
   update();
 

--- a/packages/extension/src/frontend/statusBar/statusBarSessionEvents.ts
+++ b/packages/extension/src/frontend/statusBar/statusBarSessionEvents.ts
@@ -5,7 +5,7 @@ import type { SessionHandle } from '@agent/runtime/SessionHandle';
 import type { StatusBarUsageTracker } from './StatusBarUsageTracker';
 
 export interface StatusBarSessionEventOptions {
-  session: Pick<SessionHandle, 'events' | 'status'>;
+  session: Pick<SessionHandle, 'events'>;
   tracker: StatusBarUsageTracker;
   onStatusChanged: () => void;
   onUsageChanged: () => void;
@@ -21,10 +21,12 @@ export function subscribeStatusBarSessionEvents({
   onStatusChanged,
   onUsageChanged,
 }: StatusBarSessionEventOptions): () => void {
-  const disposeStatus = session.status.onDidChange(({ streamId, status }) => {
-    tracker.updateStreamStatus(streamId, status);
-    onStatusChanged();
-  });
+  const disposeStatus = session.events.subscribeStatus(
+    ({ streamId, phase }) => {
+      tracker.updateStreamStatus(streamId, phase);
+      onStatusChanged();
+    },
+  );
 
   const disposeUsage = session.events.subscribe(
     (sessionEvent) => {

--- a/src/agent/runtime/SessionEventHub.ts
+++ b/src/agent/runtime/SessionEventHub.ts
@@ -1,6 +1,6 @@
 import process from 'node:process';
 
-import type { AgentEvent } from '@agent/trace';
+import type { AgentEvent, StatusEvent } from '@agent/trace';
 import { createChannelTrace } from '@agent/trace';
 import type {
   ClearMissingOutputsPayload,
@@ -13,16 +13,15 @@ import type {
   StreamTabId,
   UpdateQueuedFollowUpsPayload,
   UpdateStreamDescriptionPayload,
-  UpdateStreamStatusPayload,
 } from '@shared/schemas';
 
 const logger = createChannelTrace('SessionEventHub');
 
 /**
- * Session-scoped fact vocabulary. Each arm's payload is a fact-native named
- * type from `@shared/schemas`; retained runtime-host progress projections
- * derive their payloads from those names, never the reverse. Run-scoped facts
- * live on `AgentEvent` (trace), not here.
+ * Session-scoped fact vocabulary. Payload-bearing arms use fact-native named
+ * types from `@shared/schemas`; status reuses the canonical trace event shape
+ * directly. Retained runtime-host projections derive their payloads here,
+ * never the reverse. Run-scoped facts live on `AgentEvent` (trace), not here.
  */
 export type SessionFact =
   | {
@@ -53,10 +52,7 @@ export type SessionFact =
       readonly type: 'updateStreamDescription';
       readonly payload: UpdateStreamDescriptionPayload;
     }
-  | {
-      readonly type: 'updateStreamStatus';
-      readonly payload: UpdateStreamStatusPayload;
-    }
+  | StatusEvent
   | {
       readonly type: 'setParentStream';
       readonly payload: SetParentStreamPayload;
@@ -165,6 +161,18 @@ export class SessionEventHub {
         this.runScopeSubscriberCountsByStream.delete(streamId);
       }
     };
+  }
+
+  /** Subscribe to canonical status facts on the synchronous session rail. */
+  subscribeStatus(subscriber: (event: StatusEvent) => void): () => void {
+    return this.subscribe(
+      (event) => {
+        if (event.scope === 'session' && event.event.type === 'status') {
+          subscriber(event.event);
+        }
+      },
+      { scope: 'session' },
+    );
   }
 
   /**

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -101,7 +101,7 @@ function isReplayableTerminalResult(event: ResultEvent): boolean {
 /**
  * A valid transcript store is required; other owners may be injected.
  *
- * `status` is deliberately absent: the machine publishes `updateStreamStatus`
+ * `status` is deliberately absent: the machine publishes canonical `status`
  * on the hub it is handed at construction, so a separately-injected machine
  * could be bound to a different hub than `events` and silently drop every
  * status fact. The session always co-constructs the pair instead.

--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -310,13 +310,14 @@ export class StreamStatusMachine {
         : {}),
       ...(options.substate ? { substate: options.substate } : {}),
     };
+    // Transcript recording still consumes run traces. Forward the same
+    // canonical fact first so recorder-owned rows settle before synchronous
+    // host projectors read them. This is a compatibility bridge, not a second
+    // status vocabulary or delivery rail.
+    options.trace?.emit(event);
     this.eventHub.emit({
       scope: 'session',
       event,
     });
-    // Transcript recording still consumes run traces. Forward the same
-    // canonical fact after the session hub has published it; this is a
-    // compatibility bridge, not a second status vocabulary.
-    options.trace?.emit(event);
   }
 }

--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -1,5 +1,5 @@
 import type { AgentTrace, StatusEvent } from '@agent/trace';
-import type { SessionEventHub } from '@agent/runtime/SessionEventHub';
+import { SessionEventHub } from '@agent/runtime/SessionEventHub';
 import {
   STREAM_PHASE,
   STREAM_SUBSTATE,
@@ -15,14 +15,6 @@ import {
   STREAM_TRANSITION_CAUSE,
   type StreamTransitionCause,
 } from '@shared/streams/streamStatus';
-
-export interface StreamStatusChange {
-  streamId: StreamTabId;
-  status: StreamPhase;
-  previousStatus?: StreamPhase;
-  cause: StreamTransitionCause;
-  substate?: StreamSubstate;
-}
 
 export interface StreamStatusEmitOptions {
   trace?: AgentTrace;
@@ -63,29 +55,29 @@ function effectiveState(entry: StreamEntry): StreamPhaseState {
   return entry.kind === 'reserved' ? RESERVED_STATE : entry.state;
 }
 
-function projectStatusEvent(event: StatusEvent): StreamStatusChange {
-  return {
-    streamId: event.streamId,
-    status: event.phase,
-    ...(event.previousPhase ? { previousStatus: event.previousPhase } : {}),
-    cause: event.cause,
-    ...(event.substate ? { substate: event.substate } : {}),
-  };
-}
-
 export class StreamStatusMachine {
   private readonly streams = new Map<StreamTabId, StreamEntry>();
-  private readonly statusListeners = new Set<
-    (change: StreamStatusChange) => void
-  >();
+  private eventHub: SessionEventHub;
 
   /**
-   * @param events Session hub this machine publishes `updateStreamStatus`
-   *   facts on. The session constructs both and hands the hub over once, so a
-   *   transition reaches every projector on the session-fact rail no matter
-   *   which caller triggered it — callers pass only their own trace.
+   * @param events Session hub this machine publishes canonical `status` facts
+   *   on. The session constructs both and hands the hub over once, so a
+   *   transition reaches every consumer on the session-fact rail no matter
+   *   which caller triggered it. Callers pass a trace only for the transcript
+   *   compatibility bridge.
    */
-  constructor(private readonly events?: SessionEventHub) {}
+  constructor(events: SessionEventHub = new SessionEventHub()) {
+    this.eventHub = events;
+  }
+
+  /** Bind status publication to the owning session's fact rail. */
+  attachSessionEvents(events: SessionEventHub): void {
+    this.eventHub = events;
+  }
+
+  get sessionEvents(): SessionEventHub {
+    return this.eventHub;
+  }
 
   get(stream: StreamTabId): StreamPhase | undefined {
     return this.stateFor(stream)?.phase;
@@ -295,13 +287,6 @@ export class StreamStatusMachine {
     return isInFlightPhase(this.get(stream));
   }
 
-  onDidChange(listener: (change: StreamStatusChange) => void): () => void {
-    this.statusListeners.add(listener);
-    return () => {
-      this.statusListeners.delete(listener);
-    };
-  }
-
   private stateFor(stream: StreamTabId): StreamPhaseState | undefined {
     const entry = this.streams.get(stream);
     return entry ? effectiveState(entry) : undefined;
@@ -325,18 +310,13 @@ export class StreamStatusMachine {
         : {}),
       ...(options.substate ? { substate: options.substate } : {}),
     };
-    options.trace?.emit(event);
-
-    const change = projectStatusEvent(event);
-    this.events?.emit({
+    this.eventHub.emit({
       scope: 'session',
-      event: {
-        type: 'updateStreamStatus',
-        payload: change,
-      },
+      event,
     });
-    for (const listener of this.statusListeners) {
-      listener(change);
-    }
+    // Transcript recording still consumes run traces. Forward the same
+    // canonical fact after the session hub has published it; this is a
+    // compatibility bridge, not a second status vocabulary.
+    options.trace?.emit(event);
   }
 }

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -110,7 +110,7 @@ export class ExecutionRegistry {
   private readonly handles = new Map<string, ExecutionHandle>();
   private disposed = false;
   private readonly changeCallbacks = new Map<string, Array<() => void>>();
-  private readonly disposeStatusListener: () => void;
+  private disposeStatusSubscription = (): void => undefined;
   private readonly streamStatus: StreamStatusMachine;
   private events: SessionEventHub | undefined;
   private approvals: SessionApprovals | undefined;
@@ -142,47 +142,51 @@ export class ExecutionRegistry {
     (activation: ChildExecutionActivation, active: boolean) => void
   >();
 
-  constructor({
-    events = new SessionEventHub(),
-    streamStatus = new StreamStatusMachine(events),
-    publishResult,
-  }: {
-    readonly streamStatus?: StreamStatusMachine;
-    readonly events?: SessionEventHub;
-    readonly publishResult?: (
-      event: ResultEvent,
-      streamId: StreamTabId,
-    ) => void;
-  } = {}) {
+  constructor(
+    options: {
+      readonly streamStatus?: StreamStatusMachine;
+      readonly events?: SessionEventHub;
+      readonly publishResult?: (
+        event: ResultEvent,
+        streamId: StreamTabId,
+      ) => void;
+    } = {},
+  ) {
+    const events =
+      options.events ??
+      options.streamStatus?.sessionEvents ??
+      new SessionEventHub();
+    const streamStatus =
+      options.streamStatus ?? new StreamStatusMachine(events);
     this.streamStatus = streamStatus;
-    this.attachSessionEvents(events, publishResult);
-    // Notify waiters and refresh UI badges when stream status changes
-    // (e.g. RUNNING → WAITING). Without this, waitForChange only resolves
-    // on progress/kill/untrack, and the background-tasks panel shows stale badges.
-    this.disposeStatusListener = this.streamStatus.onDidChange(
-      ({ streamId }) => {
-        for (const [executionId, handle] of this.handles) {
-          if (
-            handle instanceof AgentExecutionHandle &&
-            handle.childStreamId === streamId
-          ) {
-            this.notifyWaiters(executionId);
-            if (handle.isChildExecution) {
-              this.emitChildActivity(handle.parentStreamId);
-            }
-            break;
-          }
-        }
-      },
-    );
+    this.attachSessionEvents(events, options.publishResult);
   }
 
   attachSessionEvents(
     events: SessionEventHub,
     publishResult?: (event: ResultEvent, streamId: StreamTabId) => void,
   ): void {
+    this.disposeStatusSubscription();
     this.events = events;
+    this.streamStatus.attachSessionEvents(events);
     if (publishResult) this.publishResult = publishResult;
+    // Notify waiters and refresh UI badges when stream status changes
+    // (e.g. RUNNING → WAITING). SessionEventHub dispatch is synchronous, so
+    // bookkeeping retains the status machine subscription's original ordering.
+    this.disposeStatusSubscription = events.subscribeStatus(({ streamId }) => {
+      for (const [executionId, handle] of this.handles) {
+        if (
+          handle instanceof AgentExecutionHandle &&
+          handle.childStreamId === streamId
+        ) {
+          this.notifyWaiters(executionId);
+          if (handle.isChildExecution) {
+            this.emitChildActivity(handle.parentStreamId);
+          }
+          break;
+        }
+      }
+    });
   }
 
   /** Bind the session-owned approval state used when a child is detached. */
@@ -200,7 +204,7 @@ export class ExecutionRegistry {
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
-    this.disposeStatusListener();
+    this.disposeStatusSubscription();
     const executionIds = [...this.handles.keys()];
     this.handles.clear();
     for (const executionId of executionIds) {

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -367,7 +367,7 @@ export type AgentEvent =
  * `RunFactEvent`: it also includes transient runtime events that hosts project.
  *
  * `status` is deliberately absent. `StreamStatusMachine` publishes every
- * transition as an `updateStreamStatus` session fact, so projectors read
+ * transition as a canonical `status` session fact, so projectors read
  * status from that one rail; the `status` trace event survives only for
  * `TexraTranscriptRecorder`, which subscribes to the run trace directly.
  */

--- a/src/controllers/progressView/backend/events/ProgressFactApplier.ts
+++ b/src/controllers/progressView/backend/events/ProgressFactApplier.ts
@@ -234,12 +234,12 @@ export class ProgressFactApplier {
           return this.handleSetActiveStream(fact.payload);
         case 'updateStreamDescription':
           return this.handleUpdateStreamDescription(fact.payload);
-        case 'updateStreamStatus':
+        case 'status':
           return this.setStreamStatus(
-            fact.payload.streamId,
-            fact.payload.status,
-            fact.payload.previousStatus,
-            fact.payload.substate,
+            fact.streamId,
+            fact.phase,
+            fact.previousPhase,
+            fact.substate,
           );
         case 'setParentStream':
           return this.handleSetParentStream(fact.payload);
@@ -713,9 +713,7 @@ export class ProgressFactApplier {
   async setStreamStatus(
     streamId: StreamTabId,
     status: StreamPhase,
-    // Kept until Stage 5 removes the legacy bus projection; the status machine
-    // now owns repair writes, so this projection no longer consumes it.
-    _previousStatus?: StreamPhase,
+    previousPhase?: StreamPhase,
     substate?: StreamSubstate,
   ): Promise<void> {
     // Land the status-machine phase in the parent rosters before this handler
@@ -738,7 +736,7 @@ export class ProgressFactApplier {
     }
 
     const isNewRunningTransition =
-      status === STREAM_PHASE.RUNNING && _previousStatus !== status;
+      status === STREAM_PHASE.RUNNING && previousPhase !== status;
     const runningCategory = isNewRunningTransition
       ? this.handleRunningTransition(streamId)
       : undefined;

--- a/src/test-kernel/agent/progressTestUtils.ts
+++ b/src/test-kernel/agent/progressTestUtils.ts
@@ -71,7 +71,21 @@ export function recordSessionEvents(
   return { events, detach };
 }
 
-export function sessionFactPayloads<T extends SessionFact['type']>(
+export function sessionFactsOfType<T extends SessionFact['type']>(
+  events: readonly SessionEvent[],
+  type: T,
+): Array<Extract<SessionFact, { type: T }>> {
+  const facts: Array<Extract<SessionFact, { type: T }>> = [];
+  for (const entry of events) {
+    if (entry.scope !== 'session' || entry.event.type !== type) continue;
+    facts.push(entry.event as Extract<SessionFact, { type: T }>);
+  }
+  return facts;
+}
+
+type PayloadSessionFact = Exclude<SessionFact, { type: 'status' }>;
+
+export function sessionFactPayloads<T extends PayloadSessionFact['type']>(
   events: readonly SessionEvent[],
   type: T,
 ): unknown[] {

--- a/src/test-kernel/agent/progressTestUtils.ts
+++ b/src/test-kernel/agent/progressTestUtils.ts
@@ -83,7 +83,7 @@ export function sessionFactsOfType<T extends SessionFact['type']>(
   return facts;
 }
 
-type PayloadSessionFact = Exclude<SessionFact, { type: 'status' }>;
+export type PayloadSessionFact = Exclude<SessionFact, { type: 'status' }>;
 
 export function sessionFactPayloads<T extends PayloadSessionFact['type']>(
   events: readonly SessionEvent[],

--- a/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentLaunchContext.vitest.ts
@@ -146,8 +146,8 @@ describe('AgentLaunchContext', () => {
       responseTextProcessing,
     });
     const detachEvents = session.events.subscribe(() => undefined);
-    const detachStatus = session.status.onDidChange(({ status }) => {
-      if (status === STREAM_PHASE.FAILED) order.push('terminal');
+    const detachStatus = session.events.subscribeStatus(({ phase }) => {
+      if (phase === STREAM_PHASE.FAILED) order.push('terminal');
     });
     const stage = noopTrace.openStage('Run');
     const endStage = vi.spyOn(stage, 'end').mockImplementation(() => {

--- a/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
+++ b/src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts
@@ -6,16 +6,13 @@ import { describe, expect, it, vi } from 'vitest';
 
 // Local imports
 import type { FinalizeExecutionResult } from '@agent/storage';
-import { noopTrace, TraceEmitter } from '@agent/trace';
+import { noopTrace, TraceEmitter, type StatusEvent } from '@agent/trace';
 import {
   acquireResumedExecutionLease,
   inspectExecutionLease,
   releaseOwnedExecutionLease,
 } from '@agent/storage/executionLease';
-import {
-  StreamStatusMachine,
-  type StreamStatusChange,
-} from '@agent/runtime/StreamStatusService';
+import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import {
   AgentExecutionHandle,
   type AgentRunHandle,
@@ -62,6 +59,7 @@ import {
   recordSessionEvents,
   runEventsOfType,
   sessionFactPayloads,
+  sessionFactsOfType,
 } from '../progressTestUtils';
 import { createTestLaunchContext } from './launchContextTestUtils';
 
@@ -375,9 +373,7 @@ describe('runFlowWithLifecycle', () => {
       await runFlowWithLifecycle(ctx, async () => {
         expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.RUNNING);
         expect(streamStatus.getSubstate(streamId)).toBeUndefined();
-        expect(
-          sessionFactPayloads(recorded.events, 'updateStreamStatus'),
-        ).toEqual([]);
+        expect(sessionFactsOfType(recorded.events, 'status')).toEqual([]);
         return toolUseResult(executionId, streamId, RUN_OUTCOME.COMPLETED);
       });
 
@@ -662,9 +658,9 @@ describe('runFlowWithLifecycle', () => {
     const { executionId, streamId, streamStatus, ctx } = lifecycleFixture(
       'lifecycle-early-stop-no-blip',
     );
-    const changes: StreamStatusChange[] = [];
-    const detachStatus = streamStatus.onDidChange((change) => {
-      if (change.streamId === streamId) changes.push(change);
+    const changes: StatusEvent[] = [];
+    const detachStatus = defaultSession().events.subscribeStatus((event) => {
+      if (event.streamId === streamId) changes.push(event);
     });
 
     try {
@@ -681,7 +677,7 @@ describe('runFlowWithLifecycle', () => {
       );
 
       expect(result.outcome).toBe(RUN_OUTCOME.CANCELLED);
-      expect(changes.map((change) => change.status)).toEqual([
+      expect(changes.map((change) => change.phase)).toEqual([
         STREAM_PHASE.CANCELLED,
       ]);
     } finally {

--- a/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
+++ b/src/test-kernel/agent/runtime/ExecutionRegistry.vitest.ts
@@ -40,6 +40,7 @@ import {
   recordSessionEvents,
   runEventsOfType,
   sessionFactPayloads,
+  sessionFactsOfType,
 } from '../progressTestUtils';
 
 const storageMocks = vi.hoisted(() => ({
@@ -159,7 +160,8 @@ describe('executionRegistry', () => {
   });
 
   it('settles without persisting a stopped waiting handle after lease loss', async () => {
-    const streamStatus = new StreamStatusMachine();
+    const events = new SessionEventHub();
+    const streamStatus = new StreamStatusMachine(events);
     const registry = new ExecutionRegistry({ streamStatus });
     const executionId = 'exec-waiting-lease-lost' as ExecutionId;
     const streamId = 'stream-waiting-lease-lost' as StreamTabId;
@@ -406,11 +408,12 @@ describe('executionRegistry', () => {
     // callback SessionHandle injects (see SessionHandle.publishRunEvent) so
     // this path can reach those subscribers directly, since the turn's own
     // trace subscriptions are already torn down by the time a kill runs.
-    const streamStatus = new StreamStatusMachine();
+    const events = new SessionEventHub();
+    const streamStatus = new StreamStatusMachine(events);
     const publishResult = vi.fn();
     const registry = new ExecutionRegistry({
       streamStatus,
-      events: new SessionEventHub(),
+      events,
       publishResult,
     });
     const executionId = 'exec-waiting-kill-publish-result-test';
@@ -1014,12 +1017,10 @@ describe('executionRegistry', () => {
       expect(childInterrupt).toHaveBeenCalledOnce();
       expect(streamStatus.get(rootStreamId)).toBe(STREAM_PHASE.CANCELLED);
       expect(streamStatus.get(childStreamId)).toBe(STREAM_PHASE.CANCELLED);
-      expect(
-        sessionFactPayloads(recorded.events, 'updateStreamStatus'),
-      ).toEqual(
+      expect(sessionFactsOfType(recorded.events, 'status')).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            status: STREAM_PHASE.CANCELLED,
+            phase: STREAM_PHASE.CANCELLED,
           }),
         ]),
       );
@@ -1282,9 +1283,9 @@ describe('executionRegistry', () => {
 
       expect(streamStatus.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
       expect(
-        sessionFactPayloads(recorded.events, 'updateStreamStatus').at(-1),
+        sessionFactsOfType(recorded.events, 'status').at(-1),
       ).toMatchObject({
-        status: STREAM_PHASE.CANCELLED,
+        phase: STREAM_PHASE.CANCELLED,
       });
     } finally {
       registry.dispose();
@@ -1821,7 +1822,7 @@ describe('executionRegistry', () => {
     }
   });
 
-  it('detaches its stream-status listener when disposed', () => {
+  it('detaches its stream-status subscription when disposed', () => {
     const explicit = createRecordingHost();
     const streamStatus = new StreamStatusMachine();
     const registry = new ExecutionRegistry({ streamStatus });

--- a/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionResultEvent.vitest.ts
@@ -92,12 +92,11 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
   it('emits exactly one completed result even if terminal stream-status cleanup throws', async () => {
     const { ctx, streamStatus, results } = setupResultCase();
     // A status subscriber that throws on the terminal (COMPLETED) transition,
-    // not the initial RUNNING one — models a host emit / status listener throwing
-    // during post-completion cleanup. The run already emitted `completed`, so
-    // this must NOT re-enter the catch arm and publish a second `failed`.
-    const off = streamStatus.onDidChange((change) => {
-      if (change.status === STREAM_PHASE.COMPLETED) {
-        throw new Error('status listener boom');
+    // not the initial RUNNING one. The hub isolates subscribers, so the run's
+    // completed result remains the sole terminal result.
+    const off = ctx.runScope.session.events.subscribeStatus(({ phase }) => {
+      if (phase === STREAM_PHASE.COMPLETED) {
+        throw new Error('status subscriber boom');
       }
     });
     try {
@@ -266,11 +265,11 @@ describe('terminal result event (SDK Step 7d PR 6)', () => {
     }
   });
 
-  it('emits the failed result before terminal error status listeners run', async () => {
+  it('emits the failed result before terminal error status subscribers run', async () => {
     const { ctx, streamStatus, results } = setupResultCase();
-    const off = streamStatus.onDidChange((change) => {
-      if (change.status === STREAM_PHASE.FAILED) {
-        throw new Error('status listener boom');
+    const off = ctx.runScope.session.events.subscribeStatus(({ phase }) => {
+      if (phase === STREAM_PHASE.FAILED) {
+        throw new Error('status subscriber boom');
       }
     });
     try {

--- a/src/test-kernel/agent/runtime/StreamStatusService.vitest.ts
+++ b/src/test-kernel/agent/runtime/StreamStatusService.vitest.ts
@@ -386,7 +386,7 @@ describe('StreamStatusMachine', () => {
     });
   });
 
-  it('emits status trace events when a trace owns publication', () => {
+  it('bridges canonical status facts to a supplied run trace', () => {
     const events = new SessionEventHub();
     const machine = new StreamStatusMachine(events);
     const publishedRunEvents = recordSessionEvents(events, { scope: 'run' });
@@ -423,13 +423,30 @@ describe('StreamStatusMachine', () => {
     );
   });
 
+  it('settles trace subscribers before publishing to session subscribers', () => {
+    const events = new SessionEventHub();
+    const machine = new StreamStatusMachine(events);
+    const trace = new TraceEmitter();
+    const streamId = 'stream-status-order-test' as StreamTabId;
+    const order: string[] = [];
+
+    trace.subscribe((event) => {
+      if (event.type === 'status') order.push('trace');
+    });
+    events.subscribeStatus(() => order.push('session'));
+
+    machine.transition(streamId, STREAM_PHASE.RUNNING, 'lifecycle', { trace });
+
+    expect(order).toEqual(['trace', 'session']);
+  });
+
   // One rail: the session fact is published by the machine itself, so a
   // trace-owned transition (run start, terminal, manual-retry wait, restart
   // repair) reaches every projector without the caller passing a hub. Before
   // this became unconditional, those transitions were visible only as
   // run-scope `status` trace events, which is why each projector carried its
   // own duplicate trace arm.
-  it('publishes the session fact even when a trace owns publication', () => {
+  it('publishes the session fact when a trace bridge is present', () => {
     const { machine, statusEvents, streamId } = setupMachine(
       'stream-status-single-rail',
     );

--- a/src/test-kernel/agent/runtime/StreamStatusService.vitest.ts
+++ b/src/test-kernel/agent/runtime/StreamStatusService.vitest.ts
@@ -4,10 +4,7 @@ import { describe, expect, it } from 'vitest';
 // Local imports
 import { TraceEmitter, type StatusEvent } from '@agent/trace';
 import { SessionEventHub } from '@agent/runtime/SessionEventHub';
-import {
-  StreamStatusMachine,
-  type StreamStatusChange,
-} from '@agent/runtime/StreamStatusService';
+import { StreamStatusMachine } from '@agent/runtime/StreamStatusService';
 import {
   STREAM_PHASE,
   STREAM_STATUS,
@@ -26,21 +23,20 @@ import { seedStreamStatusForTest } from '@test/helpers/streamStatusTestUtils';
 import {
   recordSessionEvents,
   runEventsOfType,
-  sessionFactPayloads,
+  sessionFactsOfType,
 } from '../progressTestUtils';
 
 /** Fresh registry + recording host, keyed to a per-test stream id. */
 function setupMachine(streamId: string): {
   machine: StreamStatusMachine;
-  statusPayloads: () => unknown[];
+  statusEvents: () => StatusEvent[];
   streamId: StreamTabId;
 } {
   const events = new SessionEventHub();
   const published = recordSessionEvents(events, { scope: 'session' });
   return {
     machine: new StreamStatusMachine(events),
-    statusPayloads: () =>
-      sessionFactPayloads(published.events, 'updateStreamStatus'),
+    statusEvents: () => sessionFactsOfType(published.events, 'status'),
     streamId: streamId as StreamTabId,
   };
 }
@@ -62,21 +58,25 @@ describe('StreamStatusMachine', () => {
     expect(second.get(streamId)).toBeUndefined();
   });
 
-  it('keeps listeners per instance', () => {
-    const events = new SessionEventHub();
-    const first = new StreamStatusMachine(events);
-    const second = new StreamStatusMachine(events);
-    const published = recordSessionEvents(events, { scope: 'session' });
+  it('publishes only through its owning session hub', () => {
+    const firstEvents = new SessionEventHub();
+    const secondEvents = new SessionEventHub();
+    const first = new StreamStatusMachine(firstEvents);
+    const second = new StreamStatusMachine(secondEvents);
+    const firstPublished = recordSessionEvents(firstEvents, {
+      scope: 'session',
+    });
+    const secondPublished = recordSessionEvents(secondEvents, {
+      scope: 'session',
+    });
     const streamId = 'stream-status-listener-test' as StreamTabId;
-    const changes: string[] = [];
 
-    first.onDidChange((change) => changes.push(change.streamId));
     second.transition(streamId, STREAM_PHASE.WAITING, 'restart-repair');
 
-    expect(changes).toEqual([]);
-    expect(
-      sessionFactPayloads(published.events, 'updateStreamStatus'),
-    ).toHaveLength(1);
+    expect(sessionFactsOfType(firstPublished.events, 'status')).toEqual([]);
+    expect(sessionFactsOfType(secondPublished.events, 'status')).toHaveLength(
+      1,
+    );
   });
 
   it('exercises the live machine against the exhaustive transition table', () => {
@@ -124,7 +124,7 @@ describe('StreamStatusMachine', () => {
   });
 
   it('repairs terminal streams to waiting through resume then wait', () => {
-    const { machine, statusPayloads, streamId } = setupMachine(
+    const { machine, statusEvents, streamId } = setupMachine(
       'stream-status-terminal-waiting-repair',
     );
 
@@ -133,24 +133,26 @@ describe('StreamStatusMachine', () => {
     expect(machine.transitionToWaiting(streamId, 'restart-repair')).toBe(true);
 
     expect(machine.get(streamId)).toBe(STREAM_PHASE.WAITING);
-    expect(statusPayloads()).toEqual([
+    expect(statusEvents()).toEqual([
       {
         streamId,
-        status: STREAM_PHASE.RUNNING,
-        previousStatus: STREAM_PHASE.CANCELLED,
+        type: 'status',
+        phase: STREAM_PHASE.RUNNING,
+        previousPhase: STREAM_PHASE.CANCELLED,
         cause: 'resume',
       },
       {
         streamId,
-        status: STREAM_PHASE.WAITING,
-        previousStatus: STREAM_PHASE.RUNNING,
+        type: 'status',
+        phase: STREAM_PHASE.WAITING,
+        previousPhase: STREAM_PHASE.RUNNING,
         cause: 'restart-repair',
       },
     ]);
   });
 
   it('terminalizes waiting streams through resume then lifecycle', () => {
-    const { machine, statusPayloads, streamId } = setupMachine(
+    const { machine, statusEvents, streamId } = setupMachine(
       'stream-status-waiting-terminal-repair',
     );
 
@@ -165,24 +167,26 @@ describe('StreamStatusMachine', () => {
     ).toBe(true);
 
     expect(machine.get(streamId)).toBe(STREAM_PHASE.FAILED);
-    expect(statusPayloads()).toEqual([
+    expect(statusEvents()).toEqual([
       {
         streamId,
-        status: STREAM_PHASE.RUNNING,
-        previousStatus: STREAM_PHASE.WAITING,
+        type: 'status',
+        phase: STREAM_PHASE.RUNNING,
+        previousPhase: STREAM_PHASE.WAITING,
         cause: 'resume',
       },
       {
         streamId,
-        status: STREAM_PHASE.FAILED,
-        previousStatus: STREAM_PHASE.RUNNING,
+        type: 'status',
+        phase: STREAM_PHASE.FAILED,
+        previousPhase: STREAM_PHASE.RUNNING,
         cause: 'lifecycle',
       },
     ]);
   });
 
   it('terminalizes waiting streams with the restart-repair cause', () => {
-    const { machine, statusPayloads, streamId } = setupMachine(
+    const { machine, statusEvents, streamId } = setupMachine(
       'stream-status-waiting-terminal-restart-repair',
     );
 
@@ -197,24 +201,26 @@ describe('StreamStatusMachine', () => {
     ).toBe(true);
 
     expect(machine.get(streamId)).toBe(STREAM_PHASE.FAILED);
-    expect(statusPayloads()).toEqual([
+    expect(statusEvents()).toEqual([
       {
         streamId,
-        status: STREAM_PHASE.RUNNING,
-        previousStatus: STREAM_PHASE.WAITING,
+        type: 'status',
+        phase: STREAM_PHASE.RUNNING,
+        previousPhase: STREAM_PHASE.WAITING,
         cause: 'resume',
       },
       {
         streamId,
-        status: STREAM_PHASE.FAILED,
-        previousStatus: STREAM_PHASE.RUNNING,
+        type: 'status',
+        phase: STREAM_PHASE.FAILED,
+        previousPhase: STREAM_PHASE.RUNNING,
         cause: 'restart-repair',
       },
     ]);
   });
 
   it('terminalizes visible streams that were not started yet', () => {
-    const { machine, statusPayloads, streamId } = setupMachine(
+    const { machine, statusEvents, streamId } = setupMachine(
       'stream-status-undefined-terminal-repair',
     );
 
@@ -227,23 +233,25 @@ describe('StreamStatusMachine', () => {
     ).toBe(true);
 
     expect(machine.get(streamId)).toBe(STREAM_PHASE.FAILED);
-    expect(statusPayloads()).toEqual([
+    expect(statusEvents()).toEqual([
       {
         streamId,
-        status: STREAM_PHASE.RUNNING,
+        type: 'status',
+        phase: STREAM_PHASE.RUNNING,
         cause: 'lifecycle',
       },
       {
         streamId,
-        status: STREAM_PHASE.FAILED,
-        previousStatus: STREAM_PHASE.RUNNING,
+        type: 'status',
+        phase: STREAM_PHASE.FAILED,
+        previousPhase: STREAM_PHASE.RUNNING,
         cause: 'lifecycle',
       },
     ]);
   });
 
   it('accepts already-matching terminal outcomes without warning callers', () => {
-    const { machine, statusPayloads, streamId } = setupMachine(
+    const { machine, statusEvents, streamId } = setupMachine(
       'stream-status-matching-terminal',
     );
 
@@ -258,11 +266,11 @@ describe('StreamStatusMachine', () => {
     ).toBe(true);
 
     expect(machine.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
-    expect(statusPayloads()).toEqual([]);
+    expect(statusEvents()).toEqual([]);
   });
 
   it('clears a transient running substate through the table-checked resume transition', () => {
-    const { machine, statusPayloads, streamId } = setupMachine(
+    const { machine, statusEvents, streamId } = setupMachine(
       'stream-status-clear-running-substate',
     );
 
@@ -274,18 +282,19 @@ describe('StreamStatusMachine', () => {
 
     expect(machine.get(streamId)).toBe(STREAM_PHASE.RUNNING);
     expect(machine.getSubstate(streamId)).toBeUndefined();
-    expect(statusPayloads()).toEqual([
+    expect(statusEvents()).toEqual([
       {
         streamId,
-        status: STREAM_PHASE.RUNNING,
-        previousStatus: STREAM_PHASE.RUNNING,
+        type: 'status',
+        phase: STREAM_PHASE.RUNNING,
+        previousPhase: STREAM_PHASE.RUNNING,
         cause: 'resume',
       },
     ]);
   });
 
   it('skips the write and publish for a no-op RUNNING resume with no substate to clear', () => {
-    const { machine, statusPayloads, streamId } = setupMachine(
+    const { machine, statusEvents, streamId } = setupMachine(
       'stream-status-noop-running-resume',
     );
 
@@ -297,17 +306,16 @@ describe('StreamStatusMachine', () => {
 
     expect(machine.get(streamId)).toBe(STREAM_PHASE.RUNNING);
     expect(machine.getSubstate(streamId)).toBeUndefined();
-    expect(statusPayloads()).toEqual([]);
+    expect(statusEvents()).toEqual([]);
   });
 
-  it('rolls back reservation state identically with and without observers', () => {
+  it('rolls back reservation state identically with and without a hub', () => {
     const hidden = new StreamStatusMachine();
-    const observed = new StreamStatusMachine();
+    const events = new SessionEventHub();
+    const observed = new StreamStatusMachine(events);
+    const published = recordSessionEvents(events, { scope: 'session' });
     const streamId =
       'stream-status-observer-independent-rollback' as StreamTabId;
-    const changes: StreamStatusChange[] = [];
-
-    observed.onDidChange((change) => changes.push(change));
 
     expect(hidden.tryAcquire(streamId)).toBe(true);
     expect(observed.tryAcquire(streamId)).toBe(true);
@@ -317,14 +325,15 @@ describe('StreamStatusMachine', () => {
 
     expect(hidden.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
     expect(observed.get(streamId)).toBe(hidden.get(streamId));
-    expect(changes.map((change) => change.status)).toEqual([
-      STREAM_PHASE.RUNNING,
-      STREAM_PHASE.CANCELLED,
-    ]);
+    expect(
+      sessionFactsOfType(published.events, 'status').map(
+        (event) => event.phase,
+      ),
+    ).toEqual([STREAM_PHASE.RUNNING, STREAM_PHASE.CANCELLED]);
   });
 
   it('publishes rollback when a visible reservation is released', () => {
-    const { machine, statusPayloads, streamId } = setupMachine(
+    const { machine, statusEvents, streamId } = setupMachine(
       'stream-status-reservation-rollback',
     );
 
@@ -332,24 +341,26 @@ describe('StreamStatusMachine', () => {
     machine.releaseIfReserved(streamId);
 
     expect(machine.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
-    expect(statusPayloads()).toEqual([
+    expect(statusEvents()).toEqual([
       {
         streamId,
-        status: STREAM_PHASE.RUNNING,
+        type: 'status',
+        phase: STREAM_PHASE.RUNNING,
         cause: 'lifecycle',
         substate: STREAM_SUBSTATE.STARTING,
       },
       {
         streamId,
-        status: STREAM_PHASE.CANCELLED,
-        previousStatus: STREAM_PHASE.RUNNING,
+        type: 'status',
+        phase: STREAM_PHASE.CANCELLED,
+        previousPhase: STREAM_PHASE.RUNNING,
         cause: 'reservation-rollback',
       },
     ]);
   });
 
   it('overlays reservations on stale terminal phases and restores them on rollback', () => {
-    const { machine, statusPayloads, streamId } = setupMachine(
+    const { machine, statusEvents, streamId } = setupMachine(
       'stream-status-reservation-overlay',
     );
 
@@ -366,10 +377,11 @@ describe('StreamStatusMachine', () => {
     machine.releaseIfReserved(streamId);
 
     expect(machine.get(streamId)).toBe(STREAM_PHASE.COMPLETED);
-    expect(statusPayloads().at(-1)).toEqual({
+    expect(statusEvents().at(-1)).toEqual({
       streamId,
-      status: STREAM_PHASE.COMPLETED,
-      previousStatus: STREAM_PHASE.RUNNING,
+      type: 'status',
+      phase: STREAM_PHASE.COMPLETED,
+      previousPhase: STREAM_PHASE.RUNNING,
       cause: 'reservation-rollback',
     });
   });
@@ -377,18 +389,19 @@ describe('StreamStatusMachine', () => {
   it('emits status trace events when a trace owns publication', () => {
     const events = new SessionEventHub();
     const machine = new StreamStatusMachine(events);
-    const published = recordSessionEvents(events, { scope: 'run' });
+    const publishedRunEvents = recordSessionEvents(events, { scope: 'run' });
+    const publishedSessionEvents = recordSessionEvents(events, {
+      scope: 'session',
+    });
     const trace = new TraceEmitter();
     const streamId = 'stream-status-projection-test' as StreamTabId;
     const statusEvents: StatusEvent[] = [];
-    const changes: StreamStatusChange[] = [];
 
     trace.subscribe((event) => {
       if (event.type !== 'status') return;
       statusEvents.push(event);
       events.emit({ scope: 'run', streamId, event });
     });
-    machine.onDidChange((change) => changes.push(change));
 
     expect(
       machine.transition(streamId, STREAM_PHASE.RUNNING, 'lifecycle', {
@@ -402,16 +415,12 @@ describe('StreamStatusMachine', () => {
       phase: STREAM_PHASE.RUNNING,
       cause: 'lifecycle',
     });
-    expect(runEventsOfType(published.events, 'status')).toEqual([
+    expect(runEventsOfType(publishedRunEvents.events, 'status')).toEqual([
       statusEvents[0],
     ]);
-    expect(changes).toEqual([
-      {
-        streamId,
-        status: STREAM_PHASE.RUNNING,
-        cause: 'lifecycle',
-      },
-    ]);
+    expect(sessionFactsOfType(publishedSessionEvents.events, 'status')).toEqual(
+      statusEvents,
+    );
   });
 
   // One rail: the session fact is published by the machine itself, so a
@@ -421,7 +430,7 @@ describe('StreamStatusMachine', () => {
   // run-scope `status` trace events, which is why each projector carried its
   // own duplicate trace arm.
   it('publishes the session fact even when a trace owns publication', () => {
-    const { machine, statusPayloads, streamId } = setupMachine(
+    const { machine, statusEvents, streamId } = setupMachine(
       'stream-status-single-rail',
     );
     const trace = new TraceEmitter();
@@ -435,26 +444,27 @@ describe('StreamStatusMachine', () => {
       }),
     ).toBe(true);
 
-    const payloads = statusPayloads();
+    const payloads = statusEvents();
 
-    // Field-for-field identical to the hand-built projection the CLI NDJSON
-    // trace arm used to emit, so public `updateStreamStatus` records keep the
-    // same content on the surviving rail.
+    // The hub and transcript bridge share the canonical status vocabulary;
+    // the public CLI adapter alone performs the frozen wire rename.
     expect(payloads).toEqual([
       {
         streamId,
-        status: STREAM_PHASE.RUNNING,
-        previousStatus: STREAM_PHASE.WAITING,
+        type: 'status',
+        phase: STREAM_PHASE.RUNNING,
+        previousPhase: STREAM_PHASE.WAITING,
         cause: 'resume',
         substate: STREAM_SUBSTATE.RESUMING,
       },
     ]);
     expect(Object.keys(payloads[0] ?? {}).toSorted()).toEqual([
       'cause',
-      'previousStatus',
-      'status',
+      'phase',
+      'previousPhase',
       'streamId',
       'substate',
+      'type',
     ]);
   });
 });

--- a/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
+++ b/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
@@ -65,13 +65,31 @@ function workflowConfig(
   };
 }
 
-function sessionFact<K extends SessionFact['type']>(
+type PayloadSessionFact = Exclude<SessionFact, { type: 'status' }>;
+
+function sessionFact<K extends PayloadSessionFact['type']>(
   type: K,
-  payload: Extract<SessionFact, { type: K }>['payload'],
+  payload: Extract<PayloadSessionFact, { type: K }>['payload'],
 ): SessionEvent {
   return {
     scope: 'session',
     event: { type, payload } as Extract<SessionFact, { type: K }>,
+  };
+}
+
+function statusFact(payload: RunStatusProjectionPayload): SessionEvent {
+  return {
+    scope: 'session',
+    event: {
+      type: 'status',
+      streamId: payload.streamId,
+      phase: payload.status,
+      cause: payload.cause,
+      ...(payload.previousStatus
+        ? { previousPhase: payload.previousStatus }
+        : {}),
+      ...(payload.substate ? { substate: payload.substate } : {}),
+    },
   };
 }
 
@@ -111,11 +129,16 @@ const PROGRESS_PROJECTION_CASES = {
     payload: { streamId },
   },
   updateStreamStatus: {
-    source: sessionFact('updateStreamStatus', {
+    source: statusFact({
       streamId,
       status: STREAM_PHASE.RUNNING,
+      cause: STREAM_TRANSITION_CAUSE.LIFECYCLE,
     }),
-    payload: { streamId, status: STREAM_PHASE.RUNNING },
+    payload: {
+      streamId,
+      status: STREAM_PHASE.RUNNING,
+      cause: STREAM_TRANSITION_CAUSE.LIFECYCLE,
+    },
   },
   addOutputFiles: {
     source: runEvent({
@@ -349,15 +372,9 @@ const resumingStatusPayload: RunStatusProjectionPayload = {
 
 function emitSessionStatus(
   events: SessionEventHub,
-  payload: UpdateStreamStatusPayload,
+  payload: RunStatusProjectionPayload,
 ): void {
-  events.emit({
-    scope: 'session',
-    event: {
-      type: 'updateStreamStatus',
-      payload,
-    },
-  });
+  events.emit(statusFact(payload));
 }
 
 describe('attachCliSessionProgressProjection', () => {
@@ -434,7 +451,7 @@ describe('attachCliSessionProgressProjection', () => {
   it('ignores run-scope status trace events', () => {
     withProjection(({ events, writeRecord }) => {
       // `status` is no longer a projected run fact: `StreamStatusMachine` owns
-      // the single `updateStreamStatus` rail, so a stray run-scope status event
+      // the canonical session-fact rail, so a stray run-scope status event
       // must never reach the public NDJSON stream.
       events.emit({
         scope: 'run',

--- a/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
+++ b/src/test-kernel/cli/CliSessionProgressSubscription.vitest.mts
@@ -33,6 +33,7 @@ import {
   STREAM_TRANSITION_CAUSE,
   type StreamTransitionCause,
 } from '@shared/streams/streamStatus';
+import type { PayloadSessionFact } from '@test/agent/progressTestUtils';
 
 const streamId = 'stream:cli-session-projection' as StreamTabId;
 const executionId = 'execution:cli-session-projection' as ExecutionId;
@@ -64,8 +65,6 @@ function workflowConfig(
     ...overrides,
   };
 }
-
-type PayloadSessionFact = Exclude<SessionFact, { type: 'status' }>;
 
 function sessionFact<K extends PayloadSessionFact['type']>(
   type: K,

--- a/src/test-kernel/cli/RunProgressRenderer.vitest.mts
+++ b/src/test-kernel/cli/RunProgressRenderer.vitest.mts
@@ -224,19 +224,16 @@ function handleStreamStatus(
   streamId: string,
   status: StreamPhase,
 ): void {
-  // Status reaches the renderer on the session-fact rail only: `StreamStatusMachine`
-  // publishes every transition as `updateStreamStatus`, and the renderer no longer
-  // reads run-scope `status` trace events.
+  // Status reaches the renderer on the session-fact rail only; the renderer
+  // no longer reads run-scope `status` trace events.
   renderer?.handleSessionEvent({
     scope: 'session',
     event: {
-      type: 'updateStreamStatus',
-      payload: {
-        streamId: streamId as StreamTabId,
-        status,
-        previousStatus: STREAM_PHASE.RUNNING,
-        cause: STREAM_TRANSITION_CAUSE.LIFECYCLE,
-      },
+      type: 'status',
+      streamId: streamId as StreamTabId,
+      phase: status,
+      previousPhase: STREAM_PHASE.RUNNING,
+      cause: STREAM_TRANSITION_CAUSE.LIFECYCLE,
     },
   });
 }
@@ -764,11 +761,11 @@ describe('CLI run progress renderer', () => {
       events.emit({
         scope: 'session',
         event: {
-          type: 'updateStreamStatus',
-          payload: {
-            streamId: 'stream-1' as StreamTabId,
-            status: STREAM_PHASE.COMPLETED,
-          },
+          type: 'status',
+          streamId: 'stream-1' as StreamTabId,
+          phase: STREAM_PHASE.COMPLETED,
+          previousPhase: STREAM_PHASE.RUNNING,
+          cause: STREAM_TRANSITION_CAUSE.LIFECYCLE,
         },
       });
 

--- a/src/test-kernel/cli/WorkflowPlainProjection.vitest.mts
+++ b/src/test-kernel/cli/WorkflowPlainProjection.vitest.mts
@@ -71,8 +71,10 @@ function completeWorkflow(
   events.emit({
     scope: 'session',
     event: {
-      type: 'updateStreamStatus',
-      payload: { streamId, status },
+      type: 'status',
+      streamId,
+      phase: status,
+      cause: 'lifecycle',
     },
   });
 }

--- a/src/test-kernel/cli/chatSessionController.vitest.mts
+++ b/src/test-kernel/cli/chatSessionController.vitest.mts
@@ -339,7 +339,7 @@ function installOwnerSession(): {
   readonly interactions: SessionHostInteractions;
 } {
   const events = new SessionEventHub();
-  const status = new StreamStatusMachine();
+  const status = new StreamStatusMachine(events);
   const executions = new ExecutionRegistry({ events, streamStatus: status });
   const interactions = new SessionHostInteractions();
   installSession({

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -629,10 +629,12 @@ async function settleProgressEvents(): Promise<void> {
   await new Promise((resolve) => setImmediate(resolve));
 }
 
-function emitSessionFact<K extends SessionFact['type']>(
+type PayloadSessionFact = Exclude<SessionFact, { type: 'status' }>;
+
+function emitSessionFact<K extends PayloadSessionFact['type']>(
   bridge: TestableBridge,
   type: K,
-  payload: Extract<SessionFact, { type: K }>['payload'],
+  payload: Extract<PayloadSessionFact, { type: K }>['payload'],
 ): void {
   bridgeSession(bridge).events.emit({
     scope: 'session',
@@ -676,16 +678,19 @@ function emitStatusFact(
     previousStatus?: StreamPhase;
   },
 ): void {
-  // Status reaches the bridge on the session-fact rail only: `StreamStatusMachine`
-  // publishes every transition as `updateStreamStatus`, and no projector reads
-  // run-scope `status` trace events any more.
-  emitSessionFact(bridge, 'updateStreamStatus', {
-    streamId: payload.streamId,
-    status: payload.status,
-    ...(payload.previousStatus
-      ? { previousStatus: payload.previousStatus }
-      : {}),
-    cause: STREAM_TRANSITION_CAUSE.LIFECYCLE,
+  // Status reaches the bridge on the canonical session-fact rail only; no
+  // projector reads run-scope `status` trace events any more.
+  bridgeSession(bridge).events.emit({
+    scope: 'session',
+    event: {
+      type: 'status',
+      streamId: payload.streamId,
+      phase: payload.status,
+      ...(payload.previousStatus
+        ? { previousPhase: payload.previousStatus }
+        : {}),
+      cause: STREAM_TRANSITION_CAUSE.LIFECYCLE,
+    },
   });
 }
 
@@ -3719,7 +3724,7 @@ describe('DesktopProgressBridge', () => {
       }
     });
 
-    it('publishes canonical status changes as updateStreamStatus session facts (#8256)', async () => {
+    it('publishes canonical status session facts (#8256)', async () => {
       const streamId = 'rebound-stream-7' as StreamTabId;
       const executionId = 'ec00f7' as ExecutionId;
       const owner = await createProcessOwner({ streamId, executionId });
@@ -3741,11 +3746,9 @@ describe('DesktopProgressBridge', () => {
         expect(bridgeB.session.status.get(streamId)).toBe(STREAM_PHASE.WAITING);
         expect(facts).toContainEqual(
           expect.objectContaining({
-            type: 'updateStreamStatus',
-            payload: expect.objectContaining({
-              streamId,
-              status: STREAM_PHASE.WAITING,
-            }),
+            type: 'status',
+            streamId,
+            phase: STREAM_PHASE.WAITING,
           }),
         );
       } finally {
@@ -3801,11 +3804,9 @@ describe('DesktopProgressBridge', () => {
         );
         expect(facts).toContainEqual(
           expect.objectContaining({
-            type: 'updateStreamStatus',
-            payload: expect.objectContaining({
-              streamId: childStreamId,
-              status: STREAM_PHASE.COMPLETED,
-            }),
+            type: 'status',
+            streamId: childStreamId,
+            phase: STREAM_PHASE.COMPLETED,
           }),
         );
       } finally {

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -53,6 +53,7 @@ import { createDeferred } from '@test/support/asyncTestUtils';
 import { createModuleMocks } from '@test/support/moduleMocks';
 import { createToolUseResumeData } from '@test/support/toolUseResumeTestUtils';
 import { seedStreamStatusForTest } from '@test/helpers/streamStatusTestUtils';
+import type { PayloadSessionFact } from '@test/agent/progressTestUtils';
 import {
   isApprovalBypassedForStream,
   isBashApprovalBypassedForStream,
@@ -628,8 +629,6 @@ async function settleProgressEvents(): Promise<void> {
   await Promise.resolve();
   await new Promise((resolve) => setImmediate(resolve));
 }
-
-type PayloadSessionFact = Exclude<SessionFact, { type: 'status' }>;
 
 function emitSessionFact<K extends PayloadSessionFact['type']>(
   bridge: TestableBridge,

--- a/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
+++ b/src/test-kernel/progressView/ProgressBackendFactProjection.vitest.ts
@@ -1050,8 +1050,8 @@ describe('ProgressBackend', () => {
     // `withEventErrorHandling` `undefined`, leaving this untouched — and a
     // post-await rejection would then escape logging as an unhandled rejection.
     // `setStreamStatus` now has exactly one caller — the session-fact
-    // `updateStreamStatus` path — since `StreamStatusMachine` publishes every
-    // transition on that rail and the run-fact `status` arm is gone.
+    // canonical `status` path — since `StreamStatusMachine` publishes every
+    // transition on that rail and the run-fact arm is gone.
     let adopted = 0;
     const tracking: PromiseLike<void> = {
       then(onFulfilled, onRejected) {
@@ -1064,8 +1064,10 @@ describe('ProgressBackend', () => {
     );
 
     backend.factApplier.handleSessionFact({
-      type: 'updateStreamStatus',
-      payload: { streamId: stream, status: STREAM_PHASE.RUNNING },
+      type: 'status',
+      streamId: stream,
+      phase: STREAM_PHASE.RUNNING,
+      cause: 'lifecycle',
     });
 
     // Thenable adoption runs on a microtask; flush before asserting.

--- a/src/transcript/TexraTranscriptRecorder.ts
+++ b/src/transcript/TexraTranscriptRecorder.ts
@@ -456,7 +456,7 @@ export function attachTranscriptRecorder(
             return;
           }
           // Status is emitted through AgentTrace before StreamStatusMachine
-          // notifies host listeners. Settle recorder-owned source rows here,
+          // publishes to synchronous session subscribers. Settle recorder-owned source rows here,
           // so every row the CLI may promote at the boundary already has one
           // durable settlement coordinate. Workflow calls are deliberately
           // absent: their typed bridge cleanup owns planned/running terminal


### PR DESCRIPTION
## Summary

Stream status transitions now use the canonical `StatusEvent` vocabulary and the session event hub as their single internal delivery rail. The trace event is retained only as a compatibility bridge for transcript recording, while the public CLI event projection remains unchanged.

## Issue acceptance gates

Closes #9427.

- Makes the session fact the owner because status transitions may not have a run trace.
- Publishes the same canonical `StatusEvent` unconditionally to the session hub and, when present, through the transcript trace bridge first to preserve settlement ordering.
- Removes `projectStatusEvent`, `StreamStatusChange`, and the `statusListeners`/`onDidChange` rail.
- Migrates all extension, desktop, CLI, and execution-registry consumers to synchronous session-hub subscriptions.
- Removes the unfinished Stage 5 legacy projection in `ProgressFactApplier`.
- Preserves the published CLI NDJSON `updateStreamStatus` shape at its external boundary.

## Single source of truth

`StreamStatusMachine` owns transition validity and emits one canonical `StatusEvent`. `SessionEventHub` owns synchronous in-session distribution of that fact. A transition is forwarded to a supplied run trace only for transcript compatibility, immediately before hub publication so the recorder settles source rows before host projections read them.

## Duplication and abstraction budget

The change removes the duplicate phase-to-status projection, its twin type, and the separate listener collection. `SessionEventHub.subscribeStatus` gives status consumers a typed view of the existing synchronous hub rather than introducing another channel. `StreamStatusMachine.attachSessionEvents` records the owning session boundary when an execution registry is injected or rebound.

## Net elements (R6)

- Files: 27 modified; none added or deleted.
- LoC: +363 / -309, net +54, including cross-host fixture and assertion migrations.
- Exported symbols: removes `StreamStatusChange`; no new exported type, class, interface, enum, or free function.
- Runtime elements removed: `projectStatusEvent`, `statusListeners`, and `StreamStatusMachine.onDidChange`.
- Runtime elements added: the typed `SessionEventHub.subscribeStatus` view and explicit event-hub binding accessors on `StreamStatusMachine`.

## Consumer counts (R8)

The old `onDidChange` rail had five non-test call sites at the merge base: execution-registry bookkeeping, the desktop title, the extension status bar, CLI status state, and the CLI completion notification. All five now subscribe through `SessionEventHub.subscribeStatus`. Session-fact projectors consume canonical `status` events directly. The sole old-name projection is the documented public CLI compatibility boundary.

## Host impact

Extension: status-bar behavior is unchanged and follows canonical session status facts.

Desktop: window-title activity updates are unchanged and follow canonical session status facts.

CLI: interactive state, completion notification, plain progress, and workflow progress use canonical session status facts; public NDJSON output retains its existing event and field names.

## Scheduled refactoring

None.

## Validation

- `npm run format`
- `npm run compile:fast`
- `npm run lint`
- `npm run typecheck` (all seven targets)
- `npm run check:dead-code-ratchet`
- `npm test` (814 files passed, 1 skipped; 8,235 tests passed, 4 skipped)
- `git diff --check`
- Final focused verification after terminology cleanup: `npm run typecheck:workspace` and 57 runtime status/registry tests
