### PR TITLE
ci: harden the interactive Claude workflow

### DIFF
--- a/.github/automation/allowed-tools.json
+++ b/.github/automation/allowed-tools.json
@@ -1,5 +1,5 @@
 {
-  "claude-interactive": "Read,Edit,Write,Glob,Grep,Bash(corepack pnpm install),Bash(pnpm install),Bash(npm run typecheck),Bash(npm run lint),Bash(npm run compile:fast),Bash(npm run compile:safe),Bash(npm run build:fast),Bash(npm run check:*),Bash(npm run test),Bash(node *),Bash(git diff *),Bash(git status),Bash(gh pr:*),Bash(gh issue:*),mcp__github__*",
+  "claude-interactive": "Read,Edit,Write,Glob,Grep,Bash(corepack pnpm install),Bash(pnpm install),Bash(npm run typecheck),Bash(npm run lint),Bash(npm run compile:fast),Bash(npm run compile:safe),Bash(npm run build:fast),Bash(npm run check:*),Bash(npm run test),Bash(node scripts/*),Bash(git diff *),Bash(git status),Bash(gh pr:*),Bash(gh issue:*),mcp__github__*",
   "quality-improver": "mcp__github__*,Bash(find:*),Bash(grep:*),Bash(wc:*),Bash(jq:*),Bash(git log:*),Bash(git diff:*)",
   "issue-tracker": "mcp__github__*,Bash(git diff:*),Bash(git log:*),Bash(git show:*)",
   "issue-tree": "mcp__github__*",

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,7 +29,7 @@ jobs:
       vars.CLAUDE_CODE_ENABLED != 'false' &&
       github.event.sender.type != 'Bot' &&
       (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
         (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
         (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
@@ -57,6 +57,10 @@ jobs:
         with:
           fetch-depth: 1
           token: ${{ env.GH_TOKEN }}
+          # Do not leave the token in .git/config. The agent reaches GitHub
+          # through mcp__github__*, never through git credentials, and it runs
+          # with Read over a workspace that would otherwise contain the PAT.
+          persist-credentials: false
 
       - name: Checkout trusted automation
         uses: actions/checkout@v6
@@ -64,6 +68,10 @@ jobs:
           ref: ${{ github.event.pull_request.base.ref || github.event.repository.default_branch }}
           path: .trusted-actions
           fetch-depth: 1
+          # This checkout defaults to the job's GITHUB_TOKEN and would otherwise
+          # leave it write-capable in .trusted-actions/.git/config, inside the
+          # workspace the agent can Read. Nothing here needs git credentials.
+          persist-credentials: false
 
       - name: Check trusted provider wrapper
         id: trusted-provider-wrapper


### PR DESCRIPTION
## Scope

Split from #9523. Workflow hardening only:
- require both the commenter and issue author to be trusted for `issue_comment` runs;
- disable credential persistence on both checkouts;
- narrow the interactive Node tool from `Bash(node *)` to `Bash(node scripts/*)`.

No code, docs, dependency, alias, or relocation changes are included.

## Security / SSOT decisions

- The issue-author gate is the canonical protection for event-derived agent context; sanitizing only the later PR-creation metadata would not protect the agent invocation.
- Neither checkout stores a token in workspace-readable Git config.
- Tool policy remains centralized in `.github/automation/allowed-tools.json`.

## Validation

- Ruby YAML parse: pass
- JSON parse of `allowed-tools.json`: pass
- invariant check: exactly two `persist-credentials: false` entries
- invariant grep: trusted issue-author association gate and `Bash(node scripts/*)` present
- `git diff --check`: pass

Base: `2afcda67fd869f7b468c342b613c6c53743e3aab` (latest `origin/main` when opened).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication/trust gates and agent Bash policy for a write-capable bot workflow; misconfiguration could block legitimate @claude runs or leave gaps if other events lack the same author checks.
> 
> **Overview**
> Hardens the mention-driven **Claude Code** GitHub Actions job so untrusted issue context cannot trigger runs and tokens are not left in the agent-readable workspace.
> 
> For **`issue_comment`** triggers, the job now requires **both** the commenter and the **issue author** to have trusted `author_association` (`OWNER`, `MEMBER`, or `COLLABORATOR`), not just the commenter. Both **`actions/checkout`** steps set **`persist-credentials: false`** so PAT/`GITHUB_TOKEN` are not written into `.git/config` under paths the agent can read.
> 
> Interactive tool policy in **`allowed-tools.json`** narrows **`Bash(node *)`** to **`Bash(node scripts/*)`**, limiting arbitrary Node execution while keeping repo scripts available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6989028b028e18fdb43104fc65487372fad823c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->