### PR TITLE
test: guard generated build aliases

### DIFF
--- a/src/test-kernel/scripts/AliasMapGeneration.vitest.ts
+++ b/src/test-kernel/scripts/AliasMapGeneration.vitest.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from 'vitest';
 type TsconfigPaths = Record<string, string[]>;
 
 interface AliasUtilsModule {
+  deriveBuildPaths(rootPaths: TsconfigPaths): TsconfigPaths;
   deriveDesktopPaths(rootPaths: TsconfigPaths): TsconfigPaths;
   deriveExtensionPaths(rootPaths: TsconfigPaths): TsconfigPaths;
   EXTENSION_EXCLUDED_ALIASES: readonly string[];
@@ -17,6 +18,7 @@ interface AliasUtilsModule {
 
 const rootDir = fileURLToPath(new URL('../../../', import.meta.url));
 const {
+  deriveBuildPaths,
   deriveDesktopPaths,
   deriveExtensionPaths,
   EXTENSION_EXCLUDED_ALIASES,
@@ -81,6 +83,16 @@ describe('generated tsconfig paths match the committed copies', () => {
   // `npm run check:tsconfig-paths`; this test gives the same signal in the
   // normal `npm test` loop).
   const rootPaths = loadRootPaths(rootDir);
+
+  it('tsconfig.build.json paths derive from the root map', () => {
+    const committed = JSON.parse(
+      readFileSync(resolve(rootDir, 'tsconfig.build.json'), 'utf8'),
+    );
+
+    expect(committed.compilerOptions.paths).toEqual(
+      deriveBuildPaths(rootPaths),
+    );
+  });
 
   it('packages/extension/tsconfig.json paths derive from the root map', () => {
     const committed = JSON.parse(


### PR DESCRIPTION
## Summary

- add `tsconfig.build.json` to the generated-alias regression suite
- derive the expected declaration-build map from the root `tsconfig.json`, matching the synchronization command

## Validation

- `pnpm vitest run src/test-kernel/scripts/AliasMapGeneration.vitest.ts` (11 tests)
- Prettier check
- changed-file lint through the pre-push hook
- `git diff --check`

## Context

This closes the local-test coverage gap identified in the exact-head review of #9539. The CI synchronization gate already covered the build map; this change gives the ordinary test loop the same regression signal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime or build behavior modifications.
> 
> **Overview**
> Extends the **generated tsconfig paths** regression suite so the normal `npm test` loop also verifies **`tsconfig.build.json`**.
> 
> A new case reads the committed `compilerOptions.paths` and asserts they equal **`deriveBuildPaths(loadRootPaths(...))`**, the same derivation used by the tsconfig-paths sync/CI check. The test module’s typings and imports now include **`deriveBuildPaths`** alongside the existing extension/desktop guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fd53f5fddd3151ba3cda16fae7b3f77c374bf38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->