### PR TITLE
refactor: replace hand-rolled terminal truncation with cli-truncate

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -69,6 +69,7 @@
     "citty": "^0.2.2",
     "cli-highlight": "^2.1.11",
     "cli-table3": "^0.6.5",
+    "cli-truncate": "^6.1.1",
     "diff": "^9.0.0",
     "esbuild": "^0.28.1",
     "ink": "^7.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -80,6 +80,7 @@
     "picocolors": "^1.1.1",
     "react": "^19.2.8",
     "semver": "^7.8.5",
+    "slice-ansi": "^9.0.0",
     "string-width": "^8.2.2",
     "strip-ansi": "^7.2.0",
     "typescript": "^6.0.3",

--- a/packages/cli/src/chat/tui/render/terminalText.ts
+++ b/packages/cli/src/chat/tui/render/terminalText.ts
@@ -1,3 +1,4 @@
+import cliTruncate from 'cli-truncate';
 import stringWidth from 'string-width';
 import stripAnsi from 'strip-ansi';
 
@@ -20,22 +21,14 @@ export function textDisplayWidth(text: string): number {
   return stringWidth(text);
 }
 
+/** Hard-clip to `width` display columns with no ellipsis. */
 export function clipToWidth(text: string, width: number): string {
-  let clipped = '';
-  for (const char of text) {
-    if (textDisplayWidth(clipped + char) > width) break;
-    clipped += char;
-  }
-  return clipped;
+  return cliTruncate(text, Math.max(0, width), { truncationCharacter: '' });
 }
