### PR TITLE
docs: correct channel trace invocation census

### DIFF
--- a/docs/proposals/2026-08-01-agent-sdk-readiness-checkpoint.md
+++ b/docs/proposals/2026-08-01-agent-sdk-readiness-checkpoint.md
@@ -175,7 +175,7 @@ here.
 - **[TRACKED] `createChannelTrace` fabricates an inert `AgentTrace` as a module
   logger.** A defined census finds **24** non-test module-scope
   `const … = createChannelTrace(...)` declarations. A broader file-level search
-  finds **36** non-test files invoking the factory; tests contain three local trace
+  finds **35** non-test files invoking the factory; tests contain three local trace
   constructions rather than one module singleton. The narrower 24-declaration
   population is the relevant module-logger cleanup scope.
   Standing `-07-08`/`-07-18`/`-07-30` + `logger-surface-cleanup` PRD item; `-07-30`'s
@@ -399,7 +399,7 @@ and expose the helper-model one-shots without touching the tested invariants abo
 - The headline claims were independently re-verified this pass by direct grep/read at
   HEAD: the 43-member `Pick`, 0 vscode/packages imports, 0 cycle-schema parses,
   `MapToolRegistry` shape, the ceiling leaks, §New-8/§New-9 presence, the
-  defined `createChannelTrace` census (24 non-test module-scope declarations; 36
+  defined `createChannelTrace` census (24 non-test module-scope declarations; 35
   non-test invoking files), the §New-14 `default: return` fall-through (read directly),
   the §New-17 mutable-field claim and cohesive-helper assessment, the §New-12
   build-ready-but-unpublished/R-b-and-R-a-landed status, and the shared snapshot


### PR DESCRIPTION
## Summary

Correct the post-merge `createChannelTrace` census in the 2026-08-01 SDK-readiness checkpoint:

- 36 non-test files contain the search token
- one is the factory definition itself
- therefore 35 non-test files actually invoke the factory

The independently verified count of 24 module-scope declarations remains unchanged. Documentation only; no changelog entry is needed.

## Verification

- reproduced the census against the pinned `6ab67ce` source snapshot
- Prettier check passed
- `git diff --check` passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal proposal doc wording only; no code, config, or published user-facing docs affected.
> 
> **Overview**
> Corrects the **`createChannelTrace` census** in `docs/proposals/2026-08-01-agent-sdk-readiness-checkpoint.md` in two places: the **[TRACKED]** module-logger bullet and the **Coverage gaps** headline-claims list.
> 
> The **24** non-test module-scope `const … = createChannelTrace(...)` count is unchanged. The broader metric drops from **36** to **35** non-test files that invoke the factory, reflecting that one file match is the factory definition rather than a caller.
> 
> Documentation-only; no runtime or tooling behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46caa775dcf072ab8199098027b1b776a966dc37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->