### PR TITLE
fix(openai): distinguish background-mode rejection causes

### DIFF
--- a/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/openai/modelHandlerOpenAIResponse.ts
@@ -1528,9 +1528,15 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       this.isBackgroundModeToggleEnabled() &&
       this.isBackgroundModeEligible()
     ) {
-      this.logger.debug(
-        'Background mode toggle is enabled but this handler does not support background execution. Proceeding without background mode.',
-      );
+      if (this.getOpenAIResponseCapabilities()?.backgroundMode === 'disabled') {
+        this.logger.debug(
+          'Background mode toggle is enabled but the active provider profile disables background execution. Proceeding without background mode.',
+        );
+      } else {
+        this.logger.debug(
+          'Background mode toggle is enabled but this handler does not support background execution. Proceeding without background mode.',
+        );
+      }
     } else if (streamingToggleEnabled && useBackgroundResponses) {
       this.logger.debug(
         'Background mode enabled; skipping streaming to avoid unstable behavior.',

--- a/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponseBackground.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/ModelHandlerOpenAIResponseBackground.vitest.ts
@@ -4,14 +4,55 @@ import { describe, it, afterEach, vi } from 'vitest';
 import { type ModelConfig, ModelProvider } from 'llm-zoo';
 
 // Local imports - agent
+import { noopTrace } from '@agent/trace';
 import { AgentCategory } from '@agent/core/definition/AgentDataclass';
 import { ModelHandlerCodex } from '@agent/modelHandlers/openai/modelHandlerCodex';
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/openai/modelHandlerOpenAIResponse';
+import { resolveProviderCapabilities } from '@model/providerCapabilities';
 import { buildTestModelConfig } from '@test/support/modelConfigTestUtils';
 import * as configModule from '@utils/config/configUtils';
+import type OpenAI from 'openai';
 
 class UnsupportedBackgroundHandler extends ModelHandlerOpenAIResponse {
   protected override backgroundModeSupported = false;
+}
+
+class ProfileDisabledBackgroundHandler extends ModelHandlerOpenAIResponse {
+  protected override getActiveProviderCapabilities() {
+    return resolveProviderCapabilities({
+      model: { ...this.config, codexSubscription: true },
+      useOpenRouter: false,
+    });
+  }
+}
+
+async function captureBackgroundModeDebug(
+  handler: ModelHandlerOpenAIResponse,
+): Promise<string[]> {
+  const messages: string[] = [];
+  handler.setLogger({
+    ...noopTrace,
+    debug: (message) => messages.push(message),
+  });
+  handler.setAgentCategory(AgentCategory.Workflow);
+  handler.getStreamingConfig = () => false;
+
+  await handler.createResponse({
+    client: {
+      responses: {
+        create: async () => ({
+          id: 'response-1',
+          output: [],
+          output_text: 'ok',
+          status: 'completed',
+        }),
+      },
+    } as unknown as OpenAI,
+    messages: [{ role: 'user', content: 'test' }],
+    temperature: 0,
+  });
+
+  return messages;
 }
 
 function createOpenAIConfig(name: string): ModelConfig {
@@ -85,6 +126,38 @@ describe('ModelHandlerOpenAIResponse background mode', () => {
 
     assert.equal(handler.isBackgroundModeActive(), false);
     assert.equal(handler.getStreamingConfig(), true);
+  });
+
+  it('identifies handler support as the reason background mode is inactive', async () => {
+    const messages = await captureBackgroundModeDebug(
+      new UnsupportedBackgroundHandler(createOpenAIConfig('gpt-5')),
+    );
+
+    assert.ok(
+      messages.some((message) =>
+        message.includes('this handler does not support background execution'),
+      ),
+    );
+  });
+
+  it('identifies provider policy as the reason background mode is inactive', async () => {
+    const messages = await captureBackgroundModeDebug(
+      new ProfileDisabledBackgroundHandler(createOpenAIConfig('gpt-5')),
+    );
+
+    assert.ok(
+      messages.some((message) =>
+        message.includes(
+          'active provider profile disables background execution',
+        ),
+      ),
+    );
+    assert.equal(
+      messages.some((message) =>
+        message.includes('this handler does not support background execution'),
+      ),
+      false,
+    );
   });
 
   it('runs the Codex fallback (subscription off) path through the shared background toggle', () => {


### PR DESCRIPTION
## Summary

Background-mode diagnostics now distinguish two different causes:

- the handler does not implement background execution;
- the active provider profile explicitly disables background execution.

Focused tests exercise both cases through response creation and verify that the profile-disabled path no longer reports a handler limitation.

Closes #9544.

## Validation

- Background-mode suite: 10 tests passed
- Changed-file Prettier and ESLint checks passed
- Test-kernel TypeScript check passed
- Diff whitespace check passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change to debug strings; background mode activation logic is unchanged.
> 
> **Overview**
> When background mode is toggled on and the request is eligible but still runs without background execution, **debug logging now branches on why**.
> 
> If the active OpenAI Responses provider profile sets `backgroundMode` to **`disabled`** (e.g. ChatGPT subscription / Codex), the log says the **provider profile** disabled it. Otherwise it keeps the existing message that the **handler** does not support background execution.
> 
> **Tests** drive `createResponse` with stub clients and assert each path emits the correct debug string and that the profile-disabled case does not blame handler support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54b6b51c13997dc7c3c626bf8d2cf08fc31a36ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->