### PR TITLE
fix(tools): report truncated start-only file reads

### DIFF
--- a/src/test-kernel/tools/ReadToolRange.vitest.ts
+++ b/src/test-kernel/tools/ReadToolRange.vitest.ts
@@ -14,6 +14,9 @@ const EXECUTION_ID = 'read-range-exec';
 
 /** 10 lines: "line 1" … "line 10". */
 const SMALL = Array.from({ length: 10 }, (_, i) => `line ${i + 1}`).join('\n');
+const LARGE = Array.from({ length: 2500 }, (_, i) => `line ${i + 1}`).join(
+  '\n',
+);
 
 async function callRead(input: unknown) {
   const tool = new ReadFileTool();
@@ -30,7 +33,10 @@ describe('read_file line ranges', () => {
   beforeEach(async () => {
     await installFakePlatform({
       workspacePath: '/workspace',
-      files: { '/workspace/small.txt': SMALL },
+      files: {
+        '/workspace/large.txt': LARGE,
+        '/workspace/small.txt': SMALL,
+      },
     });
   });
 
@@ -97,6 +103,16 @@ describe('read_file line ranges', () => {
     expect(result.output).toContain('line 7');
     expect(result.output).toContain('line 10');
     expect(result.output).not.toContain('line 6');
+  });
+
+  it('reports remaining lines when a start-only range is truncated', async () => {
+    const result = await callRead({
+      path: 'large.txt',
+      range: { start: 2 },
+    });
+
+    expect(result.summary).toBe('Read lines 2-2001 of large.txt');
+    expect(result.output).toContain('...(truncated, 499 more lines)');
   });
 
   it('accepts the array range form some models emit', async () => {

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import { getCurrentToolCallContext } from '@agent/followUp/ToolFileInteractionContext';
 import { ToolError, type ToolResult } from '@shared/schemas/toolResult';
 import { buildBytesAttachment, buildFileAttachment } from '@tools/attachments';
-import { formatFileView, READ_FILE_MAX_LINES } from '@tools/formatting';
+import { formatFileView } from '@tools/formatting';
 import {
   resolveAndFormat,
   currentToolRoot,
@@ -123,11 +123,9 @@ export class ReadFileTool extends defineTool({
     const range = input.range;
     const totalLines = lines.length;
     const startLine = range?.start ?? 1;
-    // An omitted `end` reads a READ_FILE_MAX_LINES window from `start`. A
-    // supplied one is passed through unclamped: formatFileView already clamps
-    // both ends to the file bounds, so pre-clamping here only duplicated it.
-    const endLine =
-      range?.end ?? Math.min(startLine + READ_FILE_MAX_LINES - 1, totalLines);
+    // Pass an omitted `end` through as EOF. formatFileView owns the visible
+    // line limit and needs the full requested range to report truncation.
+    const endLine = range?.end ?? totalLines;
 
     // Append a range-exceeded warning when the caller asked beyond EOF
     const suffix =

--- a/src/tools/formatting.ts
+++ b/src/tools/formatting.ts
@@ -9,7 +9,7 @@ export const ViewRangeSchema = z
   });
 
 /** Maximum lines returned in a single file view before truncation. */
-export const READ_FILE_MAX_LINES = 2000;
+const READ_FILE_MAX_LINES = 2000;
 
 /** Default width for line number padding */
 const LINE_NUMBER_WIDTH = 6;


### PR DESCRIPTION
## Summary

The read_file tool now reports remaining lines when a start-only range exceeds the 2,000-line display limit. The tool passes the complete requested range to the shared formatter, which remains the single owner of line limiting and truncation reporting.

A regression test covers a 2,500-line file read from line 2 and verifies both the visible range and the 499-line truncation notice.

Closes #9543.

## Validation

- Focused ReadTool and formatting suites: 10 tests passed
- Changed-file Prettier and ESLint checks passed
- Test-kernel TypeScript check passed
- Diff whitespace check passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized read_file range/truncation behavior with a focused test; no auth, data, or API surface changes.
> 
> **Overview**
> **Start-only `read_file` ranges** that span more than 2,000 lines now show the `...(truncated, N more lines)` notice and a summary that reflects the visible window (e.g. lines 2–2001), instead of silently capping the range in `ReadTool` before formatting.
> 
> `ReadTool` no longer pre-limits omitted `range.end` to `READ_FILE_MAX_LINES`; it passes **EOF** into `formatFileView`, which remains the single place that applies the line cap and truncation messaging. `READ_FILE_MAX_LINES` is **module-private** in `formatting.ts` (no longer exported).
> 
> A regression test uses a 2,500-line fixture with `range: { start: 2 }` and asserts the summary and truncation footer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0644821af538dd978aef385d6c23209159b9e6e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->