### PR TITLE
fix(openai): preserve fast service tier requests

### DIFF
--- a/docs/proposals/2026-07-03-ink-practices-from-claude-code.md
+++ b/docs/proposals/2026-07-03-ink-practices-from-claude-code.md
@@ -131,9 +131,10 @@ from a write-only stdout. The provocative name prevents someone "optimizing" the
 Evidence: `ink/log-update.ts:136-147,503-513`, `ink/frame.ts:105-124`.
 **TeXRA:** Already does exactly this — the vendored patch swaps count-based erase for a
 debounced full repaint (`clearTerminal` then reprint reflowed `fullStaticOutput`), and
-`CLAUDE.md` explicitly forbids reverting to line-count erasing. Strong alignment
-(`ink@7.1.0.patch:26-66,69-82,87-124`). The only borrowable nuance is naming/commenting the
-cost in code so it stays.
+`CLAUDE.md` explicitly forbids reverting to line-count erasing. Strong alignment. The patch
+examined here as 7.1.0 is unchanged and now lives at
+`patches/ink@7.1.1.patch:26-66,69-82,87-124`. The only borrowable nuance is naming/commenting
+the cost in code so it stays.
 
 **Handle SIGWINCH synchronously (no debounce) but dedupe same-dimension events.**
 `handleResize` runs synchronously, early-returns on `(cols,rows)` equality, updates cached
@@ -143,7 +144,7 @@ render in that window detects a width change, clears, then the debounce fires an
 = double flicker.
 Evidence: `ink/ink.tsx:303-346,212-216`.
 **TeXRA:** **Divergence worth examining.** TeXRA's patch _debounces_ the full repaint at 24ms
-(`ink@7.1.0.patch`). Claude Code's argument is that debouncing desyncs source-of-truth width
+(`patches/ink@7.1.1.patch`). Claude Code's argument is that debouncing desyncs source-of-truth width
 from rendered width and can double-flicker if any other render fires in the debounce window.
 TeXRA's debounce may be safe _because_ it routes all repaints through one full-reset path (no
 spinner can paint a half-resized frame if nothing else renders independently), but this is the

--- a/docs/proposals/2026-07-03-tech-debt-audit.md
+++ b/docs/proposals/2026-07-03-tech-debt-audit.md
@@ -156,7 +156,8 @@ architecture needed.
   host. `packages/desktop/tsconfig.paths.json` is a second hand-maintained copy.
 - Desktop carries 5 tsconfigs; `scripts/extension-package-invariants.snapshot.json`
   is a 70 KB committed generated artifact (see B4 for the better end-state).
-- `patches/ink@7.1.0.patch` has no documented exit plan (upstream issue or
+- The patch audited as `patches/ink@7.1.0.patch`, now carried unchanged as
+  `patches/ink@7.1.1.patch`, has no documented exit plan (upstream issue or
   re-evaluation trigger on ink bumps).
 
 **Fixes:** use `tsconfck`/`strip-json-comments`; drop `~/*`; move host aliases

--- a/docs/proposals/2026-07-09-state-of-the-architecture.md
+++ b/docs/proposals/2026-07-09-state-of-the-architecture.md
@@ -105,8 +105,8 @@ release lane**), Supabase relay (Deno; billing constants hand-mirrored from
 `sharedConfig.ts` with a rotted pointer comment; llm-zoo pinned ^1.11 vs
 workspace ^1.12; zero CI involvement in deploys), public agent-YAML authoring
 surface (19 definition fields, 10 settings fields), `texra.*` command catalog
-(67 unique ids, SSOT + satisfies-checked), vendored `ink@7.1.0` patch (164
-lines, exact-version keyed).
+(67 unique ids, SSOT + satisfies-checked), then-vendored `ink@7.1.0` patch (164
+lines, exact-version keyed; now carried unchanged as `patches/ink@7.1.1.patch`).
 
 **Test architecture.** 613 suites; 83% mock nothing; 306 mock sites in 104
 suites; 52 host-side mock sites in 32 suites pin runtime-internal module

--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -1747,6 +1747,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       ...baseParams,
       max_output_tokens: maxOutputTokens,
       store: this.storesResponsesServerSide,
