### PR TITLE
fix(tooling): auto-format staged files with pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
         run: pnpm --filter @texra-ai/cli smoke:react-compiler
 
       # Formatting remains a CI gate instead of an auto-committing workflow:
-      # the pre-commit prettier hook checks staged files, and a bot `style:
+      # the pre-commit prettier hook formats staged files locally, and a bot `style:
       # format` push would cancel and re-trigger every PR workflow (including
       # both AI reviews).
       - name: Check formatting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,9 +104,8 @@ jobs:
         run: pnpm --filter @texra-ai/cli smoke:react-compiler
 
       # Formatting remains a CI gate instead of an auto-committing workflow:
-      # the pre-commit prettier hook formats staged files locally, and a bot `style:
-      # format` push would cancel and re-trigger every PR workflow (including
-      # both AI reviews).
+      # the pre-commit hook formats staged files locally, avoiding a bot push and
+      # its token, retrigger, cancellation, and branch-race complexity.
       - name: Check formatting
         run: pnpm run format:check
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,10 +3,10 @@ repos:
     hooks:
       - id: npm-format
         name: prettier --write staged files
-        # Pre-commit supplies only staged paths and temporarily hides unstaged
-        # changes. Re-stage the formatter's output so this commit includes
-        # the corrected staged snapshot.
-        entry: bash -c 'corepack pnpm exec prettier --write --ignore-unknown --no-error-on-unmatched-pattern "$@" && git add -- "$@"' --
+        # During commits, pre-commit supplies staged paths and temporarily hides
+        # unstaged changes. It detects rewrites, aborts, and lets the contributor
+        # review and stage the formatter's output before retrying.
+        entry: corepack pnpm exec prettier --write --ignore-unknown --no-error-on-unmatched-pattern
         language: system
       # Forbid a stray internal doc at the docs root from being published to
       # texra.ai. The boundary lives in docs/.vitepress/publicDocs.js; this

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,8 +2,11 @@ repos:
   - repo: local
     hooks:
       - id: npm-format
-        name: prettier staged files
-        entry: corepack pnpm exec prettier --check --ignore-unknown --no-error-on-unmatched-pattern
+        name: prettier --write staged files
+        # Pre-commit supplies only staged paths and temporarily hides unstaged
+        # changes. Re-stage the formatter's output so the next commit attempt
+        # uses the corrected staged snapshot.
+        entry: bash -c 'corepack pnpm exec prettier --write --ignore-unknown --no-error-on-unmatched-pattern "$@" && git add -- "$@"' --
         language: system
       # Forbid a stray internal doc at the docs root from being published to
       # texra.ai. The boundary lives in docs/.vitepress/publicDocs.js; this

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,8 @@ repos:
       - id: npm-format
         name: prettier --write staged files
         # Pre-commit supplies only staged paths and temporarily hides unstaged
-        # changes. Re-stage the formatter's output so the next commit attempt
-        # uses the corrected staged snapshot.
+        # changes. Re-stage the formatter's output so this commit includes
+        # the corrected staged snapshot.
         entry: bash -c 'corepack pnpm exec prettier --write --ignore-unknown --no-error-on-unmatched-pattern "$@" && git add -- "$@"' --
         language: system
       # Forbid a stray internal doc at the docs root from being published to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ When updating CHANGELOG.md:
 2. **Install the local hooks (recommended)**: install `pre-commit` with
    `python -m pip install pre-commit`, then run `pre-commit install`. The
    formatting hook rewrites and re-stages supported staged files; if it changes
-   a file, inspect the staged diff and retry the commit.
+   a file, inspect the staged diff before pushing.
 3. **Run checks before committing**:
    - Format code using `npm run format`.
    - Build the extension bundle with `npm run compile:fast`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,12 +21,16 @@ When updating CHANGELOG.md:
 ## Development workflow
 
 1. **Install dependencies**: run `corepack pnpm install` if needed.
-2. **Run checks before committing**:
+2. **Install the local hooks (recommended)**: install `pre-commit` with
+   `python -m pip install pre-commit`, then run `pre-commit install`. The
+   formatting hook rewrites and re-stages supported staged files; if it changes
+   a file, inspect the staged diff and retry the commit.
+3. **Run checks before committing**:
    - Format code using `npm run format`.
    - Build the extension bundle with `npm run compile:fast`.
    - Lint TypeScript sources with `npm run lint`.
    - Run the Vitest suite with `npm test`.
