### PR TITLE
ci: harden claude.yml against untrusted issue and PR content

### DIFF
--- a/.github/automation/allowed-tools.json
+++ b/.github/automation/allowed-tools.json
@@ -1,5 +1,5 @@
 {
-  "claude-interactive": "Read,Edit,Write,Glob,Grep,Bash(corepack pnpm install),Bash(pnpm install),Bash(npm run typecheck),Bash(npm run lint),Bash(npm run compile:fast),Bash(npm run compile:safe),Bash(npm run build:fast),Bash(npm run check:*),Bash(npm run test),Bash(node *),Bash(git diff *),Bash(git status),Bash(gh pr:*),Bash(gh issue:*),mcp__github__*",
+  "claude-interactive": "Read,Edit,Write,Glob,Grep,Bash(corepack pnpm install),Bash(pnpm install),Bash(npm run typecheck),Bash(npm run lint),Bash(npm run compile:fast),Bash(npm run compile:safe),Bash(npm run build:fast),Bash(npm run check:*),Bash(npm run test),Bash(node scripts/*),Bash(git diff *),Bash(git status),Bash(gh pr:*),Bash(gh issue:*),mcp__github__*",
   "quality-improver": "mcp__github__*,Bash(find:*),Bash(grep:*),Bash(wc:*),Bash(jq:*),Bash(git log:*),Bash(git diff:*)",
   "issue-tracker": "mcp__github__*,Bash(git diff:*),Bash(git log:*),Bash(git show:*)",
   "issue-tree": "mcp__github__*",

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,9 +29,9 @@ jobs:
       vars.CLAUDE_CODE_ENABLED != 'false' &&
       github.event.sender.type != 'Bot' &&
       (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association) && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)) ||
         (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
       )
     runs-on: ubuntu-latest
@@ -57,6 +57,10 @@ jobs:
         with:
           fetch-depth: 1
           token: ${{ env.GH_TOKEN }}
+          # Do not leave the token in .git/config. The agent reaches GitHub
+          # through mcp__github__*, never through git credentials, and it runs
+          # with Read over a workspace that would otherwise contain the PAT.
+          persist-credentials: false
 
       - name: Checkout trusted automation
         uses: actions/checkout@v6
@@ -64,6 +68,10 @@ jobs:
           ref: ${{ github.event.pull_request.base.ref || github.event.repository.default_branch }}
           path: .trusted-actions
           fetch-depth: 1
+          # This checkout defaults to the job's GITHUB_TOKEN and would otherwise
+          # leave it write-capable in .trusted-actions/.git/config, inside the
+          # workspace the agent can Read. Nothing here needs git credentials.
+          persist-credentials: false
 
       - name: Check trusted provider wrapper
         id: trusted-provider-wrapper


### PR DESCRIPTION
Split (1 of 3) out of #9523 so the security change is reviewable on its own. Two files.

## What

| Change | Why |
|---|---|
| `persist-credentials: false` on **both** checkouts | The repo checkout passes `token: ${{ env.GH_TOKEN }}` and `actions/checkout` still defaults this to `true`, so the PAT landed in `.git/config` inside a workspace the agent can `Read`. The `.trusted-actions` checkout left the job's `GITHUB_TOKEN` there the same way. The agent reaches GitHub via `mcp__github__*`, never git credentials. `texra-code-review.yml:94,104` already does this. |
| Gate all three mention events on the author of the *content*, not just the mention | `issue_comment` checked the commenter; `pull_request_review_comment` and `pull_request_review` checked the reviewer — while the issue body and PR head they pull in are attacker-authorable. The `issues` event was already correct. |
| `Bash(node *)` → `Bash(node scripts/*)` | The broad form permits `node -e` with arbitrary code and network egress. Repo scripts still run; the `npm run` entries beside it are unaffected. |

## The gap this closes

The job holds `contents: write`, `pull-requests: write`, `issues: write`. Before this, a maintainer replying `@claude` on an outside contributor's issue or PR fed untrusted content to an agent holding those permissions, with a PAT sitting in `.git/config` and `Bash(node *)` available.

I tried a narrower fix first — gating the forwarded `issue-body`/`issue-title` instead of the job — and it was **wrong**: those inputs feed `auto-create-issue-pr`, which only scans them for a label, while the preceding `agent-ci-actions` step wraps `claude-code-action` with no explicit prompt and derives context from the event payload directly. The job gate is the only workflow-level control that reaches the agent.

## Cost

A maintainer can no longer trigger Claude by replying on an outside contribution. They can still restate the request in their own comment, which is trusted content by construction. That tradeoff is deliberate; say the word if you'd rather have the convenience back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3sUAZ2ygoZ58tBPerPjS6

---
_Generated by [Claude Code](https://claude.ai/code/session_01K3sUAZ2ygoZ58tBPerPjS6)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes security boundaries and trigger rules for a high-privilege CI agent (write scopes + secrets); behavior tradeoff may block @claude on outside-contributor threads until a maintainer posts trusted content.
> 
> **Overview**
> **Tightens the mention-driven Claude Code job** so untrusted outside-contributor content is less likely to drive an agent that has `contents`/`issues`/`pull-requests` write access.
> 
> Both `actions/checkout` steps now set **`persist-credentials: false`**, so the PAT/`GITHUB_TOKEN` are not left in `.git/config` inside a tree the agent can `Read` (aligned with `texra-code-review.yml`).
> 
> For **`issue_comment`**, **`pull_request_review_comment`**, and **`pull_request_review`**, the job `if` now requires the **issue or PR author** to be `OWNER`/`MEMBER`/`COLLABORATOR`, not only the person who wrote the `@claude` mention—so a maintainer reply on an outsider’s thread no longer starts the job.
> 
> In **`allowed-tools.json`**, **`Bash(node *)`** is narrowed to **`Bash(node scripts/*)`** to block arbitrary `node -e` while still allowing repo scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8631329071c572be3e38c6acee584c55b81fdf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->