+      // llm-zoo's Fast tier maps to the SDK's current priority wire value.
+      ...(this.config.serviceTier === 'fast' && {
+        service_tier: 'priority',
+      }),
       ...(convertedTools?.length && {
         tool_choice: finalTool
           ? ({ type: 'function', name: finalTool.name } as const)

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponse.vitest.ts
@@ -6,7 +6,12 @@ import * as path from 'node:path';
 
 // Third-party imports
 import { describe, it, vi } from 'vitest';
-import { type ModelConfig, ModelProvider, ReasoningEffort } from 'llm-zoo';
+import {
+  MODEL_CONFIGS,
+  type ModelConfig,
+  ModelProvider,
+  ReasoningEffort,
+} from 'llm-zoo';
 import { APIUserAbortError, OpenAIError } from 'openai';
 
 // Local imports
@@ -409,6 +414,21 @@ describe('ModelHandlerOpenAIResponse.createResponse', () => {
       { effort?: string; mode?: string } | undefined;
     assert.equal(reasoning?.mode, 'pro');
     assert.equal(reasoning?.effort, 'medium');
+  });
+
+  it('requests priority processing for the gpt56fast registry entry', async () => {
+    assert.equal(MODEL_CONFIGS.gpt56fast.serviceTier, 'fast');
+    const handler = createHandler(MODEL_CONFIGS.gpt56fast);
+    const { client, requests } = createCapturingClient('resp-fast-tier');
+
+    await handler.createResponse({
+      client,
+      messages: createMessages(1),
+      temperature: 0,
+    });
+
+    assert.equal(requests[0]?.model, 'gpt-5.6-sol');
+    assert.equal(requests[0]?.service_tier, 'priority');
   });
 
   it('sends max effort when the model declares max as its native ceiling', async () => {

--- a/src/test-kernel/cli/InkResizePatch.vitest.mts
+++ b/src/test-kernel/cli/InkResizePatch.vitest.mts
@@ -14,7 +14,7 @@ const cliRequire = createRequire(
   new URL('../../../packages/cli/package.json', import.meta.url),
 );
 
-// The CLI vendors a patch (patches/ink@7.1.0.patch) that rewrites Ink's resize
+// The CLI vendors a patch (patches/ink@7.1.1.patch) that rewrites Ink's resize
 // handling: instead of erasing the live region by logical line count — which is
 // wrong once the emulator reflows soft-wrapped lines at the new width (too few
 // rows leaves residue, too many eats the <Static> header) — it repaints from a

--- a/src/test-kernel/support/inkTestHarness.mts
+++ b/src/test-kernel/support/inkTestHarness.mts
@@ -53,7 +53,7 @@ export class FakeStdout extends EventEmitter {
 /** Ink's render instance, narrowed to what the test kernel drives. `ink` is a
  *  `packages/cli` dependency that repo-root type resolution does not see, so
  *  the module handle itself stays untyped. `repaint` comes from the workspace
- *  Ink patch (`patches/ink@7.1.0.patch`), not upstream Ink. */
+ *  Ink patch (`patches/ink@7.1.1.patch`), not upstream Ink. */
 interface InkInstance {
   unmount(): void;
   rerender(node: any): void;
@@ -126,7 +126,7 @@ export function renderWithTerminalSize(
  *  Tests that drive keystrokes or their own clock keep the handles from
  *  `renderWithTerminalSize` instead.
  *
- *  This uses Ink's debug mode, where Ink 7.1.0 writes each render as a complete
+ *  This uses Ink's debug mode, where Ink 7.1.1 writes each render as a complete
  *  frame instead of terminal cursor/erase updates. `until` receives the latest
  *  painted frame, which is also returned; it defaults to "Ink has painted
  *  something". */

--- a/supabase/functions/relay/providerTier_test.ts
+++ b/supabase/functions/relay/providerTier_test.ts
@@ -217,6 +217,31 @@ Deno.test('gates relay providers by tier at the route boundary', async () => {
   });
 });
 
+Deno.test('preserves OpenAI priority service tier requests', async () => {
+  await withTestEnvironment(async () => {
+    const response = await app.request('/relay/openai/v1/responses', {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer Ultra-token',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: MODEL_CONFIGS.gpt56fast.fullName,
+        service_tier: 'priority',
+        input: 'hello',
+      }),
+    });
+
+    assert.equal(response.status, 204);
+    assert.equal(upstreamRequests.length, 1);
+    assert.deepEqual(await upstreamRequests[0]?.json(), {
+      model: 'gpt-5.6-sol',
+      service_tier: 'priority',
+      input: 'hello',
+    });
+  });
+});
+
 Deno.test(
   'excludes Ultra-only provider models from lower-tier config',
   async () => {


### PR DESCRIPTION
## Summary

Focused follow-up to merged dependency refresh #9529:

- Map `llm-zoo@1.24.0`'s `gpt56fast.serviceTier: 'fast'` to OpenAI Responses `service_tier: 'priority'`.
- Verify the shared request builder covers streaming HTTP, non-streaming HTTP, and WebSocket transports.
- Add request-construction and relay pass-through regressions.
- Update live Ink patch references to 7.1.1 while labeling historical 7.1.0 proposal observations honestly.

The broad manifest and lockfile refresh formerly in this PR was removed after #9529 merged; this branch now contains only the migration and reference fixes that #9529 omitted.

## Single source of truth

`llm-zoo` remains the canonical owner of model tier intent. The OpenAI Responses handler performs the one internal-to-wire translation. The relay remains a transparent JSON pass-through; its test pins that property without adding relay-specific production logic.

## Abstraction budget

No new layer or helper was added. Four production lines extend the existing shared Responses parameter builder. Models without the registry's `fast` tier are unchanged.

## Scope

- 8 files changed, +62/-11.
- One production file; the remaining changes are focused tests and stale-reference corrections.
- No manifest or lockfile changes relative to current main.

## Validation

- Full workspace typecheck passed.
- Repository lint and Prettier checks passed.
- Focused model/OpenAI/relay/terminal/Ink runs passed (151 tests); independent review rerun passed 60/60 focused tests.
- Deno 2.8.3 relay `check`, `lint`, and full tests passed: 9/9.
- Documentation boundary, guidance references, and `git diff --check` passed.
- Two independent code reviews and current-head Claude/Codex reviews found no remaining issue before the branch was narrowed; narrowing removed only changes already merged in #9529.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, conditional field on Responses create params with focused tests; relay remains pass-through. No auth or billing logic changes in this diff.
> 
> **Overview**
> **OpenAI Responses** requests now translate registry intent into wire format: when `llm-zoo` marks a model with `serviceTier: 'fast'` (e.g. `gpt56fast`), the shared Responses parameter builder adds `service_tier: 'priority'` on the API call.
> 
> **Tests** pin that mapping in the OpenAI Responses handler and assert the Supabase relay forwards `service_tier: 'priority'` unchanged on `/relay/openai/v1/responses`.
> 
> **Docs and Ink patch references** are updated from `patches/ink@7.1.0.patch` to `patches/ink@7.1.1.patch` (unchanged patch content), including the Ink resize regression test and test harness comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f155717a87dd0a0cd4a99c2b3f92e62a40813387. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->