### PR TITLE
refactor(model,transcript,tools): retire token diagnostics and three duplicated shapes

### DIFF
--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -426,9 +426,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   /** Internal compaction recovery already attempted during this public call. */
   private compactionRetrySource: 'threshold' | 'overflow' | null = null;
 
-  /** DIAGNOSTIC: Pre-flight token estimate for comparison with actual usage */
-  private _diagPreFlightTokens: number | null = null;
-
   // =========================================================================
   // WebSocket transport
   // =========================================================================
@@ -495,23 +492,25 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   }
 
   /**
-   * Finalize response state after a successful API call.
-   * Updates the chain anchor, conversation state, and token counts.
+   * Finalize response state after a successful API call, and build the result
+   * every transport path returns. Updates the chain anchor, conversation state,
+   * and token counts, then surfaces {@link ResponseFinalizeContext.compactedMessages}
+   * so a finalized-but-not-returned (or returned-but-not-finalized) response is
+   * unrepresentable.
    */
   private finalizeResponse(
     response: Response,
-    effectiveMessagesCount: number,
-    compactedThisCall: boolean,
-  ): void {
+    ctx: ResponseFinalizeContext,
+  ): CreateResponseResult<Response, ResponseInputItem> {
     // Apply compaction state if compaction happened this call
-    if (compactedThisCall) {
+    if (ctx.compactedThisCall) {
       this.applyCompactionState();
     }
 
     // Only chain from completed responses with usage data. Missing usage
-    // signals streaming instability (see the [TOKEN_DIAG] branch below);
-    // chaining from such responses has produced stale-id and token-count
-    // drift in practice, so treat it the same as a non-completed status.
+    // signals streaming instability; chaining from such responses has produced
+    // stale-id and token-count drift in practice, so treat it the same as a
+    // non-completed status.
     // Use a typeof check rather than truthiness so a legitimate 0 wouldn't
     // be misclassified.
     const hasInputTokens = typeof response.usage?.input_tokens === 'number';
@@ -520,7 +519,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       response.status === 'completed' &&
       hasInputTokens;
     if (safeToChain) {
-      this.chainState.recordChained(response.id, effectiveMessagesCount);
+      this.chainState.recordChained(response.id, ctx.effectiveMessagesLength);
     } else {
       const errorDetail =
         response.error?.message ?? response.incomplete_details?.reason;
@@ -563,57 +562,27 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     // actual context usage (e.g., timing between count and API call, tool definitions,
     // or reasoning token accounting). See PRD Known Issues for investigation details.
     if (response.usage?.input_tokens) {
-      const actualTokens = response.usage.input_tokens;
-      this.chainState.setCumulativeInputTokens(actualTokens);
-
-      // DIAGNOSTIC: Compare pre-flight estimate with actual usage
-      if (this._diagPreFlightTokens !== null) {
-        const diff = actualTokens - this._diagPreFlightTokens;
-        const diffPercent =
-          this._diagPreFlightTokens > 0
-            ? ((diff / this._diagPreFlightTokens) * 100).toFixed(1)
-            : 'N/A';
-        const reasoningTokens =
-          response.usage.output_tokens_details?.reasoning_tokens ?? 0;
-        const outputTokens = response.usage.output_tokens ?? 0;
-
-        this.logger.debug('[TOKEN_DIAG] Actual vs pre-flight', {
-          data: {
-            actualInputTokens: actualTokens,
-            preFlightTokens: this._diagPreFlightTokens,
-            difference: diff,
-            differencePercent: diffPercent,
-            outputTokens,
-            reasoningTokens,
-            totalTokens: response.usage.total_tokens,
-            contextWindow: this.getEffectiveContextWindow(),
-            utilizationActual:
-              (actualTokens / this.getEffectiveContextWindow()) * 100,
-          },
-        });
-        this._diagPreFlightTokens = null; // Clear for next request
-      }
+      this.chainState.setCumulativeInputTokens(response.usage.input_tokens);
     } else {
-      // DIAGNOSTIC: Log when usage data is missing (streaming instability?)
+      // Not silent degradation: the chain anchor was already refused above
+      // (hasInputTokens gates safeToChain), this records that the context
+      // baseline could not be advanced for this turn.
       this.logger.debug(
-        `[TOKEN_DIAG] response.usage.input_tokens MISSING - cannot track context usage`,
+        'Response usage missing input_tokens; context usage not tracked',
         {
           data: {
             responseId: response.id,
             responseStatus: response.status,
             hasUsage: !!response.usage,
-            inputTokens: response.usage?.input_tokens,
-            outputTokens: response.usage?.output_tokens,
-            totalTokens: response.usage?.total_tokens,
-            preFlightTokens: this._diagPreFlightTokens,
           },
         },
       );
-      this._diagPreFlightTokens = null; // Clear anyway
     }
 
     // Reset compacted flag after successful request (ready for next compaction if needed)
     this.chainState.clearCompactedFlag();
+
+    return { response, updatedMessages: ctx.compactedMessages };
   }
 
   /**
@@ -721,19 +690,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     sourceMessages: ResponseInputItem[];
     sourceFingerprint: string;
   };
-
-  /**
-   * Best available estimate of current input tokens.
-   * Returns compactionResult.tokensAfter if compaction just happened,
-   * otherwise falls back to cumulativeInputTokens from previous response.
-   * Returns 0 if no token data available (first turn).
-   */
-  private getBestInputTokenEstimate(): number {
-    return (
-      this.compactionResult?.tokensAfter ??
-      this.chainState.getCumulativeInputTokens()
-    );
-  }
 
   /**
    * Get the appropriate safety buffer for token validation.
@@ -1058,8 +1014,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       // payload next turn (system items + the summary message with its
       // "[Previous conversation summary]" prefix), not the OUTPUT cost of
       // generating the summary — mirroring the stateful path, which counts the
-      // compacted items' input tokens. `getBestInputTokenEstimate()` prefers
-      // this value, and on the Codex profile it is load-bearing: token counting
+      // compacted items' input tokens. `applyTokenCountFailureFallback()`
+      // prefers this value over the chain's cumulative count, and on the Codex
+      // profile it is load-bearing: token counting
       // is unavailable and `failWhenFallbackOutputBudgetIsReduced` fails the
       // request locally when the estimate + budget overflow the context window,
       // so an output-token underestimate could let through a request the backend
@@ -1395,7 +1352,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   }
 
   private applyTokenCountFailureFallback(maxOutputTokens: number): number {
-    const inputEstimate = this.getBestInputTokenEstimate();
+    // Best available estimate of current input tokens: the post-compaction
+    // figure when compaction just happened, else the previous response's
+    // cumulative count, else 0 on the first turn.
+    const inputEstimate =
+      this.compactionResult?.tokensAfter ??
+      this.chainState.getCumulativeInputTokens();
     if (inputEstimate <= 0) return maxOutputTokens;
 
     const buffer = this.getTokenSafetyBuffer();
@@ -1738,27 +1700,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         },
         onCounted: (inputTokens) => {
           preFlightTokens = inputTokens;
-          // DIAGNOSTIC: Log token count details for investigation.
-          // Compare pre-flight estimate with cumulative tokens from prev response.
-          const prevCumulative = this.chainState.getCumulativeInputTokens();
-          const utilizationEstimate =
-            (inputTokens / this.getEffectiveContextWindow()) * 100;
-          this._diagPreFlightTokens = inputTokens; // Compared in finalizeResponse
-          this.logger.debug('[TOKEN_DIAG] Pre-flight count', {
-            data: {
-              preFlightTokens: inputTokens,
-              utilizationEstimate,
-              prevCumulativeTokens: prevCumulative,
-              delta: inputTokens - prevCumulative,
-              newMessagesCount: newMessages.length,
-              totalMessagesCount: effectiveMessages.length,
-              hasPreviousResponseId: !!this.chainState.getPreviousResponseId(),
-              hasTools: !!convertedTools?.length,
-              toolCount: convertedTools?.length ?? 0,
-              contextWindow: this.getEffectiveContextWindow(),
-              maxOutputTokens,
-            },
-          });
         },
         onCountFailure: (err) => {
           this.logger.debug('Token counting failed; applying fallback cap', {
@@ -1794,7 +1735,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       );
       this.compactionRetrySource = 'threshold';
       this.requestCompaction();
-      this._diagPreFlightTokens = null;
       return this.createResponseImpl(options);
     }
 
@@ -1929,15 +1869,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       signal,
     );
     if (!resumedResponse) return null;
-    this.finalizeResponse(
-      resumedResponse,
-      ctx.effectiveMessagesLength,
-      ctx.compactedThisCall,
-    );
-    return {
-      response: resumedResponse,
-      updatedMessages: ctx.compactedMessages,
-    };
+    return this.finalizeResponse(resumedResponse, ctx);
   }
 
   /**
@@ -2054,12 +1986,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     // reflects the completed response, not the pre-poll snapshot.
     processor.finalize(response);
 
-    this.finalizeResponse(
-      response,
-      ctx.effectiveMessagesLength,
-      ctx.compactedThisCall,
-    );
-    return { response, updatedMessages: ctx.compactedMessages };
+    return this.finalizeResponse(response, ctx);
   }
 
   /**
@@ -2180,12 +2107,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
       processor.finalize(response);
 
-      this.finalizeResponse(
-        response,
-        ctx.effectiveMessagesLength,
-        ctx.compactedThisCall,
-      );
-      return { response, updatedMessages: ctx.compactedMessages };
+      return this.finalizeResponse(response, ctx);
     } catch (error) {
       return handleStreamingFailure(error, {
         // Finalize the progress streams on error so the view does not hang
@@ -2260,12 +2182,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       },
     );
 
-    this.finalizeResponse(
-      response,
-      ctx.effectiveMessagesLength,
-      ctx.compactedThisCall,
-    );
-    return { response, updatedMessages: ctx.compactedMessages };
+    return this.finalizeResponse(response, ctx);
   }
 
   /**
@@ -2330,7 +2247,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       this.backgroundLifecycle.clearPending();
       this.compactionRetrySource = 'overflow';
       this.requestCompaction();
-      this._diagPreFlightTokens = null;
       // Retry internally: the recursive call will compact (shouldCompact()=true)
       // and send all messages without server-side state.
       // Call the impl directly — we're still inside the outer createResponse's
@@ -2355,9 +2271,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           'next attempt will try to resume polling instead of creating new request',
       );
     }
-
-    // Clear diagnostic state to avoid stale comparison on retry
-    this._diagPreFlightTokens = null;
 
     throw error;
   }

--- a/src/test-kernel/tools/ReadToolRange.vitest.ts
+++ b/src/test-kernel/tools/ReadToolRange.vitest.ts
@@ -1,0 +1,119 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
+// Third-party imports
+import { describe, expect, it, beforeEach } from 'vitest';
+
+// Local imports
+import { createRunContext, withRunContext } from '@agent/runtime/RunContext';
+import type { StreamTabId } from '@shared/schemas';
+import { installPlatform as installFakePlatform } from '@test/support/setupPlatform';
+import { ReadFileTool } from '@tools/ReadTool';
+
+const EXECUTION_ID = 'read-range-exec';
+
+/** 10 lines: "line 1" … "line 10". */
+const SMALL = Array.from({ length: 10 }, (_, i) => `line ${i + 1}`).join('\n');
+
+async function callRead(input: unknown) {
+  const tool = new ReadFileTool();
+  return withRunContext(
+    createRunContext({
+      streamId: `stream:${EXECUTION_ID}` as StreamTabId,
+      executionId: EXECUTION_ID,
+    }),
+    () => tool.call(input),
+  );
+}
+
+describe('read_file line ranges', () => {
+  beforeEach(async () => {
+    await installFakePlatform({
+      workspacePath: '/workspace',
+      files: { '/workspace/small.txt': SMALL },
+    });
+  });
+
+  it('reads the whole file when no range is given', async () => {
+    const result = await callRead({ path: 'small.txt' });
+
+    expect(result.summary).toBe('Read small.txt');
+    expect(result.output).toContain('line 1');
+    expect(result.output).toContain('line 10');
+  });
+
+  it('reads an explicit in-bounds range inclusively', async () => {
+    const result = await callRead({
+      path: 'small.txt',
+      range: { start: 3, end: 5 },
+    });
+
+    expect(result.summary).toBe('Read lines 3-5 of small.txt');
+    expect(result.output).toContain('line 3');
+    expect(result.output).toContain('line 5');
+    expect(result.output).not.toContain('line 6');
+    expect(result.output).not.toContain('line 2');
+  });
+
+  it('renders a single-line range with the singular label', async () => {
+    const result = await callRead({
+      path: 'small.txt',
+      range: { start: 4, end: 4 },
+    });
+
+    expect(result.summary).toBe('Read line 4 of small.txt');
+    expect(result.output).toContain('line 4');
+    expect(result.output).not.toContain('line 5');
+  });
+
+  it('clamps an end past EOF and says so in the summary', async () => {
+    const result = await callRead({
+      path: 'small.txt',
+      range: { start: 8, end: 999 },
+    });
+
+    expect(result.summary).toBe(
+      'Read lines 8-10 of small.txt (requested end 999 exceeds file length 10)',
+    );
+    expect(result.output).toContain('line 10');
+  });
+
+  it('reports an empty view when the start is past EOF', async () => {
+    const result = await callRead({
+      path: 'small.txt',
+      range: { start: 50, end: 60 },
+    });
+
+    expect(result.summary).toBe(
+      'Read small.txt (no lines in requested range) (requested end 60 exceeds file length 10)',
+    );
+    expect(result.output).toBe('');
+  });
+
+  it('reads to EOF when only a start is given', async () => {
+    const result = await callRead({ path: 'small.txt', range: { start: 7 } });
+
+    expect(result.summary).toBe('Read lines 7-10 of small.txt');
+    expect(result.output).toContain('line 7');
+    expect(result.output).toContain('line 10');
+    expect(result.output).not.toContain('line 6');
+  });
+
+  it('accepts the array range form some models emit', async () => {
+    const result = await callRead({ path: 'small.txt', range: [2, 4] });
+
+    expect(result.summary).toBe('Read lines 2-4 of small.txt');
+    expect(result.output).toContain('line 2');
+    expect(result.output).toContain('line 4');
+    expect(result.output).not.toContain('line 5');
+  });
+
+  it('rejects an end below the start', async () => {
+    const result = await callRead({
+      path: 'small.txt',
+      range: { start: 5, end: 2 },
+    });
+
+    expect(result.status).toBe('error');
+  });
+});

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -122,30 +122,18 @@ export class ReadFileTool extends defineTool({
 
     const range = input.range;
     const totalLines = lines.length;
-    const requestedStartLine = range?.start ?? 1;
-    let requestedEndLine = totalLines;
-    if (range?.end != null) {
-      requestedEndLine = range.end;
-    } else if (range) {
-      requestedEndLine = Math.min(
-        requestedStartLine + READ_FILE_MAX_LINES - 1,
-        totalLines,
-      );
-    }
-
-    // Clamp the 1-based range to the file bounds so callers can safely
-    // request windows beyond the file length.
-    const startLine = Math.min(requestedStartLine, totalLines + 1);
-    const endLine = Math.min(
-      Math.max(requestedEndLine, requestedStartLine),
-      totalLines,
-    );
+    const startLine = range?.start ?? 1;
+    // An omitted `end` reads a READ_FILE_MAX_LINES window from `start`. A
+    // supplied one is passed through unclamped: formatFileView already clamps
+    // both ends to the file bounds, so pre-clamping here only duplicated it.
+    const endLine =
+      range?.end ?? Math.min(startLine + READ_FILE_MAX_LINES - 1, totalLines);
 
     // Append a range-exceeded warning when the caller asked beyond EOF
-    const rangeEndExceeded = range?.end != null && range.end > totalLines;
-    const suffix = rangeEndExceeded
-      ? ` (requested end ${requestedEndLine} exceeds file length ${totalLines})`
-      : '';
+    const suffix =
+      range?.end != null && range.end > totalLines
+        ? ` (requested end ${range.end} exceeds file length ${totalLines})`
+        : '';
 
     const result = formatFileView({
       path: displayPath,

--- a/src/transcript/StreamLogStore.ts
+++ b/src/transcript/StreamLogStore.ts
@@ -733,21 +733,33 @@ export class StreamLogStore {
     return appended;
   }
 
-  update(
+  /**
+   * Shared body of the entry mutators: guard writability, resolve the resident
+   * log, apply the mutation, and commit only when the log reports a change.
+   * The three public mutators differ solely in which `StreamLog` method runs.
+   */
+  private mutateEntry(
     streamId: StreamTabId,
-    id: string,
-    patch: StreamLogUpdatePatch,
+    apply: (log: StreamLog) => StreamLogEntry | undefined,
   ): StreamLogEntry | undefined {
     this.assertWritableStream(streamId);
     const logInstance = this.streams.get(streamId)?.log;
     if (!logInstance) return undefined;
 
-    const updated = logInstance.update(id, patch);
+    const updated = apply(logInstance);
     if (!updated) return undefined;
 
     this.commitChange(streamId, logInstance);
     void this.save();
     return updated;
+  }
+
+  update(
+    streamId: StreamTabId,
+    id: string,
+    patch: StreamLogUpdatePatch,
+  ): StreamLogEntry | undefined {
+    return this.mutateEntry(streamId, (log) => log.update(id, patch));
   }
 
   settle(
@@ -755,16 +767,7 @@ export class StreamLogStore {
     id: string,
     patch: StreamLogUpdatePatch,
   ): StreamLogEntry | undefined {
-    this.assertWritableStream(streamId);
-    const logInstance = this.streams.get(streamId)?.log;
-    if (!logInstance) return undefined;
-
-    const updated = logInstance.settle(id, patch);
-    if (!updated) return undefined;
-
-    this.commitChange(streamId, logInstance);
-    void this.save();
-    return updated;
+    return this.mutateEntry(streamId, (log) => log.settle(id, patch));
   }
 
   appendText(
@@ -772,16 +775,7 @@ export class StreamLogStore {
     id: string,
     appendText: string,
   ): StreamLogEntry | undefined {
-    this.assertWritableStream(streamId);
-    const logInstance = this.streams.get(streamId)?.log;
-    if (!logInstance) return undefined;
-
-    const updated = logInstance.appendText(id, appendText);
-    if (!updated) return undefined;
-
-    this.commitChange(streamId, logInstance);
-    void this.save();
-    return updated;
+    return this.mutateEntry(streamId, (log) => log.appendText(id, appendText));
   }
 
   clearDirtyUpdates(streamId: StreamTabId): void {


### PR DESCRIPTION
## Summary

Four behavior-preserving cleanups found by a codebase debt audit, verified against current `main`. Net **−105 production lines**, no export surface change.

1. **Delete the `[TOKEN_DIAG]` scaffolding** (`modelHandlerOpenAIResponse`). Added 2026-02-03 for a token-counting investigation — recorded under "Completed" in `docs/prds/2026-02-02-prd-context-compactization.md:816-821` — and unreferenced since. The `_diagPreFlightTokens` field coupled three methods through hidden state that had to be cleared on five separate exit paths. Every number it logged is already emitted by a live path: the pre-flight count (`Token count of message: N`), `logMaxTokensReduced`, and the `Response not safe for chaining` record which already carries `hasUsage`/`hasInputTokens`/`status`/`responseId`.

   Its one non-redundant signal — a completed response whose `usage` carries no `input_tokens` — is **kept** as an explicit debug line rather than dropped, so a context baseline that could not be advanced stays visible instead of degrading silently.

2. **`finalizeResponse` returns its result** instead of `void`. Four transport paths each called it and then rebuilt the identical `CreateResponseResult` out of the `ResponseFinalizeContext` they had just handed in — the context exists precisely so those methods do not carry a transposable positional tail. Returning from inside makes "finalized but not returned" (and the reverse) unrepresentable.

3. **Collapse three `StreamLogStore` mutators.** `update`, `settle` and `appendText` were three 16-line methods differing only in which `StreamLog` method they invoked.

4. **Drop `ReadTool`'s range pre-clamping.** `formatFileView` already clamps both ends to the file bounds: the start clamp is subsumed by `rangeStartIndex` (`formatting.ts:95`), the end clamp is re-done verbatim at `:94`, and the `Math.max` by `sliceLineRange`'s own `Math.max` (`:28`).

## Issue acceptance gates

No issue — these came from an audit sweep. Deliberately **not** touching the neighbouring items already tracked: #9384 (StreamSnapshotStore staged-deletion coordinator), #9385 (Google streaming accumulator), #9414 (prefill machinery), #9410 (GenAI handler, maintainer-gated).

## Single source of truth

- **Response finalization + result construction** now belong to `finalizeResponse` alone; the four transport paths no longer each restate the result shape.
- **Entry mutation** (writability guard → resident-log lookup → commit-on-change → save) belongs to `StreamLogStore.mutateEntry`; the three public mutators supply only the operation.
- **Line-range clamping** belongs to `formatFileView`, which already documented itself as clamping ("Values are clamped to the file bounds automatically", `formatting.ts:63`). `read_file` no longer holds a second, subtly different copy.

## Duplication and abstraction budget

Removed: four copies of the finalize-then-rebuild-result idiom, two copies of the 16-line mutator body, one duplicated clamp block, and one single-caller helper (`getBestInputTokenEstimate`, inlined per the repo's single-caller rule).

One new abstraction: `StreamLogStore.mutateEntry` — private, three callers, captured `this`, owns the invariant *commit and save exactly when the log reports a change*. No pass-through layers added.

Explicitly **not** done, having been costed and found net-negative: splitting `createResponseImpl` (~20 locals cross phase boundaries; every extracted helper would be single-caller → +LoC), and converting the two bounded self-recursions into a loop (+5–10 LoC and a ~410-line reindent for a bound that is already monotone and test-pinned at `ModelHandlerOpenAIResponse.vitest.ts:1250`).

## Net elements (R6)

| | |
|---|---|
| Files | 3 changed, 1 added (test) |
| Exported symbols | **0 added, 0 removed** (`^[+-]export` over the diff is empty) |
| Classes / interfaces / enums | **0 added, 0 removed** |
| Methods | −2 (`getBestInputTokenEstimate` inlined; `_diagPreFlightTokens` field removed), +1 private (`mutateEntry`) |
| Net LoC | **production −105** (+60 / −165); tests +119 |

## Consumer counts (R8)

No emit path or export was re-routed. Removed members were all `private` and are now at **0 repo-wide references**: `_diagPreFlightTokens` (0), `getBestInputTokenEstimate` (0), `TOKEN_DIAG` (0). `finalizeResponse` remains private with its 4 call sites; `mutateEntry` is private with 3.

## Host impact

Extension: none — no host-facing surface touched.

Desktop: none.

CLI: none.

## Scheduled refactoring

Two follow-ups found during this work, deliberately left out to keep the diff behavior-preserving:

- **`read_file` silently truncates paginated reads.** On a 5000-line file, `read_file(path)` emits `...(truncated, 3000 more lines)` but `read_file(path, range:{start:1})` emits no marker at all — `ReadTool` pre-clamps the default window to exactly `start + 1999`, so `formatFileView`'s `truncated = rangeSize > maxLines` computes `2000 > 2000 → false`. A model paginating with `{start: N}` is silently told it reached EOF. Behavior fix, filed separately.
- **Background-mode log conflates two causes** (`modelHandlerOpenAIResponse.ts:1564-1571`): it says the handler does not support background execution, but the false conjunct may instead be the provider profile setting `backgroundMode: 'disabled'` (Codex subscription profile).

Also deferred: a `nullishDefault` helper for the mandatory `.nullish().transform((v) => v ?? X)` idiom. Measured at ≈−10 LoC across 10 files in three architectural zones — too close to neutral to justify the review surface here.

## Validation

- `npm run typecheck` — clean (exit 0)
- `npm run lint` — clean
- `npx prettier --check` on all touched files — clean
- `npm run check:dead-code-ratchet` — OK, 17 current vs 17 baselined
- `npm test` — **8239 passed, 9 skipped, 0 failed** (816 files)

`read_file` had **no test coverage**, so `ReadToolRange.vitest.ts` was written and landed against the *unmodified* code first, pinning the range table: in-bounds, single-line, end past EOF with its warning suffix, start past EOF, start-only, the array form some models emit, and end-below-start rejection. All eight assertions pass identically before and after, so the clamp removal is observably inert.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFbcZB4mfWQT23WuN69XSe)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactors and diagnostic removal only; behavior is test-pinned for read ranges and described as unchanged for handler/transcript paths. No public API or auth/data surface changes.
> 
> **Overview**
> Behavior-preserving debt cleanup across the OpenAI Responses handler, transcript store, and `read_file` tool, with new range tests and no export changes.
> 
> **OpenAI Responses handler:** Removes the `[TOKEN_DIAG]` / `_diagPreFlightTokens` scaffolding and inlines `getBestInputTokenEstimate` into `applyTokenCountFailureFallback`. **`finalizeResponse`** now takes `ResponseFinalizeContext` and **returns** `CreateResponseResult` so background, WebSocket, streaming, and non-streaming paths cannot finalize without returning the same result shape. When usage lacks `input_tokens`, logging is a plain debug line instead of diagnostic noise.
> 
> **`StreamLogStore`:** **`update`**, **`settle`**, and **`appendText`** share private **`mutateEntry`** (writability guard, log lookup, commit-on-change, save).
> 
> **`read_file`:** Drops duplicate line-range pre-clamping; **`formatFileView`** / **`sliceLineRange`** own bounds. Adds **`ReadToolRange.vitest.ts`** to pin range behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 925bcc51fe2dcec7bf9f5df069a21eaf0e8981db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->