### PR TITLE
docs: rule ModelCell ownership authoritative

### DIFF
--- a/docs/dev/audits/2026-07-25-agent-sdk-readiness-audit.md
+++ b/docs/dev/audits/2026-07-25-agent-sdk-readiness-audit.md
@@ -25,8 +25,11 @@ historical context and this one as the post-retirement snapshot.
 > boundaries enforced by ratchet tests rather than a package fence. This audit does
 > **not** reopen those proposals. `RunDescriptor` (frozen-injection), `ModelCell`,
 > `PendingRequests`, `RetryPolicy`/`RetryGate`, and `HostUiBus` remain retired and
-> must not be implemented from this record. The findings below are the residue that
-> the lighter path leaves, nothing more.
+> must not be implemented from this record. The later
+> [narrow ModelCell ownership ruling](../../proposals/2026-08-01-architecture-rulings-ledger.md#modelcell--current-ownership-ruling-supersedes-only-the-retired-prohibition)
+> governs only the current primitive on `main`; it does not revive these proposals
+> or make their other retired designs authoritative. The findings below are the
+> residue that the lighter path leaves, nothing more.
 
 ## Headline
 
@@ -256,7 +259,10 @@ Clean and well-factored; the only defect is finding #2 above.
 ## What is explicitly _not_ worth doing
 
 - Don't resurrect the retired package-fence / `RunDescriptor` / `ModelCell` /
-  `RetryGate` proposals — `main` chose the lighter path on purpose.
+  `RetryGate` proposals — `main` chose the lighter path on purpose. The current
+  `ModelCell` primitive is governed only by the
+  [narrow ownership ruling](../../proposals/2026-08-01-architecture-rulings-ledger.md#modelcell--current-ownership-ruling-supersedes-only-the-retired-prohibition),
+  which does not revive those proposals.
 - Don't invent new abstractions or split the runtime directory — the flat
   `runtime/` layout is a documented, deliberate choice (~180 call sites import
   specific files; a directory split is mechanical churn, not a refactor).

--- a/docs/dev/audits/2026-07-25-agent-sdk-readiness-audit.md
+++ b/docs/dev/audits/2026-07-25-agent-sdk-readiness-audit.md
@@ -31,7 +31,7 @@ historical context and this one as the post-retirement snapshot.
 > or make their other retired designs authoritative. The findings below are the
 > residue that the lighter path leaves, nothing more.
 
-[modelcell-ownership-ruling]: ../../proposals/2026-08-01-architecture-rulings-ledger.md
+[modelcell-ownership-ruling]: ../../proposals/2026-08-01-architecture-rulings-ledger.md#modelcell
 
 ## Headline
 

--- a/docs/dev/audits/2026-07-25-agent-sdk-readiness-audit.md
+++ b/docs/dev/audits/2026-07-25-agent-sdk-readiness-audit.md
@@ -26,7 +26,7 @@ historical context and this one as the post-retirement snapshot.
 > **not** reopen those proposals. `RunDescriptor` (frozen-injection), `ModelCell`,
 > `PendingRequests`, `RetryPolicy`/`RetryGate`, and `HostUiBus` remain retired and
 > must not be implemented from this record. The later
-> [narrow ModelCell ownership ruling](../../proposals/2026-08-01-architecture-rulings-ledger.md#modelcell--current-ownership-ruling-supersedes-only-the-retired-prohibition)
+> [ModelCell ruling](../../proposals/2026-08-01-architecture-rulings-ledger.md#modelcell)
 > governs only the current primitive on `main`; it does not revive these proposals
 > or make their other retired designs authoritative. The findings below are the
 > residue that the lighter path leaves, nothing more.
@@ -261,7 +261,7 @@ Clean and well-factored; the only defect is finding #2 above.
 - Don't resurrect the retired package-fence / `RunDescriptor` / `ModelCell` /
   `RetryGate` proposals — `main` chose the lighter path on purpose. The current
   `ModelCell` primitive is governed only by the
-  [narrow ownership ruling](../../proposals/2026-08-01-architecture-rulings-ledger.md#modelcell--current-ownership-ruling-supersedes-only-the-retired-prohibition),
+  [narrow ownership ruling](../../proposals/2026-08-01-architecture-rulings-ledger.md#modelcell),
   which does not revive those proposals.
 - Don't invent new abstractions or split the runtime directory — the flat
   `runtime/` layout is a documented, deliberate choice (~180 call sites import

--- a/docs/dev/audits/2026-07-25-agent-sdk-readiness-audit.md
+++ b/docs/dev/audits/2026-07-25-agent-sdk-readiness-audit.md
@@ -26,10 +26,12 @@ historical context and this one as the post-retirement snapshot.
 > **not** reopen those proposals. `RunDescriptor` (frozen-injection), `ModelCell`,
 > `PendingRequests`, `RetryPolicy`/`RetryGate`, and `HostUiBus` remain retired and
 > must not be implemented from this record. The later
-> [ModelCell ruling](../../proposals/2026-08-01-architecture-rulings-ledger.md#modelcell)
+> [narrow ModelCell ownership ruling][modelcell-ownership-ruling]
 > governs only the current primitive on `main`; it does not revive these proposals
 > or make their other retired designs authoritative. The findings below are the
 > residue that the lighter path leaves, nothing more.
+
+[modelcell-ownership-ruling]: ../../proposals/2026-08-01-architecture-rulings-ledger.md
 
 ## Headline
 
@@ -261,7 +263,7 @@ Clean and well-factored; the only defect is finding #2 above.
 - Don't resurrect the retired package-fence / `RunDescriptor` / `ModelCell` /
   `RetryGate` proposals — `main` chose the lighter path on purpose. The current
   `ModelCell` primitive is governed only by the
-  [narrow ownership ruling](../../proposals/2026-08-01-architecture-rulings-ledger.md#modelcell),
+  [narrow ownership ruling][modelcell-ownership-ruling],
   which does not revive those proposals.
 - Don't invent new abstractions or split the runtime directory — the flat
   `runtime/` layout is a documented, deliberate choice (~180 call sites import

--- a/docs/prds/2026-06-27-prd-runtime-host-decoupling.md
+++ b/docs/prds/2026-06-27-prd-runtime-host-decoupling.md
@@ -16,7 +16,7 @@ updated: 2026-08-01
 > frozen `RunDescriptor` injection model, `ModelCell`, `PendingRequests`,
 > `RetryPolicy`, `RetryGate`, and `HostUiBus` are retired and must not be
 > implemented from this record. The later
-> [ModelCell ruling](../proposals/2026-08-01-architecture-rulings-ledger.md#modelcell)
+> [narrow ModelCell ownership ruling][modelcell-ownership-ruling]
 > governs only the current primitive on `main`; it does not revive this proposal
 > or make its other retired designs authoritative. The `RunDescriptor` name on
 > `main` denotes the
@@ -32,6 +32,7 @@ updated: 2026-08-01
 [#7624]: https://github.com/LionSR/TeXRA/pull/7624
 [#7914]: https://github.com/LionSR/TeXRA/pull/7914
 [#8322]: https://github.com/LionSR/TeXRA/pull/8322
+[modelcell-ownership-ruling]: ../proposals/2026-08-01-architecture-rulings-ledger.md
 
 ## Overview
 

--- a/docs/prds/2026-06-27-prd-runtime-host-decoupling.md
+++ b/docs/prds/2026-06-27-prd-runtime-host-decoupling.md
@@ -32,7 +32,7 @@ updated: 2026-08-01
 [#7624]: https://github.com/LionSR/TeXRA/pull/7624
 [#7914]: https://github.com/LionSR/TeXRA/pull/7914
 [#8322]: https://github.com/LionSR/TeXRA/pull/8322
-[modelcell-ownership-ruling]: ../proposals/2026-08-01-architecture-rulings-ledger.md
+[modelcell-ownership-ruling]: ../proposals/2026-08-01-architecture-rulings-ledger.md#modelcell
 
 ## Overview
 

--- a/docs/prds/2026-06-27-prd-runtime-host-decoupling.md
+++ b/docs/prds/2026-06-27-prd-runtime-host-decoupling.md
@@ -15,7 +15,11 @@ updated: 2026-07-18
 > ratchet tests and centralized baselines in [#7914] and [#8322]. The proposed
 > frozen `RunDescriptor` injection model, `ModelCell`, `PendingRequests`,
 > `RetryPolicy`, `RetryGate`, and `HostUiBus` are retired and must not be
-> implemented from this record. The `RunDescriptor` name on `main` denotes the
+> implemented from this record. The later
+> [narrow ModelCell ownership ruling](../proposals/2026-08-01-architecture-rulings-ledger.md#modelcell--current-ownership-ruling-supersedes-only-the-retired-prohibition)
+> governs only the current primitive on `main`; it does not revive this proposal
+> or make its other retired designs authoritative. The `RunDescriptor` name on
+> `main` denotes the
 > unrelated persisted stream schema introduced in [#7164].
 
 [#7164]: https://github.com/LionSR/TeXRA/pull/7164

--- a/docs/prds/2026-06-27-prd-runtime-host-decoupling.md
+++ b/docs/prds/2026-06-27-prd-runtime-host-decoupling.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-06-27
-updated: 2026-07-18
+updated: 2026-08-01
 ---
 
 # PRD: Runtime/Host Decoupling by Deep Modules
@@ -16,7 +16,7 @@ updated: 2026-07-18
 > frozen `RunDescriptor` injection model, `ModelCell`, `PendingRequests`,
 > `RetryPolicy`, `RetryGate`, and `HostUiBus` are retired and must not be
 > implemented from this record. The later
-> [narrow ModelCell ownership ruling](../proposals/2026-08-01-architecture-rulings-ledger.md#modelcell--current-ownership-ruling-supersedes-only-the-retired-prohibition)
+> [ModelCell ruling](../proposals/2026-08-01-architecture-rulings-ledger.md#modelcell)
 > governs only the current primitive on `main`; it does not revive this proposal
 > or make its other retired designs authoritative. The `RunDescriptor` name on
 > `main` denotes the

--- a/docs/prds/2026-06-29-prd-agent-sdk-boundary.md
+++ b/docs/prds/2026-06-29-prd-agent-sdk-boundary.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-06-29
-updated: 2026-07-18
+updated: 2026-08-01
 ---
 
 # PRD: The Agent-SDK Boundary - Publishing the Runtime the UIs Sit On
@@ -16,7 +16,7 @@ updated: 2026-07-18
 > package fence. The proposed frozen `RunDescriptor` injection model,
 > `ModelCell`, `PendingRequests`, `RetryPolicy`, `RetryGate`, and `HostUiBus` are
 > retired and must not be implemented from this record. The later
-> [narrow ModelCell ownership ruling](../proposals/2026-08-01-architecture-rulings-ledger.md#modelcell--current-ownership-ruling-supersedes-only-the-retired-prohibition)
+> [ModelCell ruling](../proposals/2026-08-01-architecture-rulings-ledger.md#modelcell)
 > governs only the current primitive on `main`; it does not revive this proposal
 > or make its other retired designs authoritative. The `RunDescriptor` name
 > on `main` denotes the unrelated persisted stream schema introduced in [#7164].

--- a/docs/prds/2026-06-29-prd-agent-sdk-boundary.md
+++ b/docs/prds/2026-06-29-prd-agent-sdk-boundary.md
@@ -15,7 +15,10 @@ updated: 2026-07-18
 > ratchet tests and centralized baselines in [#7914] and [#8322] rather than a
 > package fence. The proposed frozen `RunDescriptor` injection model,
 > `ModelCell`, `PendingRequests`, `RetryPolicy`, `RetryGate`, and `HostUiBus` are
-> retired and must not be implemented from this record. The `RunDescriptor` name
+> retired and must not be implemented from this record. The later
+> [narrow ModelCell ownership ruling](../proposals/2026-08-01-architecture-rulings-ledger.md#modelcell--current-ownership-ruling-supersedes-only-the-retired-prohibition)
+> governs only the current primitive on `main`; it does not revive this proposal
+> or make its other retired designs authoritative. The `RunDescriptor` name
 > on `main` denotes the unrelated persisted stream schema introduced in [#7164].
 > The companion `2026-06-28-prd-architecture-patterns.md` record remains only on
 > the source branch and is not part of this extraction; references to it below

--- a/docs/prds/2026-06-29-prd-agent-sdk-boundary.md
+++ b/docs/prds/2026-06-29-prd-agent-sdk-boundary.md
@@ -34,7 +34,7 @@ updated: 2026-08-01
 [#7624]: https://github.com/LionSR/TeXRA/pull/7624
 [#7914]: https://github.com/LionSR/TeXRA/pull/7914
 [#8322]: https://github.com/LionSR/TeXRA/pull/8322
-[modelcell-ownership-ruling]: ../proposals/2026-08-01-architecture-rulings-ledger.md
+[modelcell-ownership-ruling]: ../proposals/2026-08-01-architecture-rulings-ledger.md#modelcell
 
 Decided by an adversarial design pass (3 designs x 2 lenses, 2026-06-29). This is
 the **published boundary** of the gold-standard runtime core

--- a/docs/prds/2026-06-29-prd-agent-sdk-boundary.md
+++ b/docs/prds/2026-06-29-prd-agent-sdk-boundary.md
@@ -16,7 +16,7 @@ updated: 2026-08-01
 > package fence. The proposed frozen `RunDescriptor` injection model,
 > `ModelCell`, `PendingRequests`, `RetryPolicy`, `RetryGate`, and `HostUiBus` are
 > retired and must not be implemented from this record. The later
-> [ModelCell ruling](../proposals/2026-08-01-architecture-rulings-ledger.md#modelcell)
+> [narrow ModelCell ownership ruling][modelcell-ownership-ruling]
 > governs only the current primitive on `main`; it does not revive this proposal
 > or make its other retired designs authoritative. The `RunDescriptor` name
 > on `main` denotes the unrelated persisted stream schema introduced in [#7164].
@@ -34,6 +34,7 @@ updated: 2026-08-01
 [#7624]: https://github.com/LionSR/TeXRA/pull/7624
 [#7914]: https://github.com/LionSR/TeXRA/pull/7914
 [#8322]: https://github.com/LionSR/TeXRA/pull/8322
+[modelcell-ownership-ruling]: ../proposals/2026-08-01-architecture-rulings-ledger.md
 
 Decided by an adversarial design pass (3 designs x 2 lenses, 2026-06-29). This is
 the **published boundary** of the gold-standard runtime core

--- a/docs/prds/2026-06-29-prd-runtime-gold-standard.md
+++ b/docs/prds/2026-06-29-prd-runtime-gold-standard.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-06-29
-updated: 2026-07-18
+updated: 2026-08-01
 ---
 
 # PRD: Runtime Gold-Standard - The SDK Core (PocketFlow / Lifecycle / Injection / Retry)
@@ -15,7 +15,7 @@ updated: 2026-07-18
 > centralized baselines in [#7914] and [#8322]. The proposed frozen
 > `RunDescriptor` injection model, `ModelCell`, `PendingRequests`, `RetryPolicy`,
 > `RetryGate`, and `HostUiBus` are retired and must not be implemented from this
-> record. The later [narrow ModelCell ownership ruling](../proposals/2026-08-01-architecture-rulings-ledger.md#modelcell--current-ownership-ruling-supersedes-only-the-retired-prohibition)
+> record. The later [ModelCell ruling](../proposals/2026-08-01-architecture-rulings-ledger.md#modelcell)
 > supersedes only this prohibition's claim that no `ModelCell` exists on `main`;
 > it does not revive this PRD. The `RunDescriptor` name on `main` denotes the
 > unrelated persisted stream schema introduced in [#7164].

--- a/docs/prds/2026-06-29-prd-runtime-gold-standard.md
+++ b/docs/prds/2026-06-29-prd-runtime-gold-standard.md
@@ -15,7 +15,7 @@ updated: 2026-08-01
 > centralized baselines in [#7914] and [#8322]. The proposed frozen
 > `RunDescriptor` injection model, `ModelCell`, `PendingRequests`, `RetryPolicy`,
 > `RetryGate`, and `HostUiBus` are retired and must not be implemented from this
-> record. The later [ModelCell ruling](../proposals/2026-08-01-architecture-rulings-ledger.md#modelcell)
+> record. The later [narrow ModelCell ownership ruling][modelcell-ownership-ruling]
 > supersedes only this prohibition's claim that no `ModelCell` exists on `main`;
 > it does not revive this PRD. The `RunDescriptor` name on `main` denotes the
 > unrelated persisted stream schema introduced in [#7164].
@@ -34,6 +34,7 @@ updated: 2026-08-01
 [#7624]: https://github.com/LionSR/TeXRA/pull/7624
 [#7914]: https://github.com/LionSR/TeXRA/pull/7914
 [#8322]: https://github.com/LionSR/TeXRA/pull/8322
+[modelcell-ownership-ruling]: ../proposals/2026-08-01-architecture-rulings-ledger.md
 
 Decided by an adversarial design pass (4 designs x 3 lenses x 4 phases,
 2026-06-29). This is the gold-standard target for TeXRA's agent runtime core: the

--- a/docs/prds/2026-06-29-prd-runtime-gold-standard.md
+++ b/docs/prds/2026-06-29-prd-runtime-gold-standard.md
@@ -34,7 +34,7 @@ updated: 2026-08-01
 [#7624]: https://github.com/LionSR/TeXRA/pull/7624
 [#7914]: https://github.com/LionSR/TeXRA/pull/7914
 [#8322]: https://github.com/LionSR/TeXRA/pull/8322
-[modelcell-ownership-ruling]: ../proposals/2026-08-01-architecture-rulings-ledger.md
+[modelcell-ownership-ruling]: ../proposals/2026-08-01-architecture-rulings-ledger.md#modelcell
 
 Decided by an adversarial design pass (4 designs x 3 lenses x 4 phases,
 2026-06-29). This is the gold-standard target for TeXRA's agent runtime core: the

--- a/docs/prds/2026-06-29-prd-runtime-gold-standard.md
+++ b/docs/prds/2026-06-29-prd-runtime-gold-standard.md
@@ -15,8 +15,10 @@ updated: 2026-07-18
 > centralized baselines in [#7914] and [#8322]. The proposed frozen
 > `RunDescriptor` injection model, `ModelCell`, `PendingRequests`, `RetryPolicy`,
 > `RetryGate`, and `HostUiBus` are retired and must not be implemented from this
-> record. The `RunDescriptor` name on `main` denotes the unrelated persisted
-> stream schema introduced in [#7164].
+> record. The later [narrow ModelCell ownership ruling](../proposals/2026-08-01-architecture-rulings-ledger.md#modelcell--current-ownership-ruling-supersedes-only-the-retired-prohibition)
+> supersedes only this prohibition's claim that no `ModelCell` exists on `main`;
+> it does not revive this PRD. The `RunDescriptor` name on `main` denotes the
+> unrelated persisted stream schema introduced in [#7164].
 > The companion `2026-06-28-prd-architecture-patterns.md` and
 > `cross-host-consolidation/` records remain only on the source branch and are
 > not part of this extraction; references to them below are historical context,

--- a/docs/proposals/2026-08-01-architecture-rulings-ledger.md
+++ b/docs/proposals/2026-08-01-architecture-rulings-ledger.md
@@ -92,7 +92,7 @@ it the assert is knowingly wrong for `LogList`.
 
 ---
 
-## ModelCell — current ownership ruling supersedes only the retired prohibition
+## ModelCell
 
 **Question.** Does the retired runtime gold-standard PRD's statement that
 `ModelCell` “must not be implemented from this record” still prohibit the

--- a/docs/proposals/2026-08-01-architecture-rulings-ledger.md
+++ b/docs/proposals/2026-08-01-architecture-rulings-ledger.md
@@ -138,9 +138,11 @@ approve its `PendingRequests`, `RetryPolicy`, `RetryGate`, `HostUiBus`, stage
 sequence, or concept-count claims. Those passages remain historical.
 
 **Implementation evidence.** The accepted behavior is defined by
-`src/agent/runtime/ModelCell.ts`, `AgentLaunchContext.ts`,
-`AgentRunLifecycle.ts`, `SessionResumeRetrieval.ts`, `executeAgent.ts`, and the
-model-switch path in
+`src/agent/runtime/ModelCell.ts`,
+`src/agent/runtime/AgentLaunchContext.ts`,
+`src/agent/runtime/AgentRunLifecycle.ts`,
+`src/agent/runtime/SessionResumeRetrieval.ts`,
+`src/agent/runtime/executeAgent.ts`, and the model-switch path in
 `src/agent/implementations/flows/tooluse/runToolUseFlow.ts`.
 
 **Test evidence.** The focused coverage is in

--- a/docs/proposals/2026-08-01-architecture-rulings-ledger.md
+++ b/docs/proposals/2026-08-01-architecture-rulings-ledger.md
@@ -101,8 +101,9 @@ it the assert is knowingly wrong for `LogList`.
 **Ruling.** No. The implementation merged in
 [#9547](https://github.com/LionSR/TeXRA/pull/9547) is authoritative for the
 narrow ownership and lifecycle guarantees below. It supersedes the retired
-PRD's [top-level prohibition](../prds/2026-06-29-prd-runtime-gold-standard.md#L8-L19)
-and [§2 ModelCell text](../prds/2026-06-29-prd-runtime-gold-standard.md#2-modelcell-the-one-mutable-seam)
+PRD's top-level [historical-status clause](../prds/2026-06-29-prd-runtime-gold-standard.md),
+which says the listed designs “must not be implemented from this record,” and
+its [§2 ModelCell text](../prds/2026-06-29-prd-runtime-gold-standard.md#2-modelcell-the-one-mutable-seam)
 only where those passages deny that this primitive exists on `main`.
 
 **Current guarantees.** The code, rather than the retired design, defines the
@@ -122,13 +123,31 @@ accepted shape:
   identity.
 - The run lifecycle calls `ModelCell.dispose()` in its `finally` path. Thus the
   cell disposes handlers retired by successful swaps and the handler still live
-  when the run ends; failed replacement handlers are disposed before ownership
-  can transfer to the cell.
+  when the run ends. In the tool-use switch path, the runtime explicitly
+  disposes a replacement candidate before ownership transfer only when the
+  conversation-format check rejects it or either persistence write fails. This
+  is not a blanket guarantee for exceptions from compatibility inspection,
+  `setAgentCategory`, or `setLogger`. On success, `ModelCell.swap` adopts the
+  replacement before disposing the distinct handler it retires.
 
 **Scope of supersession.** This ruling does **not** revive the retired PRD as a
 plan, make its unmerged `RunDescriptor` injection program authoritative, or
 approve its `PendingRequests`, `RetryPolicy`, `RetryGate`, `HostUiBus`, stage
-sequence, or concept-count claims. Those passages remain historical. Future
-changes to model ownership must be justified against the current implementation
-and tests in `src/agent/runtime/ModelCell.ts`, not by treating the retired
-gold-standard program as normative.
+sequence, or concept-count claims. Those passages remain historical.
+
+**Implementation evidence.** The accepted behavior is defined by
+`src/agent/runtime/ModelCell.ts`, `AgentLaunchContext.ts`,
+`AgentRunLifecycle.ts`, `SessionResumeRetrieval.ts`, `executeAgent.ts`, and the
+model-switch path in
+`src/agent/implementations/flows/tooluse/runToolUseFlow.ts`.
+
+**Test evidence.** The focused coverage is in
+`src/test-kernel/agent/runtime/ModelCell.vitest.ts`,
+`src/test-kernel/agent/runtime/AgentRunLifecycle.vitest.ts`,
+`src/test-kernel/agent/SessionResumeRetrieval.vitest.ts`,
+`src/test-kernel/agent/runtime/ResumeToolUseCancellation.vitest.ts`, and
+`src/test-kernel/agent/followUp/ModelSwitchState.vitest.ts`.
+
+Future changes to model ownership must be justified against that current
+implementation and test coverage, not by treating the retired gold-standard
+program as normative.

--- a/docs/proposals/2026-08-01-architecture-rulings-ledger.md
+++ b/docs/proposals/2026-08-01-architecture-rulings-ledger.md
@@ -89,3 +89,46 @@ helper.
 **What this forbids.** Do not file the registry again. Do not land a
 construction-time duplicate-key assert without the disposal path above; without
 it the assert is knowingly wrong for `LogList`.
+
+---
+
+## ModelCell — current ownership ruling supersedes only the retired prohibition
+
+**Question.** Does the retired runtime gold-standard PRD's statement that
+`ModelCell` “must not be implemented from this record” still prohibit the
+`ModelCell` ownership primitive now present on `main`?
+
+**Ruling.** No. The implementation merged in
+[#9547](https://github.com/LionSR/TeXRA/pull/9547) is authoritative for the
+narrow ownership and lifecycle guarantees below. It supersedes the retired
+PRD's [top-level prohibition](../prds/2026-06-29-prd-runtime-gold-standard.md#L8-L19)
+and [§2 ModelCell text](../prds/2026-06-29-prd-runtime-gold-standard.md#2-modelcell-the-one-mutable-seam)
+only where those passages deny that this primitive exists on `main`.
+
+**Current guarantees.** The code, rather than the retired design, defines the
+accepted shape:
+
+- `AgentLaunchContext` constructs one `ModelCell` for the run from its launch
+  handler and model id. Flow services and the tool-facing run context share that
+  cell instead of copying a live handler/client pair.
+- `ModelCell.swap` synchronously adopts the replacement handler and model id,
+  clears the cached client, and disposes the distinct handler it retires. A
+  lazily built client is reused until `rebind` or `swap`; build and rebind
+  completion guards prevent a client produced for a retired handler from being
+  published as current.
+- A tool-use model switch persists `shared.modelId` and the run config before
+  the live swap, then updates the launch-context mirrors through
+  `onModelChanged`. Resume reconstructs the handler from that persisted model
+  identity.
+- The run lifecycle calls `ModelCell.dispose()` in its `finally` path. Thus the
+  cell disposes handlers retired by successful swaps and the handler still live
+  when the run ends; failed replacement handlers are disposed before ownership
+  can transfer to the cell.
+
+**Scope of supersession.** This ruling does **not** revive the retired PRD as a
+plan, make its unmerged `RunDescriptor` injection program authoritative, or
+approve its `PendingRequests`, `RetryPolicy`, `RetryGate`, `HostUiBus`, stage
+sequence, or concept-count claims. Those passages remain historical. Future
+changes to model ownership must be justified against the current implementation
+and tests in `src/agent/runtime/ModelCell.ts`, not by treating the retired
+gold-standard program as normative.

--- a/docs/proposals/2026-08-01-architecture-rulings-ledger.md
+++ b/docs/proposals/2026-08-01-architecture-rulings-ledger.md
@@ -92,7 +92,7 @@ it the assert is knowingly wrong for `LogList`.
 
 ---
 
-## ModelCell
+## ModelCell — current ownership ruling supersedes only the retired prohibition
 
 **Question.** Does the retired runtime gold-standard PRD's statement that
 `ModelCell` “must not be implemented from this record” still prohibit the

--- a/docs/proposals/2026-08-01-architecture-rulings-ledger.md
+++ b/docs/proposals/2026-08-01-architecture-rulings-ledger.md
@@ -92,6 +92,8 @@ it the assert is knowingly wrong for `LogList`.
 
 ---
 
+<a id="modelcell"></a>
+
 ## ModelCell — current ownership ruling supersedes only the retired prohibition
 
 **Question.** Does the retired runtime gold-standard PRD's statement that


### PR DESCRIPTION
## Summary

- add a current architecture ruling for the exact `ModelCell` ownership and lifecycle guarantees merged on `main`
- link the retired PRD's prohibition and §2 text as superseded only where they deny the current primitive
- add a reciprocal pointer from the retired status note to the narrow ruling
- explicitly keep the rest of the retired gold-standard program historical and non-authoritative

## Compatibility boundary

This is documentation-only. The boundary being clarified is architectural compatibility between current `ModelCell` handler/client/model ownership and the retired 2026-06-29 PRD. It changes no runtime, persistence, resume, model-switch, or disposal behavior.

This is a focused documentation follow-up to #9547. It records only the ownership/lifecycle behavior actually merged there and does not retroactively authorize the retired `RunDescriptor`, retry/coordinator, host-bus, stage, or concept-count program.

## Validation

- `npm run check:guidance-refs` — passed
- changed-file Prettier check — passed
- `git diff --check` — passed
- manual source verification against `ModelCell.ts`, `AgentLaunchContext.ts`, `AgentRunLifecycle.ts`, `runToolUseFlow.ts`, and `modelSwitchState.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only guidance and cross-links; no code or behavioral changes.
> 
> **Overview**
> This PR is **documentation-only**; it does not change runtime, persistence, resume, model-switch, or disposal behavior.
> 
> It adds a **ModelCell** entry to the architecture rulings ledger that makes the merged [#9547](https://github.com/LionSR/TeXRA/pull/9547) implementation authoritative for ownership and lifecycle (single cell per run, `swap`/`dispose`, persistence before switch, resume from `shared.modelId`). It explicitly **supersedes** only the retired gold-standard PRD passages that claimed `ModelCell` must not exist on `main`—not `RunDescriptor`, `PendingRequests`, `RetryGate`, `HostUiBus`, or the rest of that proposal.
> 
> The agent SDK readiness audit and three retired PRDs (runtime/host decoupling, agent SDK boundary, runtime gold-standard) gain reciprocal links and wording that the **narrow** ruling governs the current primitive without reviving the retired designs. Implementation and test file references are listed in the ledger for future changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8456f3edd503eba594c583b1dd9b1a600115673c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->