### PR TITLE
fix(runtime): share waiting repair results

### DIFF
--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -169,8 +169,11 @@ export class SessionHandle {
    */
   readonly workflowControls: WorkflowControlRegistry;
   private restartRepairPromise: Promise<unknown> | undefined;
-  /** Streams with a {@link repairWaitingIfResumable} probe already in flight. */
-  private readonly waitingRepairProbes = new Set<StreamTabId>();
+  /** Per-stream {@link repairWaitingIfResumable} result currently in flight. */
+  private readonly waitingRepairProbes = new Map<
+    StreamTabId,
+    Promise<boolean>
+  >();
   private readonly restartRepairQueue = new PQueue({ concurrency: 1 });
   private readonly restartRepairRetry = new RestartRepairRetryScheduler();
   private readonly restartRepairAbort = new AbortController();
@@ -309,31 +312,43 @@ export class SessionHandle {
     const phase = this.status.get(streamId);
     if (phase === STREAM_PHASE.WAITING) return true;
     if (isInFlightPhase(phase)) return false;
-    if (this.waitingRepairProbes.has(streamId)) return false;
+
+    const inFlight = this.waitingRepairProbes.get(streamId);
+    if (inFlight) return inFlight;
 
     const executionId = this.snapshots.getExecutionId(streamId);
     if (!executionId) return false;
 
-    this.waitingRepairProbes.add(streamId);
+    const probe = this.probeWaitingRepair(streamId, executionId);
+    this.waitingRepairProbes.set(streamId, probe);
     try {
-      const resumability = await deriveResumability(executionId);
-      if (!resumability.resumable) return false;
-      const repaired = this.status.transitionToWaiting(
-        streamId,
-        STREAM_TRANSITION_CAUSE.RESTART_REPAIR,
-        { trace: logger },
-      );
-      if (repaired) {
-        logger.debug(`Stream ${streamId} restored to WAITING before follow-up`);
-      } else {
-        logger.warn(
-          `Failed to restore resumable stream ${streamId} to WAITING before follow-up`,
-        );
-      }
-      return repaired;
+      return await probe;
     } finally {
-      this.waitingRepairProbes.delete(streamId);
+      if (this.waitingRepairProbes.get(streamId) === probe) {
+        this.waitingRepairProbes.delete(streamId);
+      }
     }
+  }
+
+  private async probeWaitingRepair(
+    streamId: StreamTabId,
+    executionId: string,
+  ): Promise<boolean> {
+    const resumability = await deriveResumability(executionId);
+    if (!resumability.resumable) return false;
+    const repaired = this.status.transitionToWaiting(
+      streamId,
+      STREAM_TRANSITION_CAUSE.RESTART_REPAIR,
+      { trace: logger },
+    );
+    if (repaired) {
+      logger.debug(`Stream ${streamId} restored to WAITING before follow-up`);
+    } else {
+      logger.warn(
+        `Failed to restore resumable stream ${streamId} to WAITING before follow-up`,
+      );
+    }
+    return repaired;
   }
 
   private enqueueRestartRepair<T>(work: () => Promise<T>): Promise<T> {

--- a/src/test-kernel/agent/runtime/SessionWaitingRepair.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionWaitingRepair.vitest.ts
@@ -135,11 +135,10 @@ describe('SessionHandle.repairWaitingIfResumable', () => {
     const first = session.repairWaitingIfResumable(streamId);
     const second = session.repairWaitingIfResumable(streamId);
 
-    await expect(second).resolves.toBe(false);
     expect(resumabilityMocks.deriveResumability).toHaveBeenCalledTimes(1);
 
     release?.();
-    await expect(first).resolves.toBe(true);
+    await expect(Promise.all([first, second])).resolves.toEqual([true, true]);
     expect(session.status.get(streamId)).toBe(STREAM_PHASE.WAITING);
 
     // The slot is released with the probe, so a later submission probes again.

--- a/src/test-kernel/commands/agent/FollowUpCommandWaitingRepair.vitest.ts
+++ b/src/test-kernel/commands/agent/FollowUpCommandWaitingRepair.vitest.ts
@@ -1,0 +1,98 @@
+// Test composition imports
+import '@test/support/defaultSessionTestSetup';
+
+// Third-party imports
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  deriveResumability: vi.fn(),
+  handler: undefined as ((payload: unknown) => Promise<void>) | undefined,
+  submitFollowUp: vi.fn(),
+}));
+
+vi.mock('@agent/storage/resumability', () => ({
+  deriveResumability: mocks.deriveResumability,
+}));
+vi.mock('@agent/followUp/ToolUseFollowUp', () => ({
+  presentFollowUpResult: vi.fn(),
+  submitFollowUp: mocks.submitFollowUp,
+}));
+vi.mock('@commands/_shared/registerCommands', () => ({
+  registerCommands: (
+    _context: unknown,
+    entries: Array<{
+      id: string;
+      handler: (payload: unknown) => Promise<void>;
+    }>,
+  ) => {
+    mocks.handler = entries.find(
+      ({ id }) => id === 'texra.sendFollowUp',
+    )?.handler;
+  },
+}));
+
+// Local imports
+import { AgentCategory } from '@agent/core/definition/AgentDataclass';
+import { defaultSession } from '@agent/runtime/SessionHandle';
+import { registerFollowUpCommand } from '@commands/agent/followUpCommand';
+import {
+  buildRunDescriptor,
+  STREAM_PHASE,
+  type ExecutionId,
+  type StreamTabId,
+} from '@shared/schemas';
+
+const STREAM = 'stream:concurrent-waiting-repair' as StreamTabId;
+const EXECUTION = 'babcde' as ExecutionId;
+
+describe('texra.sendFollowUp waiting repair admission', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.handler = undefined;
+    registerFollowUpCommand({ subscriptions: [] } as never);
+
+    const session = defaultSession();
+    session.snapshots.setRunDescriptor(
+      buildRunDescriptor({
+        streamId: STREAM,
+        executionId: EXECUTION,
+        agent: 'assistant',
+        category: AgentCategory.ToolUse,
+        kind: 'agent',
+      }),
+    );
+    session.status.transition(STREAM, STREAM_PHASE.RUNNING, 'lifecycle');
+    session.status.transition(STREAM, STREAM_PHASE.CANCELLED, 'user-stop');
+  });
+
+  it('admits two concurrent submissions in order after one repair probe', async () => {
+    let release: (() => void) | undefined;
+    mocks.deriveResumability.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          release = () =>
+            resolve({ resumable: true, cause: 'interrupted-with-flow' });
+        }),
+    );
+    const admitted: string[] = [];
+    mocks.submitFollowUp.mockImplementation(
+      async (_streamId: StreamTabId, input: { text: string }) => {
+        admitted.push(input.text);
+        return { status: 'sent' };
+      },
+    );
+
+    const first = mocks.handler?.({ stream: STREAM, text: 'first' });
+    const second = mocks.handler?.({ stream: STREAM, text: 'second' });
+
+    expect(mocks.deriveResumability).toHaveBeenCalledTimes(1);
+    expect(mocks.submitFollowUp).not.toHaveBeenCalled();
+
+    release?.();
+    await Promise.all([first, second]);
+
+    expect(admitted).toEqual(['first', 'second']);
+    expect(mocks.submitFollowUp).toHaveBeenCalledTimes(2);
+    expect(defaultSession().status.get(STREAM)).toBe(STREAM_PHASE.WAITING);
+  });
+});


