### PR TITLE
fix(runtime): reject stale waiting repair probes

### DIFF
--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -88,7 +88,7 @@ interface ArtifactFlushBatch {
 
 interface WaitingRepairProbe {
   readonly executionId: string;
-  readonly statusGeneration: object;
+  readonly statusGeneration: object | undefined;
   readonly result: Promise<boolean>;
 }
 
@@ -330,7 +330,7 @@ export class SessionHandle {
     if (phase === STREAM_PHASE.WAITING) return true;
     if (isInFlightPhase(phase)) return false;
 
-    if (!executionId || !statusGeneration) return false;
+    if (!executionId) return false;
 
     const probe: WaitingRepairProbe = {
       executionId,
@@ -350,7 +350,7 @@ export class SessionHandle {
   private async probeWaitingRepair(
     streamId: StreamTabId,
     executionId: string,
-    statusGeneration: object,
+    statusGeneration: object | undefined,
   ): Promise<boolean> {
     const resumability = await deriveResumability(executionId);
     if (!resumability.resumable) return false;

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -309,17 +309,22 @@ export class SessionHandle {
    * runtime that owns the stream phase.
    */
   async repairWaitingIfResumable(streamId: StreamTabId): Promise<boolean> {
+    const inFlight = this.waitingRepairProbes.get(streamId);
+    if (inFlight) return inFlight;
+
+    const statusGeneration = this.status.getGeneration(streamId);
     const phase = this.status.get(streamId);
     if (phase === STREAM_PHASE.WAITING) return true;
     if (isInFlightPhase(phase)) return false;
 
-    const inFlight = this.waitingRepairProbes.get(streamId);
-    if (inFlight) return inFlight;
-
     const executionId = this.snapshots.getExecutionId(streamId);
-    if (!executionId) return false;
+    if (!executionId || !statusGeneration) return false;
 
-    const probe = this.probeWaitingRepair(streamId, executionId);
+    const probe = this.probeWaitingRepair(
+      streamId,
+      executionId,
+      statusGeneration,
+    );
     this.waitingRepairProbes.set(streamId, probe);
     try {
       return await probe;
@@ -333,9 +338,16 @@ export class SessionHandle {
   private async probeWaitingRepair(
     streamId: StreamTabId,
     executionId: string,
+    statusGeneration: object,
   ): Promise<boolean> {
     const resumability = await deriveResumability(executionId);
     if (!resumability.resumable) return false;
+    if (
+      this.snapshots.getExecutionId(streamId) !== executionId ||
+      !this.status.isCurrentGeneration(streamId, statusGeneration)
+    ) {
+      return false;
+    }
     const repaired = this.status.transitionToWaiting(
       streamId,
       STREAM_TRANSITION_CAUSE.RESTART_REPAIR,

--- a/src/agent/runtime/SessionHandle.ts
+++ b/src/agent/runtime/SessionHandle.ts
@@ -86,6 +86,12 @@ interface ArtifactFlushBatch {
   readonly reject: (error: unknown) => void;
 }
 
+interface WaitingRepairProbe {
+  readonly executionId: string;
+  readonly statusGeneration: object;
+  readonly result: Promise<boolean>;
+}
+
 function createArtifactFlushBatch(): ArtifactFlushBatch {
   let resolve: () => void = () => undefined;
   let reject: (error: unknown) => void = () => undefined;
@@ -172,7 +178,7 @@ export class SessionHandle {
   /** Per-stream {@link repairWaitingIfResumable} result currently in flight. */
   private readonly waitingRepairProbes = new Map<
     StreamTabId,
-    Promise<boolean>
+    WaitingRepairProbe
   >();
   private readonly restartRepairQueue = new PQueue({ concurrency: 1 });
   private readonly restartRepairRetry = new RestartRepairRetryScheduler();
@@ -309,25 +315,31 @@ export class SessionHandle {
    * runtime that owns the stream phase.
    */
   async repairWaitingIfResumable(streamId: StreamTabId): Promise<boolean> {
+    const executionId = this.snapshots.getExecutionId(streamId);
     const inFlight = this.waitingRepairProbes.get(streamId);
-    if (inFlight) return inFlight;
+    if (
+      inFlight &&
+      inFlight.executionId === executionId &&
+      this.status.isCurrentGeneration(streamId, inFlight.statusGeneration)
+    ) {
+      return inFlight.result;
+    }
 
     const statusGeneration = this.status.getGeneration(streamId);
     const phase = this.status.get(streamId);
     if (phase === STREAM_PHASE.WAITING) return true;
     if (isInFlightPhase(phase)) return false;
 
-    const executionId = this.snapshots.getExecutionId(streamId);
     if (!executionId || !statusGeneration) return false;
 
-    const probe = this.probeWaitingRepair(
-      streamId,
+    const probe: WaitingRepairProbe = {
       executionId,
       statusGeneration,
-    );
+      result: this.probeWaitingRepair(streamId, executionId, statusGeneration),
+    };
     this.waitingRepairProbes.set(streamId, probe);
     try {
-      return await probe;
+      return await probe.result;
     } finally {
       if (this.waitingRepairProbes.get(streamId) === probe) {
         this.waitingRepairProbes.delete(streamId);

--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -88,8 +88,11 @@ export class StreamStatusMachine {
     return this.streams.get(stream);
   }
 
-  /** Whether an earlier status read still belongs to the current entry. */
-  isCurrentGeneration(stream: StreamTabId, generation: object): boolean {
+  /** Whether an earlier status read, including absence, is still current. */
+  isCurrentGeneration(
+    stream: StreamTabId,
+    generation: object | undefined,
+  ): boolean {
     return this.streams.get(stream) === generation;
   }
 

--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -83,6 +83,16 @@ export class StreamStatusMachine {
     return this.stateFor(stream)?.phase;
   }
 
+  /** Opaque identity replaced whenever this stream's status entry changes. */
+  getGeneration(stream: StreamTabId): object | undefined {
+    return this.streams.get(stream);
+  }
+
+  /** Whether an earlier status read still belongs to the current entry. */
+  isCurrentGeneration(stream: StreamTabId, generation: object): boolean {
+    return this.streams.get(stream) === generation;
+  }
+
   getSubstate(stream: StreamTabId): StreamSubstate | undefined {
     return this.stateFor(stream)?.substate;
   }

--- a/src/test-kernel/agent/runtime/SessionWaitingRepair.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionWaitingRepair.vitest.ts
@@ -153,4 +153,120 @@ describe('SessionHandle.repairWaitingIfResumable', () => {
     );
     expect(resumabilityMocks.deriveResumability).toHaveBeenCalledTimes(2);
   });
+
+  it('shares rejection and releases the probe slot for retry', async () => {
+    seedCancelled();
+    const failure = new Error('resumability read failed');
+    resumabilityMocks.deriveResumability.mockRejectedValueOnce(failure);
+
+    const first = session.repairWaitingIfResumable(streamId);
+    session.status.transition(streamId, STREAM_PHASE.RUNNING, 'resume');
+    const second = session.repairWaitingIfResumable(streamId);
+
+    await expect(first).rejects.toBe(failure);
+    await expect(second).rejects.toBe(failure);
+    expect(resumabilityMocks.deriveResumability).toHaveBeenCalledTimes(1);
+
+    session.status.transition(streamId, STREAM_PHASE.CANCELLED, 'user-stop');
+    resumabilityMocks.deriveResumability.mockResolvedValue({
+      resumable: true,
+      cause: 'interrupted-with-flow',
+    });
+    await expect(session.repairWaitingIfResumable(streamId)).resolves.toBe(
+      true,
+    );
+    expect(resumabilityMocks.deriveResumability).toHaveBeenCalledTimes(2);
+  });
+
+  it('shares a stale false verdict after resume starts during the probe', async () => {
+    seedCancelled();
+    let release: (() => void) | undefined;
+    resumabilityMocks.deriveResumability.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          release = () =>
+            resolve({ resumable: true, cause: 'interrupted-with-flow' });
+        }),
+    );
+
+    const first = session.repairWaitingIfResumable(streamId);
+    session.status.transition(streamId, STREAM_PHASE.RUNNING, 'resume');
+    const second = session.repairWaitingIfResumable(streamId);
+    release?.();
+
+    await expect(Promise.all([first, second])).resolves.toEqual([false, false]);
+    expect(resumabilityMocks.deriveResumability).toHaveBeenCalledTimes(1);
+    expect(session.status.get(streamId)).toBe(STREAM_PHASE.RUNNING);
+  });
+
+  it('does not recreate a stream cleared during the probe', async () => {
+    seedCancelled();
+    let release: (() => void) | undefined;
+    resumabilityMocks.deriveResumability.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          release = () =>
+            resolve({ resumable: true, cause: 'interrupted-with-flow' });
+        }),
+    );
+
+    const repair = session.repairWaitingIfResumable(streamId);
+    session.status.clearStream(streamId);
+    session.snapshots.evict(streamId);
+    release?.();
+
+    await expect(repair).resolves.toBe(false);
+    expect(session.status.get(streamId)).toBeUndefined();
+  });
+
+  it('does not repair a replacement execution', async () => {
+    seedCancelled();
+    let release: (() => void) | undefined;
+    resumabilityMocks.deriveResumability.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          release = () =>
+            resolve({ resumable: true, cause: 'interrupted-with-flow' });
+        }),
+    );
+
+    const repair = session.repairWaitingIfResumable(streamId);
+    const replacementExecutionId = `c${executionId.slice(1)}` as ExecutionId;
+    session.snapshots.setRunDescriptor(
+      buildRunDescriptor({
+        streamId,
+        executionId: replacementExecutionId,
+        agent: 'assistant',
+        category: AgentCategory.ToolUse,
+        kind: 'agent',
+      }),
+    );
+    release?.();
+
+    await expect(repair).resolves.toBe(false);
+    expect(session.status.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
+    expect(resumabilityMocks.deriveResumability).toHaveBeenCalledWith(
+      executionId,
+    );
+  });
+
+  it('does not repair a recreated terminal generation', async () => {
+    seedCancelled();
+    let release: (() => void) | undefined;
+    resumabilityMocks.deriveResumability.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          release = () =>
+            resolve({ resumable: true, cause: 'interrupted-with-flow' });
+        }),
+    );
+
+    const repair = session.repairWaitingIfResumable(streamId);
+    session.status.clearStream(streamId);
+    seedCancelled();
+    release?.();
+
+    await expect(repair).resolves.toBe(false);
+    expect(session.status.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
+  });
 });

--- a/src/test-kernel/agent/runtime/SessionWaitingRepair.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionWaitingRepair.vitest.ts
@@ -21,6 +21,28 @@ vi.mock('@agent/storage/resumability', () => ({
   deriveResumability: resumabilityMocks.deriveResumability,
 }));
 
+interface DeferredResumability {
+  readonly promise: Promise<{
+    readonly resumable: true;
+    readonly cause: 'interrupted-with-flow';
+  }>;
+  readonly resolve: () => void;
+  readonly reject: (error: Error) => void;
+}
+
+function createDeferredResumability(): DeferredResumability {
+  let resolve: DeferredResumability['resolve'] = () => undefined;
+  let reject: DeferredResumability['reject'] = () => undefined;
+  const promise = new Promise<Awaited<DeferredResumability['promise']>>(
+    (settle, fail) => {
+      resolve = () =>
+        settle({ resumable: true, cause: 'interrupted-with-flow' });
+      reject = fail;
+    },
+  );
+  return { promise, resolve, reject };
+}
+
 /**
  * `SessionHandle.repairWaitingIfResumable` is the re-homed lazy WAITING repair
  * that used to be a private helper in the VS Code `texra.sendFollowUp` command
@@ -60,6 +82,22 @@ describe('SessionHandle.repairWaitingIfResumable', () => {
 
   it('restores a terminal stream to WAITING when its execution is resumable', async () => {
     seedCancelled();
+    resumabilityMocks.deriveResumability.mockResolvedValue({
+      resumable: true,
+      cause: 'interrupted-with-flow',
+    });
+
+    await expect(session.repairWaitingIfResumable(streamId)).resolves.toBe(
+      true,
+    );
+
+    expect(resumabilityMocks.deriveResumability).toHaveBeenCalledWith(
+      executionId,
+    );
+    expect(session.status.get(streamId)).toBe(STREAM_PHASE.WAITING);
+  });
+
+  it('restores a persisted execution whose status entry is absent', async () => {
     resumabilityMocks.deriveResumability.mockResolvedValue({
       resumable: true,
       cause: 'interrupted-with-flow',
@@ -123,13 +161,9 @@ describe('SessionHandle.repairWaitingIfResumable', () => {
 
   it('collapses concurrent probes for one stream onto the first', async () => {
     seedCancelled();
-    let release: (() => void) | undefined;
+    const deferred = createDeferredResumability();
     resumabilityMocks.deriveResumability.mockImplementation(
-      async () =>
-        new Promise((resolve) => {
-          release = () =>
-            resolve({ resumable: true, cause: 'interrupted-with-flow' });
-        }),
+      () => deferred.promise,
     );
 
     const first = session.repairWaitingIfResumable(streamId);
@@ -137,7 +171,7 @@ describe('SessionHandle.repairWaitingIfResumable', () => {
 
     expect(resumabilityMocks.deriveResumability).toHaveBeenCalledTimes(1);
 
-    release?.();
+    deferred.resolve();
     await expect(Promise.all([first, second])).resolves.toEqual([true, true]);
     expect(session.status.get(streamId)).toBe(STREAM_PHASE.WAITING);
 
@@ -178,13 +212,9 @@ describe('SessionHandle.repairWaitingIfResumable', () => {
 
   it('does not join a stale probe after resume starts', async () => {
     seedCancelled();
-    let release: (() => void) | undefined;
+    const deferred = createDeferredResumability();
     resumabilityMocks.deriveResumability.mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          release = () =>
-            resolve({ resumable: true, cause: 'interrupted-with-flow' });
-        }),
+      () => deferred.promise,
     );
 
     const first = session.repairWaitingIfResumable(streamId);
@@ -195,25 +225,21 @@ describe('SessionHandle.repairWaitingIfResumable', () => {
     expect(resumabilityMocks.deriveResumability).toHaveBeenCalledTimes(1);
     expect(session.status.get(streamId)).toBe(STREAM_PHASE.RUNNING);
 
-    release?.();
+    deferred.resolve();
     await expect(first).resolves.toBe(false);
   });
 
   it('does not recreate a stream cleared during the probe', async () => {
     seedCancelled();
-    let release: (() => void) | undefined;
+    const deferred = createDeferredResumability();
     resumabilityMocks.deriveResumability.mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          release = () =>
-            resolve({ resumable: true, cause: 'interrupted-with-flow' });
-        }),
+      () => deferred.promise,
     );
 
     const repair = session.repairWaitingIfResumable(streamId);
     session.status.clearStream(streamId);
     session.snapshots.evict(streamId);
-    release?.();
+    deferred.resolve();
 
     await expect(repair).resolves.toBe(false);
     expect(session.status.get(streamId)).toBeUndefined();
@@ -221,13 +247,9 @@ describe('SessionHandle.repairWaitingIfResumable', () => {
 
   it('does not repair a replacement execution', async () => {
     seedCancelled();
-    let release: (() => void) | undefined;
+    const deferred = createDeferredResumability();
     resumabilityMocks.deriveResumability.mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          release = () =>
-            resolve({ resumable: true, cause: 'interrupted-with-flow' });
-        }),
+      () => deferred.promise,
     );
 
     const repair = session.repairWaitingIfResumable(streamId);
@@ -241,7 +263,7 @@ describe('SessionHandle.repairWaitingIfResumable', () => {
         kind: 'agent',
       }),
     );
-    release?.();
+    deferred.resolve();
 
     await expect(repair).resolves.toBe(false);
     expect(session.status.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
@@ -252,16 +274,13 @@ describe('SessionHandle.repairWaitingIfResumable', () => {
 
   it('starts a distinct probe for a replacement execution', async () => {
     seedCancelled();
-    let releaseOriginal: (() => void) | undefined;
-    let releaseReplacement: (() => void) | undefined;
+    const originalDeferred = createDeferredResumability();
+    const replacementDeferred = createDeferredResumability();
     resumabilityMocks.deriveResumability.mockImplementation(
       (requestedId: string) =>
-        new Promise((resolve) => {
-          const release = () =>
-            resolve({ resumable: true, cause: 'interrupted-with-flow' });
-          if (requestedId === executionId) releaseOriginal = release;
-          else releaseReplacement = release;
-        }),
+        requestedId === executionId
+          ? originalDeferred.promise
+          : replacementDeferred.promise,
     );
 
     const original = session.repairWaitingIfResumable(streamId);
@@ -286,28 +305,24 @@ describe('SessionHandle.repairWaitingIfResumable', () => {
       replacementExecutionId,
     );
 
-    releaseReplacement?.();
+    replacementDeferred.resolve();
     await expect(replacement).resolves.toBe(true);
-    releaseOriginal?.();
+    originalDeferred.resolve();
     await expect(original).resolves.toBe(false);
     expect(session.status.get(streamId)).toBe(STREAM_PHASE.WAITING);
   });
 
   it('does not repair a recreated terminal generation', async () => {
     seedCancelled();
-    let release: (() => void) | undefined;
+    const deferred = createDeferredResumability();
     resumabilityMocks.deriveResumability.mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          release = () =>
-            resolve({ resumable: true, cause: 'interrupted-with-flow' });
-        }),
+      () => deferred.promise,
     );
 
     const repair = session.repairWaitingIfResumable(streamId);
     session.status.clearStream(streamId);
     seedCancelled();
-    release?.();
+    deferred.resolve();
 
     await expect(repair).resolves.toBe(false);
     expect(session.status.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
@@ -316,12 +331,9 @@ describe('SessionHandle.repairWaitingIfResumable', () => {
   it('does not let a stale rejected probe poison the WAITING fast path', async () => {
     seedCancelled();
     const failure = new Error('resumability read failed');
-    let reject: ((error: Error) => void) | undefined;
+    const deferred = createDeferredResumability();
     resumabilityMocks.deriveResumability.mockImplementation(
-      () =>
-        new Promise((_resolve, fail) => {
-          reject = fail;
-        }),
+      () => deferred.promise,
     );
 
     const first = session.repairWaitingIfResumable(streamId);
@@ -334,30 +346,18 @@ describe('SessionHandle.repairWaitingIfResumable', () => {
     );
     expect(resumabilityMocks.deriveResumability).toHaveBeenCalledTimes(1);
 
-    reject?.(failure);
+    deferred.reject(failure);
     await firstRejection;
     expect(session.status.get(streamId)).toBe(STREAM_PHASE.WAITING);
   });
 
   it('starts a distinct probe for a new terminal generation', async () => {
     seedCancelled();
-    let releaseFirst: (() => void) | undefined;
-    let releaseSecond: (() => void) | undefined;
+    const firstDeferred = createDeferredResumability();
+    const secondDeferred = createDeferredResumability();
     resumabilityMocks.deriveResumability
-      .mockImplementationOnce(
-        () =>
-          new Promise((resolve) => {
-            releaseFirst = () =>
-              resolve({ resumable: true, cause: 'interrupted-with-flow' });
-          }),
-      )
-      .mockImplementationOnce(
-        () =>
-          new Promise((resolve) => {
-            releaseSecond = () =>
-              resolve({ resumable: true, cause: 'interrupted-with-flow' });
-          }),
-      );
+      .mockImplementationOnce(() => firstDeferred.promise)
+      .mockImplementationOnce(() => secondDeferred.promise);
 
     const first = session.repairWaitingIfResumable(streamId);
     session.status.clearStream(streamId);
@@ -365,12 +365,12 @@ describe('SessionHandle.repairWaitingIfResumable', () => {
     const second = session.repairWaitingIfResumable(streamId);
     expect(resumabilityMocks.deriveResumability).toHaveBeenCalledTimes(2);
 
-    releaseFirst?.();
+    firstDeferred.resolve();
     await expect(first).resolves.toBe(false);
 
     const third = session.repairWaitingIfResumable(streamId);
     expect(resumabilityMocks.deriveResumability).toHaveBeenCalledTimes(2);
-    releaseSecond?.();
+    secondDeferred.resolve();
 
     await expect(Promise.all([second, third])).resolves.toEqual([true, true]);
     expect(session.status.get(streamId)).toBe(STREAM_PHASE.WAITING);

--- a/src/test-kernel/agent/runtime/SessionWaitingRepair.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionWaitingRepair.vitest.ts
@@ -80,6 +80,20 @@ describe('SessionHandle.repairWaitingIfResumable', () => {
     session.status.transition(streamId, STREAM_PHASE.CANCELLED, 'user-stop');
   }
 
+  it('does not overwrite status created during an absent-generation probe', async () => {
+    const deferred = createDeferredResumability();
+    resumabilityMocks.deriveResumability.mockImplementation(
+      () => deferred.promise,
+    );
+
+    const repair = session.repairWaitingIfResumable(streamId);
+    session.status.transition(streamId, STREAM_PHASE.RUNNING, 'lifecycle');
+    deferred.resolve();
+
+    await expect(repair).resolves.toBe(false);
+    expect(session.status.get(streamId)).toBe(STREAM_PHASE.RUNNING);
+  });
+
   it('restores a terminal stream to WAITING when its execution is resumable', async () => {
     seedCancelled();
     resumabilityMocks.deriveResumability.mockResolvedValue({

--- a/src/test-kernel/agent/runtime/SessionWaitingRepair.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionWaitingRepair.vitest.ts
@@ -250,6 +250,49 @@ describe('SessionHandle.repairWaitingIfResumable', () => {
     );
   });
 
+  it('starts a distinct probe for a replacement execution', async () => {
+    seedCancelled();
+    let releaseOriginal: (() => void) | undefined;
+    let releaseReplacement: (() => void) | undefined;
+    resumabilityMocks.deriveResumability.mockImplementation(
+      (requestedId: string) =>
+        new Promise((resolve) => {
+          const release = () =>
+            resolve({ resumable: true, cause: 'interrupted-with-flow' });
+          if (requestedId === executionId) releaseOriginal = release;
+          else releaseReplacement = release;
+        }),
+    );
+
+    const original = session.repairWaitingIfResumable(streamId);
+    const replacementExecutionId = `d${executionId.slice(1)}` as ExecutionId;
+    session.snapshots.setRunDescriptor(
+      buildRunDescriptor({
+        streamId,
+        executionId: replacementExecutionId,
+        agent: 'assistant',
+        category: AgentCategory.ToolUse,
+        kind: 'agent',
+      }),
+    );
+    const replacement = session.repairWaitingIfResumable(streamId);
+
+    expect(resumabilityMocks.deriveResumability).toHaveBeenNthCalledWith(
+      1,
+      executionId,
+    );
+    expect(resumabilityMocks.deriveResumability).toHaveBeenNthCalledWith(
+      2,
+      replacementExecutionId,
+    );
+
+    releaseReplacement?.();
+    await expect(replacement).resolves.toBe(true);
+    releaseOriginal?.();
+    await expect(original).resolves.toBe(false);
+    expect(session.status.get(streamId)).toBe(STREAM_PHASE.WAITING);
+  });
+
   it('does not repair a recreated terminal generation', async () => {
     seedCancelled();
     let release: (() => void) | undefined;

--- a/src/test-kernel/agent/runtime/SessionWaitingRepair.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionWaitingRepair.vitest.ts
@@ -312,4 +312,67 @@ describe('SessionHandle.repairWaitingIfResumable', () => {
     await expect(repair).resolves.toBe(false);
     expect(session.status.get(streamId)).toBe(STREAM_PHASE.CANCELLED);
   });
+
+  it('does not let a stale rejected probe poison the WAITING fast path', async () => {
+    seedCancelled();
+    const failure = new Error('resumability read failed');
+    let reject: ((error: Error) => void) | undefined;
+    resumabilityMocks.deriveResumability.mockImplementation(
+      () =>
+        new Promise((_resolve, fail) => {
+          reject = fail;
+        }),
+    );
+
+    const first = session.repairWaitingIfResumable(streamId);
+    const firstRejection = expect(first).rejects.toBe(failure);
+    session.status.transition(streamId, STREAM_PHASE.RUNNING, 'resume');
+    session.status.transition(streamId, STREAM_PHASE.WAITING, 'wait');
+
+    await expect(session.repairWaitingIfResumable(streamId)).resolves.toBe(
+      true,
+    );
+    expect(resumabilityMocks.deriveResumability).toHaveBeenCalledTimes(1);
+
+    reject?.(failure);
+    await firstRejection;
+    expect(session.status.get(streamId)).toBe(STREAM_PHASE.WAITING);
+  });
+
+  it('starts a distinct probe for a new terminal generation', async () => {
+    seedCancelled();
+    let releaseFirst: (() => void) | undefined;
+    let releaseSecond: (() => void) | undefined;
+    resumabilityMocks.deriveResumability
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            releaseFirst = () =>
+              resolve({ resumable: true, cause: 'interrupted-with-flow' });
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            releaseSecond = () =>
+              resolve({ resumable: true, cause: 'interrupted-with-flow' });
+          }),
+      );
+
+    const first = session.repairWaitingIfResumable(streamId);
+    session.status.clearStream(streamId);
+    seedCancelled();
+    const second = session.repairWaitingIfResumable(streamId);
+    expect(resumabilityMocks.deriveResumability).toHaveBeenCalledTimes(2);
+
+    releaseFirst?.();
+    await expect(first).resolves.toBe(false);
+
+    const third = session.repairWaitingIfResumable(streamId);
+    expect(resumabilityMocks.deriveResumability).toHaveBeenCalledTimes(2);
+    releaseSecond?.();
+
+    await expect(Promise.all([second, third])).resolves.toEqual([true, true]);
+    expect(session.status.get(streamId)).toBe(STREAM_PHASE.WAITING);
+  });
 });

--- a/src/test-kernel/agent/runtime/SessionWaitingRepair.vitest.ts
+++ b/src/test-kernel/agent/runtime/SessionWaitingRepair.vitest.ts
@@ -160,14 +160,12 @@ describe('SessionHandle.repairWaitingIfResumable', () => {
     resumabilityMocks.deriveResumability.mockRejectedValueOnce(failure);
 
     const first = session.repairWaitingIfResumable(streamId);
-    session.status.transition(streamId, STREAM_PHASE.RUNNING, 'resume');
     const second = session.repairWaitingIfResumable(streamId);
 
     await expect(first).rejects.toBe(failure);
     await expect(second).rejects.toBe(failure);
     expect(resumabilityMocks.deriveResumability).toHaveBeenCalledTimes(1);
 
-    session.status.transition(streamId, STREAM_PHASE.CANCELLED, 'user-stop');
     resumabilityMocks.deriveResumability.mockResolvedValue({
       resumable: true,
       cause: 'interrupted-with-flow',
@@ -178,7 +176,7 @@ describe('SessionHandle.repairWaitingIfResumable', () => {
     expect(resumabilityMocks.deriveResumability).toHaveBeenCalledTimes(2);
   });
 
-  it('shares a stale false verdict after resume starts during the probe', async () => {
+  it('does not join a stale probe after resume starts', async () => {
     seedCancelled();
     let release: (() => void) | undefined;
     resumabilityMocks.deriveResumability.mockImplementation(
@@ -192,11 +190,13 @@ describe('SessionHandle.repairWaitingIfResumable', () => {
     const first = session.repairWaitingIfResumable(streamId);
     session.status.transition(streamId, STREAM_PHASE.RUNNING, 'resume');
     const second = session.repairWaitingIfResumable(streamId);
-    release?.();
 
-    await expect(Promise.all([first, second])).resolves.toEqual([false, false]);
+    await expect(second).resolves.toBe(false);
     expect(resumabilityMocks.deriveResumability).toHaveBeenCalledTimes(1);
     expect(session.status.get(streamId)).toBe(STREAM_PHASE.RUNNING);
+
+    release?.();
+    await expect(first).resolves.toBe(false);
   });
 
   it('does not recreate a stream cleared during the probe', async () => {

--- a/src/test-kernel/commands/agent/FollowUpCommandWaitingRepair.vitest.ts
+++ b/src/test-kernel/commands/agent/FollowUpCommandWaitingRepair.vitest.ts
@@ -95,4 +95,32 @@ describe('texra.sendFollowUp waiting repair admission', () => {
     expect(mocks.submitFollowUp).toHaveBeenCalledTimes(2);
     expect(defaultSession().status.get(STREAM)).toBe(STREAM_PHASE.WAITING);
   });
+
+  it('does not let a stale rejected probe block an active flow', async () => {
+    const failure = new Error('resumability read failed');
+    let rejectProbe: ((error: Error) => void) | undefined;
+    mocks.deriveResumability.mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectProbe = reject;
+        }),
+    );
+    mocks.submitFollowUp.mockResolvedValue({ status: 'sent' });
+
+    const first = mocks.handler?.({ stream: STREAM, text: 'first' });
+    const firstRejection = expect(first).rejects.toBe(failure);
+    defaultSession().status.transition(STREAM, STREAM_PHASE.RUNNING, 'resume');
+
+    await expect(
+      mocks.handler?.({ stream: STREAM, text: 'second' }),
+    ).resolves.toBeUndefined();
+    expect(mocks.submitFollowUp).toHaveBeenCalledOnce();
+    expect(mocks.submitFollowUp).toHaveBeenCalledWith(STREAM, {
+      text: 'second',
+      mediaFiles: undefined,
+    });
+
+    rejectProbe?.(failure);
+    await firstRejection;
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to #9553. That PR made overlapping waiting-repair callers share one probe, but the probe could still become stale while `deriveResumability` was pending and then overwrite or resurrect newer stream state.

- cache each resumability probe with its execution ID and opaque status generation, including the valid absent-status generation used during restart recovery
- share a probe only with callers from that same current execution and stream generation
- verify both identities after probing before transitioning to `WAITING`; callers from a newer generation use the current phase or start their own probe
- refuse to overwrite `RUNNING`/resuming state or recreate a cleared/replaced stream
- centralize the deferred resumability fixture and cover absent status, status creation during an absent-generation probe, shared rejection cleanup, intervening resume, cleared streams, replacement executions, and recreated terminal generations

## Verification

- focused runtime suites: 47 tests passed
- `npm run typecheck`
- `npm run lint`
- Prettier check on all changed files
- `git diff --check`