-3. Commit only when `npm run lint` completes without errors.
+4. Commit only when `npm run lint` completes without errors.
 
 ### Build system: esbuild + Vite
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,10 @@ When updating CHANGELOG.md:
    `python -m pip install pre-commit`, then run `pre-commit install`. The
    formatting hook rewrites supported staged files; if it changes a file,
    review the diff and stage only the intended hunks before retrying. For a
-   partially staged file, use `git add -p` so unrelated unstaged edits stay out.
+   partially staged file, use `git add -p` so unrelated unstaged edits stay
+   out. If the retry aborts again with nothing new to stage, the rewrite
+   conflicted with your unstaged edits and pre-commit discarded it -- commit
+   or stash those edits separately first, then retry.
 3. **Run checks before committing**:
    - Format code using `npm run format`.
    - Build the extension bundle with `npm run compile:fast`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,8 +23,8 @@ When updating CHANGELOG.md:
 1. **Install dependencies**: run `corepack pnpm install` if needed.
 2. **Install the local hooks (recommended)**: install `pre-commit` with
    `python -m pip install pre-commit`, then run `pre-commit install`. The
-   formatting hook rewrites and re-stages supported staged files; if it changes
-   a file, inspect the staged diff before pushing.
+   formatting hook rewrites supported staged files; if it changes a file,
+   review and stage the formatter's output before retrying the commit.
 3. **Run checks before committing**:
    - Format code using `npm run format`.
    - Build the extension bundle with `npm run compile:fast`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,8 @@ When updating CHANGELOG.md:
 2. **Install the local hooks (recommended)**: install `pre-commit` with
    `python -m pip install pre-commit`, then run `pre-commit install`. The
    formatting hook rewrites supported staged files; if it changes a file,
-   review and stage the formatter's output before retrying the commit.
+   review the diff and stage only the intended hunks before retrying. For a
+   partially staged file, use `git add -p` so unrelated unstaged edits stay out.
 3. **Run checks before committing**:
    - Format code using `npm run format`.
    - Build the extension bundle with `npm run compile:fast`.


### PR DESCRIPTION
## Summary

- Make the existing local pre-commit formatting hook rewrite supported staged files with Prettier instead of merely reporting differences.
- Leave rewritten files for the contributor to review and stage before retrying the commit; manual all-files runs never mutate the index.
- Document the explicit `pre-commit` installation step; the Node dependency installation no longer pretends to install an unavailable Python tool.

The earlier dependency refresh has been separated from this PR. The proposed CI job that wrote commits to PR branches has also been removed: its default-token push did not create a new pull-request validation run, and executing PR-controlled package commands with repository write permission was an unnecessarily broad trust boundary.

## Single source of truth

The existing `.pre-commit-config.yaml` remains the sole definition of local hook behavior. `AGENTS.md` only documents how to install and use it.

## Duplication and abstraction budget

No wrapper script or CI-side formatting path is added. The change deepens the existing hook directly and retains the current hard `format:check` CI gate.

## Net elements (R6)

- Files: 3 modified; none added or deleted.
- Exported symbols: none.
- LoC: +17/-7, net +10.

## Host impact

Extension: None.

Desktop: None.

CLI: None.

## Scheduled refactoring

None.

## Validation

- Isolated `pre-commit` 4.6.1 installation
- `pre-commit validate-config`
- `pre-commit run npm-format --files AGENTS.md .pre-commit-config.yaml` (retry passes without a loop)
- `npm run format`
- `npm run compile:fast`
- `npm run lint`
- `npm run typecheck`
- `npm run check:dead-code-ratchet` (17 current findings, equal to the 17-finding baseline)
- Complete suite attempted: 8,197 tests passed; four unrelated UI/desktop timing failures
- Focused rerun of all affected failure files: 3 files and 106 tests passed
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer workflow and documentation only; no runtime, auth, or product code paths change, and CI formatting enforcement is unchanged.
> 
> **Overview**
> **Local commits** now auto-format supported **staged** files via the existing `npm-format` pre-commit hook, which switches from Prettier `--check` to `--write`. When formatting changes a file, pre-commit aborts so you can review, stage the formatter output (e.g. `git add -p` for partial stages), and retry.
> 
> **CI** keeps **`pnpm run format:check`** as the gate; only the comment in `.github/workflows/ci.yml` is updated to say formatting is handled locally through the hook instead of a bot push (avoiding token/retrigger/race issues).
> 
> **`AGENTS.md`** adds an explicit **pre-commit** install step (`pip install pre-commit`, `pre-commit install`) and explains the rewrite-and-retry flow, including conflicts with unstaged edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35292c66daa15377a68646bf6eba77ea1ecc1284. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->