### PR TITLE
fix(cli): require human approval for retry batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ All notable changes to this project will be documented in this file.
   been removed with explicit maintainer approval. Streamed NDJSON
   progress records are unchanged.
 
+#### Bug Fixes
+
+- **Automatic CLI runs stop after their model retry limit** — automatic
+  approval mode no longer restarts another full retry sequence when every
+  configured attempt has failed.
+
 ### Desktop
 
 #### Breaking Changes

--- a/packages/cli/src/chat/tui/state/subscribeApprovals.ts
+++ b/packages/cli/src/chat/tui/state/subscribeApprovals.ts
@@ -408,6 +408,9 @@ async function requestRetryInteraction(
   const decision = await reservation.decided;
   try {
     if (!decision.accepted) {
+      if (immediate) {
+        return { action: 'deny', reason: decision.userMessage };
+      }
       // A cleared or replaced entry was never denied by a user, so it must not
       // mark the run as approval-denied.
       if (!reservation.signal.aborted) markApprovalDenied(context);

--- a/packages/cli/src/runtime/approval/approvalPolicy.ts
+++ b/packages/cli/src/runtime/approval/approvalPolicy.ts
@@ -203,11 +203,13 @@ export function immediateDecisionForApproval(
   context: CliContext,
 ): ApprovalDecision | undefined {
   if (event === 'showRetryRequest' && context.approvalPolicy === 'yolo') {
-    if (isCredentialRetryRequest(event, payload)) markApprovalDenied(context);
+    const credentialRetry = isCredentialRetryRequest(event, payload);
+    if (credentialRetry) markApprovalDenied(context);
     return {
       accepted: false,
-      userMessage:
-        'Retry skipped: explicit interactive approval is required after automatic attempts are exhausted.',
+      userMessage: credentialRetry
+        ? 'Retry skipped: credential exhausted or unauthorized.'
+        : 'Retry skipped: explicit interactive approval is required after automatic attempts are exhausted.',
     };
   }
   return immediateDecision(context);

--- a/packages/cli/src/runtime/approval/approvalPolicy.ts
+++ b/packages/cli/src/runtime/approval/approvalPolicy.ts
@@ -184,33 +184,17 @@ export function immediateDecision(
   return { accepted: false, userMessage: denyMessage(context.approvalPolicy) };
 }
 
-/** Retry requests caused by exhausted credentials or auth failures need user
- *  action (key swap, top-up, re-login). Interactive runs must still surface the
- *  retry panel so the user can switch to personal API keys; non-interactive
- *  and auto-approval modes should not burn the retry budget. */
-function isUnretryableRetryRequest(
-  event: CliDecisionApprovalEvent,
-  payload: CliDecisionApprovalPayloads[CliDecisionApprovalEvent],
-): boolean {
-  if (event !== 'showRetryRequest') return false;
-  const details = (payload as RetryPermission).errorDetails;
-  if (!details) return false;
-  if (isCredentialExhausted(details)) return true;
-  if (details.statusCode === 401 || details.statusCode === 403) return true;
-  return false;
-}
-
 export function immediateDecisionForApproval(
   event: CliDecisionApprovalEvent,
-  payload: CliDecisionApprovalPayloads[CliDecisionApprovalEvent],
+  _payload: CliDecisionApprovalPayloads[CliDecisionApprovalEvent],
   context: CliContext,
 ): ApprovalDecision | undefined {
-  if (isUnretryableRetryRequest(event, payload)) {
-    if (approvalPromptAllowed(context)) return undefined;
+  if (event === 'showRetryRequest' && context.approvalPolicy === 'yolo') {
     markApprovalDenied(context);
     return {
       accepted: false,
-      userMessage: 'Retry skipped: credential exhausted or unauthorized.',
+      userMessage:
+        'Retry skipped: explicit interactive approval is required after automatic attempts are exhausted.',
     };
   }
   return immediateDecision(context);

--- a/packages/cli/src/runtime/approval/approvalPolicy.ts
+++ b/packages/cli/src/runtime/approval/approvalPolicy.ts
@@ -184,13 +184,26 @@ export function immediateDecision(
   return { accepted: false, userMessage: denyMessage(context.approvalPolicy) };
 }
 
+/** Retry requests caused by exhausted credentials or auth failures retain
+ *  their approval-denied classification even when yolo denies another batch. */
+function isCredentialRetryRequest(
+  event: CliDecisionApprovalEvent,
+  payload: CliDecisionApprovalPayloads[CliDecisionApprovalEvent],
+): boolean {
+  if (event !== 'showRetryRequest') return false;
+  const details = (payload as RetryPermission).errorDetails;
+  if (!details) return false;
+  if (isCredentialExhausted(details)) return true;
+  return details.statusCode === 401 || details.statusCode === 403;
+}
+
 export function immediateDecisionForApproval(
   event: CliDecisionApprovalEvent,
-  _payload: CliDecisionApprovalPayloads[CliDecisionApprovalEvent],
+  payload: CliDecisionApprovalPayloads[CliDecisionApprovalEvent],
   context: CliContext,
 ): ApprovalDecision | undefined {
   if (event === 'showRetryRequest' && context.approvalPolicy === 'yolo') {
-    markApprovalDenied(context);
+    if (isCredentialRetryRequest(event, payload)) markApprovalDenied(context);
     return {
       accepted: false,
       userMessage:

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.mts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.mts
@@ -10,8 +10,12 @@ vi.mock('@tools/inquiry/ExternalInquiryTool', () => ({
   handleExternalInquiryAction: handleExternalInquiryActionMock,
 }));
 
+import { Node } from '@agent/node';
+import type {
+  HostInteractions,
+  HostRetryRequest,
+} from '@agent/runtime/HostInteractions';
 import { defaultSession } from '@agent/runtime/SessionHandle';
-import type { HostRetryRequest } from '@agent/runtime/HostInteractions';
 import {
   appendCliApiSwitchHint,
   approvalPromptAllowed,
@@ -100,20 +104,34 @@ describe('immediateDecisionForApproval', () => {
     ).toBeUndefined();
   });
 
-  it('denies exhausted credential retries outside interactive ask mode', () => {
-    expect(
-      immediateDecisionForApproval(
-        'showRetryRequest',
-        credentialExhaustedRetry,
-        context({ approvalPolicy: 'yolo' }),
-      ),
-    ).toMatchObject({ accepted: false });
+  it.each([
+    { approvalPolicy: 'yolo' as const, mode: 'interactive' as const },
+    { approvalPolicy: 'never' as const, mode: 'interactive' as const },
+    { approvalPolicy: 'ask' as const, mode: 'headless' as const },
+  ])(
+    'denies retries without an interactive human in $approvalPolicy/$mode mode',
+    ({ approvalPolicy, mode }) => {
+      expect(
+        immediateDecisionForApproval(
+          'showRetryRequest',
+          credentialExhaustedRetry,
+          context({ approvalPolicy, mode }),
+        ),
+      ).toMatchObject({ accepted: false });
+    },
+  );
 
+  it('denies an ordinary transient retry in yolo mode', () => {
     expect(
       immediateDecisionForApproval(
         'showRetryRequest',
-        credentialExhaustedRetry,
-        context({ mode: 'headless' }),
+        {
+          requestId: 'transient-retry',
+          streamId: 'test-stream' as StreamTabId,
+          operation: 'Model request',
+          errorMessage: 'stream dropped before first token',
+        },
+        context({ approvalPolicy: 'yolo' }),
       ),
     ).toMatchObject({ accepted: false });
   });
@@ -285,12 +303,78 @@ describe('requestRetry classification (#7331)', () => {
     });
   });
 
+  it('denies (not approves) a transient retry under yolo policy', async () => {
+    const result = await createHeadlessCliHostInteractions(
+      context({ approvalPolicy: 'yolo' }),
+    ).requestRetry?.(retryRequest);
+
+    expect(result).toEqual({
+      action: 'deny',
+      reason:
+        'Retry skipped: explicit interactive approval is required after automatic attempts are exhausted.',
+    });
+  });
+
   it('cancels a retry the interactive user explicitly rejects', async () => {
     const result = await createHeadlessCliHostInteractions(
       context({ approvalPrompt: async () => 'n not now' }),
     ).requestRetry?.(retryRequest);
 
     expect(result).toEqual({ action: 'cancel' });
+  });
+});
+
+class PermanentlyFailingProviderNode extends Node {
+  providerCalls = 0;
+
+  constructor(
+    private readonly interactions: HostInteractions,
+    private readonly streamId: StreamTabId,
+  ) {
+    super(3, 0);
+  }
+
+  override async exec(): Promise<never> {
+    this.providerCalls += 1;
+    throw new Error('permanent provider failure');
+  }
+
+  override async retryPrompt(): Promise<boolean> {
+    const result = await this.interactions.requestRetry?.({
+      requestId: `retry-${this.streamId}`,
+      streamId: this.streamId,
+      operation: 'Model invocation',
+      errorMessage: 'permanent provider failure',
+    });
+    return result?.action === 'retry';
+  }
+}
+
+describe('bounded yolo retry batches (#9532)', () => {
+  it('stops root and delegated failures after one automatic batch', async () => {
+    // The CLI installs one policy adapter on the session; root and delegated
+    // streams therefore make retry decisions through this same interaction.
+    const interactions = createHeadlessCliHostInteractions(
+      context({ approvalPolicy: 'yolo' }),
+    );
+    const root = new PermanentlyFailingProviderNode(
+      interactions,
+      'root@deepseekT#retry' as StreamTabId,
+    );
+    const delegated = new PermanentlyFailingProviderNode(
+      interactions,
+      'review@deepseekT#retry' as StreamTabId,
+    );
+
+    await expect(root._exec(undefined)).rejects.toThrow(
+      'permanent provider failure',
+    );
+    await expect(delegated._exec(undefined)).rejects.toThrow(
+      'permanent provider failure',
+    );
+
+    expect(root.providerCalls).toBe(3);
+    expect(delegated.providerCalls).toBe(3);
   });
 });
 

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.mts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.mts
@@ -29,10 +29,13 @@ import {
   isCliApiSwitchableRetry,
 } from '@cli/runtime/approvalAdapter';
 import type { CliContext } from '@cli/runtime/cliContext';
+import { CliExitCode } from '@cli/runtime/exitCodes';
+import { runOutcomeExitCode } from '@cli/runtime/terminalStatus';
 import type { CliApprovalPromptHooks } from '@cli/runtime/approval/approvalPolicy';
 import {
   AgentCategory,
   DEFAULT_TOOL_CONFIG,
+  RUN_OUTCOME,
   type AgentProposalPermission,
   type RetryPermission,
   type StreamTabId,
@@ -94,7 +97,7 @@ afterEach(() => {
 });
 
 describe('immediateDecisionForApproval', () => {
-  it('shows the interactive retry panel for exhausted credentials', () => {
+  it('shows the retry panel in interactive ask mode', () => {
     expect(
       immediateDecisionForApproval(
         'showRetryRequest',
@@ -121,7 +124,9 @@ describe('immediateDecisionForApproval', () => {
     },
   );
 
-  it('denies an ordinary transient retry in yolo mode', () => {
+  it('denies an ordinary transient retry in yolo mode without marking approval denied', () => {
+    const ctx = context({ approvalPolicy: 'yolo' });
+
     expect(
       immediateDecisionForApproval(
         'showRetryRequest',
@@ -131,9 +136,13 @@ describe('immediateDecisionForApproval', () => {
           operation: 'Model request',
           errorMessage: 'stream dropped before first token',
         },
-        context({ approvalPolicy: 'yolo' }),
+        ctx,
       ),
     ).toMatchObject({ accepted: false });
+    expect(hasCliApprovalDenied(ctx)).toBe(false);
+    expect(runOutcomeExitCode(RUN_OUTCOME.FAILED, ctx)).toBe(
+      CliExitCode.AgentError,
+    );
   });
 });
 
@@ -291,9 +300,9 @@ describe('requestRetry classification (#7331)', () => {
   };
 
   it('denies (not cancels) a retry when no human input is available', async () => {
-    const result = await createHeadlessCliHostInteractions(
-      context({ approvalPolicy: 'never', mode: 'headless' }),
-    ).requestRetry?.(retryRequest);
+    const ctx = context({ approvalPolicy: 'never', mode: 'headless' });
+    const result =
+      await createHeadlessCliHostInteractions(ctx).requestRetry?.(retryRequest);
 
     // A policy/headless auto-denial is a distinct failure, not a user cancel,
     // so a zero-output run reports FAILED rather than COMPLETED.
@@ -301,19 +310,47 @@ describe('requestRetry classification (#7331)', () => {
       action: 'deny',
       reason: 'Denied by CLI approval policy.',
     });
+    expect(hasCliApprovalDenied(ctx)).toBe(true);
+    expect(runOutcomeExitCode(RUN_OUTCOME.FAILED, ctx)).toBe(
+      CliExitCode.ApprovalDenied,
+    );
   });
 
-  it('denies (not approves) a transient retry under yolo policy', async () => {
-    const result = await createHeadlessCliHostInteractions(
-      context({ approvalPolicy: 'yolo' }),
-    ).requestRetry?.(retryRequest);
+  it('denies a yolo retry without changing provider-failure exit classification', async () => {
+    const ctx = context({ approvalPolicy: 'yolo' });
+    const result =
+      await createHeadlessCliHostInteractions(ctx).requestRetry?.(retryRequest);
 
     expect(result).toEqual({
       action: 'deny',
       reason:
         'Retry skipped: explicit interactive approval is required after automatic attempts are exhausted.',
     });
+    expect(hasCliApprovalDenied(ctx)).toBe(false);
+    expect(runOutcomeExitCode(RUN_OUTCOME.FAILED, ctx)).toBe(
+      CliExitCode.AgentError,
+    );
   });
+
+  it.each([
+    credentialExhaustedRetry.errorDetails,
+    { message: 'Unauthorized', statusCode: 401 },
+    { message: 'Forbidden', statusCode: 403 },
+  ])(
+    'preserves ApprovalDenied for yolo credential/auth failure %#',
+    async (errorDetails) => {
+      const ctx = context({ approvalPolicy: 'yolo' });
+      const result = await createHeadlessCliHostInteractions(
+        ctx,
+      ).requestRetry?.({ ...retryRequest, errorDetails });
+
+      expect(result?.action).toBe('deny');
+      expect(hasCliApprovalDenied(ctx)).toBe(true);
+      expect(runOutcomeExitCode(RUN_OUTCOME.FAILED, ctx)).toBe(
+        CliExitCode.ApprovalDenied,
+      );
+    },
+  );
 
   it('cancels a retry the interactive user explicitly rejects', async () => {
     const result = await createHeadlessCliHostInteractions(
@@ -324,8 +361,9 @@ describe('requestRetry classification (#7331)', () => {
   });
 });
 
-class PermanentlyFailingProviderNode extends Node {
+class RepresentativeFailingProviderNode extends Node {
   providerCalls = 0;
+  readonly providerError = new Error('permanent provider failure');
 
   constructor(
     private readonly interactions: HostInteractions,
@@ -336,7 +374,7 @@ class PermanentlyFailingProviderNode extends Node {
 
   override async exec(): Promise<never> {
     this.providerCalls += 1;
-    throw new Error('permanent provider failure');
+    throw this.providerError;
   }
 
   override async retryPrompt(): Promise<boolean> {
@@ -351,30 +389,26 @@ class PermanentlyFailingProviderNode extends Node {
 }
 
 describe('bounded yolo retry batches (#9532)', () => {
-  it('stops root and delegated failures after one automatic batch', async () => {
-    // The CLI installs one policy adapter on the session; root and delegated
-    // streams therefore make retry decisions through this same interaction.
+  it('stops two representative streams after one automatic batch', async () => {
+    // Representative streams share the session's CLI policy adapter. This
+    // proves stream-agnostic bounding, not delegation inheritance.
     const interactions = createHeadlessCliHostInteractions(
       context({ approvalPolicy: 'yolo' }),
     );
-    const root = new PermanentlyFailingProviderNode(
+    const first = new RepresentativeFailingProviderNode(
       interactions,
-      'root@deepseekT#retry' as StreamTabId,
+      'representative-a' as StreamTabId,
     );
-    const delegated = new PermanentlyFailingProviderNode(
+    const second = new RepresentativeFailingProviderNode(
       interactions,
-      'review@deepseekT#retry' as StreamTabId,
+      'representative-b' as StreamTabId,
     );
 
-    await expect(root._exec(undefined)).rejects.toThrow(
-      'permanent provider failure',
-    );
-    await expect(delegated._exec(undefined)).rejects.toThrow(
-      'permanent provider failure',
-    );
+    await expect(first._exec(undefined)).rejects.toBe(first.providerError);
+    await expect(second._exec(undefined)).rejects.toBe(second.providerError);
 
-    expect(root.providerCalls).toBe(3);
-    expect(delegated.providerCalls).toBe(3);
+    expect(first.providerCalls).toBe(3);
+    expect(second.providerCalls).toBe(3);
   });
 });
 

--- a/src/test-kernel/cli/ApprovalAdapter.vitest.mts
+++ b/src/test-kernel/cli/ApprovalAdapter.vitest.mts
@@ -344,7 +344,10 @@ describe('requestRetry classification (#7331)', () => {
         ctx,
       ).requestRetry?.({ ...retryRequest, errorDetails });
 
-      expect(result?.action).toBe('deny');
+      expect(result).toEqual({
+        action: 'deny',
+        reason: 'Retry skipped: credential exhausted or unauthorized.',
+      });
       expect(hasCliApprovalDenied(ctx)).toBe(true);
       expect(runOutcomeExitCode(RUN_OUTCOME.FAILED, ctx)).toBe(
         CliExitCode.ApprovalDenied,

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
@@ -109,10 +109,16 @@ import {
 } from '@cli/chat/tui/state/cliState';
 import { createTuiHostInteractions } from '@cli/chat/tui/state/subscribeApprovals';
 import type { CliContext } from '@cli/runtime/cliContext';
+import { CliExitCode } from '@cli/runtime/exitCodes';
+import { runOutcomeExitCode } from '@cli/runtime/terminalStatus';
 import type { CliRuntimeHost } from '@cli/runtime/cliPresentationHost';
 import { hasCliApprovalDenied } from '@cli/runtime/approvalAdapter';
 import type { ApiProvider } from '@model/apiProviders';
-import { AgentCategory, type RetryPermission } from '@shared/schemas';
+import {
+  AgentCategory,
+  RUN_OUTCOME,
+  type RetryPermission,
+} from '@shared/schemas';
 import { GlobalStateKey } from '@shared/state/stateKeys';
 import { createTestCliContext } from '@test/cli/fixtures/cliContext';
 import { setGoalSessionBashAutoApproval } from '@tools/goal';
@@ -323,7 +329,10 @@ describe('TUI retry approvals', () => {
       reason:
         'Retry skipped: explicit interactive approval is required after automatic attempts are exhausted.',
     });
-    expect(hasCliApprovalDenied(cliContext)).toBe(true);
+    expect(hasCliApprovalDenied(cliContext)).toBe(false);
+    expect(runOutcomeExitCode(RUN_OUTCOME.FAILED, cliContext)).toBe(
+      CliExitCode.AgentError,
+    );
     expect(currentApproval.get()).toBeUndefined();
   });
 

--- a/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
+++ b/src/test-kernel/cli/TuiApprovalRetry.vitest.mts
@@ -123,13 +123,14 @@ import {
   proposalApprovals,
 } from '@tools/approval';
 
-function context(): CliContext {
+function context(overrides: Partial<CliContext> = {}): CliContext {
   return createTestCliContext({
     cwd: '/work',
     mode: 'interactive',
     approvalPolicy: 'ask',
     version: 'test',
     resourcesPath: '/resources',
+    ...overrides,
   });
 }
 
@@ -141,14 +142,17 @@ function host(): CliRuntimeHost {
   } as unknown as CliRuntimeHost;
 }
 
-function tui(presentationHost = host()): {
+function tui(
+  presentationHost = host(),
+  contextOverrides: Partial<CliContext> = {},
+): {
   readonly presentationHost: CliRuntimeHost;
   readonly cliContext: CliContext;
   readonly interactions: HostInteractions;
   readonly prepareRetry: ReturnType<typeof vi.fn>;
   readonly dispose: () => void;
 } {
-  const cliContext = context();
+  const cliContext = context(contextOverrides);
   const hostInteractions = createTuiHostInteractions(
     presentationHost,
     cliContext,
@@ -302,6 +306,27 @@ afterEach(() => {
 });
 
 describe('TUI retry approvals', () => {
+  it('reports an automatic yolo retry rejection as a policy denial', async () => {
+    const { interactions, cliContext } = tui(host(), {
+      approvalPolicy: 'yolo',
+    });
+
+    const result = interactions.requestRetry?.({
+      requestId: 'yolo-transient-retry',
+      streamId: 'yolo-transient-stream',
+      operation: 'model request',
+      errorMessage: 'Temporary connection error.',
+    });
+
+    await expect(result).resolves.toEqual({
+      action: 'deny',
+      reason:
+        'Retry skipped: explicit interactive approval is required after automatic attempts are exhausted.',
+    });
+    expect(hasCliApprovalDenied(cliContext)).toBe(true);
+    expect(currentApproval.get()).toBeUndefined();
+  });
+
   it('does not mutate the runtime host emitter', () => {
     const presentationHost = host();
     const originalEmit = presentationHost.emit;


### PR DESCRIPTION
## Summary

Contain the unbounded retry storm described in #9532 at the CLI policy boundary.

- stop `yolo` from treating an exhausted automatic model-retry batch as an explicit human retry decision
- preserve automatic approval for privileged tools and other ordinary `yolo` approvals
- preserve interactive `ask` retry prompts and the existing `never` and headless denial behavior
- preserve failure outcomes in both the headless CLI and TUI; transient retry exhaustion retains the agent-error exit code, while credential and authorization failures retain the approval-denied classification
- verify that permanently failing representative streams each stop after exactly one three-attempt automatic batch and retain the original provider error
- record the user-visible correction in the changelog

This is the first, immediate-containment part of #9532. It does not yet prove delegated-child inheritance, introduce the operation-wide cumulative budget, or repair provider-specific background lifetimes.

## Verification

- focused CLI and RetryState suites: 128 tests passed
- `npm run typecheck`
- `npm run lint`
- Prettier check on changed files
- `git diff --check`

Refs #9532

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI approval policy and retry/exit-code classification on a critical automatic-run path; behavior is well covered by new tests but affects yolo and headless retry semantics.
> 
> **Overview**
> Fixes unbounded model retry loops in automatic approval mode (#9532) by treating **exhausted automatic retry batches** as requiring an interactive human decision, not another implicit `yolo` approval.
> 
> **Policy (`immediateDecisionForApproval`)** — In `yolo`, every `showRetryRequest` is **denied immediately** with a fixed message. Credential exhaustion and 401/403 failures still call `markApprovalDenied`; ordinary transient failures deny **without** that flag so failed runs keep the **agent-error** exit path instead of **approval-denied**.
> 
> **TUI / headless retry handling** — When the policy path auto-denies a retry (`immediate`), `requestRetry` returns **`deny` + reason** instead of **`cancel`**, matching headless behavior and avoiding misclassifying policy skips as user cancellation.
> 
> **Tests** — Coverage expands for interactive `ask`, `never`/headless, and `yolo` (transient vs credential/auth), plus a representative failing provider node proving each stream stops after **one three-attempt automatic batch**.
> 
> Changelog records that automatic CLI runs no longer restart a full retry sequence after all configured attempts fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cb5cdf6f6c20aea435f1d72cfbf0e6ae525d37b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