-
-const ELLIPSIS = '…';
 
 /** Truncate to `maxColumns` display columns, ending with `…` when cut. */
 export function truncateToWidth(text: string, maxColumns: number): string {
-  if (textDisplayWidth(text) <= maxColumns) return text;
-  const contentColumns = Math.max(0, maxColumns - textDisplayWidth(ELLIPSIS));
-  return `${clipToWidth(text, contentColumns)}${ELLIPSIS}`;
+  return cliTruncate(text, Math.max(0, maxColumns));
 }
 
 /** Collapse whitespace, then truncate — the one-line-summary form used by

--- a/packages/cli/src/chat/tui/render/terminalText.ts
+++ b/packages/cli/src/chat/tui/render/terminalText.ts
@@ -1,4 +1,5 @@
 import cliTruncate from 'cli-truncate';
+import sliceAnsi from 'slice-ansi';
 import stringWidth from 'string-width';
 import stripAnsi from 'strip-ansi';
 
@@ -21,14 +22,21 @@ export function textDisplayWidth(text: string): number {
   return stringWidth(text);
 }
 
+function normalizeColumns(width: number): number {
+  if (!Number.isFinite(width)) {
+    throw new TypeError('Terminal width must be finite.');
+  }
+  return Math.max(0, Math.floor(width));
+}
+
 /** Hard-clip to `width` display columns with no ellipsis. */
 export function clipToWidth(text: string, width: number): string {
-  return cliTruncate(text, Math.max(0, width), { truncationCharacter: '' });
+  return sliceAnsi(text, 0, normalizeColumns(width));
 }
 
 /** Truncate to `maxColumns` display columns, ending with `…` when cut. */
 export function truncateToWidth(text: string, maxColumns: number): string {
-  return cliTruncate(text, Math.max(0, maxColumns));
+  return cliTruncate(text, normalizeColumns(maxColumns));
 }
 
 /** Collapse whitespace, then truncate — the one-line-summary form used by

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -684,6 +684,9 @@ importers:
       cli-table3:
         specifier: ^0.6.5
         version: 0.6.5
+      cli-truncate:
+        specifier: ^6.1.1
+        version: 6.1.1
       diff:
         specifier: ^9.0.0
         version: 9.0.0
@@ -3513,6 +3516,10 @@ packages:
 
   cli-truncate@6.0.0:
     resolution: {integrity: sha512-3+YKIUFsohD9MIoOFPFBldjAlnfCmCDcqe6aYGFqlDTRKg80p4wg35L+j83QQ63iOlKRccEkbn8IuM++HsgEjA==}
+    engines: {node: '>=22'}
+
+  cli-truncate@6.1.1:
+    resolution: {integrity: sha512-06p9vyLahLa4zkGcgsGxU6iEkSOiuI4fhCH6Emhe2lPAcoUv73n72DnODsnHA+5wwXGnV0n9M9/qOQJSjYhFhw==}
     engines: {node: '>=22'}
 
   clipboard-image@0.1.0:
@@ -9250,6 +9257,11 @@ snapshots:
       '@colors/colors': 1.5.0
 
   cli-truncate@6.0.0:
+    dependencies:
+      slice-ansi: 9.0.0
+      string-width: 8.2.2
+
+  cli-truncate@6.1.1:
     dependencies:
       slice-ansi: 9.0.0
       string-width: 8.2.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -717,6 +717,9 @@ importers:
       semver:
         specifier: ^7.8.5
         version: 7.8.5
+      slice-ansi:
+        specifier: ^9.0.0
+        version: 9.0.0
       string-width:
         specifier: ^8.2.2
         version: 8.2.2

--- a/src/agent/output/compileCheck.ts
+++ b/src/agent/output/compileCheck.ts
@@ -26,6 +26,7 @@ import { toErrorMessage } from '@utils/errors/errorMessage';
 import { hasExtension } from '@utils/core/pathCore';
 import { readPlatformSetting } from '@utils/config/platformSettings';
 import { getRunDir } from '@utils/files/runStorageFs';
+import { sanitizePathSegment } from '@utils/text/sanitizePathSegment';
 
 import {
   publishCompiledPdfArtifact,
@@ -258,7 +259,10 @@ async function compileOne(
   // "a_b.tex") both collapse to the same string, so a second file's log
   // write/delete would clobber the first's. Suffix with a short hash of the
   // untruncated path so every output gets its own collision-free log slot.
-  const legacySafeName = pathForSafeName.replaceAll(/[^a-zA-Z0-9._-]/g, '_');
+  const legacySafeName = sanitizePathSegment(pathForSafeName, {
+    invalidCharPattern: /[^a-zA-Z0-9._-]/g,
+    replacement: '_',
+  });
   const pathHash = createHash('sha1')
     .update(pathForSafeName)
     .digest('hex')

--- a/src/agent/utils/debugMessageSaver.ts
+++ b/src/agent/utils/debugMessageSaver.ts
@@ -6,6 +6,7 @@ import type { ExecutionId } from '@shared/schemas';
 import { WorkspaceFS, StorageFS } from '@utils/files';
 import { getConfig } from '@utils/config/configUtils';
 import { ensureRunDir } from '@utils/files/taskRunStorage';
+import { sanitizePathSegment } from '@utils/text/sanitizePathSegment';
 
 interface DebugContext {
   logger: AgentTrace;
@@ -67,7 +68,9 @@ export async function maybeSaveDebugObject({
     ? path.basename(outputFile, path.extname(outputFile))
     : baseName;
   const cont = continuationCount ? `_cont${continuationCount}` : '';
-  const modelPart = modelName ? `_${modelName.replaceAll(/[\\/]/g, '_')}` : '';
+  const modelPart = modelName
+    ? `_${sanitizePathSegment(modelName, { invalidCharPattern: /[\\/]/g, replacement: '_' })}`
+    : '';
   const debugFileName = `${fileBase}${modelPart}${cont}.json`;
 
   try {

--- a/src/test-kernel/cli/TerminalText.vitest.ts
+++ b/src/test-kernel/cli/TerminalText.vitest.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  clipToWidth,
+  truncateToWidth,
+} from '@cli/chat/tui/render/terminalText';
+
+describe('terminal text width limits', () => {
+  describe('clipToWidth', () => {
+    it('hard-clips plain text at widths 0, 1, and 2', () => {
+      expect([
+        clipToWidth('ab', 0),
+        clipToWidth('ab', 1),
+        clipToWidth('ab', 2),
+      ]).toEqual(['', 'a', 'ab']);
+    });
+
+    it('does not split wide or multi-code-point graphemes', () => {
+      expect(clipToWidth('界a', 1)).toBe('');
+      expect(clipToWidth('界a', 2)).toBe('界');
+      expect(clipToWidth('e\u0301x', 1)).toBe('e\u0301');
+      expect(clipToWidth('👨‍👩‍👧‍👦x', 1)).toBe('');
+      expect(clipToWidth('👨‍👩‍👧‍👦x', 2)).toBe('👨‍👩‍👧‍👦');
+    });
+
+    it('closes ANSI styles when clipping styled text', () => {
+      expect(clipToWidth('\u001B[31mab\u001B[39m', 1)).toBe(
+        '\u001B[31ma\u001B[39m',
+      );
+    });
+
+    it('returns fitting text unchanged', () => {
+      const text = '\u001B[31mab\u001B[39m';
+      expect(clipToWidth(text, 2)).toBe(text);
+    });
+
+    it('normalizes finite widths to non-negative integers', () => {
+      expect(clipToWidth('ab', -1)).toBe('');
+      expect(clipToWidth('ab', 1.9)).toBe('a');
+    });
+
+    it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+      'rejects the non-finite width %s',
+      (width) => {
+        expect(() => clipToWidth('ab', width)).toThrow(
+          'Terminal width must be finite.',
+        );
+      },
+    );
+  });
+
+  describe('truncateToWidth', () => {
+    it('uses the default Unicode ellipsis when truncating', () => {
+      expect(truncateToWidth('abc', 0)).toBe('');
+      expect(truncateToWidth('abc', 1)).toBe('…');
+      expect(truncateToWidth('abc', 2)).toBe('a…');
+    });
+
+    it('returns fitting text unchanged', () => {
+      expect(truncateToWidth('ab', 2)).toBe('ab');
+    });
+  });
+});

--- a/src/tools/subagentDiffs.ts
+++ b/src/tools/subagentDiffs.ts
@@ -10,6 +10,7 @@ import {
   DIFF_EQUAL,
   DIFF_INSERT,
 } from '@utils/text/diff';
+import { sanitizePathSegment } from '@utils/text/sanitizePathSegment';
 import { countLines } from '@utils/text/stringUtils';
 
 /** Maximum lines of diff to include per file in deliveries. */