### PR DESCRIPTION
## Summary

- replace the per-stream waiting-repair `Set` with the in-flight `Promise<boolean>` for that stream
- make concurrent callers await the same repair verdict instead of treating the second submission as immediately unrepaired
- preserve probe cleanup after success, false results, and rejection so a later submission can retry
- add runtime and extension-command regressions proving two concurrent follow-ups trigger one probe and are admitted in submission order only after repair

## Compatibility boundary

This preserves the restart/follow-up admission boundary: a persisted resumable execution must be restored to `WAITING` before any concurrent `texra.sendFollowUp` submission reaches `submitFollowUp`. It does not change resumability detection, stream transition rules, or later retry behavior.

This is a focused follow-up to #9547; it corrects the concurrency behavior of the lazy waiting repair introduced there without redesigning session repair.

## Validation

- `env -u FORCE_COLOR npx vitest run --config vitest.config.mjs src/test-kernel/agent/runtime/SessionWaitingRepair.vitest.ts src/test-kernel/commands/agent/FollowUpCommandWaitingRepair.vitest.ts` — 2 files, 7 tests passed
- `npm run typecheck` — passed all workspace/package typechecks
- `npm run lint` — passed
- changed-file Prettier check — passed
- `git diff --check` — passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches follow-up admission and stream phase transitions before submitFollowUp; behavior change is narrow but affects concurrent restart-repair paths.
> 
> **Overview**
> Fixes a concurrency bug in **`repairWaitingIfResumable`**: a second concurrent caller no longer gets an immediate `false` while the first probe is still running.
> 
> **`SessionHandle`** now tracks per-stream in-flight repair work as a **`Promise<boolean>`** (replacing a presence-only `Set`). Later callers **await the same probe**; resumability is still read once per stream. Probe logic moves into **`probeWaitingRepair`**, with map cleanup keyed to the specific promise so a later submission can retry after success, failure, or rejection.
> 
> Tests expect both concurrent repairs to resolve **`true`** when sharing one probe, and a new **`texra.sendFollowUp`** regression confirms two concurrent follow-ups trigger **one** `deriveResumability` call and reach **`submitFollowUp`** in submission order after the stream is restored to **`WAITING`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea3ed0ffae877ac9685ebb20c5ab79603b2cfec5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->