### PR TITLE
fix(cli): collapse background workflow list by default

### DIFF
--- a/packages/cli/scripts/validate-tui.mjs
+++ b/packages/cli/scripts/validate-tui.mjs
@@ -153,7 +153,7 @@ const SCENARIOS = [
     bootExpect: 'Tab children',
     keys: ['\t', DOWN, '\r'],
     expect: [
-      'repositoryAudit completed',
+      'Repository audit Finished',
       'Generated files',
       'paper.tex',
       'Compile check failed',
@@ -2770,11 +2770,9 @@ const SCENARIOS = [
     },
     bootExpect: 'Tab children',
     keys: ['\t', DOWN, DOWN, DOWN, '\r'],
-    expect: [
-      'strategy is checking the harness-child-strategy details',
-      '✓ ● strategy running',
-    ],
+    expect: ['strategy is checking the harness-child-strategy details'],
     unexpect: [
+      '✓ ● strategy running',
       'agent: chat · model: harness-model',
       'entry-1 chat history line',
       'entry-4 chat history line',

--- a/packages/cli/src/chat/tui/appLayout.ts
+++ b/packages/cli/src/chat/tui/appLayout.ts
@@ -160,8 +160,12 @@ export function allocateConversationBottomPanelRows({
   readonly sessionPanelRows: number;
   readonly todosPlanRows: number;
 } {
-  const childListRowCount = sessionCount;
-  // The persistent child list owns one blank separator row above its Select.
+  // Child sessions already have a compact count and navigation affordance in
+  // the status bar. Keep their rows collapsed until the user focuses the
+  // list; a large workflow must not take transcript space merely because it
+  // is running in the background.
+  const childListRowCount = childListFocused ? sessionCount : 0;
+  // The expanded child list owns one blank separator row above its Select.
   const sessionPanelContentRows =
     childListRowCount > 0 ? childListRowCount + 1 : 0;
   // The todos/plan panel likewise owns a separator row above its checklist.

--- a/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
+++ b/packages/cli/src/chat/tui/panes/ConversationRegion.tsx
@@ -166,9 +166,9 @@ export function ConversationRegion({
     staticTranscriptRows: staticTranscriptRows ?? 0,
   });
   // The subagent/todos panels live at the bottom of the same vertical column.
-  // Reserve only as many rows as the panels actually need. Unfocused panels
-  // use at most half the transcript, except for the one row needed to keep a
-  // multi-child list visible in a short terminal.
+  // Reserve only as many rows as the panels actually need. Child sessions stay
+  // behind the status-bar navigation affordance until the list has focus, so a
+  // background workflow cannot expand over the conversation by default.
   const todosPlanContentRows =
     hasTodosPlanPanel && activeSlice
       ? todosPlanPanelRowCount(activeSlice.todos, activeSlice.plan)

--- a/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
+++ b/src/test-kernel/cli/TuiStateAndFocus.vitest.mts
@@ -713,12 +713,26 @@ describe('CLI TUI row allocation', () => {
     });
   });
 
-  it('allocates session rows from the session count alone', () => {
+  it('keeps the child list collapsed until it receives focus', () => {
     expect(
       allocateConversationBottomPanelRows({
         maxRows: 10,
         sessionCount: 2,
         childListFocused: false,
+        todosPlanContentRows: 0,
+        transcriptRows: 6,
+      }),
+    ).toEqual({
+      bottomPanelRows: 0,
+      sessionPanelRows: 0,
+      todosPlanRows: 0,
+    });
+
+    expect(
+      allocateConversationBottomPanelRows({
+        maxRows: 10,
+        sessionCount: 2,
+        childListFocused: true,
         todosPlanContentRows: 0,
         transcriptRows: 6,
       }),
@@ -742,14 +756,14 @@ describe('CLI TUI row allocation', () => {
     ).toMatchObject({ bottomPanelRows: 3, todosPlanRows: 3 });
   });
 
-  it('borrows a child-list row so an active todo stays visible', () => {
+  it('borrows a focused child-list row so an active todo stays visible', () => {
     // Codex review case: many children + one todo under the 10-row cap. The
     // proportional split grants todos one row — too small for separator +
     // content — so one row shifts from the ample child list instead.
     const allocation = allocateConversationBottomPanelRows({
       maxRows: 10,
       sessionCount: 11,
-      childListFocused: false,
+      childListFocused: true,
       todosPlanContentRows: 1,
       transcriptRows: 30,
     });
@@ -776,12 +790,12 @@ describe('CLI TUI row allocation', () => {
     });
   });
 
-  it('preserves todo content when the child list can yield one row', () => {
+  it('preserves todo content when the focused child list can yield one row', () => {
     expect(
       allocateConversationBottomPanelRows({
         maxRows: 10,
         sessionCount: 11,
-        childListFocused: false,
+        childListFocused: true,
         todosPlanContentRows: 1,
         transcriptRows: 20,
       }),


### PR DESCRIPTION
This PR keeps the child-session list collapsed until it receives focus. Background workflows therefore retain transcript space while the status bar continues to expose the child count and navigation affordance.

The focused list retains the existing row-allocation behavior, including the allocation that preserves active todo content.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only change gated on existing `childListFocused` state; focused-list and todos borrowing paths are explicitly preserved in tests.
> 
> **Overview**
> **Background child workflows no longer reserve bottom-panel rows** in the CLI TUI. `allocateConversationBottomPanelRows` now treats `childListRowCount` as `sessionCount` only when `childListFocused` is true; otherwise it is zero, so running subagents/workflows do not shrink the conversation transcript unless the user opens the child list (Tab / status-bar affordance).
> 
> **Focused behavior is unchanged:** when the list has focus, row allocation—including splits with the todos/plan panel and the “borrow a row for active todos” cases—still applies as before.
> 
> **Tests and harness** were updated: unit tests in `TuiStateAndFocus.vitest.mts` assert collapsed vs expanded allocation, and `validate-tui.mjs` scenarios (`workflow-timeline`, `subagent-list-focus-full-frame`) match the new UI (e.g. no persistent `✓ ● strategy running` in the child list until expanded).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9066a701f45efdef6f9d2ba95a45b93c09e5c84d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->