@@ -121,7 +122,10 @@ export async function computeAndWriteWorkflowDiffs(
           const truncated = truncateDiff(diff, limit);
           // Use full relativePath (with separators replaced) to avoid collisions
           // when multiple files share the same basename in different directories.
-          const safeName = o.relativePath.replaceAll(/[\\/]/g, '_');
+          const safeName = sanitizePathSegment(o.relativePath, {
+            invalidCharPattern: /[\\/]/g,
+            replacement: '_',
+          });
           const diffRelPath = `diffs/${safeName}.diff`;
           results.set(o.absolutePath, { diffRelPath, largeChange });
           diffsToWrite.push({ diffRelPath, content: truncated });


### PR DESCRIPTION
## Summary

Follow-up from a codebase-wide scan for ad-hoc implementations that duplicate maintained packages:

1. `packages/cli/src/chat/tui/render/terminalText.ts` now uses `slice-ansi` for hard clipping and `cli-truncate` for ellipsis truncation. The existing exported helpers remain the call-site boundary.
2. Three filename-fragment call sites (`debugMessageSaver.ts`, `subagentDiffs.ts`, `compileCheck.ts`) now use the existing `sanitizePathSegment` helper with options equivalent to their former inline replacements.
3. Direct terminal-text tests now pin narrow-width, wide-character, grapheme, ANSI, and invalid-width behavior.

## Issue acceptance gates

No linked issue; this is proactive cleanup from a scheduled code-quality scan. Gate: remove the confirmed duplicate implementations without regressing valid terminal-width clipping or filename sanitization.

## Single source of truth

- `slice-ansi` owns ANSI/grapheme-safe hard clipping.
- `cli-truncate` owns ellipsis truncation.
- `sanitizePathSegment` owns filename-segment sanitization at all six matching call sites.

The local helpers remain because they define the project's width-normalization contract and are used by 17+ CLI call sites.

## Duplication and abstraction budget

Removed the hand-rolled character loop and three inline sanitizing replacements. Added no project abstraction: both truncation helpers delegate directly to maintained packages, and the sanitizer already existed.

Deliberately left alone: timestamp formatting in `src/housekeeping/utils.ts` and HTML-attribute escaping in `src/shared/highlighting/highlightCode.ts`, which are different concerns.

## Defined width behavior

- Finite widths are floored to integers and clamped to zero.
- Non-finite widths throw `TypeError` instead of relying on accidental loop/library behavior.
- Hard clipping preserves complete graphemes and closes ANSI styles.
- Ellipsis truncation uses `cli-truncate`'s Unicode ellipsis; a zero-column budget returns an empty string.

## Net elements (R6)

- One focused test file added.
- Two direct CLI dependencies declared (`cli-truncate` and `slice-ansi`).
- No exported symbol added or removed; helper signatures are unchanged.

## Host impact

Extension: none.

Desktop: none.

CLI: terminal text clipping/truncation is now package-backed with an explicit normalized-width contract.

## Validation

- Focused terminal-text tests: 10/10 passed.
- Existing sanitizer/consumer suites passed.
- CLI typecheck passed.
- Test-kernel typecheck passed.
- Focused ESLint passed.
- Prettier and `git diff --check` passed.
